### PR TITLE
[dsbx] HTTP/2 inbound termination with h1 outbound bridge

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -317,7 +317,10 @@ version = "0.1.16"
 dependencies = [
  "anyhow",
  "base64",
+ "bytes",
  "clap",
+ "h2",
+ "http",
  "httparse",
  "libc",
  "lru",
@@ -365,6 +368,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,6 +408,12 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -446,6 +461,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,6 +489,12 @@ dependencies = [
  "equivalent",
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -665,6 +705,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,7 +807,7 @@ version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1585,6 +1635,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -12,6 +12,9 @@ clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 anyhow = "1"
 base64 = "0.22"
+bytes = "1"
+h2 = "0.4"
+http = "1"
 libc = "0.2"
 lru = "0.16"
 httparse = "1"

--- a/cli/dust-sandbox/src/commands/forward/deny_log.rs
+++ b/cli/dust-sandbox/src/commands/forward/deny_log.rs
@@ -21,7 +21,6 @@ pub enum DenyReason {
     AbsoluteUriAuthorityMismatch,
     Port80Placeholder,
     HeaderSizeExceeded,
-    H2WebsocketUnsupported,
     ExpectContinueUnsupported,
     RequestTrailersUnsupported,
 }
@@ -42,7 +41,6 @@ impl DenyReason {
             Self::AbsoluteUriAuthorityMismatch => "absolute_uri_authority_mismatch",
             Self::Port80Placeholder => "port_80_placeholder",
             Self::HeaderSizeExceeded => "header_size_exceeded",
-            Self::H2WebsocketUnsupported => "h2_websocket_unsupported",
             Self::ExpectContinueUnsupported => "expect_continue_unsupported",
             Self::RequestTrailersUnsupported => "request_trailers_unsupported",
         }

--- a/cli/dust-sandbox/src/commands/forward/deny_log.rs
+++ b/cli/dust-sandbox/src/commands/forward/deny_log.rs
@@ -22,6 +22,8 @@ pub enum DenyReason {
     Port80Placeholder,
     HeaderSizeExceeded,
     H2WebsocketUnsupported,
+    ExpectContinueUnsupported,
+    RequestTrailersUnsupported,
 }
 
 impl DenyReason {
@@ -41,6 +43,8 @@ impl DenyReason {
             Self::Port80Placeholder => "port_80_placeholder",
             Self::HeaderSizeExceeded => "header_size_exceeded",
             Self::H2WebsocketUnsupported => "h2_websocket_unsupported",
+            Self::ExpectContinueUnsupported => "expect_continue_unsupported",
+            Self::RequestTrailersUnsupported => "request_trailers_unsupported",
         }
     }
 }

--- a/cli/dust-sandbox/src/commands/forward/deny_log.rs
+++ b/cli/dust-sandbox/src/commands/forward/deny_log.rs
@@ -21,6 +21,7 @@ pub enum DenyReason {
     AbsoluteUriAuthorityMismatch,
     Port80Placeholder,
     HeaderSizeExceeded,
+    H2WebsocketUnsupported,
 }
 
 impl DenyReason {
@@ -39,6 +40,7 @@ impl DenyReason {
             Self::AbsoluteUriAuthorityMismatch => "absolute_uri_authority_mismatch",
             Self::Port80Placeholder => "port_80_placeholder",
             Self::HeaderSizeExceeded => "header_size_exceeded",
+            Self::H2WebsocketUnsupported => "h2_websocket_unsupported",
         }
     }
 }

--- a/cli/dust-sandbox/src/commands/forward/http2_rewriter.rs
+++ b/cli/dust-sandbox/src/commands/forward/http2_rewriter.rs
@@ -25,7 +25,10 @@ const MAX_HEADER_BLOCK_BYTES: usize = 64 * 1024;
 const MAX_HEADER_LINE_BYTES: usize = 16 * 1024;
 const MAX_TRAILER_BLOCK_BYTES: usize = 64 * 1024;
 // Safety cap for one declared h1 chunk. Forwarding still streams chunks in
-// READ_CHUNK_BYTES pieces so normal large responses do not need one allocation.
+// READ_CHUNK_BYTES pieces, so this only bounds the largest single chunk an
+// upstream is allowed to declare in its framing. 64 MiB is well above any
+// chunk an LB or origin we forward through is expected to emit while still
+// keeping a hard ceiling against pathological framing.
 const MAX_H1_RESPONSE_CHUNK_BYTES: usize = 64 * 1024 * 1024;
 
 pub(super) trait AsyncReadWrite: AsyncRead + AsyncWrite + Unpin + Send {}
@@ -130,12 +133,7 @@ async fn handle_h2_stream(
     let authority = match h2_request_authority(&parts.uri, &parts.headers) {
         Ok(authority) => authority,
         Err(error) => {
-            let entry = deny_entry(
-                RewriteMode::Tls { sni: &sni },
-                DenyReason::MalformedHeaders,
-                None,
-                None,
-            );
+            let entry = deny_entry(mode, DenyReason::MalformedHeaders, None, None);
             append_deny_log(&deny_log, entry)
                 .await
                 .context("failed to append h2 malformed-authority deny log entry")?;
@@ -317,8 +315,8 @@ fn has_expect_100_continue(headers: &[HeaderPart]) -> bool {
 }
 
 fn send_expectation_failed(respond: &mut SendResponse<Bytes>) -> Result<()> {
-    // TODO: Replace this synthetic response with concurrent request upload and
-    // upstream response forwarding in https://github.com/dust-tt/dust/issues/26109.
+    // TODO(2026-05-25 #26109): Replace this synthetic response with concurrent
+    // request upload and upstream response forwarding.
     let response = Response::builder()
         .status(StatusCode::EXPECTATION_FAILED)
         .body(())
@@ -330,14 +328,27 @@ fn send_expectation_failed(respond: &mut SendResponse<Bytes>) -> Result<()> {
 }
 
 fn discard_h2_request_body(mut body: RecvStream) {
+    // Spawned per Expect: 100-continue rejection, bounded by
+    // H2_MAX_CONCURRENT_STREAMS per session. The task drains DATA + trailers so
+    // the h2 layer can release flow-control credit after the synthetic 417 has
+    // closed the local stream for sending.
     tokio::spawn(async move {
         while let Some(chunk) = body.data().await {
-            let Ok(chunk) = chunk else {
-                return;
+            let chunk = match chunk {
+                Ok(chunk) => chunk,
+                Err(error) => {
+                    warn!(error = %error, "h2 request-body drain failed");
+                    return;
+                }
             };
-            let _ = body.flow_control().release_capacity(chunk.len());
+            if let Err(error) = body.flow_control().release_capacity(chunk.len()) {
+                warn!(error = %error, "h2 request-body flow-control release failed");
+                return;
+            }
         }
-        let _ = body.trailers().await;
+        if let Err(error) = body.trailers().await {
+            warn!(error = %error, "h2 request-body trailers drain failed");
+        }
     });
 }
 
@@ -962,7 +973,6 @@ fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::path::PathBuf;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use anyhow::{ensure, Result};
@@ -1043,7 +1053,8 @@ mod tests {
         );
 
         let (client_io, server_io) = tokio::io::duplex(64 * 1024);
-        let deny_log = Arc::new(PathBuf::from("/tmp/dust-h2-deny-test.log"));
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
         let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
             server_io,
             sni.to_string(),
@@ -1093,7 +1104,8 @@ mod tests {
         let opener = test_h1_opener(request_tx, b"HTTP/1.1 204 No Content\r\n\r\n");
 
         let (client_io, server_io) = tokio::io::duplex(64 * 1024);
-        let deny_log = Arc::new(PathBuf::from("/tmp/dust-h2-basic-deny-test.log"));
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
         let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
             server_io,
             sni.to_string(),
@@ -1144,7 +1156,8 @@ mod tests {
         );
 
         let (client_io, server_io) = tokio::io::duplex(64 * 1024);
-        let deny_log = Arc::new(PathBuf::from("/tmp/dust-h2-body-deny-test.log"));
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
         let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
             server_io,
             sni.to_string(),
@@ -1196,7 +1209,8 @@ mod tests {
         );
 
         let (client_io, server_io) = tokio::io::duplex(64 * 1024);
-        let deny_log = Arc::new(PathBuf::from("/tmp/dust-h2-empty-data-deny-test.log"));
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
         let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
             server_io,
             sni.to_string(),
@@ -1248,7 +1262,8 @@ mod tests {
         );
 
         let (client_io, server_io) = tokio::io::duplex(64 * 1024);
-        let deny_log = Arc::new(PathBuf::from("/tmp/dust-h2-empty-only-deny-test.log"));
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
         let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
             server_io,
             sni.to_string(),
@@ -1298,7 +1313,8 @@ mod tests {
         );
 
         let (client_io, server_io) = tokio::io::duplex(64 * 1024);
-        let deny_log = Arc::new(PathBuf::from("/tmp/dust-h2-chunked-deny-test.log"));
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
         let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
             server_io,
             sni.to_string(),
@@ -1365,7 +1381,8 @@ mod tests {
         );
 
         let (client_io, server_io) = tokio::io::duplex(64 * 1024);
-        let deny_log = Arc::new(PathBuf::from("/tmp/dust-h2-large-chunk-deny-test.log"));
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
         let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
             server_io,
             sni.to_string(),
@@ -1429,7 +1446,8 @@ mod tests {
         let opener = test_h1_opener(request_tx, response.as_bytes());
 
         let (client_io, server_io) = tokio::io::duplex(64 * 1024);
-        let deny_log = Arc::new(PathBuf::from("/tmp/dust-h2-chunk-cap-deny-test.log"));
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
         let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
             server_io,
             sni.to_string(),
@@ -1479,7 +1497,8 @@ mod tests {
         );
 
         let (client_io, server_io) = tokio::io::duplex(64 * 1024);
-        let deny_log = Arc::new(PathBuf::from("/tmp/dust-h2-ambiguous-deny-test.log"));
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
         let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
             server_io,
             sni.to_string(),
@@ -1522,7 +1541,8 @@ mod tests {
         );
 
         let (client_io, server_io) = tokio::io::duplex(64 * 1024);
-        let deny_log = Arc::new(PathBuf::from("/tmp/dust-h2-connection-deny-test.log"));
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
         let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
             server_io,
             sni.to_string(),
@@ -1842,7 +1862,8 @@ mod tests {
         );
 
         let (client_io, server_io) = tokio::io::duplex(64 * 1024);
-        let deny_log = Arc::new(PathBuf::from("/tmp/dust-h2-empty-trailers-deny-test.log"));
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
         let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
             server_io,
             sni.to_string(),

--- a/cli/dust-sandbox/src/commands/forward/http2_rewriter.rs
+++ b/cli/dust-sandbox/src/commands/forward/http2_rewriter.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::future::{poll_fn, Future};
 use std::pin::Pin;
 use std::sync::Arc;
@@ -6,7 +7,7 @@ use anyhow::{anyhow, Context, Result};
 use bytes::Bytes;
 use h2::server::SendResponse;
 use h2::{RecvStream, SendStream};
-use http::header::{CONTENT_LENGTH, HOST, TRANSFER_ENCODING};
+use http::header::{CONTENT_LENGTH, EXPECT, HOST, TRANSFER_ENCODING};
 use http::{HeaderMap, HeaderName, HeaderValue, Request, Response, StatusCode};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tracing::warn;
@@ -23,6 +24,9 @@ const READ_CHUNK_BYTES: usize = 8 * 1024;
 const MAX_HEADER_BLOCK_BYTES: usize = 64 * 1024;
 const MAX_HEADER_LINE_BYTES: usize = 16 * 1024;
 const MAX_TRAILER_BLOCK_BYTES: usize = 64 * 1024;
+// Safety cap for one declared h1 chunk. Forwarding still streams chunks in
+// READ_CHUNK_BYTES pieces so normal large responses do not need one allocation.
+const MAX_H1_RESPONSE_CHUNK_BYTES: usize = 64 * 1024 * 1024;
 
 pub(super) trait AsyncReadWrite: AsyncRead + AsyncWrite + Unpin + Send {}
 
@@ -38,6 +42,35 @@ pub(super) type OpenH1Upstream = Arc<
     dyn Fn() -> Pin<Box<dyn Future<Output = Result<BoxedAsyncReadWrite>> + Send>> + Send + Sync,
 >;
 
+#[derive(Clone, Copy)]
+struct H2RequestDeny {
+    reason: DenyReason,
+    reset: h2::Reason,
+}
+
+impl H2RequestDeny {
+    fn internal(reason: DenyReason) -> Self {
+        Self {
+            reason,
+            reset: h2::Reason::INTERNAL_ERROR,
+        }
+    }
+
+    fn refused(reason: DenyReason) -> Self {
+        Self {
+            reason,
+            reset: h2::Reason::REFUSED_STREAM,
+        }
+    }
+}
+
+enum WriteH1RequestError {
+    Denied(H2RequestDeny),
+    Bridge(anyhow::Error),
+}
+
+type WriteH1RequestResult<T> = std::result::Result<T, WriteH1RequestError>;
+
 pub(super) async fn run_h2_to_h1_bridge<C>(
     agent_tls: C,
     sni: String,
@@ -51,12 +84,9 @@ where
     let mut builder = h2::server::Builder::new();
     builder
         .max_concurrent_streams(H2_MAX_CONCURRENT_STREAMS)
-        // Advertise SETTINGS_ENABLE_CONNECT_PROTOCOL so RFC 8441 extended
-        // CONNECT bootstraps (h2 WebSocket) reach our handler and we can emit
-        // a structured `h2_websocket_unsupported` deny instead of letting the
-        // h2 protocol layer silently reject them. The handler resets the
-        // stream with REFUSED_STREAM after logging.
-        .enable_connect_protocol();
+        // Keep inbound h2 request headers under the same bound as the h1
+        // rewriter before HPACK decoding can buffer a much larger block.
+        .max_header_list_size(MAX_HEADER_BLOCK_BYTES as u32);
     // We do not advertise SETTINGS_ENABLE_PUSH on the server side: per RFC 7540
     // ENABLE_PUSH is the client telling the server whether it accepts pushes,
     // and a server only pushes if it calls `push_promise`, which we do not.
@@ -161,6 +191,39 @@ async fn handle_h2_stream(
         }
     };
 
+    if has_expect_100_continue(&policy.headers) {
+        let entry = deny_entry(
+            mode,
+            DenyReason::ExpectContinueUnsupported,
+            None,
+            Some(&authority),
+        );
+        append_deny_log(&deny_log, entry)
+            .await
+            .context("failed to append h2 expect-continue deny log entry")?;
+        send_expectation_failed(&mut respond).context("failed to send h2 417 response")?;
+        discard_h2_request_body(body);
+        return Ok(());
+    }
+
+    let (header_bytes, use_chunked) = match build_h1_request_head(
+        &method,
+        &target,
+        &authority,
+        &policy.headers,
+        body.is_end_stream(),
+    ) {
+        Ok(result) => result,
+        Err(deny) => {
+            let entry = deny_entry(mode, deny.reason, None, Some(&authority));
+            append_deny_log(&deny_log, entry)
+                .await
+                .context("failed to append h2 request-header deny log entry")?;
+            respond.send_reset(deny.reset);
+            return Ok(());
+        }
+    };
+
     let mut upstream = match open_upstream().await {
         Ok(upstream) => upstream,
         Err(error) => {
@@ -169,18 +232,22 @@ async fn handle_h2_stream(
                 .with_context(|| format!("failed to open h1 upstream for {authority}"));
         }
     };
-    if let Err(error) = write_h1_request(
-        &mut upstream,
-        &method,
-        &target,
-        &authority,
-        &policy.headers,
-        body,
-    )
-    .await
-    {
-        respond.send_reset(h2::Reason::INTERNAL_ERROR);
-        return Err(error);
+    match write_h1_request(&mut upstream, header_bytes, use_chunked, body).await {
+        Ok(()) => {}
+        Err(WriteH1RequestError::Denied(deny)) => {
+            let entry = deny_entry(mode, deny.reason, None, Some(&authority));
+            append_deny_log(&deny_log, entry)
+                .await
+                .context("failed to append h2 request-body deny log entry")?;
+            respond.send_reset(deny.reset);
+            let _ = upstream.shutdown().await;
+            return Ok(());
+        }
+        Err(WriteH1RequestError::Bridge(error)) => {
+            respond.send_reset(h2::Reason::INTERNAL_ERROR);
+            let _ = upstream.shutdown().await;
+            return Err(error);
+        }
     }
     if let Err(error) = forward_h1_response_to_h2(&mut upstream, &mut respond, &method).await {
         respond.send_reset(h2::Reason::INTERNAL_ERROR);
@@ -240,6 +307,40 @@ fn header_map_to_parts(headers: &HeaderMap) -> Vec<HeaderPart> {
         .collect()
 }
 
+fn has_expect_100_continue(headers: &[HeaderPart]) -> bool {
+    headers.iter().any(|header| {
+        header.name.eq_ignore_ascii_case(EXPECT.as_str())
+            && std::str::from_utf8(&header.value)
+                .map(|value| value.trim().eq_ignore_ascii_case("100-continue"))
+                .unwrap_or(false)
+    })
+}
+
+fn send_expectation_failed(respond: &mut SendResponse<Bytes>) -> Result<()> {
+    // TODO: Replace this synthetic response with concurrent request upload and
+    // upstream response forwarding in https://github.com/dust-tt/dust/issues/26109.
+    let response = Response::builder()
+        .status(StatusCode::EXPECTATION_FAILED)
+        .body(())
+        .context("failed to build h2 417 response")?;
+    respond
+        .send_response(response, true)
+        .context("failed to send h2 417 response")?;
+    Ok(())
+}
+
+fn discard_h2_request_body(mut body: RecvStream) {
+    tokio::spawn(async move {
+        while let Some(chunk) = body.data().await {
+            let Ok(chunk) = chunk else {
+                return;
+            };
+            let _ = body.flow_control().release_capacity(chunk.len());
+        }
+        let _ = body.trailers().await;
+    });
+}
+
 fn is_h2_websocket_connect(extensions: &http::Extensions) -> bool {
     // RFC 8441 extended CONNECT: the `:protocol` pseudo-header is carried by
     // the h2 crate as `h2::ext::Protocol` in the request extensions, NOT as a
@@ -251,125 +352,151 @@ fn is_h2_websocket_connect(extensions: &http::Extensions) -> bool {
         .unwrap_or(false)
 }
 
-async fn write_h1_request<W>(
-    upstream: &mut W,
+fn build_h1_request_head(
     method: &str,
     target: &str,
     authority: &str,
     headers: &[HeaderPart],
-    mut body: RecvStream,
-) -> Result<()>
-where
-    W: AsyncWrite + Unpin,
-{
+    body_is_end_stream: bool,
+) -> std::result::Result<(Vec<u8>, bool), H2RequestDeny> {
     let has_content_length = headers
         .iter()
         .any(|header| header.name.eq_ignore_ascii_case(CONTENT_LENGTH.as_str()));
-    let use_chunked = !has_content_length && !body.is_end_stream();
+    let use_chunked = !has_content_length && !body_is_end_stream;
     let mut header_bytes = Vec::new();
-    header_bytes.extend_from_slice(format!("{method} {target} HTTP/1.1\r\n").as_bytes());
-    header_bytes.extend_from_slice(format!("Host: {authority}\r\n").as_bytes());
-    header_bytes.extend_from_slice(b"Connection: close\r\n");
+    append_h1_head_bytes(
+        &mut header_bytes,
+        format!("{method} {target} HTTP/1.1\r\n").as_bytes(),
+    )?;
+    append_h1_header_line(&mut header_bytes, b"Host", authority.as_bytes())?;
+    append_h1_header_line(&mut header_bytes, b"Connection", b"close")?;
     if use_chunked {
-        header_bytes.extend_from_slice(b"Transfer-Encoding: chunked\r\n");
+        append_h1_header_line(&mut header_bytes, b"Transfer-Encoding", b"chunked")?;
     }
 
     for header in headers {
         if should_strip_h1_bridge_header(&header.name) {
             continue;
         }
-        header_bytes.extend_from_slice(header.name.as_bytes());
-        header_bytes.extend_from_slice(b": ");
-        header_bytes.extend_from_slice(&header.value);
-        header_bytes.extend_from_slice(b"\r\n");
+        append_h1_header_line(&mut header_bytes, header.name.as_bytes(), &header.value)?;
     }
+    append_h1_head_bytes(&mut header_bytes, b"\r\n")?;
+
+    Ok((header_bytes, use_chunked))
+}
+
+fn append_h1_head_bytes(
+    header_bytes: &mut Vec<u8>,
+    bytes: &[u8],
+) -> std::result::Result<(), H2RequestDeny> {
+    if header_bytes.len() + bytes.len() > MAX_HEADER_BLOCK_BYTES {
+        return Err(H2RequestDeny::internal(DenyReason::HeaderSizeExceeded));
+    }
+    header_bytes.extend_from_slice(bytes);
+    Ok(())
+}
+
+fn append_h1_header_line(
+    header_bytes: &mut Vec<u8>,
+    name: &[u8],
+    value: &[u8],
+) -> std::result::Result<(), H2RequestDeny> {
+    let line_len = name.len() + b": ".len() + value.len() + b"\r\n".len();
+    if line_len > MAX_HEADER_LINE_BYTES {
+        return Err(H2RequestDeny::internal(DenyReason::HeaderSizeExceeded));
+    }
+    if header_bytes.len() + line_len > MAX_HEADER_BLOCK_BYTES {
+        return Err(H2RequestDeny::internal(DenyReason::HeaderSizeExceeded));
+    }
+    header_bytes.extend_from_slice(name);
+    header_bytes.extend_from_slice(b": ");
+    header_bytes.extend_from_slice(value);
     header_bytes.extend_from_slice(b"\r\n");
+    Ok(())
+}
+
+async fn write_h1_request<W>(
+    upstream: &mut W,
+    header_bytes: Vec<u8>,
+    use_chunked: bool,
+    mut body: RecvStream,
+) -> WriteH1RequestResult<()>
+where
+    W: AsyncWrite + Unpin,
+{
     upstream
         .write_all(&header_bytes)
         .await
-        .context("failed to write h1 request headers")?;
+        .context("failed to write h1 request headers")
+        .map_err(WriteH1RequestError::Bridge)?;
 
     while let Some(chunk) = body.data().await {
-        let chunk = chunk.context("failed to read h2 request body chunk")?;
+        let chunk = chunk
+            .context("failed to read h2 request body chunk")
+            .map_err(WriteH1RequestError::Bridge)?;
+        body.flow_control()
+            .release_capacity(chunk.len())
+            .context("failed to release h2 request flow-control capacity")
+            .map_err(WriteH1RequestError::Bridge)?;
+        if chunk.is_empty() {
+            continue;
+        }
         if use_chunked {
             upstream
                 .write_all(format!("{:x}\r\n", chunk.len()).as_bytes())
                 .await
-                .context("failed to write h1 request chunk header")?;
+                .context("failed to write h1 request chunk header")
+                .map_err(WriteH1RequestError::Bridge)?;
             upstream
                 .write_all(&chunk)
                 .await
-                .context("failed to write h1 request chunk body")?;
+                .context("failed to write h1 request chunk body")
+                .map_err(WriteH1RequestError::Bridge)?;
             upstream
                 .write_all(b"\r\n")
                 .await
-                .context("failed to write h1 request chunk terminator")?;
+                .context("failed to write h1 request chunk terminator")
+                .map_err(WriteH1RequestError::Bridge)?;
         } else {
             upstream
                 .write_all(&chunk)
                 .await
-                .context("failed to write h1 request body chunk")?;
+                .context("failed to write h1 request body chunk")
+                .map_err(WriteH1RequestError::Bridge)?;
         }
-        body.flow_control()
-            .release_capacity(chunk.len())
-            .context("failed to release h2 request flow-control capacity")?;
     }
 
     if let Some(trailers) = body
         .trailers()
         .await
-        .context("failed to read h2 trailers")?
+        .context("failed to read h2 trailers")
+        .map_err(WriteH1RequestError::Bridge)?
     {
+        if !trailers.is_empty() {
+            return Err(WriteH1RequestError::Denied(H2RequestDeny::refused(
+                DenyReason::RequestTrailersUnsupported,
+            )));
+        }
         if use_chunked {
-            write_h1_trailers(upstream, trailers).await?;
+            upstream
+                .write_all(b"0\r\n\r\n")
+                .await
+                .context("failed to terminate h1 chunked request body")
+                .map_err(WriteH1RequestError::Bridge)?;
         }
     } else if use_chunked {
         upstream
             .write_all(b"0\r\n\r\n")
             .await
-            .context("failed to terminate h1 chunked request body")?;
+            .context("failed to terminate h1 chunked request body")
+            .map_err(WriteH1RequestError::Bridge)?;
     }
 
     upstream
         .flush()
         .await
-        .context("failed to flush h1 request")?;
-    Ok(())
-}
-
-async fn write_h1_trailers<W>(upstream: &mut W, trailers: HeaderMap) -> Result<()>
-where
-    W: AsyncWrite + Unpin,
-{
-    upstream
-        .write_all(b"0\r\n")
-        .await
-        .context("failed to write final h1 request chunk")?;
-    for (name, value) in trailers.iter() {
-        if should_strip_h1_bridge_header(name.as_str()) {
-            continue;
-        }
-        upstream
-            .write_all(name.as_str().as_bytes())
-            .await
-            .context("failed to write h1 trailer name")?;
-        upstream
-            .write_all(b": ")
-            .await
-            .context("failed to write h1 trailer separator")?;
-        upstream
-            .write_all(value.as_bytes())
-            .await
-            .context("failed to write h1 trailer value")?;
-        upstream
-            .write_all(b"\r\n")
-            .await
-            .context("failed to write h1 trailer terminator")?;
-    }
-    upstream
-        .write_all(b"\r\n")
-        .await
-        .context("failed to finish h1 trailers")?;
+        .context("failed to flush h1 request")
+        .map_err(WriteH1RequestError::Bridge)?;
     Ok(())
 }
 
@@ -384,6 +511,24 @@ fn should_strip_h1_bridge_header(name: &str) -> bool {
             | "transfer-encoding"
             | "upgrade"
     )
+}
+
+fn connection_nominated_headers(headers: &[HeaderPart]) -> Result<HashSet<String>> {
+    let mut nominated = HashSet::new();
+    for header in headers {
+        if !header.name.eq_ignore_ascii_case("connection") {
+            continue;
+        }
+        let value =
+            std::str::from_utf8(&header.value).context("connection response header is not utf8")?;
+        for token in value.split(',') {
+            let token = token.trim();
+            if !token.is_empty() {
+                nominated.insert(token.to_ascii_lowercase());
+            }
+        }
+    }
+    Ok(nominated)
 }
 
 async fn forward_h1_response_to_h2<R>(
@@ -401,8 +546,12 @@ where
         .context("failed to read h1 response head")?;
     let no_body = response_has_no_body(request_method, response_head.status);
     let mut response = Response::builder().status(response_head.status);
+    let nominated_hop_headers = connection_nominated_headers(&response_head.headers)?;
     for header in &response_head.headers {
         if should_strip_h1_bridge_header(header.name.as_str()) {
+            continue;
+        }
+        if nominated_hop_headers.contains(&header.name.to_ascii_lowercase()) {
             continue;
         }
         let name = HeaderName::from_bytes(header.name.as_bytes())
@@ -621,6 +770,12 @@ where
         loop {
             let line = self.read_line().await?;
             let chunk_size = parse_chunk_size(&line)?;
+            if chunk_size > MAX_H1_RESPONSE_CHUNK_BYTES {
+                return Err(anyhow!(
+                    "h1 response chunk exceeded {} byte limit",
+                    MAX_H1_RESPONSE_CHUNK_BYTES
+                ));
+            }
             if chunk_size == 0 {
                 let trailers = self.read_trailers().await?;
                 if trailers.is_empty() {
@@ -631,12 +786,17 @@ where
                 }
                 return Ok(());
             }
-            let chunk = self.read_exact_bytes(chunk_size).await?;
+            let mut remaining = chunk_size;
+            while remaining > 0 {
+                let slice_len = remaining.min(READ_CHUNK_BYTES);
+                let chunk = self.read_exact_bytes(slice_len).await?;
+                remaining -= chunk.len();
+                send_data(send, chunk, false).await?;
+            }
             let crlf = self.read_exact_bytes(2).await?;
             if crlf.as_ref() != b"\r\n" {
                 return Err(anyhow!("h1 chunk missing CRLF"));
             }
-            send_data(send, chunk, false).await?;
         }
     }
 
@@ -742,6 +902,11 @@ fn response_body_kind(headers: &[HeaderPart]) -> Result<H1BodyKind> {
     }
 
     if has_chunked_transfer_encoding {
+        if seen_content_length {
+            return Err(anyhow!(
+                "ambiguous h1 response framing: transfer-encoding and content-length"
+            ));
+        }
         return Ok(H1BodyKind::Chunked);
     }
 
@@ -798,6 +963,7 @@ fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
 mod tests {
     use std::collections::HashMap;
     use std::path::PathBuf;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use anyhow::{ensure, Result};
     use base64::{engine::general_purpose, Engine as _};
@@ -840,6 +1006,24 @@ mod tests {
         assert!(error
             .to_string()
             .contains("unsupported h1 response transfer-encoding"));
+    }
+
+    #[test]
+    fn rejects_ambiguous_chunked_and_content_length_h1_response() {
+        let headers = vec![
+            HeaderPart {
+                name: "transfer-encoding".to_string(),
+                value: b"chunked".to_vec(),
+            },
+            HeaderPart {
+                name: "content-length".to_string(),
+                value: b"999".to_vec(),
+            },
+        ];
+
+        let error = response_body_kind(&headers)
+            .expect_err("TE plus content-length response should be rejected");
+        assert!(error.to_string().contains("ambiguous h1 response framing"));
     }
 
     #[tokio::test]
@@ -997,6 +1181,108 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn h2_bridge_ignores_empty_data_frames_inside_chunked_request() -> Result<()> {
+        let sni = "api.openai.com";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            "__DSEC_21212121212121214343434343434343__",
+            "sk-real",
+            &[sni],
+        )?);
+        let (request_tx, mut request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_opener_with_chunked_body(
+            request_tx,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        );
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let deny_log = Arc::new(PathBuf::from("/tmp/dust-h2-empty-data-deny-test.log"));
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            deny_log,
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let request = Request::builder()
+            .method("POST")
+            .uri(format!("https://{sni}/chunked"))
+            .body(())?;
+        let (response, mut stream) = send_request.send_request(request, false)?;
+        stream.send_data(Bytes::from_static(b"he"), false)?;
+        stream.send_data(Bytes::new(), false)?;
+        stream.send_data(Bytes::from_static(b"llo"), true)?;
+        let response = response.await?;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let request_text = request_rx
+            .recv()
+            .await
+            .ok_or_else(|| anyhow!("test upstream did not receive request"))?;
+        assert!(request_text.contains("Transfer-Encoding: chunked\r\n"));
+        assert!(request_text.ends_with("\r\n\r\n2\r\nhe\r\n3\r\nllo\r\n0\r\n\r\n"));
+        assert!(!request_text.contains("0\r\n\r\n3\r\nllo"));
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_writes_single_terminator_for_empty_chunked_request_body() -> Result<()> {
+        let sni = "api.openai.com";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            "__DSEC_23232323232323234545454545454545__",
+            "sk-real",
+            &[sni],
+        )?);
+        let (request_tx, mut request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_opener_with_chunked_body(
+            request_tx,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        );
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let deny_log = Arc::new(PathBuf::from("/tmp/dust-h2-empty-only-deny-test.log"));
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            deny_log,
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let request = Request::builder()
+            .method("POST")
+            .uri(format!("https://{sni}/empty"))
+            .body(())?;
+        let (response, mut stream) = send_request.send_request(request, false)?;
+        stream.send_data(Bytes::new(), true)?;
+        let response = response.await?;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let request_text = request_rx
+            .recv()
+            .await
+            .ok_or_else(|| anyhow!("test upstream did not receive request"))?;
+        assert!(request_text.contains("Transfer-Encoding: chunked\r\n"));
+        assert!(request_text.ends_with("\r\n\r\n0\r\n\r\n"));
+        assert_eq!(request_text.matches("0\r\n\r\n").count(), 1);
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn h2_bridge_maps_chunked_response_and_trailers() -> Result<()> {
         let sni = "api.openai.com";
         let secret_table = Arc::new(secret_table_with_secret(
@@ -1031,6 +1317,7 @@ mod tests {
         let response = response.await?;
         assert_eq!(response.status(), StatusCode::OK);
         assert!(response.headers().get(TRANSFER_ENCODING).is_none());
+        assert!(response.headers().get(CONTENT_LENGTH).is_none());
         let mut body = response.into_body();
         let mut output = Vec::new();
         while let Some(chunk) = body.data().await {
@@ -1047,6 +1334,540 @@ mod tests {
             trailers.get("x-done"),
             Some(&HeaderValue::from_static("yes"))
         );
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_streams_large_h1_chunk_before_full_chunk_arrives() -> Result<()> {
+        let sni = "api.openai.com";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            "__DSEC_24242424242424244646464646464646__",
+            "sk-real",
+            &[sni],
+        )?);
+        let (request_tx, _request_rx) = mpsc::unbounded_channel();
+        let (first_write_tx, mut first_write_rx) = mpsc::unbounded_channel();
+        let continue_response = Arc::new(tokio::sync::Notify::new());
+        let first_part = vec![b'a'; READ_CHUNK_BYTES];
+        let second_part = vec![b'b'; 1024];
+        let total_len = first_part.len() + second_part.len();
+        let opener = test_h1_opener_with_split_chunked_response(
+            request_tx,
+            first_write_tx,
+            Arc::clone(&continue_response),
+            first_part,
+            second_part,
+        );
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let deny_log = Arc::new(PathBuf::from("/tmp/dust-h2-large-chunk-deny-test.log"));
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            deny_log,
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let request = Request::builder()
+            .method("GET")
+            .uri(format!("https://{sni}/stream-large"))
+            .body(())?;
+        let (response, _stream) = send_request.send_request(request, true)?;
+        let response = response.await?;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        first_write_rx
+            .recv()
+            .await
+            .ok_or_else(|| anyhow!("test upstream did not write first chunk part"))?;
+        let mut body = response.into_body();
+        let first_chunk = tokio::time::timeout(std::time::Duration::from_secs(1), body.data())
+            .await
+            .context("bridge did not emit partial chunk before the full h1 chunk arrived")?
+            .ok_or_else(|| anyhow!("h2 body ended before first chunk"))??;
+        assert_eq!(first_chunk.len(), READ_CHUNK_BYTES);
+        body.flow_control().release_capacity(first_chunk.len())?;
+
+        continue_response.notify_waiters();
+        let mut received = first_chunk.len();
+        while let Some(chunk) = body.data().await {
+            let chunk = chunk?;
+            received += chunk.len();
+            body.flow_control().release_capacity(chunk.len())?;
+        }
+        ensure!(body.trailers().await?.is_none(), "unexpected trailers");
+        assert_eq!(received, total_len);
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_resets_chunked_response_over_single_chunk_cap() -> Result<()> {
+        let sni = "api.openai.com";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            "__DSEC_25252525252525254747474747474747__",
+            "sk-real",
+            &[sni],
+        )?);
+        let (request_tx, _request_rx) = mpsc::unbounded_channel();
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n{:x}\r\n",
+            MAX_H1_RESPONSE_CHUNK_BYTES + 1
+        );
+        let opener = test_h1_opener(request_tx, response.as_bytes());
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let deny_log = Arc::new(PathBuf::from("/tmp/dust-h2-chunk-cap-deny-test.log"));
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            deny_log,
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let request = Request::builder()
+            .method("GET")
+            .uri(format!("https://{sni}/too-large"))
+            .body(())?;
+        let (response, _stream) = send_request.send_request(request, true)?;
+        match response.await {
+            Ok(response) => {
+                assert_eq!(response.status(), StatusCode::OK);
+                let body_result = read_h2_body(response.into_body()).await;
+                assert!(
+                    body_result.is_err(),
+                    "oversized h1 chunk should reset the response body"
+                );
+            }
+            Err(_error) => {}
+        }
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_resets_ambiguous_chunked_content_length_response() -> Result<()> {
+        let sni = "api.openai.com";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            "__DSEC_10101010101010102020202020202020__",
+            "sk-real",
+            &[sni],
+        )?);
+        let (request_tx, _request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_opener(
+            request_tx,
+            b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nContent-Length: 5\r\n\r\n2\r\nok\r\n0\r\n\r\n",
+        );
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let deny_log = Arc::new(PathBuf::from("/tmp/dust-h2-ambiguous-deny-test.log"));
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            deny_log,
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let request = Request::builder()
+            .method("GET")
+            .uri(format!("https://{sni}/ambiguous"))
+            .body(())?;
+        let (response, _stream) = send_request.send_request(request, true)?;
+        assert!(
+            response.await.is_err(),
+            "ambiguous TE/content-length response should reset the stream"
+        );
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_strips_connection_nominated_response_headers() -> Result<()> {
+        let sni = "api.openai.com";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            "__DSEC_12121212121212123434343434343434__",
+            "sk-real",
+            &[sni],
+        )?);
+        let (request_tx, _request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_opener(
+            request_tx,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: keep-alive, x-foo, x-bar\r\nx-foo: leak\r\nx-bar: leak\r\n\r\nok",
+        );
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let deny_log = Arc::new(PathBuf::from("/tmp/dust-h2-connection-deny-test.log"));
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            deny_log,
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let request = Request::builder()
+            .method("GET")
+            .uri(format!("https://{sni}/headers"))
+            .body(())?;
+        let (response, _stream) = send_request.send_request(request, true)?;
+        let response = response.await?;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(response.headers().get("connection").is_none());
+        assert!(response.headers().get("x-foo").is_none());
+        assert!(response.headers().get("x-bar").is_none());
+        assert_eq!(read_h2_body(response.into_body()).await?, b"ok");
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_denies_rewritten_header_block_over_limit() -> Result<()> {
+        let sni = "api.openai.com";
+        let placeholder = "__DSEC_26262626262626264848484848484848__";
+        let secret_value = "x".repeat(8 * 1024);
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            placeholder,
+            &secret_value,
+            &[sni],
+        )?);
+        let open_count = Arc::new(AtomicUsize::new(0));
+        let (request_tx, _request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_counting_opener(
+            Arc::clone(&open_count),
+            request_tx,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        );
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            Arc::clone(&deny_log),
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let mut builder = Request::builder()
+            .method("GET")
+            .uri(format!("https://{sni}/headers"));
+        for index in 0..9 {
+            builder = builder.header(format!("x-secret-{index}"), placeholder);
+        }
+        let request = builder.body(())?;
+        let (response, _stream) = send_request.send_request(request, true)?;
+        assert!(
+            response.await.is_err(),
+            "rewritten header block over 64 KiB should reset"
+        );
+
+        let deny_log_text = tokio::fs::read_to_string(deny_log.as_ref()).await?;
+        assert!(
+            deny_log_text.contains("\"reason\":\"header_size_exceeded\""),
+            "deny log should record header_size_exceeded, got: {deny_log_text}"
+        );
+        assert_eq!(open_count.load(Ordering::SeqCst), 0);
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_denies_rewritten_header_line_over_limit() -> Result<()> {
+        let sni = "api.openai.com";
+        let placeholder = "__DSEC_27272727272727274949494949494949__";
+        let secret_value = "x".repeat(MAX_HEADER_LINE_BYTES);
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            placeholder,
+            &secret_value,
+            &[sni],
+        )?);
+        let open_count = Arc::new(AtomicUsize::new(0));
+        let (request_tx, _request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_counting_opener(
+            Arc::clone(&open_count),
+            request_tx,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        );
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            Arc::clone(&deny_log),
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let request = Request::builder()
+            .method("GET")
+            .uri(format!("https://{sni}/line"))
+            .header("authorization", format!("Bearer {placeholder}"))
+            .body(())?;
+        let (response, _stream) = send_request.send_request(request, true)?;
+        assert!(
+            response.await.is_err(),
+            "rewritten header line over 16 KiB should reset"
+        );
+
+        let deny_log_text = tokio::fs::read_to_string(deny_log.as_ref()).await?;
+        assert!(
+            deny_log_text.contains("\"reason\":\"header_size_exceeded\""),
+            "deny log should record header_size_exceeded, got: {deny_log_text}"
+        );
+        assert_eq!(open_count.load(Ordering::SeqCst), 0);
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_rejects_expect_continue_with_417() -> Result<()> {
+        let sni = "api.openai.com";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            "__DSEC_28282828282828285050505050505050__",
+            "sk-real",
+            &[sni],
+        )?);
+        let open_count = Arc::new(AtomicUsize::new(0));
+        let (request_tx, _request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_counting_opener(
+            Arc::clone(&open_count),
+            request_tx,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        );
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            Arc::clone(&deny_log),
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let request = Request::builder()
+            .method("POST")
+            .uri(format!("https://{sni}/expect"))
+            .header("expect", "100-continue")
+            .body(())?;
+        let (response, _stream) = send_request.send_request(request, false)?;
+        let response = response.await?;
+        assert_eq!(response.status(), StatusCode::EXPECTATION_FAILED);
+        assert_eq!(read_h2_body(response.into_body()).await?, b"");
+
+        let deny_log_text = tokio::fs::read_to_string(deny_log.as_ref()).await?;
+        assert!(
+            deny_log_text.contains("\"reason\":\"expect_continue_unsupported\""),
+            "deny log should record expect_continue_unsupported, got: {deny_log_text}"
+        );
+        assert_eq!(open_count.load(Ordering::SeqCst), 0);
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_rejects_expect_continue_without_body_data_with_417() -> Result<()> {
+        let sni = "api.openai.com";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            "__DSEC_29292929292929295151515151515151__",
+            "sk-real",
+            &[sni],
+        )?);
+        let open_count = Arc::new(AtomicUsize::new(0));
+        let (request_tx, _request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_counting_opener(
+            Arc::clone(&open_count),
+            request_tx,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        );
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            Arc::clone(&deny_log),
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let request = Request::builder()
+            .method("POST")
+            .uri(format!("https://{sni}/expect-empty"))
+            .header("expect", "100-continue")
+            .body(())?;
+        let (response, mut stream) = send_request.send_request(request, false)?;
+        stream.send_data(Bytes::new(), true)?;
+        let response = response.await?;
+        assert_eq!(response.status(), StatusCode::EXPECTATION_FAILED);
+
+        let deny_log_text = tokio::fs::read_to_string(deny_log.as_ref()).await?;
+        assert!(
+            deny_log_text.contains("\"reason\":\"expect_continue_unsupported\""),
+            "deny log should record expect_continue_unsupported, got: {deny_log_text}"
+        );
+        assert_eq!(open_count.load(Ordering::SeqCst), 0);
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_denies_non_empty_request_trailers() -> Result<()> {
+        let sni = "api.openai.com";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            "__DSEC_30303030303030305252525252525252__",
+            "sk-real",
+            &[sni],
+        )?);
+        let (request_tx, _request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_opener_with_chunked_body(
+            request_tx,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        );
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            Arc::clone(&deny_log),
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let request = Request::builder()
+            .method("POST")
+            .uri(format!("https://{sni}/trailers"))
+            .body(())?;
+        let (response, mut stream) = send_request.send_request(request, false)?;
+        stream.send_data(Bytes::from_static(b"hello"), false)?;
+        let mut trailers = HeaderMap::new();
+        trailers.insert("x-trailer", HeaderValue::from_static("value"));
+        stream.send_trailers(trailers)?;
+        assert!(
+            response.await.is_err(),
+            "non-empty h2 request trailers should reset the stream"
+        );
+
+        let deny_log_text = tokio::fs::read_to_string(deny_log.as_ref()).await?;
+        assert!(
+            deny_log_text.contains("\"reason\":\"request_trailers_unsupported\""),
+            "deny log should record request_trailers_unsupported, got: {deny_log_text}"
+        );
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_accepts_empty_request_trailers() -> Result<()> {
+        let sni = "api.openai.com";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            "__DSEC_31313131313131315353535353535353__",
+            "sk-real",
+            &[sni],
+        )?);
+        let (request_tx, mut request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_opener_with_chunked_body(
+            request_tx,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        );
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let deny_log = Arc::new(PathBuf::from("/tmp/dust-h2-empty-trailers-deny-test.log"));
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            deny_log,
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let request = Request::builder()
+            .method("POST")
+            .uri(format!("https://{sni}/empty-trailers"))
+            .body(())?;
+        let (response, mut stream) = send_request.send_request(request, false)?;
+        stream.send_data(Bytes::from_static(b"hello"), false)?;
+        stream.send_trailers(HeaderMap::new())?;
+        let response = response.await?;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let request_text = request_rx
+            .recv()
+            .await
+            .ok_or_else(|| anyhow!("test upstream did not receive request"))?;
+        assert!(request_text.ends_with("\r\n\r\n5\r\nhello\r\n0\r\n\r\n"));
 
         drop(send_request);
         connection_task.abort();
@@ -1116,7 +1937,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn h2_bridge_denies_websocket_connect_via_extended_protocol() -> Result<()> {
+    async fn h2_bridge_settings_omit_extended_connect_and_bound_headers() -> Result<()> {
         let sni = "api.openai.com";
         let secret_table = Arc::new(secret_table_with_secret(
             "OPENAI_API_KEY",
@@ -1138,26 +1959,23 @@ mod tests {
             opener,
         ));
 
-        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
-        let connection_task = tokio::spawn(connection);
-        let mut request = Request::builder()
-            .method("CONNECT")
-            .uri(format!("https://{sni}/"))
-            .body(())?;
-        request
-            .extensions_mut()
-            .insert(h2::ext::Protocol::from("websocket"));
-        let (response, _stream) = send_request.send_request(request, true)?;
-        assert!(response.await.is_err(), "CONNECT websocket should be reset");
-
-        let deny_log_text = tokio::fs::read_to_string(deny_log.as_ref()).await?;
+        let mut client_io = client_io;
+        client_io
+            .write_all(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
+            .await?;
+        client_io.write_all(&[0, 0, 0, 4, 0, 0, 0, 0, 0]).await?;
+        let settings = read_h2_settings(&mut client_io).await?;
         assert!(
-            deny_log_text.contains("\"reason\":\"h2_websocket_unsupported\""),
-            "deny log should record h2_websocket_unsupported, got: {deny_log_text}"
+            settings
+                .iter()
+                .any(|(id, value)| *id == 0x06 && *value == MAX_HEADER_BLOCK_BYTES as u32),
+            "server SETTINGS should bound MAX_HEADER_LIST_SIZE"
+        );
+        assert!(
+            settings.iter().all(|(id, _)| *id != 0x08),
+            "server SETTINGS should not advertise ENABLE_CONNECT_PROTOCOL"
         );
 
-        drop(send_request);
-        connection_task.abort();
         bridge_task.abort();
         Ok(())
     }
@@ -1301,12 +2119,70 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn h2_bridge_rejects_protocol_header_list_over_limit_before_handler() -> Result<()> {
+        let sni = "api.openai.com";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            "__DSEC_babababababababacbcbcbcbcbcbcbcb__",
+            "sk-real",
+            &[sni],
+        )?);
+        let open_count = Arc::new(AtomicUsize::new(0));
+        let (request_tx, _request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_counting_opener(
+            Arc::clone(&open_count),
+            request_tx,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        );
+
+        let (client_io, server_io) = tokio::io::duplex(512 * 1024);
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            Arc::clone(&deny_log),
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let request = Request::builder()
+            .method("GET")
+            .uri(format!("https://{sni}/too-many-headers"))
+            .header(
+                "authorization",
+                format!("Bearer {}", "x".repeat(128 * 1024)),
+            )
+            .body(())?;
+        match send_request.send_request(request, true) {
+            Ok((response, _stream)) => {
+                assert!(
+                    response.await.is_err(),
+                    "oversized h2 header list should reset before upstream handling"
+                );
+            }
+            Err(_error) => {}
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert_eq!(open_count.load(Ordering::SeqCst), 0);
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
     fn test_h1_opener(
         request_tx: mpsc::UnboundedSender<String>,
-        response: &'static [u8],
+        response: impl Into<Vec<u8>>,
     ) -> OpenH1Upstream {
+        let response = Arc::new(response.into());
         Arc::new(move || {
             let request_tx = request_tx.clone();
+            let response = Arc::clone(&response);
             Box::pin(async move {
                 let (dsbx_io, mut upstream_io) = tokio::io::duplex(64 * 1024);
                 tokio::spawn(async move {
@@ -1323,7 +2199,7 @@ mod tests {
                     request_tx
                         .send(request_text)
                         .map_err(|_| anyhow!("failed to send captured request"))?;
-                    upstream_io.write_all(response).await?;
+                    upstream_io.write_all(response.as_slice()).await?;
                     upstream_io.shutdown().await?;
                     Ok::<(), anyhow::Error>(())
                 });
@@ -1334,10 +2210,12 @@ mod tests {
 
     fn test_h1_opener_with_content_length_body(
         request_tx: mpsc::UnboundedSender<String>,
-        response: &'static [u8],
+        response: impl Into<Vec<u8>>,
     ) -> OpenH1Upstream {
+        let response = Arc::new(response.into());
         Arc::new(move || {
             let request_tx = request_tx.clone();
+            let response = Arc::clone(&response);
             Box::pin(async move {
                 let (dsbx_io, mut upstream_io) = tokio::io::duplex(64 * 1024);
                 tokio::spawn(async move {
@@ -1359,13 +2237,183 @@ mod tests {
                     request_tx
                         .send(request_text)
                         .map_err(|_| anyhow!("failed to send captured request"))?;
-                    upstream_io.write_all(response).await?;
+                    upstream_io.write_all(response.as_slice()).await?;
                     upstream_io.shutdown().await?;
                     Ok::<(), anyhow::Error>(())
                 });
                 Ok(Box::new(dsbx_io) as BoxedAsyncReadWrite)
             })
         })
+    }
+
+    fn test_h1_counting_opener(
+        open_count: Arc<AtomicUsize>,
+        request_tx: mpsc::UnboundedSender<String>,
+        response: impl Into<Vec<u8>>,
+    ) -> OpenH1Upstream {
+        let response = response.into();
+        let opener = test_h1_opener(request_tx, response);
+        Arc::new(move || {
+            open_count.fetch_add(1, Ordering::SeqCst);
+            opener()
+        })
+    }
+
+    fn test_h1_opener_with_chunked_body(
+        request_tx: mpsc::UnboundedSender<String>,
+        response: impl Into<Vec<u8>>,
+    ) -> OpenH1Upstream {
+        let response = Arc::new(response.into());
+        Arc::new(move || {
+            let request_tx = request_tx.clone();
+            let response = Arc::clone(&response);
+            Box::pin(async move {
+                let (dsbx_io, mut upstream_io) = tokio::io::duplex(64 * 1024);
+                tokio::spawn(async move {
+                    let mut request = Vec::new();
+                    loop {
+                        let mut byte = [0_u8; 1];
+                        if upstream_io.read_exact(&mut byte).await.is_err() {
+                            return Ok::<(), anyhow::Error>(());
+                        }
+                        request.push(byte[0]);
+                        if request.ends_with(b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+                    loop {
+                        let line = read_test_crlf_line(&mut upstream_io).await?;
+                        request.extend_from_slice(&line);
+                        let chunk_size = parse_test_chunk_size(&line)?;
+                        if chunk_size == 0 {
+                            let terminator = read_test_crlf_line(&mut upstream_io).await?;
+                            request.extend_from_slice(&terminator);
+                            break;
+                        }
+                        let mut body = vec![0_u8; chunk_size];
+                        upstream_io.read_exact(&mut body).await?;
+                        request.extend_from_slice(&body);
+                        let crlf = read_test_crlf_line(&mut upstream_io).await?;
+                        request.extend_from_slice(&crlf);
+                    }
+                    let request_text = String::from_utf8(request)?;
+                    request_tx
+                        .send(request_text)
+                        .map_err(|_| anyhow!("failed to send captured request"))?;
+                    upstream_io.write_all(response.as_slice()).await?;
+                    upstream_io.shutdown().await?;
+                    Ok::<(), anyhow::Error>(())
+                });
+                Ok(Box::new(dsbx_io) as BoxedAsyncReadWrite)
+            })
+        })
+    }
+
+    fn test_h1_opener_with_split_chunked_response(
+        request_tx: mpsc::UnboundedSender<String>,
+        first_write_tx: mpsc::UnboundedSender<()>,
+        continue_response: Arc<tokio::sync::Notify>,
+        first_part: Vec<u8>,
+        second_part: Vec<u8>,
+    ) -> OpenH1Upstream {
+        let first_part = Arc::new(first_part);
+        let second_part = Arc::new(second_part);
+        Arc::new(move || {
+            let request_tx = request_tx.clone();
+            let first_write_tx = first_write_tx.clone();
+            let continue_response = Arc::clone(&continue_response);
+            let first_part = Arc::clone(&first_part);
+            let second_part = Arc::clone(&second_part);
+            Box::pin(async move {
+                let (dsbx_io, mut upstream_io) = tokio::io::duplex(64 * 1024);
+                tokio::spawn(async move {
+                    let mut request = Vec::new();
+                    loop {
+                        let mut byte = [0_u8; 1];
+                        upstream_io.read_exact(&mut byte).await?;
+                        request.push(byte[0]);
+                        if request.ends_with(b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+                    let request_text = String::from_utf8(request)?;
+                    request_tx
+                        .send(request_text)
+                        .map_err(|_| anyhow!("failed to send captured request"))?;
+
+                    let total_len = first_part.len() + second_part.len();
+                    upstream_io
+                        .write_all(
+                            format!(
+                                "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n{total_len:x}\r\n"
+                            )
+                            .as_bytes(),
+                        )
+                        .await?;
+                    upstream_io.write_all(first_part.as_slice()).await?;
+                    first_write_tx
+                        .send(())
+                        .map_err(|_| anyhow!("failed to signal first response write"))?;
+                    continue_response.notified().await;
+                    upstream_io.write_all(second_part.as_slice()).await?;
+                    upstream_io.write_all(b"\r\n0\r\n\r\n").await?;
+                    upstream_io.shutdown().await?;
+                    Ok::<(), anyhow::Error>(())
+                });
+                Ok(Box::new(dsbx_io) as BoxedAsyncReadWrite)
+            })
+        })
+    }
+
+    async fn read_test_crlf_line<R>(reader: &mut R) -> Result<Vec<u8>>
+    where
+        R: AsyncRead + Unpin,
+    {
+        let mut line = Vec::new();
+        loop {
+            let mut byte = [0_u8; 1];
+            reader.read_exact(&mut byte).await?;
+            line.push(byte[0]);
+            if line.ends_with(b"\r\n") {
+                return Ok(line);
+            }
+        }
+    }
+
+    fn parse_test_chunk_size(line: &[u8]) -> Result<usize> {
+        let text = std::str::from_utf8(line).context("test chunk line should be utf8")?;
+        let size = text
+            .strip_suffix("\r\n")
+            .ok_or_else(|| anyhow!("test chunk line missing CRLF"))?;
+        usize::from_str_radix(size, 16).context("invalid test chunk size")
+    }
+
+    async fn read_h2_settings<R>(reader: &mut R) -> Result<Vec<(u16, u32)>>
+    where
+        R: AsyncRead + Unpin,
+    {
+        loop {
+            let mut head = [0_u8; 9];
+            reader.read_exact(&mut head).await?;
+            let len = ((head[0] as usize) << 16) | ((head[1] as usize) << 8) | head[2] as usize;
+            let frame_type = head[3];
+            let flags = head[4];
+            let mut payload = vec![0_u8; len];
+            reader.read_exact(&mut payload).await?;
+            if frame_type != 4 || flags & 0x1 != 0 {
+                continue;
+            }
+            ensure!(len % 6 == 0, "invalid SETTINGS payload length");
+            return payload
+                .chunks_exact(6)
+                .map(|setting| {
+                    let id = u16::from_be_bytes([setting[0], setting[1]]);
+                    let value =
+                        u32::from_be_bytes([setting[2], setting[3], setting[4], setting[5]]);
+                    Ok((id, value))
+                })
+                .collect();
+        }
     }
 
     fn parse_test_content_length(headers: &str) -> Result<usize> {

--- a/cli/dust-sandbox/src/commands/forward/http2_rewriter.rs
+++ b/cli/dust-sandbox/src/commands/forward/http2_rewriter.rs
@@ -7,7 +7,7 @@ use anyhow::{anyhow, Context, Result};
 use bytes::Bytes;
 use h2::server::SendResponse;
 use h2::{RecvStream, SendStream};
-use http::header::{CONTENT_LENGTH, EXPECT, HOST, TRANSFER_ENCODING};
+use http::header::{CONTENT_LENGTH, COOKIE, EXPECT, HOST, TRANSFER_ENCODING};
 use http::{HeaderMap, HeaderName, HeaderValue, Request, Response, StatusCode};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tracing::warn;
@@ -134,7 +134,15 @@ async fn handle_h2_stream(
             return Err(error);
         }
     };
-    if let Err(error) = validate_h2_request_headers(&parts.headers) {
+    if !method.eq_ignore_ascii_case("CONNECT") && parts.uri.scheme_str() != Some("https") {
+        let entry = deny_entry(mode, DenyReason::MalformedHeaders, None, Some(&authority));
+        append_deny_log(&deny_log, entry)
+            .await
+            .context("failed to append h2 scheme deny log entry")?;
+        respond.send_reset(h2::Reason::PROTOCOL_ERROR);
+        return Ok(());
+    }
+    if let Err(error) = validate_h2_request_headers(&parts.headers, body.is_end_stream()) {
         let entry = deny_entry(mode, DenyReason::MalformedHeaders, None, Some(&authority));
         append_deny_log(&deny_log, entry)
             .await
@@ -164,8 +172,9 @@ async fn handle_h2_stream(
             return Ok(());
         }
     };
+    let headers = fold_request_cookies(policy.headers);
 
-    if has_expect_100_continue(&policy.headers) {
+    if has_expect_100_continue(&headers) {
         let entry = deny_entry(
             mode,
             DenyReason::ExpectContinueUnsupported,
@@ -180,23 +189,18 @@ async fn handle_h2_stream(
         return Ok(());
     }
 
-    let (header_bytes, use_chunked) = match build_h1_request_head(
-        &method,
-        &target,
-        &authority,
-        &policy.headers,
-        body.is_end_stream(),
-    ) {
-        Ok(result) => result,
-        Err(deny) => {
-            let entry = deny_entry(mode, deny.reason, None, Some(&authority));
-            append_deny_log(&deny_log, entry)
-                .await
-                .context("failed to append h2 request-header deny log entry")?;
-            respond.send_reset(deny.reset);
-            return Ok(());
-        }
-    };
+    let (header_bytes, use_chunked) =
+        match build_h1_request_head(&method, &target, &authority, &headers, body.is_end_stream()) {
+            Ok(result) => result,
+            Err(deny) => {
+                let entry = deny_entry(mode, deny.reason, None, Some(&authority));
+                append_deny_log(&deny_log, entry)
+                    .await
+                    .context("failed to append h2 request-header deny log entry")?;
+                respond.send_reset(deny.reset);
+                return Ok(());
+            }
+        };
 
     let mut upstream = match open_upstream().await {
         Ok(upstream) => upstream,
@@ -252,8 +256,9 @@ fn h2_request_authority(uri: &http::Uri, headers: &HeaderMap) -> Result<String> 
     Ok(host.to_string())
 }
 
-fn validate_h2_request_headers(headers: &HeaderMap) -> Result<()> {
+fn validate_h2_request_headers(headers: &HeaderMap, body_is_end_stream: bool) -> Result<()> {
     let mut content_length_count = 0;
+    let mut content_length = None;
     for value in headers.get_all(CONTENT_LENGTH).iter() {
         content_length_count += 1;
         if content_length_count > 1 {
@@ -262,10 +267,14 @@ fn validate_h2_request_headers(headers: &HeaderMap) -> Result<()> {
         let value = value
             .to_str()
             .context("content-length request header is not visible ASCII")?;
-        value
+        let parsed = value
             .trim()
             .parse::<u64>()
             .context("invalid content-length request header")?;
+        content_length = Some(parsed);
+    }
+    if body_is_end_stream && content_length.is_some_and(|value| value != 0) {
+        return Err(anyhow!("nonzero content-length with end-stream h2 request"));
     }
 
     Ok(())
@@ -279,6 +288,31 @@ fn header_map_to_parts(headers: &HeaderMap) -> Vec<HeaderPart> {
             value: value.as_bytes().to_vec(),
         })
         .collect()
+}
+
+fn fold_request_cookies(headers: Vec<HeaderPart>) -> Vec<HeaderPart> {
+    let mut folded: Vec<HeaderPart> = Vec::with_capacity(headers.len());
+    let mut cookie_index = None;
+
+    for header in headers {
+        if header.name.eq_ignore_ascii_case(COOKIE.as_str()) {
+            match cookie_index {
+                Some(index) => {
+                    let existing: &mut HeaderPart = &mut folded[index];
+                    existing.value.extend_from_slice(b"; ");
+                    existing.value.extend_from_slice(&header.value);
+                }
+                None => {
+                    cookie_index = Some(folded.len());
+                    folded.push(header);
+                }
+            }
+        } else {
+            folded.push(header);
+        }
+    }
+
+    folded
 }
 
 fn has_expect_100_continue(headers: &[HeaderPart]) -> bool {
@@ -963,7 +997,7 @@ mod tests {
         headers.append(CONTENT_LENGTH, HeaderValue::from_static("5"));
         headers.append(CONTENT_LENGTH, HeaderValue::from_static("5"));
 
-        let error = validate_h2_request_headers(&headers)
+        let error = validate_h2_request_headers(&headers, false)
             .expect_err("duplicate h2 content-length should be rejected");
         assert!(error.to_string().contains("duplicate content-length"));
     }
@@ -973,9 +1007,19 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert(CONTENT_LENGTH, HeaderValue::from_static("5, 5"));
 
-        let error = validate_h2_request_headers(&headers)
+        let error = validate_h2_request_headers(&headers, false)
             .expect_err("invalid h2 content-length should be rejected");
         assert!(error.to_string().contains("invalid content-length"));
+    }
+
+    #[test]
+    fn rejects_nonzero_h2_content_length_with_end_stream_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_LENGTH, HeaderValue::from_static("5"));
+
+        let error = validate_h2_request_headers(&headers, true)
+            .expect_err("nonzero end-stream h2 content-length should be rejected");
+        assert!(error.to_string().contains("nonzero content-length"));
     }
 
     #[test]
@@ -1107,6 +1151,160 @@ mod tests {
         let expected = general_purpose::STANDARD.encode("user:sk-real");
         assert!(request_text.contains(&format!("authorization: Basic {expected}\r\n")));
         assert!(!request_text.contains(placeholder));
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_folds_split_cookie_headers_into_single_h1_cookie() -> Result<()> {
+        let sni = "api.openai.com";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            "__DSEC_41414141414141416161616161616161__",
+            "sk-real",
+            &[sni],
+        )?);
+        let (request_tx, mut request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_opener(
+            request_tx,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        );
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            deny_log,
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let request = Request::builder()
+            .method("GET")
+            .uri(format!("https://{sni}/cookies"))
+            .header("cookie", "a=1")
+            .header("cookie", "b=2")
+            .body(())?;
+        let (response, _stream) = send_request.send_request(request, true)?;
+        let response = response.await?;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let request_text = request_rx
+            .recv()
+            .await
+            .ok_or_else(|| anyhow!("test upstream did not receive request"))?;
+        assert_eq!(h1_header_values(&request_text, "cookie"), vec!["a=1; b=2"]);
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_folds_split_cookie_headers_after_dsec_substitution() -> Result<()> {
+        let sni = "api.openai.com";
+        let placeholder = "__DSEC_42424242424242426262626262626262__";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            placeholder,
+            "cookie-secret",
+            &[sni],
+        )?);
+        let (request_tx, mut request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_opener(
+            request_tx,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        );
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            deny_log,
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let request = Request::builder()
+            .method("GET")
+            .uri(format!("https://{sni}/cookies"))
+            .header("cookie", "a=1")
+            .header("cookie", format!("session={placeholder}"))
+            .body(())?;
+        let (response, _stream) = send_request.send_request(request, true)?;
+        let response = response.await?;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let request_text = request_rx
+            .recv()
+            .await
+            .ok_or_else(|| anyhow!("test upstream did not receive request"))?;
+        assert_eq!(
+            h1_header_values(&request_text, "cookie"),
+            vec!["a=1; session=cookie-secret"]
+        );
+        assert!(!request_text.contains(placeholder));
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_passes_through_single_cookie_header() -> Result<()> {
+        let sni = "api.openai.com";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            "__DSEC_43434343434343436363636363636363__",
+            "sk-real",
+            &[sni],
+        )?);
+        let (request_tx, mut request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_opener(
+            request_tx,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        );
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            deny_log,
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let request = Request::builder()
+            .method("GET")
+            .uri(format!("https://{sni}/cookies"))
+            .header("cookie", "a=1")
+            .body(())?;
+        let (response, _stream) = send_request.send_request(request, true)?;
+        let response = response.await?;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let request_text = request_rx
+            .recv()
+            .await
+            .ok_or_else(|| anyhow!("test upstream did not receive request"))?;
+        assert_eq!(h1_header_values(&request_text, "cookie"), vec!["a=1"]);
 
         drop(send_request);
         connection_task.abort();
@@ -1949,6 +2147,151 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn h2_bridge_does_not_open_upstream_on_nonzero_cl_with_end_stream_headers() -> Result<()>
+    {
+        let sni = "api.openai.com";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            "__DSEC_44444444444444446464646464646464__",
+            "sk-real",
+            &[sni],
+        )?);
+        let open_count = Arc::new(AtomicUsize::new(0));
+        let (request_tx, _request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_counting_opener(
+            Arc::clone(&open_count),
+            request_tx,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        );
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            Arc::clone(&deny_log),
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let request = Request::builder()
+            .method("POST")
+            .uri(format!("https://{sni}/bad-length"))
+            .header("content-length", "5")
+            .body(())?;
+        let (response, _stream) = send_request.send_request(request, true)?;
+        let error = match response.await {
+            Ok(_) => {
+                return Err(anyhow!(
+                    "nonzero end-stream h2 content-length should reset the stream"
+                ))
+            }
+            Err(error) => error,
+        };
+        assert_h2_reset_reason(error, h2::Reason::PROTOCOL_ERROR);
+
+        assert_eq!(open_count.load(Ordering::SeqCst), 0);
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_does_not_complete_request_on_cl_overflow() -> Result<()> {
+        let sni = "api.openai.com";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            "__DSEC_45454545454545456565656565656565__",
+            "sk-real",
+            &[sni],
+        )?);
+        let (request_tx, mut request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_opener_capture_until_eof(request_tx);
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            deny_log,
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let request = Request::builder()
+            .method("POST")
+            .uri(format!("https://{sni}/length-overflow"))
+            .header("content-length", "5")
+            .body(())?;
+        let (response, mut stream) = send_request.send_request(request, false)?;
+        stream.send_data(Bytes::from_static(b"hello!"), true)?;
+        let error = match response.await {
+            Ok(_) => return Err(anyhow!("content-length overflow should reset the stream")),
+            Err(error) => error,
+        };
+        assert_h2_reset(error);
+        assert_no_complete_chunked_request(&mut request_rx).await?;
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_does_not_complete_request_on_cl_underflow() -> Result<()> {
+        let sni = "api.openai.com";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            "__DSEC_46464646464646466666666666666666__",
+            "sk-real",
+            &[sni],
+        )?);
+        let (request_tx, mut request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_opener_capture_until_eof(request_tx);
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            deny_log,
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let request = Request::builder()
+            .method("POST")
+            .uri(format!("https://{sni}/length-underflow"))
+            .header("content-length", "5")
+            .body(())?;
+        let (response, mut stream) = send_request.send_request(request, false)?;
+        stream.send_data(Bytes::from_static(b"hey"), true)?;
+        let error = match response.await {
+            Ok(_) => return Err(anyhow!("content-length underflow should reset the stream")),
+            Err(error) => error,
+        };
+        assert_h2_reset(error);
+        assert_no_complete_chunked_request(&mut request_rx).await?;
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn h2_bridge_accepts_empty_request_trailers() -> Result<()> {
         let sni = "api.openai.com";
         let secret_table = Arc::new(secret_table_with_secret(
@@ -2143,6 +2486,114 @@ mod tests {
             deny_log_text.contains("\"reason\":\"host_sni_mismatch\""),
             "deny log should record host_sni_mismatch, got: {deny_log_text}"
         );
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_rejects_http_scheme_on_tls_session() -> Result<()> {
+        let sni = "api.openai.com";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            "__DSEC_47474747474747476767676767676767__",
+            "sk-real",
+            &[sni],
+        )?);
+        let open_count = Arc::new(AtomicUsize::new(0));
+        let (request_tx, _request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_counting_opener(
+            Arc::clone(&open_count),
+            request_tx,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        );
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            Arc::clone(&deny_log),
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let request = Request::builder()
+            .method("GET")
+            .uri(format!("http://{sni}/plain"))
+            .body(())?;
+        let (response, _stream) = send_request.send_request(request, true)?;
+        let error = match response.await {
+            Ok(_) => return Err(anyhow!("http :scheme should reset the stream")),
+            Err(error) => error,
+        };
+        assert_h2_reset_reason(error, h2::Reason::PROTOCOL_ERROR);
+
+        let deny_log_text = tokio::fs::read_to_string(deny_log.as_ref()).await?;
+        assert!(
+            deny_log_text.contains("\"reason\":\"malformed_headers\""),
+            "deny log should record malformed_headers, got: {deny_log_text}"
+        );
+        assert_eq!(open_count.load(Ordering::SeqCst), 0);
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_rejects_unknown_scheme_on_tls_session() -> Result<()> {
+        let sni = "api.openai.com";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            "__DSEC_48484848484848486868686868686868__",
+            "sk-real",
+            &[sni],
+        )?);
+        let open_count = Arc::new(AtomicUsize::new(0));
+        let (request_tx, _request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_counting_opener(
+            Arc::clone(&open_count),
+            request_tx,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        );
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            Arc::clone(&deny_log),
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let request = Request::builder()
+            .method("GET")
+            .uri(format!("ftp://{sni}/plain"))
+            .body(())?;
+        let (response, _stream) = send_request.send_request(request, true)?;
+        let error = match response.await {
+            Ok(_) => return Err(anyhow!("unknown :scheme should reset the stream")),
+            Err(error) => error,
+        };
+        assert_h2_reset_reason(error, h2::Reason::PROTOCOL_ERROR);
+
+        let deny_log_text = tokio::fs::read_to_string(deny_log.as_ref()).await?;
+        assert!(
+            deny_log_text.contains("\"reason\":\"malformed_headers\""),
+            "deny log should record malformed_headers, got: {deny_log_text}"
+        );
+        assert_eq!(open_count.load(Ordering::SeqCst), 0);
 
         drop(send_request);
         connection_task.abort();
@@ -2531,6 +2982,47 @@ mod tests {
         }
         ensure!(body.trailers().await?.is_none(), "unexpected trailers");
         Ok(output)
+    }
+
+    fn h1_header_values<'a>(request_text: &'a str, name: &str) -> Vec<&'a str> {
+        request_text
+            .lines()
+            .filter_map(|line| {
+                let (header_name, value) = line.split_once(": ")?;
+                if header_name.eq_ignore_ascii_case(name) {
+                    Some(value.trim_end_matches('\r'))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    async fn assert_no_complete_chunked_request(
+        request_rx: &mut mpsc::UnboundedReceiver<String>,
+    ) -> Result<()> {
+        let request_text = match tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            request_rx.recv(),
+        )
+        .await
+        {
+            Ok(Some(request_text)) => request_text,
+            Ok(None) | Err(_) => return Ok(()),
+        };
+        assert!(request_text.contains("Transfer-Encoding: chunked\r\n"));
+        assert!(
+            !request_text.contains("\r\n0\r\n\r\n"),
+            "upstream received a complete chunked request: {request_text}"
+        );
+        Ok(())
+    }
+
+    fn assert_h2_reset(error: h2::Error) {
+        assert!(
+            error.reason().is_some(),
+            "expected h2 reset reason, got: {error}"
+        );
     }
 
     fn assert_h2_reset_reason(error: h2::Error, reason: h2::Reason) {

--- a/cli/dust-sandbox/src/commands/forward/http2_rewriter.rs
+++ b/cli/dust-sandbox/src/commands/forward/http2_rewriter.rs
@@ -58,13 +58,6 @@ impl H2RequestDeny {
             reset: h2::Reason::INTERNAL_ERROR,
         }
     }
-
-    fn refused(reason: DenyReason) -> Self {
-        Self {
-            reason,
-            reset: h2::Reason::REFUSED_STREAM,
-        }
-    }
 }
 
 enum WriteH1RequestError {
@@ -155,23 +148,6 @@ async fn handle_h2_stream(
         target: target.clone(),
         headers,
     };
-
-    if method.eq_ignore_ascii_case("CONNECT") && is_h2_websocket_connect(&parts.extensions) {
-        let entry = deny_entry(
-            mode,
-            DenyReason::H2WebsocketUnsupported,
-            None,
-            Some(&authority),
-        );
-        append_deny_log(&deny_log, entry)
-            .await
-            .context("failed to append h2 websocket deny log entry")?;
-        // REFUSED_STREAM (vs INTERNAL_ERROR for policy denies below) signals
-        // per RFC 7540 that the request was never processed, which is honest
-        // for an unconditional protocol-level refusal.
-        respond.send_reset(h2::Reason::REFUSED_STREAM);
-        return Ok(());
-    }
 
     let policy = match process_request_policy(
         &policy_request,
@@ -352,17 +328,6 @@ fn discard_h2_request_body(mut body: RecvStream) {
     });
 }
 
-fn is_h2_websocket_connect(extensions: &http::Extensions) -> bool {
-    // RFC 8441 extended CONNECT: the `:protocol` pseudo-header is carried by
-    // the h2 crate as `h2::ext::Protocol` in the request extensions, NOT as a
-    // header. Looking it up in the header map (as an earlier version did)
-    // would always miss real h2 WebSocket bootstraps.
-    extensions
-        .get::<h2::ext::Protocol>()
-        .map(|protocol| protocol.as_str().eq_ignore_ascii_case("websocket"))
-        .unwrap_or(false)
-}
-
 fn build_h1_request_head(
     method: &str,
     target: &str,
@@ -370,10 +335,9 @@ fn build_h1_request_head(
     headers: &[HeaderPart],
     body_is_end_stream: bool,
 ) -> std::result::Result<(Vec<u8>, bool), H2RequestDeny> {
-    let has_content_length = headers
-        .iter()
-        .any(|header| header.name.eq_ignore_ascii_case(CONTENT_LENGTH.as_str()));
-    let use_chunked = !has_content_length && !body_is_end_stream;
+    // Force chunked framing whenever there is a request body stream. If h2
+    // trailers arrive after DATA, we can withhold the h1 chunked terminator.
+    let use_chunked = !body_is_end_stream;
     let mut header_bytes = Vec::new();
     append_h1_head_bytes(
         &mut header_bytes,
@@ -387,6 +351,9 @@ fn build_h1_request_head(
 
     for header in headers {
         if should_strip_h1_bridge_header(&header.name) {
+            continue;
+        }
+        if use_chunked && header.name.eq_ignore_ascii_case(CONTENT_LENGTH.as_str()) {
             continue;
         }
         append_h1_header_line(&mut header_bytes, header.name.as_bytes(), &header.value)?;
@@ -445,11 +412,11 @@ where
         let chunk = chunk
             .context("failed to read h2 request body chunk")
             .map_err(WriteH1RequestError::Bridge)?;
-        body.flow_control()
-            .release_capacity(chunk.len())
-            .context("failed to release h2 request flow-control capacity")
-            .map_err(WriteH1RequestError::Bridge)?;
         if chunk.is_empty() {
+            body.flow_control()
+                .release_capacity(chunk.len())
+                .context("failed to release h2 request flow-control capacity")
+                .map_err(WriteH1RequestError::Bridge)?;
             continue;
         }
         if use_chunked {
@@ -475,6 +442,10 @@ where
                 .context("failed to write h1 request body chunk")
                 .map_err(WriteH1RequestError::Bridge)?;
         }
+        body.flow_control()
+            .release_capacity(chunk.len())
+            .context("failed to release h2 request flow-control capacity")
+            .map_err(WriteH1RequestError::Bridge)?;
     }
 
     if let Some(trailers) = body
@@ -484,7 +455,7 @@ where
         .map_err(WriteH1RequestError::Bridge)?
     {
         if !trailers.is_empty() {
-            return Err(WriteH1RequestError::Denied(H2RequestDeny::refused(
+            return Err(WriteH1RequestError::Denied(H2RequestDeny::internal(
                 DenyReason::RequestTrailersUnsupported,
             )));
         }
@@ -1141,7 +1112,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn h2_bridge_forwards_request_body_with_content_length() -> Result<()> {
+    async fn h2_bridge_forces_chunked_when_content_length_present_and_body_not_end_stream(
+    ) -> Result<()> {
         let sni = "api.openai.com";
         let secret_table = Arc::new(secret_table_with_secret(
             "OPENAI_API_KEY",
@@ -1150,7 +1122,7 @@ mod tests {
             &[sni],
         )?);
         let (request_tx, mut request_rx) = mpsc::unbounded_channel();
-        let opener = test_h1_opener_with_content_length_body(
+        let opener = test_h1_opener_with_chunked_body(
             request_tx,
             b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
         );
@@ -1184,8 +1156,63 @@ mod tests {
             .await
             .ok_or_else(|| anyhow!("test upstream did not receive request"))?;
         assert!(request_text.contains("POST /upload HTTP/1.1\r\n"));
-        assert!(request_text.contains("content-length: 5\r\n"));
-        assert!(request_text.ends_with("\r\n\r\nhello"));
+        assert!(request_text.contains("Transfer-Encoding: chunked\r\n"));
+        assert!(!request_text
+            .to_ascii_lowercase()
+            .contains("content-length:"));
+        assert!(request_text.ends_with("\r\n\r\n5\r\nhello\r\n0\r\n\r\n"));
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_end_stream_with_content_length_keeps_content_length() -> Result<()> {
+        let sni = "api.openai.com";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            "__DSEC_32323232323232325454545454545454__",
+            "sk-real",
+            &[sni],
+        )?);
+        let (request_tx, mut request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_opener(
+            request_tx,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        );
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            deny_log,
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let request = Request::builder()
+            .method("POST")
+            .uri(format!("https://{sni}/empty-upload"))
+            .header("content-length", "0")
+            .body(())?;
+        let (response, _stream) = send_request.send_request(request, true)?;
+        let response = response.await?;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(read_h2_body(response.into_body()).await?, b"ok");
+
+        let request_text = request_rx
+            .recv()
+            .await
+            .ok_or_else(|| anyhow!("test upstream did not receive request"))?;
+        assert!(request_text.contains("POST /empty-upload HTTP/1.1\r\n"));
+        assert!(request_text.contains("content-length: 0\r\n"));
+        assert!(!request_text.contains("Transfer-Encoding: chunked\r\n"));
 
         drop(send_request);
         connection_task.abort();
@@ -1829,16 +1856,90 @@ mod tests {
         let mut trailers = HeaderMap::new();
         trailers.insert("x-trailer", HeaderValue::from_static("value"));
         stream.send_trailers(trailers)?;
-        assert!(
-            response.await.is_err(),
-            "non-empty h2 request trailers should reset the stream"
-        );
+        let error = match response.await {
+            Ok(_) => {
+                return Err(anyhow!(
+                    "non-empty h2 request trailers should reset the stream"
+                ))
+            }
+            Err(error) => error,
+        };
+        assert_h2_reset_reason(error, h2::Reason::INTERNAL_ERROR);
 
         let deny_log_text = tokio::fs::read_to_string(deny_log.as_ref()).await?;
         assert!(
             deny_log_text.contains("\"reason\":\"request_trailers_unsupported\""),
             "deny log should record request_trailers_unsupported, got: {deny_log_text}"
         );
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_denies_trailers_with_content_length() -> Result<()> {
+        let sni = "api.openai.com";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            "__DSEC_34343434343434345656565656565656__",
+            "sk-real",
+            &[sni],
+        )?);
+        let (request_tx, mut request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_opener_capture_until_eof(request_tx);
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            Arc::clone(&deny_log),
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let request = Request::builder()
+            .method("POST")
+            .uri(format!("https://{sni}/trailers-with-length"))
+            .header("content-length", "5")
+            .body(())?;
+        let (response, mut stream) = send_request.send_request(request, false)?;
+        stream.send_data(Bytes::from_static(b"hello"), false)?;
+        let mut trailers = HeaderMap::new();
+        trailers.insert("x-trailer", HeaderValue::from_static("value"));
+        stream.send_trailers(trailers)?;
+        let error = match response.await {
+            Ok(_) => {
+                return Err(anyhow!(
+                    "content-length plus non-empty h2 trailers should reset the stream"
+                ))
+            }
+            Err(error) => error,
+        };
+        assert_h2_reset_reason(error, h2::Reason::INTERNAL_ERROR);
+
+        let deny_log_text = tokio::fs::read_to_string(deny_log.as_ref()).await?;
+        assert!(
+            deny_log_text.contains("\"reason\":\"request_trailers_unsupported\""),
+            "deny log should record request_trailers_unsupported, got: {deny_log_text}"
+        );
+        let request_text =
+            tokio::time::timeout(std::time::Duration::from_secs(1), request_rx.recv())
+                .await
+                .context("test upstream did not observe the partial request before shutdown")?
+                .ok_or_else(|| anyhow!("test upstream capture channel closed"))?;
+        assert!(request_text.contains("POST /trailers-with-length HTTP/1.1\r\n"));
+        assert!(request_text.contains("Transfer-Encoding: chunked\r\n"));
+        assert!(!request_text
+            .to_ascii_lowercase()
+            .contains("content-length:"));
+        assert!(request_text.ends_with("\r\n\r\n5\r\nhello\r\n"));
+        assert!(!request_text.ends_with("\r\n\r\n5\r\nhello\r\n0\r\n\r\n"));
 
         drop(send_request);
         connection_task.abort();
@@ -2229,37 +2330,20 @@ mod tests {
         })
     }
 
-    fn test_h1_opener_with_content_length_body(
+    fn test_h1_opener_capture_until_eof(
         request_tx: mpsc::UnboundedSender<String>,
-        response: impl Into<Vec<u8>>,
     ) -> OpenH1Upstream {
-        let response = Arc::new(response.into());
         Arc::new(move || {
             let request_tx = request_tx.clone();
-            let response = Arc::clone(&response);
             Box::pin(async move {
                 let (dsbx_io, mut upstream_io) = tokio::io::duplex(64 * 1024);
                 tokio::spawn(async move {
                     let mut request = Vec::new();
-                    loop {
-                        let mut byte = [0_u8; 1];
-                        upstream_io.read_exact(&mut byte).await?;
-                        request.push(byte[0]);
-                        if request.ends_with(b"\r\n\r\n") {
-                            break;
-                        }
-                    }
-                    let header_text = String::from_utf8(request.clone())?;
-                    let content_length = parse_test_content_length(&header_text)?;
-                    let mut body = vec![0_u8; content_length];
-                    upstream_io.read_exact(&mut body).await?;
-                    request.extend_from_slice(&body);
+                    upstream_io.read_to_end(&mut request).await?;
                     let request_text = String::from_utf8(request)?;
                     request_tx
                         .send(request_text)
                         .map_err(|_| anyhow!("failed to send captured request"))?;
-                    upstream_io.write_all(response.as_slice()).await?;
-                    upstream_io.shutdown().await?;
                     Ok::<(), anyhow::Error>(())
                 });
                 Ok(Box::new(dsbx_io) as BoxedAsyncReadWrite)
@@ -2437,19 +2521,6 @@ mod tests {
         }
     }
 
-    fn parse_test_content_length(headers: &str) -> Result<usize> {
-        headers
-            .lines()
-            .find_map(|line| {
-                line.split_once(':').and_then(|(name, value)| {
-                    name.eq_ignore_ascii_case("content-length")
-                        .then(|| value.trim().parse::<usize>())
-                })
-            })
-            .ok_or_else(|| anyhow!("missing content-length"))?
-            .context("invalid content-length")
-    }
-
     async fn read_h2_body(mut body: RecvStream) -> Result<Vec<u8>> {
         let mut output = Vec::new();
         while let Some(chunk) = body.data().await {
@@ -2459,6 +2530,14 @@ mod tests {
         }
         ensure!(body.trailers().await?.is_none(), "unexpected trailers");
         Ok(output)
+    }
+
+    fn assert_h2_reset_reason(error: h2::Error, reason: h2::Reason) {
+        assert_eq!(
+            error.reason(),
+            Some(reason),
+            "unexpected h2 reset reason: {error}"
+        );
     }
 
     fn secret_table_with_secret(

--- a/cli/dust-sandbox/src/commands/forward/http2_rewriter.rs
+++ b/cli/dust-sandbox/src/commands/forward/http2_rewriter.rs
@@ -1,0 +1,1419 @@
+use std::future::{poll_fn, Future};
+use std::pin::Pin;
+use std::sync::Arc;
+
+use anyhow::{anyhow, Context, Result};
+use bytes::Bytes;
+use h2::server::SendResponse;
+use h2::{RecvStream, SendStream};
+use http::header::{CONTENT_LENGTH, HOST, TRANSFER_ENCODING};
+use http::{HeaderMap, HeaderName, HeaderValue, Request, Response, StatusCode};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tracing::warn;
+
+use crate::egress_secrets::SecretTable;
+
+use super::deny_log::{append_deny_log, DenyReason};
+use super::rewrite_policy::{
+    deny_entry, process_request_policy, Authority, HeaderPart, RequestParts, RewriteMode,
+};
+
+const H2_MAX_CONCURRENT_STREAMS: u32 = 256;
+const READ_CHUNK_BYTES: usize = 8 * 1024;
+const MAX_HEADER_BLOCK_BYTES: usize = 64 * 1024;
+const MAX_HEADER_LINE_BYTES: usize = 16 * 1024;
+const MAX_TRAILER_BLOCK_BYTES: usize = 64 * 1024;
+
+pub(super) trait AsyncReadWrite: AsyncRead + AsyncWrite + Unpin + Send {}
+
+impl<T> AsyncReadWrite for T where T: AsyncRead + AsyncWrite + Unpin + Send {}
+
+pub(super) type BoxedAsyncReadWrite = Box<dyn AsyncReadWrite>;
+// The authority is intentionally not a parameter: every h2 stream on a session
+// has already been gated by `process_request_policy` to match the session SNI,
+// so opening upstream means opening the SNI's upstream. The opener captures
+// the SNI itself; passing it back in would be redundant and would invite a
+// future relaxation of the policy gate to silently bypass the SNI binding.
+pub(super) type OpenH1Upstream = Arc<
+    dyn Fn() -> Pin<Box<dyn Future<Output = Result<BoxedAsyncReadWrite>> + Send>> + Send + Sync,
+>;
+
+pub(super) async fn run_h2_to_h1_bridge<C>(
+    agent_tls: C,
+    sni: String,
+    secret_table: Arc<SecretTable>,
+    deny_log: Arc<std::path::PathBuf>,
+    open_upstream: OpenH1Upstream,
+) -> Result<()>
+where
+    C: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    let mut builder = h2::server::Builder::new();
+    builder
+        .max_concurrent_streams(H2_MAX_CONCURRENT_STREAMS)
+        // Advertise SETTINGS_ENABLE_CONNECT_PROTOCOL so RFC 8441 extended
+        // CONNECT bootstraps (h2 WebSocket) reach our handler and we can emit
+        // a structured `h2_websocket_unsupported` deny instead of letting the
+        // h2 protocol layer silently reject them. The handler resets the
+        // stream with REFUSED_STREAM after logging.
+        .enable_connect_protocol();
+    // We do not advertise SETTINGS_ENABLE_PUSH on the server side: per RFC 7540
+    // ENABLE_PUSH is the client telling the server whether it accepts pushes,
+    // and a server only pushes if it calls `push_promise`, which we do not.
+    // The opposite-direction client-side setting lives on h2::client::Builder
+    // and will be set in the outbound h2 origination slice.
+    let mut connection = builder
+        .handshake::<_, Bytes>(agent_tls)
+        .await
+        .context("failed to establish inbound h2 server session")?;
+
+    while let Some(accepted) = connection.accept().await {
+        let (request, respond) = accepted.context("failed to accept inbound h2 stream")?;
+        let sni = sni.clone();
+        let secret_table = Arc::clone(&secret_table);
+        let deny_log = Arc::clone(&deny_log);
+        let open_upstream = Arc::clone(&open_upstream);
+        tokio::spawn(async move {
+            if let Err(error) =
+                handle_h2_stream(request, respond, sni, secret_table, deny_log, open_upstream).await
+            {
+                warn!(error = %error, "h2 stream bridge failed");
+            }
+        });
+    }
+
+    Ok(())
+}
+
+async fn handle_h2_stream(
+    request: Request<RecvStream>,
+    mut respond: SendResponse<Bytes>,
+    sni: String,
+    secret_table: Arc<SecretTable>,
+    deny_log: Arc<std::path::PathBuf>,
+    open_upstream: OpenH1Upstream,
+) -> Result<()> {
+    let (parts, body) = request.into_parts();
+    let method = parts.method.to_string();
+    let target = h2_request_target(&parts.uri);
+    let mode = RewriteMode::Tls { sni: &sni };
+    let authority = match h2_request_authority(&parts.uri, &parts.headers) {
+        Ok(authority) => authority,
+        Err(error) => {
+            let entry = deny_entry(
+                RewriteMode::Tls { sni: &sni },
+                DenyReason::MalformedHeaders,
+                None,
+                None,
+            );
+            append_deny_log(&deny_log, entry)
+                .await
+                .context("failed to append h2 malformed-authority deny log entry")?;
+            respond.send_reset(h2::Reason::PROTOCOL_ERROR);
+            return Err(error);
+        }
+    };
+    if let Err(error) = validate_h2_request_headers(&parts.headers) {
+        let entry = deny_entry(mode, DenyReason::MalformedHeaders, None, Some(&authority));
+        append_deny_log(&deny_log, entry)
+            .await
+            .context("failed to append h2 malformed-header deny log entry")?;
+        respond.send_reset(h2::Reason::PROTOCOL_ERROR);
+        return Err(error);
+    }
+    let headers = header_map_to_parts(&parts.headers);
+    let policy_request = RequestParts {
+        method: method.clone(),
+        target: target.clone(),
+        headers,
+    };
+
+    if method.eq_ignore_ascii_case("CONNECT") && is_h2_websocket_connect(&parts.extensions) {
+        let entry = deny_entry(
+            mode,
+            DenyReason::H2WebsocketUnsupported,
+            None,
+            Some(&authority),
+        );
+        append_deny_log(&deny_log, entry)
+            .await
+            .context("failed to append h2 websocket deny log entry")?;
+        // REFUSED_STREAM (vs INTERNAL_ERROR for policy denies below) signals
+        // per RFC 7540 that the request was never processed, which is honest
+        // for an unconditional protocol-level refusal.
+        respond.send_reset(h2::Reason::REFUSED_STREAM);
+        return Ok(());
+    }
+
+    let policy = match process_request_policy(
+        &policy_request,
+        Authority::Explicit { value: &authority },
+        &secret_table,
+        mode,
+    ) {
+        Ok(policy) => policy,
+        Err(entry) => {
+            append_deny_log(&deny_log, entry)
+                .await
+                .context("failed to append h2 deny log entry")?;
+            respond.send_reset(h2::Reason::INTERNAL_ERROR);
+            return Ok(());
+        }
+    };
+
+    let mut upstream = match open_upstream().await {
+        Ok(upstream) => upstream,
+        Err(error) => {
+            respond.send_reset(h2::Reason::INTERNAL_ERROR);
+            return Err(error)
+                .with_context(|| format!("failed to open h1 upstream for {authority}"));
+        }
+    };
+    if let Err(error) = write_h1_request(
+        &mut upstream,
+        &method,
+        &target,
+        &authority,
+        &policy.headers,
+        body,
+    )
+    .await
+    {
+        respond.send_reset(h2::Reason::INTERNAL_ERROR);
+        return Err(error);
+    }
+    if let Err(error) = forward_h1_response_to_h2(&mut upstream, &mut respond, &method).await {
+        respond.send_reset(h2::Reason::INTERNAL_ERROR);
+        return Err(error);
+    }
+    let _ = upstream.shutdown().await;
+
+    Ok(())
+}
+
+fn h2_request_target(uri: &http::Uri) -> String {
+    uri.path_and_query()
+        .map(|value| value.as_str().to_string())
+        .unwrap_or_else(|| "/".to_string())
+}
+
+fn h2_request_authority(uri: &http::Uri, headers: &HeaderMap) -> Result<String> {
+    if let Some(authority) = uri.authority() {
+        return Ok(authority.as_str().to_string());
+    }
+
+    let Some(host) = headers.get(HOST) else {
+        return Err(anyhow!("h2 request missing :authority"));
+    };
+    let host = host
+        .to_str()
+        .context("h2 host header is not visible ASCII")?;
+    Ok(host.to_string())
+}
+
+fn validate_h2_request_headers(headers: &HeaderMap) -> Result<()> {
+    let mut content_length_count = 0;
+    for value in headers.get_all(CONTENT_LENGTH).iter() {
+        content_length_count += 1;
+        if content_length_count > 1 {
+            return Err(anyhow!("duplicate content-length in h2 request"));
+        }
+        let value = value
+            .to_str()
+            .context("content-length request header is not visible ASCII")?;
+        value
+            .trim()
+            .parse::<u64>()
+            .context("invalid content-length request header")?;
+    }
+
+    Ok(())
+}
+
+fn header_map_to_parts(headers: &HeaderMap) -> Vec<HeaderPart> {
+    headers
+        .iter()
+        .map(|(name, value)| HeaderPart {
+            name: name.as_str().to_string(),
+            value: value.as_bytes().to_vec(),
+        })
+        .collect()
+}
+
+fn is_h2_websocket_connect(extensions: &http::Extensions) -> bool {
+    // RFC 8441 extended CONNECT: the `:protocol` pseudo-header is carried by
+    // the h2 crate as `h2::ext::Protocol` in the request extensions, NOT as a
+    // header. Looking it up in the header map (as an earlier version did)
+    // would always miss real h2 WebSocket bootstraps.
+    extensions
+        .get::<h2::ext::Protocol>()
+        .map(|protocol| protocol.as_str().eq_ignore_ascii_case("websocket"))
+        .unwrap_or(false)
+}
+
+async fn write_h1_request<W>(
+    upstream: &mut W,
+    method: &str,
+    target: &str,
+    authority: &str,
+    headers: &[HeaderPart],
+    mut body: RecvStream,
+) -> Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    let has_content_length = headers
+        .iter()
+        .any(|header| header.name.eq_ignore_ascii_case(CONTENT_LENGTH.as_str()));
+    let use_chunked = !has_content_length && !body.is_end_stream();
+    let mut header_bytes = Vec::new();
+    header_bytes.extend_from_slice(format!("{method} {target} HTTP/1.1\r\n").as_bytes());
+    header_bytes.extend_from_slice(format!("Host: {authority}\r\n").as_bytes());
+    header_bytes.extend_from_slice(b"Connection: close\r\n");
+    if use_chunked {
+        header_bytes.extend_from_slice(b"Transfer-Encoding: chunked\r\n");
+    }
+
+    for header in headers {
+        if should_strip_h1_bridge_header(&header.name) {
+            continue;
+        }
+        header_bytes.extend_from_slice(header.name.as_bytes());
+        header_bytes.extend_from_slice(b": ");
+        header_bytes.extend_from_slice(&header.value);
+        header_bytes.extend_from_slice(b"\r\n");
+    }
+    header_bytes.extend_from_slice(b"\r\n");
+    upstream
+        .write_all(&header_bytes)
+        .await
+        .context("failed to write h1 request headers")?;
+
+    while let Some(chunk) = body.data().await {
+        let chunk = chunk.context("failed to read h2 request body chunk")?;
+        if use_chunked {
+            upstream
+                .write_all(format!("{:x}\r\n", chunk.len()).as_bytes())
+                .await
+                .context("failed to write h1 request chunk header")?;
+            upstream
+                .write_all(&chunk)
+                .await
+                .context("failed to write h1 request chunk body")?;
+            upstream
+                .write_all(b"\r\n")
+                .await
+                .context("failed to write h1 request chunk terminator")?;
+        } else {
+            upstream
+                .write_all(&chunk)
+                .await
+                .context("failed to write h1 request body chunk")?;
+        }
+        body.flow_control()
+            .release_capacity(chunk.len())
+            .context("failed to release h2 request flow-control capacity")?;
+    }
+
+    if let Some(trailers) = body
+        .trailers()
+        .await
+        .context("failed to read h2 trailers")?
+    {
+        if use_chunked {
+            write_h1_trailers(upstream, trailers).await?;
+        }
+    } else if use_chunked {
+        upstream
+            .write_all(b"0\r\n\r\n")
+            .await
+            .context("failed to terminate h1 chunked request body")?;
+    }
+
+    upstream
+        .flush()
+        .await
+        .context("failed to flush h1 request")?;
+    Ok(())
+}
+
+async fn write_h1_trailers<W>(upstream: &mut W, trailers: HeaderMap) -> Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    upstream
+        .write_all(b"0\r\n")
+        .await
+        .context("failed to write final h1 request chunk")?;
+    for (name, value) in trailers.iter() {
+        if should_strip_h1_bridge_header(name.as_str()) {
+            continue;
+        }
+        upstream
+            .write_all(name.as_str().as_bytes())
+            .await
+            .context("failed to write h1 trailer name")?;
+        upstream
+            .write_all(b": ")
+            .await
+            .context("failed to write h1 trailer separator")?;
+        upstream
+            .write_all(value.as_bytes())
+            .await
+            .context("failed to write h1 trailer value")?;
+        upstream
+            .write_all(b"\r\n")
+            .await
+            .context("failed to write h1 trailer terminator")?;
+    }
+    upstream
+        .write_all(b"\r\n")
+        .await
+        .context("failed to finish h1 trailers")?;
+    Ok(())
+}
+
+fn should_strip_h1_bridge_header(name: &str) -> bool {
+    matches!(
+        name.to_ascii_lowercase().as_str(),
+        "connection"
+            | "host"
+            | "keep-alive"
+            | "proxy-connection"
+            | "te"
+            | "transfer-encoding"
+            | "upgrade"
+    )
+}
+
+async fn forward_h1_response_to_h2<R>(
+    upstream: &mut R,
+    respond: &mut SendResponse<Bytes>,
+    request_method: &str,
+) -> Result<()>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut reader = H1ResponseReader::new(upstream);
+    let response_head = reader
+        .read_final_response_head()
+        .await
+        .context("failed to read h1 response head")?;
+    let no_body = response_has_no_body(request_method, response_head.status);
+    let mut response = Response::builder().status(response_head.status);
+    for header in &response_head.headers {
+        if should_strip_h1_bridge_header(header.name.as_str()) {
+            continue;
+        }
+        let name = HeaderName::from_bytes(header.name.as_bytes())
+            .context("invalid h1 response header name")?;
+        let value =
+            HeaderValue::from_bytes(&header.value).context("invalid h1 response header value")?;
+        response = response.header(name, value);
+    }
+    let response = response
+        .body(())
+        .context("failed to build h2 response head")?;
+
+    if no_body || response_head.body_kind == H1BodyKind::None {
+        respond
+            .send_response(response, true)
+            .context("failed to send h2 response head")?;
+        return Ok(());
+    }
+
+    let mut send = respond
+        .send_response(response, false)
+        .context("failed to send h2 response head")?;
+    match response_head.body_kind {
+        H1BodyKind::None => {}
+        H1BodyKind::ContentLength(len) => {
+            reader
+                .forward_content_length_body(len, &mut send)
+                .await
+                .context("failed to forward h1 content-length body")?;
+        }
+        H1BodyKind::Chunked => {
+            reader
+                .forward_chunked_body(&mut send)
+                .await
+                .context("failed to forward h1 chunked body")?;
+        }
+        H1BodyKind::EofDelimited => {
+            reader
+                .forward_eof_body(&mut send)
+                .await
+                .context("failed to forward h1 EOF-delimited body")?;
+        }
+    }
+
+    Ok(())
+}
+
+fn response_has_no_body(request_method: &str, status: StatusCode) -> bool {
+    request_method.eq_ignore_ascii_case("HEAD")
+        || status.is_informational()
+        || status == StatusCode::NO_CONTENT
+        || status == StatusCode::NOT_MODIFIED
+}
+
+struct H1ResponseHead {
+    status: StatusCode,
+    headers: Vec<HeaderPart>,
+    body_kind: H1BodyKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum H1BodyKind {
+    None,
+    ContentLength(usize),
+    Chunked,
+    EofDelimited,
+}
+
+struct H1ResponseReader<'a, R> {
+    inner: &'a mut R,
+    buffer: Vec<u8>,
+}
+
+impl<'a, R> H1ResponseReader<'a, R>
+where
+    R: AsyncRead + Unpin,
+{
+    fn new(inner: &'a mut R) -> Self {
+        Self {
+            inner,
+            buffer: Vec::new(),
+        }
+    }
+
+    async fn read_final_response_head(&mut self) -> Result<H1ResponseHead> {
+        loop {
+            let head = self.read_response_head().await?;
+            if !head.status.is_informational() {
+                return Ok(head);
+            }
+        }
+    }
+
+    async fn read_response_head(&mut self) -> Result<H1ResponseHead> {
+        let header_len = self.read_header_block().await?;
+        let mut headers = [httparse::EMPTY_HEADER; 256];
+        let mut response = httparse::Response::new(&mut headers);
+        let status = response
+            .parse(&self.buffer[..header_len])
+            .context("failed to parse h1 response head")?;
+        if !status.is_complete() {
+            return Err(anyhow!("incomplete h1 response head"));
+        }
+        let code = response
+            .code
+            .ok_or_else(|| anyhow!("h1 response missing status code"))?;
+        let status = StatusCode::from_u16(code).context("invalid h1 response status")?;
+        let headers = response
+            .headers
+            .iter()
+            .map(|header| HeaderPart {
+                name: header.name.to_string(),
+                value: header.value.to_vec(),
+            })
+            .collect::<Vec<_>>();
+        let body_kind = response_body_kind(&headers)?;
+        self.buffer.drain(..header_len);
+        Ok(H1ResponseHead {
+            status,
+            headers,
+            body_kind,
+        })
+    }
+
+    async fn read_header_block(&mut self) -> Result<usize> {
+        loop {
+            if let Some(header_end) = find_subslice(&self.buffer, b"\r\n\r\n") {
+                let header_len = header_end + 4;
+                if header_len > MAX_HEADER_BLOCK_BYTES {
+                    return Err(anyhow!("h1 response header block exceeded limit"));
+                }
+                return Ok(header_len);
+            }
+            if self.buffer.len() >= MAX_HEADER_BLOCK_BYTES {
+                return Err(anyhow!("h1 response header block exceeded limit"));
+            }
+            let mut chunk = [0_u8; READ_CHUNK_BYTES];
+            let bytes_read = self
+                .inner
+                .read(&mut chunk)
+                .await
+                .context("failed to read h1 response")?;
+            if bytes_read == 0 {
+                return Err(anyhow!("upstream closed before h1 response head"));
+            }
+            self.buffer.extend_from_slice(&chunk[..bytes_read]);
+        }
+    }
+
+    async fn read_line(&mut self) -> Result<Vec<u8>> {
+        loop {
+            if let Some(line_end) = find_subslice(&self.buffer, b"\r\n") {
+                let line_len = line_end + 2;
+                if line_len > MAX_HEADER_LINE_BYTES {
+                    return Err(anyhow!("h1 line exceeded limit"));
+                }
+                let line = self.buffer[..line_len].to_vec();
+                self.buffer.drain(..line_len);
+                return Ok(line);
+            }
+            if self.buffer.len() > MAX_HEADER_LINE_BYTES {
+                return Err(anyhow!("h1 line exceeded limit"));
+            }
+            let mut chunk = [0_u8; READ_CHUNK_BYTES];
+            let bytes_read = self
+                .inner
+                .read(&mut chunk)
+                .await
+                .context("failed to read h1 line")?;
+            if bytes_read == 0 {
+                return Err(anyhow!("upstream closed before line terminator"));
+            }
+            self.buffer.extend_from_slice(&chunk[..bytes_read]);
+        }
+    }
+
+    async fn read_exact_bytes(&mut self, len: usize) -> Result<Bytes> {
+        while self.buffer.len() < len {
+            let mut chunk = [0_u8; READ_CHUNK_BYTES];
+            let bytes_read = self
+                .inner
+                .read(&mut chunk)
+                .await
+                .context("failed to read h1 body")?;
+            if bytes_read == 0 {
+                return Err(anyhow!("upstream closed mid-body"));
+            }
+            self.buffer.extend_from_slice(&chunk[..bytes_read]);
+        }
+        let bytes = Bytes::copy_from_slice(&self.buffer[..len]);
+        self.buffer.drain(..len);
+        Ok(bytes)
+    }
+
+    async fn forward_content_length_body(
+        &mut self,
+        len: usize,
+        send: &mut SendStream<Bytes>,
+    ) -> Result<()> {
+        let mut remaining = len;
+        if remaining == 0 {
+            send_data(send, Bytes::new(), true).await?;
+            return Ok(());
+        }
+
+        while remaining > 0 {
+            let chunk_len = remaining.min(READ_CHUNK_BYTES);
+            let chunk = self.read_exact_bytes(chunk_len).await?;
+            remaining -= chunk.len();
+            send_data(send, chunk, remaining == 0).await?;
+        }
+        Ok(())
+    }
+
+    async fn forward_chunked_body(&mut self, send: &mut SendStream<Bytes>) -> Result<()> {
+        loop {
+            let line = self.read_line().await?;
+            let chunk_size = parse_chunk_size(&line)?;
+            if chunk_size == 0 {
+                let trailers = self.read_trailers().await?;
+                if trailers.is_empty() {
+                    send_data(send, Bytes::new(), true).await?;
+                } else {
+                    send.send_trailers(trailers)
+                        .context("failed to send h2 response trailers")?;
+                }
+                return Ok(());
+            }
+            let chunk = self.read_exact_bytes(chunk_size).await?;
+            let crlf = self.read_exact_bytes(2).await?;
+            if crlf.as_ref() != b"\r\n" {
+                return Err(anyhow!("h1 chunk missing CRLF"));
+            }
+            send_data(send, chunk, false).await?;
+        }
+    }
+
+    async fn read_trailers(&mut self) -> Result<HeaderMap> {
+        let mut trailer_bytes = Vec::new();
+        loop {
+            let line = self.read_line().await?;
+            trailer_bytes.extend_from_slice(&line);
+            if trailer_bytes.len() > MAX_TRAILER_BLOCK_BYTES {
+                return Err(anyhow!("h1 trailer block exceeded limit"));
+            }
+            if line == b"\r\n" {
+                break;
+            }
+        }
+
+        let mut map = HeaderMap::new();
+        if trailer_bytes == b"\r\n" {
+            return Ok(map);
+        }
+        let mut headers = [httparse::EMPTY_HEADER; 64];
+        let mut request = httparse::Request::new(&mut headers);
+        let mut synthetic = b"GET / HTTP/1.1\r\n".to_vec();
+        synthetic.extend_from_slice(&trailer_bytes);
+        request
+            .parse(&synthetic)
+            .context("failed to parse h1 trailers")?;
+        for header in request.headers.iter() {
+            if should_strip_h1_bridge_header(header.name) {
+                continue;
+            }
+            let name = HeaderName::from_bytes(header.name.as_bytes())
+                .context("invalid h1 trailer name")?;
+            let value =
+                HeaderValue::from_bytes(header.value).context("invalid h1 trailer value")?;
+            map.append(name, value);
+        }
+        Ok(map)
+    }
+
+    async fn forward_eof_body(&mut self, send: &mut SendStream<Bytes>) -> Result<()> {
+        if !self.buffer.is_empty() {
+            let bytes = Bytes::copy_from_slice(&self.buffer);
+            self.buffer.clear();
+            send_data(send, bytes, false).await?;
+        }
+
+        loop {
+            let mut chunk = vec![0_u8; READ_CHUNK_BYTES];
+            let bytes_read = self
+                .inner
+                .read(&mut chunk)
+                .await
+                .context("failed to read EOF-delimited h1 body")?;
+            if bytes_read == 0 {
+                send_data(send, Bytes::new(), true).await?;
+                return Ok(());
+            }
+            chunk.truncate(bytes_read);
+            send_data(send, Bytes::from(chunk), false).await?;
+        }
+    }
+}
+
+fn response_body_kind(headers: &[HeaderPart]) -> Result<H1BodyKind> {
+    let mut content_length = None;
+    let mut seen_content_length = false;
+    let mut seen_transfer_encoding = false;
+    let mut has_chunked_transfer_encoding = false;
+
+    for header in headers {
+        if header.name.eq_ignore_ascii_case(CONTENT_LENGTH.as_str()) {
+            if seen_content_length {
+                return Err(anyhow!("duplicate content-length in h1 response"));
+            }
+            seen_content_length = true;
+            let value = std::str::from_utf8(&header.value)
+                .context("content-length response header is not utf8")?;
+            content_length = Some(
+                value
+                    .trim()
+                    .parse::<usize>()
+                    .context("invalid content-length response header")?,
+            );
+        } else if header.name.eq_ignore_ascii_case(TRANSFER_ENCODING.as_str()) {
+            if seen_transfer_encoding {
+                return Err(anyhow!("multiple h1 response transfer-encoding headers"));
+            }
+            seen_transfer_encoding = true;
+            let value = std::str::from_utf8(&header.value)
+                .context("transfer-encoding response header is not utf8")?;
+            let mut tokens = value
+                .split(',')
+                .map(str::trim)
+                .filter(|value| !value.is_empty());
+            match (tokens.next(), tokens.next()) {
+                (Some(token), None) if token.eq_ignore_ascii_case("chunked") => {
+                    has_chunked_transfer_encoding = true;
+                }
+                _ => return Err(anyhow!("unsupported h1 response transfer-encoding")),
+            }
+        }
+    }
+
+    if has_chunked_transfer_encoding {
+        return Ok(H1BodyKind::Chunked);
+    }
+
+    Ok(content_length.map_or(H1BodyKind::EofDelimited, H1BodyKind::ContentLength))
+}
+
+fn parse_chunk_size(line: &[u8]) -> Result<usize> {
+    let text = std::str::from_utf8(line).context("chunk size line is not utf8")?;
+    let line = text
+        .strip_suffix("\r\n")
+        .ok_or_else(|| anyhow!("chunk size line missing CRLF"))?;
+    let size = line.split_once(';').map_or(line, |(size, _)| size).trim();
+    usize::from_str_radix(size, 16).context("invalid chunk size")
+}
+
+async fn send_data(send: &mut SendStream<Bytes>, data: Bytes, end_stream: bool) -> Result<()> {
+    if data.is_empty() {
+        send.send_data(data, end_stream)
+            .context("failed to send h2 data")?;
+        return Ok(());
+    }
+
+    let mut offset = 0;
+    while offset < data.len() {
+        while send.capacity() == 0 {
+            let remaining = data.len() - offset;
+            send.reserve_capacity(remaining.min(READ_CHUNK_BYTES));
+            let capacity = poll_fn(|cx| send.poll_capacity(cx))
+                .await
+                .ok_or_else(|| anyhow!("h2 send stream closed while waiting for capacity"))?
+                .context("h2 send capacity failed")?;
+            if capacity == 0 {
+                continue;
+            }
+        }
+
+        let chunk_len = send.capacity().min(data.len() - offset);
+        let chunk = data.slice(offset..offset + chunk_len);
+        offset += chunk_len;
+        send.send_data(chunk, end_stream && offset == data.len())
+            .context("failed to send h2 data")?;
+    }
+
+    Ok(())
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    use anyhow::{ensure, Result};
+    use base64::{engine::general_purpose, Engine as _};
+    use tokio::sync::mpsc;
+
+    use crate::egress_secrets::{DomainSet, Secret};
+
+    use super::*;
+
+    #[test]
+    fn rejects_duplicate_h2_content_length_request_headers() {
+        let mut headers = HeaderMap::new();
+        headers.append(CONTENT_LENGTH, HeaderValue::from_static("5"));
+        headers.append(CONTENT_LENGTH, HeaderValue::from_static("5"));
+
+        let error = validate_h2_request_headers(&headers)
+            .expect_err("duplicate h2 content-length should be rejected");
+        assert!(error.to_string().contains("duplicate content-length"));
+    }
+
+    #[test]
+    fn rejects_invalid_h2_content_length_request_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_LENGTH, HeaderValue::from_static("5, 5"));
+
+        let error = validate_h2_request_headers(&headers)
+            .expect_err("invalid h2 content-length should be rejected");
+        assert!(error.to_string().contains("invalid content-length"));
+    }
+
+    #[test]
+    fn rejects_non_plain_chunked_h1_response_transfer_encoding() {
+        let headers = vec![HeaderPart {
+            name: "transfer-encoding".to_string(),
+            value: b"gzip, chunked".to_vec(),
+        }];
+
+        let error = response_body_kind(&headers)
+            .expect_err("non-plain chunked transfer-encoding should be rejected");
+        assert!(error
+            .to_string()
+            .contains("unsupported h1 response transfer-encoding"));
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_substitutes_header_and_maps_h1_response() -> Result<()> {
+        let sni = "api.openai.com";
+        let placeholder = "__DSEC_0123456789abcdef0123456789abcdef__";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            placeholder,
+            "sk-real",
+            &[sni],
+        )?);
+        let (request_tx, mut request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_opener(
+            request_tx,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        );
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let deny_log = Arc::new(PathBuf::from("/tmp/dust-h2-deny-test.log"));
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            deny_log,
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let request = Request::builder()
+            .method("GET")
+            .uri(format!("https://{sni}/v1/models"))
+            .header("authorization", format!("Bearer {placeholder}"))
+            .body(())?;
+        let (response, _stream) = send_request.send_request(request, true)?;
+        let response = response.await?;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(read_h2_body(response.into_body()).await?, b"ok");
+
+        let request_text = request_rx
+            .recv()
+            .await
+            .ok_or_else(|| anyhow!("test upstream did not receive request"))?;
+        assert!(request_text.contains("GET /v1/models HTTP/1.1\r\n"));
+        assert!(request_text.contains("Host: api.openai.com\r\n"));
+        assert!(request_text.contains("authorization: Bearer sk-real\r\n"));
+        assert!(!request_text.contains(placeholder));
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_preserves_basic_auth_round_trip() -> Result<()> {
+        let sni = "api.openai.com";
+        let placeholder = "__DSEC_aabbccddeeff00112233445566778899__";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            placeholder,
+            "sk-real",
+            &[sni],
+        )?);
+        let (request_tx, mut request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_opener(request_tx, b"HTTP/1.1 204 No Content\r\n\r\n");
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let deny_log = Arc::new(PathBuf::from("/tmp/dust-h2-basic-deny-test.log"));
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            deny_log,
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let encoded = general_purpose::STANDARD.encode(format!("user:{placeholder}"));
+        let request = Request::builder()
+            .method("GET")
+            .uri(format!("https://{sni}/"))
+            .header("authorization", format!("Basic {encoded}"))
+            .body(())?;
+        let (response, _stream) = send_request.send_request(request, true)?;
+        let response = response.await?;
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+        let request_text = request_rx
+            .recv()
+            .await
+            .ok_or_else(|| anyhow!("test upstream did not receive request"))?;
+        let expected = general_purpose::STANDARD.encode("user:sk-real");
+        assert!(request_text.contains(&format!("authorization: Basic {expected}\r\n")));
+        assert!(!request_text.contains(placeholder));
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_forwards_request_body_with_content_length() -> Result<()> {
+        let sni = "api.openai.com";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            "__DSEC_0123456789abcdef0123456789abcdef__",
+            "sk-real",
+            &[sni],
+        )?);
+        let (request_tx, mut request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_opener_with_content_length_body(
+            request_tx,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        );
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let deny_log = Arc::new(PathBuf::from("/tmp/dust-h2-body-deny-test.log"));
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            deny_log,
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let request = Request::builder()
+            .method("POST")
+            .uri(format!("https://{sni}/upload"))
+            .header("content-length", "5")
+            .body(())?;
+        let (response, mut stream) = send_request.send_request(request, false)?;
+        stream.send_data(Bytes::from_static(b"hello"), true)?;
+        let response = response.await?;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(read_h2_body(response.into_body()).await?, b"ok");
+
+        let request_text = request_rx
+            .recv()
+            .await
+            .ok_or_else(|| anyhow!("test upstream did not receive request"))?;
+        assert!(request_text.contains("POST /upload HTTP/1.1\r\n"));
+        assert!(request_text.contains("content-length: 5\r\n"));
+        assert!(request_text.ends_with("\r\n\r\nhello"));
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_maps_chunked_response_and_trailers() -> Result<()> {
+        let sni = "api.openai.com";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            "__DSEC_0123456789abcdef0123456789abcdef__",
+            "sk-real",
+            &[sni],
+        )?);
+        let (request_tx, _request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_opener(
+            request_tx,
+            b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n2\r\nok\r\n0\r\nx-done: yes\r\n\r\n",
+        );
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let deny_log = Arc::new(PathBuf::from("/tmp/dust-h2-chunked-deny-test.log"));
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            deny_log,
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let request = Request::builder()
+            .method("GET")
+            .uri(format!("https://{sni}/stream"))
+            .body(())?;
+        let (response, _stream) = send_request.send_request(request, true)?;
+        let response = response.await?;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(response.headers().get(TRANSFER_ENCODING).is_none());
+        let mut body = response.into_body();
+        let mut output = Vec::new();
+        while let Some(chunk) = body.data().await {
+            let chunk = chunk?;
+            output.extend_from_slice(&chunk);
+            body.flow_control().release_capacity(chunk.len())?;
+        }
+        assert_eq!(output, b"ok");
+        let trailers = body
+            .trailers()
+            .await?
+            .ok_or_else(|| anyhow!("missing h2 trailers"))?;
+        assert_eq!(
+            trailers.get("x-done"),
+            Some(&HeaderValue::from_static("yes"))
+        );
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_resets_denied_stream_without_closing_sibling() -> Result<()> {
+        let sni = "api.openai.com";
+        let placeholder = "__DSEC_33333333333333334444444444444444__";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "ANTHROPIC_API_KEY",
+            placeholder,
+            "sk-real",
+            &["api.anthropic.com"],
+        )?);
+        let (request_tx, mut request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_opener(
+            request_tx,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+        );
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            Arc::clone(&deny_log),
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+
+        let denied = Request::builder()
+            .method("GET")
+            .uri(format!("https://{sni}/denied"))
+            .header("authorization", format!("Bearer {placeholder}"))
+            .body(())?;
+        let (denied_response, _stream) = send_request.send_request(denied, true)?;
+        assert!(denied_response.await.is_err());
+
+        let allowed = Request::builder()
+            .method("GET")
+            .uri(format!("https://{sni}/allowed"))
+            .body(())?;
+        let (allowed_response, _stream) = send_request.send_request(allowed, true)?;
+        let allowed_response = allowed_response.await?;
+        assert_eq!(allowed_response.status(), StatusCode::OK);
+        assert_eq!(read_h2_body(allowed_response.into_body()).await?, b"ok");
+
+        let request_text = request_rx
+            .recv()
+            .await
+            .ok_or_else(|| anyhow!("allowed sibling did not reach upstream"))?;
+        assert!(request_text.contains("GET /allowed HTTP/1.1\r\n"));
+        let deny_log_text = tokio::fs::read_to_string(deny_log.as_ref()).await?;
+        assert!(deny_log_text.contains("\"reason\":\"placeholder_on_non_allowed\""));
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_denies_websocket_connect_via_extended_protocol() -> Result<()> {
+        let sni = "api.openai.com";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            "__DSEC_55555555555555556666666666666666__",
+            "sk-real",
+            &[sni],
+        )?);
+        let (request_tx, _request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_opener(request_tx, b"HTTP/1.1 200 OK\r\n\r\n");
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            Arc::clone(&deny_log),
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let mut request = Request::builder()
+            .method("CONNECT")
+            .uri(format!("https://{sni}/"))
+            .body(())?;
+        request
+            .extensions_mut()
+            .insert(h2::ext::Protocol::from("websocket"));
+        let (response, _stream) = send_request.send_request(request, true)?;
+        assert!(response.await.is_err(), "CONNECT websocket should be reset");
+
+        let deny_log_text = tokio::fs::read_to_string(deny_log.as_ref()).await?;
+        assert!(
+            deny_log_text.contains("\"reason\":\"h2_websocket_unsupported\""),
+            "deny log should record h2_websocket_unsupported, got: {deny_log_text}"
+        );
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_denies_authority_sni_mismatch() -> Result<()> {
+        let sni = "api.openai.com";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            "__DSEC_77777777777777778888888888888888__",
+            "sk-real",
+            &[sni],
+        )?);
+        let (request_tx, _request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_opener(request_tx, b"HTTP/1.1 200 OK\r\n\r\n");
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            Arc::clone(&deny_log),
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let request = Request::builder()
+            .method("GET")
+            .uri("https://api.anthropic.com/v1/messages")
+            .body(())?;
+        let (response, _stream) = send_request.send_request(request, true)?;
+        assert!(
+            response.await.is_err(),
+            ":authority/SNI mismatch should reset"
+        );
+
+        let deny_log_text = tokio::fs::read_to_string(deny_log.as_ref()).await?;
+        assert!(
+            deny_log_text.contains("\"reason\":\"host_sni_mismatch\""),
+            "deny log should record host_sni_mismatch, got: {deny_log_text}"
+        );
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_denies_placeholder_in_path() -> Result<()> {
+        let sni = "api.openai.com";
+        let placeholder = "__DSEC_99999999999999990000000000000000__";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            placeholder,
+            "sk-real",
+            &[sni],
+        )?);
+        let (request_tx, _request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_opener(request_tx, b"HTTP/1.1 200 OK\r\n\r\n");
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            Arc::clone(&deny_log),
+            opener,
+        ));
+
+        let (mut send_request, connection) = h2::client::handshake(client_io).await?;
+        let connection_task = tokio::spawn(connection);
+        let request = Request::builder()
+            .method("GET")
+            .uri(format!("https://{sni}/v1/{placeholder}/list"))
+            .body(())?;
+        let (response, _stream) = send_request.send_request(request, true)?;
+        assert!(response.await.is_err(), "placeholder in :path should reset");
+
+        let deny_log_text = tokio::fs::read_to_string(deny_log.as_ref()).await?;
+        assert!(
+            deny_log_text.contains("\"reason\":\"url_line_placeholder\""),
+            "deny log should record url_line_placeholder, got: {deny_log_text}"
+        );
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn h2_bridge_advertises_max_concurrent_streams_cap() -> Result<()> {
+        // We assert the cap is advertised in the server's SETTINGS frame.
+        // Exhausting the budget with 257 concurrent streams would need a
+        // synchronization primitive to hold all sibling streams open
+        // simultaneously; the SETTINGS check covers the load-bearing fact
+        // (the cap is sent), and h2 enforces the rest.
+        let sni = "api.openai.com";
+        let secret_table = Arc::new(secret_table_with_secret(
+            "OPENAI_API_KEY",
+            "__DSEC_aaaaaaaaaaaaaaaabbbbbbbbbbbbbbbb__",
+            "sk-real",
+            &[sni],
+        )?);
+        let (request_tx, _request_rx) = mpsc::unbounded_channel();
+        let opener = test_h1_opener(request_tx, b"HTTP/1.1 200 OK\r\n\r\n");
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let tempdir = tempfile::tempdir()?;
+        let deny_log = Arc::new(tempdir.path().join("deny.log"));
+        let bridge_task = tokio::spawn(run_h2_to_h1_bridge(
+            server_io,
+            sni.to_string(),
+            secret_table,
+            Arc::clone(&deny_log),
+            opener,
+        ));
+
+        let (send_request, connection) = h2::client::handshake(client_io).await?;
+        // The server's SETTINGS frame is consumed during handshake; the client
+        // exposes the negotiated value via `max_concurrent_send_streams`.
+        // Driving the connection forward at least once is required for the
+        // SETTINGS frame to be parsed.
+        let connection_task = tokio::spawn(connection);
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert_eq!(
+            send_request.current_max_send_streams(),
+            H2_MAX_CONCURRENT_STREAMS as usize,
+            "server should advertise MAX_CONCURRENT_STREAMS={H2_MAX_CONCURRENT_STREAMS}"
+        );
+
+        drop(send_request);
+        connection_task.abort();
+        bridge_task.abort();
+        Ok(())
+    }
+
+    fn test_h1_opener(
+        request_tx: mpsc::UnboundedSender<String>,
+        response: &'static [u8],
+    ) -> OpenH1Upstream {
+        Arc::new(move || {
+            let request_tx = request_tx.clone();
+            Box::pin(async move {
+                let (dsbx_io, mut upstream_io) = tokio::io::duplex(64 * 1024);
+                tokio::spawn(async move {
+                    let mut request = Vec::new();
+                    loop {
+                        let mut byte = [0_u8; 1];
+                        upstream_io.read_exact(&mut byte).await?;
+                        request.push(byte[0]);
+                        if request.ends_with(b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+                    let request_text = String::from_utf8(request)?;
+                    request_tx
+                        .send(request_text)
+                        .map_err(|_| anyhow!("failed to send captured request"))?;
+                    upstream_io.write_all(response).await?;
+                    upstream_io.shutdown().await?;
+                    Ok::<(), anyhow::Error>(())
+                });
+                Ok(Box::new(dsbx_io) as BoxedAsyncReadWrite)
+            })
+        })
+    }
+
+    fn test_h1_opener_with_content_length_body(
+        request_tx: mpsc::UnboundedSender<String>,
+        response: &'static [u8],
+    ) -> OpenH1Upstream {
+        Arc::new(move || {
+            let request_tx = request_tx.clone();
+            Box::pin(async move {
+                let (dsbx_io, mut upstream_io) = tokio::io::duplex(64 * 1024);
+                tokio::spawn(async move {
+                    let mut request = Vec::new();
+                    loop {
+                        let mut byte = [0_u8; 1];
+                        upstream_io.read_exact(&mut byte).await?;
+                        request.push(byte[0]);
+                        if request.ends_with(b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+                    let header_text = String::from_utf8(request.clone())?;
+                    let content_length = parse_test_content_length(&header_text)?;
+                    let mut body = vec![0_u8; content_length];
+                    upstream_io.read_exact(&mut body).await?;
+                    request.extend_from_slice(&body);
+                    let request_text = String::from_utf8(request)?;
+                    request_tx
+                        .send(request_text)
+                        .map_err(|_| anyhow!("failed to send captured request"))?;
+                    upstream_io.write_all(response).await?;
+                    upstream_io.shutdown().await?;
+                    Ok::<(), anyhow::Error>(())
+                });
+                Ok(Box::new(dsbx_io) as BoxedAsyncReadWrite)
+            })
+        })
+    }
+
+    fn parse_test_content_length(headers: &str) -> Result<usize> {
+        headers
+            .lines()
+            .find_map(|line| {
+                line.split_once(':').and_then(|(name, value)| {
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>())
+                })
+            })
+            .ok_or_else(|| anyhow!("missing content-length"))?
+            .context("invalid content-length")
+    }
+
+    async fn read_h2_body(mut body: RecvStream) -> Result<Vec<u8>> {
+        let mut output = Vec::new();
+        while let Some(chunk) = body.data().await {
+            let chunk = chunk?;
+            output.extend_from_slice(&chunk);
+            body.flow_control().release_capacity(chunk.len())?;
+        }
+        ensure!(body.trailers().await?.is_none(), "unexpected trailers");
+        Ok(output)
+    }
+
+    fn secret_table_with_secret(
+        name: &str,
+        placeholder: &str,
+        value: &str,
+        patterns: &[&str],
+    ) -> Result<SecretTable> {
+        let allowed_domains = patterns
+            .iter()
+            .map(|pattern| (*pattern).to_string())
+            .collect::<Vec<_>>();
+        let domain_set = DomainSet::from_patterns(&allowed_domains)?;
+        let secret = Secret {
+            name: name.to_string(),
+            placeholder: placeholder.to_string(),
+            value: value.to_string(),
+            allowed_domains: domain_set,
+        };
+        let mut by_placeholder = HashMap::new();
+        by_placeholder.insert(placeholder.to_string(), secret);
+        Ok(SecretTable {
+            by_placeholder,
+            sni_match_set: DomainSet::from_patterns(&allowed_domains)?,
+        })
+    }
+}

--- a/cli/dust-sandbox/src/commands/forward/http2_rewriter.rs
+++ b/cli/dust-sandbox/src/commands/forward/http2_rewriter.rs
@@ -335,8 +335,12 @@ fn build_h1_request_head(
     headers: &[HeaderPart],
     body_is_end_stream: bool,
 ) -> std::result::Result<(Vec<u8>, bool), H2RequestDeny> {
-    // Force chunked framing whenever there is a request body stream. If h2
-    // trailers arrive after DATA, we can withhold the h1 chunked terminator.
+    // Force chunked framing whenever there is a request body stream. We do
+    // not know up front whether the h2 client will follow DATA with
+    // unsupported trailers, and content-length framing would force us to
+    // either pre-buffer the whole upload (memory blowup) or commit the body
+    // to the upstream before we can observe trailers. Chunked lets us
+    // withhold the h1 terminator if a late deny fires.
     let use_chunked = !body_is_end_stream;
     let mut header_bytes = Vec::new();
     append_h1_head_bytes(
@@ -350,10 +354,9 @@ fn build_h1_request_head(
     }
 
     for header in headers {
-        if should_strip_h1_bridge_header(&header.name) {
-            continue;
-        }
-        if use_chunked && header.name.eq_ignore_ascii_case(CONTENT_LENGTH.as_str()) {
+        if should_strip_h1_bridge_header(&header.name)
+            || (use_chunked && header.name.eq_ignore_ascii_case(CONTENT_LENGTH.as_str()))
+        {
             continue;
         }
         append_h1_header_line(&mut header_bytes, header.name.as_bytes(), &header.value)?;
@@ -1112,8 +1115,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn h2_bridge_forces_chunked_when_content_length_present_and_body_not_end_stream(
-    ) -> Result<()> {
+    async fn h2_bridge_forces_chunked_on_streaming_request_with_content_length() -> Result<()> {
         let sni = "api.openai.com";
         let secret_table = Arc::new(secret_table_with_secret(
             "OPENAI_API_KEY",
@@ -1939,7 +1941,6 @@ mod tests {
             .to_ascii_lowercase()
             .contains("content-length:"));
         assert!(request_text.ends_with("\r\n\r\n5\r\nhello\r\n"));
-        assert!(!request_text.ends_with("\r\n\r\n5\r\nhello\r\n0\r\n\r\n"));
 
         drop(send_request);
         connection_task.abort();

--- a/cli/dust-sandbox/src/commands/forward/mod.rs
+++ b/cli/dust-sandbox/src/commands/forward/mod.rs
@@ -10,6 +10,7 @@ mod tls_mitm;
 
 use std::future::Future;
 use std::path::PathBuf;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -49,6 +50,9 @@ const MITM_CA_CERT_PATH: &str = "/run/dust/egress-ca.pem";
 const MITM_CA_KEY_PATH: &str = "/run/dust/egress-ca.key";
 // Must match `front/lib/api/sandbox/egress_secrets.ts:EGRESS_SECRETS_PATH`.
 const EGRESS_SECRETS_PATH: &str = "/run/dust/egress-secrets.json";
+
+type OpenProxyTunnel<S> =
+    Arc<dyn Fn() -> Pin<Box<dyn Future<Output = Result<S>> + Send>> + Send + Sync>;
 
 #[derive(clap::Args, Debug, Clone)]
 pub struct ForwardArgs {
@@ -357,23 +361,27 @@ async fn run_mitm_session<C>(runtime: &ForwardRuntime, sni: &str, client_stream:
 where
     C: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
-    run_mitm_session_with_proxy_opener(runtime, sni, client_stream, || {
-        open_allowed_proxy_tunnel(runtime, sni, 443)
-    })
-    .await
+    let runtime = runtime.clone();
+    let sni = sni.to_string();
+    let runtime_for_opener = runtime.clone();
+    let opener_sni = sni.clone();
+    let opener: OpenProxyTunnel<tokio_rustls::client::TlsStream<TcpStream>> = Arc::new(move || {
+        let runtime = runtime_for_opener.clone();
+        let sni = opener_sni.clone();
+        Box::pin(async move { open_allowed_proxy_tunnel(&runtime, &sni, 443).await })
+    });
+    run_mitm_session_with_proxy_opener(&runtime, &sni, client_stream, opener).await
 }
 
-async fn run_mitm_session_with_proxy_opener<C, S, F, Fut>(
+async fn run_mitm_session_with_proxy_opener<C, S>(
     runtime: &ForwardRuntime,
     sni: &str,
     client_stream: C,
-    open_proxy_tunnel: F,
+    open_proxy_tunnel: OpenProxyTunnel<S>,
 ) -> Result<()>
 where
     C: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
-    F: FnOnce() -> Fut,
-    Fut: Future<Output = Result<S>>,
 {
     let server_config = runtime
         .mitm_ca
@@ -403,11 +411,13 @@ where
         let secret_table = Arc::clone(&runtime.secret_table);
         let deny_log = Arc::clone(&runtime.deny_log);
         let opener_sni = sni.clone();
+        let open_proxy_tunnel = Arc::clone(&open_proxy_tunnel);
         let opener: OpenH1Upstream = Arc::new(move || {
             let runtime = runtime.clone();
             let sni = opener_sni.clone();
+            let open_proxy_tunnel = Arc::clone(&open_proxy_tunnel);
             Box::pin(async move {
-                let proxy_stream = open_allowed_proxy_tunnel(&runtime, &sni, 443)
+                let proxy_stream = open_proxy_tunnel()
                     .await
                     .context("failed to open per-stream proxy tunnel")?;
                 let upstream_tls = connect_mitm_upstream_tls(&runtime, &sni, proxy_stream)
@@ -786,9 +796,12 @@ mod tests {
             Ok::<(), anyhow::Error>(())
         });
 
-        run_mitm_session_with_proxy_opener(&runtime, sni, agent_dsbx_io, || async {
-            Ok(dsbx_proxy_io)
-        })
+        run_mitm_session_with_proxy_opener(
+            &runtime,
+            sni,
+            agent_dsbx_io,
+            single_proxy_opener(dsbx_proxy_io),
+        )
         .await?;
         agent_task.await.context("test agent task panicked")??;
         upstream_task
@@ -881,9 +894,104 @@ mod tests {
             Ok::<(), anyhow::Error>(())
         });
 
-        run_mitm_session_with_proxy_opener(&runtime, sni, agent_dsbx_io, || async {
-            Ok(dsbx_proxy_io)
-        })
+        run_mitm_session_with_proxy_opener(
+            &runtime,
+            sni,
+            agent_dsbx_io,
+            single_proxy_opener(dsbx_proxy_io),
+        )
+        .await?;
+        agent_task.await.context("test agent task panicked")??;
+        upstream_task
+            .await
+            .context("test upstream task panicked")??;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn mitm_session_routes_h2_alpn_through_h2_bridge() -> Result<()> {
+        let sni = "api.openai.com";
+        let mitm_ca = Arc::new(MitmCa::generate()?);
+        let (upstream_server_config, upstream_ca_der) = test_upstream_server_config(sni)?;
+        let mut runtime = test_runtime(Arc::clone(&mitm_ca), upstream_ca_der)?;
+        runtime.secret_table = Arc::new(secret_table(&[sni])?);
+
+        let (agent_client_io, agent_dsbx_io) = tokio::io::duplex(16 * 1024);
+        let (dsbx_proxy_io, upstream_server_io) = tokio::io::duplex(16 * 1024);
+
+        let upstream_task = tokio::spawn(async move {
+            let acceptor = TlsAcceptor::from(upstream_server_config);
+            let mut tls = acceptor
+                .accept(upstream_server_io)
+                .await
+                .context("test upstream failed to accept TLS")?;
+            ensure!(
+                tls.get_ref().1.alpn_protocol() == Some(HTTP_1_1_ALPN),
+                "test upstream did not negotiate http/1.1"
+            );
+
+            let mut request = Vec::new();
+            loop {
+                let mut byte = [0_u8; 1];
+                tls.read_exact(&mut byte)
+                    .await
+                    .context("test upstream failed to read request byte")?;
+                request.push(byte[0]);
+                if request.ends_with(b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let request_text = String::from_utf8(request).context("request should be utf8")?;
+            assert!(request_text.contains("GET /h2-mitm HTTP/1.1\r\n"));
+            assert!(request_text.contains("Host: api.openai.com\r\n"));
+
+            tls.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
+                .await
+                .context("test upstream failed to write response")?;
+            tls.shutdown()
+                .await
+                .context("test upstream failed to shut down TLS")?;
+            Ok::<(), anyhow::Error>(())
+        });
+
+        let agent_connector = test_tls_connector(
+            mitm_ca.ca_cert_der(),
+            vec![H2_ALPN.to_vec(), HTTP_1_1_ALPN.to_vec()],
+        )?;
+        let agent_task = tokio::spawn(async move {
+            let server_name =
+                ServerName::try_from(sni.to_string()).context("invalid test agent SNI")?;
+            let tls = agent_connector
+                .connect(server_name, agent_client_io)
+                .await
+                .context("test agent failed to connect to dsbx MITM")?;
+            ensure!(
+                tls.get_ref().1.alpn_protocol() == Some(H2_ALPN),
+                "test agent did not negotiate h2"
+            );
+
+            let (mut send_request, connection) = h2::client::handshake(tls).await?;
+            let connection_task = tokio::spawn(connection);
+            let request = http::Request::builder()
+                .method("GET")
+                .uri(format!("https://{sni}/h2-mitm"))
+                .body(())?;
+            let (response, _stream) = send_request.send_request(request, true)?;
+            let response = response.await?;
+            assert_eq!(response.status(), http::StatusCode::OK);
+            assert_eq!(read_h2_body(response.into_body()).await?, b"ok");
+            drop(send_request);
+            connection_task.abort();
+            Ok::<(), anyhow::Error>(())
+        });
+
+        run_mitm_session_with_proxy_opener(
+            &runtime,
+            sni,
+            agent_dsbx_io,
+            single_proxy_opener(dsbx_proxy_io),
+        )
         .await?;
         agent_task.await.context("test agent task panicked")??;
         upstream_task
@@ -996,9 +1104,12 @@ mod tests {
             Ok::<(), anyhow::Error>(())
         });
 
-        run_mitm_session_with_proxy_opener(&runtime, sni, agent_dsbx_io, || async {
-            Ok(dsbx_proxy_io)
-        })
+        run_mitm_session_with_proxy_opener(
+            &runtime,
+            sni,
+            agent_dsbx_io,
+            single_proxy_opener(dsbx_proxy_io),
+        )
         .await?;
         agent_task.await.context("test agent task panicked")??;
         upstream_task
@@ -1109,9 +1220,12 @@ mod tests {
             Ok::<(), anyhow::Error>(())
         });
 
-        run_mitm_session_with_proxy_opener(&runtime, sni, agent_dsbx_io, || async {
-            Ok(dsbx_proxy_io)
-        })
+        run_mitm_session_with_proxy_opener(
+            &runtime,
+            sni,
+            agent_dsbx_io,
+            single_proxy_opener(dsbx_proxy_io),
+        )
         .await?;
         agent_task.await.context("test agent task panicked")??;
         upstream_task
@@ -1207,6 +1321,34 @@ mod tests {
         // Silence the dead variable warning when MitmCa stays unused on this path.
         let _ = mitm_ca;
         Ok(())
+    }
+
+    fn single_proxy_opener<S>(stream: S) -> OpenProxyTunnel<S>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
+        let stream = Arc::new(tokio::sync::Mutex::new(Some(stream)));
+        Arc::new(move || {
+            let stream = Arc::clone(&stream);
+            Box::pin(async move {
+                stream
+                    .lock()
+                    .await
+                    .take()
+                    .ok_or_else(|| anyhow::anyhow!("test proxy opener reused"))
+            })
+        })
+    }
+
+    async fn read_h2_body(mut body: h2::RecvStream) -> Result<Vec<u8>> {
+        let mut output = Vec::new();
+        while let Some(chunk) = body.data().await {
+            let chunk = chunk?;
+            output.extend_from_slice(&chunk);
+            body.flow_control().release_capacity(chunk.len())?;
+        }
+        ensure!(body.trailers().await?.is_none(), "unexpected trailers");
+        Ok(output)
     }
 
     fn secret_table(patterns: &[&str]) -> Result<SecretTable> {

--- a/cli/dust-sandbox/src/commands/forward/mod.rs
+++ b/cli/dust-sandbox/src/commands/forward/mod.rs
@@ -51,6 +51,10 @@ const MITM_CA_KEY_PATH: &str = "/run/dust/egress-ca.key";
 // Must match `front/lib/api/sandbox/egress_secrets.ts:EGRESS_SECRETS_PATH`.
 const EGRESS_SECRETS_PATH: &str = "/run/dust/egress-secrets.json";
 
+// Reusable opener for the per-h2-stream upstream proxy tunnel. Each h2 stream
+// opens its own TCP + proxy CONNECT + TLS handshake, so the opener must be
+// callable more than once (unlike the previous FnOnce closure used by the
+// pre-h2 path).
 type OpenProxyTunnel<S> =
     Arc<dyn Fn() -> Pin<Box<dyn Future<Output = Result<S>> + Send>> + Send + Sync>;
 

--- a/cli/dust-sandbox/src/commands/forward/mod.rs
+++ b/cli/dust-sandbox/src/commands/forward/mod.rs
@@ -1,5 +1,6 @@
 mod deny_log;
 mod handshake;
+mod http2_rewriter;
 mod http_host;
 mod http_rewriter;
 mod original_dst;
@@ -29,6 +30,7 @@ use crate::egress_secrets::SecretTable;
 
 use self::deny_log::{append_deny_log, DenyLogEntry, DenyReason};
 use self::handshake::{build_handshake_frame, ALLOW_RESPONSE, DENY_RESPONSE};
+use self::http2_rewriter::{run_h2_to_h1_bridge, BoxedAsyncReadWrite, OpenH1Upstream};
 use self::http_host::parse_http_host;
 use self::http_rewriter::{
     copy_responses_with_websocket_watch, forward_http1_requests, HttpRewriteError,
@@ -36,7 +38,7 @@ use self::http_rewriter::{
 use self::original_dst::resolve_original_dst;
 use self::rewrite_policy::RewriteMode as HttpRewriteMode;
 use self::sni::parse_client_hello_sni;
-use self::tls_mitm::{MitmCa, HTTP_1_1_ALPN};
+use self::tls_mitm::{MitmCa, H2_ALPN, HTTP_1_1_ALPN};
 
 const DOMAIN_PEEK_TIMEOUT: Duration = Duration::from_secs(2);
 const DOMAIN_PEEK_RETRY_DELAY: Duration = Duration::from_millis(25);
@@ -384,15 +386,42 @@ where
         .await
         .context("failed to accept agent TLS for MITM")?;
 
-    let inbound_alpn = agent_tls.get_ref().1.alpn_protocol();
-    let inbound_alpn = if inbound_alpn == Some(HTTP_1_1_ALPN) {
-        "http/1.1"
-    } else {
-        "<none>"
-    };
+    let inbound_alpn = agent_tls
+        .get_ref()
+        .1
+        .alpn_protocol()
+        .map(|value| value.to_vec());
+    if inbound_alpn.as_deref() == Some(H2_ALPN) {
+        info!(
+            domain = sni,
+            inbound_alpn = "h2",
+            outbound_alpn = "http/1.1",
+            "starting h2 MITM bridge session"
+        );
+        let runtime = runtime.clone();
+        let sni = sni.to_string();
+        let secret_table = Arc::clone(&runtime.secret_table);
+        let deny_log = Arc::clone(&runtime.deny_log);
+        let opener_sni = sni.clone();
+        let opener: OpenH1Upstream = Arc::new(move || {
+            let runtime = runtime.clone();
+            let sni = opener_sni.clone();
+            Box::pin(async move {
+                let proxy_stream = open_allowed_proxy_tunnel(&runtime, &sni, 443)
+                    .await
+                    .context("failed to open per-stream proxy tunnel")?;
+                let upstream_tls = connect_mitm_upstream_tls(&runtime, &sni, proxy_stream)
+                    .await
+                    .context("failed to establish per-stream upstream TLS")?;
+                Ok(Box::new(upstream_tls) as BoxedAsyncReadWrite)
+            })
+        });
+        return run_h2_to_h1_bridge(agent_tls, sni, secret_table, deny_log, opener).await;
+    }
+
     info!(
         domain = sni,
-        inbound_alpn,
+        inbound_alpn = "http/1.1",
         outbound_alpn = "http/1.1",
         "starting h1 MITM session"
     );
@@ -729,10 +758,8 @@ mod tests {
             Ok::<(), anyhow::Error>(())
         });
 
-        let agent_connector = test_tls_connector(
-            mitm_ca.ca_cert_der(),
-            vec![b"h2".to_vec(), HTTP_1_1_ALPN.to_vec()],
-        )?;
+        let agent_connector =
+            test_tls_connector(mitm_ca.ca_cert_der(), vec![HTTP_1_1_ALPN.to_vec()])?;
         let agent_task = tokio::spawn(async move {
             let server_name =
                 ServerName::try_from(sni.to_string()).context("invalid test agent SNI")?;
@@ -820,10 +847,8 @@ mod tests {
             Ok::<(), anyhow::Error>(())
         });
 
-        let agent_connector = test_tls_connector(
-            mitm_ca.ca_cert_der(),
-            vec![b"h2".to_vec(), HTTP_1_1_ALPN.to_vec()],
-        )?;
+        let agent_connector =
+            test_tls_connector(mitm_ca.ca_cert_der(), vec![HTTP_1_1_ALPN.to_vec()])?;
         let request =
             format!("GET / HTTP/1.1\r\nHost: {sni}\r\nAuthorization: Bearer {placeholder}\r\n\r\n");
         let agent_task = tokio::spawn(async move {
@@ -922,10 +947,8 @@ mod tests {
             Ok::<(), anyhow::Error>(())
         });
 
-        let agent_connector = test_tls_connector(
-            mitm_ca.ca_cert_der(),
-            vec![b"h2".to_vec(), HTTP_1_1_ALPN.to_vec()],
-        )?;
+        let agent_connector =
+            test_tls_connector(mitm_ca.ca_cert_der(), vec![HTTP_1_1_ALPN.to_vec()])?;
         let agent_task = tokio::spawn(async move {
             let server_name =
                 ServerName::try_from(sni.to_string()).context("invalid test agent SNI")?;
@@ -1041,10 +1064,8 @@ mod tests {
             Ok::<(), anyhow::Error>(())
         });
 
-        let agent_connector = test_tls_connector(
-            mitm_ca.ca_cert_der(),
-            vec![b"h2".to_vec(), HTTP_1_1_ALPN.to_vec()],
-        )?;
+        let agent_connector =
+            test_tls_connector(mitm_ca.ca_cert_der(), vec![HTTP_1_1_ALPN.to_vec()])?;
         let agent_task = tokio::spawn(async move {
             let server_name =
                 ServerName::try_from(sni.to_string()).context("invalid test agent SNI")?;

--- a/cli/dust-sandbox/src/commands/forward/rewrite_policy.rs
+++ b/cli/dust-sandbox/src/commands/forward/rewrite_policy.rs
@@ -56,10 +56,7 @@ pub(super) struct RequestParts {
 
 pub(super) enum Authority<'a> {
     HostHeader,
-    #[allow(dead_code)]
-    Explicit {
-        value: &'a str,
-    },
+    Explicit { value: &'a str },
 }
 
 #[allow(dead_code)]

--- a/cli/dust-sandbox/src/commands/forward/rewrite_policy.rs
+++ b/cli/dust-sandbox/src/commands/forward/rewrite_policy.rs
@@ -123,7 +123,7 @@ pub(super) fn rewrite_request_headers(
         .headers
         .iter()
         .map(|header| {
-            rewrite_header_value(header, &host, secret_table, mode).map(|value| HeaderPart {
+            rewrite_header_value(header, host, secret_table, mode).map(|value| HeaderPart {
                 name: header.name.clone(),
                 value,
             })

--- a/cli/dust-sandbox/src/commands/forward/tls_mitm.rs
+++ b/cli/dust-sandbox/src/commands/forward/tls_mitm.rs
@@ -20,6 +20,7 @@ use tokio::sync::Mutex;
 
 const CA_COMMON_NAME: &str = "Dust Sandbox Egress MITM CA";
 const LEAF_CACHE_CAPACITY: usize = 256;
+pub(super) const H2_ALPN: &[u8] = b"h2";
 pub(super) const HTTP_1_1_ALPN: &[u8] = b"http/1.1";
 
 pub struct MitmCa {
@@ -122,7 +123,7 @@ impl MitmCa {
         let mut config = ServerConfig::builder()
             .with_no_client_auth()
             .with_cert_resolver(Arc::new(resolver));
-        config.alpn_protocols = vec![HTTP_1_1_ALPN.to_vec()];
+        config.alpn_protocols = vec![H2_ALPN.to_vec(), HTTP_1_1_ALPN.to_vec()];
         Ok(Arc::new(config))
     }
 
@@ -401,12 +402,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn server_config_for_forces_http1_alpn() -> Result<()> {
+    async fn server_config_for_advertises_h2_then_http1_alpn() -> Result<()> {
         let ca = Arc::new(MitmCa::generate()?);
 
         let config = ca.server_config_for("api.openai.com").await?;
 
-        assert_eq!(config.alpn_protocols, vec![HTTP_1_1_ALPN.to_vec()]);
+        assert_eq!(
+            config.alpn_protocols,
+            vec![H2_ALPN.to_vec(), HTTP_1_1_ALPN.to_vec()]
+        );
         Ok(())
     }
 

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -65,7 +65,7 @@ function expectContentInOrder(
 }
 
 describe("sandbox image registry", () => {
-  test("bumps the base image for the DNS resolver rollout", () => {
+  test("bumps the base image for the dsbx h2 rollout", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
       tag: "0.8.21",

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -68,7 +68,7 @@ describe("sandbox image registry", () => {
   test("bumps the base image for the DNS resolver rollout", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.20",
+      tag: "0.8.21",
     });
   });
 

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -15,8 +15,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.7.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.20";
-const DSBX_CLI_VERSION = "0.1.16";
+const DUST_BASE_IMAGE_VERSION = "0.8.21";
+const DSBX_CLI_VERSION = "0.1.17";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that
 // list must not silently change this user's UID.


### PR DESCRIPTION
## Description

Adds HTTP/2 inbound termination for MITM-scoped domains and bridges each h2 stream to a fresh h1 upstream connection. The h2 path reuses the shared rewrite policy from dust-tt/dust#26033, so allowlist checks, DSEC substitution, Basic-auth rewriting, and authority/SNI validation stay aligned with h1. Uses the proxy-tunnel and upstream-TLS helpers factored out in dust-tt/dust#26034 to open one upstream per h2 stream.

Inbound TLS advertises `h2` and `http/1.1`; outbound remains h1 in this change.

Bumps `dust-sandbox` to `0.1.17` and the sandbox base image to `0.8.21` so the new dsbx binary is picked up by sandboxes. Otherwise `release-dsbx-cli` would retag `dsbx-v0.1.16` and the image at `0.8.20` would keep pulling the previous binary.

> [!WARNING]
> This opens one TCP, proxy, and upstream TLS handshake per h2 stream. h2 outbound origination is a later change.

> [!NOTE]
> Request conversion contract on the h2 to h1 bridge: streaming h2 uploads are bridged as `Transfer-Encoding: chunked` on the h1 wire, and inbound `Content-Length` is stripped in that path so we can withhold the chunked terminator if h2 trailers force a late deny. End-stream-at-headers requests still preserve `Content-Length` verbatim, and an end-stream-at-headers request with a non-zero `Content-Length` is rejected with `PROTOCOL_ERROR`. Non-empty h2 request trailers are unsupported and reset the stream with `INTERNAL_ERROR`. Split h2 `cookie` request headers are folded into one h1 `Cookie` line joined by `"; "` after DSEC substitution. Non-CONNECT h2 requests on the TLS bridge must carry `:scheme: https`; other schemes reset with `PROTOCOL_ERROR`.

> [!NOTE]
> `Expect: 100-continue` is handled with a deterministic synthetic `417 Expectation Failed` because the bridge currently serializes request upload ahead of upstream response reads. Full-duplex per-stream forwarding (concurrent upload + response, informational 1xx pass-through, early final responses such as 413) is tracked in dust-tt/tasks#9262. This is a known and bounded limitation; agents in the workloads we run today do not rely on `Expect: 100-continue` or full duplex.

## Tests

- `cargo test --manifest-path cli/dust-sandbox/Cargo.toml`
- `cargo clippy --manifest-path cli/dust-sandbox/Cargo.toml --all-targets -- -D warnings`
- `NODE_ENV=test npm --prefix front test -- lib/api/sandbox/image/registry.test.ts`

## Risk

Medium. New protocol surface, but h1 remains the fallback ALPN path. Worst case, h2 clients fail; reverting this PR restores h1-only ALPN advertising while keeping dust-tt/dust#26033 and dust-tt/dust#26034 in main. Image bump means rollback also needs to revert `DUST_BASE_IMAGE_VERSION`.

## Deploy Plan

- [ ] Merge.
- [ ] Trigger `Release dsbx CLI` workflow to publish `dsbx-v0.1.17`.
- [ ] Trigger the sandbox image build for `0.8.21`.
- [ ] Standard front deploy.