### PR TITLE
Fix node ID missing from attachment XML when source URL is absent

### DIFF
--- a/front/lib/api/assistant/conversation/attachments.test.ts
+++ b/front/lib/api/assistant/conversation/attachments.test.ts
@@ -1,8 +1,13 @@
 import {
+  getAttachmentFromContentNodeContentFragment,
   getAttachmentFromFileContentFragment,
   makeFileAttachment,
+  renderAttachmentXml,
 } from "@app/lib/api/assistant/conversation/attachments";
-import type { FileContentFragmentType } from "@app/types/content_fragment";
+import type {
+  ContentNodeContentFragmentType,
+  FileContentFragmentType,
+} from "@app/types/content_fragment";
 import { describe, expect, it } from "vitest";
 
 describe("makeFileAttachment", () => {
@@ -100,6 +105,70 @@ function makeFileContentFragment({
     hidden: false,
   };
 }
+
+function makeContentNodeContentFragment({
+  sourceUrl = null,
+}: {
+  sourceUrl?: string | null;
+}): ContentNodeContentFragmentType & { expiredReason: null } {
+  return {
+    type: "content_fragment",
+    id: 1,
+    sId: "cf_node_123",
+    created: Date.now(),
+    visibility: "visible",
+    version: 1,
+    rank: 0,
+    branchId: null,
+    sourceUrl,
+    title: "dashboard.tsx",
+    contentType: "text/plain",
+    context: {
+      username: null,
+      fullName: null,
+      email: null,
+      profilePictureUrl: null,
+    },
+    contentFragmentId: "cf_node_123",
+    contentFragmentVersion: "latest",
+    expiredReason: null,
+    contentFragmentType: "content_node",
+    nodeId: "node_abc",
+    nodeDataSourceViewId: "dsv_xyz",
+    nodeType: "document",
+    contentNodeData: {
+      nodeId: "node_abc",
+      nodeDataSourceViewId: "dsv_xyz",
+      nodeType: "document",
+      provider: null,
+      spaceName: "My Space",
+    },
+  };
+}
+
+describe("renderAttachmentXml", () => {
+  it("always includes nodeId for content node attachments even when sourceUrl is null", () => {
+    const attachment = getAttachmentFromContentNodeContentFragment(
+      makeContentNodeContentFragment({ sourceUrl: null })
+    );
+
+    const xml = renderAttachmentXml({ attachment });
+
+    expect(xml).toContain('nodeId="node_abc"');
+    expect(xml).not.toContain("sourceUrl");
+  });
+
+  it("includes both nodeId and sourceUrl for content node attachments with a source URL", () => {
+    const attachment = getAttachmentFromContentNodeContentFragment(
+      makeContentNodeContentFragment({ sourceUrl: "https://example.com/doc" })
+    );
+
+    const xml = renderAttachmentXml({ attachment });
+
+    expect(xml).toContain('nodeId="node_abc"');
+    expect(xml).toContain('sourceUrl="https://example.com/doc"');
+  });
+});
 
 describe("getAttachmentFromFileContentFragment", () => {
   it("suppresses queryable and includable hints for raw sandbox delimited files", () => {

--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -363,9 +363,11 @@ export function renderAttachmentXml({
         ]),
   ];
 
-  if (isContentNodeAttachmentType(attachment) && attachment.sourceUrl) {
-    params.push(`sourceUrl="${attachment.sourceUrl}"`);
+  if (isContentNodeAttachmentType(attachment)) {
     params.push(`nodeId="${attachment.nodeId}"`);
+    if (attachment.sourceUrl) {
+      params.push(`sourceUrl="${attachment.sourceUrl}"`);
+    }
   }
 
   let tag = `<attachment ${params.join(" ")}`;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
When a user attaches a content node from a space to a conversation, the attachment was rendered without a nodeId attribute whenever the node had no source URL. This happened `because` nodeId was nested inside the same condition as `sourceUrl`. Both were only emitted together. As a result, MCP tools that rely on the node ID to reference the attachment had no way to identify it.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25896">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->