### PR TITLE
Change how we find the logo file so it works on front-api

### DIFF
--- a/front/lib/api/files/pdf_footer.ts
+++ b/front/lib/api/files/pdf_footer.ts
@@ -2,18 +2,22 @@ import logger from "@app/logger/logger";
 import fs from "fs";
 import path from "path";
 
-const LOGO_PATH = "public/static/landing/logos/dust/Dust_LogoSquare.svg";
+// Resolved relative to this file so the lookup works regardless of the
+// process' cwd (front/, front-api/, tests, …).
+const LOGO_PATH = path.resolve(
+  __dirname,
+  "../../../public/static/landing/logos/dust/Dust_LogoSquare.svg"
+);
 
 // Read logo SVG once at module load time (not per request).
 // Falls back to empty string if file is missing - footer still works, just no logo.
 function loadLogoSvg(): string {
-  const fullPath = path.join(process.cwd(), LOGO_PATH);
   try {
     return fs
-      .readFileSync(fullPath, "utf-8")
+      .readFileSync(LOGO_PATH, "utf-8")
       .replace(/width="48" height="48"/, 'width="16" height="16"');
   } catch (err) {
-    logger.error({ err, path: fullPath }, "Failed to load PDF footer logo");
+    logger.error({ err, path: LOGO_PATH }, "Failed to load PDF footer logo!");
     return "";
   }
 }


### PR DESCRIPTION
## Description

It was finding it relative to the current working dir, which is not reliable. Now finds it relative to the current file. Also a bit fragile, but at least agnostic of front vs front-api.

## Tests

Manual

## Risk

Low

## Deploy Plan

Front

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25897">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->