### PR TITLE
Include file ID in MCP files listing for frame and slideshow entries

### DIFF
--- a/front/lib/api/actions/servers/files/tools/list.test.ts
+++ b/front/lib/api/actions/servers/files/tools/list.test.ts
@@ -6,6 +6,7 @@ import { Authenticator } from "@app/lib/auth";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { ConversationType } from "@app/types/assistant/conversation";
+import { frameContentType, frameSlideshowContentType } from "@app/types/files";
 import assert from "assert";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -119,6 +120,59 @@ describe("listHandler", () => {
       useCase: "project",
       projectId: projectId,
     });
+  });
+
+  it("includes fil_ id in listing for frame and slideshow files but not for regular files", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+
+    const conversation = await createConversation(auth, {
+      title: "Test",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    mockListGCSMountFiles.mockResolvedValue([
+      {
+        isDirectory: false,
+        fileName: "chart.html",
+        path: "conversation/chart.html",
+        sizeBytes: 2048,
+        lastModifiedMs: 0,
+        contentType: frameContentType,
+        fileId: "fil_frameabc123",
+        thumbnailUrl: null,
+      },
+      {
+        isDirectory: false,
+        fileName: "slides.html",
+        path: "conversation/slides.html",
+        sizeBytes: 4096,
+        lastModifiedMs: 0,
+        contentType: frameSlideshowContentType,
+        fileId: "fil_slidexyz789",
+        thumbnailUrl: null,
+      },
+      {
+        isDirectory: false,
+        fileName: "report.pdf",
+        path: "conversation/report.pdf",
+        sizeBytes: 8192,
+        lastModifiedMs: 0,
+        contentType: "application/pdf",
+        fileId: "fil_pdfdef456",
+        thumbnailUrl: null,
+      },
+    ]);
+
+    const result = await listHandler({}, makeExtra(auth, conversation));
+
+    assert(result.isOk());
+    const text = result.value[0];
+    assert(text.type === "text");
+
+    expect(text.text).toContain("[id: fil_frameabc123]");
+    expect(text.text).toContain("[id: fil_slidexyz789]");
+    expect(text.text).not.toContain("[id: fil_pdfdef456]");
   });
 
   it("returns Err when scope=project in a non-project conversation", async () => {

--- a/front/lib/api/actions/servers/files/tools/list.ts
+++ b/front/lib/api/actions/servers/files/tools/list.ts
@@ -6,7 +6,10 @@ import type {
 import { resolveMountByUseCase } from "@app/lib/api/actions/servers/files/tools/utils";
 import { listGCSMountFiles } from "@app/lib/api/files/gcs_mount/files";
 import { parseProcessedFilename } from "@app/lib/api/files/mount_path";
-import { stripMimeParameters } from "@app/types/files";
+import {
+  isInteractiveContentType,
+  stripMimeParameters,
+} from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import partition from "lodash/partition";
 
@@ -114,7 +117,16 @@ export async function listHandler(
     const annotation = sourcePath
       ? ` (processed version of ${sourcePath})`
       : "";
-    lines.push(`${file.path} (${mimeType}, ${kb} KB)${annotation}`);
+    // Frames are created and updated via the interactive_content MCP server, which
+    // identifies them by file ID rather than path. Exposing the ID here lets the agent
+    // reference the correct frame when calling those tools.
+    const fileIdSuffix =
+      isInteractiveContentType(mimeType) && file.fileId
+        ? ` [id: ${file.fileId}]`
+        : "";
+    lines.push(
+      `${file.path} (${mimeType}, ${kb} KB)${fileIdSuffix}${annotation}`
+    );
   }
 
   return new Ok([{ type: "text", text: lines.join("\n") }]);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The interactive content MCP server identifies frames by their `fil_` ID rather than by path, but the `files__list` tool only
surfaced the path. This meant an agent had no way to retrieve a frame's ID from the file listing in order to edit it.

The listing output now appends `[id: fil_...]` for any file whose content type is interactive. Regular files are unaffected.

Example:
```
conversation/project/src/utils/formatters.ts (text/vnd.trolltech.linguist, 1 KB)
conversation/project/src/utils/validators.ts (text/vnd.trolltech.linguist, 1 KB)
conversation/project/tests/integration/api.test.ts (text/vnd.trolltech.linguist, 1 KB)
conversation/RandomDashboard.tsx (application/vnd.dust.frame, 6 KB) [id: fil_RgerN9TcGu]
```

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25898">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->