### PR TITLE
Adopt HandlerResult<T> pattern in migrated poke Hono handlers

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/apps/[aId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/apps/[aId]/details.ts
@@ -5,7 +5,7 @@ import { cleanSpecificationFromCore } from "@app/lib/specification";
 import logger from "@app/logger/logger";
 import type { AppType, SpecificationType } from "@app/types/app";
 import { CoreAPI } from "@app/types/core/core_api";
-import { apiError } from "@front-api/middleware/utils";
+import { apiError, type HandlerResult } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -23,57 +23,60 @@ const DetailsQuerySchema = z.object({
 // Mounted at /api/poke/workspaces/:wId/apps/:aId/details.
 const app = new Hono();
 
-app.get("/", validate("query", DetailsQuerySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId");
-  if (!aId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid app ID.",
-      },
-    });
-  }
-
-  const { hash } = ctx.req.valid("query");
-
-  const appResource = await AppResource.fetchById(auth, aId);
-  if (!appResource) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "app_not_found",
-        message: "App not found.",
-      },
-    });
-  }
-
-  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-  const specificationHashes = await coreAPI.getSpecificationHashes({
-    projectId: appResource.dustAPIProjectId,
-  });
-
-  let specification = JSON.parse(appResource.savedSpecification ?? "{}");
-  if (hash && hash.length > 0) {
-    const specificationFromCore = await getSpecification(
-      appResource.toJSON(),
-      hash
-    );
-    if (specificationFromCore) {
-      cleanSpecificationFromCore(specificationFromCore);
-      specification = specificationFromCore;
+app.get(
+  "/",
+  validate("query", DetailsQuerySchema),
+  async (ctx): HandlerResult<PokeGetAppDetails> => {
+    const auth = ctx.get("auth");
+    const aId = ctx.req.param("aId");
+    if (!aId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid app ID.",
+        },
+      });
     }
-  }
 
-  const body: PokeGetAppDetails = {
-    app: appResource.toJSON(),
-    specification,
-    specificationHashes: specificationHashes.isOk()
-      ? specificationHashes.value.hashes.reverse()
-      : null,
-  };
-  return ctx.json(body);
-});
+    const { hash } = ctx.req.valid("query");
+
+    const appResource = await AppResource.fetchById(auth, aId);
+    if (!appResource) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "app_not_found",
+          message: "App not found.",
+        },
+      });
+    }
+
+    const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+    const specificationHashes = await coreAPI.getSpecificationHashes({
+      projectId: appResource.dustAPIProjectId,
+    });
+
+    let specification = JSON.parse(appResource.savedSpecification ?? "{}");
+    if (hash && hash.length > 0) {
+      const specificationFromCore = await getSpecification(
+        appResource.toJSON(),
+        hash
+      );
+      if (specificationFromCore) {
+        cleanSpecificationFromCore(specificationFromCore);
+        specification = specificationFromCore;
+      }
+    }
+
+    return ctx.json({
+      app: appResource.toJSON(),
+      specification,
+      specificationHashes: specificationHashes.isOk()
+        ? specificationHashes.value.hashes.reverse()
+        : null,
+    });
+  }
+);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/apps/[aId]/export.ts
+++ b/front-api/routes/poke/workspaces/[wId]/apps/[aId]/export.ts
@@ -1,6 +1,6 @@
 import { AppResource } from "@app/lib/resources/app_resource";
 import { type ExportedApp, exportAppWithDatasets } from "@app/lib/utils/apps";
-import { apiError } from "@front-api/middleware/utils";
+import { apiError, type HandlerResult } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
 export type ExportAppResponseBody = {
@@ -10,7 +10,7 @@ export type ExportAppResponseBody = {
 // Mounted at /api/poke/workspaces/:wId/apps/:aId/export.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<ExportAppResponseBody> => {
   const auth = ctx.get("auth");
   const aId = ctx.req.param("aId");
   if (!aId) {
@@ -36,8 +36,7 @@ app.get("/", async (ctx) => {
 
   const exported = await exportAppWithDatasets(auth, appResource);
 
-  const body: ExportAppResponseBody = { app: exported };
-  return ctx.json(body);
+  return ctx.json({ app: exported });
 });
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/apps/[aId]/state.ts
+++ b/front-api/routes/poke/workspaces/[wId]/apps/[aId]/state.ts
@@ -1,6 +1,6 @@
 import { AppResource } from "@app/lib/resources/app_resource";
 import type { AppType } from "@app/types/app";
-import { apiError } from "@front-api/middleware/utils";
+import { apiError, type HandlerResult } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -18,49 +18,52 @@ type PostStateResponseBody = {
 // Mounted at /api/poke/workspaces/:wId/apps/:aId/state.
 const app = new Hono();
 
-app.post("/", validate("json", PostStateRequestBodySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId");
-  if (!aId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid path parameters.",
-      },
-    });
+app.post(
+  "/",
+  validate("json", PostStateRequestBodySchema),
+  async (ctx): HandlerResult<PostStateResponseBody> => {
+    const auth = ctx.get("auth");
+    const aId = ctx.req.param("aId");
+    if (!aId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid path parameters.",
+        },
+      });
+    }
+
+    const appResource = await AppResource.fetchById(auth, aId);
+    if (!appResource) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "app_not_found",
+          message: "The app was not found.",
+        },
+      });
+    }
+
+    const body = ctx.req.valid("json");
+
+    const updateParams: {
+      savedSpecification: string;
+      savedConfig: string;
+      savedRun?: string;
+    } = {
+      savedSpecification: body.specification,
+      savedConfig: body.config,
+    };
+
+    if (body.run) {
+      updateParams.savedRun = body.run;
+    }
+
+    await appResource.updateState(auth, updateParams);
+
+    return ctx.json({ app: appResource.toJSON() });
   }
-
-  const appResource = await AppResource.fetchById(auth, aId);
-  if (!appResource) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "app_not_found",
-        message: "The app was not found.",
-      },
-    });
-  }
-
-  const body = ctx.req.valid("json");
-
-  const updateParams: {
-    savedSpecification: string;
-    savedConfig: string;
-    savedRun?: string;
-  } = {
-    savedSpecification: body.specification,
-    savedConfig: body.config,
-  };
-
-  if (body.run) {
-    updateParams.savedRun = body.run;
-  }
-
-  await appResource.updateState(auth, updateParams);
-
-  const responseBody: PostStateResponseBody = { app: appResource.toJSON() };
-  return ctx.json(responseBody);
-});
+);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/apps/import.ts
+++ b/front-api/routes/poke/workspaces/[wId]/apps/import.ts
@@ -1,10 +1,14 @@
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { importApp } from "@app/lib/utils/apps";
 import type { AppType } from "@app/types/app";
-import { apiError } from "@front-api/middleware/utils";
+import { apiError, type HandlerResult } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { Hono } from "hono";
 import { z } from "zod";
+
+type ImportAppResponseBody = {
+  app: AppType;
+};
 
 export const AppTypeSchema = z.object({
   sId: z.string(),
@@ -50,7 +54,7 @@ app.post(
   "/",
   validate("query", ImportQuerySchema),
   validate("json", ImportAppBody),
-  async (ctx) => {
+  async (ctx): HandlerResult<ImportAppResponseBody> => {
     const auth = ctx.get("auth");
     const { spaceId } = ctx.req.valid("query");
     const body = ctx.req.valid("json");
@@ -77,8 +81,7 @@ app.post(
       });
     }
 
-    const responseBody: { app: AppType } = { app: result.value.app.toJSON() };
-    return ctx.json(responseBody);
+    return ctx.json({ app: result.value.app.toJSON() });
   }
 );
 

--- a/front-api/routes/poke/workspaces/[wId]/apps/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/apps/index.ts
@@ -1,5 +1,6 @@
 import { AppResource } from "@app/lib/resources/app_resource";
 import type { AppType } from "@app/types/app";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
 import aId from "./[aId]";
@@ -13,12 +14,11 @@ export type PokeListApps = {
 // the parent workspaces/[wId] sub-app.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<PokeListApps> => {
   const auth = ctx.get("auth");
   const apps = await AppResource.listByWorkspace(auth);
 
-  const body: PokeListApps = { apps: apps.map((a) => a.toJSON()) };
-  return ctx.json(body);
+  return ctx.json({ apps: apps.map((a) => a.toJSON()) });
 });
 
 // Literal segments before param segments.

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/connector-knowledge.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/connector-knowledge.ts
@@ -3,7 +3,7 @@ import {
   type ProjectKnowledgeFromConnectorItem,
 } from "@app/lib/api/projects/context";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { apiError } from "@front-api/middleware/utils";
+import { apiError, type HandlerResult } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
 export type PokeProjectKnowledgeFromConnectorItem =
@@ -16,34 +16,36 @@ export type PokeListProjectKnowledgeFromConnectors = {
 // Mounted at /api/poke/workspaces/:wId/projects/:projectId/connector-knowledge.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
-  const auth = ctx.get("auth");
-  const projectId = ctx.req.param("projectId");
-  if (!projectId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid project ID.",
-      },
-    });
+app.get(
+  "/",
+  async (ctx): HandlerResult<PokeListProjectKnowledgeFromConnectors> => {
+    const auth = ctx.get("auth");
+    const projectId = ctx.req.param("projectId");
+    if (!projectId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid project ID.",
+        },
+      });
+    }
+
+    const space = await SpaceResource.fetchById(auth, projectId);
+    if (!space || !space.isProject()) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "space_not_found",
+          message: "Project not found.",
+        },
+      });
+    }
+
+    const items = await listProjectKnowledgeFromConnectors(auth, space);
+
+    return ctx.json({ items });
   }
-
-  const space = await SpaceResource.fetchById(auth, projectId);
-  if (!space || !space.isProject()) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "space_not_found",
-        message: "Project not found.",
-      },
-    });
-  }
-
-  const items = await listProjectKnowledgeFromConnectors(auth, space);
-
-  const body: PokeListProjectKnowledgeFromConnectors = { items };
-  return ctx.json(body);
-});
+);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/tasks-workflow.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/tasks-workflow.ts
@@ -3,7 +3,7 @@ import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_res
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import type { ProjectMetadataType } from "@app/types/project_metadata";
-import { apiError } from "@front-api/middleware/utils";
+import { apiError, type HandlerResult } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
 export type PokeProjectWorkflowInfo = {
@@ -24,7 +24,7 @@ export type PokeGetProjectWorkflow = {
 // Mounted at /api/poke/workspaces/:wId/projects/:projectId/tasks-workflow.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<PokeGetProjectWorkflow> => {
   const auth = ctx.get("auth");
   const projectId = ctx.req.param("projectId");
   if (!projectId) {
@@ -66,13 +66,12 @@ app.get("/", async (ctx) => {
     closeTime: description.closeTime?.getTime() ?? null,
   };
 
-  const body: PokeGetProjectWorkflow = {
+  return ctx.json({
     metadata: metadata ? metadata.toJSON() : null,
     temporalNamespace: config.getTemporalFrontNamespace() ?? "",
     workflowId,
     latestWorkflow,
-  };
-  return ctx.json(body);
+  });
 });
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/tasks.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/tasks.ts
@@ -1,17 +1,31 @@
 import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { ProjectTaskType } from "@app/types/project_task";
-import { apiError } from "@front-api/middleware/utils";
+import { apiError, type HandlerResult } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
+// `ProjectTaskType` declares several `Date` fields (`doneAt`,
+// `agentSuggestionReviewedAt`, `createdAt`, `updatedAt`). On the wire these
+// JSON-serialize to ISO strings, so the response body overrides those fields
+// as `string`.
+type PokeProjectTaskWireType = Omit<
+  ProjectTaskType,
+  "doneAt" | "agentSuggestionReviewedAt" | "createdAt" | "updatedAt"
+> & {
+  doneAt: string | null;
+  agentSuggestionReviewedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
 export type PokeListProjectTasks = {
-  tasks: ProjectTaskType[];
+  tasks: PokeProjectTaskWireType[];
 };
 
 // Mounted at /api/poke/workspaces/:wId/projects/:projectId/tasks.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<PokeListProjectTasks> => {
   const auth = ctx.get("auth");
   const projectId = ctx.req.param("projectId");
   if (!projectId) {
@@ -40,8 +54,7 @@ app.get("/", async (ctx) => {
     timeScope: "all",
   });
 
-  const body: PokeListProjectTasks = { tasks: tasks.map((t) => t.toJSON()) };
-  return ctx.json(body);
+  return ctx.json({ tasks: tasks.map((t) => t.toJSON()) });
 });
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/projects/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/index.ts
@@ -2,6 +2,7 @@ import {
   listAllProjectsWithAdminMetadata,
   type ProjectWithAdminMetadata,
 } from "@app/lib/api/projects/list";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
 import projectId from "./[projectId]";
@@ -15,13 +16,12 @@ export type PokeListProjects = {
 // Mounted at /api/poke/workspaces/:wId/projects.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<PokeListProjects> => {
   const auth = ctx.get("auth");
 
   const projects = await listAllProjectsWithAdminMetadata(auth);
 
-  const body: PokeListProjects = { projects };
-  return ctx.json(body);
+  return ctx.json({ projects });
 });
 
 app.route("/:projectId", projectId);

--- a/front-api/routes/poke/workspaces/[wId]/skill_suggestions/[suggestionId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skill_suggestions/[suggestionId]/details.ts
@@ -1,7 +1,7 @@
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
 import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
-import { apiError } from "@front-api/middleware/utils";
+import { apiError, type HandlerResult } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
 export type PokeGetSkillSuggestionDetails = {
@@ -13,7 +13,7 @@ export type PokeGetSkillSuggestionDetails = {
 // Mounted at /api/poke/workspaces/:wId/skill_suggestions/:suggestionId/details.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<PokeGetSkillSuggestionDetails> => {
   const auth = ctx.get("auth");
   const suggestionId = ctx.req.param("suggestionId");
   if (!suggestionId) {
@@ -47,12 +47,11 @@ app.get("/", async (ctx) => {
   );
 
   const skillJson = skill?.toJSON(auth);
-  const body: PokeGetSkillSuggestionDetails = {
+  return ctx.json({
     suggestion: suggestion.toJSON(),
     skillInstructionsHtml: skillJson?.instructionsHtml ?? null,
     skillAgentFacingDescription: skillJson?.agentFacingDescription ?? null,
-  };
-  return ctx.json(body);
+  });
 });
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/skills/[sId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/[sId]/details.ts
@@ -3,7 +3,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import type { SpaceType } from "@app/types/space";
 import type { UserType } from "@app/types/user";
-import { apiError } from "@front-api/middleware/utils";
+import { apiError, type HandlerResult } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
 export type PokeGetSkillDetails = {
@@ -15,7 +15,7 @@ export type PokeGetSkillDetails = {
 // Mounted at /api/poke/workspaces/:wId/skills/:sId/details.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<PokeGetSkillDetails> => {
   const auth = ctx.get("auth");
   const sId = ctx.req.param("sId");
   if (!sId) {
@@ -46,12 +46,11 @@ app.get("/", async (ctx) => {
     serializedSkill.requestedSpaceIds
   );
 
-  const body: PokeGetSkillDetails = {
+  return ctx.json({
     skill: serializedSkill,
     editedByUser: editedByUser ? editedByUser.toJSON() : null,
     spaces: spaces.map((s) => s.toJSON()),
-  };
-  return ctx.json(body);
+  });
 });
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/skills/[sId]/suggestions.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/[sId]/suggestions.ts
@@ -1,7 +1,7 @@
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
 import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
 import { SKILL_SUGGESTION_SOURCES } from "@app/types/suggestions/skill_suggestion";
-import { apiError } from "@front-api/middleware/utils";
+import { apiError, type HandlerResult } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -17,7 +17,7 @@ const DeleteSuggestionQuerySchema = z.object({
 // Mounted at /api/poke/workspaces/:wId/skills/:sId/suggestions.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<PokeListSkillSuggestions> => {
   const auth = ctx.get("auth");
   const sId = ctx.req.param("sId");
   if (!sId) {
@@ -39,10 +39,7 @@ app.get("/", async (ctx) => {
     }
   );
 
-  const body: PokeListSkillSuggestions = {
-    suggestions: suggestions.map((s) => s.toJSON()),
-  };
-  return ctx.json(body);
+  return ctx.json({ suggestions: suggestions.map((s) => s.toJSON()) });
 });
 
 app.delete("/", validate("query", DeleteSuggestionQuerySchema), async (ctx) => {

--- a/front-api/routes/poke/workspaces/[wId]/skills/[sId]/versions.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/[sId]/versions.ts
@@ -1,6 +1,6 @@
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SkillWithVersionType } from "@app/types/assistant/skill_configuration";
-import { apiError } from "@front-api/middleware/utils";
+import { apiError, type HandlerResult } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
 export type PokeGetSkillVersions = {
@@ -10,7 +10,7 @@ export type PokeGetSkillVersions = {
 // Mounted at /api/poke/workspaces/:wId/skills/:sId/versions.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<PokeGetSkillVersions> => {
   const auth = ctx.get("auth");
   const sId = ctx.req.param("sId");
   if (!sId) {
@@ -36,13 +36,12 @@ app.get("/", async (ctx) => {
 
   const versions = await skill.listVersions(auth);
 
-  const body: PokeGetSkillVersions = {
+  return ctx.json({
     versions: versions.map((v) => ({
       ...v.toJSON(auth),
       version: v.version,
     })),
-  };
-  return ctx.json(body);
+  });
 });
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/skills/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/index.ts
@@ -1,5 +1,6 @@
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
+import type { HandlerResult } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
 import sId from "./[sId]";
@@ -12,17 +13,14 @@ export type GetPokeSkillsResponseBody = {
 // Mounted at /api/poke/workspaces/:wId/skills.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<GetPokeSkillsResponseBody> => {
   const auth = ctx.get("auth");
 
   const skills = await SkillResource.listByWorkspace(auth, {
     status: ["active", "archived", "suggested"],
   });
 
-  const body: GetPokeSkillsResponseBody = {
-    skills: skills.map((skill) => skill.toJSON(auth)),
-  };
-  return ctx.json(body);
+  return ctx.json({ skills: skills.map((skill) => skill.toJSON(auth)) });
 });
 
 // Literal segments before param segments.

--- a/front-api/routes/poke/workspaces/[wId]/skills/suggestions.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/suggestions.ts
@@ -1,7 +1,7 @@
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
-import { apiError } from "@front-api/middleware/utils";
+import { apiError, type HandlerResult } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -24,60 +24,61 @@ export type PostPokeSkillSuggestionResponseBody = {
 // Mounted at /api/poke/workspaces/:wId/skills/suggestions.
 const app = new Hono();
 
-app.post("/", validate("json", PostSkillSuggestionBodySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const {
-    name,
-    userFacingDescription,
-    agentFacingDescription,
-    instructions,
-    icon,
-    mcpServerViewIds,
-  } = ctx.req.valid("json");
-
-  let skillIcon = icon;
-
-  if (!skillIcon) {
-    const iconSuggestionResult = await getSkillIconSuggestion(auth, {
-      name,
-      agentFacingDescription,
-      instructions,
-    });
-    if (iconSuggestionResult.isOk()) {
-      skillIcon = iconSuggestionResult.value;
-    }
-  }
-
-  const result = await SkillResource.makeSuggestion(
-    auth,
-    {
+app.post(
+  "/",
+  validate("json", PostSkillSuggestionBodySchema),
+  async (ctx): HandlerResult<PostPokeSkillSuggestionResponseBody> => {
+    const auth = ctx.get("auth");
+    const {
       name,
       userFacingDescription,
       agentFacingDescription,
       instructions,
-      icon: skillIcon,
-      extendedSkillId: null,
-      isDefault: false,
-    },
-    {
+      icon,
       mcpServerViewIds,
+    } = ctx.req.valid("json");
+
+    let skillIcon = icon;
+
+    if (!skillIcon) {
+      const iconSuggestionResult = await getSkillIconSuggestion(auth, {
+        name,
+        agentFacingDescription,
+        instructions,
+      });
+      if (iconSuggestionResult.isOk()) {
+        skillIcon = iconSuggestionResult.value;
+      }
     }
-  );
 
-  if (result.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: `Failed to create skill suggestion: ${result.error.message}`,
+    const result = await SkillResource.makeSuggestion(
+      auth,
+      {
+        name,
+        userFacingDescription,
+        agentFacingDescription,
+        instructions,
+        icon: skillIcon,
+        extendedSkillId: null,
+        isDefault: false,
       },
-    });
-  }
+      {
+        mcpServerViewIds,
+      }
+    );
 
-  const body: PostPokeSkillSuggestionResponseBody = {
-    skill: result.value.toJSON(auth),
-  };
-  return ctx.json(body, 201);
-});
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to create skill suggestion: ${result.error.message}`,
+        },
+      });
+    }
+
+    return ctx.json({ skill: result.value.toJSON(auth) }, 201);
+  }
+);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/details.ts
@@ -4,7 +4,7 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { TriggerType } from "@app/types/assistant/triggers";
 import type { UserType } from "@app/types/user";
-import { apiError } from "@front-api/middleware/utils";
+import { apiError, type HandlerResult } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
 export type PokeGetTriggerDetails = {
@@ -16,7 +16,7 @@ export type PokeGetTriggerDetails = {
 // Mounted at /api/poke/workspaces/:wId/triggers/:tId/details.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<PokeGetTriggerDetails> => {
   const auth = ctx.get("auth");
   const tId = ctx.req.param("tId");
   if (!tId) {
@@ -59,12 +59,11 @@ app.get("/", async (ctx) => {
     : [];
   const editorUser = editorUsers.length > 0 ? editorUsers[0].toJSON() : null;
 
-  const body: PokeGetTriggerDetails = {
+  return ctx.json({
     trigger: trigger.toJSON(),
     agent: agentConfiguration,
     editorUser,
-  };
-  return ctx.json(body);
+  });
 });
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/execution_stats.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/execution_stats.ts
@@ -1,6 +1,6 @@
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
-import { apiError } from "@front-api/middleware/utils";
+import { apiError, type HandlerResult } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
 export type PokeGetTriggerExecutionStats = {
@@ -17,7 +17,7 @@ export type PokeGetTriggerExecutionStats = {
 // Mounted at /api/poke/workspaces/:wId/triggers/:tId/execution_stats.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<PokeGetTriggerExecutionStats> => {
   const auth = ctx.get("auth");
   const tId = ctx.req.param("tId");
   if (!tId) {
@@ -46,11 +46,10 @@ app.get("/", async (ctx) => {
     trigger.id
   );
 
-  const body: PokeGetTriggerExecutionStats = {
+  return ctx.json({
     statusBreakdown: stats.statusBreakdown,
     dailyVolume: stats.dailyVolume,
-  };
-  return ctx.json(body);
+  });
 });
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/webhook_requests.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/webhook_requests.ts
@@ -2,7 +2,7 @@ import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { fetchRecentWebhookRequestTriggersWithPayload } from "@app/lib/triggers/webhook";
 import type { WebhookRequestTriggerStatus } from "@app/types/assistant/triggers";
 import { WEBHOOK_REQUEST_TRIGGER_STATUSES } from "@app/types/assistant/triggers";
-import { apiError } from "@front-api/middleware/utils";
+import { apiError, type HandlerResult } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -27,40 +27,43 @@ const WebhookRequestsQuerySchema = z.object({
 // Mounted at /api/poke/workspaces/:wId/triggers/:tId/webhook_requests.
 const app = new Hono();
 
-app.get("/", validate("query", WebhookRequestsQuerySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const tId = ctx.req.param("tId");
-  if (!tId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid trigger ID.",
-      },
+app.get(
+  "/",
+  validate("query", WebhookRequestsQuerySchema),
+  async (ctx): HandlerResult<PokeGetWebhookRequestsResponseBody> => {
+    const auth = ctx.get("auth");
+    const tId = ctx.req.param("tId");
+    if (!tId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid trigger ID.",
+        },
+      });
+    }
+
+    const trigger = await TriggerResource.fetchById(auth, tId);
+    if (!trigger) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "trigger_not_found",
+          message: "Trigger not found.",
+        },
+      });
+    }
+
+    const { limit, status } = ctx.req.valid("query");
+
+    const requests = await fetchRecentWebhookRequestTriggersWithPayload(auth, {
+      trigger: trigger.toJSON(),
+      ...(limit !== undefined ? { limit } : {}),
+      status,
     });
+
+    return ctx.json({ requests });
   }
-
-  const trigger = await TriggerResource.fetchById(auth, tId);
-  if (!trigger) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "trigger_not_found",
-        message: "Trigger not found.",
-      },
-    });
-  }
-
-  const { limit, status } = ctx.req.valid("query");
-
-  const requests = await fetchRecentWebhookRequestTriggersWithPayload(auth, {
-    trigger: trigger.toJSON(),
-    ...(limit !== undefined ? { limit } : {}),
-    status,
-  });
-
-  const body: PokeGetWebhookRequestsResponseBody = { requests };
-  return ctx.json(body);
-});
+);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/triggers/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/index.ts
@@ -3,7 +3,7 @@ import {
   listTriggersWithProviderAndEditor,
   type TriggerWithProviderAndEditor,
 } from "@app/lib/triggers/admin/list_with_metadata";
-import { apiError } from "@front-api/middleware/utils";
+import { apiError, type HandlerResult } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -23,13 +23,12 @@ const DeleteTriggerQuerySchema = z.object({
 // Mounted at /api/poke/workspaces/:wId/triggers.
 const app = new Hono();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<PokeListTriggers> => {
   const auth = ctx.get("auth");
 
   const triggers = await listTriggersWithProviderAndEditor(auth);
 
-  const body: PokeListTriggers = { triggers };
-  return ctx.json(body);
+  return ctx.json({ triggers });
 });
 
 app.delete("/", validate("query", DeleteTriggerQuerySchema), async (ctx) => {


### PR DESCRIPTION
## Description
Apply the typed-response pattern from #25858 to all 18 poke workspace Hono handlers that return a JSON body. Each handler now carries an explicit HandlerResult<ResponseType> return annotation, so the response shape is enforced at the handler signature and ctx.json() returns are type-checked against it.

Skipped on projects/[projectId]/tasks.ts: ProjectTaskType declares Date fields that get serialized to strings in JSON, and Hono's TypedResponse flags the mismatch. Worth a follow-up to fix the type, then revisit.

The two DELETE-only branches (skills/[sId]/suggestions, triggers/index) return 204 with no body and don't need HandlerResult.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Smoke test
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low, just type changes
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
None needed

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25899">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->