### PR TITLE
[Slack] Clean up user-action post failures

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.test.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.test.ts
@@ -1,0 +1,122 @@
+import type { SlackStreamHandler } from "@connectors/connectors/slack/chat/slack_stream_handler";
+import type { SlackUserInfo } from "@connectors/connectors/slack/lib/slack_client";
+import type { SlackChatBotMessageModel } from "@connectors/lib/models/slack";
+import type { ConnectorResource } from "@connectors/resources/connector_resource";
+import type {
+  AgentEvent,
+  ConversationPublicType,
+  DustAPI,
+  UserMessageType,
+} from "@dust-tt/client";
+import { Ok } from "@dust-tt/client";
+import type { WebClient } from "@slack/web-api";
+import { describe, expect, it, vi } from "vitest";
+
+const mockMakeConversationUrl = vi.hoisted(() =>
+  vi.fn((workspaceId: string, conversationId: string | null | undefined) =>
+    conversationId
+      ? `https://dust.test/w/${workspaceId}/conversation/${conversationId}`
+      : null
+  )
+);
+
+vi.mock("@connectors/lib/bot/conversation_utils", () => ({
+  makeConversationUrl: mockMakeConversationUrl,
+}));
+
+import { streamConversationToSlack } from "./stream_conversation_handler";
+
+describe("streamConversationToSlack", () => {
+  it("stops Slack streaming without cancelling the blocked agent message when controls fail", async () => {
+    const invalidBlocksError = Object.assign(new Error("invalid_blocks"), {
+      data: { error: "invalid_blocks" },
+    });
+    const toolAskUserQuestionEvent = {
+      type: "tool_ask_user_question",
+      actionId: "action_1",
+      conversationId: "conv_1",
+      messageId: "agent_msg_1",
+      question: {
+        question: "Which option?",
+        options: [{ label: "One" }],
+        multiSelect: false,
+      },
+    } as AgentEvent;
+
+    async function* eventStream() {
+      yield toolAskUserQuestionEvent;
+    }
+
+    const dustAPI = {
+      streamAgentAnswerEvents: vi.fn(async () => {
+        return new Ok({ eventStream: eventStream() });
+      }),
+      cancelMessageGeneration: vi.fn(async () => {
+        return new Ok({ success: true });
+      }),
+    };
+    const slackClient = {
+      chat: {
+        postEphemeral: vi.fn(async () => {
+          throw invalidBlocksError;
+        }),
+        postMessage: vi.fn(async () => ({ ts: "fallback_ts" })),
+        delete: vi.fn(async () => ({ ok: true })),
+      },
+    } as unknown as WebClient;
+    const streamHandler = {
+      messageTs: "stream_ts",
+      stop: vi.fn(async () => {
+        throw new Error("stream stop failed");
+      }),
+      setThinking: vi.fn(async () => undefined),
+      appendText: vi.fn(async () => undefined),
+      isStopped: false,
+    } as unknown as SlackStreamHandler;
+
+    const res = await streamConversationToSlack(dustAPI as unknown as DustAPI, {
+      assistantName: "Support",
+      agentConfigurations: [],
+      connector: {
+        id: 123,
+        workspaceId: "w_test",
+      } as ConnectorResource,
+      conversation: {
+        sId: "conv_1",
+        content: [],
+      } as unknown as ConversationPublicType,
+      feedbackVisibleToAuthorOnly: true,
+      slack: {
+        slackChannelId: "C123",
+        slackClient,
+        slackMessageTs: "1700000000.000001",
+        slackTeamId: "T123",
+        slackUserId: "U123",
+        slackUserInfo: {
+          is_bot: false,
+        } as unknown as SlackUserInfo,
+      },
+      slackChatBotMessage: {
+        id: 42,
+      } as SlackChatBotMessageModel,
+      streamHandler,
+      userMessage: {
+        sId: "user_msg_1",
+      } as UserMessageType,
+    });
+
+    expect(res.isOk()).toBe(true);
+    if (res.isErr()) {
+      throw res.error;
+    }
+    expect(dustAPI.cancelMessageGeneration).not.toHaveBeenCalled();
+    expect(streamHandler.stop).toHaveBeenCalled();
+    expect(slackClient.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C123",
+        text: expect.stringContaining("could not display"),
+        thread_ts: "1700000000.000001",
+      })
+    );
+  });
+});

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -42,7 +42,14 @@ import type {
   Result,
   UserMessageType,
 } from "@dust-tt/client";
-import { assertNever, DustAPI, Err, Ok, removeNulls } from "@dust-tt/client";
+import {
+  assertNever,
+  DustAPI,
+  Err,
+  normalizeError,
+  Ok,
+  removeNulls,
+} from "@dust-tt/client";
 import type { WebClient } from "@slack/web-api";
 import * as t from "io-ts";
 
@@ -229,6 +236,8 @@ type SlackUserActionType = Extract<
 
 export const SLACK_USER_ACTION_IDLE_TIMEOUT_MS = 4 * 60 * 1000 + 30 * 1000; // 4.5 minutes
 
+type SlackUserActionEvent = Extract<AgentEvent, { type: SlackUserActionType }>;
+
 function getUserActionLabel(actionType: SlackUserActionType): string {
   switch (actionType) {
     case "tool_approve_execution":
@@ -253,6 +262,13 @@ function getUserActionFallbackMessage(
   conversationUrl: string | null
 ): string {
   return `:hourglass_flowing_sand: _Streaming was interrupted after 5 mins waiting on a ${getUserActionLabel(actionType)}.${getContinueOnDustSuffix(conversationUrl)}_`;
+}
+
+function getUserActionPostFailureFallbackMessage(
+  actionType: SlackUserActionType,
+  conversationUrl: string | null
+): string {
+  return `:warning: _Dust could not display the Slack controls for a ${getUserActionLabel(actionType)}.${getContinueOnDustSuffix(conversationUrl)}_`;
 }
 
 async function streamAgentAnswerToSlack(
@@ -367,19 +383,94 @@ async function streamAgentAnswerToSlack(
     );
   };
 
-  const postUserActionEphemeral = async <T extends { text: string }>(
-    payload: T
-  ): Promise<void> => {
-    if (!slackUserId || slackUserInfo.is_bot) {
-      return;
+  const stopSlackStreamWithUserActionFallback = async ({
+    fallbackText,
+    logContext,
+    postFailureLogMessage,
+    successLogMessage,
+  }: {
+    fallbackText: string;
+    logContext: Record<string, unknown>;
+    postFailureLogMessage: string;
+    successLogMessage: string;
+  }): Promise<Result<undefined, Error>> => {
+    await runBestEffortSlackCleanup({
+      planHandler,
+      streamHandler,
+      logContext,
+    });
+
+    try {
+      await slackClient.chat.postMessage({
+        channel: slackChannelId,
+        text: fallbackText,
+        blocks: makeMarkdownBlock(fallbackText),
+        thread_ts: slackMessageTs,
+        unfurl_links: false,
+      });
+      logger.info(logContext, successLogMessage);
+    } catch (postError) {
+      logger.error({ error: postError, ...logContext }, postFailureLogMessage);
     }
 
-    await slackClient.chat.postEphemeral({
-      ...payload,
-      channel: slackChannelId,
-      thread_ts: slackMessageTs,
-      user: slackUserId,
+    return new Ok(undefined);
+  };
+
+  const handleUserActionPostFailure = async (
+    event: SlackUserActionEvent,
+    error: unknown
+  ): Promise<Result<undefined, Error>> => {
+    clearUserActionTimeout();
+    abortController.abort();
+    const logContext = {
+      connectorId: connector.id,
+      conversationId: event.conversationId,
+      messageId: event.messageId,
+      actionType: event.type,
+    };
+
+    logger.error(
+      { error, ...logContext },
+      "Failed to post Slack user-action controls, stopping Slack stream."
+    );
+
+    const conversationUrl = makeConversationUrl(
+      connector.workspaceId,
+      event.conversationId
+    );
+    const fallbackText = getUserActionPostFailureFallbackMessage(
+      event.type,
+      conversationUrl
+    );
+
+    return stopSlackStreamWithUserActionFallback({
+      fallbackText,
+      logContext,
+      postFailureLogMessage:
+        "Failed to post Slack fallback after user-action controls failed.",
+      successLogMessage:
+        "Posted user-action controls failure fallback message to Slack.",
     });
+  };
+
+  const postUserActionEphemeral = async <T extends { text: string }>(
+    payload: T
+  ): Promise<Result<undefined, Error>> => {
+    if (!slackUserId || slackUserInfo.is_bot) {
+      return new Ok(undefined);
+    }
+
+    try {
+      await slackClient.chat.postEphemeral({
+        ...payload,
+        channel: slackChannelId,
+        thread_ts: slackMessageTs,
+        user: slackUserId,
+      });
+      return new Ok(undefined);
+    } catch (error) {
+      return new Err(normalizeError(error));
+    }
   };
 
   async function* eventStreamWithTimeoutCleanup() {
@@ -447,7 +538,7 @@ async function streamAgentAnswerToSlack(
         await planHandler.upsertPlanMessage(AWAITING_TOOL_APPROVAL_LABEL);
         await streamHandler.setThinking(AWAITING_TOOL_APPROVAL_LABEL);
 
-        await postUserActionEphemeral({
+        const postResult = await postUserActionEphemeral({
           text: "Approve tool execution",
           blocks: makeToolValidationBlock({
             agentName: event.metadata.agentName,
@@ -455,6 +546,9 @@ async function streamAgentAnswerToSlack(
             id: JSON.stringify(blockId),
           }),
         });
+        if (postResult.isErr()) {
+          return handleUserActionPostFailure(event, postResult.error);
+        }
         break;
       }
 
@@ -467,7 +561,7 @@ async function streamAgentAnswerToSlack(
         );
 
         if (slackUserId && !slackUserInfo.is_bot && conversationUrl) {
-          await postUserActionEphemeral({
+          const postResult = await postUserActionEphemeral({
             text: "Personal authentication required",
             blocks: makeToolAuthenticationBlock({
               agentName: event.metadata.agentName,
@@ -479,6 +573,9 @@ async function streamAgentAnswerToSlack(
               }),
             }),
           });
+          if (postResult.isErr()) {
+            return handleUserActionPostFailure(event, postResult.error);
+          }
 
           pendingPersonalAuth = {
             redisKey: getAuthResponseUrlRedisKey(
@@ -503,7 +600,7 @@ async function streamAgentAnswerToSlack(
         );
 
         if (slackUserId && !slackUserInfo.is_bot && conversationUrl) {
-          await postUserActionEphemeral({
+          const postResult = await postUserActionEphemeral({
             text: "File authorization required",
             blocks: makeToolFileAuthorizationBlock({
               agentName: event.metadata.agentName,
@@ -515,6 +612,9 @@ async function streamAgentAnswerToSlack(
               }),
             }),
           });
+          if (postResult.isErr()) {
+            return handleUserActionPostFailure(event, postResult.error);
+          }
         }
 
         await streamHandler.setThinking("Waiting for file authorization...");
@@ -838,13 +938,16 @@ async function streamAgentAnswerToSlack(
           slackChatBotMessageId: slackChatBotMessage.id,
         });
 
-        await postUserActionEphemeral({
+        const postResult = await postUserActionEphemeral({
           text: event.question.question,
           blocks: makeUserQuestionBlock({
             question: event.question,
             value: questionValue,
           }),
         });
+        if (postResult.isErr()) {
+          return handleUserActionPostFailure(event, postResult.error);
+        }
         break;
       }
 
@@ -862,10 +965,6 @@ async function streamAgentAnswerToSlack(
   }
 
   if (abortController.signal.aborted && timedOutUserActionType) {
-    planHandler.abortAllChildStreams();
-    await planHandler.deletePlanMessage();
-    await streamHandler.stop();
-
     const conversationUrl = makeConversationUrl(
       connector.workspaceId,
       conversation.sId
@@ -875,24 +974,18 @@ async function streamAgentAnswerToSlack(
       conversationUrl
     );
 
-    await slackClient.chat.postMessage({
-      channel: slackChannelId,
-      text: fallbackText,
-      blocks: makeMarkdownBlock(fallbackText),
-      thread_ts: slackMessageTs,
-      unfurl_links: false,
-    });
-
-    logger.info(
-      {
+    return stopSlackStreamWithUserActionFallback({
+      fallbackText,
+      logContext: {
         connectorId: connector.id,
         conversationId: conversation.sId,
         pendingActionType: timedOutUserActionType,
       },
-      "Posted user-action timeout fallback message to Slack."
-    );
-
-    return new Ok(undefined);
+      postFailureLogMessage:
+        "Failed to post Slack fallback after user-action timeout.",
+      successLogMessage:
+        "Posted user-action timeout fallback message to Slack.",
+    });
   }
 
   // Clean up if the event stream ended without a terminal event.


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/25967.

Slack agent replies can pause on user actions: tool approvals, personal authentication, file authorization, or an agent question. For those cases, the connector posts Slack controls in the thread so the user can unblock the running agent loop from Slack.

When Slack rejects one of those control messages, for example with `invalid_blocks`, the user never sees the button or prompt needed to continue from Slack. The Dust agent message is still blocked on a real user action, and the Dust app can still show the corresponding approval/auth/question UI. Before this change, the Slack connector treated the failed control post as an unexpected exception, which could leave Slack placeholders around and make follow-up Slack replies look stuck behind the still-running agent loop.

This change handles the Slack posting failure using the same Slack-side fallback shape as the user-action timeout path:
- clear the pending Slack user-action timeout;
- abort the Slack stream and child streams;
- remove Slack plan/stream placeholders on a best-effort basis;
- post a fallback message in the Slack thread with a link to continue from the Dust conversation;
- leave the Dust agent message blocked so the user can approve, authenticate, authorize, or answer in the Dust app.

Example: if Slack returns `invalid_blocks` while posting a tool approval prompt, the bot now stops the Slack stream and tells the user to continue in Dust, instead of cancelling the agent message or leaving the Slack thread waiting on controls that were never displayed.

## Risks
Blast radius: Slack bot streaming around actions requiring user input: tool approvals, personal auth, file authorization, and agent questions.
Risk: standard

The Slack cleanup calls are best effort so a Slack cleanup failure does not prevent the fallback path from completing.

## Deploy Plan
- pmrr
- deploy connectors

## Tests
- [x] `npx biome check --error-on-warnings connectors/src/connectors/slack/chat/stream_conversation_handler.ts connectors/src/connectors/slack/chat/stream_conversation_handler.test.ts`
- [x] `NODE_ENV=test CONNECTORS_DATABASE_URI=postgres://dev:dev@localhost:5432/dust_connectors_test npx vitest run src/connectors/slack/chat/stream_conversation_handler.test.ts --config vite.config.mjs`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25900">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
