### PR TITLE
[Slack] Handle pending message promotion timeout

### DIFF
--- a/connectors/src/connectors/slack/bot.test.ts
+++ b/connectors/src/connectors/slack/bot.test.ts
@@ -1,6 +1,5 @@
 import type { ConversationEvent } from "@dust-tt/client";
 import { Ok } from "@dust-tt/client";
-import type { WebClient } from "@slack/web-api";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@connectors/lib/bot/conversation_utils", () => ({
@@ -9,22 +8,9 @@ vi.mock("@connectors/lib/bot/conversation_utils", () => ({
 
 import { resolveSlackPendingUserMessage } from "./bot";
 
-type PendingUserMessage = {
-  sId: string;
-  type: "user_message";
-  visibility: "pending" | "visible";
-};
-
-type PendingConversation = {
-  sId: string;
-  content: (
-    | PendingUserMessage
-    | {
-        type: "agent_message";
-        parentMessageId: string;
-      }
-  )[][];
-};
+type PendingMessage =
+  | { sId: string; type: "user_message"; visibility: "pending" | "visible" }
+  | { type: "agent_message"; parentMessageId: string };
 
 const connector = {
   id: 123,
@@ -32,17 +18,11 @@ const connector = {
 };
 
 const slackMessageTs = "1700000000.000001";
-const pendingUserMessage: PendingUserMessage = {
+const pendingUserMessage = {
   sId: "user_msg_1",
   type: "user_message",
   visibility: "pending",
-};
-
-async function* neverPromotedEventStream(signal?: AbortSignal) {
-  await new Promise<void>((resolve) => {
-    signal?.addEventListener("abort", () => resolve(), { once: true });
-  });
-}
+} satisfies PendingMessage;
 
 const promotedEvent = {
   type: "user_message_promoted",
@@ -50,27 +30,23 @@ const promotedEvent = {
   messageId: pendingUserMessage.sId,
 } satisfies ConversationEvent;
 
-async function* promotedEventStream() {
-  yield promotedEvent;
-}
-
-function makeConversation(content: PendingConversation["content"] = []) {
+function makeConversation(content: PendingMessage[][] = []) {
   return { sId: "conv_1", content };
 }
 
 async function resolvePending({
-  eventStream = neverPromotedEventStream,
+  events = [],
   refetchedConversation = makeConversation([[pendingUserMessage]]),
   timeoutMs = 100,
 }: {
-  eventStream?: (signal?: AbortSignal) => AsyncGenerator<ConversationEvent>;
-  refetchedConversation?: PendingConversation;
+  events?: ConversationEvent[];
+  refetchedConversation?: ReturnType<typeof makeConversation>;
   timeoutMs?: number;
 } = {}) {
   const dustAPI = {
     streamConversationEvents: vi.fn(
       async ({ signal }: { signal?: AbortSignal }) => {
-        return new Ok({ eventStream: eventStream(signal) });
+        return new Ok({ eventStream: pendingEventsStream(events, signal) });
       }
     ),
     getConversation: vi.fn(async () => {
@@ -79,7 +55,7 @@ async function resolvePending({
   };
   const slackClient = {
     chat: {
-      postMessage: vi.fn<WebClient["chat"]["postMessage"]>(async () => ({
+      postMessage: vi.fn(async () => ({
         ok: true,
         ts: "fallback_ts",
       })),
@@ -103,24 +79,37 @@ async function resolvePending({
     userMessage: pendingUserMessage,
   });
 
-  return { dustAPI, res, slackClient, streamHandler };
+  return { res, slackClient, streamHandler };
+}
+
+async function* pendingEventsStream(
+  events: ConversationEvent[],
+  signal?: AbortSignal
+) {
+  if (events.length === 0) {
+    await new Promise<void>((resolve) => {
+      signal?.addEventListener("abort", () => resolve(), { once: true });
+    });
+  }
+
+  yield* events;
 }
 
 describe("resolveSlackPendingUserMessage", () => {
-  it("refetches the conversation and streams normally after promotion", async () => {
+  it("continues after the pending message is promoted", async () => {
     const promotedConversation = makeConversation([
       [{ ...pendingUserMessage, visibility: "visible" }],
       [{ type: "agent_message", parentMessageId: pendingUserMessage.sId }],
     ]);
     const ctx = await resolvePending({
-      eventStream: promotedEventStream,
+      events: [promotedEvent],
       refetchedConversation: promotedConversation,
     });
 
     expect(ctx.res).toEqual(new Ok(promotedConversation));
   });
 
-  it("posts a controlled fallback when the pending message is not promoted", async () => {
+  it("posts a fallback when the pending message is not promoted", async () => {
     const ctx = await resolvePending({ timeoutMs: 1 });
 
     expect(ctx.res).toEqual(new Ok(null));

--- a/connectors/src/connectors/slack/bot.test.ts
+++ b/connectors/src/connectors/slack/bot.test.ts
@@ -1,0 +1,136 @@
+import type { ConversationEvent } from "@dust-tt/client";
+import { Ok } from "@dust-tt/client";
+import type { WebClient } from "@slack/web-api";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@connectors/lib/bot/conversation_utils", () => ({
+  makeConversationUrl: () => "https://dust.test/conversation",
+}));
+
+import { resolveSlackPendingUserMessage } from "./bot";
+
+type PendingUserMessage = {
+  sId: string;
+  type: "user_message";
+  visibility: "pending" | "visible";
+};
+
+type PendingConversation = {
+  sId: string;
+  content: (
+    | PendingUserMessage
+    | {
+        type: "agent_message";
+        parentMessageId: string;
+      }
+  )[][];
+};
+
+const connector = {
+  id: 123,
+  workspaceId: "w_test",
+};
+
+const slackMessageTs = "1700000000.000001";
+const pendingUserMessage: PendingUserMessage = {
+  sId: "user_msg_1",
+  type: "user_message",
+  visibility: "pending",
+};
+
+async function* neverPromotedEventStream(signal?: AbortSignal) {
+  await new Promise<void>((resolve) => {
+    signal?.addEventListener("abort", () => resolve(), { once: true });
+  });
+}
+
+const promotedEvent = {
+  type: "user_message_promoted",
+  created: Date.now(),
+  messageId: pendingUserMessage.sId,
+} satisfies ConversationEvent;
+
+async function* promotedEventStream() {
+  yield promotedEvent;
+}
+
+function makeConversation(content: PendingConversation["content"] = []) {
+  return { sId: "conv_1", content };
+}
+
+async function resolvePending({
+  eventStream = neverPromotedEventStream,
+  refetchedConversation = makeConversation([[pendingUserMessage]]),
+  timeoutMs = 100,
+}: {
+  eventStream?: (signal?: AbortSignal) => AsyncGenerator<ConversationEvent>;
+  refetchedConversation?: PendingConversation;
+  timeoutMs?: number;
+} = {}) {
+  const dustAPI = {
+    streamConversationEvents: vi.fn(
+      async ({ signal }: { signal?: AbortSignal }) => {
+        return new Ok({ eventStream: eventStream(signal) });
+      }
+    ),
+    getConversation: vi.fn(async () => {
+      return new Ok(refetchedConversation);
+    }),
+  };
+  const slackClient = {
+    chat: {
+      postMessage: vi.fn<WebClient["chat"]["postMessage"]>(async () => ({
+        ok: true,
+        ts: "fallback_ts",
+      })),
+    },
+  };
+  const streamHandler = {
+    stop: vi.fn(async () => undefined),
+  };
+
+  const res = await resolveSlackPendingUserMessage({
+    connector,
+    conversation: makeConversation([[pendingUserMessage]]),
+    dustAPI,
+    slack: {
+      slackChannelId: "C123",
+      slackClient,
+      slackMessageTs,
+    },
+    streamHandler,
+    timeoutMs,
+    userMessage: pendingUserMessage,
+  });
+
+  return { dustAPI, res, slackClient, streamHandler };
+}
+
+describe("resolveSlackPendingUserMessage", () => {
+  it("refetches the conversation and streams normally after promotion", async () => {
+    const promotedConversation = makeConversation([
+      [{ ...pendingUserMessage, visibility: "visible" }],
+      [{ type: "agent_message", parentMessageId: pendingUserMessage.sId }],
+    ]);
+    const ctx = await resolvePending({
+      eventStream: promotedEventStream,
+      refetchedConversation: promotedConversation,
+    });
+
+    expect(ctx.res).toEqual(new Ok(promotedConversation));
+  });
+
+  it("posts a controlled fallback when the pending message is not promoted", async () => {
+    const ctx = await resolvePending({ timeoutMs: 1 });
+
+    expect(ctx.res).toEqual(new Ok(null));
+    expect(ctx.streamHandler.stop).toHaveBeenCalledTimes(1);
+    expect(ctx.slackClient.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C123",
+        thread_ts: slackMessageTs,
+        text: expect.stringContaining("Continue on Dust"),
+      })
+    );
+  });
+});

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -1,3 +1,4 @@
+import { resolveSlackPendingUserMessage } from "@connectors/connectors/slack/bot_pending_message";
 import {
   makeErrorBlock,
   makeMarkdownBlock,
@@ -73,7 +74,6 @@ import {
   isSupportedAudioContentType,
   isSupportedFileContentType,
   isSupportedImageContentType,
-  normalizeError,
   Ok,
   removeNulls,
 } from "@dust-tt/client";
@@ -92,8 +92,6 @@ const MAX_IMAGE_FILE_SIZE_TO_UPLOAD = 20 * 1024 * 1024; // 20 MB
 const MAX_AUDIO_FILE_SIZE_TO_UPLOAD = 100 * 1024 * 1024; // 100 MB
 
 const DEFAULT_AGENTS = ["dust", "claude-4-sonnet", "gpt-5"];
-const SLACK_PENDING_PROMOTION_RECONNECT_DELAY_MS = 1_000;
-const SLACK_PENDING_PROMOTION_RECONNECT_ATTEMPT_BUFFER = 2;
 
 function getMaxFileSizeToUpload(contentType: SupportedFileContentType): number {
   if (isSupportedImageContentType(contentType)) {
@@ -118,210 +116,6 @@ type BotAnswerParams = {
   slackMessageTs: string;
   slackThreadTs?: string;
 };
-
-type SlackPendingConversation = {
-  sId: string;
-  content: {
-    type: "user_message" | "agent_message" | "content_fragment";
-    parentMessageId?: string | null;
-  }[][];
-};
-
-type SlackPendingUserMessageDustAPI<
-  TConversation extends SlackPendingConversation,
-> = Pick<DustAPI, "streamConversationEvents"> & {
-  getConversation: (params: {
-    conversationId: string;
-  }) => Promise<Result<TConversation, APIError>>;
-};
-
-function hasAgentMessageForUserMessage(
-  conversation: SlackPendingConversation,
-  userMessageId: string
-): boolean {
-  return conversation.content.some((messageVersions) => {
-    const message = messageVersions.at(-1);
-    return (
-      message?.type === "agent_message" &&
-      message.parentMessageId === userMessageId
-    );
-  });
-}
-
-async function waitForSlackUserMessagePromotion({
-  dustAPI,
-  conversationId,
-  timeoutMs,
-  userMessageId,
-}: {
-  dustAPI: Pick<DustAPI, "streamConversationEvents">;
-  conversationId: string;
-  timeoutMs: number;
-  userMessageId: string;
-}): Promise<Result<undefined, Error | APIError>> {
-  const abortController = new AbortController();
-  const timeout = setTimeout(() => {
-    abortController.abort();
-  }, timeoutMs);
-  timeout.unref?.();
-  const handleStreamError = (error: unknown) =>
-    abortController.signal.aborted
-      ? new Ok(undefined)
-      : new Err(normalizeError(error));
-
-  try {
-    const streamRes = await dustAPI.streamConversationEvents({
-      conversationId,
-      signal: abortController.signal,
-      options: {
-        maxReconnectAttempts:
-          Math.ceil(timeoutMs / SLACK_PENDING_PROMOTION_RECONNECT_DELAY_MS) +
-          SLACK_PENDING_PROMOTION_RECONNECT_ATTEMPT_BUFFER,
-        reconnectDelay: SLACK_PENDING_PROMOTION_RECONNECT_DELAY_MS,
-      },
-    });
-    if (streamRes.isErr()) {
-      return handleStreamError(streamRes.error);
-    }
-
-    try {
-      for await (const event of streamRes.value.eventStream) {
-        if (
-          event.type === "user_message_promoted" &&
-          event.messageId === userMessageId
-        ) {
-          return new Ok(undefined);
-        }
-      }
-    } catch (error) {
-      return handleStreamError(error);
-    }
-  } finally {
-    clearTimeout(timeout);
-  }
-
-  return new Ok(undefined);
-}
-
-export async function resolveSlackPendingUserMessage<
-  TConversation extends SlackPendingConversation = ConversationPublicType,
->({
-  connector,
-  conversation,
-  dustAPI,
-  slack,
-  streamHandler,
-  timeoutMs,
-  userMessage,
-}: {
-  connector: Pick<ConnectorResource, "id" | "workspaceId">;
-  conversation: TConversation;
-  dustAPI: SlackPendingUserMessageDustAPI<TConversation>;
-  slack: {
-    slackChannelId: string;
-    slackClient: { chat: Pick<WebClient["chat"], "postMessage"> };
-    slackMessageTs: string;
-  };
-  streamHandler: Pick<SlackStreamHandler, "stop">;
-  timeoutMs: number;
-  userMessage: Pick<UserMessageType, "sId" | "visibility">;
-}): Promise<Result<TConversation | null, Error | APIError>> {
-  if (userMessage.visibility !== "pending") {
-    return new Ok(conversation);
-  }
-  if (hasAgentMessageForUserMessage(conversation, userMessage.sId)) {
-    return new Ok(conversation);
-  }
-
-  logger.info(
-    {
-      connectorId: connector.id,
-      conversationId: conversation.sId,
-      userMessageId: userMessage.sId,
-    },
-    "Slack user message is pending, waiting for promotion before streaming."
-  );
-
-  const waitRes = await waitForSlackUserMessagePromotion({
-    dustAPI,
-    conversationId: conversation.sId,
-    timeoutMs,
-    userMessageId: userMessage.sId,
-  });
-  if (waitRes.isErr()) {
-    return waitRes;
-  }
-
-  const conversationRes = await dustAPI.getConversation({
-    conversationId: conversation.sId,
-  });
-
-  if (
-    conversationRes.isOk() &&
-    hasAgentMessageForUserMessage(conversationRes.value, userMessage.sId)
-  ) {
-    return new Ok(conversationRes.value);
-  }
-
-  if (conversationRes.isErr()) {
-    logger.warn(
-      {
-        error: conversationRes.error,
-        connectorId: connector.id,
-        conversationId: conversation.sId,
-        userMessageId: userMessage.sId,
-      },
-      "Failed to refetch Slack conversation after pending user message timeout."
-    );
-  }
-
-  await streamHandler.stop();
-
-  const conversationUrl = makeConversationUrl(
-    connector.workspaceId,
-    conversation.sId
-  );
-  const fallbackText = `:hourglass_flowing_sand: _Dust is still finishing the previous request, so this Slack reply could not start in time.${
-    conversationUrl ? ` <${conversationUrl}|Continue on Dust>.` : ""
-  }_`;
-
-  try {
-    reportSlackUsage({
-      connectorId: connector.id,
-      method: "chat.postMessage",
-      channelId: slack.slackChannelId,
-      useCase: "bot",
-    });
-    await slack.slackClient.chat.postMessage({
-      channel: slack.slackChannelId,
-      text: fallbackText,
-      blocks: makeMarkdownBlock(fallbackText),
-      thread_ts: slack.slackMessageTs,
-      unfurl_links: false,
-    });
-  } catch (error) {
-    logger.error(
-      {
-        error,
-        connectorId: connector.id,
-        conversationId: conversation.sId,
-        userMessageId: userMessage.sId,
-      },
-      "Failed to post Slack pending user message fallback."
-    );
-  }
-
-  logger.info(
-    {
-      connectorId: connector.id,
-      conversationId: conversation.sId,
-      userMessageId: userMessage.sId,
-    },
-    "Posted Slack pending user message fallback after promotion timeout."
-  );
-
-  return new Ok(null);
-}
 
 export async function getSlackConnector(params: BotAnswerParams) {
   const { slackTeamId } = params;

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -123,8 +123,6 @@ type SlackPendingConversation = {
   sId: string;
   content: {
     type: "user_message" | "agent_message" | "content_fragment";
-    sId?: string;
-    visibility?: UserMessageType["visibility"];
     parentMessageId?: string | null;
   }[][];
 };
@@ -137,37 +135,17 @@ type SlackPendingUserMessageDustAPI<
   }) => Promise<Result<TConversation, APIError>>;
 };
 
-type SlackPendingUserMessageResult = "promoted" | "timed_out";
-
-function getSlackPendingUserMessageFallbackText(
-  conversationUrl: string | null
-): string {
-  const urlPart = conversationUrl
-    ? ` <${conversationUrl}|Continue on Dust>.`
-    : "";
-
-  return `:hourglass_flowing_sand: _Dust is still finishing the previous request, so this Slack reply could not start in time.${urlPart}_`;
-}
-
 function hasAgentMessageForUserMessage(
   conversation: SlackPendingConversation,
   userMessageId: string
 ): boolean {
-  for (const messageVersions of conversation.content) {
-    const message = messageVersions[messageVersions.length - 1];
-    if (!message) {
-      continue;
-    }
-
-    if (
-      message.type === "agent_message" &&
+  return conversation.content.some((messageVersions) => {
+    const message = messageVersions.at(-1);
+    return (
+      message?.type === "agent_message" &&
       message.parentMessageId === userMessageId
-    ) {
-      return true;
-    }
-  }
-
-  return false;
+    );
+  });
 }
 
 async function waitForSlackUserMessagePromotion({
@@ -180,14 +158,16 @@ async function waitForSlackUserMessagePromotion({
   conversationId: string;
   timeoutMs: number;
   userMessageId: string;
-}): Promise<Result<SlackPendingUserMessageResult, Error | APIError>> {
+}): Promise<Result<undefined, Error | APIError>> {
   const abortController = new AbortController();
-  let timedOut = false;
   const timeout = setTimeout(() => {
-    timedOut = true;
     abortController.abort();
   }, timeoutMs);
   timeout.unref?.();
+  const handleStreamError = (error: unknown) =>
+    abortController.signal.aborted
+      ? new Ok(undefined)
+      : new Err(normalizeError(error));
 
   try {
     const streamRes = await dustAPI.streamConversationEvents({
@@ -201,10 +181,7 @@ async function waitForSlackUserMessagePromotion({
       },
     });
     if (streamRes.isErr()) {
-      if (timedOut || abortController.signal.aborted) {
-        return new Ok("timed_out");
-      }
-      return new Err(normalizeError(streamRes.error));
+      return handleStreamError(streamRes.error);
     }
 
     try {
@@ -213,20 +190,17 @@ async function waitForSlackUserMessagePromotion({
           event.type === "user_message_promoted" &&
           event.messageId === userMessageId
         ) {
-          return new Ok("promoted");
+          return new Ok(undefined);
         }
       }
     } catch (error) {
-      if (timedOut || abortController.signal.aborted) {
-        return new Ok("timed_out");
-      }
-      return new Err(normalizeError(error));
+      return handleStreamError(error);
     }
   } finally {
     clearTimeout(timeout);
   }
 
-  return new Ok("timed_out");
+  return new Ok(undefined);
 }
 
 export async function resolveSlackPendingUserMessage<
@@ -307,7 +281,9 @@ export async function resolveSlackPendingUserMessage<
     connector.workspaceId,
     conversation.sId
   );
-  const fallbackText = getSlackPendingUserMessageFallbackText(conversationUrl);
+  const fallbackText = `:hourglass_flowing_sand: _Dust is still finishing the previous request, so this Slack reply could not start in time.${
+    conversationUrl ? ` <${conversationUrl}|Continue on Dust>.` : ""
+  }_`;
 
   try {
     reportSlackUsage({

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -4,8 +4,11 @@ import {
   // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
 } from "@connectors/connectors/slack/chat/blocks";
 import { SlackStreamHandler } from "@connectors/connectors/slack/chat/slack_stream_handler";
-// biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
-import { streamConversationToSlack } from "@connectors/connectors/slack/chat/stream_conversation_handler";
+import {
+  SLACK_USER_ACTION_IDLE_TIMEOUT_MS,
+  streamConversationToSlack,
+  // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
+} from "@connectors/connectors/slack/chat/stream_conversation_handler";
 import {
   getBotUserIdResponse,
   getUserInfo,
@@ -70,6 +73,7 @@ import {
   isSupportedAudioContentType,
   isSupportedFileContentType,
   isSupportedImageContentType,
+  normalizeError,
   Ok,
   removeNulls,
 } from "@dust-tt/client";
@@ -88,6 +92,8 @@ const MAX_IMAGE_FILE_SIZE_TO_UPLOAD = 20 * 1024 * 1024; // 20 MB
 const MAX_AUDIO_FILE_SIZE_TO_UPLOAD = 100 * 1024 * 1024; // 100 MB
 
 const DEFAULT_AGENTS = ["dust", "claude-4-sonnet", "gpt-5"];
+const SLACK_PENDING_PROMOTION_RECONNECT_DELAY_MS = 1_000;
+const SLACK_PENDING_PROMOTION_RECONNECT_ATTEMPT_BUFFER = 2;
 
 function getMaxFileSizeToUpload(contentType: SupportedFileContentType): number {
   if (isSupportedImageContentType(contentType)) {
@@ -112,6 +118,234 @@ type BotAnswerParams = {
   slackMessageTs: string;
   slackThreadTs?: string;
 };
+
+type SlackPendingConversation = {
+  sId: string;
+  content: {
+    type: "user_message" | "agent_message" | "content_fragment";
+    sId?: string;
+    visibility?: UserMessageType["visibility"];
+    parentMessageId?: string | null;
+  }[][];
+};
+
+type SlackPendingUserMessageDustAPI<
+  TConversation extends SlackPendingConversation,
+> = Pick<DustAPI, "streamConversationEvents"> & {
+  getConversation: (params: {
+    conversationId: string;
+  }) => Promise<Result<TConversation, APIError>>;
+};
+
+type SlackPendingUserMessageResult = "promoted" | "timed_out";
+
+function getSlackPendingUserMessageFallbackText(
+  conversationUrl: string | null
+): string {
+  const urlPart = conversationUrl
+    ? ` <${conversationUrl}|Continue on Dust>.`
+    : "";
+
+  return `:hourglass_flowing_sand: _Dust is still finishing the previous request, so this Slack reply could not start in time.${urlPart}_`;
+}
+
+function hasAgentMessageForUserMessage(
+  conversation: SlackPendingConversation,
+  userMessageId: string
+): boolean {
+  for (const messageVersions of conversation.content) {
+    const message = messageVersions[messageVersions.length - 1];
+    if (!message) {
+      continue;
+    }
+
+    if (
+      message.type === "agent_message" &&
+      message.parentMessageId === userMessageId
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+async function waitForSlackUserMessagePromotion({
+  dustAPI,
+  conversationId,
+  timeoutMs,
+  userMessageId,
+}: {
+  dustAPI: Pick<DustAPI, "streamConversationEvents">;
+  conversationId: string;
+  timeoutMs: number;
+  userMessageId: string;
+}): Promise<Result<SlackPendingUserMessageResult, Error | APIError>> {
+  const abortController = new AbortController();
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    abortController.abort();
+  }, timeoutMs);
+  timeout.unref?.();
+
+  try {
+    const streamRes = await dustAPI.streamConversationEvents({
+      conversationId,
+      signal: abortController.signal,
+      options: {
+        maxReconnectAttempts:
+          Math.ceil(timeoutMs / SLACK_PENDING_PROMOTION_RECONNECT_DELAY_MS) +
+          SLACK_PENDING_PROMOTION_RECONNECT_ATTEMPT_BUFFER,
+        reconnectDelay: SLACK_PENDING_PROMOTION_RECONNECT_DELAY_MS,
+      },
+    });
+    if (streamRes.isErr()) {
+      if (timedOut || abortController.signal.aborted) {
+        return new Ok("timed_out");
+      }
+      return new Err(normalizeError(streamRes.error));
+    }
+
+    try {
+      for await (const event of streamRes.value.eventStream) {
+        if (
+          event.type === "user_message_promoted" &&
+          event.messageId === userMessageId
+        ) {
+          return new Ok("promoted");
+        }
+      }
+    } catch (error) {
+      if (timedOut || abortController.signal.aborted) {
+        return new Ok("timed_out");
+      }
+      return new Err(normalizeError(error));
+    }
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  return new Ok("timed_out");
+}
+
+export async function resolveSlackPendingUserMessage<
+  TConversation extends SlackPendingConversation = ConversationPublicType,
+>({
+  connector,
+  conversation,
+  dustAPI,
+  slack,
+  streamHandler,
+  timeoutMs,
+  userMessage,
+}: {
+  connector: Pick<ConnectorResource, "id" | "workspaceId">;
+  conversation: TConversation;
+  dustAPI: SlackPendingUserMessageDustAPI<TConversation>;
+  slack: {
+    slackChannelId: string;
+    slackClient: { chat: Pick<WebClient["chat"], "postMessage"> };
+    slackMessageTs: string;
+  };
+  streamHandler: Pick<SlackStreamHandler, "stop">;
+  timeoutMs: number;
+  userMessage: Pick<UserMessageType, "sId" | "visibility">;
+}): Promise<Result<TConversation | null, Error | APIError>> {
+  if (userMessage.visibility !== "pending") {
+    return new Ok(conversation);
+  }
+  if (hasAgentMessageForUserMessage(conversation, userMessage.sId)) {
+    return new Ok(conversation);
+  }
+
+  logger.info(
+    {
+      connectorId: connector.id,
+      conversationId: conversation.sId,
+      userMessageId: userMessage.sId,
+    },
+    "Slack user message is pending, waiting for promotion before streaming."
+  );
+
+  const waitRes = await waitForSlackUserMessagePromotion({
+    dustAPI,
+    conversationId: conversation.sId,
+    timeoutMs,
+    userMessageId: userMessage.sId,
+  });
+  if (waitRes.isErr()) {
+    return waitRes;
+  }
+
+  const conversationRes = await dustAPI.getConversation({
+    conversationId: conversation.sId,
+  });
+
+  if (
+    conversationRes.isOk() &&
+    hasAgentMessageForUserMessage(conversationRes.value, userMessage.sId)
+  ) {
+    return new Ok(conversationRes.value);
+  }
+
+  if (conversationRes.isErr()) {
+    logger.warn(
+      {
+        error: conversationRes.error,
+        connectorId: connector.id,
+        conversationId: conversation.sId,
+        userMessageId: userMessage.sId,
+      },
+      "Failed to refetch Slack conversation after pending user message timeout."
+    );
+  }
+
+  await streamHandler.stop();
+
+  const conversationUrl = makeConversationUrl(
+    connector.workspaceId,
+    conversation.sId
+  );
+  const fallbackText = getSlackPendingUserMessageFallbackText(conversationUrl);
+
+  try {
+    reportSlackUsage({
+      connectorId: connector.id,
+      method: "chat.postMessage",
+      channelId: slack.slackChannelId,
+      useCase: "bot",
+    });
+    await slack.slackClient.chat.postMessage({
+      channel: slack.slackChannelId,
+      text: fallbackText,
+      blocks: makeMarkdownBlock(fallbackText),
+      thread_ts: slack.slackMessageTs,
+      unfurl_links: false,
+    });
+  } catch (error) {
+    logger.error(
+      {
+        error,
+        connectorId: connector.id,
+        conversationId: conversation.sId,
+        userMessageId: userMessage.sId,
+      },
+      "Failed to post Slack pending user message fallback."
+    );
+  }
+
+  logger.info(
+    {
+      connectorId: connector.id,
+      conversationId: conversation.sId,
+      userMessageId: userMessage.sId,
+    },
+    "Posted Slack pending user message fallback after promotion timeout."
+  );
+
+  return new Ok(null);
+}
 
 export async function getSlackConnector(params: BotAnswerParams) {
   const { slackTeamId } = params;
@@ -1164,6 +1398,7 @@ async function answerMessage(
       | "getConversation"
       | "createConversation"
       | "postUserMessage"
+      | "waitForUserMessagePromotion"
       | "streamConversationToSlack"
   ) => {
     logger.error(
@@ -1287,6 +1522,30 @@ async function answerMessage(
     slackChatBotMessage.conversationId = conversation.sId;
     await slackChatBotMessage.save();
   }
+
+  const pendingUserMessageRes = await resolveSlackPendingUserMessage({
+    connector,
+    conversation,
+    dustAPI,
+    slack: {
+      slackChannelId: slackChannel,
+      slackClient,
+      slackMessageTs,
+    },
+    streamHandler,
+    timeoutMs: SLACK_USER_ACTION_IDLE_TIMEOUT_MS,
+    userMessage,
+  });
+  if (pendingUserMessageRes.isErr()) {
+    return buildSlackMessageError(
+      pendingUserMessageRes,
+      "waitForUserMessagePromotion"
+    );
+  }
+  if (pendingUserMessageRes.value === null) {
+    return new Ok(undefined);
+  }
+  conversation = pendingUserMessageRes.value;
 
   const streamRes = await streamConversationToSlack(dustAPI, {
     assistantName: mention.agentName,

--- a/connectors/src/connectors/slack/bot_pending_message.test.ts
+++ b/connectors/src/connectors/slack/bot_pending_message.test.ts
@@ -12,23 +12,12 @@ type PendingMessage =
   | { sId: string; type: "user_message"; visibility: "pending" | "visible" }
   | { type: "agent_message"; parentMessageId: string };
 
-const connector = {
-  id: 123,
-  workspaceId: "w_test",
-};
-
-const slackMessageTs = "1700000000.000001";
+const connector = { id: 123, workspaceId: "w_test" };
 const pendingUserMessage = {
   sId: "user_msg_1",
   type: "user_message",
   visibility: "pending",
 } satisfies PendingMessage;
-
-const promotedEvent = {
-  type: "user_message_promoted",
-  created: Date.now(),
-  messageId: pendingUserMessage.sId,
-} satisfies ConversationEvent;
 
 function makeConversation(content: PendingMessage[][] = []) {
   return { sId: "conv_1", content };
@@ -51,16 +40,11 @@ async function resolvePending({
         return new Ok({ eventStream: pendingEventsStream(events, signal) });
       }
     ),
-    getConversation: vi.fn(async () => {
-      return new Ok(refetchedConversation);
-    }),
+    getConversation: vi.fn(async () => new Ok(refetchedConversation)),
   };
   const slackClient = {
     chat: {
-      postMessage: vi.fn(async () => ({
-        ok: true,
-        ts: "fallback_ts",
-      })),
+      postMessage: vi.fn(async () => undefined),
     },
   };
   const streamHandler = {
@@ -78,7 +62,7 @@ async function resolvePending({
     slack: {
       slackChannelId: "C123",
       slackClient,
-      slackMessageTs,
+      slackMessageTs: "1700000000.000001",
     },
     streamHandler,
     timeoutMs,
@@ -108,7 +92,13 @@ describe("resolveSlackPendingUserMessage", () => {
       [{ type: "agent_message", parentMessageId: pendingUserMessage.sId }],
     ]);
     const ctx = await resolvePending({
-      events: [promotedEvent],
+      events: [
+        {
+          type: "user_message_promoted",
+          created: Date.now(),
+          messageId: pendingUserMessage.sId,
+        },
+      ],
       refetchedConversation: promotedConversation,
     });
 
@@ -123,7 +113,7 @@ describe("resolveSlackPendingUserMessage", () => {
     expect(ctx.slackClient.chat.postMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "C123",
-        thread_ts: slackMessageTs,
+        thread_ts: "1700000000.000001",
         text: expect.stringContaining("Continue on Dust"),
       })
     );

--- a/connectors/src/connectors/slack/bot_pending_message.test.ts
+++ b/connectors/src/connectors/slack/bot_pending_message.test.ts
@@ -44,7 +44,7 @@ async function resolvePending({
   };
   const slackClient = {
     chat: {
-      postMessage: vi.fn(async () => undefined),
+      postMessage: vi.fn(async () => ({ ok: true, ts: "fallback_ts" })),
     },
   };
   const streamHandler = {

--- a/connectors/src/connectors/slack/bot_pending_message.test.ts
+++ b/connectors/src/connectors/slack/bot_pending_message.test.ts
@@ -6,7 +6,7 @@ vi.mock("@connectors/lib/bot/conversation_utils", () => ({
   makeConversationUrl: () => "https://dust.test/conversation",
 }));
 
-import { resolveSlackPendingUserMessage } from "./bot";
+import { resolveSlackPendingUserMessage } from "./bot_pending_message";
 
 type PendingMessage =
   | { sId: string; type: "user_message"; visibility: "pending" | "visible" }
@@ -37,10 +37,12 @@ function makeConversation(content: PendingMessage[][] = []) {
 async function resolvePending({
   events = [],
   refetchedConversation = makeConversation([[pendingUserMessage]]),
+  stopRejects = false,
   timeoutMs = 100,
 }: {
   events?: ConversationEvent[];
   refetchedConversation?: ReturnType<typeof makeConversation>;
+  stopRejects?: boolean;
   timeoutMs?: number;
 } = {}) {
   const dustAPI = {
@@ -62,7 +64,11 @@ async function resolvePending({
     },
   };
   const streamHandler = {
-    stop: vi.fn(async () => undefined),
+    stop: vi.fn(async () => {
+      if (stopRejects) {
+        throw new Error("stop failed");
+      }
+    }),
   };
 
   const res = await resolveSlackPendingUserMessage({
@@ -110,7 +116,7 @@ describe("resolveSlackPendingUserMessage", () => {
   });
 
   it("posts a fallback when the pending message is not promoted", async () => {
-    const ctx = await resolvePending({ timeoutMs: 1 });
+    const ctx = await resolvePending({ stopRejects: true, timeoutMs: 1 });
 
     expect(ctx.res).toEqual(new Ok(null));
     expect(ctx.streamHandler.stop).toHaveBeenCalledTimes(1);

--- a/connectors/src/connectors/slack/bot_pending_message.ts
+++ b/connectors/src/connectors/slack/bot_pending_message.ts
@@ -240,14 +240,5 @@ export async function resolveSlackPendingUserMessage<
     );
   }
 
-  logger.info(
-    {
-      connectorId: connector.id,
-      conversationId: conversation.sId,
-      userMessageId: userMessage.sId,
-    },
-    "Posted Slack pending user message fallback after promotion timeout."
-  );
-
   return new Ok(null);
 }

--- a/connectors/src/connectors/slack/bot_pending_message.ts
+++ b/connectors/src/connectors/slack/bot_pending_message.ts
@@ -1,0 +1,253 @@
+import type { SlackStreamHandler } from "@connectors/connectors/slack/chat/slack_stream_handler";
+import { reportSlackUsage } from "@connectors/connectors/slack/lib/slack_client";
+import { makeConversationUrl } from "@connectors/lib/bot/conversation_utils";
+import logger from "@connectors/logger/logger";
+import type { ConnectorResource } from "@connectors/resources/connector_resource";
+import type {
+  APIError,
+  ConversationPublicType,
+  DustAPI,
+  Result,
+  UserMessageType,
+} from "@dust-tt/client";
+import { Err, normalizeError, Ok } from "@dust-tt/client";
+import type { WebClient } from "@slack/web-api";
+
+const SLACK_PENDING_PROMOTION_RECONNECT_DELAY_MS = 1_000;
+const SLACK_PENDING_PROMOTION_RECONNECT_ATTEMPT_BUFFER = 2;
+
+type SlackPendingConversation = {
+  sId: string;
+  content: {
+    type: "user_message" | "agent_message" | "content_fragment";
+    parentMessageId?: string | null;
+  }[][];
+};
+
+type SlackPendingUserMessageDustAPI<
+  TConversation extends SlackPendingConversation,
+> = Pick<DustAPI, "streamConversationEvents"> & {
+  getConversation: (params: {
+    conversationId: string;
+  }) => Promise<Result<TConversation, APIError>>;
+};
+
+function hasAgentMessageForUserMessage(
+  conversation: SlackPendingConversation,
+  userMessageId: string
+): boolean {
+  return conversation.content.some((messageVersions) => {
+    const message = messageVersions.at(-1);
+    return (
+      message?.type === "agent_message" &&
+      message.parentMessageId === userMessageId
+    );
+  });
+}
+
+async function waitForSlackUserMessagePromotion({
+  dustAPI,
+  conversationId,
+  timeoutMs,
+  userMessageId,
+}: {
+  dustAPI: Pick<DustAPI, "streamConversationEvents">;
+  conversationId: string;
+  timeoutMs: number;
+  userMessageId: string;
+}): Promise<Result<undefined, Error | APIError>> {
+  const abortController = new AbortController();
+  const timeout = setTimeout(() => {
+    abortController.abort();
+  }, timeoutMs);
+  const handleStreamError = (error: unknown) =>
+    abortController.signal.aborted
+      ? new Ok(undefined)
+      : new Err(normalizeError(error));
+
+  try {
+    const streamRes = await dustAPI.streamConversationEvents({
+      conversationId,
+      signal: abortController.signal,
+      options: {
+        maxReconnectAttempts:
+          Math.ceil(timeoutMs / SLACK_PENDING_PROMOTION_RECONNECT_DELAY_MS) +
+          SLACK_PENDING_PROMOTION_RECONNECT_ATTEMPT_BUFFER,
+        reconnectDelay: SLACK_PENDING_PROMOTION_RECONNECT_DELAY_MS,
+      },
+    });
+    if (streamRes.isErr()) {
+      return handleStreamError(streamRes.error);
+    }
+
+    try {
+      for await (const event of streamRes.value.eventStream) {
+        if (
+          event.type === "user_message_promoted" &&
+          event.messageId === userMessageId
+        ) {
+          return new Ok(undefined);
+        }
+      }
+    } catch (error) {
+      return handleStreamError(error);
+    }
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  return new Ok(undefined);
+}
+
+async function stopSlackStreamBestEffort({
+  connector,
+  conversation,
+  streamHandler,
+  userMessage,
+}: {
+  connector: Pick<ConnectorResource, "id">;
+  conversation: Pick<SlackPendingConversation, "sId">;
+  streamHandler: Pick<SlackStreamHandler, "stop">;
+  userMessage: Pick<UserMessageType, "sId">;
+}) {
+  try {
+    await streamHandler.stop();
+  } catch (error) {
+    logger.warn(
+      {
+        error,
+        connectorId: connector.id,
+        conversationId: conversation.sId,
+        userMessageId: userMessage.sId,
+      },
+      "Failed to stop Slack stream before posting pending user message fallback."
+    );
+  }
+}
+
+export async function resolveSlackPendingUserMessage<
+  TConversation extends SlackPendingConversation = ConversationPublicType,
+>({
+  connector,
+  conversation,
+  dustAPI,
+  slack,
+  streamHandler,
+  timeoutMs,
+  userMessage,
+}: {
+  connector: Pick<ConnectorResource, "id" | "workspaceId">;
+  conversation: TConversation;
+  dustAPI: SlackPendingUserMessageDustAPI<TConversation>;
+  slack: {
+    slackChannelId: string;
+    slackClient: { chat: Pick<WebClient["chat"], "postMessage"> };
+    slackMessageTs: string;
+  };
+  streamHandler: Pick<SlackStreamHandler, "stop">;
+  timeoutMs: number;
+  userMessage: Pick<UserMessageType, "sId" | "visibility">;
+}): Promise<Result<TConversation | null, Error | APIError>> {
+  if (userMessage.visibility !== "pending") {
+    return new Ok(conversation);
+  }
+  if (hasAgentMessageForUserMessage(conversation, userMessage.sId)) {
+    return new Ok(conversation);
+  }
+
+  logger.info(
+    {
+      connectorId: connector.id,
+      conversationId: conversation.sId,
+      userMessageId: userMessage.sId,
+    },
+    "Slack user message is pending, waiting for promotion before streaming."
+  );
+
+  const waitRes = await waitForSlackUserMessagePromotion({
+    dustAPI,
+    conversationId: conversation.sId,
+    timeoutMs,
+    userMessageId: userMessage.sId,
+  });
+  if (waitRes.isErr()) {
+    return waitRes;
+  }
+
+  // The promotion event only carries the user message id. Refetch once to get the
+  // new agent message id before streaming; otherwise the SDK opens a second
+  // conversation-events stream and refetches internally.
+  const conversationRes = await dustAPI.getConversation({
+    conversationId: conversation.sId,
+  });
+
+  if (
+    conversationRes.isOk() &&
+    hasAgentMessageForUserMessage(conversationRes.value, userMessage.sId)
+  ) {
+    return new Ok(conversationRes.value);
+  }
+
+  if (conversationRes.isErr()) {
+    logger.warn(
+      {
+        error: conversationRes.error,
+        connectorId: connector.id,
+        conversationId: conversation.sId,
+        userMessageId: userMessage.sId,
+      },
+      "Failed to refetch Slack conversation after pending user message timeout."
+    );
+  }
+
+  await stopSlackStreamBestEffort({
+    connector,
+    conversation,
+    streamHandler,
+    userMessage,
+  });
+
+  const conversationUrl = makeConversationUrl(
+    connector.workspaceId,
+    conversation.sId
+  );
+  const fallbackText = `:hourglass_flowing_sand: _Dust is still finishing the previous request, so this Slack reply could not start in time.${
+    conversationUrl ? ` <${conversationUrl}|Continue on Dust>.` : ""
+  }_`;
+
+  try {
+    reportSlackUsage({
+      connectorId: connector.id,
+      method: "chat.postMessage",
+      channelId: slack.slackChannelId,
+      useCase: "bot",
+    });
+    await slack.slackClient.chat.postMessage({
+      channel: slack.slackChannelId,
+      text: fallbackText,
+      thread_ts: slack.slackMessageTs,
+      unfurl_links: false,
+    });
+  } catch (error) {
+    logger.error(
+      {
+        error,
+        connectorId: connector.id,
+        conversationId: conversation.sId,
+        userMessageId: userMessage.sId,
+      },
+      "Failed to post Slack pending user message fallback."
+    );
+  }
+
+  logger.info(
+    {
+      connectorId: connector.id,
+      conversationId: conversation.sId,
+      userMessageId: userMessage.sId,
+    },
+    "Posted Slack pending user message fallback after promotion timeout."
+  );
+
+  return new Ok(null);
+}

--- a/connectors/src/connectors/slack/bot_pending_message.ts
+++ b/connectors/src/connectors/slack/bot_pending_message.ts
@@ -211,7 +211,7 @@ export async function resolveSlackPendingUserMessage<
     connector.workspaceId,
     conversation.sId
   );
-  const fallbackText = `:hourglass_flowing_sand: _Dust is still finishing the previous request, so this Slack reply could not start in time.${
+  const fallbackText = `:hourglass_flowing_sand: _Dust is still finishing the previous request.${
     conversationUrl ? ` <${conversationUrl}|Continue on Dust>.` : ""
   }_`;
 


### PR DESCRIPTION
## Description

Slack replies can create a Dust user message with `visibility: "pending"` when the
conversation is still blocked on an earlier user action, such as a tool approval,
personal auth request, or user question.

In that state, Dust has accepted the Slack reply, but it has not promoted the reply into
the runnable conversation yet. The previous Slack path still tried to stream the next
agent answer immediately. Since the matching agent message did not exist yet, the SDK
kept reconnecting until it hit its maximum reconnect attempts, and Slack eventually
surfaced a generic failure.

This PR handles that pending state explicitly:

- after `createConversation` / `postUserMessage`, detect `userMessage.visibility ===
  "pending"`;
- wait for the matching `user_message_promoted` conversation event for the Slack
  user-action timeout;
- when promotion happens, refetch the conversation and stream the agent answer normally;
- when promotion does not happen in time, stop the Slack placeholder and post a clear
  fallback with a link to continue in Dust.

Example flow:

1. An agent asks for tool approval in Slack.
2. The user replies in the same thread before approving the tool.
3. Dust stores that reply as pending because the previous turn is still blocked.
4. If the tool is approved soon enough, Slack sees the promotion event and continues
   streaming normally.
5. If not, Slack posts a controlled fallback instead of waiting for SDK reconnect
   exhaustion.

This keeps the reconnect settings bounded and treats pending Slack replies as an expected
blocked-conversation state, not as an unexpected streaming error.

## Risks

Blast radius: Slack bot replies posted while a previous user-action gate is still pending.
Risk: standard. The timeout path posts a fallback message instead of continuing to wait in
Slack.

## Deploy Plan
- pmrr
- deploy connectors

## Tests

- [x] `NODE_ENV=test CONNECTORS_DATABASE_URI=postgres://dev:dev@localhost:5432/dust_connectors_test npx vitest run src/connectors/slack/bot.test.ts src/connectors/slack/chat/stream_conversation_handler.test.ts --config vite.config.mjs`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25901">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
