### PR TITLE
No longer return skill instructions when listing skills

### DIFF
--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -15,9 +15,8 @@ import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory"
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type {
-  SkillType,
   SkillWithoutInstructionsAndToolsType,
-  SkillWithRelationsType,
+  SkillWithoutInstructionsAndToolsWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 import type { MembershipRoleType } from "@app/types/memberships";
 import { honoApp } from "@front-api/app";
@@ -69,7 +68,9 @@ describe("GET /api/w/:wId/skills", () => {
     const data = await response.json();
     expect(data).toHaveProperty("skills");
 
-    const skillNames = data.skills.map((s: SkillType) => s.name);
+    const skillNames = data.skills.map(
+      (s: SkillWithoutInstructionsAndToolsType) => s.name
+    );
     expect(skillNames).toContain("Test Skill 1");
     expect(skillNames).toContain("Test Skill 2");
   });
@@ -100,7 +101,9 @@ describe("GET /api/w/:wId/skills", () => {
     expect(response.status).toBe(200);
     const data = await response.json();
 
-    const skillNames = data.skills.map((s: SkillType) => s.name);
+    const skillNames = data.skills.map(
+      (s: SkillWithoutInstructionsAndToolsType) => s.name
+    );
     expect(skillNames).toContain("Active Skill");
     expect(skillNames).not.toContain("Archived Skill");
   });
@@ -120,7 +123,7 @@ describe("GET /api/w/:wId/skills", () => {
     const response1 = await getSkills(workspace);
     expect(response1.status).toBe(200);
     const allSkillIds = (await response1.json()).skills.map(
-      (s: SkillType) => s.sId
+      (s: SkillWithoutInstructionsAndToolsType) => s.sId
     );
     expect(allSkillIds).toContain("frames");
     expect(allSkillIds).toContain(customSkill.sId);
@@ -128,7 +131,7 @@ describe("GET /api/w/:wId/skills", () => {
     const response2 = await getSkills(workspace, { onlyCustom: "true" });
     expect(response2.status).toBe(200);
     const customOnlySIds = (await response2.json()).skills.map(
-      (s: SkillType) => s.sId
+      (s: SkillWithoutInstructionsAndToolsType) => s.sId
     );
     expect(customOnlySIds).not.toContain("frames");
     expect(customOnlySIds).toContain(customSkill.sId);
@@ -157,7 +160,9 @@ describe("GET /api/w/:wId/skills", () => {
     expect(response.status).toBe(200);
     const data = await response.json();
 
-    const skillNames = data.skills.map((s: SkillType) => s.name);
+    const skillNames = data.skills.map(
+      (s: SkillWithoutInstructionsAndToolsType) => s.name
+    );
     expect(skillNames).toContain("Suggested Skill");
     expect(skillNames).not.toContain("Active Skill");
     expect(skillNames).not.toContain("Archived Skill");
@@ -178,7 +183,7 @@ describe("GET /api/w/:wId/skills", () => {
 
       expect(response.status).toBe(200);
       const skillNames = (await response.json()).skills.map(
-        (s: SkillType) => s.name
+        (s: SkillWithoutInstructionsAndToolsType) => s.name
       );
       expect(skillNames).toContain(`Skill for ${role}`);
     }
@@ -200,7 +205,7 @@ describe("GET /api/w/:wId/skills", () => {
 
     expect(response.status).toBe(200);
     const skillNames = (await response.json()).skills.map(
-      (s: SkillType) => s.name
+      (s: SkillWithoutInstructionsAndToolsType) => s.name
     );
     expect(skillNames).toContain("Accessible Skill");
     expect(skillNames).not.toContain("Restricted Skill");
@@ -223,12 +228,12 @@ describe("GET /api/w/:wId/skills", () => {
 
     expect(response.status).toBe(200);
     const skillNames = (await response.json()).skills.map(
-      (s: SkillType) => s.name
+      (s: SkillWithoutInstructionsAndToolsType) => s.name
     );
     expect(skillNames).toContain("Skill In Restricted Space");
   });
 
-  it("should return skill summaries for viewType=summary", async () => {
+  it("should not return instructions or tools in skill list", async () => {
     const { workspace, auth, user } = await setupTest();
 
     const skill = await SkillFactory.create(auth, {
@@ -236,7 +241,7 @@ describe("GET /api/w/:wId/skills", () => {
       userFacingDescription: "Shown in the capabilities picker",
     });
 
-    const response = await getSkills(workspace, { viewType: "summary" });
+    const response = await getSkills(workspace);
 
     expect(response.status).toBe(200);
 
@@ -269,7 +274,7 @@ describe("GET /api/w/:wId/skills", () => {
     expect(skillWithoutInstructionsAndTools).not.toHaveProperty("tools");
   });
 
-  it("should not fetch dynamic global instructions for viewType=summary", async () => {
+  it("should not fetch dynamic global instructions", async () => {
     const { workspace } = await setupTest();
 
     const fetchInstructionsSpy = vi.spyOn(
@@ -279,7 +284,6 @@ describe("GET /api/w/:wId/skills", () => {
     try {
       const response = await getSkills(workspace, {
         globalSpaceOnly: "true",
-        viewType: "summary",
       });
 
       expect(response.status).toBe(200);
@@ -326,7 +330,8 @@ describe("GET /api/w/:wId/skills?withRelations=true", () => {
       workspaceId: workspace.id,
     });
     const skillResult = (await response.json()).skills.find(
-      (s: SkillWithRelationsType) => s.sId === skillId
+      (s: SkillWithoutInstructionsAndToolsWithRelationsType) =>
+        s.sId === skillId
     );
 
     expect(skillResult).toMatchObject({
@@ -361,7 +366,8 @@ describe("GET /api/w/:wId/skills?withRelations=true", () => {
     expect(response.status).toBe(200);
 
     const skillResult = (await response.json()).skills.find(
-      (s: SkillWithRelationsType) => s.sId === "frames"
+      (s: SkillWithoutInstructionsAndToolsWithRelationsType) =>
+        s.sId === "frames"
     );
 
     expect(skillResult).toMatchObject({
@@ -395,7 +401,8 @@ describe("GET /api/w/:wId/skills?withRelations=true", () => {
       workspaceId: workspace.id,
     });
     const skillResult = (await response.json()).skills.find(
-      (s: SkillWithRelationsType) => s.sId === skillId
+      (s: SkillWithoutInstructionsAndToolsWithRelationsType) =>
+        s.sId === skillId
     );
 
     expect(skillResult).toMatchObject({
@@ -426,7 +433,7 @@ describe("GET /api/w/:wId/skills?withRelations=true", () => {
       workspaceId: workspace.id,
     });
     const skillResult = (await response.json()).skills.find(
-      (s: SkillType) => s.sId === skillId
+      (s: SkillWithoutInstructionsAndToolsType) => s.sId === skillId
     );
 
     expect(skillResult).toBeDefined();
@@ -468,7 +475,8 @@ describe("GET /api/w/:wId/skills?withRelations=true", () => {
       workspaceId: workspace.id,
     });
     const skillResult = (await response.json()).skills.find(
-      (s: SkillWithRelationsType) => s.sId === skillId
+      (s: SkillWithoutInstructionsAndToolsWithRelationsType) =>
+        s.sId === skillId
     );
 
     expect(skillResult).toMatchObject({

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -7,14 +7,12 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import {
-  SKILL_VIEWS,
-  type SkillType,
-  type SkillViewType,
-  type SkillWithoutInstructionsAndToolsType,
-  type SkillWithRelationsType,
+import type {
+  SkillType,
+  SkillWithoutInstructionsAndToolsType,
+  SkillWithoutInstructionsAndToolsWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
-import { isString, removeNulls } from "@app/types/shared/utils/general";
+import { removeNulls } from "@app/types/shared/utils/general";
 import { isBuilder } from "@app/types/user";
 import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
@@ -29,16 +27,12 @@ import reinforcementDailySpend from "./reinforcement_daily_spend";
 import reinforcementSpend from "./reinforcement_spend";
 import similar from "./similar";
 
-export type GetSkillsWithoutInstructionsAndToolsResponseBody = {
+export type GetSkillsResponseBody = {
   skills: SkillWithoutInstructionsAndToolsType[];
 };
 
-export type GetSkillsResponseBody = {
-  skills: SkillType[];
-};
-
 export type GetSkillsWithRelationsResponseBody = {
-  skills: SkillWithRelationsType[];
+  skills: SkillWithoutInstructionsAndToolsWithRelationsType[];
 };
 
 export type PostSkillResponseBody = {
@@ -48,10 +42,6 @@ export type PostSkillResponseBody = {
 const SkillStatusSchema = z
   .enum(["active", "archived", "suggested"])
   .optional();
-
-function isSkillViewType(value: string): value is SkillViewType {
-  return SKILL_VIEWS.some((skillViewType) => skillViewType === value);
-}
 
 // Schema for attached knowledge.
 export const AttachedKnowledgeSchema = z.object({
@@ -115,43 +105,17 @@ app.get(
   async (
     ctx
   ): HandlerResult<
-    | GetSkillsResponseBody
-    | GetSkillsWithRelationsResponseBody
-    | GetSkillsWithoutInstructionsAndToolsResponseBody
+    GetSkillsResponseBody | GetSkillsWithRelationsResponseBody
   > => {
     const auth = ctx.get("auth");
 
+    // @deprecated viewType query param is ignored — instructions and tools
+    // are never returned from the list endpoint. Use GET /skills/:sId for full details.
     const withRelations = ctx.req.query("withRelations");
     const status = ctx.req.query("status");
     const globalSpaceOnly = ctx.req.query("globalSpaceOnly");
     const onlyCustom = ctx.req.query("onlyCustom");
     const isDefault = ctx.req.query("isDefault");
-    const viewType = ctx.req.query("viewType");
-
-    let skillView: SkillViewType = "full";
-    if (viewType !== undefined) {
-      if (!isString(viewType) || !isSkillViewType(viewType)) {
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: `Invalid viewType: ${viewType}. Expected "full" or "summary".`,
-          },
-        });
-      }
-
-      skillView = viewType;
-    }
-
-    if (withRelations === "true" && skillView === "summary") {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "viewType=summary is incompatible with withRelations=true.",
-        },
-      });
-    }
 
     const statusValidation = SkillStatusSchema.safeParse(status);
     if (!statusValidation.success) {
@@ -170,8 +134,8 @@ app.get(
       globalSpaceOnly: globalSpaceOnly === "true",
       onlyCustom: onlyCustom === "true",
       isDefault: isDefault === "true" ? true : undefined,
-      withInstructions: skillView !== "summary",
-      withTools: skillView === "full",
+      withInstructions: false,
+      withTools: false,
     });
 
     if (withRelations === "true") {
@@ -184,12 +148,18 @@ app.get(
       const skillsWithRelations = await concurrentExecutor(
         skills,
         async (sc) => {
+          const {
+            instructions,
+            instructionsHtml,
+            tools,
+            ...skillWithoutInstructionsAndTools
+          } = sc.toJSON(auth);
           const usage = await sc.fetchUsage(auth);
           const editors = await sc.listEditors(auth);
           const editedByUser = await sc.fetchEditedByUser(auth);
 
           return {
-            ...sc.toJSON(auth),
+            ...skillWithoutInstructionsAndTools,
             relations: {
               usage,
               editors: editors ? editors.map((e) => e.toJSON()) : null,
@@ -199,7 +169,7 @@ app.get(
                   null)
                 : null,
             },
-          } satisfies SkillWithRelationsType;
+          } satisfies SkillWithoutInstructionsAndToolsWithRelationsType;
         },
         { concurrency: 10 }
       );
@@ -207,23 +177,17 @@ app.get(
       return ctx.json({ skills: skillsWithRelations });
     }
 
-    if (skillView === "summary") {
-      return ctx.json({
-        skills: skills.map((sc) => {
-          const {
-            instructions,
-            instructionsHtml,
-            tools,
-            ...skillWithoutInstructionsAndTools
-          } = sc.toJSON(auth);
-
-          return skillWithoutInstructionsAndTools;
-        }),
-      });
-    }
-
     return ctx.json({
-      skills: skills.map((sc) => sc.toJSON(auth)),
+      skills: skills.map((sc) => {
+        const {
+          instructions,
+          instructionsHtml,
+          tools,
+          ...skillWithoutInstructionsAndTools
+        } = sc.toJSON(auth);
+
+        return skillWithoutInstructionsAndTools;
+      }),
     });
   }
 );

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -111,9 +111,7 @@ export function useSkills({
 } {
   const { fetcher } = useFetcher();
 
-  const queryParams = new URLSearchParams({
-    viewType: "summary",
-  });
+  const queryParams = new URLSearchParams();
   if (status) {
     queryParams.set("status", status);
   }

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -15,9 +15,8 @@ import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory"
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type {
-  SkillType,
   SkillWithoutInstructionsAndToolsType,
-  SkillWithRelationsType,
+  SkillWithoutInstructionsAndToolsWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 import type { MembershipRoleType } from "@app/types/memberships";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -65,7 +64,9 @@ describe("GET /api/w/[wId]/skills", () => {
     const data = res._getJSONData();
     expect(data).toHaveProperty("skills");
 
-    const skillNames = data.skills.map((s: SkillType) => s.name);
+    const skillNames = data.skills.map(
+      (s: SkillWithoutInstructionsAndToolsType) => s.name
+    );
     expect(skillNames).toContain("Test Skill 1");
     expect(skillNames).toContain("Test Skill 2");
   });
@@ -98,7 +99,9 @@ describe("GET /api/w/[wId]/skills", () => {
     expect(res._getStatusCode()).toBe(200);
     const data = res._getJSONData();
 
-    const skillNames = data.skills.map((s: SkillType) => s.name);
+    const skillNames = data.skills.map(
+      (s: SkillWithoutInstructionsAndToolsType) => s.name
+    );
     expect(skillNames).toContain("Active Skill");
     expect(skillNames).not.toContain("Archived Skill");
   });
@@ -119,7 +122,9 @@ describe("GET /api/w/[wId]/skills", () => {
     req.query = { wId: workspace.sId };
     await handler(req, res);
     expect(res._getStatusCode()).toBe(200);
-    const allSkillIds = res._getJSONData().skills.map((s: SkillType) => s.sId);
+    const allSkillIds = res
+      ._getJSONData()
+      .skills.map((s: SkillWithoutInstructionsAndToolsType) => s.sId);
     expect(allSkillIds).toContain("frames");
     expect(allSkillIds).toContain(customSkill.sId);
 
@@ -136,7 +141,7 @@ describe("GET /api/w/[wId]/skills", () => {
     expect(res2._getStatusCode()).toBe(200);
     const customOnlySIds = res2
       ._getJSONData()
-      .skills.map((s: SkillType) => s.sId);
+      .skills.map((s: SkillWithoutInstructionsAndToolsType) => s.sId);
     expect(customOnlySIds).not.toContain("frames");
     expect(customOnlySIds).toContain(customSkill.sId);
   });
@@ -169,7 +174,9 @@ describe("GET /api/w/[wId]/skills", () => {
     expect(res._getStatusCode()).toBe(200);
     const data = res._getJSONData();
 
-    const skillNames = data.skills.map((s: SkillType) => s.name);
+    const skillNames = data.skills.map(
+      (s: SkillWithoutInstructionsAndToolsType) => s.name
+    );
     expect(skillNames).toContain("Suggested Skill");
     expect(skillNames).not.toContain("Active Skill");
     expect(skillNames).not.toContain("Archived Skill");
@@ -195,7 +202,7 @@ describe("GET /api/w/[wId]/skills", () => {
       expect(res._getStatusCode()).toBe(200);
       const skillNames = res
         ._getJSONData()
-        .skills.map((s: SkillType) => s.name);
+        .skills.map((s: SkillWithoutInstructionsAndToolsType) => s.name);
       expect(skillNames).toContain(`Skill for ${role}`);
     }
   });
@@ -222,7 +229,9 @@ describe("GET /api/w/[wId]/skills", () => {
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
-    const skillNames = res._getJSONData().skills.map((s: SkillType) => s.name);
+    const skillNames = res
+      ._getJSONData()
+      .skills.map((s: SkillWithoutInstructionsAndToolsType) => s.name);
     expect(skillNames).toContain("Accessible Skill");
     expect(skillNames).not.toContain("Restricted Skill");
   });
@@ -248,11 +257,13 @@ describe("GET /api/w/[wId]/skills", () => {
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
-    const skillNames = res._getJSONData().skills.map((s: SkillType) => s.name);
+    const skillNames = res
+      ._getJSONData()
+      .skills.map((s: SkillWithoutInstructionsAndToolsType) => s.name);
     expect(skillNames).toContain("Skill In Restricted Space");
   });
 
-  it("should return skill summaries for viewType=summary", async () => {
+  it("should not return instructions or tools in skill list", async () => {
     const { req, res, workspace, auth, user } = await setupTest();
 
     const skill = await SkillFactory.create(auth, {
@@ -260,7 +271,7 @@ describe("GET /api/w/[wId]/skills", () => {
       userFacingDescription: "Shown in the capabilities picker",
     });
 
-    req.query = { ...req.query, wId: workspace.sId, viewType: "summary" };
+    req.query = { ...req.query, wId: workspace.sId };
 
     await handler(req, res);
 
@@ -295,7 +306,7 @@ describe("GET /api/w/[wId]/skills", () => {
     expect(skillWithoutInstructionsAndTools).not.toHaveProperty("tools");
   });
 
-  it("should not fetch dynamic global instructions for viewType=summary", async () => {
+  it("should not fetch dynamic global instructions", async () => {
     const { req, res, workspace } = await setupTest();
 
     const fetchInstructionsSpy = vi.spyOn(
@@ -307,7 +318,6 @@ describe("GET /api/w/[wId]/skills", () => {
         ...req.query,
         wId: workspace.sId,
         globalSpaceOnly: "true",
-        viewType: "summary",
       };
 
       await handler(req, res);
@@ -362,7 +372,10 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
     });
     const skillResult = res
       ._getJSONData()
-      .skills.find((s: SkillWithRelationsType) => s.sId === skillId);
+      .skills.find(
+        (s: SkillWithoutInstructionsAndToolsWithRelationsType) =>
+          s.sId === skillId
+      );
 
     expect(skillResult).toMatchObject({
       relations: {
@@ -399,7 +412,10 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
 
     const skillResult = res
       ._getJSONData()
-      .skills.find((s: SkillWithRelationsType) => s.sId === "frames");
+      .skills.find(
+        (s: SkillWithoutInstructionsAndToolsWithRelationsType) =>
+          s.sId === "frames"
+      );
 
     expect(skillResult).toMatchObject({
       relations: {
@@ -435,7 +451,10 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
     });
     const skillResult = res
       ._getJSONData()
-      .skills.find((s: SkillWithRelationsType) => s.sId === skillId);
+      .skills.find(
+        (s: SkillWithoutInstructionsAndToolsWithRelationsType) =>
+          s.sId === skillId
+      );
 
     expect(skillResult).toMatchObject({
       relations: {
@@ -471,7 +490,9 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
     });
     const skillResult = res
       ._getJSONData()
-      .skills.find((s: SkillType) => s.sId === skillId);
+      .skills.find(
+        (s: SkillWithoutInstructionsAndToolsType) => s.sId === skillId
+      );
 
     expect(skillResult).toBeDefined();
     expect(skillResult).not.toHaveProperty("usage");
@@ -517,7 +538,10 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
     });
     const skillResult = res
       ._getJSONData()
-      .skills.find((s: SkillWithRelationsType) => s.sId === skillId);
+      .skills.find(
+        (s: SkillWithoutInstructionsAndToolsWithRelationsType) =>
+          s.sId === skillId
+      );
 
     expect(skillResult).toMatchObject({
       relations: {

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -11,31 +11,25 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
-import {
-  SKILL_VIEWS,
-  type SkillType,
-  type SkillViewType,
-  type SkillWithoutInstructionsAndToolsType,
-  type SkillWithRelationsType,
+import type {
+  SkillType,
+  SkillWithoutInstructionsAndToolsType,
+  SkillWithoutInstructionsAndToolsWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isString, removeNulls } from "@app/types/shared/utils/general";
+import { removeNulls } from "@app/types/shared/utils/general";
 import { isBuilder } from "@app/types/user";
 import uniq from "lodash/uniq";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
-export type GetSkillsWithoutInstructionsAndToolsResponseBody = {
+export type GetSkillsResponseBody = {
   skills: SkillWithoutInstructionsAndToolsType[];
 };
 
-export type GetSkillsResponseBody = {
-  skills: SkillType[];
-};
-
 export type GetSkillsWithRelationsResponseBody = {
-  skills: SkillWithRelationsType[];
+  skills: SkillWithoutInstructionsAndToolsWithRelationsType[];
 };
 
 export type PostSkillResponseBody = {
@@ -45,10 +39,6 @@ export type PostSkillResponseBody = {
 const SkillStatusSchema = z
   .enum(["active", "archived", "suggested"])
   .optional();
-
-function isSkillViewType(value: string): value is SkillViewType {
-  return SKILL_VIEWS.some((skillViewType) => skillViewType === value);
-}
 
 // Schema for attached knowledge.
 export const AttachedKnowledgeSchema = z.object({
@@ -103,7 +93,6 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<
-      | GetSkillsWithoutInstructionsAndToolsResponseBody
       | GetSkillsResponseBody
       | GetSkillsWithRelationsResponseBody
       | PostSkillResponseBody
@@ -115,40 +104,10 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const {
-        withRelations,
-        status,
-        globalSpaceOnly,
-        onlyCustom,
-        isDefault,
-        viewType,
-      } = req.query;
-
-      let skillView: SkillViewType = "full";
-      if (viewType !== undefined) {
-        if (!isString(viewType) || !isSkillViewType(viewType)) {
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: `Invalid viewType: ${viewType}. Expected "full" or "summary".`,
-            },
-          });
-        }
-
-        skillView = viewType;
-      }
-
-      if (withRelations === "true" && skillView === "summary") {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message:
-              "viewType=summary is incompatible with withRelations=true.",
-          },
-        });
-      }
+      // @deprecated viewType query param is ignored — instructions and tools
+      // are never returned from the list endpoint. Use GET /skills/:sId for full details.
+      const { withRelations, status, globalSpaceOnly, onlyCustom, isDefault } =
+        req.query;
 
       const statusValidation = SkillStatusSchema.safeParse(status);
       if (!statusValidation.success) {
@@ -167,8 +126,8 @@ async function handler(
         globalSpaceOnly: globalSpaceOnly === "true",
         onlyCustom: onlyCustom === "true",
         isDefault: isDefault === "true" ? true : undefined,
-        withInstructions: skillView !== "summary",
-        withTools: skillView === "full",
+        withInstructions: false,
+        withTools: false,
       });
 
       if (withRelations === "true") {
@@ -183,12 +142,18 @@ async function handler(
         const skillsWithRelations = await concurrentExecutor(
           skills,
           async (sc) => {
+            const {
+              instructions,
+              instructionsHtml,
+              tools,
+              ...skillWithoutInstructionsAndTools
+            } = sc.toJSON(auth);
             const usage = await sc.fetchUsage(auth);
             const editors = await sc.listEditors(auth);
             const editedByUser = await sc.fetchEditedByUser(auth);
 
             return {
-              ...sc.toJSON(auth),
+              ...skillWithoutInstructionsAndTools,
               relations: {
                 usage,
                 editors: editors ? editors.map((e) => e.toJSON()) : null,
@@ -198,7 +163,7 @@ async function handler(
                     null)
                   : null,
               },
-            } satisfies SkillWithRelationsType;
+            } satisfies SkillWithoutInstructionsAndToolsWithRelationsType;
           },
           { concurrency: 10 }
         );
@@ -206,23 +171,17 @@ async function handler(
         return res.status(200).json({ skills: skillsWithRelations });
       }
 
-      if (skillView === "summary") {
-        return res.status(200).json({
-          skills: skills.map((sc) => {
-            const {
-              instructions,
-              instructionsHtml,
-              tools,
-              ...skillWithoutInstructionsAndTools
-            } = sc.toJSON(auth);
-
-            return skillWithoutInstructionsAndTools;
-          }),
-        });
-      }
-
       return res.status(200).json({
-        skills: skills.map((sc) => sc.toJSON(auth)),
+        skills: skills.map((sc) => {
+          const {
+            instructions,
+            instructionsHtml,
+            tools,
+            ...skillWithoutInstructionsAndTools
+          } = sc.toJSON(auth);
+
+          return skillWithoutInstructionsAndTools;
+        }),
       });
     }
 


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/8101

The endpoint listing the skill no longer returns the instructions and instructionsHtml.
The individual endpoint for one skill still return it.

## Tests

 - updated unit tests
 - tested locally, all the pages tested still work (skill table, side panel, editor, slash command for skill...)

## Risk

low, typing make it sure we are not using the instructions somewhere it's not available.
biggest risk IMHO is retro-compatibility, we may break the side panel of someone who has not refreshed the page.
But I think it is OK 🤷 

## Deploy Plan

deploy front 


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25902">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->