### PR TITLE
fix(sandbox): dsbx tool-call auth and response parsing

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/src/api/types.rs
+++ b/cli/dust-sandbox/src/api/types.rs
@@ -44,7 +44,11 @@ pub struct CallToolRequest {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(tag = "status", rename_all = "snake_case")]
+#[serde(
+    tag = "status",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase"
+)]
 pub enum CallToolPostResponse {
     Pending { action_id: String },
 }
@@ -241,6 +245,15 @@ mod tests {
             ActionPollResponse::Success { is_error, .. } => assert!(is_error),
             _ => panic!("expected success"),
         }
+    }
+
+    #[test]
+    fn parse_call_tool_post_response_pending() {
+        let resp: CallToolPostResponse =
+            serde_json::from_str(r#"{"status":"pending","actionId":"act_abc"}"#)
+                .expect("should parse");
+        let CallToolPostResponse::Pending { action_id } = resp;
+        assert_eq!(action_id, "act_abc");
     }
 
     #[test]

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -52,7 +52,7 @@ describe("sandbox image registry", () => {
   test("bumps the base image for the scoped MITM rollout", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.17",
+      tag: "0.8.18",
     });
   });
 

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -14,8 +14,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.7.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.17";
-const DSBX_CLI_VERSION = "0.1.13";
+const DUST_BASE_IMAGE_VERSION = "0.8.18";
+const DSBX_CLI_VERSION = "0.1.14";
 const AGENT_PROXIED_UID = 1003;
 // Built from https://github.com/openai/codex at tag rust-v0.115.0 (Apache-2.0).
 // Released via the "Release sandbox tool" GitHub Actions workflow.

--- a/front/pages/api/v1/w/[wId]/sandbox/actions/[aId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/sandbox/actions/[aId]/index.ts
@@ -51,13 +51,24 @@ async function handler(
     });
   }
 
-  const claims = await verifySandboxExecToken(req.headers.authorization ?? "");
-  if (!claims) {
+  const token = req.headers.authorization?.replace("Bearer ", "");
+  if (!token) {
     return apiError(req, res, {
-      status_code: 403,
+      status_code: 401,
       api_error: {
         type: "not_authenticated",
-        message: "The authentication token is invalid.",
+        message: "The request does not have valid authentication credentials.",
+      },
+    });
+  }
+
+  const claims = await verifySandboxExecToken(token);
+  if (!claims) {
+    return apiError(req, res, {
+      status_code: 401,
+      api_error: {
+        type: "invalid_sandbox_token_error",
+        message: "The sandbox token is invalid or expired.",
       },
     });
   }

--- a/front/pages/api/v1/w/[wId]/sandbox/actions/call.ts
+++ b/front/pages/api/v1/w/[wId]/sandbox/actions/call.ts
@@ -32,13 +32,24 @@ async function handler(
     });
   }
 
-  const claims = await verifySandboxExecToken(req.headers.authorization ?? "");
-  if (!claims) {
+  const token = req.headers.authorization?.replace("Bearer ", "");
+  if (!token) {
     return apiError(req, res, {
-      status_code: 403,
+      status_code: 401,
       api_error: {
         type: "not_authenticated",
-        message: "The authentication token is invalid.",
+        message: "The request does not have valid authentication credentials.",
+      },
+    });
+  }
+
+  const claims = await verifySandboxExecToken(token);
+  if (!claims) {
+    return apiError(req, res, {
+      status_code: 401,
+      api_error: {
+        type: "invalid_sandbox_token_error",
+        message: "The sandbox token is invalid or expired.",
       },
     });
   }


### PR DESCRIPTION
## Description

Two bugs were blocking dsbx tool calls end-to-end:

1. **403 on every `dsbx tools` call.** `POST /api/v1/w/[wId]/sandbox/actions/call` and `GET /api/v1/w/[wId]/sandbox/actions/[aId]` were passing the raw `Authorization` header to `verifySandboxExecToken`. The very first check there is `token.startsWith(SANDBOX_TOKEN_PREFIX)`, which fails because the header still has the `Bearer ` prefix. Strip it the same way the sibling `GET /sandbox/actions` endpoint already does, and align the failure shape (`401 invalid_sandbox_token_error`) with it too.

2. **`failed to parse response` after fixing the 403.** The Rust client declared `#[serde(tag = "status", rename_all = "snake_case")]` on `CallToolPostResponse`, but `rename_all` on an enum only renames variant names — the `action_id` field inside `Pending` stayed snake_case, while the endpoint returns `actionId`. Add `rename_all_fields = "camelCase"` (the same pattern already in use on `ContentBlock` right below it). Covered by a new parse test.

Bumps:
- `dsbx` → `0.1.14`
- `DUST_BASE_IMAGE_VERSION` → `0.8.18`

## Tests

- Added `parse_call_tool_post_response_pending` in `cli/dust-sandbox/src/api/types.rs` — deserializes the exact `{"status":"pending","actionId":"..."}` shape the endpoint returns; passes with the new attribute, would fail without it.
- Updated `front/lib/api/sandbox/image/registry.test.ts` to the new base image tag.
- `cargo check` and `cargo test` both clean in `cli/dust-sandbox`.

End-to-end `dsbx tools ...` call to be re-run from the hive once the new image and CLI are rolled out (requires a freshly-issued sandbox JWT).

## Risk

Low. The auth fix is a strict subset of the working pattern from the GET endpoint right next door. The serde change only widens what the client accepts (was rejecting the only shape the server actually sends).

The image bump rolls the dsbx binary baked into the sandbox image — same operational profile as #25881.

## Deploy Plan

Standard deploy. The new image must be rolled out before any production sandbox can pick up the fixed CLI; until then, agent tool calls from the sandbox keep failing as they do today.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25905">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->