### PR TITLE
Add: ability to pin one frame in a Pod.

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
@@ -59,6 +59,7 @@ export type RichSpaceType = SpaceType & {
   /** Background todo suggestions from project activity (project spaces only). */
   todoGenerationEnabled: boolean;
   lastTodoAnalysisAt: number | null;
+  pinnedFramePath: string | null;
 };
 
 export type GetSpaceResponseBody = {
@@ -193,6 +194,7 @@ app.get(
         archivedAt: meta?.archivedAt?.getTime() ?? null,
         todoGenerationEnabled: meta?.todoGenerationEnabled ?? false,
         lastTodoAnalysisAt: meta?.lastTodoAnalysisAt?.getTime() ?? null,
+        pinnedFramePath: meta?.pinnedFramePath ?? null,
       },
     });
   }

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -1,3 +1,4 @@
+import { validatePinnedFramePath } from "@app/lib/api/projects/pinned_frame";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import {
   launchOrSignalProjectTodoWorkflow,
@@ -78,6 +79,23 @@ app.patch(
 
     const body = ctx.req.valid("json");
 
+    if (body.pinnedFramePath !== undefined) {
+      const validation = await validatePinnedFramePath(
+        auth,
+        space,
+        body.pinnedFramePath
+      );
+      if (validation.isErr()) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: validation.error.message,
+          },
+        });
+      }
+    }
+
     let metadata = await ProjectMetadataResource.fetchBySpace(auth, space);
 
     const priorLastTodoAnalysisAt = metadata?.lastTodoAnalysisAt ?? null;
@@ -94,6 +112,7 @@ app.patch(
         archivedAt: body.archive ? new Date() : null,
         todoGenerationEnabled: body.todoGenerationEnabled ?? false,
         initialTodoAnalysisLookback: body.initialTodoAnalysisLookback ?? null,
+        pinnedFramePath: body.pinnedFramePath ?? null,
       });
       if (!body.archive) {
         void launchOrSignalProjectTodoWorkflow({
@@ -136,6 +155,9 @@ app.patch(
         await metadata.updateInitialTodoAnalysisLookback(
           body.initialTodoAnalysisLookback
         );
+      }
+      if (body.pinnedFramePath !== undefined) {
+        await metadata.updatePinnedFramePath(body.pinnedFramePath);
       }
       if (body.todoGenerationEnabled === true && !priorTodoGenerationEnabled) {
         void launchOrSignalProjectTodoWorkflow({

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -383,7 +383,7 @@ export const VisualizationActionIframe = forwardRef<
       <div
         className={cn(
           "relative w-full overflow-hidden",
-          codeFullyGenerated && !isErrored && "min-h-96",
+          codeFullyGenerated && !isErrored && !isInDrawer && "min-h-96",
           errorMessage && "h-full",
           isInDrawer && "h-full"
         )}
@@ -416,7 +416,10 @@ export const VisualizationActionIframe = forwardRef<
                 >
                   <iframe
                     ref={combinedRef}
-                    className={cn("h-full w-full", !errorMessage && "min-h-96")}
+                    className={cn(
+                      "h-full w-full",
+                      !errorMessage && !isInDrawer && "min-h-96"
+                    )}
                     src={vizUrl}
                     sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
                   />

--- a/front/components/assistant/conversation/space/PodPinnedBanner.tsx
+++ b/front/components/assistant/conversation/space/PodPinnedBanner.tsx
@@ -1,0 +1,264 @@
+import { VisualizationActionIframe } from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
+import { getFrameDisplayTitle } from "@app/components/assistant/conversation/space/frame_display_title";
+import { usePinPodBanner } from "@app/hooks/usePinPodBanner";
+import { useScopedUIPreferences } from "@app/hooks/useScopedUIPreferences";
+import { useAuth } from "@app/lib/auth/AuthContext";
+import { useFileContent } from "@app/lib/swr/files";
+import { useProjectFiles } from "@app/lib/swr/projects";
+import logger from "@app/logger/logger";
+import type { RichSpaceType } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
+import type { WorkspaceType } from "@app/types/user";
+import {
+  Button,
+  cn,
+  FullscreenExitIcon,
+  FullscreenIcon,
+  Spinner,
+  XMarkIcon,
+} from "@dust-tt/sparkle";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+const BANNER_HEIGHT_PX = 280;
+
+const DEFAULT_POD_PINNED_BANNER_PREFERENCES = {
+  collapsed: false,
+} as const;
+
+interface PodPinnedBannerProps {
+  owner: WorkspaceType;
+  spaceInfo: RichSpaceType;
+}
+
+function PodPinnedBannerFrame({
+  owner,
+  spaceId,
+  fileId,
+  fileContent,
+  vizUrl,
+}: {
+  owner: WorkspaceType;
+  spaceId: string;
+  fileId: string;
+  fileContent: string;
+  vizUrl: string;
+}) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  return (
+    <VisualizationActionIframe
+      agentConfigurationId={null}
+      workspaceId={owner.sId}
+      vizUrl={vizUrl}
+      visualization={{
+        code: fileContent,
+        complete: true,
+        identifier: `viz-banner-${fileId}`,
+      }}
+      conversationId={null}
+      spaceId={spaceId}
+      isInDrawer={true}
+      ref={iframeRef}
+    />
+  );
+}
+
+export function PodPinnedBanner({ owner, spaceInfo }: PodPinnedBannerProps) {
+  const { vizUrl } = useAuth();
+  const pinnedFramePath = spaceInfo.pinnedFramePath;
+
+  const { value: bannerPreferences, setValue: setBannerPreferences } =
+    useScopedUIPreferences({
+      scope: "podPinnedBanner",
+      resourceId: spaceInfo.sId,
+      defaultValue: DEFAULT_POD_PINNED_BANNER_PREFERENCES,
+    });
+  const isCollapsed = bannerPreferences.collapsed;
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  const toggleCollapsed = useCallback(() => {
+    setBannerPreferences({
+      collapsed: !bannerPreferences.collapsed,
+    });
+  }, [bannerPreferences.collapsed, setBannerPreferences]);
+
+  const { unpinFrame } = usePinPodBanner({
+    owner,
+    spaceId: spaceInfo.sId,
+    pinnedFramePath: spaceInfo.pinnedFramePath ?? null,
+    isEditor: spaceInfo.isEditor,
+  });
+
+  const { files: projectFiles, isProjectFilesLoading } = useProjectFiles({
+    owner,
+    spaceId: spaceInfo.sId,
+    disabled: !pinnedFramePath,
+  });
+
+  const pinnedFile = useMemo(() => {
+    if (!pinnedFramePath) {
+      return null;
+    }
+    return (
+      projectFiles.find(
+        (f) => !f.isDirectory && f.path === pinnedFramePath && f.fileId
+      ) ?? null
+    );
+  }, [pinnedFramePath, projectFiles]);
+
+  const fileId =
+    pinnedFile && !pinnedFile.isDirectory ? pinnedFile.fileId : null;
+
+  useEffect(() => {
+    if (
+      pinnedFramePath &&
+      !isProjectFilesLoading &&
+      projectFiles.length > 0 &&
+      !fileId
+    ) {
+      logger.warn(
+        { spaceId: spaceInfo.sId, pinnedFramePath },
+        "Pinned Pod banner file not found; skipping render."
+      );
+    }
+  }, [
+    fileId,
+    isProjectFilesLoading,
+    pinnedFramePath,
+    projectFiles.length,
+    spaceInfo.sId,
+  ]);
+
+  const { fileContent } = useFileContent({
+    fileId,
+    owner,
+    config: { disabled: !fileId },
+  });
+
+  useEffect(() => {
+    if (!isFullscreen) {
+      return;
+    }
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setIsFullscreen(false);
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [isFullscreen]);
+
+  if (!pinnedFramePath) {
+    return null;
+  }
+
+  if (isProjectFilesLoading || (fileId && !fileContent)) {
+    return (
+      <div className="mb-4 flex h-16 items-center justify-center rounded-xl bg-muted-background dark:bg-muted-background-night">
+        <Spinner size="sm" />
+      </div>
+    );
+  }
+
+  if (!fileId || !fileContent || !vizUrl) {
+    return null;
+  }
+
+  const fileName =
+    pinnedFile && !pinnedFile.isDirectory
+      ? pinnedFile.fileName
+      : pinnedFramePath;
+  const displayTitle = getFrameDisplayTitle(fileName, fileContent);
+
+  const frameProps = {
+    owner,
+    spaceId: spaceInfo.sId,
+    fileId,
+    fileContent,
+    vizUrl,
+  };
+
+  return (
+    <>
+      <div className="mb-4 overflow-hidden rounded-xl ring-1 ring-border/60 dark:ring-border-night/60">
+        <div className="flex items-center gap-2 border-b border-border/60 bg-muted-background/40 px-3 py-1.5 dark:border-border-night/60 dark:bg-muted-background-night/40">
+          <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground dark:text-foreground-night">
+            {displayTitle}
+          </span>
+          <Button
+            label={isCollapsed ? "Show" : "Hide"}
+            variant="ghost"
+            size="xs"
+            onClick={toggleCollapsed}
+          />
+          {spaceInfo.isEditor && (
+            <Button
+              label="Unpin"
+              variant="ghost"
+              size="xs"
+              onClick={() => void unpinFrame({ displayName: displayTitle })}
+            />
+          )}
+          <Button
+            icon={FullscreenIcon}
+            variant="ghost"
+            size="xs"
+            tooltip="Open in full screen"
+            onClick={() => setIsFullscreen(true)}
+          />
+        </div>
+        {!isCollapsed && (
+          <div
+            className="bg-background dark:bg-background-night"
+            style={{ height: BANNER_HEIGHT_PX }}
+          >
+            <PodPinnedBannerFrame key={`banner-${fileId}`} {...frameProps} />
+          </div>
+        )}
+      </div>
+
+      {isFullscreen &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <div className="fixed inset-0 z-50 flex flex-col bg-background dark:bg-background-night">
+            <div className="flex shrink-0 items-center gap-2 border-b border-border px-4 py-2 dark:border-border-night">
+              <span className="min-w-0 flex-1 truncate heading-lg">
+                {displayTitle}
+              </span>
+              {spaceInfo.isEditor && (
+                <Button
+                  label="Unpin"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => void unpinFrame({ displayName: displayTitle })}
+                />
+              )}
+              <Button
+                icon={FullscreenExitIcon}
+                variant="ghost"
+                size="sm"
+                tooltip="Exit full screen"
+                onClick={() => setIsFullscreen(false)}
+              />
+              <Button
+                icon={XMarkIcon}
+                variant="ghost"
+                size="sm"
+                tooltip="Close"
+                onClick={() => setIsFullscreen(false)}
+              />
+            </div>
+            <div className="min-h-0 flex-1 p-4">
+              <div className={cn("h-full overflow-hidden rounded-xl")}>
+                <PodPinnedBannerFrame
+                  key={`banner-fs-${fileId}`}
+                  {...frameProps}
+                />
+              </div>
+            </div>
+          </div>,
+          document.body
+        )}
+    </>
+  );
+}

--- a/front/components/assistant/conversation/space/ProjectFileExplorer.tsx
+++ b/front/components/assistant/conversation/space/ProjectFileExplorer.tsx
@@ -11,6 +11,7 @@ import type {
   ContentNodeEntry,
   FileEntry,
   FileExplorerEntry,
+  FileExplorerMenuAction,
 } from "@app/components/file_explorer/types";
 import { useFileDownload } from "@app/components/file_explorer/useFileDownload";
 import {
@@ -20,6 +21,7 @@ import {
 import { DropzoneContainer } from "@app/components/misc/DropzoneContainer";
 import SpaceManagedDatasourcesViewsModal from "@app/components/spaces/SpaceManagedDatasourcesViewsModal";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
+import { usePinPodBanner } from "@app/hooks/usePinPodBanner";
 import type { ContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import { isContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import config from "@app/lib/api/config";
@@ -35,15 +37,19 @@ import {
 } from "@app/lib/swr/projects";
 import { useSpaceDataSourceViews, useSpaces } from "@app/lib/swr/spaces";
 import { isManualProjectKnowledgeManagementAllowed } from "@app/lib/workspace_policies";
+import type { RichSpaceType } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
 import type { ConnectorProvider } from "@app/types/data_source";
 import type {
   DataSourceViewSelectionConfigurations,
   DataSourceViewType,
 } from "@app/types/data_source_view";
-import { getSupportedFileExtensions } from "@app/types/files";
-import type { ProjectType } from "@app/types/space";
+import {
+  getSupportedFileExtensions,
+  isInteractiveContentType,
+} from "@app/types/files";
 import type { WorkspaceType } from "@app/types/user";
 import {
+  ActionMapPinIcon,
   Button,
   CloudArrowLeftRightIcon,
   CloudArrowUpIcon,
@@ -204,7 +210,7 @@ function NoCompanyDataDialog({
 
 interface ProjectFileExplorerProps {
   owner: WorkspaceType;
-  space: ProjectType;
+  space: RichSpaceType;
 }
 
 export function ProjectFileExplorer({
@@ -249,6 +255,40 @@ function ProjectFileExplorerContent({
 
   const podMountParentRelativePath = currentFolderPath;
   const isArchived = !!space.archivedAt;
+  const isEditor = space.isEditor;
+  const { togglePin, isPinned } = usePinPodBanner({
+    owner,
+    spaceId: space.sId,
+    pinnedFramePath: space.pinnedFramePath ?? null,
+    isEditor,
+  });
+
+  const getExtraFileMenuItems = useCallback(
+    (entry: FileExplorerEntry): FileExplorerMenuAction[] => {
+      if (
+        !isEditor ||
+        isArchived ||
+        entry.kind !== "file" ||
+        !isInteractiveContentType(entry.contentType)
+      ) {
+        return [];
+      }
+
+      const pinned = isPinned(entry.path);
+      return [
+        {
+          label: pinned ? "Unpin from banner" : "Pin as Pod banner",
+          icon: ActionMapPinIcon,
+          onClick: (e) => {
+            e.stopPropagation();
+            void togglePin(entry.path, { displayName: entry.fileName });
+          },
+        },
+      ];
+    },
+    [isArchived, isEditor, isPinned, togglePin]
+  );
+
   const canManuallyManageProjectKnowledge =
     isManualProjectKnowledgeManagementAllowed(owner);
   const confirm = useContext(ConfirmContext);
@@ -711,6 +751,7 @@ function ProjectFileExplorerContent({
         onMoveFile={!isArchived ? onMoveFile : undefined}
         onRename={!isArchived ? onRename : undefined}
         onOpenInteractive={(entry) => setFrameFileId(entry.fileId)}
+        getExtraFileMenuItems={getExtraFileMenuItems}
         headerActions={addButton}
         isLoading={isLoading}
       />

--- a/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
@@ -1,10 +1,11 @@
 import { ProjectFileExplorer } from "@app/components/assistant/conversation/space/ProjectFileExplorer";
-import type { ProjectType } from "@app/types/space";
+import type { RichSpaceType } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
+
 import type { WorkspaceType } from "@app/types/user";
 
 interface SpaceKnowledgeTabProps {
   owner: WorkspaceType;
-  space: ProjectType;
+  space: RichSpaceType;
 }
 
 export function SpaceKnowledgeTab({ owner, space }: SpaceKnowledgeTabProps) {

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -2,6 +2,7 @@ import { InputBar } from "@app/components/assistant/conversation/input_bar/Input
 import { SpaceConversationListItem } from "@app/components/assistant/conversation/space/conversations/SpaceConversationListItem";
 import { SpaceConversationsActions } from "@app/components/assistant/conversation/space/conversations/SpaceConversationsActions";
 import { SpaceLoadingConversationListItem } from "@app/components/assistant/conversation/space/conversations/SpaceLoadingConversationListItem";
+import { PodPinnedBanner } from "@app/components/assistant/conversation/space/PodPinnedBanner";
 import { getGroupConversationsByDate } from "@app/components/assistant/conversation/utils";
 import { InfiniteScroll } from "@app/components/InfiniteScroll";
 import { DropzoneContainer } from "@app/components/misc/DropzoneContainer";
@@ -208,6 +209,8 @@ export function SpaceConversationsTab({
               />
             )}
           </div>
+
+          <PodPinnedBanner owner={owner} spaceInfo={spaceInfo} />
 
           {/* Suggestions for empty rooms */}
           {isProjectEmpty ? (

--- a/front/components/assistant/conversation/space/frame_display_title.test.ts
+++ b/front/components/assistant/conversation/space/frame_display_title.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { getFrameDisplayTitle } from "./frame_display_title";
+
+describe("getFrameDisplayTitle", () => {
+  it("extracts title from frame metadata", () => {
+    const source = `export const metadata = { title: "Team dashboard" };`;
+    expect(getFrameDisplayTitle("banner.html", source)).toBe("Team dashboard");
+  });
+
+  it("extracts title from heading class", () => {
+    const source = `<p className="heading-2xl font-bold">Hello, World!</p>`;
+    expect(getFrameDisplayTitle("banner.html", source)).toBe("Hello, World!");
+  });
+
+  it("humanizes the file name when no title is found", () => {
+    expect(getFrameDisplayTitle("team_status_board.html")).toBe(
+      "Team Status Board"
+    );
+  });
+});

--- a/front/components/assistant/conversation/space/frame_display_title.ts
+++ b/front/components/assistant/conversation/space/frame_display_title.ts
@@ -1,0 +1,42 @@
+/**
+ * Derive a user-facing title for a frame file.
+ * Prefers an in-frame heading when present, otherwise humanizes the file name.
+ */
+export function getFrameDisplayTitle(
+  fileName: string,
+  frameSource?: string | null
+): string {
+  if (frameSource) {
+    const metadataTitle = frameSource.match(
+      /\btitle\s*:\s*["']([^"']+)["']/
+    )?.[1];
+    if (metadataTitle?.trim()) {
+      return metadataTitle.trim();
+    }
+
+    const headingTagMatch = frameSource.match(
+      /<h[12][^>]*>\s*([^<]+?)\s*<\/h[12]>/i
+    );
+    if (headingTagMatch?.[1]?.trim()) {
+      return headingTagMatch[1].trim();
+    }
+
+    const headingClassMatch = frameSource.match(
+      /className=["'][^"']*heading-(?:2xl|xl|lg)[^"']*["'][^>]*>\s*([^<{]+?)\s*</
+    );
+    if (headingClassMatch?.[1]?.trim()) {
+      return headingClassMatch[1].trim();
+    }
+  }
+
+  return humanizeFrameFileName(fileName);
+}
+
+function humanizeFrameFileName(fileName: string): string {
+  const base = fileName.replace(/\.(html|tsx|jsx)$/i, "");
+  const words = base.replace(/[-_]+/g, " ").trim();
+  if (!words) {
+    return fileName;
+  }
+  return words.replace(/\b\w/g, (char) => char.toUpperCase());
+}

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -84,6 +84,9 @@ interface FileExplorerProps {
   ) => Promise<Result<void, Error>>;
   onOpenInteractive?: (entry: FileEntryWithId) => void;
   onRename?: (entry: FileEntry) => void;
+  getExtraFileMenuItems?: (
+    entry: FileExplorerEntry
+  ) => FileExplorerMenuAction[];
 }
 
 export function FileExplorer({
@@ -104,6 +107,7 @@ export function FileExplorer({
   onMoveFile,
   onOpenInteractive,
   onRename,
+  getExtraFileMenuItems,
 }: FileExplorerProps) {
   const [currentFolderPath, setCurrentFolderPath] = useState("");
   const prevNavigationResetKey = useRef(navigationResetKey);
@@ -167,7 +171,8 @@ export function FileExplorer({
 
   const getMenuItems = useCallback(
     (entry: FileExplorerEntry): FileExplorerMenuAction[] => {
-      const items: FileExplorerMenuAction[] = [];
+      const items: FileExplorerMenuAction[] =
+        getExtraFileMenuItems?.(entry) ?? [];
       if (onRename && entry.kind === "file") {
         items.push({
           label: "Rename",
@@ -207,7 +212,7 @@ export function FileExplorer({
       }
       return items;
     },
-    [onDelete, onMoveFile, onRename, totalFolderCount]
+    [getExtraFileMenuItems, onDelete, onMoveFile, onRename, totalFolderCount]
   );
 
   const handleMoveToFolder = useCallback(
@@ -369,7 +374,9 @@ export function FileExplorer({
             onMoveFileDrop={fileDragEnabled ? handleMoveFileDrop : undefined}
             onNodeOpen={handleNodeOpen}
             getFileMenuItems={
-              onDelete || onRename || onMoveFile ? getMenuItems : undefined
+              onDelete || onRename || onMoveFile || getExtraFileMenuItems
+                ? getMenuItems
+                : undefined
             }
           />
         </div>

--- a/front/hooks/usePinPodBanner.ts
+++ b/front/hooks/usePinPodBanner.ts
@@ -1,0 +1,104 @@
+import { getFrameDisplayTitle } from "@app/components/assistant/conversation/space/frame_display_title";
+import { ConfirmContext } from "@app/components/Confirm";
+import { useUpdateProjectMetadata } from "@app/lib/swr/spaces";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useCallback, useContext } from "react";
+
+type PinPodBannerOptions = {
+  displayName?: string;
+};
+
+export function usePinPodBanner({
+  owner,
+  spaceId,
+  pinnedFramePath,
+  isEditor,
+}: {
+  owner: LightWorkspaceType;
+  spaceId: string;
+  pinnedFramePath: string | null;
+  isEditor: boolean;
+}) {
+  const confirm = useContext(ConfirmContext);
+  const updateProjectMetadata = useUpdateProjectMetadata({
+    owner,
+    spaceId,
+  });
+
+  const pinFrame = useCallback(
+    async (path: string, options?: PinPodBannerOptions) => {
+      if (!isEditor) {
+        return;
+      }
+
+      const label =
+        options?.displayName ??
+        getFrameDisplayTitle(path.split("/").pop() ?? path);
+
+      const confirmed = await confirm({
+        title: "Pin as Pod banner?",
+        message: `"${label}" will appear at the top of this Pod for all members.`,
+        validateLabel: "Pin",
+        validateVariant: "primary",
+      });
+      if (!confirmed) {
+        return;
+      }
+
+      await updateProjectMetadata({ pinnedFramePath: path });
+    },
+    [confirm, isEditor, updateProjectMetadata]
+  );
+
+  const unpinFrame = useCallback(
+    async (options?: PinPodBannerOptions) => {
+      if (!isEditor) {
+        return;
+      }
+
+      const label = options?.displayName
+        ? `"${options.displayName}"`
+        : "The pinned banner";
+
+      const confirmed = await confirm({
+        title: "Unpin Pod banner?",
+        message: `${label} will no longer appear at the top of this Pod.`,
+        validateLabel: "Unpin",
+        validateVariant: "warning",
+      });
+      if (!confirmed) {
+        return;
+      }
+
+      await updateProjectMetadata({ pinnedFramePath: null });
+    },
+    [confirm, isEditor, updateProjectMetadata]
+  );
+
+  const togglePin = useCallback(
+    async (path: string, options?: PinPodBannerOptions) => {
+      if (!isEditor) {
+        return;
+      }
+      if (pinnedFramePath === path) {
+        await unpinFrame(options);
+      } else {
+        await pinFrame(path, options);
+      }
+    },
+    [isEditor, pinFrame, pinnedFramePath, unpinFrame]
+  );
+
+  const isPinned = useCallback(
+    (path: string) => pinnedFramePath === path,
+    [pinnedFramePath]
+  );
+
+  return {
+    pinFrame,
+    unpinFrame,
+    togglePin,
+    isPinned,
+    pinnedFramePath,
+  };
+}

--- a/front/hooks/useScopedUIPreferences.ts
+++ b/front/hooks/useScopedUIPreferences.ts
@@ -12,7 +12,14 @@ const scopedUIPreferencesSchemaByScope = {
       .unknown()
       .transform(normalizeTasksOwnerFilterFromPersistedBlob),
   }),
+  podPinnedBanner: z.object({
+    collapsed: z.boolean().default(false),
+  }),
 } as const;
+
+export type PodPinnedBannerScopedPreferences = z.infer<
+  (typeof scopedUIPreferencesSchemaByScope)["podPinnedBanner"]
+>;
 
 export type ProjectUIScopedPreferences = z.infer<
   (typeof scopedUIPreferencesSchemaByScope)["projectUI"]

--- a/front/lib/api/projects/pinned_frame.ts
+++ b/front/lib/api/projects/pinned_frame.ts
@@ -1,0 +1,45 @@
+import { getGCSPathFromScopedPath } from "@app/lib/api/files/gcs_mount/files";
+import { getProjectFilesBasePath } from "@app/lib/api/files/mount_path";
+import type { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { Err, Ok, type Result } from "@app/types/shared/result";
+
+/**
+ * Validate a pinned frame path for a project space.
+ * Path must be scoped under `project/` and resolve to an existing GCS object.
+ */
+export async function validatePinnedFramePath(
+  auth: Authenticator,
+  space: SpaceResource,
+  pinnedFramePath: string | null
+): Promise<Result<string | null, Error>> {
+  if (pinnedFramePath === null) {
+    return new Ok(null);
+  }
+
+  const owner = auth.getNonNullableWorkspace();
+  const prefix = getProjectFilesBasePath({
+    workspaceId: owner.sId,
+    projectId: space.sId,
+  });
+
+  const gcsPath = getGCSPathFromScopedPath({
+    prefix,
+    scopedPath: pinnedFramePath,
+    useCase: "project",
+  });
+  if (!gcsPath) {
+    return new Err(
+      new Error("Path must start with project/ and be a valid file path.")
+    );
+  }
+
+  const bucket = getPrivateUploadBucket();
+  const contentTypeResult = await bucket.getFileContentType(gcsPath);
+  if (contentTypeResult.isErr()) {
+    return new Err(new Error("Pinned frame file not found."));
+  }
+
+  return new Ok(pinnedFramePath);
+}

--- a/front/lib/resources/project_metadata_resource.test.ts
+++ b/front/lib/resources/project_metadata_resource.test.ts
@@ -115,6 +115,7 @@ describe("ProjectMetadataResource", () => {
       expect(typeof json.createdAt).toBe("number");
       expect(json.todoGenerationEnabled).toBe(false);
       expect(json.lastTodoAnalysisAt).toBeNull();
+      expect(json.pinnedFramePath).toBeNull();
     });
   });
 });

--- a/front/lib/resources/project_metadata_resource.ts
+++ b/front/lib/resources/project_metadata_resource.ts
@@ -156,6 +156,13 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
     await this.update({ initialTodoAnalysisLookback }, transaction);
   }
 
+  async updatePinnedFramePath(
+    pinnedFramePath: string | null,
+    transaction?: Transaction
+  ) {
+    await this.update({ pinnedFramePath }, transaction);
+  }
+
   async delete(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction }
@@ -183,6 +190,7 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
       archivedAt: this.archivedAt?.getTime() ?? null,
       todoGenerationEnabled: this.todoGenerationEnabled,
       lastTodoAnalysisAt: this.lastTodoAnalysisAt?.getTime() ?? null,
+      pinnedFramePath: this.pinnedFramePath ?? null,
     };
   }
 }

--- a/front/lib/resources/storage/models/project_metadata.ts
+++ b/front/lib/resources/storage/models/project_metadata.ts
@@ -16,6 +16,8 @@ export class ProjectMetadataModel extends WorkspaceAwareModel<ProjectMetadataMod
   declare spaceId: ForeignKey<SpaceModel["id"]>;
 
   declare description: string | null;
+  /** Scoped path to a project frame file, e.g. `project/banner.html`. */
+  declare pinnedFramePath: CreationOptional<string | null>;
 }
 
 ProjectMetadataModel.init(
@@ -48,6 +50,10 @@ ProjectMetadataModel.init(
       defaultValue: false,
     },
     initialTodoAnalysisLookback: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    pinnedFramePath: {
       type: DataTypes.STRING,
       allowNull: true,
     },

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -1031,15 +1031,19 @@ export function useUpdateProjectMetadata({
     void mutateSpaceInfoRegardlessOfQueryParams();
 
     const title =
-      updates.archive !== undefined
-        ? updates.archive
-          ? "Pod archived"
-          : "Pod unarchived"
-        : updates.todoGenerationEnabled !== undefined
-          ? updates.todoGenerationEnabled
-            ? "Automatic task suggestions turned on"
-            : "Automatic task suggestions turned off"
-          : "Pod updated";
+      updates.pinnedFramePath !== undefined
+        ? updates.pinnedFramePath
+          ? "Frame pinned as Pod banner"
+          : "Banner unpinned"
+        : updates.archive !== undefined
+          ? updates.archive
+            ? "Pod archived"
+            : "Pod unarchived"
+          : updates.todoGenerationEnabled !== undefined
+            ? updates.todoGenerationEnabled
+              ? "Automatic task suggestions turned on"
+              : "Automatic task suggestions turned off"
+            : "Pod updated";
 
     sendNotification({
       type: "success",

--- a/front/migrations/db/migration_647.sql
+++ b/front/migrations/db/migration_647.sql
@@ -1,0 +1,3 @@
+-- Migration created on May 20, 2026
+ALTER TABLE "public"."project_metadata"
+ADD COLUMN "pinnedFramePath" VARCHAR(255);

--- a/front/pages/api/swagger_private_schemas.ts
+++ b/front/pages/api/swagger_private_schemas.ts
@@ -874,6 +874,10 @@
  *               type: integer
  *               nullable: true
  *               description: Unix timestamp (ms) of the last automatic todo suggestion scan, if any.
+ *             pinnedFramePath:
+ *               type: string
+ *               nullable: true
+ *               description: Scoped path to the frame file pinned as the Pod banner (e.g. project/banner.html).
  *     PrivateDataSourceView:
  *       type: object
  *       description: A view on a data source within a space.

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -192,12 +192,43 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_metadata", () => {
       createdAt: expect.anything(),
       description: "Test project description",
       lastTodoAnalysisAt: null,
+      pinnedFramePath: null,
       sId: expect.anything(),
       spaceId: space.sId,
       todoGenerationEnabled: false,
       updatedAt: expect.anything(),
       members: [],
     });
+  });
+
+  it("should return pinnedFramePath when set", async () => {
+    const { req, res, workspace } = await createPublicApiMockRequest({
+      systemKey: true,
+      method: "GET",
+    });
+
+    const space = await SpaceFactory.project(workspace);
+
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
+    const adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    await ProjectMetadataResource.makeNew(adminAuth, space, {
+      description: "Pod with banner",
+      pinnedFramePath: "project/banner.html",
+    });
+
+    req.query.spaceId = space.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData().metadata.pinnedFramePath).toBe(
+      "project/banner.html"
+    );
   });
 
   it("should return project metadata with members", async () => {
@@ -248,6 +279,7 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_metadata", () => {
       createdAt: expect.anything(),
       description: "Test project with members",
       lastTodoAnalysisAt: null,
+      pinnedFramePath: null,
       sId: expect.anything(),
       spaceId: space.sId,
       todoGenerationEnabled: false,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
@@ -82,6 +82,10 @@
  *                           type: integer
  *                           nullable: true
  *                           description: Unix timestamp (ms) of the last automatic todo suggestion scan, if any.
+ *                         pinnedFramePath:
+ *                           type: string
+ *                           nullable: true
+ *                           description: Scoped path to the frame file pinned as the Pod banner.
  *       401:
  *         description: Unauthorized
  *   patch:
@@ -224,6 +228,7 @@ export type RichSpaceType = SpaceType & {
   /** Background todo suggestions from project activity (project spaces only). */
   todoGenerationEnabled: boolean;
   lastTodoAnalysisAt: number | null;
+  pinnedFramePath: string | null;
 };
 export type GetSpaceResponseBody = {
   space: RichSpaceType;
@@ -354,6 +359,7 @@ async function handler(
             projectMetadata?.todoGenerationEnabled ?? false,
           lastTodoAnalysisAt:
             projectMetadata?.lastTodoAnalysisAt?.getTime() ?? null,
+          pinnedFramePath: projectMetadata?.pinnedFramePath ?? null,
         },
       });
     }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -1,6 +1,7 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { validatePinnedFramePath } from "@app/lib/api/projects/pinned_frame";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
@@ -80,6 +81,23 @@ async function handler(
 
       const body = bodyValidation.data;
 
+      if (body.pinnedFramePath !== undefined) {
+        const validation = await validatePinnedFramePath(
+          auth,
+          space,
+          body.pinnedFramePath
+        );
+        if (validation.isErr()) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: validation.error.message,
+            },
+          });
+        }
+      }
+
       let metadata = await ProjectMetadataResource.fetchBySpace(auth, space);
 
       const priorLastTodoAnalysisAt = metadata?.lastTodoAnalysisAt ?? null;
@@ -97,6 +115,7 @@ async function handler(
           archivedAt: body.archive ? new Date() : null,
           todoGenerationEnabled: body.todoGenerationEnabled ?? false,
           initialTodoAnalysisLookback: body.initialTodoAnalysisLookback ?? null,
+          pinnedFramePath: body.pinnedFramePath ?? null,
         });
         if (!body.archive) {
           void launchOrSignalProjectTodoWorkflow({
@@ -143,6 +162,9 @@ async function handler(
           await metadata.updateInitialTodoAnalysisLookback(
             body.initialTodoAnalysisLookback
           );
+        }
+        if (body.pinnedFramePath !== undefined) {
+          await metadata.updatePinnedFramePath(body.pinnedFramePath);
         }
         if (
           body.todoGenerationEnabled === true &&

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -9168,6 +9168,11 @@
                               "type": "integer",
                               "nullable": true,
                               "description": "Unix timestamp (ms) of the last automatic todo suggestion scan, if any."
+                            },
+                            "pinnedFramePath": {
+                              "type": "string",
+                              "nullable": true,
+                              "description": "Scoped path to the frame file pinned as the Pod banner."
                             }
                           }
                         }
@@ -11190,6 +11195,11 @@
                 "type": "integer",
                 "nullable": true,
                 "description": "Unix timestamp (ms) of the last automatic todo suggestion scan, if any."
+              },
+              "pinnedFramePath": {
+                "type": "string",
+                "nullable": true,
+                "description": "Scoped path to the frame file pinned as the Pod banner (e.g. project/banner.html)."
               }
             }
           }

--- a/front/types/api/internal/spaces.ts
+++ b/front/types/api/internal/spaces.ts
@@ -38,6 +38,7 @@ export const PatchProjectMetadataBodySchema = z.object({
   archive: z.boolean().optional(),
   todoGenerationEnabled: z.boolean().optional(),
   initialTodoAnalysisLookback: z.enum(["now", "last_24h", "max"]).optional(),
+  pinnedFramePath: z.string().nullable().optional(),
 });
 
 export type PatchProjectMetadataBodyType = z.infer<

--- a/front/types/project_metadata.ts
+++ b/front/types/project_metadata.ts
@@ -7,4 +7,5 @@ export interface ProjectMetadataType {
   archivedAt: number | null;
   todoGenerationEnabled: boolean;
   lastTodoAnalysisAt: number | null;
+  pinnedFramePath: string | null;
 }

--- a/front/types/space.ts
+++ b/front/types/space.ts
@@ -34,6 +34,7 @@ export type ProjectType = SpaceType & {
   description: string | null;
   isMember: boolean;
   archivedAt: number | null;
+  pinnedFramePath?: string | null;
 };
 
 export type ProjectListItemType = ProjectType & {


### PR DESCRIPTION
## Description

Adds the ability to pin one Frame file as a persistent banner at the top of a Pod's conversations tab. Pod editors can right-click any interactive file in the file explorer to "Pin as Pod banner"; the banner then renders the frame via `VisualizationActionIframe` with collapse/expand and fullscreen controls. Unpinning is available from both the banner header and the fullscreen overlay. The pinned path is stored in `pinnedFramePath` on the `project_metadata` table, exposed on the space API, and validated server-side via `validatePinnedFramePath`.

Also fixes `VisualizationActionIframe` incorrectly applying `min-h-96` when rendered inside a drawer/banner — height is now parent-controlled when `isInDrawer=true`.

<img width="971" height="780" alt="image" src="https://github.com/user-attachments/assets/76e295c4-0d69-4790-8ccf-cd3976bef846" />

## Tests

- Added unit tests for `getFrameDisplayTitle` (metadata title, heading tag, heading class, filename humanization).
- Tested pin/unpin flow manually in a local Pod with a Frame file.

## Risk

Low. The DB migration is additive (`ADD COLUMN pinnedFramePath VARCHAR(255)` — nullable, no default required). The banner only renders when `pinnedFramePath` is set; existing Pods are unaffected. `VisualizationActionIframe` change is guarded by the existing `isInDrawer` prop. Rollback is safe — removing the column is straightforward and the frontend degrades gracefully to `null`.

## Deploy Plan

1. Run migration `migration_647.sql` (`ALTER TABLE project_metadata ADD COLUMN "pinnedFramePath" VARCHAR(255)`).
2. Deploy `front-api`.
3. Deploy `front`.
