### PR TITLE
[slim-api]: Migrate poke search workspaces

### DIFF
--- a/front-api/esbuild.server.ts
+++ b/front-api/esbuild.server.ts
@@ -1,5 +1,41 @@
 import esbuild from "esbuild";
 
+// ESM-only packages that Node 22 cannot correctly `require()` at runtime
+// (it wraps the default export in `{ default: ... }`, breaking the
+// library's internal validation). Bundle these via esbuild instead of
+// externalizing them, so CJS/ESM interop is resolved at build time.
+//
+// Add new entries here as we discover them during migration.
+const ESM_ONLY_PACKAGES = ["libphonenumber-js"];
+
+// Externalize every node_modules import (`bare specifier`, i.e. doesn't
+// start with `.` or `/`) by default, except for the packages above which
+// esbuild bundles inline. This replaces the broader `packages: "external"`
+// option which had no way to opt specific packages back into bundling.
+const bundleEsmPlugin: esbuild.Plugin = {
+  name: "bundle-esm-packages",
+  setup(build) {
+    build.onResolve({ filter: /^[^./]/ }, (args) => {
+      // Path aliases (`@app/*`, `@front-api/*`) point at source code we want
+      // to bundle, not at node_modules. Skip them so esbuild's alias
+      // resolution applies and the resolved path gets bundled normally.
+      if (
+        args.path.startsWith("@app/") ||
+        args.path.startsWith("@front-api/")
+      ) {
+        return;
+      }
+      const pkg = args.path.startsWith("@")
+        ? args.path.split("/").slice(0, 2).join("/")
+        : args.path.split("/")[0];
+      if (ESM_ONLY_PACKAGES.includes(pkg)) {
+        return;
+      }
+      return { external: true };
+    });
+  },
+};
+
 async function buildServer() {
   try {
     console.log("Building front-api server with esbuild...");
@@ -13,7 +49,7 @@ async function buildServer() {
       alias: {
         "@app": "../front",
       },
-      packages: "external",
+      plugins: [bundleEsmPlugin],
       logLevel: "info",
       metafile: true,
     });

--- a/front-api/routes/poke/index.ts
+++ b/front-api/routes/poke/index.ts
@@ -10,6 +10,7 @@ import globalAgentFeedbacks from "./global-agent-feedbacks";
 import kill from "./kill";
 import plans from "./plans";
 import region from "./region";
+import search from "./search";
 import templates from "./templates";
 import workspaces from "./workspaces";
 
@@ -28,6 +29,7 @@ app.route("/global-agent-feedbacks", globalAgentFeedbacks);
 app.route("/kill", kill);
 app.route("/plans", plans);
 app.route("/region", region);
+app.route("/search", search);
 app.route("/templates", templates);
 app.route("/workspaces", workspaces);
 

--- a/front-api/routes/poke/search.test.ts
+++ b/front-api/routes/poke/search.test.ts
@@ -1,0 +1,157 @@
+import { WorkspaceVerificationAttemptResource } from "@app/lib/resources/workspace_verification_attempt_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it, vi } from "vitest";
+
+// The poke search also queries the Connectors API (for connector ID lookups).
+// Mock it to return a dummy URL so it doesn't throw on missing env var.
+vi.mock("@app/lib/api/config", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@app/lib/api/config")>();
+  return {
+    ...mod,
+    default: {
+      ...mod.default,
+      getConnectorsAPIConfig: vi.fn().mockReturnValue({
+        url: "http://localhost:0",
+        secret: "test",
+        webhookSecret: "test",
+      }),
+      getPokeAppUrl: vi.fn().mockReturnValue("http://localhost:3000/poke"),
+    },
+  };
+});
+
+function searchRequest(query: string) {
+  return honoApp.request(
+    `/api/poke/search?search=${encodeURIComponent(query)}`
+  );
+}
+
+describe("GET /api/poke/search - phone number", () => {
+  it("returns workspace when searching by phone number in E.164 format", async () => {
+    const { auth } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const phoneNumber = "+33612345678";
+    const phoneHash =
+      WorkspaceVerificationAttemptResource.hashPhoneNumber(phoneNumber);
+
+    await WorkspaceVerificationAttemptResource.makeVerified(auth, {
+      phoneNumberHash: phoneHash,
+    });
+
+    const response = await searchRequest(phoneNumber);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: expect.stringContaining("(phone trial)"),
+          type: "Workspace",
+        }),
+      ])
+    );
+  });
+
+  it("returns workspace when searching by phone number without +", async () => {
+    const { auth } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const phoneNumber = "+33612345678";
+    const phoneHash =
+      WorkspaceVerificationAttemptResource.hashPhoneNumber(phoneNumber);
+
+    await WorkspaceVerificationAttemptResource.makeVerified(auth, {
+      phoneNumberHash: phoneHash,
+    });
+
+    // Search with digits only (no "+").
+    const response = await searchRequest("33612345678");
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: expect.stringContaining("(phone trial)"),
+          type: "Workspace",
+        }),
+      ])
+    );
+  });
+
+  it("returns no results for unverified phone numbers", async () => {
+    const { auth } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const phoneNumber = "+33611111111";
+    const phoneHash =
+      WorkspaceVerificationAttemptResource.hashPhoneNumber(phoneNumber);
+
+    // Create an unverified attempt.
+    await WorkspaceVerificationAttemptResource.makeNew(auth, {
+      phoneNumberHash: phoneHash,
+      twilioVerificationSid: "VEtest123",
+    });
+
+    const response = await searchRequest(phoneNumber);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    const phoneResults = data.results.filter(
+      (r: { name: string }) =>
+        typeof r.name === "string" && r.name.includes("(phone trial)")
+    );
+    expect(phoneResults).toHaveLength(0);
+  });
+
+  it("returns both workspace and phone trial when digits match both", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    // Use a phone number whose digits (without +) equal the workspace model ID.
+    // Both the workspace-by-ID and the phone-trial search should return results.
+    const phoneNumber = "+33612345678";
+    const phoneHash =
+      WorkspaceVerificationAttemptResource.hashPhoneNumber(phoneNumber);
+
+    await WorkspaceVerificationAttemptResource.makeVerified(auth, {
+      phoneNumberHash: phoneHash,
+    });
+
+    // Search with the workspace's own model ID — should still return the
+    // workspace.
+    const response = await searchRequest(String(workspace.id));
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    // The workspace should appear via the workspace-by-ID search.
+    expect(data.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "Workspace",
+          id: workspace.id,
+        }),
+      ])
+    );
+  });
+
+  it("returns no results for random non-phone strings", async () => {
+    await createPrivateApiMockRequest({ isSuperUser: true });
+
+    const response = await searchRequest("hello world");
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.results).toEqual([]);
+  });
+});

--- a/front-api/routes/poke/search.ts
+++ b/front-api/routes/poke/search.ts
@@ -1,0 +1,32 @@
+import { searchPokeResources } from "@app/lib/poke/search";
+import type { PokeItemBase } from "@app/types/poke";
+import { isString } from "@app/types/shared/utils/general";
+import type { HandlerResult } from "@front-api/middleware/utils";
+import { apiError } from "@front-api/middleware/utils";
+import { Hono } from "hono";
+
+export type GetPokeSearchItemsResponseBody = {
+  results: PokeItemBase[];
+};
+
+// Mounted at /api/poke/search. pokeAuth is applied by the parent poke sub-app.
+const app = new Hono();
+
+app.get("/", async (ctx): HandlerResult<GetPokeSearchItemsResponseBody> => {
+  const auth = ctx.get("auth");
+  const search = ctx.req.query("search");
+  if (!isString(search)) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "The search query parameter is required.",
+      },
+    });
+  }
+
+  const results = await searchPokeResources(auth, search);
+  return ctx.json({ results });
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/index.test.ts
+++ b/front-api/routes/poke/workspaces/index.test.ts
@@ -1,0 +1,64 @@
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+async function createNamedWorkspace(name: string) {
+  const workspace = await WorkspaceFactory.basic();
+  const resource = await WorkspaceResource.fetchById(workspace.sId);
+  if (!resource) {
+    throw new Error("Workspace not found after creation");
+  }
+  await WorkspaceResource.updateName(resource.id, name);
+  return workspace;
+}
+
+function searchWorkspaces(search: string, limit: string) {
+  const params = new URLSearchParams({
+    search: encodeURIComponent(search),
+    limit,
+  });
+  return honoApp.request(`/api/poke/workspaces?${params.toString()}`);
+}
+
+describe("GET /api/poke/workspaces — workspace name search", () => {
+  it("matches by prefix", async () => {
+    const workspace = await createNamedWorkspace("Zorbix Industries");
+    await createPrivateApiMockRequest({ isSuperUser: true, workspace });
+
+    const response = await searchWorkspaces("Zorbix", "20");
+
+    expect(response.status).toBe(200);
+    const { workspaces } = await response.json();
+    expect(
+      workspaces.some((w: { sId: string }) => w.sId === workspace.sId)
+    ).toBe(true);
+  });
+
+  it("matches by a word in the middle of the name", async () => {
+    const workspace = await createNamedWorkspace("Zorbix Industries");
+    await createPrivateApiMockRequest({ isSuperUser: true, workspace });
+
+    const response = await searchWorkspaces("Industries", "20");
+
+    expect(response.status).toBe(200);
+    const { workspaces } = await response.json();
+    expect(
+      workspaces.some((w: { sId: string }) => w.sId === workspace.sId)
+    ).toBe(true);
+  });
+
+  it("matches case-insensitively", async () => {
+    const workspace = await createNamedWorkspace("Zorbix Industries");
+    await createPrivateApiMockRequest({ isSuperUser: true, workspace });
+
+    const response = await searchWorkspaces("industries", "20");
+
+    expect(response.status).toBe(200);
+    const { workspaces } = await response.json();
+    expect(
+      workspaces.some((w: { sId: string }) => w.sId === workspace.sId)
+    ).toBe(true);
+  });
+});

--- a/front-api/routes/poke/workspaces/index.ts
+++ b/front-api/routes/poke/workspaces/index.ts
@@ -1,11 +1,242 @@
+import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
+import { FREE_NO_PLAN_DATA } from "@app/lib/plans/free_plans";
+import { getPlanCodeSortPriority } from "@app/lib/plans/plan_codes";
+import { renderSubscriptionFromModels } from "@app/lib/plans/renderers";
+import { tryParsePhoneNumber } from "@app/lib/plans/trial/phone";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { WorkspaceVerificationAttemptResource } from "@app/lib/resources/workspace_verification_attempt_resource";
+import { isDomain, isEmailValid } from "@app/lib/utils";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import logger from "@app/logger/logger";
+import type { SubscriptionType } from "@app/types/plan";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { HandlerResult } from "@front-api/middleware/utils";
+import { apiError } from "@front-api/middleware/utils";
 import { Hono } from "hono";
+import type { FindOptions, Order, WhereOptions } from "sequelize";
+import { Op } from "sequelize";
 
 import wId from "./[wId]";
 
+export type PokeWorkspaceType = LightWorkspaceType & {
+  createdAt: string;
+  subscription: SubscriptionType;
+  membersCount: number;
+};
+
+export type GetPokeWorkspacesResponseBody = {
+  workspaces: PokeWorkspaceType[];
+};
+
 // Note: the parent poke/index.ts already applies pokeAuth (super-user gate).
-// This sub-router adds workspace resolution on top via pokeWorkspaceAuth on
-// the [wId] sub-app.
+// This sub-router handles the workspace LIST endpoint (GET /) and mounts the
+// per-workspace [wId] sub-app (which adds workspace resolution on top via
+// pokeWorkspaceAuth).
 const app = new Hono();
+
+app.get("/", async (ctx): HandlerResult<GetPokeWorkspacesResponseBody> => {
+  const auth = ctx.get("auth");
+  const upgradedQuery = ctx.req.query("upgraded");
+  const searchQuery = ctx.req.query("search");
+  const limitQuery = ctx.req.query("limit");
+
+  let listUpgraded: boolean | undefined;
+  if (upgradedQuery !== undefined) {
+    if (!["true", "false"].includes(upgradedQuery)) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "The request query is invalid, expects { upgraded: boolean }.",
+        },
+      });
+    }
+    listUpgraded = upgradedQuery === "true";
+  }
+
+  let originalLimit = 0;
+  let limit = 0;
+  if (limitQuery !== undefined) {
+    if (!/^\d+$/.test(limitQuery)) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "The request query is invalid, expects { limit: number }.",
+        },
+      });
+    }
+    originalLimit = parseInt(limitQuery, 10);
+    limit = originalLimit;
+  }
+
+  const searchTerm = searchQuery
+    ? decodeURIComponent(searchQuery).trim()
+    : undefined;
+
+  const order: Order = [["createdAt", "DESC"]];
+  const conditions: WhereOptions<WorkspaceModel>[] = [];
+
+  if (listUpgraded !== undefined) {
+    const subscriptions =
+      await SubscriptionResource.internalListAllActiveNoFreeTestPlan();
+    const workspaceIds = subscriptions.map((s) => s.workspaceId);
+    if (listUpgraded) {
+      conditions.push({ id: { [Op.in]: workspaceIds } });
+    } else {
+      conditions.push({ id: { [Op.notIn]: workspaceIds } });
+    }
+  }
+
+  if (searchTerm) {
+    // Search by Stripe subscription ID (exact match).
+    let isSearchByStripeSubscription = false;
+    if (searchTerm.startsWith("sub_")) {
+      const subscription =
+        await SubscriptionResource.fetchByStripeId(searchTerm);
+      if (subscription) {
+        isSearchByStripeSubscription = true;
+        conditions.push({ id: subscription.workspaceId });
+      }
+    }
+
+    let isSearchByEmail = false;
+    if (isEmailValid(searchTerm)) {
+      // We can have 2 users with the same email if a Google user and a Github
+      // user have the same email.
+      const users = await UserResource.listByEmail(searchTerm);
+      if (users.length) {
+        const { memberships, total } =
+          await MembershipResource.getLatestMemberships({ users });
+        if (total > 0) {
+          conditions.push({
+            id: { [Op.in]: memberships.map((m) => m.workspaceId) },
+          });
+          isSearchByEmail = true;
+        }
+      }
+    }
+
+    let isSearchByDomain = false;
+    if (isDomain(searchTerm)) {
+      const workspace = await WorkspaceResource.fetchByDomain(searchTerm);
+      if (workspace) {
+        isSearchByDomain = true;
+        conditions.push({ id: workspace.id });
+      }
+    }
+
+    let isSearchByPhone = false;
+    // Phone-number search is one of several axes (sId / Stripe sub / email /
+    // domain / phone). Production is fine (front-api's esbuild config bundles
+    // `libphonenumber-js` inline), but the front-api dev runtime (tsx) can
+    // still hit the CJS metadata interop issue. Degrade gracefully so the
+    // other axes keep working in dev.
+    try {
+      const e164PhoneNumber = tryParsePhoneNumber(searchTerm);
+      if (e164PhoneNumber) {
+        const workspaceModelId =
+          await WorkspaceVerificationAttemptResource.findWorkspaceModelIdFromPhoneNumber(
+            e164PhoneNumber
+          );
+        if (workspaceModelId) {
+          isSearchByPhone = true;
+          conditions.push({ id: workspaceModelId });
+        }
+      }
+    } catch (err) {
+      logger.warn(
+        { err: normalizeError(err) },
+        "Phone number parsing unavailable; skipping phone-search axis"
+      );
+    }
+
+    if (
+      !isSearchByEmail &&
+      !isSearchByDomain &&
+      !isSearchByStripeSubscription &&
+      !isSearchByPhone
+    ) {
+      conditions.push({
+        [Op.or]: [
+          { sId: { [Op.iLike]: `%${searchTerm}%` } },
+          { name: { [Op.iLike]: `%${searchTerm}%` } },
+        ],
+      });
+    }
+
+    // In case of search, we increase the limit for the sql query to 100
+    // because we'll sort manually (until a better solution is found).
+    // Note from seb: I tried ordering directly in the query but I stumbled
+    // into sequelize behaviors that I don't understand.
+    limit = 100;
+  }
+
+  const where: FindOptions<WorkspaceModel>["where"] = conditions.length
+    ? { [Op.and]: conditions }
+    : {};
+
+  const workspaces = await WorkspaceModel.findAll({
+    where,
+    limit,
+    include: [
+      {
+        model: SubscriptionModel,
+        as: "subscriptions",
+        where: { status: "active" },
+        required: false,
+        include: [{ model: PlanModel, as: "plan" }],
+      },
+    ],
+    order,
+  });
+
+  // If limit was bumped above originalLimit, sort by plan priority
+  // (enterprise first, then pro, then free / old-free) and trim back.
+  let displayed = workspaces;
+  if (limit > originalLimit) {
+    const sorted = [...workspaces].sort((a, b) => {
+      const planAPriority = getPlanCodeSortPriority(
+        a.subscriptions?.[0]?.plan?.code || ""
+      );
+      const planBPriority = getPlanCodeSortPriority(
+        b.subscriptions?.[0]?.plan?.code || ""
+      );
+      return planAPriority - planBPriority;
+    });
+    displayed = sorted.slice(0, originalLimit);
+  }
+
+  const lightWorkspaces = displayed.map((workspace) =>
+    renderLightWorkspaceType({ workspace, role: "admin" })
+  );
+  const membersCountByWorkspaceId =
+    await MembershipResource.getMembersCountsForWorkspaces(auth, {
+      workspaces: lightWorkspaces,
+      activeOnly: true,
+    });
+
+  return ctx.json({
+    workspaces: displayed.map((workspace) => ({
+      ...renderLightWorkspaceType({ workspace, role: "admin" }),
+      createdAt: workspace.createdAt.toISOString(),
+      subscription: renderSubscriptionFromModels({
+        plan: workspace.subscriptions[0]
+          ? workspace.subscriptions[0].plan
+          : // If there is no active subscription, we use the free plan data.
+            FREE_NO_PLAN_DATA,
+        activeSubscription: workspace.subscriptions[0],
+      }),
+      membersCount: membersCountByWorkspaceId[workspace.sId] ?? 0,
+    })),
+  });
+});
 
 app.route("/:wId", wId);
 

--- a/front/lib/plans/plan_codes.ts
+++ b/front/lib/plans/plan_codes.ts
@@ -55,6 +55,29 @@ export const isFreeTrialPhonePlan = (planCode: string) =>
 export const isOldFreePlan = (planCode: string) =>
   planCode === FREE_TEST_PLAN_CODE;
 
+// Sort priority for plan-code buckets. Lower number sorts first.
+// Used by the poke workspaces list to surface enterprise / pro tenants
+// ahead of free / old-free ones when the result set is over the requested
+// limit.
+export const getPlanCodeSortPriority = (planCode: string): number => {
+  if (isEntreprisePlanPrefix(planCode)) {
+    return 1;
+  }
+  if (isFriendsAndFamilyPlan(planCode)) {
+    return 2;
+  }
+  if (isProPlanPrefix(planCode)) {
+    return 3;
+  }
+  if (isFreePlan(planCode)) {
+    return 4;
+  }
+  if (isOldFreePlan(planCode)) {
+    return 5;
+  }
+  return 6;
+};
+
 export function isProPlan(plan?: PlanType) {
   return (
     plan?.code === PRO_PLAN_SEAT_29_CODE ||

--- a/front/lib/poke/search.ts
+++ b/front/lib/poke/search.ts
@@ -193,10 +193,12 @@ async function searchByPhoneNumber(
 ): Promise<PokeItemBase[]> {
   let e164PhoneNumber: string | null;
   try {
-    // `tryParsePhoneNumber` loads `libphonenumber-js`, whose CJS metadata
-    // `require()` breaks under the front-api dev runtime (tsx wraps the JSON
-    // in `{ default }`). Degrade gracefully — phone search is one of several
-    // search axes, and most search terms aren't phone numbers anyway.
+    // `tryParsePhoneNumber` loads `libphonenumber-js`. Production is fine
+    // (front-api's esbuild config bundles it inline; see `ESM_ONLY_PACKAGES`
+    // in front-api/esbuild.server.ts), but the front-api dev runtime (tsx)
+    // can still hit the CJS metadata interop issue. Degrade gracefully so
+    // the other search axes work in dev — most search terms aren't phone
+    // numbers anyway.
     e164PhoneNumber = tryParsePhoneNumber(searchTerm);
   } catch (err) {
     logger.warn(

--- a/front/lib/poke/search.ts
+++ b/front/lib/poke/search.ts
@@ -21,6 +21,7 @@ import logger from "@app/logger/logger";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import type { ConnectorType } from "@app/types/data_source";
 import type { PokeItemBase } from "@app/types/poke";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
 import { validate as validateUuid } from "uuid";
 
@@ -190,14 +191,27 @@ async function searchPokeFrames(searchTerm: string): Promise<PokeItemBase[]> {
 async function searchByPhoneNumber(
   searchTerm: string
 ): Promise<PokeItemBase[]> {
-  const e164 = tryParsePhoneNumber(searchTerm);
-  if (!e164) {
+  let e164PhoneNumber: string | null;
+  try {
+    // `tryParsePhoneNumber` loads `libphonenumber-js`, whose CJS metadata
+    // `require()` breaks under the front-api dev runtime (tsx wraps the JSON
+    // in `{ default }`). Degrade gracefully — phone search is one of several
+    // search axes, and most search terms aren't phone numbers anyway.
+    e164PhoneNumber = tryParsePhoneNumber(searchTerm);
+  } catch (err) {
+    logger.warn(
+      { err: normalizeError(err) },
+      "Phone number parsing unavailable; skipping phone-search axis"
+    );
+    return [];
+  }
+  if (!e164PhoneNumber) {
     return [];
   }
 
   const workspaceModelId =
     await WorkspaceVerificationAttemptResource.findWorkspaceModelIdFromPhoneNumber(
-      e164
+      e164PhoneNumber
     );
   if (!workspaceModelId) {
     return [];

--- a/front/pages/api/poke/search.ts
+++ b/front/pages/api/poke/search.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -1,16 +1,11 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
 import { FREE_NO_PLAN_DATA } from "@app/lib/plans/free_plans";
-import {
-  isEntreprisePlanPrefix,
-  isFreePlan,
-  isFriendsAndFamilyPlan,
-  isOldFreePlan,
-  isProPlanPrefix,
-} from "@app/lib/plans/plan_codes";
+import { getPlanCodeSortPriority } from "@app/lib/plans/plan_codes";
 import { renderSubscriptionFromModels } from "@app/lib/plans/renderers";
 import { tryParsePhoneNumber } from "@app/lib/plans/trial/phone";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
@@ -37,30 +32,6 @@ export type PokeWorkspaceType = LightWorkspaceType & {
 
 export type GetPokeWorkspacesResponseBody = {
   workspaces: PokeWorkspaceType[];
-};
-
-const getPlanPriority = (planCode: string) => {
-  if (isEntreprisePlanPrefix(planCode)) {
-    return 1;
-  }
-
-  if (isFriendsAndFamilyPlan(planCode)) {
-    return 2;
-  }
-
-  if (isProPlanPrefix(planCode)) {
-    return 3;
-  }
-
-  if (isFreePlan(planCode)) {
-    return 4;
-  }
-
-  if (isOldFreePlan(planCode)) {
-    return 5;
-  }
-
-  return 6;
 };
 
 async function handler(
@@ -205,11 +176,11 @@ async function handler(
         }
 
         let isSearchByPhone = false;
-        const e164 = tryParsePhoneNumber(searchTerm);
-        if (e164) {
+        const e164PhoneNumber = tryParsePhoneNumber(searchTerm);
+        if (e164PhoneNumber) {
           const workspaceModelId =
             await WorkspaceVerificationAttemptResource.findWorkspaceModelIdFromPhoneNumber(
-              e164
+              e164PhoneNumber
             );
           if (workspaceModelId) {
             isSearchByPhone = true;
@@ -279,10 +250,10 @@ async function handler(
         workspaces.sort((a, b) => {
           // Note: TypeScript may incorrectly assume that `subscriptions` is always defined.
           // Using optional chaining and default values to handle potential undefined cases.
-          const planAPriority = getPlanPriority(
+          const planAPriority = getPlanCodeSortPriority(
             a.subscriptions?.[0]?.plan?.code || ""
           );
-          const planBPriority = getPlanPriority(
+          const planBPriority = getPlanCodeSortPriority(
             b.subscriptions?.[0]?.plan?.code || ""
           );
 


### PR DESCRIPTION
## Description
Finishes the poke root-route Hono migration (#25804) by porting the two routes held back due to a libphonenumber-js interop bug: GET /api/poke/search and GET /api/poke/workspaces. Also fixes the underlying issue in front-api's esbuild config.

Notable details
ESM/CJS interop fix ([front-api/esbuild.server.ts](vscode-webview://0nl7k2h9k64vs77jjdi34dkr8mkmg3qol5ijn3am87hpacr0tmk8/front-api/esbuild.server.ts)): replaced packages: "external" with a plugin that externalizes node_modules by default but bundles an allowlist of ESM-only packages inline. libphonenumber-js is the only entry today. Bundle size grows ~0.8 MB → ~6.9 MB.

Dev mitigation kept: tsx doesn't bundle, so dev still hits the issue. The existing try/catch around tryParsePhoneNumber stays in place; comments updated to clarify it's now dev-only.

Workspaces list endpoint is added to the existing workspaces/ sub-app that origin/main set up for the [wId] children — same file, app.get("/", ...) alongside app.route("/:wId", wId).
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Smoke test search workspaces
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Should be low - but we probably want to rip this logic out once we remove next entirely.
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
None needed
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25907">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->