### PR TITLE
[slim-api]: Migrate poke batch 2

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/assistants/[aId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/assistants/[aId]/index.ts
@@ -1,0 +1,9 @@
+import { Hono } from "hono";
+
+import suggestions from "./suggestions";
+
+const app = new Hono();
+
+app.route("/suggestions", suggestions);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/assistants/[aId]/suggestions.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/assistants/[aId]/suggestions.test.ts
@@ -1,0 +1,117 @@
+import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { AgentSuggestionFactory } from "@app/tests/utils/AgentSuggestionFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function listSuggestions(workspace: { sId: string }, aId: string) {
+  return honoApp.request(
+    `/api/poke/workspaces/${workspace.sId}/assistants/${aId}/suggestions`
+  );
+}
+
+function deleteSuggestion(
+  workspace: { sId: string },
+  aId: string,
+  query: Record<string, string> = {}
+) {
+  const search = new URLSearchParams(query).toString();
+  return honoApp.request(
+    `/api/poke/workspaces/${workspace.sId}/assistants/${aId}/suggestions${
+      search ? `?${search}` : ""
+    }`,
+    { method: "DELETE" }
+  );
+}
+
+describe("GET /api/poke/workspaces/:wId/assistants/:aId/suggestions", () => {
+  it("returns 401 for non super users", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      isSuperUser: false,
+      role: "admin",
+    });
+
+    const response = await listSuggestions(workspace, "some-agent-id");
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns suggestions for a given agent", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      method: "GET",
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    await AgentSuggestionFactory.createInstructions(auth, agent);
+
+    const response = await listSuggestions(workspace, agent.sId);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.suggestions).toHaveLength(1);
+    expect(data.suggestions[0].kind).toBe("instructions");
+  });
+});
+
+describe("DELETE /api/poke/workspaces/:wId/assistants/:aId/suggestions", () => {
+  it("returns 400 when sId query param is missing", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const response = await deleteSuggestion(workspace, "some-agent-id");
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 404 when suggestion does not exist", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const response = await deleteSuggestion(workspace, "some-agent-id", {
+      sId: "non-existent-suggestion-id",
+    });
+
+    expect(response.status).toBe(404);
+    const data = await response.json();
+    expect(data.error.type).toBe("agent_configuration_not_found");
+  });
+
+  it("deletes the suggestion and returns 204", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const suggestion = await AgentSuggestionFactory.createInstructions(
+      auth,
+      agent
+    );
+
+    const response = await deleteSuggestion(workspace, agent.sId, {
+      sId: suggestion.sId,
+    });
+
+    expect(response.status).toBe(204);
+
+    // Verify the suggestion is actually deleted.
+    const deleted = await AgentSuggestionResource.fetchById(
+      auth,
+      suggestion.sId
+    );
+    expect(deleted).toBeNull();
+  });
+});

--- a/front-api/routes/poke/workspaces/[wId]/assistants/[aId]/suggestions.ts
+++ b/front-api/routes/poke/workspaces/[wId]/assistants/[aId]/suggestions.ts
@@ -1,0 +1,69 @@
+import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
+import type { AgentSuggestionType } from "@app/types/suggestions/agent_suggestion";
+import { apiError, type HandlerResult } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+import { Hono } from "hono";
+import { z } from "zod";
+
+export type PokeListSuggestions = {
+  suggestions: AgentSuggestionType[];
+};
+
+const DeleteSuggestionQuerySchema = z.object({
+  sId: z.string(),
+});
+
+// Mounted at /api/poke/workspaces/:wId/assistants/:aId/suggestions.
+const app = new Hono();
+
+app.get("/", async (ctx): HandlerResult<PokeListSuggestions> => {
+  const auth = ctx.get("auth");
+  const aId = ctx.req.param("aId");
+  if (!aId) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid agent ID.",
+      },
+    });
+  }
+
+  const suggestions = await AgentSuggestionResource.listByAgentConfigurationId(
+    auth,
+    aId
+  );
+
+  return ctx.json({ suggestions: suggestions.map((s) => s.toJSON()) });
+});
+
+app.delete("/", validate("query", DeleteSuggestionQuerySchema), async (ctx) => {
+  const auth = ctx.get("auth");
+  const { sId } = ctx.req.valid("query");
+
+  const suggestion = await AgentSuggestionResource.fetchById(auth, sId);
+  if (!suggestion) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: {
+        type: "agent_configuration_not_found",
+        message: "The suggestion was not found.",
+      },
+    });
+  }
+
+  const deleteResult = await suggestion.delete(auth);
+  if (deleteResult.isErr()) {
+    return apiError(ctx, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "Failed to delete suggestion.",
+      },
+    });
+  }
+
+  return ctx.body(null, 204);
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/assistants/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/assistants/index.ts
@@ -1,0 +1,9 @@
+import { Hono } from "hono";
+
+import aId from "./[aId]";
+
+const app = new Hono();
+
+app.route("/:aId", aId);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/data_source_views/[dsvId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_source_views/[dsvId]/details.ts
@@ -1,0 +1,46 @@
+import { dataSourceViewToPokeJSON } from "@app/lib/poke/utils";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import type { PokeDataSourceViewType } from "@app/types/poke";
+import { apiError, type HandlerResult } from "@front-api/middleware/utils";
+import { Hono } from "hono";
+
+export type PokeGetDataSourceViewDetails = {
+  dataSourceView: PokeDataSourceViewType;
+};
+
+// Mounted at /api/poke/workspaces/:wId/data_source_views/:dsvId/details.
+const app = new Hono();
+
+app.get("/", async (ctx): HandlerResult<PokeGetDataSourceViewDetails> => {
+  const auth = ctx.get("auth");
+  const dsvId = ctx.req.param("dsvId");
+  if (!dsvId) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid data source view ID.",
+      },
+    });
+  }
+
+  const dataSourceView = await DataSourceViewResource.fetchById(auth, dsvId, {
+    includeEditedBy: true,
+  });
+
+  if (!dataSourceView) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_view_not_found",
+        message: "Data source view not found.",
+      },
+    });
+  }
+
+  const dataSourceViewJSON = await dataSourceViewToPokeJSON(dataSourceView);
+
+  return ctx.json({ dataSourceView: dataSourceViewJSON });
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/data_source_views/[dsvId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_source_views/[dsvId]/index.ts
@@ -1,0 +1,9 @@
+import { Hono } from "hono";
+
+import details from "./details";
+
+const app = new Hono();
+
+app.route("/details", details);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/data_source_views/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_source_views/index.ts
@@ -1,6 +1,4 @@
-import { getDataSourceViewUsage } from "@app/lib/api/agent_data_sources";
-import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { listDataSourceViewsWithUsage } from "@app/lib/api/data_source_view";
 import type { AgentsUsageType } from "@app/types/data_source";
 import type { DataSourceViewType } from "@app/types/data_source_view";
 import type { HandlerResult } from "@front-api/middleware/utils";
@@ -22,24 +20,7 @@ const app = new Hono();
 app.get("/", async (ctx): HandlerResult<PokeListDataSourceViews> => {
   const auth = ctx.get("auth");
 
-  const dataSourceViews = await DataSourceViewResource.listByWorkspace(auth, {
-    includeEditedBy: true,
-  });
-
-  const dataSourceViewsWithUsage = await concurrentExecutor(
-    dataSourceViews,
-    async (dsv) => {
-      const usageResult = await getDataSourceViewUsage({
-        auth,
-        dataSourceView: dsv,
-      });
-      return {
-        ...dsv.toJSON(),
-        usage: usageResult.isOk() ? usageResult.value : null,
-      };
-    },
-    { concurrency: 4 }
-  );
+  const dataSourceViewsWithUsage = await listDataSourceViewsWithUsage(auth);
 
   return ctx.json({ data_source_views: dataSourceViewsWithUsage });
 });

--- a/front-api/routes/poke/workspaces/[wId]/data_source_views/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_source_views/index.ts
@@ -1,0 +1,49 @@
+import { getDataSourceViewUsage } from "@app/lib/api/agent_data_sources";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { AgentsUsageType } from "@app/types/data_source";
+import type { DataSourceViewType } from "@app/types/data_source_view";
+import type { HandlerResult } from "@front-api/middleware/utils";
+import { Hono } from "hono";
+
+import dsvId from "./[dsvId]";
+
+export type DataSourceViewWithUsage = DataSourceViewType & {
+  usage: AgentsUsageType | null;
+};
+
+export type PokeListDataSourceViews = {
+  data_source_views: DataSourceViewWithUsage[];
+};
+
+// Mounted at /api/poke/workspaces/:wId/data_source_views.
+const app = new Hono();
+
+app.get("/", async (ctx): HandlerResult<PokeListDataSourceViews> => {
+  const auth = ctx.get("auth");
+
+  const dataSourceViews = await DataSourceViewResource.listByWorkspace(auth, {
+    includeEditedBy: true,
+  });
+
+  const dataSourceViewsWithUsage = await concurrentExecutor(
+    dataSourceViews,
+    async (dsv) => {
+      const usageResult = await getDataSourceViewUsage({
+        auth,
+        dataSourceView: dsv,
+      });
+      return {
+        ...dsv.toJSON(),
+        usage: usageResult.isOk() ? usageResult.value : null,
+      };
+    },
+    { concurrency: 4 }
+  );
+
+  return ctx.json({ data_source_views: dataSourceViewsWithUsage });
+});
+
+app.route("/:dsvId", dsvId);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/files/[sId].ts
+++ b/front-api/routes/poke/workspaces/[wId]/files/[sId].ts
@@ -1,0 +1,62 @@
+import { FileResource } from "@app/lib/resources/file_resource";
+import type { FileTypeWithMetadata } from "@app/types/files";
+import { apiError, type HandlerResult } from "@front-api/middleware/utils";
+import { Hono } from "hono";
+
+export interface GetPokeFileResponseBody {
+  content: string;
+  file: FileTypeWithMetadata;
+}
+
+// Mounted at /api/poke/workspaces/:wId/files/:sId.
+const app = new Hono();
+
+app.get("/", async (ctx): HandlerResult<GetPokeFileResponseBody> => {
+  const auth = ctx.get("auth");
+  const sId = ctx.req.param("sId");
+  if (!sId) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "The sId parameter is required.",
+      },
+    });
+  }
+
+  const file = await FileResource.fetchById(auth, sId);
+  if (!file) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: {
+        type: "file_not_found",
+        message: "File not found.",
+      },
+    });
+  }
+
+  // Only allow access to interactive content files (frames).
+  if (!file.isInteractiveContent) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Only interactive content files can be viewed.",
+      },
+    });
+  }
+
+  const readStream = file.getReadStream({ auth, version: "original" });
+  const chunks: Buffer[] = [];
+  for await (const chunk of readStream) {
+    chunks.push(chunk);
+  }
+  const content = Buffer.concat(chunks).toString("utf-8");
+
+  return ctx.json({
+    file: file.toJSONWithMetadata(auth),
+    content,
+  });
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/files/[sId].ts
+++ b/front-api/routes/poke/workspaces/[wId]/files/[sId].ts
@@ -1,5 +1,6 @@
-import { FileResource } from "@app/lib/resources/file_resource";
+import { readInteractiveContentFile } from "@app/lib/api/files/read";
 import type { FileTypeWithMetadata } from "@app/types/files";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { apiError, type HandlerResult } from "@front-api/middleware/utils";
 import { Hono } from "hono";
 
@@ -24,39 +25,32 @@ app.get("/", async (ctx): HandlerResult<GetPokeFileResponseBody> => {
     });
   }
 
-  const file = await FileResource.fetchById(auth, sId);
-  if (!file) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "file_not_found",
-        message: "File not found.",
-      },
-    });
+  const result = await readInteractiveContentFile(auth, sId);
+  if (result.isErr()) {
+    const err = result.error;
+    switch (err) {
+      case "file_not_found":
+        return apiError(ctx, {
+          status_code: 404,
+          api_error: {
+            type: "file_not_found",
+            message: "File not found.",
+          },
+        });
+      case "not_interactive_content":
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Only interactive content files can be viewed.",
+          },
+        });
+      default:
+        return assertNever(err);
+    }
   }
 
-  // Only allow access to interactive content files (frames).
-  if (!file.isInteractiveContent) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Only interactive content files can be viewed.",
-      },
-    });
-  }
-
-  const readStream = file.getReadStream({ auth, version: "original" });
-  const chunks: Buffer[] = [];
-  for await (const chunk of readStream) {
-    chunks.push(chunk);
-  }
-  const content = Buffer.concat(chunks).toString("utf-8");
-
-  return ctx.json({
-    file: file.toJSONWithMetadata(auth),
-    content,
-  });
+  return ctx.json(result.value);
 });
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/files/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/files/index.ts
@@ -1,0 +1,9 @@
+import { Hono } from "hono";
+
+import sId from "./[sId]";
+
+const app = new Hono();
+
+app.route("/:sId", sId);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/groups/[groupId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/groups/[groupId]/details.ts
@@ -1,4 +1,4 @@
-import { getMembers } from "@app/lib/api/workspace";
+import { getGroupMembersWithWorkspaces } from "@app/lib/api/workspace";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import type { GroupType } from "@app/types/groups";
 import type { UserTypeWithWorkspaces } from "@app/types/user";
@@ -38,19 +38,10 @@ app.get("/", async (ctx): HandlerResult<PokeGetGroupDetails> => {
   }
 
   const group = groupRes.value;
-
-  const groupMembers = await group.getActiveMembers(auth);
-  const memberships = await getMembers(auth);
-
-  const memberById = new Map(memberships.members.map((m) => [m.sId, m]));
-
-  const userWithWorkspaces = groupMembers.flatMap((user) => {
-    const member = memberById.get(user.sId);
-    return member ? [member] : [];
-  });
+  const members = await getGroupMembersWithWorkspaces(auth, group);
 
   return ctx.json({
-    members: userWithWorkspaces,
+    members,
     group: group.toJSON(),
   });
 });

--- a/front-api/routes/poke/workspaces/[wId]/groups/[groupId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/groups/[groupId]/details.ts
@@ -1,0 +1,58 @@
+import { getMembers } from "@app/lib/api/workspace";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import type { GroupType } from "@app/types/groups";
+import type { UserTypeWithWorkspaces } from "@app/types/user";
+import { apiError, type HandlerResult } from "@front-api/middleware/utils";
+import { Hono } from "hono";
+
+export type PokeGetGroupDetails = {
+  members: UserTypeWithWorkspaces[];
+  group: GroupType;
+};
+
+// Mounted at /api/poke/workspaces/:wId/groups/:groupId/details.
+const app = new Hono();
+
+app.get("/", async (ctx): HandlerResult<PokeGetGroupDetails> => {
+  const auth = ctx.get("auth");
+  const groupId = ctx.req.param("groupId");
+  if (!groupId) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid group ID.",
+      },
+    });
+  }
+
+  const groupRes = await GroupResource.fetchById(auth, groupId);
+  if (groupRes.isErr()) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: {
+        type: "group_not_found",
+        message: "Group not found.",
+      },
+    });
+  }
+
+  const group = groupRes.value;
+
+  const groupMembers = await group.getActiveMembers(auth);
+  const memberships = await getMembers(auth);
+
+  const memberById = new Map(memberships.members.map((m) => [m.sId, m]));
+
+  const userWithWorkspaces = groupMembers.flatMap((user) => {
+    const member = memberById.get(user.sId);
+    return member ? [member] : [];
+  });
+
+  return ctx.json({
+    members: userWithWorkspaces,
+    group: group.toJSON(),
+  });
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/groups/[groupId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/groups/[groupId]/index.ts
@@ -1,0 +1,9 @@
+import { Hono } from "hono";
+
+import details from "./details";
+
+const app = new Hono();
+
+app.route("/details", details);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/groups/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/groups/index.ts
@@ -1,0 +1,27 @@
+import { GroupResource } from "@app/lib/resources/group_resource";
+import type { GroupType } from "@app/types/groups";
+import type { HandlerResult } from "@front-api/middleware/utils";
+import { Hono } from "hono";
+
+import groupId from "./[groupId]";
+
+export type PokeListGroups = {
+  groups: GroupType[];
+};
+
+// Mounted at /api/poke/workspaces/:wId/groups.
+const app = new Hono();
+
+app.get("/", async (ctx): HandlerResult<PokeListGroups> => {
+  const auth = ctx.get("auth");
+
+  const groups = await GroupResource.listAllWorkspaceGroups(auth, {
+    groupKinds: ["global", "regular", "space_editors", "provisioned"],
+  });
+
+  return ctx.json({ groups: groups.map((g) => g.toJSON()) });
+});
+
+app.route("/:groupId", groupId);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/index.ts
@@ -2,10 +2,19 @@ import { pokeWorkspaceAuth } from "@front-api/middleware/poke_workspace_auth";
 import { Hono } from "hono";
 
 import apps from "./apps";
+import assistants from "./assistants";
+import dataSourceViews from "./data_source_views";
+import files from "./files";
+import groups from "./groups";
+import llmTraces from "./llm-traces";
+import mcp from "./mcp";
+import mcpServerViews from "./mcp_server_views";
+import observability from "./observability";
 import projects from "./projects";
 import skillSuggestions from "./skill_suggestions";
 import skills from "./skills";
 import triggers from "./triggers";
+import webhookSources from "./webhook_sources";
 
 // Mounted at /api/poke/workspaces/:wId. Every route below inherits
 // pokeWorkspaceAuth, which resolves the super-user Authenticator for the
@@ -15,9 +24,18 @@ const app = new Hono();
 app.use("*", pokeWorkspaceAuth);
 
 app.route("/apps", apps);
+app.route("/assistants", assistants);
+app.route("/data_source_views", dataSourceViews);
+app.route("/files", files);
+app.route("/groups", groups);
+app.route("/llm-traces", llmTraces);
+app.route("/mcp", mcp);
+app.route("/mcp_server_views", mcpServerViews);
+app.route("/observability", observability);
 app.route("/projects", projects);
 app.route("/skill_suggestions", skillSuggestions);
 app.route("/skills", skills);
 app.route("/triggers", triggers);
+app.route("/webhook_sources", webhookSources);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/llm-traces/[runId].ts
+++ b/front-api/routes/poke/workspaces/[wId]/llm-traces/[runId].ts
@@ -1,0 +1,41 @@
+import { fetchLLMTrace, isLLMTraceId } from "@app/lib/api/llm/traces/buffer";
+import { apiError, type HandlerResult } from "@front-api/middleware/utils";
+import { Hono } from "hono";
+
+interface GetLLMTraceResponseBody {
+  trace: unknown | null;
+}
+
+// Mounted at /api/poke/workspaces/:wId/llm-traces/:runId.
+const app = new Hono();
+
+app.get("/", async (ctx): HandlerResult<GetLLMTraceResponseBody> => {
+  const auth = ctx.get("auth");
+  const runId = ctx.req.param("runId");
+  if (!runId) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "The runId parameter is required.",
+      },
+    });
+  }
+
+  // Validate that this is actually an LLM runId.
+  if (!isLLMTraceId(runId)) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "RunId does not have the expected LLM prefix.",
+      },
+    });
+  }
+
+  const trace = await fetchLLMTrace(auth, { runId });
+
+  return ctx.json({ trace });
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/llm-traces/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/llm-traces/index.ts
@@ -1,0 +1,9 @@
+import { Hono } from "hono";
+
+import runId from "./[runId]";
+
+const app = new Hono();
+
+app.route("/:runId", runId);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/mcp/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/mcp/index.ts
@@ -1,0 +1,9 @@
+import { Hono } from "hono";
+
+import views from "./views";
+
+const app = new Hono();
+
+app.route("/views", views);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/mcp/views/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/mcp/views/index.ts
@@ -1,0 +1,44 @@
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { HandlerResult } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+import { Hono } from "hono";
+import { z } from "zod";
+
+export type PokeListMCPServerViews = {
+  serverViews: MCPServerViewType[];
+};
+
+const QuerySchema = z.object({
+  globalSpaceOnly: z.enum(["true", "false"]).optional(),
+});
+
+// Mounted at /api/poke/workspaces/:wId/mcp/views.
+const app = new Hono();
+
+app.get(
+  "/",
+  validate("query", QuerySchema),
+  async (ctx): HandlerResult<PokeListMCPServerViews> => {
+    const auth = ctx.get("auth");
+    const { globalSpaceOnly } = ctx.req.valid("query");
+
+    let mcpServerViews: MCPServerViewResource[];
+    if (globalSpaceOnly === "true") {
+      const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
+      mcpServerViews = await MCPServerViewResource.listBySpace(
+        auth,
+        globalSpace
+      );
+    } else {
+      mcpServerViews = await MCPServerViewResource.listByWorkspace(auth);
+    }
+
+    return ctx.json({
+      serverViews: mcpServerViews.map((sv) => sv.toJSON()),
+    });
+  }
+);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/mcp_server_views/[svId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/mcp_server_views/[svId]/details.ts
@@ -1,0 +1,43 @@
+import { mcpServerViewToPokeJSON } from "@app/lib/poke/utils";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import type { PokeMCPServerViewType } from "@app/types/poke";
+import { apiError, type HandlerResult } from "@front-api/middleware/utils";
+import { Hono } from "hono";
+
+export type PokeGetMCPServerViewDetails = {
+  mcpServerView: PokeMCPServerViewType;
+};
+
+// Mounted at /api/poke/workspaces/:wId/mcp_server_views/:svId/details.
+const app = new Hono();
+
+app.get("/", async (ctx): HandlerResult<PokeGetMCPServerViewDetails> => {
+  const auth = ctx.get("auth");
+  const svId = ctx.req.param("svId");
+  if (!svId) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid MCP server view ID.",
+      },
+    });
+  }
+
+  const mcpServerView = await MCPServerViewResource.fetchById(auth, svId);
+  if (!mcpServerView) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: {
+        type: "mcp_server_view_not_found",
+        message: "MCP server view not found.",
+      },
+    });
+  }
+
+  const mcpServerViewJSON = await mcpServerViewToPokeJSON(mcpServerView, auth);
+
+  return ctx.json({ mcpServerView: mcpServerViewJSON });
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/mcp_server_views/[svId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/mcp_server_views/[svId]/index.ts
@@ -1,0 +1,9 @@
+import { Hono } from "hono";
+
+import details from "./details";
+
+const app = new Hono();
+
+app.route("/details", details);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/mcp_server_views/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/mcp_server_views/index.ts
@@ -1,0 +1,9 @@
+import { Hono } from "hono";
+
+import svId from "./[svId]";
+
+const app = new Hono();
+
+app.route("/:svId", svId);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/observability/datasource-retrieval.ts
+++ b/front-api/routes/poke/workspaces/[wId]/observability/datasource-retrieval.ts
@@ -1,0 +1,51 @@
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import {
+  fetchWorkspaceDatasourceRetrievalMetrics,
+  type WorkspaceDatasourceRetrievalData,
+} from "@app/lib/api/assistant/observability/datasource_retrieval";
+import { apiError, type HandlerResult } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+import { Hono } from "hono";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+export type PokeGetWorkspaceDatasourceRetrievalResponse = {
+  datasources: WorkspaceDatasourceRetrievalData[];
+  total: number;
+};
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+});
+
+// Mounted at /api/poke/workspaces/:wId/observability/datasource-retrieval.
+const app = new Hono();
+
+app.get(
+  "/",
+  validate("query", QuerySchema),
+  async (ctx): HandlerResult<PokeGetWorkspaceDatasourceRetrievalResponse> => {
+    const auth = ctx.get("auth");
+    const { days } = ctx.req.valid("query");
+
+    const datasourceRetrievalResult =
+      await fetchWorkspaceDatasourceRetrievalMetrics(auth, { days });
+
+    if (datasourceRetrievalResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve workspace datasource retrieval metrics: ${fromError(datasourceRetrievalResult.error).toString()}`,
+        },
+      });
+    }
+
+    const datasources = datasourceRetrievalResult.value;
+    const total = datasources.reduce((sum, ds) => sum + ds.count, 0);
+
+    return ctx.json({ datasources, total });
+  }
+);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/observability/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/observability/index.ts
@@ -1,0 +1,9 @@
+import { Hono } from "hono";
+
+import datasourceRetrieval from "./datasource-retrieval";
+
+const app = new Hono();
+
+app.route("/datasource-retrieval", datasourceRetrieval);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/webhook_sources/[wsId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/webhook_sources/[wsId]/details.ts
@@ -1,0 +1,91 @@
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
+import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
+import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
+import type { TriggerType } from "@app/types/assistant/triggers";
+import { removeNulls } from "@app/types/shared/utils/general";
+import type {
+  WebhookSourceForAdminType,
+  WebhookSourceViewForAdminType,
+} from "@app/types/triggers/webhooks";
+import type { UserType } from "@app/types/user";
+import { apiError, type HandlerResult } from "@front-api/middleware/utils";
+import { Hono } from "hono";
+
+export type PokeGetWebhookSourceDetails = {
+  webhookSource: WebhookSourceForAdminType;
+  views: WebhookSourceViewForAdminType[];
+  triggers: Array<TriggerType & { editorUser: UserType | null }>;
+  requestStats: { last24h: number; last7d: number; last30d: number };
+};
+
+// Mounted at /api/poke/workspaces/:wId/webhook_sources/:wsId/details.
+const app = new Hono();
+
+app.get("/", async (ctx): HandlerResult<PokeGetWebhookSourceDetails> => {
+  const auth = ctx.get("auth");
+  const wsId = ctx.req.param("wsId");
+  if (!wsId) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid webhook source ID.",
+      },
+    });
+  }
+
+  const source = await WebhookSourceResource.fetchById(auth, wsId);
+  if (!source) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: {
+        type: "webhook_source_not_found",
+        message: "Webhook source not found.",
+      },
+    });
+  }
+
+  const views = await WebhookSourcesViewResource.listByWebhookSource(
+    auth,
+    source.id
+  );
+
+  // Collect all triggers from all views
+  const allTriggers: TriggerType[] = [];
+  for (const view of views) {
+    const triggers = await TriggerResource.listByWebhookSourceViewId(
+      auth,
+      view.id
+    );
+    for (const t of triggers) {
+      allTriggers.push(t.toJSON());
+    }
+  }
+
+  // Batch-fetch editor users
+  const editorIds = removeNulls(allTriggers.map((t) => t.editor));
+  const editorUsers =
+    editorIds.length > 0 ? await UserResource.fetchByModelIds(editorIds) : [];
+  const editorUserMap = new Map(editorUsers.map((u) => [u.id, u.toJSON()]));
+
+  const triggersWithEditors = allTriggers.map((t) => ({
+    ...t,
+    editorUser: editorUserMap.get(t.editor) ?? null,
+  }));
+
+  const requestStats = await WebhookRequestResource.countBySourceInPeriods(
+    auth,
+    source.id
+  );
+
+  return ctx.json({
+    webhookSource: source.toJSONForAdmin(),
+    views: views.map((v) => v.toJSONForAdmin()),
+    triggers: triggersWithEditors,
+    requestStats,
+  });
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/webhook_sources/[wsId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/webhook_sources/[wsId]/details.ts
@@ -1,10 +1,6 @@
-import { TriggerResource } from "@app/lib/resources/trigger_resource";
-import { UserResource } from "@app/lib/resources/user_resource";
-import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
+import { getWebhookSourceAdminDetails } from "@app/lib/api/webhook_source";
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
-import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import type { TriggerType } from "@app/types/assistant/triggers";
-import { removeNulls } from "@app/types/shared/utils/general";
 import type {
   WebhookSourceForAdminType,
   WebhookSourceViewForAdminType,
@@ -47,45 +43,9 @@ app.get("/", async (ctx): HandlerResult<PokeGetWebhookSourceDetails> => {
     });
   }
 
-  const views = await WebhookSourcesViewResource.listByWebhookSource(
-    auth,
-    source.id
-  );
+  const details = await getWebhookSourceAdminDetails(auth, source);
 
-  // Collect all triggers from all views
-  const allTriggers: TriggerType[] = [];
-  for (const view of views) {
-    const triggers = await TriggerResource.listByWebhookSourceViewId(
-      auth,
-      view.id
-    );
-    for (const t of triggers) {
-      allTriggers.push(t.toJSON());
-    }
-  }
-
-  // Batch-fetch editor users
-  const editorIds = removeNulls(allTriggers.map((t) => t.editor));
-  const editorUsers =
-    editorIds.length > 0 ? await UserResource.fetchByModelIds(editorIds) : [];
-  const editorUserMap = new Map(editorUsers.map((u) => [u.id, u.toJSON()]));
-
-  const triggersWithEditors = allTriggers.map((t) => ({
-    ...t,
-    editorUser: editorUserMap.get(t.editor) ?? null,
-  }));
-
-  const requestStats = await WebhookRequestResource.countBySourceInPeriods(
-    auth,
-    source.id
-  );
-
-  return ctx.json({
-    webhookSource: source.toJSONForAdmin(),
-    views: views.map((v) => v.toJSONForAdmin()),
-    triggers: triggersWithEditors,
-    requestStats,
-  });
+  return ctx.json(details);
 });
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/webhook_sources/[wsId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/webhook_sources/[wsId]/index.ts
@@ -1,0 +1,9 @@
+import { Hono } from "hono";
+
+import details from "./details";
+
+const app = new Hono();
+
+app.route("/details", details);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/webhook_sources/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/webhook_sources/index.ts
@@ -1,0 +1,51 @@
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
+import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
+import type { WebhookSourceType } from "@app/types/triggers/webhooks";
+import type { HandlerResult } from "@front-api/middleware/utils";
+import { Hono } from "hono";
+
+import wsId from "./[wsId]";
+
+export type PokeListWebhookSources = {
+  webhookSources: Array<
+    WebhookSourceType & { viewCount: number; triggerCount: number }
+  >;
+};
+
+// Mounted at /api/poke/workspaces/:wId/webhook_sources.
+const app = new Hono();
+
+app.get("/", async (ctx): HandlerResult<PokeListWebhookSources> => {
+  const auth = ctx.get("auth");
+
+  const sources = await WebhookSourceResource.listByWorkspace(auth);
+  const results: PokeListWebhookSources["webhookSources"] = [];
+
+  for (const source of sources) {
+    const views = await WebhookSourcesViewResource.listByWebhookSource(
+      auth,
+      source.id
+    );
+    let triggerCount = 0;
+    for (const view of views) {
+      const triggers = await TriggerResource.listByWebhookSourceViewId(
+        auth,
+        view.id
+      );
+      triggerCount += triggers.length;
+    }
+
+    results.push({
+      ...source.toJSON(),
+      viewCount: views.length,
+      triggerCount,
+    });
+  }
+
+  return ctx.json({ webhookSources: results });
+});
+
+app.route("/:wsId", wsId);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/webhook_sources/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/webhook_sources/index.ts
@@ -1,6 +1,4 @@
-import { TriggerResource } from "@app/lib/resources/trigger_resource";
-import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
-import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
+import { listWebhookSourcesWithCounts } from "@app/lib/api/webhook_source";
 import type { WebhookSourceType } from "@app/types/triggers/webhooks";
 import type { HandlerResult } from "@front-api/middleware/utils";
 import { Hono } from "hono";
@@ -19,31 +17,9 @@ const app = new Hono();
 app.get("/", async (ctx): HandlerResult<PokeListWebhookSources> => {
   const auth = ctx.get("auth");
 
-  const sources = await WebhookSourceResource.listByWorkspace(auth);
-  const results: PokeListWebhookSources["webhookSources"] = [];
+  const webhookSources = await listWebhookSourcesWithCounts(auth);
 
-  for (const source of sources) {
-    const views = await WebhookSourcesViewResource.listByWebhookSource(
-      auth,
-      source.id
-    );
-    let triggerCount = 0;
-    for (const view of views) {
-      const triggers = await TriggerResource.listByWebhookSourceViewId(
-        auth,
-        view.id
-      );
-      triggerCount += triggers.length;
-    }
-
-    results.push({
-      ...source.toJSON(),
-      viewCount: views.length,
-      triggerCount,
-    });
-  }
-
-  return ctx.json({ webhookSources: results });
+  return ctx.json({ webhookSources });
 });
 
 app.route("/:wsId", wsId);

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -1,3 +1,4 @@
+import { getDataSourceViewUsage } from "@app/lib/api/agent_data_sources";
 import config from "@app/lib/api/config";
 import {
   FOLDERS_TO_HIDE_IF_EMPTY_MIME_TYPES,
@@ -10,12 +11,14 @@ import type {
 import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { PatchDataSourceViewType } from "@app/types/api/public/spaces";
 import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
 import type { CoreAPIContentNode } from "@app/types/core/content_node";
 import type { CoreAPIDatasourceViewFilter } from "@app/types/core/core_api";
 import { CoreAPI } from "@app/types/core/core_api";
+import type { AgentsUsageType } from "@app/types/data_source";
 import type {
   DataSourceViewContentNode,
   DataSourceViewType,
@@ -327,4 +330,36 @@ export async function handlePatchDataSourceView(
   await dataSourceView.setEditedBy(auth);
 
   return new Ok(dataSourceView);
+}
+
+export type DataSourceViewWithUsage = DataSourceViewType & {
+  usage: AgentsUsageType | null;
+};
+
+/**
+ * Every data source view in the workspace, each enriched with its agent
+ * usage. Usage fetches run concurrently with bounded parallelism. Used by
+ * the poke admin UI.
+ */
+export async function listDataSourceViewsWithUsage(
+  auth: Authenticator
+): Promise<DataSourceViewWithUsage[]> {
+  const dataSourceViews = await DataSourceViewResource.listByWorkspace(auth, {
+    includeEditedBy: true,
+  });
+
+  return concurrentExecutor(
+    dataSourceViews,
+    async (dsv) => {
+      const usageResult = await getDataSourceViewUsage({
+        auth,
+        dataSourceView: dsv,
+      });
+      return {
+        ...dsv.toJSON(),
+        usage: usageResult.isOk() ? usageResult.value : null,
+      };
+    },
+    { concurrency: 4 }
+  );
 }

--- a/front/lib/api/files/read.ts
+++ b/front/lib/api/files/read.ts
@@ -1,0 +1,43 @@
+import type { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import type { FileTypeWithMetadata } from "@app/types/files";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export type ReadInteractiveContentFileError =
+  | "file_not_found"
+  | "not_interactive_content";
+
+export type InteractiveContentFile = {
+  file: FileTypeWithMetadata;
+  content: string;
+};
+
+/**
+ * Fetches an interactive-content file (a frame) by sId and returns its
+ * serialized metadata together with the original file contents as a UTF-8
+ * string. Returns a domain error when the file does not exist or is not an
+ * interactive-content file.
+ */
+export async function readInteractiveContentFile(
+  auth: Authenticator,
+  sId: string
+): Promise<Result<InteractiveContentFile, ReadInteractiveContentFileError>> {
+  const file = await FileResource.fetchById(auth, sId);
+  if (!file) {
+    return new Err("file_not_found");
+  }
+
+  if (!file.isInteractiveContent) {
+    return new Err("not_interactive_content");
+  }
+
+  const readStream = file.getReadStream({ auth, version: "original" });
+  const chunks: Buffer[] = [];
+  for await (const chunk of readStream) {
+    chunks.push(chunk);
+  }
+  const content = Buffer.concat(chunks).toString("utf-8");
+
+  return new Ok({ file: file.toJSONWithMetadata(auth), content });
+}

--- a/front/lib/api/webhook_source.ts
+++ b/front/lib/api/webhook_source.ts
@@ -2,12 +2,21 @@ import { WEBHOOK_SERVICES } from "@app/lib/api/triggers/built-in-webhooks/servic
 import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
-import type { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
+import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import logger from "@app/logger/logger";
+import type { TriggerType } from "@app/types/assistant/triggers";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
+import { removeNulls } from "@app/types/shared/utils/general";
+import type {
+  WebhookSourceForAdminType,
+  WebhookSourceType,
+  WebhookSourceViewForAdminType,
+} from "@app/types/triggers/webhooks";
+import type { UserType } from "@app/types/user";
 import assert from "assert";
 import type { Transaction } from "sequelize";
 
@@ -81,4 +90,100 @@ export async function deleteWebhookSource(
   await webhookSource.hardDelete(auth, { transaction });
 
   return new Ok(undefined);
+}
+
+export type WebhookSourceWithCounts = WebhookSourceType & {
+  viewCount: number;
+  triggerCount: number;
+};
+
+/**
+ * Every webhook source in the workspace, with the number of views and the
+ * total number of triggers across those views. Used by the poke admin UI.
+ */
+export async function listWebhookSourcesWithCounts(
+  auth: Authenticator
+): Promise<WebhookSourceWithCounts[]> {
+  const sources = await WebhookSourceResource.listByWorkspace(auth);
+  const results: WebhookSourceWithCounts[] = [];
+
+  for (const source of sources) {
+    const views = await WebhookSourcesViewResource.listByWebhookSource(
+      auth,
+      source.id
+    );
+    let triggerCount = 0;
+    for (const view of views) {
+      const triggers = await TriggerResource.listByWebhookSourceViewId(
+        auth,
+        view.id
+      );
+      triggerCount += triggers.length;
+    }
+
+    results.push({
+      ...source.toJSON(),
+      viewCount: views.length,
+      triggerCount,
+    });
+  }
+
+  return results;
+}
+
+export type WebhookSourceAdminDetails = {
+  webhookSource: WebhookSourceForAdminType;
+  views: WebhookSourceViewForAdminType[];
+  triggers: Array<TriggerType & { editorUser: UserType | null }>;
+  requestStats: { last24h: number; last7d: number; last30d: number };
+};
+
+/**
+ * For a given webhook source, return its admin-only JSON, all of its views,
+ * every trigger across those views (enriched with the editor user record), and
+ * request-volume counts over recent periods. Used by the poke admin UI.
+ */
+export async function getWebhookSourceAdminDetails(
+  auth: Authenticator,
+  source: WebhookSourceResource
+): Promise<WebhookSourceAdminDetails> {
+  const views = await WebhookSourcesViewResource.listByWebhookSource(
+    auth,
+    source.id
+  );
+
+  // Collect all triggers from all views.
+  const allTriggers: TriggerType[] = [];
+  for (const view of views) {
+    const triggers = await TriggerResource.listByWebhookSourceViewId(
+      auth,
+      view.id
+    );
+    for (const t of triggers) {
+      allTriggers.push(t.toJSON());
+    }
+  }
+
+  // Batch-fetch editor users.
+  const editorIds = removeNulls(allTriggers.map((t) => t.editor));
+  const editorUsers =
+    editorIds.length > 0 ? await UserResource.fetchByModelIds(editorIds) : [];
+  const editorUserMap = new Map(editorUsers.map((u) => [u.id, u.toJSON()]));
+
+  const triggersWithEditors = allTriggers.map((t) => ({
+    ...t,
+    editorUser: editorUserMap.get(t.editor) ?? null,
+  }));
+
+  const requestStats = await WebhookRequestResource.countBySourceInPeriods(
+    auth,
+    source.id
+  );
+
+  return {
+    webhookSource: source.toJSONForAdmin(),
+    views: views.map((v) => v.toJSONForAdmin()),
+    triggers: triggersWithEditors,
+    requestStats,
+  };
 }

--- a/front/lib/api/webhook_source.ts
+++ b/front/lib/api/webhook_source.ts
@@ -107,6 +107,10 @@ export async function listWebhookSourcesWithCounts(
   const sources = await WebhookSourceResource.listByWorkspace(auth);
   const results: WebhookSourceWithCounts[] = [];
 
+  // O(sources × views) sequential DB round-trips. Acceptable for the poke
+  // admin UI: webhook sources and views per workspace are small (< 20 each
+  // in practice), and this endpoint is not on a user hot path. If counts
+  // grow, batch the view + trigger fetches into one query each.
   for (const source of sources) {
     const views = await WebhookSourcesViewResource.listByWebhookSource(
       auth,

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -244,6 +244,27 @@ export async function getActiveAdminEmails(
   return Array.from(new Set(members.map((member) => member.email)));
 }
 
+/**
+ * For a given group, return the workspace members that belong to it. Members
+ * are returned as `UserTypeWithWorkspaces` (matching `getMembers`) so callers
+ * have the workspace context. Users in the group who are not workspace
+ * members are filtered out.
+ */
+export async function getGroupMembersWithWorkspaces(
+  auth: Authenticator,
+  group: GroupResource
+): Promise<UserTypeWithWorkspaces[]> {
+  const groupMembers = await group.getActiveMembers(auth);
+  const { members } = await getMembers(auth);
+
+  const memberById = new Map(members.map((m) => [m.sId, m]));
+
+  return groupMembers.flatMap((user) => {
+    const member = memberById.get(user.sId);
+    return member ? [member] : [];
+  });
+}
+
 export async function searchMembers(
   auth: Authenticator,
   options: {

--- a/front/pages/api/poke/workspaces/[wId]/assistants/[aId]/suggestions.ts
+++ b/front/pages/api/poke/workspaces/[wId]/assistants/[aId]/suggestions.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/data_source_views/[dsvId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_source_views/[dsvId]/details.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/data_source_views/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_source_views/index.ts
@@ -1,11 +1,9 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
-import { getDataSourceViewUsage } from "@app/lib/api/agent_data_sources";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { listDataSourceViewsWithUsage } from "@app/lib/api/data_source_view";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError } from "@app/logger/withlogging";
 import type { AgentsUsageType } from "@app/types/data_source";
 import type { DataSourceViewType } from "@app/types/data_source_view";
@@ -52,29 +50,10 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const dataSourceViews = await DataSourceViewResource.listByWorkspace(
-        auth,
-        { includeEditedBy: true }
-      );
-
-      const dataSourceViewsWithUsage = await concurrentExecutor(
-        dataSourceViews,
-        async (dsv) => {
-          const usageResult = await getDataSourceViewUsage({
-            auth,
-            dataSourceView: dsv,
-          });
-          return {
-            ...dsv.toJSON(),
-            usage: usageResult.isOk() ? usageResult.value : null,
-          };
-        },
-        { concurrency: 4 }
-      );
-
-      return res.status(200).json({
-        data_source_views: dataSourceViewsWithUsage,
-      });
+      const dataSourceViewsWithUsage = await listDataSourceViewsWithUsage(auth);
+      return res
+        .status(200)
+        .json({ data_source_views: dataSourceViewsWithUsage });
 
     default:
       return apiError(req, res, {

--- a/front/pages/api/poke/workspaces/[wId]/data_source_views/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_source_views/index.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { getDataSourceViewUsage } from "@app/lib/api/agent_data_sources";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/files/[sId].ts
+++ b/front/pages/api/poke/workspaces/[wId]/files/[sId].ts
@@ -1,12 +1,13 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { readInteractiveContentFile } from "@app/lib/api/files/read";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import { FileResource } from "@app/lib/resources/file_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { FileTypeWithMetadata } from "@app/types/files";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -53,40 +54,34 @@ async function handler(
   }
 
   switch (req.method) {
-    case "GET":
-      const file = await FileResource.fetchById(auth, sId);
-      if (!file) {
-        return apiError(req, res, {
-          status_code: 404,
-          api_error: {
-            type: "file_not_found",
-            message: "File not found.",
-          },
-        });
+    case "GET": {
+      const result = await readInteractiveContentFile(auth, sId);
+      if (result.isErr()) {
+        const err = result.error;
+        switch (err) {
+          case "file_not_found":
+            return apiError(req, res, {
+              status_code: 404,
+              api_error: {
+                type: "file_not_found",
+                message: "File not found.",
+              },
+            });
+          case "not_interactive_content":
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: "Only interactive content files can be viewed.",
+              },
+            });
+          default:
+            return assertNever(err);
+        }
       }
 
-      // Only allow access to interactive content files (frames).
-      if (!file.isInteractiveContent) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: "Only interactive content files can be viewed.",
-          },
-        });
-      }
-
-      const readStream = file.getReadStream({ auth, version: "original" });
-      const chunks: Buffer[] = [];
-      for await (const chunk of readStream) {
-        chunks.push(chunk);
-      }
-      const content = Buffer.concat(chunks).toString("utf-8");
-
-      return res.status(200).json({
-        file: file.toJSONWithMetadata(auth),
-        content,
-      });
+      return res.status(200).json(result.value);
+    }
 
     default:
       return apiError(req, res, {

--- a/front/pages/api/poke/workspaces/[wId]/files/[sId].ts
+++ b/front/pages/api/poke/workspaces/[wId]/files/[sId].ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/groups/[groupId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/groups/[groupId]/details.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/groups/[groupId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/groups/[groupId]/details.ts
@@ -1,7 +1,7 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
-import { getMembers } from "@app/lib/api/workspace";
+import { getGroupMembersWithWorkspaces } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { GroupResource } from "@app/lib/resources/group_resource";
@@ -59,19 +59,10 @@ async function handler(
       }
 
       const group = groupRes.value;
-
-      const groupMembers = await group.getActiveMembers(auth);
-      const memberships = await getMembers(auth);
-
-      const memberById = new Map(memberships.members.map((m) => [m.sId, m]));
-
-      const userWithWorkspaces = groupMembers.flatMap((user) => {
-        const member = memberById.get(user.sId);
-        return member ? [member] : [];
-      });
+      const members = await getGroupMembersWithWorkspaces(auth, group);
 
       return res.status(200).json({
-        members: userWithWorkspaces,
+        members,
         group: group.toJSON(),
       });
 

--- a/front/pages/api/poke/workspaces/[wId]/groups/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/groups/index.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/llm-traces/[runId].ts
+++ b/front/pages/api/poke/workspaces/[wId]/llm-traces/[runId].ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { fetchLLMTrace, isLLMTraceId } from "@app/lib/api/llm/traces/buffer";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/mcp/views/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/mcp/views/index.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/mcp_server_views/[svId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/mcp_server_views/[svId]/details.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/observability/datasource-retrieval.ts
+++ b/front/pages/api/poke/workspaces/[wId]/observability/datasource-retrieval.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type { WorkspaceDatasourceRetrievalData } from "@app/lib/api/assistant/observability/datasource_retrieval";
 import { fetchWorkspaceDatasourceRetrievalMetrics } from "@app/lib/api/assistant/observability/datasource_retrieval";

--- a/front/pages/api/poke/workspaces/[wId]/webhook_sources/[wsId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/webhook_sources/[wsId]/details.ts
@@ -1,17 +1,14 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { getWebhookSourceAdminDetails } from "@app/lib/api/webhook_source";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import { TriggerResource } from "@app/lib/resources/trigger_resource";
-import { UserResource } from "@app/lib/resources/user_resource";
-import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
-import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { TriggerType } from "@app/types/assistant/triggers";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { isString, removeNulls } from "@app/types/shared/utils/general";
+import { isString } from "@app/types/shared/utils/general";
 import type {
   WebhookSourceForAdminType,
   WebhookSourceViewForAdminType,
@@ -68,48 +65,9 @@ async function handler(
         });
       }
 
-      const views = await WebhookSourcesViewResource.listByWebhookSource(
-        auth,
-        source.id
-      );
+      const details = await getWebhookSourceAdminDetails(auth, source);
 
-      // Collect all triggers from all views
-      const allTriggers: TriggerType[] = [];
-      for (const view of views) {
-        const triggers = await TriggerResource.listByWebhookSourceViewId(
-          auth,
-          view.id
-        );
-        for (const t of triggers) {
-          allTriggers.push(t.toJSON());
-        }
-      }
-
-      // Batch-fetch editor users
-      const editorIds = removeNulls(allTriggers.map((t) => t.editor));
-      const editorUsers =
-        editorIds.length > 0
-          ? await UserResource.fetchByModelIds(editorIds)
-          : [];
-      const editorUserMap = new Map(editorUsers.map((u) => [u.id, u.toJSON()]));
-
-      const triggersWithEditors = allTriggers.map((t) => ({
-        ...t,
-        editorUser: editorUserMap.get(t.editor) ?? null,
-      }));
-
-      // Get request stats
-      const requestStats = await WebhookRequestResource.countBySourceInPeriods(
-        auth,
-        source.id
-      );
-
-      return res.status(200).json({
-        webhookSource: source.toJSONForAdmin(),
-        views: views.map((v) => v.toJSONForAdmin()),
-        triggers: triggersWithEditors,
-        requestStats,
-      });
+      return res.status(200).json(details);
     }
 
     default:

--- a/front/pages/api/poke/workspaces/[wId]/webhook_sources/[wsId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/webhook_sources/[wsId]/details.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/webhook_sources/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/webhook_sources/index.ts
@@ -1,11 +1,9 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { listWebhookSourcesWithCounts } from "@app/lib/api/webhook_source";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import { TriggerResource } from "@app/lib/resources/trigger_resource";
-import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
-import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
@@ -49,31 +47,8 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const sources = await WebhookSourceResource.listByWorkspace(auth);
-      const results: PokeListWebhookSources["webhookSources"] = [];
-
-      for (const source of sources) {
-        const views = await WebhookSourcesViewResource.listByWebhookSource(
-          auth,
-          source.id
-        );
-        let triggerCount = 0;
-        for (const view of views) {
-          const triggers = await TriggerResource.listByWebhookSourceViewId(
-            auth,
-            view.id
-          );
-          triggerCount += triggers.length;
-        }
-
-        results.push({
-          ...source.toJSON(),
-          viewCount: views.length,
-          triggerCount,
-        });
-      }
-
-      return res.status(200).json({ webhookSources: results });
+      const webhookSources = await listWebhookSourcesWithCounts(auth);
+      return res.status(200).json({ webhookSources });
     }
 
     default:

--- a/front/pages/api/poke/workspaces/[wId]/webhook_sources/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/webhook_sources/index.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";


### PR DESCRIPTION
## Description
Migrates 12 more poke admin routes from Next.js to Hono under
`/api/poke/workspaces/:wId/`, following the conventions established in the
prior poke migration (#25783 et al.):

- `pokeWorkspaceAuth` middleware at the `[wId]` sub-app
- `HandlerResult<ResponseType>` typed returns on every JSON handler
- `apiError(ctx, ...)` for all error responses
- `validate(target, schema)` (Zod) for input validation
- Response types declared inline in each handler, duplicated across the
  Next/Hono pair (no shared types between the two)
- Original Next handlers marked `// @migration-status: MIGRATED_TO_HONO`

**Routes migrated:**

- `observability/datasource-retrieval`
- `files/[sId]`
- `llm-traces/[runId]`
- `mcp/views`
- `mcp_server_views/[svId]/details`
- `webhook_sources` (list + `[wsId]/details`)
- `data_source_views` (list + `[dsvId]/details`)
- `groups` (list + `[groupId]/details`)
- `assistants/[aId]/suggestions` (+ test mirrored to Hono)

**Business-logic extracted to `lib/api/*` per [BACK16]:**

- `listWebhookSourcesWithCounts` — fan-out over sources / views / triggers
- `getWebhookSourceAdminDetails` — orchestrates 5 resources for the
  source-details response
- `listDataSourceViewsWithUsage` — concurrent usage fetches alongside
  the DSV list
- `readInteractiveContentFile` — file fetch + interactive-content
  validation + stream-to-string, with a domain `Result` the handler
  maps to HTTP
- `getGroupMembersWithWorkspaces` — group members hydrated with
  workspace context

Both Next and Hono handlers in each pair call the same lib helper —
behavior unchanged.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Manually smoke test poke
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low, not active
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
None needed
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25908">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->