### PR TITLE
[front] fix: simplify YAML agent patch imports

### DIFF
--- a/front/lib/agent_yaml_converter/converter.ts
+++ b/front/lib/agent_yaml_converter/converter.ts
@@ -4,6 +4,7 @@ import {
   isAutoInternalMCPServerName,
   isInternalMCPServerName,
 } from "@app/lib/actions/mcp_internal_actions/constants";
+import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import type {
   AgentYAMLAction,
   AgentYAMLConfig,
@@ -19,12 +20,93 @@ import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { PostOrPatchAgentConfigurationRequestBody } from "@app/types/api/internal/agent_configuration";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import * as yaml from "js-yaml";
 
 export class AgentYAMLConverter {
+  static generationSettingsToModel(
+    generationSettings: AgentYAMLConfig["generation_settings"]
+  ): PostOrPatchAgentConfigurationRequestBody["assistant"]["model"] {
+    const {
+      model_id: modelId,
+      provider_id: providerId,
+      reasoning_effort: reasoningEffort,
+      response_format: responseFormat,
+      temperature,
+    } = generationSettings;
+
+    return {
+      modelId,
+      providerId,
+      temperature,
+      reasoningEffort,
+      responseFormat,
+    };
+  }
+
+  static mergeGenerationSettingsPatch(
+    model: PostOrPatchAgentConfigurationRequestBody["assistant"]["model"],
+    generationSettings: Partial<AgentYAMLConfig["generation_settings"]> = {}
+  ): PostOrPatchAgentConfigurationRequestBody["assistant"]["model"] {
+    const {
+      model_id = model.modelId,
+      provider_id = model.providerId,
+      reasoning_effort = model.reasoningEffort,
+      response_format = model.responseFormat,
+      temperature = model.temperature,
+    } = generationSettings;
+
+    return {
+      ...model,
+      modelId: model_id,
+      providerId: provider_id,
+      temperature,
+      reasoningEffort: reasoning_effort,
+      responseFormat: response_format,
+    };
+  }
+
+  static agentConfigurationActionsToAssistantActions(
+    actions: AgentConfigurationType["actions"]
+  ): PostOrPatchAgentConfigurationRequestBody["assistant"]["actions"] {
+    return actions
+      .filter(isServerSideMCPServerConfiguration)
+      .map(
+        ({
+          additionalConfiguration,
+          childAgentId,
+          dataSources,
+          description,
+          dustAppConfiguration,
+          dustProject,
+          jsonSchema,
+          mcpServerViewId,
+          name,
+          secretName,
+          tables,
+          timeFrame,
+          type,
+        }) => ({
+          additionalConfiguration,
+          childAgentId,
+          dataSources,
+          description,
+          dustAppConfiguration,
+          dustProject,
+          jsonSchema,
+          mcpServerViewId,
+          name,
+          secretName,
+          tables,
+          timeFrame,
+          type,
+        })
+      );
+  }
+
   static async fromBuilderFormData(
     auth: Authenticator,
     formData: AgentBuilderFormData,
@@ -433,6 +515,35 @@ export class AgentYAMLConverter {
     } catch (error) {
       return new Err(normalizeError(error));
     }
+  }
+
+  static async convertYAMLToolsetToAssistantActions(
+    auth: Authenticator,
+    toolset: AgentYAMLConfig["toolset"]
+  ): Promise<
+    Result<
+      {
+        actions: PostOrPatchAgentConfigurationRequestBody["assistant"]["actions"];
+        skippedActions: { name: string; reason: string }[];
+      },
+      Error
+    >
+  > {
+    const result = await this.convertYAMLActionsToMCPConfigurations(
+      auth,
+      toolset
+    );
+    if (result.isErr()) {
+      return result;
+    }
+
+    return new Ok({
+      actions: result.value.configurations,
+      skippedActions: result.value.skipped.map(({ action, reason }) => ({
+        name: action.name ?? "",
+        reason,
+      })),
+    });
   }
 
   static fromYAMLString(yamlString: string): Result<AgentYAMLConfig, Error> {

--- a/front/lib/agent_yaml_converter/converter.ts
+++ b/front/lib/agent_yaml_converter/converter.ts
@@ -4,7 +4,6 @@ import {
   isAutoInternalMCPServerName,
   isInternalMCPServerName,
 } from "@app/lib/actions/mcp_internal_actions/constants";
-import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import type {
   AgentYAMLAction,
   AgentYAMLConfig,
@@ -20,93 +19,12 @@ import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { PostOrPatchAgentConfigurationRequestBody } from "@app/types/api/internal/agent_configuration";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import * as yaml from "js-yaml";
 
 export class AgentYAMLConverter {
-  static generationSettingsToModel(
-    generationSettings: AgentYAMLConfig["generation_settings"]
-  ): PostOrPatchAgentConfigurationRequestBody["assistant"]["model"] {
-    const {
-      model_id: modelId,
-      provider_id: providerId,
-      reasoning_effort: reasoningEffort,
-      response_format: responseFormat,
-      temperature,
-    } = generationSettings;
-
-    return {
-      modelId,
-      providerId,
-      temperature,
-      reasoningEffort,
-      responseFormat,
-    };
-  }
-
-  static mergeGenerationSettingsPatch(
-    model: PostOrPatchAgentConfigurationRequestBody["assistant"]["model"],
-    generationSettings: Partial<AgentYAMLConfig["generation_settings"]> = {}
-  ): PostOrPatchAgentConfigurationRequestBody["assistant"]["model"] {
-    const {
-      model_id = model.modelId,
-      provider_id = model.providerId,
-      reasoning_effort = model.reasoningEffort,
-      response_format = model.responseFormat,
-      temperature = model.temperature,
-    } = generationSettings;
-
-    return {
-      ...model,
-      modelId: model_id,
-      providerId: provider_id,
-      temperature,
-      reasoningEffort: reasoning_effort,
-      responseFormat: response_format,
-    };
-  }
-
-  static agentConfigurationActionsToAssistantActions(
-    actions: AgentConfigurationType["actions"]
-  ): PostOrPatchAgentConfigurationRequestBody["assistant"]["actions"] {
-    return actions
-      .filter(isServerSideMCPServerConfiguration)
-      .map(
-        ({
-          additionalConfiguration,
-          childAgentId,
-          dataSources,
-          description,
-          dustAppConfiguration,
-          dustProject,
-          jsonSchema,
-          mcpServerViewId,
-          name,
-          secretName,
-          tables,
-          timeFrame,
-          type,
-        }) => ({
-          additionalConfiguration,
-          childAgentId,
-          dataSources,
-          description,
-          dustAppConfiguration,
-          dustProject,
-          jsonSchema,
-          mcpServerViewId,
-          name,
-          secretName,
-          tables,
-          timeFrame,
-          type,
-        })
-      );
-  }
-
   static async fromBuilderFormData(
     auth: Authenticator,
     formData: AgentBuilderFormData,

--- a/front/lib/agent_yaml_converter/converter.ts
+++ b/front/lib/agent_yaml_converter/converter.ts
@@ -435,35 +435,6 @@ export class AgentYAMLConverter {
     }
   }
 
-  static async convertYAMLToolsetToAssistantActions(
-    auth: Authenticator,
-    toolset: AgentYAMLConfig["toolset"]
-  ): Promise<
-    Result<
-      {
-        actions: PostOrPatchAgentConfigurationRequestBody["assistant"]["actions"];
-        skippedActions: { name: string; reason: string }[];
-      },
-      Error
-    >
-  > {
-    const result = await this.convertYAMLActionsToMCPConfigurations(
-      auth,
-      toolset
-    );
-    if (result.isErr()) {
-      return result;
-    }
-
-    return new Ok({
-      actions: result.value.configurations,
-      skippedActions: result.value.skipped.map(({ action, reason }) => ({
-        name: action.name ?? "",
-        reason,
-      })),
-    });
-  }
-
   static fromYAMLString(yamlString: string): Result<AgentYAMLConfig, Error> {
     if (!yamlString?.trim()) {
       return new Err(new Error("YAML string is empty"));

--- a/front/lib/api/assistant/configuration/yaml_export.ts
+++ b/front/lib/api/assistant/configuration/yaml_export.ts
@@ -46,7 +46,7 @@ function isExportableAgentConfiguration(
   );
 }
 
-export async function getAgentConfigurationForExport(
+export async function getExportableAgentConfiguration(
   auth: Authenticator,
   agentId: string
 ): Promise<Result<ExportableAgentConfiguration, APIErrorWithStatusCode>> {
@@ -83,7 +83,7 @@ export async function getAgentConfigurationYAMLContext(
   agentId: string,
   { requireEditorGroup = false }: { requireEditorGroup?: boolean } = {}
 ): Promise<Result<AgentConfigurationYAMLContext, APIErrorWithStatusCode>> {
-  const agentResult = await getAgentConfigurationForExport(auth, agentId);
+  const agentResult = await getExportableAgentConfiguration(auth, agentId);
   if (agentResult.isErr()) {
     return agentResult;
   }

--- a/front/lib/api/assistant/configuration/yaml_export.ts
+++ b/front/lib/api/assistant/configuration/yaml_export.ts
@@ -16,18 +16,33 @@ import { GroupResource } from "@app/lib/resources/group_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
-import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
+import type { APIErrorWithStatusCode } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { UserType } from "@app/types/user";
 
 const AGENT_NAME_SANITATION_REGEX = /[^a-zA-Z0-9-_]/g;
 
-export async function getAgentConfigurationAsYAMLConfig(
+export type ExportableAgentConfiguration = AgentConfigurationType & {
+  scope: Exclude<AgentConfigurationType["scope"], "global">;
+  status: "active";
+};
+
+function isExportableAgentConfiguration(
+  agentConfiguration: AgentConfigurationType
+): agentConfiguration is ExportableAgentConfiguration {
+  return (
+    agentConfiguration.status === "active" &&
+    agentConfiguration.scope !== "global"
+  );
+}
+
+export async function getAgentConfigurationForExport(
   auth: Authenticator,
   agentId: string
-): Promise<Result<AgentYAMLConfig, APIErrorWithContentfulStatusCode>> {
+): Promise<Result<ExportableAgentConfiguration, APIErrorWithStatusCode>> {
   const agentConfiguration = await getAgentConfiguration(auth, {
     agentId,
     variant: "full",
@@ -43,10 +58,7 @@ export async function getAgentConfigurationAsYAMLConfig(
     });
   }
 
-  if (
-    agentConfiguration.status !== "active" ||
-    agentConfiguration.scope === "global"
-  ) {
+  if (!isExportableAgentConfiguration(agentConfiguration)) {
     return new Err({
       status_code: 400,
       api_error: {
@@ -56,6 +68,13 @@ export async function getAgentConfigurationAsYAMLConfig(
     });
   }
 
+  return new Ok(agentConfiguration);
+}
+
+export async function convertAgentConfigurationToYAMLConfig(
+  auth: Authenticator,
+  agentConfiguration: AgentConfigurationType
+): Promise<Result<AgentYAMLConfig, APIErrorWithStatusCode>> {
   const { dataSourceViews, mcpServerViews } =
     await getAccessibleSourcesAndAppsForActions(auth);
   const skills = await SkillResource.listByAgentConfiguration(
@@ -181,23 +200,24 @@ export async function exportAgentConfigurationAsYAML(
   auth: Authenticator,
   agentId: string
 ): Promise<
-  Result<
-    { yamlContent: string; filename: string },
-    APIErrorWithContentfulStatusCode
-  >
+  Result<{ yamlContent: string; filename: string }, APIErrorWithStatusCode>
 > {
-  const yamlConfigResult = await getAgentConfigurationAsYAMLConfig(
-    auth,
-    agentId
-  );
+  const agentResult = await getAgentConfigurationForExport(auth, agentId);
+  if (agentResult.isErr()) {
+    return agentResult;
+  }
 
+  const yamlConfigResult = await convertAgentConfigurationToYAMLConfig(
+    auth,
+    agentResult.value
+  );
   if (yamlConfigResult.isErr()) {
     return yamlConfigResult;
   }
 
-  const yamlStringResult = AgentYAMLConverter.toYAMLString(
-    yamlConfigResult.value
-  );
+  const yamlConfig = yamlConfigResult.value;
+
+  const yamlStringResult = AgentYAMLConverter.toYAMLString(yamlConfig);
 
   if (yamlStringResult.isErr()) {
     return new Err({
@@ -209,7 +229,7 @@ export async function exportAgentConfigurationAsYAML(
     });
   }
 
-  const sanitizedName = yamlConfigResult.value.agent.handle.replace(
+  const sanitizedName = yamlConfig.agent.handle.replace(
     AGENT_NAME_SANITATION_REGEX,
     "_"
   );

--- a/front/lib/api/assistant/configuration/yaml_export.ts
+++ b/front/lib/api/assistant/configuration/yaml_export.ts
@@ -15,6 +15,7 @@ import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
@@ -29,6 +30,12 @@ export type ExportableAgentConfiguration = AgentConfigurationType & {
   scope: Exclude<AgentConfigurationType["scope"], "global">;
   status: "active";
 };
+
+interface AgentConfigurationYAMLContext {
+  agentConfiguration: ExportableAgentConfiguration;
+  editorUsers: UserResource[];
+  skills: SkillResource[];
+}
 
 function isExportableAgentConfiguration(
   agentConfiguration: AgentConfigurationType
@@ -71,10 +78,11 @@ export async function getAgentConfigurationForExport(
   return new Ok(agentConfiguration);
 }
 
-export async function getAgentConfigurationAsYAMLConfig(
+export async function getAgentConfigurationYAMLContext(
   auth: Authenticator,
-  agentId: string
-): Promise<Result<AgentYAMLConfig, APIErrorWithStatusCode>> {
+  agentId: string,
+  { requireEditorGroup = false }: { requireEditorGroup?: boolean } = {}
+): Promise<Result<AgentConfigurationYAMLContext, APIErrorWithStatusCode>> {
   const agentResult = await getAgentConfigurationForExport(auth, agentId);
   if (agentResult.isErr()) {
     return agentResult;
@@ -82,8 +90,6 @@ export async function getAgentConfigurationAsYAMLConfig(
 
   const agentConfiguration = agentResult.value;
 
-  const { dataSourceViews, mcpServerViews } =
-    await getAccessibleSourcesAndAppsForActions(auth);
   const skills = await SkillResource.listByAgentConfiguration(
     auth,
     agentConfiguration
@@ -92,6 +98,45 @@ export async function getAgentConfigurationAsYAMLConfig(
     auth,
     agentConfiguration
   );
+
+  if (editorsResult.isErr()) {
+    if (requireEditorGroup) {
+      return new Err({
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `Unable to resolve existing agent editors: ${editorsResult.error.message}`,
+        },
+      });
+    }
+
+    return new Ok({
+      agentConfiguration,
+      editorUsers: [],
+      skills,
+    });
+  }
+
+  return new Ok({
+    agentConfiguration,
+    editorUsers: await editorsResult.value.getActiveMembers(auth),
+    skills,
+  });
+}
+
+export async function getAgentConfigurationAsYAMLConfig(
+  auth: Authenticator,
+  agentId: string
+): Promise<Result<AgentYAMLConfig, APIErrorWithStatusCode>> {
+  const contextResult = await getAgentConfigurationYAMLContext(auth, agentId);
+  if (contextResult.isErr()) {
+    return contextResult;
+  }
+
+  const { agentConfiguration, editorUsers, skills } = contextResult.value;
+
+  const { dataSourceViews, mcpServerViews } =
+    await getAccessibleSourcesAndAppsForActions(auth);
   const spaceResources = await SpaceResource.fetchByIds(
     auth,
     agentConfiguration.requestedSpaceIds
@@ -110,9 +155,7 @@ export async function getAgentConfigurationAsYAMLConfig(
     mcpServerViews: mcpServerViewsJSON,
   });
 
-  const editors: UserType[] = editorsResult.isOk()
-    ? (await editorsResult.value.getActiveMembers(auth)).map((m) => m.toJSON())
-    : [];
+  const editors: UserType[] = editorUsers.map((m) => m.toJSON());
 
   let slackProvider: "slack" | "slack_bot" | null = null;
   let slackChannels: { slackChannelId: string; slackChannelName: string }[] =

--- a/front/lib/api/assistant/configuration/yaml_export.ts
+++ b/front/lib/api/assistant/configuration/yaml_export.ts
@@ -71,10 +71,17 @@ export async function getAgentConfigurationForExport(
   return new Ok(agentConfiguration);
 }
 
-export async function convertAgentConfigurationToYAMLConfig(
+export async function getAgentConfigurationAsYAMLConfig(
   auth: Authenticator,
-  agentConfiguration: AgentConfigurationType
+  agentId: string
 ): Promise<Result<AgentYAMLConfig, APIErrorWithStatusCode>> {
+  const agentResult = await getAgentConfigurationForExport(auth, agentId);
+  if (agentResult.isErr()) {
+    return agentResult;
+  }
+
+  const agentConfiguration = agentResult.value;
+
   const { dataSourceViews, mcpServerViews } =
     await getAccessibleSourcesAndAppsForActions(auth);
   const skills = await SkillResource.listByAgentConfiguration(
@@ -202,22 +209,18 @@ export async function exportAgentConfigurationAsYAML(
 ): Promise<
   Result<{ yamlContent: string; filename: string }, APIErrorWithStatusCode>
 > {
-  const agentResult = await getAgentConfigurationForExport(auth, agentId);
-  if (agentResult.isErr()) {
-    return agentResult;
-  }
-
-  const yamlConfigResult = await convertAgentConfigurationToYAMLConfig(
+  const yamlConfigResult = await getAgentConfigurationAsYAMLConfig(
     auth,
-    agentResult.value
+    agentId
   );
+
   if (yamlConfigResult.isErr()) {
     return yamlConfigResult;
   }
 
-  const yamlConfig = yamlConfigResult.value;
-
-  const yamlStringResult = AgentYAMLConverter.toYAMLString(yamlConfig);
+  const yamlStringResult = AgentYAMLConverter.toYAMLString(
+    yamlConfigResult.value
+  );
 
   if (yamlStringResult.isErr()) {
     return new Err({
@@ -229,7 +232,7 @@ export async function exportAgentConfigurationAsYAML(
     });
   }
 
-  const sanitizedName = yamlConfig.agent.handle.replace(
+  const sanitizedName = yamlConfigResult.value.agent.handle.replace(
     AGENT_NAME_SANITATION_REGEX,
     "_"
   );

--- a/front/lib/api/assistant/configuration/yaml_export.ts
+++ b/front/lib/api/assistant/configuration/yaml_export.ts
@@ -31,11 +31,11 @@ export type ExportableAgentConfiguration = AgentConfigurationType & {
   status: "active";
 };
 
-interface AgentConfigurationYAMLContext {
+type AgentConfigurationYAMLContext = {
   agentConfiguration: ExportableAgentConfiguration;
   editorUsers: UserResource[];
   skills: SkillResource[];
-}
+};
 
 function isExportableAgentConfiguration(
   agentConfiguration: AgentConfigurationType

--- a/front/lib/api/assistant/configuration/yaml_export.ts
+++ b/front/lib/api/assistant/configuration/yaml_export.ts
@@ -19,7 +19,7 @@ import type { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
-import type { APIErrorWithStatusCode } from "@app/types/error";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { UserType } from "@app/types/user";
@@ -49,7 +49,9 @@ function isExportableAgentConfiguration(
 export async function getExportableAgentConfiguration(
   auth: Authenticator,
   agentId: string
-): Promise<Result<ExportableAgentConfiguration, APIErrorWithStatusCode>> {
+): Promise<
+  Result<ExportableAgentConfiguration, APIErrorWithContentfulStatusCode>
+> {
   const agentConfiguration = await getAgentConfiguration(auth, {
     agentId,
     variant: "full",
@@ -82,7 +84,9 @@ export async function getAgentConfigurationYAMLContext(
   auth: Authenticator,
   agentId: string,
   { requireEditorGroup = false }: { requireEditorGroup?: boolean } = {}
-): Promise<Result<AgentConfigurationYAMLContext, APIErrorWithStatusCode>> {
+): Promise<
+  Result<AgentConfigurationYAMLContext, APIErrorWithContentfulStatusCode>
+> {
   const agentResult = await getExportableAgentConfiguration(auth, agentId);
   if (agentResult.isErr()) {
     return agentResult;
@@ -127,7 +131,7 @@ export async function getAgentConfigurationYAMLContext(
 export async function getAgentConfigurationAsYAMLConfig(
   auth: Authenticator,
   agentId: string
-): Promise<Result<AgentYAMLConfig, APIErrorWithStatusCode>> {
+): Promise<Result<AgentYAMLConfig, APIErrorWithContentfulStatusCode>> {
   const contextResult = await getAgentConfigurationYAMLContext(auth, agentId);
   if (contextResult.isErr()) {
     return contextResult;
@@ -250,7 +254,10 @@ export async function exportAgentConfigurationAsYAML(
   auth: Authenticator,
   agentId: string
 ): Promise<
-  Result<{ yamlContent: string; filename: string }, APIErrorWithStatusCode>
+  Result<
+    { yamlContent: string; filename: string },
+    APIErrorWithContentfulStatusCode
+  >
 > {
   const yamlConfigResult = await getAgentConfigurationAsYAMLConfig(
     auth,

--- a/front/lib/api/assistant/configuration/yaml_import.test.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.test.ts
@@ -1,5 +1,5 @@
 import { createAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import { getAgentConfigurationForExport } from "@app/lib/api/assistant/configuration/yaml_export";
+import { getExportableAgentConfiguration } from "@app/lib/api/assistant/configuration/yaml_export";
 import { patchAgentConfigurationFromJSON } from "@app/lib/api/assistant/configuration/yaml_import";
 import type { Authenticator } from "@app/lib/auth";
 import type { GroupResource as GroupResourceType } from "@app/lib/resources/group_resource";
@@ -85,7 +85,7 @@ async function createPatchableAgent({
     agentConfigurationId: agent.id,
   });
 
-  const agentForPatch = await getAgentConfigurationForExport(auth, agent.sId);
+  const agentForPatch = await getExportableAgentConfiguration(auth, agent.sId);
   expect(agentForPatch.isOk()).toBe(true);
   if (agentForPatch.isErr()) {
     throw new Error(agentForPatch.error.api_error.message);

--- a/front/lib/api/assistant/configuration/yaml_import.test.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.test.ts
@@ -1,0 +1,207 @@
+import { createAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { getAgentConfigurationForExport } from "@app/lib/api/assistant/configuration/yaml_export";
+import { patchAgentConfigurationFromJSON } from "@app/lib/api/assistant/configuration/yaml_import";
+import type { Authenticator } from "@app/lib/auth";
+import type { GroupResource as GroupResourceType } from "@app/lib/resources/group_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { AgentMCPServerConfigurationFactory } from "@app/tests/utils/AgentMCPServerConfigurationFactory";
+import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { TagFactory } from "@app/tests/utils/TagFactory";
+import { TemplateFactory } from "@app/tests/utils/TemplateFactory";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import { describe, expect, it } from "vitest";
+
+async function createPatchableAgent({
+  auth,
+  globalGroup,
+}: {
+  auth: Authenticator;
+  globalGroup: GroupResourceType;
+}) {
+  const workspace = auth.getNonNullableWorkspace();
+  const user = auth.getNonNullableUser();
+
+  const space = await SpaceFactory.regular(workspace);
+  await GroupSpaceFactory.associate(space, globalGroup);
+
+  const tag = await TagFactory.create(workspace, { name: "yaml-import-test" });
+  const template = await TemplateFactory.published();
+
+  const createResult = await createAgentConfiguration(auth, {
+    name: "YAML import test agent",
+    description: "Initial description",
+    instructions: "Initial instructions",
+    instructionsHtml: "<p>Initial instructions</p>",
+    pictureUrl: "https://dust.tt/static/systemavatar/test_avatar_1.png",
+    status: "active",
+    scope: "hidden",
+    model: {
+      providerId: "anthropic",
+      modelId: "claude-sonnet-4-5-20250929",
+      temperature: 0.5,
+    },
+    agentConfigurationId: undefined,
+    templateId: template.sId,
+    requestedSpaceIds: [space.id],
+    tags: [tag.toJSON()],
+    editors: [user.toJSON()],
+    authorId: user.id,
+  });
+  expect(createResult.isOk()).toBe(true);
+  if (createResult.isErr()) {
+    throw createResult.error;
+  }
+
+  const agent = {
+    ...createResult.value,
+    instructionsHtml: "<p>Initial instructions</p>",
+    actions: [],
+  } satisfies AgentConfigurationType;
+
+  const server = await RemoteMCPServerFactory.create(workspace, {
+    name: "YAML Import Test Server",
+  });
+  const serverView = await MCPServerViewFactory.create(
+    workspace,
+    server.sId,
+    space
+  );
+  await AgentMCPServerConfigurationFactory.create(auth, space, {
+    agent,
+    mcpServerView: serverView,
+  });
+
+  const skill = await SkillFactory.create(auth, {
+    name: "YAML Import Test Skill",
+  });
+  await SkillFactory.linkToAgent(auth, {
+    skillId: skill.id,
+    agentConfigurationId: agent.id,
+  });
+
+  const agentForPatch = await getAgentConfigurationForExport(auth, agent.sId);
+  expect(agentForPatch.isOk()).toBe(true);
+  if (agentForPatch.isErr()) {
+    throw new Error(agentForPatch.error.api_error.message);
+  }
+
+  return {
+    agent: agentForPatch.value,
+    skill,
+    space,
+    tag,
+    template,
+    user,
+  };
+}
+
+async function getEditorIds(
+  auth: Authenticator,
+  agent: AgentConfigurationType
+) {
+  const editorGroupResult = await GroupResource.findEditorGroupForAgent(
+    auth,
+    agent
+  );
+  expect(editorGroupResult.isOk()).toBe(true);
+  if (editorGroupResult.isErr()) {
+    throw editorGroupResult.error;
+  }
+
+  const editors = await editorGroupResult.value.getActiveMembers(auth);
+
+  return editors.map((editor) => editor.sId);
+}
+
+describe("patchAgentConfigurationFromJSON", () => {
+  it("should preserve existing state when applying a description-only YAML patch", async () => {
+    const { authenticator, globalGroup } = await createResourceTest({
+      role: "admin",
+    });
+    const { agent, skill, space, tag, template, user } =
+      await createPatchableAgent({ auth: authenticator, globalGroup });
+
+    const result = await patchAgentConfigurationFromJSON(
+      authenticator,
+      agent.sId,
+      {
+        agent: {
+          description: "Updated description",
+        },
+      }
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw new Error(result.error.api_error.message);
+    }
+
+    const updatedAgent = result.value.agentConfiguration;
+    expect(updatedAgent.description).toBe("Updated description");
+    expect(updatedAgent.name).toBe(agent.name);
+    expect(updatedAgent.instructions).toBe(agent.instructions);
+    expect(updatedAgent.instructionsHtml).toBe(agent.instructionsHtml);
+    expect(updatedAgent.templateId).toBe(template.sId);
+    expect(updatedAgent.requestedSpaceIds).toContain(space.sId);
+    expect(updatedAgent.tags.map((t) => t.sId)).toContain(tag.sId);
+    await expect(
+      SkillResource.listByAgentConfiguration(authenticator, updatedAgent).then(
+        (skills) => skills.map((s) => s.sId)
+      )
+    ).resolves.toContain(skill.sId);
+    expect(updatedAgent.actions).toHaveLength(1);
+
+    await expect(getEditorIds(authenticator, updatedAgent)).resolves.toContain(
+      user.sId
+    );
+  });
+
+  it("should replace actions and report skipped actions when patching toolset", async () => {
+    const { authenticator, globalGroup } = await createResourceTest({
+      role: "admin",
+    });
+    const { agent, space } = await createPatchableAgent({
+      auth: authenticator,
+      globalGroup,
+    });
+
+    const result = await patchAgentConfigurationFromJSON(
+      authenticator,
+      agent.sId,
+      {
+        toolset: [
+          {
+            name: "Missing MCP server",
+            description: "Should be skipped",
+            type: "MCP",
+            configuration: {
+              mcp_server_name: "missing_server",
+            },
+          },
+        ],
+      }
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw new Error(result.error.api_error.message);
+    }
+
+    expect(result.value.skippedActions).toEqual([
+      {
+        name: "Missing MCP server",
+        reason: "Invalid internal MCP server name: missing_server",
+      },
+    ]);
+    expect(result.value.agentConfiguration.actions).toHaveLength(0);
+    expect(result.value.agentConfiguration.requestedSpaceIds).not.toContain(
+      space.sId
+    );
+  });
+});

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -328,21 +328,21 @@ export async function patchAgentConfigurationFromJSON(
   let skippedActions: SkippedAction[] = [];
 
   if (patch.agent) {
-    if (patch.agent.handle !== undefined) {
+    if (patch.agent.handle) {
       assistant.name = patch.agent.handle;
     }
-    if (patch.agent.description !== undefined) {
+    if (patch.agent.description) {
       assistant.description = patch.agent.description;
     }
-    if (patch.agent.avatar_url !== undefined) {
+    if (patch.agent.avatar_url) {
       assistant.pictureUrl = patch.agent.avatar_url;
     }
-    if (patch.agent.scope !== undefined) {
+    if (patch.agent.scope) {
       assistant.scope = patch.agent.scope;
     }
   }
 
-  if (patch.instructions !== undefined) {
+  if (patch.instructions) {
     assistant.instructions = patch.instructions;
     assistant.instructionsHtml = null;
   }
@@ -407,17 +407,13 @@ export async function patchAgentConfigurationFromJSON(
     );
   }
 
-  if (patch.skills !== undefined) {
+  if (patch.skills) {
     assistant.skills = patch.skills.map((skill) => ({
       sId: skill.sId,
     }));
   }
 
-  if (
-    patch.spaces !== undefined ||
-    patch.toolset !== undefined ||
-    patch.skills !== undefined
-  ) {
+  if (patch.spaces || patch.toolset || patch.skills) {
     assistant.additionalRequestedSpaceIds =
       patch.spaces?.map((space) => space.space_id) ?? [];
   }

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -7,14 +7,9 @@ import {
   agentYAMLGenerationSettingsSchema,
 } from "@app/lib/agent_yaml_converter/schemas";
 import { createOrUpgradeAgentConfiguration } from "@app/lib/api/assistant/configuration/create_or_upgrade";
-import {
-  type ExportableAgentConfiguration,
-  getAgentConfigurationForExport,
-} from "@app/lib/api/assistant/configuration/yaml_export";
+import { getAgentConfigurationYAMLContext } from "@app/lib/api/assistant/configuration/yaml_export";
 import type { Authenticator } from "@app/lib/auth";
-import { GroupResource } from "@app/lib/resources/group_resource";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
-import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { TagResource } from "@app/lib/resources/tags_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { PostOrPatchAgentConfigurationRequestBody } from "@app/types/api/internal/agent_configuration";
@@ -37,8 +32,7 @@ type ImportResult = Result<
   APIErrorWithStatusCode
 >;
 
-type PatchRequestBody =
-  PostOrPatchAgentConfigurationRequestBody["assistant"];
+type PatchRequestBody = PostOrPatchAgentConfigurationRequestBody["assistant"];
 
 const agentYAMLConfigPatchSchema = agentYAMLConfigSchema.partial().extend({
   agent: agentYAMLBasicInfoSchema.partial().optional(),
@@ -88,30 +82,6 @@ async function resolveEditorUsersFromEmails(
   );
 
   return resolveEditorUsers(auth, fetchedEditors);
-}
-
-async function resolveEditorUsersFromAgentConfiguration(
-  auth: Authenticator,
-  agentConfiguration: ExportableAgentConfiguration
-): Promise<Result<ResolvedEditors, APIErrorWithStatusCode>> {
-  const editorsResult = await GroupResource.findEditorGroupForAgent(
-    auth,
-    agentConfiguration
-  );
-  if (editorsResult.isErr()) {
-    return new Err({
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: `Unable to resolve existing agent editors: ${editorsResult.error.message}`,
-      },
-    });
-  }
-
-  return resolveEditorUsers(
-    auth,
-    await editorsResult.value.getActiveMembers(auth)
-  );
 }
 
 async function resolveTags(
@@ -317,25 +287,19 @@ export async function patchAgentConfigurationFromJSON(
     return saveEnabledResult;
   }
 
-  const agentResult = await getAgentConfigurationForExport(auth, agentId);
-  if (agentResult.isErr()) {
-    return agentResult;
+  const contextResult = await getAgentConfigurationYAMLContext(auth, agentId, {
+    requireEditorGroup: true,
+  });
+  if (contextResult.isErr()) {
+    return contextResult;
   }
 
-  const agentConfiguration = agentResult.value;
-
-  const editorsResult = await resolveEditorUsersFromAgentConfiguration(
-    auth,
-    agentConfiguration
-  );
+  const { agentConfiguration, editorUsers, skills } = contextResult.value;
+  const editorsResult = resolveEditorUsers(auth, editorUsers);
   if (editorsResult.isErr()) {
     return editorsResult;
   }
 
-  const skills = await SkillResource.listByAgentConfiguration(
-    auth,
-    agentConfiguration
-  );
   const patch = parsed.data;
   const assistant: PatchRequestBody = {
     name: agentConfiguration.name,
@@ -346,7 +310,9 @@ export async function patchAgentConfigurationFromJSON(
     status: agentConfiguration.status,
     scope: agentConfiguration.scope,
     model: agentConfiguration.model,
-    actions: agentConfiguration.actions.filter(isServerSideMCPServerConfiguration),
+    actions: agentConfiguration.actions.filter(
+      isServerSideMCPServerConfiguration
+    ),
     templateId: agentConfiguration.templateId,
     tags: agentConfiguration.tags,
     editors: editorsResult.value.editors,
@@ -439,11 +405,7 @@ export async function patchAgentConfigurationFromJSON(
     }));
   }
 
-  if (
-    patch.spaces ||
-    patch.toolset ||
-    patch.skills
-  ) {
+  if (patch.spaces || patch.toolset || patch.skills) {
     assistant.additionalRequestedSpaceIds =
       patch.spaces?.map((space) => space.space_id) ?? [];
   }

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -304,6 +304,13 @@ export async function patchAgentConfigurationFromJSON(
   }
 
   const patch = parsed.data;
+  const {
+    model_id = agentConfiguration.model.modelId,
+    provider_id = agentConfiguration.model.providerId,
+    reasoning_effort = agentConfiguration.model.reasoningEffort,
+    response_format = agentConfiguration.model.responseFormat,
+    temperature = agentConfiguration.model.temperature,
+  } = patch.generation_settings ?? {};
   const assistant: PatchRequestBody = {
     name: agentConfiguration.name,
     description: agentConfiguration.description,
@@ -312,7 +319,14 @@ export async function patchAgentConfigurationFromJSON(
     pictureUrl: agentConfiguration.pictureUrl,
     status: agentConfiguration.status,
     scope: agentConfiguration.scope,
-    model: agentConfiguration.model,
+    model: {
+      ...agentConfiguration.model,
+      modelId: model_id,
+      providerId: provider_id,
+      temperature,
+      reasoningEffort: reasoning_effort,
+      responseFormat: response_format,
+    },
     actions: agentConfiguration.actions.filter(
       isServerSideMCPServerConfiguration
     ),
@@ -323,45 +337,18 @@ export async function patchAgentConfigurationFromJSON(
       sId: skill.sId,
     })),
     additionalRequestedSpaceIds: agentConfiguration.requestedSpaceIds,
+    ...(patch.agent?.handle ? { name: patch.agent.handle } : {}),
+    ...(patch.agent?.description
+      ? { description: patch.agent.description }
+      : {}),
+    ...(patch.agent?.avatar_url ? { pictureUrl: patch.agent.avatar_url } : {}),
+    ...(patch.agent?.scope ? { scope: patch.agent.scope } : {}),
+    ...(patch.instructions
+      ? { instructions: patch.instructions, instructionsHtml: null }
+      : {}),
   };
   let { authorModelId } = editorsResult.value;
   let skippedActions: SkippedAction[] = [];
-
-  if (patch.agent) {
-    if (patch.agent.handle) {
-      assistant.name = patch.agent.handle;
-    }
-    if (patch.agent.description) {
-      assistant.description = patch.agent.description;
-    }
-    if (patch.agent.avatar_url) {
-      assistant.pictureUrl = patch.agent.avatar_url;
-    }
-    if (patch.agent.scope) {
-      assistant.scope = patch.agent.scope;
-    }
-  }
-
-  if (patch.instructions) {
-    assistant.instructions = patch.instructions;
-    assistant.instructionsHtml = null;
-  }
-
-  const {
-    model_id = assistant.model.modelId,
-    provider_id = assistant.model.providerId,
-    reasoning_effort = assistant.model.reasoningEffort,
-    response_format = assistant.model.responseFormat,
-    temperature = assistant.model.temperature,
-  } = patch.generation_settings ?? {};
-  assistant.model = {
-    ...assistant.model,
-    modelId: model_id,
-    providerId: provider_id,
-    temperature,
-    reasoningEffort: reasoning_effort,
-    responseFormat: response_format,
-  };
 
   if (patch.tags) {
     const tagsResult = await resolveTags(auth, patch.tags);

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -172,7 +172,7 @@ async function importAgentConfiguration(
   }
 
   const actionsResult =
-    await AgentYAMLConverter.convertYAMLToolsetToAssistantActions(
+    await AgentYAMLConverter.convertYAMLActionsToMCPConfigurations(
       auth,
       yamlConfig.toolset
     );
@@ -215,7 +215,7 @@ async function importAgentConfiguration(
         reasoningEffort: yamlConfig.generation_settings.reasoning_effort,
         responseFormat: yamlConfig.generation_settings.response_format,
       },
-      actions: actionsResult.value.actions,
+      actions: actionsResult.value.configurations,
       templateId: null,
       tags: tagsResult.value,
       editors: editorsResult.value.editors,
@@ -224,7 +224,10 @@ async function importAgentConfiguration(
       })),
       additionalRequestedSpaceIds: [],
     },
-    skippedActions: actionsResult.value.skippedActions,
+    skippedActions: actionsResult.value.skipped.map(({ action, reason }) => ({
+      name: action.name ?? "",
+      reason,
+    })),
     authorId: editorsResult.value.authorId,
     agentConfigurationId,
   });
@@ -382,7 +385,7 @@ export async function patchAgentConfigurationFromJSON(
 
   if (patch.toolset !== undefined) {
     const patchActionsResult =
-      await AgentYAMLConverter.convertYAMLToolsetToAssistantActions(
+      await AgentYAMLConverter.convertYAMLActionsToMCPConfigurations(
         auth,
         patch.toolset
       );
@@ -395,8 +398,13 @@ export async function patchAgentConfigurationFromJSON(
         },
       });
     }
-    assistant.actions = patchActionsResult.value.actions;
-    skippedActions = patchActionsResult.value.skippedActions;
+    assistant.actions = patchActionsResult.value.configurations;
+    skippedActions = patchActionsResult.value.skipped.map(
+      ({ action, reason }) => ({
+        name: action.name ?? "",
+        reason,
+      })
+    );
   }
 
   if (patch.skills) {

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -324,7 +324,7 @@ export async function patchAgentConfigurationFromJSON(
     })),
     additionalRequestedSpaceIds: agentConfiguration.requestedSpaceIds,
   };
-  let authorModelId = editorsResult.value.authorModelId;
+  let { authorModelId } = editorsResult.value;
   let skippedActions: SkippedAction[] = [];
 
   if (patch.agent) {

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -6,13 +6,20 @@ import {
   agentYAMLGenerationSettingsSchema,
 } from "@app/lib/agent_yaml_converter/schemas";
 import { createOrUpgradeAgentConfiguration } from "@app/lib/api/assistant/configuration/create_or_upgrade";
-import { getAgentConfigurationAsYAMLConfig } from "@app/lib/api/assistant/configuration/yaml_export";
+import {
+  type ExportableAgentConfiguration,
+  getAgentConfigurationForExport,
+} from "@app/lib/api/assistant/configuration/yaml_export";
 import type { Authenticator } from "@app/lib/auth";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { TagResource } from "@app/lib/resources/tags_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
+import type { PostOrPatchAgentConfigurationRequestBody } from "@app/types/api/internal/agent_configuration";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
-import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
+import type { APIErrorWithStatusCode } from "@app/types/error";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -26,40 +33,63 @@ type ImportResult = Result<
     agentConfiguration: AgentConfigurationType;
     skippedActions: SkippedAction[];
   },
-  APIErrorWithContentfulStatusCode
+  APIErrorWithStatusCode
 >;
 
-async function importAgentConfiguration(
+type AssistantRequestBody =
+  PostOrPatchAgentConfigurationRequestBody["assistant"];
+
+const agentYAMLConfigPatchSchema = agentYAMLConfigSchema.partial().extend({
+  agent: agentYAMLBasicInfoSchema.partial().optional(),
+  generation_settings: agentYAMLGenerationSettingsSchema.partial().optional(),
+});
+
+interface ResolvedEditors {
+  editors: AssistantRequestBody["editors"];
+  authorId: ModelId;
+}
+
+async function resolveYAMLActions(
   auth: Authenticator,
-  yamlConfig: AgentYAMLConfig,
-  agentConfigurationId?: string
-): Promise<ImportResult> {
-  const isSaveAgentConfigurationsEnabled =
-    await KillSwitchResource.isKillSwitchEnabled("save_agent_configurations");
-  if (isSaveAgentConfigurationsEnabled) {
+  toolset: AgentYAMLConfig["toolset"]
+): Promise<
+  Result<
+    {
+      actions: AssistantRequestBody["actions"];
+      skippedActions: SkippedAction[];
+    },
+    APIErrorWithStatusCode
+  >
+> {
+  const result = await AgentYAMLConverter.convertYAMLToolsetToAssistantActions(
+    auth,
+    toolset
+  );
+
+  if (result.isErr()) {
     return new Err({
       status_code: 400,
       api_error: {
-        type: "app_auth_error",
-        message:
-          "Saving agent configurations is temporarily disabled, try again later.",
+        type: "invalid_request_error",
+        message: `Error converting YAML actions: ${result.error.message}`,
       },
     });
   }
 
-  const editorEmails = yamlConfig.editors;
-  const fetchedEditors = await UserResource.listUserWithExactEmails(
-    auth.getNonNullableWorkspace(),
-    editorEmails
-  );
+  return new Ok(result.value);
+}
 
+function resolveEditorUsers(
+  auth: Authenticator,
+  editorUsers: UserResource[]
+): Result<ResolvedEditors, APIErrorWithStatusCode> {
   const uploadingUser = auth.user();
-  const editorUsers =
-    uploadingUser && !fetchedEditors.some((u) => u.id === uploadingUser.id)
-      ? [...fetchedEditors, uploadingUser]
-      : fetchedEditors;
+  const resolvedEditorUsers =
+    uploadingUser && !editorUsers.some((u) => u.id === uploadingUser.id)
+      ? [...editorUsers, uploadingUser]
+      : editorUsers;
 
-  if (editorUsers.length === 0) {
+  if (resolvedEditorUsers.length === 0) {
     return new Err({
       status_code: 400,
       api_error: {
@@ -69,32 +99,58 @@ async function importAgentConfiguration(
     });
   }
 
-  const authorModelId = editorUsers[0].id;
+  return new Ok({
+    editors: resolvedEditorUsers.map((user) => ({
+      sId: user.sId,
+    })),
+    authorId: resolvedEditorUsers[0].id,
+  });
+}
 
-  const mcpConfigurationsResult =
-    await AgentYAMLConverter.convertYAMLActionsToMCPConfigurations(
-      auth,
-      yamlConfig.toolset
-    );
+async function resolveEditorUsersFromEmails(
+  auth: Authenticator,
+  editorEmails: string[]
+): Promise<Result<ResolvedEditors, APIErrorWithStatusCode>> {
+  const fetchedEditors = await UserResource.listUserWithExactEmails(
+    auth.getNonNullableWorkspace(),
+    editorEmails
+  );
 
-  if (mcpConfigurationsResult.isErr()) {
+  return resolveEditorUsers(auth, fetchedEditors);
+}
+
+async function resolveEditorUsersFromAgentConfiguration(
+  auth: Authenticator,
+  agentConfiguration: ExportableAgentConfiguration
+): Promise<Result<ResolvedEditors, APIErrorWithStatusCode>> {
+  const editorsResult = await GroupResource.findEditorGroupForAgent(
+    auth,
+    agentConfiguration
+  );
+  if (editorsResult.isErr()) {
     return new Err({
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: `Error converting YAML actions: ${mcpConfigurationsResult.error.message}`,
+        message: `Unable to resolve existing agent editors: ${editorsResult.error.message}`,
       },
     });
   }
 
-  const { configurations: mcpConfigurations, skipped: skippedActions } =
-    mcpConfigurationsResult.value;
-
-  const tagNames = yamlConfig.tags.map((t) => t.name);
-  const resolvedTags = await TagResource.findByNames(auth, tagNames);
-  const missingTags = tagNames.filter(
-    (name) => !resolvedTags.some((t) => t.name === name)
+  return resolveEditorUsers(
+    auth,
+    await editorsResult.value.getActiveMembers(auth)
   );
+}
+
+async function resolveTags(
+  auth: Authenticator,
+  yamlTags: AgentYAMLConfig["tags"]
+): Promise<Result<AssistantRequestBody["tags"], APIErrorWithStatusCode>> {
+  const tagNames = yamlTags.map((t) => t.name);
+  const resolvedTags = await TagResource.findByNames(auth, tagNames);
+  const resolvedTagNames = new Set(resolvedTags.map((t) => t.name));
+  const missingTags = tagNames.filter((name) => !resolvedTagNames.has(name));
 
   if (missingTags.length > 0) {
     return new Err({
@@ -106,38 +162,46 @@ async function importAgentConfiguration(
     });
   }
 
-  const assistant = {
-    name: yamlConfig.agent.handle,
-    description: yamlConfig.agent.description,
-    instructions: yamlConfig.instructions,
-    pictureUrl: yamlConfig.agent.avatar_url ?? "",
-    status: "active" as const,
-    scope: yamlConfig.agent.scope,
-    model: {
-      modelId: yamlConfig.generation_settings.model_id,
-      providerId: yamlConfig.generation_settings.provider_id,
-      temperature: yamlConfig.generation_settings.temperature,
-      reasoningEffort: yamlConfig.generation_settings.reasoning_effort,
-      responseFormat: yamlConfig.generation_settings.response_format,
-    },
-    maxStepsPerRun: yamlConfig.agent.max_steps_per_run,
-    actions: mcpConfigurations,
-    templateId: null,
-    tags: resolvedTags.map((t) => t.toJSON()),
-    editors: editorUsers.map((user) => ({
-      sId: user.sId,
-    })),
-    skills: (yamlConfig.skills ?? []).map((skill) => ({
-      sId: skill.sId,
-    })),
-    additionalRequestedSpaceIds: [],
-  };
+  return new Ok(resolvedTags.map((t) => t.toJSON()));
+}
 
+async function ensureAgentConfigurationSavingEnabled(): Promise<
+  Result<void, APIErrorWithStatusCode>
+> {
+  const isSaveAgentConfigurationsDisabled =
+    await KillSwitchResource.isKillSwitchEnabled("save_agent_configurations");
+  if (isSaveAgentConfigurationsDisabled) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "app_auth_error",
+        message:
+          "Saving agent configurations is temporarily disabled, try again later.",
+      },
+    });
+  }
+
+  return new Ok(undefined);
+}
+
+async function saveAgentConfigurationFromAssistant({
+  auth,
+  assistant,
+  skippedActions,
+  authorId,
+  agentConfigurationId,
+}: {
+  auth: Authenticator;
+  assistant: AssistantRequestBody;
+  skippedActions: SkippedAction[];
+  authorId: ModelId;
+  agentConfigurationId?: string;
+}): Promise<ImportResult> {
   const agentConfigurationRes = await createOrUpgradeAgentConfiguration({
     auth,
     assistant,
     agentConfigurationId,
-    authorId: authorModelId,
+    authorId,
   });
 
   if (agentConfigurationRes.isErr()) {
@@ -152,10 +216,62 @@ async function importAgentConfiguration(
 
   return new Ok({
     agentConfiguration: agentConfigurationRes.value,
-    skippedActions: skippedActions.map(({ action, reason }) => ({
-      name: action.name ?? "",
-      reason,
-    })),
+    skippedActions,
+  });
+}
+
+async function importAgentConfiguration(
+  auth: Authenticator,
+  yamlConfig: AgentYAMLConfig,
+  agentConfigurationId?: string
+): Promise<ImportResult> {
+  const saveEnabledResult = await ensureAgentConfigurationSavingEnabled();
+  if (saveEnabledResult.isErr()) {
+    return saveEnabledResult;
+  }
+
+  const actionsResult = await resolveYAMLActions(auth, yamlConfig.toolset);
+  if (actionsResult.isErr()) {
+    return actionsResult;
+  }
+
+  const editorsResult = await resolveEditorUsersFromEmails(
+    auth,
+    yamlConfig.editors
+  );
+  if (editorsResult.isErr()) {
+    return editorsResult;
+  }
+
+  const tagsResult = await resolveTags(auth, yamlConfig.tags);
+  if (tagsResult.isErr()) {
+    return tagsResult;
+  }
+
+  return saveAgentConfigurationFromAssistant({
+    auth,
+    assistant: {
+      name: yamlConfig.agent.handle,
+      description: yamlConfig.agent.description,
+      instructions: yamlConfig.instructions,
+      pictureUrl: yamlConfig.agent.avatar_url ?? "",
+      status: "active",
+      scope: yamlConfig.agent.scope,
+      model: AgentYAMLConverter.generationSettingsToModel(
+        yamlConfig.generation_settings
+      ),
+      actions: actionsResult.value.actions,
+      templateId: null,
+      tags: tagsResult.value,
+      editors: editorsResult.value.editors,
+      skills: (yamlConfig.skills ?? []).map((skill) => ({
+        sId: skill.sId,
+      })),
+      additionalRequestedSpaceIds: [],
+    },
+    skippedActions: actionsResult.value.skippedActions,
+    authorId: editorsResult.value.authorId,
+    agentConfigurationId,
   });
 }
 
@@ -195,11 +311,6 @@ export async function importAgentConfigurationFromJSON(
   return importAgentConfiguration(auth, parsed.data);
 }
 
-const agentYAMLConfigPatchSchema = agentYAMLConfigSchema.partial().extend({
-  agent: agentYAMLBasicInfoSchema.partial().optional(),
-  generation_settings: agentYAMLGenerationSettingsSchema.partial().optional(),
-});
-
 export async function patchAgentConfigurationFromJSON(
   auth: Authenticator,
   agentId: string,
@@ -216,24 +327,130 @@ export async function patchAgentConfigurationFromJSON(
     });
   }
 
-  const patch = parsed.data;
-
-  const existingResult = await getAgentConfigurationAsYAMLConfig(auth, agentId);
-  if (existingResult.isErr()) {
-    return existingResult;
+  const saveEnabledResult = await ensureAgentConfigurationSavingEnabled();
+  if (saveEnabledResult.isErr()) {
+    return saveEnabledResult;
   }
 
-  const existing = existingResult.value;
+  const agentResult = await getAgentConfigurationForExport(auth, agentId);
+  if (agentResult.isErr()) {
+    return agentResult;
+  }
 
-  const merged: AgentYAMLConfig = {
-    ...existing,
-    ...patch,
-    agent: { ...existing.agent, ...patch.agent },
-    generation_settings: {
-      ...existing.generation_settings,
-      ...patch.generation_settings,
-    },
+  const agentConfiguration = agentResult.value;
+  const actions =
+    AgentYAMLConverter.agentConfigurationActionsToAssistantActions(
+      agentConfiguration.actions
+    );
+
+  const editorsResult = await resolveEditorUsersFromAgentConfiguration(
+    auth,
+    agentConfiguration
+  );
+  if (editorsResult.isErr()) {
+    return editorsResult;
+  }
+
+  const skills = await SkillResource.listByAgentConfiguration(
+    auth,
+    agentConfiguration
+  );
+  const patch = parsed.data;
+  const assistant: AssistantRequestBody = {
+    name: agentConfiguration.name,
+    description: agentConfiguration.description,
+    instructions: agentConfiguration.instructions,
+    instructionsHtml: agentConfiguration.instructionsHtml,
+    pictureUrl: agentConfiguration.pictureUrl,
+    status: agentConfiguration.status,
+    scope: agentConfiguration.scope,
+    model: agentConfiguration.model,
+    actions,
+    templateId: agentConfiguration.templateId,
+    tags: agentConfiguration.tags,
+    editors: editorsResult.value.editors,
+    skills: skills.map((skill) => ({
+      sId: skill.sId,
+    })),
+    additionalRequestedSpaceIds: agentConfiguration.requestedSpaceIds,
   };
+  let authorId = editorsResult.value.authorId;
+  let skippedActions: SkippedAction[] = [];
 
-  return importAgentConfiguration(auth, merged, agentId);
+  if (patch.agent) {
+    if (patch.agent.handle !== undefined) {
+      assistant.name = patch.agent.handle;
+    }
+    if (patch.agent.description !== undefined) {
+      assistant.description = patch.agent.description;
+    }
+    if (patch.agent.avatar_url !== undefined) {
+      assistant.pictureUrl = patch.agent.avatar_url;
+    }
+    if (patch.agent.scope !== undefined) {
+      assistant.scope = patch.agent.scope;
+    }
+  }
+
+  if (patch.instructions !== undefined) {
+    assistant.instructions = patch.instructions;
+    assistant.instructionsHtml = null;
+  }
+
+  assistant.model = AgentYAMLConverter.mergeGenerationSettingsPatch(
+    assistant.model,
+    patch.generation_settings
+  );
+
+  if (patch.tags !== undefined) {
+    const tagsResult = await resolveTags(auth, patch.tags);
+    if (tagsResult.isErr()) {
+      return tagsResult;
+    }
+    assistant.tags = tagsResult.value;
+  }
+
+  if (patch.editors !== undefined) {
+    const patchEditorsResult = await resolveEditorUsersFromEmails(
+      auth,
+      patch.editors
+    );
+    if (patchEditorsResult.isErr()) {
+      return patchEditorsResult;
+    }
+    assistant.editors = patchEditorsResult.value.editors;
+    authorId = patchEditorsResult.value.authorId;
+  }
+
+  if (patch.toolset !== undefined) {
+    const patchActionsResult = await resolveYAMLActions(auth, patch.toolset);
+    if (patchActionsResult.isErr()) {
+      return patchActionsResult;
+    }
+    assistant.actions = patchActionsResult.value.actions;
+    skippedActions = patchActionsResult.value.skippedActions;
+  }
+
+  if (patch.skills !== undefined) {
+    assistant.skills = patch.skills.map((skill) => ({
+      sId: skill.sId,
+    }));
+  }
+
+  if (
+    patch.spaces !== undefined ||
+    patch.toolset !== undefined ||
+    patch.skills !== undefined
+  ) {
+    assistant.additionalRequestedSpaceIds =
+      patch.spaces?.map((space) => space.space_id) ?? [];
+  }
+
+  return saveAgentConfigurationFromAssistant({
+    auth,
+    assistant,
+    skippedActions,
+    authorId,
+    agentConfigurationId: agentId,
+  });
 }

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -14,7 +14,7 @@ import { TagResource } from "@app/lib/resources/tags_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { PostOrPatchAgentConfigurationRequestBody } from "@app/types/api/internal/agent_configuration";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
-import type { APIErrorWithStatusCode } from "@app/types/error";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -29,7 +29,7 @@ type ImportResult = Result<
     agentConfiguration: AgentConfigurationType;
     skippedActions: SkippedAction[];
   },
-  APIErrorWithStatusCode
+  APIErrorWithContentfulStatusCode
 >;
 
 type PatchRequestBody = PostOrPatchAgentConfigurationRequestBody["assistant"];
@@ -47,7 +47,7 @@ const agentYAMLConfigPatchSchema = agentYAMLConfigSchema.partial().extend({
 function resolveEditorUsers(
   auth: Authenticator,
   editorUsers: UserResource[]
-): Result<ResolvedEditors, APIErrorWithStatusCode> {
+): Result<ResolvedEditors, APIErrorWithContentfulStatusCode> {
   const uploadingUser = auth.user();
   const resolvedEditorUsers =
     uploadingUser && !editorUsers.some((u) => u.id === uploadingUser.id)
@@ -75,7 +75,7 @@ function resolveEditorUsers(
 async function resolveEditorUsersFromEmails(
   auth: Authenticator,
   editorEmails: string[]
-): Promise<Result<ResolvedEditors, APIErrorWithStatusCode>> {
+): Promise<Result<ResolvedEditors, APIErrorWithContentfulStatusCode>> {
   const fetchedEditors = await UserResource.listUserWithExactEmails(
     auth.getNonNullableWorkspace(),
     editorEmails
@@ -87,7 +87,7 @@ async function resolveEditorUsersFromEmails(
 async function resolveTags(
   auth: Authenticator,
   yamlTags: AgentYAMLConfig["tags"]
-): Promise<Result<PatchRequestBody["tags"], APIErrorWithStatusCode>> {
+): Promise<Result<PatchRequestBody["tags"], APIErrorWithContentfulStatusCode>> {
   const tagNames = yamlTags.map((t) => t.name);
   const resolvedTags = await TagResource.findByNames(auth, tagNames);
   const resolvedTagNames = new Set(resolvedTags.map((t) => t.name));
@@ -107,7 +107,7 @@ async function resolveTags(
 }
 
 async function ensureAgentConfigurationSavingEnabled(): Promise<
-  Result<void, APIErrorWithStatusCode>
+  Result<void, APIErrorWithContentfulStatusCode>
 > {
   const isSaveAgentConfigurationsDisabled =
     await KillSwitchResource.isKillSwitchEnabled("save_agent_configurations");

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -1,3 +1,4 @@
+import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import { AgentYAMLConverter } from "@app/lib/agent_yaml_converter/converter";
 import type { AgentYAMLConfig } from "@app/lib/agent_yaml_converter/schemas";
 import {
@@ -257,9 +258,13 @@ async function importAgentConfiguration(
       pictureUrl: yamlConfig.agent.avatar_url ?? "",
       status: "active",
       scope: yamlConfig.agent.scope,
-      model: AgentYAMLConverter.generationSettingsToModel(
-        yamlConfig.generation_settings
-      ),
+      model: {
+        modelId: yamlConfig.generation_settings.model_id,
+        providerId: yamlConfig.generation_settings.provider_id,
+        temperature: yamlConfig.generation_settings.temperature,
+        reasoningEffort: yamlConfig.generation_settings.reasoning_effort,
+        responseFormat: yamlConfig.generation_settings.response_format,
+      },
       actions: actionsResult.value.actions,
       templateId: null,
       tags: tagsResult.value,
@@ -338,9 +343,38 @@ export async function patchAgentConfigurationFromJSON(
   }
 
   const agentConfiguration = agentResult.value;
-  const actions =
-    AgentYAMLConverter.agentConfigurationActionsToAssistantActions(
-      agentConfiguration.actions
+  const actions: AssistantRequestBody["actions"] = agentConfiguration.actions
+    .filter(isServerSideMCPServerConfiguration)
+    .map(
+      ({
+        additionalConfiguration,
+        childAgentId,
+        dataSources,
+        description,
+        dustAppConfiguration,
+        dustProject,
+        jsonSchema,
+        mcpServerViewId,
+        name,
+        secretName,
+        tables,
+        timeFrame,
+        type,
+      }) => ({
+        additionalConfiguration,
+        childAgentId,
+        dataSources,
+        description,
+        dustAppConfiguration,
+        dustProject,
+        jsonSchema,
+        mcpServerViewId,
+        name,
+        secretName,
+        tables,
+        timeFrame,
+        type,
+      })
     );
 
   const editorsResult = await resolveEditorUsersFromAgentConfiguration(
@@ -397,10 +431,21 @@ export async function patchAgentConfigurationFromJSON(
     assistant.instructionsHtml = null;
   }
 
-  assistant.model = AgentYAMLConverter.mergeGenerationSettingsPatch(
-    assistant.model,
-    patch.generation_settings
-  );
+  const {
+    model_id = assistant.model.modelId,
+    provider_id = assistant.model.providerId,
+    reasoning_effort = assistant.model.reasoningEffort,
+    response_format = assistant.model.responseFormat,
+    temperature = assistant.model.temperature,
+  } = patch.generation_settings ?? {};
+  assistant.model = {
+    ...assistant.model,
+    modelId: model_id,
+    providerId: provider_id,
+    temperature,
+    reasoningEffort: reasoning_effort,
+    responseFormat: response_format,
+  };
 
   if (patch.tags !== undefined) {
     const tagsResult = await resolveTags(auth, patch.tags);

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -39,10 +39,10 @@ const agentYAMLConfigPatchSchema = agentYAMLConfigSchema.partial().extend({
   generation_settings: agentYAMLGenerationSettingsSchema.partial().optional(),
 });
 
-interface ResolvedEditors {
+type ResolvedEditors = {
   editors: PatchRequestBody["editors"];
-  authorId: ModelId;
-}
+  authorModelId: ModelId;
+};
 
 function resolveEditorUsers(
   auth: Authenticator,
@@ -68,7 +68,7 @@ function resolveEditorUsers(
     editors: resolvedEditorUsers.map((user) => ({
       sId: user.sId,
     })),
-    authorId: resolvedEditorUsers[0].id,
+    authorModelId: resolvedEditorUsers[0].id,
   });
 }
 
@@ -129,20 +129,20 @@ async function saveAgentConfigurationFromAssistant({
   auth,
   assistant,
   skippedActions,
-  authorId,
+  authorModelId,
   agentConfigurationId,
 }: {
   auth: Authenticator;
   assistant: PatchRequestBody;
   skippedActions: SkippedAction[];
-  authorId: ModelId;
+  authorModelId: ModelId;
   agentConfigurationId?: string;
 }): Promise<ImportResult> {
   const agentConfigurationRes = await createOrUpgradeAgentConfiguration({
     auth,
     assistant,
     agentConfigurationId,
-    authorId,
+    authorId: authorModelId,
   });
 
   if (agentConfigurationRes.isErr()) {
@@ -228,7 +228,7 @@ async function importAgentConfiguration(
       name: action.name ?? "",
       reason,
     })),
-    authorId: editorsResult.value.authorId,
+    authorModelId: editorsResult.value.authorModelId,
     agentConfigurationId,
   });
 }
@@ -324,7 +324,7 @@ export async function patchAgentConfigurationFromJSON(
     })),
     additionalRequestedSpaceIds: agentConfiguration.requestedSpaceIds,
   };
-  let authorId = editorsResult.value.authorId;
+  let authorModelId = editorsResult.value.authorModelId;
   let skippedActions: SkippedAction[] = [];
 
   if (patch.agent) {
@@ -380,7 +380,7 @@ export async function patchAgentConfigurationFromJSON(
       return patchEditorsResult;
     }
     assistant.editors = patchEditorsResult.value.editors;
-    authorId = patchEditorsResult.value.authorId;
+    authorModelId = patchEditorsResult.value.authorModelId;
   }
 
   if (patch.toolset) {
@@ -422,7 +422,7 @@ export async function patchAgentConfigurationFromJSON(
     auth,
     assistant,
     skippedActions,
-    authorId,
+    authorModelId,
     agentConfigurationId: agentId,
   });
 }

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -363,7 +363,7 @@ export async function patchAgentConfigurationFromJSON(
     responseFormat: response_format,
   };
 
-  if (patch.tags !== undefined) {
+  if (patch.tags) {
     const tagsResult = await resolveTags(auth, patch.tags);
     if (tagsResult.isErr()) {
       return tagsResult;
@@ -371,7 +371,7 @@ export async function patchAgentConfigurationFromJSON(
     assistant.tags = tagsResult.value;
   }
 
-  if (patch.editors !== undefined) {
+  if (patch.editors) {
     const patchEditorsResult = await resolveEditorUsersFromEmails(
       auth,
       patch.editors
@@ -383,7 +383,7 @@ export async function patchAgentConfigurationFromJSON(
     authorId = patchEditorsResult.value.authorId;
   }
 
-  if (patch.toolset !== undefined) {
+  if (patch.toolset) {
     const patchActionsResult =
       await AgentYAMLConverter.convertYAMLActionsToMCPConfigurations(
         auth,

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -328,21 +328,21 @@ export async function patchAgentConfigurationFromJSON(
   let skippedActions: SkippedAction[] = [];
 
   if (patch.agent) {
-    if (patch.agent.handle) {
+    if (patch.agent.handle !== undefined) {
       assistant.name = patch.agent.handle;
     }
-    if (patch.agent.description) {
+    if (patch.agent.description !== undefined) {
       assistant.description = patch.agent.description;
     }
-    if (patch.agent.avatar_url) {
+    if (patch.agent.avatar_url !== undefined) {
       assistant.pictureUrl = patch.agent.avatar_url;
     }
-    if (patch.agent.scope) {
+    if (patch.agent.scope !== undefined) {
       assistant.scope = patch.agent.scope;
     }
   }
 
-  if (patch.instructions) {
+  if (patch.instructions !== undefined) {
     assistant.instructions = patch.instructions;
     assistant.instructionsHtml = null;
   }
@@ -407,13 +407,17 @@ export async function patchAgentConfigurationFromJSON(
     );
   }
 
-  if (patch.skills) {
+  if (patch.skills !== undefined) {
     assistant.skills = patch.skills.map((skill) => ({
       sId: skill.sId,
     }));
   }
 
-  if (patch.spaces || patch.toolset || patch.skills) {
+  if (
+    patch.spaces !== undefined ||
+    patch.toolset !== undefined ||
+    patch.skills !== undefined
+  ) {
     assistant.additionalRequestedSpaceIds =
       patch.spaces?.map((space) => space.space_id) ?? [];
   }

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -344,38 +344,7 @@ export async function patchAgentConfigurationFromJSON(
 
   const agentConfiguration = agentResult.value;
   const actions: AssistantRequestBody["actions"] = agentConfiguration.actions
-    .filter(isServerSideMCPServerConfiguration)
-    .map(
-      ({
-        additionalConfiguration,
-        childAgentId,
-        dataSources,
-        description,
-        dustAppConfiguration,
-        dustProject,
-        jsonSchema,
-        mcpServerViewId,
-        name,
-        secretName,
-        tables,
-        timeFrame,
-        type,
-      }) => ({
-        additionalConfiguration,
-        childAgentId,
-        dataSources,
-        description,
-        dustAppConfiguration,
-        dustProject,
-        jsonSchema,
-        mcpServerViewId,
-        name,
-        secretName,
-        tables,
-        timeFrame,
-        type,
-      })
-    );
+    .filter(isServerSideMCPServerConfiguration);
 
   const editorsResult = await resolveEditorUsersFromAgentConfiguration(
     auth,

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -50,36 +50,6 @@ interface ResolvedEditors {
   authorId: ModelId;
 }
 
-async function resolveYAMLActions(
-  auth: Authenticator,
-  toolset: AgentYAMLConfig["toolset"]
-): Promise<
-  Result<
-    {
-      actions: AssistantRequestBody["actions"];
-      skippedActions: SkippedAction[];
-    },
-    APIErrorWithStatusCode
-  >
-> {
-  const result = await AgentYAMLConverter.convertYAMLToolsetToAssistantActions(
-    auth,
-    toolset
-  );
-
-  if (result.isErr()) {
-    return new Err({
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: `Error converting YAML actions: ${result.error.message}`,
-      },
-    });
-  }
-
-  return new Ok(result.value);
-}
-
 function resolveEditorUsers(
   auth: Authenticator,
   editorUsers: UserResource[]
@@ -231,9 +201,19 @@ async function importAgentConfiguration(
     return saveEnabledResult;
   }
 
-  const actionsResult = await resolveYAMLActions(auth, yamlConfig.toolset);
+  const actionsResult =
+    await AgentYAMLConverter.convertYAMLToolsetToAssistantActions(
+      auth,
+      yamlConfig.toolset
+    );
   if (actionsResult.isErr()) {
-    return actionsResult;
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Error converting YAML actions: ${actionsResult.error.message}`,
+      },
+    });
   }
 
   const editorsResult = await resolveEditorUsersFromEmails(
@@ -343,8 +323,8 @@ export async function patchAgentConfigurationFromJSON(
   }
 
   const agentConfiguration = agentResult.value;
-  const actions: AssistantRequestBody["actions"] = agentConfiguration.actions
-    .filter(isServerSideMCPServerConfiguration);
+  const actions: AssistantRequestBody["actions"] =
+    agentConfiguration.actions.filter(isServerSideMCPServerConfiguration);
 
   const editorsResult = await resolveEditorUsersFromAgentConfiguration(
     auth,
@@ -437,9 +417,19 @@ export async function patchAgentConfigurationFromJSON(
   }
 
   if (patch.toolset !== undefined) {
-    const patchActionsResult = await resolveYAMLActions(auth, patch.toolset);
+    const patchActionsResult =
+      await AgentYAMLConverter.convertYAMLToolsetToAssistantActions(
+        auth,
+        patch.toolset
+      );
     if (patchActionsResult.isErr()) {
-      return patchActionsResult;
+      return new Err({
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `Error converting YAML actions: ${patchActionsResult.error.message}`,
+        },
+      });
     }
     assistant.actions = patchActionsResult.value.actions;
     skippedActions = patchActionsResult.value.skippedActions;

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -37,7 +37,7 @@ type ImportResult = Result<
   APIErrorWithStatusCode
 >;
 
-type AssistantRequestBody =
+type PatchRequestBody =
   PostOrPatchAgentConfigurationRequestBody["assistant"];
 
 const agentYAMLConfigPatchSchema = agentYAMLConfigSchema.partial().extend({
@@ -46,7 +46,7 @@ const agentYAMLConfigPatchSchema = agentYAMLConfigSchema.partial().extend({
 });
 
 interface ResolvedEditors {
-  editors: AssistantRequestBody["editors"];
+  editors: PatchRequestBody["editors"];
   authorId: ModelId;
 }
 
@@ -117,7 +117,7 @@ async function resolveEditorUsersFromAgentConfiguration(
 async function resolveTags(
   auth: Authenticator,
   yamlTags: AgentYAMLConfig["tags"]
-): Promise<Result<AssistantRequestBody["tags"], APIErrorWithStatusCode>> {
+): Promise<Result<PatchRequestBody["tags"], APIErrorWithStatusCode>> {
   const tagNames = yamlTags.map((t) => t.name);
   const resolvedTags = await TagResource.findByNames(auth, tagNames);
   const resolvedTagNames = new Set(resolvedTags.map((t) => t.name));
@@ -163,7 +163,7 @@ async function saveAgentConfigurationFromAssistant({
   agentConfigurationId,
 }: {
   auth: Authenticator;
-  assistant: AssistantRequestBody;
+  assistant: PatchRequestBody;
   skippedActions: SkippedAction[];
   authorId: ModelId;
   agentConfigurationId?: string;
@@ -323,8 +323,6 @@ export async function patchAgentConfigurationFromJSON(
   }
 
   const agentConfiguration = agentResult.value;
-  const actions: AssistantRequestBody["actions"] =
-    agentConfiguration.actions.filter(isServerSideMCPServerConfiguration);
 
   const editorsResult = await resolveEditorUsersFromAgentConfiguration(
     auth,
@@ -339,7 +337,7 @@ export async function patchAgentConfigurationFromJSON(
     agentConfiguration
   );
   const patch = parsed.data;
-  const assistant: AssistantRequestBody = {
+  const assistant: PatchRequestBody = {
     name: agentConfiguration.name,
     description: agentConfiguration.description,
     instructions: agentConfiguration.instructions,
@@ -348,7 +346,7 @@ export async function patchAgentConfigurationFromJSON(
     status: agentConfiguration.status,
     scope: agentConfiguration.scope,
     model: agentConfiguration.model,
-    actions,
+    actions: agentConfiguration.actions.filter(isServerSideMCPServerConfiguration),
     templateId: agentConfiguration.templateId,
     tags: agentConfiguration.tags,
     editors: editorsResult.value.editors,
@@ -361,21 +359,21 @@ export async function patchAgentConfigurationFromJSON(
   let skippedActions: SkippedAction[] = [];
 
   if (patch.agent) {
-    if (patch.agent.handle !== undefined) {
+    if (patch.agent.handle) {
       assistant.name = patch.agent.handle;
     }
-    if (patch.agent.description !== undefined) {
+    if (patch.agent.description) {
       assistant.description = patch.agent.description;
     }
-    if (patch.agent.avatar_url !== undefined) {
+    if (patch.agent.avatar_url) {
       assistant.pictureUrl = patch.agent.avatar_url;
     }
-    if (patch.agent.scope !== undefined) {
+    if (patch.agent.scope) {
       assistant.scope = patch.agent.scope;
     }
   }
 
-  if (patch.instructions !== undefined) {
+  if (patch.instructions) {
     assistant.instructions = patch.instructions;
     assistant.instructionsHtml = null;
   }
@@ -435,16 +433,16 @@ export async function patchAgentConfigurationFromJSON(
     skippedActions = patchActionsResult.value.skippedActions;
   }
 
-  if (patch.skills !== undefined) {
+  if (patch.skills) {
     assistant.skills = patch.skills.map((skill) => ({
       sId: skill.sId,
     }));
   }
 
   if (
-    patch.spaces !== undefined ||
-    patch.toolset !== undefined ||
-    patch.skills !== undefined
+    patch.spaces ||
+    patch.toolset ||
+    patch.skills
   ) {
     assistant.additionalRequestedSpaceIds =
       patch.spaces?.map((space) => space.space_id) ?? [];

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -34,15 +34,16 @@ type ImportResult = Result<
 
 type PatchRequestBody = PostOrPatchAgentConfigurationRequestBody["assistant"];
 
+type ResolvedEditors = {
+  editors: PatchRequestBody["editors"];
+  authorModelId: ModelId;
+};
+
 const agentYAMLConfigPatchSchema = agentYAMLConfigSchema.partial().extend({
   agent: agentYAMLBasicInfoSchema.partial().optional(),
   generation_settings: agentYAMLGenerationSettingsSchema.partial().optional(),
 });
 
-type ResolvedEditors = {
-  editors: PatchRequestBody["editors"];
-  authorModelId: ModelId;
-};
 
 function resolveEditorUsers(
   auth: Authenticator,

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -44,7 +44,6 @@ const agentYAMLConfigPatchSchema = agentYAMLConfigSchema.partial().extend({
   generation_settings: agentYAMLGenerationSettingsSchema.partial().optional(),
 });
 
-
 function resolveEditorUsers(
   auth: Authenticator,
   editorUsers: UserResource[]


### PR DESCRIPTION
## Description

- Fixes https://github.com/dust-tt/tasks/issues/7989
- Simplifies YAML PATCH imports by building the assistant request body directly from the existing agent
configuration, instead of round-tripping through YAML form data.
- Preserves existing agent state for metadata-only patches, including template, editors, tags, skills, actions,
instructions HTML, and requested spaces.
- Recomputes requested spaces when patching capabilities through `toolset`, `skills`, or explicit `spaces`.
- Splits agent export lookup from YAML conversion so import can reuse the typed exportable agent configuration
directly.

## Tests

- Added some tests.

## Risk

- Low: scoped to YAML agent import/export paths.

## Deploy Plan

- Deploy front

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/dust-tt/dust/pull/25912">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->