### PR TITLE
[metronome] fix: drop seatType gate in dispatchPerUserCap* and transition all seat types

### DIFF
--- a/front/lib/api/metronome/credit_state_dispatcher.test.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.test.ts
@@ -1,0 +1,84 @@
+import { transitionUserCreditState } from "@app/lib/metronome/user_credit_state_machine";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  dispatchPerUserCapReached,
+  dispatchPerUserCapResolved,
+} from "./credit_state_dispatcher";
+
+vi.mock("@app/lib/metronome/user_credit_state_machine", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/user_credit_state_machine")
+  >("@app/lib/metronome/user_credit_state_machine");
+  return {
+    ...actual,
+    transitionUserCreditState: vi.fn(),
+  };
+});
+
+const TEST_METRONOME_CUSTOMER_ID = "cust_test_xxx";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(transitionUserCreditState).mockResolvedValue(new Ok("normal"));
+});
+
+describe("credit_state_dispatcher per-user caps", () => {
+  it("dispatchPerUserCapReached transitions any seat type", async () => {
+    const workspaceType = await WorkspaceFactory.metronome({
+      metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
+    });
+    const workspace = await WorkspaceResource.fetchById(workspaceType.sId);
+    expect(workspace).not.toBeNull();
+    if (!workspace) {
+      throw new Error("Workspace not found");
+    }
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspaceType, user, {
+      role: "user",
+      seatType: "pro",
+    });
+
+    await dispatchPerUserCapReached({
+      workspace,
+      userId: user.sId,
+    });
+
+    expect(transitionUserCreditState).toHaveBeenCalledWith(
+      expect.objectContaining({ seatType: "pro", creditState: "normal" }),
+      { type: "per_user_cap_reached" },
+      { workspaceId: workspaceType.sId, userId: user.sId }
+    );
+  });
+
+  it("dispatchPerUserCapResolved transitions any seat type", async () => {
+    const workspaceType = await WorkspaceFactory.metronome({
+      metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
+    });
+    const workspace = await WorkspaceResource.fetchById(workspaceType.sId);
+    expect(workspace).not.toBeNull();
+    if (!workspace) {
+      throw new Error("Workspace not found");
+    }
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspaceType, user, {
+      role: "user",
+      seatType: "max",
+    });
+
+    await dispatchPerUserCapResolved({
+      workspace,
+      userId: user.sId,
+    });
+
+    expect(transitionUserCreditState).toHaveBeenCalledWith(
+      expect.objectContaining({ seatType: "max", creditState: "normal" }),
+      { type: "per_user_cap_resolved" },
+      { workspaceId: workspaceType.sId, userId: user.sId }
+    );
+  });
+});

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -1,9 +1,6 @@
 import { Authenticator } from "@app/lib/auth";
 import { isPAYGEnabled } from "@app/lib/credits/payg";
-import {
-  clearUserCapBlocked,
-  setUserCapBlocked,
-} from "@app/lib/metronome/user_block";
+import { clearUserCapBlocked } from "@app/lib/metronome/user_block";
 import { transitionUserCreditState } from "@app/lib/metronome/user_credit_state_machine";
 import type { WorkspaceCreditEvent } from "@app/lib/metronome/workspace_credit_state_machine";
 import { transitionWorkspaceCreditState } from "@app/lib/metronome/workspace_credit_state_machine";
@@ -48,11 +45,6 @@ export async function dispatchPerUserCapReached({
     return;
   }
 
-  if (membership.seatType !== "workspace") {
-    await setUserCapBlocked(workspace.sId, userId);
-    return;
-  }
-
   await transitionUserCreditState(
     membership,
     { type: "per_user_cap_reached" },
@@ -89,11 +81,6 @@ export async function dispatchPerUserCapResolved({
       { workspaceId: workspace.sId, userId },
       "[CreditStateDispatcher] per_user_cap_resolved: no active membership, clearing legacy block"
     );
-    await clearUserCapBlocked(workspace.sId, userId);
-    return;
-  }
-
-  if (membership.seatType !== "workspace") {
     await clearUserCapBlocked(workspace.sId, userId);
     return;
   }

--- a/front/tests/utils/MembershipFactory.ts
+++ b/front/tests/utils/MembershipFactory.ts
@@ -3,6 +3,7 @@ import type { UserResource } from "@app/lib/resources/user_resource";
 import type {
   MembershipOriginType,
   MembershipRoleType,
+  MembershipSeatType,
 } from "@app/types/memberships";
 import type { WorkspaceType } from "@app/types/user";
 import type { Transaction } from "sequelize";
@@ -14,9 +15,11 @@ export class MembershipFactory {
     {
       role,
       origin = "invited",
+      seatType,
     }: {
       role: MembershipRoleType;
       origin?: MembershipOriginType;
+      seatType?: MembershipSeatType;
     },
     t?: Transaction
   ) {
@@ -25,6 +28,7 @@ export class MembershipFactory {
       user,
       role,
       origin,
+      seatType,
       transaction: t,
     });
   }

--- a/front/tests/utils/WorkspaceFactory.ts
+++ b/front/tests/utils/WorkspaceFactory.ts
@@ -16,6 +16,7 @@ import { expect } from "vitest";
 
 interface WorkspaceOverrides {
   whiteListedProviders?: ModelProviderIdType[] | null;
+  metronomeCustomerId?: string | null;
 }
 
 export class WorkspaceFactory {
@@ -53,6 +54,7 @@ export class WorkspaceFactory {
       name: faker.company.name(),
       description: workspaceDescription,
       workOSOrganizationId: faker.string.alpha(10),
+      metronomeCustomerId: overrides?.metronomeCustomerId ?? null,
       ...(overrides?.whiteListedProviders !== undefined && {
         whiteListedProviders: overrides.whiteListedProviders,
       }),


### PR DESCRIPTION
## Description

Previously, dispatchPerUserCapReached / dispatchPerUserCapResolved only ran transitionUserCreditState for "workspace" seats and short-circuited to the Redis-only setUserCapBlocked / clearUserCapBlocked path for pro/max. That left the DB membership.creditState unchanged for those users, so the cache could drift from the source of truth.

Run the state machine for every seat type. Extend MembershipFactory with a seatType option and WorkspaceFactory with a metronomeCustomerId override so the new dispatcher test can exercise non-workspace seats.

## Tests

Unit + local

## Risk

low
## Deploy Plan

front