### PR TITLE
[Metronome] feat: per-user spend-limit endpoint and Metronome alert plumbing

### DIFF
--- a/front-api/routes/metronome/webhook.ts
+++ b/front-api/routes/metronome/webhook.ts
@@ -141,7 +141,28 @@ app.post("/", async (ctx) => {
           );
           break;
         }
-        await dispatchPerUserCapReached({ workspace, userId });
+        const dispatchResult = await dispatchPerUserCapReached({
+          workspace,
+          userId,
+        });
+        if (dispatchResult.isErr()) {
+          logger.error(
+            {
+              eventId: event.id,
+              workspaceId: workspace.sId,
+              userId,
+              err: dispatchResult.error,
+            },
+            "[Metronome Webhook] spend_threshold_reached: per_user dispatch failed"
+          );
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: `Error dispatching per-user cap reached: ${dispatchResult.error.message}`,
+            },
+          });
+        }
         logger.info(
           {
             eventId: event.id,
@@ -180,7 +201,28 @@ app.post("/", async (ctx) => {
           break;
         }
 
-        await dispatchPerUserCapResolved({ workspace, userId });
+        const dispatchResult = await dispatchPerUserCapResolved({
+          workspace,
+          userId,
+        });
+        if (dispatchResult.isErr()) {
+          logger.error(
+            {
+              eventId: event.id,
+              workspaceId: workspace.sId,
+              userId,
+              err: dispatchResult.error,
+            },
+            "[Metronome Webhook] spend_threshold_resolved: per-user dispatch failed"
+          );
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: `Error dispatching per-user cap resolved: ${dispatchResult.error.message}`,
+            },
+          });
+        }
         logger.info(
           {
             eventId: event.id,

--- a/front-api/routes/w/[wId]/credits/members-usage.ts
+++ b/front-api/routes/w/[wId]/credits/members-usage.ts
@@ -1,138 +1,12 @@
+import type { GetMembersUsageResponseBody } from "@app/lib/api/credits/members_usage";
 import {
-  ceilToMidnightUTC,
-  floorToMidnightUTC,
-  listMetronomeDraftInvoices,
-  listMetronomeUsageWithGroups,
-} from "@app/lib/metronome/client";
-import { getMetricLlmProviderCostAwuId } from "@app/lib/metronome/constants";
-import { buildSeatDataByUserId } from "@app/lib/metronome/seats";
-import type { BillingFrequency } from "@app/lib/metronome/types";
-import {
-  MembershipResource,
-  type MembershipsPaginationParams,
-} from "@app/lib/resources/membership_resource";
-import type { MembershipSeatType } from "@app/types/memberships";
+  getMembersUsage,
+  MembersUsagePaginationSchema,
+} from "@app/lib/api/credits/members_usage";
 import type { HandlerResult } from "@front-api/middleware/utils";
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { Hono } from "hono";
-import { z } from "zod";
-
-export type MemberUsageType = {
-  sId: string;
-  name: string;
-  email: string | null;
-  image: string | null;
-  seatType: MembershipSeatType | null;
-  seatUsagePercent: number | null;
-  consumedWorkplacePoolCredits: number;
-  billingFrequency: BillingFrequency | null;
-};
-
-export type GetMembersUsageResponseBody = {
-  members: MemberUsageType[];
-  total: number;
-  nextPageUrl?: string;
-};
-
-export const DEFAULT_MEMBERS_USAGE_PAGE_LIMIT = 50;
-export const MAX_MEMBERS_USAGE_PAGE_LIMIT = 150;
-
-const MembersUsagePaginationSchema = z.object({
-  limit: z.coerce
-    .number()
-    .int()
-    .min(0)
-    .max(MAX_MEMBERS_USAGE_PAGE_LIMIT)
-    .catch(DEFAULT_MEMBERS_USAGE_PAGE_LIMIT),
-  orderColumn: z.literal("createdAt").catch("createdAt"),
-  orderDirection: z.enum(["asc", "desc"]).catch("desc"),
-  lastValue: z.coerce.number().optional().catch(undefined),
-});
-
-function buildUrlWithParams(
-  currentUrl: string,
-  newParams: MembershipsPaginationParams | undefined
-) {
-  if (!newParams) {
-    return undefined;
-  }
-  const url = new URL(currentUrl);
-  Object.entries(newParams).forEach(([key, value]) => {
-    if (value === null || value === undefined) {
-      url.searchParams.delete(key);
-    } else {
-      url.searchParams.set(key, value.toString());
-    }
-  });
-  return url.pathname + url.search;
-}
-
-async function fetchPerUserUsageCredits({
-  metronomeCustomerId,
-  metronomeContractId,
-}: {
-  metronomeCustomerId: string | null;
-  metronomeContractId: string | null;
-}): Promise<Map<string, number>> {
-  if (!metronomeCustomerId || !metronomeContractId) {
-    return new Map();
-  }
-
-  const invoicesResult = await listMetronomeDraftInvoices(metronomeCustomerId);
-  if (invoicesResult.isErr()) {
-    return new Map();
-  }
-
-  const now = Date.now();
-  const currentInvoice = invoicesResult.value.find((inv) => {
-    if (inv.contract_id !== metronomeContractId) {
-      return false;
-    }
-    if (!inv.start_timestamp || !inv.end_timestamp) {
-      return false;
-    }
-    const startMs = new Date(inv.start_timestamp).getTime();
-    const endMs = new Date(inv.end_timestamp).getTime();
-    return startMs <= now && now < endMs;
-  });
-
-  if (!currentInvoice?.start_timestamp || !currentInvoice.end_timestamp) {
-    return new Map();
-  }
-
-  const startingOn = floorToMidnightUTC(
-    new Date(currentInvoice.start_timestamp)
-  ).toISOString();
-  const endingBefore = ceilToMidnightUTC(
-    new Date(currentInvoice.end_timestamp)
-  ).toISOString();
-
-  const usageResult = await listMetronomeUsageWithGroups({
-    customerId: metronomeCustomerId,
-    billableMetricId: getMetricLlmProviderCostAwuId(),
-    startingOn,
-    endingBefore,
-    windowSize: "NONE",
-    groupKey: ["user_id", "usage_type"],
-  });
-
-  if (usageResult.isErr()) {
-    return new Map();
-  }
-
-  const perUser = new Map<string, number>();
-  for (const entry of usageResult.value) {
-    const userId = entry.group?.["user_id"];
-    const usageType = entry.group?.["usage_type"];
-    if (!userId || usageType !== "user" || entry.value === null) {
-      continue;
-    }
-    const existing = perUser.get(userId) ?? 0;
-    perUser.set(userId, existing + entry.value);
-  }
-  return perUser;
-}
 
 // Mounted at /api/w/:wId/credits/members-usage.
 const app = new Hono();
@@ -153,69 +27,12 @@ app.get(
       });
     }
 
-    const paginationParams = ctx.req.valid("query");
-    const workspace = auth.getNonNullableWorkspace();
-    const subscription = auth.subscription();
-    const { metronomeCustomerId } = workspace;
-    const metronomeContractId = subscription?.metronomeContractId ?? null;
-
-    const [membershipsResult, perUserTotalCredits, seatDataByUserId] =
-      await Promise.all([
-        MembershipResource.getActiveMemberships({
-          workspace,
-          paginationParams,
-        }),
-        fetchPerUserUsageCredits({
-          metronomeCustomerId: metronomeCustomerId ?? null,
-          metronomeContractId,
-        }),
-        metronomeCustomerId && metronomeContractId
-          ? buildSeatDataByUserId({
-              metronomeCustomerId,
-              contractId: metronomeContractId,
-            })
-          : Promise.resolve(new Map()),
-      ]);
-
-    const { memberships, total, nextPageParams } = membershipsResult;
-
-    const membersUsage: MemberUsageType[] = memberships.flatMap((m) => {
-      if (!m.user) {
-        return [];
-      }
-      const userId = m.user.sId;
-      const totalCredits = perUserTotalCredits.get(userId) ?? 0;
-      const seatData = seatDataByUserId.get(userId);
-      const awuAllocation = seatData?.awuAllocation ?? 0;
-
-      let seatUsagePercent: number | null = null;
-      let poolConsumedCredits = totalCredits;
-
-      if (awuAllocation > 0) {
-        const seatConsumed = Math.min(totalCredits, awuAllocation);
-        seatUsagePercent = (seatConsumed / awuAllocation) * 100;
-        poolConsumedCredits = Math.max(0, totalCredits - awuAllocation);
-      }
-
-      return [
-        {
-          sId: userId,
-          name: m.user.name,
-          email: m.user.email ?? null,
-          image: m.user.imageUrl ?? null,
-          seatType: m.seatType ?? null,
-          seatUsagePercent,
-          consumedWorkplacePoolCredits: poolConsumedCredits,
-          billingFrequency: seatData?.billingFrequency ?? null,
-        },
-      ];
+    const body = await getMembersUsage({
+      auth,
+      paginationParams: ctx.req.valid("query"),
+      currentUrl: ctx.req.url,
     });
-
-    return ctx.json({
-      members: membersUsage,
-      total,
-      nextPageUrl: buildUrlWithParams(ctx.req.url, nextPageParams),
-    });
+    return ctx.json(body);
   }
 );
 

--- a/front/admin/audit_log_schemas/member.spend_limit_updated.json
+++ b/front/admin/audit_log_schemas/member.spend_limit_updated.json
@@ -1,0 +1,15 @@
+{
+  "action": "member.spend_limit_updated",
+  "targets": [
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "user"
+    }
+  ],
+  "metadata": {
+    "kind": "string",
+    "awu_credits": "string"
+  }
+}

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -364,7 +364,7 @@ export function MembersUsageTable({
     image: m.image,
     seatType: m.seatType,
     seatUsagePercent: m.seatUsagePercent,
-    consumedWorkplacePoolCredits: m.consumedWorkplacePoolCredits,
+    consumedWorkplacePoolCredits: m.consumedAwuCredits,
     billingFrequency: m.billingFrequency,
     scheduledSeatType: m.scheduledSeatType,
     scheduledSeatChangeAt: m.scheduledSeatChangeAt,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -39,6 +39,7 @@ type AuditAction =
   | "invitation.role_updated"
   | "member.bulk_invited"
   | "member.bulk_revoked"
+  | "member.spend_limit_updated"
   // Domains & SSO.
   | "domain.verified"
   | "domain.verification_failed"

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1,4 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
+import { listMetronomePerUserCapsForWorkspace } from "@app/lib/metronome/per_user_alerts";
 import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
 import { buildSeatDataByUserId, type SeatData } from "@app/lib/metronome/seats";
 import type { BillingFrequency } from "@app/lib/metronome/types";
@@ -17,13 +18,17 @@ export type MemberUsageType = {
   seatType: MembershipSeatType | null;
   // Percentage of seat allocation consumed (0–100), null when seat balances are unavailable.
   seatUsagePercent: number | null;
-  // Pool consumption only (AWU credits): total usage minus what was covered by the seat credit.
-  consumedWorkplacePoolCredits: number;
+  // Total user AWU consumption for the period, regardless of whether it
+  // was covered by the seat allocation or overflowed into the workspace
+  // pool.
+  consumedAwuCredits: number;
   // Billing cadence for the seat subscription the user is assigned to; null when unknown.
   billingFrequency: BillingFrequency | null;
   // Set when a future seat change is scheduled (e.g. at the next credit refresh).
   scheduledSeatType: MembershipSeatType | null;
   scheduledSeatChangeAt: string | null;
+  // Per-user total spend cap in AWU credits for the billing period
+  spendLimitAwuCredits: number | null;
 };
 
 export type GetMembersUsageResponseBody = {
@@ -105,6 +110,26 @@ async function fetchSeatDataForMembersTable({
   });
 }
 
+async function fetchPerUserSpendLimitsForMembersTable({
+  metronomeCustomerId,
+  workspaceId,
+}: {
+  metronomeCustomerId: string | null;
+  workspaceId: string;
+}): Promise<Map<string, number>> {
+  if (!metronomeCustomerId) {
+    return new Map();
+  }
+  const result = await listMetronomePerUserCapsForWorkspace({
+    metronomeCustomerId,
+    workspaceId,
+  });
+  if (result.isErr()) {
+    return new Map();
+  }
+  return result.value;
+}
+
 export async function getMembersUsage({
   auth,
   paginationParams,
@@ -119,21 +144,29 @@ export async function getMembersUsage({
   const { metronomeCustomerId } = workspace;
   const metronomeContractId = subscription?.metronomeContractId ?? null;
 
-  const [membershipsResult, perUserTotalCredits, seatDataByUserId] =
-    await Promise.all([
-      MembershipResource.getActiveMemberships({
-        workspace,
-        paginationParams,
-      }),
-      fetchPerUserUsageCreditsForMembersTable({
-        metronomeCustomerId: metronomeCustomerId ?? null,
-        metronomeContractId,
-      }),
-      fetchSeatDataForMembersTable({
-        metronomeCustomerId: metronomeCustomerId ?? null,
-        metronomeContractId,
-      }),
-    ]);
+  const [
+    membershipsResult,
+    perUserTotalCredits,
+    seatDataByUserId,
+    perUserSpendLimits,
+  ] = await Promise.all([
+    MembershipResource.getActiveMemberships({
+      workspace,
+      paginationParams,
+    }),
+    fetchPerUserUsageCreditsForMembersTable({
+      metronomeCustomerId: metronomeCustomerId ?? null,
+      metronomeContractId,
+    }),
+    fetchSeatDataForMembersTable({
+      metronomeCustomerId: metronomeCustomerId ?? null,
+      metronomeContractId,
+    }),
+    fetchPerUserSpendLimitsForMembersTable({
+      metronomeCustomerId: metronomeCustomerId ?? null,
+      workspaceId: workspace.sId,
+    }),
+  ]);
 
   const { memberships, total, nextPageParams } = membershipsResult;
 
@@ -153,12 +186,9 @@ export async function getMembersUsage({
     const awuAllocation = seatData?.awuAllocation ?? 0;
 
     let seatUsagePercent: number | null = null;
-    let poolConsumedCredits = totalCredits;
-
     if (awuAllocation > 0) {
       const seatConsumed = Math.min(totalCredits, awuAllocation);
       seatUsagePercent = (seatConsumed / awuAllocation) * 100;
-      poolConsumedCredits = Math.max(0, totalCredits - awuAllocation);
     }
 
     const scheduled = scheduledByUserId.get(m.userId);
@@ -171,10 +201,11 @@ export async function getMembersUsage({
         image: m.user.imageUrl ?? null,
         seatType: m.seatType ?? null,
         seatUsagePercent,
-        consumedWorkplacePoolCredits: poolConsumedCredits,
+        consumedAwuCredits: totalCredits,
         billingFrequency: seatData?.billingFrequency ?? null,
         scheduledSeatType: scheduled?.seatType ?? null,
         scheduledSeatChangeAt: scheduled?.startAt.toISOString() ?? null,
+        spendLimitAwuCredits: perUserSpendLimits.get(userId) ?? null,
       },
     ];
   });

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -63,7 +63,7 @@ function buildUrlWithParams(
   if (!newParams) {
     return undefined;
   }
-  const url = new URL(currentUrl, "http://placeholder");
+  const url = new URL(currentUrl);
   Object.entries(newParams).forEach(([key, value]) => {
     if (value === null || value === undefined) {
       url.searchParams.delete(key);

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1,23 +1,13 @@
 import type { Authenticator } from "@app/lib/auth";
-import {
-  ceilToMidnightUTC,
-  floorToMidnightUTC,
-  listMetronomeDraftInvoices,
-  listMetronomeUsageWithGroups,
-} from "@app/lib/metronome/client";
-import { getMetricLlmProviderCostAwuId } from "@app/lib/metronome/constants";
-import { buildSeatDataByUserId } from "@app/lib/metronome/seats";
+import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
+import { buildSeatDataByUserId, type SeatData } from "@app/lib/metronome/seats";
 import type { BillingFrequency } from "@app/lib/metronome/types";
 import {
   MembershipResource,
   type MembershipsPaginationParams,
 } from "@app/lib/resources/membership_resource";
-import { apiError } from "@app/logger/withlogging";
-import type { WithAPIErrorResponse } from "@app/types/error";
 import type { MembershipSeatType } from "@app/types/memberships";
-import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
-import { fromError } from "zod-validation-error";
 
 export type MemberUsageType = {
   sId: string;
@@ -45,7 +35,7 @@ export type GetMembersUsageResponseBody = {
 export const DEFAULT_MEMBERS_USAGE_PAGE_LIMIT = 50;
 export const MAX_MEMBERS_USAGE_PAGE_LIMIT = 150;
 
-const MembersUsagePaginationSchema = z.object({
+export const MembersUsagePaginationSchema = z.object({
   limit: z.coerce
     .number()
     .int()
@@ -57,14 +47,18 @@ const MembersUsagePaginationSchema = z.object({
   lastValue: z.coerce.number().optional().catch(undefined),
 });
 
+export type MembersUsagePaginationInput = z.infer<
+  typeof MembersUsagePaginationSchema
+>;
+
 function buildUrlWithParams(
-  req: NextApiRequest,
+  currentUrl: string,
   newParams: MembershipsPaginationParams | undefined
 ) {
   if (!newParams) {
     return undefined;
   }
-  const url = new URL(req.url!, `http://${req.headers.host}`);
+  const url = new URL(currentUrl, "http://placeholder");
   Object.entries(newParams).forEach(([key, value]) => {
     if (value === null || value === undefined) {
       url.searchParams.delete(key);
@@ -75,7 +69,7 @@ function buildUrlWithParams(
   return url.pathname + url.search;
 }
 
-async function fetchPerUserUsageCredits({
+async function fetchPerUserUsageCreditsForMembersTable({
   metronomeCustomerId,
   metronomeContractId,
 }: {
@@ -85,171 +79,109 @@ async function fetchPerUserUsageCredits({
   if (!metronomeCustomerId || !metronomeContractId) {
     return new Map();
   }
-
-  const invoicesResult = await listMetronomeDraftInvoices(metronomeCustomerId);
-  if (invoicesResult.isErr()) {
-    return new Map();
-  }
-
-  const now = Date.now();
-  const currentInvoice = invoicesResult.value.find((inv) => {
-    if (inv.contract_id !== metronomeContractId) {
-      return false;
-    }
-    if (!inv.start_timestamp || !inv.end_timestamp) {
-      return false;
-    }
-    const startMs = new Date(inv.start_timestamp).getTime();
-    const endMs = new Date(inv.end_timestamp).getTime();
-    return startMs <= now && now < endMs;
+  const result = await fetchPerUserAwuUsage({
+    metronomeCustomerId,
+    metronomeContractId,
   });
-
-  if (!currentInvoice?.start_timestamp || !currentInvoice.end_timestamp) {
+  if (result.isErr()) {
     return new Map();
   }
-
-  const startingOn = floorToMidnightUTC(
-    new Date(currentInvoice.start_timestamp)
-  ).toISOString();
-  const endingBefore = ceilToMidnightUTC(
-    new Date(currentInvoice.end_timestamp)
-  ).toISOString();
-
-  const usageResult = await listMetronomeUsageWithGroups({
-    customerId: metronomeCustomerId,
-    billableMetricId: getMetricLlmProviderCostAwuId(),
-    startingOn,
-    endingBefore,
-    windowSize: "NONE",
-    groupKey: ["user_id", "usage_type"],
-  });
-
-  if (usageResult.isErr()) {
-    return new Map();
-  }
-
-  const perUser = new Map<string, number>();
-  for (const entry of usageResult.value) {
-    const userId = entry.group?.["user_id"];
-    const usageType = entry.group?.["usage_type"];
-    if (!userId || usageType !== "user" || entry.value === null) {
-      continue;
-    }
-    const existing = perUser.get(userId) ?? 0;
-    perUser.set(userId, existing + entry.value);
-  }
-  return perUser;
+  return result.value;
 }
 
-export async function handleGetMembersUsageRequest(
-  req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetMembersUsageResponseBody>>,
-  auth: Authenticator
-): Promise<void> {
-  if (!auth.isAdmin()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message: "Only workspace admins can access the members usage list.",
-      },
+async function fetchSeatDataForMembersTable({
+  metronomeCustomerId,
+  metronomeContractId,
+}: {
+  metronomeCustomerId: string | null;
+  metronomeContractId: string | null;
+}): Promise<Map<string, SeatData>> {
+  if (!metronomeCustomerId || !metronomeContractId) {
+    return new Map();
+  }
+  return buildSeatDataByUserId({
+    metronomeCustomerId,
+    contractId: metronomeContractId,
+  });
+}
+
+export async function getMembersUsage({
+  auth,
+  paginationParams,
+  currentUrl,
+}: {
+  auth: Authenticator;
+  paginationParams: MembersUsagePaginationInput;
+  currentUrl: string;
+}): Promise<GetMembersUsageResponseBody> {
+  const workspace = auth.getNonNullableWorkspace();
+  const subscription = auth.subscription();
+  const { metronomeCustomerId } = workspace;
+  const metronomeContractId = subscription?.metronomeContractId ?? null;
+
+  const [membershipsResult, perUserTotalCredits, seatDataByUserId] =
+    await Promise.all([
+      MembershipResource.getActiveMemberships({
+        workspace,
+        paginationParams,
+      }),
+      fetchPerUserUsageCreditsForMembersTable({
+        metronomeCustomerId: metronomeCustomerId ?? null,
+        metronomeContractId,
+      }),
+      fetchSeatDataForMembersTable({
+        metronomeCustomerId: metronomeCustomerId ?? null,
+        metronomeContractId,
+      }),
+    ]);
+
+  const { memberships, total, nextPageParams } = membershipsResult;
+
+  const scheduledByUserId =
+    await MembershipResource.getScheduledMembershipsByUserIdInWorkspace({
+      workspace,
+      userIds: memberships.map((m) => m.userId),
     });
-  }
 
-  switch (req.method) {
-    case "GET": {
-      const paginationRes = MembersUsagePaginationSchema.safeParse(req.query);
-      if (!paginationRes.success) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: `Invalid pagination parameters: ${fromError(paginationRes.error).toString()}`,
-          },
-        });
-      }
-
-      const paginationParams = paginationRes.data;
-      const workspace = auth.getNonNullableWorkspace();
-      const subscription = auth.subscription();
-      const { metronomeCustomerId } = workspace;
-      const metronomeContractId = subscription?.metronomeContractId ?? null;
-
-      const [membershipsResult, perUserTotalCredits, seatDataByUserId] =
-        await Promise.all([
-          MembershipResource.getActiveMemberships({
-            workspace,
-            paginationParams,
-          }),
-          fetchPerUserUsageCredits({
-            metronomeCustomerId: metronomeCustomerId ?? null,
-            metronomeContractId,
-          }),
-          metronomeCustomerId && metronomeContractId
-            ? buildSeatDataByUserId({
-                metronomeCustomerId,
-                contractId: metronomeContractId,
-              })
-            : Promise.resolve(new Map()),
-        ]);
-
-      const { memberships, total, nextPageParams } = membershipsResult;
-
-      const scheduledByUserId =
-        await MembershipResource.getScheduledMembershipsByUserIdInWorkspace({
-          workspace,
-          userIds: memberships.map((m) => m.userId),
-        });
-
-      const membersUsage: MemberUsageType[] = memberships.flatMap((m) => {
-        if (!m.user) {
-          return [];
-        }
-        const userId = m.user.sId;
-        const totalCredits = perUserTotalCredits.get(userId) ?? 0;
-        const seatData = seatDataByUserId.get(userId);
-        const awuAllocation = seatData?.awuAllocation ?? 0;
-
-        let seatUsagePercent: number | null = null;
-        let poolConsumedCredits = totalCredits;
-
-        if (awuAllocation > 0) {
-          const seatConsumed = Math.min(totalCredits, awuAllocation);
-          seatUsagePercent = (seatConsumed / awuAllocation) * 100;
-          poolConsumedCredits = Math.max(0, totalCredits - awuAllocation);
-        }
-
-        const scheduled = scheduledByUserId.get(m.userId);
-
-        return [
-          {
-            sId: userId,
-            name: m.user.name,
-            email: m.user.email ?? null,
-            image: m.user.imageUrl ?? null,
-            seatType: m.seatType ?? null,
-            seatUsagePercent,
-            consumedWorkplacePoolCredits: poolConsumedCredits,
-            billingFrequency: seatData?.billingFrequency ?? null,
-            scheduledSeatType: scheduled?.seatType ?? null,
-            scheduledSeatChangeAt: scheduled?.startAt.toISOString() ?? null,
-          },
-        ];
-      });
-
-      return res.status(200).json({
-        members: membersUsage,
-        total,
-        nextPageUrl: buildUrlWithParams(req, nextPageParams),
-      });
+  const membersUsage: MemberUsageType[] = memberships.flatMap((m) => {
+    if (!m.user) {
+      return [];
     }
-    default:
-      return apiError(req, res, {
-        status_code: 405,
-        api_error: {
-          type: "method_not_supported_error",
-          message: "The method passed is not supported, GET is expected.",
-        },
-      });
-  }
+    const userId = m.user.sId;
+    const totalCredits = perUserTotalCredits.get(userId) ?? 0;
+    const seatData = seatDataByUserId.get(userId);
+    const awuAllocation = seatData?.awuAllocation ?? 0;
+
+    let seatUsagePercent: number | null = null;
+    let poolConsumedCredits = totalCredits;
+
+    if (awuAllocation > 0) {
+      const seatConsumed = Math.min(totalCredits, awuAllocation);
+      seatUsagePercent = (seatConsumed / awuAllocation) * 100;
+      poolConsumedCredits = Math.max(0, totalCredits - awuAllocation);
+    }
+
+    const scheduled = scheduledByUserId.get(m.userId);
+
+    return [
+      {
+        sId: userId,
+        name: m.user.name,
+        email: m.user.email ?? null,
+        image: m.user.imageUrl ?? null,
+        seatType: m.seatType ?? null,
+        seatUsagePercent,
+        consumedWorkplacePoolCredits: poolConsumedCredits,
+        billingFrequency: seatData?.billingFrequency ?? null,
+        scheduledSeatType: scheduled?.seatType ?? null,
+        scheduledSeatChangeAt: scheduled?.startAt.toISOString() ?? null,
+      },
+    ];
+  });
+
+  return {
+    members: membersUsage,
+    total,
+    nextPageUrl: buildUrlWithParams(currentUrl, nextPageParams),
+  };
 }

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -9,6 +9,8 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
 
 async function isPaygEnabled(workspace: WorkspaceResource): Promise<boolean> {
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
@@ -21,14 +23,14 @@ export async function dispatchPerUserCapReached({
 }: {
   workspace: WorkspaceResource;
   userId: string;
-}): Promise<void> {
+}): Promise<Result<void, Error>> {
   const user = await UserResource.fetchById(userId);
   if (!user) {
     logger.warn(
       { workspaceId: workspace.sId, userId },
       "[CreditStateDispatcher] per_user_cap_reached: user not found, skipping"
     );
-    return;
+    return new Ok(undefined);
   }
 
   const lightWorkspace = renderLightWorkspaceType({ workspace });
@@ -42,14 +44,18 @@ export async function dispatchPerUserCapReached({
       { workspaceId: workspace.sId, userId },
       "[CreditStateDispatcher] per_user_cap_reached: no active membership, skipping"
     );
-    return;
+    return new Ok(undefined);
   }
 
-  await transitionUserCreditState(
+  const result = await transitionUserCreditState(
     membership,
     { type: "per_user_cap_reached" },
     { workspaceId: workspace.sId, userId }
   );
+  if (result.isErr()) {
+    return result;
+  }
+  return new Ok(undefined);
 }
 
 export async function dispatchPerUserCapResolved({
@@ -58,7 +64,7 @@ export async function dispatchPerUserCapResolved({
 }: {
   workspace: WorkspaceResource;
   userId: string;
-}): Promise<void> {
+}): Promise<Result<void, Error>> {
   const user = await UserResource.fetchById(userId);
   if (!user) {
     logger.warn(
@@ -66,7 +72,7 @@ export async function dispatchPerUserCapResolved({
       "[CreditStateDispatcher] per_user_cap_resolved: user not found, clearing legacy block"
     );
     await clearUserCapBlocked(workspace.sId, userId);
-    return;
+    return new Ok(undefined);
   }
 
   const lightWorkspace = renderLightWorkspaceType({ workspace });
@@ -82,14 +88,18 @@ export async function dispatchPerUserCapResolved({
       "[CreditStateDispatcher] per_user_cap_resolved: no active membership, clearing legacy block"
     );
     await clearUserCapBlocked(workspace.sId, userId);
-    return;
+    return new Ok(undefined);
   }
 
-  await transitionUserCreditState(
+  const result = await transitionUserCreditState(
     membership,
     { type: "per_user_cap_resolved" },
     { workspaceId: workspace.sId, userId }
   );
+  if (result.isErr()) {
+    return result;
+  }
+  return new Ok(undefined);
 }
 
 export async function dispatchPoolExhausted({

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -194,17 +194,16 @@ export async function setUserSpendLimit(
           new UserSpendLimitError("metronome_error", clearResult.error.message)
         );
       }
-      try {
-        await dispatchPerUserCapResolved({
-          workspace: workspaceResource,
-          userId: user.sId,
-        });
-      } catch (error) {
+      const dispatchResult = await dispatchPerUserCapResolved({
+        workspace: workspaceResource,
+        userId: user.sId,
+      });
+      if (dispatchResult.isErr()) {
         logger.warn(
           {
             workspaceId: workspace.sId,
             userId: user.sId,
-            err: error,
+            err: dispatchResult.error,
           },
           "[Metronome PerUserCap] dispatchPerUserCapResolved failed after spend-limit update; continuing"
         );
@@ -230,28 +229,38 @@ export async function setUserSpendLimit(
         userId: user.sId,
         awuCapCredits: limit.awuCredits,
       });
-      try {
-        if (transitionedTo === "reached") {
-          await dispatchPerUserCapReached({
-            workspace: workspaceResource,
-            userId: user.sId,
-          });
-        } else if (transitionedTo === "resolved") {
-          await dispatchPerUserCapResolved({
-            workspace: workspaceResource,
-            userId: user.sId,
-          });
+      if (transitionedTo === "reached") {
+        const dispatchResult = await dispatchPerUserCapReached({
+          workspace: workspaceResource,
+          userId: user.sId,
+        });
+        if (dispatchResult.isErr()) {
+          logger.warn(
+            {
+              workspaceId: workspace.sId,
+              userId: user.sId,
+              transitionedTo,
+              err: dispatchResult.error,
+            },
+            "[Metronome PerUserCap] dispatch after spend-limit update failed; continuing"
+          );
         }
-      } catch (error) {
-        logger.warn(
-          {
-            workspaceId: workspace.sId,
-            userId: user.sId,
-            transitionedTo,
-            err: error,
-          },
-          "[Metronome PerUserCap] dispatch after spend-limit update failed; continuing"
-        );
+      } else if (transitionedTo === "resolved") {
+        const dispatchResult = await dispatchPerUserCapResolved({
+          workspace: workspaceResource,
+          userId: user.sId,
+        });
+        if (dispatchResult.isErr()) {
+          logger.warn(
+            {
+              workspaceId: workspace.sId,
+              userId: user.sId,
+              transitionedTo,
+              err: dispatchResult.error,
+            },
+            "[Metronome PerUserCap] dispatch after spend-limit update failed; continuing"
+          );
+        }
       }
       // transitionedTo === null: usage unavailable — let webhook reconcile.
       break;

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -1,0 +1,282 @@
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+} from "@app/lib/api/audit/workos_audit";
+import {
+  dispatchPerUserCapReached,
+  dispatchPerUserCapResolved,
+} from "@app/lib/api/metronome/credit_state_dispatcher";
+import { getUserForWorkspace } from "@app/lib/api/user";
+import type { AuditLogContext } from "@app/lib/api/workos/organization";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  clearMetronomePerUserCapAlert,
+  getMetronomePerUserCap,
+  syncMetronomePerUserCapAlert,
+} from "@app/lib/metronome/per_user_alerts";
+import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+export const MIN_USER_SPEND_LIMIT_AWU_CREDITS = 1;
+export const MAX_USER_SPEND_LIMIT_AWU_CREDITS = 1_000_000;
+
+export type UserSpendLimit =
+  | { kind: "unlimited" }
+  | { kind: "limited"; awuCredits: number };
+
+export type GetUserSpendLimitResponse = UserSpendLimit;
+
+export type SetUserSpendLimitResponse = {
+  limit: UserSpendLimit;
+  // The credit-state we transitioned the user to, computed locally from
+  // current pool consumption. `null` when usage couldn't be determined and
+  // we therefore did not dispatch a transition (the Metronome webhook
+  // will reconcile on the next state change).
+  transitionedTo: "reached" | "resolved" | null;
+};
+
+export type UserSpendLimitErrorType =
+  | "user_not_found"
+  | "workspace_not_metronome_billed"
+  | "metronome_error";
+
+export class UserSpendLimitError extends Error {
+  constructor(
+    readonly type: UserSpendLimitErrorType,
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+export async function getUserSpendLimit(
+  auth: Authenticator,
+  { userId }: { userId: string }
+): Promise<Result<GetUserSpendLimitResponse, UserSpendLimitError>> {
+  const workspace = auth.getNonNullableWorkspace();
+  if (!workspace.metronomeCustomerId) {
+    return new Err(
+      new UserSpendLimitError(
+        "workspace_not_metronome_billed",
+        "Workspace is not on Metronome billing."
+      )
+    );
+  }
+
+  const user = await getUserForWorkspace(auth, { userId });
+  if (!user) {
+    return new Err(
+      new UserSpendLimitError(
+        "user_not_found",
+        "Could not find the user in this workspace."
+      )
+    );
+  }
+
+  const result = await getMetronomePerUserCap({
+    metronomeCustomerId: workspace.metronomeCustomerId,
+    workspaceSId: workspace.sId,
+    userSId: user.sId,
+  });
+  if (result.isErr()) {
+    return new Err(
+      new UserSpendLimitError("metronome_error", result.error.message)
+    );
+  }
+
+  if (!result.value) {
+    return new Ok({ kind: "unlimited" });
+  }
+  return new Ok({ kind: "limited", awuCredits: result.value.threshold });
+}
+
+/**
+ * Resolve the credit state for a user given a freshly applied cap, by
+ * comparing the user's current pool consumption to the cap. The Metronome
+ * alert we just created/cleared remains the source of truth for *future*
+ * crossings (the webhook keeps the state in sync); this local comparison
+ * just sets the immediate state without depending on Metronome's eventual-
+ * consistent alert evaluation (which can sit in `evaluating` for minutes).
+ *
+ * Returns `null` if usage couldn't be fetched — caller should not dispatch
+ * and let the webhook reconcile.
+ */
+async function resolveLocalCapState({
+  metronomeCustomerId,
+  metronomeContractId,
+  userSId,
+  awuCapCredits,
+}: {
+  metronomeCustomerId: string;
+  metronomeContractId: string | null;
+  userSId: string;
+  awuCapCredits: number;
+}): Promise<"reached" | "resolved" | null> {
+  if (!metronomeContractId) {
+    return null;
+  }
+  const usageResult = await fetchPerUserAwuUsage({
+    metronomeCustomerId,
+    metronomeContractId,
+  });
+  if (usageResult.isErr()) {
+    logger.warn(
+      {
+        metronomeCustomerId,
+        userId: userSId,
+        err: usageResult.error,
+      },
+      "[Metronome PerUserCap] Could not fetch current usage; skipping immediate state dispatch"
+    );
+    return null;
+  }
+  const consumed = usageResult.value.get(userSId) ?? 0;
+  return consumed >= awuCapCredits ? "reached" : "resolved";
+}
+
+export async function setUserSpendLimit(
+  auth: Authenticator,
+  {
+    userId,
+    limit,
+    auditContext,
+  }: {
+    userId: string;
+    limit: UserSpendLimit;
+    auditContext: AuditLogContext;
+  }
+): Promise<Result<SetUserSpendLimitResponse, UserSpendLimitError>> {
+  const workspace = auth.getNonNullableWorkspace();
+  if (!workspace.metronomeCustomerId) {
+    return new Err(
+      new UserSpendLimitError(
+        "workspace_not_metronome_billed",
+        "Workspace is not on Metronome billing."
+      )
+    );
+  }
+
+  const user = await getUserForWorkspace(auth, { userId });
+  if (!user) {
+    return new Err(
+      new UserSpendLimitError(
+        "user_not_found",
+        "Could not find the user in this workspace."
+      )
+    );
+  }
+
+  const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
+  if (!workspaceResource) {
+    return new Err(
+      new UserSpendLimitError(
+        "user_not_found",
+        "Could not load workspace resource."
+      )
+    );
+  }
+
+  let transitionedTo: "reached" | "resolved" | null;
+
+  switch (limit.kind) {
+    case "unlimited": {
+      const clearResult = await clearMetronomePerUserCapAlert({
+        metronomeCustomerId: workspace.metronomeCustomerId,
+        workspaceSId: workspace.sId,
+        userSId: user.sId,
+      });
+      if (clearResult.isErr()) {
+        return new Err(
+          new UserSpendLimitError("metronome_error", clearResult.error.message)
+        );
+      }
+      try {
+        await dispatchPerUserCapResolved({
+          workspace: workspaceResource,
+          userId: user.sId,
+        });
+      } catch (error) {
+        logger.warn(
+          {
+            workspaceId: workspace.sId,
+            userId: user.sId,
+            err: error,
+          },
+          "[Metronome PerUserCap] dispatchPerUserCapResolved failed after spend-limit update; continuing"
+        );
+      }
+      transitionedTo = "resolved";
+      break;
+    }
+    case "limited": {
+      const syncResult = await syncMetronomePerUserCapAlert({
+        metronomeCustomerId: workspace.metronomeCustomerId,
+        workspaceSId: workspace.sId,
+        userSId: user.sId,
+        awuCredits: limit.awuCredits,
+      });
+      if (syncResult.isErr()) {
+        return new Err(
+          new UserSpendLimitError("metronome_error", syncResult.error.message)
+        );
+      }
+      transitionedTo = await resolveLocalCapState({
+        metronomeCustomerId: workspace.metronomeCustomerId,
+        metronomeContractId: auth.subscription()?.metronomeContractId ?? null,
+        userSId: user.sId,
+        awuCapCredits: limit.awuCredits,
+      });
+      try {
+        if (transitionedTo === "reached") {
+          await dispatchPerUserCapReached({
+            workspace: workspaceResource,
+            userId: user.sId,
+          });
+        } else if (transitionedTo === "resolved") {
+          await dispatchPerUserCapResolved({
+            workspace: workspaceResource,
+            userId: user.sId,
+          });
+        }
+      } catch (error) {
+        logger.warn(
+          {
+            workspaceId: workspace.sId,
+            userId: user.sId,
+            transitionedTo,
+            err: error,
+          },
+          "[Metronome PerUserCap] dispatch after spend-limit update failed; continuing"
+        );
+      }
+      // transitionedTo === null: usage unavailable — let webhook reconcile.
+      break;
+    }
+    default:
+      assertNever(limit);
+  }
+
+  void emitAuditLogEvent({
+    auth,
+    action: "member.spend_limit_updated",
+    targets: [
+      buildAuditLogTarget("workspace", workspace),
+      buildAuditLogTarget("user", {
+        sId: user.sId,
+        name: user.fullName() ?? "unknown",
+      }),
+    ],
+    context: auditContext,
+    metadata: {
+      kind: limit.kind,
+      awu_credits:
+        limit.kind === "limited" ? String(limit.awuCredits) : "unlimited",
+    },
+  });
+
+  return new Ok({ limit, transitionedTo });
+}

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -79,8 +79,8 @@ export async function getUserSpendLimit(
 
   const result = await getMetronomePerUserCap({
     metronomeCustomerId: workspace.metronomeCustomerId,
-    workspaceSId: workspace.sId,
-    userSId: user.sId,
+    workspaceId: workspace.sId,
+    userId: user.sId,
   });
   if (result.isErr()) {
     return new Err(
@@ -108,12 +108,12 @@ export async function getUserSpendLimit(
 async function resolveLocalCapState({
   metronomeCustomerId,
   metronomeContractId,
-  userSId,
+  userId,
   awuCapCredits,
 }: {
   metronomeCustomerId: string;
   metronomeContractId: string | null;
-  userSId: string;
+  userId: string;
   awuCapCredits: number;
 }): Promise<"reached" | "resolved" | null> {
   if (!metronomeContractId) {
@@ -127,14 +127,14 @@ async function resolveLocalCapState({
     logger.warn(
       {
         metronomeCustomerId,
-        userId: userSId,
+        userId: userId,
         err: usageResult.error,
       },
       "[Metronome PerUserCap] Could not fetch current usage; skipping immediate state dispatch"
     );
     return null;
   }
-  const consumed = usageResult.value.get(userSId) ?? 0;
+  const consumed = usageResult.value.get(userId) ?? 0;
   return consumed >= awuCapCredits ? "reached" : "resolved";
 }
 
@@ -186,8 +186,8 @@ export async function setUserSpendLimit(
     case "unlimited": {
       const clearResult = await clearMetronomePerUserCapAlert({
         metronomeCustomerId: workspace.metronomeCustomerId,
-        workspaceSId: workspace.sId,
-        userSId: user.sId,
+        workspaceId: workspace.sId,
+        userId: user.sId,
       });
       if (clearResult.isErr()) {
         return new Err(
@@ -215,8 +215,8 @@ export async function setUserSpendLimit(
     case "limited": {
       const syncResult = await syncMetronomePerUserCapAlert({
         metronomeCustomerId: workspace.metronomeCustomerId,
-        workspaceSId: workspace.sId,
-        userSId: user.sId,
+        workspaceId: workspace.sId,
+        userId: user.sId,
         awuCredits: limit.awuCredits,
       });
       if (syncResult.isErr()) {
@@ -227,7 +227,7 @@ export async function setUserSpendLimit(
       transitionedTo = await resolveLocalCapState({
         metronomeCustomerId: workspace.metronomeCustomerId,
         metronomeContractId: auth.subscription()?.metronomeContractId ?? null,
-        userSId: user.sId,
+        userId: user.sId,
         awuCapCredits: limit.awuCredits,
       });
       try {

--- a/front/lib/metronome/per_user_alerts.ts
+++ b/front/lib/metronome/per_user_alerts.ts
@@ -1,0 +1,229 @@
+import { getMetronomeClient } from "@app/lib/metronome/client";
+import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+const USER_ID_GROUP_KEY = "user_id";
+
+function perUserAlertUniquenessKeyPrefix(workspaceSId: string): string {
+  return `per-user-cap-${workspaceSId}-`;
+}
+
+function perUserAlertUniquenessKey(
+  workspaceSId: string,
+  userSId: string
+): string {
+  return `${perUserAlertUniquenessKeyPrefix(workspaceSId)}${userSId}`;
+}
+
+async function findExistingPerUserAlert({
+  metronomeCustomerId,
+  workspaceSId,
+  userSId,
+}: {
+  metronomeCustomerId: string;
+  workspaceSId: string;
+  userSId: string;
+}): Promise<Result<{ id: string; threshold: number } | null, Error>> {
+  const target = perUserAlertUniquenessKey(workspaceSId, userSId);
+  try {
+    const client = getMetronomeClient();
+    for await (const entry of client.v1.customers.alerts.list({
+      customer_id: metronomeCustomerId,
+      alert_statuses: ["ENABLED", "DISABLED"],
+    })) {
+      if (entry.alert.uniqueness_key === target) {
+        return new Ok({
+          id: entry.alert.id,
+          threshold: entry.alert.threshold,
+        });
+      }
+    }
+    return new Ok(null);
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}
+
+/**
+ * Look up the current per-user cap (if any) for a workspace/user pair by
+ * matching `uniqueness_key`. Returns the alert id and threshold, or
+ * `null` if no cap is configured.
+ */
+export async function getMetronomePerUserCap({
+  metronomeCustomerId,
+  workspaceSId,
+  userSId,
+}: {
+  metronomeCustomerId: string;
+  workspaceSId: string;
+  userSId: string;
+}): Promise<Result<{ alertId: string; threshold: number } | null, Error>> {
+  const findResult = await findExistingPerUserAlert({
+    metronomeCustomerId,
+    workspaceSId,
+    userSId,
+  });
+  if (findResult.isErr()) {
+    return new Err(findResult.error);
+  }
+  const existing = findResult.value;
+  if (!existing) {
+    return new Ok(null);
+  }
+  return new Ok({ alertId: existing.id, threshold: existing.threshold });
+}
+
+/**
+ * List per-user cap thresholds for a workspace. Returns a `Map<userSId,
+ * threshold>` built from all enabled/disabled alerts whose
+ * `uniqueness_key` matches the per-user cap pattern for this workspace.
+ */
+export async function listMetronomePerUserCapsForWorkspace({
+  metronomeCustomerId,
+  workspaceSId,
+}: {
+  metronomeCustomerId: string;
+  workspaceSId: string;
+}): Promise<Result<Map<string, number>, Error>> {
+  const prefix = perUserAlertUniquenessKeyPrefix(workspaceSId);
+  const caps = new Map<string, number>();
+  try {
+    const client = getMetronomeClient();
+    for await (const entry of client.v1.customers.alerts.list({
+      customer_id: metronomeCustomerId,
+      alert_statuses: ["ENABLED", "DISABLED"],
+    })) {
+      const key = entry.alert.uniqueness_key;
+      if (!key || !key.startsWith(prefix)) {
+        continue;
+      }
+      const userSId = key.slice(prefix.length);
+      if (!userSId) {
+        continue;
+      }
+      caps.set(userSId, entry.alert.threshold);
+    }
+    return new Ok(caps);
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}
+
+/**
+ * Idempotently ensure a Metronome `spend_threshold_reached` alert exists on
+ * the customer for this user, with the given AWU threshold. If an alert
+ * with a different threshold already exists, it's archived (with key
+ * release) and recreated.
+ */
+export async function syncMetronomePerUserCapAlert({
+  metronomeCustomerId,
+  workspaceSId,
+  userSId,
+  awuCredits,
+}: {
+  metronomeCustomerId: string;
+  workspaceSId: string;
+  userSId: string;
+  awuCredits: number;
+}): Promise<Result<{ alertId: string }, Error>> {
+  const findResult = await findExistingPerUserAlert({
+    metronomeCustomerId,
+    workspaceSId,
+    userSId,
+  });
+  if (findResult.isErr()) {
+    return new Err(findResult.error);
+  }
+  const existing = findResult.value;
+
+  if (existing && existing.threshold === awuCredits) {
+    return new Ok({ alertId: existing.id });
+  }
+
+  const client = getMetronomeClient();
+  if (existing) {
+    try {
+      await client.v1.alerts.archive({
+        id: existing.id,
+        release_uniqueness_key: true,
+      });
+    } catch (err) {
+      return new Err(normalizeError(err));
+    }
+  }
+
+  try {
+    const created = await client.v1.alerts.create({
+      alert_type: "spend_threshold_reached",
+      name: `Per-user cap (${userSId})`,
+      threshold: awuCredits,
+      credit_type_id: getCreditTypeAwuId(),
+      customer_id: metronomeCustomerId,
+      group_values: [{ key: USER_ID_GROUP_KEY, value: userSId }],
+      uniqueness_key: perUserAlertUniquenessKey(workspaceSId, userSId),
+    });
+    logger.info(
+      {
+        workspaceId: workspaceSId,
+        userId: userSId,
+        metronomeCustomerId,
+        alertId: created.data.id,
+        awuCredits,
+      },
+      "[Metronome PerUserCap] Synced per-user cap alert"
+    );
+    return new Ok({ alertId: created.data.id });
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}
+
+/**
+ * Archive the per-user cap alert for this workspace/user pair, if any.
+ * Idempotent — no-op when no matching alert exists.
+ */
+export async function clearMetronomePerUserCapAlert({
+  metronomeCustomerId,
+  workspaceSId,
+  userSId,
+}: {
+  metronomeCustomerId: string;
+  workspaceSId: string;
+  userSId: string;
+}): Promise<Result<void, Error>> {
+  const findResult = await findExistingPerUserAlert({
+    metronomeCustomerId,
+    workspaceSId,
+    userSId,
+  });
+  if (findResult.isErr()) {
+    return new Err(findResult.error);
+  }
+  const existing = findResult.value;
+  if (!existing) {
+    return new Ok(undefined);
+  }
+
+  try {
+    const client = getMetronomeClient();
+    await client.v1.alerts.archive({
+      id: existing.id,
+      release_uniqueness_key: true,
+    });
+    logger.info(
+      {
+        workspaceId: workspaceSId,
+        userId: userSId,
+        metronomeCustomerId,
+        alertId: existing.id,
+      },
+      "[Metronome PerUserCap] Cleared per-user cap alert"
+    );
+    return new Ok(undefined);
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}

--- a/front/lib/metronome/per_user_alerts.ts
+++ b/front/lib/metronome/per_user_alerts.ts
@@ -7,27 +7,27 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 const USER_ID_GROUP_KEY = "user_id";
 
-function perUserAlertUniquenessKeyPrefix(workspaceSId: string): string {
-  return `per-user-cap-${workspaceSId}-`;
+function perUserAlertUniquenessKeyPrefix(workspaceId: string): string {
+  return `per-user-cap-${workspaceId}-`;
 }
 
 function perUserAlertUniquenessKey(
-  workspaceSId: string,
-  userSId: string
+  workspaceId: string,
+  userId: string
 ): string {
-  return `${perUserAlertUniquenessKeyPrefix(workspaceSId)}${userSId}`;
+  return `${perUserAlertUniquenessKeyPrefix(workspaceId)}${userId}`;
 }
 
 async function findExistingPerUserAlert({
   metronomeCustomerId,
-  workspaceSId,
-  userSId,
+  workspaceId,
+  userId,
 }: {
   metronomeCustomerId: string;
-  workspaceSId: string;
-  userSId: string;
+  workspaceId: string;
+  userId: string;
 }): Promise<Result<{ id: string; threshold: number } | null, Error>> {
-  const target = perUserAlertUniquenessKey(workspaceSId, userSId);
+  const target = perUserAlertUniquenessKey(workspaceId, userId);
   try {
     const client = getMetronomeClient();
     for await (const entry of client.v1.customers.alerts.list({
@@ -54,17 +54,17 @@ async function findExistingPerUserAlert({
  */
 export async function getMetronomePerUserCap({
   metronomeCustomerId,
-  workspaceSId,
-  userSId,
+  workspaceId,
+  userId,
 }: {
   metronomeCustomerId: string;
-  workspaceSId: string;
-  userSId: string;
+  workspaceId: string;
+  userId: string;
 }): Promise<Result<{ alertId: string; threshold: number } | null, Error>> {
   const findResult = await findExistingPerUserAlert({
     metronomeCustomerId,
-    workspaceSId,
-    userSId,
+    workspaceId,
+    userId,
   });
   if (findResult.isErr()) {
     return new Err(findResult.error);
@@ -77,18 +77,18 @@ export async function getMetronomePerUserCap({
 }
 
 /**
- * List per-user cap thresholds for a workspace. Returns a `Map<userSId,
+ * List per-user cap thresholds for a workspace. Returns a `Map<userId,
  * threshold>` built from all enabled/disabled alerts whose
  * `uniqueness_key` matches the per-user cap pattern for this workspace.
  */
 export async function listMetronomePerUserCapsForWorkspace({
   metronomeCustomerId,
-  workspaceSId,
+  workspaceId,
 }: {
   metronomeCustomerId: string;
-  workspaceSId: string;
+  workspaceId: string;
 }): Promise<Result<Map<string, number>, Error>> {
-  const prefix = perUserAlertUniquenessKeyPrefix(workspaceSId);
+  const prefix = perUserAlertUniquenessKeyPrefix(workspaceId);
   const caps = new Map<string, number>();
   try {
     const client = getMetronomeClient();
@@ -100,11 +100,11 @@ export async function listMetronomePerUserCapsForWorkspace({
       if (!key || !key.startsWith(prefix)) {
         continue;
       }
-      const userSId = key.slice(prefix.length);
-      if (!userSId) {
+      const userId = key.slice(prefix.length);
+      if (!userId) {
         continue;
       }
-      caps.set(userSId, entry.alert.threshold);
+      caps.set(userId, entry.alert.threshold);
     }
     return new Ok(caps);
   } catch (err) {
@@ -120,19 +120,19 @@ export async function listMetronomePerUserCapsForWorkspace({
  */
 export async function syncMetronomePerUserCapAlert({
   metronomeCustomerId,
-  workspaceSId,
-  userSId,
+  workspaceId,
+  userId,
   awuCredits,
 }: {
   metronomeCustomerId: string;
-  workspaceSId: string;
-  userSId: string;
+  workspaceId: string;
+  userId: string;
   awuCredits: number;
 }): Promise<Result<{ alertId: string }, Error>> {
   const findResult = await findExistingPerUserAlert({
     metronomeCustomerId,
-    workspaceSId,
-    userSId,
+    workspaceId,
+    userId,
   });
   if (findResult.isErr()) {
     return new Err(findResult.error);
@@ -158,17 +158,17 @@ export async function syncMetronomePerUserCapAlert({
   try {
     const created = await client.v1.alerts.create({
       alert_type: "spend_threshold_reached",
-      name: `Per-user cap (${userSId})`,
+      name: `Per-user cap (${userId})`,
       threshold: awuCredits,
       credit_type_id: getCreditTypeAwuId(),
       customer_id: metronomeCustomerId,
-      group_values: [{ key: USER_ID_GROUP_KEY, value: userSId }],
-      uniqueness_key: perUserAlertUniquenessKey(workspaceSId, userSId),
+      group_values: [{ key: USER_ID_GROUP_KEY, value: userId }],
+      uniqueness_key: perUserAlertUniquenessKey(workspaceId, userId),
     });
     logger.info(
       {
-        workspaceId: workspaceSId,
-        userId: userSId,
+        workspaceId: workspaceId,
+        userId: userId,
         metronomeCustomerId,
         alertId: created.data.id,
         awuCredits,
@@ -187,17 +187,17 @@ export async function syncMetronomePerUserCapAlert({
  */
 export async function clearMetronomePerUserCapAlert({
   metronomeCustomerId,
-  workspaceSId,
-  userSId,
+  workspaceId,
+  userId,
 }: {
   metronomeCustomerId: string;
-  workspaceSId: string;
-  userSId: string;
+  workspaceId: string;
+  userId: string;
 }): Promise<Result<void, Error>> {
   const findResult = await findExistingPerUserAlert({
     metronomeCustomerId,
-    workspaceSId,
-    userSId,
+    workspaceId,
+    userId,
   });
   if (findResult.isErr()) {
     return new Err(findResult.error);
@@ -215,8 +215,8 @@ export async function clearMetronomePerUserCapAlert({
     });
     logger.info(
       {
-        workspaceId: workspaceSId,
-        userId: userSId,
+        workspaceId: workspaceId,
+        userId: userId,
         metronomeCustomerId,
         alertId: existing.id,
       },

--- a/front/lib/metronome/per_user_usage.ts
+++ b/front/lib/metronome/per_user_usage.ts
@@ -1,0 +1,71 @@
+import {
+  ceilToMidnightUTC,
+  floorToMidnightUTC,
+  listMetronomeDraftInvoices,
+  listMetronomeUsageWithGroups,
+} from "@app/lib/metronome/client";
+import { getMetricLlmProviderCostAwuId } from "@app/lib/metronome/constants";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export async function fetchPerUserAwuUsage({
+  metronomeCustomerId,
+  metronomeContractId,
+}: {
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+}): Promise<Result<Map<string, number>, Error>> {
+  const invoicesResult = await listMetronomeDraftInvoices(metronomeCustomerId);
+  if (invoicesResult.isErr()) {
+    return new Err(invoicesResult.error);
+  }
+
+  const now = Date.now();
+  const currentInvoice = invoicesResult.value.find((inv) => {
+    if (inv.contract_id !== metronomeContractId) {
+      return false;
+    }
+    if (!inv.start_timestamp || !inv.end_timestamp) {
+      return false;
+    }
+    const startMs = new Date(inv.start_timestamp).getTime();
+    const endMs = new Date(inv.end_timestamp).getTime();
+    return startMs <= now && now < endMs;
+  });
+
+  if (!currentInvoice?.start_timestamp || !currentInvoice.end_timestamp) {
+    return new Ok(new Map());
+  }
+
+  const startingOn = floorToMidnightUTC(
+    new Date(currentInvoice.start_timestamp)
+  ).toISOString();
+  const endingBefore = ceilToMidnightUTC(
+    new Date(currentInvoice.end_timestamp)
+  ).toISOString();
+
+  const usageResult = await listMetronomeUsageWithGroups({
+    customerId: metronomeCustomerId,
+    billableMetricId: getMetricLlmProviderCostAwuId(),
+    startingOn,
+    endingBefore,
+    windowSize: "NONE",
+    groupKey: ["user_id", "usage_type"],
+  });
+
+  if (usageResult.isErr()) {
+    return new Err(usageResult.error);
+  }
+
+  const perUser = new Map<string, number>();
+  for (const entry of usageResult.value) {
+    const userId = entry.group?.["user_id"];
+    const usageType = entry.group?.["usage_type"];
+    if (!userId || usageType !== "user" || entry.value === null) {
+      continue;
+    }
+    const existing = perUser.get(userId) ?? 0;
+    perUser.set(userId, existing + entry.value);
+  }
+  return new Ok(perUser);
+}

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -192,7 +192,28 @@ async function handler(
                 );
                 break;
               }
-              await dispatchPerUserCapReached({ workspace, userId });
+              const dispatchResult = await dispatchPerUserCapReached({
+                workspace,
+                userId,
+              });
+              if (dispatchResult.isErr()) {
+                logger.error(
+                  {
+                    eventId: event.id,
+                    workspaceId: workspace.sId,
+                    userId,
+                    err: dispatchResult.error,
+                  },
+                  "[Metronome Webhook] spend_threshold_reached: per_user dispatch failed"
+                );
+                return apiError(req, res, {
+                  status_code: 500,
+                  api_error: {
+                    type: "internal_server_error",
+                    message: `Error dispatching per-user cap reached: ${dispatchResult.error.message}`,
+                  },
+                });
+              }
               logger.info(
                 {
                   eventId: event.id,
@@ -238,7 +259,28 @@ async function handler(
                 break;
               }
 
-              await dispatchPerUserCapResolved({ workspace, userId });
+              const dispatchResult = await dispatchPerUserCapResolved({
+                workspace,
+                userId,
+              });
+              if (dispatchResult.isErr()) {
+                logger.error(
+                  {
+                    eventId: event.id,
+                    workspaceId: workspace.sId,
+                    userId,
+                    err: dispatchResult.error,
+                  },
+                  "[Metronome Webhook] spend_threshold_resolved: per-user dispatch failed"
+                );
+                return apiError(req, res, {
+                  status_code: 500,
+                  api_error: {
+                    type: "internal_server_error",
+                    message: `Error dispatching per-user cap resolved: ${dispatchResult.error.message}`,
+                  },
+                });
+              }
               logger.info(
                 {
                   eventId: event.id,

--- a/front/pages/api/w/[wId]/credits/members-usage.ts
+++ b/front/pages/api/w/[wId]/credits/members-usage.ts
@@ -3,17 +3,61 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { GetMembersUsageResponseBody } from "@app/lib/api/credits/members_usage";
-import { handleGetMembersUsageRequest } from "@app/lib/api/credits/members_usage";
+import {
+  getMembersUsage,
+  MembersUsagePaginationSchema,
+} from "@app/lib/api/credits/members_usage";
 import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { fromError } from "zod-validation-error";
 
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<GetMembersUsageResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  return handleGetMembersUsageRequest(req, res, auth);
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access the members usage list.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const paginationRes = MembersUsagePaginationSchema.safeParse(req.query);
+      if (!paginationRes.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid pagination parameters: ${fromError(paginationRes.error).toString()}`,
+          },
+        });
+      }
+
+      const body = await getMembersUsage({
+        auth,
+        paginationParams: paginationRes.data,
+        currentUrl: req.url ?? "/",
+      });
+
+      return res.status(200).json(body);
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
 }
 
 export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/members/[uId]/spend_limit.test.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/spend_limit.test.ts
@@ -67,10 +67,10 @@ beforeEach(() => {
     new Ok(new Map())
   );
   vi.mocked(creditStateDispatcher.dispatchPerUserCapReached).mockResolvedValue(
-    undefined
+    new Ok(undefined)
   );
   vi.mocked(creditStateDispatcher.dispatchPerUserCapResolved).mockResolvedValue(
-    undefined
+    new Ok(undefined)
   );
 });
 
@@ -261,8 +261,8 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
       expect(perUserAlerts.clearMetronomePerUserCapAlert).toHaveBeenCalledWith(
         expect.objectContaining({
           metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
-          workspaceSId: workspace.sId,
-          userSId: targetUser.sId,
+          workspaceId: workspace.sId,
+          userId: targetUser.sId,
         })
       );
       expect(
@@ -302,8 +302,8 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
       expect(perUserAlerts.syncMetronomePerUserCapAlert).toHaveBeenCalledWith(
         expect.objectContaining({
           metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
-          workspaceSId: workspace.sId,
-          userSId: targetUser.sId,
+          workspaceId: workspace.sId,
+          userId: targetUser.sId,
           awuCredits: 1500,
         })
       );

--- a/front/pages/api/w/[wId]/members/[uId]/spend_limit.test.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/spend_limit.test.ts
@@ -1,0 +1,349 @@
+import * as creditStateDispatcher from "@app/lib/api/metronome/credit_state_dispatcher";
+import * as perUserAlerts from "@app/lib/metronome/per_user_alerts";
+import * as perUserUsage from "@app/lib/metronome/per_user_usage";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Ok } from "@app/types/shared/result";
+import type { WorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import handler from "./spend_limit";
+
+vi.mock("@app/lib/metronome/per_user_alerts", async () => {
+  const actual = await vi.importActual<typeof perUserAlerts>(
+    "@app/lib/metronome/per_user_alerts"
+  );
+  return {
+    ...actual,
+    syncMetronomePerUserCapAlert: vi.fn(),
+    clearMetronomePerUserCapAlert: vi.fn(),
+    getMetronomePerUserCap: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/metronome/per_user_usage", async () => {
+  const actual = await vi.importActual<typeof perUserUsage>(
+    "@app/lib/metronome/per_user_usage"
+  );
+  return {
+    ...actual,
+    fetchPerUserAwuUsage: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/api/metronome/credit_state_dispatcher", async () => {
+  const actual = await vi.importActual<typeof creditStateDispatcher>(
+    "@app/lib/api/metronome/credit_state_dispatcher"
+  );
+  return {
+    ...actual,
+    dispatchPerUserCapReached: vi.fn(),
+    dispatchPerUserCapResolved: vi.fn(),
+  };
+});
+
+const TEST_METRONOME_CUSTOMER_ID = "cust_test_xxx";
+const TEST_ALERT_ID = "alert_test_xxx";
+
+async function makeMetronomeWorkspaceWithCustomer(): Promise<WorkspaceType> {
+  return WorkspaceFactory.metronome({
+    metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(perUserAlerts.syncMetronomePerUserCapAlert).mockResolvedValue(
+    new Ok({ alertId: TEST_ALERT_ID })
+  );
+  vi.mocked(perUserAlerts.clearMetronomePerUserCapAlert).mockResolvedValue(
+    new Ok(undefined)
+  );
+  vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValue(
+    new Ok(null)
+  );
+  vi.mocked(perUserUsage.fetchPerUserAwuUsage).mockResolvedValue(
+    new Ok(new Map())
+  );
+  vi.mocked(creditStateDispatcher.dispatchPerUserCapReached).mockResolvedValue(
+    undefined
+  );
+  vi.mocked(creditStateDispatcher.dispatchPerUserCapResolved).mockResolvedValue(
+    undefined
+  );
+});
+
+describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
+  describe("auth", () => {
+    it("returns 403 when caller is not an admin", async () => {
+      const { req, res, user } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "user",
+      });
+      req.query.uId = user.sId;
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(403);
+      expect(res._getJSONData().error.type).toBe("workspace_auth_error");
+    });
+
+    it("returns 403 when workspace is not on Metronome billing", async () => {
+      const { req, res, user } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+      });
+      req.query.uId = user.sId;
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(403);
+      expect(res._getJSONData().error.type).toBe("plan_limit_error");
+    });
+  });
+
+  describe("method validation", () => {
+    it("returns 405 for unsupported methods", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const { req, res, user } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "admin",
+        workspace,
+      });
+      req.query.uId = user.sId;
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(405);
+    });
+  });
+
+  describe("input validation", () => {
+    it("returns 400 when uId is missing", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+      expect(res._getJSONData().error.type).toBe("invalid_request_error");
+    });
+
+    it("returns 404 when uId does not exist", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+      req.query.uId = "nonexistent-user-id";
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(404);
+      expect(res._getJSONData().error.type).toBe("workspace_user_not_found");
+    });
+
+    it("returns 400 on PUT with negative awuCredits", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const { req, res, user } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+      req.query.uId = user.sId;
+      req.body = { kind: "limited", awuCredits: -1 };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+      expect(res._getJSONData().error.type).toBe("invalid_request_error");
+    });
+
+    it("returns 400 on PUT with non-integer awuCredits", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const { req, res, user } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+      req.query.uId = user.sId;
+      req.body = { kind: "limited", awuCredits: 1.5 };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+    });
+
+    it("returns 400 on PUT with awuCredits above max", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const { req, res, user } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+      req.query.uId = user.sId;
+      req.body = { kind: "limited", awuCredits: 100_000_000 };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+    });
+  });
+
+  describe("GET", () => {
+    it("returns unlimited when no per-user alert exists", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const { req, res, user } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+      req.query.uId = user.sId;
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData()).toEqual({ kind: "unlimited" });
+    });
+
+    it("returns limited with threshold when alert exists", async () => {
+      vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValueOnce(
+        new Ok({
+          alertId: TEST_ALERT_ID,
+          threshold: 2500,
+        })
+      );
+
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const { req, res, user } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+      req.query.uId = user.sId;
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData()).toEqual({ kind: "limited", awuCredits: 2500 });
+    });
+  });
+
+  describe("PUT", () => {
+    it("clears alert + dispatches resolved for unlimited", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const targetUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, targetUser, {
+        role: "user",
+      });
+
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+      req.query.uId = targetUser.sId;
+      req.body = { kind: "unlimited" };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData()).toEqual({
+        limit: { kind: "unlimited" },
+        transitionedTo: "resolved",
+      });
+      expect(perUserAlerts.clearMetronomePerUserCapAlert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
+          workspaceSId: workspace.sId,
+          userSId: targetUser.sId,
+        })
+      );
+      expect(
+        creditStateDispatcher.dispatchPerUserCapResolved
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: targetUser.sId })
+      );
+      expect(perUserAlerts.syncMetronomePerUserCapAlert).not.toHaveBeenCalled();
+    });
+
+    it("syncs alert + dispatches resolved when usage is below cap", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const targetUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, targetUser, {
+        role: "user",
+      });
+
+      vi.mocked(perUserUsage.fetchPerUserAwuUsage).mockResolvedValueOnce(
+        new Ok(new Map([[targetUser.sId, 500]]))
+      );
+
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+      req.query.uId = targetUser.sId;
+      req.body = { kind: "limited", awuCredits: 1500 };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData()).toEqual({
+        limit: { kind: "limited", awuCredits: 1500 },
+        transitionedTo: "resolved",
+      });
+      expect(perUserAlerts.syncMetronomePerUserCapAlert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
+          workspaceSId: workspace.sId,
+          userSId: targetUser.sId,
+          awuCredits: 1500,
+        })
+      );
+      expect(
+        creditStateDispatcher.dispatchPerUserCapResolved
+      ).toHaveBeenCalled();
+      expect(
+        creditStateDispatcher.dispatchPerUserCapReached
+      ).not.toHaveBeenCalled();
+    });
+
+    it("dispatches reached when usage is at/above cap", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const targetUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, targetUser, {
+        role: "user",
+      });
+
+      vi.mocked(perUserUsage.fetchPerUserAwuUsage).mockResolvedValueOnce(
+        new Ok(new Map([[targetUser.sId, 2000]]))
+      );
+
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+      req.query.uId = targetUser.sId;
+      req.body = { kind: "limited", awuCredits: 1500 };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData().transitionedTo).toBe("reached");
+      expect(
+        creditStateDispatcher.dispatchPerUserCapReached
+      ).toHaveBeenCalled();
+      expect(
+        creditStateDispatcher.dispatchPerUserCapResolved
+      ).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/front/pages/api/w/[wId]/members/[uId]/spend_limit.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/spend_limit.ts
@@ -1,0 +1,161 @@
+/** @ignoreswagger */
+
+import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import {
+  type GetUserSpendLimitResponse,
+  getUserSpendLimit,
+  MAX_USER_SPEND_LIMIT_AWU_CREDITS,
+  MIN_USER_SPEND_LIMIT_AWU_CREDITS,
+  type SetUserSpendLimitResponse,
+  setUserSpendLimit,
+  type UserSpendLimitError,
+} from "@app/lib/api/users/spend_limit";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+const UpdateUserSpendLimitBodySchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("unlimited") }),
+  z.object({
+    kind: z.literal("limited"),
+    awuCredits: z
+      .number()
+      .int()
+      .min(MIN_USER_SPEND_LIMIT_AWU_CREDITS)
+      .max(MAX_USER_SPEND_LIMIT_AWU_CREDITS),
+  }),
+]);
+
+export type GetUserSpendLimitResponseBody = GetUserSpendLimitResponse;
+
+export type PutUserSpendLimitResponseBody = SetUserSpendLimitResponse;
+
+function mapErrorToHttp(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  error: UserSpendLimitError
+): void {
+  switch (error.type) {
+    case "user_not_found":
+      return apiError(req, res, {
+        status_code: 404,
+        api_error: {
+          type: "workspace_user_not_found",
+          message: error.message,
+        },
+      });
+    case "workspace_not_metronome_billed":
+      return apiError(req, res, {
+        status_code: 403,
+        api_error: {
+          type: "plan_limit_error",
+          message: error.message,
+        },
+      });
+    case "metronome_error":
+      return apiError(req, res, {
+        status_code: 502,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to update spend limit in billing system.",
+        },
+      });
+    default:
+      assertNever(error.type);
+  }
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<
+      GetUserSpendLimitResponseBody | PutUserSpendLimitResponseBody
+    >
+  >,
+  auth: Authenticator
+): Promise<void> {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can manage member spend limits.",
+      },
+    });
+  }
+
+  if (!auth.getNonNullableSubscriptionResource().isMetronomeOnlyBilled) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "plan_limit_error",
+        message:
+          "Per-user spend limits are only available on Metronome-billed workspaces.",
+      },
+    });
+  }
+
+  const { uId } = req.query;
+  if (!isString(uId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `uId` (string) is required.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const result = await getUserSpendLimit(auth, { userId: uId });
+      if (result.isErr()) {
+        return mapErrorToHttp(req, res, result.error);
+      }
+      return res.status(200).json(result.value);
+    }
+
+    case "PUT": {
+      const auditContext = getAuditLogContext(auth, req);
+      const bodyValidation = UpdateUserSpendLimitBodySchema.safeParse(req.body);
+      if (!bodyValidation.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${fromError(bodyValidation.error).toString()}`,
+          },
+        });
+      }
+
+      const result = await setUserSpendLimit(auth, {
+        userId: uId,
+        limit: bodyValidation.data,
+        auditContext,
+      });
+      if (result.isErr()) {
+        return mapErrorToHttp(req, res, result.error);
+      }
+      return res.status(200).json(result.value);
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, GET or PUT is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

Backend-only addition for the upcoming admin UI:

- lib/metronome/per_user_alerts.ts wraps Metronome's spend_threshold_reached alerts: get/sync/clear/list, keyed on a workspace+user uniqueness key so caps can be looked up later without per-user round-trips.
- lib/api/users/spend_limit.ts holds the get/set business logic, including the local "did we just cross the cap?" computation (Metronome alert evaluation can sit in EVALUATING for minutes, so we don't rely on it for the immediate state transition) and the audit emit.
- pages/api/w/[wId]/members/[uId]/spend_limit.ts is the admin-only GET/PUT endpoint, gated to Metronome-billed workspaces.
- member.spend_limit_updated audit schema + AuditAction entry.

No callers yet, the UI lands in a later PR.

## Tests

Unit + local

## Risk

low

## Deploy Plan

front