### PR TITLE
[connectors] fix: collapse consecutive line breaks in text extraction

### DIFF
--- a/connectors/src/connectors/shared/file.ts
+++ b/connectors/src/connectors/shared/file.ts
@@ -190,7 +190,8 @@ export async function handleTextExtraction(
           prefix: prefix
             ? `\n${prefix}: ${page.pageNumber}/${pages.length}\n`
             : null,
-          content: page.content,
+          // Collapse consecutive line breaks as they do not have much semantic meaning and cause overhead in chunking.
+          content: page.content.replace(/\n{5,}/g, "\n\n"),
           sections: [],
         })),
       })


### PR DESCRIPTION
## Description

- Upserting certain `.docx` documents causes a stack overflow in core ([logs](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E14%20%40dd.service%3Afront-worker&additional_filters=%5B%5D&clustering_pattern_field_path=message&cols=host%2C%40activityType&event=AwAAAZ5JUt7RfU5begAAABhBWjVKVXUtdEFBQk5LTWZhT0lWbzZBQVIAAAAkMDE5ZTQ5NTMtMjQ0Yy00YjM4LWJkZWYtNzA4NTU5MmEyNDBiAAN3Rw&fromUser=true&messageDisplay=inline&refresh_mode=sliding&saved-view-id=186561&storage=hot&stream_sort=desc&viz=stream&from_ts=1779343042574&to_ts=1779346642574&live=true)).
- Core logs [here](https://app.datadoghq.eu/logs?query=service%3Acore%20status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2C%40activityType&context_event=AZ5JUu-tAABNKMfaOIVo6AAR&event=AwAAAZ5JUtrYsO03CAAAABhBWjVKVXVidkFBQ2ctMXYwZEhnV1V3RHAAAAAkMDE5ZTQ5NTQtM2Q2My00YmRjLTgzYWYtMjQxYzUzNzBiYzM0AAKyug&fromUser=true&messageDisplay=inline&refresh_mode=paused&saved-view-id=186561&storage=hot&stream_sort=time%2Cdesc&viz=&from_ts=1779346616237&to_ts=1779346627511&live=false).
- Example of such doc [here](https://console.cloud.google.com/storage/browser/_details/bkt-prj-dust-europe-west1-upsert-queue/14947f3c-8bee-44cf-a0b4-f3c94edeb3a7.json;tab=live_object?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%257B_22k_22_3A_22_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_2214947f3c-8bee-44cf-a0b4-f3c94edeb3a7_5C_22_22%257D%255D%22))&inv=1&invt=AbpYpQ&project=prj-dust-europe-west1), in this example it's a docx that contain large tables with many empty cells, which produces an enormous consecutive runs of `\n` (2 millions).
- This PR handles in connectors, on a path generic to other documents (Google drive also) as the difference in number of line breaks typically does not add much semantic meaning. Goal is to also avoid exchanging this huge, abnormal payload.

## Tests

- Tested locally the upsert with the stripped content, was able to confirm this fixes the stack overflow.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
