### PR TITLE
[Forks] Enable branch-from-here using GCS versioned file copy

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -52,6 +52,7 @@ import { useRetryMessage } from "@app/hooks/useRetryMessage";
 import { CONTEXT_WINDOW_DOC_URL } from "@app/lib/api/assistant/errors";
 import config from "@app/lib/api/config";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { showDebugTools } from "@app/lib/development";
 import { clientFetch } from "@app/lib/egress/client";
 import type { DustError } from "@app/lib/error";
 import { FILE_ID_PATTERN } from "@app/lib/files";
@@ -120,9 +121,6 @@ import {
 } from "react";
 import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
-
-// TODO(sessions-branching): Re-enable once branching from a source message is fixed.
-const SHOW_BRANCH_FROM_HERE_ACTION = false;
 
 function PrunedContextChip() {
   return (
@@ -238,7 +236,7 @@ export function AgentMessage({
 }: AgentMessageProps) {
   const sId = agentMessage.sId;
   const [streamId, setStreamId] = useState<string>(`message-${sId}`);
-  const { hasFeature } = useFeatureFlags();
+  const { hasFeature, featureFlags } = useFeatureFlags();
   const isCollapsibleEnabled = hasFeature("collapsible_messages");
 
   const [isRetryHandlerProcessing, setIsRetryHandlerProcessing] =
@@ -715,7 +713,7 @@ export function AgentMessage({
     !isAgentMessageHandingOver &&
     !isProjectArchived;
 
-  const canBranchConversation = SHOW_BRANCH_FROM_HERE_ACTION && shouldShowCopy;
+  const canBranchConversation = showDebugTools(featureFlags) && shouldShowCopy;
 
   const shouldShowFeedback =
     !isDeleted &&

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -684,6 +684,9 @@ export async function createConversationFork(
       childConversationId: childConversation.sId,
       forkCompactionModel,
       sourceMessageRank: sourceMessage.value.rank,
+      sourceMessageCreatedAtMs: sourceMessageId
+        ? sourceMessage.value.agentMessage?.updatedAt.getTime()
+        : undefined,
     });
   });
 
@@ -700,6 +703,8 @@ export async function createConversationFork(
     workspaceId: auth.getNonNullableWorkspace().sId,
     sourceConversationId: parentConversation.sId,
     destConversationId: childConversationId.value.childConversationId,
+    sourceMessageTimestampMs:
+      childConversationId.value.sourceMessageCreatedAtMs,
   });
   if (launchForkWorkflowResult.isErr()) {
     logger.error(

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -591,6 +591,156 @@ describe("copyConversationGCSMount", () => {
       expect(result.error.message).toContain("GCS copy unavailable");
     }
   });
+
+  describe("slow path (sourceTimestampMs)", () => {
+    let getSortedFileVersionsMock: ReturnType<typeof vi.fn>;
+    const forkMs = new Date("2025-06-01T12:00:00.000Z").getTime();
+    const beforeFork = "2025-06-01T11:59:00.000Z";
+    const afterFork = "2025-06-01T12:01:00.000Z";
+
+    beforeEach(() => {
+      getSortedFileVersionsMock = vi.fn().mockResolvedValue([]);
+      vi.mocked(getPrivateUploadBucket).mockReturnValue({
+        getFiles: getFilesMock,
+        copyFile: copyFileMock,
+        getSortedFileVersions: getSortedFileVersionsMock,
+      } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+    });
+
+    it("copies files predating the fork directly without fetching version history", async () => {
+      const sourcePrefix = `w/${workspaceId}/conversations/${source.sId}/files/`;
+      const destPrefix = `w/${workspaceId}/conversations/${dest.sId}/files/`;
+      getFilesMock.mockResolvedValue([
+        { name: `${sourcePrefix}old.txt`, metadata: { updated: beforeFork } },
+      ]);
+
+      const result = await copyConversationGCSMount(auth, {
+        source,
+        dest,
+        sourceTimestampMs: forkMs,
+      });
+
+      assert(result.isOk());
+      expect(result.value.copiedCount).toBe(1);
+      expect(getSortedFileVersionsMock).not.toHaveBeenCalled();
+      expect(copyFileMock).toHaveBeenCalledOnce();
+      expect(copyFileMock).toHaveBeenCalledWith(
+        `${sourcePrefix}old.txt`,
+        `${destPrefix}old.txt`
+      );
+    });
+
+    it("fetches version history and copies the pre-fork generation for files written after the fork", async () => {
+      const sourcePrefix = `w/${workspaceId}/conversations/${source.sId}/files/`;
+      const destPrefix = `w/${workspaceId}/conversations/${dest.sId}/files/`;
+      const filePath = `${sourcePrefix}modified.txt`;
+      getFilesMock.mockResolvedValue([
+        { name: filePath, metadata: { updated: afterFork } },
+      ]);
+      getSortedFileVersionsMock.mockResolvedValue([
+        { name: filePath, metadata: { updated: afterFork, generation: "456" } },
+        {
+          name: filePath,
+          metadata: { updated: beforeFork, generation: "123" },
+        },
+      ]);
+
+      const result = await copyConversationGCSMount(auth, {
+        source,
+        dest,
+        sourceTimestampMs: forkMs,
+      });
+
+      assert(result.isOk());
+      expect(result.value.copiedCount).toBe(1);
+      expect(getSortedFileVersionsMock).toHaveBeenCalledOnce();
+      expect(getSortedFileVersionsMock).toHaveBeenCalledWith({ filePath });
+      expect(copyFileMock).toHaveBeenCalledWith(
+        filePath,
+        `${destPrefix}modified.txt`,
+        undefined,
+        { sourceGeneration: "123" }
+      );
+    });
+
+    it("skips a file written after the fork when no pre-fork version exists", async () => {
+      const sourcePrefix = `w/${workspaceId}/conversations/${source.sId}/files/`;
+      const filePath = `${sourcePrefix}new-file.txt`;
+      getFilesMock.mockResolvedValue([
+        { name: filePath, metadata: { updated: afterFork } },
+      ]);
+      getSortedFileVersionsMock.mockResolvedValue([
+        { name: filePath, metadata: { updated: afterFork, generation: "456" } },
+      ]);
+
+      const result = await copyConversationGCSMount(auth, {
+        source,
+        dest,
+        sourceTimestampMs: forkMs,
+      });
+
+      assert(result.isOk());
+      expect(result.value.copiedCount).toBe(0);
+      expect(copyFileMock).not.toHaveBeenCalled();
+    });
+
+    it("handles a mix of unchanged, version-filtered, and skipped files", async () => {
+      const sourcePrefix = `w/${workspaceId}/conversations/${source.sId}/files/`;
+      const destPrefix = `w/${workspaceId}/conversations/${dest.sId}/files/`;
+      const oldPath = `${sourcePrefix}old.txt`;
+      const modifiedPath = `${sourcePrefix}modified.txt`;
+      const newPath = `${sourcePrefix}new.txt`;
+
+      getFilesMock.mockResolvedValue([
+        { name: oldPath, metadata: { updated: beforeFork } },
+        { name: modifiedPath, metadata: { updated: afterFork } },
+        { name: newPath, metadata: { updated: afterFork } },
+      ]);
+      getSortedFileVersionsMock.mockImplementation(
+        ({ filePath }: { filePath: string }) => {
+          if (filePath === modifiedPath) {
+            return Promise.resolve([
+              {
+                name: modifiedPath,
+                metadata: { updated: afterFork, generation: "200" },
+              },
+              {
+                name: modifiedPath,
+                metadata: { updated: beforeFork, generation: "100" },
+              },
+            ]);
+          }
+          return Promise.resolve([
+            {
+              name: newPath,
+              metadata: { updated: afterFork, generation: "300" },
+            },
+          ]);
+        }
+      );
+
+      const result = await copyConversationGCSMount(auth, {
+        source,
+        dest,
+        sourceTimestampMs: forkMs,
+      });
+
+      assert(result.isOk());
+      expect(result.value.copiedCount).toBe(2);
+      expect(getSortedFileVersionsMock).toHaveBeenCalledTimes(2);
+      expect(copyFileMock).toHaveBeenCalledTimes(2);
+      expect(copyFileMock).toHaveBeenCalledWith(
+        oldPath,
+        `${destPrefix}old.txt`
+      );
+      expect(copyFileMock).toHaveBeenCalledWith(
+        modifiedPath,
+        `${destPrefix}modified.txt`,
+        undefined,
+        { sourceGeneration: "100" }
+      );
+    });
+  });
 });
 
 describe("copyMountFile", () => {

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -19,6 +19,7 @@ import logger from "@app/logger/logger";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { Ok } from "@app/types/shared/result";
 import assert from "assert";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -608,7 +609,7 @@ describe("copyConversationGCSMount", () => {
     const afterFork = "2025-06-01T12:01:00.000Z";
 
     beforeEach(() => {
-      getSortedFileVersionsMock = vi.fn().mockResolvedValue([]);
+      getSortedFileVersionsMock = vi.fn().mockResolvedValue(new Ok([]));
       vi.mocked(getPrivateUploadBucket).mockReturnValue({
         getFiles: getFilesMock,
         copyFile: copyFileMock,
@@ -646,13 +647,18 @@ describe("copyConversationGCSMount", () => {
       getFilesMock.mockResolvedValue([
         { name: filePath, metadata: { updated: afterFork } },
       ]);
-      getSortedFileVersionsMock.mockResolvedValue([
-        { name: filePath, metadata: { updated: afterFork, generation: "456" } },
-        {
-          name: filePath,
-          metadata: { updated: beforeFork, generation: "123" },
-        },
-      ]);
+      getSortedFileVersionsMock.mockResolvedValue(
+        new Ok([
+          {
+            name: filePath,
+            metadata: { updated: afterFork, generation: "456" },
+          },
+          {
+            name: filePath,
+            metadata: { updated: beforeFork, generation: "123" },
+          },
+        ])
+      );
 
       const result = await copyConversationGCSMount(auth, {
         source,
@@ -678,9 +684,14 @@ describe("copyConversationGCSMount", () => {
       getFilesMock.mockResolvedValue([
         { name: filePath, metadata: { updated: afterFork } },
       ]);
-      getSortedFileVersionsMock.mockResolvedValue([
-        { name: filePath, metadata: { updated: afterFork, generation: "456" } },
-      ]);
+      getSortedFileVersionsMock.mockResolvedValue(
+        new Ok([
+          {
+            name: filePath,
+            metadata: { updated: afterFork, generation: "456" },
+          },
+        ])
+      );
 
       const result = await copyConversationGCSMount(auth, {
         source,
@@ -708,23 +719,27 @@ describe("copyConversationGCSMount", () => {
       getSortedFileVersionsMock.mockImplementation(
         ({ filePath }: { filePath: string }) => {
           if (filePath === modifiedPath) {
-            return Promise.resolve([
-              {
-                name: modifiedPath,
-                metadata: { updated: afterFork, generation: "200" },
-              },
-              {
-                name: modifiedPath,
-                metadata: { updated: beforeFork, generation: "100" },
-              },
-            ]);
+            return Promise.resolve(
+              new Ok([
+                {
+                  name: modifiedPath,
+                  metadata: { updated: afterFork, generation: "200" },
+                },
+                {
+                  name: modifiedPath,
+                  metadata: { updated: beforeFork, generation: "100" },
+                },
+              ])
+            );
           }
-          return Promise.resolve([
-            {
-              name: newPath,
-              metadata: { updated: afterFork, generation: "300" },
-            },
-          ]);
+          return Promise.resolve(
+            new Ok([
+              {
+                name: newPath,
+                metadata: { updated: afterFork, generation: "300" },
+              },
+            ])
+          );
         }
       );
 

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -519,10 +519,14 @@ describe("copyConversationGCSMount", () => {
   it("copies every file under the source prefix to the dest prefix", async () => {
     const sourcePrefix = `w/${workspaceId}/conversations/${source.sId}/files/`;
     const destPrefix = `w/${workspaceId}/conversations/${dest.sId}/files/`;
+    const past = "2020-01-01T00:00:00.000Z";
     getFilesMock.mockResolvedValue([
-      { name: `${sourcePrefix}report.pdf` },
-      { name: `${sourcePrefix}.tool_outputs/chart.png` },
-      { name: `${sourcePrefix}data/foo.csv` },
+      { name: `${sourcePrefix}report.pdf`, metadata: { updated: past } },
+      {
+        name: `${sourcePrefix}.tool_outputs/chart.png`,
+        metadata: { updated: past },
+      },
+      { name: `${sourcePrefix}data/foo.csv`, metadata: { updated: past } },
     ]);
 
     const result = await copyConversationGCSMount(auth, { source, dest });
@@ -581,7 +585,12 @@ describe("copyConversationGCSMount", () => {
 
   it("returns Err when a copy fails", async () => {
     const sourcePrefix = `w/${workspaceId}/conversations/${source.sId}/files/`;
-    getFilesMock.mockResolvedValue([{ name: `${sourcePrefix}report.pdf` }]);
+    getFilesMock.mockResolvedValue([
+      {
+        name: `${sourcePrefix}report.pdf`,
+        metadata: { updated: "2020-01-01T00:00:00.000Z" },
+      },
+    ]);
     copyFileMock.mockRejectedValue(new Error("GCS copy unavailable"));
 
     const result = await copyConversationGCSMount(auth, { source, dest });

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -579,9 +579,13 @@ export async function copyConversationGCSMount(
   {
     source,
     dest,
+    sourceTimestampMs,
   }: {
     source: ConversationResource;
     dest: ConversationResource;
+    // When set, only copy file versions that existed at or before this timestamp.
+    // Used when branching from a specific mid-conversation message.
+    sourceTimestampMs?: number;
   }
 ): Promise<Result<{ copiedCount: number }, Error>> {
   const owner = auth.getNonNullableWorkspace();
@@ -602,12 +606,12 @@ export async function copyConversationGCSMount(
   const bucket = getPrivateUploadBucket();
 
   try {
-    const gcsFiles = await bucket.getFiles({
+    const currentFiles = await bucket.getFiles({
       prefix: sourcePrefix,
       maxResults: GCS_MOUNT_COPY_MAX_FILES,
     });
 
-    if (gcsFiles.length >= GCS_MOUNT_COPY_MAX_FILES) {
+    if (currentFiles.length >= GCS_MOUNT_COPY_MAX_FILES) {
       logger.warn(
         {
           workspaceId: owner.sId,
@@ -622,17 +626,76 @@ export async function copyConversationGCSMount(
       throw new Error("GCS mount copy hit the max files cap");
     }
 
+    if (sourceTimestampMs === undefined) {
+      // Fast path: full-conversation or latest-message branch — copy current versions as-is.
+      await concurrentExecutor(
+        currentFiles,
+        async (gcsFile) => {
+          const relativePath = gcsFile.name.slice(sourcePrefix.length);
+          const destPath = `${destPrefix}${relativePath}`;
+          await bucket.copyFile(gcsFile.name, destPath);
+        },
+        { concurrency: GCS_MOUNT_COPY_CONCURRENCY }
+      );
+
+      return new Ok({ copiedCount: currentFiles.length });
+    }
+
+    // Slow path: mid-conversation branch.
+    // For each file: if the current version predates the fork, copy directly.
+    // Otherwise fetch per-file version history to find the most recent pre-fork
+    // generation, or skip if the file didn't exist yet.
+    // All files run in a single concurrent pass to avoid waterfall between the two cases.
+    let copiedCount = 0;
+
     await concurrentExecutor(
-      gcsFiles,
+      currentFiles,
       async (gcsFile) => {
         const relativePath = gcsFile.name.slice(sourcePrefix.length);
         const destPath = `${destPrefix}${relativePath}`;
-        await bucket.copyFile(gcsFile.name, destPath);
+
+        const isUnchanged =
+          isString(gcsFile.metadata.updated) &&
+          new Date(gcsFile.metadata.updated).getTime() <= sourceTimestampMs;
+
+        if (isUnchanged) {
+          await bucket.copyFile(gcsFile.name, destPath);
+          copiedCount++;
+          return;
+        }
+
+        const versions = await bucket.getSortedFileVersions({
+          filePath: gcsFile.name,
+        });
+        const preFork = versions.find((v) => {
+          if (
+            !isString(v.metadata.updated) ||
+            !isString(v.metadata.generation)
+          ) {
+            logger.warn(
+              {
+                workspaceId: owner.sId,
+                sourceConversationId: source.sId,
+                fileName: gcsFile.name,
+              },
+              "GCS mount versioned copy: skipping file version with missing metadata."
+            );
+            return false;
+          }
+          return new Date(v.metadata.updated).getTime() <= sourceTimestampMs;
+        });
+        if (!preFork) {
+          return; // file didn't exist before the fork point
+        }
+        await bucket.copyFile(gcsFile.name, destPath, undefined, {
+          sourceGeneration: String(preFork.metadata.generation),
+        });
+        copiedCount++;
       },
       { concurrency: GCS_MOUNT_COPY_CONCURRENCY }
     );
 
-    return new Ok({ copiedCount: gcsFiles.length });
+    return new Ok({ copiedCount });
   } catch (err) {
     return new Err(normalizeError(err));
   }

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -650,10 +650,13 @@ export async function copyConversationGCSMount(
           return;
         }
 
-        const versions = await bucket.getSortedFileVersions({
+        const versionsResult = await bucket.getSortedFileVersions({
           filePath: gcsFile.name,
         });
-        const preFork = versions.find((v) => {
+        if (versionsResult.isErr()) {
+          throw versionsResult.error;
+        }
+        const preFork = versionsResult.value.find((v) => {
           if (
             !isString(v.metadata.updated) ||
             !isString(v.metadata.generation)

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -626,26 +626,12 @@ export async function copyConversationGCSMount(
       throw new Error("GCS mount copy hit the max files cap");
     }
 
-    if (sourceTimestampMs === undefined) {
-      // Fast path: full-conversation or latest-message branch — copy current versions as-is.
-      await concurrentExecutor(
-        currentFiles,
-        async (gcsFile) => {
-          const relativePath = gcsFile.name.slice(sourcePrefix.length);
-          const destPath = `${destPrefix}${relativePath}`;
-          await bucket.copyFile(gcsFile.name, destPath);
-        },
-        { concurrency: GCS_MOUNT_COPY_CONCURRENCY }
-      );
-
-      return new Ok({ copiedCount: currentFiles.length });
-    }
-
-    // Slow path: mid-conversation branch.
-    // For each file: if the current version predates the fork, copy directly.
-    // Otherwise fetch per-file version history to find the most recent pre-fork
-    // generation, or skip if the file didn't exist yet.
-    // All files run in a single concurrent pass to avoid waterfall between the two cases.
+    // Single path for both cases. Using `Date.now()` as the cutoff when no
+    // timestamp is given means every live file predates it, so all pass the
+    // `isUnchanged` check and are copied directly — no version lookups needed.
+    // When branching from a specific message, files unchanged since the fork
+    // are copied directly while modified files get a per-file version lookup.
+    const forkTimestampMs = sourceTimestampMs ?? Date.now();
     let copiedCount = 0;
 
     await concurrentExecutor(
@@ -656,7 +642,7 @@ export async function copyConversationGCSMount(
 
         const isUnchanged =
           isString(gcsFile.metadata.updated) &&
-          new Date(gcsFile.metadata.updated).getTime() <= sourceTimestampMs;
+          new Date(gcsFile.metadata.updated).getTime() <= forkTimestampMs;
 
         if (isUnchanged) {
           await bucket.copyFile(gcsFile.name, destPath);
@@ -682,7 +668,7 @@ export async function copyConversationGCSMount(
             );
             return false;
           }
-          return new Date(v.metadata.updated).getTime() <= sourceTimestampMs;
+          return new Date(v.metadata.updated).getTime() <= forkTimestampMs;
         });
         if (!preFork) {
           return; // file didn't exist before the fork point

--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -224,32 +224,26 @@ export class FileStorage {
     filePath: string;
     maxResults?: number;
   }) {
-    try {
-      const [files] = await this.bucket.getFiles({
-        prefix: filePath,
-        versions: true,
-        maxResults,
+    const [files] = await this.bucket.getFiles({
+      prefix: filePath,
+      versions: true,
+      maxResults,
+    });
+
+    // Filter to only the exact file path and sort by generation (newest first)
+    // Generation represents the version order in GCS
+    // can be string or number per GCS types, though in practice it seems to always be a number
+    return files
+      .filter((file) => file.name === filePath)
+      .sort((a, b) => {
+        const genA = isNumber(a.metadata.generation)
+          ? a.metadata.generation
+          : Number(a.metadata.generation ?? 0);
+        const genB = isNumber(b.metadata.generation)
+          ? b.metadata.generation
+          : Number(b.metadata.generation ?? 0);
+        return genB - genA;
       });
-
-      // Filter to only the exact file path and sort by generation (newest first)
-      // Generation represents the version order in GCS
-      // can be string or number per GCS types, though in practice it seems to always be a number
-      const versions = files
-        .filter((file) => file.name === filePath)
-        .sort((a, b) => {
-          const genA = isNumber(a.metadata.generation)
-            ? a.metadata.generation
-            : Number(a.metadata.generation ?? 0);
-          const genB = isNumber(b.metadata.generation)
-            ? b.metadata.generation
-            : Number(b.metadata.generation ?? 0);
-          return genB - genA;
-        });
-
-      return versions;
-    } catch {
-      return [];
-    }
   }
 
   get name() {

--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -285,13 +285,17 @@ export class FileStorage {
   async copyFile(
     srcPath: string,
     destPath: string,
-    destinationStorage: FileStorage = this
+    destinationStorage: FileStorage = this,
+    { sourceGeneration }: { sourceGeneration?: string } = {}
   ): Promise<void> {
     const destinationFile = destinationStorage.file(destPath);
+    const sourceFile = sourceGeneration
+      ? this.bucket.file(srcPath, { generation: sourceGeneration })
+      : this.file(srcPath);
 
     for (let attempt = 1; attempt <= GCS_COPY_MAX_RETRIES; attempt++) {
       try {
-        await this.file(srcPath).copy(destinationFile);
+        await sourceFile.copy(destinationFile);
         return;
       } catch (err) {
         if (attempt === GCS_COPY_MAX_RETRIES) {

--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -223,27 +223,33 @@ export class FileStorage {
   }: {
     filePath: string;
     maxResults?: number;
-  }) {
-    const [files] = await this.bucket.getFiles({
-      prefix: filePath,
-      versions: true,
-      maxResults,
-    });
-
-    // Filter to only the exact file path and sort by generation (newest first)
-    // Generation represents the version order in GCS
-    // can be string or number per GCS types, though in practice it seems to always be a number
-    return files
-      .filter((file) => file.name === filePath)
-      .sort((a, b) => {
-        const genA = isNumber(a.metadata.generation)
-          ? a.metadata.generation
-          : Number(a.metadata.generation ?? 0);
-        const genB = isNumber(b.metadata.generation)
-          ? b.metadata.generation
-          : Number(b.metadata.generation ?? 0);
-        return genB - genA;
+  }): Promise<Result<File[], Error>> {
+    try {
+      const [files] = await this.bucket.getFiles({
+        prefix: filePath,
+        versions: true,
+        maxResults,
       });
+
+      // Filter to only the exact file path and sort by generation (newest first)
+      // Generation represents the version order in GCS
+      // can be string or number per GCS types, though in practice it seems to always be a number
+      return new Ok(
+        files
+          .filter((file) => file.name === filePath)
+          .sort((a, b) => {
+            const genA = isNumber(a.metadata.generation)
+              ? a.metadata.generation
+              : Number(a.metadata.generation ?? 0);
+            const genB = isNumber(b.metadata.generation)
+              ? b.metadata.generation
+              : Number(b.metadata.generation ?? 0);
+            return genB - genA;
+          })
+      );
+    } catch (err) {
+      return new Err(normalizeError(err));
+    }
   }
 
   get name() {

--- a/front/lib/resources/conversation_fork_resource.ts
+++ b/front/lib/resources/conversation_fork_resource.ts
@@ -14,6 +14,7 @@ import {
   makeSId,
 } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import logger from "@app/logger/logger";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
@@ -218,7 +219,7 @@ export class ConversationForkResource extends BaseResource<ConversationForkModel
   ): Promise<void> {
     const owner = auth.getNonNullableWorkspace();
 
-    await this.model.update(
+    const [affectedCount] = await this.model.update(
       { fileCopyStatus: "done" },
       {
         where: {
@@ -227,6 +228,35 @@ export class ConversationForkResource extends BaseResource<ConversationForkModel
         },
       }
     );
+
+    if (affectedCount === 0) {
+      logger.warn(
+        {
+          childConversationModelId,
+          workspaceId: owner.id,
+        },
+        "[conversation_fork_queue] markFileCopied updated 0 rows — fork may remain blocked."
+      );
+    }
+  }
+
+  static async markFileCopiedByDestSId(
+    auth: Authenticator,
+    { childConversationSId }: { childConversationSId: string }
+  ): Promise<void> {
+    const owner = auth.getNonNullableWorkspace();
+    const conv = await ConversationModel.findOne({
+      where: { sId: childConversationSId, workspaceId: owner.id },
+      attributes: ["id"],
+    });
+    if (!conv) {
+      logger.warn(
+        { childConversationSId, workspaceId: owner.id },
+        "[conversation_fork_queue] markFileCopiedByDestSId: conversation not found, fork may remain blocked."
+      );
+      return;
+    }
+    await this.markFileCopied(auth, { childConversationModelId: conv.id });
   }
 
   static async fetchByModelIds(

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -3147,7 +3147,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           model: AgentMessageModel,
           as: "agentMessage",
           required: true,
-          attributes: ["status"],
+          attributes: ["status", "updatedAt"],
           where: {
             status: { [Op.ne]: "created" },
           },

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -771,20 +771,14 @@ export class FileResource extends BaseResource<FileModel> {
   /**
    * Get sorted file versions from GCS (newest first).
    * Used for reverting Interactive Content files to previous versions.
-   * Returns an empty array if versions cannot be retrieved.
    */
   private async getSortedFileVersions(
     auth: Authenticator,
     maxResults?: number
-  ): Promise<File[]> {
+  ): Promise<Result<File[], Error>> {
     const filePath = this.getCloudStoragePath(auth, "original");
     const fileStorage = getPrivateUploadBucket();
-
-    try {
-      return await fileStorage.getSortedFileVersions({ filePath, maxResults });
-    } catch {
-      return [];
-    }
+    return fileStorage.getSortedFileVersions({ filePath, maxResults });
   }
 
   /**
@@ -801,7 +795,8 @@ export class FileResource extends BaseResource<FileModel> {
     }
   ): Promise<Result<undefined, string>> {
     // Get all versions of the file (sorted newest to oldest)
-    const versions = await this.getSortedFileVersions(auth);
+    const versionsResult = await this.getSortedFileVersions(auth);
+    const versions = versionsResult.isOk() ? versionsResult.value : [];
 
     // Check if there's a previous version available before attempting revert
     if (versions.length < 2) {

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -780,10 +780,11 @@ export class FileResource extends BaseResource<FileModel> {
     const filePath = this.getCloudStoragePath(auth, "original");
     const fileStorage = getPrivateUploadBucket();
 
-    return fileStorage.getSortedFileVersions({
-      filePath,
-      maxResults,
-    });
+    try {
+      return await fileStorage.getSortedFileVersions({ filePath, maxResults });
+    } catch {
+      return [];
+    }
   }
 
   /**

--- a/front/temporal/conversation_fork_queue/activities.ts
+++ b/front/temporal/conversation_fork_queue/activities.ts
@@ -8,10 +8,12 @@ export async function copyConversationGCSMountActivity({
   workspaceId,
   sourceConversationId,
   destConversationId,
+  sourceMessageTimestampMs,
 }: {
   workspaceId: string;
   sourceConversationId: string;
   destConversationId: string;
+  sourceMessageTimestampMs?: number;
 }): Promise<void> {
   const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
 
@@ -42,7 +44,11 @@ export async function copyConversationGCSMountActivity({
     return;
   }
 
-  const result = await copyConversationGCSMount(auth, { source, dest });
+  const result = await copyConversationGCSMount(auth, {
+    source,
+    dest,
+    sourceTimestampMs: sourceMessageTimestampMs,
+  });
   if (result.isErr()) {
     // GCS copy failed. Log and unblock anyway — permanently blocking the fork
     // is worse than letting the user post with potentially missing files.

--- a/front/temporal/conversation_fork_queue/activities.ts
+++ b/front/temporal/conversation_fork_queue/activities.ts
@@ -39,6 +39,10 @@ export async function copyConversationGCSMountActivity({
       await ConversationForkResource.markFileCopied(auth, {
         childConversationModelId: dest.id,
       });
+    } else {
+      await ConversationForkResource.markFileCopiedByDestSId(auth, {
+        childConversationSId: destConversationId,
+      });
     }
 
     return;

--- a/front/temporal/conversation_fork_queue/client.ts
+++ b/front/temporal/conversation_fork_queue/client.ts
@@ -12,10 +12,12 @@ export async function launchConversationForkWorkflow({
   workspaceId,
   sourceConversationId,
   destConversationId,
+  sourceMessageTimestampMs,
 }: {
   workspaceId: string;
   sourceConversationId: string;
   destConversationId: string;
+  sourceMessageTimestampMs?: number;
 }): Promise<Result<undefined, Error>> {
   const client = await getTemporalClientForFrontNamespace();
   const workflowId = makeConversationForkWorkflowId({
@@ -25,7 +27,14 @@ export async function launchConversationForkWorkflow({
 
   try {
     await client.workflow.start(conversationForkWorkflow, {
-      args: [{ workspaceId, sourceConversationId, destConversationId }],
+      args: [
+        {
+          workspaceId,
+          sourceConversationId,
+          destConversationId,
+          sourceMessageTimestampMs,
+        },
+      ],
       taskQueue: QUEUE_NAME,
       workflowId,
       memo: {

--- a/front/temporal/conversation_fork_queue/workflows.ts
+++ b/front/temporal/conversation_fork_queue/workflows.ts
@@ -17,14 +17,17 @@ export async function conversationForkWorkflow({
   workspaceId,
   sourceConversationId,
   destConversationId,
+  sourceMessageTimestampMs,
 }: {
   workspaceId: string;
   sourceConversationId: string;
   destConversationId: string;
+  sourceMessageTimestampMs?: number;
 }): Promise<void> {
   await copyConversationGCSMountActivity({
     workspaceId,
     sourceConversationId,
     destConversationId,
+    sourceMessageTimestampMs,
   });
 }


### PR DESCRIPTION
## Description

## Summary

Conversation branching was disabled mid-conversation because the GCS mount copy (agent filesystem state) blindly cloned all files regardless of the fork point.

The fix threads the source message timestamp through to the GCS copy and splits into two paths: if no source message is given (full branch), the existing bulk copy runs unchanged. If a source message is given, we first list current file versions -> files that predate the fork are copied directly, files written after the fork get a per-file version history lookup to find their pre-fork state, and files that didn't exist yet are skipped.

We initially considered a single `getFiles({ versions: true })` scan over all files, but that fetches full version history for every file even when most haven't changed since the fork. The two-pass approach only pays the version-history cost for files actually written after the fork point.

## Tests

Locally. 
Will then test on prod since under a flag. 

## Risk

To be able to test quickly on prod, shipping only for workspace with dev tools = only for dust. 
Can be rolled back. 

## Deploy Plan

Deploy front. 
No Temporal version bump needed: the workflow input change is additive (optional field). The workflow is short-lived with no wait states, so there is no history replay risk from in-flight executions at deploy time.