### PR TITLE
[front] fix: retry GCS socket hang ups with SDK retry settings

### DIFF
--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -20,6 +20,7 @@ import { pipeline } from "stream/promises";
 
 const GCS_COPY_MAX_RETRIES = 3;
 const GCS_COPY_BASE_DELAY_MS = 500;
+const GCS_MAX_RETRIES = 3; // Same as the SDK default.
 const GCS_EXTRA_RETRYABLE_ERROR_MESSAGE_REGEX = /socket hang up/i;
 
 const DEFAULT_SIGNED_URL_EXPIRATION_DELAY_MS = 5 * 60 * 1000; // 5 minutes.
@@ -46,6 +47,7 @@ export class FileStorage {
     this.storage = new Storage({
       keyFilename: useServiceAccount ? config.getServiceAccount() : undefined,
       retryOptions: {
+        maxRetries: GCS_MAX_RETRIES,
         retryableErrorFn: isRetryableGCSError,
       },
     });

--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -11,8 +11,8 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { stripNullBytes } from "@app/types/shared/utils/string_utils";
-import type { Bucket, File } from "@google-cloud/storage";
-import { Storage } from "@google-cloud/storage";
+import type { ApiError, Bucket, File } from "@google-cloud/storage";
+import { RETRYABLE_ERR_FN_DEFAULT, Storage } from "@google-cloud/storage";
 import type formidable from "formidable";
 import fs from "fs";
 import isNumber from "lodash/isNumber";
@@ -20,11 +20,19 @@ import { pipeline } from "stream/promises";
 
 const GCS_COPY_MAX_RETRIES = 3;
 const GCS_COPY_BASE_DELAY_MS = 500;
+const GCS_EXTRA_RETRYABLE_ERROR_MESSAGE_REGEX = /socket hang up/i;
 
 const DEFAULT_SIGNED_URL_EXPIRATION_DELAY_MS = 5 * 60 * 1000; // 5 minutes.
 
 interface FileStorageOptions {
   useServiceAccount?: boolean;
+}
+
+function isRetryableGCSError(err: ApiError): boolean {
+  return (
+    RETRYABLE_ERR_FN_DEFAULT(err) ||
+    GCS_EXTRA_RETRYABLE_ERROR_MESSAGE_REGEX.test(err.message)
+  );
 }
 
 export class FileStorage {
@@ -37,6 +45,9 @@ export class FileStorage {
   ) {
     this.storage = new Storage({
       keyFilename: useServiceAccount ? config.getServiceAccount() : undefined,
+      retryOptions: {
+        retryableErrorFn: isRetryableGCSError,
+      },
     });
 
     this.bucket = this.storage.bucket(bucketKey);


### PR DESCRIPTION
## Description

- We have seen some fetch errors when listing files for a proejct (`project_files` endpoint, `listGCSMountFiles`)
- The errors are socket hang up errors written by node ([logs](https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20status%3Aerror%20%40dd.env%3Aprod&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZ5JikgcKNJtwwAAABhBWjVKaWxmdkFBRGVHX0hyVzF6VlBnQW8AAAAkMDE5ZTQ5OGEtYThmNS00NWVlLTg1ODEtNDM5YmU5ZDc3Mzg0AAKR5g&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1779350052000&to_ts=1779350652000&live=false)).
- We do not seem to retry on these errors, this PR adds retrying in thje GCS SDK.
- Preserve the SDK default retry predicate and retry settings for existing retryable errors, including `ECONNRESET`, rate limits, and 5xx responses.

## Tests

## Risk

- Low. Safe to rollback.

## Deploy Plan

- Deploy front.
