### PR TITLE
[dust-hive] chore: Support front-api

### DIFF
--- a/x/henry/dust-hive/src/commands/logs.ts
+++ b/x/henry/dust-hive/src/commands/logs.ts
@@ -5,7 +5,7 @@ import { withEnvironment } from "../lib/commands";
 import { getLogPath } from "../lib/paths";
 import { CommandError, Err, Ok, type Result } from "../lib/result";
 import { ensureServiceLogsTui } from "../lib/scripts";
-import { ALL_SERVICES, type ServiceName, isServiceName } from "../lib/services";
+import { ALL_SERVICES, type ServiceName, getFrontService, isServiceName } from "../lib/services";
 
 interface LogsOptions {
   follow?: boolean;
@@ -54,8 +54,8 @@ export const logsCommand = withEnvironment(
       return runInteractiveMode(env.name, serviceArg);
     }
 
-    // Determine target service (default to front)
-    let targetService: ServiceName = "front";
+    // Determine target service (default to the active front variant)
+    let targetService: ServiceName = getFrontService();
     if (serviceArg) {
       const result = validateServiceArg(serviceArg);
       if (!result.ok) return result;

--- a/x/henry/dust-hive/src/commands/restart.ts
+++ b/x/henry/dust-hive/src/commands/restart.ts
@@ -5,12 +5,12 @@ import { stopService } from "../lib/process";
 import { restoreTerminal } from "../lib/prompt";
 import { startService, waitForServiceReady } from "../lib/registry";
 import { CommandError, Err, Ok, type Result } from "../lib/result";
-import { ALL_SERVICES, type ServiceName, isServiceName } from "../lib/services";
+import { ALL_SERVICES, type ServiceName, getActiveServices, isServiceName } from "../lib/services";
 
 async function selectService(): Promise<ServiceName | null> {
   const result = await p.select({
     message: "Select service to restart",
-    options: ALL_SERVICES.map((name) => ({ value: name, label: name })),
+    options: getActiveServices().map((name) => ({ value: name, label: name })),
   });
 
   if (p.isCancel(result)) {

--- a/x/henry/dust-hive/src/commands/status.ts
+++ b/x/henry/dust-hive/src/commands/status.ts
@@ -4,13 +4,13 @@ import type { PortAllocation } from "../lib/ports";
 import { isServiceRunning } from "../lib/process";
 import { checkServiceHealth, getHealthChecks } from "../lib/registry";
 import { Ok } from "../lib/result";
-import { ALL_SERVICES } from "../lib/services";
+import { getActiveServices } from "../lib/services";
 import { getStateInfo, isDockerRunning } from "../lib/state";
 
 async function printServiceStatus(name: string): Promise<void> {
   console.log("Services:");
 
-  for (const service of ALL_SERVICES) {
+  for (const service of getActiveServices()) {
     const running = await isServiceRunning(name, service);
     const status = running ? "\x1b[32m●\x1b[0m" : "\x1b[90m○\x1b[0m";
     console.log(`  ${status} ${service}`);

--- a/x/henry/dust-hive/src/commands/warm.ts
+++ b/x/henry/dust-hive/src/commands/warm.ts
@@ -12,7 +12,7 @@ import { cleanupServicePorts, formatBlockedPorts } from "../lib/ports";
 import { isServiceRunning, readPid } from "../lib/process";
 import { startService, waitForServiceReady } from "../lib/registry";
 import { CommandError, Err, Ok } from "../lib/result";
-import type { ServiceName } from "../lib/services";
+import { type ServiceName, getFrontService } from "../lib/services";
 import { buildShell } from "../lib/shell";
 import { isDockerRunning } from "../lib/state";
 
@@ -152,8 +152,10 @@ export const warmCommand = withEnvironment("warm", async (env, options: WarmOpti
 
   // Check if already warm
   const dockerRunning = await isDockerRunning(env.name);
+  const frontService = getFrontService();
+
   if (dockerRunning) {
-    const frontRunning = await isServiceRunning(env.name, "front");
+    const frontRunning = await isServiceRunning(env.name, frontService);
     if (frontRunning) {
       logger.info(`Environment '${env.name}' is already warm`);
       return Ok(undefined);
@@ -164,7 +166,7 @@ export const warmCommand = withEnvironment("warm", async (env, options: WarmOpti
   console.log();
 
   // Clean up orphaned processes on service ports
-  const portServices: ServiceName[] = ["front", "core", "connectors", "oauth"];
+  const portServices: ServiceName[] = [frontService, "core", "connectors", "oauth"];
   const servicePids = await Promise.all(portServices.map((service) => readPid(env.name, service)));
   const allowedPids = new Set(servicePids.filter((pid): pid is number => pid !== null));
   const { killedPorts, blockedPorts } = await cleanupServicePorts(env.ports, {
@@ -199,7 +201,7 @@ export const warmCommand = withEnvironment("warm", async (env, options: WarmOpti
 
   // Start front immediately to begin page compilation
   // It will retry connections to DB/Redis until they're ready
-  await startService(env, "front");
+  await startService(env, frontService);
 
   // Start pre-warming immediately - curls will retry until Next.js is ready
   // Pages compile while Docker containers start and init runs
@@ -280,7 +282,7 @@ export const warmCommand = withEnvironment("warm", async (env, options: WarmOpti
   // Start forwarder as soon as front is healthy (don't wait for core/oauth)
   logger.step("Waiting for services to be healthy...");
   await Promise.all([
-    waitForServiceReady(env, "front").then(async () => {
+    waitForServiceReady(env, frontService).then(async () => {
       if (!noForward) {
         await startForwarder(env.ports.base, env.name);
       }
@@ -299,7 +301,7 @@ export const warmCommand = withEnvironment("warm", async (env, options: WarmOpti
   console.log();
   logger.success(`Environment '${env.name}' is now warm! (${elapsed}s)`);
   console.log();
-  console.log(`  Front:       http://localhost:${env.ports.front}`);
+  console.log(`  ${`${frontService}:`.padEnd(13)}http://localhost:${env.ports.front}`);
   console.log(`  Core:        http://localhost:${env.ports.core}`);
   console.log(`  Connectors:  http://localhost:${env.ports.connectors}`);
   console.log(`  Front app:   http://localhost:${env.ports.frontSpaApp}`);

--- a/x/henry/dust-hive/src/lib/envgen.ts
+++ b/x/henry/dust-hive/src/lib/envgen.ts
@@ -39,7 +39,7 @@ export NEXT_PUBLIC_DUST_API_URL=http://localhost:${ports.front}
 export NEXT_PUBLIC_DUST_STATIC_WEBSITE_URL=http://localhost:${ports.front}
 export NEXT_PUBLIC_DUST_APP_URL=http://localhost:${ports.frontSpaApp}
 export POKE_APP_URL=http://localhost:${ports.frontSpaPoke}
-export DUST_AUTH_REDIRECT_BASE_URL=http://localhost:3000
+export DUST_AUTH_REDIRECT_BASE_URL=http://localhost:${ports.front}
 export CONNECTORS_PUBLIC_URL=http://localhost:${ports.connectors}
 
 # === Database URIs ===

--- a/x/henry/dust-hive/src/lib/multiplexer/index.ts
+++ b/x/henry/dust-hive/src/lib/multiplexer/index.ts
@@ -12,7 +12,7 @@ import { ZellijAdapter } from "./zellij";
 
 // Re-export types for convenience
 export type { MultiplexerAdapter, MultiplexerType, LayoutConfig, MainLayoutConfig } from "./types";
-export { getSessionName, MAIN_SESSION_NAME, SESSION_PREFIX, TAB_NAMES } from "./types";
+export { getSessionName, getTabName, MAIN_SESSION_NAME, SESSION_PREFIX } from "./types";
 
 /**
  * Registry of available multiplexer adapters

--- a/x/henry/dust-hive/src/lib/multiplexer/tmux.ts
+++ b/x/henry/dust-hive/src/lib/multiplexer/tmux.ts
@@ -3,7 +3,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { logger } from "../logger";
 import { getInstallInstructions as getPlatformInstallInstructions } from "../platform";
-import { ALL_SERVICES } from "../services";
+import { getActiveServices } from "../services";
 import { shellQuote } from "../shell";
 import type {
   InstallCheckResult,
@@ -12,7 +12,7 @@ import type {
   MultiplexerAdapter,
   MultiplexerType,
 } from "./types";
-import { SESSION_PREFIX, TAB_NAMES } from "./types";
+import { SESSION_PREFIX, getTabName } from "./types";
 
 /**
  * Base directory for tmux layout scripts
@@ -219,8 +219,8 @@ export class TmuxAdapter implements MultiplexerAdapter {
       );
     } else {
       // Individual service windows
-      for (const service of ALL_SERVICES) {
-        const tabName = TAB_NAMES[service];
+      for (const service of getActiveServices()) {
+        const tabName = getTabName(service);
         lines.push(
           `# Create ${service} logs window`,
           `tmux new-window -t "$SESSION_NAME" -n ${shellQuote(tabName)} -c "$WORKTREE_PATH"`,

--- a/x/henry/dust-hive/src/lib/multiplexer/types.ts
+++ b/x/henry/dust-hive/src/lib/multiplexer/types.ts
@@ -217,12 +217,13 @@ export function getSessionName(envName: string): string {
 export const MAIN_SESSION_NAME = "dust-hive-main";
 
 /**
- * Tab display names (shorter names for better display in tab bar)
+ * Tab display names (shorter names for better display in tab bar).
  */
-export const TAB_NAMES: Record<ServiceName, string> = {
+const TAB_NAMES: Record<ServiceName, string> = {
   sparkle: "sparkle",
   sdk: "sdk",
   front: "front",
+  "front-api": "front-api",
   core: "core",
   oauth: "oauth",
   connectors: "connectors",
@@ -231,3 +232,7 @@ export const TAB_NAMES: Record<ServiceName, string> = {
   "front-spa-app": "spa-app",
   viz: "viz",
 };
+
+export function getTabName(service: ServiceName): string {
+  return TAB_NAMES[service];
+}

--- a/x/henry/dust-hive/src/lib/multiplexer/zellij.ts
+++ b/x/henry/dust-hive/src/lib/multiplexer/zellij.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { logger } from "../logger";
 import { getInstallInstructions as getPlatformInstallInstructions } from "../platform";
 import { restoreTerminal } from "../prompt";
-import { ALL_SERVICES, type ServiceName } from "../services";
+import { type ServiceName, getActiveServices } from "../services";
 import { shellQuote } from "../shell";
 import type {
   InstallCheckResult,
@@ -13,7 +13,7 @@ import type {
   MultiplexerAdapter,
   MultiplexerType,
 } from "./types";
-import { SESSION_PREFIX, TAB_NAMES } from "./types";
+import { SESSION_PREFIX, getTabName } from "./types";
 
 /**
  * Base directory for zellij layouts
@@ -245,9 +245,9 @@ export class ZellijAdapter implements MultiplexerAdapter {
     }`;
     } else {
       // Individual service tabs (default)
-      logsTabs = ALL_SERVICES.map((service) =>
-        this.generateServiceTab(envName, service, worktreePath)
-      ).join("\n\n");
+      logsTabs = getActiveServices()
+        .map((service) => this.generateServiceTab(envName, service, worktreePath))
+        .join("\n\n");
     }
 
     // When compact mode is enabled, use bottom bar; otherwise use top bar
@@ -298,7 +298,7 @@ ${tabTemplate}
   }
 
   private generateServiceTab(envName: string, service: ServiceName, worktreePath: string): string {
-    const tabName = TAB_NAMES[service];
+    const tabName = getTabName(service);
     return `    tab name="${tabName}" {
         pane {
             cwd "${kdlEscape(worktreePath)}"

--- a/x/henry/dust-hive/src/lib/registry.ts
+++ b/x/henry/dust-hive/src/lib/registry.ts
@@ -6,7 +6,7 @@ import { logger } from "./logger";
 import { getEnvFilePath, getLogPath, getWorktreeDir } from "./paths";
 import type { PortAllocation } from "./ports";
 import { isServiceRunning, readFileTail, spawnShellDaemon } from "./process";
-import { ALL_SERVICES, type ServiceName } from "./services";
+import { ALL_SERVICES, type ServiceName, getActiveServices } from "./services";
 import { buildShell } from "./shell";
 
 // Readiness check types - how to determine if a service is ready
@@ -55,6 +55,17 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceConfig> = {
   },
   front: {
     cwd: "front",
+    needsNvm: true,
+    needsEnvSh: true,
+    buildCommand: () => "npm run dev",
+    readinessCheck: {
+      type: "http",
+      url: (ports) => `http://localhost:${ports.front}/api/healthz`,
+    },
+    portKey: "front",
+  },
+  "front-api": {
+    cwd: "front-api",
     needsNvm: true,
     needsEnvSh: true,
     buildCommand: () => "npm run dev",
@@ -146,8 +157,9 @@ if (missingKeys.length > 0 || extraKeys.length > 0) {
   );
 }
 
-// Services to start during warm (all services except sparkle, SDK, and viz which start at spawn/manually)
-export const WARM_SERVICES: ServiceName[] = ALL_SERVICES.filter(
+// Services to start during warm (all active services except sparkle, SDK, and viz which start at spawn/manually).
+// Uses getActiveServices() so only the active front variant (front or front-api) is included.
+export const WARM_SERVICES: ServiceName[] = getActiveServices().filter(
   (service) => service !== "sparkle" && service !== "sdk" && service !== "viz"
 );
 
@@ -312,16 +324,17 @@ export async function waitForServiceReady(
   return waitForFileReady(service, env, check.path(env), timeoutMs);
 }
 
-// Get HTTP health checks for all services (for status display)
+// Get HTTP health checks for active services (for status display)
 export function getHealthChecks(
   ports: PortAllocation
 ): Array<{ service: ServiceName; url: string }> {
   const checks: Array<{ service: ServiceName; url: string }> = [];
 
-  for (const [service, config] of Object.entries(SERVICE_REGISTRY)) {
+  for (const service of getActiveServices()) {
+    const config = SERVICE_REGISTRY[service];
     if (config.readinessCheck?.type === "http") {
       checks.push({
-        service: service as ServiceName,
+        service,
         url: config.readinessCheck.url(ports),
       });
     }

--- a/x/henry/dust-hive/src/lib/scripts.ts
+++ b/x/henry/dust-hive/src/lib/scripts.ts
@@ -1,6 +1,6 @@
 import { mkdir } from "node:fs/promises";
 import { DUST_HIVE_SCRIPTS, getServiceLogsTuiPath } from "./paths";
-import { ALL_SERVICES } from "./services";
+import { getActiveServices } from "./services";
 
 /**
  * Generates the service logs TUI bash script content.
@@ -20,7 +20,7 @@ import { ALL_SERVICES } from "./services";
  *   x   - exit
  */
 export function getServiceLogsTuiContent(): string {
-  const services = ALL_SERVICES.join(" ");
+  const services = getActiveServices().join(" ");
 
   // Script header and argument parsing
   const header = `#!/usr/bin/env bash

--- a/x/henry/dust-hive/src/lib/services.ts
+++ b/x/henry/dust-hive/src/lib/services.ts
@@ -1,8 +1,11 @@
-// Service names - array order defines start order, reverse for stop order
+// Service names - array order defines start order, reverse for stop order.
+// "front" and "front-api" are mutually exclusive: exactly one of them is in
+// the active service set for a given hive run (see getActiveServices).
 export const ALL_SERVICES = [
   "sdk",
   "sparkle",
   "front",
+  "front-api",
   "core",
   "oauth",
   "connectors",
@@ -16,6 +19,26 @@ export const ALL_SERVICES = [
 export const COLD_STATE_SERVICES = ["sdk", "sparkle"] as const satisfies readonly ServiceName[];
 
 export type ServiceName = (typeof ALL_SERVICES)[number];
+
+// When set, the hive runs front-api (Hono+Next hybrid server out of front-api/)
+// instead of the plain Next server out of front/. The two services share the
+// "front" port slot; opt-in via env var for now until front-api is the default.
+export function useFrontApi(): boolean {
+  const v = process.env["DUST_HIVE_USE_FRONT_API"];
+  return v === "1" || v === "true";
+}
+
+// Returns whichever front variant is active for this hive run.
+export function getFrontService(): ServiceName {
+  return useFrontApi() ? "front-api" : "front";
+}
+
+// Returns the services that apply to the current hive run. front-api and front
+// are mutually exclusive — useFrontApi() picks which one is active.
+export function getActiveServices(): readonly ServiceName[] {
+  const excluded: ServiceName = useFrontApi() ? "front" : "front-api";
+  return ALL_SERVICES.filter((s) => s !== excluded);
+}
 
 /**
  * Type guard to check if a string is a valid service name.

--- a/x/henry/dust-hive/tests/lib/envgen.test.ts
+++ b/x/henry/dust-hive/tests/lib/envgen.test.ts
@@ -58,7 +58,7 @@ describe("envgen", () => {
       expect(content).toContain(
         "export NEXT_PUBLIC_DUST_STATIC_WEBSITE_URL=http://localhost:10000"
       );
-      expect(content).toContain("export DUST_AUTH_REDIRECT_BASE_URL=http://localhost:3000");
+      expect(content).toContain("export DUST_AUTH_REDIRECT_BASE_URL=http://localhost:10000");
       expect(content).toContain("export CONNECTORS_PUBLIC_URL=http://localhost:10002");
     });
 

--- a/x/henry/dust-hive/tests/lib/registry.test.ts
+++ b/x/henry/dust-hive/tests/lib/registry.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { calculatePorts } from "../../src/lib/ports";
 import { SERVICE_REGISTRY, WARM_SERVICES, getHealthChecks } from "../../src/lib/registry";
-import { ALL_SERVICES, type ServiceName } from "../../src/lib/services";
+import { ALL_SERVICES, getFrontService, useFrontApi } from "../../src/lib/services";
 
 describe("registry", () => {
   describe("SERVICE_REGISTRY", () => {
@@ -21,6 +21,16 @@ describe("registry", () => {
     it("front config has correct settings", () => {
       const config = SERVICE_REGISTRY.front;
       expect(config.cwd).toBe("front");
+      expect(config.needsNvm).toBe(true);
+      expect(config.needsEnvSh).toBe(true);
+      expect(config.portKey).toBe("front");
+      expect(config.readinessCheck).toBeDefined();
+      expect(config.readinessCheck?.type).toBe("http");
+    });
+
+    it("front-api config has correct settings", () => {
+      const config = SERVICE_REGISTRY["front-api"];
+      expect(config.cwd).toBe("front-api");
       expect(config.needsNvm).toBe(true);
       expect(config.needsEnvSh).toBe(true);
       expect(config.portKey).toBe("front");
@@ -74,7 +84,7 @@ describe("registry", () => {
     });
 
     it("includes all other services", () => {
-      expect(WARM_SERVICES).toContain("front");
+      expect(WARM_SERVICES).toContain(getFrontService());
       expect(WARM_SERVICES).toContain("core");
       expect(WARM_SERVICES).toContain("oauth");
       expect(WARM_SERVICES).toContain("connectors");
@@ -83,16 +93,14 @@ describe("registry", () => {
       expect(WARM_SERVICES).toContain("front-spa-app");
     });
 
-    it("has 7 services (all except sparkle, sdk, and viz)", () => {
+    it("has 7 services (all except sparkle, sdk, viz, and the inactive front variant)", () => {
       expect(WARM_SERVICES).toHaveLength(7);
     });
 
-    it("is derived from SERVICE_REGISTRY", () => {
-      const registryServices = Object.keys(SERVICE_REGISTRY) as ServiceName[];
-      const expectedWarm = registryServices.filter(
-        (s) => s !== "sparkle" && s !== "sdk" && s !== "viz"
-      );
-      expect(WARM_SERVICES.sort()).toEqual(expectedWarm.sort());
+    it("includes only the active front variant", () => {
+      const inactive = useFrontApi() ? "front" : "front-api";
+      expect(WARM_SERVICES).toContain(getFrontService());
+      expect(WARM_SERVICES).not.toContain(inactive);
     });
   });
 
@@ -104,9 +112,9 @@ describe("registry", () => {
       expect(Array.isArray(checks)).toBe(true);
     });
 
-    it("includes front health check", () => {
+    it("includes the active front health check", () => {
       const checks = getHealthChecks(ports);
-      const frontCheck = checks.find((c) => c.service === "front");
+      const frontCheck = checks.find((c) => c.service === getFrontService());
       expect(frontCheck).toBeDefined();
       expect(frontCheck?.url).toBe("http://localhost:10000/api/healthz");
     });
@@ -132,7 +140,7 @@ describe("registry", () => {
       const secondPorts = calculatePorts(11000);
       const checks = getHealthChecks(secondPorts);
 
-      const frontCheck = checks.find((c) => c.service === "front");
+      const frontCheck = checks.find((c) => c.service === getFrontService());
       expect(frontCheck?.url).toBe("http://localhost:11000/api/healthz");
 
       const coreCheck = checks.find((c) => c.service === "core");

--- a/x/henry/dust-hive/tests/lib/services.test.ts
+++ b/x/henry/dust-hive/tests/lib/services.test.ts
@@ -7,6 +7,7 @@ describe("services", () => {
       expect(ALL_SERVICES).toContain("sparkle");
       expect(ALL_SERVICES).toContain("sdk");
       expect(ALL_SERVICES).toContain("front");
+      expect(ALL_SERVICES).toContain("front-api");
       expect(ALL_SERVICES).toContain("core");
       expect(ALL_SERVICES).toContain("oauth");
       expect(ALL_SERVICES).toContain("connectors");
@@ -16,8 +17,8 @@ describe("services", () => {
       expect(ALL_SERVICES).toContain("viz");
     });
 
-    it("has 10 services total", () => {
-      expect(ALL_SERVICES).toHaveLength(10);
+    it("has 11 services total", () => {
+      expect(ALL_SERVICES).toHaveLength(11);
     });
 
     it("has sdk as first service (start order)", () => {
@@ -56,6 +57,7 @@ describe("services", () => {
         "sdk",
         "sparkle",
         "front",
+        "front-api",
         "core",
         "oauth",
         "connectors",


### PR DESCRIPTION
## Description


Add support for front-api, which replaces front if you `export DUST_HIVE_USE_FRONT_API=true`

Also fix workos redirect url being hardcoded to localhost:3000

## Tests

Tested manually.

## Risk

Low

## Deploy Plan

Merge