### PR TITLE
fix(sandbox): clear actionRequired when resolving sandbox child actions

### DIFF
--- a/front/lib/api/assistant/conversation/answer_user_question.ts
+++ b/front/lib/api/assistant/conversation/answer_user_question.ts
@@ -8,7 +8,7 @@ import { resumeSandboxChildAction } from "@app/lib/api/sandbox/resume_child_acti
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
-import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import type { Result } from "@app/types/shared/result";
@@ -110,6 +110,10 @@ export async function registerUserAnswer(
   }, getMessageChannelId(messageId));
 
   if (isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo)) {
+    // Clear the orange dot when the user resolves a sandbox child action — the
+    // normal path would call launchAgentLoopWorkflow which handles this, but the
+    // sandbox child path returns early without going through that codepath.
+    await ConversationResource.clearActionRequired(auth, conversationId);
     await resumeSandboxChildAction(auth, {
       action,
       conversationId,

--- a/front/lib/api/assistant/conversation/resolve_authentication.ts
+++ b/front/lib/api/assistant/conversation/resolve_authentication.ts
@@ -146,6 +146,10 @@ export async function resolveAuthentication(
   }, getMessageChannelId(messageId));
 
   if (isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo)) {
+    // Clear the orange dot when the user resolves a sandbox child action — the
+    // normal path would call launchAgentLoopWorkflow which handles this, but the
+    // sandbox child path returns early without going through that codepath.
+    await ConversationResource.clearActionRequired(auth, conversationId);
     if (outcome === "completed") {
       await resumeSandboxChildAction(auth, {
         action,

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -17,7 +17,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
-import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import type { Result } from "@app/types/shared/result";
@@ -155,6 +155,10 @@ export async function validateAction(
   }, getMessageChannelId(messageId));
 
   if (isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo)) {
+    // Clear the orange dot when the user resolves a sandbox child action — the
+    // normal path would call launchAgentLoopWorkflow which handles this, but the
+    // sandbox child path returns early without going through that codepath.
+    await ConversationResource.clearActionRequired(auth, conversationId);
     if (approvalState !== "rejected") {
       await resumeSandboxChildAction(auth, {
         action,


### PR DESCRIPTION
## Problem

When a sandbox child action (triggered via `dsbx` tool calls) blocks on tool approval, user question, or personal/file authentication, `markAsActionRequired` is called — this puts the conversation in the **actionRequired** state (orange dot in the sidebar/inbox).

On the **normal (non-sandbox) path**, all three resolution handlers (`validateAction`, `registerUserAnswer`, `resolveAuthentication`) end up calling `launchAgentLoopWorkflow`, which calls `clearActionRequired` before starting the loop. So the orange dot disappears once the user acts.

On the **sandbox child action path**, added in #25850, those same handlers short-circuit early — they call `resumeSandboxChildAction` (which launches the sandbox child workflow) and return immediately, **never reaching `launchAgentLoopWorkflow`**. As a result, `clearActionRequired` was never called and the orange dot stuck around even after the event was approved/answered.

## Fix

Add `ConversationResource.clearActionRequired(auth, conversationId)` at the top of the sandbox short-circuit block in all three resolution handlers, mirroring exactly what `launchAgentLoopWorkflow` already does. This covers:

- **approval / rejection** (`validate_actions.ts`) — both branches, since rejection doesn't call `resumeSandboxChildAction`
- **user question answers** (`answer_user_question.ts`)
- **authentication / file-authorization** (`resolve_authentication.ts`) — both completed and denied outcomes

Also converts the two files that had `import type { ConversationResource }` to a value import so the static method can actually be called.

## Files changed

- `front/lib/api/assistant/conversation/validate_actions.ts`
- `front/lib/api/assistant/conversation/answer_user_question.ts`
- `front/lib/api/assistant/conversation/resolve_authentication.ts`
