### PR TITLE
[connectors] enh: add fallback to retrieve connector ID from args

### DIFF
--- a/connectors/src/lib/temporal.ts
+++ b/connectors/src/lib/temporal.ts
@@ -1,8 +1,13 @@
 import logger from "@connectors/logger/logger";
 import type { ModelId } from "@connectors/types";
 import { Context } from "@temporalio/activity";
-import type { ConnectionOptions } from "@temporalio/client";
-import { Client, Connection, WorkflowNotFoundError } from "@temporalio/client";
+import {
+  Client,
+  Connection,
+  type ConnectionOptions,
+  defaultPayloadConverter,
+  WorkflowNotFoundError,
+} from "@temporalio/client";
 import { defineSearchAttributeKey } from "@temporalio/common";
 import { NativeConnection } from "@temporalio/worker";
 import fs from "fs-extra";
@@ -74,6 +79,29 @@ async function getConnectionOptions(): Promise<
       },
     },
   };
+}
+
+// Programmatically retrieves the arguments that were passed to a Temporal workflow.
+async function getTemporalWorkflowArguments({
+  workflowId,
+}: {
+  workflowId: string;
+}): Promise<unknown[]> {
+  const client = await getTemporalClient();
+
+  // Fetch the first event.
+  const response = await client.workflowService.getWorkflowExecutionHistory({
+    namespace: process.env.TEMPORAL_NAMESPACE,
+    execution: { workflowId },
+    maximumPageSize: 1,
+  });
+  const startEvent = response.history?.events?.[0];
+
+  const payloads =
+    startEvent?.workflowExecutionStartedEventAttributes?.input?.payloads ?? [];
+
+  // This will always return an array, each entry matches a line of what's under Input in the UI under the event.
+  return payloads.map((p) => defaultPayloadConverter.fromPayload(p));
 }
 
 export async function getTemporalWorkerConnection(): Promise<{

--- a/connectors/src/lib/temporal.ts
+++ b/connectors/src/lib/temporal.ts
@@ -140,6 +140,20 @@ export async function getConnectorId(
         null;
     }
 
+    // If we still don't have a connector ID, look it up in the arguments of the workflow.
+    if (connectorId === null) {
+      const args = await getTemporalWorkflowArguments({ workflowId });
+
+      if (
+        typeof args[0] === "object" &&
+        args[0] !== null &&
+        "connectorId" in args[0] &&
+        typeof args[0].connectorId === "number"
+      ) {
+        connectorId = args[0].connectorId;
+      }
+    }
+
     if (connectorId !== null) {
       CONNECTOR_ID_CACHE[workflowId] = connectorId;
     }


### PR DESCRIPTION
## Description

- We are seeing some errors with `ExternalOAuthTokenErrors` that are not correctly handled by pausing the connector following https://github.com/dust-tt/dust/blob/2fe028d12c342baab786ebbf171e32a2f76b9645/connectors/src/lib/temporal_monitoring.ts#L211
- Logs [here](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker&additional_filters=%5B%5D&clustering_pattern_field_path=message&cols=%40workflowId%2C%40error.type%2C%40activityType&event=AwAAAZ5Jm7f47zO2vgAAABhBWjVKbTdoVEFBRHlFekJKUmxidFdBQUQAAAAkMDE5ZTQ5OWItZDQ4Yi00NmY5LTg0NWYtNDQzNDM4ZTQzNDJjAADcmg&fromUser=true&messageDisplay=inline&refresh_mode=sliding&saved-view-id=186044&storage=hot&stream_sort=desc&viz=stream&from_ts=1779347878516&to_ts=1779351478516&live=true).
- After investigation this is due to the connector ID not being correctly resolved; we look it up in the workflow's memo first, then fallback to the search attributes if not found (with some caching first).
- This PR adds an additional fallback by parsing the arguments passed to the workflow. Kind of a trick, but passing the `connectorId` in the arguments is common-enough to almost be a convention.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
