### PR TITLE
Change slack feedback modal to be more work oriented

### DIFF
--- a/connectors/src/connectors/slack/feedback_modal.ts
+++ b/connectors/src/connectors/slack/feedback_modal.ts
@@ -78,7 +78,7 @@ export async function openFeedbackModal({
             type: "section",
             text: {
               type: "mrkdwn",
-              text: "Help us improve by sharing your feedback about this response.",
+              text: "Share whether this helped you get things done.",
             },
           },
           {
@@ -86,7 +86,7 @@ export async function openFeedbackModal({
             block_id: "feedback_rating",
             label: {
               type: "plain_text",
-              text: "How was this response?",
+              text: "Did this help you in your work?",
             },
             element: {
               type: "radio_buttons",


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/8184

Replaces the 2 top sentence in this modal to be more "work" oriented and less "question->response"

Help us improve by sharing your feedback about this response. -> Share whether this helped you get things done.
How was this response? -> Did this help you in your work?

<img width="1028" height="982" alt="image" src="https://github.com/user-attachments/assets/3931e2f8-ba8f-49a3-9d6c-c63aca1018dd" />


## Tests

not tested

## Risk

low

## Deploy Plan

deploy connector
