### PR TITLE
Fix: allow any participants to handle a tool approval, a user question or a connexion request IF the message has no user (api or agent on behalf of).

### DIFF
--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -1,5 +1,6 @@
 import { useConversations } from "@app/hooks/conversations";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
+import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
 import { useBlockedActions } from "@app/lib/swr/blocked_actions";
 import type { ConversationListItemType } from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -200,7 +201,10 @@ export function BlockedActionsProvider({
       return blockedActionsQueue.some(
         (action) =>
           action.blockedAction.status === "blocked_validation_required" &&
-          action.blockedAction.userId === userId
+          canCurrentUserRespondToParentUserMessage({
+            parentUserId: action.blockedAction.userId,
+            currentUserId: userId,
+          })
       );
     },
     [blockedActionsQueue]
@@ -208,17 +212,14 @@ export function BlockedActionsProvider({
 
   const getBlockedActions = useCallback(
     (userId: string) => {
-      return (
-        blockedActionsQueue
-          // Either actions associated to the user or actions created through the Public API and not
-          // associated to any user.
-          .filter(
-            (action) =>
-              action.blockedAction.userId === userId ||
-              !action.blockedAction.userId
-          )
-          .map((action) => action.blockedAction)
-      );
+      return blockedActionsQueue
+        .filter((action) =>
+          canCurrentUserRespondToParentUserMessage({
+            parentUserId: action.blockedAction.userId,
+            currentUserId: userId,
+          })
+        )
+        .map((action) => action.blockedAction);
     },
     [blockedActionsQueue]
   );

--- a/front/components/assistant/conversation/GoogleDriveFileAuthorizationRequired.tsx
+++ b/front/components/assistant/conversation/GoogleDriveFileAuthorizationRequired.tsx
@@ -6,6 +6,7 @@ import type {
   BlockedToolExecution,
   FileAuthorizationInfo,
 } from "@app/lib/actions/mcp";
+import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import { useClientType } from "@app/lib/context/clientType";
@@ -59,14 +60,18 @@ export function GoogleDriveFileAuthorizationRequired({
   });
   const isExtension = clientType === "extension";
 
-  const isTriggeredByCurrentUser = useMemo(
-    () => triggeringUser?.sId === user?.sId,
+  const canCurrentUserRespond = useMemo(
+    () =>
+      canCurrentUserRespondToParentUserMessage({
+        parentUserId: triggeringUser?.sId,
+        currentUserId: user?.sId,
+      }),
     [triggeringUser, user?.sId]
   );
 
   // Pre-fetch picker credentials on mount for faster picker opening
   useEffect(() => {
-    if (isExtension || !isTriggeredByCurrentUser || pickerCredentials) {
+    if (isExtension || !canCurrentUserRespond || pickerCredentials) {
       return;
     }
 
@@ -95,7 +100,7 @@ export function GoogleDriveFileAuthorizationRequired({
     void fetchCredentials();
   }, [
     isExtension,
-    isTriggeredByCurrentUser,
+    canCurrentUserRespond,
     owner.sId,
     mcpServerId,
     pickerCredentials,
@@ -191,7 +196,7 @@ export function GoogleDriveFileAuthorizationRequired({
       icon={isAuthorized ? CheckCircleIcon : DocumentTextIcon}
       className="flex w-80 min-w-[300px] flex-col gap-3 sm:min-w-[500px]"
     >
-      {isTriggeredByCurrentUser ? (
+      {canCurrentUserRespond ? (
         <>
           <div className="font-sm whitespace-normal break-words text-foreground dark:text-foreground-night">
             {isAuthorized ? (

--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
@@ -7,6 +7,7 @@ import { getAvatarFromIcon } from "@app/components/resources/resources_icons";
 import { useResolveAuthentication } from "@app/hooks/useResolveAuthentication";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
+import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import {
@@ -73,8 +74,12 @@ export function MCPServerPersonalAuthenticationRequired({
       ? getMcpServerDisplayName(mcpServer)
       : undefined;
 
-  const isTriggeredByCurrentUser = useMemo(
-    () => triggeringUser?.sId === user?.sId,
+  const canCurrentUserRespond = useMemo(
+    () =>
+      canCurrentUserRespondToParentUserMessage({
+        parentUserId: triggeringUser?.sId,
+        currentUserId: user?.sId,
+      }),
     [triggeringUser, user?.sId]
   );
 
@@ -142,7 +147,7 @@ export function MCPServerPersonalAuthenticationRequired({
 
   // Determine the ActionCardBlock state.
   let cardState: "active" | "disabled" | "accepted";
-  if (!isTriggeredByCurrentUser) {
+  if (!canCurrentUserRespond) {
     cardState = "disabled";
   } else if (isConnected) {
     cardState = "accepted";
@@ -156,7 +161,7 @@ export function MCPServerPersonalAuthenticationRequired({
 
   // Build description based on current state.
   let description: React.ReactNode;
-  if (!isTriggeredByCurrentUser) {
+  if (!canCurrentUserRespond) {
     description = (
       <div className="text-sm">
         {`${triggeringUser?.fullName} is trying to use ${serverDisplayName ?? "a tool"}.`}
@@ -195,7 +200,7 @@ export function MCPServerPersonalAuthenticationRequired({
 
   // Build actions — only show Connect/Retry button for current user when not yet connected.
   const actions =
-    isTriggeredByCurrentUser && !isConnected && mcpServer ? (
+    canCurrentUserRespond && !isConnected && mcpServer ? (
       <div className="flex justify-end gap-3">
         <Button
           variant="outline"

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -4,6 +4,7 @@ import { getIcon } from "@app/components/resources/resources_icons";
 import { useValidateAction } from "@app/hooks/useValidateAction";
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
+import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
@@ -78,8 +79,12 @@ export function MCPToolValidationRequired({
     onError: setErrorMessage,
   });
 
-  const isTriggeredByCurrentUser = useMemo(
-    () => blockedAction.userId === user?.sId,
+  const canCurrentUserRespond = useMemo(
+    () =>
+      canCurrentUserRespondToParentUserMessage({
+        parentUserId: blockedAction.userId,
+        currentUserId: user?.sId,
+      }),
     [blockedAction.userId, user?.sId]
   );
 
@@ -137,7 +142,7 @@ export function MCPToolValidationRequired({
     ];
 
   function getTitle() {
-    if (!isTriggeredByCurrentUser) {
+    if (!canCurrentUserRespond) {
       return `Permission needed for ${asDisplayName(blockedAction.metadata.mcpServerName)}.`;
     }
     if (toolOverride?.title) {
@@ -194,7 +199,7 @@ export function MCPToolValidationRequired({
       className="flex w-full flex-col gap-3 sm:w-80 sm:min-w-[500px]"
       icon={icon}
     >
-      {isTriggeredByCurrentUser ? (
+      {canCurrentUserRespond ? (
         <>
           <ToolValidationDetails
             blockedAction={blockedAction}

--- a/front/components/assistant/conversation/MentionInvalid.tsx
+++ b/front/components/assistant/conversation/MentionInvalid.tsx
@@ -1,4 +1,5 @@
 import type { VirtuosoMessage } from "@app/components/assistant/conversation/types";
+import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { useDismissMention } from "@app/lib/swr/mentions";
 import type {
@@ -47,8 +48,12 @@ export function MentionInvalid({
     messageId: message.sId,
   });
 
-  const isTriggeredByCurrentUser = useMemo(
-    () => !triggeringUser || triggeringUser.sId === user?.sId,
+  const canCurrentUserRespond = useMemo(
+    () =>
+      canCurrentUserRespondToParentUserMessage({
+        parentUserId: triggeringUser?.sId,
+        currentUserId: user?.sId,
+      }),
     [triggeringUser, user?.sId]
   );
 
@@ -61,7 +66,7 @@ export function MentionInvalid({
     }
   };
 
-  if (!isTriggeredByCurrentUser || mention.dismissed) {
+  if (!canCurrentUserRespond || mention.dismissed) {
     return null;
   }
 

--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -1,5 +1,6 @@
 import type { VirtuosoMessage } from "@app/components/assistant/conversation/types";
 import { isAgentMessageWithStreaming } from "@app/components/assistant/conversation/types";
+import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { useMentionValidation } from "@app/lib/swr/mentions";
 import type {
@@ -46,8 +47,12 @@ export function MentionValidationRequired({
     isProjectConversation: isProjectMembership,
   });
 
-  const isTriggeredByCurrentUser = useMemo(
-    () => !triggeringUser || triggeringUser.sId === user?.sId,
+  const canCurrentUserRespond = useMemo(
+    () =>
+      canCurrentUserRespondToParentUserMessage({
+        parentUserId: triggeringUser?.sId,
+        currentUserId: user?.sId,
+      }),
     [triggeringUser, user?.sId]
   );
 
@@ -69,7 +74,7 @@ export function MentionValidationRequired({
     }
   };
 
-  if (!isTriggeredByCurrentUser) {
+  if (!canCurrentUserRespond) {
     return null;
   }
 

--- a/front/components/assistant/conversation/ToolValidationDetails.tsx
+++ b/front/components/assistant/conversation/ToolValidationDetails.tsx
@@ -214,8 +214,8 @@ function AshbyReferralDetails({
   return (
     <div className="flex flex-col gap-3 pt-2">
       <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-        {/* Safe to show: this component only renders for the user who
-            triggered the action (isTriggeredByCurrentUser guard in parent). */}
+        {/* Safe to show: this component only renders for users authorized to
+            respond (canCurrentUserRespond guard in parent). */}
         <>
           The referral will be credited to&nbsp;
           <span className="font-medium text-foreground dark:text-foreground-night">

--- a/front/components/assistant/conversation/UserAnswerRequired.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.tsx
@@ -3,6 +3,7 @@ import { useAnswerUserQuestion } from "@app/hooks/useAnswerUserQuestion";
 import { useUserAnswerDraft } from "@app/hooks/useUserAnswerDraft";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import type { UserQuestionAnswer } from "@app/lib/actions/types";
+import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import {
@@ -66,7 +67,10 @@ export function UserAnswerRequired({
   const customResponseInputRef = useRef<HTMLInputElement>(null);
 
   const { question } = blockedAction;
-  const isTriggeredByCurrentUser = blockedAction.userId === user?.sId;
+  const canCurrentUserRespond = canCurrentUserRespondToParentUserMessage({
+    parentUserId: blockedAction.userId,
+    currentUserId: user?.sId,
+  });
 
   const isCustomResponseActive =
     isCustomResponseFocused ||
@@ -246,7 +250,7 @@ export function UserAnswerRequired({
     }
   }
 
-  if (!isTriggeredByCurrentUser) {
+  if (!canCurrentUserRespond) {
     return (
       <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
         Waiting for&nbsp;

--- a/front/lib/api/assistant/conversation/answer_user_question.ts
+++ b/front/lib/api/assistant/conversation/answer_user_question.ts
@@ -1,6 +1,7 @@
 import { isToolAskUserQuestionEvent } from "@app/lib/actions/mcp";
 import type { UserQuestionAnswer } from "@app/lib/actions/types";
 import { isSandboxChildActionInfo } from "@app/lib/actions/types";
+import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
 import { getUserMessageIdFromMessageId } from "@app/lib/api/assistant/conversation/messages";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
@@ -54,7 +55,12 @@ export async function registerUserAnswer(
     messageId,
   });
 
-  if (userMessageUserId !== user?.id) {
+  if (
+    !canCurrentUserRespondToParentUserMessage({
+      parentUserId: userMessageUserId,
+      currentUserId: user?.id,
+    })
+  ) {
     return new Err(
       new DustError(
         "unauthorized",

--- a/front/lib/api/assistant/conversation/can_current_user_respond.test.ts
+++ b/front/lib/api/assistant/conversation/can_current_user_respond.test.ts
@@ -1,0 +1,52 @@
+import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
+import { describe, expect, it } from "vitest";
+
+describe("canCurrentUserRespondToParentUserMessage", () => {
+  it("allows any viewer when the parent message has no user", () => {
+    expect(
+      canCurrentUserRespondToParentUserMessage({
+        parentUserId: null,
+        currentUserId: "user_1",
+      })
+    ).toBe(true);
+
+    expect(
+      canCurrentUserRespondToParentUserMessage({
+        parentUserId: null,
+        currentUserId: 42,
+      })
+    ).toBe(true);
+  });
+
+  it("allows the parent message author", () => {
+    expect(
+      canCurrentUserRespondToParentUserMessage({
+        parentUserId: "user_1",
+        currentUserId: "user_1",
+      })
+    ).toBe(true);
+
+    expect(
+      canCurrentUserRespondToParentUserMessage({
+        parentUserId: 42,
+        currentUserId: 42,
+      })
+    ).toBe(true);
+  });
+
+  it("denies other users when the parent message has an author", () => {
+    expect(
+      canCurrentUserRespondToParentUserMessage({
+        parentUserId: "user_1",
+        currentUserId: "user_2",
+      })
+    ).toBe(false);
+
+    expect(
+      canCurrentUserRespondToParentUserMessage({
+        parentUserId: 1,
+        currentUserId: 2,
+      })
+    ).toBe(false);
+  });
+});

--- a/front/lib/api/assistant/conversation/can_current_user_respond.ts
+++ b/front/lib/api/assistant/conversation/can_current_user_respond.ts
@@ -1,0 +1,16 @@
+/**
+ * Whether the current user may respond to a blocked action or mention tied to a
+ * parent user message. When the parent message has no associated user (e.g. API
+ * key auth), any authenticated viewer may respond.
+ */
+export function canCurrentUserRespondToParentUserMessage<
+  TId extends string | number,
+>({
+  parentUserId,
+  currentUserId,
+}: {
+  parentUserId: TId | null | undefined;
+  currentUserId: TId | undefined;
+}): boolean {
+  return parentUserId == null || parentUserId === currentUserId;
+}

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -1,4 +1,5 @@
 import { getRelatedContentFragments } from "@app/lib/api/assistant/content_fragments";
+import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
 import { getUserMessageIdFromMessageId } from "@app/lib/api/assistant/conversation/messages";
 import {
   canCurrentUserAddProjectMembers,
@@ -316,7 +317,12 @@ export async function validateUserMention(
 
   if (isUserMessageType(message)) {
     // Verify user is authorized to edit the message by checking the message user.
-    if (message.user && message.user.id !== auth.getNonNullableUser().id) {
+    if (
+      !canCurrentUserRespondToParentUserMessage({
+        parentUserId: message.user?.id,
+        currentUserId: auth.getNonNullableUser().id,
+      })
+    ) {
       return new Err({
         status_code: 403,
         api_error: {
@@ -331,8 +337,10 @@ export async function validateUserMention(
       messageId,
     });
     if (
-      userMessageUserId !== null &&
-      userMessageUserId !== auth.getNonNullableUser().id
+      !canCurrentUserRespondToParentUserMessage({
+        parentUserId: userMessageUserId,
+        currentUserId: auth.getNonNullableUser().id,
+      })
     ) {
       return new Err({
         status_code: 403,
@@ -514,7 +522,12 @@ export async function dismissMention(
 
   if (isUserMessageType(message)) {
     // Verify user is authorized to edit the message by checking the message user.
-    if (message.user && message.user.id !== auth.getNonNullableUser().id) {
+    if (
+      !canCurrentUserRespondToParentUserMessage({
+        parentUserId: message.user?.id,
+        currentUserId: auth.getNonNullableUser().id,
+      })
+    ) {
       return new Err({
         status_code: 403,
         api_error: {
@@ -529,8 +542,10 @@ export async function dismissMention(
       messageId,
     });
     if (
-      userMessageUserId !== null &&
-      userMessageUserId !== auth.getNonNullableUser().id
+      !canCurrentUserRespondToParentUserMessage({
+        parentUserId: userMessageUserId,
+        currentUserId: auth.getNonNullableUser().id,
+      })
     ) {
       return new Err({
         status_code: 403,

--- a/front/lib/api/assistant/conversation/resolve_authentication.ts
+++ b/front/lib/api/assistant/conversation/resolve_authentication.ts
@@ -3,6 +3,7 @@ import {
   isToolPersonalAuthRequiredEvent,
 } from "@app/lib/actions/mcp";
 import { isSandboxChildActionInfo } from "@app/lib/actions/types";
+import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
 import { getUserMessageIdFromMessageId } from "@app/lib/api/assistant/conversation/messages";
 import { resumeAncestorConversations as resumeAncestorConversationsHelper } from "@app/lib/api/assistant/conversation/resume_ancestor_conversations";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
@@ -94,7 +95,12 @@ export async function resolveAuthentication(
     messageId,
   });
 
-  if (userMessageUserId !== user?.id) {
+  if (
+    !canCurrentUserRespondToParentUserMessage({
+      parentUserId: userMessageUserId,
+      currentUserId: user?.id,
+    })
+  ) {
     return new Err(
       new DustError(
         "unauthorized",

--- a/front/lib/api/assistant/conversation/validate_actions.test.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.test.ts
@@ -21,12 +21,14 @@ vi.mock("@app/lib/api/redis-hybrid-manager", () => ({
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { postUserMessage } from "@app/lib/api/assistant/conversation";
+import { registerUserAnswer } from "@app/lib/api/assistant/conversation/answer_user_question";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import {
   createUserMentions,
   dismissMention,
 } from "@app/lib/api/assistant/conversation/mentions";
 import { createAgentMessages } from "@app/lib/api/assistant/conversation/messages";
+import { resolveAuthentication } from "@app/lib/api/assistant/conversation/resolve_authentication";
 import { validateAction } from "@app/lib/api/assistant/conversation/validate_actions";
 import {
   publishAgentMessagesEvents,
@@ -40,6 +42,7 @@ import {
   AgentMessageModel,
   MentionModel,
   MessageModel,
+  UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -815,6 +818,7 @@ describe("validateAction", () => {
       citationsAllocated: 0,
       augmentedInputs: {},
       toolConfiguration,
+      stepContentId: stepContent.id,
       stepContext: {
         citationsCount: 0,
         citationsOffset: 0,
@@ -838,6 +842,53 @@ describe("validateAction", () => {
     });
 
     return { action, actionId, stepContent };
+  }
+
+  async function createAgentMessageWithNullUserParent() {
+    const userMessageRow = await UserMessageModel.create({
+      userId: null,
+      workspaceId: workspace.id,
+      content: "Message without user",
+      userContextUsername: "api-user",
+      userContextTimezone: "UTC",
+      userContextFullName: null,
+      userContextEmail: null,
+      userContextProfilePictureUrl: null,
+      userContextOrigin: "api",
+      clientSideMCPServerIds: [],
+    });
+
+    const messageRow = await MessageModel.create({
+      workspaceId: workspace.id,
+      sId: generateRandomModelSId(),
+      conversationId: conversation.id,
+      rank: 0,
+      parentId: null,
+      userMessageId: userMessageRow.id,
+    });
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+    });
+
+    const agentMessageRow = await AgentMessageModel.create({
+      workspaceId: workspace.id,
+      status: "created",
+      agentConfigurationId: agentConfig.sId,
+      agentConfigurationVersion: 0,
+      skipToolsValidation: false,
+    });
+
+    const agentMessageMessage = await MessageModel.create({
+      workspaceId: workspace.id,
+      sId: generateRandomModelSId(),
+      conversationId: conversation.id,
+      rank: 1,
+      parentId: messageRow.id,
+      agentMessageId: agentMessageRow.id,
+    });
+
+    return { agentMessageMessage, agentMessageRow };
   }
 
   describe("authorization", () => {
@@ -910,6 +961,116 @@ describe("validateAction", () => {
       if (result.isErr()) {
         expect(result.error.code).toBe("unauthorized");
       }
+    });
+
+    it("should allow validation when parent user message has no user", async () => {
+      const otherUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, otherUser, {
+        role: "user",
+      });
+      const otherUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        otherUser.sId,
+        workspace.sId
+      );
+
+      const { agentMessageMessage, agentMessageRow } =
+        await createAgentMessageWithNullUserParent();
+
+      const { actionId } = await createBlockedAction({
+        agentMessageId: agentMessageRow.id,
+      });
+
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      expect(conversationResource).not.toBeNull();
+
+      const result = await validateAction(
+        otherUserAuth,
+        conversationResource!,
+        {
+          actionId,
+          approvalState: "approved",
+          messageId: agentMessageMessage.sId,
+        }
+      );
+
+      expect(result.isOk()).toBe(true);
+    });
+
+    it("should allow resolving authentication when parent user message has no user", async () => {
+      const otherUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, otherUser, {
+        role: "user",
+      });
+      const otherUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        otherUser.sId,
+        workspace.sId
+      );
+
+      const { agentMessageMessage, agentMessageRow } =
+        await createAgentMessageWithNullUserParent();
+
+      const { actionId } = await createBlockedAction({
+        agentMessageId: agentMessageRow.id,
+        status: "blocked_authentication_required",
+      });
+
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      expect(conversationResource).not.toBeNull();
+
+      const result = await resolveAuthentication(
+        otherUserAuth,
+        conversationResource!,
+        {
+          actionId,
+          messageId: agentMessageMessage.sId,
+          outcome: "denied",
+        }
+      );
+
+      expect(result.isOk()).toBe(true);
+    });
+
+    it("should allow answering user questions when parent user message has no user", async () => {
+      const otherUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, otherUser, {
+        role: "user",
+      });
+      const otherUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        otherUser.sId,
+        workspace.sId
+      );
+
+      const { agentMessageMessage, agentMessageRow } =
+        await createAgentMessageWithNullUserParent();
+
+      const { actionId } = await createBlockedAction({
+        agentMessageId: agentMessageRow.id,
+        status: "blocked_user_answer_required",
+      });
+
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      expect(conversationResource).not.toBeNull();
+
+      const result = await registerUserAnswer(
+        otherUserAuth,
+        conversationResource!,
+        {
+          actionId,
+          messageId: agentMessageMessage.sId,
+          answer: { selectedOptions: [0] },
+        }
+      );
+
+      expect(result.isOk()).toBe(true);
     });
 
     it("should successfully validate action when user is authorized", async () => {

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -8,6 +8,7 @@ import {
   setUserAlwaysApprovedTool,
 } from "@app/lib/actions/tool_status";
 import { isSandboxChildActionInfo } from "@app/lib/actions/types";
+import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
 import { getUserMessageIdFromMessageId } from "@app/lib/api/assistant/conversation/messages";
 import { resumeAncestorConversations as resumeAncestorConversationsHelper } from "@app/lib/api/assistant/conversation/resume_ancestor_conversations";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
@@ -66,7 +67,12 @@ export async function validateAction(
     messageId,
   });
 
-  if (userMessageUserId !== user?.id) {
+  if (
+    !canCurrentUserRespondToParentUserMessage({
+      parentUserId: userMessageUserId,
+      currentUserId: user?.id,
+    })
+  ) {
     return new Err(
       new DustError(
         "unauthorized",


### PR DESCRIPTION
## Description

Introduces `canCurrentUserRespondToParentUserMessage` in `front/lib/api/assistant/conversation/can_current_user_respond.ts` to centralize the "can this participant act on this blocked action?" check. The previous inline comparisons (`blockedAction.userId === user.sId`) only allowed the triggering user to handle tool approvals, user questions, and connection requests — which breaks when the parent message has no user (API key auth or agent-on-behalf-of). The new function returns `true` when `parentUserId` is null/undefined, meaning any conversation participant can respond. Replaces `isTriggeredByCurrentUser` across `BlockedActionsProvider`, `GoogleDriveFileAuthorizationRequired`, `MCPServerPersonalAuthenticationRequired`, and `MCPToolValidationRequired`.

## Tests

Tested manually by triggering tool validation / connection requests via API-initiated conversations and verifying that any participant sees the actionable UI instead of the disabled/observer state.

## Risk

Low. The change widens who can act on a blocked action only for API/agent-initiated messages (no `userId`). For user-initiated messages, the existing ownership check is preserved. Rollback is safe — no schema or API changes.

## Deploy Plan

Deploy `front`.
