### PR TITLE
Use internal api endpoints for dust_project connector.

### DIFF
--- a/connectors/src/connectors/dust_project/temporal/activities.ts
+++ b/connectors/src/connectors/dust_project/temporal/activities.ts
@@ -60,7 +60,7 @@ export async function dustProjectConversationsFullSyncActivity({
     );
 
     // Fetch all conversations for the project from Front API
-    const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: false });
+    const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: true });
     const conversationsResult =
       await dustAPI.getSpaceConversationsForDataSource({
         spaceId: configuration.projectId,
@@ -197,7 +197,7 @@ export async function dustProjectConversationsIncrementalSyncActivity({
     const maxSourceUpdatedAt =
       await DustProjectConversationResource.getMaxSourceUpdatedAt(connectorId);
 
-    const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: false });
+    const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: true });
     const conversationsResult =
       await dustAPI.getSpaceConversationsForDataSource({
         spaceId: configuration.projectId,
@@ -285,7 +285,7 @@ async function dustProjectConversationsGarbageCollectActivity({
 
     // Fetch all visible conversation IDs from Front API
     // This endpoint only returns conversations that still exist (not hard-deleted)
-    const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: false });
+    const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: true });
     const conversationIdsResult = await dustAPI.getSpaceConversationIds({
       spaceId: configuration.projectId,
     });
@@ -396,7 +396,7 @@ export async function dustProjectMountFilesFullSyncActivity({
     "Starting full sync for dust_project mount files"
   );
 
-  const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: false });
+  const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: true });
   const listRes = await dustAPI.getSpaceProjectFiles({
     spaceId: configuration.projectId,
   });
@@ -476,7 +476,7 @@ export async function dustProjectMountFilesIncrementalSyncActivity({
   const maxSourceUpdatedAt =
     await DustProjectMountFileResource.getMaxSourceUpdatedAt(connectorId);
 
-  const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: false });
+  const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: true });
   const listRes = await dustAPI.getSpaceProjectFiles({
     spaceId: configuration.projectId,
     updatedSince:
@@ -542,7 +542,7 @@ export async function dustProjectMountFilesGarbageCollectActivity({
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
   try {
-    const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: false });
+    const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: true });
     const listRes = await dustAPI.getSpaceProjectFiles({
       spaceId: configuration.projectId,
     });
@@ -626,7 +626,7 @@ export async function dustProjectSyncMetadataActivity({
     "Fetching and syncing project metadata"
   );
 
-  const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: false });
+  const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: true });
   const metadataResult = await dustAPI.getSpaceMetadata({
     spaceId: configuration.projectId,
   });


### PR DESCRIPTION
## Description

Switches all `getDustAPI` calls in `dust_project` Temporal activities to `useInternalAPI: true`. All 7 call sites — across `dustProjectConversationsFullSyncActivity`, `dustProjectConversationsIncrementalSyncActivity`, `dustProjectConversationsGarbageCollectActivity`, `dustProjectMountFilesFullSyncActivity`, `dustProjectMountFilesIncrementalSyncActivity`, `dustProjectMountFilesGarbageCollectActivity`, and `dustProjectSyncMetadataActivity` — were incorrectly using the public API. This ensures the connector routes through the internal API consistently, as intended for server-side connectors.

## Tests

Tested manually by triggering a sync for a `dust_project` connector and verifying the activities complete successfully.

## Risk

Low. This is a one-line flag change per call site. The internal API is the correct path for server-side connectors; the public API was being used inadvertently. Rollback is safe — just revert the flag back to `false`.

## Deploy Plan

Deploy connectors.
