### PR TITLE
[metronome] feat: per-user spend-limit admin UI

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -394,24 +394,20 @@ export function UsagePage() {
           />
         )}
 
-        {changeSeatMember && (
-          <ChangeSeatModal
-            isOpen={true}
-            onClose={() => setChangeSeatMember(null)}
-            member={changeSeatMember}
-            owner={owner}
-            seatPlans={seatPlans}
-          />
-        )}
+        <ChangeSeatModal
+          isOpen={changeSeatMember !== null}
+          onClose={() => setChangeSeatMember(null)}
+          member={changeSeatMember}
+          owner={owner}
+          seatPlans={seatPlans}
+        />
 
-        {editSpendLimitMember && (
-          <EditSpendLimitModal
-            isOpen={true}
-            onClose={() => setEditSpendLimitMember(null)}
-            member={editSpendLimitMember}
-            owner={owner}
-          />
-        )}
+        <EditSpendLimitModal
+          isOpen={editSpendLimitMember !== null}
+          onClose={() => setEditSpendLimitMember(null)}
+          member={editSpendLimitMember}
+          owner={owner}
+        />
 
         {/* TODO: Settings section*/}
         <div />

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -3,6 +3,7 @@ import { ReachedLimitPopup } from "@app/components/app/ReachedLimitPopup";
 import { InviteEmailButtonWithModal } from "@app/components/members/InviteEmailButtonWithModal";
 import { BuyAwuCreditsDialog } from "@app/components/workspace/BuyAwuCreditsDialog";
 import { ChangeSeatModal } from "@app/components/workspace/ChangeSeatModal";
+import { EditSpendLimitModal } from "@app/components/workspace/EditSpendLimitModal";
 import { MembersUsageTable } from "@app/components/workspace/MembersUsageTable";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import {
@@ -145,6 +146,8 @@ export function UsagePage() {
   >(null);
   const [showBuyCreditDialog, setShowBuyCreditDialog] = useState(false);
   const [changeSeatMember, setChangeSeatMember] =
+    useState<MemberUsageType | null>(null);
+  const [editSpendLimitMember, setEditSpendLimitMember] =
     useState<MemberUsageType | null>(null);
   const [inviteBlockedPopupReason, setInviteBlockedPopupReason] =
     useState<WorkspaceLimit | null>(null);
@@ -376,6 +379,7 @@ export function UsagePage() {
             seatTypeFilter={seatTypeFilter}
             showSeatColumns={hasSeatSubscription}
             onChangeSeat={setChangeSeatMember}
+            onEditSpendLimit={setEditSpendLimitMember}
           />
         </Page.Vertical>
 
@@ -397,6 +401,15 @@ export function UsagePage() {
             member={changeSeatMember}
             owner={owner}
             seatPlans={seatPlans}
+          />
+        )}
+
+        {editSpendLimitMember && (
+          <EditSpendLimitModal
+            isOpen={true}
+            onClose={() => setEditSpendLimitMember(null)}
+            member={editSpendLimitMember}
+            owner={owner}
           />
         )}
 

--- a/front/components/workspace/ChangeSeatModal.tsx
+++ b/front/components/workspace/ChangeSeatModal.tsx
@@ -23,7 +23,7 @@ import {
   SeatMaxIcon,
   SeatProIcon,
 } from "@dust-tt/sparkle";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 // Per-seat-type display icon. The label / name comes from the API
 // (`SeatTypeInfo.name`) so adding a new seat tier only requires tagging the
@@ -109,7 +109,7 @@ function SeatCard({
 interface ChangeSeatModalProps {
   isOpen: boolean;
   onClose: () => void;
-  member: MemberUsageType;
+  member: MemberUsageType | null;
   owner: WorkspaceType;
   seatPlans: SeatPlanResponseBody;
 }
@@ -121,10 +121,21 @@ export function ChangeSeatModal({
   owner,
   seatPlans,
 }: ChangeSeatModalProps) {
+  // Keep the last non-null member so the dialog can render its content through
+  // the exit animation after the parent has cleared `member`.
+  const lastMemberRef = useRef<MemberUsageType | null>(null);
+  if (member) {
+    lastMemberRef.current = member;
+  }
+  const displayedMember = member ?? lastMemberRef.current;
+
   const seatTypes = sortSeatTypes(
     Object.keys(seatPlans).filter(isMembershipSeatType)
   );
-  const currentSeatType: MembershipSeatType | null = member.seatType;
+  const firstSeatType = seatTypes[0] ?? null;
+  const displayedMemberId = displayedMember?.sId ?? null;
+  const displayedMemberSeatType = displayedMember?.seatType ?? null;
+  const currentSeatType: MembershipSeatType | null = displayedMemberSeatType;
   const [selectedSeat, setSelectedSeat] = useState<MembershipSeatType | null>(
     currentSeatType ?? seatTypes[0] ?? null
   );
@@ -132,6 +143,30 @@ export function ChangeSeatModal({
   const { doUpdateSeatType } = useUpdateMemberSeatType({
     workspaceId: owner.sId,
   });
+  const initializedMemberIdRef = useRef<string | null>(null);
+
+  // Reset transient state when the dialog closes and initialize the selected
+  // seat once per member open. Do not re-run on seat plan refetches.
+  useEffect(() => {
+    if (!isOpen || !displayedMemberId) {
+      initializedMemberIdRef.current = null;
+      setIsSaving(false);
+      return;
+    }
+
+    if (initializedMemberIdRef.current === displayedMemberId) {
+      return;
+    }
+
+    const nextSelectedSeat = displayedMemberSeatType ?? firstSeatType;
+    if (nextSelectedSeat === null) {
+      return;
+    }
+
+    setSelectedSeat(nextSelectedSeat);
+    initializedMemberIdRef.current = displayedMemberId;
+    setIsSaving(false);
+  }, [displayedMemberId, displayedMemberSeatType, firstSeatType, isOpen]);
 
   function getBadge(
     seatType: MembershipSeatType,
@@ -153,10 +188,10 @@ export function ChangeSeatModal({
 
   // Member has a scheduled seat change and is re-selecting their current seat to cancel it.
   const isCancellingScheduledChange =
-    !!member.scheduledSeatType && selectedSeat === currentSeatType;
+    !!displayedMember?.scheduledSeatType && selectedSeat === currentSeatType;
 
   async function handleValidate() {
-    if (!selectedSeat) {
+    if (!selectedSeat || !displayedMember) {
       return;
     }
     if (selectedSeat === currentSeatType && !isCancellingScheduledChange) {
@@ -167,8 +202,8 @@ export function ChangeSeatModal({
     setIsSaving(true);
     try {
       const ok = await doUpdateSeatType({
-        memberId: member.sId,
-        memberName: member.name,
+        memberId: displayedMember.sId,
+        memberName: displayedMember.name,
         seatType: selectedSeat,
         isCancellingScheduledChange,
       });
@@ -189,13 +224,15 @@ export function ChangeSeatModal({
         <DialogHeader>
           <div className="flex items-center gap-3">
             <Avatar
-              visual={member.image ?? undefined}
-              name={member.name}
+              visual={displayedMember?.image ?? undefined}
+              name={displayedMember?.name}
               size="md"
               isRounded
             />
             <div>
-              <DialogTitle>Change Seat Type for {member.name}</DialogTitle>
+              <DialogTitle>
+                Change Seat Type for {displayedMember?.name}
+              </DialogTitle>
               <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
                 They will be able to consume this amount from the pool after
                 reaching their plan usage limit.
@@ -237,7 +274,9 @@ export function ChangeSeatModal({
             {isCancellingScheduledChange && (
               <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
                 Scheduled change to{" "}
-                <span className="capitalize">{member.scheduledSeatType}</span>{" "}
+                <span className="capitalize">
+                  {displayedMember?.scheduledSeatType}
+                </span>{" "}
                 will be cancelled.
               </p>
             )}

--- a/front/components/workspace/EditSpendLimitModal.tsx
+++ b/front/components/workspace/EditSpendLimitModal.tsx
@@ -22,7 +22,7 @@ import {
   RadioGroupItem,
   Spinner,
 } from "@dust-tt/sparkle";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 const MIN_AWU_CREDITS = 1;
 const MAX_AWU_CREDITS = 1_000_000;
@@ -36,7 +36,7 @@ function isSpendLimitKind(value: string): value is SpendLimitKind {
 interface EditSpendLimitModalProps {
   isOpen: boolean;
   onClose: () => void;
-  member: MemberUsageType;
+  member: MemberUsageType | null;
   owner: WorkspaceType;
 }
 
@@ -46,6 +46,14 @@ export function EditSpendLimitModal({
   member,
   owner,
 }: EditSpendLimitModalProps) {
+  // Keep the last non-null member so the dialog can render its content through
+  // the exit animation after the parent has cleared `member`.
+  const lastMemberRef = useRef<MemberUsageType | null>(null);
+  if (member) {
+    lastMemberRef.current = member;
+  }
+  const displayedMember = member ?? lastMemberRef.current;
+
   const {
     spendLimit,
     isSpendLimitLoading,
@@ -53,8 +61,8 @@ export function EditSpendLimitModal({
     mutateSpendLimit,
   } = useUserSpendLimit({
     workspaceId: owner.sId,
-    memberId: member.sId,
-    disabled: !isOpen,
+    memberId: displayedMember?.sId ?? "",
+    disabled: !isOpen || !displayedMember,
   });
   const { doUpdateSpendLimit } = useUpdateUserSpendLimit({
     workspaceId: owner.sId,
@@ -69,6 +77,8 @@ export function EditSpendLimitModal({
 
   useEffect(() => {
     if (!isOpen) {
+      setIsSaving(false);
+      setValidationMessage(null);
       return;
     }
     if (!spendLimit) {
@@ -133,6 +143,10 @@ export function EditSpendLimitModal({
       return;
     }
 
+    if (!displayedMember) {
+      return;
+    }
+
     setIsSaving(true);
     try {
       let limit:
@@ -150,8 +164,8 @@ export function EditSpendLimitModal({
           return;
       }
       const body = await doUpdateSpendLimit({
-        memberId: member.sId,
-        memberName: member.name,
+        memberId: displayedMember.sId,
+        memberName: displayedMember.name,
         limit,
       });
       if (body) {
@@ -176,13 +190,15 @@ export function EditSpendLimitModal({
         <DialogHeader>
           <div className="flex items-center gap-3">
             <Avatar
-              visual={member.image ?? undefined}
-              name={member.name}
+              visual={displayedMember?.image ?? undefined}
+              name={displayedMember?.name}
               size="md"
               isRounded
             />
             <div>
-              <DialogTitle>Edit spend limit for {member.name}</DialogTitle>
+              <DialogTitle>
+                Edit spend limit for {displayedMember?.name}
+              </DialogTitle>
               <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
                 They will be able to consume this amount from the pool after
                 reaching their plan usage limit.

--- a/front/components/workspace/EditSpendLimitModal.tsx
+++ b/front/components/workspace/EditSpendLimitModal.tsx
@@ -8,12 +8,14 @@ import type { WorkspaceType } from "@app/types/user";
 import {
   ActionCreditCoinsIcon,
   Avatar,
+  ContentMessage,
   Dialog,
   DialogContainer,
   DialogContent,
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  ExclamationCircleIcon,
   Icon,
   Input,
   RadioGroup,
@@ -44,7 +46,12 @@ export function EditSpendLimitModal({
   member,
   owner,
 }: EditSpendLimitModalProps) {
-  const { spendLimit, isSpendLimitLoading } = useUserSpendLimit({
+  const {
+    spendLimit,
+    isSpendLimitLoading,
+    isSpendLimitError,
+    mutateSpendLimit,
+  } = useUserSpendLimit({
     workspaceId: owner.sId,
     memberId: member.sId,
     disabled: !isOpen,
@@ -159,6 +166,9 @@ export function EditSpendLimitModal({
     isSaving ||
     isSpendLimitLoading ||
     (kind === "limited" && creditsInput.length === 0);
+  const primaryDisabled = isSpendLimitError
+    ? isSaving || isSpendLimitLoading
+    : validateDisabled;
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
@@ -181,7 +191,18 @@ export function EditSpendLimitModal({
           </div>
         </DialogHeader>
         <DialogContainer>
-          {isSpendLimitLoading ? (
+          {isSpendLimitError ? (
+            <ContentMessage
+              title="Failed to load spend limit"
+              icon={ExclamationCircleIcon}
+              variant="warning"
+            >
+              <p>
+                We couldn’t load the current spend limit. Please retry before
+                making changes.
+              </p>
+            </ContentMessage>
+          ) : isSpendLimitLoading ? (
             <div className="flex justify-center py-6">
               <Spinner />
             </div>
@@ -246,10 +267,12 @@ export function EditSpendLimitModal({
             onClick: onClose,
           }}
           rightButtonProps={{
-            label: "Validate",
+            label: isSpendLimitError ? "Retry" : "Validate",
             variant: "primary",
-            disabled: validateDisabled,
-            onClick: handleValidate,
+            disabled: primaryDisabled,
+            onClick: isSpendLimitError
+              ? () => void mutateSpendLimit()
+              : handleValidate,
           }}
         />
       </DialogContent>

--- a/front/components/workspace/EditSpendLimitModal.tsx
+++ b/front/components/workspace/EditSpendLimitModal.tsx
@@ -3,6 +3,7 @@ import {
   useUpdateUserSpendLimit,
   useUserSpendLimit,
 } from "@app/lib/swr/memberships";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { WorkspaceType } from "@app/types/user";
 import {
   ActionCreditCoinsIcon,
@@ -66,12 +67,17 @@ export function EditSpendLimitModal({
     if (!spendLimit) {
       return;
     }
-    if (spendLimit.kind === "limited") {
-      setKind("limited");
-      setCreditsInput(String(spendLimit.awuCredits));
-    } else {
-      setKind("unlimited");
-      setCreditsInput("");
+    switch (spendLimit.kind) {
+      case "limited":
+        setKind("limited");
+        setCreditsInput(String(spendLimit.awuCredits));
+        break;
+      case "unlimited":
+        setKind("unlimited");
+        setCreditsInput("");
+        break;
+      default:
+        assertNeverAndIgnore(spendLimit);
     }
     setValidationMessage(null);
   }, [isOpen, spendLimit]);
@@ -89,23 +95,29 @@ export function EditSpendLimitModal({
   }
 
   function validate(): { ok: true; awuCredits: number } | { ok: false } {
-    if (kind === "unlimited") {
-      return { ok: true, awuCredits: 0 };
+    switch (kind) {
+      case "unlimited":
+        return { ok: true, awuCredits: 0 };
+      case "limited": {
+        const parsed = Number(creditsInput);
+        if (!Number.isInteger(parsed) || parsed < MIN_AWU_CREDITS) {
+          setValidationMessage(
+            `Enter a whole number of credits between ${MIN_AWU_CREDITS.toLocaleString("en-US")} and ${MAX_AWU_CREDITS.toLocaleString("en-US")}.`
+          );
+          return { ok: false };
+        }
+        if (parsed > MAX_AWU_CREDITS) {
+          setValidationMessage(
+            `Credits cannot exceed ${MAX_AWU_CREDITS.toLocaleString("en-US")}.`
+          );
+          return { ok: false };
+        }
+        return { ok: true, awuCredits: parsed };
+      }
+      default:
+        assertNeverAndIgnore(kind);
+        return { ok: false };
     }
-    const parsed = Number(creditsInput);
-    if (!Number.isInteger(parsed) || parsed < MIN_AWU_CREDITS) {
-      setValidationMessage(
-        `Enter a whole number of credits between ${MIN_AWU_CREDITS.toLocaleString("en-US")} and ${MAX_AWU_CREDITS.toLocaleString("en-US")}.`
-      );
-      return { ok: false };
-    }
-    if (parsed > MAX_AWU_CREDITS) {
-      setValidationMessage(
-        `Credits cannot exceed ${MAX_AWU_CREDITS.toLocaleString("en-US")}.`
-      );
-      return { ok: false };
-    }
-    return { ok: true, awuCredits: parsed };
   }
 
   async function handleValidate() {
@@ -116,10 +128,20 @@ export function EditSpendLimitModal({
 
     setIsSaving(true);
     try {
-      const limit =
-        kind === "unlimited"
-          ? ({ kind: "unlimited" } as const)
-          : ({ kind: "limited", awuCredits: result.awuCredits } as const);
+      let limit:
+        | { kind: "unlimited" }
+        | { kind: "limited"; awuCredits: number };
+      switch (kind) {
+        case "unlimited":
+          limit = { kind: "unlimited" };
+          break;
+        case "limited":
+          limit = { kind: "limited", awuCredits: result.awuCredits };
+          break;
+        default:
+          assertNeverAndIgnore(kind);
+          return;
+      }
       const body = await doUpdateSpendLimit({
         memberId: member.sId,
         memberName: member.name,

--- a/front/components/workspace/EditSpendLimitModal.tsx
+++ b/front/components/workspace/EditSpendLimitModal.tsx
@@ -1,0 +1,236 @@
+import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
+import {
+  useUpdateUserSpendLimit,
+  useUserSpendLimit,
+} from "@app/lib/swr/memberships";
+import type { WorkspaceType } from "@app/types/user";
+import {
+  ActionCreditCoinsIcon,
+  Avatar,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Icon,
+  Input,
+  RadioGroup,
+  RadioGroupItem,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { useEffect, useState } from "react";
+
+const MIN_AWU_CREDITS = 1;
+const MAX_AWU_CREDITS = 1_000_000;
+
+type SpendLimitKind = "unlimited" | "limited";
+
+function isSpendLimitKind(value: string): value is SpendLimitKind {
+  return value === "unlimited" || value === "limited";
+}
+
+interface EditSpendLimitModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  member: MemberUsageType;
+  owner: WorkspaceType;
+}
+
+export function EditSpendLimitModal({
+  isOpen,
+  onClose,
+  member,
+  owner,
+}: EditSpendLimitModalProps) {
+  const { spendLimit, isSpendLimitLoading } = useUserSpendLimit({
+    workspaceId: owner.sId,
+    memberId: member.sId,
+    disabled: !isOpen,
+  });
+  const { doUpdateSpendLimit } = useUpdateUserSpendLimit({
+    workspaceId: owner.sId,
+  });
+
+  const [kind, setKind] = useState<SpendLimitKind>("limited");
+  const [creditsInput, setCreditsInput] = useState<string>("");
+  const [isSaving, setIsSaving] = useState(false);
+  const [validationMessage, setValidationMessage] = useState<string | null>(
+    null
+  );
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    if (!spendLimit) {
+      return;
+    }
+    if (spendLimit.kind === "limited") {
+      setKind("limited");
+      setCreditsInput(String(spendLimit.awuCredits));
+    } else {
+      setKind("unlimited");
+      setCreditsInput("");
+    }
+    setValidationMessage(null);
+  }, [isOpen, spendLimit]);
+
+  function handleSelectKind(next: SpendLimitKind) {
+    setKind(next);
+    setValidationMessage(null);
+  }
+
+  function handleCreditsChange(value: string) {
+    // Keep only digits — credits are integers and the API range starts at 1.
+    const cleaned = value.replace(/[^\d]/g, "");
+    setCreditsInput(cleaned);
+    setValidationMessage(null);
+  }
+
+  function validate(): { ok: true; awuCredits: number } | { ok: false } {
+    if (kind === "unlimited") {
+      return { ok: true, awuCredits: 0 };
+    }
+    const parsed = Number(creditsInput);
+    if (!Number.isInteger(parsed) || parsed < MIN_AWU_CREDITS) {
+      setValidationMessage(
+        `Enter a whole number of credits between ${MIN_AWU_CREDITS.toLocaleString("en-US")} and ${MAX_AWU_CREDITS.toLocaleString("en-US")}.`
+      );
+      return { ok: false };
+    }
+    if (parsed > MAX_AWU_CREDITS) {
+      setValidationMessage(
+        `Credits cannot exceed ${MAX_AWU_CREDITS.toLocaleString("en-US")}.`
+      );
+      return { ok: false };
+    }
+    return { ok: true, awuCredits: parsed };
+  }
+
+  async function handleValidate() {
+    const result = validate();
+    if (!result.ok) {
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const limit =
+        kind === "unlimited"
+          ? ({ kind: "unlimited" } as const)
+          : ({ kind: "limited", awuCredits: result.awuCredits } as const);
+      const body = await doUpdateSpendLimit({
+        memberId: member.sId,
+        memberName: member.name,
+        limit,
+      });
+      if (body) {
+        onClose();
+      }
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  const validateDisabled =
+    isSaving ||
+    isSpendLimitLoading ||
+    (kind === "limited" && creditsInput.length === 0);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent size="md">
+        <DialogHeader>
+          <div className="flex items-center gap-3">
+            <Avatar
+              visual={member.image ?? undefined}
+              name={member.name}
+              size="md"
+              isRounded
+            />
+            <div>
+              <DialogTitle>Edit spend limit for {member.name}</DialogTitle>
+              <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                They will be able to consume this amount from the pool after
+                reaching their plan usage limit.
+              </p>
+            </div>
+          </div>
+        </DialogHeader>
+        <DialogContainer>
+          {isSpendLimitLoading ? (
+            <div className="flex justify-center py-6">
+              <Spinner />
+            </div>
+          ) : (
+            <RadioGroup
+              value={kind}
+              onValueChange={(v) => {
+                if (isSpendLimitKind(v)) {
+                  handleSelectKind(v);
+                }
+              }}
+              className="flex flex-col gap-3"
+            >
+              <RadioGroupItem
+                value="unlimited"
+                id="spend-limit-unlimited"
+                label="Unlimited spend"
+              />
+              <RadioGroupItem
+                value="limited"
+                id="spend-limit-limited"
+                label="Set credit amount"
+              />
+
+              {kind === "limited" && (
+                <div className="flex flex-col gap-1.5 pl-6">
+                  <label
+                    htmlFor="spend-credit-limit-input"
+                    className="text-sm font-medium text-foreground dark:text-foreground-night"
+                  >
+                    Spend credit limit
+                  </label>
+                  <div className="relative">
+                    <div className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground dark:text-muted-foreground-night">
+                      <Icon visual={ActionCreditCoinsIcon} size="xs" />
+                    </div>
+                    <Input
+                      id="spend-credit-limit-input"
+                      type="text"
+                      inputMode="numeric"
+                      pattern="[0-9]*"
+                      placeholder="1000"
+                      value={creditsInput}
+                      onChange={(e) => handleCreditsChange(e.target.value)}
+                      className="pl-8"
+                      isError={validationMessage !== null}
+                      message={validationMessage ?? undefined}
+                      messageStatus={
+                        validationMessage !== null ? "error" : undefined
+                      }
+                    />
+                  </div>
+                </div>
+              )}
+            </RadioGroup>
+          )}
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: onClose,
+          }}
+          rightButtonProps={{
+            label: "Validate",
+            variant: "primary",
+            disabled: validateDisabled,
+            onClick: handleValidate,
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -22,7 +22,8 @@ type RowData = {
   image: string | null;
   seatType: MembershipSeatType | null;
   seatUsagePercent: number | null;
-  consumedWorkplacePoolCredits: number;
+  consumedAwuCredits: number;
+  spendLimitAwuCredits: number | null;
   billingFrequency: BillingFrequency | null;
   scheduledSeatType: MembershipSeatType | null;
   scheduledSeatChangeAt: string | null;
@@ -103,12 +104,12 @@ function formatCredits(credits: number): string {
   return credits.toLocaleString("en-US", { maximumFractionDigits: 1 });
 }
 
-interface WorkspaceUsageBarProps {
+interface AwuUsageBarProps {
   consumed: number;
   limit: number | null;
 }
 
-function WorkspaceUsageBar({ consumed, limit }: WorkspaceUsageBarProps) {
+function AwuUsageBar({ consumed, limit }: AwuUsageBarProps) {
   const percentage =
     limit !== null && limit > 0 ? Math.min((consumed / limit) * 100, 100) : 0;
 
@@ -259,20 +260,20 @@ const seatUsagePercentColumn: ColumnDef<RowData, string> = {
     (a.original.seatUsagePercent ?? -1) - (b.original.seatUsagePercent ?? -1),
 };
 
-const consumedWorkplacePoolCreditsColumn: ColumnDef<RowData, string> = {
-  id: "consumedWorkplacePoolCredits" as const,
+const consumedAwuCreditsColumn: ColumnDef<RowData, string> = {
+  id: "consumedAwuCredits" as const,
   header: () => (
     <span className="flex items-center gap-1.5">
       <Icon visual={ActionCreditCoinsIcon} size="xs" />
-      Workspace usage
+      AWU usage
     </span>
   ),
-  accessorFn: (row) => row.consumedWorkplacePoolCredits.toString(),
+  accessorFn: (row) => row.consumedAwuCredits.toString(),
   cell: (info: Info) => (
     <div className="w-full pr-3">
-      <WorkspaceUsageBar
-        consumed={info.row.original.consumedWorkplacePoolCredits}
-        limit={null}
+      <AwuUsageBar
+        consumed={info.row.original.consumedAwuCredits}
+        limit={info.row.original.spendLimitAwuCredits}
       />
     </div>
   ),
@@ -281,8 +282,7 @@ const consumedWorkplacePoolCreditsColumn: ColumnDef<RowData, string> = {
   },
   enableSorting: true,
   sortingFn: (a, b) =>
-    a.original.consumedWorkplacePoolCredits -
-    b.original.consumedWorkplacePoolCredits,
+    a.original.consumedAwuCredits - b.original.consumedAwuCredits,
 };
 
 const actionsColumn: ColumnDef<RowData, string> = {
@@ -303,7 +303,7 @@ function buildColumns(showSeatColumns: boolean): ColumnDef<RowData, string>[] {
     ...(showSeatColumns
       ? [seatTypeColumn, billingFrequencyColumn, seatUsagePercentColumn]
       : []),
-    consumedWorkplacePoolCreditsColumn,
+    consumedAwuCreditsColumn,
     ...(showSeatColumns ? [actionsColumn] : []),
   ];
 }
@@ -315,6 +315,7 @@ interface MembersUsageTableProps {
   seatTypeFilter: MembershipSeatType | "none" | null;
   showSeatColumns: boolean;
   onChangeSeat: (member: MemberUsageType) => void;
+  onEditSpendLimit: (member: MemberUsageType) => void;
 }
 
 export function MembersUsageTable({
@@ -324,6 +325,7 @@ export function MembersUsageTable({
   seatTypeFilter,
   showSeatColumns,
   onChangeSeat,
+  onEditSpendLimit,
 }: MembersUsageTableProps) {
   if (isLoading) {
     return (
@@ -364,7 +366,8 @@ export function MembersUsageTable({
     image: m.image,
     seatType: m.seatType,
     seatUsagePercent: m.seatUsagePercent,
-    consumedWorkplacePoolCredits: m.consumedAwuCredits,
+    consumedAwuCredits: m.consumedAwuCredits,
+    spendLimitAwuCredits: m.spendLimitAwuCredits,
     billingFrequency: m.billingFrequency,
     scheduledSeatType: m.scheduledSeatType,
     scheduledSeatChangeAt: m.scheduledSeatChangeAt,
@@ -373,6 +376,11 @@ export function MembersUsageTable({
         kind: "item" as const,
         label: "Change Seat Type",
         onClick: () => onChangeSeat(m),
+      },
+      {
+        kind: "item" as const,
+        label: "Update User Spend Limit",
+        onClick: () => onEditSpendLimit(m),
       },
     ],
   }));

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -5,6 +5,10 @@ import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import { debounce } from "@app/lib/utils/debounce";
 import type { GetWorkspaceInvitationsResponseBody } from "@app/pages/api/w/[wId]/invitations";
 import type { GetMembersResponseBody } from "@app/pages/api/w/[wId]/members";
+import type {
+  GetUserSpendLimitResponseBody,
+  PutUserSpendLimitResponseBody,
+} from "@app/pages/api/w/[wId]/members/[uId]/spend_limit";
 import type { MembersLookupResponseBody } from "@app/pages/api/w/[wId]/members/lookup";
 import type { SearchMembersResponseBody } from "@app/pages/api/w/[wId]/members/search";
 import type { GroupKind } from "@app/types/groups";
@@ -14,6 +18,24 @@ import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Fetcher } from "swr";
 import { mutate } from "swr";
+import { z } from "zod";
+
+const SpendLimitResponseSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("unlimited") }),
+  z.object({
+    kind: z.literal("limited"),
+    awuCredits: z.number(),
+  }),
+]);
+
+const PutUserSpendLimitResponseSchema = z.object({
+  limit: SpendLimitResponseSchema,
+  transitionedTo: z.union([
+    z.literal("reached"),
+    z.literal("resolved"),
+    z.null(),
+  ]),
+});
 
 type PaginationParams = {
   orderColumn: "createdAt";
@@ -276,4 +298,86 @@ export function useUpdateMemberSeatType({
   );
 
   return { doUpdateSeatType };
+}
+
+function spendLimitUrl(workspaceId: string, memberId: string): string {
+  return `/api/w/${workspaceId}/members/${memberId}/spend_limit`;
+}
+
+export function useUserSpendLimit({
+  workspaceId,
+  memberId,
+  disabled,
+}: {
+  workspaceId: string;
+  memberId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const spendLimitFetcher: Fetcher<GetUserSpendLimitResponseBody> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    spendLimitUrl(workspaceId, memberId),
+    spendLimitFetcher,
+    { disabled }
+  );
+
+  return {
+    spendLimit: data,
+    isSpendLimitLoading: !error && !data && !disabled,
+    isSpendLimitError: !!error,
+    mutateSpendLimit: mutate,
+  };
+}
+
+export function useUpdateUserSpendLimit({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const sendNotification = useSendNotification();
+
+  const doUpdateSpendLimit = useCallback(
+    async ({
+      memberId,
+      memberName,
+      limit,
+    }: {
+      memberId: string;
+      memberName: string;
+      limit: { kind: "unlimited" } | { kind: "limited"; awuCredits: number };
+    }): Promise<PutUserSpendLimitResponseBody | null> => {
+      const res = await clientFetch(spendLimitUrl(workspaceId, memberId), {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(limit),
+      });
+
+      if (!res.ok) {
+        const error = await res.json();
+        sendNotification({
+          type: "error",
+          title: "Failed to update spend limit",
+          description: error?.error?.message ?? "An unexpected error occurred.",
+        });
+        return null;
+      }
+
+      const body = PutUserSpendLimitResponseSchema.parse(await res.json());
+      sendNotification({
+        type: "success",
+        title: "Spend limit updated",
+        description:
+          limit.kind === "unlimited"
+            ? `${memberName}'s spend limit has been removed.`
+            : `${memberName}'s spend limit has been set to ${limit.awuCredits.toLocaleString("en-US")} credits.`,
+      });
+
+      await mutate(spendLimitUrl(workspaceId, memberId));
+      await mutate(`/api/w/${workspaceId}/credits/members-usage`);
+      return body;
+    },
+    [workspaceId, sendNotification]
+  );
+
+  return { doUpdateSpendLimit };
 }

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -14,6 +14,7 @@ import type { SearchMembersResponseBody } from "@app/pages/api/w/[wId]/members/s
 import type { GroupKind } from "@app/types/groups";
 import { isGroupKind } from "@app/types/groups";
 import type { MembershipSeatType } from "@app/types/memberships";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Fetcher } from "swr";
@@ -363,13 +364,22 @@ export function useUpdateUserSpendLimit({
       }
 
       const body = PutUserSpendLimitResponseSchema.parse(await res.json());
+      let description: string;
+      switch (limit.kind) {
+        case "unlimited":
+          description = `${memberName}'s spend limit has been removed.`;
+          break;
+        case "limited":
+          description = `${memberName}'s spend limit has been set to ${limit.awuCredits.toLocaleString("en-US")} credits.`;
+          break;
+        default:
+          assertNeverAndIgnore(limit);
+          description = "";
+      }
       sendNotification({
         type: "success",
         title: "Spend limit updated",
-        description:
-          limit.kind === "unlimited"
-            ? `${memberName}'s spend limit has been removed.`
-            : `${memberName}'s spend limit has been set to ${limit.awuCredits.toLocaleString("en-US")} credits.`,
+        description,
       });
 
       await mutate(spendLimitUrl(workspaceId, memberId));


### PR DESCRIPTION
## Description

Surface the new per-user cap in the Usage table: rename consumedWorkplacePoolCredits → consumedAwuCredits and switch the bar to total AWU consumption (with the per-user cap as the limit), since "Workspace pool only" is no longer the most useful number once users can have their own ceiling. Plumb a per-workspace listMetronome cap fetch into getMembersUsage so the table receives spendLimitAwuCredits without an extra round-trip.

Add EditSpendLimitModal and useUserSpendLimit / useUpdateUserSpendLimit SWR hooks on top of the GET/PUT endpoint added in the previous commit.

## Tests

Local
## Risk

Low
## Deploy Plan

Front