### PR TITLE
fix(mcp): make AgentMCPActionResource.makeNew atomic

### DIFF
--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -206,7 +206,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     );
 
     const action = await withTransaction(async (t) => {
-      const action = await AgentMCPActionModel.create(
+      const agentMCPAction = await AgentMCPActionModel.create(
         {
           ...blob,
           workspaceId: workspace.id,
@@ -219,13 +219,13 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
           workspaceId: workspace.id,
           agentMessageId: blob.agentMessageId,
           conversationId: conversation.id,
-          agentMCPActionId: action.id,
+          agentMCPActionId: agentMCPAction.id,
           stepContentId: stepContent.id,
         },
         { transaction: t }
       );
 
-      return action;
+      return agentMCPAction;
     }, transaction);
 
     assert(

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -55,6 +55,7 @@ import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrapp
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
@@ -204,26 +205,28 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       blob.toolConfiguration.toolServerId
     );
 
-    const action = await AgentMCPActionModel.create(
-      {
-        ...blob,
-        workspaceId: workspace.id,
-      },
-      { transaction }
-    );
+    const action = await withTransaction(async (t) => {
+      const action = await AgentMCPActionModel.create(
+        {
+          ...blob,
+          workspaceId: workspace.id,
+        },
+        { transaction: t }
+      );
 
-    await AgentStepContentToolExecutionModel.create(
-      {
-        workspaceId: workspace.id,
-        agentMessageId: blob.agentMessageId,
-        conversationId: conversation.id,
-        agentMCPActionId: action.id,
-        stepContentId: stepContent.id,
-      },
-      {
-        transaction,
-      }
-    );
+      await AgentStepContentToolExecutionModel.create(
+        {
+          workspaceId: workspace.id,
+          agentMessageId: blob.agentMessageId,
+          conversationId: conversation.id,
+          agentMCPActionId: action.id,
+          stepContentId: stepContent.id,
+        },
+        { transaction: t }
+      );
+
+      return action;
+    }, transaction);
 
     assert(
       stepContent.isFunctionCallContent(),


### PR DESCRIPTION
## Description

`AgentMCPActionResource.makeNew` was inserting the `AgentMCPAction` row and its companion `agent_step_content_tool_executions` row as **two separate autocommit statements**. A transient failure on the second insert (deadlock, statement timeout, FK race against a freshly-created step content, network blip) left the first one orphaned.

The read path (`baseFetch`) then trips this assertion:

```
AssertionError [ERR_ASSERTION]: Step content not found.
    at _AgentMCPActionResource.baseFetch (.../agent_mcp_action_resource.ts:173)
    at storeAgentAnalytics (.../analytics_queue/activities.ts)
```

A previous attempt (#25830) added `{ transaction }` to the second insert, but every production caller (`createMCPAction` from `temporal/agent_loop/lib/create_tool_actions.ts`, `lib/api/sandbox/create_child_action.ts`, `lib/reinforcement/tool_execution.ts`) calls `makeNew` **without** a transaction — so forwarding the (undefined) `transaction` to the second insert changed nothing in practice. Orphans kept accumulating.

This change wraps both inserts in `withTransaction`, which:

- reuses the caller's transaction if one is provided,
- otherwise opens a fresh one for `makeNew` itself.

Either both rows land or neither does, regardless of how the caller invokes \`makeNew\`.

## Impact assessment

Ran `SELECT a.id FROM agent_mcp_actions a LEFT JOIN agent_step_content_tool_executions e ON e."agentMCPActionId" = a.id WHERE e.id IS NULL;` on both regions. We have 8 matches in US, and 2 in EU. 

Follow up of this PR once the bleeding is officially stopped is to backfill those 10 rows.

## Tests

- `npx tsgo --noEmit` clean.
- Existing tests around `makeNew` (`agent_mcp_action_resource.test.ts`) still pass.
- Manual reasoning verified against the three production call sites — none pass a transaction, so the wrapped path is what runs.

## Risk

Low. The change strictly tightens atomicity:

- Single-statement callers (the common case) now use one transaction instead of two autocommits — same end state on success, correct rollback on failure.
- Callers that *do* pass a transaction (none in prod today, but tests via CLS) keep using it — `withTransaction` is a no-op in that case.
- No schema change, no behavior change visible to consumers of `AgentMCPActionResource`.

Rollback: revert the commit; the previous code is still correct under the same assumptions (just slightly leakier).

## Deploy Plan

Standard front deploy. No migration. The orphan-backfill SQL is run separately, out-of-band.