### PR TITLE
Do some refactoring of login logic to prepare for Hono

### DIFF
--- a/front/lib/api/login.ts
+++ b/front/lib/api/login.ts
@@ -22,10 +22,8 @@ import { ServerSideTracking } from "@app/lib/tracking/server";
 import { readAnonymousIdFromCookies } from "@app/lib/utils/anonymous_id";
 import type { UTMParams } from "@app/lib/utils/utm";
 import logger from "@app/logger/logger";
-import { apiError } from "@app/logger/withlogging";
-import type { WithAPIErrorResponse } from "@app/types/error";
+import type { APIErrorWithStatusCode } from "@app/types/error";
 import type { LightWorkspaceType } from "@app/types/user";
-import type { NextApiRequest, NextApiResponse } from "next";
 
 export interface PerformLoginOptions {
   inviteToken: string | null;
@@ -39,18 +37,47 @@ export interface PerformLoginOptions {
   returnTo: string | null;
 }
 
+/**
+ * Transport-agnostic input for `performLogin`. Carries only the request
+ * fields the login flow actually reads, so both the Next handler and the
+ * Hono handler can call into it.
+ */
+export interface PerformLoginRequest {
+  cookieHeader: string | undefined;
+  forwardedFor: string | string[] | undefined;
+  remoteAddress: string | undefined;
+}
+
+/**
+ * Result of `performLogin`. The handler at the transport boundary
+ * (Next API route or Hono route) maps this to the actual HTTP response.
+ */
+export type LoginOutcome =
+  | { kind: "redirect"; url: string }
+  | { kind: "unauthorized" }
+  | { kind: "apiError"; error: APIErrorWithStatusCode };
+
+function resolveClientIp(request: PerformLoginRequest): string | undefined {
+  const { forwardedFor, remoteAddress } = request;
+  if (forwardedFor) {
+    return (Array.isArray(forwardedFor) ? forwardedFor[0] : forwardedFor)
+      .split(",")[0]
+      .trim();
+  }
+  return remoteAddress;
+}
+
 export async function performLogin(
-  req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<void>>,
+  request: PerformLoginRequest,
   session: SessionWithUser,
   options: PerformLoginOptions
-): Promise<void> {
+): Promise<LoginOutcome> {
   const { inviteToken, wId, utmParams, join, conversationId, returnTo } =
     options;
   const { isSSO, workspaceId } = session;
 
   const anonymousId =
-    readAnonymousIdFromCookies(req.headers.cookie) ?? undefined;
+    readAnonymousIdFromCookies(request.cookieHeader) ?? undefined;
 
   // Use the workspaceId from the query if it exists, otherwise use the workspaceId from the workos session.
   const targetWorkspaceId = wId ?? workspaceId;
@@ -69,13 +96,16 @@ export async function performLogin(
     const { error } = membershipInviteRes;
 
     if (error instanceof AuthFlowError) {
-      return apiError(req, res, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: error.message,
+      return {
+        kind: "apiError",
+        error: {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: error.message,
+          },
         },
-      });
+      };
     }
 
     throw error;
@@ -96,8 +126,7 @@ export async function performLogin(
         },
         "User not found in database, but found in cache. Flush redis cache for this workOSUserId."
       );
-      res.status(401).end();
-      return;
+      return { kind: "unauthorized" };
     }
   }
 
@@ -159,8 +188,7 @@ export async function performLogin(
         const targetUrl = multiRegionsConfig.getRegionUrl(
           workspaceRegionRes.value
         );
-        res.redirect(`${targetUrl}/api/login`);
-        return;
+        return { kind: "redirect", url: `${targetUrl}/api/login` };
       }
 
       logger.error(
@@ -169,10 +197,10 @@ export async function performLogin(
       );
 
       // Workspace not in other region or lookup failed: show login error.
-      res.redirect(
-        `/api/workos/logout?returnTo=/login-error${encodeURIComponent(`?type=sso-login&reason=${flow}`)}`
-      );
-      return;
+      return {
+        kind: "redirect",
+        url: `/api/workos/logout?returnTo=/login-error${encodeURIComponent(`?type=sso-login&reason=${flow}`)}`,
+      };
     }
 
     targetWorkspace = workspace;
@@ -200,8 +228,10 @@ export async function performLogin(
 
     // More than one pending invitation, redirect to invite choose page - otherwise use the first one.
     if (pendingInvitations && pendingInvitations.length > 1) {
-      res.redirect(`${config.getAppUrl()}/invite-choose`);
-      return;
+      return {
+        kind: "redirect",
+        url: `${config.getAppUrl()}/invite-choose`,
+      };
     }
 
     const finalMembershipInvite = membershipInvite ?? pendingInvitations?.[0];
@@ -233,10 +263,10 @@ export async function performLogin(
           },
           "Error during login flow."
         );
-        res.redirect(
-          `/api/workos/logout?returnTo=/login-error${encodeURIComponent(`?type=login&reason=${error.code}`)}`
-        );
-        return;
+        return {
+          kind: "redirect",
+          url: `/api/workos/logout?returnTo=/login-error${encodeURIComponent(`?type=login&reason=${error.code}`)}`,
+        };
       }
 
       // Delete newly created user if SSO is mandatory.
@@ -258,16 +288,18 @@ export async function performLogin(
         "SSO enforcement : redirecting to SSO login."
       );
 
-      res.redirect(
-        `/api/workos/logout?returnTo=${encodeURIComponent(ssoLoginUrl)}`
-      );
-      return;
+      return {
+        kind: "redirect",
+        url: `/api/workos/logout?returnTo=${encodeURIComponent(ssoLoginUrl)}`,
+      };
     }
 
     const { flow, workspace } = result.value;
     if (flow === "no-auto-join" || flow === "revoked") {
-      res.redirect(`${config.getAppUrl()}/no-workspace?flow=${flow}`);
-      return;
+      return {
+        kind: "redirect",
+        url: `${config.getAppUrl()}/no-workspace?flow=${flow}`,
+      };
     }
 
     targetWorkspace = workspace;
@@ -276,8 +308,10 @@ export async function performLogin(
 
   const u = await getUserFromSession(session);
   if (!u || u.workspaces.length === 0) {
-    res.redirect(`${config.getAppUrl()}/no-workspace?flow=revoked`);
-    return;
+    return {
+      kind: "redirect",
+      url: `${config.getAppUrl()}/no-workspace?flow=revoked`,
+    };
   }
 
   const redirectOptions: Parameters<typeof buildPostLoginUrl>[1] = {
@@ -288,12 +322,7 @@ export async function performLogin(
   await user.recordLoginActivity();
 
   if (targetWorkspace) {
-    const forwarded = req.headers["x-forwarded-for"];
-    const ip = forwarded
-      ? (Array.isArray(forwarded) ? forwarded[0] : forwarded)
-          .split(",")[0]
-          .trim()
-      : req.socket?.remoteAddress;
+    const ip = resolveClientIp(request);
     void emitAuditLogEventDirect({
       workspace: targetWorkspace,
       action: "user.login",
@@ -329,24 +358,26 @@ export async function performLogin(
     if (join && conversationId) {
       redirectOptions.conversationId = conversationId;
     }
-    res.redirect(buildPostLoginUrl(targetWorkspace.sId, redirectOptions));
-    return;
+    return {
+      kind: "redirect",
+      url: buildPostLoginUrl(targetWorkspace.sId, redirectOptions),
+    };
   }
 
   // If caller provided a safe deep-link returnTo, honor it over the default
   // workspace destination. This is used by the WorkOS callback to restore the
   // URL the user was originally trying to reach.
   if (returnTo) {
-    res.redirect(returnTo);
-    return;
+    return { kind: "redirect", url: returnTo };
   }
 
-  res.redirect(
-    buildPostLoginUrl(
+  return {
+    kind: "redirect",
+    url: buildPostLoginUrl(
       targetWorkspace?.sId ?? u.workspaces[0].sId,
       redirectOptions
-    )
-  );
+    ),
+  };
 }
 
 const buildPostLoginUrl = (

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { performLogin } from "@app/lib/api/login";
@@ -5,6 +7,7 @@ import type { SessionWithUser } from "@app/lib/iam/provider";
 import { extractUTMParams } from "@app/lib/utils/utm";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -25,14 +28,35 @@ async function handler(
 
   const { inviteToken, wId, join, cId } = req.query;
 
-  return performLogin(req, res, session, {
-    inviteToken: isString(inviteToken) ? inviteToken : null,
-    wId: isString(wId) ? wId : null,
-    utmParams: extractUTMParams(req.query),
-    join: join === "true",
-    conversationId: isString(cId) ? cId : null,
-    returnTo: null,
-  });
+  const outcome = await performLogin(
+    {
+      cookieHeader: req.headers.cookie,
+      forwardedFor: req.headers["x-forwarded-for"],
+      remoteAddress: req.socket?.remoteAddress,
+    },
+    session,
+    {
+      inviteToken: isString(inviteToken) ? inviteToken : null,
+      wId: isString(wId) ? wId : null,
+      utmParams: extractUTMParams(req.query),
+      join: join === "true",
+      conversationId: isString(cId) ? cId : null,
+      returnTo: null,
+    }
+  );
+
+  switch (outcome.kind) {
+    case "redirect":
+      res.redirect(outcome.url);
+      return;
+    case "unauthorized":
+      res.status(401).end();
+      return;
+    case "apiError":
+      return apiError(req, res, outcome.error);
+    default:
+      assertNever(outcome);
+  }
 }
 
 export default withSessionAuthentication(handler);

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /**
  * @swagger
  * /api/workos/login:
@@ -137,8 +139,10 @@ import { getStatsDClient } from "@app/lib/utils/statsd";
 import { extractUTMParams } from "@app/lib/utils/utm";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
 
 import { isDevelopment } from "@app/types/shared/env";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
 import { validateRelativePath } from "@app/types/shared/utils/url_utils";
@@ -585,7 +589,27 @@ async function handleCallback(req: NextApiRequest, res: NextApiResponse) {
       return { ...base, returnTo: appendUtmToUrl(sanitizedReturnTo) };
     })();
 
-    await performLogin(req, res, loginSession, loginOptions);
+    const outcome = await performLogin(
+      {
+        cookieHeader: req.headers.cookie,
+        forwardedFor: req.headers["x-forwarded-for"],
+        remoteAddress: req.socket?.remoteAddress,
+      },
+      loginSession,
+      loginOptions
+    );
+    switch (outcome.kind) {
+      case "redirect":
+        res.redirect(outcome.url);
+        return;
+      case "unauthorized":
+        res.status(401).end();
+        return;
+      case "apiError":
+        return apiError(req, res, outcome.error);
+      default:
+        assertNever(outcome);
+    }
     return;
   } catch (error) {
     logger.error({ error }, "Error during WorkOS callback");


### PR DESCRIPTION
## Description

The `performLogin` helper was tied to NextApiRequest/NextApiResponse, so I had to do some refactor to make it fx agnostic. It does add a bit of extra logic to abstract the request and convey the redirect, but not too bad.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
