### PR TITLE
[connectors] chore: handle GitHub bad credentials in retrieve permissions

### DIFF
--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -1,3 +1,4 @@
+import { isBadCredentials } from "@connectors/connectors/github/lib/errors";
 import {
   getRepo,
   getReposPage,
@@ -495,7 +496,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         }
       }
     } catch (e) {
-      if (e instanceof ExternalOAuthTokenError) {
+      if (e instanceof ExternalOAuthTokenError || isBadCredentials(e)) {
         return new Err(
           new ConnectorManagerError(
             "EXTERNAL_OAUTH_TOKEN_ERROR",


### PR DESCRIPTION
## Description

- Small janitorial change to avoid raising a monitor on Unhandled connectors error, does not change anything for end users.
- Handle GitHub `Bad credentials` responses while retrieving permissions.

## Tests

- Tested manually

## Risk

- Low.

## Deploy Plan

- Deploy connectors
