### PR TITLE
Fix tooltip anchor jumping to corner on mouse-leave

### DIFF
--- a/viz/app/components/EditableFrame.tsx
+++ b/viz/app/components/EditableFrame.tsx
@@ -48,6 +48,7 @@ interface EditableFrameProps {
 export function EditableFrame({ children }: EditableFrameProps) {
   const { editText } = useVizContext();
   const [hoverState, setHoverState] = useState<HoverState | null>(null);
+  const lastHoverPosRef = useRef<HoverState | null>(null);
   const hoveredSpanRef = useRef<HTMLElement | null>(null);
   const isSavingRef = useRef(false);
 
@@ -67,7 +68,9 @@ export function EditableFrame({ children }: EditableFrameProps) {
       }
 
       const rect = target.getBoundingClientRect();
-      setHoverState({ top: rect.top, left: rect.left + rect.width / 2 });
+      const pos = { top: rect.top, left: rect.left + rect.width / 2 };
+      lastHoverPosRef.current = pos;
+      setHoverState(pos);
     } else {
       hoveredSpanRef.current = null;
       setHoverState(null);
@@ -185,6 +188,8 @@ export function EditableFrame({ children }: EditableFrameProps) {
     }
   }, []);
 
+  const anchorPos = hoverState ?? lastHoverPosRef.current;
+
   return (
     <>
       <div
@@ -199,11 +204,7 @@ export function EditableFrame({ children }: EditableFrameProps) {
       <Tooltip open={!!hoverState}>
         <TooltipTrigger asChild>
           <span
-            style={
-              hoverState
-                ? { top: hoverState.top, left: hoverState.left }
-                : undefined
-            }
+            style={anchorPos ? { top: anchorPos.top, left: anchorPos.left } : undefined}
             className="pointer-events-none fixed size-px"
           />
         </TooltipTrigger>

--- a/viz/app/components/EditableFrame.tsx
+++ b/viz/app/components/EditableFrame.tsx
@@ -204,7 +204,11 @@ export function EditableFrame({ children }: EditableFrameProps) {
       <Tooltip open={!!hoverState}>
         <TooltipTrigger asChild>
           <span
-            style={anchorPos ? { top: anchorPos.top, left: anchorPos.left } : undefined}
+            style={
+              anchorPos
+                ? { top: anchorPos.top, left: anchorPos.left }
+                : undefined
+            }
             className="pointer-events-none fixed size-px"
           />
         </TooltipTrigger>


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of 

When leaving an editable span, `hoverState` was set to `null` before Radix's fade-out animation completed. The anchor span lost its position (style became undefined → fixed at 0,0), causing the tooltip to flash in the corner during the exit transition.

This PR fixes it by keeping the last known position on the anchor via `lastHoverPosRef` so the tooltip fades out in place.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
