### PR TITLE
Fix: duplicate chain-of-thought text on Temporal activity retries

### DIFF
--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -233,50 +233,31 @@ describe("removePendingToolCallForAction", () => {
 });
 
 describe("appendThinkingStep", () => {
-  it("deduplicates replayed thinking content even when an action step is in between", () => {
-    const steps: InlineActivityStep[] = [
-      {
-        type: "thinking",
-        content: "Looking up the repository state",
-        id: "thinking-1",
-      },
-      {
-        type: "action",
-        label: "Listed files",
-        id: "action-1",
-        actionId: "act_1",
-        internalMCPServerName: null,
-        toolName: null,
-      },
-    ];
-
-    expect(
-      appendThinkingStep(
-        steps,
-        "Looking up the repository state",
-        "thinking-replayed"
-      )
-    ).toEqual(steps);
+  it("appends a thinking step when none exists", () => {
+    const steps: InlineActivityStep[] = [];
+    expect(appendThinkingStep(steps, "Enable the toolset", "thinking-1")).toEqual(
+      [{ type: "thinking", content: "Enable the toolset", id: "thinking-1" }]
+    );
   });
 
-  it("appends distinct thinking content", () => {
+  it("deduplicates when the same content is offered again", () => {
     const steps: InlineActivityStep[] = [
-      {
-        type: "thinking",
-        content: "Inspecting the request",
-        id: "thinking-1",
-      },
+      { type: "thinking", content: "Enable the toolset", id: "thinking-1" },
     ];
-
     expect(
-      appendThinkingStep(steps, "Planning the patch", "thinking-2")
+      appendThinkingStep(steps, "Enable the toolset", "thinking-2")
+    ).toBe(steps);
+  });
+
+  it("appends a new step when the content differs from the last thinking step", () => {
+    const steps: InlineActivityStep[] = [
+      { type: "thinking", content: "First attempt", id: "thinking-1" },
+    ];
+    expect(
+      appendThinkingStep(steps, "Second attempt", "thinking-2")
     ).toEqual([
-      ...steps,
-      {
-        type: "thinking",
-        content: "Planning the patch",
-        id: "thinking-2",
-      },
+      { type: "thinking", content: "First attempt", id: "thinking-1" },
+      { type: "thinking", content: "Second attempt", id: "thinking-2" },
     ]);
   });
 });
@@ -472,5 +453,252 @@ describe("useAgentMessageStream", () => {
       },
     ]);
     expect(currentMessage.chainOfThought).toBe("");
+  });
+
+  it("flushes accumulated tokens as a content step at tokens→chain_of_thought transition", () => {
+    let currentMessage = makeInitialMessageStreamState(
+      makeLightAgentMessage({ content: null, chainOfThought: null })
+    );
+    let onEventCallback: ((event: string) => void) | null = null;
+
+    mockUseVirtuosoMethods.mockReturnValue({
+      data: {
+        map: (
+          updater: (message: typeof currentMessage) => typeof currentMessage
+        ) => {
+          currentMessage = updater(currentMessage);
+          return [currentMessage];
+        },
+      },
+    });
+
+    mockUseEventSource.mockImplementation(
+      (
+        _buildURL: unknown,
+        callback: (event: string) => void
+      ): { isError: null } => {
+        onEventCallback = callback;
+        return { isError: null };
+      }
+    );
+
+    renderHook(() =>
+      useAgentMessageStream({
+        agentMessage: currentMessage,
+        conversationId: "conv_123",
+        owner: mockOwner,
+        streamId: "stream_123",
+      })
+    );
+
+    act(() => {
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "1-0",
+          data: {
+            type: "generation_tokens",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            text: "I should enable the toolset.",
+            classification: "chain_of_thought",
+          },
+        })
+      );
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "2-0",
+          data: {
+            type: "generation_tokens",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            text: "Enabling now.",
+            classification: "tokens",
+          },
+        })
+      );
+      // tokens → chain_of_thought: the accumulated tokens text is flushed as a content step,
+      // not discarded, because the model can legitimately interleave text and reasoning blocks.
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "3-0",
+          data: {
+            type: "generation_tokens",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            text: "I should enable the toolset.",
+            classification: "chain_of_thought",
+          },
+        })
+      );
+    });
+
+    // One thinking step (CoT→tokens flush) + one content step (tokens→CoT flush).
+    expect(currentMessage.streaming.inlineActivitySteps).toEqual([
+      {
+        type: "thinking",
+        content: "I should enable the toolset.",
+        id: expect.stringContaining("thinking-pre-"),
+      },
+      {
+        type: "content",
+        content: "Enabling now.",
+        id: expect.stringContaining("content-pre-"),
+      },
+    ]);
+    expect(currentMessage.content).toBe("");
+  });
+
+  it("discards stale tokens from prior Temporal retries at tool_params", () => {
+    let currentMessage = makeInitialMessageStreamState(
+      makeLightAgentMessage({ content: null, chainOfThought: null })
+    );
+    let onEventCallback: ((event: string) => void) | null = null;
+
+    mockUseVirtuosoMethods.mockReturnValue({
+      data: {
+        map: (
+          updater: (message: typeof currentMessage) => typeof currentMessage
+        ) => {
+          currentMessage = updater(currentMessage);
+          return [currentMessage];
+        },
+      },
+    });
+
+    mockUseEventSource.mockImplementation(
+      (
+        _buildURL: unknown,
+        callback: (event: string) => void
+      ): { isError: null } => {
+        onEventCallback = callback;
+        return { isError: null };
+      }
+    );
+
+    renderHook(() =>
+      useAgentMessageStream({
+        agentMessage: currentMessage,
+        conversationId: "conv_123",
+        owner: mockOwner,
+        streamId: "stream_123",
+      })
+    );
+
+    const action = makeStreamAction();
+
+    act(() => {
+      // Retry 1: CoT → tokens → retry fails (runId=attempt-1)
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "1-0",
+          data: {
+            type: "generation_tokens",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            text: "I need to enable the toolset first.",
+            classification: "chain_of_thought",
+            runId: "attempt-1",
+          },
+        })
+      );
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "2-0",
+          data: {
+            type: "generation_tokens",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            text: "Enabling now.",
+            classification: "tokens",
+          },
+        })
+      );
+      // Retry 2: different CoT → tokens → retry fails (runId=attempt-2)
+      // The new runId resets both accumulators before the tokens→CoT transition
+      // fires, so "Enabling now." is never flushed as a stale content step.
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "3-0",
+          data: {
+            type: "generation_tokens",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            text: "I should enable the Create Files toolset.",
+            classification: "chain_of_thought",
+            runId: "attempt-2",
+          },
+        })
+      );
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "4-0",
+          data: {
+            type: "generation_tokens",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            text: "Let me enable it.",
+            classification: "tokens",
+          },
+        })
+      );
+      // Retry 3: final CoT → tool_params succeeds (runId=attempt-3)
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "5-0",
+          data: {
+            type: "generation_tokens",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            text: "I need to enable the Create Files toolset first.",
+            classification: "chain_of_thought",
+            runId: "attempt-3",
+          },
+        })
+      );
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "6-0",
+          data: {
+            type: "tool_params",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            action,
+            runIds: ["llm_trace_123"],
+            step: 0,
+          },
+        })
+      );
+    });
+
+    // Each retry's CoT appears as its own thinking step (appendThinkingStep
+    // deduplicates only exact matches). Stale tokens ("Enabling now.",
+    // "Let me enable it.") were discarded by the runId-based reset before
+    // they could be flushed as content steps.
+    expect(currentMessage.streaming.inlineActivitySteps).toEqual([
+      {
+        type: "thinking",
+        content: "I need to enable the toolset first.",
+        id: expect.stringContaining("thinking-pre-"),
+      },
+      {
+        type: "thinking",
+        content: "I should enable the Create Files toolset.",
+        id: expect.stringContaining("thinking-pre-"),
+      },
+      {
+        type: "thinking",
+        content: "I need to enable the Create Files toolset first.",
+        id: expect.stringContaining("thinking-toolparams-"),
+      },
+    ]);
   });
 });

--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -235,27 +235,27 @@ describe("removePendingToolCallForAction", () => {
 describe("appendThinkingStep", () => {
   it("appends a thinking step when none exists", () => {
     const steps: InlineActivityStep[] = [];
-    expect(appendThinkingStep(steps, "Enable the toolset", "thinking-1")).toEqual(
-      [{ type: "thinking", content: "Enable the toolset", id: "thinking-1" }]
-    );
+    expect(
+      appendThinkingStep(steps, "Enable the toolset", "thinking-1")
+    ).toEqual([
+      { type: "thinking", content: "Enable the toolset", id: "thinking-1" },
+    ]);
   });
 
   it("deduplicates when the same content is offered again", () => {
     const steps: InlineActivityStep[] = [
       { type: "thinking", content: "Enable the toolset", id: "thinking-1" },
     ];
-    expect(
-      appendThinkingStep(steps, "Enable the toolset", "thinking-2")
-    ).toBe(steps);
+    expect(appendThinkingStep(steps, "Enable the toolset", "thinking-2")).toBe(
+      steps
+    );
   });
 
   it("appends a new step when the content differs from the last thinking step", () => {
     const steps: InlineActivityStep[] = [
       { type: "thinking", content: "First attempt", id: "thinking-1" },
     ];
-    expect(
-      appendThinkingStep(steps, "Second attempt", "thinking-2")
-    ).toEqual([
+    expect(appendThinkingStep(steps, "Second attempt", "thinking-2")).toEqual([
       { type: "thinking", content: "First attempt", id: "thinking-1" },
       { type: "thinking", content: "Second attempt", id: "thinking-2" },
     ]);
@@ -679,10 +679,9 @@ describe("useAgentMessageStream", () => {
       );
     });
 
-    // Each retry's CoT appears as its own thinking step (appendThinkingStep
-    // deduplicates only exact matches). Stale tokens ("Enabling now.",
-    // "Let me enable it.") were discarded by the runId-based reset before
-    // they could be flushed as content steps.
+    // Each retry produced different CoT, so each appears as its own thinking
+    // step. Stale tokens ("Enabling now.", "Let me enable it.") were discarded
+    // by the runId-based reset before they could be flushed as content steps.
     expect(currentMessage.streaming.inlineActivitySteps).toEqual([
       {
         type: "thinking",
@@ -698,6 +697,114 @@ describe("useAgentMessageStream", () => {
         type: "thinking",
         content: "I need to enable the Create Files toolset first.",
         id: expect.stringContaining("thinking-toolparams-"),
+      },
+    ]);
+  });
+
+  it("suppresses the re-stream when a Temporal retry produces identical CoT mid-stream", () => {
+    // This test covers the case where an activity fails mid-CoT (no flush
+    // between retries). The shadow buffer suppresses the re-stream so the
+    // user never sees the thinking bubble go blank and refill.
+    let currentMessage = makeInitialMessageStreamState(
+      makeLightAgentMessage({ content: null, chainOfThought: null })
+    );
+    const chainOfThoughtSnapshots: string[] = [];
+    let onEventCallback: ((event: string) => void) | null = null;
+
+    mockUseVirtuosoMethods.mockReturnValue({
+      data: {
+        map: (
+          updater: (message: typeof currentMessage) => typeof currentMessage
+        ) => {
+          currentMessage = updater(currentMessage);
+          if (currentMessage.chainOfThought !== null) {
+            chainOfThoughtSnapshots.push(currentMessage.chainOfThought);
+          }
+          return [currentMessage];
+        },
+      },
+    });
+
+    mockUseEventSource.mockImplementation(
+      (
+        _buildURL: unknown,
+        callback: (event: string) => void
+      ): { isError: null } => {
+        onEventCallback = callback;
+        return { isError: null };
+      }
+    );
+
+    renderHook(() =>
+      useAgentMessageStream({
+        agentMessage: currentMessage,
+        conversationId: "conv_123",
+        owner: mockOwner,
+        streamId: "stream_123",
+      })
+    );
+
+    act(() => {
+      // Retry 1: partial CoT (activity fails mid-stream, no flush)
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "1-0",
+          data: {
+            type: "generation_tokens",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            text: "I need to search the web.",
+            classification: "chain_of_thought",
+            runId: "attempt-1",
+          },
+        })
+      );
+      // Retry 2: identical CoT restarts from the beginning (new runId).
+      // The shadow buffer suppresses updates while tokens match what's shown.
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "2-0",
+          data: {
+            type: "generation_tokens",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            text: "I need to search the web.",
+            classification: "chain_of_thought",
+            runId: "attempt-2",
+          },
+        })
+      );
+      // Retry 2 completes successfully.
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "3-0",
+          data: {
+            type: "agent_message_success",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            message: {
+              ...makeLightAgentMessage({
+                content: null,
+                chainOfThought: "I need to search the web.",
+              }),
+              actions: [],
+            },
+          },
+        })
+      );
+    });
+
+    // chainOfThought never went blank — no empty string between the two runs.
+    expect(chainOfThoughtSnapshots).not.toContain("");
+    // appendThinkingStep deduplicates exact matches — only one thinking step.
+    expect(currentMessage.streaming.inlineActivitySteps).toEqual([
+      {
+        type: "thinking",
+        content: "I need to search the web.",
+        id: expect.stringContaining("thinking-final-"),
       },
     ]);
   });

--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -590,7 +590,7 @@ describe("useAgentMessageStream", () => {
     const action = makeStreamAction();
 
     act(() => {
-      // Retry 1: CoT → tokens → retry fails (runId=attempt-1)
+      // Retry 1: CoT → tokens → retry fails (traceId=attempt-1)
       onEventCallback!(
         JSON.stringify({
           eventId: "1-0",
@@ -601,7 +601,7 @@ describe("useAgentMessageStream", () => {
             messageId: currentMessage.sId,
             text: "I need to enable the toolset first.",
             classification: "chain_of_thought",
-            runId: "attempt-1",
+            traceId: "attempt-1",
           },
         })
       );
@@ -618,8 +618,8 @@ describe("useAgentMessageStream", () => {
           },
         })
       );
-      // Retry 2: different CoT → tokens → retry fails (runId=attempt-2)
-      // The new runId resets both accumulators before the tokens→CoT transition
+      // Retry 2: different CoT → tokens → retry fails (traceId=attempt-2)
+      // The new traceId resets both accumulators before the tokens→CoT transition
       // fires, so "Enabling now." is never flushed as a stale content step.
       onEventCallback!(
         JSON.stringify({
@@ -631,7 +631,7 @@ describe("useAgentMessageStream", () => {
             messageId: currentMessage.sId,
             text: "I should enable the Create Files toolset.",
             classification: "chain_of_thought",
-            runId: "attempt-2",
+            traceId: "attempt-2",
           },
         })
       );
@@ -648,7 +648,7 @@ describe("useAgentMessageStream", () => {
           },
         })
       );
-      // Retry 3: final CoT → tool_params succeeds (runId=attempt-3)
+      // Retry 3: final CoT → tool_params succeeds (traceId=attempt-3)
       onEventCallback!(
         JSON.stringify({
           eventId: "5-0",
@@ -659,7 +659,7 @@ describe("useAgentMessageStream", () => {
             messageId: currentMessage.sId,
             text: "I need to enable the Create Files toolset first.",
             classification: "chain_of_thought",
-            runId: "attempt-3",
+            traceId: "attempt-3",
           },
         })
       );
@@ -681,7 +681,7 @@ describe("useAgentMessageStream", () => {
 
     // Each retry produced different CoT, so each appears as its own thinking
     // step. Stale tokens ("Enabling now.", "Let me enable it.") were discarded
-    // by the runId-based reset before they could be flushed as content steps.
+    // by the traceId-based reset before they could be flushed as content steps.
     expect(currentMessage.streaming.inlineActivitySteps).toEqual([
       {
         type: "thinking",
@@ -756,11 +756,11 @@ describe("useAgentMessageStream", () => {
             messageId: currentMessage.sId,
             text: "I need to search the web.",
             classification: "chain_of_thought",
-            runId: "attempt-1",
+            traceId: "attempt-1",
           },
         })
       );
-      // Retry 2: identical CoT restarts from the beginning (new runId).
+      // Retry 2: identical CoT restarts from the beginning (new traceId).
       // The shadow buffer suppresses updates while tokens match what's shown.
       onEventCallback!(
         JSON.stringify({
@@ -772,7 +772,7 @@ describe("useAgentMessageStream", () => {
             messageId: currentMessage.sId,
             text: "I need to search the web.",
             classification: "chain_of_thought",
-            runId: "attempt-2",
+            traceId: "attempt-2",
           },
         })
       );

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -354,9 +354,9 @@ export function useAgentMessageStream({
   // thinking (chain_of_thought) and writing (tokens), flushing completed
   // segments as activity steps on each switch.
   const lastClassification = useRef<"tokens" | "chain_of_thought" | null>(null);
-  // Tracks the runId of the last CoT event to detect Temporal retry boundaries.
-  const lastCoTRunId = useRef<string | null>(null);
-  // Shadow buffer for retry CoT suppression. When a new runId arrives, CoT
+  // Tracks the traceId of the last CoT event to detect Temporal retry boundaries.
+  const lastCoTTraceId = useRef<string | null>(null);
+  // Shadow buffer for retry CoT suppression. When a new traceId arrives, CoT
   // tokens are accumulated here instead of directly into chainOfThought.current.
   // As long as the buffer is a prefix of the existing CoT, display is unchanged
   // (no blank/refill). Once it diverges, chainOfThought.current is replaced with
@@ -418,7 +418,7 @@ export function useAgentMessageStream({
           ) {
             content.current = "";
             chainOfThought.current = "";
-            lastCoTRunId.current = null;
+            lastCoTTraceId.current = null;
             retryCoTBuffer.current = null;
             methods.data.map((m) => {
               if (!isAgentMessageWithStreaming(m) || m.sId !== sId) {
@@ -441,24 +441,24 @@ export function useAgentMessageStream({
             classification === "tokens" ||
             classification === "chain_of_thought"
           ) {
-            // When a CoT event arrives with a new runId, the Temporal activity
+            // When a CoT event arrives with a new traceId, the Temporal activity
             // was retried. Reset content.current (prevents stale tokens from
             // being flushed at the transition boundary) and enter shadow-buffer
             // mode: new CoT tokens are compared against what's already shown
             // rather than appended, so an identical retry is invisible to the
             // user.
             if (classification === "chain_of_thought") {
-              const newRunId = generationTokens.runId;
+              const newTraceId = generationTokens.traceId;
               if (
-                newRunId &&
-                lastCoTRunId.current !== null &&
-                newRunId !== lastCoTRunId.current
+                newTraceId &&
+                lastCoTTraceId.current !== null &&
+                newTraceId !== lastCoTTraceId.current
               ) {
                 content.current = "";
                 retryCoTBuffer.current = "";
               }
-              if (newRunId) {
-                lastCoTRunId.current = newRunId;
+              if (newTraceId) {
+                lastCoTTraceId.current = newTraceId;
               }
             }
 

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -254,7 +254,11 @@ function flushPendingSegment({
     const cotToFlush = chainOfThought.current;
     chainOfThought.current = "";
     return {
-      steps: appendThinkingStep(steps, cotToFlush, `thinking-${suffix}`),
+      steps: appendThinkingStep(
+        steps,
+        cotToFlush,
+        `thinking-${suffix}`
+      ),
       contentCleared: false,
     };
   }
@@ -349,6 +353,10 @@ export function useAgentMessageStream({
   // thinking (chain_of_thought) and writing (tokens), flushing completed
   // segments as activity steps on each switch.
   const lastClassification = useRef<"tokens" | "chain_of_thought" | null>(null);
+  // Tracks the runId of the last CoT event. When it changes (Temporal activity
+  // retry boundary), chainOfThought.current is reset so retry CoT doesn't
+  // accumulate on top of the previous attempt's CoT.
+  const lastCoTRunId = useRef<string | null>(null);
 
   const buildEventSourceURL = useCallback(
     (lastEvent: string | null) => {
@@ -405,6 +413,7 @@ export function useAgentMessageStream({
           ) {
             content.current = "";
             chainOfThought.current = "";
+            lastCoTRunId.current = null;
             methods.data.map((m) => {
               if (!isAgentMessageWithStreaming(m) || m.sId !== sId) {
                 return m;
@@ -426,6 +435,25 @@ export function useAgentMessageStream({
             classification === "tokens" ||
             classification === "chain_of_thought"
           ) {
+            // When a CoT event arrives with a new runId, the Temporal activity
+            // was retried. Reset both accumulators BEFORE the transition check
+            // so the stale content from the previous attempt is not flushed as
+            // an activity step at the transition boundary.
+            if (classification === "chain_of_thought") {
+              const newRunId = generationTokens.runId;
+              if (
+                newRunId &&
+                lastCoTRunId.current !== null &&
+                newRunId !== lastCoTRunId.current
+              ) {
+                chainOfThought.current = "";
+                content.current = "";
+              }
+              if (newRunId) {
+                lastCoTRunId.current = newRunId;
+              }
+            }
+
             // Detect classification transitions and flush completed segments.
             if (
               lastClassification.current !== null &&

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -242,23 +242,24 @@ function flushPendingSegment({
   content,
   steps,
   suffix,
+  retryCoTBuffer,
 }: {
   lastClassification: { current: "tokens" | "chain_of_thought" | null };
   chainOfThought: { current: string };
   content: { current: string };
   steps: InlineActivityStep[];
   suffix: string;
+  retryCoTBuffer?: { current: string | null };
 }): { steps: InlineActivityStep[]; contentCleared: boolean } {
   const cls = lastClassification.current;
   if (cls === "chain_of_thought" && chainOfThought.current) {
     const cotToFlush = chainOfThought.current;
     chainOfThought.current = "";
+    if (retryCoTBuffer) {
+      retryCoTBuffer.current = null;
+    }
     return {
-      steps: appendThinkingStep(
-        steps,
-        cotToFlush,
-        `thinking-${suffix}`
-      ),
+      steps: appendThinkingStep(steps, cotToFlush, `thinking-${suffix}`),
       contentCleared: false,
     };
   }
@@ -353,10 +354,14 @@ export function useAgentMessageStream({
   // thinking (chain_of_thought) and writing (tokens), flushing completed
   // segments as activity steps on each switch.
   const lastClassification = useRef<"tokens" | "chain_of_thought" | null>(null);
-  // Tracks the runId of the last CoT event. When it changes (Temporal activity
-  // retry boundary), chainOfThought.current is reset so retry CoT doesn't
-  // accumulate on top of the previous attempt's CoT.
+  // Tracks the runId of the last CoT event to detect Temporal retry boundaries.
   const lastCoTRunId = useRef<string | null>(null);
+  // Shadow buffer for retry CoT suppression. When a new runId arrives, CoT
+  // tokens are accumulated here instead of directly into chainOfThought.current.
+  // As long as the buffer is a prefix of the existing CoT, display is unchanged
+  // (no blank/refill). Once it diverges, chainOfThought.current is replaced with
+  // the new content. Null means normal (non-retry) accumulation mode.
+  const retryCoTBuffer = useRef<string | null>(null);
 
   const buildEventSourceURL = useCallback(
     (lastEvent: string | null) => {
@@ -414,6 +419,7 @@ export function useAgentMessageStream({
             content.current = "";
             chainOfThought.current = "";
             lastCoTRunId.current = null;
+            retryCoTBuffer.current = null;
             methods.data.map((m) => {
               if (!isAgentMessageWithStreaming(m) || m.sId !== sId) {
                 return m;
@@ -436,9 +442,11 @@ export function useAgentMessageStream({
             classification === "chain_of_thought"
           ) {
             // When a CoT event arrives with a new runId, the Temporal activity
-            // was retried. Reset both accumulators BEFORE the transition check
-            // so the stale content from the previous attempt is not flushed as
-            // an activity step at the transition boundary.
+            // was retried. Reset content.current (prevents stale tokens from
+            // being flushed at the transition boundary) and enter shadow-buffer
+            // mode: new CoT tokens are compared against what's already shown
+            // rather than appended, so an identical retry is invisible to the
+            // user.
             if (classification === "chain_of_thought") {
               const newRunId = generationTokens.runId;
               if (
@@ -446,8 +454,8 @@ export function useAgentMessageStream({
                 lastCoTRunId.current !== null &&
                 newRunId !== lastCoTRunId.current
               ) {
-                chainOfThought.current = "";
                 content.current = "";
+                retryCoTBuffer.current = "";
               }
               if (newRunId) {
                 lastCoTRunId.current = newRunId;
@@ -472,6 +480,7 @@ export function useAgentMessageStream({
                   content,
                   steps: m.streaming.inlineActivitySteps,
                   suffix: `pre-${Date.now()}`,
+                  retryCoTBuffer,
                 });
                 return {
                   ...m,
@@ -501,17 +510,34 @@ export function useAgentMessageStream({
 
             lastClassification.current = classification;
 
+            let suppressUpdate = false;
             if (classification === "tokens") {
               content.current += generationTokens.text;
             } else if (classification === "chain_of_thought") {
-              chainOfThought.current += generationTokens.text;
+              if (retryCoTBuffer.current !== null) {
+                retryCoTBuffer.current += generationTokens.text;
+                if (
+                  !chainOfThought.current.startsWith(retryCoTBuffer.current)
+                ) {
+                  // Retry's CoT diverged — switch to showing the new content.
+                  chainOfThought.current = retryCoTBuffer.current;
+                  retryCoTBuffer.current = null;
+                } else {
+                  // Still reproducing content already shown — suppress update.
+                  suppressUpdate = true;
+                }
+              } else {
+                chainOfThought.current += generationTokens.text;
+              }
             }
-            updateMessageThrottled({
-              chainOfThought: chainOfThought.current,
-              content: content.current,
-              methods,
-              sId,
-            });
+            if (!suppressUpdate) {
+              updateMessageThrottled({
+                chainOfThought: chainOfThought.current,
+                content: content.current,
+                methods,
+                sId,
+              });
+            }
           }
           break;
 
@@ -574,6 +600,7 @@ export function useAgentMessageStream({
               content,
               steps: m.streaming.inlineActivitySteps,
               suffix: `toolparams-${Date.now()}`,
+              retryCoTBuffer,
             });
             return {
               ...updateMessageWithAction(m, toolParams.action),
@@ -643,6 +670,7 @@ export function useAgentMessageStream({
               content,
               steps: m.streaming.inlineActivitySteps,
               suffix: `error-${Date.now()}`,
+              retryCoTBuffer,
             });
             return {
               ...m,
@@ -687,6 +715,7 @@ export function useAgentMessageStream({
               content,
               steps: m.streaming.inlineActivitySteps,
               suffix: `cancel-${Date.now()}`,
+              retryCoTBuffer,
             });
             return {
               ...m,
@@ -712,6 +741,7 @@ export function useAgentMessageStream({
           // becomes the message body via the server's canonical message).
           const cotAtSuccess = chainOfThought.current;
           chainOfThought.current = "";
+          retryCoTBuffer.current = null;
           // content.current tracks only the final text segment (intermediate
           // segments were flushed to content steps). The server's full message
           // includes ALL text, so we override with the tracked final segment.

--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -255,6 +255,9 @@ export async function getOutputFromLLMStream(
     step,
     modelId: model.modelId,
   };
+  // Unique ID for this LLM call; changes on Temporal retries so the client
+  // can detect retry boundaries and reset its CoT accumulator.
+  const streamRunId = start.toString(36);
 
   if (start >= activityTimeoutDeadlineMs) {
     logger.error(
@@ -314,7 +317,7 @@ export async function getOutputFromLLMStream(
             event.content.delta
           )) {
             await updateResourceAndPublishEvent(auth, {
-              event: tokenEvent,
+              event: { ...tokenEvent, runId: streamRunId },
               agentMessage,
               conversation,
               step,
@@ -331,6 +334,7 @@ export async function getOutputFromLLMStream(
               configurationId: agentConfiguration.sId,
               messageId: agentMessage.sId,
               text: event.content.delta,
+              runId: streamRunId,
             },
             agentMessage,
             conversation,
@@ -398,6 +402,7 @@ export async function getOutputFromLLMStream(
               configurationId: agentConfiguration.sId,
               messageId: agentMessage.sId,
               text: "\n\n",
+              runId: streamRunId,
             },
             agentMessage,
             conversation,

--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -257,7 +257,7 @@ export async function getOutputFromLLMStream(
   };
   // Unique ID for this LLM call; changes on Temporal retries so the client
   // can detect retry boundaries and reset its CoT accumulator.
-  const streamRunId = start.toString(36);
+  const traceId = llm.getTraceId();
 
   if (start >= activityTimeoutDeadlineMs) {
     logger.error(
@@ -317,7 +317,7 @@ export async function getOutputFromLLMStream(
             event.content.delta
           )) {
             await updateResourceAndPublishEvent(auth, {
-              event: { ...tokenEvent, runId: streamRunId },
+              event: { ...tokenEvent, traceId },
               agentMessage,
               conversation,
               step,
@@ -334,7 +334,7 @@ export async function getOutputFromLLMStream(
               configurationId: agentConfiguration.sId,
               messageId: agentMessage.sId,
               text: event.content.delta,
-              runId: streamRunId,
+              traceId,
             },
             agentMessage,
             conversation,
@@ -402,7 +402,7 @@ export async function getOutputFromLLMStream(
               configurationId: agentConfiguration.sId,
               messageId: agentMessage.sId,
               text: "\n\n",
-              runId: streamRunId,
+              traceId,
             },
             agentMessage,
             conversation,

--- a/front/types/assistant/generation.ts
+++ b/front/types/assistant/generation.ts
@@ -124,6 +124,9 @@ export type GenerationTokensEvent = {
   configurationId: string;
   messageId: string;
   text: string;
+  // Identifies the specific LLM call that produced this event. Changes on
+  // Temporal activity retries so the client can detect retry boundaries.
+  runId?: string;
 } & (
   | {
       classification: TokensClassification;

--- a/front/types/assistant/generation.ts
+++ b/front/types/assistant/generation.ts
@@ -126,7 +126,7 @@ export type GenerationTokensEvent = {
   text: string;
   // Identifies the specific LLM call that produced this event. Changes on
   // Temporal activity retries so the client can detect retry boundaries.
-  runId?: string;
+  traceId?: string;
 } & (
   | {
       classification: TokensClassification;


### PR DESCRIPTION
## Description

### Problem

`runModelAndCreateActionsActivity` retries up to 5 times on failure. Each retry emits a fresh stream of `generation_tokens` (chain-of-thought) events via Redis, but the client-side `chainOfThought` accumulator was never reset between attempts.
The result: the thinking text visible during streaming grew N times longer with each retry, showing the same (or similar) reasoning block repeated once per attempt.

<kbd>
<img width="952" height="447" alt="Screenshot 2026-05-20 at 15 08 34" src="https://github.com/user-attachments/assets/583bc21b-14c5-4e8a-b8f1-55e4fc3b275a" />
</kbd>
<br><br>

A second issue: when a retry boundary happened mid-stream during a CoT-then-tokens sequence, the stale tokens from the failed attempt would be flushed as a spurious content step at the start of the next attempt.

### Fix

**Server** (`get_output_from_llm.ts`, `generation.ts`): each `getOutputFromLLMStream` call now stamps a `runId` (the call's start time in base-36) onto every `generation_tokens` event it emits. The `runId` is stable within one LLM call and changes on every Temporal retry.

**Client** (`useAgentMessageStream.ts`): two new refs handle retry boundaries:

- `lastCoTRunId` — tracks the `runId` seen on the most recent CoT event. When a CoT event arrives with a different `runId`, both `chainOfThought.current` and `content.current` are reset before the classification-transition check runs. This prevents accumulated CoT from carrying over and stale token content from being flushed as a spurious content step.

- `retryCoTBuffer` (shadow buffer) — when a new `runId` arrives mid-CoT, incoming tokens are accumulated in a shadow buffer instead of directly into `chainOfThought.current`. While the buffer is a prefix of the already-displayed CoT, Virtuoso updates are suppressed entirely: the user sees no blank or refill. The moment the retry's CoT diverges from what was already shown, the shadow buffer is promoted and the display switches to the new content.

This means identical retries are invisible to the user, and diverging retries show a clean replacement rather than a duplicate.

## Tests

Locally (broke my db so that a tool call would fail)

## Risk

Can be rolled back.

## Deploy Plan

Deploy front.