### PR TITLE
[front] enh: batch fetch of run usages in programmatic usage tracking

### DIFF
--- a/front/lib/api/programmatic_usage/tracking.ts
+++ b/front/lib/api/programmatic_usage/tracking.ts
@@ -13,7 +13,6 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import type { Logger } from "@app/logger/logger";
 import logger from "@app/logger/logger";
@@ -304,13 +303,7 @@ export async function trackProgrammaticCost(
   const runs = await RunResource.listByDustRunIds(auth, { dustRunIds });
 
   // Compute the token usage for each run.
-  const runUsages = await concurrentExecutor(
-    runs,
-    async (run) => {
-      return run.listRunUsages(auth);
-    },
-    { concurrency: 10 }
-  );
+  const runUsages = await RunResource.listRunUsagesForRuns(auth, { runs });
 
   // There is a race condition where the run is not created before we emit the event.
   if (runUsages.length === 0 && dustRunIds.length > 0) {
@@ -318,9 +311,10 @@ export async function trackProgrammaticCost(
   }
 
   // Compute the price for all the runs.
-  const runsCostMicroUsd = runUsages
-    .flat()
-    .reduce((acc, usage) => acc + usage.costMicroUsd, 0);
+  const runsCostMicroUsd = runUsages.reduce(
+    (acc, usage) => acc + usage.costMicroUsd,
+    0
+  );
 
   const costWithMarkupMicroUsd = Math.ceil(
     runsCostMicroUsd * (1 + DUST_MARKUP_PERCENT / 100)

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -169,6 +169,38 @@ export class RunResource extends BaseResource<RunModel> {
     return runs.map((r) => new this(this.model, r.get()));
   }
 
+  static async listRunUsagesForRuns(
+    auth: Authenticator,
+    {
+      runs,
+    }: {
+      runs: RunResource[];
+    }
+  ): Promise<RunUsageType[]> {
+    const runModelIds = runs.map((run) => run.id);
+    if (runModelIds.length === 0) {
+      return [];
+    }
+
+    const usages = await RunUsageModel.findAll({
+      where: {
+        runId: { [Op.in]: runModelIds },
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+
+    return usages.map((usage) => ({
+      completionTokens: usage.completionTokens,
+      modelId: usage.modelId as ModelIdType,
+      promptTokens: usage.promptTokens,
+      providerId: usage.providerId as ModelProviderIdType,
+      cachedTokens: usage.cachedTokens,
+      cacheCreationTokens: usage.cacheCreationTokens,
+      costMicroUsd: usage.costMicroUsd,
+      isBatch: usage.isBatch,
+    }));
+  }
+
   static async fetchByDustRunId(
     auth: Authenticator,
     { dustRunId }: { dustRunId: string }
@@ -380,23 +412,7 @@ export class RunResource extends BaseResource<RunModel> {
   }
 
   async listRunUsages(auth: Authenticator): Promise<RunUsageType[]> {
-    const usages = await RunUsageModel.findAll({
-      where: {
-        runId: this.id,
-        workspaceId: auth.getNonNullableWorkspace().id,
-      },
-    });
-
-    return usages.map((usage) => ({
-      completionTokens: usage.completionTokens,
-      modelId: usage.modelId as ModelIdType,
-      promptTokens: usage.promptTokens,
-      providerId: usage.providerId as ModelProviderIdType,
-      cachedTokens: usage.cachedTokens,
-      cacheCreationTokens: usage.cacheCreationTokens,
-      costMicroUsd: usage.costMicroUsd,
-      isBatch: usage.isBatch,
-    }));
+    return RunResource.listRunUsagesForRuns(auth, { runs: [this] });
   }
 }
 

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -176,7 +176,7 @@ export class RunResource extends BaseResource<RunModel> {
     }: {
       runs: RunResource[];
     }
-  ): Promise<RunUsageType[]> {
+  ): Promise<(RunUsageType & { runModelId: ModelId })[]> {
     const runModelIds = runs.map((run) => run.id);
     if (runModelIds.length === 0) {
       return [];
@@ -190,6 +190,7 @@ export class RunResource extends BaseResource<RunModel> {
     });
 
     return usages.map((usage) => ({
+      runModelId: usage.runId,
       completionTokens: usage.completionTokens,
       modelId: usage.modelId as ModelIdType,
       promptTokens: usage.promptTokens,
@@ -412,7 +413,11 @@ export class RunResource extends BaseResource<RunModel> {
   }
 
   async listRunUsages(auth: Authenticator): Promise<RunUsageType[]> {
-    return RunResource.listRunUsagesForRuns(auth, { runs: [this] });
+    const usages = await RunResource.listRunUsagesForRuns(auth, {
+      runs: [this],
+    });
+
+    return usages.map(({ runModelId, ...usage }) => usage);
   }
 }
 

--- a/front/temporal/agent_loop/activities/cost_threshold_warnings.ts
+++ b/front/temporal/agent_loop/activities/cost_threshold_warnings.ts
@@ -5,7 +5,6 @@ import {
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { RunResource } from "@app/lib/resources/run_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
@@ -117,13 +116,11 @@ async function getCumulativeCostMicroUsd(
   }
 
   const runResources = await RunResource.listByDustRunIds(auth, { dustRunIds });
-  const runUsages = await concurrentExecutor(
-    runResources,
-    async (runResource) => runResource.listRunUsages(auth),
-    { concurrency: 5 }
-  );
+  const runUsages = await RunResource.listRunUsagesForRuns(auth, {
+    runs: runResources,
+  });
 
-  return runUsages.flat().reduce((acc, usage) => acc + usage.costMicroUsd, 0);
+  return runUsages.reduce((acc, usage) => acc + usage.costMicroUsd, 0);
 }
 
 /**

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -38,7 +38,6 @@ import type { SkillDefinition } from "@app/lib/resources/skill/code_defined/shar
 import { SystemSkillsRegistry } from "@app/lib/resources/skill/code_defined/system_registry";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { makeSId } from "@app/lib/resources/string_ids";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type {
   AgentLoopArgs,
@@ -258,13 +257,11 @@ async function collectTokenUsage(
   const runResources = await RunResource.listByDustRunIds(auth, {
     dustRunIds: agentMessage.runIds,
   });
-  const runUsages = await concurrentExecutor(
-    runResources,
-    async (runResource) => runResource.listRunUsages(auth),
-    { concurrency: 5 }
-  );
+  const runUsages = await RunResource.listRunUsagesForRuns(auth, {
+    runs: runResources,
+  });
 
-  return runUsages.flat().reduce(
+  return runUsages.reduce(
     (acc, usage) => {
       return {
         prompt: acc.prompt + usage.promptTokens,

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -460,17 +460,18 @@ export async function recordSelfImprovingSkillsUsageActivity({
     const runs = await RunResource.listByDustRunIds(auth, {
       dustRunIds: allDustRunIds,
     });
+    const runByModelId = new Map(runs.map((run) => [run.id, run]));
+    const runUsages = await RunResource.listRunUsagesForRuns(auth, { runs });
 
-    for (const run of runs) {
-      const usages = await run.listRunUsages(auth);
-      const runCostMicroUsd = usages.reduce(
-        (sum, usage) => sum + usage.costMicroUsd,
-        0
-      );
+    for (const usage of runUsages) {
+      const dustRunId = runByModelId.get(usage.runModelId)?.dustRunId;
+      if (!dustRunId) {
+        continue;
+      }
 
       runCostMicroUsdByDustRunId.set(
-        run.dustRunId,
-        (runCostMicroUsdByDustRunId.get(run.dustRunId) ?? 0) + runCostMicroUsd
+        dustRunId,
+        (runCostMicroUsdByDustRunId.get(dustRunId) ?? 0) + usage.costMicroUsd
       );
     }
   }

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -300,15 +300,7 @@ export async function emitMetronomeUsageEventsActivity(
   const runs = await RunResource.listByDustRunIds(auth, {
     dustRunIds: effectiveRunIds,
   });
-  const runUsages = (
-    await concurrentExecutor(
-      runs,
-      (run) => {
-        return run.listRunUsages(auth);
-      },
-      { concurrency: 10 }
-    )
-  ).flat();
+  const runUsages = await RunResource.listRunUsagesForRuns(auth, { runs });
 
   // Get MCP actions — filter to this execution's steps if startStep is available,
   // and only include actions with a final status (succeeded/errored/denied).


### PR DESCRIPTION
## Description

- Replace the per-run `run_usages` query `concurrentExecutor` in cost tracking with a single batch query.
- Keep single-run usage reads on the same resource path, so usage rendering stays consistent.

## Tests

- Well covered by existing tests.

## Risk

- Low.

## Deploy Plan

- Deploy front
