### PR TITLE
fix: pod hash bug with agent details sheet

### DIFF
--- a/front-spa/src/lib/platform.tsx
+++ b/front-spa/src/lib/platform.tsx
@@ -85,7 +85,7 @@ function urlToString(url: string | UrlObject): string {
     }
   }
   if (url.hash) {
-    result += url.hash;
+    result += url.hash.startsWith("#") ? url.hash : `#${url.hash}`;
   }
   return result;
 }


### PR DESCRIPTION
## Description

This PR fixes a bug in the `urlToString` utility where the `#` prefix was sometimes not prepended to the URL hash, which broke navigation from the agent details sheet to the pods pages.

Before:


https://github.com/user-attachments/assets/27decbe3-1adb-4421-9c45-a277dcc48d43


After:


https://github.com/user-attachments/assets/89f1a4d8-203c-46af-87ca-4015fd14c10e



## Tests

Manually.

## Risks

<!-- Discuss potential risks and how they will be mitigated. -->

## Deploy Plan

<!-- Outline the deployment steps. -->
