### PR TITLE
fix(migrations): use pg client directly to avoid implicit transaction wrapping

### DIFF
--- a/connectors/scripts/migrate.ts
+++ b/connectors/scripts/migrate.ts
@@ -1,7 +1,8 @@
 import logger from "@connectors/logger/logger";
 import { connectorsSequelize } from "@connectors/resources/storage";
+import { dbConfig } from "@connectors/resources/storage/config";
 import { assertNever } from "@dust-tt/client";
-import fs from "fs";
+import { execFileSync } from "child_process";
 import { makeScript } from "scripts/helpers";
 import { QueryTypes } from "sequelize";
 import type { MigrationParams } from "umzug";
@@ -71,8 +72,23 @@ function createUmzug(phase: Phase) {
           if (!filePath) {
             throw new Error(`Missing path for migration ${name}.`);
           }
-          const sql = fs.readFileSync(filePath, "utf8");
-          await connectorsSequelize.query(sql);
+          // Use psql -f so the file runs in a single direct PostgreSQL session,
+          // bypassing pgbouncer. This is required because pg-schema-diff emits
+          // files that mix SET SESSION, regular DDL, and CREATE/DROP INDEX
+          // CONCURRENTLY — the latter two require autocommit, which pgbouncer's
+          // transaction-pooling mode would break if we used a library client.
+          try {
+            execFileSync("psql", ["--version"], { stdio: "pipe" });
+          } catch {
+            throw new Error(
+              "psql is not available — install the PostgreSQL client tools."
+            );
+          }
+          execFileSync(
+            "psql",
+            [dbConfig.getRequiredDatabaseURI(), "-f", filePath],
+            { stdio: "inherit" }
+          );
         },
         // Down migrations are intentionally not supported. The expand/contract
         // pattern means rolling back a schema change is a new forward migration.

--- a/front/scripts/migrate.ts
+++ b/front/scripts/migrate.ts
@@ -1,8 +1,9 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { dbConfig } from "@app/lib/resources/storage/config";
 import logger from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import fs from "fs";
+import { execFileSync } from "child_process";
 import { QueryTypes } from "sequelize";
 import type { MigrationParams } from "umzug";
 import { Umzug } from "umzug";
@@ -74,9 +75,23 @@ function createUmzug(phase: Phase) {
           if (!filePath) {
             throw new Error(`Missing path for migration ${name}.`);
           }
-          const sql = fs.readFileSync(filePath, "utf8");
-          // biome-ignore lint/plugin/noRawSql: migration files are raw SQL by design.
-          await frontSequelize.query(sql);
+          // Use psql -f so the file runs in a single direct PostgreSQL session,
+          // bypassing pgbouncer. This is required because pg-schema-diff emits
+          // files that mix SET SESSION, regular DDL, and CREATE/DROP INDEX
+          // CONCURRENTLY — the latter two require autocommit, which pgbouncer's
+          // transaction-pooling mode would break if we used a library client.
+          try {
+            execFileSync("psql", ["--version"], { stdio: "pipe" });
+          } catch {
+            throw new Error(
+              "psql is not available — install the PostgreSQL client tools."
+            );
+          }
+          execFileSync(
+            "psql",
+            [dbConfig.getRequiredFrontDatabaseURI(), "-f", filePath],
+            { stdio: "inherit" }
+          );
         },
         // Down migrations are intentionally not supported. The expand/contract
         // pattern means rolling back a schema change is a new forward migration.


### PR DESCRIPTION
## Description

When running migration SQL files, using a library client (pg, Sequelize) routes through pgbouncer in production. In transaction-pooling mode, pgbouncer may reassign the backend connection between statements, which breaks `SET SESSION` semantics and causes `CREATE/DROP INDEX CONCURRENTLY` to fail with "cannot run inside a transaction block".

Fix: exec `psql -f <file>` directly for each migration. psql opens a single direct PostgreSQL connection that bypasses pgbouncer entirely, so the full file runs in one session with autocommit semantics preserved.

Applies to both `front/scripts/migrate.ts` and `connectors/scripts/migrate.ts`.
