### PR TITLE
feat(front): inline email editor for gmail tool validation

### DIFF
--- a/connectors/scripts/migrate.ts
+++ b/connectors/scripts/migrate.ts
@@ -1,7 +1,9 @@
 import logger from "@connectors/logger/logger";
 import { connectorsSequelize } from "@connectors/resources/storage";
+import { dbConfig } from "@connectors/resources/storage/config";
 import { assertNever } from "@dust-tt/client";
 import fs from "fs";
+import { Client } from "pg";
 import { makeScript } from "scripts/helpers";
 import { QueryTypes } from "sequelize";
 import type { MigrationParams } from "umzug";
@@ -72,7 +74,21 @@ function createUmzug(phase: Phase) {
             throw new Error(`Missing path for migration ${name}.`);
           }
           const sql = fs.readFileSync(filePath, "utf8");
-          await connectorsSequelize.query(sql);
+          // Use a dedicated pg Client rather than connectorsSequelize.query() so
+          // that the SQL file is sent as a single simple-protocol message with no
+          // implicit transaction wrapping. This is required because pg-schema-diff
+          // emits files that mix SET SESSION, regular DDL, and
+          // CREATE/DROP INDEX CONCURRENTLY — the latter two cannot run inside a
+          // transaction block, which Sequelize may add implicitly.
+          const client = new Client({
+            connectionString: dbConfig.getRequiredDatabaseURI(),
+          });
+          await client.connect();
+          try {
+            await client.query(sql);
+          } finally {
+            await client.end();
+          }
         },
         // Down migrations are intentionally not supported. The expand/contract
         // pattern means rolling back a schema change is a new forward migration.

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
@@ -9,6 +9,7 @@ const ValidateActionSchema = z.object({
   actionId: z.string(),
   approved: z.enum(["approved", "rejected", "always_approved"]),
   resumeAncestorConversations: z.boolean().optional(),
+  updatedInputs: z.record(z.unknown()).optional(),
 });
 
 // Mounted at /api/w/:wId/assistant/conversations/:cId/messages/:mId/validate-action.
@@ -30,7 +31,7 @@ app.post("/", validate("json", ValidateActionSchema), async (ctx) => {
     });
   }
 
-  const { actionId, approved, resumeAncestorConversations } =
+  const { actionId, approved, resumeAncestorConversations, updatedInputs } =
     ctx.req.valid("json");
 
   const result = await validateAction(auth, conversation, {
@@ -38,6 +39,7 @@ app.post("/", validate("json", ValidateActionSchema), async (ctx) => {
     approvalState: approved,
     messageId: mId,
     resumeAncestorConversations,
+    updatedInputs,
   });
 
   if (result.isErr()) {

--- a/front/components/assistant/conversation/BlockedAction.tsx
+++ b/front/components/assistant/conversation/BlockedAction.tsx
@@ -1,8 +1,10 @@
+import { EmailComposerValidation } from "@app/components/assistant/conversation/EmailComposerValidation";
 import { GoogleDriveFileAuthorizationRequired } from "@app/components/assistant/conversation/GoogleDriveFileAuthorizationRequired";
 import { MCPServerPersonalAuthenticationRequired } from "@app/components/assistant/conversation/MCPServerPersonalAuthenticationRequired";
 import { MCPToolValidationRequired } from "@app/components/assistant/conversation/MCPToolValidationRequired";
 import { UserAnswerRequired } from "@app/components/assistant/conversation/UserAnswerRequired";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
+import { isEmailComposeTool } from "@app/lib/actions/mcp_email_tools";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 
@@ -28,6 +30,20 @@ export function BlockedAction({
 }: BlockedActionProps) {
   switch (blockedAction.status) {
     case "blocked_validation_required":
+      if (
+        isEmailComposeTool(
+          blockedAction.metadata.mcpServerName,
+          blockedAction.metadata.toolName
+        )
+      ) {
+        return (
+          <EmailComposerValidation
+            triggeringUser={triggeringUser}
+            owner={owner}
+            blockedAction={blockedAction}
+          />
+        );
+      }
       return (
         <MCPToolValidationRequired
           triggeringUser={triggeringUser}

--- a/front/components/assistant/conversation/EmailComposerValidation.tsx
+++ b/front/components/assistant/conversation/EmailComposerValidation.tsx
@@ -1,0 +1,272 @@
+import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
+import { useValidateAction } from "@app/hooks/useValidateAction";
+import type { BlockedToolExecution } from "@app/lib/actions/mcp";
+import { getEmailComposeFields } from "@app/lib/actions/mcp_email_tools";
+import { useAuth } from "@app/lib/auth/AuthContext";
+import type { LightWorkspaceType, UserType } from "@app/types/user";
+import {
+  Button,
+  ChevronDownIcon,
+  ContentMessage,
+  Input,
+  TextArea,
+  XMarkIcon,
+} from "@dust-tt/sparkle";
+import { useMemo, useState } from "react";
+
+interface EmailComposerValidationProps {
+  triggeringUser: UserType | null;
+  owner: LightWorkspaceType;
+  blockedAction: BlockedToolExecution;
+}
+
+function parseEmailList(raw: unknown): string[] {
+  if (Array.isArray(raw)) {
+    return raw.map(String).filter(Boolean);
+  }
+  if (typeof raw === "string" && raw.trim()) {
+    return raw
+      .split(",")
+      .map((e) => e.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+function emailListToString(list: string[]): string {
+  return list.join(", ");
+}
+
+export function EmailComposerValidation({
+  triggeringUser,
+  owner,
+  blockedAction,
+}: EmailComposerValidationProps) {
+  const { user } = useAuth();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [showCcBcc, setShowCcBcc] = useState(false);
+
+  const { removeCompletedAction, isActionPulsing, stopPulsingAction } =
+    useBlockedActionsContext();
+  const { validateAction, isValidating } = useValidateAction({
+    owner,
+    onError: setErrorMessage,
+  });
+
+  const fields = useMemo(
+    () =>
+      getEmailComposeFields(
+        blockedAction.metadata.mcpServerName,
+        blockedAction.metadata.toolName
+      ),
+    [blockedAction.metadata.mcpServerName, blockedAction.metadata.toolName]
+  );
+
+  const inputs = blockedAction.inputs;
+
+  const [to, setTo] = useState(() =>
+    emailListToString(parseEmailList(inputs.to))
+  );
+  const [cc, setCc] = useState(() =>
+    emailListToString(parseEmailList(inputs.cc))
+  );
+  const [bcc, setBcc] = useState(() =>
+    emailListToString(parseEmailList(inputs.bcc))
+  );
+  const [subject, setSubject] = useState(() =>
+    typeof inputs.subject === "string" ? inputs.subject : ""
+  );
+  const [body, setBody] = useState(() =>
+    typeof inputs.body === "string" ? inputs.body : ""
+  );
+
+  const isTriggeredByCurrentUser = useMemo(
+    () => blockedAction.userId === user?.sId,
+    [blockedAction.userId, user?.sId]
+  );
+
+  const isPulsing = isActionPulsing(blockedAction.actionId);
+
+  const buildUpdatedInputs = (): Record<string, unknown> => {
+    const updated: Record<string, unknown> = { ...inputs };
+    if (fields?.to) {
+      updated.to = parseEmailList(to);
+    }
+    if (fields?.cc) {
+      updated.cc = parseEmailList(cc);
+    }
+    if (fields?.bcc) {
+      updated.bcc = parseEmailList(bcc);
+    }
+    if (fields?.subject) {
+      updated.subject = subject;
+    }
+    if (fields?.body) {
+      updated.body = body;
+    }
+    return updated;
+  };
+
+  const handleSend = async () => {
+    stopPulsingAction(blockedAction.actionId);
+    setErrorMessage(null);
+
+    const result = await validateAction({
+      validationRequest: blockedAction,
+      approved: "approved",
+      updatedInputs: buildUpdatedInputs(),
+    });
+
+    if (!result.success) {
+      setErrorMessage("Failed to send email. Please try again.");
+      return;
+    }
+    removeCompletedAction(blockedAction.actionId);
+  };
+
+  const handleDiscard = async () => {
+    stopPulsingAction(blockedAction.actionId);
+    setErrorMessage(null);
+
+    const result = await validateAction({
+      validationRequest: blockedAction,
+      approved: "rejected",
+    });
+
+    if (!result.success) {
+      setErrorMessage("Failed to discard email. Please try again.");
+      return;
+    }
+    removeCompletedAction(blockedAction.actionId);
+  };
+
+  const hasCcOrBcc =
+    parseEmailList(inputs.cc).length > 0 ||
+    parseEmailList(inputs.bcc).length > 0;
+
+  const showExpandedCcBcc = showCcBcc || hasCcOrBcc;
+
+  return (
+    <ContentMessage
+      title="Review email draft"
+      variant="primary"
+      className="flex w-full flex-col gap-0 overflow-hidden rounded-xl sm:w-80 sm:min-w-[500px]"
+    >
+      {isTriggeredByCurrentUser ? (
+        <div className="flex flex-col">
+          <div className="flex flex-col divide-y divide-border dark:divide-border-night">
+            {fields?.to && (
+              <div className="flex flex-row items-start gap-2 px-1 py-2">
+                <span className="w-12 shrink-0 pt-1 text-xs font-medium text-muted-foreground dark:text-muted-foreground-night">
+                  To
+                </span>
+                <Input
+                  value={to}
+                  onChange={(e) => setTo(e.target.value)}
+                  placeholder="recipient@example.com"
+                  className="flex-1 border-0 bg-transparent p-0 text-sm shadow-none focus-visible:ring-0"
+                />
+              </div>
+            )}
+            {fields?.cc && fields?.bcc && (
+              <>
+                {!showExpandedCcBcc ? (
+                  <div className="px-1 py-2">
+                    <button
+                      type="button"
+                      onClick={() => setShowCcBcc(true)}
+                      className="flex flex-row items-center gap-1 text-xs text-muted-foreground hover:text-foreground dark:text-muted-foreground-night dark:hover:text-foreground-night"
+                    >
+                      <span>CC / BCC</span>
+                      <ChevronDownIcon className="h-3 w-3" />
+                    </button>
+                  </div>
+                ) : (
+                  <>
+                    <div className="flex flex-row items-start gap-2 px-1 py-2">
+                      <span className="w-12 shrink-0 pt-1 text-xs font-medium text-muted-foreground dark:text-muted-foreground-night">
+                        CC
+                      </span>
+                      <Input
+                        value={cc}
+                        onChange={(e) => setCc(e.target.value)}
+                        placeholder="cc@example.com"
+                        className="flex-1 border-0 bg-transparent p-0 text-sm shadow-none focus-visible:ring-0"
+                      />
+                    </div>
+                    <div className="flex flex-row items-start gap-2 px-1 py-2">
+                      <span className="w-12 shrink-0 pt-1 text-xs font-medium text-muted-foreground dark:text-muted-foreground-night">
+                        BCC
+                      </span>
+                      <Input
+                        value={bcc}
+                        onChange={(e) => setBcc(e.target.value)}
+                        placeholder="bcc@example.com"
+                        className="flex-1 border-0 bg-transparent p-0 text-sm shadow-none focus-visible:ring-0"
+                      />
+                    </div>
+                  </>
+                )}
+              </>
+            )}
+            {fields?.subject && (
+              <div className="flex flex-row items-start gap-2 px-1 py-2">
+                <span className="w-12 shrink-0 pt-1 text-xs font-medium text-muted-foreground dark:text-muted-foreground-night">
+                  Subject
+                </span>
+                <Input
+                  value={subject}
+                  onChange={(e) => setSubject(e.target.value)}
+                  placeholder="Subject"
+                  className="flex-1 border-0 bg-transparent p-0 text-sm shadow-none focus-visible:ring-0"
+                />
+              </div>
+            )}
+          </div>
+          {fields?.body && (
+            <div className="mt-2">
+              <TextArea
+                value={body}
+                onChange={(e) => setBody(e.target.value)}
+                placeholder="Email body..."
+                minRows={6}
+                resize="vertical"
+                className="w-full border-0 bg-transparent text-sm shadow-none focus-visible:ring-0"
+              />
+            </div>
+          )}
+          {errorMessage && (
+            <div className="mt-2 text-sm font-medium text-warning-800 dark:text-warning-800-night">
+              {errorMessage}
+            </div>
+          )}
+          <div className="mt-3 flex flex-row gap-2 self-end">
+            <Button
+              label="Discard"
+              variant="outline"
+              size="xs"
+              icon={XMarkIcon}
+              disabled={isValidating}
+              isPulsing={isPulsing}
+              onClick={() => void handleDiscard()}
+            />
+            <Button
+              label="Send email"
+              variant="highlight"
+              size="xs"
+              disabled={isValidating}
+              isPulsing={isPulsing}
+              onClick={() => void handleSend()}
+            />
+          </div>
+        </div>
+      ) : (
+        <div className="font-sm whitespace-normal break-words text-foreground dark:text-foreground-night">
+          Waiting for{" "}
+          <span className="font-semibold">{triggeringUser?.fullName}</span> to
+          review and send.
+        </div>
+      )}
+    </ContentMessage>
+  );
+}

--- a/front/hooks/useValidateAction.ts
+++ b/front/hooks/useValidateAction.ts
@@ -18,9 +18,11 @@ export function useValidateAction({ owner, onError }: UseValidateActionParams) {
     async ({
       validationRequest,
       approved,
+      updatedInputs,
     }: {
       validationRequest: MCPActionValidationRequest;
       approved: MCPValidationOutputType;
+      updatedInputs?: Record<string, unknown>;
     }) => {
       setIsValidating(true);
 
@@ -38,6 +40,7 @@ export function useValidateAction({ owner, onError }: UseValidateActionParams) {
               actionId: validationRequest.actionId,
               approved,
               resumeAncestorConversations: true,
+              updatedInputs,
             }),
           }
         );

--- a/front/lib/actions/mcp_email_tools.ts
+++ b/front/lib/actions/mcp_email_tools.ts
@@ -1,0 +1,52 @@
+export type EmailComposeFields = {
+  to: boolean;
+  cc: boolean;
+  bcc: boolean;
+  subject: boolean;
+  body: boolean;
+};
+
+type EmailComposeToolsConfig = Record<
+  string,
+  Record<string, EmailComposeFields>
+>;
+
+export const EMAIL_COMPOSE_TOOLS: EmailComposeToolsConfig = {
+  gmail: {
+    create_draft: {
+      to: true,
+      cc: true,
+      bcc: true,
+      subject: true,
+      body: true,
+    },
+    create_reply_draft: {
+      to: true,
+      cc: true,
+      bcc: true,
+      subject: false,
+      body: true,
+    },
+    send_mail: {
+      to: true,
+      cc: true,
+      bcc: true,
+      subject: true,
+      body: true,
+    },
+  },
+};
+
+export function getEmailComposeFields(
+  mcpServerName: string,
+  toolName: string
+): EmailComposeFields | null {
+  return EMAIL_COMPOSE_TOOLS[mcpServerName]?.[toolName] ?? null;
+}
+
+export function isEmailComposeTool(
+  mcpServerName: string,
+  toolName: string
+): boolean {
+  return getEmailComposeFields(mcpServerName, toolName) !== null;
+}

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -31,11 +31,13 @@ export async function validateAction(
     approvalState,
     messageId,
     resumeAncestorConversations = false,
+    updatedInputs,
   }: {
     actionId: string;
     approvalState: ActionApprovalStateType;
     messageId: string;
     resumeAncestorConversations?: boolean;
+    updatedInputs?: Record<string, unknown>;
   }
 ): Promise<Result<void, DustError>> {
   const owner = auth.getNonNullableWorkspace();
@@ -89,6 +91,14 @@ export async function validateAction(
         `Action is not blocked: ${action.status}`
       )
     );
+  }
+
+  if (
+    updatedInputs &&
+    approvalState !== "rejected" &&
+    Object.keys(updatedInputs).length > 0
+  ) {
+    await action.updateAugmentedInputs(updatedInputs);
   }
 
   const [updatedCount] = await action.updateStatus(

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -1175,6 +1175,14 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     });
   }
 
+  async updateAugmentedInputs(
+    augmentedInputs: Record<string, unknown>
+  ): Promise<[affectedCount: number]> {
+    return this.update({
+      augmentedInputs,
+    });
+  }
+
   async markAsErrored({
     executionDurationMs,
   }: {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
@@ -13,6 +13,7 @@ export const ValidateActionSchema = z.object({
   actionId: z.string(),
   approved: z.enum(["approved", "rejected", "always_approved"]),
   resumeAncestorConversations: z.boolean().optional(),
+  updatedInputs: z.record(z.unknown()).optional(),
 });
 
 export type ValidateActionResponse = {
@@ -72,13 +73,15 @@ async function handler(
     });
   }
 
-  const { actionId, approved, resumeAncestorConversations } = parseResult.data;
+  const { actionId, approved, resumeAncestorConversations, updatedInputs } =
+    parseResult.data;
 
   const result = await validateAction(auth, conversation, {
     actionId,
     approvalState: approved,
     messageId: mId,
     resumeAncestorConversations,
+    updatedInputs,
   });
 
   if (result.isErr()) {

--- a/front/scripts/migrate.ts
+++ b/front/scripts/migrate.ts
@@ -1,8 +1,10 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { dbConfig } from "@app/lib/resources/storage/config";
 import logger from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import fs from "fs";
+import { Client } from "pg";
 import { QueryTypes } from "sequelize";
 import type { MigrationParams } from "umzug";
 import { Umzug } from "umzug";
@@ -75,8 +77,21 @@ function createUmzug(phase: Phase) {
             throw new Error(`Missing path for migration ${name}.`);
           }
           const sql = fs.readFileSync(filePath, "utf8");
-          // biome-ignore lint/plugin/noRawSql: migration files are raw SQL by design.
-          await frontSequelize.query(sql);
+          // Use a dedicated pg Client rather than frontSequelize.query() so that
+          // the SQL file is sent as a single simple-protocol message with no
+          // implicit transaction wrapping. This is required because pg-schema-diff
+          // emits files that mix SET SESSION, regular DDL, and
+          // CREATE/DROP INDEX CONCURRENTLY — the latter two cannot run inside a
+          // transaction block, which Sequelize may add implicitly.
+          const client = new Client({
+            connectionString: dbConfig.getRequiredFrontDatabaseURI(),
+          });
+          await client.connect();
+          try {
+            await client.query(sql);
+          } finally {
+            await client.end();
+          }
         },
         // Down migrations are intentionally not supported. The expand/contract
         // pattern means rolling back a schema change is a new forward migration.


### PR DESCRIPTION
## Description

Replaces the generic Allow/Deny validation prompt for email-compose MCP tools (Gmail `create_draft`, `create_reply_draft`, `send_mail`) with an inline email editor embedded in the conversation flow.

**What changed:**
- When the agent wants to call an email-compose tool, the user now sees a pre-filled email form (To, CC/BCC, Subject, Body) instead of the "Allow X to create_draft?" prompt
- Fields are live-editable; clicking **Send email** persists the edited inputs to `augmentedInputs` on the action record and resumes the agent loop with the updated content
- Clicking **Discard** rejects the action as before
- CC/BCC are collapsed by default and expand on demand (or automatically if pre-filled)
- Waiting-for-another-user state is preserved

**Implementation:**
- New `EMAIL_COMPOSE_TOOLS` config in `lib/actions/mcp_email_tools.ts` — maps server+tool to visible fields; designed to accept future email providers without code changes
- New `EmailComposerValidation` component routed from `BlockedAction` for matching tools
- `validate-action` endpoint (Next.js + Hono) accepts an optional `updatedInputs` body field — backward-compatible
- `AgentMCPActionResource.updateAugmentedInputs()` persists the edited inputs before status is changed to `ready_allowed_explicitly`

## Tests

Tested manually with the Gmail `create_draft` tool: edited To/Subject/Body in the form, clicked Send, and verified the draft was created in Gmail with the edited content.
