### PR TITLE
[front] enh: add index `agent_sc_te_workspace_message`

### DIFF
--- a/front/lib/models/agent/actions/agent_step_content_tool_execution.ts
+++ b/front/lib/models/agent/actions/agent_step_content_tool_execution.ts
@@ -85,6 +85,11 @@ AgentStepContentToolExecutionModel.init(
         concurrently: true,
         name: "agent_step_content_tool_executions_conversation_id",
       },
+      {
+        fields: ["workspaceId", "agentMessageId"],
+        concurrently: true,
+        name: "agent_sc_te_workspace_message",
+      },
     ],
   }
 );

--- a/front/lib/models/agent/actions/agent_step_content_tool_execution.ts
+++ b/front/lib/models/agent/actions/agent_step_content_tool_execution.ts
@@ -86,9 +86,9 @@ AgentStepContentToolExecutionModel.init(
         name: "agent_step_content_tool_executions_conversation_id",
       },
       {
-        fields: ["workspaceId", "agentMessageId"],
+        fields: ["agentMessageId"],
         concurrently: true,
-        name: "agent_sc_te_workspace_message",
+        name: "agent_step_content_tool_executions_agent_message_id",
       },
     ],
   }

--- a/front/migrations/db/migration_648.sql
+++ b/front/migrations/db/migration_648.sql
@@ -1,0 +1,2 @@
+-- Migration created on May 21, 2026
+CREATE INDEX CONCURRENTLY "agent_sc_te_workspace_message" ON "agent_step_content_tool_executions" ("workspaceId", "agentMessageId");

--- a/front/migrations/db/migration_648.sql
+++ b/front/migrations/db/migration_648.sql
@@ -1,2 +1,2 @@
 -- Migration created on May 21, 2026
-CREATE INDEX CONCURRENTLY "agent_sc_te_workspace_message" ON "agent_step_content_tool_executions" ("workspaceId", "agentMessageId");
+CREATE INDEX CONCURRENTLY "agent_step_content_tool_executions_agent_message_id" ON "agent_step_content_tool_executions" ("agentMessageId");


### PR DESCRIPTION
## Description

- This PR adds an index on `"agent_step_content_tool_executions"` `("workspaceId", "agentMessageId")`
- Looking at [this query](https://console.cloud.google.com/sql/instances/cell-00001-front-db/insights;database=front;duration=PT1H;trace=99ea44218c79a9c43d1b09d33a523721;span=9d29f84c46749e67;query_hash=15444518433361260671;sort_by=TOTAL_EXEC_TIME/executed?project=prj-dust-europe-west1), the index scan on `agent_sc_te_workspace_conversation_message` has a very high cost.
- This PR adds a focused index, specific to this query that we do often.
- We may not need `agent_sc_te_workspace_conversation_message` in addition to this one. We should monitor for a bit and consider dropping if not used (did not seem used in the code).

## Tests

- Tested locally.

## Risk

- Medium.

## Deploy Plan

- Run migration
- Deploy front
