### PR TITLE
feat: change pods route to pods/

### DIFF
--- a/extension/ui/pages/MainPage.tsx
+++ b/extension/ui/pages/MainPage.tsx
@@ -9,7 +9,7 @@ import { useConversation } from "@app/hooks/conversations/useConversation";
 import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import { useSetupNotifications } from "@app/hooks/useSetupNotifications";
 import { useAuth } from "@app/lib/auth/AuthContext";
-import { getProjectRoute } from "@app/lib/utils/router";
+import { getPodRoute } from "@app/lib/utils/router";
 import { AttachmentIcon, Button, MoreIcon } from "@dust-tt/sparkle";
 import { useMcpServer } from "@extension/shared/hooks/useMcpServer";
 import { ConversationLayout } from "@extension/ui/components/conversation/ConversationLayout";
@@ -54,7 +54,7 @@ export const MainPage = () => {
       title={headerTitle}
       backHref={
         conversation?.spaceId
-          ? getProjectRoute(workspace.sId, conversation.spaceId)
+          ? getPodRoute(workspace.sId, conversation.spaceId)
           : undefined
       }
       rightActions={

--- a/extension/ui/pages/ProjectMainPage.tsx
+++ b/extension/ui/pages/ProjectMainPage.tsx
@@ -9,11 +9,11 @@ import { useParams } from "react-router-dom";
 
 export const ProjectMainPage = () => {
   const { workspace } = useAuth();
-  const { spaceId } = useParams<{ spaceId: string }>();
+  const { podId } = useParams<{ podId: string }>();
 
   const { spaceInfo } = useSpaceInfo({
     workspaceId: workspace.sId,
-    spaceId: spaceId ?? null,
+    spaceId: podId ?? null,
   });
 
   return (

--- a/extension/ui/pages/routes.tsx
+++ b/extension/ui/pages/routes.tsx
@@ -25,7 +25,7 @@ export const routes = [
         element: <SubscribePage />,
       },
       {
-        path: "/w/:wId/conversation/space/:spaceId",
+        path: "/w/:wId/pods/:podId",
         element: <ProjectMainPage />,
       },
       {

--- a/front-spa/src/app/layouts/PodRouterLayout.tsx
+++ b/front-spa/src/app/layouts/PodRouterLayout.tsx
@@ -1,0 +1,18 @@
+import { PodLayout } from "@dust-tt/front/components/pages/pod/PodLayout";
+import { useAuth, useWorkspace } from "@dust-tt/front/lib/auth/AuthContext";
+import { Outlet } from "react-router-dom";
+
+/**
+ * Router layout that provides PodLayout for SPA pod routes.
+ * Gets auth context from AppAuthContextLayout and passes it to PodLayout.
+ */
+export function PodRouterLayout() {
+  const owner = useWorkspace();
+  const { user } = useAuth();
+
+  return (
+    <PodLayout owner={owner} user={user}>
+      <Outlet />
+    </PodLayout>
+  );
+}

--- a/front-spa/src/app/routes.tsx
+++ b/front-spa/src/app/routes.tsx
@@ -19,6 +19,7 @@ import {
   loginUnauthenticatedRoutes,
 } from "@spa/app/routes/loginRoutes";
 import { onboardingRoutes } from "@spa/app/routes/onboardingRoutes";
+import { podsRoutes } from "@spa/app/routes/podsRoutes";
 import {
   spacesRedirectRoutes,
   spacesRoutes,
@@ -64,6 +65,7 @@ export const routes: RouteObject[] = [
               ...appsRoutes,
               ...builderContentRoutes,
               ...spacesRedirectRoutes,
+              ...podsRoutes,
             ],
           },
 

--- a/front-spa/src/app/routes/conversationRoutes.tsx
+++ b/front-spa/src/app/routes/conversationRoutes.tsx
@@ -12,13 +12,6 @@ const ConversationPage = withSuspense(
   () => import("@dust-tt/front/components/pages/conversation/ConversationPage"),
   "ConversationPage"
 );
-const SpaceConversationsPage = withSuspense(
-  () =>
-    import(
-      "@dust-tt/front/components/pages/conversation/SpaceConversationsPage"
-    ),
-  "SpaceConversationsPage"
-);
 
 export const conversationRoutes: RouteObject[] = [
   // Workspace index redirects to conversation/new
@@ -29,12 +22,6 @@ export const conversationRoutes: RouteObject[] = [
   {
     path: "conversation",
     element: <ConversationRouterLayout />,
-    children: [
-      { path: ":cId", element: <ConversationPage /> },
-      {
-        path: "space/:spaceId",
-        element: <SpaceConversationsPage />,
-      },
-    ],
+    children: [{ path: ":cId", element: <ConversationPage /> }],
   },
 ];

--- a/front-spa/src/app/routes/podsRoutes.tsx
+++ b/front-spa/src/app/routes/podsRoutes.tsx
@@ -1,0 +1,42 @@
+import { PodRouterLayout } from "@spa/app/layouts/PodRouterLayout";
+import { withSuspense } from "@spa/app/routes/withSuspense";
+import type { RouteObject } from "react-router-dom";
+import { Navigate, useLocation, useParams } from "react-router-dom";
+
+const SpaceConversationsPage = withSuspense(
+  () =>
+    import(
+      "@dust-tt/front/components/pages/conversation/SpaceConversationsPage"
+    ),
+  "SpaceConversationsPage"
+);
+
+// Redirect legacy /conversation/space/:spaceId URLs
+// to the new /pods/:podId path.
+function LegacySpaceToPodRedirect() {
+  const { spaceId } = useParams();
+  const location = useLocation();
+  return (
+    <Navigate
+      to={`../pods/${spaceId}${location.search}${location.hash}`}
+      replace
+    />
+  );
+}
+
+export const podsRoutes: RouteObject[] = [
+  {
+    path: "pods/:podId",
+    element: <PodRouterLayout />,
+    children: [
+      {
+        index: true,
+        element: <SpaceConversationsPage />,
+      },
+    ],
+  },
+  {
+    path: "conversation/space/:spaceId",
+    element: <LegacySpaceToPodRedirect />,
+  },
+];

--- a/front/components/assistant/AssistantLayout.tsx
+++ b/front/components/assistant/AssistantLayout.tsx
@@ -1,0 +1,70 @@
+import { BlockedActionsProvider } from "@app/components/assistant/conversation/BlockedActionsProvider";
+import { AgentSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
+import { AgentDetailsSheet } from "@app/components/assistant/details/AgentDetailsSheet";
+import { MemberDetails } from "@app/components/assistant/details/MemberDetails";
+import { useSetNavChildren } from "@app/components/sparkle/AppLayoutContext";
+import { useURLSheet } from "@app/hooks/useURLSheet";
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
+import { useAppRouter } from "@app/lib/platform";
+import type { ConversationListItemType } from "@app/types/assistant/conversation";
+import { isString } from "@app/types/shared/utils/general";
+import type { LightWorkspaceType } from "@app/types/user";
+import type React from "react";
+import { useMemo } from "react";
+
+interface AssistantLayoutProps {
+  children: React.ReactNode;
+  owner: LightWorkspaceType;
+  user: AuthContextValue["user"];
+  conversation?: ConversationListItemType;
+}
+
+/**
+ * Shared layout for any surface where the user interacts with agents
+ * (conversation pages, pod pages). Provides the sidebar nav, the URL-driven
+ * agent / member detail sheets, and the BlockedActionsProvider that the
+ * input bar depends on.
+ */
+export function AssistantLayout({
+  children,
+  owner,
+  user,
+  conversation,
+}: AssistantLayoutProps) {
+  const router = useAppRouter();
+  const { onOpenChange: onOpenChangeAgentModal } = useURLSheet("agentDetails");
+  const { onOpenChange: onOpenChangeUserModal } = useURLSheet("userDetails");
+
+  const agentId = useMemo(() => {
+    const sid = router.query.agentDetails ?? [];
+    return isString(sid) ? sid : null;
+  }, [router.query.agentDetails]);
+
+  const userId = useMemo(() => {
+    const sid = router.query.userDetails ?? [];
+    return isString(sid) ? sid : null;
+  }, [router.query.userDetails]);
+
+  const navChildren = useMemo(
+    () => <AgentSidebarMenu owner={owner} />,
+    [owner]
+  );
+  useSetNavChildren(navChildren);
+
+  return (
+    <BlockedActionsProvider owner={owner} conversation={conversation}>
+      <AgentDetailsSheet
+        owner={owner}
+        user={user}
+        agentId={agentId}
+        onClose={() => onOpenChangeAgentModal(false)}
+      />
+      <MemberDetails
+        owner={owner}
+        userId={userId}
+        onClose={() => onOpenChangeUserModal(false)}
+      />
+      {children}
+    </BlockedActionsProvider>
+  );
+}

--- a/front/components/assistant/conversation/ConversationBranchApprovalModal.tsx
+++ b/front/components/assistant/conversation/ConversationBranchApprovalModal.tsx
@@ -11,7 +11,7 @@ import {
   useConversationBranchActions,
 } from "@app/hooks/conversations";
 import { useAppRouter } from "@app/lib/platform";
-import { getProjectRoute } from "@app/lib/utils/router";
+import { getPodRoute } from "@app/lib/utils/router";
 import {
   ArrowLeftIcon,
   ScrollArea,
@@ -191,7 +191,7 @@ export function ConversationBranchApprovalModal({
                     // the project page rather than a stale conversation view.
                     if (conversationDeleted && context.conversation?.spaceId) {
                       void router.push(
-                        getProjectRoute(
+                        getPodRoute(
                           context.owner.sId,
                           context.conversation.spaceId
                         )

--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -1,4 +1,4 @@
-import { BlockedActionsProvider } from "@app/components/assistant/conversation/BlockedActionsProvider";
+import { AssistantLayout } from "@app/components/assistant/AssistantLayout";
 import {
   ConversationErrorDisplay,
   ErrorDisplay,
@@ -8,21 +8,15 @@ import { ConversationSidePanelProvider } from "@app/components/assistant/convers
 import { ConversationTitle } from "@app/components/assistant/conversation/ConversationTitle";
 import { FileDropProvider } from "@app/components/assistant/conversation/FileUploaderContext";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
-import { AgentSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
-import { AgentDetailsSheet } from "@app/components/assistant/details/AgentDetailsSheet";
-import { MemberDetails } from "@app/components/assistant/details/MemberDetails";
 import { WelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuide";
 import { useWelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuideProvider";
 import { ErrorBoundary } from "@app/components/error_boundary/ErrorBoundary";
 import {
   useSetHasTitle,
-  useSetNavChildren,
   useSetPageTitle,
 } from "@app/components/sparkle/AppLayoutContext";
 import { useConversation } from "@app/hooks/conversations";
 import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
-import { useActiveSpaceId } from "@app/hooks/useActiveSpaceId";
-import { useURLSheet } from "@app/hooks/useURLSheet";
 import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 import { ONBOARDING_CONVERSATION_ENABLED } from "@app/lib/onboarding";
 import { useAppRouter } from "@app/lib/platform";
@@ -31,7 +25,6 @@ import type {
   ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
 import { getConversationDisplayTitle } from "@app/types/assistant/conversation";
-import { isString } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType } from "@app/types/user";
 import { ResizablePanel, ResizablePanelGroup } from "@dust-tt/sparkle";
 import type React from "react";
@@ -67,30 +60,11 @@ const ConversationLayoutContent = ({
   isAdmin,
 }: ConversationLayoutContentProps) => {
   const router = useAppRouter();
-  const { onOpenChange: onOpenChangeAgentModal } = useURLSheet("agentDetails");
-  const { onOpenChange: onOpenChangeUserModal } = useURLSheet("userDetails");
   const activeConversationId = useActiveConversationId();
-  const activeSpaceId = useActiveSpaceId();
   const { conversation, conversationError } = useConversation({
     conversationId: activeConversationId,
     workspaceId: owner.sId,
   });
-
-  const agentId = useMemo(() => {
-    const sid = router.query.agentDetails ?? [];
-    if (isString(sid)) {
-      return sid;
-    }
-    return null;
-  }, [router.query.agentDetails]);
-
-  const userId = useMemo(() => {
-    const sid = router.query.userDetails ?? [];
-    if (isString(sid)) {
-      return sid;
-    }
-    return null;
-  }, [router.query.userDetails]);
 
   // Logic for the welcome tour guide. We display it if the welcome query param is set to true.
   const { startConversationRef, spaceMenuButtonRef, createAgentButtonRef } =
@@ -116,30 +90,11 @@ const ConversationLayoutContent = ({
     ? `Dust - ${getConversationDisplayTitle(conversation)}`
     : "Dust - New Conversation";
 
-  const navChildren = useMemo(
-    () => <AgentSidebarMenu owner={owner} />,
-    [owner]
-  );
-
-  useSetHasTitle(!!activeConversationId || !!activeSpaceId);
+  useSetHasTitle(!!activeConversationId);
   useSetPageTitle(pageTitle);
-  useSetNavChildren(navChildren);
 
   return (
-    <BlockedActionsProvider owner={owner} conversation={conversation}>
-      <AgentDetailsSheet
-        owner={owner}
-        user={user}
-        agentId={agentId}
-        onClose={() => onOpenChangeAgentModal(false)}
-      />
-
-      <MemberDetails
-        owner={owner}
-        userId={userId}
-        onClose={() => onOpenChangeUserModal(false)}
-      />
-
+    <AssistantLayout owner={owner} user={user} conversation={conversation}>
       <ConversationSidePanelProvider>
         <ConversationInnerLayout
           activeConversationId={activeConversationId}
@@ -161,7 +116,7 @@ const ConversationLayoutContent = ({
           onTourGuideEnd={onTourGuideEnd}
         />
       )}
-    </BlockedActionsProvider>
+    </AssistantLayout>
   );
 };
 

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -26,7 +26,7 @@ import { hasHealthyProviders } from "@app/lib/utils/providersHealth";
 import {
   getAgentBuilderRoute,
   getConversationRoute,
-  getProjectRoute,
+  getPodRoute,
   setQueryParam,
 } from "@app/lib/utils/router";
 import {
@@ -298,7 +298,7 @@ export function ConversationMenu({
       if (isConversationDisplayed && res) {
         const redirectRoute =
           conversation && isProjectConversation(conversation)
-            ? getProjectRoute(owner.sId, conversation.spaceId)
+            ? getPodRoute(owner.sId, conversation.spaceId)
             : getConversationRoute(owner.sId);
         void router.push(redirectRoute);
       }

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -12,7 +12,7 @@ import { useAuth } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
-import { getConversationRoute, getProjectRoute } from "@app/lib/utils/router";
+import { getConversationRoute, getPodRoute } from "@app/lib/utils/router";
 import { getConversationDisplayTitle } from "@app/types/assistant/conversation";
 import type { WorkspaceType } from "@app/types/user";
 import type { BreadcrumbItem } from "@dust-tt/sparkle";
@@ -77,7 +77,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
       icon: isMobile ? undefined : ArrowLeftIcon,
       label: spaceInfo.name,
       onClick: () => {
-        void router.push(getProjectRoute(owner.sId, spaceId), undefined, {
+        void router.push(getPodRoute(owner.sId, spaceId), undefined, {
           shallow: true,
         });
       },

--- a/front/components/assistant/conversation/CreateProjectModal.tsx
+++ b/front/components/assistant/conversation/CreateProjectModal.tsx
@@ -2,7 +2,7 @@ import { useSpaceConversationsSummary } from "@app/hooks/conversations";
 import { useAppRouter } from "@app/lib/platform";
 import { useCheckProjectName } from "@app/lib/swr/projects";
 import { useCreateSpace } from "@app/lib/swr/spaces";
-import { getProjectRoute } from "@app/lib/utils/router";
+import { getPodRoute } from "@app/lib/utils/router";
 import { areOpenProjectsAllowed } from "@app/lib/workspace_policies";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
@@ -112,7 +112,7 @@ export function CreateProjectModal({
       void mutateSpaceSummary();
       onCreated();
       handleClose();
-      void router.push(getProjectRoute(owner.sId, createdSpace.sId));
+      void router.push(getPodRoute(owner.sId, createdSpace.sId));
     }
   }, [
     projectName,

--- a/front/components/assistant/conversation/ProjectMenu.tsx
+++ b/front/components/assistant/conversation/ProjectMenu.tsx
@@ -10,7 +10,7 @@ import { useAppRouter } from "@app/lib/platform";
 import { useSpaceInfo, useStarProject } from "@app/lib/swr/spaces";
 import {
   getConversationRoute,
-  getProjectRoute,
+  getPodRoute,
   setQueryParam,
 } from "@app/lib/utils/router";
 import type { SpaceType } from "@app/types/space";
@@ -156,7 +156,7 @@ export function ProjectMenu({
   });
 
   const shareLink = activeSpaceId
-    ? `${config.getApiBaseUrl()}${getProjectRoute(owner.sId, activeSpaceId)}`
+    ? `${config.getApiBaseUrl()}${getPodRoute(owner.sId, activeSpaceId)}`
     : undefined;
 
   const spaceName = space?.name ?? spaceInfo?.name ?? "";

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -24,7 +24,7 @@ import {
   useSpaceConversationsSummary,
 } from "@app/hooks/conversations";
 import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
-import { useActiveSpaceId } from "@app/hooks/useActiveSpaceId";
+import { useActivePodId } from "@app/hooks/useActivePodId";
 import { useDeleteConversation } from "@app/hooks/useDeleteConversation";
 import { useHideTriggeredConversations } from "@app/hooks/useHideTriggeredConversations";
 import { useMarkAllConversationsAsRead } from "@app/hooks/useMarkAllConversationsAsRead";
@@ -46,7 +46,7 @@ import { hasHealthyProviders } from "@app/lib/utils/providersHealth";
 import {
   getAgentBuilderRoute,
   getConversationRoute,
-  getProjectRoute,
+  getPodRoute,
   getSkillBuilderRoute,
 } from "@app/lib/utils/router";
 import { formatWakeUpSidebarLabel } from "@app/lib/utils/wakeup_description";
@@ -153,7 +153,7 @@ function SearchProjectItem({
       className={cn(!isMember && "italic")}
       onClick={async () => {
         setSidebarOpen(false);
-        await router.push(getProjectRoute(owner.sId, space.sId));
+        await router.push(getPodRoute(owner.sId, space.sId));
       }}
       suffix={
         isArchived ? (
@@ -415,7 +415,7 @@ export function AgentSidebarMenu({
 }: AgentSidebarMenuProps) {
   const router = useAppRouter();
   const activeConversationId = useActiveConversationId();
-  const activeSpaceId = useActiveSpaceId();
+  const activeSpaceId = useActivePodId();
   const { hasFeature } = useFeatureFlags();
   const moveConversationToProject = useMoveConversationToProject(owner);
 

--- a/front/components/assistant/conversation/sidebar/ProjectsBrowsePopover.tsx
+++ b/front/components/assistant/conversation/sidebar/ProjectsBrowsePopover.tsx
@@ -2,7 +2,7 @@ import { InfiniteScroll } from "@app/components/InfiniteScroll";
 import { useSearchProjects } from "@app/hooks/useSearchProjects";
 import { useAppRouter } from "@app/lib/platform";
 import { getSpaceIcon } from "@app/lib/spaces";
-import { getProjectRoute } from "@app/lib/utils/router";
+import { getPodRoute } from "@app/lib/utils/router";
 import type { ProjectType } from "@app/types/space";
 import type { WorkspaceType } from "@app/types/user";
 import {
@@ -135,9 +135,7 @@ export function ProjectsBrowsePopover({ owner }: ProjectsBrowsePopoverProps) {
                     onClick={async () => {
                       setIsOpen(false);
                       setSearchQuery("");
-                      await router.push(
-                        getProjectRoute(owner.sId, project.sId)
-                      );
+                      await router.push(getPodRoute(owner.sId, project.sId));
                     }}
                   />
                 ))}

--- a/front/components/assistant/conversation/sidebar/ProjectsList.tsx
+++ b/front/components/assistant/conversation/sidebar/ProjectsList.tsx
@@ -9,7 +9,7 @@ import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import { useAppRouter } from "@app/lib/platform";
 import { getSpaceIcon } from "@app/lib/spaces";
 import { removeDiacritics, subFilter } from "@app/lib/utils";
-import { getProjectRoute } from "@app/lib/utils/router";
+import { getPodRoute } from "@app/lib/utils/router";
 import type { GetBySpacesSummaryResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/spaces";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { SpaceType } from "@app/types/space";
@@ -40,7 +40,7 @@ const ProjectListItem = memo(
     const { sidebarOpen, setSidebarOpen } = useContext(SidebarContext);
     const dropZoneRef = useRef<HTMLDivElement>(null);
 
-    const spacePath = getProjectRoute(owner.sId, space.sId);
+    const spacePath = getPodRoute(owner.sId, space.sId);
 
     const { isMenuOpen, menuTriggerPosition, handleMenuOpenChange } =
       useProjectMenu();

--- a/front/components/assistant/conversation/space/ProjectHeaderActions.tsx
+++ b/front/components/assistant/conversation/space/ProjectHeaderActions.tsx
@@ -1,7 +1,7 @@
 import { LeaveProjectDialog } from "@app/components/assistant/conversation/LeaveProjectDialog";
 import { useLeaveProjectDialog } from "@app/hooks/useLeaveProjectDialog";
 import { useAppRouter } from "@app/lib/platform";
-import { getConversationRoute, getProjectRoute } from "@app/lib/utils/router";
+import { getConversationRoute, getPodRoute } from "@app/lib/utils/router";
 import type {
   LightWorkspaceType,
   SpaceUserType,
@@ -46,7 +46,7 @@ export function ProjectHeaderActions({
     if (isRestricted) {
       void router.push(getConversationRoute(owner.sId));
     } else {
-      void router.push(getProjectRoute(owner.sId, spaceId));
+      void router.push(getPodRoute(owner.sId, spaceId));
     }
   }, [isRestricted, owner.sId, router, spaceId]);
 

--- a/front/components/markdown/TaskDirectiveBlock.tsx
+++ b/front/components/markdown/TaskDirectiveBlock.tsx
@@ -6,7 +6,7 @@ import { useStartProjectTaskConversation } from "@app/lib/swr/projects";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import { timeAgoFrom } from "@app/lib/utils";
 import type { ConversationDotStatus } from "@app/lib/utils/conversation_dot_status";
-import { getConversationRoute, getProjectRoute } from "@app/lib/utils/router";
+import { getConversationRoute, getPodRoute } from "@app/lib/utils/router";
 import type { GetWorkspaceProjectTaskResponseBody } from "@app/pages/api/w/[wId]/project_tasks/[taskSId]/index";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { compareAgentsForSort } from "@app/types/assistant/assistant";
@@ -162,7 +162,7 @@ function TaskDirectivePopoverBodyLoaded({
   onTaskUpdated?: () => void;
 }) {
   const { task, space } = data;
-  const projectHref = getProjectRoute(owner.sId, space.sId);
+  const projectHref = getPodRoute(owner.sId, space.sId);
   const assignee = task.user;
   const dotStatus: ConversationDotStatus =
     task.conversationSidebarStatus ?? "idle";

--- a/front/components/pages/conversation/SpaceConversationsPage.tsx
+++ b/front/components/pages/conversation/SpaceConversationsPage.tsx
@@ -9,7 +9,7 @@ import { SpaceTasksTab } from "@app/components/assistant/conversation/space/Spac
 
 import { useSpaceConversations } from "@app/hooks/conversations";
 import type { SpaceConversationListFilter } from "@app/hooks/conversations/useSpaceConversations";
-import { useActiveSpaceId } from "@app/hooks/useActiveSpaceId";
+import { useActivePodId } from "@app/hooks/useActivePodId";
 import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useScopedUIPreferences } from "@app/hooks/useScopedUIPreferences";
@@ -56,7 +56,7 @@ export function SpaceConversationsPage() {
   const { user } = useAuth();
   const clientType = useClientType();
   const router = useAppRouter();
-  const spaceId = useActiveSpaceId();
+  const spaceId = useActivePodId();
   const sendNotification = useSendNotification();
 
   const { spaceInfo, isSpaceInfoLoading, isSpaceInfoError, mutateSpaceInfo } =

--- a/front/components/pages/pod/PodLayout.tsx
+++ b/front/components/pages/pod/PodLayout.tsx
@@ -1,0 +1,58 @@
+import { AssistantLayout } from "@app/components/assistant/AssistantLayout";
+import { ErrorDisplay } from "@app/components/assistant/conversation/ConversationError";
+import { FileDropProvider } from "@app/components/assistant/conversation/FileUploaderContext";
+import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
+import { ErrorBoundary } from "@app/components/error_boundary/ErrorBoundary";
+import {
+  useSetHasTitle,
+  useSetPageTitle,
+} from "@app/components/sparkle/AppLayoutContext";
+import { useActivePodId } from "@app/hooks/useActivePodId";
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
+import { useSpaceInfo } from "@app/lib/swr/spaces";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { ReactNode } from "react";
+
+interface PodLayoutProps {
+  children: ReactNode;
+  owner: LightWorkspaceType;
+  user: AuthContextValue["user"];
+}
+
+export function PodLayout({ children, owner, user }: PodLayoutProps) {
+  const activePodId = useActivePodId();
+
+  const { spaceInfo } = useSpaceInfo({
+    workspaceId: owner.sId,
+    spaceId: activePodId,
+  });
+
+  const pageTitle = spaceInfo ? `Dust - ${spaceInfo.name}` : "Dust";
+
+  useSetHasTitle(!!activePodId);
+  useSetPageTitle(pageTitle);
+
+  return (
+    <AssistantLayout owner={owner} user={user}>
+      <ErrorBoundary fallback={<UncaughtPodErrorFallback />}>
+        <div className="flex h-full w-full flex-col">
+          <FileDropProvider>
+            <GenerationContextProvider>{children}</GenerationContextProvider>
+          </FileDropProvider>
+        </div>
+      </ErrorBoundary>
+    </AssistantLayout>
+  );
+}
+
+function UncaughtPodErrorFallback() {
+  return (
+    <ErrorDisplay
+      title="Something unexpected happened"
+      message={[
+        "Try refreshing the page to continue.",
+        "Still having trouble? Reach out at support@dust.tt",
+      ]}
+    />
+  );
+}

--- a/front/hooks/useActivePodId.ts
+++ b/front/hooks/useActivePodId.ts
@@ -1,0 +1,5 @@
+import { usePathParam } from "@app/lib/platform";
+
+export function useActivePodId() {
+  return usePathParam("podId");
+}

--- a/front/hooks/useActiveSpaceId.ts
+++ b/front/hooks/useActiveSpaceId.ts
@@ -1,5 +1,0 @@
-import { usePathParam } from "@app/lib/platform";
-
-export function useActiveSpaceId() {
-  return usePathParam("spaceId");
-}

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -47,7 +47,7 @@ import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_res
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import { getConversationRoute, getProjectRoute } from "@app/lib/utils/router";
+import { getConversationRoute, getPodRoute } from "@app/lib/utils/router";
 import { areOpenProjectsAllowed } from "@app/lib/workspace_policies";
 import {
   isUserMessageType,
@@ -295,7 +295,7 @@ export function createProjectManagerTools(
         ).length;
 
         // Construct project URL
-        const projectPath = getProjectRoute(owner.sId, space.sId);
+        const projectPath = getPodRoute(owner.sId, space.sId);
         const projectUrl = `${config.getAppUrl()}${projectPath}`;
 
         return new Ok(
@@ -576,7 +576,7 @@ export function createProjectManagerTools(
           }
         }
 
-        const projectUrl = `${config.getAppUrl()}${getProjectRoute(
+        const projectUrl = `${config.getAppUrl()}${getPodRoute(
           owner.sId,
           projectSpace.sId
         )}`;

--- a/front/lib/api/projects/connector.ts
+++ b/front/lib/api/projects/connector.ts
@@ -21,7 +21,7 @@ import { executeWithLock } from "@app/lib/lock";
 import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import { getProjectRoute } from "@app/lib/utils/router";
+import { getPodRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
 import { DEFAULT_EMBEDDING_PROVIDER_ID } from "@app/types/assistant/models/embedding";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
@@ -193,8 +193,7 @@ export async function createDataSourceAndConnectorForProject(
         parentId: null,
         parents: [PROJECT_CONTEXT_FOLDER_ID],
         mimeType: INTERNAL_MIME_TYPES.DUST_PROJECT.CONTEXT_FOLDER,
-        sourceUrl:
-          config.getAppUrl() + getProjectRoute(workspace.sId, space.sId),
+        sourceUrl: config.getAppUrl() + getPodRoute(workspace.sId, space.sId),
         timestamp: null,
         providerVisibility: null,
         title: PROJECT_CONTEXT_FOLDER_NAME,

--- a/front/lib/notifications/workflows/project-added-as-member.ts
+++ b/front/lib/notifications/workflows/project-added-as-member.ts
@@ -9,7 +9,7 @@ import {
 import { renderEmail } from "@app/lib/notifications/email-templates/default";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
-import { getProjectRoute } from "@app/lib/utils/router";
+import { getPodRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
 import { PROJECT_ADDED_AS_MEMBER_TRIGGER_ID } from "@app/types/notification_preferences";
 import type { Result } from "@app/types/shared/result";
@@ -124,7 +124,7 @@ export const projectAddedAsMemberWorkflow = workflow(
           primaryAction: {
             label: "View",
             redirect: {
-              url: getProjectRoute(payload.workspaceId, payload.projectId),
+              url: getPodRoute(payload.workspaceId, payload.projectId),
             },
           },
           data: {
@@ -143,7 +143,7 @@ export const projectAddedAsMemberWorkflow = workflow(
       async () => {
         const projectUrl =
           config.getAppUrl() +
-          getProjectRoute(payload.workspaceId, payload.projectId);
+          getPodRoute(payload.workspaceId, payload.projectId);
 
         const baseMessage = `${details.userThatAddedYouFullname} added you to project "${details.projectName}"`;
 
@@ -185,7 +185,7 @@ export const projectAddedAsMemberWorkflow = workflow(
             label: "View project",
             url:
               config.getAppUrl() +
-              getProjectRoute(payload.workspaceId, payload.projectId),
+              getPodRoute(payload.workspaceId, payload.projectId),
           },
         });
         return {

--- a/front/lib/utils/router.ts
+++ b/front/lib/utils/router.ts
@@ -88,6 +88,6 @@ export const getSpaceRoute = (workspaceId: string, spaceId: string) => {
   return `/w/${workspaceId}/spaces/${spaceId}`;
 };
 
-export const getProjectRoute = (workspaceId: string, spaceId: string) => {
-  return `/w/${workspaceId}/conversation/space/${spaceId}`;
+export const getPodRoute = (workspaceId: string, spaceId: string) => {
+  return `/w/${workspaceId}/pods/${spaceId}`;
 };

--- a/front/pages/api/v1/public/frames/[token]/index.ts
+++ b/front/pages/api/v1/public/frames/[token]/index.ts
@@ -9,7 +9,7 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import { getConversationRoute, getProjectRoute } from "@app/lib/utils/router";
+import { getConversationRoute, getPodRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -233,8 +233,7 @@ async function handler(
         )
       : null,
     // Only return the project URL if the user can read the project.
-    projectUrl:
-      canRead && spaceId ? getProjectRoute(workspace.sId, spaceId) : null,
+    projectUrl: canRead && spaceId ? getPodRoute(workspace.sId, spaceId) : null,
   });
 }
 


### PR DESCRIPTION
## Description

This PR renames the `conversation/space/:spaceId` route to `pods/:podId` across the frontend and extension, and introduces a `PodRouterLayout` and dedicated `podsRoutes` for the SPA.

- Renames `getProjectRoute` to `getPodRoute`
- Adds a new `podsRoutes.tsx` with the `/pods/:podId` route and a `LegacySpaceToPodRedirect` component to handle backward compatibility with old `/conversation/space/:spaceId` URLs
- Adds a `PodRouterLayout` component for SPA pod routes
- Extracts shared sidebar/sheet logic from `ConversationLayout` into a new `AssistantLayout` component reused by both conversation and pod pages.

## Tests

Manually.

## Risks
Missing context providers in the new layout can cause errors. Check in particular that the input bar works as expected.
<!-- Discuss potential risks and how they will be mitigated. -->

## Deploy Plan
Standard deployment.
<!-- Outline the deployment steps. -->

