### PR TITLE
[front] chore: add index on `group_agents` and `agent_mcp_server_configurations`

### DIFF
--- a/front/lib/models/agent/actions/mcp.ts
+++ b/front/lib/models/agent/actions/mcp.ts
@@ -179,6 +179,11 @@ AgentMCPServerConfigurationModel.init(
         fields: ["sId"],
         concurrently: true,
       },
+      {
+        fields: ["mcpServerViewId", "workspaceId"],
+        concurrently: true,
+        name: "agent_mcp_srv_config_mcp_view_id_w_id",
+      },
     ],
   }
 );

--- a/front/lib/models/agent/group_agent.ts
+++ b/front/lib/models/agent/group_agent.ts
@@ -60,6 +60,7 @@ GroupAgentModel.init(
       },
       { fields: ["agentConfigurationId"] },
       { fields: ["workspaceId"], concurrently: true },
+      { fields: ["groupId"], concurrently: true },
     ],
   }
 );

--- a/front/migrations/db/migration_649.sql
+++ b/front/migrations/db/migration_649.sql
@@ -1,0 +1,3 @@
+-- Migration created on May 21, 2026
+CREATE INDEX CONCURRENTLY "group_agents_group_id" ON "group_agents" ("groupId");
+CREATE INDEX CONCURRENTLY "agent_mcp_srv_config_mcp_view_id_w_id" ON "agent_mcp_server_configurations" ("mcpServerViewId", "workspaceId");


### PR DESCRIPTION
## Description

- Follow up on [this check](https://app.pganalyze.com/databases/-642267661/checks/index_advisor/indexing_engine).
- This PR adds two indexes `"group_agents_group_id"` and `"agent_mcp_srv_config_mcp_view_id_w_id"`.
- See [here](https://app.pganalyze.com/databases/-642267661/checks/index_advisor/indexing_engine/34953097#I-1000007) for queries that will be sped up + which routes run these queries.

## Tests

- Checked locally

## Risk

- Low.

## Deploy Plan

- Run migration.
