### PR TITLE
[front] Log peak concurrent queries for Temporal activities

### DIFF
--- a/front/lib/api/query_tracker.ts
+++ b/front/lib/api/query_tracker.ts
@@ -10,9 +10,10 @@ export interface QueryTrackerStore {
  *
  * Usage:
  * - `withLogging` wraps each request handler in `queryTracker.run(store, ...)`.
+ * - `ActivityInboundLogInterceptor` wraps each Temporal activity execution the same way.
  * - `SequelizeWithComments.query()` increments/decrements `store.concurrent` around
  *   every query and updates `store.peak`.
- * - At request completion, `store.peak` is logged as `peakConcurrentQueries` to help
- *   identify endpoints that hold many connections simultaneously.
+ * - At request/activity completion, `store.peak` is logged as `peakConcurrentQueries`
+ *   to help identify code paths that hold many connections simultaneously.
  */
 export const queryTracker = new AsyncLocalStorage<QueryTrackerStore>();

--- a/front/lib/temporal_monitoring.ts
+++ b/front/lib/temporal_monitoring.ts
@@ -1,3 +1,4 @@
+import { queryTracker } from "@app/lib/api/query_tracker";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import type logger from "@app/logger/logger";
 import type { Logger } from "@app/logger/logger";
@@ -58,28 +59,31 @@ export class ActivityInboundLogInterceptor
       `workflow_name:${this.context.info.workflowType}`,
       `attempt:${this.context.info.attempt}`,
     ];
+    const queryTrackerStore = { concurrent: 0, peak: 0 };
 
     try {
       this.logger.info("Activity started.");
-      return await tracer.trace(
-        `${this.context.info.workflowType}-${this.context.info.activityType}`,
-        {
-          resource: this.context.info.activityType,
-          type: "temporal-activity",
-        },
-        async (span) => {
-          span?.setTag("attempt", this.context.info.attempt);
-          span?.setTag(
-            "workflow_id",
-            this.context.info.workflowExecution.workflowId
-          );
-          span?.setTag(
-            "workflow_run_id",
-            this.context.info.workflowExecution.runId
-          );
+      return await queryTracker.run(queryTrackerStore, () =>
+        tracer.trace(
+          `${this.context.info.workflowType}-${this.context.info.activityType}`,
+          {
+            resource: this.context.info.activityType,
+            type: "temporal-activity",
+          },
+          async (span) => {
+            span?.setTag("attempt", this.context.info.attempt);
+            span?.setTag(
+              "workflow_id",
+              this.context.info.workflowExecution.workflowId
+            );
+            span?.setTag(
+              "workflow_run_id",
+              this.context.info.workflowExecution.runId
+            );
 
-          return next(input);
-        }
+            return next(input);
+          }
+        )
       );
     } catch (err: unknown) {
       error = err;
@@ -104,6 +108,7 @@ export class ActivityInboundLogInterceptor
             errorType,
             durationMs,
             attempt: this.context.info.attempt,
+            peakConcurrentQueries: queryTrackerStore.peak,
           },
           "Activity failed"
         );
@@ -111,7 +116,13 @@ export class ActivityInboundLogInterceptor
         tags.push(`error_type:${errorType}`);
         getStatsDClient().increment("activity_failed.count", 1, tags);
       } else {
-        this.logger.info({ durationMs: durationMs }, "Activity completed.");
+        this.logger.info(
+          {
+            durationMs,
+            peakConcurrentQueries: queryTrackerStore.peak,
+          },
+          "Activity completed."
+        );
         getStatsDClient().increment("activities_success.count", 1, tags);
       }
     }


### PR DESCRIPTION
## Description

- Track peak concurrent db queries during the execution of Temporal activities.
- Same instrumentation as used for route handlers.
- Works by wrapping `ActivityInboundLogInterceptor` in the shared `queryTracker` context so activity logs include `peakConcurrentQueries`.

## Tests

- Tested locally (got an acitivity peaking at 16 concurrent queries)

## Risk

- Medium. Safe to rollback.

## Deploy Plan

- Deploy front
