### PR TITLE
[front] Fix import of server-side code in `SwitchContractDialog`

### DIFF
--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -17,6 +17,7 @@ import {
   usePokePlans,
   usePokeStripeCustomerCurrency,
 } from "@app/lib/swr/poke";
+import assert from "@app/lib/utils/assert";
 import type { ProgrammaticUsageConfigurationType } from "@app/types/programmatic_usage";
 import type { WorkspaceType } from "@app/types/user";
 import {
@@ -34,7 +35,6 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
-import assert from "assert";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";


### PR DESCRIPTION
## Description

- The poke SPA build is failing on an import from server-side code in the front-end https://github.com/dust-tt/dust/actions/runs/26233588110/job/77200718159
- This PR fixes that.
- `assert` is actually the node util.

## Tests

- build works locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
