### PR TITLE
 Add export tool (PDF & PNG) to the interactive content MCP server

### DIFF
--- a/front-api/routes/w/[wId]/files/[fileId]/export/pdf.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/export/pdf.ts
@@ -1,20 +1,5 @@
-import config from "@app/lib/api/config";
-import { PDF_FOOTER_HTML } from "@app/lib/api/files/pdf_footer";
-import { generateVizAccessToken } from "@app/lib/api/viz/access_tokens";
-import {
-  isDustCompanyPlan,
-  isEntreprisePlanPrefix,
-  isFriendsAndFamilyPlan,
-} from "@app/lib/plans/plan_codes";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { FileResource } from "@app/lib/resources/file_resource";
-import logger from "@app/logger/logger";
-import {
-  frameSlideshowContentType,
-  isInteractiveContentType,
-} from "@app/types/files";
-import type { PdfOptions } from "@app/types/shared/document_renderer";
-import { DocumentRenderer } from "@app/types/shared/document_renderer";
+import { exportInteractiveContentFileAsPdf } from "@app/lib/api/files/pdf_export";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { apiError } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { Hono } from "hono";
@@ -30,164 +15,49 @@ const app = new Hono();
 app.post("/", validate("json", PostPdfExportBodySchema), async (ctx) => {
   const auth = ctx.get("auth");
   const fileId = ctx.req.param("fileId") ?? "";
+  const { orientation } = ctx.req.valid("json");
 
-  const documentRendererUrl = config.getDocumentRendererUrl();
-  if (!documentRendererUrl) {
-    return apiError(ctx, {
-      status_code: 501,
-      api_error: {
-        type: "internal_server_error",
-        message: "PDF export is not configured.",
-      },
-    });
-  }
-
-  const file = await FileResource.fetchById(auth, fileId);
-  if (!file) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: { type: "file_not_found", message: "File not found." },
-    });
-  }
-
-  // Only allow Frame files.
-  if (
-    !file.isInteractiveContent ||
-    !isInteractiveContentType(file.contentType)
-  ) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Only Frame files can be exported as PDF.",
-      },
-    });
-  }
-
-  // Check conversation access.
-  if (file.useCaseMetadata?.conversationId) {
-    const conversation = await ConversationResource.fetchById(
-      auth,
-      file.useCaseMetadata.conversationId
-    );
-    if (!conversation) {
-      return apiError(ctx, {
-        status_code: 404,
-        api_error: { type: "file_not_found", message: "File not found." },
-      });
-    }
-  }
-
-  // Get share info to retrieve the share token.
-  const shareInfo = await file.getShareInfo();
-  if (!shareInfo) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "File is not shareable.",
-      },
-    });
-  }
-
-  // Extract token from share URL.
-  const shareUrlParts = shareInfo.shareUrl.split("/");
-  const shareToken = shareUrlParts[shareUrlParts.length - 1];
-
-  // Generate access token for viz rendering.
-  const owner = auth.getNonNullableWorkspace();
-  const user = auth.user();
-  const accessToken = generateVizAccessToken({
-    contentType: file.contentType,
-    fileToken: shareToken,
-    userId: user?.sId,
-    shareScope: shareInfo.scope,
-    workspaceId: owner.sId,
+  const result = await exportInteractiveContentFileAsPdf(auth, {
+    fileId,
+    orientation,
   });
-
-  // Build viz URL. Use public URL since Gotenberg routes through egress proxy
-  // which blocks internal K8s IPs.
-  const vizUrl = config.getVizPublicUrl();
-  if (!vizUrl) {
-    return apiError(ctx, {
-      status_code: 501,
-      api_error: {
-        type: "internal_server_error",
-        message: "VIZ_PUBLIC_URL is not configured.",
-      },
-    });
-  }
-
-  const params = new URLSearchParams({
-    accessToken,
-    identifier: `viz-${fileId}`,
-    pdfMode: "true",
-  });
-  const targetUrl = `${vizUrl}/content?${params.toString()}`;
-
-  // Default to landscape for slideshow content, portrait for regular frames.
-  const { orientation: requestedOrientation } = ctx.req.valid("json");
-  const orientation =
-    requestedOrientation ??
-    (file.contentType === frameSlideshowContentType ? "landscape" : "portrait");
-
-  const isSlideshow = file.contentType === frameSlideshowContentType;
-
-  // Only show footer for non-Enterprise plans and non-FriendsAndFamily plans.
-  const plan = auth.plan();
-  const shouldHideFooter =
-    plan &&
-    (isDustCompanyPlan(plan.code) ||
-      isEntreprisePlanPrefix(plan.code) ||
-      isFriendsAndFamilyPlan(plan.code));
-  const showFooter = !shouldHideFooter;
-
-  const renderer = new DocumentRenderer(documentRendererUrl, logger);
-
-  // Slideshows use zero margins (full-bleed slides).
-  const options: PdfOptions = showFooter
-    ? {
-        footerHtml: PDF_FOOTER_HTML,
-        marginBottom: isSlideshow ? "0" : "1cm",
-      }
-    : {};
-
-  const result = await renderer.exportToPdf(
-    {
-      url: targetUrl,
-      waitForExpression:
-        "document.querySelector('[data-viz-ready=\"true\"]') !== null",
-    },
-    {
-      ...options,
-      orientation,
-    }
-  );
 
   if (result.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Failed to generate PDF.",
-      },
-    });
+    const { error } = result;
+    switch (error.type) {
+      case "file_not_found":
+        return apiError(ctx, {
+          status_code: 404,
+          api_error: { type: "file_not_found", message: error.message },
+        });
+      case "invalid_request":
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: { type: "invalid_request_error", message: error.message },
+        });
+      case "render_failed":
+        return apiError(ctx, {
+          status_code: 500,
+          api_error: { type: "internal_server_error", message: error.message },
+        });
+      default:
+        assertNever(error.type);
+    }
   }
 
-  // Set response headers for PDF download.
-  const pdfFileName = file.fileName?.replace(/\.[^.]+$/, ".pdf") || "frame.pdf";
+  const { buffer, fileName } = result.value;
   // Sanitize filename for Content-Disposition: use ASCII-only fallback for
   // `filename` and RFC 5987 `filename*` for the full UTF-8 name.
-  const asciiFallback = pdfFileName.replace(/[^\x20-\x7E]/g, "_");
-  const encodedName = encodeURIComponent(pdfFileName);
+  const asciiFallback = fileName.replace(/[^\x20-\x7E]/g, "_");
+  const encodedName = encodeURIComponent(fileName);
 
   // Convert Node `Buffer` to `Uint8Array` so it satisfies `BodyInit`.
-  return new Response(new Uint8Array(result.value), {
+  return new Response(new Uint8Array(buffer), {
     status: 200,
     headers: {
       "Content-Type": "application/pdf",
       "Content-Disposition": `attachment; filename="${asciiFallback}"; filename*=UTF-8''${encodedName}`,
-      "Content-Length": String(result.value.length),
+      "Content-Length": String(buffer.length),
     },
   });
 });

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -311,6 +311,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   "interactive_content": {
     "create_interactive_content_file": "never_ask",
     "edit_interactive_content_file": "never_ask",
+    "export_interactive_content_file": "never_ask",
     "get_interactive_content_file_share_url": "never_ask",
     "rename_interactive_content_file": "never_ask",
     "retrieve_interactive_content_file": "never_ask",

--- a/front/lib/api/actions/servers/interactive_content/metadata.ts
+++ b/front/lib/api/actions/servers/interactive_content/metadata.ts
@@ -26,6 +26,8 @@ export const RENAME_INTERACTIVE_CONTENT_FILE_TOOL_NAME =
   "rename_interactive_content_file";
 export const GET_INTERACTIVE_CONTENT_FILE_SHARE_URL_TOOL_NAME =
   "get_interactive_content_file_share_url";
+export const EXPORT_INTERACTIVE_CONTENT_FILE_TOOL_NAME =
+  "export_interactive_content_file";
 
 export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
   [CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
@@ -218,6 +220,38 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Getting share URL",
       done: "Get share URL",
+    },
+  },
+  [EXPORT_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
+    description:
+      "Export an Interactive Content file as a PNG screenshot or PDF document. " +
+      "PNG returns a visual snapshot of the rendered frame. " +
+      "PDF renders the frame with optional orientation (portrait/landscape for regular frames, " +
+      "landscape by default for slideshows).",
+    schema: {
+      file_id: z
+        .string()
+        .describe(
+          "The ID of the Interactive Content file to export (e.g., 'fil_abc123')"
+        ),
+      format: z
+        .enum(["png", "pdf"])
+        .describe(
+          "Export format: 'png' for a screenshot, 'pdf' for a paginated document."
+        ),
+      orientation: z
+        .enum(["portrait", "landscape"])
+        .optional()
+        .describe(
+          "PDF orientation. Only used when format is 'pdf'. " +
+            "Defaults to 'landscape' for slideshows and 'portrait' for regular frames."
+        ),
+    },
+    enableAlerting: false,
+    stake: "never_ask",
+    displayLabels: {
+      running: "Exporting Frame",
+      done: "Export Frame",
     },
   },
 });

--- a/front/lib/api/actions/servers/interactive_content/tools/index.ts
+++ b/front/lib/api/actions/servers/interactive_content/tools/index.ts
@@ -18,6 +18,8 @@ import {
   revertClientExecutableFileChanges,
 } from "@app/lib/api/files/client_executable";
 import { formatValidationWarningsForLLM } from "@app/lib/api/files/content_validation";
+import { exportInteractiveContentFileAsPdf } from "@app/lib/api/files/pdf_export";
+import { screenshotInteractiveContentFile } from "@app/lib/api/files/screenshot";
 import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
@@ -287,6 +289,43 @@ export function createInteractiveContentTools(
         {
           type: "text",
           text: `URL: ${shareUrlRes.value}`,
+        },
+      ]);
+    },
+
+    export_interactive_content_file: async ({ file_id, format, orientation }) => {
+      if (format === "pdf") {
+        const result = await exportInteractiveContentFileAsPdf(auth, {
+          fileId: file_id,
+          orientation,
+        });
+        if (result.isErr()) {
+          return new Err(new MCPError(result.error.message, { tracked: false }));
+        }
+        return new Ok([
+          {
+            type: "resource",
+            resource: {
+              uri: `dust://files/${file_id}/export/pdf`,
+              mimeType: "application/pdf",
+              blob: result.value.buffer.toString("base64"),
+            },
+          },
+        ]);
+      }
+
+      const result = await screenshotInteractiveContentFile(auth, {
+        fileId: file_id,
+      });
+      if (result.isErr()) {
+        return new Err(new MCPError(result.error.message, { tracked: false }));
+      }
+
+      return new Ok([
+        {
+          type: "image",
+          data: result.value.buffer.toString("base64"),
+          mimeType: "image/png",
         },
       ]);
     },

--- a/front/lib/api/actions/servers/interactive_content/tools/index.ts
+++ b/front/lib/api/actions/servers/interactive_content/tools/index.ts
@@ -22,6 +22,7 @@ import { exportInteractiveContentFileAsPdf } from "@app/lib/api/files/pdf_export
 import { screenshotInteractiveContentFile } from "@app/lib/api/files/screenshot";
 import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
 export function createInteractiveContentTools(
@@ -293,41 +294,53 @@ export function createInteractiveContentTools(
       ]);
     },
 
-    export_interactive_content_file: async ({ file_id, format, orientation }) => {
-      if (format === "pdf") {
-        const result = await exportInteractiveContentFileAsPdf(auth, {
-          fileId: file_id,
-          orientation,
-        });
-        if (result.isErr()) {
-          return new Err(new MCPError(result.error.message, { tracked: false }));
-        }
-        return new Ok([
-          {
-            type: "resource",
-            resource: {
-              uri: `dust://files/${file_id}/export/pdf`,
-              mimeType: "application/pdf",
-              blob: result.value.buffer.toString("base64"),
+    export_interactive_content_file: async ({
+      file_id,
+      format,
+      orientation,
+    }) => {
+      switch (format) {
+        case "pdf": {
+          const result = await exportInteractiveContentFileAsPdf(auth, {
+            fileId: file_id,
+            orientation,
+          });
+          if (result.isErr()) {
+            return new Err(
+              new MCPError(result.error.message, { tracked: false })
+            );
+          }
+          return new Ok([
+            {
+              type: "resource",
+              resource: {
+                uri: `dust://files/${file_id}/export/pdf`,
+                mimeType: "application/pdf",
+                blob: result.value.buffer.toString("base64"),
+              },
             },
-          },
-        ]);
+          ]);
+        }
+        case "png": {
+          const result = await screenshotInteractiveContentFile(auth, {
+            fileId: file_id,
+          });
+          if (result.isErr()) {
+            return new Err(
+              new MCPError(result.error.message, { tracked: false })
+            );
+          }
+          return new Ok([
+            {
+              type: "image",
+              data: result.value.buffer.toString("base64"),
+              mimeType: "image/png",
+            },
+          ]);
+        }
+        default:
+          assertNever(format);
       }
-
-      const result = await screenshotInteractiveContentFile(auth, {
-        fileId: file_id,
-      });
-      if (result.isErr()) {
-        return new Err(new MCPError(result.error.message, { tracked: false }));
-      }
-
-      return new Ok([
-        {
-          type: "image",
-          data: result.value.buffer.toString("base64"),
-          mimeType: "image/png",
-        },
-      ]);
     },
   };
 

--- a/front/lib/api/actions/servers/interactive_content/tools/index.ts
+++ b/front/lib/api/actions/servers/interactive_content/tools/index.ts
@@ -314,7 +314,7 @@ export function createInteractiveContentTools(
             {
               type: "resource",
               resource: {
-                uri: `dust://files/${file_id}/export/pdf`,
+                uri: result.value.fileName,
                 mimeType: "application/pdf",
                 blob: result.value.buffer.toString("base64"),
               },

--- a/front/lib/api/files/pdf_export.ts
+++ b/front/lib/api/files/pdf_export.ts
@@ -14,7 +14,10 @@ import {
   frameSlideshowContentType,
   isInteractiveContentType,
 } from "@app/types/files";
-import type { PdfOptions, PdfOrientation } from "@app/types/shared/document_renderer";
+import type {
+  PdfOptions,
+  PdfOrientation,
+} from "@app/types/shared/document_renderer";
 import { DocumentRenderer } from "@app/types/shared/document_renderer";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -37,7 +40,10 @@ export async function exportInteractiveContentFileAsPdf(
 ): Promise<Result<{ buffer: Buffer; fileName: string }, FrameExportError>> {
   const documentRendererUrl = config.getDocumentRendererUrl();
   if (!documentRendererUrl) {
-    return new Err({ type: "render_failed", message: "PDF export is not configured." });
+    return new Err({
+      type: "render_failed",
+      message: "PDF export is not configured.",
+    });
   }
 
   const file = await FileResource.fetchById(auth, fileId);
@@ -67,7 +73,10 @@ export async function exportInteractiveContentFileAsPdf(
 
   const shareInfo = await file.getShareInfo();
   if (!shareInfo) {
-    return new Err({ type: "invalid_request", message: "File is not shareable." });
+    return new Err({
+      type: "invalid_request",
+      message: "File is not shareable.",
+    });
   }
 
   const shareUrlParts = shareInfo.shareUrl.split("/");
@@ -132,7 +141,10 @@ export async function exportInteractiveContentFileAsPdf(
   );
 
   if (result.isErr()) {
-    return new Err({ type: "render_failed", message: "Failed to generate PDF." });
+    return new Err({
+      type: "render_failed",
+      message: "Failed to generate PDF.",
+    });
   }
 
   const fileName = file.fileName?.replace(/\.[^.]+$/, ".pdf") || "frame.pdf";

--- a/front/lib/api/files/pdf_export.ts
+++ b/front/lib/api/files/pdf_export.ts
@@ -1,0 +1,140 @@
+import config from "@app/lib/api/config";
+import { PDF_FOOTER_HTML } from "@app/lib/api/files/pdf_footer";
+import { generateVizAccessToken } from "@app/lib/api/viz/access_tokens";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  isDustCompanyPlan,
+  isEntreprisePlanPrefix,
+  isFriendsAndFamilyPlan,
+} from "@app/lib/plans/plan_codes";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
+import logger from "@app/logger/logger";
+import {
+  frameSlideshowContentType,
+  isInteractiveContentType,
+} from "@app/types/files";
+import type { PdfOptions, PdfOrientation } from "@app/types/shared/document_renderer";
+import { DocumentRenderer } from "@app/types/shared/document_renderer";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+// Shared by pdf_export and screenshot — kept here as the primary export file.
+export type FrameExportError = {
+  type: "file_not_found" | "invalid_request" | "render_failed";
+  message: string;
+};
+
+export async function exportInteractiveContentFileAsPdf(
+  auth: Authenticator,
+  {
+    fileId,
+    orientation,
+  }: {
+    fileId: string;
+    orientation?: PdfOrientation;
+  }
+): Promise<Result<{ buffer: Buffer; fileName: string }, FrameExportError>> {
+  const documentRendererUrl = config.getDocumentRendererUrl();
+  if (!documentRendererUrl) {
+    return new Err({ type: "render_failed", message: "PDF export is not configured." });
+  }
+
+  const file = await FileResource.fetchById(auth, fileId);
+  if (!file) {
+    return new Err({ type: "file_not_found", message: "File not found." });
+  }
+
+  if (
+    !file.isInteractiveContent ||
+    !isInteractiveContentType(file.contentType)
+  ) {
+    return new Err({
+      type: "invalid_request",
+      message: "Only Frame files can be exported as PDF.",
+    });
+  }
+
+  if (file.useCaseMetadata?.conversationId) {
+    const conversation = await ConversationResource.fetchById(
+      auth,
+      file.useCaseMetadata.conversationId
+    );
+    if (!conversation) {
+      return new Err({ type: "file_not_found", message: "File not found." });
+    }
+  }
+
+  const shareInfo = await file.getShareInfo();
+  if (!shareInfo) {
+    return new Err({ type: "invalid_request", message: "File is not shareable." });
+  }
+
+  const shareUrlParts = shareInfo.shareUrl.split("/");
+  const shareToken = shareUrlParts[shareUrlParts.length - 1];
+
+  const owner = auth.getNonNullableWorkspace();
+  const user = auth.user();
+  const accessToken = generateVizAccessToken({
+    contentType: file.contentType,
+    fileToken: shareToken,
+    userId: user?.sId,
+    shareScope: shareInfo.scope,
+    workspaceId: owner.sId,
+  });
+
+  // Build viz URL. Use public URL since Gotenberg routes through egress proxy
+  // which blocks internal K8s IPs.
+  const params = new URLSearchParams({
+    accessToken,
+    identifier: `viz-${fileId}`,
+    pdfMode: "true",
+  });
+  const targetUrl = `${config.getVizPublicUrl()}/content?${params.toString()}`;
+
+  // Default to landscape for slideshow content, portrait for regular frames.
+  const resolvedOrientation =
+    orientation ??
+    (file.contentType === frameSlideshowContentType ? "landscape" : "portrait");
+
+  const isSlideshow = file.contentType === frameSlideshowContentType;
+
+  // Only show footer for non-Enterprise plans and non-FriendsAndFamily plans.
+  const plan = auth.plan();
+  const shouldHideFooter =
+    plan &&
+    (isDustCompanyPlan(plan.code) ||
+      isEntreprisePlanPrefix(plan.code) ||
+      isFriendsAndFamilyPlan(plan.code));
+  const showFooter = !shouldHideFooter;
+
+  // Slideshows use zero margins (full-bleed slides).
+  const options: PdfOptions = showFooter
+    ? {
+        footerHtml: PDF_FOOTER_HTML,
+        marginBottom: isSlideshow ? "0" : "1cm",
+      }
+    : {};
+
+  const renderer = new DocumentRenderer(documentRendererUrl, logger, {
+    timeoutMs: 90000,
+  });
+  const result = await renderer.exportToPdf(
+    {
+      url: targetUrl,
+      waitForExpression:
+        "document.querySelector('[data-viz-ready=\"true\"]') !== null",
+    },
+    {
+      ...options,
+      orientation: resolvedOrientation,
+    }
+  );
+
+  if (result.isErr()) {
+    return new Err({ type: "render_failed", message: "Failed to generate PDF." });
+  }
+
+  const fileName = file.fileName?.replace(/\.[^.]+$/, ".pdf") || "frame.pdf";
+  return new Ok({ buffer: result.value, fileName });
+}

--- a/front/lib/api/files/screenshot.ts
+++ b/front/lib/api/files/screenshot.ts
@@ -57,7 +57,10 @@ export async function screenshotInteractiveContentFile(
 
   const shareInfo = await file.getShareInfo();
   if (!shareInfo) {
-    return new Err({ type: "invalid_request", message: "File is not shareable." });
+    return new Err({
+      type: "invalid_request",
+      message: "File is not shareable.",
+    });
   }
 
   const shareUrlParts = shareInfo.shareUrl.split("/");

--- a/front/lib/api/files/screenshot.ts
+++ b/front/lib/api/files/screenshot.ts
@@ -1,0 +1,105 @@
+import config from "@app/lib/api/config";
+import type { FrameExportError } from "@app/lib/api/files/pdf_export";
+import { generateVizAccessToken } from "@app/lib/api/viz/access_tokens";
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
+import logger from "@app/logger/logger";
+import { isInteractiveContentType } from "@app/types/files";
+import type { ScreenshotOptions } from "@app/types/shared/document_renderer";
+import { DocumentRenderer } from "@app/types/shared/document_renderer";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export async function screenshotInteractiveContentFile(
+  auth: Authenticator,
+  {
+    fileId,
+    screenshotOptions,
+  }: {
+    fileId: string;
+    screenshotOptions?: ScreenshotOptions;
+  }
+): Promise<Result<{ buffer: Buffer; fileName: string }, FrameExportError>> {
+  const documentRendererUrl = config.getDocumentRendererUrl();
+  if (!documentRendererUrl) {
+    return new Err({
+      type: "render_failed",
+      message: "Screenshot export is not configured.",
+    });
+  }
+
+  const file = await FileResource.fetchById(auth, fileId);
+  if (!file) {
+    return new Err({ type: "file_not_found", message: "File not found." });
+  }
+
+  if (
+    !file.isInteractiveContent ||
+    !isInteractiveContentType(file.contentType)
+  ) {
+    return new Err({
+      type: "invalid_request",
+      message: "Only Frame files can be exported as PNG.",
+    });
+  }
+
+  if (file.useCaseMetadata?.conversationId) {
+    const conversation = await ConversationResource.fetchById(
+      auth,
+      file.useCaseMetadata.conversationId
+    );
+
+    if (!conversation) {
+      return new Err({ type: "file_not_found", message: "File not found." });
+    }
+  }
+
+  const shareInfo = await file.getShareInfo();
+  if (!shareInfo) {
+    return new Err({ type: "invalid_request", message: "File is not shareable." });
+  }
+
+  const shareUrlParts = shareInfo.shareUrl.split("/");
+  const shareToken = shareUrlParts[shareUrlParts.length - 1];
+
+  const owner = auth.getNonNullableWorkspace();
+  const user = auth.user();
+  const accessToken = generateVizAccessToken({
+    contentType: file.contentType,
+    fileToken: shareToken,
+    userId: user?.sId,
+    shareScope: shareInfo.scope,
+    workspaceId: owner.sId,
+  });
+
+  // Build viz URL. Use public URL since Gotenberg routes through egress proxy
+  // which blocks internal K8s IPs.
+  const params = new URLSearchParams({
+    accessToken,
+    identifier: `viz-${fileId}`,
+  });
+  const targetUrl = `${config.getVizPublicUrl()}/content?${params.toString()}`;
+
+  const renderer = new DocumentRenderer(documentRendererUrl, logger, {
+    timeoutMs: 90000,
+  });
+  const result = await renderer.captureScreenshot(
+    {
+      url: targetUrl,
+      waitForExpression:
+        "document.querySelector('[data-viz-ready=\"true\"]') !== null",
+    },
+    screenshotOptions
+  );
+
+  if (result.isErr()) {
+    return new Err({
+      type: "render_failed",
+      message: "Failed to generate PNG screenshot.",
+    });
+  }
+
+  const fileName = file.fileName?.replace(/\.[^.]+$/, ".png") || "frame.png";
+  return new Ok({ buffer: result.value, fileName });
+}

--- a/front/pages/api/w/[wId]/files/[fileId]/export/pdf.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/export/pdf.ts
@@ -1,26 +1,11 @@
 // @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import config from "@app/lib/api/config";
-import { PDF_FOOTER_HTML } from "@app/lib/api/files/pdf_footer";
-import { generateVizAccessToken } from "@app/lib/api/viz/access_tokens";
+import { exportInteractiveContentFileAsPdf } from "@app/lib/api/files/pdf_export";
 import type { Authenticator } from "@app/lib/auth";
-import {
-  isDustCompanyPlan,
-  isEntreprisePlanPrefix,
-  isFriendsAndFamilyPlan,
-} from "@app/lib/plans/plan_codes";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { FileResource } from "@app/lib/resources/file_resource";
-import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import {
-  frameSlideshowContentType,
-  isInteractiveContentType,
-} from "@app/types/files";
-import type { PdfOptions } from "@app/types/shared/document_renderer";
-import { DocumentRenderer } from "@app/types/shared/document_renderer";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
@@ -44,17 +29,6 @@ async function handler(
     });
   }
 
-  const documentRendererUrl = config.getDocumentRendererUrl();
-  if (!documentRendererUrl) {
-    return apiError(req, res, {
-      status_code: 501,
-      api_error: {
-        type: "internal_server_error",
-        message: "PDF export is not configured.",
-      },
-    });
-  }
-
   const { fileId } = req.query;
   if (!isString(fileId)) {
     return apiError(req, res, {
@@ -66,7 +40,6 @@ async function handler(
     });
   }
 
-  // Parse and validate request body.
   const bodyResult = PostPdfExportBodySchema.safeParse(req.body);
   if (!bodyResult.success) {
     return apiError(req, res, {
@@ -78,145 +51,35 @@ async function handler(
     });
   }
 
-  const file = await FileResource.fetchById(auth, fileId);
-  if (!file) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "file_not_found",
-        message: "File not found.",
-      },
-    });
-  }
-
-  // Only allow Frame files.
-  if (
-    !file.isInteractiveContent ||
-    !isInteractiveContentType(file.contentType)
-  ) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Only Frame files can be exported as PDF.",
-      },
-    });
-  }
-
-  // Check conversation access.
-  if (file.useCaseMetadata?.conversationId) {
-    const conversation = await ConversationResource.fetchById(
-      auth,
-      file.useCaseMetadata.conversationId
-    );
-    if (!conversation) {
-      return apiError(req, res, {
-        status_code: 404,
-        api_error: {
-          type: "file_not_found",
-          message: "File not found.",
-        },
-      });
-    }
-  }
-
-  // Get share info to retrieve the share token.
-  const shareInfo = await file.getShareInfo();
-  if (!shareInfo) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "File is not shareable.",
-      },
-    });
-  }
-
-  // Extract token from share URL.
-  const shareUrlParts = shareInfo.shareUrl.split("/");
-  const shareToken = shareUrlParts[shareUrlParts.length - 1];
-
-  // Generate access token for viz rendering.
-  const owner = auth.getNonNullableWorkspace();
-  const user = auth.user();
-  const accessToken = generateVizAccessToken({
-    contentType: file.contentType,
-    fileToken: shareToken,
-    userId: user?.sId,
-    shareScope: shareInfo.scope,
-    workspaceId: owner.sId,
+  const result = await exportInteractiveContentFileAsPdf(auth, {
+    fileId,
+    orientation: bodyResult.data.orientation,
   });
-
-  // Build viz URL. Use public URL since Gotenberg routes through egress proxy
-  // which blocks internal K8s IPs.
-  const vizUrl = config.getVizPublicUrl();
-  if (!vizUrl) {
-    return apiError(req, res, {
-      status_code: 501,
-      api_error: {
-        type: "internal_server_error",
-        message: "VIZ_PUBLIC_URL is not configured.",
-      },
-    });
-  }
-
-  const params = new URLSearchParams({
-    accessToken,
-    identifier: `viz-${fileId}`,
-    pdfMode: "true",
-  });
-  const targetUrl = `${vizUrl}/content?${params.toString()}`;
-
-  // Default to landscape for slideshow content, portrait for regular frames.
-  const orientation =
-    bodyResult.data.orientation ??
-    (file.contentType === frameSlideshowContentType ? "landscape" : "portrait");
-
-  const isSlideshow = file.contentType === frameSlideshowContentType;
-
-  // Only show footer for non-Enterprise plans and non-FriendsAndFamily plans.
-  const plan = auth.plan();
-  const shouldHideFooter =
-    plan &&
-    (isDustCompanyPlan(plan.code) ||
-      isEntreprisePlanPrefix(plan.code) ||
-      isFriendsAndFamilyPlan(plan.code));
-  const showFooter = !shouldHideFooter;
-
-  const renderer = new DocumentRenderer(documentRendererUrl, logger);
-
-  // Slideshows use zero margins (full-bleed slides).
-  const options: PdfOptions = showFooter
-    ? {
-        footerHtml: PDF_FOOTER_HTML,
-        marginBottom: isSlideshow ? "0" : "1cm",
-      }
-    : {};
-
-  const result = await renderer.exportToPdf(
-    {
-      url: targetUrl,
-      waitForExpression:
-        "document.querySelector('[data-viz-ready=\"true\"]') !== null",
-    },
-    {
-      ...options,
-      orientation,
-    }
-  );
 
   if (result.isErr()) {
-    return apiError(req, res, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Failed to generate PDF.",
-      },
-    });
+    const { error } = result;
+    switch (error.type) {
+      case "file_not_found":
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: { type: "file_not_found", message: error.message },
+        });
+      case "invalid_request":
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: { type: "invalid_request_error", message: error.message },
+        });
+      case "render_failed":
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: { type: "internal_server_error", message: error.message },
+        });
+      default:
+        assertNever(error.type);
+    }
   }
 
-  // Set response headers for PDF download.
-  const fileName = file.fileName?.replace(/\.[^.]+$/, ".pdf") || "frame.pdf";
+  const { buffer, fileName } = result.value;
   // Sanitize filename for Content-Disposition: use ASCII-only fallback for
   // `filename` and RFC 5987 `filename*` for the full UTF-8 name.
   const asciiFallback = fileName.replace(/[^\x20-\x7E]/g, "_");
@@ -226,9 +89,8 @@ async function handler(
     "Content-Disposition",
     `attachment; filename="${asciiFallback}"; filename*=UTF-8''${encodedName}`
   );
-  res.setHeader("Content-Length", result.value.length);
-
-  res.status(200).send(result.value);
+  res.setHeader("Content-Length", buffer.length);
+  res.status(200).send(buffer);
 }
 
 export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The interactive content MCP server can now export frames as PDF or PNG via a new
`export_interactive_content_file` tool. The agent specifies a file ID, a format, and an optional orientation for
PDF. The tool returns the PNG as a `base64` image the model can inspect, or the PDF as a blob resource.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
