### PR TITLE
Add yearly seats

### DIFF
--- a/front/components/workspace/ChangeSeatModal.tsx
+++ b/front/components/workspace/ChangeSeatModal.tsx
@@ -1,5 +1,6 @@
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import type {
+  SeatBillingFrequency,
   SeatPlanResponseBody,
   SeatTypeInfo,
 } from "@app/lib/api/credits/seat_plan";
@@ -22,23 +23,34 @@ import {
   SeatFreeIcon,
   SeatMaxIcon,
   SeatProIcon,
+  Tabs,
+  TabsList,
+  TabsTrigger,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 // Per-seat-type display icon. The label / name comes from the API
 // (`SeatTypeInfo.name`) so adding a new seat tier only requires tagging the
 // product in Metronome — no code change here.
-const SEAT_TYPE_ICONS: Partial<
-  Record<MembershipSeatType, React.ComponentType>
-> = {
+const SEAT_TYPE_ICONS: Record<MembershipSeatType, React.ComponentType> = {
   free: SeatFreeIcon,
   pro: SeatProIcon,
+  pro_yearly: SeatProIcon,
   max: SeatMaxIcon,
+  max_yearly: SeatMaxIcon,
+  workspace: SeatProIcon,
+  workspace_yearly: SeatProIcon,
 };
 
 // Display order when multiple seat tiers are returned by the endpoint. Seat
 // types not in this list are appended in the order they came in.
-const SEAT_DISPLAY_ORDER: MembershipSeatType[] = ["free", "pro", "max"];
+const SEAT_DISPLAY_ORDER: MembershipSeatType[] = [
+  "free",
+  "pro",
+  "pro_yearly",
+  "max",
+  "max_yearly",
+];
 
 function sortSeatTypes(seatTypes: MembershipSeatType[]): MembershipSeatType[] {
   const indexOf = (s: MembershipSeatType) => {
@@ -48,10 +60,17 @@ function sortSeatTypes(seatTypes: MembershipSeatType[]): MembershipSeatType[] {
   return [...seatTypes].sort((a, b) => indexOf(a) - indexOf(b));
 }
 
-function formatPriceCents(cents: number, currency: SupportedCurrency): string {
+function formatPriceCents(
+  cents: number,
+  currency: SupportedCurrency,
+  billingFrequency: SeatBillingFrequency
+): string {
   const symbol = CURRENCY_SYMBOLS[currency];
   const amount = (cents / 100).toFixed(2).replace(/\.00$/, "");
-  return currency === "usd" ? `${symbol}${amount}/mo` : `${amount}${symbol}/mo`;
+  const suffix = billingFrequency === "annual" ? "/yr" : "/mo";
+  return currency === "usd"
+    ? `${symbol}${amount}${suffix}`
+    : `${amount}${symbol}${suffix}`;
 }
 
 function formatAwuCredits(awuCredits: number): string {
@@ -133,6 +152,34 @@ export function ChangeSeatModal({
     workspaceId: owner.sId,
   });
 
+  const seatTypesByFrequency: Record<
+    SeatBillingFrequency,
+    MembershipSeatType[]
+  > = {
+    monthly: [],
+    annual: [],
+  };
+  for (const seatType of seatTypes) {
+    const info = seatPlans[seatType];
+    if (info) {
+      seatTypesByFrequency[info.billingFrequency].push(seatType);
+    }
+  }
+
+  const availableFrequencies: SeatBillingFrequency[] = (
+    ["monthly", "annual"] as const
+  ).filter((f) => seatTypesByFrequency[f].length > 0);
+
+  // Default the active tab to the frequency of the user's current seat — falls
+  // back to the first frequency that has any seats to show.
+  const currentFrequency =
+    currentSeatType && seatPlans[currentSeatType]
+      ? seatPlans[currentSeatType].billingFrequency
+      : null;
+  const [activeFrequency, setActiveFrequency] = useState<SeatBillingFrequency>(
+    currentFrequency ?? availableFrequencies[0] ?? "monthly"
+  );
+
   function getBadge(
     seatType: MembershipSeatType,
     info: SeatTypeInfo
@@ -146,7 +193,11 @@ export function ChangeSeatModal({
     }
     return (
       <span className="text-xs font-medium text-muted-foreground dark:text-muted-foreground-night">
-        {formatPriceCents(info.priceCents, info.currency)}
+        {formatPriceCents(
+          info.priceCents,
+          info.currency,
+          info.billingFrequency
+        )}
       </span>
     );
   }
@@ -205,13 +256,22 @@ export function ChangeSeatModal({
         </DialogHeader>
         <DialogContainer>
           <div className="flex flex-col gap-2">
-            <div className="mb-1 flex items-center gap-1">
-              <span className="rounded-md bg-muted px-2.5 py-1 text-xs font-medium text-foreground dark:bg-muted-night dark:text-foreground-night">
-                Monthly
-              </span>
-            </div>
+            {availableFrequencies.length > 1 && (
+              <Tabs value={activeFrequency} className="mb-1">
+                <TabsList border={false}>
+                  {availableFrequencies.map((f) => (
+                    <TabsTrigger
+                      key={f}
+                      value={f}
+                      label={f === "annual" ? "Annual" : "Monthly"}
+                      onClick={() => setActiveFrequency(f)}
+                    />
+                  ))}
+                </TabsList>
+              </Tabs>
+            )}
 
-            {seatTypes.map((seatType) => {
+            {seatTypesByFrequency[activeFrequency].map((seatType) => {
               const info = seatPlans[seatType];
               if (!info) {
                 return null;

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -350,7 +350,8 @@ export function MembersUsageTable({
     if (
       seatTypeFilter !== null &&
       seatTypeFilter !== "none" &&
-      m.seatType !== seatTypeFilter
+      m.seatType &&
+      !m.seatType.startsWith(seatTypeFilter)
     ) {
       return false;
     }

--- a/front/lib/api/credits/seat_plan.ts
+++ b/front/lib/api/credits/seat_plan.ts
@@ -6,6 +6,7 @@ import { getActiveContract } from "@app/lib/metronome/plan_type";
 import {
   getAwuAllocationForSeatType,
   getProductSeatTypes,
+  getSeatSubscriptionsFromContract,
   getSeatTypesByProductIdFromContract,
   isMauContract,
 } from "@app/lib/metronome/seat_types";
@@ -17,6 +18,8 @@ import type { MembershipSeatType } from "@app/types/memberships";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+export type SeatBillingFrequency = "monthly" | "annual";
+
 export interface SeatTypeInfo {
   // Human-readable plan name surfaced by Metronome (e.g. "Pro Seat") — use
   // for display so the UI doesn't need to know about specific seat types.
@@ -24,6 +27,9 @@ export interface SeatTypeInfo {
   awuCredits: number;
   priceCents: number;
   currency: SupportedCurrency;
+  // `priceCents` is the amount billed per `billingFrequency` (per month for
+  // monthly, per year for annual).
+  billingFrequency: SeatBillingFrequency;
 }
 
 // Dynamic seat-type → info map. The list of seat types is driven by the
@@ -97,6 +103,27 @@ export async function handleSeatPlanRequest(
     return res.status(200).json({});
   }
 
+  // Resolve each seat's billing frequency from the matching subscription on
+  // the contract. Default to "monthly" if the subscription declares anything
+  // other than ANNUAL — Metronome's enum has WEEKLY / QUARTERLY too, but we
+  // only ship monthly and annual seats.
+  const billingFrequencyBySeatType = new Map<
+    MembershipSeatType,
+    SeatBillingFrequency
+  >();
+  const seatSubscriptions = getSeatSubscriptionsFromContract(
+    contract,
+    productSeatTypes
+  );
+  for (const [seatType, sub] of seatSubscriptions) {
+    billingFrequencyBySeatType.set(
+      seatType,
+      sub.subscription_rate.billing_frequency === "ANNUAL"
+        ? "annual"
+        : "monthly"
+    );
+  }
+
   const monthlyPriceCentsBySeatType = new Map<MembershipSeatType, number>();
   const nameBySeatType = new Map<MembershipSeatType, string>();
   try {
@@ -167,6 +194,7 @@ export async function handleSeatPlanRequest(
       ),
       priceCents,
       currency,
+      billingFrequency: billingFrequencyBySeatType.get(seatType) ?? "monthly",
     };
   }
   return res.status(200).json(response);

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -55,6 +55,7 @@ const getOverageAwuRate = (currency: SupportedCurrency) => {
 const WORKSPACE_SEAT_PRODUCT_NAME = "Workspace Seat";
 const PRO_SEAT_PRODUCT_NAME = "Pro Seat";
 const MAX_SEAT_PRODUCT_NAME = "Max Seat";
+const YEARLY_SUFFIX = " (Yearly)";
 const FREE_SEAT_PRODUCT_NAME = "Free Seat";
 const PRO_SEAT_CREDIT_NAME = "Pro Seat Credits";
 const MAX_SEAT_CREDIT_NAME = "Max Seat Credits";
@@ -400,6 +401,11 @@ const PRODUCTS: ProductDef[] = [
     type: "SUBSCRIPTION",
     custom_fields: { [SEAT_TYPE_CUSTOM_FIELD_KEY]: "workspace" },
   },
+  {
+    name: WORKSPACE_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+    type: "SUBSCRIPTION",
+    custom_fields: { [SEAT_TYPE_CUSTOM_FIELD_KEY]: "workspace_yearly" },
+  },
   // Pro Seat / Max Seat — SUBSCRIPTION products for the new Business / Enterprise
   // seat-based plans. Used as SEAT_BASED subscriptions in packages with per-seat
   // INDIVIDUAL recurring credits (Pro: 8000 AWU/mo, Max: 40000 AWU/mo).
@@ -409,10 +415,21 @@ const PRODUCTS: ProductDef[] = [
     custom_fields: { [SEAT_TYPE_CUSTOM_FIELD_KEY]: "pro" },
   },
   {
+    name: PRO_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+    type: "SUBSCRIPTION",
+    custom_fields: { [SEAT_TYPE_CUSTOM_FIELD_KEY]: "pro_yearly" },
+  },
+  {
     name: MAX_SEAT_PRODUCT_NAME,
     type: "SUBSCRIPTION",
     custom_fields: { [SEAT_TYPE_CUSTOM_FIELD_KEY]: "max" },
   },
+  {
+    name: MAX_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+    type: "SUBSCRIPTION",
+    custom_fields: { [SEAT_TYPE_CUSTOM_FIELD_KEY]: "max_yearly" },
+  },
+
   // Free Seat — SUBSCRIPTION product priced at $0/seat. Carries a one-shot
   // lifetime AWU credit (300 AWU per seat) so free users have a small drawdown
   // pool without being billed.
@@ -872,6 +889,15 @@ function getRateCards(): RateCardDef[] {
           credit_type_id: CREDIT_TYPE_USD_ID,
         },
         {
+          product_name: WORKSPACE_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          billing_frequency: "ANNUAL",
+          price: 24000,
+          credit_type_id: CREDIT_TYPE_USD_ID,
+        },
+        {
           product_name: PRO_SEAT_PRODUCT_NAME,
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: false,
@@ -881,12 +907,30 @@ function getRateCards(): RateCardDef[] {
           credit_type_id: CREDIT_TYPE_USD_ID,
         },
         {
+          product_name: PRO_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: false,
+          rate_type: "FLAT",
+          billing_frequency: "ANNUAL",
+          price: 528000,
+          credit_type_id: CREDIT_TYPE_USD_ID,
+        },
+        {
           product_name: MAX_SEAT_PRODUCT_NAME,
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: false,
           rate_type: "FLAT",
           billing_frequency: "MONTHLY",
           price: 14000,
+          credit_type_id: CREDIT_TYPE_USD_ID,
+        },
+        {
+          product_name: MAX_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: false,
+          rate_type: "FLAT",
+          billing_frequency: "ANNUAL",
+          price: 168000,
           credit_type_id: CREDIT_TYPE_USD_ID,
         },
         {
@@ -930,6 +974,15 @@ function getRateCards(): RateCardDef[] {
           credit_type_id: CREDIT_TYPE_EUR_ID,
         },
         {
+          product_name: WORKSPACE_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          billing_frequency: "ANNUAL",
+          price: 240,
+          credit_type_id: CREDIT_TYPE_EUR_ID,
+        },
+        {
           product_name: PRO_SEAT_PRODUCT_NAME,
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: false,
@@ -939,12 +992,30 @@ function getRateCards(): RateCardDef[] {
           credit_type_id: CREDIT_TYPE_EUR_ID,
         },
         {
+          product_name: PRO_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: false,
+          rate_type: "FLAT",
+          billing_frequency: "ANNUAL",
+          price: 528,
+          credit_type_id: CREDIT_TYPE_EUR_ID,
+        },
+        {
           product_name: MAX_SEAT_PRODUCT_NAME,
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: false,
           rate_type: "FLAT",
           billing_frequency: "MONTHLY",
           price: 140,
+          credit_type_id: CREDIT_TYPE_EUR_ID,
+        },
+        {
+          product_name: MAX_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: false,
+          rate_type: "FLAT",
+          billing_frequency: "ANNUAL",
+          price: 1680,
           credit_type_id: CREDIT_TYPE_EUR_ID,
         },
         {
@@ -988,12 +1059,30 @@ function getRateCards(): RateCardDef[] {
           credit_type_id: CREDIT_TYPE_USD_ID,
         },
         {
+          product_name: PRO_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          billing_frequency: "ANNUAL",
+          price: 28800,
+          credit_type_id: CREDIT_TYPE_USD_ID,
+        },
+        {
           product_name: MAX_SEAT_PRODUCT_NAME,
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: true,
           rate_type: "FLAT",
           billing_frequency: "MONTHLY",
           price: 15000,
+          credit_type_id: CREDIT_TYPE_USD_ID,
+        },
+        {
+          product_name: MAX_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          billing_frequency: "ANNUAL",
+          price: 144000,
           credit_type_id: CREDIT_TYPE_USD_ID,
         },
         {
@@ -1035,12 +1124,30 @@ function getRateCards(): RateCardDef[] {
           credit_type_id: CREDIT_TYPE_EUR_ID,
         },
         {
+          product_name: PRO_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          billing_frequency: "ANNUAL",
+          price: 288,
+          credit_type_id: CREDIT_TYPE_EUR_ID,
+        },
+        {
           product_name: MAX_SEAT_PRODUCT_NAME,
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: true,
           rate_type: "FLAT",
           billing_frequency: "MONTHLY",
           price: 150,
+          credit_type_id: CREDIT_TYPE_EUR_ID,
+        },
+        {
+          product_name: MAX_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          billing_frequency: "ANNUAL",
+          price: 1440,
           credit_type_id: CREDIT_TYPE_EUR_ID,
         },
         {
@@ -1092,8 +1199,14 @@ function getRateCards(): RateCardDef[] {
 function buildSeatEntitlementFlipOverrides(): PackageOverrideDef[] {
   return [
     { product_name: WORKSPACE_SEAT_PRODUCT_NAME, entitled: false },
+    {
+      product_name: WORKSPACE_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+      entitled: false,
+    },
     { product_name: PRO_SEAT_PRODUCT_NAME, entitled: true },
+    { product_name: PRO_SEAT_PRODUCT_NAME + YEARLY_SUFFIX, entitled: true },
     { product_name: MAX_SEAT_PRODUCT_NAME, entitled: true },
+    { product_name: MAX_SEAT_PRODUCT_NAME + YEARLY_SUFFIX, entitled: true },
     { product_name: FREE_SEAT_PRODUCT_NAME, entitled: true },
   ];
 }
@@ -1201,14 +1314,24 @@ const WORKSPACE_SEAT_MONTHLY_SUBSCRIPTION: PackageSubscription = {
     invoice_behavior: "BILL_ON_NEXT_COLLECTION_DATE",
   },
 };
+const WORKSPACE_SEAT_ANNUAL_SUBSCRIPTION: PackageSubscription = {
+  temporary_id: "workspace-seat-annual-sub",
+  product_name: WORKSPACE_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+  billing_frequency: "ANNUAL",
+  collection_schedule: "ADVANCE",
+  quantity_management_mode: "QUANTITY_ONLY",
+  initial_quantity: 1,
+  proration: {
+    is_prorated: true,
+    invoice_behavior: "BILL_ON_NEXT_COLLECTION_DATE",
+  },
+};
 
 // SEAT_BASED subscriptions for the Business (and seat-based Enterprise) plans.
 // Seat group key is `user_id` — usage events carrying that property draw down
 // only the credits attached to the matching seat. The seat count is controlled
 // by add_seat_ids / remove_seat_ids via the contract edit API.
 const PRO_SEAT_SUBSCRIPTION_TEMPORARY_ID = "pro-seat-sub";
-const MAX_SEAT_SUBSCRIPTION_TEMPORARY_ID = "max-seat-sub";
-
 const PRO_SEAT_SUBSCRIPTION: PackageSubscription = {
   temporary_id: PRO_SEAT_SUBSCRIPTION_TEMPORARY_ID,
   product_name: PRO_SEAT_PRODUCT_NAME,
@@ -1222,10 +1345,39 @@ const PRO_SEAT_SUBSCRIPTION: PackageSubscription = {
   },
 };
 
+const PRO_SEAT_ANNUAL_SUBSCRIPTION_TEMPORARY_ID = "pro-seat-annual-sub";
+const PRO_SEAT_ANNUAL_SUBSCRIPTION: PackageSubscription = {
+  temporary_id: PRO_SEAT_ANNUAL_SUBSCRIPTION_TEMPORARY_ID,
+  product_name: PRO_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+  billing_frequency: "ANNUAL",
+  collection_schedule: "ADVANCE",
+  quantity_management_mode: "SEAT_BASED",
+  seat_config: { seat_group_key: "user_id" },
+  proration: {
+    is_prorated: true,
+    invoice_behavior: "BILL_ON_NEXT_COLLECTION_DATE",
+  },
+};
+
+const MAX_SEAT_SUBSCRIPTION_TEMPORARY_ID = "max-seat-sub";
 const MAX_SEAT_SUBSCRIPTION: PackageSubscription = {
   temporary_id: MAX_SEAT_SUBSCRIPTION_TEMPORARY_ID,
   product_name: MAX_SEAT_PRODUCT_NAME,
   billing_frequency: "MONTHLY",
+  collection_schedule: "ADVANCE",
+  quantity_management_mode: "SEAT_BASED",
+  seat_config: { seat_group_key: "user_id" },
+  proration: {
+    is_prorated: true,
+    invoice_behavior: "BILL_ON_NEXT_COLLECTION_DATE",
+  },
+};
+
+const MAX_SEAT_ANNUAL_SUBSCRIPTION_TEMPORARY_ID = "max-seat-annual-sub";
+const MAX_SEAT_ANNUAL_SUBSCRIPTION: PackageSubscription = {
+  temporary_id: MAX_SEAT_ANNUAL_SUBSCRIPTION_TEMPORARY_ID,
+  product_name: MAX_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+  billing_frequency: "ANNUAL",
   collection_schedule: "ADVANCE",
   quantity_management_mode: "SEAT_BASED",
   seat_config: { seat_group_key: "user_id" },
@@ -1442,7 +1594,10 @@ function getPackages(): PackageDef[] {
       name: "Enterprise Pooled USD",
       aliases: [{ name: "enterprise-usd" }],
       rate_card_name: "Enterprise USD",
-      subscriptions: [WORKSPACE_SEAT_MONTHLY_SUBSCRIPTION],
+      subscriptions: [
+        WORKSPACE_SEAT_MONTHLY_SUBSCRIPTION,
+        WORKSPACE_SEAT_ANNUAL_SUBSCRIPTION,
+      ],
       scheduled_charges_on_usage_invoices: "ALL",
       recurring_credits: [
         getFreeExcessRecurringCredits(getCreditTypeAwuId(), 5_000),
@@ -1453,7 +1608,10 @@ function getPackages(): PackageDef[] {
       name: "Enterprise Pooled EUR",
       aliases: [{ name: "enterprise-eur" }],
       rate_card_name: "Enterprise EUR",
-      subscriptions: [WORKSPACE_SEAT_MONTHLY_SUBSCRIPTION],
+      subscriptions: [
+        WORKSPACE_SEAT_MONTHLY_SUBSCRIPTION,
+        WORKSPACE_SEAT_ANNUAL_SUBSCRIPTION,
+      ],
       scheduled_charges_on_usage_invoices: "ALL",
       recurring_credits: [
         getFreeExcessRecurringCredits(getCreditTypeAwuId(), 5_000),
@@ -1466,11 +1624,33 @@ function getPackages(): PackageDef[] {
       rate_card_name: "Enterprise USD",
       subscriptions: [
         PRO_SEAT_SUBSCRIPTION,
+        PRO_SEAT_ANNUAL_SUBSCRIPTION,
         MAX_SEAT_SUBSCRIPTION,
+        MAX_SEAT_ANNUAL_SUBSCRIPTION,
         FREE_SEAT_SUBSCRIPTION,
       ],
       scheduled_charges_on_usage_invoices: "ALL",
       recurring_credits: [
+        getPerSeatIndividualAwuCredits({
+          subscriptionTemporaryId: MAX_SEAT_SUBSCRIPTION_TEMPORARY_ID,
+          quantityPerSeat: MAX_SEAT_MONTHLY_AWU_CREDITS,
+          name: MAX_SEAT_CREDIT_NAME,
+        }),
+        getPerSeatIndividualAwuCredits({
+          subscriptionTemporaryId: PRO_SEAT_ANNUAL_SUBSCRIPTION_TEMPORARY_ID,
+          quantityPerSeat: PRO_SEAT_MONTHLY_AWU_CREDITS,
+          name: PRO_SEAT_CREDIT_NAME,
+        }),
+        getPerSeatIndividualAwuCredits({
+          subscriptionTemporaryId: PRO_SEAT_SUBSCRIPTION_TEMPORARY_ID,
+          quantityPerSeat: PRO_SEAT_MONTHLY_AWU_CREDITS,
+          name: PRO_SEAT_CREDIT_NAME,
+        }),
+        getPerSeatIndividualAwuCredits({
+          subscriptionTemporaryId: MAX_SEAT_ANNUAL_SUBSCRIPTION_TEMPORARY_ID,
+          quantityPerSeat: MAX_SEAT_MONTHLY_AWU_CREDITS,
+          name: MAX_SEAT_CREDIT_NAME,
+        }),
         getFreeExcessRecurringCredits(getCreditTypeAwuId(), 5_000),
       ],
       overrides: buildSeatEntitlementFlipOverrides(),
@@ -1482,11 +1662,33 @@ function getPackages(): PackageDef[] {
       rate_card_name: "Enterprise EUR",
       subscriptions: [
         PRO_SEAT_SUBSCRIPTION,
+        PRO_SEAT_ANNUAL_SUBSCRIPTION,
         MAX_SEAT_SUBSCRIPTION,
+        MAX_SEAT_ANNUAL_SUBSCRIPTION,
         FREE_SEAT_SUBSCRIPTION,
       ],
       scheduled_charges_on_usage_invoices: "ALL",
       recurring_credits: [
+        getPerSeatIndividualAwuCredits({
+          subscriptionTemporaryId: PRO_SEAT_SUBSCRIPTION_TEMPORARY_ID,
+          quantityPerSeat: PRO_SEAT_MONTHLY_AWU_CREDITS,
+          name: PRO_SEAT_CREDIT_NAME,
+        }),
+        getPerSeatIndividualAwuCredits({
+          subscriptionTemporaryId: PRO_SEAT_ANNUAL_SUBSCRIPTION_TEMPORARY_ID,
+          quantityPerSeat: PRO_SEAT_MONTHLY_AWU_CREDITS,
+          name: PRO_SEAT_CREDIT_NAME,
+        }),
+        getPerSeatIndividualAwuCredits({
+          subscriptionTemporaryId: MAX_SEAT_SUBSCRIPTION_TEMPORARY_ID,
+          quantityPerSeat: MAX_SEAT_MONTHLY_AWU_CREDITS,
+          name: MAX_SEAT_CREDIT_NAME,
+        }),
+        getPerSeatIndividualAwuCredits({
+          subscriptionTemporaryId: MAX_SEAT_ANNUAL_SUBSCRIPTION_TEMPORARY_ID,
+          quantityPerSeat: MAX_SEAT_MONTHLY_AWU_CREDITS,
+          name: MAX_SEAT_CREDIT_NAME,
+        }),
         getFreeExcessRecurringCredits(getCreditTypeAwuId(), 5_000),
       ],
       overrides: buildSeatEntitlementFlipOverrides(),
@@ -1502,7 +1704,9 @@ function getPackages(): PackageDef[] {
       rate_card_name: "Business USD",
       subscriptions: [
         PRO_SEAT_SUBSCRIPTION,
+        PRO_SEAT_ANNUAL_SUBSCRIPTION,
         MAX_SEAT_SUBSCRIPTION,
+        MAX_SEAT_ANNUAL_SUBSCRIPTION,
         FREE_SEAT_SUBSCRIPTION,
       ],
       scheduled_charges_on_usage_invoices: "ALL",
@@ -1513,7 +1717,17 @@ function getPackages(): PackageDef[] {
           name: PRO_SEAT_CREDIT_NAME,
         }),
         getPerSeatIndividualAwuCredits({
+          subscriptionTemporaryId: PRO_SEAT_ANNUAL_SUBSCRIPTION_TEMPORARY_ID,
+          quantityPerSeat: PRO_SEAT_MONTHLY_AWU_CREDITS,
+          name: PRO_SEAT_CREDIT_NAME,
+        }),
+        getPerSeatIndividualAwuCredits({
           subscriptionTemporaryId: MAX_SEAT_SUBSCRIPTION_TEMPORARY_ID,
+          quantityPerSeat: MAX_SEAT_MONTHLY_AWU_CREDITS,
+          name: MAX_SEAT_CREDIT_NAME,
+        }),
+        getPerSeatIndividualAwuCredits({
+          subscriptionTemporaryId: MAX_SEAT_ANNUAL_SUBSCRIPTION_TEMPORARY_ID,
           quantityPerSeat: MAX_SEAT_MONTHLY_AWU_CREDITS,
           name: MAX_SEAT_CREDIT_NAME,
         }),
@@ -1528,7 +1742,9 @@ function getPackages(): PackageDef[] {
       rate_card_name: "Business EUR",
       subscriptions: [
         PRO_SEAT_SUBSCRIPTION,
+        PRO_SEAT_ANNUAL_SUBSCRIPTION,
         MAX_SEAT_SUBSCRIPTION,
+        MAX_SEAT_ANNUAL_SUBSCRIPTION,
         FREE_SEAT_SUBSCRIPTION,
       ],
       scheduled_charges_on_usage_invoices: "ALL",
@@ -1539,7 +1755,17 @@ function getPackages(): PackageDef[] {
           name: PRO_SEAT_CREDIT_NAME,
         }),
         getPerSeatIndividualAwuCredits({
+          subscriptionTemporaryId: PRO_SEAT_ANNUAL_SUBSCRIPTION_TEMPORARY_ID,
+          quantityPerSeat: PRO_SEAT_MONTHLY_AWU_CREDITS,
+          name: PRO_SEAT_CREDIT_NAME,
+        }),
+        getPerSeatIndividualAwuCredits({
           subscriptionTemporaryId: MAX_SEAT_SUBSCRIPTION_TEMPORARY_ID,
+          quantityPerSeat: MAX_SEAT_MONTHLY_AWU_CREDITS,
+          name: MAX_SEAT_CREDIT_NAME,
+        }),
+        getPerSeatIndividualAwuCredits({
+          subscriptionTemporaryId: MAX_SEAT_ANNUAL_SUBSCRIPTION_TEMPORARY_ID,
           quantityPerSeat: MAX_SEAT_MONTHLY_AWU_CREDITS,
           name: MAX_SEAT_CREDIT_NAME,
         }),

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -25,8 +25,11 @@ export function isMembershipOriginType(
 export const MEMBERSHIP_SEAT_TYPES = [
   "free",
   "workspace",
+  "workspace_yearly",
   "pro",
+  "pro_yearly",
   "max",
+  "max_yearly",
 ] as const;
 
 export type MembershipSeatType = (typeof MEMBERSHIP_SEAT_TYPES)[number];


### PR DESCRIPTION
## Description

Adds yearly billing variants of the seat-based plans: `workspace_yearly`, `pro_yearly`, `max_yearly`. Stacked on top of the free-plan PR.

- **Metronome setup** (`scripts/metronome_setup.ts`): yearly product (`* (Yearly)` suffix) + ANNUAL rate-card entries + ANNUAL `SEAT_BASED` subscription + per-seat AWU recurring credit for each of `WORKSPACE_SEAT`, `PRO_SEAT`, `MAX_SEAT`. Yearly seats are wired into both Enterprise Pooled, Enterprise Seat-based, and Business packages (USD + EUR). Yearly seat AWU allocations match their monthly counterparts (Pro 8000, Max 40000).
- **Seat types** (`types/memberships.ts`): new `workspace_yearly` / `pro_yearly` / `max_yearly` values in `MEMBERSHIP_SEAT_TYPES`.
- **/seats/plan endpoint** (`lib/api/credits/seat_plan.ts`): now returns `billingFrequency: "monthly" | "annual"` per seat. Resolved from the matching subscription's `subscription_rate.billing_frequency`. `priceCents` keeps its meaning (per the seat's billing period, so the annual seats return their annual price).
- **ChangeSeatModal** (`components/workspace/ChangeSeatModal.tsx`): replaced the static "Monthly" pill with a `Monthly | Annual` `Tabs` strip, only rendered when both groups have at least one seat. The active tab defaults to the frequency of the member's current seat. Price label uses `/yr` for annual seats.
- **MembersUsageTable** (`components/workspace/MembersUsageTable.tsx`): the seat-type filter now matches by prefix so selecting "Pro" matches both `pro` and `pro_yearly` members.

## Tests

Manual: re-ran the Metronome setup (after dropping the affected packages), verified the response from `/api/w/<wId>/seats/plan` now returns `pro: 8000`, `pro_yearly: 8000`, `max: 40000`, `max_yearly: 40000` with `billingFrequency` set correctly per entry, and verified the modal tabs render and switch as expected.

## Risk

Low. The runtime code paths are dynamic over whatever seat types Metronome exposes, so adding the yearly variants does not change behavior for contracts that don't have them. The MembersUsageTable filter widening is intentional: existing "Pro"/"Max" filters now also match the yearly variants.

## Deploy Plan

1. Merge.
2. Run `metronome_setup` against each environment to provision the yearly products / rate-card entries / subscriptions / recurring credits. Existing packages are reconciled; this picks up the new yearly subscriptions and credits automatically.
3. Yearly seats become assignable to contracts via the existing seat-management flow.