### PR TITLE
[front] enh: prevent concurrent identical workspace fetches

### DIFF
--- a/front/lib/api/assistant/email/email_reply.test.ts
+++ b/front/lib/api/assistant/email/email_reply.test.ts
@@ -9,7 +9,9 @@ import {
 import { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { getAgentLoopData } from "@app/types/assistant/agent_run";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { getAgentLoopDataWithAuth } from "@app/types/assistant/agent_run";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/api/assistant/configuration/agent", () => ({
@@ -30,12 +32,6 @@ vi.mock("@app/lib/api/config", () => ({
   },
 }));
 
-vi.mock("@app/lib/auth", () => ({
-  Authenticator: {
-    fromJSON: vi.fn(),
-  },
-}));
-
 vi.mock("@app/lib/resources/agent_mcp_action_resource", () => ({
   AgentMCPActionResource: {
     listBlockedActionsForConversation: vi.fn(),
@@ -53,23 +49,25 @@ vi.mock("@app/lib/utils/router", () => ({
 }));
 
 vi.mock("@app/types/assistant/agent_run", () => ({
-  getAgentLoopData: vi.fn(),
+  getAgentLoopDataWithAuth: vi.fn(),
 }));
 
 import { sendEmailReplyOnCompletion } from "@app/lib/api/assistant/email/email_reply";
 
 describe("sendEmailReplyOnCompletion", () => {
+  async function makeAuth({ allowEmailAgents }: { allowEmailAgents: boolean }) {
+    const workspace = await WorkspaceFactory.basic();
+    const updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
+      allowEmailAgents,
+    });
+    expect(updateResult.isOk()).toBe(true);
+
+    return Authenticator.internalAdminForWorkspace(workspace.sId);
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
 
-    vi.mocked(Authenticator.fromJSON).mockResolvedValue({
-      isErr: () => false,
-      value: {
-        getNonNullableWorkspace: () => ({
-          metadata: { allowEmailAgents: true },
-        }),
-      },
-    } as never);
     vi.mocked(ConversationResource.fetchById).mockResolvedValue({} as never);
     vi.mocked(
       AgentMCPActionResource.listBlockedActionsForConversation
@@ -93,10 +91,9 @@ describe("sendEmailReplyOnCompletion", () => {
       replyCc: ["security@dust.tt"],
     } as never);
 
-    vi.mocked(getAgentLoopData).mockResolvedValue({
+    vi.mocked(getAgentLoopDataWithAuth).mockResolvedValue({
       isErr: () => false,
       value: {
-        auth: {},
         agentMessage: {
           sId: "agent-message-1",
           content: "Done",
@@ -107,16 +104,15 @@ describe("sendEmailReplyOnCompletion", () => {
       },
     } as never);
 
-    await sendEmailReplyOnCompletion(
-      { workspaceId: "workspace-1" } as never,
-      {
-        agentMessageId: "agent-message-1",
-        userMessageOrigin: "email",
-      } as never
-    );
+    const auth = await makeAuth({ allowEmailAgents: true });
+
+    await sendEmailReplyOnCompletion(auth, {
+      agentMessageId: "agent-message-1",
+      userMessageOrigin: "email",
+    } as never);
 
     expect(deleteEmailReplyContext).toHaveBeenCalledWith(
-      "workspace-1",
+      auth.getNonNullableWorkspace().sId,
       "agent-message-1"
     );
     expect(replyToEmail).toHaveBeenCalledWith(
@@ -130,14 +126,6 @@ describe("sendEmailReplyOnCompletion", () => {
   });
 
   it("skips the reply when email agents are disabled in workspace metadata", async () => {
-    vi.mocked(Authenticator.fromJSON).mockResolvedValue({
-      isErr: () => false,
-      value: {
-        getNonNullableWorkspace: () => ({
-          metadata: { allowEmailAgents: false },
-        }),
-      },
-    } as never);
     vi.mocked(getEmailReplyContext).mockResolvedValue({
       subject: "Test",
       originalText: "Hello",
@@ -150,10 +138,9 @@ describe("sendEmailReplyOnCompletion", () => {
       workspaceId: "workspace-1",
       conversationId: "conversation-1",
     } as never);
-    vi.mocked(getAgentLoopData).mockResolvedValue({
+    vi.mocked(getAgentLoopDataWithAuth).mockResolvedValue({
       isErr: () => false,
       value: {
-        auth: {},
         agentMessage: {
           sId: "agent-message-1",
           content: "Done",
@@ -164,16 +151,15 @@ describe("sendEmailReplyOnCompletion", () => {
       },
     } as never);
 
-    await sendEmailReplyOnCompletion(
-      { workspaceId: "workspace-1" } as never,
-      {
-        agentMessageId: "agent-message-1",
-        userMessageOrigin: "email",
-      } as never
-    );
+    const auth = await makeAuth({ allowEmailAgents: false });
+
+    await sendEmailReplyOnCompletion(auth, {
+      agentMessageId: "agent-message-1",
+      userMessageOrigin: "email",
+    } as never);
 
     expect(deleteEmailReplyContext).toHaveBeenCalledWith(
-      "workspace-1",
+      auth.getNonNullableWorkspace().sId,
       "agent-message-1"
     );
     expect(replyToEmail).not.toHaveBeenCalled();

--- a/front/lib/api/assistant/email/email_reply.ts
+++ b/front/lib/api/assistant/email/email_reply.ts
@@ -11,13 +11,13 @@ import {
   storeEmailReplyContext,
 } from "@app/lib/api/assistant/email/email_trigger";
 import config from "@app/lib/api/config";
-import { Authenticator, type AuthenticatorType } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { getConversationRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
-import { getAgentLoopData } from "@app/types/assistant/agent_run";
+import { getAgentLoopDataWithAuth } from "@app/types/assistant/agent_run";
 import { marked } from "marked";
 import sanitizeHtml from "sanitize-html";
 
@@ -54,18 +54,11 @@ function reconstructEmailFromContext(context: EmailReplyContext): InboundEmail {
  * Duplicates the webhook handler check in case Redis data is manipulated or
  * context is stored incorrectly.
  */
-async function isEmailAgentsEnabled(
-  authType: AuthenticatorType
-): Promise<boolean> {
-  const authResult = await Authenticator.fromJSON(authType);
-  if (authResult.isErr()) {
-    logger.warn("[email] Failed to create authenticator for email reply check");
-    return false;
-  }
-  const workspace = authResult.value.getNonNullableWorkspace();
+async function isEmailAgentsEnabled(auth: Authenticator): Promise<boolean> {
+  const workspace = auth.getNonNullableWorkspace();
   if (workspace.metadata?.allowEmailAgents !== true) {
     logger.info(
-      { workspaceId: authType.workspaceId },
+      { workspaceId: workspace.sId },
       "[email] allowEmailAgents not enabled in workspace metadata, skipping reply"
     );
     return false;
@@ -160,9 +153,10 @@ async function handleBlockedValidation(
  * Fire-and-forget: failures are logged but don't throw.
  */
 export async function sendEmailReplyOnCompletion(
-  authType: AuthenticatorType,
+  auth: Authenticator,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
+  const workspaceId = auth.getNonNullableWorkspace().sId;
   try {
     // Only process email-originated messages.
     if (agentLoopArgs.userMessageOrigin !== "email") {
@@ -171,7 +165,7 @@ export async function sendEmailReplyOnCompletion(
 
     // Read without deleting — only delete after actually sending the final reply.
     const context = await getEmailReplyContext(
-      authType.workspaceId,
+      workspaceId,
       agentLoopArgs.agentMessageId
     );
     if (!context) {
@@ -183,7 +177,7 @@ export async function sendEmailReplyOnCompletion(
     }
 
     // Get the completed agent message data.
-    const dataRes = await getAgentLoopData(authType, agentLoopArgs);
+    const dataRes = await getAgentLoopDataWithAuth(auth, agentLoopArgs);
     if (dataRes.isErr()) {
       logger.warn(
         {
@@ -195,19 +189,17 @@ export async function sendEmailReplyOnCompletion(
       return;
     }
 
-    const { auth, agentMessage, conversation } = dataRes.value;
+    const { agentMessage, conversation } = dataRes.value;
 
-    if (!(await isEmailAgentsEnabled(authType))) {
-      await deleteEmailReplyContext(
-        authType.workspaceId,
-        agentLoopArgs.agentMessageId
-      );
+    const isEnabled = await isEmailAgentsEnabled(auth);
+    if (!isEnabled) {
+      await deleteEmailReplyContext(workspaceId, agentLoopArgs.agentMessageId);
       return;
     }
 
     if (agentMessage.status === "failed") {
       await sendEmailReplyOnError(
-        authType,
+        auth,
         agentLoopArgs,
         agentMessage.error?.message ?? "Agent execution failed."
       );
@@ -225,10 +217,7 @@ export async function sendEmailReplyOnCompletion(
     }
 
     // No blocked actions — send the normal reply and delete the context.
-    await deleteEmailReplyContext(
-      authType.workspaceId,
-      agentLoopArgs.agentMessageId
-    );
+    await deleteEmailReplyContext(workspaceId, agentLoopArgs.agentMessageId);
 
     // Get agent configuration for the reply sender name.
     const agentConfiguration = await getAgentConfiguration(auth, {
@@ -298,17 +287,18 @@ export async function sendEmailReplyOnCompletion(
  * Fire-and-forget: failures are logged but don't throw.
  */
 export async function sendEmailReplyOnError(
-  authType: AuthenticatorType,
+  auth: Authenticator,
   agentLoopArgs: AgentLoopArgs,
   errorMessage: string
 ): Promise<void> {
+  const workspaceId = auth.getNonNullableWorkspace().sId;
   try {
     if (agentLoopArgs.userMessageOrigin !== "email") {
       return;
     }
 
     const context = await getEmailReplyContext(
-      authType.workspaceId,
+      workspaceId,
       agentLoopArgs.agentMessageId
     );
     if (!context) {
@@ -319,12 +309,10 @@ export async function sendEmailReplyOnError(
       return;
     }
 
-    await deleteEmailReplyContext(
-      authType.workspaceId,
-      agentLoopArgs.agentMessageId
-    );
+    await deleteEmailReplyContext(workspaceId, agentLoopArgs.agentMessageId);
 
-    if (!(await isEmailAgentsEnabled(authType))) {
+    const isEnabled = await isEmailAgentsEnabled(auth);
+    if (!isEnabled) {
       return;
     }
 

--- a/front/lib/api/assistant/email/email_reply.ts
+++ b/front/lib/api/assistant/email/email_reply.ts
@@ -157,129 +157,120 @@ export async function sendEmailReplyOnCompletion(
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
   const workspaceId = auth.getNonNullableWorkspace().sId;
-  try {
-    // Only process email-originated messages.
-    if (agentLoopArgs.userMessageOrigin !== "email") {
-      return;
-    }
 
-    // Read without deleting — only delete after actually sending the final reply.
-    const context = await getEmailReplyContext(
-      workspaceId,
-      agentLoopArgs.agentMessageId
-    );
-    if (!context) {
-      logger.info(
-        { agentMessageId: agentLoopArgs.agentMessageId },
-        "[email] No email reply context found, skipping reply"
-      );
-      return;
-    }
+  // Only process email-originated messages.
+  if (agentLoopArgs.userMessageOrigin !== "email") {
+    return;
+  }
 
-    // Get the completed agent message data.
-    const dataRes = await getAgentLoopDataWithAuth(auth, agentLoopArgs);
-    if (dataRes.isErr()) {
-      logger.warn(
-        {
-          agentMessageId: agentLoopArgs.agentMessageId,
-          error: dataRes.error,
-        },
-        "[email] Failed to get agent loop data for email reply"
-      );
-      return;
-    }
-
-    const { agentMessage, conversation } = dataRes.value;
-
-    const isEnabled = await isEmailAgentsEnabled(auth);
-    if (!isEnabled) {
-      await deleteEmailReplyContext(workspaceId, agentLoopArgs.agentMessageId);
-      return;
-    }
-
-    if (agentMessage.status === "failed") {
-      await sendEmailReplyOnError(
-        auth,
-        agentLoopArgs,
-        agentMessage.error?.message ?? "Agent execution failed."
-      );
-      return;
-    }
-
-    // Check if blocked on tool validation — send validation email instead.
-    const blocked = await handleBlockedValidation(
-      auth,
-      agentMessage.sId,
-      context
-    );
-    if (blocked) {
-      return;
-    }
-
-    // No blocked actions — send the normal reply and delete the context.
-    await deleteEmailReplyContext(workspaceId, agentLoopArgs.agentMessageId);
-
-    // Get agent configuration for the reply sender name.
-    const agentConfiguration = await getAgentConfiguration(auth, {
-      agentId: context.agentConfigurationId,
-      variant: "light",
-    });
-
-    // Render the agent message content as HTML.
-    const htmlContent = sanitizeHtml(
-      await marked.parse(agentMessage.content ?? ""),
-      {
-        allowedTags: sanitizeHtml.defaults.allowedTags.concat(["img"]),
-      }
-    );
-
-    // Build the full HTML with conversation link.
-    const conversationLink = getConversationRoute(
-      context.workspaceId,
-      conversation.sId,
-      undefined,
-      config.getAppUrl()
-    );
-    const agentName = agentConfiguration
-      ? sanitizeHtml(agentConfiguration.name, {
-          allowedTags: [],
-          allowedAttributes: {},
-        })
-      : null;
-    const attribution = agentName
-      ? `Answered by <strong>${agentName}</strong>`
-      : "Answered";
-    const fullHtmlContent =
-      `<div><div>${htmlContent}</div>` +
-      `<p style="color: #666; font-size: 13px; margin-top: 16px;">${attribution} · <a href="${conversationLink}" style="color: #2563eb;">View full conversation</a></p>` +
-      `</div>`;
-
-    // Reconstruct the email and send reply.
-    const email = reconstructEmailFromContext(context);
-    await replyToEmail({
-      email,
-      agentConfiguration: agentConfiguration ?? undefined,
-      htmlContent: fullHtmlContent,
-      recipient: context.fromEmail,
-    });
-
+  // Read without deleting — only delete after actually sending the final reply.
+  const context = await getEmailReplyContext(
+    workspaceId,
+    agentLoopArgs.agentMessageId
+  );
+  if (!context) {
     logger.info(
-      {
-        agentMessageId: agentLoopArgs.agentMessageId,
-        conversationId: conversation.sId,
-        to: context.fromEmail,
-      },
-      "[email] Sent email reply on agent completion"
+      { agentMessageId: agentLoopArgs.agentMessageId },
+      "[email] No email reply context found, skipping reply"
     );
-  } catch (err) {
+    return;
+  }
+
+  // Get the completed agent message data.
+  const dataRes = await getAgentLoopDataWithAuth(auth, agentLoopArgs);
+  if (dataRes.isErr()) {
     logger.warn(
       {
-        err,
         agentMessageId: agentLoopArgs.agentMessageId,
+        error: dataRes.error,
       },
-      "[email] Failed to send email reply on completion, skipping"
+      "[email] Failed to get agent loop data for email reply"
     );
+    return;
   }
+
+  const { agentMessage, conversation } = dataRes.value;
+
+  const isEnabled = await isEmailAgentsEnabled(auth);
+  if (!isEnabled) {
+    await deleteEmailReplyContext(workspaceId, agentLoopArgs.agentMessageId);
+    return;
+  }
+
+  if (agentMessage.status === "failed") {
+    await sendEmailReplyOnError(
+      auth,
+      agentLoopArgs,
+      agentMessage.error?.message ?? "Agent execution failed."
+    );
+    return;
+  }
+
+  // Check if blocked on tool validation — send validation email instead.
+  const blocked = await handleBlockedValidation(
+    auth,
+    agentMessage.sId,
+    context
+  );
+  if (blocked) {
+    return;
+  }
+
+  // No blocked actions — send the normal reply and delete the context.
+  await deleteEmailReplyContext(workspaceId, agentLoopArgs.agentMessageId);
+
+  // Get agent configuration for the reply sender name.
+  const agentConfiguration = await getAgentConfiguration(auth, {
+    agentId: context.agentConfigurationId,
+    variant: "light",
+  });
+
+  // Render the agent message content as HTML.
+  const htmlContent = sanitizeHtml(
+    await marked.parse(agentMessage.content ?? ""),
+    {
+      allowedTags: sanitizeHtml.defaults.allowedTags.concat(["img"]),
+    }
+  );
+
+  // Build the full HTML with conversation link.
+  const conversationLink = getConversationRoute(
+    context.workspaceId,
+    conversation.sId,
+    undefined,
+    config.getAppUrl()
+  );
+  const agentName = agentConfiguration
+    ? sanitizeHtml(agentConfiguration.name, {
+        allowedTags: [],
+        allowedAttributes: {},
+      })
+    : null;
+  const attribution = agentName
+    ? `Answered by <strong>${agentName}</strong>`
+    : "Answered";
+  const fullHtmlContent =
+    `<div><div>${htmlContent}</div>` +
+    `<p style="color: #666; font-size: 13px; margin-top: 16px;">${attribution} · <a href="${conversationLink}" style="color: #2563eb;">View full conversation</a></p>` +
+    `</div>`;
+
+  // Reconstruct the email and send reply.
+  const email = reconstructEmailFromContext(context);
+  await replyToEmail({
+    email,
+    agentConfiguration: agentConfiguration ?? undefined,
+    htmlContent: fullHtmlContent,
+    recipient: context.fromEmail,
+  });
+
+  logger.info(
+    {
+      agentMessageId: agentLoopArgs.agentMessageId,
+      conversationId: conversation.sId,
+      to: context.fromEmail,
+    },
+    "[email] Sent email reply on agent completion"
+  );
 }
 
 /**
@@ -292,56 +283,46 @@ export async function sendEmailReplyOnError(
   errorMessage: string
 ): Promise<void> {
   const workspaceId = auth.getNonNullableWorkspace().sId;
-  try {
-    if (agentLoopArgs.userMessageOrigin !== "email") {
-      return;
-    }
-
-    const context = await getEmailReplyContext(
-      workspaceId,
-      agentLoopArgs.agentMessageId
-    );
-    if (!context) {
-      logger.info(
-        { agentMessageId: agentLoopArgs.agentMessageId },
-        "[email] No email reply context found for error reply, skipping"
-      );
-      return;
-    }
-
-    await deleteEmailReplyContext(workspaceId, agentLoopArgs.agentMessageId);
-
-    const isEnabled = await isEmailAgentsEnabled(auth);
-    if (!isEnabled) {
-      return;
-    }
-
-    const email = reconstructEmailFromContext(context);
-    const htmlContent =
-      `<p>Error running agent:</p>\n` +
-      `<p>${sanitizeHtml(errorMessage, { allowedTags: [], allowedAttributes: {} })}</p>\n`;
-
-    await replyToEmail({
-      email,
-      htmlContent,
-      recipient: context.fromEmail,
-    });
-
-    logger.info(
-      {
-        agentMessageId: agentLoopArgs.agentMessageId,
-        to: context.fromEmail,
-        errorMessage,
-      },
-      "[email] Sent error email reply"
-    );
-  } catch (err) {
-    logger.warn(
-      {
-        err,
-        agentMessageId: agentLoopArgs.agentMessageId,
-      },
-      "[email] Failed to send error email reply, skipping"
-    );
+  if (agentLoopArgs.userMessageOrigin !== "email") {
+    return;
   }
+
+  const context = await getEmailReplyContext(
+    workspaceId,
+    agentLoopArgs.agentMessageId
+  );
+  if (!context) {
+    logger.info(
+      { agentMessageId: agentLoopArgs.agentMessageId },
+      "[email] No email reply context found for error reply, skipping"
+    );
+    return;
+  }
+
+  await deleteEmailReplyContext(workspaceId, agentLoopArgs.agentMessageId);
+
+  const isEnabled = await isEmailAgentsEnabled(auth);
+  if (!isEnabled) {
+    return;
+  }
+
+  const email = reconstructEmailFromContext(context);
+  const htmlContent =
+    `<p>Error running agent:</p>\n` +
+    `<p>${sanitizeHtml(errorMessage, { allowedTags: [], allowedAttributes: {} })}</p>\n`;
+
+  await replyToEmail({
+    email,
+    htmlContent,
+    recipient: context.fromEmail,
+  });
+
+  logger.info(
+    {
+      agentMessageId: agentLoopArgs.agentMessageId,
+      to: context.fromEmail,
+      errorMessage,
+    },
+    "[email] Sent error email reply"
+  );
 }

--- a/front/temporal/agent_loop/activities/analytics.ts
+++ b/front/temporal/agent_loop/activities/analytics.ts
@@ -1,5 +1,4 @@
-import { getWorkspaceInfos } from "@app/lib/api/workspace";
-import type { AuthenticatorType } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { launchStoreAgentAnalyticsWorkflow } from "@app/temporal/analytics_queue/client";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
@@ -8,22 +7,11 @@ import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
  * Launch agent message analytics workflow in fire-and-forget mode.
  */
 export async function launchAgentMessageAnalytics(
-  authType: AuthenticatorType,
+  auth: Authenticator,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
-  // Use `getWorkspaceInfos` for lightweight workspace info.
-  const owner = await getWorkspaceInfos(authType.workspaceId);
-  if (!owner) {
-    logger.warn(
-      { workspaceId: authType.workspaceId },
-      "Failed to fetch workspace infos for agent message analytics"
-    );
-
-    return;
-  }
-
   const result = await launchStoreAgentAnalyticsWorkflow({
-    authType,
+    authType: auth.toJSON(),
     agentLoopArgs,
   });
 
@@ -32,7 +20,7 @@ export async function launchAgentMessageAnalytics(
       {
         agentMessageId: agentLoopArgs.agentMessageId,
         error: result.error,
-        workspaceId: authType.workspaceId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
       },
       "Failed to launch agent message analytics workflow"
     );

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -11,7 +11,7 @@ import {
   notifyWorkflowError,
 } from "@app/temporal/agent_loop/activities/common";
 import { handleMentions } from "@app/temporal/agent_loop/activities/mentions";
-import { conversationUnreadNotificationActivity } from "@app/temporal/agent_loop/activities/notification";
+import { conversationUnreadNotification } from "@app/temporal/agent_loop/activities/notification";
 import { snapshotAgentMessageSkills } from "@app/temporal/agent_loop/activities/snapshot_skills";
 import {
   launchEmitMetronomeUsageEvents,
@@ -27,15 +27,16 @@ export async function finalizeSuccessfulAgentLoopActivity(
   if (authResult.isErr()) {
     return;
   }
+  const auth = authResult.value;
 
   await Promise.all([
-    snapshotAgentMessageSkills(authType, agentLoopArgs),
-    launchAgentMessageAnalytics(authType, agentLoopArgs),
-    launchTrackProgrammaticUsage(authType, agentLoopArgs),
-    launchEmitMetronomeUsageEvents(authType, agentLoopArgs),
-    conversationUnreadNotificationActivity(authType, agentLoopArgs),
-    handleMentions(authType, agentLoopArgs),
-    sendEmailReplyOnCompletion(authType, agentLoopArgs),
+    snapshotAgentMessageSkills(auth, agentLoopArgs),
+    launchAgentMessageAnalytics(auth, agentLoopArgs),
+    launchTrackProgrammaticUsage(auth, agentLoopArgs),
+    launchEmitMetronomeUsageEvents(auth, agentLoopArgs),
+    conversationUnreadNotification(auth, agentLoopArgs),
+    handleMentions(auth, agentLoopArgs),
+    sendEmailReplyOnCompletion(auth, agentLoopArgs),
   ]);
 }
 
@@ -51,14 +52,20 @@ export async function finalizeGracefullyStoppedAgentLoopActivity(
 ): Promise<void> {
   await finalizeGracefulStop(authType, agentLoopArgs);
 
-  await Promise.all([
-    snapshotAgentMessageSkills(authType, agentLoopArgs),
-    launchAgentMessageAnalytics(authType, agentLoopArgs),
-    launchTrackProgrammaticUsage(authType, agentLoopArgs),
-    launchEmitMetronomeUsageEvents(authType, agentLoopArgs),
+  const authResult = await Authenticator.fromJSON(authType);
+  if (authResult.isErr()) {
+    return;
+  }
+  const auth = authResult.value;
 
-    conversationUnreadNotificationActivity(authType, agentLoopArgs),
-    handleMentions(authType, agentLoopArgs),
+  await Promise.all([
+    snapshotAgentMessageSkills(auth, agentLoopArgs),
+    launchAgentMessageAnalytics(auth, agentLoopArgs),
+    launchTrackProgrammaticUsage(auth, agentLoopArgs),
+    launchEmitMetronomeUsageEvents(auth, agentLoopArgs),
+
+    conversationUnreadNotification(auth, agentLoopArgs),
+    handleMentions(auth, agentLoopArgs),
   ]);
 }
 
@@ -76,13 +83,19 @@ export async function finalizeInterruptedAgentLoopActivity(
 ): Promise<void> {
   await finalizeInterruption(authType, agentLoopArgs);
 
+  const authResult = await Authenticator.fromJSON(authType);
+  if (authResult.isErr()) {
+    return;
+  }
+  const auth = authResult.value;
+
   await Promise.all([
-    snapshotAgentMessageSkills(authType, agentLoopArgs),
-    launchAgentMessageAnalytics(authType, agentLoopArgs),
-    launchTrackProgrammaticUsage(authType, agentLoopArgs),
-    launchEmitMetronomeUsageEvents(authType, agentLoopArgs),
-    conversationUnreadNotificationActivity(authType, agentLoopArgs),
-    handleMentions(authType, agentLoopArgs),
+    snapshotAgentMessageSkills(auth, agentLoopArgs),
+    launchAgentMessageAnalytics(auth, agentLoopArgs),
+    launchTrackProgrammaticUsage(auth, agentLoopArgs),
+    launchEmitMetronomeUsageEvents(auth, agentLoopArgs),
+    conversationUnreadNotification(auth, agentLoopArgs),
+    handleMentions(auth, agentLoopArgs),
   ]);
 }
 
@@ -92,13 +105,19 @@ export async function finalizeCancelledAgentLoopActivity(
 ): Promise<void> {
   await finalizeCancellation(authType, agentLoopArgs);
 
+  const authResult = await Authenticator.fromJSON(authType);
+  if (authResult.isErr()) {
+    return;
+  }
+  const auth = authResult.value;
+
   await Promise.all([
-    snapshotAgentMessageSkills(authType, agentLoopArgs),
-    launchAgentMessageAnalytics(authType, agentLoopArgs),
-    launchTrackProgrammaticUsage(authType, agentLoopArgs),
-    launchEmitMetronomeUsageEvents(authType, agentLoopArgs),
+    snapshotAgentMessageSkills(auth, agentLoopArgs),
+    launchAgentMessageAnalytics(auth, agentLoopArgs),
+    launchTrackProgrammaticUsage(auth, agentLoopArgs),
+    launchEmitMetronomeUsageEvents(auth, agentLoopArgs),
     sendEmailReplyOnError(
-      authType,
+      auth,
       agentLoopArgs,
       "Agent execution was cancelled."
     ),
@@ -112,13 +131,19 @@ export async function finalizeErroredAgentLoopActivity(
 ): Promise<void> {
   await notifyWorkflowError(authType, agentLoopArgs, error);
 
+  const authResult = await Authenticator.fromJSON(authType);
+  if (authResult.isErr()) {
+    return;
+  }
+  const auth = authResult.value;
+
   await Promise.all([
-    snapshotAgentMessageSkills(authType, agentLoopArgs),
-    launchAgentMessageAnalytics(authType, agentLoopArgs),
-    launchTrackProgrammaticUsage(authType, agentLoopArgs),
-    launchEmitMetronomeUsageEvents(authType, agentLoopArgs),
+    snapshotAgentMessageSkills(auth, agentLoopArgs),
+    launchAgentMessageAnalytics(auth, agentLoopArgs),
+    launchTrackProgrammaticUsage(auth, agentLoopArgs),
+    launchEmitMetronomeUsageEvents(auth, agentLoopArgs),
     sendEmailReplyOnError(
-      authType,
+      auth,
       agentLoopArgs,
       `Agent execution failed: ${error.message}`
     ),

--- a/front/temporal/agent_loop/activities/mentions.ts
+++ b/front/temporal/agent_loop/activities/mentions.ts
@@ -1,5 +1,4 @@
-import { getWorkspaceInfos } from "@app/lib/api/workspace";
-import type { AuthenticatorType } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { launchHandleMentionsWorkflow } from "@app/temporal/mentions_queue/client";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
@@ -8,21 +7,11 @@ import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
  * Launch mentions workflow in fire-and-forget mode.
  */
 export async function handleMentions(
-  authType: AuthenticatorType,
+  auth: Authenticator,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
-  // Use `getWorkspaceInfos` for lightweight workspace info.
-  const owner = await getWorkspaceInfos(authType.workspaceId);
-  if (!owner) {
-    logger.warn(
-      { workspaceId: authType.workspaceId },
-      "Failed to fetch workspace infos for mentions"
-    );
-    return;
-  }
-
   const result = await launchHandleMentionsWorkflow({
-    authType,
+    authType: auth.toJSON(),
     agentLoopArgs,
   });
 
@@ -31,7 +20,7 @@ export async function handleMentions(
       {
         agentMessageId: agentLoopArgs.agentMessageId,
         error: result.error,
-        workspaceId: authType.workspaceId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
       },
       "Failed to launch mentions workflow"
     );

--- a/front/temporal/agent_loop/activities/notification.ts
+++ b/front/temporal/agent_loop/activities/notification.ts
@@ -1,5 +1,4 @@
-import { getWorkspaceInfos } from "@app/lib/api/workspace";
-import type { AuthenticatorType } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { launchConversationUnreadNotificationWorkflow } from "@app/temporal/notifications_queue/client";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
@@ -7,22 +6,12 @@ import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 /**
  * Launch conversation unread notification activity.
  */
-export async function conversationUnreadNotificationActivity(
-  authType: AuthenticatorType,
+export async function conversationUnreadNotification(
+  auth: Authenticator,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
-  // Use `getWorkspaceInfos` for lightweight workspace info.
-  const owner = await getWorkspaceInfos(authType.workspaceId);
-  if (!owner) {
-    logger.warn(
-      { workspaceId: authType.workspaceId },
-      "Failed to fetch workspace infos for conversation unread notification"
-    );
-    return;
-  }
-
   const result = await launchConversationUnreadNotificationWorkflow({
-    authType,
+    authType: auth.toJSON(),
     agentLoopArgs,
   });
 
@@ -31,7 +20,7 @@ export async function conversationUnreadNotificationActivity(
       {
         agentMessageId: agentLoopArgs.agentMessageId,
         error: result.error,
-        workspaceId: authType.workspaceId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
       },
       "Failed to launch conversation unread notification workflow"
     );

--- a/front/temporal/agent_loop/activities/snapshot_skills.ts
+++ b/front/temporal/agent_loop/activities/snapshot_skills.ts
@@ -1,5 +1,4 @@
-import type { AuthenticatorType } from "@app/lib/auth";
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import {
   AgentMessageModel,
   MessageModel,
@@ -8,15 +7,9 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 
 export async function snapshotAgentMessageSkills(
-  authType: AuthenticatorType,
+  auth: Authenticator,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
-  const authResult = await Authenticator.fromJSON(authType);
-  if (authResult.isErr()) {
-    return;
-  }
-
-  const auth = authResult.value;
   const owner = auth.getNonNullableWorkspace();
 
   const { agentMessageId } = agentLoopArgs;

--- a/front/temporal/agent_loop/activities/usage_tracking.ts
+++ b/front/temporal/agent_loop/activities/usage_tracking.ts
@@ -1,5 +1,4 @@
-import { getWorkspaceInfos } from "@app/lib/api/workspace";
-import type { AuthenticatorType } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import {
   launchEmitMetronomeUsageEventsWorkflow,
@@ -11,21 +10,11 @@ import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
  * Launch agent message analytics workflow in fire-and-forget mode.
  */
 export async function launchTrackProgrammaticUsage(
-  authType: AuthenticatorType,
+  auth: Authenticator,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
-  // Use `getWorkspaceInfos` for lightweight workspace info.
-  const owner = await getWorkspaceInfos(authType.workspaceId);
-  if (!owner) {
-    logger.warn(
-      { workspaceId: authType.workspaceId },
-      "Failed to fetch workspace infos for agent message analytics"
-    );
-    return;
-  }
-
   const result = await launchTrackProgrammaticUsageWorkflow({
-    authType,
+    authType: auth.toJSON(),
     agentLoopArgs,
   });
 
@@ -34,7 +23,7 @@ export async function launchTrackProgrammaticUsage(
       {
         agentMessageId: agentLoopArgs.agentMessageId,
         error: result.error,
-        workspaceId: authType.workspaceId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
       },
       "Failed to launch agent message analytics workflow"
     );
@@ -46,16 +35,15 @@ export async function launchTrackProgrammaticUsage(
  * Only starts if the workspace has a metronomeCustomerId (i.e. is provisioned in Metronome).
  */
 export async function launchEmitMetronomeUsageEvents(
-  authType: AuthenticatorType,
+  auth: Authenticator,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
-  const owner = await getWorkspaceInfos(authType.workspaceId);
-  if (!owner?.metronomeCustomerId) {
+  if (!auth.getNonNullableWorkspace().metronomeCustomerId) {
     return;
   }
 
   const result = await launchEmitMetronomeUsageEventsWorkflow({
-    authType,
+    authType: auth.toJSON(),
     agentLoopArgs,
   });
 
@@ -64,7 +52,7 @@ export async function launchEmitMetronomeUsageEvents(
       {
         agentMessageId: agentLoopArgs.agentMessageId,
         error: result.error,
-        workspaceId: authType.workspaceId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
       },
       "[Metronome] Failed to launch usage events workflow"
     );

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -112,7 +112,6 @@ async function reportSelfImprovingSkillsStepUsage({
     return;
   }
 
-  const authType = auth.toJSON();
   // Reinforcement messages are created with default version 0 and are never
   // retried at a higher version (Temporal retries create new message sIds).
   const agentLoopArgs: AgentLoopArgs = {
@@ -129,9 +128,9 @@ async function reportSelfImprovingSkillsStepUsage({
 
   try {
     await Promise.all([
-      launchAgentMessageAnalytics(authType, agentLoopArgs),
-      launchTrackProgrammaticUsage(authType, agentLoopArgs),
-      launchEmitMetronomeUsageEvents(authType, agentLoopArgs),
+      launchAgentMessageAnalytics(auth, agentLoopArgs),
+      launchTrackProgrammaticUsage(auth, agentLoopArgs),
+      launchEmitMetronomeUsageEvents(auth, agentLoopArgs),
     ]);
   } catch (err) {
     logger.warn(


### PR DESCRIPTION
## Description

- We are fetching the exact same row from `workspaces` several times in each `finalizeXxxAgentLoopActivity`.
- This PR prevents this by fetching the authenticator once (fetched anyway as it's required for `snapshotAgentMessageSkills`) and passing it down.
- Also removes a try catch in email processing, checked the log [here](https://app.datadoghq.eu/logs?query=%22%5Bemail%5D%20Failed%20to%20send%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1778085606915&to_ts=1779381606915&live=true).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front