### PR TITLE
Inline the PDF footer logo SVG to fix path resolution in front-api

### DIFF
--- a/front/lib/api/files/pdf_footer.ts
+++ b/front/lib/api/files/pdf_footer.ts
@@ -1,28 +1,15 @@
-import logger from "@app/logger/logger";
-import fs from "fs";
-import path from "path";
-
-// Resolved relative to this file so the lookup works regardless of the
-// process' cwd (front/, front-api/, tests, …).
-const LOGO_PATH = path.resolve(
-  __dirname,
-  "../../../public/static/landing/logos/dust/Dust_LogoSquare.svg"
-);
-
-// Read logo SVG once at module load time (not per request).
-// Falls back to empty string if file is missing - footer still works, just no logo.
-function loadLogoSvg(): string {
-  try {
-    return fs
-      .readFileSync(LOGO_PATH, "utf-8")
-      .replace(/width="48" height="48"/, 'width="16" height="16"');
-  } catch (err) {
-    logger.error({ err, path: LOGO_PATH }, "Failed to load PDF footer logo!");
-    return "";
-  }
-}
-
-const logoSvg = loadLogoSvg();
+// 16x16 inline version of public/static/landing/logos/dust/Dust_LogoSquare.svg.
+// Inlined to avoid bundler-dependent __dirname / cwd path resolution across
+// front (Next.js standalone) and front-api (esbuild bundle).
+const logoSvg = `<svg width="16" height="16" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M36 24H24V48H36V24Z" fill="#FE9C1A"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M12 36C8.68629 36 6 33.3137 6 30C6 26.6863 8.68629 24 12 24H48V36H12Z" fill="#3B82F6"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 48V36H12C15.3137 36 18 38.6863 18 42C18 45.3137 15.3137 48 12 48H0Z" fill="#9FDBFF"/>
+<path d="M12 24C18.6274 24 24 18.6274 24 12C24 5.37258 18.6274 0 12 0C5.37258 0 0 5.37258 0 12C0 18.6274 5.37258 24 12 24Z" fill="#E2F78C"/>
+<path d="M36 24C42.6274 24 48 18.6274 48 12C48 5.37258 42.6274 0 36 0C29.3726 0 24 5.37258 24 12C24 18.6274 29.3726 24 36 24Z" fill="#FFC3DF"/>
+<path d="M12 0H0V24H12V0Z" fill="#418B5C"/>
+<path d="M48 0H24V12H48V0Z" fill="#E14322"/>
+</svg>`;
 
 export const PDF_FOOTER_HTML = `<!DOCTYPE html>
 <html>


### PR DESCRIPTION
## Description

  The PDF footer for Frame exports references the Dust logo via
  `path.resolve(__dirname, "../../../public/static/landing/logos/dust/Dust_LogoSquare.svg")`
  in `lib/api/files/pdf_footer.ts`. This works locally and in the front
  (Next.js standalone) image, but fails in **front-api** at runtime with:

  ENOENT: no such file or directory, open '/public/static/landing/logos/dust/Dust_LogoSquare.svg'

 ### Root cause

  front-api is bundled by esbuild into a single `dist/server.js`
  (`front-api/esbuild.server.ts`). At runtime, `__dirname` for code inside that
  bundle is the bundle's output directory — `/app/front-api/dist` — not the
  source location. Going up three levels lands at `/`, so the resolved path
  becomes `/public/static/landing/logos/dust/Dust_LogoSquare.svg`.

  The original `process.cwd()`-based code from before #25897 had the symmetric
  problem: cwd is `/app/front-api` in the front-api image, not `/app/front`.

 ### Fix

  Inline the SVG (800 bytes, loaded once at module init, never changes at
  runtime) directly into `pdf_footer.ts`, with the dimensions already adjusted
  to 16x16. Removes the `fs` / `path` / `__dirname` / `logger` machinery and
  the whole class of bundler-vs-path-resolution bugs that goes with it.

  Affected feature: **Frame export to PDF** — both the `Export to PDF` button
  and the agent-initiated `interactive_content` MCP tool. The footer renders
  the Dust logo + "Created with Dust" tagline at the bottom of generated PDFs
  for non-Enterprise plans.

## Tests

I'm not set up to test PDFs locally

## Risk

Could conceivably break PDFs, will need to monitor

## Deploy Plan

Front