### PR TITLE
[slim-api] Migrate poke plugins & analytics routes

### DIFF
--- a/front-api/routes/poke/plugins/[pluginId]/async-args.ts
+++ b/front-api/routes/poke/plugins/[pluginId]/async-args.ts
@@ -1,11 +1,8 @@
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
 import { fetchPluginResource } from "@app/lib/api/poke/utils";
 import { Authenticator } from "@app/lib/auth";
-import type {
-  AsyncEnumValues,
-  EnumValues,
-  SupportedResourceType,
-} from "@app/types/poke/plugins";
+import type { AsyncEnumValues, EnumValues } from "@app/types/poke/plugins";
+import { supportedResourceTypes } from "@app/types/poke/plugins";
 import { apiError, type HandlerResult } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
 import { Hono } from "hono";
@@ -19,7 +16,7 @@ export interface PokeGetPluginAsyncArgsResponseBody {
 }
 
 const AsyncArgsQuerySchema = z.object({
-  resourceType: z.string(),
+  resourceType: z.enum(supportedResourceTypes),
   resourceId: z.string().optional(),
   workspaceId: z.string().optional(),
 });
@@ -87,11 +84,7 @@ app.get(
 
     let resource = null;
     if (resourceId) {
-      resource = await fetchPluginResource(
-        auth,
-        resourceType as SupportedResourceType,
-        resourceId
-      );
+      resource = await fetchPluginResource(auth, resourceType, resourceId);
       if (!resource) {
         return apiError(ctx, {
           status_code: 404,

--- a/front-api/routes/poke/plugins/[pluginId]/async-args.ts
+++ b/front-api/routes/poke/plugins/[pluginId]/async-args.ts
@@ -1,0 +1,121 @@
+import { pluginManager } from "@app/lib/api/poke/plugin_manager";
+import { fetchPluginResource } from "@app/lib/api/poke/utils";
+import { Authenticator } from "@app/lib/auth";
+import type {
+  AsyncEnumValues,
+  EnumValues,
+  SupportedResourceType,
+} from "@app/types/poke/plugins";
+import { apiError, type HandlerResult } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+import { Hono } from "hono";
+import { z } from "zod";
+
+export interface PokeGetPluginAsyncArgsResponseBody {
+  asyncArgs: Record<
+    string,
+    string | number | boolean | AsyncEnumValues | EnumValues
+  >;
+}
+
+const AsyncArgsQuerySchema = z.object({
+  resourceType: z.string(),
+  resourceId: z.string().optional(),
+  workspaceId: z.string().optional(),
+});
+
+// Mounted at /api/poke/plugins/:pluginId/async-args.
+const app = new Hono();
+
+app.get(
+  "/",
+  validate("query", AsyncArgsQuerySchema),
+  async (ctx): HandlerResult<PokeGetPluginAsyncArgsResponseBody> => {
+    const pluginId = ctx.req.param("pluginId");
+    if (!pluginId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Missing `pluginId` in path.",
+        },
+      });
+    }
+
+    const { resourceType, resourceId, workspaceId } = ctx.req.valid("query");
+
+    const plugin = pluginManager.getPluginById(pluginId);
+    if (!plugin) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "plugin_not_found",
+          message: "Could not find the plugin.",
+        },
+      });
+    }
+
+    const hasAsyncFields = Object.values(plugin.manifest.args).some(
+      (arg) => arg.async === true
+    );
+    if (!hasAsyncFields) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Plugin does not have any async fields defined.",
+        },
+      });
+    }
+
+    if (!plugin.populateAsyncArgs) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message:
+            "Plugin has async fields but missing populateAsyncArgs implementation. This should not happen with proper TypeScript validation.",
+        },
+      });
+    }
+
+    let auth = ctx.get("auth");
+    if (workspaceId) {
+      const session = ctx.get("session");
+      auth = await Authenticator.fromSuperUserSession(session, workspaceId);
+    }
+
+    let resource = null;
+    if (resourceId) {
+      resource = await fetchPluginResource(
+        auth,
+        resourceType as SupportedResourceType,
+        resourceId
+      );
+      if (!resource) {
+        return apiError(ctx, {
+          status_code: 404,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Could not find the resource.",
+          },
+        });
+      }
+    }
+
+    const asyncArgsResult = await plugin.populateAsyncArgs(auth, resource);
+    if (asyncArgsResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to populate async args: ${asyncArgsResult.error.message}`,
+        },
+      });
+    }
+
+    return ctx.json({ asyncArgs: asyncArgsResult.value });
+  }
+);
+
+export default app;

--- a/front-api/routes/poke/plugins/[pluginId]/index.ts
+++ b/front-api/routes/poke/plugins/[pluginId]/index.ts
@@ -1,9 +1,13 @@
 import { Hono } from "hono";
 
+import asyncArgs from "./async-args";
 import manifest from "./manifest";
+import run from "./run";
 
 const app = new Hono();
 
+app.route("/async-args", asyncArgs);
 app.route("/manifest", manifest);
+app.route("/run", run);
 
 export default app;

--- a/front-api/routes/poke/plugins/[pluginId]/run.ts
+++ b/front-api/routes/poke/plugins/[pluginId]/run.ts
@@ -14,10 +14,26 @@ import {
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { apiError, type HandlerResult } from "@front-api/middleware/utils";
 import { validate } from "@front-api/middleware/validator";
-import type formidable from "formidable";
 import { Hono } from "hono";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
+
+// Subset of `formidable.File` that poke plugins consume from file args
+// (the plugin Zod schema declares files as `z.any()`, so this is the
+// runtime contract). Used to bridge Web `File` to formidable-style on the
+// multipart path without an `as` cast.
+interface BridgedFormidableFile {
+  filepath: string;
+  originalFilename: string | null;
+  size: number;
+  newFilename: string;
+  mimetype: string | null;
+  hash: null;
+  hashAlgorithm: false;
+  mtime: null;
+  toJSON: () => Record<string, never>;
+  toString: () => string;
+}
 
 const RunPluginQuerySchema = z.object({
   resourceType: z.enum(supportedResourceTypes),
@@ -83,11 +99,14 @@ app.post(
       : null;
 
     const contentType = ctx.req.header("content-type") ?? "";
-    let formData: Record<string, unknown>;
+    // Typed as `unknown` because the real validation boundary is
+    // `pluginSchema.safeParse` below — no point pretending the JSON body
+    // is more structured than it is at this point.
+    let formData: unknown;
 
     if (contentType.includes("application/json")) {
       try {
-        formData = (await ctx.req.json()) as Record<string, unknown>;
+        formData = await ctx.req.json();
       } catch {
         return apiError(ctx, {
           status_code: 400,
@@ -116,7 +135,7 @@ app.post(
 
       // Bridge Web `File` instances to a formidable.File-like shape so
       // existing plugins that read `file.filepath` keep working unchanged.
-      const bridged: Record<string, unknown> = {};
+      const bridged: Record<string, BridgedFormidableFile | string> = {};
       let tmpDir: string | null = null;
       let fileIndex = 0;
       for (const [key, value] of Object.entries(parsed)) {
@@ -136,9 +155,9 @@ app.post(
             hash: null,
             hashAlgorithm: false,
             mtime: null,
-            toJSON: () => ({}) as never,
+            toJSON: () => ({}),
             toString: () => filepath,
-          } as unknown as formidable.File;
+          };
         } else {
           bridged[key] = value;
         }

--- a/front-api/routes/poke/plugins/[pluginId]/run.ts
+++ b/front-api/routes/poke/plugins/[pluginId]/run.ts
@@ -1,0 +1,213 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pluginManager } from "@app/lib/api/poke/plugin_manager";
+import type { PluginResponse } from "@app/lib/api/poke/types";
+import { fetchPluginResource } from "@app/lib/api/poke/utils";
+import { Authenticator } from "@app/lib/auth";
+import { PluginRunResource } from "@app/lib/resources/plugin_run_resource";
+import { getClientIp } from "@app/lib/utils/request";
+import {
+  createZodSchemaFromArgs,
+  supportedResourceTypes,
+} from "@app/types/poke/plugins";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { apiError, type HandlerResult } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+import type formidable from "formidable";
+import { Hono } from "hono";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+const RunPluginQuerySchema = z.object({
+  resourceType: z.enum(supportedResourceTypes),
+  resourceId: z.string().optional(),
+  workspaceId: z.string().optional(),
+});
+
+export interface PokeRunPluginResponseBody {
+  result: PluginResponse;
+}
+
+// Mounted at /api/poke/plugins/:pluginId/run.
+const app = new Hono();
+
+app.post(
+  "/",
+  validate("query", RunPluginQuerySchema),
+  async (ctx): HandlerResult<PokeRunPluginResponseBody> => {
+    const pluginId = ctx.req.param("pluginId");
+    if (!pluginId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Missing `pluginId` in path.",
+        },
+      });
+    }
+
+    const { resourceType, resourceId, workspaceId } = ctx.req.valid("query");
+
+    const headers: Record<string, string | string[] | undefined> = {};
+    ctx.req.raw.headers.forEach((value, key) => {
+      headers[key] = value;
+    });
+    const ip = getClientIp({ headers });
+
+    let auth = ctx.get("auth");
+    if (ip !== "internal") {
+      auth.setClientIp(ip);
+    }
+    if (workspaceId) {
+      const session = ctx.get("session");
+      auth = await Authenticator.fromSuperUserSession(session, workspaceId);
+      if (ip !== "internal") {
+        auth.setClientIp(ip);
+      }
+    }
+
+    const plugin = pluginManager.getPluginById(pluginId);
+    if (!plugin) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "plugin_not_found",
+          message: "Could not find the plugin.",
+        },
+      });
+    }
+
+    const resource = resourceId
+      ? await fetchPluginResource(auth, resourceType, resourceId)
+      : null;
+
+    const contentType = ctx.req.header("content-type") ?? "";
+    let formData: Record<string, unknown>;
+
+    if (contentType.includes("application/json")) {
+      try {
+        formData = (await ctx.req.json()) as Record<string, unknown>;
+      } catch {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Invalid JSON in request body",
+          },
+        });
+      }
+    } else if (
+      contentType.includes("multipart/form-data") ||
+      contentType.includes("application/x-www-form-urlencoded")
+    ) {
+      let parsed: Record<string, string | File>;
+      try {
+        parsed = await ctx.req.parseBody();
+      } catch (err) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Form parsing failed: ${normalizeError(err).message}`,
+          },
+        });
+      }
+
+      // Bridge Web `File` instances to a formidable.File-like shape so
+      // existing plugins that read `file.filepath` keep working unchanged.
+      const bridged: Record<string, unknown> = {};
+      let tmpDir: string | null = null;
+      let fileIndex = 0;
+      for (const [key, value] of Object.entries(parsed)) {
+        if (value instanceof File) {
+          if (!tmpDir) {
+            tmpDir = await mkdtemp(join(tmpdir(), "poke-plugin-run-"));
+          }
+          const filename = `upload-${fileIndex++}`;
+          const filepath = join(tmpDir, filename);
+          await writeFile(filepath, Buffer.from(await value.arrayBuffer()));
+          bridged[key] = {
+            filepath,
+            originalFilename: value.name || null,
+            size: value.size,
+            newFilename: filename,
+            mimetype: value.type || null,
+            hash: null,
+            hashAlgorithm: false,
+            mtime: null,
+            toJSON: () => ({}) as never,
+            toString: () => filepath,
+          } as unknown as formidable.File;
+        } else {
+          bridged[key] = value;
+        }
+      }
+      formData = bridged;
+    } else {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "Unsupported content type. Expected application/json, application/x-www-form-urlencoded or multipart/form-data",
+        },
+      });
+    }
+
+    const pluginSchema = createZodSchemaFromArgs(plugin.manifest.args);
+    const pluginArgsValidation = pluginSchema.safeParse(formData);
+    if (!pluginArgsValidation.success) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `The request body is invalid: ${fromError(pluginArgsValidation.error).toString()}`,
+        },
+      });
+    }
+
+    const pluginRun = await PluginRunResource.makeNew(
+      plugin,
+      pluginArgsValidation.data,
+      auth.getNonNullableUser(),
+      workspaceId ? auth.getNonNullableWorkspace() : null,
+      {
+        resourceId: resourceId ?? undefined,
+        resourceType,
+      }
+    );
+
+    let runRes;
+    try {
+      runRes = await plugin.execute(auth, resource, pluginArgsValidation.data);
+    } catch (error) {
+      const errorMessage = normalizeError(error).message;
+      await pluginRun.recordError(errorMessage);
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "plugin_execution_failed",
+          message: errorMessage,
+        },
+      });
+    }
+
+    if (runRes.isErr()) {
+      await pluginRun.recordError(runRes.error.message);
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "plugin_execution_failed",
+          message: runRes.error.message,
+        },
+      });
+    }
+
+    await pluginRun.recordResult(runRes.value, plugin);
+
+    return ctx.json({ result: runRes.value });
+  }
+);
+
+export default app;

--- a/front-api/routes/poke/plugins/index.ts
+++ b/front-api/routes/poke/plugins/index.ts
@@ -1,9 +1,69 @@
+import { pluginManager } from "@app/lib/api/poke/plugin_manager";
+import type { PluginListItem } from "@app/lib/api/poke/types";
+import { fetchPluginResource } from "@app/lib/api/poke/utils";
+import { Authenticator } from "@app/lib/auth";
+import { isSupportedResourceType } from "@app/types/poke/plugins";
+import type { HandlerResult } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
 import { Hono } from "hono";
+import { z } from "zod";
 
 import pluginId from "./[pluginId]";
+import runs from "./runs";
 
+export interface PokeListPluginsForScopeResponseBody {
+  plugins: PluginListItem[];
+}
+
+const ListPluginsQuerySchema = z.object({
+  resourceType: z.string().refine(isSupportedResourceType, {
+    message: "Invalid resource type.",
+  }),
+  resourceId: z.string().optional(),
+  workspaceId: z.string().optional(),
+});
+
+// Mounted at /api/poke/plugins.
 const app = new Hono();
 
+app.get(
+  "/",
+  validate("query", ListPluginsQuerySchema),
+  async (ctx): HandlerResult<PokeListPluginsForScopeResponseBody> => {
+    const { resourceType, resourceId, workspaceId } = ctx.req.valid("query");
+
+    let auth = ctx.get("auth");
+    if (workspaceId) {
+      const session = ctx.get("session");
+      auth = await Authenticator.fromSuperUserSession(session, workspaceId);
+    }
+
+    const workspace = auth.workspace();
+    const maintenance = workspace?.metadata?.maintenance;
+
+    const plugins = pluginManager.getPluginsForResourceType(resourceType);
+
+    const resource = resourceId
+      ? await fetchPluginResource(auth, resourceType, resourceId)
+      : null;
+
+    const pluginList = plugins
+      .filter((p) => !resourceId || p.isApplicableTo(auth, resource))
+      .filter((p) => !p.manifest.isHidden)
+      // During maintenance, only show readonly plugins.
+      .filter((p) => !maintenance || p.manifest.readonly)
+      .map((p) => ({
+        id: p.manifest.id,
+        name: p.manifest.name,
+        description: p.manifest.description,
+        readonly: p.manifest.readonly,
+      }));
+
+    return ctx.json({ plugins: pluginList });
+  }
+);
+
+app.route("/runs", runs);
 app.route("/:pluginId", pluginId);
 
 export default app;

--- a/front-api/routes/poke/plugins/runs.ts
+++ b/front-api/routes/poke/plugins/runs.ts
@@ -1,0 +1,55 @@
+import { Authenticator } from "@app/lib/auth";
+import { PluginRunResource } from "@app/lib/resources/plugin_run_resource";
+import type { PluginRunType } from "@app/types/poke/plugins";
+import type { HandlerResult } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+import { Hono } from "hono";
+import { z } from "zod";
+
+export interface PokeListPluginRunsResponseBody {
+  pluginRuns: PluginRunType[];
+}
+
+const ListPluginRunsQuerySchema = z.object({
+  workspaceId: z.string().optional(),
+  resourceType: z.string().optional(),
+  resourceId: z.string().optional(),
+});
+
+// Mounted at /api/poke/plugins/runs.
+const app = new Hono();
+
+app.get(
+  "/",
+  validate("query", ListPluginRunsQuerySchema),
+  async (ctx): HandlerResult<PokeListPluginRunsResponseBody> => {
+    const { workspaceId, resourceType, resourceId } = ctx.req.valid("query");
+
+    let auth = ctx.get("auth");
+    if (workspaceId) {
+      const session = ctx.get("session");
+      auth = await Authenticator.fromSuperUserSession(session, workspaceId);
+    }
+
+    let pluginRuns;
+    if (resourceType && resourceId) {
+      // Resource-level plugins: specific to a resource within a workspace.
+      pluginRuns = await PluginRunResource.findByWorkspaceAndResource(auth, {
+        resourceId,
+        resourceType,
+      });
+    } else if (workspaceId) {
+      // Workspace-level plugins: all plugins for a workspace.
+      pluginRuns = await PluginRunResource.findByWorkspaceId(auth);
+    } else {
+      // Global plugins: system-wide plugins with no workspace context.
+      pluginRuns = await PluginRunResource.findGlobalRuns();
+    }
+
+    return ctx.json({
+      pluginRuns: pluginRuns.map((run) => run.toJSON()),
+    });
+  }
+);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/analytics/active-users.ts
+++ b/front-api/routes/poke/workspaces/[wId]/analytics/active-users.ts
@@ -1,0 +1,53 @@
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import type { ActiveUsersMetricsPoint } from "@app/lib/api/assistant/observability/active_users_metrics";
+import { fetchActiveUsersMetrics } from "@app/lib/api/assistant/observability/active_users_metrics";
+import {
+  daysToDateRange,
+  timezoneSchema,
+} from "@app/lib/api/assistant/observability/utils";
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+import { Hono } from "hono";
+import { z } from "zod";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+  timezone: timezoneSchema,
+});
+
+export type PokeGetWorkspaceActiveUsersResponse = {
+  points: ActiveUsersMetricsPoint[];
+};
+
+// Mounted at /api/poke/workspaces/:wId/analytics/active-users.
+const app = new Hono();
+
+app.get("/", validate("query", QuerySchema), async (ctx) => {
+  const auth = ctx.get("auth");
+  const owner = auth.getNonNullableWorkspace();
+
+  const { days, timezone } = ctx.req.valid("query");
+
+  const { startDate, endDate } = daysToDateRange(days, timezone);
+  const result = await fetchActiveUsersMetrics(
+    owner,
+    startDate,
+    endDate,
+    timezone
+  );
+
+  if (result.isErr()) {
+    return apiError(ctx, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to retrieve active users metrics: ${result.error.message}`,
+      },
+    });
+  }
+
+  const body: PokeGetWorkspaceActiveUsersResponse = { points: result.value };
+  return ctx.json(body);
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/analytics/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/analytics/index.ts
@@ -1,0 +1,11 @@
+import { Hono } from "hono";
+
+import activeUsers from "./active-users";
+import usageMetrics from "./usage-metrics";
+
+const app = new Hono();
+
+app.route("/active-users", activeUsers);
+app.route("/usage-metrics", usageMetrics);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/analytics/usage-metrics.ts
+++ b/front-api/routes/poke/workspaces/[wId]/analytics/usage-metrics.ts
@@ -1,0 +1,69 @@
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import type {
+  MessageMetricsPoint,
+  UsageMetricsInterval,
+} from "@app/lib/api/assistant/observability/messages_metrics";
+import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
+import {
+  buildAgentAnalyticsBaseQuery,
+  timezoneSchema,
+} from "@app/lib/api/assistant/observability/utils";
+import { apiError } from "@front-api/middleware/utils";
+import { validate } from "@front-api/middleware/validator";
+import { Hono } from "hono";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+  interval: z.enum(["day", "week"]).optional().default("day"),
+  timezone: timezoneSchema,
+});
+
+export type PokeGetWorkspaceUsageMetricsResponse = {
+  interval: UsageMetricsInterval;
+  points: Pick<
+    MessageMetricsPoint,
+    "timestamp" | "count" | "conversations" | "activeUsers"
+  >[];
+};
+
+// Mounted at /api/poke/workspaces/:wId/analytics/usage-metrics.
+const app = new Hono();
+
+app.get("/", validate("query", QuerySchema), async (ctx) => {
+  const auth = ctx.get("auth");
+  const owner = auth.getNonNullableWorkspace();
+
+  const { days, interval, timezone } = ctx.req.valid("query");
+
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId: owner.sId,
+    days,
+  });
+
+  const usageMetricsResult = await fetchMessageMetrics(
+    baseQuery,
+    interval,
+    ["conversations", "activeUsers"] as const,
+    timezone
+  );
+
+  if (usageMetricsResult.isErr()) {
+    return apiError(ctx, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to retrieve usage metrics: ${fromError(usageMetricsResult.error).toString()}`,
+      },
+    });
+  }
+
+  const body: PokeGetWorkspaceUsageMetricsResponse = {
+    interval,
+    points: usageMetricsResult.value,
+  };
+  return ctx.json(body);
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/index.ts
@@ -6,6 +6,7 @@ import { validate } from "@front-api/middleware/validator";
 import { Hono } from "hono";
 import { z } from "zod";
 
+import analytics from "./analytics";
 import apps from "./apps";
 import assistants from "./assistants";
 import authContext from "./auth-context";
@@ -67,6 +68,7 @@ app.patch(
   }
 );
 
+app.route("/analytics", analytics);
 app.route("/apps", apps);
 app.route("/assistants", assistants);
 app.route("/data_retention", dataRetention);

--- a/front/pages/api/poke/plugins/[pluginId]/async-args.ts
+++ b/front/pages/api/poke/plugins/[pluginId]/async-args.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
 import { fetchPluginResource } from "@app/lib/api/poke/utils";

--- a/front/pages/api/poke/plugins/[pluginId]/run.ts
+++ b/front/pages/api/poke/plugins/[pluginId]/run.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
 import type { PluginResponse } from "@app/lib/api/poke/types";

--- a/front/pages/api/poke/plugins/index.ts
+++ b/front/pages/api/poke/plugins/index.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
 import type { PluginListItem } from "@app/lib/api/poke/types";

--- a/front/pages/api/poke/plugins/runs.ts
+++ b/front/pages/api/poke/plugins/runs.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";

--- a/front/pages/api/poke/workspaces/[wId]/analytics/active-users.ts
+++ b/front/pages/api/poke/workspaces/[wId]/analytics/active-users.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { fetchActiveUsersMetrics } from "@app/lib/api/assistant/observability/active_users_metrics";
 import {

--- a/front/pages/api/poke/workspaces/[wId]/analytics/usage-metrics.ts
+++ b/front/pages/api/poke/workspaces/[wId]/analytics/usage-metrics.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
 import {


### PR DESCRIPTION
## Description
Migrates the remaining poke plugin routes plus two simple poke analytics
routes to Hono.

Poke plugin routes (4):
- GET  /api/poke/plugins/                       (list plugins for a resource scope)
- GET  /api/poke/plugins/runs                   (list plugin runs)
- GET  /api/poke/plugins/:pluginId/async-args
- POST /api/poke/plugins/:pluginId/run

All four share an optional workspaceId re-resolution pattern: pokeAuth
gives a workspace-less Authenticator, and if the request targets a
specific workspace, the handler re-resolves a workspace-scoped one
inline using the session stashed on ctx by pokeAuth (no second WorkOS
round trip).

The /run handler drops the Next bodyParser bypass + formidable
IncomingForm in favor of Hono's native ctx.req.parseBody() /
ctx.req.json(), then bridges Web File instances back to a
formidable.File-like shape so existing plugins that read file.filepath
(e.g. spaces/import_app) keep working unchanged. Same bridging pattern
already in use in raw_content_fragment and skills/import upload.

Poke analytics routes (2):
- GET /api/poke/workspaces/:wId/analytics/active-users
- GET /api/poke/workspaces/:wId/analytics/usage-metrics

Both are thin wrappers over already-clean Result-returning lib helpers
(fetchActiveUsersMetrics, fetchMessageMetrics) — no lib refactor needed.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Smoke test
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
None yet
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
