### PR TITLE
[Attach Files] Expand source URL search normalization

### DIFF
--- a/front/lib/connectors.test.ts
+++ b/front/lib/connectors.test.ts
@@ -303,6 +303,13 @@ describe("nodeCandidateFromUrl", () => {
 
       expect(result).toBeNull();
     });
+
+    it("should not match non-Gong hostnames ending with app.gong.io", () => {
+      const url = "https://notapp.gong.io/call?id=12345";
+      const result = nodeCandidateFromUrl(url);
+
+      expect(result).toBeNull();
+    });
   });
 
   describe("Zendesk", () => {
@@ -340,6 +347,13 @@ describe("nodeCandidateFromUrl", () => {
         expect(result.url).toBe("https://example.zendesk.com/tickets/12345");
         expect(result.provider).toBe("zendesk");
       }
+    });
+
+    it("should not match non-Zendesk hostnames ending with zendesk.com", () => {
+      const url = "https://notzendesk.com/tickets/12345";
+      const result = nodeCandidateFromUrl(url);
+
+      expect(result).toBeNull();
     });
   });
 
@@ -380,6 +394,13 @@ describe("nodeCandidateFromUrl", () => {
         expect(result.url).toBe("https://app.intercom.com/a/inbox/12345");
         expect(result.provider).toBe("intercom");
       }
+    });
+
+    it("should not match non-Intercom app hostnames", () => {
+      const url = "https://appnotintercom.com/a/inbox/12345";
+      const result = nodeCandidateFromUrl(url);
+
+      expect(result).toBeNull();
     });
   });
 
@@ -563,9 +584,56 @@ describe("normalizeUrlForSourceUrlSearch", () => {
     );
   });
 
-  it("should preserve non-GitHub URL candidate search queries", () => {
+  it("should normalize Zendesk agent URLs", () => {
+    expect(
+      normalizeUrlForSourceUrlSearch(
+        "https://example.zendesk.com/agent/tickets/12345?foo=bar#comment"
+      )
+    ).toBe("https://example.zendesk.com/tickets/12345");
+  });
+
+  it("should normalize Intercom app URLs", () => {
+    expect(
+      normalizeUrlForSourceUrlSearch(
+        "https://app.eu.intercom.com/a/inbox/workspace/inbox/conversation/123?view=conversation#part"
+      )
+    ).toBe(
+      "https://app.eu.intercom.com/a/inbox/workspace/inbox/conversation/123"
+    );
+  });
+
+  it("should preserve Intercom custom help center URLs", () => {
+    const url = "https://help.example.com/articles/article-123?foo=bar#section";
+
+    expect(normalizeUrlForSourceUrlSearch(url)).toBe(url);
+  });
+
+  it("should normalize Gong call URLs", () => {
+    expect(
+      normalizeUrlForSourceUrlSearch(
+        "https://us-5302.app.gong.io/call?id=12345&foo=bar#section"
+      )
+    ).toBe("https://us-5302.app.gong.io/call?id=12345");
+  });
+
+  it("should normalize Dust project URLs", () => {
+    expect(
+      normalizeUrlForSourceUrlSearch(
+        "https://app.dust.tt/w/workspace123/conversation/conv456?utm=value#message"
+      )
+    ).toBe("https://app.dust.tt/w/workspace123/conversation/conv456");
+  });
+
+  it("should preserve non-opted URL candidate search queries", () => {
     const confluenceUrl = "https://example.atlassian.net/wiki/spaces/SPACE";
 
     expect(normalizeUrlForSourceUrlSearch(confluenceUrl)).toBe(confluenceUrl);
+  });
+
+  it("should preserve URLs handled through node candidates", () => {
+    const slackUrl =
+      "https://dust4ai.slack.com/archives/C05V0P20A72/p1748353621866279?thread_ts=1748353030.562719&cid=C05V0P20A72";
+
+    expect(normalizeUrlForSourceUrlSearch(slackUrl)).toBe(slackUrl);
   });
 });

--- a/front/lib/connectors.ts
+++ b/front/lib/connectors.ts
@@ -89,6 +89,8 @@ export function orderDatasourceViewSelectionConfigurationByImportance<
 
 type BaseProvider = {
   matcher: (url: URL) => boolean;
+  // Source URL search is exact, so only opt in providers whose stored source URLs are canonical.
+  sourceUrlSearchNormalizer?: (url: URL) => UrlCandidate | null;
 };
 
 export type UrlCandidate = { url: string | null; provider: ConnectorProvider };
@@ -128,6 +130,56 @@ type Provider =
   | ProviderWithExtractor
   | ProviderWithNormalizer
   | ProviderWithBoth;
+
+function normalizeGithubUrl(url: URL): UrlCandidate {
+  const normalizedUrl = new URL(url.toString());
+  normalizedUrl.search = "";
+  normalizedUrl.hash = "";
+
+  return { url: normalizedUrl.toString(), provider: "github" };
+}
+
+function normalizeZendeskUrl(url: URL): UrlCandidate {
+  const path = url.pathname.endsWith("/")
+    ? url.pathname.slice(0, -1)
+    : url.pathname;
+
+  return {
+    url: `${url.origin}${path.replace("/agent", "")}`,
+    provider: "zendesk",
+  };
+}
+
+function isIntercomAppUrl(url: URL): boolean {
+  return (
+    url.hostname.startsWith("app.") && url.hostname.endsWith(".intercom.com")
+  );
+}
+
+function normalizeIntercomUrl(url: URL): UrlCandidate {
+  const path = url.pathname.endsWith("/")
+    ? url.pathname.slice(0, -1)
+    : url.pathname;
+
+  return { url: `${url.origin}${path}`, provider: "intercom" };
+}
+
+function normalizeGongSourceUrl(url: URL): UrlCandidate {
+  const callId = url.searchParams.get("id");
+  if (!callId) {
+    throw new Error("Unexpected Gong URL without a call id.");
+  }
+
+  return { url: `${url.origin}${url.pathname}?id=${callId}`, provider: "gong" };
+}
+
+function normalizeDustProjectUrl(url: URL): UrlCandidate {
+  const path = url.pathname.endsWith("/")
+    ? url.pathname.slice(0, -1)
+    : url.pathname;
+
+  return { url: `${url.origin}${path}`, provider: "dust_project" };
+}
 
 const providers: Partial<Record<ConnectorProvider, Provider>> = {
   confluence: {
@@ -184,13 +236,8 @@ const providers: Partial<Record<ConnectorProvider, Provider>> = {
         url.hostname === "github.com" || url.hostname.endsWith(".github.com")
       );
     },
-    urlNormalizer: (url: URL): UrlCandidate => {
-      const normalizedUrl = new URL(url.toString());
-      normalizedUrl.search = "";
-      normalizedUrl.hash = "";
-
-      return { url: normalizedUrl.toString(), provider: "github" };
-    },
+    urlNormalizer: normalizeGithubUrl,
+    sourceUrlSearchNormalizer: normalizeGithubUrl,
   },
   notion: {
     matcher: (url: URL): boolean => {
@@ -248,7 +295,8 @@ const providers: Partial<Record<ConnectorProvider, Provider>> = {
   gong: {
     matcher: (url: URL): boolean => {
       return (
-        url.hostname.endsWith("app.gong.io") &&
+        (url.hostname === "app.gong.io" ||
+          url.hostname.endsWith(".app.gong.io")) &&
         url.pathname === "/call" &&
         url.searchParams.has("id")
       );
@@ -256,48 +304,37 @@ const providers: Partial<Record<ConnectorProvider, Provider>> = {
     urlNormalizer: (url: URL): UrlCandidate => {
       return { url: url.toString(), provider: "gong" };
     },
+    sourceUrlSearchNormalizer: normalizeGongSourceUrl,
   },
   zendesk: {
     matcher: (url: URL): boolean => {
-      return url.hostname.endsWith("zendesk.com");
+      return (
+        url.hostname === "zendesk.com" || url.hostname.endsWith(".zendesk.com")
+      );
     },
-    urlNormalizer: (url: URL): UrlCandidate => {
-      const path = url.pathname.endsWith("/")
-        ? url.pathname.slice(0, -1)
-        : url.pathname;
-      // Zendesk ticket URL can contain /agent/ in the path if viewed from the agent page.
-      return {
-        url: `${url.origin}${path.replace("/agent", "")}`,
-        provider: "zendesk",
-      };
-    },
+    // Zendesk ticket URLs can contain /agent/ in the path when viewed from the agent page.
+    urlNormalizer: normalizeZendeskUrl,
+    sourceUrlSearchNormalizer: normalizeZendeskUrl,
   },
   intercom: {
     matcher: (url: URL): boolean => {
       return (
-        (url.hostname.includes("intercom.com") &&
-          url.hostname.startsWith("app")) ||
+        isIntercomAppUrl(url) ||
         // custom help center domains (websiteTurnedOn is true)
         url.hostname.startsWith("help")
       );
     },
-    urlNormalizer: (url: URL): UrlCandidate => {
-      const path = url.pathname.endsWith("/")
-        ? url.pathname.slice(0, -1)
-        : url.pathname;
-      return { url: `${url.origin}${path}`, provider: "intercom" };
+    urlNormalizer: normalizeIntercomUrl,
+    sourceUrlSearchNormalizer: (url: URL): UrlCandidate | null => {
+      return isIntercomAppUrl(url) ? normalizeIntercomUrl(url) : null;
     },
   },
   dust_project: {
     matcher: (url: URL): boolean => {
       return url.toString().startsWith(config.getAppUrl());
     },
-    urlNormalizer: (url: URL): UrlCandidate => {
-      const path = url.pathname.endsWith("/")
-        ? url.pathname.slice(0, -1)
-        : url.pathname;
-      return { url: `${url.origin}${path}`, provider: "dust_project" };
-    },
+    urlNormalizer: normalizeDustProjectUrl,
+    sourceUrlSearchNormalizer: normalizeDustProjectUrl,
   },
 };
 
@@ -384,16 +421,25 @@ export function nodeCandidateFromUrl(
   }
 }
 
-export function normalizeUrlForSourceUrlSearch(query: string): string {
-  const candidate = nodeCandidateFromUrl(query.trim());
+function sourceUrlCandidateFromUrl(url: string): UrlCandidate | null {
+  try {
+    const urlObj = new URL(url);
 
-  // This endpoint-level normalization only exists for GitHub anchors/notification
-  // parameters; other connectors keep their existing source URL search behavior.
-  if (
-    isUrlCandidate(candidate) &&
-    candidate.provider === "github" &&
-    candidate.url
-  ) {
+    for (const provider of Object.values(providers)) {
+      if (provider.matcher(urlObj)) {
+        return provider.sourceUrlSearchNormalizer?.(urlObj) ?? null;
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function normalizeUrlForSourceUrlSearch(query: string): string {
+  const candidate = sourceUrlCandidateFromUrl(query.trim());
+
+  if (candidate?.url) {
     return candidate.url;
   }
 


### PR DESCRIPTION
## Description
Related to https://github.com/dust-tt/tasks/issues/8147
Follows https://github.com/dust-tt/dust/pull/25946.

Extends exact source URL search normalization to provider-specific canonical URLs where sampled Core `source_url` rows and connector writers agree on stable stored formats: Zendesk, Intercom app URLs, Gong call URLs, and Dust project URLs. Keeps custom help-center URLs and node-candidate connectors out of endpoint normalization so Slack, Drive, Notion, and Confluence behavior stays unchanged.

## Risks
Blast radius: attach/search flows using `searchSourceUrls` for URL paste searches.
Risk: low

## Deploy Plan
- pmrr
- deploy front