### PR TITLE
Migrate poke conversations routes to Hono

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/config.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/config.ts
@@ -1,0 +1,47 @@
+import config from "@app/lib/api/config";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { pokeApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+
+export type PokeGetConversationConfig = {
+  conversationDataSourceId: string | null;
+  langfuseUiBaseUrl: string | null;
+  temporalWorkspace: string;
+};
+
+// Mounted at /api/poke/workspaces/:wId/conversations/:cId/config.
+const app = pokeApp();
+
+app.get("/", async (ctx): HandlerResult<PokeGetConversationConfig> => {
+  const auth = ctx.get("auth");
+  const cId = ctx.req.param("cId") ?? "";
+
+  const cRes = await ConversationResource.fetchConversationWithoutContent(
+    auth,
+    cId,
+    { includeDeleted: true }
+  );
+  if (cRes.isErr()) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "Conversation not found.",
+      },
+    });
+  }
+
+  const conversationDataSource = await DataSourceResource.fetchByConversation(
+    auth,
+    cRes.value
+  );
+
+  return ctx.json({
+    conversationDataSourceId: conversationDataSource?.sId ?? null,
+    langfuseUiBaseUrl: config.getLangfuseUiBaseUrl() ?? null,
+    temporalWorkspace: config.getTemporalAgentNamespace() ?? "",
+  });
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/index.ts
@@ -1,0 +1,34 @@
+import { getConversationApiError } from "@app/lib/api/assistant/conversation/helper";
+import { getPokeConversation } from "@app/lib/poke/conversation";
+import type { PokeConversationType } from "@app/types/poke";
+import { pokeApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+
+import config from "./config";
+import reinforcementTestCase from "./reinforcement_test_case";
+import render from "./render";
+
+export type PokeGetConversationResponseBody = {
+  conversation: PokeConversationType;
+};
+
+// Mounted at /api/poke/workspaces/:wId/conversations/:cId.
+const app = pokeApp();
+
+app.get("/", async (ctx): HandlerResult<PokeGetConversationResponseBody> => {
+  const auth = ctx.get("auth");
+  const cId = ctx.req.param("cId") ?? "";
+
+  const conversationRes = await getPokeConversation(auth, cId, true);
+  if (conversationRes.isErr()) {
+    return apiError(ctx, getConversationApiError(conversationRes.error));
+  }
+
+  return ctx.json({ conversation: conversationRes.value });
+});
+
+app.route("/config", config);
+app.route("/reinforcement_test_case", reinforcementTestCase);
+app.route("/render", render);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/reinforcement_test_case.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/reinforcement_test_case.ts
@@ -1,0 +1,215 @@
+import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import type { AvailableTool } from "@app/lib/api/assistant/workspace_capabilities";
+import { listAvailableTools } from "@app/lib/api/assistant/workspace_capabilities";
+import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import {
+  isAgentMessageType,
+  isUserMessageType,
+} from "@app/types/assistant/conversation";
+import type { ModelId } from "@app/types/shared/model_id";
+import { pokeApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+
+interface ReinforcementTestCaseMockAction {
+  functionCallName: string;
+  status: "succeeded" | "failed";
+  params?: Record<string, unknown>;
+  output?: string | null;
+}
+
+interface ReinforcementTestCaseMockFeedback {
+  direction: "up" | "down";
+  comment?: string;
+}
+
+interface ReinforcementTestCaseMockMessage {
+  role: "user" | "agent";
+  content: string;
+  feedback?: ReinforcementTestCaseMockFeedback;
+  actions?: ReinforcementTestCaseMockAction[];
+}
+
+interface ReinforcementTestCaseMockSkillTool {
+  name: string;
+  sId: string;
+}
+
+interface ReinforcementTestCaseMockSkillConfig {
+  name: string;
+  sId: string;
+  description?: string;
+  instructions?: string;
+  tools?: ReinforcementTestCaseMockSkillTool[];
+}
+
+interface ReinforcementTestCaseWorkspaceContext {
+  tools: AvailableTool[];
+}
+
+export interface ReinforcementTestCaseType {
+  scenarioId: string;
+  type: "analysis";
+  skillConfigs: ReinforcementTestCaseMockSkillConfig[];
+  conversation: ReinforcementTestCaseMockMessage[];
+  workspaceContext: ReinforcementTestCaseWorkspaceContext;
+  expectedToolCalls: [];
+  judgeCriteria: string;
+}
+
+export type PokeGetReinforcementTestCaseResponseBody = {
+  testCase: ReinforcementTestCaseType;
+};
+
+function serializeActionOutput(
+  output: Array<{ type: string; text?: string }> | null | undefined
+): string | null {
+  if (!output) {
+    return null;
+  }
+  const texts = output
+    .filter(
+      (block): block is { type: "text"; text: string } =>
+        block.type === "text" && typeof block.text === "string"
+    )
+    .map((block) => block.text);
+  return texts.length > 0 ? texts.join("\n") : null;
+}
+
+// Mounted at /api/poke/workspaces/:wId/conversations/:cId/reinforcement_test_case.
+const app = pokeApp();
+
+app.get(
+  "/",
+  async (ctx): HandlerResult<PokeGetReinforcementTestCaseResponseBody> => {
+    const auth = ctx.get("auth");
+    const cId = ctx.req.param("cId") ?? "";
+
+    const conversationRes = await getConversation(auth, cId, true);
+    if (conversationRes.isErr()) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: conversationRes.error.message,
+        },
+      });
+    }
+    const conversation = conversationRes.value;
+
+    const skills = await SkillResource.listByConversationModelId(
+      auth,
+      conversation.id
+    );
+
+    const skillConfigs: ReinforcementTestCaseMockSkillConfig[] = skills.map(
+      (skill) => {
+        const tools: ReinforcementTestCaseMockSkillTool[] = skill.mcpServerViews
+          .map((view) => {
+            const viewJson = view.toJSON();
+            if (!viewJson) {
+              return null;
+            }
+            return {
+              name: getMcpServerViewDisplayName(viewJson),
+              sId: viewJson.sId,
+            };
+          })
+          .filter((t): t is ReinforcementTestCaseMockSkillTool => t !== null);
+
+        const config: ReinforcementTestCaseMockSkillConfig = {
+          name: skill.name,
+          sId: skill.sId,
+          description: skill.agentFacingDescription,
+        };
+        if (skill.instructions) {
+          config.instructions = skill.instructions;
+        }
+        if (tools.length > 0) {
+          config.tools = tools;
+        }
+        return config;
+      }
+    );
+
+    const feedbacks =
+      await AgentMessageFeedbackResource.listByConversationModelId(
+        auth,
+        conversation.id
+      );
+    const feedbackByAgentMessageModelId = new Map<
+      ModelId,
+      ReinforcementTestCaseMockFeedback
+    >();
+    for (const f of feedbacks) {
+      if (feedbackByAgentMessageModelId.has(f.agentMessageId)) {
+        continue;
+      }
+      const feedback: ReinforcementTestCaseMockFeedback = {
+        direction: f.thumbDirection,
+      };
+      if (f.content) {
+        feedback.comment = f.content;
+      }
+      feedbackByAgentMessageModelId.set(f.agentMessageId, feedback);
+    }
+
+    const mockMessages: ReinforcementTestCaseMockMessage[] = [];
+    for (const messageVersions of conversation.content) {
+      if (messageVersions.length === 0) {
+        continue;
+      }
+      const last = messageVersions[messageVersions.length - 1];
+      if (isUserMessageType(last)) {
+        mockMessages.push({ role: "user", content: last.content });
+      } else if (isAgentMessageType(last)) {
+        const actions: ReinforcementTestCaseMockAction[] = last.actions.map(
+          (a) => {
+            const action: ReinforcementTestCaseMockAction = {
+              functionCallName: a.functionCallName,
+              status: a.status === "succeeded" ? "succeeded" : "failed",
+            };
+            if (a.params && Object.keys(a.params).length > 0) {
+              action.params = a.params;
+            }
+            const output = serializeActionOutput(a.output);
+            if (output !== null) {
+              action.output = output;
+            }
+            return action;
+          }
+        );
+        const feedback = feedbackByAgentMessageModelId.get(last.agentMessageId);
+        const message: ReinforcementTestCaseMockMessage = {
+          role: "agent",
+          content: last.content ?? "",
+        };
+        if (actions.length > 0) {
+          message.actions = actions;
+        }
+        if (feedback) {
+          message.feedback = feedback;
+        }
+        mockMessages.push(message);
+      }
+    }
+
+    const availableTools = await listAvailableTools(auth);
+
+    const testCase: ReinforcementTestCaseType = {
+      scenarioId: conversation.sId,
+      type: "analysis",
+      skillConfigs,
+      conversation: mockMessages,
+      workspaceContext: { tools: availableTools },
+      expectedToolCalls: [],
+      judgeCriteria:
+        "TODO: describe expected analyst behavior and scoring rubric.",
+    };
+
+    return ctx.json({ testCase });
+  }
+);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -1,0 +1,304 @@
+import { buildToolSpecification } from "@app/lib/actions/mcp";
+import { tryListMCPTools } from "@app/lib/actions/mcp_actions";
+import { createClientSideMCPServerConfigurations } from "@app/lib/api/actions/mcp_client_side";
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
+import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
+import { getJITServers } from "@app/lib/api/assistant/jit_actions";
+import { listAttachments } from "@app/lib/api/assistant/jit_utils";
+import { getSkillServers } from "@app/lib/api/assistant/skill_actions";
+import { renderEquippedSkillsUserMessage } from "@app/lib/api/assistant/skills_rendering";
+import { systemPromptToText } from "@app/lib/api/llm/types/options";
+import { getLlmCredentials } from "@app/lib/api/provider_credentials";
+import { hasFeatureFlag } from "@app/lib/auth";
+import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
+import { constructProjectContext } from "@app/lib/resources/skill/code_defined/projects";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { tokenCountForTexts } from "@app/lib/tokenization";
+import type {
+  AgentMessageType,
+  ConversationType,
+  UserMessageType,
+} from "@app/types/assistant/conversation";
+import { isUserMessageType } from "@app/types/assistant/conversation";
+import { removeNulls } from "@app/types/shared/utils/general";
+import { pokeApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const RenderConversationBodySchema = z.object({
+  agentId: z.string(),
+  contextSizeOverride: z.number().positive().nullable().optional(),
+  excludeActions: z.boolean().optional(),
+  excludeImages: z.boolean().optional(),
+  onMissingAction: z.enum(["inject-placeholder", "skip"]).optional(),
+});
+
+export type PostRenderConversationResponseBody = {
+  tokensUsed: number;
+  modelConversation: unknown;
+  modelContextSizeUsed: number;
+  promptTokenCountApprox: number;
+  toolsTokenCountApprox: number;
+};
+
+// Mounted at /api/poke/workspaces/:wId/conversations/:cId/render.
+const app = pokeApp();
+
+app.post(
+  "/",
+  validate("json", RenderConversationBodySchema),
+  async (ctx): HandlerResult<PostRenderConversationResponseBody> => {
+    const auth = ctx.get("auth");
+    const cId = ctx.req.param("cId") ?? "";
+    const {
+      agentId,
+      contextSizeOverride,
+      excludeActions,
+      excludeImages,
+      onMissingAction,
+    } = ctx.req.valid("json");
+
+    const [conversationRes, agentConfiguration] = await Promise.all([
+      getConversation(auth, cId, true),
+      getAgentConfiguration(auth, { agentId, variant: "full" }),
+    ]);
+
+    if (conversationRes.isErr()) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: conversationRes.error.message,
+        },
+      });
+    }
+    const conversation: ConversationType = conversationRes.value;
+
+    if (!agentConfiguration) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: `Agent configuration not found for sId ${agentId}.`,
+        },
+      });
+    }
+
+    const model = getSupportedModelConfig(agentConfiguration.model);
+    if (!model) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `Model ${agentConfiguration.model.modelId} is not supported for rendering.`,
+        },
+      });
+    }
+
+    const lastUserMessage = conversation.content
+      .map((tuple) => tuple[0])
+      .filter((m): m is UserMessageType => isUserMessageType(m))
+      .at(-1);
+    if (!lastUserMessage) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "No user message found in conversation content.",
+        },
+      });
+    }
+    const userMessage: UserMessageType = lastUserMessage;
+
+    const attachments = await listAttachments(auth, { conversation });
+    const { servers: jitServers } = await getJITServers(auth, {
+      agentConfiguration,
+      conversation,
+      attachments,
+    });
+
+    const renderSkillsAsUserMessages = await hasFeatureFlag(
+      auth,
+      "skills_as_user_messages"
+    );
+
+    const { enabledSkills, systemSkills, equippedSkills } =
+      await SkillResource.listForAgentLoop(auth, {
+        agentConfiguration,
+        conversation,
+      });
+
+    const skillServers = await getSkillServers(auth, {
+      agentConfiguration,
+      skills: [...systemSkills, ...enabledSkills],
+    });
+
+    const clientSideMCPActionConfigurations =
+      await createClientSideMCPServerConfigurations(
+        auth,
+        userMessage.context.clientSideMCPServerIds
+      );
+
+    const placeholderAgentMessage: AgentMessageType = {
+      type: "agent_message",
+      sId: generateRandomModelSId("msg"),
+      version: 0,
+      rank: 0,
+      branchId: null,
+      created: Date.now(),
+      completedTs: null,
+      parentMessageId: userMessage.sId,
+      parentAgentMessageId: null,
+      status: "created",
+      content: null,
+      chainOfThought: null,
+      error: null,
+      id: -1,
+      agentMessageId: -1,
+      visibility: "visible",
+      configuration: agentConfiguration,
+      skipToolsValidation: false,
+      actions: [],
+      contents: [],
+      modelInteractionDurationMs: null,
+      completionDurationMs: null,
+      richMentions: [],
+      reactions: [],
+    };
+
+    const { serverToolsAndInstructions, error: mcpToolsListingError } =
+      await tryListMCPTools(
+        auth,
+        {
+          agentConfiguration,
+          conversation,
+          agentMessage: placeholderAgentMessage,
+          clientSideActionConfigurations: clientSideMCPActionConfigurations,
+        },
+        { jitServers, skillServers }
+      );
+
+    const availableActions = serverToolsAndInstructions.flatMap((s) => s.tools);
+
+    let fallbackPrompt = "You are a conversational agent";
+    if (agentConfiguration.actions.length || availableActions.length > 0) {
+      fallbackPrompt += " with access to tool use.";
+    } else {
+      fallbackPrompt += ".";
+    }
+
+    const agentsList = agentConfiguration.instructions?.includes(
+      "{ASSISTANTS_LIST}"
+    )
+      ? await getAgentConfigurationsForView({
+          auth,
+          agentsGetView: auth.user() ? "list" : "all",
+          variant: "light",
+        })
+      : null;
+
+    const projectContext = await constructProjectContext(auth, {
+      conversation,
+    });
+
+    const isNewFileExplorer = conversation.metadata?.useFileSystem === true;
+
+    const promptSections = constructPromptMultiActions(auth, {
+      userMessage,
+      agentConfiguration,
+      fallbackPrompt,
+      model,
+      hasAvailableActions: availableActions.length > 0,
+      errorContext: mcpToolsListingError,
+      agentsList,
+      conversation,
+      serverToolsAndInstructions,
+      enabledSkills,
+      systemSkills,
+      equippedSkills,
+      renderSkillsAsUserMessages,
+      projectContext,
+      isNewFileExplorer,
+    });
+    const prompt = systemPromptToText(promptSections);
+    const leadingMessages = renderSkillsAsUserMessages
+      ? removeNulls([renderEquippedSkillsUserMessage(equippedSkills)])
+      : [];
+
+    const specifications = availableActions.map((t) =>
+      buildToolSpecification(t)
+    );
+    const tools = JSON.stringify(
+      specifications.map((s) => ({
+        name: s.name,
+        description: s.description,
+        inputSchema: s.inputSchema,
+      }))
+    );
+
+    const contextSize =
+      typeof contextSizeOverride === "number" && contextSizeOverride > 0
+        ? contextSizeOverride
+        : model.contextSize;
+    const allowedTokenCount = Math.max(
+      0,
+      contextSize - model.generationTokensCount
+    );
+
+    const convoRes = await renderConversationForModel(auth, {
+      conversation,
+      model,
+      prompt,
+      tools,
+      allowedTokenCount,
+      excludeActions,
+      excludeImages,
+      onMissingAction,
+      agentConfiguration,
+      leadingMessages,
+      enabledSkills,
+      renderSkillsAsUserMessages,
+    });
+
+    if (convoRes.isErr()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: convoRes.error.message,
+        },
+      });
+    }
+
+    const { modelConversation, tokensUsed } = convoRes.value;
+
+    let promptTokenCountApprox = 0;
+    let toolsTokenCountApprox = 0;
+    const credentials = await getLlmCredentials(auth, {
+      skipEmbeddingApiKeyRequirement: true,
+    });
+    const tokenCountsRes = await tokenCountForTexts(
+      [prompt, tools],
+      model,
+      credentials
+    );
+    if (tokenCountsRes.isOk()) {
+      [promptTokenCountApprox, toolsTokenCountApprox] = tokenCountsRes.value;
+    }
+
+    return ctx.json({
+      tokensUsed,
+      modelConversation,
+      modelContextSizeUsed: contextSize,
+      promptTokenCountApprox,
+      toolsTokenCountApprox,
+    });
+  }
+);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/conversations/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/index.ts
@@ -1,0 +1,104 @@
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type {
+  ConversationVisibility,
+  ConversationWithoutContentType,
+} from "@app/types/assistant/conversation";
+import { pokeApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+import conversationId from "./[cId]";
+
+export type PokeListConversationItem = ConversationWithoutContentType & {
+  visibility?: ConversationVisibility;
+};
+
+export type PokeListConversations = {
+  conversations: PokeListConversationItem[];
+};
+
+const ListConversationsQuerySchema = z.object({
+  agentId: z.string().optional(),
+  triggerId: z.string().optional(),
+  reinforcedSkillId: z.string().optional(),
+});
+
+// Mounted at /api/poke/workspaces/:wId/conversations.
+const app = pokeApp();
+
+app.get(
+  "/",
+  validate("query", ListConversationsQuerySchema),
+  async (ctx): HandlerResult<PokeListConversations> => {
+    const auth = ctx.get("auth");
+    const { agentId, triggerId, reinforcedSkillId } = ctx.req.valid("query");
+
+    let conversations: PokeListConversationItem[];
+
+    if (triggerId) {
+      conversations = await ConversationResource.listConversationsForTrigger(
+        auth,
+        triggerId
+      );
+    } else if (reinforcedSkillId) {
+      const oneWeekAgo = new Date();
+      oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
+
+      conversations =
+        await ConversationResource.listSkillReinforcementConversations(
+          auth,
+          reinforcedSkillId,
+          { after: oneWeekAgo }
+        );
+    } else if (agentId) {
+      const conversationResources =
+        await ConversationResource.listConversationWithAgentCreatedBeforeDate(
+          auth,
+          {
+            agentConfigurationId: agentId,
+            cutoffDate: new Date(),
+          },
+          { includeDeleted: true }
+        );
+
+      conversations = conversationResources.map((c) => ({
+        id: c.id,
+        created: c.createdAt.getTime(),
+        updated: c.updatedAt.getTime(),
+        sId: c.sId,
+        owner: auth.getNonNullableWorkspace(),
+        title: c.title,
+        visibility: c.visibility,
+        depth: c.depth,
+        triggerId: c.triggerSId,
+        actionRequired: false,
+        unread: false,
+        lastReadMs: Date.now(),
+        hasError: c.hasError,
+        requestedSpaceIds: c.getRequestedSpaceIdsFromModel(),
+        spaceId: c.space?.sId ?? null,
+        metadata: c.metadata,
+        branchId: null,
+        isRunningAgentLoop: c.isRunningAgentLoop,
+      }));
+
+      conversations.sort((a, b) => b.created - a.created);
+    } else {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "Either agent ID, reinforcedSkill ID or trigger ID is required.",
+        },
+      });
+    }
+
+    return ctx.json({ conversations });
+  }
+);
+
+app.route("/:cId", conversationId);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/index.ts
@@ -10,6 +10,7 @@ import analytics from "./analytics";
 import apps from "./apps";
 import assistants from "./assistants";
 import authContext from "./auth-context";
+import conversations from "./conversations";
 import dataRetention from "./data_retention";
 import dataSourceViews from "./data_source_views";
 import dataSources from "./data_sources";
@@ -70,6 +71,7 @@ app.patch(
 app.route("/analytics", analytics);
 app.route("/apps", apps);
 app.route("/assistants", assistants);
+app.route("/conversations", conversations);
 app.route("/data_retention", dataRetention);
 app.route("/data_source_views", dataSourceViews);
 app.route("/data_sources", dataSources);

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/config.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/config.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/index.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/reinforcement_test_case.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/reinforcement_test_case.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import type { AvailableTool } from "@app/lib/api/assistant/workspace_capabilities";

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { buildToolSpecification } from "@app/lib/actions/mcp";
 import { tryListMCPTools } from "@app/lib/actions/mcp_actions";
 import { createClientSideMCPServerConfigurations } from "@app/lib/api/actions/mcp_client_side";

--- a/front/pages/api/poke/workspaces/[wId]/conversations/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/index.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";


### PR DESCRIPTION
## Description
Migrates the five poke conversations routes:

- GET  /api/poke/workspaces/:wId/conversations
- GET  /api/poke/workspaces/:wId/conversations/:cId
- GET  /api/poke/workspaces/:wId/conversations/:cId/config
- POST /api/poke/workspaces/:wId/conversations/:cId/render
- GET  /api/poke/workspaces/:wId/conversations/:cId/reinforcement_test_case

All five are thin wrappers over lib helpers that already return Result (getPokeConversation, getConversation, ConversationResource.* fetch helpers, renderConversationForModel, etc.) — no business-layer extraction needed. Conversation errors use the existing transport-agnostic getConversationApiError mapper so the Hono and Next paths produce the same envelopes.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Manual smoke test
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
None yet
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
