### PR TITLE
Migrate poke agent_configurations routes to Hono

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
@@ -1,0 +1,84 @@
+import { listsAgentConfigurationVersions } from "@app/lib/api/assistant/configuration/agent";
+import { getAuthors, getEditors } from "@app/lib/api/assistant/editors";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import { isGlobalAgentId } from "@app/types/assistant/assistant";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
+import type { SpaceType } from "@app/types/space";
+import type { UserType } from "@app/types/user";
+import { pokeApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+
+export type PokeGetAgentDetails = {
+  agentConfigurations: AgentConfigurationType[];
+  authors: UserType[];
+  lastVersionEditors: UserType[];
+  spaces: SpaceType[];
+  skillsByVersion: Record<number, SkillType[]>;
+};
+
+// Mounted at /api/poke/workspaces/:wId/agent_configurations/:aId/details.
+const app = pokeApp();
+
+app.get("/", async (ctx): HandlerResult<PokeGetAgentDetails> => {
+  const auth = ctx.get("auth");
+  const aId = ctx.req.param("aId") ?? "";
+
+  const agentConfigurations = await listsAgentConfigurationVersions(auth, {
+    agentId: aId,
+    variant: "full",
+  });
+
+  if (agentConfigurations.length === 0) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: {
+        type: "agent_configuration_not_found",
+        message: "Agent configuration not found.",
+      },
+    });
+  }
+
+  const lastVersionEditors = await getEditors(auth, agentConfigurations[0]);
+  const [latestAgentConfiguration] = agentConfigurations;
+
+  const spaces = await SpaceResource.fetchByIds(
+    auth,
+    latestAgentConfiguration.requestedSpaceIds
+  );
+  const authors = await getAuthors(agentConfigurations);
+
+  // `SkillResource.listByAgentConfigurations` only works for custom agents, as global agents are not versioned.
+  const skillsByVersion: Record<number, SkillType[]> = {};
+  if (isGlobalAgentId(aId)) {
+    const allSkills = await SkillResource.listByAgentConfiguration(
+      auth,
+      latestAgentConfiguration
+    );
+    skillsByVersion[latestAgentConfiguration.version] = allSkills.map((s) =>
+      s.toJSON(auth)
+    );
+  } else {
+    const skillsByAgent = await SkillResource.listByAgentConfigurations(
+      auth,
+      agentConfigurations
+    );
+    for (const config of agentConfigurations) {
+      skillsByVersion[config.version] = [];
+    }
+    for (const { agentConfiguration, skill } of skillsByAgent) {
+      skillsByVersion[agentConfiguration.version].push(skill.toJSON(auth));
+    }
+  }
+
+  return ctx.json({
+    agentConfigurations,
+    authors,
+    lastVersionEditors,
+    spaces: spaces.map((s) => s.toJSON()),
+    skillsByVersion,
+  });
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/export.ts
+++ b/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/export.ts
@@ -1,0 +1,101 @@
+import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import { pokeApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import assert from "assert";
+
+export type PokeExportAgentConfigurationResponseBody = {
+  assistant: Omit<
+    AgentConfigurationType,
+    | "id"
+    | "versionCreatedAt"
+    | "sId"
+    | "version"
+    | "owner"
+    | "workspace"
+    | "createdAt"
+    | "versionAuthorId"
+    | "userFavorite"
+    | "requestedGroupIds"
+    | "requestedSpaceIds"
+    | "actions"
+    | "skills"
+  > & {
+    actions: Omit<MCPServerConfigurationType, "id" | "sId">[];
+  };
+};
+
+// Mounted at /api/poke/workspaces/:wId/agent_configurations/:aId/export.
+const app = pokeApp();
+
+app.get(
+  "/",
+  async (ctx): HandlerResult<PokeExportAgentConfigurationResponseBody> => {
+    const auth = ctx.get("auth");
+    const aId = ctx.req.param("aId") ?? "";
+
+    const agentConfiguration = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "full",
+    });
+    if (!agentConfiguration) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "The agent configuration you requested was not found.",
+        },
+      });
+    }
+
+    if (
+      agentConfiguration.status !== "active" ||
+      agentConfiguration.scope === "global"
+    ) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "The agent configuration is not active, or has global scope.",
+        },
+      });
+    }
+
+    return ctx.json({
+      assistant: {
+        name: agentConfiguration.name,
+        description: agentConfiguration.description,
+        instructions: agentConfiguration.instructions,
+        instructionsHtml: agentConfiguration.instructionsHtml,
+        pictureUrl: agentConfiguration.pictureUrl,
+        status: agentConfiguration.status,
+        scope: agentConfiguration.scope,
+        model: agentConfiguration.model,
+        actions: agentConfiguration.actions.map((action) => {
+          assert(
+            action.type === "mcp_server_configuration",
+            "Legacy action type, non-MCP, are no longer supported."
+          );
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { id, sId, ...actionWithoutIds } = action;
+          return {
+            ...actionWithoutIds,
+            ...("dataSources" in action ? { dataSources: [] } : {}),
+            ...("tables" in action ? { tables: [] } : {}),
+          };
+        }),
+        templateId: agentConfiguration.templateId,
+        maxStepsPerRun: agentConfiguration.maxStepsPerRun,
+        tags: agentConfiguration.tags,
+        reinforcement: agentConfiguration.reinforcement,
+        canRead: agentConfiguration.canRead,
+        canEdit: agentConfiguration.canEdit,
+        editors: [],
+      },
+    });
+  }
+);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
@@ -1,0 +1,51 @@
+import {
+  archiveAgentConfiguration,
+  getAgentConfiguration,
+} from "@app/lib/api/assistant/configuration/agent";
+import { pokeApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+
+import details from "./details";
+import exportRoute from "./export";
+import observability from "./observability";
+import restore from "./restore";
+
+export type PokeDeleteAgentConfigurationResponseBody = {
+  success: true;
+};
+
+// Mounted at /api/poke/workspaces/:wId/agent_configurations/:aId.
+const app = pokeApp();
+
+app.delete(
+  "/",
+  async (ctx): HandlerResult<PokeDeleteAgentConfigurationResponseBody> => {
+    const auth = ctx.get("auth");
+    const aId = ctx.req.param("aId") ?? "";
+
+    const agentConfiguration = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "light",
+    });
+    if (!agentConfiguration) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "Could not find the agent configuration.",
+        },
+      });
+    }
+
+    await archiveAgentConfiguration(auth, agentConfiguration.sId);
+
+    return ctx.json({ success: true });
+  }
+);
+
+app.route("/details", details);
+app.route("/export", exportRoute);
+app.route("/observability", observability);
+app.route("/restore", restore);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/observability/datasource-retrieval.ts
+++ b/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/observability/datasource-retrieval.ts
@@ -1,0 +1,67 @@
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import type { DatasourceRetrievalData } from "@app/lib/api/assistant/observability/datasource_retrieval";
+import { fetchDatasourceRetrievalMetrics } from "@app/lib/api/assistant/observability/datasource_retrieval";
+import { pokeApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+});
+
+export type PokeGetDatasourceRetrievalResponse = {
+  datasources: DatasourceRetrievalData[];
+  total: number;
+};
+
+// Mounted at /api/poke/workspaces/:wId/agent_configurations/:aId/observability/datasource-retrieval.
+const app = pokeApp();
+
+app.get(
+  "/",
+  validate("query", QuerySchema),
+  async (ctx): HandlerResult<PokeGetDatasourceRetrievalResponse> => {
+    const auth = ctx.get("auth");
+    const aId = ctx.req.param("aId") ?? "";
+    const { days } = ctx.req.valid("query");
+
+    const assistant = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "light",
+    });
+    if (!assistant) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "The agent you're trying to access was not found.",
+        },
+      });
+    }
+
+    const datasourceRetrievalResult = await fetchDatasourceRetrievalMetrics(
+      auth,
+      { agentId: assistant.sId, days }
+    );
+
+    if (datasourceRetrievalResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve datasource retrieval metrics: ${fromError(datasourceRetrievalResult.error).toString()}`,
+        },
+      });
+    }
+
+    const datasources = datasourceRetrievalResult.value;
+    const total = datasources.reduce((sum, ds) => sum + ds.count, 0);
+
+    return ctx.json({ datasources, total });
+  }
+);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/observability/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/observability/index.ts
@@ -1,0 +1,9 @@
+import { pokeApp } from "@front-api/middlewares/ctx";
+
+import datasourceRetrieval from "./datasource-retrieval";
+
+const app = pokeApp();
+
+app.route("/datasource-retrieval", datasourceRetrieval);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/restore.ts
+++ b/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/restore.ts
@@ -1,0 +1,86 @@
+import {
+  getAgentConfiguration,
+  restoreAgentConfiguration,
+} from "@app/lib/api/assistant/configuration/agent";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { pokeApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+
+export type PokeRestoreAgentConfigurationResponseBody = {
+  success: true;
+};
+
+// Mounted at /api/poke/workspaces/:wId/agent_configurations/:aId/restore.
+const app = pokeApp();
+
+app.post(
+  "/",
+  async (ctx): HandlerResult<PokeRestoreAgentConfigurationResponseBody> => {
+    const auth = ctx.get("auth");
+    const aId = ctx.req.param("aId") ?? "";
+
+    const agentConfiguration = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "light",
+    });
+    if (!agentConfiguration) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "Could not find the agent configuration.",
+        },
+      });
+    }
+
+    const restoredResult = await restoreAgentConfiguration(
+      auth,
+      agentConfiguration.sId
+    );
+
+    if (restoredResult.isErr()) {
+      switch (restoredResult.error.code) {
+        case "name_conflict":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: restoredResult.error.message,
+            },
+          });
+        case "unauthorized":
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: {
+              type: "app_auth_error",
+              message: restoredResult.error.message,
+            },
+          });
+        case "internal_error":
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: "Could not restore the agent configuration.",
+            },
+          });
+        default:
+          assertNever(restoredResult.error.code);
+      }
+    }
+
+    if (!restoredResult.value.restored) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Could not restore the agent configuration.",
+        },
+      });
+    }
+
+    return ctx.json({ success: true });
+  }
+);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/agent_configurations/import.ts
+++ b/front-api/routes/poke/workspaces/[wId]/agent_configurations/import.ts
@@ -1,0 +1,41 @@
+import { createOrUpgradeAgentConfiguration } from "@app/lib/api/assistant/configuration/create_or_upgrade";
+import { PostOrPatchAgentConfigurationRequestBodySchema } from "@app/types/api/internal/agent_configuration";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import { pokeApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+
+export type PokeImportAgentConfigurationResponseBody = {
+  assistant: AgentConfigurationType;
+};
+
+// Mounted at /api/poke/workspaces/:wId/agent_configurations/import.
+const app = pokeApp();
+
+app.post(
+  "/",
+  validate("json", PostOrPatchAgentConfigurationRequestBodySchema),
+  async (ctx): HandlerResult<PokeImportAgentConfigurationResponseBody> => {
+    const auth = ctx.get("auth");
+    const body = ctx.req.valid("json");
+
+    const result = await createOrUpgradeAgentConfiguration({
+      auth,
+      assistant: body.assistant,
+    });
+
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: result.error.message,
+        },
+      });
+    }
+
+    return ctx.json({ assistant: result.value });
+  }
+);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/agent_configurations/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/agent_configurations/index.ts
@@ -1,0 +1,61 @@
+import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
+import { getAuthors } from "@app/lib/api/assistant/editors";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { UserType } from "@app/types/user";
+import { pokeApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+import agentId from "./[aId]";
+import importRoute from "./import";
+
+export type PokeAgentConfigurationType = LightAgentConfigurationType & {
+  versionAuthor?: UserType | null;
+};
+
+export type PokeGetAgentConfigurationsResponseBody = {
+  agentConfigurations: PokeAgentConfigurationType[];
+};
+
+const ListAgentConfigurationsQuerySchema = z.object({
+  view: z.enum(["admin_internal", "archived"]),
+});
+
+// Mounted at /api/poke/workspaces/:wId/agent_configurations.
+const app = pokeApp();
+
+app.get(
+  "/",
+  validate("query", ListAgentConfigurationsQuerySchema),
+  async (ctx): HandlerResult<PokeGetAgentConfigurationsResponseBody> => {
+    const auth = ctx.get("auth");
+    const { view } = ctx.req.valid("query");
+
+    const agentConfigurations = await getAgentConfigurationsForView({
+      auth,
+      agentsGetView: view,
+      variant: "light",
+      sort: view === "archived" ? "updatedAt" : undefined,
+      dangerouslySkipPermissionFiltering: true,
+    });
+
+    const authors = await getAuthors(agentConfigurations);
+    const authorMap = new Map(authors.map((a) => [a.id, a]));
+
+    const agentsWithAuthors: PokeAgentConfigurationType[] =
+      agentConfigurations.map((a) => ({
+        ...a,
+        versionAuthor: a.versionAuthorId
+          ? (authorMap.get(a.versionAuthorId) ?? null)
+          : null,
+      }));
+
+    return ctx.json({ agentConfigurations: agentsWithAuthors });
+  }
+);
+
+app.route("/import", importRoute);
+app.route("/:aId", agentId);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/index.ts
@@ -6,6 +6,7 @@ import type { HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
+import agentConfigurations from "./agent_configurations";
 import analytics from "./analytics";
 import apps from "./apps";
 import assistants from "./assistants";
@@ -67,6 +68,7 @@ app.patch(
   }
 );
 
+app.route("/agent_configurations", agentConfigurations);
 app.route("/analytics", analytics);
 app.route("/apps", apps);
 app.route("/assistants", assistants);

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { listsAgentConfigurationVersions } from "@app/lib/api/assistant/configuration/agent";
 import { getAuthors, getEditors } from "@app/lib/api/assistant/editors";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/export.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/export.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import {
   archiveAgentConfiguration,
   getAgentConfiguration,

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/observability/datasource-retrieval.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/observability/datasource-retrieval.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type { DatasourceRetrievalData } from "@app/lib/api/assistant/observability/datasource_retrieval";

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/restore.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/restore.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import {
   getAgentConfiguration,
   restoreAgentConfiguration,

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/import.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/import.ts
@@ -1,3 +1,4 @@
+// @migration-status: MIGRATED_TO_HONO
 import { createOrUpgradeAgentConfiguration } from "@app/lib/api/assistant/configuration/create_or_upgrade";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/index.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import { getAuthors } from "@app/lib/api/assistant/editors";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";


### PR DESCRIPTION
## Description
Migrates the seven poke agent_configurations routes:

- GET    /api/poke/workspaces/:wId/agent_configurations
- POST   /api/poke/workspaces/:wId/agent_configurations/import
- DELETE /api/poke/workspaces/:wId/agent_configurations/:aId
- GET    /api/poke/workspaces/:wId/agent_configurations/:aId/details
- GET    /api/poke/workspaces/:wId/agent_configurations/:aId/export
- POST   /api/poke/workspaces/:wId/agent_configurations/:aId/restore
- GET    /api/poke/workspaces/:wId/agent_configurations/:aId/observability/datasource-retrieval

All seven are thin wrappers over lib helpers that already return Result (getAgentConfigurationsForView, archiveAgentConfiguration, restoreAgentConfiguration, createOrUpgradeAgentConfiguration, fetchDatasourceRetrievalMetrics) — no business-layer extraction needed.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Manual smoke test
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
None yet
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
