### PR TITLE
Add script to enable self-improving skills workspace settings when feature flag is set

### DIFF
--- a/front/scripts/enable_reinforcement_from_feature_flag.ts
+++ b/front/scripts/enable_reinforcement_from_feature_flag.ts
@@ -1,5 +1,5 @@
-import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import { updateWorkspaceMetadata } from "@app/lib/api/workspace";
+import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 

--- a/front/scripts/enable_reinforcement_from_feature_flag.ts
+++ b/front/scripts/enable_reinforcement_from_feature_flag.ts
@@ -1,0 +1,54 @@
+import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
+import { updateWorkspaceMetadata } from "@app/lib/api/workspace";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+
+makeScript({}, async ({ execute }, logger) => {
+  let updated = 0;
+  let skipped = 0;
+
+  await runOnAllWorkspaces(async (workspace) => {
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const hasFlagEnabled = await hasFeatureFlag(auth, "reinforced_agents");
+    if (!hasFlagEnabled) {
+      return;
+    }
+
+    if (workspace.metadata?.allowReinforcement === true) {
+      logger.info(
+        { workspaceId: workspace.sId, workspaceName: workspace.name },
+        "Already enabled, skipping."
+      );
+      skipped++;
+      return;
+    }
+
+    logger.info(
+      { workspaceId: workspace.sId, workspaceName: workspace.name },
+      execute
+        ? "Enabling allowReinforcement."
+        : "Would enable allowReinforcement."
+    );
+
+    if (execute) {
+      const result = await updateWorkspaceMetadata(workspace, {
+        allowReinforcement: true,
+      });
+      if (result.isErr()) {
+        logger.error(
+          { workspaceId: workspace.sId, error: result.error },
+          "Failed to update workspace metadata."
+        );
+        return;
+      }
+    }
+
+    updated++;
+  });
+
+  logger.info(
+    { updated, skipped },
+    execute ? "Migration completed." : "Dry run completed."
+  );
+});


### PR DESCRIPTION
## Description

I want to move the workspace settings to disable by default so need to enable it explicitly for beta testers

## Tests

tested the script locally

```
 # npx tsx scripts/enable_reinforcement_from_feature_flag.ts --execute
{"level":"info","time":1779433331046,"pid":17287,"hostname":"mac.home","origin":"cache_with_redis","msg":"Redis Client Connected"}
{"level":"info","time":1779433331046,"pid":17287,"hostname":"mac.home","msg":"Redis Client Ready"}
{"level":"info","time":1779433331052,"pid":17287,"hostname":"mac.home","execute":true,"workspaceId":"DevWkSpace","workspaceName":"fabien","msg":"Enabling allowReinforcement."}
{"level":"info","time":1779433331059,"pid":17287,"hostname":"mac.home","execute":true,"updated":1,"skipped":0,"msg":"Migration completed."}
```


## Risk

low

## Deploy Plan

none
