### PR TITLE
Scripts to reset self-improving skills before release

### DIFF
--- a/front/migrations/20260522_delete_all_self_improving_skills_usage.sql
+++ b/front/migrations/20260522_delete_all_self_improving_skills_usage.sql
@@ -1,0 +1,2 @@
+-- Delete all consumption records from self_improving_skills_usage.
+DELETE FROM self_improving_skills_usage;

--- a/front/migrations/20260522_delete_skill_suggestions_without_flag.ts
+++ b/front/migrations/20260522_delete_skill_suggestions_without_flag.ts
@@ -1,0 +1,57 @@
+import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
+import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+
+makeScript({}, async ({ execute }, logger) => {
+  let deleted = 0;
+  let skipped = 0;
+
+  await runOnAllWorkspaces(async (workspace) => {
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const hasFlagEnabled = await hasFeatureFlag(auth, "reinforced_agents");
+    if (hasFlagEnabled) {
+      return;
+    }
+
+    const suggestions = await SkillSuggestionResource.listByWorkspace(auth);
+
+    if (suggestions.length === 0) {
+      return;
+    }
+
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        workspaceName: workspace.name,
+        count: suggestions.length,
+      },
+      execute
+        ? "Deleting skill suggestions."
+        : "Would delete skill suggestions."
+    );
+
+    if (execute) {
+      const result = await SkillSuggestionResource.bulkDelete(
+        auth,
+        suggestions
+      );
+      if (result.isErr()) {
+        logger.error(
+          { workspaceId: workspace.sId, error: result.error },
+          "Failed to delete skill suggestions."
+        );
+        return;
+      }
+      deleted += result.value;
+    } else {
+      skipped += suggestions.length;
+    }
+  });
+
+  logger.info(
+    { deleted, skipped },
+    execute ? "Migration completed." : "Dry run completed."
+  );
+});


### PR DESCRIPTION
## Description

 - SQL script to reset all self_improving_skills_usage, to be run just before release, because during beta testing the feature was free
 - script to delete the suggestions for all workspaces which are not beta testers (to be run immediately) 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

none
