### PR TITLE
Run the front-api tests on the CI

### DIFF
--- a/.github/workflows/build-and-test-front.yml
+++ b/.github/workflows/build-and-test-front.yml
@@ -6,6 +6,7 @@ on:
       - package-lock.json
       - sdks/js/**
       - front/**
+      - front-api/**
       - sparkle/**
       - .github/workflows/build-and-test-front.yml
 
@@ -68,6 +69,23 @@ jobs:
           flaky_summary: true
           group_suite: true
           check_name: Tests Report (Shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
+      - name: Run Front-API Tests
+        working-directory: front-api
+        env:
+          FRONT_DATABASE_URI: "postgres://test:test@localhost:5433/front_test_shard_${{ matrix.shardIndex }}"
+          REDIS_CACHE_URI: "redis://localhost:5434"
+          REDIS_URI: "redis://localhost:5434"
+          NODE_ENV: test
+        run: npm run test:ci -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --outputFile=junit-shard-${{ matrix.shardIndex }}.xml
+      - name: Build Front-API Tests Report
+        if: always()
+        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6.4.0
+        with:
+          report_paths: "front-api/junit-shard-${{ matrix.shardIndex }}.xml"
+          detailed_summary: true
+          flaky_summary: true
+          group_suite: true
+          check_name: Front-API Tests Report (Shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
   tsgo:
     runs-on: ubuntu-latest
     steps:

--- a/front-api/package.json
+++ b/front-api/package.json
@@ -7,6 +7,7 @@
     "start": "NODE_ENV=production node dist/server.js",
     "build": "tsx esbuild.server.ts",
     "test": "FRONT_DATABASE_URI=$TEST_FRONT_DATABASE_URI REDIS_URI=$TEST_REDIS_URI REDIS_CACHE_URI=$TEST_REDIS_URI vitest --run",
+    "test:ci": "vitest --reporter=junit --watch=false --test-timeout=30000",
     "tsgo": "tsgo"
   },
   "dependencies": {


### PR DESCRIPTION
## Description

  - CI workflow `build-and-test-front.yml` was running front tests but not front-api
  - Adds `front-api/**` to the workflow's trigger paths and adds a `Run Front-API Tests` step (plus its JUnit report) in each test shard, reusing the same Postgres/Redis services and the same `--shard=N/3` split.
  - Adds a `test:ci` script to `front-api/package.json` mirroring front's (`vitest --reporter=junit --watch=false --test-timeout=30000`).

One potential concern is that it'll make runs a bit longer. Though eventually we won't run the matching tests in Front.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
