### PR TITLE
[front] chore: add index on `content_fragments`

### DIFF
--- a/front/lib/resources/storage/models/content_fragment.ts
+++ b/front/lib/resources/storage/models/content_fragment.ts
@@ -130,6 +130,11 @@ ContentFragmentModel.init(
         fields: ["workspaceId", "spaceId"],
         concurrently: true,
       },
+      {
+        fields: ["nodeDataSourceViewId", "workspaceId"],
+        concurrently: true,
+        name: "content_fragments_node_dsv_id_workspace_id",
+      },
     ],
   }
 );

--- a/front/lib/resources/storage/models/content_fragment.ts
+++ b/front/lib/resources/storage/models/content_fragment.ts
@@ -131,9 +131,9 @@ ContentFragmentModel.init(
         concurrently: true,
       },
       {
-        fields: ["nodeDataSourceViewId", "workspaceId"],
+        fields: ["nodeDataSourceViewId"],
         concurrently: true,
-        name: "content_fragments_node_dsv_id_workspace_id",
+        name: "content_fragments_node_dsv_id",
       },
     ],
   }

--- a/front/migrations/db/migration_650.sql
+++ b/front/migrations/db/migration_650.sql
@@ -1,2 +1,2 @@
 -- Migration created on May 22, 2026
-CREATE INDEX CONCURRENTLY "content_fragments_node_dsv_id_workspace_id" ON "content_fragments" ("nodeDataSourceViewId", "workspaceId");
+CREATE INDEX CONCURRENTLY "content_fragments_node_dsv_id" ON "content_fragments" ("nodeDataSourceViewId");

--- a/front/migrations/db/migration_650.sql
+++ b/front/migrations/db/migration_650.sql
@@ -1,0 +1,2 @@
+-- Migration created on May 22, 2026
+CREATE INDEX CONCURRENTLY "content_fragments_node_dsv_id_workspace_id" ON "content_fragments" ("nodeDataSourceViewId", "workspaceId");


### PR DESCRIPTION
## Description

- This PR adds a btree index on `content_fragments` `("nodeDataSourceViewId", "workspaceId")`
- Speeds up the query here https://github.com/dust-tt/dust/blob/e0c8ec2bf1f18ff6b45e9d090286563cba428d97/front/lib/resources/data_source_view_resource.ts#L734-L744
- More details [here](https://console.cloud.google.com/sql/instances/cell-00000-front-db/insights;database=front;duration=PT1H;trace=c49eeec22dfbf87776676f28d4dd61de;span=45a7abbc6cc8a48f;query_hash=12041477276186867372;sort_by=TOTAL_EXEC_TIME/executed?project=or1g1n-186209&rapt=AEjHL4MnqBL-tdmvpo1uKhw5Up3gfHZDAwc2AQc2cm5UumTvVo_9c6EWgEZODv0iD-3LW3DBsqS9zbmjUz_6Ug4aBPdBpSrgKdxWINTW3K3vVZAEmlOCrP0) and [here](https://app.pganalyze.com/databases/-642267661/checks/index_advisor/indexing_engine/34953093).

## Tests

- Migration ran locally

## Risk

- Low.

## Deploy Plan

- Run migration.
