### PR TITLE
[CONNECTORS] Increase incremental sync intervals for Notion and Gdrive

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -297,7 +297,7 @@ export async function googleDriveIncrementalSync(
 
   await syncSucceeded(connectorId);
 
-  await sleep("5 minutes");
+  await sleep("10 minutes");
   await continueAsNew<typeof googleDriveIncrementalSync>(connectorId);
 }
 
@@ -799,6 +799,6 @@ export async function googleDriveIncrementalSyncV2(
   await syncSucceeded(connectorId);
 
   // Sleep and continue
-  await sleep("5 minutes");
+  await sleep("10 minutes");
   await continueAsNew<typeof googleDriveIncrementalSyncV2>(connectorId);
 }

--- a/connectors/src/connectors/notion/temporal/config.ts
+++ b/connectors/src/connectors/notion/temporal/config.ts
@@ -7,7 +7,7 @@ export const GARBAGE_COLLECT_QUEUE_NAME = `notion-gc-queue-v${GC_WORKFLOW_VERSIO
 export const SYNC_PERIOD_DURATION_MS = 60_000;
 
 // How long to wait before running the incremental sync again
-export const INTERVAL_BETWEEN_SYNCS_MS = 60_000; // 1 minute
+export const INTERVAL_BETWEEN_SYNCS_MS = 120_000; // 2 minutes
 
 // How long to wait before running the GC sync again
 export const INTERVAL_BETWEEN_GC_SYNCS_MS = 12 * 60 * 60 * 1000; // 12 hours


### PR DESCRIPTION
## Description

Bumps Notion incremental sync from 1 → 2 min and Gdrive from 5 → 10 min to reduce load on Temporal workers and upstream APIs.

## Tests

None — sleep duration change only.

## Risk

Medium. Modifies infinite Temporal workflows (`googleDriveIncrementalSync`, `googleDriveIncrementalSyncV2`, `notionSyncWorkflow`) that loop via `continueAsNew`. The change is only a sleep duration — no control flow change, so no workflow versioning needed. Running instances will adopt the new interval on their next `continueAsNew` cycle. User-visible impact: Notion changes surface within 2 min (was 1), Gdrive within 10 min (was 5). Rollback is a straight revert.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `connectors`