### PR TITLE
Document scoped file path support in Google Drive and Microsoft Drive upload tools

### DIFF
--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -573,7 +573,7 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       fileId: z
         .string()
         .describe(
-          "The Dust fileId from the conversation attachments to upload."
+          "The file reference from the conversation. Accepts a scoped file path (e.g. 'conversation/report.pdf') or a legacy file sId."
         ),
       parentId: z
         .string()

--- a/front/lib/api/actions/servers/microsoft_drive/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/metadata.ts
@@ -129,7 +129,7 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
       fileId: z
         .string()
         .describe(
-          "The Dust fileId from the conversation attachments to upload."
+          "The file reference from the conversation. Accepts a scoped file path (e.g. 'conversation/report.pdf') or a legacy file sId."
         ),
       driveId: z
         .string()


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
`getFileFromConversationAttachment` already accepts both scoped file paths (e.g. `conversation/report.pdf`) and
legacy file sIds, but the `fileId` parameter description in the Google Drive and Microsoft Drive `upload_file`
tools only mentioned legacy fileIds. This aligns their descriptions with the pattern already in place in the
Jira and Slack MCP servers.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
