### PR TITLE
Include personal unpublished agents in agent router MCP

### DIFF
--- a/front/lib/api/actions/servers/agent_router/metadata.ts
+++ b/front/lib/api/actions/servers/agent_router/metadata.ts
@@ -6,14 +6,15 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const AGENT_ROUTER_SERVER_NAME = "agent_router" as const;
 export const AGENT_ROUTER_ACTION_DESCRIPTION =
-  "Tools with access to the published agents of the workspace.";
+  "Tools with access to the agents of the workspace.";
 
 export const SUGGEST_AGENTS_TOOL_NAME = "suggest_agents_for_content" as const;
 
 export const AGENT_ROUTER_TOOLS_METADATA = createToolsRecord({
   list_all_published_agents: {
     description:
-      "Returns a complete list of all published agents in the workspace. " +
+      "Returns a complete list of all agents accessible to the user in the workspace, " +
+      "including their personal (unpublished) agents. " +
       "Each agent includes its name, description, and mention directive " +
       "(e.g., `:mention[agent-name]{sId=xyz}`) to display a clickable link to the agent.",
     schema: {},

--- a/front/lib/api/actions/servers/agent_router/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_router/tools/index.ts
@@ -34,10 +34,10 @@ const handlers: ToolHandlers<typeof AGENT_ROUTER_TOOLS_METADATA> = {
 
     // We cannot call the internal getAgentConfigurations() here because it causes a circular dependency.
     // Instead, we call the public API endpoint.
-    // Since this endpoint is using the workspace credentials we do not have the user and as a result
-    // we cannot use the "list" view, meaning we do not have the user's unpublished agents.
+    // When the user is available, use the "list" view to include the user's unpublished agents
+    // (the x-api-user-email header allows the API to resolve the user from the system key).
     const res = await api.getAgentConfigurations({
-      view: "all",
+      view: user ? "list" : "all",
     });
     if (res.isErr()) {
       return new Err(new MCPError("Error fetching agent configurations"));
@@ -56,7 +56,7 @@ const handlers: ToolHandlers<typeof AGENT_ROUTER_TOOLS_METADATA> = {
     return new Ok([
       {
         type: "text" as const,
-        text: `# Published Agents\n\n${formattedAgents}`,
+        text: `# Available Agents\n\n${formattedAgents}`,
       },
     ]);
   },
@@ -80,10 +80,10 @@ const handlers: ToolHandlers<typeof AGENT_ROUTER_TOOLS_METADATA> = {
 
     // We cannot call the internal getAgentConfigurations() here because it causes a circular dependency.
     // Instead, we call the public API endpoint.
-    // Since this endpoint is using the workspace credentials we do not have the user and as a result
-    // we cannot use the "list" view, meaning we do not have the user's unpublished agents.
+    // When the user is available, use the "list" view to include the user's unpublished agents
+    // (the x-api-user-email header allows the API to resolve the user from the system key).
     const getAgentsRes = await api.getAgentConfigurations({
-      view: "all",
+      view: user ? "list" : "all",
     });
     if (getAgentsRes.isErr()) {
       logger.error(


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/8163

Includ persqonnal un-published agents in agent router MCP so Dust can aknowledge that the agent exists.

Change is a bit unintuitive: "all" does not includ all agents at all. "list" mode include published agents +  personal user agents.

## Tests

tested locally and dust is able to list unpublished agent 

## Risk

low, info is only available to user

## Deploy Plan

deploy front
