### PR TITLE
[front] chore: handle MCP OAuth resource URL mismatches

### DIFF
--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -32,6 +32,7 @@ import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { redactString } from "@app/types/shared/utils/string_utils";
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
@@ -469,12 +470,27 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       );
     }
 
-    const resource: URL | undefined = await selectResourceURL(
-      serverUrl,
-      provider,
-      // we default to null, so swap it for undefined if not set
-      resourceMetadata ?? undefined
-    );
+    let resource: URL | undefined;
+    try {
+      resource = await selectResourceURL(
+        serverUrl,
+        provider,
+        // we default to null, so swap it for undefined if not set
+        resourceMetadata ?? undefined
+      );
+    } catch (e) {
+      const error = normalizeError(e);
+      logger.info(
+        { error, serverUrl },
+        "Failed to select OAuth protected resource URL"
+      );
+      return new Err(
+        new DustError(
+          "internal_error",
+          `Failed to discover OAuth metadata for MCP server URL ${serverUrl}: ${error.message}`
+        )
+      );
+    }
 
     let metadata: AuthorizationServerMetadata | undefined;
     try {

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -487,7 +487,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       return new Err(
         new DustError(
           "internal_error",
-          `Failed to discover OAuth metadata for MCP server URL ${serverUrl}: ${error.message}`
+          `Failed to discover OAuth metadata for ${serverUrl}: ${error.message}`
         )
       );
     }


### PR DESCRIPTION
## Description

- This PR adds graceful handling for errors like [these ones](https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20status%3Aerror%20%40dd.env%3Aprod&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZ5OjyIeThiWxAAAABhBWjVPankyLUFBRDhBd21mWFJYVnhRRDMAAAAkMDE5ZTRlOTMtNzg2ZC00M2I4LThiNTgtYzRhYzdkNGY2OGIxAARtdg&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1779434172000&to_ts=1779434772000&live=false) by catching the SDK's error.
- Goal is to make it actionable on the user's end (they need to change the URL in this case)

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
