### PR TITLE
Enable inline text editing for imported sub-frames

### DIFF
--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -190,6 +190,7 @@ function useVisualizationDataHandler({
             const editResult = await onEditText({
               newText: data.params.newText,
               oldText: data.params.oldText,
+              targetFileId: data.params.targetFileId,
             });
 
             sendResponseToIframe(data, editResult, event.source);

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -131,10 +131,18 @@ export function FrameRenderer({
   const [showCode, setShowCode] = React.useState(false);
 
   const handleEditText = useCallback(
-    async ({ newText, oldText }: { newText: string; oldText: string }) => {
+    async ({
+      newText,
+      oldText,
+      targetFileId,
+    }: {
+      newText: string;
+      oldText: string;
+      targetFileId?: string;
+    }) => {
       try {
         const response = await clientFetch(
-          `/api/w/${owner.sId}/files/${fileId}/edit-text`,
+          `/api/w/${owner.sId}/files/${targetFileId ?? fileId}/edit-text`,
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },

--- a/front/types/assistant/visualization.ts
+++ b/front/types/assistant/visualization.ts
@@ -73,6 +73,7 @@ const DisplayCodeRequestSchema = VisualizationRPCRequestBaseSchema.extend({
 const EditTextParamsSchema = z.object({
   newText: z.string(),
   oldText: z.string(),
+  targetFileId: z.string().optional(),
 });
 
 type EditTextParams = z.infer<typeof EditTextParamsSchema>;

--- a/viz/app/components/EditableFrame.tsx
+++ b/viz/app/components/EditableFrame.tsx
@@ -139,6 +139,10 @@ export function EditableFrame({ children }: EditableFrameProps) {
       const rawText = decodeURIComponent(target.dataset.rawText ?? "");
       const ctxBefore = decodeURIComponent(target.dataset.ctxBefore ?? "");
       const ctxAfter = decodeURIComponent(target.dataset.ctxAfter ?? "");
+      const rawFileId = target.dataset.fileId;
+      const targetFileId = rawFileId?.startsWith("edit:")
+        ? rawFileId.slice(5)
+        : undefined;
       // rawText may start/end with \n+indent (multi-line JSX) that the browser strips from
       // textContent. Re-attach only that newline-based whitespace so the file replacement matches
       // the exact source bytes. Inline spaces are already present in textContent, so we skip them.
@@ -149,7 +153,7 @@ export function EditableFrame({ children }: EditableFrameProps) {
       const newText = ctxBefore + newRawText + ctxAfter;
 
       isSavingRef.current = true;
-      void editText({ oldText, newText })
+      void editText({ oldText, newText, targetFileId })
         .then((result) => {
           if (!result.success) {
             target.textContent = originalVisibleText;
@@ -204,11 +208,7 @@ export function EditableFrame({ children }: EditableFrameProps) {
       <Tooltip open={!!hoverState}>
         <TooltipTrigger asChild>
           <span
-            style={
-              anchorPos
-                ? { top: anchorPos.top, left: anchorPos.left }
-                : undefined
-            }
+            style={anchorPos ? { top: anchorPos.top, left: anchorPos.left } : undefined}
             className="pointer-events-none fixed size-px"
           />
         </TooltipTrigger>

--- a/viz/app/components/EditableFrame.tsx
+++ b/viz/app/components/EditableFrame.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useVizContext } from "@viz/app/components/VizContext";
+import { EDITABLE_FILE_ID_PREFIX } from "@viz/app/lib/transformEditableText";
 import {
   Tooltip,
   TooltipContent,
@@ -140,8 +141,8 @@ export function EditableFrame({ children }: EditableFrameProps) {
       const ctxBefore = decodeURIComponent(target.dataset.ctxBefore ?? "");
       const ctxAfter = decodeURIComponent(target.dataset.ctxAfter ?? "");
       const rawFileId = target.dataset.fileId;
-      const targetFileId = rawFileId?.startsWith("edit:")
-        ? rawFileId.slice(5)
+      const targetFileId = rawFileId?.startsWith(EDITABLE_FILE_ID_PREFIX)
+        ? rawFileId.slice(EDITABLE_FILE_ID_PREFIX.length)
         : undefined;
       // rawText may start/end with \n+indent (multi-line JSX) that the browser strips from
       // textContent. Re-attach only that newline-based whitespace so the file replacement matches

--- a/viz/app/components/EditableFrame.tsx
+++ b/viz/app/components/EditableFrame.tsx
@@ -208,7 +208,11 @@ export function EditableFrame({ children }: EditableFrameProps) {
       <Tooltip open={!!hoverState}>
         <TooltipTrigger asChild>
           <span
-            style={anchorPos ? { top: anchorPos.top, left: anchorPos.left } : undefined}
+            style={
+              anchorPos
+                ? { top: anchorPos.top, left: anchorPos.left }
+                : undefined
+            }
             className="pointer-events-none fixed size-px"
           />
         </TooltipTrigger>

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -78,12 +78,20 @@ async function resolveFileRef(
           const nestedKey = ref.type === "fileId" ? ref.fileId : ref.scopedPath;
           return [
             nestedKey,
-            await resolveFileRef(nestedKey, dataAPI, baseImports, cache, isEditable),
+            await resolveFileRef(
+              nestedKey,
+              dataAPI,
+              baseImports,
+              cache,
+              isEditable
+            ),
           ] as const;
         })
       );
       const nestedScope = Object.fromEntries(nestedEntries);
-      return importCode(codeToUse, { import: { ...baseImports, ...nestedScope } });
+      return importCode(codeToUse, {
+        import: { ...baseImports, ...nestedScope },
+      });
     }
 
     return { default: file };
@@ -435,7 +443,13 @@ export function VisualizationWrapper({
             const key = ref.type === "fileId" ? ref.fileId : ref.scopedPath;
             return [
               key,
-              await resolveFileRef(key, api.data, baseImports, cache, isEditable),
+              await resolveFileRef(
+                key,
+                api.data,
+                baseImports,
+                cache,
+                isEditable
+              ),
             ] as const;
           })
         );

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -55,7 +55,8 @@ async function resolveFileRef(
   key: string,
   dataAPI: VisualizationDataAPI,
   baseImports: Record<string, unknown>,
-  cache: Map<string, Promise<unknown>>
+  cache: Map<string, Promise<unknown>>,
+  isEditable: boolean
 ): Promise<unknown> {
   const cached = cache.get(key);
   if (cached) {
@@ -70,18 +71,19 @@ async function resolveFileRef(
 
     if (FRAME_MIME_TYPES.has(file.type)) {
       const text = await file.text();
-      const refs = extractFileRefs(text);
+      const codeToUse = isEditable ? transformEditableText(text, key) : text;
+      const refs = extractFileRefs(codeToUse);
       const nestedEntries = await Promise.all(
         refs.map(async (ref) => {
           const nestedKey = ref.type === "fileId" ? ref.fileId : ref.scopedPath;
           return [
             nestedKey,
-            await resolveFileRef(nestedKey, dataAPI, baseImports, cache),
+            await resolveFileRef(nestedKey, dataAPI, baseImports, cache, isEditable),
           ] as const;
         })
       );
       const nestedScope = Object.fromEntries(nestedEntries);
-      return importCode(text, { import: { ...baseImports, ...nestedScope } });
+      return importCode(codeToUse, { import: { ...baseImports, ...nestedScope } });
     }
 
     return { default: file };
@@ -174,10 +176,19 @@ export function useVisualizationAPI(
   }, [sendCrossDocumentMessage]);
 
   const editText = useCallback(
-    async ({ newText, oldText }: { newText: string; oldText: string }) => {
+    async ({
+      newText,
+      oldText,
+      targetFileId,
+    }: {
+      newText: string;
+      oldText: string;
+      targetFileId?: string;
+    }) => {
       return await sendCrossDocumentMessage("editText", {
         oldText,
         newText,
+        targetFileId,
       });
     },
     [sendCrossDocumentMessage]
@@ -424,7 +435,7 @@ export function VisualizationWrapper({
             const key = ref.type === "fileId" ? ref.fileId : ref.scopedPath;
             return [
               key,
-              await resolveFileRef(key, api.data, baseImports, cache),
+              await resolveFileRef(key, api.data, baseImports, cache, isEditable),
             ] as const;
           })
         );

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -71,7 +71,12 @@ async function resolveFileRef(
 
     if (FRAME_MIME_TYPES.has(file.type)) {
       const text = await file.text();
-      const codeToUse = isEditable ? transformEditableText(text, key) : text;
+      // Only make child-frame text editable when imported via a fil_ ID. Scoped paths
+      // (e.g. ./Foo) have no stable file ID to route edits back to.
+      const codeToUse =
+        isEditable && key.startsWith("fil_")
+          ? transformEditableText(text, key)
+          : text;
       const refs = extractFileRefs(codeToUse);
       const nestedEntries = await Promise.all(
         refs.map(async (ref) => {

--- a/viz/app/lib/transformEditableText.ts
+++ b/viz/app/lib/transformEditableText.ts
@@ -51,7 +51,7 @@ function collectJsxTextNodes(code: string): JSXTextReplacement[] {
   return replacements;
 }
 
-// Returns span metadata in document order — used to refresh ctx after an edit without
+// Returns span metadata in document order, used to refresh ctx after an edit without
 // re-executing the viz.
 export function getEditableSpansMeta(code: string): EditableSpanMeta[] {
   try {

--- a/viz/app/lib/transformEditableText.ts
+++ b/viz/app/lib/transformEditableText.ts
@@ -9,37 +9,66 @@ interface JSXTextReplacement {
   start: number;
 }
 
+export interface EditableSpanMeta {
+  ctxAfter: string;
+  ctxBefore: string;
+  rawText: string;
+}
+
 // Characters of surrounding source stored in each span so the server can do a unique string match
 // even when the same visible text appears multiple times in the file (e.g. repeated table labels).
 const CONTEXT_CHARS = 60;
 
-export function transformEditableText(code: string): string {
+function collectJsxTextNodes(code: string): JSXTextReplacement[] {
   const replacements: JSXTextReplacement[] = [];
 
+  const sourceFile = ts.createSourceFile(
+    "frame.tsx",
+    code,
+    ts.ScriptTarget.Latest,
+    false,
+    ts.ScriptKind.TSX
+  );
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isJsxText(node) && node.text.trim() !== "") {
+      const { pos, end } = node;
+      replacements.push({
+        start: pos,
+        end,
+        rawText: code.slice(pos, end),
+        ctxBefore: code.slice(Math.max(0, pos - CONTEXT_CHARS), pos),
+        ctxAfter: code.slice(end, Math.min(code.length, end + CONTEXT_CHARS)),
+      });
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return replacements;
+}
+
+// Returns span metadata in document order — used to refresh ctx after an edit without
+// re-executing the viz.
+export function getEditableSpansMeta(code: string): EditableSpanMeta[] {
   try {
-    const sourceFile = ts.createSourceFile(
-      "frame.tsx",
-      code,
-      ts.ScriptTarget.Latest,
-      false,
-      ts.ScriptKind.TSX
-    );
+    return collectJsxTextNodes(code).map(({ rawText, ctxBefore, ctxAfter }) => ({
+      rawText,
+      ctxBefore,
+      ctxAfter,
+    }));
+  } catch (err) {
+    logger.error({ err }, "Failed to extract editable span metadata");
+    return [];
+  }
+}
 
-    const visit = (node: ts.Node): void => {
-      if (ts.isJsxText(node) && node.text.trim() !== "") {
-        const { pos, end } = node;
-        replacements.push({
-          start: pos,
-          end,
-          rawText: code.slice(pos, end),
-          ctxBefore: code.slice(Math.max(0, pos - CONTEXT_CHARS), pos),
-          ctxAfter: code.slice(end, Math.min(code.length, end + CONTEXT_CHARS)),
-        });
-      }
-      ts.forEachChild(node, visit);
-    };
+// fileId is passed for sub-frames so EditableFrame can route edits to the correct file.
+export function transformEditableText(code: string, fileId?: string): string {
+  let replacements: JSXTextReplacement[] = [];
 
-    visit(sourceFile);
+  try {
+    replacements = collectJsxTextNodes(code);
   } catch (err) {
     logger.error({ err }, "Failed to transform editable text");
     return code;
@@ -54,17 +83,19 @@ export function transformEditableText(code: string): string {
 
   let result = code;
   for (const { start, end, rawText, ctxBefore, ctxAfter } of replacements) {
+    const attrs = [
+      `<span`,
+      `data-editable="true"`,
+      `data-raw-text="${encodeURIComponent(rawText)}"`,
+      `data-ctx-before="${encodeURIComponent(ctxBefore)}"`,
+      `data-ctx-after="${encodeURIComponent(ctxAfter)}"`,
+      ...(fileId ? [`data-file-id="edit:${fileId}"`] : []),
+      `className="cursor-text rounded-sm"`,
+      `>`,
+    ];
     result =
       result.slice(0, start) +
-      [
-        `<span`,
-        `data-editable="true"`,
-        `data-raw-text="${encodeURIComponent(rawText)}"`,
-        `data-ctx-before="${encodeURIComponent(ctxBefore)}"`,
-        `data-ctx-after="${encodeURIComponent(ctxAfter)}"`,
-        `className="cursor-text rounded-sm"`,
-        `>`,
-      ].join(" ") +
+      attrs.join(" ") +
       rawText.replace(/^\s*\n\s*/, "").replace(/\s*\n\s*$/, "") +
       `</span>` +
       result.slice(end);

--- a/viz/app/lib/transformEditableText.ts
+++ b/viz/app/lib/transformEditableText.ts
@@ -52,11 +52,13 @@ function collectJsxTextNodes(code: string): JSXTextReplacement[] {
 // re-executing the viz.
 export function getEditableSpansMeta(code: string): EditableSpanMeta[] {
   try {
-    return collectJsxTextNodes(code).map(({ rawText, ctxBefore, ctxAfter }) => ({
-      rawText,
-      ctxBefore,
-      ctxAfter,
-    }));
+    return collectJsxTextNodes(code).map(
+      ({ rawText, ctxBefore, ctxAfter }) => ({
+        rawText,
+        ctxBefore,
+        ctxAfter,
+      })
+    );
   } catch (err) {
     logger.error({ err }, "Failed to extract editable span metadata");
     return [];

--- a/viz/app/lib/transformEditableText.ts
+++ b/viz/app/lib/transformEditableText.ts
@@ -19,6 +19,9 @@ export interface EditableSpanMeta {
 // even when the same visible text appears multiple times in the file (e.g. repeated table labels).
 const CONTEXT_CHARS = 60;
 
+// Prefix on data-file-id attributes so extractFileRefs skips them (avoids deadlocking the cache).
+export const EDITABLE_FILE_ID_PREFIX = "edit:";
+
 function collectJsxTextNodes(code: string): JSXTextReplacement[] {
   const replacements: JSXTextReplacement[] = [];
 
@@ -91,7 +94,7 @@ export function transformEditableText(code: string, fileId?: string): string {
       `data-raw-text="${encodeURIComponent(rawText)}"`,
       `data-ctx-before="${encodeURIComponent(ctxBefore)}"`,
       `data-ctx-after="${encodeURIComponent(ctxAfter)}"`,
-      ...(fileId ? [`data-file-id="edit:${fileId}"`] : []),
+      ...(fileId ? [`data-file-id="${EDITABLE_FILE_ID_PREFIX}${fileId}"`] : []),
       `className="cursor-text rounded-sm"`,
       `>`,
     ];

--- a/viz/app/lib/visualization-api.ts
+++ b/viz/app/lib/visualization-api.ts
@@ -22,6 +22,7 @@ export interface VisualizationDataAPI {
 export type EditTextFn = (params: {
   newText: string;
   oldText: string;
+  targetFileId?: string;
 }) => Promise<{ success: boolean; error?: string }>;
 
 export interface VisualizationUIAPI {

--- a/viz/app/types.ts
+++ b/viz/app/types.ts
@@ -24,6 +24,7 @@ interface SetErrorMessageParams {
 interface EditTextParams {
   oldText: string;
   newText: string;
+  targetFileId?: string;
 }
 
 // Define a mapped type to extend the base with specific parameters.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
When a Frame imports another Frame by file ID (`fil_…`), the text inside the imported component was previously
read-only. Only the top-level frame's text was editable. This change wires up inline editing end-to-end for
child frames.

The main trick is that we now pass the child file's ID down to the AST transform, which stamps a `data-file-id`
attribute on each editable span. When the user commits a text edit, that attribute tells `EditableFrame` to route
the change to the child file rather than the parent. The ID is prefixed with `edit:` on the attribute so our
file-ref parser doesn't mistake span attributes for import dependencies and deadlock the resolution cache.

One guard worth noting: child-frame editing only activates for `fil_-based` imports. If a frame imports via a
relative path like `conversation/intro`, we have no stable file ID to route the edit back to, so those frames are
left non-editable. In practice the model always generates `fil_` imports when composing frames, so this won't be
noticed, but it prevents silently sending an edit to the wrong file.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
