### PR TITLE
[front] fix(sandbox): mark/clear actionRequired around child-action approval

### DIFF
--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -22,6 +22,7 @@ import { DEFAULT_MCP_TOOL_RETRY_POLICY } from "@app/lib/api/mcp";
 import { createMCPAction } from "@app/lib/api/mcp/create_mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
 import { launchSandboxChildToolWorkflow } from "@app/temporal/agent_loop/client";
@@ -220,6 +221,8 @@ export async function createSandboxChildAction(
       conversation,
       step: parentAction.stepContent.step,
     });
+
+    await ConversationResource.markAsActionRequired(auth, { conversation });
   } else {
     const userMessageInfo = await getUserMessageIdFromMessageId(auth, {
       messageId: agentMessage.sId,

--- a/front/temporal/agent_loop/client.ts
+++ b/front/temporal/agent_loop/client.ts
@@ -216,6 +216,11 @@ export async function launchSandboxChildToolWorkflow(
     actionModelId: action.id,
   });
 
+  await ConversationResource.clearActionRequired(
+    auth,
+    agentLoopArgs.conversationId
+  );
+
   if (waitForCompletion) {
     try {
       const handle = client.workflow.getHandle(workflowId);


### PR DESCRIPTION
## Description

The non-sandbox tool flow toggles `ConversationResource.actionRequired` symmetrically:

- `run_model_and_create_actions_wrapper.ts:292` marks it when a new tool action needs approval.
- `launchAgentLoopWorkflow` (`temporal/agent_loop/client.ts:52`) clears it on every resume.

Sandbox child actions skip both sides:

- `createSandboxChildAction` publishes a `tool_approve_execution` event but never calls `markAsActionRequired`.
- The user-resolution paths (`validate_actions.ts`, `answer_user_question.ts`, `resolve_authentication.ts`) short-circuit through `resumeSandboxChildAction` → `launchSandboxChildToolWorkflow`, which doesn't clear `actionRequired`.

Net effect: when a sandbox child requires approval, the orange dot in the sidebar can be stuck on the conversation after the user approves, because nothing on the sandbox resume path clears it.

This PR mirrors the regular flow:

- `createSandboxChildAction`: call `markAsActionRequired` after publishing the approval event on the blocked branch.
- `launchSandboxChildToolWorkflow`: call `clearActionRequired` at the top of the workflow client (initial auto-approved call is a no-op; resume after approve/answer/auth clears the orange dot).

## Tests

- Manual: spawn a sandbox child action that requires approval, approve via the Dust UI, confirm the conversation is no longer flagged in the inbox sidebar.

## Risk

Low. The change only touches the `actionRequired` boolean on `ConversationParticipant` for the sandbox child flow. Both `markAsActionRequired` and `clearActionRequired` are idempotent (no-op when the value already matches). Rollback is a straight revert.

## Deploy Plan

Standard front deploy.