### PR TITLE
[front] chore: remove workspace ID from index on `agent_mcp_server_configurations`

### DIFF
--- a/front/lib/models/agent/actions/mcp.ts
+++ b/front/lib/models/agent/actions/mcp.ts
@@ -180,9 +180,9 @@ AgentMCPServerConfigurationModel.init(
         concurrently: true,
       },
       {
-        fields: ["mcpServerViewId", "workspaceId"],
+        fields: ["mcpServerViewId"],
         concurrently: true,
-        name: "agent_mcp_srv_config_mcp_view_id_w_id",
+        name: "agent_mcp_srv_config_mcp_srv_view_id",
       },
     ],
   }

--- a/front/migrations/db/migration_651.sql
+++ b/front/migrations/db/migration_651.sql
@@ -1,3 +1,3 @@
 -- Migration created on May 22, 2026
-DROP INDEX CONCURRENTLY "agent_mcp_srv_config_mcp_view_id_w_id";
 CREATE INDEX CONCURRENTLY "agent_mcp_srv_config_mcp_srv_view_id" ON "agent_mcp_server_configurations" ("mcpServerViewId");
+DROP INDEX CONCURRENTLY "agent_mcp_srv_config_mcp_view_id_w_id";

--- a/front/migrations/db/migration_651.sql
+++ b/front/migrations/db/migration_651.sql
@@ -1,0 +1,3 @@
+-- Migration created on May 22, 2026
+DROP INDEX CONCURRENTLY "agent_mcp_srv_config_mcp_view_id_w_id";
+CREATE INDEX CONCURRENTLY "agent_mcp_srv_config_mcp_srv_view_id" ON "agent_mcp_server_configurations" ("mcpServerViewId");


### PR DESCRIPTION
## Description

- Cleanup following https://github.com/dust-tt/dust/pull/25957/changes#r3286962713
- This PR removes the index on `("mcpServerViewId", "workspaceId")` to add one on `("mcpServerViewId")` only
- An MCP server view ID belongs to only one workspace, the workspace ID does not contribute effectively.
- The index is safe to drop, up until yesterday we did not have it.

## Tests

- Migration ran locally

## Risk

- Low.

## Deploy Plan

- Run migration.

