### PR TITLE
[front] chore: skip groups/subscript fetches in agent cleanup activity

### DIFF
--- a/front/temporal/activity_utils.ts
+++ b/front/temporal/activity_utils.ts
@@ -3,7 +3,7 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { concurrentExecutor } from "@app/temporal/workflow_utils";
 import { Context } from "@temporalio/activity";
 
-const DEFAULT_WORKSPACE_CONCURRENCY = 50;
+const DEFAULT_WORKSPACE_CONCURRENCY = 32;
 
 /**
  * List all workspaces and run `fn` on each in parallel (activity-safe, heartbeats

--- a/front/temporal/hard_delete/activities.ts
+++ b/front/temporal/hard_delete/activities.ts
@@ -21,6 +21,7 @@ import type { Sequelize } from "sequelize";
 import { Op, QueryTypes } from "sequelize";
 
 const BATCH_SIZE = 100;
+const WORKSPACE_CONCURRENCY = 32;
 
 export async function purgeExpiredRunExecutionsActivity() {
   const coreSequelize = getCorePrimaryDbConnection();
@@ -162,10 +163,11 @@ export async function purgeExpiredPendingAgentsActivity(
       } while (hasMore);
 
       return deleted;
-    }
+    },
+    { concurrency: WORKSPACE_CONCURRENCY }
   );
 
-  const totalDeleted = results.reduce((sum, count) => sum + count, 0);
+  const totalDeleted = deletedCounts.reduce((sum, count) => sum + count, 0);
 
   logger.info(
     { totalDeleted },
@@ -206,7 +208,8 @@ export async function purgeExpiredSyntheticSkillSuggestionsActivity(
 
       return deleted;
     },
-    { excludePlanCodes: REINFORCEMENT_EXCLUDED_PLAN_CODES }
+    { concurrency: WORKSPACE_CONCURRENCY,
+      excludePlanCodes: REINFORCEMENT_EXCLUDED_PLAN_CODES }
   );
 
   const totalDeleted = results.reduce((sum, count) => sum + count, 0);

--- a/front/temporal/hard_delete/activities.ts
+++ b/front/temporal/hard_delete/activities.ts
@@ -213,8 +213,10 @@ export async function purgeExpiredSyntheticSkillSuggestionsActivity(
 
       return deleted;
     },
-    { concurrency: WORKSPACE_CONCURRENCY,
-      excludePlanCodes: REINFORCEMENT_EXCLUDED_PLAN_CODES }
+    {
+      concurrency: WORKSPACE_CONCURRENCY,
+      excludePlanCodes: REINFORCEMENT_EXCLUDED_PLAN_CODES,
+    }
   );
 
   const totalDeleted = results.reduce((sum, count) => sum + count, 0);

--- a/front/temporal/hard_delete/activities.ts
+++ b/front/temporal/hard_delete/activities.ts
@@ -4,6 +4,7 @@ import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { REINFORCEMENT_EXCLUDED_PLAN_CODES } from "@app/lib/plans/plan_codes";
 import { getCorePrimaryDbConnection } from "@app/lib/production_checks/utils";
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
 import { runOnAllWorkspacesInActivity } from "@app/temporal/activity_utils";
 import type {
@@ -16,6 +17,7 @@ import {
   getSyntheticSuggestionsDeletionCutoffDate,
   isSequelizeForeignKeyConstraintError,
 } from "@app/temporal/hard_delete/utils";
+import { concurrentExecutor } from "@app/temporal/workflow_utils";
 import { Context } from "@temporalio/activity";
 import type { Sequelize } from "sequelize";
 import { Op, QueryTypes } from "sequelize";
@@ -136,8 +138,11 @@ export async function purgeExpiredPendingAgentsActivity(
     `About to purge pending agents created before ${cutoffDate.toISOString()}.`
   );
 
-  const results = await runOnAllWorkspacesInActivity(
-    async (_auth, workspace) => {
+  const workspaces = await WorkspaceResource.listAll();
+
+  const deletedCounts = await concurrentExecutor(
+    workspaces,
+    async (workspace) => {
       let deleted = 0;
       let hasMore = true;
 


### PR DESCRIPTION
## Description

- We are seeing Temporal activities that run up to 50 concurrent database queries in front ([log](https://app.datadoghq.eu/logs?query=%22Activity%20completed%22%20%40peakConcurrentQueries%3A%3E4&agg_m=%40peakConcurrentQueries&agg_m_source=base&agg_q=%40activityName&agg_t=max&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%5D&flat_group_bys=true&fromUser=true&refresh_mode=sliding&saved-view-id=217075&sort_m=%40peakConcurrentQueries&sort_t=max&storage=hot&top_n=50&top_o=top&viz=toplist&x_missing=true&from_ts=1779350460046&to_ts=1779436860046&live=true)), specifically `purgeExpiredPendingAgentsActivity` and `purgeExpiredSyntheticSkillSuggestionsActivity`.
- Upon further inspection, `runOnAllWorkspacesInActivity` queries groups and subscriptions for each workspace to instantiate an Authenticator, even though unused by `purgeExpiredPendingAgentsActivity`.
- This PR bypasses these additional queries for `purgeExpiredSyntheticSkillSuggestionsActivity` and reduces the concurrency to 32.

## Tests

- Covered by existing tests.

## Risk

- Low. Could slow down the activity.

## Deploy Plan

- Deploy front
