### PR TITLE
[BYOK] Hide regional model flag in agent builder

### DIFF
--- a/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
+++ b/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
@@ -7,7 +7,7 @@ import { getModelProviderLogo } from "@app/components/providers/types";
 import { RegionalFlag } from "@app/components/shared/RegionalFlag";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { RegionType } from "@app/lib/api/regions/config";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import { getProviderDisplayName } from "@app/types/assistant/models/providers";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
@@ -74,10 +74,12 @@ export function ModelSelectionSubmenu({ models }: ModelSelectionSubmenuProps) {
 
   const { regionInfo } = useRegionContext();
   const { hasFeature } = useFeatureFlags();
+  const { subscription } = useAuth();
 
   const showRegionalFlag =
     hasFeature("use_vertex_for_anthropic_models") &&
-    SHOULD_DISPLAY_FLAG[regionInfo.name];
+    SHOULD_DISPLAY_FLAG[regionInfo.name] &&
+    !subscription.plan.isByok;
 
   const flag = showRegionalFlag ? (
     <RegionalFlag region={regionInfo.name} />


### PR DESCRIPTION
## Description

BYOK workspaces use customer-managed keys, so the Vertex region flag is meaningless in the agent builder model picker. Adds `!plan.isByok` to the `showRegionalFlag` condition in `ModelSelectionSubmenu`.

## Tests

None.

## Risk

Low — purely a UI visibility tweak, no behavior change.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`