### PR TITLE
[front] metronone_setup: fix excess credits

### DIFF
--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -2677,6 +2677,53 @@ function packageMatches(ex: ExistingPackage, desired: PackageDef): boolean {
       );
       return false;
     }
+    if (
+      match.access_amount.unit_price !== desiredCredit.access_amount.unit_price
+    ) {
+      console.log(
+        `    [diff] ${desired.name}: recurring credit "${desiredCredit.name}" unit_price ${match.access_amount.unit_price} → ${desiredCredit.access_amount.unit_price}`
+      );
+      return false;
+    }
+    if (
+      (match.access_amount.quantity ?? undefined) !==
+      (desiredCredit.access_amount.quantity ?? undefined)
+    ) {
+      console.log(
+        `    [diff] ${desired.name}: recurring credit "${desiredCredit.name}" quantity ${match.access_amount.quantity} → ${desiredCredit.access_amount.quantity}`
+      );
+      return false;
+    }
+    if (
+      Number(match.commit_duration.value) !==
+      desiredCredit.commit_duration.value
+    ) {
+      console.log(
+        `    [diff] ${desired.name}: recurring credit "${desiredCredit.name}" commit_duration ${match.commit_duration.value} → ${desiredCredit.commit_duration.value}`
+      );
+      return false;
+    }
+    if (
+      match.starting_at_offset.unit !== desiredCredit.starting_at_offset.unit ||
+      Number(match.starting_at_offset.value) !==
+        desiredCredit.starting_at_offset.value
+    ) {
+      console.log(
+        `    [diff] ${desired.name}: recurring credit "${desiredCredit.name}" starting_at_offset ${match.starting_at_offset.unit}:${match.starting_at_offset.value} → ${desiredCredit.starting_at_offset.unit}:${desiredCredit.starting_at_offset.value}`
+      );
+      return false;
+    }
+    if (
+      !arraysEqual(
+        [...(match.applicable_product_tags ?? [])].sort(),
+        [...(desiredCredit.applicable_product_tags ?? [])].sort()
+      )
+    ) {
+      console.log(
+        `    [diff] ${desired.name}: recurring credit "${desiredCredit.name}" applicable_product_tags [${match.applicable_product_tags ?? ""}] → [${desiredCredit.applicable_product_tags ?? ""}]`
+      );
+      return false;
+    }
     if (match.priority !== desiredCredit.priority) {
       console.log(
         `    [diff] ${desired.name}: recurring credit "${desiredCredit.name}" priority ${match.priority} → ${desiredCredit.priority}`

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -1259,8 +1259,8 @@ function getFreeExcessRecurringCredits(
     product_name: "Excess Credits",
     access_amount: {
       credit_type_id: creditTypeId,
-      unit_price: 0,
-      quantity,
+      unit_price: quantity,
+      quantity: 1,
     },
     commit_duration: { value: 1, unit: "PERIODS" },
     priority: 999,


### PR DESCRIPTION
## Description

* Fixing error in metronome_setup so that Excess credits are properly added and started for a new contract (mix between unit_price and quantity)
* Small improvement in metronome_setup script to detect changes in RecurringCreditDef for dry runs

## Tests

Tested locally => when creating a new contract, we now have 5000 excess credits that properly added
(before the total excess credits were set to 0)
<img width="1297" height="338" alt="image" src="https://github.com/user-attachments/assets/2cda680f-6231-485a-a3ff-f86f09a30a69" />

## Risk

Low

## Deploy Plan

Execute metronome_setup script on prodbox (with dry-run for validation before)