### PR TITLE
feat(dsbx): add --json flag to `dsbx tools` for structured tool output

### DIFF
--- a/cli/dust-sandbox/src/api/mod.rs
+++ b/cli/dust-sandbox/src/api/mod.rs
@@ -2,4 +2,4 @@ mod client;
 mod types;
 
 pub use client::DustApiClient;
-pub use types::ContentBlock;
+pub use types::{parse_content_block, ContentBlock};

--- a/cli/dust-sandbox/src/api/types.rs
+++ b/cli/dust-sandbox/src/api/types.rs
@@ -58,7 +58,9 @@ pub enum ActionPollResponse {
     Pending,
     Rejected,
     Success {
-        content: Vec<ContentBlock>,
+        // Raw blocks; the plain-text formatter parses them lazily so JSON
+        // mode can emit unknown block types verbatim.
+        content: Vec<serde_json::Value>,
         is_error: bool,
     },
 }
@@ -108,18 +110,13 @@ pub fn parse_action_poll_response(body: &str) -> anyhow::Result<ActionPollRespon
         ActionPollResponseRaw::Rejected => Ok(ActionPollResponse::Rejected),
         ActionPollResponseRaw::Success { action } => {
             let is_error = action.status == "errored";
-            let content = action
-                .output
-                .unwrap_or_default()
-                .iter()
-                .map(parse_content_block)
-                .collect();
+            let content = action.output.unwrap_or_default();
             Ok(ActionPollResponse::Success { content, is_error })
         }
     }
 }
 
-fn parse_content_block(value: &serde_json::Value) -> ContentBlock {
+pub fn parse_content_block(value: &serde_json::Value) -> ContentBlock {
     match serde_json::from_value::<ContentBlock>(value.clone()) {
         Ok(block) => block,
         Err(err) => {
@@ -136,10 +133,10 @@ pub struct CallToolResponse {
     pub result: CallToolResult,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CallToolResult {
-    pub content: Vec<ContentBlock>,
+    pub content: Vec<serde_json::Value>,
     pub is_error: bool,
 }
 
@@ -227,6 +224,8 @@ mod tests {
             ActionPollResponse::Success { content, is_error } => {
                 assert!(!is_error);
                 assert_eq!(content.len(), 1);
+                assert_eq!(content[0]["type"], "text");
+                assert_eq!(content[0]["text"], "hello");
             }
             _ => panic!("expected success"),
         }
@@ -263,5 +262,41 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.to_string().contains("bad token"));
+    }
+
+    #[test]
+    fn call_tool_result_serializes_with_camelcase() {
+        let result = CallToolResult {
+            content: vec![serde_json::json!({"type": "text", "text": "hello"})],
+            is_error: false,
+        };
+
+        let value: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&result).expect("should serialize"))
+                .expect("should round-trip");
+
+        assert_eq!(value["isError"], false);
+        assert!(value.get("is_error").is_none());
+        assert_eq!(value["content"][0]["type"], "text");
+        assert_eq!(value["content"][0]["text"], "hello");
+    }
+
+    #[test]
+    fn call_tool_result_preserves_unknown_block_types_when_serialized() {
+        let result = CallToolResult {
+            content: vec![serde_json::json!({
+                "type": "future_block",
+                "payload": {"k": 1}
+            })],
+            is_error: true,
+        };
+
+        let value: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&result).expect("should serialize"))
+                .expect("should round-trip");
+
+        assert_eq!(value["isError"], true);
+        assert_eq!(value["content"][0]["type"], "future_block");
+        assert_eq!(value["content"][0]["payload"]["k"], 1);
     }
 }

--- a/cli/dust-sandbox/src/commands/tools/exec.rs
+++ b/cli/dust-sandbox/src/commands/tools/exec.rs
@@ -1,12 +1,13 @@
 use anyhow::bail;
 
-use crate::api::{ContentBlock, DustApiClient};
+use crate::api::{parse_content_block, ContentBlock, DustApiClient};
 
 pub async fn cmd_exec(
     client: &DustApiClient,
     server_name: &str,
     tool_name: &str,
     raw_args: &[String],
+    json: bool,
 ) -> anyhow::Result<()> {
     let views = client.list_tools(Some(server_name), false).await?;
 
@@ -30,37 +31,41 @@ pub async fn cmd_exec(
 
     let resp = client.call_tool(&view.s_id, tool_name, arguments).await?;
 
-    // All content blocks (text and sentinel markers) go to stdout so a caller
-    // capturing stdout sees the full tool output. stderr is reserved for
-    // ambient diagnostics.
-    for block in &resp.result.content {
-        match block {
-            ContentBlock::Text { text } => {
-                println!("{text}");
-            }
-            ContentBlock::Image { mime_type, .. } => {
-                println!("[image: {mime_type}]");
-            }
-            ContentBlock::Audio { mime_type, .. } => {
-                println!("[audio: {mime_type}]");
-            }
-            ContentBlock::Resource { resource } => {
-                if let Some(text) = &resource.text {
+    if json {
+        println!("{}", serde_json::to_string_pretty(&resp.result)?);
+    } else {
+        // All content blocks (text and sentinel markers) go to stdout so a
+        // caller capturing stdout sees the full tool output. stderr is
+        // reserved for ambient diagnostics.
+        for value in &resp.result.content {
+            match parse_content_block(value) {
+                ContentBlock::Text { text } => {
                     println!("{text}");
-                } else if resource.blob.is_some() {
-                    println!("[binary resource: {}]", resource.uri);
-                } else {
-                    println!("[resource: {}]", resource.uri);
                 }
-            }
-            ContentBlock::ResourceLink { uri, name } => {
-                if let Some(name) = name {
-                    println!("[resource link: {name} - {uri}]");
-                } else {
-                    println!("[resource link: {uri}]");
+                ContentBlock::Image { mime_type, .. } => {
+                    println!("[image: {mime_type}]");
                 }
+                ContentBlock::Audio { mime_type, .. } => {
+                    println!("[audio: {mime_type}]");
+                }
+                ContentBlock::Resource { resource } => {
+                    if let Some(text) = &resource.text {
+                        println!("{text}");
+                    } else if resource.blob.is_some() {
+                        println!("[binary resource: {}]", resource.uri);
+                    } else {
+                        println!("[resource: {}]", resource.uri);
+                    }
+                }
+                ContentBlock::ResourceLink { uri, name } => {
+                    if let Some(name) = name {
+                        println!("[resource link: {name} - {uri}]");
+                    } else {
+                        println!("[resource link: {uri}]");
+                    }
+                }
+                ContentBlock::Unknown => {}
             }
-            ContentBlock::Unknown => {}
         }
     }
 

--- a/cli/dust-sandbox/src/main.rs
+++ b/cli/dust-sandbox/src/main.rs
@@ -20,6 +20,11 @@ enum Commands {
     Forward(commands::forward::ForwardArgs),
     /// Interact with MCP servers and tools
     Tools {
+        /// Emit the tool execution result as JSON (`{ content, isError }`)
+        /// instead of plain text. Must be placed before the positional
+        /// arguments. Ignored when listing servers or tools.
+        #[arg(long)]
+        json: bool,
         /// Server name (omit to list all servers)
         server_name: Option<String>,
         /// Tool name to execute
@@ -47,6 +52,7 @@ async fn run() -> anyhow::Result<()> {
         Commands::Version => commands::cmd_version(),
         Commands::Forward(args) => commands::cmd_forward(args).await?,
         Commands::Tools {
+            json,
             server_name,
             tool_name,
             args,
@@ -56,7 +62,7 @@ async fn run() -> anyhow::Result<()> {
                 (None, _) => commands::cmd_list_servers(&client).await?,
                 (Some(server), None) => commands::cmd_list_tools(&client, &server).await?,
                 (Some(server), Some(tool)) => {
-                    commands::cmd_exec(&client, &server, &tool, &args).await?
+                    commands::cmd_exec(&client, &server, &tool, &args, json).await?
                 }
             }
         }
@@ -86,5 +92,49 @@ mod tests {
     #[test]
     fn verify_cli() {
         Cli::command().debug_assert();
+    }
+
+    fn tools_fields(cli: Cli) -> (bool, Option<String>, Option<String>, Vec<String>) {
+        match cli.command {
+            Commands::Tools {
+                json,
+                server_name,
+                tool_name,
+                args,
+            } => (json, server_name, tool_name, args),
+            _ => panic!("expected Tools subcommand"),
+        }
+    }
+
+    #[test]
+    fn json_flag_parses_before_positionals() {
+        let cli = Cli::try_parse_from(["dsbx", "tools", "--json", "srv", "tool", "--foo", "bar"])
+            .expect("should parse");
+        let (json, server, tool, args) = tools_fields(cli);
+
+        assert!(json, "--json before positionals should set json=true");
+        assert_eq!(server.as_deref(), Some("srv"));
+        assert_eq!(tool.as_deref(), Some("tool"));
+        assert_eq!(args, vec!["--foo".to_string(), "bar".to_string()]);
+    }
+
+    #[test]
+    fn json_flag_after_positionals_is_swallowed_into_args() {
+        let cli = Cli::try_parse_from(["dsbx", "tools", "srv", "tool", "--foo", "bar", "--json"])
+            .expect("should parse");
+        let (json, _, _, args) = tools_fields(cli);
+
+        assert!(!json, "--json after positionals should NOT toggle the flag");
+        assert!(
+            args.contains(&"--json".to_string()),
+            "--json should land in trailing args instead"
+        );
+    }
+
+    #[test]
+    fn tools_without_json_defaults_to_false() {
+        let cli = Cli::try_parse_from(["dsbx", "tools", "srv", "tool"]).expect("should parse");
+        let (json, ..) = tools_fields(cli);
+        assert!(!json);
     }
 }


### PR DESCRIPTION
## Description

Agents call `dsbx tools <server> <tool> ...` and currently only get plain text back. They have to scrape strings to recover any structure. This PR adds a `--json` flag that emits the raw `CallToolResult` (`{ content, isError }`) verbatim so callers can consume content blocks as structured data, including block types the CLI itself doesn't recognize yet.

```
dsbx tools --json <server> <tool> --foo bar
```

**Implementation note:** rather than deriving `Serialize` on the `ContentBlock` enum (which would lose fidelity for the `Unknown` variant), `CallToolResult.content` now stores raw `serde_json::Value`. Side-effect: the `unrecognized content block` stderr warning now fires only in plain-text mode — `--json` mode is silent on unknown blocks by design, since the consumer sees the raw value.

## Tests

- `cargo test -p dust-sandbox` → 89 passed (up from 84).
- New: `call_tool_result_serializes_with_camelcase` locks the `isError` wire shape so a future serde-attribute tweak doesn't silently break agents.
- New: `call_tool_result_preserves_unknown_block_types_when_serialized` proves the raw-`Value` storage actually preserves future block types end-to-end.
- New: three clap parser tests covering `--json` before positionals, `--json` after positionals (footgun), and default-false.
- Manual: `./target/debug/dsbx tools --help` shows the new flag.

## Risk

Safe to rollback: the new flag is purely additive, default `false`, and the plain-text path is unchanged behaviorally except for the warning being emitted lazily.

## Deploy Plan

- [ ] Release `dsbx`