### PR TITLE
[front] feat: migrate healthz/ endpoint

### DIFF
--- a/front-api/app.ts
+++ b/front-api/app.ts
@@ -2,7 +2,6 @@ import { Hono } from "hono";
 
 // Side-effect import: registers the ContextVariableMap augmentation for
 // `auth` and `session`. See middleware/context.ts for rationale.
-import "./middleware/context";
 import { cors } from "./middleware/cors";
 import preStopApp from "./routes/[preStopSecret]";
 import { appStatusApp } from "./routes/app-status";

--- a/front-api/routes/healthz.test.ts
+++ b/front-api/routes/healthz.test.ts
@@ -1,0 +1,102 @@
+import { frontSequelize } from "@app/lib/resources/storage";
+import * as shutdownSignal from "@app/lib/shutdown_signal";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const redisPingMock = vi.fn();
+
+vi.mock("@app/lib/api/redis-hybrid-manager", () => ({
+  getRedisHybridManager: () => ({ ping: redisPingMock }),
+}));
+
+describe("GET /api/healthz", () => {
+  it("returns 200 ok", async () => {
+    const response = await honoApp.request("/api/healthz");
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("ok");
+  });
+});
+
+describe("GET /api/healthz/ready", () => {
+  beforeEach(() => {
+    vi.spyOn(shutdownSignal, "isInShutdown").mockReturnValue(false);
+  });
+
+  it("returns 200 with status ready when not shutting down", async () => {
+    const response = await honoApp.request("/api/healthz/ready");
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual({
+      status: "ready",
+      commitHash: expect.any(String),
+    });
+  });
+
+  it("returns 503 with status shutting_down when in shutdown", async () => {
+    vi.spyOn(shutdownSignal, "isInShutdown").mockReturnValue(true);
+
+    const response = await honoApp.request("/api/healthz/ready");
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ status: "shutting_down" });
+  });
+});
+
+describe("GET /api/healthz/startup", () => {
+  beforeEach(() => {
+    redisPingMock.mockReset();
+    redisPingMock.mockResolvedValue(undefined);
+  });
+
+  it("returns 200 when redis and database are healthy", async () => {
+    const response = await honoApp.request("/api/healthz/startup");
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("ready");
+    expect(body.dependencies).toEqual([
+      expect.objectContaining({ name: "redis", ok: true }),
+      expect.objectContaining({ name: "database", ok: true }),
+    ]);
+  });
+
+  it("returns 503 when redis ping fails", async () => {
+    redisPingMock.mockRejectedValue(new Error("redis down"));
+
+    const response = await honoApp.request("/api/healthz/startup");
+
+    expect(response.status).toBe(503);
+    const body = await response.json();
+    expect(body.status).toBe("not ready");
+    expect(body.dependencies).toEqual([
+      expect.objectContaining({
+        name: "redis",
+        ok: false,
+        error: "redis down",
+      }),
+      expect.objectContaining({ name: "database", ok: true }),
+    ]);
+  });
+
+  it("returns 503 when database query fails", async () => {
+    vi.spyOn(frontSequelize, "query").mockRejectedValueOnce(
+      new Error("db down")
+    );
+
+    const response = await honoApp.request("/api/healthz/startup");
+
+    expect(response.status).toBe(503);
+    const body = await response.json();
+    expect(body.status).toBe("not ready");
+    expect(body.dependencies).toEqual([
+      expect.objectContaining({ name: "redis", ok: true }),
+      expect.objectContaining({
+        name: "database",
+        ok: false,
+        error: "db down",
+      }),
+    ]);
+  });
+});

--- a/front-api/routes/healthz.ts
+++ b/front-api/routes/healthz.ts
@@ -1,4 +1,10 @@
+import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
+import { COMMIT_HASH } from "@app/lib/commit-hash";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { isInShutdown } from "@app/lib/shutdown_signal";
 import { getStatsDClient } from "@app/lib/utils/statsd";
+import logger from "@app/logger/logger";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { Hono } from "hono";
 
 export const healthzApp = new Hono();
@@ -11,4 +17,124 @@ healthzApp.get("/", (ctx) => {
   getStatsDClient().distribution("requests.health.check", elapsedMs);
 
   return response;
+});
+
+/**
+ * Readiness probe endpoint.
+ *
+ * This endpoint is checked continuously by Kubernetes to determine if the pod should receive
+ * traffic. It's kept simple and doesn't check dependencies to avoid marking all pods unready if
+ * Redis/DB have transient issues.
+ *
+ * During pod shutdown, this probe fails immediately to signal the load balancer to stop
+ * sending new connections and begin connection draining.
+ *
+ * The startup probe (/api/healthz/startup) handles dependency checking at pod startup.
+ */
+healthzApp.get("/ready", (ctx) => {
+  const startMs = performance.now();
+
+  if (isInShutdown()) {
+    const durationMs = performance.now() - startMs;
+    getStatsDClient().distribution("healthz.ready.duration_ms", durationMs);
+    getStatsDClient().increment("healthz.ready.shutdown");
+
+    return ctx.json({ status: "shutting_down" }, 503);
+  }
+
+  const response = ctx.json({ status: "ready", commitHash: COMMIT_HASH }, 200);
+
+  const durationMs = performance.now() - startMs;
+  getStatsDClient().distribution("healthz.ready.duration_ms", durationMs);
+
+  return response;
+});
+
+const DEPENDENCY_CHECK_TIMEOUT_MS = 2000;
+
+type DependencyName = "redis" | "database";
+
+interface DependencyResult {
+  name: DependencyName;
+  ok: boolean;
+  error?: string;
+  durationMs: number;
+}
+
+async function checkDependency(
+  name: DependencyName,
+  check: () => Promise<unknown>
+): Promise<DependencyResult> {
+  const startMs = performance.now();
+  try {
+    await Promise.race([
+      check(),
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error(`${name} check timed out`)),
+          DEPENDENCY_CHECK_TIMEOUT_MS
+        )
+      ),
+    ]);
+    return { name, ok: true, durationMs: performance.now() - startMs };
+  } catch (err) {
+    return {
+      name,
+      ok: false,
+      error: normalizeError(err).message,
+      durationMs: performance.now() - startMs,
+    };
+  }
+}
+
+/**
+ * Startup probe endpoint.
+ *
+ * This endpoint checks that critical dependencies (Redis, DB) are connected before the pod starts
+ * accepting traffic. It's called during pod startup only.
+ *
+ */
+healthzApp.get("/startup", async (ctx) => {
+  const startMs = performance.now();
+
+  const results = await Promise.all([
+    checkDependency("redis", () => getRedisHybridManager().ping()),
+    checkDependency("database", () =>
+      // biome-ignore lint/plugin: health check needs direct DB ping
+      frontSequelize.query("SELECT 1")
+    ),
+  ]);
+
+  const failed = results.filter((r) => !r.ok);
+  const durationMs = performance.now() - startMs;
+
+  if (failed.length === 0) {
+    logger.info(
+      { durationMs, results },
+      "Startup probe succeeded - dependencies connected"
+    );
+
+    getStatsDClient().distribution("healthz.startup.duration_ms", durationMs, [
+      "status:success",
+    ]);
+
+    return ctx.json(
+      { status: "ready", durationMs, dependencies: results },
+      200
+    );
+  }
+
+  logger.warn(
+    { durationMs, results, failedDependencies: failed.map((r) => r.name) },
+    `Startup probe failed - ${failed.map((r) => r.name).join(", ")} not ready`
+  );
+
+  getStatsDClient().distribution("healthz.startup.duration_ms", durationMs, [
+    "status:failure",
+  ]);
+
+  return ctx.json(
+    { status: "not ready", durationMs, dependencies: results },
+    503
+  );
 });

--- a/front/pages/api/healthz/ready.ts
+++ b/front/pages/api/healthz/ready.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 import { COMMIT_HASH } from "@app/lib/commit-hash";
 import { isInShutdown } from "@app/lib/shutdown_signal";

--- a/front/pages/api/healthz/startup.ts
+++ b/front/pages/api/healthz/startup.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 /** @ignoreswagger */
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import { frontSequelize } from "@app/lib/resources/storage";


### PR DESCRIPTION
## Description

We recently changed the way we build bleeding-edge's front-api, removing the strangler.
As expected, it broke a few things, including the startup/readiness probes that were not migrated (and thus resulted in 404) 


these are the main endpoints used by k8s to promote a new replica-set, mark a pod a healthy, or to decide to kill it.

## Tests

Unit tests

## Risk

None

## Deploy Plan

- Merge