### PR TITLE
feat(dsbx): support file: value prefix in dsbx tool args

### DIFF
--- a/cli/dust-sandbox/src/commands/tools/exec.rs
+++ b/cli/dust-sandbox/src/commands/tools/exec.rs
@@ -76,8 +76,8 @@ pub async fn cmd_exec(
 /// Parse `--key value` pairs into a JSON object.
 /// Auto-detects numbers, booleans, JSON objects/arrays, and falls back to string.
 ///
-/// A value prefixed with `file:` is interpreted as a path reference: the
-/// file at that path is read (UTF-8, capped at 100 MB) and its contents
+/// A value prefixed with `__file__:` is interpreted as a path reference:
+/// the file at that path is read (UTF-8, capped at 100 MB) and its contents
 /// are used as a string value for the key. This bypasses type coercion
 /// and lets agents pass values larger than the OS argv limit (ARG_MAX)
 /// by writing them to disk first.
@@ -121,7 +121,7 @@ fn parse_args(raw: &[String]) -> anyhow::Result<Option<serde_json::Value>> {
 }
 
 fn coerce_value_or_read_file(s: &str) -> anyhow::Result<serde_json::Value> {
-    if let Some(path) = s.strip_prefix("file:") {
+    if let Some(path) = s.strip_prefix("__file__:") {
         return Ok(serde_json::Value::String(read_file_arg(path)?));
     }
     Ok(coerce_value(s))
@@ -129,18 +129,18 @@ fn coerce_value_or_read_file(s: &str) -> anyhow::Result<serde_json::Value> {
 
 fn read_file_arg(path: &str) -> anyhow::Result<String> {
     if path.is_empty() {
-        bail!("file: prefix requires a path");
+        bail!("__file__: prefix requires a path");
     }
     let metadata =
-        std::fs::metadata(path).with_context(|| format!("failed to stat file:{path}"))?;
+        std::fs::metadata(path).with_context(|| format!("failed to stat __file__:{path}"))?;
     if metadata.len() > MAX_FILE_ARG_SIZE_BYTES {
         bail!(
-            "file:{path} is {} bytes; exceeds the {MAX_FILE_ARG_SIZE_BYTES}-byte limit",
+            "__file__:{path} is {} bytes; exceeds the {MAX_FILE_ARG_SIZE_BYTES}-byte limit",
             metadata.len()
         );
     }
     std::fs::read_to_string(path)
-        .with_context(|| format!("failed to read file:{path} (must be UTF-8)"))
+        .with_context(|| format!("failed to read __file__:{path} (must be UTF-8)"))
 }
 
 fn coerce_value(s: &str) -> serde_json::Value {
@@ -277,7 +277,7 @@ mod tests {
         let file = write_tempfile(b"hello world");
         let args = vec![
             "--query".to_string(),
-            format!("file:{}", file.path().to_string_lossy()),
+            format!("__file__:{}", file.path().to_string_lossy()),
         ];
         let result = parse_args(&args)
             .expect("should parse")
@@ -290,7 +290,7 @@ mod tests {
         let file = write_tempfile(b"42");
         let args = vec![
             "--count".to_string(),
-            format!("file:{}", file.path().to_string_lossy()),
+            format!("__file__:{}", file.path().to_string_lossy()),
         ];
         let result = parse_args(&args)
             .expect("should parse")
@@ -301,7 +301,7 @@ mod tests {
 
     #[test]
     fn parse_file_prefix_empty_path_errors() {
-        let args = vec!["--query".to_string(), "file:".to_string()];
+        let args = vec!["--query".to_string(), "__file__:".to_string()];
         assert!(parse_args(&args).is_err());
     }
 
@@ -309,15 +309,15 @@ mod tests {
     fn parse_file_prefix_nonexistent_path_errors() {
         let args = vec![
             "--query".to_string(),
-            "file:/nonexistent/dsbx-test-12345".to_string(),
+            "__file__:/nonexistent/dsbx-test-12345".to_string(),
         ];
         assert!(parse_args(&args).is_err());
     }
 
     #[test]
     fn parse_value_without_file_prefix_treated_as_literal_string() {
-        // A value that doesn't start with `file:` is coerced normally; no
-        // filesystem touch.
+        // A value that doesn't start with `__file__:` is coerced normally;
+        // no filesystem touch.
         let args = vec!["--query".to_string(), "hello world".to_string()];
         let result = parse_args(&args)
             .expect("should parse")

--- a/cli/dust-sandbox/src/commands/tools/exec.rs
+++ b/cli/dust-sandbox/src/commands/tools/exec.rs
@@ -1,6 +1,8 @@
-use anyhow::bail;
+use anyhow::{bail, Context};
 
 use crate::api::{ContentBlock, DustApiClient};
+
+const MAX_FILE_ARG_SIZE_BYTES: u64 = 100 * 1024 * 1024;
 
 pub async fn cmd_exec(
     client: &DustApiClient,
@@ -73,6 +75,12 @@ pub async fn cmd_exec(
 
 /// Parse `--key value` pairs into a JSON object.
 /// Auto-detects numbers, booleans, JSON objects/arrays, and falls back to string.
+///
+/// A value prefixed with `file:` is interpreted as a path reference: the
+/// file at that path is read (UTF-8, capped at 100 MB) and its contents
+/// are used as a string value for the key. This bypasses type coercion
+/// and lets agents pass values larger than the OS argv limit (ARG_MAX)
+/// by writing them to disk first.
 fn parse_args(raw: &[String]) -> anyhow::Result<Option<serde_json::Value>> {
     if raw.is_empty() {
         return Ok(Some(serde_json::Value::Object(serde_json::Map::new())));
@@ -105,11 +113,34 @@ fn parse_args(raw: &[String]) -> anyhow::Result<Option<serde_json::Value>> {
             continue;
         }
 
-        map.insert(key, coerce_value(val));
+        map.insert(key, coerce_value_or_read_file(val)?);
         i += 1;
     }
 
     Ok(Some(serde_json::Value::Object(map)))
+}
+
+fn coerce_value_or_read_file(s: &str) -> anyhow::Result<serde_json::Value> {
+    if let Some(path) = s.strip_prefix("file:") {
+        return Ok(serde_json::Value::String(read_file_arg(path)?));
+    }
+    Ok(coerce_value(s))
+}
+
+fn read_file_arg(path: &str) -> anyhow::Result<String> {
+    if path.is_empty() {
+        bail!("file: prefix requires a path");
+    }
+    let metadata =
+        std::fs::metadata(path).with_context(|| format!("failed to stat file:{path}"))?;
+    if metadata.len() > MAX_FILE_ARG_SIZE_BYTES {
+        bail!(
+            "file:{path} is {} bytes; exceeds the {MAX_FILE_ARG_SIZE_BYTES}-byte limit",
+            metadata.len()
+        );
+    }
+    std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read file:{path} (must be UTF-8)"))
 }
 
 fn coerce_value(s: &str) -> serde_json::Value {
@@ -232,5 +263,65 @@ mod tests {
     fn parse_missing_dashes_errors() {
         let args = vec!["name".to_string(), "hello".to_string()];
         assert!(parse_args(&args).is_err());
+    }
+
+    fn write_tempfile(contents: &[u8]) -> tempfile::NamedTempFile {
+        use std::io::Write;
+        let mut file = tempfile::NamedTempFile::new().expect("create tempfile");
+        file.write_all(contents).expect("write tempfile");
+        file
+    }
+
+    #[test]
+    fn parse_file_prefix_reads_contents() {
+        let file = write_tempfile(b"hello world");
+        let args = vec![
+            "--query".to_string(),
+            format!("file:{}", file.path().to_string_lossy()),
+        ];
+        let result = parse_args(&args)
+            .expect("should parse")
+            .expect("should have value");
+        assert_eq!(result["query"], "hello world");
+    }
+
+    #[test]
+    fn parse_file_prefix_skips_coercion() {
+        let file = write_tempfile(b"42");
+        let args = vec![
+            "--count".to_string(),
+            format!("file:{}", file.path().to_string_lossy()),
+        ];
+        let result = parse_args(&args)
+            .expect("should parse")
+            .expect("should have value");
+        assert_eq!(result["count"], "42");
+        assert!(result["count"].is_string());
+    }
+
+    #[test]
+    fn parse_file_prefix_empty_path_errors() {
+        let args = vec!["--query".to_string(), "file:".to_string()];
+        assert!(parse_args(&args).is_err());
+    }
+
+    #[test]
+    fn parse_file_prefix_nonexistent_path_errors() {
+        let args = vec![
+            "--query".to_string(),
+            "file:/nonexistent/dsbx-test-12345".to_string(),
+        ];
+        assert!(parse_args(&args).is_err());
+    }
+
+    #[test]
+    fn parse_value_without_file_prefix_treated_as_literal_string() {
+        // A value that doesn't start with `file:` is coerced normally; no
+        // filesystem touch.
+        let args = vec!["--query".to_string(), "hello world".to_string()];
+        let result = parse_args(&args)
+            .expect("should parse")
+            .expect("should have value");
+        assert_eq!(result["query"], "hello world");
     }
 }

--- a/front/lib/resources/skill/code_defined/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.ts
@@ -30,7 +30,8 @@ function buildSandboxInstructionProse({
   if (hasDsbxTools) {
     instructions.push(
       "You can use the `dsbx` command line tool to list and run tools programmatically in the sandbox.",
-      "Use it with `dsbx tools [SERVER_NAME] [TOOL_NAME] [ARGS]...`. Run `dsbx tools --help` for more information."
+      "Use it with `dsbx tools [SERVER_NAME] [TOOL_NAME] [ARGS]...`. Run `dsbx tools --help` for more information.",
+      "For very large argument values, write the value to a file in the sandbox and pass the path with a `file:` prefix (e.g. `--query file:/tmp/q.txt`) instead of inlining the value on the command line. Any value starting with `file:` is read as a UTF-8 string (max 100 MB) and used as the value for that key. The file must already exist in the sandbox filesystem."
     );
   }
 

--- a/front/lib/resources/skill/code_defined/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.ts
@@ -31,7 +31,7 @@ function buildSandboxInstructionProse({
     instructions.push(
       "You can use the `dsbx` command line tool to list and run tools programmatically in the sandbox.",
       "Use it with `dsbx tools [SERVER_NAME] [TOOL_NAME] [ARGS]...`. Run `dsbx tools --help` for more information.",
-      "For very large argument values, write the value to a file in the sandbox and pass the path with a `file:` prefix (e.g. `--query file:/tmp/q.txt`) instead of inlining the value on the command line. Any value starting with `file:` is read as a UTF-8 string (max 100 MB) and used as the value for that key. The file must already exist in the sandbox filesystem."
+      "For very large argument values, write the value to a file in the sandbox and pass the path with a `__file__:` prefix (e.g. `--query __file__:/tmp/q.txt`) instead of inlining the value on the command line. Any value starting with `__file__:` is read as a UTF-8 string (max 100 MB) and used as the value for that key. The file must already exist in the sandbox filesystem."
     );
   }
 


### PR DESCRIPTION
## Description

Agents invoking `dsbx` tools in the sandbox could hit the OS `ARG_MAX` limit when passing multi-MB string values inline (e.g. PR-creation flows where a diff or file payload is passed as a literal argv string). bash rejects the `execve`, `dsbx` never runs, and the agent only sees an opaque `bash: /opt/bin/dsbx: Argument list too long`.

Repro:

```bash
HUGE=$(python3 -c "print('x' * 1000000)")
dsbx tools web_search_browse__websearch query "$HUGE" 2>&1 | head -20
# bash: line 4: /opt/bin/dsbx: Argument list too long
```

This PR adds two coordinated fixes:

1. **`dsbx` now accepts a `file:` value prefix** in tool args. Any value of the form `file:<path>` is interpreted as a path reference: the file is read as a UTF-8 string (max **100 MB**) and substituted for the key, bypassing argv entirely. Type coercion is skipped — the value is always a string.

   ```bash
   echo "$HUGE" > /tmp/q.txt
   dsbx tools web_search_browse__websearch --query file:/tmp/q.txt
   ```
2. **Sandbox skill prose** mentions the convention so the agent learns about `file:` proactively, not only after a failure.

## Tests

## Risk

The `file:` value prefix is additive: any value not starting with `file:` flows through the existing `coerce_value` path unchanged. No existing argument parses differently.

## Deploy Plan

- [ ] Build & publish new `dsbx`
- [ ] Deploy front