### PR TITLE
[connectors] chore: remove data source ID from upsert metric tags

### DIFF
--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -133,7 +133,6 @@ async function _upsertDataSourceDocument({
         parents,
       });
       const statsDTags = [
-        `data_source_Id:${dataSourceConfig.dataSourceId}`,
         `workspace_id:${dataSourceConfig.workspaceId}`,
       ];
 

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -210,7 +210,10 @@ async function _upsertDataSourceDocument({
           elapsed,
           statsDTags
         );
-        localLogger.info("Successfully uploaded document to Dust.");
+        localLogger.info(
+          { elapsed },
+          "Successfully uploaded document to Dust."
+        );
       } else {
         statsDClient.increment(
           "data_source_upserts_error.count",

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -132,9 +132,7 @@ async function _upsertDataSourceDocument({
         endpoint,
         parents,
       });
-      const statsDTags = [
-        `workspace_id:${dataSourceConfig.workspaceId}`,
-      ];
+      const statsDTags = [`workspace_id:${dataSourceConfig.workspaceId}`];
 
       localLogger.info("Attempting to upload document to Dust.");
       statsDClient.increment(


### PR DESCRIPTION
## Description

This PR drops the `data_source_Id` tag from the `data_source_upserts_xxx` metrics.
Goal is to reduce the cardinality of the metric https://app.datadoghq.eu/metric/volume?metric=data_source_upserts_success.duration.distribution&sort=-volume_total

The two main use cases for these metrics seem to be:
- Global anomaly detection: detecting when upsert duration/error rate is elevated across the board
- Per-customer investigation: confirming whether a specific customer is affected

Anomaly detection can be performed at the workspace-level, the per-data-source breakdown is available using the logs (added `elapsed` there).
Same for per-customer investigation, the main entry point is the workspace.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy connectors
