### PR TITLE
[front] chore: batch query to fetch workspaces in `webhookCleanupActivity`

### DIFF
--- a/front/lib/resources/webhook_request_resource.test.ts
+++ b/front/lib/resources/webhook_request_resource.test.ts
@@ -13,7 +13,7 @@ describe("WebhookRequestResource", () => {
       });
 
       const result =
-        await WebhookRequestResource.getWorkspaceIdsWithTooManyRequests({
+        await WebhookRequestResource.getWorkspacesWithTooManyRequests({
           maxWebhookRequestsToKeep: 1000,
           webhookRequestTtl: "30 day",
         });
@@ -55,7 +55,7 @@ describe("WebhookRequestResource", () => {
       await WebhookRequestModel.bulkCreate(requests);
 
       const result =
-        await WebhookRequestResource.getWorkspaceIdsWithTooManyRequests({
+        await WebhookRequestResource.getWorkspacesWithTooManyRequests({
           maxWebhookRequestsToKeep: 3,
           webhookRequestTtl: "30 day",
         });
@@ -95,7 +95,7 @@ describe("WebhookRequestResource", () => {
 
       // With custom limit of 3, this workspace should be returned
       const result =
-        await WebhookRequestResource.getWorkspaceIdsWithTooManyRequests({
+        await WebhookRequestResource.getWorkspacesWithTooManyRequests({
           maxWebhookRequestsToKeep: 3,
           webhookRequestTtl: "30 day",
         });
@@ -127,7 +127,7 @@ describe("WebhookRequestResource", () => {
       });
 
       const result =
-        await WebhookRequestResource.getWorkspaceIdsWithTooManyRequests({
+        await WebhookRequestResource.getWorkspacesWithTooManyRequests({
           maxWebhookRequestsToKeep: 1000,
           webhookRequestTtl: "30 day",
         });
@@ -159,7 +159,7 @@ describe("WebhookRequestResource", () => {
       });
 
       const result =
-        await WebhookRequestResource.getWorkspaceIdsWithTooManyRequests({
+        await WebhookRequestResource.getWorkspacesWithTooManyRequests({
           maxWebhookRequestsToKeep: 1000,
           webhookRequestTtl: "30 day",
         });
@@ -247,7 +247,7 @@ describe("WebhookRequestResource", () => {
       });
 
       const workspaces =
-        await WebhookRequestResource.getWorkspaceIdsWithTooManyRequests({
+        await WebhookRequestResource.getWorkspacesWithTooManyRequests({
           maxWebhookRequestsToKeep: 3,
           webhookRequestTtl: "30 day",
         });
@@ -301,7 +301,7 @@ describe("WebhookRequestResource", () => {
       });
 
       const result =
-        await WebhookRequestResource.getWorkspaceIdsWithTooManyRequests({
+        await WebhookRequestResource.getWorkspacesWithTooManyRequests({
           maxWebhookRequestsToKeep: 1000,
           webhookRequestTtl: "30 day",
         });
@@ -367,7 +367,7 @@ describe("WebhookRequestResource", () => {
       await WebhookRequestModel.bulkCreate(requests);
 
       const result =
-        await WebhookRequestResource.getWorkspaceIdsWithTooManyRequests({
+        await WebhookRequestResource.getWorkspacesWithTooManyRequests({
           maxWebhookRequestsToKeep: 3,
           webhookRequestTtl: "30 day",
         });
@@ -408,7 +408,7 @@ describe("WebhookRequestResource", () => {
 
       // Call with only the custom maxWebhookRequestsToKeep to test defaults for TTL
       const result =
-        await WebhookRequestResource.getWorkspaceIdsWithTooManyRequests({
+        await WebhookRequestResource.getWorkspacesWithTooManyRequests({
           maxWebhookRequestsToKeep: 3,
         });
 
@@ -446,7 +446,7 @@ describe("WebhookRequestResource", () => {
       await WebhookRequestModel.bulkCreate(requests);
 
       let result =
-        await WebhookRequestResource.getWorkspaceIdsWithTooManyRequests({
+        await WebhookRequestResource.getWorkspacesWithTooManyRequests({
           maxWebhookRequestsToKeep: 3,
           webhookRequestTtl: "30 day",
         });
@@ -465,7 +465,7 @@ describe("WebhookRequestResource", () => {
         updatedAt: new Date(),
       });
 
-      result = await WebhookRequestResource.getWorkspaceIdsWithTooManyRequests({
+      result = await WebhookRequestResource.getWorkspacesWithTooManyRequests({
         maxWebhookRequestsToKeep: 3,
         webhookRequestTtl: "30 day",
       });

--- a/front/lib/resources/webhook_request_resource.test.ts
+++ b/front/lib/resources/webhook_request_resource.test.ts
@@ -19,7 +19,9 @@ describe("WebhookRequestResource", () => {
         });
 
       expect(Array.isArray(result)).toBe(true);
-      expect(result).not.toContain(workspace.id);
+      expect(result.map((workspace) => workspace.id)).not.toContain(
+        workspace.id
+      );
     });
 
     it("should return workspaces that exceed max webhook requests limit", async () => {
@@ -58,7 +60,7 @@ describe("WebhookRequestResource", () => {
           webhookRequestTtl: "30 day",
         });
 
-      expect(result).toContain(workspace.id);
+      expect(result.map((workspace) => workspace.id)).toContain(workspace.id);
     });
 
     it("should respect the custom maxWebhookRequestsToKeep parameter", async () => {
@@ -98,7 +100,7 @@ describe("WebhookRequestResource", () => {
           webhookRequestTtl: "30 day",
         });
 
-      expect(result).toContain(workspace.id);
+      expect(result.map((workspace) => workspace.id)).toContain(workspace.id);
     });
 
     it("should return workspaces with old requests beyond TTL", async () => {
@@ -130,7 +132,7 @@ describe("WebhookRequestResource", () => {
           webhookRequestTtl: "30 day",
         });
 
-      expect(result).toContain(workspace.id);
+      expect(result.map((workspace) => workspace.id)).toContain(workspace.id);
     });
 
     it("should not return workspaces with old requests within TTL", async () => {
@@ -162,7 +164,9 @@ describe("WebhookRequestResource", () => {
           webhookRequestTtl: "30 day",
         });
 
-      expect(result).not.toContain(workspace.id);
+      expect(result.map((workspace) => workspace.id)).not.toContain(
+        workspace.id
+      );
     });
 
     it("should handle multiple workspaces correctly", async () => {
@@ -242,16 +246,18 @@ describe("WebhookRequestResource", () => {
         updatedAt: oldDate,
       });
 
-      const result =
+      const workspaces =
         await WebhookRequestResource.getWorkspaceIdsWithTooManyRequests({
           maxWebhookRequestsToKeep: 3,
           webhookRequestTtl: "30 day",
         });
 
+      const workspaceIds = workspaces.map((workspace) => workspace.id);
+
       // Workspace 1 and 3 should be returned, but not workspace 2
-      expect(result).toContain(workspace1.id);
-      expect(result).not.toContain(workspace2.id);
-      expect(result).toContain(workspace3.id);
+      expect(workspaceIds).toContain(workspace1.id);
+      expect(workspaceIds).not.toContain(workspace2.id);
+      expect(workspaceIds).toContain(workspace3.id);
     });
 
     it("should return results sorted by workspaceId ascending", async () => {
@@ -301,9 +307,9 @@ describe("WebhookRequestResource", () => {
         });
 
       // Filter to only include our test workspaces
-      const testResult = result.filter(
-        (id) => id === workspace1.id || id === workspace2.id
-      );
+      const testResult = result
+        .filter(({ id }) => id === workspace1.id || id === workspace2.id)
+        .map(({ id }) => id);
 
       // Verify sorted order
       if (testResult.length > 1) {
@@ -367,7 +373,7 @@ describe("WebhookRequestResource", () => {
         });
 
       // Total of 5 requests, should exceed limit of 3
-      expect(result).toContain(workspace.id);
+      expect(result.map((workspace) => workspace.id)).toContain(workspace.id);
     });
 
     it("should use default constants when not provided", async () => {
@@ -406,7 +412,7 @@ describe("WebhookRequestResource", () => {
           maxWebhookRequestsToKeep: 3,
         });
 
-      expect(result).toContain(workspace.id);
+      expect(result.map((workspace) => workspace.id)).toContain(workspace.id);
     });
 
     it("should handle edge case at boundary of max requests", async () => {
@@ -446,7 +452,9 @@ describe("WebhookRequestResource", () => {
         });
 
       // Should not be returned (HAVING COUNT(*) > limit)
-      expect(result).not.toContain(workspace.id);
+      expect(result.map((workspace) => workspace.id)).not.toContain(
+        workspace.id
+      );
 
       // Add one more request to exceed limit
       await WebhookRequestModel.create({
@@ -463,7 +471,7 @@ describe("WebhookRequestResource", () => {
       });
 
       // Should now be returned (4 > 3)
-      expect(result).toContain(workspace.id);
+      expect(result.map((workspace) => workspace.id)).toContain(workspace.id);
     });
   });
 

--- a/front/lib/resources/webhook_request_resource.ts
+++ b/front/lib/resources/webhook_request_resource.ts
@@ -6,6 +6,7 @@ import { BaseResource } from "@app/lib/resources/base_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type {
@@ -230,7 +231,7 @@ export class WebhookRequestResource extends BaseResource<WebhookRequestModel> {
   static async getWorkspaceIdsWithTooManyRequests({
     webhookRequestTtl = WEBHOOK_REQUEST_TTL,
     maxWebhookRequestsToKeep = MAX_WEBHOOK_REQUESTS_TO_KEEP,
-  }: Partial<CleanUpWorkspaceOptions> = {}) {
+  }: Partial<CleanUpWorkspaceOptions> = {}): Promise<WorkspaceResource[]> {
     // biome-ignore lint/plugin/noRawSql: automatic suppress
     const rows = await frontSequelize.query<{
       workspaceId: ModelId;
@@ -258,7 +259,9 @@ export class WebhookRequestResource extends BaseResource<WebhookRequestModel> {
       }
     );
 
-    return rows.map((row) => row.workspaceId);
+    return WorkspaceResource.fetchByModelIds(
+      rows.map((row) => row.workspaceId)
+    );
   }
 
   static async cleanUpWorkspace(

--- a/front/lib/resources/webhook_request_resource.ts
+++ b/front/lib/resources/webhook_request_resource.ts
@@ -228,7 +228,7 @@ export class WebhookRequestResource extends BaseResource<WebhookRequestModel> {
     });
   }
 
-  static async getWorkspaceIdsWithTooManyRequests({
+  static async getWorkspacesWithTooManyRequests({
     webhookRequestTtl = WEBHOOK_REQUEST_TTL,
     maxWebhookRequestsToKeep = MAX_WEBHOOK_REQUESTS_TO_KEEP,
   }: Partial<CleanUpWorkspaceOptions> = {}): Promise<WorkspaceResource[]> {

--- a/front/temporal/triggers_garbage_collect/activities.ts
+++ b/front/temporal/triggers_garbage_collect/activities.ts
@@ -4,7 +4,7 @@ import logger from "@app/logger/logger";
 
 export async function webhookCleanupActivity() {
   const workspacesToCleanup =
-    await WebhookRequestResource.getWorkspaceIdsWithTooManyRequests();
+    await WebhookRequestResource.getWorkspacesWithTooManyRequests();
 
   if (workspacesToCleanup.length === 0) {
     logger.info("No workspaces with too many webhook requests to cleanup.");

--- a/front/temporal/triggers_garbage_collect/activities.ts
+++ b/front/temporal/triggers_garbage_collect/activities.ts
@@ -1,6 +1,5 @@
 import { Authenticator } from "@app/lib/auth";
 import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
-import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
 
 export async function webhookCleanupActivity() {
@@ -12,12 +11,7 @@ export async function webhookCleanupActivity() {
     return;
   }
 
-  for (const workspaceId of workspacesToCleanup) {
-    const workspace = await WorkspaceResource.fetchByModelId(workspaceId);
-    if (!workspace) {
-      logger.error({ workspaceId }, "Workspace not found.");
-      continue;
-    }
+  for (const workspace of workspacesToCleanup) {
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
     await WebhookRequestResource.cleanUpWorkspace(auth);
     logger.info(


### PR DESCRIPTION
## Description

- This PR batches the query to fetch workspaces in `webhookCleanupActivity`, which were previously fetched in a loop.
- Also strenghtens the contract of `getWorkspaceIdsWithTooManyRequests` to return workspaces instead of raw model IDs.

## Tests

- Updated existing tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
