### PR TITLE
feat: double write to pods for copy, delete and create folder

### DIFF
--- a/front/lib/api/actions/servers/files/tools/copy.test.ts
+++ b/front/lib/api/actions/servers/files/tools/copy.test.ts
@@ -186,4 +186,66 @@ describe("copyHandler", () => {
     }
     expect(result.error.message).toContain("project conversations");
   });
+
+  it("dual-writes to the pods/ mirror when copying to a project mount", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    const workspaceId = auth.getNonNullableWorkspace().sId;
+    const projectId = conversation.spaceId;
+    assert(projectId, "Expected project conversation to have a spaceId");
+
+    const copyFileMock = vi.fn().mockResolvedValue(undefined);
+    const getMetadataMock = vi
+      .fn()
+      .mockResolvedValue([{ contentType: "application/pdf", size: "100" }]);
+    const mockBucket = {
+      file: vi.fn(() => ({ getMetadata: getMetadataMock })),
+      copyFile: copyFileMock,
+    };
+    vi.mocked(getPrivateUploadBucket).mockReturnValue(
+      mockBucket as unknown as ReturnType<typeof getPrivateUploadBucket>
+    );
+
+    const result = await copyHandler(
+      { source: "conversation/report.pdf", dest: "project/report.pdf" },
+      makeExtra(auth, conversation)
+    );
+
+    assert(result.isOk());
+
+    const sourcePath = `w/${workspaceId}/conversations/${conversation.sId}/files/report.pdf`;
+    const destProjectPath = `w/${workspaceId}/projects/${projectId}/files/report.pdf`;
+    const destPodsPath = `w/${workspaceId}/pods/${projectId}/files/report.pdf`;
+
+    expect(copyFileMock).toHaveBeenCalledTimes(2);
+    expect(copyFileMock).toHaveBeenNthCalledWith(
+      1,
+      sourcePath,
+      destProjectPath
+    );
+    expect(copyFileMock).toHaveBeenNthCalledWith(2, sourcePath, destPodsPath);
+  });
+
+  it("does not write to pods/ when copying to a conversation mount", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+
+    const copyFileMock = vi.fn().mockResolvedValue(undefined);
+    const getMetadataMock = vi
+      .fn()
+      .mockResolvedValue([{ contentType: "application/pdf", size: "100" }]);
+    const mockBucket = {
+      file: vi.fn(() => ({ getMetadata: getMetadataMock })),
+      copyFile: copyFileMock,
+    };
+    vi.mocked(getPrivateUploadBucket).mockReturnValue(
+      mockBucket as unknown as ReturnType<typeof getPrivateUploadBucket>
+    );
+
+    const result = await copyHandler(
+      { source: "project/spec.md", dest: "conversation/spec.md" },
+      makeExtra(auth, conversation)
+    );
+
+    assert(result.isOk());
+    expect(copyFileMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/front/lib/api/actions/servers/files/tools/copy.ts
+++ b/front/lib/api/actions/servers/files/tools/copy.ts
@@ -9,14 +9,17 @@ import {
   FILES_SERVER_NAME,
 } from "@app/lib/api/actions/servers/files/metadata";
 import { resolveMountPoint } from "@app/lib/api/actions/servers/files/tools/utils";
-import { getGCSPathFromScopedPath } from "@app/lib/api/files/gcs_mount/files";
+import {
+  copyMountFile,
+  getGCSPathFromScopedPath,
+} from "@app/lib/api/files/gcs_mount/files";
+import { parseScopedFilePath } from "@app/lib/api/files/mount_path";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import {
   isInteractiveContentType,
   stripMimeParameters,
 } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
 
 export async function copyHandler(
@@ -99,12 +102,31 @@ export async function copyHandler(
     );
   }
 
-  try {
-    await sourceFile.copy(bucket.file(destGcsPath));
-  } catch (err) {
+  const sourceParsed = parseScopedFilePath(source);
+  const destParsed = parseScopedFilePath(dest);
+  if (!sourceParsed || !destParsed) {
     return new Err(
       new MCPError(
-        `Failed to copy \`${source}\` to \`${dest}\`: ${normalizeError(err).message}`
+        "Invalid path: `source` or `dest` does not match the resolved mount point.",
+        { tracked: false }
+      )
+    );
+  }
+
+  const copyRes = await copyMountFile(auth, {
+    source: {
+      scope: sourceMountRes.value.scope,
+      relativeFilePath: sourceParsed.rel,
+    },
+    dest: {
+      scope: destMountRes.value.scope,
+      relativeFilePath: destParsed.rel,
+    },
+  });
+  if (copyRes.isErr()) {
+    return new Err(
+      new MCPError(
+        `Failed to copy \`${source}\` to \`${dest}\`: ${copyRes.error.message}`
       )
     );
   }

--- a/front/lib/api/actions/servers/files/tools/delete.test.ts
+++ b/front/lib/api/actions/servers/files/tools/delete.test.ts
@@ -1,0 +1,134 @@
+import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { deleteHandler } from "@app/lib/api/actions/servers/files/tools/delete";
+import { createConversation } from "@app/lib/api/assistant/conversation";
+import { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import assert from "assert";
+import { describe, expect, it, vi } from "vitest";
+
+function makeExtra(
+  auth: Authenticator,
+  conversation: ConversationType
+): ToolHandlerExtra {
+  const agentLoopContext = {
+    runContext: { conversation },
+  } as unknown as AgentLoopContextType;
+  return { auth, agentLoopContext } as unknown as ToolHandlerExtra;
+}
+
+async function setupProjectConversation(
+  role: "admin" | "user" = "admin"
+): Promise<{
+  auth: Authenticator;
+  conversation: ConversationType;
+}> {
+  const { authenticator: auth, workspace } = await createResourceTest({ role });
+  const user = auth.getNonNullableUser();
+
+  const space = await SpaceFactory.project(workspace, user.id);
+  const addRes = await space.addMembers(auth, { userIds: [user.sId] });
+  assert(addRes.isOk(), "Failed to add user to project space");
+
+  const projectAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+
+  const conversation = await createConversation(projectAuth, {
+    title: "Test",
+    visibility: "unlisted",
+    spaceId: space.id,
+  });
+
+  return {
+    auth: projectAuth,
+    conversation,
+  };
+}
+
+describe("deleteHandler", () => {
+  it("dual-deletes from the pods/ mirror when deleting from a project mount", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    const workspaceId = auth.getNonNullableWorkspace().sId;
+    const projectId = conversation.spaceId;
+    assert(projectId, "Expected project conversation to have a spaceId");
+
+    const deleteMock = vi.fn().mockResolvedValue(undefined);
+    const existsMock = vi.fn().mockResolvedValue([true]);
+    const mockBucket = {
+      file: vi.fn(() => ({ exists: existsMock })),
+      delete: deleteMock,
+    };
+    vi.mocked(getPrivateUploadBucket).mockReturnValue(
+      mockBucket as unknown as ReturnType<typeof getPrivateUploadBucket>
+    );
+
+    const result = await deleteHandler(
+      { path: "project/report.pdf" },
+      makeExtra(auth, conversation)
+    );
+
+    assert(result.isOk());
+
+    const projectPath = `w/${workspaceId}/projects/${projectId}/files/report.pdf`;
+    const podsPath = `w/${workspaceId}/pods/${projectId}/files/report.pdf`;
+
+    expect(deleteMock).toHaveBeenCalledTimes(2);
+    expect(deleteMock).toHaveBeenNthCalledWith(1, projectPath, {
+      ignoreNotFound: true,
+    });
+    expect(deleteMock).toHaveBeenNthCalledWith(2, podsPath, {
+      ignoreNotFound: true,
+    });
+  });
+
+  it("does not delete from pods/ when deleting from a conversation mount", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+
+    const deleteMock = vi.fn().mockResolvedValue(undefined);
+    const existsMock = vi.fn().mockResolvedValue([true]);
+    const mockBucket = {
+      file: vi.fn(() => ({ exists: existsMock })),
+      delete: deleteMock,
+    };
+    vi.mocked(getPrivateUploadBucket).mockReturnValue(
+      mockBucket as unknown as ReturnType<typeof getPrivateUploadBucket>
+    );
+
+    const result = await deleteHandler(
+      { path: "conversation/report.pdf" },
+      makeExtra(auth, conversation)
+    );
+
+    assert(result.isOk());
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns Err when the file does not exist", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+
+    const existsMock = vi.fn().mockResolvedValue([false]);
+    const mockBucket = {
+      file: vi.fn(() => ({ exists: existsMock })),
+      delete: vi.fn(),
+    };
+    vi.mocked(getPrivateUploadBucket).mockReturnValue(
+      mockBucket as unknown as ReturnType<typeof getPrivateUploadBucket>
+    );
+
+    const result = await deleteHandler(
+      { path: "project/missing.pdf" },
+      makeExtra(auth, conversation)
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) {
+      return;
+    }
+    expect(result.error.message).toContain("File not found");
+  });
+});

--- a/front/lib/api/actions/servers/files/tools/delete.ts
+++ b/front/lib/api/actions/servers/files/tools/delete.ts
@@ -4,10 +4,13 @@ import type {
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { resolveMountPoint } from "@app/lib/api/actions/servers/files/tools/utils";
-import { getGCSPathFromScopedPath } from "@app/lib/api/files/gcs_mount/files";
+import {
+  deleteGCSMountFile,
+  getGCSPathFromScopedPath,
+} from "@app/lib/api/files/gcs_mount/files";
+import { parseScopedFilePath } from "@app/lib/api/files/mount_path";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { Err, Ok } from "@app/types/shared/result";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 export async function deleteHandler(
   { path }: { path: string },
@@ -35,7 +38,8 @@ export async function deleteHandler(
     scopedPath: path,
     useCase: scope.useCase,
   });
-  if (!gcsPath) {
+  const parsed = parseScopedFilePath(path);
+  if (!gcsPath || !parsed) {
     return new Err(
       new MCPError(
         `Invalid path: \`${path}\` does not match the resolved mount point.`,
@@ -45,21 +49,20 @@ export async function deleteHandler(
   }
 
   const bucket = getPrivateUploadBucket();
-  const file = bucket.file(gcsPath);
-
-  const [exists] = await file.exists();
+  const [exists] = await bucket.file(gcsPath).exists();
   if (!exists) {
     return new Err(
       new MCPError(`File not found: \`${path}\`.`, { tracked: false })
     );
   }
 
-  try {
-    await file.delete();
-  } catch (err) {
+  const deleteRes = await deleteGCSMountFile(auth, scope, {
+    relativeFilePath: parsed.rel,
+  });
+  if (deleteRes.isErr()) {
     return new Err(
       new MCPError(
-        `Failed to delete file \`${path}\`: ${normalizeError(err).message}`
+        `Failed to delete file \`${path}\`: ${deleteRes.error.message}`
       )
     );
   }

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -240,6 +240,41 @@ describe("createGCSMountDirectory", () => {
     }
     expect(saveMock).not.toHaveBeenCalled();
   });
+
+  it("dual-writes the placeholder on the pods/ mirror for project use-case", async () => {
+    const entryRes = await createGCSMountDirectory(
+      auth,
+      { useCase: "project", projectId: "proj123" },
+      { relativeDirPath: "reports/q1" }
+    );
+
+    assert(entryRes.isOk());
+    const bucket = vi.mocked(getPrivateUploadBucket)();
+    expect(bucket.file).toHaveBeenCalledWith(
+      `w/${workspaceId}/projects/proj123/files/reports/q1/`
+    );
+    expect(bucket.file).toHaveBeenCalledWith(
+      `w/${workspaceId}/pods/proj123/files/reports/q1/`
+    );
+    expect(saveMock).toHaveBeenCalledTimes(2);
+    expect(saveMock).toHaveBeenNthCalledWith(1, Buffer.alloc(0), {
+      contentType: "application/x-directory",
+    });
+    expect(saveMock).toHaveBeenNthCalledWith(2, Buffer.alloc(0), {
+      contentType: "application/x-directory",
+    });
+  });
+
+  it("does not write to pods/ for conversation use-case", async () => {
+    const entryRes = await createGCSMountDirectory(
+      auth,
+      { useCase: "conversation", conversationId },
+      { relativeDirPath: "reports/q1" }
+    );
+
+    assert(entryRes.isOk());
+    expect(saveMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("listGCSMountFiles", () => {

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -485,6 +485,18 @@ export async function createGCSMountDirectory(
     await bucket.file(gcsPath).save(Buffer.alloc(0), {
       contentType: "application/x-directory",
     });
+
+    // Mirror the directory placeholder on the pods/ side for project files.
+    if (scope.useCase === "project") {
+      const podsPrefix = getPodFilesBasePath({
+        workspaceId: owner.sId,
+        projectId: scope.projectId,
+      });
+      const podsGcsPath = `${podsPrefix}${normalized}/`;
+      await bucket.file(podsGcsPath).save(Buffer.alloc(0), {
+        contentType: "application/x-directory",
+      });
+    }
   } catch (error) {
     return new Err(normalizeError(error));
   }


### PR DESCRIPTION
## Description

This PR extends the dual-write pattern to GCS pods for the `copy`, `delete`, and `create folder` file operations on project mounts.

- When a file is copied, deleted, or a folder is created in a project scope, the same operation is mirrored to the `pods/<projectId>/files/` GCS path in addition to `projects/<projectId>/files/`
- Conversation-scoped operations are unaffected

## Tests

Unit tests added for each operation (`copy.test.ts`, `delete.test.ts`, `gcs_mount/files.test.ts`) covering both the dual-write (project) and single-write (conversation) cases.

## Risks

<!-- Discuss potential risks and how they will be mitigated. -->

## Deploy Plan

<!-- Outline the deployment steps. -->
