### PR TITLE
Hubspot limit scopes

### DIFF
--- a/core/src/oauth/providers/hubspot.rs
+++ b/core/src/oauth/providers/hubspot.rs
@@ -60,19 +60,50 @@ impl Provider for HubspotConnectionProvider {
             .as_u64()
             .ok_or_else(|| anyhow!("Missing expires_in in response"))?;
 
+        let access_token = result["access_token"]
+            .as_str()
+            .ok_or_else(|| anyhow!("Missing access_token in response"))?
+            .to_string();
+
+        // HubSpot does not return granted scopes in the token response, so we call the
+        // introspection endpoint once at finalization time to store them in metadata.
+        let introspect_params = [
+            ("client_id", OAUTH_HUBSPOT_CLIENT_ID.as_str()),
+            ("client_secret", OAUTH_HUBSPOT_CLIENT_SECRET.as_str()),
+            ("token", access_token.as_str()),
+            ("token_type_hint", "access_token"),
+        ];
+        let introspect_req = self
+            .reqwest_client()
+            .post("https://api.hubapi.com/oauth/2026-03/token/introspect")
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .form(&introspect_params);
+        let introspect_result = execute_request(ConnectionProvider::Hubspot, introspect_req)
+            .await
+            .map_err(|e| self.handle_provider_request_error(e))?;
+
+        let extra_metadata = introspect_result["scopes"].as_array().map(|scopes| {
+            let scope_str = scopes
+                .iter()
+                .filter_map(|s| s.as_str())
+                .collect::<Vec<_>>()
+                .join(" ");
+            serde_json::Map::from_iter([(
+                "scope".to_string(),
+                serde_json::Value::String(scope_str),
+            )])
+        });
+
         Ok(FinalizeResult {
             redirect_uri: redirect_uri.to_string(),
             code: code.to_string(),
-            access_token: result["access_token"]
-                .as_str()
-                .ok_or_else(|| anyhow!("Missing access_token in response"))?
-                .to_string(),
+            access_token,
             access_token_expiry: Some(
                 crate::utils::now() + (expires_in - PROVIDER_TIMEOUT_SECONDS) * 1000,
             ),
             refresh_token: result["refresh_token"].as_str().map(|s| s.to_string()),
             raw_json: result,
-            extra_metadata: None,
+            extra_metadata,
         })
     }
 

--- a/front/lib/api/oauth/providers/hubspot.ts
+++ b/front/lib/api/oauth/providers/hubspot.ts
@@ -14,35 +14,10 @@ import type {
 } from "@app/types/oauth/lib";
 import { OAuthAPI } from "@app/types/oauth/oauth_api";
 import type { ParsedUrlQuery } from "querystring";
-import { z } from "zod";
-
-const ALL_OPTIONAL_SCOPES = [
-  "crm.objects.contacts.read",
-  "crm.objects.contacts.write",
-  "crm.schemas.contacts.read",
-  "crm.objects.companies.read",
-  "crm.objects.companies.write",
-  "crm.schemas.companies.read",
-  "crm.objects.deals.read",
-  "crm.objects.deals.write",
-  "crm.schemas.deals.read",
-  "crm.objects.owners.read",
-  "crm.schemas.custom.read",
-  "crm.objects.custom.read",
-  "crm.objects.quotes.read",
-  "crm.objects.line_items.read",
-  "files",
-  "sales-email-read",
-  "timeline",
-  "crm.lists.read",
-  "crm.lists.write",
-  "marketing-email",
-  "content",
-] as const;
-
-const HubSpotScrubbed = z.object({ scope: z.string() }).passthrough();
 
 export class HubspotOAuthProvider implements BaseOAuthStrategyProvider {
+  requiresWorkspaceConnectionForPersonalAuth = true;
+
   setupUri({
     connection,
     extraConfig,
@@ -53,21 +28,46 @@ export class HubspotOAuthProvider implements BaseOAuthStrategyProvider {
   }) {
     const requiredScopes = ["oauth"];
 
+    // Optional scopes - user can still install app without these
+    const optionalScopes = [
+      "crm.objects.contacts.read",
+      "crm.objects.contacts.write",
+      "crm.schemas.contacts.read",
+      "crm.objects.companies.read",
+      "crm.objects.companies.write",
+      "crm.schemas.companies.read",
+      "crm.objects.deals.read",
+      "crm.objects.deals.write",
+      "crm.schemas.deals.read",
+      "crm.objects.owners.read",
+      "crm.schemas.custom.read",
+      "crm.objects.custom.read",
+      "crm.objects.quotes.read",
+      "crm.objects.line_items.read",
+      "files",
+      "sales-email-read",
+      "timeline",
+      "crm.lists.read",
+      "crm.lists.write",
+      "marketing-email",
+      "content",
+    ];
+
     const workspaceGrantedScopes = extraConfig?.workspace_granted_scopes;
     const grantedSet =
       workspaceGrantedScopes && workspaceGrantedScopes.length > 0
         ? new Set(workspaceGrantedScopes.split(" "))
         : null;
-    const optionalScopes = grantedSet
-      ? ALL_OPTIONAL_SCOPES.filter((s) => grantedSet.has(s))
-      : ALL_OPTIONAL_SCOPES;
+    const filteredOptionalScopes = grantedSet
+      ? optionalScopes.filter((s) => grantedSet.has(s))
+      : optionalScopes;
 
     return (
       `https://app.hubspot.com/oauth/authorize` +
       `?client_id=${config.getOAuthHubspotClientId()}` +
       `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("hubspot"))}` +
       `&scope=${encodeURIComponent(requiredScopes.join(" "))}` +
-      `&optional_scope=${encodeURIComponent(optionalScopes.join(" "))}` +
+      `&optional_scope=${encodeURIComponent(filteredOptionalScopes.join(" "))}` +
       `&state=${connection.connection_id}`
     );
   }
@@ -113,21 +113,25 @@ export class HubspotOAuthProvider implements BaseOAuthStrategyProvider {
     }
 
     const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
-    const tokenRes = await oauthApi.getAccessToken({
+    const metadataRes = await oauthApi.getConnectionMetadata({
       connectionId: oauthConnectionIdRes.value,
     });
-    if (tokenRes.isErr()) {
+    if (metadataRes.isErr()) {
       throw new Error(
-        "Failed to get workspace connection: " + tokenRes.error.message
+        "Failed to get workspace connection metadata: " +
+          metadataRes.error.message
       );
     }
 
-    const parsed = HubSpotScrubbed.safeParse(tokenRes.value.scrubbed_raw_json);
-    const workspaceGrantedScopes = parsed.success ? parsed.data.scope : "";
+    const { scope } = metadataRes.value.connection.metadata;
+
+    if (!scope) {
+      return extraConfig;
+    }
 
     return {
       ...extraConfig,
-      workspace_granted_scopes: workspaceGrantedScopes,
+      workspace_granted_scopes: scope,
     };
   }
 }

--- a/front/lib/api/oauth/providers/hubspot.ts
+++ b/front/lib/api/oauth/providers/hubspot.ts
@@ -1,50 +1,66 @@
 import config from "@app/lib/api/config";
+import { getWorkspaceOAuthConnectionIdForMCPServer } from "@app/lib/api/oauth/mcp_server_connection_auth";
 import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
 import {
   finalizeUriForProvider,
   getStringFromQuery,
 } from "@app/lib/api/oauth/utils";
+import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
 import type {
   ExtraConfigType,
   OAuthConnectionType,
   OAuthUseCase,
 } from "@app/types/oauth/lib";
+import { OAuthAPI } from "@app/types/oauth/oauth_api";
 import type { ParsedUrlQuery } from "querystring";
+import { z } from "zod";
+
+const ALL_OPTIONAL_SCOPES = [
+  "crm.objects.contacts.read",
+  "crm.objects.contacts.write",
+  "crm.schemas.contacts.read",
+  "crm.objects.companies.read",
+  "crm.objects.companies.write",
+  "crm.schemas.companies.read",
+  "crm.objects.deals.read",
+  "crm.objects.deals.write",
+  "crm.schemas.deals.read",
+  "crm.objects.owners.read",
+  "crm.schemas.custom.read",
+  "crm.objects.custom.read",
+  "crm.objects.quotes.read",
+  "crm.objects.line_items.read",
+  "files",
+  "sales-email-read",
+  "timeline",
+  "crm.lists.read",
+  "crm.lists.write",
+  "marketing-email",
+  "content",
+] as const;
+
+const HubSpotScrubbed = z.object({ scope: z.string() }).passthrough();
 
 export class HubspotOAuthProvider implements BaseOAuthStrategyProvider {
   setupUri({
     connection,
+    extraConfig,
   }: {
     connection: OAuthConnectionType;
     useCase: OAuthUseCase;
+    extraConfig?: ExtraConfigType;
   }) {
-    // Required scopes - user must have access to these
     const requiredScopes = ["oauth"];
 
-    // Optional scopes - user can still install app without these
-    const optionalScopes = [
-      "crm.objects.contacts.read",
-      "crm.objects.contacts.write",
-      "crm.schemas.contacts.read",
-      "crm.objects.companies.read",
-      "crm.objects.companies.write",
-      "crm.schemas.companies.read",
-      "crm.objects.deals.read",
-      "crm.objects.deals.write",
-      "crm.schemas.deals.read",
-      "crm.objects.owners.read",
-      "crm.schemas.custom.read",
-      "crm.objects.custom.read",
-      "crm.objects.quotes.read",
-      "crm.objects.line_items.read",
-      "files",
-      "sales-email-read",
-      "timeline",
-      "crm.lists.read",
-      "crm.lists.write",
-      "marketing-email",
-      "content",
-    ];
+    const workspaceGrantedScopes = extraConfig?.workspace_granted_scopes;
+    const grantedSet =
+      workspaceGrantedScopes && workspaceGrantedScopes.length > 0
+        ? new Set(workspaceGrantedScopes.split(" "))
+        : null;
+    const optionalScopes = grantedSet
+      ? ALL_OPTIONAL_SCOPES.filter((s) => grantedSet.has(s))
+      : ALL_OPTIONAL_SCOPES;
 
     return (
       `https://app.hubspot.com/oauth/authorize` +
@@ -71,5 +87,47 @@ export class HubspotOAuthProvider implements BaseOAuthStrategyProvider {
       }
     }
     return Object.keys(extraConfig).length === 0;
+  }
+
+  async getUpdatedExtraConfig(
+    auth: Authenticator,
+    {
+      extraConfig,
+      useCase,
+    }: {
+      extraConfig: ExtraConfigType;
+      useCase: OAuthUseCase;
+    }
+  ): Promise<ExtraConfigType> {
+    if (useCase !== "personal_actions" || !extraConfig.mcp_server_id) {
+      return extraConfig;
+    }
+
+    const oauthConnectionIdRes =
+      await getWorkspaceOAuthConnectionIdForMCPServer(
+        auth,
+        extraConfig.mcp_server_id
+      );
+    if (oauthConnectionIdRes.isErr()) {
+      throw new Error(oauthConnectionIdRes.error.message);
+    }
+
+    const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+    const tokenRes = await oauthApi.getAccessToken({
+      connectionId: oauthConnectionIdRes.value,
+    });
+    if (tokenRes.isErr()) {
+      throw new Error(
+        "Failed to get workspace connection: " + tokenRes.error.message
+      );
+    }
+
+    const parsed = HubSpotScrubbed.safeParse(tokenRes.value.scrubbed_raw_json);
+    const workspaceGrantedScopes = parsed.success ? parsed.data.scope : "";
+
+    return {
+      ...extraConfig,
+      workspace_granted_scopes: workspaceGrantedScopes,
+    };
   }
 }


### PR DESCRIPTION
## Description

To fix: https://github.com/dust-tt/tasks/issues/8138

HubSpot OAuth uses two scope categories: required (`oauth`) and optional (CRM, files, timeline, etc.). When an admin installs the HubSpot MCP connector at the workspace level, they approve a subset of optional scopes. Until this PR, when a user then connected their personal credentials, the OAuth consent screen offered ALL optional scopes, meaning a user could request permissions the admin never granted if that user had the app_marketplace permission.

**Root cause:** HubSpot does not include granted scopes in the token response (neither the initial authorization response nor refresh responses). The `oauth` service had no record of which scopes the admin actually approved.

**`core/src/oauth/providers/hubspot.rs`**

At workspace connection finalization, after exchanging the authorization code for tokens, we now call HubSpot's token introspection endpoint (`POST https://api.hubapi.com/oauth/2026-03/token/introspect`, the current date-versioned API replacing the deprecated v1). The introspection response includes the `scopes` array of actually-granted scopes. We join them as a space-separated string and store the result in `extra_metadata` under the key `scope`, which gets persisted into the connection's metadata.

This call is **fatal**: if introspection fails, workspace OAuth finalization fails entirely. Making it non-fatal would be a somewhat security issue a missing `scope` in metadata causes the personal auth flow to fall back to offering all optional scopes, defeating the whole feature (even if it was only possible to override for people in Hubspot who have the right to install an app on their Hubspot).

**`front/lib/api/oauth/providers/hubspot.ts`**

- `requiresWorkspaceConnectionForPersonalAuth = true`: enforces that a workspace-level connection must exist before a user can connect personal credentials.
- `getUpdatedExtraConfig`: before building the personal auth OAuth URL, fetches the workspace connection's metadata (via `getConnectionMetadata`, which does not trigger a token refresh) and injects the stored `scope` value as `workspace_granted_scopes` in `extraConfig`.
- `setupUri`: reads `workspace_granted_scopes` from `extraConfig`, builds a `Set` of admin-approved scopes, and filters the optional scopes list down to only those. If `workspace_granted_scopes` is absent (pre-existing connections created before this fix), the full list is used as a fallback.

Note: HubSpot's refresh token response also does not include scopes. Scopes are fixed at authorization time and cannot change on refresh, so calling introspection once at finalization and storing the result permanently is correct and sufficient.

## Tests

Tested manually end-to-end:
1. Installed HubSpot at workspace level with a specific subset of optional scopes approved.
2. Verified the workspace connection's metadata contains a `scope` field with the exact approved scopes (space-separated).
3. Connected personal credentials as a second user -> confirmed the OAuth consent screen only offered the scopes the admin approved, not the full list.


## Risk

Low. The only behavioral change for existing workspace connections (created before this PR) is that personal auth will fall back to offering all optional scopes, which is the current behavior. No regression.

The only new failure mode is: if HubSpot's introspection endpoint is down at the moment of workspace OAuth finalization, the admin will get an error and need to retry. This is intentional (see description).

Rollback is safe: both changes are additive. The Rust change populates a previously-null `extra_metadata` field; the TypeScript change reads it but falls back gracefully if absent.

## Deploy Plan

Deploy oauth, then deploy front. 
