### PR TITLE
Remove isLegacyPlan + Navigation scaffolding for new Billing page

### DIFF
--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -289,7 +289,7 @@ export const subNavigationAdmin = ({
           href: `/w/${owner.sId}/analytics`,
           current: isCurrent("analytics"),
         },
-        subscription.plan && isCreditPricedPlan(subscription.plan)
+        isCreditPricedPlan(subscription.plan)
           ? {
               id: "billing",
               label: "Billing",

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -264,7 +264,7 @@ export const subNavigationAdmin = ({
           href: `/w/${owner.sId}/workspace`,
           current: isCurrent("workspace"),
         },
-        ...(isCreditPricedPlanPrefix(subscription.plan.code)
+        ...(isCreditPricedPlan(subscription.plan)
           ? [
               {
                 id: "usage" as const,

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -1,3 +1,4 @@
+import { isLegacyPlan } from "@app/lib/metronome/plan_type";
 import { isCreditPricedPlan } from "@app/lib/plans/plan_codes";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { AppType } from "@app/types/app";
@@ -79,6 +80,7 @@ export type SubNavigationAssistantsId =
 
 export type SubNavigationAdminId =
   | "subscription"
+  | "billing"
   | "workspace"
   | "model_providers"
   | "members"
@@ -97,6 +99,7 @@ export const ADMIN_ROUTE_PATTERNS: Record<SubNavigationAdminId, string[]> = {
   model_providers: ["/w/[wId]/model-providers"],
   analytics: ["/w/[wId]/analytics"],
   subscription: ["/w/[wId]/subscription"],
+  billing: ["/w/[wId]/subscription"],
   api_keys: ["/w/[wId]/developers/api-keys"],
   credits_usage: ["/w/[wId]/developers/credits-usage"],
   providers: ["/w/[wId]/developers/providers"],
@@ -288,13 +291,21 @@ export const subNavigationAdmin = ({
           href: `/w/${owner.sId}/analytics`,
           current: isCurrent("analytics"),
         },
-        {
-          id: "subscription",
-          label: "Subscription",
-          icon: CardIcon,
-          href: `/w/${owner.sId}/subscription`,
-          current: isCurrent("subscription"),
-        },
+        subscription.plan && !isLegacyPlan(subscription.plan)
+          ? {
+              id: "billing",
+              label: "Billing",
+              icon: CardIcon,
+              href: `/w/${owner.sId}/subscription`,
+              current: isCurrent("subscription"),
+            }
+          : {
+              id: "subscription",
+              label: "Subscription",
+              icon: CardIcon,
+              href: `/w/${owner.sId}/subscription`,
+              current: isCurrent("subscription"),
+            },
       ],
     });
 

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -1,5 +1,4 @@
-import { isLegacyPlan } from "@app/lib/metronome/plan_type";
-import { isCreditPricedPlan } from "@app/lib/plans/plan_codes";
+import { isCreditPricedPlanPrefix } from "@app/lib/plans/plan_codes";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { AppType } from "@app/types/app";
 import type { SubscriptionType } from "@app/types/plan";
@@ -266,7 +265,7 @@ export const subNavigationAdmin = ({
           href: `/w/${owner.sId}/workspace`,
           current: isCurrent("workspace"),
         },
-        ...(isCreditPricedPlan(subscription.plan.code)
+        ...(isCreditPricedPlanPrefix(subscription.plan.code)
           ? [
               {
                 id: "usage" as const,
@@ -291,7 +290,7 @@ export const subNavigationAdmin = ({
           href: `/w/${owner.sId}/analytics`,
           current: isCurrent("analytics"),
         },
-        subscription.plan && !isLegacyPlan(subscription.plan)
+        subscription.plan && isCreditPricedPlanPrefix(subscription.plan.code)
           ? {
               id: "billing",
               label: "Billing",

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -1,7 +1,6 @@
-import { isCreditPricedPlanPrefix } from "@app/lib/plans/plan_codes";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { AppType } from "@app/types/app";
-import type { SubscriptionType } from "@app/types/plan";
+import { isCreditPricedPlan, type SubscriptionType } from "@app/types/plan";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { WorkspaceType } from "@app/types/user";
 import { isAdmin, isBuilder } from "@app/types/user";
@@ -290,7 +289,7 @@ export const subNavigationAdmin = ({
           href: `/w/${owner.sId}/analytics`,
           current: isCurrent("analytics"),
         },
-        subscription.plan && isCreditPricedPlanPrefix(subscription.plan.code)
+        subscription.plan && isCreditPricedPlan(subscription.plan)
           ? {
               id: "billing",
               label: "Billing",

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -7,7 +7,7 @@ import { EditSpendLimitModal } from "@app/components/workspace/EditSpendLimitMod
 import { MembersUsageTable } from "@app/components/workspace/MembersUsageTable";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
-import { isCreditPricedPlan, isUpgraded } from "@app/lib/plans/plan_codes";
+import { isCreditPricedPlanPrefix, isUpgraded } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
 import {
   useAwuPoolSummary,
@@ -135,7 +135,7 @@ export function UsagePage() {
   const owner = useWorkspace();
   const { subscription } = useAuth();
   const router = useAppRouter();
-  const isCreditPriced = isCreditPricedPlan(subscription.plan.code);
+  const isCreditPriced = isCreditPricedPlanPrefix(subscription.plan.code);
   const [searchTerm, setSearchTerm] = useState("");
   const [seatTypeFilter, setSeatTypeFilter] = useState<
     MembershipSeatType | "none" | null

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -7,7 +7,10 @@ import { EditSpendLimitModal } from "@app/components/workspace/EditSpendLimitMod
 import { MembersUsageTable } from "@app/components/workspace/MembersUsageTable";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
-import { isCreditPricedPlanPrefix, isUpgraded } from "@app/lib/plans/plan_codes";
+import {
+  isCreditPricedPlanPrefix,
+  isUpgraded,
+} from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
 import {
   useAwuPoolSummary,

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -7,10 +7,7 @@ import { EditSpendLimitModal } from "@app/components/workspace/EditSpendLimitMod
 import { MembersUsageTable } from "@app/components/workspace/MembersUsageTable";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
-import {
-  isCreditPricedPlanPrefix,
-  isUpgraded,
-} from "@app/lib/plans/plan_codes";
+import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
 import {
   useAwuPoolSummary,
@@ -24,6 +21,7 @@ import {
   useWorkspaceSeatAvailability,
 } from "@app/lib/swr/workspaces";
 import type { MembershipSeatType } from "@app/types/memberships";
+import { isCreditPricedPlan } from "@app/types/plan";
 import { isAdmin } from "@app/types/user";
 import {
   ActionCreditCoinsIcon,
@@ -138,7 +136,7 @@ export function UsagePage() {
   const owner = useWorkspace();
   const { subscription } = useAuth();
   const router = useAppRouter();
-  const isCreditPriced = isCreditPricedPlanPrefix(subscription.plan.code);
+  const isCreditPriced = isCreditPricedPlan(subscription.plan);
   const [searchTerm, setSearchTerm] = useState("");
   const [seatTypeFilter, setSeatTypeFilter] = useState<
     MembershipSeatType | "none" | null

--- a/front/components/poke/subscriptions/FreePlanUpgradeDialog.tsx
+++ b/front/components/poke/subscriptions/FreePlanUpgradeDialog.tsx
@@ -4,15 +4,11 @@ import {
   SelectField,
 } from "@app/components/poke/shadcn/ui/form/fields";
 import { clientFetch } from "@app/lib/egress/client";
-import {
-  isCreditPricedPlanPrefix,
-  isFreePlan,
-  isOldFreePlan,
-} from "@app/lib/plans/plan_codes";
+import { isFreePlan, isOldFreePlan } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
 import { usePokePlans } from "@app/lib/swr/poke";
 import type { FreePlanUpgradeFormType } from "@app/types/plan";
-import { FreePlanUpgradeFormSchema } from "@app/types/plan";
+import { FreePlanUpgradeFormSchema, isCreditPricedPlan } from "@app/types/plan";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { WorkspaceType } from "@app/types/user";
 import {
@@ -149,7 +145,7 @@ export default function FreePlanUpgradeDialog({
                           (plan) =>
                             isFreePlan(plan.code) &&
                             !isOldFreePlan(plan.code) &&
-                            !isCreditPricedPlanPrefix(plan.code)
+                            !isCreditPricedPlan(plan)
                         )
                         .map((plan) => ({
                           value: plan.code,

--- a/front/components/poke/subscriptions/FreePlanUpgradeDialog.tsx
+++ b/front/components/poke/subscriptions/FreePlanUpgradeDialog.tsx
@@ -5,7 +5,7 @@ import {
 } from "@app/components/poke/shadcn/ui/form/fields";
 import { clientFetch } from "@app/lib/egress/client";
 import {
-  isCreditPricedPlan,
+  isCreditPricedPlanPrefix,
   isFreePlan,
   isOldFreePlan,
 } from "@app/lib/plans/plan_codes";
@@ -149,7 +149,7 @@ export default function FreePlanUpgradeDialog({
                           (plan) =>
                             isFreePlan(plan.code) &&
                             !isOldFreePlan(plan.code) &&
-                            !isCreditPricedPlan(plan.code)
+                            !isCreditPricedPlanPrefix(plan.code)
                         )
                         .map((plan) => ({
                           value: plan.code,

--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -8,7 +8,7 @@ import { isPaygEligibleTier } from "@app/lib/metronome/types";
 import {
   CREDIT_PRICED_BUSINESS_PLAN_CODE,
   CREDIT_PRICED_FREE_PLAN_CODE,
-  isCreditPricedPlan,
+  isCreditPricedPlanPrefix,
   isEntreprisePlanPrefix,
   PRO_PLAN_SEAT_29_CODE,
   PRO_PLAN_SEAT_39_CODE,
@@ -250,7 +250,7 @@ export default function SwitchContractDialog({
       plans
         .filter(
           (plan) =>
-            isEntreprisePlanPrefix(plan.code) && isCreditPricedPlan(plan.code)
+            isEntreprisePlanPrefix(plan.code) && isCreditPricedPlanPrefix(plan.code)
         )
         .map((plan) => ({
           value: plan.code,

--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -8,7 +8,6 @@ import { isPaygEligibleTier } from "@app/lib/metronome/types";
 import {
   CREDIT_PRICED_BUSINESS_PLAN_CODE,
   CREDIT_PRICED_FREE_PLAN_CODE,
-  isCreditPricedPlanPrefix,
   isEntreprisePlanPrefix,
   PRO_PLAN_SEAT_29_CODE,
   PRO_PLAN_SEAT_39_CODE,
@@ -20,6 +19,7 @@ import {
   usePokeStripeCustomerCurrency,
 } from "@app/lib/swr/poke";
 import assert from "@app/lib/utils/assert";
+import { isCreditPricedPlan } from "@app/types/plan";
 import type { ProgrammaticUsageConfigurationType } from "@app/types/programmatic_usage";
 import type { WorkspaceType } from "@app/types/user";
 import {
@@ -250,8 +250,7 @@ export default function SwitchContractDialog({
       plans
         .filter(
           (plan) =>
-            isEntreprisePlanPrefix(plan.code) &&
-            isCreditPricedPlanPrefix(plan.code)
+            isEntreprisePlanPrefix(plan.code) && isCreditPricedPlan(plan)
         )
         .map((plan) => ({
           value: plan.code,

--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -250,7 +250,8 @@ export default function SwitchContractDialog({
       plans
         .filter(
           (plan) =>
-            isEntreprisePlanPrefix(plan.code) && isCreditPricedPlanPrefix(plan.code)
+            isEntreprisePlanPrefix(plan.code) &&
+            isCreditPricedPlanPrefix(plan.code)
         )
         .map((plan) => ({
           value: plan.code,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -61,7 +61,6 @@ import { isModelAvailable, isProviderWhitelisted } from "@app/lib/assistant";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { extractFromString, serializeMention } from "@app/lib/mentions/format";
-import { isLegacyPlan } from "@app/lib/metronome/plan_type";
 import { isUserBlocked } from "@app/lib/metronome/user_block";
 import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
 import {
@@ -146,6 +145,7 @@ import type {
   ContentFragmentType,
 } from "@app/types/content_fragment";
 import type { APIErrorWithStatusCode } from "@app/types/error";
+import { isCreditPricedPlan } from "@app/types/plan";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -2391,7 +2391,7 @@ async function checkMessagesLimit(
   const owner = auth.getNonNullableWorkspace();
   const plan = auth.subscription()?.plan;
   const user = auth.user();
-  if (owner.metronomeCustomerId && plan && !isLegacyPlan(plan) && user) {
+  if (owner.metronomeCustomerId && plan && isCreditPricedPlan(plan) && user) {
     const blocked = await isUserBlocked(owner.sId, user.sId);
     if (blocked) {
       return new Err({

--- a/front/lib/credits/awu_purchase.test.ts
+++ b/front/lib/credits/awu_purchase.test.ts
@@ -41,6 +41,14 @@ vi.mock("@app/lib/metronome/plan_type", async () => {
   };
 });
 
+vi.mock("@app/types/plan", async () => {
+  const actual = await vi.importActual("@app/types/plan");
+  return {
+    ...actual,
+    isCreditPricedPlan: vi.fn(),
+  };
+});
+
 vi.mock("@app/lib/plans/stripe", async () => {
   const actual = await vi.importActual("@app/lib/plans/stripe");
   return {

--- a/front/lib/credits/awu_purchase.test.ts
+++ b/front/lib/credits/awu_purchase.test.ts
@@ -5,13 +5,13 @@ import { getCreditTypeFromContract } from "@app/lib/metronome/coupons";
 import {
   type CachedContract,
   getActiveContract,
-  isLegacyPlan,
 } from "@app/lib/metronome/plan_type";
 import { getStripeClient } from "@app/lib/plans/stripe";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { isCreditPricedPlan } from "@app/types/plan";
 import { Ok } from "@app/types/shared/result";
 import type Stripe from "stripe";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -99,7 +99,7 @@ describe("getAwuPurchaseInfo", () => {
       workspace.sId
     );
 
-    vi.mocked(isLegacyPlan).mockReturnValue(false);
+    vi.mocked(isCreditPricedPlan).mockReturnValue(true);
     vi.mocked(getMetronomeCustomerStripeCustomerId).mockResolvedValue(
       new Ok("cus_123")
     );

--- a/front/lib/credits/awu_purchase.ts
+++ b/front/lib/credits/awu_purchase.ts
@@ -19,11 +19,14 @@ import {
   getProductPrepaidCommitId,
 } from "@app/lib/metronome/constants";
 import { getCreditTypeFromContract } from "@app/lib/metronome/coupons";
-import { getActiveContract, isLegacyPlan } from "@app/lib/metronome/plan_type";
+import { getActiveContract } from "@app/lib/metronome/plan_type";
 import { getStripeClient } from "@app/lib/plans/stripe";
 import logger from "@app/logger/logger";
 import type { SupportedCurrency } from "@app/types/currency";
-import { isSubscriptionMetronomeBilled } from "@app/types/plan";
+import {
+  isCreditPricedPlan,
+  isSubscriptionMetronomeBilled,
+} from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type Stripe from "stripe";
@@ -126,7 +129,7 @@ async function checkAwuPurchaseEligibility(
     return new Err({ code: "not_metronome_billed" });
   }
 
-  if (isLegacyPlan(subscription.plan)) {
+  if (!isCreditPricedPlan(subscription.plan)) {
     return new Err({ code: "legacy_plan" });
   }
 

--- a/front/lib/metronome/plan_type.ts
+++ b/front/lib/metronome/plan_type.ts
@@ -1,10 +1,8 @@
 import { getMetronomeClient } from "@app/lib/metronome/client";
 import { SubscriptionModel } from "@app/lib/models/plan";
-import { isCreditPricedPlan } from "@app/lib/plans/plan_codes";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { cacheWithRedis, invalidateCacheWithRedis } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
-import type { PlanType } from "@app/types/plan";
 import type { ContractV2 } from "@metronome/sdk/resources";
 
 // Commits and credits are stripped before caching — their balances/ledgers change
@@ -83,17 +81,6 @@ export async function getActiveContract(
   workspaceId: string
 ): Promise<CachedContract | null> {
   return await getCachedActiveContract(workspaceId);
-}
-
-/**
- * Returns true if the workspace is on a legacy Metronome plan.
- *
- * Legacy plans price the `Programmatic Usage` product (programmatic-USD credit
- * type); new plans bill all usage in AWU. Fails open (returns true) when the
- * plan cannot be determined.
- */
-export function isLegacyPlan(plan: PlanType): boolean {
-  return !isCreditPricedPlan(plan.code);
 }
 
 /**

--- a/front/lib/plans/plan_codes.ts
+++ b/front/lib/plans/plan_codes.ts
@@ -35,7 +35,7 @@ export const REINFORCEMENT_EXCLUDED_PLAN_CODES = new Set([
 ]);
 
 // Credit priced plan billed/tracked through Metronome and not legacy.
-export const isCreditPricedPlan = (planCode: string) =>
+export const isCreditPricedPlanPrefix = (planCode: string) =>
   planCode.startsWith("CP_");
 
 // If the plan code starts with ENT_, it's an entreprise plan

--- a/front/types/plan.ts
+++ b/front/types/plan.ts
@@ -1,3 +1,4 @@
+import { isCreditPricedPlanPrefix } from "@app/lib/plans/plan_codes";
 import * as t from "io-ts";
 import { NonEmptyString } from "io-ts-types/lib/NonEmptyString";
 import { NumberFromString } from "io-ts-types/lib/NumberFromString";
@@ -113,6 +114,22 @@ export function isSubscriptionMetronomeBilled(
     subscription.metronomeContractId !== null &&
     !isSubscriptionStripeBilled(subscription)
   );
+}
+
+/**
+ * Returns true if the workspace is on a credit-priced plan.
+ *
+ * Credit-priced plans are prefixed by CP_ by convention.
+ *
+ * - isCreditPricedPlan && isSubscriptionMetronomeBilled: new credit-priced plans.
+ * - isCredeitPricedPlan && !isSubscriptionMetronomeBilled: no possible.
+ * - !isCreditPricedPlan && !isSubscriptionStripeBilled: Legacy PRO/Business (before transition to
+ *   metronome) and Enterprise before renewal
+ * - !isCreditPricedPlan && isSubscriptionStripeBilled: Legacy PRO/Business (after transition to
+ *   metronome)
+ */
+export function isCreditPricedPlan(plan: PlanType): boolean {
+  return !isCreditPricedPlanPrefix(plan.code);
 }
 
 export type BillingPeriod = "monthly" | "yearly";

--- a/front/types/plan.ts
+++ b/front/types/plan.ts
@@ -129,7 +129,7 @@ export function isSubscriptionMetronomeBilled(
  *   metronome)
  */
 export function isCreditPricedPlan(plan: PlanType): boolean {
-  return !isCreditPricedPlanPrefix(plan.code);
+  return isCreditPricedPlanPrefix(plan.code);
 }
 
 export type BillingPeriod = "monthly" | "yearly";


### PR DESCRIPTION
## Description

- Remove isLegacyPlan (name too general + was in a file that could not be imported from front-end)
- Introduce isCreditPricedPlan with a useful comment
- Standardize usage on isCreditPricedPlan (instead of gone isLegacyPlan and isCreditPricedPlanPrefix)
- Navigation scaffolding for new billing page

## Tests

Tested locally + build

## Risk

None

## Deploy Plan

- deploy `front`