### PR TITLE
Hide the Maanage agent button when user cannot create agent

### DIFF
--- a/front/components/assistant/conversation/agent_browser/WebAgentBrowser.tsx
+++ b/front/components/assistant/conversation/agent_browser/WebAgentBrowser.tsx
@@ -108,16 +108,21 @@ export function WebAgentBrowser({
             {isBuilder(owner) ? (
               <ManageDropdownMenu owner={owner} />
             ) : (
-              <Button
-                href={getAgentBuilderRoute(owner.sId, "manage")}
-                variant="primary"
-                icon={ContactsRobotIcon}
-                label="Manage agents"
-                data-gtm-label="assistantManagementButton"
-                data-gtm-location="homepage"
-                size="sm"
-                onClick={withTracking(TRACKING_AREAS.BUILDER, "manage_agents")}
-              />
+              !isRestrictedFromAgentCreation && (
+                <Button
+                  href={getAgentBuilderRoute(owner.sId, "manage")}
+                  variant="primary"
+                  icon={ContactsRobotIcon}
+                  label="Manage agents"
+                  data-gtm-label="assistantManagementButton"
+                  data-gtm-location="homepage"
+                  size="sm"
+                  onClick={withTracking(
+                    TRACKING_AREAS.BUILDER,
+                    "manage_agents"
+                  )}
+                />
+              )
             )}
           </div>
         </div>


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/8238

Removing this "Manage Agents" button when the user is not a builder and only builder can create agent, because it redirect to 404

<img width="1726" height="364" alt="image" src="https://github.com/user-attachments/assets/3b8b2e33-916e-4486-bdd5-6f971f73cb23" />


## Tests



## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
