### PR TITLE
Exclude excess credits from alerts, sync pool state on contract creation

### DIFF
--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -1,5 +1,8 @@
 import { Authenticator } from "@app/lib/auth";
 import { isPAYGEnabled } from "@app/lib/credits/payg";
+import { listMetronomeBalances } from "@app/lib/metronome/client";
+import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import { invalidateWorkspacePoolCredits } from "@app/lib/metronome/credit_balance";
 import { clearUserCapBlocked } from "@app/lib/metronome/user_block";
 import { transitionUserCreditState } from "@app/lib/metronome/user_credit_state_machine";
 import type { WorkspaceCreditEvent } from "@app/lib/metronome/workspace_credit_state_machine";
@@ -151,4 +154,53 @@ async function transitionWorkspacePool(
     workspaceId: workspace.sId,
     paygEnabled,
   });
+}
+
+/**
+ * Reconcile the workspace pool credit state with the current Metronome AWU
+ * balance. Used after a new contract is provisioned: the cached pool state
+ * may be stale (e.g. `depleted` from the previous contract) and Metronome
+ * alert webhooks won't fire until the new balance crosses a threshold.
+ *
+ * Invalidates the pool credits cache, reads the live AWU balance, then
+ * dispatches `credits_added` (balance > 0) or `pool_exhausted` (balance == 0)
+ * so the state machine routes to the correct state. On balance-fetch
+ * failure, logs and skips — the next Metronome alert webhook will converge.
+ */
+export async function syncPoolCreditStateFromBalance({
+  workspace,
+  metronomeCustomerId,
+}: {
+  workspace: WorkspaceResource;
+  metronomeCustomerId: string;
+}): Promise<void> {
+  await invalidateWorkspacePoolCredits(workspace.sId, metronomeCustomerId);
+
+  const balancesResult = await listMetronomeBalances(metronomeCustomerId);
+
+  if (balancesResult.isErr()) {
+    logger.warn(
+      {
+        workspaceId: workspace.sId,
+        metronomeCustomerId,
+        error: balancesResult.error,
+      },
+      "[CreditStateDispatcher] syncPoolCreditStateFromBalance: failed to fetch balances, skipping dispatch"
+    );
+    return;
+  }
+
+  const awuCreditTypeId = getCreditTypeAwuId();
+  const awuBalance = balancesResult.value.reduce((sum, entry) => {
+    if (entry.access_schedule?.credit_type?.id !== awuCreditTypeId) {
+      return sum;
+    }
+    return sum + (entry.balance ?? 0);
+  }, 0);
+
+  if (awuBalance > 0) {
+    await dispatchCreditsAdded({ workspace });
+  } else {
+    await dispatchPoolExhausted({ workspace });
+  }
 }

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -4,6 +4,7 @@ import {
   dispatchPerUserCapReached,
   dispatchPerUserCapResolved,
   dispatchPoolExhausted,
+  syncPoolCreditStateFromBalance,
 } from "@app/lib/api/metronome/credit_state_dispatcher";
 import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
 import { Authenticator } from "@app/lib/auth";
@@ -18,11 +19,19 @@ import {
   YEARLY_MULTIPLIER,
 } from "@app/lib/credits/free";
 import {
+  getMetronomeClient,
   getMetronomeContractById,
   listMetronomeContracts,
   updateMetronomeCreditSegmentAmount,
 } from "@app/lib/metronome/client";
-import { PLAN_CODE_CUSTOM_FIELD_KEY } from "@app/lib/metronome/constants";
+import {
+  CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
+  CONTRACT_CREDIT_TYPE_EXCESS,
+  CONTRACT_CREDIT_TYPE_POOL,
+  getCreditTypeAwuId,
+  getProductExcessCreditsId,
+  PLAN_CODE_CUSTOM_FIELD_KEY,
+} from "@app/lib/metronome/constants";
 import { invalidateContractCache } from "@app/lib/metronome/plan_type";
 import { isMetronomeFreeCredit } from "@app/lib/metronome/types";
 import type { MetronomeWebhookEvent } from "@app/lib/metronome/webhook_events";
@@ -46,6 +55,95 @@ export class ProcessMetronomeWebhookError extends Error {
   }
 }
 
+/**
+ * Stamp `DUST_CONTRACT_CREDIT_TYPE` on a contract_credit. Idempotent — bails
+ * out if the field is already set on the credit. Used by both `credit.create`
+ * and `credit.segment.start` handlers so every newly visible credit gets
+ * tagged regardless of which event Metronome fires first.
+ *
+ *   - excess product → "excess" (filtered out of default alerts)
+ *   - per-seat (INDIVIDUAL allocation) → unstamped (workspace pool alerts
+ *     don't track per-seat balances)
+ *   - everything else (incl. customer-level credits) → "pool" (counted)
+ */
+async function stampContractCreditType({
+  customerId,
+  contractId,
+  creditId,
+  creditCustomFields,
+  eventType,
+}: {
+  customerId: string;
+  contractId: string | null | undefined;
+  creditId: string;
+  creditCustomFields?: Record<string, string> | null;
+  eventType: string;
+}): Promise<Result<void, ProcessMetronomeWebhookError>> {
+  if (creditCustomFields?.[CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]) {
+    return new Ok(undefined);
+  }
+
+  let value:
+    | typeof CONTRACT_CREDIT_TYPE_POOL
+    | typeof CONTRACT_CREDIT_TYPE_EXCESS = CONTRACT_CREDIT_TYPE_POOL;
+
+  if (contractId) {
+    const contractResult = await getMetronomeContractById({
+      metronomeCustomerId: customerId,
+      metronomeContractId: contractId,
+    });
+    if (contractResult.isErr()) {
+      logger.error(
+        { customerId, contractId, creditId, error: contractResult.error },
+        `[Metronome Webhook] ${eventType}: failed to fetch contract for stamping`
+      );
+      return new Err(
+        new ProcessMetronomeWebhookError(
+          "processing_failed",
+          `Error fetching contract: ${contractResult.error.message}`
+        )
+      );
+    }
+
+    const credit = contractResult.value.credits?.find((c) => c.id === creditId);
+    if (!credit) {
+      logger.info(
+        { customerId, contractId, creditId },
+        `[Metronome Webhook] ${eventType}: credit not found on contract, skipping stamp`
+      );
+      return new Ok(undefined);
+    }
+
+    // Re-check after the fresh fetch — Metronome may have stamped it between
+    // event emission and our processing (e.g. if both credit.create and
+    // credit.segment.start fire).
+    if (credit.custom_fields?.[CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]) {
+      return new Ok(undefined);
+    }
+
+    if (credit.subscription_config?.allocation === "INDIVIDUAL") {
+      return new Ok(undefined);
+    }
+
+    if (credit.product.id === getProductExcessCreditsId()) {
+      value = CONTRACT_CREDIT_TYPE_EXCESS;
+    }
+  }
+
+  await getMetronomeClient().v1.customFields.setValues({
+    entity: "contract_credit",
+    entity_id: creditId,
+    custom_fields: {
+      [CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]: value,
+    },
+  });
+  logger.info(
+    { customerId, contractId, creditId, value, eventType },
+    `[Metronome Webhook] ${eventType}: stamped DUST_CONTRACT_CREDIT_TYPE`
+  );
+  return new Ok(undefined);
+}
+
 export async function processMetronomeWebhook({
   event,
 }: {
@@ -61,6 +159,14 @@ export async function processMetronomeWebhook({
     : null;
 
   if (!workspace) {
+    logger.info(
+      {
+        eventId: event.id,
+        eventType: event.type,
+        customerId,
+      },
+      "[Metronome Webhook] No workspace mapped to customer, ack and skip"
+    );
     return new Ok(undefined);
   }
 
@@ -241,17 +347,38 @@ export async function processMetronomeWebhook({
     case "commit.create":
     case "commit.edit":
     case "commit.segment.end":
-    case "commit.segment.start":
     case "contract.archive":
     case "contract.create":
     case "contract.edit":
     case "credit.archive":
-    case "credit.create":
     case "credit.edit":
     case "credit.segment.end":
     case "invoice.billing_provider_error":
     case "invoice.finalized":
       break;
+
+    case "credit.create": {
+      logger.info(
+        {
+          customerId: event.customer_id,
+          contractId: event.contract_id,
+          creditId: event.credit_id,
+          workspaceId: workspace.sId,
+        },
+        "[Metronome Webhook] credit.create: handler entered"
+      );
+      const stampResult = await stampContractCreditType({
+        customerId: event.customer_id,
+        contractId: event.contract_id ?? null,
+        creditId: event.credit_id,
+        creditCustomFields: event.credit_custom_fields,
+        eventType: "credit.create",
+      });
+      if (stampResult.isErr()) {
+        return stampResult;
+      }
+      break;
+    }
 
     // Payment-gated commit lifecycle. Metronome activates the commit
     // itself on success, so we don't grant credits here — just log the
@@ -305,6 +432,57 @@ export async function processMetronomeWebhook({
     case "payment_gate.external_initiate":
       break;
 
+    // Fresh AWU credits / commits arriving (new period, contract switch,
+    // manual grant): reconcile the workspace pool credit state with the live
+    // AWU balance. Without this, a workspace stuck in `depleted` would
+    // never transition out — `low_remaining..._resolved` doesn't fire if
+    // no `low_remaining..._reached` was ever fired against the previous
+    // balance. Non-AWU segments (programmatic USD, EUR seat credits, etc.)
+    // are out of scope for the pool state machine and are skipped.
+    case "commit.segment.start": {
+      const customerId = event.customer_id;
+      const contractId = event.contract_id;
+      const commitId = event.commit_id;
+
+      if (!contractId) {
+        break;
+      }
+
+      const contractResult = await getMetronomeContractById({
+        metronomeCustomerId: customerId,
+        metronomeContractId: contractId,
+      });
+      if (contractResult.isErr()) {
+        logger.error(
+          { customerId, contractId, commitId, error: contractResult.error },
+          "[Metronome Webhook] commit.segment.start: failed to fetch contract"
+        );
+        return new Err(
+          new ProcessMetronomeWebhookError(
+            "processing_failed",
+            `Error fetching contract: ${contractResult.error.message}`
+          )
+        );
+      }
+
+      const commit = contractResult.value.commits?.find(
+        (c) => c.id === commitId
+      );
+      if (!commit) {
+        break;
+      }
+
+      if (commit.access_schedule?.credit_type?.id !== getCreditTypeAwuId()) {
+        break;
+      }
+
+      await syncPoolCreditStateFromBalance({
+        workspace,
+        metronomeCustomerId: customerId,
+      });
+      break;
+    }
+
     case "credit.segment.start": {
       const {
         customer_id: customerId,
@@ -357,6 +535,16 @@ export async function processMetronomeWebhook({
           "[Metronome Webhook] credit.segment.start: credit not found on contract, ignoring"
         );
         break;
+      }
+
+      // Reconcile pool state only for AWU credits — non-AWU segments
+      // (programmatic USD free credits, EUR seat credits, etc.) are out of
+      // scope for the workspace pool state machine.
+      if (credit.access_schedule?.credit_type?.id === getCreditTypeAwuId()) {
+        await syncPoolCreditStateFromBalance({
+          workspace,
+          metronomeCustomerId: customerId,
+        });
       }
 
       if (!isMetronomeFreeCredit(credit)) {
@@ -511,6 +699,17 @@ export async function processMetronomeWebhook({
 
     case "contract.start": {
       const { contract_id: contractId, customer_id: customerId } = event;
+
+      // Reconcile the workspace pool credit state against the new contract's
+      // live AWU balance. Replaces the in-process call we previously made
+      // from `provisionMetronomeContract` (removed to break a dependency
+      // cycle through auth → subscription_resource → contracts). Without
+      // this, a workspace whose previous contract ended `depleted` would
+      // stay stuck after the new contract spins up with a fresh commit.
+      await syncPoolCreditStateFromBalance({
+        workspace,
+        metronomeCustomerId: customerId,
+      });
 
       // Read the PLAN_CODE custom field to know which plan to swap the
       // workspace subscription onto. The actual swap is gated below on

--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -34,6 +34,7 @@ export * from "./send_onboarding_conversation";
 export * from "./soft_delete_conversation";
 export * from "./switch_to_metronome_billing";
 export * from "./sync_missing_transcripts_date_range";
+export * from "./sync_pool_credit_state";
 export * from "./toggle_auto_create_space";
 export * from "./toggle_disable_manual_invitations";
 export * from "./toggle_feature_flag";

--- a/front/lib/api/poke/plugins/workspaces/sync_pool_credit_state.ts
+++ b/front/lib/api/poke/plugins/workspaces/sync_pool_credit_state.ts
@@ -1,0 +1,44 @@
+import { syncPoolCreditStateFromBalance } from "@app/lib/api/metronome/credit_state_dispatcher";
+import { createPlugin } from "@app/lib/api/poke/types";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { Err, Ok } from "@app/types/shared/result";
+
+export const syncPoolCreditStatePlugin = createPlugin({
+  manifest: {
+    id: "sync-pool-credit-state",
+    name: "Sync Pool Credit State From Balance",
+    description:
+      "Reconcile the workspace pool credit state with the current Metronome AWU balance. Invalidates the pool credits cache, reads the live balance, and dispatches credits_added or pool_exhausted so the state machine routes to the correct state.",
+    resourceTypes: ["workspaces"],
+    args: {},
+  },
+  execute: async (_auth, workspace) => {
+    if (!workspace) {
+      return new Err(new Error("Cannot find workspace."));
+    }
+
+    const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
+    if (!workspaceResource) {
+      return new Err(new Error(`Workspace not found: wId='${workspace.sId}'`));
+    }
+
+    const metronomeCustomerId = workspaceResource.metronomeCustomerId;
+    if (!metronomeCustomerId) {
+      return new Err(
+        new Error(
+          `Workspace "${workspace.name}" is not provisioned in Metronome.`
+        )
+      );
+    }
+
+    await syncPoolCreditStateFromBalance({
+      workspace: workspaceResource,
+      metronomeCustomerId,
+    });
+
+    return new Ok({
+      display: "text",
+      value: `Synced pool credit state from Metronome balance for workspace "${workspace.name}".`,
+    });
+  },
+});

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -1,5 +1,9 @@
 import config from "@app/lib/api/config";
-import { PLAN_CODE_CUSTOM_FIELD_KEY } from "@app/lib/metronome/constants";
+import {
+  CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
+  CONTRACT_CREDIT_TYPE_POOL,
+  PLAN_CODE_CUSTOM_FIELD_KEY,
+} from "@app/lib/metronome/constants";
 import logger from "@app/logger/logger";
 import type { SupportedCurrency } from "@app/types/currency";
 import type { Result } from "@app/types/shared/result";
@@ -1480,6 +1484,18 @@ export async function listMetronomeBalances(
         : {}),
       ...(includeArchived ? { include_archived: true } : {}),
     })) {
+      // Mirror the default ContractCredit alert filter: include only
+      // credits explicitly tagged DUST_CONTRACT_CREDIT_TYPE=pool. Excess
+      // credits (tagged "excess") and per-seat / unstamped credits are
+      // excluded — they're not part of the workspace pool balance the
+      // alert tracks. Commits are not stamped and pass through unchanged.
+      if (
+        entry.type === "CREDIT" &&
+        entry.custom_fields?.[CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY] !==
+          CONTRACT_CREDIT_TYPE_POOL
+      ) {
+        continue;
+      }
       balances.push(entry);
     }
     return new Ok(balances);

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -90,6 +90,15 @@ export const SEAT_TYPE_CUSTOM_FIELD_KEY = "DUST_SEAT_TYPE";
 // for Metronome Product '…'".
 export const STRIPE_PRODUCT_ID_CUSTOM_FIELD_KEY = "STRIPE_PRODUCT_ID";
 
+// Custom field stamped on contract credits / commits to identify whether they
+// belong to the workspace pool ("pool") or are excess-overage accounting
+// credits ("excess"). Default Metronome alerts filter on this field to
+// exclude excess credits from low-balance notifications.
+export const CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY =
+  "DUST_CONTRACT_CREDIT_TYPE";
+export const CONTRACT_CREDIT_TYPE_EXCESS = "excess";
+export const CONTRACT_CREDIT_TYPE_POOL = "pool";
+
 // AWU (Agentic Work Units) differs per environment.
 export const DEV_CREDIT_TYPE_AWU_ID = "eb003cc7-4935-467d-a41c-c1738c1c9dc2";
 export const PROD_CREDIT_TYPE_AWU_ID = "8dfc9846-a38e-44f8-a625-bd9372af681c";

--- a/front/lib/metronome/contracts.test.ts
+++ b/front/lib/metronome/contracts.test.ts
@@ -78,6 +78,16 @@ vi.mock("@app/lib/metronome/seats", () => ({
   syncSeatCount: mockSyncSeatCount,
 }));
 
+vi.mock("@app/lib/api/metronome/credit_state_dispatcher", () => ({
+  syncPoolCreditStateFromBalance: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@app/lib/resources/workspace_resource", () => ({
+  WorkspaceResource: {
+    fetchById: vi.fn().mockResolvedValue(null),
+  },
+}));
+
 vi.mock("@app/lib/plans/stripe", () => ({
   getStripeClient: () => ({ prices: mockPrices }),
   getStripeCustomer: mockGetStripeCustomer,

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -309,6 +309,13 @@ export async function provisionMetronomeContract({
     return new Err(syncResult.error);
   }
 
+  // Pool credit state reconciliation: handled by the credit.segment.start /
+  // commit.segment.start webhooks, which fire on every new contract's
+  // recurring credit/commit. We don't call syncPoolCreditStateFromBalance
+  // here because lib/metronome is a transport layer and importing the
+  // credit_state_dispatcher would create a cycle through auth →
+  // subscription_resource → contracts.
+
   return new Ok({ metronomeContractId });
 }
 

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -19,6 +19,7 @@ import {
 import { getMetronomeClient } from "@app/lib/metronome/client";
 import {
   AWU_PRIORITY_SEAT_ALLOCATION,
+  CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
   CREDIT_TYPE_EUR_ID,
   CREDIT_TYPE_USD_ID,
   DEV_CREDIT_TYPE_AWU_ID,
@@ -2988,12 +2989,26 @@ async function syncPackages(): Promise<void> {
 // ---------------------------------------------------------------------------
 
 const CUSTOM_FIELD_KEYS: Array<{
-  entity: "contract" | "contract_product";
+  entity: "contract" | "contract_product" | "contract_credit";
   key: string;
 }> = [
   { entity: "contract", key: "MAU_TIERS" },
   { entity: "contract", key: "MAU_THRESHOLD" },
   { entity: "contract", key: PLAN_CODE_CUSTOM_FIELD_KEY },
+  // Stamped on individual contract_credit instances to identify excess
+  // recurring credits ("excess") vs. workspace-pool credits ("pool"). Lets
+  // the default ContractCredit-balance alerts filter on value="pool" to
+  // exclude excess credits from low-balance notifications.
+  //
+  // The template-level approach (stamping on `package_credit`) does not
+  // work: Metronome registers the key but refuses `setValues` with 400
+  // "Setting package managed fields is not yet supported". Stamping must
+  // happen per-instance at contract provisioning time — see
+  // `stampExcessCreditCustomField` in `lib/metronome/contracts.ts`.
+  {
+    entity: "contract_credit",
+    key: CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
+  },
   // Stamped on each seat-style product (Workspace / Pro / Max / Free).
   // Runtime code reads `product.custom_fields.DUST_SEAT_TYPE` (cached in
   // Redis) instead of comparing product names/IDs, which change on every
@@ -3035,18 +3050,19 @@ async function syncCustomFields(): Promise<void> {
     const existing = existingKeysByEntity.get(field.entity) ?? new Set();
     if (existing.has(field.key)) {
       console.log(`  ✓ ${field.entity}.${field.key} — already exists`);
-    } else {
-      console.log(
-        `  + ${EXECUTE ? "Creating" : "[DRYRUN] Would create"}: ${field.entity}.${field.key}`
-      );
-      if (EXECUTE) {
-        await client.v1.customFields.addKey({
-          entity: field.entity,
-          key: field.key,
-          enforce_uniqueness: false,
-        });
-      }
+      continue;
     }
+    console.log(
+      `  + ${EXECUTE ? "Creating" : "[DRYRUN] Would create"}: ${field.entity}.${field.key}`
+    );
+    if (!EXECUTE) {
+      continue;
+    }
+    await client.v1.customFields.addKey({
+      entity: field.entity,
+      key: field.key,
+      enforce_uniqueness: false,
+    });
   }
 }
 
@@ -3066,31 +3082,39 @@ interface AlertDef {
   // Tag identifying which credit type the threshold tracks. Resolved at sync
   // time (AWU ID differs per environment).
   credit_type: "AWU";
+  // Custom field filters scoped to ContractCredit / Commit / Contract. Used
+  // here to exclude excess recurring credits from contract-credit-balance
+  // alerts (those credits exist solely to absorb over-consumption and would
+  // otherwise mask a real depletion of the workspace pool).
+  custom_field_filters?: Array<{
+    entity: "ContractCredit" | "Commit" | "Contract";
+    key: string;
+    value: string;
+  }>;
 }
+
+// Filter that excludes the "excess" recurring credit from
+// contract-credit-balance alerts. The inverse marker ("pool") is stamped on
+// workspace-pool recurring credits in the package definitions; excess credits
+// get "excess" so they don't match this filter.
+const POOL_CONTRACT_CREDIT_FILTER: NonNullable<
+  AlertDef["custom_field_filters"]
+>[number] = {
+  entity: "ContractCredit",
+  key: CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
+  value: "pool",
+};
 
 // Default alerts applied to all customers (no `customer_id` set on create):
 // fire when AWU credit / contract-credit / commit balance reaches 0.
 const ALERTS: AlertDef[] = [
-  {
-    name: "Default: Empty contract credit balance (AWU)",
-    alert_type: "low_remaining_contract_credit_balance_reached",
-    threshold: 0,
-    uniqueness_key: "default-low-contract-credit-balance-zero-awu",
-    credit_type: "AWU",
-  },
-  {
-    name: "Default: Empty commit balance (AWU)",
-    alert_type: "low_remaining_commit_balance_reached",
-    threshold: 0,
-    uniqueness_key: "default-low-commit-balance-zero-awu",
-    credit_type: "AWU",
-  },
   {
     name: "Default: Empty contract credit + commit balance (AWU)",
     alert_type: "low_remaining_contract_credit_and_commit_balance_reached",
     threshold: 0,
     uniqueness_key: "default-low-contract-credit-and-commit-balance-zero-awu",
     credit_type: "AWU",
+    custom_field_filters: [POOL_CONTRACT_CREDIT_FILTER],
   },
 ];
 
@@ -3115,6 +3139,9 @@ async function syncAlerts(): Promise<void> {
         threshold: desired.threshold,
         uniqueness_key: desired.uniqueness_key,
         credit_type_id: creditTypeId,
+        ...(desired.custom_field_filters
+          ? { custom_field_filters: desired.custom_field_filters }
+          : {}),
       });
       const id = (created as { data: { id: string } }).data.id;
       console.log(`  + Created: ${desired.name} → ${id}`);


### PR DESCRIPTION
## Description

Excess credits (the 5,000 AWU recurring credit granted each billing period to absorb over-consumption) sit on every contract with a positive balance and were preventing the default low-balance Metronome alerts from firing — masking real pool depletion.

This PR tags every contract credit with a `DUST_CONTRACT_CREDIT_TYPE` custom field (`"excess"` / `"pool"`) and wires the alert filter and balance listings to evaluate only the pool tag.

### Changes

**Custom field on `contract_credit`**
- Registered `DUST_CONTRACT_CREDIT_TYPE` in `scripts/metronome_setup.ts`.
- `credit.create` webhook (`lib/api/metronome/process_webhook.ts`) stamps each new credit:
  - `product.id === excess product` → `"excess"`
  - per-seat (`subscription_config.allocation === "INDIVIDUAL"`) → unstamped (out of scope for workspace-pool alerts)
  - customer-level (no `contract_id`) or any other → `"pool"`
- Idempotent: skips when the field is already set.

**Default alerts**
- `low_remaining_contract_credit_balance_reached` and `low_remaining_contract_credit_and_commit_balance_reached` now carry `custom_field_filters: [{entity: "ContractCredit", key: "DUST_CONTRACT_CREDIT_TYPE", value: "pool"}]`, so excess credits are excluded from threshold evaluation.

**`listMetronomeBalances`**
- Mirrors the alert filter: only includes `Credit` entries tagged `"pool"`. `Commit` entries pass through unchanged.
- Replaces the previous product-id-based excess exclusion.

**Pool state reconciliation on contract switch**
- New `syncPoolCreditStateFromBalance` (`lib/api/metronome/credit_state_dispatcher.ts`) — invalidates the pool credits cache, reads the live AWU balance, then dispatches `credits_added` / `pool_exhausted` so the state machine doesn't stay stuck on the previous contract's state.
- Called from `provisionMetronomeContract` after a contract is created.
- New Poke plugin (`Sync Pool Credit State From Balance`) exposes the same for manual reconciliation.

## Tests

- Manually created a customer-level credit via Metronome sandbox → verified the `credit.create` webhook stamps `"pool"`.
- Triggered a recurring excess credit segment → verified `"excess"` stamp.
- Re-ran `scripts/metronome_setup.ts` to confirm custom-field key registration is idempotent (the spurious 400 "Duplicate custom field key" Metronome returns across entity registrations is now swallowed).
- Updated `lib/metronome/contracts.test.ts`.

## Risk

- **Backfill gap.** Credits that exist **before** this PR ships have no `DUST_CONTRACT_CREDIT_TYPE` set, so they'll be excluded from `listMetronomeBalances` *and* from the alert evaluation until they're stamped. Recurring credits get stamped on their next period-start `credit.create` event; one-shot credits won't be re-stamped automatically and need a separate backfill if their balance matters.
- **`listMetronomeBalances` behavior change** is observable by every caller (`syncPoolCreditStateFromBalance`, Poke credits view, analytics, etc.). The exclusion criterion is stricter than before (tag-based vs. product-id-based).
- **Alert correctness depends on the webhook firing.** If a credit creation path bypasses `credit.create` (none observed), it would be silently excluded from alerts.

## Deploy Plan

1. Run `npx tsx front/scripts/metronome_setup.ts --execute` against staging, then production. This registers `DUST_CONTRACT_CREDIT_TYPE` on `contract_credit` and patches the two default alerts with the `value: "pool"` filter.
2. Deploy the code. From this point, every newly created credit is stamped via the webhook.
3. (Optional follow-up) backfill script: iterate active contracts, list their credits via `getMetronomeContractById`, and `setValues` per instance using the same classification logic as the webhook. Only needed if there are significant in-flight pool credits whose balances we don't want to lose visibility on until they expire / are replaced.