### PR TITLE
[Agent Loop] Preserve cancelled sub-agent messages

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -544,10 +544,7 @@ export async function* tryCallMCPTool(
         return makeMCPToolExit({
           message: TOOL_EXECUTION_CANCELLED_MESSAGE,
           isError: true,
-          reason:
-            abortClassification === "user_cancellation"
-              ? "user_cancellation"
-              : undefined,
+          reason: abortClassification,
         });
       }
 

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -544,6 +544,10 @@ export async function* tryCallMCPTool(
         return makeMCPToolExit({
           message: TOOL_EXECUTION_CANCELLED_MESSAGE,
           isError: true,
+          reason:
+            abortClassification === "user_cancellation"
+              ? "user_cancellation"
+              : undefined,
         });
       }
 

--- a/front/lib/actions/mcp_internal_actions/events.ts
+++ b/front/lib/actions/mcp_internal_actions/events.ts
@@ -88,5 +88,5 @@ export type ToolEarlyExitEvent = {
   conversationId: string;
   text: string;
   isError: boolean;
-  reason?: "user_cancellation";
+  reason?: "deploy_interruption" | "user_cancellation" | "none";
 };

--- a/front/lib/actions/mcp_internal_actions/events.ts
+++ b/front/lib/actions/mcp_internal_actions/events.ts
@@ -88,4 +88,5 @@ export type ToolEarlyExitEvent = {
   conversationId: string;
   text: string;
   isError: boolean;
+  reason?: "user_cancellation";
 };

--- a/front/lib/actions/mcp_internal_actions/exit_events.test.ts
+++ b/front/lib/actions/mcp_internal_actions/exit_events.test.ts
@@ -1,0 +1,44 @@
+import type { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
+import { makeMCPToolExit } from "@app/lib/actions/mcp_internal_actions/utils";
+import { getExitOrPauseEvents } from "@app/lib/actions/mcp_internal_actions/exit_events";
+import type { Authenticator } from "@app/lib/auth";
+import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import type {
+  AgentMessageType,
+  ConversationWithoutContentType,
+} from "@app/types/assistant/conversation";
+import { describe, expect, it } from "vitest";
+
+describe("getExitOrPauseEvents", () => {
+  it("should propagate user cancellation early-exit reasons", async () => {
+    const output = makeMCPToolExit({
+      message: "The tool execution was cancelled.",
+      isError: true,
+      reason: "user_cancellation",
+    });
+
+    const events = await getExitOrPauseEvents({} as Authenticator, {
+      outputItems: output.content.map((content) => ({
+        content,
+      })) as unknown as AgentMCPActionOutputItemModel[],
+      action: {} as AgentMCPActionResource,
+      agentConfiguration: {
+        sId: "agent-configuration-id",
+      } as AgentConfigurationType,
+      agentMessage: { sId: "agent-message-id" } as AgentMessageType,
+      conversation: { sId: "conversation-id" } as ConversationWithoutContentType,
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "tool_early_exit",
+      configurationId: "agent-configuration-id",
+      conversationId: "conversation-id",
+      messageId: "agent-message-id",
+      text: "The tool execution was cancelled.",
+      isError: true,
+      reason: "user_cancellation",
+    });
+  });
+});

--- a/front/lib/actions/mcp_internal_actions/exit_events.test.ts
+++ b/front/lib/actions/mcp_internal_actions/exit_events.test.ts
@@ -1,7 +1,7 @@
-import type { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
-import { makeMCPToolExit } from "@app/lib/actions/mcp_internal_actions/utils";
 import { getExitOrPauseEvents } from "@app/lib/actions/mcp_internal_actions/exit_events";
+import { makeMCPToolExit } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { Authenticator } from "@app/lib/auth";
+import type { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
@@ -27,7 +27,9 @@ describe("getExitOrPauseEvents", () => {
         sId: "agent-configuration-id",
       } as AgentConfigurationType,
       agentMessage: { sId: "agent-message-id" } as AgentMessageType,
-      conversation: { sId: "conversation-id" } as ConversationWithoutContentType,
+      conversation: {
+        sId: "conversation-id",
+      } as ConversationWithoutContentType,
     });
 
     expect(events).toHaveLength(1);

--- a/front/lib/actions/mcp_internal_actions/exit_events.test.ts
+++ b/front/lib/actions/mcp_internal_actions/exit_events.test.ts
@@ -10,7 +10,7 @@ import type {
 import { describe, expect, it } from "vitest";
 
 describe("getExitOrPauseEvents", () => {
-  it("should propagate user cancellation early-exit reasons", async () => {
+  it("should normalize user cancellation early exits to non-errors", async () => {
     const output = makeMCPToolExit({
       message: "The tool execution was cancelled.",
       isError: true,
@@ -38,7 +38,7 @@ describe("getExitOrPauseEvents", () => {
       conversationId: "conversation-id",
       messageId: "agent-message-id",
       text: "The tool execution was cancelled.",
-      isError: true,
+      isError: false,
       reason: "user_cancellation",
     });
   });

--- a/front/lib/actions/mcp_internal_actions/exit_events.test.ts
+++ b/front/lib/actions/mcp_internal_actions/exit_events.test.ts
@@ -1,7 +1,6 @@
 import { getExitOrPauseEvents } from "@app/lib/actions/mcp_internal_actions/exit_events";
 import { makeMCPToolExit } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { Authenticator } from "@app/lib/auth";
-import type { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
@@ -21,7 +20,7 @@ describe("getExitOrPauseEvents", () => {
     const events = await getExitOrPauseEvents({} as Authenticator, {
       outputItems: output.content.map((content) => ({
         content,
-      })) as unknown as AgentMCPActionOutputItemModel[],
+      })),
       action: {} as AgentMCPActionResource,
       agentConfiguration: {
         sId: "agent-configuration-id",

--- a/front/lib/actions/mcp_internal_actions/exit_events.ts
+++ b/front/lib/actions/mcp_internal_actions/exit_events.ts
@@ -5,7 +5,6 @@ import type {
   ToolPersonalAuthRequiredEvent,
 } from "@app/lib/actions/mcp_internal_actions/events";
 import type { Authenticator } from "@app/lib/auth";
-import type { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
@@ -14,6 +13,11 @@ import type {
 } from "@app/types/assistant/conversation";
 import type { MCPApproveExecutionEvent } from "@dust-tt/client";
 import { assertNever, isAgentPauseOutputResourceType } from "@dust-tt/client";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+type MCPActionOutputItemWithContent = {
+  content: CallToolResult["content"][number];
+};
 
 /**
  * Server-only utility for processing exit/pause events from MCP tool outputs.
@@ -29,7 +33,7 @@ export async function getExitOrPauseEvents(
     agentMessage,
     conversation,
   }: {
-    outputItems: AgentMCPActionOutputItemModel[];
+    outputItems: MCPActionOutputItemWithContent[];
     action: AgentMCPActionResource;
     agentConfiguration: AgentConfigurationType;
     agentMessage: AgentMessageType;

--- a/front/lib/actions/mcp_internal_actions/exit_events.ts
+++ b/front/lib/actions/mcp_internal_actions/exit_events.ts
@@ -51,7 +51,7 @@ export async function getExitOrPauseEvents(
   if (exitOutputItem) {
     switch (exitOutputItem.type) {
       case "tool_early_exit": {
-        const { isError, text } = exitOutputItem;
+        const { isError, reason, text } = exitOutputItem;
         return [
           {
             type: "tool_early_exit",
@@ -61,6 +61,7 @@ export async function getExitOrPauseEvents(
             messageId: agentMessage.sId,
             text: text,
             isError: isError,
+            reason,
           },
         ];
       }

--- a/front/lib/actions/mcp_internal_actions/exit_events.ts
+++ b/front/lib/actions/mcp_internal_actions/exit_events.ts
@@ -56,6 +56,8 @@ export async function getExitOrPauseEvents(
     switch (exitOutputItem.type) {
       case "tool_early_exit": {
         const { isError, reason, text } = exitOutputItem;
+        const eventIsError = reason === "user_cancellation" ? false : isError;
+
         return [
           {
             type: "tool_early_exit",
@@ -64,7 +66,7 @@ export async function getExitOrPauseEvents(
             conversationId: conversation.sId,
             messageId: agentMessage.sId,
             text: text,
-            isError: isError,
+            isError: eventIsError,
             reason,
           },
         ];

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -1125,6 +1125,7 @@ export const EarlyExitOutputResourceSchema = z.object({
   type: z.literal("tool_early_exit"),
   text: z.string(),
   isError: z.boolean(),
+  reason: z.literal("user_cancellation").optional(),
   uri: z.string(),
 });
 

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -1125,7 +1125,9 @@ export const EarlyExitOutputResourceSchema = z.object({
   type: z.literal("tool_early_exit"),
   text: z.string(),
   isError: z.boolean(),
-  reason: z.literal("user_cancellation").optional(),
+  reason: z
+    .enum(["deploy_interruption", "user_cancellation", "none"])
+    .optional(),
   uri: z.string(),
 });
 

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -79,9 +79,11 @@ export function makeFileAuthorizationError({
 export function makeMCPToolExit({
   message,
   isError,
+  reason,
 }: {
   message: string;
   isError: boolean;
+  reason?: EarlyExitOutputResourceType["reason"];
 }): SingleResourceToolOutput<EarlyExitOutputResourceType> {
   return {
     content: [
@@ -92,6 +94,7 @@ export function makeMCPToolExit({
           text: message,
           type: "tool_early_exit",
           isError,
+          ...(reason ? { reason } : {}),
           uri: "",
         },
       },

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -161,6 +161,19 @@ import { col } from "sequelize";
 // Rate limit for programmatic usage: 1 message per this amount of dollars per minute.
 const PROGRAMMATIC_RATE_LIMIT_DOLLARS_PER_MESSAGE = 3;
 
+const FAILURE_PROTECTED_AGENT_MESSAGE_STATUSES = [
+  "cancelled",
+  "interrupted",
+] as const satisfies readonly AgentMessageStatus[];
+
+function isFailureProtectedAgentMessageStatus(
+  status: AgentMessageStatus
+): status is (typeof FAILURE_PROTECTED_AGENT_MESSAGE_STATUSES)[number] {
+  return FAILURE_PROTECTED_AGENT_MESSAGE_STATUSES.includes(
+    status as (typeof FAILURE_PROTECTED_AGENT_MESSAGE_STATUSES)[number]
+  );
+}
+
 /** Citations and generated files aggregated from source MCP output items (e.g. branch merge). */
 export type CitationsAndFilesFromOutputItemsType = {
   citationsAllocated: number;
@@ -2761,8 +2774,35 @@ export async function updateAgentMessageWithFinalStatus(
     promotedUserMessages,
     promotedAuth,
     agentMessage: newAgentMessage,
+    completedAt: persistedCompletedAt,
+    status: persistedStatus,
   } = await withTransaction(async (t) => {
     await getConversationRankVersionLock(auth, conversation, t);
+
+    // Primary-key lookup under the conversation lock: a late tool/model failure must not
+    // overwrite a user cancellation or interruption already finalized by another activity.
+    const currentAgentMessage = await AgentMessageModel.findOne({
+      attributes: ["status", "completedAt"],
+      where: {
+        id: agentMessage.agentMessageId,
+        workspaceId: owner.id,
+      },
+      transaction: t,
+    });
+    assert(currentAgentMessage, "Agent message not found");
+
+    if (
+      status === "failed" &&
+      isFailureProtectedAgentMessageStatus(currentAgentMessage.status)
+    ) {
+      return {
+        promotedUserMessages: [] as UserMessageTypeWithoutMentions[],
+        promotedAuth: auth,
+        agentMessage: null as AgentMessageType | null,
+        completedAt: currentAgentMessage.completedAt ?? completedAt,
+        status: currentAgentMessage.status,
+      };
+    }
 
     await AgentMessageModel.update(
       {
@@ -2805,6 +2845,8 @@ export async function updateAgentMessageWithFinalStatus(
         promotedUserMessages: [] as UserMessageTypeWithoutMentions[],
         promotedAuth: auth,
         agentMessage: null as AgentMessageType | null,
+        completedAt,
+        status,
       };
     }
 
@@ -2860,6 +2902,8 @@ export async function updateAgentMessageWithFinalStatus(
         promotedUserMessages,
         promotedAuth,
         agentMessage: null,
+        completedAt,
+        status,
       };
     }
 
@@ -2871,6 +2915,8 @@ export async function updateAgentMessageWithFinalStatus(
         promotedUserMessages,
         promotedAuth,
         agentMessage: null,
+        completedAt,
+        status,
       };
     }
 
@@ -2897,6 +2943,8 @@ export async function updateAgentMessageWithFinalStatus(
       promotedUserMessages,
       promotedAuth,
       agentMessage: agentMessages[0] ?? null,
+      completedAt,
+      status,
     };
   });
 
@@ -2945,7 +2993,7 @@ export async function updateAgentMessageWithFinalStatus(
   }
 
   return {
-    completedTs: completedAt.getTime(),
-    status,
+    completedTs: persistedCompletedAt.getTime(),
+    status: persistedStatus,
   };
 }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -161,17 +161,18 @@ import { col } from "sequelize";
 // Rate limit for programmatic usage: 1 message per this amount of dollars per minute.
 const PROGRAMMATIC_RATE_LIMIT_DOLLARS_PER_MESSAGE = 3;
 
-const FAILURE_PROTECTED_AGENT_MESSAGE_STATUSES = [
-  "cancelled",
-  "interrupted",
-] as const satisfies readonly AgentMessageStatus[];
+type FailureProtectedAgentMessageStatus = Extract<
+  AgentMessageStatus,
+  "cancelled" | "interrupted"
+>;
+
+const FAILURE_PROTECTED_AGENT_MESSAGE_STATUSES: readonly AgentMessageStatus[] =
+  ["cancelled", "interrupted"];
 
 function isFailureProtectedAgentMessageStatus(
   status: AgentMessageStatus
-): status is (typeof FAILURE_PROTECTED_AGENT_MESSAGE_STATUSES)[number] {
-  return FAILURE_PROTECTED_AGENT_MESSAGE_STATUSES.includes(
-    status as (typeof FAILURE_PROTECTED_AGENT_MESSAGE_STATUSES)[number]
-  );
+): status is FailureProtectedAgentMessageStatus {
+  return FAILURE_PROTECTED_AGENT_MESSAGE_STATUSES.includes(status);
 }
 
 /** Citations and generated files aggregated from source MCP output items (e.g. branch merge). */

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -161,20 +161,6 @@ import { col } from "sequelize";
 // Rate limit for programmatic usage: 1 message per this amount of dollars per minute.
 const PROGRAMMATIC_RATE_LIMIT_DOLLARS_PER_MESSAGE = 3;
 
-type FailureProtectedAgentMessageStatus = Extract<
-  AgentMessageStatus,
-  "cancelled" | "interrupted"
->;
-
-const FAILURE_PROTECTED_AGENT_MESSAGE_STATUSES: readonly AgentMessageStatus[] =
-  ["cancelled", "interrupted"];
-
-function isFailureProtectedAgentMessageStatus(
-  status: AgentMessageStatus
-): status is FailureProtectedAgentMessageStatus {
-  return FAILURE_PROTECTED_AGENT_MESSAGE_STATUSES.includes(status);
-}
-
 /** Citations and generated files aggregated from source MCP output items (e.g. branch merge). */
 export type CitationsAndFilesFromOutputItemsType = {
   citationsAllocated: number;
@@ -2775,35 +2761,8 @@ export async function updateAgentMessageWithFinalStatus(
     promotedUserMessages,
     promotedAuth,
     agentMessage: newAgentMessage,
-    completedAt: persistedCompletedAt,
-    status: persistedStatus,
   } = await withTransaction(async (t) => {
     await getConversationRankVersionLock(auth, conversation, t);
-
-    // Primary-key lookup under the conversation lock: a late tool/model failure must not
-    // overwrite a user cancellation or interruption already finalized by another activity.
-    const currentAgentMessage = await AgentMessageModel.findOne({
-      attributes: ["status", "completedAt"],
-      where: {
-        id: agentMessage.agentMessageId,
-        workspaceId: owner.id,
-      },
-      transaction: t,
-    });
-    assert(currentAgentMessage, "Agent message not found");
-
-    if (
-      status === "failed" &&
-      isFailureProtectedAgentMessageStatus(currentAgentMessage.status)
-    ) {
-      return {
-        promotedUserMessages: [] as UserMessageTypeWithoutMentions[],
-        promotedAuth: auth,
-        agentMessage: null as AgentMessageType | null,
-        completedAt: currentAgentMessage.completedAt ?? completedAt,
-        status: currentAgentMessage.status,
-      };
-    }
 
     await AgentMessageModel.update(
       {
@@ -2846,8 +2805,6 @@ export async function updateAgentMessageWithFinalStatus(
         promotedUserMessages: [] as UserMessageTypeWithoutMentions[],
         promotedAuth: auth,
         agentMessage: null as AgentMessageType | null,
-        completedAt,
-        status,
       };
     }
 
@@ -2903,8 +2860,6 @@ export async function updateAgentMessageWithFinalStatus(
         promotedUserMessages,
         promotedAuth,
         agentMessage: null,
-        completedAt,
-        status,
       };
     }
 
@@ -2916,8 +2871,6 @@ export async function updateAgentMessageWithFinalStatus(
         promotedUserMessages,
         promotedAuth,
         agentMessage: null,
-        completedAt,
-        status,
       };
     }
 
@@ -2944,8 +2897,6 @@ export async function updateAgentMessageWithFinalStatus(
       promotedUserMessages,
       promotedAuth,
       agentMessage: agentMessages[0] ?? null,
-      completedAt,
-      status,
     };
   });
 
@@ -2994,7 +2945,7 @@ export async function updateAgentMessageWithFinalStatus(
   }
 
   return {
-    completedTs: persistedCompletedAt.getTime(),
-    status: persistedStatus,
+    completedTs: completedAt.getTime(),
+    status,
   };
 }

--- a/front/temporal/agent_loop/activities/common.test.ts
+++ b/front/temporal/agent_loop/activities/common.test.ts
@@ -1,11 +1,10 @@
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
-import { globalCoalescer } from "@app/temporal/agent_loop/lib/event_coalescer";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type { AgentMessageSuccessEvent } from "@app/types/assistant/agent";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
   processEventForDatabase,
   updateAgentMessageDBAndMemory,
@@ -31,10 +30,6 @@ describe("processEventForDatabase", () => {
     const setup = await createResourceTest({});
     auth = setup.authenticator;
     workspace = setup.workspace;
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   describe("modelInteractionDurationMs", () => {
@@ -293,10 +288,6 @@ describe("processEventForDatabase", () => {
         conversation,
       });
 
-      const handleEventSpy = vi
-        .spyOn(globalCoalescer, "handleEvent")
-        .mockResolvedValue();
-
       await updateResourceAndPublishEvent(auth, {
         event: {
           type: "tool_error",
@@ -328,7 +319,6 @@ describe("processEventForDatabase", () => {
       expect(dbMessage?.errorCode).toBeNull();
       expect(dbMessage?.errorMessage).toBeNull();
       expect(staleAgentMessage.status).toBe(status);
-      expect(handleEventSpy).not.toHaveBeenCalled();
     });
 
     it("should mark a normal early-exit tool error as failed", async () => {

--- a/front/temporal/agent_loop/activities/common.test.ts
+++ b/front/temporal/agent_loop/activities/common.test.ts
@@ -3,11 +3,13 @@ import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { globalCoalescer } from "@app/temporal/agent_loop/lib/event_coalescer";
 import type { AgentMessageSuccessEvent } from "@app/types/assistant/agent";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   processEventForDatabase,
   updateAgentMessageDBAndMemory,
+  updateResourceAndPublishEvent,
 } from "./common";
 
 // Helper to create an event with runIds for testing
@@ -29,6 +31,10 @@ describe("processEventForDatabase", () => {
     const setup = await createResourceTest({});
     auth = setup.authenticator;
     workspace = setup.workspace;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   describe("modelInteractionDurationMs", () => {
@@ -286,7 +292,11 @@ describe("processEventForDatabase", () => {
           conversation,
         });
 
-        await processEventForDatabase(auth, {
+        const handleEventSpy = vi
+          .spyOn(globalCoalescer, "handleEvent")
+          .mockResolvedValue();
+
+        await updateResourceAndPublishEvent(auth, {
           event: {
             type: "tool_error",
             created: Date.now(),
@@ -317,6 +327,7 @@ describe("processEventForDatabase", () => {
         expect(dbMessage?.errorCode).toBeNull();
         expect(dbMessage?.errorMessage).toBeNull();
         expect(staleAgentMessage.status).toBe(status);
+        expect(handleEventSpy).not.toHaveBeenCalled();
       }
     );
 

--- a/front/temporal/agent_loop/activities/common.test.ts
+++ b/front/temporal/agent_loop/activities/common.test.ts
@@ -249,6 +249,129 @@ describe("processEventForDatabase", () => {
     });
   });
 
+  describe("terminal errors after cancellation", () => {
+    it.each(["cancelled", "interrupted"] as const)(
+      "should keep a %s message when a late early-exit tool error arrives",
+      async (status) => {
+        const agentConfig = await AgentConfigurationFactory.createTestAgent(
+          auth,
+          {
+            name: "Test Agent",
+          }
+        );
+        const conversation = await ConversationFactory.create(auth, {
+          agentConfigurationId: agentConfig.sId,
+          messagesCreatedAt: [],
+        });
+        const { agentMessage } = await ConversationFactory.createAgentMessage(
+          auth,
+          {
+            workspace,
+            conversation,
+            agentConfig,
+          }
+        );
+        const staleAgentMessage = { ...agentMessage };
+
+        await processEventForDatabase(auth, {
+          event: {
+            type: "agent_generation_cancelled",
+            created: Date.now(),
+            configurationId: agentConfig.sId,
+            messageId: agentMessage.sId,
+            status,
+          },
+          agentMessage,
+          step: 0,
+          conversation,
+        });
+
+        await processEventForDatabase(auth, {
+          event: {
+            type: "tool_error",
+            created: Date.now(),
+            configurationId: agentConfig.sId,
+            messageId: agentMessage.sId,
+            conversationId: conversation.sId,
+            error: {
+              code: "early_exit",
+              message: "The tool execution was cancelled.",
+              metadata: {
+                errorTitle: "Early exit",
+              },
+            },
+            isLastBlockingEventForStep: true,
+          },
+          agentMessage: staleAgentMessage,
+          step: 0,
+          conversation,
+        });
+
+        const dbMessage = await AgentMessageModel.findOne({
+          where: {
+            id: agentMessage.agentMessageId,
+            workspaceId: workspace.id,
+          },
+        });
+        expect(dbMessage?.status).toBe(status);
+        expect(dbMessage?.errorCode).toBeNull();
+        expect(dbMessage?.errorMessage).toBeNull();
+        expect(staleAgentMessage.status).toBe(status);
+      }
+    );
+
+    it("should mark a normal early-exit tool error as failed", async () => {
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+        name: "Test Agent",
+      });
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [],
+      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation,
+          agentConfig,
+        }
+      );
+
+      await processEventForDatabase(auth, {
+        event: {
+          type: "tool_error",
+          created: Date.now(),
+          configurationId: agentConfig.sId,
+          messageId: agentMessage.sId,
+          conversationId: conversation.sId,
+          error: {
+            code: "early_exit",
+            message: "The tool execution stopped unexpectedly.",
+            metadata: {
+              errorTitle: "Early exit",
+            },
+          },
+          isLastBlockingEventForStep: true,
+        },
+        agentMessage,
+        step: 0,
+        conversation,
+      });
+
+      const dbMessage = await AgentMessageModel.findOne({
+        where: {
+          id: agentMessage.agentMessageId,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(dbMessage?.status).toBe("failed");
+      expect(dbMessage?.errorCode).toBe("early_exit");
+      expect(dbMessage?.errorMessage).toBe(
+        "The tool execution stopped unexpectedly."
+      );
+    });
+  });
+
   describe("runIds", () => {
     it("should merge runIds when event contains runIds", async () => {
       // Arrange: Create agent message

--- a/front/temporal/agent_loop/activities/common.test.ts
+++ b/front/temporal/agent_loop/activities/common.test.ts
@@ -8,7 +8,6 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
   processEventForDatabase,
   updateAgentMessageDBAndMemory,
-  updateResourceAndPublishEvent,
 } from "./common";
 
 // Helper to create an event with runIds for testing
@@ -250,77 +249,7 @@ describe("processEventForDatabase", () => {
     });
   });
 
-  describe("terminal errors after cancellation", () => {
-    it.each([
-      "cancelled",
-      "interrupted",
-    ] as const)("should keep a %s message when a late early-exit tool error arrives", async (status) => {
-      const agentConfig = await AgentConfigurationFactory.createTestAgent(
-        auth,
-        {
-          name: "Test Agent",
-        }
-      );
-      const conversation = await ConversationFactory.create(auth, {
-        agentConfigurationId: agentConfig.sId,
-        messagesCreatedAt: [],
-      });
-      const { agentMessage } = await ConversationFactory.createAgentMessage(
-        auth,
-        {
-          workspace,
-          conversation,
-          agentConfig,
-        }
-      );
-      const staleAgentMessage = { ...agentMessage };
-
-      await processEventForDatabase(auth, {
-        event: {
-          type: "agent_generation_cancelled",
-          created: Date.now(),
-          configurationId: agentConfig.sId,
-          messageId: agentMessage.sId,
-          status,
-        },
-        agentMessage,
-        step: 0,
-        conversation,
-      });
-
-      await updateResourceAndPublishEvent(auth, {
-        event: {
-          type: "tool_error",
-          created: Date.now(),
-          configurationId: agentConfig.sId,
-          messageId: agentMessage.sId,
-          conversationId: conversation.sId,
-          error: {
-            code: "early_exit",
-            message: "The tool execution was cancelled.",
-            metadata: {
-              errorTitle: "Early exit",
-            },
-          },
-          isLastBlockingEventForStep: true,
-        },
-        agentMessage: staleAgentMessage,
-        step: 0,
-        conversation,
-      });
-
-      const dbMessage = await AgentMessageModel.findOne({
-        where: {
-          id: agentMessage.agentMessageId,
-          workspaceId: workspace.id,
-        },
-      });
-      expect(dbMessage?.status).toBe(status);
-      expect(dbMessage?.errorCode).toBeNull();
-      expect(dbMessage?.errorMessage).toBeNull();
-      expect(staleAgentMessage.status).toBe(status);
-    });
-
+  describe("tool errors", () => {
     it("should mark a normal early-exit tool error as failed", async () => {
       const agentConfig = await AgentConfigurationFactory.createTestAgent(
         auth,

--- a/front/temporal/agent_loop/activities/common.test.ts
+++ b/front/temporal/agent_loop/activities/common.test.ts
@@ -1,9 +1,9 @@
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
+import { globalCoalescer } from "@app/temporal/agent_loop/lib/event_coalescer";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
-import { globalCoalescer } from "@app/temporal/agent_loop/lib/event_coalescer";
 import type { AgentMessageSuccessEvent } from "@app/types/assistant/agent";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -256,85 +256,88 @@ describe("processEventForDatabase", () => {
   });
 
   describe("terminal errors after cancellation", () => {
-    it.each(["cancelled", "interrupted"] as const)(
-      "should keep a %s message when a late early-exit tool error arrives",
-      async (status) => {
-        const agentConfig = await AgentConfigurationFactory.createTestAgent(
-          auth,
-          {
-            name: "Test Agent",
-          }
-        );
-        const conversation = await ConversationFactory.create(auth, {
-          agentConfigurationId: agentConfig.sId,
-          messagesCreatedAt: [],
-        });
-        const { agentMessage } = await ConversationFactory.createAgentMessage(
-          auth,
-          {
-            workspace,
-            conversation,
-            agentConfig,
-          }
-        );
-        const staleAgentMessage = { ...agentMessage };
-
-        await processEventForDatabase(auth, {
-          event: {
-            type: "agent_generation_cancelled",
-            created: Date.now(),
-            configurationId: agentConfig.sId,
-            messageId: agentMessage.sId,
-            status,
-          },
-          agentMessage,
-          step: 0,
+    it.each([
+      "cancelled",
+      "interrupted",
+    ] as const)("should keep a %s message when a late early-exit tool error arrives", async (status) => {
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        {
+          name: "Test Agent",
+        }
+      );
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [],
+      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
           conversation,
-        });
+          agentConfig,
+        }
+      );
+      const staleAgentMessage = { ...agentMessage };
 
-        const handleEventSpy = vi
-          .spyOn(globalCoalescer, "handleEvent")
-          .mockResolvedValue();
+      await processEventForDatabase(auth, {
+        event: {
+          type: "agent_generation_cancelled",
+          created: Date.now(),
+          configurationId: agentConfig.sId,
+          messageId: agentMessage.sId,
+          status,
+        },
+        agentMessage,
+        step: 0,
+        conversation,
+      });
 
-        await updateResourceAndPublishEvent(auth, {
-          event: {
-            type: "tool_error",
-            created: Date.now(),
-            configurationId: agentConfig.sId,
-            messageId: agentMessage.sId,
-            conversationId: conversation.sId,
-            error: {
-              code: "early_exit",
-              message: "The tool execution was cancelled.",
-              metadata: {
-                errorTitle: "Early exit",
-              },
+      const handleEventSpy = vi
+        .spyOn(globalCoalescer, "handleEvent")
+        .mockResolvedValue();
+
+      await updateResourceAndPublishEvent(auth, {
+        event: {
+          type: "tool_error",
+          created: Date.now(),
+          configurationId: agentConfig.sId,
+          messageId: agentMessage.sId,
+          conversationId: conversation.sId,
+          error: {
+            code: "early_exit",
+            message: "The tool execution was cancelled.",
+            metadata: {
+              errorTitle: "Early exit",
             },
-            isLastBlockingEventForStep: true,
           },
-          agentMessage: staleAgentMessage,
-          step: 0,
-          conversation,
-        });
+          isLastBlockingEventForStep: true,
+        },
+        agentMessage: staleAgentMessage,
+        step: 0,
+        conversation,
+      });
 
-        const dbMessage = await AgentMessageModel.findOne({
-          where: {
-            id: agentMessage.agentMessageId,
-            workspaceId: workspace.id,
-          },
-        });
-        expect(dbMessage?.status).toBe(status);
-        expect(dbMessage?.errorCode).toBeNull();
-        expect(dbMessage?.errorMessage).toBeNull();
-        expect(staleAgentMessage.status).toBe(status);
-        expect(handleEventSpy).not.toHaveBeenCalled();
-      }
-    );
+      const dbMessage = await AgentMessageModel.findOne({
+        where: {
+          id: agentMessage.agentMessageId,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(dbMessage?.status).toBe(status);
+      expect(dbMessage?.errorCode).toBeNull();
+      expect(dbMessage?.errorMessage).toBeNull();
+      expect(staleAgentMessage.status).toBe(status);
+      expect(handleEventSpy).not.toHaveBeenCalled();
+    });
 
     it("should mark a normal early-exit tool error as failed", async () => {
-      const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
-        name: "Test Agent",
-      });
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        {
+          name: "Test Agent",
+        }
+      );
       const conversation = await ConversationFactory.create(auth, {
         agentConfigurationId: agentConfig.sId,
         messagesCreatedAt: [],

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -201,7 +201,7 @@ export async function markAgentMessageAsFailed(
     conversation: ConversationWithoutContentType;
     error: ToolErrorEvent["error"];
   }
-): Promise<boolean> {
+): Promise<void> {
   await updateAgentMessageDBAndMemory(auth, {
     agentMessage,
     conversation,
@@ -210,8 +210,6 @@ export async function markAgentMessageAsFailed(
       error,
     },
   });
-
-  return agentMessage.status === "failed";
 }
 
 // Process database operations for agent events before publishing to Redis.
@@ -230,7 +228,7 @@ export async function processEventForDatabase(
     conversation: ConversationWithoutContentType;
     modelInteractionDurationMs?: number;
   }
-): Promise<boolean> {
+): Promise<void> {
   // If we have a model interaction duration, store it.
   if (modelInteractionDurationMs) {
     await updateAgentMessageDBAndMemory(auth, {
@@ -257,15 +255,11 @@ export async function processEventForDatabase(
   switch (event.type) {
     case "agent_error":
       // Store error in database.
-      if (
-        !(await markAgentMessageAsFailed(auth, {
-          agentMessage,
-          conversation,
-          error: event.error,
-        }))
-      ) {
-        return false;
-      }
+      await markAgentMessageAsFailed(auth, {
+        agentMessage,
+        conversation,
+        error: event.error,
+      });
 
       // Mark the conversation as errored.
       await ConversationResource.markHasError(auth, {
@@ -293,15 +287,11 @@ export async function processEventForDatabase(
       break;
 
     case "tool_error":
-      if (
-        !(await markAgentMessageAsFailed(auth, {
-          agentMessage,
-          conversation,
-          error: event.error,
-        }))
-      ) {
-        return false;
-      }
+      await markAgentMessageAsFailed(auth, {
+        agentMessage,
+        conversation,
+        error: event.error,
+      });
 
       // Mark the conversation as errored.
       await ConversationResource.markHasError(auth, {
@@ -353,8 +343,6 @@ export async function processEventForDatabase(
       isRunningAgentLoop: false,
     });
   }
-
-  return true;
 }
 
 // Process unread state for agent events before publishing to Redis.

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -27,6 +27,7 @@ import {
   isAgentLoopDataSoftDeleteError,
 } from "@app/types/assistant/agent_run";
 import type {
+  AgentMessageStatus,
   AgentMessageType,
   ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
@@ -44,6 +45,11 @@ const SUB_AGENT_FLUSH_INTERVAL_MS = 2 * DEFAULT_EVENT_FLUSH_INTERVAL_MS;
 const DEEP_CONVERSATION_FLUSH_INTERVAL_MS =
   10 * DEFAULT_EVENT_FLUSH_INTERVAL_MS;
 
+type AgentMessageStatusUpdate = Extract<
+  AgentMessageStatus,
+  "succeeded" | "cancelled" | "interrupted" | "gracefully_stopped"
+>;
+
 /**
  * Update in database as well as in-memory agent message.
  * Note that we are mutating the agentMessage object in memory and not returning a new object.
@@ -58,7 +64,7 @@ export async function updateAgentMessageDBAndMemory(
         update:
           | {
               type: "status";
-              status: "succeeded" | "cancelled" | "gracefully_stopped";
+              status: AgentMessageStatusUpdate;
             }
           | {
               type: "error";
@@ -102,7 +108,9 @@ export async function updateAgentMessageDBAndMemory(
           });
           agentMessage.status = result.status;
           agentMessage.completedTs = result.completedTs;
-          agentMessage.error = update.error;
+          if (result.status === "failed") {
+            agentMessage.error = update.error;
+          }
         }
         break;
 
@@ -195,7 +203,7 @@ export async function markAgentMessageAsFailed(
     conversation: ConversationWithoutContentType;
     error: ToolErrorEvent["error"];
   }
-): Promise<void> {
+): Promise<boolean> {
   await updateAgentMessageDBAndMemory(auth, {
     agentMessage,
     conversation,
@@ -204,6 +212,8 @@ export async function markAgentMessageAsFailed(
       error,
     },
   });
+
+  return agentMessage.status === "failed";
 }
 
 // Process database operations for agent events before publishing to Redis.
@@ -249,11 +259,15 @@ export async function processEventForDatabase(
   switch (event.type) {
     case "agent_error":
       // Store error in database.
-      await markAgentMessageAsFailed(auth, {
-        agentMessage,
-        conversation,
-        error: event.error,
-      });
+      if (
+        !(await markAgentMessageAsFailed(auth, {
+          agentMessage,
+          conversation,
+          error: event.error,
+        }))
+      ) {
+        break;
+      }
 
       // Mark the conversation as errored.
       await ConversationResource.markHasError(auth, {
@@ -281,11 +295,15 @@ export async function processEventForDatabase(
       break;
 
     case "tool_error":
-      await markAgentMessageAsFailed(auth, {
-        agentMessage,
-        conversation,
-        error: event.error,
-      });
+      if (
+        !(await markAgentMessageAsFailed(auth, {
+          agentMessage,
+          conversation,
+          error: event.error,
+        }))
+      ) {
+        break;
+      }
 
       // Mark the conversation as errored.
       await ConversationResource.markHasError(auth, {
@@ -300,7 +318,7 @@ export async function processEventForDatabase(
         conversation,
         update: {
           type: "status",
-          status: "cancelled",
+          status: event.status,
         },
       });
       break;

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -232,7 +232,7 @@ export async function processEventForDatabase(
     conversation: ConversationWithoutContentType;
     modelInteractionDurationMs?: number;
   }
-): Promise<void> {
+): Promise<boolean> {
   // If we have a model interaction duration, store it.
   if (modelInteractionDurationMs) {
     await updateAgentMessageDBAndMemory(auth, {
@@ -266,7 +266,7 @@ export async function processEventForDatabase(
           error: event.error,
         }))
       ) {
-        break;
+        return false;
       }
 
       // Mark the conversation as errored.
@@ -302,7 +302,7 @@ export async function processEventForDatabase(
           error: event.error,
         }))
       ) {
-        break;
+        return false;
       }
 
       // Mark the conversation as errored.
@@ -355,6 +355,8 @@ export async function processEventForDatabase(
       isRunningAgentLoop: false,
     });
   }
+
+  return true;
 }
 
 // Process unread state for agent events before publishing to Redis.
@@ -404,17 +406,20 @@ export async function updateResourceAndPublishEvent(
     modelInteractionDurationMs?: number;
   }
 ): Promise<void> {
-  // Process DB updates and unread state for all events.
-  await Promise.all([
-    processEventForDatabase(auth, {
-      event,
-      agentMessage,
-      step,
-      conversation,
-      modelInteractionDurationMs,
-    }),
-    processEventForUnreadState(auth, { event, conversation }),
-  ]);
+  // Process DB updates before publishing so stale terminal errors protected by the DB guard
+  // don't briefly flip live clients to failed.
+  const shouldPublishEvent = await processEventForDatabase(auth, {
+    event,
+    agentMessage,
+    step,
+    conversation,
+    modelInteractionDurationMs,
+  });
+  if (!shouldPublishEvent) {
+    return;
+  }
+
+  await processEventForUnreadState(auth, { event, conversation });
 
   // All events go through the coalescer, which handles batching logic internally.
   const key = `${conversation.sId}-${event.messageId}-${step}`;

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -108,9 +108,7 @@ export async function updateAgentMessageDBAndMemory(
           });
           agentMessage.status = result.status;
           agentMessage.completedTs = result.completedTs;
-          if (result.status === "failed") {
-            agentMessage.error = update.error;
-          }
+          agentMessage.error = update.error;
         }
         break;
 
@@ -406,20 +404,17 @@ export async function updateResourceAndPublishEvent(
     modelInteractionDurationMs?: number;
   }
 ): Promise<void> {
-  // Process DB updates before publishing so stale terminal errors protected by the DB guard
-  // don't briefly flip live clients to failed.
-  const shouldPublishEvent = await processEventForDatabase(auth, {
-    event,
-    agentMessage,
-    step,
-    conversation,
-    modelInteractionDurationMs,
-  });
-  if (!shouldPublishEvent) {
-    return;
-  }
-
-  await processEventForUnreadState(auth, { event, conversation });
+  // Process DB updates and unread state for all events.
+  await Promise.all([
+    processEventForDatabase(auth, {
+      event,
+      agentMessage,
+      step,
+      conversation,
+      modelInteractionDurationMs,
+    }),
+    processEventForUnreadState(auth, { event, conversation }),
+  ]);
 
   // All events go through the coalescer, which handles batching logic internally.
   const key = `${conversation.sId}-${event.messageId}-${step}`;

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -256,21 +256,17 @@ async function executeToolStreaming(
 
         return { deferredEvents };
 
-      case "tool_early_exit":
+      case "tool_early_exit": {
+        const isError =
+          event.reason === "user_cancellation" ? false : event.isError;
+
         updateActiveObservation(
           {
             output: {
-              status:
-                event.reason === "user_cancellation"
-                  ? "cancelled"
-                  : "early_exit",
-              isError:
-                event.reason === "user_cancellation" ? false : event.isError,
+              status: "early_exit",
+              isError,
             },
-            level:
-              event.reason === "user_cancellation" || !event.isError
-                ? "WARNING"
-                : "ERROR",
+            level: isError ? "ERROR" : "WARNING",
             statusMessage: event.text ?? "Early exit",
           },
           { asType: "tool" }
@@ -353,6 +349,7 @@ async function executeToolStreaming(
         });
 
         return { deferredEvents, shouldPauseAgentLoop: true };
+      }
 
       case "tool_personal_auth_required":
       case "tool_file_auth_required":

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -277,19 +277,6 @@ async function executeToolStreaming(
         );
 
         if (event.reason === "user_cancellation") {
-          await handleNonDeferredEvents(auth, {
-            event: {
-              type: "agent_generation_cancelled",
-              created: event.created,
-              configurationId: agentConfiguration.sId,
-              messageId: agentMessage.sId,
-              status: "cancelled",
-            },
-            agentMessage,
-            conversation,
-            step,
-          });
-
           return { deferredEvents, shouldPauseAgentLoop: true };
         }
 

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -256,17 +256,11 @@ async function executeToolStreaming(
 
         return { deferredEvents };
 
-      case "tool_early_exit": {
-        const isError =
-          event.reason === "user_cancellation" ? false : event.isError;
-
+      case "tool_early_exit":
         updateActiveObservation(
           {
-            output: {
-              status: "early_exit",
-              isError,
-            },
-            level: isError ? "ERROR" : "WARNING",
+            output: { status: "early_exit", isError: event.isError },
+            level: event.isError ? "ERROR" : "WARNING",
             statusMessage: event.text ?? "Early exit",
           },
           { asType: "tool" }
@@ -349,7 +343,6 @@ async function executeToolStreaming(
         });
 
         return { deferredEvents, shouldPauseAgentLoop: true };
-      }
 
       case "tool_personal_auth_required":
       case "tool_file_auth_required":

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -259,12 +259,39 @@ async function executeToolStreaming(
       case "tool_early_exit":
         updateActiveObservation(
           {
-            output: { status: "early_exit", isError: event.isError },
-            level: event.isError ? "ERROR" : "WARNING",
+            output: {
+              status:
+                event.reason === "user_cancellation"
+                  ? "cancelled"
+                  : "early_exit",
+              isError:
+                event.reason === "user_cancellation" ? false : event.isError,
+            },
+            level:
+              event.reason === "user_cancellation" || !event.isError
+                ? "WARNING"
+                : "ERROR",
             statusMessage: event.text ?? "Early exit",
           },
           { asType: "tool" }
         );
+
+        if (event.reason === "user_cancellation") {
+          await handleNonDeferredEvents(auth, {
+            event: {
+              type: "agent_generation_cancelled",
+              created: event.created,
+              configurationId: agentConfiguration.sId,
+              messageId: agentMessage.sId,
+              status: "cancelled",
+            },
+            agentMessage,
+            conversation,
+            step,
+          });
+
+          return { deferredEvents, shouldPauseAgentLoop: true };
+        }
 
         let updatedAgentMessage = agentMessage;
         if (

--- a/sdks/js/src/output_schemas.ts
+++ b/sdks/js/src/output_schemas.ts
@@ -624,7 +624,9 @@ export const EarlyExitOutputResourceSchema = z.object({
   type: z.literal("tool_early_exit"),
   text: z.string(),
   isError: z.boolean(),
-  reason: z.literal("user_cancellation").optional(),
+  reason: z
+    .enum(["deploy_interruption", "user_cancellation", "none"])
+    .optional(),
   uri: z.string(),
 });
 

--- a/sdks/js/src/output_schemas.ts
+++ b/sdks/js/src/output_schemas.ts
@@ -624,6 +624,7 @@ export const EarlyExitOutputResourceSchema = z.object({
   type: z.literal("tool_early_exit"),
   text: z.string(),
   isError: z.boolean(),
+  reason: z.literal("user_cancellation").optional(),
   uri: z.string(),
 });
 


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8233.

When a user stops a generation while a `run_agent` sub-agent tool is running, the cancelled MCP tool can return a `tool_early_exit` that is structurally marked as `isError: true`. Before this PR, `run_tool` converted that early exit into a `tool_error`, so the persisted agent message could become `failed`; after refresh the UI showed a red `Early exit / The tool execution was cancelled.` banner instead of the normal stopped state.

This PR carries the internal abort classification on `tool_early_exit`, normalizes `user_cancellation` early exits to non-errors before they reach the agent-loop activity, and lets the existing workflow cancellation finalizer own the final `cancelled` vs `interrupted` status. Other early exits still behave as errors or successful graceful stops according to their `isError` value.

## Risks

Blast radius: Agent loop MCP tool cancellation handling.
Risk: standard

## Deploy Plan
- pmrr
- deploy front