### PR TITLE
[Slack] Show queued status for pending messages

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -92,8 +92,6 @@ const MAX_IMAGE_FILE_SIZE_TO_UPLOAD = 20 * 1024 * 1024; // 20 MB
 const MAX_AUDIO_FILE_SIZE_TO_UPLOAD = 100 * 1024 * 1024; // 100 MB
 
 const DEFAULT_AGENTS = ["dust", "claude-4-sonnet", "gpt-5"];
-// Slack clears assistant thread statuses after 2 minutes without a new message.
-const SLACK_QUEUED_STATUS_REFRESH_INTERVAL_MS = 90_000;
 
 function getMaxFileSizeToUpload(contentType: SupportedFileContentType): number {
   if (isSupportedImageContentType(contentType)) {
@@ -1301,56 +1299,27 @@ async function answerMessage(
     await slackChatBotMessage.save();
   }
 
-  const postedConversation = conversation;
-  const postedUserMessage = userMessage;
-  const isPendingUserMessage = postedUserMessage.visibility === "pending";
-  let queuedStatusRefreshInterval: ReturnType<typeof setInterval> | undefined =
-    undefined;
+  const isPendingUserMessage = userMessage.visibility === "pending";
   if (isPendingUserMessage) {
-    const refreshQueuedStatus = async () =>
-      streamHandler.setThinking(
-        makeSlackAssistantThreadStatus(mention.agentName, "queued"),
-        "Queued..."
-      );
-
-    await refreshQueuedStatus();
-    queuedStatusRefreshInterval = setInterval(() => {
-      refreshQueuedStatus().catch((error) => {
-        logger.warn(
-          {
-            error,
-            connectorId: connector.id,
-            conversationId: postedConversation.sId,
-            userMessageId: postedUserMessage.sId,
-          },
-          "Failed to refresh Slack queued status."
-        );
-      });
-    }, SLACK_QUEUED_STATUS_REFRESH_INTERVAL_MS);
-    queuedStatusRefreshInterval.unref?.();
+    await streamHandler.setThinking(
+      makeSlackAssistantThreadStatus(mention.agentName, "queued"),
+      "Queued..."
+    );
   }
 
-  const pendingUserMessageRes = await (async () => {
-    try {
-      return await resolveSlackPendingUserMessage({
-        connector,
-        conversation: postedConversation,
-        dustAPI,
-        slack: {
-          slackChannelId: slackChannel,
-          slackClient,
-          slackMessageTs,
-        },
-        streamHandler,
-        timeoutMs: SLACK_USER_ACTION_IDLE_TIMEOUT_MS,
-        userMessage: postedUserMessage,
-      });
-    } finally {
-      if (queuedStatusRefreshInterval) {
-        clearInterval(queuedStatusRefreshInterval);
-      }
-    }
-  })();
+  const pendingUserMessageRes = await resolveSlackPendingUserMessage({
+    connector,
+    conversation,
+    dustAPI,
+    slack: {
+      slackChannelId: slackChannel,
+      slackClient,
+      slackMessageTs,
+    },
+    streamHandler,
+    timeoutMs: SLACK_USER_ACTION_IDLE_TIMEOUT_MS,
+    userMessage,
+  });
   if (pendingUserMessageRes.isErr()) {
     return buildSlackMessageError(
       pendingUserMessageRes,

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -92,6 +92,8 @@ const MAX_IMAGE_FILE_SIZE_TO_UPLOAD = 20 * 1024 * 1024; // 20 MB
 const MAX_AUDIO_FILE_SIZE_TO_UPLOAD = 100 * 1024 * 1024; // 100 MB
 
 const DEFAULT_AGENTS = ["dust", "claude-4-sonnet", "gpt-5"];
+// Slack clears assistant thread statuses after 2 minutes without a new message.
+const SLACK_QUEUED_STATUS_REFRESH_INTERVAL_MS = 90_000;
 
 function getMaxFileSizeToUpload(contentType: SupportedFileContentType): number {
   if (isSupportedImageContentType(contentType)) {
@@ -1299,27 +1301,56 @@ async function answerMessage(
     await slackChatBotMessage.save();
   }
 
-  const isPendingUserMessage = userMessage.visibility === "pending";
+  const postedConversation = conversation;
+  const postedUserMessage = userMessage;
+  const isPendingUserMessage = postedUserMessage.visibility === "pending";
+  let queuedStatusRefreshInterval: ReturnType<typeof setInterval> | undefined =
+    undefined;
   if (isPendingUserMessage) {
-    await streamHandler.setThinking(
-      makeSlackAssistantThreadStatus(mention.agentName, "queued"),
-      "Queued..."
-    );
+    const refreshQueuedStatus = async () =>
+      streamHandler.setThinking(
+        makeSlackAssistantThreadStatus(mention.agentName, "queued"),
+        "Queued..."
+      );
+
+    await refreshQueuedStatus();
+    queuedStatusRefreshInterval = setInterval(() => {
+      refreshQueuedStatus().catch((error) => {
+        logger.warn(
+          {
+            error,
+            connectorId: connector.id,
+            conversationId: postedConversation.sId,
+            userMessageId: postedUserMessage.sId,
+          },
+          "Failed to refresh Slack queued status."
+        );
+      });
+    }, SLACK_QUEUED_STATUS_REFRESH_INTERVAL_MS);
+    queuedStatusRefreshInterval.unref?.();
   }
 
-  const pendingUserMessageRes = await resolveSlackPendingUserMessage({
-    connector,
-    conversation,
-    dustAPI,
-    slack: {
-      slackChannelId: slackChannel,
-      slackClient,
-      slackMessageTs,
-    },
-    streamHandler,
-    timeoutMs: SLACK_USER_ACTION_IDLE_TIMEOUT_MS,
-    userMessage,
-  });
+  const pendingUserMessageRes = await (async () => {
+    try {
+      return await resolveSlackPendingUserMessage({
+        connector,
+        conversation: postedConversation,
+        dustAPI,
+        slack: {
+          slackChannelId: slackChannel,
+          slackClient,
+          slackMessageTs,
+        },
+        streamHandler,
+        timeoutMs: SLACK_USER_ACTION_IDLE_TIMEOUT_MS,
+        userMessage: postedUserMessage,
+      });
+    } finally {
+      if (queuedStatusRefreshInterval) {
+        clearInterval(queuedStatusRefreshInterval);
+      }
+    }
+  })();
   if (pendingUserMessageRes.isErr()) {
     return buildSlackMessageError(
       pendingUserMessageRes,

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -107,6 +107,14 @@ function getMaxFileSizeToUpload(contentType: SupportedFileContentType): number {
 // Pattern to match +mention, ~mention, or =mention at the beginning of the string.
 const SLACK_MENTION_PATTERN = /^\s*([+~=][a-zA-Z0-9_\.-]{1,40})(?=\s|,|$)/;
 
+function makeSlackAssistantThreadStatus(
+  agentName: string,
+  status: "thinking" | "queued"
+) {
+  const statusText = `is ${status}...`;
+  return agentName === "dust" ? statusText : `(${agentName}) ${statusText}`;
+}
+
 type BotAnswerParams = {
   responseUrl?: string;
   slackTeamId: string;
@@ -1155,9 +1163,7 @@ async function answerMessage(
     slackUserId,
   });
   await streamHandler.setThinking(
-    mention.agentName === "dust"
-      ? "is thinking..."
-      : `(${mention.agentName}) is thinking...`
+    makeSlackAssistantThreadStatus(mention.agentName, "thinking")
   );
 
   const buildSlackMessageError = (
@@ -1293,6 +1299,14 @@ async function answerMessage(
     await slackChatBotMessage.save();
   }
 
+  const isPendingUserMessage = userMessage.visibility === "pending";
+  if (isPendingUserMessage) {
+    await streamHandler.setThinking(
+      makeSlackAssistantThreadStatus(mention.agentName, "queued"),
+      "Queued..."
+    );
+  }
+
   const pendingUserMessageRes = await resolveSlackPendingUserMessage({
     connector,
     conversation,
@@ -1316,6 +1330,11 @@ async function answerMessage(
     return new Ok(undefined);
   }
   conversation = pendingUserMessageRes.value;
+  if (isPendingUserMessage) {
+    await streamHandler.setThinking(
+      makeSlackAssistantThreadStatus(mention.agentName, "thinking")
+    );
+  }
 
   const streamRes = await streamConversationToSlack(dustAPI, {
     assistantName: mention.agentName,

--- a/connectors/src/connectors/slack/chat/slack_stream_handler.ts
+++ b/connectors/src/connectors/slack/chat/slack_stream_handler.ts
@@ -45,12 +45,12 @@ export class SlackStreamHandler {
     });
   }
 
-  async setThinking(status: string) {
+  async setThinking(status: string, loadingMessage = "Thinking...") {
     await this.slackClient.assistant.threads.setStatus({
       channel_id: this.channelId,
       thread_ts: this.threadTs ?? this.slackMessageTs,
       status,
-      loading_messages: ["Thinking..."],
+      loading_messages: [loadingMessage],
     });
   }
 


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/25901.

When a Slack reply creates a pending Dust user message behind an existing blocked run, the Slack assistant thread now switches from the normal thinking status to a queued status. If the pending message is promoted, the status switches back to thinking before streaming resumes.

## Risks
Blast radius: Slack bot assistant thread status while handling pending user messages.
Risk: low

## Deploy Plan
- pmrr
- deploy connectors

## Test
- [x] Slack pending-message and stream handler Vitest files