### PR TITLE
[front] chore: batch webhook request cleanup

### DIFF
--- a/front/lib/resources/webhook_request_resource.ts
+++ b/front/lib/resources/webhook_request_resource.ts
@@ -271,8 +271,11 @@ export class WebhookRequestResource extends BaseResource<WebhookRequestModel> {
       maxWebhookRequestsToKeep = MAX_WEBHOOK_REQUESTS_TO_KEEP,
     }: Partial<CleanUpWorkspaceOptions> = {}
   ) {
-    const oldRequests = await this.baseFetch(auth, {
+    const workspace = auth.getNonNullableWorkspace();
+
+    const oldRequestsDeletedCount = await this.model.destroy({
       where: {
+        workspaceId: workspace.id,
         createdAt: {
           [Op.lt]: literal(`now() - interval '${webhookRequestTtl}'`),
         },
@@ -281,39 +284,37 @@ export class WebhookRequestResource extends BaseResource<WebhookRequestModel> {
 
     logger.info(
       {
-        toDelete: oldRequests.length,
-        workspaceId: auth.getNonNullableWorkspace().sId,
+        toDelete: oldRequestsDeletedCount,
+        workspaceId: workspace.sId,
       },
       "Cleaning up old webhook requests"
     );
 
-    await concurrentExecutor(
-      oldRequests,
-      async (request) => {
-        await request.delete(auth);
+    const totalRequestsCount = await this.model.count({
+      where: {
+        workspaceId: workspace.id,
       },
-      { concurrency: 16 }
-    );
-
-    const excessiveRequests = await this.baseFetch(auth, {
-      order: [["createdAt", "DESC"]],
-      offset: maxWebhookRequestsToKeep,
     });
+    const excessiveRequestsCount = Math.max(
+      totalRequestsCount - maxWebhookRequestsToKeep,
+      0
+    );
+    const excessiveRequestsDeletedCount =
+      excessiveRequestsCount > 0
+        ? await this.model.destroy({
+            where: {
+              workspaceId: workspace.id,
+            },
+            limit: excessiveRequestsCount,
+          })
+        : 0;
 
     logger.info(
       {
-        toDelete: excessiveRequests.length,
-        workspaceId: auth.getNonNullableWorkspace().sId,
+        toDelete: excessiveRequestsDeletedCount,
+        workspaceId: workspace.sId,
       },
       "Cleaning up excessive webhook requests"
-    );
-
-    await concurrentExecutor(
-      excessiveRequests,
-      async (request) => {
-        await request.delete(auth);
-      },
-      { concurrency: 16 }
     );
   }
 

--- a/front/lib/resources/webhook_request_resource.ts
+++ b/front/lib/resources/webhook_request_resource.ts
@@ -7,7 +7,6 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type {
   TriggerType,
@@ -290,32 +289,25 @@ export class WebhookRequestResource extends BaseResource<WebhookRequestModel> {
       "Cleaning up old webhook requests"
     );
 
-    const totalRequestsCount = await this.model.count({
-      where: {
-        workspaceId: workspace.id,
-      },
+    const excessiveRequests = await this.baseFetch(auth, {
+      order: [["createdAt", "DESC"]],
+      offset: maxWebhookRequestsToKeep,
     });
-    const excessiveRequestsCount = Math.max(
-      totalRequestsCount - maxWebhookRequestsToKeep,
-      0
-    );
-    const excessiveRequestsDeletedCount =
-      excessiveRequestsCount > 0
-        ? await this.model.destroy({
-            where: {
-              workspaceId: workspace.id,
-            },
-            limit: excessiveRequestsCount,
-          })
-        : 0;
 
     logger.info(
       {
-        toDelete: excessiveRequestsDeletedCount,
-        workspaceId: workspace.sId,
+        toDelete: excessiveRequests.length,
+        workspaceId: auth.getNonNullableWorkspace().sId,
       },
       "Cleaning up excessive webhook requests"
     );
+
+    await this.model.destroy({
+      where: {
+        workspaceId: workspace.id,
+        id: excessiveRequests.map((request) => request.id),
+      },
+    });
   }
 
   /**


### PR DESCRIPTION
## Description

- Replace per-request resource fetching/deletion in `cleanUpWorkspace` with Sequelize bulk deletes scoped to the workspace.
- Tracked [here](https://app.datadoghq.eu/logs?query=%22Activity%20completed%22%20%40peakConcurrentQueries%3A%3E4&agg_m=%40peakConcurrentQueries&agg_m_source=base&agg_q=%40activityName&agg_t=max&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%5D&flat_group_bys=true&fromUser=true&refresh_mode=sliding&saved-view-id=217075&sort_m=%40peakConcurrentQueries&sort_t=max&storage=hot&top_n=50&top_o=top&viz=toplist&x_missing=true&from_ts=1779369472659&to_ts=1779455872659&live=true).

## Tests

- Covered by existing webhook request cleanup tests.

## Risk

- Low. Limited to webhook request garbage collection.

## Deploy Plan

- Deploy front.