### PR TITLE
Resource/Endpoint/Hook to get Seats count for the workspace

### DIFF
--- a/front-api/routes/w/[wId]/credits/index.ts
+++ b/front-api/routes/w/[wId]/credits/index.ts
@@ -10,6 +10,7 @@ import { workspaceApp } from "@front-api/middleware/env";
 import { apiError } from "@front-api/middleware/utils";
 
 import awuPoolSummary from "./awu-pool-summary";
+import membersSeats from "./members-seats";
 import membersUsage from "./members-usage";
 import metronomeBalances from "./metronome-balances";
 
@@ -17,6 +18,7 @@ import metronomeBalances from "./metronome-balances";
 const app = workspaceApp();
 
 app.route("/awu-pool-summary", awuPoolSummary);
+app.route("/members-seats", membersSeats);
 app.route("/members-usage", membersUsage);
 app.route("/metronome-balances", metronomeBalances);
 

--- a/front-api/routes/w/[wId]/credits/members-seats.ts
+++ b/front-api/routes/w/[wId]/credits/members-seats.ts
@@ -1,6 +1,6 @@
 import {
-  getMembersSeats,
   type GetMembersSeatsResponseBody,
+  getMembersSeats,
 } from "@app/lib/api/credits/members_seats";
 import { workspaceApp } from "@front-api/middleware/env";
 import type { HandlerResult } from "@front-api/middleware/utils";

--- a/front-api/routes/w/[wId]/credits/members-seats.ts
+++ b/front-api/routes/w/[wId]/credits/members-seats.ts
@@ -1,0 +1,29 @@
+import {
+  getMembersSeats,
+  type GetMembersSeatsResponseBody,
+} from "@app/lib/api/credits/members_seats";
+import { workspaceApp } from "@front-api/middleware/env";
+import type { HandlerResult } from "@front-api/middleware/utils";
+import { apiError } from "@front-api/middleware/utils";
+
+// Mounted at /api/w/:wId/credits/members-seats.
+const app = workspaceApp();
+
+app.get("/", async (ctx): HandlerResult<GetMembersSeatsResponseBody> => {
+  const auth = ctx.get("auth");
+
+  if (!auth.isAdmin()) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access the members seats summary.",
+      },
+    });
+  }
+
+  const body = await getMembersSeats({ auth });
+  return ctx.json(body);
+});
+
+export default app;

--- a/front/components/pages/workspace/billing/BillingPage.tsx
+++ b/front/components/pages/workspace/billing/BillingPage.tsx
@@ -2,7 +2,7 @@ import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { CardIcon, Page } from "@dust-tt/sparkle";
 
 export function BillingPage() {
-  const owner = useWorkspace();
+  // const owner = useWorkspace();
   // const { subscription } = useAuth();
   // const router = useAppRouter();
 

--- a/front/components/pages/workspace/billing/BillingPage.tsx
+++ b/front/components/pages/workspace/billing/BillingPage.tsx
@@ -1,4 +1,3 @@
-import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { CardIcon, Page } from "@dust-tt/sparkle";
 
 export function BillingPage() {

--- a/front/components/pages/workspace/billing/BillingPage.tsx
+++ b/front/components/pages/workspace/billing/BillingPage.tsx
@@ -1,7 +1,8 @@
+import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { CardIcon, Page } from "@dust-tt/sparkle";
 
 export function BillingPage() {
-  // const owner = useWorkspace();
+  const owner = useWorkspace();
   // const { subscription } = useAuth();
   // const router = useAppRouter();
 

--- a/front/lib/api/credits/members_seats.ts
+++ b/front/lib/api/credits/members_seats.ts
@@ -1,0 +1,25 @@
+import type { Authenticator } from "@app/lib/auth";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import type { MembershipSeatType } from "@app/types/memberships";
+
+export type GetMembersSeatsResponseBody = {
+  seatTypes: Record<MembershipSeatType, number>;
+  total: number;
+};
+
+export async function getMembersSeats({
+  auth,
+}: {
+  auth: Authenticator;
+}): Promise<GetMembersSeatsResponseBody> {
+  const workspace = auth.getNonNullableWorkspace();
+  const seatTypes =
+    await MembershipResource.getActiveSeatTypeCountsForWorkspace({
+      workspace,
+    });
+
+  return {
+    seatTypes,
+    total: Object.values(seatTypes).reduce((sum, count) => sum + count, 0),
+  };
+}

--- a/front/lib/api/credits/members_seats.ts
+++ b/front/lib/api/credits/members_seats.ts
@@ -1,9 +1,8 @@
 import type { Authenticator } from "@app/lib/auth";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
-import type { MembershipSeatType } from "@app/types/memberships";
 
 export type GetMembersSeatsResponseBody = {
-  seatTypes: Record<MembershipSeatType, number>;
+  seatTypes: Record<string, number>;
   total: number;
 };
 

--- a/front/lib/api/credits/members_seats.ts
+++ b/front/lib/api/credits/members_seats.ts
@@ -1,8 +1,9 @@
 import type { Authenticator } from "@app/lib/auth";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import type { MembershipSeatType } from "@app/types/memberships";
 
 export type GetMembersSeatsResponseBody = {
-  seatTypes: Record<string, number>;
+  seatTypes: Partial<Record<MembershipSeatType, number>>;
   total: number;
 };
 

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -18,12 +18,11 @@ import {
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger, { auditLog } from "@app/logger/logger";
 import { launchIndexUserSearchWorkflow } from "@app/temporal/es_indexation/client";
-import {
-  isMembershipSeatType,
-  type MembershipOriginType,
-  type MembershipRoleType,
-  type MembershipSeatType,
-  type UserCreditState,
+import type {
+  MembershipOriginType,
+  MembershipRoleType,
+  MembershipSeatType,
+  UserCreditState,
 } from "@app/types/memberships";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -708,13 +707,15 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     });
   }
 
+  // We use Record<string, number> instead of Record<MembershipSeatType, number> because it's likely
+  // that we will add new seat types dynamically in the near future.
   static async getActiveSeatTypeCountsForWorkspace({
     workspace,
     transaction,
   }: {
     workspace: LightWorkspaceType;
     transaction?: Transaction;
-  }): Promise<Record<MembershipSeatType, number>> {
+  }): Promise<Record<string, number>> {
     const now = new Date();
     const rows = await this.model.count({
       where: {
@@ -732,19 +733,10 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       transaction,
     });
 
-    const counts: Record<MembershipSeatType, number> = {
-      free: 0,
-      workspace: 0,
-      workspace_yearly: 0,
-      pro: 0,
-      pro_yearly: 0,
-      max: 0,
-      max_yearly: 0,
-    };
-
+    const counts: Record<string, number> = {};
     for (const row of rows) {
       const { seatType } = row;
-      if (isMembershipSeatType(seatType)) {
+      if (typeof seatType === "string") {
         counts[seatType] = row.count;
       }
     }

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -18,11 +18,12 @@ import {
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger, { auditLog } from "@app/logger/logger";
 import { launchIndexUserSearchWorkflow } from "@app/temporal/es_indexation/client";
-import type {
-  MembershipOriginType,
-  MembershipRoleType,
-  MembershipSeatType,
-  UserCreditState,
+import {
+  isMembershipSeatType,
+  type MembershipOriginType,
+  type MembershipRoleType,
+  type MembershipSeatType,
+  type UserCreditState,
 } from "@app/types/memberships";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -707,15 +708,13 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     });
   }
 
-  // We use Record<string, number> instead of Record<MembershipSeatType, number> because it's likely
-  // that we will add new seat types dynamically in the near future.
   static async getActiveSeatTypeCountsForWorkspace({
     workspace,
     transaction,
   }: {
     workspace: LightWorkspaceType;
     transaction?: Transaction;
-  }): Promise<Record<string, number>> {
+  }): Promise<Partial<Record<MembershipSeatType, number>>> {
     const now = new Date();
     const rows = await this.model.count({
       where: {
@@ -733,10 +732,10 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       transaction,
     });
 
-    const counts: Record<string, number> = {};
+    const counts: Partial<Record<MembershipSeatType, number>> = {};
     for (const row of rows) {
       const { seatType } = row;
-      if (typeof seatType === "string") {
+      if (isMembershipSeatType(seatType)) {
         counts[seatType] = row.count;
       }
     }

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -18,11 +18,12 @@ import {
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger, { auditLog } from "@app/logger/logger";
 import { launchIndexUserSearchWorkflow } from "@app/temporal/es_indexation/client";
-import type {
-  MembershipOriginType,
-  MembershipRoleType,
-  MembershipSeatType,
-  UserCreditState,
+import {
+  isMembershipSeatType,
+  type MembershipOriginType,
+  type MembershipRoleType,
+  type MembershipSeatType,
+  type UserCreditState,
 } from "@app/types/memberships";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -705,6 +706,50 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       distinct: true,
       col: "userId",
     });
+  }
+
+  static async getActiveSeatTypeCountsForWorkspace({
+    workspace,
+    transaction,
+  }: {
+    workspace: LightWorkspaceType;
+    transaction?: Transaction;
+  }): Promise<Record<MembershipSeatType, number>> {
+    const now = new Date();
+    const rows = await this.model.count({
+      where: {
+        workspaceId: workspace.id,
+        startAt: {
+          [Op.lte]: now,
+        },
+        endAt: {
+          [Op.or]: [{ [Op.eq]: null }, { [Op.gte]: now }],
+        },
+      },
+      distinct: true,
+      col: "userId",
+      group: ["seatType"],
+      transaction,
+    });
+
+    const counts: Record<MembershipSeatType, number> = {
+      free: 0,
+      workspace: 0,
+      workspace_yearly: 0,
+      pro: 0,
+      pro_yearly: 0,
+      max: 0,
+      max_yearly: 0,
+    };
+
+    for (const row of rows) {
+      const { seatType } = row;
+      if (isMembershipSeatType(seatType)) {
+        counts[seatType] = row.count;
+      }
+    }
+
+    return counts;
   }
 
   /**

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -328,16 +328,6 @@ export function useAwuPurchaseInfo({
 
 const EMPTY_SEAT_PLANS: SeatPlanResponseBody = {};
 
-const EMPTY_MEMBERS_SEATS: GetMembersSeatsResponseBody["seatTypes"] = {
-  free: 0,
-  workspace: 0,
-  workspace_yearly: 0,
-  pro: 0,
-  pro_yearly: 0,
-  max: 0,
-  max_yearly: 0,
-};
-
 export function useMembersSeats({
   workspaceId,
   disabled,
@@ -355,7 +345,7 @@ export function useMembersSeats({
   );
 
   return {
-    membersSeats: data?.seatTypes ?? EMPTY_MEMBERS_SEATS,
+    membersSeats: data?.seatTypes ?? {},
     totalMembersSeats: data?.total ?? 0,
     isMembersSeatsLoading: !error && !data && !disabled,
     isMembersSeatsError: error,

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -1,4 +1,5 @@
 import type { AwuPoolSummaryResponseBody } from "@app/lib/api/credits/awu_pool_summary";
+import type { GetMembersSeatsResponseBody } from "@app/lib/api/credits/members_seats";
 import type { SeatPlanResponseBody } from "@app/lib/api/credits/seat_plan";
 import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
@@ -326,6 +327,42 @@ export function useAwuPurchaseInfo({
 }
 
 const EMPTY_SEAT_PLANS: SeatPlanResponseBody = {};
+
+const EMPTY_MEMBERS_SEATS: GetMembersSeatsResponseBody["seatTypes"] = {
+  free: 0,
+  workspace: 0,
+  workspace_yearly: 0,
+  pro: 0,
+  pro_yearly: 0,
+  max: 0,
+  max_yearly: 0,
+};
+
+export function useMembersSeats({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const membersSeatsFetcher: Fetcher<GetMembersSeatsResponseBody> = fetcher;
+
+  const { data, error, isValidating, mutate } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/credits/members-seats`,
+    membersSeatsFetcher,
+    { disabled }
+  );
+
+  return {
+    membersSeats: data?.seatTypes ?? EMPTY_MEMBERS_SEATS,
+    totalMembersSeats: data?.total ?? 0,
+    isMembersSeatsLoading: !error && !data && !disabled,
+    isMembersSeatsError: error,
+    isMembersSeatsValidating: isValidating,
+    mutateMembersSeats: mutate,
+  };
+}
 
 export function useSeatPlan({
   workspaceId,

--- a/front/pages/api/w/[wId]/credits/members-seats.ts
+++ b/front/pages/api/w/[wId]/credits/members-seats.ts
@@ -1,0 +1,46 @@
+// @migration-status: MIGRATED_TO_HONO
+
+/** @ignoreswagger */
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import {
+  getMembersSeats,
+  type GetMembersSeatsResponseBody,
+} from "@app/lib/api/credits/members_seats";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetMembersSeatsResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access the members seats summary.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const body = await getMembersSeats({ auth });
+
+      return res.status(200).json(body);
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/credits/members-seats.ts
+++ b/front/pages/api/w/[wId]/credits/members-seats.ts
@@ -3,8 +3,8 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import {
-  getMembersSeats,
   type GetMembersSeatsResponseBody,
+  getMembersSeats,
 } from "@app/lib/api/credits/members_seats";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";


### PR DESCRIPTION
## Description

- Adds MembershipResource `getActiveSeatTypeCountsForWorkspace`
- Adds lib/api/credits `getMembersSeats` 
- Adds API route `credits/members-seats`
- Adds hook `useMembersSeats` 

All for billing page aggregated view 

## Tests

N/A 

## Risk

None unused for now

## Deploy Plan

- N/A