### PR TITLE
Take overrides into account

### DIFF
--- a/front/lib/api/credits/seat_plan.ts
+++ b/front/lib/api/credits/seat_plan.ts
@@ -127,18 +127,27 @@ export async function handleSeatPlanRequest(
   const monthlyPriceCentsBySeatType = new Map<MembershipSeatType, number>();
   const nameBySeatType = new Map<MembershipSeatType, string>();
   try {
-    const startingAt = new Date().toISOString();
+    // Use the contract-level rate schedule (not the rate card's) so contract
+    // overrides on entitlement and price are applied. This endpoint only
+    // returns entitled rates and exposes `override_rate` when a contract
+    // override changes the price.
+    const at = new Date().toISOString();
     let nextPage: string | null | undefined = undefined;
     do {
       const rateSchedule =
-        await getMetronomeClient().v1.contracts.rateCards.retrieveRateSchedule({
-          rate_card_id: contract.rate_card_id,
-          starting_at: startingAt,
+        await getMetronomeClient().v1.contracts.retrieveRateSchedule({
+          contract_id: contract.id,
+          customer_id: contract.customer_id,
+          at,
           ...(nextPage ? { next_page: nextPage } : {}),
         });
 
       for (const entry of rateSchedule.data ?? []) {
-        if (!entry.entitled || entry.rate.price === undefined) {
+        if (!entry.entitled) {
+          continue;
+        }
+        const price = entry.override_rate?.price ?? entry.list_rate.price;
+        if (price === undefined) {
           continue;
         }
         const seatType = seatTypesByProductId.get(entry.product_id);
@@ -148,10 +157,7 @@ export async function handleSeatPlanRequest(
         // Metronome quotes prices in its per-currency native unit (USD in
         // cents, others in whole units); normalize to actual cents here.
         // TODO (https://github.com/dust-tt/tasks/issues/8072): Add annual pricing
-        monthlyPriceCentsBySeatType.set(
-          seatType,
-          amountCents(entry.rate.price, currency)
-        );
+        monthlyPriceCentsBySeatType.set(seatType, amountCents(price, currency));
         nameBySeatType.set(seatType, entry.product_name);
       }
 

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -3112,7 +3112,8 @@ const ALERTS: AlertDef[] = [
     name: "Default: Empty contract credit + commit balance (AWU)",
     alert_type: "low_remaining_contract_credit_and_commit_balance_reached",
     threshold: 0,
-    uniqueness_key: "default-low-contract-credit-and-commit-balance-zero-awu-pooled",
+    uniqueness_key:
+      "default-low-contract-credit-and-commit-balance-zero-awu-pooled",
     credit_type: "AWU",
     custom_field_filters: [POOL_CONTRACT_CREDIT_FILTER],
   },


### PR DESCRIPTION
## Description

The seat plan endpoint was reading prices and entitlement from the rate card's default schedule (`v1.contracts.rateCards.retrieveRateSchedule`), ignoring any contract-level overrides. Customers with negotiated per-seat prices or disabled seat types via overrides were seeing the list prices instead.

Switched to the contract-level schedule (`v1.contracts.retrieveRateSchedule`), which applies overrides on both entitlement and rate. Price is now read as `override_rate?.price ?? list_rate.price`.

Also dropped two stray `console.log` calls.

## Tests

Manually verified against a workspace with a contract override — the returned seat price now reflects the override rather than the default rate card price.

## Risk

Low. Same endpoint surface and response shape; only the underlying Metronome call changes. The contract endpoint only returns entitled rates, so seat types disabled by override are correctly excluded.

## Deploy Plan

Standard front deploy.