### PR TITLE
[front] chore: fix call to `getNonNullableWorkspace` in poke dsync

### DIFF
--- a/front/pages/api/poke/workspaces/[wId]/dsync.ts
+++ b/front/pages/api/poke/workspaces/[wId]/dsync.ts
@@ -18,7 +18,9 @@ async function handler(
   >,
   session: SessionWithUser
 ) {
-  if (!isString(req.query.wId)) {
+  const { wId } = req.query;
+
+  if (!isString(wId)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -28,7 +30,7 @@ async function handler(
     });
   }
 
-  const auth = await Authenticator.fromSuperUserSession(session, req.query.wId);
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
 
   const owner = auth.workspace();
 

--- a/front/pages/api/poke/workspaces/[wId]/dsync.ts
+++ b/front/pages/api/poke/workspaces/[wId]/dsync.ts
@@ -8,6 +8,7 @@ import type { WorkOSConnectionSyncStatus } from "@app/lib/types/workos";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 async function handler(
@@ -17,11 +18,19 @@ async function handler(
   >,
   session: SessionWithUser
 ) {
-  const auth = await Authenticator.fromSuperUserSession(
-    session,
-    req.query.wId as string
-  );
-  const owner = auth.getNonNullableWorkspace();
+  if (!isString(req.query.wId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing or invalid workspace id.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, req.query.wId);
+
+  const owner = auth.workspace();
 
   if (!owner || !auth.isDustSuperUser()) {
     return apiError(req, res, {


### PR DESCRIPTION
## Description

- Fixes errors such as [here](https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20status%3Aerror%20%40dd.env%3Aprod%20%40route%3A%22%2Fapi%2Fpoke%2Fworkspaces%2F%5BwId%5D%2Fdsync%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZ5P6BnFHFw2RwAAABhBWjVQNkNQSUFBQ2ctMXYwZEZHQndnQW8AAAAkZjE5ZTRmZWQtMjNjMy00Zjc4LWFlMzgtNmQ1NWFjNGRhNDU0AAjbjw&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=service%2Casc&viz=stream&from_ts=1779456552000&to_ts=1779457152000&live=false).
- This PR removes a call to `auth.getNonNullableWorkspace`, replacing it with a check.

## Tests

## Risk

- Low, poke-only and very small change.

## Deploy Plan

- Deploy front.
