### PR TITLE
Fix front-spa not building

### DIFF
--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -1,6 +1,5 @@
 import type { RegionType } from "@app/lib/api/regions/config";
 import type { Authenticator } from "@app/lib/auth";
-import { hasFeatureFlag } from "@app/lib/auth";
 import {
   isByokTransitioningPlan,
   isDustCompanyPlan,
@@ -120,28 +119,12 @@ export function getSmallWhitelistedModel(
 
 export function getLargeWhitelistedModel(
   auth: Authenticator,
-  excludeProviders: ReadonlySet<ModelProviderIdType> = new Set()
+  excludeProviders: ReadonlySet<ModelProviderIdType> = new Set(),
+  { forBatch = false }: { forBatch?: boolean } = {}
 ): ModelConfigurationType | null {
   return _getLargeWhitelistedModel(
-    getWhitelistedProviders(auth).difference(excludeProviders)
-  );
-}
-
-export async function getLargeWhitelistedModelWithBatchMode(
-  auth: Authenticator
-): Promise<ModelConfigurationType | null> {
-  // TODO: remove this when vertex supports batch mode
-  const useVertex = await hasFeatureFlag(
-    auth,
-    "use_vertex_for_anthropic_models"
-  );
-  const excludedProviders: Set<ModelProviderIdType> = useVertex
-    ? new Set(["anthropic"])
-    : new Set();
-
-  return _getLargeWhitelistedModel(
-    getWhitelistedProviders(auth).difference(excludedProviders),
-    { forBatch: true }
+    getWhitelistedProviders(auth).difference(excludeProviders),
+    { forBatch }
   );
 }
 

--- a/front/lib/reinforcement/models.ts
+++ b/front/lib/reinforcement/models.ts
@@ -1,0 +1,19 @@
+import { getLargeWhitelistedModel } from "@app/lib/assistant";
+import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+
+// TODO: remove the vertex exclusion when vertex supports batch mode
+export async function getLargeWhitelistedModelWithBatchMode(
+  auth: Authenticator
+): Promise<ModelConfigurationType | null> {
+  const useVertex = await hasFeatureFlag(
+    auth,
+    "use_vertex_for_anthropic_models"
+  );
+  const excludedProviders = useVertex
+    ? new Set<"anthropic">(["anthropic"])
+    : new Set<never>();
+
+  return getLargeWhitelistedModel(auth, excludedProviders, { forBatch: true });
+}

--- a/front/lib/reinforcement/run_reinforced_analysis.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.ts
@@ -5,11 +5,9 @@ import type { LLM } from "@app/lib/api/llm/llm";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
-import {
-  getLargeWhitelistedModel,
-  getLargeWhitelistedModelWithBatchMode,
-} from "@app/lib/assistant";
+import { getLargeWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
+import { getLargeWhitelistedModelWithBatchMode } from "@app/lib/reinforcement/models";
 import {
   hasSuggestionSelfConflict,
   pruneConflictingSkillEditSuggestions,

--- a/front/lib/reinforcement/workspace_check.ts
+++ b/front/lib/reinforcement/workspace_check.ts
@@ -1,6 +1,6 @@
-import { getLargeWhitelistedModelWithBatchMode } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { hasFeatureFlag } from "@app/lib/auth";
+import { getLargeWhitelistedModelWithBatchMode } from "@app/lib/reinforcement/models";
 
 /**
  * Check whether reinforcement is enabled for the workspace:


### PR DESCRIPTION
## Description

Fixes the broken SPA build introduced by #25547. 
CI error: https://github.com/dust-tt/dust/actions/runs/26290820748/job/77390936693

That PR added `import { hasFeatureFlag } from "@app/lib/auth"` to `front/lib/assistant.ts`, which is reachable from the SPA via `adminRoutes.tsx -> ModelProvidersPage -> assistant.ts`. This pulled the full server-side auth module into the browser bundle, including Sequelize, `jsonwebtoken`, and `@napi-rs/blake-hash` (a native Node.js binary that Rollup cannot parse).

Fix: `getLargeWhitelistedModelWithBatchMode` (the only function in `assistant.ts` that used `hasFeatureFlag`) is moved to a new `front/lib/reinforcement/models.ts`, colocated with its two callers. `getLargeWhitelistedModel` gains an optional `{ forBatch }` parameter to support it. `assistant.ts` loses the server-only import entirely.

No logic change -- purely a relocation.

## Tests

SPA build passes locally. TypeScript type-check passes with no errors.

## Risk

Very low. Pure refactor, no behavioral change. Rollback is safe but will re-break the SPA build on `main`.

## Deploy Plan

Standard deploy, no ordering constraints.