### PR TITLE
[front] chore: fix user check in public API

### DIFF
--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
@@ -317,7 +317,7 @@ async function handler(
       }
 
       // it's a public endpoint, so we need to check we are auth with a user, to set a favorite
-      if (r.data.userFavorite !== undefined && auth.isUser()) {
+      if (r.data.userFavorite !== undefined && auth.user()) {
         const updateRes = await setAgentUserFavorite({
           auth,
           agentId: sId,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/feedbacks.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/feedbacks.ts
@@ -117,7 +117,7 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      if (!auth.isUser()) {
+      if (!auth.user()) {
         return apiError(req, res, {
           status_code: 401,
           api_error: {


### PR DESCRIPTION
## Description

- Logs [here](https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20status%3Aerror%20%40dd.env%3Aprod%20%40route%3A%2Afeedbacks&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZ5PPFb-AZ89zQAAABhBWjVQUEdsdkFBQXlzblluM05jN1NnQWoAAAAkMDE5ZTRmNGUtMGYxNC00NWVkLTk0MTQtOGRkZTNhOWQ4MzhmAAThaw&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=service%2Casc&viz=stream&from_ts=1779286793331&to_ts=1779459593331&live=true).
- This PR fixes two user checks in the public API, in the endpoints to post a feedback and to set an agent as favorite.
- `auth.isUser` checks if we have at least user role, which is always true for API keys.
- `auth.user() !== null` is true if a user is attached to the Authenticator instance.
- The goal is to have a clear error message, the purpose of the `/feedbacks` endpoint is debatable.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
