### PR TITLE
Fix front-api build: correct middlewares import path in members-seats

### DIFF
--- a/front-api/routes/w/[wId]/credits/members-seats.ts
+++ b/front-api/routes/w/[wId]/credits/members-seats.ts
@@ -2,9 +2,9 @@ import {
   type GetMembersSeatsResponseBody,
   getMembersSeats,
 } from "@app/lib/api/credits/members_seats";
-import { workspaceApp } from "@front-api/middleware/env";
-import type { HandlerResult } from "@front-api/middleware/utils";
-import { apiError } from "@front-api/middleware/utils";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
 
 // Mounted at /api/w/:wId/credits/members-seats.
 const app = workspaceApp();


### PR DESCRIPTION
## Description

Deploy of main failed because `front-api/routes/w/[wId]/credits/members-seats.ts` (introduced in #26025) imported from `@front-api/middleware/env` and `@front-api/middleware/utils`. Neither path exists: the actual module is `@front-api/middlewares/...` (plural), and `workspaceApp` lives in `middlewares/ctx`.

esbuild bailed during the front image build with `Could not resolve "@front-api/middleware/env"` / `"@front-api/middleware/utils"`. Failed run: https://github.com/dust-tt/dust/actions/runs/26292338692/job/77396795819

## Tests

Inspected the corrected imports against other route files in `front-api/routes/` to confirm the canonical path is `@front-api/middlewares/`. Relying on CI for the actual build.

## Risk

Low. Three import path fixes in a single new file, no behavior change.

## Deploy Plan

Standard deploy.