### PR TITLE
[LLM] route supported Gemini models through Vertex AI

### DIFF
--- a/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
+++ b/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
@@ -77,7 +77,7 @@ export function ModelSelectionSubmenu({ models }: ModelSelectionSubmenuProps) {
   const { subscription } = useAuth();
 
   const showRegionalFlag =
-    hasFeature("use_vertex_for_anthropic_models") &&
+    hasFeature("use_vertex_for_supported_models") &&
     SHOULD_DISPLAY_FLAG[regionInfo.name] &&
     !subscription.plan.isByok;
 

--- a/front/components/pages/workspace/model_providers/RegionalModelsOnlyToggle.tsx
+++ b/front/components/pages/workspace/model_providers/RegionalModelsOnlyToggle.tsx
@@ -39,7 +39,7 @@ export function RegionalModelsOnlyToggle({
   } = useUpdateWorkspaceRegionalModelsOnly({ owner: workspace });
   const { hasFeature } = useFeatureFlags();
 
-  if (!hasFeature("use_vertex_for_anthropic_models")) {
+  if (!hasFeature("use_vertex_for_supported_models")) {
     return <></>;
   }
 

--- a/front/lib/api/assistant/global_agents/configurations/google.ts
+++ b/front/lib/api/assistant/global_agents/configurations/google.ts
@@ -10,7 +10,7 @@ import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
-import { GEMINI_3_PRO_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
+import { GEMINI_3_1_PRO_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
 
 export function _getGeminiProGlobalAgent({
   auth,
@@ -44,10 +44,10 @@ export function _getGeminiProGlobalAgent({
     scope: "global",
     userFavorite: false,
     model: {
-      providerId: GEMINI_3_PRO_MODEL_CONFIG.providerId,
-      modelId: GEMINI_3_PRO_MODEL_CONFIG.modelId,
+      providerId: GEMINI_3_1_PRO_MODEL_CONFIG.providerId,
+      modelId: GEMINI_3_1_PRO_MODEL_CONFIG.modelId,
       temperature: 0.7,
-      reasoningEffort: GEMINI_3_PRO_MODEL_CONFIG.defaultReasoningEffort,
+      reasoningEffort: GEMINI_3_1_PRO_MODEL_CONFIG.defaultReasoningEffort,
     },
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({

--- a/front/lib/api/llm/clients/anthropic/types.ts
+++ b/front/lib/api/llm/clients/anthropic/types.ts
@@ -113,7 +113,7 @@ export const VERTEX_MODEL_ID_MAP: Partial<
   [CLAUDE_4_5_HAIKU_20251001_MODEL_ID]: "claude-haiku-4-5@20251001",
 };
 
-export function isVertexWhitelistedModelId(
+export function isAnthropicVertexWhitelistedModelId(
   modelId: ModelIdType
 ): modelId is keyof typeof VERTEX_MODEL_ID_MAP {
   return modelId in VERTEX_MODEL_ID_MAP;

--- a/front/lib/api/llm/clients/google/index.ts
+++ b/front/lib/api/llm/clients/google/index.ts
@@ -67,7 +67,6 @@ export class GoogleLLM extends LLM<GoogleGenerateContentRequestParams> {
       this.client = new GoogleGenAI({
         vertexai: true,
         project: config.getGoogleCloudProjectId(),
-        location: "europe-west1",
       });
     } else {
       const { GOOGLE_AI_STUDIO_API_KEY } = llmParameters.credentials;

--- a/front/lib/api/llm/clients/google/index.ts
+++ b/front/lib/api/llm/clients/google/index.ts
@@ -1,3 +1,4 @@
+import config from "@app/lib/api/config";
 import type { GoogleAIStudioWhitelistedModelId } from "@app/lib/api/llm/clients/google/types";
 import {
   GOOGLE_AI_STUDIO_PROVIDER_ID,
@@ -43,25 +44,42 @@ interface GoogleGenerateContentRequestParams {
 
 export class GoogleLLM extends LLM<GoogleGenerateContentRequestParams> {
   private client: GoogleGenAI;
+  private useVertex: boolean;
   protected modelId: GoogleAIStudioWhitelistedModelId;
 
   constructor(
     auth: Authenticator,
-    llmParameters: LLMParameters & { modelId: GoogleAIStudioWhitelistedModelId }
+    llmParameters: LLMParameters & {
+      modelId: GoogleAIStudioWhitelistedModelId;
+      useVertex?: boolean;
+    }
   ) {
     const params = overwriteLLMParameters(llmParameters);
     super(auth, GOOGLE_AI_STUDIO_PROVIDER_ID, params);
     this.modelId = llmParameters.modelId;
 
-    const { GOOGLE_AI_STUDIO_API_KEY } = llmParameters.credentials;
-    assert(
-      GOOGLE_AI_STUDIO_API_KEY,
-      "GOOGLE_AI_STUDIO_API_KEY credential is required"
-    );
+    this.useVertex = llmParameters.useVertex ?? false;
+    if (this.useVertex) {
+      this.metadata = {
+        ...this.metadata,
+        inferenceProvider: "google_vertex_ai",
+      };
+      this.client = new GoogleGenAI({
+        vertexai: true,
+        project: config.getGoogleCloudProjectId(),
+        location: "europe-west1",
+      });
+    } else {
+      const { GOOGLE_AI_STUDIO_API_KEY } = llmParameters.credentials;
+      assert(
+        GOOGLE_AI_STUDIO_API_KEY,
+        "GOOGLE_AI_STUDIO_API_KEY credential is required"
+      );
 
-    this.client = new GoogleGenAI({
-      apiKey: GOOGLE_AI_STUDIO_API_KEY,
-    });
+      this.client = new GoogleGenAI({
+        apiKey: GOOGLE_AI_STUDIO_API_KEY,
+      });
+    }
   }
 
   private buildGenerateContentConfig(

--- a/front/lib/api/llm/clients/google/types.ts
+++ b/front/lib/api/llm/clients/google/types.ts
@@ -39,6 +39,8 @@ export const GOOGLE_VERTEX_WHITELISTED_MODEL_IDS = [
   GEMINI_2_5_FLASH_MODEL_ID,
   GEMINI_2_5_FLASH_LITE_MODEL_ID,
   GEMINI_2_5_PRO_MODEL_ID,
+  // Only available on global endpoint
+  GEMINI_3_5_FLASH_MODEL_ID,
 ] as const;
 
 export type GoogleVertexWhitelistedModelId =

--- a/front/lib/api/llm/clients/google/types.ts
+++ b/front/lib/api/llm/clients/google/types.ts
@@ -34,7 +34,7 @@ export const GOOGLE_AI_STUDIO_WHITELISTED_MODEL_IDS = [
 export type GoogleAIStudioWhitelistedModelId =
   (typeof GOOGLE_AI_STUDIO_WHITELISTED_MODEL_IDS)[number];
 
-// Temporary list to route only certain models to vertex while we gather data and feedback
+// TODO(eu-endpoint): temporary list — remove once availability is per-model, not per-provider.
 export const GOOGLE_VERTEX_WHITELISTED_MODEL_IDS = [
   GEMINI_2_5_FLASH_MODEL_ID,
   GEMINI_2_5_FLASH_LITE_MODEL_ID,

--- a/front/lib/api/llm/clients/google/types.ts
+++ b/front/lib/api/llm/clients/google/types.ts
@@ -40,6 +40,7 @@ export const GOOGLE_VERTEX_WHITELISTED_MODEL_IDS = [
   GEMINI_2_5_FLASH_LITE_MODEL_ID,
   GEMINI_2_5_PRO_MODEL_ID,
   // Only available on global endpoint
+  GEMINI_3_1_PRO_MODEL_ID,
   GEMINI_3_5_FLASH_MODEL_ID,
 ] as const;
 

--- a/front/lib/api/llm/clients/google/types.ts
+++ b/front/lib/api/llm/clients/google/types.ts
@@ -34,6 +34,16 @@ export const GOOGLE_AI_STUDIO_WHITELISTED_MODEL_IDS = [
 export type GoogleAIStudioWhitelistedModelId =
   (typeof GOOGLE_AI_STUDIO_WHITELISTED_MODEL_IDS)[number];
 
+// Temporary list to route only certain models to vertex while we gather data and feedback
+export const GOOGLE_VERTEX_WHITELISTED_MODEL_IDS = [
+  GEMINI_2_5_FLASH_MODEL_ID,
+  GEMINI_2_5_FLASH_LITE_MODEL_ID,
+  GEMINI_2_5_PRO_MODEL_ID,
+] as const;
+
+export type GoogleVertexWhitelistedModelId =
+  (typeof GOOGLE_VERTEX_WHITELISTED_MODEL_IDS)[number];
+
 const PRE_GEMINI_3_THINKING_CONFIG_MAPPING: Record<
   ReasoningEffort,
   ThinkingConfig
@@ -170,6 +180,14 @@ export function isGoogleAIStudioWhitelistedModelId(
   modelId: ModelIdType
 ): modelId is GoogleAIStudioWhitelistedModelId {
   return (GOOGLE_AI_STUDIO_WHITELISTED_MODEL_IDS as readonly string[]).includes(
+    modelId
+  );
+}
+
+export function isGoogleVertexWhitelistedModelId(
+  modelId: ModelIdType
+): modelId is GoogleVertexWhitelistedModelId {
+  return (GOOGLE_VERTEX_WHITELISTED_MODEL_IDS as readonly string[]).includes(
     modelId
   );
 }

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -6,10 +6,7 @@ import {
 import { FireworksLLM } from "@app/lib/api/llm/clients/fireworks";
 import { isFireworksWhitelistedModelId } from "@app/lib/api/llm/clients/fireworks/types";
 import { GoogleLLM } from "@app/lib/api/llm/clients/google";
-import {
-  isGoogleAIStudioWhitelistedModelId,
-  isGoogleVertexWhitelistedModelId,
-} from "@app/lib/api/llm/clients/google/types";
+import { isGoogleAIStudioWhitelistedModelId } from "@app/lib/api/llm/clients/google/types";
 import { MistralLLM } from "@app/lib/api/llm/clients/mistral";
 import { isMistralWhitelistedModelId } from "@app/lib/api/llm/clients/mistral/types";
 import { NoopLLM } from "@app/lib/api/llm/clients/noop";
@@ -117,11 +114,8 @@ export async function getLLM(
     !auth.getNonNullablePlan().isByok;
 
   if (isGoogleAIStudioWhitelistedModelId(modelId)) {
-    const useVertex =
-      useVertexPrerequisite && isGoogleVertexWhitelistedModelId(modelId);
-
     return new GoogleLLM(auth, {
-      useVertex,
+      useVertex: useVertexPrerequisite,
       credentials,
       getTraceInput,
       getTraceOutput,

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -113,7 +113,7 @@ export async function getLLM(
   const featureFlags = await getFeatureFlags(auth);
 
   const useVertexPrerequisite =
-    featureFlags.includes("use_vertex_for_anthropic_models") &&
+    featureFlags.includes("use_vertex_for_supported_models") &&
     !auth.getNonNullablePlan().isByok;
 
   if (isGoogleAIStudioWhitelistedModelId(modelId)) {

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -1,12 +1,15 @@
 import { AnthropicLLM } from "@app/lib/api/llm/clients/anthropic";
 import {
+  isAnthropicVertexWhitelistedModelId,
   isAnthropicWhitelistedModelId,
-  isVertexWhitelistedModelId,
 } from "@app/lib/api/llm/clients/anthropic/types";
 import { FireworksLLM } from "@app/lib/api/llm/clients/fireworks";
 import { isFireworksWhitelistedModelId } from "@app/lib/api/llm/clients/fireworks/types";
 import { GoogleLLM } from "@app/lib/api/llm/clients/google";
-import { isGoogleAIStudioWhitelistedModelId } from "@app/lib/api/llm/clients/google/types";
+import {
+  isGoogleAIStudioWhitelistedModelId,
+  isGoogleVertexWhitelistedModelId,
+} from "@app/lib/api/llm/clients/google/types";
 import { MistralLLM } from "@app/lib/api/llm/clients/mistral";
 import { isMistralWhitelistedModelId } from "@app/lib/api/llm/clients/mistral/types";
 import { NoopLLM } from "@app/lib/api/llm/clients/noop";
@@ -56,20 +59,6 @@ export async function getLLM(
     });
   }
 
-  if (isGoogleAIStudioWhitelistedModelId(modelId)) {
-    return new GoogleLLM(auth, {
-      credentials,
-      getTraceInput,
-      getTraceOutput,
-      modelId,
-      temperature,
-      reasoningEffort,
-      responseFormat,
-      bypassFeatureFlag,
-      context,
-    });
-  }
-
   if (isOpenAIResponsesWhitelistedModelId(modelId)) {
     return new OpenAIResponsesLLM(auth, {
       credentials,
@@ -81,29 +70,6 @@ export async function getLLM(
       responseFormat,
       bypassFeatureFlag,
       context,
-    });
-  }
-
-  if (isAnthropicWhitelistedModelId(modelId)) {
-    const featureFlags = await getFeatureFlags(auth);
-
-    const useVertex =
-      featureFlags.includes("use_vertex_for_anthropic_models") &&
-      !auth.getNonNullablePlan().isByok &&
-      isVertexWhitelistedModelId(modelId);
-
-    return new AnthropicLLM(auth, {
-      useVertex,
-      credentials,
-      getTraceInput,
-      getTraceOutput,
-      modelId,
-      temperature,
-      reasoningEffort,
-      responseFormat,
-      bypassFeatureFlag,
-      context,
-      omittedThinking,
     });
   }
 
@@ -141,6 +107,49 @@ export async function getLLM(
       reasoningEffort,
       responseFormat,
       bypassFeatureFlag,
+    });
+  }
+
+  const featureFlags = await getFeatureFlags(auth);
+
+  const useVertexPrerequisite =
+    featureFlags.includes("use_vertex_for_anthropic_models") &&
+    !auth.getNonNullablePlan().isByok;
+
+  if (isGoogleAIStudioWhitelistedModelId(modelId)) {
+    const useVertex =
+      useVertexPrerequisite && isGoogleVertexWhitelistedModelId(modelId);
+
+    return new GoogleLLM(auth, {
+      useVertex,
+      credentials,
+      getTraceInput,
+      getTraceOutput,
+      modelId,
+      temperature,
+      reasoningEffort,
+      responseFormat,
+      bypassFeatureFlag,
+      context,
+    });
+  }
+
+  if (isAnthropicWhitelistedModelId(modelId)) {
+    const useVertex =
+      useVertexPrerequisite && isAnthropicVertexWhitelistedModelId(modelId);
+
+    return new AnthropicLLM(auth, {
+      useVertex,
+      credentials,
+      getTraceInput,
+      getTraceOutput,
+      modelId,
+      temperature,
+      reasoningEffort,
+      responseFormat,
+      bypassFeatureFlag,
+      context,
+      omittedThinking,
     });
   }
 

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -6,7 +6,10 @@ import {
 import { FireworksLLM } from "@app/lib/api/llm/clients/fireworks";
 import { isFireworksWhitelistedModelId } from "@app/lib/api/llm/clients/fireworks/types";
 import { GoogleLLM } from "@app/lib/api/llm/clients/google";
-import { isGoogleAIStudioWhitelistedModelId } from "@app/lib/api/llm/clients/google/types";
+import {
+  isGoogleAIStudioWhitelistedModelId,
+  isGoogleVertexWhitelistedModelId,
+} from "@app/lib/api/llm/clients/google/types";
 import { MistralLLM } from "@app/lib/api/llm/clients/mistral";
 import { isMistralWhitelistedModelId } from "@app/lib/api/llm/clients/mistral/types";
 import { NoopLLM } from "@app/lib/api/llm/clients/noop";
@@ -114,8 +117,11 @@ export async function getLLM(
     !auth.getNonNullablePlan().isByok;
 
   if (isGoogleAIStudioWhitelistedModelId(modelId)) {
+    const useVertex =
+      useVertexPrerequisite && isGoogleVertexWhitelistedModelId(modelId);
+
     return new GoogleLLM(auth, {
-      useVertex: useVertexPrerequisite,
+      useVertex,
       credentials,
       getTraceInput,
       getTraceOutput,

--- a/front/lib/reinforcement/models.ts
+++ b/front/lib/reinforcement/models.ts
@@ -9,7 +9,7 @@ export async function getLargeWhitelistedModelWithBatchMode(
 ): Promise<ModelConfigurationType | null> {
   const useVertex = await hasFeatureFlag(
     auth,
-    "use_vertex_for_anthropic_models"
+    "use_vertex_for_supported_models"
   );
   const excludedProviders = useVertex
     ? new Set<"anthropic">(["anthropic"])

--- a/front/types/assistant/models/google_ai_studio.ts
+++ b/front/types/assistant/models/google_ai_studio.ts
@@ -41,7 +41,7 @@ export const GEMINI_2_5_FLASH_LITE_MODEL_CONFIG: ModelConfigurationType = {
   supportsBatchProcessing: true,
   regionalAvailability: {
     "us-central1": true,
-    "europe-west1": true,
+    "europe-west1": false,
   },
 };
 export const GEMINI_3_1_FLASH_LITE_MODEL_CONFIG: ModelConfigurationType = {
@@ -101,7 +101,7 @@ export const GEMINI_2_5_FLASH_MODEL_CONFIG: ModelConfigurationType = {
   supportsBatchProcessing: true,
   regionalAvailability: {
     "us-central1": true,
-    "europe-west1": true,
+    "europe-west1": false,
   },
 };
 export const GEMINI_2_5_PRO_MODEL_CONFIG: ModelConfigurationType = {
@@ -131,7 +131,7 @@ export const GEMINI_2_5_PRO_MODEL_CONFIG: ModelConfigurationType = {
   supportsBatchProcessing: true,
   regionalAvailability: {
     "us-central1": true,
-    "europe-west1": true,
+    "europe-west1": false,
   },
 };
 export const GEMINI_3_PRO_MODEL_CONFIG: ModelConfigurationType = {

--- a/front/types/assistant/models/google_ai_studio.ts
+++ b/front/types/assistant/models/google_ai_studio.ts
@@ -41,7 +41,7 @@ export const GEMINI_2_5_FLASH_LITE_MODEL_CONFIG: ModelConfigurationType = {
   supportsBatchProcessing: true,
   regionalAvailability: {
     "us-central1": true,
-    "europe-west1": false,
+    "europe-west1": true,
   },
 };
 export const GEMINI_3_1_FLASH_LITE_MODEL_CONFIG: ModelConfigurationType = {
@@ -101,7 +101,7 @@ export const GEMINI_2_5_FLASH_MODEL_CONFIG: ModelConfigurationType = {
   supportsBatchProcessing: true,
   regionalAvailability: {
     "us-central1": true,
-    "europe-west1": false,
+    "europe-west1": true,
   },
 };
 export const GEMINI_2_5_PRO_MODEL_CONFIG: ModelConfigurationType = {
@@ -131,7 +131,7 @@ export const GEMINI_2_5_PRO_MODEL_CONFIG: ModelConfigurationType = {
   supportsBatchProcessing: true,
   regionalAvailability: {
     "us-central1": true,
-    "europe-west1": false,
+    "europe-west1": true,
   },
 };
 export const GEMINI_3_PRO_MODEL_CONFIG: ModelConfigurationType = {


### PR DESCRIPTION
## Description

Adds Vertex AI support to the Google LLM client so Gemini 2.5 (Flash, Flash Lite, Pro), Gemini 3.5 flash and 3.1 pro preview can be served by vertex (under feature flag)

Only 2.x models are available in EU so this PR does not focus on this, but rather testing vertex ai endpoints

## Tests

Tested locally, needs to be tested on front-edge

## Risk

Low — Vertex routing is gated behind ff

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`