### PR TITLE
Handle commit/credit manual edits

### DIFF
--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -352,13 +352,11 @@ export async function processMetronomeWebhook({
     case "alerts.usage_threshold_resolved":
     case "commit.archive":
     case "commit.create":
-    case "commit.edit":
     case "commit.segment.end":
     case "contract.archive":
     case "contract.create":
     case "contract.edit":
     case "credit.archive":
-    case "credit.edit":
     case "credit.segment.end":
     case "invoice.billing_provider_error":
     case "invoice.finalized":
@@ -453,13 +451,18 @@ export async function processMetronomeWebhook({
       break;
 
     // Fresh AWU credits / commits arriving (new period, contract switch,
-    // manual grant): reconcile the workspace pool credit state with the live
-    // AWU balance. Without this, a workspace stuck in `depleted` would
-    // never transition out — `low_remaining..._resolved` doesn't fire if
-    // no `low_remaining..._reached` was ever fired against the previous
-    // balance. Non-AWU segments (programmatic USD, EUR seat credits, etc.)
-    // are out of scope for the pool state machine and are skipped.
-    case "commit.segment.start": {
+    // manual grant) or being mutated (manual expiration, amount edit):
+    // reconcile the workspace pool credit state with the live AWU balance.
+    // Without this, a workspace stuck in `depleted` would never transition
+    // out — `low_remaining..._resolved` doesn't fire if no
+    // `low_remaining..._reached` was ever fired against the previous
+    // balance. Likewise, a manual expiration that empties the pool wouldn't
+    // transition to `depleted` because no alert was ever fired. Non-AWU
+    // segments (programmatic USD, EUR seat credits, etc.) are out of scope
+    // for the pool state machine and are skipped.
+    case "commit.segment.start":
+    case "commit.edit": {
+      const eventType = event.type;
       const customerId = event.customer_id;
       const contractId = event.contract_id;
       const commitId = event.commit_id;
@@ -474,8 +477,13 @@ export async function processMetronomeWebhook({
       });
       if (contractResult.isErr()) {
         logger.error(
-          { customerId, contractId, commitId, error: contractResult.error },
-          "[Metronome Webhook] commit.segment.start: failed to fetch contract"
+          {
+            customerId,
+            contractId,
+            commitId,
+            error: contractResult.error,
+          },
+          `[Metronome Webhook] ${eventType}: failed to fetch contract`
         );
         return new Err(
           new ProcessMetronomeWebhookError(
@@ -500,6 +508,50 @@ export async function processMetronomeWebhook({
         workspace,
         metronomeCustomerId: customerId,
       });
+      break;
+    }
+
+    case "credit.edit": {
+      const {
+        customer_id: customerId,
+        contract_id: contractId,
+        credit_id: creditId,
+      } = event;
+
+      if (!contractId) {
+        break;
+      }
+
+      const contractResult = await getMetronomeContractById({
+        metronomeCustomerId: customerId,
+        metronomeContractId: contractId,
+      });
+      if (contractResult.isErr()) {
+        logger.error(
+          { customerId, contractId, creditId, error: contractResult.error },
+          "[Metronome Webhook] credit.edit: failed to fetch contract"
+        );
+        return new Err(
+          new ProcessMetronomeWebhookError(
+            "processing_failed",
+            `Error fetching contract: ${contractResult.error.message}`
+          )
+        );
+      }
+
+      const credit = contractResult.value.credits?.find(
+        (c) => c.id === creditId
+      );
+      if (!credit) {
+        break;
+      }
+
+      if (credit.access_schedule?.credit_type?.id === getCreditTypeAwuId()) {
+        await syncPoolCreditStateFromBalance({
+          workspace,
+          metronomeCustomerId: customerId,
+        });
+      }
       break;
     }
 


### PR DESCRIPTION
## Description

Pool credit state now reconciles from the live AWU balance when a contract spins up, when an AWU period begins, and when an admin manually edits an AWU commit or credit (e.g. shortens the expiration in the Metronome UI to drain a pool).

Before this PR the pool state machine only transitioned on Metronome alert webhooks. That fails in two cases:

1. **Stale `depleted` state.** A new contract ships with a fresh commit, but `low_remaining..._resolved` doesn't fire unless `low_remaining..._reached` had previously fired on the new balance — so the workspace stays stuck on the previous contract's `depleted` state.
2. **Manual expiration that drains the pool.** Editing a commit's expiration in Metronome empties the balance silently — no alert fires because the threshold isn't crossed by usage. The workspace stays in `active` while the balance is actually 0.

### Changes (`lib/api/metronome/process_webhook.ts`)

Added `syncPoolCreditStateFromBalance` calls on the webhook events that change AWU balance:

| Event | Trigger | Gate |
|---|---|---|
| `contract.start` | new contract spins up | unconditional |
| `commit.segment.start` | new AWU period begins | AWU credit_type |
| `commit.edit` | manual expiration / amount change | AWU credit_type |
| `credit.segment.start` | new AWU credit segment | AWU credit_type |
| `credit.edit` | credit edited | AWU credit_type |

All `*.edit` and `*.segment.start` cases fetch the contract via `getMetronomeContractById`, locate the commit/credit, and only call sync when `access_schedule.credit_type.id === getCreditTypeAwuId()` — avoiding wasted API calls for programmatic-USD / EUR / seat credits. `contract.start` runs unconditionally since it precedes the per-segment events on a fresh contract.

`commit.segment.start` and `commit.edit` share a case body (same shape, just different trigger). The reconciliation block was removed from `provisionMetronomeContract` in a prior PR to break a `lib/metronome → lib/api/metronome → auth → subscription_resource → lib/metronome/contracts` cycle; `contract.start` is now the equivalent hook from the webhook layer.

## Tests

- Manually shortened an AWU commit's expiration via Metronome UI on a sandbox workspace → `commit.edit` webhook fired → live balance read returned 0 → `dispatchPoolExhausted` dispatched → workspace transitioned to `depleted`.
- Provisioned a new contract on a `depleted` workspace → `contract.start` fired → live balance > 0 → `dispatchCreditsAdded` → state moved back to `active`.
- Confirmed non-AWU `commit.edit` / `credit.edit` events (programmatic USD legacy commits) no longer trigger a sync — the AWU gate breaks early.

## Risk

- **Extra Metronome API calls** on every AWU lifecycle event (one `getMetronomeContractById` plus one `listMetronomeBalances`). Volume is bounded by Metronome's webhook rate, which is small per workspace.
- **`commit.edit` and `credit.edit` are broad events.** Any edit (description, name, custom field) fires them. For AWU commits we'll re-sync on edits that don't change balance — wasted work but no incorrect state transitions (the sync reads live balance).
- Rollback is safe: removing the new cases restores the previous behavior (alert-only reconciliation).

## Deploy Plan

1. Deploy. No setup script changes — the Metronome webhook subscription already delivers these event types.
2. Spot-check a few existing workspaces stuck in `depleted` with non-zero balance: they should auto-recover on their next AWU `commit.segment.start` / `commit.edit` event, or operators can run the `Sync Pool Credit State From Balance` Poke plugin to force reconciliation.