### PR TITLE
Fix sandbox egress healthcheck nft fragment matching

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/src/commands/healthcheck.rs
+++ b/cli/dust-sandbox/src/commands/healthcheck.rs
@@ -87,8 +87,14 @@ fn run_healthcheck(args: &HealthcheckArgs) -> EgressHealthcheck {
         &ipv4_rules,
         &format!("tcp dport != 0 redirect to :{forwarder_port}"),
     );
-    let nft_udp_drop_ok = uid_rule(&ipv4_rules, "meta l4proto udp drop");
-    let nft_icmp_drop_ok = uid_rule(&ipv4_rules, "meta l4proto icmp drop");
+    // `nft list` normalizes `meta l4proto udp` to `meta l4proto 17` and
+    // `meta l4proto icmp` to `meta l4proto 1`, even though the script writes
+    // the named form. Accept both so the check works regardless of how nft
+    // prints the ruleset on a given kernel/nft version.
+    let nft_udp_drop_ok = uid_rule(&ipv4_rules, "meta l4proto 17 drop")
+        || uid_rule(&ipv4_rules, "meta l4proto udp drop");
+    let nft_icmp_drop_ok = uid_rule(&ipv4_rules, "meta l4proto 1 drop")
+        || uid_rule(&ipv4_rules, "meta l4proto icmp drop");
     // The ip6 table has a single catch-all drop for the proxied uid; match on
     // the bare `drop` verdict scoped to that uid.
     let nft_ipv6_drop_ok = uid_rule(&ipv6_rules, "drop");
@@ -246,5 +252,43 @@ table ip dust-egress {
             1004,
             "udp dport 53 redirect to :1053"
         ));
+    }
+
+    // `nft list table` normalizes `meta l4proto udp` to `meta l4proto 17`
+    // (and `icmp` to `1`) even though the install script writes the named
+    // form. The healthcheck accepts both so the verification doesn't depend
+    // on the printer's choice.
+    #[test]
+    fn matches_meta_l4proto_drops_in_numeric_form() {
+        let rules = r#"
+table ip dust-egress {
+  chain filter_output {
+    type filter hook output priority 0; policy accept;
+    meta skuid 1003 meta l4proto 17 drop
+    meta skuid 1003 meta l4proto 1 drop
+  }
+}
+"#;
+
+        assert!(contains_uid_rule(rules, 1003, "meta l4proto 17 drop"));
+        assert!(contains_uid_rule(rules, 1003, "meta l4proto 1 drop"));
+        assert!(!contains_uid_rule(rules, 1003, "meta l4proto udp drop"));
+        assert!(!contains_uid_rule(rules, 1003, "meta l4proto icmp drop"));
+    }
+
+    #[test]
+    fn matches_meta_l4proto_drops_in_named_form() {
+        let rules = r#"
+table ip dust-egress {
+  chain filter_output {
+    type filter hook output priority 0; policy accept;
+    meta skuid 1003 meta l4proto udp drop
+    meta skuid 1003 meta l4proto icmp drop
+  }
+}
+"#;
+
+        assert!(contains_uid_rule(rules, 1003, "meta l4proto udp drop"));
+        assert!(contains_uid_rule(rules, 1003, "meta l4proto icmp drop"));
     }
 }

--- a/cli/dust-sandbox/src/commands/healthcheck.rs
+++ b/cli/dust-sandbox/src/commands/healthcheck.rs
@@ -87,10 +87,10 @@ fn run_healthcheck(args: &HealthcheckArgs) -> EgressHealthcheck {
         &ipv4_rules,
         &format!("tcp dport != 0 redirect to :{forwarder_port}"),
     );
-    // `nft list` normalizes `meta l4proto udp` to `meta l4proto 17` and
-    // `meta l4proto icmp` to `meta l4proto 1`, even though the script writes
-    // the named form. Accept both so the check works regardless of how nft
-    // prints the ruleset on a given kernel/nft version.
+    // `nft list` may print `meta l4proto` matches either by name (`udp`,
+    // `icmp`) or by IANA protocol number (17, 1). Accept both so the check
+    // works regardless of how nft prints the ruleset on a given kernel/nft
+    // version.
     let nft_udp_drop_ok = uid_rule(&ipv4_rules, "meta l4proto 17 drop")
         || uid_rule(&ipv4_rules, "meta l4proto udp drop");
     let nft_icmp_drop_ok = uid_rule(&ipv4_rules, "meta l4proto 1 drop")

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -531,35 +531,65 @@ describe("sandbox egress helpers", () => {
 
   it.each([
     "nft_tcp_forward_redirect_ok" as const,
-    "nft_udp_drop_ok" as const,
-    "nft_icmp_drop_ok" as const,
     "nft_ipv6_drop_ok" as const,
-  ])("fails closed when %s is false (broader no-UDP/no-IPv6 invariant)", async (missing) => {
-    const sandbox = {
-      providerId: "provider-sandbox-id",
-      sId: "sandbox-id",
-      exec: vi.fn().mockResolvedValueOnce(
-        new Ok({
-          exitCode: 0,
-          stdout: healthStdout({ [missing]: false }),
-          stderr: "",
-        })
-      ),
-    };
+  ])(
+    "fails closed when %s is false (broader no-IPv6 / TCP-forward invariant)",
+    async (missing) => {
+      const sandbox = {
+        providerId: "provider-sandbox-id",
+        sId: "sandbox-id",
+        exec: vi.fn().mockResolvedValueOnce(
+          new Ok({
+            exitCode: 0,
+            stdout: healthStdout({ [missing]: false }),
+            stderr: "",
+          })
+        ),
+      };
 
-    const result = await ensureSandboxEgressOnExec(auth, sandbox as never, {
-      wokeFromSleep: false,
-    });
+      const result = await ensureSandboxEgressOnExec(auth, sandbox as never, {
+        wokeFromSleep: false,
+      });
 
-    expect(result.isErr()).toBe(true);
-    expect(mockLoggerWarn).toHaveBeenCalledWith(
-      expect.objectContaining({
-        event: "egress.enforcement_health_fail",
-        nftablesOk: false,
-      }),
-      expect.any(String)
-    );
-  });
+      expect(result.isErr()).toBe(true);
+      expect(mockLoggerWarn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "egress.enforcement_health_fail",
+          nftablesOk: false,
+        }),
+        expect.any(String)
+      );
+    }
+  );
+
+  it.each(["nft_udp_drop_ok" as const, "nft_icmp_drop_ok" as const])(
+    "tolerates %s=false from old dsbx binaries (rules installed at boot under set -eu)",
+    async (advisory) => {
+      const sandbox = {
+        providerId: "provider-sandbox-id",
+        sId: "sandbox-id",
+        exec: vi.fn().mockResolvedValueOnce(
+          new Ok({
+            exitCode: 0,
+            stdout: healthStdout({ [advisory]: false }),
+            stderr: "",
+          })
+        ),
+      };
+
+      const result = await ensureSandboxEgressOnExec(auth, sandbox as never, {
+        wokeFromSleep: false,
+      });
+
+      // No enforcement failure raised: the aggregate doesn't gate on these
+      // two signals. With everything else healthy, the function returns Ok.
+      expect(result.isErr()).toBe(false);
+      expect(mockLoggerWarn).not.toHaveBeenCalledWith(
+        expect.objectContaining({ event: "egress.enforcement_health_fail" }),
+        expect.any(String)
+      );
+    }
+  );
 
   it("does a full restart when the port is not listening", async () => {
     const sandbox = {

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -531,65 +531,35 @@ describe("sandbox egress helpers", () => {
 
   it.each([
     "nft_tcp_forward_redirect_ok" as const,
+    "nft_udp_drop_ok" as const,
+    "nft_icmp_drop_ok" as const,
     "nft_ipv6_drop_ok" as const,
-  ])(
-    "fails closed when %s is false (broader no-IPv6 / TCP-forward invariant)",
-    async (missing) => {
-      const sandbox = {
-        providerId: "provider-sandbox-id",
-        sId: "sandbox-id",
-        exec: vi.fn().mockResolvedValueOnce(
-          new Ok({
-            exitCode: 0,
-            stdout: healthStdout({ [missing]: false }),
-            stderr: "",
-          })
-        ),
-      };
+  ])("fails closed when %s is false (broader no-UDP/no-IPv6 invariant)", async (missing) => {
+    const sandbox = {
+      providerId: "provider-sandbox-id",
+      sId: "sandbox-id",
+      exec: vi.fn().mockResolvedValueOnce(
+        new Ok({
+          exitCode: 0,
+          stdout: healthStdout({ [missing]: false }),
+          stderr: "",
+        })
+      ),
+    };
 
-      const result = await ensureSandboxEgressOnExec(auth, sandbox as never, {
-        wokeFromSleep: false,
-      });
+    const result = await ensureSandboxEgressOnExec(auth, sandbox as never, {
+      wokeFromSleep: false,
+    });
 
-      expect(result.isErr()).toBe(true);
-      expect(mockLoggerWarn).toHaveBeenCalledWith(
-        expect.objectContaining({
-          event: "egress.enforcement_health_fail",
-          nftablesOk: false,
-        }),
-        expect.any(String)
-      );
-    }
-  );
-
-  it.each(["nft_udp_drop_ok" as const, "nft_icmp_drop_ok" as const])(
-    "tolerates %s=false from old dsbx binaries (rules installed at boot under set -eu)",
-    async (advisory) => {
-      const sandbox = {
-        providerId: "provider-sandbox-id",
-        sId: "sandbox-id",
-        exec: vi.fn().mockResolvedValueOnce(
-          new Ok({
-            exitCode: 0,
-            stdout: healthStdout({ [advisory]: false }),
-            stderr: "",
-          })
-        ),
-      };
-
-      const result = await ensureSandboxEgressOnExec(auth, sandbox as never, {
-        wokeFromSleep: false,
-      });
-
-      // No enforcement failure raised: the aggregate doesn't gate on these
-      // two signals. With everything else healthy, the function returns Ok.
-      expect(result.isErr()).toBe(false);
-      expect(mockLoggerWarn).not.toHaveBeenCalledWith(
-        expect.objectContaining({ event: "egress.enforcement_health_fail" }),
-        expect.any(String)
-      );
-    }
-  );
+    expect(result.isErr()).toBe(true);
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "egress.enforcement_health_fail",
+        nftablesOk: false,
+      }),
+      expect.any(String)
+    );
+  });
 
   it("does a full restart when the port is not listening", async () => {
     const sandbox = {

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -194,17 +194,41 @@ function parseEgressHealthcheckOutput(
   // DNS interception alone isn't load-bearing without the generic UDP/ICMP/
   // IPv6 drops and the broad TCP redirect to the forwarder. Treating a
   // partially damaged table as healthy would silently reopen non-53 UDP.
+  //
+  // nft_udp_drop_ok and nft_icmp_drop_ok are intentionally excluded from the
+  // aggregate. The 0.1.15 dsbx binary baked into dust-base 0.8.19 looks for
+  // the literal fragments `meta l4proto udp drop` / `meta l4proto icmp drop`,
+  // but `nft list` normalizes those to `meta l4proto 17 drop` / `meta l4proto
+  // 1 drop`, so the binary reports `false` on every healthy sandbox. The
+  // fragment matching is fixed for the next dsbx release; the rules
+  // themselves are installed by egress-nftables.sh under `set -eu` at boot,
+  // so their presence is already gated by the sandbox coming online.
+  const nftablesOk =
+    data.nft_dns_udp_redirect_ok &&
+    data.nft_dns_tcp_redirect_ok &&
+    data.nft_dns_udp_accept_ok &&
+    data.nft_tcp_forward_redirect_ok &&
+    data.nft_ipv6_drop_ok;
+  if (nftablesOk && (!data.nft_udp_drop_ok || !data.nft_icmp_drop_ok)) {
+    logger.info(
+      {
+        ...logContext,
+        nft_udp_drop_ok: data.nft_udp_drop_ok,
+        nft_icmp_drop_ok: data.nft_icmp_drop_ok,
+      },
+      "Sandbox egress healthcheck reported l4proto udp/icmp drops missing (expected on dsbx <=0.1.15 due to nft printer normalization; rules still installed)"
+    );
+  }
+  if (!nftablesOk) {
+    logger.warn(
+      { ...logContext, signals: data },
+      "Sandbox egress healthcheck aggregate failed; per-signal breakdown"
+    );
+  }
   return {
     portOk: data.forwarder_port_ok,
     resolverOk: data.resolver_udp_ok && data.resolver_tcp_ok,
-    nftablesOk:
-      data.nft_dns_udp_redirect_ok &&
-      data.nft_dns_tcp_redirect_ok &&
-      data.nft_dns_udp_accept_ok &&
-      data.nft_tcp_forward_redirect_ok &&
-      data.nft_udp_drop_ok &&
-      data.nft_icmp_drop_ok &&
-      data.nft_ipv6_drop_ok,
+    nftablesOk,
     bundleOk: data.bundle_ok,
   };
 }

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -194,31 +194,14 @@ function parseEgressHealthcheckOutput(
   // DNS interception alone isn't load-bearing without the generic UDP/ICMP/
   // IPv6 drops and the broad TCP redirect to the forwarder. Treating a
   // partially damaged table as healthy would silently reopen non-53 UDP.
-  //
-  // nft_udp_drop_ok and nft_icmp_drop_ok are intentionally excluded from the
-  // aggregate. The 0.1.15 dsbx binary baked into dust-base 0.8.19 looks for
-  // the literal fragments `meta l4proto udp drop` / `meta l4proto icmp drop`,
-  // but `nft list` normalizes those to `meta l4proto 17 drop` / `meta l4proto
-  // 1 drop`, so the binary reports `false` on every healthy sandbox. The
-  // fragment matching is fixed for the next dsbx release; the rules
-  // themselves are installed by egress-nftables.sh under `set -eu` at boot,
-  // so their presence is already gated by the sandbox coming online.
   const nftablesOk =
     data.nft_dns_udp_redirect_ok &&
     data.nft_dns_tcp_redirect_ok &&
     data.nft_dns_udp_accept_ok &&
     data.nft_tcp_forward_redirect_ok &&
+    data.nft_udp_drop_ok &&
+    data.nft_icmp_drop_ok &&
     data.nft_ipv6_drop_ok;
-  if (nftablesOk && (!data.nft_udp_drop_ok || !data.nft_icmp_drop_ok)) {
-    logger.info(
-      {
-        ...logContext,
-        nft_udp_drop_ok: data.nft_udp_drop_ok,
-        nft_icmp_drop_ok: data.nft_icmp_drop_ok,
-      },
-      "Sandbox egress healthcheck reported l4proto udp/icmp drops missing (expected on dsbx <=0.1.15 due to nft printer normalization; rules still installed)"
-    );
-  }
   if (!nftablesOk) {
     logger.warn(
       { ...logContext, signals: data },

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -68,7 +68,7 @@ describe("sandbox image registry", () => {
   test("bumps the base image for the DNS resolver rollout", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.19",
+      tag: "0.8.20",
     });
   });
 

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -15,7 +15,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.7.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.19";
+const DUST_BASE_IMAGE_VERSION = "0.8.20";
 const DSBX_CLI_VERSION = "0.1.16";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -16,7 +16,7 @@ import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.7.0";
 const DUST_BASE_IMAGE_VERSION = "0.8.19";
-const DSBX_CLI_VERSION = "0.1.15";
+const DSBX_CLI_VERSION = "0.1.16";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that
 // list must not silently change this user's UID.


### PR DESCRIPTION
## Description

The 0.1.15 dsbx binary baked into dust-base 0.8.19 looks for `meta l4proto udp drop` and `meta l4proto icmp drop` in the live nft ruleset. `nft list` may print those matches either by name or by IANA protocol number (`17` / `1`), and on the kernels we run it normalizes to numeric, so the matcher never hits. Every healthy 0.8.19 sandbox reports `nft_udp_drop_ok: false` / `nft_icmp_drop_ok: false`, and the strict aggregate rejects every sandbox tool call as "DNS enforcement health check failed". This broke 100% of sandbox tool calls in prod.

Fix:

- `cli/dust-sandbox/src/commands/healthcheck.rs`: accept both numeric (`17` / `1`) and named (`udp` / `icmp`) `meta l4proto` forms.
- Bump dsbx 0.1.15 -> 0.1.16 and `DUST_BASE_IMAGE_VERSION` 0.8.19 -> 0.8.20 so the matcher fix actually ships in the next image.
- `front/lib/api/sandbox/egress.ts`: add a per-signal warn log on `nftablesOk` aggregate failure so future fragment mismatches are diagnosable from logs alone (the current failure log only emitted the aggregate boolean, which is why this one took a sandbox spin-up to debug).

The `nftablesOk` aggregate stays strict on all 7 signals.

## Tests

Reproduced on a fresh 0.8.19 sandbox via the e2b API: `nft -n list table ip dust-egress` prints `meta l4proto 17 drop` / `meta l4proto 1 drop` literally, and `/opt/bin/dsbx healthcheck` returns `nft_udp_drop_ok: false` / `nft_icmp_drop_ok: false` even though the rules are clearly installed. New unit tests in `healthcheck.rs` cover both the numeric and named forms.

## Risk

Worst case, a sandbox boots with the new image and the new dsbx matcher still rejects some signal we hadn't anticipated. The per-signal warn log now points directly at the bad fragment, so debugging is a single Datadog query instead of an e2b spin-up. Safe to rollback by reverting `DUST_BASE_IMAGE_VERSION` and re-killing 0.8.20 sandboxes.

## Deploy Plan

Order matters: the image registry workflow pulls dsbx from the GitHub release tag, so the dsbx release must exist before the image build.

> [!WARNING]
> Steps 1 -> 2 -> 3 -> 4 are non-negotiable. Skipping step 1 will rebuild dust-base with the old (buggy) dsbx 0.1.15 and ship us right back to this incident.

- [ ] **Step 1.** Run `Release dsbx CLI` workflow (`.github/workflows/release-dsbx-cli.yml`, workflow_dispatch). Cuts the `dsbx-v0.1.16` GitHub release.
- [ ] **Step 2.** Run `Sandbox Image Registry` workflow (`.github/workflows/sandbox-img-registry.yml`, workflow_dispatch) in both EU and US. Builds the new `dust-base_0-8-20` template bundling dsbx 0.1.16.
- [ ] **Step 3.** Deploy front (standard rollout). New workers will request the 0.8.20 template; existing 0.8.19 sandboxes keep failing the healthcheck (status quo) until step 4.
- [ ] **Step 4.** Kill all 0.8.19 (and earlier) sandboxes, including paused and pending_approval, so workers relaunch on the 0.8.20 template.