### PR TITLE
[front] refactor: extract listMetronomeAlerts async iterator

### DIFF
--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -127,7 +127,11 @@ async function fetchPerUserSpendLimitsForMembersTable({
   if (result.isErr()) {
     return new Map();
   }
-  return result.value;
+  const thresholds = new Map<string, number>();
+  for (const [userId, alert] of result.value) {
+    thresholds.set(userId, alert.threshold);
+  }
+  return thresholds;
 }
 
 export async function getMembersUsage({

--- a/front/lib/metronome/alerts.ts
+++ b/front/lib/metronome/alerts.ts
@@ -4,9 +4,16 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { V1 } from "@metronome/sdk/resources";
 
+// Mirrors the Metronome SDK's `CustomerAlert.customer_status`. `null` means
+// the alert has been archived; the dispatch layer treats it the same as
+// "evaluating" (no-op).
+export type MetronomeAlertState = "ok" | "in_alarm" | "evaluating" | null;
+
 export type MetronomeAlert = {
   id: string;
   threshold: number;
+  state: MetronomeAlertState;
+  uniquenessKey: string | null;
 };
 
 type UpsertMetronomeAlertParams = V1.AlertCreateParams & {
@@ -31,6 +38,24 @@ async function archiveMetronomeAlert(
   });
 }
 
+// Lazily iterates Metronome customer alerts, transparently auto-paginating via
+// the SDK's PagePromise. Callers can `break` to early-exit (no extra pages are
+// fetched) or iterate to the end to scan everything. Errors thrown by the SDK
+// surface through the iterator — callers wrap with try/catch + `Result`.
+export async function* listMetronomeAlerts(
+  params: V1.Customers.AlertListParams
+): AsyncGenerator<MetronomeAlert> {
+  const client = getMetronomeClient();
+  for await (const entry of client.v1.customers.alerts.list(params)) {
+    yield {
+      id: entry.alert.id,
+      threshold: entry.alert.threshold,
+      state: entry.customer_status,
+      uniquenessKey: entry.alert.uniqueness_key ?? null,
+    };
+  }
+}
+
 export async function findMetronomeAlert({
   metronomeCustomerId,
   uniquenessKey,
@@ -39,16 +64,12 @@ export async function findMetronomeAlert({
   uniquenessKey: string;
 }): Promise<Result<MetronomeAlert | null, Error>> {
   try {
-    const client = getMetronomeClient();
-    for await (const entry of client.v1.customers.alerts.list({
+    for await (const alert of listMetronomeAlerts({
       customer_id: metronomeCustomerId,
       alert_statuses: ["ENABLED", "DISABLED"],
     })) {
-      if (entry.alert.uniqueness_key === uniquenessKey) {
-        return new Ok({
-          id: entry.alert.id,
-          threshold: entry.alert.threshold,
-        });
+      if (alert.uniquenessKey === uniquenessKey) {
+        return new Ok(alert);
       }
     }
     return new Ok(null);

--- a/front/lib/metronome/per_user_alerts.ts
+++ b/front/lib/metronome/per_user_alerts.ts
@@ -1,9 +1,10 @@
+import type { MetronomeAlert } from "@app/lib/metronome/alerts";
 import {
   clearMetronomeAlert,
   findMetronomeAlert,
+  listMetronomeAlerts,
   upsertMetronomeAlert,
 } from "@app/lib/metronome/alerts";
-import { getMetronomeClient } from "@app/lib/metronome/client";
 import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
@@ -25,8 +26,8 @@ function perUserAlertUniquenessKey(
 
 /**
  * Look up the current per-user cap (if any) for a workspace/user pair by
- * matching `uniqueness_key`. Returns the alert id and threshold, or
- * `null` if no cap is configured.
+ * matching `uniqueness_key`. Returns the alert id, threshold and current
+ * Metronome evaluation state, or `null` if no cap is configured.
  */
 export async function getMetronomePerUserCap({
   metronomeCustomerId,
@@ -36,25 +37,18 @@ export async function getMetronomePerUserCap({
   metronomeCustomerId: string;
   workspaceId: string;
   userId: string;
-}): Promise<Result<{ alertId: string; threshold: number } | null, Error>> {
-  const findResult = await findMetronomeAlert({
+}): Promise<Result<MetronomeAlert | null, Error>> {
+  return findMetronomeAlert({
     metronomeCustomerId,
     uniquenessKey: perUserAlertUniquenessKey(workspaceId, userId),
   });
-  if (findResult.isErr()) {
-    return new Err(findResult.error);
-  }
-  const existing = findResult.value;
-  if (!existing) {
-    return new Ok(null);
-  }
-  return new Ok({ alertId: existing.id, threshold: existing.threshold });
 }
 
 /**
- * List per-user cap thresholds for a workspace. Returns a `Map<userId,
- * threshold>` built from all enabled/disabled alerts whose
- * `uniqueness_key` matches the per-user cap pattern for this workspace.
+ * List per-user caps for a workspace. Returns a `Map<userId, MetronomeAlert>`
+ * built from all enabled alerts whose `uniqueness_key` matches the per-user
+ * cap pattern for this workspace. Each entry exposes the current threshold
+ * and Metronome evaluation state.
  */
 export async function listMetronomePerUserCapsForWorkspace({
   metronomeCustomerId,
@@ -62,16 +56,15 @@ export async function listMetronomePerUserCapsForWorkspace({
 }: {
   metronomeCustomerId: string;
   workspaceId: string;
-}): Promise<Result<Map<string, number>, Error>> {
+}): Promise<Result<Map<string, MetronomeAlert>, Error>> {
   const prefix = perUserAlertUniquenessKeyPrefix(workspaceId);
-  const caps = new Map<string, number>();
+  const caps = new Map<string, MetronomeAlert>();
   try {
-    const client = getMetronomeClient();
-    for await (const entry of client.v1.customers.alerts.list({
+    for await (const alert of listMetronomeAlerts({
       customer_id: metronomeCustomerId,
       alert_statuses: ["ENABLED"],
     })) {
-      const key = entry.alert.uniqueness_key;
+      const key = alert.uniquenessKey;
       if (!key || !key.startsWith(prefix)) {
         continue;
       }
@@ -79,7 +72,7 @@ export async function listMetronomePerUserCapsForWorkspace({
       if (!userId) {
         continue;
       }
-      caps.set(userId, entry.alert.threshold);
+      caps.set(userId, alert);
     }
     return new Ok(caps);
   } catch (err) {

--- a/front/pages/api/w/[wId]/members/[uId]/spend_limit.test.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/spend_limit.test.ts
@@ -215,8 +215,10 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
     it("returns limited with threshold when alert exists", async () => {
       vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValueOnce(
         new Ok({
-          alertId: TEST_ALERT_ID,
+          id: TEST_ALERT_ID,
           threshold: 2500,
+          state: "ok",
+          uniquenessKey: null,
         })
       );
 


### PR DESCRIPTION
## Description

* Wrap client.v1.customers.alerts.list in a single async generator so callers
can early-exit (findMetronomeAlert) or scan all pages (per-user caps lookup)
while reusing the SDK's lazy auto-pagination.
* Surfaces `customer_status` from Metronome alongside the threshold so callers
can distinguish "in_alarm" from "ok"/"evaluating" instead of only knowing
the cap exists.

## Tests

unit and local

## Risk

low
## Deploy Plan

front