### PR TITLE
Minor fixes in 'Change Seat Type' modal

### DIFF
--- a/front/components/workspace/ChangeSeatModal.tsx
+++ b/front/components/workspace/ChangeSeatModal.tsx
@@ -4,6 +4,7 @@ import type {
   SeatPlanResponseBody,
   SeatTypeInfo,
 } from "@app/lib/api/credits/seat_plan";
+import { SEAT_PRODUCT_YEARLY_SUFFIX } from "@app/lib/metronome/constants";
 import { useUpdateMemberSeatType } from "@app/lib/swr/memberships";
 import type { SupportedCurrency } from "@app/types/currency";
 import { CURRENCY_SYMBOLS } from "@app/types/currency";
@@ -14,6 +15,11 @@ import {
 import type { WorkspaceType } from "@app/types/user";
 import {
   Avatar,
+  Button,
+  ButtonGroup,
+  Card,
+  Chip,
+  CoinsStacked03V2,
   Dialog,
   DialogContainer,
   DialogContent,
@@ -23,9 +29,6 @@ import {
   SeatFreeIcon,
   SeatMaxIcon,
   SeatProIcon,
-  Tabs,
-  TabsList,
-  TabsTrigger,
 } from "@dust-tt/sparkle";
 import { useEffect, useRef, useState } from "react";
 
@@ -86,20 +89,32 @@ function formatPriceCents(
 }
 
 function formatAwuCredits(info: SeatTypeInfo): string {
-  const suffixByPeriod: Record<SeatTypeInfo["awuCreditsPeriod"], string> = {
-    weekly: "/week",
-    monthly: "/month",
-    quarterly: "/quarter",
-    annual: "/year",
-    lifetime: " lifetime",
+  const periodLabel: Record<SeatTypeInfo["awuCreditsPeriod"], string> = {
+    weekly: "per week",
+    monthly: "per month",
+    quarterly: "per quarter",
+    annual: "per year",
+    lifetime: "lifetime",
   };
-  return `${info.awuCredits.toLocaleString("en-US")} credits${
-    suffixByPeriod[info.awuCreditsPeriod]
+  return `${info.awuCredits.toLocaleString("en-US")} credits ${
+    periodLabel[info.awuCreditsPeriod]
   }`;
 }
 
 function formatFrequencyLabel(frequency: SeatBillingFrequency): string {
+  if (frequency === "annual") {
+    return "Yearly";
+  }
   return frequency.charAt(0).toUpperCase() + frequency.slice(1);
+}
+
+// The Metronome product names append SEAT_PRODUCT_YEARLY_SUFFIX to the
+// annual variant (e.g. "Pro Seat (Yearly)"). The billing cadence is conveyed
+// by the tab selector, so the suffix is redundant in the seat card label.
+function stripYearlySuffix(name: string): string {
+  return name.endsWith(SEAT_PRODUCT_YEARLY_SUFFIX)
+    ? name.slice(0, -SEAT_PRODUCT_YEARLY_SUFFIX.length)
+    : name;
 }
 
 interface SeatCardProps {
@@ -122,31 +137,29 @@ function SeatCard({
   const Icon = SEAT_TYPE_ICONS[seatType];
 
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={isDisabled}
-      className={[
-        "flex w-full items-center gap-3 rounded-xl border p-3 text-left transition-colors",
-        isSelected
-          ? "border-blue-500 bg-blue-50 dark:bg-blue-950/20"
-          : "border-border dark:border-border-night hover:border-blue-300 dark:hover:border-blue-700",
-        isDisabled ? "cursor-not-allowed opacity-40" : "cursor-pointer",
-      ].join(" ")}
+    <Card
+      variant="primary"
+      size="sm"
+      selected={isSelected}
+      onClick={isDisabled ? undefined : onClick}
+      className="w-full flex-col items-stretch gap-2"
     >
-      {Icon && <Icon />}
-      <div className="flex flex-1 flex-col">
-        <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
-          {info.name}
-        </span>
-        {info.awuCredits > 0 && (
-          <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-            {formatAwuCredits(info)}
+      <div className="flex w-full items-center justify-between">
+        <div className="flex items-center gap-2">
+          {Icon && <Icon />}
+          <span className="text-base font-semibold text-foreground dark:text-foreground-night">
+            {stripYearlySuffix(info.name)}
           </span>
-        )}
+        </div>
+        {badge}
       </div>
-      {badge}
-    </button>
+      {info.awuCredits > 0 && (
+        <div className="flex items-center gap-2 text-muted-foreground dark:text-muted-foreground-night">
+          <CoinsStacked03V2 className="size-4" />
+          <span className="text-xs">{formatAwuCredits(info)}</span>
+        </div>
+      )}
+    </Card>
   );
 }
 
@@ -173,8 +186,13 @@ export function ChangeSeatModal({
   }
   const displayedMember = member ?? lastMemberRef.current;
 
+  // "free" seats are not user-selectable — a member can never be switched to
+  // a Free seat from this modal. Filter the API response so the option never
+  // appears in the picker even if it's returned by the seat plans endpoint.
   const seatTypes = sortSeatTypes(
-    Object.keys(seatPlans).filter(isMembershipSeatType)
+    Object.keys(seatPlans)
+      .filter(isMembershipSeatType)
+      .filter((s) => s !== "free")
   );
   const firstSeatType = seatTypes[0] ?? null;
   const displayedMemberId = displayedMember?.sId ?? null;
@@ -188,29 +206,6 @@ export function ChangeSeatModal({
     workspaceId: owner.sId,
   });
   const initializedMemberIdRef = useRef<string | null>(null);
-
-  // Reset transient state when the dialog closes and initialize the selected
-  // seat once per member open. Do not re-run on seat plan refetches.
-  useEffect(() => {
-    if (!isOpen || !displayedMemberId) {
-      initializedMemberIdRef.current = null;
-      setIsSaving(false);
-      return;
-    }
-
-    if (initializedMemberIdRef.current === displayedMemberId) {
-      return;
-    }
-
-    const nextSelectedSeat = displayedMemberSeatType ?? firstSeatType;
-    if (nextSelectedSeat === null) {
-      return;
-    }
-
-    setSelectedSeat(nextSelectedSeat);
-    initializedMemberIdRef.current = displayedMemberId;
-    setIsSaving(false);
-  }, [displayedMemberId, displayedMemberSeatType, firstSeatType, isOpen]);
 
   const seatTypesByFrequency: Record<
     SeatBillingFrequency,
@@ -233,7 +228,8 @@ export function ChangeSeatModal({
   );
 
   // Default the active tab to the frequency of the user's current seat — falls
-  // back to the first frequency that has any seats to show.
+  // back to the first frequency that has any seats to show. The effect below
+  // resets the selection when a different member opens the modal.
   const currentFrequency =
     currentSeatType && seatPlans[currentSeatType]
       ? seatPlans[currentSeatType].billingFrequency
@@ -241,6 +237,42 @@ export function ChangeSeatModal({
   const [activeFrequency, setActiveFrequency] = useState<SeatBillingFrequency>(
     currentFrequency ?? availableFrequencies[0] ?? "monthly"
   );
+
+  // Reset transient state when the dialog closes and initialize the selected
+  // seat + active tab once per member open. Do not re-run on seat plan
+  // refetches.
+  useEffect(() => {
+    if (!isOpen || !displayedMemberId) {
+      initializedMemberIdRef.current = null;
+      setIsSaving(false);
+      return;
+    }
+
+    if (initializedMemberIdRef.current === displayedMemberId) {
+      return;
+    }
+
+    const nextSelectedSeat = displayedMemberSeatType ?? firstSeatType;
+    if (nextSelectedSeat === null) {
+      return;
+    }
+
+    setSelectedSeat(nextSelectedSeat);
+    if (currentFrequency) {
+      setActiveFrequency(currentFrequency);
+    } else if (availableFrequencies[0]) {
+      setActiveFrequency(availableFrequencies[0]);
+    }
+    initializedMemberIdRef.current = displayedMemberId;
+    setIsSaving(false);
+  }, [
+    availableFrequencies,
+    currentFrequency,
+    displayedMemberId,
+    displayedMemberSeatType,
+    firstSeatType,
+    isOpen,
+  ]);
 
   function getBadge(
     seatType: MembershipSeatType,
@@ -254,7 +286,7 @@ export function ChangeSeatModal({
       );
     }
     return (
-      <span className="text-xs font-medium text-muted-foreground dark:text-muted-foreground-night">
+      <span className="text-xs text-foreground dark:text-foreground-night">
         {formatPriceCents(
           info.priceCents,
           info.currency,
@@ -263,6 +295,36 @@ export function ChangeSeatModal({
       </span>
     );
   }
+
+  // Compute the yearly discount as a percentage by comparing the yearly price
+  // to monthly × 12 for the cheapest tier present in both frequencies. Falls
+  // back to no chip when the data doesn't allow a meaningful comparison.
+  function computeYearlyDiscountPercent(): number | null {
+    const yearlyDiscounts: number[] = [];
+    for (const yearlyKey of Object.keys(seatPlans)) {
+      if (!yearlyKey.endsWith("_yearly")) {
+        continue;
+      }
+      const monthlyKey = yearlyKey.slice(0, -"_yearly".length);
+      const yearly = seatPlans[yearlyKey as MembershipSeatType];
+      const monthly = seatPlans[monthlyKey as MembershipSeatType];
+      if (!yearly || !monthly || monthly.priceCents <= 0) {
+        continue;
+      }
+      const expectedYearly = monthly.priceCents * 12;
+      if (yearly.priceCents >= expectedYearly) {
+        continue;
+      }
+      yearlyDiscounts.push(1 - yearly.priceCents / expectedYearly);
+    }
+    if (yearlyDiscounts.length === 0) {
+      return null;
+    }
+    // Use the max discount surfaced — matches "best savings" framing.
+    const max = Math.max(...yearlyDiscounts);
+    return Math.round(max * 100);
+  }
+  const yearlyDiscountPercent = computeYearlyDiscountPercent();
 
   // Member has a scheduled seat change and is re-selecting their current seat to cancel it.
   const isCancellingScheduledChange =
@@ -293,46 +355,71 @@ export function ChangeSeatModal({
     }
   }
 
-  // Max → Pro is deferred (downgrade waits for next billing period).
-  const isDeferredChange = currentSeatType === "max" && selectedSeat === "pro";
+  // Mirrors the backend `classifySeatTransition` rule
+  // (lib/metronome/seat_types.ts): a transition is deferred when the target
+  // seat has strictly lower AWU allocation than the current one — the user
+  // keeps the richer access through the period they already paid for.
+  // Identical seats are never deferred (they're a no-op).
+  const currentAwuCredits = currentSeatType
+    ? (seatPlans[currentSeatType]?.awuCredits ?? 0)
+    : 0;
+  const selectedAwuCredits = selectedSeat
+    ? (seatPlans[selectedSeat]?.awuCredits ?? 0)
+    : 0;
+  const isDeferredChange =
+    !!selectedSeat &&
+    selectedSeat !== currentSeatType &&
+    selectedAwuCredits < currentAwuCredits;
+
+  const displayedFirstName =
+    displayedMember?.name?.trim().split(/\s+/)[0] ?? null;
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
       <DialogContent size="md">
         <DialogHeader>
-          <div className="flex items-center gap-3">
+          <div className="flex flex-col gap-2">
             <Avatar
               visual={displayedMember?.image ?? undefined}
               name={displayedMember?.name}
               size="md"
               isRounded
             />
-            <div>
+            <div className="flex flex-col gap-1">
               <DialogTitle>
-                Change seat type for {displayedMember?.name}
+                {displayedFirstName
+                  ? `Change seat for ${displayedFirstName}`
+                  : "Change seat"}
               </DialogTitle>
               <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                They will be able to consume this amount from the Workspace
-                Credits Pool after reaching their plan usage limit.
+                Choose a new plan to continue
               </p>
             </div>
           </div>
         </DialogHeader>
         <DialogContainer>
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-3">
             {availableFrequencies.length > 1 && (
-              <Tabs value={activeFrequency} className="mb-1">
-                <TabsList border={false}>
+              <div className="mb-1 flex items-center gap-2 self-start">
+                <ButtonGroup>
                   {availableFrequencies.map((f) => (
-                    <TabsTrigger
+                    <Button
                       key={f}
-                      value={f}
+                      size="sm"
+                      variant={activeFrequency === f ? "primary" : "outline"}
                       label={formatFrequencyLabel(f)}
                       onClick={() => setActiveFrequency(f)}
                     />
                   ))}
-                </TabsList>
-              </Tabs>
+                </ButtonGroup>
+                {yearlyDiscountPercent !== null && (
+                  <Chip
+                    size="xs"
+                    color="green"
+                    label={`-${yearlyDiscountPercent}%`}
+                  />
+                )}
+              </div>
             )}
 
             {seatTypesByFrequency[activeFrequency].map((seatType) => {

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -1,6 +1,9 @@
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import type { BillingFrequency } from "@app/lib/metronome/types";
-import type { MembershipSeatType } from "@app/types/memberships";
+import {
+  isMembershipSeatType,
+  type MembershipSeatType,
+} from "@app/types/memberships";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import {
   ActionCreditCoinsIcon,
@@ -41,6 +44,17 @@ const SEAT_TYPE_ICONS: Partial<
   free: SeatFreeIcon,
 };
 
+// Yearly seat types are billed yearly but render in the table identically to
+// their monthly counterpart — the billing cadence is shown in the dedicated
+// billing frequency column. Strip the suffix for icon lookup and display.
+function getDisplaySeatType(seatType: MembershipSeatType): MembershipSeatType {
+  if (seatType.endsWith("_yearly")) {
+    const stripped = seatType.slice(0, -"_yearly".length);
+    return isMembershipSeatType(stripped) ? stripped : seatType;
+  }
+  return seatType;
+}
+
 interface SeatTypeIconProps {
   seatType: MembershipSeatType | null;
 }
@@ -49,7 +63,7 @@ function SeatTypeIcon({ seatType }: SeatTypeIconProps) {
   if (!seatType) {
     return null;
   }
-  const Icon = SEAT_TYPE_ICONS[seatType];
+  const Icon = SEAT_TYPE_ICONS[getDisplaySeatType(seatType)];
   if (!Icon) {
     return null;
   }
@@ -233,11 +247,11 @@ const seatTypeColumn: ColumnDef<RowData, string> = {
         <span className="flex flex-col">
           <span className="flex items-center gap-1.5 text-sm font-semibold capitalize text-muted-foreground dark:text-muted-foreground-night">
             <SeatTypeIcon seatType={seatType} />
-            {seatType ?? "—"}
+            {seatType ? getDisplaySeatType(seatType) : "—"}
           </span>
           {scheduledSeatType && scheduledDate && (
             <span className="text-xs capitalize text-amber-600 dark:text-amber-400">
-              → {scheduledSeatType} on {scheduledDate}
+              → {getDisplaySeatType(scheduledSeatType)} on {scheduledDate}
             </span>
           )}
         </span>

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -99,6 +99,12 @@ export const CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY =
 export const CONTRACT_CREDIT_TYPE_EXCESS = "excess";
 export const CONTRACT_CREDIT_TYPE_POOL = "pool";
 
+// Suffix appended to the annual variant of each seat product name in
+// Metronome (e.g. "Pro Seat (Yearly)"). Used by the setup script when
+// declaring products and by the UI to strip the suffix from displayed seat
+// labels — the billing cadence is conveyed by the tab selector.
+export const SEAT_PRODUCT_YEARLY_SUFFIX = " (Yearly)";
+
 // AWU (Agentic Work Units) differs per environment.
 export const DEV_CREDIT_TYPE_AWU_ID = "eb003cc7-4935-467d-a41c-c1738c1c9dc2";
 export const PROD_CREDIT_TYPE_AWU_ID = "8dfc9846-a38e-44f8-a625-bd9372af681c";

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -27,6 +27,7 @@ import {
   PLAN_CODE_CUSTOM_FIELD_KEY,
   PROD_CREDIT_TYPE_AWU_ID,
   PROD_CREDIT_TYPE_PROG_USD_ID,
+  SEAT_PRODUCT_YEARLY_SUFFIX,
   SEAT_TYPE_CUSTOM_FIELD_KEY,
   STRIPE_PRODUCT_ID_CUSTOM_FIELD_KEY,
 } from "@app/lib/metronome/constants";
@@ -67,7 +68,6 @@ const getOverageAwuRate = (currency: SupportedCurrency) => {
 const WORKSPACE_SEAT_PRODUCT_NAME = "Workspace Seat";
 const PRO_SEAT_PRODUCT_NAME = "Pro Seat";
 const MAX_SEAT_PRODUCT_NAME = "Max Seat";
-const YEARLY_SUFFIX = " (Yearly)";
 const FREE_SEAT_PRODUCT_NAME = "Free Seat";
 const PRO_SEAT_CREDIT_NAME = "Pro Seat Credits";
 const MAX_SEAT_CREDIT_NAME = "Max Seat Credits";
@@ -414,7 +414,7 @@ const PRODUCTS: ProductDef[] = [
     custom_fields: { [SEAT_TYPE_CUSTOM_FIELD_KEY]: "workspace" },
   },
   {
-    name: WORKSPACE_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+    name: WORKSPACE_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
     type: "SUBSCRIPTION",
     custom_fields: { [SEAT_TYPE_CUSTOM_FIELD_KEY]: "workspace_yearly" },
   },
@@ -427,7 +427,7 @@ const PRODUCTS: ProductDef[] = [
     custom_fields: { [SEAT_TYPE_CUSTOM_FIELD_KEY]: "pro" },
   },
   {
-    name: PRO_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+    name: PRO_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
     type: "SUBSCRIPTION",
     custom_fields: { [SEAT_TYPE_CUSTOM_FIELD_KEY]: "pro_yearly" },
   },
@@ -437,7 +437,7 @@ const PRODUCTS: ProductDef[] = [
     custom_fields: { [SEAT_TYPE_CUSTOM_FIELD_KEY]: "max" },
   },
   {
-    name: MAX_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+    name: MAX_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
     type: "SUBSCRIPTION",
     custom_fields: { [SEAT_TYPE_CUSTOM_FIELD_KEY]: "max_yearly" },
   },
@@ -893,7 +893,8 @@ function getRateCards(): RateCardDef[] {
           credit_type_id: CREDIT_TYPE_USD_ID,
         },
         {
-          product_name: WORKSPACE_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+          product_name:
+            WORKSPACE_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: true,
           rate_type: "FLAT",
@@ -911,7 +912,7 @@ function getRateCards(): RateCardDef[] {
           credit_type_id: CREDIT_TYPE_USD_ID,
         },
         {
-          product_name: PRO_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+          product_name: PRO_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: false,
           rate_type: "FLAT",
@@ -929,7 +930,7 @@ function getRateCards(): RateCardDef[] {
           credit_type_id: CREDIT_TYPE_USD_ID,
         },
         {
-          product_name: MAX_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+          product_name: MAX_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: false,
           rate_type: "FLAT",
@@ -978,7 +979,8 @@ function getRateCards(): RateCardDef[] {
           credit_type_id: CREDIT_TYPE_EUR_ID,
         },
         {
-          product_name: WORKSPACE_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+          product_name:
+            WORKSPACE_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: true,
           rate_type: "FLAT",
@@ -996,7 +998,7 @@ function getRateCards(): RateCardDef[] {
           credit_type_id: CREDIT_TYPE_EUR_ID,
         },
         {
-          product_name: PRO_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+          product_name: PRO_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: false,
           rate_type: "FLAT",
@@ -1014,7 +1016,7 @@ function getRateCards(): RateCardDef[] {
           credit_type_id: CREDIT_TYPE_EUR_ID,
         },
         {
-          product_name: MAX_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+          product_name: MAX_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: false,
           rate_type: "FLAT",
@@ -1063,7 +1065,7 @@ function getRateCards(): RateCardDef[] {
           credit_type_id: CREDIT_TYPE_USD_ID,
         },
         {
-          product_name: PRO_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+          product_name: PRO_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: true,
           rate_type: "FLAT",
@@ -1081,7 +1083,7 @@ function getRateCards(): RateCardDef[] {
           credit_type_id: CREDIT_TYPE_USD_ID,
         },
         {
-          product_name: MAX_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+          product_name: MAX_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: true,
           rate_type: "FLAT",
@@ -1128,7 +1130,7 @@ function getRateCards(): RateCardDef[] {
           credit_type_id: CREDIT_TYPE_EUR_ID,
         },
         {
-          product_name: PRO_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+          product_name: PRO_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: true,
           rate_type: "FLAT",
@@ -1146,7 +1148,7 @@ function getRateCards(): RateCardDef[] {
           credit_type_id: CREDIT_TYPE_EUR_ID,
         },
         {
-          product_name: MAX_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+          product_name: MAX_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
           starting_at: "2026-04-01T00:00:00.000Z",
           entitled: true,
           rate_type: "FLAT",
@@ -1204,13 +1206,19 @@ function buildSeatEntitlementFlipOverrides(): PackageOverrideDef[] {
   return [
     { product_name: WORKSPACE_SEAT_PRODUCT_NAME, entitled: false },
     {
-      product_name: WORKSPACE_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+      product_name: WORKSPACE_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
       entitled: false,
     },
     { product_name: PRO_SEAT_PRODUCT_NAME, entitled: true },
-    { product_name: PRO_SEAT_PRODUCT_NAME + YEARLY_SUFFIX, entitled: true },
+    {
+      product_name: PRO_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
+      entitled: true,
+    },
     { product_name: MAX_SEAT_PRODUCT_NAME, entitled: true },
-    { product_name: MAX_SEAT_PRODUCT_NAME + YEARLY_SUFFIX, entitled: true },
+    {
+      product_name: MAX_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
+      entitled: true,
+    },
   ];
 }
 
@@ -1319,7 +1327,7 @@ const WORKSPACE_SEAT_MONTHLY_SUBSCRIPTION: PackageSubscription = {
 };
 const WORKSPACE_SEAT_ANNUAL_SUBSCRIPTION: PackageSubscription = {
   temporary_id: "workspace-seat-annual-sub",
-  product_name: WORKSPACE_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+  product_name: WORKSPACE_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
   billing_frequency: "ANNUAL",
   collection_schedule: "ADVANCE",
   quantity_management_mode: "QUANTITY_ONLY",
@@ -1351,7 +1359,7 @@ const PRO_SEAT_SUBSCRIPTION: PackageSubscription = {
 const PRO_SEAT_ANNUAL_SUBSCRIPTION_TEMPORARY_ID = "pro-seat-annual-sub";
 const PRO_SEAT_ANNUAL_SUBSCRIPTION: PackageSubscription = {
   temporary_id: PRO_SEAT_ANNUAL_SUBSCRIPTION_TEMPORARY_ID,
-  product_name: PRO_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+  product_name: PRO_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
   billing_frequency: "ANNUAL",
   collection_schedule: "ADVANCE",
   quantity_management_mode: "SEAT_BASED",
@@ -1379,7 +1387,7 @@ const MAX_SEAT_SUBSCRIPTION: PackageSubscription = {
 const MAX_SEAT_ANNUAL_SUBSCRIPTION_TEMPORARY_ID = "max-seat-annual-sub";
 const MAX_SEAT_ANNUAL_SUBSCRIPTION: PackageSubscription = {
   temporary_id: MAX_SEAT_ANNUAL_SUBSCRIPTION_TEMPORARY_ID,
-  product_name: MAX_SEAT_PRODUCT_NAME + YEARLY_SUFFIX,
+  product_name: MAX_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
   billing_frequency: "ANNUAL",
   collection_schedule: "ADVANCE",
   quantity_management_mode: "SEAT_BASED",


### PR DESCRIPTION
## Description

<img width="576" height="472" alt="Screenshot 2026-05-22 at 18 22 06" src="https://github.com/user-attachments/assets/470d8683-28b1-4ef4-b247-45cadd09882f" />


UI polish for the **Change Seat Type** modal to match the latest Figma design ([node 6278:16544](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=6278-16544)), plus a couple of follow-ons:

### Modal (`ChangeSeatModal.tsx`)
- Header: avatar above title; copy is now "Change seat for {firstName}" + subtitle "Choose a new plan to continue".
- Cadence toggle: switched to Sparkle `ButtonGroup` + `Button` (`primary` for active, `outline` for inactive) so it renders as a connected pill. Label renamed Annual → Yearly.
- Discount chip (Sparkle `Chip`, green, `xs`) rendered next to the toggle. The chip is gated on real data: `1 - yearly / (monthly × 12)` taken as the max across tiers; auto-hides when no actual discount exists (e.g. parity-priced EUR plans). Note: the chip lives next to the toggle rather than inside the Yearly button because `Button.label` only accepts a string.
- Seat option: replaced the custom `<button>` with Sparkle `Card` (`variant="primary"` for the gray surface, `selected` for the ring). Layout matches Figma — icon + name + price on top row, `CoinsStacked03V2` + "{N} credits per month" on the bottom row.
- Auto-selection: opening the modal now also picks the cadence tab matching the user's current seat (was: only the seat itself was selected, frequency could be stale across members).
- Free seats are filtered out of the picker — users can never be switched to a Free seat.
- `(Yearly)` suffix is stripped from displayed seat names (cadence is already conveyed by the tab).
- `isDeferredChange` no longer hardcodes `max → pro`; it mirrors the backend's `classifySeatTransition` rule by comparing `awuCredits` for current vs. selected seat. Any downgrade now shows the "change will take effect at the next credit refresh" notice.

### Members table (`MembersUsageTable.tsx`)
- Seat column: strips the `_yearly` suffix for display (e.g. `pro_yearly` → `Pro`) and the icon lookup falls back to the monthly counterpart. The yearly distinction remains visible in the dedicated billing-frequency column.

### Shared constant
- Moved the `" (Yearly)"` product-name suffix from a local `const` in `scripts/metronome_setup.ts` to a new exported `SEAT_PRODUCT_YEARLY_SUFFIX` in `lib/metronome/constants.ts`. Both the setup script and the modal now reference the single source of truth.

## Tests

- Manually exercised the modal across plans:
  - Business USD (Pro `$30/mo` vs `$288/yr`): green `-20%` chip renders.
  - Enterprise EUR (Pro `€44/mo` vs `€528/yr`): no chip — yearly is monthly × 12 to the cent. Confirmed via temporary debug log of `seatPlans` / `yearlyDiscountPercent`.
  - Free seat removed from the picker.
  - Cadence tab auto-selects to the member's current seat frequency.
  - Downgrade (`max → pro`, also `max_yearly → max`) surfaces the deferred-change notice.
- Members table verified — `pro_yearly` row renders as "Pro" with the Pro icon; billing-frequency column still says Annual.
- `npx tsgo --noEmit` clean.

## Risk

- Visual-only changes in the modal — no behavior change to the seat-update API call.
- `MembersUsageTable.tsx` change is a display transform; the underlying `seatType` value (used by filters, scheduled-change banner, etc.) is unchanged.
- The new shared constant is referenced from a `front` script and a front component — both inside the same TS project, no cross-package concerns.
- Rollback is safe: revert restores the previous modal/table look without any data-side cleanup.

## Deploy Plan

- Standard deploy. No setup script run required; the `SEAT_PRODUCT_YEARLY_SUFFIX` move is internal-only and doesn't change product names on Metronome.