### PR TITLE
[front] feat: add default per-user cap Metronome alert helpers

### DIFF
--- a/front/lib/metronome/default_user_cap_alert.ts
+++ b/front/lib/metronome/default_user_cap_alert.ts
@@ -1,0 +1,80 @@
+import type { MetronomeAlert } from "@app/lib/metronome/alerts";
+import {
+  findMetronomeAlert,
+  upsertMetronomeAlert,
+} from "@app/lib/metronome/alerts";
+import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+const USER_ID_GROUP_KEY = "user_id";
+
+function defaultUserCapAlertUniquenessKey(workspaceId: string): string {
+  return `default-user-cap-${workspaceId}`;
+}
+
+/**
+ * Look up the workspace-wide default per-user cap alert. Returns the alert
+ * id, threshold and current Metronome evaluation state, or `null` if no
+ * default cap has been configured yet.
+ *
+ * The default alert is fanned out per `user_id` by Metronome: it uses
+ * `group_values: [{ key: "user_id" }]` with no value, so a single alert
+ * configuration produces per-user `reached` / `resolved` events.
+ */
+export async function getMetronomeDefaultUserCapAlert({
+  metronomeCustomerId,
+  workspaceId,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+}): Promise<Result<MetronomeAlert | null, Error>> {
+  return findMetronomeAlert({
+    metronomeCustomerId,
+    uniquenessKey: defaultUserCapAlertUniquenessKey(workspaceId),
+  });
+}
+
+/**
+ * Idempotently ensure a workspace-wide default per-user cap alert exists on
+ * the customer, with the given AWU threshold. If an alert with a different
+ * threshold already exists, it's archived (with key release) and recreated.
+ *
+ * Fan-out: `group_values: [{ key: "user_id" }]` with no value — Metronome
+ * fires one `reached` / `resolved` event per user that crosses the threshold,
+ * with that user's id populated in `group_values[].value`.
+ */
+export async function upsertMetronomeDefaultUserCapAlert({
+  metronomeCustomerId,
+  workspaceId,
+  awuCredits,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+  awuCredits: number;
+}): Promise<Result<{ alertId: string }, Error>> {
+  const upsertResult = await upsertMetronomeAlert({
+    alert_type: "spend_threshold_reached",
+    name: `Default per-user cap ${workspaceId} (${awuCredits} AWU)`,
+    threshold: awuCredits,
+    credit_type_id: getCreditTypeAwuId(),
+    customer_id: metronomeCustomerId,
+    group_values: [{ key: USER_ID_GROUP_KEY }],
+    uniqueness_key: defaultUserCapAlertUniquenessKey(workspaceId),
+  });
+  if (upsertResult.isErr()) {
+    return new Err(upsertResult.error);
+  }
+
+  logger.info(
+    {
+      workspaceId,
+      metronomeCustomerId,
+      alertId: upsertResult.value.alertId,
+      awuCredits,
+    },
+    "[Metronome DefaultUserCap] Synced default per-user cap alert"
+  );
+  return new Ok({ alertId: upsertResult.value.alertId });
+}


### PR DESCRIPTION
## Description

Introduce get/upsert helpers for the workspace-wide default per-user cap alert, fanned out via Metronome's user_id group_values.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low, not plugged anywhere yet

## Deploy Plan

front
