### PR TITLE
getAwuAllocationInfoForSeatType to get allocation as number AND period

### DIFF
--- a/front-api/routes/w/[wId]/seats/plan.ts
+++ b/front-api/routes/w/[wId]/seats/plan.ts
@@ -3,6 +3,7 @@ import type {
   SeatPlanResponseBody,
   SeatTypeInfo,
 } from "@app/lib/api/credits/seat_plan";
+import { getSeatBillingFrequency } from "@app/lib/api/credits/seat_plan";
 import { amountCents } from "@app/lib/metronome/amounts";
 import { getMetronomeClient } from "@app/lib/metronome/client";
 import { getCreditTypeFromContract } from "@app/lib/metronome/coupons";
@@ -22,22 +23,6 @@ import { apiError } from "@front-api/middlewares/utils";
 
 // Mounted at /api/w/:wId/seats/plan.
 const app = workspaceApp();
-
-function getSeatBillingFrequency(
-  billingFrequency: string
-): SeatBillingFrequency {
-  switch (billingFrequency) {
-    case "WEEKLY":
-      return "weekly";
-    case "QUARTERLY":
-      return "quarterly";
-    case "ANNUAL":
-      return "annual";
-    case "MONTHLY":
-    default:
-      return "monthly";
-  }
-}
 
 app.get("/", async (ctx) => {
   const auth = ctx.get("auth");

--- a/front-api/routes/w/[wId]/seats/plan.ts
+++ b/front-api/routes/w/[wId]/seats/plan.ts
@@ -8,7 +8,7 @@ import { getMetronomeClient } from "@app/lib/metronome/client";
 import { getCreditTypeFromContract } from "@app/lib/metronome/coupons";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import {
-  getAwuAllocationForSeatType,
+  getAwuAllocationInfoForSeatType,
   getProductSeatTypes,
   getSeatSubscriptionsFromContract,
   getSeatTypesByProductIdFromContract,
@@ -22,6 +22,22 @@ import { apiError } from "@front-api/middlewares/utils";
 
 // Mounted at /api/w/:wId/seats/plan.
 const app = workspaceApp();
+
+function getSeatBillingFrequency(
+  billingFrequency: string
+): SeatBillingFrequency {
+  switch (billingFrequency) {
+    case "WEEKLY":
+      return "weekly";
+    case "QUARTERLY":
+      return "quarterly";
+    case "ANNUAL":
+      return "annual";
+    case "MONTHLY":
+    default:
+      return "monthly";
+  }
+}
 
 app.get("/", async (ctx) => {
   const auth = ctx.get("auth");
@@ -78,9 +94,8 @@ app.get("/", async (ctx) => {
   }
 
   // Resolve each seat's billing frequency from the matching subscription on
-  // the contract. Default to "monthly" if the subscription declares anything
-  // other than ANNUAL — Metronome's enum has WEEKLY / QUARTERLY too, but we
-  // only ship monthly and annual seats.
+  // the contract. Keep the full Metronome cadence in the response so callers
+  // don't need to assume that all non-annual seats are monthly.
   const billingFrequencyBySeatType = new Map<
     MembershipSeatType,
     SeatBillingFrequency
@@ -92,9 +107,7 @@ app.get("/", async (ctx) => {
   for (const [seatType, sub] of seatSubscriptions) {
     billingFrequencyBySeatType.set(
       seatType,
-      sub.subscription_rate.billing_frequency === "ANNUAL"
-        ? "annual"
-        : "monthly"
+      getSeatBillingFrequency(sub.subscription_rate.billing_frequency)
     );
   }
 
@@ -164,13 +177,15 @@ app.get("/", async (ctx) => {
     if (priceCents === undefined || name === undefined) {
       continue;
     }
+    const awuAllocation = getAwuAllocationInfoForSeatType(
+      contract,
+      seatType,
+      productSeatTypes
+    );
     const info: SeatTypeInfo = {
       name,
-      awuCredits: getAwuAllocationForSeatType(
-        contract,
-        seatType,
-        productSeatTypes
-      ),
+      awuCredits: awuAllocation.credits,
+      awuCreditsPeriod: awuAllocation.period,
       priceCents,
       currency,
       billingFrequency: billingFrequencyBySeatType.get(seatType) ?? "monthly",

--- a/front/components/workspace/ChangeSeatModal.tsx
+++ b/front/components/workspace/ChangeSeatModal.tsx
@@ -52,6 +52,13 @@ const SEAT_DISPLAY_ORDER: MembershipSeatType[] = [
   "max_yearly",
 ];
 
+const SEAT_BILLING_FREQUENCIES: SeatBillingFrequency[] = [
+  "weekly",
+  "monthly",
+  "quarterly",
+  "annual",
+];
+
 function sortSeatTypes(seatTypes: MembershipSeatType[]): MembershipSeatType[] {
   const indexOf = (s: MembershipSeatType) => {
     const i = SEAT_DISPLAY_ORDER.indexOf(s);
@@ -67,14 +74,32 @@ function formatPriceCents(
 ): string {
   const symbol = CURRENCY_SYMBOLS[currency];
   const amount = (cents / 100).toFixed(2).replace(/\.00$/, "");
-  const suffix = billingFrequency === "annual" ? "/yr" : "/mo";
+  const suffixByFrequency: Record<SeatBillingFrequency, string> = {
+    weekly: "/wk",
+    monthly: "/mo",
+    quarterly: "/qtr",
+    annual: "/yr",
+  };
   return currency === "usd"
-    ? `${symbol}${amount}${suffix}`
-    : `${amount}${symbol}${suffix}`;
+    ? `${symbol}${amount}${suffixByFrequency[billingFrequency]}`
+    : `${amount}${symbol}${suffixByFrequency[billingFrequency]}`;
 }
 
-function formatAwuCredits(awuCredits: number): string {
-  return `${awuCredits.toLocaleString("en-US")} credits/month`;
+function formatAwuCredits(info: SeatTypeInfo): string {
+  const suffixByPeriod: Record<SeatTypeInfo["awuCreditsPeriod"], string> = {
+    weekly: "/week",
+    monthly: "/month",
+    quarterly: "/quarter",
+    annual: "/year",
+    lifetime: " lifetime",
+  };
+  return `${info.awuCredits.toLocaleString("en-US")} credits${
+    suffixByPeriod[info.awuCreditsPeriod]
+  }`;
+}
+
+function formatFrequencyLabel(frequency: SeatBillingFrequency): string {
+  return frequency.charAt(0).toUpperCase() + frequency.slice(1);
 }
 
 interface SeatCardProps {
@@ -116,7 +141,7 @@ function SeatCard({
         </span>
         {info.awuCredits > 0 && (
           <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-            {formatAwuCredits(info.awuCredits)}
+            {formatAwuCredits(info)}
           </span>
         )}
       </div>
@@ -191,7 +216,9 @@ export function ChangeSeatModal({
     SeatBillingFrequency,
     MembershipSeatType[]
   > = {
+    weekly: [],
     monthly: [],
+    quarterly: [],
     annual: [],
   };
   for (const seatType of seatTypes) {
@@ -201,9 +228,9 @@ export function ChangeSeatModal({
     }
   }
 
-  const availableFrequencies: SeatBillingFrequency[] = (
-    ["monthly", "annual"] as const
-  ).filter((f) => seatTypesByFrequency[f].length > 0);
+  const availableFrequencies = SEAT_BILLING_FREQUENCIES.filter(
+    (f) => seatTypesByFrequency[f].length > 0
+  );
 
   // Default the active tab to the frequency of the user's current seat — falls
   // back to the first frequency that has any seats to show.
@@ -300,7 +327,7 @@ export function ChangeSeatModal({
                     <TabsTrigger
                       key={f}
                       value={f}
-                      label={f === "annual" ? "Annual" : "Monthly"}
+                      label={formatFrequencyLabel(f)}
                       onClick={() => setActiveFrequency(f)}
                     />
                   ))}

--- a/front/components/workspace/billing/BillingSeatsOverview.tsx
+++ b/front/components/workspace/billing/BillingSeatsOverview.tsx
@@ -69,6 +69,21 @@ function seatTypeGroup(seatType: MembershipSeatType): MembershipSeatType {
   }
 }
 
+function formatAwuCreditsPeriod(period: SeatTypeInfo["awuCreditsPeriod"]) {
+  switch (period) {
+    case "weekly":
+      return "per week";
+    case "monthly":
+      return "per month";
+    case "quarterly":
+      return "per quarter";
+    case "annual":
+      return "per year";
+    case "lifetime":
+      return "lifetime";
+  }
+}
+
 interface BillingSeatsOverviewProps {
   owner: LightWorkspaceType;
 }
@@ -183,7 +198,8 @@ export function BillingSeatsOverview({ owner }: BillingSeatsOverviewProps) {
                 <div className="flex items-center gap-2">
                   <Icon visual={ActionCreditCoinsIcon} size="xs" />
                   <span>
-                    {primaryPlan.awuCredits.toLocaleString()} credits per month
+                    {primaryPlan.awuCredits.toLocaleString()} credits{" "}
+                    {formatAwuCreditsPeriod(primaryPlan.awuCreditsPeriod)}
                   </span>
                 </div>
               </div>

--- a/front/lib/api/credits/seat_plan.ts
+++ b/front/lib/api/credits/seat_plan.ts
@@ -45,7 +45,7 @@ export type SeatPlanResponseBody = Partial<
   Record<MembershipSeatType, SeatTypeInfo>
 >;
 
-function getSeatBillingFrequency(
+export function getSeatBillingFrequency(
   billingFrequency: string
 ): SeatBillingFrequency {
   switch (billingFrequency) {

--- a/front/lib/api/credits/seat_plan.ts
+++ b/front/lib/api/credits/seat_plan.ts
@@ -4,11 +4,12 @@ import { getMetronomeClient } from "@app/lib/metronome/client";
 import { getCreditTypeFromContract } from "@app/lib/metronome/coupons";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import {
-  getAwuAllocationForSeatType,
+  getAwuAllocationInfoForSeatType,
   getProductSeatTypes,
   getSeatSubscriptionsFromContract,
   getSeatTypesByProductIdFromContract,
   isMauContract,
+  type SeatAwuCreditsPeriod,
 } from "@app/lib/metronome/seat_types";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -18,13 +19,18 @@ import type { MembershipSeatType } from "@app/types/memberships";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export type SeatBillingFrequency = "monthly" | "annual";
+export type SeatBillingFrequency =
+  | "weekly"
+  | "monthly"
+  | "quarterly"
+  | "annual";
 
 export interface SeatTypeInfo {
   // Human-readable plan name surfaced by Metronome (e.g. "Pro Seat") — use
   // for display so the UI doesn't need to know about specific seat types.
   name: string;
   awuCredits: number;
+  awuCreditsPeriod: SeatAwuCreditsPeriod;
   priceCents: number;
   currency: SupportedCurrency;
   // `priceCents` is the amount billed per `billingFrequency` (per month for
@@ -38,6 +44,22 @@ export interface SeatTypeInfo {
 export type SeatPlanResponseBody = Partial<
   Record<MembershipSeatType, SeatTypeInfo>
 >;
+
+function getSeatBillingFrequency(
+  billingFrequency: string
+): SeatBillingFrequency {
+  switch (billingFrequency) {
+    case "WEEKLY":
+      return "weekly";
+    case "QUARTERLY":
+      return "quarterly";
+    case "ANNUAL":
+      return "annual";
+    case "MONTHLY":
+    default:
+      return "monthly";
+  }
+}
 
 export async function handleSeatPlanRequest(
   req: NextApiRequest,
@@ -104,9 +126,8 @@ export async function handleSeatPlanRequest(
   }
 
   // Resolve each seat's billing frequency from the matching subscription on
-  // the contract. Default to "monthly" if the subscription declares anything
-  // other than ANNUAL — Metronome's enum has WEEKLY / QUARTERLY too, but we
-  // only ship monthly and annual seats.
+  // the contract. Keep the full Metronome cadence in the response so callers
+  // don't need to assume that all non-annual seats are monthly.
   const billingFrequencyBySeatType = new Map<
     MembershipSeatType,
     SeatBillingFrequency
@@ -118,9 +139,7 @@ export async function handleSeatPlanRequest(
   for (const [seatType, sub] of seatSubscriptions) {
     billingFrequencyBySeatType.set(
       seatType,
-      sub.subscription_rate.billing_frequency === "ANNUAL"
-        ? "annual"
-        : "monthly"
+      getSeatBillingFrequency(sub.subscription_rate.billing_frequency)
     );
   }
 
@@ -191,13 +210,15 @@ export async function handleSeatPlanRequest(
     if (priceCents === undefined || name === undefined) {
       continue;
     }
+    const awuAllocation = getAwuAllocationInfoForSeatType(
+      contract,
+      seatType,
+      productSeatTypes
+    );
     response[seatType] = {
       name,
-      awuCredits: getAwuAllocationForSeatType(
-        contract,
-        seatType,
-        productSeatTypes
-      ),
+      awuCredits: awuAllocation.credits,
+      awuCreditsPeriod: awuAllocation.period,
       priceCents,
       currency,
       billingFrequency: billingFrequencyBySeatType.get(seatType) ?? "monthly",

--- a/front/lib/metronome/seat_types.ts
+++ b/front/lib/metronome/seat_types.ts
@@ -240,6 +240,38 @@ export function getSeatTypesByProductIdFromContract(
   return result;
 }
 
+export type SeatAwuCreditsPeriod =
+  | "weekly"
+  | "monthly"
+  | "quarterly"
+  | "annual"
+  | "lifetime";
+
+export type SeatAwuAllocationInfo = {
+  credits: number;
+  period: SeatAwuCreditsPeriod;
+};
+
+function getSeatAwuCreditsPeriod(
+  credit: NonNullable<CachedContract["recurring_credits"]>[number]
+): SeatAwuCreditsPeriod {
+  if (credit.commit_duration.value > 1) {
+    return "lifetime";
+  }
+
+  switch (credit.recurrence_frequency) {
+    case "WEEKLY":
+      return "weekly";
+    case "ANNUAL":
+      return "annual";
+    case "QUARTERLY":
+      return "quarterly";
+    case "MONTHLY":
+    case undefined:
+      return "monthly";
+  }
+}
+
 /**
  * Look up the per-seat AWU allocation for a given seat type from the
  * contract's recurring credits. Credits are linked to seat subscriptions
@@ -249,23 +281,42 @@ export function getSeatTypesByProductIdFromContract(
  * Returns 0 when the seat type has no recurring credit (e.g. workspace
  * seats on legacy plans).
  */
-export function getAwuAllocationForSeatType(
+export function getAwuAllocationInfoForSeatType(
   contract: Pick<CachedContract, "subscriptions" | "recurring_credits">,
   seatType: MembershipSeatType,
   productSeatTypes: Map<string, MembershipSeatType>
-): number {
+): SeatAwuAllocationInfo {
   const seatSubscriptions = getSeatSubscriptionsFromContract(
     contract,
     productSeatTypes
   );
   const subscription = seatSubscriptions.get(seatType);
   if (!subscription?.id) {
-    return 0;
+    return { credits: 0, period: "monthly" };
   }
   const credit = (contract.recurring_credits ?? []).find(
     (c) => c.subscription_config?.subscription_id === subscription.id
   );
-  return credit?.access_amount.unit_price ?? 0;
+  if (!credit) {
+    return { credits: 0, period: "monthly" };
+  }
+
+  return {
+    credits: credit.access_amount.unit_price,
+    period: getSeatAwuCreditsPeriod(credit),
+  };
+}
+
+export function getAwuAllocationForSeatType(
+  contract: Pick<CachedContract, "subscriptions" | "recurring_credits">,
+  seatType: MembershipSeatType,
+  productSeatTypes: Map<string, MembershipSeatType>
+): number {
+  return getAwuAllocationInfoForSeatType(
+    contract,
+    seatType,
+    productSeatTypes
+  ).credits;
 }
 
 /**

--- a/front/lib/metronome/seat_types.ts
+++ b/front/lib/metronome/seat_types.ts
@@ -312,11 +312,8 @@ export function getAwuAllocationForSeatType(
   seatType: MembershipSeatType,
   productSeatTypes: Map<string, MembershipSeatType>
 ): number {
-  return getAwuAllocationInfoForSeatType(
-    contract,
-    seatType,
-    productSeatTypes
-  ).credits;
+  return getAwuAllocationInfoForSeatType(contract, seatType, productSeatTypes)
+    .credits;
 }
 
 /**

--- a/front/pages/api/w/[wId]/seats/plan.ts
+++ b/front/pages/api/w/[wId]/seats/plan.ts
@@ -14,6 +14,8 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<SeatPlanResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
+  // Seat plan behavior lives in the shared handler so this legacy route stays
+  // aligned with the Hono route while migration is in progress.
   return handleSeatPlanRequest(req, res, auth);
 }
 


### PR DESCRIPTION
## Description

Getting the allocation with number and period lets us render the priod properly in the Billing page.

## Tests

Tested locally

## Risk

Low since we add a new method and this is well covered by the typing system

## Deploy Plan

- deploy `front`