### PR TITLE
[Webhooks] Make create-only GCS uploads explicit

### DIFF
--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -27,12 +27,26 @@ const GCS_COPY_MAX_RETRIES = 3;
 const GCS_COPY_BASE_DELAY_MS = 500;
 const GCS_MAX_RETRIES = 3; // Same as the SDK default.
 const GCS_EXTRA_RETRYABLE_ERROR_MESSAGE_REGEX = /socket hang up/i;
+// GCS generations are object versions. Matching generation 0 means "create only
+// if the object does not already exist", which makes the create safe to retry.
+const GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH = 0;
 
 const DEFAULT_SIGNED_URL_EXPIRATION_DELAY_MS = 5 * 60 * 1000; // 5 minutes.
 
 interface FileStorageOptions {
   useServiceAccount?: boolean;
 }
+
+type RawContentUpload = {
+  content: string;
+  contentType: AllSupportedFileContentType;
+  filePath: string;
+};
+
+type RawContentSaveOptions = Pick<
+  SaveOptions,
+  "preconditionOpts" | "resumable"
+>;
 
 function isRetryableGCSError(err: ApiError): boolean {
   return (
@@ -82,13 +96,30 @@ export class FileStorage {
     content,
     contentType,
     filePath,
-    saveOptions,
-  }: {
-    content: string;
-    contentType: AllSupportedFileContentType;
-    filePath: string;
-    saveOptions?: Pick<SaveOptions, "preconditionOpts" | "resumable">;
-  }) {
+  }: RawContentUpload) {
+    await this.saveRawContentToBucket({ content, contentType, filePath });
+  }
+
+  async uploadSmallRawContentToBucketAsNewFile({
+    content,
+    contentType,
+    filePath,
+  }: RawContentUpload) {
+    await this.saveRawContentToBucket(
+      { content, contentType, filePath },
+      {
+        resumable: false,
+        preconditionOpts: {
+          ifGenerationMatch: GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
+        },
+      }
+    );
+  }
+
+  private async saveRawContentToBucket(
+    { content, contentType, filePath }: RawContentUpload,
+    saveOptions?: RawContentSaveOptions
+  ) {
     const gcsFile = this.file(filePath);
 
     const contentToSave = Buffer.from(stripNullBytes(content), "utf8");

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -50,10 +50,6 @@ export const HEADERS_ALLOWED_LIST = [
   "webhook-timestamp",
 ];
 
-// GCS generations are object versions. Matching generation 0 means "create only
-// if the object does not already exist".
-const GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH = 0;
-
 export function checkSignature({
   headerName,
   algorithm,
@@ -522,20 +518,12 @@ export async function storePayloadInGCS(
   });
 
   try {
-    // Store in GCS
-    await bucket.uploadRawContentToBucket({
+    // Webhook payloads are capped at 2MB and paths include the request id, so
+    // use the small create-only upload helper instead of a resumable overwrite.
+    await bucket.uploadSmallRawContentToBucketAsNewFile({
       content,
       contentType: "application/json",
       filePath: gcsPath,
-      // Webhook payloads are capped at 2MB, so resumable uploads add overhead
-      // without helping. The path includes the webhook request id and should be
-      // unique; the generation match makes that create-only write retryable.
-      saveOptions: {
-        resumable: false,
-        preconditionOpts: {
-          ifGenerationMatch: GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH,
-        },
-      },
     });
   } catch (error: unknown) {
     // Log the error, but do not throw, as we want to continue processing the webhook.

--- a/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
@@ -32,6 +32,9 @@ vi.mock("@app/lib/utils/statsd", () => ({
 vi.mock("@app/lib/file_storage", () => ({
   getWebhookRequestsBucket: () => ({
     uploadRawContentToBucket: vi.fn().mockResolvedValue(undefined),
+    uploadSmallRawContentToBucketAsNewFile: vi
+      .fn()
+      .mockResolvedValue(undefined),
   }),
 }));
 

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -80,6 +80,9 @@ class FileStorageMock {
       getSignedUrl: vi.fn().mockResolvedValue("https://signed-url.test"),
       uploadFileToBucket: vi.fn().mockResolvedValue(undefined),
       uploadRawContentToBucket: vi.fn().mockResolvedValue(undefined),
+      uploadSmallRawContentToBucketAsNewFile: vi
+        .fn()
+        .mockResolvedValue(undefined),
       fetchFileContent: vi.fn().mockResolvedValue("mock content"),
       copyFile: vi.fn().mockResolvedValue(undefined),
       delete: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Description
Related to https://github.com/dust-tt/tasks/issues/8104
Follows https://github.com/dust-tt/dust/pull/26048

Small refactor: this makes the storage helper API explicit for small create-only uploads instead of exposing low-level GCS `saveOptions` at each call site.

Webhook payload storage now calls the named create-only helper. Generic `uploadRawContentToBucket` keeps overwrite semantics for existing callers.

## Risks
Blast radius: raw GCS content upload helper and webhook payload storage.
Risk: low

## Deploy Plan
- pmrr
- deploy front
