### PR TITLE
Use Hono's built-in getCookie instead of a custom cookie parser

### DIFF
--- a/front-api/middlewares/session_resolution.ts
+++ b/front-api/middlewares/session_resolution.ts
@@ -1,8 +1,9 @@
 import { getWorkOSSessionWithSetCookies } from "@app/lib/api/workos/user";
 import { getSessionFromBearerToken } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import { apiError, parseCookieHeader } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
 import type { Context } from "hono";
+import { getCookie } from "hono/cookie";
 
 /**
  * Resolves the session for a Hono request by trying the bearer token first,
@@ -30,9 +31,8 @@ export async function resolveSession(
 
   let session: SessionWithUser | null | undefined = bearerRes.value;
   if (!session) {
-    const cookies = parseCookieHeader(ctx.req.header("cookie"));
     const result = await getWorkOSSessionWithSetCookies(
-      cookies["workos_session"]
+      getCookie(ctx, "workos_session")
     );
     for (const cookie of result.setCookies) {
       ctx.header("Set-Cookie", cookie, { append: true });

--- a/front-api/middlewares/utils.ts
+++ b/front-api/middlewares/utils.ts
@@ -128,24 +128,3 @@ export const unhandledErrorHandler: ErrorHandler = (err, ctx) => {
     500
   );
 };
-
-export function parseCookieHeader(
-  header: string | undefined
-): Record<string, string> {
-  if (!header) {
-    return {};
-  }
-  const cookies: Record<string, string> = {};
-  for (const part of header.split(";")) {
-    const trimmed = part.trim();
-    if (!trimmed) {
-      continue;
-    }
-    const eq = trimmed.indexOf("=");
-    if (eq === -1) {
-      continue;
-    }
-    cookies[trimmed.slice(0, eq)] = decodeURIComponent(trimmed.slice(eq + 1));
-  }
-  return cookies;
-}

--- a/front-api/routes/workos/[action].ts
+++ b/front-api/routes/workos/[action].ts
@@ -33,10 +33,11 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
 import { validateRelativePath } from "@app/types/shared/utils/url_utils";
-import { apiError, parseCookieHeader } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
 import { OauthException } from "@workos-inc/node";
 import type { Context } from "hono";
 import { Hono } from "hono";
+import { getCookie } from "hono/cookie";
 import { sealData } from "iron-session";
 
 function isValidScreenHint(
@@ -511,9 +512,8 @@ async function handleCallback(ctx: Context) {
 }
 
 async function handleLogout(ctx: Context) {
-  const cookies = parseCookieHeader(ctx.req.header("cookie"));
   const result = await getWorkOSSessionWithSetCookies(
-    cookies["workos_session"]
+    getCookie(ctx, "workos_session")
   );
   for (const cookie of result.setCookies) {
     ctx.header("Set-Cookie", cookie, { append: true });


### PR DESCRIPTION
## Description

Removed the hand-rolled parseCookieHeader helper from front-api/middlewares/utils.ts and replaced both call sites with getCookie from hono/cookie.

  Changes

  - middlewares/session_resolution.ts: use getCookie(ctx, "workos_session") directly.
  - routes/workos/[action].ts (handleLogout): same swap.
  - middlewares/utils.ts: delete parseCookieHeader.


## Tests

Existing

## Risk

Small

## Deploy Plan

Front