### PR TITLE
Remove titles from Pods tab's content, fix a bunch of file explorer UI issues

### DIFF
--- a/front/components/assistant/conversation/space/ProjectFileExplorer.tsx
+++ b/front/components/assistant/conversation/space/ProjectFileExplorer.tsx
@@ -752,7 +752,7 @@ function ProjectFileExplorerContent({
         onRename={!isArchived ? onRename : undefined}
         onOpenInteractive={(entry) => setFrameFileId(entry.fileId)}
         getExtraFileMenuItems={getExtraFileMenuItems}
-        headerActions={addButton}
+        toolbarExtraActions={addButton}
         isLoading={isLoading}
       />
     </>

--- a/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
@@ -9,5 +9,9 @@ interface SpaceKnowledgeTabProps {
 }
 
 export function SpaceKnowledgeTab({ owner, space }: SpaceKnowledgeTabProps) {
-  return <ProjectFileExplorer owner={owner} space={space} />;
+  return (
+    <div className="flex  py-8">
+      <ProjectFileExplorer owner={owner} space={space} />
+    </div>
+  );
 }

--- a/front/components/assistant/conversation/space/SpaceTasksTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceTasksTab.tsx
@@ -24,11 +24,6 @@ export function SpaceTasksTab({
   return (
     <div className="flex h-full min-h-0 w-full flex-1 flex-col overflow-y-auto px-6">
       <div className="mx-auto flex w-full max-w-4xl flex-col gap-4 py-8">
-        <div className="flex gap-2">
-          <h3 className="heading-2xl flex-1 items-center">
-            {`${spaceInfo.name}'s Tasks`}
-          </h3>
-        </div>
         <ProjectTasksPanelProvider
           owner={owner}
           spaceId={spaceInfo.sId}

--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -23,13 +23,8 @@ import {
   ArrowUpOnSquareIcon,
   Button,
   ContentMessage,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
   GlobeAltIcon,
   Input,
-  MoreIcon,
   ScrollArea,
   SearchInput,
   SliderToggle,
@@ -221,34 +216,6 @@ export function SpaceAboutTab({
   return (
     <div className="flex h-full min-h-0 w-full flex-1 flex-col overflow-y-auto px-6">
       <div className="mx-auto flex w-full max-w-4xl flex-col gap-8 py-8">
-        <div className="flex gap-2">
-          <h2 className="heading-2xl flex-1 text-foreground dark:text-foreground-night">
-            Settings
-          </h2>
-          {isProjectEditor && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="outline" icon={MoreIcon} />
-              </DropdownMenuTrigger>
-              <DropdownMenuContent>
-                {projectMetadata?.archivedAt ? (
-                  <DropdownMenuItem
-                    icon={ArrowUpOnSquareIcon}
-                    label="Unarchive Pod"
-                    onClick={handleArchiveToggle}
-                  />
-                ) : (
-                  <DropdownMenuItem
-                    icon={ArchiveIcon}
-                    label="Archive Pod"
-                    variant="warning"
-                    onClick={handleArchiveToggle}
-                  />
-                )}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          )}
-        </div>
         {space.archivedAt && (
           <ContentMessage variant="info" size="lg">
             This Pod has been archived.

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -11,6 +11,7 @@ import { useSpaceUnreadConversationIds } from "@app/hooks/conversations";
 import type { SpaceConversationListFilter } from "@app/hooks/conversations/useSpaceConversations";
 import { useMarkAllConversationsAsRead } from "@app/hooks/useMarkAllConversationsAsRead";
 import { useSearchConversations } from "@app/hooks/useSearchConversations";
+import { getRandomGreetingForName } from "@app/lib/client/greetings";
 import { useAppRouter } from "@app/lib/platform";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { GetSpaceResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
@@ -38,7 +39,7 @@ import {
 } from "@dust-tt/sparkle";
 import moment from "moment";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 
 type GroupLabel =
   | "Today"
@@ -145,6 +146,11 @@ export function SpaceConversationsTab({
     [owner.sId, router, setSearchText]
   );
 
+  const [greeting, setGreeting] = useState<string>("");
+  useEffect(() => {
+    setGreeting(getRandomGreetingForName(user.firstName));
+  }, [user]);
+
   const isProjectEmpty = !isConversationsLoading && isSpaceEmpty;
   const isFilteredEmpty =
     !isConversationsLoading && !isSpaceEmpty && !hasHistory;
@@ -163,6 +169,7 @@ export function SpaceConversationsTab({
           )}
         >
           <div className="flex w-full flex-col gap-3">
+            <PodPinnedBanner owner={owner} spaceInfo={spaceInfo} />
             <div className="flex items-center gap-2">
               <h2
                 className={cn(
@@ -171,17 +178,12 @@ export function SpaceConversationsTab({
                     "text-muted-foreground dark:text-muted-foreground-night"
                 )}
               >
-                {spaceInfo.name}
+                {greeting}
               </h2>
               {spaceInfo.archivedAt && (
                 <Chip size="xs" color="rose" label="Archived" />
               )}
             </div>
-            {isProjectEmpty && (
-              <h3 className="heading-lg text-foreground dark:text-foreground-night">
-                Start a first conversation!
-              </h3>
-            )}
             {spaceInfo.archivedAt ? (
               <div className="mx-auto flex flex-col w-full py-4 sm:max-w-conversation">
                 <EmptyCTA
@@ -209,8 +211,6 @@ export function SpaceConversationsTab({
               />
             )}
           </div>
-
-          <PodPinnedBanner owner={owner} spaceInfo={spaceInfo} />
 
           {/* Suggestions for empty rooms */}
           {isProjectEmpty ? (

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -60,7 +60,7 @@ function FileExplorerBreadcrumb({
     })),
   ];
 
-  return <Breadcrumbs items={items} size="sm" />;
+  return <Breadcrumbs items={items} size="sm" buttonVariant="outline" />;
 }
 
 interface FileExplorerProps {
@@ -71,7 +71,7 @@ interface FileExplorerProps {
   hideTitleBorder?: boolean;
   files: GCSMountEntry[];
   getFileUrl: (path: string) => string;
-  headerActions?: React.ReactNode;
+  toolbarExtraActions?: React.ReactNode;
   isLoading: boolean;
   navigationResetKey?: number;
   onClose?: () => void;
@@ -96,7 +96,7 @@ export function FileExplorer({
   emptyState,
   files,
   getFileUrl,
-  headerActions,
+  toolbarExtraActions,
   hideTitleBorder = false,
   isLoading,
   navigationResetKey,
@@ -308,35 +308,27 @@ export function FileExplorer({
   return (
     <>
       <div className="flex h-full w-full min-h-0 flex-1 flex-col">
-        <AppLayoutTitle className={hideTitleBorder ? "border-b-0" : undefined}>
-          <div
-            className={cn(
-              "flex h-full items-center justify-between gap-2 px-4",
-              contentClassName
-            )}
+        {onClose && (
+          <AppLayoutTitle
+            className={cn("pt-5", hideTitleBorder ? "border-b-0" : undefined)}
           >
-            <FileExplorerBreadcrumb
-              currentFolderPath={currentFolderPath}
-              onNavigate={handleBreadcrumbNavigate}
-            />
-            <div className="flex items-center gap-2">
-              {headerActions}
-              {onClose && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  icon={XMarkIcon}
-                  onClick={onClose}
-                />
+            <div
+              className={cn(
+                "flex h-full items-center justify-end gap-2 px-4",
+                contentClassName
               )}
+            >
+              <Button
+                variant="ghost"
+                size="sm"
+                icon={XMarkIcon}
+                onClick={onClose}
+              />
             </div>
-          </div>
-        </AppLayoutTitle>
+          </AppLayoutTitle>
+        )}
         <div
-          className={cn(
-            "flex flex-1 min-h-0 flex-col gap-5 pt-5",
-            contentClassName
-          )}
+          className={cn("flex flex-1 min-h-0 flex-col gap-5", contentClassName)}
         >
           <div className="px-4">
             <FileExplorerToolbar
@@ -346,15 +338,26 @@ export function FileExplorer({
               onViewModeChange={setViewMode}
               sortMode={sortMode}
               onSortModeChange={setSortMode}
+              toolbarExtraActions={toolbarExtraActions}
             />
           </div>
-          <div className="px-4">
-            <FileExplorerFilters
-              active={activeFilter}
-              onActiveChange={setActiveFilter}
-              counts={filterCounts}
-            />
-          </div>
+          {Object.keys(filterCounts).length > 1 && (
+            <div className="px-4">
+              <FileExplorerFilters
+                active={activeFilter}
+                onActiveChange={setActiveFilter}
+                counts={filterCounts}
+              />
+            </div>
+          )}
+          {currentFolderPath !== "" && (
+            <div className="px-4">
+              <FileExplorerBreadcrumb
+                currentFolderPath={currentFolderPath}
+                onNavigate={handleBreadcrumbNavigate}
+              />
+            </div>
+          )}
           <FileExplorerContent
             isLoading={isLoading}
             sortedNodes={sortedNodes}

--- a/front/components/file_explorer/FileExplorerToolbar.tsx
+++ b/front/components/file_explorer/FileExplorerToolbar.tsx
@@ -13,6 +13,7 @@ import {
   ListIcon,
   SearchInput,
 } from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
 
 const SORT_ITEMS: Record<
   FileExplorerSortMode,
@@ -89,6 +90,7 @@ interface FileExplorerToolbarProps {
   onViewModeChange: (v: ViewMode) => void;
   sortMode: FileExplorerSortMode;
   onSortModeChange: (v: FileExplorerSortMode) => void;
+  toolbarExtraActions?: ReactNode;
 }
 
 export function FileExplorerToolbar({
@@ -98,6 +100,7 @@ export function FileExplorerToolbar({
   onViewModeChange,
   sortMode,
   onSortModeChange,
+  toolbarExtraActions,
 }: FileExplorerToolbarProps) {
   return (
     <div className="flex shrink-0 items-center gap-2">
@@ -110,6 +113,7 @@ export function FileExplorerToolbar({
       />
       <ViewToggle value={viewMode} onValueChange={onViewModeChange} />
       <SortDropdown value={sortMode} onValueChange={onSortModeChange} />
+      {toolbarExtraActions}
     </div>
   );
 }

--- a/sparkle/src/components/Breadcrumbs.tsx
+++ b/sparkle/src/components/Breadcrumbs.tsx
@@ -1,4 +1,8 @@
-import { Button, ICON_SIZE_MAP } from "@sparkle/components/Button";
+import {
+  Button,
+  type ButtonVariantType,
+  ICON_SIZE_MAP,
+} from "@sparkle/components/Button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -85,6 +89,7 @@ interface BreadcrumbItemProps {
   isLast: boolean;
   itemsHidden?: BreadcrumbItem[];
   size?: "xs" | "sm";
+  buttonVariant?: ButtonVariantType;
   hasLighterFont?: boolean;
   truncateLengthMiddle?: number;
   truncateLengthEnd?: number;
@@ -95,6 +100,7 @@ function BreadcrumbItem({
   isLast,
   itemsHidden,
   size = "sm",
+  buttonVariant = "ghost",
   hasLighterFont = true,
   truncateLengthMiddle = DEFAULT_LABEL_TRUNCATE_LENGTH_MIDDLE,
   truncateLengthEnd = DEFAULT_LABEL_TRUNCATE_LENGTH_END,
@@ -104,7 +110,7 @@ function BreadcrumbItem({
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button
-            variant="ghost"
+            variant={buttonVariant}
             label={ELLIPSIS_STRING}
             icon={item.icon}
             size={size}
@@ -146,7 +152,7 @@ function BreadcrumbItem({
       <Button
         href={item.href}
         icon={item.icon}
-        variant={isLast ? "ghost" : "ghost-secondary"}
+        variant={buttonVariant ?? (isLast ? "ghost" : "ghost-secondary")}
         label={truncatedLabel}
         tooltip={isLabelTruncated ? item.label : undefined}
         size={size}
@@ -160,7 +166,7 @@ function BreadcrumbItem({
       <Button
         onClick={item.onClick}
         icon={item.icon}
-        variant={isLast ? "ghost" : "ghost-secondary"}
+        variant={buttonVariant ?? (isLast ? "ghost" : "ghost-secondary")}
         label={truncatedLabel}
         tooltip={isLabelTruncated ? item.label : undefined}
         size={size}
@@ -191,6 +197,7 @@ interface BreadcrumbProps {
   items: BreadcrumbItem[];
   className?: string;
   size?: "xs" | "sm";
+  buttonVariant?: ButtonVariantType;
   hasLighterFont?: boolean;
   truncateLengthMiddle?: number;
   truncateLengthEnd?: number;
@@ -205,6 +212,7 @@ export function Breadcrumbs({
   items,
   className,
   size = "sm",
+  buttonVariant = "ghost",
   hasLighterFont = true,
   truncateLengthMiddle,
   truncateLengthEnd,
@@ -237,6 +245,7 @@ export function Breadcrumbs({
               isLast={index === itemsShown.length - 1}
               itemsHidden={itemsHidden}
               size={size}
+              buttonVariant={buttonVariant}
               hasLighterFont={hasLighterFont}
               truncateLengthMiddle={truncateLengthMiddle}
               truncateLengthEnd={truncateLengthEnd}


### PR DESCRIPTION
## Description

Two independent cleanup passes on the Pods UI:

- **Tabs titles removed**: Strips the hardcoded `h2`/`h3` headings from `SpaceTasksTab`, `SpaceAboutTab`, and `SpaceConversationsTab`. The conversations header now shows a random greeting from `getRandomGreetingForName(user.firstName)` instead of the space name, and `PodPinnedBanner` is promoted above the heading. The archive action dropdown is removed from the Settings tab header.
- **`FileExplorer` fixes**: Renames `headerActions` → `toolbarExtraActions` and moves it into `FileExplorerToolbar`. `AppLayoutTitle` is now only rendered when `onClose` is present. `FileExplorerBreadcrumb` is relocated into the content area and only shown when `currentFolderPath !== ""`. `FileExplorerFilters` is conditionally rendered when more than one filter type exists. Breadcrumb uses `buttonVariant="outline"`.

## Tests

Tested locally across the Pods Conversations, Tasks, Settings, and Knowledge tabs, and the file explorer in both modal (with close button) and inline modes.

## Risk

Low. Pure frontend layout/prop changes with no data or API impact. Fully rollback-safe.

## Deploy Plan

Deploy front.
