### PR TITLE
Fix: height is fixed while loading pined informations.

### DIFF
--- a/front/components/assistant/conversation/space/PodPinnedBanner.tsx
+++ b/front/components/assistant/conversation/space/PodPinnedBanner.tsx
@@ -14,7 +14,6 @@ import {
   EyeSlashIcon,
   FullscreenExitIcon,
   FullscreenIcon,
-  Spinner,
 } from "@dust-tt/sparkle";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
@@ -252,9 +251,10 @@ export function PodPinnedBanner({ owner, spaceInfo }: PodPinnedBannerProps) {
 
   if (isProjectFilesLoading || (fileId && !fileContent)) {
     return (
-      <div className="mb-4 flex h-16 items-center justify-center rounded-xl bg-muted-background dark:bg-muted-background-night">
-        <Spinner size="sm" />
-      </div>
+      <div
+        className="mb-4 flex h-16 items-center justify-center rounded-xl bg-muted-background dark:bg-muted-background-night"
+        style={{ height: BANNER_HEIGHT_PX }}
+      />
     );
   }
 


### PR DESCRIPTION
## Description

The `PodPinnedBanner` loading placeholder used a hardcoded Tailwind `h-16` class and a `Spinner`, which didn't match the actual banner height controlled by `BANNER_HEIGHT_PX`. Replaced the spinner with a silent empty placeholder div using `style={{ height: BANNER_HEIGHT_PX }}` so the layout height is consistent between the loading and loaded states, eliminating layout shift.


## Tests

Tested locally — verified the banner loading state no longer causes a height jump when pinned content resolves.

## Risk

Low. Purely cosmetic fix scoped to the loading state of `PodPinnedBanner`. No logic changes, no API impact, trivially rollback-safe.

## Deploy Plan

Deploy front.
