### PR TITLE
Find front handlers not ported to front-api

### DIFF
--- a/scripts/find-missing-front-api-handlers.sh
+++ b/scripts/find-missing-front-api-handlers.sh
@@ -13,6 +13,7 @@ FRONT_API_ROUTES_DIR="$REPO_ROOT/front-api/routes"
 cd "$FRONT_API_DIR"
 find . -type f \( -name "*.ts" -o -name "*.tsx" \) \
   ! -name "*.test.ts" ! -name "*.test.tsx" \
+  ! -path "./marketing/*" \
   | sed 's|^\./||' \
   | sort \
   | while IFS= read -r rel; do

--- a/scripts/find-missing-front-api-handlers.sh
+++ b/scripts/find-missing-front-api-handlers.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Outputs the list of API handler files in front/pages/api that do not have a
+# matching file in front-api/routes. Test files (*.test.ts, *.test.tsx) are
+# excluded. Paths are printed relative to front/, e.g.:
+#   pages/api/w/[wId]/dust_app_secrets/index.ts
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FRONT_API_DIR="$REPO_ROOT/front/pages/api"
+FRONT_API_ROUTES_DIR="$REPO_ROOT/front-api/routes"
+
+cd "$FRONT_API_DIR"
+find . -type f \( -name "*.ts" -o -name "*.tsx" \) \
+  ! -name "*.test.ts" ! -name "*.test.tsx" \
+  | sed 's|^\./||' \
+  | sort \
+  | while IFS= read -r rel; do
+      if [[ ! -f "$FRONT_API_ROUTES_DIR/$rel" ]]; then
+        echo "pages/api/$rel"
+      fi
+    done


### PR DESCRIPTION
## Description

  - Adds `scripts/find-missing-front-api-handlers.sh`, which walks `front/pages/api/` and prints any handler that does not have a matching file at the same relative path under `front-api/routes/`.
  - Output is sorted, one path per line (e.g. `pages/api/w/[wId]/dust_app_secrets/index.ts`), so it can be piped into other tools or used to track migration progress.
  - Excludes `*.test.ts(x)` files and everything under `pages/api/marketing/` (not in scope for the front-api migration).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
