### PR TITLE
[front] enh: speed up Notion workflow production check

### DIFF
--- a/front/lib/production_checks/checks/check_notion_active_workflows.ts
+++ b/front/lib/production_checks/checks/check_notion_active_workflows.ts
@@ -21,6 +21,17 @@ interface NotionConnector {
   pausedAt: Date | null;
 }
 
+type MissingWorkflow = {
+  connectorId: number;
+  workspaceId: string;
+  details: string;
+};
+
+type StalledWorkflow = {
+  connectorId: number;
+  workspaceId: string;
+};
+
 async function listAllNotionConnectors() {
   const connectorsDb = getConnectorsPrimaryDbConnection();
 
@@ -206,17 +217,6 @@ export const checkNotionActiveWorkflows: CheckFunction = async (
   const client = await getTemporalClientForConnectorsNamespace();
 
   logger.info(`Found ${notionConnectors.length} Notion connectors.`);
-
-  type MissingWorkflow = {
-    connectorId: number;
-    workspaceId: string;
-    details: string;
-  };
-
-  type StalledWorkflow = {
-    connectorId: number;
-    workspaceId: string;
-  };
 
   const missingActiveWorkflows: MissingWorkflow[] = [];
   const stalledWorkflows: StalledWorkflow[] = [];

--- a/front/lib/production_checks/checks/check_notion_active_workflows.ts
+++ b/front/lib/production_checks/checks/check_notion_active_workflows.ts
@@ -113,13 +113,10 @@ async function areTemporalWorkflowsRunning(
 
   const latestEventTimes = await withRetries(
     logger,
-    async ({
-      client,
-      descriptions,
-    }: {
-      client: Client;
-      descriptions: WorkflowExecutionDescription[];
-    }): Promise<(Date | null)[]> => {
+    async (
+      client: Client,
+      descriptions: WorkflowExecutionDescription[]
+    ): Promise<(Date | null)[]> => {
       // Bounded (only three elements), Temporal-only Promise.all.
       return Promise.all(
         descriptions.map((description) =>
@@ -130,10 +127,7 @@ async function areTemporalWorkflowsRunning(
     {
       retries: TEMPORAL_WORKFLOW_CHECK_RETRIES,
     }
-  )({
-    client,
-    descriptions,
-  });
+  )(client, descriptions);
 
   logger.info("Workflow latest events retrieved");
 

--- a/front/lib/production_checks/checks/check_notion_active_workflows.ts
+++ b/front/lib/production_checks/checks/check_notion_active_workflows.ts
@@ -7,7 +7,7 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { getNotionWorkflowId } from "@app/types/connectors/workflows";
 import type { ActionLink, CheckFunction } from "@app/types/production_checks";
 import { withRetries } from "@app/types/shared/retries";
-import type { Client } from "@temporalio/client";
+import type { Client, WorkflowExecutionDescription } from "@temporalio/client";
 import type pino from "pino";
 import { QueryTypes } from "sequelize";
 
@@ -93,7 +93,7 @@ async function getLatestWorkflowEventTime({
   description,
 }: {
   client: Client;
-  description: Pick<WorkflowExecutionDescription, "workflowId" | "runId">;
+  description: WorkflowExecutionDescription;
 }): Promise<Date | null> {
   const response =
     await client.workflowService.getWorkflowExecutionHistoryReverse({
@@ -153,55 +153,20 @@ async function areTemporalWorkflowsRunning(
       };
     }
 
-    const latests = await withRetries(
+    const latestEventTimes = await withRetries(
       logger,
       async ({
         client,
         descriptions,
-        logger,
-        notionConnector,
       }: {
         client: Client;
         descriptions: NotionWorkflowDescriptions;
-        logger: pino.Logger;
-        notionConnector: NotionConnector;
       }): Promise<(Date | null)[]> => {
-        const [
-          incrementalSyncDescription,
-          garbageCollectorDescription,
-          processDatabaseUpsertQueueDescription,
-        ] = descriptions;
-
-        logger.info(
-          {
-            connectorId: notionConnector.id,
-          },
-          "Retrieving latest history events"
+        return Promise.all(
+          descriptions.map((description) =>
+            getLatestWorkflowEventTime({ client, description })
+          )
         );
-
-        const latestEventTimes = await Promise.all([
-          getLatestWorkflowEventTime({
-            client,
-            description: incrementalSyncDescription,
-          }),
-          getLatestWorkflowEventTime({
-            client,
-            description: garbageCollectorDescription,
-          }),
-          getLatestWorkflowEventTime({
-            client,
-            description: processDatabaseUpsertQueueDescription,
-          }),
-        ]);
-
-        logger.info(
-          {
-            connectorId: notionConnector.id,
-          },
-          "Retrieved latest history events"
-        );
-
-        return latestEventTimes;
       },
       {
         retries: TEMPORAL_WORKFLOW_CHECK_RETRIES,
@@ -209,17 +174,14 @@ async function areTemporalWorkflowsRunning(
     )({
       client,
       descriptions,
-      logger,
-      notionConnector,
     });
+
+    const now = new Date().getTime();
 
     return {
       isRunning,
-      isNotStalled: latests.every(
-        (d) =>
-          d &&
-          new Date().getTime() - d.getTime() <
-            TEMPORAL_WORKFLOW_STALLED_THRESHOLD_MS
+      isNotStalled: latestEventTimes.every(
+        (d) => d && now - d.getTime() < TEMPORAL_WORKFLOW_STALLED_THRESHOLD_MS
       ),
       details,
     };

--- a/front/lib/production_checks/checks/check_notion_active_workflows.ts
+++ b/front/lib/production_checks/checks/check_notion_active_workflows.ts
@@ -11,6 +11,9 @@ import type { Client } from "@temporalio/client";
 import type pino from "pino";
 import { QueryTypes } from "sequelize";
 
+const TEMPORAL_WORKFLOW_CHECK_RETRIES = 10;
+const TEMPORAL_WORKFLOW_STALLED_THRESHOLD_MS = 12 * 60 * 60 * 1000;
+
 interface NotionConnector {
   id: number;
   dataSourceId: string;
@@ -32,7 +35,13 @@ async function listAllNotionConnectors() {
   return notionConnectors;
 }
 
-async function getDescriptionsAndHistories({
+type NotionWorkflowDescriptions = [
+  WorkflowExecutionDescription,
+  WorkflowExecutionDescription,
+  WorkflowExecutionDescription,
+];
+
+async function getWorkflowDescriptions({
   client,
   notionConnector,
   logger,
@@ -40,7 +49,7 @@ async function getDescriptionsAndHistories({
   client: Client;
   notionConnector: NotionConnector;
   logger: pino.Logger;
-}) {
+}): Promise<NotionWorkflowDescriptions> {
   logger.info(
     {
       connectorId: notionConnector.id,
@@ -76,22 +85,32 @@ async function getDescriptionsAndHistories({
     "Retrieved descriptions"
   );
 
-  const histories = await Promise.all([
-    incrementalSyncHandle.fetchHistory(),
-    garbageCollectorHandle.fetchHistory(),
-    processDatabaseUpsertQueueHandle.fetchHistory(),
-  ]);
-  logger.info(
-    {
-      connectorId: notionConnector.id,
-    },
-    "Retrieved histories"
-  );
+  return descriptions;
+}
 
-  return {
-    descriptions,
-    histories,
-  };
+async function getLatestWorkflowEventTime({
+  client,
+  description,
+}: {
+  client: Client;
+  description: Pick<WorkflowExecutionDescription, "workflowId" | "runId">;
+}): Promise<Date | null> {
+  const response =
+    await client.workflowService.getWorkflowExecutionHistoryReverse({
+      namespace: client.options.namespace,
+      execution: {
+        workflowId: description.workflowId,
+        runId: description.runId,
+      },
+      maximumPageSize: 1,
+    });
+
+  const latestEvent = response.history?.events?.[0];
+  const latestEventSeconds = latestEvent?.eventTime?.seconds;
+
+  return latestEventSeconds
+    ? new Date(Number(latestEventSeconds) * 1000)
+    : null;
 }
 
 async function areTemporalWorkflowsRunning(
@@ -100,11 +119,9 @@ async function areTemporalWorkflowsRunning(
   logger: pino.Logger
 ) {
   try {
-    const { descriptions, histories } = await withRetries(
-      logger,
-      getDescriptionsAndHistories,
-      { retries: 10 }
-    )({
+    const descriptions = await withRetries(logger, getWorkflowDescriptions, {
+      retries: TEMPORAL_WORKFLOW_CHECK_RETRIES,
+    })({
       client,
       notionConnector,
       logger,
@@ -114,23 +131,8 @@ async function areTemporalWorkflowsRunning(
       {
         connectorId: notionConnector.id,
       },
-      "getDescriptionsAndHistories completed"
+      "Workflow descriptions retrieved"
     );
-
-    const latests: (Date | null)[] = histories.map((h) => {
-      let latest: Date | null = null;
-      if (h.events) {
-        h.events.forEach((e) => {
-          if (e.eventTime?.seconds) {
-            const d = new Date(Number(e.eventTime.seconds) * 1000);
-            if (!latest || d > latest) {
-              latest = d;
-            }
-          }
-        });
-      }
-      return latest;
-    });
 
     const isRunning = descriptions.every(
       ({ status: { name } }) => name === "RUNNING"
@@ -143,11 +145,81 @@ async function areTemporalWorkflowsRunning(
           .map(({ status: { name }, workflowId }) => `${workflowId}: ${name}`)
           .join(", ");
 
+    if (!isRunning) {
+      return {
+        isRunning,
+        isNotStalled: false,
+        details,
+      };
+    }
+
+    const latests = await withRetries(
+      logger,
+      async ({
+        client,
+        descriptions,
+        logger,
+        notionConnector,
+      }: {
+        client: Client;
+        descriptions: NotionWorkflowDescriptions;
+        logger: pino.Logger;
+        notionConnector: NotionConnector;
+      }): Promise<(Date | null)[]> => {
+        const [
+          incrementalSyncDescription,
+          garbageCollectorDescription,
+          processDatabaseUpsertQueueDescription,
+        ] = descriptions;
+
+        logger.info(
+          {
+            connectorId: notionConnector.id,
+          },
+          "Retrieving latest history events"
+        );
+
+        const latestEventTimes = await Promise.all([
+          getLatestWorkflowEventTime({
+            client,
+            description: incrementalSyncDescription,
+          }),
+          getLatestWorkflowEventTime({
+            client,
+            description: garbageCollectorDescription,
+          }),
+          getLatestWorkflowEventTime({
+            client,
+            description: processDatabaseUpsertQueueDescription,
+          }),
+        ]);
+
+        logger.info(
+          {
+            connectorId: notionConnector.id,
+          },
+          "Retrieved latest history events"
+        );
+
+        return latestEventTimes;
+      },
+      {
+        retries: TEMPORAL_WORKFLOW_CHECK_RETRIES,
+      }
+    )({
+      client,
+      descriptions,
+      logger,
+      notionConnector,
+    });
+
     return {
       isRunning,
       isNotStalled: latests.every(
-        // Check `latest` is less than 12h old.
-        (d) => d && new Date().getTime() - d.getTime() < 12 * 60 * 60 * 1000
+        (d) =>
+          d &&
+          new Date().getTime() - d.getTime() <
+            TEMPORAL_WORKFLOW_STALLED_THRESHOLD_MS
       ),
       details,
     };

--- a/front/lib/production_checks/checks/check_notion_active_workflows.ts
+++ b/front/lib/production_checks/checks/check_notion_active_workflows.ts
@@ -34,19 +34,13 @@ async function listAllNotionConnectors() {
   );
 }
 
-type NotionWorkflowDescriptions = [
-  WorkflowExecutionDescription,
-  WorkflowExecutionDescription,
-  WorkflowExecutionDescription,
-];
-
 async function getWorkflowDescriptions({
   client,
   notionConnector,
 }: {
   client: Client;
   notionConnector: NotionConnector;
-}): Promise<NotionWorkflowDescriptions> {
+}): Promise<WorkflowExecutionDescription[]> {
   const incrementalSyncHandle = client.workflow.getHandle(
     getNotionWorkflowId(notionConnector.id, "sync")
   );
@@ -121,9 +115,9 @@ async function areTemporalWorkflowsRunning(
       descriptions,
     }: {
       client: Client;
-      descriptions: NotionWorkflowDescriptions;
+      descriptions: WorkflowExecutionDescription[];
     }): Promise<(Date | null)[]> => {
-      // Bounded (only 3 elements in NotionWorkflowDescriptions), Temporal-only Promise.all.
+      // Bounded (only three elements), Temporal-only Promise.all.
       return Promise.all(
         descriptions.map((description) =>
           getLatestWorkflowEventDate({ client, description })

--- a/front/lib/production_checks/checks/check_notion_active_workflows.ts
+++ b/front/lib/production_checks/checks/check_notion_active_workflows.ts
@@ -118,80 +118,72 @@ async function areTemporalWorkflowsRunning(
   notionConnector: NotionConnector,
   logger: pino.Logger
 ) {
-  try {
-    const descriptions = await withRetries(logger, getWorkflowDescriptions, {
-      retries: TEMPORAL_WORKFLOW_CHECK_RETRIES,
-    })({
-      client,
-      notionConnector,
-      logger,
-    });
+  const descriptions = await withRetries(logger, getWorkflowDescriptions, {
+    retries: TEMPORAL_WORKFLOW_CHECK_RETRIES,
+  })({
+    client,
+    notionConnector,
+    logger,
+  });
 
-    logger.info(
-      {
-        connectorId: notionConnector.id,
-      },
-      "Workflow descriptions retrieved"
-    );
+  logger.info(
+    {
+      connectorId: notionConnector.id,
+    },
+    "Workflow descriptions retrieved"
+  );
 
-    const isRunning = descriptions.every(
-      ({ status: { name } }) => name === "RUNNING"
-    );
+  const isRunning = descriptions.every(
+    ({ status: { name } }) => name === "RUNNING"
+  );
 
-    const details = isRunning
-      ? ""
-      : "Statuses of workflows are " +
-        descriptions
-          .map(({ status: { name }, workflowId }) => `${workflowId}: ${name}`)
-          .join(", ");
+  const details = isRunning
+    ? ""
+    : "Statuses of workflows are " +
+      descriptions
+        .map(({ status: { name }, workflowId }) => `${workflowId}: ${name}`)
+        .join(", ");
 
-    if (!isRunning) {
-      return {
-        isRunning,
-        isNotStalled: false,
-        details,
-      };
-    }
-
-    const latestEventTimes = await withRetries(
-      logger,
-      async ({
-        client,
-        descriptions,
-      }: {
-        client: Client;
-        descriptions: NotionWorkflowDescriptions;
-      }): Promise<(Date | null)[]> => {
-        return Promise.all(
-          descriptions.map((description) =>
-            getLatestWorkflowEventTime({ client, description })
-          )
-        );
-      },
-      {
-        retries: TEMPORAL_WORKFLOW_CHECK_RETRIES,
-      }
-    )({
-      client,
-      descriptions,
-    });
-
-    const now = new Date().getTime();
-
+  if (!isRunning) {
     return {
       isRunning,
-      isNotStalled: latestEventTimes.every(
-        (d) => d && now - d.getTime() < TEMPORAL_WORKFLOW_STALLED_THRESHOLD_MS
-      ),
+      isNotStalled: false,
       details,
     };
-  } catch (err) {
-    return {
-      isRunning: false,
-      isNotStalled: false,
-      details: `Got Error: ${err}`,
-    };
   }
+
+  const latestEventTimes = await withRetries(
+    logger,
+    async ({
+      client,
+      descriptions,
+    }: {
+      client: Client;
+      descriptions: NotionWorkflowDescriptions;
+    }): Promise<(Date | null)[]> => {
+      return Promise.all(
+        descriptions.map((description) =>
+          getLatestWorkflowEventTime({ client, description })
+        )
+      );
+    },
+    {
+      retries: TEMPORAL_WORKFLOW_CHECK_RETRIES,
+    }
+  )({
+    client,
+    descriptions,
+  });
+
+  const now = new Date().getTime();
+
+  return {
+    isRunning,
+    isNotStalled: latestEventTimes.every(
+      (d) => d && now - d.getTime() < TEMPORAL_WORKFLOW_STALLED_THRESHOLD_MS
+    ),
+    details,
+  };
 }
 
 export const checkNotionActiveWorkflows: CheckFunction = async (

--- a/front/lib/production_checks/checks/check_notion_active_workflows.ts
+++ b/front/lib/production_checks/checks/check_notion_active_workflows.ts
@@ -213,17 +213,21 @@ export const checkNotionActiveWorkflows: CheckFunction = async (
 
   if (missingActiveWorkflows.length > 0) {
     const actionLinks: ActionLink[] = [
-      ...missingActiveWorkflows.map((c) => ({
-        label: `Missing: connector ${c.connectorId}`,
-        url: `/poke/connectors/${c.connectorId}`,
+      ...missingActiveWorkflows.map(({ connectorId }) => ({
+        label: `Missing: connector ${connectorId}`,
+        url: `/poke/connectors/${connectorId}`,
       })),
-      ...stalledWorkflows.map((c) => ({
-        label: `Stalled: connector ${c.connectorId}`,
-        url: `/poke/connectors/${c.connectorId}`,
+      ...stalledWorkflows.map(({ connectorId }) => ({
+        label: `Stalled: connector ${connectorId}`,
+        url: `/poke/connectors/${connectorId}`,
       })),
     ];
     reportFailure(
-      { missingActiveWorkflows, stalledWorkflows, actionLinks },
+      {
+        missingActiveWorkflows,
+        stalledWorkflows,
+        actionLinks,
+      },
       "Missing or stalled Notion temporal workflows"
     );
   } else {

--- a/front/lib/production_checks/checks/check_notion_active_workflows.ts
+++ b/front/lib/production_checks/checks/check_notion_active_workflows.ts
@@ -8,7 +8,7 @@ import { getNotionWorkflowId } from "@app/types/connectors/workflows";
 import type { ActionLink, CheckFunction } from "@app/types/production_checks";
 import { withRetries } from "@app/types/shared/retries";
 import type { Client, WorkflowExecutionDescription } from "@temporalio/client";
-import type pino from "pino";
+import type { Logger } from "pino";
 import { QueryTypes } from "sequelize";
 
 const TEMPORAL_WORKFLOW_CHECK_RETRIES = 10;
@@ -55,18 +55,10 @@ type NotionWorkflowDescriptions = [
 async function getWorkflowDescriptions({
   client,
   notionConnector,
-  logger,
 }: {
   client: Client;
   notionConnector: NotionConnector;
-  logger: pino.Logger;
 }): Promise<NotionWorkflowDescriptions> {
-  logger.info(
-    {
-      connectorId: notionConnector.id,
-    },
-    "Retrieving Notion handles"
-  );
   const incrementalSyncHandle = client.workflow.getHandle(
     getNotionWorkflowId(notionConnector.id, "sync")
   );
@@ -77,26 +69,11 @@ async function getWorkflowDescriptions({
     getNotionWorkflowId(notionConnector.id, "process-database-upsert-queue")
   );
 
-  logger.info(
-    {
-      connectorId: notionConnector.id,
-    },
-    "Retrieved Notion handles"
-  );
-
-  const descriptions = await Promise.all([
+  return Promise.all([
     incrementalSyncHandle.describe(),
     garbageCollectorHandle.describe(),
     processDatabaseUpsertQueueHandle.describe(),
   ]);
-  logger.info(
-    {
-      connectorId: notionConnector.id,
-    },
-    "Retrieved descriptions"
-  );
-
-  return descriptions;
 }
 
 async function getLatestWorkflowEventTime({
@@ -127,22 +104,16 @@ async function getLatestWorkflowEventTime({
 async function areTemporalWorkflowsRunning(
   client: Client,
   notionConnector: NotionConnector,
-  logger: pino.Logger
+  logger: Logger
 ) {
   const descriptions = await withRetries(logger, getWorkflowDescriptions, {
     retries: TEMPORAL_WORKFLOW_CHECK_RETRIES,
   })({
     client,
     notionConnector,
-    logger,
   });
 
-  logger.info(
-    {
-      connectorId: notionConnector.id,
-    },
-    "Workflow descriptions retrieved"
-  );
+  logger.info("Workflow descriptions retrieved");
 
   const isRunning = descriptions.every(
     ({ status: { name } }) => name === "RUNNING"
@@ -186,6 +157,8 @@ async function areTemporalWorkflowsRunning(
     descriptions,
   });
 
+  logger.info("Workflow latest events retrieved");
+
   const now = new Date().getTime();
 
   return {
@@ -222,6 +195,8 @@ export const checkNotionActiveWorkflows: CheckFunction = async (
   const stalledWorkflows: StalledWorkflow[] = [];
 
   for (const notionConnector of notionConnectors) {
+    const localLogger = logger.child({ connectorId: notionConnector.id });
+
     if (notionConnector.pausedAt) {
       continue;
     }
@@ -235,7 +210,7 @@ export const checkNotionActiveWorkflows: CheckFunction = async (
     heartbeat();
 
     const { isRunning, isNotStalled, details } =
-      await areTemporalWorkflowsRunning(client, notionConnector, logger);
+      await areTemporalWorkflowsRunning(client, notionConnector, localLogger);
 
     if (!isRunning) {
       missingActiveWorkflows.push({

--- a/front/lib/production_checks/checks/check_notion_active_workflows.ts
+++ b/front/lib/production_checks/checks/check_notion_active_workflows.ts
@@ -87,7 +87,10 @@ async function areTemporalWorkflowsRunning(
   client: Client,
   notionConnector: NotionConnector,
   logger: Logger
-) {
+): Promise<{
+  isRunning: boolean;
+  isNotStalled: boolean;
+}> {
   const descriptions = await withRetries(logger, getWorkflowDescriptions, {
     retries: TEMPORAL_WORKFLOW_CHECK_RETRIES,
   })({
@@ -200,13 +203,11 @@ export const checkNotionActiveWorkflows: CheckFunction = async (
         connectorId: notionConnector.id,
         workspaceId: notionConnector.workspaceId,
       });
-    } else {
-      if (!isNotStalled) {
-        stalledWorkflows.push({
-          connectorId: notionConnector.id,
-          workspaceId: notionConnector.workspaceId,
-        });
-      }
+    } else if (!isNotStalled) {
+      stalledWorkflows.push({
+        connectorId: notionConnector.id,
+        workspaceId: notionConnector.workspaceId,
+      });
     }
   }
 

--- a/front/lib/production_checks/checks/check_notion_active_workflows.ts
+++ b/front/lib/production_checks/checks/check_notion_active_workflows.ts
@@ -6,6 +6,7 @@ import { getTemporalClientForConnectorsNamespace } from "@app/lib/temporal";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { getNotionWorkflowId } from "@app/types/connectors/workflows";
 import type { ActionLink, CheckFunction } from "@app/types/production_checks";
+import type { ModelId } from "@app/types/shared/model_id";
 import { withRetries } from "@app/types/shared/retries";
 import type { Client, WorkflowExecutionDescription } from "@temporalio/client";
 import type { Logger } from "pino";
@@ -20,17 +21,6 @@ interface NotionConnector {
   workspaceId: string;
   pausedAt: Date | null;
 }
-
-type MissingWorkflow = {
-  connectorId: number;
-  workspaceId: string;
-  details: string;
-};
-
-type StalledWorkflow = {
-  connectorId: number;
-  workspaceId: string;
-};
 
 async function listAllNotionConnectors() {
   const connectorsDb = getConnectorsPrimaryDbConnection();
@@ -119,18 +109,10 @@ async function areTemporalWorkflowsRunning(
     ({ status: { name } }) => name === "RUNNING"
   );
 
-  const details = isRunning
-    ? ""
-    : "Statuses of workflows are " +
-      descriptions
-        .map(({ status: { name }, workflowId }) => `${workflowId}: ${name}`)
-        .join(", ");
-
   if (!isRunning) {
     return {
       isRunning,
       isNotStalled: false,
-      details,
     };
   }
 
@@ -167,7 +149,6 @@ async function areTemporalWorkflowsRunning(
     isNotStalled: latestEventTimes.every(
       (d) => d && now - d.getTime() < TEMPORAL_WORKFLOW_STALLED_THRESHOLD_MS
     ),
-    details,
   };
 }
 
@@ -192,8 +173,14 @@ export const checkNotionActiveWorkflows: CheckFunction = async (
 
   logger.info(`Found ${notionConnectors.length} Notion connectors.`);
 
-  const missingActiveWorkflows: MissingWorkflow[] = [];
-  const stalledWorkflows: StalledWorkflow[] = [];
+  const missingActiveWorkflows: {
+    connectorId: ModelId;
+    workspaceId: string;
+  }[] = [];
+  const stalledWorkflows: {
+    connectorId: ModelId;
+    workspaceId: string;
+  }[] = [];
 
   for (const notionConnector of notionConnectors) {
     const localLogger = logger.child({ connectorId: notionConnector.id });
@@ -210,14 +197,16 @@ export const checkNotionActiveWorkflows: CheckFunction = async (
 
     heartbeat();
 
-    const { isRunning, isNotStalled, details } =
-      await areTemporalWorkflowsRunning(client, notionConnector, localLogger);
+    const { isRunning, isNotStalled } = await areTemporalWorkflowsRunning(
+      client,
+      notionConnector,
+      localLogger
+    );
 
     if (!isRunning) {
       missingActiveWorkflows.push({
         connectorId: notionConnector.id,
         workspaceId: notionConnector.workspaceId,
-        details,
       });
     } else {
       if (!isNotStalled) {

--- a/front/lib/production_checks/checks/check_notion_active_workflows.ts
+++ b/front/lib/production_checks/checks/check_notion_active_workflows.ts
@@ -143,6 +143,7 @@ async function areTemporalWorkflowsRunning(
       client: Client;
       descriptions: NotionWorkflowDescriptions;
     }): Promise<(Date | null)[]> => {
+      // Bounded (only 3 elements in NotionWorkflowDescriptions), Temporal-only Promise.all.
       return Promise.all(
         descriptions.map((description) =>
           getLatestWorkflowEventTime({ client, description })

--- a/front/lib/production_checks/checks/check_notion_active_workflows.ts
+++ b/front/lib/production_checks/checks/check_notion_active_workflows.ts
@@ -13,7 +13,7 @@ import type { Logger } from "pino";
 import { QueryTypes } from "sequelize";
 
 const TEMPORAL_WORKFLOW_CHECK_RETRIES = 10;
-const TEMPORAL_WORKFLOW_STALLED_THRESHOLD_MS = 12 * 60 * 60 * 1000;
+const TEMPORAL_WORKFLOW_STALLED_THRESHOLD_MS = 12 * 60 * 60 * 1000; // 12 hours.
 
 interface NotionConnector {
   id: number;

--- a/front/lib/production_checks/checks/check_notion_active_workflows.ts
+++ b/front/lib/production_checks/checks/check_notion_active_workflows.ts
@@ -9,6 +9,7 @@ import type { ActionLink, CheckFunction } from "@app/types/production_checks";
 import type { ModelId } from "@app/types/shared/model_id";
 import { withRetries } from "@app/types/shared/retries";
 import type { Client, WorkflowExecutionDescription } from "@temporalio/client";
+import { WorkflowNotFoundError } from "@temporalio/client";
 import type { Logger } from "pino";
 import { QueryTypes } from "sequelize";
 
@@ -36,37 +37,57 @@ async function listAllNotionConnectors() {
 
 async function getWorkflowDescriptions({
   client,
+  logger,
   notionConnector,
 }: {
   client: Client;
+  logger: Logger;
   notionConnector: NotionConnector;
-}): Promise<WorkflowExecutionDescription[]> {
-  const incrementalSyncHandle = client.workflow.getHandle(
-    getNotionWorkflowId(notionConnector.id, "sync")
-  );
-  const garbageCollectorHandle = client.workflow.getHandle(
-    getNotionWorkflowId(notionConnector.id, "garbage-collector")
-  );
-  const processDatabaseUpsertQueueHandle = client.workflow.getHandle(
-    getNotionWorkflowId(notionConnector.id, "process-database-upsert-queue")
-  );
+}): Promise<WorkflowExecutionDescription[] | null> {
+  try {
+    const incrementalSyncHandle = client.workflow.getHandle(
+      getNotionWorkflowId(notionConnector.id, "sync")
+    );
+    const garbageCollectorHandle = client.workflow.getHandle(
+      getNotionWorkflowId(notionConnector.id, "garbage-collector")
+    );
+    const processDatabaseUpsertQueueHandle = client.workflow.getHandle(
+      getNotionWorkflowId(notionConnector.id, "process-database-upsert-queue")
+    );
 
-  return Promise.all([
-    incrementalSyncHandle.describe(),
-    garbageCollectorHandle.describe(),
-    processDatabaseUpsertQueueHandle.describe(),
-  ]);
+    return await Promise.all([
+      incrementalSyncHandle.describe(),
+      garbageCollectorHandle.describe(),
+      processDatabaseUpsertQueueHandle.describe(),
+    ]);
+  } catch (error) {
+    if (!(error instanceof WorkflowNotFoundError)) {
+      logger.error(
+        {
+          error,
+        },
+        "Failed to retrieve Notion Temporal workflow descriptions."
+      );
+    }
+
+    return null;
+  }
 }
 
 async function getLatestWorkflowEventDate({
   client,
   description,
+  logger,
 }: {
   client: Client;
   description: WorkflowExecutionDescription;
+  logger: Logger;
 }): Promise<Date | null> {
-  const response =
-    await client.workflowService.getWorkflowExecutionHistoryReverse({
+  let response: Awaited<
+    ReturnType<Client["workflowService"]["getWorkflowExecutionHistoryReverse"]>
+  >;
+  try {
+    response = await client.workflowService.getWorkflowExecutionHistoryReverse({
       namespace: client.options.namespace,
       execution: {
         workflowId: description.workflowId,
@@ -74,6 +95,18 @@ async function getLatestWorkflowEventDate({
       },
       maximumPageSize: 1,
     });
+  } catch (error) {
+    logger.error(
+      {
+        error,
+        runId: description.runId,
+        workflowId: description.workflowId,
+      },
+      "Failed to retrieve latest Notion Temporal history event."
+    );
+
+    return null;
+  }
 
   const latestEvent = response.history?.events?.[0];
   const latestEventSeconds = latestEvent?.eventTime?.seconds;
@@ -96,9 +129,17 @@ async function areTemporalWorkflowsRunning(
   })({
     client,
     notionConnector,
+    logger,
   });
 
   logger.info("Workflow descriptions retrieved");
+
+  if (!descriptions) {
+    return {
+      isRunning: false,
+      isNotStalled: false,
+    };
+  }
 
   const isRunning = descriptions.every(
     ({ status: { name } }) => name === "RUNNING"
@@ -116,21 +157,23 @@ async function areTemporalWorkflowsRunning(
     async ({
       client,
       descriptions,
+      logger,
     }: {
       client: Client;
       descriptions: WorkflowExecutionDescription[];
+      logger: Logger;
     }): Promise<(Date | null)[]> => {
       // Bounded (only three elements), Temporal-only Promise.all.
       return Promise.all(
         descriptions.map((description) =>
-          getLatestWorkflowEventDate({ client, description })
+          getLatestWorkflowEventDate({ client, description, logger })
         )
       );
     },
     {
       retries: TEMPORAL_WORKFLOW_CHECK_RETRIES,
     }
-  )({ client, descriptions });
+  )({ client, descriptions, logger });
 
   logger.info("Workflow latest events retrieved");
 
@@ -208,7 +251,7 @@ export const checkNotionActiveWorkflows: CheckFunction = async (
     }
   }
 
-  if (missingActiveWorkflows.length > 0) {
+  if (missingActiveWorkflows.length > 0 || stalledWorkflows.length > 0) {
     const actionLinks: ActionLink[] = [
       ...missingActiveWorkflows.map(({ connectorId }) => ({
         label: `Missing: connector ${connectorId}`,

--- a/front/lib/production_checks/checks/check_notion_active_workflows.ts
+++ b/front/lib/production_checks/checks/check_notion_active_workflows.ts
@@ -76,7 +76,7 @@ async function getWorkflowDescriptions({
   ]);
 }
 
-async function getLatestWorkflowEventTime({
+async function getLatestWorkflowEventDate({
   client,
   description,
 }: {
@@ -146,7 +146,7 @@ async function areTemporalWorkflowsRunning(
       // Bounded (only 3 elements in NotionWorkflowDescriptions), Temporal-only Promise.all.
       return Promise.all(
         descriptions.map((description) =>
-          getLatestWorkflowEventTime({ client, description })
+          getLatestWorkflowEventDate({ client, description })
         )
       );
     },

--- a/front/lib/production_checks/checks/check_notion_active_workflows.ts
+++ b/front/lib/production_checks/checks/check_notion_active_workflows.ts
@@ -7,13 +7,11 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { getNotionWorkflowId } from "@app/types/connectors/workflows";
 import type { ActionLink, CheckFunction } from "@app/types/production_checks";
 import type { ModelId } from "@app/types/shared/model_id";
-import { withRetries } from "@app/types/shared/retries";
 import type { Client, WorkflowExecutionDescription } from "@temporalio/client";
 import { WorkflowNotFoundError } from "@temporalio/client";
 import type { Logger } from "pino";
 import { QueryTypes } from "sequelize";
 
-const TEMPORAL_WORKFLOW_CHECK_RETRIES = 10;
 const TEMPORAL_WORKFLOW_STALLED_THRESHOLD_MS = 12 * 60 * 60 * 1000; // 12 hours.
 
 interface NotionConnector {
@@ -124,9 +122,7 @@ async function areTemporalWorkflowsRunning(
   isRunning: boolean;
   isNotStalled: boolean;
 }> {
-  const descriptions = await withRetries(logger, getWorkflowDescriptions, {
-    retries: TEMPORAL_WORKFLOW_CHECK_RETRIES,
-  })({
+  const descriptions = await getWorkflowDescriptions({
     client,
     notionConnector,
     logger,
@@ -152,28 +148,12 @@ async function areTemporalWorkflowsRunning(
     };
   }
 
-  const latestEventTimes = await withRetries(
-    logger,
-    async ({
-      client,
-      descriptions,
-      logger,
-    }: {
-      client: Client;
-      descriptions: WorkflowExecutionDescription[];
-      logger: Logger;
-    }): Promise<(Date | null)[]> => {
-      // Bounded (only three elements), Temporal-only Promise.all.
-      return Promise.all(
-        descriptions.map((description) =>
-          getLatestWorkflowEventDate({ client, description, logger })
-        )
-      );
-    },
-    {
-      retries: TEMPORAL_WORKFLOW_CHECK_RETRIES,
-    }
-  )({ client, descriptions, logger });
+  // Bounded (only three elements), Temporal-only Promise.all.
+  const latestEventTimes = await Promise.all(
+    descriptions.map((description) =>
+      getLatestWorkflowEventDate({ client, description, logger })
+    )
+  );
 
   logger.info("Workflow latest events retrieved");
 

--- a/front/lib/production_checks/checks/check_notion_active_workflows.ts
+++ b/front/lib/production_checks/checks/check_notion_active_workflows.ts
@@ -26,14 +26,12 @@ async function listAllNotionConnectors() {
   const connectorsDb = getConnectorsPrimaryDbConnection();
 
   // biome-ignore lint/plugin/noRawSql: production check uses read replica
-  const notionConnectors: NotionConnector[] = await connectorsDb.query(
+  return connectorsDb.query<NotionConnector>(
     `SELECT id, "dataSourceId", "workspaceId", "pausedAt" FROM connectors WHERE "type" = 'notion' and  "errorType" IS NULL`,
     {
       type: QueryTypes.SELECT,
     }
   );
-
-  return notionConnectors;
 }
 
 type NotionWorkflowDescriptions = [

--- a/front/lib/production_checks/checks/check_notion_active_workflows.ts
+++ b/front/lib/production_checks/checks/check_notion_active_workflows.ts
@@ -113,10 +113,13 @@ async function areTemporalWorkflowsRunning(
 
   const latestEventTimes = await withRetries(
     logger,
-    async (
-      client: Client,
-      descriptions: WorkflowExecutionDescription[]
-    ): Promise<(Date | null)[]> => {
+    async ({
+      client,
+      descriptions,
+    }: {
+      client: Client;
+      descriptions: WorkflowExecutionDescription[];
+    }): Promise<(Date | null)[]> => {
       // Bounded (only three elements), Temporal-only Promise.all.
       return Promise.all(
         descriptions.map((description) =>
@@ -127,7 +130,7 @@ async function areTemporalWorkflowsRunning(
     {
       retries: TEMPORAL_WORKFLOW_CHECK_RETRIES,
     }
-  )(client, descriptions);
+  )({ client, descriptions });
 
   logger.info("Workflow latest events retrieved");
 


### PR DESCRIPTION
## Description

- Implements an optimization in the production check `check_notion_active_workflows`, in an effort to make sure we run production checks at least once every 90 minutes (related monitor).
- This check is the 2nd slowest, after the Google Drive GC check.
- The check currently fetches the entire history of each Notion workflow from Temporal to get the date of the latest event and find out whether it is stalled. Some Notion workflows are known to have huge histories (sometimes takes dozens of minutes to load in the webapp).
- This PR only fetches the last event (there's a method available to do this in the raw service).
- Also removes the retries, checked [here](https://app.datadoghq.eu/logs?query=%22Error%20while%20executing%20retriable%20function.%20Retrying%22%20%40dd.service%3Afront-worker&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1779170115594&to_ts=1779774915594&live=true) that they were not triggered.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
