### PR TITLE
[front] fix: handle missing project task workflows in Poke

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/tasks-workflow.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/tasks-workflow.ts
@@ -1,7 +1,10 @@
 import config from "@app/lib/api/config";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import {
+  describeTemporalWorkflow,
+  getTemporalClientForFrontNamespace,
+} from "@app/lib/temporal";
 import type { ProjectMetadataType } from "@app/types/project_metadata";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
@@ -55,16 +58,18 @@ app.get("/", async (ctx): HandlerResult<PokeGetProjectWorkflow> => {
 
   const temporalClient = await getTemporalClientForFrontNamespace();
 
-  const description = await temporalClient.workflow
-    .getHandle(workflowId)
-    .describe();
-  const latestWorkflow: PokeProjectWorkflowInfo = {
+  const description = await describeTemporalWorkflow(temporalClient, {
     workflowId,
-    runId: description.runId,
-    status: description.status.name,
-    startTime: description.startTime?.getTime() ?? null,
-    closeTime: description.closeTime?.getTime() ?? null,
-  };
+  });
+  const latestWorkflow: PokeProjectWorkflowInfo | null = description
+    ? {
+        workflowId,
+        runId: description.runId,
+        status: description.status.name,
+        startTime: description.startTime?.getTime() ?? null,
+        closeTime: description.closeTime?.getTime() ?? null,
+      }
+    : null;
 
   return ctx.json({
     metadata: metadata ? metadata.toJSON() : null,

--- a/front/lib/temporal.ts
+++ b/front/lib/temporal.ts
@@ -1,8 +1,9 @@
 import type {
   ConnectionOptions,
   WorkflowClientInterceptor,
+  WorkflowExecutionDescription,
 } from "@temporalio/client";
-import { Client, Connection } from "@temporalio/client";
+import { Client, Connection, WorkflowNotFoundError } from "@temporalio/client";
 import { OpenTelemetryWorkflowClientInterceptor } from "@temporalio/interceptors-opentelemetry";
 import { NativeConnection } from "@temporalio/worker";
 import fs from "fs-extra";
@@ -118,6 +119,22 @@ export async function getTemporalClientForFrontNamespace() {
 
 export async function getTemporalClientForConnectorsNamespace() {
   return getTemporalClientForNamespace("connectors");
+}
+
+export async function describeTemporalWorkflow(temporalClient: Client, {
+  workflowId,
+}: {
+  workflowId: string;
+}): Promise<WorkflowExecutionDescription | null> {
+  try {
+    return await temporalClient.workflow.getHandle(workflowId).describe();
+  } catch (err) {
+    if (err instanceof WorkflowNotFoundError) {
+      return null;
+    }
+
+    throw err;
+  }
 }
 
 /**

--- a/front/lib/temporal.ts
+++ b/front/lib/temporal.ts
@@ -121,11 +121,14 @@ export async function getTemporalClientForConnectorsNamespace() {
   return getTemporalClientForNamespace("connectors");
 }
 
-export async function describeTemporalWorkflow(temporalClient: Client, {
-  workflowId,
-}: {
-  workflowId: string;
-}): Promise<WorkflowExecutionDescription | null> {
+export async function describeTemporalWorkflow(
+  temporalClient: Client,
+  {
+    workflowId,
+  }: {
+    workflowId: string;
+  }
+): Promise<WorkflowExecutionDescription | null> {
   try {
     return await temporalClient.workflow.getHandle(workflowId).describe();
   } catch (err) {

--- a/front/pages/api/poke/workspaces/[wId]/projects/[projectId]/tasks-workflow.ts
+++ b/front/pages/api/poke/workspaces/[wId]/projects/[projectId]/tasks-workflow.ts
@@ -6,7 +6,10 @@ import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import {
+  describeTemporalWorkflow,
+  getTemporalClientForFrontNamespace,
+} from "@app/lib/temporal";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { ProjectMetadataType } from "@app/types/project_metadata";
@@ -75,17 +78,18 @@ async function handler(
 
       const temporalClient = await getTemporalClientForFrontNamespace();
 
-      let latestWorkflow: PokeProjectWorkflowInfo | null = null;
-      const description = await temporalClient.workflow
-        .getHandle(workflowId)
-        .describe();
-      latestWorkflow = {
+      const description = await describeTemporalWorkflow(temporalClient, {
         workflowId,
-        runId: description.runId,
-        status: description.status.name,
-        startTime: description.startTime?.getTime() ?? null,
-        closeTime: description.closeTime?.getTime() ?? null,
-      };
+      });
+      const latestWorkflow: PokeProjectWorkflowInfo | null = description
+        ? {
+            workflowId,
+            runId: description.runId,
+            status: description.status.name,
+            startTime: description.startTime?.getTime() ?? null,
+            closeTime: description.closeTime?.getTime() ?? null,
+          }
+        : null;
 
       return res.status(200).json({
         metadata: metadata ? metadata.toJSON() : null,


### PR DESCRIPTION
## Description

We are seeing unhandled API errors from the project task workflow endpoint when the expected Temporal workflow is not found ([logs](https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20status%3Aerror%20%40dd.env%3Aprod&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZ5QkuYrR8CXwQAAABhBWjVRa3V2WkFBQ0ZYR1ZNMi1RZU1nQVQAAAAkMDE5ZTUwOTUtYTdmNC00NjMxLThhZGQtYjY3ZjE0ODdlNjUxAAR93g&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1779468012000&to_ts=1779468612000&live=false)).

This PR adds a graceful handling by returning a null workflow in this case, which the UI already handles as no executions.

## Tests

## Risk

- Low. Scoped to the Poke project task workflow endpoint.

## Deploy Plan

- Deploy front.
