### PR TITLE
[core] fix: prevent datasource document deletion deadlocks

### DIFF
--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -2346,7 +2346,17 @@ impl Store for PostgresStore {
             .await?;
 
         let stmt_documents = c
-            .prepare("DELETE FROM data_sources_documents WHERE id = ANY($1)")
+            .prepare(
+                "WITH documents_to_delete AS (
+                   SELECT id FROM data_sources_documents
+                   WHERE id = ANY($1)
+                   ORDER BY id
+                   FOR UPDATE
+                 )
+                 DELETE FROM data_sources_documents
+                 USING documents_to_delete
+                 WHERE data_sources_documents.id = documents_to_delete.id",
+            )
             .await?;
 
         // First remove active documents, which are linked to a node
@@ -2371,9 +2381,16 @@ impl Store for PostgresStore {
         // Then remove all remaining documents
         let stmt = c
             .prepare(
-                "DELETE FROM data_sources_documents WHERE id IN (
-                   SELECT id FROM data_sources_documents WHERE data_source = $1 LIMIT $2
-                 )",
+                "WITH documents_to_delete AS (
+                   SELECT id FROM data_sources_documents
+                   WHERE data_source = $1
+                   ORDER BY id
+                   LIMIT $2
+                   FOR UPDATE
+                 )
+                 DELETE FROM data_sources_documents
+                 USING documents_to_delete
+                 WHERE data_sources_documents.id = documents_to_delete.id",
             )
             .await?;
 


### PR DESCRIPTION
## Description

We are seeing conversation retention fail while deleting data sources in core, with deadlocks in the final
`data_sources_documents` cleanup.

- workflow error logs [here](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E15%20%40dd.service%3Afront-worker%20region%3Aus-central1&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZ5QvBrxubJdrwAAABhBWjVRdkM2NEFBRHItanJoU3MtU3FnQUIAAAAkMDE5ZTUwYmMtM2EzNC00YjhiLWJiNTctNDJjYTJmZWY4NjU2AABydg&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1779467384000&to_ts=1779470984000&live=false)
- db logs [here](https://console.cloud.google.com/logs/query;query=resource.type%3D%22cloudsql_database%22%0Aresource.labels.database_id%3D%22or1g1n-186209:dust-api-db%22%0Alog_name%3D%22projects%2For1g1n-186209%2Flogs%2Fcloudsql.googleapis.com%252Fpostgres.log%22%0AlogName%3D%22projects%2For1g1n-186209%2Flogs%2Fcloudsql.googleapis.com%252Fpostgres.log%22;cursorTimestamp=2026-05-22T20:18:55.730935Z;histogramBreakdownField=severity;aroundTime=2026-05-22T20:18:58.472986763Z;duration=PT15S?project=or1g1n-186209).

We see in the logs two docment delete statements used by `delete_data_source`: one deletes document rows returned from node cleanup, the other deletes remaining document rows in batches.
This PR keeps the change scoped to those two statements and makes both lock document rows in `id` order before deleting them, so that concurrent datasource deletions acquire tuple locks consistently.

Should not have a major impact on perf: the ordering is on id, we're already batching, this path is very async.

Not very high priority as this can resolve transiently after an arbitrary number of retries but can still get stuck for a while.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy core.
