### PR TITLE
Fix: margin on FileExplorer

### DIFF
--- a/front/components/assistant/conversation/space/ProjectFileExplorer.tsx
+++ b/front/components/assistant/conversation/space/ProjectFileExplorer.tsx
@@ -65,7 +65,6 @@ import {
   DropdownMenuTrigger,
   EmptyCTA,
   FolderIcon,
-  PlusIcon,
   Tooltip,
 } from "@dust-tt/sparkle";
 import type React from "react";
@@ -99,7 +98,12 @@ function AttachKnowledgeDropdown({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button label={buttonLabel} icon={PlusIcon} disabled={isDisabled} />
+        <Button
+          label={buttonLabel}
+          isSelect
+          variant="highlight"
+          disabled={isDisabled}
+        />
       </DropdownMenuTrigger>
       <DropdownMenuContent>
         <DropdownMenuItem

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -305,12 +305,14 @@ export function FileExplorer({
       ? () => setPreviewFile(fileEntriesAtLevel[previewIndex + 1] ?? null)
       : undefined;
 
+  const inPanel = !!onClose;
+
   return (
     <>
       <div className="flex h-full w-full min-h-0 flex-1 flex-col">
-        {onClose && (
+        {inPanel && (
           <AppLayoutTitle
-            className={cn("pt-5", hideTitleBorder ? "border-b-0" : undefined)}
+            className={hideTitleBorder ? "border-b-0" : undefined}
           >
             <div
               className={cn(
@@ -328,9 +330,13 @@ export function FileExplorer({
           </AppLayoutTitle>
         )}
         <div
-          className={cn("flex flex-1 min-h-0 flex-col gap-5", contentClassName)}
+          className={cn(
+            "flex flex-1 min-h-0 flex-col gap-5",
+            contentClassName,
+            inPanel ? "pt-5" : undefined
+          )}
         >
-          <div className="px-4">
+          <div className={inPanel ? "px-4" : undefined}>
             <FileExplorerToolbar
               searchQuery={searchQuery}
               onSearchQueryChange={setSearchQuery}
@@ -342,7 +348,7 @@ export function FileExplorer({
             />
           </div>
           {Object.keys(filterCounts).length > 1 && (
-            <div className="px-4">
+            <div className={inPanel ? "px-4" : undefined}>
               <FileExplorerFilters
                 active={activeFilter}
                 onActiveChange={setActiveFilter}
@@ -351,7 +357,7 @@ export function FileExplorer({
             </div>
           )}
           {currentFolderPath !== "" && (
-            <div className="px-4">
+            <div className={inPanel ? "px-4" : undefined}>
               <FileExplorerBreadcrumb
                 currentFolderPath={currentFolderPath}
                 onNavigate={handleBreadcrumbNavigate}


### PR DESCRIPTION
## Description

`FileExplorer` now derives `inPanel = !!onClose` and uses it to conditionally apply `pt-5` and `px-4` padding — previously these were always applied, causing unwanted margins when the component is rendered outside of a sliding panel. Also updates the `AttachKnowledgeDropdown` button in `ProjectFileExplorer` to use `isSelect` + `variant="highlight"` instead of a plain `PlusIcon` button.

## Tests

Tested locally by verifying `FileExplorer` renders correctly both in-panel and inline (no excess padding in the inline case).

## Risk

Low. Pure layout/styling change with no logic or API impact. Trivially rollback-safe.

## Deploy Plan

Deploy front.
