### PR TITLE
Fix: ios scroll behavior.

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -1327,6 +1327,8 @@ export const ConversationViewer = ({
           className={cn(
             "dd-privacy-mask",
             "@container/conversation",
+            "touch-pan-y",
+            "overscroll-contain",
             "h-full w-full px-5",
             !agentBuilderContext && "md:px-8"
           )}

--- a/front/styles/global.css
+++ b/front/styles/global.css
@@ -49,6 +49,7 @@ main {
 
 body {
   overflow-x: hidden;
+  overscroll-behavior: none;
 }
 
 #__next {


### PR DESCRIPTION
## Description

Fixes erratic scroll behavior on iOS in the conversation view. `ConversationViewer` gets `touch-pan-y` (restricts touch handling to vertical panning) and `overscroll-contain` (prevents scroll chaining to the parent). `global.css` adds `overscroll-behavior: none` on `body` to suppress native iOS bounce/overscroll effects.

## Tests

Tested manually on iOS (Safari). No automated tests needed for CSS-only changes.

## Risk

Low. Pure CSS changes scoped to scroll behavior — no logic affected. Easily rolled back by reverting the two class additions and the global CSS rule.

## Deploy Plan

Deploy front.
