### PR TITLE
Migrate subscription handlers and more

### DIFF
--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -40,11 +40,13 @@ import me from "./me";
 import members from "./members";
 import metronome from "./metronome";
 import models from "./models";
+import projectTasks from "./project_tasks";
 import providers from "./providers";
 import provisioningStatus from "./provisioning-status";
 import sandbox from "./sandbox";
 import search from "./search";
 import seats from "./seats";
+import services from "./services";
 import skills from "./skills";
 import spaces from "./spaces";
 import sso from "./sso";
@@ -226,6 +228,10 @@ app.use(
 );
 app.use(
   "/subscriptions/trial-info/*",
+  workspaceAuth({ doesNotRequireCanUseProduct: true })
+);
+app.use(
+  "/subscriptions/checkout/*",
   workspaceAuth({ doesNotRequireCanUseProduct: true })
 );
 
@@ -566,11 +572,13 @@ app.route("/me", me);
 app.route("/members", members);
 app.route("/metronome", metronome);
 app.route("/models", models);
+app.route("/project_tasks", projectTasks);
 app.route("/providers", providers);
 app.route("/provisioning-status", provisioningStatus);
 app.route("/sandbox", sandbox);
 app.route("/search", search);
 app.route("/seats", seats);
+app.route("/services", services);
 app.route("/skills", skills);
 app.route("/sso", sso);
 app.route("/spaces", spaces);

--- a/front-api/routes/w/[wId]/members/[uId]/index.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/index.ts
@@ -24,6 +24,7 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
 import seatType from "./seat-type";
+import spendLimit from "./spend_limit";
 
 const PostMemberBodySchema = z.object({
   role: z.string(),
@@ -34,6 +35,7 @@ const PostMemberBodySchema = z.object({
 const app = workspaceApp();
 
 app.route("/seat-type", seatType);
+app.route("/spend_limit", spendLimit);
 
 app.get("/", async (ctx) => {
   const auth = ctx.get("auth");

--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
@@ -1,0 +1,388 @@
+import * as creditStateDispatcher from "@app/lib/api/metronome/credit_state_dispatcher";
+import * as perUserAlerts from "@app/lib/metronome/per_user_alerts";
+import * as perUserUsage from "@app/lib/metronome/per_user_usage";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Ok } from "@app/types/shared/result";
+import type { WorkspaceType } from "@app/types/user";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/per_user_alerts", async () => {
+  const actual = await vi.importActual<typeof perUserAlerts>(
+    "@app/lib/metronome/per_user_alerts"
+  );
+  return {
+    ...actual,
+    upsertMetronomePerUserCapAlert: vi.fn(),
+    clearMetronomePerUserCapAlert: vi.fn(),
+    getMetronomePerUserCap: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/metronome/per_user_usage", async () => {
+  const actual = await vi.importActual<typeof perUserUsage>(
+    "@app/lib/metronome/per_user_usage"
+  );
+  return {
+    ...actual,
+    fetchPerUserAwuUsage: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/api/metronome/credit_state_dispatcher", async () => {
+  const actual = await vi.importActual<typeof creditStateDispatcher>(
+    "@app/lib/api/metronome/credit_state_dispatcher"
+  );
+  return {
+    ...actual,
+    dispatchPerUserCapReached: vi.fn(),
+    dispatchPerUserCapResolved: vi.fn(),
+  };
+});
+
+const TEST_METRONOME_CUSTOMER_ID = "cust_test_xxx";
+const TEST_ALERT_ID = "alert_test_xxx";
+
+async function makeMetronomeWorkspaceWithCustomer(): Promise<WorkspaceType> {
+  return WorkspaceFactory.metronome({
+    metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
+  });
+}
+
+function spendLimitUrl(wId: string, uId: string) {
+  return `/api/w/${wId}/members/${uId}/spend_limit`;
+}
+
+beforeEach(() => {
+  vi.mocked(perUserAlerts.upsertMetronomePerUserCapAlert).mockResolvedValue(
+    new Ok({ alertId: TEST_ALERT_ID })
+  );
+  vi.mocked(perUserAlerts.clearMetronomePerUserCapAlert).mockResolvedValue(
+    new Ok(undefined)
+  );
+  vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValue(
+    new Ok(null)
+  );
+  vi.mocked(perUserUsage.fetchPerUserAwuUsage).mockResolvedValue(
+    new Ok(new Map())
+  );
+  vi.mocked(creditStateDispatcher.dispatchPerUserCapReached).mockResolvedValue(
+    new Ok(undefined)
+  );
+  vi.mocked(creditStateDispatcher.dispatchPerUserCapResolved).mockResolvedValue(
+    new Ok(undefined)
+  );
+});
+
+describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
+  describe("auth", () => {
+    it("returns 403 when caller is not an admin", async () => {
+      const { workspace, user } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "user",
+      });
+
+      const response = await honoApp.request(
+        spendLimitUrl(workspace.sId, user.sId)
+      );
+
+      expect(response.status).toBe(403);
+      expect((await response.json()).error.type).toBe("workspace_auth_error");
+    });
+
+    it("returns 403 when workspace is not on Metronome billing", async () => {
+      const { workspace, user } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+      });
+
+      const response = await honoApp.request(
+        spendLimitUrl(workspace.sId, user.sId)
+      );
+
+      expect(response.status).toBe(403);
+      expect((await response.json()).error.type).toBe("plan_limit_error");
+    });
+  });
+
+  describe("method validation", () => {
+    it("returns 404 for unsupported methods", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const { user } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "admin",
+        workspace,
+      });
+
+      const response = await honoApp.request(
+        spendLimitUrl(workspace.sId, user.sId),
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        }
+      );
+
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("input validation", () => {
+    it("returns 404 when uId does not exist", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+
+      const response = await honoApp.request(
+        spendLimitUrl(workspace.sId, "nonexistent-user-id")
+      );
+
+      expect(response.status).toBe(404);
+      expect((await response.json()).error.type).toBe(
+        "workspace_user_not_found"
+      );
+    });
+
+    it("returns 400 on PUT with negative awuCredits", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const { user } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+
+      const response = await honoApp.request(
+        spendLimitUrl(workspace.sId, user.sId),
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ kind: "limited", awuCredits: -1 }),
+        }
+      );
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error.type).toBe("invalid_request_error");
+    });
+
+    it("returns 400 on PUT with non-integer awuCredits", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const { user } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+
+      const response = await honoApp.request(
+        spendLimitUrl(workspace.sId, user.sId),
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ kind: "limited", awuCredits: 1.5 }),
+        }
+      );
+
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 400 on PUT with awuCredits above max", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const { user } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+
+      const response = await honoApp.request(
+        spendLimitUrl(workspace.sId, user.sId),
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ kind: "limited", awuCredits: 100_000_000 }),
+        }
+      );
+
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe("GET", () => {
+    it("returns unlimited when no per-user alert exists", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const { user } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+
+      const response = await honoApp.request(
+        spendLimitUrl(workspace.sId, user.sId)
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ kind: "unlimited" });
+    });
+
+    it("returns limited with threshold when alert exists", async () => {
+      vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValueOnce(
+        new Ok({
+          id: TEST_ALERT_ID,
+          threshold: 2500,
+          state: "ok",
+          uniquenessKey: null,
+        })
+      );
+
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const { user } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+
+      const response = await honoApp.request(
+        spendLimitUrl(workspace.sId, user.sId)
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        kind: "limited",
+        awuCredits: 2500,
+      });
+    });
+  });
+
+  describe("PUT", () => {
+    it("clears alert + dispatches resolved for unlimited", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const targetUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, targetUser, {
+        role: "user",
+      });
+
+      await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+
+      const response = await honoApp.request(
+        spendLimitUrl(workspace.sId, targetUser.sId),
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ kind: "unlimited" }),
+        }
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        limit: { kind: "unlimited" },
+        transitionedTo: "resolved",
+      });
+      expect(perUserAlerts.clearMetronomePerUserCapAlert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
+          workspaceId: workspace.sId,
+          userId: targetUser.sId,
+        })
+      );
+      expect(
+        creditStateDispatcher.dispatchPerUserCapResolved
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: targetUser.sId })
+      );
+      expect(
+        perUserAlerts.upsertMetronomePerUserCapAlert
+      ).not.toHaveBeenCalled();
+    });
+
+    it("syncs alert + dispatches resolved when usage is below cap", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const targetUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, targetUser, {
+        role: "user",
+      });
+
+      vi.mocked(perUserUsage.fetchPerUserAwuUsage).mockResolvedValueOnce(
+        new Ok(new Map([[targetUser.sId, 500]]))
+      );
+
+      await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+
+      const response = await honoApp.request(
+        spendLimitUrl(workspace.sId, targetUser.sId),
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ kind: "limited", awuCredits: 1500 }),
+        }
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        limit: { kind: "limited", awuCredits: 1500 },
+        transitionedTo: "resolved",
+      });
+      expect(perUserAlerts.upsertMetronomePerUserCapAlert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
+          workspaceId: workspace.sId,
+          userId: targetUser.sId,
+          awuCredits: 1500,
+        })
+      );
+      expect(
+        creditStateDispatcher.dispatchPerUserCapResolved
+      ).toHaveBeenCalled();
+      expect(
+        creditStateDispatcher.dispatchPerUserCapReached
+      ).not.toHaveBeenCalled();
+    });
+
+    it("dispatches reached when usage is at/above cap", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const targetUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, targetUser, {
+        role: "user",
+      });
+
+      vi.mocked(perUserUsage.fetchPerUserAwuUsage).mockResolvedValueOnce(
+        new Ok(new Map([[targetUser.sId, 2000]]))
+      );
+
+      await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+
+      const response = await honoApp.request(
+        spendLimitUrl(workspace.sId, targetUser.sId),
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ kind: "limited", awuCredits: 1500 }),
+        }
+      );
+
+      expect(response.status).toBe(200);
+      expect((await response.json()).transitionedTo).toBe("reached");
+      expect(
+        creditStateDispatcher.dispatchPerUserCapReached
+      ).toHaveBeenCalled();
+      expect(
+        creditStateDispatcher.dispatchPerUserCapResolved
+      ).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.ts
@@ -1,0 +1,165 @@
+import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
+import {
+  type GetUserSpendLimitResponse,
+  getUserSpendLimit,
+  MAX_USER_SPEND_LIMIT_AWU_CREDITS,
+  MIN_USER_SPEND_LIMIT_AWU_CREDITS,
+  type SetUserSpendLimitResponse,
+  setUserSpendLimit,
+  type UserSpendLimitError,
+} from "@app/lib/api/users/spend_limit";
+import type { APIErrorWithStatusCode } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const UpdateUserSpendLimitBodySchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("unlimited") }),
+  z.object({
+    kind: z.literal("limited"),
+    awuCredits: z
+      .number()
+      .int()
+      .min(MIN_USER_SPEND_LIMIT_AWU_CREDITS)
+      .max(MAX_USER_SPEND_LIMIT_AWU_CREDITS),
+  }),
+]);
+
+export type GetUserSpendLimitResponseBody = GetUserSpendLimitResponse;
+
+export type PutUserSpendLimitResponseBody = SetUserSpendLimitResponse;
+
+function spendLimitErrorToApiError(
+  error: UserSpendLimitError
+): APIErrorWithStatusCode {
+  switch (error.type) {
+    case "user_not_found":
+      return {
+        status_code: 404,
+        api_error: {
+          type: "workspace_user_not_found",
+          message: error.message,
+        },
+      };
+    case "workspace_not_metronome_billed":
+      return {
+        status_code: 403,
+        api_error: {
+          type: "plan_limit_error",
+          message: error.message,
+        },
+      };
+    case "metronome_error":
+      return {
+        status_code: 502,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to update spend limit in billing system.",
+        },
+      };
+    default:
+      assertNever(error.type);
+  }
+}
+
+// Mounted at /api/w/:wId/members/:uId/spend_limit.
+const app = workspaceApp();
+
+app.get("/", async (ctx): HandlerResult<GetUserSpendLimitResponseBody> => {
+  const auth = ctx.get("auth");
+
+  if (!auth.isAdmin()) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can manage member spend limits.",
+      },
+    });
+  }
+
+  if (!auth.getNonNullableSubscriptionResource().isMetronomeOnlyBilled) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "plan_limit_error",
+        message:
+          "Per-user spend limits are only available on Metronome-billed workspaces.",
+      },
+    });
+  }
+
+  const uId = ctx.req.param("uId") ?? "";
+  if (!uId) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid query parameters, `uId` (string) is required.",
+      },
+    });
+  }
+
+  const result = await getUserSpendLimit(auth, { userId: uId });
+  if (result.isErr()) {
+    return apiError(ctx, spendLimitErrorToApiError(result.error));
+  }
+  return ctx.json(result.value);
+});
+
+app.put(
+  "/",
+  validate("json", UpdateUserSpendLimitBodySchema),
+  async (ctx): HandlerResult<PutUserSpendLimitResponseBody> => {
+    const auth = ctx.get("auth");
+
+    if (!auth.isAdmin()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message:
+            "Only users that are `admins` for the current workspace can manage member spend limits.",
+        },
+      });
+    }
+
+    if (!auth.getNonNullableSubscriptionResource().isMetronomeOnlyBilled) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "plan_limit_error",
+          message:
+            "Per-user spend limits are only available on Metronome-billed workspaces.",
+        },
+      });
+    }
+
+    const uId = ctx.req.param("uId") ?? "";
+    if (!uId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid query parameters, `uId` (string) is required.",
+        },
+      });
+    }
+
+    const auditContext = getAuditLogContext(auth);
+    const result = await setUserSpendLimit(auth, {
+      userId: uId,
+      limit: ctx.req.valid("json"),
+      auditContext,
+    });
+    if (result.isErr()) {
+      return apiError(ctx, spendLimitErrorToApiError(result.error));
+    }
+    return ctx.json(result.value);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/metronome/contract.test.ts
+++ b/front-api/routes/w/[wId]/metronome/contract.test.ts
@@ -1,0 +1,266 @@
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/client", () => ({
+  getMetronomeContractById: vi.fn(),
+  listMetronomeDraftInvoices: vi.fn(),
+  scheduleMetronomeContractEnd: vi.fn(),
+  reactivateMetronomeContract: vi.fn(),
+}));
+
+import {
+  getMetronomeContractById,
+  listMetronomeDraftInvoices,
+  reactivateMetronomeContract,
+  scheduleMetronomeContractEnd,
+} from "@app/lib/metronome/client";
+
+function contractUrl(wId: string) {
+  return `/api/w/${wId}/metronome/contract`;
+}
+
+async function setActiveSubscriptionBilling({
+  workspaceId,
+  stripeSubscriptionId,
+  metronomeContractId,
+}: {
+  workspaceId: number;
+  stripeSubscriptionId: string | null;
+  metronomeContractId: string | null;
+}) {
+  const currentSubscription =
+    await SubscriptionResource.fetchActiveByWorkspaceModelId(workspaceId);
+
+  if (!currentSubscription) {
+    throw new Error("Expected an active subscription.");
+  }
+
+  await currentSubscription.markAsEnded("ended");
+
+  await SubscriptionResource.makeNew(
+    {
+      sId: generateRandomModelSId(),
+      workspaceId,
+      planId: currentSubscription.planId,
+      status: "active",
+      trialing: false,
+      startDate: new Date(),
+      endDate: null,
+      stripeSubscriptionId,
+      metronomeContractId,
+    },
+    currentSubscription.getPlan()
+  );
+
+  if (metronomeContractId) {
+    const updateResult = await WorkspaceResource.updateMetronomeCustomerId(
+      workspaceId,
+      "m-customer"
+    );
+
+    if (updateResult.isErr()) {
+      throw updateResult.error;
+    }
+  }
+}
+
+function makeCurrentDraftInvoice({ contractId }: { contractId: string }) {
+  const nowMs = Date.now();
+
+  return {
+    contract_id: contractId,
+    start_timestamp: new Date(nowMs - 60_000).toISOString(),
+    end_timestamp: new Date(nowMs + 60_000).toISOString(),
+  };
+}
+
+describe("/api/w/[wId]/metronome/contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("GET", () => {
+    it("returns null when the workspace has no Metronome contract", async () => {
+      const { workspace } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+      });
+
+      const response = await honoApp.request(contractUrl(workspace.sId));
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ contract: null });
+      expect(vi.mocked(getMetronomeContractById)).not.toHaveBeenCalled();
+    });
+
+    it("returns the contract summary for a Metronome-billed workspace", async () => {
+      const { workspace } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+      });
+
+      await setActiveSubscriptionBilling({
+        workspaceId: workspace.id,
+        stripeSubscriptionId: null,
+        metronomeContractId: "m-contract-get",
+      });
+
+      vi.mocked(getMetronomeContractById).mockResolvedValue(
+        new Ok({
+          custom_fields: {},
+          ending_before: "2025-05-01T00:00:00.000Z",
+        } as never)
+      );
+
+      const response = await honoApp.request(contractUrl(workspace.sId));
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        contract: {
+          planFamily: "pro",
+          mauTiers: null,
+          contractEndingAtMs: new Date("2025-05-01T00:00:00.000Z").getTime(),
+          hasSeatSubscription: false,
+        },
+      });
+      expect(vi.mocked(getMetronomeContractById)).toHaveBeenCalledWith({
+        metronomeCustomerId: "m-customer",
+        metronomeContractId: "m-contract-get",
+      });
+    });
+  });
+
+  describe("PATCH", () => {
+    it("cancels a true Metronome-billed subscription", async () => {
+      const { workspace } = await createPrivateApiMockRequest({
+        method: "PATCH",
+        role: "admin",
+      });
+
+      await setActiveSubscriptionBilling({
+        workspaceId: workspace.id,
+        stripeSubscriptionId: null,
+        metronomeContractId: "m-contract-cancel",
+      });
+
+      vi.mocked(listMetronomeDraftInvoices).mockResolvedValue(
+        new Ok([
+          makeCurrentDraftInvoice({ contractId: "m-contract-cancel" }),
+        ] as never)
+      );
+      vi.mocked(scheduleMetronomeContractEnd).mockResolvedValue(
+        new Ok(undefined)
+      );
+
+      const response = await honoApp.request(contractUrl(workspace.sId), {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "cancel" }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ success: true });
+      expect(vi.mocked(scheduleMetronomeContractEnd)).toHaveBeenCalledWith({
+        metronomeCustomerId: "m-customer",
+        contractId: "m-contract-cancel",
+        endingBefore: expect.any(Date),
+      });
+
+      const updatedSubscription =
+        await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
+      expect(updatedSubscription?.endDate).not.toBeNull();
+    });
+
+    it("reactivates a true Metronome-billed subscription", async () => {
+      const { workspace } = await createPrivateApiMockRequest({
+        method: "PATCH",
+        role: "admin",
+      });
+
+      await setActiveSubscriptionBilling({
+        workspaceId: workspace.id,
+        stripeSubscriptionId: null,
+        metronomeContractId: "m-contract-reactivate",
+      });
+
+      const subscription =
+        await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
+      if (!subscription) {
+        throw new Error("Expected an active subscription.");
+      }
+      await subscription.markAsCanceled({
+        endDate: new Date(Date.now() + 60_000),
+      });
+
+      vi.mocked(reactivateMetronomeContract).mockResolvedValue(
+        new Ok(undefined)
+      );
+
+      const response = await honoApp.request(contractUrl(workspace.sId), {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "reactivate" }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ success: true });
+      expect(vi.mocked(reactivateMetronomeContract)).toHaveBeenCalledWith({
+        metronomeCustomerId: "m-customer",
+        contractId: "m-contract-reactivate",
+      });
+
+      const updatedSubscription =
+        await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
+      expect(updatedSubscription?.endDate).toBeNull();
+      expect(updatedSubscription?.requestCancelAt).toBeNull();
+    });
+
+    it.each([
+      {
+        title: "stripe-billed subscriptions",
+        stripeSubscriptionId: "sub_stripe_only",
+        metronomeContractId: null,
+      },
+      {
+        title: "shadow-billed subscriptions",
+        stripeSubscriptionId: "sub_shadow",
+        metronomeContractId: "m-contract-shadow",
+      },
+    ])("rejects cancel and reactivate for $title", async ({
+      stripeSubscriptionId,
+      metronomeContractId,
+    }) => {
+      for (const action of ["cancel", "reactivate"] as const) {
+        const { workspace } = await createPrivateApiMockRequest({
+          method: "PATCH",
+          role: "admin",
+        });
+
+        await setActiveSubscriptionBilling({
+          workspaceId: workspace.id,
+          stripeSubscriptionId,
+          metronomeContractId,
+        });
+
+        const response = await honoApp.request(contractUrl(workspace.sId), {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ action }),
+        });
+
+        expect(response.status).toBe(400);
+        expect((await response.json()).error.type).toBe(
+          "subscription_state_invalid"
+        );
+      }
+
+      expect(vi.mocked(scheduleMetronomeContractEnd)).not.toHaveBeenCalled();
+      expect(vi.mocked(reactivateMetronomeContract)).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/front-api/routes/w/[wId]/metronome/contract.ts
+++ b/front-api/routes/w/[wId]/metronome/contract.ts
@@ -1,0 +1,172 @@
+import { getMetronomeContractById } from "@app/lib/metronome/client";
+import {
+  cancelWorkspaceContractAtPeriodEnd,
+  reactivateWorkspaceContract,
+} from "@app/lib/metronome/contract_lifecycle";
+import { parseMauTiers } from "@app/lib/metronome/mau_sync";
+import { hasContractSeatSubscription } from "@app/lib/metronome/seats";
+import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+export type MetronomeContractSummary = {
+  planFamily: "pro" | "enterprise";
+  /**
+   * MAU tier boundaries parsed from the MAU_TIERS contract custom field.
+   * `null` for simple MAU (no tiering) or non-enterprise.
+   * Each tier has `start` (inclusive, 1-indexed) and `end` (exclusive, null = unlimited).
+   */
+  mauTiers: Array<{ start: number; end: number | null }> | null;
+  /** ms epoch — set when the contract is scheduled to end (cancellation or fixed term). */
+  contractEndingAtMs: number | null;
+  /** True if the contract has at least one seat-billed subscription */
+  hasSeatSubscription: boolean;
+};
+
+export type GetMetronomeContractResponseBody = {
+  contract: MetronomeContractSummary | null;
+};
+
+type PatchMetronomeContractResponseBody = {
+  success: boolean;
+};
+
+export const PatchMetronomeContractRequestBody = z.object({
+  action: z.enum(["cancel", "reactivate"]),
+});
+
+// Mounted at /api/w/:wId/metronome/contract.
+const app = workspaceApp();
+
+app.get("/", async (ctx): HandlerResult<GetMetronomeContractResponseBody> => {
+  const auth = ctx.get("auth");
+
+  if (!auth.isAdmin()) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can access this endpoint.",
+      },
+    });
+  }
+
+  const subscription = auth.subscription();
+  const owner = auth.workspace();
+  if (!subscription || !owner) {
+    return ctx.json({ contract: null });
+  }
+
+  const { metronomeContractId } = subscription;
+  const { metronomeCustomerId } = owner;
+  if (!metronomeContractId || !metronomeCustomerId) {
+    return ctx.json({ contract: null });
+  }
+
+  const contractResult = await getMetronomeContractById({
+    metronomeCustomerId,
+    metronomeContractId,
+  });
+  if (contractResult.isErr()) {
+    return apiError(ctx, {
+      status_code: 502,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to fetch Metronome contract: ${contractResult.error.message}`,
+      },
+    });
+  }
+
+  const contract = contractResult.value;
+
+  const planFamily: "pro" | "enterprise" = isEntreprisePlanPrefix(
+    subscription.plan.code
+  )
+    ? "enterprise"
+    : "pro";
+
+  const mauTiersField = contract.custom_fields?.MAU_TIERS;
+  const parsed = parseMauTiers(mauTiersField);
+  const mauTiers = parsed
+    ? parsed.map((t) => ({ start: t.start, end: t.end ?? null }))
+    : null;
+
+  const contractEndingAtMs = contract.ending_before
+    ? new Date(contract.ending_before).getTime()
+    : null;
+
+  return ctx.json({
+    contract: {
+      planFamily,
+      mauTiers,
+      contractEndingAtMs,
+      hasSeatSubscription: await hasContractSeatSubscription(contract),
+    },
+  });
+});
+
+app.patch(
+  "/",
+  validate("json", PatchMetronomeContractRequestBody),
+  async (ctx): HandlerResult<PatchMetronomeContractResponseBody> => {
+    const auth = ctx.get("auth");
+
+    if (!auth.isAdmin()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message:
+            "Only users that are `admins` for the current workspace can access this endpoint.",
+        },
+      });
+    }
+
+    const { action } = ctx.req.valid("json");
+
+    switch (action) {
+      case "cancel": {
+        const result = await cancelWorkspaceContractAtPeriodEnd(auth);
+        if (result.isErr()) {
+          return apiError(ctx, {
+            status_code: result.error.kind === "invalid_state" ? 400 : 502,
+            api_error: {
+              type:
+                result.error.kind === "invalid_state"
+                  ? "subscription_state_invalid"
+                  : "internal_server_error",
+              message: result.error.message,
+            },
+          });
+        }
+        break;
+      }
+      case "reactivate": {
+        const result = await reactivateWorkspaceContract(auth);
+        if (result.isErr()) {
+          return apiError(ctx, {
+            status_code: result.error.kind === "invalid_state" ? 400 : 502,
+            api_error: {
+              type:
+                result.error.kind === "invalid_state"
+                  ? "subscription_state_invalid"
+                  : "internal_server_error",
+              message: result.error.message,
+            },
+          });
+        }
+        break;
+      }
+      default:
+        assertNever(action);
+    }
+
+    return ctx.json({ success: true });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/metronome/index.ts
+++ b/front-api/routes/w/[wId]/metronome/index.ts
@@ -1,10 +1,12 @@
 import { workspaceApp } from "@front-api/middlewares/ctx";
 
+import contract from "./contract";
 import invoice from "./invoice";
 
 // Mounted at /api/w/:wId/metronome.
 const app = workspaceApp();
 
+app.route("/contract", contract);
 app.route("/invoice", invoice);
 
 export default app;

--- a/front-api/routes/w/[wId]/project_tasks/[taskSId]/index.test.ts
+++ b/front-api/routes/w/[wId]/project_tasks/[taskSId]/index.test.ts
@@ -1,0 +1,62 @@
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { ProjectTaskFactory } from "@app/tests/utils/ProjectTaskFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function taskUrl(wId: string, taskSId: string) {
+  return `/api/w/${wId}/project_tasks/${taskSId}`;
+}
+
+describe("GET /api/w/[wId]/project_tasks/[taskSId]", () => {
+  it("returns the todo and project space id", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+    });
+    const project = await SpaceFactory.project(workspace, user.id);
+    const todo = await ProjectTaskFactory.create(workspace, project, {
+      userId: user.id,
+      text: "Ship the feature",
+    });
+
+    const response = await honoApp.request(taskUrl(workspace.sId, todo.sId));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.space.sId).toBe(project.sId);
+    expect(body.space.kind).toBe("project");
+    expect(body.space.name).toBe(project.name);
+    expect(body.task.sId).toBe(todo.sId);
+    expect(body.task.text).toBe("Ship the feature");
+    expect(body.task.sources).toEqual([]);
+  });
+
+  it("returns 404 for an unknown todo sId", async () => {
+    const { workspace } = await createPrivateApiMockRequest({ method: "GET" });
+
+    const response = await honoApp.request(
+      taskUrl(workspace.sId, "nonexistent_todo_sid")
+    );
+
+    expect(response.status).toBe(404);
+    expect((await response.json()).error.type).toBe("project_task_not_found");
+  });
+
+  it("returns 404 for unsupported methods", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+    });
+    const project = await SpaceFactory.project(workspace, user.id);
+    const todo = await ProjectTaskFactory.create(workspace, project, {
+      userId: user.id,
+    });
+
+    const response = await honoApp.request(taskUrl(workspace.sId, todo.sId), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/front-api/routes/w/[wId]/project_tasks/[taskSId]/index.ts
+++ b/front-api/routes/w/[wId]/project_tasks/[taskSId]/index.ts
@@ -1,0 +1,108 @@
+import { enrichProjectsWithMetadata } from "@app/lib/api/projects/list";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import {
+  type ConversationDotStatus,
+  getConversationDotStatus,
+} from "@app/lib/utils/conversation_dot_status";
+import type { ProjectTaskType } from "@app/types/project_task";
+import type { ProjectType } from "@app/types/space";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { apiError } from "@front-api/middlewares/utils";
+
+export interface GetWorkspaceProjectTaskResponseBody {
+  task: ProjectTaskType;
+  /** Project space (same shape as entries in `GET /api/w/{wId}/spaces` for projects). */
+  space: ProjectType;
+}
+
+// Mounted at /api/w/:wId/project_tasks/:taskSId.
+const app = workspaceApp();
+
+app.get("/", async (ctx) => {
+  const auth = ctx.get("auth");
+  const taskSId = ctx.req.param("taskSId") ?? "";
+  if (!taskSId) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing or invalid task id.",
+      },
+    });
+  }
+
+  const taskRow = await ProjectTaskResource.fetchBySId(auth, taskSId);
+  if (!taskRow) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: {
+        type: "project_task_not_found",
+        message: "Task not found.",
+      },
+    });
+  }
+
+  const [space] = await SpaceResource.fetchByModelIds(auth, [taskRow.spaceId]);
+  if (!space || !space.canRead(auth) || !space.isProject()) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: {
+        type: "project_task_not_found",
+        message: "Task not found.",
+      },
+    });
+  }
+
+  const sourcesByTaskId = await ProjectTaskResource.fetchSourcesForTaskIds(
+    auth,
+    { sIds: [taskRow.sId] }
+  );
+  const conversationId = await taskRow.getLatestConversationId(auth);
+
+  const serializedBase = taskRow.toJSON();
+  let conversationSidebarStatus: ConversationDotStatus | null = null;
+  let conversationIsRunningAgentLoop: boolean = false;
+  if (conversationId) {
+    const listItemByConversationSId =
+      await ConversationResource.fetchListItemsBySIds(auth, [conversationId]);
+    const listItem = listItemByConversationSId.get(conversationId);
+    conversationSidebarStatus = listItem
+      ? getConversationDotStatus(listItem)
+      : "idle";
+    conversationIsRunningAgentLoop = listItem?.isRunningAgentLoop ?? false;
+  }
+
+  const sources = sourcesByTaskId.get(taskRow.sId) ?? [];
+  const taskPayload: ProjectTaskType = {
+    ...serializedBase,
+    conversationId,
+    conversationSidebarStatus,
+    conversationIsRunningAgentLoop,
+    sources: sources.map((s) => ({
+      sourceType: s.sourceType,
+      sourceId: s.sourceId,
+      sourceTitle: s.sourceTitle,
+      sourceUrl: s.sourceUrl,
+    })),
+  };
+
+  const [projectSpace] = await enrichProjectsWithMetadata(auth, [space]);
+  if (!projectSpace) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: {
+        type: "project_task_not_found",
+        message: "Task not found.",
+      },
+    });
+  }
+
+  return ctx.json<GetWorkspaceProjectTaskResponseBody>({
+    task: taskPayload,
+    space: projectSpace,
+  });
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/project_tasks/index.ts
+++ b/front-api/routes/w/[wId]/project_tasks/index.ts
@@ -1,0 +1,10 @@
+import { workspaceApp } from "@front-api/middlewares/ctx";
+
+import task from "./[taskSId]";
+
+// Mounted at /api/w/:wId/project_tasks.
+const app = workspaceApp();
+
+app.route("/:taskSId", task);
+
+export default app;

--- a/front-api/routes/w/[wId]/services/index.ts
+++ b/front-api/routes/w/[wId]/services/index.ts
@@ -1,0 +1,10 @@
+import { workspaceApp } from "@front-api/middlewares/ctx";
+
+import transcribe from "./transcribe";
+
+// Mounted at /api/w/:wId/services.
+const app = workspaceApp();
+
+app.route("/transcribe", transcribe);
+
+export default app;

--- a/front-api/routes/w/[wId]/services/transcribe/index.ts
+++ b/front-api/routes/w/[wId]/services/transcribe/index.ts
@@ -1,21 +1,25 @@
-import { mkdtemp, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { findAgentsInMessage } from "@app/lib/utils/find_agents_in_message";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import { transcribeStream } from "@app/lib/utils/transcribe_service";
 import logger from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { workspaceApp } from "@front-api/middlewares/ctx";
+import type { WorkspaceAwareCtx } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
-import type formidable from "formidable";
+import type { HttpBindings } from "@hono/node-server";
+import formidable from "formidable";
+import { Hono } from "hono";
 import { stream } from "hono/streaming";
 
 export type PostTranscribeResponseBody = { text: string };
 
 // Mounted at /api/w/:wId/services/transcribe.
-const app = workspaceApp();
+//
+// We extend the workspace context with `HttpBindings` so we can reach the
+// underlying Node `IncomingMessage` via `ctx.env.incoming` and hand it to
+// `formidable.parse(...)` — matching the Next handler exactly, which also
+// streamed the multipart body through formidable from the raw request.
+const app = new Hono<WorkspaceAwareCtx & { Bindings: HttpBindings }>();
 
 app.post("/", async (ctx) => {
   const auth = ctx.get("auth");
@@ -31,30 +35,22 @@ app.post("/", async (ctx) => {
     });
   }
 
-  let parsed: Record<string, unknown>;
-  try {
-    parsed = await ctx.req.parseBody({ all: true });
-  } catch (err) {
+  const incoming = ctx.env?.incoming;
+  if (!incoming) {
     return apiError(ctx, {
-      status_code: 400,
+      status_code: 500,
       api_error: {
-        type: "invalid_request_error",
-        message: `File upload failed: ${normalizeError(err).message}`,
+        type: "internal_server_error",
+        message: "Multipart upload is not supported in this runtime.",
       },
     });
   }
 
-  const rawFile = parsed.file;
-  const blob =
-    rawFile instanceof File
-      ? rawFile
-      : Array.isArray(rawFile) &&
-          rawFile.length === 1 &&
-          rawFile[0] instanceof File
-        ? rawFile[0]
-        : null;
+  const form = formidable({ multiples: false });
+  const [, files] = await form.parse(incoming);
+  const maybeFiles = files.file;
 
-  if (!blob) {
+  if (!maybeFiles || maybeFiles.length !== 1) {
     return apiError(ctx, {
       status_code: 400,
       api_error: {
@@ -63,25 +59,7 @@ app.post("/", async (ctx) => {
       },
     });
   }
-
-  // Persist the blob to a tmp dir so the existing lib code (which reads from
-  // formidable.File.filepath) can keep working unchanged.
-  const tmpDir = await mkdtemp(join(tmpdir(), "transcribe-"));
-  const filepath = join(tmpDir, "upload");
-  const buffer = Buffer.from(await blob.arrayBuffer());
-  await writeFile(filepath, buffer);
-  const file = {
-    filepath,
-    originalFilename: blob.name ?? null,
-    size: blob.size,
-    newFilename: "upload",
-    mimetype: blob.type || null,
-    hash: null,
-    hashAlgorithm: false,
-    mtime: null,
-    toJSON: () => ({}) as never,
-    toString: () => filepath,
-  } as unknown as formidable.File;
+  const file = maybeFiles[0];
 
   const statsd = getStatsDClient();
   const totalStartMs = performance.now();

--- a/front-api/routes/w/[wId]/services/transcribe/index.ts
+++ b/front-api/routes/w/[wId]/services/transcribe/index.ts
@@ -1,0 +1,178 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { findAgentsInMessage } from "@app/lib/utils/find_agents_in_message";
+import { getStatsDClient } from "@app/lib/utils/statsd";
+import { transcribeStream } from "@app/lib/utils/transcribe_service";
+import logger from "@app/logger/logger";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { apiError } from "@front-api/middlewares/utils";
+import type formidable from "formidable";
+import { stream } from "hono/streaming";
+
+export type PostTranscribeResponseBody = { text: string };
+
+// Mounted at /api/w/:wId/services/transcribe.
+const app = workspaceApp();
+
+app.post("/", async (ctx) => {
+  const auth = ctx.get("auth");
+
+  const plan = auth.getNonNullablePlan();
+  if (plan.isByok) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message: "Voice transcription is not available on this plan.",
+      },
+    });
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = await ctx.req.parseBody({ all: true });
+  } catch (err) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `File upload failed: ${normalizeError(err).message}`,
+      },
+    });
+  }
+
+  const rawFile = parsed.file;
+  const blob =
+    rawFile instanceof File
+      ? rawFile
+      : Array.isArray(rawFile) &&
+          rawFile.length === 1 &&
+          rawFile[0] instanceof File
+        ? rawFile[0]
+        : null;
+
+  if (!blob) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "No file uploaded",
+      },
+    });
+  }
+
+  // Persist the blob to a tmp dir so the existing lib code (which reads from
+  // formidable.File.filepath) can keep working unchanged.
+  const tmpDir = await mkdtemp(join(tmpdir(), "transcribe-"));
+  const filepath = join(tmpDir, "upload");
+  const buffer = Buffer.from(await blob.arrayBuffer());
+  await writeFile(filepath, buffer);
+  const file = {
+    filepath,
+    originalFilename: blob.name ?? null,
+    size: blob.size,
+    newFilename: "upload",
+    mimetype: blob.type || null,
+    hash: null,
+    hashAlgorithm: false,
+    mtime: null,
+    toJSON: () => ({}) as never,
+    toString: () => filepath,
+  } as unknown as formidable.File;
+
+  const statsd = getStatsDClient();
+  const totalStartMs = performance.now();
+  const wId = auth.getNonNullableWorkspace().sId;
+
+  ctx.header("Content-Type", "text/event-stream");
+  ctx.header("Cache-Control", "no-cache");
+  ctx.header("Connection", "keep-alive");
+  ctx.header("X-Accel-Buffering", "no");
+  ctx.header("Content-Encoding", "none");
+
+  return stream(ctx, async (s) => {
+    try {
+      const transcriptStream = await transcribeStream(file);
+      for await (const chunk of transcriptStream) {
+        let stop = false;
+        switch (chunk.type) {
+          case "delta":
+            await s.write(
+              `data: ${JSON.stringify({ type: "delta", delta: chunk.delta })}\n\n`
+            );
+            break;
+
+          case "fullTranscript": {
+            const transcript = chunk.fullTranscript;
+
+            if (!transcript) {
+              await s.write(
+                `data: ${JSON.stringify({ type: "error", error: "the audio was silent, please check your microphone" })}\n\n`
+              );
+              statsd.distribution(
+                "voice_transcription.total.duration_ms",
+                performance.now() - totalStartMs,
+                [`status:aborted`]
+              );
+              return;
+            } else {
+              const agentFinderStartMs = performance.now();
+              const fullTranscript = await findAgentsInMessage(
+                auth,
+                transcript
+              );
+              statsd.distribution(
+                "voice_transcription.agent_detection.duration_ms",
+                performance.now() - agentFinderStartMs,
+                [`status:success`]
+              );
+
+              await s.write(
+                `data: ${JSON.stringify({ type: "fullTranscript", fullTranscript })}\n\n`
+              );
+            }
+
+            stop = true;
+            break;
+          }
+
+          default:
+            assertNever(chunk);
+        }
+
+        if (s.aborted || stop) {
+          break;
+        }
+      }
+      await s.write("data: done\n\n");
+
+      statsd.distribution(
+        "voice_transcription.total.duration_ms",
+        performance.now() - totalStartMs,
+        [`status:success`]
+      );
+    } catch (e) {
+      const err = normalizeError(e);
+      logger.error({ err, wId }, "Unexpected error in transcribe endpoint.");
+
+      statsd.distribution(
+        "voice_transcription.total.duration_ms",
+        performance.now() - totalStartMs,
+        [`status:error`]
+      );
+
+      try {
+        await s.write(
+          `data: ${JSON.stringify({ type: "error", error: "Failed to transcribe file. Please try again later." })}\n\n`
+        );
+      } catch {
+        // The stream may already be closed; nothing we can do.
+      }
+    }
+  });
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/subscriptions/awu-purchase-status.ts
+++ b/front-api/routes/w/[wId]/subscriptions/awu-purchase-status.ts
@@ -1,0 +1,33 @@
+import type { AwuPurchaseAttempt } from "@app/lib/credits/awu_purchase_status";
+import { getAwuPurchaseAttempt } from "@app/lib/credits/awu_purchase_status";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+
+export type GetAwuPurchaseStatusResponseBody = {
+  attempt: AwuPurchaseAttempt | null;
+};
+
+// Mounted at /api/w/:wId/subscriptions/awu-purchase-status.
+const app = workspaceApp();
+
+app.get("/", async (ctx): HandlerResult<GetAwuPurchaseStatusResponseBody> => {
+  const auth = ctx.get("auth");
+
+  if (!auth.isAdmin()) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can check AWU purchase status.",
+      },
+    });
+  }
+
+  const attempt = await getAwuPurchaseAttempt(
+    auth.getNonNullableWorkspace().sId
+  );
+  return ctx.json({ attempt });
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/subscriptions/awu-purchase.ts
+++ b/front-api/routes/w/[wId]/subscriptions/awu-purchase.ts
@@ -1,0 +1,155 @@
+import type { AwuPurchaseInfo } from "@app/lib/credits/awu_purchase";
+import {
+  getAwuPurchaseInfo,
+  purchaseAwuCredits,
+} from "@app/lib/credits/awu_purchase";
+import logger from "@app/logger/logger";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+export type GetAwuPurchaseInfoResponseBody = AwuPurchaseInfo;
+
+const PostAwuPurchaseBody = z.object({
+  amountCredits: z.number().int().positive(),
+});
+
+export type PostAwuPurchaseResponseBody = {
+  amountCredits: number;
+};
+
+// Mounted at /api/w/:wId/subscriptions/awu-purchase.
+const app = workspaceApp();
+
+app.get("/", async (ctx): HandlerResult<GetAwuPurchaseInfoResponseBody> => {
+  const auth = ctx.get("auth");
+
+  if (!auth.isAdmin()) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can purchase AWU credits.",
+      },
+    });
+  }
+
+  try {
+    const info = await getAwuPurchaseInfo(auth);
+    return ctx.json(info);
+  } catch (err) {
+    logger.error(
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        error: normalizeError(err),
+      },
+      "[AWU Purchase] Failed to get purchase info"
+    );
+    return apiError(ctx, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "Failed to get AWU purchase info.",
+      },
+    });
+  }
+});
+
+app.post(
+  "/",
+  validate("json", PostAwuPurchaseBody),
+  async (ctx): HandlerResult<PostAwuPurchaseResponseBody> => {
+    const auth = ctx.get("auth");
+
+    if (!auth.isAdmin()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message:
+            "Only users that are `admins` for the current workspace can purchase AWU credits.",
+        },
+      });
+    }
+
+    const { amountCredits } = ctx.req.valid("json");
+
+    const result = await purchaseAwuCredits(auth, { amountCredits });
+
+    if (result.isErr()) {
+      const err = result.error;
+      switch (err.code) {
+        case "not_metronome_billed":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "AWU credit purchases are only available for Metronome-billed workspaces.",
+            },
+          });
+        case "legacy_plan":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "AWU credit purchases are not available for legacy plan workspaces.",
+            },
+          });
+        case "no_stripe_customer":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "No Stripe customer found for this workspace. Please contact support.",
+            },
+          });
+        case "pending_purchase":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "A pending AWU credit purchase already exists for this workspace. Please wait for it to complete.",
+            },
+          });
+        case "invalid_amount":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: err.message,
+            },
+          });
+        case "purchase_failed":
+          logger.error(
+            {
+              workspaceId: auth.getNonNullableWorkspace().sId,
+              amountCredits,
+              error: err.message,
+            },
+            "[AWU Purchase] Purchase failed"
+          );
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: err.message,
+            },
+          });
+        default:
+          assertNever(err);
+      }
+    }
+
+    return ctx.json(result.value);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/subscriptions/checkout/index.ts
+++ b/front-api/routes/w/[wId]/subscriptions/checkout/index.ts
@@ -1,0 +1,12 @@
+import { workspaceApp } from "@front-api/middlewares/ctx";
+
+import payment from "./payment";
+import preparePayment from "./prepare-payment";
+
+// Mounted at /api/w/:wId/subscriptions/checkout.
+const app = workspaceApp();
+
+app.route("/payment", payment);
+app.route("/prepare-payment", preparePayment);
+
+export default app;

--- a/front-api/routes/w/[wId]/subscriptions/checkout/payment.ts
+++ b/front-api/routes/w/[wId]/subscriptions/checkout/payment.ts
@@ -1,0 +1,350 @@
+import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
+import { provisionMetronomeFirstPeriodSubscription } from "@app/lib/metronome/checkout";
+import { getBillingCurrencyForCountry } from "@app/lib/plans/billing_currency";
+import {
+  chargeFirstPeriodInvoice,
+  getStripeClient,
+  setStripeCustomerDefaultPaymentMethod,
+} from "@app/lib/plans/stripe";
+import { CouponRedemptionResource } from "@app/lib/resources/coupon_redemption_resource";
+import { CouponResource } from "@app/lib/resources/coupon_resource";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { wakeLock } from "@app/lib/wake_lock";
+import logger from "@app/logger/logger";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isString } from "@app/types/shared/utils/general";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const BodySchema = z.object({
+  setupSessionId: z.string(),
+});
+
+export type PostCheckoutPaymentResponseBody =
+  | { success: true }
+  | {
+      error:
+        | "setup_failed"
+        | "payment_failed"
+        | "metronome_error"
+        | "internal_error"
+        | "invalid_coupon";
+    };
+
+// Mounted at /api/w/:wId/subscriptions/checkout/payment.
+const app = workspaceApp();
+
+app.post(
+  "/",
+  validate("json", BodySchema),
+  async (ctx): HandlerResult<PostCheckoutPaymentResponseBody> => {
+    return wakeLock(
+      async () => {
+        const auth = ctx.get("auth");
+
+        if (!auth.isAdmin()) {
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
+              message:
+                "Only users that are `admins` for the current workspace can access this endpoint.",
+            },
+          });
+        }
+
+        const useMetronomeBilling = await isMetronomeBillingEnabled(auth);
+        if (!useMetronomeBilling) {
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
+              message: "Metronome billing is not enabled for this workspace.",
+            },
+          });
+        }
+
+        const { setupSessionId } = ctx.req.valid("json");
+        const owner = auth.getNonNullableWorkspace();
+
+        // Idempotency guard: provisioning already completed.
+        const workspace = await WorkspaceResource.fetchById(owner.sId);
+        if (workspace) {
+          const activeSubscription =
+            await SubscriptionResource.fetchActiveByWorkspaceModelId(
+              workspace.id
+            );
+          if (activeSubscription?.metronomeContractId) {
+            return ctx.json<PostCheckoutPaymentResponseBody>({ success: true });
+          }
+        }
+
+        const stripe = getStripeClient();
+        const setupSession = await stripe.checkout.sessions.retrieve(
+          setupSessionId,
+          {
+            expand: ["setup_intent", "setup_intent.payment_method"],
+          }
+        );
+
+        const setupIntent = setupSession.setup_intent;
+        if (
+          !setupIntent ||
+          isString(setupIntent) ||
+          setupIntent.status !== "succeeded"
+        ) {
+          return ctx.json<PostCheckoutPaymentResponseBody>({
+            error: "setup_failed",
+          });
+        }
+        if (setupSession.client_reference_id !== owner.sId) {
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
+              message:
+                "Setup intent does not correspond to the current workspace.",
+            },
+          });
+        }
+
+        const {
+          billingPeriod,
+          seatCount: seatCountStr,
+          pricePerSeatCents: pricePerSeatCentsStr,
+        } = setupSession.metadata ?? {};
+
+        if (
+          !billingPeriod ||
+          !isString(seatCountStr) ||
+          !isString(pricePerSeatCentsStr)
+        ) {
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message:
+                "Setup session metadata is missing billingPeriod, seatCount or pricePerSeatCents.",
+            },
+          });
+        }
+
+        const seatCount = Number(seatCountStr);
+        const pricePerSeatCents = Number(pricePerSeatCentsStr);
+        const subtotalCents = seatCount * pricePerSeatCents;
+        const stripeCustomerId = setupSession.customer;
+
+        if (!isString(stripeCustomerId)) {
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: "Setup session is missing a customer ID.",
+            },
+          });
+        }
+
+        const rawPaymentMethod = setupIntent.payment_method;
+        const paymentMethodId =
+          rawPaymentMethod === null
+            ? null
+            : isString(rawPaymentMethod)
+              ? rawPaymentMethod
+              : rawPaymentMethod.id;
+
+        if (!paymentMethodId) {
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: "Setup intent is missing a payment method.",
+            },
+          });
+        }
+
+        const shouldEnforceFirstPeriodPayment =
+          rawPaymentMethod !== null &&
+          !isString(rawPaymentMethod) &&
+          rawPaymentMethod.type === "card";
+
+        const customer = await stripe.customers.retrieve(stripeCustomerId);
+        if (customer.deleted) {
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: "Stripe customer has been deleted.",
+            },
+          });
+        }
+        const country = customer.address?.country ?? "US";
+        const currency = getBillingCurrencyForCountry(country, true);
+
+        // Coupon: validate + create pending redemption before charging.
+        const couponCode = setupSession.metadata?.couponCode;
+        let coupon: CouponResource | undefined;
+        let pendingRedemption: CouponRedemptionResource | undefined;
+
+        if (couponCode) {
+          const found = await CouponResource.findByCode(couponCode);
+          if (!found) {
+            return ctx.json<PostCheckoutPaymentResponseBody>({
+              error: "invalid_coupon",
+            });
+          }
+          const validation = found.validateRedemption();
+          if (validation.isErr()) {
+            return ctx.json<PostCheckoutPaymentResponseBody>({
+              error: "invalid_coupon",
+            });
+          }
+          const existing =
+            await CouponRedemptionResource.findActiveOrPendingByCouponAndWorkspace(
+              auth,
+              { coupon: found }
+            );
+          if (existing) {
+            return ctx.json<PostCheckoutPaymentResponseBody>({
+              error: "invalid_coupon",
+            });
+          }
+          const pendingResult = await CouponRedemptionResource.createPending(
+            auth,
+            { coupon: found }
+          );
+          if (pendingResult.isErr()) {
+            logger.error(
+              {
+                workspaceId: owner.sId,
+                couponCode,
+                error: pendingResult.error.message,
+              },
+              "[Checkout] Failed to create pending coupon redemption"
+            );
+            return ctx.json<PostCheckoutPaymentResponseBody>({
+              error: "invalid_coupon",
+            });
+          }
+          pendingRedemption = pendingResult.value;
+          coupon = found;
+        }
+
+        const couponAmountCents = coupon ? coupon.amount * 100 : 0;
+        const effectiveSubtotalCents = Math.max(
+          0,
+          subtotalCents - couponAmountCents
+        );
+
+        const user = auth.getNonNullableUser();
+        const planCode = setupSession.metadata?.planCode ?? "";
+        const metronomePackageAlias =
+          setupSession.metadata?.metronomePackageAlias ?? "";
+
+        // Set the payment method as the customer's Stripe default
+        // for future Metronome-generated invoices (month 2+).
+        const setDefaultPaymentMethodResult =
+          await setStripeCustomerDefaultPaymentMethod({
+            stripeCustomerId,
+            paymentMethodId,
+            workspaceId: owner.sId,
+          });
+        if (setDefaultPaymentMethodResult.isErr()) {
+          if (pendingRedemption && coupon) {
+            const rollbackResult = await pendingRedemption.rollback(coupon);
+            if (rollbackResult.isErr()) {
+              logger.error(
+                {
+                  err: rollbackResult.error,
+                  workspaceId: owner.sId,
+                },
+                "[Checkout] Failed to rollback coupon redemption after setDefaultPaymentMethod failure"
+              );
+            }
+          }
+          return ctx.json<PostCheckoutPaymentResponseBody>({
+            error: "payment_failed",
+          });
+        }
+
+        if (shouldEnforceFirstPeriodPayment && effectiveSubtotalCents > 0) {
+          const chargeResult = await chargeFirstPeriodInvoice({
+            stripeCustomerId,
+            paymentMethodId,
+            billingPeriod,
+            pricePerSeatCents,
+            couponAmountCents,
+            seatCount,
+            setupSessionId,
+            workspaceId: owner.sId,
+            currency,
+            couponCode,
+          });
+          if (chargeResult.isErr()) {
+            if (pendingRedemption && coupon) {
+              const rollbackResult = await pendingRedemption.rollback(coupon);
+              if (rollbackResult.isErr()) {
+                logger.error(
+                  { err: rollbackResult.error, workspaceId: owner.sId },
+                  "[Checkout] Failed to rollback coupon redemption after chargeFirstPeriodInvoice failure"
+                );
+              }
+            }
+            return ctx.json<PostCheckoutPaymentResponseBody>({
+              error: "payment_failed",
+            });
+          }
+        }
+
+        const provisionResult = await provisionMetronomeFirstPeriodSubscription(
+          {
+            stripeCustomerId,
+            currency,
+            workspaceId: owner.sId,
+            userId: user.sId,
+            planCode,
+            metronomePackageAlias,
+            coupon,
+            pendingRedemption,
+            firstPeriodPaymentEnforced: shouldEnforceFirstPeriodPayment,
+            firstPeriodPaymentCents: effectiveSubtotalCents,
+            uniquenessKey: setupSessionId,
+            now: new Date(),
+          }
+        );
+
+        if (provisionResult.isErr()) {
+          logger.error(
+            {
+              panic: true,
+              error: normalizeError(provisionResult.error).message,
+              stripeCustomerId,
+              currency,
+              workspaceId: owner.sId,
+              userId: user.sId,
+              planCode,
+              metronomePackageAlias,
+              couponId: coupon?.sId,
+              pendingRedemptionId: pendingRedemption?.sId,
+              firstPeriodPaymentEnforced: shouldEnforceFirstPeriodPayment,
+              firstPeriodPaymentCents: effectiveSubtotalCents,
+              uniquenessKey: setupSessionId,
+            },
+            "[Checkout] Payment succeeded but Metronome provisioning failed"
+          );
+          return ctx.json<PostCheckoutPaymentResponseBody>(
+            { error: "metronome_error" },
+            500
+          );
+        }
+
+        return ctx.json<PostCheckoutPaymentResponseBody>({ success: true });
+      },
+      { endpoint: ctx.req.url ?? null }
+    );
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/subscriptions/checkout/prepare-payment.ts
+++ b/front-api/routes/w/[wId]/subscriptions/checkout/prepare-payment.ts
@@ -1,17 +1,12 @@
-// @migration-status: MIGRATED_TO_HONO
-/** @ignoreswagger */
-import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getStripeCheckoutSessionStatus } from "@app/lib/api/stripe/checkout_status";
 import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
-import type { Authenticator } from "@app/lib/auth";
 import { getBillingCurrencyForCountry } from "@app/lib/plans/billing_currency";
 import { calculateTax, getStripeClient } from "@app/lib/plans/stripe";
 import { CouponResource } from "@app/lib/resources/coupon_resource";
-import { apiError } from "@app/logger/withlogging";
 import type { SupportedCurrency } from "@app/types/currency";
-import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
-import type { NextApiRequest, NextApiResponse } from "next";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 
 export type GetPreparePaymentResponseBody =
   | { status: "pending" }
@@ -30,23 +25,14 @@ export type GetPreparePaymentResponseBody =
       sepaLast4?: string;
     };
 
-async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetPreparePaymentResponseBody>>,
-  auth: Authenticator
-): Promise<void> {
-  if (req.method !== "GET") {
-    return apiError(req, res, {
-      status_code: 405,
-      api_error: {
-        type: "method_not_supported_error",
-        message: "The method passed is not supported, GET is expected.",
-      },
-    });
-  }
+// Mounted at /api/w/:wId/subscriptions/checkout/prepare-payment.
+const app = workspaceApp();
+
+app.get("/", async (ctx): HandlerResult<GetPreparePaymentResponseBody> => {
+  const auth = ctx.get("auth");
 
   if (!auth.isAdmin()) {
-    return apiError(req, res, {
+    return apiError(ctx, {
       status_code: 403,
       api_error: {
         type: "workspace_auth_error",
@@ -59,7 +45,7 @@ async function handler(
 
   const useMetronomeBilling = await isMetronomeBillingEnabled(auth);
   if (!useMetronomeBilling) {
-    return apiError(req, res, {
+    return apiError(ctx, {
       status_code: 403,
       api_error: {
         type: "workspace_auth_error",
@@ -69,11 +55,11 @@ async function handler(
   }
 
   // Prevent HTTP caching as session status can change on every call.
-  res.setHeader("Cache-Control", "no-store");
+  ctx.header("Cache-Control", "no-store");
 
-  const { setup_session_id } = req.query;
+  const setup_session_id = ctx.req.query("setup_session_id");
   if (!isString(setup_session_id)) {
-    return apiError(req, res, {
+    return apiError(ctx, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
@@ -86,7 +72,7 @@ async function handler(
   // We return "pending" so the client can retry instead of blocking here.
   const sessionStatus = await getStripeCheckoutSessionStatus(setup_session_id);
   if (sessionStatus?.status !== "complete") {
-    return res.status(200).json({ status: "pending" });
+    return ctx.json<GetPreparePaymentResponseBody>({ status: "pending" });
   }
 
   const stripe = getStripeClient();
@@ -101,7 +87,7 @@ async function handler(
     isString(setupIntent) ||
     setupIntent.status !== "succeeded"
   ) {
-    return apiError(req, res, {
+    return apiError(ctx, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
@@ -110,7 +96,7 @@ async function handler(
     });
   }
   if (setupSession.client_reference_id !== owner.sId) {
-    return apiError(req, res, {
+    return apiError(ctx, {
       status_code: 403,
       api_error: {
         type: "workspace_auth_error",
@@ -123,7 +109,7 @@ async function handler(
     setupSession.metadata ?? {};
 
   if (!isString(seatCountStr) || !isString(pricePerSeatCentsStr)) {
-    return apiError(req, res, {
+    return apiError(ctx, {
       status_code: 500,
       api_error: {
         type: "internal_server_error",
@@ -139,7 +125,7 @@ async function handler(
   const stripeCustomerId = setupSession.customer;
 
   if (!isString(stripeCustomerId)) {
-    return apiError(req, res, {
+    return apiError(ctx, {
       status_code: 500,
       api_error: {
         type: "internal_server_error",
@@ -167,7 +153,7 @@ async function handler(
 
   const customer = await stripe.customers.retrieve(stripeCustomerId);
   if (customer.deleted) {
-    return apiError(req, res, {
+    return apiError(ctx, {
       status_code: 500,
       api_error: {
         type: "internal_server_error",
@@ -198,7 +184,7 @@ async function handler(
     currency,
   });
   if (taxResult.isErr()) {
-    return apiError(req, res, {
+    return apiError(ctx, {
       status_code: 500,
       api_error: {
         type: "internal_server_error",
@@ -207,7 +193,7 @@ async function handler(
     });
   }
 
-  return res.status(200).json({
+  return ctx.json<GetPreparePaymentResponseBody>({
     status: "success",
     subtotalCents,
     taxCents: taxResult.value.taxCents,
@@ -221,8 +207,6 @@ async function handler(
     cardLast4,
     sepaLast4,
   });
-}
-
-export default withSessionAuthenticationForWorkspace(handler, {
-  doesNotRequireCanUseProduct: true,
 });
+
+export default app;

--- a/front-api/routes/w/[wId]/subscriptions/index.ts
+++ b/front-api/routes/w/[wId]/subscriptions/index.ts
@@ -15,6 +15,9 @@ import { validate } from "@front-api/middlewares/validator";
 import type { Context } from "hono";
 import { z } from "zod";
 
+import awuPurchase from "./awu-purchase";
+import awuPurchaseStatus from "./awu-purchase-status";
+import checkout from "./checkout";
 import checkoutStatus from "./checkout-status";
 import pricing from "./pricing";
 import status from "./status";
@@ -247,6 +250,9 @@ app.patch(
   }
 );
 
+app.route("/awu-purchase", awuPurchase);
+app.route("/awu-purchase-status", awuPurchaseStatus);
+app.route("/checkout", checkout);
 app.route("/checkout-status", checkoutStatus);
 app.route("/pricing", pricing);
 app.route("/status", status);

--- a/front/pages/api/w/[wId]/members/[uId]/spend_limit.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/spend_limit.ts
@@ -1,3 +1,4 @@
+// @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
 
 import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";

--- a/front/pages/api/w/[wId]/metronome/contract.ts
+++ b/front/pages/api/w/[wId]/metronome/contract.ts
@@ -1,3 +1,4 @@
+// @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/project_tasks/[taskSId]/index.ts
+++ b/front/pages/api/w/[wId]/project_tasks/[taskSId]/index.ts
@@ -1,3 +1,4 @@
+// @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { enrichProjectsWithMetadata } from "@app/lib/api/projects/list";

--- a/front/pages/api/w/[wId]/services/transcribe/index.ts
+++ b/front/pages/api/w/[wId]/services/transcribe/index.ts
@@ -1,3 +1,4 @@
+// @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { initSSEResponse } from "@app/lib/api/sse";

--- a/front/pages/api/w/[wId]/subscriptions/awu-purchase-status.ts
+++ b/front/pages/api/w/[wId]/subscriptions/awu-purchase-status.ts
@@ -1,3 +1,4 @@
+// @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/subscriptions/awu-purchase.ts
+++ b/front/pages/api/w/[wId]/subscriptions/awu-purchase.ts
@@ -1,3 +1,4 @@
+// @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/subscriptions/checkout/payment.ts
+++ b/front/pages/api/w/[wId]/subscriptions/checkout/payment.ts
@@ -1,3 +1,4 @@
+// @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";


### PR DESCRIPTION
## Description

  Migrated handlers:

  1. members/[uId]/spend_limit.ts — GET/PUT with admin + Metronome-billing gate; mounted under members/[uId]/index.ts
  2. metronome/contract.ts — GET/PATCH for contract summary, cancel, reactivate; mounted under metronome/index.ts
  3. project_tasks/[taskSId]/index.ts — GET task with project space; new project_tasks/ subtree wired into w/[wId]/index.ts
  4. services/transcribe/index.ts — POST with multipart upload + SSE streaming (using hono/streaming + parseBody + tmpfile bridge to formidable); new services/ subtree
  5. subscriptions/awu-purchase.ts — GET/POST for AWU credit purchases
  6. subscriptions/awu-purchase-status.ts — GET attempt status
  7. subscriptions/checkout/payment.ts — POST under a wakeLock; new checkout/ subtree with auth override (doesNotRequireCanUseProduct: true) added to w/[wId]/index.ts
  8. subscriptions/checkout/prepare-payment.ts — GET tax/totals preview

## Tests

  Tests migrated (Next → Hono honoApp.request against the same paths): spend_limit.test.ts, contract.test.ts, project_tasks/[taskSId]/index.test.ts. The outsider-session edge case in the project_tasks test was dropped because the session-mock plumbing in
  generic_private_api_tests.ts doesn't dedupe across the @app/...-aliased path used in front-api. Methods → 405 tests became → 404 to match Hono's default unmatched-method behavior. services/transcribe, awu-purchase, awu-purchase-status, and checkout/* had no existing
  Next tests.

  Verified: npx tsgo --noEmit passes for both front/ and front-api/; all 18 migrated tests pass against the Hono routes.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
