### PR TITLE
Fix icons and copy as well as polish mobile navigation.

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -2,6 +2,7 @@ import { useBlockedActionsContext } from "@app/components/assistant/conversation
 import { ContextUsageWarningBanner } from "@app/components/assistant/conversation/ContextUsageWarningBanner";
 import { useGenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
+import { InputBarMessageNavigation } from "@app/components/assistant/conversation/input_bar/InputBarMessageNavigation";
 import type {
   VirtuosoMessage,
   VirtuosoMessageListContext,
@@ -33,16 +34,10 @@ import {
 } from "@app/types/assistant/mentions";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import {
-  ArrowDownIcon,
-  ArrowUpIcon,
-  BoltIcon,
-  Button,
   ContentMessageAction,
   ContentMessageInline,
   EmptyCTA,
-  IconButton,
   InformationCircleIcon,
-  StopIcon,
 } from "@dust-tt/sparkle";
 import {
   useVirtuosoLocation,
@@ -91,6 +86,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
   const methods = useVirtuosoMethods<VirtuosoMessage>();
   const { bottomOffset, listOffset, visibleListHeight } = useVirtuosoLocation();
   const [isInputBarExpanded, setIsInputBarExpanded] = useState(true);
+  const [isEditorFocused, setIsEditorFocused] = useState(false);
   const prevListOffsetRef = useRef<number | null>(null);
 
   useEffect(() => {
@@ -107,6 +103,7 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
 
   const isInputBarCompact =
     isMobile && !agentBuilderContext && !isInputBarExpanded;
+  const effectiveIsCompact = isInputBarCompact && !isEditorFocused;
 
   const allMessages = methods.data.get();
 
@@ -458,6 +455,27 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
     void mutateConversation();
   };
 
+  const handleStopClick = () => {
+    if (hasPendingMessages) {
+      void handleAction("interrupt");
+    } else {
+      void handleAction("cancel");
+    }
+  };
+
+  const messageNavigationProps = {
+    showStopButton,
+    showMessageNavigation,
+    stopButtonLabel: getStopButtonLabel(),
+    hasPendingMessages,
+    pendingAction,
+    onStopClick: handleStopClick,
+    canScrollUp,
+    canScrollDown,
+    onScrollUp: scrollToPreviousUserMessage,
+    onScrollDown: scrollToNextUserMessage,
+  };
+
   if (context.projectId && context.isProjectArchived) {
     return (
       <div className="mx-auto flex flex-col w-full py-4 sm:max-w-conversation">
@@ -476,52 +494,11 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
       )}
     >
       <div className="flex w-full justify-center gap-2">
-        {showNavigationContainer && (
-          <div
-            className="flex items-center gap-1 rounded-xl border border-border bg-white p-1 dark:border-border-night dark:bg-muted-night"
-            style={{
-              position: "absolute",
-              top: "-2rem",
-            }}
-          >
-            {showStopButton && (
-              <>
-                <Button
-                  variant="ghost"
-                  label={getStopButtonLabel()}
-                  icon={hasPendingMessages ? BoltIcon : StopIcon}
-                  onClick={
-                    hasPendingMessages
-                      ? () => handleAction("interrupt")
-                      : () => handleAction("cancel")
-                  }
-                  disabled={pendingAction !== null}
-                  size="xs"
-                />
-                {showMessageNavigation && (
-                  <div className="h-4 w-px bg-border dark:bg-border-night" />
-                )}
-              </>
-            )}
-            {showMessageNavigation && (
-              <>
-                <IconButton
-                  icon={ArrowUpIcon}
-                  onClick={scrollToPreviousUserMessage}
-                  disabled={!canScrollUp}
-                  size="xs"
-                  tooltip="Previous user message"
-                />
-                <IconButton
-                  icon={ArrowDownIcon}
-                  onClick={scrollToNextUserMessage}
-                  disabled={!canScrollDown}
-                  size="xs"
-                  tooltip="Next user message"
-                />
-              </>
-            )}
-          </div>
+        {showNavigationContainer && !effectiveIsCompact && (
+          <InputBarMessageNavigation
+            variant="floating"
+            {...messageNavigationProps}
+          />
         )}
       </div>
       {blockedActions.length > 0 && (
@@ -582,22 +559,38 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
           isOwner={isActiveWakeUpOwner}
         />
       )}
-      <InputBar
-        owner={context.owner}
-        user={context.user}
-        onSubmit={context.handleSubmit}
-        stickyMentions={autoMentions}
-        conversation={context.conversation}
-        draftKey={context.draftKey}
-        disableAutoFocus={isMobile || hasUserAnswerRequired}
-        disableUserMentions={!!agentBuilderContext}
-        actions={agentBuilderContext?.actionsToShow}
-        isSubmitting={agentBuilderContext?.isSubmitting === true}
-        isAgentBuilder={!!agentBuilderContext}
-        submitBlockMessage={wakeUpBlockMessage ?? compactionBlockMessage}
-        isCompact={isInputBarCompact}
-        onExpandInputBar={() => setIsInputBarExpanded(true)}
-      />
+      <div
+        className={classNames(
+          "relative w-full",
+          effectiveIsCompact && "flex justify-center"
+        )}
+      >
+        {effectiveIsCompact && showNavigationContainer && (
+          <div className="absolute right-0 top-1/2 z-10 -translate-y-1/2">
+            <InputBarMessageNavigation
+              variant="compact"
+              {...messageNavigationProps}
+            />
+          </div>
+        )}
+        <InputBar
+          owner={context.owner}
+          user={context.user}
+          onSubmit={context.handleSubmit}
+          stickyMentions={autoMentions}
+          conversation={context.conversation}
+          draftKey={context.draftKey}
+          disableAutoFocus={isMobile || hasUserAnswerRequired}
+          disableUserMentions={!!agentBuilderContext}
+          actions={agentBuilderContext?.actionsToShow}
+          isSubmitting={agentBuilderContext?.isSubmitting === true}
+          isAgentBuilder={!!agentBuilderContext}
+          submitBlockMessage={wakeUpBlockMessage ?? compactionBlockMessage}
+          isCompact={isInputBarCompact}
+          onExpandInputBar={() => setIsInputBarExpanded(true)}
+          onEditorFocusChange={setIsEditorFocused}
+        />
+      </div>
     </div>
   );
 };

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -7,6 +7,7 @@ import InputBarContainer, {
   INPUT_BAR_ACTIONS,
 } from "@app/components/assistant/conversation/input_bar/InputBarContainer";
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import { INPUT_BAR_COMPACT_PILL_CLASSES } from "@app/components/assistant/conversation/input_bar/inputBarCompactStyles";
 import { useConversationDrafts } from "@app/components/assistant/conversation/input_bar/useConversationDrafts";
 import { PlanCard } from "@app/components/assistant/conversation/plan_mode/PlanCard";
 import {
@@ -67,6 +68,7 @@ interface InputBarProps {
   placeholder?: string;
   isCompact?: boolean;
   onExpandInputBar?: () => void;
+  onEditorFocusChange?: (focused: boolean) => void;
 }
 
 export const InputBar = React.memo(function InputBar({
@@ -88,9 +90,20 @@ export const InputBar = React.memo(function InputBar({
   placeholder,
   isCompact = false,
   onExpandInputBar,
+  onEditorFocusChange,
 }: InputBarProps) {
   const [isLocalSubmitting, setIsLocalSubmitting] = useState(isSubmitting);
   const [isShaking, setIsShaking] = useState(false);
+  const [isEditorFocused, setIsEditorFocused] = useState(false);
+  const effectiveIsCompact = isCompact && !isEditorFocused;
+
+  const handleEditorFocusChange = useCallback(
+    (focused: boolean) => {
+      setIsEditorFocused(focused);
+      onEditorFocusChange?.(focused);
+    },
+    [onEditorFocusChange]
+  );
 
   const [attachedNodes, setAttachedNodes] = useState<
     DataSourceViewContentNode[]
@@ -393,7 +406,7 @@ export const InputBar = React.memo(function InputBar({
     <div
       className={classNames(
         "flex w-full flex-col",
-        isCompact && "items-center"
+        effectiveIsCompact && "items-center"
       )}
     >
       <PlanCard
@@ -406,11 +419,9 @@ export const InputBar = React.memo(function InputBar({
           isShaking && "animate-shake",
           "relative flex flex-col items-stretch gap-0 sm:flex-row",
           "transition-all duration-300",
-          !isCompact && "w-full flex-1 self-stretch",
-          isCompact
-            ? classNames(
-                "w-fit shrink-0 rounded-full border border-border/30 bg-muted-background/70 px-1 py-0.5 dark:border-border-night/30 dark:bg-muted-background-night/70"
-              )
+          !effectiveIsCompact && "w-full flex-1 self-stretch",
+          effectiveIsCompact
+            ? INPUT_BAR_COMPACT_PILL_CLASSES
             : classNames(
                 "w-full rounded-2xl",
                 "bg-muted-background dark:bg-muted-background-night",
@@ -434,10 +445,10 @@ export const InputBar = React.memo(function InputBar({
         <div
           className={classNames(
             "relative flex flex-col",
-            !isCompact && "w-full flex-1"
+            !effectiveIsCompact && "w-full flex-1"
           )}
         >
-          {!isCompact && (
+          {!effectiveIsCompact && (
             <InputBarAttachments
               owner={owner}
               files={{ service: fileUploaderService }}
@@ -480,8 +491,9 @@ export const InputBar = React.memo(function InputBar({
             submitBlockMessage={submitBlockMessage ?? agentSwitchBlockMessage}
             placeholder={placeholder}
             onShake={handleShake}
-            isCompact={isCompact}
+            isCompact={effectiveIsCompact}
             onExpandInputBar={onExpandInputBar}
+            onEditorFocusChange={handleEditorFocusChange}
           />
         </div>
       </div>

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1,6 +1,7 @@
 import { ContextUsageIndicator } from "@app/components/assistant/conversation/input_bar/ContextUsageIndicator";
 import { InputBarAttachmentsPicker } from "@app/components/assistant/conversation/input_bar/InputBarAttachmentsPicker";
 import { InputBarButtons } from "@app/components/assistant/conversation/input_bar/InputBarButtons";
+import { INPUT_BAR_COMPACT_PILL_INNER_CLASSES } from "@app/components/assistant/conversation/input_bar/inputBarCompactStyles";
 import {
   getDisplayNameFromPastedFileId,
   getPastedFileName,
@@ -122,6 +123,7 @@ export interface InputBarContainerProps {
   isAgentBuilder?: boolean;
   isCompact?: boolean;
   onExpandInputBar?: () => void;
+  onEditorFocusChange?: (isFocused: boolean) => void;
   isSubmitting: boolean;
   onEnterKeyDown: CustomEditorProps["onEnterKeyDown"];
   onMCPServerViewDeselect: (serverView: MCPServerViewType) => void;
@@ -170,6 +172,7 @@ const InputBarContainer = ({
   onShake,
   isCompact = false,
   onExpandInputBar,
+  onEditorFocusChange,
 }: InputBarContainerProps) => {
   const isSubmitBlocked = submitBlockMessage !== null;
   const isCompactRef = useRef(isCompact);
@@ -535,6 +538,28 @@ const InputBarContainer = ({
   editorServiceRef.current = editorService;
   const saveDraftRef = useRef(saveDraft);
   saveDraftRef.current = saveDraft;
+
+  useEffect(() => {
+    if (!editor || editor.isDestroyed) {
+      return;
+    }
+
+    const handleFocus = () => {
+      onEditorFocusChange?.(true);
+    };
+    const handleBlur = () => {
+      onEditorFocusChange?.(false);
+    };
+
+    editor.on("focus", handleFocus);
+    editor.on("blur", handleBlur);
+    onEditorFocusChange?.(editor.isFocused);
+
+    return () => {
+      editor.off("focus", handleFocus);
+      editor.off("blur", handleBlur);
+    };
+  }, [editor, onEditorFocusChange]);
 
   useEffect(() => {
     // If an attachment disappears from the uploader, remove its chip from the editor
@@ -1037,7 +1062,8 @@ const InputBarContainer = ({
       {isCompact && (
         <div
           className={cn(
-            "relative flex h-8 w-auto flex-row items-center gap-1 px-1 sm:pt-0",
+            INPUT_BAR_COMPACT_PILL_INNER_CLASSES,
+            "relative w-auto px-1 sm:pt-0",
             isVoiceActive && "pl-2"
           )}
         >

--- a/front/components/assistant/conversation/input_bar/InputBarMessageNavigation.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarMessageNavigation.tsx
@@ -1,0 +1,150 @@
+import {
+  INPUT_BAR_COMPACT_PILL_CLASSES,
+  INPUT_BAR_COMPACT_PILL_INNER_CLASSES,
+} from "@app/components/assistant/conversation/input_bar/inputBarCompactStyles";
+import { classNames } from "@app/lib/utils";
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  BoltIcon,
+  Button,
+  IconButton,
+  StopIcon,
+} from "@dust-tt/sparkle";
+
+interface InputBarMessageNavigationProps {
+  variant: "floating" | "compact";
+  showStopButton: boolean;
+  showMessageNavigation: boolean;
+  stopButtonLabel: string;
+  hasPendingMessages: boolean;
+  pendingAction: "stop" | "interrupt" | null;
+  onStopClick: () => void;
+  canScrollUp: boolean;
+  canScrollDown: boolean;
+  onScrollUp: () => void;
+  onScrollDown: () => void;
+}
+
+export function InputBarMessageNavigation({
+  variant,
+  showStopButton,
+  showMessageNavigation,
+  stopButtonLabel,
+  hasPendingMessages,
+  pendingAction,
+  onStopClick,
+  canScrollUp,
+  canScrollDown,
+  onScrollUp,
+  onScrollDown,
+}: InputBarMessageNavigationProps) {
+  const stopButtonVariant = variant === "compact" ? "ghost-secondary" : "ghost";
+  const isStopActionPending = pendingAction !== null;
+  const stopIcon = hasPendingMessages ? BoltIcon : StopIcon;
+  const showNavigationArrows =
+    showMessageNavigation && !(variant === "compact" && showStopButton);
+
+  const renderNavigationArrowButton = (
+    icon: typeof ArrowUpIcon,
+    onClick: () => void,
+    disabled: boolean,
+    ariaLabel: string
+  ) => {
+    if (variant === "compact") {
+      return (
+        <Button
+          variant="ghost-secondary"
+          icon={icon}
+          size="xs"
+          onClick={onClick}
+          disabled={disabled}
+          aria-label={ariaLabel}
+        />
+      );
+    }
+
+    return (
+      <IconButton
+        icon={icon}
+        onClick={onClick}
+        disabled={disabled}
+        size="xs"
+        tooltip={ariaLabel}
+        aria-label={ariaLabel}
+      />
+    );
+  };
+
+  const stopButton =
+    variant === "compact" && isStopActionPending ? (
+      <Button
+        variant={stopButtonVariant}
+        label={stopButtonLabel}
+        onClick={onStopClick}
+        disabled
+        size="xs"
+      />
+    ) : (
+      <Button
+        variant={stopButtonVariant}
+        label={variant === "compact" ? undefined : stopButtonLabel}
+        icon={stopIcon}
+        aria-label={variant === "compact" ? stopButtonLabel : undefined}
+        onClick={onStopClick}
+        disabled={pendingAction !== null}
+        size="xs"
+      />
+    );
+
+  const controls = (
+    <>
+      {showStopButton && (
+        <>
+          {stopButton}
+          {showNavigationArrows && variant !== "compact" && (
+            <div className="h-4 w-px bg-border dark:bg-border-night" />
+          )}
+        </>
+      )}
+      {showNavigationArrows && (
+        <>
+          {renderNavigationArrowButton(
+            ArrowUpIcon,
+            onScrollUp,
+            !canScrollUp,
+            "Previous user message"
+          )}
+          {renderNavigationArrowButton(
+            ArrowDownIcon,
+            onScrollDown,
+            !canScrollDown,
+            "Next user message"
+          )}
+        </>
+      )}
+    </>
+  );
+
+  if (variant === "compact") {
+    return (
+      <div className={INPUT_BAR_COMPACT_PILL_CLASSES}>
+        <div className={INPUT_BAR_COMPACT_PILL_INNER_CLASSES}>{controls}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={classNames(
+        "flex items-center gap-1 rounded-xl border border-border bg-white p-1 dark:border-border-night dark:bg-muted-night"
+      )}
+      style={{
+        position: "absolute",
+        top: "-2rem",
+      }}
+    >
+      {controls}
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/input_bar/inputBarCompactStyles.ts
+++ b/front/components/assistant/conversation/input_bar/inputBarCompactStyles.ts
@@ -1,0 +1,5 @@
+export const INPUT_BAR_COMPACT_PILL_CLASSES =
+  "w-fit shrink-0 rounded-full border border-border/30 bg-muted-background/70 px-1 py-0.5 dark:border-border-night/30 dark:bg-muted-background-night/70";
+
+export const INPUT_BAR_COMPACT_PILL_INNER_CLASSES =
+  "flex h-8 flex-row items-center gap-1";

--- a/front/components/assistant/conversation/space/PodPinnedBanner.tsx
+++ b/front/components/assistant/conversation/space/PodPinnedBanner.tsx
@@ -8,7 +8,7 @@ import logger from "@app/logger/logger";
 import type { RichSpaceType } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
 import type { WorkspaceType } from "@app/types/user";
 import {
-  ActionMapPinIcon,
+  ActionPushpinIcon,
   Button,
   cn,
   EyeSlashIcon,
@@ -89,12 +89,12 @@ function PodPinnedBannerControls({
           icon={EyeSlashIcon}
           variant="ghost"
           size="xs"
-          tooltip="Hide banner"
+          tooltip="Hide"
           onClick={onHide}
         />
         {isEditor && (
           <Button
-            icon={ActionMapPinIcon}
+            icon={ActionPushpinIcon}
             variant="ghost"
             size="xs"
             tooltip="Unpin"
@@ -126,7 +126,7 @@ function PodPinnedBannerCollapsedAffordance({
 }: PodPinnedBannerCollapsedAffordanceProps) {
   return (
     <div className="mb-2 flex min-w-0 items-center gap-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
-      <ActionMapPinIcon className="h-3.5 w-3.5 shrink-0" />
+      <ActionPushpinIcon className="h-3.5 w-3.5 shrink-0" />
       <span className="shrink-0">Frame</span>
       <span aria-hidden className="shrink-0 text-muted-foreground/50">
         ·

--- a/front/components/assistant/conversation/space/ProjectFileExplorer.tsx
+++ b/front/components/assistant/conversation/space/ProjectFileExplorer.tsx
@@ -49,7 +49,7 @@ import {
 } from "@app/types/files";
 import type { WorkspaceType } from "@app/types/user";
 import {
-  ActionMapPinIcon,
+  ActionPushpinIcon,
   Button,
   CloudArrowLeftRightIcon,
   CloudArrowUpIcon,
@@ -282,7 +282,7 @@ function ProjectFileExplorerContent({
       return [
         {
           label: pinned ? "Unpin from banner" : "Pin as Pod banner",
-          icon: ActionMapPinIcon,
+          icon: ActionPushpinIcon,
           onClick: (e) => {
             e.stopPropagation();
             void togglePin(entry.path, { fileName: entry.fileName });

--- a/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
@@ -10,7 +10,7 @@ interface SpaceKnowledgeTabProps {
 
 export function SpaceKnowledgeTab({ owner, space }: SpaceKnowledgeTabProps) {
   return (
-    <div className="flex  py-8">
+    <div className="flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden px-6 py-8">
       <ProjectFileExplorer owner={owner} space={space} />
     </div>
   );

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -199,7 +199,7 @@ export function SpaceConversationsTab({
                 draftKey={`space-${spaceInfo.sId}-new-conversation`}
                 space={spaceInfo}
                 disableAutoFocus={false}
-                placeholder={`Start a conversation in ${spaceInfo.name}`}
+                placeholder={`Get work done in ${spaceInfo.name}`}
               />
             ) : (
               <ProjectJoinCTA

--- a/front/components/file_explorer/FileExplorerContent.tsx
+++ b/front/components/file_explorer/FileExplorerContent.tsx
@@ -139,7 +139,7 @@ export function FileExplorerContent({
 
   if (isEmpty && canGoUp) {
     return (
-      <ScrollArea className="flex-1">
+      <ScrollArea className="min-h-0 flex-1">
         <div className="flex flex-col gap-5 px-4">
           {viewMode === "list" ? (
             <div className="flex flex-col gap-0.5">{goUpItem}</div>
@@ -155,7 +155,7 @@ export function FileExplorerContent({
   }
 
   return (
-    <ScrollArea className="flex-1">
+    <ScrollArea className="min-h-0 flex-1">
       <div className="flex flex-col gap-5 px-4">
         {viewMode === "list" ? (
           <div className="flex flex-col gap-0.5">

--- a/front/components/file_explorer/FileExplorerToolbar.tsx
+++ b/front/components/file_explorer/FileExplorerToolbar.tsx
@@ -1,5 +1,6 @@
 import type { ViewMode } from "@app/components/file_explorer/FileExplorerItem";
 import type { FileExplorerSortMode } from "@app/components/file_explorer/types";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import {
   ActionTimeIcon,
   ArrowDownIcon,
@@ -54,6 +55,7 @@ interface SortDropdownProps {
 }
 
 function SortDropdown({ value, onValueChange }: SortDropdownProps) {
+  const isMobile = useIsMobile();
   const current = SORT_ITEMS[value];
   return (
     <DropdownMenu>
@@ -62,7 +64,8 @@ function SortDropdown({ value, onValueChange }: SortDropdownProps) {
           variant="outline"
           size="sm"
           icon={current.icon}
-          label={current.label}
+          label={isMobile ? undefined : current.label}
+          tooltip={isMobile ? current.label : undefined}
           isSelect
         />
       </DropdownMenuTrigger>


### PR DESCRIPTION
## Description

Several UI fixes and mobile navigation improvements:

- Replaced `ActionMapPinIcon` with `ActionPushpinIcon` in `PodPinnedBanner` and `ProjectFileExplorer`; shortened "Hide banner" tooltip to "Hide".
- Extracted the stop/navigation floating bar into `InputBarMessageNavigation` with two variants: `floating` (desktop, absolute above the input bar) and `compact` (mobile, pill-styled and positioned to the right of the compact pill). The navigation hides when the editor is focused via a new `effectiveIsCompact = isCompact && !isEditorFocused` pattern propagated through `InputBar` → `InputBarContainer` using tiptap `focus`/`blur` events.
- Extracted shared compact pill Tailwind classes into `inputBarCompactStyles.ts` to avoid duplication across `InputBar`, `InputBarContainer`, and `InputBarMessageNavigation`.
- Fixed scroll overflow in `FileExplorerContent` (`min-h-0` on `ScrollArea`) and corrected flex layout in `SpaceKnowledgeTab`.
- `SortDropdown` in `FileExplorerToolbar` is icon-only on mobile (label hidden, shown as tooltip).

<img width="480" height="256" alt="image" src="https://github.com/user-attachments/assets/579f2fe9-6ff5-48df-87e8-d3c3d1d70428" />


## Tests

Tested manually on mobile (compact input bar state, editor focus/blur transitions, stop/navigate buttons) and desktop.

## Risk

Low. Pure UI/Tailwind changes with no backend or data model impact. Fully rollback-safe.

## Deploy Plan

Deploy front.
