### PR TITLE
Move some webhook_sources/views/[viewId] helpers to the lib/api

### DIFF
--- a/front/lib/api/webhook_source.ts
+++ b/front/lib/api/webhook_source.ts
@@ -1,5 +1,10 @@
+import type {
+  CustomResourceIconType,
+  InternalAllowedIconType,
+} from "@app/components/resources/resources_icons";
 import { WEBHOOK_SERVICES } from "@app/lib/api/triggers/built-in-webhooks/services";
 import type { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -9,7 +14,7 @@ import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_v
 import logger from "@app/logger/logger";
 import type { TriggerType } from "@app/types/assistant/triggers";
 import type { Result } from "@app/types/shared/result";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type {
   WebhookSourceForAdminType,
@@ -190,4 +195,106 @@ export async function getWebhookSourceAdminDetails(
     triggers: triggersWithEditors,
     requestStats,
   };
+}
+
+export async function propagateWebhookSourceViewName(
+  auth: Authenticator,
+  webhookSourceView: WebhookSourcesViewResource,
+  newName: string
+): Promise<Result<undefined, DustError<"unauthorized">>> {
+  const systemView =
+    await WebhookSourcesViewResource.getWebhookSourceViewForSystemSpace(
+      auth,
+      webhookSourceView.webhookSource.sId
+    );
+
+  if (!systemView) {
+    // This should never happen as we already validated that the view is a system view
+    return new Err(new DustError("unauthorized", "Only system views allowed"));
+  }
+
+  // Get all views with the same webhook source (excluding the system view already updated)
+  const allViews = await WebhookSourcesViewResource.listByWebhookSource(
+    auth,
+    webhookSourceView.webhookSourceId
+  );
+
+  // Check that the user can administrate all views
+  for (const view of allViews) {
+    if (view.sId !== webhookSourceView.sId && !view.canAdministrate(auth)) {
+      return new Err(
+        new DustError("unauthorized", "Not allowed to update all views.")
+      );
+    }
+  }
+
+  // Get IDs of views to update (excluding the system view)
+  const viewIdsToUpdate = allViews
+    .filter((view) => view.sId !== webhookSourceView.sId)
+    .map((view) => view.id);
+
+  if (viewIdsToUpdate.length === 0) {
+    return new Ok(undefined);
+  }
+
+  // Bulk update all views at once
+  await WebhookSourcesViewResource.bulkUpdateName(
+    auth,
+    viewIdsToUpdate,
+    newName
+  );
+
+  return new Ok(undefined);
+}
+
+export async function propagateWebhookSourceViewDescriptionAndIcon(
+  auth: Authenticator,
+  webhookSourceView: WebhookSourcesViewResource,
+  description?: string,
+  icon?: InternalAllowedIconType | CustomResourceIconType
+): Promise<Result<undefined, DustError<"unauthorized">>> {
+  const systemView =
+    await WebhookSourcesViewResource.getWebhookSourceViewForSystemSpace(
+      auth,
+      webhookSourceView.webhookSource.sId
+    );
+
+  if (!systemView) {
+    // This should never happen as we already validated that the view is a system view
+    return new Err(new DustError("unauthorized", "Only system views allowed"));
+  }
+
+  // Get all views with the same webhook source (excluding the system view already updated)
+  const allViews = await WebhookSourcesViewResource.listByWebhookSource(
+    auth,
+    webhookSourceView.webhookSourceId
+  );
+
+  // Check that the user can administrate all views
+  for (const view of allViews) {
+    if (view.sId !== webhookSourceView.sId && !view.canAdministrate(auth)) {
+      return new Err(
+        new DustError("unauthorized", "Not allowed to update all views.")
+      );
+    }
+  }
+
+  // Get IDs of views to update (excluding the system view)
+  const viewIdsToUpdate = allViews
+    .filter((view) => view.sId !== webhookSourceView.sId)
+    .map((view) => view.id);
+
+  if (viewIdsToUpdate.length === 0) {
+    return new Ok(undefined);
+  }
+
+  // Bulk update all views at once
+  await WebhookSourcesViewResource.bulkUpdateDescriptionAndIcon(
+    auth,
+    viewIdsToUpdate,
+    description,
+    icon
+  );
+
+  return new Ok(undefined);
 }

--- a/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
@@ -1,18 +1,15 @@
 /** @ignoreswagger */
-import type {
-  CustomResourceIconType,
-  InternalAllowedIconType,
-} from "@app/components/resources/resources_icons";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import {
+  propagateWebhookSourceViewDescriptionAndIcon,
+  propagateWebhookSourceViewName,
+} from "@app/lib/api/webhook_source";
 import type { Authenticator } from "@app/lib/auth";
-import { DustError } from "@app/lib/error";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import { normalizeWebhookIcon } from "@app/lib/webhook_source";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { Result } from "@app/types/shared/result";
-import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -156,7 +153,7 @@ async function handler(
         }
       }
 
-      const updateResult = await editWebhookSourceViewsName(
+      const updateResult = await propagateWebhookSourceViewName(
         auth,
         webhookSourceView,
         name
@@ -211,12 +208,13 @@ async function handler(
         }
 
         // Propagate changes from system view to all space views
-        const propagateResult = await editWebhookSourceDescriptionAndIcon(
-          auth,
-          webhookSourceView,
-          description,
-          normalizedIcon
-        );
+        const propagateResult =
+          await propagateWebhookSourceViewDescriptionAndIcon(
+            auth,
+            webhookSourceView,
+            description,
+            normalizedIcon
+          );
         if (propagateResult.isErr()) {
           switch (propagateResult.error.code) {
             case "unauthorized":
@@ -249,108 +247,6 @@ async function handler(
         },
       });
   }
-}
-
-async function editWebhookSourceViewsName(
-  auth: Authenticator,
-  webhookSourceView: WebhookSourcesViewResource,
-  newName: string
-): Promise<Result<undefined, DustError<"unauthorized">>> {
-  const systemView =
-    await WebhookSourcesViewResource.getWebhookSourceViewForSystemSpace(
-      auth,
-      webhookSourceView.webhookSource.sId
-    );
-
-  if (!systemView) {
-    // This should never happen as we already validated that the view is a system view
-    return new Err(new DustError("unauthorized", "Only system views allowed"));
-  }
-
-  // Get all views with the same webhook source (excluding the system view already updated)
-  const allViews = await WebhookSourcesViewResource.listByWebhookSource(
-    auth,
-    webhookSourceView.webhookSourceId
-  );
-
-  // Check that the user can administrate all views
-  for (const view of allViews) {
-    if (view.sId !== webhookSourceView.sId && !view.canAdministrate(auth)) {
-      return new Err(
-        new DustError("unauthorized", "Not allowed to update all views.")
-      );
-    }
-  }
-
-  // Get IDs of views to update (excluding the system view)
-  const viewIdsToUpdate = allViews
-    .filter((view) => view.sId !== webhookSourceView.sId)
-    .map((view) => view.id);
-
-  if (viewIdsToUpdate.length === 0) {
-    return new Ok(undefined);
-  }
-
-  // Bulk update all views at once
-  await WebhookSourcesViewResource.bulkUpdateName(
-    auth,
-    viewIdsToUpdate,
-    newName
-  );
-
-  return new Ok(undefined);
-}
-
-async function editWebhookSourceDescriptionAndIcon(
-  auth: Authenticator,
-  webhookSourceView: WebhookSourcesViewResource,
-  description?: string,
-  icon?: InternalAllowedIconType | CustomResourceIconType
-): Promise<Result<undefined, DustError<"unauthorized">>> {
-  const systemView =
-    await WebhookSourcesViewResource.getWebhookSourceViewForSystemSpace(
-      auth,
-      webhookSourceView.webhookSource.sId
-    );
-
-  if (!systemView) {
-    // This should never happen as we already validated that the view is a system view
-    return new Err(new DustError("unauthorized", "Only system views allowed"));
-  }
-
-  // Get all views with the same webhook source (excluding the system view already updated)
-  const allViews = await WebhookSourcesViewResource.listByWebhookSource(
-    auth,
-    webhookSourceView.webhookSourceId
-  );
-
-  // Check that the user can administrate all views
-  for (const view of allViews) {
-    if (view.sId !== webhookSourceView.sId && !view.canAdministrate(auth)) {
-      return new Err(
-        new DustError("unauthorized", "Not allowed to update all views.")
-      );
-    }
-  }
-
-  // Get IDs of views to update (excluding the system view)
-  const viewIdsToUpdate = allViews
-    .filter((view) => view.sId !== webhookSourceView.sId)
-    .map((view) => view.id);
-
-  if (viewIdsToUpdate.length === 0) {
-    return new Ok(undefined);
-  }
-
-  // Bulk update all views at once
-  await WebhookSourcesViewResource.bulkUpdateDescriptionAndIcon(
-    auth,
-    viewIdsToUpdate,
-    description,
-    icon
-  );
-
-  return new Ok(undefined);
 }
 
 export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

  Refactored front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts — moved the two ~50-line local helpers (editWebhookSourceViewsName and editWebhookSourceDescriptionAndIcon) into front/lib/api/webhook_source.ts as propagateWebhookSourceViewName and   propagateWebhookSourceViewDescriptionAndIcon.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
