### PR TITLE
Migrate handlers under credit, keys, verification, webhook_sources

### DIFF
--- a/front-api/routes/w/[wId]/credits/index.ts
+++ b/front-api/routes/w/[wId]/credits/index.ts
@@ -13,6 +13,7 @@ import awuPoolSummary from "./awu-pool-summary";
 import membersSeats from "./members-seats";
 import membersUsage from "./members-usage";
 import metronomeBalances from "./metronome-balances";
+import purchase from "./purchase";
 
 // Mounted at /api/w/:wId/credits.
 const app = workspaceApp();
@@ -21,6 +22,7 @@ app.route("/awu-pool-summary", awuPoolSummary);
 app.route("/members-seats", membersSeats);
 app.route("/members-usage", membersUsage);
 app.route("/metronome-balances", metronomeBalances);
+app.route("/purchase", purchase);
 
 app.get("/", async (ctx) => {
   const auth = ctx.get("auth");

--- a/front-api/routes/w/[wId]/credits/purchase.ts
+++ b/front-api/routes/w/[wId]/credits/purchase.ts
@@ -1,6 +1,3 @@
-/** @ignoreswagger */
-// @migration-status: MIGRATED_TO_HONO
-import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type {
   CreateCreditPurchaseError,
   CreatedCreditPurchase,
@@ -11,13 +8,13 @@ import {
   createCreditPurchase,
   getCreditPurchaseInfo,
 } from "@app/lib/api/credits/purchase";
-import type { Authenticator } from "@app/lib/auth";
-import { apiError } from "@app/logger/withlogging";
-import type { WithAPIErrorResponse } from "@app/types/error";
+import type { APIErrorWithStatusCode } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import type { NextApiRequest, NextApiResponse } from "next";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-import { fromError } from "zod-validation-error";
 
 export const PostCreditPurchaseRequestBody = z.object({
   amountDollars: z.number().positive(),
@@ -29,50 +26,44 @@ type PostCreditPurchaseResponseBody = CreatedCreditPurchase & {
 
 export type GetCreditPurchaseInfoResponseBody = CreditPurchaseInfo;
 
-function infoErrorToApi(
-  req: NextApiRequest,
-  res: NextApiResponse,
-  err: CreditPurchaseInfoError
-) {
+function infoErrorToApi(err: CreditPurchaseInfoError): APIErrorWithStatusCode {
   switch (err.type) {
     case "subscription_not_found":
-      return apiError(req, res, {
+      return {
         status_code: 400,
         api_error: {
           type: "subscription_not_found",
           message:
             "No active subscription found. Please subscribe to a plan first.",
         },
-      });
+      };
     case "internal":
-      return apiError(req, res, {
+      return {
         status_code: 500,
         api_error: {
           type: "internal_server_error",
           message: "Failed to resolve billing currency for this workspace.",
         },
-      });
+      };
     default:
       assertNever(err.type);
   }
 }
 
 function purchaseErrorToApi(
-  req: NextApiRequest,
-  res: NextApiResponse,
   err: CreateCreditPurchaseError
-) {
+): APIErrorWithStatusCode {
   switch (err.type) {
     case "subscription_not_found":
-      return apiError(req, res, {
+      return {
         status_code: 400,
         api_error: {
           type: "subscription_not_found",
           message: "[Credit Purchase] Stripe subscription not found.",
         },
-      });
+      };
     case "purchase_not_allowed":
-      return apiError(req, res, {
+      return {
         status_code: 403,
         api_error: {
           type: "workspace_auth_error",
@@ -81,41 +72,38 @@ function purchaseErrorToApi(
               ? "Credit purchases are not available during trial. Please contact support."
               : "Credit purchases require an active subscription. Please ensure your payment method is up to date.",
         },
-      });
+      };
     case "amount_exceeds_limit": {
       const maxDollars = (err.details.maxAmountMicroUsd ?? 0) / 1_000_000;
-      return apiError(req, res, {
+      return {
         status_code: 400,
         api_error: {
           type: "invalid_request_error",
           message: `Amount exceeds maximum allowed: $${maxDollars}. Please contact support for higher limits.`,
         },
-      });
+      };
     }
     case "internal":
-      return apiError(req, res, {
+      return {
         status_code: 500,
         api_error: {
           type: "internal_server_error",
           message: "Failed to process credit purchase.",
         },
-      });
+      };
     default:
       assertNever(err.type);
   }
 }
 
-async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse<
-    WithAPIErrorResponse<
-      PostCreditPurchaseResponseBody | GetCreditPurchaseInfoResponseBody
-    >
-  >,
-  auth: Authenticator
-): Promise<void> {
+// Mounted at /api/w/:wId/credits/purchase.
+const app = workspaceApp();
+
+app.get("/", async (ctx): HandlerResult<GetCreditPurchaseInfoResponseBody> => {
+  const auth = ctx.get("auth");
+
   if (!auth.isAdmin()) {
-    return apiError(req, res, {
+    return apiError(ctx, {
       status_code: 403,
       api_error: {
         type: "workspace_auth_error",
@@ -125,47 +113,39 @@ async function handler(
     });
   }
 
-  switch (req.method) {
-    case "GET": {
-      const infoRes = await getCreditPurchaseInfo(auth);
-      if (infoRes.isErr()) {
-        return infoErrorToApi(req, res, infoRes.error);
-      }
-      return res.status(200).json(infoRes.value);
-    }
+  const infoRes = await getCreditPurchaseInfo(auth);
+  if (infoRes.isErr()) {
+    return apiError(ctx, infoErrorToApi(infoRes.error));
+  }
+  return ctx.json(infoRes.value);
+});
 
-    case "POST": {
-      const bodyValidation = PostCreditPurchaseRequestBody.safeParse(req.body);
-      if (!bodyValidation.success) {
-        const pathError = fromError(bodyValidation.error).toString();
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
-          },
-        });
-      }
+app.post(
+  "/",
+  validate("json", PostCreditPurchaseRequestBody),
+  async (ctx): HandlerResult<PostCreditPurchaseResponseBody> => {
+    const auth = ctx.get("auth");
 
-      const purchaseRes = await createCreditPurchase(auth, bodyValidation.data);
-      if (purchaseRes.isErr()) {
-        return purchaseErrorToApi(req, res, purchaseRes.error);
-      }
-
-      return res.status(200).json({ success: true, ...purchaseRes.value });
-    }
-
-    default:
-      return apiError(req, res, {
-        status_code: 405,
+    if (!auth.isAdmin()) {
+      return apiError(ctx, {
+        status_code: 403,
         api_error: {
-          type: "method_not_supported_error",
-          message: "The method passed is not supported.",
+          type: "workspace_auth_error",
+          message:
+            "Only users that are `admins` for the current workspace can access credit purchases.",
         },
       });
-  }
-}
+    }
 
-export default withSessionAuthenticationForWorkspace(handler, {
-  doesNotRequireCanUseProduct: true,
-});
+    const body = ctx.req.valid("json");
+
+    const purchaseRes = await createCreditPurchase(auth, body);
+    if (purchaseRes.isErr()) {
+      return apiError(ctx, purchaseErrorToApi(purchaseRes.error));
+    }
+
+    return ctx.json({ success: true as const, ...purchaseRes.value });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -34,6 +34,7 @@ import featureFlags from "./feature-flags";
 import files from "./files";
 import groups from "./groups";
 import invitations from "./invitations";
+import keys from "./keys";
 import labs from "./labs";
 import mcp from "./mcp";
 import me from "./me";
@@ -53,8 +54,10 @@ import sso from "./sso";
 import subscriptions from "./subscriptions";
 import trial from "./trial";
 import trialMessageUsage from "./trial-message-usage";
+import verification from "./verification";
 import verifiedDomains from "./verified-domains";
 import verify from "./verify";
+import webhookSources from "./webhook_sources";
 import welcome from "./welcome";
 import workspaceAnalytics from "./workspace-analytics";
 import workspaceUsage from "./workspace-usage";
@@ -216,6 +219,14 @@ app.route("/trial", trial);
 // the `app.route()` must sit below the catch-all so non-override sub-paths
 // inherit the default.
 app.use("/credits", workspaceAuth({ doesNotRequireCanUseProduct: true }));
+app.use(
+  "/credits/purchase",
+  workspaceAuth({ doesNotRequireCanUseProduct: true })
+);
+app.use(
+  "/verification/*",
+  workspaceAuth({ doesNotRequireCanUseProduct: true })
+);
 app.use("/seats/count", workspaceAuth({ doesNotRequireCanUseProduct: true }));
 app.use("/subscriptions", workspaceAuth({ doesNotRequireCanUseProduct: true }));
 app.use(
@@ -566,6 +577,7 @@ app.route("/extension", extension);
 app.route("/files", files);
 app.route("/groups", groups);
 app.route("/invitations", invitations);
+app.route("/keys", keys);
 app.route("/labs", labs);
 app.route("/mcp", mcp);
 app.route("/me", me);
@@ -583,7 +595,9 @@ app.route("/skills", skills);
 app.route("/sso", sso);
 app.route("/spaces", spaces);
 app.route("/subscriptions", subscriptions);
+app.route("/verification", verification);
 app.route("/verified-domains", verifiedDomains);
+app.route("/webhook_sources", webhookSources);
 app.route("/workspace-analytics", workspaceAnalytics);
 app.route("/workspace-usage", workspaceUsage);
 

--- a/front-api/routes/w/[wId]/keys/index.ts
+++ b/front-api/routes/w/[wId]/keys/index.ts
@@ -1,0 +1,222 @@
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { KeyResource } from "@app/lib/resources/key_resource";
+import { rateLimiter } from "@app/lib/utils/rate_limiter";
+import logger from "@app/logger/logger";
+import type { KeyType } from "@app/types/key";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { z } from "zod";
+
+const MAX_API_KEY_CREATION_PER_DAY = 30;
+
+export type GetKeysResponseBody = {
+  keys: KeyType[];
+};
+
+export type PostKeysResponseBody = {
+  key: KeyType;
+};
+
+const CreateKeyPostBodySchema = z.object({
+  name: z.string(),
+  group_id: z.string().optional(),
+  group_ids: z.array(z.string()).optional(),
+  monthly_cap_micro_usd: z.number().nullish(),
+  role: z.enum(["user", "builder", "admin"]).optional(),
+});
+
+// Mounted at /api/w/:wId/keys.
+const app = workspaceApp();
+
+app.get("/", async (ctx): HandlerResult<GetKeysResponseBody> => {
+  const auth = ctx.get("auth");
+  const owner = auth.getNonNullableWorkspace();
+
+  if (!auth.isAdmin()) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message:
+          "Only the users that are `admins` for the current workspace can interact with keys",
+      },
+    });
+  }
+
+  const keys = await KeyResource.listNonSystemKeysByWorkspace(owner);
+
+  return ctx.json({
+    keys: keys.map((k) => k.toJSON()),
+  });
+});
+
+app.post("/", async (ctx): HandlerResult<PostKeysResponseBody> => {
+  const auth = ctx.get("auth");
+  const user = auth.getNonNullableUser();
+  const owner = auth.getNonNullableWorkspace();
+
+  if (!auth.isAdmin()) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message:
+          "Only the users that are `admins` for the current workspace can interact with keys",
+      },
+    });
+  }
+
+  const rawBody = await ctx.req.json().catch(() => undefined);
+  const bodyValidation = CreateKeyPostBodySchema.safeParse(rawBody);
+  if (!bodyValidation.success) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid request body",
+      },
+    });
+  }
+
+  const { name, group_id, group_ids, monthly_cap_micro_usd, role } =
+    bodyValidation.data;
+  const trimmedName = name.trim();
+  const keyRole = role ?? "builder";
+
+  if (trimmedName.length === 0) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "API key name cannot be empty.",
+      },
+    });
+  }
+
+  if (
+    monthly_cap_micro_usd !== null &&
+    monthly_cap_micro_usd !== undefined &&
+    monthly_cap_micro_usd < 0
+  ) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "monthly_cap_micro_usd must be greater than or equal to 0",
+      },
+    });
+  }
+
+  const existingKey = await KeyResource.fetchByName(auth, {
+    name: trimmedName,
+    onlyActive: true,
+  });
+  if (existingKey) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "An API key with this name already exists in this workspace.",
+      },
+    });
+  }
+
+  // Resolve groups: prefer group_ids (new), fall back to group_id (retro-compatibility).
+  const globalGroupRes = await GroupResource.fetchWorkspaceGlobalGroup(auth);
+  if (globalGroupRes.isErr()) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: {
+        type: "group_not_found",
+        message: "Global group not found",
+      },
+    });
+  }
+  const globalGroup = globalGroupRes.value;
+
+  const resolvedGroups: GroupResource[] = [globalGroup];
+
+  const additionalGroupIds = group_ids
+    ? group_ids.filter((gId) => gId !== globalGroup.sId)
+    : group_id && group_id !== globalGroup.sId
+      ? [group_id]
+      : [];
+
+  if (additionalGroupIds.length > 0) {
+    const groupsRes = await GroupResource.fetchByIds(auth, additionalGroupIds);
+    if (groupsRes.isErr()) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "group_not_found",
+          message: "Invalid group",
+        },
+      });
+    }
+    resolvedGroups.push(...groupsRes.value);
+  }
+
+  const rateLimitKey = `api_key_creation_${owner.sId}`;
+  const remaining = await rateLimiter({
+    key: rateLimitKey,
+    maxPerTimeframe: MAX_API_KEY_CREATION_PER_DAY,
+    timeframeSeconds: 24 * 60 * 60, // 1 day
+    logger,
+  });
+
+  if (remaining === 0) {
+    return apiError(ctx, {
+      status_code: 429,
+      api_error: {
+        type: "rate_limit_error",
+        message:
+          `You have reached the limit of ${MAX_API_KEY_CREATION_PER_DAY} API keys ` +
+          "creations per day. Please try again later.",
+      },
+    });
+  }
+
+  const key = await KeyResource.makeNew(
+    {
+      name: trimmedName,
+      status: "active",
+      userId: user.id,
+      workspaceId: owner.id,
+      isSystem: false,
+      role: keyRole,
+      monthlyCapMicroUsd: monthly_cap_micro_usd ?? null,
+    },
+    resolvedGroups
+  );
+
+  void emitAuditLogEvent({
+    auth,
+    action: "api_key.created",
+    targets: [
+      buildAuditLogTarget("workspace", owner),
+      buildAuditLogTarget("api_key", {
+        sId: String(key.id),
+        name: trimmedName,
+      }),
+    ],
+    context: getAuditLogContext(auth),
+    metadata: {
+      group_ids: resolvedGroups.map((g) => g.sId).join(","),
+      role: keyRole,
+    },
+  });
+
+  return ctx.json(
+    {
+      key: key.toJSON(),
+    },
+    201
+  );
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/verification/index.ts
+++ b/front-api/routes/w/[wId]/verification/index.ts
@@ -1,0 +1,12 @@
+import { workspaceApp } from "@front-api/middlewares/ctx";
+
+import start from "./start";
+import validate from "./validate";
+
+// Mounted at /api/w/:wId/verification.
+const app = workspaceApp();
+
+app.route("/start", start);
+app.route("/validate", validate);
+
+export default app;

--- a/front-api/routes/w/[wId]/verification/start.ts
+++ b/front-api/routes/w/[wId]/verification/start.ts
@@ -1,0 +1,108 @@
+import { startVerification } from "@app/lib/api/workspace_verification";
+import { verifyTurnstileToken } from "@app/lib/api/workspace_verification/turnstile";
+import { PHONE_REGEXP } from "@app/lib/resources/workspace_verification_attempt_resource";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import type {
+  StartVerificationResponse,
+  VerificationErrorResponse,
+  VerificationErrorType,
+} from "@app/types/workspace_verification";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { z } from "zod";
+
+export const E164PhoneNumber = z
+  .string()
+  .regex(PHONE_REGEXP, { message: "E164PhoneNumber" });
+
+export const OtpCode = z.string().regex(/^\d{6}$/, { message: "OtpCode" });
+
+export function getStatusCodeForError(type: VerificationErrorType): number {
+  switch (type) {
+    case "rate_limit_error":
+      return 429;
+    case "invalid_request_error":
+    case "verification_error":
+    case "invalid_captcha":
+      return 400;
+    case "phone_already_used_error":
+      return 403;
+    default:
+      assertNever(type);
+  }
+}
+
+const PostStartVerificationRequestBody = z.object({
+  phoneNumber: E164PhoneNumber,
+  captchaToken: z.string().min(1),
+});
+
+// Mounted at /api/w/:wId/verification/start.
+const app = workspaceApp();
+
+app.post(
+  "/",
+  validate("json", PostStartVerificationRequestBody),
+  async (
+    ctx
+  ): HandlerResult<StartVerificationResponse | VerificationErrorResponse> => {
+    const auth = ctx.get("auth");
+
+    if (!auth.isAdmin()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message:
+            "Only users that are `admins` for the current workspace can start verification.",
+        },
+      });
+    }
+
+    const { phoneNumber, captchaToken } = ctx.req.valid("json");
+
+    const captchaResult = await verifyTurnstileToken({
+      token: captchaToken,
+      remoteIp: auth.clientIp(),
+    });
+    if (captchaResult.isErr()) {
+      return ctx.json(
+        {
+          error: {
+            type: "invalid_captcha" as const,
+            message: "Captcha verification failed. Please try again.",
+          },
+        },
+        getStatusCodeForError("invalid_captcha") as ContentfulStatusCode
+      );
+    }
+
+    const result = await startVerification(auth, phoneNumber);
+
+    if (result.isErr()) {
+      const error = result.error;
+      return ctx.json(
+        {
+          error: {
+            type: error.type,
+            message: error.message,
+            ...(error.retryAfterSeconds !== undefined && {
+              retryAfterSeconds: error.retryAfterSeconds,
+            }),
+          },
+        },
+        getStatusCodeForError(error.type) as ContentfulStatusCode
+      );
+    }
+
+    return ctx.json({
+      success: true as const,
+      message: "Verification code sent successfully.",
+    });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/verification/validate.ts
+++ b/front-api/routes/w/[wId]/verification/validate.ts
@@ -1,0 +1,66 @@
+import { validateVerification } from "@app/lib/api/workspace_verification";
+import type {
+  VerificationErrorResponse,
+  VerifyCodeResponse,
+} from "@app/types/workspace_verification";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { z } from "zod";
+
+import { E164PhoneNumber, getStatusCodeForError, OtpCode } from "./start";
+
+const PostValidateVerificationRequestBody = z.object({
+  phoneNumber: E164PhoneNumber,
+  code: OtpCode,
+});
+
+// Mounted at /api/w/:wId/verification/validate.
+const app = workspaceApp();
+
+app.post(
+  "/",
+  validate("json", PostValidateVerificationRequestBody),
+  async (
+    ctx
+  ): HandlerResult<VerifyCodeResponse | VerificationErrorResponse> => {
+    const auth = ctx.get("auth");
+
+    if (!auth.isAdmin()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message:
+            "Only users that are `admins` for the current workspace can validate verification.",
+        },
+      });
+    }
+
+    const { phoneNumber, code } = ctx.req.valid("json");
+
+    const result = await validateVerification(auth, phoneNumber, code);
+
+    if (result.isErr()) {
+      const error = result.error;
+      return ctx.json(
+        {
+          error: {
+            type: error.type,
+            message: error.message,
+          },
+        },
+        getStatusCodeForError(error.type) as ContentfulStatusCode
+      );
+    }
+
+    return ctx.json({
+      success: true as const,
+      verified: true as const,
+    });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/webhook_sources/index.ts
+++ b/front-api/routes/w/[wId]/webhook_sources/index.ts
@@ -1,0 +1,10 @@
+import { workspaceApp } from "@front-api/middlewares/ctx";
+
+import views from "./views";
+
+// Mounted at /api/w/:wId/webhook_sources.
+const app = workspaceApp();
+
+app.route("/views", views);
+
+export default app;

--- a/front-api/routes/w/[wId]/webhook_sources/views/[viewId]/index.test.ts
+++ b/front-api/routes/w/[wId]/webhook_sources/views/[viewId]/index.test.ts
@@ -1,0 +1,352 @@
+import { DustError } from "@app/lib/error";
+import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { WebhookSourceViewFactory } from "@app/tests/utils/WebhookSourceViewFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
+import { Err } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it, vi } from "vitest";
+
+async function setupTest(role: MembershipRoleType = "admin") {
+  const { workspace, auth, systemSpace, globalSpace } =
+    await createPrivateApiMockRequest({
+      role,
+    });
+
+  return { workspace, auth, systemSpace, globalSpace };
+}
+
+function getView(wId: string, viewId: string) {
+  return honoApp.request(`/api/w/${wId}/webhook_sources/views/${viewId}`);
+}
+
+function patchView(wId: string, viewId: string, body: unknown) {
+  return honoApp.request(`/api/w/${wId}/webhook_sources/views/${viewId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("GET /api/w/[wId]/webhook_sources/views/[viewId]", () => {
+  it("should return webhook source view when valid viewId is provided", async () => {
+    const { workspace, globalSpace } = await setupTest("admin");
+
+    const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
+    const webhookSourceView =
+      await webhookSourceViewFactory.create(globalSpace);
+
+    // Get the webhook source name from the toJSON() output since customName can be null
+    const webhookSourceName = webhookSourceView.toJSONForAdmin().customName;
+
+    expect(webhookSourceView).not.toBeNull();
+
+    const response = await getView(workspace.sId, webhookSourceView.sId);
+
+    expect(response.status).toBe(200);
+    const responseData = await response.json();
+    expect(responseData.webhookSourceView).toBeDefined();
+    expect(responseData.webhookSourceView.sId).toBe(webhookSourceView.sId);
+    expect(responseData.webhookSourceView.webhookSource).toBeDefined();
+    expect(responseData.webhookSourceView.customName).toBe(webhookSourceName);
+    expect(responseData.webhookSourceView.description).toBe(
+      webhookSourceView.description
+    );
+    expect(responseData.webhookSourceView.icon).toBe(webhookSourceView.icon);
+  });
+
+  it("should return 404 when webhook source view does not exist", async () => {
+    const { workspace } = await setupTest("admin");
+
+    const response = await getView(workspace.sId, "non_existent_view_id");
+
+    expect(response.status).toBe(404);
+    const responseData = await response.json();
+    expect(responseData.error.type).toBe("webhook_source_view_not_found");
+    expect(responseData.error.message).toBe("Webhook source view not found");
+  });
+
+  it("should work for user role when accessing valid webhook source view", async () => {
+    const { workspace, globalSpace } = await setupTest("user");
+
+    const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
+    const webhookSourceView =
+      await webhookSourceViewFactory.create(globalSpace);
+
+    expect(webhookSourceView).not.toBeNull();
+
+    const response = await getView(workspace.sId, webhookSourceView.sId);
+
+    expect(response.status).toBe(200);
+    const responseData = await response.json();
+    expect(responseData.webhookSourceView).toBeDefined();
+    expect(responseData.webhookSourceView.sId).toBe(webhookSourceView.sId);
+  });
+
+  it("should return nothing if user does not have access to webhook source view", async () => {
+    const { workspace } = await setupTest("user");
+
+    const space = await SpaceFactory.regular(workspace);
+    const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
+    const webhookSourceView = await webhookSourceViewFactory.create(space);
+
+    expect(webhookSourceView).not.toBeNull();
+
+    const response = await getView(workspace.sId, webhookSourceView.sId);
+
+    expect(response.status).toBe(404);
+  });
+});
+
+describe("PATCH /api/w/[wId]/webhook_sources/views/[viewId]", () => {
+  it("should update webhook source view name successfully", async () => {
+    const { workspace, systemSpace } = await setupTest("admin");
+
+    const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
+    const webhookSourceView =
+      await webhookSourceViewFactory.create(systemSpace);
+
+    expect(webhookSourceView).not.toBeNull();
+
+    const response = await patchView(workspace.sId, webhookSourceView.sId, {
+      name: "Updated Webhook View Name",
+    });
+
+    expect(response.status).toBe(200);
+    const responseData = await response.json();
+    expect(responseData.webhookSourceView).toBeDefined();
+    expect(responseData.webhookSourceView.customName).toBe(
+      "Updated Webhook View Name"
+    );
+  });
+
+  it("should return 400 when name is not provided in request body", async () => {
+    const { workspace, systemSpace } = await setupTest("admin");
+
+    const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
+    const webhookSourceView =
+      await webhookSourceViewFactory.create(systemSpace);
+
+    expect(webhookSourceView).not.toBeNull();
+
+    const response = await patchView(workspace.sId, webhookSourceView.sId, {});
+
+    expect(response.status).toBe(400);
+    const responseData = await response.json();
+    expect(responseData.error.type).toBe("invalid_request_error");
+    expect(responseData.error.message).toBe("Invalid request body");
+  });
+
+  it("should return 400 when name is empty string", async () => {
+    const { workspace, systemSpace } = await setupTest("admin");
+
+    const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
+    const webhookSourceView =
+      await webhookSourceViewFactory.create(systemSpace);
+
+    expect(webhookSourceView).not.toBeNull();
+
+    const response = await patchView(workspace.sId, webhookSourceView.sId, {
+      name: "",
+    });
+
+    expect(response.status).toBe(400);
+    const responseData = await response.json();
+    expect(responseData.error.type).toBe("invalid_request_error");
+    expect(responseData.error.message).toBe("Invalid request body");
+  });
+
+  it("should return 404 when trying to update non-existent webhook source view", async () => {
+    const { workspace } = await setupTest("admin");
+
+    const response = await patchView(workspace.sId, "non_existent_view_id", {
+      name: "Updated Name",
+    });
+
+    expect(response.status).toBe(404);
+    const responseData = await response.json();
+    expect(responseData.error.type).toBe("webhook_source_view_not_found");
+    expect(responseData.error.message).toBe("Webhook source view not found");
+  });
+
+  it("should fail to update view when user has insufficient permissions", async () => {
+    const { workspace, systemSpace } = await setupTest("user");
+
+    const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
+    const webhookSourceView =
+      await webhookSourceViewFactory.create(systemSpace);
+
+    expect(webhookSourceView).not.toBeNull();
+
+    const response = await patchView(workspace.sId, webhookSourceView.sId, {
+      name: "Updated Name",
+    });
+
+    expect(response.status).toBe(403);
+    const responseData = await response.json();
+    expect(responseData.error.type).toBe("webhook_source_view_auth_error");
+  });
+
+  it("should handle update failure gracefully", async () => {
+    const { workspace, systemSpace } = await setupTest("admin");
+
+    const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
+    const webhookSourceView =
+      await webhookSourceViewFactory.create(systemSpace);
+
+    expect(webhookSourceView).not.toBeNull();
+
+    // Mock the fetchById method to return a webhook source view with failing updateName
+    const mockWebhookSourceView = {
+      ...webhookSourceView,
+      updateName: vi
+        .fn()
+        .mockResolvedValue(
+          new Err(new DustError("internal_error", "Test error"))
+        ),
+      toJSON: vi.fn().mockReturnValue(webhookSourceView.toJSONForAdmin()),
+    };
+
+    const fetchByIdSpy = vi
+      .spyOn(WebhookSourcesViewResource, "fetchById")
+      .mockResolvedValue(mockWebhookSourceView as any);
+
+    const response = await patchView(workspace.sId, webhookSourceView.sId, {
+      name: "Updated Name",
+    });
+
+    expect(response.status).toBe(500);
+    const responseData = await response.json();
+    expect(responseData.error.type).toBe("internal_server_error");
+    expect(responseData.error.message).toBe(
+      "Failed to update webhook source view name."
+    );
+
+    // Restore the spy
+    fetchByIdSpy.mockRestore();
+  });
+
+  it("should update name for all views of the same webhook source when admin", async () => {
+    const { workspace, auth, systemSpace, globalSpace } =
+      await setupTest("admin");
+
+    const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
+    const systemView = await webhookSourceViewFactory.create(systemSpace);
+
+    expect(systemView).not.toBeNull();
+
+    // Create additional views in global space for the same webhook source
+    await webhookSourceViewFactory.create(globalSpace, {
+      webhookSourceId: systemView.webhookSource.sId,
+    });
+
+    // Verify initial state
+    const initialViews = await WebhookSourcesViewResource.listByWebhookSource(
+      auth,
+      systemView.webhookSourceId
+    );
+    expect(initialViews.length).toBeGreaterThanOrEqual(2);
+
+    // Update via system view
+    const response = await patchView(workspace.sId, systemView.sId, {
+      name: "Updated Webhook Name",
+    });
+
+    expect(response.status).toBe(200);
+    const responseData = await response.json();
+    expect(responseData.webhookSourceView).toBeDefined();
+    expect(responseData.webhookSourceView.customName).toBe(
+      "Updated Webhook Name"
+    );
+
+    // Verify all views were updated
+    const updatedViews = await WebhookSourcesViewResource.listByWebhookSource(
+      auth,
+      systemView.webhookSourceId
+    );
+    expect(updatedViews.length).toBe(initialViews.length);
+    for (const view of updatedViews) {
+      expect(view.customName).toBe("Updated Webhook Name");
+    }
+  });
+
+  it("should update webhook source view description and icon successfully", async () => {
+    const { workspace, systemSpace } = await setupTest("admin");
+
+    const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
+    const webhookSourceView =
+      await webhookSourceViewFactory.create(systemSpace);
+
+    expect(webhookSourceView).not.toBeNull();
+
+    const response = await patchView(workspace.sId, webhookSourceView.sId, {
+      name: "Updated Webhook View Name",
+      description: "This is a test description",
+      icon: "ActionBrainIcon",
+    });
+
+    expect(response.status).toBe(200);
+    const responseData = await response.json();
+    expect(responseData.webhookSourceView).toBeDefined();
+    expect(responseData.webhookSourceView.customName).toBe(
+      "Updated Webhook View Name"
+    );
+    expect(responseData.webhookSourceView.description).toBe(
+      "This is a test description"
+    );
+    expect(responseData.webhookSourceView.icon).toBe("ActionBrainIcon");
+  });
+
+  it("should update icon and description for all views of the same webhook source when admin", async () => {
+    const { workspace, auth, systemSpace, globalSpace } =
+      await setupTest("admin");
+
+    const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
+    const systemView = await webhookSourceViewFactory.create(systemSpace);
+
+    expect(systemView).not.toBeNull();
+
+    // Create additional views in global space for the same webhook source
+    await webhookSourceViewFactory.create(globalSpace, {
+      webhookSourceId: systemView.webhookSource.sId,
+    });
+
+    // Verify initial state
+    const initialViews = await WebhookSourcesViewResource.listByWebhookSource(
+      auth,
+      systemView.webhookSourceId
+    );
+    expect(initialViews.length).toBeGreaterThanOrEqual(2);
+
+    // Update via system view
+    const response = await patchView(workspace.sId, systemView.sId, {
+      name: "Updated Webhook Name",
+      description: "Updated description for all views",
+      icon: "ActionBrainIcon",
+    });
+
+    expect(response.status).toBe(200);
+    const responseData = await response.json();
+    expect(responseData.webhookSourceView).toBeDefined();
+    expect(responseData.webhookSourceView.customName).toBe(
+      "Updated Webhook Name"
+    );
+    expect(responseData.webhookSourceView.description).toBe(
+      "Updated description for all views"
+    );
+    expect(responseData.webhookSourceView.icon).toBe("ActionBrainIcon");
+
+    // Verify all views were updated with the new description and icon
+    const updatedViews = await WebhookSourcesViewResource.listByWebhookSource(
+      auth,
+      systemView.webhookSourceId
+    );
+    expect(updatedViews.length).toBe(initialViews.length);
+    for (const view of updatedViews) {
+      expect(view.customName).toBe("Updated Webhook Name");
+      expect(view.description).toBe("Updated description for all views");
+      expect(view.icon).toBe("ActionBrainIcon");
+    }
+  });
+});

--- a/front-api/routes/w/[wId]/webhook_sources/views/[viewId]/index.ts
+++ b/front-api/routes/w/[wId]/webhook_sources/views/[viewId]/index.ts
@@ -1,0 +1,232 @@
+import {
+  propagateWebhookSourceViewDescriptionAndIcon,
+  propagateWebhookSourceViewName,
+} from "@app/lib/api/webhook_source";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
+import { normalizeWebhookIcon } from "@app/lib/webhook_source";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { z } from "zod";
+
+const PatchWebhookSourceViewBodySchema = z.object({
+  name: z.string().min(1, "Name is required."),
+  description: z
+    .string()
+    .max(4000, "Description must be at most 4000 characters.")
+    .optional(),
+  icon: z.string().optional(),
+});
+
+export type GetWebhookSourceViewResponseBody = {
+  webhookSourceView: WebhookSourceViewType;
+};
+
+export type PatchWebhookSourceViewResponseBody = {
+  webhookSourceView: WebhookSourceViewType;
+};
+
+// Mounted at /api/w/:wId/webhook_sources/views/:viewId.
+const app = workspaceApp();
+
+app.get("/", async (ctx): HandlerResult<GetWebhookSourceViewResponseBody> => {
+  const auth = ctx.get("auth");
+  const viewId = ctx.req.param("viewId") ?? "";
+
+  const webhookSourceView = await WebhookSourcesViewResource.fetchById(
+    auth,
+    viewId
+  );
+
+  if (webhookSourceView === null) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: {
+        type: "webhook_source_view_not_found",
+        message: "Webhook source view not found",
+      },
+    });
+  }
+  if (!webhookSourceView.canRead(auth)) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: `Cannot read view with id ${viewId}.`,
+      },
+    });
+  }
+  return ctx.json({
+    webhookSourceView: webhookSourceView.toJSON(),
+  });
+});
+
+app.patch(
+  "/",
+  async (ctx): HandlerResult<PatchWebhookSourceViewResponseBody> => {
+    const auth = ctx.get("auth");
+    const viewId = ctx.req.param("viewId") ?? "";
+
+    const isAdmin = await SpaceResource.canAdministrateSystemSpace(auth);
+    if (!isAdmin) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "webhook_source_view_auth_error",
+          message:
+            "User is not authorized to update webhook source views in a space.",
+        },
+      });
+    }
+
+    const webhookSourceView = await WebhookSourcesViewResource.fetchById(
+      auth,
+      viewId
+    );
+
+    if (webhookSourceView === null) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "webhook_source_view_not_found",
+          message: "Webhook source view not found",
+        },
+      });
+    }
+
+    const rawBody = await ctx.req.json().catch(() => undefined);
+    const bodyValidation = PatchWebhookSourceViewBodySchema.safeParse(rawBody);
+    if (!bodyValidation.success) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid request body",
+        },
+      });
+    }
+
+    // Validate that this is a system view
+    if (webhookSourceView.space.kind !== "system") {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Updates can only be performed on system views.",
+        },
+      });
+    }
+
+    const { name, description, icon } = bodyValidation.data;
+
+    const nameResult = await webhookSourceView.updateName(auth, name);
+    if (nameResult.isErr()) {
+      switch (nameResult.error.code) {
+        case "unauthorized":
+          return apiError(ctx, {
+            status_code: 401,
+            api_error: {
+              type: "webhook_source_view_auth_error",
+              message:
+                "You are not authorized to update this webhook source view.",
+            },
+          });
+        default:
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: "Failed to update webhook source view name.",
+            },
+          });
+      }
+    }
+
+    const updateResult = await propagateWebhookSourceViewName(
+      auth,
+      webhookSourceView,
+      name
+    );
+    if (updateResult.isErr()) {
+      switch (updateResult.error.code) {
+        case "unauthorized":
+          return apiError(ctx, {
+            status_code: 401,
+            api_error: {
+              type: "workspace_auth_error",
+              message:
+                "You are not authorized to update the webhook source view.",
+            },
+          });
+        default:
+          assertNever(updateResult.error.code);
+      }
+    }
+
+    if (description !== undefined || icon !== undefined) {
+      // Normalize the icon to ensure it's a valid icon type
+      const normalizedIcon =
+        icon !== undefined ? normalizeWebhookIcon(icon) : undefined;
+
+      const descIconResult = await webhookSourceView.updateDescriptionAndIcon(
+        auth,
+        description,
+        normalizedIcon
+      );
+      if (descIconResult.isErr()) {
+        switch (descIconResult.error.code) {
+          case "unauthorized":
+            return apiError(ctx, {
+              status_code: 401,
+              api_error: {
+                type: "webhook_source_view_auth_error",
+                message:
+                  "You are not authorized to update this webhook source view.",
+              },
+            });
+          default:
+            return apiError(ctx, {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
+                message:
+                  "Failed to update webhook source view description or icon.",
+              },
+            });
+        }
+      }
+
+      // Propagate changes from system view to all space views
+      const propagateResult =
+        await propagateWebhookSourceViewDescriptionAndIcon(
+          auth,
+          webhookSourceView,
+          description,
+          normalizedIcon
+        );
+      if (propagateResult.isErr()) {
+        switch (propagateResult.error.code) {
+          case "unauthorized":
+            return apiError(ctx, {
+              status_code: 401,
+              api_error: {
+                type: "workspace_auth_error",
+                message:
+                  "You are not authorized to update the webhook source view.",
+              },
+            });
+          default:
+            assertNever(propagateResult.error.code);
+        }
+      }
+    }
+
+    return ctx.json({
+      webhookSourceView: webhookSourceView.toJSON(),
+    });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/webhook_sources/views/index.ts
+++ b/front-api/routes/w/[wId]/webhook_sources/views/index.ts
@@ -1,0 +1,10 @@
+import { workspaceApp } from "@front-api/middlewares/ctx";
+
+import viewById from "./[viewId]";
+
+// Mounted at /api/w/:wId/webhook_sources/views.
+const app = workspaceApp();
+
+app.route("/:viewId", viewById);
+
+export default app;

--- a/front/pages/api/w/[wId]/keys/index.ts
+++ b/front/pages/api/w/[wId]/keys/index.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import {
   buildAuditLogTarget,
   emitAuditLogEvent,

--- a/front/pages/api/w/[wId]/verification/start.ts
+++ b/front/pages/api/w/[wId]/verification/start.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { startVerification } from "@app/lib/api/workspace_verification";
 import { verifyTurnstileToken } from "@app/lib/api/workspace_verification/turnstile";

--- a/front/pages/api/w/[wId]/verification/validate.ts
+++ b/front/pages/api/w/[wId]/verification/validate.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { validateVerification } from "@app/lib/api/workspace_verification";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import {
   propagateWebhookSourceViewDescriptionAndIcon,


### PR DESCRIPTION
## Description

Migrated the following to Hono: 

- front/pages/api/w/[wId]/credits/purchase.ts
- front/pages/api/w/[wId]/keys/index.ts
- front/pages/api/w/[wId]/verification/start.ts
- front/pages/api/w/[wId]/verification/validate.ts
- front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
