### PR TITLE
Refactor public API handlers: extract helpers into lib/api/*

### DIFF
--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -160,6 +160,26 @@ export async function registerSlackWebhookRouterEntry({
 // If we have 10k documents of 100kB each (which is a lot) we are at 1GB here.
 const FILE_BATCH_SIZE = 10_000;
 
+/**
+ * Resolves the spaceId for legacy data source endpoints, which accept the spaceId either in the
+ * URL or implicitly from auth. When the URL omits it, system keys fall back to the data source's
+ * own space (to support connectors targeting non-global spaces), and user-scoped auth falls back
+ * to the workspace's global space.
+ */
+export async function resolveLegacyDataSourceSpaceId(
+  auth: Authenticator,
+  rawSpaceId: string | string[] | undefined,
+  dataSource: DataSourceResource | null
+): Promise<string | undefined> {
+  if (typeof rawSpaceId === "string") {
+    return rawSpaceId;
+  }
+  if (auth.isSystemKey()) {
+    return dataSource?.space.sId;
+  }
+  return (await SpaceResource.fetchWorkspaceGlobalSpace(auth)).sId;
+}
+
 export async function getDataSources(
   auth: Authenticator,
   { includeEditedBy }: { includeEditedBy: boolean } = {

--- a/front/lib/api/run.ts
+++ b/front/lib/api/run.ts
@@ -1,14 +1,78 @@
+import { computeTokensCostForUsageInMicroUsd } from "@app/lib/api/assistant/token_pricing";
 import apiConfig from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
+import type { RunUsageType } from "@app/lib/resources/run_resource";
 import logger from "@app/logger/logger";
 import type { AppType, SpecificationType } from "@app/types/app";
+import type {
+  ModelIdType,
+  ModelProviderIdType,
+} from "@app/types/assistant/models/types";
 import { CoreAPI } from "@app/types/core/core_api";
-import type { RunConfig, RunType } from "@app/types/run";
+import type { RunConfig, RunType, TraceType } from "@app/types/run";
 import fs from "fs";
 import path from "path";
 import peg from "pegjs";
 
 import { recomputeIndents, restoreTripleBackticks } from "../specification";
+
+/**
+ * Walks an app-run's `block_execution` traces and emits one `RunUsageType` per trace that carries
+ * `meta.token_usage`, attaching the block's provider/model and the computed cost in micro-USD.
+ */
+export function extractUsageFromExecutions(
+  block: { provider_id: ModelProviderIdType; model_id: ModelIdType },
+  traces: TraceType[][]
+): RunUsageType[] {
+  if (!block) {
+    return [];
+  }
+
+  const usages: RunUsageType[] = [];
+
+  traces.forEach((tracesInner) => {
+    tracesInner.forEach((trace) => {
+      if (trace?.meta) {
+        const { token_usage } = trace.meta as {
+          token_usage: {
+            prompt_tokens: number;
+            completion_tokens: number;
+            cached_tokens?: number;
+            cache_creation_input_tokens?: number;
+            reasoning_tokens?: number;
+          };
+        };
+        if (token_usage) {
+          const promptTokens = token_usage.prompt_tokens;
+          const completionTokens = token_usage.completion_tokens;
+          const cachedTokens = token_usage.cached_tokens;
+          const cacheCreationTokens = token_usage.cache_creation_input_tokens;
+
+          const usageCostMicroUsd = computeTokensCostForUsageInMicroUsd({
+            modelId: block.model_id,
+            promptTokens,
+            completionTokens,
+            cachedTokens: cachedTokens ?? null,
+            cacheCreationTokens: cacheCreationTokens ?? null,
+          });
+
+          usages.push({
+            providerId: block.provider_id,
+            modelId: block.model_id,
+            promptTokens,
+            completionTokens,
+            cachedTokens: cachedTokens ?? null,
+            cacheCreationTokens: cacheCreationTokens ?? null,
+            costMicroUsd: usageCostMicroUsd,
+            isBatch: false,
+          });
+        }
+      }
+    });
+  });
+
+  return usages;
+}
 
 export async function getSpecification(
   app: AppType,

--- a/front/lib/api/user.ts
+++ b/front/lib/api/user.ts
@@ -14,12 +14,46 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type {
   LightWorkspaceType,
+  UserType,
   UserTypeWithExtensionWorkspaces,
   UserTypeWithWorkspaces,
 } from "@app/types/user";
 
 import { MembershipResource } from "../resources/membership_resource";
 import { findWorkOSOrganizationsForUserId } from "./workos/organization_membership";
+
+/**
+ * Returns the acting user for an authenticated request. Falls back to looking up the user by
+ * email when auth is an API key (used by the Slack integration to attribute actions to the
+ * Slack user via the user-email header).
+ */
+export async function getActiveUserFromAuthOrEmail(
+  auth: Authenticator,
+  fallbackEmail: string | null | undefined
+): Promise<UserType | null> {
+  const authUser = auth.user();
+  if (authUser) {
+    return authUser.toJSON();
+  }
+
+  if (!auth.isKey() || !fallbackEmail) {
+    return null;
+  }
+
+  const users = await UserResource.listByEmail(fallbackEmail);
+  if (users.length === 0) {
+    return null;
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    users,
+    workspace,
+  });
+  const activeUserIds = new Set(memberships.map((m) => m.userId));
+  const firstActive = users.find((u) => activeUserIds.has(u.id));
+  return firstActive ? firstActive.toJSON() : null;
+}
 
 export async function getUserForWorkspace(
   auth: Authenticator,

--- a/front/lib/api/viz/access_tokens.ts
+++ b/front/lib/api/viz/access_tokens.ts
@@ -9,6 +9,8 @@ import {
   frameContentType,
   frameSlideshowContentType,
 } from "@app/types/files";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import jwt from "jsonwebtoken";
 import { z } from "zod";
@@ -93,4 +95,31 @@ export function verifyVizAccessToken(
   }
 
   return parseResult.data;
+}
+
+const BEARER_PREFIX = "Bearer ";
+
+/**
+ * Pulls a viz access token out of an `Authorization: Bearer ...` header and verifies it. All
+ * failure cases map to a `401 / workspace_auth_error` at the handler layer; only the user-facing
+ * message differs, which is why the error type is a plain string rather than an HTTP envelope.
+ */
+export function extractAndVerifyVizAccessTokenFromHeader(
+  authHeader: string | undefined
+): Result<VizAccessTokenPayload, string> {
+  if (!authHeader) {
+    return new Err("Authorization header required.");
+  }
+  if (!authHeader.startsWith(BEARER_PREFIX)) {
+    return new Err("Authorization header must use Bearer token format.");
+  }
+  const accessToken = authHeader.substring(BEARER_PREFIX.length).trim();
+  if (!accessToken) {
+    return new Err("Access token is required.");
+  }
+  const tokenPayload = verifyVizAccessToken(accessToken);
+  if (!tokenPayload) {
+    return new Err("Invalid or expired access token.");
+  }
+  return new Ok(tokenPayload);
 }

--- a/front/pages/api/v1/viz/content.ts
+++ b/front/pages/api/v1/viz/content.ts
@@ -1,4 +1,4 @@
-import { verifyVizAccessToken } from "@app/lib/api/viz/access_tokens";
+import { extractAndVerifyVizAccessTokenFromHeader } from "@app/lib/api/viz/access_tokens";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { apiError, withLogging } from "@app/logger/withlogging";
@@ -27,51 +27,19 @@ async function handler(
     });
   }
 
-  // Extract and validate access token from Authorization header.
-  const authHeader = req.headers.authorization;
-  if (!authHeader) {
+  const tokenRes = extractAndVerifyVizAccessTokenFromHeader(
+    req.headers.authorization
+  );
+  if (tokenRes.isErr()) {
     return apiError(req, res, {
       status_code: 401,
       api_error: {
         type: "workspace_auth_error",
-        message: "Authorization header required.",
+        message: tokenRes.error,
       },
     });
   }
-
-  const bearerPrefix = "Bearer ";
-  if (!authHeader.startsWith(bearerPrefix)) {
-    return apiError(req, res, {
-      status_code: 401,
-      api_error: {
-        type: "workspace_auth_error",
-        message: "Authorization header must use Bearer token format.",
-      },
-    });
-  }
-
-  const accessToken = authHeader.substring(bearerPrefix.length).trim();
-  if (!accessToken) {
-    return apiError(req, res, {
-      status_code: 401,
-      api_error: {
-        type: "workspace_auth_error",
-        message: "Access token is required.",
-      },
-    });
-  }
-
-  const tokenPayload = verifyVizAccessToken(accessToken);
-  if (!tokenPayload) {
-    return apiError(req, res, {
-      status_code: 401,
-      api_error: {
-        type: "workspace_auth_error",
-        message: "Invalid or expired access token.",
-      },
-    });
-  }
-
+  const tokenPayload = tokenRes.value;
   const { fileToken } = tokenPayload;
 
   const result = await FileResource.fetchByShareTokenWithContent(fileToken);

--- a/front/pages/api/v1/viz/files/[...segments].ts
+++ b/front/pages/api/v1/viz/files/[...segments].ts
@@ -5,7 +5,7 @@ import {
   getProjectFilesBasePath,
   scopedFilePathPrefixSchema,
 } from "@app/lib/api/files/mount_path";
-import { verifyVizAccessToken } from "@app/lib/api/viz/access_tokens";
+import { extractAndVerifyVizAccessTokenFromHeader } from "@app/lib/api/viz/access_tokens";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -64,39 +64,19 @@ async function handler(
     });
   }
 
-  // Extract and validate access token from Authorization header.
-  const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith("Bearer ")) {
+  const tokenRes = extractAndVerifyVizAccessTokenFromHeader(
+    req.headers.authorization
+  );
+  if (tokenRes.isErr()) {
     return apiError(req, res, {
       status_code: 401,
       api_error: {
         type: "workspace_auth_error",
-        message: "Authorization header with Bearer token required.",
+        message: tokenRes.error,
       },
     });
   }
-
-  const accessToken = authHeader.slice("Bearer ".length).trim();
-  if (!accessToken) {
-    return apiError(req, res, {
-      status_code: 401,
-      api_error: {
-        type: "workspace_auth_error",
-        message: "Access token is required.",
-      },
-    });
-  }
-
-  const tokenPayload = verifyVizAccessToken(accessToken);
-  if (!tokenPayload) {
-    return apiError(req, res, {
-      status_code: 401,
-      api_error: {
-        type: "workspace_auth_error",
-        message: "Invalid or expired access token.",
-      },
-    });
-  }
+  const tokenPayload = tokenRes.value;
 
   // Get file info using the fileToken from the access token.
   const result = await FileResource.fetchByShareTokenWithContent(

--- a/front/pages/api/v1/viz/files/[fileId].ts
+++ b/front/pages/api/v1/viz/files/[fileId].ts
@@ -1,6 +1,6 @@
 /* eslint-disable dust/enforce-client-types-in-public-api */
 
-import { verifyVizAccessToken } from "@app/lib/api/viz/access_tokens";
+import { extractAndVerifyVizAccessTokenFromHeader } from "@app/lib/api/viz/access_tokens";
 import {
   canAccessFileInConversation,
   canAccessFileInProject,
@@ -48,50 +48,19 @@ async function handler(
     });
   }
 
-  // Extract and validate access token from Authorization header.
-  const authHeader = req.headers.authorization;
-  if (!authHeader) {
+  const tokenRes = extractAndVerifyVizAccessTokenFromHeader(
+    req.headers.authorization
+  );
+  if (tokenRes.isErr()) {
     return apiError(req, res, {
       status_code: 401,
       api_error: {
         type: "workspace_auth_error",
-        message: "Authorization header required.",
+        message: tokenRes.error,
       },
     });
   }
-
-  const bearerPrefix = "Bearer ";
-  if (!authHeader.startsWith(bearerPrefix)) {
-    return apiError(req, res, {
-      status_code: 401,
-      api_error: {
-        type: "workspace_auth_error",
-        message: "Authorization header must use Bearer token format.",
-      },
-    });
-  }
-
-  const accessToken = authHeader.substring(bearerPrefix.length).trim();
-  if (!accessToken) {
-    return apiError(req, res, {
-      status_code: 401,
-      api_error: {
-        type: "workspace_auth_error",
-        message: "Access token is required.",
-      },
-    });
-  }
-
-  const tokenPayload = verifyVizAccessToken(accessToken);
-  if (!tokenPayload) {
-    return apiError(req, res, {
-      status_code: 401,
-      api_error: {
-        type: "workspace_auth_error",
-        message: "Invalid or expired access token.",
-      },
-    });
-  }
+  const tokenPayload = tokenRes.value;
 
   // Get file info using the fileToken from the access token.
   const result = await FileResource.fetchByShareTokenWithContent(

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks.ts
@@ -3,11 +3,10 @@ import {
   upsertMessageFeedback,
 } from "@app/lib/api/assistant/feedback";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import { getActiveUserFromAuthOrEmail } from "@app/lib/api/user";
 import type { Authenticator } from "@app/lib/auth";
 import { triggerAgentMessageFeedbackNotification } from "@app/lib/notifications/workflows/agent-message-feedback";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { MembershipResource } from "@app/lib/resources/membership_resource";
-import { UserResource } from "@app/lib/resources/user_resource";
 import { apiError } from "@app/logger/withlogging";
 import { launchAgentMessageFeedbackWorkflow } from "@app/temporal/analytics_queue/client";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -140,31 +139,10 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<PostMessageFeedbackResponseType>>,
   auth: Authenticator
 ): Promise<void> {
-  // Try to get user from auth, or from email header if using API key
-  let userResource = auth.user();
-  let user = userResource ? userResource.toJSON() : null;
-
-  if (!user && auth.isKey()) {
-    // Check if we have a user email header (used by Slack integration)
-    const userEmail = getUserEmailFromHeaders(req.headers);
-    if (userEmail) {
-      // Find user by email
-      const users = await UserResource.listByEmail(userEmail);
-      if (users.length > 0) {
-        const workspace = auth.getNonNullableWorkspace();
-        const { memberships } = await MembershipResource.getActiveMemberships({
-          users,
-          workspace,
-        });
-        const activeUserIds = new Set(memberships.map((m) => m.userId));
-        const firstActive = users.find((u) => activeUserIds.has(u.id));
-        if (firstActive) {
-          userResource = firstActive;
-          user = firstActive.toJSON();
-        }
-      }
-    }
-  }
+  const user = await getActiveUserFromAuthOrEmail(
+    auth,
+    getUserEmailFromHeaders(req.headers)
+  );
 
   if (!user) {
     return apiError(req, res, {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -1,9 +1,9 @@
-import { computeTokensCostForUsageInMicroUsd } from "@app/lib/api/assistant/token_pricing";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import apiConfig from "@app/lib/api/config";
 import { getDustAppSecrets } from "@app/lib/api/dust_app_secrets";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
+import { extractUsageFromExecutions } from "@app/lib/api/run";
 import { initSSEResponse } from "@app/lib/api/sse";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
@@ -19,10 +19,6 @@ import {
   credentialsFromProviders,
   dustManagedServiceCredentials,
 } from "@app/types/api/credentials";
-import type {
-  ModelIdType,
-  ModelProviderIdType,
-} from "@app/types/assistant/models/types";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { CredentialsType } from "@app/types/provider";
@@ -45,60 +41,6 @@ export const config = {
 type RunFlavor = "blocking" | "streaming" | "non-blocking";
 
 type Trace = [[BlockType, string], TraceType[][]];
-
-function extractUsageFromExecutions(
-  block: { provider_id: ModelProviderIdType; model_id: ModelIdType },
-  traces: TraceType[][]
-): RunUsageType[] {
-  if (!block) {
-    return [];
-  }
-
-  const usages: RunUsageType[] = [];
-
-  traces.forEach((tracesInner) => {
-    tracesInner.forEach((trace) => {
-      if (trace?.meta) {
-        const { token_usage } = trace.meta as {
-          token_usage: {
-            prompt_tokens: number;
-            completion_tokens: number;
-            cached_tokens?: number;
-            cache_creation_input_tokens?: number;
-            reasoning_tokens?: number;
-          };
-        };
-        if (token_usage) {
-          const promptTokens = token_usage.prompt_tokens;
-          const completionTokens = token_usage.completion_tokens;
-          const cachedTokens = token_usage.cached_tokens;
-          const cacheCreationTokens = token_usage.cache_creation_input_tokens;
-
-          const usageCostMicroUsd = computeTokensCostForUsageInMicroUsd({
-            modelId: block.model_id,
-            promptTokens,
-            completionTokens,
-            cachedTokens: cachedTokens ?? null,
-            cacheCreationTokens: cacheCreationTokens ?? null,
-          });
-
-          usages.push({
-            providerId: block.provider_id,
-            modelId: block.model_id,
-            promptTokens,
-            completionTokens,
-            cachedTokens: cachedTokens ?? null,
-            cacheCreationTokens: cacheCreationTokens ?? null,
-            costMicroUsd: usageCostMicroUsd,
-            isBatch: false,
-          });
-        }
-      }
-    });
-  });
-
-  return usages;
-}
 
 /**
  * @swagger

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -1,6 +1,9 @@
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import apiConfig from "@app/lib/api/config";
-import { computeWorkspaceOverallSizeCached } from "@app/lib/api/data_sources";
+import {
+  computeWorkspaceOverallSizeCached,
+  resolveLegacyDataSourceSpaceId,
+} from "@app/lib/api/data_sources";
 import {
   getLlmCredentials,
   MISSING_EMBEDDING_API_KEY_ERROR_MESSAGE,
@@ -10,7 +13,6 @@ import { MAX_NODE_TITLE_LENGTH } from "@app/lib/content_nodes_constants";
 import { DATASOURCE_QUOTA_PER_SEAT } from "@app/lib/plans/usage/types";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
 import { enqueueUpsertDocument } from "@app/lib/upsert_queue";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import { cleanTimestamp } from "@app/lib/utils/timestamps";
@@ -300,20 +302,11 @@ async function handler(
     { origin: "v1_data_sources_documents_document_get_or_upsert" }
   );
 
-  // Handling the case where `spaceId` is undefined to keep support for the legacy endpoint (not under
-  // space, global space assumed for the auth (the authenticator associated with the app, not the
-  // user)).
-  let { spaceId } = req.query;
-  if (typeof spaceId !== "string") {
-    if (auth.isSystemKey()) {
-      // We also handle the legacy usage of connectors that taps into connected data sources which
-      // are not in the global space. If this is a system key we trust it and set the `spaceId` to the
-      // dataSource.space.sId.
-      spaceId = dataSource?.space.sId;
-    } else {
-      spaceId = (await SpaceResource.fetchWorkspaceGlobalSpace(auth)).sId;
-    }
-  }
+  const spaceId = await resolveLegacyDataSourceSpaceId(
+    auth,
+    req.query.spaceId,
+    dataSource
+  );
 
   if (
     !dataSource ||

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/parents.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/parents.ts
@@ -1,8 +1,8 @@
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import { resolveLegacyDataSourceSpaceId } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import { CoreAPI } from "@app/types/core/core_api";
@@ -99,20 +99,11 @@ async function handler(
     { origin: "v1_data_sources_documents_document_parents" }
   );
 
-  // Handling the case where `spaceId` is undefined to keep support for the legacy endpoint (not under
-  // space, global space assumed for the auth (the authenticator associated with the app, not the
-  // user)).
-  let { spaceId } = req.query;
-  if (typeof spaceId !== "string") {
-    if (auth.isSystemKey()) {
-      // We also handle the legacy usage of connectors that taps into connected data sources which
-      // are not in the global space. If this is a system key we trust it and set the `spaceId` to the
-      // dataSource.space.sId.
-      spaceId = dataSource?.space.sId;
-    } else {
-      spaceId = (await SpaceResource.fetchWorkspaceGlobalSpace(auth)).sId;
-    }
-  }
+  const spaceId = await resolveLegacyDataSourceSpaceId(
+    auth,
+    req.query.spaceId,
+    dataSource
+  );
 
   if (
     !dataSource ||

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/index.ts
@@ -1,8 +1,8 @@
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import { resolveLegacyDataSourceSpaceId } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import { CoreAPI } from "@app/types/core/core_api";
@@ -99,20 +99,11 @@ async function handler(
     { origin: "v1_data_sources_documents" }
   );
 
-  // Handling the case where `spaceId` is undefined to keep support for the legacy endpoint (not under
-  // space, global space assumed for the auth (the authenticator associated with the app, not the
-  // user)).
-  let { spaceId } = req.query;
-  if (typeof spaceId !== "string") {
-    if (auth.isSystemKey()) {
-      // We also handle the legacy usage of connectors that taps into connected data sources which
-      // are not in the global space. If this is a system key we trust it and set the `spaceId` to the
-      // dataSource.space.sId.
-      spaceId = dataSource?.space.sId;
-    } else {
-      spaceId = (await SpaceResource.fetchWorkspaceGlobalSpace(auth)).sId;
-    }
-  }
+  const spaceId = await resolveLegacyDataSourceSpaceId(
+    auth,
+    req.query.spaceId,
+    dataSource
+  );
 
   if (
     !dataSource ||

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/search.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/search.ts
@@ -1,8 +1,10 @@
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
-import { handleDataSourceSearch } from "@app/lib/api/data_sources";
+import {
+  handleDataSourceSearch,
+  resolveLegacyDataSourceSpaceId,
+} from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -170,20 +172,11 @@ async function handler(
     { origin: "v1_data_sources_search" }
   );
 
-  // Handling the case where `spaceId` is undefined to keep support for the legacy endpoint (not under
-  // space, global space assumed for the auth (the authenticator associated with the app, not the
-  // user)).
-  let { spaceId } = req.query;
-  if (typeof spaceId !== "string") {
-    if (auth.isSystemKey()) {
-      // We also handle the legacy usage of connectors that taps into connected data sources which
-      // are not in the global space. If this is a system key we trust it and set the `spaceId` to the
-      // dataSource.space.sId.
-      spaceId = dataSource?.space.sId;
-    } else {
-      spaceId = (await SpaceResource.fetchWorkspaceGlobalSpace(auth)).sId;
-    }
-  }
+  const spaceId = await resolveLegacyDataSourceSpaceId(
+    auth,
+    req.query.spaceId,
+    dataSource
+  );
 
   if (
     !dataSource ||

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/index.ts
@@ -1,9 +1,9 @@
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import { resolveLegacyDataSourceSpaceId } from "@app/lib/api/data_sources";
 import { deleteTable } from "@app/lib/api/tables";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import { CoreAPI } from "@app/types/core/core_api";
@@ -126,20 +126,11 @@ async function handler(
     { origin: "v1_data_sources_tables" }
   );
 
-  // Handling the case where `spaceId` is undefined to keep support for the legacy endpoint (not under
-  // space, global space assumed for the auth (the authenticator associated with the app, not the
-  // user)).
-  let { spaceId } = req.query;
-  if (typeof spaceId !== "string") {
-    if (auth.isSystemKey()) {
-      // We also handle the legacy usage of connectors that taps into connected data sources which
-      // are not in the global space. If this is a system key we trust it and set the `spaceId` to the
-      // dataSource.space.sId.
-      spaceId = dataSource?.space.sId;
-    } else {
-      spaceId = (await SpaceResource.fetchWorkspaceGlobalSpace(auth)).sId;
-    }
-  }
+  const spaceId = await resolveLegacyDataSourceSpaceId(
+    auth,
+    req.query.spaceId,
+    dataSource
+  );
 
   if (
     !dataSource ||

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/parents.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/parents.ts
@@ -1,8 +1,8 @@
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import { resolveLegacyDataSourceSpaceId } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import { CoreAPI } from "@app/types/core/core_api";
@@ -52,20 +52,11 @@ async function handler(
     { origin: "v1_data_sources_tables_table_parents" }
   );
 
-  // Handling the case where `spaceId` is undefined to keep support for the legacy endpoint (not under
-  // space, global space assumed for the auth (the authenticator associated with the app, not the
-  // user)).
-  let { spaceId } = req.query;
-  if (typeof spaceId !== "string") {
-    if (auth.isSystemKey()) {
-      // We also handle the legacy usage of connectors that taps into connected data sources which
-      // are not in the global space. If this is a system key we trust it and set the `spaceId` to the
-      // dataSource.space.sId.
-      spaceId = dataSource?.space.sId;
-    } else {
-      spaceId = (await SpaceResource.fetchWorkspaceGlobalSpace(auth)).sId;
-    }
-  }
+  const spaceId = await resolveLegacyDataSourceSpaceId(
+    auth,
+    req.query.spaceId,
+    dataSource
+  );
 
   if (!dataSource || dataSource.space.sId !== spaceId) {
     return apiError(req, res, {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/rows/[rId].ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/rows/[rId].ts
@@ -1,8 +1,8 @@
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import { resolveLegacyDataSourceSpaceId } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import { CoreAPI } from "@app/types/core/core_api";
@@ -141,20 +141,11 @@ async function handler(
     { origin: "v1_data_sources_tables_table_rows_row" }
   );
 
-  // Handling the case where `spaceId` is undefined to keep support for the legacy endpoint (not under
-  // space, global space assumed for the auth (the authenticator associated with the app, not the
-  // user)).
-  let { spaceId } = req.query;
-  if (typeof spaceId !== "string") {
-    if (auth.isSystemKey()) {
-      // We also handle the legacy usage of connectors that taps into connected data sources which
-      // are not in the global space. If this is a system key we trust it and set the `spaceId` to the
-      // dataSource.space.sId.
-      spaceId = dataSource?.space.sId;
-    } else {
-      spaceId = (await SpaceResource.fetchWorkspaceGlobalSpace(auth)).sId;
-    }
-  }
+  const spaceId = await resolveLegacyDataSourceSpaceId(
+    auth,
+    req.query.spaceId,
+    dataSource
+  );
 
   if (
     !dataSource ||

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/rows/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/rows/index.ts
@@ -1,8 +1,8 @@
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import { resolveLegacyDataSourceSpaceId } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import { CoreAPI } from "@app/types/core/core_api";
@@ -188,20 +188,11 @@ async function handler(
     { origin: "v1_data_sources_tables_table_rows" }
   );
 
-  // Handling the case where `spaceId` is undefined to keep support for the legacy endpoint (not under
-  // space, global space assumed for the auth (the authenticator associated with the app, not the
-  // user)).
-  let { spaceId } = req.query;
-  if (typeof spaceId !== "string") {
-    if (auth.isSystemKey()) {
-      // We also handle the legacy usage of connectors that taps into connected data sources which
-      // are not in the global space. If this is a system key we trust it and set the `spaceId` to the
-      // dataSource.space.sId.
-      spaceId = dataSource?.space.sId;
-    } else {
-      spaceId = (await SpaceResource.fetchWorkspaceGlobalSpace(auth)).sId;
-    }
-  }
+  const spaceId = await resolveLegacyDataSourceSpaceId(
+    auth,
+    req.query.spaceId,
+    dataSource
+  );
 
   if (
     !dataSource ||

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
@@ -1,8 +1,10 @@
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
-import { upsertTable } from "@app/lib/api/data_sources";
+import {
+  resolveLegacyDataSourceSpaceId,
+  upsertTable,
+} from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type {
@@ -56,20 +58,11 @@ async function handler(
     { origin: "v1_data_sources_tables_csv" }
   );
 
-  // Handling the case where `spaceId` is undefined to keep support for the legacy endpoint (not under
-  // space, global space assumed for the auth (the authenticator associated with the app, not the
-  // user)).
-  let { spaceId } = req.query;
-  if (typeof spaceId !== "string") {
-    if (auth.isSystemKey()) {
-      // We also handle the legacy usage of connectors that taps into connected data sources which
-      // are not in the global space. If this is a system key we trust it and set the `spaceId` to the
-      // dataSource.space.sId.
-      spaceId = dataSource?.space.sId;
-    } else {
-      spaceId = (await SpaceResource.fetchWorkspaceGlobalSpace(auth)).sId;
-    }
-  }
+  const spaceId = await resolveLegacyDataSourceSpaceId(
+    auth,
+    req.query.spaceId,
+    dataSource
+  );
 
   if (!dataSource || dataSource.space.sId !== spaceId) {
     return apiError(req, res, {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -1,9 +1,9 @@
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { UNTITLED_TITLE } from "@app/lib/api/content_nodes";
+import { resolveLegacyDataSourceSpaceId } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { cleanTimestamp } from "@app/lib/utils/timestamps";
 import logger from "@app/logger/logger";
@@ -158,20 +158,11 @@ async function handler(
     { origin: "v1_data_sources_tables" }
   );
 
-  // Handling the case where `spaceId` is undefined to keep support for the legacy endpoint (not under
-  // space, global space assumed for the auth (the authenticator associated with the app, not the
-  // user)).
-  let { spaceId } = req.query;
-  if (typeof spaceId !== "string") {
-    if (auth.isSystemKey()) {
-      // We also handle the legacy usage of connectors that taps into connected data sources which
-      // are not in the global space. If this is a system key we trust it and set the `spaceId` to the
-      // dataSource.space.sId.
-      spaceId = dataSource?.space.sId;
-    } else {
-      spaceId = (await SpaceResource.fetchWorkspaceGlobalSpace(auth)).sId;
-    }
-  }
+  const spaceId = await resolveLegacyDataSourceSpaceId(
+    auth,
+    req.query.spaceId,
+    dataSource
+  );
 
   if (
     !dataSource ||

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tokenize.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tokenize.ts
@@ -1,8 +1,8 @@
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import { resolveLegacyDataSourceSpaceId } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import { CoreAPI } from "@app/types/core/core_api";
@@ -51,20 +51,11 @@ async function handler(
     { origin: "v1_data_sources_tokenize" }
   );
 
-  // Handling the case where `spaceId` is undefined to keep support for the legacy endpoint (not under
-  // space, global space assumed for the auth (the authenticator associated with the app, not the
-  // user)).
-  let { spaceId } = req.query;
-  if (typeof spaceId !== "string") {
-    if (auth.isSystemKey()) {
-      // We also handle the legacy usage of connectors that taps into connected data sources which
-      // are not in the global space. If this is a system key we trust it and set the `spaceId` to the
-      // dataSource.space.sId.
-      spaceId = dataSource?.space.sId;
-    } else {
-      spaceId = (await SpaceResource.fetchWorkspaceGlobalSpace(auth)).sId;
-    }
-  }
+  const spaceId = await resolveLegacyDataSourceSpaceId(
+    auth,
+    req.query.spaceId,
+    dataSource
+  );
 
   if (
     !dataSource ||


### PR DESCRIPTION
## Description

  Move helper logic out of Next.js handlers under `pages/api/v1/` and into `lib/api/*` where it belongs. Same behavior.

  ### `lib/api/user.ts` — `getActiveUserFromAuthOrEmail`

  Extracted from `messages/[mId]/feedbacks.ts`. Resolves the acting user from `auth`, falling back to looking up the user by email when auth is an API key (used by the Slack integration to attribute actions to the Slack user via the user-email header). Pure auth → user
  lookup, no req/res coupling.

  ### `lib/api/viz/access_tokens.ts` — `extractAndVerifyVizAccessTokenFromHeader`

  The "extract Bearer token + verify viz JWT" pattern was duplicated ~33 lines across three handlers (`viz/content.ts`, `viz/files/[fileId].ts`, `viz/files/[...segments].ts`). All four failure cases map to the same `401 / workspace_auth_error` with only the message
  differing, so the helper returns `Result<TokenPayload, string>` and each handler does one HTTP mapping instead of four. Removed ~100 lines.

  Minor visible change: `[...segments].ts` previously collapsed the "missing header" and "wrong prefix" cases into a single message. It now returns the more specific messages used by the other two endpoints (same 401, same error type).

  ### `lib/api/data_sources.ts` — `resolveLegacyDataSourceSpaceId`

  The "spaceId fallback for legacy data source endpoints" block was duplicated **identically** across 11 handlers. When the URL omits `spaceId`, system keys fall back to the data source's own space (for connectors targeting non-global spaces) and user-scoped auth falls
  back to the workspace's global space. Pure transformation, no HTTP errors. Replaced 11 × ~11 lines with single helper calls (~110 lines removed).

  Updated callers:

  - `data_sources/[dsId]/search.ts`
  - `data_sources/[dsId]/tokenize.ts`
  - `data_sources/[dsId]/tables/csv.ts`
  - `data_sources/[dsId]/tables/index.ts`
  - `data_sources/[dsId]/tables/[tId]/index.ts`
  - `data_sources/[dsId]/tables/[tId]/parents.ts`
  - `data_sources/[dsId]/tables/[tId]/rows/index.ts`
  - `data_sources/[dsId]/tables/[tId]/rows/[rId].ts`
  - `data_sources/[dsId]/documents/index.ts`
  - `data_sources/[dsId]/documents/[documentId]/index.ts`
  - `data_sources/[dsId]/documents/[documentId]/parents.ts`

  ### `lib/api/run.ts` — `extractUsageFromExecutions`

  Moved a 53-line top-level helper out of `spaces/[spaceId]/apps/[aId]/runs/index.ts`. Walks an app-run's `block_execution` traces and emits `RunUsageType[]` with per-block provider/model and computed cost. Pure function with no req/res coupling — belonged in `lib/api`
  from day one.

## Tests

Existing

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
