### PR TITLE
Typing improvements to reduce need for cast

### DIFF
--- a/front-api/middlewares/public_api_auth.ts
+++ b/front-api/middlewares/public_api_auth.ts
@@ -8,7 +8,7 @@ import {
 } from "@app/lib/auth";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { getClientIp } from "@app/lib/utils/request";
-import type { APIErrorWithStatusCode } from "@app/types/error";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import { getGroupIdsFromHeaders, getRoleFromHeaders } from "@app/types/groups";
 import { getUserEmailFromHeaders } from "@app/types/user";
 import type { PublicApiCtx } from "@front-api/middlewares/ctx";
@@ -29,7 +29,7 @@ function readHeaders(ctx: Context): HeaderRecord {
 
 function validateWorkspaceFromAuth(
   auth: Authenticator
-): APIErrorWithStatusCode | null {
+): APIErrorWithContentfulStatusCode | null {
   const owner = auth.workspace();
   const plan = auth.plan();
   if (!owner || !plan) {

--- a/front-api/middlewares/utils.ts
+++ b/front-api/middlewares/utils.ts
@@ -5,11 +5,10 @@ import tracer from "@app/logger/tracer";
 import { getSequelizeErrorDetails } from "@app/logger/withlogging";
 import type {
   APIErrorResponse,
-  APIErrorWithStatusCode,
+  APIErrorWithContentfulStatusCode,
 } from "@app/types/error";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { Context, ErrorHandler, TypedResponse } from "hono";
-import type { ContentfulStatusCode } from "hono/utils/http-status";
 
 /**
  * Return type for a Hono JSON handler. Wraps the success body type with the
@@ -27,14 +26,10 @@ export type HandlerResult<T> = Promise<TypedResponse<T | APIErrorResponse>>;
  *
  * Pass `error` when forwarding an underlying exception so its message and
  * stack are captured in the log instead of the synthetic one.
- *
- * The `status_code` field is typed as `number` but Hono's `ctx.json` expects
- * the narrower `ContentfulStatusCode` — the cast is safe because all our
- * status codes are valid HTTP error codes.
  */
 export function apiError(
   ctx: Context,
-  err: APIErrorWithStatusCode,
+  err: APIErrorWithContentfulStatusCode,
   error?: Error
 ) {
   const callstack = new Error().stack;
@@ -67,10 +62,7 @@ export function apiError(
     `error_type:${err.api_error.type}`,
   ]);
 
-  return ctx.json(
-    { error: err.api_error },
-    err.status_code as ContentfulStatusCode
-  );
+  return ctx.json({ error: err.api_error }, err.status_code);
 }
 
 /**

--- a/front-api/middlewares/workspace_auth.ts
+++ b/front-api/middlewares/workspace_auth.ts
@@ -5,7 +5,7 @@ import {
 } from "@app/lib/api/workspace_validation";
 import { Authenticator } from "@app/lib/auth";
 import { getClientIp } from "@app/lib/utils/request";
-import type { APIErrorWithStatusCode } from "@app/types/error";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { WorkspaceAwareCtx } from "@front-api/middlewares/ctx";
 import { resolveSession } from "@front-api/middlewares/session_resolution";
@@ -14,7 +14,7 @@ import { createMiddleware } from "hono/factory";
 
 function workspaceAccessErrorToApiError(
   err: WorkspaceAccessError
-): APIErrorWithStatusCode {
+): APIErrorWithContentfulStatusCode {
   switch (err.type) {
     case "workspace_not_found":
       return {

--- a/front-api/routes/w/[wId]/credits/purchase.ts
+++ b/front-api/routes/w/[wId]/credits/purchase.ts
@@ -8,7 +8,7 @@ import {
   createCreditPurchase,
   getCreditPurchaseInfo,
 } from "@app/lib/api/credits/purchase";
-import type { APIErrorWithStatusCode } from "@app/types/error";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
@@ -26,7 +26,9 @@ type PostCreditPurchaseResponseBody = CreatedCreditPurchase & {
 
 export type GetCreditPurchaseInfoResponseBody = CreditPurchaseInfo;
 
-function infoErrorToApi(err: CreditPurchaseInfoError): APIErrorWithStatusCode {
+function infoErrorToApi(
+  err: CreditPurchaseInfoError
+): APIErrorWithContentfulStatusCode {
   switch (err.type) {
     case "subscription_not_found":
       return {
@@ -52,7 +54,7 @@ function infoErrorToApi(err: CreditPurchaseInfoError): APIErrorWithStatusCode {
 
 function purchaseErrorToApi(
   err: CreateCreditPurchaseError
-): APIErrorWithStatusCode {
+): APIErrorWithContentfulStatusCode {
   switch (err.type) {
     case "subscription_not_found":
       return {

--- a/front-api/routes/w/[wId]/labs/transcripts/[tId].ts
+++ b/front-api/routes/w/[wId]/labs/transcripts/[tId].ts
@@ -6,6 +6,7 @@ import {
   launchRetrieveTranscriptsWorkflow,
   stopRetrieveTranscriptsWorkflow,
 } from "@app/temporal/labs/transcripts/client";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import type { LabsTranscriptsConfigurationType } from "@app/types/labs";
 import { isProviderWithDefaultWorkspaceConfiguration } from "@app/types/oauth/lib";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -26,10 +27,10 @@ type GetResponseBody = {
   configuration: LabsTranscriptsConfigurationType | null;
 };
 
-const NOT_FOUND_ERROR = {
+const NOT_FOUND_ERROR: APIErrorWithContentfulStatusCode = {
   status_code: 404,
   api_error: {
-    type: "transcripts_configuration_not_found" as const,
+    type: "transcripts_configuration_not_found",
     message: "The transcript configuration was not found.",
   },
 };

--- a/front-api/routes/w/[wId]/mcp/connections/[connectionType]/index.ts
+++ b/front-api/routes/w/[wId]/mcp/connections/[connectionType]/index.ts
@@ -13,7 +13,7 @@ import {
   MCPServerConnectionResource,
 } from "@app/lib/resources/mcp_server_connection_resource";
 import logger from "@app/logger/logger";
-import type { APIErrorWithStatusCode } from "@app/types/error";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import { OAuthAPI } from "@app/types/oauth/oauth_api";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
@@ -63,14 +63,16 @@ type PostConnectionAuthReference =
   | { kind: "oauth_connection"; connectionId: string }
   | { kind: "credential"; credentialId: string };
 
-function makeInvalidRequestError(message: string): APIErrorWithStatusCode {
+function makeInvalidRequestError(
+  message: string
+): APIErrorWithContentfulStatusCode {
   return {
     status_code: 400,
     api_error: { type: "invalid_request_error", message },
   };
 }
 
-function makeCredentialNotFoundError(): APIErrorWithStatusCode {
+function makeCredentialNotFoundError(): APIErrorWithContentfulStatusCode {
   return {
     status_code: 404,
     api_error: {
@@ -105,7 +107,7 @@ async function validateCredentialAuthReference(
     serverType: ReturnType<typeof getServerTypeAndIdFromSId>["serverType"];
     credentialId: string;
   }
-): Promise<APIErrorWithStatusCode | null> {
+): Promise<APIErrorWithContentfulStatusCode | null> {
   if (connectionType !== "workspace") {
     return makeInvalidRequestError(
       "Credential-backed MCP server connections are only supported for workspace connections."
@@ -174,7 +176,7 @@ async function validateAuthReferenceForMCPConnection(
     connectionType: MCPServerConnectionConnectionType;
     serverType: ReturnType<typeof getServerTypeAndIdFromSId>["serverType"];
   }
-): Promise<APIErrorWithStatusCode | null> {
+): Promise<APIErrorWithContentfulStatusCode | null> {
   if (authReference.kind === "oauth_connection") {
     const ownershipRes = await checkConnectionOwnership(
       auth,

--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.ts
@@ -8,7 +8,7 @@ import {
   setUserSpendLimit,
   type UserSpendLimitError,
 } from "@app/lib/api/users/spend_limit";
-import type { APIErrorWithStatusCode } from "@app/types/error";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
@@ -33,7 +33,7 @@ export type PutUserSpendLimitResponseBody = SetUserSpendLimitResponse;
 
 function spendLimitErrorToApiError(
   error: UserSpendLimitError
-): APIErrorWithStatusCode {
+): APIErrorWithContentfulStatusCode {
   switch (error.type) {
     case "user_not_found":
       return {

--- a/front-api/routes/w/[wId]/verification/start.ts
+++ b/front-api/routes/w/[wId]/verification/start.ts
@@ -20,7 +20,9 @@ export const E164PhoneNumber = z
 
 export const OtpCode = z.string().regex(/^\d{6}$/, { message: "OtpCode" });
 
-export function getStatusCodeForError(type: VerificationErrorType): number {
+export function getStatusCodeForError(
+  type: VerificationErrorType
+): ContentfulStatusCode {
   switch (type) {
     case "rate_limit_error":
       return 429;
@@ -76,7 +78,7 @@ app.post(
             message: "Captcha verification failed. Please try again.",
           },
         },
-        getStatusCodeForError("invalid_captcha") as ContentfulStatusCode
+        getStatusCodeForError("invalid_captcha")
       );
     }
 
@@ -94,7 +96,7 @@ app.post(
             }),
           },
         },
-        getStatusCodeForError(error.type) as ContentfulStatusCode
+        getStatusCodeForError(error.type)
       );
     }
 

--- a/front-api/routes/w/[wId]/verification/validate.ts
+++ b/front-api/routes/w/[wId]/verification/validate.ts
@@ -7,7 +7,6 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { z } from "zod";
 
 import { E164PhoneNumber, getStatusCodeForError, OtpCode } from "./start";
@@ -52,7 +51,7 @@ app.post(
             message: error.message,
           },
         },
-        getStatusCodeForError(error.type) as ContentfulStatusCode
+        getStatusCodeForError(error.type)
       );
     }
 

--- a/front/lib/api/analytics/programmatic_cost_export.ts
+++ b/front/lib/api/analytics/programmatic_cost_export.ts
@@ -14,6 +14,7 @@ import type { APIError } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { z } from "zod";
 
 const COMPOSITE_AGG_SIZE = 10000;
@@ -59,7 +60,7 @@ export type ProgrammaticCostExport = {
 };
 
 type ProgrammaticCostExportError = {
-  status: number;
+  status: ContentfulStatusCode;
   error: APIError;
 };
 

--- a/front/lib/api/assistant/configuration/yaml_export.ts
+++ b/front/lib/api/assistant/configuration/yaml_export.ts
@@ -17,7 +17,7 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
-import type { APIErrorWithStatusCode } from "@app/types/error";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { UserType } from "@app/types/user";
@@ -27,7 +27,7 @@ const AGENT_NAME_SANITATION_REGEX = /[^a-zA-Z0-9-_]/g;
 export async function getAgentConfigurationAsYAMLConfig(
   auth: Authenticator,
   agentId: string
-): Promise<Result<AgentYAMLConfig, APIErrorWithStatusCode>> {
+): Promise<Result<AgentYAMLConfig, APIErrorWithContentfulStatusCode>> {
   const agentConfiguration = await getAgentConfiguration(auth, {
     agentId,
     variant: "full",
@@ -181,7 +181,10 @@ export async function exportAgentConfigurationAsYAML(
   auth: Authenticator,
   agentId: string
 ): Promise<
-  Result<{ yamlContent: string; filename: string }, APIErrorWithStatusCode>
+  Result<
+    { yamlContent: string; filename: string },
+    APIErrorWithContentfulStatusCode
+  >
 > {
   const yamlConfigResult = await getAgentConfigurationAsYAMLConfig(
     auth,

--- a/front/lib/api/assistant/configuration/yaml_import.ts
+++ b/front/lib/api/assistant/configuration/yaml_import.ts
@@ -12,7 +12,7 @@ import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { TagResource } from "@app/lib/resources/tags_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
-import type { APIErrorWithStatusCode } from "@app/types/error";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -26,7 +26,7 @@ type ImportResult = Result<
     agentConfiguration: AgentConfigurationType;
     skippedActions: SkippedAction[];
   },
-  APIErrorWithStatusCode
+  APIErrorWithContentfulStatusCode
 >;
 
 async function importAgentConfiguration(

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -144,7 +144,7 @@ import type {
   ContentFragmentContextType,
   ContentFragmentType,
 } from "@app/types/content_fragment";
-import type { APIErrorWithStatusCode } from "@app/types/error";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -530,7 +530,7 @@ export async function postUserMessage(
       userMessage: UserMessageType;
       agentMessages: AgentMessageType[];
     },
-    APIErrorWithStatusCode
+    APIErrorWithContentfulStatusCode
   >
 > {
   const user = auth.user();
@@ -1120,7 +1120,7 @@ export async function editUserMessage(
 ): Promise<
   Result<
     { userMessage: UserMessageType; agentMessages: AgentMessageType[] },
-    APIErrorWithStatusCode
+    APIErrorWithContentfulStatusCode
   >
 > {
   const user = auth.user();
@@ -1676,7 +1676,7 @@ export async function retryAgentMessage(
     conversation: ConversationType;
     message: AgentMessageType;
   }
-): Promise<Result<AgentMessageType, APIErrorWithStatusCode>> {
+): Promise<Result<AgentMessageType, APIErrorWithContentfulStatusCode>> {
   // Find the parent user message to get the original context for rate limiting.
   // This ensures retries are counted with the same origin (web vs programmatic) as the original.
   const parentUserMessage = conversation.content
@@ -2380,7 +2380,7 @@ async function checkMessagesLimit(
     mentions: MentionType[];
     context: UserMessageContext;
   }
-): Promise<Result<void, APIErrorWithStatusCode>> {
+): Promise<Result<void, APIErrorWithContentfulStatusCode>> {
   // Skip rate limiting for system-initiated messages (e.g. reinforced agent workflows).
   if (!auth.user() && !auth.key() && auth.authMethod() === "internal") {
     return new Ok(undefined);

--- a/front/lib/api/assistant/conversation/compaction.ts
+++ b/front/lib/api/assistant/conversation/compaction.ts
@@ -25,7 +25,7 @@ import {
   isCompactionMessageType,
 } from "@app/types/assistant/conversation";
 import type { SupportedModel } from "@app/types/assistant/models/types";
-import type { APIErrorWithStatusCode } from "@app/types/error";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -48,7 +48,10 @@ export async function compactConversation(
     sourceConversation?: CompactionSourceConversation;
   }
 ): Promise<
-  Result<{ compactionMessage: CompactionMessageType }, APIErrorWithStatusCode>
+  Result<
+    { compactionMessage: CompactionMessageType },
+    APIErrorWithContentfulStatusCode
+  >
 > {
   const owner = auth.getNonNullableWorkspace();
 

--- a/front/lib/api/assistant/conversation/helper.ts
+++ b/front/lib/api/assistant/conversation/helper.ts
@@ -1,11 +1,15 @@
 import { apiError } from "@app/logger/withlogging";
 import type { ConversationErrorType } from "@app/types/assistant/conversation";
 import { ConversationError } from "@app/types/assistant/conversation";
-import type { APIErrorWithStatusCode } from "@app/types/error";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import { isOverflowingDBString } from "@app/types/shared/utils/general";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-const STATUS_FOR_ERROR_TYPE: Record<ConversationErrorType, number> = {
+const STATUS_FOR_ERROR_TYPE: Record<
+  ConversationErrorType,
+  ContentfulStatusCode
+> = {
   conversation_access_restricted: 403,
   conversation_not_found: 404,
   conversation_with_unavailable_agent: 403,
@@ -21,7 +25,9 @@ const STATUS_FOR_ERROR_TYPE: Record<ConversationErrorType, number> = {
  * shape. Use this from any framework (Next or Hono) — only the response
  * dispatch differs.
  */
-export function getConversationApiError(error: Error): APIErrorWithStatusCode {
+export function getConversationApiError(
+  error: Error
+): APIErrorWithContentfulStatusCode {
   if (error instanceof ConversationError) {
     return {
       status_code: STATUS_FOR_ERROR_TYPE[error.type],

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -44,7 +44,7 @@ import {
   toMentionType,
 } from "@app/types/assistant/mentions";
 import { isContentFragmentType } from "@app/types/content_fragment";
-import type { APIErrorWithStatusCode } from "@app/types/error";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -226,7 +226,7 @@ export async function validateUserMention(
     messageId: string;
     approvalState: "approved" | "rejected";
   }
-): Promise<Result<void, APIErrorWithStatusCode>> {
+): Promise<Result<void, APIErrorWithContentfulStatusCode>> {
   const conversationRes = await getConversation(auth, conversationId);
   if (conversationRes.isErr()) {
     return new Err({
@@ -493,7 +493,7 @@ export async function dismissMention(
     type: "user" | "agent";
     id: string;
   }
-): Promise<Result<void, APIErrorWithStatusCode>> {
+): Promise<Result<void, APIErrorWithContentfulStatusCode>> {
   const conversationRes = await getConversation(auth, conversationId);
   if (conversationRes.isErr()) {
     return new Err({

--- a/front/lib/api/assistant/onboarding.ts
+++ b/front/lib/api/assistant/onboarding.ts
@@ -13,7 +13,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { EmailProviderType } from "@app/lib/utils/email_provider_detection";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { UserMessageContext } from "@app/types/assistant/conversation";
-import type { APIErrorWithStatusCode } from "@app/types/error";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import type { FavoritePlatform } from "@app/types/favorite_platforms";
 import { isFavoritePlatform } from "@app/types/favorite_platforms";
 import type { JobType } from "@app/types/job_type";
@@ -461,7 +461,7 @@ export async function createOnboardingConversationIfNeeded(
     force: false,
     language: null,
   }
-): Promise<Result<string | null, APIErrorWithStatusCode>> {
+): Promise<Result<string | null, APIErrorWithContentfulStatusCode>> {
   const owner = auth.workspace();
   const subscription = auth.subscription();
   const user = auth.user();

--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -13,7 +13,7 @@ import { getClientIp } from "@app/lib/utils/request";
 import type { NextApiRequestWithContext } from "@app/logger/withlogging";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type {
-  APIErrorWithStatusCode,
+  APIErrorWithContentfulStatusCode,
   WithAPIErrorResponse,
 } from "@app/types/error";
 import { getGroupIdsFromHeaders, getRoleFromHeaders } from "@app/types/groups";
@@ -32,7 +32,7 @@ function setClientIpOnAuth(auth: Authenticator, req: NextApiRequest): void {
 
 function getMaintenanceError(
   maintenance: string | number | true | object
-): APIErrorWithStatusCode {
+): APIErrorWithContentfulStatusCode {
   // During relocation, we return 503, but once relocation is done, we return 404 since
   // at that point, the workspace should be treated as if it did not exist in this region anymore.
   // And that matches what will happen it gets purged later.
@@ -56,7 +56,7 @@ function getMaintenanceError(
   };
 }
 
-function getWorkspaceKillSwitchError(): APIErrorWithStatusCode {
+function getWorkspaceKillSwitchError(): APIErrorWithContentfulStatusCode {
   return {
     status_code: 503,
     api_error: {
@@ -67,7 +67,7 @@ function getWorkspaceKillSwitchError(): APIErrorWithStatusCode {
   };
 }
 
-function getConversationKillSwitchError(): APIErrorWithStatusCode {
+function getConversationKillSwitchError(): APIErrorWithContentfulStatusCode {
   return {
     status_code: 503,
     api_error: {
@@ -92,7 +92,7 @@ function getAssistantConversationIdFromRequest(
 function getConversationKillSwitchErrorForRequest(
   req: NextApiRequest,
   killSwitched: unknown
-): APIErrorWithStatusCode | null {
+): APIErrorWithContentfulStatusCode | null {
   const conversationId = getAssistantConversationIdFromRequest(req);
   if (!conversationId) {
     return null;
@@ -108,13 +108,13 @@ function getConversationKillSwitchErrorForRequest(
 
 /**
  * Checks workspace-level guards: owner/plan existence, canUseProduct, maintenance, and kill switches.
- * Returns an APIErrorWithStatusCode if any check fails, or null if all pass.
+ * Returns an APIErrorWithContentfulStatusCode if any check fails, or null if all pass.
  */
 function validateWorkspace(
   req: NextApiRequest,
   auth: Authenticator,
   opts: { doesNotRequireCanUseProduct?: boolean } = {}
-): APIErrorWithStatusCode | null {
+): APIErrorWithContentfulStatusCode | null {
   const owner = auth.workspace();
   const plan = auth.plan();
   if (!owner || !plan) {
@@ -552,7 +552,7 @@ export function withTokenAuthentication<T>(
 async function handleSandboxAuth(
   token: string,
   wId: string
-): Promise<Result<Authenticator, APIErrorWithStatusCode>> {
+): Promise<Result<Authenticator, APIErrorWithContentfulStatusCode>> {
   const payload = await verifySandboxExecToken(token);
   if (!payload) {
     return new Err({

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -17,7 +17,7 @@ import { isEmailValid } from "@app/lib/utils";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
-import type { APIErrorWithStatusCode } from "@app/types/error";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import type { MembershipInvitationType } from "@app/types/membership_invitation";
 import type { SubscriptionType } from "@app/types/plan";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -190,7 +190,9 @@ export async function handleMembershipInvitations(
     invitationRequests: MembershipInvitationBlob[];
     force?: boolean;
   }
-): Promise<Result<HandleMembershipInvitationResult[], APIErrorWithStatusCode>> {
+): Promise<
+  Result<HandleMembershipInvitationResult[], APIErrorWithContentfulStatusCode>
+> {
   const { maxUsers } = subscription.plan.limits.users;
 
   // Emails are sent after the transaction commits so the DB transaction is
@@ -199,7 +201,7 @@ export async function handleMembershipInvitations(
     async (
       t
     ): Promise<
-      Result<InvitationTransactionPayload, APIErrorWithStatusCode>
+      Result<InvitationTransactionPayload, APIErrorWithContentfulStatusCode>
     > => {
       if (maxUsers !== -1) {
         await getWorkspaceAdministrationVersionLock(owner, t);

--- a/front/lib/api/login.ts
+++ b/front/lib/api/login.ts
@@ -22,7 +22,7 @@ import { ServerSideTracking } from "@app/lib/tracking/server";
 import { readAnonymousIdFromCookies } from "@app/lib/utils/anonymous_id";
 import type { UTMParams } from "@app/lib/utils/utm";
 import logger from "@app/logger/logger";
-import type { APIErrorWithStatusCode } from "@app/types/error";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import type { LightWorkspaceType } from "@app/types/user";
 
 export interface PerformLoginOptions {
@@ -55,7 +55,7 @@ export interface PerformLoginRequest {
 export type LoginOutcome =
   | { kind: "redirect"; url: string }
   | { kind: "unauthorized" }
-  | { kind: "apiError"; error: APIErrorWithStatusCode };
+  | { kind: "apiError"; error: APIErrorWithContentfulStatusCode };
 
 function resolveClientIp(request: PerformLoginRequest): string | undefined {
   const { forwardedFor, remoteAddress } = request;

--- a/front/lib/api/search.ts
+++ b/front/lib/api/search.ts
@@ -21,6 +21,7 @@ import type { APIError } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { ParsedUrlQuery } from "querystring";
 import { z } from "zod";
 
@@ -37,7 +38,7 @@ export type SearchResult = {
 };
 
 type SearchError = {
-  status: number;
+  status: ContentfulStatusCode;
   error: APIError;
 };
 

--- a/front/lib/api/stripe/webhook_handler.ts
+++ b/front/lib/api/stripe/webhook_handler.ts
@@ -55,7 +55,7 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { launchScheduleWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
 import { launchWorkOSWorkspaceSubscriptionCreatedWorkflow } from "@app/temporal/workos_events_queue/client";
-import type { APIErrorWithStatusCode } from "@app/types/error";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -667,7 +667,7 @@ async function handleStripeCheckoutCompleted({
  * the event is constructed, this function does everything else.
  *
  * Returns `Ok(undefined)` on success (route should respond 200) and an
- * `APIErrorWithStatusCode` on failures the caller should surface as an HTTP
+ * `APIErrorWithContentfulStatusCode` on failures the caller should surface as an HTTP
  * error response.
  */
 export async function processStripeWebhookEvent({
@@ -678,7 +678,7 @@ export async function processStripeWebhookEvent({
   event: Stripe.Event;
   stripe: Stripe;
   now: Date;
-}): Promise<Result<void, APIErrorWithStatusCode>> {
+}): Promise<Result<void, APIErrorWithContentfulStatusCode>> {
   logger.info({ stripeError: false, event }, "Processing Stripe event.");
 
   let stripeSubscription;

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -27,7 +27,7 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
-import type { APIErrorWithStatusCode } from "@app/types/error";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import type { PlanType, SubscriptionType } from "@app/types/plan";
 import type { ProvidersHealth } from "@app/types/provider_credential";
 import type {
@@ -472,7 +472,7 @@ export class Authenticator {
   static async fromSandboxToken(
     claims: SandboxExecTokenPayload,
     wId: string
-  ): Promise<Result<Authenticator, APIErrorWithStatusCode>> {
+  ): Promise<Result<Authenticator, APIErrorWithContentfulStatusCode>> {
     if (claims.wId !== wId) {
       return new Err({
         status_code: 401,
@@ -1283,7 +1283,7 @@ export async function getSession(
  */
 export async function getBearerToken(
   authHeader: string | undefined
-): Promise<Result<string, APIErrorWithStatusCode>> {
+): Promise<Result<string, APIErrorWithContentfulStatusCode>> {
   if (!authHeader) {
     return new Err({
       status_code: 401,
@@ -1381,11 +1381,11 @@ export async function getSessionFromBearerToken(
 
 /**
  * Retrieves the API Key from the Authorization header value.
- * @returns Result<Key, APIErrorWithStatusCode>
+ * @returns Result<Key, APIErrorWithContentfulStatusCode>
  */
 export async function getAPIKey(
   authHeader: string | undefined
-): Promise<Result<KeyResource, APIErrorWithStatusCode>> {
+): Promise<Result<KeyResource, APIErrorWithContentfulStatusCode>> {
   const token = await getBearerToken(authHeader);
 
   if (token.isErr()) {

--- a/front/lib/project_task/start_agent.ts
+++ b/front/lib/project_task/start_agent.ts
@@ -16,10 +16,11 @@ import type {
 } from "@app/types/project_task";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { toFileContentFragment } from "../api/assistant/conversation/content_fragment";
 
 type StartProjectTaskAgentError = {
-  statusCode: number;
+  statusCode: ContentfulStatusCode;
   type: APIErrorType;
   message: string;
 };

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -26,7 +26,7 @@ import {
   type WakeUpStatus,
   type WakeUpType,
 } from "@app/types/assistant/wakeups";
-import type { APIErrorWithStatusCode } from "@app/types/error";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -342,7 +342,7 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
   static async canUserInteract(
     auth: Authenticator,
     conversation: ConversationWithoutContentType
-  ): Promise<Result<void, APIErrorWithStatusCode>> {
+  ): Promise<Result<void, APIErrorWithContentfulStatusCode>> {
     const activeWakeUps = await this.listByConversation(auth, conversation, {
       status: ACTIVE_WAKE_UP_STATUSES,
     });

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -24,7 +24,7 @@ import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type { TriggerType } from "@app/types/assistant/triggers";
 import type { WakeUpType } from "@app/types/assistant/wakeups";
-import type { APIErrorWithStatusCode } from "@app/types/error";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -44,7 +44,7 @@ async function createConversationForAgentConfiguration({
   trigger: TriggerType;
   lastRunAt: Date | null;
   webhookRequest: WebhookRequestResource | null;
-}): Promise<Result<ConversationType, APIErrorWithStatusCode>> {
+}): Promise<Result<ConversationType, APIErrorWithContentfulStatusCode>> {
   const newConversation = await createConversation(auth, {
     title: null,
     visibility: "unlisted",

--- a/front/types/assistant/pubsub.ts
+++ b/front/types/assistant/pubsub.ts
@@ -1,3 +1,3 @@
-import type { APIErrorWithStatusCode } from "../error";
+import type { APIErrorWithContentfulStatusCode } from "../error";
 
-export type PubSubError = APIErrorWithStatusCode;
+export type PubSubError = APIErrorWithContentfulStatusCode;

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -5,6 +5,7 @@ import { CONVERSATION_ERROR_TYPES } from "@app/types/assistant/conversation";
 import type { CoreAPIError } from "@app/types/core/core_api";
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
 import type { ConnectorsAPIError } from "@dust-tt/client";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 
 export type InternalErrorWithStatusCode = {
   status_code: number;
@@ -202,10 +203,19 @@ export function isAPIError(obj: unknown): obj is APIError {
  * Type to transport a HTTP error with its http status code (eg: 404)
  * and the error object returned by our public API endpoints (api/v1/*)
  */
-export type APIErrorWithStatusCode = {
+export type APIErrorWithStatusCode<T extends number = number> = {
   api_error: APIError;
-  status_code: number;
+  status_code: T;
 };
+
+/**
+ * Narrow alias of `APIErrorWithStatusCode` constrained to Hono's
+ * `ContentfulStatusCode`. Use this in code that ultimately dispatches the
+ * error through `c.json(..., status_code)` so the status code can be passed
+ * without an `as ContentfulStatusCode` cast.
+ */
+export type APIErrorWithContentfulStatusCode =
+  APIErrorWithStatusCode<ContentfulStatusCode>;
 
 export type APIErrorResponse = {
   error: APIError;


### PR DESCRIPTION
## Description

  - Make `APIErrorWithStatusCode` generic over its status code type and add an `APIErrorWithContentfulStatusCode` alias (= `APIErrorWithStatusCode<ContentfulStatusCode>`).
  - Type Hono's `apiError` parameter as `APIErrorWithContentfulStatusCode`, removing the `err.status_code as ContentfulStatusCode` cast inside `c.json(...)`.
  - Cascade the narrowing through helpers in `front/lib/*` and `front-api/*` that ultimately feed `apiError`, plus a few sibling error shapes (`SearchError`, `ProgrammaticCostExportError`, `StartProjectTaskAgentError`, `STATUS_FOR_ERROR_TYPE`).
  - Drop the `as ContentfulStatusCode` casts in `front-api/routes/w/[wId]/verification/{start,validate}.ts` by narrowing `getStatusCodeForError`'s return type from `number` to `ContentfulStatusCode`.

  Re-applies cbc5086 and extends the same pattern to the helpers and routes added since.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
