### PR TITLE
front-api: keep next out of skill-instructions HTML import graph

### DIFF
--- a/front/components/editor/extensions/skill_builder/KnowledgeNode.ts
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNode.ts
@@ -1,17 +1,14 @@
-import {
-  computeHasChildren,
-  isFullKnowledgeItem,
-} from "@app/components/editor/extensions/skill_builder/KnowledgeNodeTypes";
 import type {
   BaseKnowledgeItem,
   KnowledgeItem,
 } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeTypes";
+import {
+  computeHasChildren,
+  isFullKnowledgeItem,
+} from "@app/components/editor/extensions/skill_builder/KnowledgeNodeTypes";
 import { Node } from "@tiptap/core";
 
-import {
-  KNOWLEDGE_TAG,
-  KNOWLEDGE_TAG_REGEX,
-} from "./KnowledgeNodeConstants";
+import { KNOWLEDGE_TAG, KNOWLEDGE_TAG_REGEX } from "./KnowledgeNodeConstants";
 
 export interface KnowledgeNodeAttributes {
   selectedItems: KnowledgeItem[];

--- a/front/components/editor/extensions/skill_builder/KnowledgeNode.ts
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNode.ts
@@ -1,16 +1,12 @@
-import type {
-  BaseKnowledgeItem,
-  KnowledgeItem,
-} from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
 import {
   computeHasChildren,
   isFullKnowledgeItem,
-  KnowledgeNodeView,
-} from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
+} from "@app/components/editor/extensions/skill_builder/KnowledgeNodeTypes";
+import type {
+  BaseKnowledgeItem,
+  KnowledgeItem,
+} from "@app/components/editor/extensions/skill_builder/KnowledgeNodeTypes";
 import { Node } from "@tiptap/core";
-import type { NodeViewProps } from "@tiptap/react";
-import { NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
-import type React from "react";
 
 import {
   KNOWLEDGE_TAG,
@@ -28,21 +24,6 @@ const KNOWLEDGE_CHIP_CLASS =
 // namespace elements. Using the emoji in both paths keeps additions and deletions
 // visually consistent in the suggestion diff view.
 const DOCUMENT_ICON = "📄";
-
-const KnowledgeNodeReadOnlyView: React.FC<NodeViewProps> = ({ node }) => {
-  const { selectedItems } = node.attrs;
-  const item = selectedItems[0] as KnowledgeItem | undefined;
-  if (!item) {
-    return null;
-  }
-  // No background or explicit color so diff decorations act on the content directly
-  return (
-    <NodeViewWrapper as="span" className={KNOWLEDGE_CHIP_CLASS}>
-      <span>{DOCUMENT_ICON}</span>
-      <span>{` ${item.label}`}</span>
-    </NodeViewWrapper>
-  );
-};
 
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
@@ -243,12 +224,6 @@ export const KnowledgeNode = Node.create<KnowledgeNodeOptions>({
         selectedItems: [selectedItem],
       },
     };
-  },
-
-  addNodeView() {
-    return ReactNodeViewRenderer(
-      this.options.readOnly ? KnowledgeNodeReadOnlyView : KnowledgeNodeView
-    );
   },
 
   addCommands() {

--- a/front/components/editor/extensions/skill_builder/KnowledgeNode.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNode.tsx
@@ -12,6 +12,11 @@ import type { NodeViewProps } from "@tiptap/react";
 import { NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
 import type React from "react";
 
+import {
+  KNOWLEDGE_TAG,
+  KNOWLEDGE_TAG_REGEX,
+} from "./KnowledgeNodeConstants";
+
 export interface KnowledgeNodeAttributes {
   selectedItems: KnowledgeItem[];
 }
@@ -48,11 +53,6 @@ declare module "@tiptap/core" {
 }
 
 export const KNOWLEDGE_NODE_TYPE = "knowledgeNode";
-
-const KNOWLEDGE_TAG = "knowledge";
-export const KNOWLEDGE_TAG_REGEX = new RegExp(
-  `^<${KNOWLEDGE_TAG}\\s+([^>]+)\\s*/>`
-);
 
 export interface KnowledgeNodeOptions {
   readOnly: boolean;

--- a/front/components/editor/extensions/skill_builder/KnowledgeNodeConstants.ts
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNodeConstants.ts
@@ -1,0 +1,7 @@
+// Pure constants for the knowledge node — kept React-free so server-side
+// code (e.g. skill_instructions_html) can import them without dragging the
+// editor's React/TipTap node-view chain into the import graph.
+export const KNOWLEDGE_TAG = "knowledge";
+export const KNOWLEDGE_TAG_REGEX = new RegExp(
+  `^<${KNOWLEDGE_TAG}\\s+([^>]+)\\s*/>`
+);

--- a/front/components/editor/extensions/skill_builder/KnowledgeNodeTypes.ts
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNodeTypes.ts
@@ -1,0 +1,49 @@
+// Pure types and helpers for the knowledge node — kept React-free so the
+// schema-only KnowledgeNode extension and any server-side TipTap pipeline
+// can import them without dragging in the React NodeView chain.
+import type { DataSourceViewContentNode } from "@app/types/data_source_view";
+
+// Minimal data from serialization.
+export interface BaseKnowledgeItem {
+  dataSourceViewId: string;
+  hasChildren: boolean;
+  label: string;
+  nodeId: string;
+  spaceId: string;
+}
+
+// Fresh selection from search with complete node data.
+export interface FullKnowledgeItem extends BaseKnowledgeItem {
+  node: DataSourceViewContentNode;
+}
+
+export type KnowledgeItem = BaseKnowledgeItem | FullKnowledgeItem;
+
+export function isFullKnowledgeItem(
+  item: KnowledgeItem
+): item is FullKnowledgeItem {
+  return "node" in item && item.node !== undefined;
+}
+
+/**
+ * Computes whether a node has children, with special handling for Notion.
+ * For Notion: pages and databases can have children even if they're currently empty.
+ * For others: uses expandable field or node type.
+ */
+export function computeHasChildren(node: DataSourceViewContentNode): boolean {
+  const isNotion =
+    node.dataSourceView.dataSource.connectorProvider === "notion";
+
+  if (isNotion) {
+    // In Notion, pages (documents) and databases (tables) can have children.
+    // Folders always can have children (though Notion doesn't actually use folders).
+    return (
+      node.type === "folder" ||
+      node.type === "document" ||
+      node.type === "table"
+    );
+  }
+
+  // For non-Notion sources, use the childrenCount field.
+  return node.childrenCount > 0;
+}

--- a/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
@@ -4,6 +4,14 @@ import {
   KnowledgeErrorChip,
 } from "@app/components/editor/extensions/skill_builder/KnowledgeChip";
 import type { KnowledgeNodeAttributes } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
+import type {
+  FullKnowledgeItem,
+  KnowledgeItem,
+} from "@app/components/editor/extensions/skill_builder/KnowledgeNodeTypes";
+import {
+  computeHasChildren,
+  isFullKnowledgeItem,
+} from "@app/components/editor/extensions/skill_builder/KnowledgeNodeTypes";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers_ui";
 import {
   getLocationForDataSourceViewContentNodeWithSpace,
@@ -13,14 +21,6 @@ import { isFolder, isWebsite } from "@app/lib/data_sources";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import { useUnifiedSearch } from "@app/lib/swr/search";
 import { useSpaceDataSourceView, useSpaces } from "@app/lib/swr/spaces";
-import {
-  computeHasChildren,
-  isFullKnowledgeItem,
-} from "@app/components/editor/extensions/skill_builder/KnowledgeNodeTypes";
-import type {
-  FullKnowledgeItem,
-  KnowledgeItem,
-} from "@app/components/editor/extensions/skill_builder/KnowledgeNodeTypes";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType } from "@app/types/user";
 import {

--- a/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
@@ -13,7 +13,14 @@ import { isFolder, isWebsite } from "@app/lib/data_sources";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import { useUnifiedSearch } from "@app/lib/swr/search";
 import { useSpaceDataSourceView, useSpaces } from "@app/lib/swr/spaces";
-import type { DataSourceViewContentNode } from "@app/types/data_source_view";
+import {
+  computeHasChildren,
+  isFullKnowledgeItem,
+} from "@app/components/editor/extensions/skill_builder/KnowledgeNodeTypes";
+import type {
+  FullKnowledgeItem,
+  KnowledgeItem,
+} from "@app/components/editor/extensions/skill_builder/KnowledgeNodeTypes";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
@@ -31,50 +38,17 @@ import { NodeViewWrapper } from "@tiptap/react";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-// Minimal data from serialization.
-export interface BaseKnowledgeItem {
-  dataSourceViewId: string;
-  hasChildren: boolean;
-  label: string;
-  nodeId: string;
-  spaceId: string;
-}
-
-// Fresh selection from search with complete node data.
-export interface FullKnowledgeItem extends BaseKnowledgeItem {
-  node: DataSourceViewContentNode;
-}
-
-export type KnowledgeItem = BaseKnowledgeItem | FullKnowledgeItem;
-
-export function isFullKnowledgeItem(
-  item: KnowledgeItem
-): item is FullKnowledgeItem {
-  return "node" in item && item.node !== undefined;
-}
-
-/**
- * Computes whether a node has children, with special handling for Notion.
- * For Notion: pages and databases can have children even if they're currently empty.
- * For others: uses expandable field or node type.
- */
-export function computeHasChildren(node: DataSourceViewContentNode): boolean {
-  const isNotion =
-    node.dataSourceView.dataSource.connectorProvider === "notion";
-
-  if (isNotion) {
-    // In Notion, pages (documents) and databases (tables) can have children.
-    // Folders always can have children (though Notion doesn't actually use folders).
-    return (
-      node.type === "folder" ||
-      node.type === "document" ||
-      node.type === "table"
-    );
-  }
-
-  // For non-Notion sources, use the childrenCount field.
-  return node.childrenCount > 0;
-}
+// Re-exports for existing consumers that import these from KnowledgeNodeView.
+// The canonical home is now KnowledgeNodeTypes.ts (React-free).
+export type {
+  BaseKnowledgeItem,
+  FullKnowledgeItem,
+  KnowledgeItem,
+} from "@app/components/editor/extensions/skill_builder/KnowledgeNodeTypes";
+export {
+  computeHasChildren,
+  isFullKnowledgeItem,
+} from "@app/components/editor/extensions/skill_builder/KnowledgeNodeTypes";
 
 interface KnowledgeDisplayProps {
   item: KnowledgeItem;

--- a/front/components/editor/extensions/skill_builder/KnowledgeNodeWithView.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNodeWithView.tsx
@@ -1,0 +1,33 @@
+import { KnowledgeNode } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
+import type { KnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeTypes";
+import { KnowledgeNodeView } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
+import type { NodeViewProps } from "@tiptap/react";
+import { NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
+import type React from "react";
+
+const KNOWLEDGE_CHIP_CLASS =
+  "inline-flex items-center gap-0.5 border border-current/40 rounded px-0.5 text-xs leading-tight";
+const DOCUMENT_ICON = "📄";
+
+const KnowledgeNodeReadOnlyView: React.FC<NodeViewProps> = ({ node }) => {
+  const { selectedItems } = node.attrs;
+  const item = selectedItems[0] as KnowledgeItem | undefined;
+  if (!item) {
+    return null;
+  }
+  // No background or explicit color so diff decorations act on the content directly
+  return (
+    <NodeViewWrapper as="span" className={KNOWLEDGE_CHIP_CLASS}>
+      <span>{DOCUMENT_ICON}</span>
+      <span>{` ${item.label}`}</span>
+    </NodeViewWrapper>
+  );
+};
+
+export const KnowledgeNodeWithView = KnowledgeNode.extend({
+  addNodeView() {
+    return ReactNodeViewRenderer(
+      this.options.readOnly ? KnowledgeNodeReadOnlyView : KnowledgeNodeView
+    );
+  },
+});

--- a/front/lib/editor/build_skill_instructions_extensions_server.ts
+++ b/front/lib/editor/build_skill_instructions_extensions_server.ts
@@ -1,3 +1,7 @@
+// Server-side variant of buildSkillInstructionsExtensions. Mirrors the editor
+// builder but uses schema-only TipTap extensions and skips React/sparkle
+// imports, so it can be loaded by server code (e.g. skill_instructions_html)
+// without dragging the editor's React NodeView chain into the import graph.
 import { InstructionSuggestionExtension } from "@app/components/editor/extensions/agent_builder/InstructionSuggestionExtension";
 import { CodeExtension } from "@app/components/editor/extensions/CodeExtension";
 import { HeadingExtension } from "@app/components/editor/extensions/HeadingExtension";
@@ -5,30 +9,22 @@ import { BlockIdExtension } from "@app/components/editor/extensions/instructions
 import { InstructionsDocumentExtension } from "@app/components/editor/extensions/instructions/InstructionsDocumentExtension";
 import { InstructionsRootExtension } from "@app/components/editor/extensions/instructions/InstructionsRootExtension";
 import { ListItemExtension } from "@app/components/editor/extensions/ListItemExtension";
-import { KnowledgeNodeWithView } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeWithView";
+import { KnowledgeNode } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
 import {
   RawMarkdownBlock,
   rawMarkdownBlockParsers,
 } from "@app/components/editor/extensions/skill_builder/RawMarkdownBlock";
 import { LinkExtension } from "@app/components/editor/input_bar/LinkExtension";
-import { markdownStyles } from "@dust-tt/sparkle";
 import type { Extensions } from "@tiptap/core";
 import { Markdown } from "@tiptap/markdown";
 import { StarterKit } from "@tiptap/starter-kit";
 
-export const INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT = 120_000;
-
-/**
- * Build the TipTap extension list for the skill instructions editor.
- *
- * @param isReadOnly - When true, interactive editing extensions are omitted.
- * @param editableExtensions - Extensions appended when `isReadOnly` is false.
- */
-export function buildSkillInstructionsExtensions(
-  isReadOnly: boolean,
-  editableExtensions: Extensions = []
-): Extensions {
-  const baseExtensions: Extensions = [
+// Server-side rendering strips presentation attributes from the output HTML
+// (see stripPresentationAttributes in skill_instructions_html.ts), so the
+// editor's markdownStyles classes would be removed anyway. Omit them here
+// to avoid importing @dust-tt/sparkle.
+export function buildSkillInstructionsExtensionsForServer(): Extensions {
+  return [
     InstructionsDocumentExtension,
     InstructionsRootExtension,
     Markdown.configure(),
@@ -36,64 +32,27 @@ export function buildSkillInstructionsExtensions(
       // document: false is required because InstructionsDocumentExtension
       // replaces StarterKit's default Document node.
       document: false,
-      orderedList: {
-        HTMLAttributes: {
-          class: markdownStyles.orderedList(),
-        },
-      },
       listItem: false,
       link: false,
-      bulletList: {
-        HTMLAttributes: {
-          class: markdownStyles.unorderedList(),
-        },
-      },
       blockquote: false,
       horizontalRule: false,
       strike: false,
       heading: false,
       code: false,
-      codeBlock: {
-        HTMLAttributes: {
-          class: markdownStyles.codeBlock(),
-        },
-      },
-      paragraph: {
-        HTMLAttributes: {
-          class: markdownStyles.paragraph(),
-        },
-      },
     }),
-    CodeExtension.configure({
-      HTMLAttributes: {
-        class: markdownStyles.codeInline(),
-      },
-    }),
-    ListItemExtension.configure({
-      HTMLAttributes: {
-        class: markdownStyles.list(),
-      },
-    }),
+    CodeExtension,
+    ListItemExtension,
     LinkExtension.configure({
       autolink: false,
       openOnClick: false,
     }),
     HeadingExtension.configure({
       levels: [1, 2, 3, 4, 5, 6],
-      HTMLAttributes: {
-        class: "mt-4 mb-3",
-      },
     }),
     BlockIdExtension,
-    KnowledgeNodeWithView.configure({ readOnly: isReadOnly }),
+    KnowledgeNode.configure({ readOnly: true }),
     InstructionSuggestionExtension.configure({ showBlockHighlight: false }),
     RawMarkdownBlock,
     ...rawMarkdownBlockParsers,
   ];
-
-  if (!isReadOnly) {
-    baseExtensions.push(...editableExtensions);
-  }
-
-  return baseExtensions;
 }

--- a/front/lib/notifications/email-templates/_layout.tsx
+++ b/front/lib/notifications/email-templates/_layout.tsx
@@ -1,7 +1,5 @@
-// biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import config from "@app/lib/api/config";
 import { Html } from "@react-email/html";
-import Head from "next/head";
 import type React from "react";
 
 export const EmailLayout = ({
@@ -13,9 +11,9 @@ export const EmailLayout = ({
 }) => {
   return (
     <Html>
-      <Head>
+      <head>
         <title>An email from Dust about {workspace.name}</title>
-      </Head>
+      </head>
       <body
         style={{
           fontFamily: "Open Sans, Helvetica Neue, Helvetica, Arial, sans-serif",

--- a/front/lib/reinforcement/skill_instructions_html.ts
+++ b/front/lib/reinforcement/skill_instructions_html.ts
@@ -3,7 +3,7 @@ import {
   BLOCK_ID_UNIQUE_ID_NODE_TYPES,
 } from "@app/components/editor/extensions/instructions/BlockIdExtension";
 import { INSTRUCTIONS_ROOT_NODE_NAME } from "@app/components/editor/extensions/instructions/InstructionsRootExtension";
-import { KNOWLEDGE_TAG_REGEX } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
+import { KNOWLEDGE_TAG_REGEX } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeConstants";
 import { buildSkillInstructionsExtensions } from "@app/lib/editor/build_skill_instructions_extensions";
 import { preprocessMarkdownForEditor } from "@app/lib/editor/skill_instructions_preprocessing";
 import { generateShortBlockId } from "@app/lib/generate_short_block_id";

--- a/front/lib/reinforcement/skill_instructions_html.ts
+++ b/front/lib/reinforcement/skill_instructions_html.ts
@@ -4,7 +4,7 @@ import {
 } from "@app/components/editor/extensions/instructions/BlockIdExtension";
 import { INSTRUCTIONS_ROOT_NODE_NAME } from "@app/components/editor/extensions/instructions/InstructionsRootExtension";
 import { KNOWLEDGE_TAG_REGEX } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeConstants";
-import { buildSkillInstructionsExtensions } from "@app/lib/editor/build_skill_instructions_extensions";
+import { buildSkillInstructionsExtensionsForServer } from "@app/lib/editor/build_skill_instructions_extensions_server";
 import { preprocessMarkdownForEditor } from "@app/lib/editor/skill_instructions_preprocessing";
 import { generateShortBlockId } from "@app/lib/generate_short_block_id";
 import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
@@ -13,7 +13,7 @@ import { MarkdownManager } from "@tiptap/markdown";
 import { renderToHTMLString } from "@tiptap/static-renderer/pm/html-string";
 import * as cheerio from "cheerio";
 
-const SKILL_EDITOR_EXTENSIONS = buildSkillInstructionsExtensions(true, []);
+const SKILL_EDITOR_EXTENSIONS = buildSkillInstructionsExtensionsForServer();
 const MARKDOWN_MANAGER = new MarkdownManager({
   extensions: SKILL_EDITOR_EXTENSIONS,
 });

--- a/tools/mprocs.yaml
+++ b/tools/mprocs.yaml
@@ -76,25 +76,6 @@ procs:
       # exec replaces this shell with tsx so mprocs's signals reach node
       # directly (npm doesn't reliably forward signals to its child).
       export NODE_ENV=development
-      exec ../node_modules/.bin/tsx ./server.ts
-    autostart: false
-
-  front-hono-strict:
-    cwd: "<CONFIG_DIR>/../front-api"
-    shell: |
-      set -euo pipefail
-      export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
-      [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-      nvm use
-      echo "Node $(node --version)"
-      READY_FILE="../sdks/js/dist/client.esm.js.map"
-      echo "Waiting for sdks-js to compile..."
-      echo "Expecting file: $READY_FILE"
-      while [ ! -f "$READY_FILE" ]; do sleep 1; done
-      echo "sdks-js ready. Starting front-api (Hono only, no Next)."
-      # exec replaces this shell with tsx so mprocs's signals reach node
-      # directly (npm doesn't reliably forward signals to its child).
-      export NODE_ENV=development
       # Guard: throw if anything tries to load `next` at runtime.
       export NODE_OPTIONS="--require=./forbid-next.cjs"
       exec ../node_modules/.bin/tsx ./server.ts


### PR DESCRIPTION
## Description

  The Hono-only `front-api` server is guarded at runtime by `forbid-next.cjs`, which throws if anything resolves `next` or `next/*`. Two chains in the front-side code base were tripping it:

  1. `front/lib/notifications/email-templates/_layout.tsx` imported `Head` from `next/head` to render a `<title>` inside React Email markup. Replaced with a plain `<head><title>…</title></head>` — same output, no Next dependency.

  2. Route handlers under `routes/w/[wId]/skills/...` transitively reach `front/lib/reinforcement/skill_instructions_html.ts`, which calls `buildSkillInstructionsExtensions(...)`. That builder imported the full TipTap extension set, including the React `addNodeView` on
  `KnowledgeNode` — which pulled the React `KnowledgeNodeView` → app hooks → SWR → `@app/lib/platform` (the routing shim) → `next/navigation`.

  The TipTap static HTML renderer (`renderToHTMLString`) never instantiates `NodeView`s — it only calls `renderHTML` / `parseHTML` / `markdownTokenizer`. So the React side is dead weight on the server path. This PR splits the affected extension so the server-side build doesn't load it.

  ## Changes

  - **Split `KnowledgeNode` into schema vs React-view halves:**
    - `KnowledgeNode.ts` — schema-only `Node.create({...})`: attrs, parseHTML, renderHTML, markdown tokenizer, renderMarkdown, parseMarkdown, addCommands. No React imports.
    - `KnowledgeNodeWithView.tsx` — `KnowledgeNode.extend({ addNodeView: ... })` plus the read-only NodeView JSX.
  - **Pull types and pure helpers out of `KnowledgeNodeView.tsx`** into `KnowledgeNodeTypes.ts` (`BaseKnowledgeItem`, `FullKnowledgeItem`, `KnowledgeItem`, `isFullKnowledgeItem`, `computeHasChildren`). `KnowledgeNodeView.tsx` re-exports them for backward compatibility
  with existing client consumers.
  - **Server-side extensions builder:** new `build_skill_instructions_extensions_server.ts` mirrors the editor builder but uses the schema-only `KnowledgeNode` and omits `@dust-tt/sparkle`'s `markdownStyles` (the server already strips presentation attributes from the
  rendered HTML).
  - **`skill_instructions_html.ts`** switched to `buildSkillInstructionsExtensionsForServer()`.
  - **Editor builder** (`build_skill_instructions_extensions.ts`) now imports `KnowledgeNodeWithView` so the in-browser editor keeps its React NodeView.
  - **`_layout.tsx`** uses a plain `<head><title>…</title></head>` inside `<Html>`.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
