### PR TITLE
Refactor compact mode to improve the behavior

### DIFF
--- a/front/components/assistant/AgentPicker.tsx
+++ b/front/components/assistant/AgentPicker.tsx
@@ -1,5 +1,6 @@
 import { CreateDropdown } from "@app/components/assistant/CreateDropdown";
 import { useClientType } from "@app/lib/context/clientType";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { filterAndSortAgents } from "@app/lib/utils";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -30,6 +31,7 @@ interface AgentPickerProps {
   isLoading?: boolean;
   disabled?: boolean;
   mountPortal?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 export function AgentPicker({
@@ -44,8 +46,10 @@ export function AgentPicker({
   size = "md",
   isLoading = false,
   disabled = false,
+  onOpenChange,
 }: AgentPickerProps) {
   const clientType = useClientType();
+  const isMobile = useIsMobile();
   const [searchText, setSearchText] = useState("");
   const [isOpen, setIsOpen] = useState(false);
 
@@ -56,6 +60,7 @@ export function AgentPicker({
       open={isOpen}
       onOpenChange={(open) => {
         setIsOpen(open);
+        onOpenChange?.(open);
         if (open) {
           setSearchText("");
         }
@@ -83,7 +88,7 @@ export function AgentPicker({
         dropdownHeaders={
           <>
             <DropdownMenuSearchbar
-              autoFocus
+              autoFocus={!isMobile}
               name="search-agents"
               placeholder="Search Agents"
               value={searchText}

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -20,6 +20,7 @@ import {
   useSkillWithRelations,
 } from "@app/lib/swr/skill_configurations";
 import { useSpaces } from "@app/lib/swr/spaces";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import {
   TRACKING_ACTIONS,
   TRACKING_AREAS,
@@ -309,6 +310,7 @@ interface CapabilitiesPickerProps {
   isLoading?: boolean;
   disabled?: boolean;
   buttonSize?: "xs" | "sm" | "md";
+  onOpenChange?: (open: boolean) => void;
 }
 
 export function CapabilitiesPicker({
@@ -320,7 +322,9 @@ export function CapabilitiesPicker({
   isLoading = false,
   disabled = false,
   buttonSize = "xs",
+  onOpenChange,
 }: CapabilitiesPickerProps) {
+  const isMobile = useIsMobile();
   const [searchText, setSearchText] = useState("");
   const [isOpen, setIsOpen] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
@@ -593,6 +597,7 @@ export function CapabilitiesPicker({
         open={isOpen}
         onOpenChange={(open) => {
           setIsOpen(open);
+          onOpenChange?.(open);
           if (open) {
             setIsClosing(false);
             trackEvent({
@@ -625,7 +630,7 @@ export function CapabilitiesPicker({
           }}
         >
           <DropdownMenuSearchbar
-            autoFocus
+            autoFocus={!isMobile}
             name="search-capabilities"
             placeholder="Search capabilities"
             value={searchText}

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -3,6 +3,8 @@ import { ContextUsageWarningBanner } from "@app/components/assistant/conversatio
 import { useGenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
 import { InputBarMessageNavigation } from "@app/components/assistant/conversation/input_bar/InputBarMessageNavigation";
+import { INPUT_BAR_COMPACT_NAV_ENTER_ANIMATION_CLASSES } from "@app/components/assistant/conversation/input_bar/inputBarCompactStyles";
+import { useInputBarCompactMode } from "@app/components/assistant/conversation/input_bar/useInputBarCompactMode";
 import type {
   VirtuosoMessage,
   VirtuosoMessageListContext,
@@ -85,25 +87,16 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
   );
   const methods = useVirtuosoMethods<VirtuosoMessage>();
   const { bottomOffset, listOffset, visibleListHeight } = useVirtuosoLocation();
-  const [isInputBarExpanded, setIsInputBarExpanded] = useState(true);
-  const [isEditorFocused, setIsEditorFocused] = useState(false);
-  const prevListOffsetRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    if (prevListOffsetRef.current === null) {
-      prevListOffsetRef.current = listOffset;
-      return;
-    }
-
-    if (listOffset !== prevListOffsetRef.current) {
-      prevListOffsetRef.current = listOffset;
-      setIsInputBarExpanded(false);
-    }
-  }, [listOffset]);
-
-  const isInputBarCompact =
-    isMobile && !agentBuilderContext && !isInputBarExpanded;
-  const effectiveIsCompact = isInputBarCompact && !isEditorFocused;
+  const {
+    effectiveIsCompact,
+    expandInputBar,
+    onEditorFocusChange,
+    onOverlayOpenChange,
+    onVoiceActiveChange,
+  } = useInputBarCompactMode({
+    enabled: isMobile && !agentBuilderContext,
+    listOffset,
+  });
 
   const allMessages = methods.data.get();
 
@@ -567,10 +560,12 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
       >
         {effectiveIsCompact && showNavigationContainer && (
           <div className="absolute right-0 top-1/2 z-10 -translate-y-1/2">
-            <InputBarMessageNavigation
-              variant="compact"
-              {...messageNavigationProps}
-            />
+            <div className={INPUT_BAR_COMPACT_NAV_ENTER_ANIMATION_CLASSES}>
+              <InputBarMessageNavigation
+                variant="compact"
+                {...messageNavigationProps}
+              />
+            </div>
           </div>
         )}
         <InputBar
@@ -586,9 +581,11 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
           isSubmitting={agentBuilderContext?.isSubmitting === true}
           isAgentBuilder={!!agentBuilderContext}
           submitBlockMessage={wakeUpBlockMessage ?? compactionBlockMessage}
-          isCompact={isInputBarCompact}
-          onExpandInputBar={() => setIsInputBarExpanded(true)}
-          onEditorFocusChange={setIsEditorFocused}
+          effectiveIsCompact={effectiveIsCompact}
+          onExpandInputBar={expandInputBar}
+          onEditorFocusChange={onEditorFocusChange}
+          onOverlayOpenChange={onOverlayOpenChange}
+          onVoiceActiveChange={onVoiceActiveChange}
         />
       </div>
     </div>

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -7,7 +7,11 @@ import InputBarContainer, {
   INPUT_BAR_ACTIONS,
 } from "@app/components/assistant/conversation/input_bar/InputBarContainer";
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
-import { INPUT_BAR_COMPACT_PILL_CLASSES } from "@app/components/assistant/conversation/input_bar/inputBarCompactStyles";
+import {
+  INPUT_BAR_COMPACT_ENTER_ANIMATION_CLASSES,
+  INPUT_BAR_COMPACT_MORPH_TRANSITION_CLASSES,
+  INPUT_BAR_COMPACT_PILL_CLASSES,
+} from "@app/components/assistant/conversation/input_bar/inputBarCompactStyles";
 import { useConversationDrafts } from "@app/components/assistant/conversation/input_bar/useConversationDrafts";
 import { PlanCard } from "@app/components/assistant/conversation/plan_mode/PlanCard";
 import {
@@ -66,9 +70,11 @@ interface InputBarProps {
   disableInput?: boolean;
   submitBlockMessage?: string | null;
   placeholder?: string;
-  isCompact?: boolean;
+  effectiveIsCompact?: boolean;
   onExpandInputBar?: () => void;
   onEditorFocusChange?: (focused: boolean) => void;
+  onOverlayOpenChange?: (open: boolean) => void;
+  onVoiceActiveChange?: (active: boolean) => void;
 }
 
 export const InputBar = React.memo(function InputBar({
@@ -88,22 +94,14 @@ export const InputBar = React.memo(function InputBar({
   disableInput = false,
   submitBlockMessage = null,
   placeholder,
-  isCompact = false,
+  effectiveIsCompact = false,
   onExpandInputBar,
   onEditorFocusChange,
+  onOverlayOpenChange,
+  onVoiceActiveChange,
 }: InputBarProps) {
   const [isLocalSubmitting, setIsLocalSubmitting] = useState(isSubmitting);
   const [isShaking, setIsShaking] = useState(false);
-  const [isEditorFocused, setIsEditorFocused] = useState(false);
-  const effectiveIsCompact = isCompact && !isEditorFocused;
-
-  const handleEditorFocusChange = useCallback(
-    (focused: boolean) => {
-      setIsEditorFocused(focused);
-      onEditorFocusChange?.(focused);
-    },
-    [onEditorFocusChange]
-  );
 
   const [attachedNodes, setAttachedNodes] = useState<
     DataSourceViewContentNode[]
@@ -415,13 +413,29 @@ export const InputBar = React.memo(function InputBar({
       />
       <div
         onAnimationEnd={() => setIsShaking(false)}
+        onClick={(e) => {
+          if (!effectiveIsCompact || disableInput) {
+            return;
+          }
+          if (
+            e.target instanceof HTMLElement &&
+            e.target.closest("[data-compact-voice]")
+          ) {
+            return;
+          }
+          onExpandInputBar?.();
+        }}
         className={classNames(
           isShaking && "animate-shake",
           "relative flex flex-col items-stretch gap-0 sm:flex-row",
-          "transition-all duration-300",
+          INPUT_BAR_COMPACT_MORPH_TRANSITION_CLASSES,
           !effectiveIsCompact && "w-full flex-1 self-stretch",
           effectiveIsCompact
-            ? INPUT_BAR_COMPACT_PILL_CLASSES
+            ? classNames(
+                INPUT_BAR_COMPACT_PILL_CLASSES,
+                INPUT_BAR_COMPACT_ENTER_ANIMATION_CLASSES,
+                !disableInput && "cursor-pointer"
+              )
             : classNames(
                 "w-full rounded-2xl",
                 "bg-muted-background dark:bg-muted-background-night",
@@ -493,7 +507,9 @@ export const InputBar = React.memo(function InputBar({
             onShake={handleShake}
             isCompact={effectiveIsCompact}
             onExpandInputBar={onExpandInputBar}
-            onEditorFocusChange={handleEditorFocusChange}
+            onEditorFocusChange={onEditorFocusChange}
+            onOverlayOpenChange={onOverlayOpenChange}
+            onVoiceActiveChange={onVoiceActiveChange}
           />
         </div>
       </div>

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -23,6 +23,7 @@ import type {
 } from "@app/lib/search/tools/types";
 import { useUnifiedSearch } from "@app/lib/swr/search";
 import { useSpaces } from "@app/lib/swr/spaces";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/utils";
 import type { DataSourceType } from "@app/types/data_source";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
@@ -105,6 +106,7 @@ interface InputBarAttachmentsPickerProps {
   onFileChange?: () => void;
   externalOpen?: boolean;
   onExternalOpenChange?: (open: boolean) => void;
+  onOpenChange?: (open: boolean) => void;
   anchorRef?: React.RefObject<HTMLElement | null>;
 }
 
@@ -274,8 +276,10 @@ export const InputBarAttachmentsPicker = ({
   onFileChange,
   externalOpen,
   onExternalOpenChange,
+  onOpenChange,
   anchorRef,
 }: InputBarAttachmentsPickerProps) => {
+  const isMobile = useIsMobile();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const itemsContainerRef = useRef<HTMLDivElement>(null);
   const [internalOpen, setInternalOpen] = useState(false);
@@ -549,6 +553,7 @@ export const InputBarAttachmentsPicker = ({
       open={isOpen}
       onOpenChange={(open) => {
         setIsOpen(open);
+        onOpenChange?.(open);
         if (open) {
           setSearch("");
         }
@@ -625,7 +630,7 @@ export const InputBarAttachmentsPicker = ({
               multiple={true}
             />
             <DropdownMenuSearchbar
-              autoFocus
+              autoFocus={!isMobile}
               name="search-files"
               placeholder="Search"
               value={search}

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -48,6 +48,9 @@ interface InputBarButtonsProps {
   selectedMCPServerViews: MCPServerViewType[];
   space: SpaceType | undefined;
   user: UserType | null;
+  onAgentPickerOpenChange?: (open: boolean) => void;
+  onCapabilitiesPickerOpenChange?: (open: boolean) => void;
+  onAttachmentsPickerOpenChange?: (open: boolean) => void;
 }
 
 export const InputBarButtons = React.memo(function InputBarButtons({
@@ -74,6 +77,9 @@ export const InputBarButtons = React.memo(function InputBarButtons({
   selectedMCPServerViews,
   space,
   user,
+  onAgentPickerOpenChange,
+  onCapabilitiesPickerOpenChange,
+  onAttachmentsPickerOpenChange,
 }: InputBarButtonsProps) {
   const router = useAppRouter();
   // Current space is taken from the conversation (if already set) or from the space prop (if provided).
@@ -89,6 +95,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
       owner={owner}
       size={buttonSize}
       onAgentDetailsClick={handleAgentDetailsClick}
+      onOpenChange={onAgentPickerOpenChange}
       onItemClick={(c) => {
         handleSingleAgentSelect(toRichAgentMentionType(c));
       }}
@@ -154,6 +161,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
       selectedMCPServerViews={selectedMCPServerViews}
       onSelect={onMCPServerViewSelect}
       onSkillSelect={onSkillSelect}
+      onOpenChange={onCapabilitiesPickerOpenChange}
       buttonSize={buttonSize}
       disabled={isInputDisabled}
     />
@@ -183,6 +191,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
           onNodeUnselect={onNodeUnselect}
           attachedNodes={attachedNodes}
           buttonSize={buttonSize}
+          onOpenChange={onAttachmentsPickerOpenChange}
           toolFileUpload={{
             useCase: "conversation",
             useCaseMetadata: {

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1,12 +1,16 @@
 import { ContextUsageIndicator } from "@app/components/assistant/conversation/input_bar/ContextUsageIndicator";
 import { InputBarAttachmentsPicker } from "@app/components/assistant/conversation/input_bar/InputBarAttachmentsPicker";
 import { InputBarButtons } from "@app/components/assistant/conversation/input_bar/InputBarButtons";
-import { INPUT_BAR_COMPACT_PILL_INNER_CLASSES } from "@app/components/assistant/conversation/input_bar/inputBarCompactStyles";
+import {
+  INPUT_BAR_COMPACT_CONTENT_ENTER_ANIMATION_CLASSES,
+  INPUT_BAR_COMPACT_PILL_INNER_CLASSES,
+} from "@app/components/assistant/conversation/input_bar/inputBarCompactStyles";
 import {
   getDisplayNameFromPastedFileId,
   getPastedFileName,
 } from "@app/components/assistant/conversation/input_bar/pasted_utils";
 import { ToolBarContent } from "@app/components/assistant/conversation/input_bar/toolbar/ToolbarContent";
+import { useInputBarOverlayTracker } from "@app/components/assistant/conversation/input_bar/useInputBarOverlayTracker";
 import type { InputBarSlashSuggestionCapability } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes";
 import type { CustomEditorProps } from "@app/components/editor/input_bar/useCustomEditor";
 import useCustomEditor from "@app/components/editor/input_bar/useCustomEditor";
@@ -124,6 +128,8 @@ export interface InputBarContainerProps {
   isCompact?: boolean;
   onExpandInputBar?: () => void;
   onEditorFocusChange?: (isFocused: boolean) => void;
+  onOverlayOpenChange?: (open: boolean) => void;
+  onVoiceActiveChange?: (active: boolean) => void;
   isSubmitting: boolean;
   onEnterKeyDown: CustomEditorProps["onEnterKeyDown"];
   onMCPServerViewDeselect: (serverView: MCPServerViewType) => void;
@@ -173,7 +179,16 @@ const InputBarContainer = ({
   isCompact = false,
   onExpandInputBar,
   onEditorFocusChange,
+  onOverlayOpenChange,
+  onVoiceActiveChange,
 }: InputBarContainerProps) => {
+  const { setOverlayOpen } = useInputBarOverlayTracker(onOverlayOpenChange);
+  const onSuggestionActiveChangeRef = useRef<(active: boolean) => void>(
+    () => {}
+  );
+  onSuggestionActiveChangeRef.current = (active) => {
+    setOverlayOpen("editor-suggestion", active);
+  };
   const isSubmitBlocked = submitBlockMessage !== null;
   const isCompactRef = useRef(isCompact);
   isCompactRef.current = isCompact;
@@ -224,6 +239,7 @@ const InputBarContainer = ({
   >(undefined);
   const [isCaptureDropdownOpen, setIsCaptureDropdownOpen] = useState(false);
   const [showKnowledgePicker, setShowKnowledgePicker] = useState(false);
+  const [isToolbarOpen, setIsToolbarOpen] = useState(false);
   const plusButtonRef = useRef<HTMLDivElement>(null);
   const clientType = useClientType();
   const shouldEnableSlashSuggestion = actions.includes("capabilities");
@@ -488,6 +504,7 @@ const InputBarContainer = ({
       selectedMCPServerViewIdsRef,
     },
     placeholderOverride: disableInput ? submitBlockMessage : placeholder,
+    onSuggestionActiveChangeRef,
     onLongTextPaste: async ({ text, from, to }) => {
       let filename = "";
       let inserted = false;
@@ -560,6 +577,18 @@ const InputBarContainer = ({
       editor.off("blur", handleBlur);
     };
   }, [editor, onEditorFocusChange]);
+
+  useEffect(() => {
+    setOverlayOpen("capture-dropdown", isCaptureDropdownOpen);
+  }, [isCaptureDropdownOpen, setOverlayOpen]);
+
+  useEffect(() => {
+    setOverlayOpen("knowledge-picker", showKnowledgePicker);
+  }, [showKnowledgePicker, setOverlayOpen]);
+
+  useEffect(() => {
+    setOverlayOpen("toolbar", isToolbarOpen);
+  }, [isToolbarOpen, setOverlayOpen]);
 
   useEffect(() => {
     // If an attachment disappears from the uploader, remove its chip from the editor
@@ -1010,7 +1039,6 @@ const InputBarContainer = ({
     isSubmitBlocked ||
     voiceTranscriberService.status !== "idle";
 
-  const [isToolbarOpen, setIsToolbarOpen] = useState(false);
   const hideCapabilities = startsWithUserMention && !selectedSingleAgent;
 
   const contentEditableClasses = classNames(
@@ -1022,6 +1050,10 @@ const InputBarContainer = ({
 
   const isRecording = voiceTranscriberService.status === "recording";
   const isVoiceActive = voiceTranscriberService.status !== "idle";
+
+  useEffect(() => {
+    onVoiceActiveChange?.(isVoiceActive);
+  }, [isVoiceActive, onVoiceActiveChange]);
 
   submitCompactVoiceMessageRef.current = async () => {
     if (disableAutoFocus) {
@@ -1063,18 +1095,15 @@ const InputBarContainer = ({
         <div
           className={cn(
             INPUT_BAR_COMPACT_PILL_INNER_CLASSES,
-            "relative w-auto px-1 sm:pt-0",
-            isVoiceActive && "pl-2"
+            INPUT_BAR_COMPACT_CONTENT_ENTER_ANIMATION_CLASSES,
+            "relative w-auto gap-0 sm:pt-0",
+            isVoiceActive ? "px-0.5" : "px-1"
           )}
         >
           {!isVoiceActive && (
-            <>
+            <div className="flex min-w-0 flex-1 items-center gap-1 px-1">
               <div
-                aria-label={
-                  selectedSingleAgent
-                    ? `Selected agent: ${selectedSingleAgent.label}`
-                    : "No agent selected"
-                }
+                aria-hidden
                 className="inline-flex min-w-0 max-w-24 items-center gap-1"
               >
                 {selectedSingleAgent ? (
@@ -1096,40 +1125,35 @@ const InputBarContainer = ({
                   </>
                 )}
               </div>
-              <Button
-                variant="ghost-secondary"
-                icon={ChevronUpDownIcon}
-                size="xs"
-                tooltip="Expand input"
-                disabled={disableInput}
-                onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  onExpandInputBar?.();
-                }}
-              />
-            </>
+              <ChevronUpDownIcon className="h-3.5 w-3.5 shrink-0 text-faint dark:text-faint-night" />
+            </div>
           )}
           {!subscription.plan.isByok &&
             owner.metadata?.allowVoiceTranscription !== false &&
             actions.includes("voice") && (
-              <VoicePicker
-                status={voiceTranscriberService.status}
-                level={voiceTranscriberService.level}
-                elapsedSeconds={voiceTranscriberService.elapsedSeconds}
-                onRecordStart={voiceTranscriberService.startRecording}
-                onRecordStop={voiceTranscriberService.stopRecording}
-                size="xs"
-                showStopLabel={false}
-                disabled={disableInput}
-              />
+              <div
+                className="flex shrink-0 flex-row items-center"
+                data-compact-voice
+              >
+                <VoicePicker
+                  status={voiceTranscriberService.status}
+                  level={voiceTranscriberService.level}
+                  elapsedSeconds={voiceTranscriberService.elapsedSeconds}
+                  onRecordStart={voiceTranscriberService.startRecording}
+                  onRecordStop={voiceTranscriberService.stopRecording}
+                  size="xs"
+                  compact
+                  showStopLabel={false}
+                  disabled={disableInput}
+                />
+              </div>
             )}
         </div>
       )}
       <div
         id="InputBarContainer"
         className={cn(
-          "relative flex flex-1 cursor-text flex-row sm:pt-0",
+          "relative flex flex-1 cursor-text flex-row transition-opacity duration-200 sm:pt-0",
           isCompact &&
             "pointer-events-none absolute h-0 w-0 overflow-hidden opacity-0"
         )}
@@ -1252,6 +1276,15 @@ const InputBarContainer = ({
                       selectedMCPServerViews={selectedMCPServerViews}
                       space={space}
                       user={user}
+                      onAgentPickerOpenChange={(open) =>
+                        setOverlayOpen("agent-picker", open)
+                      }
+                      onCapabilitiesPickerOpenChange={(open) =>
+                        setOverlayOpen("capabilities-picker", open)
+                      }
+                      onAttachmentsPickerOpenChange={(open) =>
+                        setOverlayOpen("attachments-picker", open)
+                      }
                     />
                   </div>
                 )}
@@ -1366,7 +1399,8 @@ const InputBarContainer = ({
               )}
               {!subscription.plan.isByok &&
                 owner.metadata?.allowVoiceTranscription !== false &&
-                actions.includes("voice") && (
+                actions.includes("voice") &&
+                !isCompact && (
                   <VoicePicker
                     status={voiceTranscriberService.status}
                     level={voiceTranscriberService.level}

--- a/front/components/assistant/conversation/input_bar/inputBarCompactStyles.ts
+++ b/front/components/assistant/conversation/input_bar/inputBarCompactStyles.ts
@@ -3,3 +3,15 @@ export const INPUT_BAR_COMPACT_PILL_CLASSES =
 
 export const INPUT_BAR_COMPACT_PILL_INNER_CLASSES =
   "flex h-8 flex-row items-center gap-1";
+
+export const INPUT_BAR_COMPACT_ENTER_ANIMATION_CLASSES =
+  "motion-safe:origin-bottom motion-safe:animate-input-bar-compact-in";
+
+export const INPUT_BAR_COMPACT_CONTENT_ENTER_ANIMATION_CLASSES =
+  "motion-safe:animate-input-bar-compact-content-in";
+
+export const INPUT_BAR_COMPACT_NAV_ENTER_ANIMATION_CLASSES =
+  "motion-safe:origin-center motion-safe:animate-input-bar-compact-nav-in";
+
+export const INPUT_BAR_COMPACT_MORPH_TRANSITION_CLASSES =
+  "transition-[border-radius,background-color,padding,border-color,box-shadow,opacity] duration-300 ease-out";

--- a/front/components/assistant/conversation/input_bar/useInputBarCompactMode.ts
+++ b/front/components/assistant/conversation/input_bar/useInputBarCompactMode.ts
@@ -1,0 +1,84 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const SCROLL_COMPACT_THRESHOLD_PX = 12;
+const SCROLL_COMPACT_DEBOUNCE_MS = 150;
+
+interface UseInputBarCompactModeOptions {
+  enabled: boolean;
+  listOffset: number;
+}
+
+export function useInputBarCompactMode({
+  enabled,
+  listOffset,
+}: UseInputBarCompactModeOptions) {
+  const [isExpanded, setIsExpanded] = useState(true);
+  const [isEditorFocused, setIsEditorFocused] = useState(false);
+  const [isOverlayOpen, setIsOverlayOpen] = useState(false);
+  const [isVoiceActive, setIsVoiceActive] = useState(false);
+
+  const isInteractingRef = useRef(false);
+  isInteractingRef.current = isEditorFocused || isOverlayOpen || isVoiceActive;
+
+  const prevListOffsetRef = useRef<number | null>(null);
+  const collapseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (collapseTimerRef.current) {
+        clearTimeout(collapseTimerRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      setIsExpanded(true);
+      prevListOffsetRef.current = listOffset;
+      return;
+    }
+
+    if (prevListOffsetRef.current === null) {
+      prevListOffsetRef.current = listOffset;
+      return;
+    }
+
+    const delta = Math.abs(listOffset - prevListOffsetRef.current);
+    prevListOffsetRef.current = listOffset;
+
+    if (delta < SCROLL_COMPACT_THRESHOLD_PX) {
+      return;
+    }
+
+    if (isInteractingRef.current) {
+      return;
+    }
+
+    if (collapseTimerRef.current) {
+      clearTimeout(collapseTimerRef.current);
+    }
+
+    collapseTimerRef.current = setTimeout(() => {
+      collapseTimerRef.current = null;
+      if (!isInteractingRef.current) {
+        setIsExpanded(false);
+      }
+    }, SCROLL_COMPACT_DEBOUNCE_MS);
+  }, [enabled, listOffset]);
+
+  const isScrolledCompactIntent = enabled && !isExpanded;
+  const effectiveIsCompact =
+    isScrolledCompactIntent && !isEditorFocused && !isOverlayOpen;
+
+  const expandInputBar = useCallback(() => {
+    setIsExpanded(true);
+  }, []);
+
+  return {
+    effectiveIsCompact,
+    expandInputBar,
+    onEditorFocusChange: setIsEditorFocused,
+    onOverlayOpenChange: setIsOverlayOpen,
+    onVoiceActiveChange: setIsVoiceActive,
+  };
+}

--- a/front/components/assistant/conversation/input_bar/useInputBarOverlayTracker.ts
+++ b/front/components/assistant/conversation/input_bar/useInputBarOverlayTracker.ts
@@ -1,0 +1,32 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export function useInputBarOverlayTracker(
+  onOverlayOpenChange?: (open: boolean) => void
+) {
+  const openOverlaysRef = useRef(new Set<string>());
+  const [isOverlayOpen, setIsOverlayOpen] = useState(false);
+
+  const notifyOverlayOpenChange = useCallback(() => {
+    const open = openOverlaysRef.current.size > 0;
+    setIsOverlayOpen(open);
+    onOverlayOpenChange?.(open);
+  }, [onOverlayOpenChange]);
+
+  const setOverlayOpen = useCallback(
+    (key: string, open: boolean) => {
+      if (open) {
+        openOverlaysRef.current.add(key);
+      } else {
+        openOverlaysRef.current.delete(key);
+      }
+      notifyOverlayOpenChange();
+    },
+    [notifyOverlayOpenChange]
+  );
+
+  useEffect(() => {
+    notifyOverlayOpenChange();
+  }, [notifyOverlayOpenChange]);
+
+  return { isOverlayOpen, setOverlayOpen };
+}

--- a/front/components/editor/extensions/EmojiExtension.tsx
+++ b/front/components/editor/extensions/EmojiExtension.tsx
@@ -39,43 +39,50 @@ function getEmojiFromCache(name: string): EmojiItem | undefined {
   return emojiMapCache?.get(name);
 }
 
-// Create extension that lazily loads emoji data
-export const EmojiExtension = Emoji.extend({
-  renderMarkdown: (node) => {
-    const name = node.attrs?.name;
+export function createEmojiExtension({
+  onActiveChange,
+}: {
+  onActiveChange?: (active: boolean) => void;
+} = {}) {
+  return Emoji.extend({
+    renderMarkdown: (node) => {
+      const name = node.attrs?.name;
 
-    // If name is null/undefined, return empty string to avoid displaying :null:
-    if (!name) {
-      return "";
-    }
+      // If name is null/undefined, return empty string to avoid displaying :null:
+      if (!name) {
+        return "";
+      }
 
-    // Try to get from cache, fallback to shortcode format
-    const emojiItem = getEmojiFromCache(name);
-    return emojiItem?.emoji ?? `:${name}:`;
-  },
+      // Try to get from cache, fallback to shortcode format
+      const emojiItem = getEmojiFromCache(name);
+      return emojiItem?.emoji ?? `:${name}:`;
+    },
 
-  async onCreate() {
-    await loadEmojiData();
-  },
-}).configure({
-  // Disable emoticon conversion to prevent :null: bug
-  // When enableEmoticons is true with an empty emojis array, TipTap creates
-  // an input rule with regex (?:^|\s)() $ which matches any double space,
-  // creating emoji nodes with name: null that render as :null:
-  // TODO: To enable emoticons, we need to either:
-  // 1. Load emoji data synchronously before extension creation, or
-  // 2. Implement a mechanism to update input rules after async data loads
-  enableEmoticons: false,
+    async onCreate() {
+      await loadEmojiData();
+    },
+  }).configure({
+    // Disable emoticon conversion to prevent :null: bug
+    // When enableEmoticons is true with an empty emojis array, TipTap creates
+    // an input rule with regex (?:^|\s)() $ which matches any double space,
+    // creating emoji nodes with name: null that render as :null:
+    // TODO: To enable emoticons, we need to either:
+    // 1. Load emoji data synchronously before extension creation, or
+    // 2. Implement a mechanism to update input rules after async data loads
+    enableEmoticons: false,
 
-  // HTML attributes for styling
-  HTMLAttributes: {
-    class: "inline-block",
-  },
+    // HTML attributes for styling
+    HTMLAttributes: {
+      class: "inline-block",
+    },
 
-  // Configure suggestion plugin for :emoji: syntax
-  suggestion: createEmojiSuggestion(),
+    // Configure suggestion plugin for :emoji: syntax
+    suggestion: createEmojiSuggestion({ onActiveChange }),
 
-  // Start with empty emojis array - this is populated asynchronously in onCreate()
-  // The emoji picker/search uses EmojiDropdown which loads data independently
-  emojis,
-});
+    // Start with empty emojis array - this is populated asynchronously in onCreate()
+    // The emoji picker/search uses EmojiDropdown which loads data independently
+    emojis,
+  });
+}
+
+export const EmojiExtension = createEmojiExtension();

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension.tsx
@@ -47,6 +47,7 @@ export interface InputBarSlashSuggestionExtensionOptions {
     ((capability: InputBarSlashSuggestionCapability) => void) | undefined
   >;
   selectedMCPServerViewIdsRef: RefObject<Set<string>>;
+  onActiveChangeRef?: RefObject<((active: boolean) => void) | undefined>;
 }
 
 export const InputBarSlashSuggestionExtension =
@@ -126,6 +127,7 @@ export const InputBarSlashSuggestionExtension =
                   return;
                 }
 
+                extensionOptions.onActiveChangeRef?.current?.(true);
                 activeEditorView = props.editor.view;
                 component = new ReactRenderer(InputBarSlashSuggestionDropdown, {
                   props: {
@@ -171,6 +173,7 @@ export const InputBarSlashSuggestionExtension =
               },
 
               onExit() {
+                extensionOptions.onActiveChangeRef?.current?.(false);
                 activeEditorView = null;
                 activeTriggerStart = null;
                 component?.element?.remove();

--- a/front/components/editor/input_bar/emojiSuggestion.tsx
+++ b/front/components/editor/input_bar/emojiSuggestion.tsx
@@ -15,7 +15,11 @@ import type { RefAttributes } from "react";
 
 export const emojiPluginKey = new PluginKey("emoji-suggestion");
 
-export function createEmojiSuggestion() {
+export function createEmojiSuggestion({
+  onActiveChange,
+}: {
+  onActiveChange?: (active: boolean) => void;
+} = {}) {
   return {
     pluginKey: emojiPluginKey,
     char: ":",
@@ -44,6 +48,7 @@ export function createEmojiSuggestion() {
 
       return {
         onStart: (props: SuggestionProps<{ name: string }>) => {
+          onActiveChange?.(true);
           component = new ReactRenderer(EmojiDropdown, {
             editor: props.editor,
             props: {
@@ -76,6 +81,7 @@ export function createEmojiSuggestion() {
         },
 
         onExit: () => {
+          onActiveChange?.(false);
           component?.element.remove();
           component?.destroy();
         },

--- a/front/components/editor/input_bar/mentionSuggestion.tsx
+++ b/front/components/editor/input_bar/mentionSuggestion.tsx
@@ -22,6 +22,7 @@ export function createMentionSuggestion({
   select,
   includeCurrentUser = false,
   onAgentSelect,
+  onActiveChange,
 }: {
   owner: WorkspaceType;
   conversationId?: string | null;
@@ -32,6 +33,7 @@ export function createMentionSuggestion({
     users: boolean;
   };
   onAgentSelect?: (mention: RichMention) => void;
+  onActiveChange?: (active: boolean) => void;
 }) {
   return {
     pluginKey: mentionPluginKey,
@@ -75,6 +77,7 @@ export function createMentionSuggestion({
 
       return {
         onStart: (props: SuggestionProps<RichMention, RichMention>) => {
+          onActiveChange?.(true);
           component = new ReactRenderer(MentionDropdown, {
             editor: props.editor,
             props: {
@@ -122,6 +125,7 @@ export function createMentionSuggestion({
         },
 
         onExit: () => {
+          onActiveChange?.(false);
           component?.element.remove();
           component?.destroy();
         },

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -1,5 +1,5 @@
 import { CodeExtension } from "@app/components/editor/extensions/CodeExtension";
-import { EmojiExtension } from "@app/components/editor/extensions/EmojiExtension";
+import { createEmojiExtension } from "@app/components/editor/extensions/EmojiExtension";
 import { DataSourceLinkExtension } from "@app/components/editor/extensions/input_bar/DataSourceLinkExtension";
 import {
   InputBarSlashSuggestionExtension,
@@ -213,6 +213,9 @@ export interface CustomEditorProps {
   };
   // Override the default editor placeholder (e.g. to show a blocked-state reason).
   placeholderOverride?: string | null;
+  onSuggestionActiveChangeRef?: React.RefObject<
+    ((active: boolean) => void) | undefined
+  >;
 }
 
 export const buildEditorExtensions = ({
@@ -227,6 +230,7 @@ export const buildEditorExtensions = ({
   onFirstAgentMentionPasteRef,
   slashSuggestion,
   placeholderOverride,
+  onSuggestionActiveChangeRef,
 }: {
   owner: WorkspaceType;
   conversationId?: string | null;
@@ -241,7 +245,12 @@ export const buildEditorExtensions = ({
   >;
   slashSuggestion?: CustomEditorProps["slashSuggestion"];
   placeholderOverride?: string | null;
+  onSuggestionActiveChangeRef?: CustomEditorProps["onSuggestionActiveChangeRef"];
 }) => {
+  const notifySuggestionActiveChange = (active: boolean) => {
+    onSuggestionActiveChangeRef?.current?.(active);
+  };
+
   const extensions = [
     KeyboardShortcutsExtension,
     StarterKit.configure({
@@ -316,10 +325,11 @@ export const buildEditorExtensions = ({
           users: !disableUserMentions,
         },
         onAgentSelect,
+        onActiveChange: notifySuggestionActiveChange,
       }),
     }),
     SkillNode,
-    EmojiExtension,
+    createEmojiExtension({ onActiveChange: notifySuggestionActiveChange }),
     Placeholder.configure({
       placeholder: ({ node }) => {
         if (node.type.name !== "paragraph") {
@@ -344,6 +354,7 @@ export const buildEditorExtensions = ({
         onSelectRef: slashSuggestion.onSelectRef,
         selectedMCPServerViewIdsRef:
           slashSuggestion.selectedMCPServerViewIdsRef,
+        onActiveChangeRef: onSuggestionActiveChangeRef,
       })
     );
   }
@@ -375,6 +386,7 @@ const useCustomEditor = ({
   onFirstAgentMentionPasteRef,
   slashSuggestion,
   placeholderOverride,
+  onSuggestionActiveChangeRef,
 }: CustomEditorProps) => {
   const editor = useEditor(
     {
@@ -391,6 +403,7 @@ const useCustomEditor = ({
         onFirstAgentMentionPasteRef,
         slashSuggestion,
         placeholderOverride,
+        onSuggestionActiveChangeRef,
       }),
       shouldRerenderOnTransaction: true, // necessary to update the editor state (and so the toolbar icons "activation") in real time
       editorProps: {

--- a/front/tailwind.config.js
+++ b/front/tailwind.config.js
@@ -72,6 +72,44 @@ module.exports = {
           from: { opacity: "0", transform: "translateY(10px)" },
           to: { opacity: "1", transform: "translateY(0)" },
         },
+        "input-bar-compact-in": {
+          "0%": {
+            opacity: "0.45",
+            transform: "scale(0.82) translateY(18px)",
+          },
+          "55%": {
+            opacity: "1",
+            transform: "scale(1.05) translateY(-3px)",
+          },
+          "100%": {
+            opacity: "1",
+            transform: "scale(1) translateY(0)",
+          },
+        },
+        "input-bar-compact-content-in": {
+          "0%": {
+            opacity: "0",
+            transform: "translateX(-8px)",
+          },
+          "100%": {
+            opacity: "1",
+            transform: "translateX(0)",
+          },
+        },
+        "input-bar-compact-nav-in": {
+          "0%": {
+            opacity: "0",
+            transform: "scale(0.86) translateX(14px)",
+          },
+          "60%": {
+            opacity: "1",
+            transform: "scale(1.04) translateX(-2px)",
+          },
+          "100%": {
+            opacity: "1",
+            transform: "scale(1) translateX(0)",
+          },
+        },
         "saved-pulse": {
           "0%, 100%": { color: "inherit" },
           "15%": { color: "#86efac" },
@@ -87,6 +125,12 @@ module.exports = {
         fadeout: "fadeout 500ms ease-out",
         marquee: "marquee 25s linear infinite",
         "fade-in-up": "fade-in-up 0.5s ease-in-out",
+        "input-bar-compact-in":
+          "input-bar-compact-in 480ms cubic-bezier(0.34, 1.56, 0.64, 1) both",
+        "input-bar-compact-content-in":
+          "input-bar-compact-content-in 320ms ease-out 100ms both",
+        "input-bar-compact-nav-in":
+          "input-bar-compact-nav-in 420ms cubic-bezier(0.34, 1.56, 0.64, 1) 160ms both",
         "saved-pulse": "saved-pulse 2s ease-out",
       },
     },

--- a/sparkle/src/components/VoicePicker.tsx
+++ b/sparkle/src/components/VoicePicker.tsx
@@ -29,6 +29,7 @@ export interface VoicePickerProps {
   size?: Exclude<RegularButtonSize, "xmini" | "mini">;
   disabled?: boolean;
   showStopLabel?: boolean;
+  compact?: boolean;
   pressDelayMs?: number;
   buttonProps?: Omit<
     ButtonProps,
@@ -45,13 +46,26 @@ export function VoicePicker({
   size = "xs",
   disabled = false,
   showStopLabel = false,
+  compact = false,
   pressDelayMs = DEFAULT_PRESS_DELAY_MS,
   buttonProps,
 }: VoicePickerProps): React.ReactElement {
   const [interactionMode, setInteractionMode] =
     React.useState<VoicePickerInteractionMode>("hold");
+  const interactionModeRef = React.useRef<VoicePickerInteractionMode>("hold");
   const pressStartRef = React.useRef<number | null>(null);
   const pressTimeoutRef = React.useRef<number | null>(null);
+  const suppressNextClickRef = React.useRef(false);
+  const ignoreLeaveUntilRef = React.useRef(0);
+
+  const setMode = (mode: VoicePickerInteractionMode): void => {
+    interactionModeRef.current = mode;
+    setInteractionMode(mode);
+  };
+
+  const markRecordingStarted = (): void => {
+    ignoreLeaveUntilRef.current = Date.now() + 300;
+  };
 
   const isRecording = status === "recording";
   const isTranscribing = status === "transcribing";
@@ -85,14 +99,21 @@ export function VoicePicker({
       return;
     }
 
+    try {
+      event.currentTarget.setPointerCapture(event.pointerId);
+    } catch {
+      // Ignore if pointer capture is not supported.
+    }
+
     pressStartRef.current = Date.now();
 
     clearPressTimeout();
     pressTimeoutRef.current = window.setTimeout(async () => {
       if (pressStartRef.current !== null) {
-        setInteractionMode("hold");
+        setMode("hold");
         if (status === "idle") {
           await onRecordStart();
+          markRecordingStarted();
         }
       }
     }, pressDelayMs);
@@ -116,13 +137,21 @@ export function VoicePicker({
     clearPressTimeout();
     pressStartRef.current = null;
 
+    try {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    } catch {
+      // Ignore if pointer capture was not set.
+    }
+
     const duration =
       start === null ? Number.POSITIVE_INFINITY : Date.now() - start;
 
     if (duration < pressDelayMs) {
-      setInteractionMode("click");
+      setMode("click");
       if (status === "idle") {
+        suppressNextClickRef.current = true;
         await onRecordStart();
+        markRecordingStarted();
         return;
       }
       await onRecordStop();
@@ -142,7 +171,15 @@ export function VoicePicker({
       return;
     }
 
-    if (disabled || interactionMode !== "hold" || status !== "recording") {
+    if (
+      disabled ||
+      interactionModeRef.current !== "hold" ||
+      status !== "recording"
+    ) {
+      return;
+    }
+
+    if (Date.now() < ignoreLeaveUntilRef.current) {
       return;
     }
 
@@ -163,7 +200,12 @@ export function VoicePicker({
 
     stopEvent(event);
 
-    if (disabled || interactionMode !== "click") {
+    if (suppressNextClickRef.current) {
+      suppressNextClickRef.current = false;
+      return;
+    }
+
+    if (disabled || interactionModeRef.current !== "click") {
       return;
     }
     if (status === "recording") {
@@ -177,10 +219,11 @@ export function VoicePicker({
   const tooltip = computeTooltip(interactionMode, isRecording, isTranscribing);
 
   return (
-    <>
+    <div className="s-flex s-items-center">
       <div
         className={cn(
-          "s-duration-600 s-flex s-items-center s-justify-end s-gap-2 s-overflow-hidden s-px-2 s-transition-all s-ease-in-out",
+          "s-duration-600 s-flex s-items-center s-justify-end s-gap-2 s-overflow-hidden s-transition-all s-ease-in-out",
+          compact ? "s-px-1" : "s-px-2",
           isRecording ? "s-opacity-100" : "s-hidden"
         )}
       >
@@ -203,7 +246,7 @@ export function VoicePicker({
         onPointerLeave={handlePointerLeave}
         onClick={handleClick}
       />
-    </>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Description

Refactors the mobile input bar compact mode to fix cases where the bar incorrectly collapsed while the user was interacting with it (picker open, editor focused, voice active, suggestion dropdown visible).

- Extracts compact-mode state into `useInputBarCompactMode`: adds a 12px scroll threshold, a 150ms debounce, and an `isInteractingRef` guard that blocks collapse while editor/overlay/voice are active.
- Adds `useInputBarOverlayTracker` to aggregate open states from all overlays (`agent-picker`, `capabilities-picker`, `attachments-picker`, `capture-dropdown`, `knowledge-picker`, `toolbar`, `editor-suggestion`) into a single `onOverlayOpenChange` callback via a keyed `Set`.
- Surfaces `onOpenChange` on `AgentPicker`, `CapabilitiesPicker`, and `InputBarAttachmentsPicker`; surfaces `onActiveChange` on mention, emoji, and slash suggestion plugins.
- Renames `isCompact` → `effectiveIsCompact` on `InputBar`/`InputBarContainer` (now computed in the hook, not duplicated downstream).
- Adds pill enter animations and morph transition classes in `inputBarCompactStyles.ts`; compact pill is now click-to-expand, excluding `[data-compact-voice]` clicks.

## Tests

Tested locally on mobile viewport: verified the bar stays expanded when typing, using pickers, recording voice, or navigating suggestions, and collapses correctly after scrolling past the threshold with no active interaction.

## Risk

Low. Pure front-end refactor, no API or data changes. Compact mode only activates on mobile outside the agent builder — no impact on desktop. Rollback-safe.

## Deploy Plan

Deploy front.
