### PR TITLE
Fix: inconsistency with keyboard appearance when moving from compact to normal input bar.

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1076,18 +1076,18 @@ const InputBarContainer = ({
 
   const prevIsCompactRef = useRef(isCompact);
   useEffect(() => {
-    if (!prevIsCompactRef.current && isCompact) {
-      editorService.blur();
-    } else if (prevIsCompactRef.current && !isCompact) {
-      editorService.focusEnd();
-      if (editor && !editor.isDestroyed) {
-        requestAnimationFrame(() => {
-          editor.view.dispatch(editor.state.tr);
-        });
-      }
+    if (
+      prevIsCompactRef.current &&
+      !isCompact &&
+      editor &&
+      !editor.isDestroyed
+    ) {
+      requestAnimationFrame(() => {
+        editor.view.dispatch(editor.state.tr);
+      });
     }
     prevIsCompactRef.current = isCompact;
-  }, [editor, editorService, isCompact]);
+  }, [editor, isCompact]);
 
   return (
     <>

--- a/front/components/assistant/conversation/input_bar/inputBarCompactStyles.ts
+++ b/front/components/assistant/conversation/input_bar/inputBarCompactStyles.ts
@@ -14,4 +14,4 @@ export const INPUT_BAR_COMPACT_NAV_ENTER_ANIMATION_CLASSES =
   "motion-safe:origin-center motion-safe:animate-input-bar-compact-nav-in";
 
 export const INPUT_BAR_COMPACT_MORPH_TRANSITION_CLASSES =
-  "transition-[border-radius,background-color,padding,border-color,box-shadow,opacity] duration-300 ease-out";
+  "transition-[background-color,padding,border-color,box-shadow,opacity] duration-300 ease-out";


### PR DESCRIPTION
## Description

When transitioning from compact to normal input bar mode on mobile, `editorService.focusEnd()` was triggering the soft keyboard unexpectedly. Removing that call (and the symmetric `editorService.blur()` on collapse) fixes the inconsistency — the `requestAnimationFrame` dispatch to force a TipTap state update is still applied on expand. Also drops `border-radius` from `INPUT_BAR_COMPACT_MORPH_TRANSITION_CLASSES` to prevent a visual glitch during the morph animation.

## Tests

Tested manually on mobile — keyboard no longer pops up when the input bar expands from compact mode.

## Risk

Low. Two small, isolated changes in `InputBarContainer` and `inputBarCompactStyles.ts`; no logic shared with other flows. Fully rollback-safe.

## Deploy Plan

Deploy front.
