### PR TITLE
Avoid immediate move back to compact when expanding at the bottom of the convo.

### DIFF
--- a/front/components/assistant/conversation/input_bar/useInputBarCompactMode.ts
+++ b/front/components/assistant/conversation/input_bar/useInputBarCompactMode.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 const SCROLL_COMPACT_THRESHOLD_PX = 12;
 const SCROLL_COMPACT_DEBOUNCE_MS = 150;
+const EXPAND_SCROLL_GRACE_MS = 300;
 
 interface UseInputBarCompactModeOptions {
   enabled: boolean;
@@ -20,8 +21,12 @@ export function useInputBarCompactMode({
   const isInteractingRef = useRef(false);
   isInteractingRef.current = isEditorFocused || isOverlayOpen || isVoiceActive;
 
+  const listOffsetRef = useRef(listOffset);
+  listOffsetRef.current = listOffset;
+
   const prevListOffsetRef = useRef<number | null>(null);
   const collapseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const ignoreScrollUntilRef = useRef(0);
 
   useEffect(() => {
     return () => {
@@ -35,10 +40,24 @@ export function useInputBarCompactMode({
     if (!enabled) {
       setIsExpanded(true);
       prevListOffsetRef.current = listOffset;
+      ignoreScrollUntilRef.current = 0;
       return;
     }
 
     if (prevListOffsetRef.current === null) {
+      prevListOffsetRef.current = listOffset;
+      return;
+    }
+
+    // Only use scroll to enter compact while the bar is expanded. While compact,
+    // keep the baseline in sync but ignore deltas (layout noise from footer size).
+    if (!isExpanded) {
+      prevListOffsetRef.current = listOffset;
+      return;
+    }
+
+    // Ignore layout-induced listOffset shifts right after an explicit expand.
+    if (Date.now() < ignoreScrollUntilRef.current) {
       prevListOffsetRef.current = listOffset;
       return;
     }
@@ -64,13 +83,19 @@ export function useInputBarCompactMode({
         setIsExpanded(false);
       }
     }, SCROLL_COMPACT_DEBOUNCE_MS);
-  }, [enabled, listOffset]);
+  }, [enabled, isExpanded, listOffset]);
 
   const isScrolledCompactIntent = enabled && !isExpanded;
   const effectiveIsCompact =
     isScrolledCompactIntent && !isEditorFocused && !isOverlayOpen;
 
   const expandInputBar = useCallback(() => {
+    if (collapseTimerRef.current) {
+      clearTimeout(collapseTimerRef.current);
+      collapseTimerRef.current = null;
+    }
+    prevListOffsetRef.current = listOffsetRef.current;
+    ignoreScrollUntilRef.current = Date.now() + EXPAND_SCROLL_GRACE_MS;
     setIsExpanded(true);
   }, []);
 


### PR DESCRIPTION
## Description

When tapping the compact input bar pill at the bottom of a conversation to expand it, the bar immediately snapped back to compact. The layout shift from the bar re-expanding changed `listOffset`, which the scroll effect interpreted as a scroll event and re-triggered collapse.

Fixed in `useInputBarCompactMode` with two guards:
- `ignoreScrollUntilRef`: a 300ms grace window set on `expandInputBar()` that suppresses `listOffset` delta processing, absorbing the layout-induced offset shift.
- Early-return while `!isExpanded`: while already compact, keep `prevListOffsetRef` in sync but skip delta checks entirely (avoids layout noise from footer resizing).

Also clears any pending `collapseTimerRef` on explicit expand to prevent the debounce from firing right after.

## Tests

Tested locally on mobile viewport — expanding the bar at the bottom of a long conversation no longer snaps back to compact.

## Risk

Low. Single-file change confined to the compact mode hook. Existing compact/expand behavior on scroll is unaffected; the guards only apply during and immediately after an explicit user-triggered expand.

## Deploy Plan

Deploy front.
