### PR TITLE
[front-api] fix: Skip instrumentation for /healthz

### DIFF
--- a/front-api/middlewares/request_logger.ts
+++ b/front-api/middlewares/request_logger.ts
@@ -9,11 +9,24 @@ type RequestLoggerEnv = {
   Variables: {
     auth?: Authenticator;
     session?: SessionWithUser;
+    streaming?: boolean;
   };
 };
 
+// We skip k8s probes path to avoid noisy logs and skewed distribution
+const SKIP_LOGGER_PATHS = new Set([
+  "/api/healthz",
+  "/api/healthz/ready",
+  "/api/healthz/startup",
+  "/api/kill",
+]);
+
 export const requestLogger = createMiddleware<RequestLoggerEnv>(
   async (c, next) => {
+    if (SKIP_LOGGER_PATHS.has(c.req.path)) {
+      return next();
+    }
+
     const startMs = performance.now();
     await next();
     const durationMs = Math.round(performance.now() - startMs);
@@ -29,8 +42,13 @@ export const requestLogger = createMiddleware<RequestLoggerEnv>(
 
     const auth = c.get("auth");
     const session = c.get("session");
+    const streaming = c.get("streaming") ?? false;
 
-    const tags = [`method:${c.req.method}`, `status_code:${statusCode}`];
+    const tags = [
+      `method:${c.req.method}`,
+      `streaming:${streaming}`,
+      `status_code:${statusCode}`,
+    ];
     getStatsDClient().increment("requests.count", 1, tags);
     getStatsDClient().distribution(
       "requests.duration.distribution",
@@ -46,6 +64,7 @@ export const requestLogger = createMiddleware<RequestLoggerEnv>(
         route,
         sessionId: session?.sessionId ?? "unknown",
         statusCode,
+        streaming,
         url: c.req.url,
         userId: auth?.user()?.sId,
         workspaceId: auth?.workspace()?.sId,

--- a/front-api/middlewares/streaming.ts
+++ b/front-api/middlewares/streaming.ts
@@ -1,7 +1,15 @@
 import tracer from "@app/logger/tracer";
 import { createMiddleware } from "hono/factory";
 
-export const streamingTag = createMiddleware(async (_c, next) => {
+type StreamingEnv = {
+  Variables: {
+    streaming?: boolean;
+  };
+};
+
+export const streamingTag = createMiddleware<StreamingEnv>(async (c, next) => {
+  c.set("streaming", true);
+
   const span = tracer.scope().active();
   if (span) {
     span.setTag("streaming", true);


### PR DESCRIPTION
## Description

On front-api:
- We produce "Processed request" logs for /healthz endpoints, which makes it noisy, and skews the measurement (duration between 0 and 1 ms)
- We did not put `streaming` tag in the duration distrib metrics, and in that case datadog drops the points when you filter on `streaming=false` (makes sense after all).

## Tests

Tested locally (that front-api still works)

## Risk

Low

## Deploy Plan

- [ ] Deploy front