### PR TITLE
[connectors] fix: reduce Notion search page size on rendering timeout

### DIFF
--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -12,6 +12,7 @@ import { cacheWithRedis } from "@connectors/types";
 import { assertNever } from "@dust-tt/client";
 import type { LogLevel } from "@notionhq/client";
 import {
+  APIErrorCode,
   APIResponseError,
   Client,
   isFullBlock,
@@ -33,6 +34,8 @@ import { stringify } from "csv-stringify";
 import type { Logger } from "pino";
 
 const logger = mainLogger.child({ provider: "notion" });
+const NOTION_SEARCH_PAGE_SIZE = 90;
+const MIN_NOTION_SEARCH_PAGE_SIZE_ON_RENDERING_BUDGET_ERROR = 10;
 
 const notionClientLogger = (
   level: LogLevel,
@@ -62,6 +65,22 @@ function getRandomPageSize(min: number, max: number): number {
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
+function getReducedNotionSearchPageSize(pageSize: number): number {
+  return Math.max(
+    MIN_NOTION_SEARCH_PAGE_SIZE_ON_RENDERING_BUDGET_ERROR,
+    Math.floor(pageSize / 2)
+  );
+}
+
+function isNotionSearchRenderingBudgetError(err: unknown): boolean {
+  return (
+    APIResponseError.isAPIResponseError(err) &&
+    err.code === APIErrorCode.ServiceUnavailable &&
+    err.status === 503 &&
+    err.message.toLowerCase().includes("response time budget")
+  );
+}
+
 async function refreshLastPageCursor(
   notionClient: Client,
   {
@@ -79,10 +98,9 @@ async function refreshLastPageCursor(
   // Using a lower page_size (between originalPageSize - 10 and originalPageSize - 1) is safe.
   // In the worst case, some pages/databases might be processed multiple times,
   // but this is properly handled downstream.
-  const pageSize = getRandomPageSize(
-    originalPageSize - 10,
-    originalPageSize - 1
-  );
+  const minPageSize = Math.max(1, originalPageSize - 10);
+  const maxPageSize = Math.max(minPageSize, originalPageSize - 1);
+  const pageSize = getRandomPageSize(minPageSize, maxPageSize);
 
   const localLogger = logger.child({ ...loggerArgs, pageSize });
 
@@ -180,13 +198,14 @@ export async function getPagesAndDatabasesEditedSince({
   let resultsPage: SearchResponse | null = null;
 
   let tries = 0;
-  const pageSize = 90;
+  let pageSize = NOTION_SEARCH_PAGE_SIZE;
 
   let lastCursor = cursors.last;
   while (tries < retry.retries) {
     const tryLogger = localLogger.child({
       tries,
       maxTries: retry.retries,
+      pageSize,
     });
 
     const now = Date.now();
@@ -212,6 +231,15 @@ export async function getPagesAndDatabasesEditedSince({
       tries += 1;
       if (tries >= retry.retries) {
         throw e;
+      }
+
+      if (isNotionSearchRenderingBudgetError(e)) {
+        const previousPageSize = pageSize;
+        pageSize = getReducedNotionSearchPageSize(pageSize);
+        tryLogger.info(
+          { previousPageSize, nextPageSize: pageSize },
+          "Reducing Notion search page_size after rendering budget error."
+        );
       }
 
       // Notion API sometimes returns 504 errors.


### PR DESCRIPTION
## Description

- We are seeing Notion search fail with 503s when rendering objects exceeds Notion's response time budget ([logs](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker%20%40workflowType%3AnotionGarbageCollectionWorkflow&agg_m=count&agg_m_source=base&agg_q=%40workflowId&agg_q_source=base&agg_t=count&clustering_pattern_field_path=message&cols=%40workflowId%2C%40error.type&event=AwAAAZ5ZK8i0pio9jgAAABhBWjVaSzlLN0FBQmd0c25oR2EwMVVBQUkAAAAkMDE5ZTU5MmQtNDk2Zi00ZmIzLWEzZDEtN2ViMmQxN2Y1MzFlAAWm3w&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=6000198897476506285&storage=hot&stream_sort=time%2Cdesc&top_n=25&top_o=top&viz=stream&x_missing=true&from_ts=1758745662562&to_ts=1758749262562&live=true)).
- This PR keeps the default search `page_size` unchanged, but progressively reduces it when Notion returns that specific rendering-budget error.
- Only affects retries for the specific failing Notion error (unfortunately not well typed by the SDK).

## Tests

- Tested locally.

## Risk

- Low. Scoped to Notion search retries after a specific upstream 503.

## Deploy Plan

- Deploy connectors.
