### PR TITLE
Fixes in credits/usage wording

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -72,7 +72,7 @@ function getResetDateLabel(resetDate: string): string {
     month: "long",
     timeZone: "UTC",
   });
-  return `Monthly resets on the ${resetDay}${suffix}, ${resetMonth}`;
+  return `Resets on the ${resetDay}${suffix} of each month. Next reset: ${resetMonth} ${resetDay}${suffix}.`;
 }
 
 interface CreditPoolUsageBarProps {
@@ -104,7 +104,7 @@ function CreditPoolUsageBar({
       <div
         className="flex h-2 w-full overflow-hidden rounded-full bg-muted-foreground/10 dark:bg-muted-foreground-night/10"
         role="progressbar"
-        aria-label="Credit pool usage"
+        aria-label="Workspace Credits Pool usage"
         aria-valuenow={Math.round(totalConsumedPercentage)}
         aria-valuemin={0}
         aria-valuemax={100}
@@ -125,7 +125,7 @@ function CreditPoolUsageBar({
         </span>
         <span className="flex items-center gap-1.5">
           <span className="h-2 w-2 bg-purple-500" />
-          Programmatic Usage
+          Programmatic usage
         </span>
       </div>
     </Page.Vertical>
@@ -249,7 +249,7 @@ export function UsagePage() {
         <Page.Vertical gap="sm" align="stretch">
           <div className="flex items-center justify-between">
             <span className="text-[16px] font-medium leading-[24px] tracking-[-0.32px] text-foreground dark:text-foreground-night">
-              Credit pool
+              Workspace Credits Pool
             </span>
             {!isAwuPoolSummaryLoading && (
               <div className="flex flex-col items-end gap-0.5">
@@ -275,12 +275,12 @@ export function UsagePage() {
 
           {isAwuPoolSummaryError && (
             <ContentMessage
-              title="Failed to load credit pool"
+              title="Failed to load Workspace Credits Pool"
               icon={ExclamationCircleIcon}
               variant="warning"
             >
-              An error occurred while loading your credit pool data. Please
-              refresh the page or contact support if the issue persists.
+              An error occurred while loading your Workspace Credits Pool data.
+              Please refresh the page or contact support if the issue persists.
             </ContentMessage>
           )}
 

--- a/front/components/pages/workspace/developers/CreditsUsagePage.tsx
+++ b/front/components/pages/workspace/developers/CreditsUsagePage.tsx
@@ -417,7 +417,7 @@ export function CreditsUsagePage() {
                 <div className="flex items-end justify-between">
                   <p>Complete your payment to activate your credits.</p>
                   <Button
-                    label={isSingle ? "Complete Payment" : "Manage Invoices"}
+                    label={isSingle ? "Complete payment" : "Manage invoices"}
                     variant="primary"
                     onClick={() => {
                       window.open(

--- a/front/components/workspace/BuyAwuCreditsDialog.tsx
+++ b/front/components/workspace/BuyAwuCreditsDialog.tsx
@@ -291,7 +291,7 @@ export function BuyAwuCreditsDialog({
               onValueChange={(v) => setSelectedTab(v as TopUpTab)}
             >
               <TabsList>
-                <TabsTrigger value="one-time" label="One time top-up" />
+                <TabsTrigger value="one-time" label="One-time top-up" />
                 <TabsTrigger value="automatic" label="Automatic top-up" />
               </TabsList>
 
@@ -330,7 +330,7 @@ export function BuyAwuCreditsDialog({
                       </div>
                       {isValidAmount && (
                         <span className="flex items-center gap-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
-                          {formatCredits(addedCredits)} credit
+                          {formatCredits(addedCredits)} credits
                           <Icon visual={ActionCreditCoinsIcon} size="xs" />
                         </span>
                       )}
@@ -355,7 +355,7 @@ export function BuyAwuCreditsDialog({
                       </p>
                       {currentBalanceCredits !== undefined && (
                         <SummaryRow
-                          label="Current Balance"
+                          label="Current balance"
                           value={
                             <CreditValue credits={currentBalanceCredits} />
                           }
@@ -448,7 +448,7 @@ export function BuyAwuCreditsDialog({
               onClick: resetModalStateAndClose,
             }}
             rightButtonProps={{
-              label: "Manage Invoices",
+              label: "Manage invoices",
               variant: "primary",
               onClick: () => {
                 window.open(`/w/${workspaceId}/subscription/manage`, "_blank");
@@ -480,7 +480,7 @@ export function BuyAwuCreditsDialog({
       <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
         <DialogContent size="md">
           <DialogHeader>
-            <DialogTitle>Credit pool top-up</DialogTitle>
+            <DialogTitle>Workspace Credits Pool top-up</DialogTitle>
           </DialogHeader>
           <DialogContainer>
             <div className="flex justify-center py-8">
@@ -509,16 +509,16 @@ export function BuyAwuCreditsDialog({
       <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
         <DialogContent size="md">
           <DialogHeader>
-            <DialogTitle>Credit pool top-up</DialogTitle>
+            <DialogTitle>Workspace Credits Pool top-up</DialogTitle>
             <DialogDescription>
-              AWU credit purchases are not available for your current plan.
+              Credit purchases are not available for your current plan.
             </DialogDescription>
           </DialogHeader>
           <DialogContainer>
             <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
               Please{" "}
               <a
-                href={`mailto:${supportEmail}?subject=AWU%20credit%20purchase`}
+                href={`mailto:${supportEmail}?subject=Credit%20purchase`}
                 className="text-action-500 hover:underline"
               >
                 contact support
@@ -549,7 +549,7 @@ export function BuyAwuCreditsDialog({
       <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
         <DialogContent size="md">
           <DialogHeader>
-            <DialogTitle>Credit pool top-up</DialogTitle>
+            <DialogTitle>Workspace Credits Pool top-up</DialogTitle>
             <DialogDescription>
               No billing configuration found for this workspace.
             </DialogDescription>
@@ -558,7 +558,7 @@ export function BuyAwuCreditsDialog({
             <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
               Please{" "}
               <a
-                href={`mailto:${supportEmail}?subject=AWU%20credit%20purchase%20-%20billing%20setup`}
+                href={`mailto:${supportEmail}?subject=Credit%20purchase%20-%20billing%20setup`}
                 className="text-action-500 hover:underline"
               >
                 contact support
@@ -589,7 +589,7 @@ export function BuyAwuCreditsDialog({
       <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
         <DialogContent size="md">
           <DialogHeader>
-            <DialogTitle>Credit pool top-up</DialogTitle>
+            <DialogTitle>Workspace Credits Pool top-up</DialogTitle>
             <DialogDescription>
               You have pending credit purchases awaiting payment.
             </DialogDescription>
@@ -614,7 +614,7 @@ export function BuyAwuCreditsDialog({
               onClick: onClose,
             }}
             rightButtonProps={{
-              label: "Manage Invoices",
+              label: "Manage invoices",
               variant: "primary",
               onClick: () => {
                 window.open(`/w/${workspaceId}/subscription/manage`, "_blank");
@@ -636,7 +636,7 @@ export function BuyAwuCreditsDialog({
       <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
         <DialogContent size="md">
           <DialogHeader>
-            <DialogTitle>Credit pool top-up</DialogTitle>
+            <DialogTitle>Workspace Credits Pool top-up</DialogTitle>
             <DialogDescription>
               You've reached your credit limit for this billing cycle.
             </DialogDescription>
@@ -674,8 +674,10 @@ export function BuyAwuCreditsDialog({
     >
       <DialogContent size="md">
         <DialogHeader>
-          <DialogTitle>Credit pool top-up</DialogTitle>
-          <DialogDescription>Add credit to your credit pool.</DialogDescription>
+          <DialogTitle>Workspace Credits Pool top-up</DialogTitle>
+          <DialogDescription>
+            Add credits to your Workspace Credits Pool.
+          </DialogDescription>
         </DialogHeader>
         <DialogContainer>{renderContent()}</DialogContainer>
         {renderFooter()}

--- a/front/components/workspace/BuyCreditDialog.tsx
+++ b/front/components/workspace/BuyCreditDialog.tsx
@@ -445,7 +445,7 @@ export function BuyCreditDialog({
               onClick: resetModalStateAndClose,
             }}
             rightButtonProps={{
-              label: "Go to Payment",
+              label: "Go to payment",
               variant: "primary",
               onClick: () => {
                 if (paymentUrl) {
@@ -464,7 +464,7 @@ export function BuyCreditDialog({
               onClick: resetModalStateAndClose,
             }}
             rightButtonProps={{
-              label: "Manage Invoices",
+              label: "Manage invoices",
               variant: "primary",
               onClick: () => {
                 window.open(`/w/${workspaceId}/subscription/manage`, "_blank");
@@ -481,7 +481,7 @@ export function BuyCreditDialog({
               onClick={resetModalStateAndClose}
             />
             <Button
-              label="Purchase Credits"
+              label="Purchase credits"
               variant="primary"
               onClick={handlePurchase}
               disabled={!canPurchase}
@@ -501,7 +501,7 @@ export function BuyCreditDialog({
       <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
         <DialogContent size="md">
           <DialogHeader>
-            <DialogTitle>Purchase Programmatic Credits</DialogTitle>
+            <DialogTitle>Purchase programmatic credits</DialogTitle>
             <DialogDescription>
               Credit purchases are not available during your trial period.
             </DialogDescription>
@@ -547,7 +547,7 @@ export function BuyCreditDialog({
       <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
         <DialogContent size="md">
           <DialogHeader>
-            <DialogTitle>Purchase Programmatic Credits</DialogTitle>
+            <DialogTitle>Purchase programmatic credits</DialogTitle>
             <DialogDescription>
               Credit purchases require an active subscription.
             </DialogDescription>
@@ -593,7 +593,7 @@ export function BuyCreditDialog({
       <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
         <DialogContent size="md">
           <DialogHeader>
-            <DialogTitle>Purchase Programmatic Credits</DialogTitle>
+            <DialogTitle>Purchase programmatic credits</DialogTitle>
             <DialogDescription>
               You have pending credit purchases awaiting payment.
             </DialogDescription>
@@ -621,7 +621,7 @@ export function BuyCreditDialog({
               onClick: onClose,
             }}
             rightButtonProps={{
-              label: "Manage Invoices",
+              label: "Manage invoices",
               variant: "primary",
               onClick: () => {
                 window.open(`/w/${workspaceId}/subscription/manage`, "_blank");
@@ -643,7 +643,7 @@ export function BuyCreditDialog({
       <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
         <DialogContent size="md">
           <DialogHeader>
-            <DialogTitle>Purchase Programmatic Credits</DialogTitle>
+            <DialogTitle>Purchase programmatic credits</DialogTitle>
             <DialogDescription>
               You've reached your credit limit for this billing cycle.
             </DialogDescription>
@@ -687,7 +687,7 @@ export function BuyCreditDialog({
     >
       <DialogContent size="md">
         <DialogHeader>
-          <DialogTitle>Purchase Programmatic Credits</DialogTitle>
+          <DialogTitle>Purchase programmatic credits</DialogTitle>
           <DialogDescription>
             Purchase credits for programmatic API usage.
           </DialogDescription>

--- a/front/components/workspace/ChangeSeatModal.tsx
+++ b/front/components/workspace/ChangeSeatModal.tsx
@@ -282,11 +282,11 @@ export function ChangeSeatModal({
             />
             <div>
               <DialogTitle>
-                Change Seat Type for {displayedMember?.name}
+                Change seat type for {displayedMember?.name}
               </DialogTitle>
               <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                They will be able to consume this amount from the pool after
-                reaching their plan usage limit.
+                They will be able to consume this amount from the Workspace
+                Credits Pool after reaching their plan usage limit.
               </p>
             </div>
           </div>

--- a/front/components/workspace/EditSpendLimitModal.tsx
+++ b/front/components/workspace/EditSpendLimitModal.tsx
@@ -200,8 +200,8 @@ export function EditSpendLimitModal({
                 Edit spend limit for {displayedMember?.name}
               </DialogTitle>
               <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                They will be able to consume this amount from the pool after
-                reaching their plan usage limit.
+                They will be able to consume this amount from the Workspace
+                Credits Pool after reaching their plan usage limit.
               </p>
             </div>
           </div>
@@ -245,12 +245,6 @@ export function EditSpendLimitModal({
 
               {kind === "limited" && (
                 <div className="flex flex-col gap-1.5 pl-6">
-                  <label
-                    htmlFor="spend-credit-limit-input"
-                    className="text-sm font-medium text-foreground dark:text-foreground-night"
-                  >
-                    Spend credit limit
-                  </label>
                   <div className="relative">
                     <div className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground dark:text-muted-foreground-night">
                       <Icon visual={ActionCreditCoinsIcon} size="xs" />

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -265,7 +265,7 @@ const consumedAwuCreditsColumn: ColumnDef<RowData, string> = {
   header: () => (
     <span className="flex items-center gap-1.5">
       <Icon visual={ActionCreditCoinsIcon} size="xs" />
-      AWU usage
+      Credits usage
     </span>
   ),
   accessorFn: (row) => row.consumedAwuCredits.toString(),
@@ -375,12 +375,12 @@ export function MembersUsageTable({
     menuItems: [
       {
         kind: "item" as const,
-        label: "Change Seat Type",
+        label: "Change seat type",
         onClick: () => onChangeSeat(m),
       },
       {
         kind: "item" as const,
-        label: "Update User Spend Limit",
+        label: "Edit spend limit",
         onClick: () => onEditSpendLimit(m),
       },
     ],

--- a/front/components/workspace/MetronomeUsageChart.tsx
+++ b/front/components/workspace/MetronomeUsageChart.tsx
@@ -147,7 +147,7 @@ function UsageTooltip(
 
   if (shouldShowTotalCredits) {
     rows.push({
-      label: "Total Credits",
+      label: "Total credits",
       value: `$${(data.totalCreditsMicroUsd / 1_000_000).toFixed(2)}`,
       colorClassName: COST_PALETTE.totalCredits,
     });
@@ -391,7 +391,7 @@ export function BaseMetronomeUsageChart({
     if (shouldShowTotalCredits) {
       items.push({
         key: "totalCredits",
-        label: "Total Credits",
+        label: "Total credits",
         colorClassName: COST_PALETTE.totalCredits,
         isActive: true,
       });
@@ -679,7 +679,7 @@ export function BaseMetronomeUsageChart({
           <Line
             type="monotone"
             dataKey="totalCreditsMicroUsd"
-            name="Total Credits"
+            name="Total credits"
             stroke="currentColor"
             strokeWidth={2}
             className={COST_PALETTE.totalCredits}

--- a/front/components/workspace/ProgrammaticCostChart.tsx
+++ b/front/components/workspace/ProgrammaticCostChart.tsx
@@ -169,7 +169,7 @@ function GroupedTooltip(
   // Add credits row only in cumulative mode
   if (shouldShowTotalCredits) {
     rows.push({
-      label: "Total Credits",
+      label: "Total credits",
       value: `$${(data.totalCreditsMicroUsd / 1_000_000).toFixed(2)}`,
       colorClassName: COST_PALETTE.totalCredits,
     });
@@ -436,7 +436,7 @@ export function BaseProgrammaticCostChart({
   if (shouldShowTotalCredits) {
     legendItems.push({
       key: "totalCredits",
-      label: "Total Credits",
+      label: "Total credits",
       colorClassName: COST_PALETTE.totalCredits,
       isActive: true,
     });
@@ -830,7 +830,7 @@ export function BaseProgrammaticCostChart({
           <Line
             type="monotone"
             dataKey="totalCreditsMicroUsd"
-            name="Total Credits"
+            name="Total credits"
             stroke="currentColor"
             strokeWidth={2}
             className={COST_PALETTE.totalCredits}


### PR DESCRIPTION
## Description

Wording cleanup across the credits / AWU / checkout surfaces. No behavior changes — strings only.

**Consistent terminology**
- "pool" / "credit pool" → **Workspace Credits Pool** (in `UsagePage`, `BuyAwuCreditsDialog`, `EditSpendLimitModal`, `ChangeSeatModal`)
- "AWU" removed from all user-facing copy (column header, dialog description, mailto subjects); kept in code identifiers only

**Reset date label**
- Old: `Monthly resets on the 23rd, June`
- New: `Resets on the 23rd of each month. Next reset: June 23rd.`

**Sentence case across buttons / titles / labels**
- `BuyAwuCreditsDialog`: "Manage Invoices" → "Manage invoices"; "Current Balance" → "Current balance"; "One time top-up" → "One-time top-up"; `{n} credit` → `{n} credits`
- `BuyCreditDialog`: "Purchase Programmatic Credits" → "Purchase programmatic credits" (×5); "Purchase Credits" → "Purchase credits"; "Go to Payment" → "Go to payment"; "Manage Invoices" → "Manage invoices"
- `CreditsUsagePage`: "Complete Payment / Manage Invoices" → "Complete payment / Manage invoices"
- `MembersUsageTable`: "Change Seat Type" → "Change seat type"; "Update User Spend Limit" → "Edit spend limit" (also aligns wording with the modal)
- `ChangeSeatModal`: title now sentence case
- `MetronomeUsageChart` / `ProgrammaticCostChart`: legend / tooltip / Recharts series "Total Credits" → "Total credits"
- `UsagePage`: legend "Programmatic Usage" → "Programmatic usage" (matches adjacent "Users")

**Edit spend limit modal cleanup**
- Menu item aligned with the dialog title ("Edit spend limit")
- Removed the redundant "Spend credit limit" sub-label inside the "Set credit amount" radio option

## Tests

Strings-only change. Verified via `tsgo --noEmit` on the touched files. Reviewed visually in each modal/page.

## Risk

Low — no logic, schema, or API changes. Recharts series names changed from "Total Credits" to "Total credits"; legend/tooltip rendering uses custom components and does not key off this string.

## Deploy Plan

Standard deploy. No migration, no flag, no coordinated rollout needed.