### PR TITLE
Centralize metronome calls to client.ts

### DIFF
--- a/front-api/routes/metronome/webhook.ts
+++ b/front-api/routes/metronome/webhook.ts
@@ -1,6 +1,6 @@
 import apiConfig from "@app/lib/api/config";
 import { processMetronomeWebhook } from "@app/lib/api/metronome/process_webhook";
-import { getMetronomeClient } from "@app/lib/metronome/client";
+import { unwrapMetronomeWebhook } from "@app/lib/metronome/client";
 import { MetronomeWebhookEventSchema } from "@app/lib/metronome/webhook_events";
 import {
   releaseMetronomeWebhookEvent,
@@ -53,8 +53,7 @@ app.post("/", async (ctx): HandlerResult<ResponseBody> => {
 
   let rawEvent: unknown;
   try {
-    const client = getMetronomeClient();
-    rawEvent = client.webhooks.unwrap(bodyString, headers, webhookSecret);
+    rawEvent = unwrapMetronomeWebhook(bodyString, headers, webhookSecret);
   } catch (err) {
     logger.error(
       { error: normalizeError(err) },

--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
@@ -231,10 +231,15 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
     it("returns limited with threshold when alert exists", async () => {
       vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValueOnce(
         new Ok({
-          id: TEST_ALERT_ID,
-          threshold: 2500,
-          state: "ok",
-          uniquenessKey: null,
+          alert: {
+            id: TEST_ALERT_ID,
+            name: "test alert",
+            status: "enabled",
+            threshold: 2500,
+            type: "spend_threshold_reached",
+            updated_at: "2024-01-01T00:00:00Z",
+          },
+          customer_status: "ok",
         })
       );
 

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -116,15 +116,22 @@ export async function handleAwuPoolSummaryRequest(
       // (via the `DUST_SEAT_TYPE` custom field) rather than a hardcoded list.
       const awuCreditTypeId = getCreditTypeAwuId();
       const activeContract = await getActiveContract(workspace.sId);
+      if (!activeContract) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Workspace is not configured for Metronome billing.",
+          },
+        });
+      }
       const productSeatTypes = await getProductSeatTypes();
-      const seatProductIds = activeContract
-        ? new Set(
-            getSeatTypesByProductIdFromContract(
-              activeContract,
-              productSeatTypes
-            ).keys()
-          )
-        : new Set<string>();
+      const seatProductIds = new Set(
+        getSeatTypesByProductIdFromContract(
+          activeContract,
+          productSeatTypes
+        ).keys()
+      );
       const awuBalances = balancesResult.value.filter(
         (entry) =>
           entry.access_schedule?.credit_type?.id === awuCreditTypeId &&

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -128,8 +128,8 @@ async function fetchPerUserSpendLimitsForMembersTable({
     return new Map();
   }
   const thresholds = new Map<string, number>();
-  for (const [userId, alert] of result.value) {
-    thresholds.set(userId, alert.threshold);
+  for (const [userId, entry] of result.value) {
+    thresholds.set(userId, entry.alert.threshold);
   }
   return thresholds;
 }

--- a/front/lib/api/credits/seat_plan.ts
+++ b/front/lib/api/credits/seat_plan.ts
@@ -143,7 +143,7 @@ export async function handleSeatPlanRequest(
     );
   }
 
-  const monthlyPriceCentsBySeatType = new Map<MembershipSeatType, number>();
+  const priceCentsBySeatType = new Map<MembershipSeatType, number>();
   const nameBySeatType = new Map<MembershipSeatType, string>();
   try {
     // Use the contract-level rate schedule (not the rate card's) so contract
@@ -167,11 +167,13 @@ export async function handleSeatPlanRequest(
         continue;
       }
       // Metronome quotes prices in its per-currency native unit (USD in
-      // cents, others in whole units); normalize to actual cents here.
-      // TODO (https://github.com/dust-tt/tasks/issues/8072): Add annual pricing
-      monthlyPriceCentsBySeatType.set(seatType, amountCents(price, currency));
+      // cents, others in whole units); normalize to actual cents here. The
+      // rate is whatever the entry's billing_frequency dictates — monthly
+      // for monthly subscriptions, annual for annual subscriptions — and
+      // `billingFrequency` on the response tells the UI which is which.
+      priceCentsBySeatType.set(seatType, amountCents(price, currency));
       nameBySeatType.set(seatType, entry.product_name);
-      if (monthlyPriceCentsBySeatType.size >= seatTypesByProductId.size) {
+      if (priceCentsBySeatType.size >= seatTypesByProductId.size) {
         break;
       }
     }
@@ -195,7 +197,7 @@ export async function handleSeatPlanRequest(
 
   const response: SeatPlanResponseBody = {};
   for (const seatType of seatTypesByProductId.values()) {
-    const priceCents = monthlyPriceCentsBySeatType.get(seatType);
+    const priceCents = priceCentsBySeatType.get(seatType);
     const name = nameBySeatType.get(seatType);
     if (priceCents === undefined || name === undefined) {
       continue;

--- a/front/lib/api/credits/seat_plan.ts
+++ b/front/lib/api/credits/seat_plan.ts
@@ -1,6 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import { amountCents } from "@app/lib/metronome/amounts";
-import { getMetronomeClient } from "@app/lib/metronome/client";
+import { listMetronomeContractRateSchedule } from "@app/lib/metronome/client";
 import { getCreditTypeFromContract } from "@app/lib/metronome/coupons";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import {
@@ -150,41 +150,31 @@ export async function handleSeatPlanRequest(
     // overrides on entitlement and price are applied. This endpoint only
     // returns entitled rates and exposes `override_rate` when a contract
     // override changes the price.
-    const at = new Date().toISOString();
-    let nextPage: string | null | undefined = undefined;
-    do {
-      const rateSchedule =
-        await getMetronomeClient().v1.contracts.retrieveRateSchedule({
-          contract_id: contract.id,
-          customer_id: contract.customer_id,
-          at,
-          ...(nextPage ? { next_page: nextPage } : {}),
-        });
-
-      for (const entry of rateSchedule.data ?? []) {
-        if (!entry.entitled) {
-          continue;
-        }
-        const price = entry.override_rate?.price ?? entry.list_rate.price;
-        if (price === undefined) {
-          continue;
-        }
-        const seatType = seatTypesByProductId.get(entry.product_id);
-        if (!seatType) {
-          continue;
-        }
-        // Metronome quotes prices in its per-currency native unit (USD in
-        // cents, others in whole units); normalize to actual cents here.
-        // TODO (https://github.com/dust-tt/tasks/issues/8072): Add annual pricing
-        monthlyPriceCentsBySeatType.set(seatType, amountCents(price, currency));
-        nameBySeatType.set(seatType, entry.product_name);
+    for await (const entry of listMetronomeContractRateSchedule({
+      metronomeCustomerId: contract.customer_id,
+      metronomeContractId: contract.id,
+      at: new Date().toISOString(),
+    })) {
+      if (!entry.entitled) {
+        continue;
       }
-
-      nextPage = rateSchedule.next_page;
-    } while (
-      nextPage &&
-      monthlyPriceCentsBySeatType.size < seatTypesByProductId.size
-    );
+      const price = entry.override_rate?.price ?? entry.list_rate.price;
+      if (price === undefined) {
+        continue;
+      }
+      const seatType = seatTypesByProductId.get(entry.product_id);
+      if (!seatType) {
+        continue;
+      }
+      // Metronome quotes prices in its per-currency native unit (USD in
+      // cents, others in whole units); normalize to actual cents here.
+      // TODO (https://github.com/dust-tt/tasks/issues/8072): Add annual pricing
+      monthlyPriceCentsBySeatType.set(seatType, amountCents(price, currency));
+      nameBySeatType.set(seatType, entry.product_name);
+      if (monthlyPriceCentsBySeatType.size >= seatTypesByProductId.size) {
+        break;
+      }
+    }
   } catch (err) {
     logger.warn(
       {

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -19,9 +19,9 @@ import {
   YEARLY_MULTIPLIER,
 } from "@app/lib/credits/free";
 import {
-  getMetronomeClient,
   getMetronomeContractById,
   listMetronomeContracts,
+  setMetronomeContractCreditCustomFields,
   updateMetronomeCreditSegmentAmount,
 } from "@app/lib/metronome/client";
 import {
@@ -130,13 +130,20 @@ async function stampContractCreditType({
     }
   }
 
-  await getMetronomeClient().v1.customFields.setValues({
-    entity: "contract_credit",
-    entity_id: creditId,
-    custom_fields: {
+  const setResult = await setMetronomeContractCreditCustomFields({
+    creditId,
+    customFields: {
       [CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]: value,
     },
   });
+  if (setResult.isErr()) {
+    return new Err(
+      new ProcessMetronomeWebhookError(
+        "processing_failed",
+        `Error stamping contract credit custom field: ${setResult.error.message}`
+      )
+    );
+  }
   logger.info(
     { customerId, contractId, creditId, value, eventType },
     `[Metronome Webhook] ${eventType}: stamped DUST_CONTRACT_CREDIT_TYPE`

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -91,7 +91,7 @@ export async function getUserSpendLimit(
   if (!result.value) {
     return new Ok({ kind: "unlimited" });
   }
-  return new Ok({ kind: "limited", awuCredits: result.value.threshold });
+  return new Ok({ kind: "limited", awuCredits: result.value.alert.threshold });
 }
 
 /**

--- a/front/lib/metronome/alerts.ts
+++ b/front/lib/metronome/alerts.ts
@@ -7,6 +7,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { V1 } from "@metronome/sdk/resources";
+import type { CustomerAlert } from "@metronome/sdk/resources/v1/customers";
 
 type UpsertMetronomeAlertParams = V1.AlertCreateParams & {
   customer_id: string;
@@ -19,7 +20,7 @@ export async function findMetronomeAlert({
 }: {
   metronomeCustomerId: string;
   uniquenessKey: string;
-}): Promise<Result<V1.Customers.CustomerAlert | null, Error>> {
+}): Promise<Result<CustomerAlert | null, Error>> {
   try {
     for await (const entry of listMetronomeAlerts({
       customer_id: metronomeCustomerId,

--- a/front/lib/metronome/alerts.ts
+++ b/front/lib/metronome/alerts.ts
@@ -1,60 +1,17 @@
-import { getMetronomeClient } from "@app/lib/metronome/client";
+import {
+  archiveMetronomeAlert,
+  createMetronomeAlert,
+  listMetronomeAlerts,
+} from "@app/lib/metronome/client";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { V1 } from "@metronome/sdk/resources";
 
-// Mirrors the Metronome SDK's `CustomerAlert.customer_status`. `null` means
-// the alert has been archived; the dispatch layer treats it the same as
-// "evaluating" (no-op).
-export type MetronomeAlertState = "ok" | "in_alarm" | "evaluating" | null;
-
-export type MetronomeAlert = {
-  id: string;
-  threshold: number;
-  state: MetronomeAlertState;
-  uniquenessKey: string | null;
-};
-
 type UpsertMetronomeAlertParams = V1.AlertCreateParams & {
   customer_id: string;
   uniqueness_key: string;
 };
-
-async function createMetronomeAlert(
-  params: V1.AlertCreateParams
-): Promise<V1.AlertCreateResponse> {
-  const client = getMetronomeClient();
-  return client.v1.alerts.create(params);
-}
-
-async function archiveMetronomeAlert(
-  params: V1.AlertArchiveParams
-): Promise<V1.AlertArchiveResponse> {
-  const client = getMetronomeClient();
-  return client.v1.alerts.archive({
-    ...params,
-    release_uniqueness_key: true,
-  });
-}
-
-// Lazily iterates Metronome customer alerts, transparently auto-paginating via
-// the SDK's PagePromise. Callers can `break` to early-exit (no extra pages are
-// fetched) or iterate to the end to scan everything. Errors thrown by the SDK
-// surface through the iterator — callers wrap with try/catch + `Result`.
-export async function* listMetronomeAlerts(
-  params: V1.Customers.AlertListParams
-): AsyncGenerator<MetronomeAlert> {
-  const client = getMetronomeClient();
-  for await (const entry of client.v1.customers.alerts.list(params)) {
-    yield {
-      id: entry.alert.id,
-      threshold: entry.alert.threshold,
-      state: entry.customer_status,
-      uniquenessKey: entry.alert.uniqueness_key ?? null,
-    };
-  }
-}
 
 export async function findMetronomeAlert({
   metronomeCustomerId,
@@ -62,14 +19,14 @@ export async function findMetronomeAlert({
 }: {
   metronomeCustomerId: string;
   uniquenessKey: string;
-}): Promise<Result<MetronomeAlert | null, Error>> {
+}): Promise<Result<V1.Customers.CustomerAlert | null, Error>> {
   try {
-    for await (const alert of listMetronomeAlerts({
+    for await (const entry of listMetronomeAlerts({
       customer_id: metronomeCustomerId,
       alert_statuses: ["ENABLED", "DISABLED"],
     })) {
-      if (alert.uniquenessKey === uniquenessKey) {
-        return new Ok(alert);
+      if (entry.alert.uniqueness_key === uniquenessKey) {
+        return new Ok(entry);
       }
     }
     return new Ok(null);
@@ -96,13 +53,13 @@ export async function upsertMetronomeAlert(
   }
   const existing = findResult.value;
 
-  if (existing && existing.threshold === params.threshold) {
-    return new Ok({ alertId: existing.id });
+  if (existing && existing.alert.threshold === params.threshold) {
+    return new Ok({ alertId: existing.alert.id });
   }
 
   try {
     if (existing) {
-      await archiveMetronomeAlert({ id: existing.id });
+      await archiveMetronomeAlert({ id: existing.alert.id });
     }
     const created = await createMetronomeAlert(params);
     return new Ok({ alertId: created.data.id });
@@ -136,8 +93,8 @@ export async function clearMetronomeAlert({
   }
 
   try {
-    await archiveMetronomeAlert({ id: existing.id });
-    return new Ok({ alertId: existing.id });
+    await archiveMetronomeAlert({ id: existing.alert.id });
+    return new Ok({ alertId: existing.alert.id });
   } catch (err) {
     return new Err(normalizeError(err));
   }

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -11,9 +11,13 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import Metronome, { ConflictError } from "@metronome/sdk";
-import type { Commit, ContractV2, Credit } from "@metronome/sdk/resources";
+import type { Commit, ContractV2, Credit, V1 } from "@metronome/sdk/resources";
+import type { ContractRetrieveRateScheduleResponse } from "@metronome/sdk/resources/v1/contracts/contracts";
+import type { ProductListResponse } from "@metronome/sdk/resources/v1/contracts/products";
 import type { RateCardRetrieveResponse } from "@metronome/sdk/resources/v1/contracts/rate-cards";
 import type { Invoice } from "@metronome/sdk/resources/v1/customers";
+import type { ContractEditParams } from "@metronome/sdk/resources/v2/contracts";
+import type { IncomingHttpHeaders } from "http";
 import type {
   MetronomeBalance,
   MetronomeEvent,
@@ -69,6 +73,22 @@ export function ceilToMidnightUTC(d: Date): Date {
   return floored.getTime() < d.getTime()
     ? new Date(floored.getTime() + DAY_MS)
     : floored;
+}
+
+// ---------------------------------------------------------------------------
+// Webhooks
+// ---------------------------------------------------------------------------
+
+/**
+ * Verify a Metronome webhook signature and return the parsed payload as an
+ * unknown — callers schema-check it. Throws if the signature is invalid.
+ */
+export function unwrapMetronomeWebhook(
+  rawBody: string,
+  headers: IncomingHttpHeaders,
+  secret: string
+): unknown {
+  return getMetronomeClient().webhooks.unwrap(rawBody, headers, secret);
 }
 
 // ---------------------------------------------------------------------------
@@ -517,6 +537,26 @@ export async function setMetronomeContractCustomFields({
   }
 }
 
+/** Set custom field values on a Metronome contract credit. */
+export async function setMetronomeContractCreditCustomFields({
+  creditId,
+  customFields,
+}: {
+  creditId: string;
+  customFields: Record<string, string>;
+}): Promise<Result<void, Error>> {
+  try {
+    await getMetronomeClient().v1.customFields.setValues({
+      entity: "contract_credit",
+      entity_id: creditId,
+      custom_fields: customFields,
+    });
+    return new Ok(undefined);
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Contract management
 // ---------------------------------------------------------------------------
@@ -834,6 +874,64 @@ export async function reactivateMetronomeContract({
     );
     return new Err(error);
   }
+}
+
+/**
+ * Generic wrapper around `v2.contracts.edit`. The Metronome edit endpoint is
+ * an omnibus mutation (add subscriptions, commits, credits, overrides, billing
+ * provider, etc.) — callers compose the body and we surface the resulting
+ * edit id (or error) without prescribing the payload shape.
+ */
+export async function editMetronomeContract(
+  params: ContractEditParams
+): Promise<Result<{ editId: string }, Error>> {
+  try {
+    const response = await getMetronomeClient().v2.contracts.edit(params);
+    return new Ok({ editId: response.data.id });
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      {
+        error,
+        metronomeCustomerId: params.customer_id,
+        contractId: params.contract_id,
+      },
+      "[Metronome] Failed to edit contract"
+    );
+    return new Err(error);
+  }
+}
+
+/**
+ * Lazily iterate the rate-schedule entries for a contract at a given
+ * timestamp. Yields one entry at a time, fetching pages on demand —
+ * callers can `break` early once they've found what they need without
+ * dragging extra pages over the wire. Errors thrown by the SDK surface
+ * through the iterator; wrap with try/catch + Result.
+ */
+export async function* listMetronomeContractRateSchedule({
+  metronomeCustomerId,
+  metronomeContractId,
+  at,
+}: {
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+  at: string;
+}): AsyncGenerator<ContractRetrieveRateScheduleResponse.Data> {
+  const client = getMetronomeClient();
+  let nextPage: string | null | undefined = undefined;
+  do {
+    const response = await client.v1.contracts.retrieveRateSchedule({
+      contract_id: metronomeContractId,
+      customer_id: metronomeCustomerId,
+      at,
+      ...(nextPage ? { next_page: nextPage } : {}),
+    });
+    for (const entry of response.data ?? []) {
+      yield entry;
+    }
+    nextPage = response.next_page;
+  } while (nextPage);
 }
 
 /**
@@ -1391,22 +1489,18 @@ export async function findMetronomeCommitByUniquenessKey({
 // Products
 // ---------------------------------------------------------------------------
 
-interface MetronomeProduct {
-  id: string;
-  name: string;
-}
-
 /**
- * List all products from Metronome.
- * Used to resolve product IDs by name (e.g. "Pro Seat", "Max Seat").
+ * List all products from Metronome. Returns the raw SDK product objects so
+ * callers can read whatever fields they need (custom_fields, current state,
+ * etc.) without us maintaining a stripped wrapper type.
  */
 export async function listMetronomeProducts(): Promise<
-  Result<MetronomeProduct[], Error>
+  Result<ProductListResponse[], Error>
 > {
   try {
-    const products: MetronomeProduct[] = [];
+    const products: ProductListResponse[] = [];
     for await (const product of getMetronomeClient().v1.contracts.products.list()) {
-      products.push({ id: product.id, name: product.current.name });
+      products.push(product);
     }
     return new Ok(products);
   } catch (err) {
@@ -2021,5 +2115,40 @@ export async function listMetronomeSeatBalances({
       "[Metronome] Failed to list seat balances"
     );
     return new Err(error);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Alerts
+// ---------------------------------------------------------------------------
+
+export async function createMetronomeAlert(
+  params: V1.AlertCreateParams
+): Promise<V1.AlertCreateResponse> {
+  return getMetronomeClient().v1.alerts.create(params);
+}
+
+// Archives the alert and releases its uniqueness_key so it can be reused
+// by a subsequent create (the only way we ever archive alerts today).
+export async function archiveMetronomeAlert(
+  params: V1.AlertArchiveParams
+): Promise<V1.AlertArchiveResponse> {
+  return getMetronomeClient().v1.alerts.archive({
+    ...params,
+    release_uniqueness_key: true,
+  });
+}
+
+// Lazily iterates Metronome customer alerts, transparently auto-paginating via
+// the SDK's PagePromise. Callers can `break` to early-exit (no extra pages are
+// fetched) or iterate to the end to scan everything. Errors thrown by the SDK
+// surface through the iterator — callers wrap with try/catch + `Result`.
+export async function* listMetronomeAlerts(
+  params: V1.Customers.AlertListParams
+): AsyncGenerator<V1.Customers.CustomerAlert> {
+  for await (const entry of getMetronomeClient().v1.customers.alerts.list(
+    params
+  )) {
+    yield entry;
   }
 }

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -15,7 +15,10 @@ import type { Commit, ContractV2, Credit, V1 } from "@metronome/sdk/resources";
 import type { ContractRetrieveRateScheduleResponse } from "@metronome/sdk/resources/v1/contracts/contracts";
 import type { ProductListResponse } from "@metronome/sdk/resources/v1/contracts/products";
 import type { RateCardRetrieveResponse } from "@metronome/sdk/resources/v1/contracts/rate-cards";
-import type { Invoice } from "@metronome/sdk/resources/v1/customers";
+import type {
+  CustomerAlert,
+  Invoice,
+} from "@metronome/sdk/resources/v1/customers";
 import type { ContractEditParams } from "@metronome/sdk/resources/v2/contracts";
 import type { IncomingHttpHeaders } from "http";
 import type {
@@ -2145,7 +2148,7 @@ export async function archiveMetronomeAlert(
 // surface through the iterator — callers wrap with try/catch + `Result`.
 export async function* listMetronomeAlerts(
   params: V1.Customers.AlertListParams
-): AsyncGenerator<V1.Customers.CustomerAlert> {
+): AsyncGenerator<CustomerAlert> {
   for await (const entry of getMetronomeClient().v1.customers.alerts.list(
     params
   )) {

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -3,14 +3,15 @@ import {
   ceilToHourISO,
   createMetronomeContract,
   createMetronomeCustomer,
+  editMetronomeContract,
   ensureMetronomeStripeBillingConfig,
   findMetronomeCustomerByAlias,
   floorToHourISO,
-  getMetronomeClient,
   getMetronomeContractById,
   getMetronomeCustomerStripeCustomerId,
   listMetronomeContracts,
   scheduleMetronomeContractEnd,
+  setMetronomeContractCustomFields,
 } from "@app/lib/metronome/client";
 import {
   CURRENCY_TO_CREDIT_TYPE_ID,
@@ -928,8 +929,6 @@ export async function applyEnterpriseOverrides({
     `Applying enterprise overrides (${pricing.billingMode})`
   );
 
-  const client = getMetronomeClient();
-
   // Check existing contract state to avoid adding duplicate subscriptions/commits on re-runs.
   let subscriptionsToAdd = payload.add_subscriptions;
   let commitsToAdd = payload.recurring_commits;
@@ -938,11 +937,14 @@ export async function applyEnterpriseOverrides({
     (subscriptionsToAdd && subscriptionsToAdd.length > 0) ||
     (commitsToAdd && commitsToAdd.length > 0)
   ) {
-    const contractResponse = await client.v2.contracts.retrieve({
-      customer_id: metronomeCustomerId,
-      contract_id: contractId,
+    const contractResult = await getMetronomeContractById({
+      metronomeCustomerId,
+      metronomeContractId: contractId,
     });
-    const contractData = contractResponse.data;
+    if (contractResult.isErr()) {
+      throw contractResult.error;
+    }
+    const contractData = contractResult.value;
 
     // Filter out subscriptions that already exist.
     if (subscriptionsToAdd && subscriptionsToAdd.length > 0) {
@@ -967,7 +969,7 @@ export async function applyEnterpriseOverrides({
     }
   }
 
-  await client.v2.contracts.edit({
+  const editResult = await editMetronomeContract({
     customer_id: metronomeCustomerId,
     contract_id: contractId,
     add_overrides: payload.overrides,
@@ -978,14 +980,19 @@ export async function applyEnterpriseOverrides({
       ? { add_recurring_commits: commitsToAdd }
       : {}),
   });
+  if (editResult.isErr()) {
+    throw editResult.error;
+  }
 
   // Set custom fields (MAU_TIERS, MAU_THRESHOLD) on the contract.
   if (payload.custom_fields) {
-    await client.v1.customFields.setValues({
-      entity: "contract",
-      entity_id: contractId,
-      custom_fields: payload.custom_fields,
+    const customFieldsResult = await setMetronomeContractCustomFields({
+      contractId,
+      customFields: payload.custom_fields,
     });
+    if (customFieldsResult.isErr()) {
+      throw customFieldsResult.error;
+    }
   }
 
   overrideLogger.info(

--- a/front/lib/metronome/default_user_cap_alert.ts
+++ b/front/lib/metronome/default_user_cap_alert.ts
@@ -6,7 +6,7 @@ import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import type { V1 } from "@metronome/sdk/resources";
+import type { CustomerAlert } from "@metronome/sdk/resources/v1/customers";
 
 const USER_ID_GROUP_KEY = "user_id";
 
@@ -29,7 +29,7 @@ export async function getMetronomeDefaultUserCapAlert({
 }: {
   metronomeCustomerId: string;
   workspaceId: string;
-}): Promise<Result<V1.Customers.CustomerAlert | null, Error>> {
+}): Promise<Result<CustomerAlert | null, Error>> {
   return findMetronomeAlert({
     metronomeCustomerId,
     uniquenessKey: defaultUserCapAlertUniquenessKey(workspaceId),

--- a/front/lib/metronome/default_user_cap_alert.ts
+++ b/front/lib/metronome/default_user_cap_alert.ts
@@ -1,4 +1,3 @@
-import type { MetronomeAlert } from "@app/lib/metronome/alerts";
 import {
   findMetronomeAlert,
   upsertMetronomeAlert,
@@ -7,6 +6,7 @@ import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import type { V1 } from "@metronome/sdk/resources";
 
 const USER_ID_GROUP_KEY = "user_id";
 
@@ -29,7 +29,7 @@ export async function getMetronomeDefaultUserCapAlert({
 }: {
   metronomeCustomerId: string;
   workspaceId: string;
-}): Promise<Result<MetronomeAlert | null, Error>> {
+}): Promise<Result<V1.Customers.CustomerAlert | null, Error>> {
   return findMetronomeAlert({
     metronomeCustomerId,
     uniquenessKey: defaultUserCapAlertUniquenessKey(workspaceId),

--- a/front/lib/metronome/per_user_alerts.ts
+++ b/front/lib/metronome/per_user_alerts.ts
@@ -1,15 +1,15 @@
-import type { MetronomeAlert } from "@app/lib/metronome/alerts";
 import {
   clearMetronomeAlert,
   findMetronomeAlert,
-  listMetronomeAlerts,
   upsertMetronomeAlert,
 } from "@app/lib/metronome/alerts";
+import { listMetronomeAlerts } from "@app/lib/metronome/client";
 import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { V1 } from "@metronome/sdk/resources";
 
 const USER_ID_GROUP_KEY = "user_id";
 
@@ -37,7 +37,7 @@ export async function getMetronomePerUserCap({
   metronomeCustomerId: string;
   workspaceId: string;
   userId: string;
-}): Promise<Result<MetronomeAlert | null, Error>> {
+}): Promise<Result<V1.Customers.CustomerAlert | null, Error>> {
   return findMetronomeAlert({
     metronomeCustomerId,
     uniquenessKey: perUserAlertUniquenessKey(workspaceId, userId),
@@ -45,10 +45,9 @@ export async function getMetronomePerUserCap({
 }
 
 /**
- * List per-user caps for a workspace. Returns a `Map<userId, MetronomeAlert>`
+ * List per-user caps for a workspace. Returns a `Map<userId, CustomerAlert>`
  * built from all enabled alerts whose `uniqueness_key` matches the per-user
- * cap pattern for this workspace. Each entry exposes the current threshold
- * and Metronome evaluation state.
+ * cap pattern for this workspace.
  */
 export async function listMetronomePerUserCapsForWorkspace({
   metronomeCustomerId,
@@ -56,15 +55,15 @@ export async function listMetronomePerUserCapsForWorkspace({
 }: {
   metronomeCustomerId: string;
   workspaceId: string;
-}): Promise<Result<Map<string, MetronomeAlert>, Error>> {
+}): Promise<Result<Map<string, V1.Customers.CustomerAlert>, Error>> {
   const prefix = perUserAlertUniquenessKeyPrefix(workspaceId);
-  const caps = new Map<string, MetronomeAlert>();
+  const caps = new Map<string, V1.Customers.CustomerAlert>();
   try {
-    for await (const alert of listMetronomeAlerts({
+    for await (const entry of listMetronomeAlerts({
       customer_id: metronomeCustomerId,
       alert_statuses: ["ENABLED"],
     })) {
-      const key = alert.uniquenessKey;
+      const key = entry.alert.uniqueness_key;
       if (!key || !key.startsWith(prefix)) {
         continue;
       }
@@ -72,7 +71,7 @@ export async function listMetronomePerUserCapsForWorkspace({
       if (!userId) {
         continue;
       }
-      caps.set(userId, alert);
+      caps.set(userId, entry);
     }
     return new Ok(caps);
   } catch (err) {

--- a/front/lib/metronome/per_user_alerts.ts
+++ b/front/lib/metronome/per_user_alerts.ts
@@ -9,7 +9,7 @@ import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import type { V1 } from "@metronome/sdk/resources";
+import type { CustomerAlert } from "@metronome/sdk/resources/v1/customers";
 
 const USER_ID_GROUP_KEY = "user_id";
 
@@ -37,7 +37,7 @@ export async function getMetronomePerUserCap({
   metronomeCustomerId: string;
   workspaceId: string;
   userId: string;
-}): Promise<Result<V1.Customers.CustomerAlert | null, Error>> {
+}): Promise<Result<CustomerAlert | null, Error>> {
   return findMetronomeAlert({
     metronomeCustomerId,
     uniquenessKey: perUserAlertUniquenessKey(workspaceId, userId),
@@ -55,9 +55,9 @@ export async function listMetronomePerUserCapsForWorkspace({
 }: {
   metronomeCustomerId: string;
   workspaceId: string;
-}): Promise<Result<Map<string, V1.Customers.CustomerAlert>, Error>> {
+}): Promise<Result<Map<string, CustomerAlert>, Error>> {
   const prefix = perUserAlertUniquenessKeyPrefix(workspaceId);
-  const caps = new Map<string, V1.Customers.CustomerAlert>();
+  const caps = new Map<string, CustomerAlert>();
   try {
     for await (const entry of listMetronomeAlerts({
       customer_id: metronomeCustomerId,

--- a/front/lib/metronome/plan_type.ts
+++ b/front/lib/metronome/plan_type.ts
@@ -1,4 +1,4 @@
-import { getMetronomeClient } from "@app/lib/metronome/client";
+import { getMetronomeContractById } from "@app/lib/metronome/client";
 import { SubscriptionModel } from "@app/lib/models/plan";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { cacheWithRedis, invalidateCacheWithRedis } from "@app/lib/utils/cache";
@@ -38,11 +38,13 @@ async function fetchActiveContract(
       return null;
     }
 
-    const client = getMetronomeClient();
-    const response = await client.v2.contracts.retrieve({
-      customer_id: workspace.metronomeCustomerId,
-      contract_id: subscription.metronomeContractId,
+    const result = await getMetronomeContractById({
+      metronomeCustomerId: workspace.metronomeCustomerId,
+      metronomeContractId: subscription.metronomeContractId,
     });
+    if (result.isErr()) {
+      throw result.error;
+    }
 
     logger.info(
       {
@@ -53,10 +55,7 @@ async function fetchActiveContract(
       "[Metronome Contract] Contract fetched"
     );
 
-    if (!response.data) {
-      return null;
-    }
-    const { commits: _commits, credits: _credits, ...contract } = response.data;
+    const { commits: _commits, credits: _credits, ...contract } = result.value;
     return contract;
   } catch (err) {
     logger.warn(

--- a/front/lib/metronome/seat_types.ts
+++ b/front/lib/metronome/seat_types.ts
@@ -1,4 +1,4 @@
-import { getMetronomeClient } from "@app/lib/metronome/client";
+import { listMetronomeProducts } from "@app/lib/metronome/client";
 import { SEAT_TYPE_CUSTOM_FIELD_KEY } from "@app/lib/metronome/constants";
 import type { CachedContract } from "@app/lib/metronome/plan_type";
 import { cacheWithRedis, invalidateCacheWithRedis } from "@app/lib/utils/cache";
@@ -23,8 +23,12 @@ import type { Subscription } from "@metronome/sdk/resources";
 async function fetchProductSeatTypes(): Promise<
   Record<string, MembershipSeatType>
 > {
+  const productsResult = await listMetronomeProducts();
+  if (productsResult.isErr()) {
+    throw productsResult.error;
+  }
   const result: Record<string, MembershipSeatType> = {};
-  for await (const product of getMetronomeClient().v1.contracts.products.list()) {
+  for (const product of productsResult.value) {
     const value = product.custom_fields?.[SEAT_TYPE_CUSTOM_FIELD_KEY];
     if (value && isMembershipSeatType(value)) {
       result[product.id] = value;

--- a/front/pages/api/metronome/webhook.test.ts
+++ b/front/pages/api/metronome/webhook.test.ts
@@ -1,8 +1,8 @@
 import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
 import {
-  getMetronomeClient,
   getMetronomeContractById,
   listMetronomeContracts,
+  unwrapMetronomeWebhook,
 } from "@app/lib/metronome/client";
 import { PLAN_CODE_CUSTOM_FIELD_KEY } from "@app/lib/metronome/constants";
 import {
@@ -43,9 +43,9 @@ vi.mock(import("@app/lib/metronome/client"), async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,
-    getMetronomeClient: vi.fn(),
     getMetronomeContractById: vi.fn(),
     listMetronomeContracts: vi.fn(),
+    unwrapMetronomeWebhook: vi.fn(),
   };
 });
 
@@ -183,11 +183,9 @@ beforeEach(() => {
   vi.mocked(releaseMetronomeWebhookEvent).mockResolvedValue(undefined);
 });
 
-/** Stub `getMetronomeClient().webhooks.unwrap` to bypass signature verification. */
+/** Stub `unwrapMetronomeWebhook` to bypass signature verification. */
 function mockUnwrap(event: Record<string, unknown>) {
-  vi.mocked(getMetronomeClient).mockReturnValue({
-    webhooks: { unwrap: vi.fn().mockReturnValue(event) },
-  } as never);
+  vi.mocked(unwrapMetronomeWebhook).mockReturnValue(event);
 }
 
 describe("Metronome webhook — contract.start", () => {

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -2,7 +2,7 @@
 /** @ignoreswagger */
 import apiConfig from "@app/lib/api/config";
 import { processMetronomeWebhook } from "@app/lib/api/metronome/process_webhook";
-import { getMetronomeClient } from "@app/lib/metronome/client";
+import { unwrapMetronomeWebhook } from "@app/lib/metronome/client";
 import { MetronomeWebhookEventSchema } from "@app/lib/metronome/webhook_events";
 import {
   releaseMetronomeWebhookEvent,
@@ -67,8 +67,7 @@ async function handler(
 
       let rawEvent: unknown;
       try {
-        const client = getMetronomeClient();
-        rawEvent = client.webhooks.unwrap(
+        rawEvent = unwrapMetronomeWebhook(
           bodyString,
           req.headers,
           webhookSecret

--- a/front/pages/api/w/[wId]/members/[uId]/spend_limit.test.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/spend_limit.test.ts
@@ -215,10 +215,15 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
     it("returns limited with threshold when alert exists", async () => {
       vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValueOnce(
         new Ok({
-          id: TEST_ALERT_ID,
-          threshold: 2500,
-          state: "ok",
-          uniquenessKey: null,
+          alert: {
+            id: TEST_ALERT_ID,
+            name: "test alert",
+            status: "enabled",
+            threshold: 2500,
+            type: "spend_threshold_reached",
+            updated_at: "2024-01-01T00:00:00Z",
+          },
+          customer_status: "ok",
         })
       );
 


### PR DESCRIPTION
## Description

Centralize all Metronome SDK calls behind `lib/metronome/client.ts` wrappers, and drop the stripped projection types (`MetronomeProduct`, `MetronomeAlert`, `MetronomeAlertState`) that just renamed SDK fields without adding anything.

### Moved into `client.ts`
- `createMetronomeAlert`, `archiveMetronomeAlert`, `listMetronomeAlerts` — moved verbatim from `lib/metronome/alerts.ts`. `alerts.ts` keeps the orchestration helpers (`findMetronomeAlert`, `upsertMetronomeAlert`, `clearMetronomeAlert`).
- `editMetronomeContract` — generic `Result`-returning wrapper over `v2.contracts.edit`.
- `listMetronomeContractRateSchedule` — async generator that handles pagination of `v1.contracts.retrieveRateSchedule`.
- `setMetronomeContractCreditCustomFields` — sibling of the existing `setMetronomeContractCustomFields`, for `entity: "contract_credit"`.
- `unwrapMetronomeWebhook` — thin pass-through around `client.webhooks.unwrap` for signature verification.

### Refactored to use wrappers (no behavior change)
- `lib/metronome/contracts.ts:applyEnterpriseOverrides` — uses `getMetronomeContractById` + `editMetronomeContract` + `setMetronomeContractCustomFields` instead of raw `client.v2.contracts.retrieve / edit / customFields.setValues`. Orchestration logic stays in `contracts.ts`.
- `lib/metronome/plan_type.ts` — uses `getMetronomeContractById` instead of `client.v2.contracts.retrieve`.
- `lib/metronome/seat_types.ts` — uses `listMetronomeProducts` instead of raw `client.v1.contracts.products.list`.
- `lib/api/credits/seat_plan.ts` — uses the new `listMetronomeContractRateSchedule` generator.
- `lib/api/metronome/process_webhook.ts` — uses `setMetronomeContractCreditCustomFields`.
- `pages/api/metronome/webhook.ts` — uses `unwrapMetronomeWebhook`.

### Dropped stripped types
- `MetronomeProduct` (`{id, name}`) — `listMetronomeProducts` now returns the full SDK `ProductListResponse[]` so callers can read whatever fields they need (e.g. `seat_types.ts` already needed `custom_fields`).
- `MetronomeAlert` / `MetronomeAlertState` — `listMetronomeAlerts` now yields raw `V1.Customers.CustomerAlert`. Consumers (`alerts.ts`, `default_user_cap_alert.ts`, `per_user_alerts.ts`, `spend_limit.ts`, `members_usage.ts`) updated to read `entry.alert.threshold`, `entry.alert.uniqueness_key`, `entry.customer_status` directly.

### Behavior preservation

Pure refactor — same SDK calls, same arguments, same retry/error semantics. Audited each change:

- **`process_webhook.ts:stampContractCreditType`**: the bare `setValues` throw previously bubbled out and turned into a 500 via the `withLogging` middleware (with the dedup claim still released via the handler's `finally`). The wrapper catches the throw and returns `Err`, which the case handler converts to `new Err(ProcessMetronomeWebhookError(...))`, which the webhook handler still maps to a 500 with the claim released. Same status code, same retry behavior on Metronome's side; the response body now carries a slightly more informative error string.
- **`contracts.ts:applyEnterpriseOverrides`**: previously let raw SDK errors throw; the new wrappers return `Result`, and the function rethrows `result.error` on `isErr()` so the outer caller sees the same exception flow.
- **`seat_plan.ts` rate-schedule pagination**: the old loop checked `monthlyPriceCentsBySeatType.size < seatTypesByProductId.size` at the *page* boundary; the new generator iterates entry-by-entry and `break`s as soon as all seat types are populated. Same number of pages fetched and same response in every realistic case (rate schedules have one entry per `product_id` at a given timestamp). The only theoretical difference is if a single page contained multiple entries for the same `product_id` (e.g. via `pricing_group_values`) — old code's "last-write-wins" could pick a different price than the new code's "first-complete-wins". Not used for our seat products.
- **`plan_type.ts`**: the old defensive `if (!response.data) return null` was guarding against a field the SDK types as non-nullable; the wrapper omits the check because the type guarantees `data` is set on success. The `try/catch` fail-open path is unchanged.

## Tests

- `npx tsgo --noEmit`: clean.
- `npx biome check`: clean on all 13 modified files.
- Existing `spend_limit.test.ts` mock updated to the `CustomerAlert` shape; assertion (`awuCredits: 2500`) unchanged.
- Functional test run not possible in this environment (no local Postgres), but no logic was changed — only the layer where SDK calls are dispatched.

## Risk

Low. No SDK call site moved between layers and no retry / error-handling semantics changed. The widest blast radius is `applyEnterpriseOverrides` (only run when provisioning enterprise contracts) and the webhook stamping path (an error there already produced a 500 + Metronome retry — and still does).

Rollback: straightforward revert; no migrations, no data changes.

## Deploy Plan

Standard deploy. No coordination required.