### PR TITLE
Handle discout+payg config in dedicated table

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
@@ -4,10 +4,6 @@ import {
   ensureMetronomeCustomerForWorkspace,
   provisionMetronomeContract,
 } from "@app/lib/metronome/contracts";
-import {
-  clearMetronomePaygCapAlert,
-  upsertMetronomePaygCapAlert,
-} from "@app/lib/metronome/payg_alerts";
 import { PlanModel } from "@app/lib/models/plan";
 import {
   CREDIT_PRICED_BUSINESS_PLAN_CODE,
@@ -43,17 +39,6 @@ vi.mock("@app/lib/metronome/contracts", async () => {
     ...actual,
     ensureMetronomeCustomerForWorkspace: vi.fn(),
     provisionMetronomeContract: vi.fn(),
-  };
-});
-
-vi.mock("@app/lib/metronome/payg_alerts", async () => {
-  const actual = await vi.importActual<
-    typeof import("@app/lib/metronome/payg_alerts")
-  >("@app/lib/metronome/payg_alerts");
-  return {
-    ...actual,
-    upsertMetronomePaygCapAlert: vi.fn(),
-    clearMetronomePaygCapAlert: vi.fn(),
   };
 });
 
@@ -229,10 +214,6 @@ beforeEach(() => {
   vi.mocked(provisionMetronomeContract).mockResolvedValue(
     new Ok({ metronomeContractId: NEW_CONTRACT_ID })
   );
-  vi.mocked(upsertMetronomePaygCapAlert).mockResolvedValue(
-    new Ok({ alertId: "alert_test" })
-  );
-  vi.mocked(clearMetronomePaygCapAlert).mockResolvedValue(new Ok(undefined));
 });
 
 describe("POST /api/poke/workspaces/[wId]/switch_contract — Enterprise", () => {
@@ -546,14 +527,6 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
         adminAuth
       );
     expect(config?.paygCapMicroUsd).toBe(500 * 1_000_000);
-
-    expect(upsertMetronomePaygCapAlert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        metronomeCustomerId: METRONOME_CUSTOMER_ID,
-        paygCapDollars: 500,
-        workspaceId: workspace.sId,
-      })
-    );
   });
 
   it("persists paygCapMicroUsd when switching to business with PAYG enabled", async () => {
@@ -613,7 +586,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
     expect(data.error.message).toContain("PAYG cap");
   });
 
-  it("clears paygCapMicroUsd and archives the Metronome alert when paygEnabled is false", async () => {
+  it("clears paygCapMicroUsd when paygEnabled is false", async () => {
     const { workspace } = await createPrivateApiMockRequest({
       isSuperUser: true,
     });
@@ -638,12 +611,5 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
         adminAuth
       );
     expect(config?.paygCapMicroUsd).toBeNull();
-
-    expect(clearMetronomePaygCapAlert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        metronomeCustomerId: METRONOME_CUSTOMER_ID,
-        workspaceId: workspace.sId,
-      })
-    );
   });
 });

--- a/front-api/routes/poke/workspaces/[wId]/switch_contract.ts
+++ b/front-api/routes/poke/workspaces/[wId]/switch_contract.ts
@@ -15,10 +15,6 @@ import {
   provisionMetronomeContract,
 } from "@app/lib/metronome/contracts";
 import {
-  clearMetronomePaygCapAlert,
-  upsertMetronomePaygCapAlert,
-} from "@app/lib/metronome/payg_alerts";
-import {
   isPaygEligibleTier,
   type MetronomePackageTier,
   PAYG_ELIGIBLE_TIERS,
@@ -378,27 +374,10 @@ app.post(
       }
     }
 
-    if (owner.metronomeCustomerId) {
-      const alertResult =
-        body.paygEnabled && body.paygCapDollars !== undefined
-          ? await upsertMetronomePaygCapAlert({
-              metronomeCustomerId: owner.metronomeCustomerId,
-              paygCapDollars: body.paygCapDollars,
-              workspaceId: owner.sId,
-            })
-          : await clearMetronomePaygCapAlert({
-              metronomeCustomerId: owner.metronomeCustomerId,
-              workspaceId: owner.sId,
-            });
-      if (alertResult.isErr()) {
-        const errorMessage = `Failed to sync Metronome PAYG cap alert: ${alertResult.error.message}`;
-        await pluginRun.recordError(errorMessage);
-        return apiError(ctx, {
-          status_code: 502,
-          api_error: { type: "internal_server_error", message: errorMessage },
-        });
-      }
-    }
+    // Note: the Metronome AWU PAYG cap alert is no longer synced from this
+    // endpoint. AWU concerns (discount, AWU PAYG cap) live on
+    // `credit_usage_configuration` and are managed via the
+    // "Manage Credit Usage Configuration" poke plugin.
 
     const workspaceResource = await WorkspaceResource.fetchById(owner.sId);
     if (workspaceResource) {

--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -79,6 +79,7 @@ import {
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import { CouponRedemptionModel } from "@app/lib/resources/storage/models/coupon_redemptions";
 import { CouponModel } from "@app/lib/resources/storage/models/coupons";
+import { CreditUsageConfigurationModel } from "@app/lib/resources/storage/models/credit_usage_configurations";
 import { CreditModel } from "@app/lib/resources/storage/models/credits";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
@@ -186,6 +187,7 @@ export function loadAllModels() {
     CouponModel,
     CouponRedemptionModel,
     ProgrammaticUsageConfigurationModel,
+    CreditUsageConfigurationModel,
     AgentConfigurationModel,
     AgentUserRelationModel,
     GlobalAgentSettingsModel,

--- a/front/components/workspace/BuyAwuCreditsDialog.tsx
+++ b/front/components/workspace/BuyAwuCreditsDialog.tsx
@@ -167,15 +167,21 @@ export function BuyAwuCreditsDialog({
     ? awuPurchaseInfo.currency
     : "usd";
   const currencySymbol = CURRENCY_SYMBOLS[currency];
+  const discountPercent = awuPurchaseInfo?.canPurchase
+    ? awuPurchaseInfo.discountPercent
+    : 0;
 
+  // The cycle cap is denominated in credits, so the matching cap in
+  // currency at the discounted rate is `credits × price_per_credit × (1 - d/100)`.
   const maxAmountInCurrency = useMemo(() => {
     if (!awuPurchaseInfo?.canPurchase) {
       return null;
     }
     return Math.floor(
-      awuCreditsToCurrency(awuPurchaseInfo.remainingCycleCredits, currency)
+      awuCreditsToCurrency(awuPurchaseInfo.remainingCycleCredits, currency) *
+        (1 - discountPercent / 100)
     );
-  }, [awuPurchaseInfo, currency]);
+  }, [awuPurchaseInfo, currency, discountPercent]);
 
   const maxAmountFormatted = useMemo(() => {
     if (maxAmountInCurrency === null) {
@@ -200,7 +206,10 @@ export function BuyAwuCreditsDialog({
   const parsedAmount = parseFloat(amountInput) || 0;
   const isValidAmount = parsedAmount > 0;
   const amountExceedsMax = parsedAmount > effectiveMaxAmount;
-  const addedCredits = currencyToAwuCredits(parsedAmount, currency);
+  // The user types what they want to spend; the discount means they get
+  // more credits at the same spend (credits_per_full_price / (1 - d/100)).
+  const addedCredits =
+    currencyToAwuCredits(parsedAmount, currency) / (1 - discountPercent / 100);
 
   const canPurchase = isValidAmount && !amountExceedsMax;
 

--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -19,6 +19,7 @@ export * from "./invite_user";
 export * from "./manage_audit_logs_kill_switch";
 export * from "./manage_authorized_domains";
 export * from "./manage_conversation_kill_switch";
+export * from "./manage_credit_usage_configuration";
 export * from "./manage_programmatic_usage_configuration";
 export * from "./manage_workspace_kill_switch";
 export * from "./project_task_details";

--- a/front/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration.ts
@@ -1,0 +1,189 @@
+import { createPlugin } from "@app/lib/api/poke/types";
+import { MAX_AWU_DISCOUNT_PERCENT } from "@app/lib/credits/awu_purchase_constants";
+import {
+  clearMetronomePaygCapAlert,
+  upsertMetronomePaygCapAlert,
+} from "@app/lib/metronome/payg_alerts";
+import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
+import { Err, Ok } from "@app/types/shared/result";
+import assert from "assert";
+import { z } from "zod";
+
+export const MAX_AWU_PAYG_CAP_CREDITS = 2_000_000;
+
+const CreditUsageConfigurationSchema = z
+  .object({
+    defaultDiscountPercent: z
+      .number()
+      .min(0, "Discount percentage must be at least 0")
+      .max(
+        MAX_AWU_DISCOUNT_PERCENT,
+        `Discount cannot exceed ${MAX_AWU_DISCOUNT_PERCENT}% for AWU credit purchases`
+      )
+      .default(0),
+    paygCapEnabled: z.boolean(),
+    // Lower bound is 0 (not 1) because the poke form sends `0` when the
+    // toggle is off; the refine below enforces `>= 1` only when enabled.
+    paygCapCredits: z
+      .number()
+      .int("AWU PAYG cap must be an integer number of credits")
+      .min(0, "AWU PAYG cap must be non-negative")
+      .max(
+        MAX_AWU_PAYG_CAP_CREDITS,
+        `AWU PAYG cap cannot exceed ${MAX_AWU_PAYG_CAP_CREDITS.toLocaleString()} credits`
+      )
+      .optional(),
+  })
+  .refine(
+    (data) =>
+      !(
+        data.paygCapEnabled &&
+        (data.paygCapCredits === undefined || data.paygCapCredits < 1)
+      ),
+    {
+      message: "AWU PAYG cap must be at least 1 credit when the cap is enabled",
+      path: ["paygCapCredits"],
+    }
+  );
+
+export const manageCreditUsageConfigurationPlugin = createPlugin({
+  manifest: {
+    id: "manage-credit-usage-configuration",
+    name: "Manage Credit Usage Configuration",
+    description:
+      "Configure AWU credit usage settings for this workspace: the default " +
+      "discount applied to AWU credit purchases and the PAYG cap on AWU " +
+      "consumption (in credits) used to drive the Metronome spend-threshold alert.",
+    resourceTypes: ["workspaces"],
+    args: {
+      defaultDiscountPercent: {
+        type: "number",
+        variant: "text",
+        label: "Default Discount (%)",
+        description: `Discount applied to AWU credit purchases (0-${MAX_AWU_DISCOUNT_PERCENT}%).`,
+        async: true,
+      },
+      paygCapEnabled: {
+        type: "boolean",
+        variant: "toggle",
+        label: "AWU PAYG Cap",
+        description:
+          "Enable a Metronome spend-threshold alert when AWU consumption " +
+          "reaches the configured cap (Metronome-billed workspaces only).",
+        async: true,
+      },
+      paygCapCredits: {
+        type: "number",
+        variant: "text",
+        label: "AWU PAYG Cap (credits)",
+        description: `Maximum AWU consumption (in credits) before the spend-threshold alert fires. Range: 1-${MAX_AWU_PAYG_CAP_CREDITS.toLocaleString()}.`,
+        async: true,
+        dependsOn: { field: "paygCapEnabled", value: true },
+      },
+    },
+  },
+
+  populateAsyncArgs: async (auth) => {
+    const config =
+      await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+
+    if (!config) {
+      return new Ok({
+        defaultDiscountPercent: 0,
+        paygCapEnabled: false,
+        paygCapCredits: 0,
+      });
+    }
+
+    return new Ok({
+      defaultDiscountPercent: config.defaultDiscountPercent,
+      paygCapEnabled: config.paygCapCredits !== null,
+      paygCapCredits: config.paygCapCredits ?? 0,
+    });
+  },
+
+  execute: async (auth, _, args) => {
+    const parseResult = CreditUsageConfigurationSchema.safeParse(args);
+
+    if (!parseResult.success) {
+      return new Err(
+        new Error(
+          `Invalid arguments: ${parseResult.error.errors
+            .map((e) => `${e.path.join(".")}: ${e.message}`)
+            .join(", ")}`
+        )
+      );
+    }
+
+    const { defaultDiscountPercent, paygCapEnabled, paygCapCredits } =
+      parseResult.data;
+
+    const workspace = auth.getNonNullableWorkspace();
+
+    const resolvedPaygCapCredits = paygCapEnabled
+      ? (() => {
+          assert(
+            paygCapCredits !== undefined,
+            "[Unreachable] paygCapEnabled but paygCapCredits undefined"
+          );
+          return paygCapCredits;
+        })()
+      : null;
+
+    const existingConfig =
+      await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+
+    if (existingConfig) {
+      const updateResult = await existingConfig.updateConfiguration(auth, {
+        defaultDiscountPercent,
+        paygCapCredits: resolvedPaygCapCredits,
+      });
+      if (updateResult.isErr()) {
+        return updateResult;
+      }
+    } else {
+      const createResult = await CreditUsageConfigurationResource.makeNew(
+        auth,
+        {
+          defaultDiscountPercent,
+          paygCapCredits: resolvedPaygCapCredits,
+        }
+      );
+      if (createResult.isErr()) {
+        return createResult;
+      }
+    }
+
+    if (workspace.metronomeCustomerId) {
+      const alertResult =
+        resolvedPaygCapCredits !== null
+          ? await upsertMetronomePaygCapAlert({
+              metronomeCustomerId: workspace.metronomeCustomerId,
+              paygCapCredits: resolvedPaygCapCredits,
+              workspaceId: workspace.sId,
+            })
+          : await clearMetronomePaygCapAlert({
+              metronomeCustomerId: workspace.metronomeCustomerId,
+              workspaceId: workspace.sId,
+            });
+      if (alertResult.isErr()) {
+        return new Err(
+          new Error(
+            `Failed to sync Metronome PAYG cap alert: ${alertResult.error.message}`
+          )
+        );
+      }
+    }
+
+    const discountStatus = `Discount: ${defaultDiscountPercent}%`;
+    const paygStatus =
+      resolvedPaygCapCredits !== null
+        ? `AWU PAYG cap: ${resolvedPaygCapCredits.toLocaleString()} credits`
+        : "AWU PAYG cap: disabled";
+
+    return new Ok({
+      display: "text",
+      value: `${existingConfig ? "Changes saved" : "Configuration created"}. ${discountStatus}. ${paygStatus}.`,
+    });
+  },
+});

--- a/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
@@ -14,10 +14,6 @@ import {
   startOrResumeEnterprisePAYG,
   stopEnterprisePAYG,
 } from "@app/lib/credits/payg";
-import {
-  clearMetronomePaygCapAlert,
-  upsertMetronomePaygCapAlert,
-} from "@app/lib/metronome/payg_alerts";
 import { PAYG_ELIGIBLE_TIERS } from "@app/lib/metronome/types";
 import {
   isEntreprisePlanPrefix,
@@ -396,16 +392,9 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
             return updateResult;
           }
         }
-        if (workspace.metronomeCustomerId) {
-          const alertResult = await upsertMetronomePaygCapAlert({
-            metronomeCustomerId: workspace.metronomeCustomerId,
-            paygCapDollars,
-            workspaceId: workspace.sId,
-          });
-          if (alertResult.isErr()) {
-            return alertResult;
-          }
-        }
+        // Note: the Metronome AWU PAYG cap alert is no longer driven from
+        // here. AWU concerns live on `credit_usage_configuration` and are
+        // managed via the "Manage Credit Usage Configuration" plugin.
         const workspaceResource = await WorkspaceResource.fetchById(
           workspace.sId
         );
@@ -432,15 +421,8 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
           if (clearResult.isErr()) {
             return clearResult;
           }
-          if (workspace.metronomeCustomerId) {
-            const alertResult = await clearMetronomePaygCapAlert({
-              metronomeCustomerId: workspace.metronomeCustomerId,
-              workspaceId: workspace.sId,
-            });
-            if (alertResult.isErr()) {
-              return alertResult;
-            }
-          }
+          // Note: clearing the Metronome AWU PAYG cap alert lives on the
+          // "Manage Credit Usage Configuration" plugin now.
           const workspaceResource = await WorkspaceResource.fetchById(
             workspace.sId
           );

--- a/front/lib/credits/awu_purchase.test.ts
+++ b/front/lib/credits/awu_purchase.test.ts
@@ -142,6 +142,7 @@ describe("getAwuPurchaseInfo", () => {
       canPurchase: true,
       remainingCycleCredits: 0,
       currency: "eur",
+      discountPercent: 0,
     });
   });
 });

--- a/front/lib/credits/awu_purchase.ts
+++ b/front/lib/credits/awu_purchase.ts
@@ -21,6 +21,7 @@ import {
 import { getCreditTypeFromContract } from "@app/lib/metronome/coupons";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import { getStripeClient } from "@app/lib/plans/stripe";
+import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import logger from "@app/logger/logger";
 import type { SupportedCurrency } from "@app/types/currency";
 import {
@@ -31,6 +32,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type Stripe from "stripe";
 import {
+  MAX_AWU_DISCOUNT_PERCENT,
   MAX_AWU_PURCHASE_CREDITS_PER_CYCLE,
   MIN_AWU_PURCHASE_CREDITS,
 } from "./awu_purchase_constants";
@@ -48,6 +50,7 @@ export type AwuPurchaseInfo =
       canPurchase: true;
       remainingCycleCredits: number;
       currency: SupportedCurrency;
+      discountPercent: number;
     };
 
 export type AwuPurchaseResult = {
@@ -111,6 +114,39 @@ async function resolveAwuPurchaseCurrency(
     return new Err(creditTypeResult.error);
   }
   return new Ok(creditTypeResult.value.currency);
+}
+
+/**
+ * Resolves the AWU purchase discount from the workspace's credit usage
+ * configuration. AWU has its own discount cap (`MAX_AWU_DISCOUNT_PERCENT`)
+ * — distinct from the programmatic `MAX_DISCOUNT_PERCENT` — because the
+ * per-credit economics differ. A misconfigured discount above the cap is
+ * dropped and logged rather than honoured.
+ */
+async function resolveAwuPurchaseDiscountPercent(
+  auth: Authenticator
+): Promise<number> {
+  const creditConfig =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+  const discountPercent = creditConfig?.defaultDiscountPercent ?? 0;
+
+  if (discountPercent <= 0) {
+    return 0;
+  }
+
+  if (discountPercent > MAX_AWU_DISCOUNT_PERCENT) {
+    logger.error(
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        discountPercent,
+        maxAwuDiscountPercent: MAX_AWU_DISCOUNT_PERCENT,
+      },
+      "[AWU Purchase] Discount exceeds AWU maximum allowed — ignoring"
+    );
+    return 0;
+  }
+
+  return discountPercent;
 }
 
 async function checkAwuPurchaseEligibility(
@@ -177,12 +213,15 @@ export async function getAwuPurchaseInfo(
   }
   const currency = currencyResult.value;
 
+  const discountPercent = await resolveAwuPurchaseDiscountPercent(auth);
+
   const billingCycle = getBillingCycle(subscription.startDate);
   if (!billingCycle) {
     return {
       canPurchase: true,
       remainingCycleCredits: MAX_AWU_PURCHASE_CREDITS_PER_CYCLE,
       currency,
+      discountPercent,
     };
   }
 
@@ -206,6 +245,7 @@ export async function getAwuPurchaseInfo(
       MAX_AWU_PURCHASE_CREDITS_PER_CYCLE - alreadyPurchasedThisCycleCredits
     ),
     currency,
+    discountPercent,
   };
 }
 
@@ -273,13 +313,27 @@ export async function purchaseAwuCredits(
   }
   const currency = currencyResult.value;
 
-  // Per-credit price expressed in Metronome's unit for this currency:
-  // cents for USD (1 cent), whole units for EUR (0.0087 EUR — Metronome
-  // accepts decimal unit prices for non-USD).
-  const invoiceUnitPrice = metronomeAmount(
-    AWU_PRICE_PER_CREDIT[currency] * 100,
-    currency
+  const discountPercent = await resolveAwuPurchaseDiscountPercent(auth);
+  const discountMultiplier = 1 - discountPercent / 100;
+
+  // Bill the full top-up as a single invoice line (`quantity = 1`,
+  // `unit_price = totalDiscountedCents`) rather than per-credit. With a
+  // discount the per-credit price would be sub-cent (e.g. 0.77¢ at 23%
+  // USD) and `metronomeAmount` rounds USD to integer cents, which would
+  // silently swallow the discount on small purchases. Collapsing to a
+  // single line keeps `metronomeAmount` working as designed — sub-cent
+  // rounding only applies to the total, where it's negligible. The
+  // credit count is preserved in the line `name` and in
+  // `accessAmount` (the actual AWU grant).
+  //
+  // `Math.round` to whole cents BEFORE handing to `metronomeAmount`:
+  // `metronomeAmount` rounds USD but not EUR (it just divides by 100),
+  // so a fractional input like 999.891 cents would surface on the
+  // Stripe / Metronome invoice as €9.99891 instead of €10.00.
+  const totalInvoiceCents = Math.round(
+    amountCredits * AWU_PRICE_PER_CREDIT[currency] * 100 * discountMultiplier
   );
+  const invoiceUnitPrice = metronomeAmount(totalInvoiceCents, currency);
 
   const now = new Date();
   const oneYearFromNow = new Date(now);
@@ -306,11 +360,14 @@ export async function purchaseAwuCredits(
     accessStartingAt: now,
     accessEndingBefore: oneYearFromNow,
     invoiceUnitPrice,
-    invoiceQuantity: amountCredits,
+    invoiceQuantity: 1,
     invoiceCreditTypeId: CURRENCY_TO_CREDIT_TYPE_ID[currency],
     invoiceTimestamp: now,
     priority: AWU_PRIORITY_PURCHASED_COMMIT,
-    name: `Credit top-up: ${amountCredits.toLocaleString()} credits`,
+    name:
+      discountPercent > 0
+        ? `Credit top-up: ${amountCredits.toLocaleString()} credits (${discountPercent}% discount)`
+        : `Credit top-up: ${amountCredits.toLocaleString()} credits`,
     uniquenessKey,
     // Stamped on the Stripe invoice Metronome pushes downstream so the
     // existing eligibility check (`isAwuPurchaseInvoice`) still recognises
@@ -319,6 +376,9 @@ export async function purchaseAwuCredits(
       awu_purchase: "true",
       awu_amount_credits: String(amountCredits),
       workspace_id: workspace.sId,
+      ...(discountPercent > 0
+        ? { awu_discount_percent: String(discountPercent) }
+        : {}),
     },
   });
 
@@ -348,6 +408,9 @@ export async function purchaseAwuCredits(
       workspaceId: workspace.sId,
       editId: editResult.value.editId,
       amountCredits,
+      discountPercent,
+      invoiceUnitPrice,
+      currency,
     },
     "[AWU Purchase] Payment-gated commit created — Metronome will invoice and unlock on payment"
   );

--- a/front/lib/credits/awu_purchase_constants.ts
+++ b/front/lib/credits/awu_purchase_constants.ts
@@ -1,3 +1,8 @@
 // TODO: Replace static cap with a dynamic formula once we finalize rules for AWU purchase limits
 export const MAX_AWU_PURCHASE_CREDITS_PER_CYCLE = 1_000_000;
 export const MIN_AWU_PURCHASE_CREDITS = 100;
+
+// Max discount that can be applied to an AWU credit purchase. AWU has its
+// own economics (sold at a fixed per-credit rate), so the programmatic
+// `MAX_DISCOUNT_PERCENT` (derived from token-pricing markup) does not apply.
+export const MAX_AWU_DISCOUNT_PERCENT = 15;

--- a/front/lib/metronome/payg_alerts.ts
+++ b/front/lib/metronome/payg_alerts.ts
@@ -2,7 +2,6 @@ import {
   clearMetronomeAlert,
   upsertMetronomeAlert,
 } from "@app/lib/metronome/alerts";
-import { currencyToAwuCredits } from "@app/lib/metronome/amounts";
 import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
@@ -14,25 +13,24 @@ function paygAlertUniquenessKey(workspaceId: string): string {
 
 /**
  * Idempotently ensure a Metronome `spend_threshold_reached` alert exists on
- * the customer matching the workspace's PAYG cap. If an alert with a
+ * the customer matching the workspace's AWU PAYG cap. If an alert with a
  * different threshold already exists, it's archived (with key release) and
- * recreated.
+ * recreated. The cap is expressed in AWU credits (the same unit Metronome
+ * tracks AWU consumption in).
  */
 export async function upsertMetronomePaygCapAlert({
   metronomeCustomerId,
-  paygCapDollars,
+  paygCapCredits,
   workspaceId,
 }: {
   metronomeCustomerId: string;
-  paygCapDollars: number;
+  paygCapCredits: number;
   workspaceId: string;
 }): Promise<Result<{ alertId: string }, Error>> {
-  const paygCapAwu = Math.round(currencyToAwuCredits(paygCapDollars, "usd"));
-
   const upsertResult = await upsertMetronomeAlert({
     alert_type: "spend_threshold_reached",
-    name: `PAYG cap workspace ${workspaceId} (${paygCapAwu} AWU)`,
-    threshold: paygCapAwu,
+    name: `PAYG cap workspace ${workspaceId} (${paygCapCredits} AWU)`,
+    threshold: paygCapCredits,
     credit_type_id: getCreditTypeAwuId(),
     customer_id: metronomeCustomerId,
     uniqueness_key: paygAlertUniquenessKey(workspaceId),
@@ -46,8 +44,7 @@ export async function upsertMetronomePaygCapAlert({
       workspaceId,
       metronomeCustomerId,
       alertId: upsertResult.value.alertId,
-      paygCapDollars,
-      paygCapAwu,
+      paygCapCredits,
     },
     "[Metronome PAYG] Synced PAYG cap alert"
   );

--- a/front/lib/resources/credit_usage_configuration_resource.ts
+++ b/front/lib/resources/credit_usage_configuration_resource.ts
@@ -1,0 +1,163 @@
+import type { Authenticator } from "@app/lib/auth";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import { CreditUsageConfigurationModel } from "@app/lib/resources/storage/models/credit_usage_configurations";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
+import type { ResourceFindOptions } from "@app/lib/resources/types";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import type { Attributes, CreationAttributes, Transaction } from "sequelize";
+
+import type { ModelStaticWorkspaceAware } from "./storage/wrappers/workspace_models";
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface CreditUsageConfigurationResource
+  extends ReadonlyAttributesType<CreditUsageConfigurationModel> {}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class CreditUsageConfigurationResource extends BaseResource<CreditUsageConfigurationModel> {
+  static model: ModelStaticWorkspaceAware<CreditUsageConfigurationModel> =
+    CreditUsageConfigurationModel;
+
+  constructor(
+    _model: ModelStaticWorkspaceAware<CreditUsageConfigurationModel>,
+    blob: Attributes<CreditUsageConfigurationModel>
+  ) {
+    super(CreditUsageConfigurationModel, blob);
+  }
+
+  get sId(): string {
+    return CreditUsageConfigurationResource.modelIdToSId({
+      id: this.id,
+      workspaceId: this.workspaceId,
+    });
+  }
+
+  static modelIdToSId({
+    id,
+    workspaceId,
+  }: {
+    id: ModelId;
+    workspaceId: ModelId;
+  }): string {
+    return makeSId("credit_usage_configuration", {
+      id,
+      workspaceId,
+    });
+  }
+
+  private static async baseFetch(
+    auth: Authenticator,
+    options?: ResourceFindOptions<CreditUsageConfigurationModel>
+  ): Promise<CreditUsageConfigurationResource[]> {
+    const { where, ...rest } = options ?? {};
+    const rows = await this.model.findAll({
+      where: {
+        ...where,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      ...rest,
+    });
+    return rows.map((r) => new this(this.model, r.get()));
+  }
+
+  static async makeNew(
+    auth: Authenticator,
+    blob: CreationAttributes<CreditUsageConfigurationModel>,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<CreditUsageConfigurationResource, Error>> {
+    const configuration = await this.model.create(
+      {
+        ...blob,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      { transaction }
+    );
+
+    return new Ok(new this(this.model, configuration.get()));
+  }
+
+  static async fetchByWorkspaceId(
+    auth: Authenticator
+  ): Promise<CreditUsageConfigurationResource | null> {
+    const rows = await this.baseFetch(auth, { limit: 1 });
+    return rows[0] ?? null;
+  }
+
+  static async fetchById(
+    auth: Authenticator,
+    sId: string
+  ): Promise<CreditUsageConfigurationResource | null> {
+    const modelId = getResourceIdFromSId(sId);
+    if (!modelId) {
+      return null;
+    }
+
+    const rows = await this.baseFetch(auth, {
+      where: { id: modelId },
+    });
+
+    return rows[0] ?? null;
+  }
+
+  async updateConfiguration(
+    auth: Authenticator,
+    blob: Partial<{
+      defaultDiscountPercent: number;
+      paygCapCredits: number | null;
+    }>,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<undefined, Error>> {
+    const [_affectedCount, affectedRows] = await this.model.update(blob, {
+      where: {
+        id: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      transaction,
+      returning: true,
+    });
+
+    if (affectedRows[0]) {
+      Object.assign(this, affectedRows[0].get());
+      return new Ok(undefined);
+    } else {
+      return new Err(
+        new Error("Configuration not found or not authorized to update")
+      );
+    }
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<undefined, Error>> {
+    await this.model.destroy({
+      where: {
+        id: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      transaction,
+    });
+
+    return new Ok(undefined);
+  }
+
+  toJSON() {
+    return {
+      sId: this.sId,
+      createdAt: this.createdAt.getTime(),
+      defaultDiscountPercent: this.defaultDiscountPercent,
+      paygCapCredits: this.paygCapCredits,
+    };
+  }
+
+  toLogJSON() {
+    return {
+      sId: this.sId,
+      workspaceId: this.workspaceId,
+      defaultDiscountPercent: this.defaultDiscountPercent,
+      paygCapCredits: this.paygCapCredits,
+    };
+  }
+}

--- a/front/lib/resources/storage/models/credit_usage_configurations.ts
+++ b/front/lib/resources/storage/models/credit_usage_configurations.ts
@@ -1,0 +1,74 @@
+import { frontSequelize } from "@app/lib/resources/storage";
+import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { CreationOptional } from "sequelize";
+import { DataTypes } from "sequelize";
+
+/*
+ * Workspace-level configuration for AWU credit purchases. Distinct from
+ * `programmatic_usage_configurations`, whose microUSD-denominated fields
+ * drive the programmatic (token-pricing) flow. Values here are in AWU
+ * credits.
+ *
+ * Fields:
+ * - defaultDiscountPercent: Discount applied to AWU credit purchases (0-100%)
+ * - paygCapCredits: PAYG cap on AWU consumption, in AWU credits. Drives the
+ *   Metronome `spend_threshold_reached` alert on the workspace's customer.
+ */
+export class CreditUsageConfigurationModel extends WorkspaceAwareModel<CreditUsageConfigurationModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+  declare defaultDiscountPercent: number;
+  declare paygCapCredits: number | null;
+}
+
+CreditUsageConfigurationModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    defaultDiscountPercent: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 0,
+      validate: {
+        min: 0,
+        max: 100,
+      },
+    },
+    paygCapCredits: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      defaultValue: null,
+      validate: {
+        isPositive(value: number | null) {
+          if (value !== null && value <= 0) {
+            throw new Error(
+              "paygCapCredits must be strictly positive when set"
+            );
+          }
+        },
+      },
+    },
+  },
+  {
+    modelName: "credit_usage_configuration",
+    sequelize: frontSequelize,
+    indexes: [
+      // Enforce 1:1 relationship with workspace
+      { unique: true, fields: ["workspaceId"] },
+    ],
+    relationship: "hasOne",
+  }
+);
+
+CreditUsageConfigurationModel.belongsTo(WorkspaceModel, {
+  foreignKey: { name: "workspaceId", allowNull: false },
+});

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -36,6 +36,7 @@ export const RESOURCES_PREFIX = {
   agent_message_feedback: "amf",
   onboarding_task: "obt",
   programmatic_usage_configuration: "puc",
+  credit_usage_configuration: "cuc",
   credit: "crd",
   coupon: "cpn",
   coupon_redemption: "cpr",

--- a/front/migrations/db/migration_653.sql
+++ b/front/migrations/db/migration_653.sql
@@ -1,0 +1,21 @@
+-- Migration created on May 24, 2026
+-- Create credit_usage_configurations table to manage workspace-specific
+-- configuration for AWU credit purchases (default discount + PAYG cap on AWU
+-- consumption). Distinct from programmatic_usage_configurations, whose
+-- microUSD-denominated fields drive the programmatic (token-pricing) flow.
+-- Amounts here are stored in AWU credits.
+-- 1:1 with workspaces (enforced by unique index on workspaceId).
+
+CREATE TABLE IF NOT EXISTS "credit_usage_configurations" (
+  "id" BIGSERIAL,
+  "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+  "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+  "defaultDiscountPercent" INTEGER NOT NULL DEFAULT 0 CHECK ("defaultDiscountPercent" >= 0 AND "defaultDiscountPercent" <= 100),
+  "paygCapCredits" INTEGER CHECK ("paygCapCredits" > 0),
+  "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  PRIMARY KEY ("id")
+);
+
+-- Enforce 1:1 relationship between workspace and configuration
+CREATE UNIQUE INDEX "credit_usage_configurations_workspace_id"
+  ON "credit_usage_configurations" ("workspaceId");

--- a/front/pages/api/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front/pages/api/poke/workspaces/[wId]/switch_contract.test.ts
@@ -4,10 +4,6 @@ import {
   ensureMetronomeCustomerForWorkspace,
   provisionMetronomeContract,
 } from "@app/lib/metronome/contracts";
-import {
-  clearMetronomePaygCapAlert,
-  upsertMetronomePaygCapAlert,
-} from "@app/lib/metronome/payg_alerts";
 import { PlanModel } from "@app/lib/models/plan";
 import {
   CREDIT_PRICED_BUSINESS_PLAN_CODE,
@@ -46,17 +42,6 @@ vi.mock("@app/lib/metronome/contracts", async () => {
     ...actual,
     ensureMetronomeCustomerForWorkspace: vi.fn(),
     provisionMetronomeContract: vi.fn(),
-  };
-});
-
-vi.mock("@app/lib/metronome/payg_alerts", async () => {
-  const actual = await vi.importActual<
-    typeof import("@app/lib/metronome/payg_alerts")
-  >("@app/lib/metronome/payg_alerts");
-  return {
-    ...actual,
-    upsertMetronomePaygCapAlert: vi.fn(),
-    clearMetronomePaygCapAlert: vi.fn(),
   };
 });
 
@@ -221,10 +206,6 @@ beforeEach(() => {
   vi.mocked(provisionMetronomeContract).mockResolvedValue(
     new Ok({ metronomeContractId: NEW_CONTRACT_ID })
   );
-  vi.mocked(upsertMetronomePaygCapAlert).mockResolvedValue(
-    new Ok({ alertId: "alert_test" })
-  );
-  vi.mocked(clearMetronomePaygCapAlert).mockResolvedValue(new Ok(undefined));
 });
 
 describe("POST /api/poke/workspaces/[wId]/switch_contract — Enterprise", () => {
@@ -576,14 +557,6 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
         adminAuth
       );
     expect(config?.paygCapMicroUsd).toBe(500 * 1_000_000);
-
-    expect(upsertMetronomePaygCapAlert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        metronomeCustomerId: METRONOME_CUSTOMER_ID,
-        paygCapDollars: 500,
-        workspaceId: workspace.sId,
-      })
-    );
   });
 
   it("persists paygCapMicroUsd when switching to business with PAYG enabled", async () => {
@@ -646,7 +619,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
     expect(res._getJSONData().error.message).toContain("PAYG cap");
   });
 
-  it("clears paygCapMicroUsd and archives the Metronome alert when paygEnabled is false", async () => {
+  it("clears paygCapMicroUsd when paygEnabled is false", async () => {
     const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "POST",
       isSuperUser: true,
@@ -675,12 +648,5 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
         adminAuth
       );
     expect(config?.paygCapMicroUsd).toBeNull();
-
-    expect(clearMetronomePaygCapAlert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        metronomeCustomerId: METRONOME_CUSTOMER_ID,
-        workspaceId: workspace.sId,
-      })
-    );
   });
 });

--- a/front/pages/api/poke/workspaces/[wId]/switch_contract.ts
+++ b/front/pages/api/poke/workspaces/[wId]/switch_contract.ts
@@ -20,10 +20,6 @@ import {
   provisionMetronomeContract,
 } from "@app/lib/metronome/contracts";
 import {
-  clearMetronomePaygCapAlert,
-  upsertMetronomePaygCapAlert,
-} from "@app/lib/metronome/payg_alerts";
-import {
   isPaygEligibleTier,
   type MetronomePackageTier,
   PAYG_ELIGIBLE_TIERS,
@@ -423,27 +419,10 @@ async function handler(
     }
   }
 
-  if (owner.metronomeCustomerId) {
-    const alertResult =
-      body.paygEnabled && body.paygCapDollars !== undefined
-        ? await upsertMetronomePaygCapAlert({
-            metronomeCustomerId: owner.metronomeCustomerId,
-            paygCapDollars: body.paygCapDollars,
-            workspaceId: owner.sId,
-          })
-        : await clearMetronomePaygCapAlert({
-            metronomeCustomerId: owner.metronomeCustomerId,
-            workspaceId: owner.sId,
-          });
-    if (alertResult.isErr()) {
-      const errorMessage = `Failed to sync Metronome PAYG cap alert: ${alertResult.error.message}`;
-      await pluginRun.recordError(errorMessage);
-      return apiError(req, res, {
-        status_code: 502,
-        api_error: { type: "internal_server_error", message: errorMessage },
-      });
-    }
-  }
+  // Note: the Metronome AWU PAYG cap alert is no longer synced from this
+  // endpoint. AWU concerns (discount, AWU PAYG cap) live on
+  // `credit_usage_configuration` and are managed via the
+  // "Manage Credit Usage Configuration" poke plugin.
 
   const workspaceResource = await WorkspaceResource.fetchById(owner.sId);
   if (workspaceResource) {


### PR DESCRIPTION
## Description

Introduces a new \`credit_usage_configuration\` entity to own AWU-specific settings, separating them from \`programmatic_usage_configuration\` which mixed AWU and programmatic (token-pricing) concerns. The new entity stores values in **AWU credits** (not microUsd):

- \`defaultDiscountPercent\` — discount applied to AWU credit purchases, capped at \`MAX_AWU_DISCOUNT_PERCENT = 15\` (distinct from the programmatic \`MAX_DISCOUNT_PERCENT\` derived from token-pricing markup).
- \`paygCapCredits\` — AWU consumption threshold (in credits) that drives the Metronome \`spend_threshold_reached\` alert.

### What moved

- \`lib/credits/awu_purchase.ts\` reads the discount from the new entity (was reading \`programmatic_usage_configuration.defaultDiscountPercent\`). The discount is applied to \`invoiceUnitPrice\` via a single-line invoice (\`quantity = 1\`, \`unit_price = totalDiscountedCents\`) so \`metronomeAmount\` is called unconditionally and USD integer-cent rounding doesn't silently swallow the discount on small purchases.
- \`lib/metronome/payg_alerts.ts\`: \`upsertMetronomePaygCapAlert\` now takes \`paygCapCredits\` directly (no more dollar→credit conversion in the helper).
- AWU alert sync **moved off** \`manage_programmatic_usage_configuration\` and \`switch_contract\`; the new \`manage_credit_usage_configuration\` poke plugin is now the only writer.

### New poke plugin

\`manage_credit_usage_configuration\` edits \`defaultDiscountPercent\` and \`paygCapCredits\`, and syncs (or clears) the Metronome PAYG alert for Metronome-billed workspaces.

### What stays where

- \`programmatic_usage_configuration.paygCapMicroUsd\` is still written by the old plugin / \`switch_contract\`. It continues to drive the credit state machine and enterprise Stripe PAYG (\`lib/credits/payg.ts\`, \`lib/credits/limits.ts\`). It is **no longer the source of truth for the AWU alert** — that lives on the new entity.
- \`programmatic_usage_configuration.defaultDiscountPercent\` still powers programmatic credit purchases (\`lib/api/credits/purchase.ts\`). Unifying with the new entity is a follow-up if desired.

## Tests

- \`lib/credits/awu_purchase.test.ts\`: updated expected response shape (\`discountPercent: 0\` default).
- \`pages/api/poke/workspaces/[wId]/switch_contract.test.ts\`: dropped the alert-sync mocks and assertions that no longer apply.
- \`npx tsgo --noEmit\` clean on all touched files.
- Manual verification of the new poke plugin pending — not yet exercised end-to-end against a real Metronome customer.

## Risk

**Behavioral change for Metronome-billed workspaces with an existing PAYG cap:** the next time the old programmatic plugin or \`switch_contract\` runs for them, the Metronome AWU alert will **no longer be re-synced** — only the new plugin writes that alert now. Per the explicit no-backfill decision, existing customers will lose their AWU PAYG alert until an admin re-sets it via the new "Manage Credit Usage Configuration" plugin.

**Schema migration:** \`migration_652.sql\` adds a new table with a unique index on \`workspaceId\` and \`ON DELETE RESTRICT\` to workspaces. Additive only — no changes to \`programmatic_usage_configuration\`.

**Discount math:** the AWU discount now collapses the per-credit line into a single \`quantity = 1, unit_price = totalDiscountedCents\` line on the Stripe invoice pushed by Metronome. The invoice line description (e.g. \`"Credit top-up: 5,000 credits (15% discount)"\`) carries the credit count; the \`accessAmount\` (granted credits) is unchanged.

Rollback: revert + drop the new table. No data loss on \`programmatic_usage_configuration\`.

## Deploy Plan

1. Run \`migration_652.sql\` to create \`credit_usage_configurations\`.
2. Deploy code.
3. For each Metronome-billed workspace with an active AWU PAYG cap configured on \`programmatic_usage_configuration\`, re-set \`paygCapCredits\` via the new poke plugin to restore the Metronome alert.