### PR TITLE
[front] fix: handle GCS write retries in webhook processing

### DIFF
--- a/front/lib/file_storage/types.ts
+++ b/front/lib/file_storage/types.ts
@@ -14,3 +14,9 @@ function isGCSApiError(error: unknown): error is GCSAPIError {
 export function isGCSNotFoundError(error: unknown): error is GCSAPIError {
   return isGCSApiError(error) && error.code === 404;
 }
+
+export function isGCSPreconditionFailedError(
+  error: unknown
+): error is GCSAPIError {
+  return isGCSApiError(error) && error.code === 412;
+}

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -3,6 +3,7 @@ import { FathomClient } from "@app/lib/api/triggers/built-in-webhooks/fathom/fat
 import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
 import { getWebhookRequestsBucket } from "@app/lib/file_storage";
+import { isGCSPreconditionFailedError } from "@app/lib/file_storage/types";
 import { matchPayload, parseMatcherExpression } from "@app/lib/matcher";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
@@ -538,6 +539,24 @@ export async function storePayloadInGCS(
       },
     });
   } catch (error: unknown) {
+    if (isGCSPreconditionFailedError(error)) {
+      logger.info(
+        {
+          webhookRequestId: webhookRequest.id,
+          error,
+          gcsPath,
+        },
+        "Webhook request payload was already stored in GCS"
+      );
+
+      getStatsDClient().increment("webhook_gcs_precondition.count", 1, [
+        `provider:${provider}`,
+        `workspace_id:${auth.getNonNullableWorkspace().sId}`,
+      ]);
+
+      return;
+    }
+
     // Log the error, but do not throw, as we want to continue processing the webhook.
     // The webhook request will be marked as failed later in the processing if needed.
     logger.error(


### PR DESCRIPTION
## Description

- We are seeing errors in webhook processing due to GCS precondition checks failing ([logs](https://app.datadoghq.eu/logs?query=region%3Aus-central1%20%22Failed%20to%20store%20webhook%20request%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1779631752000&to_ts=1779632952000&live=false)).
- GCS payload uploads for webhook requests use `ifGenerationMatch: 0` so the error may occur on SDK retries, which are thus safe when the first write succeeds but the response is lost.
- This PR treats the resulting 412 as an expected precondition hit (i.e. no-op).
- Processing continues normally since the payload is already stored and the in-memory request body is still available.
- Complements https://github.com/dust-tt/dust/pull/26048, which prevents duplicate. This PR fixes how 412 are reported.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
