### PR TITLE
Switch 4 handlers to use the correct validate() pattern for body validation

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/index.ts
@@ -14,6 +14,7 @@ import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import keyBy from "lodash/keyBy";
 import omit from "lodash/omit";
 
@@ -176,6 +177,7 @@ app.get("/", async (ctx): HandlerResult<GetAgentConfigurationsResponseBody> => {
 
 app.post(
   "/",
+  validate("json", PostOrPatchAgentConfigurationRequestBodySchema),
   async (ctx): HandlerResult<PostAgentConfigurationResponseBody> => {
     const auth = ctx.get("auth");
 
@@ -192,22 +194,11 @@ app.post(
       });
     }
 
-    const body = await ctx.req.json();
-    const bodyValidation =
-      PostOrPatchAgentConfigurationRequestBodySchema.safeParse(body);
-    if (!bodyValidation.success) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: `Invalid request body: ${bodyValidation.error.message}`,
-        },
-      });
-    }
+    const { assistant } = ctx.req.valid("json");
 
     const agentConfigurationRes = await createOrUpgradeAgentConfiguration({
       auth,
-      assistant: bodyValidation.data.assistant,
+      assistant,
     });
 
     if (agentConfigurationRes.isErr()) {

--- a/front-api/routes/w/[wId]/keys/index.ts
+++ b/front-api/routes/w/[wId]/keys/index.ts
@@ -10,6 +10,7 @@ import logger from "@app/logger/logger";
 import type { KeyType } from "@app/types/key";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
 import keyId from "./[id]";
@@ -57,169 +58,165 @@ app.get("/", async (ctx): HandlerResult<GetKeysResponseBody> => {
   });
 });
 
-app.post("/", async (ctx): HandlerResult<PostKeysResponseBody> => {
-  const auth = ctx.get("auth");
-  const user = auth.getNonNullableUser();
-  const owner = auth.getNonNullableWorkspace();
+app.post(
+  "/",
+  validate("json", CreateKeyPostBodySchema),
+  async (ctx): HandlerResult<PostKeysResponseBody> => {
+    const auth = ctx.get("auth");
+    const user = auth.getNonNullableUser();
+    const owner = auth.getNonNullableWorkspace();
 
-  if (!auth.isAdmin()) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message:
-          "Only the users that are `admins` for the current workspace can interact with keys",
-      },
+    if (!auth.isAdmin()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "app_auth_error",
+          message:
+            "Only the users that are `admins` for the current workspace can interact with keys",
+        },
+      });
+    }
+
+    const { name, group_id, group_ids, monthly_cap_micro_usd, role } =
+      ctx.req.valid("json");
+    const trimmedName = name.trim();
+    const keyRole = role ?? "builder";
+
+    if (trimmedName.length === 0) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "API key name cannot be empty.",
+        },
+      });
+    }
+
+    if (
+      monthly_cap_micro_usd !== null &&
+      monthly_cap_micro_usd !== undefined &&
+      monthly_cap_micro_usd < 0
+    ) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "monthly_cap_micro_usd must be greater than or equal to 0",
+        },
+      });
+    }
+
+    const existingKey = await KeyResource.fetchByName(auth, {
+      name: trimmedName,
+      onlyActive: true,
     });
-  }
+    if (existingKey) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "An API key with this name already exists in this workspace.",
+        },
+      });
+    }
 
-  const rawBody = await ctx.req.json().catch(() => undefined);
-  const bodyValidation = CreateKeyPostBodySchema.safeParse(rawBody);
-  if (!bodyValidation.success) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid request body",
-      },
-    });
-  }
-
-  const { name, group_id, group_ids, monthly_cap_micro_usd, role } =
-    bodyValidation.data;
-  const trimmedName = name.trim();
-  const keyRole = role ?? "builder";
-
-  if (trimmedName.length === 0) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "API key name cannot be empty.",
-      },
-    });
-  }
-
-  if (
-    monthly_cap_micro_usd !== null &&
-    monthly_cap_micro_usd !== undefined &&
-    monthly_cap_micro_usd < 0
-  ) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "monthly_cap_micro_usd must be greater than or equal to 0",
-      },
-    });
-  }
-
-  const existingKey = await KeyResource.fetchByName(auth, {
-    name: trimmedName,
-    onlyActive: true,
-  });
-  if (existingKey) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "An API key with this name already exists in this workspace.",
-      },
-    });
-  }
-
-  // Resolve groups: prefer group_ids (new), fall back to group_id (retro-compatibility).
-  const globalGroupRes = await GroupResource.fetchWorkspaceGlobalGroup(auth);
-  if (globalGroupRes.isErr()) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "group_not_found",
-        message: "Global group not found",
-      },
-    });
-  }
-  const globalGroup = globalGroupRes.value;
-
-  const resolvedGroups: GroupResource[] = [globalGroup];
-
-  const additionalGroupIds = group_ids
-    ? group_ids.filter((gId) => gId !== globalGroup.sId)
-    : group_id && group_id !== globalGroup.sId
-      ? [group_id]
-      : [];
-
-  if (additionalGroupIds.length > 0) {
-    const groupsRes = await GroupResource.fetchByIds(auth, additionalGroupIds);
-    if (groupsRes.isErr()) {
+    // Resolve groups: prefer group_ids (new), fall back to group_id (retro-compatibility).
+    const globalGroupRes = await GroupResource.fetchWorkspaceGlobalGroup(auth);
+    if (globalGroupRes.isErr()) {
       return apiError(ctx, {
         status_code: 404,
         api_error: {
           type: "group_not_found",
-          message: "Invalid group",
+          message: "Global group not found",
         },
       });
     }
-    resolvedGroups.push(...groupsRes.value);
-  }
+    const globalGroup = globalGroupRes.value;
 
-  const rateLimitKey = `api_key_creation_${owner.sId}`;
-  const remaining = await rateLimiter({
-    key: rateLimitKey,
-    maxPerTimeframe: MAX_API_KEY_CREATION_PER_DAY,
-    timeframeSeconds: 24 * 60 * 60, // 1 day
-    logger,
-  });
+    const resolvedGroups: GroupResource[] = [globalGroup];
 
-  if (remaining === 0) {
-    return apiError(ctx, {
-      status_code: 429,
-      api_error: {
-        type: "rate_limit_error",
-        message:
-          `You have reached the limit of ${MAX_API_KEY_CREATION_PER_DAY} API keys ` +
-          "creations per day. Please try again later.",
+    const additionalGroupIds = group_ids
+      ? group_ids.filter((gId) => gId !== globalGroup.sId)
+      : group_id && group_id !== globalGroup.sId
+        ? [group_id]
+        : [];
+
+    if (additionalGroupIds.length > 0) {
+      const groupsRes = await GroupResource.fetchByIds(
+        auth,
+        additionalGroupIds
+      );
+      if (groupsRes.isErr()) {
+        return apiError(ctx, {
+          status_code: 404,
+          api_error: {
+            type: "group_not_found",
+            message: "Invalid group",
+          },
+        });
+      }
+      resolvedGroups.push(...groupsRes.value);
+    }
+
+    const rateLimitKey = `api_key_creation_${owner.sId}`;
+    const remaining = await rateLimiter({
+      key: rateLimitKey,
+      maxPerTimeframe: MAX_API_KEY_CREATION_PER_DAY,
+      timeframeSeconds: 24 * 60 * 60, // 1 day
+      logger,
+    });
+
+    if (remaining === 0) {
+      return apiError(ctx, {
+        status_code: 429,
+        api_error: {
+          type: "rate_limit_error",
+          message:
+            `You have reached the limit of ${MAX_API_KEY_CREATION_PER_DAY} API keys ` +
+            "creations per day. Please try again later.",
+        },
+      });
+    }
+
+    const key = await KeyResource.makeNew(
+      {
+        name: trimmedName,
+        status: "active",
+        userId: user.id,
+        workspaceId: owner.id,
+        isSystem: false,
+        role: keyRole,
+        monthlyCapMicroUsd: monthly_cap_micro_usd ?? null,
+      },
+      resolvedGroups
+    );
+
+    void emitAuditLogEvent({
+      auth,
+      action: "api_key.created",
+      targets: [
+        buildAuditLogTarget("workspace", owner),
+        buildAuditLogTarget("api_key", {
+          sId: String(key.id),
+          name: trimmedName,
+        }),
+      ],
+      context: getAuditLogContext(auth),
+      metadata: {
+        group_ids: resolvedGroups.map((g) => g.sId).join(","),
+        role: keyRole,
       },
     });
+
+    return ctx.json(
+      {
+        key: key.toJSON(),
+      },
+      201
+    );
   }
-
-  const key = await KeyResource.makeNew(
-    {
-      name: trimmedName,
-      status: "active",
-      userId: user.id,
-      workspaceId: owner.id,
-      isSystem: false,
-      role: keyRole,
-      monthlyCapMicroUsd: monthly_cap_micro_usd ?? null,
-    },
-    resolvedGroups
-  );
-
-  void emitAuditLogEvent({
-    auth,
-    action: "api_key.created",
-    targets: [
-      buildAuditLogTarget("workspace", owner),
-      buildAuditLogTarget("api_key", {
-        sId: String(key.id),
-        name: trimmedName,
-      }),
-    ],
-    context: getAuditLogContext(auth),
-    metadata: {
-      group_ids: resolvedGroups.map((g) => g.sId).join(","),
-      role: keyRole,
-    },
-  });
-
-  return ctx.json(
-    {
-      key: key.toJSON(),
-    },
-    201
-  );
-});
+);
 
 app.route("/:id", keyId);
 

--- a/front-api/routes/w/[wId]/members/[uId]/seat-type.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/seat-type.ts
@@ -7,8 +7,8 @@ import {
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-import { fromError } from "zod-validation-error";
 
 const UpdateMemberSeatTypeBodySchema = z.object({
   seatType: z.enum(MEMBERSHIP_SEAT_TYPES),
@@ -22,107 +22,98 @@ type PatchMemberSeatTypeResponseBody = {
 // Mounted at /api/w/:wId/members/:uId/seat-type.
 const app = workspaceApp();
 
-app.patch("/", async (ctx) => {
-  const auth = ctx.get("auth");
-  const isAdmin = auth.isAdmin();
+app.patch(
+  "/",
+  validate("json", UpdateMemberSeatTypeBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const isAdmin = auth.isAdmin();
 
-  if (!isAdmin) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users that are `admins` for the current workspace can modify memberships.",
-      },
-    });
-  }
-
-  const isMetronomeBilled =
-    auth.getNonNullableSubscriptionResource().isMetronomeOnlyBilled;
-
-  if (!isMetronomeBilled) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "plan_limit_error",
-        message:
-          "Seat type management is only available for workspaces on Metronome billing.",
-      },
-    });
-  }
-
-  const bodyValidation = UpdateMemberSeatTypeBodySchema.safeParse(
-    await ctx.req.json()
-  );
-  if (!bodyValidation.success) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: `Invalid request body: ${fromError(bodyValidation.error).toString()}`,
-      },
-    });
-  }
-
-  const uId = ctx.req.param("uId") ?? "";
-  const user = await getUserForWorkspace(auth, { userId: uId });
-
-  if (!user) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_user_not_found",
-        message: "Could not find the user or their active membership.",
-      },
-    });
-  }
-
-  const { seatType } = bodyValidation.data;
-
-  const result = await updateMembershipSeatAndTrack({
-    user,
-    workspace: auth.getNonNullableWorkspace(),
-    newSeatType: seatType,
-    author: auth.getNonNullableUser().toJSON(),
-  });
-
-  if (result.isErr()) {
-    switch (result.error.type) {
-      case "not_found":
-        return apiError(ctx, {
-          status_code: 404,
-          api_error: {
-            type: "workspace_user_not_found",
-            message: "Could not find the user or their active membership.",
-          },
-        });
-      case "free_seat_not_allowed":
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message:
-              "The free seat is reserved for first-time members and cannot be assigned again.",
-          },
-        });
-      case "metronome_error":
-        return apiError(ctx, {
-          status_code: 502,
-          api_error: {
-            type: "internal_server_error",
-            message: "Failed to update seat in billing system.",
-          },
-        });
-      default:
-        assertNever(result.error.type);
+    if (!isAdmin) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message:
+            "Only users that are `admins` for the current workspace can modify memberships.",
+        },
+      });
     }
-  }
 
-  return ctx.json<PatchMemberSeatTypeResponseBody>({
-    seatType: result.value.newSeatType,
-    scheduledSeatChangeAt:
-      result.value.scheduledSeatChangeAt?.toISOString() ?? null,
-  });
-});
+    const isMetronomeBilled =
+      auth.getNonNullableSubscriptionResource().isMetronomeOnlyBilled;
+
+    if (!isMetronomeBilled) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "plan_limit_error",
+          message:
+            "Seat type management is only available for workspaces on Metronome billing.",
+        },
+      });
+    }
+
+    const uId = ctx.req.param("uId") ?? "";
+    const user = await getUserForWorkspace(auth, { userId: uId });
+
+    if (!user) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "workspace_user_not_found",
+          message: "Could not find the user or their active membership.",
+        },
+      });
+    }
+
+    const { seatType } = ctx.req.valid("json");
+
+    const result = await updateMembershipSeatAndTrack({
+      user,
+      workspace: auth.getNonNullableWorkspace(),
+      newSeatType: seatType,
+      author: auth.getNonNullableUser().toJSON(),
+    });
+
+    if (result.isErr()) {
+      switch (result.error.type) {
+        case "not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: {
+              type: "workspace_user_not_found",
+              message: "Could not find the user or their active membership.",
+            },
+          });
+        case "free_seat_not_allowed":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "The free seat is reserved for first-time members and cannot be assigned again.",
+            },
+          });
+        case "metronome_error":
+          return apiError(ctx, {
+            status_code: 502,
+            api_error: {
+              type: "internal_server_error",
+              message: "Failed to update seat in billing system.",
+            },
+          });
+        default:
+          assertNever(result.error.type);
+      }
+    }
+
+    return ctx.json<PatchMemberSeatTypeResponseBody>({
+      seatType: result.value.newSeatType,
+      scheduledSeatChangeAt:
+        result.value.scheduledSeatChangeAt?.toISOString() ?? null,
+    });
+  }
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/webhook_sources/views/[viewId]/index.test.ts
+++ b/front-api/routes/w/[wId]/webhook_sources/views/[viewId]/index.test.ts
@@ -135,7 +135,9 @@ describe("PATCH /api/w/[wId]/webhook_sources/views/[viewId]", () => {
     expect(response.status).toBe(400);
     const responseData = await response.json();
     expect(responseData.error.type).toBe("invalid_request_error");
-    expect(responseData.error.message).toBe("Invalid request body");
+    expect(responseData.error.message).toBe(
+      'Invalid request body: Validation error: Required at "name"'
+    );
   });
 
   it("should return 400 when name is empty string", async () => {
@@ -154,7 +156,9 @@ describe("PATCH /api/w/[wId]/webhook_sources/views/[viewId]", () => {
     expect(response.status).toBe(400);
     const responseData = await response.json();
     expect(responseData.error.type).toBe("invalid_request_error");
-    expect(responseData.error.message).toBe("Invalid request body");
+    expect(responseData.error.message).toBe(
+      'Invalid request body: Validation error: String must contain at least 1 character(s) at "name"'
+    );
   });
 
   it("should return 404 when trying to update non-existent webhook source view", async () => {

--- a/front-api/routes/w/[wId]/webhook_sources/views/[viewId]/index.ts
+++ b/front-api/routes/w/[wId]/webhook_sources/views/[viewId]/index.ts
@@ -9,6 +9,7 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
 const PatchWebhookSourceViewBodySchema = z.object({
@@ -65,6 +66,7 @@ app.get("/", async (ctx): HandlerResult<GetWebhookSourceViewResponseBody> => {
 
 app.patch(
   "/",
+  validate("json", PatchWebhookSourceViewBodySchema),
   async (ctx): HandlerResult<PatchWebhookSourceViewResponseBody> => {
     const auth = ctx.get("auth");
     const viewId = ctx.req.param("viewId") ?? "";
@@ -96,18 +98,6 @@ app.patch(
       });
     }
 
-    const rawBody = await ctx.req.json().catch(() => undefined);
-    const bodyValidation = PatchWebhookSourceViewBodySchema.safeParse(rawBody);
-    if (!bodyValidation.success) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid request body",
-        },
-      });
-    }
-
     // Validate that this is a system view
     if (webhookSourceView.space.kind !== "system") {
       return apiError(ctx, {
@@ -119,7 +109,7 @@ app.patch(
       });
     }
 
-    const { name, description, icon } = bodyValidation.data;
+    const { name, description, icon } = ctx.req.valid("json");
 
     const nameResult = await webhookSourceView.updateName(auth, name);
     if (nameResult.isErr()) {

--- a/front-api/routes/w/[wId]/webhook_sources/views/[viewId]/index.ts
+++ b/front-api/routes/w/[wId]/webhook_sources/views/[viewId]/index.ts
@@ -13,7 +13,7 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
 const PatchWebhookSourceViewBodySchema = z.object({
-  name: z.string().min(1, "Name is required."),
+  name: z.string().min(1),
   description: z
     .string()
     .max(4000, "Description must be at most 4000 characters.")


### PR DESCRIPTION
## Description

  1. routes/w/[wId]/assistant/agent_configurations/index.ts — POST handler now uses validate("json", PostOrPatchAgentConfigurationRequestBodySchema).
  2. routes/w/[wId]/webhook_sources/views/[viewId]/index.ts — PATCH handler now uses validate("json", PatchWebhookSourceViewBodySchema).
  3. routes/w/[wId]/keys/index.ts — POST handler now uses validate("json", CreateKeyPostBodySchema). Side-effect bug fix: previously returned 404 on invalid body; now correctly returns 400.
  4. routes/w/[wId]/members/[uId]/seat-type.ts — PATCH handler now uses validate("json", UpdateMemberSeatTypeBodySchema). Removed now-unused fromError import.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
