### PR TITLE
[connectors] fix: revert changes on Microsoft label reconciliation folder traversal

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -969,7 +969,7 @@ export async function reconcileSensitivityLabelsForParent({
 
   const childNodes = childrenResult.results
     .filter((item) => item.folder)
-    .map((item) => getDriveItemInternalId(item));
+    .map((item) => getDriveInternalIdFromItem(item));
 
   return {
     childNodes,


### PR DESCRIPTION
## Description

- Reverts dust-tt/dust#25848, which updates Microsoft `reconcileSensitivityLabels` so folder children are re-enqueued using their folder item ids instead of re-enqueuing the same drive ID.
- This change seems to have cause start-to-close timeouts since we are processing more data

## Tests

## Risk

- Low. Safe to rollback.

## Deploy Plan

- Deploy connectors
