### PR TITLE
[front] enh: batch queries in group space editor/member fetching

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/apply_group_roles.ts
+++ b/front/lib/api/poke/plugins/workspaces/apply_group_roles.ts
@@ -7,6 +7,7 @@ import {
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { Err, Ok } from "@app/types/shared/result";
+import { removeNulls } from "@app/types/shared/utils/general";
 
 export const applyGroupRoles = createPlugin({
   manifest: {

--- a/front/lib/api/poke/plugins/workspaces/apply_group_roles.ts
+++ b/front/lib/api/poke/plugins/workspaces/apply_group_roles.ts
@@ -1,7 +1,7 @@
 import { createPlugin } from "@app/lib/api/poke/types";
-import { determineUserRoleFromGroups } from "@app/lib/api/user";
 import {
   ADMIN_GROUP_NAME,
+  BUILDER_GROUP_NAME,
   GroupResource,
 } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
@@ -44,30 +44,50 @@ export const applyGroupRoles = createPlugin({
       });
     }
 
-    if (provisioningGroups.length === 0) {
-      return new Ok({
-        display: "text",
-        value:
-          "dust-admins or dust-builders group both not found in workspace.",
-      });
-    }
+    const [builderGroup] = provisioningGroups.filter(
+      (g) => g.name === BUILDER_GROUP_NAME
+    );
 
     const { memberships } = await MembershipResource.getActiveMemberships({
       workspace,
     });
 
+    const users = await UserResource.fetchByModelIds(
+      [...new Set(memberships.map((m) => m.userId))]
+    );
+    const userByModelId = new Map(users.map((user) => [user.id, user]));
+
+    const membershipsByProvisioningGroup =
+      await GroupResource.getActiveMembershipsForGroups(
+        auth,
+        removeNulls([adminGroup, builderGroup])
+      );
+
+    const adminUserIds = new Set(
+      membershipsByProvisioningGroup[adminGroup.id] ?? []
+    );
+    const builderUserIds = new Set(
+      builderGroup
+        ? (membershipsByProvisioningGroup[builderGroup.id] ?? [])
+        : []
+    );
+
     let updatedCount = 0;
     const errors: string[] = [];
 
     for (const membership of memberships) {
-      const user = await UserResource.fetchByModelId(membership.userId);
+      const user = userByModelId.get(membership.userId);
       if (!user) {
         errors.push(`User not found: ${membership.userId}`);
         continue;
       }
 
       const currentRole = membership.role;
-      const expectedRole = await determineUserRoleFromGroups(workspace, user);
+      const expectedRole = adminUserIds.has(user.id)
+        ? "admin"
+        : builderUserIds.has(user.id)
+          ? "builder"
+          : "user";
 
       if (currentRole !== expectedRole) {
         const updateResult = await MembershipResource.updateMembershipRole({

--- a/front/lib/api/poke/plugins/workspaces/apply_group_roles.ts
+++ b/front/lib/api/poke/plugins/workspaces/apply_group_roles.ts
@@ -53,9 +53,9 @@ export const applyGroupRoles = createPlugin({
       workspace,
     });
 
-    const users = await UserResource.fetchByModelIds(
-      [...new Set(memberships.map((m) => m.userId))]
-    );
+    const users = await UserResource.fetchByModelIds([
+      ...new Set(memberships.map((m) => m.userId)),
+    ]);
     const userByModelId = new Map(users.map((user) => [user.id, user]));
 
     const membershipsByProvisioningGroup =

--- a/front/lib/resources/group_space_editor_resource.ts
+++ b/front/lib/resources/group_space_editor_resource.ts
@@ -5,7 +5,6 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type {
   CombinedResourcePermissions,
   GroupPermission,
@@ -82,51 +81,56 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
       },
     });
 
-    const groupSpacesResources = await concurrentExecutor(
-      groupSpaces,
-      async (groupSpace) => {
-        const groupModels = await GroupModel.findAll({
-          where: {
-            id: groupSpace.groupId,
-            workspaceId: space.workspaceId,
-          },
-          transaction,
-        });
-        assert(
-          groupModels.length === 1,
-          "One and only one group must exist for editor group space"
-        );
-        const groupModel = groupModels[0];
-        assert(
-          groupModel.kind === "space_editors" ||
-            groupModel.kind === "provisioned",
-          "Only space_editors or provisioned groups can be editor groups"
-        );
+    if (groupSpaces.length === 0) {
+      return [];
+    }
 
-        if (filterOnManagementMode) {
-          // Keep only space_editors groups in manual mode, provisioned groups in provisioned mode
-          const filterOnKind =
-            space.managementMode === "manual" ? "space_editors" : "provisioned";
-          if (groupModel.kind !== filterOnKind) {
-            return null;
-          }
-        }
-
-        const group = new GroupResource(GroupModel, groupModel.get());
-        assert(
-          group.isSpaceEditor() || group.isProvisioned(),
-          "Only space editors or provisioned groups can be an editor group"
-        );
-
-        return new GroupSpaceEditorResource(
-          GroupSpaceModel,
-          groupSpace.get(),
-          space,
-          group
-        );
+    const groupModels = await GroupModel.findAll({
+      where: {
+        id: groupSpaces.map((groupSpace) => groupSpace.groupId),
+        workspaceId: space.workspaceId,
       },
-      { concurrency: 1 }
+      transaction,
+    });
+    const groupModelsByModelId = new Map(
+      groupModels.map((groupModel) => [groupModel.id, groupModel])
     );
+    assert(groupModelsByModelId.size === groupSpaces.length, "All editor group spaces must have exactly one associated group");
+
+    const groupSpacesResources = groupSpaces.map((groupSpace) => {
+      const groupModel = groupModelsByModelId.get(groupSpace.groupId);
+      assert(
+        groupModel,
+        "One and only one group must exist for editor group space"
+      );
+      assert(
+        groupModel.kind === "space_editors" ||
+          groupModel.kind === "provisioned",
+        "Only space_editors or provisioned groups can be editor groups"
+      );
+
+      if (filterOnManagementMode) {
+        // Keep only space_editors groups in manual mode, provisioned groups in provisioned mode
+        const filterOnKind =
+          space.managementMode === "manual" ? "space_editors" : "provisioned";
+        if (groupModel.kind !== filterOnKind) {
+          return null;
+        }
+      }
+
+      const group = new GroupResource(GroupModel, groupModel.get());
+      assert(
+        group.isSpaceEditor() || group.isProvisioned(),
+        "Only space editors or provisioned groups can be an editor group"
+      );
+
+      return new this(
+        GroupSpaceModel,
+        groupSpace.get(),
+        space,
+        group
+      );
+    });
     return removeNulls(groupSpacesResources);
   }
 

--- a/front/lib/resources/group_space_editor_resource.ts
+++ b/front/lib/resources/group_space_editor_resource.ts
@@ -95,7 +95,10 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
     const groupModelsByModelId = new Map(
       groupModels.map((groupModel) => [groupModel.id, groupModel])
     );
-    assert(groupModelsByModelId.size === groupSpaces.length, "All editor group spaces must have exactly one associated group");
+    assert(
+      groupModelsByModelId.size === groupSpaces.length,
+      "All editor group spaces must have exactly one associated group"
+    );
 
     const groupSpacesResources = groupSpaces.map((groupSpace) => {
       const groupModel = groupModelsByModelId.get(groupSpace.groupId);
@@ -124,12 +127,7 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
         "Only space editors or provisioned groups can be an editor group"
       );
 
-      return new this(
-        GroupSpaceModel,
-        groupSpace.get(),
-        space,
-        group
-      );
+      return new this(GroupSpaceModel, groupSpace.get(), space, group);
     });
     return removeNulls(groupSpacesResources);
   }

--- a/front/lib/resources/group_space_editor_resource.ts
+++ b/front/lib/resources/group_space_editor_resource.ts
@@ -95,10 +95,6 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
     const groupModelsByModelId = new Map(
       groupModels.map((groupModel) => [groupModel.id, groupModel])
     );
-    assert(
-      groupModelsByModelId.size === groupSpaces.length,
-      "All editor group spaces must have exactly one associated group"
-    );
 
     const groupSpacesResources = groupSpaces.map((groupSpace) => {
       const groupModel = groupModelsByModelId.get(groupSpace.groupId);

--- a/front/lib/resources/group_space_member_resource.ts
+++ b/front/lib/resources/group_space_member_resource.ts
@@ -6,7 +6,6 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type {
   CombinedResourcePermissions,
   GroupPermission,
@@ -79,44 +78,49 @@ export class GroupSpaceMemberResource extends GroupSpaceBaseResource {
       transaction,
     });
 
-    const groupSpacesResources = await concurrentExecutor(
-      groupSpaces,
-      async (groupSpace) => {
-        const groupModels = await GroupModel.findAll({
-          where: {
-            id: groupSpace.groupId,
-            workspaceId: space.workspaceId,
-          },
-          transaction,
-        });
-        assert(
-          groupModels.length === 1,
-          "One and only one group must exist for member group space"
-        );
-        const groupModel = groupModels[0];
-        assert(
-          groupModel.kind !== "space_editors",
-          "Editors groups cannot be member groups"
-        );
-        if (filterOnManagementMode) {
-          // Keep only regular groups in manual mode, provisioned groups in provisioned mode
-          const filterOnKind =
-            space.managementMode === "manual" ? "regular" : "provisioned";
-          if (groupModel.kind !== filterOnKind) {
-            return null;
-          }
-        }
-        const group = new GroupResource(GroupModel, groupModel.get());
+    if (groupSpaces.length === 0) {
+      return [];
+    }
 
-        return new GroupSpaceMemberResource(
-          GroupSpaceModel,
-          groupSpace.get(),
-          space,
-          group
-        );
+    const groupModels = await GroupModel.findAll({
+      where: {
+        id: groupSpaces.map((groupSpace) => groupSpace.groupId),
+        workspaceId: space.workspaceId,
       },
-      { concurrency: 1 }
+      transaction,
+    });
+    const groupModelsByModelId = new Map(
+      groupModels.map((groupModel) => [groupModel.id, groupModel])
     );
+    assert(groupModelsByModelId.size === groupSpaces.length, "All member group spaces must have exactly one associated group");
+
+    const groupSpacesResources = groupSpaces.map((groupSpace) => {
+      const groupModel = groupModelsByModelId.get(groupSpace.groupId);
+      assert(
+        groupModel,
+        "One and only one group must exist for member group space"
+      );
+      assert(
+        groupModel.kind !== "space_editors",
+        "Editors groups cannot be member groups"
+      );
+      if (filterOnManagementMode) {
+        // Keep only regular groups in manual mode, provisioned groups in provisioned mode
+        const filterOnKind =
+          space.managementMode === "manual" ? "regular" : "provisioned";
+        if (groupModel.kind !== filterOnKind) {
+          return null;
+        }
+      }
+      const group = new GroupResource(GroupModel, groupModel.get());
+
+      return new this(
+        GroupSpaceModel,
+        groupSpace.get(),
+        space,
+        group
+      );
+    });
     return removeNulls(groupSpacesResources);
   }
 

--- a/front/lib/resources/group_space_member_resource.ts
+++ b/front/lib/resources/group_space_member_resource.ts
@@ -92,7 +92,10 @@ export class GroupSpaceMemberResource extends GroupSpaceBaseResource {
     const groupModelsByModelId = new Map(
       groupModels.map((groupModel) => [groupModel.id, groupModel])
     );
-    assert(groupModelsByModelId.size === groupSpaces.length, "All member group spaces must have exactly one associated group");
+    assert(
+      groupModelsByModelId.size === groupSpaces.length,
+      "All member group spaces must have exactly one associated group"
+    );
 
     const groupSpacesResources = groupSpaces.map((groupSpace) => {
       const groupModel = groupModelsByModelId.get(groupSpace.groupId);
@@ -114,12 +117,7 @@ export class GroupSpaceMemberResource extends GroupSpaceBaseResource {
       }
       const group = new GroupResource(GroupModel, groupModel.get());
 
-      return new this(
-        GroupSpaceModel,
-        groupSpace.get(),
-        space,
-        group
-      );
+      return new this(GroupSpaceModel, groupSpace.get(), space, group);
     });
     return removeNulls(groupSpacesResources);
   }

--- a/front/lib/resources/group_space_member_resource.ts
+++ b/front/lib/resources/group_space_member_resource.ts
@@ -92,10 +92,6 @@ export class GroupSpaceMemberResource extends GroupSpaceBaseResource {
     const groupModelsByModelId = new Map(
       groupModels.map((groupModel) => [groupModel.id, groupModel])
     );
-    assert(
-      groupModelsByModelId.size === groupSpaces.length,
-      "All member group spaces must have exactly one associated group"
-    );
 
     const groupSpacesResources = groupSpaces.map((groupSpace) => {
       const groupModel = groupModelsByModelId.get(groupSpace.groupId);


### PR DESCRIPTION
## Description

This PR removes a few small N+1 queries in group space editor/member retrieval, fetching related resources in one batch. The existing group-kind checks and management-mode filtering are all preserved.
Also bundles a similar change in the poke plugin to apply group roles.
Refactor-only, no change in logic.

## Tests

- Well covered by existing tests.
- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
