### PR TITLE
[front] fix auto-scroll during agent response streaming

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -1341,6 +1341,7 @@ export const ConversationViewer = ({
           // Large buffer to avoid manipulating the dom too much when the user scrolls a bit.
           increaseViewportBy={8192}
           enforceStickyFooterAtBottom
+          autoscrollToBottomBehavior="smooth"
         />
       </VirtuosoMessageListLicense>
     </>


### PR DESCRIPTION
## Description

`VirtuosoMessageList` in `ConversationViewer` was missing `autoscrollToBottomBehavior`, so Virtuoso had no instruction to scroll as streaming content grew the list. Adds `autoscrollToBottomBehavior="smooth"` — Virtuoso's built-in behavior only fires when the user is already near the bottom, so it won't interrupt anyone who has scrolled up to read earlier messages.

## Tests

Tested locally: sent a message and confirmed the viewport scrolls smoothly as the agent streams its response.

## Risk

Low. Single prop addition to `VirtuosoMessageList`; no logic changes. Rollback-safe — removing the prop reverts to the previous (broken) behavior.

## Deploy Plan

Deploy front.
