### PR TITLE
Add: autoscroll agent message.

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -112,6 +112,7 @@ import {
 import { useVirtuosoMethods } from "@virtuoso.dev/message-list";
 import { marked } from "marked";
 import {
+  type MutableRefObject,
   type ReactElement,
   useCallback,
   useContext,
@@ -214,6 +215,7 @@ interface AgentMessageProps {
   ) => Promise<Result<undefined, DustError>>;
   additionalMarkdownComponents?: Components;
   additionalMarkdownPlugins?: PluggableList;
+  isAutoScrollEnabledRef: MutableRefObject<boolean>;
   isProjectArchived?: boolean;
 }
 
@@ -232,6 +234,7 @@ export function AgentMessage({
   handleSubmit,
   additionalMarkdownComponents,
   additionalMarkdownPlugins,
+  isAutoScrollEnabledRef,
   isProjectArchived = false,
 }: AgentMessageProps) {
   const sId = agentMessage.sId;
@@ -291,6 +294,7 @@ export function AgentMessage({
   const { shouldStream, streamError } = useAgentMessageStream({
     agentMessage: agentMessage,
     conversationId,
+    isAutoScrollEnabledRef,
     owner,
     onEventCallback: useCallback(
       (eventPayload: {

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -82,14 +82,8 @@ import {
   VirtuosoMessageListLicense,
 } from "@virtuoso.dev/message-list";
 import debounce from "lodash/debounce";
-// biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import type { MutableRefObject } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
 import { mutate } from "swr";
@@ -120,6 +114,35 @@ function customSmoothScroll() {
     animationFrameCount: 30,
     easing: easeOutQuint,
   };
+}
+
+// This function is used to update the auto scroll enabled state based on the scroll location.
+// Goal is to detect when the user is scrolling manually to pause the auto scroll.
+function updateAutoScrollEnabledFromLocation({
+  isAutoScrollEnabledRef,
+  location,
+  prevLocationRef,
+}: {
+  isAutoScrollEnabledRef: MutableRefObject<boolean>;
+  location: Pick<ListScrollLocation, "scrollHeight" | "bottomOffset">;
+  prevLocationRef: MutableRefObject<
+    Pick<ListScrollLocation, "scrollHeight" | "bottomOffset">
+  >;
+}) {
+  const { scrollHeight, bottomOffset } = location;
+  const prev = prevLocationRef.current;
+
+  // Scroll up with out change in content.
+  if (scrollHeight === prev.scrollHeight && bottomOffset > prev.bottomOffset) {
+    isAutoScrollEnabledRef.current = false;
+  }
+
+  // Scroll to bottom with no change in content.
+  if (scrollHeight === prev.scrollHeight && bottomOffset == 0) {
+    isAutoScrollEnabledRef.current = true;
+  }
+
+  prevLocationRef.current = { scrollHeight, bottomOffset };
 }
 
 export function getBranchedInsertIndex(
@@ -250,6 +273,11 @@ export const ConversationViewer = ({
     useRef<
       VirtuosoMessageListMethods<VirtuosoMessage, VirtuosoMessageListContext>
     >(null);
+  const isAutoScrollEnabledRef = useRef(true);
+  const prevScrollLocationRef = useRef({
+    scrollHeight: 0,
+    bottomOffset: 0,
+  });
   const sendNotification = useSendNotification();
   const { incrementPendingSteeringCount } = useGenerationContext();
 
@@ -1189,6 +1217,12 @@ export const ConversationViewer = ({
 
   const onScroll = useCallback(
     (location: ListScrollLocation) => {
+      updateAutoScrollEnabledFromLocation({
+        isAutoScrollEnabledRef,
+        location,
+        prevLocationRef: prevScrollLocationRef,
+      });
+
       const isLoadingData =
         isLoadingInitialData || isMessagesLoading || isValidating;
 
@@ -1276,6 +1310,7 @@ export const ConversationViewer = ({
       projectSpaceName: spaceInfo?.name,
       branchIdToApprove: branchIdToApprove ?? undefined,
       setBranchIdToApprove,
+      isAutoScrollEnabledRef,
     };
   }, [
     user,

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -349,6 +349,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
                 context.additionalMarkdownComponents
               }
               additionalMarkdownPlugins={context.additionalMarkdownPlugins}
+              isAutoScrollEnabledRef={context.isAutoScrollEnabledRef}
               isProjectArchived={context.isProjectArchived}
             />
           )}

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -30,6 +30,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
+import type { MutableRefObject } from "react";
 import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
 
@@ -138,6 +139,7 @@ export type VirtuosoMessageListContext = {
   projectSpaceName?: string;
   branchIdToApprove?: string;
   setBranchIdToApprove?: (branchId: string | null) => void;
+  isAutoScrollEnabledRef: MutableRefObject<boolean>;
 };
 
 export const areSameRankAndBranch = (

--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -18,6 +18,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mockUseEventSource = vi.fn();
 const mockMutateContextUsage = vi.fn();
 const mockUseVirtuosoMethods = vi.fn();
+const mockIsAutoScrollEnabledRef = { current: true };
+
+function makeVirtuosoMethodsMock<T>(map: (updater: (message: T) => T) => T[]) {
+  return {
+    data: {
+      map,
+      batch: (callback: () => void) => {
+        callback();
+      },
+    },
+  };
+}
 
 vi.mock("@app/hooks/useEventSource", () => ({
   useEventSource: (...args: unknown[]) => mockUseEventSource(...args),
@@ -272,9 +284,9 @@ describe("useAgentMessageStream", () => {
     }> = [];
     let onEventCallback: ((event: string) => void) | null = null;
 
-    mockUseVirtuosoMethods.mockReturnValue({
-      data: {
-        map: (
+    mockUseVirtuosoMethods.mockReturnValue(
+      makeVirtuosoMethodsMock(
+        (
           updater: (message: typeof currentMessage) => typeof currentMessage
         ) => {
           currentMessage = updater(currentMessage);
@@ -284,9 +296,9 @@ describe("useAgentMessageStream", () => {
             agentState: currentMessage.streaming.agentState,
           });
           return [currentMessage];
-        },
-      },
-    });
+        }
+      )
+    );
 
     mockUseEventSource.mockImplementation(
       (
@@ -302,6 +314,7 @@ describe("useAgentMessageStream", () => {
       useAgentMessageStream({
         agentMessage: currentMessage,
         conversationId: "conv_123",
+        isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
         owner: mockOwner,
         streamId: "stream_123",
       })
@@ -343,16 +356,16 @@ describe("useAgentMessageStream", () => {
     );
     let onEventCallback: ((event: string) => void) | null = null;
 
-    mockUseVirtuosoMethods.mockReturnValue({
-      data: {
-        map: (
+    mockUseVirtuosoMethods.mockReturnValue(
+      makeVirtuosoMethodsMock(
+        (
           updater: (message: typeof currentMessage) => typeof currentMessage
         ) => {
           currentMessage = updater(currentMessage);
           return [currentMessage];
-        },
-      },
-    });
+        }
+      )
+    );
 
     mockUseEventSource.mockImplementation(
       (
@@ -368,6 +381,7 @@ describe("useAgentMessageStream", () => {
       useAgentMessageStream({
         agentMessage: currentMessage,
         conversationId: "conv_123",
+        isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
         owner: mockOwner,
         streamId: "stream_123",
       })
@@ -461,16 +475,16 @@ describe("useAgentMessageStream", () => {
     );
     let onEventCallback: ((event: string) => void) | null = null;
 
-    mockUseVirtuosoMethods.mockReturnValue({
-      data: {
-        map: (
+    mockUseVirtuosoMethods.mockReturnValue(
+      makeVirtuosoMethodsMock(
+        (
           updater: (message: typeof currentMessage) => typeof currentMessage
         ) => {
           currentMessage = updater(currentMessage);
           return [currentMessage];
-        },
-      },
-    });
+        }
+      )
+    );
 
     mockUseEventSource.mockImplementation(
       (
@@ -486,6 +500,7 @@ describe("useAgentMessageStream", () => {
       useAgentMessageStream({
         agentMessage: currentMessage,
         conversationId: "conv_123",
+        isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
         owner: mockOwner,
         streamId: "stream_123",
       })
@@ -557,16 +572,16 @@ describe("useAgentMessageStream", () => {
     );
     let onEventCallback: ((event: string) => void) | null = null;
 
-    mockUseVirtuosoMethods.mockReturnValue({
-      data: {
-        map: (
+    mockUseVirtuosoMethods.mockReturnValue(
+      makeVirtuosoMethodsMock(
+        (
           updater: (message: typeof currentMessage) => typeof currentMessage
         ) => {
           currentMessage = updater(currentMessage);
           return [currentMessage];
-        },
-      },
-    });
+        }
+      )
+    );
 
     mockUseEventSource.mockImplementation(
       (
@@ -582,6 +597,7 @@ describe("useAgentMessageStream", () => {
       useAgentMessageStream({
         agentMessage: currentMessage,
         conversationId: "conv_123",
+        isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
         owner: mockOwner,
         streamId: "stream_123",
       })
@@ -711,9 +727,9 @@ describe("useAgentMessageStream", () => {
     const chainOfThoughtSnapshots: string[] = [];
     let onEventCallback: ((event: string) => void) | null = null;
 
-    mockUseVirtuosoMethods.mockReturnValue({
-      data: {
-        map: (
+    mockUseVirtuosoMethods.mockReturnValue(
+      makeVirtuosoMethodsMock(
+        (
           updater: (message: typeof currentMessage) => typeof currentMessage
         ) => {
           currentMessage = updater(currentMessage);
@@ -721,9 +737,9 @@ describe("useAgentMessageStream", () => {
             chainOfThoughtSnapshots.push(currentMessage.chainOfThought);
           }
           return [currentMessage];
-        },
-      },
-    });
+        }
+      )
+    );
 
     mockUseEventSource.mockImplementation(
       (
@@ -739,6 +755,7 @@ describe("useAgentMessageStream", () => {
       useAgentMessageStream({
         agentMessage: currentMessage,
         conversationId: "conv_123",
+        isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
         owner: mockOwner,
         streamId: "stream_123",
       })

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -25,26 +25,81 @@ import type { LightWorkspaceType } from "@app/types/user";
 import type { VirtuosoMessageListMethods } from "@virtuoso.dev/message-list";
 import { useVirtuosoMethods } from "@virtuoso.dev/message-list";
 import throttle from "lodash/throttle";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import {
+  type MutableRefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
 
-function createUpdateMessageThrottled() {
+const TOKEN_BUFFER_THRESHOLD_MS = 500;
+
+type VirtuosoMethods = VirtuosoMessageListMethods<
+  VirtuosoMessage,
+  VirtuosoMessageListContext
+>;
+
+function createAutoScrollToBottomBehavior(
+  isAutoScrollEnabledRef: MutableRefObject<boolean>
+) {
+  return ({
+    scrollLocation,
+    scrollInProgress,
+  }: {
+    scrollLocation: { bottomOffset: number };
+    scrollInProgress: boolean;
+  }) => {
+    if (!isAutoScrollEnabledRef.current || scrollInProgress) {
+      return false;
+    }
+
+    if (scrollLocation.bottomOffset < 0) {
+      return false;
+    }
+
+    return {
+      index: "LAST" as const,
+      align: "end" as const,
+      behavior: "smooth" as const,
+    };
+  };
+}
+
+function batchMapMessagesWithAutoScroll(
+  methods: VirtuosoMethods,
+  isAutoScrollEnabledRef: MutableRefObject<boolean>,
+  mapFn: (message: VirtuosoMessage, index: number) => VirtuosoMessage
+) {
+  methods.data.batch(
+    () => methods.data.map(mapFn),
+    createAutoScrollToBottomBehavior(isAutoScrollEnabledRef)
+  );
+}
+
+function createUpdateMessageThrottled(
+  isAutoScrollEnabledRef: MutableRefObject<boolean>,
+  methods: VirtuosoMethods
+) {
   return throttle(
     ({
       chainOfThought,
       content,
-      methods,
       sId,
     }: {
       chainOfThought: string;
       content: string;
-      methods: VirtuosoMessageListMethods<
-        VirtuosoMessage,
-        VirtuosoMessageListContext
-      >;
       sId: string;
     }) => {
-      methods.data.map((m) => {
+      batchMapMessagesWithAutoScroll(methods, isAutoScrollEnabledRef, (m) => {
         if (isAgentMessageWithStreaming(m) && m.sId === sId) {
+          // Enable auto scroll if we are starting to receive content or chain of thought.
+          if (
+            (!m.content && content) ||
+            (!m.chainOfThought && chainOfThought)
+          ) {
+            isAutoScrollEnabledRef.current = true;
+          }
           return {
             ...m,
             content,
@@ -54,7 +109,7 @@ function createUpdateMessageThrottled() {
         return m;
       });
     },
-    100
+    TOKEN_BUFFER_THRESHOLD_MS
   );
 }
 
@@ -277,6 +332,7 @@ function flushPendingSegment({
 interface UseAgentMessageStreamParams {
   agentMessage: AgentMessageWithStreaming;
   conversationId: string | null;
+  isAutoScrollEnabledRef: MutableRefObject<boolean>;
   owner: LightWorkspaceType;
   onEventCallback?: (event: {
     eventId: string;
@@ -288,6 +344,7 @@ interface UseAgentMessageStreamParams {
 export function useAgentMessageStream({
   agentMessage,
   conversationId,
+  isAutoScrollEnabledRef,
   owner,
   onEventCallback: customOnEventCallback,
   streamId,
@@ -298,13 +355,22 @@ export function useAgentMessageStream({
     workspaceId: owner.sId,
     options: { disabled: true },
   });
+
   const methods = useVirtuosoMethods<
     VirtuosoMessage,
     VirtuosoMessageListContext
   >();
+
   const updateMessageThrottled = useMemo(
-    () => createUpdateMessageThrottled(),
-    []
+    () => createUpdateMessageThrottled(isAutoScrollEnabledRef, methods),
+    [isAutoScrollEnabledRef, methods]
+  );
+
+  const mapMessagesWithAutoScroll = useCallback(
+    (mapFn: (message: VirtuosoMessage, index: number) => VirtuosoMessage) => {
+      batchMapMessagesWithAutoScroll(methods, isAutoScrollEnabledRef, mapFn);
+    },
+    [methods, isAutoScrollEnabledRef]
   );
 
   // Short-circuit replays of events we've already processed in this hook
@@ -420,7 +486,7 @@ export function useAgentMessageStream({
             chainOfThought.current = "";
             lastCoTTraceId.current = null;
             retryCoTBuffer.current = null;
-            methods.data.map((m) => {
+            mapMessagesWithAutoScroll((m) => {
               if (!isAgentMessageWithStreaming(m) || m.sId !== sId) {
                 return m;
               }
@@ -470,7 +536,7 @@ export function useAgentMessageStream({
               updateMessageThrottled.cancel();
               const newAgentState =
                 classification === "tokens" ? "writing" : "thinking";
-              methods.data.map((m) => {
+              mapMessagesWithAutoScroll((m) => {
                 if (!isAgentMessageWithStreaming(m) || m.sId !== sId) {
                   return m;
                 }
@@ -497,7 +563,7 @@ export function useAgentMessageStream({
               classification === "tokens"
             ) {
               // First tokens event in inline mode — set agentState to writing.
-              methods.data.map((m) => {
+              mapMessagesWithAutoScroll((m) => {
                 if (!isAgentMessageWithStreaming(m) || m.sId !== sId) {
                   return m;
                 }
@@ -534,7 +600,6 @@ export function useAgentMessageStream({
               updateMessageThrottled({
                 chainOfThought: chainOfThought.current,
                 content: content.current,
-                methods,
                 sId,
               });
             }
@@ -543,7 +608,7 @@ export function useAgentMessageStream({
 
         case "agent_action_success":
           const action = eventPayload.data.action;
-          methods.data.map((m) => {
+          mapMessagesWithAutoScroll((m) => {
             if (!isAgentMessageWithStreaming(m) || m.sId !== sId) {
               return m;
             }
@@ -590,7 +655,7 @@ export function useAgentMessageStream({
         case "tool_params":
           updateMessageThrottled.cancel();
           const toolParams = eventPayload.data;
-          methods.data.map((m) => {
+          mapMessagesWithAutoScroll((m) => {
             if (!isAgentMessageWithStreaming(m) || m.sId !== sId) {
               return m;
             }
@@ -621,7 +686,7 @@ export function useAgentMessageStream({
 
         case "tool_notification":
           const toolNotification = eventPayload.data;
-          methods.data.map((m) =>
+          mapMessagesWithAutoScroll((m) =>
             isAgentMessageWithStreaming(m) && m.sId === sId
               ? updateProgress(m, toolNotification)
               : m
@@ -633,7 +698,7 @@ export function useAgentMessageStream({
           if (toolCallStarted.type !== "tool_call_started") {
             break;
           }
-          methods.data.map((m) => {
+          mapMessagesWithAutoScroll((m) => {
             if (!isAgentMessageWithStreaming(m) || m.sId !== sId) {
               return m;
             }
@@ -660,7 +725,7 @@ export function useAgentMessageStream({
           isStreamTerminated.current = true;
           updateMessageThrottled.cancel();
           const error = eventPayload.data.error;
-          methods.data.map((m) => {
+          mapMessagesWithAutoScroll((m) => {
             if (!isAgentMessageWithStreaming(m) || m.sId !== sId) {
               return m;
             }
@@ -688,7 +753,7 @@ export function useAgentMessageStream({
           break;
 
         case "agent_context_pruned":
-          methods.data.map((m) =>
+          mapMessagesWithAutoScroll((m) =>
             isAgentMessageWithStreaming(m) && m.sId === sId
               ? {
                   ...m,
@@ -705,7 +770,7 @@ export function useAgentMessageStream({
           if (cancelData.type !== "agent_generation_cancelled") {
             break;
           }
-          methods.data.map((m) => {
+          mapMessagesWithAutoScroll((m) => {
             if (!isAgentMessageWithStreaming(m) || m.sId !== sId) {
               return m;
             }
@@ -752,7 +817,7 @@ export function useAgentMessageStream({
           const finalSegment = content.current;
           const hadStreamedTokens = lastClassification.current !== null;
           lastClassification.current = null;
-          methods.data.map((m) => {
+          mapMessagesWithAutoScroll((m) => {
             if (!isAgentMessageWithStreaming(m) || m.sId !== sId) {
               return m;
             }
@@ -802,7 +867,7 @@ export function useAgentMessageStream({
     },
     [
       customOnEventCallback,
-      methods,
+      mapMessagesWithAutoScroll,
       sId,
       mutateContextUsage,
       updateMessageThrottled,

--- a/front/hooks/useVoiceTranscriberService.ts
+++ b/front/hooks/useVoiceTranscriberService.ts
@@ -16,9 +16,9 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 // We are using webm with Opus codec
 // In general browsers are using a 48 kbps bitrate
-// A 1-minute recording will be around 400kB
-// 60 seconds * 48000bps / 8 => 360 000 bit, round up to 400kB
-const MAXIMUM_FILE_SIZE_FOR_INPUT_BAR_IN_BYTES = 400 * 1024;
+// A 3-minute recording will be around 1200kB
+// 180 seconds * 48000bps / 8 => 1 080 000 bit, round up to 1200kB
+const MAXIMUM_FILE_SIZE_FOR_INPUT_BAR_IN_BYTES = 1200 * 1024;
 
 const MICROPHONE_POPUP_TIMEOUT_MS = 60_000; // 1 minute
 

--- a/front/package.json
+++ b/front/package.json
@@ -130,7 +130,7 @@
     "@types/turndown": "^5.0.6",
     "@uiw/react-textarea-code-editor": "^3.0.2",
     "@valtown/sdk": "^2.0.0",
-    "@virtuoso.dev/message-list": "^1.14.0",
+    "@virtuoso.dev/message-list": "^1.16.0",
     "@workos-inc/node": "^7.77.0",
     "adm-zip": "^0.5.16",
     "ajv": "^8.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -573,7 +573,7 @@
         "@types/turndown": "^5.0.6",
         "@uiw/react-textarea-code-editor": "^3.0.2",
         "@valtown/sdk": "^2.0.0",
-        "@virtuoso.dev/message-list": "^1.14.0",
+        "@virtuoso.dev/message-list": "^1.16.0",
         "@workos-inc/node": "^7.77.0",
         "adm-zip": "^0.5.16",
         "ajv": "^8.17.1",


### PR DESCRIPTION
## Description

Adds user-intent-aware autoscroll to agent messages during streaming. `ConversationViewer` now tracks an `isAutoScrollEnabledRef` ref — enabled by default, disabled when the user scrolls up (same `scrollHeight`, increasing `bottomOffset`), and re-enabled when they scroll back to the bottom or when new content/chain-of-thought tokens start arriving.

The ref flows down through `VirtuosoMessageListContext` → `MessageItem` → `AgentMessage` → `useAgentMessageStream`. In the hook, `batchMapMessagesWithAutoScroll` wraps every Virtuoso data mutation with a `createAutoScrollToBottomBehavior` callback that gates scroll-to-`LAST` on both the ref state and `scrollInProgress`. The throttle window on token updates is also bumped from 100 ms to 500 ms (since we have intermediary animation now, thanks to yuka).

## Tests

- Updated `useAgentMessageStream.test.ts`: added `mockIsAutoScrollEnabledRef`, refactored all mock setups to use the new `makeVirtuosoMethodsMock` helper (which includes the `batch` method), and passed `isAutoScrollEnabledRef` to all hook invocations.
- Tested manually.

## Risk

Low. The autoscroll gating is ref-based (no re-renders) and only affects scroll behavior during streaming. Existing Virtuoso rendering and message mutation logic is unchanged. Safe to rollback.

## Deploy Plan

Deploy front.
