### PR TITLE
Add: custom component for approving the creation and update of pod tasks.

### DIFF
--- a/front/components/assistant/conversation/BlockedAction.tsx
+++ b/front/components/assistant/conversation/BlockedAction.tsx
@@ -33,6 +33,7 @@ export function BlockedAction({
           triggeringUser={triggeringUser}
           owner={owner}
           blockedAction={blockedAction}
+          conversationId={conversationId}
         />
       );
 

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -4,6 +4,20 @@ import { getIcon } from "@app/components/resources/resources_icons";
 import { useValidateAction } from "@app/hooks/useValidateAction";
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
+import {
+  POD_MANAGER_SERVER_NAME,
+  UPDATE_MEMBERS_TOOL_NAME,
+} from "@app/lib/api/actions/servers/pod_manager/metadata";
+import { isPodManagerUpdateMembersInput } from "@app/lib/api/actions/servers/pod_manager/types";
+import {
+  CREATE_TASKS_TOOL_NAME,
+  POD_TASKS_SERVER_NAME,
+  UPDATE_TASKS_TOOL_NAME,
+} from "@app/lib/api/actions/servers/pod_tasks/metadata";
+import {
+  isPodTasksCreateTasksInput,
+  isPodTasksUpdateTasksInput,
+} from "@app/lib/api/actions/servers/pod_tasks/types";
 import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
@@ -51,18 +65,74 @@ const MCP_TOOL_OVERRIDES: Partial<
       detailsExpanded: true,
     },
   },
+  [POD_TASKS_SERVER_NAME]: {
+    [CREATE_TASKS_TOOL_NAME]: {
+      title: (agentName, inputs) => {
+        if (!isPodTasksCreateTasksInput(inputs)) {
+          return `Allow ${asDisplayName(agentName)} to create tasks?`;
+        }
+        const count = inputs.tasks.length;
+        return `Allow ${asDisplayName(agentName)} to create ${count} task${count === 1 ? "" : "s"}?`;
+      },
+      alwaysAllowLabel: (agentName) =>
+        `Always allow ${asDisplayName(agentName)} to create tasks`,
+    },
+    [UPDATE_TASKS_TOOL_NAME]: {
+      title: (agentName, inputs) => {
+        if (!isPodTasksUpdateTasksInput(inputs)) {
+          return `Allow ${asDisplayName(agentName)} to update tasks?`;
+        }
+        const count = inputs.tasks.length;
+        const doneCount = inputs.tasks.filter(
+          (task) => task.doneRationale
+        ).length;
+        if (doneCount > 0 && doneCount === count) {
+          return `Allow ${asDisplayName(agentName)} to mark ${count} task${count === 1 ? "" : "s"} as done?`;
+        }
+        if (doneCount > 0) {
+          return `Allow ${asDisplayName(agentName)} to update ${count} task${count === 1 ? "" : "s"} (${doneCount} marked as done)?`;
+        }
+        return `Allow ${asDisplayName(agentName)} to update ${count} task${count === 1 ? "" : "s"}?`;
+      },
+      alwaysAllowLabel: (agentName) =>
+        `Always allow ${asDisplayName(agentName)} to update tasks`,
+    },
+  },
+  [POD_MANAGER_SERVER_NAME]: {
+    [UPDATE_MEMBERS_TOOL_NAME]: {
+      title: (agentName, inputs) => {
+        if (!isPodManagerUpdateMembersInput(inputs)) {
+          return `Allow ${asDisplayName(agentName)} to update Pod members?`;
+        }
+        const addCount = inputs.addMemberIds?.length ?? 0;
+        const removeCount = inputs.removeMemberIds?.length ?? 0;
+        const parts: string[] = [];
+        if (addCount > 0) {
+          parts.push(`add ${addCount}`);
+        }
+        if (removeCount > 0) {
+          parts.push(`remove ${removeCount}`);
+        }
+        return `Allow ${asDisplayName(agentName)} to ${parts.join(" and ")} Pod member${addCount + removeCount === 1 ? "" : "s"}?`;
+      },
+      alwaysAllowLabel: (agentName) =>
+        `Always allow ${asDisplayName(agentName)} to update Pod members`,
+    },
+  },
 };
 
 interface MCPToolValidationRequiredProps {
   triggeringUser: UserType | null;
   owner: LightWorkspaceType;
   blockedAction: BlockedToolExecution;
+  conversationId?: string | null;
 }
 
 export function MCPToolValidationRequired({
   triggeringUser,
   owner,
   blockedAction,
+  conversationId,
 }: MCPToolValidationRequiredProps) {
   const { user } = useAuth();
   const [neverAskAgain, setNeverAskAgain] = useState(false);
@@ -204,6 +274,8 @@ export function MCPToolValidationRequired({
           <ToolValidationDetails
             blockedAction={blockedAction}
             user={user}
+            owner={owner}
+            conversationId={conversationId}
             defaultExpanded={toolOverride?.detailsExpanded}
           />
           {errorMessage && (

--- a/front/components/assistant/conversation/ToolValidationDetails.tsx
+++ b/front/components/assistant/conversation/ToolValidationDetails.tsx
@@ -1,3 +1,10 @@
+import {
+  AshbyJobPostingUpdateDetails,
+  AshbyReferralDetails,
+} from "@app/components/assistant/conversation/tool_validation/AshbyValidationDetails";
+import { PodMembersUpdateValidationDetails } from "@app/components/assistant/conversation/tool_validation/PodMembersUpdateValidationDetails";
+import { PodTasksCreateValidationDetails } from "@app/components/assistant/conversation/tool_validation/PodTasksCreateValidationDetails";
+import { PodTasksUpdateValidationDetails } from "@app/components/assistant/conversation/tool_validation/PodTasksUpdateValidationDetails";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import { ASHBY_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
@@ -8,14 +15,26 @@ import {
   isAshbyCreateReferralInput,
   isAshbyUpdateJobPostingInput,
 } from "@app/lib/api/actions/servers/ashby/types";
-import { isString } from "@app/types/shared/utils/general";
-import type { UserType } from "@app/types/user";
 import {
-  Button,
+  POD_MANAGER_SERVER_NAME,
+  UPDATE_MEMBERS_TOOL_NAME,
+} from "@app/lib/api/actions/servers/pod_manager/metadata";
+import { isPodManagerUpdateMembersInput } from "@app/lib/api/actions/servers/pod_manager/types";
+import {
+  CREATE_TASKS_TOOL_NAME,
+  POD_TASKS_SERVER_NAME,
+  UPDATE_TASKS_TOOL_NAME,
+} from "@app/lib/api/actions/servers/pod_tasks/metadata";
+import {
+  isPodTasksCreateTasksInput,
+  isPodTasksUpdateTasksInput,
+} from "@app/lib/api/actions/servers/pod_tasks/types";
+import { isString } from "@app/types/shared/utils/general";
+import type { LightWorkspaceType, UserType } from "@app/types/user";
+import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
-  ExternalLinkIcon,
 } from "@dust-tt/sparkle";
 import { useMemo } from "react";
 
@@ -55,12 +74,16 @@ interface DisplayableInput {
 interface ToolValidationDetailsProps {
   blockedAction: BlockedToolExecution;
   user: UserType;
+  owner: LightWorkspaceType;
+  conversationId?: string | null;
   defaultExpanded?: boolean;
 }
 
 export function ToolValidationDetails({
   blockedAction,
   user,
+  owner,
+  conversationId,
   defaultExpanded = false,
 }: ToolValidationDetailsProps) {
   const displayableInputs: DisplayableInput[] = useMemo(() => {
@@ -75,7 +98,6 @@ export function ToolValidationDetails({
       .filter((entry): entry is DisplayableInput => entry.value !== null);
   }, [blockedAction.inputs]);
 
-  // Custom component for Ashby referral creation.
   if (
     blockedAction.metadata.mcpServerName === ASHBY_SERVER_NAME &&
     blockedAction.metadata.toolName === CREATE_REFERRAL_TOOL_NAME &&
@@ -89,13 +111,57 @@ export function ToolValidationDetails({
     );
   }
 
-  // Custom component for Ashby job posting update.
   if (
     blockedAction.metadata.mcpServerName === ASHBY_SERVER_NAME &&
     blockedAction.metadata.toolName === UPDATE_JOB_POSTING_TOOL_NAME &&
     isAshbyUpdateJobPostingInput(blockedAction.inputs)
   ) {
     return <AshbyJobPostingUpdateDetails {...blockedAction.inputs} />;
+  }
+
+  if (
+    blockedAction.metadata.mcpServerName === POD_TASKS_SERVER_NAME &&
+    blockedAction.metadata.toolName === CREATE_TASKS_TOOL_NAME &&
+    isPodTasksCreateTasksInput(blockedAction.inputs)
+  ) {
+    return (
+      <PodTasksCreateValidationDetails
+        input={blockedAction.inputs}
+        owner={owner}
+        user={user}
+        conversationId={conversationId}
+      />
+    );
+  }
+
+  if (
+    blockedAction.metadata.mcpServerName === POD_TASKS_SERVER_NAME &&
+    blockedAction.metadata.toolName === UPDATE_TASKS_TOOL_NAME &&
+    isPodTasksUpdateTasksInput(blockedAction.inputs)
+  ) {
+    return (
+      <PodTasksUpdateValidationDetails
+        input={blockedAction.inputs}
+        owner={owner}
+        user={user}
+        conversationId={conversationId}
+      />
+    );
+  }
+
+  if (
+    blockedAction.metadata.mcpServerName === POD_MANAGER_SERVER_NAME &&
+    blockedAction.metadata.toolName === UPDATE_MEMBERS_TOOL_NAME &&
+    isPodManagerUpdateMembersInput(blockedAction.inputs)
+  ) {
+    return (
+      <PodMembersUpdateValidationDetails
+        input={blockedAction.inputs}
+        owner={owner}
+        user={user}
+        conversationId={conversationId}
+      />
+    );
   }
 
   if (displayableInputs.length === 0) {
@@ -120,131 +186,5 @@ export function ToolValidationDetails({
         </div>
       </CollapsibleContent>
     </Collapsible>
-  );
-}
-
-function formatFieldValue(value: string | number | boolean): string {
-  if (typeof value === "boolean") {
-    return value ? "Yes" : "No";
-  }
-  return String(value);
-}
-
-interface AshbyReferralDetailsProps {
-  fieldSubmissions: ReadonlyArray<{
-    title: string;
-    value: string | number | boolean;
-  }>;
-  userEmail: string;
-}
-
-interface AshbyJobPostingUpdateDetailsProps {
-  jobPostingId: string;
-  jobId: string;
-  title?: string;
-  descriptionHtml?: string;
-  workplaceType?: string | null;
-}
-
-function AshbyJobPostingUpdateDetails({
-  jobPostingId,
-  jobId,
-  title,
-  descriptionHtml,
-  workplaceType,
-}: AshbyJobPostingUpdateDetailsProps) {
-  const jobPostingUrl = `https://app.ashbyhq.com/jobs/${jobId}/job-postings/${jobPostingId}/description`;
-
-  const fields: DisplayableInput[] = [];
-
-  if (title) {
-    fields.push({ label: "New title", value: title });
-  }
-  if (workplaceType) {
-    fields.push({ label: "Workplace type", value: workplaceType });
-  }
-
-  return (
-    <div className="flex flex-col gap-3 pt-2">
-      <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-        This will update the job posting on Ashby. Changes are applied
-        immediately and visible to candidates.
-      </p>
-
-      <Button
-        variant="outline"
-        size="xs"
-        label="View on Ashby"
-        icon={ExternalLinkIcon}
-        href={jobPostingUrl}
-        target="_blank"
-      />
-
-      {fields.map(({ label, value }) => (
-        <div key={label}>
-          <div className="text-xs font-medium text-muted-foreground dark:text-muted-foreground-night">
-            {label}
-          </div>
-          <div className="mt-0.5 text-sm text-foreground dark:text-foreground-night">
-            {value}
-          </div>
-        </div>
-      ))}
-
-      {descriptionHtml && (
-        <Collapsible>
-          <CollapsibleTrigger>
-            <span className="text-sm font-medium">New description</span>
-          </CollapsibleTrigger>
-          <CollapsibleContent>
-            <div className="max-h-80 overflow-auto whitespace-pre-wrap break-words rounded-lg bg-muted px-3 text-sm dark:bg-muted-night">
-              {descriptionHtml.replace(/<(?!\/)/g, "\n<")}
-            </div>
-          </CollapsibleContent>
-        </Collapsible>
-      )}
-    </div>
-  );
-}
-
-function AshbyReferralDetails({
-  fieldSubmissions,
-  userEmail,
-}: AshbyReferralDetailsProps) {
-  return (
-    <div className="flex flex-col gap-3 pt-2">
-      <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-        {/* Safe to show: this component only renders for users authorized to
-            respond (canCurrentUserRespond guard in parent). */}
-        <>
-          The referral will be credited to&nbsp;
-          <span className="font-medium text-foreground dark:text-foreground-night">
-            {userEmail}
-          </span>
-          .
-        </>
-      </p>
-
-      <div className="divide-y divide-separator overflow-hidden rounded-xl bg-background dark:divide-separator-night dark:bg-background-night">
-        {fieldSubmissions.map(({ title, value }) => {
-          const displayValue = formatFieldValue(value);
-
-          if (!displayValue) {
-            return null;
-          }
-
-          return (
-            <div key={title} className="px-3 py-2">
-              <div className="text-xs font-medium text-muted-foreground dark:text-muted-foreground-night">
-                {title}
-              </div>
-              <div className="mt-0.5 text-sm text-foreground dark:text-foreground-night">
-                {displayValue}
-              </div>
-            </div>
-          );
-        })}
-      </div>
-    </div>
   );
 }

--- a/front/components/assistant/conversation/space/about/MembersTable.tsx
+++ b/front/components/assistant/conversation/space/about/MembersTable.tsx
@@ -202,7 +202,7 @@ export function MembersTable({
           return (
             <DataTable.CellContent>
               {info.row.original.isEditor && (
-                <Chip color="green" size="xs" label="editor" />
+                <Chip color="green" size="xs" label="Editor" />
               )}
             </DataTable.CellContent>
           );

--- a/front/components/assistant/conversation/tool_validation/AshbyValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/AshbyValidationDetails.tsx
@@ -1,0 +1,138 @@
+import {
+  Button,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  ExternalLinkIcon,
+} from "@dust-tt/sparkle";
+
+function formatFieldValue(value: string | number | boolean): string {
+  if (typeof value === "boolean") {
+    return value ? "Yes" : "No";
+  }
+  return String(value);
+}
+
+interface DisplayableInput {
+  label: string;
+  value: string;
+}
+
+interface AshbyReferralDetailsProps {
+  fieldSubmissions: ReadonlyArray<{
+    title: string;
+    value: string | number | boolean;
+  }>;
+  userEmail: string;
+}
+
+interface AshbyJobPostingUpdateDetailsProps {
+  jobPostingId: string;
+  jobId: string;
+  title?: string;
+  descriptionHtml?: string;
+  workplaceType?: string | null;
+}
+
+export function AshbyJobPostingUpdateDetails({
+  jobPostingId,
+  jobId,
+  title,
+  descriptionHtml,
+  workplaceType,
+}: AshbyJobPostingUpdateDetailsProps) {
+  const jobPostingUrl = `https://app.ashbyhq.com/jobs/${jobId}/job-postings/${jobPostingId}/description`;
+
+  const fields: DisplayableInput[] = [];
+
+  if (title) {
+    fields.push({ label: "New title", value: title });
+  }
+  if (workplaceType) {
+    fields.push({ label: "Workplace type", value: workplaceType });
+  }
+
+  return (
+    <div className="flex flex-col gap-3 pt-2">
+      <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        This will update the job posting on Ashby. Changes are applied
+        immediately and visible to candidates.
+      </p>
+
+      <Button
+        variant="outline"
+        size="xs"
+        label="View on Ashby"
+        icon={ExternalLinkIcon}
+        href={jobPostingUrl}
+        target="_blank"
+      />
+
+      {fields.map(({ label, value }) => (
+        <div key={label}>
+          <div className="text-xs font-medium text-muted-foreground dark:text-muted-foreground-night">
+            {label}
+          </div>
+          <div className="mt-0.5 text-sm text-foreground dark:text-foreground-night">
+            {value}
+          </div>
+        </div>
+      ))}
+
+      {descriptionHtml && (
+        <Collapsible>
+          <CollapsibleTrigger>
+            <span className="text-sm font-medium">New description</span>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <div className="max-h-80 overflow-auto whitespace-pre-wrap break-words rounded-lg bg-muted px-3 text-sm dark:bg-muted-night">
+              {descriptionHtml.replace(/<(?!\/)/g, "\n<")}
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
+      )}
+    </div>
+  );
+}
+
+export function AshbyReferralDetails({
+  fieldSubmissions,
+  userEmail,
+}: AshbyReferralDetailsProps) {
+  return (
+    <div className="flex flex-col gap-3 pt-2">
+      <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        {/* Safe to show: this component only renders for users authorized to
+            respond (canCurrentUserRespond guard in parent). */}
+        <>
+          The referral will be credited to&nbsp;
+          <span className="font-medium text-foreground dark:text-foreground-night">
+            {userEmail}
+          </span>
+          .
+        </>
+      </p>
+
+      <div className="divide-y divide-separator overflow-hidden rounded-xl bg-background dark:divide-separator-night dark:bg-background-night">
+        {fieldSubmissions.map(({ title, value }) => {
+          const displayValue = formatFieldValue(value);
+
+          if (!displayValue) {
+            return null;
+          }
+
+          return (
+            <div key={title} className="px-3 py-2">
+              <div className="text-xs font-medium text-muted-foreground dark:text-muted-foreground-night">
+                {title}
+              </div>
+              <div className="mt-0.5 text-sm text-foreground dark:text-foreground-night">
+                {displayValue}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/tool_validation/PodMembersUpdateValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/PodMembersUpdateValidationDetails.tsx
@@ -1,0 +1,186 @@
+import { usePodLabel } from "@app/components/assistant/conversation/tool_validation/usePodLabel";
+import type { PodManagerUpdateMembersInput } from "@app/lib/api/actions/servers/pod_manager/types";
+import {
+  type MemberDisplayInfo,
+  useMemberDetails,
+} from "@app/lib/swr/assistants";
+import type { LightWorkspaceType, UserType } from "@app/types/user";
+import { Avatar, Chip, cn } from "@dust-tt/sparkle";
+import { useMemo } from "react";
+
+interface PodMembersUpdateValidationDetailsProps {
+  input: PodManagerUpdateMembersInput;
+  owner: LightWorkspaceType;
+  user: UserType;
+  conversationId?: string | null;
+}
+
+function formatMemberName({
+  memberSId,
+  currentUserSId,
+  memberDisplayBySId,
+  isMembersLoading,
+}: {
+  memberSId: string;
+  currentUserSId: string;
+  memberDisplayBySId: Record<string, MemberDisplayInfo>;
+  isMembersLoading: boolean;
+}): string {
+  if (memberSId === currentUserSId) {
+    return "You";
+  }
+  const member = memberDisplayBySId[memberSId];
+  if (member) {
+    return member.fullName;
+  }
+  if (isMembersLoading) {
+    return "Loading…";
+  }
+  return memberSId;
+}
+
+interface MemberChangeRowProps {
+  memberSId: string;
+  action: "add" | "remove";
+  currentUserSId: string;
+  memberDisplayBySId: Record<string, MemberDisplayInfo>;
+  isMembersLoading: boolean;
+}
+
+function MemberChangeRow({
+  memberSId,
+  action,
+  currentUserSId,
+  memberDisplayBySId,
+  isMembersLoading,
+}: MemberChangeRowProps) {
+  const member = memberDisplayBySId[memberSId];
+  const displayName = formatMemberName({
+    memberSId,
+    currentUserSId,
+    memberDisplayBySId,
+    isMembersLoading,
+  });
+
+  return (
+    <div className="flex items-center gap-3 px-3 py-2.5">
+      <Avatar
+        size="xs"
+        visual={member?.image ?? null}
+        name={member?.fullName ?? displayName}
+        isRounded
+      />
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-medium text-foreground dark:text-foreground-night">
+          {displayName}
+        </div>
+        {member?.email && displayName !== member.email && (
+          <div className="truncate text-xs text-muted-foreground dark:text-muted-foreground-night">
+            {member.email}
+          </div>
+        )}
+      </div>
+      <Chip
+        size="xs"
+        color={action === "add" ? "green" : "rose"}
+        label={action === "add" ? "Will add" : "Will remove"}
+      />
+    </div>
+  );
+}
+
+export function PodMembersUpdateValidationDetails({
+  input,
+  owner,
+  user,
+  conversationId,
+}: PodMembersUpdateValidationDetailsProps) {
+  const addMemberIds = input.addMemberIds ?? [];
+  const removeMemberIds = input.removeMemberIds ?? [];
+  const { podLabel, isPodLabelLoading } = usePodLabel({
+    owner,
+    dustPodUri: input.dustPod?.uri,
+    conversationId,
+  });
+
+  const memberSIds = useMemo(
+    () => [...new Set([...addMemberIds, ...removeMemberIds])],
+    [addMemberIds, removeMemberIds]
+  );
+  const { membersBySId, isMembersLoading } = useMemberDetails({
+    workspaceId: owner.sId,
+    userIds: memberSIds,
+  });
+
+  const summaryParts: string[] = [];
+  if (addMemberIds.length > 0) {
+    summaryParts.push(
+      `add ${addMemberIds.length} member${addMemberIds.length === 1 ? "" : "s"}`
+    );
+  }
+  if (removeMemberIds.length > 0) {
+    summaryParts.push(
+      `remove ${removeMemberIds.length} member${removeMemberIds.length === 1 ? "" : "s"}`
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3 pt-2">
+      <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        The agent wants to {summaryParts.join(" and ")} in{" "}
+        <span className="font-medium text-foreground dark:text-foreground-night">
+          {isPodLabelLoading ? "Loading…" : podLabel}
+        </span>
+        .
+      </p>
+
+      {addMemberIds.length > 0 && (
+        <div className="flex flex-col gap-1.5">
+          <div className="text-xs font-medium text-muted-foreground dark:text-muted-foreground-night">
+            Members to add
+          </div>
+          <div
+            className={cn(
+              "divide-y divide-separator overflow-hidden rounded-xl border border-separator bg-background dark:divide-separator-night dark:border-separator-night dark:bg-background-night"
+            )}
+          >
+            {addMemberIds.map((memberSId) => (
+              <MemberChangeRow
+                key={`add-${memberSId}`}
+                memberSId={memberSId}
+                action="add"
+                currentUserSId={user.sId}
+                memberDisplayBySId={membersBySId}
+                isMembersLoading={isMembersLoading}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {removeMemberIds.length > 0 && (
+        <div className="flex flex-col gap-1.5">
+          <div className="text-xs font-medium text-muted-foreground dark:text-muted-foreground-night">
+            Members to remove
+          </div>
+          <div
+            className={cn(
+              "divide-y divide-separator overflow-hidden rounded-xl border border-separator bg-background dark:divide-separator-night dark:border-separator-night dark:bg-background-night"
+            )}
+          >
+            {removeMemberIds.map((memberSId) => (
+              <MemberChangeRow
+                key={`remove-${memberSId}`}
+                memberSId={memberSId}
+                action="remove"
+                currentUserSId={user.sId}
+                memberDisplayBySId={membersBySId}
+                isMembersLoading={isMembersLoading}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/tool_validation/PodTasksCreateValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/PodTasksCreateValidationDetails.tsx
@@ -1,0 +1,201 @@
+import { usePodLabel } from "@app/components/assistant/conversation/tool_validation/usePodLabel";
+import { inferProjectTaskSourceFromUrl } from "@app/lib/api/actions/servers/pod_tasks/source_utils";
+import type { PodTasksCreateTasksInput } from "@app/lib/api/actions/servers/pod_tasks/types";
+import { useMemberDetails } from "@app/lib/swr/assistants";
+import type { ProjectTaskSourceType } from "@app/types/project_task";
+import { PROJECT_TASK_NO_ASSIGNEE_LABEL } from "@app/types/project_task";
+import type { LightWorkspaceType, UserType } from "@app/types/user";
+import {
+  BookOpenIcon,
+  ChatBubbleLeftRightIcon,
+  Checkbox,
+  Chip,
+  ConfluenceLogo,
+  DriveLogo,
+  ExternalLinkIcon,
+  GithubLogo,
+  Icon,
+  MicrosoftLogo,
+  NotionLogo,
+  SlackLogo,
+} from "@dust-tt/sparkle";
+import type { ComponentType } from "react";
+import { useMemo } from "react";
+
+const SOURCE_ICON_BY_TYPE: Record<
+  ProjectTaskSourceType,
+  ComponentType<{ className?: string }>
+> = {
+  project_conversation: ChatBubbleLeftRightIcon,
+  project_knowledge: BookOpenIcon,
+  slack: SlackLogo,
+  notion: NotionLogo,
+  gdrive: DriveLogo,
+  confluence: ConfluenceLogo,
+  github: GithubLogo,
+  microsoft: MicrosoftLogo,
+};
+
+interface PodTasksCreateValidationDetailsProps {
+  input: PodTasksCreateTasksInput;
+  owner: LightWorkspaceType;
+  user: UserType;
+  conversationId?: string | null;
+}
+
+function formatAssigneeLabel({
+  userId,
+  currentUserSId,
+  memberDisplayBySId,
+  isMembersLoading,
+}: {
+  userId: string | null | undefined;
+  currentUserSId: string;
+  memberDisplayBySId: Record<string, { fullName: string }>;
+  isMembersLoading: boolean;
+}): string {
+  if (userId === null || userId === undefined) {
+    return PROJECT_TASK_NO_ASSIGNEE_LABEL;
+  }
+  if (userId === currentUserSId) {
+    return "You";
+  }
+  const member = memberDisplayBySId[userId];
+  if (member) {
+    return member.fullName;
+  }
+  if (isMembersLoading) {
+    return "Loading…";
+  }
+  return userId;
+}
+
+export function PodTasksCreateValidationDetails({
+  input,
+  owner,
+  user,
+  conversationId,
+}: PodTasksCreateValidationDetailsProps) {
+  const { podLabel, isPodLabelLoading } = usePodLabel({
+    owner,
+    dustPodUri: input.dustPod?.uri,
+    conversationId,
+  });
+
+  const assigneeSIds = useMemo(
+    () =>
+      input.tasks
+        .map((task) => task.userId)
+        .filter((userId): userId is string => typeof userId === "string"),
+    [input.tasks]
+  );
+  const { membersBySId, isMembersLoading } = useMemberDetails({
+    workspaceId: owner.sId,
+    userIds: assigneeSIds,
+  });
+
+  const taskCount = input.tasks.length;
+  const doneCount = input.tasks.filter((task) => task.doneRationale).length;
+
+  return (
+    <div className="flex flex-col gap-3 pt-2">
+      <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        {input.creatorType === "user" ? (
+          <>
+            Review the{" "}
+            <span className="font-medium text-foreground dark:text-foreground-night">
+              {taskCount}
+            </span>{" "}
+            task{taskCount === 1 ? "" : "s"} below before adding them to{" "}
+            <span className="font-medium text-foreground dark:text-foreground-night">
+              {isPodLabelLoading ? "Loading…" : podLabel}
+            </span>
+            .
+          </>
+        ) : (
+          <>
+            The agent wants to create{" "}
+            <span className="font-medium text-foreground dark:text-foreground-night">
+              {taskCount}
+            </span>{" "}
+            task{taskCount === 1 ? "" : "s"} in{" "}
+            <span className="font-medium text-foreground dark:text-foreground-night">
+              {isPodLabelLoading ? "Loading…" : podLabel}
+            </span>
+            .
+          </>
+        )}
+        {doneCount > 0 && <> {doneCount} will be marked as done immediately.</>}
+      </p>
+
+      <div className="divide-y divide-separator overflow-hidden rounded-xl border border-separator bg-background dark:divide-separator-night dark:border-separator-night dark:bg-background-night">
+        {input.tasks.map((task, index) => {
+          const assigneeLabel = formatAssigneeLabel({
+            userId: task.userId,
+            currentUserSId: user.sId,
+            memberDisplayBySId: membersBySId,
+            isMembersLoading,
+          });
+          const isDone = Boolean(task.doneRationale);
+
+          return (
+            <div
+              key={`${index}-${task.text}`}
+              className="flex items-start gap-3 px-3 py-3"
+            >
+              <div className="mt-0.5 shrink-0">
+                <Checkbox size="xs" checked={isDone} disabled />
+              </div>
+              <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+                <div className="flex flex-wrap items-start gap-2">
+                  <p className="min-w-0 flex-1 break-words text-sm leading-5 text-foreground dark:text-foreground-night">
+                    {task.text}
+                  </p>
+                  {isDone && <Chip size="xs" color="green" label="Done" />}
+                </div>
+                <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                  Assignee: {assigneeLabel}
+                </p>
+                {task.doneRationale && (
+                  <p className="text-xs italic text-muted-foreground dark:text-muted-foreground-night">
+                    {task.doneRationale}
+                  </p>
+                )}
+                {task.sources && task.sources.length > 0 && (
+                  <div className="flex flex-wrap items-center gap-2">
+                    {task.sources.map((source) => {
+                      const inferred = inferProjectTaskSourceFromUrl({
+                        url: source.url,
+                        title: source.title,
+                      });
+                      const SourceIcon =
+                        SOURCE_ICON_BY_TYPE[inferred.sourceType];
+
+                      return (
+                        <a
+                          key={source.url}
+                          href={source.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex max-w-full items-center gap-1 rounded-md bg-muted px-2 py-1 text-xs text-foreground hover:bg-muted/80 dark:bg-muted-night dark:text-foreground-night dark:hover:bg-muted-night/80"
+                        >
+                          <Icon
+                            size="xs"
+                            visual={SourceIcon}
+                            className="shrink-0"
+                          />
+                          <span className="truncate">{source.title}</span>
+                          <ExternalLinkIcon className="h-3 w-3 shrink-0 opacity-60" />
+                        </a>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/tool_validation/PodTasksUpdateValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/PodTasksUpdateValidationDetails.tsx
@@ -1,0 +1,383 @@
+import { usePodLabel } from "@app/components/assistant/conversation/tool_validation/usePodLabel";
+import type {
+  PodTasksUpdateTaskItemInput,
+  PodTasksUpdateTasksInput,
+} from "@app/lib/api/actions/servers/pod_tasks/types";
+import {
+  type MemberDisplayInfo,
+  useMemberDetails,
+} from "@app/lib/swr/assistants";
+import { useWorkspaceProjectTask } from "@app/lib/swr/projects";
+import {
+  PROJECT_TASK_NO_ASSIGNEE_LABEL,
+  type ProjectTaskStatus,
+} from "@app/types/project_task";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import type { LightWorkspaceType, UserType } from "@app/types/user";
+import { Avatar, Checkbox, Chip, Spinner } from "@dust-tt/sparkle";
+import { useMemo } from "react";
+
+interface PodTasksUpdateValidationDetailsProps {
+  input: PodTasksUpdateTasksInput;
+  owner: LightWorkspaceType;
+  user: UserType;
+  conversationId?: string | null;
+}
+
+interface ChangeRowProps {
+  label: string;
+  before: string;
+  after: string;
+}
+
+interface AssigneeChangeRowProps {
+  currentAssigneeSId: string | null;
+  nextAssigneeSId: string | null;
+  currentUserSId: string;
+  memberDisplayBySId: Record<string, MemberDisplayInfo>;
+  isMembersLoading: boolean;
+}
+
+interface TaskUpdateRowProps {
+  workspaceId: string;
+  taskInput: PodTasksUpdateTaskItemInput;
+  user: UserType;
+}
+
+interface FormatAssigneeLabelParams {
+  userId: string | null | undefined;
+  currentUserSId: string;
+  memberDisplayBySId: Record<string, { fullName: string }>;
+  isMembersLoading: boolean;
+}
+
+function formatTaskStatusLabel(status: ProjectTaskStatus): string {
+  switch (status) {
+    case "todo":
+      return "Open";
+    case "in_progress":
+      return "In progress";
+    case "done":
+      return "Done";
+    default:
+      assertNeverAndIgnore(status);
+      return status;
+  }
+}
+
+function normalizeAssigneeUserId(
+  userId: string | null | undefined
+): string | null {
+  if (
+    userId === null ||
+    userId === undefined ||
+    userId === "" ||
+    userId === "null"
+  ) {
+    return null;
+  }
+  return userId;
+}
+
+function formatAssigneeLabel({
+  userId,
+  currentUserSId,
+  memberDisplayBySId,
+  isMembersLoading,
+}: FormatAssigneeLabelParams): string {
+  if (userId === null || userId === undefined) {
+    return PROJECT_TASK_NO_ASSIGNEE_LABEL;
+  }
+  if (userId === currentUserSId) {
+    return "You";
+  }
+  const member = memberDisplayBySId[userId];
+  if (member) {
+    return member.fullName;
+  }
+  if (isMembersLoading) {
+    return "Loading…";
+  }
+  return userId;
+}
+
+function ChangeRow({ label, before, after }: ChangeRowProps) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-xs font-medium text-muted-foreground dark:text-muted-foreground-night">
+        {label}
+      </span>
+      <div className="flex flex-wrap items-center gap-2 text-sm text-foreground dark:text-foreground-night">
+        <span className="text-muted-foreground line-through dark:text-muted-foreground-night">
+          {before}
+        </span>
+        <span className="text-muted-foreground dark:text-muted-foreground-night">
+          →
+        </span>
+        <span className="font-medium">{after}</span>
+      </div>
+    </div>
+  );
+}
+
+function AssigneeChangeRow({
+  currentAssigneeSId,
+  nextAssigneeSId,
+  currentUserSId,
+  memberDisplayBySId,
+  isMembersLoading,
+}: AssigneeChangeRowProps) {
+  const beforeLabel = formatAssigneeLabel({
+    userId: currentAssigneeSId,
+    currentUserSId,
+    memberDisplayBySId,
+    isMembersLoading,
+  });
+  const afterLabel = formatAssigneeLabel({
+    userId: nextAssigneeSId,
+    currentUserSId,
+    memberDisplayBySId,
+    isMembersLoading,
+  });
+  const currentMember = currentAssigneeSId
+    ? memberDisplayBySId[currentAssigneeSId]
+    : null;
+  const isUnassigning = nextAssigneeSId === null && currentAssigneeSId !== null;
+
+  if (isUnassigning) {
+    return (
+      <div className="flex flex-col gap-1.5">
+        <span className="text-xs font-medium text-muted-foreground dark:text-muted-foreground-night">
+          Assignee
+        </span>
+        <div className="flex items-center gap-3">
+          <Avatar
+            size="xs"
+            visual={currentMember?.image ?? null}
+            name={currentMember?.fullName ?? beforeLabel}
+            isRounded
+          />
+          <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground dark:text-foreground-night">
+            {beforeLabel}
+          </span>
+          <Chip size="xs" color="rose" label="Unassign" />
+        </div>
+      </div>
+    );
+  }
+
+  return <ChangeRow label="Assignee" before={beforeLabel} after={afterLabel} />;
+}
+
+function TaskUpdateRow({ workspaceId, taskInput, user }: TaskUpdateRowProps) {
+  const { task: currentTask, isWorkspaceProjectTaskLoading } =
+    useWorkspaceProjectTask({
+      workspaceId,
+      taskSId: taskInput.taskId,
+    });
+
+  const memberSIds = useMemo(() => {
+    const ids = new Set<string>();
+    if (currentTask?.user?.sId) {
+      ids.add(currentTask.user.sId);
+    }
+    if (taskInput.userId !== undefined) {
+      const normalizedNextAssigneeSId = normalizeAssigneeUserId(
+        taskInput.userId
+      );
+      if (normalizedNextAssigneeSId) {
+        ids.add(normalizedNextAssigneeSId);
+      }
+    }
+    return [...ids];
+  }, [currentTask?.user?.sId, taskInput.userId]);
+
+  const { membersBySId, isMembersLoading } = useMemberDetails({
+    workspaceId,
+    userIds: memberSIds,
+  });
+
+  const effectiveStatus: ProjectTaskStatus = taskInput.doneRationale
+    ? "done"
+    : (taskInput.status ?? currentTask?.status ?? "todo");
+
+  const currentAssigneeSId = currentTask?.user?.sId ?? null;
+  const nextAssigneeSId =
+    taskInput.userId !== undefined
+      ? normalizeAssigneeUserId(taskInput.userId)
+      : currentAssigneeSId;
+
+  const textChange =
+    taskInput.text !== undefined && taskInput.text !== currentTask?.text;
+  const assigneeChange =
+    taskInput.userId !== undefined && nextAssigneeSId !== currentAssigneeSId;
+  const currentStatus = currentTask?.status;
+  const statusChange =
+    currentStatus !== undefined && effectiveStatus !== currentStatus;
+  const displayText = taskInput.text ?? currentTask?.text ?? taskInput.taskId;
+  const isDone = effectiveStatus === "done";
+
+  if (isWorkspaceProjectTaskLoading) {
+    return (
+      <div className="flex items-center justify-center px-3 py-6">
+        <Spinner size="sm" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-start gap-3 px-3 py-3">
+      <div className="mt-0.5 shrink-0">
+        <Checkbox size="xs" checked={isDone} disabled />
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col gap-2">
+        <div className="flex flex-wrap items-start gap-2">
+          <p className="min-w-0 flex-1 break-words text-sm leading-5 text-foreground dark:text-foreground-night">
+            {displayText}
+          </p>
+          {isDone && <Chip size="xs" color="green" label="Done" />}
+        </div>
+
+        {currentTask ? (
+          <div className="mt-2 flex flex-col gap-2">
+            {textChange && (
+              <ChangeRow
+                label="Description"
+                before={currentTask.text}
+                after={taskInput.text ?? currentTask.text}
+              />
+            )}
+            {assigneeChange && (
+              <AssigneeChangeRow
+                currentAssigneeSId={currentAssigneeSId}
+                nextAssigneeSId={nextAssigneeSId}
+                currentUserSId={user.sId}
+                memberDisplayBySId={membersBySId}
+                isMembersLoading={isMembersLoading}
+              />
+            )}
+            {statusChange && (
+              <ChangeRow
+                label="Status"
+                before={formatTaskStatusLabel(currentTask.status)}
+                after={formatTaskStatusLabel(effectiveStatus)}
+              />
+            )}
+            {taskInput.doneRationale && (
+              <div className="flex flex-col gap-0.5">
+                <span className="text-xs font-medium text-muted-foreground dark:text-muted-foreground-night">
+                  Done rationale
+                </span>
+                <p className="text-sm italic text-foreground dark:text-foreground-night">
+                  {taskInput.doneRationale}
+                </p>
+              </div>
+            )}
+            {!textChange &&
+              !assigneeChange &&
+              !statusChange &&
+              !taskInput.doneRationale && (
+                <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                  No visible changes detected.
+                </p>
+              )}
+          </div>
+        ) : (
+          <div className="mt-2 flex flex-col gap-2">
+            <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+              Could not load the current task details.
+            </p>
+            {taskInput.text && (
+              <ChangeRow
+                label="Description"
+                before="—"
+                after={taskInput.text}
+              />
+            )}
+            {taskInput.userId !== undefined &&
+              normalizeAssigneeUserId(taskInput.userId) !== null && (
+                <ChangeRow
+                  label="Assignee"
+                  before="—"
+                  after={formatAssigneeLabel({
+                    userId: normalizeAssigneeUserId(taskInput.userId),
+                    currentUserSId: user.sId,
+                    memberDisplayBySId: membersBySId,
+                    isMembersLoading,
+                  })}
+                />
+              )}
+            {taskInput.userId !== undefined &&
+              normalizeAssigneeUserId(taskInput.userId) === null && (
+                <ChangeRow
+                  label="Assignee"
+                  before="—"
+                  after={PROJECT_TASK_NO_ASSIGNEE_LABEL}
+                />
+              )}
+            {taskInput.status && (
+              <ChangeRow
+                label="Status"
+                before="—"
+                after={formatTaskStatusLabel(taskInput.status)}
+              />
+            )}
+            {taskInput.doneRationale && (
+              <div className="flex flex-col gap-0.5">
+                <span className="text-xs font-medium text-muted-foreground dark:text-muted-foreground-night">
+                  Done rationale
+                </span>
+                <p className="text-sm italic text-foreground dark:text-foreground-night">
+                  {taskInput.doneRationale}
+                </p>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function PodTasksUpdateValidationDetails({
+  input,
+  owner,
+  user,
+  conversationId,
+}: PodTasksUpdateValidationDetailsProps) {
+  const { podLabel, isPodLabelLoading } = usePodLabel({
+    owner,
+    dustPodUri: input.dustPod?.uri,
+    conversationId,
+  });
+
+  const taskCount = input.tasks.length;
+  const doneCount = input.tasks.filter((task) => task.doneRationale).length;
+
+  return (
+    <div className="flex flex-col gap-3 pt-2">
+      <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        The agent wants to update{" "}
+        <span className="font-medium text-foreground dark:text-foreground-night">
+          {taskCount}
+        </span>{" "}
+        task{taskCount === 1 ? "" : "s"} in{" "}
+        <span className="font-medium text-foreground dark:text-foreground-night">
+          {isPodLabelLoading ? "Loading…" : podLabel}
+        </span>
+        .{doneCount > 0 && <> {doneCount} will be marked as done.</>}
+      </p>
+
+      <div className="divide-y divide-separator overflow-hidden rounded-xl border border-separator bg-background dark:divide-separator-night dark:border-separator-night dark:bg-background-night">
+        {input.tasks.map((taskInput) => (
+          <TaskUpdateRow
+            key={taskInput.taskId}
+            workspaceId={owner.sId}
+            taskInput={taskInput}
+            user={user}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/tool_validation/usePodLabel.ts
+++ b/front/components/assistant/conversation/tool_validation/usePodLabel.ts
@@ -1,0 +1,50 @@
+import { useConversation } from "@app/hooks/conversations/useConversation";
+import { parseProjectConfigurationURI } from "@app/lib/actions/mcp_internal_actions/project_configuration_uri";
+import { useSpaceInfo } from "@app/lib/swr/spaces";
+import type { LightWorkspaceType } from "@app/types/user";
+
+import { useMemo } from "react";
+
+export function usePodLabel({
+  owner,
+  dustPodUri,
+  conversationId,
+}: {
+  owner: LightWorkspaceType;
+  dustPodUri: string | undefined;
+  conversationId: string | null | undefined;
+}) {
+  const { conversation, isConversationLoading } = useConversation({
+    workspaceId: owner.sId,
+    conversationId: conversationId ?? null,
+    options: { disabled: !conversationId },
+  });
+
+  const podSpaceId = useMemo(() => {
+    if (dustPodUri) {
+      const parsed = parseProjectConfigurationURI(dustPodUri);
+      if (parsed.isOk()) {
+        return parsed.value.projectId;
+      }
+      return null;
+    }
+    return conversation?.spaceId ?? null;
+  }, [conversation?.spaceId, dustPodUri]);
+
+  const isWaitingForConversationSpaceId =
+    !dustPodUri && !!conversationId && isConversationLoading;
+
+  const { spaceInfo, isSpaceInfoLoading } = useSpaceInfo({
+    workspaceId: owner.sId,
+    spaceId: podSpaceId,
+    disabled: !podSpaceId,
+  });
+
+  const isPodLabelLoading =
+    isWaitingForConversationSpaceId ||
+    (podSpaceId !== null && isSpaceInfoLoading && !spaceInfo);
+
+  const podLabel = spaceInfo?.name ?? (isPodLabelLoading ? null : "this Pod");
+
+  return { podLabel, isPodLabelLoading };
+}

--- a/front/components/assistant/details/MemberDetails.tsx
+++ b/front/components/assistant/details/MemberDetails.tsx
@@ -43,11 +43,10 @@ const getRoleBadgeColor = (
 };
 
 export function MemberDetails({ userId, onClose, owner }: MemberDetailsProps) {
-  const { userDetails, isUserDetailsLoading, isUserDetailsError } =
-    useMemberDetails({
-      workspaceId: owner.sId,
-      userId: userId,
-    });
+  const { userDetails, isMembersLoading, isMembersError } = useMemberDetails({
+    workspaceId: owner.sId,
+    userIds: userId ? [userId] : [],
+  });
 
   return (
     <Sheet open={!!userId} onOpenChange={onClose}>
@@ -55,11 +54,11 @@ export function MemberDetails({ userId, onClose, owner }: MemberDetailsProps) {
         <VisuallyHidden>
           <SheetTitle />
         </VisuallyHidden>
-        {isUserDetailsLoading ? (
+        {isMembersLoading ? (
           <div className="flex h-full w-full items-center justify-center">
             <Spinner size="lg" />
           </div>
-        ) : isUserDetailsError ? (
+        ) : isMembersError ? (
           <ContentMessage title="Not Available" icon={LockIcon} size="md">
             This user is not available.
           </ContentMessage>

--- a/front/components/markdown/TaskDirectiveBlock.tsx
+++ b/front/components/markdown/TaskDirectiveBlock.tsx
@@ -2,8 +2,10 @@ import { ConversationSidebarStatusDot } from "@app/components/assistant/conversa
 import { ProjectTaskStartWorkingDropdown } from "@app/components/assistant/conversation/space/conversations/project_tasks/ProjectTaskStartWorkingDropdown";
 import { useAppRouter } from "@app/lib/platform";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
-import { useStartProjectTaskConversation } from "@app/lib/swr/projects";
-import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import {
+  useStartProjectTaskConversation,
+  useWorkspaceProjectTask,
+} from "@app/lib/swr/projects";
 import { timeAgoFrom } from "@app/lib/utils";
 import type { ConversationDotStatus } from "@app/lib/utils/conversation_dot_status";
 import { getConversationRoute, getPodRoute } from "@app/lib/utils/router";
@@ -29,7 +31,6 @@ import {
   Tooltip,
 } from "@dust-tt/sparkle";
 import { useMemo, useState } from "react";
-import type { Fetcher } from "swr";
 import { visit } from "unist-util-visit";
 
 function formatTaskStatusLabel(status: ProjectTaskStatus): string {
@@ -306,12 +307,16 @@ function TaskDirectivePopoverContent({
   owner: LightWorkspaceType;
   taskSId: string;
 }) {
-  const { fetcher } = useFetcher();
-  const url = `/api/w/${owner.sId}/project_tasks/${encodeURIComponent(taskSId)}`;
-  const { data, error, isLoading, mutate } = useSWRWithDefaults(
-    url,
-    fetcher as Fetcher<GetWorkspaceProjectTaskResponseBody, string>
-  );
+  const {
+    task,
+    space,
+    isWorkspaceProjectTaskLoading,
+    isWorkspaceProjectTaskError,
+    mutateWorkspaceProjectTask,
+  } = useWorkspaceProjectTask({
+    workspaceId: owner.sId,
+    taskSId,
+  });
 
   const { agentConfigurations, isLoading: agentsLoading } =
     useUnifiedAgentConfigurations({
@@ -325,7 +330,7 @@ function TaskDirectivePopoverContent({
     return agents;
   }, [agentConfigurations]);
 
-  if (isLoading) {
+  if (isWorkspaceProjectTaskLoading) {
     return (
       <div className="flex min-h-[7rem] items-center justify-center p-3">
         <Spinner size="sm" />
@@ -333,7 +338,7 @@ function TaskDirectivePopoverContent({
     );
   }
 
-  if (error || !data) {
+  if (isWorkspaceProjectTaskError || !task || !space) {
     return (
       <div className="p-3 text-center text-sm text-muted-foreground dark:text-muted-foreground-night">
         Could not load this task.
@@ -345,10 +350,10 @@ function TaskDirectivePopoverContent({
     <TaskDirectivePopoverBodyLoaded
       owner={owner}
       taskSId={taskSId}
-      data={data}
+      data={{ task, space }}
       activeAgents={activeAgents}
       agentsLoading={agentsLoading}
-      onTaskUpdated={() => void mutate()}
+      onTaskUpdated={() => void mutateWorkspaceProjectTask()}
     />
   );
 }

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -491,7 +491,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "list_tasks": "never_ask",
     "mark_task_done": "low",
     "start_task_agent": "low",
-    "update_task": "low",
+    "update_tasks": "low",
   },
   "poke": {
     "check_notion_page": "high",

--- a/front/lib/actions/mcp_internal_actions/project_configuration_uri.ts
+++ b/front/lib/actions/mcp_internal_actions/project_configuration_uri.ts
@@ -1,6 +1,30 @@
+import { PROJECT_CONFIGURATION_URI_PATTERN } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import { Err, Ok, type Result } from "@app/types/shared/result";
+
 export function makeProjectConfigurationURI(
   workspaceId: string,
   projectId: string
 ): string {
   return `project://dust/w/${workspaceId}/projects/${projectId}`;
+}
+
+export type ProjectConfigInfo = {
+  workspaceId: string;
+  projectId: string;
+};
+
+export function parseProjectConfigurationURI(
+  uri: string
+): Result<ProjectConfigInfo, Error> {
+  const match = uri.match(PROJECT_CONFIGURATION_URI_PATTERN);
+  if (!match) {
+    return new Err(new Error(`Invalid URI for a pod configuration: ${uri}`));
+  }
+
+  const [, workspaceId, projectId] = match;
+
+  return new Ok({
+    workspaceId,
+    projectId,
+  });
 }

--- a/front/lib/actions/mcp_internal_actions/tools/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/utils.ts
@@ -5,9 +5,12 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import {
   DATA_SOURCE_CONFIGURATION_URI_PATTERN,
-  PROJECT_CONFIGURATION_URI_PATTERN,
   TABLE_CONFIGURATION_URI_PATTERN,
 } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import {
+  type ProjectConfigInfo,
+  parseProjectConfigurationURI,
+} from "@app/lib/actions/mcp_internal_actions/project_configuration_uri";
 import type { TagsInputType } from "@app/lib/actions/mcp_internal_actions/types";
 import type {
   DataSourceConfiguration,
@@ -564,23 +567,5 @@ export async function getCoreSearchArgs(
   return new Ok(toCoreSearchArgs(configRes.value));
 }
 
-export type ProjectConfigInfo = {
-  workspaceId: string;
-  projectId: string;
-};
-
-export function parseProjectConfigurationURI(
-  uri: string
-): Result<ProjectConfigInfo, Error> {
-  const match = uri.match(PROJECT_CONFIGURATION_URI_PATTERN);
-  if (!match) {
-    return new Err(new Error(`Invalid URI for a pod configuration: ${uri}`));
-  }
-
-  const [, workspaceId, projectId] = match;
-
-  return new Ok({
-    workspaceId,
-    projectId,
-  });
-}
+export type { ProjectConfigInfo };
+export { parseProjectConfigurationURI };

--- a/front/lib/api/actions/servers/pod_manager/metadata.ts
+++ b/front/lib/api/actions/servers/pod_manager/metadata.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const POD_MANAGER_SERVER_NAME = "pod_manager" as const;
+export const UPDATE_MEMBERS_TOOL_NAME = "update_members" as const;
 
 export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
   add_content_node: {

--- a/front/lib/api/actions/servers/pod_manager/types.ts
+++ b/front/lib/api/actions/servers/pod_manager/types.ts
@@ -1,0 +1,18 @@
+import { DustProjectConfigurationSchema } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import { z } from "zod";
+
+export const PodManagerUpdateMembersInputSchema = z.object({
+  addMemberIds: z.array(z.string()).optional(),
+  removeMemberIds: z.array(z.string()).optional(),
+  dustPod: DustProjectConfigurationSchema.optional(),
+});
+
+export type PodManagerUpdateMembersInput = z.infer<
+  typeof PodManagerUpdateMembersInputSchema
+>;
+
+export function isPodManagerUpdateMembersInput(
+  input: Record<string, unknown>
+): input is PodManagerUpdateMembersInput {
+  return PodManagerUpdateMembersInputSchema.safeParse(input).success;
+}

--- a/front/lib/api/actions/servers/pod_tasks/metadata.ts
+++ b/front/lib/api/actions/servers/pod_tasks/metadata.ts
@@ -1,12 +1,18 @@
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import {
+  PodTasksCreateTasksInputSchema,
+  PodTasksUpdateTasksInputSchema,
+} from "@app/lib/api/actions/servers/pod_tasks/types";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const POD_TASKS_SERVER_NAME = "pod_tasks" as const;
+export const CREATE_TASKS_TOOL_NAME = "create_tasks" as const;
+export const UPDATE_TASKS_TOOL_NAME = "update_tasks" as const;
 
 export const POD_TASKS_TOOLS_METADATA = createToolsRecord({
   list_tasks: {
@@ -53,67 +59,7 @@ export const POD_TASKS_TOOLS_METADATA = createToolsRecord({
   create_tasks: {
     description:
       "Create one or more new tasks at once in the Pod. Omitting userId (or null) creates an unassigned task unless the Pod has exactly one assignable member, in which case that member is assigned. Pass userId when a specific person should own the task.",
-    schema: {
-      creatorType: z
-        .enum(["user", "agent"])
-        .describe(
-          "Who is initiating the task creation? Use 'user' when the user explicitly asked for it."
-        ),
-      tasks: z
-        .array(
-          z.object({
-            text: z
-              .string()
-              .min(16)
-              .max(256)
-              .describe(
-                "The task description. Do not include the assignee's name — " +
-                  "the assignee is tracked separately via userId. Refer to the " +
-                  "assignee with 'you'/'your' pronouns when needed."
-              ),
-            userId: z
-              .union([z.string(), z.null()])
-              .optional()
-              .describe(
-                "Pod member's user sId to assign this task to. Omit userId entirely (or use null) for an unassigned task, unless the Pod has exactly one assignable member (then that member is assigned)."
-              ),
-            doneRationale: z
-              .string()
-              .optional()
-              .describe(
-                "The rationale for marking the task as done. Leave empty if the task should not be marked as done."
-              ),
-            sources: z
-              .array(
-                z.object({
-                  url: z
-                    .string()
-                    .url()
-                    .describe(
-                      "URL of a related source (e.g. Slack thread, GitHub issue, Notion page)"
-                    ),
-                  title: z
-                    .string()
-                    .describe("Human-readable title for the source"),
-                })
-              )
-              .optional()
-              .describe(
-                "Optional context sources to attach to this task when the agent can provide them"
-              ),
-          })
-        )
-        .min(1)
-        .max(30)
-        .describe("List of tasks to create (max 30)."),
-      dustPod: ConfigurableToolInputSchemas[
-        INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
-      ]
-        .optional()
-        .describe(
-          "Optional Pod to create the tasks in; falls back to the conversation's Pod."
-        ),
-    },
+    schema: PodTasksCreateTasksInputSchema.shape,
     stake: "low",
     displayLabels: {
       running: "Creating tasks",
@@ -147,45 +93,13 @@ export const POD_TASKS_TOOLS_METADATA = createToolsRecord({
       done: "Mark tasks as done",
     },
   },
-  update_task: {
-    description: "Update a task.",
-    schema: {
-      taskId: z.string().describe("The sId of the task."),
-      text: z
-        .string()
-        .min(16)
-        .max(256)
-        .optional()
-        .describe("The new task description."),
-      userId: z
-        .string()
-        .optional()
-        .describe(
-          "The sId of the user to assign the task to; must be a member of the Pod. Defaults to the current user."
-        ),
-      doneRationale: z
-        .string()
-        .optional()
-        .describe(
-          "The rationale for marking the task as done. Leave empty if the task should not be marked as done."
-        ),
-      status: z
-        .enum(["todo", "in_progress", "done"])
-        .optional()
-        .describe("The new task status. Defaults to the current status."),
-
-      dustPod: ConfigurableToolInputSchemas[
-        INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
-      ]
-        .optional()
-        .describe(
-          "Optional Pod to look up the task in; falls back to the conversation's Pod."
-        ),
-    },
+  update_tasks: {
+    description: "Update one or more existing tasks at once in the Pod.",
+    schema: PodTasksUpdateTasksInputSchema.shape,
     stake: "low",
     displayLabels: {
-      running: "Updating task",
-      done: "Update task",
+      running: "Updating tasks",
+      done: "Update tasks",
     },
   },
   start_task_agent: {

--- a/front/lib/api/actions/servers/pod_tasks/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_tasks/tools/index.ts
@@ -16,12 +16,59 @@ import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
 import { startAgentForProjectTask } from "@app/lib/project_task/start_agent";
 import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { getConversationRoute } from "@app/lib/utils/router";
+import type { ProjectTaskStatus } from "@app/types/project_task";
 import { PROJECT_TASK_NO_ASSIGNEE_LABEL } from "@app/types/project_task";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Err, Ok } from "@app/types/shared/result";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+type PodTaskUpdateItem = {
+  taskId: string;
+  text?: string;
+  userId?: string | null;
+  doneRationale?: string;
+  status?: ProjectTaskStatus;
+};
+
+async function buildTaskUpdatePayload(
+  space: SpaceResource,
+  workspaceSId: string,
+  row: ProjectTaskResource,
+  item: PodTaskUpdateItem
+): Promise<
+  | { updates: Parameters<ProjectTaskResource["updateWithVersion"]>[1] }
+  | { error: string }
+> {
+  const updates: Parameters<ProjectTaskResource["updateWithVersion"]>[1] = {
+    status: item.doneRationale ? "done" : (item.status ?? row.status),
+    doneAt: item.doneRationale ? new Date() : null,
+    actorRationale: item.doneRationale ?? row.actorRationale,
+  };
+
+  if (item.text !== undefined) {
+    updates.text = item.text;
+  }
+
+  if (item.userId === null) {
+    updates.userId = null;
+  } else if (typeof item.userId === "string") {
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      item.userId,
+      workspaceSId
+    );
+    if (!space.isMember(userAuth)) {
+      return {
+        error: `User ${item.userId} is not a member of the Pod for task ${item.taskId}.`,
+      };
+    }
+    updates.userId = userAuth.getNonNullableUser().id;
+  }
+
+  return { updates };
+}
 
 function formatTaskListingLine(row: ProjectTaskResource): string {
   const json = row.toJSON();
@@ -289,14 +336,7 @@ export function createProjectTasksTools(
       }, "Failed to mark task as done");
     },
 
-    update_task: async ({
-      taskId,
-      text,
-      userId,
-      doneRationale,
-      status,
-      dustPod,
-    }) => {
+    update_tasks: async ({ tasks, dustPod }) => {
       return withErrorHandling(async () => {
         const contextRes = await getProjectSpace(auth, {
           agentLoopContext,
@@ -305,46 +345,48 @@ export function createProjectTasksTools(
         if (contextRes.isErr()) {
           return contextRes;
         }
+        const { space } = contextRes.value;
 
-        const row = await ProjectTaskResource.fetchBySId(auth, taskId);
+        const updated: string[] = [];
+        const errors: string[] = [];
 
-        if (!row) {
-          return new Err(
-            new MCPError(`Task not found: ${taskId}`, { tracked: false })
-          );
-        }
+        for (const item of tasks) {
+          const row = await ProjectTaskResource.fetchBySId(auth, item.taskId);
 
-        let newUserModelId: ModelId | undefined;
-        if (userId) {
-          const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
-            userId,
-            owner.sId
-          );
-          if (!contextRes.value.space.isMember(userAuth)) {
-            return new Err(
-              new MCPError(`User is not a member of the Pod.`, {
-                tracked: false,
-              })
-            );
+          if (!row) {
+            errors.push(`Task not found: ${item.taskId}`);
+            continue;
           }
-          newUserModelId = userAuth.getNonNullableUser().id;
-        }
 
-        await row.updateWithVersion(auth, {
-          text: text,
-          userId: newUserModelId ?? row.userId,
-          status: doneRationale ? "done" : (status ?? row.status),
-          doneAt: doneRationale ? new Date() : null,
-          actorRationale: doneRationale ?? row.actorRationale,
-        });
+          const payloadRes = await buildTaskUpdatePayload(
+            space,
+            owner.sId,
+            row,
+            item
+          );
+          if ("error" in payloadRes) {
+            errors.push(payloadRes.error);
+            continue;
+          }
+
+          const updatedRow = await row.updateWithVersion(
+            auth,
+            payloadRes.updates
+          );
+          updated.push(formatTaskListingLine(updatedRow));
+        }
 
         return new Ok([
           {
             type: "text" as const,
-            text: `Task updated: "${row.text}"`,
+            text: [
+              `Updated ${updated.length} task(s):`,
+              ...updated.map((line) => line),
+              ...errors.map((error) => `- ${error}`),
+            ].join("\n"),
           },
         ]);
-      }, "Failed to update task");
+      }, "Failed to update tasks");
     },
 
     start_task_agent: async ({ taskId, agentName, customMessage, dustPod }) => {

--- a/front/lib/api/actions/servers/pod_tasks/types.ts
+++ b/front/lib/api/actions/servers/pod_tasks/types.ts
@@ -1,0 +1,125 @@
+import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import { z } from "zod";
+
+const PodTasksDustPodInputSchema =
+  ConfigurableToolInputSchemas[
+    INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
+  ].optional();
+
+export const PodTasksCreateTaskSourceInputSchema = z.object({
+  url: z
+    .string()
+    .url()
+    .describe(
+      "URL of a related source (e.g. Slack thread, GitHub issue, Notion page)"
+    ),
+  title: z.string().describe("Human-readable title for the source"),
+});
+
+export const PodTasksCreateTaskInputSchema = z.object({
+  text: z
+    .string()
+    .min(16)
+    .max(256)
+    .describe(
+      "The task description. Do not include the assignee's name — " +
+        "the assignee is tracked separately via userId. Refer to the " +
+        "assignee with 'you'/'your' pronouns when needed."
+    ),
+  userId: z
+    .union([z.string(), z.null()])
+    .optional()
+    .describe(
+      "Pod member's user sId to assign this task to. Omit userId entirely (or use null) for an unassigned task, unless the Pod has exactly one assignable member (then that member is assigned)."
+    ),
+  doneRationale: z
+    .string()
+    .optional()
+    .describe(
+      "The rationale for marking the task as done. Leave empty if the task should not be marked as done."
+    ),
+  sources: z
+    .array(PodTasksCreateTaskSourceInputSchema)
+    .optional()
+    .describe(
+      "Optional context sources to attach to this task when the agent can provide them"
+    ),
+});
+
+export const PodTasksCreateTasksInputSchema = z.object({
+  creatorType: z
+    .enum(["user", "agent"])
+    .describe(
+      "Who is initiating the task creation? Use 'user' when the user explicitly asked for it."
+    ),
+  tasks: z
+    .array(PodTasksCreateTaskInputSchema)
+    .min(1)
+    .max(30)
+    .describe("List of tasks to create (max 30)."),
+  dustPod: PodTasksDustPodInputSchema.describe(
+    "Optional Pod to create the tasks in; falls back to the conversation's Pod."
+  ),
+});
+
+export type PodTasksCreateTasksInput = z.infer<
+  typeof PodTasksCreateTasksInputSchema
+>;
+
+export function isPodTasksCreateTasksInput(
+  input: Record<string, unknown>
+): input is PodTasksCreateTasksInput {
+  return PodTasksCreateTasksInputSchema.safeParse(input).success;
+}
+
+export const PodTasksUpdateTaskItemInputSchema = z.object({
+  taskId: z.string().describe("The sId of the task to update."),
+  text: z
+    .string()
+    .min(16)
+    .max(256)
+    .optional()
+    .describe("The new task description."),
+  userId: z
+    .union([z.string(), z.null()])
+    .optional()
+    .describe(
+      "The sId of the user to assign the task to; must be a member of the Pod. Pass null to unassign. Omit to keep the current assignee."
+    ),
+  doneRationale: z
+    .string()
+    .optional()
+    .describe(
+      "The rationale for marking the task as done. Leave empty if the task should not be marked as done."
+    ),
+  status: z
+    .enum(["todo", "in_progress", "done"])
+    .optional()
+    .describe("The new task status. Defaults to the current status."),
+});
+
+export const PodTasksUpdateTasksInputSchema = z.object({
+  tasks: z
+    .array(PodTasksUpdateTaskItemInputSchema)
+    .min(1)
+    .max(30)
+    .describe("List of tasks to update (max 30)."),
+  dustPod: PodTasksDustPodInputSchema.describe(
+    "Optional Pod to look up the tasks in; falls back to the conversation's Pod."
+  ),
+});
+
+export type PodTasksUpdateTasksInput = z.infer<
+  typeof PodTasksUpdateTasksInputSchema
+>;
+
+export type PodTasksUpdateTaskItemInput = z.infer<
+  typeof PodTasksUpdateTaskItemInputSchema
+>;
+
+export function isPodTasksUpdateTasksInput(
+  input: Record<string, unknown>
+): input is PodTasksUpdateTasksInput {
+  return PodTasksUpdateTasksInputSchema.safeParse(input).success;
+}

--- a/front/lib/resources/project_task_resource.test.ts
+++ b/front/lib/resources/project_task_resource.test.ts
@@ -6,6 +6,8 @@ import type { ProjectTaskModel } from "@app/lib/resources/storage/models/project
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { CreationAttributes } from "sequelize";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -66,6 +68,11 @@ describe("ProjectTaskResource", () => {
       expect(todo.userId).toBe(user.id);
       expect(todo.text).toBe("My todo");
       expect(todo.status).toBe("todo");
+      expect(todo.toJSON().user).toEqual({
+        sId: user.sId,
+        fullName: user.fullName(),
+        image: user.imageUrl,
+      });
     });
 
     it("should compute the same sId as modelIdToSId", async () => {
@@ -241,6 +248,38 @@ describe("ProjectTaskResource", () => {
       expect(updated.status).toBe("done");
       expect(updated.markedAsDoneByType).toBe("user");
       expect(updated.markedAsDoneByUserId).toBe(user.id);
+    });
+
+    it("should refresh assignee in toJSON after userId is updated", async () => {
+      const todo = await ProjectTaskResource.makeNew(
+        auth,
+        makeTodoBlob(space.id, user.id)
+      );
+      expect(todo.toJSON().user?.sId).toBe(user.sId);
+
+      const otherUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+
+      const updated = await todo.updateWithVersion(auth, {
+        userId: otherUser.id,
+      });
+
+      expect(updated.toJSON().user).toEqual({
+        sId: otherUser.sId,
+        fullName: otherUser.fullName(),
+        image: otherUser.imageUrl,
+      });
+    });
+
+    it("should clear assignee in toJSON after userId is set to null", async () => {
+      const todo = await ProjectTaskResource.makeNew(
+        auth,
+        makeTodoBlob(space.id, user.id)
+      );
+
+      const updated = await todo.updateWithVersion(auth, { userId: null });
+
+      expect(updated.toJSON().user).toBeNull();
     });
   });
 

--- a/front/lib/resources/project_task_resource.ts
+++ b/front/lib/resources/project_task_resource.ts
@@ -118,7 +118,22 @@ export class ProjectTaskResource extends BaseResource<ProjectTaskModel> {
         { transaction: t }
       );
 
-      return new this(ProjectTaskModel, todo.get());
+      const todoBlob = todo.get();
+      let assignee: ProjectTaskAssigneeType | null = null;
+      if (todoBlob.userId !== null) {
+        const [user] = await UserResource.fetchByModelIds([todoBlob.userId], {
+          transaction: t,
+        });
+        if (user) {
+          assignee = {
+            sId: user.sId,
+            fullName: user.fullName(),
+            image: user.imageUrl,
+          };
+        }
+      }
+
+      return new this(ProjectTaskModel, todoBlob, { assignee });
     }, transaction);
   }
 
@@ -155,6 +170,15 @@ export class ProjectTaskResource extends BaseResource<ProjectTaskModel> {
     return withTransaction(async (t) => {
       await this.saveVersion(t);
       await this.update(updates, t);
+
+      if (updates.userId !== undefined) {
+        const [refreshed] = await ProjectTaskResource.baseFetch(
+          auth,
+          { where: { id: this.id }, limit: 1 },
+          t
+        );
+        return refreshed ?? this;
+      }
 
       return this;
     }, transaction);

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -1260,26 +1260,109 @@ export function useAgentDatasourceRetrievalDocuments({
   };
 }
 
+export type MemberDisplayInfo = {
+  fullName: string;
+  email: string | null;
+  image: string | null;
+};
+
+function buildMemberDetailsSwrKey(
+  workspaceId: string,
+  userIds: string[]
+): string | null {
+  const normalizedUserIds = [...new Set(userIds.filter(Boolean))].sort();
+  if (normalizedUserIds.length === 0) {
+    return null;
+  }
+  if (normalizedUserIds.length === 1) {
+    return `/api/w/${workspaceId}/members/${normalizedUserIds[0]}`;
+  }
+  const sIdsKey = normalizedUserIds.join(",");
+  return `/api/w/${workspaceId}/members/batch?sIds=${encodeURIComponent(sIdsKey)}`;
+}
+
 export function useMemberDetails({
   workspaceId,
-  userId,
+  userIds,
 }: {
   workspaceId: string;
-  userId: string | null;
+  userIds: string[];
 }) {
   const { fetcher } = useFetcher();
-  const userConfigurationFetcher: Fetcher<GetMemberResponseBody> = fetcher;
-
-  const { data, error, mutate, isValidating } = useSWRWithDefaults(
-    userId ? `/api/w/${workspaceId}/members/${userId}` : null,
-    userConfigurationFetcher
+  const normalizedUserIds = useMemo(
+    () => [...new Set(userIds.filter(Boolean))].sort(),
+    [userIds]
+  );
+  const swrKey = useMemo(
+    () => buildMemberDetailsSwrKey(workspaceId, normalizedUserIds),
+    [workspaceId, normalizedUserIds]
   );
 
+  const memberDetailsFetcher = useCallback(
+    async (
+      key: string
+    ): Promise<
+      | { kind: "single"; member: GetMemberResponseBody["member"] }
+      | { kind: "batch"; membersBySId: Record<string, MemberDisplayInfo> }
+    > => {
+      if (key.includes("/members/batch?")) {
+        const url = new URL(key, "https://dust.local");
+        const sIdsParam = url.searchParams.get("sIds");
+        if (!sIdsParam) {
+          return { kind: "batch", membersBySId: {} };
+        }
+
+        const membersBySId: Record<string, MemberDisplayInfo> = {};
+        for (const memberSId of sIdsParam.split(",")) {
+          try {
+            const response = (await fetcher(
+              `/api/w/${workspaceId}/members/${memberSId}`
+            )) as GetMemberResponseBody;
+
+            membersBySId[memberSId] = {
+              fullName: response.member.fullName,
+              email: response.member.email,
+              image: response.member.image,
+            };
+          } catch {
+            // Member lookup can fail for privacy or membership reasons.
+          }
+        }
+
+        return { kind: "batch", membersBySId };
+      }
+
+      const response = (await fetcher(key)) as GetMemberResponseBody;
+      return { kind: "single", member: response.member };
+    },
+    [fetcher, workspaceId]
+  );
+
+  const { data, error, mutate, isValidating, isLoading } = useSWRWithDefaults(
+    swrKey,
+    memberDetailsFetcher
+  );
+
+  const userDetails = data?.kind === "single" ? data.member : undefined;
+  const membersBySId =
+    data?.kind === "batch"
+      ? data.membersBySId
+      : userDetails
+        ? {
+            [userDetails.id]: {
+              fullName: userDetails.fullName,
+              email: userDetails.email,
+              image: userDetails.image,
+            },
+          }
+        : {};
+
   return {
-    userDetails: data?.member,
-    isUserDetailsLoading: !error && !data && !!userId,
-    isUserDetailsError: error,
-    isUserConfigurationValidating: isValidating,
-    mutateUserConfiguration: mutate,
+    userDetails,
+    membersBySId,
+    isMembersLoading: !error && isLoading && !!swrKey,
+    isMembersError: error,
+    isMembersValidating: isValidating,
+    mutateMembers: mutate,
   };
 }

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -13,6 +13,7 @@ import {
   useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
+import type { GetWorkspaceProjectTaskResponseBody } from "@app/pages/api/w/[wId]/project_tasks/[taskSId]/index";
 import type {
   GCSMountEntry,
   GetSpaceFilesResponseBody,
@@ -840,5 +841,36 @@ export function useStartProjectTaskConversation({
       });
       return new Err(new Error(errorMessage));
     }
+  };
+}
+
+export function useWorkspaceProjectTask({
+  workspaceId,
+  taskSId,
+  disabled,
+}: {
+  workspaceId: string;
+  taskSId: string | null;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const url =
+    !disabled && taskSId
+      ? `/api/w/${workspaceId}/project_tasks/${encodeURIComponent(taskSId)}`
+      : null;
+  const projectTaskFetcher: Fetcher<GetWorkspaceProjectTaskResponseBody> =
+    fetcher;
+
+  const { data, error, isLoading, mutate } = useSWRWithDefaults(
+    url,
+    projectTaskFetcher
+  );
+
+  return {
+    task: data?.task ?? null,
+    space: data?.space ?? null,
+    isWorkspaceProjectTaskLoading: !error && isLoading && !!url,
+    isWorkspaceProjectTaskError: !!error,
+    mutateWorkspaceProjectTask: mutate,
   };
 }


### PR DESCRIPTION
## Description

Adds rich approval UI for Pod MCP tool calls in the `MCPToolValidationRequired` flow. When an agent triggers `create_tasks` or `update_tasks` (`pod_tasks` server), or `update_members` (`pod_manager` server), users now see a structured preview instead of raw JSON:

- **Create tasks**: task list with text, assignee (resolved to name), done status, and source links (Slack/Notion/GitHub/etc.) with per-source icons.
- **Update tasks**: before/after diff fetched via SWR for each task — shows changes to text, assignee, and status.
- **Update members**: add/remove lists with avatars, full names, and emails.

Modal titles in `MCP_TOOL_OVERRIDES` are now context-aware (task count, done count, member add/remove counts). `conversationId` is threaded from `BlockedAction` → `MCPToolValidationRequired` → `ToolValidationDetails` → custom components to support pod label resolution via `usePodLabel`. As part of this refactor, the Ashby detail components are extracted from `ToolValidationDetails.tsx` into `AshbyValidationDetails.tsx`.

<img width="519" height="297" alt="image" src="https://github.com/user-attachments/assets/94ad2a67-59ae-419a-8be0-6155e79a70f6" />

<img width="792" height="709" alt="image" src="https://github.com/user-attachments/assets/96ab85a3-5db1-41b2-ab85-8137baedcc5b" />

<img width="522" height="1096" alt="image" src="https://github.com/user-attachments/assets/3b3d4768-dd60-40fd-8f45-325e221105f1" />


## Tests

Tested manually by triggering Pod task creation, update, and member update flows in the conversation UI.

## Risk

Low. UI-only changes scoped to the MCP tool validation approval modal. Ashby validation is refactored (extracted to a new file) but behavior is unchanged. No API or data model changes.

## Deploy Plan

Deploy front.
