### PR TITLE
Block shrinkwrap option for mobile users

### DIFF
--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -22,6 +22,7 @@ import { useClientType } from "@app/lib/context/clientType";
 import { useAppRouter } from "@app/lib/platform";
 import { getSpaceIcon } from "@app/lib/spaces";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { hasHealthyProviders } from "@app/lib/utils/providersHealth";
 import {
   getAgentBuilderRoute,
@@ -167,6 +168,7 @@ export function ConversationMenu({
   const confirm = useContext(ConfirmContext);
 
   const clientType = useClientType();
+  const isMobile = useIsMobile();
 
   const router = useAppRouter();
 
@@ -177,6 +179,7 @@ export function ConversationMenu({
     !!conversation &&
     !!user &&
     !isRestrictedFromAgentCreation &&
+    !isMobile &&
     clientType !== "extension";
   const sendNotification = useSendNotification();
 


### PR DESCRIPTION
## Description

* Blocking shrink wrap option for mobile users. Using the same useIsMobile swr that we use for agent builder