### PR TITLE
[metronome] feat: worspace default per-user usage limits

### DIFF
--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
@@ -1,4 +1,5 @@
 import * as creditStateDispatcher from "@app/lib/api/metronome/credit_state_dispatcher";
+import * as defaultUserCapAlert from "@app/lib/metronome/default_user_cap_alert";
 import * as perUserAlerts from "@app/lib/metronome/per_user_alerts";
 import * as perUserUsage from "@app/lib/metronome/per_user_usage";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
@@ -19,6 +20,16 @@ vi.mock("@app/lib/metronome/per_user_alerts", async () => {
     upsertMetronomePerUserCapAlert: vi.fn(),
     clearMetronomePerUserCapAlert: vi.fn(),
     getMetronomePerUserCap: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/metronome/default_user_cap_alert", async () => {
+  const actual = await vi.importActual<typeof defaultUserCapAlert>(
+    "@app/lib/metronome/default_user_cap_alert"
+  );
+  return {
+    ...actual,
+    getMetronomeDefaultUserCapAlert: vi.fn(),
   };
 });
 
@@ -69,6 +80,9 @@ beforeEach(() => {
   vi.mocked(perUserUsage.fetchPerUserAwuUsage).mockResolvedValue(
     new Ok(new Map())
   );
+  vi.mocked(
+    defaultUserCapAlert.getMetronomeDefaultUserCapAlert
+  ).mockResolvedValue(new Ok(null));
   vi.mocked(creditStateDispatcher.dispatchPerUserCapReached).mockResolvedValue(
     new Ok(undefined)
   );

--- a/front/lib/api/metronome/process_webhook.test.ts
+++ b/front/lib/api/metronome/process_webhook.test.ts
@@ -1,9 +1,17 @@
+import {
+  dispatchPaygCapReached,
+  dispatchPerUserCapReached,
+  dispatchPerUserCapResolved,
+} from "@app/lib/api/metronome/credit_state_dispatcher";
 import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
 import {
   getMetronomeContractById,
   listMetronomeContracts,
 } from "@app/lib/metronome/client";
 import { PLAN_CODE_CUSTOM_FIELD_KEY } from "@app/lib/metronome/constants";
+import * as defaultUserCapAlert from "@app/lib/metronome/default_user_cap_alert";
+import * as perUserAlerts from "@app/lib/metronome/per_user_alerts";
+import type { MetronomeWebhookEvent } from "@app/lib/metronome/webhook_events";
 import { PlanModel } from "@app/lib/models/plan";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
@@ -13,6 +21,7 @@ import {
   launchScheduleWorkspaceScrubWorkflow,
   terminateScheduleWorkspaceScrubWorkflow,
 } from "@app/temporal/scrub_workspace/client";
+import { mockCustomerAlert } from "@app/tests/utils/mocks/metronome";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { Err, Ok } from "@app/types/shared/result";
 import type { ContractV2 } from "@metronome/sdk/resources";
@@ -38,10 +47,43 @@ vi.mock("@app/lib/api/subscription", () => ({
   restoreWorkspaceAfterSubscription: vi.fn(),
 }));
 
+vi.mock("@app/lib/api/metronome/credit_state_dispatcher", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/api/metronome/credit_state_dispatcher")
+  >("@app/lib/api/metronome/credit_state_dispatcher");
+  return {
+    ...actual,
+    dispatchPerUserCapReached: vi.fn(),
+    dispatchPerUserCapResolved: vi.fn(),
+    dispatchPaygCapReached: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/metronome/per_user_alerts", async () => {
+  const actual = await vi.importActual<typeof perUserAlerts>(
+    "@app/lib/metronome/per_user_alerts"
+  );
+  return {
+    ...actual,
+    getMetronomePerUserCap: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/metronome/default_user_cap_alert", async () => {
+  const actual = await vi.importActual<typeof defaultUserCapAlert>(
+    "@app/lib/metronome/default_user_cap_alert"
+  );
+  return {
+    ...actual,
+    getMetronomeDefaultUserCapAlert: vi.fn(),
+  };
+});
+
 const METRONOME_CUSTOMER_ID = "cust_test_xxx";
 const OLD_CONTRACT_ID = "contract_old_xxx";
 const NEW_CONTRACT_ID = "contract_new_yyy";
 const ENT_PLAN_CODE = "ENT_TEST_PLAN";
+const USER_ID = "user_test_xxx";
 
 async function ensureEnterprisePlan(): Promise<void> {
   await PlanModel.upsert({
@@ -91,6 +133,21 @@ function contractEvent(
   };
 }
 
+function spendThresholdEvent(
+  type: "alerts.spend_threshold_reached" | "alerts.spend_threshold_resolved",
+  groupValues?: Array<{ key: string; value?: string }>
+): MetronomeWebhookEvent {
+  return {
+    id: `evt_${type}_xxx`,
+    type,
+    properties: {
+      customer_id: METRONOME_CUSTOMER_ID,
+      current_spend: 1234,
+      group_values: groupValues,
+    },
+  } as MetronomeWebhookEvent;
+}
+
 async function setupMetronomeWorkspace(
   contractId: string,
   { stripeSubscriptionId = null }: { stripeSubscriptionId?: string | null } = {}
@@ -121,6 +178,13 @@ async function setupMetronomeWorkspace(
   return workspace;
 }
 
+async function setupMetronomeWorkspaceResource(): Promise<WorkspaceResource> {
+  const lightWorkspace = await WorkspaceFactory.metronome({
+    metronomeCustomerId: METRONOME_CUSTOMER_ID,
+  });
+  return (await WorkspaceResource.fetchById(lightWorkspace.sId))!;
+}
+
 beforeEach(() => {
   vi.mocked(launchScheduleWorkspaceScrubWorkflow).mockResolvedValue(
     new Ok(undefined as never)
@@ -129,6 +193,15 @@ beforeEach(() => {
     new Ok({} as never)
   );
   vi.mocked(restoreWorkspaceAfterSubscription).mockResolvedValue(undefined);
+  vi.mocked(dispatchPerUserCapReached).mockResolvedValue(new Ok(undefined));
+  vi.mocked(dispatchPerUserCapResolved).mockResolvedValue(new Ok(undefined));
+  vi.mocked(dispatchPaygCapReached).mockResolvedValue(undefined);
+  vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValue(
+    new Ok(null)
+  );
+  vi.mocked(
+    defaultUserCapAlert.getMetronomeDefaultUserCapAlert
+  ).mockResolvedValue(new Ok(null));
 });
 
 describe("processMetronomeWebhook — contract.start", () => {
@@ -454,5 +527,277 @@ describe("processMetronomeWebhook — contract.end", () => {
     );
     expect(sub!.status).toBe("active");
     expect(sub!.metronomeContractId).toBe(OLD_CONTRACT_ID);
+  });
+});
+
+describe("processMetronomeWebhook — per-user spend threshold (no default alert)", () => {
+  it("dispatches reached when override is IN_ALARM (on reached event)", async () => {
+    const workspace = await setupMetronomeWorkspaceResource();
+    vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValue(
+      new Ok(
+        mockCustomerAlert({
+          id: "alert_override_xxx",
+          threshold: 1000,
+          customer_status: "in_alarm",
+        })
+      )
+    );
+
+    const result = await processMetronomeWebhook({
+      event: spendThresholdEvent("alerts.spend_threshold_reached", [
+        { key: "user_id", value: USER_ID },
+      ]),
+      workspace,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(dispatchPerUserCapReached).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: USER_ID })
+    );
+    expect(dispatchPerUserCapResolved).not.toHaveBeenCalled();
+  });
+
+  it("dispatches resolved when override is OK (on resolved event)", async () => {
+    const workspace = await setupMetronomeWorkspaceResource();
+    vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValue(
+      new Ok(
+        mockCustomerAlert({
+          id: "alert_override_xxx",
+          threshold: 1000,
+          customer_status: "ok",
+        })
+      )
+    );
+
+    const result = await processMetronomeWebhook({
+      event: spendThresholdEvent("alerts.spend_threshold_resolved", [
+        { key: "user_id", value: USER_ID },
+      ]),
+      workspace,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(dispatchPerUserCapResolved).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: USER_ID })
+    );
+    expect(dispatchPerUserCapReached).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when neither override nor default is configured (defensive)", async () => {
+    const workspace = await setupMetronomeWorkspaceResource();
+    // getMetronomePerUserCap and getMetronomeDefaultUserCapAlert default to Ok(null).
+
+    const result = await processMetronomeWebhook({
+      event: spendThresholdEvent("alerts.spend_threshold_reached", [
+        { key: "user_id", value: USER_ID },
+      ]),
+      workspace,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(dispatchPerUserCapReached).not.toHaveBeenCalled();
+    // With no alert in place, effective state is "ok" → dispatch resolved.
+    expect(dispatchPerUserCapResolved).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: USER_ID })
+    );
+  });
+
+  it("skips per-user events with no user_id value", async () => {
+    const workspace = await setupMetronomeWorkspaceResource();
+
+    const result = await processMetronomeWebhook({
+      event: spendThresholdEvent("alerts.spend_threshold_reached", [
+        { key: "user_id" },
+      ]),
+      workspace,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(dispatchPerUserCapReached).not.toHaveBeenCalled();
+    expect(dispatchPerUserCapResolved).not.toHaveBeenCalled();
+    // No fetch attempted — handler bails before reading override state.
+    expect(perUserAlerts.getMetronomePerUserCap).not.toHaveBeenCalled();
+  });
+});
+
+describe("processMetronomeWebhook — per-user spend threshold (default alert configured)", () => {
+  it("uses default alert state when no override exists (IN_ALARM → reached)", async () => {
+    const workspace = await setupMetronomeWorkspaceResource();
+    vi.mocked(
+      defaultUserCapAlert.getMetronomeDefaultUserCapAlert
+    ).mockResolvedValue(
+      new Ok(
+        mockCustomerAlert({
+          id: "alert_default_xxx",
+          threshold: 50_000,
+          customer_status: "in_alarm",
+        })
+      )
+    );
+
+    const result = await processMetronomeWebhook({
+      event: spendThresholdEvent("alerts.spend_threshold_reached", [
+        { key: "user_id", value: USER_ID },
+      ]),
+      workspace,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(dispatchPerUserCapReached).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: USER_ID })
+    );
+    expect(dispatchPerUserCapResolved).not.toHaveBeenCalled();
+  });
+
+  it("override (OK) wins over default (IN_ALARM) — dispatches resolved", async () => {
+    const workspace = await setupMetronomeWorkspaceResource();
+    vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValue(
+      new Ok(
+        mockCustomerAlert({
+          id: "alert_override_xxx",
+          threshold: 999_999,
+          customer_status: "ok",
+        })
+      )
+    );
+    vi.mocked(
+      defaultUserCapAlert.getMetronomeDefaultUserCapAlert
+    ).mockResolvedValue(
+      new Ok(
+        mockCustomerAlert({
+          id: "alert_default_xxx",
+          threshold: 1000,
+          customer_status: "in_alarm",
+        })
+      )
+    );
+
+    const result = await processMetronomeWebhook({
+      event: spendThresholdEvent("alerts.spend_threshold_reached", [
+        { key: "user_id", value: USER_ID },
+      ]),
+      workspace,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(dispatchPerUserCapResolved).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: USER_ID })
+    );
+    expect(dispatchPerUserCapReached).not.toHaveBeenCalled();
+    // Override existed → default lookup was skipped.
+    expect(
+      defaultUserCapAlert.getMetronomeDefaultUserCapAlert
+    ).not.toHaveBeenCalled();
+  });
+
+  it("override (IN_ALARM) wins over default (OK) — dispatches reached", async () => {
+    const workspace = await setupMetronomeWorkspaceResource();
+    vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValue(
+      new Ok(
+        mockCustomerAlert({
+          id: "alert_override_xxx",
+          threshold: 100,
+          customer_status: "in_alarm",
+        })
+      )
+    );
+    vi.mocked(
+      defaultUserCapAlert.getMetronomeDefaultUserCapAlert
+    ).mockResolvedValue(
+      new Ok(
+        mockCustomerAlert({
+          id: "alert_default_xxx",
+          threshold: 1_000_000,
+          customer_status: "ok",
+        })
+      )
+    );
+
+    const result = await processMetronomeWebhook({
+      event: spendThresholdEvent("alerts.spend_threshold_resolved", [
+        { key: "user_id", value: USER_ID },
+      ]),
+      workspace,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(dispatchPerUserCapReached).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: USER_ID })
+    );
+    expect(dispatchPerUserCapResolved).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when effective state is EVALUATING", async () => {
+    const workspace = await setupMetronomeWorkspaceResource();
+    vi.mocked(
+      defaultUserCapAlert.getMetronomeDefaultUserCapAlert
+    ).mockResolvedValue(
+      new Ok(
+        mockCustomerAlert({
+          id: "alert_default_xxx",
+          threshold: 50_000,
+          customer_status: "evaluating",
+        })
+      )
+    );
+
+    const result = await processMetronomeWebhook({
+      event: spendThresholdEvent("alerts.spend_threshold_reached", [
+        { key: "user_id", value: USER_ID },
+      ]),
+      workspace,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(dispatchPerUserCapReached).not.toHaveBeenCalled();
+    expect(dispatchPerUserCapResolved).not.toHaveBeenCalled();
+  });
+
+  it("returns processing_failed when override lookup fails", async () => {
+    const workspace = await setupMetronomeWorkspaceResource();
+    vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValue(
+      new Err(new Error("metronome down"))
+    );
+
+    const result = await processMetronomeWebhook({
+      event: spendThresholdEvent("alerts.spend_threshold_reached", [
+        { key: "user_id", value: USER_ID },
+      ]),
+      workspace,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.type).toBe("processing_failed");
+    }
+    expect(dispatchPerUserCapReached).not.toHaveBeenCalled();
+  });
+});
+
+describe("processMetronomeWebhook — workspace-level spend threshold", () => {
+  it("dispatches PAYG cap reached when group_values has no user_id key", async () => {
+    const workspace = await setupMetronomeWorkspaceResource();
+
+    const result = await processMetronomeWebhook({
+      event: spendThresholdEvent("alerts.spend_threshold_reached"),
+      workspace,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(dispatchPaygCapReached).toHaveBeenCalled();
+    expect(dispatchPerUserCapReached).not.toHaveBeenCalled();
+  });
+
+  it("logs and no-ops on workspace-level resolved", async () => {
+    const workspace = await setupMetronomeWorkspaceResource();
+
+    const result = await processMetronomeWebhook({
+      event: spendThresholdEvent("alerts.spend_threshold_resolved"),
+      workspace,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(dispatchPaygCapReached).not.toHaveBeenCalled();
+    expect(dispatchPerUserCapResolved).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -33,6 +33,8 @@ import {
   getProductExcessCreditsId,
   PLAN_CODE_CUSTOM_FIELD_KEY,
 } from "@app/lib/metronome/constants";
+import { getMetronomeDefaultUserCapAlert } from "@app/lib/metronome/default_user_cap_alert";
+import { getMetronomePerUserCap } from "@app/lib/metronome/per_user_alerts";
 import { invalidateContractCache } from "@app/lib/metronome/plan_type";
 import { isMetronomeFreeCredit } from "@app/lib/metronome/types";
 import type { MetronomeWebhookEvent } from "@app/lib/metronome/webhook_events";
@@ -47,6 +49,9 @@ import { launchScheduleWorkspaceScrubWorkflow } from "@app/temporal/scrub_worksp
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import type { CustomerAlert } from "@metronome/sdk/resources/v1/customers";
+
+type MetronomeAlertState = CustomerAlert["customer_status"];
 
 export class ProcessMetronomeWebhookError extends Error {
   constructor(
@@ -187,6 +192,156 @@ async function ensureWorkOSOrganizationForPaidPlan({
   }
 }
 
+/**
+ * Resolve the effective per-user spend-cap state by re-deriving from
+ * Metronome on every event, then dispatch to the local credit-state machine.
+ *
+ * Override-replaces-default: if a per-user override exists, its evaluation
+ * state wins regardless of the default. Otherwise the workspace-wide
+ * default's state is used. With neither configured, the user is uncapped
+ * (defensive — no alert should be firing in that case).
+ *
+ * The dispatch is idempotent: `setUserSpendLimit` and
+ * `setDefaultUserSpendLimit` (PR B) recompute and dispatch eagerly, so the
+ * webhook arriving later either re-confirms the state or skips (when
+ * Metronome is still in `evaluating`).
+ */
+async function handlePerUserSpendThresholdEvent({
+  workspace,
+  userId,
+  event,
+}: {
+  workspace: WorkspaceResource;
+  userId: string;
+  event: MetronomeWebhookEvent;
+}): Promise<Result<undefined, ProcessMetronomeWebhookError>> {
+  const metronomeCustomerId = workspace.metronomeCustomerId;
+  if (!metronomeCustomerId) {
+    logger.warn(
+      { eventId: event.id, eventType: event.type, workspaceId: workspace.sId },
+      "[Metronome Webhook] per-user spend threshold event for workspace without metronomeCustomerId, skipping"
+    );
+    return new Ok(undefined);
+  }
+
+  const overrideResult = await getMetronomePerUserCap({
+    metronomeCustomerId,
+    workspaceId: workspace.sId,
+    userId,
+  });
+  if (overrideResult.isErr()) {
+    return new Err(
+      new ProcessMetronomeWebhookError(
+        "processing_failed",
+        `Error reading per-user cap override: ${overrideResult.error.message}`
+      )
+    );
+  }
+
+  let effectiveState: MetronomeAlertState;
+  let source: "override" | "default" | "none";
+  if (overrideResult.value) {
+    effectiveState = overrideResult.value.customer_status;
+    source = "override";
+  } else {
+    const defaultResult = await getMetronomeDefaultUserCapAlert({
+      metronomeCustomerId,
+      workspaceId: workspace.sId,
+    });
+    if (defaultResult.isErr()) {
+      return new Err(
+        new ProcessMetronomeWebhookError(
+          "processing_failed",
+          `Error reading default user cap: ${defaultResult.error.message}`
+        )
+      );
+    }
+    if (defaultResult.value) {
+      effectiveState = defaultResult.value.customer_status;
+      source = "default";
+    } else {
+      effectiveState = "ok";
+      source = "none";
+    }
+  }
+
+  switch (effectiveState) {
+    case "in_alarm": {
+      const dispatchResult = await dispatchPerUserCapReached({
+        workspace,
+        userId,
+      });
+      if (dispatchResult.isErr()) {
+        logger.error(
+          {
+            eventId: event.id,
+            eventType: event.type,
+            workspaceId: workspace.sId,
+            userId,
+            source,
+            err: dispatchResult.error,
+          },
+          "[Metronome Webhook] per-user spend threshold: dispatchPerUserCapReached failed"
+        );
+        return new Err(
+          new ProcessMetronomeWebhookError(
+            "processing_failed",
+            `Error dispatching per-user cap reached: ${dispatchResult.error.message}`
+          )
+        );
+      }
+      break;
+    }
+    case "ok": {
+      const dispatchResult = await dispatchPerUserCapResolved({
+        workspace,
+        userId,
+      });
+      if (dispatchResult.isErr()) {
+        logger.error(
+          {
+            eventId: event.id,
+            eventType: event.type,
+            workspaceId: workspace.sId,
+            userId,
+            source,
+            err: dispatchResult.error,
+          },
+          "[Metronome Webhook] per-user spend threshold: dispatchPerUserCapResolved failed"
+        );
+        return new Err(
+          new ProcessMetronomeWebhookError(
+            "processing_failed",
+            `Error dispatching per-user cap resolved: ${dispatchResult.error.message}`
+          )
+        );
+      }
+      break;
+    }
+    case "evaluating":
+    case null:
+      // No-op: Metronome hasn't settled yet (or the alert is archived). The
+      // eager dispatch from `setUserSpendLimit` / `setDefaultUserSpendLimit`
+      // already set the right state; a follow-up event will reconcile.
+      break;
+    default:
+      assertNever(effectiveState);
+  }
+
+  logger.info(
+    {
+      eventId: event.id,
+      eventType: event.type,
+      workspaceId: workspace.sId,
+      userId,
+      effectiveState,
+      source,
+    },
+    "[Metronome Webhook] per-user spend threshold: handled"
+  );
+  return new Ok(undefined);
+}
+
 export async function processMetronomeWebhook({
   event,
   workspace,
@@ -218,36 +373,14 @@ export async function processMetronomeWebhook({
           );
           break;
         }
-        const dispatchResult = await dispatchPerUserCapReached({
+        const handleResult = await handlePerUserSpendThresholdEvent({
           workspace,
           userId,
+          event,
         });
-        if (dispatchResult.isErr()) {
-          logger.error(
-            {
-              eventId: event.id,
-              workspaceId: workspace.sId,
-              userId,
-              err: dispatchResult.error,
-            },
-            "[Metronome Webhook] spend_threshold_reached: per_user dispatch failed"
-          );
-          return new Err(
-            new ProcessMetronomeWebhookError(
-              "processing_failed",
-              `Error dispatching per-user cap reached: ${dispatchResult.error.message}`
-            )
-          );
+        if (handleResult.isErr()) {
+          return handleResult;
         }
-        logger.info(
-          {
-            eventId: event.id,
-            workspaceId: workspace.sId,
-            userId,
-            currentSpend: event.properties.current_spend,
-          },
-          "[Metronome Webhook] spend_threshold_reached: per_user dispatched"
-        );
       } else {
         await dispatchPaygCapReached({ workspace });
         logger.info(
@@ -263,12 +396,13 @@ export async function processMetronomeWebhook({
     }
     case "alerts.spend_threshold_resolved": {
       // Per-user: at billing-cycle renewal current_spend resets to 0, so
-      // Metronome fires this for every previously-capped user, we uncap them.
+      // Metronome fires this for every previously-capped user — we re-derive
+      // the effective state (override > default > uncapped) and dispatch.
       //
-      // Workspace-level: a `payg_cap_resolved` event means
-      // spend dropped back below the PAYG threshold. We do not transition
-      // on this signal: once the workspace is `depleted`, only a real
-      // pool replenishment (commit.segment.start) brings it back.
+      // Workspace-level: a `payg_cap_resolved` event means spend dropped
+      // back below the PAYG threshold. We do not transition on this signal:
+      // once the workspace is `depleted`, only a real pool replenishment
+      // (commit.segment.start) brings it back.
       const userIdGroup = event.properties.group_values?.find(
         (g) => g.key === "user_id"
       );
@@ -283,36 +417,14 @@ export async function processMetronomeWebhook({
           );
           break;
         }
-
-        const dispatchResult = await dispatchPerUserCapResolved({
+        const handleResult = await handlePerUserSpendThresholdEvent({
           workspace,
           userId,
+          event,
         });
-        if (dispatchResult.isErr()) {
-          logger.error(
-            {
-              eventId: event.id,
-              workspaceId: workspace.sId,
-              userId,
-              err: dispatchResult.error,
-            },
-            "[Metronome Webhook] spend_threshold_resolved: per-user dispatch failed"
-          );
-          return new Err(
-            new ProcessMetronomeWebhookError(
-              "processing_failed",
-              `Error dispatching per-user cap resolved: ${dispatchResult.error.message}`
-            )
-          );
+        if (handleResult.isErr()) {
+          return handleResult;
         }
-        logger.info(
-          {
-            eventId: event.id,
-            workspaceId: workspace.sId,
-            userId,
-          },
-          "[Metronome Webhook] spend_threshold_resolved: per-user dispatched"
-        );
       } else {
         logger.info(
           { eventId: event.id, workspaceId: workspace.sId },

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -9,6 +9,7 @@ import {
 import { getUserForWorkspace } from "@app/lib/api/user";
 import type { AuditLogContext } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
+import { getMetronomeDefaultUserCapAlert } from "@app/lib/metronome/default_user_cap_alert";
 import {
   clearMetronomePerUserCapAlert,
   getMetronomePerUserCap,
@@ -138,6 +139,32 @@ async function resolveLocalCapState({
   return consumed >= awuCapCredits ? "reached" : "resolved";
 }
 
+async function dispatchTransition({
+  workspace,
+  userId,
+  transitionedTo,
+}: {
+  workspace: WorkspaceResource;
+  userId: string;
+  transitionedTo: "reached" | "resolved";
+}): Promise<void> {
+  const dispatchResult =
+    transitionedTo === "reached"
+      ? await dispatchPerUserCapReached({ workspace, userId })
+      : await dispatchPerUserCapResolved({ workspace, userId });
+  if (dispatchResult.isErr()) {
+    logger.warn(
+      {
+        workspaceId: workspace.sId,
+        userId,
+        transitionedTo,
+        err: dispatchResult.error,
+      },
+      "[Metronome PerUserCap] dispatch after spend-limit update failed; continuing"
+    );
+  }
+}
+
 export async function setUserSpendLimit(
   auth: Authenticator,
   {
@@ -194,21 +221,40 @@ export async function setUserSpendLimit(
           new UserSpendLimitError("metronome_error", clearResult.error.message)
         );
       }
-      const dispatchResult = await dispatchPerUserCapResolved({
-        workspace: workspaceResource,
-        userId: user.sId,
+
+      const defaultResult = await getMetronomeDefaultUserCapAlert({
+        metronomeCustomerId: workspace.metronomeCustomerId,
+        workspaceId: workspace.sId,
       });
-      if (dispatchResult.isErr()) {
-        logger.warn(
-          {
-            workspaceId: workspace.sId,
-            userId: user.sId,
-            err: dispatchResult.error,
-          },
-          "[Metronome PerUserCap] dispatchPerUserCapResolved failed after spend-limit update; continuing"
+      if (defaultResult.isErr()) {
+        return new Err(
+          new UserSpendLimitError(
+            "metronome_error",
+            defaultResult.error.message
+          )
         );
       }
-      transitionedTo = "resolved";
+      const defaultAlert = defaultResult.value;
+
+      if (defaultAlert) {
+        transitionedTo = await resolveLocalCapState({
+          metronomeCustomerId: workspace.metronomeCustomerId,
+          metronomeContractId: auth.subscription()?.metronomeContractId ?? null,
+          userId: user.sId,
+          awuCapCredits: defaultAlert.alert.threshold,
+        });
+      } else {
+        transitionedTo = "resolved";
+      }
+
+      if (transitionedTo !== null) {
+        await dispatchTransition({
+          workspace: workspaceResource,
+          userId: user.sId,
+          transitionedTo,
+        });
+      }
+      // transitionedTo === null: usage unavailable — let webhook reconcile.
       break;
     }
     case "limited": {
@@ -229,38 +275,12 @@ export async function setUserSpendLimit(
         userId: user.sId,
         awuCapCredits: limit.awuCredits,
       });
-      if (transitionedTo === "reached") {
-        const dispatchResult = await dispatchPerUserCapReached({
+      if (transitionedTo !== null) {
+        await dispatchTransition({
           workspace: workspaceResource,
           userId: user.sId,
+          transitionedTo,
         });
-        if (dispatchResult.isErr()) {
-          logger.warn(
-            {
-              workspaceId: workspace.sId,
-              userId: user.sId,
-              transitionedTo,
-              err: dispatchResult.error,
-            },
-            "[Metronome PerUserCap] dispatch after spend-limit update failed; continuing"
-          );
-        }
-      } else if (transitionedTo === "resolved") {
-        const dispatchResult = await dispatchPerUserCapResolved({
-          workspace: workspaceResource,
-          userId: user.sId,
-        });
-        if (dispatchResult.isErr()) {
-          logger.warn(
-            {
-              workspaceId: workspace.sId,
-              userId: user.sId,
-              transitionedTo,
-              err: dispatchResult.error,
-            },
-            "[Metronome PerUserCap] dispatch after spend-limit update failed; continuing"
-          );
-        }
       }
       // transitionedTo === null: usage unavailable — let webhook reconcile.
       break;

--- a/front/lib/metronome/default_user_cap_alert.test.ts
+++ b/front/lib/metronome/default_user_cap_alert.test.ts
@@ -1,0 +1,155 @@
+import * as alerts from "@app/lib/metronome/alerts";
+import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import {
+  getMetronomeDefaultUserCapAlert,
+  upsertMetronomeDefaultUserCapAlert,
+} from "@app/lib/metronome/default_user_cap_alert";
+import { mockCustomerAlert } from "@app/tests/utils/mocks/metronome";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/alerts", async () => {
+  const actual = await vi.importActual<typeof alerts>(
+    "@app/lib/metronome/alerts"
+  );
+  return {
+    ...actual,
+    findMetronomeAlert: vi.fn(),
+    upsertMetronomeAlert: vi.fn(),
+  };
+});
+
+const METRONOME_CUSTOMER_ID = "cust_test_xxx";
+const WORKSPACE_ID = "wks_test_xxx";
+
+beforeEach(() => {
+  vi.mocked(alerts.findMetronomeAlert).mockReset();
+  vi.mocked(alerts.upsertMetronomeAlert).mockReset();
+});
+
+describe("getMetronomeDefaultUserCapAlert", () => {
+  it("queries by the workspace-scoped uniqueness key", async () => {
+    vi.mocked(alerts.findMetronomeAlert).mockResolvedValue(new Ok(null));
+
+    await getMetronomeDefaultUserCapAlert({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+      workspaceId: WORKSPACE_ID,
+    });
+
+    expect(alerts.findMetronomeAlert).toHaveBeenCalledWith({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+      uniquenessKey: `default-user-cap-${WORKSPACE_ID}`,
+    });
+  });
+
+  it("returns null when no alert is configured", async () => {
+    vi.mocked(alerts.findMetronomeAlert).mockResolvedValue(new Ok(null));
+
+    const result = await getMetronomeDefaultUserCapAlert({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+      workspaceId: WORKSPACE_ID,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBeNull();
+    }
+  });
+
+  it("returns the alert when configured", async () => {
+    const alert = mockCustomerAlert({
+      id: "alert_default_xxx",
+      threshold: 50_000,
+      customer_status: "ok",
+      uniqueness_key: `default-user-cap-${WORKSPACE_ID}`,
+    });
+    vi.mocked(alerts.findMetronomeAlert).mockResolvedValue(new Ok(alert));
+
+    const result = await getMetronomeDefaultUserCapAlert({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+      workspaceId: WORKSPACE_ID,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual(alert);
+    }
+  });
+
+  it("propagates Metronome errors", async () => {
+    vi.mocked(alerts.findMetronomeAlert).mockResolvedValue(
+      new Err(new Error("metronome down"))
+    );
+
+    const result = await getMetronomeDefaultUserCapAlert({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+      workspaceId: WORKSPACE_ID,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe("metronome down");
+    }
+  });
+});
+
+describe("upsertMetronomeDefaultUserCapAlert", () => {
+  it("upserts a spend_threshold_reached alert with a no-value user_id group fan-out", async () => {
+    vi.mocked(alerts.upsertMetronomeAlert).mockResolvedValue(
+      new Ok({ alertId: "alert_default_xxx" })
+    );
+
+    const result = await upsertMetronomeDefaultUserCapAlert({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+      workspaceId: WORKSPACE_ID,
+      awuCredits: 50_000,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(alerts.upsertMetronomeAlert).toHaveBeenCalledWith({
+      alert_type: "spend_threshold_reached",
+      name: `Default per-user cap ${WORKSPACE_ID} (50000 AWU)`,
+      threshold: 50_000,
+      credit_type_id: getCreditTypeAwuId(),
+      customer_id: METRONOME_CUSTOMER_ID,
+      // Fan-out marker: `user_id` key with no `value` tells Metronome to
+      // emit one event per user that crosses the threshold.
+      group_values: [{ key: "user_id" }],
+      uniqueness_key: `default-user-cap-${WORKSPACE_ID}`,
+    });
+  });
+
+  it("returns the alert id on success", async () => {
+    vi.mocked(alerts.upsertMetronomeAlert).mockResolvedValue(
+      new Ok({ alertId: "alert_default_xxx" })
+    );
+
+    const result = await upsertMetronomeDefaultUserCapAlert({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+      workspaceId: WORKSPACE_ID,
+      awuCredits: 50_000,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual({ alertId: "alert_default_xxx" });
+    }
+  });
+
+  it("propagates Metronome errors", async () => {
+    vi.mocked(alerts.upsertMetronomeAlert).mockResolvedValue(
+      new Err(new Error("metronome down"))
+    );
+
+    const result = await upsertMetronomeDefaultUserCapAlert({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+      workspaceId: WORKSPACE_ID,
+      awuCredits: 50_000,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe("metronome down");
+    }
+  });
+});

--- a/front/pages/api/w/[wId]/members/[uId]/spend_limit.test.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/spend_limit.test.ts
@@ -1,8 +1,10 @@
 import * as creditStateDispatcher from "@app/lib/api/metronome/credit_state_dispatcher";
+import * as defaultUserCapAlert from "@app/lib/metronome/default_user_cap_alert";
 import * as perUserAlerts from "@app/lib/metronome/per_user_alerts";
 import * as perUserUsage from "@app/lib/metronome/per_user_usage";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { mockCustomerAlert } from "@app/tests/utils/mocks/metronome";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { Ok } from "@app/types/shared/result";
@@ -20,6 +22,16 @@ vi.mock("@app/lib/metronome/per_user_alerts", async () => {
     upsertMetronomePerUserCapAlert: vi.fn(),
     clearMetronomePerUserCapAlert: vi.fn(),
     getMetronomePerUserCap: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/metronome/default_user_cap_alert", async () => {
+  const actual = await vi.importActual<typeof defaultUserCapAlert>(
+    "@app/lib/metronome/default_user_cap_alert"
+  );
+  return {
+    ...actual,
+    getMetronomeDefaultUserCapAlert: vi.fn(),
   };
 });
 
@@ -66,6 +78,9 @@ beforeEach(() => {
   vi.mocked(perUserUsage.fetchPerUserAwuUsage).mockResolvedValue(
     new Ok(new Map())
   );
+  vi.mocked(
+    defaultUserCapAlert.getMetronomeDefaultUserCapAlert
+  ).mockResolvedValue(new Ok(null));
   vi.mocked(creditStateDispatcher.dispatchPerUserCapReached).mockResolvedValue(
     new Ok(undefined)
   );
@@ -243,7 +258,7 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
   });
 
   describe("PUT", () => {
-    it("clears alert + dispatches resolved for unlimited", async () => {
+    it("clears alert + dispatches resolved for unlimited with no default", async () => {
       const workspace = await makeMetronomeWorkspaceWithCustomer();
       const targetUser = await UserFactory.basic();
       await MembershipFactory.associate(workspace, targetUser, {
@@ -279,6 +294,102 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
       );
       expect(
         perUserAlerts.upsertMetronomePerUserCapAlert
+      ).not.toHaveBeenCalled();
+      // No default → no usage fetch needed; behavior matches pre-PR-A.
+      expect(perUserUsage.fetchPerUserAwuUsage).not.toHaveBeenCalled();
+    });
+
+    it("clears alert + dispatches reached for unlimited when default exists and usage is over it", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const targetUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, targetUser, {
+        role: "user",
+      });
+
+      vi.mocked(
+        defaultUserCapAlert.getMetronomeDefaultUserCapAlert
+      ).mockResolvedValueOnce(
+        new Ok(
+          mockCustomerAlert({
+            id: "alert_default_xxx",
+            threshold: 1000,
+            customer_status: "ok",
+          })
+        )
+      );
+      vi.mocked(perUserUsage.fetchPerUserAwuUsage).mockResolvedValueOnce(
+        new Ok(new Map([[targetUser.sId, 2500]]))
+      );
+
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+      req.query.uId = targetUser.sId;
+      req.body = { kind: "unlimited" };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData()).toEqual({
+        limit: { kind: "unlimited" },
+        transitionedTo: "reached",
+      });
+      expect(
+        creditStateDispatcher.dispatchPerUserCapReached
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: targetUser.sId })
+      );
+      expect(
+        creditStateDispatcher.dispatchPerUserCapResolved
+      ).not.toHaveBeenCalled();
+    });
+
+    it("clears alert + dispatches resolved for unlimited when default exists and usage is under it", async () => {
+      const workspace = await makeMetronomeWorkspaceWithCustomer();
+      const targetUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, targetUser, {
+        role: "user",
+      });
+
+      vi.mocked(
+        defaultUserCapAlert.getMetronomeDefaultUserCapAlert
+      ).mockResolvedValueOnce(
+        new Ok(
+          mockCustomerAlert({
+            id: "alert_default_xxx",
+            threshold: 5000,
+            customer_status: "ok",
+          })
+        )
+      );
+      vi.mocked(perUserUsage.fetchPerUserAwuUsage).mockResolvedValueOnce(
+        new Ok(new Map([[targetUser.sId, 100]]))
+      );
+
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+      req.query.uId = targetUser.sId;
+      req.body = { kind: "unlimited" };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData()).toEqual({
+        limit: { kind: "unlimited" },
+        transitionedTo: "resolved",
+      });
+      expect(
+        creditStateDispatcher.dispatchPerUserCapResolved
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: targetUser.sId })
+      );
+      expect(
+        creditStateDispatcher.dispatchPerUserCapReached
       ).not.toHaveBeenCalled();
     });
 

--- a/front/tests/utils/mocks/metronome.ts
+++ b/front/tests/utils/mocks/metronome.ts
@@ -1,0 +1,26 @@
+import type { CustomerAlert } from "@metronome/sdk/resources/v1/customers";
+
+export function mockCustomerAlert({
+  id,
+  threshold,
+  customer_status,
+  uniqueness_key,
+}: {
+  id: string;
+  threshold: number;
+  customer_status: CustomerAlert["customer_status"];
+  uniqueness_key?: string;
+}): CustomerAlert {
+  return {
+    alert: {
+      id,
+      name: id,
+      status: "enabled",
+      threshold,
+      type: "spend_threshold_reached",
+      updated_at: "2024-01-01T00:00:00Z",
+      ...(uniqueness_key !== undefined ? { uniqueness_key } : {}),
+    },
+    customer_status,
+  };
+}


### PR DESCRIPTION
## Description

Re-derive effective per-user cap state on every spend_threshold event (override > default > uncapped) instead of trusting the event type, so a workspace-wide default alert can coexist with per-user overrides. The clear-override path in `setUserSpendLimit` now falls back to the default threshold when one exists, dispatching reached/resolved based on usage instead of always dispatching resolved. Behavior is unchanged when no default alert is configured.

## Tests

Unit

## Risk

None, not plugged yet

## Deploy Plan

Front
