### PR TITLE
Clean up dsbx forwarder invariants

### DIFF
--- a/.github/workflows/build-dust-sandbox.yml
+++ b/.github/workflows/build-dust-sandbox.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install minimal stable
         uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
         with:
-          components: rustfmt
+          components: rustfmt, clippy
 
       - name: Setup Rust Cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -61,6 +61,10 @@ jobs:
       - name: Lint
         working-directory: cli/dust-sandbox
         run: cargo fmt --all -- --check
+
+      - name: Clippy
+        working-directory: cli/dust-sandbox
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Build
         working-directory: cli/dust-sandbox

--- a/cli/dust-sandbox/src/commands/forward/deny_log.rs
+++ b/cli/dust-sandbox/src/commands/forward/deny_log.rs
@@ -7,7 +7,7 @@ use time::OffsetDateTime;
 use tokio::io::AsyncWriteExt;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum DenyReason {
+pub(super) enum DenyReason {
     ProxyDenied,
     ProxyProtocolError,
     DomainExtractionFailed,
@@ -25,7 +25,7 @@ pub enum DenyReason {
 }
 
 impl DenyReason {
-    pub fn as_str(self) -> &'static str {
+    pub(super) fn as_str(self) -> &'static str {
         match self {
             Self::ProxyDenied => "proxy_denied",
             Self::ProxyProtocolError => "proxy_protocol_error",
@@ -46,17 +46,17 @@ impl DenyReason {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct DenyLogEntry {
-    pub reason: DenyReason,
-    pub domain: Option<String>,
-    pub port: Option<u16>,
-    pub secret_name: Option<String>,
-    pub sni: Option<String>,
-    pub host: Option<String>,
+pub(super) struct DenyLogEntry {
+    pub(super) reason: DenyReason,
+    pub(super) domain: Option<String>,
+    pub(super) port: Option<u16>,
+    pub(super) secret_name: Option<String>,
+    pub(super) sni: Option<String>,
+    pub(super) host: Option<String>,
 }
 
 impl DenyLogEntry {
-    pub fn proxy(domain: &str, port: u16, reason: DenyReason) -> Self {
+    pub(super) fn proxy(domain: &str, port: u16, reason: DenyReason) -> Self {
         Self {
             reason,
             domain: (!domain.is_empty()).then(|| domain.to_string()),
@@ -67,7 +67,7 @@ impl DenyLogEntry {
         }
     }
 
-    pub fn mitm(
+    pub(super) fn mitm(
         reason: DenyReason,
         domain: Option<&str>,
         port: u16,
@@ -86,7 +86,7 @@ impl DenyLogEntry {
     }
 }
 
-pub async fn append_deny_log(path: &Path, entry: DenyLogEntry) -> Result<()> {
+pub(super) async fn append_deny_log(path: &Path, entry: DenyLogEntry) -> Result<()> {
     let mut file = tokio::fs::OpenOptions::new()
         .create(true)
         .append(true)

--- a/cli/dust-sandbox/src/commands/forward/handshake.rs
+++ b/cli/dust-sandbox/src/commands/forward/handshake.rs
@@ -1,11 +1,11 @@
 use anyhow::{Context, Result};
 
 // Keep these constants and frame layout in sync with egress-proxy/src/handshake.rs.
-pub const PROTOCOL_VERSION: u8 = 0x01;
-pub const ALLOW_RESPONSE: u8 = 0x00;
-pub const DENY_RESPONSE: u8 = 0x01;
+pub(super) const PROTOCOL_VERSION: u8 = 0x01;
+pub(super) const ALLOW_RESPONSE: u8 = 0x00;
+pub(super) const DENY_RESPONSE: u8 = 0x01;
 
-pub fn build_handshake_frame(
+pub(super) fn build_handshake_frame(
     token: &str,
     domain: &str,
     original_dest_port: u16,

--- a/cli/dust-sandbox/src/commands/forward/http2_rewriter.rs
+++ b/cli/dust-sandbox/src/commands/forward/http2_rewriter.rs
@@ -5730,9 +5730,12 @@ mod tests {
             if frame_type != 4 || flags & 0x1 != 0 {
                 continue;
             }
-            ensure!(len % 6 == 0, "invalid SETTINGS payload length");
-            return payload
-                .chunks_exact(6)
+            let settings = payload.chunks_exact(6);
+            ensure!(
+                settings.remainder().is_empty(),
+                "invalid SETTINGS payload length"
+            );
+            return settings
                 .map(|setting| {
                     let id = u16::from_be_bytes([setting[0], setting[1]]);
                     let value =

--- a/cli/dust-sandbox/src/commands/forward/http2_rewriter.rs
+++ b/cli/dust-sandbox/src/commands/forward/http2_rewriter.rs
@@ -3,7 +3,7 @@ use std::future::{poll_fn, Future};
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex, Weak};
+use std::sync::{Arc, Weak};
 use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
@@ -14,6 +14,7 @@ use h2::{RecvStream, SendStream};
 use http::header::{CONTENT_LENGTH, COOKIE, HOST, TE, TRANSFER_ENCODING};
 use http::{HeaderMap, HeaderName, HeaderValue, Request, Response, StatusCode};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::sync::Mutex;
 use tracing::warn;
 
 use crate::egress_secrets::SecretTable;
@@ -137,11 +138,15 @@ pub(super) enum UpstreamLease {
 }
 
 pub(super) struct H2ConnectionLease {
-    connection: Arc<PooledH2Connection>,
-    send_request: Option<SendRequest<Bytes>>,
+    reservation: H2ConnectionReservation,
+    send_request: SendRequest<Bytes>,
 }
 
-impl Drop for H2ConnectionLease {
+struct H2ConnectionReservation {
+    connection: Arc<PooledH2Connection>,
+}
+
+impl Drop for H2ConnectionReservation {
     fn drop(&mut self) {
         self.connection
             .active_streams
@@ -153,42 +158,36 @@ impl Drop for H2ConnectionLease {
 }
 
 impl H2ConnectionLease {
-    async fn ready(mut self) -> std::result::Result<Self, h2::Error> {
-        let send_request = self
-            .send_request
-            .take()
-            .expect("pooled h2 lease missing send request")
-            .ready()
-            .await;
+    async fn ready(self) -> std::result::Result<Self, h2::Error> {
+        let Self {
+            reservation,
+            send_request,
+        } = self;
+        let send_request = send_request.ready().await;
         match send_request {
-            Ok(send_request) => {
-                self.send_request = Some(send_request);
-                Ok(self)
-            }
+            Ok(send_request) => Ok(Self {
+                reservation,
+                send_request,
+            }),
             Err(error) => {
-                self.mark_draining();
+                reservation
+                    .connection
+                    .draining
+                    .store(true, Ordering::SeqCst);
                 Err(error)
             }
         }
     }
 
     fn send_request(&self) -> SendRequest<Bytes> {
-        self.send_request
-            .as_ref()
-            .expect("pooled h2 lease missing send request")
-            .clone()
+        self.send_request.clone()
     }
 
-    // Draining means "do not hand this connection out for new leases", but
-    // already-leased streams may still complete. Closed is stronger: the
-    // underlying h2 session has gone away and the connection driver task has
-    // resolved; the pool entry is eligible for eviction on the next prune.
-    fn mark_draining(&self) {
-        self.connection.draining.store(true, Ordering::SeqCst);
-    }
-
+    // Closed means the underlying h2 session has gone away and the connection
+    // driver task has resolved; the pool entry is eligible for eviction on the
+    // next prune.
     fn mark_closed(&self) {
-        mark_h2_connection_closed(&self.connection);
+        mark_h2_connection_closed(&self.reservation.connection);
     }
 }
 
@@ -359,8 +358,8 @@ async fn insert_h2_connection_locked(
     let send_request = pooled.send_request.clone();
 
     Ok(H2ConnectionLease {
-        connection: pooled,
-        send_request: Some(send_request),
+        reservation: H2ConnectionReservation { connection: pooled },
+        send_request,
     })
 }
 
@@ -389,8 +388,8 @@ fn reserve_h2_connection(
     connection.active_streams.fetch_add(1, Ordering::SeqCst);
     let send_request = connection.send_request.clone();
     Some(H2ConnectionLease {
-        connection,
-        send_request: Some(send_request),
+        reservation: H2ConnectionReservation { connection },
+        send_request,
     })
 }
 
@@ -585,13 +584,13 @@ struct H2H1ForwardRequest {
 
 type H2RequestDenySlot = Arc<Mutex<Option<H2RequestDeny>>>;
 
-fn store_h2_request_body_deny(slot: &H2RequestDenySlot, deny: H2RequestDeny) {
-    let mut slot = slot.lock().expect("h2 request deny slot poisoned");
+async fn store_h2_request_body_deny(slot: &H2RequestDenySlot, deny: H2RequestDeny) {
+    let mut slot = slot.lock().await;
     *slot = Some(deny);
 }
 
-fn take_h2_request_body_deny(slot: &H2RequestDenySlot) -> Option<H2RequestDeny> {
-    let mut slot = slot.lock().expect("h2 request deny slot poisoned");
+async fn take_h2_request_body_deny(slot: &H2RequestDenySlot) -> Option<H2RequestDeny> {
+    let mut slot = slot.lock().await;
     slot.take()
 }
 
@@ -974,7 +973,7 @@ async fn handle_h2_to_h2_stream(
         response_result = &mut response_task => {
             drop(response_task);
             if let Err(error) = response_result {
-                if let Some(deny) = take_h2_request_body_deny(&request_body_deny) {
+                if let Some(deny) = take_h2_request_body_deny(&request_body_deny).await {
                     request_task.abort();
                     handle_h2_request_body_deny(
                         &policy,
@@ -1016,7 +1015,7 @@ async fn handle_h2_to_h2_stream(
                         }
                     }
                     Err(_) => {
-                        if let Some(deny) = take_h2_request_body_deny(&request_body_deny) {
+                        if let Some(deny) = take_h2_request_body_deny(&request_body_deny).await {
                             request_task.abort();
                             handle_h2_request_body_deny(
                                 &policy,
@@ -1131,7 +1130,7 @@ async fn forward_h2_request_body(
     if let Some(trailers) = trailers {
         if !trailers.is_empty() {
             let deny = H2RequestDeny::internal(DenyReason::RequestTrailersUnsupported);
-            store_h2_request_body_deny(&denied, deny);
+            store_h2_request_body_deny(&denied, deny).await;
             outbound.send_reset(h2::Reason::INTERNAL_ERROR);
             return Err(ForwardH2RequestBodyError::Denied(deny));
         }

--- a/cli/dust-sandbox/src/commands/forward/http_host.rs
+++ b/cli/dust-sandbox/src/commands/forward/http_host.rs
@@ -1,6 +1,6 @@
 use super::DomainParseResult;
 
-pub fn parse_http_host(bytes: &[u8]) -> DomainParseResult {
+pub(super) fn parse_http_host(bytes: &[u8]) -> DomainParseResult {
     let header_end = find_subslice(bytes, b"\r\n\r\n");
     let parse_end = header_end.map_or(bytes.len(), |index| index + 4);
     let header_bytes = &bytes[..parse_end];

--- a/cli/dust-sandbox/src/commands/forward/original_dst.rs
+++ b/cli/dust-sandbox/src/commands/forward/original_dst.rs
@@ -13,12 +13,12 @@ use tokio::net::TcpStream;
 const SO_ORIGINAL_DST: libc::c_int = 80;
 
 #[cfg(target_os = "linux")]
-pub fn resolve_original_dst(stream: &TcpStream) -> io::Result<SocketAddr> {
+pub(super) fn resolve_original_dst(stream: &TcpStream) -> io::Result<SocketAddr> {
     resolve_original_dst_linux(stream)
 }
 
 #[cfg(not(target_os = "linux"))]
-pub fn resolve_original_dst(stream: &TcpStream) -> io::Result<SocketAddr> {
+pub(super) fn resolve_original_dst(stream: &TcpStream) -> io::Result<SocketAddr> {
     stream.peer_addr()
 }
 

--- a/cli/dust-sandbox/src/commands/forward/rewrite_policy.rs
+++ b/cli/dust-sandbox/src/commands/forward/rewrite_policy.rs
@@ -59,13 +59,10 @@ pub(super) enum Authority<'a> {
     Explicit { value: &'a str },
 }
 
-#[allow(dead_code)]
 pub(super) struct ProcessedPolicyRequest {
-    pub host: String,
     pub headers: Vec<HeaderPart>,
 }
 
-#[allow(dead_code)]
 pub(super) fn process_request_policy(
     request: &RequestParts,
     authority: Authority<'_>,
@@ -76,7 +73,7 @@ pub(super) fn process_request_policy(
     let host = normalized_authority(request, authority, mode)?;
     let headers = rewrite_request_headers(request, &host, secret_table, mode)?;
 
-    Ok(ProcessedPolicyRequest { host, headers })
+    Ok(ProcessedPolicyRequest { headers })
 }
 
 pub(super) fn validate_request_line_policy(

--- a/cli/dust-sandbox/src/commands/forward/sni.rs
+++ b/cli/dust-sandbox/src/commands/forward/sni.rs
@@ -1,6 +1,6 @@
 use super::DomainParseResult;
 
-pub fn parse_client_hello_sni(bytes: &[u8]) -> DomainParseResult {
+pub(super) fn parse_client_hello_sni(bytes: &[u8]) -> DomainParseResult {
     let record = match bytes.get(..5) {
         Some(record) => record,
         None => return DomainParseResult::Incomplete,

--- a/cli/dust-sandbox/src/commands/forward/tls_mitm.rs
+++ b/cli/dust-sandbox/src/commands/forward/tls_mitm.rs
@@ -23,7 +23,7 @@ const LEAF_CACHE_CAPACITY: usize = 256;
 pub(super) const H2_ALPN: &[u8] = b"h2";
 pub(super) const HTTP_1_1_ALPN: &[u8] = b"http/1.1";
 
-pub struct MitmCa {
+pub(super) struct MitmCa {
     ca_cert: Certificate,
     ca_key_pair: KeyPair,
     ca_cert_pem: String,
@@ -31,7 +31,7 @@ pub struct MitmCa {
 }
 
 impl MitmCa {
-    pub fn load_or_generate(cert_path: &Path, key_path: &Path) -> Result<Self> {
+    pub(super) fn load_or_generate(cert_path: &Path, key_path: &Path) -> Result<Self> {
         let cert_exists = cert_path
             .try_exists()
             .with_context(|| format!("failed to stat CA cert file {}", cert_path.display()))?;
@@ -59,7 +59,7 @@ impl MitmCa {
         }
     }
 
-    pub fn generate() -> Result<Self> {
+    pub(super) fn generate() -> Result<Self> {
         let params = Self::new_ca_params()?;
         let ca_key_pair = KeyPair::generate().context("failed to generate CA key pair")?;
         let ca_cert = params
@@ -71,7 +71,7 @@ impl MitmCa {
             ca_cert,
             ca_key_pair,
             ca_cert_pem,
-            leaf_cache: Mutex::new(Self::new_leaf_cache()),
+            leaf_cache: Mutex::new(Self::new_leaf_cache()?),
         })
     }
 
@@ -109,11 +109,11 @@ impl MitmCa {
             ca_cert,
             ca_key_pair,
             ca_cert_pem,
-            leaf_cache: Mutex::new(Self::new_leaf_cache()),
+            leaf_cache: Mutex::new(Self::new_leaf_cache()?),
         })
     }
 
-    pub async fn server_config_for(&self, sni: &str) -> Result<Arc<ServerConfig>> {
+    pub(super) async fn server_config_for(&self, sni: &str) -> Result<Arc<ServerConfig>> {
         // Idempotent. Keeps focused tests (e.g. `cargo test server_config_for`)
         // from panicking when no other test installed the provider first.
         let _ = rustls::crypto::ring::default_provider().install_default();
@@ -143,11 +143,10 @@ impl MitmCa {
         Ok(params)
     }
 
-    fn new_leaf_cache() -> LruCache<String, Arc<CertifiedKey>> {
-        let Some(capacity) = NonZeroUsize::new(LEAF_CACHE_CAPACITY) else {
-            unreachable!("leaf cache capacity must be non-zero");
-        };
-        LruCache::new(capacity)
+    fn new_leaf_cache() -> Result<LruCache<String, Arc<CertifiedKey>>> {
+        let capacity = NonZeroUsize::new(LEAF_CACHE_CAPACITY)
+            .context("leaf cache capacity must be non-zero")?;
+        Ok(LruCache::new(capacity))
     }
 
     fn write_persistent(&self, cert_path: &Path, key_path: &Path) -> Result<()> {

--- a/cli/dust-sandbox/src/egress_secrets/mod.rs
+++ b/cli/dust-sandbox/src/egress_secrets/mod.rs
@@ -67,12 +67,6 @@ impl SecretTable {
         self.by_placeholder.len()
     }
 
-    // Consumed by Slice 5 to short-circuit MITM when no secrets are loaded.
-    #[allow(dead_code)]
-    pub fn is_empty(&self) -> bool {
-        self.by_placeholder.is_empty()
-    }
-
     fn parse(contents: &str) -> Result<Self> {
         let raw_secrets: Vec<RawSecret> =
             serde_json::from_str(contents).context("invalid egress secrets JSON")?;
@@ -111,8 +105,6 @@ impl DomainSet {
         Ok(set)
     }
 
-    // Consumed by Slice 5 to gate MITM on SNI; tested directly in this slice.
-    #[allow(dead_code)]
     pub fn matches(&self, domain: &str) -> bool {
         let domain = match normalize_dns_name(domain) {
             Ok(domain) => domain,


### PR DESCRIPTION
## Description

Tightens small dsbx forwarder invariants and removes unused plumbing around forward setup.

## Tests

Tested locally with the dsbx Rust test suite during the stack verification.

## Risk

Low. This is cleanup around existing behavior.

## Deploy Plan

Standard deploy.