### PR TITLE
Extract shared HTTP framing helpers

### DIFF
--- a/cli/dust-sandbox/src/commands/forward/http2_rewriter.rs
+++ b/cli/dust-sandbox/src/commands/forward/http2_rewriter.rs
@@ -20,15 +20,15 @@ use tracing::warn;
 use crate::egress_secrets::SecretTable;
 
 use super::deny_log::{append_deny_log, DenyReason};
+use super::http_framing::{
+    find_subslice, is_common_bridge_stripped_header, parse_chunk_size, MAX_HEADER_BLOCK_BYTES,
+    MAX_HEADER_LINE_BYTES, MAX_TRAILER_BLOCK_BYTES, READ_CHUNK_BYTES,
+};
 use super::rewrite_policy::{
     deny_entry, process_request_policy, Authority, HeaderPart, RequestParts, RewriteMode,
 };
 
 const H2_MAX_CONCURRENT_STREAMS: u32 = 256;
-const READ_CHUNK_BYTES: usize = 8 * 1024;
-const MAX_HEADER_BLOCK_BYTES: usize = 64 * 1024;
-const MAX_HEADER_LINE_BYTES: usize = 16 * 1024;
-const MAX_TRAILER_BLOCK_BYTES: usize = 64 * 1024;
 // 1 MiB initial window for h2 streams on both sides. The h2 spec default
 // (64 KiB - 1) throttles single uploads to one round-trip per window; 1 MiB
 // keeps large request/response bodies flowing without explicit WINDOW_UPDATEs
@@ -1083,15 +1083,7 @@ fn build_h2_upstream_request(
 }
 
 fn should_strip_h2_upstream_header(name: &str) -> bool {
-    const STRIPPED: &[&str] = &[
-        "connection",
-        "host",
-        "keep-alive",
-        "proxy-connection",
-        "transfer-encoding",
-        "upgrade",
-    ];
-    STRIPPED.iter().any(|s| name.eq_ignore_ascii_case(s))
+    is_common_bridge_stripped_header(name)
 }
 
 async fn forward_h2_request_body(
@@ -1542,16 +1534,7 @@ where
 }
 
 fn should_strip_h1_bridge_header(name: &str) -> bool {
-    matches!(
-        name.to_ascii_lowercase().as_str(),
-        "connection"
-            | "host"
-            | "keep-alive"
-            | "proxy-connection"
-            | "te"
-            | "transfer-encoding"
-            | "upgrade"
-    )
+    is_common_bridge_stripped_header(name) || name.eq_ignore_ascii_case("te")
 }
 
 fn connection_nominated_headers(headers: &[HeaderPart]) -> Result<HashSet<String>> {
@@ -1959,15 +1942,6 @@ fn response_body_kind(headers: &[HeaderPart]) -> Result<H1BodyKind> {
     Ok(content_length.map_or(H1BodyKind::EofDelimited, H1BodyKind::ContentLength))
 }
 
-fn parse_chunk_size(line: &[u8]) -> Result<usize> {
-    let text = std::str::from_utf8(line).context("chunk size line is not utf8")?;
-    let line = text
-        .strip_suffix("\r\n")
-        .ok_or_else(|| anyhow!("chunk size line missing CRLF"))?;
-    let size = line.split_once(';').map_or(line, |(size, _)| size).trim();
-    usize::from_str_radix(size, 16).context("invalid chunk size")
-}
-
 async fn send_data(send: &mut SendStream<Bytes>, data: Bytes, end_stream: bool) -> Result<()> {
     if data.is_empty() {
         send.send_data(data, end_stream)
@@ -1997,12 +1971,6 @@ async fn send_data(send: &mut SendStream<Bytes>, data: Bytes, end_stream: bool) 
     }
 
     Ok(())
-}
-
-fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    haystack
-        .windows(needle.len())
-        .position(|window| window == needle)
 }
 
 #[cfg(test)]

--- a/cli/dust-sandbox/src/commands/forward/http2_rewriter.rs
+++ b/cli/dust-sandbox/src/commands/forward/http2_rewriter.rs
@@ -1067,7 +1067,7 @@ fn build_h2_upstream_request(
         .method(method)
         .uri(uri);
     for header in headers {
-        if should_strip_h2_upstream_header(&header.name) {
+        if is_common_bridge_stripped_header(&header.name) {
             continue;
         }
         let name = HeaderName::from_bytes(header.name.as_bytes())
@@ -1080,10 +1080,6 @@ fn build_h2_upstream_request(
     request
         .body(())
         .map_err(|_| H2RequestDeny::internal(DenyReason::MalformedHeaders))
-}
-
-fn should_strip_h2_upstream_header(name: &str) -> bool {
-    is_common_bridge_stripped_header(name)
 }
 
 async fn forward_h2_request_body(
@@ -1229,7 +1225,7 @@ fn sanitize_h2_response_head<B>(response: Response<B>) -> Result<Response<()>> {
     let (parts, _) = response.into_parts();
     let mut builder = Response::builder().status(parts.status);
     for (name, value) in &parts.headers {
-        if should_strip_h2_upstream_header(name.as_str()) {
+        if is_common_bridge_stripped_header(name.as_str()) {
             continue;
         }
         builder = builder.header(name, value);
@@ -1245,12 +1241,12 @@ fn filter_h2_header_map(headers: HeaderMap) -> HeaderMap {
     for (name, value) in headers {
         if let Some(name) = name {
             last_name = Some(name.clone());
-            if should_strip_h2_upstream_header(name.as_str()) {
+            if is_common_bridge_stripped_header(name.as_str()) {
                 continue;
             }
             filtered.append(name, value);
         } else if let Some(name) = &last_name {
-            if should_strip_h2_upstream_header(name.as_str()) {
+            if is_common_bridge_stripped_header(name.as_str()) {
                 continue;
             }
             filtered.append(name.clone(), value);
@@ -1392,7 +1388,8 @@ fn build_h1_request_head(
             append_h1_header_line(&mut header_bytes, header.name.as_bytes(), &header.value)?;
             continue;
         }
-        if should_strip_h1_bridge_header(&header.name)
+        if is_common_bridge_stripped_header(&header.name)
+            || header.name.eq_ignore_ascii_case(TE.as_str())
             || (use_chunked && header.name.eq_ignore_ascii_case(CONTENT_LENGTH.as_str()))
         {
             continue;
@@ -1533,10 +1530,6 @@ where
     Ok(())
 }
 
-fn should_strip_h1_bridge_header(name: &str) -> bool {
-    is_common_bridge_stripped_header(name) || name.eq_ignore_ascii_case("te")
-}
-
 fn connection_nominated_headers(headers: &[HeaderPart]) -> Result<HashSet<String>> {
     let mut nominated = HashSet::new();
     for header in headers {
@@ -1619,7 +1612,9 @@ fn build_h2_response_head(response_head: &H1ResponseHead) -> Result<Response<()>
     let mut response = Response::builder().status(response_head.status);
     let nominated_hop_headers = connection_nominated_headers(&response_head.headers)?;
     for header in &response_head.headers {
-        if should_strip_h1_bridge_header(header.name.as_str()) {
+        if is_common_bridge_stripped_header(header.name.as_str())
+            || header.name.eq_ignore_ascii_case(TE.as_str())
+        {
             continue;
         }
         if nominated_hop_headers.contains(&header.name.to_ascii_lowercase()) {
@@ -1854,7 +1849,9 @@ where
             .parse(&synthetic)
             .context("failed to parse h1 trailers")?;
         for header in request.headers.iter() {
-            if should_strip_h1_bridge_header(header.name) {
+            if is_common_bridge_stripped_header(header.name)
+                || header.name.eq_ignore_ascii_case(TE.as_str())
+            {
                 continue;
             }
             let name = HeaderName::from_bytes(header.name.as_bytes())
@@ -4195,7 +4192,7 @@ mod tests {
         };
         assert_h2_reset_reason(error, h2::Reason::INTERNAL_ERROR);
 
-        let deny_log_text = tokio::fs::read_to_string(deny_log.as_ref()).await?;
+        let deny_log_text = read_test_file_eventually(deny_log.as_ref()).await?;
         assert!(
             deny_log_text.contains("\"reason\":\"request_trailers_unsupported\""),
             "deny log should record request_trailers_unsupported, got: {deny_log_text}"
@@ -4252,7 +4249,7 @@ mod tests {
         };
         assert_h2_reset_reason(error, h2::Reason::INTERNAL_ERROR);
 
-        let deny_log_text = tokio::fs::read_to_string(deny_log.as_ref()).await?;
+        let deny_log_text = read_test_file_eventually(deny_log.as_ref()).await?;
         assert!(
             deny_log_text.contains("\"reason\":\"request_trailers_unsupported\""),
             "deny log should record request_trailers_unsupported, got: {deny_log_text}"
@@ -4522,7 +4519,7 @@ mod tests {
             .await
             .ok_or_else(|| anyhow!("allowed sibling did not reach upstream"))?;
         assert!(request_text.contains("GET /allowed HTTP/1.1\r\n"));
-        let deny_log_text = tokio::fs::read_to_string(deny_log.as_ref()).await?;
+        let deny_log_text = read_test_file_eventually(deny_log.as_ref()).await?;
         assert!(deny_log_text.contains("\"reason\":\"placeholder_on_non_allowed\""));
 
         drop(send_request);
@@ -4656,7 +4653,7 @@ mod tests {
             ":authority/SNI mismatch should reset"
         );
 
-        let deny_log_text = tokio::fs::read_to_string(deny_log.as_ref()).await?;
+        let deny_log_text = read_test_file_eventually(deny_log.as_ref()).await?;
         assert!(
             deny_log_text.contains("\"reason\":\"host_sni_mismatch\""),
             "deny log should record host_sni_mismatch, got: {deny_log_text}"
@@ -4709,7 +4706,7 @@ mod tests {
         };
         assert_h2_reset_reason(error, h2::Reason::PROTOCOL_ERROR);
 
-        let deny_log_text = tokio::fs::read_to_string(deny_log.as_ref()).await?;
+        let deny_log_text = read_test_file_eventually(deny_log.as_ref()).await?;
         assert!(
             deny_log_text.contains("\"reason\":\"malformed_headers\""),
             "deny log should record malformed_headers, got: {deny_log_text}"
@@ -4763,7 +4760,7 @@ mod tests {
         };
         assert_h2_reset_reason(error, h2::Reason::PROTOCOL_ERROR);
 
-        let deny_log_text = tokio::fs::read_to_string(deny_log.as_ref()).await?;
+        let deny_log_text = read_test_file_eventually(deny_log.as_ref()).await?;
         assert!(
             deny_log_text.contains("\"reason\":\"malformed_headers\""),
             "deny log should record malformed_headers, got: {deny_log_text}"
@@ -4809,7 +4806,7 @@ mod tests {
         let (response, _stream) = send_request.send_request(request, true)?;
         assert!(response.await.is_err(), "placeholder in :path should reset");
 
-        let deny_log_text = tokio::fs::read_to_string(deny_log.as_ref()).await?;
+        let deny_log_text = read_test_file_eventually(deny_log.as_ref()).await?;
         assert!(
             deny_log_text.contains("\"reason\":\"url_line_placeholder\""),
             "deny log should record url_line_placeholder, got: {deny_log_text}"

--- a/cli/dust-sandbox/src/commands/forward/http2_rewriter.rs
+++ b/cli/dust-sandbox/src/commands/forward/http2_rewriter.rs
@@ -21,8 +21,9 @@ use crate::egress_secrets::SecretTable;
 
 use super::deny_log::{append_deny_log, DenyReason};
 use super::http_framing::{
-    find_subslice, is_common_bridge_stripped_header, parse_chunk_size, MAX_HEADER_BLOCK_BYTES,
-    MAX_HEADER_LINE_BYTES, MAX_TRAILER_BLOCK_BYTES, READ_CHUNK_BYTES,
+    find_subslice, is_common_bridge_stripped_header, is_h1_bridge_stripped_header,
+    parse_chunk_size, MAX_HEADER_BLOCK_BYTES, MAX_HEADER_LINE_BYTES, MAX_TRAILER_BLOCK_BYTES,
+    READ_CHUNK_BYTES,
 };
 use super::rewrite_policy::{
     deny_entry, process_request_policy, Authority, HeaderPart, RequestParts, RewriteMode,
@@ -1388,8 +1389,7 @@ fn build_h1_request_head(
             append_h1_header_line(&mut header_bytes, header.name.as_bytes(), &header.value)?;
             continue;
         }
-        if is_common_bridge_stripped_header(&header.name)
-            || header.name.eq_ignore_ascii_case(TE.as_str())
+        if is_h1_bridge_stripped_header(&header.name)
             || (use_chunked && header.name.eq_ignore_ascii_case(CONTENT_LENGTH.as_str()))
         {
             continue;
@@ -1612,9 +1612,7 @@ fn build_h2_response_head(response_head: &H1ResponseHead) -> Result<Response<()>
     let mut response = Response::builder().status(response_head.status);
     let nominated_hop_headers = connection_nominated_headers(&response_head.headers)?;
     for header in &response_head.headers {
-        if is_common_bridge_stripped_header(header.name.as_str())
-            || header.name.eq_ignore_ascii_case(TE.as_str())
-        {
+        if is_h1_bridge_stripped_header(header.name.as_str()) {
             continue;
         }
         if nominated_hop_headers.contains(&header.name.to_ascii_lowercase()) {
@@ -1849,9 +1847,7 @@ where
             .parse(&synthetic)
             .context("failed to parse h1 trailers")?;
         for header in request.headers.iter() {
-            if is_common_bridge_stripped_header(header.name)
-                || header.name.eq_ignore_ascii_case(TE.as_str())
-            {
+            if is_h1_bridge_stripped_header(header.name) {
                 continue;
             }
             let name = HeaderName::from_bytes(header.name.as_bytes())

--- a/cli/dust-sandbox/src/commands/forward/http_framing.rs
+++ b/cli/dust-sandbox/src/commands/forward/http_framing.rs
@@ -55,11 +55,23 @@ pub(super) fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
         .position(|window| window == needle)
 }
 
+// Hop-by-hop headers we strip when re-serializing a bridged request or response.
+// Connection, Keep-Alive, Proxy-Connection, Transfer-Encoding, and Upgrade are
+// hop-by-hop per RFC 7230. Host is stripped because we re-set it from the
+// bridged authority.
+const COMMON_STRIPPED_HEADERS: &[&str] = &[
+    "connection",
+    "host",
+    "keep-alive",
+    "proxy-connection",
+    "transfer-encoding",
+    "upgrade",
+];
+
 pub(super) fn is_common_bridge_stripped_header(name: &str) -> bool {
-    matches!(
-        name.to_ascii_lowercase().as_str(),
-        "connection" | "host" | "keep-alive" | "proxy-connection" | "transfer-encoding" | "upgrade"
-    )
+    COMMON_STRIPPED_HEADERS
+        .iter()
+        .any(|stripped| name.eq_ignore_ascii_case(stripped))
 }
 
 #[cfg(test)]

--- a/cli/dust-sandbox/src/commands/forward/http_framing.rs
+++ b/cli/dust-sandbox/src/commands/forward/http_framing.rs
@@ -74,6 +74,12 @@ pub(super) fn is_common_bridge_stripped_header(name: &str) -> bool {
         .any(|stripped| name.eq_ignore_ascii_case(stripped))
 }
 
+// h2-to-h1 fallback strips TE in addition to the common set. TE is an
+// h1-specific hop-by-hop header and should not be forwarded raw.
+pub(super) fn is_h1_bridge_stripped_header(name: &str) -> bool {
+    is_common_bridge_stripped_header(name) || name.eq_ignore_ascii_case("te")
+}
+
 #[cfg(test)]
 mod tests {
     use super::{

--- a/cli/dust-sandbox/src/commands/forward/http_framing.rs
+++ b/cli/dust-sandbox/src/commands/forward/http_framing.rs
@@ -1,0 +1,136 @@
+use std::fmt;
+use std::num::ParseIntError;
+use std::str::Utf8Error;
+
+// Limits are intentionally generous compared to nginx/Apache defaults
+// (~8-32 KiB / ~100 headers). This rewriter sits in front of arbitrary
+// outbound HTTP traffic from the sandbox (curl, git, package managers,
+// browsers, anything), so the role of these limits is to bound our own
+// memory use and reject obviously-malformed traffic, not to enforce a
+// policy on what the destination accepts.
+pub(super) const MAX_HEADER_BLOCK_BYTES: usize = 64 * 1024;
+pub(super) const MAX_HEADER_LINE_BYTES: usize = 16 * 1024;
+pub(super) const MAX_TRAILER_BLOCK_BYTES: usize = 64 * 1024;
+pub(super) const READ_CHUNK_BYTES: usize = 8 * 1024;
+
+#[derive(Debug)]
+pub(super) enum ParseChunkError {
+    InvalidUtf8(Utf8Error),
+    MissingCrlf,
+    InvalidSize(ParseIntError),
+}
+
+impl fmt::Display for ParseChunkError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidUtf8(error) => write!(formatter, "chunk size line is not utf8: {error}"),
+            Self::MissingCrlf => write!(formatter, "chunk size line missing CRLF"),
+            Self::InvalidSize(error) => write!(formatter, "invalid chunk size: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for ParseChunkError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::InvalidUtf8(error) => Some(error),
+            Self::MissingCrlf => None,
+            Self::InvalidSize(error) => Some(error),
+        }
+    }
+}
+
+pub(super) fn parse_chunk_size(line: &[u8]) -> Result<usize, ParseChunkError> {
+    let text = std::str::from_utf8(line).map_err(ParseChunkError::InvalidUtf8)?;
+    let line = text
+        .strip_suffix("\r\n")
+        .ok_or(ParseChunkError::MissingCrlf)?;
+    let size = line.split_once(';').map_or(line, |(size, _)| size).trim();
+    usize::from_str_radix(size, 16).map_err(ParseChunkError::InvalidSize)
+}
+
+pub(super) fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+pub(super) fn is_common_bridge_stripped_header(name: &str) -> bool {
+    matches!(
+        name.to_ascii_lowercase().as_str(),
+        "connection" | "host" | "keep-alive" | "proxy-connection" | "transfer-encoding" | "upgrade"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        find_subslice, is_common_bridge_stripped_header, parse_chunk_size, ParseChunkError,
+    };
+
+    #[test]
+    fn parses_chunk_sizes() -> anyhow::Result<()> {
+        assert_eq!(parse_chunk_size(b"0\r\n")?, 0);
+        assert_eq!(parse_chunk_size(b"1a\r\n")?, 26);
+        assert_eq!(parse_chunk_size(b"1A\r\n")?, 26);
+        assert_eq!(parse_chunk_size(b"f;foo=bar\r\n")?, 15);
+        assert_eq!(parse_chunk_size(b" f ; foo=bar\r\n")?, 15);
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_chunk_sizes_without_crlf() {
+        assert!(matches!(
+            parse_chunk_size(b"1a"),
+            Err(ParseChunkError::MissingCrlf)
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_chunk_sizes() {
+        assert!(matches!(
+            parse_chunk_size(b"1a garbage\r\n"),
+            Err(ParseChunkError::InvalidSize(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_non_utf8_chunk_sizes() {
+        assert!(matches!(
+            parse_chunk_size(&[0xff, b'\r', b'\n']),
+            Err(ParseChunkError::InvalidUtf8(_))
+        ));
+    }
+
+    #[test]
+    fn finds_subslices() {
+        assert_eq!(find_subslice(b"abc", b"x"), None);
+        assert_eq!(find_subslice(b"abc", b"ab"), Some(0));
+        assert_eq!(find_subslice(b"abc", b"bc"), Some(1));
+        assert_eq!(find_subslice(b"ababa", b"aba"), Some(0));
+    }
+
+    #[test]
+    #[should_panic]
+    fn empty_subslice_needle_matches_previous_behavior() {
+        let _ = find_subslice(b"abc", b"");
+    }
+
+    #[test]
+    fn classifies_common_bridge_stripped_headers() {
+        for name in [
+            "connection",
+            "HOST",
+            "keep-alive",
+            "proxy-connection",
+            "transfer-encoding",
+            "upgrade",
+        ] {
+            assert!(is_common_bridge_stripped_header(name));
+        }
+
+        for name in ["te", "cookie", "authorization", "x-foo"] {
+            assert!(!is_common_bridge_stripped_header(name));
+        }
+    }
+}

--- a/cli/dust-sandbox/src/commands/forward/http_host.rs
+++ b/cli/dust-sandbox/src/commands/forward/http_host.rs
@@ -1,3 +1,4 @@
+use super::http_framing::find_subslice;
 use super::DomainParseResult;
 
 pub(super) fn parse_http_host(bytes: &[u8]) -> DomainParseResult {
@@ -47,12 +48,6 @@ fn strip_port(host: &str) -> &str {
     }
 
     host
-}
-
-fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    haystack
-        .windows(needle.len())
-        .position(|window| window == needle)
 }
 
 #[cfg(test)]

--- a/cli/dust-sandbox/src/commands/forward/http_rewriter.rs
+++ b/cli/dust-sandbox/src/commands/forward/http_rewriter.rs
@@ -2,32 +2,26 @@ use std::collections::HashSet;
 use std::fmt;
 use std::io::ErrorKind;
 
-use anyhow::{anyhow, Context};
+use anyhow::anyhow;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::sync::{mpsc, oneshot};
 
 use crate::egress_secrets::SecretTable;
 
 use super::deny_log::{DenyLogEntry, DenyReason};
+use super::http_framing::{
+    find_subslice, parse_chunk_size, MAX_HEADER_BLOCK_BYTES, MAX_HEADER_LINE_BYTES,
+    MAX_TRAILER_BLOCK_BYTES, READ_CHUNK_BYTES,
+};
 use super::rewrite_policy::{
     deny_entry, normalize_host, normalized_authority, rewrite_request_headers,
     validate_request_line_policy, Authority, HeaderPart, RequestParts,
     RewriteMode as HttpRewriteMode,
 };
 
-// Limits are intentionally generous compared to nginx/Apache defaults
-// (~8-32 KiB / ~100 headers). This rewriter sits in front of arbitrary
-// outbound HTTP traffic from the sandbox (curl, git, package managers,
-// browsers, anything), so the role of these limits is to bound our own
-// memory use and reject obviously-malformed traffic, not to enforce a
-// policy on what the destination accepts.
-const MAX_HEADER_BLOCK_BYTES: usize = 64 * 1024;
-const MAX_HEADER_LINE_BYTES: usize = 16 * 1024;
 const MAX_HEADERS: usize = 256;
-const READ_CHUNK_BYTES: usize = 8 * 1024;
 const NON_HTTP_FALLBACK_BYTES: usize = 4 * 1024;
 const MAX_CHUNK_LINE_BYTES: usize = 8 * 1024;
-const MAX_TRAILER_BLOCK_BYTES: usize = 64 * 1024;
 // Cap how many bytes we stage while waiting for a CRLF on the upstream
 // response status line. A real `HTTP/1.x NNN ...` line is well under a few
 // hundred bytes; well past that we treat the upstream as non-HTTP and stop
@@ -660,18 +654,6 @@ where
     }
 }
 
-fn parse_chunk_size(line: &[u8]) -> anyhow::Result<usize> {
-    let text = std::str::from_utf8(line).context("chunk line is not utf8")?;
-    let line_without_crlf = text
-        .strip_suffix("\r\n")
-        .ok_or_else(|| anyhow!("chunk line missing CRLF"))?;
-    let size_text = line_without_crlf
-        .split_once(';')
-        .map_or(line_without_crlf, |(size, _)| size)
-        .trim();
-    usize::from_str_radix(size_text, 16).context("invalid chunk size")
-}
-
 async fn copy_raw_client_to_upstream<R, W>(
     reader: &mut BufferedReader<'_, R>,
     upstream: &mut W,
@@ -890,12 +872,6 @@ fn looks_like_http_request_line(bytes: &[u8]) -> bool {
     parts.len() == 3
         && parts[0].bytes().all(|byte| byte.is_ascii_uppercase())
         && parts[2].starts_with("HTTP/")
-}
-
-fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    haystack
-        .windows(needle.len())
-        .position(|window| window == needle)
 }
 
 #[cfg(test)]

--- a/cli/dust-sandbox/src/commands/forward/mod.rs
+++ b/cli/dust-sandbox/src/commands/forward/mod.rs
@@ -1,6 +1,7 @@
 mod deny_log;
 mod handshake;
 mod http2_rewriter;
+mod http_framing;
 mod http_host;
 mod http_rewriter;
 mod original_dst;


### PR DESCRIPTION
## Description

Moves shared HTTP framing helpers into one module so h1 and h2 bridge tests exercise the same parsing behavior.

## Tests

Tested locally with the dsbx Rust test suite during the stack verification.

## Risk

Low. Refactor around shared parsing helpers.

## Deploy Plan

Standard deploy after the parent PR.