### PR TITLE
Deny h1 request trailers

### DIFF
--- a/cli/dust-sandbox/src/commands/forward/http_rewriter.rs
+++ b/cli/dust-sandbox/src/commands/forward/http_rewriter.rs
@@ -628,22 +628,40 @@ where
 
         if chunk_size == 0 {
             let mut trailer_bytes = 0_usize;
+            let mut has_trailers = false;
             loop {
                 let trailer_line = reader.read_line(mode).await?;
-                trailer_bytes = trailer_bytes
+                let Some(next_trailer_bytes) = trailer_bytes
                     .checked_add(trailer_line.len())
                     .filter(|total| *total <= MAX_TRAILER_BLOCK_BYTES)
-                    .ok_or_else(|| {
-                        HttpRewriteError::denied(mode, DenyReason::MalformedHeaders, None, None)
-                    })?;
+                else {
+                    shutdown_upstream(upstream).await?;
+                    return Err(HttpRewriteError::denied(
+                        mode,
+                        DenyReason::MalformedHeaders,
+                        None,
+                        None,
+                    ));
+                };
+                trailer_bytes = next_trailer_bytes;
                 let done = trailer_line == b"\r\n";
-                upstream
-                    .write_all(&trailer_line)
-                    .await
-                    .map_err(|error| HttpRewriteError::io(anyhow!(error)))?;
                 if done {
+                    if has_trailers {
+                        shutdown_upstream(upstream).await?;
+                        return Err(HttpRewriteError::denied(
+                            mode,
+                            DenyReason::RequestTrailersUnsupported,
+                            None,
+                            None,
+                        ));
+                    }
+                    upstream
+                        .write_all(&trailer_line)
+                        .await
+                        .map_err(|error| HttpRewriteError::io(anyhow!(error)))?;
                     return Ok(());
                 }
+                has_trailers = true;
             }
         }
 
@@ -940,6 +958,44 @@ mod tests {
 
         assert!(text.contains("Transfer-Encoding: chunked\r\n"));
         assert!(text.contains("5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn forwards_empty_chunked_trailer_block() -> Result<()> {
+        let (result, output) = forward_chunked_once(b"5\r\nhello\r\n0\r\n\r\n").await?;
+
+        result?;
+        assert_eq!(output, b"5\r\nhello\r\n0\r\n\r\n");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn denies_non_empty_chunked_request_trailers() -> Result<()> {
+        let (result, output) =
+            forward_chunked_once(b"5\r\nhello\r\n0\r\nTrailer-Foo: bar\r\n\r\n").await?;
+        let error = result.expect_err("non-empty request trailers should deny");
+
+        assert_deny_reason(error, DenyReason::RequestTrailersUnsupported);
+        assert_eq!(output, b"5\r\nhello\r\n0\r\n");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn oversized_chunked_request_trailer_block_stays_malformed() -> Result<()> {
+        let trailer_value = "x".repeat(MAX_CHUNK_LINE_BYTES - b"X: \r\n".len());
+        let trailer_line = format!("X: {trailer_value}\r\n");
+        let mut input = String::from("0\r\n");
+        for _ in 0..9 {
+            input.push_str(&trailer_line);
+        }
+        input.push_str("\r\n");
+
+        let (result, output) = forward_chunked_once(input.as_bytes()).await?;
+        let error = result.expect_err("oversized request trailers should deny");
+
+        assert_deny_reason(error, DenyReason::MalformedHeaders);
+        assert_eq!(output, b"0\r\n");
         Ok(())
     }
 
@@ -1617,6 +1673,41 @@ mod tests {
             .await
             .map_err(|error| HttpRewriteError::io(anyhow!(error)))?;
         Ok(output)
+    }
+
+    async fn forward_chunked_once(input: &[u8]) -> Result<(RewriteResult<()>, Vec<u8>)> {
+        let (mut client_write, mut client_read) = tokio::io::duplex(16 * 1024);
+        let (mut upstream_write, mut upstream_read) = tokio::io::duplex(16 * 1024);
+        let input = input.to_vec();
+        let writer_task = tokio::spawn(async move {
+            client_write.write_all(&input).await?;
+            client_write.shutdown().await?;
+            Ok::<(), std::io::Error>(())
+        });
+
+        let result = forward_chunked(
+            &mut BufferedReader::new(&mut client_read),
+            &mut upstream_write,
+            HttpRewriteMode::Tls {
+                sni: "api.openai.com",
+            },
+        )
+        .await;
+        drop(upstream_write);
+        drop(client_read);
+
+        if let Err(error) = writer_task.await? {
+            if !matches!(
+                error.kind(),
+                ErrorKind::BrokenPipe | ErrorKind::ConnectionReset | ErrorKind::UnexpectedEof
+            ) {
+                return Err(error.into());
+            }
+        }
+
+        let mut output = Vec::new();
+        upstream_read.read_to_end(&mut output).await?;
+        Ok((result, output))
     }
 
     fn empty_table() -> Result<SecretTable> {

--- a/cli/dust-sandbox/src/commands/forward/mod.rs
+++ b/cli/dust-sandbox/src/commands/forward/mod.rs
@@ -869,6 +869,7 @@ mod tests {
         KeyUsagePurpose, SanType,
     };
     use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, ServerName};
+    use tempfile::tempdir;
     use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 
     use crate::egress_secrets::{DomainSet, Secret};
@@ -1077,6 +1078,87 @@ mod tests {
         upstream_task
             .await
             .context("test upstream task panicked")??;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn mitm_session_denies_h1_chunked_request_trailers() -> Result<()> {
+        let sni = "api.openai.com";
+        let mitm_ca = Arc::new(MitmCa::generate()?);
+        let (upstream_server_config, upstream_ca_der) = test_upstream_server_config(sni)?;
+        let mut runtime = test_runtime(Arc::clone(&mitm_ca), upstream_ca_der)?;
+        runtime.secret_table = Arc::new(secret_table(&[sni])?);
+        let tempdir = tempdir()?;
+        let deny_log = tempdir.path().join("deny.log");
+        runtime.deny_log = Arc::new(deny_log.clone());
+
+        let (agent_client_io, agent_dsbx_io) = tokio::io::duplex(16 * 1024);
+        let (dsbx_proxy_io, upstream_server_io) = tokio::io::duplex(16 * 1024);
+
+        let upstream_task = tokio::spawn(async move {
+            let acceptor = TlsAcceptor::from(upstream_server_config);
+            let mut tls = acceptor
+                .accept(upstream_server_io)
+                .await
+                .context("test upstream failed to accept TLS")?;
+
+            let mut request = Vec::new();
+            tls.read_to_end(&mut request)
+                .await
+                .context("test upstream failed to read request")?;
+            let request_text = String::from_utf8(request).context("request should be utf8")?;
+            assert!(request_text.contains("Transfer-Encoding: chunked\r\n"));
+            assert!(request_text.contains("5\r\nhello\r\n0\r\n"));
+            assert!(!request_text.contains("Trailer-Foo: bar"));
+            assert!(
+                request_text.ends_with("0\r\n"),
+                "upstream should receive only the body through the zero chunk, got {request_text:?}"
+            );
+            Ok::<(), anyhow::Error>(())
+        });
+
+        let agent_connector =
+            test_tls_connector(mitm_ca.ca_cert_der(), vec![HTTP_1_1_ALPN.to_vec()])?;
+        let agent_task = tokio::spawn(async move {
+            let server_name =
+                ServerName::try_from(sni.to_string()).context("invalid test agent SNI")?;
+            let mut tls = agent_connector
+                .connect(server_name, agent_client_io)
+                .await
+                .context("test agent failed to connect to dsbx MITM")?;
+            tls.write_all(
+                format!(
+                    "POST /upload HTTP/1.1\r\nHost: {sni}\r\n\
+                     Transfer-Encoding: chunked\r\n\r\n\
+                     5\r\nhello\r\n0\r\nTrailer-Foo: bar\r\n\r\n"
+                )
+                .as_bytes(),
+            )
+            .await
+            .context("test agent failed to write request")?;
+
+            let mut buffer = [0_u8; 1];
+            let _ = tls.read(&mut buffer).await;
+            Ok::<(), anyhow::Error>(())
+        });
+
+        run_mitm_session_with_proxy_opener(
+            &runtime,
+            sni,
+            agent_dsbx_io,
+            single_proxy_opener(dsbx_proxy_io),
+        )
+        .await?;
+        agent_task.await.context("test agent task panicked")??;
+        upstream_task
+            .await
+            .context("test upstream task panicked")??;
+
+        let deny_log_content = tokio::fs::read_to_string(&deny_log)
+            .await
+            .context("deny log should be written")?;
+        assert!(deny_log_content.contains("request_trailers_unsupported"));
 
         Ok(())
     }


### PR DESCRIPTION
## Description

Rejects h1 request trailers in the forwarder and records the request-trailers deny reason.

## Tests

Tested locally with the dsbx Rust test suite during the stack verification.

## Risk

Low. Tightens unsupported request framing handling.

## Deploy Plan

Standard deploy after the parent PR.