### PR TITLE
Bound dsbx deny log growth

### DIFF
--- a/cli/dust-sandbox/src/commands/forward/deny_log.rs
+++ b/cli/dust-sandbox/src/commands/forward/deny_log.rs
@@ -1,10 +1,17 @@
-use std::path::Path;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use serde::Serialize;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 use tokio::io::AsyncWriteExt;
+
+// Keep deny logging bounded on the sandbox writable mount. One previous
+// generation is retained as `<path>.1`; a single line larger than this cap can
+// still exceed the cap after rotation, but normal deny entries are tiny.
+const DENY_LOG_MAX_BYTES: u64 = 8 * 1024 * 1024;
+static DENY_LOG_WRITE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum DenyReason {
@@ -87,17 +94,73 @@ impl DenyLogEntry {
 }
 
 pub(super) async fn append_deny_log(path: &Path, entry: DenyLogEntry) -> Result<()> {
+    let line = format_deny_log_line(&entry)?;
+    append_deny_log_line(path, &line, DENY_LOG_MAX_BYTES).await
+}
+
+async fn append_deny_log_line(path: &Path, line: &str, max_bytes: u64) -> Result<()> {
+    let _guard = DENY_LOG_WRITE_LOCK.lock().await;
+    rotate_deny_log_if_needed(path, line.len() as u64, max_bytes).await?;
     let mut file = tokio::fs::OpenOptions::new()
         .create(true)
         .append(true)
         .open(path)
         .await
         .with_context(|| format!("failed to open deny log {}", path.display()))?;
-    let line = format_deny_log_line(&entry)?;
     file.write_all(line.as_bytes())
         .await
         .with_context(|| format!("failed to write deny log {}", path.display()))?;
     Ok(())
+}
+
+async fn rotate_deny_log_if_needed(
+    path: &Path,
+    next_line_bytes: u64,
+    max_bytes: u64,
+) -> Result<()> {
+    let current_bytes = match tokio::fs::metadata(path).await {
+        Ok(metadata) => metadata.len(),
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("failed to stat deny log {}", path.display()));
+        }
+    };
+
+    if current_bytes.saturating_add(next_line_bytes) <= max_bytes {
+        return Ok(());
+    }
+
+    let rotated_path = rotated_deny_log_path(path);
+    match tokio::fs::remove_file(&rotated_path).await {
+        Ok(()) => {}
+        Err(error) if error.kind() == ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!(
+                    "failed to remove rotated deny log {}",
+                    rotated_path.display()
+                )
+            });
+        }
+    }
+    match tokio::fs::rename(path, &rotated_path).await {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error).with_context(|| {
+            format!(
+                "failed to rotate deny log {} to {}",
+                path.display(),
+                rotated_path.display()
+            )
+        }),
+    }
+}
+
+fn rotated_deny_log_path(path: &Path) -> PathBuf {
+    let mut rotated = path.as_os_str().to_os_string();
+    rotated.push(".1");
+    PathBuf::from(rotated)
 }
 
 #[derive(Serialize)]
@@ -129,10 +192,14 @@ fn format_deny_log_line(entry: &DenyLogEntry) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use serde_json::Value;
     use tempfile::tempdir;
 
-    use super::{append_deny_log, DenyLogEntry, DenyReason};
+    use super::{
+        append_deny_log, append_deny_log_line, rotated_deny_log_path, DenyLogEntry, DenyReason,
+    };
 
     #[tokio::test]
     async fn appends_json_deny_log_entries() {
@@ -177,5 +244,103 @@ mod tests {
         assert_eq!(second["secret_name"], "OPENAI_API_KEY");
         assert_eq!(second["sni"], "api.openai.com");
         assert_eq!(second["host"], "evil.example");
+    }
+
+    #[tokio::test]
+    async fn preserves_appends_below_cap() {
+        let tempdir = tempdir().expect("tempdir should be created");
+        let path = tempdir.path().join("deny.log");
+
+        append_deny_log_line(&path, "first\n", 64)
+            .await
+            .expect("first append should succeed");
+        append_deny_log_line(&path, "second\n", 64)
+            .await
+            .expect("second append should succeed");
+
+        let content = tokio::fs::read_to_string(&path)
+            .await
+            .expect("deny log should be readable");
+        assert_eq!(content, "first\nsecond\n");
+        assert!(
+            tokio::fs::metadata(rotated_deny_log_path(&path))
+                .await
+                .is_err(),
+            "rotation should not create a previous generation below cap"
+        );
+    }
+
+    #[tokio::test]
+    async fn rotates_when_append_crosses_cap() {
+        let tempdir = tempdir().expect("tempdir should be created");
+        let path = tempdir.path().join("deny.log");
+        let rotated_path = rotated_deny_log_path(&path);
+
+        append_deny_log_line(&path, "first\n", 12)
+            .await
+            .expect("first append should succeed");
+        append_deny_log_line(&path, "second\n", 12)
+            .await
+            .expect("second append should succeed");
+
+        let current = tokio::fs::read_to_string(&path)
+            .await
+            .expect("current deny log should be readable");
+        let rotated = tokio::fs::read_to_string(&rotated_path)
+            .await
+            .expect("rotated deny log should be readable");
+        assert_eq!(current, "second\n");
+        assert_eq!(rotated, "first\n");
+    }
+
+    #[tokio::test]
+    async fn concurrent_appends_near_cap_do_not_tear_lines() {
+        let tempdir = tempdir().expect("tempdir should be created");
+        let path = tempdir.path().join("deny.log");
+        let rotated_path = rotated_deny_log_path(&path);
+        append_deny_log_line(
+            &path,
+            "pppppppppppppppppppppppppppppppppppppppppppppppppp\n",
+            80,
+        )
+        .await
+        .expect("prefill append should succeed");
+
+        let first_path = path.clone();
+        let first = tokio::spawn(async move {
+            append_deny_log_line(&first_path, "line-a-aaaaaaaaaaaa\n", 80).await
+        });
+        let second_path = path.clone();
+        let second = tokio::spawn(async move {
+            append_deny_log_line(&second_path, "line-b-bbbbbbbbbbbb\n", 80).await
+        });
+
+        first
+            .await
+            .expect("first append task should finish")
+            .expect("first append should succeed");
+        second
+            .await
+            .expect("second append task should finish")
+            .expect("second append should succeed");
+
+        let current = tokio::fs::read_to_string(&path)
+            .await
+            .expect("current deny log should be readable");
+        let rotated = tokio::fs::read_to_string(&rotated_path)
+            .await
+            .expect("rotated deny log should be readable");
+        let observed = current.lines().chain(rotated.lines()).collect::<Vec<_>>();
+        let allowed = HashSet::from([
+            "pppppppppppppppppppppppppppppppppppppppppppppppppp",
+            "line-a-aaaaaaaaaaaa",
+            "line-b-bbbbbbbbbbbb",
+        ]);
+        assert!(
+            observed.iter().all(|line| allowed.contains(line)),
+            "observed torn or unexpected lines: {observed:?}"
+        );
+        assert!(observed.contains(&"line-a-aaaaaaaaaaaa"));
+        assert!(observed.contains(&"line-b-bbbbbbbbbbbb"));
     }
 }

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -1,8 +1,8 @@
-import { Err, Ok } from "@app/types/shared/result";
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Err, Ok } from "@app/types/shared/result";
 import jwt from "jsonwebtoken";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -312,6 +312,26 @@ describe("sandbox egress helpers", () => {
     );
   });
 
+  it("resets the deny log offset when the log shrinks", async () => {
+    const sandbox = {
+      exec: vi
+        .fn()
+        .mockResolvedValue(new Ok({ exitCode: 0, stdout: "", stderr: "" })),
+    };
+
+    const result = await readNewDenyLogEntries(auth, sandbox as never);
+
+    expect(result.isOk()).toBe(true);
+    const command = sandbox.exec.mock.calls[0][1];
+    expect(command).toContain("set -- $_state;");
+    expect(command).toContain(
+      `if [ "$_total" -lt "$_off" ] || [ "$_size" -lt "$_size_off" ]; then _off=0; fi;`
+    );
+    expect(command).toContain(
+      `echo "$_total $_size" > '/tmp/.dust-egress-deny-offset'`
+    );
+  });
+
   it("returns empty array when there are no new deny log entries", async () => {
     const sandbox = {
       exec: vi

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -1,4 +1,8 @@
 import { Err, Ok } from "@app/types/shared/result";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import jwt from "jsonwebtoken";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -649,6 +653,120 @@ describe("sandbox egress helpers", () => {
       expect.objectContaining({ event: "egress.health_ok" }),
       expect.any(String)
     );
+  });
+
+  // The mocked tests above only assert the TS wrapper (stdout parsing, exec
+  // options). The actual offset tracking / cap / rotation reset lives in the
+  // shell command the function sends to the sandbox. This block runs that
+  // exact command through `sh -c` against tempfiles to exercise the real
+  // bash logic.
+  describe("readNewDenyLogEntries shell behavior", () => {
+    let denyLogDir: string;
+    let logPath: string;
+    let offsetPath: string;
+
+    beforeEach(() => {
+      denyLogDir = mkdtempSync(join(tmpdir(), "deny-log-"));
+      logPath = join(denyLogDir, "deny.log");
+      offsetPath = join(denyLogDir, "deny-offset");
+    });
+
+    afterEach(() => {
+      rmSync(denyLogDir, { recursive: true, force: true });
+    });
+
+    // Re-points the command's hardcoded log + offset paths at our tempfiles,
+    // then runs it through `sh -c` and returns the parsed lines. Each call
+    // mirrors what `readNewDenyLogEntries` does on the sandbox: parse stdout,
+    // drop blank lines, persist the new offset state.
+    async function runReader(): Promise<string[]> {
+      const sandbox = {
+        exec: vi.fn(async (_auth: unknown, command: string) => {
+          const rewritten = command
+            .replace(/'\/tmp\/dust-egress-denied\.log'/g, `'${logPath}'`)
+            .replace(/'\/tmp\/\.dust-egress-deny-offset'/g, `'${offsetPath}'`);
+          const result = spawnSync("sh", ["-c", rewritten], {
+            encoding: "utf8",
+          });
+          return new Ok({
+            exitCode: result.status ?? 0,
+            stdout: result.stdout,
+            stderr: result.stderr,
+          });
+        }),
+      };
+
+      const result = await readNewDenyLogEntries(auth, sandbox as never);
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw new Error("unreachable");
+      }
+      return result.value;
+    }
+
+    it("returns nothing when the deny log file does not exist", async () => {
+      expect(await runReader()).toEqual([]);
+    });
+
+    it("returns all entries on first read, then only new entries", async () => {
+      writeFileSync(logPath, "a denied\nb denied\n");
+      expect(await runReader()).toEqual(["a denied", "b denied"]);
+
+      writeFileSync(logPath, "a denied\nb denied\nc denied\n");
+      expect(await runReader()).toEqual(["c denied"]);
+    });
+
+    it("returns nothing on a second read when the log has not grown", async () => {
+      writeFileSync(logPath, "a denied\n");
+      expect(await runReader()).toEqual(["a denied"]);
+      expect(await runReader()).toEqual([]);
+    });
+
+    it("resets the offset and replays from the start when the log is truncated", async () => {
+      writeFileSync(logPath, "a denied\nb denied\n");
+      await runReader();
+
+      // Simulate rotation: file shrinks below the persisted offset.
+      writeFileSync(logPath, "x denied\n");
+      expect(await runReader()).toEqual(["x denied"]);
+    });
+
+    it("resets the offset when the log size shrinks but line count is unchanged", async () => {
+      writeFileSync(logPath, "long-line-a denied\nlong-line-b denied\n");
+      await runReader();
+
+      // Same line count, smaller bytes: still must reset.
+      writeFileSync(logPath, "a\nb\n");
+      expect(await runReader()).toEqual(["a", "b"]);
+    });
+
+    it("caps lines returned per call and drops the overflow", async () => {
+      // 50 lines in a single burst, cap is 20. Document that the overflow is
+      // dropped on this call AND not replayed on the next call (the offset
+      // is advanced to the file's total, not to "offset + cap").
+      const lines = Array.from({ length: 50 }, (_, i) => `line${i} denied`);
+      writeFileSync(logPath, lines.join("\n") + "\n");
+
+      const first = await runReader();
+      expect(first).toHaveLength(20);
+      expect(first[0]).toBe("line0 denied");
+      expect(first[19]).toBe("line19 denied");
+
+      // Overflow is gone, not queued for the next call.
+      expect(await runReader()).toEqual([]);
+    });
+
+    it("recovers from a malformed offset state file by resetting to zero", async () => {
+      writeFileSync(logPath, "a denied\nb denied\n");
+      writeFileSync(offsetPath, "garbage notanumber\n");
+      expect(await runReader()).toEqual(["a denied", "b denied"]);
+    });
+
+    it("recovers from an empty offset state file", async () => {
+      writeFileSync(logPath, "a denied\n");
+      writeFileSync(offsetPath, "");
+      expect(await runReader()).toEqual(["a denied"]);
+    });
   });
 
   describe("teardownInSandboxEgressRedirect", () => {

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -578,12 +578,20 @@ export async function readNewDenyLogEntries(
   sandbox: SandboxResource
 ): Promise<Result<string[], Error>> {
   const command =
-    `_off=$(cat ${shellEscape(EGRESS_DENY_LOG_OFFSET_PATH)} 2>/dev/null || echo 0); ` +
-    `_total=$(wc -l < ${shellEscape(EGRESS_DENY_LOG_PATH)} 2>/dev/null || echo 0); ` +
+    `_state=$(cat ${shellEscape(EGRESS_DENY_LOG_OFFSET_PATH)} 2>/dev/null || true); ` +
+    `set -- $_state; ` +
+    `_off=\${1:-0}; _size_off=\${2:-0}; ` +
+    `case "$_off" in ''|*[!0-9]*) _off=0;; esac; ` +
+    `case "$_size_off" in ''|*[!0-9]*) _size_off=0;; esac; ` +
+    `if [ -f ${shellEscape(EGRESS_DENY_LOG_PATH)} ]; then ` +
+    `_total=$(wc -l < ${shellEscape(EGRESS_DENY_LOG_PATH)} | tr -d ' '); ` +
+    `_size=$(wc -c < ${shellEscape(EGRESS_DENY_LOG_PATH)} | tr -d ' '); ` +
+    `else _total=0; _size=0; fi; ` +
+    `if [ "$_total" -lt "$_off" ] || [ "$_size" -lt "$_size_off" ]; then _off=0; fi; ` +
     `if [ "$_total" -gt "$_off" ]; then ` +
     `tail -n +$((_off + 1)) ${shellEscape(EGRESS_DENY_LOG_PATH)} | head -n ${MAX_DENY_LOG_LINES_PER_EXEC}; ` +
     `fi; ` +
-    `echo "$_total" > ${shellEscape(EGRESS_DENY_LOG_OFFSET_PATH)}`;
+    `echo "$_total $_size" > ${shellEscape(EGRESS_DENY_LOG_OFFSET_PATH)}`;
 
   const result = await sandbox.exec(auth, command, {
     user: "root",


### PR DESCRIPTION
## Description

Adds deny-log rotation in dsbx and makes the front-side reader recover when the log file shrinks.

## Tests

Adds focused coverage for deny-log appends and offset recovery.

## Risk

Low. Deny-log retention changes are bounded and reader recovery only resets stale offsets.

## Deploy Plan

Standard deploy after the cleanup PR.