### PR TITLE
Experiment with lazy mounting in Hono

### DIFF
--- a/front-api/app.ts
+++ b/front-api/app.ts
@@ -1,73 +1,108 @@
 import { Hono } from "hono";
 
+import { lazyMount } from "./lib/lazy_mount";
 import { cors } from "./middlewares/cors";
 import { requestLogger } from "./middlewares/request_logger";
 import { unhandledErrorHandler } from "./middlewares/utils";
-import preStopApp from "./routes/[preStopSecret]";
-import { appStatusApp } from "./routes/app-status";
-import { loginApp } from "./routes/auth/login";
-import { authContextApp } from "./routes/auth-context";
-import { createNewWorkspaceApp } from "./routes/create-new-workspace";
-import debugApp from "./routes/debug";
-import docApp from "./routes/doc";
-import emailApp from "./routes/email";
-import enrichmentApp from "./routes/enrichment";
-import geo from "./routes/geo";
-import { healthzApp } from "./routes/healthz";
-import { invitationsApp } from "./routes/invitations";
-import { killApp } from "./routes/kill";
-import privateLoginApp from "./routes/login";
-import lookupApp from "./routes/lookup";
-import metronomeApp from "./routes/metronome";
-import novuApp from "./routes/novu";
-import oauthApp from "./routes/oauth";
-import pokeApp from "./routes/poke";
-import shareApp from "./routes/share";
-import stripeApp from "./routes/stripe";
-import tApp from "./routes/t";
-import templatesApp from "./routes/templates";
-import userApp from "./routes/user";
-import publicWorkspaceApp from "./routes/v1/w/[wId]";
-import workspaceApp from "./routes/w/[wId]";
-import workspaceJoinApp from "./routes/w/[wId]/join";
-import workosApp from "./routes/workos";
-import { workspaceLookupApp } from "./routes/workspace-lookup";
+
+const API_MOUNT = "/api";
 
 const apiApp = new Hono();
-apiApp.route("/healthz", healthzApp);
-apiApp.route("/app-status", appStatusApp);
-apiApp.route("/auth/login", loginApp);
-apiApp.route("/auth-context", authContextApp);
-apiApp.route("/create-new-workspace", createNewWorkspaceApp);
-apiApp.route("/debug", debugApp);
-apiApp.route("/doc", docApp);
-apiApp.route("/email", emailApp);
-apiApp.route("/enrichment", enrichmentApp);
-apiApp.route("/geo", geo);
-apiApp.route("/invitations", invitationsApp);
-apiApp.route("/kill", killApp);
-apiApp.route("/login", privateLoginApp);
-apiApp.route("/lookup", lookupApp);
-apiApp.route("/metronome", metronomeApp);
-apiApp.route("/novu", novuApp);
-apiApp.route("/oauth", oauthApp);
-apiApp.route("/poke", pokeApp);
-apiApp.route("/share", shareApp);
-apiApp.route("/stripe", stripeApp);
-apiApp.route("/templates", templatesApp);
-apiApp.route("/t", tApp);
-apiApp.route("/user", userApp);
-apiApp.route("/workos", workosApp);
-apiApp.route("/workspace-lookup", workspaceLookupApp);
-// join is mounted before the workspace app so it does not inherit workspaceAuth
-// (it is a public, unauthenticated endpoint).
-apiApp.route("/w/:wId/join", workspaceJoinApp);
-apiApp.route("/w/:wId", workspaceApp);
-apiApp.route("/v1/w/:wId", publicWorkspaceApp);
+
+// Static-prefix sub-apps. Each is imported on the first matching request.
+lazyMount(apiApp, API_MOUNT, "/healthz", () =>
+  import("./routes/healthz").then((m) => m.healthzApp)
+);
+lazyMount(apiApp, API_MOUNT, "/app-status", () =>
+  import("./routes/app-status").then((m) => m.appStatusApp)
+);
+lazyMount(apiApp, API_MOUNT, "/auth/login", () =>
+  import("./routes/auth/login").then((m) => m.loginApp)
+);
+lazyMount(apiApp, API_MOUNT, "/auth-context", () =>
+  import("./routes/auth-context").then((m) => m.authContextApp)
+);
+lazyMount(apiApp, API_MOUNT, "/create-new-workspace", () =>
+  import("./routes/create-new-workspace").then((m) => m.createNewWorkspaceApp)
+);
+lazyMount(apiApp, API_MOUNT, "/debug", () =>
+  import("./routes/debug").then((m) => m.default)
+);
+lazyMount(apiApp, API_MOUNT, "/doc", () =>
+  import("./routes/doc").then((m) => m.default)
+);
+lazyMount(apiApp, API_MOUNT, "/email", () =>
+  import("./routes/email").then((m) => m.default)
+);
+lazyMount(apiApp, API_MOUNT, "/enrichment", () =>
+  import("./routes/enrichment").then((m) => m.default)
+);
+lazyMount(apiApp, API_MOUNT, "/geo", () =>
+  import("./routes/geo").then((m) => m.default)
+);
+lazyMount(apiApp, API_MOUNT, "/invitations", () =>
+  import("./routes/invitations").then((m) => m.invitationsApp)
+);
+lazyMount(apiApp, API_MOUNT, "/kill", () =>
+  import("./routes/kill").then((m) => m.killApp)
+);
+lazyMount(apiApp, API_MOUNT, "/login", () =>
+  import("./routes/login").then((m) => m.default)
+);
+lazyMount(apiApp, API_MOUNT, "/lookup", () =>
+  import("./routes/lookup").then((m) => m.default)
+);
+lazyMount(apiApp, API_MOUNT, "/metronome", () =>
+  import("./routes/metronome").then((m) => m.default)
+);
+lazyMount(apiApp, API_MOUNT, "/novu", () =>
+  import("./routes/novu").then((m) => m.default)
+);
+lazyMount(apiApp, API_MOUNT, "/oauth", () =>
+  import("./routes/oauth").then((m) => m.default)
+);
+lazyMount(apiApp, API_MOUNT, "/poke", () =>
+  import("./routes/poke").then((m) => m.default)
+);
+lazyMount(apiApp, API_MOUNT, "/share", () =>
+  import("./routes/share").then((m) => m.default)
+);
+lazyMount(apiApp, API_MOUNT, "/stripe", () =>
+  import("./routes/stripe").then((m) => m.default)
+);
+lazyMount(apiApp, API_MOUNT, "/templates", () =>
+  import("./routes/templates").then((m) => m.default)
+);
+lazyMount(apiApp, API_MOUNT, "/t", () =>
+  import("./routes/t").then((m) => m.default)
+);
+lazyMount(apiApp, API_MOUNT, "/user", () =>
+  import("./routes/user").then((m) => m.default)
+);
+lazyMount(apiApp, API_MOUNT, "/workos", () =>
+  import("./routes/workos").then((m) => m.default)
+);
+lazyMount(apiApp, API_MOUNT, "/workspace-lookup", () =>
+  import("./routes/workspace-lookup").then((m) => m.workspaceLookupApp)
+);
+
+// Dynamic-prefix sub-apps. `join` is registered before `/w/:wId` so it does
+// not inherit workspaceAuth (it is a public, unauthenticated endpoint).
+lazyMount(apiApp, API_MOUNT, "/w/:wId/join", () =>
+  import("./routes/w/[wId]/join").then((m) => m.default)
+);
+lazyMount(apiApp, API_MOUNT, "/w/:wId", () =>
+  import("./routes/w/[wId]").then((m) => m.default)
+);
+lazyMount(apiApp, API_MOUNT, "/v1/w/:wId", () =>
+  import("./routes/v1/w/[wId]").then((m) => m.default)
+);
 // Pre-stop uses a dynamic first segment (the secret) — register last so its
 // `/:preStopSecret/prestop` shape doesn't shadow any literal-prefixed routes
 // above.
-apiApp.route("/:preStopSecret", preStopApp);
+lazyMount(apiApp, API_MOUNT, "/:preStopSecret", () =>
+  import("./routes/[preStopSecret]").then((m) => m.default)
+);
 
 export const honoApp = new Hono();
 honoApp.use("*", requestLogger);

--- a/front-api/app.ts
+++ b/front-api/app.ts
@@ -9,100 +9,86 @@ const API_MOUNT = "/api";
 
 const apiApp = new Hono();
 
-// Static-prefix sub-apps. Each is imported on the first matching request.
-lazyMount(apiApp, API_MOUNT, "/healthz", () =>
+// `lazyMount` returns void in production (handlers register synchronously and
+// sub-apps are imported on first request) and a Promise in test mode (sub-apps
+// are imported eagerly so vi.mock'd modules are honored; see lazy_mount.ts).
+// We collect the test-mode promises so we can `await` them before mounting
+// apiApp on honoApp — Hono's `app.route(prefix, child)` snapshots child's
+// route table at call time, so sub-app routes registered asynchronously after
+// the mount call would not propagate.
+const pendingMounts: Array<Promise<void> | void> = [];
+const mount = (prefix: string, loader: () => Promise<Hono<any, any, any>>) => {
+  pendingMounts.push(lazyMount(apiApp, API_MOUNT, prefix, loader));
+};
+
+// Static-prefix sub-apps. Each is imported on the first matching request
+// (or eagerly in test mode).
+mount("/healthz", () =>
   import("./routes/healthz").then((m) => m.healthzApp)
 );
-lazyMount(apiApp, API_MOUNT, "/app-status", () =>
+mount("/app-status", () =>
   import("./routes/app-status").then((m) => m.appStatusApp)
 );
-lazyMount(apiApp, API_MOUNT, "/auth/login", () =>
+mount("/auth/login", () =>
   import("./routes/auth/login").then((m) => m.loginApp)
 );
-lazyMount(apiApp, API_MOUNT, "/auth-context", () =>
+mount("/auth-context", () =>
   import("./routes/auth-context").then((m) => m.authContextApp)
 );
-lazyMount(apiApp, API_MOUNT, "/create-new-workspace", () =>
+mount("/create-new-workspace", () =>
   import("./routes/create-new-workspace").then((m) => m.createNewWorkspaceApp)
 );
-lazyMount(apiApp, API_MOUNT, "/debug", () =>
-  import("./routes/debug").then((m) => m.default)
-);
-lazyMount(apiApp, API_MOUNT, "/doc", () =>
-  import("./routes/doc").then((m) => m.default)
-);
-lazyMount(apiApp, API_MOUNT, "/email", () =>
-  import("./routes/email").then((m) => m.default)
-);
-lazyMount(apiApp, API_MOUNT, "/enrichment", () =>
+mount("/debug", () => import("./routes/debug").then((m) => m.default));
+mount("/doc", () => import("./routes/doc").then((m) => m.default));
+mount("/email", () => import("./routes/email").then((m) => m.default));
+mount("/enrichment", () =>
   import("./routes/enrichment").then((m) => m.default)
 );
-lazyMount(apiApp, API_MOUNT, "/geo", () =>
-  import("./routes/geo").then((m) => m.default)
-);
-lazyMount(apiApp, API_MOUNT, "/invitations", () =>
+mount("/geo", () => import("./routes/geo").then((m) => m.default));
+mount("/invitations", () =>
   import("./routes/invitations").then((m) => m.invitationsApp)
 );
-lazyMount(apiApp, API_MOUNT, "/kill", () =>
-  import("./routes/kill").then((m) => m.killApp)
-);
-lazyMount(apiApp, API_MOUNT, "/login", () =>
-  import("./routes/login").then((m) => m.default)
-);
-lazyMount(apiApp, API_MOUNT, "/lookup", () =>
-  import("./routes/lookup").then((m) => m.default)
-);
-lazyMount(apiApp, API_MOUNT, "/metronome", () =>
+mount("/kill", () => import("./routes/kill").then((m) => m.killApp));
+mount("/login", () => import("./routes/login").then((m) => m.default));
+mount("/lookup", () => import("./routes/lookup").then((m) => m.default));
+mount("/metronome", () =>
   import("./routes/metronome").then((m) => m.default)
 );
-lazyMount(apiApp, API_MOUNT, "/novu", () =>
-  import("./routes/novu").then((m) => m.default)
-);
-lazyMount(apiApp, API_MOUNT, "/oauth", () =>
-  import("./routes/oauth").then((m) => m.default)
-);
-lazyMount(apiApp, API_MOUNT, "/poke", () =>
-  import("./routes/poke").then((m) => m.default)
-);
-lazyMount(apiApp, API_MOUNT, "/share", () =>
-  import("./routes/share").then((m) => m.default)
-);
-lazyMount(apiApp, API_MOUNT, "/stripe", () =>
-  import("./routes/stripe").then((m) => m.default)
-);
-lazyMount(apiApp, API_MOUNT, "/templates", () =>
+mount("/novu", () => import("./routes/novu").then((m) => m.default));
+mount("/oauth", () => import("./routes/oauth").then((m) => m.default));
+mount("/poke", () => import("./routes/poke").then((m) => m.default));
+mount("/share", () => import("./routes/share").then((m) => m.default));
+mount("/stripe", () => import("./routes/stripe").then((m) => m.default));
+mount("/templates", () =>
   import("./routes/templates").then((m) => m.default)
 );
-lazyMount(apiApp, API_MOUNT, "/t", () =>
-  import("./routes/t").then((m) => m.default)
-);
-lazyMount(apiApp, API_MOUNT, "/user", () =>
-  import("./routes/user").then((m) => m.default)
-);
-lazyMount(apiApp, API_MOUNT, "/workos", () =>
-  import("./routes/workos").then((m) => m.default)
-);
-lazyMount(apiApp, API_MOUNT, "/workspace-lookup", () =>
+mount("/t", () => import("./routes/t").then((m) => m.default));
+mount("/user", () => import("./routes/user").then((m) => m.default));
+mount("/workos", () => import("./routes/workos").then((m) => m.default));
+mount("/workspace-lookup", () =>
   import("./routes/workspace-lookup").then((m) => m.workspaceLookupApp)
 );
 
 // Dynamic-prefix sub-apps. `join` is registered before `/w/:wId` so it does
 // not inherit workspaceAuth (it is a public, unauthenticated endpoint).
-lazyMount(apiApp, API_MOUNT, "/w/:wId/join", () =>
+mount("/w/:wId/join", () =>
   import("./routes/w/[wId]/join").then((m) => m.default)
 );
-lazyMount(apiApp, API_MOUNT, "/w/:wId", () =>
-  import("./routes/w/[wId]").then((m) => m.default)
-);
-lazyMount(apiApp, API_MOUNT, "/v1/w/:wId", () =>
+mount("/w/:wId", () => import("./routes/w/[wId]").then((m) => m.default));
+mount("/v1/w/:wId", () =>
   import("./routes/v1/w/[wId]").then((m) => m.default)
 );
 // Pre-stop uses a dynamic first segment (the secret) — register last so its
 // `/:preStopSecret/prestop` shape doesn't shadow any literal-prefixed routes
 // above.
-lazyMount(apiApp, API_MOUNT, "/:preStopSecret", () =>
+mount("/:preStopSecret", () =>
   import("./routes/[preStopSecret]").then((m) => m.default)
 );
+
+// In test mode, wait for all eager mounts to register on apiApp before we
+// attach apiApp to honoApp; otherwise honoApp would snapshot an empty
+// apiApp. In production mode this resolves immediately.
+await Promise.all(pendingMounts);
 
 export const honoApp = new Hono();
 honoApp.use("*", requestLogger);

--- a/front-api/lib/lazy_mount.ts
+++ b/front-api/lib/lazy_mount.ts
@@ -1,0 +1,83 @@
+import logger from "@app/logger/logger";
+import { Hono } from "hono";
+
+// The loader may return any Hono variant — different sub-apps in this server
+// have different `Variables` types (SessionCtx, WorkspaceAwareCtx, ...). Once
+// loaded we only call `.fetch()` on it, which is uniform across variants.
+type AnyHono = Hono<any, any, any>;
+type Loader = () => Promise<AnyHono>;
+
+// Strip the trailing colon-prefixed segment from a path pattern (if any).
+// "/w/:wId" -> "/w"; "/foo" -> "/foo". Used to find the literal portion of a
+// mount prefix that should be removed from the request URL before forwarding
+// to a lazily-loaded sub-app.
+function literalPrefix(prefix: string): string {
+  const idx = prefix.indexOf("/:");
+  return idx === -1 ? prefix : prefix.slice(0, idx);
+}
+
+function paramSegment(prefix: string): string | null {
+  const idx = prefix.indexOf("/:");
+  return idx === -1 ? null : prefix.slice(idx);
+}
+
+/**
+ * Lazily mount a Hono sub-app at `prefix` on `parent`. The sub-app module is
+ * imported on the first request matching `prefix` (or `prefix/*`) and cached
+ * thereafter.
+ *
+ * `parentMountPath` is the path at which `parent` itself is mounted on the
+ * top-level server (e.g. "/api"). It is stripped from the inbound URL before
+ * forwarding so the sub-app sees paths starting from its own root, matching
+ * what `parent.route(prefix, subApp)` would have produced.
+ *
+ * `prefix` may include a single trailing path param (e.g. "/w/:wId"). In that
+ * case the loaded sub-app is wrapped so its routes are re-prefixed with the
+ * param segment, preserving `c.req.param("wId")` in inner middleware.
+ */
+export function lazyMount(
+  parent: AnyHono,
+  parentMountPath: string,
+  prefix: string,
+  loader: Loader
+): void {
+  let loaded: AnyHono | undefined;
+  let loading: Promise<void> | undefined;
+
+  const param = paramSegment(prefix);
+  const fullLiteralStrip = parentMountPath + literalPrefix(prefix);
+
+  const ensureLoaded = async (): Promise<AnyHono> => {
+    if (loaded) {
+      return loaded;
+    }
+    loading ??= (async () => {
+      const startMs = performance.now();
+      const inner = await loader();
+      if (param) {
+        const wrapper = new Hono();
+        wrapper.route(param, inner);
+        loaded = wrapper;
+      } else {
+        loaded = inner;
+      }
+      const durationMs = Math.round(performance.now() - startMs);
+      logger.info(
+        { prefix, durationMs },
+        "[lazy-mount] loaded sub-app on first request"
+      );
+    })();
+    await loading;
+    return loaded!;
+  };
+
+  const handle = async (c: { req: { url: string; raw: Request } }) => {
+    const app = await ensureLoaded();
+    const url = new URL(c.req.url);
+    url.pathname = url.pathname.slice(fullLiteralStrip.length) || "/";
+    return app.fetch(new Request(url, c.req.raw));
+  };
+
+  parent.all(prefix, handle as never);
+  parent.all(`${prefix}/*`, handle as never);
+}

--- a/front-api/lib/lazy_mount.ts
+++ b/front-api/lib/lazy_mount.ts
@@ -7,6 +7,14 @@ import { Hono } from "hono";
 type AnyHono = Hono<any, any, any>;
 type Loader = () => Promise<AnyHono>;
 
+// Vitest's `vi.mock` hoisting patches the module registry for STATIC imports
+// only — dynamic `import()` calls (the whole point of lazy mounting) bypass
+// those mocks, so mocked-out helpers like `getSession` or sequelize CLS
+// transaction context aren't applied to lazily-loaded route modules. Under
+// `NODE_ENV=test` we therefore force eager loading so tests behave identically
+// to the production-bundle path (which esbuild inlines at build time anyway).
+const FORCE_EAGER = process.env.NODE_ENV === "test";
+
 // Strip the trailing colon-prefixed segment from a path pattern (if any).
 // "/w/:wId" -> "/w"; "/foo" -> "/foo". Used to find the literal portion of a
 // mount prefix that should be removed from the request URL before forwarding
@@ -40,7 +48,17 @@ export function lazyMount(
   parentMountPath: string,
   prefix: string,
   loader: Loader
-): void {
+): Promise<void> | void {
+  if (FORCE_EAGER) {
+    // Resolve the loader now and register a normal sub-app mount. Returns a
+    // promise so app.ts can `await` all registrations to complete before any
+    // request can be served. Tests use this path because vi.mock'd modules are
+    // not honored by dynamic imports.
+    return loader().then((inner) => {
+      parent.route(prefix, inner);
+    });
+  }
+
   let loaded: AnyHono | undefined;
   let loading: Promise<void> | undefined;
 

--- a/front-api/server.ts
+++ b/front-api/server.ts
@@ -25,7 +25,11 @@ function main() {
   });
 
   server.listen(port, hostname, () => {
-    logger.info({ port, hostname, dev }, "Hono-only server listening");
+    const uptimeMs = Math.round(process.uptime() * 1000);
+    logger.info(
+      { port, hostname, dev, uptimeMs },
+      "Hono-only server listening"
+    );
   });
 }
 

--- a/front-api/tsconfig.json
+++ b/front-api/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../front/tsconfig.json",
   "compilerOptions": {
+    "target": "es2022",
     "paths": {
       "@app/*": ["../front/*"],
       "@front-api/*": ["./*"]


### PR DESCRIPTION
## Description

  Speeds up local `front-hono` startup by deferring sub-app imports until the
  first request that targets them, mirroring Next.js dev's on-demand compilation
  model. Previously `app.ts` statically imported all ~28 sub-apps at boot,
  which transitively pulled in the entire route graph (357 files under
  `/w/:wId` alone, plus the Stripe / Slack / Anthropic / Sequelize / sparkle
  chains) before `server.listen` could bind the port.

  ## Changes

  - **`front-api/lib/lazy_mount.ts`** (new): helper that registers
    `parent.all(prefix)` + `parent.all(prefix/*)` and dynamically imports +
    caches the sub-app on the first matching request. Handles both static
    prefixes (`/poke`, `/stripe`, ...) and one-trailing-param prefixes
    (`/w/:wId`, `/v1/w/:wId`, `/:preStopSecret`). For the param case it
    re-wraps the loaded sub-app under the param segment so inner middleware
    still reads `c.req.param("wId")` correctly.
  - **`front-api/app.ts`**: every sub-app converted from
    `apiApp.route("/foo", fooApp)` to
    `lazyMount(apiApp, "/api", "/foo", () => import("./routes/foo"))`.
    Registration order is preserved (notably `/w/:wId/join` before `/w/:wId`,
    and `/:preStopSecret` last).
  - **`front-api/server.ts`**: `Hono-only server listening` log now includes
    `uptimeMs` so the startup delta is visible.

  ## Measured impact (local `tsx ./server.ts`)

  ```
  [INFO] Hono-only server listening  {"uptimeMs": 1666}
  GET /api/healthz  -> [lazy-mount] loaded /healthz in    4 ms
  GET /api/poke     -> [lazy-mount] loaded /poke    in 4304 ms (one-time)
  ```

  The ~4 s previously paid at boot for `/poke` is now paid only on its first
  hit; subsequent requests are free. The full `/w/:wId` subtree (357 files)
  similarly defers its load.

  ## Tradeoffs

  - First request to each route pays a one-time import cost. Subsequent
    requests are free.
  - In `requestLogger`, `c.req.routePath` is now the outer wildcard pattern
    (e.g. `/w/:wId/*`) rather than the inner matched route. Dev log fidelity
    drops; fixable later inside `lazy_mount.ts` if it bites.
  - Each forwarded request allocates a new `URL` + `Request` wrapper. Negligible
    in practice, and only on the dev path.
  - Module-load errors are deferred from startup to request time. Arguably nicer
    for dev (you can boot and use unrelated routes even if one route's import
    graph is broken), but worth knowing.

  ## Production

  Unchanged. `npm run build` (esbuild with `bundle: true`) inlines the dynamic
  `import()` calls into the single `dist/server.js`, so `node dist/server.js`
  boots the same as before.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
