### PR TITLE
Add: tool to update conversation title (universal harness)

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -66,6 +66,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "generate_random_number": "never_ask",
     "get_current_time": "never_ask",
     "math_operation": "never_ask",
+    "set_conversation_title": "never_ask",
     "wait": "never_ask",
   },
   "confluence": {

--- a/front/lib/api/actions/servers/common_utilities/metadata.ts
+++ b/front/lib/api/actions/servers/common_utilities/metadata.ts
@@ -88,6 +88,21 @@ export const COMMON_UTILITIES_TOOLS_METADATA = createToolsRecord({
       done: "Calculate",
     },
   },
+  set_conversation_title: {
+    description:
+      "Update the title of the current conversation. Use this to give the conversation a descriptive name that summarizes its topic.",
+    schema: {
+      title: z
+        .string()
+        .min(1)
+        .describe("The new title for the current conversation."),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Setting conversation title",
+      done: "Set conversation title",
+    },
+  },
 });
 
 export const COMMON_UTILITIES_SERVER = {

--- a/front/lib/api/actions/servers/common_utilities/tools/index.ts
+++ b/front/lib/api/actions/servers/common_utilities/tools/index.ts
@@ -2,6 +2,7 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { COMMON_UTILITIES_TOOLS_METADATA } from "@app/lib/api/actions/servers/common_utilities/metadata";
+import { updateConversationTitle } from "@app/lib/api/assistant/conversation/title";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { compile } from "mathjs";
@@ -92,6 +93,40 @@ const handlers: ToolHandlers<typeof COMMON_UTILITIES_TOOLS_METADATA> = {
         })
       );
     }
+  },
+
+  set_conversation_title: async ({ title }, { auth, agentLoopContext }) => {
+    const conversation =
+      agentLoopContext?.runContext?.conversation ??
+      agentLoopContext?.listToolsContext?.conversation;
+
+    if (!conversation) {
+      return new Err(
+        new MCPError(
+          "No conversation context available. This tool can only be used within a conversation."
+        )
+      );
+    }
+
+    const result = await updateConversationTitle(auth, {
+      conversationId: conversation.sId,
+      title,
+    });
+
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(
+          `Failed to update conversation title: ${result.error.message}`
+        )
+      );
+    }
+
+    return new Ok([
+      {
+        type: "text",
+        text: `Conversation title updated to "${title}".`,
+      },
+    ]);
   },
 };
 


### PR DESCRIPTION
## Description

Adds a `set_conversation_title` tool to the `common_utilities` MCP server (universal harness), allowing agents to programmatically rename the current conversation. The tool resolves the conversation from `agentLoopContext.runContext.conversation` (with fallback to `listToolsContext.conversation`), then delegates to the existing `updateConversationTitle` API. Stake is `never_ask` — no user approval required.

## Tests

Updated the `mcp_servers_metadata` snapshot test to include `set_conversation_title: "never_ask"`. Tested manually by triggering the tool in a live conversation.

## Risk

Low. Thin wrapper over an existing, well-tested `updateConversationTitle` path. The tool gracefully returns an `MCPError` if no conversation context is available (e.g., called outside a conversation), preventing silent failures. No schema changes.

## Deploy Plan

Deploy front.
