### PR TITLE
Add pin button to the frame renderer and preview

### DIFF
--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -5,6 +5,7 @@ import { CenteredState } from "@app/components/assistant/conversation/interactiv
 import { ExportContentDropdown } from "@app/components/assistant/conversation/interactive_content/ExportContentDropdown";
 import { ShareFrameSheet } from "@app/components/assistant/conversation/interactive_content/frame/ShareFrameSheet";
 import { InteractiveContentHeader } from "@app/components/assistant/conversation/interactive_content/InteractiveContentHeader";
+import { PinPodBannerButton } from "@app/components/assistant/conversation/space/PinPodBannerButton";
 import { ConfirmContext } from "@app/components/Confirm";
 import { useDesktopNavigation } from "@app/components/navigation/DesktopNavigationContext";
 import { useVisualizationRevert } from "@app/hooks/conversations";
@@ -14,6 +15,7 @@ import { useAuth } from "@app/lib/auth/AuthContext";
 import { useClientType } from "@app/lib/context/clientType";
 import { clientFetch } from "@app/lib/egress/client";
 import { useFileContent, useFileMetadata } from "@app/lib/swr/files";
+import { useProjectFiles } from "@app/lib/swr/projects";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
@@ -74,6 +76,10 @@ export function FrameRenderer({
     spaceId: conversation?.spaceId ?? projectId ?? null,
   });
 
+  const isFrameInPod = Boolean(
+    projectId && projectInfo?.kind === "project" && !projectInfo.archivedAt
+  );
+
   const projectSaveState = useMemo(() => {
     if (!projectInfo && isSpaceInfoLoading) {
       return "unknown";
@@ -91,6 +97,19 @@ export function FrameRenderer({
 
     return "saved";
   }, [conversation?.spaceId, projectId, projectInfo, isSpaceInfoLoading]);
+
+  const { files: projectFiles } = useProjectFiles({
+    owner,
+    spaceId: projectId ?? "",
+    disabled: !isFrameInPod,
+  });
+
+  const framePath = useMemo(() => {
+    const entry = projectFiles.find(
+      (file) => !file.isDirectory && file.fileId === fileId
+    );
+    return entry?.path ?? null;
+  }, [fileId, projectFiles]);
 
   const { closePanel, panelRef } = useConversationSidePanelContext();
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -354,6 +373,15 @@ export function FrameRenderer({
               fileName={fileMetadata?.fileName}
             />
             <ShareFrameSheet fileId={fileId} owner={owner} />
+            <PinPodBannerButton
+              owner={owner}
+              spaceId={projectId ?? ""}
+              pinnedFramePath={projectInfo?.pinnedFramePath ?? null}
+              isEditor={projectInfo?.isEditor ?? false}
+              framePath={framePath}
+              fileName={fileMetadata?.fileName}
+              hidden={!isFrameInPod}
+            />
             {projectSaveState === "saved" && (
               <Button
                 icon={CheckCircleIcon}

--- a/front/components/assistant/conversation/space/PinPodBannerButton.tsx
+++ b/front/components/assistant/conversation/space/PinPodBannerButton.tsx
@@ -1,0 +1,52 @@
+import { usePinPodBanner } from "@app/hooks/usePinPodBanner";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
+import type { LightWorkspaceType } from "@app/types/user";
+import { ActionPushpinIcon, Button } from "@dust-tt/sparkle";
+
+interface PinPodBannerButtonProps {
+  owner: LightWorkspaceType;
+  spaceId: string;
+  pinnedFramePath: string | null;
+  isEditor: boolean;
+  framePath: string | null;
+  fileName?: string;
+  hidden?: boolean;
+}
+
+export function PinPodBannerButton({
+  owner,
+  spaceId,
+  pinnedFramePath,
+  isEditor,
+  framePath,
+  fileName,
+  hidden,
+}: PinPodBannerButtonProps) {
+  const isMobile = useIsMobile();
+  const { togglePin, isPinned } = usePinPodBanner({
+    owner,
+    spaceId,
+    pinnedFramePath,
+    isEditor,
+  });
+
+  if (hidden || !isEditor || !framePath) {
+    return null;
+  }
+
+  const pinnedAsBanner = isPinned(framePath);
+
+  return (
+    <Button
+      icon={ActionPushpinIcon}
+      variant="ghost"
+      label={isMobile ? undefined : pinnedAsBanner ? "Pinned" : "Pin"}
+      tooltip={pinnedAsBanner ? "Unpin from Pod banner" : "Pin as Pod banner"}
+      onClick={() =>
+        void togglePin(framePath, {
+          fileName,
+        })
+      }
+    />
+  );
+}

--- a/front/components/assistant/conversation/space/ProjectFileExplorer.tsx
+++ b/front/components/assistant/conversation/space/ProjectFileExplorer.tsx
@@ -243,7 +243,11 @@ function ProjectFileExplorerContent({
   owner,
   space,
 }: ProjectFileExplorerProps) {
-  const [frameFileId, setFrameFileId] = useState<string | null>(null);
+  const [framePreview, setFramePreview] = useState<{
+    fileId: string;
+    path: string;
+    fileName: string;
+  } | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [currentFolderPath, setCurrentFolderPath] = useState("");
   const [navigationResetKey, setNavigationResetKey] = useState(0);
@@ -685,9 +689,15 @@ function ProjectFileExplorerContent({
     <>
       <ProjectFrameSheet
         owner={owner}
-        fileId={frameFileId}
-        isOpen={frameFileId !== null}
-        onClose={() => setFrameFileId(null)}
+        fileId={framePreview?.fileId ?? null}
+        framePath={framePreview?.path ?? null}
+        fileName={framePreview?.fileName}
+        spaceId={space.sId}
+        pinnedFramePath={space.pinnedFramePath ?? null}
+        isEditor={isEditor}
+        isArchived={isArchived}
+        isOpen={framePreview !== null}
+        onClose={() => setFramePreview(null)}
       />
 
       <RenameFileDialog
@@ -754,7 +764,15 @@ function ProjectFileExplorerContent({
         onDelete={!isArchived ? onDelete : undefined}
         onMoveFile={!isArchived ? onMoveFile : undefined}
         onRename={!isArchived ? onRename : undefined}
-        onOpenInteractive={(entry) => setFrameFileId(entry.fileId)}
+        onOpenInteractive={(entry) => {
+          if (entry.fileId) {
+            setFramePreview({
+              fileId: entry.fileId,
+              path: entry.path,
+              fileName: entry.fileName,
+            });
+          }
+        }}
         getExtraFileMenuItems={getExtraFileMenuItems}
         toolbarExtraActions={addButton}
         isLoading={isLoading}

--- a/front/components/assistant/conversation/space/ProjectFrameSheet.tsx
+++ b/front/components/assistant/conversation/space/ProjectFrameSheet.tsx
@@ -1,6 +1,7 @@
 import { VisualizationActionIframe } from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
 import { ExportContentDropdown } from "@app/components/assistant/conversation/interactive_content/ExportContentDropdown";
 import { ShareFrameSheet } from "@app/components/assistant/conversation/interactive_content/frame/ShareFrameSheet";
+import { PinPodBannerButton } from "@app/components/assistant/conversation/space/PinPodBannerButton";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { useFileContent, useFileMetadata } from "@app/lib/swr/files";
 import type { WorkspaceType } from "@app/types/user";
@@ -18,6 +19,12 @@ import { useRef } from "react";
 
 interface ProjectFrameSheetProps {
   fileId: string | null;
+  framePath: string | null;
+  fileName?: string;
+  spaceId: string;
+  pinnedFramePath: string | null;
+  isEditor: boolean;
+  isArchived: boolean;
   isOpen: boolean;
   onClose: () => void;
   owner: WorkspaceType;
@@ -25,6 +32,12 @@ interface ProjectFrameSheetProps {
 
 export function ProjectFrameSheet({
   fileId,
+  framePath,
+  fileName,
+  spaceId,
+  pinnedFramePath,
+  isEditor,
+  isArchived,
   isOpen,
   onClose,
   owner,
@@ -61,6 +74,15 @@ export function ProjectFrameSheet({
                   fileName={fileMetadata?.fileName}
                 />
                 <ShareFrameSheet fileId={fileId} owner={owner} />
+                <PinPodBannerButton
+                  owner={owner}
+                  spaceId={spaceId}
+                  pinnedFramePath={pinnedFramePath}
+                  isEditor={isEditor}
+                  framePath={framePath}
+                  fileName={fileName}
+                  hidden={isArchived}
+                />
               </div>
             )}
             <SheetClose asChild>


### PR DESCRIPTION
## Description

Adds `PinPodBannerButton` to both `FrameRenderer` (conversation side-panel) and `ProjectFrameSheet` (file explorer preview), letting Pod editors pin or unpin a frame as the Pod banner directly from those views. The button uses the existing `usePinPodBanner` hook and renders only for active (non-archived) pods where the viewer is an editor.

To resolve the frame path in `FrameRenderer` (which only had `fileId`), `useProjectFiles` is now called when the frame is inside a pod, with the path looked up via a `useMemo`. In `ProjectFileExplorerContent`, `frameFileId` state is expanded to `framePreview: { fileId, path, fileName }` so path and filename flow cleanly into `ProjectFrameSheet`.

> 📸 UI change — please attach a screenshot or GIF showing the pin button in both surfaces.

## Tests

Tested locally: opened a frame from a Pod conversation side-panel and from the file explorer preview sheet, verified the pin/unpin button appears for editors and is hidden for viewers and archived pods.

## Risk

Low. Purely additive UI — new component, no data model changes, no API changes. `PinPodBannerButton` renders `null` for all non-pod contexts, so existing non-pod frame flows are unaffected. `useProjectFiles` is only called when `isFrameInPod` is true, so no extra fetches in the common case.

## Deploy Plan

Deploy front.
