### PR TITLE
[front] start CP_FREE_PLAN from trial page (if metronome enabled)

### DIFF
--- a/front-api/routes/w/[wId]/trial/start.ts
+++ b/front-api/routes/w/[wId]/trial/start.ts
@@ -1,4 +1,6 @@
+import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
 import {
+  activateCreditPricedFreePlan,
   activatePhoneTrial,
   isWorkspaceEligibleForTrial,
 } from "@app/lib/plans/trial";
@@ -51,7 +53,11 @@ app.post("/", async (ctx): HandlerResult<PostTrialVerifyResponseBody> => {
     });
   }
 
-  await activatePhoneTrial(auth);
+  if (await isMetronomeBillingEnabled(auth)) {
+    await activateCreditPricedFreePlan(auth);
+  } else {
+    await activatePhoneTrial(auth);
+  }
 
   return ctx.json({ success: true });
 });

--- a/front-api/routes/w/[wId]/trial/start.ts
+++ b/front-api/routes/w/[wId]/trial/start.ts
@@ -1,6 +1,8 @@
-import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
 import {
   activateCreditPricedFreePlan,
+  isMetronomeBillingEnabled,
+} from "@app/lib/api/subscription";
+import {
   activatePhoneTrial,
   isWorkspaceEligibleForTrial,
 } from "@app/lib/plans/trial";

--- a/front/components/pages/onboarding/TrialPage.tsx
+++ b/front/components/pages/onboarding/TrialPage.tsx
@@ -1,5 +1,6 @@
-import { useAuth } from "@app/lib/auth/AuthContext";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
+import { useKillSwitches } from "@app/lib/swr/kill";
 import {
   Button,
   CheckIcon,
@@ -13,16 +14,22 @@ import React from "react";
 export function TrialPage() {
   const { workspace } = useAuth();
   const router = useAppRouter();
+  const { hasFeature } = useFeatureFlags();
+  const { killSwitches } = useKillSwitches();
+
+  const isMetronome =
+    hasFeature("metronome_billing") ||
+    !killSwitches?.includes("global_disable_metronome_billing");
 
   const skip = async () => {
     void router.push(`/w/${workspace.sId}/subscribe`);
   };
 
-  const startTrial = async () => {
+  const startFreePlan = async () => {
     void router.push(`/w/${workspace.sId}/verify`);
   };
 
-  const features = [
+  const legacyFeatures = [
     "Free 14-day trial",
     "Advanced models (GPT-5, Claude..)",
     "Custom agents which can execute actions",
@@ -30,6 +37,64 @@ export function TrialPage() {
     "Native integrations (Zendesk, Slack, Chrome Extension)",
     "100 free messages",
   ];
+
+  // TODO: improve copy and design in a follow-up
+  const freePlanFeatures = [
+    "Up to 5 users",
+    "300 AI credits per user (lifetime)",
+    "Advanced models (GPT-5, Claude..)",
+    "Custom agents which can execute actions",
+    "No credit card required · No time limit",
+  ];
+
+  if (isMetronome) {
+    // TODO: improve copy, layout and design in a follow-up
+    return (
+      <Page>
+        <div className="flex h-full flex-col justify-center">
+          <Page.Horizontal>
+            <Page.Vertical sizing="grow" gap="lg">
+              <Page.Header
+                title="Get started for free"
+                icon={() => <DustLogoSquare className="-ml-11 h-10 w-32" />}
+              />
+              <p className="-mt-4 text-muted-foreground dark:text-muted-foreground-night">
+                No credit card required · No time limit
+              </p>
+
+              <ul className="flex flex-col gap-4">
+                {freePlanFeatures.map((feature, index) => (
+                  <li key={index} className="flex items-center gap-3">
+                    <Icon
+                      visual={CheckIcon}
+                      size="sm"
+                      className="text-primary-500"
+                    />
+                    <span className="text-foreground dark:text-foreground-night">
+                      {feature}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+
+              <div className="flex flex-row gap-3">
+                <Button
+                  onClick={startFreePlan}
+                  variant="primary"
+                  label="Start for free"
+                />
+                <Button
+                  onClick={skip}
+                  variant="outline"
+                  label="Subscribe now"
+                />
+              </div>
+            </Page.Vertical>
+          </Page.Horizontal>
+        </div>
+      </Page>
+    );
+  }
 
   return (
     <Page>
@@ -43,9 +108,8 @@ export function TrialPage() {
             <p className="-mt-4 text-muted-foreground dark:text-muted-foreground-night">
               No credit card required
             </p>
-
             <ul className="flex flex-col gap-4">
-              {features.map((feature, index) => (
+              {legacyFeatures.map((feature, index) => (
                 <li key={index} className="flex items-center gap-3">
                   <Icon
                     visual={CheckIcon}
@@ -58,10 +122,9 @@ export function TrialPage() {
                 </li>
               ))}
             </ul>
-
             <div className="flex flex-row gap-3">
               <Button
-                onClick={startTrial}
+                onClick={startFreePlan}
                 variant="primary"
                 label="Start free trial"
               />

--- a/front/lib/api/subscription.ts
+++ b/front/lib/api/subscription.ts
@@ -2,8 +2,18 @@ import apiConfig from "@app/lib/api/config";
 import { getDataSources } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import { hasFeatureFlag } from "@app/lib/auth";
+import { floorToHourISO } from "@app/lib/metronome/client";
+import {
+  ensureMetronomeCustomerForWorkspace,
+  provisionMetronomeContract,
+} from "@app/lib/metronome/contracts";
+import { FREE_PACKAGE_ALIAS } from "@app/lib/metronome/types";
+import { PlanModel } from "@app/lib/models/plan";
+import { CREDIT_PRICED_FREE_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { terminateScheduleWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
@@ -33,6 +43,66 @@ export async function isMetronomeBillingEnabled(
  * - Unpauses all connectors (including webcrawler connectors)
  * - Re-enables all triggers that point to non-archived agents
  */
+export async function activateCreditPricedFreePlan(
+  auth: Authenticator
+): Promise<void> {
+  const owner = auth.getNonNullableWorkspace();
+  const lightWorkspace = renderLightWorkspaceType({ workspace: owner });
+  const now = new Date(floorToHourISO(new Date()));
+
+  const customerResult = await ensureMetronomeCustomerForWorkspace({
+    workspace: lightWorkspace,
+  });
+  if (customerResult.isErr()) {
+    throw new Error(
+      `Failed to ensure Metronome customer: ${customerResult.error.message}`
+    );
+  }
+  const { metronomeCustomerId } = customerResult.value;
+
+  const contractResult = await provisionMetronomeContract({
+    metronomeCustomerId,
+    workspace: lightWorkspace,
+    packageAlias: FREE_PACKAGE_ALIAS,
+    uniquenessKey: `cp-free-plan-${owner.sId}`,
+    startingAt: now,
+    swapAt: "current-hour",
+    enableStripeBilling: false,
+    planCode: CREDIT_PRICED_FREE_PLAN_CODE,
+  });
+  if (contractResult.isErr()) {
+    throw new Error(
+      `Failed to provision Metronome contract: ${contractResult.error.message}`
+    );
+  }
+  const { metronomeContractId } = contractResult.value;
+
+  const plan = await PlanModel.findOne({
+    where: { code: CREDIT_PRICED_FREE_PLAN_CODE },
+  });
+  if (!plan) {
+    throw new Error(
+      `Plan row for ${CREDIT_PRICED_FREE_PLAN_CODE} not found in DB. ` +
+        `Seed it in production before enabling Metronome billing.`
+    );
+  }
+
+  const subscriptionResult =
+    await SubscriptionResource.createSubscriptionFromCheckout({
+      workspaceModelId: owner.id,
+      plan,
+      metronomeContractId,
+      now,
+    });
+  if (subscriptionResult.isErr()) {
+    throw new Error(
+      `Failed to create subscription: ${subscriptionResult.error.message}`
+    );
+  }
+
+  await restoreWorkspaceAfterSubscription(auth);
+}
+
 export async function restoreWorkspaceAfterSubscription(auth: Authenticator) {
   const owner = auth.getNonNullableWorkspace();
 

--- a/front/lib/metronome/types.ts
+++ b/front/lib/metronome/types.ts
@@ -27,6 +27,9 @@ export const LEGACY_PRO_ANNUAL_EUR_PACKAGE_ALIAS = "legacy-pro-annual-eur";
 export const LEGACY_BUSINESS_EUR_PACKAGE_ALIAS = "legacy-business-eur";
 export const LEGACY_ENTERPRISE_EUR_PACKAGE_ALIAS = "legacy-enterprise-eur";
 
+// Free plan
+export const FREE_PACKAGE_ALIAS = "free-plan";
+
 export type MetronomePackageTier = "free" | "pro" | "business" | "enterprise";
 
 export const PAYG_ELIGIBLE_TIERS: readonly MetronomePackageTier[] = [

--- a/front/lib/plans/trial/index.ts
+++ b/front/lib/plans/trial/index.ts
@@ -1,14 +1,5 @@
-import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
 import type { Authenticator } from "@app/lib/auth";
-import { floorToHourISO } from "@app/lib/metronome/client";
 import {
-  ensureMetronomeCustomerForWorkspace,
-  provisionMetronomeContract,
-} from "@app/lib/metronome/contracts";
-import { FREE_PACKAGE_ALIAS } from "@app/lib/metronome/types";
-import { PlanModel } from "@app/lib/models/plan";
-import {
-  CREDIT_PRICED_FREE_PLAN_CODE,
   FREE_TRIAL_PHONE_PLAN_CODE,
   isOldFreePlan,
 } from "@app/lib/plans/plan_codes";
@@ -17,7 +8,6 @@ import {
   TRIAL_DURATION_DAYS,
 } from "@app/lib/plans/trial/constants";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
-import { renderLightWorkspaceType } from "@app/lib/workspace";
 
 /**
  * Checks if a workspace is eligible for the trial page.
@@ -54,71 +44,6 @@ export async function isWorkspaceEligibleForTrial(
   }
 
   return true;
-}
-
-/**
- * Activates the new credit-priced Free Plan (CP_FREE_PLAN) for a workspace.
- *
- * Do NOT call this directly. Use the isMetronomeBillingEnabled gate in trial/start.ts.
- */
-export async function activateCreditPricedFreePlan(
-  auth: Authenticator
-): Promise<void> {
-  const owner = auth.getNonNullableWorkspace();
-  const lightWorkspace = renderLightWorkspaceType({ workspace: owner });
-  const now = new Date(floorToHourISO(new Date()));
-
-  const customerResult = await ensureMetronomeCustomerForWorkspace({
-    workspace: lightWorkspace,
-  });
-  if (customerResult.isErr()) {
-    throw new Error(
-      `Failed to ensure Metronome customer: ${customerResult.error.message}`
-    );
-  }
-  const { metronomeCustomerId } = customerResult.value;
-
-  const contractResult = await provisionMetronomeContract({
-    metronomeCustomerId,
-    workspace: lightWorkspace,
-    packageAlias: FREE_PACKAGE_ALIAS,
-    uniquenessKey: `cp-free-plan-${owner.sId}`,
-    startingAt: now,
-    swapAt: "current-hour",
-    enableStripeBilling: false,
-    planCode: CREDIT_PRICED_FREE_PLAN_CODE,
-  });
-  if (contractResult.isErr()) {
-    throw new Error(
-      `Failed to provision Metronome contract: ${contractResult.error.message}`
-    );
-  }
-  const { metronomeContractId } = contractResult.value;
-
-  const plan = await PlanModel.findOne({
-    where: { code: CREDIT_PRICED_FREE_PLAN_CODE },
-  });
-  if (!plan) {
-    throw new Error(
-      `Plan row for ${CREDIT_PRICED_FREE_PLAN_CODE} not found in DB. ` +
-        `Seed it in production before enabling Metronome billing.`
-    );
-  }
-
-  const subscriptionResult =
-    await SubscriptionResource.createSubscriptionFromCheckout({
-      workspaceModelId: owner.id,
-      plan,
-      metronomeContractId,
-      now,
-    });
-  if (subscriptionResult.isErr()) {
-    throw new Error(
-      `Failed to create subscription: ${subscriptionResult.error.message}`
-    );
-  }
-
-  await restoreWorkspaceAfterSubscription(auth);
 }
 
 /**

--- a/front/lib/plans/trial/index.ts
+++ b/front/lib/plans/trial/index.ts
@@ -1,5 +1,14 @@
+import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
 import type { Authenticator } from "@app/lib/auth";
+import { floorToHourISO } from "@app/lib/metronome/client";
 import {
+  ensureMetronomeCustomerForWorkspace,
+  provisionMetronomeContract,
+} from "@app/lib/metronome/contracts";
+import { FREE_PACKAGE_ALIAS } from "@app/lib/metronome/types";
+import { PlanModel } from "@app/lib/models/plan";
+import {
+  CREDIT_PRICED_FREE_PLAN_CODE,
   FREE_TRIAL_PHONE_PLAN_CODE,
   isOldFreePlan,
 } from "@app/lib/plans/plan_codes";
@@ -8,6 +17,7 @@ import {
   TRIAL_DURATION_DAYS,
 } from "@app/lib/plans/trial/constants";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
 
 /**
  * Checks if a workspace is eligible for the trial page.
@@ -44,6 +54,71 @@ export async function isWorkspaceEligibleForTrial(
   }
 
   return true;
+}
+
+/**
+ * Activates the new credit-priced Free Plan (CP_FREE_PLAN) for a workspace.
+ *
+ * Do NOT call this directly. Use the isMetronomeBillingEnabled gate in trial/start.ts.
+ */
+export async function activateCreditPricedFreePlan(
+  auth: Authenticator
+): Promise<void> {
+  const owner = auth.getNonNullableWorkspace();
+  const lightWorkspace = renderLightWorkspaceType({ workspace: owner });
+  const now = new Date(floorToHourISO(new Date()));
+
+  const customerResult = await ensureMetronomeCustomerForWorkspace({
+    workspace: lightWorkspace,
+  });
+  if (customerResult.isErr()) {
+    throw new Error(
+      `Failed to ensure Metronome customer: ${customerResult.error.message}`
+    );
+  }
+  const { metronomeCustomerId } = customerResult.value;
+
+  const contractResult = await provisionMetronomeContract({
+    metronomeCustomerId,
+    workspace: lightWorkspace,
+    packageAlias: FREE_PACKAGE_ALIAS,
+    uniquenessKey: `cp-free-plan-${owner.sId}`,
+    startingAt: now,
+    swapAt: "current-hour",
+    enableStripeBilling: false,
+    planCode: CREDIT_PRICED_FREE_PLAN_CODE,
+  });
+  if (contractResult.isErr()) {
+    throw new Error(
+      `Failed to provision Metronome contract: ${contractResult.error.message}`
+    );
+  }
+  const { metronomeContractId } = contractResult.value;
+
+  const plan = await PlanModel.findOne({
+    where: { code: CREDIT_PRICED_FREE_PLAN_CODE },
+  });
+  if (!plan) {
+    throw new Error(
+      `Plan row for ${CREDIT_PRICED_FREE_PLAN_CODE} not found in DB. ` +
+        `Seed it in production before enabling Metronome billing.`
+    );
+  }
+
+  const subscriptionResult =
+    await SubscriptionResource.createSubscriptionFromCheckout({
+      workspaceModelId: owner.id,
+      plan,
+      metronomeContractId,
+      now,
+    });
+  if (subscriptionResult.isErr()) {
+    throw new Error(
+      `Failed to create subscription: ${subscriptionResult.error.message}`
+    );
+  }
+
+  await restoreWorkspaceAfterSubscription(auth);
 }
 
 /**

--- a/front/pages/api/w/[wId]/trial/start.ts
+++ b/front/pages/api/w/[wId]/trial/start.ts
@@ -2,8 +2,10 @@
 
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
 import type { Authenticator } from "@app/lib/auth";
 import {
+  activateCreditPricedFreePlan,
   activatePhoneTrial,
   isWorkspaceEligibleForTrial,
 } from "@app/lib/plans/trial";
@@ -57,7 +59,11 @@ async function handler(
         });
       }
 
-      await activatePhoneTrial(auth);
+      if (await isMetronomeBillingEnabled(auth)) {
+        await activateCreditPricedFreePlan(auth);
+      } else {
+        await activatePhoneTrial(auth);
+      }
 
       return res.status(200).json({ success: true });
     }

--- a/front/pages/api/w/[wId]/trial/start.ts
+++ b/front/pages/api/w/[wId]/trial/start.ts
@@ -2,10 +2,12 @@
 
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
-import type { Authenticator } from "@app/lib/auth";
 import {
   activateCreditPricedFreePlan,
+  isMetronomeBillingEnabled,
+} from "@app/lib/api/subscription";
+import type { Authenticator } from "@app/lib/auth";
+import {
   activatePhoneTrial,
   isWorkspaceEligibleForTrial,
 } from "@app/lib/plans/trial";

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -35,6 +35,15 @@ import {
   EXCESS_CREDIT_NAME,
   FREE_ANNUAL_CREDIT_NAME,
   FREE_MONTHLY_CREDIT_NAME,
+  FREE_PACKAGE_ALIAS,
+  LEGACY_BUSINESS_EUR_PACKAGE_ALIAS,
+  LEGACY_BUSINESS_PACKAGE_ALIAS,
+  LEGACY_ENTERPRISE_EUR_PACKAGE_ALIAS,
+  LEGACY_ENTERPRISE_PACKAGE_ALIAS,
+  LEGACY_PRO_ANNUAL_EUR_PACKAGE_ALIAS,
+  LEGACY_PRO_ANNUAL_PACKAGE_ALIAS,
+  LEGACY_PRO_MONTHLY_EUR_PACKAGE_ALIAS,
+  LEGACY_PRO_MONTHLY_PACKAGE_ALIAS,
 } from "@app/lib/metronome/types";
 import type { SupportedCurrency } from "@app/types/currency";
 
@@ -1499,7 +1508,7 @@ function getPackages(): PackageDef[] {
   return [
     {
       name: "Legacy Pro USD",
-      aliases: [{ name: "legacy-pro-monthly" }],
+      aliases: [{ name: LEGACY_PRO_MONTHLY_PACKAGE_ALIAS }],
       rate_card_name: "Legacy Pro USD",
       subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
       recurring_credits: [
@@ -1510,7 +1519,7 @@ function getPackages(): PackageDef[] {
     },
     {
       name: "Legacy Business USD",
-      aliases: [{ name: "legacy-business" }],
+      aliases: [{ name: LEGACY_BUSINESS_PACKAGE_ALIAS }],
       rate_card_name: "Legacy Business USD",
       subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
       recurring_credits: [
@@ -1521,7 +1530,7 @@ function getPackages(): PackageDef[] {
     },
     {
       name: "Legacy Pro Annual USD",
-      aliases: [{ name: "legacy-pro-annual" }],
+      aliases: [{ name: LEGACY_PRO_ANNUAL_PACKAGE_ALIAS }],
       rate_card_name: "Legacy Pro Annual USD",
       subscriptions: [LEGACY_SEAT_ANNUAL_SUBSCRIPTION],
       recurring_credits: [
@@ -1533,7 +1542,7 @@ function getPackages(): PackageDef[] {
     // Enterprise: MAU-based billing, no seat subscriptions.
     {
       name: "Legacy Enterprise USD",
-      aliases: [{ name: "legacy-enterprise" }],
+      aliases: [{ name: LEGACY_ENTERPRISE_PACKAGE_ALIAS }],
       rate_card_name: "Legacy Enterprise MAU USD",
       scheduled_charges_on_usage_invoices: "ALL",
       recurring_credits: [
@@ -1545,7 +1554,7 @@ function getPackages(): PackageDef[] {
     // EUR variants
     {
       name: "Legacy Pro EUR",
-      aliases: [{ name: "legacy-pro-monthly-eur" }],
+      aliases: [{ name: LEGACY_PRO_MONTHLY_EUR_PACKAGE_ALIAS }],
       rate_card_name: "Legacy Pro EUR",
       subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
       recurring_credits: [
@@ -1556,7 +1565,7 @@ function getPackages(): PackageDef[] {
     },
     {
       name: "Legacy Business EUR",
-      aliases: [{ name: "legacy-business-eur" }],
+      aliases: [{ name: LEGACY_BUSINESS_EUR_PACKAGE_ALIAS }],
       rate_card_name: "Legacy Business EUR",
       subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
       recurring_credits: [
@@ -1567,7 +1576,7 @@ function getPackages(): PackageDef[] {
     },
     {
       name: "Legacy Pro Annual EUR",
-      aliases: [{ name: "legacy-pro-annual-eur" }],
+      aliases: [{ name: LEGACY_PRO_ANNUAL_EUR_PACKAGE_ALIAS }],
       rate_card_name: "Legacy Pro Annual EUR",
       subscriptions: [LEGACY_SEAT_ANNUAL_SUBSCRIPTION],
       recurring_credits: [
@@ -1578,7 +1587,7 @@ function getPackages(): PackageDef[] {
     },
     {
       name: "Legacy Enterprise EUR",
-      aliases: [{ name: "legacy-enterprise-eur" }],
+      aliases: [{ name: LEGACY_ENTERPRISE_EUR_PACKAGE_ALIAS }],
       rate_card_name: "Legacy Enterprise MAU EUR",
       scheduled_charges_on_usage_invoices: "ALL",
       recurring_credits: [
@@ -1777,7 +1786,7 @@ function getPackages(): PackageDef[] {
     // Free plan — entitles only the Free Seat
     {
       name: "Free plan",
-      aliases: [{ name: "free-plan" }],
+      aliases: [{ name: FREE_PACKAGE_ALIAS }],
       rate_card_name: "Free plan",
       subscriptions: [FREE_SEAT_SUBSCRIPTION],
       scheduled_charges_on_usage_invoices: "ALL",


### PR DESCRIPTION
## Description

* small cleaning using package aliases defined in types in metronome_setup
* when metronome is enabled only (feature flag enabled or kill switch disabled)
  * placeholder update for the trial page for the free plan (instead of the trial plan)
  * call activateCreditPricedFreePlan (new function in subscription lib/api)

Not included: call activateCreditPricedFreePlan when using poke plugin for workspace creation with CREDIT_PRICED_FREE_PLAN_CODE

## Tests

Tested locally

## Risk

Low, path not used yet (metronome enabled for new free plans)

## Deploy Plan

Deploy front