### PR TITLE
Billing info endpoints

### DIFF
--- a/front-api/routes/w/[wId]/billing/index.ts
+++ b/front-api/routes/w/[wId]/billing/index.ts
@@ -1,0 +1,10 @@
+import { workspaceApp } from "@front-api/middlewares/ctx";
+
+import info from "./info";
+
+// Mounted at /api/w/:wId/billing.
+const app = workspaceApp();
+
+app.route("/info", info);
+
+export default app;

--- a/front-api/routes/w/[wId]/billing/info.ts
+++ b/front-api/routes/w/[wId]/billing/info.ts
@@ -1,0 +1,39 @@
+import {
+  getWorkspaceBillingInfo,
+  type GetBillingInfoResponseBody,
+} from "@app/lib/api/billing/info";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+
+// Mounted at /api/w/:wId/billing/info.
+const app = workspaceApp();
+
+app.get("/", async (ctx): HandlerResult<GetBillingInfoResponseBody> => {
+  const auth = ctx.get("auth");
+
+  if (!auth.isAdmin()) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can access this endpoint.",
+      },
+    });
+  }
+
+  const result = await getWorkspaceBillingInfo(auth);
+  if (result.isErr()) {
+    return apiError(ctx, {
+      status_code: 502,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to fetch Stripe billing information: ${result.error.message}`,
+      },
+    });
+  }
+
+  return ctx.json({ billingInfo: result.value });
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/billing/info.ts
+++ b/front-api/routes/w/[wId]/billing/info.ts
@@ -1,6 +1,6 @@
 import {
-  getWorkspaceBillingInfo,
   type GetBillingInfoResponseBody,
+  getWorkspaceBillingInfo,
 } from "@app/lib/api/billing/info";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -19,6 +19,7 @@ import { z } from "zod";
 import assistant from "./assistant";
 import auditLogs from "./audit-logs";
 import authContext from "./auth-context";
+import billing from "./billing";
 import builder from "./builder";
 import coupon from "./coupon";
 import credentials from "./credentials";
@@ -564,6 +565,7 @@ app.post(
 // targets declared above.
 app.route("/assistant", assistant);
 app.route("/audit-logs", auditLogs);
+app.route("/billing", billing);
 app.route("/builder", builder);
 app.route("/credentials", credentials);
 app.route("/credits", credits);

--- a/front/lib/api/billing/info.ts
+++ b/front/lib/api/billing/info.ts
@@ -143,8 +143,8 @@ async function getDefaultPaymentMethod(
 export async function getWorkspaceBillingInfo(
   auth: Authenticator
 ): Promise<Result<BillingInfo | null, Error>> {
-  const owner = auth.workspace() as WorkspaceType | null;
-  const subscription = auth.subscription() as SubscriptionType | null;
+  const owner = auth.workspace() ?? null;
+  const subscription = auth.subscription() ?? null;
 
   if (!owner || !subscription || !isCreditPricedPlan(subscription.plan)) {
     return new Ok(null);

--- a/front/lib/api/billing/info.ts
+++ b/front/lib/api/billing/info.ts
@@ -126,8 +126,7 @@ function serializePaymentMethod(
 async function getDefaultPaymentMethod(
   customer: Stripe.Customer
 ): Promise<BillingPaymentMethod | null> {
-  const defaultPaymentMethod =
-    customer.invoice_settings.default_payment_method;
+  const defaultPaymentMethod = customer.invoice_settings.default_payment_method;
   if (!defaultPaymentMethod) {
     return null;
   }

--- a/front/lib/api/billing/info.ts
+++ b/front/lib/api/billing/info.ts
@@ -3,12 +3,10 @@ import {
   getBillingStripeCustomerId,
   getStripeClient,
 } from "@app/lib/plans/stripe";
-import type { SubscriptionType } from "@app/types/plan";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { errorToString } from "@app/types/shared/utils/error_utils";
-import type { WorkspaceType } from "@app/types/user";
 import type Stripe from "stripe";
 
 export type BillingAddress = {

--- a/front/lib/api/billing/info.ts
+++ b/front/lib/api/billing/info.ts
@@ -1,0 +1,189 @@
+import type { Authenticator } from "@app/lib/auth";
+import {
+  getBillingStripeCustomerId,
+  getStripeClient,
+} from "@app/lib/plans/stripe";
+import type { SubscriptionType } from "@app/types/plan";
+import { isCreditPricedPlan } from "@app/types/plan";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { errorToString } from "@app/types/shared/utils/error_utils";
+import type { WorkspaceType } from "@app/types/user";
+import type Stripe from "stripe";
+
+export type BillingAddress = {
+  line1: string | null;
+  line2: string | null;
+  city: string | null;
+  state: string | null;
+  postalCode: string | null;
+  country: string | null;
+};
+
+export type BillingProfile = {
+  name: string | null;
+  email: string | null;
+  phone: string | null;
+  address: BillingAddress | null;
+};
+
+export type BillingPaymentMethod = {
+  type: string;
+  brand: string | null;
+  last4: string | null;
+  expMonth: number | null;
+  expYear: number | null;
+  bankName: string | null;
+  country: string | null;
+};
+
+export type BillingInfo = {
+  profile: BillingProfile;
+  paymentMethod: BillingPaymentMethod | null;
+};
+
+export type GetBillingInfoResponseBody = {
+  billingInfo: BillingInfo | null;
+};
+
+function serializeAddress(
+  address: Stripe.Address | null | undefined
+): BillingAddress | null {
+  if (!address) {
+    return null;
+  }
+
+  const serialized = {
+    line1: address.line1 ?? null,
+    line2: address.line2 ?? null,
+    city: address.city ?? null,
+    state: address.state ?? null,
+    postalCode: address.postal_code ?? null,
+    country: address.country ?? null,
+  };
+
+  return Object.values(serialized).some((value) => value !== null)
+    ? serialized
+    : null;
+}
+
+function isExpandedPaymentMethod(
+  paymentMethod: Stripe.Customer.InvoiceSettings["default_payment_method"]
+): paymentMethod is Stripe.PaymentMethod {
+  return typeof paymentMethod === "object" && paymentMethod !== null;
+}
+
+function serializePaymentMethod(
+  paymentMethod: Stripe.PaymentMethod
+): BillingPaymentMethod {
+  switch (paymentMethod.type) {
+    case "card":
+      return {
+        type: paymentMethod.type,
+        brand: paymentMethod.card?.brand ?? null,
+        last4: paymentMethod.card?.last4 ?? null,
+        expMonth: paymentMethod.card?.exp_month ?? null,
+        expYear: paymentMethod.card?.exp_year ?? null,
+        bankName: null,
+        country: paymentMethod.card?.country ?? null,
+      };
+
+    case "sepa_debit":
+      return {
+        type: paymentMethod.type,
+        brand: null,
+        last4: paymentMethod.sepa_debit?.last4 ?? null,
+        expMonth: null,
+        expYear: null,
+        bankName: paymentMethod.sepa_debit?.bank_code ?? null,
+        country: paymentMethod.sepa_debit?.country ?? null,
+      };
+
+    case "us_bank_account":
+      return {
+        type: paymentMethod.type,
+        brand: null,
+        last4: paymentMethod.us_bank_account?.last4 ?? null,
+        expMonth: null,
+        expYear: null,
+        bankName: paymentMethod.us_bank_account?.bank_name ?? null,
+        country: null,
+      };
+
+    default:
+      return {
+        type: paymentMethod.type,
+        brand: null,
+        last4: null,
+        expMonth: null,
+        expYear: null,
+        bankName: null,
+        country: null,
+      };
+  }
+}
+
+async function getDefaultPaymentMethod(
+  customer: Stripe.Customer
+): Promise<BillingPaymentMethod | null> {
+  const defaultPaymentMethod =
+    customer.invoice_settings.default_payment_method;
+  if (!defaultPaymentMethod) {
+    return null;
+  }
+
+  if (isExpandedPaymentMethod(defaultPaymentMethod)) {
+    return serializePaymentMethod(defaultPaymentMethod);
+  }
+
+  const paymentMethod =
+    await getStripeClient().paymentMethods.retrieve(defaultPaymentMethod);
+  return serializePaymentMethod(paymentMethod);
+}
+
+export async function getWorkspaceBillingInfo(
+  auth: Authenticator
+): Promise<Result<BillingInfo | null, Error>> {
+  const owner = auth.workspace() as WorkspaceType | null;
+  const subscription = auth.subscription() as SubscriptionType | null;
+
+  if (!owner || !subscription || !isCreditPricedPlan(subscription.plan)) {
+    return new Ok(null);
+  }
+
+  const stripeCustomerIdRes = await getBillingStripeCustomerId({
+    owner,
+    subscription,
+  });
+  if (stripeCustomerIdRes.isErr()) {
+    return stripeCustomerIdRes;
+  }
+  if (!stripeCustomerIdRes.value) {
+    return new Ok(null);
+  }
+
+  try {
+    const customer = await getStripeClient().customers.retrieve(
+      stripeCustomerIdRes.value,
+      {
+        expand: ["invoice_settings.default_payment_method"],
+      }
+    );
+
+    if (customer.deleted) {
+      return new Ok(null);
+    }
+
+    return new Ok({
+      profile: {
+        name: customer.name ?? null,
+        email: customer.email ?? null,
+        phone: customer.phone ?? null,
+        address: serializeAddress(customer.address),
+      },
+      paymentMethod: await getDefaultPaymentMethod(customer),
+    });
+  } catch (error) {
+    return new Err(new Error(errorToString(error)));
+  }
+}

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -613,55 +613,65 @@ export const createCustomerPortalSession = async ({
 }): Promise<string | null> => {
   const stripe = getStripeClient();
 
-  // Resolve the Stripe customer: prefer the Stripe subscription's customer
-  // when available; for Metronome-only billed workspaces (no Stripe sub),
-  // read the linked Stripe customer from the Metronome billing config.
-  let stripeCustomerId: string | null = null;
-
-  if (subscription.stripeSubscriptionId) {
-    const stripeSubscription = await getStripeSubscription(
-      subscription.stripeSubscriptionId
-    );
-    if (!stripeSubscription) {
-      throw new Error(
-        `No stripeSubscription found for the workspace: ${owner.sId}`
-      );
-    }
-    const customer = stripeSubscription.customer;
-    if (typeof customer !== "string") {
-      throw new Error(
-        `No stripeCustomerId found for the workspace: ${owner.sId}`
-      );
-    }
-    stripeCustomerId = customer;
-  } else if (owner.metronomeCustomerId) {
-    const result = await getMetronomeCustomerStripeCustomerId(
-      owner.metronomeCustomerId
-    );
-    if (result.isErr()) {
-      throw new Error(
-        `Failed to resolve Stripe customer for Metronome-only workspace ${owner.sId}: ${result.error.message}`
-      );
-    }
-    if (!result.value) {
-      throw new Error(
-        `No Stripe billing configuration found for Metronome customer of workspace ${owner.sId}`
-      );
-    }
-    stripeCustomerId = result.value;
-  } else {
+  const stripeCustomerIdRes = await getBillingStripeCustomerId({
+    owner,
+    subscription,
+  });
+  if (stripeCustomerIdRes.isErr()) {
+    throw stripeCustomerIdRes.error;
+  }
+  if (!stripeCustomerIdRes.value) {
     throw new Error(
       `No Stripe subscription or Metronome customer for the workspace: ${owner.sId}`
     );
   }
 
   const portalSession = await stripe.billingPortal.sessions.create({
-    customer: stripeCustomerId,
+    customer: stripeCustomerIdRes.value,
     return_url: `${config.getAppUrl()}/w/${owner.sId}/subscription`,
   });
 
   return portalSession.url;
 };
+
+export async function getBillingStripeCustomerId({
+  owner,
+  subscription,
+}: {
+  owner: WorkspaceType;
+  subscription: SubscriptionType;
+}): Promise<Result<string | null, Error>> {
+  if (subscription.stripeSubscriptionId) {
+    const stripeSubscription = await getStripeSubscription(
+      subscription.stripeSubscriptionId
+    );
+    if (!stripeSubscription) {
+      return new Err(
+        new Error(`No stripeSubscription found for workspace ${owner.sId}.`)
+      );
+    }
+
+    return new Ok(getCustomerId(stripeSubscription));
+  }
+
+  if (owner.metronomeCustomerId) {
+    const result = await getMetronomeCustomerStripeCustomerId(
+      owner.metronomeCustomerId
+    );
+    if (result.isErr()) {
+      return new Err(
+        new Error(
+          `Failed to resolve Stripe customer for Metronome workspace ` +
+            `${owner.sId}: ${result.error.message}`
+        )
+      );
+    }
+
+    return new Ok(result.value);
+  }
+
+  return new Ok(null);
+}
 
 /**
  * Calls the Stripe API to retrieve a product by its ID.

--- a/front/pages/api/w/[wId]/billing/info.ts
+++ b/front/pages/api/w/[wId]/billing/info.ts
@@ -1,11 +1,11 @@
 // @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
 
-import {
-  getWorkspaceBillingInfo,
-  type GetBillingInfoResponseBody,
-} from "@app/lib/api/billing/info";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import {
+  type GetBillingInfoResponseBody,
+  getWorkspaceBillingInfo,
+} from "@app/lib/api/billing/info";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";

--- a/front/pages/api/w/[wId]/billing/info.ts
+++ b/front/pages/api/w/[wId]/billing/info.ts
@@ -1,0 +1,54 @@
+// @migration-status: MIGRATED_TO_HONO
+/** @ignoreswagger */
+
+import {
+  getWorkspaceBillingInfo,
+  type GetBillingInfoResponseBody,
+} from "@app/lib/api/billing/info";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetBillingInfoResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can access this endpoint.",
+      },
+    });
+  }
+
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  const result = await getWorkspaceBillingInfo(auth);
+  if (result.isErr()) {
+    return apiError(req, res, {
+      status_code: 502,
+      api_error: {
+        type: "internal_server_error",
+        message: `Failed to fetch Stripe billing information: ${result.error.message}`,
+      },
+    });
+  }
+
+  return res.status(200).json({ billingInfo: result.value });
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

Introduce billing info endpoints to retrieve general billing information see `BillingInfo` object.

Extracts `getBillingStripeCustomerId` out of `createCustomerPortalSession` to reuse in new `getWorkspaceBillingInfo` 

Work for https://github.com/dust-tt/tasks/issues/7481

## Tests

Tested locally (both flows)

## Risk

None

## Deploy Plan

- deploy `front`