### PR TITLE
[ASSISTANT] move whitelisted-model helpers to front/lib/api

### DIFF
--- a/front-api/routes/w/[wId]/assistant/builder/process/generate_schema.ts
+++ b/front-api/routes/w/[wId]/assistant/builder/process/generate_schema.ts
@@ -1,8 +1,6 @@
 import { getBuilderJsonSchemaGenerator } from "@app/lib/api/assistant/json_schema_generator";
-import {
-  getLargeWhitelistedModel,
-  getSmallWhitelistedModel,
-} from "@app/lib/assistant";
+import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
+import { getLargeWhitelistedModel } from "@app/lib/assistant";
 import { InternalPostBuilderGenerateSchemaRequestBodySchema } from "@app/types/api/internal/assistant";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/assistant/builder/process/generate_schema.ts
+++ b/front-api/routes/w/[wId]/assistant/builder/process/generate_schema.ts
@@ -1,6 +1,8 @@
 import { getBuilderJsonSchemaGenerator } from "@app/lib/api/assistant/json_schema_generator";
-import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
-import { getLargeWhitelistedModel } from "@app/lib/assistant";
+import {
+  getLargeWhitelistedModel,
+  getSmallWhitelistedModel,
+} from "@app/lib/api/assistant/models";
 import { InternalPostBuilderGenerateSchemaRequestBodySchema } from "@app/types/api/internal/assistant";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/compactions.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/compactions.ts
@@ -1,6 +1,6 @@
 import { compactConversation } from "@app/lib/api/assistant/conversation/compaction";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
-import { isProviderWhitelisted } from "@app/lib/assistant";
+import { isProviderWhitelisted } from "@app/lib/api/assistant/models";
 import { isSupportedModel } from "@app/types/assistant/assistant";
 import type { CompactionMessageType } from "@app/types/assistant/conversation";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";

--- a/front-api/routes/w/[wId]/models.ts
+++ b/front-api/routes/w/[wId]/models.ts
@@ -2,11 +2,9 @@ import {
   REASONING_MODEL_CONFIGS,
   USED_MODEL_CONFIGS,
 } from "@app/components/providers/model_configs";
+import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
 import { config as regionConfig } from "@app/lib/api/regions/config";
-import {
-  filterCustomAvailableAndWhitelistedModels,
-  getWhitelistedProviders,
-} from "@app/lib/assistant";
+import { filterCustomAvailableAndWhitelistedModels } from "@app/lib/assistant";
 import { getFeatureFlags } from "@app/lib/auth";
 import { CUSTOM_MODEL_CONFIGS } from "@app/types/assistant/models/custom_models.generated";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";

--- a/front/lib/actions/mcp_internal_actions/utils/web_summarization.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/web_summarization.ts
@@ -1,7 +1,9 @@
 import type { AgentLoopRunContextType } from "@app/lib/actions/types";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
-import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
-import { getSmallWhitelistedModel } from "@app/lib/assistant";
+import {
+  getSmallWhitelistedModel,
+  getWhitelistedProviders,
+} from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
 import { CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";

--- a/front/lib/actions/mcp_internal_actions/utils/web_summarization.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/web_summarization.ts
@@ -1,9 +1,7 @@
 import type { AgentLoopRunContextType } from "@app/lib/actions/types";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
-import {
-  getSmallWhitelistedModel,
-  getWhitelistedProviders,
-} from "@app/lib/assistant";
+import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
+import { getSmallWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
 import { CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";

--- a/front/lib/api/assistant/agent_suggestion.ts
+++ b/front/lib/api/assistant/agent_suggestion.ts
@@ -1,6 +1,6 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
-import { getFastestWhitelistedModel } from "@app/lib/assistant";
+import { getFastestWhitelistedModel } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { Result } from "@app/types/shared/result";

--- a/front/lib/api/assistant/configuration/triggers/webhook_filter.ts
+++ b/front/lib/api/assistant/configuration/triggers/webhook_filter.ts
@@ -1,6 +1,6 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
-import { getLargeWhitelistedModel } from "@app/lib/assistant";
+import { getLargeWhitelistedModel } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -26,6 +26,7 @@ import {
   batchRenderMessages,
   batchRenderUserMessagesWithoutMentions,
 } from "@app/lib/api/assistant/messages";
+import { isProviderWhitelisted } from "@app/lib/api/assistant/models";
 import { gracefullyStopAgentLoop } from "@app/lib/api/assistant/pubsub";
 import {
   MESSAGE_RATE_LIMIT_PER_ACTOR_PER_HOUR,
@@ -57,7 +58,7 @@ import {
 } from "@app/lib/api/programmatic_usage/tracking";
 import { fetchLatestProjectContextFileContentFragment } from "@app/lib/api/projects/context";
 import { config as regionConfig } from "@app/lib/api/regions/config";
-import { isModelAvailable, isProviderWhitelisted } from "@app/lib/assistant";
+import { isModelAvailable } from "@app/lib/assistant";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { extractFromString, serializeMention } from "@app/lib/mentions/format";

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -9,6 +9,7 @@ import { compactConversation } from "@app/lib/api/assistant/conversation/compact
 import { replaceStandaloneAttachmentIds } from "@app/lib/api/assistant/conversation/compaction_attachment_id_replacements";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
+import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
 import { getOrCreateConversationDataSourceFromFile } from "@app/lib/api/data_sources";
 import { isSandboxRawDelimitedConversationFile } from "@app/lib/api/files/sandbox_raw";
 import {
@@ -16,7 +17,6 @@ import {
   processAndUpsertToDataSource,
 } from "@app/lib/api/files/upsert";
 import { getFileContent } from "@app/lib/api/files/utils";
-import { getSmallWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";

--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -1,9 +1,11 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import { renderConversationAsText } from "@app/lib/api/assistant/conversation/render_as_text";
-import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
+import {
+  getSmallWhitelistedModel,
+  getWhitelistedProviders,
+} from "@app/lib/api/assistant/models";
 import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
-import { getSmallWhitelistedModel } from "@app/lib/assistant";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";

--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -1,11 +1,9 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import { renderConversationAsText } from "@app/lib/api/assistant/conversation/render_as_text";
+import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
 import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
-import {
-  getSmallWhitelistedModel,
-  getWhitelistedProviders,
-} from "@app/lib/assistant";
+import { getSmallWhitelistedModel } from "@app/lib/assistant";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -19,8 +19,10 @@ import {
   _getToolsetsToolsConfiguration,
 } from "@app/lib/api/assistant/global_agents/tools";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
-import { isProviderWhitelisted } from "@app/lib/api/assistant/models";
-import { getLargeWhitelistedModel } from "@app/lib/assistant";
+import {
+  getLargeWhitelistedModel,
+  isProviderWhitelisted,
+} from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import type {

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -19,10 +19,8 @@ import {
   _getToolsetsToolsConfiguration,
 } from "@app/lib/api/assistant/global_agents/tools";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
-import {
-  getLargeWhitelistedModel,
-  isProviderWhitelisted,
-} from "@app/lib/assistant";
+import { isProviderWhitelisted } from "@app/lib/api/assistant/models";
+import { getLargeWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import type {

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -25,10 +25,10 @@ import {
 } from "@app/lib/api/assistant/global_agents/tools";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
 import {
+  getLargeWhitelistedModel,
   getSmallWhitelistedModel,
   isProviderWhitelisted,
 } from "@app/lib/api/assistant/models";
-import { getLargeWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import {

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -24,11 +24,11 @@ import {
   _getToolsetsToolsConfiguration,
 } from "@app/lib/api/assistant/global_agents/tools";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
-import { isProviderWhitelisted } from "@app/lib/api/assistant/models";
 import {
-  getLargeWhitelistedModel,
   getSmallWhitelistedModel,
-} from "@app/lib/assistant";
+  isProviderWhitelisted,
+} from "@app/lib/api/assistant/models";
+import { getLargeWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import {

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -24,10 +24,10 @@ import {
   _getToolsetsToolsConfiguration,
 } from "@app/lib/api/assistant/global_agents/tools";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
+import { isProviderWhitelisted } from "@app/lib/api/assistant/models";
 import {
   getLargeWhitelistedModel,
   getSmallWhitelistedModel,
-  isProviderWhitelisted,
 } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";

--- a/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
@@ -6,10 +6,10 @@ import type {
   PrefetchedDataSourcesType,
 } from "@app/lib/api/assistant/global_agents/tools";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
+import { isProviderWhitelisted } from "@app/lib/api/assistant/models";
 import {
   getLargeWhitelistedModel,
   getSmallWhitelistedModel,
-  isProviderWhitelisted,
 } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import type {

--- a/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
@@ -7,10 +7,10 @@ import type {
 } from "@app/lib/api/assistant/global_agents/tools";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
 import {
+  getLargeWhitelistedModel,
   getSmallWhitelistedModel,
   isProviderWhitelisted,
 } from "@app/lib/api/assistant/models";
-import { getLargeWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import type {
   AgentConfigurationType,

--- a/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/sidekick.ts
@@ -6,11 +6,11 @@ import type {
   PrefetchedDataSourcesType,
 } from "@app/lib/api/assistant/global_agents/tools";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
-import { isProviderWhitelisted } from "@app/lib/api/assistant/models";
 import {
-  getLargeWhitelistedModel,
   getSmallWhitelistedModel,
-} from "@app/lib/assistant";
+  isProviderWhitelisted,
+} from "@app/lib/api/assistant/models";
+import { getLargeWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import type {
   AgentConfigurationType,

--- a/front/lib/api/assistant/global_agents/configurations/helper.ts
+++ b/front/lib/api/assistant/global_agents/configurations/helper.ts
@@ -7,8 +7,10 @@ import {
   _getDefaultWebActionsForGlobalAgent,
 } from "@app/lib/api/assistant/global_agents/tools";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
-import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
-import { getLargeWhitelistedModel } from "@app/lib/assistant";
+import {
+  getLargeWhitelistedModel,
+  getSmallWhitelistedModel,
+} from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import type {
   AgentConfigurationType,

--- a/front/lib/api/assistant/global_agents/configurations/helper.ts
+++ b/front/lib/api/assistant/global_agents/configurations/helper.ts
@@ -7,10 +7,8 @@ import {
   _getDefaultWebActionsForGlobalAgent,
 } from "@app/lib/api/assistant/global_agents/tools";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
-import {
-  getLargeWhitelistedModel,
-  getSmallWhitelistedModel,
-} from "@app/lib/assistant";
+import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
+import { getLargeWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import type {
   AgentConfigurationType,

--- a/front/lib/api/assistant/global_agents/configurations/retired_managed.ts
+++ b/front/lib/api/assistant/global_agents/configurations/retired_managed.ts
@@ -6,10 +6,8 @@ import type {
   PrefetchedDataSourcesType,
 } from "@app/lib/api/assistant/global_agents/tools";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
-import {
-  getLargeWhitelistedModel,
-  getSmallWhitelistedModel,
-} from "@app/lib/assistant";
+import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
+import { getLargeWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";

--- a/front/lib/api/assistant/global_agents/configurations/retired_managed.ts
+++ b/front/lib/api/assistant/global_agents/configurations/retired_managed.ts
@@ -6,8 +6,10 @@ import type {
   PrefetchedDataSourcesType,
 } from "@app/lib/api/assistant/global_agents/tools";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
-import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
-import { getLargeWhitelistedModel } from "@app/lib/assistant";
+import {
+  getLargeWhitelistedModel,
+  getSmallWhitelistedModel,
+} from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -96,7 +96,7 @@ import {
   getDataSourcesAndWorkspaceIdForGlobalAgents,
   getMCPServerViewsForGlobalAgents,
 } from "@app/lib/api/assistant/global_agents/tools";
-import { isProviderWhitelisted } from "@app/lib/assistant";
+import { isProviderWhitelisted } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";

--- a/front/lib/api/assistant/models.test.ts
+++ b/front/lib/api/assistant/models.test.ts
@@ -1,0 +1,79 @@
+import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
+import { Authenticator } from "@app/lib/auth";
+import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
+import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/resources/provider_credential_resource");
+
+function mockCredentials(
+  credentials: Array<{
+    providerId: ModelProviderIdType;
+    isHealthy: boolean;
+  }>
+) {
+  const health = Object.fromEntries(
+    credentials.map((c) => [c.providerId, c.isHealthy])
+  ) as Partial<Record<ModelProviderIdType, boolean>>;
+
+  vi.mocked(
+    ProviderCredentialResource.fetchProvidersHealthByWorkspaceId
+  ).mockResolvedValue(health);
+}
+
+describe("getWhitelistedProviders", () => {
+  it("returns all providers including noop when whiteListedProviders is null", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const providers = getWhitelistedProviders(auth);
+    expect(providers).toEqual(new Set(MODEL_PROVIDER_IDS));
+  });
+
+  it("returns only whitelisted providers plus noop", async () => {
+    const workspace = await WorkspaceFactory.basic({
+      whiteListedProviders: ["anthropic"],
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const providers = getWhitelistedProviders(auth);
+    expect(providers).toEqual(new Set(["anthropic", "noop"]));
+  });
+
+  it("BYOK: only includes providers with configured keys plus noop", async () => {
+    const workspace = await WorkspaceFactory.byok();
+    mockCredentials([
+      { providerId: "openai", isHealthy: true },
+      { providerId: "anthropic", isHealthy: false },
+    ]);
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const providers = getWhitelistedProviders(auth);
+    expect(providers).toEqual(new Set(["openai", "anthropic", "noop"]));
+  });
+
+  it("BYOK + restricted whitelist: healthy key for non-whitelisted provider is ignored", async () => {
+    const workspace = await WorkspaceFactory.byok({
+      whiteListedProviders: ["anthropic"],
+    });
+    mockCredentials([
+      { providerId: "openai", isHealthy: true },
+      { providerId: "anthropic", isHealthy: true },
+    ]);
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const providers = getWhitelistedProviders(auth);
+    expect(providers).toEqual(new Set(["anthropic", "noop"]));
+  });
+
+  it("BYOK + no keys: only noop is whitelisted", async () => {
+    const workspace = await WorkspaceFactory.byok();
+    mockCredentials([]);
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const providers = getWhitelistedProviders(auth);
+    expect(providers).toEqual(new Set(["noop"]));
+  });
+});

--- a/front/lib/api/assistant/models.ts
+++ b/front/lib/api/assistant/models.ts
@@ -1,0 +1,11 @@
+import { getWhitelistedProviders } from "@app/lib/assistant";
+import type { Authenticator } from "@app/lib/auth";
+import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+
+export function isProviderWhitelisted(
+  auth: Authenticator,
+  providerId: ModelProviderIdType
+): boolean {
+  const whitelistedProviders = getWhitelistedProviders(auth);
+  return whitelistedProviders.has(providerId);
+}

--- a/front/lib/api/assistant/models.ts
+++ b/front/lib/api/assistant/models.ts
@@ -1,10 +1,21 @@
 import type { Authenticator } from "@app/lib/auth";
 import { isByokTransitioningPlan } from "@app/lib/plans/plan_codes";
+import { CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
+import {
+  GEMINI_2_5_FLASH_MODEL_CONFIG,
+  GEMINI_3_FLASH_MODEL_CONFIG,
+} from "@app/types/assistant/models/google_ai_studio";
+import { MISTRAL_SMALL_MODEL_CONFIG } from "@app/types/assistant/models/mistral";
+import { GPT_5_MINI_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import {
   BYOK_MODEL_PROVIDER_IDS,
   MODEL_PROVIDER_IDS,
 } from "@app/types/assistant/models/providers";
-import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+import type {
+  ModelConfigurationType,
+  ModelProviderIdType,
+} from "@app/types/assistant/models/types";
+import { GROK_4_1_FAST_NON_REASONING_MODEL_CONFIG } from "@app/types/assistant/models/xai";
 
 export function getWhitelistedProviders(
   auth: Authenticator
@@ -52,4 +63,47 @@ export function isProviderWhitelisted(
 ): boolean {
   const whitelistedProviders = getWhitelistedProviders(auth);
   return whitelistedProviders.has(providerId);
+}
+
+export function getFastestWhitelistedModel(
+  auth: Authenticator
+): ModelConfigurationType | null {
+  const whitelistedProviders = getWhitelistedProviders(auth);
+  if (whitelistedProviders.has("mistral")) {
+    return MISTRAL_SMALL_MODEL_CONFIG;
+  }
+  if (whitelistedProviders.has("google_ai_studio")) {
+    return GEMINI_2_5_FLASH_MODEL_CONFIG;
+  }
+  return _getSmallWhitelistedModel(whitelistedProviders);
+}
+
+export function getSmallWhitelistedModel(
+  auth: Authenticator,
+  excludeProviders: ReadonlySet<ModelProviderIdType> = new Set()
+): ModelConfigurationType | null {
+  return _getSmallWhitelistedModel(
+    getWhitelistedProviders(auth).difference(excludeProviders)
+  );
+}
+
+function _getSmallWhitelistedModel(
+  whitelistedProviders: Set<ModelProviderIdType>
+): ModelConfigurationType | null {
+  if (whitelistedProviders.has("openai")) {
+    return GPT_5_MINI_MODEL_CONFIG;
+  }
+  if (whitelistedProviders.has("anthropic")) {
+    return CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG;
+  }
+  if (whitelistedProviders.has("google_ai_studio")) {
+    return GEMINI_3_FLASH_MODEL_CONFIG;
+  }
+  if (whitelistedProviders.has("mistral")) {
+    return MISTRAL_SMALL_MODEL_CONFIG;
+  }
+  if (whitelistedProviders.has("xai")) {
+    return GROK_4_1_FAST_NON_REASONING_MODEL_CONFIG;
+  }
+  return null;
 }

--- a/front/lib/api/assistant/models.ts
+++ b/front/lib/api/assistant/models.ts
@@ -1,6 +1,50 @@
-import { getWhitelistedProviders } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
+import { isByokTransitioningPlan } from "@app/lib/plans/plan_codes";
+import {
+  BYOK_MODEL_PROVIDER_IDS,
+  MODEL_PROVIDER_IDS,
+} from "@app/types/assistant/models/providers";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+
+export function getWhitelistedProviders(
+  auth: Authenticator
+): Set<ModelProviderIdType> {
+  const owner = auth.getNonNullableWorkspace();
+  const plan = auth.getNonNullablePlan();
+  const whiteListedProviders = new Set<ModelProviderIdType>(
+    owner.whiteListedProviders ?? MODEL_PROVIDER_IDS
+  );
+
+  // noop never sees user data, always whitelisted.
+  whiteListedProviders.add("noop");
+
+  if (!plan.isByok) {
+    return whiteListedProviders;
+  }
+
+  // For BYOK_TRANSITIONING workspaces, we fall back on Dust-managed keys for BYOK providers when
+  // the customer hasn't configured their own. Whitelist all BYOK providers so they remain available
+  // even if not yet configured.
+  if (isByokTransitioningPlan(plan)) {
+    const allByokProviderIds = new Set<ModelProviderIdType>(
+      BYOK_MODEL_PROVIDER_IDS
+    );
+    allByokProviderIds.add("noop");
+
+    return allByokProviderIds;
+  }
+
+  const providersHealth = auth.providersHealth();
+
+  const configuredProviders = new Set(
+    Object.keys(providersHealth ?? {}) as ModelProviderIdType[]
+  );
+
+  // noop never needs credentials.
+  configuredProviders.add("noop");
+
+  return whiteListedProviders.intersection(configuredProviders);
+}
 
 export function isProviderWhitelisted(
   auth: Authenticator,

--- a/front/lib/api/assistant/models.ts
+++ b/front/lib/api/assistant/models.ts
@@ -1,12 +1,22 @@
 import type { Authenticator } from "@app/lib/auth";
 import { isByokTransitioningPlan } from "@app/lib/plans/plan_codes";
-import { CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
+import {
+  CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
+  CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+} from "@app/types/assistant/models/anthropic";
 import {
   GEMINI_2_5_FLASH_MODEL_CONFIG,
   GEMINI_3_FLASH_MODEL_CONFIG,
+  GEMINI_3_PRO_MODEL_CONFIG,
 } from "@app/types/assistant/models/google_ai_studio";
-import { MISTRAL_SMALL_MODEL_CONFIG } from "@app/types/assistant/models/mistral";
-import { GPT_5_MINI_MODEL_CONFIG } from "@app/types/assistant/models/openai";
+import {
+  MISTRAL_MEDIUM_3_5_MODEL_CONFIG,
+  MISTRAL_SMALL_MODEL_CONFIG,
+} from "@app/types/assistant/models/mistral";
+import {
+  GPT_5_5_MODEL_CONFIG,
+  GPT_5_MINI_MODEL_CONFIG,
+} from "@app/types/assistant/models/openai";
 import {
   BYOK_MODEL_PROVIDER_IDS,
   MODEL_PROVIDER_IDS,
@@ -15,7 +25,10 @@ import type {
   ModelConfigurationType,
   ModelProviderIdType,
 } from "@app/types/assistant/models/types";
-import { GROK_4_1_FAST_NON_REASONING_MODEL_CONFIG } from "@app/types/assistant/models/xai";
+import {
+  GROK_4_1_FAST_NON_REASONING_MODEL_CONFIG,
+  GROK_4_MODEL_CONFIG,
+} from "@app/types/assistant/models/xai";
 
 export function getWhitelistedProviders(
   auth: Authenticator
@@ -87,6 +100,17 @@ export function getSmallWhitelistedModel(
   );
 }
 
+export function getLargeWhitelistedModel(
+  auth: Authenticator,
+  excludeProviders: ReadonlySet<ModelProviderIdType> = new Set(),
+  { forBatch = false }: { forBatch?: boolean } = {}
+): ModelConfigurationType | null {
+  return _getLargeWhitelistedModel(
+    getWhitelistedProviders(auth).difference(excludeProviders),
+    { forBatch }
+  );
+}
+
 function _getSmallWhitelistedModel(
   whitelistedProviders: Set<ModelProviderIdType>
 ): ModelConfigurationType | null {
@@ -106,4 +130,25 @@ function _getSmallWhitelistedModel(
     return GROK_4_1_FAST_NON_REASONING_MODEL_CONFIG;
   }
   return null;
+}
+
+const LARGE_MODEL_CONFIGS: ModelConfigurationType[] = [
+  CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+  GPT_5_5_MODEL_CONFIG,
+  GEMINI_3_PRO_MODEL_CONFIG,
+  MISTRAL_MEDIUM_3_5_MODEL_CONFIG,
+  GROK_4_MODEL_CONFIG,
+];
+
+function _getLargeWhitelistedModel(
+  whitelistedProviders: Set<ModelProviderIdType>,
+  { forBatch: hasBatch }: { forBatch?: boolean } = {}
+): ModelConfigurationType | null {
+  const compatibleModels = LARGE_MODEL_CONFIGS.filter(
+    (m) =>
+      whitelistedProviders.has(m.providerId) &&
+      (!hasBatch || m.supportsBatchProcessing)
+  );
+
+  return compatibleModels[0] ?? null;
 }

--- a/front/lib/api/assistant/suggestions/description.ts
+++ b/front/lib/api/assistant/suggestions/description.ts
@@ -1,7 +1,7 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+import { getFastestWhitelistedModel } from "@app/lib/api/assistant/models";
 import type { SuggestionResults } from "@app/lib/api/assistant/suggestions/types";
-import { getFastestWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import type { BuilderSuggestionInputType } from "@app/types/api/internal/assistant";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";

--- a/front/lib/api/assistant/suggestions/emoji.ts
+++ b/front/lib/api/assistant/suggestions/emoji.ts
@@ -1,7 +1,7 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+import { getFastestWhitelistedModel } from "@app/lib/api/assistant/models";
 import type { SuggestionResults } from "@app/lib/api/assistant/suggestions/types";
-import { getFastestWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import type { BuilderSuggestionInputType } from "@app/types/api/internal/assistant";
 import { BuilderEmojiSuggestionsResponseBodySchema } from "@app/types/api/internal/assistant";

--- a/front/lib/api/assistant/suggestions/index.ts
+++ b/front/lib/api/assistant/suggestions/index.ts
@@ -1,9 +1,9 @@
+import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
 import { getBuilderDescriptionSuggestions } from "@app/lib/api/assistant/suggestions/description";
 import { getBuilderEmojiSuggestions } from "@app/lib/api/assistant/suggestions/emoji";
 import { getBuilderNameSuggestions } from "@app/lib/api/assistant/suggestions/name";
 import { getBuilderTagSuggestions } from "@app/lib/api/assistant/suggestions/tags";
 import type { SuggestionResults } from "@app/lib/api/assistant/suggestions/types";
-import { getSmallWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import type {
   BuilderSuggestionInputType,

--- a/front/lib/api/assistant/suggestions/name.ts
+++ b/front/lib/api/assistant/suggestions/name.ts
@@ -1,7 +1,7 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+import { getFastestWhitelistedModel } from "@app/lib/api/assistant/models";
 import type { SuggestionResults } from "@app/lib/api/assistant/suggestions/types";
-import { getFastestWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import type { BuilderSuggestionInputType } from "@app/types/api/internal/assistant";

--- a/front/lib/api/assistant/suggestions/tags.ts
+++ b/front/lib/api/assistant/suggestions/tags.ts
@@ -1,7 +1,7 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+import { getFastestWhitelistedModel } from "@app/lib/api/assistant/models";
 import type { SuggestionResults } from "@app/lib/api/assistant/suggestions/types";
-import { getFastestWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import type { BuilderSuggestionInputType } from "@app/types/api/internal/assistant";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";

--- a/front/lib/api/assistant/tag_manager.ts
+++ b/front/lib/api/assistant/tag_manager.ts
@@ -1,6 +1,6 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
-import { getLargeWhitelistedModel } from "@app/lib/assistant";
+import { getLargeWhitelistedModel } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";

--- a/front/lib/api/assistant/template_suggestion.ts
+++ b/front/lib/api/assistant/template_suggestion.ts
@@ -1,6 +1,6 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
-import { getFastestWhitelistedModel } from "@app/lib/assistant";
+import { getFastestWhitelistedModel } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import type { TemplateResource } from "@app/lib/resources/template_resource";
 import type { Result } from "@app/types/shared/result";

--- a/front/lib/api/assistant/voice_agent_finder.ts
+++ b/front/lib/api/assistant/voice_agent_finder.ts
@@ -1,6 +1,6 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
-import { getSmallWhitelistedModel } from "@app/lib/assistant";
+import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";

--- a/front/lib/api/assistant/workspace_capabilities.ts
+++ b/front/lib/api/assistant/workspace_capabilities.ts
@@ -4,12 +4,10 @@ import {
   getMcpServerViewDisplayName,
   isToolWithKnowledge,
 } from "@app/lib/actions/mcp_helper";
+import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
 import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
 import { config as regionConfig } from "@app/lib/api/regions/config";
-import {
-  filterCustomAvailableAndWhitelistedModels,
-  getWhitelistedProviders,
-} from "@app/lib/assistant";
+import { filterCustomAvailableAndWhitelistedModels } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";

--- a/front/lib/api/llm/getImageGenerationLLM.test.ts
+++ b/front/lib/api/llm/getImageGenerationLLM.test.ts
@@ -14,7 +14,7 @@ vi.mock("@app/lib/api/provider_credentials", () => ({
   getLlmCredentials: mockGetLlmCredentials,
 }));
 
-vi.mock("@app/lib/assistant", () => ({
+vi.mock("@app/lib/api/assistant/models", () => ({
   isProviderWhitelisted: mockIsProviderWhitelisted,
 }));
 

--- a/front/lib/api/llm/getImageGenerationLLM.ts
+++ b/front/lib/api/llm/getImageGenerationLLM.ts
@@ -1,9 +1,9 @@
+import { isProviderWhitelisted } from "@app/lib/api/assistant/models";
 import { ImageGenerationGoogleLLM } from "@app/lib/api/llm/clients/google/imageGeneration";
 import { ImageGenerationOpenAILLM } from "@app/lib/api/llm/clients/openai/imageGeneration";
 import type { ImageGenerationLLM } from "@app/lib/api/llm/imageGeneration";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import { config as regionConfig } from "@app/lib/api/regions/config";
-import { isProviderWhitelisted } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { GEMINI_3_PRO_IMAGE_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
 import {

--- a/front/lib/api/skills/description_suggestion.ts
+++ b/front/lib/api/skills/description_suggestion.ts
@@ -1,6 +1,6 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
-import { getLargeWhitelistedModel } from "@app/lib/assistant";
+import { getLargeWhitelistedModel } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
 import type { Result } from "@app/types/shared/result";

--- a/front/lib/api/skills/existing_skill_checker.ts
+++ b/front/lib/api/skills/existing_skill_checker.ts
@@ -1,6 +1,6 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
-import { getSmallWhitelistedModel } from "@app/lib/assistant";
+import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import logger from "@app/logger/logger";

--- a/front/lib/api/skills/icon_suggestion.ts
+++ b/front/lib/api/skills/icon_suggestion.ts
@@ -1,7 +1,7 @@
 import type { InternalActionIcons } from "@app/components/resources/resources_icons";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
-import { getLargeWhitelistedModel } from "@app/lib/assistant";
+import { getLargeWhitelistedModel } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
 import type { Result } from "@app/types/shared/result";

--- a/front/lib/assistant.test.ts
+++ b/front/lib/assistant.test.ts
@@ -1,7 +1,7 @@
+import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
 import type { RegionType } from "@app/lib/api/regions/config";
 import {
   filterCustomAvailableAndWhitelistedModels,
-  getWhitelistedProviders,
   isModelCustomAvailable,
 } from "@app/lib/assistant";
 import { Authenticator } from "@app/lib/auth";

--- a/front/lib/assistant.test.ts
+++ b/front/lib/assistant.test.ts
@@ -11,37 +11,15 @@ import {
   FREE_UPGRADED_PLAN_CODE,
   PRO_PLAN_SEAT_29_CODE,
 } from "@app/lib/plans/plan_codes";
-import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
 import { LightWorkspaceFactory } from "@app/tests/utils/LightWorkspaceFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { SUPPORTED_MODEL_CONFIGS } from "@app/types/assistant/models/models";
-import { MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
-import type {
-  ModelConfigurationType,
-  ModelProviderIdType,
-} from "@app/types/assistant/models/types";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { PlanType } from "@app/types/plan";
 import type { WorkspaceType } from "@app/types/user";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 const TEST_REGION: RegionType = "us-central1";
-
-vi.mock("@app/lib/resources/provider_credential_resource");
-
-function mockCredentials(
-  credentials: Array<{
-    providerId: ModelProviderIdType;
-    isHealthy: boolean;
-  }>
-) {
-  const health = Object.fromEntries(
-    credentials.map((c) => [c.providerId, c.isHealthy])
-  ) as Partial<Record<ModelProviderIdType, boolean>>;
-
-  vi.mocked(
-    ProviderCredentialResource.fetchProvidersHealthByWorkspaceId
-  ).mockResolvedValue(health);
-}
 
 function createMockModel(
   overrides: Partial<ModelConfigurationType>
@@ -104,61 +82,6 @@ function createMockPlan(code: string): PlanType {
     isAuditLogsAllowed: false,
   };
 }
-
-describe("getWhitelistedProviders", () => {
-  it("returns all providers including noop when whiteListedProviders is null", async () => {
-    const workspace = await WorkspaceFactory.basic();
-    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-
-    const providers = getWhitelistedProviders(auth);
-    expect(providers).toEqual(new Set(MODEL_PROVIDER_IDS));
-  });
-
-  it("returns only whitelisted providers plus noop", async () => {
-    const workspace = await WorkspaceFactory.basic({
-      whiteListedProviders: ["anthropic"],
-    });
-    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-
-    const providers = getWhitelistedProviders(auth);
-    expect(providers).toEqual(new Set(["anthropic", "noop"]));
-  });
-
-  it("BYOK: only includes providers with configured keys plus noop", async () => {
-    const workspace = await WorkspaceFactory.byok();
-    mockCredentials([
-      { providerId: "openai", isHealthy: true },
-      { providerId: "anthropic", isHealthy: false },
-    ]);
-    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-
-    const providers = getWhitelistedProviders(auth);
-    expect(providers).toEqual(new Set(["openai", "anthropic", "noop"]));
-  });
-
-  it("BYOK + restricted whitelist: healthy key for non-whitelisted provider is ignored", async () => {
-    const workspace = await WorkspaceFactory.byok({
-      whiteListedProviders: ["anthropic"],
-    });
-    mockCredentials([
-      { providerId: "openai", isHealthy: true },
-      { providerId: "anthropic", isHealthy: true },
-    ]);
-    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-
-    const providers = getWhitelistedProviders(auth);
-    expect(providers).toEqual(new Set(["anthropic", "noop"]));
-  });
-
-  it("BYOK + no keys: only noop is whitelisted", async () => {
-    const workspace = await WorkspaceFactory.byok();
-    mockCredentials([]);
-    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-
-    const providers = getWhitelistedProviders(auth);
-    expect(providers).toEqual(new Set(["noop"]));
-  });
-});
 
 describe("isModelCustomAvailable", () => {
   const owner: WorkspaceType = LightWorkspaceFactory.build();

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -1,21 +1,14 @@
-import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
 import type { RegionType } from "@app/lib/api/regions/config";
-import type { Authenticator } from "@app/lib/auth";
 import {
   isDustCompanyPlan,
   isEntreprisePlanPrefix,
   isUpgraded,
 } from "@app/lib/plans/plan_codes";
-import { CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
-import { GEMINI_3_PRO_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
-import { MISTRAL_MEDIUM_3_5_MODEL_CONFIG } from "@app/types/assistant/models/mistral";
-import { GPT_5_5_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import { isByokProviderId } from "@app/types/assistant/models/providers";
 import type {
   ModelConfigurationType,
   ModelProviderIdType,
 } from "@app/types/assistant/models/types";
-import { GROK_4_MODEL_CONFIG } from "@app/types/assistant/models/xai";
 import type { PlanType } from "@app/types/plan";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { WorkspaceType } from "@app/types/user";
@@ -25,38 +18,6 @@ export function isEnterpriseOrDust(plan: PlanType | null): boolean {
     plan !== null &&
     (isEntreprisePlanPrefix(plan.code) || isDustCompanyPlan(plan.code))
   );
-}
-
-export function getLargeWhitelistedModel(
-  auth: Authenticator,
-  excludeProviders: ReadonlySet<ModelProviderIdType> = new Set(),
-  { forBatch = false }: { forBatch?: boolean } = {}
-): ModelConfigurationType | null {
-  return _getLargeWhitelistedModel(
-    getWhitelistedProviders(auth).difference(excludeProviders),
-    { forBatch }
-  );
-}
-
-const LARGE_MODEL_CONFIGS: ModelConfigurationType[] = [
-  CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
-  GPT_5_5_MODEL_CONFIG,
-  GEMINI_3_PRO_MODEL_CONFIG,
-  MISTRAL_MEDIUM_3_5_MODEL_CONFIG,
-  GROK_4_MODEL_CONFIG,
-];
-
-function _getLargeWhitelistedModel(
-  whitelistedProviders: Set<ModelProviderIdType>,
-  { forBatch: hasBatch }: { forBatch?: boolean } = {}
-): ModelConfigurationType | null {
-  const compatibleModels = LARGE_MODEL_CONFIGS.filter(
-    (m) =>
-      whitelistedProviders.has(m.providerId) &&
-      (!hasBatch || m.supportsBatchProcessing)
-  );
-
-  return compatibleModels[0] ?? null;
 }
 
 // Returns true if the model is available to the workspace for use.

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -1,7 +1,7 @@
+import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
 import type { RegionType } from "@app/lib/api/regions/config";
 import type { Authenticator } from "@app/lib/auth";
 import {
-  isByokTransitioningPlan,
   isDustCompanyPlan,
   isEntreprisePlanPrefix,
   isUpgraded,
@@ -23,11 +23,7 @@ import {
   GPT_5_5_MODEL_CONFIG,
   GPT_5_MINI_MODEL_CONFIG,
 } from "@app/types/assistant/models/openai";
-import {
-  BYOK_MODEL_PROVIDER_IDS,
-  isByokProviderId,
-  MODEL_PROVIDER_IDS,
-} from "@app/types/assistant/models/providers";
+import { isByokProviderId } from "@app/types/assistant/models/providers";
 import type {
   ModelConfigurationType,
   ModelProviderIdType,
@@ -45,46 +41,6 @@ export function isEnterpriseOrDust(plan: PlanType | null): boolean {
     plan !== null &&
     (isEntreprisePlanPrefix(plan.code) || isDustCompanyPlan(plan.code))
   );
-}
-
-export function getWhitelistedProviders(
-  auth: Authenticator
-): Set<ModelProviderIdType> {
-  const owner = auth.getNonNullableWorkspace();
-  const plan = auth.getNonNullablePlan();
-  const whiteListedProviders = new Set<ModelProviderIdType>(
-    owner.whiteListedProviders ?? MODEL_PROVIDER_IDS
-  );
-
-  // noop never sees user data, always whitelisted.
-  whiteListedProviders.add("noop");
-
-  if (!plan.isByok) {
-    return whiteListedProviders;
-  }
-
-  // For BYOK_TRANSITIONING workspaces, we fall back on Dust-managed keys for BYOK providers when
-  // the customer hasn't configured their own. Whitelist all BYOK providers so they remain available
-  // even if not yet configured.
-  if (isByokTransitioningPlan(plan)) {
-    const allByokProviderIds = new Set<ModelProviderIdType>(
-      BYOK_MODEL_PROVIDER_IDS
-    );
-    allByokProviderIds.add("noop");
-
-    return allByokProviderIds;
-  }
-
-  const providersHealth = auth.providersHealth();
-
-  const configuredProviders = new Set(
-    Object.keys(providersHealth ?? {}) as ModelProviderIdType[]
-  );
-
-  // noop never needs credentials.
-  configuredProviders.add("noop");
-
-  return whiteListedProviders.intersection(configuredProviders);
 }
 
 export function getFastestWhitelistedModel(

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -87,14 +87,6 @@ export function getWhitelistedProviders(
   return whiteListedProviders.intersection(configuredProviders);
 }
 
-export function isProviderWhitelisted(
-  auth: Authenticator,
-  providerId: ModelProviderIdType
-): boolean {
-  const whitelistedProviders = getWhitelistedProviders(auth);
-  return whitelistedProviders.has(providerId);
-}
-
 export function getFastestWhitelistedModel(
   auth: Authenticator
 ): ModelConfigurationType | null {

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -6,32 +6,16 @@ import {
   isEntreprisePlanPrefix,
   isUpgraded,
 } from "@app/lib/plans/plan_codes";
-import {
-  CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
-  CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
-} from "@app/types/assistant/models/anthropic";
-import {
-  GEMINI_2_5_FLASH_MODEL_CONFIG,
-  GEMINI_3_FLASH_MODEL_CONFIG,
-  GEMINI_3_PRO_MODEL_CONFIG,
-} from "@app/types/assistant/models/google_ai_studio";
-import {
-  MISTRAL_MEDIUM_3_5_MODEL_CONFIG,
-  MISTRAL_SMALL_MODEL_CONFIG,
-} from "@app/types/assistant/models/mistral";
-import {
-  GPT_5_5_MODEL_CONFIG,
-  GPT_5_MINI_MODEL_CONFIG,
-} from "@app/types/assistant/models/openai";
+import { CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
+import { GEMINI_3_PRO_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
+import { MISTRAL_MEDIUM_3_5_MODEL_CONFIG } from "@app/types/assistant/models/mistral";
+import { GPT_5_5_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import { isByokProviderId } from "@app/types/assistant/models/providers";
 import type {
   ModelConfigurationType,
   ModelProviderIdType,
 } from "@app/types/assistant/models/types";
-import {
-  GROK_4_1_FAST_NON_REASONING_MODEL_CONFIG,
-  GROK_4_MODEL_CONFIG,
-} from "@app/types/assistant/models/xai";
+import { GROK_4_MODEL_CONFIG } from "@app/types/assistant/models/xai";
 import type { PlanType } from "@app/types/plan";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { WorkspaceType } from "@app/types/user";
@@ -40,28 +24,6 @@ export function isEnterpriseOrDust(plan: PlanType | null): boolean {
   return (
     plan !== null &&
     (isEntreprisePlanPrefix(plan.code) || isDustCompanyPlan(plan.code))
-  );
-}
-
-export function getFastestWhitelistedModel(
-  auth: Authenticator
-): ModelConfigurationType | null {
-  const whitelistedProviders = getWhitelistedProviders(auth);
-  if (whitelistedProviders.has("mistral")) {
-    return MISTRAL_SMALL_MODEL_CONFIG;
-  }
-  if (whitelistedProviders.has("google_ai_studio")) {
-    return GEMINI_2_5_FLASH_MODEL_CONFIG;
-  }
-  return _getSmallWhitelistedModel(whitelistedProviders);
-}
-
-export function getSmallWhitelistedModel(
-  auth: Authenticator,
-  excludeProviders: ReadonlySet<ModelProviderIdType> = new Set()
-): ModelConfigurationType | null {
-  return _getSmallWhitelistedModel(
-    getWhitelistedProviders(auth).difference(excludeProviders)
   );
 }
 
@@ -74,27 +36,6 @@ export function getLargeWhitelistedModel(
     getWhitelistedProviders(auth).difference(excludeProviders),
     { forBatch }
   );
-}
-
-function _getSmallWhitelistedModel(
-  whitelistedProviders: Set<ModelProviderIdType>
-): ModelConfigurationType | null {
-  if (whitelistedProviders.has("openai")) {
-    return GPT_5_MINI_MODEL_CONFIG;
-  }
-  if (whitelistedProviders.has("anthropic")) {
-    return CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG;
-  }
-  if (whitelistedProviders.has("google_ai_studio")) {
-    return GEMINI_3_FLASH_MODEL_CONFIG;
-  }
-  if (whitelistedProviders.has("mistral")) {
-    return MISTRAL_SMALL_MODEL_CONFIG;
-  }
-  if (whitelistedProviders.has("xai")) {
-    return GROK_4_1_FAST_NON_REASONING_MODEL_CONFIG;
-  }
-  return null;
 }
 
 const LARGE_MODEL_CONFIGS: ModelConfigurationType[] = [

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -6,8 +6,8 @@ import {
   countConversationMessages,
   renderConversationAsText,
 } from "@app/lib/api/assistant/conversation/render_as_text";
+import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
 import config from "@app/lib/api/config";
-import { getSmallWhitelistedModel } from "@app/lib/assistant";
 import { Authenticator } from "@app/lib/auth";
 import {
   getAgentsDataRetention,

--- a/front/lib/project_task/analyze_document/index.ts
+++ b/front/lib/project_task/analyze_document/index.ts
@@ -1,6 +1,6 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
-import { getSmallWhitelistedModel } from "@app/lib/assistant";
+import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import {
   buildActionItems,

--- a/front/lib/project_task/merge_into_project.ts
+++ b/front/lib/project_task/merge_into_project.ts
@@ -25,7 +25,7 @@
 //       - Key in dedupMap → upsertSource on existing task.
 //       - Not in dedupMap → makeNew + addSource.
 
-import { getSmallWhitelistedModel } from "@app/lib/assistant";
+import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import {
   batchDeduplicateCandidates,

--- a/front/lib/reinforcement/models.ts
+++ b/front/lib/reinforcement/models.ts
@@ -1,4 +1,4 @@
-import { getLargeWhitelistedModel } from "@app/lib/assistant";
+import { getLargeWhitelistedModel } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import { hasFeatureFlag } from "@app/lib/auth";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";

--- a/front/lib/reinforcement/run_reinforced_analysis.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.ts
@@ -1,11 +1,11 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { getLargeWhitelistedModel } from "@app/lib/api/assistant/models";
 import { getLLM } from "@app/lib/api/llm";
 import { writeBatchUserMessages } from "@app/lib/api/llm/batch_llm";
 import type { LLM } from "@app/lib/api/llm/llm";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
-import { getLargeWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { getLargeWhitelistedModelWithBatchMode } from "@app/lib/reinforcement/models";
 import {

--- a/front/pages/api/v1/w/[wId]/assistant/generic_agents.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/generic_agents.ts
@@ -3,8 +3,8 @@ import {
   assistantHandleIsValid,
   getAgentPictureUrl,
 } from "@app/lib/api/assistant/configuration/generic_agent_helpers";
+import { getLargeWhitelistedModel } from "@app/lib/api/assistant/models";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
-import { getLargeWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";

--- a/front/pages/api/w/[wId]/assistant/builder/process/generate_schema.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/process/generate_schema.ts
@@ -1,9 +1,11 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { getBuilderJsonSchemaGenerator } from "@app/lib/api/assistant/json_schema_generator";
-import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
+import {
+  getLargeWhitelistedModel,
+  getSmallWhitelistedModel,
+} from "@app/lib/api/assistant/models";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { getLargeWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import { InternalPostBuilderGenerateSchemaRequestBodySchema } from "@app/types/api/internal/assistant";

--- a/front/pages/api/w/[wId]/assistant/builder/process/generate_schema.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/process/generate_schema.ts
@@ -1,11 +1,9 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { getBuilderJsonSchemaGenerator } from "@app/lib/api/assistant/json_schema_generator";
+import { getSmallWhitelistedModel } from "@app/lib/api/assistant/models";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import {
-  getLargeWhitelistedModel,
-  getSmallWhitelistedModel,
-} from "@app/lib/assistant";
+import { getLargeWhitelistedModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import { InternalPostBuilderGenerateSchemaRequestBodySchema } from "@app/types/api/internal/assistant";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/compactions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/compactions.ts
@@ -61,8 +61,8 @@
 import { compactConversation } from "@app/lib/api/assistant/conversation/compaction";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { isProviderWhitelisted } from "@app/lib/api/assistant/models";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { isProviderWhitelisted } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import { isSupportedModel } from "@app/types/assistant/assistant";

--- a/front/pages/api/w/[wId]/models.ts
+++ b/front/pages/api/w/[wId]/models.ts
@@ -5,12 +5,10 @@ import {
   REASONING_MODEL_CONFIGS,
   USED_MODEL_CONFIGS,
 } from "@app/components/providers/model_configs";
+import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { config as regionConfig } from "@app/lib/api/regions/config";
-import {
-  filterCustomAvailableAndWhitelistedModels,
-  getWhitelistedProviders,
-} from "@app/lib/assistant";
+import { filterCustomAvailableAndWhitelistedModels } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -5,12 +5,12 @@ import { replaceStandaloneAttachmentIds } from "@app/lib/api/assistant/conversat
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { renderConversationAsText } from "@app/lib/api/assistant/conversation/render_as_text";
 import { PREVIOUS_INTERACTIONS_TO_PRESERVE } from "@app/lib/api/assistant/conversation_rendering";
+import { isProviderWhitelisted } from "@app/lib/api/assistant/models";
 import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
 import {
   createGCSMountFile,
   type GCSMountFileEntry,
 } from "@app/lib/api/files/gcs_mount/files";
-import { isProviderWhitelisted } from "@app/lib/assistant";
 import { type Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";


### PR DESCRIPTION
## Description

Refactor only — moves the whitelisted-model helpers (`isProviderWhitelisted`, `getWhitelistedProviders`, `getLargeWhitelistedModel`, and the related selectors) from `front/lib/assistant.ts` into `front/lib/api/assistant/models.ts`, and relocates their tests accordingly. All call sites have their imports updated. No logic or code change — backend code is being isolated under `front/lib/api`.

## Tests

Tested agent loop locally

## Risk

Low — pure code move with import path updates, no behavioral change.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`