### PR TITLE
Handle hierarchy in pod files sync.

### DIFF
--- a/connectors/src/connectors/dust_project/lib/mount_path_utils.test.ts
+++ b/connectors/src/connectors/dust_project/lib/mount_path_utils.test.ts
@@ -1,0 +1,104 @@
+import { PROJECT_CONTEXT_FOLDER_ID } from "@connectors/connectors/dust_project/lib/constants";
+import {
+  buildMountDirectoryParents,
+  getMountDirectoryParentPrefixes,
+  getMountDirectoryPrefixes,
+  getMountDirInternalId,
+  inferMountFileParents,
+  parseProjectScopedPath,
+} from "@connectors/connectors/dust_project/lib/mount_path_utils";
+import { describe, expect, it } from "vitest";
+
+const PROJECT_ID = "spc_test123";
+
+describe("parseProjectScopedPath", () => {
+  it("strips the project scope prefix", () => {
+    expect(parseProjectScopedPath("project/reports/q1/summary.pdf")).toBe(
+      "reports/q1/summary.pdf"
+    );
+  });
+
+  it("returns null for non-project paths", () => {
+    expect(parseProjectScopedPath("conversation/file.pdf")).toBeNull();
+  });
+});
+
+describe("getMountDirInternalId", () => {
+  it("generates a stable id for the same input", () => {
+    const id1 = getMountDirInternalId(PROJECT_ID, "reports/q1");
+    const id2 = getMountDirInternalId(PROJECT_ID, "reports/q1");
+    expect(id1).toBe(id2);
+    expect(id1.startsWith("dpd_")).toBe(true);
+  });
+
+  it("returns different ids for different paths", () => {
+    const id1 = getMountDirInternalId(PROJECT_ID, "reports");
+    const id2 = getMountDirInternalId(PROJECT_ID, "reports/q1");
+    expect(id1).not.toBe(id2);
+  });
+});
+
+describe("buildMountDirectoryParents", () => {
+  it("returns the context folder for root-level files", () => {
+    expect(buildMountDirectoryParents(PROJECT_ID, "summary.pdf")).toEqual({
+      parentInternalId: PROJECT_CONTEXT_FOLDER_ID,
+      parents: [PROJECT_CONTEXT_FOLDER_ID],
+    });
+  });
+
+  it("builds nested directory parents for nested files", () => {
+    const { parentInternalId, parents } = buildMountDirectoryParents(
+      PROJECT_ID,
+      "reports/q1/summary.pdf"
+    );
+
+    expect(parentInternalId).toBe(
+      getMountDirInternalId(PROJECT_ID, "reports/q1")
+    );
+    expect(parents).toEqual([
+      getMountDirInternalId(PROJECT_ID, "reports/q1"),
+      getMountDirInternalId(PROJECT_ID, "reports"),
+      PROJECT_CONTEXT_FOLDER_ID,
+    ]);
+  });
+
+  it("builds parents for nested directories", () => {
+    const { parentInternalId, parents } = buildMountDirectoryParents(
+      PROJECT_ID,
+      "reports/q1"
+    );
+
+    expect(parentInternalId).toBe(getMountDirInternalId(PROJECT_ID, "reports"));
+    expect(parents).toEqual([
+      getMountDirInternalId(PROJECT_ID, "reports"),
+      PROJECT_CONTEXT_FOLDER_ID,
+    ]);
+  });
+});
+
+describe("inferMountFileParents", () => {
+  it("includes the document id first in the parent chain", () => {
+    const documentId = "fil_abc";
+    const { parents } = inferMountFileParents({
+      projectId: PROJECT_ID,
+      pathWithinMount: "reports/q1/summary.pdf",
+      documentId,
+    });
+
+    expect(parents[0]).toBe(documentId);
+    expect(parents.at(-1)).toBe(PROJECT_CONTEXT_FOLDER_ID);
+  });
+});
+
+describe("directory prefix helpers", () => {
+  it("returns directory prefixes for nested files", () => {
+    expect(getMountDirectoryPrefixes("reports/q1/summary.pdf")).toEqual([
+      "reports",
+      "reports/q1",
+    ]);
+  });
+
+  it("returns parent prefixes for nested directories", () => {
+    expect(getMountDirectoryParentPrefixes("reports/q1")).toEqual(["reports"]);
+  });
+});

--- a/connectors/src/connectors/dust_project/lib/mount_path_utils.ts
+++ b/connectors/src/connectors/dust_project/lib/mount_path_utils.ts
@@ -1,0 +1,145 @@
+import { PROJECT_CONTEXT_FOLDER_ID } from "@connectors/connectors/dust_project/lib/constants";
+import { createHash } from "crypto";
+
+const PROJECT_SCOPE_PREFIX = "project/";
+
+/**
+ * Strip the `project/` scope prefix from a scoped mount path.
+ * Returns null when the path is not a project-scoped mount path.
+ */
+export function parseProjectScopedPath(scopedPath: string): string | null {
+  if (!scopedPath.startsWith(PROJECT_SCOPE_PREFIX)) {
+    return null;
+  }
+
+  const relativePath = scopedPath.slice(PROJECT_SCOPE_PREFIX.length);
+  return relativePath.length > 0 ? relativePath : null;
+}
+
+export function getMountDirInternalId(
+  projectId: string,
+  relativeDirPath: string
+): string {
+  const h = createHash("sha256")
+    .update(`dust-project:${projectId}:dir:${relativeDirPath}`, "utf8")
+    .digest("hex")
+    .slice(0, 16);
+  return `dpd_${h}`;
+}
+
+/**
+ * Build parent relationships from a path within the project mount.
+ *
+ * For `reports/q1/summary.pdf`:
+ * - parents: [q1DirId, reportsDirId, PROJECT_CONTEXT_FOLDER_ID]
+ * - parentInternalId: q1DirId
+ *
+ * For `summary.pdf`:
+ * - parents: [PROJECT_CONTEXT_FOLDER_ID]
+ * - parentInternalId: PROJECT_CONTEXT_FOLDER_ID
+ */
+export function buildMountDirectoryParents(
+  projectId: string,
+  pathWithinMount: string
+): {
+  parentInternalId: string;
+  parents: string[];
+} {
+  const pathParts = pathWithinMount
+    .split("/")
+    .filter((part) => part.trim() !== "");
+
+  // Remove the last segment (file name or directory name).
+  const directoryParts = pathParts.slice(0, -1);
+
+  if (directoryParts.length === 0) {
+    return {
+      parentInternalId: PROJECT_CONTEXT_FOLDER_ID,
+      parents: [PROJECT_CONTEXT_FOLDER_ID],
+    };
+  }
+
+  const parents = [PROJECT_CONTEXT_FOLDER_ID];
+
+  for (let i = 1; i <= directoryParts.length; i++) {
+    const dirPath = directoryParts.slice(0, i).join("/");
+    parents.push(getMountDirInternalId(projectId, dirPath));
+  }
+
+  parents.reverse();
+
+  const immediateParentPath = directoryParts.join("/");
+  const parentInternalId = getMountDirInternalId(
+    projectId,
+    immediateParentPath
+  );
+
+  return {
+    parentInternalId,
+    parents,
+  };
+}
+
+export function inferMountFileParents({
+  projectId,
+  pathWithinMount,
+  documentId,
+}: {
+  projectId: string;
+  pathWithinMount: string;
+  documentId: string;
+}): {
+  parentInternalId: string;
+  parents: string[];
+} {
+  const { parentInternalId, parents: directoryParents } =
+    buildMountDirectoryParents(projectId, pathWithinMount);
+
+  return {
+    parentInternalId,
+    parents: [documentId, ...directoryParents],
+  };
+}
+
+/**
+ * Returns mount directory paths from shallowest to deepest for a file path.
+ * For `reports/q1/summary.pdf`, returns [`reports`, `reports/q1`].
+ */
+export function getMountDirectoryPrefixes(pathWithinMount: string): string[] {
+  const pathParts = pathWithinMount
+    .split("/")
+    .filter((part) => part.trim() !== "");
+  const directoryParts = pathParts.slice(0, -1);
+
+  return directoryParts.map((_, index) =>
+    directoryParts.slice(0, index + 1).join("/")
+  );
+}
+
+/**
+ * Returns mount directory parent paths from shallowest to deepest for a directory path.
+ * For `reports/q1`, returns [`reports`].
+ */
+export function getMountDirectoryParentPrefixes(
+  relativeDirPath: string
+): string[] {
+  const pathParts = relativeDirPath
+    .split("/")
+    .filter((part) => part.trim() !== "");
+  if (pathParts.length <= 1) {
+    return [];
+  }
+
+  const parentParts = pathParts.slice(0, -1);
+  return parentParts.map((_, index) =>
+    parentParts.slice(0, index + 1).join("/")
+  );
+}
+
+export function sortEntriesByScopedPathDepth<T extends { path: string }>(
+  entries: T[]
+): T[] {
+  return [...entries].sort(
+    (a, b) => a.path.split("/").length - b.path.split("/").length
+  );
+}

--- a/connectors/src/connectors/dust_project/lib/sync_project_mount_files.ts
+++ b/connectors/src/connectors/dust_project/lib/sync_project_mount_files.ts
@@ -1,4 +1,11 @@
-import { PROJECT_CONTEXT_FOLDER_ID } from "@connectors/connectors/dust_project/lib/constants";
+import {
+  buildMountDirectoryParents,
+  getMountDirectoryParentPrefixes,
+  getMountDirectoryPrefixes,
+  getMountDirInternalId,
+  inferMountFileParents,
+  parseProjectScopedPath,
+} from "@connectors/connectors/dust_project/lib/mount_path_utils";
 import {
   handleTextExtraction,
   handleTextFile,
@@ -9,12 +16,19 @@ import {
   MAX_SMALL_DOCUMENT_TXT_LEN,
   renderDocumentTitleAndContent,
   upsertDataSourceDocument,
+  upsertDataSourceFolder,
 } from "@connectors/lib/data_sources";
 import logger from "@connectors/logger/logger";
 import { DustProjectMountFileResource } from "@connectors/resources/dust_project_mount_file_resource";
 import type { DataSourceConfig, ModelId } from "@connectors/types";
-import { isTextExtractionSupportedContentType } from "@connectors/types";
-import type { ProjectMountFileEntryType } from "@dust-tt/client";
+import {
+  INTERNAL_MIME_TYPES,
+  isTextExtractionSupportedContentType,
+} from "@connectors/types";
+import type {
+  ProjectMountDirectoryEntryType,
+  ProjectMountFileEntryType,
+} from "@dust-tt/client";
 import axios, { isAxiosError } from "axios";
 import { createHash } from "crypto";
 
@@ -102,9 +116,93 @@ export async function deleteProjectMountFile({
   }
 }
 
+async function upsertProjectMountFolder({
+  dataSourceConfig,
+  projectId,
+  relativeDirPath,
+  title,
+}: {
+  dataSourceConfig: DataSourceConfig;
+  projectId: string;
+  relativeDirPath: string;
+  title: string;
+}): Promise<void> {
+  const folderId = getMountDirInternalId(projectId, relativeDirPath);
+  const { parentInternalId, parents } = buildMountDirectoryParents(
+    projectId,
+    relativeDirPath
+  );
+
+  await upsertDataSourceFolder({
+    dataSourceConfig,
+    folderId,
+    parents: [folderId, ...parents],
+    parentId: parentInternalId,
+    title,
+    mimeType: INTERNAL_MIME_TYPES.DUST_PROJECT.MOUNT_FOLDER,
+  });
+}
+
+async function ensureMountFolderHierarchy({
+  dataSourceConfig,
+  projectId,
+  pathWithinMount,
+}: {
+  dataSourceConfig: DataSourceConfig;
+  projectId: string;
+  pathWithinMount: string;
+}): Promise<void> {
+  for (const relativeDirPath of getMountDirectoryPrefixes(pathWithinMount)) {
+    const dirName = relativeDirPath.split("/").pop() ?? relativeDirPath;
+    await upsertProjectMountFolder({
+      dataSourceConfig,
+      projectId,
+      relativeDirPath,
+      title: dirName,
+    });
+  }
+}
+
+/**
+ * Upserts a project mount directory node under the Context folder hierarchy.
+ */
+export async function syncProjectMountDirectory({
+  dataSourceConfig,
+  projectId,
+  entry,
+}: {
+  dataSourceConfig: DataSourceConfig;
+  projectId: string;
+  entry: ProjectMountDirectoryEntryType;
+}): Promise<void> {
+  const pathWithinMount = parseProjectScopedPath(entry.path);
+  if (!pathWithinMount) {
+    return;
+  }
+
+  for (const relativeDirPath of getMountDirectoryParentPrefixes(
+    pathWithinMount
+  )) {
+    const dirName = relativeDirPath.split("/").pop() ?? relativeDirPath;
+    await upsertProjectMountFolder({
+      dataSourceConfig,
+      projectId,
+      relativeDirPath,
+      title: dirName,
+    });
+  }
+
+  await upsertProjectMountFolder({
+    dataSourceConfig,
+    projectId,
+    relativeDirPath: pathWithinMount,
+    title: entry.fileName,
+  });
+}
+
 /**
  * Downloads a project GCS mount file via signed URL, extracts content, and upserts to the
- * project data source under {@link PROJECT_CONTEXT_FOLDER_ID}.
+ * project data source under the Context folder hierarchy.
  */
 export async function syncProjectMountFile({
   connectorId,
@@ -145,6 +243,24 @@ export async function syncProjectMountFile({
     workspaceId,
     scopedPath: entry.path,
     fileId: entry.fileId,
+  });
+
+  const pathWithinMount = parseProjectScopedPath(entry.path);
+  if (!pathWithinMount) {
+    localLogger.warn("Skipping mount file: invalid project scoped path");
+    return;
+  }
+
+  await ensureMountFolderHierarchy({
+    dataSourceConfig,
+    projectId,
+    pathWithinMount,
+  });
+
+  const { parentInternalId, parents } = inferMountFileParents({
+    projectId,
+    pathWithinMount,
+    documentId,
   });
 
   const sourceUpdatedAt = new Date(entry.lastModifiedMs);
@@ -189,8 +305,8 @@ export async function syncProjectMountFile({
       documentUrl: undefined,
       timestampMs: entry.lastModifiedMs,
       tags,
-      parents: [documentId, PROJECT_CONTEXT_FOLDER_ID],
-      parentId: PROJECT_CONTEXT_FOLDER_ID,
+      parents,
+      parentId: parentInternalId,
       upsertContext: { sync_type: syncType },
       title: entry.fileName,
       mimeType,
@@ -223,8 +339,8 @@ export async function syncProjectMountFile({
       documentUrl: undefined,
       timestampMs: entry.lastModifiedMs,
       tags,
-      parents: [documentId, PROJECT_CONTEXT_FOLDER_ID],
-      parentId: PROJECT_CONTEXT_FOLDER_ID,
+      parents,
+      parentId: parentInternalId,
       upsertContext: { sync_type: syncType },
       title: entry.fileName,
       mimeType,

--- a/connectors/src/connectors/dust_project/temporal/activities.ts
+++ b/connectors/src/connectors/dust_project/temporal/activities.ts
@@ -1,3 +1,4 @@
+import { sortEntriesByScopedPathDepth } from "@connectors/connectors/dust_project/lib/mount_path_utils";
 import {
   deleteConversation,
   syncConversation,
@@ -5,6 +6,7 @@ import {
 import { syncProjectMetadata } from "@connectors/connectors/dust_project/lib/sync_metadata";
 import {
   deleteProjectMountFile,
+  syncProjectMountDirectory,
   syncProjectMountFile,
 } from "@connectors/connectors/dust_project/lib/sync_project_mount_files";
 import { launchDustProjectIncrementalSyncWorkflow } from "@connectors/connectors/dust_project/temporal/client";
@@ -23,6 +25,7 @@ import { DustProjectMountFileResource } from "@connectors/resources/dust_project
 import type { ModelId } from "@connectors/types";
 import { concurrentExecutor } from "@connectors/types";
 import type {
+  ProjectMountDirectoryEntryType,
   ProjectMountFileEntryType,
   ProjectMountListEntryType,
 } from "@dust-tt/client";
@@ -362,6 +365,12 @@ async function dustProjectConversationsGarbageCollectActivity({
   }
 }
 
+function isMountDirectoryEntry(
+  e: ProjectMountListEntryType
+): e is ProjectMountDirectoryEntryType {
+  return e.isDirectory;
+}
+
 function isMountFileEntry(
   e: ProjectMountListEntryType
 ): e is ProjectMountFileEntryType {
@@ -407,6 +416,9 @@ export async function dustProjectMountFilesFullSyncActivity({
     );
   }
 
+  const directoryEntries = sortEntriesByScopedPathDepth(
+    listRes.value.files.filter(isMountDirectoryEntry)
+  );
   const fileEntries = listRes.value.files.filter(isMountFileEntry);
   const fetchedPaths = new Set(fileEntries.map((e) => e.path));
 
@@ -428,6 +440,18 @@ export async function dustProjectMountFilesFullSyncActivity({
       { concurrency: 5 }
     );
   }
+
+  await concurrentExecutor(
+    directoryEntries,
+    async (entry) => {
+      await syncProjectMountDirectory({
+        dataSourceConfig,
+        projectId: configuration.projectId,
+        entry,
+      });
+    },
+    { concurrency: 3 }
+  );
 
   await concurrentExecutor(
     fileEntries,
@@ -489,15 +513,31 @@ export async function dustProjectMountFilesIncrementalSyncActivity({
     );
   }
 
+  const directoryEntries = sortEntriesByScopedPathDepth(
+    listRes.value.files.filter(isMountDirectoryEntry)
+  );
   const fileEntries = listRes.value.files.filter(isMountFileEntry);
 
   localLogger.info(
     {
       projectId: configuration.projectId,
+      directoryCount: directoryEntries.length,
       count: fileEntries.length,
       lastSourceUpdatedAt: maxSourceUpdatedAt,
     },
     "Fetched project mount files for incremental sync"
+  );
+
+  await concurrentExecutor(
+    directoryEntries,
+    async (entry) => {
+      await syncProjectMountDirectory({
+        dataSourceConfig,
+        projectId: configuration.projectId,
+        entry,
+      });
+    },
+    { concurrency: 3 }
   );
 
   await concurrentExecutor(

--- a/connectors/src/types/shared/internal_mime_types.ts
+++ b/connectors/src/types/shared/internal_mime_types.ts
@@ -152,6 +152,7 @@ export const INTERNAL_MIME_TYPES = {
       "CONVERSATION_FOLDER",
       "CONVERSATION_MESSAGES",
       "CONTEXT_FOLDER",
+      "MOUNT_FOLDER",
     ],
   }),
 };

--- a/sdks/js/src/internal_mime_types.ts
+++ b/sdks/js/src/internal_mime_types.ts
@@ -171,6 +171,7 @@ export const CONTENT_NODE_MIME_TYPES = {
       "CONVERSATION_FOLDER",
       "CONVERSATION_MESSAGES",
       "CONTEXT_FOLDER",
+      "MOUNT_FOLDER",
     ],
   }),
 };


### PR DESCRIPTION
## Description

Pod mount files were previously upserted flat under `PROJECT_CONTEXT_FOLDER_ID`, ignoring their actual directory structure. This PR adds full hierarchy support: directory entries (`ProjectMountDirectoryEntryType`) are now synced as `MOUNT_FOLDER` nodes with correct parent chains, and mount files are reparented to their immediate directory instead of the root context folder.

New `mount_path_utils.ts` centralises all path logic: `parseProjectScopedPath`, `getMountDirInternalId` (stable `dpd_`-prefixed SHA256 IDs), `buildMountDirectoryParents`, `inferMountFileParents`, and `sortEntriesByScopedPathDepth`. Both `dustProjectMountFilesFullSyncActivity` and `dustProjectMountFilesIncrementalSyncActivity` now sync directory entries shallow-to-deep (concurrency 3) before syncing files, ensuring parent folders exist before children. `MOUNT_FOLDER` is added to `INTERNAL_MIME_TYPES.DUST_PROJECT` in both the connectors types and the JS SDK.

## Tests

Added Vitest unit tests in `mount_path_utils.test.ts` covering `parseProjectScopedPath`, `getMountDirInternalId`, `buildMountDirectoryParents`, `inferMountFileParents`, and the directory prefix helpers. Tested locally against a pod with nested files.

<img width="406" height="302" alt="image" src="https://github.com/user-attachments/assets/6c451e61-6fc3-4c2c-98ec-c00dd130fa73" />


## Risk

Low. `upsertDataSourceFolder` and `upsertDataSourceDocument` are idempotent. Files already synced flat under `PROJECT_CONTEXT_FOLDER_ID` will be re-parented on the next full or incremental sync cycle — no data loss. Rollback-safe: reverting redeploys connectors and leaves existing nodes in place.

## Deploy Plan

Deploy connectors.
