### PR TITLE
Pull a searchDocumentsByName helper into lib

### DIFF
--- a/front/lib/providers/google_drive/search.ts
+++ b/front/lib/providers/google_drive/search.ts
@@ -33,6 +33,44 @@ turndownService.addRule("removeBase64Images", {
   replacement: () => "",
 });
 
+export interface GoogleDriveAuthorizationSearchFile {
+  fileId: string;
+  fileName: string;
+  mimeType: string;
+  webViewLink: string;
+}
+
+export async function searchDocumentsByName({
+  accessToken,
+  fileName,
+}: {
+  accessToken: string;
+  fileName: string;
+}): Promise<GoogleDriveAuthorizationSearchFile[]> {
+  const drive = getGoogleDriveClient(accessToken);
+
+  // Prevent query injection in Google Drive API search syntax.
+  const escapedFileName = fileName.replace(/'/g, "\\'");
+  const query = `name contains '${escapedFileName}' and (mimeType='application/vnd.google-apps.document' or mimeType='application/vnd.google-apps.spreadsheet') and trashed=false`;
+
+  const searchRes = await drive.files.list({
+    q: query,
+    pageSize: 10,
+    orderBy: "modifiedTime desc",
+    fields: "files(id, name, mimeType, webViewLink)",
+    includeItemsFromAllDrives: true,
+    supportsAllDrives: true,
+    corpora: "allDrives",
+  });
+
+  return (searchRes.data.files ?? []).map((file) => ({
+    fileId: file.id ?? "",
+    fileName: file.name ?? "",
+    mimeType: file.mimeType ?? "",
+    webViewLink: file.webViewLink ?? "",
+  }));
+}
+
 export async function search({
   accessToken,
   query,

--- a/front/pages/api/w/[wId]/google_drive/search_for_authorization.ts
+++ b/front/pages/api/w/[wId]/google_drive/search_for_authorization.ts
@@ -3,7 +3,8 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import config from "@app/lib/api/config";
 import { checkConnectionOwnership } from "@app/lib/api/oauth";
 import type { Authenticator } from "@app/lib/auth";
-import { getGoogleDriveClient } from "@app/lib/providers/google_drive/utils";
+import type { GoogleDriveAuthorizationSearchFile } from "@app/lib/providers/google_drive/search";
+import { searchDocumentsByName } from "@app/lib/providers/google_drive/search";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -18,15 +19,8 @@ const RequestBodySchema = z.object({
   fileName: z.string().min(1, "fileName is required"),
 });
 
-interface GoogleDriveFile {
-  fileId: string;
-  fileName: string;
-  mimeType: string;
-  webViewLink: string;
-}
-
 export interface SearchForAuthorizationResponseType {
-  files: GoogleDriveFile[];
+  files: GoogleDriveAuthorizationSearchFile[];
 }
 
 async function handler(
@@ -119,32 +113,9 @@ async function handler(
       }
 
       const accessToken = tokenRes.value.access_token;
-      const drive = getGoogleDriveClient(accessToken);
-
-      // Prevent query injection in Google Drive API search syntax.
-      const escapedFileName = fileName.replace(/'/g, "\\'");
-      const query = `name contains '${escapedFileName}' and (mimeType='application/vnd.google-apps.document' or mimeType='application/vnd.google-apps.spreadsheet') and trashed=false`;
 
       try {
-        const searchRes = await drive.files.list({
-          q: query,
-          pageSize: 10,
-          orderBy: "modifiedTime desc",
-          fields: "files(id, name, mimeType, webViewLink)",
-          includeItemsFromAllDrives: true,
-          supportsAllDrives: true,
-          corpora: "allDrives",
-        });
-
-        const files: GoogleDriveFile[] = (searchRes.data.files ?? []).map(
-          (file) => ({
-            fileId: file.id ?? "",
-            fileName: file.name ?? "",
-            mimeType: file.mimeType ?? "",
-            webViewLink: file.webViewLink ?? "",
-          })
-        );
-
+        const files = await searchDocumentsByName({ accessToken, fileName });
         return res.status(200).json({ files });
       } catch (err) {
         const error = normalizeError(err);


### PR DESCRIPTION
## Description

  Extract the Google Drive search logic out of `search_for_authorization.ts` into a reusable provider helper, keeping the API handler focused on HTTP concerns.

  - Added `searchDocumentsByName` (and `GoogleDriveAuthorizationSearchFile` type) to `front/lib/providers/google_drive/search.ts`, alongside the existing Drive `search`/`download` helpers.
  - Updated `front/pages/api/w/[wId]/google_drive/search_for_authorization.ts` to call the helper. The helper throws on Drive API errors; the handler keeps its existing `try/catch` for HTTP mapping — no domain↔HTTP error translation layer introduced.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
