### PR TITLE
feat: rename pod main page components

### DIFF
--- a/extension/ui/pages/ProjectMainPage.tsx
+++ b/extension/ui/pages/ProjectMainPage.tsx
@@ -1,6 +1,6 @@
 import { BlockedActionsProvider } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
-import { SpaceConversationsPage } from "@app/components/pages/conversation/SpaceConversationsPage";
+import { PodPage } from "@app/components/pages/pod/PodPage";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { ConversationLayout } from "@extension/ui/components/conversation/ConversationLayout";
@@ -21,7 +21,7 @@ export const ProjectMainPage = () => {
       <BlockedActionsProvider owner={workspace}>
         <GenerationContextProvider>
           <ExtensionInputBarProvider workspace={workspace}>
-            <SpaceConversationsPage />
+            <PodPage />
           </ExtensionInputBarProvider>
         </GenerationContextProvider>
       </BlockedActionsProvider>

--- a/front-spa/src/app/routes/podsRoutes.tsx
+++ b/front-spa/src/app/routes/podsRoutes.tsx
@@ -3,12 +3,9 @@ import { withSuspense } from "@spa/app/routes/withSuspense";
 import type { RouteObject } from "react-router-dom";
 import { Navigate, useLocation, useParams } from "react-router-dom";
 
-const SpaceConversationsPage = withSuspense(
-  () =>
-    import(
-      "@dust-tt/front/components/pages/conversation/SpaceConversationsPage"
-    ),
-  "SpaceConversationsPage"
+const PodPage = withSuspense(
+  () => import("@dust-tt/front/components/pages/pod/PodPage"),
+  "PodPage"
 );
 
 // Redirect legacy /conversation/space/:spaceId URLs
@@ -31,7 +28,7 @@ export const podsRoutes: RouteObject[] = [
     children: [
       {
         index: true,
-        element: <SpaceConversationsPage />,
+        element: <PodPage />,
       },
     ],
   },

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -9,7 +9,7 @@ import {
   useConversationParticipationOptions,
   useConversationUrlAccessMode,
   useJoinConversation,
-  useSpaceConversationsSummary,
+  usePodConversationsSummary,
 } from "@app/hooks/conversations";
 import { useDeleteConversation } from "@app/hooks/useDeleteConversation";
 import { useMoveConversationOutOfProject } from "@app/hooks/useMoveConversationOutOfProject";
@@ -234,7 +234,7 @@ export function ConversationMenu({
     },
   });
 
-  const { summary } = useSpaceConversationsSummary({
+  const { summary } = usePodConversationsSummary({
     workspaceId: owner.sId,
     options: { disabled: shouldWaitBeforeFetching || !hasFeature("projects") },
   });

--- a/front/components/assistant/conversation/CreateProjectModal.tsx
+++ b/front/components/assistant/conversation/CreateProjectModal.tsx
@@ -1,6 +1,6 @@
-import { useSpaceConversationsSummary } from "@app/hooks/conversations";
+import { usePodConversationsSummary } from "@app/hooks/conversations";
 import { useAppRouter } from "@app/lib/platform";
-import { useCheckProjectName } from "@app/lib/swr/projects";
+import { useCheckProjectName } from "@app/lib/swr/pods";
 import { useCreateSpace } from "@app/lib/swr/spaces";
 import { getPodRoute } from "@app/lib/utils/router";
 import { areOpenProjectsAllowed } from "@app/lib/workspace_policies";
@@ -47,7 +47,7 @@ export function CreateProjectModal({
   const doCreate = useCreateSpace({ owner });
   const router = useAppRouter();
 
-  const { mutate: mutateSpaceSummary } = useSpaceConversationsSummary({
+  const { mutate: mutateSpaceSummary } = usePodConversationsSummary({
     workspaceId: owner.sId,
     options: { disabled: true },
   });

--- a/front/components/assistant/conversation/EditProjectTitleDialog.tsx
+++ b/front/components/assistant/conversation/EditProjectTitleDialog.tsx
@@ -1,7 +1,7 @@
-import { useSpaceConversationsSummary } from "@app/hooks/conversations";
+import { usePodConversationsSummary } from "@app/hooks/conversations";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
-import { useCheckProjectName } from "@app/lib/swr/projects";
+import { useCheckProjectName } from "@app/lib/swr/pods";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -50,7 +50,7 @@ export const EditProjectTitleDialog = ({
     spaceId,
     disabled: true, // Needed just to mutate
   });
-  const { mutate: mutateSpaceSummary } = useSpaceConversationsSummary({
+  const { mutate: mutateSpaceSummary } = usePodConversationsSummary({
     workspaceId: owner.sId,
     options: { disabled: true },
   });

--- a/front/components/assistant/conversation/ProjectMenu.tsx
+++ b/front/components/assistant/conversation/ProjectMenu.tsx
@@ -1,7 +1,7 @@
 import { EditProjectTitleDialog } from "@app/components/assistant/conversation/EditProjectTitleDialog";
 import { LeaveProjectDialog } from "@app/components/assistant/conversation/LeaveProjectDialog";
 import { useArchiveProject } from "@app/hooks/useArchiveProject";
-import { useLeaveProjectDialog } from "@app/hooks/useLeaveProjectDialog";
+import { useLeavePodDialog } from "@app/hooks/useLeaveProjectDialog";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useURLSheet } from "@app/hooks/useURLSheet";
 import config from "@app/lib/api/config";
@@ -168,10 +168,10 @@ export function ProjectMenu({
     }
   }, [isProjectDisplayed, owner.sId, router]);
 
-  const { leaveDialogProps, openLeaveDialog } = useLeaveProjectDialog({
+  const { leaveDialogProps, openLeaveDialog } = useLeavePodDialog({
     owner,
-    spaceId: activeSpaceId ?? "",
-    spaceName,
+    podId: activeSpaceId ?? "",
+    podName: spaceName,
     isRestricted: spaceInfo?.isRestricted ?? true,
     userName,
     onSuccess: handleLeaveSuccess,

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -19,9 +19,9 @@ import { ImportSkillsDialog } from "@app/components/skills/import/ImportSkillsDi
 import { SidebarContext } from "@app/components/sparkle/SidebarContext";
 import {
   useConversations,
+  usePodConversationsSummary,
   useSearchPrivateConversations,
   useSearchProjectConversations,
-  useSpaceConversationsSummary,
 } from "@app/hooks/conversations";
 import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import { useActivePodId } from "@app/hooks/useActivePodId";
@@ -459,7 +459,7 @@ export function AgentSidebarMenu({
     summary,
     isLoading: isSummaryLoading,
     mutate: mutateSpaceSummary,
-  } = useSpaceConversationsSummary({
+  } = usePodConversationsSummary({
     workspaceId: owner.sId,
     options: { disabled: !hasSpaceConversations },
   });

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -15,7 +15,7 @@ import { useAuth } from "@app/lib/auth/AuthContext";
 import { useClientType } from "@app/lib/context/clientType";
 import { clientFetch } from "@app/lib/egress/client";
 import { useFileContent, useFileMetadata } from "@app/lib/swr/files";
-import { useProjectFiles } from "@app/lib/swr/projects";
+import { useProjectFiles } from "@app/lib/swr/pods";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";

--- a/front/components/assistant/conversation/sidebar/ProjectsList.tsx
+++ b/front/components/assistant/conversation/sidebar/ProjectsList.tsx
@@ -4,7 +4,7 @@ import {
 } from "@app/components/assistant/conversation/ProjectMenu";
 import { SidebarContext } from "@app/components/sparkle/SidebarContext";
 import { useConversation } from "@app/hooks/conversations";
-import { useSpaceConversations } from "@app/hooks/conversations/useSpaceConversations";
+import { usePodConversations } from "@app/hooks/conversations/usePodConversations";
 import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import { useAppRouter } from "@app/lib/platform";
 import { getSpaceIcon } from "@app/lib/spaces";
@@ -51,24 +51,25 @@ const ProjectListItem = memo(
       workspaceId: owner.sId,
     });
 
-    const { mutateConversations: mutateAllConversations } =
-      useSpaceConversations({
+    const { mutateConversations: mutateAllConversations } = usePodConversations(
+      {
         workspaceId: owner.sId,
-        spaceId: space.sId,
+        podId: space.sId,
         filter: "all",
         options: { disabled: true },
-      });
+      }
+    );
     const { mutateConversations: mutateWithMeConversations } =
-      useSpaceConversations({
+      usePodConversations({
         workspaceId: owner.sId,
-        spaceId: space.sId,
+        podId: space.sId,
         filter: "with_me",
         options: { disabled: true },
       });
     const { mutateConversations: mutateGroupConversations } =
-      useSpaceConversations({
+      usePodConversations({
         workspaceId: owner.sId,
-        spaceId: space.sId,
+        podId: space.sId,
         filter: "group",
         options: { disabled: true },
       });

--- a/front/components/assistant/conversation/space/CreateFolderDialog.tsx
+++ b/front/components/assistant/conversation/space/CreateFolderDialog.tsx
@@ -1,4 +1,4 @@
-import { useCreateProjectFolder } from "@app/lib/swr/projects";
+import { useCreateProjectFolder } from "@app/lib/swr/pods";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Dialog,

--- a/front/components/assistant/conversation/space/PodPinnedBanner.tsx
+++ b/front/components/assistant/conversation/space/PodPinnedBanner.tsx
@@ -1,9 +1,9 @@
 import { VisualizationActionIframe } from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
 import { usePinPodBanner } from "@app/hooks/usePinPodBanner";
-import { useScopedUIPreferences } from "@app/hooks/useScopedUIPreferences";
+import { useScopedPodUiPreferences } from "@app/hooks/useScopedUIPreferences";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { useFileContent } from "@app/lib/swr/files";
-import { useProjectFiles } from "@app/lib/swr/projects";
+import { useProjectFiles } from "@app/lib/swr/pods";
 import logger from "@app/logger/logger";
 import type { RichSpaceType } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
 import type { WorkspaceType } from "@app/types/user";
@@ -154,7 +154,7 @@ export function PodPinnedBanner({ owner, spaceInfo }: PodPinnedBannerProps) {
   const pinnedFramePath = spaceInfo.pinnedFramePath;
 
   const { value: bannerPreferences, setValue: setBannerPreferences } =
-    useScopedUIPreferences({
+    useScopedPodUiPreferences({
       scope: "podPinnedBanner",
       resourceId: spaceInfo.sId,
       defaultValue: DEFAULT_POD_PINNED_BANNER_PREFERENCES,

--- a/front/components/assistant/conversation/space/ProjectFileExplorer.tsx
+++ b/front/components/assistant/conversation/space/ProjectFileExplorer.tsx
@@ -34,7 +34,7 @@ import {
   useProjectContextAttachments,
   useProjectFiles,
   useRemoveProjectContextContentNodes,
-} from "@app/lib/swr/projects";
+} from "@app/lib/swr/pods";
 import { useSpaceDataSourceViews, useSpaces } from "@app/lib/swr/spaces";
 import { isManualProjectKnowledgeManagementAllowed } from "@app/lib/workspace_policies";
 import type { RichSpaceType } from "@app/pages/api/w/[wId]/spaces/[spaceId]";

--- a/front/components/assistant/conversation/space/RenameFileDialog.tsx
+++ b/front/components/assistant/conversation/space/RenameFileDialog.tsx
@@ -1,4 +1,4 @@
-import { useRenameProjectFile } from "@app/lib/swr/projects";
+import { useRenameProjectFile } from "@app/lib/swr/pods";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Dialog,

--- a/front/components/assistant/conversation/space/about/DeleteSpaceDialog.tsx
+++ b/front/components/assistant/conversation/space/about/DeleteSpaceDialog.tsx
@@ -1,4 +1,4 @@
-import { useSpaceConversationsSummary } from "@app/hooks/conversations";
+import { usePodConversationsSummary } from "@app/hooks/conversations";
 import { useAppRouter } from "@app/lib/platform";
 import { getSpaceName } from "@app/lib/spaces";
 import { useDeleteSpace } from "@app/lib/swr/spaces";
@@ -30,7 +30,7 @@ export function DeleteSpaceDialog({ owner, space }: DeleteSpaceDialogProps) {
   const [isDeleting, setIsDeleting] = useState(false);
   const [confirmText, setConfirmText] = useState("");
   const doDelete = useDeleteSpace({ owner, force: true });
-  const { mutate: mutateSpaceSummary } = useSpaceConversationsSummary({
+  const { mutate: mutateSpaceSummary } = usePodConversationsSummary({
     workspaceId: owner.sId,
     options: { disabled: true },
   });

--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -3,9 +3,9 @@ import { MembersTable } from "@app/components/assistant/conversation/space/about
 import { ProjectSettingsOptionLabel } from "@app/components/assistant/conversation/space/about/ProjectSettingsOptionLabel";
 import { SuggestedTasksGenerationTile } from "@app/components/assistant/conversation/space/conversations/project_tasks/SuggestedTasksGenerationTile";
 import { ConfirmContext } from "@app/components/Confirm";
-import { useSpaceConversationsSummary } from "@app/hooks/conversations";
+import { usePodConversationsSummary } from "@app/hooks/conversations";
 import { useArchiveProject } from "@app/hooks/useArchiveProject";
-import { useCheckProjectName } from "@app/lib/swr/projects";
+import { useCheckProjectName } from "@app/lib/swr/pods";
 import {
   useProjectMetadata,
   useSpaceInfo,
@@ -109,7 +109,7 @@ export function SpaceAboutTab({
     workspaceId: owner.sId,
     spaceId: space.sId,
   });
-  const { mutate: mutateSpaceSummary } = useSpaceConversationsSummary({
+  const { mutate: mutateSpaceSummary } = usePodConversationsSummary({
     workspaceId: owner.sId,
   });
 

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsActions.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsActions.tsx
@@ -1,4 +1,4 @@
-import { useSeedInitialPodTasks } from "@app/lib/swr/projects";
+import { useSeedInitialPodTasks } from "@app/lib/swr/pods";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Card, CardGrid, CheckIcon, Icon, Spinner } from "@dust-tt/sparkle";
 

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -7,8 +7,8 @@ import { getGroupConversationsByDate } from "@app/components/assistant/conversat
 import { InfiniteScroll } from "@app/components/InfiniteScroll";
 import { DropzoneContainer } from "@app/components/misc/DropzoneContainer";
 import { ProjectJoinCTA } from "@app/components/spaces/ProjectJoinCTA";
-import { useSpaceUnreadConversationIds } from "@app/hooks/conversations";
-import type { SpaceConversationListFilter } from "@app/hooks/conversations/useSpaceConversations";
+import { usePodUnreadConversationIds } from "@app/hooks/conversations";
+import type { PodConversationListFilter } from "@app/hooks/conversations/usePodConversations";
 import { useMarkAllConversationsAsRead } from "@app/hooks/useMarkAllConversationsAsRead";
 import { useSearchConversations } from "@app/hooks/useSearchConversations";
 import { getRandomGreetingForName } from "@app/lib/client/greetings";
@@ -59,8 +59,8 @@ interface SpaceConversationsTabProps {
   isLoadingMore: boolean;
   spaceInfo: GetSpaceResponseBody["space"];
   isSpaceEmpty: boolean;
-  conversationFilter: SpaceConversationListFilter;
-  onConversationFilterChange: (filter: SpaceConversationListFilter) => void;
+  conversationFilter: PodConversationListFilter;
+  onConversationFilterChange: (filter: PodConversationListFilter) => void;
   onSubmit: (
     input: string,
     mentions: RichMention[],
@@ -95,9 +95,9 @@ export function SpaceConversationsTab({
     owner,
     spaceId: spaceInfo.sId,
   });
-  const { unreadConversationIds } = useSpaceUnreadConversationIds({
+  const { unreadConversationIds } = usePodUnreadConversationIds({
     workspaceId: owner.sId,
-    spaceId: spaceInfo.sId,
+    podId: spaceInfo.sId,
   });
 
   const [isSearchPopoverOpen, setIsSearchPopoverOpen] = useState(false);

--- a/front/components/assistant/conversation/space/conversations/project_tasks/useProjectTasksPanelState.ts
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/useProjectTasksPanelState.ts
@@ -11,8 +11,8 @@ import {
 } from "@app/components/assistant/conversation/space/conversations/project_tasks/utils";
 import { ConfirmContext } from "@app/components/Confirm";
 import {
-  useSpaceConversations,
-  useSpaceConversationsSummary,
+  usePodConversations,
+  usePodConversationsSummary,
 } from "@app/hooks/conversations";
 import { useTaskDiffAnimations } from "@app/hooks/useTaskDiffAnimations";
 import { clientFetch } from "@app/lib/egress/client";
@@ -27,7 +27,7 @@ import {
   useProjectTasks,
   useStartProjectTaskConversation,
   useUpdateProjectTask,
-} from "@app/lib/swr/projects";
+} from "@app/lib/swr/pods";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { BulkActionsBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/bulk-actions";
@@ -78,13 +78,14 @@ export function useProjectTasksPanelState({
   const confirm = useContext(ConfirmContext);
   const router = useAppRouter();
 
-  const { mutateConversations: mutateSpaceConversations } =
-    useSpaceConversations({
+  const { mutateConversations: mutateSpaceConversations } = usePodConversations(
+    {
       workspaceId: owner.sId,
-      spaceId,
+      podId: spaceId,
       options: { disabled: true },
-    });
-  const { mutate: mutateSpaceSummary } = useSpaceConversationsSummary({
+    }
+  );
+  const { mutate: mutateSpaceSummary } = usePodConversationsSummary({
     workspaceId: owner.sId,
     options: { disabled: true },
   });

--- a/front/components/assistant/conversation/tool_validation/PodTasksUpdateValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/PodTasksUpdateValidationDetails.tsx
@@ -7,7 +7,7 @@ import {
   type MemberDisplayInfo,
   useMemberDetails,
 } from "@app/lib/swr/assistants";
-import { useWorkspaceProjectTask } from "@app/lib/swr/projects";
+import { useWorkspaceProjectTask } from "@app/lib/swr/pods";
 import {
   PROJECT_TASK_NO_ASSIGNEE_LABEL,
   type ProjectTaskStatus,

--- a/front/components/markdown/TaskDirectiveBlock.tsx
+++ b/front/components/markdown/TaskDirectiveBlock.tsx
@@ -5,7 +5,7 @@ import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import {
   useStartProjectTaskConversation,
   useWorkspaceProjectTask,
-} from "@app/lib/swr/projects";
+} from "@app/lib/swr/pods";
 import { timeAgoFrom } from "@app/lib/utils";
 import type { ConversationDotStatus } from "@app/lib/utils/conversation_dot_status";
 import { getConversationRoute, getPodRoute } from "@app/lib/utils/router";

--- a/front/components/pages/pod/PodPage.tsx
+++ b/front/components/pages/pod/PodPage.tsx
@@ -2,27 +2,28 @@ import { SpaceAboutTab } from "@app/components/assistant/conversation/space/abou
 import type { TaskOwnerFilter } from "@app/components/assistant/conversation/space/conversations/project_tasks/projectTasksListScope";
 import { SpaceConversationsTab } from "@app/components/assistant/conversation/space/conversations/SpaceConversationsTab";
 import { ManageUsersPanel } from "@app/components/assistant/conversation/space/ManageUsersPanel";
-import { ProjectHeaderActions } from "@app/components/assistant/conversation/space/ProjectHeaderActions";
 import { SpaceKnowledgeTab } from "@app/components/assistant/conversation/space/SpaceKnowledgeTab";
 import { SpaceTasksTab } from "@app/components/assistant/conversation/space/SpaceTasksTab";
-
-import { useSpaceConversations } from "@app/hooks/conversations";
-import type { SpaceConversationListFilter } from "@app/hooks/conversations/useSpaceConversations";
+import { PodHeaderActions } from "@app/components/pod/PodHeaderActions";
+import {
+  type PodConversationListFilter,
+  usePodConversations,
+} from "@app/hooks/conversations/usePodConversations";
 import { useActivePodId } from "@app/hooks/useActivePodId";
 import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { useScopedUIPreferences } from "@app/hooks/useScopedUIPreferences";
+import { useScopedPodUiPreferences } from "@app/hooks/useScopedUIPreferences";
 import {
-  DEFAULT_SPACE_PROJECT_UI_PREFERENCES,
-  type SpaceProjectTab,
-  useSpaceProjectTabs,
+  DEFAULT_POD_UI_PREFERENCES,
+  type PodTab,
+  usePodTabs,
 } from "@app/hooks/useSpaceProjectTabs";
 import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { useClientType } from "@app/lib/context/clientType";
 import type { DustError } from "@app/lib/error";
 import { useAppRouter } from "@app/lib/platform";
-import { useSpaceInfo, useSystemSpace } from "@app/lib/swr/spaces";
+import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { LightConversationType } from "@app/types/assistant/conversation";
@@ -49,23 +50,23 @@ import {
 } from "@dust-tt/sparkle";
 import { useCallback, useState } from "react";
 
-export function SpaceConversationsPage() {
+export function PodPage() {
   const owner = useWorkspace();
   const { user } = useAuth();
   const clientType = useClientType();
   const router = useAppRouter();
-  const spaceId = useActivePodId();
+  const podId = useActivePodId();
   const sendNotification = useSendNotification();
 
-  const { spaceInfo, isSpaceInfoLoading, isSpaceInfoError, mutateSpaceInfo } =
-    useSpaceInfo({
-      workspaceId: owner.sId,
-      spaceId: spaceId,
-      includeAllMembers: true,
-    });
-
-  const { systemSpace, isSystemSpaceLoading } = useSystemSpace({
+  const {
+    spaceInfo: podInfo,
+    isSpaceInfoLoading: isPodsInfoLoading,
+    isSpaceInfoError: podInfoError,
+    mutateSpaceInfo: mutatePodInfo,
+  } = useSpaceInfo({
     workspaceId: owner.sId,
+    spaceId: podId,
+    includeAllMembers: true,
   });
 
   const createConversationWithMessage = useCreateConversationWithMessage({
@@ -73,16 +74,16 @@ export function SpaceConversationsPage() {
     user,
   });
 
-  const { value: projectUIPreferences, setValue: setProjectUIPreferences } =
-    useScopedUIPreferences({
-      scope: "projectUI",
-      resourceId: spaceId,
-      defaultValue: DEFAULT_SPACE_PROJECT_UI_PREFERENCES,
+  const { value: podUiPreferences, setValue: setPodUiPreferences } =
+    useScopedPodUiPreferences({
+      scope: "podUi",
+      resourceId: podId,
+      defaultValue: DEFAULT_POD_UI_PREFERENCES,
     });
-  const isSingleMemberProject = !!spaceInfo && spaceInfo.members.length === 1;
-  const conversationFilter: SpaceConversationListFilter = isSingleMemberProject
+  const isSingleMemberPod = !!podInfo && podInfo.members.length === 1;
+  const conversationFilter: PodConversationListFilter = isSingleMemberPod
     ? "all"
-    : projectUIPreferences.conversationsFilter;
+    : podUiPreferences.conversationsFilter;
 
   const {
     conversations,
@@ -92,44 +93,39 @@ export function SpaceConversationsPage() {
     isEmpty: isSpaceEmpty,
     loadMore,
     isLoadingMore,
-  } = useSpaceConversations({
+  } = usePodConversations({
     workspaceId: owner.sId,
-    spaceId: spaceId,
+    podId: podId,
     filter: conversationFilter,
   });
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [_planLimitReached, setPlanLimitReached] = useState(false);
   const [isInvitePanelOpen, setIsInvitePanelOpen] = useState(false);
-  const compactProjectTabs = useIsMobile();
+  const compactPodTabs = useIsMobile();
 
-  const { currentTab, handleTabChange } = useSpaceProjectTabs({
-    spaceId,
-    projectUIPreferences,
-    setProjectUIPreferences,
+  const { currentTab, handleTabChange } = usePodTabs({
+    podId,
+    podUiPreferences,
+    setPodUiPreferences,
   });
 
-  const handleConversationFilterChange = useCallback(
-    (filter: SpaceConversationListFilter) => {
-      setProjectUIPreferences({
-        ...projectUIPreferences,
-        conversationsFilter: filter,
-      });
-    },
-    [projectUIPreferences, setProjectUIPreferences]
-  );
+  const handleConversationFilterChange = (
+    filter: PodConversationListFilter
+  ) => {
+    setPodUiPreferences({
+      ...podUiPreferences,
+      conversationsFilter: filter,
+    });
+  };
 
-  const handleTaskOwnerFilterChange = useCallback(
-    (tasksOwnerFilter: TaskOwnerFilter) => {
-      setProjectUIPreferences({
-        ...projectUIPreferences,
-        tasksOwnerFilter,
-      });
-    },
-    [projectUIPreferences, setProjectUIPreferences]
-  );
+  const handleTaskOwnerFilterChange = (tasksOwnerFilter: TaskOwnerFilter) => {
+    setPodUiPreferences({
+      ...podUiPreferences,
+      tasksOwnerFilter,
+    });
+  };
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   const handleConversationCreation = useCallback(
     async (
       input: string,
@@ -154,7 +150,7 @@ export function SpaceConversationsPage() {
           contentFragments,
           selectedMCPServerViewIds,
         },
-        spaceId,
+        spaceId: podId,
       });
 
       setIsSubmitting(false);
@@ -235,8 +231,7 @@ export function SpaceConversationsPage() {
     [
       isSubmitting,
       owner,
-      spaceId,
-      setPlanLimitReached,
+      podId,
       sendNotification,
       router,
       mutateConversations,
@@ -245,7 +240,7 @@ export function SpaceConversationsPage() {
   );
 
   // Show loading state while fetching space info
-  if (isSpaceInfoLoading || isSystemSpaceLoading) {
+  if (isPodsInfoLoading) {
     return (
       <div className="flex h-full w-full items-center justify-center">
         <Spinner />
@@ -253,15 +248,15 @@ export function SpaceConversationsPage() {
     );
   }
 
-  // Handle space not found or access denied
-  if (isSpaceInfoError || !spaceInfo || !systemSpace) {
+  // Handle pod not found or access denied
+  if (podInfoError || !podInfo) {
     return (
       <div className="flex h-full w-full items-center justify-center">
         <div className="text-center">
-          <h2 className="text-lg font-semibold">Space not found</h2>
+          <h2 className="text-lg font-semibold">Pod not found</h2>
           <p className="text-muted-foreground">
-            The space you&apos;re looking for doesn&apos;t exist or you
-            don&apos;t have access to it.
+            The Pod you&apos;re looking for doesn&apos;t exist or you don&apos;t
+            have access to it.
           </p>
         </div>
       </div>
@@ -279,7 +274,7 @@ export function SpaceConversationsPage() {
           hasMore={hasMore}
           loadMore={loadMore}
           isLoadingMore={isLoadingMore}
-          spaceInfo={spaceInfo}
+          spaceInfo={podInfo}
           isSpaceEmpty={isSpaceEmpty}
           conversationFilter={conversationFilter}
           onConversationFilterChange={handleConversationFilterChange}
@@ -295,46 +290,46 @@ export function SpaceConversationsPage() {
     <div className="flex min-h-0 w-full flex-1 flex-col overflow-hidden">
       <Tabs
         value={currentTab}
-        onValueChange={(value) => handleTabChange(value as SpaceProjectTab)}
+        onValueChange={(value) => handleTabChange(value as PodTab)}
         className="flex min-h-0 flex-1 flex-col overflow-hidden pt-3"
       >
         <div className="flex shrink-0 items-start justify-between border-b border-separator pl-14 pr-6 lg:px-6 dark:border-separator-night">
           <TabsList border={false}>
             <TabsTrigger
               value="conversations"
-              label={compactProjectTabs ? undefined : "Conversations"}
-              tooltip={compactProjectTabs ? "Conversations" : undefined}
+              label={compactPodTabs ? undefined : "Conversations"}
+              tooltip={compactPodTabs ? "Conversations" : undefined}
               icon={ChatBubbleLeftRightIcon}
             />
             <TabsTrigger
               value="tasks"
-              label={compactProjectTabs ? undefined : "Tasks"}
-              tooltip={compactProjectTabs ? "Tasks" : undefined}
+              label={compactPodTabs ? undefined : "Tasks"}
+              tooltip={compactPodTabs ? "Tasks" : undefined}
               icon={CheckIcon}
             />
             <TabsTrigger
               value="files"
-              label={compactProjectTabs ? undefined : "Files"}
-              tooltip={compactProjectTabs ? "Files" : undefined}
+              label={compactPodTabs ? undefined : "Files"}
+              tooltip={compactPodTabs ? "Files" : undefined}
               icon={FolderIcon}
             />
             <TabsTrigger
               value="settings"
-              label={compactProjectTabs ? undefined : "Settings"}
-              tooltip={compactProjectTabs ? "Settings" : undefined}
+              label={compactPodTabs ? undefined : "Settings"}
+              tooltip={compactPodTabs ? "Settings" : undefined}
               icon={Cog6ToothIcon}
             />
           </TabsList>
 
-          {spaceInfo.kind === "project" &&
-            (spaceInfo.isMember || !spaceInfo.isRestricted) && (
-              <ProjectHeaderActions
-                isMember={spaceInfo.isMember}
-                isRestricted={spaceInfo.isRestricted}
-                members={spaceInfo.members}
+          {podInfo.kind === "project" &&
+            (podInfo.isMember || !podInfo.isRestricted) && (
+              <PodHeaderActions
+                isMember={podInfo.isMember}
+                isRestricted={podInfo.isRestricted}
+                members={podInfo.members}
                 owner={owner}
-                spaceId={spaceInfo.sId}
-                spaceName={spaceInfo.name}
+                podId={podInfo.sId}
+                podName={podInfo.name}
                 user={user}
               />
             )}
@@ -349,7 +344,7 @@ export function SpaceConversationsPage() {
             hasMore={hasMore}
             loadMore={loadMore}
             isLoadingMore={isLoadingMore}
-            spaceInfo={spaceInfo}
+            spaceInfo={podInfo}
             isSpaceEmpty={isSpaceEmpty}
             conversationFilter={conversationFilter}
             onConversationFilterChange={handleConversationFilterChange}
@@ -360,23 +355,23 @@ export function SpaceConversationsPage() {
         </TabsContent>
 
         <TabsContent value="files">
-          <SpaceKnowledgeTab owner={owner} space={spaceInfo} />
+          <SpaceKnowledgeTab owner={owner} space={podInfo} />
         </TabsContent>
 
         <TabsContent value="tasks">
           <SpaceTasksTab
             owner={owner}
-            spaceInfo={spaceInfo}
-            taskOwnerFilter={projectUIPreferences.tasksOwnerFilter}
+            spaceInfo={podInfo}
+            taskOwnerFilter={podUiPreferences.tasksOwnerFilter}
             onTaskOwnerFilterChange={handleTaskOwnerFilterChange}
           />
         </TabsContent>
 
         <TabsContent value="settings">
           <SpaceAboutTab
-            key={spaceId}
+            key={podId}
             owner={owner}
-            space={spaceInfo}
+            space={podInfo}
             onOpenMembersPanel={() => setIsInvitePanelOpen(true)}
           />
         </TabsContent>
@@ -386,9 +381,9 @@ export function SpaceConversationsPage() {
         setIsOpen={setIsInvitePanelOpen}
         owner={owner}
         mode="space-members"
-        space={spaceInfo}
-        currentProjectMembers={spaceInfo.members}
-        onSuccess={() => mutateSpaceInfo()}
+        space={podInfo}
+        currentProjectMembers={podInfo.members}
+        onSuccess={() => mutatePodInfo()}
       />
     </div>
   );

--- a/front/components/pod/PodHeaderActions.tsx
+++ b/front/components/pod/PodHeaderActions.tsx
@@ -1,5 +1,5 @@
 import { LeaveProjectDialog } from "@app/components/assistant/conversation/LeaveProjectDialog";
-import { useLeaveProjectDialog } from "@app/hooks/useLeaveProjectDialog";
+import { useLeavePodDialog } from "@app/hooks/useLeaveProjectDialog";
 import { useAppRouter } from "@app/lib/platform";
 import { getConversationRoute, getPodRoute } from "@app/lib/utils/router";
 import type {
@@ -19,53 +19,51 @@ import {
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import { useCallback } from "react";
-import { ProjectNotificationMenu } from "../ProjectNotificationMenu";
+import { ProjectNotificationMenu } from "../assistant/conversation/ProjectNotificationMenu";
 
-interface ProjectHeaderActionsProps {
+interface PodHeaderActionsProps {
   isMember: boolean;
   isRestricted: boolean;
   members: SpaceUserType[];
   owner: LightWorkspaceType;
-  spaceId: string;
-  spaceName: string;
+  podId: string;
+  podName: string;
   user: UserType;
 }
 
-export function ProjectHeaderActions({
+export function PodHeaderActions({
   isMember,
   isRestricted,
   members,
   owner,
-  spaceId,
-  spaceName,
+  podId,
+  podName,
   user,
-}: ProjectHeaderActionsProps) {
+}: PodHeaderActionsProps) {
   const router = useAppRouter();
 
   const handleLeaveSuccess = useCallback(() => {
     if (isRestricted) {
       void router.push(getConversationRoute(owner.sId));
     } else {
-      void router.push(getPodRoute(owner.sId, spaceId));
+      void router.push(getPodRoute(owner.sId, podId));
     }
-  }, [isRestricted, owner.sId, router, spaceId]);
+  }, [isRestricted, owner.sId, router, podId]);
 
-  const { leaveDialogProps, openLeaveDialog } = useLeaveProjectDialog({
+  const { leaveDialogProps, openLeaveDialog } = useLeavePodDialog({
     owner,
-    spaceId,
-    spaceName,
+    podId,
+    podName,
     isRestricted,
     userName: user.fullName,
     onSuccess: handleLeaveSuccess,
   });
 
-  const projectEditors = members.filter((member) => member.isEditor);
-  const isProjectEditor = projectEditors.some(
-    (member) => member.sId === user.sId
-  );
-  const canLeaveProject =
-    (isMember && !isProjectEditor) || // regular members can leave the project
-    (isProjectEditor && projectEditors.length > 1); // editors can leave if there's at least another editor
+  const podEditors = members.filter((member) => member.isEditor);
+  const isPodEditor = podEditors.some((member) => member.sId === user.sId);
+  const canLeavePod =
+    (isMember && !isPodEditor) || // regular members can leave the pod
+    (isPodEditor && podEditors.length > 1); // editors can leave if there's at least another editor
   return (
     <>
       <div className="flex items-center gap-2">
@@ -89,11 +87,11 @@ export function ProjectHeaderActions({
                 icon={MoreIcon}
                 variant="ghost"
                 size="sm"
-                tooltip="Project options"
+                tooltip="Pod options"
               />
             </DropdownMenuTrigger>
             <DropdownMenuContent collisionPadding={8}>
-              {!canLeaveProject ? (
+              {!canLeavePod ? (
                 <DropdownTooltipTrigger
                   description="You are the last editor of this Pod and cannot leave it."
                   side="left"
@@ -112,7 +110,7 @@ export function ProjectHeaderActions({
                 />
               )}
               <ProjectNotificationMenu
-                activeSpaceId={spaceId}
+                activeSpaceId={podId}
                 owner={owner}
                 shouldWaitBeforeFetching={false}
               />

--- a/front/hooks/conversations/index.ts
+++ b/front/hooks/conversations/index.ts
@@ -31,13 +31,13 @@ export {
 } from "./useConversationTools";
 export { useConversationUrlAccessMode } from "./useConversationUrlAccessMode";
 export { useOpenConversationBranch } from "./useOpenConversationBranch";
+export {
+  usePodConversations,
+  usePodConversationsSummary,
+  usePodUnreadConversationIds,
+} from "./usePodConversations";
 export { usePostOnboardingFollowUp } from "./usePostOnboardingFollowUp";
 export { useSearchPrivateConversations } from "./useSearchPrivateConversations";
 export { useSearchProjectConversations } from "./useSearchProjectConversations";
-export {
-  useSpaceConversations,
-  useSpaceConversationsSummary,
-  useSpaceUnreadConversationIds,
-} from "./useSpaceConversations";
 export { useVisualizationRetry } from "./useVisualizationRetry";
 export { useVisualizationRevert } from "./useVisualizationRevert";

--- a/front/hooks/conversations/useConversationMarkAsRead.ts
+++ b/front/hooks/conversations/useConversationMarkAsRead.ts
@@ -1,3 +1,4 @@
+import { usePodConversationsSummary } from "@app/hooks/conversations/usePodConversations";
 import { clientFetch } from "@app/lib/egress/client";
 import logger from "@app/logger/logger";
 import type { PatchConversationsRequestBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]";
@@ -8,7 +9,6 @@ import type {
 import { isProjectConversation } from "@app/types/assistant/conversation";
 import { useCallback, useEffect } from "react";
 import { useConversations } from "./useConversations";
-import { useSpaceConversationsSummary } from "./useSpaceConversations";
 
 const DELAY_BEFORE_MARKING_AS_READ = 2000;
 
@@ -24,7 +24,7 @@ export function useConversationMarkAsRead({
     options: { disabled: true },
   });
 
-  const { mutate: mutateSpaceSummary } = useSpaceConversationsSummary({
+  const { mutate: mutateSpaceSummary } = usePodConversationsSummary({
     workspaceId,
     options: {
       disabled: true,

--- a/front/hooks/conversations/usePodConversations.ts
+++ b/front/hooks/conversations/usePodConversations.ts
@@ -11,7 +11,7 @@ import type { LightConversationType } from "@app/types/assistant/conversation";
 import { useCallback, useMemo } from "react";
 import type { Fetcher } from "swr";
 
-export function useSpaceConversationsSummary({
+export function usePodConversationsSummary({
   workspaceId,
   options,
 }: {
@@ -37,19 +37,19 @@ export function useSpaceConversationsSummary({
 
 const DEFAULT_CONVERSATIONS_PAGE_SIZE = 12;
 
-export type SpaceConversationListFilter = "all" | "group" | "with_me";
+export type PodConversationListFilter = "all" | "group" | "with_me";
 
-export function useSpaceConversations({
+export function usePodConversations({
   workspaceId,
-  spaceId,
+  podId,
   limit = DEFAULT_CONVERSATIONS_PAGE_SIZE,
   filter = "all",
   options,
 }: {
   workspaceId: string;
-  spaceId: string | null;
+  podId: string | null;
   limit?: number;
-  filter?: SpaceConversationListFilter;
+  filter?: PodConversationListFilter;
   options?: { disabled?: boolean };
 }) {
   const { fetcher } = useFetcher();
@@ -62,7 +62,7 @@ export function useSpaceConversations({
         pageIndex: number,
         previousPageData: GetSpaceConversationsResponseBody | null
       ) => {
-        if (!spaceId) {
+        if (!podId) {
           return null;
         }
 
@@ -71,7 +71,7 @@ export function useSpaceConversations({
         });
 
         if (previousPageData === null) {
-          return `/api/w/${workspaceId}/assistant/conversations/spaces/${spaceId}?${searchParams.toString()}`;
+          return `/api/w/${workspaceId}/assistant/conversations/spaces/${podId}?${searchParams.toString()}`;
         }
 
         if (!previousPageData.hasMore) {
@@ -83,7 +83,7 @@ export function useSpaceConversations({
         }
         searchParams.set("limit", limit.toString());
 
-        return `/api/w/${workspaceId}/assistant/conversations/spaces/${spaceId}?${searchParams.toString()}`;
+        return `/api/w/${workspaceId}/assistant/conversations/spaces/${podId}?${searchParams.toString()}`;
       },
       conversationsFetcher,
       {
@@ -122,13 +122,13 @@ export function useSpaceConversations({
   };
 }
 
-export function useSpaceUnreadConversationIds({
+export function usePodUnreadConversationIds({
   workspaceId,
-  spaceId,
+  podId,
   options,
 }: {
   workspaceId: string;
-  spaceId: string | null;
+  podId: string | null;
   options?: { disabled: boolean };
 }) {
   const { fetcher } = useFetcher();
@@ -136,12 +136,12 @@ export function useSpaceUnreadConversationIds({
     fetcher;
 
   const { data, isLoading, mutate } = useSWRWithDefaults(
-    spaceId
-      ? `/api/w/${workspaceId}/assistant/conversations/spaces/${spaceId}/unread`
+    podId
+      ? `/api/w/${workspaceId}/assistant/conversations/spaces/${podId}/unread`
       : null,
     conversationsFetcher,
     {
-      disabled: options?.disabled ?? !spaceId,
+      disabled: options?.disabled ?? !podId,
     }
   );
 

--- a/front/hooks/useLeaveProjectDialog.tsx
+++ b/front/hooks/useLeaveProjectDialog.tsx
@@ -1,31 +1,31 @@
-import { useLeaveProject } from "@app/lib/swr/spaces";
+import { useLeavePod } from "@app/lib/swr/pods";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useState } from "react";
 
-interface UseLeaveProjectDialogProps {
+interface UseLeavePodDialogProps {
   owner: LightWorkspaceType;
-  spaceId: string;
-  spaceName: string;
+  podId: string;
+  podName: string;
   isRestricted: boolean;
   userName: string;
   onSuccess?: () => void;
 }
 
-export function useLeaveProjectDialog({
+export function useLeavePodDialog({
   owner,
-  spaceId,
-  spaceName,
+  podId,
+  podName,
   isRestricted,
   userName,
   onSuccess,
-}: UseLeaveProjectDialogProps) {
+}: UseLeavePodDialogProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [isLeaving, setIsLeaving] = useState(false);
 
-  const doLeave = useLeaveProject({
+  const doLeave = useLeavePod({
     owner,
-    spaceId,
-    spaceName,
+    podId: podId,
+    podName: podName,
     userName,
   });
 
@@ -39,13 +39,13 @@ export function useLeaveProjectDialog({
     }
   }, [doLeave, onSuccess]);
 
-  const openDialog = useCallback(() => {
+  const openDialog = () => {
     setIsOpen(true);
-  }, []);
+  };
 
-  const closeDialog = useCallback(() => {
+  const closeDialog = () => {
     setIsOpen(false);
-  }, []);
+  };
 
   const leaveDialogProps = {
     isOpen,
@@ -53,7 +53,7 @@ export function useLeaveProjectDialog({
     isRestricted,
     onClose: closeDialog,
     onLeave: handleLeave,
-    spaceName,
+    spaceName: podName,
   };
 
   return {

--- a/front/hooks/useMarkAllConversationsAsRead.ts
+++ b/front/hooks/useMarkAllConversationsAsRead.ts
@@ -1,8 +1,8 @@
 import {
   useConversations,
-  useSpaceConversations,
-  useSpaceConversationsSummary,
-  useSpaceUnreadConversationIds,
+  usePodConversations,
+  usePodConversationsSummary,
+  usePodUnreadConversationIds,
 } from "@app/hooks/conversations";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
@@ -25,20 +25,21 @@ export function useMarkAllConversationsAsRead({
     options: { disabled: true },
   });
 
-  const { mutate: mutateSpaceSummary } = useSpaceConversationsSummary({
+  const { mutate: mutateSpaceSummary } = usePodConversationsSummary({
     workspaceId: owner.sId,
     options: { disabled: true },
   });
 
-  const { mutateConversations: mutateSpaceConversations } =
-    useSpaceConversations({
+  const { mutateConversations: mutateSpaceConversations } = usePodConversations(
+    {
       workspaceId: owner.sId,
-      spaceId: spaceId ?? null,
-    });
+      podId: spaceId ?? null,
+    }
+  );
 
-  const { mutateUnreadConversationIds } = useSpaceUnreadConversationIds({
+  const { mutateUnreadConversationIds } = usePodUnreadConversationIds({
     workspaceId: owner.sId,
-    spaceId: spaceId ?? null,
+    podId: spaceId ?? null,
   });
 
   const markAllAsRead = useCallback(

--- a/front/hooks/useMoveConversationOutOfProject.tsx
+++ b/front/hooks/useMoveConversationOutOfProject.tsx
@@ -2,7 +2,7 @@ import { ConfirmContext } from "@app/components/Confirm";
 import {
   useConversation,
   useConversations,
-  useSpaceConversationsSummary,
+  usePodConversationsSummary,
 } from "@app/hooks/conversations";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
@@ -26,7 +26,7 @@ export function useMoveConversationOutOfProject(
     options: { disabled: true },
   });
 
-  const { mutate: mutateSpaceSummary } = useSpaceConversationsSummary({
+  const { mutate: mutateSpaceSummary } = usePodConversationsSummary({
     workspaceId: owner.sId,
     options: { disabled: true },
   });

--- a/front/hooks/useMoveConversationToProject.tsx
+++ b/front/hooks/useMoveConversationToProject.tsx
@@ -1,7 +1,7 @@
 import { ConfirmContext } from "@app/components/Confirm";
 import {
   useConversations,
-  useSpaceConversationsSummary,
+  usePodConversationsSummary,
 } from "@app/hooks/conversations";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
@@ -23,7 +23,7 @@ export function useMoveConversationToProject(owner: LightWorkspaceType) {
     options: { disabled: true },
   });
 
-  const { mutate: mutateSpaceSummary } = useSpaceConversationsSummary({
+  const { mutate: mutateSpaceSummary } = usePodConversationsSummary({
     workspaceId: owner.sId,
     options: { disabled: true },
   });

--- a/front/hooks/useScopedUIPreferences.ts
+++ b/front/hooks/useScopedUIPreferences.ts
@@ -6,7 +6,7 @@ const SCOPED_UI_PREFERENCES_KEY_PREFIX = "scopedUIPreferences";
 
 const scopedUIPreferencesSchemaByScope = {
   podUi: z.object({
-    tab: z.enum(["conversations", "tasks", "files", "settings", "alpha"]),
+    tab: z.enum(["conversations", "tasks", "files", "settings"]),
     conversationsFilter: z.enum(["all", "group", "with_me"]),
     tasksOwnerFilter: z
       .unknown()

--- a/front/hooks/useScopedUIPreferences.ts
+++ b/front/hooks/useScopedUIPreferences.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 const SCOPED_UI_PREFERENCES_KEY_PREFIX = "scopedUIPreferences";
 
 const scopedUIPreferencesSchemaByScope = {
-  projectUI: z.object({
+  podUi: z.object({
     tab: z.enum(["conversations", "tasks", "files", "settings", "alpha"]),
     conversationsFilter: z.enum(["all", "group", "with_me"]),
     tasksOwnerFilter: z
@@ -21,8 +21,8 @@ export type PodPinnedBannerScopedPreferences = z.infer<
   (typeof scopedUIPreferencesSchemaByScope)["podPinnedBanner"]
 >;
 
-export type ProjectUIScopedPreferences = z.infer<
-  (typeof scopedUIPreferencesSchemaByScope)["projectUI"]
+export type PodUiScopedPreferences = z.infer<
+  (typeof scopedUIPreferencesSchemaByScope)["podUi"]
 >;
 
 export type ScopedUIPreferencesScope =
@@ -77,7 +77,7 @@ function writePersistedValue(storageKey: string, value: unknown) {
   }
 }
 
-export function useScopedUIPreferences<
+export function useScopedPodUiPreferences<
   TScope extends ScopedUIPreferencesScope,
 >({
   scope,

--- a/front/hooks/useSpaceProjectTabs.ts
+++ b/front/hooks/useSpaceProjectTabs.ts
@@ -16,15 +16,11 @@ function parsePodTabFromLocationHash(fallbackTab: PodTab): PodTab {
     return fallbackTab;
   }
   const hash = window.location.hash.slice(1);
-  if (hash === "context" || hash === "knowledge") {
-    return "files";
-  }
   if (
     hash === "files" ||
     hash === "settings" ||
     hash === "conversations" ||
-    hash === "tasks" ||
-    hash === "alpha"
+    hash === "tasks"
   ) {
     return hash;
   }

--- a/front/hooks/useSpaceProjectTabs.ts
+++ b/front/hooks/useSpaceProjectTabs.ts
@@ -1,20 +1,17 @@
 import { DEFAULT_TASK_OWNER_FILTER } from "@app/components/assistant/conversation/space/conversations/project_tasks/projectTasksListScope";
-import type { ProjectUIScopedPreferences } from "@app/hooks/useScopedUIPreferences";
+import type { PodUiScopedPreferences } from "@app/hooks/useScopedUIPreferences";
 import { useCallback, useEffect, useRef } from "react";
 
-export type SpaceProjectTab = ProjectUIScopedPreferences["tab"];
+export type PodTab = PodUiScopedPreferences["tab"];
 
-export const DEFAULT_SPACE_PROJECT_UI_PREFERENCES: ProjectUIScopedPreferences =
-  {
-    tab: "conversations",
-    conversationsFilter: "all",
-    tasksOwnerFilter: DEFAULT_TASK_OWNER_FILTER,
-  };
+export const DEFAULT_POD_UI_PREFERENCES: PodUiScopedPreferences = {
+  tab: "conversations",
+  conversationsFilter: "all",
+  tasksOwnerFilter: DEFAULT_TASK_OWNER_FILTER,
+};
 
-/** Hash segment → tab when the user navigates with the hash (same space). */
-export function parseSpaceTabFromLocationHash(
-  fallbackTab: SpaceProjectTab
-): SpaceProjectTab {
+/** Hash segment → tab when the user navigates with the hash (same pod). */
+function parsePodTabFromLocationHash(fallbackTab: PodTab): PodTab {
   if (typeof window === "undefined") {
     return fallbackTab;
   }
@@ -34,7 +31,7 @@ export function parseSpaceTabFromLocationHash(
   return fallbackTab;
 }
 
-function replaceUrlHashWithTab(tab: SpaceProjectTab) {
+function replaceUrlHashWithTab(tab: PodTab) {
   window.history.replaceState(
     null,
     "",
@@ -42,46 +39,46 @@ function replaceUrlHashWithTab(tab: SpaceProjectTab) {
   );
 }
 
-interface UseSpaceProjectTabsParams {
-  spaceId: string | null;
-  projectUIPreferences: ProjectUIScopedPreferences;
-  setProjectUIPreferences: (value: ProjectUIScopedPreferences) => void;
+interface UsePodTabsParams {
+  podId: string | null;
+  podUiPreferences: PodUiScopedPreferences;
+  setPodUiPreferences: (value: PodUiScopedPreferences) => void;
 }
 
 /**
- * Space page tabs: URL hash mirrors `projectUIPreferences.tab` (per space).
+ * Pod page tabs: URL hash mirrors `projectUIPreferences.tab` (per pod).
  *
- * One sync function runs on mount, `spaceId` change, and `hashchange`. If
+ * One sync function runs on mount, `podId` change, and `hashchange`. If
  * the URL hash names a valid tab, state adopts it (so deep links like
- * `/space/X#tasks` win over the persisted tab); otherwise the persisted
+ * `/pod/X#tasks` win over the persisted tab); otherwise the persisted
  * tab is written back into the URL asynchronously, so other layout hooks
  * (e.g. side panel) observe the previous hash first.
  *
  * Tab clicks go through `handleTabChange`, which writes URL + state
  * synchronously and bypasses the sync function.
  */
-export function useSpaceProjectTabs({
-  spaceId,
-  projectUIPreferences,
-  setProjectUIPreferences,
-}: UseSpaceProjectTabsParams): {
-  currentTab: SpaceProjectTab;
-  handleTabChange: (tab: SpaceProjectTab) => void;
+export function usePodTabs({
+  podId,
+  podUiPreferences,
+  setPodUiPreferences,
+}: UsePodTabsParams): {
+  currentTab: PodTab;
+  handleTabChange: (tab: PodTab) => void;
 } {
   const onHashChangeRef = useRef<() => void>(() => {});
 
   onHashChangeRef.current = () => {
-    const tabFromHash = parseSpaceTabFromLocationHash(projectUIPreferences.tab);
-    if (tabFromHash !== projectUIPreferences.tab) {
-      setProjectUIPreferences({ ...projectUIPreferences, tab: tabFromHash });
-    } else if (window.location.hash !== `#${projectUIPreferences.tab}`) {
-      const newTab = projectUIPreferences.tab;
+    const tabFromHash = parsePodTabFromLocationHash(podUiPreferences.tab);
+    if (tabFromHash !== podUiPreferences.tab) {
+      setPodUiPreferences({ ...podUiPreferences, tab: tabFromHash });
+    } else if (window.location.hash !== `#${podUiPreferences.tab}`) {
+      const newTab = podUiPreferences.tab;
       window.setTimeout(() => replaceUrlHashWithTab(newTab), 0);
     }
   };
 
   useEffect(() => {
-    if (typeof window === "undefined" || !spaceId) {
+    if (typeof window === "undefined" || !podId) {
       return;
     }
     const listener = () => onHashChangeRef.current();
@@ -90,15 +87,15 @@ export function useSpaceProjectTabs({
     return () => {
       window.removeEventListener("hashchange", listener);
     };
-  }, [spaceId]);
+  }, [podId]);
 
   const handleTabChange = useCallback(
-    (newTab: SpaceProjectTab) => {
+    (newTab: PodTab) => {
       replaceUrlHashWithTab(newTab);
-      setProjectUIPreferences({ ...projectUIPreferences, tab: newTab });
+      setPodUiPreferences({ ...podUiPreferences, tab: newTab });
     },
-    [projectUIPreferences, setProjectUIPreferences]
+    [podUiPreferences, setPodUiPreferences]
   );
 
-  return { currentTab: projectUIPreferences.tab, handleTabChange };
+  return { currentTab: podUiPreferences.tab, handleTabChange };
 }

--- a/front/lib/swr/pods.ts
+++ b/front/lib/swr/pods.ts
@@ -3,10 +3,12 @@ import {
   isProjectTasksListSwrKey,
   type TaskOwnerFilter,
 } from "@app/components/assistant/conversation/space/conversations/project_tasks/projectTasksListScope";
+import { usePodConversationsSummary } from "@app/hooks/conversations";
 import { useDebounce } from "@app/hooks/useDebounce";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import { flattenProjectTasksWithStableAssigneeOrder } from "@app/lib/project_task/display_order";
+import { useSpaceInfo } from "@app/lib/swr/spaces";
 import {
   emptyArray,
   getErrorFromResponse,
@@ -932,4 +934,54 @@ export function useWorkspaceProjectTask({
     isWorkspaceProjectTaskError: !!error,
     mutateWorkspaceProjectTask: mutate,
   };
+}
+
+export function useLeavePod({
+  owner,
+  podId,
+  podName,
+  userName,
+}: {
+  owner: LightWorkspaceType;
+  podId: string;
+  podName: string;
+  userName: string;
+}) {
+  const sendNotification = useSendNotification();
+  const { mutateSpaceInfoRegardlessOfQueryParams } = useSpaceInfo({
+    workspaceId: owner.sId,
+    spaceId: podId,
+    disabled: true,
+  });
+  const { mutate: mutateSpaceSummary } = usePodConversationsSummary({
+    workspaceId: owner.sId,
+    options: { disabled: true },
+  });
+
+  const doLeave = async (): Promise<boolean> => {
+    const res = await clientFetch(`/api/w/${owner.sId}/spaces/${podId}/leave`, {
+      method: "POST",
+    });
+
+    if (res.ok) {
+      void mutateSpaceInfoRegardlessOfQueryParams();
+      void mutateSpaceSummary();
+      sendNotification({
+        type: "success",
+        title: `${userName} left Pod ${podName}`,
+        description: "You have successfully left the Pod.",
+      });
+      return true;
+    } else {
+      const errorData = await getErrorFromResponse(res);
+      sendNotification({
+        type: "error",
+        title: "Could not leave Pod",
+        description: `Error: ${errorData.message}`,
+      });
+      return false;
+    }
+  };
+
+  return doLeave;
 }

--- a/front/lib/swr/search.ts
+++ b/front/lib/swr/search.ts
@@ -1,6 +1,6 @@
 import { clientEventSource } from "@app/lib/egress/client";
 import type { ToolSearchResult } from "@app/lib/search/tools/types";
-import { useProjectFiles } from "@app/lib/swr/projects";
+import { useProjectFiles } from "@app/lib/swr/pods";
 import { emptyArray } from "@app/lib/swr/swr";
 import type { ContentNodeWithParent } from "@app/types/connectors/connectors_api";
 import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -1,4 +1,4 @@
-import { useSpaceConversationsSummary } from "@app/hooks/conversations";
+import { usePodConversationsSummary } from "@app/hooks/conversations";
 import { useSendNotification } from "@app/hooks/useNotification";
 import type {
   CursorPaginationParams,
@@ -994,7 +994,7 @@ export function useUpdateProjectMetadata({
     spaceId,
     disabled: true, // Needed just to mutate
   });
-  const { mutate: mutateSpaceSummary } = useSpaceConversationsSummary({
+  const { mutate: mutateSpaceSummary } = usePodConversationsSummary({
     workspaceId: owner.sId,
     options: { disabled: true },
   });
@@ -1136,57 +1136,6 @@ export function useUpdateProjectNotificationPreference({
   };
 }
 
-export function useLeaveProject({
-  owner,
-  spaceId,
-  spaceName,
-  userName,
-}: {
-  owner: LightWorkspaceType;
-  spaceId: string;
-  spaceName: string;
-  userName: string;
-}) {
-  const sendNotification = useSendNotification();
-  const { mutateSpaceInfoRegardlessOfQueryParams } = useSpaceInfo({
-    workspaceId: owner.sId,
-    spaceId,
-    disabled: true,
-  });
-  const { mutate: mutateSpaceSummary } = useSpaceConversationsSummary({
-    workspaceId: owner.sId,
-    options: { disabled: true },
-  });
-
-  const doLeave = async (): Promise<boolean> => {
-    const res = await clientFetch(
-      `/api/w/${owner.sId}/spaces/${spaceId}/leave`,
-      { method: "POST" }
-    );
-
-    if (res.ok) {
-      void mutateSpaceInfoRegardlessOfQueryParams();
-      void mutateSpaceSummary();
-      sendNotification({
-        type: "success",
-        title: `${userName} left Pod ${spaceName}`,
-        description: "You have successfully left the Pod.",
-      });
-      return true;
-    } else {
-      const errorData = await getErrorFromResponse(res);
-      sendNotification({
-        type: "error",
-        title: "Could not leave Pod",
-        description: `Error: ${errorData.message}`,
-      });
-      return false;
-    }
-  };
-
-  return doLeave;
-}
-
 export function useJoinProject({
   owner,
   spaceId,
@@ -1204,7 +1153,7 @@ export function useJoinProject({
     spaceId,
     disabled: true,
   });
-  const { mutate: mutateSpaceSummary } = useSpaceConversationsSummary({
+  const { mutate: mutateSpaceSummary } = usePodConversationsSummary({
     workspaceId: owner.sId,
     options: { disabled: true },
   });
@@ -1246,7 +1195,7 @@ export function useStarProject({
   spaceId: string | null;
 }) {
   const sendNotification = useSendNotification();
-  const { mutate: mutateSpaceSummary } = useSpaceConversationsSummary({
+  const { mutate: mutateSpaceSummary } = usePodConversationsSummary({
     workspaceId,
     options: { disabled: true },
   });


### PR DESCRIPTION
## Description

This PR renames pod main page component imports and hooks from the legacy `Space` or `Project`-prefixed naming to the `Pod`-prefixed naming across the frontend codebase.

Followup PRs will rename components and hooks used in other tabs.

## Tests

Manually.

## Risks

Low risk.

## Deploy Plan

Standard deployment.
