### PR TITLE
[DB] Fix conversation branch previous message index

### DIFF
--- a/front/migrations/db/migration_652.sql
+++ b/front/migrations/db/migration_652.sql
@@ -1,0 +1,11 @@
+-- Migration created on May 26, 2026
+-- Replace the legacy unique index with the non-unique index expected by the model.
+DROP INDEX CONCURRENTLY IF EXISTS "conversation_branches_previous_message_id_new";
+
+CREATE INDEX CONCURRENTLY "conversation_branches_previous_message_id_new"
+    ON "public"."conversation_branches" ("previousMessageId");
+
+DROP INDEX CONCURRENTLY IF EXISTS "conversation_branches_previous_message_id";
+
+ALTER INDEX "conversation_branches_previous_message_id_new"
+RENAME TO "conversation_branches_previous_message_id";


### PR DESCRIPTION
## Description
The conversation branch model and branch flow allow multiple branches from the same previous message, but prod can still have the legacy unique index on `conversation_branches.previousMessageId`.

This adds a forward migration that replaces `conversation_branches_previous_message_id` with a non-unique index, matching the current model and preventing duplicate-branch creation failures.

## Risks
Blast radius: conversation branch creation and reads using the `previousMessageId` index.
Risk: low

## Deploy Plan
- pmrr
- run `front/migrations/db/migration_652.sql`