### PR TITLE
Consolidate forward test helpers

### DIFF
--- a/cli/dust-sandbox/src/commands/forward/http2/test_support.rs
+++ b/cli/dust-sandbox/src/commands/forward/http2/test_support.rs
@@ -1,4 +1,3 @@
-pub(super) use std::collections::HashMap;
 pub(super) use std::future::{poll_fn, Future};
 pub(super) use std::pin::Pin;
 pub(super) use std::sync::atomic::{AtomicUsize, Ordering};
@@ -14,8 +13,9 @@ pub(super) use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 pub(super) use tokio::sync::mpsc;
 pub(super) use tracing::warn;
 
-pub(super) use crate::egress_secrets::{DomainSet, Secret, SecretTable};
+pub(super) use crate::egress_secrets::SecretTable;
 
+pub(super) use super::super::test_support::{read_h2_body, secret_table_with_secret};
 pub(super) use super::pool::{H2UpstreamPool, UpstreamLease};
 pub(super) use super::{
     run_h2_to_h1_bridge, run_h2_to_upstream_bridge, send_data, BoxedAsyncReadWrite, H2UpstreamKey,
@@ -822,17 +822,6 @@ where
     }
 }
 
-pub(super) async fn read_h2_body(mut body: RecvStream) -> Result<Vec<u8>> {
-    let mut output = Vec::new();
-    while let Some(chunk) = body.data().await {
-        let chunk = chunk?;
-        output.extend_from_slice(&chunk);
-        body.flow_control().release_capacity(chunk.len())?;
-    }
-    ensure!(body.trailers().await?.is_none(), "unexpected trailers");
-    Ok(output)
-}
-
 pub(super) async fn next_informational(
     response: &mut h2::client::ResponseFuture,
 ) -> Result<Response<()>> {
@@ -895,29 +884,4 @@ pub(super) fn assert_h2_reset_reason(error: h2::Error, reason: h2::Reason) {
         Some(reason),
         "unexpected h2 reset reason: {error}"
     );
-}
-
-pub(super) fn secret_table_with_secret(
-    name: &str,
-    placeholder: &str,
-    value: &str,
-    patterns: &[&str],
-) -> Result<SecretTable> {
-    let allowed_domains = patterns
-        .iter()
-        .map(|pattern| (*pattern).to_string())
-        .collect::<Vec<_>>();
-    let domain_set = DomainSet::from_patterns(&allowed_domains)?;
-    let secret = Secret {
-        name: name.to_string(),
-        placeholder: placeholder.to_string(),
-        value: value.to_string(),
-        allowed_domains: domain_set,
-    };
-    let mut by_placeholder = HashMap::new();
-    by_placeholder.insert(placeholder.to_string(), secret);
-    Ok(SecretTable {
-        by_placeholder,
-        sni_match_set: DomainSet::from_patterns(&allowed_domains)?,
-    })
 }

--- a/cli/dust-sandbox/src/commands/forward/http_rewriter.rs
+++ b/cli/dust-sandbox/src/commands/forward/http_rewriter.rs
@@ -894,14 +894,13 @@ fn looks_like_http_request_line(bytes: &[u8]) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
     use anyhow::Result;
     use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 
-    use crate::egress_secrets::{DomainSet, Secret};
+    use crate::egress_secrets::DomainSet;
     use base64::{engine::general_purpose, Engine as _};
 
+    use super::super::test_support::{empty_table, secret_table_with_secret};
     use super::*;
 
     #[tokio::test]
@@ -1233,7 +1232,7 @@ mod tests {
     #[tokio::test]
     async fn substitutes_placeholder_in_header_value() -> Result<()> {
         let placeholder = "__DSEC_0123456789abcdef0123456789abcdef__";
-        let table = table_with_secret(
+        let table = secret_table_with_secret(
             "OPENAI_API_KEY",
             placeholder,
             "sk-real",
@@ -1261,7 +1260,7 @@ mod tests {
     #[tokio::test]
     async fn substitutes_placeholder_inside_basic_auth_base64() -> Result<()> {
         let placeholder = "__DSEC_aabbccddeeff00112233445566778899__";
-        let table = table_with_secret(
+        let table = secret_table_with_secret(
             "OPENAI_API_KEY",
             placeholder,
             "sk-real",
@@ -1294,7 +1293,7 @@ mod tests {
     #[tokio::test]
     async fn substitutes_multiple_placeholders_in_one_value() -> Result<()> {
         let placeholder = "__DSEC_11111111111111112222222222222222__";
-        let table = table_with_secret("X", placeholder, "AB", &["api.openai.com"])?;
+        let table = secret_table_with_secret("X", placeholder, "AB", &["api.openai.com"])?;
         let input = format!(
             "GET / HTTP/1.1\r\nHost: api.openai.com\r\nX-Header: {placeholder}-and-{placeholder}\r\n\r\n"
         );
@@ -1315,7 +1314,7 @@ mod tests {
 
     #[tokio::test]
     async fn denies_unknown_placeholder_in_header_value() -> Result<()> {
-        let table = table_with_secret(
+        let table = secret_table_with_secret(
             "OTHER",
             "__DSEC_ffffffffffffffffffffffffffffffff__",
             "sk-other",
@@ -1344,7 +1343,7 @@ mod tests {
         let placeholder = "__DSEC_33333333333333334444444444444444__";
         // Secret is allowed only on api.openai.com, but the request is sent
         // to a different host whose SNI happens to also be MITM-allowlisted.
-        let mut table = table_with_secret(
+        let mut table = secret_table_with_secret(
             "OPENAI_API_KEY",
             placeholder,
             "sk-real",
@@ -1374,7 +1373,7 @@ mod tests {
     #[tokio::test]
     async fn denies_placeholder_on_url_line_in_tls_mode() -> Result<()> {
         let placeholder = "__DSEC_55555555555555556666666666666666__";
-        let table = table_with_secret("X", placeholder, "sk-real", &["api.openai.com"])?;
+        let table = secret_table_with_secret("X", placeholder, "sk-real", &["api.openai.com"])?;
         let input = format!("GET /v1/{placeholder}/items HTTP/1.1\r\nHost: api.openai.com\r\n\r\n");
 
         let error = rewrite_once(
@@ -1393,7 +1392,7 @@ mod tests {
     #[tokio::test]
     async fn denies_placeholder_shaped_http_method_in_tls_mode() -> Result<()> {
         let placeholder = "__DSEC_55555555555555556666666666666666__";
-        let table = table_with_secret("X", placeholder, "sk-real", &["api.openai.com"])?;
+        let table = secret_table_with_secret("X", placeholder, "sk-real", &["api.openai.com"])?;
         let input = format!("{placeholder} /items HTTP/1.1\r\nHost: api.openai.com\r\n\r\n");
 
         let error = rewrite_once(
@@ -1430,7 +1429,7 @@ mod tests {
     #[tokio::test]
     async fn denies_placeholder_on_plain_http_in_header_value() -> Result<()> {
         let placeholder = "__DSEC_77777777777777778888888888888888__";
-        let table = table_with_secret("X", placeholder, "sk-real", &["example.com"])?;
+        let table = secret_table_with_secret("X", placeholder, "sk-real", &["example.com"])?;
         let input = format!(
             "GET / HTTP/1.1\r\nHost: example.com\r\nAuthorization: Bearer {placeholder}\r\n\r\n"
         );
@@ -1708,38 +1707,6 @@ mod tests {
         let mut output = Vec::new();
         upstream_read.read_to_end(&mut output).await?;
         Ok((result, output))
-    }
-
-    fn empty_table() -> Result<SecretTable> {
-        Ok(SecretTable {
-            by_placeholder: HashMap::new(),
-            sni_match_set: DomainSet::from_patterns(&[])?,
-        })
-    }
-
-    fn table_with_secret(
-        name: &str,
-        placeholder: &str,
-        value: &str,
-        patterns: &[&str],
-    ) -> Result<SecretTable> {
-        let allowed_domains = patterns
-            .iter()
-            .map(|pattern| (*pattern).to_string())
-            .collect::<Vec<_>>();
-        let domain_set = DomainSet::from_patterns(&allowed_domains)?;
-        let secret = Secret {
-            name: name.to_string(),
-            placeholder: placeholder.to_string(),
-            value: value.to_string(),
-            allowed_domains: domain_set,
-        };
-        let mut by_placeholder = HashMap::new();
-        by_placeholder.insert(placeholder.to_string(), secret);
-        Ok(SecretTable {
-            by_placeholder,
-            sni_match_set: DomainSet::from_patterns(&allowed_domains)?,
-        })
     }
 
     fn assert_deny_reason(error: HttpRewriteError, expected: DenyReason) {

--- a/cli/dust-sandbox/src/commands/forward/mitm_session.rs
+++ b/cli/dust-sandbox/src/commands/forward/mitm_session.rs
@@ -341,7 +341,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
     use std::path::PathBuf;
 
     use anyhow::{ensure, Context, Result};
@@ -352,8 +351,7 @@ mod tests {
     use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, ServerName};
     use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 
-    use crate::egress_secrets::{DomainSet, Secret};
-
+    use super::super::test_support::{read_h2_body, secret_table, secret_table_with_secret};
     use super::super::*;
     use super::*;
 
@@ -1077,53 +1075,6 @@ mod tests {
                     .take()
                     .ok_or_else(|| anyhow::anyhow!("test proxy opener reused"))
             })
-        })
-    }
-
-    async fn read_h2_body(mut body: h2::RecvStream) -> Result<Vec<u8>> {
-        let mut output = Vec::new();
-        while let Some(chunk) = body.data().await {
-            let chunk = chunk?;
-            output.extend_from_slice(&chunk);
-            body.flow_control().release_capacity(chunk.len())?;
-        }
-        ensure!(body.trailers().await?.is_none(), "unexpected trailers");
-        Ok(output)
-    }
-
-    fn secret_table(patterns: &[&str]) -> Result<SecretTable> {
-        let allowed_domains = patterns
-            .iter()
-            .map(|pattern| (*pattern).to_string())
-            .collect::<Vec<_>>();
-        Ok(SecretTable {
-            by_placeholder: HashMap::new(),
-            sni_match_set: DomainSet::from_patterns(&allowed_domains)?,
-        })
-    }
-
-    fn secret_table_with_secret(
-        name: &str,
-        placeholder: &str,
-        value: &str,
-        patterns: &[&str],
-    ) -> Result<SecretTable> {
-        let allowed_domains = patterns
-            .iter()
-            .map(|pattern| (*pattern).to_string())
-            .collect::<Vec<_>>();
-        let domain_set = DomainSet::from_patterns(&allowed_domains)?;
-        let secret = Secret {
-            name: name.to_string(),
-            placeholder: placeholder.to_string(),
-            value: value.to_string(),
-            allowed_domains: domain_set,
-        };
-        let mut by_placeholder = HashMap::new();
-        by_placeholder.insert(placeholder.to_string(), secret);
-        Ok(SecretTable {
-            by_placeholder,
-            sni_match_set: DomainSet::from_patterns(&allowed_domains)?,
         })
     }
 

--- a/cli/dust-sandbox/src/commands/forward/mod.rs
+++ b/cli/dust-sandbox/src/commands/forward/mod.rs
@@ -11,6 +11,8 @@ mod proxy_tunnel;
 mod rewrite_policy;
 mod session;
 mod sni;
+#[cfg(test)]
+mod test_support;
 mod tls_mitm;
 
 use std::path::PathBuf;

--- a/cli/dust-sandbox/src/commands/forward/test_support.rs
+++ b/cli/dust-sandbox/src/commands/forward/test_support.rs
@@ -1,0 +1,56 @@
+use std::collections::HashMap;
+
+use anyhow::{ensure, Result};
+
+use crate::egress_secrets::{DomainSet, Secret, SecretTable};
+
+pub(super) async fn read_h2_body(mut body: h2::RecvStream) -> Result<Vec<u8>> {
+    let mut output = Vec::new();
+    while let Some(chunk) = body.data().await {
+        let chunk = chunk?;
+        output.extend_from_slice(&chunk);
+        body.flow_control().release_capacity(chunk.len())?;
+    }
+    ensure!(body.trailers().await?.is_none(), "unexpected trailers");
+    Ok(output)
+}
+
+pub(super) fn empty_table() -> Result<SecretTable> {
+    secret_table(&[])
+}
+
+pub(super) fn secret_table(patterns: &[&str]) -> Result<SecretTable> {
+    let allowed_domains = patterns
+        .iter()
+        .map(|pattern| (*pattern).to_string())
+        .collect::<Vec<_>>();
+    Ok(SecretTable {
+        by_placeholder: HashMap::new(),
+        sni_match_set: DomainSet::from_patterns(&allowed_domains)?,
+    })
+}
+
+pub(super) fn secret_table_with_secret(
+    name: &str,
+    placeholder: &str,
+    value: &str,
+    patterns: &[&str],
+) -> Result<SecretTable> {
+    let allowed_domains = patterns
+        .iter()
+        .map(|pattern| (*pattern).to_string())
+        .collect::<Vec<_>>();
+    let domain_set = DomainSet::from_patterns(&allowed_domains)?;
+    let secret = Secret {
+        name: name.to_string(),
+        placeholder: placeholder.to_string(),
+        value: value.to_string(),
+        allowed_domains: domain_set,
+    };
+    let mut by_placeholder = HashMap::new();
+    by_placeholder.insert(placeholder.to_string(), secret);
+    Ok(SecretTable {
+        by_placeholder,
+        sni_match_set: DomainSet::from_patterns(&allowed_domains)?,
+    })
+}


### PR DESCRIPTION
## Description

Move repeated forward test helpers into a shared test-only module and update the h2, h1 rewrite, and MITM tests to use it.

## Tests

Tested locally from `cli/dust-sandbox`:
- `cargo check`
- `cargo test --workspace`
- `cargo clippy --all-targets -- -D warnings`

## Risk

Low. This only changes test helper organization.

## Deploy Plan

Standard deploy.