### PR TITLE
Make forwarder tests deterministic

### DIFF
--- a/cli/dust-sandbox/src/commands/forward/deny_log.rs
+++ b/cli/dust-sandbox/src/commands/forward/deny_log.rs
@@ -1,11 +1,18 @@
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
+#[cfg(test)]
+use std::{
+    collections::HashMap,
+    sync::{Mutex, OnceLock},
+};
 
 use anyhow::{Context, Result};
 use serde::Serialize;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 use tokio::io::AsyncWriteExt;
+#[cfg(test)]
+use tokio::sync::broadcast;
 
 // Keep deny logging bounded on the sandbox writable mount. One previous
 // generation is retained as `<path>.1`; a single line larger than this cap can
@@ -110,6 +117,8 @@ async fn append_deny_log_line(path: &Path, line: &str, max_bytes: u64) -> Result
     file.write_all(line.as_bytes())
         .await
         .with_context(|| format!("failed to write deny log {}", path.display()))?;
+    #[cfg(test)]
+    notify_deny_log_write(path);
     Ok(())
 }
 
@@ -161,6 +170,55 @@ fn rotated_deny_log_path(path: &Path) -> PathBuf {
     let mut rotated = path.as_os_str().to_os_string();
     rotated.push(".1");
     PathBuf::from(rotated)
+}
+
+#[cfg(test)]
+static DENY_LOG_WRITE_SIGNALS: OnceLock<Mutex<HashMap<PathBuf, broadcast::Sender<()>>>> =
+    OnceLock::new();
+
+#[cfg(test)]
+pub(super) struct DenyLogWriteObserver {
+    path: PathBuf,
+    rx: broadcast::Receiver<()>,
+}
+
+#[cfg(test)]
+impl DenyLogWriteObserver {
+    pub(super) async fn wait(&mut self) -> Result<()> {
+        self.rx
+            .recv()
+            .await
+            .with_context(|| format!("deny log write signal closed for {}", self.path.display()))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub(super) fn observe_deny_log_writes(path: &Path) -> DenyLogWriteObserver {
+    DenyLogWriteObserver {
+        path: path.to_path_buf(),
+        rx: deny_log_write_signal(path).subscribe(),
+    }
+}
+
+#[cfg(test)]
+fn notify_deny_log_write(path: &Path) {
+    let _ = deny_log_write_signal(path).send(());
+}
+
+#[cfg(test)]
+fn deny_log_write_signal(path: &Path) -> broadcast::Sender<()> {
+    let mut signals = DENY_LOG_WRITE_SIGNALS
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .expect("deny log write signal lock poisoned");
+    signals
+        .entry(path.to_path_buf())
+        .or_insert_with(|| {
+            let (tx, _rx) = broadcast::channel(16);
+            tx
+        })
+        .clone()
 }
 
 #[derive(Serialize)]

--- a/cli/dust-sandbox/src/commands/forward/http2/inbound.rs
+++ b/cli/dust-sandbox/src/commands/forward/http2/inbound.rs
@@ -191,21 +191,20 @@ mod tests {
             opener,
         ));
 
-        let (send_request, connection) = h2::client::handshake(client_io).await?;
-        // The server's SETTINGS frame is consumed during handshake; the client
-        // exposes the negotiated value via `max_concurrent_send_streams`.
-        // Driving the connection forward at least once is required for the
-        // SETTINGS frame to be parsed.
-        let connection_task = tokio::spawn(connection);
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let mut client_io = client_io;
+        client_io
+            .write_all(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
+            .await?;
+        client_io.write_all(&[0, 0, 0, 4, 0, 0, 0, 0, 0]).await?;
+        let settings = read_h2_settings(&mut client_io).await?;
         assert_eq!(
-            send_request.current_max_send_streams(),
-            H2_MAX_CONCURRENT_STREAMS as usize,
+            settings
+                .iter()
+                .find_map(|(id, value)| (*id == 0x03).then_some(*value)),
+            Some(H2_MAX_CONCURRENT_STREAMS),
             "server should advertise MAX_CONCURRENT_STREAMS={H2_MAX_CONCURRENT_STREAMS}"
         );
 
-        drop(send_request);
-        connection_task.abort();
         bridge_task.abort();
         Ok(())
     }
@@ -257,7 +256,6 @@ mod tests {
             }
             Err(_error) => {}
         }
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         assert_eq!(open_count.load(Ordering::SeqCst), 0);
 
         drop(send_request);

--- a/cli/dust-sandbox/src/commands/forward/http2/pool.rs
+++ b/cli/dust-sandbox/src/commands/forward/http2/pool.rs
@@ -64,6 +64,8 @@ pub(super) struct H2UpstreamPoolInner {
 pub(super) struct PooledH2Connection {
     send_request: SendRequest<Bytes>,
     pub(super) active_streams: AtomicUsize,
+    #[cfg(test)]
+    pub(super) active_streams_changed: tokio::sync::watch::Sender<usize>,
     draining: AtomicBool,
     pub(super) closed: AtomicBool,
     started_at: tokio::time::Instant,
@@ -86,9 +88,15 @@ struct H2ConnectionReservation {
 
 impl Drop for H2ConnectionReservation {
     fn drop(&mut self) {
-        self.connection
+        let _active_streams = self
+            .connection
             .active_streams
-            .fetch_sub(1, Ordering::SeqCst);
+            .fetch_sub(1, Ordering::SeqCst)
+            - 1;
+        #[cfg(test)]
+        self.connection
+            .active_streams_changed
+            .send_replace(_active_streams);
         self.connection
             .last_used_ms
             .store(connection_now_millis(&self.connection), Ordering::SeqCst);
@@ -362,6 +370,8 @@ pub(super) async fn open_h2_connection(
         // Starts at 1: the caller of `lease()` that triggered this open already
         // holds the implicit reservation that the returned lease represents.
         active_streams: AtomicUsize::new(1),
+        #[cfg(test)]
+        active_streams_changed: tokio::sync::watch::channel(1).0,
         draining: AtomicBool::new(false),
         closed: AtomicBool::new(false),
         started_at: tokio::time::Instant::now(),
@@ -408,7 +418,11 @@ fn reserve_h2_connection(
     } else {
         select_least_busy_h2_connection(connections)?
     };
-    connection.active_streams.fetch_add(1, Ordering::SeqCst);
+    let _active_streams = connection.active_streams.fetch_add(1, Ordering::SeqCst) + 1;
+    #[cfg(test)]
+    connection
+        .active_streams_changed
+        .send_replace(_active_streams);
     let send_request = connection.send_request.clone();
     Some(H2ConnectionLease {
         reservation: H2ConnectionReservation { connection },
@@ -635,7 +649,8 @@ mod tests {
         )?);
         let handshake_count = Arc::new(AtomicUsize::new(0));
         let (path_tx, mut path_rx) = mpsc::unbounded_channel();
-        let pool = test_h2_upstream_pool_with_settings_and_open_delay(
+        let (open_gate, mut open_started_rx) = test_open_gate();
+        let pool = test_h2_upstream_pool_with_settings_and_open_gate(
             Arc::clone(&handshake_count),
             move |request, respond| {
                 let path_tx = path_tx.clone();
@@ -647,7 +662,7 @@ mod tests {
                 })
             },
             None,
-            Some(std::time::Duration::from_millis(50)),
+            open_gate.clone(),
         );
         let (mut send_request, connection_task, bridge_task) =
             start_test_h2_upstream_bridge(sni, secret_table, pool).await?;
@@ -661,7 +676,12 @@ mod tests {
             .uri(format!("https://{sni}/two"))
             .body(())?;
         let (first_response, _first_stream) = send_request.send_request(first, true)?;
+        open_started_rx
+            .recv()
+            .await
+            .ok_or_else(|| anyhow!("upstream open did not reach test gate"))?;
         let (second_response, _second_stream) = send_request.send_request(second, true)?;
+        open_gate.release();
         let (first_response, second_response) = tokio::join!(first_response, second_response);
         let first_response = first_response?;
         let second_response = second_response?;

--- a/cli/dust-sandbox/src/commands/forward/http2/stream.rs
+++ b/cli/dust-sandbox/src/commands/forward/http2/stream.rs
@@ -378,6 +378,7 @@ mod tests {
         ));
         let (mut send_request, connection) = h2::client::handshake(client_io).await?;
         let connection_task = tokio::spawn(connection);
+        let mut deny_log_write = observe_deny_log_writes(deny_log.as_ref());
 
         let mut builder = Request::builder()
             .method("GET")
@@ -392,7 +393,8 @@ mod tests {
             "rewritten header block over 64 KiB should reset before upstream lease"
         );
 
-        let deny_log_text = read_test_file_eventually(deny_log.as_ref()).await?;
+        let deny_log_text =
+            read_test_file_after_write(&mut deny_log_write, deny_log.as_ref()).await?;
         assert!(
             deny_log_text.contains("\"reason\":\"header_size_exceeded\""),
             "deny log should record header_size_exceeded, got: {deny_log_text}"
@@ -489,6 +491,7 @@ mod tests {
 
         let (mut send_request, connection) = h2::client::handshake(client_io).await?;
         let connection_task = tokio::spawn(connection);
+        let mut deny_log_write = observe_deny_log_writes(deny_log.as_ref());
 
         let denied = Request::builder()
             .method("GET")
@@ -512,7 +515,8 @@ mod tests {
             .await
             .ok_or_else(|| anyhow!("allowed sibling did not reach upstream"))?;
         assert!(request_text.contains("GET /allowed HTTP/1.1\r\n"));
-        let deny_log_text = read_test_file_eventually(deny_log.as_ref()).await?;
+        let deny_log_text =
+            read_test_file_after_write(&mut deny_log_write, deny_log.as_ref()).await?;
         assert!(deny_log_text.contains("\"reason\":\"placeholder_on_non_allowed\""));
 
         drop(send_request);
@@ -546,6 +550,7 @@ mod tests {
 
         let (mut send_request, connection) = h2::client::handshake(client_io).await?;
         let connection_task = tokio::spawn(connection);
+        let mut deny_log_write = observe_deny_log_writes(deny_log.as_ref());
         let request = Request::builder()
             .method("GET")
             .uri("https://api.anthropic.com/v1/messages")
@@ -556,7 +561,8 @@ mod tests {
             ":authority/SNI mismatch should reset"
         );
 
-        let deny_log_text = read_test_file_eventually(deny_log.as_ref()).await?;
+        let deny_log_text =
+            read_test_file_after_write(&mut deny_log_write, deny_log.as_ref()).await?;
         assert!(
             deny_log_text.contains("\"reason\":\"host_sni_mismatch\""),
             "deny log should record host_sni_mismatch, got: {deny_log_text}"
@@ -598,6 +604,7 @@ mod tests {
 
         let (mut send_request, connection) = h2::client::handshake(client_io).await?;
         let connection_task = tokio::spawn(connection);
+        let mut deny_log_write = observe_deny_log_writes(deny_log.as_ref());
         let request = Request::builder()
             .method("GET")
             .uri(format!("http://{sni}/plain"))
@@ -609,7 +616,8 @@ mod tests {
         };
         assert_h2_reset_reason(error, h2::Reason::PROTOCOL_ERROR);
 
-        let deny_log_text = read_test_file_eventually(deny_log.as_ref()).await?;
+        let deny_log_text =
+            read_test_file_after_write(&mut deny_log_write, deny_log.as_ref()).await?;
         assert!(
             deny_log_text.contains("\"reason\":\"malformed_headers\""),
             "deny log should record malformed_headers, got: {deny_log_text}"
@@ -652,6 +660,7 @@ mod tests {
 
         let (mut send_request, connection) = h2::client::handshake(client_io).await?;
         let connection_task = tokio::spawn(connection);
+        let mut deny_log_write = observe_deny_log_writes(deny_log.as_ref());
         let request = Request::builder()
             .method("GET")
             .uri(format!("ftp://{sni}/plain"))
@@ -663,7 +672,8 @@ mod tests {
         };
         assert_h2_reset_reason(error, h2::Reason::PROTOCOL_ERROR);
 
-        let deny_log_text = read_test_file_eventually(deny_log.as_ref()).await?;
+        let deny_log_text =
+            read_test_file_after_write(&mut deny_log_write, deny_log.as_ref()).await?;
         assert!(
             deny_log_text.contains("\"reason\":\"malformed_headers\""),
             "deny log should record malformed_headers, got: {deny_log_text}"
@@ -702,6 +712,7 @@ mod tests {
 
         let (mut send_request, connection) = h2::client::handshake(client_io).await?;
         let connection_task = tokio::spawn(connection);
+        let mut deny_log_write = observe_deny_log_writes(deny_log.as_ref());
         let request = Request::builder()
             .method("GET")
             .uri(format!("https://{sni}/v1/{placeholder}/list"))
@@ -709,7 +720,8 @@ mod tests {
         let (response, _stream) = send_request.send_request(request, true)?;
         assert!(response.await.is_err(), "placeholder in :path should reset");
 
-        let deny_log_text = read_test_file_eventually(deny_log.as_ref()).await?;
+        let deny_log_text =
+            read_test_file_after_write(&mut deny_log_write, deny_log.as_ref()).await?;
         assert!(
             deny_log_text.contains("\"reason\":\"url_line_placeholder\""),
             "deny log should record url_line_placeholder, got: {deny_log_text}"

--- a/cli/dust-sandbox/src/commands/forward/http2/test_support.rs
+++ b/cli/dust-sandbox/src/commands/forward/http2/test_support.rs
@@ -10,11 +10,12 @@ pub(super) use h2::server::SendResponse;
 pub(super) use h2::RecvStream;
 pub(super) use http::{HeaderMap, HeaderValue, Request, Response, StatusCode};
 pub(super) use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
-pub(super) use tokio::sync::mpsc;
+pub(super) use tokio::sync::{mpsc, watch};
 pub(super) use tracing::warn;
 
 pub(super) use crate::egress_secrets::SecretTable;
 
+pub(super) use super::super::deny_log::{observe_deny_log_writes, DenyLogWriteObserver};
 pub(super) use super::super::test_support::{read_h2_body, secret_table_with_secret};
 pub(super) use super::pool::{H2UpstreamPool, UpstreamLease};
 pub(super) use super::{
@@ -116,7 +117,7 @@ where
         + Sync
         + 'static,
 {
-    test_h2_upstream_pool_with_settings_and_open_delay(
+    test_h2_upstream_pool_with_settings_and_optional_open_gate(
         handshake_count,
         handler,
         max_concurrent_streams,
@@ -124,11 +125,58 @@ where
     )
 }
 
-pub(super) fn test_h2_upstream_pool_with_settings_and_open_delay<F>(
+#[derive(Clone)]
+pub(super) struct TestOpenGate {
+    started_tx: mpsc::UnboundedSender<()>,
+    release_tx: watch::Sender<bool>,
+}
+
+impl TestOpenGate {
+    pub(super) fn release(&self) {
+        self.release_tx.send_replace(true);
+    }
+}
+
+pub(super) fn test_open_gate() -> (TestOpenGate, mpsc::UnboundedReceiver<()>) {
+    let (started_tx, started_rx) = mpsc::unbounded_channel();
+    let (release_tx, _release_rx) = watch::channel(false);
+    (
+        TestOpenGate {
+            started_tx,
+            release_tx,
+        },
+        started_rx,
+    )
+}
+
+pub(super) fn test_h2_upstream_pool_with_settings_and_open_gate<F>(
     handshake_count: Arc<AtomicUsize>,
     handler: F,
     max_concurrent_streams: Option<u32>,
-    open_delay: Option<std::time::Duration>,
+    open_gate: TestOpenGate,
+) -> H2UpstreamPool
+where
+    F: Fn(
+            Request<RecvStream>,
+            SendResponse<Bytes>,
+        ) -> Pin<Box<dyn Future<Output = Result<()>> + Send>>
+        + Send
+        + Sync
+        + 'static,
+{
+    test_h2_upstream_pool_with_settings_and_optional_open_gate(
+        handshake_count,
+        handler,
+        max_concurrent_streams,
+        Some(open_gate),
+    )
+}
+
+pub(super) fn test_h2_upstream_pool_with_settings_and_optional_open_gate<F>(
+    handshake_count: Arc<AtomicUsize>,
+    handler: F,
+    max_concurrent_streams: Option<u32>,
+    open_gate: Option<TestOpenGate>,
 ) -> H2UpstreamPool
 where
     F: Fn(
@@ -143,9 +191,20 @@ where
     let opener: OpenUpstream = Arc::new(move |_key| {
         let handler = Arc::clone(&handler);
         let handshake_count = Arc::clone(&handshake_count);
+        let open_gate = open_gate.clone();
         Box::pin(async move {
-            if let Some(open_delay) = open_delay {
-                tokio::time::sleep(open_delay).await;
+            if let Some(open_gate) = open_gate {
+                let mut release_rx = open_gate.release_tx.subscribe();
+                open_gate
+                    .started_tx
+                    .send(())
+                    .map_err(|_| anyhow!("failed to send upstream open gate signal"))?;
+                if !*release_rx.borrow() {
+                    release_rx
+                        .changed()
+                        .await
+                        .context("upstream open gate release channel closed")?;
+                }
             }
             handshake_count.fetch_add(1, Ordering::SeqCst);
             let (dsbx_io, upstream_io) = tokio::io::duplex(64 * 1024);
@@ -253,13 +312,11 @@ pub(super) async fn send_direct_pooled_h2_get(
 pub(super) async fn assert_upstream_connection_closed(
     closed_rx: &mut mpsc::UnboundedReceiver<()>,
 ) -> Result<()> {
-    for _ in 0..16 {
-        if closed_rx.try_recv().is_ok() {
-            return Ok(());
-        }
-        tokio::task::yield_now().await;
-    }
-    Err(anyhow!("upstream h2 connection did not close"))
+    closed_rx
+        .recv()
+        .await
+        .ok_or_else(|| anyhow!("upstream h2 close observer channel closed"))?;
+    Ok(())
 }
 
 pub(super) fn assert_upstream_connection_still_open(
@@ -312,20 +369,11 @@ pub(super) async fn observe_h2_request_body_close(
     })
 }
 
-pub(super) async fn read_test_file_eventually(path: &std::path::Path) -> Result<String> {
-    for _ in 0..50 {
-        match tokio::fs::read_to_string(path).await {
-            Ok(text) if !text.is_empty() => return Ok(text),
-            Ok(_) => {
-                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-            }
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-            }
-            Err(error) => return Err(error.into()),
-        }
-    }
-
+pub(super) async fn read_test_file_after_write(
+    write_observer: &mut DenyLogWriteObserver,
+    path: &std::path::Path,
+) -> Result<String> {
+    write_observer.wait().await?;
     tokio::fs::read_to_string(path)
         .await
         .with_context(|| format!("failed to read {}", path.display()))
@@ -406,32 +454,34 @@ pub(super) async fn wait_for_pool_active_streams(
     key: &H2UpstreamKey,
     expected: usize,
 ) -> Result<()> {
-    for _ in 0..16 {
-        let active_streams = pool_active_streams(pool, key).await;
+    loop {
+        let mut active_streams_rx = {
+            let entries = pool.inner.entries.lock().await;
+            let Some(connections) = entries.get(key) else {
+                ensure!(
+                    expected == 0,
+                    "expected {expected} active h2 streams for {}, got no connection",
+                    key.authority()
+                );
+                return Ok(());
+            };
+            ensure!(
+                connections.len() == 1,
+                "test helper expected one h2 connection for {}, got {}",
+                key.authority(),
+                connections.len()
+            );
+            connections[0].active_streams_changed.subscribe()
+        };
+        let active_streams = *active_streams_rx.borrow();
         if active_streams == expected {
             return Ok(());
         }
-        tokio::task::yield_now().await;
+        active_streams_rx
+            .changed()
+            .await
+            .context("active-stream observer closed before expected value")?;
     }
-
-    let active_streams = pool_active_streams(pool, key).await;
-    Err(anyhow!(
-        "expected {expected} active h2 streams for {}, got {active_streams}",
-        key.authority()
-    ))
-}
-
-pub(super) async fn pool_active_streams(pool: &H2UpstreamPool, key: &H2UpstreamKey) -> usize {
-    let entries = pool.inner.entries.lock().await;
-    entries
-        .get(key)
-        .map(|connections| {
-            connections
-                .iter()
-                .map(|connection| connection.active_streams.load(Ordering::SeqCst))
-                .sum()
-        })
-        .unwrap_or(0)
 }
 
 pub(super) async fn start_test_h2_upstream_bridge(
@@ -858,11 +908,10 @@ pub(super) fn h1_header_values<'a>(request_text: &'a str, name: &str) -> Vec<&'a
 pub(super) async fn assert_no_complete_chunked_request(
     request_rx: &mut mpsc::UnboundedReceiver<String>,
 ) -> Result<()> {
-    let request_text =
-        match tokio::time::timeout(std::time::Duration::from_secs(1), request_rx.recv()).await {
-            Ok(Some(request_text)) => request_text,
-            Ok(None) | Err(_) => return Ok(()),
-        };
+    let request_text = request_rx
+        .recv()
+        .await
+        .ok_or_else(|| anyhow!("test upstream capture channel closed"))?;
     assert!(request_text.contains("Transfer-Encoding: chunked\r\n"));
     assert!(
         !request_text.contains("\r\n0\r\n\r\n"),

--- a/cli/dust-sandbox/src/commands/forward/http2/upstream_h1.rs
+++ b/cli/dust-sandbox/src/commands/forward/http2/upstream_h1.rs
@@ -1579,6 +1579,7 @@ mod tests {
 
         let (mut send_request, connection) = h2::client::handshake(client_io).await?;
         let connection_task = tokio::spawn(connection);
+        let mut deny_log_write = observe_deny_log_writes(deny_log.as_ref());
         let mut builder = Request::builder()
             .method("GET")
             .uri(format!("https://{sni}/headers"));
@@ -1592,7 +1593,8 @@ mod tests {
             "rewritten header block over 64 KiB should reset"
         );
 
-        let deny_log_text = read_test_file_eventually(deny_log.as_ref()).await?;
+        let deny_log_text =
+            read_test_file_after_write(&mut deny_log_write, deny_log.as_ref()).await?;
         assert!(
             deny_log_text.contains("\"reason\":\"header_size_exceeded\""),
             "deny log should record header_size_exceeded, got: {deny_log_text}"
@@ -1637,6 +1639,7 @@ mod tests {
 
         let (mut send_request, connection) = h2::client::handshake(client_io).await?;
         let connection_task = tokio::spawn(connection);
+        let mut deny_log_write = observe_deny_log_writes(deny_log.as_ref());
         let request = Request::builder()
             .method("GET")
             .uri(format!("https://{sni}/line"))
@@ -1648,7 +1651,8 @@ mod tests {
             "rewritten header line over 16 KiB should reset"
         );
 
-        let deny_log_text = read_test_file_eventually(deny_log.as_ref()).await?;
+        let deny_log_text =
+            read_test_file_after_write(&mut deny_log_write, deny_log.as_ref()).await?;
         assert!(
             deny_log_text.contains("\"reason\":\"header_size_exceeded\""),
             "deny log should record header_size_exceeded, got: {deny_log_text}"
@@ -1982,6 +1986,7 @@ mod tests {
 
         let (mut send_request, connection) = h2::client::handshake(client_io).await?;
         let connection_task = tokio::spawn(connection);
+        let mut deny_log_write = observe_deny_log_writes(deny_log.as_ref());
         let request = Request::builder()
             .method("POST")
             .uri(format!("https://{sni}/trailers"))
@@ -2001,7 +2006,8 @@ mod tests {
         };
         assert_h2_reset_reason(error, h2::Reason::INTERNAL_ERROR);
 
-        let deny_log_text = read_test_file_eventually(deny_log.as_ref()).await?;
+        let deny_log_text =
+            read_test_file_after_write(&mut deny_log_write, deny_log.as_ref()).await?;
         assert!(
             deny_log_text.contains("\"reason\":\"request_trailers_unsupported\""),
             "deny log should record request_trailers_unsupported, got: {deny_log_text}"
@@ -2038,6 +2044,7 @@ mod tests {
 
         let (mut send_request, connection) = h2::client::handshake(client_io).await?;
         let connection_task = tokio::spawn(connection);
+        let mut deny_log_write = observe_deny_log_writes(deny_log.as_ref());
         let request = Request::builder()
             .method("POST")
             .uri(format!("https://{sni}/trailers-with-length"))
@@ -2058,16 +2065,16 @@ mod tests {
         };
         assert_h2_reset_reason(error, h2::Reason::INTERNAL_ERROR);
 
-        let deny_log_text = read_test_file_eventually(deny_log.as_ref()).await?;
+        let deny_log_text =
+            read_test_file_after_write(&mut deny_log_write, deny_log.as_ref()).await?;
         assert!(
             deny_log_text.contains("\"reason\":\"request_trailers_unsupported\""),
             "deny log should record request_trailers_unsupported, got: {deny_log_text}"
         );
-        let request_text =
-            tokio::time::timeout(std::time::Duration::from_secs(1), request_rx.recv())
-                .await
-                .context("test upstream did not observe the partial request before shutdown")?
-                .ok_or_else(|| anyhow!("test upstream capture channel closed"))?;
+        let request_text = request_rx
+            .recv()
+            .await
+            .ok_or_else(|| anyhow!("test upstream capture channel closed"))?;
         assert!(request_text.contains("POST /trailers-with-length HTTP/1.1\r\n"));
         assert!(request_text.contains("Transfer-Encoding: chunked\r\n"));
         assert!(!request_text

--- a/cli/dust-sandbox/src/commands/forward/http2/upstream_h2.rs
+++ b/cli/dust-sandbox/src/commands/forward/http2/upstream_h2.rs
@@ -720,18 +720,6 @@ mod tests {
 
     #[tokio::test]
     async fn h2_to_h2_request_trailers_reset_inbound_stream() -> Result<()> {
-        run_h2_to_h2_request_trailers_reset_inbound_stream().await
-    }
-
-    #[tokio::test]
-    async fn h2_to_h2_request_trailers_reset_inbound_stream_is_stable() -> Result<()> {
-        for _ in 0..50 {
-            run_h2_to_h2_request_trailers_reset_inbound_stream().await?;
-        }
-        Ok(())
-    }
-
-    async fn run_h2_to_h2_request_trailers_reset_inbound_stream() -> Result<()> {
         let sni = "api.openai.com";
         let secret_table = Arc::new(secret_table_with_secret(
             "OPENAI_API_KEY",
@@ -768,6 +756,7 @@ mod tests {
         ));
         let (mut send_request, connection) = h2::client::handshake(client_io).await?;
         let connection_task = tokio::spawn(connection);
+        let mut deny_log_write = observe_deny_log_writes(deny_log.as_ref());
         let request = Request::builder()
             .method("POST")
             .uri(format!("https://{sni}/request-trailers"))
@@ -800,7 +789,8 @@ mod tests {
             Some(h2::Reason::INTERNAL_ERROR),
             "upstream stream should be reset after denied request trailers"
         );
-        let deny_log_text = read_test_file_eventually(deny_log.as_ref()).await?;
+        let deny_log_text =
+            read_test_file_after_write(&mut deny_log_write, deny_log.as_ref()).await?;
         assert!(
             deny_log_text.contains("\"reason\":\"request_trailers_unsupported\""),
             "deny log should record request_trailers_unsupported, got: {deny_log_text}"


### PR DESCRIPTION
## Description

Replace timing-sensitive forwarder test waits with explicit test signals for deny-log writes, h2 upstream opens, and active-stream changes.

## Tests

Tested locally from `cli/dust-sandbox`:
- `cargo check`
- `cargo test --workspace`
- `cargo clippy --all-targets -- -D warnings`

## Risk

Low. This only changes test synchronization.

## Deploy Plan

Standard deploy.