### PR TITLE
[front] enh: remove N+1 queries in agent creation/restore

### DIFF
--- a/front/lib/api/apps.ts
+++ b/front/lib/api/apps.ts
@@ -66,10 +66,16 @@ export async function checkAppsDeployment(
   apps: AppDeploymentCheck[]
 ): Promise<(AppDeploymentCheck & { deployed: boolean })[]> {
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+
+  const appResources = await AppResource.fetchByIds(auth, [
+    ...new Set(apps.map((appRequest) => appRequest.appId)),
+  ]);
+  const appById = new Map(appResources.map((app) => [app.sId, app]));
+
   return concurrentExecutor(
     apps,
     async (appRequest) => {
-      const app = await AppResource.fetchById(auth, appRequest.appId);
+      const app = appById.get(appRequest.appId);
       if (!app) {
         return { ...appRequest, deployed: false };
       }

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -719,8 +719,16 @@ export async function createAgentConfiguration(
       }
 
       if (status === "active") {
+        const tagResources = await TagResource.fetchByIds(
+          auth,
+          tags.map((tag) => tag.sId)
+        );
+        const tagResourceById = new Map(
+          tagResources.map((tagResource) => [tagResource.sId, tagResource])
+        );
+
         for (const tag of tags) {
-          const tagResource = await TagResource.fetchById(auth, tag.sId);
+          const tagResource = tagResourceById.get(tag.sId);
           if (tagResource) {
             if (
               !isBuilder(owner) &&
@@ -1411,8 +1419,15 @@ export async function restoreAgentConfiguration(
       auth,
       agentConfigurationId
     );
+    const editors = await UserResource.fetchByModelIds([
+      ...new Set(triggers.map((trigger) => trigger.editor)),
+    ]);
+    const editorByModelId = new Map(
+      editors.map((editor) => [editor.id, editor])
+    );
+
     for (const trigger of triggers) {
-      const editor = await UserResource.fetchByModelId(trigger.editor);
+      const editor = editorByModelId.get(trigger.editor);
       if (!editor) {
         logger.error(
           {


### PR DESCRIPTION
## Description

- This PR removes a few small N+1 queries in agent creation, agent restore and dust app listing.
- Refactor-only, no change in logic.

## Tests

- Well covered by existing tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
