### PR TITLE
fix(backend): displayed image extension mismatch with actual mime type

### DIFF
--- a/front/components/actions/mcp/details/MCPImageGenerationActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPImageGenerationActionDetails.tsx
@@ -6,6 +6,7 @@ import type {
 import { isGenerateImageInputType } from "@app/lib/actions/mcp_internal_actions/types";
 import { useFileMetadata } from "@app/lib/swr/files";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+import { stripFileExtension } from "@app/types/files";
 import type { LightWorkspaceType } from "@app/types/user";
 import { ActionImageIcon, Chip, cn, Separator } from "@dust-tt/sparkle";
 import React from "react";
@@ -15,12 +16,6 @@ const QUALITY_LABELS: Record<string, string> = {
   medium: "2K",
   high: "4K",
 };
-
-function formatOutputFileName(outputName: string): string {
-  return outputName.toLowerCase().endsWith(".png")
-    ? outputName
-    : `${outputName}.png`;
-}
 
 interface ReferenceImageChipProps {
   fileId: string;
@@ -88,7 +83,7 @@ export function MCPImageGenerationActionDetails({
             <Chip
               size="xs"
               color="success"
-              label={formatOutputFileName(outputName)}
+              label={stripFileExtension(outputName)}
             />
           )}
           {aspectRatio && <Chip size="xs" label={aspectRatio} />}
@@ -157,7 +152,7 @@ export function MCPImageGenerationGroupedDetails({
                     <Chip
                       size="xs"
                       color="success"
-                      label={formatOutputFileName(outputName)}
+                      label={stripFileExtension(outputName)}
                     />
                   )}
                   {aspectRatio && <Chip size="xs" label={aspectRatio} />}

--- a/front/lib/actions/tool_display_labels.ts
+++ b/front/lib/actions/tool_display_labels.ts
@@ -13,6 +13,7 @@ import {
   isWebsearchInputType,
 } from "@app/lib/actions/mcp_internal_actions/types";
 import type { ToolDisplayLabels } from "@app/lib/api/mcp";
+import { stripFileExtension } from "@app/types/files";
 import { isNumber, isString } from "@app/types/shared/utils/general";
 import { asDisplayName, slugify } from "@app/types/shared/utils/string_utils";
 
@@ -183,7 +184,7 @@ function getDynamicToolDisplayLabels({
 
     case "image_generation":
       if (toolName === "generate_image" && isGenerateImageInputType(inputs)) {
-        const name = truncateQuery(inputs.outputName);
+        const name = truncateQuery(stripFileExtension(inputs.outputName));
         return {
           running: `Generating “${name}”`,
           done: `Generate “${name}”`,

--- a/front/lib/api/actions/servers/image_generation/helpers.ts
+++ b/front/lib/api/actions/servers/image_generation/helpers.ts
@@ -16,9 +16,11 @@ import logger from "@app/logger/logger";
 import type { ImageModelIdType } from "@app/types/assistant/models/models";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import {
+  extensionsForContentType,
   fileSizeToHumanReadable,
   isSupportedImageContentType,
   MAX_FILE_SIZES,
+  stripFileExtension,
 } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -214,9 +216,7 @@ export async function uploadAndFormatImageResponse(
   }
 
   const conversationId = agentLoopContext.runContext.conversation.sId;
-  const outputFileName = fileName.toLowerCase().endsWith(".png")
-    ? fileName
-    : `${fileName}.png`;
+  const baseFileName = stripFileExtension(fileName);
 
   const resources: Array<{
     type: "resource";
@@ -233,6 +233,9 @@ export async function uploadAndFormatImageResponse(
         })
       );
     }
+
+    const extension = extensionsForContentType(mimeType)[0] ?? ".png";
+    const outputFileName = `${baseFileName}${extension}`;
 
     const uploadResult = await uploadBase64ImageToFileStorage(auth, {
       base64: image.base64,

--- a/front/lib/api/actions/servers/image_generation/metadata.ts
+++ b/front/lib/api/actions/servers/image_generation/metadata.ts
@@ -15,7 +15,9 @@ export const imageGenerationToolInputSchema = z.object({
     .string()
     .max(64)
     .describe(
-      "The filename that will be used to save the generated image. Must be 64 characters or less."
+      "The base name (without file extension) used to save the generated image. " +
+        "The extension is appended automatically based on the image format returned " +
+        "by the model. Must be 64 characters or less."
     ),
   referenceImages: z
     .array(z.string())

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -685,6 +685,10 @@ export function stripMimeParameters(contentType: string): string {
   return contentType.split(";")[0];
 }
 
+export function stripFileExtension(fileName: string): string {
+  return fileName.replace(/\.[^.]+$/, "");
+}
+
 // This function overrides the browser-reported content type with a more accurate one based on the file extension, if applicable.
 export function resolveFileContentType(
   browserContentType: string,


### PR DESCRIPTION
## Description

Fixes https://github.com/orgs/dust-tt/projects/2/views/1?pane=issue&itemId=192058848&issue=dust-tt%7Cdust%7C26129

Extension and mime type mismatch for images generated by Google (png vs jpg)

## Tests

local

## Risk

low

## Deploy Plan

front
