### PR TITLE
Fix credits modal link, remove ppul page

### DIFF
--- a/front/components/app/ReachedLimitPopup.tsx
+++ b/front/components/app/ReachedLimitPopup.tsx
@@ -3,6 +3,7 @@ import { isFreeTrialPhonePlan } from "@app/lib/plans/plan_codes";
 import type { AppRouter } from "@app/lib/platform";
 import { useAppRouter } from "@app/lib/platform";
 import type { SubscriptionType } from "@app/types/plan";
+import { isCreditPricedPlan } from "@app/types/plan";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { WorkspaceType } from "@app/types/user";
 import {
@@ -172,13 +173,16 @@ function getLimitPromptForCode(
       }
     }
 
-    case "credits_exhausted":
+    case "credits_exhausted": {
+      const creditsManagementHref = isCreditPricedPlan(subscription.plan)
+        ? `/w/${owner.sId}/usage`
+        : `/w/${owner.sId}/developers/credits-usage`;
       return {
         title: "Out of credits",
         validateLabel: isAdmin ? "Manage credits" : "Ok",
         onValidate: isAdmin
           ? () => {
-              void router.push(`/w/${owner.sId}/developers/credits-usage`);
+              void router.push(creditsManagementHref);
             }
           : undefined,
         children: (
@@ -192,6 +196,7 @@ function getLimitPromptForCode(
           </>
         ),
       };
+    }
 
     default:
       assertNeverAndIgnore(code);

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -320,13 +320,17 @@ export const subNavigationAdmin = ({
           href: `/w/${owner.sId}/developers/api-keys`,
           current: isCurrent("api_keys"),
         },
-        {
-          id: "credits_usage",
-          label: "Programmatic Usage",
-          icon: BoltIcon,
-          href: `/w/${owner.sId}/developers/credits-usage`,
-          current: isCurrent("credits_usage"),
-        },
+        ...(isCreditPricedPlan(subscription.plan)
+          ? []
+          : [
+              {
+                id: "credits_usage" as const,
+                label: "Programmatic Usage",
+                icon: BoltIcon,
+                href: `/w/${owner.sId}/developers/credits-usage`,
+                current: isCurrent("credits_usage"),
+              },
+            ]),
       ],
     });
 


### PR DESCRIPTION
## Description

Fixes the "Out of credits" modal and sidebar nav for credit-priced plans:

- The "Manage credits" button in the `credits_exhausted` modal now redirects to `/w/<wId>/usage` when the workspace is on a credit-priced plan, instead of the legacy `/developers/credits-usage` page. Non credit-priced plans still go to the legacy page.
- The "Programmatic Usage" entry under "API & Programmatic" is hidden in the admin sidebar when the workspace is on a credit-priced plan (the legacy page is not relevant in that context). The "API Keys" entry is preserved.

## Tests

Manually verified:
- On a credit-priced plan: the modal CTA routes to `/usage`, and "Programmatic Usage" is no longer visible in the sidebar.
- On a non credit-priced plan: behavior unchanged — modal routes to `/developers/credits-usage`, sidebar still shows "Programmatic Usage".

## Risk

Low. UI-only change, gated on \`isCreditPricedPlan(subscription.plan)\` which is already used elsewhere in the same nav config. Easy to roll back.

## Deploy Plan

Standard deploy. No migration or coordination needed.