### PR TITLE
fix: skip tools validation when creating conversation with a slack bot

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -1280,6 +1280,7 @@ async function answerMessage(
       visibility: "unlisted",
       message: messageReqBody,
       contentFragments: buildContentFragmentRes.value || undefined,
+      skipToolsValidation,
     });
     if (convRes.isErr()) {
       return buildSlackMessageError(convRes, "createConversation");


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8270

When sending a message with a Slack bot that creates a new conversation, the tool approval dialog incorrectly appears. 
This happens because `skipToolsValidation` is not being forwarded to `createConversation`, causing tools validation to run even when it should have been skipped.

## Tests


## Risks

Low

## Deploy Plan
