### PR TITLE
[front] enh: rewrite N+1 queries on various activities

### DIFF
--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -704,8 +704,6 @@ export async function processWebhookRequest(
 
   const launchResult = await launchTriggersWorkflows(auth, {
     filteredTriggers,
-    webhookSource,
-    body,
     webhookRequest,
   });
 

--- a/front/temporal/data_retention/activities.ts
+++ b/front/temporal/data_retention/activities.ts
@@ -36,9 +36,9 @@ export async function purgeConversationsBatchActivity({
   workspaceIds: ModelId[];
 }): Promise<PurgeConversationsBatchActivityReturnType[]> {
   const res: PurgeConversationsBatchActivityReturnType[] = [];
-  const workspaces = await WorkspaceResource.fetchByModelIds(
-    [...new Set(workspaceIds)]
-  );
+  const workspaces = await WorkspaceResource.fetchByModelIds([
+    ...new Set(workspaceIds),
+  ]);
   const workspaceByModelId = new Map(
     workspaces.map((workspace) => [workspace.id, workspace])
   );

--- a/front/temporal/data_retention/activities.ts
+++ b/front/temporal/data_retention/activities.ts
@@ -10,11 +10,12 @@ import { heartbeat } from "@temporalio/activity";
 
 const WORKSPACE_CONVERSATIONS_BATCH_SIZE = 200;
 const HEARTBEAT_RATE = 100;
+
 /**
  * Get workspace ids with conversations retention policy.
  */
 export async function getWorkspacesWithConversationsRetentionActivity(): Promise<
-  number[]
+  ModelId[]
 > {
   return WorkspaceResource.listModelIdsWithConversationsRetention();
 }
@@ -24,7 +25,7 @@ export async function getWorkspacesWithConversationsRetentionActivity(): Promise
  * We chunk the workspaces to avoid hitting the database with too many queries at once.
  */
 type PurgeConversationsBatchActivityReturnType = {
-  workspaceModelId: number;
+  workspaceModelId: ModelId;
   workspaceId: string;
   nbConversationsDeleted: number;
 };
@@ -32,12 +33,18 @@ type PurgeConversationsBatchActivityReturnType = {
 export async function purgeConversationsBatchActivity({
   workspaceIds,
 }: {
-  workspaceIds: number[];
+  workspaceIds: ModelId[];
 }): Promise<PurgeConversationsBatchActivityReturnType[]> {
   const res: PurgeConversationsBatchActivityReturnType[] = [];
+  const workspaces = await WorkspaceResource.fetchByModelIds(
+    [...new Set(workspaceIds)]
+  );
+  const workspaceByModelId = new Map(
+    workspaces.map((workspace) => [workspace.id, workspace])
+  );
 
   for (const workspaceId of workspaceIds) {
-    const workspace = await WorkspaceResource.fetchByModelId(workspaceId);
+    const workspace = workspaceByModelId.get(workspaceId);
     if (!workspace) {
       logger.error(
         { workspaceId },

--- a/front/temporal/es_indexation/activities.ts
+++ b/front/temporal/es_indexation/activities.ts
@@ -28,12 +28,16 @@ export async function indexUserSearchActivity({
   const { memberships } = await MembershipResource.getLatestMemberships({
     users: [user],
   });
+  const workspaces = await WorkspaceResource.fetchByModelIds(
+    [...new Set(memberships.map((m) => m.workspaceId))]
+  );
+  const workspaceByModelId = new Map(
+    workspaces.map((workspace) => [workspace.id, workspace])
+  );
 
   // Process each membership
   for (const membership of memberships) {
-    const workspace = await WorkspaceResource.fetchByModelId(
-      membership.workspaceId
-    );
+    const workspace = workspaceByModelId.get(membership.workspaceId);
     if (!workspace) {
       logger.warn(
         { membershipId: membership.id, workspaceId: membership.workspaceId },

--- a/front/temporal/es_indexation/activities.ts
+++ b/front/temporal/es_indexation/activities.ts
@@ -28,9 +28,9 @@ export async function indexUserSearchActivity({
   const { memberships } = await MembershipResource.getLatestMemberships({
     users: [user],
   });
-  const workspaces = await WorkspaceResource.fetchByModelIds(
-    [...new Set(memberships.map((m) => m.workspaceId))]
-  );
+  const workspaces = await WorkspaceResource.fetchByModelIds([
+    ...new Set(memberships.map((m) => m.workspaceId)),
+  ]);
   const workspaceByModelId = new Map(
     workspaces.map((workspace) => [workspace.id, workspace])
   );

--- a/front/temporal/relocation/activities/destination_region/front/es_indexation.ts
+++ b/front/temporal/relocation/activities/destination_region/front/es_indexation.ts
@@ -42,11 +42,15 @@ export async function recreateUserSearchIndex({
 
   let successCount = 0;
   let errorCount = 0;
+  const users = await UserResource.fetchByModelIds([
+    ...new Set(activeMemberships.map((m) => m.userId)),
+  ]);
+  const userByModelId = new Map(users.map((user) => [user.id, user]));
 
   await concurrentExecutor(
     activeMemberships,
     async (membership) => {
-      const user = await UserResource.fetchByModelId(membership.userId);
+      const user = userByModelId.get(membership.userId);
       if (!user) {
         localLogger.warn(
           {

--- a/front/temporal/triggers/webhook_client.ts
+++ b/front/temporal/triggers/webhook_client.ts
@@ -66,13 +66,9 @@ export async function launchTriggersWorkflows(
   auth: Authenticator,
   {
     filteredTriggers,
-    webhookSource,
-    body,
     webhookRequest,
   }: {
     filteredTriggers: WebhookTriggerType[];
-    webhookSource: WebhookSourceResource;
-    body: Record<string, unknown>;
     webhookRequest: WebhookRequestResource;
   }
 ): Promise<Result<void, Error>> {

--- a/front/temporal/triggers/webhook_client.ts
+++ b/front/temporal/triggers/webhook_client.ts
@@ -1,7 +1,6 @@
 import { Authenticator } from "@app/lib/auth";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
-import type { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
 import { getTemporalClientForAgentNamespace } from "@app/lib/temporal";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";

--- a/front/temporal/triggers/webhook_client.ts
+++ b/front/temporal/triggers/webhook_client.ts
@@ -79,12 +79,17 @@ export async function launchTriggersWorkflows(
   const workspaceId = auth.getNonNullableWorkspace().sId;
   const webhookRequestId = webhookRequest.id;
 
+  const users = await UserResource.fetchByModelIds([
+    ...new Set(filteredTriggers.map((trigger) => trigger.editor)),
+  ]);
+  const userByModelId = new Map(users.map((user) => [user.id, user]));
+
   // Launch all the triggers' workflows concurrently.
   await concurrentExecutor(
     filteredTriggers,
     async (trigger) => {
       // Get the trigger's user and create a new authenticator
-      const user = await UserResource.fetchByModelId(trigger.editor);
+      const user = userByModelId.get(trigger.editor);
 
       if (!user) {
         logger.error(


### PR DESCRIPTION
## Description

- This PR removes a few N+1 queries in `purgeConversationsBatchActivity`, `indexUserSearchActivity`, `recreateUserSearchIndex`, `launchTriggersWorkflows` by batching the queries.
- No behavior change expected.

## Tests

## Risk

- Low

## Deploy Plan

- Deploy front.
