### PR TITLE
Scope sandbox telemetry secrets to fluent-bit

### DIFF
--- a/front/lib/api/sandbox/telemetry/index.ts
+++ b/front/lib/api/sandbox/telemetry/index.ts
@@ -28,6 +28,8 @@ export async function startTelemetry(
     conversationId: conversation.sId,
   });
 
+  // /!\ DD_API_KEY must never appear literally in the command string;
+  // journalctl logs argv. Always interpolate from the envVars below.
   const result = await sandbox.exec(
     auth,
     `systemctl set-environment DD_HOST="$DD_HOST" DD_API_KEY="$DD_API_KEY" E2B_SANDBOX_ID="$E2B_SANDBOX_ID" CONVERSATION_ID="$CONVERSATION_ID" WORKSPACE_ID="$WORKSPACE_ID" && systemctl start fluent-bit`,

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -49,7 +49,6 @@ vi.mock("@app/lib/lock", () => ({
   executeWithLock: mockExecuteWithLock,
 }));
 
-import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { SandboxModel } from "@app/lib/resources/storage/models/sandbox";
@@ -527,7 +526,6 @@ describe("SandboxResource.ensureActive", () => {
           imageId: { imageName: "test-image", tag: "0.0.1" },
           envVars: {
             DST_API_TOKEN: "image-token",
-            DD_API_KEY: "image-dd-token",
             WORKSPACE_ID: "image-workspace-id",
           },
           network: { egress: "restricted" },
@@ -628,7 +626,6 @@ describe("SandboxResource.ensureActive", () => {
           NODE_EXTRA_CA_CERTS: "/run/dust/egress-ca.pem",
           DENO_CERT: "/run/dust/egress-ca.pem",
           DENO_TLS_CA_STORE: "system,mozilla",
-          DD_API_KEY: config.getDatadogApiKey() ?? "",
           CONVERSATION_ID: conversation.sId,
           WORKSPACE_ID: workspace.sId,
         }),
@@ -638,6 +635,13 @@ describe("SandboxResource.ensureActive", () => {
     expect(mockProviderCreate.mock.calls[0]?.[0].envVars).not.toHaveProperty(
       "DST_SECRET_TOKEN"
     );
+    expect(mockProviderCreate.mock.calls[0]?.[0].envVars).not.toHaveProperty(
+      "DD_API_KEY"
+    );
+    expect(mockProviderCreate.mock.calls[0]?.[0].envVars).not.toHaveProperty(
+      "DD_HOST"
+    );
+    expect(mockProviderExec).not.toHaveBeenCalled();
   });
 
   it("records baseImage and version from the registered image on fresh create", async () => {
@@ -677,6 +681,7 @@ describe("SandboxResource.ensureActive", () => {
     expect(persisted?.baseImage).toBe("test-image");
     expect(persisted?.version).toBe("0.0.1");
     expect(persisted?.providerId).toBe("provider-id");
+    expect(mockProviderExec).not.toHaveBeenCalled();
   });
 
   it("destroys and recreates when killRequestedAt is set on the existing row", async () => {

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -1,4 +1,3 @@
-import config from "@app/lib/api/config";
 import { getSandboxProvider } from "@app/lib/api/sandbox";
 import { revokeAllExecTokensForSandbox } from "@app/lib/api/sandbox/access_tokens";
 import { deleteSandboxPolicy } from "@app/lib/api/sandbox/egress_policy";
@@ -373,8 +372,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       ...httpsSecretEnvResult.value,
       ...imageEnvVars,
       ...SANDBOX_TRUST_ENV_VARS,
-      DD_API_KEY: config.getDatadogApiKey() ?? "",
-      DD_HOST: "http-intake.logs.datadoghq.eu",
       CONVERSATION_ID: conversation.sId,
       WORKSPACE_ID: auth.getNonNullableWorkspace().sId,
     });
@@ -436,19 +433,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           baseImage: createConfig.imageId.imageName,
           version: createConfig.imageId.tag,
         });
-
-        const startTelemetry = await provider.exec(
-          createResult.value.providerId,
-          "systemd-cat -t fluent-bit /opt/fluent-bit/bin/fluent-bit -c /etc/fluent-bit/fluent-bit.conf &",
-          undefined,
-          tracingOpts
-        );
-        if (startTelemetry.isErr()) {
-          logger.warn(
-            { error: startTelemetry.error.message },
-            "Failed to start fluent-bit telemetry"
-          );
-        }
 
         logger.info(
           { sandbox: sandbox.toLogJSON() },
@@ -573,19 +557,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
             killRequestedAt: null,
           });
           freshlyCreated = true;
-
-          const startTelemetry = await provider.exec(
-            createResult.value.providerId,
-            "systemd-cat -t fluent-bit /opt/fluent-bit/bin/fluent-bit -c /etc/fluent-bit/fluent-bit.conf &",
-            undefined,
-            tracingOpts
-          );
-          if (startTelemetry.isErr()) {
-            logger.warn(
-              { error: startTelemetry.error.message },
-              "Failed to start fluent-bit telemetry"
-            );
-          }
 
           logger.info(
             {


### PR DESCRIPTION
## Description

`DD_API_KEY` and `DD_HOST` were injected into the sandbox VM process env via `provider.create({ envVars })` and inherited by the agent process. The agent is untrusted code, so `printenv` would expose the Datadog API key. No known exfil incident, this is defense-in-depth.

Drop them from `buildSandboxEnvVars` and remove the two inline `systemd-cat ... fluent-bit &` starts in `ensureActive` that depended on them. Telemetry continues through `lifecycle.ts:startTelemetry`, which scopes the secrets to a one-shot root `sandbox.exec`, writes them into systemd's environment via `systemctl set-environment`, and starts `fluent-bit`. The secrets never enter the agent process env.

Also added a guard comment in `telemetry/index.ts` warning that `DD_API_KEY` must never appear literally in the command string (journalctl logs argv).

## Tests

Updated `sandbox_resource.test.ts` to assert `DD_API_KEY` / `DD_HOST` are absent from `provider.create` envVars and that `provider.exec` is no longer invoked during create. `lib/api/sandbox/lifecycle.test.ts` passes locally (9/9). `sandbox_resource.test.ts` could not be run locally due to a pre-existing mistral SDK import error on `main` (unrelated to this change).

## Risk

Low. Removes a duplicate, leaky telemetry-start path. The scoped path in `lifecycle.ts:startTelemetry` already runs on every fresh-create and wake, with idempotent `systemctl start fluent-bit`.

## Deploy Plan

Standard deploy of `front` only.

- [ ] No dsbx release needed (no changes to `cli/dust-sandbox`).
- [ ] No base-image rebuild needed (no changes to `dockerfiles/sandbox-bedrock.Dockerfile`, `fluent-bit.conf`, or `fluent-bit.service`).
- [ ] After deploy, spot-check on a fresh sandbox: `printenv | grep '^DD_'` from the agent context should be empty; `systemctl show-environment | grep DD_` from root should show both vars; Datadog should still receive logs tagged `service:sandbox-runner`.