### PR TITLE
Make the manage redirect page layout-less

### DIFF
--- a/front-spa/src/app/routes.tsx
+++ b/front-spa/src/app/routes.tsx
@@ -5,7 +5,10 @@ import { RootRouterLayout } from "@spa/app/layouts/RootRouterLayout";
 import { UnauthenticatedPage } from "@spa/app/layouts/UnauthenticatedPage";
 import { WorkspacePage } from "@spa/app/layouts/WorkspacePage";
 import { IndexPage } from "@spa/app/pages/IndexPage";
-import { adminRoutes } from "@spa/app/routes/adminRoutes";
+import {
+  adminFullPageRoutes,
+  adminRoutes,
+} from "@spa/app/routes/adminRoutes";
 import { appsRoutes } from "@spa/app/routes/appsRoutes";
 import {
   builderContentRoutes,
@@ -70,6 +73,7 @@ export const routes: RouteObject[] = [
           },
 
           // Routes WITHOUT AppContentLayout (no sidebar/navigation chrome)
+          ...adminFullPageRoutes,
           ...builderFullPageRoutes,
           ...builderRedirectRoutes,
           ...onboardingRoutes,

--- a/front-spa/src/app/routes.tsx
+++ b/front-spa/src/app/routes.tsx
@@ -5,10 +5,7 @@ import { RootRouterLayout } from "@spa/app/layouts/RootRouterLayout";
 import { UnauthenticatedPage } from "@spa/app/layouts/UnauthenticatedPage";
 import { WorkspacePage } from "@spa/app/layouts/WorkspacePage";
 import { IndexPage } from "@spa/app/pages/IndexPage";
-import {
-  adminFullPageRoutes,
-  adminRoutes,
-} from "@spa/app/routes/adminRoutes";
+import { adminFullPageRoutes, adminRoutes } from "@spa/app/routes/adminRoutes";
 import { appsRoutes } from "@spa/app/routes/appsRoutes";
 import {
   builderContentRoutes,

--- a/front-spa/src/app/routes/adminRoutes.tsx
+++ b/front-spa/src/app/routes/adminRoutes.tsx
@@ -97,10 +97,6 @@ export const adminRoutes: RouteObject[] = [
       { path: "usage", element: <UsagePage /> },
       { path: "subscription", element: <SubscriptionPage /> },
       { path: "billing", element: <BillingPage /> },
-      {
-        path: "subscription/manage",
-        element: <ManageSubscriptionPage />,
-      },
       { path: "developers/api-keys", element: <APIKeysPage /> },
       {
         path: "developers/credits-usage",
@@ -123,5 +119,12 @@ export const adminRoutes: RouteObject[] = [
         element: <SelfImprovingSkillsPage />,
       },
     ],
+  },
+];
+
+export const adminFullPageRoutes: RouteObject[] = [
+  {
+    path: "subscription/manage",
+    element: <ManageSubscriptionPage />,
   },
 ];


### PR DESCRIPTION
## Description

Make the billing manage (stripe portal redirect) page layout less to avoid the left menu empty flickering during redirect.

## Tests

Tested locally

## Risk

Low

## Deploy Plan

- deploy `front`