### PR TITLE
chore(docker): switch front to node slim image

### DIFF
--- a/dockerfiles/front.Dockerfile
+++ b/dockerfiles/front.Dockerfile
@@ -1,5 +1,5 @@
 # Base dependencies stage (shared by front-nextjs and workers)
-FROM node:24.14.0 AS base-deps
+FROM node:24.14.0-slim AS base-deps
 
 RUN apt-get update && \
   apt-get install -y libjemalloc2 libjemalloc-dev
@@ -164,10 +164,10 @@ RUN if [ -n "$DATADOG_API_KEY" ] && [ -n "$NEXT_PUBLIC_DATADOG_SERVICE" ]; then 
   fi
 
 # Frontend image (Next.js standalone) for front deployment
-FROM node:24.14.0 AS front
+FROM node:24.14.0-slim AS front
 
 RUN apt-get update && \
-  apt-get install -y redis-tools postgresql-client libjemalloc2 && \
+  apt-get install -y redis-tools postgresql-client libjemalloc2 curl && \
   rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -208,10 +208,10 @@ ENV DD_GIT_COMMIT_SHA=${COMMIT_HASH_LONG}
 CMD ["node", "--require", "dd-trace/init", "server.js"]
 
 # Workers image (Full Node.js environment) for front-workers deployment
-FROM node:24.14.0 AS workers
+FROM node:24.14.0-slim AS workers
 
 RUN apt-get update && \
-  apt-get install -y redis-tools postgresql-client libjemalloc2 && \
+  apt-get install -y redis-tools postgresql-client libjemalloc2 curl && \
   rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -323,10 +323,10 @@ WORKDIR /app/front-api
 RUN npm run build
 
 # Front-api runtime image — Hono server with Next.js fallback (strangler shim).
-FROM node:24.14.0 AS front-api
+FROM node:24.14.0-slim AS front-api
 
 RUN apt-get update && \
-  apt-get install -y redis-tools postgresql-client libjemalloc2 && \
+  apt-get install -y redis-tools postgresql-client libjemalloc2 curl && \
   rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
## Description

Switch all stages in `dockerfiles/front.Dockerfile` from `node:24.14.0` to `node:24.14.0-slim`.

The full Node.js Debian image ships ~1.1 GB of packages (compilers, Python, make, etc.) that are never used at runtime. The slim variant strips those down to ~250 MB — a saving of roughly **850 MB per image**. With three final images (`front`, `workers`, `front-api`) deployed to two regions, that's ~5 GB less in the registry on every push, faster cold-start pulls on GKE node scale-outs, and a meaningfully smaller attack surface.

The one implicit dependency that would break on slim is `curl`, which ships in the full image but not in slim. `admin/prestop.sh` calls `curl` to drain the pod gracefully before shutdown, so `curl` is added explicitly to the `apt-get install` in each runtime stage.

All other packages (`redis-tools`, `postgresql-client`, `libjemalloc2`) were already installed explicitly and are unaffected.

## Tests

Validated by inspection:
- All runtime-stage `apt-get install` commands explicitly list every package they need.
- `admin/prestop.sh` uses `curl` → added to each runtime stage.
- No other implicit system-tool dependencies found in `admin/` or `scripts/`.

## Risk

Low. The slim image is still Debian Bookworm; all explicitly installed packages resolve identically. The only behavioral change is the removal of packages that were never called.
