### PR TITLE
Handle API blocking on credit based plans

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -62,7 +62,7 @@ import { isModelAvailable } from "@app/lib/assistant";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { extractFromString, serializeMention } from "@app/lib/mentions/format";
-import { isUserBlocked } from "@app/lib/metronome/user_block";
+import { isApiBlocked, isUserBlocked } from "@app/lib/metronome/user_block";
 import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
 import {
   AgentMCPActionModel,
@@ -2387,13 +2387,21 @@ async function checkMessagesLimit(
     return new Ok(undefined);
   }
 
-  // Block users flagged by the Metronome `alerts.spend_threshold_reached` webhook. The flag is set
-  // per (workspace, user) in Redis and is only checked for non-legacy Metronome plans.
+  // Credit-state + programmatic rate-limit gate. Two systems coexist:
+  // - Credit-priced (Metronome) plans: workspace pool + per-user cap, cached in Redis.
+  //   For API calls (no user), only the workspace pool applies via `isApiBlocked`.
+  //   TODO(metronome): port `checkProgrammaticUsageRateLimit` to a pool-balance
+  //   variant so concurrent programmatic requests can't overshoot the pool while
+  //   debits settle.
+  // - Legacy plans: programmatic credits checked via `checkProgrammaticUsageLimits`,
+  //   plus a credit-balance-scaled pre-emptive rate limit (`checkProgrammaticUsageRateLimit`).
   const owner = auth.getNonNullableWorkspace();
   const plan = auth.subscription()?.plan;
   const user = auth.user();
-  if (owner.metronomeCustomerId && plan && isCreditPricedPlan(plan) && user) {
-    const blocked = await isUserBlocked(owner.sId, user.sId);
+  if (owner.metronomeCustomerId && plan && isCreditPricedPlan(plan)) {
+    const blocked = user
+      ? await isUserBlocked(owner.sId, user.sId)
+      : await isApiBlocked(owner.sId);
     if (blocked) {
       return new Err({
         status_code: 403,
@@ -2401,6 +2409,39 @@ async function checkMessagesLimit(
           type: "credits_exhausted",
           message:
             "Your workspace has run out of credits. Please purchase more credits to continue.",
+        },
+      });
+    }
+  } else if (isProgrammaticUsage(auth, { userMessageOrigin: context.origin })) {
+    const limitsResult = await checkProgrammaticUsageLimits(auth);
+    if (limitsResult.isErr()) {
+      return new Err({
+        status_code: 403,
+        api_error: {
+          type: limitsResult.error.type,
+          message: getMessageLimitErrorMessage({
+            limitType: limitsResult.error.type,
+            message: limitsResult.error.message,
+          }),
+        },
+      });
+    }
+
+    // Pre-emptive, credit-balance-scaled rate limit. Defends against the race
+    // between in-flight programmatic requests and credit-debit settlement.
+    // Reads legacy CreditResource balances, so it must only run on legacy plans
+    // — on credit-priced plans the equivalent guard must come from the Metronome
+    // pool (see TODO above).
+    const rateLimit = await checkProgrammaticUsageRateLimit(auth);
+    if (rateLimit.isLimitReached && rateLimit.limitType) {
+      return new Err({
+        status_code: 403,
+        api_error: {
+          type: rateLimit.limitType,
+          message: getMessageLimitErrorMessage({
+            limitType: rateLimit.limitType,
+            message: rateLimit.message,
+          }),
         },
       });
     }
@@ -2594,22 +2635,10 @@ async function isMessagesLimitReached(
     };
   }
 
+  // Credit-state and programmatic rate-limit checks live in `checkMessagesLimit`
+  // (the caller). Programmatic flows skip the per-seat workspace fair-use cap
+  // below, since they are gated by credits / pool balance instead.
   if (isProgrammaticUsage(auth, { userMessageOrigin: context.origin })) {
-    const limitsResult = await checkProgrammaticUsageLimits(auth);
-    if (limitsResult.isErr()) {
-      return {
-        isLimitReached: true,
-        limitType: limitsResult.error.type,
-        message: limitsResult.error.message,
-      };
-    }
-
-    const programmaticUsageRateLimit =
-      await checkProgrammaticUsageRateLimit(auth);
-    if (programmaticUsageRateLimit.isLimitReached) {
-      return programmaticUsageRateLimit;
-    }
-
     return {
       isLimitReached: false,
       limitType: null,

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -175,3 +175,40 @@ export async function isUserBlocked(
 
   return state.userCapBlocked || state.workspacePoolDepleted;
 }
+
+// Workspace-pool-only read for API calls (no per-user cap).
+export async function isApiBlocked(workspaceId: string): Promise<boolean> {
+  const poolDepleted = await runOnRedis(
+    { origin: REDIS_ORIGIN },
+    async (client) => client.get(buildWorkspacePoolDepletedKey(workspaceId))
+  );
+
+  if (isBlockFlag(poolDepleted)) {
+    return poolDepleted === BLOCKED_FLAG;
+  }
+
+  logger.info(
+    {
+      workspaceId,
+      workspacePoolCacheHit: false,
+    },
+    "[MetronomeUserBlock] Cache miss during API blocked check, falling back to DB"
+  );
+
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  if (!workspace) {
+    logger.warn(
+      { workspaceId },
+      "[MetronomeUserBlock] Workspace not found during API blocked cache read-through fallback"
+    );
+    return false;
+  }
+
+  const workspacePoolDepleted = workspace.poolCreditState === "depleted";
+  await setFlag(
+    buildWorkspacePoolDepletedKey(workspaceId),
+    workspacePoolDepleted ? "1" : "0"
+  );
+
+  return workspacePoolDepleted;
+}

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -25,6 +25,7 @@ import type {
   WebhookTriggerType,
 } from "@app/types/assistant/triggers";
 import { isWebhookTrigger } from "@app/types/assistant/triggers";
+import { isCreditPricedPlan } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -273,9 +274,15 @@ async function checkWorkspaceRateLimit({
       errorMessage = message;
     }
   } else {
-    const limitsResult = await checkProgrammaticUsageLimits(auth);
-    if (limitsResult.isErr()) {
-      errorMessage = limitsResult.error.message;
+    // Programmatic execution mode: legacy programmatic-credit gate applies to
+    // legacy plans only. Credit-priced plans are gated by the workspace pool
+    // upstream (in `checkMessagesLimit`).
+    const plan = auth.subscription()?.plan;
+    if (!plan || !isCreditPricedPlan(plan)) {
+      const limitsResult = await checkProgrammaticUsageLimits(auth);
+      if (limitsResult.isErr()) {
+        errorMessage = limitsResult.error.message;
+      }
     }
   }
 

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -17,6 +17,7 @@ import {
   checkProgrammaticUsageLimits,
   isProgrammaticUsage,
 } from "@app/lib/api/programmatic_usage/tracking";
+import { isApiBlocked } from "@app/lib/metronome/user_block";
 import {
   addBackwardCompatibleConversationFields,
   addBackwardCompatibleConversationWithoutContentFields,
@@ -44,6 +45,7 @@ import { ConversationError } from "@app/types/assistant/conversation";
 import type { ContentFragmentType } from "@app/types/content_fragment";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isInteractiveContentType } from "@app/types/files";
+import { isCreditPricedPlan } from "@app/types/plan";
 import { isEmptyString } from "@app/types/shared/utils/general";
 import type {
   GetConversationsResponseType,
@@ -176,17 +178,36 @@ async function handler(
 
       if (message) {
         // Keep this before createConversation to avoid creating an empty conversation when the
-        // initial programmatic message is blocked.
+        // initial programmatic message is blocked. Credit-priced plans gate on the workspace
+        // pool (new system); legacy plans use the programmatic-credits check.
         if (isProgrammaticUsage(auth, { userMessageOrigin: origin })) {
-          const limitsResult = await checkProgrammaticUsageLimits(auth);
-          if (limitsResult.isErr()) {
-            return apiError(req, res, {
-              status_code: 429,
-              api_error: {
-                type: "rate_limit_error",
-                message: limitsResult.error.message,
-              },
-            });
+          const workspace = auth.getNonNullableWorkspace();
+          const plan = auth.subscription()?.plan;
+          if (plan && isCreditPricedPlan(plan)) {
+            if (
+              workspace.metronomeCustomerId &&
+              (await isApiBlocked(workspace.sId))
+            ) {
+              return apiError(req, res, {
+                status_code: 429,
+                api_error: {
+                  type: "rate_limit_error",
+                  message:
+                    "Your workspace has run out of credits. Please purchase more credits to continue.",
+                },
+              });
+            }
+          } else {
+            const limitsResult = await checkProgrammaticUsageLimits(auth);
+            if (limitsResult.isErr()) {
+              return apiError(req, res, {
+                status_code: 429,
+                api_error: {
+                  type: "rate_limit_error",
+                  message: limitsResult.error.message,
+                },
+              });
+            }
           }
         }
 

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -76,6 +76,7 @@ import {
 } from "@app/temporal/agent_loop/activities/usage_tracking";
 import { ensureReinforcementWorkspaceSchedules } from "@app/temporal/reinforcement/client";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+import { isCreditPricedPlan } from "@app/types/plan";
 import { ApplicationFailure } from "@temporalio/common";
 import { Op } from "sequelize";
 
@@ -580,9 +581,13 @@ export async function getReinforcementSettingsActivity({
     );
   const globalCapMicroUsd = getReinforcementMonthlyCapMicroUsd(workspace);
 
-  const programmaticUsageLimitReached = (
-    await checkProgrammaticUsageLimits(auth)
-  ).isErr();
+  // Credit-priced plans no longer rely on legacy programmatic credits; gate the
+  // legacy check so we don't falsely report the limit as reached.
+  const plan = auth.subscription()?.plan;
+  const programmaticUsageLimitReached =
+    plan && isCreditPricedPlan(plan)
+      ? false
+      : (await checkProgrammaticUsageLimits(auth)).isErr();
 
   // Compute remaining programmatic budget: total remaining credits capped by
   // the daily usage allowance.


### PR DESCRIPTION
## Description

For credit-priced (Metronome) plans, API calls were still being blocked by the legacy "programmatic usage credits" check, returning:

> `Your workspace has run out of programmatic usage credits. Please ask a Dust workspace admin to purchase more credits.`

Credit-priced plans don't issue legacy `CreditResource` rows, so this check always failed for them — and it was running unconditionally at four sites. This PR routes credit-priced plans through the workspace pool gate instead, and leaves the legacy check in place for legacy plans.

Changes:

- **`lib/metronome/user_block.ts`** — new `isApiBlocked(workspaceId)`: pool-only variant of `isUserBlocked`, reads the `metronome:pool_depleted:<ws>` Redis flag with read-through to `workspace.poolCreditState`. Used when there is no user (API key auth).
- **`lib/api/assistant/conversation.ts`** — `checkMessagesLimit` is now the single place that gates messages on credit state. It branches once:
  - Credit-priced plan: `isUserBlocked` if a user is present, otherwise `isApiBlocked`.
  - Legacy plan + programmatic origin: `checkProgrammaticUsageLimits` + `checkProgrammaticUsageRateLimit` (moved up from `isMessagesLimitReached`).
  - `isMessagesLimitReached`'s programmatic branch now only short-circuits past the per-seat workspace cap.
  - A `TODO(metronome)` flags that the credit-balance-scaled pre-emptive rate limit (`checkProgrammaticUsageRateLimit`) needs a pool-balance equivalent — otherwise concurrent programmatic requests on credit-priced plans can overshoot the pool while debits settle.
- **`pages/api/v1/w/[wId]/assistant/conversations/index.ts`** — the upfront check that runs before `createConversation` (to avoid creating empty conversations on a rejected first message) now branches the same way: `isApiBlocked` for credit-priced, legacy check otherwise.
- **`lib/triggers/webhook.ts`** — webhook triggers in programmatic execution mode skip `checkProgrammaticUsageLimits` for credit-priced plans (gating happens downstream in `checkMessagesLimit`).
- **`temporal/reinforcement/activities.ts`** — reinforcement workspace consumption check no longer calls `checkProgrammaticUsageLimits` for credit-priced plans (it would always report limit-reached). Downstream budget math still uses legacy `remainingProgrammaticCreditsMicroUsd`; that will need a follow-up to source from the pool.

## Tests

Manually verified:
- Credit-priced workspace via API key: previously got the "programmatic usage credits" 429; now passes the gate and is only blocked once `pool_depleted` is set.
- Legacy plan via API key: legacy credits gate behaves as before (429 on empty `CreditResource`).
- UI flow on a credit-priced plan: unchanged (still goes through `isUserBlocked`).

## Risk

Medium. Touches the hot path for message creation and the public `POST /conversations` API. Mitigations:

- The legacy plan path is structurally unchanged — same call order, same error shapes.
- The credit-priced path was already partially in place (`isUserBlocked` in `checkMessagesLimit`); we only add the API-call (no-user) branch.
- `isApiBlocked` mirrors `isUserBlocked`'s cache/read-through pattern.
- The pre-emptive rate-limit gap on credit-priced plans is called out in code with a `TODO` — short-term exposure is bounded by the Metronome `spend_threshold_reached` webhook that flips `pool_depleted` during a burst.

Rollback: revert the PR; no data migrations.

## Deploy Plan

Standard deploy. No coordination required.