### PR TITLE
Show error if purchase info can't be loaded

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -167,10 +167,11 @@ export function UsagePage() {
     workspaceId: owner.sId,
   });
 
-  const { awuPurchaseInfo, isAwuPurchaseInfoLoading } = useAwuPurchaseInfo({
-    workspaceId: owner.sId,
-    disabled: !showBuyCreditDialog,
-  });
+  const { awuPurchaseInfo, isAwuPurchaseInfoLoading, isAwuPurchaseInfoError } =
+    useAwuPurchaseInfo({
+      workspaceId: owner.sId,
+      disabled: !showBuyCreditDialog,
+    });
 
   const { membersUsage, isMembersUsageLoading } = useMembersUsage({
     workspaceId: owner.sId,
@@ -232,6 +233,7 @@ export function UsagePage() {
         workspaceId={owner.sId}
         awuPurchaseInfo={awuPurchaseInfo}
         isAwuPurchaseInfoLoading={isAwuPurchaseInfoLoading}
+        isAwuPurchaseInfoError={!!isAwuPurchaseInfoError}
         currentBalanceCredits={currentBalanceCredits}
       />
 

--- a/front/components/workspace/BuyAwuCreditsDialog.tsx
+++ b/front/components/workspace/BuyAwuCreditsDialog.tsx
@@ -97,6 +97,7 @@ interface BuyAwuCreditsDialogProps {
   workspaceId: string;
   awuPurchaseInfo: AwuPurchaseInfo | null;
   isAwuPurchaseInfoLoading: boolean;
+  isAwuPurchaseInfoError: boolean;
   currentBalanceCredits?: number;
 }
 
@@ -107,6 +108,7 @@ export function BuyAwuCreditsDialog({
   workspaceId,
   awuPurchaseInfo,
   isAwuPurchaseInfoLoading,
+  isAwuPurchaseInfoError,
   currentBalanceCredits,
 }: BuyAwuCreditsDialogProps) {
   const [amountInput, setAmountInput] = useState<string>("");
@@ -506,6 +508,48 @@ export function BuyAwuCreditsDialog({
   // just-created Metronome commit would otherwise flip it to
   // `pending_purchase` and bump the user off the success screen.
   const isPurchaseInFlight = purchaseState !== "idle";
+
+  if (!isPurchaseInFlight && isAwuPurchaseInfoError) {
+    return (
+      <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+        <DialogContent size="md">
+          <DialogHeader>
+            <DialogTitle>Workspace Credits Pool top-up</DialogTitle>
+            <DialogDescription>
+              We couldn't load your purchase information.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogContainer>
+            <div className="flex flex-col items-center justify-center gap-4 py-8">
+              <Icon
+                visual={XCircleIcon}
+                size="lg"
+                className="text-warning-500"
+              />
+              <p className="text-center text-sm text-muted-foreground dark:text-muted-foreground-night">
+                Something went wrong while loading your top-up options. Please
+                try again in a moment, or{" "}
+                <a
+                  href={`mailto:${supportEmail}?subject=Credit%20purchase%20-%20unable%20to%20load`}
+                  className="text-action-500 hover:underline"
+                >
+                  contact support
+                </a>{" "}
+                if the issue persists.
+              </p>
+            </div>
+          </DialogContainer>
+          <DialogFooter
+            leftButtonProps={{
+              label: "Close",
+              variant: "outline",
+              onClick: onClose,
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+    );
+  }
 
   // Cannot purchase: legacy plan.
   if (


### PR DESCRIPTION
## Description

When `GET /api/w/[wId]/subscriptions/awu-purchase` fails (e.g. 500 from `getAwuPurchaseInfo`), `useAwuPurchaseInfo` returns `awuPurchaseInfo = null` with `isAwuPurchaseInfoLoading = false`. The top-up dialog used to fall through to the purchase form with `currency` defaulted to `"usd"`, which was misleading for EUR-billed workspaces (and let users attempt a purchase with no real limits/discount info).

The dialog now surfaces a dedicated error state with a "contact support" link instead of rendering the form with USD defaults.

## Tests

Manually tested by triggering the 500 path on `/subscriptions/awu-purchase` and confirming the dialog shows the error state instead of the USD-defaulted form.

## Risk

Low. UI-only change scoped to the AWU top-up dialog error path. Easy rollback.

## Deploy Plan

Standard deploy.