### PR TITLE
chore(docker): multi-stage build for core, drop 4+ GB from image

### DIFF
--- a/dockerfiles/core.Dockerfile
+++ b/dockerfiles/core.Dockerfile
@@ -1,14 +1,29 @@
-FROM rust:1.85.0 AS core
+# Build stage — full Rust toolchain + cmake (needed for sentencepiece)
+FROM rust:1.85.0 AS builder
 
-RUN apt-get update && apt-get install -y vim redis-tools postgresql-client htop cmake
+RUN apt-get update && apt-get install -y cmake && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
 COPY /core/ .
 
-RUN cargo build --release --bin core-api --bin sqlite-worker --bin check_table
+RUN --mount=type=cache,id=core-cargo-registry,target=/usr/local/cargo/registry \
+    --mount=type=cache,id=core-cargo-git,target=/usr/local/cargo/git \
+    cargo build --release --bin core-api --bin sqlite-worker --bin check_table
+
+# Runtime stage — only the compiled binaries + minimal system libs
+FROM debian:bookworm-slim AS core
+
+# libstdc++6: required by V8 (via deno_core) C++ runtime
+# ca-certificates: required for TLS connections to GCS, Elasticsearch, Qdrant, etc.
+RUN apt-get update && \
+  apt-get install -y libstdc++6 ca-certificates && \
+  rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/target/release/core-api /usr/local/bin/core-api
+COPY --from=builder /app/target/release/sqlite-worker /usr/local/bin/sqlite-worker
+COPY --from=builder /app/target/release/check_table /usr/local/bin/check_table
 
 EXPOSE 3001
 
-# Set a default command, it will start the API service if no command is provided
-CMD ["cargo", "run", "--release", "--bin", "core-api"]
+CMD ["core-api"]


### PR DESCRIPTION
## Description

Convert `dockerfiles/core.Dockerfile` from a single-stage build to a proper two-stage build.

**Before:** the final shipped image was `rust:1.85.0` — the full Rust toolchain, LLVM, `cargo`, `rustc`, `cmake`, `vim`, `htop`, `redis-tools`, `postgresql-client`, the entire `target/` build directory (intermediate `.rlib` files, build scripts, debug artifacts), plus the compiled binaries. Conservatively **4–7 GB** per image.

**After:** the runtime stage is `debian:bookworm-slim` containing only the three compiled binaries (`core-api`, `sqlite-worker`, `check_table`) and two system packages:
- `libstdc++6` — required by V8 (used via `deno_core` for JS execution in Dust apps)
- `ca-certificates` — required for TLS connections to GCS, Elasticsearch, and Qdrant

Everything else is statically linked into the binaries: OpenSSL (`vendored` feature), SQLite (`bundled`), jemalloc (tikv), sentencepiece (`static`), and all tokenizer data files (`include_bytes!`). The result is a runtime image of roughly **~80–100 MB** vs the previous **4–7 GB**.

Additional improvements:
- `CMD` now calls the binary directly (`core-api`) instead of `cargo run --release --bin core-api`, eliminating the cargo manifest resolution overhead on every container start
- `--mount=type=cache` added for the Cargo registry and git sources, speeding up incremental rebuilds when dependencies haven't changed
- Debug tools (`vim`, `htop`) and unnecessary clients (`redis-tools`, `postgresql-client`) removed — the core binaries use pure-Rust implementations for both PostgreSQL and Redis

## Risk

Low. All runtime library dependencies were verified against the `Cargo.toml`: every heavy dependency is vendored/bundled/static, so the only genuine runtime requirements are the C++ standard library (for V8) and CA certificates.
