### PR TITLE
chore(docker): multi-stage build for oauth, drop 4+ GB from image

### DIFF
--- a/dockerfiles/oauth.Dockerfile
+++ b/dockerfiles/oauth.Dockerfile
@@ -1,14 +1,27 @@
-FROM rust:1.85.0 as core
+# Build stage — full Rust toolchain + cmake (needed for sentencepiece)
+FROM rust:1.85.0 AS builder
 
-RUN apt-get update && apt-get install -y vim redis-tools postgresql-client htop cmake
+RUN apt-get update && apt-get install -y cmake && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
 COPY /core/ .
 
-RUN cargo build --release --bin oauth
+RUN --mount=type=cache,id=oauth-cargo-registry,target=/usr/local/cargo/registry \
+    --mount=type=cache,id=oauth-cargo-git,target=/usr/local/cargo/git \
+    cargo build --release --bin oauth
+
+# Runtime stage — only the compiled binary + minimal system libs
+FROM debian:bookworm-slim AS oauth
+
+# libstdc++6: C++ runtime, required by any C++ transitive dependencies
+# ca-certificates: required for TLS connections to external OAuth providers
+RUN apt-get update && \
+  apt-get install -y libstdc++6 ca-certificates && \
+  rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/target/release/oauth /usr/local/bin/oauth
 
 EXPOSE 3006
 
-# Set a default command, it will start the oauth service if no command is provided
-CMD ["cargo", "run", "--release", "--bin", "oauth"]
+CMD ["oauth"]


### PR DESCRIPTION
## Description

Same treatment as #26169 (core), applied to `dockerfiles/oauth.Dockerfile`.

Converts the oauth service from a single-stage `rust:1.85.0` image (~4–7 GB) to a two-stage build with a `debian:bookworm-slim` runtime stage (~80–100 MB).

The oauth binary is a pure HTTP service (OAuth provider flows via `reqwest` + vendored OpenSSL). It doesn't use V8/deno_core or sentencepiece, but cmake is still required in the builder stage because all workspace dependencies compile regardless of what the final binary links. The runtime stage only needs:
- `libstdc++6` — C++ runtime for any transitive C++ dependencies
- `ca-certificates` — TLS trust anchors for connections to external OAuth providers

Additional improvements:
- `CMD` calls the binary directly (`oauth`) instead of `cargo run --release --bin oauth`
- `--mount=type=cache` added for the Cargo registry and git sources
- `vim`, `htop`, `redis-tools`, `postgresql-client` removed from the runtime image

## Risk

Low. Same analysis as #26169 — all heavy dependencies (OpenSSL, SQLite, jemalloc) are vendored/bundled/statically linked.
