### PR TITLE
Skip programmatic-usage workflow on credit based plans

### DIFF
--- a/front/lib/api/programmatic_usage/tracking.ts
+++ b/front/lib/api/programmatic_usage/tracking.ts
@@ -19,6 +19,7 @@ import logger from "@app/logger/logger";
 
 import { launchCreditAlertWorkflow } from "@app/temporal/credit_alerts/client";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
+import { isCreditPricedPlan } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -296,6 +297,14 @@ export async function trackProgrammaticCost(
   const localLogger = parentLogger ?? logger;
 
   if (!isProgrammaticUsage(auth, { userMessageOrigin })) {
+    return;
+  }
+
+  // Credit-priced (Metronome) plans don't use the legacy credit ledger. Bypass
+  // the whole tracking path to avoid decrementing nonexistent credits or
+  // creating excess rows.
+  const plan = auth.subscription()?.plan;
+  if (plan && isCreditPricedPlan(plan)) {
     return;
   }
 

--- a/front/lib/credits/payg.ts
+++ b/front/lib/credits/payg.ts
@@ -10,6 +10,7 @@ import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/progr
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 
+import { isCreditPricedPlan } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -122,6 +123,13 @@ export async function allocatePAYGCreditsOnCycleRenewal({
 }): Promise<void> {
   const workspace = auth.getNonNullableWorkspace();
 
+  // Credit-priced (Metronome) plans don't use the legacy PAYG credit table:
+  // overages and invoicing happen in Metronome.
+  const plan = auth.subscription()?.plan;
+  if (plan && isCreditPricedPlan(plan)) {
+    return;
+  }
+
   const config =
     await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
   if (!config || config.paygCapMicroUsd === null) {
@@ -178,6 +186,16 @@ export async function startOrResumeEnterprisePAYG({
   paygCapMicroUsd: number;
 }): Promise<Result<undefined, Error>> {
   const workspace = auth.getNonNullableWorkspace();
+
+  // Credit-priced (Metronome) plans don't use the legacy PAYG credit table.
+  const plan = auth.subscription()?.plan;
+  if (plan && isCreditPricedPlan(plan)) {
+    return new Err(
+      new Error(
+        "PAYG cannot be enabled on a credit-priced plan (handled by Metronome)."
+      )
+    );
+  }
 
   assert(
     isEnterpriseSubscription(stripeSubscription),

--- a/front/temporal/agent_loop/activities/usage_tracking.ts
+++ b/front/temporal/agent_loop/activities/usage_tracking.ts
@@ -5,14 +5,23 @@ import {
   launchTrackProgrammaticUsageWorkflow,
 } from "@app/temporal/usage_queue/client";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+import { isCreditPricedPlan } from "@app/types/plan";
 
 /**
  * Launch agent message analytics workflow in fire-and-forget mode.
+ * Credit-priced (Metronome) plans bypass this entirely: consumption is tracked
+ * through `launchEmitMetronomeUsageEvents`, and there are no legacy credit rows
+ * to decrement or excess rows to create.
  */
 export async function launchTrackProgrammaticUsage(
   auth: Authenticator,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
+  const plan = auth.subscription()?.plan;
+  if (plan && isCreditPricedPlan(plan)) {
+    return;
+  }
+
   const result = await launchTrackProgrammaticUsageWorkflow({
     authType: auth.toJSON(),
     agentLoopArgs,


### PR DESCRIPTION
## Description

Follow-up to #26166. Credit-priced (Metronome) plans don't use the legacy `credits` ledger — pre-paid pools, overages and invoicing all live in Metronome. But several legacy code paths were still writing to / reading from that table on every message, which produces stale `payg` and `excess` rows and (uselessly) attempts to decrement credits that don't exist for these workspaces.

This PR bypasses those paths on credit-priced plans:

- **`temporal/agent_loop/activities/usage_tracking.ts`** — `launchTrackProgrammaticUsage` returns early on credit-priced plans. This is the fan-in point for the programmatic-usage Temporal workflow (called by every `agent_loop/finalize` exit and by the reinforcement activity), so the workflow is never launched. Consumption tracking still flows through `launchEmitMetronomeUsageEvents` for these plans.
- **`lib/api/programmatic_usage/tracking.ts`** — `trackProgrammaticCost` has a defensive early return for credit-priced plans. Prevents excess-row creation and credit decrement even if a direct (non-workflow) caller is ever introduced.
- **`lib/credits/payg.ts`** — `allocatePAYGCreditsOnCycleRenewal` early-returns; `startOrResumeEnterprisePAYG` returns an `Err` (the poke flow that enables PAYG manually — surfaces a clear message if someone tries it on a Metronome plan).
- **`lib/api/stripe/webhook_handler.ts`** — the Stripe `customer.subscription.updated` cycle handler skips the PAYG allocate + invoice block when the plan is credit-priced. Covers both `allocatePAYGCreditsOnCycleRenewal` and `invoiceEnterprisePAYGCredits` in one place.

Net effect on credit-priced plans: no new `credits` rows of `type = "payg"` or `type = "excess"`, no decrement of existing rows, no programmatic-usage workflow runs.

## Tests

Manually verified:
- Credit-priced workspace running messages: no new `credits` rows created, no programmatic-usage workflow runs in Temporal.
- Legacy workspace: PAYG cycle renewal still creates the expected row, excess rows still appear on overconsumption, the programmatic-usage workflow runs as before.

## Risk

Low–medium. Behavior change is gated entirely on `isCreditPricedPlan(plan)`; legacy plans take the exact same path as before. The early returns are pure no-ops, no data writes.

Rollback: revert the PR; no migrations.

## Deploy Plan

Standard deploy after #26166. No coordination needed.