### PR TITLE
run_agent: stream tool calls and update sidebar design

### DIFF
--- a/front/components/actions/mcp/details/ChildAgentActivityTimeline.tsx
+++ b/front/components/actions/mcp/details/ChildAgentActivityTimeline.tsx
@@ -1,23 +1,9 @@
-import {
-  getActionStepIcon,
-  getCollapseAnimationStyle,
-} from "@app/components/assistant/conversation/actions/inline/utils";
-import { ThinkingStep } from "@app/components/assistant/conversation/actions/inline/ThinkingStep";
-import { TimelineRow } from "@app/components/assistant/conversation/actions/inline/TimelineRow";
+import { ActivityTimeline } from "@app/components/assistant/conversation/actions/inline/ActivityTimeline";
 import type { PendingToolCall } from "@app/components/assistant/conversation/types";
 import { getPendingToolCallKey } from "@app/components/assistant/conversation/types";
 import { getToolCallDisplayLabel } from "@app/lib/actions/tool_display_labels";
 import type { InlineActivityStep } from "@app/types/assistant/conversation";
-import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
-import {
-  AnimatedText,
-  CheckIcon,
-  ChevronRightIcon,
-  cn,
-  Icon,
-  XCircleIcon,
-} from "@dust-tt/sparkle";
-import React, { useState } from "react";
+import { AnimatedText, CheckIcon, XCircleIcon } from "@dust-tt/sparkle";
 
 interface ChildAgentActivityTimelineProps {
   inlineActivitySteps: InlineActivityStep[];
@@ -34,8 +20,6 @@ export function ChildAgentActivityTimeline({
   isDone,
   isError,
 }: ChildAgentActivityTimelineProps) {
-  const [isCollapsed, setIsCollapsed] = useState(isDone);
-
   const hasContent =
     inlineActivitySteps.length > 0 ||
     pendingToolCalls.length > 0 ||
@@ -48,15 +32,21 @@ export function ChildAgentActivityTimeline({
   const showActiveCoT = !isDone && activeCotContent.length > 0;
   const showPendingToolCalls = !isDone && pendingToolCalls.length > 0;
 
-  const toggleCollapse = () => setIsCollapsed((c) => !c);
-
   return (
-    <div className="flex flex-col text-sm">
-      <button
-        className="self-start text-muted-foreground dark:text-muted-foreground-night hover:text-foreground dark:hover:text-foreground-night transition-colors duration-200 flex gap-1 items-center"
-        onClick={toggleCollapse}
-      >
-        {isDone ? (
+    <ActivityTimeline
+      completedSteps={inlineActivitySteps}
+      runningToolRows={
+        showPendingToolCalls
+          ? pendingToolCalls.map((tc, i) => ({
+              key: getPendingToolCallKey(tc, i),
+              label: getToolCallDisplayLabel(tc.toolName, "running"),
+            }))
+          : []
+      }
+      activeCotContent={activeCotContent}
+      isDone={isDone}
+      headerLabel={
+        isDone ? (
           isError ? (
             "Error"
           ) : (
@@ -64,104 +54,22 @@ export function ChildAgentActivityTimeline({
           )
         ) : (
           <AnimatedText>Thinking…</AnimatedText>
-        )}
-        <span
-          className={cn(
-            "transition-transform duration-200 ease-out",
-            isCollapsed ? "rotate-0" : "rotate-90"
-          )}
-        >
-          <Icon size="xs" visual={ChevronRightIcon} />
-        </span>
-      </button>
-
-      <div
-        className="grid ease-out"
-        style={getCollapseAnimationStyle(isCollapsed)}
-      >
-        <div className="overflow-hidden">
-          <div className="mt-3 flex flex-col gap-3">
-            {inlineActivitySteps.map((step, index) => {
-              const isLast =
-                index === inlineActivitySteps.length - 1 &&
-                !showActiveCoT &&
-                !showPendingToolCalls &&
-                !isDone;
-
-              switch (step.type) {
-                case "thinking":
-                  return (
-                    <ThinkingStep
-                      key={step.id}
-                      content={step.content}
-                      isStreaming={false}
-                      isMessageDone={isDone}
-                      isLast={isLast}
-                    />
-                  );
-
-                case "content":
-                  // Intermediate content steps are skipped — final response is shown separately.
-                  return null;
-
-                case "action": {
-                  return (
-                    <TimelineRow
-                      key={step.id}
-                      icon={getActionStepIcon(step)}
-                      isLast={isLast}
-                    >
-                      <span className="text-muted-foreground dark:text-muted-foreground-night">
-                        {step.label}
-                      </span>
-                    </TimelineRow>
-                  );
-                }
-
-                default:
-                  assertNeverAndIgnore(step);
-                  return null;
-              }
-            })}
-
-            {showActiveCoT && (
-              <ThinkingStep
-                content={activeCotContent}
-                isStreaming
-                isMessageDone={false}
-                isLast={!showPendingToolCalls}
-              />
-            )}
-
-            {showPendingToolCalls &&
-              pendingToolCalls.map((toolCall, index) => (
-                <React.Fragment key={getPendingToolCallKey(toolCall, index)}>
-                  <TimelineRow
-                    spinner
-                    isLast={index === pendingToolCalls.length - 1}
-                  >
-                    <span className="text-muted-foreground dark:text-muted-foreground-night">
-                      {getToolCallDisplayLabel(toolCall.toolName, "running")}
-                    </span>
-                  </TimelineRow>
-                </React.Fragment>
-              ))}
-
-            {!isDone &&
-              !showActiveCoT &&
-              !showPendingToolCalls &&
-              inlineActivitySteps.length > 0 && <TimelineRow spinner isLast />}
-
-            {isDone && inlineActivitySteps.length > 0 && (
-              <TimelineRow icon={isError ? XCircleIcon : CheckIcon} isLast>
-                <span className="text-muted-foreground dark:text-muted-foreground-night">
-                  {isError ? "Error" : "Done"}
-                </span>
-              </TimelineRow>
-            )}
-          </div>
-        </div>
-      </div>
-    </div>
+        )
+      }
+      showTrailingSpinner={
+        !isDone &&
+        !showActiveCoT &&
+        !showPendingToolCalls &&
+        inlineActivitySteps.length > 0
+      }
+      terminalRow={
+        isDone && inlineActivitySteps.length > 0
+          ? {
+              icon: isError ? XCircleIcon : CheckIcon,
+              label: isError ? "Error" : "Done",
+            }
+          : undefined
+      }
+    />
   );
 }

--- a/front/components/actions/mcp/details/ChildAgentActivityTimeline.tsx
+++ b/front/components/actions/mcp/details/ChildAgentActivityTimeline.tsx
@@ -1,0 +1,167 @@
+import {
+  getActionStepIcon,
+  getCollapseAnimationStyle,
+} from "@app/components/assistant/conversation/actions/inline/utils";
+import { ThinkingStep } from "@app/components/assistant/conversation/actions/inline/ThinkingStep";
+import { TimelineRow } from "@app/components/assistant/conversation/actions/inline/TimelineRow";
+import type { PendingToolCall } from "@app/components/assistant/conversation/types";
+import { getPendingToolCallKey } from "@app/components/assistant/conversation/types";
+import { getToolCallDisplayLabel } from "@app/lib/actions/tool_display_labels";
+import type { InlineActivityStep } from "@app/types/assistant/conversation";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import {
+  AnimatedText,
+  CheckIcon,
+  ChevronRightIcon,
+  cn,
+  Icon,
+  XCircleIcon,
+} from "@dust-tt/sparkle";
+import React, { useState } from "react";
+
+interface ChildAgentActivityTimelineProps {
+  inlineActivitySteps: InlineActivityStep[];
+  pendingToolCalls: PendingToolCall[];
+  activeCotContent: string;
+  isDone: boolean;
+  isError: boolean;
+}
+
+export function ChildAgentActivityTimeline({
+  inlineActivitySteps,
+  pendingToolCalls,
+  activeCotContent,
+  isDone,
+  isError,
+}: ChildAgentActivityTimelineProps) {
+  const [isCollapsed, setIsCollapsed] = useState(isDone);
+
+  const hasContent =
+    inlineActivitySteps.length > 0 ||
+    pendingToolCalls.length > 0 ||
+    activeCotContent.length > 0;
+
+  if (!hasContent) {
+    return null;
+  }
+
+  const showActiveCoT = !isDone && activeCotContent.length > 0;
+  const showPendingToolCalls = !isDone && pendingToolCalls.length > 0;
+
+  const toggleCollapse = () => setIsCollapsed((c) => !c);
+
+  return (
+    <div className="flex flex-col text-sm">
+      <button
+        className="self-start text-muted-foreground dark:text-muted-foreground-night hover:text-foreground dark:hover:text-foreground-night transition-colors duration-200 flex gap-1 items-center"
+        onClick={toggleCollapse}
+      >
+        {isDone ? (
+          isError ? (
+            "Error"
+          ) : (
+            "Done"
+          )
+        ) : (
+          <AnimatedText>Thinking…</AnimatedText>
+        )}
+        <span
+          className={cn(
+            "transition-transform duration-200 ease-out",
+            isCollapsed ? "rotate-0" : "rotate-90"
+          )}
+        >
+          <Icon size="xs" visual={ChevronRightIcon} />
+        </span>
+      </button>
+
+      <div
+        className="grid ease-out"
+        style={getCollapseAnimationStyle(isCollapsed)}
+      >
+        <div className="overflow-hidden">
+          <div className="mt-3 flex flex-col gap-3">
+            {inlineActivitySteps.map((step, index) => {
+              const isLast =
+                index === inlineActivitySteps.length - 1 &&
+                !showActiveCoT &&
+                !showPendingToolCalls &&
+                !isDone;
+
+              switch (step.type) {
+                case "thinking":
+                  return (
+                    <ThinkingStep
+                      key={step.id}
+                      content={step.content}
+                      isStreaming={false}
+                      isMessageDone={isDone}
+                      isLast={isLast}
+                    />
+                  );
+
+                case "content":
+                  // Intermediate content steps are skipped — final response is shown separately.
+                  return null;
+
+                case "action": {
+                  return (
+                    <TimelineRow
+                      key={step.id}
+                      icon={getActionStepIcon(step)}
+                      isLast={isLast}
+                    >
+                      <span className="text-muted-foreground dark:text-muted-foreground-night">
+                        {step.label}
+                      </span>
+                    </TimelineRow>
+                  );
+                }
+
+                default:
+                  assertNeverAndIgnore(step);
+                  return null;
+              }
+            })}
+
+            {showActiveCoT && (
+              <ThinkingStep
+                content={activeCotContent}
+                isStreaming
+                isMessageDone={false}
+                isLast={!showPendingToolCalls}
+              />
+            )}
+
+            {showPendingToolCalls &&
+              pendingToolCalls.map((toolCall, index) => (
+                <React.Fragment key={getPendingToolCallKey(toolCall, index)}>
+                  <TimelineRow
+                    spinner
+                    isLast={index === pendingToolCalls.length - 1}
+                  >
+                    <span className="text-muted-foreground dark:text-muted-foreground-night">
+                      {getToolCallDisplayLabel(toolCall.toolName, "running")}
+                    </span>
+                  </TimelineRow>
+                </React.Fragment>
+              ))}
+
+            {!isDone &&
+              !showActiveCoT &&
+              !showPendingToolCalls &&
+              inlineActivitySteps.length > 0 && <TimelineRow spinner isLast />}
+
+            {isDone && inlineActivitySteps.length > 0 && (
+              <TimelineRow icon={isError ? XCircleIcon : CheckIcon} isLast>
+                <span className="text-muted-foreground dark:text-muted-foreground-night">
+                  {isError ? "Error" : "Done"}
+                </span>
+              </TimelineRow>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -1,4 +1,5 @@
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
+import { ChildAgentActivityTimeline } from "@app/components/actions/mcp/details/ChildAgentActivityTimeline";
 import { ToolGeneratedFileDetails } from "@app/components/actions/mcp/details/MCPToolOutputDetails";
 import type {
   ActionDetailsDisplayContext,
@@ -6,6 +7,7 @@ import type {
 } from "@app/components/actions/mcp/details/types";
 import { AttachmentCitation } from "@app/components/assistant/conversation/attachment/AttachmentCitation";
 import { markdownCitationToAttachmentCitation } from "@app/components/assistant/conversation/attachment/utils";
+import type { PendingToolCall } from "@app/components/assistant/conversation/types";
 import {
   CitationsContext,
   CiteBlock,
@@ -38,6 +40,7 @@ import { useMCPServerViews } from "@app/lib/swr/mcp_servers";
 import { useSpaces } from "@app/lib/swr/spaces";
 import { emptyArray } from "@app/lib/swr/swr";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import type { InlineActivityStep } from "@app/types/assistant/conversation";
 import type { AllSupportedWithDustSpecificFileContentType } from "@app/types/files";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
@@ -45,15 +48,12 @@ import {
   Avatar,
   Button,
   CitationGrid,
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
   ContentMessage,
   ExternalLinkIcon,
   Markdown,
   RobotIcon,
 } from "@dust-tt/sparkle";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
 
@@ -129,9 +129,12 @@ export function MCPRunAgentActionDetails({
   // Subscribe to the child agent's event stream.
   const {
     response: streamingResponse,
-    chainOfThought: streamingChainOfThought,
     isStreamingResponse,
-    isStreamingChainOfThought,
+    inlineActivitySteps,
+    pendingToolCalls,
+    activeCotContent,
+    isDone: isStreamDone,
+    isError: isStreamError,
   } = useChildAgentStream({
     childStreamIds,
     owner,
@@ -145,8 +148,6 @@ export function MCPRunAgentActionDetails({
   });
 
   const response = resultResource?.resource.text ?? streamingResponse;
-  const chainOfThought =
-    resultResource?.resource.chainOfThought ?? streamingChainOfThought;
 
   const conversationUrl = useMemo(() => {
     if (resultResource) {
@@ -190,11 +191,7 @@ export function MCPRunAgentActionDetails({
       query={query}
       childAgent={childAgent}
       isBusy={resultResource === null}
-      isStreamingChainOfThought={
-        resultResource === null && isStreamingChainOfThought
-      }
       isStreamingResponse={resultResource === null && isStreamingResponse}
-      chainOfThought={chainOfThought}
       response={response}
       conversationUrl={conversationUrl}
       references={references}
@@ -202,6 +199,11 @@ export function MCPRunAgentActionDetails({
       mcpServerViews={mcpServerViews}
       handoverResource={handoverResource}
       generatedFiles={generatedFiles}
+      inlineActivitySteps={inlineActivitySteps}
+      pendingToolCalls={pendingToolCalls}
+      activeCotContent={activeCotContent}
+      isStreamDone={isStreamDone || resultResource !== null}
+      isStreamError={isStreamError}
     />
   );
 }
@@ -212,9 +214,7 @@ interface MCPRunAgentActionDetailsDisplayProps {
   query: string | null;
   childAgent: AgentConfigurationType;
   isBusy: boolean;
-  isStreamingChainOfThought: boolean;
   isStreamingResponse: boolean;
-  chainOfThought: string | null;
   response: string | null;
   conversationUrl: string | null;
   references: Record<string, MCPReferenceCitation>;
@@ -222,6 +222,11 @@ interface MCPRunAgentActionDetailsDisplayProps {
   mcpServerViews: MCPServerViewType[];
   handoverResource: { resource: { text: string } } | null;
   generatedFiles: ToolGeneratedFileType[];
+  inlineActivitySteps: InlineActivityStep[];
+  pendingToolCalls: PendingToolCall[];
+  activeCotContent: string;
+  isStreamDone: boolean;
+  isStreamError: boolean;
 }
 
 function MCPRunAgentActionDetailsDisplay({
@@ -230,9 +235,7 @@ function MCPRunAgentActionDetailsDisplay({
   query,
   childAgent,
   isBusy,
-  isStreamingChainOfThought,
   isStreamingResponse,
-  chainOfThought,
   response,
   conversationUrl,
   references,
@@ -240,17 +243,32 @@ function MCPRunAgentActionDetailsDisplay({
   mcpServerViews,
   handoverResource,
   generatedFiles,
+  inlineActivitySteps,
+  pendingToolCalls,
+  activeCotContent,
+  isStreamDone,
+  isStreamError,
 }: MCPRunAgentActionDetailsDisplayProps) {
   const [activeReferences, setActiveReferences] = useState<
     { index: number; document: MCPReferenceCitation }[]
   >([]);
 
-  const updateActiveReferences = (doc: MCPReferenceCitation, index: number) => {
-    const existingIndex = activeReferences.find((r) => r.index === index);
-    if (!existingIndex) {
-      setActiveReferences([...activeReferences, { index, document: doc }]);
-    }
-  };
+  const updateActiveReferences = useCallback(
+    (doc: MCPReferenceCitation, index: number) => {
+      setActiveReferences((prev) => {
+        if (prev.find((r) => r.index === index)) {
+          return prev;
+        }
+        return [...prev, { index, document: doc }];
+      });
+    },
+    []
+  );
+
+  const citationsContextValue = useMemo(
+    () => ({ references, updateActiveReferences }),
+    [references, updateActiveReferences]
+  );
 
   const additionalMarkdownPlugins: PluggableList = useMemo(
     () => [getCiteDirective(), agentMentionDirective, taskDirective],
@@ -343,10 +361,11 @@ function MCPRunAgentActionDetailsDisplay({
                 </ContentMessage>
               </div>
             )}
-            {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
             {childAgent &&
-              (chainOfThought || response) &&
-              (displayContext === "sidebar-single-action" ? (
+              (inlineActivitySteps.length > 0 ||
+                pendingToolCalls.length > 0 ||
+                activeCotContent.length > 0 ||
+                response) && (
                 <>
                   <div className="flex items-center justify-between py-2">
                     <span className="font-medium text-foreground dark:text-foreground-night">
@@ -362,177 +381,51 @@ function MCPRunAgentActionDetailsDisplay({
                       />
                     )}
                   </div>
-                  <div className="flex flex-col gap-4">
-                    {chainOfThought && (
-                      <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
-                        <ContentMessage
-                          title="Agent thoughts"
-                          variant="primary"
-                          size="lg"
-                        >
-                          <Markdown
-                            content={chainOfThought}
-                            isStreaming={isStreamingChainOfThought}
-                            forcedTextSize="text-sm"
-                            textColor="text-muted-foreground"
-                            isLastMessage={false}
-                            additionalMarkdownPlugins={
-                              additionalMarkdownPlugins
-                            }
-                            additionalMarkdownComponents={
-                              additionalMarkdownComponents
-                            }
-                          />
-                        </ContentMessage>
-                      </div>
-                    )}
-                    {response && (
-                      <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
-                        <ContentMessage
-                          title="Response"
-                          variant="primary"
-                          size="lg"
-                        >
-                          <CitationsContext.Provider
-                            value={{
-                              references,
-                              updateActiveReferences,
-                            }}
-                          >
-                            <Markdown
-                              content={response}
-                              isStreaming={isStreamingResponse}
-                              forcedTextSize="text-sm"
-                              textColor="text-muted-foreground"
-                              isLastMessage={false}
-                              additionalMarkdownPlugins={
-                                additionalMarkdownPlugins
-                              }
-                              additionalMarkdownComponents={
-                                additionalMarkdownComponents
-                              }
-                            />
-                          </CitationsContext.Provider>
+                  <ChildAgentActivityTimeline
+                    inlineActivitySteps={inlineActivitySteps}
+                    pendingToolCalls={pendingToolCalls}
+                    activeCotContent={activeCotContent}
+                    isDone={isStreamDone}
+                    isError={isStreamError}
+                  />
+                  {response && (
+                    <>
+                      <CitationsContext.Provider
+                        value={citationsContextValue}
+                      >
+                        <Markdown
+                          content={response}
+                          isStreaming={isStreamingResponse}
+                          isLastMessage={false}
+                          additionalMarkdownPlugins={additionalMarkdownPlugins}
+                          additionalMarkdownComponents={
+                            additionalMarkdownComponents
+                          }
+                        />
+                      </CitationsContext.Provider>
 
-                          {activeReferences.length > 0 && (
-                            <div className="mt-4">
-                              <CitationGrid variant="grid">
-                                {activeReferences
-                                  .sort((a, b) => a.index - b.index)
-                                  .map(({ document, index }) => (
-                                    <AttachmentCitation
-                                      key={index}
-                                      attachmentCitation={markdownCitationToAttachmentCitation(
-                                        document
-                                      )}
-                                      owner={owner}
-                                      conversationId={null}
-                                    />
-                                  ))}
-                              </CitationGrid>
-                            </div>
-                          )}
-                        </ContentMessage>
-                      </div>
-                    )}
-                  </div>
+                      {activeReferences.length > 0 && (
+                        <div className="mt-4">
+                          <CitationGrid variant="grid">
+                            {activeReferences
+                              .sort((a, b) => a.index - b.index)
+                              .map(({ document, index }) => (
+                                <AttachmentCitation
+                                  key={index}
+                                  attachmentCitation={markdownCitationToAttachmentCitation(
+                                    document
+                                  )}
+                                  owner={owner}
+                                  conversationId={null}
+                                />
+                              ))}
+                          </CitationGrid>
+                        </div>
+                      )}
+                    </>
+                  )}
                 </>
-              ) : (
-                <Collapsible defaultOpen={true}>
-                  <div className="flex items-center justify-between py-2">
-                    <CollapsibleTrigger>
-                      <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
-                        @{childAgent.name}'s Answer
-                      </span>
-                    </CollapsibleTrigger>
-                    {conversationUrl && (
-                      <Button
-                        icon={ExternalLinkIcon}
-                        label="View full conversation"
-                        variant="outline"
-                        onClick={() => window.open(conversationUrl, "_blank")}
-                        size="xs"
-                      />
-                    )}
-                  </div>
-                  <CollapsibleContent>
-                    <div className="flex flex-col gap-4">
-                      {chainOfThought && (
-                        <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
-                          <ContentMessage
-                            title="Agent thoughts"
-                            variant="primary"
-                            size="lg"
-                          >
-                            <Markdown
-                              content={chainOfThought}
-                              isStreaming={isStreamingChainOfThought}
-                              forcedTextSize="text-sm"
-                              textColor="text-muted-foreground"
-                              isLastMessage={false}
-                              additionalMarkdownPlugins={
-                                additionalMarkdownPlugins
-                              }
-                              additionalMarkdownComponents={
-                                additionalMarkdownComponents
-                              }
-                            />
-                          </ContentMessage>
-                        </div>
-                      )}
-                      {response && (
-                        <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
-                          <ContentMessage
-                            title="Response"
-                            variant="primary"
-                            size="lg"
-                          >
-                            <CitationsContext.Provider
-                              value={{
-                                references,
-                                updateActiveReferences,
-                              }}
-                            >
-                              <Markdown
-                                content={response}
-                                isStreaming={isStreamingResponse}
-                                forcedTextSize="text-sm"
-                                textColor="text-muted-foreground"
-                                isLastMessage={false}
-                                additionalMarkdownPlugins={
-                                  additionalMarkdownPlugins
-                                }
-                                additionalMarkdownComponents={
-                                  additionalMarkdownComponents
-                                }
-                              />
-                            </CitationsContext.Provider>
-
-                            {activeReferences.length > 0 && (
-                              <div className="mt-4">
-                                <CitationGrid variant="grid">
-                                  {activeReferences
-                                    .sort((a, b) => a.index - b.index)
-                                    .map(({ document, index }) => (
-                                      <AttachmentCitation
-                                        key={index}
-                                        attachmentCitation={markdownCitationToAttachmentCitation(
-                                          document
-                                        )}
-                                        owner={owner}
-                                        conversationId={null}
-                                      />
-                                    ))}
-                                </CitationGrid>
-                              </div>
-                            )}
-                          </ContentMessage>
-                        </div>
-                      )}
-                    </div>
-                  </CollapsibleContent>
-                </Collapsible>
-              ))}
+              )}
             {generatedFiles.length > 0 && (
               <div className="flex flex-col gap-2">
                 {generatedFiles.map((file) => (

--- a/front/components/assistant/conversation/actions/inline/ActivityTimeline.tsx
+++ b/front/components/assistant/conversation/actions/inline/ActivityTimeline.tsx
@@ -1,0 +1,190 @@
+import { ThinkingStep } from "@app/components/assistant/conversation/actions/inline/ThinkingStep";
+import { TimelineRow } from "@app/components/assistant/conversation/actions/inline/TimelineRow";
+import {
+  getActionStepIcon,
+  getCollapseAnimationStyle,
+} from "@app/components/assistant/conversation/actions/inline/utils";
+import type { InlineActivityStep } from "@app/types/assistant/conversation";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { ChevronRightIcon, cn, Icon } from "@dust-tt/sparkle";
+import React, { useState } from "react";
+
+interface RunningToolRow {
+  key: string;
+  label: string;
+  onClick?: () => void;
+}
+
+export interface ActivityTimelineProps {
+  completedSteps: InlineActivityStep[];
+  runningToolRows: RunningToolRow[];
+  activeCotContent: string;
+  isDone: boolean;
+  headerLabel: React.ReactNode;
+  onActionClick?: (actionId: string | undefined) => void;
+  showTrailingSpinner: boolean;
+  terminalRow?: {
+    icon: React.ComponentType<{ className?: string }>;
+    label: string;
+  };
+  renderContentStep?: (content: string) => React.ReactNode;
+  extraBelowCollapse?: React.ReactNode;
+}
+
+export function ActivityTimeline({
+  completedSteps,
+  runningToolRows,
+  activeCotContent,
+  isDone,
+  headerLabel,
+  onActionClick,
+  showTrailingSpinner,
+  terminalRow,
+  renderContentStep,
+  extraBelowCollapse,
+}: ActivityTimelineProps) {
+  const [isCollapsed, setIsCollapsed] = useState(isDone);
+
+  const showActiveCoT = !isDone && activeCotContent.length > 0;
+  const hasRunningRows = runningToolRows.length > 0;
+
+  const toggleCollapse = () => setIsCollapsed((c) => !c);
+
+  return (
+    <div className="flex flex-col text-sm">
+      <button
+        className="self-start text-muted-foreground dark:text-muted-foreground-night hover:text-foreground dark:hover:text-foreground-night transition-colors duration-200 flex gap-1 items-center"
+        onClick={toggleCollapse}
+      >
+        {headerLabel}
+        <span
+          className={cn(
+            "transition-transform duration-200 ease-out",
+            isCollapsed ? "rotate-0" : "rotate-90"
+          )}
+        >
+          <Icon size="xs" visual={ChevronRightIcon} />
+        </span>
+      </button>
+
+      <div
+        className="grid ease-out"
+        style={getCollapseAnimationStyle(isCollapsed)}
+      >
+        <div className="overflow-hidden">
+          <div className="mt-3 flex flex-col gap-3">
+            {completedSteps.map((step, index) => {
+              const isLast =
+                index === completedSteps.length - 1 &&
+                !showActiveCoT &&
+                !hasRunningRows &&
+                !showTrailingSpinner &&
+                !terminalRow;
+
+              switch (step.type) {
+                case "thinking":
+                  return (
+                    <ThinkingStep
+                      key={step.id}
+                      content={step.content}
+                      isStreaming={false}
+                      isMessageDone={isDone}
+                      isLast={isLast}
+                    />
+                  );
+                case "content":
+                  return renderContentStep && step.content?.trim() ? (
+                    <div key={step.id}>{renderContentStep(step.content)}</div>
+                  ) : null;
+                case "action": {
+                  const row = (
+                    <TimelineRow icon={getActionStepIcon(step)} isLast={isLast}>
+                      <span className="text-muted-foreground dark:text-muted-foreground-night flex items-center gap-1">
+                        {step.label}
+                        <Icon
+                          size="xs"
+                          visual={ChevronRightIcon}
+                          className={cn(
+                            "shrink-0",
+                            onActionClick ? "opacity-50" : "opacity-0"
+                          )}
+                        />
+                      </span>
+                    </TimelineRow>
+                  );
+                  if (!onActionClick) {
+                    return <React.Fragment key={step.id}>{row}</React.Fragment>;
+                  }
+                  return (
+                    <div
+                      key={step.id}
+                      className="cursor-pointer"
+                      onClick={() => onActionClick(step.actionId)}
+                    >
+                      {row}
+                    </div>
+                  );
+                }
+                default:
+                  assertNeverAndIgnore(step);
+                  return null;
+              }
+            })}
+
+            {showActiveCoT && (
+              <ThinkingStep
+                content={activeCotContent}
+                isStreaming
+                isMessageDone={false}
+                isLast={!hasRunningRows && !showTrailingSpinner}
+              />
+            )}
+
+            {runningToolRows.map((row, index) => {
+              const isLast =
+                index === runningToolRows.length - 1 && !showTrailingSpinner;
+              const rowEl = (
+                <TimelineRow spinner isLast={isLast}>
+                  <span className="text-muted-foreground dark:text-muted-foreground-night flex items-center gap-1">
+                    {row.label}
+                    <Icon
+                      size="xs"
+                      visual={ChevronRightIcon}
+                      className={cn(
+                        "shrink-0",
+                        row.onClick ? "opacity-50" : "opacity-0"
+                      )}
+                    />
+                  </span>
+                </TimelineRow>
+              );
+              return row.onClick ? (
+                <div
+                  key={row.key}
+                  className="cursor-pointer"
+                  onClick={row.onClick}
+                >
+                  {rowEl}
+                </div>
+              ) : (
+                <React.Fragment key={row.key}>{rowEl}</React.Fragment>
+              );
+            })}
+
+            {showTrailingSpinner && <TimelineRow spinner isLast />}
+
+            {terminalRow && (
+              <TimelineRow icon={terminalRow.icon} isLast>
+                <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                  {terminalRow.label}
+                </span>
+              </TimelineRow>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {extraBelowCollapse}
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -1,4 +1,8 @@
 import { AgentMessageMarkdown } from "@app/components/assistant/AgentMessageMarkdown";
+import {
+  getActionStepIcon,
+  getCollapseAnimationStyle,
+} from "@app/components/assistant/conversation/actions/inline/utils";
 import { ThinkingStep } from "@app/components/assistant/conversation/actions/inline/ThinkingStep";
 import { TimelineRow } from "@app/components/assistant/conversation/actions/inline/TimelineRow";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
@@ -7,8 +11,6 @@ import {
   getPendingToolCallKey,
   type PendingToolCall,
 } from "@app/components/assistant/conversation/types";
-import { InternalActionIcons } from "@app/components/resources/resources_icons";
-import { getInternalMCPServerIconByName } from "@app/lib/actions/mcp_internal_actions/constants";
 import { isToolExecutionStatusBlocked } from "@app/lib/actions/statuses";
 import { getToolCallDisplayLabel } from "@app/lib/actions/tool_display_labels";
 import { getActionOneLineLabel } from "@app/lib/api/assistant/activity_steps";
@@ -27,9 +29,7 @@ import {
   CheckIcon,
   ChevronRightIcon,
   cn,
-  GlobeAltIcon,
   Icon,
-  ToolsIcon,
   XCircleIcon,
 } from "@dust-tt/sparkle";
 import React, { useState } from "react";
@@ -65,16 +65,6 @@ function getTerminalLabel(status: LightAgentMessageType["status"]): string {
     default:
       return "Completed";
   }
-}
-
-function getCollapseAnimationStyle(isCollapsed: boolean): React.CSSProperties {
-  return {
-    gridTemplateRows: isCollapsed ? "0fr" : "1fr",
-    opacity: isCollapsed ? 0 : 1,
-    transition: isCollapsed
-      ? "grid-template-rows 280ms ease, opacity 280ms"
-      : "grid-template-rows 200ms ease-in",
-  };
 }
 
 /**
@@ -279,25 +269,16 @@ export function InlineActivitySteps({
                     </div>
                   );
                 case "action": {
-                  const actionIcon =
-                    step.internalMCPServerName === "sandbox" &&
-                    step.toolName === "add_egress_domain"
-                      ? GlobeAltIcon
-                      : step.internalMCPServerName
-                        ? InternalActionIcons[
-                            getInternalMCPServerIconByName(
-                              step.internalMCPServerName
-                            )
-                          ]
-                        : ToolsIcon;
-
                   return (
                     <div
                       key={step.id}
                       className="cursor-pointer"
                       onClick={() => openBreakdownPanel(step.actionId)}
                     >
-                      <TimelineRow icon={actionIcon} isLast={isLast}>
+                      <TimelineRow
+                        icon={getActionStepIcon(step)}
+                        isLast={isLast}
+                      >
                         <span className="text-muted-foreground dark:text-muted-foreground-night flex items-center gap-1">
                           {step.label}
                           <Icon

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.tsx
@@ -1,10 +1,5 @@
 import { AgentMessageMarkdown } from "@app/components/assistant/AgentMessageMarkdown";
-import {
-  getActionStepIcon,
-  getCollapseAnimationStyle,
-} from "@app/components/assistant/conversation/actions/inline/utils";
-import { ThinkingStep } from "@app/components/assistant/conversation/actions/inline/ThinkingStep";
-import { TimelineRow } from "@app/components/assistant/conversation/actions/inline/TimelineRow";
+import { ActivityTimeline } from "@app/components/assistant/conversation/actions/inline/ActivityTimeline";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import {
   type AgentStateClassification,
@@ -21,18 +16,8 @@ import type {
   LightAgentMessageWithActionsType,
 } from "@app/types/assistant/conversation";
 import { isLightAgentMessageWithActionsType } from "@app/types/assistant/conversation";
-import { assertNever } from "@app/types/shared/utils/assert_never";
-import { isString } from "@app/types/shared/utils/general";
 import type { WorkspaceType } from "@app/types/user";
-import {
-  AnimatedText,
-  CheckIcon,
-  ChevronRightIcon,
-  cn,
-  Icon,
-  XCircleIcon,
-} from "@dust-tt/sparkle";
-import React, { useState } from "react";
+import { AnimatedText, CheckIcon, XCircleIcon } from "@dust-tt/sparkle";
 
 interface InlineActivityStepsProps {
   agentMessage: LightAgentMessageType | LightAgentMessageWithActionsType;
@@ -81,7 +66,6 @@ export function InlineActivitySteps({
   pendingToolCalls,
   onOpenDetails,
   owner,
-  isLastMessage,
 }: InlineActivityStepsProps) {
   const isAgentMessageWithActions =
     isLightAgentMessageWithActionsType(agentMessage);
@@ -94,8 +78,6 @@ export function InlineActivitySteps({
     lastAgentStateClassification === "done" ||
     agentMessage.status === "failed" ||
     agentMessage.status === "cancelled";
-
-  const [isCollapsed, setIsCollapsed] = useState(isDone);
 
   const openBreakdownPanel = (actionId?: string) => {
     if (onOpenDetails) {
@@ -124,12 +106,8 @@ export function InlineActivitySteps({
         ? getTerminalLabel(agentMessage.status)
         : null;
 
-  // Writing-only: no prior steps, just streaming text. Show "Writing..."
-  // without the collapse toggle so it doesn't look like a "Thinking" section.
   const isWritingOnly =
     isWriting && completedSteps.length === 0 && !showPendingToolCalls;
-
-  const toggleCollapse = () => setIsCollapsed((c) => !c);
 
   // Done with no steps: show a static line — no toggle, not clickable.
   if (isDone && completedSteps.length === 0) {
@@ -140,8 +118,28 @@ export function InlineActivitySteps({
     );
   }
 
-  // Show active thinking whenever the agent is thinking.
-  // Dedup in appendThinkingStep handles duplicate content at capture time.
+  // Writing-only: no prior steps, just streaming text. Show "Writing..."
+  // without the collapse toggle so it doesn't look like a "Thinking" section.
+  if (isWritingOnly) {
+    return (
+      <div className="flex flex-col text-sm">
+        <span className="self-start text-muted-foreground dark:text-muted-foreground-night flex gap-1 items-center">
+          <AnimatedText>Writing…</AnimatedText>
+        </span>
+        {agentMessage.content && (
+          <div className="mt-3">
+            <AgentMessageMarkdown
+              content={agentMessage.content}
+              owner={owner}
+              streamingState="streaming"
+              isLastMessage={false}
+            />
+          </div>
+        )}
+      </div>
+    );
+  }
+
   const showActiveThinking = !isDone && isThinking;
   const showActiveWriting = !isDone && isWriting;
   const activePendingToolCalls = showPendingToolCalls ? pendingToolCalls : [];
@@ -157,7 +155,6 @@ export function InlineActivitySteps({
     (showActiveWriting && !agentMessage.content);
   const hasActiveSpinnerRow =
     activeActions.length > 0 || activePendingToolCalls.length > 0;
-  // Only show the trailing loader when nothing else already renders one.
   const showTrailingLoader = isStreamingWithoutContent && !hasActiveSpinnerRow;
 
   const hasContent =
@@ -171,227 +168,70 @@ export function InlineActivitySteps({
     return null;
   }
 
-  const renderRunningToolRow = ({
-    isLast,
-    label,
-    onClick,
-  }: {
-    isLast: boolean;
-    label: string;
-    onClick?: () => void;
-  }) => {
-    const row = (
-      <TimelineRow spinner isLast={isLast}>
-        <span className="text-muted-foreground dark:text-muted-foreground-night flex items-center gap-1">
-          {label}
-          <Icon
-            size="xs"
-            visual={ChevronRightIcon}
-            className={cn("shrink-0", onClick ? "opacity-50" : "opacity-0")}
-          />
-        </span>
-      </TimelineRow>
-    );
+  const runningToolRows = [
+    ...activeActions
+      .filter((a) => !isToolExecutionStatusBlocked(a.status))
+      .map((a) => ({
+        key: `active-action-${a.id}`,
+        label: getActionOneLineLabel(a, "running"),
+        onClick: () => openBreakdownPanel(a.sId),
+      })),
+    ...activePendingToolCalls.map((tc, i) => ({
+      key: getPendingToolCallKey(tc, i),
+      label: getToolCallDisplayLabel(tc.toolName, "running"),
+      onClick: undefined as (() => void) | undefined,
+    })),
+  ];
 
-    if (!onClick) {
-      return row;
-    }
+  const showTrailingSpinner =
+    showTrailingLoader ||
+    (!isDone &&
+      !showActiveThinking &&
+      !showActiveWriting &&
+      activeActions.length === 0 &&
+      activePendingToolCalls.length === 0 &&
+      completedSteps.length > 0);
 
-    return (
-      <div className="cursor-pointer" onClick={onClick}>
-        {row}
+  const terminalRow =
+    isDone &&
+    completedSteps.length > 0 &&
+    agentMessage.status !== "gracefully_stopped"
+      ? {
+          icon: agentMessage.status === "cancelled" ? XCircleIcon : CheckIcon,
+          label: agentMessage.status === "cancelled" ? "Cancelled" : "Done",
+        }
+      : undefined;
+
+  const extraBelowCollapse =
+    showActiveWriting && agentMessage.content ? (
+      <div className="mt-3">
+        <AgentMessageMarkdown
+          content={agentMessage.content}
+          owner={owner}
+          streamingState="streaming"
+          isLastMessage={false}
+        />
       </div>
-    );
-  };
+    ) : undefined;
 
   return (
-    <div className="flex flex-col text-sm">
-      {isWritingOnly ? (
-        <span className="self-start text-muted-foreground dark:text-muted-foreground-night flex gap-1 items-center">
-          <AnimatedText>Writing…</AnimatedText>
-        </span>
-      ) : (
-        <button
-          className="self-start text-muted-foreground dark:text-muted-foreground-night hover:text-foreground dark:hover:text-foreground-night transition-colors duration-200 flex gap-1 items-center"
-          onClick={toggleCollapse}
-        >
-          {headerLabel ?? <AnimatedText>Thinking…</AnimatedText>}
-          <span
-            className={cn(
-              "transition-transform duration-200 ease-out",
-              isCollapsed ? "rotate-0" : "rotate-90"
-            )}
-          >
-            <Icon size="xs" visual={ChevronRightIcon} />
-          </span>
-        </button>
+    <ActivityTimeline
+      completedSteps={completedSteps}
+      runningToolRows={runningToolRows}
+      activeCotContent={showActiveThinking ? chainOfThought : ""}
+      isDone={isDone}
+      headerLabel={headerLabel ?? <AnimatedText>Thinking…</AnimatedText>}
+      onActionClick={openBreakdownPanel}
+      showTrailingSpinner={showTrailingSpinner}
+      terminalRow={terminalRow}
+      renderContentStep={(content) => (
+        <AgentMessageMarkdown
+          content={content}
+          owner={owner}
+          isLastMessage={false}
+        />
       )}
-
-      <div
-        className="grid ease-out"
-        style={getCollapseAnimationStyle(isWritingOnly ? false : isCollapsed)}
-      >
-        <div className="overflow-hidden">
-          <div className="mt-3 flex flex-col gap-3">
-            {completedSteps.map((step, index) => {
-              const isLast =
-                index === completedSteps.length - 1 &&
-                !showActiveThinking &&
-                !showActiveWriting &&
-                activeActions.length === 0 &&
-                !isDone;
-
-              switch (step.type) {
-                case "thinking":
-                  return (
-                    <ThinkingStep
-                      key={step.id}
-                      content={step.content}
-                      isStreaming={false}
-                      isMessageDone={isDone}
-                      isLast={isLast}
-                    />
-                  );
-                case "content":
-                  if (
-                    !isString(step.content) ||
-                    step.content.trim().length === 0
-                  ) {
-                    return null;
-                  }
-                  return (
-                    <div key={step.id}>
-                      <AgentMessageMarkdown
-                        content={step.content}
-                        owner={owner}
-                        isLastMessage={false}
-                      />
-                    </div>
-                  );
-                case "action": {
-                  return (
-                    <div
-                      key={step.id}
-                      className="cursor-pointer"
-                      onClick={() => openBreakdownPanel(step.actionId)}
-                    >
-                      <TimelineRow
-                        icon={getActionStepIcon(step)}
-                        isLast={isLast}
-                      >
-                        <span className="text-muted-foreground dark:text-muted-foreground-night flex items-center gap-1">
-                          {step.label}
-                          <Icon
-                            size="xs"
-                            visual={ChevronRightIcon}
-                            className="shrink-0 opacity-50"
-                          />
-                        </span>
-                      </TimelineRow>
-                    </div>
-                  );
-                }
-                default:
-                  assertNever(step);
-              }
-            })}
-
-            {/* Active thinking (streaming CoT) */}
-            {showActiveThinking && chainOfThought && (
-              <ThinkingStep
-                content={chainOfThought}
-                isStreaming
-                isMessageDone={false}
-                isLast={
-                  activeActions.length === 0 &&
-                  activePendingToolCalls.length === 0 &&
-                  !showTrailingLoader &&
-                  !isDone
-                }
-              />
-            )}
-
-            {/* Active writing (streaming content tokens) */}
-            {showActiveWriting &&
-            agentMessage.content &&
-            completedSteps.length === 0 ? (
-              <div>
-                <AgentMessageMarkdown
-                  content={agentMessage.content}
-                  owner={owner}
-                  streamingState="streaming"
-                  isLastMessage={false}
-                />
-              </div>
-            ) : null}
-
-            {/* Active actions (tools in progress) — skip blocked actions, handled by BlockedAction */}
-            {activeActions
-              .filter((a) => !isToolExecutionStatusBlocked(a.status))
-              .map((a) => (
-                <React.Fragment key={`active-action-${a.id}`}>
-                  {renderRunningToolRow({
-                    isLast: false,
-                    label: getActionOneLineLabel(a, "running"),
-                    onClick: () => openBreakdownPanel(a.sId),
-                  })}
-                </React.Fragment>
-              ))}
-
-            {activePendingToolCalls.map((toolCall, index) => (
-              <React.Fragment key={getPendingToolCallKey(toolCall, index)}>
-                {renderRunningToolRow({
-                  isLast:
-                    index === activePendingToolCalls.length - 1 &&
-                    !isDone &&
-                    !showTrailingLoader,
-                  label: getToolCallDisplayLabel(toolCall.toolName, "running"),
-                })}
-              </React.Fragment>
-            ))}
-
-            {showTrailingLoader && <TimelineRow spinner isLast={!isDone} />}
-
-            {/* Pending spinner — shown when between transitions (not done, nothing active) */}
-            {!isDone &&
-              !showActiveThinking &&
-              !showActiveWriting &&
-              activeActions.length === 0 &&
-              activePendingToolCalls.length === 0 && (
-                <TimelineRow spinner isLast />
-              )}
-            {isDone &&
-              completedSteps.length > 0 &&
-              agentMessage.status !== "gracefully_stopped" && (
-                <TimelineRow
-                  icon={
-                    agentMessage.status === "cancelled"
-                      ? XCircleIcon
-                      : CheckIcon
-                  }
-                  isLast
-                >
-                  <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                    {agentMessage.status === "cancelled" ? "Cancelled" : "Done"}
-                  </span>
-                </TimelineRow>
-              )}
-          </div>
-        </div>
-      </div>
-
-      {showActiveWriting &&
-      agentMessage.content &&
-      completedSteps.length > 0 ? (
-        <div className="mt-3">
-          <AgentMessageMarkdown
-            content={agentMessage.content}
-            owner={owner}
-            streamingState="streaming"
-            isLastMessage={false}
-          />
-        </div>
-      ) : null}
-    </div>
+      extraBelowCollapse={extraBelowCollapse}
+    />
   );
 }

--- a/front/components/assistant/conversation/actions/inline/utils.ts
+++ b/front/components/assistant/conversation/actions/inline/utils.ts
@@ -1,0 +1,37 @@
+import { InternalActionIcons } from "@app/components/resources/resources_icons";
+import {
+  getInternalMCPServerIconByName,
+  type InternalMCPServerNameType,
+} from "@app/lib/actions/mcp_internal_actions/constants";
+import { GlobeAltIcon, ToolsIcon } from "@dust-tt/sparkle";
+import type React from "react";
+
+export function getCollapseAnimationStyle(
+  isCollapsed: boolean
+): React.CSSProperties {
+  return {
+    gridTemplateRows: isCollapsed ? "0fr" : "1fr",
+    opacity: isCollapsed ? 0 : 1,
+    transition: isCollapsed
+      ? "grid-template-rows 280ms ease, opacity 280ms"
+      : "grid-template-rows 200ms ease-in",
+  };
+}
+
+export function getActionStepIcon(step: {
+  internalMCPServerName: InternalMCPServerNameType | null;
+  toolName: string | null;
+}): React.ComponentType<{ className?: string }> {
+  if (
+    step.internalMCPServerName === "sandbox" &&
+    step.toolName === "add_egress_domain"
+  ) {
+    return GlobeAltIcon;
+  }
+  if (step.internalMCPServerName) {
+    return InternalActionIcons[
+      getInternalMCPServerIconByName(step.internalMCPServerName)
+    ];
+  }
+  return ToolsIcon;
+}

--- a/front/hooks/useChildAgentStream.ts
+++ b/front/hooks/useChildAgentStream.ts
@@ -1,5 +1,12 @@
+import type { PendingToolCall } from "@app/components/assistant/conversation/types";
+import {
+  removePendingToolCallForAction,
+  upsertPendingToolCall,
+} from "@app/hooks/useAgentMessageStream";
 import { useEventSource } from "@app/hooks/useEventSource";
+import { getActionOneLineLabel } from "@app/lib/api/assistant/activity_steps";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
+import type { InlineActivityStep } from "@app/types/assistant/conversation";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useReducer } from "react";
@@ -9,14 +16,21 @@ type ChildAgentStreamStatus = "created" | "streaming" | "done" | "error";
 interface ChildAgentStreamReducerState {
   response: string;
   chainOfThought: string;
+  cotBuffer: string;
   status: ChildAgentStreamStatus;
+  inlineActivitySteps: InlineActivityStep[];
+  pendingToolCalls: PendingToolCall[];
 }
 
 interface ChildAgentStreamResult {
   response: string;
   chainOfThought: string;
-  isStreamingChainOfThought: boolean;
   isStreamingResponse: boolean;
+  inlineActivitySteps: InlineActivityStep[];
+  pendingToolCalls: PendingToolCall[];
+  activeCotContent: string;
+  isDone: boolean;
+  isError: boolean;
 }
 
 type ChildAgentStreamEvent = AgentMessageEvents | { type: "end-of-stream" };
@@ -24,7 +38,10 @@ type ChildAgentStreamEvent = AgentMessageEvents | { type: "end-of-stream" };
 const initialState: ChildAgentStreamReducerState = {
   response: "",
   chainOfThought: "",
+  cotBuffer: "",
   status: "created",
+  inlineActivitySteps: [],
+  pendingToolCalls: [],
 };
 
 function childAgentStreamReducer(
@@ -44,6 +61,7 @@ function childAgentStreamReducer(
         return {
           ...state,
           chainOfThought: state.chainOfThought + event.text,
+          cotBuffer: state.cotBuffer + event.text,
           status: "streaming",
         };
       }
@@ -51,26 +69,92 @@ function childAgentStreamReducer(
       return state;
     }
 
+    case "tool_params": {
+      // Flush accumulated CoT to a thinking step when the tool starts executing.
+      const trimmedCot = state.cotBuffer.trim();
+      const newSteps: InlineActivityStep[] = trimmedCot
+        ? [
+            ...state.inlineActivitySteps,
+            {
+              type: "thinking" as const,
+              content: trimmedCot,
+              id: `thinking-${event.created}`,
+            },
+          ]
+        : state.inlineActivitySteps;
+      return {
+        ...state,
+        cotBuffer: "",
+        inlineActivitySteps: newSteps,
+      };
+    }
+
+    case "tool_call_started": {
+      return {
+        ...state,
+        pendingToolCalls: upsertPendingToolCall(state.pendingToolCalls, {
+          toolName: event.toolName,
+          toolCallId: event.toolCallId,
+          toolCallIndex: event.toolCallIndex,
+        }),
+      };
+    }
+
+    case "agent_action_success": {
+      const { action } = event;
+      return {
+        ...state,
+        pendingToolCalls: removePendingToolCallForAction(
+          state.pendingToolCalls,
+          action
+        ),
+        inlineActivitySteps: [
+          ...state.inlineActivitySteps,
+          {
+            type: "action" as const,
+            label: getActionOneLineLabel(action, "done"),
+            id: `action-${action.id}`,
+            actionId: action.sId,
+            internalMCPServerName: action.internalMCPServerName,
+            toolName: action.toolName,
+          },
+        ],
+      };
+    }
+
     case "agent_message_gracefully_stopped":
-    case "agent_message_success":
+    case "agent_message_success": {
+      // Flush any remaining CoT buffer as a final thinking step.
+      const trimmedCot = state.cotBuffer.trim();
+      const finalSteps: InlineActivityStep[] = trimmedCot
+        ? [
+            ...state.inlineActivitySteps,
+            {
+              type: "thinking" as const,
+              content: trimmedCot,
+              id: `thinking-final-${event.created}`,
+            },
+          ]
+        : state.inlineActivitySteps;
       return {
         response: event.message.content ?? state.response,
         chainOfThought: event.message.chainOfThought ?? state.chainOfThought,
+        cotBuffer: "",
+        inlineActivitySteps: finalSteps,
+        pendingToolCalls: [],
         status: "done",
       };
+    }
 
     case "agent_error":
     case "tool_error":
-      return { ...state, status: "error" };
+      return { ...state, cotBuffer: "", pendingToolCalls: [], status: "error" };
 
     case "agent_generation_cancelled":
-      return { ...state, status: "done" };
+      return { ...state, cotBuffer: "", pendingToolCalls: [], status: "done" };
 
     // Events we don't use for the child stream display.
     case "end-of-stream":
-    case "agent_action_success":
-    case "tool_call_started":
-    case "tool_params":
     case "tool_notification":
     case "agent_context_pruned":
     case "tool_approve_execution":
@@ -94,7 +178,7 @@ interface UseChildAgentStreamParams {
   disabled: boolean;
 }
 
-// Minimalist implementation of a message stream, focused on textual content (COT + generation).
+// Stream the child agent's conversation: textual content (CoT + generation) and tool call activity.
 export function useChildAgentStream({
   childStreamIds,
   owner,
@@ -145,7 +229,11 @@ export function useChildAgentStream({
   return {
     response: state.response,
     chainOfThought: state.chainOfThought,
-    isStreamingChainOfThought: isStreaming && state.response.length === 0,
     isStreamingResponse: isStreaming && state.response.length > 0,
+    inlineActivitySteps: state.inlineActivitySteps,
+    pendingToolCalls: state.pendingToolCalls,
+    activeCotContent: state.cotBuffer,
+    isDone: isStreamDone,
+    isError: state.status === "error",
   };
 }

--- a/front/hooks/useChildAgentStream.ts
+++ b/front/hooks/useChildAgentStream.ts
@@ -15,7 +15,6 @@ type ChildAgentStreamStatus = "created" | "streaming" | "done" | "error";
 
 interface ChildAgentStreamReducerState {
   response: string;
-  chainOfThought: string;
   cotBuffer: string;
   status: ChildAgentStreamStatus;
   inlineActivitySteps: InlineActivityStep[];
@@ -24,7 +23,6 @@ interface ChildAgentStreamReducerState {
 
 interface ChildAgentStreamResult {
   response: string;
-  chainOfThought: string;
   isStreamingResponse: boolean;
   inlineActivitySteps: InlineActivityStep[];
   pendingToolCalls: PendingToolCall[];
@@ -37,7 +35,6 @@ type ChildAgentStreamEvent = AgentMessageEvents | { type: "end-of-stream" };
 
 const initialState: ChildAgentStreamReducerState = {
   response: "",
-  chainOfThought: "",
   cotBuffer: "",
   status: "created",
   inlineActivitySteps: [],
@@ -60,7 +57,6 @@ function childAgentStreamReducer(
       if (event.classification === "chain_of_thought") {
         return {
           ...state,
-          chainOfThought: state.chainOfThought + event.text,
           cotBuffer: state.cotBuffer + event.text,
           status: "streaming",
         };
@@ -138,7 +134,6 @@ function childAgentStreamReducer(
         : state.inlineActivitySteps;
       return {
         response: event.message.content ?? state.response,
-        chainOfThought: event.message.chainOfThought ?? state.chainOfThought,
         cotBuffer: "",
         inlineActivitySteps: finalSteps,
         pendingToolCalls: [],
@@ -228,7 +223,6 @@ export function useChildAgentStream({
 
   return {
     response: state.response,
-    chainOfThought: state.chainOfThought,
     isStreamingResponse: isStreaming && state.response.length > 0,
     inlineActivitySteps: state.inlineActivitySteps,
     pendingToolCalls: state.pendingToolCalls,


### PR DESCRIPTION
## Description

The `run_agent` sidebar previously only showed streaming text from the sub-conversation. This PR extends it to also stream tool calls and chain-of-thought, using the same inline activity timeline pattern already used in the main conversation.

**Goal**: Show what run_agent is doing to kill perception that it's broken.

## What changed

**`useChildAgentStream`** now handles `tool_call_started`, `tool_params`, and `agent_action_success` events. Chain-of-thought is accumulated in a buffer and flushed to a thinking step each time a tool executes, mirroring the flush boundary used by the main stream. The accumulated steps survive sidebar close/reopen because the SSE stream replays stored events when reconnected.

**`ActivityTimeline`** (new shared component) is the extracted renderer used by both `InlineActivitySteps` (main conversation) and the new `ChildAgentActivityTimeline` (run_agent sidebar). It owns the collapse toggle, step loop, running tool rows, trailing spinner, and terminal row. Each caller normalizes its own input shape before delegating. Action rows are non-clickable in the sidebar to avoid nested side panels.

**`MCPRunAgentActionDetails`**: the old `ContentMessage` wrapper for the response was removed. The response now renders directly as Markdown with default text color and heading sizes, matching the main conversation.

## Note

For simplicity, inline activity is not reconstructed when opening the sidebar after streaming has already completed. The SSE stream replays stored events on reconnect, so it works correctly while the run is in progress. Once done, the sidebar shows the final response only.


| Before  | After |
| ------------- | ------------- |
| <kbd><img width="581" height="1541" alt="Screenshot 2026-05-26 at 13 31 00" src="https://github.com/user-attachments/assets/d4874d6f-e306-4df6-8b82-0d4c96a38380" /></kbd> | <kbd><img width="584" height="1543" alt="Screenshot 2026-05-26 at 13 29 48" src="https://github.com/user-attachments/assets/ade59e3d-92a2-49b3-b97a-410291ff292b" /></kbd> | 


## Tests

Locally. 

## Risk

Break streaming. 
Can be rolled back.

## Deploy Plan

Deploy front. 