### PR TITLE
chore(docker): switch connectors to node slim image

### DIFF
--- a/dockerfiles/connectors.Dockerfile
+++ b/dockerfiles/connectors.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.14.0 as connectors
+FROM node:24.14.0-slim as connectors
 
 RUN npm install -g npm@11.11.0
 


### PR DESCRIPTION
## Description

Switch `dockerfiles/connectors.Dockerfile` from `node:24.14.0` to `node:24.14.0-slim`.

The full Node.js Debian image ships ~850 MB of packages that are never used at runtime (GCC, G++, make, Python, and ~200 other Debian packages). The slim variant removes all of that, keeping only the Node.js runtime and its direct OS dependencies.

Unlike the `front` workers (which bundle all packages into the esbuild output), the connectors esbuild config uses `packages: "external"` — all 72 production npm packages are `require()`d from `node_modules` at runtime and cannot be excluded from the image. This means a full multi-stage build (builder + lean runtime) would require a more involved Dockerfile to reinstall only production dependencies in the runtime stage. That is a worthwhile follow-up, but the slim base switch is the highest-leverage, lowest-risk change and captures the majority of the gain.

No package was implicitly relying on tools shipped in the full image (unlike `front`, which needed `curl` added explicitly for the prestop hook). The one-line change is sufficient.

## Risk

Low. Same base OS (Debian Bookworm), same Node.js version. All installed packages in the Dockerfile are explicitly declared via `npm ci` and are unaffected by the base image change.
