### PR TITLE
Add activity to mark compaction message as failed and unblock conversation

### DIFF
--- a/front/temporal/agent_loop/activities/compaction.ts
+++ b/front/temporal/agent_loop/activities/compaction.ts
@@ -1,5 +1,8 @@
 import { Authenticator, type AuthenticatorType } from "@app/lib/auth";
-import { runCompaction } from "@app/temporal/agent_loop/lib/compaction";
+import {
+  failCompactionMessage,
+  runCompaction,
+} from "@app/temporal/agent_loop/lib/compaction";
 import type { CompactionSourceConversation } from "@app/types/assistant/compaction";
 import type { SupportedModel } from "@app/types/assistant/models/types";
 
@@ -37,4 +40,30 @@ export async function compactionActivity(
   if (compactionRes.isErr()) {
     throw new Error(`Compaction failed: ${compactionRes.error}`);
   }
+}
+
+export async function compactionCleanupActivity(
+  authType: AuthenticatorType,
+  {
+    conversationId,
+    compactionMessageId,
+    compactionMessageVersion,
+  }: {
+    conversationId: string;
+    compactionMessageId: string;
+    compactionMessageVersion: number;
+  }
+): Promise<void> {
+  const authResult = await Authenticator.fromJSON(authType);
+  if (authResult.isErr()) {
+    throw new Error(
+      `Failed to deserialize authenticator: ${authResult.error.code}`
+    );
+  }
+  const auth = authResult.value;
+  await failCompactionMessage(auth, {
+    conversationId,
+    compactionMessageId,
+    compactionMessageVersion,
+  });
 }

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -166,6 +166,96 @@ async function createCompactionHistoryFile(
   return new Ok(entryRes.value);
 }
 
+export async function failCompactionMessage(
+  auth: Authenticator,
+  {
+    conversationId,
+    compactionMessageId,
+    compactionMessageVersion,
+  }: {
+    conversationId: string;
+    compactionMessageId: string;
+    compactionMessageVersion: number;
+  }
+): Promise<void> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const targetConversationRes = await getConversation(
+    auth,
+    conversationId,
+    false,
+    null,
+    PREVIOUS_INTERACTIONS_TO_PRESERVE + 1
+  );
+  if (targetConversationRes.isErr()) {
+    logger.error(
+      {
+        workspaceId: owner.sId,
+        conversationId,
+        compactionMessageId,
+        error: targetConversationRes.error,
+      },
+      "Compaction cleanup: failed to fetch conversation"
+    );
+    return;
+  }
+  const targetConversation = targetConversationRes.value;
+
+  const compactionMessage = findCompactionMessage(
+    targetConversation,
+    compactionMessageId,
+    compactionMessageVersion
+  );
+
+  if (!compactionMessage) {
+    logger.error(
+      {
+        workspaceId: owner.sId,
+        conversationId,
+        compactionMessageId,
+      },
+      "Compaction cleanup: compaction message not found"
+    );
+    return;
+  }
+
+  // Only mark as failed if still in "created" state (the main activity may
+  // have already updated the status before timing out).
+  if (compactionMessage.status !== "created") {
+    return;
+  }
+
+  const result = await updateCompactionMessageWithContentAndFinalStatus(auth, {
+    conversation: targetConversation,
+    compactionMessage,
+    clearEnabledSkillsOnSuccess: false,
+    status: "failed",
+    content: null,
+  });
+
+  compactionMessage.status = result.status;
+  compactionMessage.content = null;
+
+  await publishConversationEvent(
+    {
+      type: "compaction_message_done",
+      created: Date.now(),
+      messageId: compactionMessage.sId,
+      message: compactionMessage,
+    },
+    { conversationId: targetConversation.sId }
+  );
+
+  logger.info(
+    {
+      workspaceId: owner.sId,
+      conversationId,
+      compactionMessageId,
+    },
+    "Compaction cleanup: marked compaction message as failed"
+  );
+}
+
 export async function runCompaction(
   auth: Authenticator,
   {

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -118,6 +118,12 @@ const { compactionActivity } = proxyActivities<typeof compactionActivities>({
   },
 });
 
+const { compactionCleanupActivity } = proxyActivities<
+  typeof compactionActivities
+>({
+  startToCloseTimeout: "1 minute",
+});
+
 const {
   finalizeSuccessfulAgentLoopActivity,
   finalizeGracefullyStoppedAgentLoopActivity,
@@ -153,13 +159,23 @@ export async function compactionWorkflow({
   model: SupportedModel;
   sourceConversation?: CompactionSourceConversation;
 }) {
-  await compactionActivity(authType, {
-    conversationId,
-    compactionMessageId,
-    compactionMessageVersion,
-    model,
-    sourceConversation,
-  });
+  try {
+    await compactionActivity(authType, {
+      conversationId,
+      compactionMessageId,
+      compactionMessageVersion,
+      model,
+      sourceConversation,
+    });
+  } catch (_error) {
+    // If the compactionActivity has failed, it may be a timeout and the
+    // compaction message remained stuck in a "created" state.
+    await compactionCleanupActivity(authType, {
+      conversationId,
+      compactionMessageId,
+      compactionMessageVersion,
+    });
+  }
 }
 
 export async function agentLoopWorkflow({


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/8269

Follow up of https://github.com/dust-tt/dust/pull/25767
There are still some activities timeout after 20 minutes

This add a new activity when the first one fail to handle the situation by marking the compaction message as failed and sending an event to the conversation.

## Tests

no tested 

## Risk

low

## Deploy Plan

deploy front 
