### PR TITLE
[front] AgentMessage: log warning when copying a null agentMessage

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -59,6 +59,7 @@ import { useConversationWakeUps } from "@app/lib/swr/wakeups";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { formatTimestring } from "@app/lib/utils/timestamps";
 import { getNextWakeUpFireAt } from "@app/lib/utils/wakeup_description";
+import datadogLogger from "@app/logger/datadogLogger";
 import type { FetchConversationMessageResponseLight } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]";
 import {
   canShowAgentConversationActions,
@@ -541,6 +542,17 @@ export function AgentMessage({
   const isGlobalAgent = isGlobalAgentId(agentMessage.configuration.sId);
 
   async function handleCopyToClipboard() {
+    if (agentMessage.content === null) {
+      datadogLogger.warn(
+        {
+          messageId: agentMessage.sId,
+          conversationId,
+          status: agentMessage.status,
+        },
+        "handleCopyToClipboard: message content is null"
+      );
+    }
+
     const messageContent = agentMessage.content ?? "";
     let footnotesMarkdown = "";
     let footnotesHtml = "";


### PR DESCRIPTION
## Description

Linked to https://github.com/dust-tt/tasks/issues/8281
Sometimes, when trying to copy a message to clipboard it fails, one possible cause is that the agentMessage is null even though is should not be
=> adding a log with datadogLogger to detect these situations

## Tests

Tested locally, not impact on copy (when agentMessage not null)

## Risk

Low, only log with datadogLogger in error case

## Deploy Plan

Deploy front
