### PR TITLE
Per-tool icon overrides in internal MCP server metadata

### DIFF
--- a/front/components/assistant/conversation/actions/inline/utils.ts
+++ b/front/components/assistant/conversation/actions/inline/utils.ts
@@ -1,7 +1,7 @@
 import { InternalActionIcons } from "@app/components/resources/resources_icons";
 import {
   getInternalMCPServerIconByName,
-  getInternalMCPServerToolIcon,
+  getInternalMCPServerToolIconOverride,
   type InternalMCPServerNameType,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { ToolsIcon } from "@dust-tt/sparkle";
@@ -27,7 +27,7 @@ export function getActionStepIcon(step: {
     return ToolsIcon;
   }
   const toolIcon = step.toolName
-    ? getInternalMCPServerToolIcon(step.internalMCPServerName, step.toolName)
+    ? getInternalMCPServerToolIconOverride(step.internalMCPServerName, step.toolName)
     : null;
   const iconName =
     toolIcon ?? getInternalMCPServerIconByName(step.internalMCPServerName);

--- a/front/components/assistant/conversation/actions/inline/utils.ts
+++ b/front/components/assistant/conversation/actions/inline/utils.ts
@@ -1,9 +1,10 @@
 import { InternalActionIcons } from "@app/components/resources/resources_icons";
 import {
   getInternalMCPServerIconByName,
+  getInternalMCPServerToolIcon,
   type InternalMCPServerNameType,
 } from "@app/lib/actions/mcp_internal_actions/constants";
-import { GlobeAltIcon, ToolsIcon } from "@dust-tt/sparkle";
+import { ToolsIcon } from "@dust-tt/sparkle";
 import type React from "react";
 
 export function getCollapseAnimationStyle(
@@ -22,16 +23,13 @@ export function getActionStepIcon(step: {
   internalMCPServerName: InternalMCPServerNameType | null;
   toolName: string | null;
 }): React.ComponentType<{ className?: string }> {
-  if (
-    step.internalMCPServerName === "sandbox" &&
-    step.toolName === "add_egress_domain"
-  ) {
-    return GlobeAltIcon;
+  if (!step.internalMCPServerName) {
+    return ToolsIcon;
   }
-  if (step.internalMCPServerName) {
-    return InternalActionIcons[
-      getInternalMCPServerIconByName(step.internalMCPServerName)
-    ];
-  }
-  return ToolsIcon;
+  const toolIcon = step.toolName
+    ? getInternalMCPServerToolIcon(step.internalMCPServerName, step.toolName)
+    : null;
+  const iconName =
+    toolIcon ?? getInternalMCPServerIconByName(step.internalMCPServerName);
+  return InternalActionIcons[iconName];
 }

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1355,9 +1355,8 @@ export function getInternalMCPServerToolIcon(
   if (!server) {
     return null;
   }
-  return (
-    server.metadata.tools.find((t) => t.name === toolName)?.icon ?? null
-  );
+  // O(n) on tools, n <= ~10 per server.
+  return server.metadata.tools.find((t) => t.name === toolName)?.icon ?? null;
 }
 
 export function getInternalMCPServerDisplayedAs(

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1345,6 +1345,21 @@ export function getInternalMCPServerIconByName(
   return server.metadata.serverInfo.icon;
 }
 
+// Per-tool icon overrides defined in tool metadata. Falls back to the
+// server-level icon (via `getInternalMCPServerIconByName`) when null.
+export function getInternalMCPServerToolIcon(
+  name: InternalMCPServerNameType,
+  toolName: string
+): InternalAllowedIconType | null {
+  const server: InternalMCPServerEntry | undefined = INTERNAL_MCP_SERVERS[name];
+  if (!server) {
+    return null;
+  }
+  return (
+    server.metadata.tools.find((t) => t.name === toolName)?.icon ?? null
+  );
+}
+
 export function getInternalMCPServerDisplayedAs(
   toolServerId: string
 ): "agent" | "server" | undefined {

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1345,9 +1345,10 @@ export function getInternalMCPServerIconByName(
   return server.metadata.serverInfo.icon;
 }
 
-// Per-tool icon overrides defined in tool metadata. Falls back to the
-// server-level icon (via `getInternalMCPServerIconByName`) when null.
-export function getInternalMCPServerToolIcon(
+// Per-tool icon overrides defined in tool metadata. Returns null when the
+// tool has no override; the caller should fall back to the server-level icon
+// (via `getInternalMCPServerIconByName`).
+export function getInternalMCPServerToolIconOverride(
   name: InternalMCPServerNameType,
   toolName: string
 ): InternalAllowedIconType | null {

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -1,3 +1,4 @@
+import type { InternalAllowedIconType } from "@app/components/resources/resources_icons";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { MCPError } from "@app/lib/actions/mcp_errors";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
@@ -51,6 +52,7 @@ export interface ToolDefinition<
   schema: TSchema;
   stake: MCPToolStakeLevelType;
   displayLabels: ToolDisplayLabels;
+  icon?: InternalAllowedIconType;
   handler: (
     params: z.infer<z.ZodObject<TSchema>>,
     extra: ToolHandlerExtra
@@ -67,6 +69,7 @@ interface ClientToolDefinition<
   schema: TSchema;
   stake: MCPToolStakeLevelType;
   displayLabels: ToolDisplayLabels;
+  icon?: InternalAllowedIconType;
   argumentsRequiringApproval?: Array<
     Extract<keyof z.infer<z.ZodObject<TSchema>>, string>
   >;
@@ -141,6 +144,7 @@ type InternalMCPToolType<TName extends string = string> = Omit<
 > & {
   name: TName;
   displayLabels: ToolDisplayLabels;
+  icon?: InternalAllowedIconType;
 };
 
 export type ServerMetadata<

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -93,6 +93,7 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
       running: "Requesting Computer network access",
       done: "Allow domain in the Computer",
     },
+    icon: "ActionGlobeAltIcon",
   },
 });
 
@@ -114,6 +115,7 @@ export const SANDBOX_SERVER = {
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
+    icon: "icon" in t ? t.icon : undefined,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(SANDBOX_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -1,4 +1,7 @@
-import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  ServerMetadata,
+  ToolMeta,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
@@ -110,12 +113,14 @@ export const SANDBOX_SERVER = {
   },
   // Note: The `as JSONSchema` cast is standard pattern across all metadata files.
   // zodToJsonSchema returns a compatible type but TypeScript can't verify it statically.
-  tools: Object.values(SANDBOX_TOOLS_METADATA).map((t) => ({
+  // Widen to `ToolMeta[]` so the optional `icon` is accessible uniformly; the
+  // inferred per-entry union otherwise drops `icon` on entries that omit it.
+  tools: (Object.values(SANDBOX_TOOLS_METADATA) as ToolMeta[]).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
-    icon: "icon" in t ? t.icon : undefined,
+    icon: t.icon,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(SANDBOX_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -1,7 +1,4 @@
-import type {
-  ServerMetadata,
-  ToolMeta,
-} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
@@ -113,14 +110,14 @@ export const SANDBOX_SERVER = {
   },
   // Note: The `as JSONSchema` cast is standard pattern across all metadata files.
   // zodToJsonSchema returns a compatible type but TypeScript can't verify it statically.
-  // Widen to `ToolMeta[]` so the optional `icon` is accessible uniformly; the
-  // inferred per-entry union otherwise drops `icon` on entries that omit it.
-  tools: (Object.values(SANDBOX_TOOLS_METADATA) as ToolMeta[]).map((t) => ({
+  // `"icon" in t` narrows the per-entry union: entries that omit `icon` aren't
+  // intersected with the field at the inferred type level.
+  tools: Object.values(SANDBOX_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
     displayLabels: t.displayLabels,
-    icon: t.icon,
+    icon: "icon" in t ? t.icon : undefined,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(SANDBOX_TOOLS_METADATA).map((t) => [t.name, t.stake])


### PR DESCRIPTION
## Description

Follow-up to #26173.

Drops the hard-coded `sandbox` + `add_egress_domain` branch in `getActionStepIcon`. Internal MCP tools can now declare an optional `icon` in their metadata (next to `displayLabels`), resolved by a new `getInternalMCPServerToolIcon` helper. The inline timeline now does: per-tool icon, then server-level icon, then `ToolsIcon`. The raw `GlobeAltIcon` import is gone.

Only `add_egress_domain` opts in (with `ActionGlobeAltIcon`). Other servers are unchanged and keep their server-level icon.

> [!NOTE]
> Only `sandbox/metadata.ts` projects `icon` from `*_TOOLS_METADATA` into `SANDBOX_SERVER.tools[]`. The other ~20 internal-server metadata files don't yet propagate `icon`. They don't need to today (no other tool declares one) but will when they want per-tool overrides. A shared `buildServerTools(toolsMetadata)` helper would be a clean follow-up.

Out of scope: `MCPActionDetails.tsx` and `MCPSandboxAddEgressDomainDetails.tsx` still import sparkle's `GlobeAltIcon` directly. Same per-tool metadata can drive those in a follow-up.

## Tests

Typecheck clean. Ran the two affected vitest files locally (`mcp_servers_metadata`, `constants`).

## Risk

Low. Pure refactor of icon resolution. Same icon ends up on screen for `add_egress_domain`; everything else goes through the unchanged server-level path. Safe to rollback.

## Deploy Plan

Standard deploy.