### PR TITLE
[Webhooks] Skip unused payload storage

### DIFF
--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -390,9 +390,7 @@ function MCPRunAgentActionDetailsDisplay({
                   />
                   {response && (
                     <>
-                      <CitationsContext.Provider
-                        value={citationsContextValue}
-                      >
+                      <CitationsContext.Provider value={citationsContextValue}>
                         <Markdown
                           content={response}
                           isStreaming={isStreamingResponse}

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -697,6 +697,16 @@ export async function processWebhookRequest(
     return new Ok(undefined);
   }
 
+  if (filteredTriggers.some((t) => t.configuration.includePayload)) {
+    await storePayloadInGCS(auth, {
+      webhookSource,
+      webhookRequest,
+      headers,
+      body,
+      provider: webhookSource.provider ?? "custom",
+    });
+  }
+
   const launchResult = await launchTriggersWorkflows(auth, {
     filteredTriggers,
     webhookSource,

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -756,9 +756,11 @@ export async function fetchRecentWebhookRequestTriggersWithPayload(
       status,
     }
   );
+  const shouldFetchPayload =
+    isWebhookTrigger(trigger) && trigger.configuration.includePayload;
 
-  // Fetch payloads from GCS for each request
-  const bucket = getWebhookRequestsBucket();
+  // Fetch payloads from GCS for each request when the trigger is configured to keep them.
+  const bucket = shouldFetchPayload ? getWebhookRequestsBucket() : null;
   const requests = await Promise.all(
     webhookRequestTriggers.map(async (wrt) => {
       let payload:
@@ -767,28 +769,33 @@ export async function fetchRecentWebhookRequestTriggersWithPayload(
             body?: unknown;
           }
         | undefined;
+      const requestCanHavePayload =
+        wrt.status === "workflow_start_succeeded" ||
+        wrt.status === "workflow_start_failed";
 
-      const gcsPath = WebhookRequestResource.getGcsPath({
-        workspaceId: workspace.sId,
-        webhookSourceId: wrt.webhookRequest.webhookSourceId,
-        webRequestId: wrt.webhookRequest.id,
-      });
+      if (bucket && requestCanHavePayload) {
+        const gcsPath = WebhookRequestResource.getGcsPath({
+          workspaceId: workspace.sId,
+          webhookSourceId: wrt.webhookRequest.webhookSourceId,
+          webRequestId: wrt.webhookRequest.id,
+        });
 
-      try {
-        const file = bucket.file(gcsPath);
-        const [content] = await file.download();
-        if (content) {
-          payload = JSON.parse(content.toString());
+        try {
+          const file = bucket.file(gcsPath);
+          const [content] = await file.download();
+          if (content) {
+            payload = JSON.parse(content.toString());
+          }
+        } catch (error) {
+          logger.warn(
+            {
+              webhookRequestId: wrt.webhookRequest.id,
+              error: error instanceof Error ? error.message : String(error),
+            },
+            "Failed to fetch webhook request payload from GCS"
+          );
+          // Continue without payload if GCS fetch fails
         }
-      } catch (error) {
-        logger.warn(
-          {
-            webhookRequestId: wrt.webhookRequest.id,
-            error: error instanceof Error ? error.message : String(error),
-          },
-          "Failed to fetch webhook request payload from GCS"
-        );
-        // Continue without payload if GCS fetch fails
       }
 
       return {

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -17,13 +17,13 @@ import {
   checkProgrammaticUsageLimits,
   isProgrammaticUsage,
 } from "@app/lib/api/programmatic_usage/tracking";
-import { isApiBlocked } from "@app/lib/metronome/user_block";
 import {
   addBackwardCompatibleConversationFields,
   addBackwardCompatibleConversationWithoutContentFields,
   normalizeConversationVisibility,
 } from "@app/lib/api/v1/backward_compatibility";
 import type { Authenticator } from "@app/lib/auth";
+import { isApiBlocked } from "@app/lib/metronome/user_block";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";

--- a/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
@@ -1,8 +1,23 @@
 import { Authenticator } from "@app/lib/auth";
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WebhookSourceFactory } from "@app/tests/utils/WebhookSourceFactory";
-import { describe, expect, it, vi } from "vitest";
+import { WebhookSourceViewFactory } from "@app/tests/utils/WebhookSourceViewFactory";
+import type { WorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const launchTriggersWorkflowsMock = vi.hoisted(() =>
+  vi.fn(async () => ({
+    isErr: () => false,
+  }))
+);
+
+const uploadWebhookPayloadMock = vi.hoisted(() =>
+  vi.fn().mockResolvedValue(undefined)
+);
 
 // Mock raw-body to return JSON.stringify(req.body) — the handler disables
 // Next.js body parsing and reads the stream via getRawBody.
@@ -32,15 +47,70 @@ vi.mock("@app/lib/utils/statsd", () => ({
 vi.mock("@app/lib/file_storage", () => ({
   getWebhookRequestsBucket: () => ({
     uploadRawContentToBucket: vi.fn().mockResolvedValue(undefined),
-    uploadSmallRawContentToBucketAsNewFile: vi
-      .fn()
-      .mockResolvedValue(undefined),
+    uploadSmallRawContentToBucketAsNewFile: uploadWebhookPayloadMock,
   }),
+}));
+
+vi.mock("@app/temporal/triggers/webhook_client", () => ({
+  launchTriggersWorkflows: launchTriggersWorkflowsMock,
 }));
 
 import handler from ".";
 
+async function makeTriggerEditorAuth(workspace: WorkspaceType) {
+  const triggerEditor = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, triggerEditor, {
+    role: "builder",
+  });
+
+  return Authenticator.fromUserIdAndWorkspaceId(
+    triggerEditor.sId,
+    workspace.sId
+  );
+}
+
+async function createWebhookSourceAndTrigger(
+  workspace: WorkspaceType,
+  {
+    includePayload,
+    filter,
+  }: {
+    includePayload: boolean;
+    filter?: string;
+  }
+) {
+  const adminAuth = await Authenticator.internalAdminForWorkspace(
+    workspace.sId
+  );
+  const triggerEditorAuth = await makeTriggerEditorAuth(workspace);
+  const { systemSpace } = await SpaceFactory.defaults(adminAuth);
+
+  const webhookSource = await new WebhookSourceFactory(workspace).create({
+    name: "Test Webhook Source",
+  });
+  const webhookSourceView = await new WebhookSourceViewFactory(
+    workspace
+  ).create(systemSpace, { webhookSourceId: webhookSource.sId });
+
+  await TriggerFactory.webhook(triggerEditorAuth, {
+    agentConfigurationId: "agent_test",
+    status: "enabled",
+    webhookSourceViewId: webhookSourceView.id,
+    configuration: {
+      includePayload,
+      ...(filter ? { filter } : {}),
+    },
+  });
+
+  return webhookSource;
+}
+
 describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]", () => {
+  beforeEach(() => {
+    launchTriggersWorkflowsMock.mockClear();
+    uploadWebhookPayloadMock.mockClear();
+  });
+
   it("returns 200 when workspace and webhook source exist", async () => {
     const { req, res, workspace } = await createPublicApiMockRequest({
       method: "POST",
@@ -225,6 +295,79 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
 
     expect(res._getStatusCode()).toBe(200);
     expect(res._getJSONData()).toEqual({ success: true });
+  });
+
+  it("stores payload when a matched trigger includes payload", async () => {
+    const { req, res, workspace } = await createPublicApiMockRequest({
+      method: "POST",
+    });
+
+    const webhookSource = await createWebhookSourceAndTrigger(workspace, {
+      includePayload: true,
+    });
+
+    req.query = {
+      wId: workspace.sId,
+      webhookSourceId: webhookSource.sId,
+      webhookSourceUrlSecret: webhookSource.urlSecret,
+    };
+    req.body = { any: "payload" };
+    req.headers["content-type"] = "application/json";
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(uploadWebhookPayloadMock).toHaveBeenCalledTimes(1);
+    expect(launchTriggersWorkflowsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not store payload when matched triggers do not include payload", async () => {
+    const { req, res, workspace } = await createPublicApiMockRequest({
+      method: "POST",
+    });
+
+    const webhookSource = await createWebhookSourceAndTrigger(workspace, {
+      includePayload: false,
+    });
+
+    req.query = {
+      wId: workspace.sId,
+      webhookSourceId: webhookSource.sId,
+      webhookSourceUrlSecret: webhookSource.urlSecret,
+    };
+    req.body = { any: "payload" };
+    req.headers["content-type"] = "application/json";
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(uploadWebhookPayloadMock).not.toHaveBeenCalled();
+    expect(launchTriggersWorkflowsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not store payload when no triggers match", async () => {
+    const { req, res, workspace } = await createPublicApiMockRequest({
+      method: "POST",
+    });
+
+    const webhookSource = await createWebhookSourceAndTrigger(workspace, {
+      includePayload: true,
+      filter: '(eq "type" "wanted")',
+    });
+
+    req.query = {
+      wId: workspace.sId,
+      webhookSourceId: webhookSource.sId,
+      webhookSourceUrlSecret: webhookSource.urlSecret,
+    };
+    req.body = { type: "ignored" };
+    req.headers["content-type"] = "application/json";
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(uploadWebhookPayloadMock).not.toHaveBeenCalled();
+    expect(launchTriggersWorkflowsMock).not.toHaveBeenCalled();
   });
 
   it("returns 400 when webhookSourceUrlSecret is undefined", async () => {

--- a/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts
+++ b/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts
@@ -7,7 +7,6 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import {
   HEADERS_ALLOWED_LIST,
   processWebhookRequest,
-  storePayloadInGCS,
 } from "@app/lib/triggers/webhook";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 
@@ -188,14 +187,6 @@ async function handler(
         isString(headers[key])
     ) as [string, string][] // Type assertion to satisfy TypeScript, we've already filtered to strings
   );
-
-  await storePayloadInGCS(auth, {
-    webhookSource,
-    webhookRequest,
-    headers: filteredHeaders,
-    body,
-    provider,
-  });
 
   const result = await processWebhookRequest(auth, {
     webhookSource: webhookSource,


### PR DESCRIPTION
## Description
Related to https://github.com/dust-tt/tasks/issues/8104
Follows https://github.com/dust-tt/dust/pull/26048 and https://github.com/dust-tt/dust/pull/26061

Webhook requests no longer store the raw payload before validation and trigger matching. We only persist the payload after at least one trigger matches and at least one matched trigger has `includePayload` enabled.

This avoids GCS writes for unmatched webhook traffic while keeping payload attachment behavior unchanged for triggers that need the body in the launched conversation.

## Risks
Blast radius: webhook trigger request processing and recent webhook request payload display.
Risk: low

## Deploy Plan
- deploy front

## Tests
- [x] `NODE_ENV=test npm test -- --dir pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]`
