### PR TITLE
feat(audit): add subscription.changed audit log event

### DIFF
--- a/front/admin/audit_log_schemas/subscription.changed.json
+++ b/front/admin/audit_log_schemas/subscription.changed.json
@@ -1,0 +1,9 @@
+{
+  "action": "subscription.changed",
+  "targets": [{ "type": "workspace" }],
+  "metadata": {
+    "plan_code": "string",
+    "previous_plan_code": "string",
+    "metronome_contract_id": "string"
+  }
+}

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -120,6 +120,8 @@ type AuditAction =
   // Audit Logs.
   | "audit_log.viewed"
   | "audit_log.export_configured"
+  // Billing & Subscriptions.
+  | "subscription.changed"
   // Coupons.
   | "coupon.redeemed"
   | "coupon.revoked";

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -23,6 +23,7 @@ import {
   getMetronomeDefaultUserCapAlert,
   getMetronomePerUserCap,
 } from "@app/lib/metronome/alerts/spend_limits";
+import { emitSubscriptionChangedAuditEvent } from "@app/lib/metronome/audit";
 import {
   getMetronomeContractById,
   listMetronomeContracts,
@@ -995,6 +996,7 @@ export async function processMetronomeWebhook({
         pendingSubscription &&
         pendingSubscription.status === "created_backend_only"
       ) {
+        const previousPlanCode = activeSubscription.getPlan().code;
         await pendingSubscription.activatePending();
         await invalidateContractCache(workspace.sId);
         const auth = await Authenticator.internalAdminForWorkspace(
@@ -1005,6 +1007,12 @@ export async function processMetronomeWebhook({
           workspace,
           planCode: targetPlan.code,
           contractId,
+        });
+        emitSubscriptionChangedAuditEvent({
+          auth,
+          planCode: targetPlanCode,
+          previousPlanCode,
+          metronomeContractId: contractId,
         });
         logger.info(
           {
@@ -1038,6 +1046,7 @@ export async function processMetronomeWebhook({
 
       // End the current subscription as `ended_backend_only` and create
       // a new active subscription on the target plan + new contract.
+      const legacyPreviousPlanCode = activeSubscription.getPlan().code;
       await activeSubscription.swapMetronomeContract({
         metronomeContractId: contractId,
         planCode: targetPlan.code,
@@ -1049,6 +1058,12 @@ export async function processMetronomeWebhook({
       // triggers. Idempotent — safe to call regardless of prior state.
       const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
       await restoreWorkspaceAfterSubscription(auth);
+      emitSubscriptionChangedAuditEvent({
+        auth,
+        planCode: targetPlan.code,
+        previousPlanCode: legacyPreviousPlanCode,
+        metronomeContractId: contractId,
+      });
 
       await ensureWorkOSOrganizationForPaidPlan({
         workspace,

--- a/front/lib/metronome/audit.ts
+++ b/front/lib/metronome/audit.ts
@@ -1,0 +1,31 @@
+import {
+  buildAuditLogTarget,
+  emitAuditLogEventDirect,
+} from "@app/lib/api/audit/workos_audit";
+import type { Authenticator } from "@app/lib/auth";
+
+export function emitSubscriptionChangedAuditEvent({
+  auth,
+  planCode,
+  previousPlanCode,
+  metronomeContractId,
+}: {
+  auth: Authenticator;
+  planCode: string;
+  previousPlanCode: string;
+  metronomeContractId: string;
+}): void {
+  const workspace = auth.getNonNullableWorkspace();
+  void emitAuditLogEventDirect({
+    workspace,
+    action: "subscription.changed",
+    actor: { type: "system", id: "metronome-webhook", name: "Metronome" },
+    targets: [buildAuditLogTarget("workspace", workspace)],
+    context: { location: "internal" },
+    metadata: {
+      plan_code: planCode,
+      previous_plan_code: previousPlanCode,
+      metronome_contract_id: metronomeContractId,
+    },
+  });
+}


### PR DESCRIPTION
## Description

Adds a `subscription.changed` audit log event fired when a workspace's Metronome subscription changes plan.

Three emit sites:
- **`switch_contract.ts`** (poke endpoint): fires with the operator's user context and IP when they schedule a plan switch via the poke UI
- **`process_webhook.ts` (preferred path)**: fires with a system actor when the `contract.start` webhook activates a pending subscription
- **`process_webhook.ts` (legacy path)**: same, for the legacy `swapMetronomeContract` fallback

The shared webhook emit logic lives in `front/lib/metronome/audit.ts` (`emitSubscriptionChangedAuditEvent`).

Also fixes a pre-existing type error in `resources_icons.tsx` that was masked when sparkle wasn't built locally — `ComponentProps<typeof Avatar>` used a type-only import; switched to `ComponentProps<typeof SparkleAvatar>` (the value import) to fix it.

Remember to register the schema after deploy:
```bash
npx tsx front/admin/register_audit_log_schemas.ts --execute subscription.changed
```

## Test plan

- Manual: trigger a `switch_contract` poke action and verify the audit event appears in WorkOS