### PR TITLE
Fail workflow image

### DIFF
--- a/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
@@ -65,9 +65,17 @@ async function userContentToParam(
         };
       }
 
-      const { mediaType, data } = await trustedFetchImageBase64(
-        content.image_url.url
-      );
+      let fetchResult: Awaited<ReturnType<typeof trustedFetchImageBase64>>;
+      try {
+        fetchResult = await trustedFetchImageBase64(content.image_url.url);
+      } catch {
+        return {
+          type: "text",
+          text: "Attachment: image could not be loaded.",
+        };
+      }
+
+      const { mediaType, data } = fetchResult;
 
       if (!isAcceptedMediaType(mediaType)) {
         return {

--- a/front/lib/api/llm/clients/anthropic/utils/test/conversation_to_anthropic.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/conversation_to_anthropic.test.ts
@@ -3,7 +3,10 @@ import { conversationMessages } from "@app/lib/api/llm/clients/anthropic/utils/t
 import { reasoningConversationMessages } from "@app/lib/api/llm/clients/anthropic/utils/test/fixtures/conversation_messages/reasoning";
 import { inputMessages } from "@app/lib/api/llm/clients/anthropic/utils/test/fixtures/model_input";
 import { reasoningInputMessages } from "@app/lib/api/llm/clients/anthropic/utils/test/fixtures/model_input/reasoning";
-import { describe, expect, it } from "vitest";
+import { trustedFetchImageBase64 } from "@app/types/shared/utils/image_utils";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/types/shared/utils/image_utils");
 
 describe("toMessage", () => {
   describe("user messages", () => {
@@ -88,6 +91,84 @@ describe("toMessage", () => {
           expect(block).not.toHaveProperty("cache_control");
         });
       }
+    });
+  });
+
+  describe("image_url in tool results", () => {
+    it("should return a text fallback when image fetch fails", async () => {
+      vi.mocked(trustedFetchImageBase64).mockRejectedValue(
+        new Error("Not Found")
+      );
+
+      const result = await toMessage(
+        {
+          role: "function",
+          name: "some_tool",
+          function_call_id: "call_1",
+          content: [
+            {
+              type: "image_url",
+              image_url: { url: "https://example.com/expired.png" },
+            },
+          ],
+        },
+        { isLast: false, omittedThinking: false, convertToBase64: true }
+      );
+
+      expect(result).toEqual({
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "call_1",
+            content: [
+              { type: "text", text: "Attachment: image could not be loaded." },
+            ],
+          },
+        ],
+      });
+    });
+
+    it("should embed image as base64 when fetch succeeds", async () => {
+      vi.mocked(trustedFetchImageBase64).mockResolvedValue({
+        mediaType: "image/jpeg",
+        data: "base64data",
+      });
+
+      const result = await toMessage(
+        {
+          role: "function",
+          name: "some_tool",
+          function_call_id: "call_1",
+          content: [
+            {
+              type: "image_url",
+              image_url: { url: "https://example.com/image.jpg" },
+            },
+          ],
+        },
+        { isLast: false, omittedThinking: false, convertToBase64: true }
+      );
+
+      expect(result).toEqual({
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "call_1",
+            content: [
+              {
+                type: "image",
+                source: {
+                  type: "base64",
+                  media_type: "image/jpeg",
+                  data: "base64data",
+                },
+              },
+            ],
+          },
+        ],
+      });
     });
   });
 });

--- a/front/lib/api/llm/clients/google/utils/conversation_to_google.ts
+++ b/front/lib/api/llm/clients/google/utils/conversation_to_google.ts
@@ -36,11 +36,16 @@ async function contentToPart(
   switch (content.type) {
     case "text":
       return { text: content.text };
-    case "image_url":
+    case "image_url": {
       // Google only accepts images as base64 inline data
-      const { mediaType, data } = await trustedFetchImageBase64(
-        content.image_url.url
-      );
+      let fetchResult: Awaited<ReturnType<typeof trustedFetchImageBase64>>;
+      try {
+        fetchResult = await trustedFetchImageBase64(content.image_url.url);
+      } catch {
+        return { text: "Attachment: image could not be loaded." };
+      }
+
+      const { mediaType, data } = fetchResult;
 
       if (!GOOGLE_AI_STUDIO_SUPPORTED_MIME_TYPES.includes(mediaType)) {
         throw new EventError(
@@ -63,6 +68,7 @@ async function contentToPart(
           data,
         },
       };
+    }
     default:
       assertNever(content);
   }
@@ -90,16 +96,31 @@ async function functionMessageToResponses(
             name: message.name,
             id: message.function_call_id,
           };
-        case "image_url":
-          const { mediaType, data } = await trustedFetchImageBase64(
-            c.image_url.url
-          );
+        case "image_url": {
+          let fetchResult: Awaited<ReturnType<typeof trustedFetchImageBase64>>;
+          try {
+            fetchResult = await trustedFetchImageBase64(c.image_url.url);
+          } catch {
+            return {
+              response: { output: "Attachment: image could not be loaded." },
+              name: message.name,
+              id: message.function_call_id,
+            };
+          }
 
           return {
-            parts: [{ inlineData: { data, mimeType: mediaType } }],
+            parts: [
+              {
+                inlineData: {
+                  data: fetchResult.data,
+                  mimeType: fetchResult.mediaType,
+                },
+              },
+            ],
             name: message.name,
             id: message.function_call_id,
           };
+        }
         default:
           assertNever(c);
       }

--- a/front/lib/api/llm/clients/google/utils/test/conversation_to_google.test.ts
+++ b/front/lib/api/llm/clients/google/utils/test/conversation_to_google.test.ts
@@ -1,7 +1,10 @@
 import { toContent } from "@app/lib/api/llm/clients/google/utils/conversation_to_google";
 import type { ModelMessageTypeMultiActionsWithoutContentFragment } from "@app/types/assistant/generation";
 import { GEMINI_2_5_PRO_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
-import { describe, expect, it } from "vitest";
+import { trustedFetchImageBase64 } from "@app/types/shared/utils/image_utils";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/types/shared/utils/image_utils");
 
 describe("toContent", () => {
   describe("user messages", () => {
@@ -13,6 +16,93 @@ describe("toContent", () => {
       );
 
       expect(messages).toEqual(expectedGoogleMessages);
+    });
+  });
+});
+
+describe("image_url handling", () => {
+  it("should return a text part fallback when image fetch fails in user message", async () => {
+    vi.mocked(trustedFetchImageBase64).mockRejectedValue(
+      new Error("Not Found")
+    );
+
+    const result = await toContent(
+      {
+        role: "user",
+        name: "Someone",
+        content: [
+          {
+            type: "image_url",
+            image_url: { url: "https://example.com/expired.png" },
+          },
+        ],
+      },
+      GEMINI_2_5_PRO_MODEL_ID
+    );
+
+    expect(result).toEqual({
+      role: "user",
+      parts: [{ text: "Attachment: image could not be loaded." }],
+    });
+  });
+
+  it("should return a text fallback when image fetch fails in tool result", async () => {
+    vi.mocked(trustedFetchImageBase64).mockRejectedValue(
+      new Error("Not Found")
+    );
+
+    const result = await toContent(
+      {
+        role: "function",
+        name: "some_tool",
+        function_call_id: "call_1",
+        content: [
+          {
+            type: "image_url",
+            image_url: { url: "https://example.com/expired.png" },
+          },
+        ],
+      },
+      GEMINI_2_5_PRO_MODEL_ID
+    );
+
+    expect(result).toEqual({
+      role: "user",
+      parts: [
+        {
+          functionResponse: {
+            response: { output: "Attachment: image could not be loaded." },
+            name: "some_tool",
+            id: "call_1",
+          },
+        },
+      ],
+    });
+  });
+
+  it("should embed image as base64 when fetch succeeds in user message", async () => {
+    vi.mocked(trustedFetchImageBase64).mockResolvedValue({
+      mediaType: "image/jpeg",
+      data: "base64data",
+    });
+
+    const result = await toContent(
+      {
+        role: "user",
+        name: "Someone",
+        content: [
+          {
+            type: "image_url",
+            image_url: { url: "https://example.com/image.jpg" },
+          },
+        ],
+      },
+      GEMINI_2_5_PRO_MODEL_ID
+    );
+
+    expect(result).toEqual({
+      role: "user",
+      parts: [{ inlineData: { mimeType: "image/jpeg", data: "base64data" } }],
     });
   });
 });


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8261

Conversations were failing in prod with `runModelAndCreateActionsActivity` hitting max retries:

```
"message": "Invalid image: Invalid image: Not Found"
"stackTrace": "Error: Invalid image: Invalid image: Not Found
    at trustedFetchImageBase64 (...)
    at async userContentToParam (...)
    at async toolResultToParam (...)
    at async functionMessage (...)"
```

When building the next model call, image URLs embedded in previous tool results are fetched and base64-encoded. If the URL has expired or been deleted (404), `trustedFetchImageBase64` throws, crashing the activity. The double `"Invalid image: Invalid image:"` prefix reveals the error is re-wrapped by the outer catch in `trustedFetchImageBase64` itself.

A TODO for this was originally left in #17325, then removed without being fixed in #17767.

## Changes

- In the Anthropic client (`userContentToParam`), wrap the fetch in a try-catch and return a text fallback (`"Attachment: image could not be loaded."`) on error, consistent with how unsupported media types are already handled
- In the Google client, apply the same try-catch in both `contentToPart` (user messages) and `functionMessageToResponses` (tool results)

Conversations with stale image URLs now degrade gracefully instead of failing the workflow entirely.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 