### PR TITLE
[LLM] add use_vertex_for_supported_models feature flag

### DIFF
--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -13,6 +13,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Route Claude model LLM calls through Vertex AI instead of the direct Anthropic API",
     stage: "dust_only",
   },
+  use_vertex_for_supported_models: {
+    description:
+      "Route LLM calls through Vertex AI when supported instead of the direct provider's API",
+    stage: "dust_only",
+  },
   audit_logs: {
     description: "Enable audit log emission via WorkOS",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -762,6 +762,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "conversation_search_read"
   | "new_file_explorer"
   | "use_vertex_for_anthropic_models"
+  | "use_vertex_for_supported_models"
   | "metronome_billing_usage_page"
 >();
 


### PR DESCRIPTION
## Description

Adds a new `use_vertex_for_supported_models` whitelistable feature flag that routes LLM calls through Vertex AI for any supported provider, not just Anthropic. This is required to smoothly transition workspaces currently on `use_vertex_for_anthropic_models` so we can remove that flag later.

## Tests

No tests — feature flag declaration only.

## Risk

Low — adds a new flag without enabling it on any workspace.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`