### PR TITLE
[sparkle] Add composable Breadcrumb primitives

### DIFF
--- a/front/components/actions/mcp/details/MCPDataSourcesFileSystemActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPDataSourcesFileSystemActionDetails.tsx
@@ -9,7 +9,7 @@ import {
   getVisualForContentNodeType,
 } from "@app/lib/content_nodes";
 import { formatDataSourceDisplayName } from "@app/types/core/utils";
-import type { BreadcrumbItem } from "@dust-tt/sparkle";
+import type { BreadcrumbsItem } from "@dust-tt/sparkle";
 import {
   ActionPinDistanceIcon,
   Breadcrumbs,
@@ -86,7 +86,7 @@ export function FilesystemPathDetails({
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const { path } = filesystemPath || { path: [] };
 
-  const breadcrumbItems: BreadcrumbItem[] = path?.map((item) =>
+  const breadcrumbItems: BreadcrumbsItem[] = path?.map((item) =>
     item.sourceUrl
       ? {
           icon: getVisualForContentNodeType(item.nodeType),

--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -390,9 +390,7 @@ function MCPRunAgentActionDetailsDisplay({
                   />
                   {response && (
                     <>
-                      <CitationsContext.Provider
-                        value={citationsContextValue}
-                      >
+                      <CitationsContext.Provider value={citationsContextValue}>
                         <Markdown
                           content={response}
                           isStreaming={isStreamingResponse}

--- a/front/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector.tsx
@@ -28,7 +28,7 @@ import {
 } from "@app/lib/swr/spaces";
 import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
 import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/utils";
-import type { BreadcrumbItem } from "@dust-tt/sparkle";
+import type { BreadcrumbsItem } from "@dust-tt/sparkle";
 import {
   Breadcrumbs,
   Button,
@@ -251,7 +251,7 @@ export const DataSourceBuilderSelector = ({
     }
   };
 
-  const breadcrumbItems: BreadcrumbItem[] = useMemo(() => {
+  const breadcrumbItems: BreadcrumbsItem[] = useMemo(() => {
     if (shouldShowSearch && currentSpace) {
       // When searching in space scope, show only up to space level
       if (searchScope === "space") {
@@ -387,7 +387,7 @@ export const DataSourceBuilderSelector = ({
 
 function getBreadcrumbConfig(
   entry: NavigationHistoryEntryType
-): BreadcrumbItem {
+): BreadcrumbsItem {
   switch (entry.type) {
     case "root":
       return {

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -15,7 +15,7 @@ import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { getConversationRoute, getPodRoute } from "@app/lib/utils/router";
 import { getConversationDisplayTitle } from "@app/types/assistant/conversation";
 import type { WorkspaceType } from "@app/types/user";
-import type { BreadcrumbItem } from "@dust-tt/sparkle";
+import type { BreadcrumbsItem } from "@dust-tt/sparkle";
 import {
   ActionGitBranchIcon,
   ArrowLeftIcon,
@@ -70,7 +70,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
   const forkedFrom = conversation?.forkingData?.forkedFrom;
   const isMobileForkedConversation = isMobile && !!forkedFrom;
 
-  const breadcrumbItems: BreadcrumbItem[] = [];
+  const breadcrumbItems: BreadcrumbsItem[] = [];
 
   if (spaceId && spaceInfo) {
     breadcrumbItems.push({

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -1,10 +1,10 @@
 import { FileExplorerContent } from "@app/components/file_explorer/FileExplorerContent";
+import { canMoveFileToParentFolder } from "@app/components/file_explorer/fileExplorerDragDrop";
 import { FileExplorerFilters } from "@app/components/file_explorer/FileExplorerFilters";
 import type { ViewMode } from "@app/components/file_explorer/FileExplorerItem";
+import { getFileExplorerPipeline } from "@app/components/file_explorer/fileExplorerPipeline";
 import { FileExplorerToolbar } from "@app/components/file_explorer/FileExplorerToolbar";
 import { FilePreviewDialog } from "@app/components/file_explorer/FilePreviewDialog";
-import { canMoveFileToParentFolder } from "@app/components/file_explorer/fileExplorerDragDrop";
-import { getFileExplorerPipeline } from "@app/components/file_explorer/fileExplorerPipeline";
 import { MoveFileToFolderDialog } from "@app/components/file_explorer/MoveFileToFolderDialog";
 import type {
   ContentNodeEntry,
@@ -30,7 +30,6 @@ import type { GCSMountEntry } from "@app/lib/api/files/gcs_mount/files";
 import { isInteractiveContentType } from "@app/types/files";
 import { Err, type Result } from "@app/types/shared/result";
 import {
-  type BreadcrumbsItem,
   Breadcrumbs,
   Button,
   cn,
@@ -38,6 +37,7 @@ import {
   PencilSquareIcon,
   TrashIcon,
   XMarkIcon,
+  type BreadcrumbsItem,
 } from "@dust-tt/sparkle";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -30,7 +30,7 @@ import type { GCSMountEntry } from "@app/lib/api/files/gcs_mount/files";
 import { isInteractiveContentType } from "@app/types/files";
 import { Err, type Result } from "@app/types/shared/result";
 import {
-  type BreadcrumbItem,
+  type BreadcrumbsItem,
   Breadcrumbs,
   Button,
   cn,
@@ -52,7 +52,7 @@ function FileExplorerBreadcrumb({
   onNavigate,
 }: FileExplorerBreadcrumbProps) {
   const segments = getFolderBreadcrumbSegments(currentFolderPath);
-  const items: BreadcrumbItem[] = [
+  const items: BreadcrumbsItem[] = [
     { label: ROOT_FOLDER_LABEL, onClick: () => onNavigate(-1) },
     ...segments.map((segment, i) => ({
       label: segment.label,

--- a/front/components/spaces/SpaceBreadcrumb.tsx
+++ b/front/components/spaces/SpaceBreadcrumb.tsx
@@ -5,7 +5,7 @@ import type { DataSourceViewCategory } from "@app/types/api/public/spaces";
 import type { DataSourceViewType } from "@app/types/data_source_view";
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";
-import type { BreadcrumbItem } from "@dust-tt/sparkle";
+import type { BreadcrumbsItem } from "@dust-tt/sparkle";
 import {
   BoltIcon,
   Breadcrumbs,
@@ -56,7 +56,7 @@ export function SpaceBreadCrumbs({
       ];
     }
 
-    const items: BreadcrumbItem[] = [
+    const items: BreadcrumbsItem[] = [
       {
         icon: getSpaceIcon(space),
         label: getSpaceName(space),

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -17,13 +17,13 @@ import {
   checkProgrammaticUsageLimits,
   isProgrammaticUsage,
 } from "@app/lib/api/programmatic_usage/tracking";
-import { isApiBlocked } from "@app/lib/metronome/user_block";
 import {
   addBackwardCompatibleConversationFields,
   addBackwardCompatibleConversationWithoutContentFields,
   normalizeConversationVisibility,
 } from "@app/lib/api/v1/backward_compatibility";
 import type { Authenticator } from "@app/lib/auth";
+import { isApiBlocked } from "@app/lib/metronome/user_block";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";

--- a/sparkle/playground/src/components/ConversationView.tsx
+++ b/sparkle/playground/src/components/ConversationView.tsx
@@ -36,7 +36,7 @@ import {
   SlackLogo,
   TableIcon,
 } from "@dust-tt/sparkle";
-import type { ActionCardState, BreadcrumbItem } from "@dust-tt/sparkle";
+import type { ActionCardState, BreadcrumbsItem } from "@dust-tt/sparkle";
 import {
   NewConversationActiveIndicator,
   NewConversationAgentMessage,
@@ -417,7 +417,7 @@ export function ConversationView({
     }
   }, [conversation.id, itemsToDisplay.length]);
 
-  const breadcrumbItems: BreadcrumbItem[] = [];
+  const breadcrumbItems: BreadcrumbsItem[] = [];
 
   if (showBackButton && projectTitle) {
     if (onBack) {

--- a/sparkle/src/components/Breadcrumbs.tsx
+++ b/sparkle/src/components/Breadcrumbs.tsx
@@ -273,12 +273,12 @@ function truncateTextToLength(text: string, length: number) {
 
 // Composable breadcrumb primitives.
 
-interface BreadcrumbProps {
+interface BreadcrumbRootProps {
   children: React.ReactNode;
   className?: string;
 }
 
-export function Breadcrumb({ children, className }: BreadcrumbProps) {
+export function Breadcrumb({ children, className }: BreadcrumbRootProps) {
   return (
     <nav
       aria-label="Breadcrumb"

--- a/sparkle/src/components/Breadcrumbs.tsx
+++ b/sparkle/src/components/Breadcrumbs.tsx
@@ -271,17 +271,14 @@ function truncateTextToLength(text: string, length: number) {
     : text;
 }
 
-// ---------------------------------------------------------------------------
-// Composable breadcrumb primitives
-// ---------------------------------------------------------------------------
+// Composable breadcrumb primitives.
 
-export function Breadcrumb({
-  children,
-  className,
-}: {
+interface BreadcrumbProps {
   children: React.ReactNode;
   className?: string;
-}) {
+}
+
+export function Breadcrumb({ children, className }: BreadcrumbProps) {
   return (
     <nav
       aria-label="Breadcrumb"
@@ -292,13 +289,12 @@ export function Breadcrumb({
   );
 }
 
-export function BreadcrumbItem({
-  children,
-  className,
-}: {
+interface BreadcrumbItemProps {
   children: React.ReactNode;
   className?: string;
-}) {
+}
+
+export function BreadcrumbItem({ children, className }: BreadcrumbItemProps) {
   return (
     <div className={cn("s-flex s-flex-row s-items-center", className)}>
       {children}
@@ -333,13 +329,12 @@ export function BreadcrumbButton({
   );
 }
 
-export function BreadcrumbPage({
-  children,
-  className,
-}: {
+interface BreadcrumbPageProps {
   children: React.ReactNode;
   className?: string;
-}) {
+}
+
+export function BreadcrumbPage({ children, className }: BreadcrumbPageProps) {
   return (
     <span
       aria-current="page"

--- a/sparkle/src/components/Breadcrumbs.tsx
+++ b/sparkle/src/components/Breadcrumbs.tsx
@@ -2,6 +2,7 @@ import {
   Button,
   type ButtonVariantType,
   ICON_SIZE_MAP,
+  type RegularButtonSize,
 } from "@sparkle/components/Button";
 import {
   DropdownMenu,
@@ -69,25 +70,25 @@ type LabelBreadcrumbItem = BaseBreadcrumbItem & {
   onClick?: never;
 };
 
-export type BreadcrumbItem =
+export type BreadcrumbsItem =
   | LinkBreadcrumbItem
   | ButtonBreadcrumbItem
   | LabelBreadcrumbItem;
 
 const isLinkItem = (
-  item: BreadcrumbItem | { label: string }
+  item: BreadcrumbsItem | { label: string }
 ): item is LinkBreadcrumbItem =>
   "href" in item && typeof item.href === "string";
 
 const isButtonItem = (
-  item: BreadcrumbItem | { label: string }
+  item: BreadcrumbsItem | { label: string }
 ): item is ButtonBreadcrumbItem =>
   "onClick" in item && typeof item.onClick === "function";
 
-interface BreadcrumbItemProps {
-  item: BreadcrumbItem;
+interface BreadcrumbItemRendererProps {
+  item: BreadcrumbsItem;
   isLast: boolean;
-  itemsHidden?: BreadcrumbItem[];
+  itemsHidden?: BreadcrumbsItem[];
   size?: "xs" | "sm";
   buttonVariant?: ButtonVariantType;
   hasLighterFont?: boolean;
@@ -95,7 +96,7 @@ interface BreadcrumbItemProps {
   truncateLengthEnd?: number;
 }
 
-function BreadcrumbItem({
+function BreadcrumbItemRenderer({
   item,
   isLast,
   itemsHidden,
@@ -104,7 +105,7 @@ function BreadcrumbItem({
   hasLighterFont = true,
   truncateLengthMiddle = DEFAULT_LABEL_TRUNCATE_LENGTH_MIDDLE,
   truncateLengthEnd = DEFAULT_LABEL_TRUNCATE_LENGTH_END,
-}: BreadcrumbItemProps) {
+}: BreadcrumbItemRendererProps) {
   if (item.label === ELLIPSIS_STRING) {
     return (
       <DropdownMenu>
@@ -194,7 +195,7 @@ function BreadcrumbItem({
 }
 
 interface BreadcrumbProps {
-  items: BreadcrumbItem[];
+  items: BreadcrumbsItem[];
   className?: string;
   size?: "xs" | "sm";
   buttonVariant?: ButtonVariantType;
@@ -204,8 +205,8 @@ interface BreadcrumbProps {
 }
 
 interface BreadcrumbsAccumulator {
-  itemsShown: BreadcrumbItem[];
-  itemsHidden: BreadcrumbItem[];
+  itemsShown: BreadcrumbsItem[];
+  itemsHidden: BreadcrumbsItem[];
 }
 
 export function Breadcrumbs({
@@ -240,7 +241,7 @@ export function Breadcrumbs({
             key={`breadcrumbs-${index}`}
             className="s-flex s-flex-row s-items-center s-gap-0"
           >
-            <BreadcrumbItem
+            <BreadcrumbItemRenderer
               item={item}
               isLast={index === itemsShown.length - 1}
               itemsHidden={itemsHidden}
@@ -268,4 +269,102 @@ function truncateTextToLength(text: string, length: number) {
   return text.length > length
     ? `${text.substring(0, length - 1)}${ELLIPSIS_STRING}`
     : text;
+}
+
+// ---------------------------------------------------------------------------
+// Composable breadcrumb primitives
+// ---------------------------------------------------------------------------
+
+export function Breadcrumb({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className={cn("s-flex s-flex-row s-items-center s-gap-0", className)}
+    >
+      {children}
+    </nav>
+  );
+}
+
+export function BreadcrumbItem({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn("s-flex s-flex-row s-items-center", className)}>
+      {children}
+    </div>
+  );
+}
+
+interface BreadcrumbButtonProps {
+  label: string;
+  onClick?: () => void;
+  variant?: ButtonVariantType;
+  size?: RegularButtonSize;
+  icon?: ComponentType<{ className?: string }>;
+}
+
+export function BreadcrumbButton({
+  label,
+  onClick,
+  variant = "ghost",
+  size = "sm",
+  icon,
+}: BreadcrumbButtonProps) {
+  return (
+    <Button
+      label={label}
+      onClick={onClick}
+      variant={variant}
+      size={size}
+      icon={icon}
+      hasLighterFont
+    />
+  );
+}
+
+export function BreadcrumbPage({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <span
+      aria-current="page"
+      className={cn(
+        "s-inline-flex s-h-9 s-items-center s-px-3",
+        breadcrumbTextVariants({
+          isLast: true,
+          size: "sm",
+          hasLighterFont: true,
+        }),
+        className
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+export function BreadcrumbSeparator({ className }: { className?: string }) {
+  return (
+    <Icon
+      aria-hidden="true"
+      visual={ChevronRightIcon}
+      className={cn("s-text-faint dark:s-text-faint-night", className)}
+      size="sm"
+    />
+  );
 }

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -14,8 +14,15 @@ export {
 export { AttachmentChip } from "./AttachmentChip";
 export { Avatar } from "./Avatar";
 export { Bar, BarFooter, BarHeader } from "./Bar";
-export type { BreadcrumbItem } from "./Breadcrumbs";
-export { Breadcrumbs } from "./Breadcrumbs";
+export type { BreadcrumbsItem } from "./Breadcrumbs";
+export {
+  Breadcrumb,
+  BreadcrumbButton,
+  BreadcrumbItem,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  Breadcrumbs,
+} from "./Breadcrumbs";
 export type {
   ButtonIconType,
   ButtonProps,


### PR DESCRIPTION
Adds `Breadcrumb`, `BreadcrumbButton`, `BreadcrumbItem`, `BreadcrumbPage`, and `BreadcrumbSeparator` as composable primitives alongside the existing `Breadcrumbs` component. Renames the `BreadcrumbItem` item-type to `BreadcrumbsItem` to free the name for the new component.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
