### PR TITLE
Source per-tool action icons from metadata instead of hardcoded UI

### DIFF
--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -390,9 +390,7 @@ function MCPRunAgentActionDetailsDisplay({
                   />
                   {response && (
                     <>
-                      <CitationsContext.Provider
-                        value={citationsContextValue}
-                      >
+                      <CitationsContext.Provider value={citationsContextValue}>
                         <Markdown
                           content={response}
                           isStreaming={isStreamingResponse}

--- a/front/components/assistant/conversation/actions/inline/utils.ts
+++ b/front/components/assistant/conversation/actions/inline/utils.ts
@@ -1,9 +1,10 @@
 import { InternalActionIcons } from "@app/components/resources/resources_icons";
 import {
   getInternalMCPServerIconByName,
+  getInternalMCPServerToolIcon,
   type InternalMCPServerNameType,
 } from "@app/lib/actions/mcp_internal_actions/constants";
-import { GlobeAltIcon, ToolsIcon } from "@dust-tt/sparkle";
+import { ToolsIcon } from "@dust-tt/sparkle";
 import type React from "react";
 
 export function getCollapseAnimationStyle(
@@ -22,16 +23,13 @@ export function getActionStepIcon(step: {
   internalMCPServerName: InternalMCPServerNameType | null;
   toolName: string | null;
 }): React.ComponentType<{ className?: string }> {
-  if (
-    step.internalMCPServerName === "sandbox" &&
-    step.toolName === "add_egress_domain"
-  ) {
-    return GlobeAltIcon;
-  }
   if (step.internalMCPServerName) {
-    return InternalActionIcons[
-      getInternalMCPServerIconByName(step.internalMCPServerName)
-    ];
+    const toolIcon = step.toolName
+      ? getInternalMCPServerToolIcon(step.internalMCPServerName, step.toolName)
+      : null;
+    const iconName =
+      toolIcon ?? getInternalMCPServerIconByName(step.internalMCPServerName);
+    return InternalActionIcons[iconName];
   }
   return ToolsIcon;
 }

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1345,6 +1345,14 @@ export function getInternalMCPServerIconByName(
   return server.metadata.serverInfo.icon;
 }
 
+export function getInternalMCPServerToolIcon(
+  serverName: InternalMCPServerNameType,
+  toolName: string
+): InternalAllowedIconType | null {
+  const labels = getInternalMCPServerToolDisplayLabels(serverName);
+  return labels?.[toolName]?.icon ?? null;
+}
+
 export function getInternalMCPServerDisplayedAs(
   toolServerId: string
 ): "agent" | "server" | undefined {

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -92,6 +92,7 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Requesting Computer network access",
       done: "Allow domain in the Computer",
+      icon: "ActionGlobeAltIcon",
     },
   },
 });

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -49,6 +49,7 @@ export function getRetryPolicyFromToolConfiguration(
 export type ToolDisplayLabels = {
   running: string; // e.g. "Searching data"
   done: string; // e.g. "Search data"
+  icon?: InternalAllowedIconType; // optional per-tool icon override
 };
 
 export type MCPToolType = {

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -17,13 +17,13 @@ import {
   checkProgrammaticUsageLimits,
   isProgrammaticUsage,
 } from "@app/lib/api/programmatic_usage/tracking";
-import { isApiBlocked } from "@app/lib/metronome/user_block";
 import {
   addBackwardCompatibleConversationFields,
   addBackwardCompatibleConversationWithoutContentFields,
   normalizeConversationVisibility,
 } from "@app/lib/api/v1/backward_compatibility";
 import type { Authenticator } from "@app/lib/auth";
+import { isApiBlocked } from "@app/lib/metronome/user_block";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";


### PR DESCRIPTION
## Description

The inline activity timeline had a hardcoded special case for sandbox/add_egress_domain to show a globe icon. This moves that configuration to where it belongs: the tool's own metadata.

ToolDisplayLabels gets an optional icon field. add_egress_domain sets it to "ActionGlobeAltIcon". A new getInternalMCPServerToolIcon helper reads it, and getActionStepIcon checks it before falling back to the server-level icon.

No behavior change.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front