### PR TITLE
feat: rename pod conversations components

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -17,7 +17,7 @@ import {
   isUserMessage,
 } from "@app/components/assistant/conversation/types";
 import { WakeUpBanner } from "@app/components/assistant/conversation/WakeUpBanner";
-import { ProjectJoinCTA } from "@app/components/spaces/ProjectJoinCTA";
+import { PodJoinCTA } from "@app/components/pod/conversation/PodJoinCTA";
 import {
   useCancelMessage,
   useConversation,
@@ -395,10 +395,10 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
   ) {
     return (
       <div className="relative z-20 mx-auto flex max-h-dvh w-full flex-col py-4 sm:w-full sm:max-w-conversation">
-        <ProjectJoinCTA
+        <PodJoinCTA
           owner={context.owner}
-          spaceId={context.projectId}
-          spaceName={context.projectSpaceName}
+          podId={context.projectId}
+          podName={context.projectSpaceName}
           isRestricted={context.isProjectRestricted ?? false}
           userName={context.user.fullName}
         />

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -15,7 +15,7 @@ import { useAuth } from "@app/lib/auth/AuthContext";
 import { useClientType } from "@app/lib/context/clientType";
 import { clientFetch } from "@app/lib/egress/client";
 import { useFileContent, useFileMetadata } from "@app/lib/swr/files";
-import { useProjectFiles } from "@app/lib/swr/pods";
+import { usePodFiles } from "@app/lib/swr/pods";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
@@ -98,9 +98,9 @@ export function FrameRenderer({
     return "saved";
   }, [conversation?.spaceId, projectId, projectInfo, isSpaceInfoLoading]);
 
-  const { files: projectFiles } = useProjectFiles({
+  const { files: projectFiles } = usePodFiles({
     owner,
-    spaceId: projectId ?? "",
+    podId: projectId ?? "",
     disabled: !isFrameInPod,
   });
 

--- a/front/components/assistant/conversation/space/PinPodBannerButton.tsx
+++ b/front/components/assistant/conversation/space/PinPodBannerButton.tsx
@@ -25,7 +25,7 @@ export function PinPodBannerButton({
   const isMobile = useIsMobile();
   const { togglePin, isPinned } = usePinPodBanner({
     owner,
-    spaceId,
+    podId: spaceId,
     pinnedFramePath,
     isEditor,
   });

--- a/front/components/assistant/conversation/space/ProjectFileExplorer.tsx
+++ b/front/components/assistant/conversation/space/ProjectFileExplorer.tsx
@@ -31,8 +31,8 @@ import { useMoveMountFile } from "@app/lib/swr/mount_files";
 import {
   useAddProjectContextContentNodes,
   useDeleteProjectFile,
+  usePodFiles,
   useProjectContextAttachments,
-  useProjectFiles,
   useRemoveProjectContextContentNodes,
 } from "@app/lib/swr/pods";
 import { useSpaceDataSourceViews, useSpaces } from "@app/lib/swr/spaces";
@@ -266,7 +266,7 @@ function ProjectFileExplorerContent({
   const isEditor = space.isEditor;
   const { togglePin, isPinned } = usePinPodBanner({
     owner,
-    spaceId: space.sId,
+    podId: space.sId,
     pinnedFramePath: space.pinnedFramePath ?? null,
     isEditor,
   });
@@ -326,11 +326,11 @@ function ProjectFileExplorerContent({
 
   const {
     files: projectGCSFiles,
-    isProjectFilesLoading,
-    refreshProjectFiles,
-  } = useProjectFiles({
+    isPodFilesLoading: isProjectFilesLoading,
+    refreshPodFiles: refreshProjectFiles,
+  } = usePodFiles({
     owner,
-    spaceId: space.sId,
+    podId: space.sId,
   });
 
   const refreshProjectKnowledge = useCallback(async () => {

--- a/front/components/pages/pod/PodPage.tsx
+++ b/front/components/pages/pod/PodPage.tsx
@@ -1,9 +1,9 @@
 import { SpaceAboutTab } from "@app/components/assistant/conversation/space/about/SpaceAboutTab";
 import type { TaskOwnerFilter } from "@app/components/assistant/conversation/space/conversations/project_tasks/projectTasksListScope";
-import { SpaceConversationsTab } from "@app/components/assistant/conversation/space/conversations/SpaceConversationsTab";
 import { ManageUsersPanel } from "@app/components/assistant/conversation/space/ManageUsersPanel";
 import { SpaceKnowledgeTab } from "@app/components/assistant/conversation/space/SpaceKnowledgeTab";
 import { SpaceTasksTab } from "@app/components/assistant/conversation/space/SpaceTasksTab";
+import { PodConversationsTab } from "@app/components/pod/conversation/PodConversationsTab";
 import { PodHeaderActions } from "@app/components/pod/PodHeaderActions";
 import {
   type PodConversationListFilter,
@@ -90,7 +90,7 @@ export function PodPage() {
     isConversationsLoading,
     mutateConversations,
     hasMore,
-    isEmpty: isSpaceEmpty,
+    isEmpty: isPodEmpty,
     loadMore,
     isLoadingMore,
   } = usePodConversations({
@@ -266,7 +266,7 @@ export function PodPage() {
   if (clientType === "extension") {
     return (
       <div className="flex h-full w-full flex-col">
-        <SpaceConversationsTab
+        <PodConversationsTab
           owner={owner}
           user={user}
           conversations={conversations}
@@ -274,8 +274,8 @@ export function PodPage() {
           hasMore={hasMore}
           loadMore={loadMore}
           isLoadingMore={isLoadingMore}
-          spaceInfo={podInfo}
-          isSpaceEmpty={isSpaceEmpty}
+          podInfo={podInfo}
+          isPodEmpty={isPodEmpty}
           conversationFilter={conversationFilter}
           onConversationFilterChange={handleConversationFilterChange}
           onSubmit={handleConversationCreation}
@@ -336,7 +336,7 @@ export function PodPage() {
         </div>
 
         <TabsContent value="conversations">
-          <SpaceConversationsTab
+          <PodConversationsTab
             owner={owner}
             user={user}
             conversations={conversations}
@@ -344,8 +344,8 @@ export function PodPage() {
             hasMore={hasMore}
             loadMore={loadMore}
             isLoadingMore={isLoadingMore}
-            spaceInfo={podInfo}
-            isSpaceEmpty={isSpaceEmpty}
+            podInfo={podInfo}
+            isPodEmpty={isPodEmpty}
             conversationFilter={conversationFilter}
             onConversationFilterChange={handleConversationFilterChange}
             onSubmit={handleConversationCreation}

--- a/front/components/pod/conversation/PodConversationListItem.tsx
+++ b/front/components/pod/conversation/PodConversationListItem.tsx
@@ -1,3 +1,5 @@
+import { isHiddenMessage } from "@app/components/assistant/conversation/types";
+import { isMessageUnread } from "@app/components/assistant/conversation/utils";
 import { useAppRouter } from "@app/lib/platform";
 import { getConversationRoute } from "@app/lib/utils/router";
 import {
@@ -16,18 +18,16 @@ import { ConversationListItem, ReplySection } from "@dust-tt/sparkle";
 import uniqBy from "lodash/uniqBy";
 import moment from "moment";
 import { useMemo } from "react";
-import { isHiddenMessage } from "../../types";
-import { isMessageUnread } from "../../utils";
 
-interface SpaceConversationListItemProps {
+interface PodConversationListItemProps {
   conversation: LightConversationType;
   owner: WorkspaceType;
 }
 
-export function SpaceConversationListItem({
+export function PodConversationListItem({
   conversation,
   owner,
-}: SpaceConversationListItemProps) {
+}: PodConversationListItemProps) {
   const router = useAppRouter();
 
   const validMessages = conversation.content.filter((message) => {

--- a/front/components/pod/conversation/PodConversationsActions.tsx
+++ b/front/components/pod/conversation/PodConversationsActions.tsx
@@ -4,21 +4,21 @@ import { Card, CardGrid, CheckIcon, Icon, Spinner } from "@dust-tt/sparkle";
 
 interface SpaceConversationsActionsProps {
   owner: LightWorkspaceType;
-  spaceId: string;
+  podId: string;
   isEditor: boolean;
   onOpenMembersPanel: () => void;
   onNavigateToTasks: () => void;
 }
 
-export function SpaceConversationsActions({
+export function PodConversationsActions({
   owner,
-  spaceId,
+  podId,
   isEditor,
   onNavigateToTasks,
 }: SpaceConversationsActionsProps) {
   const { seedInitialPodTasks, isSeeding } = useSeedInitialPodTasks({
     owner,
-    spaceId,
+    podId: podId,
   });
 
   const handleOnboardingClick = async () => {

--- a/front/components/pod/conversation/PodConversationsTab.tsx
+++ b/front/components/pod/conversation/PodConversationsTab.tsx
@@ -1,16 +1,16 @@
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
-import { SpaceConversationListItem } from "@app/components/assistant/conversation/space/conversations/SpaceConversationListItem";
-import { SpaceConversationsActions } from "@app/components/assistant/conversation/space/conversations/SpaceConversationsActions";
-import { SpaceLoadingConversationListItem } from "@app/components/assistant/conversation/space/conversations/SpaceLoadingConversationListItem";
-import { PodPinnedBanner } from "@app/components/assistant/conversation/space/PodPinnedBanner";
 import { getGroupConversationsByDate } from "@app/components/assistant/conversation/utils";
 import { InfiniteScroll } from "@app/components/InfiniteScroll";
 import { DropzoneContainer } from "@app/components/misc/DropzoneContainer";
-import { ProjectJoinCTA } from "@app/components/spaces/ProjectJoinCTA";
+import { PodConversationListItem } from "@app/components/pod/conversation/PodConversationListItem";
+import { PodConversationsActions } from "@app/components/pod/conversation/PodConversationsActions";
+import { PodJoinCTA } from "@app/components/pod/conversation/PodJoinCTA";
+import { PodLoadingConversationListItem } from "@app/components/pod/conversation/PodLoadingConversationListItem";
+import { PodPinnedBanner } from "@app/components/pod/conversation/PodPinnedBanner";
 import { usePodUnreadConversationIds } from "@app/hooks/conversations";
 import type { PodConversationListFilter } from "@app/hooks/conversations/usePodConversations";
 import { useMarkAllConversationsAsRead } from "@app/hooks/useMarkAllConversationsAsRead";
-import { useSearchConversations } from "@app/hooks/useSearchConversations";
+import { useSearchPodConversations } from "@app/hooks/useSearchPodConversations";
 import { getRandomGreetingForName } from "@app/lib/client/greetings";
 import { useAppRouter } from "@app/lib/platform";
 import { getConversationRoute } from "@app/lib/utils/router";
@@ -49,7 +49,7 @@ type GroupLabel =
   | "Last 12 Months"
   | "Older";
 
-interface SpaceConversationsTabProps {
+interface PodConversationsTabProps {
   owner: WorkspaceType;
   user: UserType;
   conversations: LightConversationType[];
@@ -57,8 +57,8 @@ interface SpaceConversationsTabProps {
   hasMore: boolean;
   loadMore: () => void;
   isLoadingMore: boolean;
-  spaceInfo: GetSpaceResponseBody["space"];
-  isSpaceEmpty: boolean;
+  podInfo: GetSpaceResponseBody["space"];
+  isPodEmpty: boolean;
   conversationFilter: PodConversationListFilter;
   onConversationFilterChange: (filter: PodConversationListFilter) => void;
   onSubmit: (
@@ -71,7 +71,7 @@ interface SpaceConversationsTabProps {
   onNavigateToTasks: () => void;
 }
 
-export function SpaceConversationsTab({
+export function PodConversationsTab({
   owner,
   user,
   conversations,
@@ -79,25 +79,25 @@ export function SpaceConversationsTab({
   hasMore,
   loadMore,
   isLoadingMore,
-  spaceInfo,
-  isSpaceEmpty,
+  podInfo,
+  isPodEmpty,
   conversationFilter,
   onConversationFilterChange,
   onSubmit,
   onOpenMembersPanel,
   onNavigateToTasks,
-}: SpaceConversationsTabProps) {
-  const { isEditor: isProjectEditor } = spaceInfo;
+}: PodConversationsTabProps) {
+  const { isEditor } = podInfo;
   const router = useAppRouter();
   const hasHistory = useMemo(() => conversations.length > 0, [conversations]);
 
   const { markAllAsRead, isMarkingAllAsRead } = useMarkAllConversationsAsRead({
     owner,
-    spaceId: spaceInfo.sId,
+    podId: podInfo.sId,
   });
   const { unreadConversationIds } = usePodUnreadConversationIds({
     workspaceId: owner.sId,
-    podId: spaceInfo.sId,
+    podId: podInfo.sId,
   });
 
   const [isSearchPopoverOpen, setIsSearchPopoverOpen] = useState(false);
@@ -119,9 +119,9 @@ export function SpaceConversationsTab({
     isSearchError,
     inputValue: searchText,
     setValue: setSearchText,
-  } = useSearchConversations({
+  } = useSearchPodConversations({
     workspaceId: owner.sId,
-    spaceId: spaceInfo.sId,
+    podId: podInfo.sId,
     limit: 10,
     initialSearchText: "",
   });
@@ -151,12 +151,10 @@ export function SpaceConversationsTab({
   const [greeting, setGreeting] = useState<string>("");
   useEffect(() => {
     setGreeting(getRandomGreetingForName(user.firstName));
-  }, [user]);
+  }, [user.firstName]);
 
-  const isProjectEmpty = !isConversationsLoading && isSpaceEmpty;
-  const isFilteredEmpty =
-    !isConversationsLoading && !isSpaceEmpty && !hasHistory;
-  const isSingleMemberProject = spaceInfo.members.length === 1;
+  const isFilteredEmpty = !isConversationsLoading && !isPodEmpty && !hasHistory;
+  const isSingleMemberPod = podInfo.members.length === 1;
 
   return (
     <div className="flex h-full min-h-0 w-full flex-1 flex-col overflow-y-auto px-6">
@@ -167,59 +165,59 @@ export function SpaceConversationsTab({
         <div
           className={cn(
             "mx-auto flex w-full max-w-4xl flex-col gap-3 py-8",
-            isProjectEmpty && "h-full justify-center py-8"
+            isPodEmpty && "h-full justify-center py-8"
           )}
         >
           <div className="flex w-full flex-col gap-3">
-            <PodPinnedBanner owner={owner} spaceInfo={spaceInfo} />
+            <PodPinnedBanner owner={owner} podInfo={podInfo} />
             <div className="flex items-center gap-2">
               <h2
                 className={cn(
                   "heading-2xl text-foreground dark:text-foreground-night",
-                  spaceInfo.archivedAt &&
+                  podInfo.archivedAt &&
                     "text-muted-foreground dark:text-muted-foreground-night"
                 )}
               >
                 {greeting}
               </h2>
-              {spaceInfo.archivedAt && (
+              {podInfo.archivedAt && (
                 <Chip size="xs" color="rose" label="Archived" />
               )}
             </div>
-            {spaceInfo.archivedAt ? (
+            {podInfo.archivedAt ? (
               <div className="mx-auto flex flex-col w-full py-4 sm:max-w-conversation">
                 <EmptyCTA
                   message="This Pod is archived and no longer appears in your sidebar. You can still search for it and view past conversations, but you cannot start new ones."
                   action={null}
                 />
               </div>
-            ) : spaceInfo.isMember ? (
+            ) : podInfo.isMember ? (
               <InputBar
                 owner={owner}
                 user={user}
                 onSubmit={onSubmit}
-                draftKey={`space-${spaceInfo.sId}-new-conversation`}
-                space={spaceInfo}
+                draftKey={`space-${podInfo.sId}-new-conversation`}
+                space={podInfo}
                 disableAutoFocus={false}
-                placeholder={`Get work done in ${spaceInfo.name}`}
+                placeholder={`Get work done in ${podInfo.name}`}
               />
             ) : (
-              <ProjectJoinCTA
+              <PodJoinCTA
                 owner={owner}
-                spaceId={spaceInfo.sId}
-                spaceName={spaceInfo.name}
-                isRestricted={spaceInfo.isRestricted}
+                podId={podInfo.sId}
+                podName={podInfo.name}
+                isRestricted={podInfo.isRestricted}
                 userName={user.fullName}
               />
             )}
           </div>
 
           {/* Suggestions for empty rooms */}
-          {isProjectEmpty ? (
-            <SpaceConversationsActions
+          {isPodEmpty ? (
+            <PodConversationsActions
               owner={owner}
-              spaceId={spaceInfo.sId}
-              isEditor={isProjectEditor}
+              podId={podInfo.sId}
+              isEditor={isEditor}
               onOpenMembersPanel={onOpenMembersPanel}
               onNavigateToTasks={onNavigateToTasks}
             />
@@ -233,7 +231,7 @@ export function SpaceConversationsTab({
                       name="conversation-search"
                       value={searchText}
                       onChange={setSearchText}
-                      placeholder={`Search in ${spaceInfo.name}`}
+                      placeholder={`Search in ${podInfo.name}`}
                       open={isSearchPopoverOpen && searchText.trim().length > 0}
                       onOpenChange={setIsSearchPopoverOpen}
                       items={searchResults}
@@ -277,7 +275,7 @@ export function SpaceConversationsTab({
                   </div>
                 </div>
                 <div className="flex flex-row items-center justify-between gap-3">
-                  {!isSingleMemberProject && (
+                  {!isSingleMemberPod && (
                     <ButtonsSwitchList
                       key={conversationFilter}
                       defaultValue={conversationFilter}
@@ -321,7 +319,7 @@ export function SpaceConversationsTab({
                       </ListItemSection>
                       <ListGroup>
                         {Array.from({ length: 6 }).map((_, index) => (
-                          <SpaceLoadingConversationListItem key={index} />
+                          <PodLoadingConversationListItem key={index} />
                         ))}
                       </ListGroup>
                     </>
@@ -347,7 +345,7 @@ export function SpaceConversationsTab({
                             {dateConversations
                               .toSorted((a, b) => b.updated - a.updated)
                               .map((conversation) => (
-                                <SpaceConversationListItem
+                                <PodConversationListItem
                                   key={conversation.sId}
                                   conversation={conversation}
                                   owner={owner}

--- a/front/components/pod/conversation/PodJoinCTA.tsx
+++ b/front/components/pod/conversation/PodJoinCTA.tsx
@@ -1,25 +1,25 @@
-import { useJoinProject } from "@app/lib/swr/spaces";
+import { useJoinPod } from "@app/lib/swr/pods";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Button, EmptyCTA } from "@dust-tt/sparkle";
 import { useState } from "react";
 
-interface ProjectJoinCTAProps {
+interface PodJoinCTAProps {
   owner: LightWorkspaceType;
-  spaceId: string;
-  spaceName: string;
+  podId: string;
+  podName: string;
   isRestricted: boolean;
   userName: string;
 }
 
-export function ProjectJoinCTA({
+export function PodJoinCTA({
   owner,
-  spaceId,
-  spaceName,
+  podId: podId,
+  podName: podName,
   isRestricted,
   userName,
-}: ProjectJoinCTAProps) {
+}: PodJoinCTAProps) {
   const [isJoining, setIsJoining] = useState(false);
-  const doJoin = useJoinProject({ owner, spaceId, spaceName, userName });
+  const doJoin = useJoinPod({ owner, podId, podName, userName });
 
   const handleJoin = async () => {
     setIsJoining(true);
@@ -35,7 +35,7 @@ export function ProjectJoinCTA({
 
   const action = isRestricted ? null : (
     <Button
-      label={isJoining ? "Joining..." : `Join the ${spaceName} Pod`}
+      label={isJoining ? "Joining..." : `Join the ${podName} Pod`}
       variant="highlight"
       onClick={handleJoin}
       disabled={isJoining}

--- a/front/components/pod/conversation/PodLoadingConversationListItem.tsx
+++ b/front/components/pod/conversation/PodLoadingConversationListItem.tsx
@@ -1,6 +1,6 @@
 import { LoadingBlock } from "@dust-tt/sparkle";
 
-export function SpaceLoadingConversationListItem() {
+export function PodLoadingConversationListItem() {
   return (
     <div className="flex flex-row gap-4 py-2">
       <LoadingBlock className="h-[36px] w-[36px] rounded-full" />

--- a/front/components/pod/conversation/PodPinnedBanner.tsx
+++ b/front/components/pod/conversation/PodPinnedBanner.tsx
@@ -3,7 +3,7 @@ import { usePinPodBanner } from "@app/hooks/usePinPodBanner";
 import { useScopedPodUiPreferences } from "@app/hooks/useScopedUIPreferences";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { useFileContent } from "@app/lib/swr/files";
-import { useProjectFiles } from "@app/lib/swr/pods";
+import { usePodFiles } from "@app/lib/swr/pods";
 import logger from "@app/logger/logger";
 import type { RichSpaceType } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
 import type { WorkspaceType } from "@app/types/user";
@@ -26,18 +26,18 @@ const DEFAULT_POD_PINNED_BANNER_PREFERENCES = {
 
 interface PodPinnedBannerProps {
   owner: WorkspaceType;
-  spaceInfo: RichSpaceType;
+  podInfo: RichSpaceType;
 }
 
 function PodPinnedBannerFrame({
   owner,
-  spaceId,
+  podId,
   fileId,
   fileContent,
   vizUrl,
 }: {
   owner: WorkspaceType;
-  spaceId: string;
+  podId: string;
   fileId: string;
   fileContent: string;
   vizUrl: string;
@@ -55,7 +55,7 @@ function PodPinnedBannerFrame({
         identifier: `viz-banner-${fileId}`,
       }}
       conversationId={null}
-      spaceId={spaceId}
+      spaceId={podId}
       isInDrawer={true}
       ref={iframeRef}
     />
@@ -149,14 +149,14 @@ function PodPinnedBannerCollapsedAffordance({
   );
 }
 
-export function PodPinnedBanner({ owner, spaceInfo }: PodPinnedBannerProps) {
+export function PodPinnedBanner({ owner, podInfo }: PodPinnedBannerProps) {
   const { vizUrl } = useAuth();
-  const pinnedFramePath = spaceInfo.pinnedFramePath;
+  const pinnedFramePath = podInfo.pinnedFramePath;
 
   const { value: bannerPreferences, setValue: setBannerPreferences } =
     useScopedPodUiPreferences({
       scope: "podPinnedBanner",
-      resourceId: spaceInfo.sId,
+      resourceId: podInfo.sId,
       defaultValue: DEFAULT_POD_PINNED_BANNER_PREFERENCES,
     });
   const isCollapsed = bannerPreferences.collapsed;
@@ -172,14 +172,14 @@ export function PodPinnedBanner({ owner, spaceInfo }: PodPinnedBannerProps) {
 
   const { unpinFrame } = usePinPodBanner({
     owner,
-    spaceId: spaceInfo.sId,
-    pinnedFramePath: spaceInfo.pinnedFramePath ?? null,
-    isEditor: spaceInfo.isEditor,
+    podId: podInfo.sId,
+    pinnedFramePath: podInfo.pinnedFramePath ?? null,
+    isEditor: podInfo.isEditor,
   });
 
-  const { files: projectFiles, isProjectFilesLoading } = useProjectFiles({
+  const { files: podFiles, isPodFilesLoading } = usePodFiles({
     owner,
-    spaceId: spaceInfo.sId,
+    podId: podInfo.sId,
     disabled: !pinnedFramePath,
   });
 
@@ -188,11 +188,11 @@ export function PodPinnedBanner({ owner, spaceInfo }: PodPinnedBannerProps) {
       return null;
     }
     return (
-      projectFiles.find(
+      podFiles.find(
         (f) => !f.isDirectory && f.path === pinnedFramePath && f.fileId
       ) ?? null
     );
-  }, [pinnedFramePath, projectFiles]);
+  }, [pinnedFramePath, podFiles]);
 
   const fileId =
     pinnedFile && !pinnedFile.isDirectory ? pinnedFile.fileId : null;
@@ -200,21 +200,21 @@ export function PodPinnedBanner({ owner, spaceInfo }: PodPinnedBannerProps) {
   useEffect(() => {
     if (
       pinnedFramePath &&
-      !isProjectFilesLoading &&
-      projectFiles.length > 0 &&
+      !isPodFilesLoading &&
+      podFiles.length > 0 &&
       !fileId
     ) {
       logger.warn(
-        { spaceId: spaceInfo.sId, pinnedFramePath },
+        { spaceId: podInfo.sId, pinnedFramePath },
         "Pinned Pod banner file not found; skipping render."
       );
     }
   }, [
     fileId,
-    isProjectFilesLoading,
+    isPodFilesLoading,
     pinnedFramePath,
-    projectFiles.length,
-    spaceInfo.sId,
+    podFiles.length,
+    podInfo.sId,
   ]);
 
   const { fileContent } = useFileContent({
@@ -249,7 +249,7 @@ export function PodPinnedBanner({ owner, spaceInfo }: PodPinnedBannerProps) {
     return null;
   }
 
-  if (isProjectFilesLoading || (fileId && !fileContent)) {
+  if (isPodFilesLoading || (fileId && !fileContent)) {
     return (
       <div
         className="mb-4 flex h-16 items-center justify-center rounded-xl bg-muted-background dark:bg-muted-background-night"
@@ -264,14 +264,14 @@ export function PodPinnedBanner({ owner, spaceInfo }: PodPinnedBannerProps) {
 
   const frameProps = {
     owner,
-    spaceId: spaceInfo.sId,
+    podId: podInfo.sId,
     fileId,
     fileContent,
     vizUrl,
   };
 
   const controlsProps = {
-    isEditor: spaceInfo.isEditor,
+    isEditor: podInfo.isEditor,
     onHide: hideBanner,
     onUnpin: handleUnpin,
     onToggleFullscreen: () => setIsFullscreen((prev) => !prev),

--- a/front/hooks/conversations/usePodConversations.ts
+++ b/front/hooks/conversations/usePodConversations.ts
@@ -136,9 +136,7 @@ export function usePodUnreadConversationIds({
     fetcher;
 
   const { data, isLoading, mutate } = useSWRWithDefaults(
-    podId
-      ? `/api/w/${workspaceId}/assistant/conversations/spaces/${podId}/unread`
-      : null,
+    `/api/w/${workspaceId}/assistant/conversations/spaces/${podId}/unread`,
     conversationsFetcher,
     {
       disabled: options?.disabled ?? !podId,

--- a/front/hooks/useMarkAllConversationsAsRead.ts
+++ b/front/hooks/useMarkAllConversationsAsRead.ts
@@ -11,12 +11,12 @@ import { useCallback, useState } from "react";
 
 interface useMarkAllConversationsAsReadParams {
   owner: WorkspaceType;
-  spaceId?: string;
+  podId?: string;
 }
 
 export function useMarkAllConversationsAsRead({
   owner,
-  spaceId,
+  podId,
 }: useMarkAllConversationsAsReadParams) {
   const [isMarkingAllAsRead, setIsMarkingAllAsRead] = useState(false);
   const sendNotification = useSendNotification();
@@ -25,21 +25,21 @@ export function useMarkAllConversationsAsRead({
     options: { disabled: true },
   });
 
-  const { mutate: mutateSpaceSummary } = usePodConversationsSummary({
+  const { mutate: mutatePodSummary } = usePodConversationsSummary({
     workspaceId: owner.sId,
     options: { disabled: true },
   });
 
-  const { mutateConversations: mutateSpaceConversations } = usePodConversations(
-    {
-      workspaceId: owner.sId,
-      podId: spaceId ?? null,
-    }
-  );
+  const { mutateConversations: mutatePodConversations } = usePodConversations({
+    workspaceId: owner.sId,
+    podId: podId ?? null,
+    options: { disabled: true },
+  });
 
   const { mutateUnreadConversationIds } = usePodUnreadConversationIds({
     workspaceId: owner.sId,
-    podId: spaceId ?? null,
+    podId: podId ?? null,
+    options: { disabled: true },
   });
 
   const markAllAsRead = useCallback(
@@ -94,8 +94,8 @@ export function useMarkAllConversationsAsRead({
           throw new Error("Failed to mark conversations as read");
         }
 
-        void mutateSpaceSummary();
-        void mutateSpaceConversations();
+        void mutatePodSummary();
+        void mutatePodConversations();
         void mutateUnreadConversationIds();
 
         sendNotification({
@@ -118,8 +118,8 @@ export function useMarkAllConversationsAsRead({
     [
       owner.sId,
       mutateConversations,
-      mutateSpaceSummary,
-      mutateSpaceConversations,
+      mutatePodSummary,
+      mutatePodConversations,
       sendNotification,
       mutateUnreadConversationIds,
     ]

--- a/front/hooks/usePinPodBanner.ts
+++ b/front/hooks/usePinPodBanner.ts
@@ -9,19 +9,19 @@ type PinPodBannerOptions = {
 
 export function usePinPodBanner({
   owner,
-  spaceId,
+  podId: podId,
   pinnedFramePath,
   isEditor,
 }: {
   owner: LightWorkspaceType;
-  spaceId: string;
+  podId: string;
   pinnedFramePath: string | null;
   isEditor: boolean;
 }) {
   const confirm = useContext(ConfirmContext);
   const updateProjectMetadata = useUpdateProjectMetadata({
     owner,
-    spaceId,
+    spaceId: podId,
   });
 
   const pinFrame = useCallback(

--- a/front/hooks/useSearchPodConversations.ts
+++ b/front/hooks/useSearchPodConversations.ts
@@ -6,21 +6,21 @@ import { useMemo } from "react";
 import type { Fetcher } from "swr";
 import useSWR from "swr";
 
-interface UseSearchConversationsParams {
+interface UseSearchPodConversationsParams {
   workspaceId: string;
-  spaceId: string;
+  podId: string;
   limit?: number;
   enabled?: boolean;
   initialSearchText?: string;
 }
 
-export function useSearchConversations({
+export function useSearchPodConversations({
   workspaceId,
-  spaceId,
+  podId,
   limit = 10,
   enabled = true,
   initialSearchText = "",
-}: UseSearchConversationsParams) {
+}: UseSearchPodConversationsParams) {
   const { fetcher } = useFetcher();
   const {
     debouncedValue: debouncedQuery,
@@ -37,12 +37,12 @@ export function useSearchConversations({
       enabled &&
       debouncedQuery.trim().length > 0 &&
       workspaceId &&
-      spaceId
+      podId
     );
-  }, [enabled, debouncedQuery, workspaceId, spaceId]);
+  }, [enabled, debouncedQuery, workspaceId, podId]);
 
   const searchKey = shouldFetch
-    ? `/api/w/${workspaceId}/spaces/${spaceId}/search_conversations?query=${encodeURIComponent(debouncedQuery)}&limit=${limit}`
+    ? `/api/w/${workspaceId}/spaces/${podId}/search_conversations?query=${encodeURIComponent(debouncedQuery)}&limit=${limit}`
     : null;
 
   const searchFetcher: Fetcher<SearchConversationsResponseBody> = fetcher;

--- a/front/lib/swr/pods.ts
+++ b/front/lib/swr/pods.ts
@@ -89,13 +89,13 @@ export function useProjectContextAttachments({
   };
 }
 
-export function useProjectFiles({
+export function usePodFiles({
   owner,
-  spaceId,
+  podId,
   disabled,
 }: {
   owner: LightWorkspaceType;
-  spaceId: string;
+  podId: string;
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
@@ -103,24 +103,22 @@ export function useProjectFiles({
 
   const { data, error, mutate, mutateRegardlessOfQueryParams } =
     useSWRWithDefaults(
-      disabled || !spaceId
-        ? null
-        : `/api/w/${owner.sId}/spaces/${spaceId}/files`,
+      disabled || !podId ? null : `/api/w/${owner.sId}/spaces/${podId}/files`,
       projectFilesFetcher,
       { keepPreviousData: true }
     );
 
-  const refreshProjectFiles = useCallback(async () => {
+  const refreshPodFiles = useCallback(async () => {
     // Do not pass `undefined` as data — it clears the cache and causes UI flicker.
     await mutateRegardlessOfQueryParams();
   }, [mutateRegardlessOfQueryParams]);
 
   return {
     files: data?.files ?? emptyArray<GCSMountEntry>(),
-    isProjectFilesLoading: !disabled && !error && !data,
-    isProjectFilesError: !!error,
-    mutateProjectFiles: mutate,
-    refreshProjectFiles,
+    isPodFilesLoading: !disabled && !error && !data,
+    isPodFilesError: !!error,
+    mutatePodFiles: mutate,
+    refreshPodFiles,
   };
 }
 
@@ -609,10 +607,10 @@ export function useMarkProjectTasksRead({
 
 export function useSeedInitialPodTasks({
   owner,
-  spaceId,
+  podId,
 }: {
   owner: LightWorkspaceType;
-  spaceId: string;
+  podId: string;
 }) {
   const sendNotification = useSendNotification();
   const { mutate } = useSWRConfig();
@@ -624,14 +622,12 @@ export function useSeedInitialPodTasks({
     setIsSeeding(true);
     try {
       const res = await clientFetch(
-        `/api/w/${owner.sId}/pods/${spaceId}/tasks/seed`,
+        `/api/w/${owner.sId}/pods/${podId}/tasks/seed`,
         { method: "POST" }
       );
 
       if (res.status === 409) {
-        await mutate((key) =>
-          isProjectTasksListSwrKey(key, owner.sId, spaceId)
-        );
+        await mutate((key) => isProjectTasksListSwrKey(key, owner.sId, podId));
         return new Ok([]);
       }
 
@@ -647,7 +643,7 @@ export function useSeedInitialPodTasks({
 
       const responseData: PostSeedInitialPodTasksResponseBody =
         await res.json();
-      await mutate((key) => isProjectTasksListSwrKey(key, owner.sId, spaceId));
+      await mutate((key) => isProjectTasksListSwrKey(key, owner.sId, podId));
       return new Ok(responseData.tasks);
     } catch (e) {
       const errorMessage = normalizeError(e).message;
@@ -660,7 +656,7 @@ export function useSeedInitialPodTasks({
     } finally {
       setIsSeeding(false);
     }
-  }, [mutate, owner.sId, sendNotification, spaceId]);
+  }, [mutate, owner.sId, sendNotification, podId]);
 
   return { seedInitialPodTasks, isSeeding };
 }
@@ -934,6 +930,56 @@ export function useWorkspaceProjectTask({
     isWorkspaceProjectTaskError: !!error,
     mutateWorkspaceProjectTask: mutate,
   };
+}
+
+export function useJoinPod({
+  owner,
+  podId: podId,
+  podName,
+  userName,
+}: {
+  owner: LightWorkspaceType;
+  podId: string;
+  podName: string;
+  userName: string;
+}) {
+  const sendNotification = useSendNotification();
+  const { mutateSpaceInfoRegardlessOfQueryParams } = useSpaceInfo({
+    workspaceId: owner.sId,
+    spaceId: podId,
+    disabled: true,
+  });
+  const { mutate: mutatePodSummary } = usePodConversationsSummary({
+    workspaceId: owner.sId,
+    options: { disabled: true },
+  });
+
+  const doJoin = async (): Promise<boolean> => {
+    const res = await clientFetch(`/api/w/${owner.sId}/spaces/${podId}/join`, {
+      method: "POST",
+    });
+
+    if (res.ok) {
+      void mutateSpaceInfoRegardlessOfQueryParams();
+      void mutatePodSummary();
+      sendNotification({
+        type: "success",
+        title: `${userName} joined Pod ${podName}`,
+        description: "You can now participate in conversations.",
+      });
+      return true;
+    } else {
+      const errorData = await getErrorFromResponse(res);
+      sendNotification({
+        type: "error",
+        title: "Could not join Pod",
+        description: `Error: ${errorData.message}`,
+      });
+      return false;
+    }
+  };
+
+  return doJoin;
 }
 
 export function useLeavePod({

--- a/front/lib/swr/search.ts
+++ b/front/lib/swr/search.ts
@@ -1,6 +1,6 @@
 import { clientEventSource } from "@app/lib/egress/client";
 import type { ToolSearchResult } from "@app/lib/search/tools/types";
-import { useProjectFiles } from "@app/lib/swr/pods";
+import { usePodFiles } from "@app/lib/swr/pods";
 import { emptyArray } from "@app/lib/swr/swr";
 import type { ContentNodeWithParent } from "@app/types/connectors/connectors_api";
 import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
@@ -72,11 +72,12 @@ export function useUnifiedSearch({
   const [hasMore, setHasMore] = useState(false);
   const eventSourceRef = useRef<EventSourcePolyfill | null>(null);
 
-  const { files: projectFiles, isProjectFilesLoading } = useProjectFiles({
-    owner,
-    spaceId: projectId ?? "",
-    disabled: disabled || !projectId,
-  });
+  const { files: projectFiles, isPodFilesLoading: isProjectFilesLoading } =
+    usePodFiles({
+      owner,
+      podId: projectId ?? "",
+      disabled: disabled || !projectId,
+    });
 
   const projectContextFiles = useMemo<ProjectFileSearchResult[]>(() => {
     return removeNulls(

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -1136,57 +1136,6 @@ export function useUpdateProjectNotificationPreference({
   };
 }
 
-export function useJoinProject({
-  owner,
-  spaceId,
-  spaceName,
-  userName,
-}: {
-  owner: LightWorkspaceType;
-  spaceId: string;
-  spaceName: string;
-  userName: string;
-}) {
-  const sendNotification = useSendNotification();
-  const { mutateSpaceInfoRegardlessOfQueryParams } = useSpaceInfo({
-    workspaceId: owner.sId,
-    spaceId,
-    disabled: true,
-  });
-  const { mutate: mutateSpaceSummary } = usePodConversationsSummary({
-    workspaceId: owner.sId,
-    options: { disabled: true },
-  });
-
-  const doJoin = async (): Promise<boolean> => {
-    const res = await clientFetch(
-      `/api/w/${owner.sId}/spaces/${spaceId}/join`,
-      { method: "POST" }
-    );
-
-    if (res.ok) {
-      void mutateSpaceInfoRegardlessOfQueryParams();
-      void mutateSpaceSummary();
-      sendNotification({
-        type: "success",
-        title: `${userName} joined Pod ${spaceName}`,
-        description: "You can now participate in conversations.",
-      });
-      return true;
-    } else {
-      const errorData = await getErrorFromResponse(res);
-      sendNotification({
-        type: "error",
-        title: "Could not join Pod",
-        description: `Error: ${errorData.message}`,
-      });
-      return false;
-    }
-  };
-
-  return doJoin;
-}
-
 export function useStarProject({
   workspaceId,
   spaceId,


### PR DESCRIPTION
## Description

This PR renames pod conversation components from the legacy `Space`/`Project` naming convention to the `Pod` terminology.

## Tests

Manually.

## Risks

Low.

## Deploy Plan

Standard deployment.

