### PR TITLE
Make usage settings page work

### DIFF
--- a/front-api/routes/w/[wId]/credits/awu-pool-summary.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-summary.ts
@@ -20,7 +20,7 @@ import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 
 export type AwuPoolSummaryResponseBody = {
-  totalCredits: number;
+  totalRemainingCredits: number;
   consumedByUsersCredits: number;
   consumedByProgrammaticCredits: number;
   resetDate: string;
@@ -97,7 +97,7 @@ app.get("/", async (ctx): HandlerResult<AwuPoolSummaryResponseBody> => {
 
   if (!currentInvoice?.start_timestamp || !currentInvoice.end_timestamp) {
     return ctx.json({
-      totalCredits: 0,
+      totalRemainingCredits: 0,
       consumedByUsersCredits: 0,
       consumedByProgrammaticCredits: 0,
       resetDate: "",
@@ -128,7 +128,7 @@ app.get("/", async (ctx): HandlerResult<AwuPoolSummaryResponseBody> => {
       !seatProductIds.has(entry.product.id)
   );
 
-  let totalCredits = 0;
+  let totalRemainingCredits = 0;
   for (const entry of awuBalances) {
     const isActive = (entry.access_schedule?.schedule_items ?? []).some(
       (item) => {
@@ -138,7 +138,7 @@ app.get("/", async (ctx): HandlerResult<AwuPoolSummaryResponseBody> => {
       }
     );
     if (isActive) {
-      totalCredits += entry.balance ?? 0;
+      totalRemainingCredits += entry.balance ?? 0;
     }
   }
 
@@ -197,7 +197,7 @@ app.get("/", async (ctx): HandlerResult<AwuPoolSummaryResponseBody> => {
   }
 
   return ctx.json({
-    totalCredits,
+    totalRemainingCredits,
     consumedByUsersCredits,
     consumedByProgrammaticCredits,
     resetDate,

--- a/front-api/routes/w/[wId]/credits/index.ts
+++ b/front-api/routes/w/[wId]/credits/index.ts
@@ -14,6 +14,7 @@ import membersSeats from "./members-seats";
 import membersUsage from "./members-usage";
 import metronomeBalances from "./metronome-balances";
 import purchase from "./purchase";
+import usageConfiguration from "./usage-configuration";
 
 // Mounted at /api/w/:wId/credits.
 const app = workspaceApp();
@@ -23,6 +24,7 @@ app.route("/members-seats", membersSeats);
 app.route("/members-usage", membersUsage);
 app.route("/metronome-balances", metronomeBalances);
 app.route("/purchase", purchase);
+app.route("/usage-configuration", usageConfiguration);
 
 app.get("/", async (ctx) => {
   const auth = ctx.get("auth");

--- a/front-api/routes/w/[wId]/credits/usage-configuration.ts
+++ b/front-api/routes/w/[wId]/credits/usage-configuration.ts
@@ -1,0 +1,127 @@
+import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+export type CreditUsageConfigurationBody = {
+  disableCreditCapWarning: boolean;
+};
+
+export type GetCreditUsageConfigurationResponseBody = {
+  configuration: CreditUsageConfigurationBody;
+};
+
+export type PatchCreditUsageConfigurationResponseBody = {
+  configuration: CreditUsageConfigurationBody;
+};
+
+export const PatchCreditUsageConfigurationRequestBody = z
+  .object({
+    disableCreditCapWarning: z.boolean().optional(),
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: "At least one field must be provided",
+  });
+
+// Defaults returned when no row exists for the workspace.
+const DEFAULT_CONFIGURATION: CreditUsageConfigurationBody = {
+  disableCreditCapWarning: false,
+};
+
+// Mounted at /api/w/:wId/credits/usage-configuration.
+const app = workspaceApp();
+
+app.get(
+  "/",
+  async (ctx): HandlerResult<GetCreditUsageConfigurationResponseBody> => {
+    const auth = ctx.get("auth");
+
+    if (!auth.isAdmin()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message:
+            "Only users that are `admins` for the current workspace can read the credit usage configuration.",
+        },
+      });
+    }
+
+    const existing =
+      await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+
+    return ctx.json({
+      configuration: existing
+        ? { disableCreditCapWarning: existing.disableCreditCapWarning }
+        : DEFAULT_CONFIGURATION,
+    });
+  }
+);
+
+app.patch(
+  "/",
+  validate("json", PatchCreditUsageConfigurationRequestBody),
+  async (ctx): HandlerResult<PatchCreditUsageConfigurationResponseBody> => {
+    const auth = ctx.get("auth");
+
+    if (!auth.isAdmin()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message:
+            "Only users that are `admins` for the current workspace can update the credit usage configuration.",
+        },
+      });
+    }
+
+    const patch = ctx.req.valid("json");
+
+    const existing =
+      await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+
+    let configuration: CreditUsageConfigurationResource;
+    if (existing) {
+      const updateResult = await existing.updateConfiguration(auth, patch);
+      if (updateResult.isErr()) {
+        return apiError(ctx, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: updateResult.error.message,
+          },
+        });
+      }
+      configuration = existing;
+    } else {
+      const createResult = await CreditUsageConfigurationResource.makeNew(
+        auth,
+        {
+          defaultDiscountPercent: 0,
+          paygCapCredits: null,
+          disableCreditCapWarning: false,
+          ...patch,
+        }
+      );
+      if (createResult.isErr()) {
+        return apiError(ctx, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: createResult.error.message,
+          },
+        });
+      }
+      configuration = createResult.value;
+    }
+
+    return ctx.json({
+      configuration: {
+        disableCreditCapWarning: configuration.disableCreditCapWarning,
+      },
+    });
+  }
+);
+
+export default app;

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -70,7 +70,7 @@ function getResetDateLabel(resetDate: string): string {
   const date = new Date(resetDate);
   const resetDay = date.getUTCDate();
   const suffix = getOrdinalSuffix(resetDay);
-  const resetMonth = date.toLocaleDateString(undefined, {
+  const resetMonth = date.toLocaleDateString("en-US", {
     month: "long",
     timeZone: "UTC",
   });
@@ -157,7 +157,7 @@ export function UsagePage() {
   }, [isCreditPriced, router, owner.sId]);
 
   const {
-    totalCredits,
+    totalRemainingCredits,
     consumedByUsersCredits,
     consumedByProgrammaticCredits,
     resetDate,
@@ -217,7 +217,9 @@ export function UsagePage() {
 
   const totalConsumedCredits =
     consumedByUsersCredits + consumedByProgrammaticCredits;
-  const currentBalanceCredits = Math.round(totalCredits - totalConsumedCredits);
+  const initialTotalCredits = Math.round(
+    totalRemainingCredits + totalConsumedCredits
+  );
 
   const resetDateLabel = getResetDateLabel(resetDate);
 
@@ -234,7 +236,7 @@ export function UsagePage() {
         awuPurchaseInfo={awuPurchaseInfo}
         isAwuPurchaseInfoLoading={isAwuPurchaseInfoLoading}
         isAwuPurchaseInfoError={!!isAwuPurchaseInfoError}
-        currentBalanceCredits={currentBalanceCredits}
+        currentBalanceCredits={totalRemainingCredits}
       />
 
       <div className="flex flex-col items-stretch gap-10 pb-20">
@@ -264,7 +266,7 @@ export function UsagePage() {
                     className="text-muted-foreground dark:text-muted-foreground-night"
                   />
                   {formatCredits(totalConsumedCredits)} /{" "}
-                  {formatCredits(totalCredits)}
+                  {formatCredits(initialTotalCredits)}
                 </span>
                 <button
                   className="flex cursor-pointer items-center gap-1 text-xs font-medium text-highlight-500 dark:text-highlight-500-night"
@@ -296,7 +298,7 @@ export function UsagePage() {
 
           {!isAwuPoolSummaryLoading && !isAwuPoolSummaryError && (
             <CreditPoolUsageBar
-              totalCredits={totalCredits}
+              totalCredits={initialTotalCredits}
               consumedByUsersCredits={consumedByUsersCredits}
               consumedByProgrammaticCredits={consumedByProgrammaticCredits}
             />

--- a/front/components/workspace/usage/UsageNotificationsCard.tsx
+++ b/front/components/workspace/usage/UsageNotificationsCard.tsx
@@ -2,15 +2,12 @@ import {
   useUpdateUsageNotifications,
   useUsageNotifications,
 } from "@app/lib/swr/usage_settings";
-import { Input, Page, SettingsList, SliderToggle } from "@dust-tt/sparkle";
-import { useEffect, useState } from "react";
+import { Page, SettingsList, SliderToggle } from "@dust-tt/sparkle";
+import { useState } from "react";
 
 interface UsageNotificationsCardProps {
   workspaceId: string;
 }
-
-const MIN_USAGE_ALERT_PERCENT = 0;
-const MAX_USAGE_ALERT_PERCENT = 100;
 
 export function UsageNotificationsCard({
   workspaceId,
@@ -20,37 +17,8 @@ export function UsageNotificationsCard({
     workspaceId,
   });
 
-  const [alertPercentInput, setAlertPercentInput] = useState<string>(
-    String(usageNotifications.creditUsageAlertPercent)
-  );
-  const [isSavingAlertPercent, setIsSavingAlertPercent] = useState(false);
   const [isSavingCreditCapWarning, setIsSavingCreditCapWarning] =
     useState(false);
-  const [isSavingUpgradeRequestEmail, setIsSavingUpgradeRequestEmail] =
-    useState(false);
-
-  useEffect(() => {
-    setAlertPercentInput(String(usageNotifications.creditUsageAlertPercent));
-  }, [usageNotifications.creditUsageAlertPercent]);
-
-  const handleCommitAlertPercent = async () => {
-    const parsed = Number(alertPercentInput);
-    if (
-      !Number.isInteger(parsed) ||
-      parsed < MIN_USAGE_ALERT_PERCENT ||
-      parsed > MAX_USAGE_ALERT_PERCENT ||
-      parsed === usageNotifications.creditUsageAlertPercent
-    ) {
-      setAlertPercentInput(String(usageNotifications.creditUsageAlertPercent));
-      return;
-    }
-    setIsSavingAlertPercent(true);
-    try {
-      await doUpdateUsageNotifications({ creditUsageAlertPercent: parsed });
-    } finally {
-      setIsSavingAlertPercent(false);
-    }
-  };
 
   const handleToggleCreditCapWarning = async () => {
     setIsSavingCreditCapWarning(true);
@@ -60,17 +28,6 @@ export function UsageNotificationsCard({
       });
     } finally {
       setIsSavingCreditCapWarning(false);
-    }
-  };
-
-  const handleToggleUpgradeRequestEmail = async () => {
-    setIsSavingUpgradeRequestEmail(true);
-    try {
-      await doUpdateUsageNotifications({
-        upgradeRequestEmail: !usageNotifications.upgradeRequestEmail,
-      });
-    } finally {
-      setIsSavingUpgradeRequestEmail(false);
     }
   };
 
@@ -86,47 +43,13 @@ export function UsageNotificationsCard({
       </div>
       <SettingsList>
         <SettingsList.Row
-          title="Credit usage alert"
-          description="Get an email when your workspace has used a percentage of its allocated credits."
-          action={
-            <div className="relative w-28">
-              <Input
-                type="text"
-                inputMode="numeric"
-                pattern="[0-9]*"
-                value={alertPercentInput}
-                onChange={(e) =>
-                  setAlertPercentInput(e.target.value.replace(/[^\d]/g, ""))
-                }
-                onBlur={() => void handleCommitAlertPercent()}
-                disabled={isSavingAlertPercent}
-                className="pr-8"
-              />
-              <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground dark:text-muted-foreground-night">
-                %
-              </div>
-            </div>
-          }
-        />
-        <SettingsList.Row
           title="Credit cap warning"
-          description="Get an email before your workspace hits its credit cap. Sent to all workspace admins."
+          description="Get an email before your workspace hits 80% of its credit cap. Sent to all workspace admins."
           action={
             <SliderToggle
               selected={usageNotifications.creditCapWarning}
               disabled={isSavingCreditCapWarning}
               onClick={() => void handleToggleCreditCapWarning()}
-            />
-          }
-        />
-        <SettingsList.Row
-          title="Upgrade request"
-          description="Receive an email when a user of your workspace is requesting an upgrade"
-          action={
-            <SliderToggle
-              selected={usageNotifications.upgradeRequestEmail}
-              disabled={isSavingUpgradeRequestEmail}
-              onClick={() => void handleToggleUpgradeRequestEmail()}
             />
           }
         />

--- a/front/components/workspace/usage/UsageSettingsCard.tsx
+++ b/front/components/workspace/usage/UsageSettingsCard.tsx
@@ -29,19 +29,7 @@ export function UsageSettingsCard({ workspaceId }: UsageSettingsCardProps) {
     setDefaultLimitInput(String(usageSettings.defaultUsageLimitCredits));
   }, [usageSettings.defaultUsageLimitCredits]);
 
-  const [isSavingAllowUpgrade, setIsSavingAllowUpgrade] = useState(false);
   const [isSavingAutoUpgrade, setIsSavingAutoUpgrade] = useState(false);
-
-  const handleToggleAllowUpgradeRequest = async () => {
-    setIsSavingAllowUpgrade(true);
-    try {
-      await doUpdateUsageSettings({
-        allowUpgradeRequest: !usageSettings.allowUpgradeRequest,
-      });
-    } finally {
-      setIsSavingAllowUpgrade(false);
-    }
-  };
 
   const handleToggleAutoUpgradeFreeToPro = async () => {
     setIsSavingAutoUpgrade(true);
@@ -78,17 +66,6 @@ export function UsageSettingsCard({ workspaceId }: UsageSettingsCardProps) {
         Settings
       </span>
       <SettingsList>
-        <SettingsList.Row
-          title="Upgrade request"
-          description="Allow users to request plan upgrades and limit increase"
-          action={
-            <SliderToggle
-              selected={usageSettings.allowUpgradeRequest}
-              disabled={isSavingAllowUpgrade}
-              onClick={() => void handleToggleAllowUpgradeRequest()}
-            />
-          }
-        />
         <SettingsList.Row
           title="Auto upgrade Free to Pro"
           description="Automatically upgrade free users to pro plan when they reach their limit"

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -21,7 +21,7 @@ import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export type AwuPoolSummaryResponseBody = {
-  totalCredits: number;
+  totalRemainingCredits: number;
   consumedByUsersCredits: number;
   consumedByProgrammaticCredits: number;
   resetDate: string;
@@ -100,7 +100,7 @@ export async function handleAwuPoolSummaryRequest(
 
       if (!currentInvoice?.start_timestamp || !currentInvoice.end_timestamp) {
         return res.status(200).json({
-          totalCredits: 0,
+          totalRemainingCredits: 0,
           consumedByUsersCredits: 0,
           consumedByProgrammaticCredits: 0,
           resetDate: "",
@@ -143,7 +143,7 @@ export async function handleAwuPoolSummaryRequest(
       // top-off that was partially consumed in a previous billing cycle). Upcoming and
       // expired schedule segments contribute 0 to the balance, so this is safe for
       // multi-period recurring credits too.
-      let totalCredits = 0;
+      let totalRemainingCredits = 0;
       for (const entry of awuBalances) {
         const isActive = (entry.access_schedule?.schedule_items ?? []).some(
           (item) => {
@@ -153,7 +153,7 @@ export async function handleAwuPoolSummaryRequest(
           }
         );
         if (isActive) {
-          totalCredits += entry.balance ?? 0;
+          totalRemainingCredits += entry.balance ?? 0;
         }
       }
 
@@ -222,7 +222,7 @@ export async function handleAwuPoolSummaryRequest(
       }
 
       return res.status(200).json({
-        totalCredits,
+        totalRemainingCredits,
         consumedByUsersCredits,
         consumedByProgrammaticCredits,
         resetDate,

--- a/front/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration.ts
@@ -157,6 +157,7 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
         {
           defaultDiscountPercent,
           paygCapCredits: resolvedPaygCapCredits,
+          disableCreditCapWarning: false,
         }
       );
       if (createResult.isErr()) {

--- a/front/lib/resources/credit_usage_configuration_resource.ts
+++ b/front/lib/resources/credit_usage_configuration_resource.ts
@@ -106,6 +106,7 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
     blob: Partial<{
       defaultDiscountPercent: number;
       paygCapCredits: number | null;
+      disableCreditCapWarning: boolean;
     }>,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, Error>> {
@@ -149,6 +150,7 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       createdAt: this.createdAt.getTime(),
       defaultDiscountPercent: this.defaultDiscountPercent,
       paygCapCredits: this.paygCapCredits,
+      disableCreditCapWarning: this.disableCreditCapWarning,
     };
   }
 
@@ -158,6 +160,7 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       workspaceId: this.workspaceId,
       defaultDiscountPercent: this.defaultDiscountPercent,
       paygCapCredits: this.paygCapCredits,
+      disableCreditCapWarning: String(this.disableCreditCapWarning),
     };
   }
 }

--- a/front/lib/resources/storage/models/credit_usage_configurations.ts
+++ b/front/lib/resources/storage/models/credit_usage_configurations.ts
@@ -15,12 +15,15 @@ import { DataTypes } from "sequelize";
  * - paygCapCredits: PAYG cap on AWU consumption, in AWU credits. NULL means
  *   PAYG is disabled; any strictly-positive value enables it and drives the
  *   Metronome `spend_threshold_reached` alert on the workspace's customer.
+ * - disableCreditCapWarning: When true, the credit cap warning email to
+ *   workspace admins is suppressed. Default false (warning is sent).
  */
 export class CreditUsageConfigurationModel extends WorkspaceAwareModel<CreditUsageConfigurationModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare defaultDiscountPercent: number;
   declare paygCapCredits: number | null;
+  declare disableCreditCapWarning: boolean;
 }
 
 CreditUsageConfigurationModel.init(
@@ -57,6 +60,11 @@ CreditUsageConfigurationModel.init(
           }
         },
       },
+    },
+    disableCreditCapWarning: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
     },
   },
   {

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -253,7 +253,7 @@ export function useAwuPoolSummary({
   );
 
   return {
-    totalCredits: data?.totalCredits ?? 0,
+    totalRemainingCredits: data?.totalRemainingCredits ?? 0,
     consumedByUsersCredits: data?.consumedByUsersCredits ?? 0,
     consumedByProgrammaticCredits: data?.consumedByProgrammaticCredits ?? 0,
     resetDate: data?.resetDate ?? "",

--- a/front/lib/swr/usage_settings.ts
+++ b/front/lib/swr/usage_settings.ts
@@ -1,10 +1,14 @@
-// TODO: Wire up real API endpoints once the backend for usage settings and
-// notifications is implemented. The hooks below expose the shape the rest of
-// the frontend should expect; the data is currently held in a module-level
-// store so toggling/editing in the UI works during development.
-
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import {
+  getErrorFromResponse,
+  useFetcher,
+  useSWRWithDefaults,
+} from "@app/lib/swr/swr";
+import type { GetCreditUsageConfigurationResponseBody } from "@app/pages/api/w/[wId]/credits/usage-configuration";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { useCallback, useSyncExternalStore } from "react";
+import type { Fetcher } from "swr";
 
 export interface UsageSettings {
   allowUpgradeRequest: boolean;
@@ -95,21 +99,37 @@ export function useUpdateUsageSettings({
   return { doUpdateUsageSettings };
 }
 
+function getCreditUsageConfigurationEndpoint(workspaceId: string): string {
+  return `/api/w/${workspaceId}/credits/usage-configuration`;
+}
+
 export function useUsageNotifications({
   workspaceId,
 }: {
   workspaceId: string;
 }) {
-  const notifications = useSyncExternalStore(
-    subscribe,
-    () => getUsageNotifications(workspaceId),
-    () => DEFAULT_USAGE_NOTIFICATIONS
+  const { fetcher } = useFetcher();
+  const configurationFetcher: Fetcher<GetCreditUsageConfigurationResponseBody> =
+    fetcher;
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    getCreditUsageConfigurationEndpoint(workspaceId),
+    configurationFetcher
   );
 
+  const fromServer: Partial<UsageNotifications> = data
+    ? { creditCapWarning: !data.configuration.disableCreditCapWarning }
+    : {};
+
+  const usageNotifications: UsageNotifications = {
+    ...DEFAULT_USAGE_NOTIFICATIONS,
+    ...fromServer,
+  };
+
   return {
-    usageNotifications: notifications,
-    isUsageNotificationsLoading: false,
-    isUsageNotificationsError: false,
+    usageNotifications,
+    isUsageNotificationsLoading: !data && !error && isValidating,
+    isUsageNotificationsError: !!error,
   };
 }
 
@@ -119,21 +139,58 @@ export function useUpdateUsageNotifications({
   workspaceId: string;
 }) {
   const sendNotification = useSendNotification();
+  const { mutate } = useSWRWithDefaults(
+    getCreditUsageConfigurationEndpoint(workspaceId),
+    null
+  );
 
   const doUpdateUsageNotifications = useCallback(
     async (patch: Partial<UsageNotifications>): Promise<boolean> => {
+      const body: Record<string, unknown> = {};
+      if (patch.creditCapWarning !== undefined) {
+        body.disableCreditCapWarning = !patch.creditCapWarning;
+      }
+
+      if (Object.keys(body).length > 0) {
+        try {
+          const res = await clientFetch(
+            getCreditUsageConfigurationEndpoint(workspaceId),
+            {
+              method: "PATCH",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(body),
+            }
+          );
+          if (!res.ok) {
+            const errorData = await getErrorFromResponse(res);
+            sendNotification({
+              type: "error",
+              title: "Failed to update notification settings",
+              description: errorData.message,
+            });
+            return false;
+          }
+        } catch (e) {
+          sendNotification({
+            type: "error",
+            title: "Failed to update notification settings",
+            description: normalizeError(e).message,
+          });
+          return false;
+        }
+        await mutate();
+      }
+
       const next = { ...getUsageNotifications(workspaceId), ...patch };
       usageNotificationsStore.set(workspaceId, next);
       notify();
-      // TODO: replace with a real POST request once the backend is available.
       sendNotification({
         type: "success",
         title: "Notification settings updated",
-        description: "Changes are not persisted yet — backend coming soon.",
       });
       return true;
     },
-    [workspaceId, sendNotification]
+    [workspaceId, sendNotification, mutate]
   );
 
   return { doUpdateUsageNotifications };

--- a/front/migrations/db/migration_654.sql
+++ b/front/migrations/db/migration_654.sql
@@ -1,0 +1,7 @@
+-- Migration created on May 26, 2026
+-- Add disableCreditCapWarning to credit_usage_configurations: when true, the
+-- credit cap warning email to workspace admins is suppressed. Default is
+-- false so workspaces without a row still receive the warning.
+
+ALTER TABLE "public"."credit_usage_configurations"
+  ADD COLUMN "disableCreditCapWarning" BOOLEAN NOT NULL DEFAULT false;

--- a/front/pages/api/w/[wId]/credits/usage-configuration.ts
+++ b/front/pages/api/w/[wId]/credits/usage-configuration.ts
@@ -1,0 +1,157 @@
+// @migration-status: MIGRATED_TO_HONO
+/** @ignoreswagger */
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+export type CreditUsageConfigurationBody = {
+  disableCreditCapWarning: boolean;
+};
+
+export type GetCreditUsageConfigurationResponseBody = {
+  configuration: CreditUsageConfigurationBody;
+};
+
+export type PatchCreditUsageConfigurationResponseBody = {
+  configuration: CreditUsageConfigurationBody;
+};
+
+export const PatchCreditUsageConfigurationRequestBody = z
+  .object({
+    disableCreditCapWarning: z.boolean().optional(),
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: "At least one field must be provided",
+  });
+
+// Defaults returned when no row exists for the workspace.
+const DEFAULT_CONFIGURATION: CreditUsageConfigurationBody = {
+  disableCreditCapWarning: false,
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<
+      | GetCreditUsageConfigurationResponseBody
+      | PatchCreditUsageConfigurationResponseBody
+    >
+  >,
+  auth: Authenticator
+): Promise<void> {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can access the credit usage configuration.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      return handleGet(req, res, auth);
+    case "PATCH":
+      return handlePatch(req, res, auth);
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, GET or PATCH is expected.",
+        },
+      });
+  }
+}
+
+async function handleGet(
+  _req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetCreditUsageConfigurationResponseBody>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  const existing =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+
+  return res.status(200).json({
+    configuration: existing
+      ? { disableCreditCapWarning: existing.disableCreditCapWarning }
+      : DEFAULT_CONFIGURATION,
+  });
+}
+
+async function handlePatch(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<PatchCreditUsageConfigurationResponseBody>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  const bodyValidation = PatchCreditUsageConfigurationRequestBody.safeParse(
+    req.body
+  );
+  if (!bodyValidation.success) {
+    const pathError = fromError(bodyValidation.error).toString();
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid request body: ${pathError}`,
+      },
+    });
+  }
+
+  const patch = bodyValidation.data;
+
+  const existing =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+
+  let configuration: CreditUsageConfigurationResource;
+  if (existing) {
+    const updateResult = await existing.updateConfiguration(auth, patch);
+    if (updateResult.isErr()) {
+      return apiError(req, res, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: updateResult.error.message,
+        },
+      });
+    }
+    configuration = existing;
+  } else {
+    const createResult = await CreditUsageConfigurationResource.makeNew(auth, {
+      defaultDiscountPercent: 0,
+      paygCapCredits: null,
+      disableCreditCapWarning: false,
+      ...patch,
+    });
+    if (createResult.isErr()) {
+      return apiError(req, res, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: createResult.error.message,
+        },
+      });
+    }
+    configuration = createResult.value;
+  }
+
+  return res.status(200).json({
+    configuration: {
+      disableCreditCapWarning: configuration.disableCreditCapWarning,
+    },
+  });
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

Fixes several small bugs and cleans up the usage page UI:

- **Rename `totalCredits` → `totalRemainingCredits`** in the AWU pool summary API response, SWR hook, and `UsagePage`. The field was already returning the _remaining_ balance from Metronome, so the old name was misleading and led to a calculation bug: the "consumed / total" label was computing `totalCredits - consumedCredits` as the denominator instead of `totalRemainingCredits + consumedCredits` (the original grant). This fixes the displayed total.
- **Fix reset date locale**: hardcode `"en-US"` instead of `undefined` in `toLocaleDateString` to prevent the month name from varying by browser locale.
- **Remove unfinished settings UI**: strip the `creditUsageAlertPercent` input and `upgradeRequestEmail` toggle from `UsageNotificationsCard`, and the `allowUpgradeRequest` toggle from `UsageSettingsCard` — these were not production-ready.
- **Store cap warning in the db**: create a new column in `credit_usage_configurations` and update it

## Tests

Manually verified on a Metronome-billed workspace: the "consumed / total" credits label and balance passed to the top-up dialog now reflect the correct original grant rather than the remaining balance.

BEFORE: Evolution of the credits were wrong
<img width="118" height="89" alt="Capture d’écran 2026-05-26 à 15 18 42" src="https://github.com/user-attachments/assets/3fcac46b-d8ba-485e-9ad1-0cbfae400c00" /> <img width="118" height="89" alt="Capture d’écran 2026-05-26 à 15 19 42" src="https://github.com/user-attachments/assets/02a6d022-c5f3-4e77-bd04-39fd134fc5df" />

AFTER:
<img width="118" height="89" alt="image" src="https://github.com/user-attachments/assets/3dc65b04-6f90-4303-aa4d-f902c158ea8e" /> <img width="118" height="89" alt="image" src="https://github.com/user-attachments/assets/a965da32-fb4e-4c02-b718-07942cbf8c73" />



## Risk

Low

## Deploy Plan

Deploy front + front-api.