### PR TITLE
feat(dsbx): retry transient network errors during action polling

### DIFF
--- a/cli/dust-sandbox/src/api/client.rs
+++ b/cli/dust-sandbox/src/api/client.rs
@@ -16,6 +16,14 @@ const POLL_INTERVAL: Duration = Duration::from_millis(500);
 const POLL_MAX_DURATION: Duration = Duration::from_secs(10 * 60);
 const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
+// Polling must survive sandbox pause/resume cycles. When the host pauses the
+// sandbox via betaPause, in-flight TCP sockets may be closed by the front
+// side or the tunnel before RAM is thawed; on resume the next `.send()`
+// surfaces an I/O error. Action IDs are durable, so re-polling is safe.
+const POLL_MAX_CONSECUTIVE_NETWORK_ERRORS: u32 = 30;
+const POLL_RETRY_BACKOFF_BASE: Duration = Duration::from_millis(500);
+const POLL_RETRY_BACKOFF_CAP: Duration = Duration::from_secs(5);
+
 const SANDBOX_TOKEN_ENV: &str = "DUST_SANDBOX_TOKEN";
 const API_URL_ENV: &str = "DUST_API_URL";
 
@@ -147,8 +155,44 @@ impl DustApiClient {
     async fn poll_action_result(&self, action_id: &str) -> anyhow::Result<CallToolResponse> {
         let deadline = Instant::now() + POLL_MAX_DURATION;
         let mut announced = false;
+        let mut consecutive_network_errors: u32 = 0;
         loop {
-            match self.get_action_status(action_id).await? {
+            let poll_result = self.get_action_status(action_id).await;
+            let response = match poll_result {
+                Ok(r) => {
+                    consecutive_network_errors = 0;
+                    r
+                }
+                Err(err) => {
+                    // Distinguish transient network errors (reqwest in the
+                    // error chain) from terminal failures (HTTP 4xx, parse
+                    // errors, anything bail!-ed). Only transient errors are
+                    // retried — re-polling the same action_id is idempotent.
+                    if err.downcast_ref::<reqwest::Error>().is_none() {
+                        return Err(err);
+                    }
+                    consecutive_network_errors += 1;
+                    if consecutive_network_errors > POLL_MAX_CONSECUTIVE_NETWORK_ERRORS {
+                        return Err(err).with_context(|| {
+                            format!(
+                                "polling action {action_id} failed after {POLL_MAX_CONSECUTIVE_NETWORK_ERRORS} consecutive network errors"
+                            )
+                        });
+                    }
+                    if Instant::now() >= deadline {
+                        bail!(
+                            "timed out waiting for action {action_id} after {} seconds",
+                            POLL_MAX_DURATION.as_secs()
+                        );
+                    }
+                    let backoff = POLL_RETRY_BACKOFF_BASE
+                        .saturating_mul(1u32 << consecutive_network_errors.saturating_sub(1).min(4))
+                        .min(POLL_RETRY_BACKOFF_CAP);
+                    sleep(backoff).await;
+                    continue;
+                }
+            };
+            match response {
                 ActionPollResponse::Pending => {
                     if Instant::now() >= deadline {
                         bail!(


### PR DESCRIPTION
## Description

Make `dust-sandbox`'s action polling resilient to sandbox pause/resume cycles.

When the host pauses a sandbox via `betaPause`, in-flight TCP sockets to the front API can be closed by either the front side or the tunnel before RAM is thawed. On resume, the next `.send()` surfaces an I/O error and the CLI aborts the action it was waiting on — even though the action ID is still valid and re-polling would succeed.

This change distinguishes transient `reqwest` errors from terminal failures (HTTP 4xx, parse errors, anything `bail!`-ed) and retries the former with exponential backoff:

- `POLL_MAX_CONSECUTIVE_NETWORK_ERRORS = 30` — bounds the worst case
- `POLL_RETRY_BACKOFF_BASE = 500ms`, doubling, capped at `POLL_RETRY_BACKOFF_CAP = 5s`
- Existing `POLL_MAX_DURATION = 10min` deadline still applies

Terminal failures still fail fast. Re-polling the same `action_id` is idempotent server-side.

## Tests

- [ ] `cargo test -p dust-sandbox` passes
- [ ] Manual: pause an active sandbox mid-`dust call`, confirm the CLI keeps polling and returns the result after thaw rather than aborting

## Risk

Low. The retry path is only entered on transient `reqwest` errors which today bubble up as fatal — i.e. the change can only turn previously-fatal polls into successful ones. The 30-error / 10-min ceilings keep worst-case latency bounded.

Rollback: revert the patch; no schema or interface changes.

## Deploy Plan

Standard CLI release. No coordination needed with `front`.