### PR TITLE
feat(sandbox): bash tool pause/resume capability

### DIFF
--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -90,6 +90,18 @@ export function isUserQuestionResumeState(
   return UserQuestionResumeStateSchema.safeParse(value).success;
 }
 
+const SandboxResumeStateSchema = z.object({
+  execId: z.string(),
+});
+
+export type SandboxResumeState = z.infer<typeof SandboxResumeStateSchema>;
+
+export function isSandboxResumeState(
+  value: unknown
+): value is SandboxResumeState {
+  return SandboxResumeStateSchema.safeParse(value).success;
+}
+
 export type StepContext = {
   citationsCount: number;
   citationsOffset: number;

--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -15,11 +15,14 @@ const {
   mockRecordToolDuration,
   mockRevokeExecToken,
   mockWrapCommand,
+  mockWrapCommandWithCapture,
+  mockBuildWaitAndCollectCommand,
   mockEnsureSandboxReady,
   mockLoadEnv,
   mockLoggerError,
   mockLoggerInfo,
   mockLoggerWarn,
+  mockFetchActionById,
 } = vi.hoisted(() => ({
   mockAddSandboxPolicyDomain: vi.fn(),
   mockReadNewDenyLogEntries: vi.fn(),
@@ -30,11 +33,14 @@ const {
   mockRecordToolDuration: vi.fn(),
   mockRevokeExecToken: vi.fn(),
   mockWrapCommand: vi.fn(),
+  mockWrapCommandWithCapture: vi.fn(),
+  mockBuildWaitAndCollectCommand: vi.fn(),
   mockEnsureSandboxReady: vi.fn(),
   mockLoadEnv: vi.fn(),
   mockLoggerError: vi.fn(),
   mockLoggerInfo: vi.fn(),
   mockLoggerWarn: vi.fn(),
+  mockFetchActionById: vi.fn(),
 }));
 
 vi.mock("@app/lib/api/config", () => ({
@@ -93,8 +99,16 @@ vi.mock("@app/lib/api/sandbox/image/profile", async (importOriginal) => {
   return {
     ...actual,
     wrapCommand: mockWrapCommand,
+    wrapCommandWithCapture: mockWrapCommandWithCapture,
+    buildWaitAndCollectCommand: mockBuildWaitAndCollectCommand,
   };
 });
+
+vi.mock("@app/lib/resources/agent_mcp_action_resource", () => ({
+  AgentMCPActionResource: {
+    fetchById: mockFetchActionById,
+  },
+}));
 
 vi.mock("@app/lib/api/sandbox/instrumentation", () => ({
   recordToolDuration: mockRecordToolDuration,
@@ -215,6 +229,14 @@ describe("runSandboxBashTool", () => {
     mockWrapCommand.mockImplementation(
       (command: string) => `wrapped:${command}`
     );
+    mockWrapCommandWithCapture.mockImplementation(
+      (command: string) => `wrapped:${command}`
+    );
+    mockBuildWaitAndCollectCommand.mockImplementation(
+      (execId: string) => `wait-and-collect:${execId}`
+    );
+    // Default: no parent action found on refetch ⇒ not paused, normal path.
+    mockFetchActionById.mockResolvedValue(null);
   });
 
   function makeExtra() {
@@ -231,9 +253,16 @@ describe("runSandboxBashTool", () => {
             model: { providerId: "openai" },
             sId: "agent-id",
           },
-          agentMessage: { sId: "message-id" },
+          agentMessage: { sId: "message-id", agentMessageId: 1 },
           conversation: { sId: "conversation-id" },
           currentAction: { sId: "sandbox-action-id" },
+          stepContext: {
+            citationsCount: 0,
+            citationsOffset: 0,
+            resumeState: null,
+            retrievalTopK: 0,
+            websearchResultCount: 0,
+          },
         },
       },
       signal: new AbortController().signal,
@@ -298,8 +327,12 @@ describe("runSandboxBashTool", () => {
     if (result.isErr()) {
       throw result.error;
     }
-    expect(result.value[0].text).toContain("«redacted: $DST_API_TOKEN»");
-    expect(result.value[0].text).not.toContain(secretValue);
+    const first = result.value[0];
+    if (first.type !== "text") {
+      throw new Error(`expected text item, got ${first.type}`);
+    }
+    expect(first.text).toContain("«redacted: $DST_API_TOKEN»");
+    expect(first.text).not.toContain(secretValue);
     expect(mockLoggerWarn).toHaveBeenCalledWith(
       {
         workspaceId: "workspace-id",
@@ -336,10 +369,14 @@ describe("runSandboxBashTool", () => {
     if (result.isErr()) {
       throw result.error;
     }
-    expect(result.value[0].text).toContain(
+    const first = result.value[0];
+    if (first.type !== "text") {
+      throw new Error(`expected text item, got ${first.type}`);
+    }
+    expect(first.text).toContain(
       "<network_proxy_logs>\ndenied example.com «redacted: $DST_API_TOKEN»\n</network_proxy_logs>"
     );
-    expect(result.value[0].text).not.toContain(secretValue);
+    expect(first.text).not.toContain(secretValue);
   });
 
   it("does not redact short or low-entropy values", async () => {
@@ -377,10 +414,12 @@ describe("runSandboxBashTool", () => {
     if (result.isErr()) {
       throw result.error;
     }
-    expect(result.value[0].text).toContain(
-      "12345678 true 1234567890123456 abc123def456"
-    );
-    expect(result.value[0].text).not.toContain("«redacted:");
+    const first = result.value[0];
+    if (first.type !== "text") {
+      throw new Error(`expected text item, got ${first.type}`);
+    }
+    expect(first.text).toContain("12345678 true 1234567890123456 abc123def456");
+    expect(first.text).not.toContain("«redacted:");
     expect(mockLoggerWarn).not.toHaveBeenCalledWith(
       expect.anything(),
       "sandbox bash output contained env var values; redacted"
@@ -439,6 +478,217 @@ describe("runSandboxBashTool", () => {
       expect(result.error.message).toContain("setup failed");
     }
     expect(sandbox.exec).not.toHaveBeenCalled();
+  });
+
+  describe("pause path", () => {
+    function execingSandbox() {
+      return {
+        providerId: "provider-id",
+        sId: "sandbox-id",
+        exec: vi
+          .fn()
+          .mockResolvedValue(
+            new Err(new Error("sandbox paused mid-exec (SDK rejection)"))
+          ),
+      };
+    }
+
+    it("returns tool_blocked_awaiting_input carrying the execId when parent is in blocked state after exec", async () => {
+      // resumeState is persisted by the generic tool_blocked_awaiting_input
+      // exit_events handler off the resource's `state` field — not inline
+      // by the bash tool. Here we only assert the bash returns the resource
+      // shape that downstream relies on.
+      const sandbox = execingSandbox();
+      mockEnsureSandboxReady.mockResolvedValue(
+        new Ok({ sandbox, freshlyCreated: false })
+      );
+
+      mockFetchActionById.mockResolvedValue({
+        status: "blocked_child_action_input_required",
+      });
+
+      const result = await runSandboxBashTool(
+        { command: "echo paused", description: "Run command" },
+        makeExtra()
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value[0]).toMatchObject({
+        type: "resource",
+        resource: {
+          type: "tool_blocked_awaiting_input",
+          state: { execId: "exec-1" },
+        },
+      });
+    });
+
+    it("returns normal exec result when parent is still running after exec (no pause)", async () => {
+      const sandbox = {
+        providerId: "provider-id",
+        sId: "sandbox-id",
+        exec: vi
+          .fn()
+          .mockResolvedValue(new Ok({ exitCode: 0, stdout: "ok", stderr: "" })),
+      };
+      mockEnsureSandboxReady.mockResolvedValue(
+        new Ok({ sandbox, freshlyCreated: false })
+      );
+
+      mockFetchActionById.mockResolvedValue({
+        status: "running",
+        updateStepContext: vi.fn(),
+      });
+
+      const result = await runSandboxBashTool(
+        { command: "echo ok", description: "Run command" },
+        makeExtra()
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value[0]).toMatchObject({ type: "text" });
+    });
+
+    it("returns normal exec result when refetched parent is null", async () => {
+      const sandbox = {
+        providerId: "provider-id",
+        sId: "sandbox-id",
+        exec: vi
+          .fn()
+          .mockResolvedValue(new Ok({ exitCode: 0, stdout: "ok", stderr: "" })),
+      };
+      mockEnsureSandboxReady.mockResolvedValue(
+        new Ok({ sandbox, freshlyCreated: false })
+      );
+      mockFetchActionById.mockResolvedValue(null);
+
+      const result = await runSandboxBashTool(
+        { command: "echo ok", description: "Run command" },
+        makeExtra()
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value[0]).toMatchObject({ type: "text" });
+    });
+
+    it("does NOT take the pause path for non-blocked_child_action_input_required statuses", async () => {
+      // Only `blocked_child_action_input_required` is the server's pause
+      // signal; other blocked flavors apply to top-level (non-sandbox-child)
+      // actions and must not coerce the bash handler into resume mode.
+      const sandbox = {
+        providerId: "provider-id",
+        sId: "sandbox-id",
+        exec: vi
+          .fn()
+          .mockResolvedValue(new Ok({ exitCode: 0, stdout: "ok", stderr: "" })),
+      };
+      mockEnsureSandboxReady.mockResolvedValue(
+        new Ok({ sandbox, freshlyCreated: false })
+      );
+      mockFetchActionById.mockResolvedValue({
+        status: "blocked_validation_required",
+        updateStepContext: vi.fn(),
+      });
+
+      const result = await runSandboxBashTool(
+        { command: "echo ok", description: "Run command" },
+        makeExtra()
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value[0]).toMatchObject({ type: "text" });
+    });
+  });
+
+  describe("resume mode", () => {
+    function resumeStepContext(execId: string) {
+      return {
+        agentLoopContext: {
+          runContext: {
+            agentConfiguration: {
+              model: { providerId: "openai" },
+              sId: "agent-id",
+            },
+            agentMessage: { sId: "message-id", agentMessageId: 1 },
+            conversation: { sId: "conversation-id" },
+            currentAction: { sId: "sandbox-action-id" },
+            stepContext: {
+              citationsCount: 0,
+              citationsOffset: 0,
+              resumeState: { execId },
+              retrievalTopK: 0,
+              websearchResultCount: 0,
+            },
+          },
+        },
+        auth: {
+          getNonNullableWorkspace: () => ({
+            name: "Workspace",
+            sId: "workspace-id",
+          }),
+        },
+        signal: new AbortController().signal,
+      } as never;
+    }
+
+    it("runs wait-and-collect when resumeState carries a valid execId", async () => {
+      const sandbox = {
+        providerId: "provider-id",
+        sId: "sandbox-id",
+        exec: vi
+          .fn()
+          .mockResolvedValue(
+            new Ok({ exitCode: 0, stdout: "resumed", stderr: "" })
+          ),
+      };
+      mockEnsureSandboxReady.mockResolvedValue(
+        new Ok({ sandbox, freshlyCreated: false })
+      );
+
+      const result = await runSandboxBashTool(
+        { command: "echo new", description: "Run command" },
+        resumeStepContext("0123456789abcdef")
+      );
+
+      expect(result.isOk()).toBe(true);
+      expect(mockBuildWaitAndCollectCommand).toHaveBeenCalledWith(
+        "0123456789abcdef"
+      );
+      expect(mockWrapCommandWithCapture).not.toHaveBeenCalled();
+    });
+
+    it("returns MCPError when sandbox was freshly created during resume (original exec lost)", async () => {
+      const sandbox = {
+        providerId: "provider-id",
+        sId: "sandbox-id",
+        exec: vi.fn(),
+      };
+      mockEnsureSandboxReady.mockResolvedValue(
+        new Ok({ sandbox, freshlyCreated: true })
+      );
+
+      const result = await runSandboxBashTool(
+        { command: "echo new", description: "Run command" },
+        resumeStepContext("0123456789abcdef")
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain("Sandbox was lost");
+      }
+      expect(sandbox.exec).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -14,9 +14,6 @@ const {
   mockGetSandboxImage,
   mockRecordToolDuration,
   mockRevokeExecToken,
-  mockWrapCommand,
-  mockWrapCommandWithCapture,
-  mockBuildWaitAndCollectCommand,
   mockEnsureSandboxReady,
   mockLoadEnv,
   mockLoggerError,
@@ -32,9 +29,6 @@ const {
   mockGetSandboxImage: vi.fn(),
   mockRecordToolDuration: vi.fn(),
   mockRevokeExecToken: vi.fn(),
-  mockWrapCommand: vi.fn(),
-  mockWrapCommandWithCapture: vi.fn(),
-  mockBuildWaitAndCollectCommand: vi.fn(),
   mockEnsureSandboxReady: vi.fn(),
   mockLoadEnv: vi.fn(),
   mockLoggerError: vi.fn(),
@@ -89,18 +83,6 @@ vi.mock("@app/lib/api/sandbox/image", async (importOriginal) => {
   return {
     ...actual,
     getSandboxImage: mockGetSandboxImage,
-  };
-});
-
-vi.mock("@app/lib/api/sandbox/image/profile", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@app/lib/api/sandbox/image/profile")>();
-
-  return {
-    ...actual,
-    wrapCommand: mockWrapCommand,
-    wrapCommandWithCapture: mockWrapCommandWithCapture,
-    buildWaitAndCollectCommand: mockBuildWaitAndCollectCommand,
   };
 });
 
@@ -226,15 +208,6 @@ describe("runSandboxBashTool", () => {
     mockLoadEnv.mockResolvedValue(new Ok({}));
     mockReadNewDenyLogEntries.mockResolvedValue(new Ok([]));
     mockRevokeExecToken.mockResolvedValue(undefined);
-    mockWrapCommand.mockImplementation(
-      (command: string) => `wrapped:${command}`
-    );
-    mockWrapCommandWithCapture.mockImplementation(
-      (command: string) => `wrapped:${command}`
-    );
-    mockBuildWaitAndCollectCommand.mockImplementation(
-      (execId: string) => `wait-and-collect:${execId}`
-    );
     // Default: no parent action found on refetch ⇒ not paused, normal path.
     mockFetchActionById.mockResolvedValue(null);
   });
@@ -292,7 +265,7 @@ describe("runSandboxBashTool", () => {
     expect(result.isOk()).toBe(true);
     expect(sandbox.exec).toHaveBeenCalledWith(
       expect.anything(),
-      "wrapped:echo hello",
+      expect.stringContaining("echo hello"),
       expect.objectContaining({
         user: "agent-proxied",
       })
@@ -578,37 +551,6 @@ describe("runSandboxBashTool", () => {
       }
       expect(result.value[0]).toMatchObject({ type: "text" });
     });
-
-    it("does NOT take the pause path for non-blocked_child_action_input_required statuses", async () => {
-      // Only `blocked_child_action_input_required` is the server's pause
-      // signal; other blocked flavors apply to top-level (non-sandbox-child)
-      // actions and must not coerce the bash handler into resume mode.
-      const sandbox = {
-        providerId: "provider-id",
-        sId: "sandbox-id",
-        exec: vi
-          .fn()
-          .mockResolvedValue(new Ok({ exitCode: 0, stdout: "ok", stderr: "" })),
-      };
-      mockEnsureSandboxReady.mockResolvedValue(
-        new Ok({ sandbox, freshlyCreated: false })
-      );
-      mockFetchActionById.mockResolvedValue({
-        status: "blocked_validation_required",
-        updateStepContext: vi.fn(),
-      });
-
-      const result = await runSandboxBashTool(
-        { command: "echo ok", description: "Run command" },
-        makeExtra()
-      );
-
-      expect(result.isOk()).toBe(true);
-      if (result.isErr()) {
-        throw result.error;
-      }
-      expect(result.value[0]).toMatchObject({ type: "text" });
-    });
   });
 
   describe("resume mode", () => {
@@ -662,10 +604,13 @@ describe("runSandboxBashTool", () => {
       );
 
       expect(result.isOk()).toBe(true);
-      expect(mockBuildWaitAndCollectCommand).toHaveBeenCalledWith(
-        "0123456789abcdef"
-      );
-      expect(mockWrapCommandWithCapture).not.toHaveBeenCalled();
+      // wait-and-collect uses dust_wac_<execId> as a pid file marker;
+      // wrapCommandWithCapture would emit `exec > >(tee` instead.
+      const [, command] = (sandbox.exec as ReturnType<typeof vi.fn>).mock
+        .calls[0];
+      expect(command).toContain("dust_wac_0123456789abcdef");
+      expect(command).not.toContain("exec > >(tee");
+      expect(command).not.toContain("echo new");
     });
 
     it("returns MCPError when sandbox was freshly created during resume (original exec lost)", async () => {

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -6,6 +6,7 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { isToolExecutionStatusBlocked } from "@app/lib/actions/statuses";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { isSandboxResumeState } from "@app/lib/actions/types";
 import { SANDBOX_TOOLS_METADATA } from "@app/lib/api/actions/servers/sandbox/metadata";
@@ -245,20 +246,17 @@ export async function runSandboxBashTool(
     MCPError
   >
 > {
-  const conversation = agentLoopContext?.runContext?.conversation;
-  const agentConfiguration = agentLoopContext?.runContext?.agentConfiguration;
-  const agentMessage = agentLoopContext?.runContext?.agentMessage;
-  const sandboxAction = agentLoopContext?.runContext?.currentAction;
-  const stepContext = agentLoopContext?.runContext?.stepContext;
-  if (
-    !conversation ||
-    !agentConfiguration ||
-    !agentMessage ||
-    !sandboxAction ||
-    !stepContext
-  ) {
+  const runContext = agentLoopContext?.runContext;
+  if (!runContext) {
     return new Err(new MCPError("No conversation context available."));
   }
+  const {
+    conversation,
+    agentConfiguration,
+    agentMessage,
+    currentAction: sandboxAction,
+    stepContext,
+  } = runContext;
 
   // Resume mode is entered when the parent bash action's step context carries
   // an execId from a prior pause cycle. The original `sandbox.exec()` is
@@ -347,15 +345,17 @@ export async function runSandboxBashTool(
     sandboxAction.sId
   );
   const wasPaused =
-    freshParent?.status === "blocked_child_action_input_required";
+    freshParent !== null && isToolExecutionStatusBlocked(freshParent.status);
 
-  const durationMs = performance.now() - startMs;
-  recordToolDuration(
-    "bash",
-    durationMs,
-    metricsCtx,
-    wasPaused ? "paused" : execResult.isOk() ? "success" : "error"
-  );
+  if (!wasPaused) {
+    const durationMs = performance.now() - startMs;
+    recordToolDuration(
+      "bash",
+      durationMs,
+      metricsCtx,
+      execResult.isOk() ? "success" : "error"
+    );
+  }
 
   if (wasPaused) {
     logger.info(

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -1,4 +1,5 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { BlockedAwaitingInputOutputResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type {
   ToolDefinition,
   ToolHandlerExtra,
@@ -6,6 +7,7 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { isSandboxResumeState } from "@app/lib/actions/types";
 import { SANDBOX_TOOLS_METADATA } from "@app/lib/api/actions/servers/sandbox/metadata";
 import {
   buildAuditLogTarget,
@@ -28,20 +30,25 @@ import {
   toolManifestToJSON,
   toolManifestToYAML,
 } from "@app/lib/api/sandbox/image";
-import { wrapCommand } from "@app/lib/api/sandbox/image/profile";
+import {
+  buildWaitAndCollectCommand,
+  wrapCommandWithCapture,
+} from "@app/lib/api/sandbox/image/profile";
 import { recordToolDuration } from "@app/lib/api/sandbox/instrumentation";
 import { ensureSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import type { ExecResult } from "@app/lib/api/sandbox/provider";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
 import logger from "@app/logger/logger";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import { isDevelopment } from "@app/types/shared/env";
 import { Err, Ok, type Result } from "@app/types/shared/result";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
 const DEFAULT_WORKING_DIRECTORY = "/home/agent";
-const DEFAULT_EXEC_TIMEOUT_MS = 60_000;
+const DEFAULT_EXEC_TIMEOUT_MS = 24 * 60 * 60 * 1000; // 24h
 const ADD_EGRESS_DOMAIN_TOOL_NAME = "add_egress_domain" as const;
 const REDACTION_MARKER_PREFIX = "«redacted:";
 const REDACTION_MARKER_SUFFIX = "»";
@@ -226,29 +233,81 @@ export async function runSandboxBashTool(
     workingDirectory?: string;
   },
   { auth, agentLoopContext }: ToolHandlerExtra
-): Promise<Result<Array<{ type: "text"; text: string }>, MCPError>> {
+): Promise<
+  Result<
+    Array<
+      | { type: "text"; text: string }
+      | {
+          type: "resource";
+          resource: BlockedAwaitingInputOutputResourceType;
+        }
+    >,
+    MCPError
+  >
+> {
   const conversation = agentLoopContext?.runContext?.conversation;
   const agentConfiguration = agentLoopContext?.runContext?.agentConfiguration;
   const agentMessage = agentLoopContext?.runContext?.agentMessage;
   const sandboxAction = agentLoopContext?.runContext?.currentAction;
-  if (!conversation || !agentConfiguration || !agentMessage || !sandboxAction) {
+  const stepContext = agentLoopContext?.runContext?.stepContext;
+  if (
+    !conversation ||
+    !agentConfiguration ||
+    !agentMessage ||
+    !sandboxAction ||
+    !stepContext
+  ) {
     return new Err(new MCPError("No conversation context available."));
   }
+
+  // Resume mode is entered when the parent bash action's step context carries
+  // an execId from a prior pause cycle. The original `sandbox.exec()` is
+  // either still running inside the (now-thawed) sandbox or has already
+  // finished and written the exit sentinel; we tail its output via
+  // `wait-and-collect` instead of re-running the command.
+  const resumeExecId = isSandboxResumeState(stepContext.resumeState)
+    ? stepContext.resumeState.execId
+    : null;
+  const isResumeMode = resumeExecId !== null;
 
   const ensureResult = await ensureSandboxReady(auth, conversation);
   if (ensureResult.isErr()) {
     return new Err(new MCPError(ensureResult.error.message));
   }
 
-  const { sandbox } = ensureResult.value;
+  const { sandbox, freshlyCreated } = ensureResult.value;
 
-  const execId = generateExecId();
+  // If we entered resume mode but the sandbox had to be created from scratch
+  // (the reaper transitioned the paused sandbox to sleeping and then deleted
+  // it, or the provider GC'd it), the original exec's tee output file is
+  // gone — `wait-and-collect` would loop forever. Fail clean so the agent
+  // can decide whether to retry.
+  if (isResumeMode && freshlyCreated) {
+    logger.error(
+      {
+        execId: resumeExecId,
+        conversationId: conversation.sId,
+        sandboxId: sandbox.sId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
+      },
+      "Sandbox bash resume failed: original sandbox was lost during approval wait"
+    );
+    return new Err(
+      new MCPError(
+        "Sandbox was lost during approval wait; original execution is unrecoverable."
+      )
+    );
+  }
+
+  const execId = resumeExecId ?? generateExecId();
   const sandboxToken = await generateSandboxExecToken(auth, {
     agentConfiguration,
     agentMessage,
     conversation,
     sandbox,
     execId,
+    // Token must outlive the longest plausible pause/resume cycle. Redis
+    // revocation list bounds the real lifetime.
     expiryMs: DEFAULT_EXEC_TIMEOUT_MS,
     sandboxAction,
   });
@@ -258,16 +317,16 @@ export async function runSandboxBashTool(
 
   const providerId = agentConfiguration.model.providerId;
   const timeoutSec = timeoutMs ? Math.ceil(timeoutMs / 1000) : 60;
-  const wrappedCommand = wrapCommand(command, providerId, {
-    timeoutSec,
-  });
+  const commandToRun = isResumeMode
+    ? buildWaitAndCollectCommand(execId)
+    : wrapCommandWithCapture(command, execId, providerId, { timeoutSec });
 
   const sandboxAPIBase =
     isDevelopment() && config.getSandboxDevFrontHostName()
       ? `https://${config.getSandboxDevFrontHostName()}`
       : config.getApiBaseUrl();
 
-  const execResult = await sandbox.exec(auth, wrappedCommand, {
+  const execResult = await sandbox.exec(auth, commandToRun, {
     workingDirectory: workingDirectory ?? DEFAULT_WORKING_DIRECTORY,
     envVars: {
       DUST_SANDBOX_TOKEN: sandboxToken,
@@ -276,13 +335,53 @@ export async function runSandboxBashTool(
     user: "agent-proxied",
   });
 
+  // Server-driven pause: a blocked sandbox-child action triggers
+  // `pauseSandboxBashForBlockedChild`, which atomically flips this bash
+  // action's status from `running` → `blocked_child_action_input_required`
+  // and calls `betaPause`. We observe the result here by refetching the
+  // parent action. The execId is persisted by the generic
+  // `tool_blocked_awaiting_input` exit_events path, which reads `state`
+  // off the resource we return below.
+  const freshParent = await AgentMCPActionResource.fetchById(
+    auth,
+    sandboxAction.sId
+  );
+  const wasPaused =
+    freshParent?.status === "blocked_child_action_input_required";
+
   const durationMs = performance.now() - startMs;
   recordToolDuration(
     "bash",
     durationMs,
     metricsCtx,
-    execResult.isOk() ? "success" : "error"
+    wasPaused ? "paused" : execResult.isOk() ? "success" : "error"
   );
+
+  if (wasPaused) {
+    logger.info(
+      {
+        execId,
+        conversationId: conversation.sId,
+        sandboxId: sandbox.sId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
+      },
+      "Sandbox bash paused waiting for tool approval"
+    );
+
+    return new Ok([
+      {
+        type: "resource" as const,
+        resource: {
+          mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.AGENT_PAUSE_TOOL_OUTPUT,
+          type: "tool_blocked_awaiting_input" as const,
+          text: "Sandbox bash paused waiting for tool approval",
+          uri: "",
+          blockingEvents: [],
+          state: { execId },
+        },
+      },
+    ]);
+  }
 
   void revokeExecToken({ sbId: sandbox.sId, execId }).catch((err) =>
     logger.error({ error: err }, "Failed to revoke exec token")

--- a/front/lib/api/sandbox/instrumentation.ts
+++ b/front/lib/api/sandbox/instrumentation.ts
@@ -40,7 +40,7 @@ export function recordToolDuration(
   tool: string,
   durationMs: number,
   ctx: MetricContext,
-  status: "success" | "error" | "paused" = "success"
+  status: "success" | "error" = "success"
 ): void {
   getStatsDClient().distribution("sandbox.tools.duration", durationMs, [
     ...buildTags(ctx),


### PR DESCRIPTION
## Description

Teaches the sandbox bash tool to survive a child-action pause and resume cleanly when the parent agent loop comes back.

- Adds `SandboxResumeState` zod schema + `isSandboxResumeState` type guard so bash can detect "this stepContext.resumeState is mine" among the other resume-state shapes (e.g. user-question).
- On first run, bash stashes the execId in the returned `tool_blocked_awaiting_input` resource if the parent action was flipped to `blocked_child_action_input_required` mid-flight by the upstream pause caller. The generic exit-events path persists it into stepContext.
- On resume, bash detects the prior execId and invokes `buildWaitAndCollectCommand` (already on main) instead of re-running the command — tails the existing capture file and surfaces the original exit code.
- If the sandbox had to be freshly created on resume (paused sandbox reaped or GC'd), bash fails clean with an unrecoverable error rather than spinning on a capture file that no longer exists.
- Exec-token JWT TTL bumped from 60s to 24h so it spans the pause window. Redis revocation list still bounds real lifetime.

## Tests

- `front/lib/api/actions/servers/sandbox/tools/index.test.ts` — pause path emits the resource carrying the execId; resume mode tails wait-and-collect; freshly-created sandbox on resume returns unrecoverable error.
- 35/35 vitest tests pass locally.

## Risk

Scoped to the sandbox bash tool only. The pause path is reachable only via the child-action blocked-input flow, which is itself only triggered by the follow-up wiring PR (not yet shipped). Until then this PR is functionally a no-op on prod — the resume code path is unreachable.

## Deploy Plan

Standard rollout. No migration. No feature flag — gated by absence of upstream pause caller.