### PR TITLE
[FILE EXPLORER] Replace GoUpCard with breadcrumb navigation

### DIFF
--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -288,7 +288,7 @@ export function FileExplorer({
           >
             <div
               className={cn(
-                "flex h-full items-center justify-between gap-2 px-4",
+                "flex h-full items-center justify-between gap-2",
                 contentClassName
               )}
             >
@@ -296,7 +296,9 @@ export function FileExplorer({
                 currentFolderPath={currentFolderPath}
                 onGoUp={handleGoUp}
                 onNavigate={handleBreadcrumbNavigate}
-                onMoveFileDrop={fileDragEnabled ? handleMoveFileDrop : undefined}
+                onMoveFileDrop={
+                  fileDragEnabled ? handleMoveFileDrop : undefined
+                }
               />
               <Button
                 variant="ghost"

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -1,11 +1,11 @@
 import { FileExplorerBreadcrumb } from "@app/components/file_explorer/FileExplorerBreadcrumb";
 import { FileExplorerContent } from "@app/components/file_explorer/FileExplorerContent";
-import { canMoveFileToParentFolder } from "@app/components/file_explorer/fileExplorerDragDrop";
 import { FileExplorerFilters } from "@app/components/file_explorer/FileExplorerFilters";
 import type { ViewMode } from "@app/components/file_explorer/FileExplorerItem";
-import { getFileExplorerPipeline } from "@app/components/file_explorer/fileExplorerPipeline";
 import { FileExplorerToolbar } from "@app/components/file_explorer/FileExplorerToolbar";
 import { FilePreviewDialog } from "@app/components/file_explorer/FilePreviewDialog";
+import { canMoveFileToParentFolder } from "@app/components/file_explorer/fileExplorerDragDrop";
+import { getFileExplorerPipeline } from "@app/components/file_explorer/fileExplorerPipeline";
 import { MoveFileToFolderDialog } from "@app/components/file_explorer/MoveFileToFolderDialog";
 import type {
   ContentNodeEntry,

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -1,3 +1,4 @@
+import { FileExplorerBreadcrumb } from "@app/components/file_explorer/FileExplorerBreadcrumb";
 import { FileExplorerContent } from "@app/components/file_explorer/FileExplorerContent";
 import { canMoveFileToParentFolder } from "@app/components/file_explorer/fileExplorerDragDrop";
 import { FileExplorerFilters } from "@app/components/file_explorer/FileExplorerFilters";
@@ -23,45 +24,21 @@ import {
   getParentFolderRelativePath,
   getScopedRelativePath,
   isFileExplorerMovableFile,
-  ROOT_FOLDER_LABEL,
 } from "@app/components/file_explorer/utils";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import type { GCSMountEntry } from "@app/lib/api/files/gcs_mount/files";
 import { isInteractiveContentType } from "@app/types/files";
 import { Err, type Result } from "@app/types/shared/result";
 import {
-  Breadcrumbs,
   Button,
   cn,
   FolderOpenIcon,
   PencilSquareIcon,
   TrashIcon,
   XMarkIcon,
-  type BreadcrumbsItem,
 } from "@dust-tt/sparkle";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-
-interface FileExplorerBreadcrumbProps {
-  currentFolderPath: string;
-  onNavigate: (index: number) => void;
-}
-
-function FileExplorerBreadcrumb({
-  currentFolderPath,
-  onNavigate,
-}: FileExplorerBreadcrumbProps) {
-  const segments = getFolderBreadcrumbSegments(currentFolderPath);
-  const items: BreadcrumbsItem[] = [
-    { label: ROOT_FOLDER_LABEL, onClick: () => onNavigate(-1) },
-    ...segments.map((segment, i) => ({
-      label: segment.label,
-      onClick: () => onNavigate(i),
-    })),
-  ];
-
-  return <Breadcrumbs items={items} size="sm" buttonVariant="outline" />;
-}
 
 interface FileExplorerProps {
   contentClassName?: string;
@@ -243,11 +220,6 @@ export function FileExplorer({
     setCurrentFolderPath(getParentFolderRelativePath(currentFolderPath));
   };
 
-  const parentFolderPath = getParentFolderRelativePath(currentFolderPath);
-  const parentFolderLabel = parentFolderPath
-    ? (parentFolderPath.split("/").at(-1) ?? ROOT_FOLDER_LABEL)
-    : ROOT_FOLDER_LABEL;
-
   const fileDragEnabled = Boolean(onMoveFile && totalFolderCount > 0);
 
   const handleMoveFileDrop = useCallback(
@@ -316,10 +288,16 @@ export function FileExplorer({
           >
             <div
               className={cn(
-                "flex h-full items-center justify-end gap-2 px-4",
+                "flex h-full items-center justify-between gap-2 px-4",
                 contentClassName
               )}
             >
+              <FileExplorerBreadcrumb
+                currentFolderPath={currentFolderPath}
+                onGoUp={handleGoUp}
+                onNavigate={handleBreadcrumbNavigate}
+                onMoveFileDrop={fileDragEnabled ? handleMoveFileDrop : undefined}
+              />
               <Button
                 variant="ghost"
                 size="sm"
@@ -336,6 +314,14 @@ export function FileExplorer({
             inPanel ? "pt-5" : undefined
           )}
         >
+          {!inPanel && (
+            <FileExplorerBreadcrumb
+              currentFolderPath={currentFolderPath}
+              onGoUp={handleGoUp}
+              onNavigate={handleBreadcrumbNavigate}
+              onMoveFileDrop={fileDragEnabled ? handleMoveFileDrop : undefined}
+            />
+          )}
           <div className={inPanel ? "px-4" : undefined}>
             <FileExplorerToolbar
               searchQuery={searchQuery}
@@ -356,14 +342,6 @@ export function FileExplorer({
               />
             </div>
           )}
-          {currentFolderPath !== "" && (
-            <div className={inPanel ? "px-4" : undefined}>
-              <FileExplorerBreadcrumb
-                currentFolderPath={currentFolderPath}
-                onNavigate={handleBreadcrumbNavigate}
-              />
-            </div>
-          )}
           <FileExplorerContent
             isLoading={isLoading}
             sortedNodes={sortedNodes}
@@ -372,11 +350,6 @@ export function FileExplorer({
             isEmpty={fileCount === 0 && folderCount === 0}
             emptyState={emptyState}
             fileDragEnabled={fileDragEnabled}
-            parentFolderDropPath={parentFolderPath}
-            parentFolderLabel={
-              currentFolderPath ? parentFolderLabel : undefined
-            }
-            onGoUp={currentFolderPath ? handleGoUp : undefined}
             onFolderNavigate={handleFolderNavigate}
             onFileOpen={handleFileOpen}
             onFileDownload={onFileDownload}

--- a/front/components/file_explorer/FileExplorerBreadcrumb.tsx
+++ b/front/components/file_explorer/FileExplorerBreadcrumb.tsx
@@ -1,0 +1,127 @@
+import {
+  canMoveFileToParentFolder,
+  useFileExplorerDropTarget,
+  useIsFileExplorerDragging,
+} from "@app/components/file_explorer/fileExplorerDragDrop";
+import {
+  getFolderBreadcrumbSegments,
+  ROOT_FOLDER_LABEL,
+} from "@app/components/file_explorer/utils";
+import {
+  ArrowLeftIcon,
+  Breadcrumb,
+  BreadcrumbButton,
+  BreadcrumbItem,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  Button,
+  cn,
+} from "@dust-tt/sparkle";
+import type React from "react";
+
+interface BreadcrumbDropZoneProps {
+  disabled: boolean;
+  parentRelativePath: string;
+  onMoveFileDrop?: (scopedFilePath: string, parentRelativePath: string) => void;
+  children: React.ReactNode;
+}
+
+function BreadcrumbDropZone({
+  disabled,
+  parentRelativePath,
+  onMoveFileDrop,
+  children,
+}: BreadcrumbDropZoneProps) {
+  const { isDragOver, dropTargetProps } = useFileExplorerDropTarget({
+    disabled,
+    onDrop: (scopedFilePath) => {
+      if (
+        onMoveFileDrop &&
+        canMoveFileToParentFolder(scopedFilePath, parentRelativePath)
+      ) {
+        onMoveFileDrop(scopedFilePath, parentRelativePath);
+      }
+    },
+  });
+
+  return (
+    <div
+      {...dropTargetProps}
+      className={
+        isDragOver
+          ? cn(
+              "rounded-xl",
+              "ring-2 ring-highlight-400 dark:ring-highlight-400-night"
+            )
+          : undefined
+      }
+    >
+      {children}
+    </div>
+  );
+}
+
+export interface FileExplorerBreadcrumbProps {
+  currentFolderPath: string;
+  onGoUp: () => void;
+  onNavigate: (index: number) => void;
+  onMoveFileDrop?: (scopedFilePath: string, parentRelativePath: string) => void;
+}
+
+export function FileExplorerBreadcrumb({
+  currentFolderPath,
+  onGoUp,
+  onNavigate,
+  onMoveFileDrop,
+}: FileExplorerBreadcrumbProps) {
+  const isDragging = useIsFileExplorerDragging();
+  const segments = getFolderBreadcrumbSegments(currentFolderPath);
+  const allItems = [
+    { label: ROOT_FOLDER_LABEL, path: "" },
+    ...segments.map((s) => ({ label: s.label, path: s.path })),
+  ];
+
+  return (
+    <div className="flex items-center gap-2">
+      {currentFolderPath !== "" &&
+        (isDragging ? (
+          <span className="animate-in fade-in slide-in-from-left-1 duration-150 text-sm font-medium leading-5 text-foreground dark:text-foreground-night">
+            Move to…
+          </span>
+        ) : (
+          <Button
+            aria-label="Go to parent folder"
+            variant="ghost"
+            size="sm"
+            icon={ArrowLeftIcon}
+            onClick={onGoUp}
+          />
+        ))}
+      <Breadcrumb>
+        {allItems.map((item, index) => {
+          const isLast = index === allItems.length - 1;
+          return (
+            <BreadcrumbItem key={item.path}>
+              <BreadcrumbDropZone
+                disabled={!isDragging || isLast || !onMoveFileDrop}
+                parentRelativePath={item.path}
+                onMoveFileDrop={onMoveFileDrop}
+              >
+                {isLast ? (
+                  <BreadcrumbPage>{item.label}</BreadcrumbPage>
+                ) : (
+                  <BreadcrumbButton
+                    label={item.label}
+                    variant={isDragging ? "outline" : "ghost"}
+                    onClick={() => onNavigate(index - 1)}
+                  />
+                )}
+              </BreadcrumbDropZone>
+              {!isLast && <BreadcrumbSeparator />}
+            </BreadcrumbItem>
+          );
+        })}
+      </Breadcrumb>
+    </div>
+  );
+}

--- a/front/components/file_explorer/FileExplorerContent.tsx
+++ b/front/components/file_explorer/FileExplorerContent.tsx
@@ -3,7 +3,6 @@ import {
   FileExplorerEmptyState,
   FileExplorerFileCard,
   FileExplorerFolderCard,
-  FileExplorerGoUpCard,
   type ViewMode,
 } from "@app/components/file_explorer/FileExplorerItem";
 import type {
@@ -29,9 +28,6 @@ interface FileExplorerContentProps {
   isEmpty: boolean;
   emptyState?: React.ReactNode;
   fileDragEnabled?: boolean;
-  parentFolderDropPath?: string;
-  parentFolderLabel?: string;
-  onGoUp?: () => void;
   onFolderNavigate: (node: FileSystemTreeNode) => void;
   onFileOpen: (entry: FileEntry) => void;
   onFileDownload: (entry: FileEntry) => Promise<void>;
@@ -48,9 +44,6 @@ export function FileExplorerContent({
   isEmpty,
   emptyState,
   fileDragEnabled,
-  parentFolderDropPath,
-  parentFolderLabel,
-  onGoUp,
   onFolderNavigate,
   onFileOpen,
   onFileDownload,
@@ -58,20 +51,6 @@ export function FileExplorerContent({
   onNodeOpen,
   getFileMenuItems,
 }: FileExplorerContentProps) {
-  const canGoUp = Boolean(onGoUp && parentFolderLabel);
-
-  const goUpItem =
-    canGoUp && parentFolderLabel && onGoUp ? (
-      <FileExplorerGoUpCard
-        key="go-up"
-        parentLabel={parentFolderLabel}
-        parentRelativePath={parentFolderDropPath ?? ""}
-        viewMode={viewMode}
-        onGoUp={onGoUp}
-        onMoveFileDrop={onMoveFileDrop}
-      />
-    ) : null;
-
   const items = sortedNodes.map((node) => {
     if (node.isDirectory) {
       return (
@@ -129,7 +108,7 @@ export function FileExplorerContent({
     );
   }
 
-  if (isEmpty && !canGoUp) {
+  if (isEmpty) {
     return (
       <div className="flex flex-1 items-center justify-center px-4">
         {emptyState ?? <FileExplorerEmptyState />}
@@ -137,36 +116,13 @@ export function FileExplorerContent({
     );
   }
 
-  if (isEmpty && canGoUp) {
-    return (
-      <ScrollArea className="min-h-0 flex-1">
-        <div className="flex flex-col gap-5 px-4">
-          {viewMode === "list" ? (
-            <div className="flex flex-col gap-0.5">{goUpItem}</div>
-          ) : (
-            <CardGrid gridClassName={cardGridClasses}>{goUpItem}</CardGrid>
-          )}
-          <div className="flex flex-1 items-center justify-center py-8">
-            {emptyState ?? <FileExplorerEmptyState />}
-          </div>
-        </div>
-      </ScrollArea>
-    );
-  }
-
   return (
     <ScrollArea className="min-h-0 flex-1">
       <div className="flex flex-col gap-5 px-4">
         {viewMode === "list" ? (
-          <div className="flex flex-col gap-0.5">
-            {goUpItem}
-            {items}
-          </div>
+          <div className="flex flex-col gap-0.5">{items}</div>
         ) : (
-          <CardGrid gridClassName={cardGridClasses}>
-            {goUpItem}
-            {items}
-          </CardGrid>
+          <CardGrid gridClassName={cardGridClasses}>{items}</CardGrid>
         )}
       </div>
     </ScrollArea>

--- a/front/components/file_explorer/FileExplorerItem.tsx
+++ b/front/components/file_explorer/FileExplorerItem.tsx
@@ -20,7 +20,6 @@ import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_provide
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
 import {
   ArrowDownOnSquareIcon,
-  ArrowLeftIcon,
   Button,
   CloudArrowLeftRightIcon,
   DropdownMenu,
@@ -258,42 +257,6 @@ function FileExplorerDropTargetWrapper({
         surfaceClassName: getFileExplorerDropSurfaceClassName(isDragOver),
       })}
     </div>
-  );
-}
-
-export interface FileExplorerGoUpCardProps {
-  parentLabel: string;
-  parentRelativePath: string;
-  viewMode: ViewMode;
-  onGoUp: () => void;
-  onMoveFileDrop?: (scopedFilePath: string, parentRelativePath: string) => void;
-}
-
-export function FileExplorerGoUpCard({
-  parentLabel,
-  parentRelativePath,
-  viewMode,
-  onGoUp,
-  onMoveFileDrop,
-}: FileExplorerGoUpCardProps) {
-  return (
-    <FileExplorerDropTargetWrapper
-      disabled={!onMoveFileDrop}
-      onDrop={onMoveFileDrop}
-      parentRelativePath={parentRelativePath}
-    >
-      {({ surfaceClassName }) => (
-        <FileExplorerItem
-          kind="icon"
-          visual={ArrowLeftIcon}
-          viewMode={viewMode}
-          title="Back"
-          subtitle={`Browse "${parentLabel}"`}
-          surfaceClassName={surfaceClassName}
-          onOpen={onGoUp}
-        />
-      )}
-    </FileExplorerDropTargetWrapper>
   );
 }
 

--- a/front/components/file_explorer/fileExplorerDragDrop.ts
+++ b/front/components/file_explorer/fileExplorerDragDrop.ts
@@ -4,12 +4,12 @@ import {
 } from "@app/components/file_explorer/utils";
 import { cn } from "@app/components/poke/shadcn/lib/utils";
 import type React from "react";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 /** Drop-target highlight for folder / go-up cards (owned by card wrappers, not FileExplorerItem). */
 export const fileExplorerDropActiveClasses = cn(
-  "ring-2 ring-primary-400 ring-inset dark:ring-primary-400-night",
-  "bg-primary-100 dark:bg-primary-100-night"
+  "ring-2 ring-highlight-400 ring-inset dark:ring-highlight-400-night",
+  "bg-highlight-100 dark:bg-highlight-100-night"
 );
 
 export function getFileExplorerDropSurfaceClassName(
@@ -51,6 +51,32 @@ export function canMoveFileToParentFolder(
   return (
     getCurrentParentRelativePath(fileScopedPath) !== targetParentRelativePath
   );
+}
+
+/** True for the lifetime of a file-explorer drag operation (dragstart → dragend/drop). */
+export function useIsFileExplorerDragging(): boolean {
+  const [isDragging, setIsDragging] = useState(false);
+
+  useEffect(() => {
+    const start = (e: DragEvent) => {
+      if (e.dataTransfer && hasFileExplorerDrag(e.dataTransfer)) {
+        setIsDragging(true);
+      }
+    };
+    const stop = () => setIsDragging(false);
+
+    document.addEventListener("dragstart", start);
+    document.addEventListener("dragend", stop);
+    document.addEventListener("drop", stop);
+
+    return () => {
+      document.removeEventListener("dragstart", start);
+      document.removeEventListener("dragend", stop);
+      document.removeEventListener("drop", stop);
+    };
+  }, []);
+
+  return isDragging;
 }
 
 export function useFileExplorerDropTarget({


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See design [here](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=9623-138975&m=dev).

This PR replaces the "go up" card in the file explorer grid with a proper breadcrumb bar. The breadcrumb is always visible, showing "All files" at the root and gains a back-arrow button when inside a subfolder. In panel mode (conversation drawer), the breadcrumb lives in the `AppLayoutTitle` alongside the close button.

Drag-and-drop is integrated into the breadcrumb: while dragging a file, all non-current breadcrumb items switch to outline buttons to signal they are drop targets, and a blue external ring appears on the item being hovered. The back-arrow is replaced by a "Move to…" label that animates in, making the drag intent explicit without being interactive itself.

This depends on the composable breadcrumb primitives (Breadcrumb, BreadcrumbButton, BreadcrumbItem, BreadcrumbPage, BreadcrumbSeparator) and the BreadcrumbsItem type rename shipped in the Sparkle PR that has already been merged.

<img width="1144" height="1104" alt="FileExplorerBreadcrumb" src="https://github.com/user-attachments/assets/5c485dfd-40a4-469d-b7cf-c7648f207d92" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
