### PR TITLE
refactor(sandbox): ensureSandboxReady returns {sandbox, freshlyCreated}

### DIFF
--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -251,7 +251,9 @@ describe("runSandboxBashTool", () => {
         ),
     };
 
-    mockEnsureSandboxReady.mockResolvedValue(new Ok(sandbox));
+    mockEnsureSandboxReady.mockResolvedValue(
+      new Ok({ sandbox, freshlyCreated: false })
+    );
 
     const result = await runSandboxBashTool(
       { command: "echo hello", description: "Run command" },
@@ -283,7 +285,9 @@ describe("runSandboxBashTool", () => {
       ),
     };
 
-    mockEnsureSandboxReady.mockResolvedValue(new Ok(sandbox));
+    mockEnsureSandboxReady.mockResolvedValue(
+      new Ok({ sandbox, freshlyCreated: false })
+    );
 
     const result = await runSandboxBashTool(
       { command: "echo token", description: "Run command" },
@@ -319,7 +323,9 @@ describe("runSandboxBashTool", () => {
         .mockResolvedValue(new Ok({ exitCode: 0, stdout: "ok", stderr: "" })),
     };
 
-    mockEnsureSandboxReady.mockResolvedValue(new Ok(sandbox));
+    mockEnsureSandboxReady.mockResolvedValue(
+      new Ok({ sandbox, freshlyCreated: false })
+    );
 
     const result = await runSandboxBashTool(
       { command: "echo ok", description: "Run command" },
@@ -358,7 +364,9 @@ describe("runSandboxBashTool", () => {
       ),
     };
 
-    mockEnsureSandboxReady.mockResolvedValue(new Ok(sandbox));
+    mockEnsureSandboxReady.mockResolvedValue(
+      new Ok({ sandbox, freshlyCreated: false })
+    );
 
     const result = await runSandboxBashTool(
       { command: "echo values", description: "Run command" },
@@ -393,7 +401,9 @@ describe("runSandboxBashTool", () => {
         ),
     };
 
-    mockEnsureSandboxReady.mockResolvedValue(new Ok(sandbox));
+    mockEnsureSandboxReady.mockResolvedValue(
+      new Ok({ sandbox, freshlyCreated: false })
+    );
 
     const result = await runSandboxBashTool(
       { command: "echo secret", description: "Run command" },
@@ -495,7 +505,9 @@ describe("addEgressDomainTool", () => {
       providerId: "provider-id",
       sId: "sandbox-id",
     };
-    mockEnsureSandboxReady.mockResolvedValue(new Ok(sandbox));
+    mockEnsureSandboxReady.mockResolvedValue(
+      new Ok({ sandbox, freshlyCreated: false })
+    );
 
     const result = await addEgressDomainTool(
       {
@@ -540,8 +552,11 @@ describe("addEgressDomainTool", () => {
   it("reports the domain as already allowed when nothing changed", async () => {
     mockEnsureSandboxReady.mockResolvedValue(
       new Ok({
-        providerId: "provider-id",
-        sId: "sandbox-id",
+        sandbox: {
+          providerId: "provider-id",
+          sId: "sandbox-id",
+        },
+        freshlyCreated: false,
       })
     );
     mockAddSandboxPolicyDomain.mockResolvedValue(
@@ -576,8 +591,11 @@ describe("addEgressDomainTool", () => {
   it("rejects wildcard domains before writing policy", async () => {
     mockEnsureSandboxReady.mockResolvedValue(
       new Ok({
-        providerId: "provider-id",
-        sId: "sandbox-id",
+        sandbox: {
+          providerId: "provider-id",
+          sId: "sandbox-id",
+        },
+        freshlyCreated: false,
       })
     );
 
@@ -636,8 +654,11 @@ describe("addEgressDomainTool", () => {
   it("surfaces sandbox policy helper errors", async () => {
     mockEnsureSandboxReady.mockResolvedValue(
       new Ok({
-        providerId: "provider-id",
-        sId: "sandbox-id",
+        sandbox: {
+          providerId: "provider-id",
+          sId: "sandbox-id",
+        },
+        freshlyCreated: false,
       })
     );
     mockAddSandboxPolicyDomain.mockResolvedValue(

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -240,7 +240,7 @@ export async function runSandboxBashTool(
     return new Err(new MCPError(ensureResult.error.message));
   }
 
-  const sandbox = ensureResult.value;
+  const { sandbox } = ensureResult.value;
 
   const execId = generateExecId();
   const sandboxToken = await generateSandboxExecToken(auth, {
@@ -343,7 +343,7 @@ export async function addEgressDomainTool(
   if (ensureResult.isErr()) {
     return new Err(new MCPError(ensureResult.error.message));
   }
-  const sandbox = ensureResult.value;
+  const { sandbox } = ensureResult.value;
 
   const parsed = parseExactEgressDomain(domain);
   if (parsed.isErr()) {

--- a/front/lib/api/actions/servers/skill_management/tools/index.test.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.test.ts
@@ -51,7 +51,10 @@ describe("skill_management enable_skill tool", () => {
     mockGetFeatureFlags.mockResolvedValue(["sandbox_tools"]);
     mockEnsureSandboxReady.mockResolvedValue(
       new Ok({
-        loadSkillFiles: mockLoadSkillFiles,
+        sandbox: {
+          loadSkillFiles: mockLoadSkillFiles,
+        },
+        freshlyCreated: false,
       })
     );
     mockLoadSkillFiles.mockResolvedValue(

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -67,7 +67,7 @@ const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
       return new Err(new MCPError(ensureResult.error.message));
     }
 
-    const sandbox = ensureResult.value;
+    const { sandbox } = ensureResult.value;
 
     let fileMessage: string | null = null;
     const fileLoadResult = await sandbox.loadSkillFiles(auth, skill);

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -14,13 +14,18 @@ import logger from "@app/logger/logger";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import { Ok, type Result } from "@app/types/shared/result";
 
+export interface EnsureSandboxReadyResult {
+  sandbox: SandboxResource;
+  freshlyCreated: boolean;
+}
+
 // /!\ All sandbox-touching tools must use this helper rather than calling
 // SandboxResource.ensureActive directly, otherwise the GCS FUSE mount and
 // egress forwarder bring-up will be skipped.
 export async function ensureSandboxReady(
   auth: Authenticator,
   conversation: ConversationType
-): Promise<Result<SandboxResource, Error>> {
+): Promise<Result<EnsureSandboxReadyResult, Error>> {
   const ensureResult = await SandboxResource.ensureActive(auth, conversation);
   if (ensureResult.isErr()) {
     return ensureResult;
@@ -87,5 +92,5 @@ export async function ensureSandboxReady(
     return ensureEgressResult;
   }
 
-  return new Ok(sandbox);
+  return new Ok({ sandbox, freshlyCreated });
 }


### PR DESCRIPTION
## Description

Refactors `ensureSandboxReady` to return `{ sandbox, freshlyCreated }` instead of `sandbox` alone, threading through a flag callers can use to detect whether the sandbox was created from scratch (vs. woken from sleep).

This is required by the upcoming bash-pause flow: when the bash tool tries to resume a paused exec, the sandbox may have been deleted across the pause window (reaper transitioned it to `sleeping` and then deleted it, or the provider GC'd it). In that case the original exec's tee output file is gone and `wait-and-collect` would loop forever. The bash tool will check `freshlyCreated` and fail clean with an MCPError. That logic lands in a follow-up PR — here `freshlyCreated` is plumbed but unused.

Touches three call sites:

- `skill_management/enable_skill` — destructures `{ sandbox }`
- `sandbox.runSandboxBashTool` — destructures `{ sandbox }`
- `sandbox.addEgressDomainTool` — destructures `{ sandbox }`

Plus the corresponding test-mock updates so `mockEnsureSandboxReady` returns the new shape.

## Tests

- `npm run test -- lib/api/actions/servers/sandbox/tools/index.test.ts` — 17 tests pass
- `npm run test -- lib/api/actions/servers/skill_management/tools/index.test.ts` — 2 tests pass

## Risk

Very low. Pure structural refactor — every caller is updated in the same PR and `freshlyCreated` has no consumer yet.

Rollback: straight revert; no schema or migration.

## Deploy Plan

Standard front rollout. No coordination needed.