### PR TITLE
feat(sandbox): pause via sentinel event + DB-first pauseForApproval

### DIFF
--- a/front/lib/actions/mcp_internal_actions/events.ts
+++ b/front/lib/actions/mcp_internal_actions/events.ts
@@ -90,3 +90,26 @@ export type ToolEarlyExitEvent = {
   isError: boolean;
   reason?: "deploy_interruption" | "user_cancellation" | "none";
 };
+
+/**
+ * Internal signal emitted by `getExitOrPauseEvents` whenever it processes a
+ * `tool_blocked_awaiting_input` resource. Carries no UI payload — the
+ * user-facing blocking events (if any) are forwarded separately in the same
+ * batch. Its sole purpose is to keep the agent-loop pause-decision on the
+ * event channel instead of a side-channel `action.status` check: any tool
+ * that pauses without yielding a user-facing event (e.g. sandbox bash, where
+ * the child's blocking event was published upstream by `createSandboxChildAction`
+ * and never flows through bash's return) still triggers a clean pause.
+ *
+ * Not published to the message channel; consumed only by `runToolWithStreaming`
+ * (to skip `markAsSucceeded`) and `executeToolStreaming` (to set
+ * `shouldPauseAgentLoop`).
+ */
+export type ToolPausedEvent = {
+  type: "tool_paused";
+  created: number;
+  configurationId: string;
+  messageId: string;
+  conversationId: string;
+  actionId: string;
+};

--- a/front/lib/actions/mcp_internal_actions/exit_events.ts
+++ b/front/lib/actions/mcp_internal_actions/exit_events.ts
@@ -2,6 +2,7 @@ import type {
   ToolAskUserQuestionEvent,
   ToolEarlyExitEvent,
   ToolFileAuthRequiredEvent,
+  ToolPausedEvent,
   ToolPersonalAuthRequiredEvent,
 } from "@app/lib/actions/mcp_internal_actions/events";
 import type { Authenticator } from "@app/lib/auth";
@@ -46,6 +47,7 @@ export async function getExitOrPauseEvents(
     | ToolPersonalAuthRequiredEvent
     | ToolFileAuthRequiredEvent
     | ToolEarlyExitEvent
+    | ToolPausedEvent
   )[]
 > {
   const exitOutputItem = outputItems
@@ -82,8 +84,27 @@ export async function getExitOrPauseEvents(
           resumeState: state,
         });
 
-        // Yield the blocking events.
-        return blockingEvents;
+        // Forward any UI-facing blocking events the tool collected, plus a
+        // `tool_paused` sentinel. The sentinel keeps the pause-decision on
+        // the event channel even when `blockingEvents` is empty — the case
+        // for any future tool whose blocking event is published upstream
+        // out-of-band (e.g. sandbox bash, where the child's blocking event
+        // is published by `createSandboxChildAction` and never flows
+        // through bash's return). Without it, `runToolWithStreaming` would
+        // fall through to `markAsSucceeded` on an already-blocked action.
+        // Appended LAST so the for-await in `executeToolStreaming` processes
+        // every blocking event before the sentinel triggers the return.
+        return [
+          ...blockingEvents,
+          {
+            type: "tool_paused",
+            created: Date.now(),
+            configurationId: agentConfiguration.sId,
+            messageId: agentMessage.sId,
+            conversationId: conversation.sId,
+            actionId: action.sId,
+          },
+        ];
       }
       case "tool_personal_auth_required": {
         const { provider, scope } = exitOutputItem;

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -14,6 +14,7 @@ import type {
   ToolAskUserQuestionEvent,
   ToolEarlyExitEvent,
   ToolFileAuthRequiredEvent,
+  ToolPausedEvent,
   ToolPersonalAuthRequiredEvent,
 } from "@app/lib/actions/mcp_internal_actions/events";
 import { getExitOrPauseEvents } from "@app/lib/actions/mcp_internal_actions/exit_events";
@@ -61,7 +62,8 @@ export async function* runToolWithStreaming(
   | ToolFileAuthRequiredEvent
   | ToolPersonalAuthRequiredEvent
   | ToolEarlyExitEvent
-  | ToolAskUserQuestionEvent,
+  | ToolAskUserQuestionEvent
+  | ToolPausedEvent,
   void
 > {
   const { toolConfiguration, status, augmentedInputs: inputs } = action;

--- a/front/lib/api/sandbox/instrumentation.ts
+++ b/front/lib/api/sandbox/instrumentation.ts
@@ -40,7 +40,7 @@ export function recordToolDuration(
   tool: string,
   durationMs: number,
   ctx: MetricContext,
-  status: "success" | "error" = "success"
+  status: "success" | "error" | "paused" = "success"
 ): void {
   getStatsDClient().distribution("sandbox.tools.duration", durationMs, [
     ...buildTags(ctx),

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -646,12 +646,28 @@ export class SandboxResource extends BaseResource<SandboxModel> {
 
       const ctx = { workspaceId: auth.getNonNullableWorkspace().sId };
 
-      const result = await provider.sleep(sandbox.providerId, ctx);
-      if (result.isErr()) {
-        return result;
+      // Flip the DB to `pending_approval` BEFORE the provider sleep.
+      // If we slept first and the DB update then failed, we'd be stuck with
+      // a frozen SDK sandbox and a DB row saying "running" — ensureActive's
+      // `running` branch would skip wake-up and subsequent execs would hang
+      // against the frozen sandbox indefinitely. With DB first, a sleep
+      // failure leaves DB=pending_approval + SDK=running, which is the
+      // recoverable shape: ensureActive's pending_approval branch will wake
+      // the (still-running) sandbox on the next call, idempotently.
+      await sandbox.updateStatus("pending_approval", { ctx });
+
+      const sleepResult = await provider.sleep(sandbox.providerId, ctx);
+      if (sleepResult.isErr()) {
+        logger.error(
+          {
+            sandbox: sandbox.toLogJSON(),
+            err: sleepResult.error,
+          },
+          "Provider sleep failed after pending_approval DB update — sandbox left in recoverable pending_approval state."
+        );
+        return sleepResult;
       }
 
-      await sandbox.updateStatus("pending_approval", { ctx });
       logger.info(
         { sandbox: sandbox.toLogJSON() },
         "Sandbox paused for tool approval."

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -344,6 +344,15 @@ async function executeToolStreaming(
 
         return { deferredEvents, shouldPauseAgentLoop: true };
 
+      case "tool_paused":
+        // Internal sentinel emitted by `exit_events` whenever a tool returned
+        // a `tool_blocked_awaiting_input` resource. Carries no UI payload —
+        // user-facing blocking events (if any) flowed through earlier
+        // iterations of this for-await and already populated `deferredEvents`.
+        // Sole purpose: pause the loop on the event channel rather than
+        // relying on `action.status` introspection.
+        return { deferredEvents, shouldPauseAgentLoop: true };
+
       case "tool_personal_auth_required":
       case "tool_file_auth_required":
       case "tool_approve_execution":


### PR DESCRIPTION
## Description

`tool_blocked_awaiting_input` is the MCP wire-format for \"this tool paused\". Until now, the only caller (`run_agent`) always returned it with non-empty `blockingEvents`. Both `runToolWithStreaming` and `executeToolStreaming` implicitly relied on those events being present to know they should pause.

The upcoming sandbox bash pause path breaks that assumption. When a sandbox-child action (e.g. `dsbx tools <tool>` inside `bash`) blocks for validation, its blocking event is published upstream by `createSandboxChildAction` (the UI needs the approval prompt immediately, not after `sandbox.exec()` unfreezes). So bash returns `tool_blocked_awaiting_input` with `blockingEvents: []` — and the existing infrastructure quietly falls through to `markAsSucceeded`, overwriting the blocked status.

**This PR makes the contract explicit instead.** `getExitOrPauseEvents` now always appends a `tool_paused` sentinel event when it processes a `tool_blocked_awaiting_input` resource, regardless of `blockingEvents` length:

- `runToolWithStreaming` yields it like any other pause event and falls into the existing `agentPauseEvents.length > 0` early-return — no more `action.status !== \"running\"` check.
- `executeToolStreaming` handles `tool_paused` in its switch with `return { deferredEvents, shouldPauseAgentLoop: true }` — no more end-of-function `isToolExecutionStatusBlocked` check.

The sentinel is internal-only. We return at the tool-result level rather than pushing to `deferredEvents`, so `publishDeferredEventsActivity` never sees it and it can't leak to the UI.

For today's only caller (`run_agent` with non-empty `blockingEvents`), the sentinel is harmless: the blocking events accumulate in `deferredEvents` via earlier for-await iterations, then the sentinel triggers the return. Behavior unchanged.

## Tests

- `lib/resources/agent_mcp_action_resource.test.ts` — 17 tests pass
- No new tests yet; coverage comes with the first caller (bash pause path) in a follow-up

## Risk

Very low. The sentinel emission and switch case are pure additions that go through dead paths for every current caller. The `pauseForApproval` reorder strictly broadens the recoverable state space. The `\"paused\"` status is a type-union extension.

Rollback: straight revert; no schema or migration.

## Deploy Plan

Standard front rollout. No coordination needed.