### PR TITLE
Batch mode when using Vertex AI

### DIFF
--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -134,7 +134,6 @@ export class AnthropicLLM extends LLM<LLMStreamParameters> {
       apiKey: ANTHROPIC_API_KEY,
     });
 
-    // Vertex does not support batches.
     this.inferenceClient = getInferenceClient(this.useVertex, {
       anthropicClient: this.client,
     });
@@ -267,24 +266,28 @@ export class AnthropicLLM extends LLM<LLMStreamParameters> {
       { concurrency: BATCH_PAYLOAD_BUILD_CONCURRENCY }
     );
 
-    const batch = await this.client.messages.batches.create({ requests });
+    // @ts-expect-error AnthropicVertex SDK omits batches but Vertex supports it.
+    const batch = await this.inferenceClient.messages.batches.create({ requests });
     return batch.id;
   }
 
   override async deleteBatch(batchId: string): Promise<boolean> {
-    await this.client.messages.batches.delete(batchId);
+    // @ts-expect-error AnthropicVertex SDK omits batches but Vertex supports it.
+    await this.inferenceClient.messages.batches.delete(batchId);
     return true;
   }
 
   override async getBatchStatus(batchId: string): Promise<BatchStatus> {
-    const batch = await this.client.messages.batches.retrieve(batchId);
+    // @ts-expect-error AnthropicVertex SDK omits batches but Vertex supports it.
+    const batch = await this.inferenceClient.messages.batches.retrieve(batchId);
     return batch.processing_status === "ended" ? "ready" : "computing";
   }
 
   protected override async internalGetBatchResult(
     batchId: string
   ): Promise<BatchResult> {
-    const results = await this.client.messages.batches.results(batchId);
+    // @ts-expect-error AnthropicVertex SDK omits batches but Vertex supports it.
+    const results = await this.inferenceClient.messages.batches.results(batchId);
     const batchResult: BatchResult = new Map();
 
     for await (const item of results) {

--- a/front/lib/api/llm/tests/llmBatch.test.ts
+++ b/front/lib/api/llm/tests/llmBatch.test.ts
@@ -8,6 +8,7 @@ import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { setTimeoutAsync } from "@app/lib/utils/async_utils";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { isModelProviderId } from "@app/types/assistant/models/providers";
 import type { ModelIdType } from "@app/types/assistant/models/types";
@@ -47,6 +48,30 @@ vi.mock("openai", async (importOriginal) => {
   };
 });
 
+// Mock the @anthropic-ai/vertex-sdk module to inject dangerouslyAllowBrowser: true
+vi.mock("@anthropic-ai/vertex-sdk", async (importOriginal) => {
+  const actual = await importOriginal();
+  // @ts-expect-error actual is unknown
+  const OriginalAnthropicVertex = actual.default;
+
+  class AnthropicVertexWithBrowserSupport extends OriginalAnthropicVertex {
+    constructor(
+      config: ConstructorParameters<typeof OriginalAnthropicVertex>[0]
+    ) {
+      super({
+        ...config,
+        dangerouslyAllowBrowser: true,
+      });
+    }
+  }
+
+  return {
+    // @ts-expect-error actual is unknown
+    ...actual,
+    default: AnthropicVertexWithBrowserSupport,
+  };
+});
+
 // Mock the @anthropic-ai/sdk module to inject dangerouslyAllowBrowser: true
 vi.mock("@anthropic-ai/sdk", async (importOriginal) => {
   const actual = await importOriginal();
@@ -71,6 +96,7 @@ vi.mock("@anthropic-ai/sdk", async (importOriginal) => {
 
 const RUN_LLM_BATCH_TEST = process.env.RUN_LLM_BATCH_TEST === "true";
 const RUN_ALL_MODEL_TESTS = process.env.RUN_ALL_MODEL_TESTS === "true";
+const VERTEX = process.env.VERTEX === "true";
 
 const modelsWithBatchSupport = Object.entries(MODELS)
   .filter(([modelId, { providerId }]) => {
@@ -274,6 +300,12 @@ describe.skipIf(!RUN_LLM_BATCH_TEST || modelsWithBatchSupport.length === 0)(
           const { authenticator } = await createResourceTest({
             role: "admin",
           });
+          if (VERTEX) {
+            await FeatureFlagFactory.basic(
+              authenticator,
+              "use_vertex_for_anthropic_models"
+            );
+          }
           const credentials = await getLlmCredentials(authenticator, {
             skipEmbeddingApiKeyRequirement: true,
           });

--- a/front/lib/api/llm/tests/models.ts
+++ b/front/lib/api/llm/tests/models.ts
@@ -103,7 +103,7 @@ export const MODELS: Record<
     providerId: "anthropic",
   },
   [CLAUDE_OPUS_4_6_MODEL_ID]: {
-    runTest: false,
+    runTest: true,
     providerId: "anthropic",
   },
   [CLAUDE_OPUS_4_7_MODEL_ID]: {

--- a/front/lib/api/llm/tests/vite.config.js
+++ b/front/lib/api/llm/tests/vite.config.js
@@ -33,6 +33,12 @@ export default defineConfig(() => {
         FILTER_CONVERSATION_IDS: process.env.FILTER_CONVERSATION_IDS ?? "",
         // When set to "true", run all model tests regardless of their `runTest` flag
         RUN_ALL_MODEL_TESTS: process.env.RUN_ALL_MODEL_TESTS ?? "false",
+        // When set to "true", route Anthropic models through Vertex AI
+        VERTEX: process.env.VERTEX ?? "false",
+        VERTEX_AI_PROJECT_ID: process.env.VERTEX_AI_PROJECT_ID ?? "",
+        // forward the google application credentials required for Vertex AI.
+        GOOGLE_APPLICATION_CREDENTIALS: process.env.GOOGLE_APPLICATION_CREDENTIALS,
+
       },
     },
   });
@@ -41,7 +47,11 @@ export default defineConfig(() => {
   const merged = mergeConfig(baseConfig, testConfig);
   // By default, skip DB setup (globalSetup/setupFiles). Set RUN_LLM_TEST_WITH_DB=true
   // to keep them (needed for tests that store LLM results in the database).
-  if (process.env.RUN_LLM_TEST_WITH_DB !== "true") {
+  // VERTEX=true implies DB setup (feature flags are stored in the database).
+  if (
+    process.env.RUN_LLM_TEST_WITH_DB !== "true" &&
+    process.env.VERTEX !== "true"
+  ) {
     merged.test.globalSetup = [];
   }
   merged.test.environment = "node"; // LLM tests need Node.js env for stream uploads

--- a/front/lib/reinforcement/models.ts
+++ b/front/lib/reinforcement/models.ts
@@ -1,19 +1,9 @@
 import { getLargeWhitelistedModel } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
-import { hasFeatureFlag } from "@app/lib/auth";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 
-// TODO: remove the vertex exclusion when vertex supports batch mode
 export async function getLargeWhitelistedModelWithBatchMode(
   auth: Authenticator
 ): Promise<ModelConfigurationType | null> {
-  const useVertex = await hasFeatureFlag(
-    auth,
-    "use_vertex_for_anthropic_models"
-  );
-  const excludedProviders = useVertex
-    ? new Set<"anthropic">(["anthropic"])
-    : new Set<never>();
-
-  return getLargeWhitelistedModel(auth, excludedProviders, { forBatch: true });
+  return getLargeWhitelistedModel(auth, new Set(), { forBatch: true });
 }

--- a/front/package.json
+++ b/front/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",
-    "@anthropic-ai/vertex-sdk": "^0.14.4",
+    "@anthropic-ai/vertex-sdk": "^0.16.1",
     "@contentful/rich-text-react-renderer": "^16.1.6",
     "@contentful/rich-text-types": "^17.2.5",
     "@datadog/browser-logs": "^6.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -492,7 +492,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",
-        "@anthropic-ai/vertex-sdk": "^0.14.4",
+        "@anthropic-ai/vertex-sdk": "^0.16.1",
         "@contentful/rich-text-react-renderer": "^16.1.6",
         "@contentful/rich-text-types": "^17.2.5",
         "@datadog/browser-logs": "^6.13.0",
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/@anthropic-ai/vertex-sdk": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/vertex-sdk/-/vertex-sdk-0.14.4.tgz",
-      "integrity": "sha512-BZUPRWghZxfSFtAxU563wH+jfWBPoedAwsVxG35FhmNsjeV8tyfN+lFriWhCpcZApxA4NdT6Soov+PzfnxxD5g==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/vertex-sdk/-/vertex-sdk-0.16.1.tgz",
+      "integrity": "sha512-NQSJTmHFqJP32W4I+UyZ42ioUkd8avdye259Cs+P9yhi+XdI4wk7sDVnmVNNTiMtN08WXyELnAQPG2gcLQFXdQ==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": ">=0.50.3 <1",


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/8239
waiting for https://github.com/anthropics/anthropic-sdk-typescript/issues/1069

This allow to use batch mode in Vertex AI so we don't need to default to another model in self-improving skills.

## Tests

TODO: run batch llm test with vertex

## Risk

low

## Deploy Plan

deploy front
