### PR TITLE
fix: replace 'Assistants' with 'Agents' in Pod settings delete section

### DIFF
--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -420,7 +420,7 @@ export function SpaceAboutTab({
             <h4 className="heading-base">Delete</h4>
             <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
               This permanently removes all content—conversations, folders,
-              websites, and data sources. Assistants using this Pod's tools will
+              websites, and data sources. Agents using this Pod's tools will
               be impacted. This cannot be undone.
             </p>
             <DeleteSpaceDialog owner={owner} space={space} />


### PR DESCRIPTION
## Description

Fixes a stale copy in `SpaceAboutTab` — the Pod delete confirmation text still referenced "Assistants" instead of the current product term "Agents".

## Tests

Verified visually in the Pod settings delete section. No logic changed.

## Risk

No risk. Single string change, no logic or data affected.

## Deploy Plan

Deploy front.