### PR TITLE
fix(streaming): reconnect SSE on iOS Safari bfcache restoration

### DIFF
--- a/front/hooks/useEventSource.ts
+++ b/front/hooks/useEventSource.ts
@@ -199,7 +199,50 @@ export function useEventSource(
     const abortController = new AbortController();
     connect(abortController.signal);
 
+    // iOS Safari puts pages in bfcache (Back/Forward Cache) when switching apps
+    // or closing the browser. While frozen, JS cannot react to the OS killing
+    // the underlying SSE/XHR connection, so onerror never fires and the stream
+    // appears permanently stuck when the user returns.
+    //
+    // We listen for two complementary events:
+    //  - "pageshow" with event.persisted === true  → bfcache restoration
+    //  - "visibilitychange" to visible             → app switch / tab return
+    //
+    // If the EventSource is found CLOSED in either case, we reset the reconnect
+    // attempt counter (the drop was caused by the OS, not a real error storm)
+    // and trigger a reconnect via setReconnectCounter. The existing lastEventId
+    // mechanism in buildEventSourceURL guarantees the reconnect picks up exactly
+    // where the stream left off.
+    const triggerReconnectIfClosed = () => {
+      const source = sourceManager.get(uniqueId);
+      if (!source || source.readyState === EventSourcePolyfill.CLOSED) {
+        // Reset attempt counter: the connection was dropped by the OS/bfcache,
+        // not by consecutive network errors. We don't want the user to hit the
+        // MAX_RECONNECT_ATTEMPTS wall just because they switched apps.
+        reconnectAttempts.current = 0;
+        setReconnectCounter((c) => c + 1);
+      }
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        triggerReconnectIfClosed();
+      }
+    };
+
+    const handlePageShow = (event: PageTransitionEvent) => {
+      // event.persisted === true means the page was restored from bfcache.
+      if (event.persisted) {
+        triggerReconnectIfClosed();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("pageshow", handlePageShow);
+
     return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("pageshow", handlePageShow);
       abortController.abort();
       sourceManager.remove(uniqueId);
 


### PR DESCRIPTION
## Description

Fixes SSE streams appearing permanently stuck after iOS Safari restores a page from bfcache. When the OS freezes JS during an app switch or browser close, the underlying XHR connection is killed but `onerror` never fires — so `EventSourcePolyfill` silently ends up in `CLOSED` state with no reconnect triggered.

In `useEventSource`, adds two event listeners inside the main `useEffect`: `visibilitychange` (tab/app return) and `pageshow` with `event.persisted === true` (bfcache restoration). Both call `triggerReconnectIfClosed`, which resets `reconnectAttempts.current` to 0 (OS drop, not an error storm) and increments `reconnectCounter` to kick a fresh `connect()`. The existing `lastEventId` mechanism in `buildEventSourceURL` handles resuming from the correct stream position.

## Tests

Manually tested on iOS Safari:
1. Start a long streaming response
2. Lock the phone or switch apps for a few seconds
3. Return — stream resumes automatically instead of appearing stuck

## Risk

Low. Change is purely additive — two new event listeners with proper cleanup in the `useEffect` return. On desktop, `visibilitychange` may fire on tab switch but is a no-op when the `EventSource` is still `OPEN` or `CONNECTING`. The `pageshow` path is gated on `event.persisted`, making it bfcache-specific. No existing reconnect logic is modified.

## Deploy Plan

Deploy front.
