### PR TITLE
fix(sandbox): flush deny log writes to fix flaky test

### DIFF
--- a/cli/dust-sandbox/src/commands/forward/deny_log.rs
+++ b/cli/dust-sandbox/src/commands/forward/deny_log.rs
@@ -117,6 +117,9 @@ async fn append_deny_log_line(path: &Path, line: &str, max_bytes: u64) -> Result
     file.write_all(line.as_bytes())
         .await
         .with_context(|| format!("failed to write deny log {}", path.display()))?;
+    file.flush()
+        .await
+        .with_context(|| format!("failed to flush deny log {}", path.display()))?;
     #[cfg(test)]
     notify_deny_log_write(path);
     Ok(())

--- a/cli/dust-sandbox/src/commands/forward/deny_log.rs
+++ b/cli/dust-sandbox/src/commands/forward/deny_log.rs
@@ -117,6 +117,8 @@ async fn append_deny_log_line(path: &Path, line: &str, max_bytes: u64) -> Result
     file.write_all(line.as_bytes())
         .await
         .with_context(|| format!("failed to write deny log {}", path.display()))?;
+    // Flush before notifying test waiters: the file is dropped after the notify,
+    // so its implicit drop-flush would race readers woken by the notify.
     file.flush()
         .await
         .with_context(|| format!("failed to flush deny log {}", path.display()))?;

--- a/cli/dust-sandbox/src/commands/forward/deny_log.rs
+++ b/cli/dust-sandbox/src/commands/forward/deny_log.rs
@@ -261,7 +261,8 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        append_deny_log, append_deny_log_line, rotated_deny_log_path, DenyLogEntry, DenyReason,
+        append_deny_log, append_deny_log_line, observe_deny_log_writes, rotated_deny_log_path,
+        DenyLogEntry, DenyReason,
     };
 
     #[tokio::test]
@@ -307,6 +308,30 @@ mod tests {
         assert_eq!(second["secret_name"], "OPENAI_API_KEY");
         assert_eq!(second["sni"], "api.openai.com");
         assert_eq!(second["host"], "evil.example");
+    }
+
+    #[tokio::test]
+    async fn write_observer_fires_after_content_is_readable() {
+        let tempdir = tempdir().expect("tempdir should be created");
+        let path = tempdir.path().join("deny.log");
+        let mut observer = observe_deny_log_writes(&path);
+        let write_path = path.clone();
+        let write =
+            tokio::spawn(async move { append_deny_log_line(&write_path, "visible\n", 64).await });
+
+        observer
+            .wait()
+            .await
+            .expect("observer should receive write notification");
+        let content = tokio::fs::read_to_string(&path)
+            .await
+            .expect("deny log should be readable after notification");
+        assert_eq!(content, "visible\n");
+
+        write
+            .await
+            .expect("append task should finish")
+            .expect("append should succeed");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

The deny log writer wrote bytes without flushing. Tokio's async file handle buffers writes, and the test-only `notify_deny_log_write(path)` fires before the file is dropped, so a test waiter could wake up and read the file before the implicit drop-flush landed the bytes on disk. Adding an explicit `file.flush().await` between `write_all` and the notify closes the race.

## Tests

Added `write_observer_fires_after_content_is_readable`: spawns a write, waits on the observer, then asserts the file content is on disk. Would fail without the flush. Full `cargo test deny_log` passes locally (5/5).

## Risk

Low. One extra flush per deny log line on a path already serialized behind `DENY_LOG_WRITE_LOCK`.

## Deploy Plan

Standard deploy.