### PR TITLE
[connectors] fix: handle Gong permission profile config errors

### DIFF
--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -1,3 +1,4 @@
+import { GongAPIError } from "@connectors/connectors/gong/lib/errors";
 import { makeGongTranscriptFolderInternalId } from "@connectors/connectors/gong/lib/internal_ids";
 import { baseUrlFromConnectionId } from "@connectors/connectors/gong/lib/oauth";
 import { fetchPermissionProfileViews } from "@connectors/connectors/gong/lib/permission_profiles";
@@ -353,8 +354,16 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
       case PERMISSION_PROFILE_ID_CONFIG_KEY:
         return new Ok(configuration.permissionProfileId ?? null);
       case PERMISSION_PROFILES_CONFIG_KEY: {
-        const views = await fetchPermissionProfileViews(connector);
-        return new Ok(JSON.stringify(views));
+        try {
+          const views = await fetchPermissionProfileViews(connector);
+          return new Ok(JSON.stringify(views));
+        } catch (err) {
+          if (err instanceof GongAPIError && (err.status === 401 || err.status === 403 || err.status === 404)) {
+            return new Ok(JSON.stringify([]))
+          }
+
+          throw err;
+        }
       }
       case EXCLUDE_TITLE_KEYWORDS_CONFIG_KEY: {
         const keywords = configuration.excludeTitleKeywords;

--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -358,8 +358,11 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
           const views = await fetchPermissionProfileViews(connector);
           return new Ok(JSON.stringify(views));
         } catch (err) {
-          if (err instanceof GongAPIError && (err.status === 401 || err.status === 403 || err.status === 404)) {
-            return new Ok(JSON.stringify([]))
+          if (
+            err instanceof GongAPIError &&
+            (err.status === 401 || err.status === 403 || err.status === 404)
+          ) {
+            return new Ok(JSON.stringify([]));
           }
 
           throw err;


### PR DESCRIPTION
## Description

- Gong permission profile configuration can currently fail when the Gong API rejects the `/workspaces` call, for example with a 401 ([logs](https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20status%3Aerror%20%40dd.env%3Aprod&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1779808272000&to_ts=1779808872000&live=false)).
- This PR handles known Gong API auth/not-found responses while reading `gongPermissionProfiles` and returns an empty profile list instead of failing and raising a monitor on unhandled errors.

## Tests

## Risk

- Low. Limited to Gong connector configuration reads.

## Deploy Plan

- Deploy connectors.
