### PR TITLE
Clear excess credits when enabling payg

### DIFF
--- a/front/lib/api/credits/credit_based_payg.ts
+++ b/front/lib/api/credits/credit_based_payg.ts
@@ -1,0 +1,73 @@
+import type { Authenticator } from "@app/lib/auth";
+import {
+  clearMetronomePaygCapAlert,
+  upsertMetronomePaygCapAlert,
+} from "@app/lib/metronome/payg_alerts";
+import { setAwuContractExcessCreditsAmount } from "@app/lib/metronome/payg_excess_credits";
+import { DEFAULT_AWU_EXCESS_RECURRING_AMOUNT } from "@app/lib/metronome/types";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+/**
+ * Apply the credit-based PAYG state to a workspace's Metronome customer.
+ *
+ * `paygCapCredits === null` means PAYG is disabled; any strictly-positive
+ * value means PAYG is enabled at that cap. The function:
+ *
+ *  - upserts (enabled) or clears (disabled) the Metronome
+ *    `spend_threshold_reached` alert,
+ *  - zeroes (enabled) or restores (disabled) the AWU recurring "Excess
+ *    Credits" credit on every active Metronome contract — when enabled
+ *    overage past the workspace's free credit pool bills as PAYG instead
+ *    of being absorbed silently.
+ *
+ * No-op when the workspace has no Metronome customer. The underlying
+ * Metronome calls are idempotent.
+ */
+export async function syncCreditBasedPayg({
+  auth,
+  paygCapCredits,
+}: {
+  auth: Authenticator;
+  paygCapCredits: number | null;
+}): Promise<Result<undefined, Error>> {
+  const workspace = auth.getNonNullableWorkspace();
+  if (!workspace.metronomeCustomerId) {
+    return new Ok(undefined);
+  }
+
+  const enabled = paygCapCredits !== null;
+
+  const alertResult = enabled
+    ? await upsertMetronomePaygCapAlert({
+        metronomeCustomerId: workspace.metronomeCustomerId,
+        paygCapCredits,
+        workspaceId: workspace.sId,
+      })
+    : await clearMetronomePaygCapAlert({
+        metronomeCustomerId: workspace.metronomeCustomerId,
+        workspaceId: workspace.sId,
+      });
+  if (alertResult.isErr()) {
+    return new Err(
+      new Error(
+        `Failed to sync Metronome PAYG cap alert: ${alertResult.error.message}`
+      )
+    );
+  }
+
+  const excessResult = await setAwuContractExcessCreditsAmount({
+    metronomeCustomerId: workspace.metronomeCustomerId,
+    workspaceId: workspace.sId,
+    amount: enabled ? 0 : DEFAULT_AWU_EXCESS_RECURRING_AMOUNT,
+  });
+  if (excessResult.isErr()) {
+    return new Err(
+      new Error(
+        `Failed to ${enabled ? "disable" : "restore"} AWU recurring excess credits: ${excessResult.error.message}`
+      )
+    );
+  }
+
+  return new Ok(undefined);
+}

--- a/front/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration.ts
@@ -1,10 +1,8 @@
+import { syncCreditBasedPayg } from "@app/lib/api/credits/credit_based_payg";
 import { createPlugin } from "@app/lib/api/poke/types";
 import { MAX_AWU_DISCOUNT_PERCENT } from "@app/lib/credits/awu_purchase_constants";
-import {
-  clearMetronomePaygCapAlert,
-  upsertMetronomePaygCapAlert,
-} from "@app/lib/metronome/payg_alerts";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
+import { isCreditPricedPlan } from "@app/types/plan";
 import { Err, Ok } from "@app/types/shared/result";
 import assert from "assert";
 import { z } from "zod";
@@ -83,6 +81,11 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
     },
   },
 
+  isApplicableTo: (auth) => {
+    const plan = auth.plan();
+    return plan !== null && isCreditPricedPlan(plan);
+  },
+
   populateAsyncArgs: async (auth) => {
     const config =
       await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
@@ -103,6 +106,15 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
   },
 
   execute: async (auth, _, args) => {
+    const plan = auth.plan();
+    if (!plan || !isCreditPricedPlan(plan)) {
+      return new Err(
+        new Error(
+          "This plugin is only applicable to credit-priced plan workspaces."
+        )
+      );
+    }
+
     const parseResult = CreditUsageConfigurationSchema.safeParse(args);
 
     if (!parseResult.success) {
@@ -117,8 +129,6 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
 
     const { defaultDiscountPercent, paygCapEnabled, paygCapCredits } =
       parseResult.data;
-
-    const workspace = auth.getNonNullableWorkspace();
 
     const resolvedPaygCapCredits = paygCapEnabled
       ? (() => {
@@ -154,25 +164,12 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
       }
     }
 
-    if (workspace.metronomeCustomerId) {
-      const alertResult =
-        resolvedPaygCapCredits !== null
-          ? await upsertMetronomePaygCapAlert({
-              metronomeCustomerId: workspace.metronomeCustomerId,
-              paygCapCredits: resolvedPaygCapCredits,
-              workspaceId: workspace.sId,
-            })
-          : await clearMetronomePaygCapAlert({
-              metronomeCustomerId: workspace.metronomeCustomerId,
-              workspaceId: workspace.sId,
-            });
-      if (alertResult.isErr()) {
-        return new Err(
-          new Error(
-            `Failed to sync Metronome PAYG cap alert: ${alertResult.error.message}`
-          )
-        );
-      }
+    const paygResult = await syncCreditBasedPayg({
+      auth,
+      paygCapCredits: resolvedPaygCapCredits,
+    });
+    if (paygResult.isErr()) {
+      return paygResult;
     }
 
     const discountStatus = `Discount: ${defaultDiscountPercent}%`;

--- a/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
@@ -25,6 +25,7 @@ import {
 } from "@app/lib/plans/stripe";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { isCreditPricedPlan } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import assert from "assert";
@@ -213,6 +214,11 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
     },
   },
 
+  isApplicableTo: (auth) => {
+    const plan = auth.plan();
+    return plan !== null && !isCreditPricedPlan(plan);
+  },
+
   populateAsyncArgs: async (auth) => {
     const workspace = auth.getNonNullableWorkspace();
     const userCount = await countEligibleUsersForFreeCredits(workspace);
@@ -269,6 +275,16 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
   },
 
   execute: async (auth, _, args) => {
+    const plan = auth.plan();
+    if (plan && isCreditPricedPlan(plan)) {
+      return new Err(
+        new Error(
+          "This plugin is not applicable to credit-priced plan workspaces. " +
+            "Use 'Manage Credit Usage Configuration' instead."
+        )
+      );
+    }
+
     const parseResult = ProgrammaticUsageConfigurationSchema.safeParse(args);
 
     if (!parseResult.success) {

--- a/front/lib/metronome/payg_excess_credits.test.ts
+++ b/front/lib/metronome/payg_excess_credits.test.ts
@@ -1,0 +1,406 @@
+import { setAwuContractExcessCreditsAmount } from "@app/lib/metronome/payg_excess_credits";
+import { Err, Ok } from "@app/types/shared/result";
+import type { ContractV2 } from "@metronome/sdk/resources";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockEditMetronomeContract,
+  mockGetMetronomeContractById,
+  mockListMetronomeContracts,
+} = vi.hoisted(() => ({
+  mockEditMetronomeContract: vi.fn(),
+  mockGetMetronomeContractById: vi.fn(),
+  mockListMetronomeContracts: vi.fn(),
+}));
+
+vi.mock("@app/lib/metronome/client", () => ({
+  editMetronomeContract: mockEditMetronomeContract,
+  getMetronomeContractById: mockGetMetronomeContractById,
+  listMetronomeContracts: mockListMetronomeContracts,
+}));
+
+const AWU_CREDIT_TYPE_ID = "awu-credit-type";
+const PROG_USD_CREDIT_TYPE_ID = "prog-usd-credit-type";
+
+vi.mock("@app/lib/metronome/constants", () => ({
+  getProductExcessCreditsId: () => "excess-product-id",
+  getCreditTypeAwuId: () => AWU_CREDIT_TYPE_ID,
+}));
+
+const EXCESS_PRODUCT = { id: "excess-product-id", name: "Excess Credits" };
+const OTHER_PRODUCT = { id: "other-product-id", name: "Other" };
+
+function makeContract({
+  id,
+  recurringCredits,
+  credits,
+}: {
+  id: string;
+  recurringCredits?: Array<{
+    id: string;
+    productId: string;
+    creditTypeId?: string;
+  }>;
+  credits?: Array<{
+    id: string;
+    recurringCreditId?: string;
+    productId: string;
+    scheduleItems?: Array<{
+      id: string;
+      amount: number;
+      startingAt: string;
+      endingBefore: string;
+    }>;
+  }>;
+}): ContractV2 {
+  return {
+    id,
+    recurring_credits: (recurringCredits ?? []).map((rc) => ({
+      id: rc.id,
+      product: { id: rc.productId, name: "x" },
+      access_amount: {
+        credit_type_id: rc.creditTypeId ?? AWU_CREDIT_TYPE_ID,
+        unit_price: 5000,
+        quantity: 1,
+      },
+    })),
+    credits: (credits ?? []).map((c) => ({
+      id: c.id,
+      type: "CREDIT",
+      product: { id: c.productId, name: "x" },
+      recurring_credit_id: c.recurringCreditId,
+      access_schedule: {
+        schedule_items: (c.scheduleItems ?? []).map((s) => ({
+          id: s.id,
+          amount: s.amount,
+          starting_at: s.startingAt,
+          ending_before: s.endingBefore,
+        })),
+      },
+    })),
+  } as unknown as ContractV2;
+}
+
+const CUSTOMER_ID = "cust_1";
+const WORKSPACE_ID = "ws_1";
+
+describe("payg_excess_credits", () => {
+  beforeEach(() => {
+    mockEditMetronomeContract.mockReset();
+    mockGetMetronomeContractById.mockReset();
+    mockListMetronomeContracts.mockReset();
+  });
+
+  it("disable zeros recurring unit_price and current/future segments only", async () => {
+    const future = new Date(Date.now() + 1000 * 60 * 60 * 24);
+    const past = new Date(Date.now() - 1000 * 60 * 60 * 24);
+    const farFuture = new Date(Date.now() + 1000 * 60 * 60 * 24 * 60);
+
+    mockListMetronomeContracts.mockResolvedValue(
+      new Ok([{ id: "contract_1" } as ContractV2])
+    );
+    mockGetMetronomeContractById.mockResolvedValue(
+      new Ok(
+        makeContract({
+          id: "contract_1",
+          recurringCredits: [{ id: "rc_excess", productId: EXCESS_PRODUCT.id }],
+          credits: [
+            {
+              id: "credit_current",
+              recurringCreditId: "rc_excess",
+              productId: EXCESS_PRODUCT.id,
+              scheduleItems: [
+                {
+                  id: "seg_past",
+                  amount: 5000,
+                  startingAt: past.toISOString(),
+                  endingBefore: past.toISOString(),
+                },
+                {
+                  id: "seg_current",
+                  amount: 5000,
+                  startingAt: past.toISOString(),
+                  endingBefore: future.toISOString(),
+                },
+                {
+                  id: "seg_future",
+                  amount: 5000,
+                  startingAt: future.toISOString(),
+                  endingBefore: farFuture.toISOString(),
+                },
+              ],
+            },
+          ],
+        })
+      )
+    );
+    mockEditMetronomeContract.mockResolvedValue(new Ok({ editId: "edit_1" }));
+
+    const result = await setAwuContractExcessCreditsAmount({
+      metronomeCustomerId: CUSTOMER_ID,
+      workspaceId: WORKSPACE_ID,
+      amount: 0,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockEditMetronomeContract).toHaveBeenCalledTimes(1);
+    const callArg = mockEditMetronomeContract.mock.calls[0][0];
+    expect(callArg.customer_id).toBe(CUSTOMER_ID);
+    expect(callArg.contract_id).toBe("contract_1");
+    expect(callArg.update_recurring_credits).toEqual([
+      {
+        recurring_credit_id: "rc_excess",
+        access_amount: { unit_price: 0, quantity: 1 },
+      },
+    ]);
+    expect(callArg.update_credits).toHaveLength(1);
+    const updatedSegmentIds =
+      callArg.update_credits[0].access_schedule.update_schedule_items
+        .map((s: { id: string }) => s.id)
+        .sort();
+    expect(updatedSegmentIds).toEqual(["seg_current", "seg_future"]);
+    expect(
+      callArg.update_credits[0].access_schedule.update_schedule_items.every(
+        (s: { amount: number }) => s.amount === 0
+      )
+    ).toBe(true);
+  });
+
+  it("restore sets recurring unit_price and segments back to default", async () => {
+    const future = new Date(Date.now() + 1000 * 60 * 60 * 24);
+    const past = new Date(Date.now() - 1000 * 60 * 60 * 24);
+
+    mockListMetronomeContracts.mockResolvedValue(
+      new Ok([{ id: "contract_1" } as ContractV2])
+    );
+    mockGetMetronomeContractById.mockResolvedValue(
+      new Ok(
+        makeContract({
+          id: "contract_1",
+          recurringCredits: [{ id: "rc_excess", productId: EXCESS_PRODUCT.id }],
+          credits: [
+            {
+              id: "credit_current",
+              recurringCreditId: "rc_excess",
+              productId: EXCESS_PRODUCT.id,
+              scheduleItems: [
+                {
+                  id: "seg_current",
+                  amount: 0,
+                  startingAt: past.toISOString(),
+                  endingBefore: future.toISOString(),
+                },
+              ],
+            },
+          ],
+        })
+      )
+    );
+    mockEditMetronomeContract.mockResolvedValue(new Ok({ editId: "edit_2" }));
+
+    const result = await setAwuContractExcessCreditsAmount({
+      metronomeCustomerId: CUSTOMER_ID,
+      workspaceId: WORKSPACE_ID,
+      amount: 5000,
+    });
+
+    expect(result.isOk()).toBe(true);
+    const callArg = mockEditMetronomeContract.mock.calls[0][0];
+    expect(callArg.update_recurring_credits).toEqual([
+      {
+        recurring_credit_id: "rc_excess",
+        access_amount: { unit_price: 5000, quantity: 1 },
+      },
+    ]);
+    expect(
+      callArg.update_credits[0].access_schedule.update_schedule_items
+    ).toEqual([{ id: "seg_current", amount: 5000 }]);
+  });
+
+  it("no-op when no active contracts", async () => {
+    mockListMetronomeContracts.mockResolvedValue(new Ok([]));
+
+    const result = await setAwuContractExcessCreditsAmount({
+      metronomeCustomerId: CUSTOMER_ID,
+      workspaceId: WORKSPACE_ID,
+      amount: 0,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.updatedContracts).toBe(0);
+    }
+    expect(mockEditMetronomeContract).not.toHaveBeenCalled();
+  });
+
+  it("skips contracts without an excess recurring credit", async () => {
+    mockListMetronomeContracts.mockResolvedValue(
+      new Ok([{ id: "contract_no_excess" } as ContractV2])
+    );
+    mockGetMetronomeContractById.mockResolvedValue(
+      new Ok(
+        makeContract({
+          id: "contract_no_excess",
+          recurringCredits: [{ id: "rc_other", productId: OTHER_PRODUCT.id }],
+          credits: [],
+        })
+      )
+    );
+
+    const result = await setAwuContractExcessCreditsAmount({
+      metronomeCustomerId: CUSTOMER_ID,
+      workspaceId: WORKSPACE_ID,
+      amount: 0,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockEditMetronomeContract).not.toHaveBeenCalled();
+  });
+
+  it("skips legacy programmatic USD excess recurring credits", async () => {
+    const future = new Date(Date.now() + 1000 * 60 * 60 * 24);
+    const past = new Date(Date.now() - 1000 * 60 * 60 * 24);
+
+    mockListMetronomeContracts.mockResolvedValue(
+      new Ok([{ id: "contract_legacy" } as ContractV2])
+    );
+    mockGetMetronomeContractById.mockResolvedValue(
+      new Ok(
+        makeContract({
+          id: "contract_legacy",
+          recurringCredits: [
+            {
+              id: "rc_excess_legacy",
+              productId: EXCESS_PRODUCT.id,
+              creditTypeId: PROG_USD_CREDIT_TYPE_ID,
+            },
+          ],
+          credits: [
+            {
+              id: "credit_legacy",
+              recurringCreditId: "rc_excess_legacy",
+              productId: EXCESS_PRODUCT.id,
+              scheduleItems: [
+                {
+                  id: "seg_current",
+                  amount: 50,
+                  startingAt: past.toISOString(),
+                  endingBefore: future.toISOString(),
+                },
+              ],
+            },
+          ],
+        })
+      )
+    );
+
+    const result = await setAwuContractExcessCreditsAmount({
+      metronomeCustomerId: CUSTOMER_ID,
+      workspaceId: WORKSPACE_ID,
+      amount: 0,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockEditMetronomeContract).not.toHaveBeenCalled();
+  });
+
+  it("updates recurring credit even when no active child segments exist", async () => {
+    const past = new Date(Date.now() - 1000 * 60 * 60 * 24);
+
+    mockListMetronomeContracts.mockResolvedValue(
+      new Ok([{ id: "contract_1" } as ContractV2])
+    );
+    mockGetMetronomeContractById.mockResolvedValue(
+      new Ok(
+        makeContract({
+          id: "contract_1",
+          recurringCredits: [{ id: "rc_excess", productId: EXCESS_PRODUCT.id }],
+          credits: [
+            {
+              id: "credit_expired",
+              recurringCreditId: "rc_excess",
+              productId: EXCESS_PRODUCT.id,
+              scheduleItems: [
+                {
+                  id: "seg_past",
+                  amount: 5000,
+                  startingAt: past.toISOString(),
+                  endingBefore: past.toISOString(),
+                },
+              ],
+            },
+          ],
+        })
+      )
+    );
+    mockEditMetronomeContract.mockResolvedValue(new Ok({ editId: "edit_3" }));
+
+    const result = await setAwuContractExcessCreditsAmount({
+      metronomeCustomerId: CUSTOMER_ID,
+      workspaceId: WORKSPACE_ID,
+      amount: 0,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockEditMetronomeContract).toHaveBeenCalledTimes(1);
+    const callArg = mockEditMetronomeContract.mock.calls[0][0];
+    expect(callArg.update_recurring_credits).toHaveLength(1);
+    expect(callArg.update_credits).toBeUndefined();
+  });
+
+  it("propagates list error", async () => {
+    mockListMetronomeContracts.mockResolvedValue(new Err(new Error("boom")));
+
+    const result = await setAwuContractExcessCreditsAmount({
+      metronomeCustomerId: CUSTOMER_ID,
+      workspaceId: WORKSPACE_ID,
+      amount: 0,
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(mockEditMetronomeContract).not.toHaveBeenCalled();
+  });
+
+  it("propagates edit error", async () => {
+    const future = new Date(Date.now() + 1000 * 60 * 60 * 24);
+    const past = new Date(Date.now() - 1000 * 60 * 60 * 24);
+
+    mockListMetronomeContracts.mockResolvedValue(
+      new Ok([{ id: "contract_1" } as ContractV2])
+    );
+    mockGetMetronomeContractById.mockResolvedValue(
+      new Ok(
+        makeContract({
+          id: "contract_1",
+          recurringCredits: [{ id: "rc_excess", productId: EXCESS_PRODUCT.id }],
+          credits: [
+            {
+              id: "credit_current",
+              recurringCreditId: "rc_excess",
+              productId: EXCESS_PRODUCT.id,
+              scheduleItems: [
+                {
+                  id: "seg_current",
+                  amount: 5000,
+                  startingAt: past.toISOString(),
+                  endingBefore: future.toISOString(),
+                },
+              ],
+            },
+          ],
+        })
+      )
+    );
+    mockEditMetronomeContract.mockResolvedValue(
+      new Err(new Error("edit-failed"))
+    );
+
+    const result = await setAwuContractExcessCreditsAmount({
+      metronomeCustomerId: CUSTOMER_ID,
+      workspaceId: WORKSPACE_ID,
+      amount: 0,
+    });
+
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/front/lib/metronome/payg_excess_credits.ts
+++ b/front/lib/metronome/payg_excess_credits.ts
@@ -1,0 +1,132 @@
+import {
+  editMetronomeContract,
+  getMetronomeContractById,
+  listMetronomeContracts,
+} from "@app/lib/metronome/client";
+import {
+  getCreditTypeAwuId,
+  getProductExcessCreditsId,
+} from "@app/lib/metronome/constants";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import type { ContractEditParams } from "@metronome/sdk/resources/v2/contracts";
+
+/**
+ * Set the per-period amount of every AWU recurring "Excess Credits" credit
+ * on every active Metronome contract for the workspace to `amount`. The
+ * current/future schedule items on each child credit instance are updated
+ * to the same value so the change applies in-flight.
+ *
+ * AWU-only by design: legacy (programmatic USD) contracts are skipped. Only
+ * meant to be called on credit-priced plan workspaces. Pass `0` to disable
+ * the buffer when PAYG is enabled; pass the package-default amount to
+ * restore it when PAYG is turned off.
+ */
+export async function setAwuContractExcessCreditsAmount({
+  metronomeCustomerId,
+  workspaceId,
+  amount,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+  amount: number;
+}): Promise<Result<{ updatedContracts: number }, Error>> {
+  const now = new Date();
+
+  const contractsResult = await listMetronomeContracts(metronomeCustomerId, {
+    coveringDate: now,
+  });
+  if (contractsResult.isErr()) {
+    return new Err(contractsResult.error);
+  }
+
+  const awuCreditTypeId = getCreditTypeAwuId();
+  let updatedContracts = 0;
+
+  for (const summary of contractsResult.value) {
+    const detailResult = await getMetronomeContractById({
+      metronomeCustomerId,
+      metronomeContractId: summary.id,
+    });
+    if (detailResult.isErr()) {
+      return new Err(detailResult.error);
+    }
+    const contract = detailResult.value;
+
+    const excessRecurringCredits = (contract.recurring_credits ?? []).filter(
+      (rc) =>
+        rc.product.id === getProductExcessCreditsId() &&
+        rc.access_amount.credit_type_id === awuCreditTypeId
+    );
+    if (excessRecurringCredits.length === 0) {
+      continue;
+    }
+
+    const excessRecurringCreditIds = new Set(
+      excessRecurringCredits.map((rc) => rc.id)
+    );
+
+    const updateCredits: NonNullable<ContractEditParams["update_credits"]> = [];
+    for (const credit of contract.credits ?? []) {
+      if (
+        !credit.recurring_credit_id ||
+        !excessRecurringCreditIds.has(credit.recurring_credit_id)
+      ) {
+        continue;
+      }
+
+      const activeOrFutureSegments = (
+        credit.access_schedule?.schedule_items ?? []
+      ).filter(
+        (item) => new Date(item.ending_before).getTime() > now.getTime()
+      );
+
+      if (activeOrFutureSegments.length === 0) {
+        continue;
+      }
+
+      updateCredits.push({
+        credit_id: credit.id,
+        access_schedule: {
+          update_schedule_items: activeOrFutureSegments.map((item) => ({
+            id: item.id,
+            amount,
+          })),
+        },
+      });
+    }
+
+    const editResult = await editMetronomeContract({
+      customer_id: metronomeCustomerId,
+      contract_id: contract.id,
+      update_recurring_credits: excessRecurringCredits.map((rc) => ({
+        recurring_credit_id: rc.id,
+        access_amount: { unit_price: amount, quantity: 1 },
+      })),
+      ...(updateCredits.length > 0 ? { update_credits: updateCredits } : {}),
+    });
+    if (editResult.isErr()) {
+      return new Err(editResult.error);
+    }
+
+    updatedContracts += 1;
+    logger.info(
+      {
+        workspaceId,
+        metronomeCustomerId,
+        contractId: contract.id,
+        recurringCreditIds: excessRecurringCredits.map((rc) => rc.id),
+        updatedSegmentCount: updateCredits.reduce(
+          (acc, c) =>
+            acc + (c.access_schedule?.update_schedule_items?.length ?? 0),
+          0
+        ),
+        amount,
+      },
+      "[Metronome PAYG] Updated AWU recurring excess credits on contract"
+    );
+  }
+
+  return new Ok({ updatedContracts });
+}

--- a/front/lib/metronome/types.ts
+++ b/front/lib/metronome/types.ts
@@ -104,6 +104,16 @@ export const FREE_ANNUAL_CREDIT_NAME = "Free Annual Credits";
 // FIXED product so it surfaces as a distinct invoice line item.
 export const EXCESS_CREDIT_NAME = "Excess Credits";
 
+// Per-period amount granted by the recurring "Excess Credits" credit in
+// every package. The amount depends on the credit type: AWU packages use a
+// larger buffer than the legacy programmatic USD packages because AWU
+// pricing is per unit while programmatic USD is in dollars. Mirrors the
+// values passed to getFreeExcessRecurringCredits(...) in
+// scripts/metronome_setup.ts. Only AWU recurring excess credits are ever
+// toggled at runtime (see lib/metronome/payg_excess_credits.ts).
+export const DEFAULT_AWU_EXCESS_RECURRING_AMOUNT = 5_000;
+export const DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT = 50;
+
 // Excess credits are an internal accounting mechanism — they should not be
 // surfaced to end users or in the Poke UI. Discriminated by product ID since
 // the excess recurring credit has its own dedicated FIXED product.

--- a/front/lib/resources/storage/models/credit_usage_configurations.ts
+++ b/front/lib/resources/storage/models/credit_usage_configurations.ts
@@ -12,7 +12,8 @@ import { DataTypes } from "sequelize";
  *
  * Fields:
  * - defaultDiscountPercent: Discount applied to AWU credit purchases (0-100%)
- * - paygCapCredits: PAYG cap on AWU consumption, in AWU credits. Drives the
+ * - paygCapCredits: PAYG cap on AWU consumption, in AWU credits. NULL means
+ *   PAYG is disabled; any strictly-positive value enables it and drives the
  *   Metronome `spend_threshold_reached` alert on the workspace's customer.
  */
 export class CreditUsageConfigurationModel extends WorkspaceAwareModel<CreditUsageConfigurationModel> {

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -33,6 +33,8 @@ import {
 import { TOOL_CATEGORIES } from "@app/lib/metronome/events";
 import { invalidateProductSeatTypesCache } from "@app/lib/metronome/seat_types";
 import {
+  DEFAULT_AWU_EXCESS_RECURRING_AMOUNT,
+  DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT,
   EXCESS_CREDIT_NAME,
   FREE_ANNUAL_CREDIT_NAME,
   FREE_MONTHLY_CREDIT_NAME,
@@ -1513,7 +1515,10 @@ function getPackages(): PackageDef[] {
       subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
       recurring_credits: [
         getFreeMonthlyRecurringCredits(),
-        getFreeExcessRecurringCredits(getCreditTypeProgrammaticUsdId(), 5_000),
+        getFreeExcessRecurringCredits(
+          getCreditTypeProgrammaticUsdId(),
+          DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT
+        ),
       ],
       ...BILLING_CYCLE_CONFIG,
     },
@@ -1524,7 +1529,10 @@ function getPackages(): PackageDef[] {
       subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
       recurring_credits: [
         getFreeMonthlyRecurringCredits(),
-        getFreeExcessRecurringCredits(getCreditTypeProgrammaticUsdId(), 5_000),
+        getFreeExcessRecurringCredits(
+          getCreditTypeProgrammaticUsdId(),
+          DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT
+        ),
       ],
       ...BILLING_CYCLE_CONFIG,
     },
@@ -1535,7 +1543,10 @@ function getPackages(): PackageDef[] {
       subscriptions: [LEGACY_SEAT_ANNUAL_SUBSCRIPTION],
       recurring_credits: [
         getFreeAnnualRecurringCredits(),
-        getFreeExcessRecurringCredits(getCreditTypeProgrammaticUsdId(), 5_000),
+        getFreeExcessRecurringCredits(
+          getCreditTypeProgrammaticUsdId(),
+          DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT
+        ),
       ],
       ...BILLING_CYCLE_CONFIG,
     },
@@ -1547,7 +1558,10 @@ function getPackages(): PackageDef[] {
       scheduled_charges_on_usage_invoices: "ALL",
       recurring_credits: [
         getFreeMonthlyRecurringCredits(),
-        getFreeExcessRecurringCredits(getCreditTypeProgrammaticUsdId(), 5_000),
+        getFreeExcessRecurringCredits(
+          getCreditTypeProgrammaticUsdId(),
+          DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT
+        ),
       ],
       ...BILLING_CYCLE_CONFIG,
     },
@@ -1559,7 +1573,10 @@ function getPackages(): PackageDef[] {
       subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
       recurring_credits: [
         getFreeMonthlyRecurringCredits(),
-        getFreeExcessRecurringCredits(getCreditTypeProgrammaticUsdId(), 5_000),
+        getFreeExcessRecurringCredits(
+          getCreditTypeProgrammaticUsdId(),
+          DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT
+        ),
       ],
       ...BILLING_CYCLE_CONFIG,
     },
@@ -1570,7 +1587,10 @@ function getPackages(): PackageDef[] {
       subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
       recurring_credits: [
         getFreeMonthlyRecurringCredits(),
-        getFreeExcessRecurringCredits(getCreditTypeProgrammaticUsdId(), 5_000),
+        getFreeExcessRecurringCredits(
+          getCreditTypeProgrammaticUsdId(),
+          DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT
+        ),
       ],
       ...BILLING_CYCLE_CONFIG,
     },
@@ -1581,7 +1601,10 @@ function getPackages(): PackageDef[] {
       subscriptions: [LEGACY_SEAT_ANNUAL_SUBSCRIPTION],
       recurring_credits: [
         getFreeAnnualRecurringCredits(),
-        getFreeExcessRecurringCredits(getCreditTypeProgrammaticUsdId(), 5_000),
+        getFreeExcessRecurringCredits(
+          getCreditTypeProgrammaticUsdId(),
+          DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT
+        ),
       ],
       ...BILLING_CYCLE_CONFIG,
     },
@@ -1592,7 +1615,10 @@ function getPackages(): PackageDef[] {
       scheduled_charges_on_usage_invoices: "ALL",
       recurring_credits: [
         getFreeMonthlyRecurringCredits(),
-        getFreeExcessRecurringCredits(getCreditTypeProgrammaticUsdId(), 5_000),
+        getFreeExcessRecurringCredits(
+          getCreditTypeProgrammaticUsdId(),
+          DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT
+        ),
       ],
       ...BILLING_CYCLE_CONFIG,
     },
@@ -1609,7 +1635,10 @@ function getPackages(): PackageDef[] {
       ],
       scheduled_charges_on_usage_invoices: "ALL",
       recurring_credits: [
-        getFreeExcessRecurringCredits(getCreditTypeAwuId(), 5_000),
+        getFreeExcessRecurringCredits(
+          getCreditTypeAwuId(),
+          DEFAULT_AWU_EXCESS_RECURRING_AMOUNT
+        ),
       ],
       ...BILLING_CYCLE_CONFIG,
     },
@@ -1623,7 +1652,10 @@ function getPackages(): PackageDef[] {
       ],
       scheduled_charges_on_usage_invoices: "ALL",
       recurring_credits: [
-        getFreeExcessRecurringCredits(getCreditTypeAwuId(), 5_000),
+        getFreeExcessRecurringCredits(
+          getCreditTypeAwuId(),
+          DEFAULT_AWU_EXCESS_RECURRING_AMOUNT
+        ),
       ],
       ...BILLING_CYCLE_CONFIG,
     },
@@ -1659,7 +1691,10 @@ function getPackages(): PackageDef[] {
           quantityPerSeat: MAX_SEAT_MONTHLY_AWU_CREDITS,
           name: MAX_SEAT_CREDIT_NAME,
         }),
-        getFreeExcessRecurringCredits(getCreditTypeAwuId(), 5_000),
+        getFreeExcessRecurringCredits(
+          getCreditTypeAwuId(),
+          DEFAULT_AWU_EXCESS_RECURRING_AMOUNT
+        ),
       ],
       overrides: buildSeatEntitlementFlipOverrides(),
       ...BILLING_CYCLE_CONFIG,
@@ -1696,7 +1731,10 @@ function getPackages(): PackageDef[] {
           quantityPerSeat: MAX_SEAT_MONTHLY_AWU_CREDITS,
           name: MAX_SEAT_CREDIT_NAME,
         }),
-        getFreeExcessRecurringCredits(getCreditTypeAwuId(), 5_000),
+        getFreeExcessRecurringCredits(
+          getCreditTypeAwuId(),
+          DEFAULT_AWU_EXCESS_RECURRING_AMOUNT
+        ),
       ],
       overrides: buildSeatEntitlementFlipOverrides(),
       ...BILLING_CYCLE_CONFIG,
@@ -1739,7 +1777,10 @@ function getPackages(): PackageDef[] {
           name: MAX_SEAT_CREDIT_NAME,
         }),
         getFreeSeatLifetimeAwuCredits(),
-        getFreeExcessRecurringCredits(getCreditTypeAwuId(), 5_000),
+        getFreeExcessRecurringCredits(
+          getCreditTypeAwuId(),
+          DEFAULT_AWU_EXCESS_RECURRING_AMOUNT
+        ),
       ],
       ...BILLING_CYCLE_CONFIG,
     },
@@ -1777,7 +1818,10 @@ function getPackages(): PackageDef[] {
           name: MAX_SEAT_CREDIT_NAME,
         }),
         getFreeSeatLifetimeAwuCredits(),
-        getFreeExcessRecurringCredits(getCreditTypeAwuId(), 5_000),
+        getFreeExcessRecurringCredits(
+          getCreditTypeAwuId(),
+          DEFAULT_AWU_EXCESS_RECURRING_AMOUNT
+        ),
       ],
       ...BILLING_CYCLE_CONFIG,
     },


### PR DESCRIPTION
## Description

When PAYG is enabled on a credit-priced plan workspace, the recurring "Excess Credits" credit on the Metronome contract has to be cleared — otherwise overage past the workspace's free credit pool keeps getting absorbed by that buffer instead of being billed as PAYG. Symmetric restore happens when PAYG is turned off again.

Source of truth is the existing `paygCapCredits` column on `credit_usage_configurations`: `NULL` means PAYG disabled, any strictly-positive value means enabled. No new column, no validation changes.

- `front/lib/metronome/payg_excess_credits.ts`: single function `setAwuContractExcessCreditsAmount({ metronomeCustomerId, workspaceId, amount })`. Lists active contracts for the workspace's Metronome customer, finds AWU recurring excess credits (filtered by both `product.id === Excess Credits` and `access_amount.credit_type_id === AWU` — legacy programmatic-USD contracts are intentionally never touched), and issues one `v2.contracts.edit` per contract that:
  - sets `update_recurring_credits[].access_amount.unit_price` to `amount`, so future segments generated by the recurrence carry that amount,
  - sets `update_credits[].access_schedule.update_schedule_items[].amount` on every current/future schedule item of every child credit instance, so the in-flight segment changes too.
- `front/lib/api/credits/credit_based_payg.ts`: `syncCreditBasedPayg({ auth, paygCapCredits })` — single orchestration entry point. `paygCapCredits != null` upserts the Metronome `spend_threshold_reached` alert + zeroes the AWU excess credit; `null` clears the alert + restores the excess credit to the package-default amount. No-op when the workspace has no Metronome customer.
- `front/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration.ts`: gated to credit-priced plans via `isApplicableTo` + defensive guard in `execute`. Delegates the Metronome side effects to `syncCreditBasedPayg`.
- `front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts`: mirror gating — `isApplicableTo` + defensive guard now block the plugin on credit-priced plans, pointing the user to "Manage Credit Usage Configuration" instead.
- `front/lib/metronome/types.ts` + `front/scripts/metronome_setup.ts`: split the previous single `5_000` constant into `DEFAULT_AWU_EXCESS_RECURRING_AMOUNT = 5_000` and `DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT = 50` (the legacy programmatic USD packages should use 50, not 5_000); all 14 `getFreeExcessRecurringCredits(...)` call sites in the setup script updated accordingly.

## Tests

- Unit tests for `payg_excess_credits.ts` (`front/lib/metronome/payg_excess_credits.test.ts`) cover: amount=0 zeros recurring + current/future segments only (past segments untouched), amount=5_000 restores values back to the AWU default, no active contracts → no-op, contract without an excess recurring credit → no-op, legacy programmatic-USD excess credit → skipped, recurring credit updated even when no in-flight child segments exist, list/edit error propagation.
- Manual: re-run the metronome setup script in sandbox to confirm legacy packages now provision Excess Credits at 50 rather than 5_000 and new AWU packages stay at 5_000.

## Risk

- Affects credit-priced (CP_) plans only — both plugins are now plan-gated (one to CP, the other away from CP) and the excess-credit lib filters by AWU credit type, so legacy programmatic-USD contracts cannot be touched at runtime by this code path.
- Metronome calls (`update_recurring_credits` + `update_credits`) are idempotent: re-running the plugin with unchanged state re-applies the same values without producing additional invoice line items.
- Rollback: revert the commit. No DB migration was added in this PR, so rollback is purely code.

## Deploy Plan

1. Re-run `scripts/metronome_setup.ts` in sandbox to provision legacy package excess credits at the corrected 50 amount; verify the AWU packages still show 5_000.
2. Merge & deploy `front`.
3. Re-run `scripts/metronome_setup.ts` in production with the same expectations.
4. Smoke-test: open the Poke "Manage Credit Usage Configuration" plugin on a credit-priced workspace, toggle the AWU PAYG cap on, verify the Metronome alert is created and the contract's AWU Excess Credits recurring credit + active segment go to 0. Toggle off; verify the alert is cleared and the recurring credit + active segment are back to 5_000. Confirm the "Manage Programmatic Usage Configuration" plugin is hidden on the same workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)