### PR TITLE
Migrate misc public spaceid APIs + 1 triggers api to Hono

### DIFF
--- a/front-api/app.ts
+++ b/front-api/app.ts
@@ -28,6 +28,7 @@ import tApp from "./routes/t";
 import templatesApp from "./routes/templates";
 import userApp from "./routes/user";
 import publicWorkspaceApp from "./routes/v1/w/[wId]";
+import publicWorkspaceTriggersApp from "./routes/v1/w/[wId]/triggers";
 import workspaceApp from "./routes/w/[wId]";
 import workspaceJoinApp from "./routes/w/[wId]/join";
 import workosApp from "./routes/workos";
@@ -63,6 +64,9 @@ apiApp.route("/workspace-lookup", workspaceLookupApp);
 // (it is a public, unauthenticated endpoint).
 apiApp.route("/w/:wId/join", workspaceJoinApp);
 apiApp.route("/w/:wId", workspaceApp);
+// Triggers is mounted before the workspace app so it does not inherit
+// publicApiAuth (it uses its own URL secret-based authentication).
+apiApp.route("/v1/w/:wId/triggers", publicWorkspaceTriggersApp);
 apiApp.route("/v1/w/:wId", publicWorkspaceApp);
 // Pre-stop uses a dynamic first segment (the secret) — register last so its
 // `/:preStopSecret/prestop` shape doesn't shadow any literal-prefixed routes

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/conversation_ids.test.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/conversation_ids.test.ts
@@ -1,0 +1,175 @@
+import { Authenticator } from "@app/lib/auth";
+import { ConversationModel } from "@app/lib/models/agent/conversation";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function getConversationIds(
+  workspace: { sId: string },
+  key: { secret: string },
+  spaceId: string
+) {
+  return honoApp.request(
+    `/api/v1/w/${workspace.sId}/spaces/${spaceId}/conversation_ids`,
+    {
+      headers: { authorization: `Bearer ${key.secret}` },
+    }
+  );
+}
+
+describe("GET /api/v1/w/[wId]/spaces/[spaceId]/conversation_ids", () => {
+  it("returns 403 if not system key", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      systemKey: false,
+    });
+
+    const space = await SpaceFactory.regular(workspace);
+
+    const response = await getConversationIds(workspace, key, space.sId);
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "invalid_oauth_token_error",
+        message: "Only system keys are allowed to use this endpoint.",
+      },
+    });
+  });
+
+  it("returns 404 if space does not exist", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      systemKey: true,
+    });
+
+    const response = await getConversationIds(
+      workspace,
+      key,
+      "non-existent-space-id"
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "space_not_found",
+        message: "Space not found.",
+      },
+    });
+  });
+
+  it("returns conversation IDs in a space", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      systemKey: true,
+    });
+
+    const space = await SpaceFactory.regular(workspace);
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
+    const adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    const addMembersRes = await space.addMembers(adminAuth, {
+      userIds: [user.sId],
+    });
+    if (!addMembersRes.isOk()) {
+      throw new Error("Failed to add user to space");
+    }
+
+    const agent = await AgentConfigurationFactory.createTestAgent(adminAuth, {
+      name: "Test Agent",
+    });
+
+    const convo1 = await ConversationFactory.create(adminAuth, {
+      agentConfigurationId: agent.sId,
+      requestedSpaceIds: [space.id],
+      spaceId: space.id,
+      messagesCreatedAt: [new Date()],
+    });
+    const convo2 = await ConversationFactory.create(adminAuth, {
+      agentConfigurationId: agent.sId,
+      requestedSpaceIds: [space.id],
+      spaceId: space.id,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const response = await getConversationIds(workspace, key, space.sId);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(Array.isArray(data.conversationIds)).toBe(true);
+    expect(data.conversationIds.length).toBeGreaterThanOrEqual(2);
+    expect(data.conversationIds).toContain(convo1.sId);
+    expect(data.conversationIds).toContain(convo2.sId);
+  });
+
+  it("excludes deleted conversations", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      systemKey: true,
+    });
+
+    const space = await SpaceFactory.regular(workspace);
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
+    const adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    const addMembersRes = await space.addMembers(adminAuth, {
+      userIds: [user.sId],
+    });
+    if (!addMembersRes.isOk()) {
+      throw new Error("Failed to add user to space");
+    }
+
+    const agent = await AgentConfigurationFactory.createTestAgent(adminAuth, {
+      name: "Test Agent",
+    });
+
+    const convo1 = await ConversationFactory.create(adminAuth, {
+      agentConfigurationId: agent.sId,
+      requestedSpaceIds: [space.id],
+      spaceId: space.id,
+      messagesCreatedAt: [new Date()],
+    });
+    const convo2 = await ConversationFactory.create(adminAuth, {
+      agentConfigurationId: agent.sId,
+      requestedSpaceIds: [space.id],
+      spaceId: space.id,
+      messagesCreatedAt: [new Date()],
+    });
+
+    await ConversationModel.update(
+      { visibility: "deleted" },
+      { where: { id: convo2.id } }
+    );
+
+    const response = await getConversationIds(workspace, key, space.sId);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.conversationIds).toContain(convo1.sId);
+    expect(data.conversationIds).not.toContain(convo2.sId);
+  });
+
+  it("returns empty array for space with no conversations", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      systemKey: true,
+    });
+
+    const space = await SpaceFactory.regular(workspace);
+
+    const response = await getConversationIds(workspace, key, space.sId);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(Array.isArray(data.conversationIds)).toBe(true);
+    expect(data.conversationIds.length).toBe(0);
+  });
+});

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/conversation_ids.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/conversation_ids.ts
@@ -1,0 +1,78 @@
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { GetSpaceConversationIdsResponseType } from "@dust-tt/client";
+import { publicApiApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  spaceId: z.string(),
+});
+
+/**
+ * @ignoreswagger
+ * System API key only endpoint. Undocumented.
+ * Returns only the conversation IDs (sIds) for conversations in a space.
+ * Used for garbage collection to identify conversations that no longer exist.
+ */
+
+// Mounted at /api/v1/w/:wId/spaces/:spaceId/conversation_ids.
+const app = publicApiApp();
+
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetSpaceConversationIdsResponseType> => {
+    const auth = ctx.get("auth");
+
+    // Only allow system keys (connectors) to access this endpoint
+    if (!auth.isSystemKey()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_oauth_token_error",
+          message: "Only system keys are allowed to use this endpoint.",
+        },
+      });
+    }
+
+    const { spaceId } = ctx.req.valid("param");
+
+    // Fetch and verify space exists
+    const space = await SpaceResource.fetchById(auth, spaceId);
+    if (!space) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "space_not_found",
+          message: "Space not found.",
+        },
+      });
+    }
+
+    // Get all conversation IDs for the space (only visible/non-deleted conversations)
+    // This endpoint is used for garbage collection to identify conversations that
+    // were hard-deleted and no longer exist in the database
+    const spaceConversations =
+      await ConversationResource.listConversationsInSpace(auth, {
+        spaceId,
+        options: {
+          dangerouslySkipPermissionFiltering: true, // System key has access
+          // Don't include deleted - we only want conversations that still exist
+          includeDeleted: false,
+          // Don't include test conversations
+          excludeTest: true,
+        },
+      });
+
+    const conversationIds = spaceConversations.map((c) => c.sId);
+
+    return ctx.json({
+      conversationIds,
+    });
+  }
+);
+
+export default app;

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/index.ts
@@ -1,11 +1,19 @@
 import { publicApiApp } from "@front-api/middlewares/ctx";
 
+import conversationIds from "./conversation_ids";
 import dataSources from "./data_sources";
+import members from "./members";
+import projectFiles from "./project_files";
+import projectMetadata from "./project_metadata";
 
 // Mounted at /api/v1/w/:wId/spaces/:spaceId. publicApiAuth is applied by the
 // parent v1 workspace sub-app, so ctx.get("auth") is always available here.
 const app = publicApiApp();
 
+app.route("/conversation_ids", conversationIds);
 app.route("/data_sources", dataSources);
+app.route("/members", members);
+app.route("/project_files", projectFiles);
+app.route("/project_metadata", projectMetadata);
 
 export default app;

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/[userId].ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/[userId].ts
@@ -1,0 +1,118 @@
+/* eslint-disable dust/enforce-client-types-in-public-api */
+// This endpoint only returns void as it is used only for deletion, so no need to use @dust-tt/client types.
+
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { publicApiApp } from "@front-api/middlewares/ctx";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  spaceId: z.string(),
+  userId: z.string(),
+});
+
+/**
+ * @ignoreswagger
+ * Admin-only endpoint. Undocumented.
+ */
+// Mounted at /api/v1/w/:wId/spaces/:spaceId/members/:userId.
+const app = publicApiApp();
+
+app.delete("/", validate("param", ParamsSchema), async (ctx) => {
+  const auth = ctx.get("auth");
+
+  if (!auth.isAdmin()) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only users that are `admins` can access this endpoint.",
+      },
+    });
+  }
+
+  const { spaceId, userId } = ctx.req.valid("param");
+
+  const space = await SpaceResource.fetchById(auth, spaceId);
+  if (!space) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space was not found.",
+      },
+    });
+  }
+
+  if (
+    space.managementMode === "group" ||
+    space.groups.some((g) => g.kind === "global")
+  ) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message:
+          space.managementMode === "group"
+            ? "Space is managed by provisioned group access, members can't be edited by API."
+            : "Non-restricted space's members can't be edited.",
+      },
+    });
+  }
+
+  const updateRes = await space.removeMembers(auth, {
+    userIds: [userId],
+  });
+  if (updateRes.isErr()) {
+    switch (updateRes.error.code) {
+      case "unauthorized":
+        return apiError(ctx, {
+          status_code: 401,
+          api_error: {
+            type: "workspace_auth_error",
+            message: "You are not authorized to update the space.",
+          },
+        });
+      case "user_not_member":
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "The user is not a member of the space.",
+          },
+        });
+      case "user_not_found":
+        return apiError(ctx, {
+          status_code: 404,
+          api_error: {
+            type: "user_not_found",
+            message: "The user was not found in the workspace.",
+          },
+        });
+      case "system_or_global_group":
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Users cannot be removed from system or global groups.",
+          },
+        });
+      case "group_not_found":
+        return apiError(ctx, {
+          status_code: 404,
+          api_error: {
+            type: "group_not_found",
+            message: "The group was not found in the workspace.",
+          },
+        });
+      default:
+        assertNever(updateRes.error.code);
+    }
+  }
+
+  return ctx.body(null, 200);
+});
+
+export default app;

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/index.ts
@@ -1,0 +1,211 @@
+import { notifyProjectMembersAdded } from "@app/lib/notifications/workflows/project-added-as-member";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import type {
+  GetSpaceMembersResponseBody,
+  PostSpaceMembersResponseBody,
+} from "@dust-tt/client";
+import { PostSpaceMembersRequestBodySchema } from "@dust-tt/client";
+import type { PublicApiCtx } from "@front-api/middlewares/ctx";
+import { publicApiApp } from "@front-api/middlewares/ctx";
+import { ensureRole } from "@front-api/middlewares/ensure_role";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { createMiddleware } from "hono/factory";
+import uniqBy from "lodash/uniqBy";
+import { z } from "zod";
+
+import userId from "./[userId]";
+
+const ParamsSchema = z.object({
+  spaceId: z.string(),
+});
+
+type MembersCtx = PublicApiCtx & {
+  Variables: {
+    space: SpaceResource;
+  };
+};
+
+/**
+ * Fetches the space named by `:spaceId`, validates it exists and is editable
+ * (not managed by provisioned groups, no global group). Used by GET and POST
+ * below to dedupe the space lookup that the Next handler had inline.
+ *
+ * Reads `spaceId` from `ctx.req.valid("param")`, so a `validate("param", ...)`
+ * with a schema containing `spaceId` must precede it in the handler chain.
+ */
+const withEditableSpace = createMiddleware<
+  MembersCtx,
+  string,
+  {
+    out: { param: z.infer<typeof ParamsSchema> };
+  }
+>(async (ctx, next) => {
+  const auth = ctx.get("auth");
+  const { spaceId } = ctx.req.valid("param");
+
+  const space = await SpaceResource.fetchById(auth, spaceId);
+  if (!space) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "The space was not found.",
+      },
+    });
+  }
+
+  if (
+    space.managementMode === "group" ||
+    space.groups.some((g) => g.kind === "global")
+  ) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message:
+          space.managementMode === "group"
+            ? "Space is managed by provisioned group access, members can't be edited by API."
+            : "Non-restricted space's members can't be edited.",
+      },
+    });
+  }
+
+  ctx.set("space", space);
+  await next();
+});
+
+/**
+ * @ignoreswagger
+ * Admin-only endpoint. Undocumented.
+ */
+// Mounted at /api/v1/w/:wId/spaces/:spaceId/members.
+const app = publicApiApp();
+
+app.get(
+  "/",
+  ensureRole({ admin: true }),
+  validate("param", ParamsSchema),
+  withEditableSpace,
+  async (ctx): HandlerResult<GetSpaceMembersResponseBody> => {
+    const auth = ctx.get("auth");
+    const space = ctx.get("space");
+
+    const currentMembers = uniqBy(
+      (
+        await concurrentExecutor(
+          space.groups,
+          (group) => group.getActiveMembers(auth),
+          { concurrency: 1 }
+        )
+      ).flat(),
+      "sId"
+    );
+
+    return ctx.json({
+      users: currentMembers.map((member) => ({
+        sId: member.sId,
+        email: member.email,
+      })),
+    });
+  }
+);
+
+app.post(
+  "/",
+  ensureRole({ admin: true }),
+  validate("param", ParamsSchema),
+  validate("json", PostSpaceMembersRequestBodySchema),
+  withEditableSpace,
+  async (ctx): HandlerResult<PostSpaceMembersResponseBody> => {
+    const auth = ctx.get("auth");
+    const space = ctx.get("space");
+
+    const { userIds } = ctx.req.valid("json");
+
+    const updateRes = await space.addMembers(auth, {
+      userIds,
+    });
+    if (updateRes.isErr()) {
+      switch (updateRes.error.code) {
+        case "unauthorized":
+          return apiError(ctx, {
+            status_code: 401,
+            api_error: {
+              type: "workspace_auth_error",
+              message: "You are not authorized to update the space.",
+            },
+          });
+        case "user_already_member":
+          return apiError(ctx, {
+            status_code: 409,
+            api_error: {
+              type: "invalid_request_error",
+              message: "The user is already a member of the space.",
+            },
+          });
+        case "user_not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: {
+              type: "user_not_found",
+              message: "The user was not found in the workspace.",
+            },
+          });
+        case "group_requirements_not_met":
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
+              message:
+                "Some users have insufficient role privilege to be added to the space.",
+            },
+          });
+        case "system_or_global_group":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "Users cannot be removed from system or global groups.",
+            },
+          });
+        case "group_not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: {
+              type: "group_not_found",
+              message: "The group was not found in the workspace.",
+            },
+          });
+        default:
+          assertNever(updateRes.error.code);
+      }
+    }
+
+    const usersJson = updateRes.value.map((user) => user.toJSON());
+
+    // Trigger notifications for newly added members (projects only).
+    if (space.isProject()) {
+      notifyProjectMembersAdded(auth, {
+        project: space.toJSON(),
+        addedUserIds: userIds,
+      });
+    }
+
+    return ctx.json({
+      space: space.toJSON(),
+      users: usersJson.map((userJson) => ({
+        sId: userJson.sId,
+        id: userJson.id,
+        email: userJson.email,
+      })),
+    });
+  }
+);
+
+app.route("/:userId", userId);
+
+export default app;

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.test.ts
@@ -1,0 +1,153 @@
+import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const listGCSMountFilesMock = vi.hoisted(() => vi.fn());
+const getConversationFileMountSignedUrlMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@app/lib/api/files/gcs_mount/files", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/files/gcs_mount/files")>();
+  return {
+    ...actual,
+    listGCSMountFiles: listGCSMountFilesMock,
+    getConversationFileMountSignedUrl: getConversationFileMountSignedUrlMock,
+  };
+});
+
+function getProjectFiles(
+  workspace: { sId: string },
+  key: { secret: string },
+  spaceId: string,
+  query: string = ""
+) {
+  return honoApp.request(
+    `/api/v1/w/${workspace.sId}/spaces/${spaceId}/project_files${query}`,
+    {
+      headers: { authorization: `Bearer ${key.secret}` },
+    }
+  );
+}
+
+describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_files", () => {
+  beforeEach(() => {
+    listGCSMountFilesMock.mockReset();
+    getConversationFileMountSignedUrlMock.mockReset();
+    getConversationFileMountSignedUrlMock.mockResolvedValue(
+      new Ok("https://signed.example/read")
+    );
+  });
+
+  it("returns 403 if not system key", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      systemKey: false,
+    });
+
+    const space = await SpaceFactory.project(workspace);
+
+    const response = await getProjectFiles(workspace, key, space.sId);
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "invalid_oauth_token_error",
+        message: "Only system keys are allowed to use this endpoint.",
+      },
+    });
+  });
+
+  it("returns 404 if space does not exist", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      systemKey: true,
+    });
+
+    const response = await getProjectFiles(
+      workspace,
+      key,
+      "non-existent-space-id"
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "space_not_found",
+        message: "Space not found.",
+      },
+    });
+  });
+
+  it("returns 400 for a non-project space", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      systemKey: true,
+    });
+
+    const space = await SpaceFactory.regular(workspace);
+
+    const response = await getProjectFiles(workspace, key, space.sId);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message:
+          "GCS mount files listing is only available for project spaces.",
+      },
+    });
+  });
+
+  it("returns files for a project space and filters by updatedSince", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      systemKey: true,
+    });
+
+    const space = await SpaceFactory.project(workspace);
+
+    const mockFile = {
+      isDirectory: false as const,
+      fileName: "a.txt",
+      path: "project/a.txt",
+      sizeBytes: 3,
+      lastModifiedMs: 2000,
+      contentType: "text/plain",
+      fileId: null,
+      thumbnailUrl: null,
+    };
+
+    const mockFileWithUrl = {
+      ...mockFile,
+      signedDownloadUrl: "https://signed.example/read",
+    };
+
+    listGCSMountFilesMock.mockResolvedValue([
+      mockFile,
+      {
+        isDirectory: false as const,
+        fileName: "old.txt",
+        path: "project/old.txt",
+        sizeBytes: 1,
+        lastModifiedMs: 500,
+        contentType: "text/plain",
+        fileId: null,
+        thumbnailUrl: null,
+      },
+    ]);
+
+    const response = await getProjectFiles(
+      workspace,
+      key,
+      space.sId,
+      "?updatedSince=1000"
+    );
+
+    expect(response.status).toBe(200);
+    expect(listGCSMountFilesMock).toHaveBeenCalledWith(expect.anything(), {
+      useCase: "project",
+      projectId: space.sId,
+    });
+    expect(await response.json()).toEqual({
+      files: [mockFileWithUrl],
+    });
+  });
+});

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
@@ -1,0 +1,131 @@
+import {
+  type GCSMountEntry,
+  getConversationFileMountSignedUrl,
+  getGCSPathFromScopedPath,
+  listGCSMountFiles,
+} from "@app/lib/api/files/gcs_mount/files";
+import { getProjectFilesBasePath } from "@app/lib/api/files/mount_path";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { publicApiApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+export type GetSpaceGCSMountFilesResponseType = {
+  files: GCSMountEntry[];
+};
+
+const ParamsSchema = z.object({
+  spaceId: z.string(),
+});
+
+const QuerySchema = z.object({
+  updatedSince: z.string().optional(),
+});
+
+/**
+ * @ignoreswagger
+ * System API key only endpoint. Undocumented.
+ */
+
+// Mounted at /api/v1/w/:wId/spaces/:spaceId/project_files.
+const app = publicApiApp();
+
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  validate("query", QuerySchema),
+  async (ctx): HandlerResult<GetSpaceGCSMountFilesResponseType> => {
+    const auth = ctx.get("auth");
+
+    if (!auth.isSystemKey()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_oauth_token_error",
+          message: "Only system keys are allowed to use this endpoint.",
+        },
+      });
+    }
+
+    const { spaceId } = ctx.req.valid("param");
+
+    const space = await SpaceResource.fetchById(auth, spaceId);
+    if (!space) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "space_not_found",
+          message: "Space not found.",
+        },
+      });
+    }
+
+    if (!space.isProject()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "GCS mount files listing is only available for project spaces.",
+        },
+      });
+    }
+
+    const { updatedSince } = ctx.req.valid("query");
+    const updatedSinceMs =
+      updatedSince !== undefined ? parseInt(updatedSince, 10) : null;
+    const updatedSinceFilter =
+      updatedSinceMs !== null && !Number.isNaN(updatedSinceMs)
+        ? updatedSinceMs
+        : null;
+
+    let files = await listGCSMountFiles(auth, {
+      useCase: "project",
+      projectId: space.sId,
+    });
+
+    if (updatedSinceFilter !== null) {
+      files = files.filter((e) => e.lastModifiedMs >= updatedSinceFilter);
+    }
+
+    const owner = auth.getNonNullableWorkspace();
+    const gcsPrefix = getProjectFilesBasePath({
+      workspaceId: owner.sId,
+      projectId: space.sId,
+    });
+
+    const filesWithSignedUrls = await concurrentExecutor(
+      files,
+      async (entry) => {
+        if (entry.isDirectory) {
+          return entry;
+        }
+        const gcsPath = getGCSPathFromScopedPath({
+          prefix: gcsPrefix,
+          scopedPath: entry.path,
+          useCase: "project",
+        });
+        if (!gcsPath) {
+          return { ...entry, signedDownloadUrl: null };
+        }
+        const signed = await getConversationFileMountSignedUrl(
+          auth,
+          { useCase: "project", projectId: space.sId },
+          gcsPath
+        );
+        return {
+          ...entry,
+          signedDownloadUrl: signed.isOk() ? signed.value : null,
+        };
+      },
+      { concurrency: 8 }
+    );
+
+    return ctx.json({ files: filesWithSignedUrls });
+  }
+);
+
+export default app;

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -1,0 +1,171 @@
+import { Authenticator } from "@app/lib/auth";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function getProjectMetadata(
+  workspace: { sId: string },
+  key: { secret: string },
+  spaceId: string
+) {
+  return honoApp.request(
+    `/api/v1/w/${workspace.sId}/spaces/${spaceId}/project_metadata`,
+    {
+      headers: { authorization: `Bearer ${key.secret}` },
+    }
+  );
+}
+
+describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_metadata", () => {
+  it("returns 403 if not system key", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      systemKey: false,
+    });
+
+    const space = await SpaceFactory.project(workspace);
+
+    const response = await getProjectMetadata(workspace, key, space.sId);
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "invalid_oauth_token_error",
+        message: "Only system keys are allowed to use this endpoint.",
+      },
+    });
+  });
+
+  it("returns 404 if space does not exist", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      systemKey: true,
+    });
+
+    const response = await getProjectMetadata(
+      workspace,
+      key,
+      "non-existent-space-id"
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "space_not_found",
+        message: "Space not found.",
+      },
+    });
+  });
+
+  it("returns 400 if space is not a project space", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      systemKey: true,
+    });
+
+    const space = await SpaceFactory.regular(workspace);
+
+    const response = await getProjectMetadata(workspace, key, space.sId);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "Pod metadata is only available for Pod spaces.",
+      },
+    });
+  });
+
+  it("returns 404 if no metadata exists", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      systemKey: true,
+    });
+
+    const space = await SpaceFactory.project(workspace);
+
+    const response = await getProjectMetadata(workspace, key, space.sId);
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns project metadata when it exists", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      systemKey: true,
+    });
+
+    const space = await SpaceFactory.project(workspace);
+
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
+    const adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    await ProjectMetadataResource.makeNew(adminAuth, space, {
+      description: "Test project description",
+    });
+
+    const response = await getProjectMetadata(workspace, key, space.sId);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.metadata).toEqual({
+      archivedAt: null,
+      createdAt: expect.anything(),
+      description: "Test project description",
+      lastTodoAnalysisAt: null,
+      pinnedFramePath: null,
+      sId: expect.anything(),
+      spaceId: space.sId,
+      todoGenerationEnabled: false,
+      updatedAt: expect.anything(),
+      members: [],
+    });
+  });
+
+  it("returns project metadata with members", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      systemKey: true,
+    });
+
+    const space = await SpaceFactory.project(workspace);
+
+    const adminUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, adminUser, { role: "admin" });
+    const adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminUser.sId,
+      workspace.sId
+    );
+
+    const member1 = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, member1, { role: "user" });
+
+    const member2 = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, member2, { role: "user" });
+
+    const projectGroup = space.groups[0];
+    await projectGroup.dangerouslyAddMember(adminAuth, {
+      user: member1.toJSON(),
+    });
+    await projectGroup.dangerouslyAddMember(adminAuth, {
+      user: member2.toJSON(),
+    });
+
+    await ProjectMetadataResource.makeNew(adminAuth, space, {
+      description: "Test project with members",
+    });
+
+    const response = await getProjectMetadata(workspace, key, space.sId);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.metadata.members).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(member1.sId),
+        expect.stringContaining(member2.sId),
+      ])
+    );
+  });
+});

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -1,0 +1,108 @@
+import { serializeMention } from "@app/lib/mentions/format";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { GetSpaceMetadataResponseType } from "@dust-tt/client";
+import { publicApiApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import uniqBy from "lodash/uniqBy";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  spaceId: z.string(),
+});
+
+/**
+ * @ignoreswagger
+ * System API key only endpoint. Undocumented.
+ * Used by connectors to fetch project metadata for syncing to data sources.
+ */
+
+// Mounted at /api/v1/w/:wId/spaces/:spaceId/project_metadata.
+const app = publicApiApp();
+
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetSpaceMetadataResponseType> => {
+    const auth = ctx.get("auth");
+
+    // Only allow system keys (connectors) to access this endpoint
+    if (!auth.isSystemKey()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_oauth_token_error",
+          message: "Only system keys are allowed to use this endpoint.",
+        },
+      });
+    }
+
+    const { spaceId } = ctx.req.valid("param");
+
+    // Fetch and verify space exists
+    const space = await SpaceResource.fetchById(auth, spaceId);
+    if (!space) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "space_not_found",
+          message: "Space not found.",
+        },
+      });
+    }
+
+    // Only project spaces can have metadata
+    if (!space.isProject()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Pod metadata is only available for Pod spaces.",
+        },
+      });
+    }
+
+    // Fetch metadata
+    const metadata = await ProjectMetadataResource.fetchBySpace(auth, space);
+    // shouldn't happen, as we create the metadata row when we create the project, but just in case
+    if (!metadata) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "project_metadata_not_found",
+          message: "Pod metadata not found for this space.",
+        },
+      });
+    }
+
+    // Fetch current members of the project
+    const memberUsers = uniqBy(
+      (
+        await concurrentExecutor(
+          space.groups,
+          (group) => group.getActiveMembers(auth),
+          { concurrency: 2 }
+        )
+      ).flat(),
+      "sId"
+    );
+
+    // Format members with mention syntax
+    const formattedMembers = memberUsers.map((user) =>
+      serializeMention({
+        id: user.sId,
+        type: "user",
+        label: user.fullName() || user.email,
+      })
+    );
+
+    return ctx.json({
+      metadata: { ...metadata.toJSON(), members: formattedMembers },
+    });
+  }
+);
+
+export default app;

--- a/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
@@ -1,0 +1,334 @@
+import { Authenticator } from "@app/lib/auth";
+import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WebhookSourceFactory } from "@app/tests/utils/WebhookSourceFactory";
+import { WebhookSourceViewFactory } from "@app/tests/utils/WebhookSourceViewFactory";
+import type { WorkspaceType } from "@app/types/user";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const launchTriggersWorkflowsMock = vi.hoisted(() =>
+  vi.fn(async () => ({
+    isErr: () => false,
+  }))
+);
+
+const uploadWebhookPayloadMock = vi.hoisted(() =>
+  vi.fn().mockResolvedValue(undefined)
+);
+
+// Shallowly mock file content fragment creation to avoid touching storage.
+vi.mock("@app/lib/api/assistant/conversation/content_fragment", () => ({
+  toFileContentFragment: vi.fn(async () => ({
+    isOk: () => true,
+    isErr: () => false,
+    value: { title: "mock", url: null, fileId: "file_mock" },
+  })),
+}));
+
+// Avoid UDP socket usage from StatsD in tests
+vi.mock("@app/lib/utils/statsd", () => ({
+  getStatsDClient: () => ({
+    increment: vi.fn(),
+    distribution: vi.fn(),
+  }),
+}));
+
+vi.mock("@app/lib/file_storage", () => ({
+  getWebhookRequestsBucket: () => ({
+    uploadRawContentToBucket: vi.fn().mockResolvedValue(undefined),
+    uploadSmallRawContentToBucketAsNewFile: uploadWebhookPayloadMock,
+  }),
+}));
+
+vi.mock("@app/temporal/triggers/webhook_client", () => ({
+  launchTriggersWorkflows: launchTriggersWorkflowsMock,
+}));
+
+function postWebhook(
+  workspace: { sId: string },
+  webhookSourceId: string,
+  webhookSourceUrlSecret: string,
+  body: unknown,
+  extraHeaders: Record<string, string> = {}
+) {
+  return honoApp.request(
+    `/api/v1/w/${workspace.sId}/triggers/hooks/${webhookSourceId}/${webhookSourceUrlSecret}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...extraHeaders,
+      },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+async function makeTriggerEditorAuth(workspace: WorkspaceType) {
+  const triggerEditor = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, triggerEditor, {
+    role: "builder",
+  });
+
+  return Authenticator.fromUserIdAndWorkspaceId(
+    triggerEditor.sId,
+    workspace.sId
+  );
+}
+
+async function createWebhookSourceAndTrigger(
+  workspace: WorkspaceType,
+  {
+    includePayload,
+    filter,
+  }: {
+    includePayload: boolean;
+    filter?: string;
+  }
+) {
+  const adminAuth = await Authenticator.internalAdminForWorkspace(
+    workspace.sId
+  );
+  const triggerEditorAuth = await makeTriggerEditorAuth(workspace);
+  const { systemSpace } = await SpaceFactory.defaults(adminAuth);
+
+  const webhookSource = await new WebhookSourceFactory(workspace).create({
+    name: "Test Webhook Source",
+  });
+  const webhookSourceView = await new WebhookSourceViewFactory(
+    workspace
+  ).create(systemSpace, { webhookSourceId: webhookSource.sId });
+
+  await TriggerFactory.webhook(triggerEditorAuth, {
+    agentConfigurationId: "agent_test",
+    status: "enabled",
+    webhookSourceViewId: webhookSourceView.id,
+    configuration: {
+      includePayload,
+      ...(filter ? { filter } : {}),
+    },
+  });
+
+  return webhookSource;
+}
+
+describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]", () => {
+  beforeEach(() => {
+    launchTriggersWorkflowsMock.mockClear();
+    uploadWebhookPayloadMock.mockClear();
+  });
+
+  it("returns 200 when workspace and webhook source exist", async () => {
+    const { workspace } = await createPublicApiMockRequest();
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await SpaceFactory.defaults(auth);
+
+    const webhookSourceFactory = new WebhookSourceFactory(workspace);
+    const webhookSource = await webhookSourceFactory.create({
+      name: "Test Webhook Source",
+    });
+
+    const response = await postWebhook(
+      workspace,
+      webhookSource.sId,
+      webhookSource.urlSecret,
+      { any: "payload" }
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+  });
+
+  it("returns 404 when webhook source does not exist", async () => {
+    const { workspace } = await createPublicApiMockRequest();
+
+    const response = await postWebhook(
+      workspace,
+      "webhook_source/nonexistent",
+      "any-secret",
+      { any: "payload" }
+    );
+
+    expect(response.status).toBe(404);
+    const data = await response.json();
+    expect(data.error.type).toBe("webhook_source_not_found");
+  });
+
+  it("returns 404 on non-POST methods", async () => {
+    const { workspace } = await createPublicApiMockRequest();
+
+    const response = await honoApp.request(
+      `/api/v1/w/${workspace.sId}/triggers/hooks/webhook_source/whatever/any-secret`,
+      {
+        method: "GET",
+      }
+    );
+
+    // Hono returns 404 when no GET route is registered (vs. 405 in Next).
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 400 when content-type is not application/json", async () => {
+    const { workspace } = await createPublicApiMockRequest();
+
+    const response = await honoApp.request(
+      `/api/v1/w/${workspace.sId}/triggers/hooks/webhook_source/whatever/any-secret`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "text/plain" },
+        body: "not json",
+      }
+    );
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error.type).toBe("invalid_request_error");
+    expect(data.error.message).toBe("Content-Type must be application/json.");
+  });
+
+  it("returns 401 when webhook URL secret is invalid", async () => {
+    const { workspace } = await createPublicApiMockRequest();
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await SpaceFactory.defaults(auth);
+
+    const webhookSourceFactory = new WebhookSourceFactory(workspace);
+    const webhookSource = await webhookSourceFactory.create({
+      name: "Test Webhook Source",
+    });
+
+    const response = await postWebhook(
+      workspace,
+      webhookSource.sId,
+      "invalid-secret",
+      { any: "payload" }
+    );
+
+    expect(response.status).toBe(401);
+    const data = await response.json();
+    expect(data.error.type).toBe("webhook_source_auth_error");
+    expect(data.error.message).toBe("Invalid webhook path.");
+  });
+
+  it("returns 200 when webhook URL secret is valid", async () => {
+    const { workspace } = await createPublicApiMockRequest();
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await SpaceFactory.defaults(auth);
+
+    const customUrlSecret = "my-custom-url-secret-123";
+    const webhookSourceFactory = new WebhookSourceFactory(workspace);
+    const webhookSource = await webhookSourceFactory.create({
+      name: "Test Webhook Source with URL Secret",
+      urlSecret: customUrlSecret,
+    });
+
+    const response = await postWebhook(
+      workspace,
+      webhookSource.sId,
+      customUrlSecret,
+      { any: "payload" }
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+  });
+
+  it("stores payload when a matched trigger includes payload", async () => {
+    const { workspace } = await createPublicApiMockRequest();
+
+    const webhookSource = await createWebhookSourceAndTrigger(workspace, {
+      includePayload: true,
+    });
+
+    const response = await postWebhook(
+      workspace,
+      webhookSource.sId,
+      webhookSource.urlSecret,
+      { any: "payload" }
+    );
+
+    expect(response.status).toBe(200);
+    expect(uploadWebhookPayloadMock).toHaveBeenCalledTimes(1);
+    expect(launchTriggersWorkflowsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not store payload when matched triggers do not include payload", async () => {
+    const { workspace } = await createPublicApiMockRequest();
+
+    const webhookSource = await createWebhookSourceAndTrigger(workspace, {
+      includePayload: false,
+    });
+
+    const response = await postWebhook(
+      workspace,
+      webhookSource.sId,
+      webhookSource.urlSecret,
+      { any: "payload" }
+    );
+
+    expect(response.status).toBe(200);
+    expect(uploadWebhookPayloadMock).not.toHaveBeenCalled();
+    expect(launchTriggersWorkflowsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not store payload when no triggers match", async () => {
+    const { workspace } = await createPublicApiMockRequest();
+
+    const webhookSource = await createWebhookSourceAndTrigger(workspace, {
+      includePayload: true,
+      filter: '(eq "type" "wanted")',
+    });
+
+    const response = await postWebhook(
+      workspace,
+      webhookSource.sId,
+      webhookSource.urlSecret,
+      { type: "ignored" }
+    );
+
+    expect(response.status).toBe(200);
+    expect(uploadWebhookPayloadMock).not.toHaveBeenCalled();
+    expect(launchTriggersWorkflowsMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 when GitHub webhook source does not subscribe to pull_request event", async () => {
+    const { workspace } = await createPublicApiMockRequest();
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await SpaceFactory.defaults(auth);
+
+    const webhookSourceFactory = new WebhookSourceFactory(workspace);
+    const webhookSource = await webhookSourceFactory.create({
+      name: "Test GitHub Webhook Source",
+      provider: "github",
+      subscribedEvents: ["issues"], // Subscribe to issues but not pull_request
+    });
+
+    const response = await postWebhook(
+      workspace,
+      webhookSource.sId,
+      webhookSource.urlSecret,
+      {
+        action: "opened",
+        issue: {
+          url: "https://api.github.com/repos/example/repo/issues/1",
+          id: 1001,
+          number: 1,
+        },
+        assignee: { login: "octocat" },
+        label: { id: 208045946 },
+        sender: { login: "octocat" },
+      },
+      { "x-github-event": "pull_request" }
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+  });
+});

--- a/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
@@ -37,12 +37,18 @@ vi.mock("@app/lib/utils/statsd", () => ({
   }),
 }));
 
-vi.mock("@app/lib/file_storage", () => ({
-  getWebhookRequestsBucket: () => ({
-    uploadRawContentToBucket: vi.fn().mockResolvedValue(undefined),
-    uploadSmallRawContentToBucketAsNewFile: uploadWebhookPayloadMock,
-  }),
-}));
+vi.mock("@app/lib/file_storage", async () => {
+  const { fileStorageMock } = await import(
+    "@app/tests/utils/mocks/file_storage"
+  );
+  return {
+    ...fileStorageMock.mock(),
+    getWebhookRequestsBucket: () => ({
+      uploadRawContentToBucket: vi.fn().mockResolvedValue(undefined),
+      uploadSmallRawContentToBucketAsNewFile: uploadWebhookPayloadMock,
+    }),
+  };
+});
 
 vi.mock("@app/temporal/triggers/webhook_client", () => ({
   launchTriggersWorkflows: launchTriggersWorkflowsMock,
@@ -149,7 +155,7 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
 
     const response = await postWebhook(
       workspace,
-      "webhook_source/nonexistent",
+      "whs_nonexistent",
       "any-secret",
       { any: "payload" }
     );
@@ -159,25 +165,27 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUr
     expect(data.error.type).toBe("webhook_source_not_found");
   });
 
-  it("returns 404 on non-POST methods", async () => {
+  it("returns 401 on non-POST methods", async () => {
     const { workspace } = await createPublicApiMockRequest();
 
     const response = await honoApp.request(
-      `/api/v1/w/${workspace.sId}/triggers/hooks/webhook_source/whatever/any-secret`,
+      `/api/v1/w/${workspace.sId}/triggers/hooks/whs_whatever/any-secret`,
       {
         method: "GET",
       }
     );
 
-    // Hono returns 404 when no GET route is registered (vs. 405 in Next).
-    expect(response.status).toBe(404);
+    // Only POST is registered on the (unauthenticated) triggers sub-app, so a
+    // GET falls through to the authenticated /v1/w/:wId app, whose publicApiAuth
+    // rejects the missing credentials with 401 (vs. 405 in the Next handler).
+    expect(response.status).toBe(401);
   });
 
   it("returns 400 when content-type is not application/json", async () => {
     const { workspace } = await createPublicApiMockRequest();
 
     const response = await honoApp.request(
-      `/api/v1/w/${workspace.sId}/triggers/hooks/webhook_source/whatever/any-secret`,
+      `/api/v1/w/${workspace.sId}/triggers/hooks/whs_whatever/any-secret`,
       {
         method: "POST",
         headers: { "Content-Type": "text/plain" },

--- a/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts
@@ -1,0 +1,209 @@
+import { timingSafeEqual } from "node:crypto";
+
+import { Authenticator } from "@app/lib/auth";
+import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
+import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import {
+  HEADERS_ALLOWED_LIST,
+  processWebhookRequest,
+} from "@app/lib/triggers/webhook";
+import { getStatsDClient } from "@app/lib/utils/statsd";
+import { isString } from "@app/types/shared/utils/general";
+import type { PostWebhookTriggerResponseType } from "@dust-tt/client";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { Hono } from "hono";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  wId: z.string(),
+  webhookSourceId: z.string(),
+  webhookSourceUrlSecret: z.string(),
+});
+
+// 2mb body limit, matches the original `raw-body` `limit: "2mb"`.
+const WEBHOOK_REQUEST_MAX_SIZE_BYTES = 2 * 1024 * 1024;
+
+/**
+ * @swagger
+ * /api/v1/w/{wId}/triggers/hooks/{webhookSourceId}:
+ *   post:
+ *     summary: Receive external webhook to trigger flows
+ *     description: Skeleton endpoint that verifies workspace and webhook source and logs receipt.
+ *     tags:
+ *       - Triggers
+ *     security:
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: Workspace ID
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: webhookSourceId
+ *         required: true
+ *         description: Webhook source ID
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *     responses:
+ *       200:
+ *         description: Webhook received
+ *       400:
+ *         description: Invalid request
+ *       404:
+ *         description: Workspace or webhook source not found
+ *       405:
+ *         description: Method not allowed
+ */
+
+// Mounted at /api/v1/w/:wId/triggers/hooks/:webhookSourceId/:webhookSourceUrlSecret.
+// This route is mounted outside `publicApiAuth` because it uses its own
+// authentication scheme based on the URL secret.
+const app = new Hono();
+
+app.post(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<PostWebhookTriggerResponseType> => {
+    const contentType = ctx.req.header("content-type");
+    if (!contentType || !contentType.includes("application/json")) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Content-Type must be application/json.",
+        },
+      });
+    }
+
+    // Read the raw body for signature verification (must match exactly what the
+    // sender signed), then parse JSON for processing.
+    const arrayBuffer = await ctx.req.arrayBuffer();
+    if (arrayBuffer.byteLength > WEBHOOK_REQUEST_MAX_SIZE_BYTES) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Request body too large.",
+        },
+      });
+    }
+    const rawBody = Buffer.from(arrayBuffer).toString("utf8");
+    let body: Record<string, unknown>;
+    try {
+      body = JSON.parse(rawBody) as Record<string, unknown>;
+    } catch {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid JSON body.",
+        },
+      });
+    }
+
+    const { wId, webhookSourceId, webhookSourceUrlSecret } =
+      ctx.req.valid("param");
+
+    const workspace = await WorkspaceResource.fetchById(wId);
+    if (!workspace) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "workspace_not_found",
+          message: `Workspace ${wId} not found.`,
+        },
+      });
+    }
+
+    const auth = await Authenticator.internalBuilderForWorkspace(wId);
+
+    const webhookSource = await WebhookSourceResource.fetchById(
+      auth,
+      webhookSourceId
+    );
+
+    if (!webhookSource) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "webhook_source_not_found",
+          message: `Webhook source ${webhookSourceId} not found in workspace ${wId}.`,
+        },
+      });
+    }
+
+    // Validate webhook url secret using constant-time comparison to prevent timing attacks.
+    const a = Buffer.from(webhookSourceUrlSecret, "utf8");
+    const b = Buffer.from(webhookSource.urlSecret, "utf8");
+    if (a.length !== b.length || !timingSafeEqual(a, b)) {
+      return apiError(ctx, {
+        status_code: 401,
+        api_error: {
+          type: "webhook_source_auth_error",
+          message: "Invalid webhook path.",
+        },
+      });
+    }
+
+    const provider = webhookSource.provider ?? "custom";
+
+    getStatsDClient().increment("webhook_request.count", 1, [
+      `provider:${provider}`,
+      `workspace_id:${workspace.sId}`,
+    ]);
+
+    const webhookRequest = await WebhookRequestResource.makeNew({
+      workspaceId: auth.getNonNullableWorkspace().id,
+      webhookSourceId: webhookSource.id,
+      status: "received",
+    });
+
+    const headers: Record<string, string | string[] | undefined> = {};
+    ctx.req.raw.headers.forEach((value, key) => {
+      headers[key] = value;
+    });
+
+    const filteredHeaders: Record<string, string> = Object.fromEntries(
+      Object.entries(headers).filter(
+        ([key]) =>
+          (HEADERS_ALLOWED_LIST.includes(key.toLowerCase()) ||
+            webhookSource.signatureHeader?.toLowerCase() ===
+              key.toLowerCase()) &&
+          isString(headers[key])
+      ) as [string, string][] // Type assertion to satisfy TypeScript, we've already filtered to strings
+    );
+
+    const result = await processWebhookRequest(auth, {
+      webhookSource,
+      webhookRequest,
+      headers: filteredHeaders,
+      body,
+      rawBody,
+    });
+
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: result.error.message,
+        },
+      });
+    }
+
+    return ctx.json({ success: true });
+  }
+);
+
+export default app;

--- a/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/index.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/index.ts
@@ -1,0 +1,10 @@
+import { Hono } from "hono";
+
+import webhookSourceUrlSecret from "./[webhookSourceUrlSecret]";
+
+// Mounted at /api/v1/w/:wId/triggers/hooks/:webhookSourceId.
+const app = new Hono();
+
+app.route("/:webhookSourceUrlSecret", webhookSourceUrlSecret);
+
+export default app;

--- a/front-api/routes/v1/w/[wId]/triggers/hooks/index.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/hooks/index.ts
@@ -1,0 +1,10 @@
+import { Hono } from "hono";
+
+import webhookSourceId from "./[webhookSourceId]";
+
+// Mounted at /api/v1/w/:wId/triggers/hooks.
+const app = new Hono();
+
+app.route("/:webhookSourceId", webhookSourceId);
+
+export default app;

--- a/front-api/routes/v1/w/[wId]/triggers/index.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/index.ts
@@ -1,0 +1,12 @@
+import { Hono } from "hono";
+
+import hooks from "./hooks";
+
+// Mounted at /api/v1/w/:wId/triggers. This sub-tree is mounted before
+// `publicWorkspaceApp` in `app.ts` so it does not inherit `publicApiAuth` —
+// the webhook endpoint uses its own URL secret-based authentication.
+const app = new Hono();
+
+app.route("/hooks", hooks);
+
+export default app;

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/conversation_ids.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/conversation_ids.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/[userId].ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/[userId].ts
@@ -1,6 +1,8 @@
 /* eslint-disable dust/enforce-client-types-in-public-api */
 // This endpoint only returns void as it is used only for deletion, so no need to use @dust-tt/client types.
 
+// @migration-status: MIGRATED_TO_HONO
+
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/index.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { notifyProjectMembersAdded } from "@app/lib/notifications/workflows/project-added-as-member";

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import {
   type GCSMountEntry,

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";

--- a/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts
+++ b/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts
@@ -1,3 +1,5 @@
+// @migration-status: MIGRATED_TO_HONO
+
 import { timingSafeEqual } from "node:crypto";
 
 import { Authenticator } from "@app/lib/auth";


### PR DESCRIPTION
## Description

Migrate:

- front/pages/api/v1/w/[wId]/spaces/[spaceId]/conversation_ids.ts
- front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_metadata.ts
- front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
- front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/index.ts
- front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/[userId].ts
- front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
