### PR TITLE
[Data Retention] Remove conversation retention 60-day floor

### DIFF
--- a/front/lib/conversations_retention.ts
+++ b/front/lib/conversations_retention.ts
@@ -1,6 +1,6 @@
 import isNumber from "lodash/isNumber";
 
-export const CONVERSATIONS_RETENTION_MIN_DAYS = 60;
+export const CONVERSATIONS_RETENTION_MIN_DAYS = 1;
 
 export const isValidConversationsRetentionDays = (
   retentionDays: string | number | boolean | object | undefined

--- a/front/lib/resources/workspace_resource.test.ts
+++ b/front/lib/resources/workspace_resource.test.ts
@@ -1,3 +1,4 @@
+import { CONVERSATIONS_RETENTION_MIN_DAYS } from "@app/lib/conversations_retention";
 import type { CacheableFunction, JsonSerializable } from "@app/lib/utils/cache";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -89,6 +90,9 @@ function getCacheKeyForWorkspace(workspaceId: string): string {
   return `cacheWithRedis-_fetchByIdUncached-workspace:sid:${workspaceId}`;
 }
 
+const INVALID_RETENTION_DAYS = CONVERSATIONS_RETENTION_MIN_DAYS - 1;
+const SHORT_RETENTION_DAYS = 30;
+
 describe("WorkspaceResource", () => {
   let workspace: WorkspaceType;
 
@@ -176,7 +180,7 @@ describe("WorkspaceResource", () => {
     it("should reject values below the minimum retention", async () => {
       const result = await WorkspaceResource.updateConversationsRetention(
         workspace.id,
-        59
+        INVALID_RETENTION_DAYS
       );
 
       expect(result.isErr()).toBe(true);
@@ -185,21 +189,24 @@ describe("WorkspaceResource", () => {
       expect(updated?.conversationsRetentionDays).toBeNull();
     });
 
-    it("should set retention days value", async () => {
+    it("should allow sub-60 retention days value", async () => {
       const result = await WorkspaceResource.updateConversationsRetention(
         workspace.id,
-        60
+        SHORT_RETENTION_DAYS
       );
 
       expect(result.isOk()).toBe(true);
 
       const updated = await WorkspaceResource.fetchById(workspace.sId);
-      expect(updated?.conversationsRetentionDays).toBe(60);
+      expect(updated?.conversationsRetentionDays).toBe(SHORT_RETENTION_DAYS);
     });
 
     it("should convert -1 to null", async () => {
       // First set a value
-      await WorkspaceResource.updateConversationsRetention(workspace.id, 60);
+      await WorkspaceResource.updateConversationsRetention(
+        workspace.id,
+        SHORT_RETENTION_DAYS
+      );
 
       // Then set -1 which should convert to null
       const result = await WorkspaceResource.updateConversationsRetention(
@@ -217,7 +224,7 @@ describe("WorkspaceResource", () => {
       const result = await WorkspaceResource.updateByModelIdAndCheckExistence(
         workspace.id,
         {
-          conversationsRetentionDays: 59,
+          conversationsRetentionDays: INVALID_RETENTION_DAYS,
         }
       );
 

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -907,7 +907,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
       ) {
         return new Err(
           new Error(
-            `Conversation retention must be -1 or >= ${CONVERSATIONS_RETENTION_MIN_DAYS} days.`
+            `Conversation retention must be -1 or at least ${CONVERSATIONS_RETENTION_MIN_DAYS} day.`
           )
         );
       }

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -907,7 +907,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
       ) {
         return new Err(
           new Error(
-            `Conversation retention must be -1 or at least ${CONVERSATIONS_RETENTION_MIN_DAYS} day.`
+            `Conversation retention must be null or at least ${CONVERSATIONS_RETENTION_MIN_DAYS} day.`
           )
         );
       }


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/7172
Follows https://github.com/dust-tt/dust/pull/23166
Context: [slack thread](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1773843215032129?thread_ts=1773843215.032129&cid=C050A0S2Z7F)

Removes the temporary 60-day minimum on workspace conversation retention now that the old analytics export surface has been deprecated. Workspaces can set conversation retention values below 60 days again while still rejecting non-positive values except -1 for unlimited.

## Risks
Blast radius: workspace conversation retention updates through admin tooling and resource helpers
Risk: low

## Deploy Plan
- pmrr
- deploy front

## Test
- [x] `NODE_ENV=test npm test lib/resources/workspace_resource.test.ts temporal/data_retention/activities.test.ts`