### PR TITLE
[front] confluence mcp: allow to add instance url in authentication step

### DIFF
--- a/front/lib/api/actions/servers/confluence/helpers.ts
+++ b/front/lib/api/actions/servers/confluence/helpers.ts
@@ -22,6 +22,8 @@ import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isString } from "@app/types/shared/utils/general";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { z } from "zod";
 
@@ -87,13 +89,62 @@ async function confluenceApiCall<T extends z.ZodTypeAny>(
   }
 }
 
+type ConfluenceResourceInfo = { id: string; url: string; name: string };
+
+async function getConfluenceBaseUrlAndResourceInfo(
+  accessToken: string,
+  cloudUrl: string | null
+): Promise<{ baseUrl: string; resourceInfo: ConfluenceResourceInfo } | null> {
+  const result = await confluenceApiCall(
+    { endpoint: "/oauth/token/accessible-resources", accessToken },
+    AtlassianResourceSchema,
+    { baseUrl: "https://api.atlassian.com" }
+  );
+
+  if (result.isErr()) {
+    logger.error("Failed to get accessible resources", { error: result.error });
+    return null;
+  }
+
+  const resources = result.value;
+  if (!resources || resources.length === 0) {
+    logger.error("No accessible resources found");
+    return null;
+  }
+
+  const resource = !cloudUrl
+    ? resources[0]
+    : (resources.find((r) => r.url === cloudUrl) ?? null);
+
+  if (!resource) {
+    return null;
+  }
+
+  return {
+    baseUrl: `https://api.atlassian.com/ex/confluence/${resource.id}`,
+    resourceInfo: { id: resource.id, url: resource.url, name: resource.name },
+  };
+}
+
+function getConfluenceCloudUrl(authInfo?: AuthInfo): string | null {
+  if (!authInfo?.extra) {
+    return null;
+  }
+  const cloudUrl = authInfo.extra.confluence_cloud_url;
+  if (!isString(cloudUrl)) {
+    return null;
+  }
+  return cloudUrl;
+}
+
 export async function withAuth<T>(
-  accessToken: string | undefined,
+  authInfo: AuthInfo | undefined,
   action: (baseUrl: string, accessToken: string) => Promise<T>
 ): Promise<
   | { success: true; result: T }
   | { success: false; error: CallToolResult["content"] }
 > {
+  const accessToken = authInfo?.token;
   if (!accessToken) {
     return {
       success: false,
@@ -102,19 +153,26 @@ export async function withAuth<T>(
   }
 
   try {
-    const baseUrl = await getConfluenceBaseUrl(accessToken);
-    if (!baseUrl) {
+    const cloudUrl = getConfluenceCloudUrl(authInfo);
+    const resolved = await getConfluenceBaseUrlAndResourceInfo(
+      accessToken,
+      cloudUrl
+    );
+    if (!resolved) {
       return {
         success: false,
         error: [
           {
             type: "text" as const,
-            text: "Failed to determine Confluence instance URL. Please check your connection.",
+            text: cloudUrl
+              ? `Confluence resource could not be found for url: ${cloudUrl}`
+              : "Failed to determine Confluence instance URL. Please check your connection.",
           },
         ],
       };
     }
 
+    const { baseUrl } = resolved;
     const result = await action(baseUrl, accessToken);
     return { success: true, result };
   } catch (error) {
@@ -129,48 +187,6 @@ export async function withAuth<T>(
       ],
     };
   }
-}
-
-async function getConfluenceBaseUrl(
-  accessToken: string
-): Promise<string | null> {
-  const resourceInfo = await getConfluenceResourceInfo(accessToken);
-  if (resourceInfo?.id) {
-    return `https://api.atlassian.com/ex/confluence/${resourceInfo.id}`;
-  }
-  return null;
-}
-
-async function getConfluenceResourceInfo(
-  accessToken: string
-): Promise<{ id: string; name: string; url: string } | null> {
-  const result = await confluenceApiCall(
-    {
-      endpoint: "/oauth/token/accessible-resources",
-      accessToken,
-    },
-    AtlassianResourceSchema,
-    {
-      baseUrl: "https://api.atlassian.com",
-    }
-  );
-
-  if (result.isErr()) {
-    logger.error("Failed to get accessible resources", { error: result.error });
-    return null;
-  }
-
-  const resources = result.value;
-  if (!resources || resources.length === 0) {
-    logger.error("No accessible resources found");
-    return null;
-  }
-  const resource = resources[0];
-  return {
-    id: resource.id,
-    name: resource.name,
-    url: resource.url,
-  };
 }
 
 export async function getCurrentUser(

--- a/front/lib/api/actions/servers/confluence/tools/index.ts
+++ b/front/lib/api/actions/servers/confluence/tools/index.ts
@@ -26,7 +26,7 @@ export function createConfluenceTools(): ToolDefinition[] {
   const handlers: ToolHandlers<typeof CONFLUENCE_TOOLS_METADATA> = {
     get_current_user: async (_params, { authInfo }: ToolHandlerExtra) => {
       const authResult = await withAuth(
-        authInfo?.token,
+        authInfo,
         async (baseUrl, accessToken) => {
           const result = await getCurrentUser(baseUrl, accessToken);
           if (result.isErr()) {
@@ -54,7 +54,7 @@ export function createConfluenceTools(): ToolDefinition[] {
 
     get_spaces: async (_params, { authInfo }: ToolHandlerExtra) => {
       const authResult = await withAuth(
-        authInfo?.token,
+        authInfo,
         async (baseUrl, accessToken) => {
           const result = await listSpaces(baseUrl, accessToken);
           if (result.isErr()) {
@@ -84,7 +84,7 @@ export function createConfluenceTools(): ToolDefinition[] {
 
     get_pages: async (params, { authInfo }: ToolHandlerExtra) => {
       const authResult = await withAuth(
-        authInfo?.token,
+        authInfo,
         async (baseUrl, accessToken) => {
           const result = await listPages(baseUrl, accessToken, params);
           if (result.isErr()) {
@@ -114,7 +114,7 @@ export function createConfluenceTools(): ToolDefinition[] {
 
     get_page: async (params, { authInfo }: ToolHandlerExtra) => {
       const authResult = await withAuth(
-        authInfo?.token,
+        authInfo,
         async (baseUrl, accessToken) => {
           const result = await getPage(
             baseUrl,
@@ -155,7 +155,7 @@ export function createConfluenceTools(): ToolDefinition[] {
 
     create_page: async (params, { authInfo }: ToolHandlerExtra) => {
       const authResult = await withAuth(
-        authInfo?.token,
+        authInfo,
         async (baseUrl, accessToken) => {
           const result = await createPage(baseUrl, accessToken, params);
           if (result.isErr()) {
@@ -180,7 +180,7 @@ export function createConfluenceTools(): ToolDefinition[] {
 
     update_page: async (params, { authInfo }: ToolHandlerExtra) => {
       const authResult = await withAuth(
-        authInfo?.token,
+        authInfo,
         async (baseUrl, accessToken) => {
           const result = await updatePage(baseUrl, accessToken, params);
           if (result.isErr()) {

--- a/front/lib/api/oauth/providers/confluence_tools.ts
+++ b/front/lib/api/oauth/providers/confluence_tools.ts
@@ -9,6 +9,7 @@ import type {
   OAuthConnectionType,
   OAuthUseCase,
 } from "@app/types/oauth/lib";
+import { isValidAtlassianCloudUrlOrEmpty } from "@app/types/oauth/lib";
 import type { ParsedUrlQuery } from "querystring";
 
 export class ConfluenceToolsOAuthProvider implements BaseOAuthStrategyProvider {
@@ -55,6 +56,7 @@ export class ConfluenceToolsOAuthProvider implements BaseOAuthStrategyProvider {
         return true;
       }
     }
-    return Object.keys(extraConfig).length === 0;
+    // confluence_cloud_url is optional — absent or empty means fall back to dynamic resolution.
+    return isValidAtlassianCloudUrlOrEmpty(extraConfig.confluence_cloud_url);
   }
 }

--- a/front/lib/api/oauth/providers/jira.ts
+++ b/front/lib/api/oauth/providers/jira.ts
@@ -9,7 +9,7 @@ import type {
   OAuthConnectionType,
   OAuthUseCase,
 } from "@app/types/oauth/lib";
-import { isValidJiraCloudUrlOrEmpty } from "@app/types/oauth/lib";
+import { isValidAtlassianCloudUrlOrEmpty } from "@app/types/oauth/lib";
 import type { ParsedUrlQuery } from "querystring";
 
 export class JiraOAuthProvider implements BaseOAuthStrategyProvider {
@@ -67,6 +67,6 @@ export class JiraOAuthProvider implements BaseOAuthStrategyProvider {
       }
     }
     // cloud_url is optional — absent or empty means fall back to dynamic resolution.
-    return isValidJiraCloudUrlOrEmpty(extraConfig.jira_cloud_url);
+    return isValidAtlassianCloudUrlOrEmpty(extraConfig.jira_cloud_url);
   }
 }

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -111,6 +111,7 @@ const SUPPORTED_OAUTH_CREDENTIALS = [
   "snowflake_warehouse",
   "ukg_ready_company_id",
   "jira_cloud_url",
+  "confluence_cloud_url",
 ] as const;
 
 export type SupportedOAuthCredentials =
@@ -316,7 +317,23 @@ export function getProviderRequiredOAuthCredentialInputs({
             helpMessage:
               "Your Atlassian Cloud URL (e.g. https://company.atlassian.net). " +
               "Optional — leave blank to use the first accessible instance.",
-            validator: isValidJiraCloudUrlOrEmpty,
+            validator: isValidAtlassianCloudUrlOrEmpty,
+            overridableAtPersonalAuth: false,
+          },
+        };
+        return result;
+      }
+      return null;
+    case "confluence_tools":
+      if (useCase === "platform_actions" || useCase === "personal_actions") {
+        const result: OAuthCredentialInputs = {
+          confluence_cloud_url: {
+            label: "Confluence Cloud URL",
+            value: undefined,
+            helpMessage:
+              "Your Atlassian Cloud URL (e.g. https://company.atlassian.net). " +
+              "Optional — leave blank to use the first accessible instance.",
+            validator: isValidAtlassianCloudUrlOrEmpty,
             overridableAtPersonalAuth: false,
           },
         };
@@ -332,7 +349,6 @@ export function getProviderRequiredOAuthCredentialInputs({
     case "monday":
     case "notion":
     case "confluence":
-    case "confluence_tools":
     case "github":
     case "google_drive":
     case "intercom":
@@ -498,7 +514,7 @@ export function isValidZendeskSubdomain(s: unknown): s is string {
 const ATLASSIAN_CLOUD_URL_REGEX =
   /^https:\/\/[a-z0-9][a-z0-9-]*\.atlassian\.net$/i;
 
-export function normalizeJiraCloudUrl(raw: string): string {
+export function normalizeAtlassianCloudUrl(raw: string): string {
   let url = raw.trim();
   if (!url.startsWith("http://") && !url.startsWith("https://")) {
     url = "https://" + url;
@@ -506,20 +522,22 @@ export function normalizeJiraCloudUrl(raw: string): string {
   return url.replace(/\/+$/, "");
 }
 
-export function isValidJiraCloudUrl(cloudUrl: string | undefined): boolean {
+export function isValidAtlassianCloudUrl(
+  cloudUrl: string | undefined
+): boolean {
   if (!cloudUrl) {
     return false;
   }
-  return ATLASSIAN_CLOUD_URL_REGEX.test(normalizeJiraCloudUrl(cloudUrl));
+  return ATLASSIAN_CLOUD_URL_REGEX.test(normalizeAtlassianCloudUrl(cloudUrl));
 }
 
-export function isValidJiraCloudUrlOrEmpty(
+export function isValidAtlassianCloudUrlOrEmpty(
   cloudUrl: string | undefined
 ): boolean {
   if (!cloudUrl || cloudUrl.trim() === "") {
     return true;
   }
-  return ATLASSIAN_CLOUD_URL_REGEX.test(normalizeJiraCloudUrl(cloudUrl));
+  return ATLASSIAN_CLOUD_URL_REGEX.test(normalizeAtlassianCloudUrl(cloudUrl));
 }
 
 export function isValidSalesforceDomain(s: unknown): s is string {


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8242

Mirrors the Jira multi-instance fix ([PR 24824](https://github.com/dust-tt/dust/pull/24824)): 
* adds an optional confluence_cloud_url to the confluence_tools OAuth provider
* uses it in withAuth to match the correct Atlassian resource

If no confluence_cloud_url instance is provided, we keep the same behavior as before for backward compatibility => the tool will use the first instance returned by Confluence

## Tests

Tested locally by the different cases:
* add a Confluence tool without cloudUrl => the tools point to the first Confluence instance in the resource list (as before)
* add a Confluence tool with a cloudUrl that corresponds to not the first one in the resource list => the tools point to this specific Confluence instance and not the first one in the list
* have a Confluence tool setup with previous code state + upgrade to new version => same behavior as before and uses first Confluence instance in the resource list

## Risk

Low, only Confluence MCP + backward compatibility with no instance url provided

## Deploy Plan

Deploy front