### PR TITLE
triggers: block on depleted pool

### DIFF
--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -5,6 +5,7 @@ import type { DustError } from "@app/lib/error";
 import { getWebhookRequestsBucket } from "@app/lib/file_storage";
 import { isGCSPreconditionFailedError } from "@app/lib/file_storage/types";
 import { matchPayload, parseMatcherExpression } from "@app/lib/matcher";
+import { isApiBlocked } from "@app/lib/metronome/user_block";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
 import type { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
@@ -258,26 +259,43 @@ async function checkWorkspaceRateLimit({
 }): Promise<RateLimitCheckResult> {
   let errorMessage: string | null = null;
 
+  const plan = auth.subscription()?.plan;
+  const owner = auth.getNonNullableWorkspace();
+
+  // Credit-priced pool gate: applies to any execution mode. If the pool is
+  // depleted, no downstream message can be posted, so reject early instead of
+  // spinning up the trigger workflow only to fail in `checkMessagesLimit`.
+  if (
+    plan &&
+    isCreditPricedPlan(plan) &&
+    owner.metronomeCustomerId &&
+    (await isApiBlocked(owner.sId))
+  ) {
+    errorMessage =
+      "Your workspace has run out of credits. Please purchase more credits to continue.";
+  }
+
   /**
    * Check for workspace-level rate limits
    * - for fair use execution mode, check global rate limits
    * - for programmatic usage mode, check public API limits
    */
-  if (!trigger.executionMode || trigger.executionMode === "fair_use") {
-    const { rateLimited, message } =
-      await checkWebhookRequestForRateLimit(auth);
-    if (rateLimited) {
-      errorMessage = message;
-    }
-  } else {
-    // Programmatic execution mode: legacy programmatic-credit gate applies to
-    // legacy plans only. Credit-priced plans are gated by the workspace pool
-    // upstream (in `checkMessagesLimit`).
-    const plan = auth.subscription()?.plan;
-    if (!plan || !isCreditPricedPlan(plan)) {
-      const limitsResult = await checkProgrammaticUsageLimits(auth);
-      if (limitsResult.isErr()) {
-        errorMessage = limitsResult.error.message;
+  if (!errorMessage) {
+    if (!trigger.executionMode || trigger.executionMode === "fair_use") {
+      const { rateLimited, message } =
+        await checkWebhookRequestForRateLimit(auth);
+      if (rateLimited) {
+        errorMessage = message;
+      }
+    } else {
+      // Programmatic execution mode: legacy programmatic-credit gate applies
+      // to legacy plans only. Credit-priced plans are already gated above by
+      // the workspace pool check.
+      if (!plan || !isCreditPricedPlan(plan)) {
+        const limitsResult = await checkProgrammaticUsageLimits(auth);
+        if (limitsResult.isErr()) {
+          errorMessage = limitsResult.error.message;
+        }
       }
     }
   }


### PR DESCRIPTION
## Description

Adds an early credit-pool gate in the webhook trigger rate-limit path. On credit-priced plans, if the workspace pool is depleted, no downstream message can be posted (the gate fires in `checkMessagesLimit` → `isApiBlocked`). Today that check runs only after the Temporal trigger workflow has spun up and the agent has started, wasting compute on requests that are guaranteed to fail.

The new gate is **additive** to the existing per-execution-mode checks:

- For any execution mode (`fair_use` or `programmatic`), credit-priced workspaces are rejected at the webhook layer when `isApiBlocked` returns true.
- `checkWebhookRequestForRateLimit` (`maxMessages`) still runs on top in `fair_use` mode — the two gates are orthogonal.
- The legacy programmatic-credit gate (`checkProgrammaticUsageLimits`) still runs for non-credit-priced plans in `programmatic` mode.

Uses `isApiBlocked` (workspace-pool only) rather than `isUserBlocked` because triggers run without a user actor.

## Tests

Manual reasoning against the existing call sites — same gate is already used in `conversation.ts:2401–2414` (`checkMessagesLimit`) for the canonical message-creation path. No behavior change for non-credit-priced plans or for credit-priced plans with available pool.

## Risk

Low. The new check is gated on `isCreditPricedPlan(plan) && owner.metronomeCustomerId`, so legacy plans are untouched. For credit-priced workspaces, the only behavioral change is that depleted-pool triggers are now rejected earlier (at the webhook ingress) instead of later (at message creation) — the rejection itself already happens today, just deeper in the pipeline.

Rollback: revert the commit.

## Deploy Plan

Standard front deploy. No migrations, no config changes.