### PR TITLE
Add: deleting and renaming Folders in Pods.

### DIFF
--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -16,6 +16,7 @@ import type {
   FileExplorerMenuAction,
   FileExplorerSortMode,
   FileSystemTreeNode,
+  FolderEntry,
 } from "@app/components/file_explorer/types";
 import {
   buildFolderTree,
@@ -60,7 +61,7 @@ interface FileExplorerProps {
     parentRelativePath: string
   ) => Promise<Result<void, Error>>;
   onOpenInteractive?: (entry: FileEntryWithId) => void;
-  onRename?: (entry: FileEntry) => void;
+  onRename?: (entry: FileEntry | FolderEntry) => void;
   getExtraFileMenuItems?: (
     entry: FileExplorerEntry
   ) => FileExplorerMenuAction[];
@@ -150,7 +151,7 @@ export function FileExplorer({
     (entry: FileExplorerEntry): FileExplorerMenuAction[] => {
       const items: FileExplorerMenuAction[] =
         getExtraFileMenuItems?.(entry) ?? [];
-      if (onRename && entry.kind === "file") {
+      if (onRename && (entry.kind === "file" || entry.kind === "folder")) {
         items.push({
           label: "Rename",
           icon: PencilSquareIcon,

--- a/front/components/file_explorer/FileExplorerContent.tsx
+++ b/front/components/file_explorer/FileExplorerContent.tsx
@@ -11,6 +11,7 @@ import type {
   FileExplorerEntry,
   FileExplorerMenuAction,
   FileSystemTreeNode,
+  FolderEntry,
 } from "@app/components/file_explorer/types";
 import { isFileExplorerMovableFile } from "@app/components/file_explorer/utils";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
@@ -53,6 +54,11 @@ export function FileExplorerContent({
 }: FileExplorerContentProps) {
   const items = sortedNodes.map((node) => {
     if (node.isDirectory) {
+      const folderEntry: FolderEntry = {
+        kind: "folder",
+        path: `project/${node.path}`,
+        name: node.name,
+      };
       return (
         <FileExplorerFolderCard
           key={`dir:${node.path}`}
@@ -60,6 +66,7 @@ export function FileExplorerContent({
           viewMode={viewMode}
           onNavigate={onFolderNavigate}
           onMoveFileDrop={onMoveFileDrop}
+          extraMenuItems={getFileMenuItems?.(folderEntry)}
         />
       );
     }
@@ -93,6 +100,9 @@ export function FileExplorerContent({
             extraMenuItems={getFileMenuItems?.(entry)}
           />
         );
+
+      case "folder":
+        return null;
 
       default:
         assertNeverAndIgnore(entry);

--- a/front/components/file_explorer/FileExplorerItem.tsx
+++ b/front/components/file_explorer/FileExplorerItem.tsx
@@ -265,6 +265,7 @@ export interface FileExplorerFolderCardProps {
   viewMode: ViewMode;
   onNavigate: (node: FileSystemTreeNode) => void;
   onMoveFileDrop?: (scopedFilePath: string, parentRelativePath: string) => void;
+  extraMenuItems?: FileExplorerMenuAction[];
 }
 
 export function FileExplorerFolderCard({
@@ -272,6 +273,7 @@ export function FileExplorerFolderCard({
   viewMode,
   onNavigate,
   onMoveFileDrop,
+  extraMenuItems,
 }: FileExplorerFolderCardProps) {
   const childCount = node.children.length;
   const subtitle =
@@ -297,6 +299,7 @@ export function FileExplorerFolderCard({
           subtitle={subtitle}
           surfaceClassName={surfaceClassName}
           onOpen={() => onNavigate(node)}
+          extraMenuItems={extraMenuItems}
         />
       )}
     </FileExplorerDropTargetWrapper>

--- a/front/components/file_explorer/types.ts
+++ b/front/components/file_explorer/types.ts
@@ -16,7 +16,13 @@ export type ContentNodeEntry = {
   connectorProvider: ConnectorProvider | null;
 };
 
-export type FileExplorerEntry = FileEntry | ContentNodeEntry;
+export type FolderEntry = {
+  kind: "folder";
+  path: string;
+  name: string;
+};
+
+export type FileExplorerEntry = FileEntry | ContentNodeEntry | FolderEntry;
 
 export type FileExplorerMenuAction = {
   label: string;

--- a/front/components/file_explorer/utils.ts
+++ b/front/components/file_explorer/utils.ts
@@ -96,6 +96,13 @@ export function isFileExplorerMovableFile(entry: FileEntry): boolean {
   return true;
 }
 
+function getEntryLastModifiedMs(entry: FileExplorerEntry | undefined): number {
+  if (!entry || entry.kind === "folder") {
+    return 0;
+  }
+  return entry.lastModifiedMs ?? 0;
+}
+
 /** Display order: Company Data refs, then folders, then GCS files. */
 function getExplorerNodeSortRank(
   node: FileSystemTreeNode,
@@ -137,8 +144,8 @@ export function compareTreeNodesForSort(
     case "last-modified": {
       // Folders have no timestamp on the tree (they're inferred from file paths). Among files,
       // sort by recency; tie-break by name.
-      const ta = entryByRelativePath.get(a.path)?.lastModifiedMs ?? 0;
-      const tb = entryByRelativePath.get(b.path)?.lastModifiedMs ?? 0;
+      const ta = getEntryLastModifiedMs(entryByRelativePath.get(a.path));
+      const tb = getEntryLastModifiedMs(entryByRelativePath.get(b.path));
       if (tb !== ta) {
         return tb - ta;
       }

--- a/front/components/pod/files/PodFileExplorer.tsx
+++ b/front/components/pod/files/PodFileExplorer.tsx
@@ -9,6 +9,7 @@ import type {
   FileEntry,
   FileExplorerEntry,
   FileExplorerMenuAction,
+  FolderEntry,
 } from "@app/components/file_explorer/types";
 import { useFileDownload } from "@app/components/file_explorer/useFileDownload";
 import {
@@ -247,10 +248,11 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
   const [navigationResetKey, setNavigationResetKey] = useState(0);
   const [showRenameDialog, setShowRenameDialog] = useState(false);
   const [showCreateFolderDialog, setShowCreateFolderDialog] = useState(false);
-  const [fileToRename, setFileToRename] = useState<{
-    path: string;
-    fileName: string;
-  } | null>(null);
+  const [itemToRename, setItemToRename] = useState<
+    | { kind: "file"; path: string; name: string }
+    | { kind: "folder"; path: string; name: string }
+    | null
+  >(null);
   const [activeOverlay, setActiveOverlay] = useState<
     "companyData" | "noCompanyData" | null
   >(null);
@@ -474,6 +476,19 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
             await refreshPodContextAttachments();
           }
         }
+      } else if (entry.kind === "folder") {
+        const confirmed = await confirm({
+          title: "Delete folder?",
+          message: `Are you sure you want to delete "${entry.name}" and all its contents? This action cannot be undone.`,
+          validateLabel: "Delete",
+          validateVariant: "warning",
+        });
+        if (confirmed) {
+          const result = await deletePodFile(entry.path);
+          if (result.isOk()) {
+            await refreshPodFiles();
+          }
+        }
       } else {
         const confirmed = await confirm({
           title: "Delete file?",
@@ -498,8 +513,20 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
     ]
   );
 
-  const onRename = useCallback((entry: FileEntry) => {
-    setFileToRename({ path: entry.path, fileName: entry.fileName });
+  const onRename = useCallback((entry: FileEntry | FolderEntry) => {
+    if (entry.kind === "file") {
+      setItemToRename({
+        kind: "file",
+        path: entry.path,
+        name: entry.fileName,
+      });
+    } else {
+      setItemToRename({
+        kind: "folder",
+        path: entry.path,
+        name: entry.name,
+      });
+    }
     setShowRenameDialog(true);
   }, []);
 
@@ -691,7 +718,7 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
         onRenamed={() => void refreshPodFiles()}
         owner={owner}
         podId={pod.sId}
-        file={fileToRename}
+        item={itemToRename}
       />
 
       <CreateFolderDialog

--- a/front/components/pod/files/RenameFileDialog.tsx
+++ b/front/components/pod/files/RenameFileDialog.tsx
@@ -32,13 +32,17 @@ function splitFileName(fileName: string): {
   };
 }
 
+type RenameMountItem =
+  | { kind: "file"; path: string; name: string }
+  | { kind: "folder"; path: string; name: string };
+
 interface RenameFileDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onRenamed: () => void;
   owner: LightWorkspaceType;
   podId: string;
-  file: { path: string; fileName: string } | null;
+  item: RenameMountItem | null;
 }
 
 export function RenameFileDialog({
@@ -47,56 +51,85 @@ export function RenameFileDialog({
   onRenamed,
   owner,
   podId,
-  file,
+  item,
 }: RenameFileDialogProps) {
-  const [baseName, setBaseName] = useState<string>("");
+  const [name, setName] = useState<string>("");
+  const [isRenaming, setIsRenaming] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const renameFile = useRenamePodFile({ owner, podId });
 
   const extension = useMemo(() => {
-    if (!file) {
+    if (!item || item.kind !== "file") {
       return "";
     }
-    return splitFileName(file.fileName).extension;
-  }, [file]);
+    return splitFileName(item.name).extension;
+  }, [item]);
+
+  const displayName = useMemo(() => {
+    if (!item || item.kind !== "file") {
+      return name;
+    }
+    return name + extension;
+  }, [extension, item, name]);
 
   useEffect(() => {
-    if (isOpen && file) {
-      const { baseName: initialBaseName } = splitFileName(file.fileName);
-      setBaseName(initialBaseName);
+    if (isOpen && item) {
+      setIsRenaming(false);
+      if (item.kind === "file") {
+        const { baseName: initialBaseName } = splitFileName(item.name);
+        setName(initialBaseName);
+      } else {
+        setName(item.name);
+      }
       setTimeout(() => {
         inputRef.current?.focus();
         inputRef.current?.select();
       }, 0);
     }
-  }, [isOpen, file]);
+  }, [isOpen, item]);
 
   const handleRename = useCallback(async () => {
-    if (!file || !baseName.trim()) {
+    if (!item || !name.trim() || isRenaming) {
       return;
     }
-    const newFileName = baseName.trim() + extension;
-    const result = await renameFile(file.path, newFileName);
-    if (result.isOk()) {
-      onRenamed();
-      onClose();
+    const newName =
+      item.kind === "file" ? name.trim() + extension : name.trim();
+    setIsRenaming(true);
+    try {
+      const result = await renameFile(item.path, newName);
+      if (result.isOk()) {
+        onRenamed();
+        onClose();
+      }
+    } finally {
+      setIsRenaming(false);
     }
-  }, [file, baseName, extension, renameFile, onRenamed, onClose]);
+  }, [item, name, extension, isRenaming, renameFile, onRenamed, onClose]);
 
   return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open && !isRenaming) {
+          onClose();
+        }
+      }}
+    >
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Rename file</DialogTitle>
+          <DialogTitle>
+            {item?.kind === "folder" ? "Rename folder" : "Rename file"}
+          </DialogTitle>
         </DialogHeader>
         <DialogContainer>
-          <div className="flex items-center gap-1">
+          {item?.kind === "folder" ? (
             <Input
               ref={inputRef}
-              placeholder="Enter new file name..."
-              value={baseName}
-              onChange={(e) => setBaseName(e.target.value)}
+              placeholder="Enter new folder name..."
+              value={name}
+              disabled={isRenaming}
+              onChange={(e) => setName(e.target.value)}
               onKeyDown={(e) => {
                 if (e.key === "Enter") {
                   e.preventDefault();
@@ -104,21 +137,41 @@ export function RenameFileDialog({
                 }
               }}
             />
-            {extension && (
-              <span className="text-sm text-muted-foreground">{extension}</span>
-            )}
-          </div>
+          ) : (
+            <div className="flex items-center gap-1">
+              <Input
+                ref={inputRef}
+                placeholder="Enter new file name..."
+                value={name}
+                disabled={isRenaming}
+                onChange={(e) => setName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    void handleRename();
+                  }
+                }}
+              />
+              {extension && (
+                <span className="text-sm text-muted-foreground">
+                  {extension}
+                </span>
+              )}
+            </div>
+          )}
         </DialogContainer>
         <DialogFooter
           rightButtonProps={{
             label: "Rename",
             variant: "primary",
             onClick: handleRename,
-            disabled: !baseName.trim(),
+            disabled: !displayName.trim() || isRenaming,
+            isLoading: isRenaming,
           }}
           leftButtonProps={{
             label: "Cancel",
             variant: "outline",
+            disabled: isRenaming,
           }}
         />
       </DialogContent>

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -10,6 +10,7 @@ import {
   getGCSPathFromScopedPath,
   getScopedPathFromGCSPath,
   listGCSMountFiles,
+  renameGCSMountDirectory,
   renameGCSMountFile,
 } from "@app/lib/api/files/gcs_mount/files";
 import type { Authenticator } from "@app/lib/auth";
@@ -1002,15 +1003,102 @@ describe("renameGCSMountFile", () => {
   });
 });
 
+describe("renameGCSMountDirectory", () => {
+  let auth: Authenticator;
+  let workspaceId: string;
+  let copyFileMock: ReturnType<typeof vi.fn>;
+  let deleteByPrefixMock: ReturnType<typeof vi.fn>;
+  let dirExistsMock: ReturnType<typeof vi.fn>;
+  let getAllFilesByPrefixMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    copyFileMock = vi.fn().mockResolvedValue(undefined);
+    deleteByPrefixMock = vi.fn().mockResolvedValue(undefined);
+    dirExistsMock = vi.fn().mockResolvedValue([false]);
+
+    const { authenticator } = await createResourceTest({});
+    auth = authenticator;
+    workspaceId = auth.getNonNullableWorkspace().sId;
+
+    const prefix = `w/${workspaceId}/projects/proj123/files/`;
+    getAllFilesByPrefixMock = vi.fn().mockResolvedValue({
+      files: [
+        { name: `${prefix}archive/` },
+        { name: `${prefix}archive/report.pdf` },
+      ],
+    });
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      copyFile: copyFileMock,
+      deleteByPrefix: deleteByPrefixMock,
+      file: vi.fn().mockReturnValue({ exists: dirExistsMock }),
+      getAllFilesByPrefix: getAllFilesByPrefixMock,
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+  });
+
+  it("moves all objects under the folder prefix and deletes the old prefix", async () => {
+    const result = await renameGCSMountDirectory(
+      auth,
+      { useCase: "project", projectId: "proj123" },
+      { relativeDirPath: "archive", newFolderName: "backup" }
+    );
+
+    const prefix = `w/${workspaceId}/projects/proj123/files/`;
+    const podsPrefix = `w/${workspaceId}/pods/proj123/files/`;
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.newRelativeDirPath).toBe("backup");
+    }
+    expect(copyFileMock).toHaveBeenCalledWith(
+      `${prefix}archive/`,
+      `${prefix}backup/`
+    );
+    expect(copyFileMock).toHaveBeenCalledWith(
+      `${prefix}archive/report.pdf`,
+      `${prefix}backup/report.pdf`
+    );
+    expect(deleteByPrefixMock).toHaveBeenCalledWith(`${prefix}archive/`);
+    expect(deleteByPrefixMock).toHaveBeenCalledWith(`${podsPrefix}archive/`);
+    expect(copyFileMock).toHaveBeenCalledWith(
+      `${prefix}backup/report.pdf`,
+      `${podsPrefix}backup/report.pdf`
+    );
+  });
+
+  it("returns Err when the destination folder already exists", async () => {
+    dirExistsMock.mockResolvedValue([true]);
+
+    const result = await renameGCSMountDirectory(
+      auth,
+      { useCase: "project", projectId: "proj123" },
+      { relativeDirPath: "archive", newFolderName: "backup" }
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(copyFileMock).not.toHaveBeenCalled();
+  });
+});
+
 describe("deleteGCSMountFile", () => {
   let auth: Authenticator;
   let workspaceId: string;
   let deleteMock: ReturnType<typeof vi.fn>;
+  let deleteByPrefixMock: ReturnType<typeof vi.fn>;
+  let dirExistsMock: ReturnType<
+    typeof vi.fn<(path: string) => Promise<[boolean]>>
+  >;
+  let getAllFilesByPrefixMock: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
     deleteMock = vi.fn().mockResolvedValue(undefined);
+    deleteByPrefixMock = vi.fn().mockResolvedValue(undefined);
+    dirExistsMock = vi.fn().mockResolvedValue([false]);
+    getAllFilesByPrefixMock = vi.fn().mockResolvedValue({ files: [] });
     vi.mocked(getPrivateUploadBucket).mockReturnValue({
       delete: deleteMock,
+      deleteByPrefix: deleteByPrefixMock,
+      file: vi.fn((path: string) => ({ exists: () => dirExistsMock(path) })),
+      getAllFilesByPrefix: getAllFilesByPrefixMock,
     } as unknown as ReturnType<typeof getPrivateUploadBucket>);
 
     const { authenticator } = await createResourceTest({});
@@ -1074,6 +1162,26 @@ describe("deleteGCSMountFile", () => {
     );
 
     expect(deleteMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("deletes a directory placeholder and its contents by prefix", async () => {
+    dirExistsMock.mockImplementation((path: string) => {
+      return Promise.resolve([path.endsWith("/")]);
+    });
+
+    const result = await deleteGCSMountFile(
+      auth,
+      { useCase: "project", projectId: "proj123" },
+      { relativeFilePath: "archive" }
+    );
+
+    const prefix = `w/${workspaceId}/projects/proj123/files/`;
+    const podsPrefix = `w/${workspaceId}/pods/proj123/files/`;
+
+    expect(result.isOk()).toBe(true);
+    expect(deleteByPrefixMock).toHaveBeenCalledWith(`${prefix}archive/`);
+    expect(deleteByPrefixMock).toHaveBeenCalledWith(`${podsPrefix}archive/`);
+    expect(deleteMock).not.toHaveBeenCalled();
   });
 });
 

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -379,6 +379,76 @@ export async function renameGCSMountFile(
 }
 
 /**
+ * Rename a folder within a GCS mount point by moving all objects under its prefix.
+ * Does not touch FileResource records; callers are responsible for any DB sync.
+ */
+export async function renameGCSMountDirectory(
+  auth: Authenticator,
+  scope: GCSMountPoint,
+  {
+    relativeDirPath,
+    newFolderName,
+  }: { relativeDirPath: string; newFolderName: string }
+): Promise<Result<{ newRelativeDirPath: string }, Error>> {
+  const owner = auth.getNonNullableWorkspace();
+  const prefix = resolvePrefix(owner, scope);
+  const normalized = relativeDirPath.replace(/^\/+|\/+$/g, "");
+  const lastSlash = normalized.lastIndexOf("/");
+  const parentDir = lastSlash >= 0 ? normalized.slice(0, lastSlash) : "";
+  const newRelativeDirPath = parentDir
+    ? `${parentDir}/${newFolderName}`
+    : newFolderName;
+
+  if (normalized === newRelativeDirPath) {
+    return new Ok({ newRelativeDirPath });
+  }
+
+  const oldDirPrefix = `${prefix}${normalized}/`;
+  const newDirPrefix = `${prefix}${newRelativeDirPath}/`;
+
+  const bucket = getPrivateUploadBucket();
+  const [newDirExists] = await bucket.file(newDirPrefix).exists();
+  if (newDirExists) {
+    return new Err(new GCSMountDirectoryAlreadyExistsError());
+  }
+
+  const { files: objects } = await bucket.getAllFilesByPrefix({
+    prefix: oldDirPrefix,
+  });
+
+  try {
+    for (const obj of objects) {
+      const destPath = obj.name.replace(oldDirPrefix, newDirPrefix);
+      if (destPath === obj.name) {
+        continue;
+      }
+      await bucket.copyFile(obj.name, destPath);
+    }
+    await bucket.deleteByPrefix(oldDirPrefix);
+
+    if (scope.useCase === "project") {
+      const podsPrefix = getPodFilesBasePath({
+        workspaceId: owner.sId,
+        projectId: scope.projectId,
+      });
+      const oldPodsDirPrefix = `${podsPrefix}${normalized}/`;
+      for (const obj of objects) {
+        const newProjectsPath = obj.name.replace(oldDirPrefix, newDirPrefix);
+        const newPodsPath = toPodMountFilePath(newProjectsPath);
+        if (newPodsPath) {
+          await bucket.copyFile(newProjectsPath, newPodsPath);
+        }
+      }
+      await bucket.deleteByPrefix(oldPodsDirPrefix);
+    }
+
+    return new Ok({ newRelativeDirPath });
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}
+
+/**
  * Generate a short-lived signed URL for a GCS mount file.
  * Validates that the path belongs to the expected scope before signing.
  */
@@ -526,10 +596,36 @@ export async function deleteGCSMountFile(
 ): Promise<Result<void, Error>> {
   const owner = auth.getNonNullableWorkspace();
   const prefix = resolvePrefix(owner, scope);
-  const gcsPath = `${prefix}${relativeFilePath}`;
+  const normalized = relativeFilePath.replace(/^\/+|\/+$/g, "");
+  const gcsPath = `${prefix}${normalized}`;
+  const dirGcsPrefix = `${prefix}${normalized}/`;
 
   const bucket = getPrivateUploadBucket();
   try {
+    const [fileExists] = await bucket.file(gcsPath).exists();
+    if (!fileExists) {
+      const [dirPlaceholderExists] = await bucket.file(dirGcsPrefix).exists();
+      const { files: dirContents } = await bucket.getAllFilesByPrefix({
+        prefix: dirGcsPrefix,
+        pageSize: 1,
+      });
+      const isDirectoryDelete = dirPlaceholderExists || dirContents.length > 0;
+
+      if (isDirectoryDelete) {
+        await bucket.deleteByPrefix(dirGcsPrefix);
+
+        if (scope.useCase === "project") {
+          const podsPrefix = getPodFilesBasePath({
+            workspaceId: owner.sId,
+            projectId: scope.projectId,
+          });
+          await bucket.deleteByPrefix(`${podsPrefix}${normalized}/`);
+        }
+
+        return new Ok(undefined);
+      }
+    }
+
     await bucket.delete(gcsPath, { ignoreNotFound: true });
 
     // Mirror delete on the pods/ side for project files
@@ -538,7 +634,7 @@ export async function deleteGCSMountFile(
         workspaceId: owner.sId,
         projectId: scope.projectId,
       });
-      const podsGcsPath = `${podsPrefix}${relativeFilePath}`;
+      const podsGcsPath = `${podsPrefix}${normalized}`;
       await bucket.delete(podsGcsPath, { ignoreNotFound: true });
     }
 

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -10,6 +10,7 @@ import {
   deleteGCSMountFile,
   type GCSMountDirectoryEntry,
   moveFile,
+  renameGCSMountDirectory,
   renameGCSMountFile,
 } from "@app/lib/api/files/gcs_mount/files";
 import { moveMountFileWithinScope } from "@app/lib/api/files/mount_file_ops";
@@ -23,6 +24,7 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import type { DustError } from "@app/lib/error";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { MessageModel } from "@app/lib/models/agent/conversation";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -648,7 +650,64 @@ export async function renameProjectFile(
   }
 ): Promise<Result<void, Error>> {
   const owner = auth.getNonNullableWorkspace();
-  const oldGcsPath = `${getProjectFilesBasePath({ workspaceId: owner.sId, projectId: space.sId })}${relativeFilePath}`;
+  const normalized = relativeFilePath.replace(/^\/+|\/+$/g, "");
+  const mountBasePath = getProjectFilesBasePath({
+    workspaceId: owner.sId,
+    projectId: space.sId,
+  });
+  const dirPrefix = `${mountBasePath}${normalized}/`;
+
+  const bucket = getPrivateUploadBucket();
+  const [dirPlaceholderExists] = await bucket.file(dirPrefix).exists();
+  const { files: dirContents } = await bucket.getAllFilesByPrefix({
+    prefix: dirPrefix,
+  });
+  const isDirectoryRename =
+    dirPlaceholderExists || dirContents.some((f) => !f.name.endsWith("/"));
+
+  if (isDirectoryRename) {
+    const folderNameRes = validateMountFolderName(newFileName);
+    if (folderNameRes.isErr()) {
+      return folderNameRes;
+    }
+
+    const mountPaths = dirContents
+      .filter((f) => !f.name.endsWith("/"))
+      .map((f) => f.name);
+    const fileResources = await FileResource.fetchByMountFilePaths(
+      auth,
+      mountPaths
+    );
+
+    const renameResult = await renameGCSMountDirectory(
+      auth,
+      { useCase: "project", projectId: space.sId },
+      {
+        relativeDirPath: normalized,
+        newFolderName: folderNameRes.value,
+      }
+    );
+    if (renameResult.isErr()) {
+      return renameResult;
+    }
+
+    const oldDirMountPrefix = `${mountBasePath}${normalized}/`;
+    const newDirMountPrefix = `${mountBasePath}${renameResult.value.newRelativeDirPath}/`;
+    for (const file of fileResources) {
+      if (!file.mountFilePath?.startsWith(oldDirMountPrefix)) {
+        continue;
+      }
+      const newMountPath = file.mountFilePath.replace(
+        oldDirMountPrefix,
+        newDirMountPrefix
+      );
+      await file.renameMountFile(file.fileName, newMountPath);
+    }
+
+    return new Ok(undefined);
+  }
+
+  const oldGcsPath = `${mountBasePath}${normalized}`;
 
   const fileResources = await FileResource.fetchByMountFilePaths(auth, [
     oldGcsPath,
@@ -657,7 +716,7 @@ export async function renameProjectFile(
   const renameResult = await renameGCSMountFile(
     auth,
     { useCase: "project", projectId: space.sId },
-    { relativeFilePath, newFileName }
+    { relativeFilePath: normalized, newFileName }
   );
   if (renameResult.isErr()) {
     return renameResult;
@@ -691,7 +750,51 @@ export async function deleteProjectFile(
   }
 ): Promise<Result<void, Error>> {
   const owner = auth.getNonNullableWorkspace();
-  const gcsPath = `${getProjectFilesBasePath({ workspaceId: owner.sId, projectId: space.sId })}${relativeFilePath}`;
+  const normalized = relativeFilePath.replace(/^\/+|\/+$/g, "");
+  const mountBasePath = getProjectFilesBasePath({
+    workspaceId: owner.sId,
+    projectId: space.sId,
+  });
+  const gcsPath = `${mountBasePath}${normalized}`;
+  const dirPrefix = `${mountBasePath}${normalized}/`;
+
+  const bucket = getPrivateUploadBucket();
+  const [fileExists] = await bucket.file(gcsPath).exists();
+
+  if (!fileExists) {
+    const [dirPlaceholderExists] = await bucket.file(dirPrefix).exists();
+    const { files: dirContents } = await bucket.getAllFilesByPrefix({
+      prefix: dirPrefix,
+      pageSize: 200,
+    });
+    const isDirectoryDelete =
+      dirPlaceholderExists || dirContents.some((f) => !f.name.endsWith("/"));
+
+    if (isDirectoryDelete) {
+      const mountPaths = dirContents
+        .filter((f) => !f.name.endsWith("/"))
+        .map((f) => f.name);
+      const fileResources = await FileResource.fetchByMountFilePaths(
+        auth,
+        mountPaths
+      );
+      for (const file of fileResources) {
+        const result = await removeFileFromProject(auth, {
+          space,
+          fileId: file.sId,
+        });
+        if (result.isErr()) {
+          return result;
+        }
+      }
+
+      return deleteGCSMountFile(
+        auth,
+        { useCase: "project", projectId: space.sId },
+        { relativeFilePath: normalized }
+      );
+    }
+  }
 
   const fileResources = await FileResource.fetchByMountFilePaths(auth, [
     gcsPath,
@@ -706,7 +809,7 @@ export async function deleteProjectFile(
   return deleteGCSMountFile(
     auth,
     { useCase: "project", projectId: space.sId },
-    { relativeFilePath }
+    { relativeFilePath: normalized }
   );
 }
 


### PR DESCRIPTION
## Description

Adds folder-level delete and rename to the Pod `FileExplorer`.

- **Delete**: `deleteProjectFile` in `context.ts` now detects directory targets (via GCS placeholder or prefix listing), calls `removeFileFromProject` for each contained `FileResource`, then `deleteGCSMountFile` which uses `deleteByPrefix` to wipe both the `projects/` and mirrored `pods/` prefix. Guarded by a warning confirmation dialog.
- **Rename**: new `renameGCSMountDirectory` in `gcs_mount/files.ts` copies all objects under the old prefix to the new prefix, deletes the old prefix, and mirrors the result to `pods/`. `renameProjectFile` detects directory targets, validates the new name via `validateMountFolderName`, and patches `FileResource.mountFilePath` records in-place. `RenameFileDialog` is generalized via a `RenameMountItem` discriminated union (`kind: "file" | "folder"`), with an `isRenaming` guard against double-submission.
- `FolderEntry` added to the `FileExplorerEntry` union; `FileExplorerFolderCard` gains an `extraMenuItems` prop to surface the Rename action.

## Tests

- Added Vitest unit tests for `renameGCSMountDirectory`: covers successful move+delete (including pods mirror) and conflict detection when destination already exists.
- Extended `deleteGCSMountFile` tests to cover directory deletion by prefix.
- Tested manually in the Pod file explorer.

## Risk

Low. Folder delete requires explicit confirmation with a warning-variant dialog. Rename checks for name conflicts before touching GCS. No DB migrations. Both operations are isolated to the `front` service and mirror the existing file-level patterns.

## Deploy Plan

Deploy front.
