### PR TITLE
Fix copy for pod visibility => access

### DIFF
--- a/front/components/assistant/conversation/CreateProjectModal.tsx
+++ b/front/components/assistant/conversation/CreateProjectModal.tsx
@@ -42,7 +42,7 @@ export function CreateProjectModal({
   const areWorkspaceOpenProjectsAllowed = areOpenProjectsAllowed(owner);
   const [projectName, setProjectName] = useState<string>("");
   const [isSaving, setIsSaving] = useState(false);
-  const [isPublic, setIsPublic] = useState(false);
+  const [isPodOpen, setIsPodOpen] = useState(false);
 
   const doCreate = useCreateSpace({ owner });
   const router = useAppRouter();
@@ -64,23 +64,23 @@ export function CreateProjectModal({
     if (isOpen) {
       setProjectName("");
       setIsSaving(false);
-      setIsPublic(false);
+      setIsPodOpen(false);
       setNameToCheck("");
     }
   }, [isOpen, setNameToCheck]);
 
   useEffect(() => {
-    if (!areWorkspaceOpenProjectsAllowed && isPublic) {
-      setIsPublic(false);
+    if (!areWorkspaceOpenProjectsAllowed && isOpen) {
+      setIsPodOpen(false);
     }
-  }, [areWorkspaceOpenProjectsAllowed, isPublic]);
+  }, [areWorkspaceOpenProjectsAllowed, isOpen]);
 
   const handleClose = useCallback(() => {
     onClose();
     setTimeout(() => {
       setProjectName("");
       setIsSaving(false);
-      setIsPublic(false);
+      setIsPodOpen(false);
       setNameToCheck("");
     }, 500);
   }, [onClose, setNameToCheck]);
@@ -95,7 +95,7 @@ export function CreateProjectModal({
     const createdSpace = await doCreate(
       {
         name: trimmedName,
-        isRestricted: !isPublic,
+        isRestricted: !isPodOpen,
         managementMode: "manual",
         memberIds: [],
         spaceKind: "project",
@@ -117,7 +117,7 @@ export function CreateProjectModal({
   }, [
     projectName,
     isNameAvailable,
-    isPublic,
+    isPodOpen,
     doCreate,
     onCreated,
     handleClose,
@@ -167,16 +167,16 @@ export function CreateProjectModal({
               )}
             </div>
             <div className="flex flex-col items-start gap-1">
-              <Label>Visibility</Label>
-              <VisibilitySwitch
-                isPublic={isPublic}
+              <Label>Access</Label>
+              <AccessSwitch
+                isOpen={isPodOpen}
                 disabled={!areWorkspaceOpenProjectsAllowed}
-                onChange={setIsPublic}
+                onChange={setIsPodOpen}
               />
               <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-                {isPublic
-                  ? "Anyone in the workspace can find and join this Pod."
-                  : "Only invited members can access this Pod."}
+                {isPodOpen
+                  ? "Anyone in the workspace can find and join the Pod."
+                  : "Only invited members can access the Pod."}
               </div>
             </div>
           </div>
@@ -196,21 +196,17 @@ export function CreateProjectModal({
   );
 }
 
-interface VisibilitySwitchProps {
-  isPublic: boolean;
+interface AccessSwitchProps {
+  isOpen: boolean;
   disabled: boolean;
-  onChange: (isPublic: boolean) => void;
+  onChange: (isOpen: boolean) => void;
 }
 
-function VisibilitySwitch({
-  isPublic,
-  disabled,
-  onChange,
-}: VisibilitySwitchProps) {
+function AccessSwitch({ isOpen, disabled, onChange }: AccessSwitchProps) {
   const switchList = (
     <ButtonsSwitchList
       size="xs"
-      defaultValue={isPublic ? "open" : "restricted"}
+      defaultValue={isOpen ? "open" : "restricted"}
       onValueChange={(value) => onChange(value === "open")}
       disabled={disabled}
     >

--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -55,10 +55,10 @@ export function SpaceAboutTab({
     isEditor: isProjectEditor,
     isRestricted,
   } = space;
-  const isPublic = !isRestricted;
+  const isOpen = !isRestricted;
   const areWorkspaceOpenProjectsAllowed = areOpenProjectsAllowed(owner);
   const isPrivateProjectAndOpenProjectsDisallowed =
-    !areWorkspaceOpenProjectsAllowed && !isPublic;
+    !areWorkspaceOpenProjectsAllowed && !isOpen;
   const isVisibilityToggleDisabled =
     !isProjectEditor || isPrivateProjectAndOpenProjectsDisallowed;
   const [searchSelectedMembers, setSearchSelectedMembers] = useState("");
@@ -170,10 +170,10 @@ export function SpaceAboutTab({
   }, [archiveProject, unarchiveProject, projectMetadata?.archivedAt]);
 
   const handleVisibilityToggle = useCallback(async () => {
-    const newIsPublic = !isPublic;
-    const title = newIsPublic ? "Switch to public?" : "Switch to restricted?";
-    const message = newIsPublic
-      ? "All workspace members will be able to join and see everything in this Pod — including existing conversations and files."
+    const newIsOpen = !isOpen;
+    const title = newIsOpen ? "Switch to open?" : "Switch to restricted?";
+    const message = newIsOpen
+      ? "All workspace members will be able to join and see everything in the Pod — including existing conversations and files."
       : "Access will be limited to invited members only.";
 
     const confirmed = await confirm({
@@ -189,7 +189,7 @@ export function SpaceAboutTab({
     const updated = await doUpdate(
       space,
       {
-        isRestricted: !newIsPublic,
+        isRestricted: !newIsOpen,
         memberIds: projectMembers.filter((m) => !m.isEditor).map((m) => m.sId),
         editorIds: projectMembers.filter((m) => m.isEditor).map((m) => m.sId),
         managementMode: "manual",
@@ -197,7 +197,7 @@ export function SpaceAboutTab({
       },
       {
         title: "Successfully updated Pod visibility",
-        description: "Pod visibility was successfully updated.",
+        description: `Pod is now ${newIsOpen ? "open" : "restricted"}.`,
       }
     );
 
@@ -207,7 +207,7 @@ export function SpaceAboutTab({
   }, [
     confirm,
     doUpdate,
-    isPublic,
+    isOpen,
     projectMembers,
     space,
     mutateSpaceInfoRegardlessOfQueryParams,
@@ -318,7 +318,7 @@ export function SpaceAboutTab({
                       <div>
                         <SliderToggle
                           size="xs"
-                          selected={isPublic}
+                          selected={isOpen}
                           onClick={handleVisibilityToggle}
                           disabled
                         />
@@ -328,7 +328,7 @@ export function SpaceAboutTab({
                 ) : (
                   <SliderToggle
                     size="xs"
-                    selected={isPublic}
+                    selected={isOpen}
                     onClick={handleVisibilityToggle}
                     disabled={isVisibilityToggleDisabled}
                   />

--- a/front/components/workspace/settings/OpenProjectsPolicy.tsx
+++ b/front/components/workspace/settings/OpenProjectsPolicy.tsx
@@ -16,15 +16,15 @@ import {
 const OPEN_PROJECTS_POLICIES = [
   {
     value: "private_and_open",
-    label: "Private and open Pods",
-    description: "Members can create either private or open Pods.",
+    label: "Restricted and open Pods",
+    description: "Members can create either restricted or open Pods.",
     icon: SpaceOpenIcon,
     allowOpenProjects: true,
   },
   {
     value: "private_only",
-    label: "Private Pods only",
-    description: "Members can only create private Pods.",
+    label: "Restricted Pods only",
+    description: "Members can only create restricted Pods.",
     icon: SpaceClosedIcon,
     allowOpenProjects: false,
   },
@@ -45,8 +45,8 @@ export function OpenProjectsPolicy({ owner }: { owner: WorkspaceType }) {
 
   return (
     <ContextItem
-      title="Pod visibility policy"
-      subElement="Control whether Pods can be private only or private and open."
+      title="Pod access policy"
+      subElement="Control whether Pods can be restricted only or restricted and open."
       visual={<SpaceClosedIcon className="h-6 w-6" />}
       hasSeparatorIfLast={true}
       action={


### PR DESCRIPTION
## Description

Renames the Pod "visibility" concept to "access" across `CreateProjectModal`, `SpaceAboutTab`, and `OpenProjectsPolicy`. "Private" becomes "restricted" and "public" becomes "open" — aligning UI copy with the intended terminology. Includes a minor fix in `CreateProjectModal`: the `useEffect` that resets pod access now correctly triggers on modal `isOpen` changes instead of tracking the pod's own `isPublic` state.

## Tests

Tested manually by opening the Pod creation modal and visiting the About/Settings tab to verify updated labels, descriptions, and confirmation dialogs.

## Risk

Low. Pure copy and variable rename — no logic changes beyond the minor `useEffect` dependency correction. Safe to rollback.

## Deploy Plan

Deploy front.
