### PR TITLE
Fix: prevent move conversation if agent loop is running

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -196,6 +196,14 @@ app.patch(
               message: "Internal server error",
             },
           });
+        case "conversation_agent_running":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "conversation_agent_running",
+              message: r.error.message,
+            },
+          });
         default:
           assertNever(r.error.code);
       }

--- a/front/lib/api/assistant/conversation/helper.ts
+++ b/front/lib/api/assistant/conversation/helper.ts
@@ -11,6 +11,7 @@ const STATUS_FOR_ERROR_TYPE: Record<
   ContentfulStatusCode
 > = {
   conversation_access_restricted: 403,
+  conversation_agent_running: 400,
   conversation_not_found: 404,
   conversation_with_unavailable_agent: 403,
   user_already_participant: 400,

--- a/front/lib/api/projects/conversations.test.ts
+++ b/front/lib/api/projects/conversations.test.ts
@@ -89,6 +89,65 @@ describe("moveConversationToProject", () => {
     expect(isProjectConversation(updatedConversation)).toBe(true);
   });
 
+  it("returns conversation_agent_running when an agent loop is running", async () => {
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent Description",
+    });
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+
+    const projectSpace = await SpaceFactory.project(workspace);
+    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const user = auth.getNonNullableUser();
+    const userJson = user.toJSON();
+
+    const projectSpaceGroup = projectSpace.groups.find(
+      (g) => g.kind === "regular"
+    );
+    if (!projectSpaceGroup) {
+      throw new Error("Project space regular group not found");
+    }
+    const addRes = await projectSpaceGroup.dangerouslyAddMember(
+      internalAdminAuth,
+      {
+        user: userJson,
+      }
+    );
+    if (addRes.isErr()) {
+      throw new Error(
+        `Failed to add user to project space group: ${addRes.error.message}`
+      );
+    }
+
+    await auth.refresh();
+
+    const result = await moveConversationToProject(auth, {
+      conversation: { ...conversation, isRunningAgentLoop: true },
+      spaceId: projectSpace.sId,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(DustError);
+      expect(result.error.code).toBe("conversation_agent_running");
+      expect(result.error.message).toContain(
+        "Wait for the agent to finish before moving this conversation."
+      );
+    }
+
+    const updatedConversationResource = await ConversationResource.fetchById(
+      auth,
+      conversation.sId
+    );
+    expect(updatedConversationResource?.spaceId).toBeNull();
+  });
+
   it("returns unauthorized when user is not a member of the project", async () => {
     const agentConfig = await AgentConfigurationFactory.createTestAgent(auth);
     const conversation = await ConversationFactory.create(auth, {

--- a/front/lib/api/projects/conversations.ts
+++ b/front/lib/api/projects/conversations.ts
@@ -32,9 +32,19 @@ export async function moveConversationToProject(
       | "unauthorized"
       | "conversation_not_found"
       | "space_not_found"
+      | "conversation_agent_running"
     >
   >
 > {
+  if (conversation.isRunningAgentLoop) {
+    return new Err(
+      new DustError(
+        "conversation_agent_running",
+        "Wait for the agent to finish before moving this conversation."
+      )
+    );
+  }
+
   if (isProjectConversation(conversation)) {
     if (conversation.spaceId === spaceId) {
       return new Err(

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -62,6 +62,7 @@ export type DustErrorCode =
   | "no_whitelisted_model_found"
   | "generation_failed"
   | "invalid_conversation"
+  | "conversation_agent_running"
   // Subscription / billing errors
   | "subscription_already_exists"
   | "workspace_not_found"

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -345,6 +345,14 @@ async function handler(
                     message: "Internal server error",
                   },
                 });
+              case "conversation_agent_running":
+                return apiError(req, res, {
+                  status_code: 400,
+                  api_error: {
+                    type: "conversation_agent_running",
+                    message: r.error.message,
+                  },
+                });
               default:
                 assertNever(r.error.code);
             }

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -645,6 +645,7 @@ export interface ConversationParticipantsType {
 export const CONVERSATION_ERROR_TYPES = [
   "conversation_not_found",
   "conversation_access_restricted",
+  "conversation_agent_running",
   "conversation_with_unavailable_agent",
   "user_already_participant",
   "message_not_found",


### PR DESCRIPTION
## Description

Two related fixes for conversation move reliability:

- `moveConversationToProject` now guards on `conversation.isRunningAgentLoop` and returns `conversation_agent_running` (400) before attempting the move. The error code is wired through `DustErrorCode`, `CONVERSATION_ERROR_TYPES`, `STATUS_FOR_ERROR_TYPE`, and the `[cId]` API handler.

## Tests

- Added a Vitest integration test in `conversations.test.ts` covering the `conversation_agent_running` guard (verifies the move is rejected and `spaceId` remains null).

## Risk

Low. The `isRunningAgentLoop` guard is purely additive.

## Deploy Plan

1. Deploy front