### PR TITLE
Fix sandbox TLS validation for strict clients

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.20"
+version = "0.1.21"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/src/commands/forward/deny_log.rs
+++ b/cli/dust-sandbox/src/commands/forward/deny_log.rs
@@ -117,6 +117,9 @@ async fn append_deny_log_line(path: &Path, line: &str, max_bytes: u64) -> Result
     file.write_all(line.as_bytes())
         .await
         .with_context(|| format!("failed to write deny log {}", path.display()))?;
+    file.flush()
+        .await
+        .with_context(|| format!("failed to flush deny log {}", path.display()))?;
     #[cfg(test)]
     notify_deny_log_write(path);
     Ok(())

--- a/cli/dust-sandbox/src/commands/forward/tls_mitm.rs
+++ b/cli/dust-sandbox/src/commands/forward/tls_mitm.rs
@@ -9,8 +9,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use anyhow::{bail, Context, Result};
 use lru::LruCache;
 use rcgen::{
-    BasicConstraints, Certificate, CertificateParams, DistinguishedName, DnType, IsCa, KeyPair,
-    KeyUsagePurpose, SanType,
+    BasicConstraints, Certificate, CertificateParams, DistinguishedName, DnType,
+    ExtendedKeyUsagePurpose, IsCa, KeyPair, KeyUsagePurpose, SanType,
 };
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 use rustls::server::ResolvesServerCert;
@@ -179,6 +179,10 @@ impl MitmCa {
                 .try_into()
                 .context("invalid SNI for leaf cert")?,
         )];
+        params.is_ca = IsCa::ExplicitNoCa;
+        params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
+        params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
+        params.use_authority_key_identifier_extension = true;
 
         let leaf_key = KeyPair::generate().context("failed to generate leaf key pair")?;
         let leaf = params
@@ -283,6 +287,9 @@ mod tests {
     use std::os::unix::fs::PermissionsExt;
 
     use super::*;
+    use x509_parser::certificate::X509Certificate;
+    use x509_parser::extensions::{GeneralName, ParsedExtension};
+    use x509_parser::prelude::FromDer;
 
     #[test]
     fn load_or_generate_writes_and_reuses_persistent_ca() -> Result<()> {
@@ -414,6 +421,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn minted_leaf_contains_strict_x509_server_extensions() -> Result<()> {
+        let ca = Arc::new(MitmCa::generate()?);
+
+        let certified = ca.get_or_mint_leaf("api.openai.com").await?;
+        let leaf_der = certified
+            .cert
+            .first()
+            .context("minted leaf did not contain a certificate")?;
+        let leaf = parse_cert(leaf_der.as_ref())?;
+
+        let san = leaf
+            .subject_alternative_name()
+            .map_err(|err| anyhow::anyhow!("failed to parse leaf SAN: {err}"))?
+            .context("leaf missing subjectAltName")?;
+        assert!(san.value.general_names.iter().any(|name| {
+            matches!(name, GeneralName::DNSName(dns_name) if *dns_name == "api.openai.com")
+        }));
+
+        let basic_constraints = leaf
+            .basic_constraints()
+            .map_err(|err| anyhow::anyhow!("failed to parse leaf basicConstraints: {err}"))?
+            .context("leaf missing basicConstraints")?;
+        assert!(basic_constraints.critical);
+        assert!(!basic_constraints.value.ca);
+
+        let key_usage = leaf
+            .key_usage()
+            .map_err(|err| anyhow::anyhow!("failed to parse leaf keyUsage: {err}"))?
+            .context("leaf missing keyUsage")?;
+        assert!(key_usage.critical);
+        assert!(key_usage.value.digital_signature());
+        assert!(!key_usage.value.key_cert_sign());
+        assert!(!key_usage.value.crl_sign());
+
+        let extended_key_usage = leaf
+            .extended_key_usage()
+            .map_err(|err| anyhow::anyhow!("failed to parse leaf extendedKeyUsage: {err}"))?
+            .context("leaf missing extendedKeyUsage")?;
+        assert!(!extended_key_usage.critical);
+        assert!(extended_key_usage.value.server_auth);
+        assert!(!extended_key_usage.value.client_auth);
+
+        let ca_cert = parse_cert(ca.ca_cert.der().as_ref())?;
+        let ca_subject_key_identifier =
+            subject_key_identifier(&ca_cert).context("CA missing subjectKeyIdentifier")?;
+        let leaf_authority_key_identifier =
+            authority_key_identifier(&leaf).context("leaf missing authorityKeyIdentifier")?;
+        assert_eq!(leaf_authority_key_identifier, ca_subject_key_identifier);
+        assert!(
+            subject_key_identifier(&leaf).is_some(),
+            "leaf missing subjectKeyIdentifier"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn leaf_cache_is_lru_bounded() -> Result<()> {
         let ca = Arc::new(MitmCa::generate()?);
 
@@ -424,5 +488,29 @@ mod tests {
 
         assert_eq!(ca.leaf_cache.lock().await.len(), LEAF_CACHE_CAPACITY);
         Ok(())
+    }
+
+    fn parse_cert(der: &[u8]) -> Result<X509Certificate<'_>> {
+        let (_, cert) = X509Certificate::from_der(der)
+            .map_err(|err| anyhow::anyhow!("failed to parse certificate DER: {err}"))?;
+        Ok(cert)
+    }
+
+    fn subject_key_identifier(cert: &X509Certificate<'_>) -> Option<Vec<u8>> {
+        cert.iter_extensions()
+            .find_map(|ext| match ext.parsed_extension() {
+                ParsedExtension::SubjectKeyIdentifier(key_id) => Some(key_id.0.to_vec()),
+                _ => None,
+            })
+    }
+
+    fn authority_key_identifier(cert: &X509Certificate<'_>) -> Option<Vec<u8>> {
+        cert.iter_extensions()
+            .find_map(|ext| match ext.parsed_extension() {
+                ParsedExtension::AuthorityKeyIdentifier(key_id) => {
+                    key_id.key_identifier.as_ref().map(|id| id.0.to_vec())
+                }
+                _ => None,
+            })
     }
 }

--- a/front/lib/api/sandbox/image/egress/dust-install-trust-bundle.sh
+++ b/front/lib/api/sandbox/image/egress/dust-install-trust-bundle.sh
@@ -11,7 +11,7 @@ if [ ! -s "$CA_PATH" ]; then
   exit 1
 fi
 
-mkdir -p /etc/dust /usr/local/share/ca-certificates
+mkdir -p /etc/dust /usr/local/share/ca-certificates /etc/ssl/certs/java
 
 if command -v update-ca-certificates >/dev/null 2>&1; then
   cp "$CA_PATH" "$SYSTEM_CA_DEST"
@@ -38,29 +38,81 @@ trap cleanup EXIT
 chmod 644 "$bundle_tmp"
 mv "$bundle_tmp" "$MERGED_BUNDLE"
 
-# Forward-compat: no JDK is installed in the base image today, so this branch
-# never runs. Left in so the next image that adds Java gets the dsbx CA in
-# $JAVA_HOME/lib/security/cacerts without a second slice.
-if [ -n "${JAVA_HOME:-}" ]; then
-  java_cacerts="$JAVA_HOME/lib/security/cacerts"
-  if [ -w "$java_cacerts" ]; then
-    if ! command -v keytool >/dev/null 2>&1; then
-      echo "JAVA_HOME is set but keytool is not available" >&2
-      exit 1
-    fi
+# No JDK is installed in the base image today. When one is added later or
+# installed at runtime, cover both JAVA_HOME and Debian's system Java keystore.
+if command -v keytool >/dev/null 2>&1; then
+  java_cacerts_candidates=()
+  if [ -n "${JAVA_HOME:-}" ]; then
+    java_cacerts_candidates+=("$JAVA_HOME/lib/security/cacerts")
+  fi
+  java_cacerts_candidates+=("/etc/ssl/certs/java/cacerts")
+  if command -v java >/dev/null 2>&1; then
+    java_bin="$(readlink -f "$(command -v java)")"
+    java_home="$(dirname "$(dirname "$java_bin")")"
+    java_cacerts_candidates+=("$java_home/lib/security/cacerts")
+  fi
 
-    keytool_output="$(mktemp)"
-    if keytool -importcert -noprompt -trustcacerts \
-      -alias dust-egress \
-      -file "$CA_PATH" \
-      -keystore "$java_cacerts" \
-      -storepass changeit >"$keytool_output" 2>&1; then
-      :
-    elif grep -qi "already exists" "$keytool_output"; then
-      :
-    else
-      cat "$keytool_output" >&2
-      exit 1
+  java_cacerts_can_write() {
+    local java_cacerts="$1"
+    local java_cacerts_dir
+    java_cacerts_dir="$(dirname "$java_cacerts")"
+
+    [ -w "$java_cacerts" ] || {
+      [ "$java_cacerts" = "/etc/ssl/certs/java/cacerts" ] &&
+        [ ! -e "$java_cacerts" ] &&
+        [ -w "$java_cacerts_dir" ]
+    }
+  }
+
+  java_has_writable_cacerts=false
+  for java_cacerts in "${java_cacerts_candidates[@]}"; do
+    if java_cacerts_can_write "$java_cacerts"; then
+      java_has_writable_cacerts=true
+      break
     fi
+  done
+
+  if [ "$java_has_writable_cacerts" = true ]; then
+    java_cacerts_seen=""
+    for java_cacerts in "${java_cacerts_candidates[@]}"; do
+      if ! java_cacerts_can_write "$java_cacerts"; then
+        continue
+      fi
+      case ":$java_cacerts_seen:" in
+        *":$java_cacerts:"*) continue ;;
+      esac
+      java_cacerts_seen="$java_cacerts_seen:$java_cacerts"
+      if [ -e "$java_cacerts" ] && [ ! -s "$java_cacerts" ]; then
+        rm -f "$java_cacerts"
+      fi
+
+      keytool_output="$(mktemp)"
+      if keytool -importcert -noprompt -trustcacerts \
+        -alias dust-egress \
+        -file "$CA_PATH" \
+        -keystore "$java_cacerts" \
+        -storepass changeit >"$keytool_output" 2>&1; then
+        :
+      elif grep -qi "already exists" "$keytool_output"; then
+        :
+      else
+        cat "$keytool_output" >&2
+        exit 1
+      fi
+      rm -f "$keytool_output"
+      keytool_output=""
+    done
+
+    for java_cacerts in "${java_cacerts_candidates[@]}"; do
+      if [ "$java_cacerts" = "/etc/ssl/certs/java/cacerts" ]; then
+        continue
+      fi
+      if [ ! -e "$java_cacerts" ] &&
+        [ -s "/etc/ssl/certs/java/cacerts" ] &&
+        [ -w "$(dirname "$java_cacerts")" ]; then
+        cp /etc/ssl/certs/java/cacerts "$java_cacerts"
+        chmod 644 "$java_cacerts"
+      fi
+    done
   fi
 fi

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -68,7 +68,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.24",
+      tag: "0.8.25",
     });
   });
 
@@ -248,21 +248,45 @@ describe("sandbox image registry", () => {
     // test rather than silently shipping a stale env file.
     const expectedEnvironment =
       Object.entries(SANDBOX_TRUST_ENV_VARS)
-        .map(([k, v]) => `${k}=${v}`)
+        .map(([k, v]) => `${k}=${formatExpectedEnvironmentValue(v)}`)
         .join("\n") + "\n";
     const expectedProfile =
       Object.entries(SANDBOX_TRUST_ENV_VARS)
-        .map(([k, v]) => `export ${k}=${v}`)
+        .map(([k, v]) => `export ${k}=${formatExpectedShellValue(v)}`)
         .join("\n") + "\n";
 
     expect(environment).toBe(expectedEnvironment);
     expect(profileScript).toBe(expectedProfile);
+    expect(environment).toContain(
+      `JAVA_TOOL_OPTIONS=${JSON.stringify(SANDBOX_TRUST_ENV_VARS.JAVA_TOOL_OPTIONS)}\n`
+    );
+    expect(profileScript).toContain(
+      `export JAVA_TOOL_OPTIONS='${SANDBOX_TRUST_ENV_VARS.JAVA_TOOL_OPTIONS}'\n`
+    );
 
     expect(tmpfilesConfig).toBe("d /run/dust 0755 root root -\n");
     expect(installer).toContain("update-ca-certificates");
     expect(installer).toContain('cat "$SYSTEM_CA_BUNDLE"');
     expect(installer).toContain('cat "$CA_PATH"');
+    expect(installer).toContain("/etc/ssl/certs/java/cacerts");
+    expect(installer).toContain("if command -v keytool >/dev/null 2>&1");
     expect(installer).toContain("keytool -importcert -noprompt -trustcacerts");
     expect(installer).toContain("already exists");
   });
 });
+
+function formatExpectedEnvironmentValue(value: string): string {
+  return isBareExpectedEnvironmentValue(value) ? value : JSON.stringify(value);
+}
+
+function formatExpectedShellValue(value: string): string {
+  if (isBareExpectedEnvironmentValue(value)) {
+    return value;
+  }
+
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function isBareExpectedEnvironmentValue(value: string): boolean {
+  return /^[A-Za-z0-9_./:,@%+=-]+$/.test(value);
+}

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -15,8 +15,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.7.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.24";
-const DSBX_CLI_VERSION = "0.1.20";
+const DUST_BASE_IMAGE_VERSION = "0.8.25";
+const DSBX_CLI_VERSION = "0.1.21";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that
 // list must not silently change this user's UID.
@@ -112,7 +112,7 @@ function getLocalContent(dir: string, filename: string): () => string {
 function buildTrustEnvironmentFile(): string {
   return (
     Object.entries(SANDBOX_TRUST_ENV_VARS)
-      .map(([k, v]) => `${k}=${v}`)
+      .map(([k, v]) => `${k}=${formatEnvironmentValue(v)}`)
       .join("\n") + "\n"
   );
 }
@@ -120,9 +120,25 @@ function buildTrustEnvironmentFile(): string {
 function buildTrustProfileScript(): string {
   return (
     Object.entries(SANDBOX_TRUST_ENV_VARS)
-      .map(([k, v]) => `export ${k}=${v}`)
+      .map(([k, v]) => `export ${k}=${formatShellValue(v)}`)
       .join("\n") + "\n"
   );
+}
+
+function formatEnvironmentValue(value: string): string {
+  return isBareEnvironmentValue(value) ? value : JSON.stringify(value);
+}
+
+function formatShellValue(value: string): string {
+  if (isBareEnvironmentValue(value)) {
+    return value;
+  }
+
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function isBareEnvironmentValue(value: string): boolean {
+  return /^[A-Za-z0-9_./:,@%+=-]+$/.test(value);
 }
 
 function getLocalDirContent(

--- a/front/lib/api/sandbox/trust_env.ts
+++ b/front/lib/api/sandbox/trust_env.ts
@@ -18,4 +18,6 @@ export const SANDBOX_TRUST_ENV_VARS: Record<string, string> = {
   NODE_EXTRA_CA_CERTS: "/run/dust/egress-ca.pem",
   DENO_CERT: "/run/dust/egress-ca.pem",
   DENO_TLS_CA_STORE: "system,mozilla",
+  JAVA_TOOL_OPTIONS:
+    "-Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit",
 };


### PR DESCRIPTION
## Description

Generated sandbox MITM leaves were accepted by curl but rejected by stricter OpenSSL/Python validation because the leaf certificates were missing authority key identifier and other server-certificate extensions.

This updates generated leaves to include AKI, SKI, basic constraints, key usage, and server auth EKU. The sandbox image tag is bumped to dust-base 0.8.25 and dsbx 0.1.21 so new sandboxes pull a binary built with this fix. The trust helper also handles Java keystores only when keytool is available and exports Java trust options so common runtimes use the sandbox CA by default.

## Tests

Tested in E2B against the current image: dsbx 0.1.19 reproduced Python 3.14 urllib failing with Missing Authority Key Identifier while curl succeeded. Replaced it with the patched dsbx binary and verified curl, urllib, requests, http.client, Node fetch, Node https, Java HttpClient, Go net/http, and Rust native-tls through the proxied MITM path. All test sandboxes were deleted.

Local:

- [x] bash -n front/lib/api/sandbox/image/egress/dust-install-trust-bundle.sh
- [x] git diff --check
- [x] cargo fmt --all -- --check
- [x] cargo test commands::forward::deny_log::tests::rotates_when_append_crosses_cap -- --exact
- [x] 50x cargo test commands::forward::deny_log::tests::rotates_when_append_crosses_cap -- --exact
- [x] cargo test trailers
- [x] cargo test --all
- [x] cargo clippy --all-targets --all-features -- -D warnings
- [x] NODE_ENV=test npm run test -- ./lib/api/sandbox/image/registry.test.ts ./lib/api/sandbox/egress.test.ts

## Risk

Worst case, sandbox image builds fail until dsbx-v0.1.21 is released, or Java truststore import is skipped on images without keytool. Safe to rollback by pointing the image back to the previous dust-base and dsbx versions.

## Deploy Plan

- [ ] Release dsbx 0.1.21.
- [ ] Build and deploy dust-base 0.8.25 normally.
- [ ] After deploy, open /poke/kill and request a kill of older dust-base versions so existing conversations get fresh sandboxes.
