### PR TITLE
[front] enh: expand dynamic MCP tool labels

### DIFF
--- a/front/lib/actions/tool_display_labels.ts
+++ b/front/lib/actions/tool_display_labels.ts
@@ -14,7 +14,11 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/types";
 import type { ToolDisplayLabels } from "@app/lib/api/mcp";
 import { stripFileExtension } from "@app/types/files";
-import { isNumber, isString } from "@app/types/shared/utils/general";
+import {
+  isNumber,
+  isString,
+  isStringArray,
+} from "@app/types/shared/utils/general";
 import { asDisplayName, slugify } from "@app/types/shared/utils/string_utils";
 
 type ToolDisplayLabelsByTool = Record<string, ToolDisplayLabels>;
@@ -29,6 +33,10 @@ function truncateQuery(query: string): string {
 
 function shortenUrl(url: string): string {
   return truncateQuery(url.replace(/^https?:\/\//, ""));
+}
+
+function formatStringList(values: string[]): string {
+  return truncateQuery(values.join(", "));
 }
 
 const INTERNAL_TOOL_DISPLAY_LABELS_BY_SERVER = Object.fromEntries(
@@ -193,6 +201,16 @@ function getDynamicToolDisplayLabels({
       return null;
 
     case "gmail":
+      if (
+        (toolName === "get_drafts" || toolName === "get_messages") &&
+        isString(inputs.q)
+      ) {
+        const q = truncateQuery(inputs.q);
+        return {
+          running: `Searching Gmail “${q}”`,
+          done: `Search Gmail “${q}”`,
+        };
+      }
       if (toolName === "create_draft" && isString(inputs.subject)) {
         const s = truncateQuery(inputs.subject);
         return {
@@ -207,15 +225,112 @@ function getDynamicToolDisplayLabels({
           done: `Send “${s}”`,
         };
       }
+      if (toolName === "delete_draft" && isString(inputs.subject)) {
+        const s = truncateQuery(inputs.subject);
+        return {
+          running: `Deleting draft “${s}”`,
+          done: `Delete draft “${s}”`,
+        };
+      }
+      if (toolName === "get_attachment" && isString(inputs.filename)) {
+        const name = truncateQuery(inputs.filename);
+        return {
+          running: `Getting attachment “${name}”`,
+          done: `Get attachment “${name}”`,
+        };
+      }
       return null;
 
     case "slack":
     case "slack_bot":
-      if (toolName === "post_message" && isString(inputs.to)) {
+      if (toolName === "post_message") {
+        if (isString(inputs.to)) {
+          const to = truncateQuery(inputs.to);
+          return {
+            running: `Posting to channel ${to}`,
+            done: `Post to channel ${to}`,
+          };
+        }
+        if (isStringArray(inputs.to)) {
+          const to = `${inputs.to.length} recipients`;
+          return {
+            running: `Posting to ${to}`,
+            done: `Post to ${to}`,
+          };
+        }
+      }
+      if (
+        toolName === "search_messages" &&
+        isStringArray(inputs.keywords) &&
+        inputs.keywords.length > 0
+      ) {
+        const keywords = formatStringList(inputs.keywords);
+        return {
+          running: `Searching Slack “${keywords}”`,
+          done: `Search Slack “${keywords}”`,
+        };
+      }
+      if (toolName === "semantic_search_messages" && isString(inputs.query)) {
+        const q = truncateQuery(inputs.query);
+        return {
+          running: `Searching Slack “${q}”`,
+          done: `Search Slack “${q}”`,
+        };
+      }
+      if (toolName === "schedule_message" && isString(inputs.to)) {
         const to = truncateQuery(inputs.to);
         return {
-          running: `Posting to channel ${to}`,
-          done: `Post to channel ${to}`,
+          running: `Scheduling message to ${to}`,
+          done: `Schedule message to ${to}`,
+        };
+      }
+      if (toolName === "search_user" && isString(inputs.query)) {
+        const q = truncateQuery(inputs.query);
+        return {
+          running: `Searching Slack user “${q}”`,
+          done: `Search Slack user “${q}”`,
+        };
+      }
+      if (toolName === "search_channels" && isString(inputs.query)) {
+        const q = truncateQuery(inputs.query);
+        return {
+          running: `Searching Slack channels “${q}”`,
+          done: `Search Slack channels “${q}”`,
+        };
+      }
+      if (toolName === "list_messages" && isString(inputs.channel)) {
+        const channel = truncateQuery(inputs.channel);
+        return {
+          running: `Listing Slack messages in ${channel}`,
+          done: `List Slack messages in ${channel}`,
+        };
+      }
+      if (toolName === "read_thread_messages" && isString(inputs.channel)) {
+        const channel = truncateQuery(inputs.channel);
+        return {
+          running: `Reading Slack thread in ${channel}`,
+          done: `Read Slack thread in ${channel}`,
+        };
+      }
+      if (toolName === "create_channel" && isString(inputs.name)) {
+        const name = truncateQuery(inputs.name);
+        return {
+          running: `Creating Slack channel ${name}`,
+          done: `Create Slack channel ${name}`,
+        };
+      }
+      if (toolName === "invite_to_channel" && isString(inputs.channel)) {
+        const channel = truncateQuery(inputs.channel);
+        return {
+          running: `Inviting users to Slack channel ${channel}`,
+          done: `Invite users to Slack channel ${channel}`,
+        };
+      }
+      if (toolName === "archive_channel" && isString(inputs.channel)) {
+        const channel = truncateQuery(inputs.channel);
+        return {
+          running: `Archiving Slack channel ${channel}`,
+          done: `Archive Slack channel ${channel}`,
         };
       }
       return null;
@@ -285,6 +400,63 @@ function getDynamicToolDisplayLabels({
         return {
           running: `Reading file`,
           done: `Read file`,
+        };
+      }
+      return null;
+
+    case "files":
+      if (toolName === "cat" && isString(inputs.path)) {
+        const path = truncateQuery(inputs.path);
+        return {
+          running: `Reading “${path}”`,
+          done: `Read “${path}”`,
+        };
+      }
+      if (
+        toolName === "grep" &&
+        isString(inputs.path) &&
+        isString(inputs.pattern)
+      ) {
+        const path = truncateQuery(inputs.path);
+        const pattern = truncateQuery(inputs.pattern);
+        return {
+          running: `Searching “${pattern}” in “${path}”`,
+          done: `Search “${pattern}” in “${path}”`,
+        };
+      }
+      if (toolName === "create" && isString(inputs.path)) {
+        const path = truncateQuery(inputs.path);
+        return {
+          running: `Writing “${path}”`,
+          done: `Write “${path}”`,
+        };
+      }
+      if (toolName === "delete" && isString(inputs.path)) {
+        const path = truncateQuery(inputs.path);
+        return {
+          running: `Deleting “${path}”`,
+          done: `Delete “${path}”`,
+        };
+      }
+      if (
+        (toolName === "copy" || toolName === "move") &&
+        isString(inputs.source) &&
+        isString(inputs.dest)
+      ) {
+        const source = truncateQuery(inputs.source);
+        const dest = truncateQuery(inputs.dest);
+        const verb = toolName === "copy" ? "Copying" : "Moving";
+        const past = toolName === "copy" ? "Copy" : "Move";
+        return {
+          running: `${verb} “${source}” to “${dest}”`,
+          done: `${past} “${source}” to “${dest}”`,
+        };
+      }
+      if (toolName === "resolve" && isString(inputs.file_id)) {
+        const fileId = truncateQuery(inputs.file_id);
+        return {
+          running: `Resolving file “${fileId}”`,
+          done: `Resolve file “${fileId}”`,
         };
       }
       return null;
@@ -418,6 +590,300 @@ function getDynamicToolDisplayLabels({
           done: `Create “${t}”`,
         };
       }
+      if (toolName === "get_worksheet" && isString(inputs.range)) {
+        const range = truncateQuery(inputs.range);
+        return {
+          running: `Retrieving worksheet range “${range}”`,
+          done: `Retrieve worksheet range “${range}”`,
+        };
+      }
+      if (toolName === "copy_file" && isString(inputs.name)) {
+        const name = truncateQuery(inputs.name);
+        return {
+          running: `Copying Drive file to “${name}”`,
+          done: `Copy Drive file to “${name}”`,
+        };
+      }
+      if (toolName === "share_file") {
+        const recipient = isString(inputs.emailAddress)
+          ? truncateQuery(inputs.emailAddress)
+          : isString(inputs.domain)
+            ? truncateQuery(inputs.domain)
+            : null;
+        if (recipient) {
+          return {
+            running: `Sharing Drive file with ${recipient}`,
+            done: `Share Drive file with ${recipient}`,
+          };
+        }
+      }
+      if (toolName === "create_comment" && isString(inputs.content)) {
+        const content = truncateQuery(inputs.content);
+        return {
+          running: `Commenting on Drive file: ${content}`,
+          done: `Comment on Drive file: ${content}`,
+        };
+      }
+      return null;
+
+    case "google_sheets":
+      if (toolName === "list_spreadsheets" && isString(inputs.nameFilter)) {
+        const q = truncateQuery(inputs.nameFilter);
+        return {
+          running: `Listing Sheets matching “${q}”`,
+          done: `List Sheets matching “${q}”`,
+        };
+      }
+      if (
+        (toolName === "get_worksheet" ||
+          toolName === "update_cells" ||
+          toolName === "append_data" ||
+          toolName === "clear_range") &&
+        isString(inputs.range)
+      ) {
+        const range = truncateQuery(inputs.range);
+        const verb =
+          toolName === "get_worksheet"
+            ? "Reading"
+            : toolName === "update_cells"
+              ? "Updating"
+              : toolName === "append_data"
+                ? "Appending to"
+                : "Clearing";
+        const past =
+          toolName === "get_worksheet"
+            ? "Read"
+            : toolName === "update_cells"
+              ? "Update"
+              : toolName === "append_data"
+                ? "Append to"
+                : "Clear";
+        return {
+          running: `${verb} Sheets range “${range}”`,
+          done: `${past} Sheets range “${range}”`,
+        };
+      }
+      if (toolName === "create_spreadsheet" && isString(inputs.title)) {
+        const title = truncateQuery(inputs.title);
+        return {
+          running: `Creating spreadsheet “${title}”`,
+          done: `Create spreadsheet “${title}”`,
+        };
+      }
+      if (toolName === "add_worksheet" && isString(inputs.title)) {
+        const title = truncateQuery(inputs.title);
+        return {
+          running: `Adding worksheet “${title}”`,
+          done: `Add worksheet “${title}”`,
+        };
+      }
+      if (toolName === "rename_worksheet" && isString(inputs.newTitle)) {
+        const title = truncateQuery(inputs.newTitle);
+        return {
+          running: `Renaming worksheet to “${title}”`,
+          done: `Rename worksheet to “${title}”`,
+        };
+      }
+      return null;
+
+    case "microsoft_drive":
+      if (
+        (toolName === "search_in_files" || toolName === "search_drive_items") &&
+        isString(inputs.query)
+      ) {
+        const q = truncateQuery(inputs.query);
+        return {
+          running: `Searching OneDrive/SharePoint “${q}”`,
+          done: `Search OneDrive/SharePoint “${q}”`,
+        };
+      }
+      if (toolName === "upload_file") {
+        const name = isString(inputs.fileName)
+          ? truncateQuery(inputs.fileName)
+          : isString(inputs.fileId)
+            ? truncateQuery(inputs.fileId)
+            : null;
+        if (name) {
+          return {
+            running: `Uploading “${name}” to OneDrive/SharePoint`,
+            done: `Upload “${name}” to OneDrive/SharePoint`,
+          };
+        }
+      }
+      if (toolName === "copy_file" && isString(inputs.name)) {
+        const name = truncateQuery(inputs.name);
+        return {
+          running: `Copying OneDrive/SharePoint file to “${name}”`,
+          done: `Copy OneDrive/SharePoint file to “${name}”`,
+        };
+      }
+      return null;
+
+    case "microsoft_excel":
+      if (toolName === "list_excel_files" && isString(inputs.query)) {
+        const q = truncateQuery(inputs.query);
+        return {
+          running: `Listing Excel files matching “${q}”`,
+          done: `List Excel files matching “${q}”`,
+        };
+      }
+      if (
+        (toolName === "read_worksheet" ||
+          toolName === "write_worksheet" ||
+          toolName === "clear_range") &&
+        isString(inputs.worksheetName)
+      ) {
+        const worksheetName = truncateQuery(inputs.worksheetName);
+        const range = isString(inputs.range)
+          ? ` range “${truncateQuery(inputs.range)}”`
+          : "";
+        const verb =
+          toolName === "read_worksheet"
+            ? "Reading"
+            : toolName === "write_worksheet"
+              ? "Writing"
+              : "Clearing";
+        const past =
+          toolName === "read_worksheet"
+            ? "Read"
+            : toolName === "write_worksheet"
+              ? "Write"
+              : "Clear";
+        return {
+          running: `${verb} Excel worksheet “${worksheetName}”${range}`,
+          done: `${past} Excel worksheet “${worksheetName}”${range}`,
+        };
+      }
+      if (toolName === "create_worksheet" && isString(inputs.worksheetName)) {
+        const worksheetName = truncateQuery(inputs.worksheetName);
+        return {
+          running: `Creating Excel worksheet “${worksheetName}”`,
+          done: `Create Excel worksheet “${worksheetName}”`,
+        };
+      }
+      return null;
+
+    case "microsoft_teams":
+      if (toolName === "search_messages_content" && isString(inputs.query)) {
+        const q = truncateQuery(inputs.query);
+        return {
+          running: `Searching Teams messages “${q}”`,
+          done: `Search Teams messages “${q}”`,
+        };
+      }
+      if (
+        (toolName === "list_users" ||
+          toolName === "list_channels" ||
+          toolName === "list_chats") &&
+        isString(inputs.nameFilter)
+      ) {
+        const q = truncateQuery(inputs.nameFilter);
+        return {
+          running: `Listing Teams results matching “${q}”`,
+          done: `List Teams results matching “${q}”`,
+        };
+      }
+      if (toolName === "post_message" && isString(inputs.targetType)) {
+        const targetType = truncateQuery(inputs.targetType);
+        return {
+          running: `Posting Teams message to ${targetType}`,
+          done: `Post Teams message to ${targetType}`,
+        };
+      }
+      if (toolName === "list_meetings" && isString(inputs.subjectFilter)) {
+        const subject = truncateQuery(inputs.subjectFilter);
+        return {
+          running: `Listing Teams meetings “${subject}”`,
+          done: `List Teams meetings “${subject}”`,
+        };
+      }
+      if (toolName === "get_transcript_content" && isString(inputs.joinUrl)) {
+        const url = shortenUrl(inputs.joinUrl);
+        return {
+          running: `Getting Teams transcript for “${url}”`,
+          done: `Get Teams transcript for “${url}”`,
+        };
+      }
+      return null;
+
+    case "salesforce":
+      if (toolName === "execute_read_query" && isString(inputs.query)) {
+        const q = truncateQuery(inputs.query);
+        return {
+          running: `Executing Salesforce query “${q}”`,
+          done: `Execute Salesforce query “${q}”`,
+        };
+      }
+      if (toolName === "describe_object" && isString(inputs.objectName)) {
+        const objectName = truncateQuery(inputs.objectName);
+        return {
+          running: `Describing Salesforce object ${objectName}`,
+          done: `Describe Salesforce object ${objectName}`,
+        };
+      }
+      if (
+        (toolName === "create_object" || toolName === "update_object") &&
+        isString(inputs.objectName)
+      ) {
+        const objectName = truncateQuery(inputs.objectName);
+        const verb = toolName === "create_object" ? "Creating" : "Updating";
+        const past = toolName === "create_object" ? "Create" : "Update";
+        return {
+          running: `${verb} Salesforce ${objectName} records`,
+          done: `${past} Salesforce ${objectName} records`,
+        };
+      }
+      if (
+        (toolName === "list_attachments" || toolName === "read_attachment") &&
+        isString(inputs.recordId)
+      ) {
+        const recordId = truncateQuery(inputs.recordId);
+        const verb = toolName === "list_attachments" ? "Listing" : "Reading";
+        const past = toolName === "list_attachments" ? "List" : "Read";
+        return {
+          running: `${verb} Salesforce attachments for ${recordId}`,
+          done: `${past} Salesforce attachments for ${recordId}`,
+        };
+      }
+      return null;
+
+    case "zendesk":
+      if (toolName === "get_ticket" && isNumber(inputs.ticketId)) {
+        return {
+          running: `Retrieving Zendesk ticket ${inputs.ticketId}`,
+          done: `Retrieve Zendesk ticket ${inputs.ticketId}`,
+        };
+      }
+      if (toolName === "search_tickets" && isString(inputs.query)) {
+        const q = truncateQuery(inputs.query);
+        return {
+          running: `Searching Zendesk tickets “${q}”`,
+          done: `Search Zendesk tickets “${q}”`,
+        };
+      }
+      if (
+        (toolName === "draft_reply" ||
+          toolName === "post_reply" ||
+          toolName === "update_ticket_tags") &&
+        isNumber(inputs.ticketId)
+      ) {
+        const verb =
+          toolName === "draft_reply"
+            ? "Drafting reply to"
+            : toolName === "post_reply"
+              ? "Posting reply to"
+              : "Updating tags on";
+        const past =
+          toolName === "draft_reply"
+            ? "Draft reply to"
+            : toolName === "post_reply"
+              ? "Post reply to"
+              : "Update tags on";
+        return {
+          running: `${verb} Zendesk ticket ${inputs.ticketId}`,
+          done: `${past} Zendesk ticket ${inputs.ticketId}`,
+        };
+      }
       return null;
 
     case "sandbox":
@@ -523,20 +989,14 @@ function getDynamicToolDisplayLabels({
     case "agent_memory":
     case "agent_router":
     case "ashby":
-    case "confluence":
     case "databricks":
     case "fathom":
     case "freshservice":
     case "gong":
-    case "google_sheets":
     case "hubspot":
     case "include_data":
     case "slideshow":
-    case "jira":
     case "luma":
-    case "microsoft_drive":
-    case "microsoft_excel":
-    case "microsoft_teams":
     case "missing_action_catcher":
     case "monday":
     case "openai_usage":
@@ -545,7 +1005,6 @@ function getDynamicToolDisplayLabels({
     case "common_utilities":
     case "jit_testing":
     case "run_dust_app":
-    case "salesforce":
     case "salesloft":
     case "slab":
     case "snowflake":
@@ -558,7 +1017,6 @@ function getDynamicToolDisplayLabels({
     case "val_town":
     case "vanta":
     case "front":
-    case "zendesk":
     case "schedules_management":
     case "poke":
     default:


### PR DESCRIPTION
## Description

- This PR expands the list of input-aware display labels for internal MCP tools so tool status text can include useful context like queries, paths, ranges, recipients, issue keys, and ticket IDs.
- Adds dynamic labels across Gmail, Slack, Files, Google Drive/Sheets (+ Microsoft Drive/Excel for parity), Salesforce, and Zendesk.
- Goal is to cover the most widely used tools (query [here](https://app.dust.tt/w/0ec9852c2f/conversation/JcMfqefhXr)).

## Tests

- Covered by existing tests.
- Tested most of them locally.

## Risk

- Low. UI label-only changes, with a fallback to the current behavior.

## Deploy Plan

- Deploy front.
