### PR TITLE
refactor(metronome): collapse tool categories to basic/advanced tiers [#7683]

### DIFF
--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -42,108 +42,92 @@ function truncatePropertyValue(value: string): string {
 // ---------------------------------------------------------------------------
 // Tool category mapping
 // ---------------------------------------------------------------------------
-
-export const TOOL_CATEGORIES = [
-  "retrieval",
-  "deep_research",
-  "reasoning",
-  "connectors",
-  "generation",
-  "agents",
-  "actions",
-  "platform",
-] as const;
+// Basic: 1 AWU
+// Advanced: 3 AWU
+export const TOOL_CATEGORIES = ["basic", "advanced"] as const;
 
 type ToolCategory = (typeof TOOL_CATEGORIES)[number];
 
 // Exhaustive map — TypeScript will error if a new internal MCP server is added
 // without being categorized here.
 const TOOL_CATEGORY_MAP: Record<InternalMCPServerNameType, ToolCategory> = {
-  // Retrieval — searching knowledge bases and data sources.
-  search: "retrieval",
-  query_tables_v2: "retrieval",
-  data_warehouses: "retrieval",
-  data_sources_file_system: "retrieval",
-  include_data: "retrieval",
-  conversation_files: "retrieval",
-  files: "retrieval",
+  // Basic (1 AWU) — web search, orchestration, platform utilities.
+  "web_search_&_browse": "basic",
+  run_agent: "basic",
+  agent_router: "basic",
+  agent_sidekick_agent_state: "basic",
+  agent_sidekick_context: "basic",
+  agent_management: "basic",
+  agent_memory: "basic",
+  run_dust_app: "basic",
+  common_utilities: "basic",
+  toolsets: "basic",
+  user_mentions: "basic",
+  missing_action_catcher: "basic",
+  primitive_types_debugger: "basic",
+  jit_testing: "basic",
+  skill_management: "basic",
+  schedules_management: "basic",
+  pod_manager: "basic",
+  pod_tasks: "basic",
+  poke: "basic",
+  ask_user_question: "basic",
+  wakeups: "basic",
+  plan_mode: "basic",
 
-  // Deep research — web search, browsing, HTTP.
-  "web_search_&_browse": "deep_research",
-  http_client: "deep_research",
-
-  // Connectors — third-party platform integrations.
-  confluence: "connectors",
-  databricks: "connectors",
-  fathom: "connectors",
-  freshservice: "connectors",
-  github: "connectors",
-  gmail: "connectors",
-  google_calendar: "connectors",
-  google_drive: "connectors",
-  google_sheets: "connectors",
-  hubspot: "connectors",
-  jira: "connectors",
-  luma: "connectors",
-  microsoft_drive: "connectors",
-  microsoft_excel: "connectors",
-  microsoft_teams: "connectors",
-  monday: "connectors",
-  notion: "connectors",
-  openai_usage: "connectors",
-  outlook_calendar: "connectors",
-  outlook: "connectors",
-  productboard: "connectors",
-  salesforce: "connectors",
-  salesloft: "connectors",
-  slab: "connectors",
-  slack: "connectors",
-  slack_bot: "connectors",
-  snowflake: "connectors",
-  statuspage: "connectors",
-  ukg_ready: "connectors",
-  val_town: "connectors",
-  vanta: "connectors",
-  front: "connectors",
-  gong: "connectors",
-  zendesk: "connectors",
-  ashby: "connectors",
-  clari_copilot: "connectors",
-
-  // Generation — file/image/sound creation.
-  file_generation: "generation",
-  image_generation: "generation",
-  sound_studio: "generation",
-  speech_generator: "generation",
-  slideshow: "generation",
-  interactive_content: "generation",
-
-  // Agents — running other agents, routing, sidekick.
-  run_agent: "agents",
-  agent_router: "agents",
-  agent_sidekick_agent_state: "agents",
-  agent_sidekick_context: "agents",
-  agent_management: "agents",
-  agent_memory: "agents",
-  run_dust_app: "agents",
-
-  // Platform — internal utilities, management.
-  extract_data: "platform",
-  common_utilities: "platform",
-  toolsets: "platform",
-  user_mentions: "platform",
-  missing_action_catcher: "platform",
-  primitive_types_debugger: "platform",
-  jit_testing: "platform",
-  skill_management: "platform",
-  schedules_management: "platform",
-  pod_manager: "platform",
-  pod_tasks: "platform",
-  poke: "platform",
-  sandbox: "platform",
-  ask_user_question: "platform",
-  wakeups: "platform",
-  plan_mode: "platform",
+  // Advanced (3 AWU) — retrieval, MCP read/write, data warehouse, generation, sandbox
+  search: "advanced",
+  query_tables_v2: "advanced",
+  data_warehouses: "advanced",
+  data_sources_file_system: "advanced",
+  include_data: "advanced",
+  conversation_files: "advanced",
+  files: "advanced",
+  extract_data: "advanced",
+  http_client: "advanced",
+  sandbox: "advanced",
+  file_generation: "advanced",
+  image_generation: "advanced",
+  sound_studio: "advanced",
+  speech_generator: "advanced",
+  slideshow: "advanced",
+  interactive_content: "advanced",
+  confluence: "advanced",
+  databricks: "advanced",
+  fathom: "advanced",
+  freshservice: "advanced",
+  github: "advanced",
+  gmail: "advanced",
+  google_calendar: "advanced",
+  google_drive: "advanced",
+  google_sheets: "advanced",
+  hubspot: "advanced",
+  jira: "advanced",
+  luma: "advanced",
+  microsoft_drive: "advanced",
+  microsoft_excel: "advanced",
+  microsoft_teams: "advanced",
+  monday: "advanced",
+  notion: "advanced",
+  openai_usage: "advanced",
+  outlook_calendar: "advanced",
+  outlook: "advanced",
+  productboard: "advanced",
+  salesforce: "advanced",
+  salesloft: "advanced",
+  slab: "advanced",
+  slack: "advanced",
+  slack_bot: "advanced",
+  snowflake: "advanced",
+  statuspage: "advanced",
+  ukg_ready: "advanced",
+  val_town: "advanced",
+  vanta: "advanced",
+  front: "advanced",
+  gong: "advanced",
+  zendesk: "advanced",
+  ashby: "advanced",
+  clari_copilot: "advanced",
 };
 
 export function getToolCategory(
@@ -153,8 +137,9 @@ export function getToolCategory(
     !internalMCPServerName ||
     !isInternalMCPServerName(internalMCPServerName)
   ) {
-    // External MCP servers (user-configured remote servers) or unknown names.
-    return "actions";
+    // External MCP servers (user-configured remote servers) fall into advanced
+    // as "Custom MCP call".
+    return "advanced";
   }
   return TOOL_CATEGORY_MAP[internalMCPServerName];
 }

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -524,21 +524,13 @@ function buildSeatTierRates({
   );
 }
 
-// Per-category AWU price for Tool Usage rates. 1 AWU per invocation by default;
-// deep_research costs 2 AWU. Shared across all AWU-priced rate cards
-// (Business USD, Business EUR, Enterprise EUR).
+// Per-tier AWU price for Tool Usage rates. Shared across all AWU-priced rate cards
 const TOOL_CATEGORY_PRICES_AWU: Record<
   (typeof TOOL_CATEGORIES)[number],
   number
 > = {
-  retrieval: 1,
-  deep_research: 2,
-  reasoning: 1,
-  connectors: 1,
-  generation: 1,
-  agents: 1,
-  actions: 1,
-  platform: 1,
+  basic: 1,
+  advanced: 3,
 };
 
 // usage_type splits each AWU usage rate: "user" and "programmatic" use the


### PR DESCRIPTION
## Description

Reconciles the tool cost classification in Metronome with the pricing decision from #7683.

The old model had **8 tool categories** (`retrieval`, `deep_research`, `reasoning`, `connectors`, `generation`, `agents`, `actions`, `platform`) all priced at 1 AWU except `deep_research` at 2 AWU — neither the category names nor the prices matched the approved pricing decision.

This PR collapses to **2 tiers** matching the decision doc exactly:

| Tier | AWU | What goes here |
|---|---|---|
| `basic` | 1 | Web search, orchestration (`run_agent`, `agent_router`), platform utilities |
| `advanced` | 3 | Retrieval, MCP read/write (all connectors), data warehouse, generation tools, sandbox, external MCPs |

### Mapping rationale for non-obvious tools

**`run_agent` / `agent_router` → basic**: These are orchestration dispatchers. The sub-agent they invoke already accrues its own LLM and tool events, so billing the dispatch at 3 AWU would double-count. The decision doc lists "Orchestrator" as Basic.

**All connectors (Slack, Notion, Jira, etc.) → advanced**: Connector calls are MCP read/write operations. The decision doc lists both "MCP read" and "MCP write" as Advanced. We don't split read vs write at the connector level — all connector calls land in the same billing tier.

**`sandbox` → advanced**: Despite being internally managed, sandbox executes code in an isolated environment backed by external providers and runners, which has real compute cost. Priced like other Advanced tools (3 AWU).

**`image_generation`, `file_generation`, `slideshow`, `sound_studio`, `speech_generator`, `interactive_content` → advanced**: These map to "Create Frame" in the decision doc (3 AWU).

**`extract_data` → advanced**: Retrieval-class operation — extracts structured data from content sources. Grouped with retrieval (3 AWU).

**`http_client` → advanced**: Direct HTTP calls to external services map to "Custom MCP call" (3 AWU).

**External/unknown MCP servers → advanced**: Previously fell back to `"actions"` (a category that no longer exists). Now correctly classified as "Custom MCP call" → advanced.

**Platform utilities (`common_utilities`, `toolsets`, `schedules_management`, `pod_*`, `poke`, `plan_mode`, etc.) → basic**: Internal agent infrastructure with no meaningful compute cost. Billing these at 3 AWU would penalize agent overhead rather than real work.

### Rate card impact

`TOOL_CATEGORY_PRICES_AWU` in `metronome_setup.ts` is updated to `{ basic: 1, advanced: 3 }`. The `buildAwuToolUsageRates()` function iterates `TOOL_CATEGORIES` automatically, so the rate card now generates 6 rate entries (2 tiers × 3 usage types) instead of 24.

### Migration note

This only affects events emitted going forward. Existing Metronome rate card entries for the old 8 categories continue to match historical events (their `tool_category` property values won't change retroactively). The `metronome_setup` script needs to be re-run to add `basic`/`advanced` rate entries to all rate cards. Old category entries can be archived once the cutover date has passed and there are no more events to rate against them.

## Tests

## Risk


## Deploy Plan

`metronome_setup.ts --execute`