### PR TITLE
[front] Push analytics report removal date to July 1st 2026

### DIFF
--- a/front/components/workspace/ActivityReport.tsx
+++ b/front/components/workspace/ActivityReport.tsx
@@ -138,7 +138,7 @@ export function ActivityReport({
           </DialogHeader>
           <DialogContainer>
             <ContentMessage variant="warning" title="Scheduled for removal">
-              This activity report download will be removed on June 1st, 2026.
+              This activity report download will be removed on July 1st, 2026.
               Switch to the new analytics export API before then.{" "}
               <Hoverable
                 variant="highlight"

--- a/front/pages/api/v1/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/v1/w/[wId]/workspace-usage.ts
@@ -23,7 +23,7 @@ import { fromError } from "zod-validation-error";
  *     summary: Get workspace usage data
  *     deprecated: true
  *     description: |
- *       Deprecated: this endpoint will be removed after 2026-06-01.
+ *       Deprecated: this endpoint will be removed after 2026-07-01.
  *       Use GET /api/v1/w/{wId}/analytics/export instead.
  *
  *       Get usage data for the workspace identified by {wId} in CSV or JSON format.

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -6079,7 +6079,7 @@
       "get": {
         "summary": "Get workspace usage data",
         "deprecated": true,
-        "description": "Deprecated: this endpoint will be removed after 2026-06-01.\nUse GET /api/v1/w/{wId}/analytics/export instead.\n\nGet usage data for the workspace identified by {wId} in CSV or JSON format.\n",
+        "description": "Deprecated: this endpoint will be removed after 2026-07-01.\nUse GET /api/v1/w/{wId}/analytics/export instead.\n\nGet usage data for the workspace identified by {wId} in CSV or JSON format.\n",
         "tags": [
           "Workspace"
         ],


### PR DESCRIPTION
## Description

Update the deprecation warning in the activity report download dialog and the matching Swagger comment on the public workspace-usage endpoint from June 1st to July 1st 2026. The date is documentation-only; nothing enforces it in code.

## Tests

none

## Risk

None, changes are purely cosmetic

## Deploy Plan

front