### PR TITLE
[Agent Loop] Heartbeat while processing tool results

### DIFF
--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -23,6 +23,7 @@ import type { AgentLoopRunContextType } from "@app/lib/actions/types";
 import { handleMCPActionError } from "@app/lib/api/mcp/error";
 import type { Authenticator } from "@app/lib/auth";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { withPeriodicHeartbeat } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
@@ -31,6 +32,9 @@ import type {
   ConversationType,
 } from "@app/types/assistant/conversation";
 import { removeNulls } from "@app/types/shared/utils/general";
+import { heartbeat } from "@temporalio/activity";
+
+const TOOL_RESULT_PROCESSING_HEARTBEAT_INTERVAL_MS = 10_000;
 
 /**
  * Runs a tool with streaming for the given MCP action configuration.
@@ -122,13 +126,22 @@ export async function* runToolWithStreaming(
     return;
   }
 
-  const { outputItems, generatedFiles } = await processToolResults(auth, {
-    action,
-    conversation,
-    localLogger,
-    toolCallResultContent: toolCallResult.content,
-    toolConfiguration,
-  });
+  // Tool result processing can legitimately take up to 5 minutes when processing files,
+  // so heartbeat while this scoped post-processing phase is running.
+  const { outputItems, generatedFiles } = await withPeriodicHeartbeat(
+    () =>
+      processToolResults(auth, {
+        action,
+        conversation,
+        localLogger,
+        toolCallResultContent: toolCallResult.content,
+        toolConfiguration,
+      }),
+    {
+      intervalMs: TOOL_RESULT_PROCESSING_HEARTBEAT_INTERVAL_MS,
+      heartbeatFn: heartbeat,
+    }
+  );
 
   // Parse the output resources to check if we find special events that require the agent loop to pause.
   // This could be an authentication, validation, or unconditional exit from the action.

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -25,7 +25,7 @@ import type { Authenticator } from "@app/lib/auth";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { withPeriodicHeartbeat } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-
+import { TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS } from "@app/temporal/agent_loop/config";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   AgentMessageType,
@@ -34,7 +34,10 @@ import type {
 import { removeNulls } from "@app/types/shared/utils/general";
 import { heartbeat } from "@temporalio/activity";
 
-const TOOL_RESULT_PROCESSING_HEARTBEAT_INTERVAL_MS = 10_000;
+const TOOL_RESULT_PROCESSING_HEARTBEAT_TIMEOUT_MARGIN_MS = 5 * 1000;
+const TOOL_RESULT_PROCESSING_HEARTBEAT_INTERVAL_MS =
+  TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS -
+  TOOL_RESULT_PROCESSING_HEARTBEAT_TIMEOUT_MARGIN_MS;
 
 /**
  * Runs a tool with streaming for the given MCP action configuration.
@@ -139,7 +142,10 @@ export async function* runToolWithStreaming(
       }),
     {
       intervalMs: TOOL_RESULT_PROCESSING_HEARTBEAT_INTERVAL_MS,
-      heartbeatFn: heartbeat,
+      heartbeatFn: () => {
+        heartbeat();
+        localLogger.info("MCP tool result processing heartbeat");
+      },
     }
   );
 

--- a/front/lib/utils/async_utils.ts
+++ b/front/lib/utils/async_utils.ts
@@ -99,3 +99,24 @@ export async function withRetry<T>(
 
   return new Err(normalizeError(lastErr));
 }
+
+export async function withPeriodicHeartbeat<T>(
+  fn: () => Promise<T>,
+  {
+    intervalMs,
+    heartbeatFn,
+  }: {
+    intervalMs: number;
+    heartbeatFn: () => void;
+  }
+): Promise<T> {
+  const interval = setInterval(() => {
+    heartbeatFn();
+  }, intervalMs);
+
+  try {
+    return await fn();
+  } finally {
+    clearInterval(interval);
+  }
+}

--- a/front/temporal/agent_loop/config.ts
+++ b/front/temporal/agent_loop/config.ts
@@ -7,3 +7,6 @@ export const RUN_MODEL_MAX_RETRIES = 5;
 
 // Leave room for our code to surface a retryable agent error before Temporal enforces StartToClose.
 export const RUN_MODEL_ACTIVITY_TIMEOUT_SAFETY_MARGIN_MS = 1 * 60 * 1000;
+
+export const TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS = 60 * 1000;
+export const MODEL_ACTIVITY_HEARTBEAT_TIMEOUT_MS = 60 * 1000;

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -10,7 +10,11 @@ import type * as finalizeActivities from "@app/temporal/agent_loop/activities/fi
 import type * as publishDeferredEventsActivities from "@app/temporal/agent_loop/activities/publish_deferred_events";
 import type * as runModelAndCreateWrapperActivities from "@app/temporal/agent_loop/activities/run_model_and_create_actions_wrapper";
 import type * as runToolActivities from "@app/temporal/agent_loop/activities/run_tool";
-import { RUN_MODEL_MAX_RETRIES } from "@app/temporal/agent_loop/config";
+import {
+  MODEL_ACTIVITY_HEARTBEAT_TIMEOUT_MS,
+  RUN_MODEL_MAX_RETRIES,
+  TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS,
+} from "@app/temporal/agent_loop/config";
 import { isTerminalRunModelAndCreateActionsTimeout } from "@app/temporal/agent_loop/lib/workflow_failures";
 import { makeAgentLoopConversationTitleWorkflowId } from "@app/temporal/agent_loop/lib/workflow_ids";
 import {
@@ -43,9 +47,6 @@ import {
 const toolActivityStartToCloseTimeoutMs =
   Math.max(RUN_AGENT_CALL_TOOL_TIMEOUT_MS, DEFAULT_MCP_REQUEST_TIMEOUT_MS) +
   60 * 1000;
-
-const TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS = 60 * 1000;
-const MODEL_ACTIVITY_HEARTBEAT_TIMEOUT_MS = 60 * 1000;
 
 import {
   OpenTelemetryInboundInterceptor,


### PR DESCRIPTION
## Description
Tool result processing can legitimately take longer than the 60s Temporal activity heartbeat timeout when returned files are processed. This wraps only the `processToolResults` call with a periodic heartbeat, keeping the heartbeat scoped to the known long-running post-processing phase.

## Risks
Blast radius: MCP tool execution post-processing in the agent loop.
Risk: low

## Deploy Plan
- pmrr
- deploy front