### PR TITLE
Show metronome switch when metronome billing is enabled

### DIFF
--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -23,10 +23,7 @@ import {
 import { useAppRouter } from "@app/lib/platform";
 import { usePokePlans } from "@app/lib/swr/poke";
 import type { PlanType, SubscriptionType } from "@app/types/plan";
-import {
-  isSubscriptionMetronomeBilled,
-  isSubscriptionStripeBilled,
-} from "@app/types/plan";
+import { isSubscriptionMetronomeBilled } from "@app/types/plan";
 import type { ProgrammaticUsageConfigurationType } from "@app/types/programmatic_usage";
 import { isDevelopment } from "@app/types/shared/env";
 import type { WorkspaceType } from "@app/types/user";
@@ -297,14 +294,12 @@ export function ActiveSubscriptionTable({
   const status = getSubscriptionDisplayStatus(subscription);
   const { chipColor, chipLabel, cardClass } = STATUS_CONFIG[status];
 
-  // For workspaces with no paid subscription yet, the flow is selected by the
-  // Metronome billing feature; otherwise it follows the active billing rail.
-  const hasNoBillingYet =
-    !isSubscriptionStripeBilled(subscription) &&
-    !isSubscriptionMetronomeBilled(subscription);
+  // Show the Metronome flow whenever the workspace is already Metronome-billed,
+  // or whenever the Metronome billing feature is enabled for it (FF or
+  // kill-switch off). This includes Stripe-billed + shadow-Metronome workspaces
+  // mid-migration, so operators can invoke switch_contract from poke.
   const useMetronomeFlow =
-    isSubscriptionMetronomeBilled(subscription) ||
-    (hasNoBillingYet && hasMetronomeBillingFeature);
+    isSubscriptionMetronomeBilled(subscription) || hasMetronomeBillingFeature;
 
   return (
     <div className="flex flex-col gap-3">


### PR DESCRIPTION
## Description

Always show the metronome switch contract version if metronome is enabled (FF enabled or KS disabled). Will allow to migrate existing subscriptions directly to metronome. 

Follow-up PRs to correctly handle the case where ws was stripe billed - need to cancel subscription.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
