### PR TITLE
feat(metronome): handle webhooks.test ping event

### DIFF
--- a/front-api/routes/metronome/webhook.ts
+++ b/front-api/routes/metronome/webhook.ts
@@ -86,6 +86,14 @@ app.post("/", async (ctx): HandlerResult<ResponseBody> => {
 
   const event = parsedEvent.data;
 
+  if (event.type === "webhooks.test") {
+    logger.info(
+      { eventId: event.id },
+      "[Metronome Webhook] Test ping received — webhook endpoint is reachable and signature verification works!"
+    );
+    return ctx.json({ success: true });
+  }
+
   logger.info({ event, rawEvent }, "[Metronome Webhook] Event received");
 
   // Resolve the workspace before enqueueing — every event except

--- a/front/lib/metronome/webhook_events.ts
+++ b/front/lib/metronome/webhook_events.ts
@@ -450,6 +450,16 @@ const PaymentGateExternalInitiateSchema = z.object({
 });
 
 // ============================================================================
+// Webhook test event — sent by Metronome when c/licking "Test" in the dashboard.
+// No customer_id; used purely to verify the endpoint is reachable.
+// ============================================================================
+
+const WebhooksTestSchema = z.object({
+  id: z.string(),
+  type: z.literal("webhooks.test"),
+});
+
+// ============================================================================
 // Discriminated union of all known event schemas.
 // ============================================================================
 
@@ -495,6 +505,7 @@ export const MetronomeWebhookEventSchema = z.discriminatedUnion("type", [
   PaymentGatePaymentPendingActionRequiredSchema,
   PaymentGateThresholdReachedSchema,
   PaymentGateExternalInitiateSchema,
+  WebhooksTestSchema,
 ]);
 
 export type MetronomeWebhookEvent = z.infer<typeof MetronomeWebhookEventSchema>;
@@ -507,7 +518,7 @@ export type MetronomeWebhookEventType = MetronomeWebhookEvent["type"];
 export function getCustomerIdFromEvent(
   event: MetronomeWebhookEvent
 ): string | null {
-  if (event.type === "integration.issue") {
+  if (event.type === "integration.issue" || event.type === "webhooks.test") {
     return null;
   }
   if ("customer_id" in event) {

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -104,6 +104,14 @@ async function handler(
 
       const event = parsedEvent.data;
 
+      if (event.type === "webhooks.test") {
+        logger.info(
+          { eventId: event.id },
+          "[Metronome Webhook] Test ping received — webhook endpoint is reachable and signature verification works!"
+        );
+        return res.status(200).json({ success: true });
+      }
+
       logger.info({ event, rawEvent }, "[Metronome Webhook] Event received");
 
       // Resolve the workspace before enqueueing — every event except


### PR DESCRIPTION
## Description

Adds `webhooks.test` to the known Metronome webhook event types. This is the silent ping Metronome sends when you click "Test" in the dashboard to verify a webhook endpoint is reachable — it has no `customer_id` and requires no processing.

Both handlers (Next.js and Hono) now detect it early and log a clear success message before returning 200, instead of silently falling through the unknown-event path.

## Tests

Manual: click "Test" in the Metronome dashboard and verify the log line appears:
`[Metronome Webhook] Test ping received — webhook endpoint is reachable and signature verification works!`
