### PR TITLE
chore(mprocs): add stripe webhook listener entry

### DIFF
--- a/front-api/routes/metronome/webhook.ts
+++ b/front-api/routes/metronome/webhook.ts
@@ -86,6 +86,14 @@ app.post("/", async (ctx): HandlerResult<ResponseBody> => {
 
   const event = parsedEvent.data;
 
+  if (event.type === "webhooks.test") {
+    logger.info(
+      { eventId: event.id },
+      "[Metronome Webhook] Test ping received — webhook endpoint is reachable and signature verification works!"
+    );
+    return ctx.json({ success: true });
+  }
+
   logger.info({ event, rawEvent }, "[Metronome Webhook] Event received");
 
   // Resolve the workspace before enqueueing — every event except

--- a/front/lib/metronome/webhook_events.ts
+++ b/front/lib/metronome/webhook_events.ts
@@ -450,6 +450,16 @@ const PaymentGateExternalInitiateSchema = z.object({
 });
 
 // ============================================================================
+// Webhook test event — sent by Metronome when c/licking "Test" in the dashboard.
+// No customer_id; used purely to verify the endpoint is reachable.
+// ============================================================================
+
+const WebhooksTestSchema = z.object({
+  id: z.string(),
+  type: z.literal("webhooks.test"),
+});
+
+// ============================================================================
 // Discriminated union of all known event schemas.
 // ============================================================================
 
@@ -495,6 +505,7 @@ export const MetronomeWebhookEventSchema = z.discriminatedUnion("type", [
   PaymentGatePaymentPendingActionRequiredSchema,
   PaymentGateThresholdReachedSchema,
   PaymentGateExternalInitiateSchema,
+  WebhooksTestSchema,
 ]);
 
 export type MetronomeWebhookEvent = z.infer<typeof MetronomeWebhookEventSchema>;
@@ -507,7 +518,7 @@ export type MetronomeWebhookEventType = MetronomeWebhookEvent["type"];
 export function getCustomerIdFromEvent(
   event: MetronomeWebhookEvent
 ): string | null {
-  if (event.type === "integration.issue") {
+  if (event.type === "integration.issue" || event.type === "webhooks.test") {
     return null;
   }
   if ("customer_id" in event) {

--- a/front/pages/api/metronome/webhook.ts
+++ b/front/pages/api/metronome/webhook.ts
@@ -104,6 +104,14 @@ async function handler(
 
       const event = parsedEvent.data;
 
+      if (event.type === "webhooks.test") {
+        logger.info(
+          { eventId: event.id },
+          "[Metronome Webhook] Test ping received — webhook endpoint is reachable and signature verification works!"
+        );
+        return res.status(200).json({ success: true });
+      }
+
       logger.info({ event, rawEvent }, "[Metronome Webhook] Event received");
 
       // Resolve the workspace before enqueueing — every event except

--- a/tools/mprocs.yaml
+++ b/tools/mprocs.yaml
@@ -211,3 +211,8 @@ procs:
     # Doc: https://docs.novu.co/framework/studio
     shell: "npx novu@latest dev --port 3000"
     autostart: false
+
+  stripe:
+    # Doc: https://www.notion.so/dust-tt/Runbook-Local-Dev-setup-720bffc7d67a447184cb957e9471380c?source=copy_link#5814f227351d4d258422e21e8de39c82/
+    shell: "stripe listen --forward-to localhost:3000/api/stripe/webhook"
+    autostart: false


### PR DESCRIPTION
## Description

Adds a `stripe` entry to `tools/mprocs.yaml` for local Stripe webhook forwarding. Disabled by default (`autostart: false`) — start it manually when testing Stripe webhook flows locally.

```
stripe listen --forward-to localhost:3000/api/stripe/webhook
```
