### PR TITLE
[LLM] fix: keep tool results contiguous after assistant tool calls

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/message_rendering.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.ts
@@ -118,8 +118,11 @@ export function renderAgentSteps(
         } satisfies AssistantContentMessageTypeModel);
       }
 
-      for (const { result, enabledSkillMessages } of step.actions) {
+      // Tool calls must be immediately followed by their results, skill messages come after.
+      for (const { result } of step.actions) {
         messages.push(result);
+      }
+      for (const { enabledSkillMessages } of step.actions) {
         messages.push(...enabledSkillMessages);
       }
     }


### PR DESCRIPTION
## Description

When `skills_as_user_messages` is enabled, skill user messages were interleaved between per-tool-call function results, breaking Anthropic's requirement that each `tool_use` block be immediately followed by its `tool_result` (causing 400s on Vertex/Anthropic). Now all tool results are emitted first, skill messages after.

## Tests

Tested locally with parallel tool calls.

## Risk

Low — reorders rendered messages only, no schema or API changes, trivially reversible.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`