### PR TITLE
[LLM] Remove use_vertex_for_anthropic_models feature flag

### DIFF
--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -8,11 +8,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Fallback to Vertex Anthropic for some Anthropic models",
     stage: "dust_only",
   },
-  use_vertex_for_anthropic_models: {
-    description:
-      "Route Claude model LLM calls through Vertex AI instead of the direct Anthropic API",
-    stage: "dust_only",
-  },
   use_vertex_for_supported_models: {
     description:
       "Route LLM calls through Vertex AI when supported instead of the direct provider's API",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -762,7 +762,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "conversation_search_indexing"
   | "conversation_search_read"
   | "new_file_explorer"
-  | "use_vertex_for_anthropic_models"
   | "use_vertex_for_supported_models"
   | "metronome_billing_usage_page"
 >();


### PR DESCRIPTION
## Description

Final step (3/3) of renaming the Vertex routing feature flag: removes the now-unused `use_vertex_for_anthropic_models` flag from the `WHITELISTABLE_FEATURES_CONFIG` and the SDK's `WhitelistableFeaturesSchema` union. Routing now goes through `use_vertex_for_supported_models`.

## Tests

No tests — pure flag definition removal; type-checking covers the union change.

## Risk

Low. The flag has no remaining consumers (removed in the prior migration steps); rollback is trivial.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`