### PR TITLE
fix(clari-mcp): coerce timestamps, expose pagination, make transcript optional

### DIFF
--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -1181,6 +1181,13 @@ export const ClariCallListResourceSchema = z.object({
   uri: z.literal(""),
   text: z.string(),
   calls: z.array(ClariCallSchema),
+  pagination: z
+    .object({
+      matched: z.number().optional(),
+      hasMore: z.boolean().optional(),
+      nextPageSkip: z.number().optional(),
+    })
+    .optional(),
 });
 
 export type ClariCallListResourceType = z.infer<

--- a/front/lib/api/actions/servers/clari_copilot/client.ts
+++ b/front/lib/api/actions/servers/clari_copilot/client.ts
@@ -1,8 +1,8 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type {
-  ClariCall,
   ClariCallDetails,
+  ClariCallsResponse,
 } from "@app/lib/api/actions/servers/clari_copilot/types";
 import {
   ClariCallDetailsResponseSchema,
@@ -131,11 +131,11 @@ export class ClariCopilotClient {
 
   async searchCalls(
     params: SearchCallsParams
-  ): Promise<Result<ClariCall[], Error>> {
+  ): Promise<Result<ClariCallsResponse, Error>> {
     const query = new URLSearchParams({
       filterStatus: CLARI_PROCESSED_STATUS,
       includePrivate: "false",
-      includePagination: "false",
+      includePagination: "true",
       limit: String(params.limit ?? CLARI_DEFAULT_LIMIT),
     });
 
@@ -170,7 +170,7 @@ export class ClariCopilotClient {
       );
     }
 
-    return new Ok(calls);
+    return new Ok({ calls, pagination: result.value.pagination });
   }
 
   async getCallDetails(

--- a/front/lib/api/actions/servers/clari_copilot/metadata.ts
+++ b/front/lib/api/actions/servers/clari_copilot/metadata.ts
@@ -57,13 +57,23 @@ export const CLARI_COPILOT_TOOLS_METADATA = createToolsRecord({
   },
   get_call_details: {
     description:
-      "Retrieve full details for a specific Clari Copilot call, including the AI summary, " +
-      "topics discussed, action items, competitor mentions, and turn-by-turn transcript. " +
+      "Retrieve details for a specific Clari Copilot call, including the AI summary, " +
+      "topics discussed, action items, and competitor mentions. " +
+      "The turn-by-turn transcript is excluded by default to limit context size; " +
+      "set include_transcript to true only when the full transcript is needed. " +
       "Requires a call ID from search_calls.",
     schema: {
       call_id: z
         .string()
         .describe("The Clari Copilot call ID (obtained from search_calls)."),
+      include_transcript: z
+        .boolean()
+        .optional()
+        .describe(
+          "Whether to include the turn-by-turn transcript (default: false). " +
+            "The AI summary, topics, and action items are always included. " +
+            "Set to true only when the full transcript is needed."
+        ),
     },
     stake: "never_ask",
     displayLabels: {

--- a/front/lib/api/actions/servers/clari_copilot/tools/index.ts
+++ b/front/lib/api/actions/servers/clari_copilot/tools/index.ts
@@ -26,21 +26,26 @@ const handlers: ToolHandlers<typeof CLARI_COPILOT_TOOLS_METADATA> = {
       );
     }
 
-    const calls = result.value;
+    const { calls, pagination } = result.value;
+    const totalText =
+      pagination?.matched !== undefined
+        ? ` (${pagination.matched} total${pagination.hasMore ? ", more available" : ""})`
+        : "";
     return new Ok([
       {
         type: "resource" as const,
         resource: {
           mimeType: CLARI_CALL_LIST_MIME_TYPE,
           uri: "",
-          text: `${calls.length} call(s) found`,
+          text: `${calls.length} call(s) returned${totalText}`,
           calls,
+          pagination,
         },
       },
     ]);
   },
 
-  get_call_details: async ({ call_id }, extra) => {
+  get_call_details: async ({ call_id, include_transcript }, extra) => {
     const clientResult = getClariClient(extra);
     if (clientResult.isErr()) {
       return new Err(clientResult.error);
@@ -56,6 +61,9 @@ const handlers: ToolHandlers<typeof CLARI_COPILOT_TOOLS_METADATA> = {
     }
 
     const call = result.value;
+    const callToReturn = include_transcript
+      ? call
+      : { ...call, transcript: undefined };
     return new Ok([
       {
         type: "resource" as const,
@@ -63,7 +71,7 @@ const handlers: ToolHandlers<typeof CLARI_COPILOT_TOOLS_METADATA> = {
           mimeType: CLARI_CALL_DETAILS_MIME_TYPE,
           uri: call.call_review_page_url ?? "",
           text: `Call details retrieved for "${call.title ?? call.id}"`,
-          call,
+          call: callToReturn,
         },
       },
     ]);

--- a/front/lib/api/actions/servers/clari_copilot/types.ts
+++ b/front/lib/api/actions/servers/clari_copilot/types.ts
@@ -72,8 +72,8 @@ const ClariTranscriptTurnSchema = z
 const ClariTopicSchema = z
   .object({
     name: z.string().optional(),
-    start_timestamp: z.number().optional(),
-    end_timestamp: z.number().optional(),
+    start_timestamp: z.coerce.number().optional(),
+    end_timestamp: z.coerce.number().optional(),
     summary: z.string().optional(),
   })
   .passthrough();
@@ -82,8 +82,8 @@ const ClariActionItemSchema = z
   .object({
     action_item: z.string().optional(),
     speaker_name: z.string().optional(),
-    start_timestamp: z.number().optional(),
-    end_timestamp: z.number().optional(),
+    start_timestamp: z.coerce.number().optional(),
+    end_timestamp: z.coerce.number().optional(),
   })
   .passthrough();
 


### PR DESCRIPTION
## Description

Three fixes/improvements to the Clari Copilot MCP server:

- **Coerce timestamps**: `start_timestamp` and `end_timestamp` fields in topics and action items now use `z.coerce.number()` to handle cases where the Clari API returns those values as strings instead of numbers, preventing schema validation failures.
- **Expose pagination**: `includePagination` is now set to `true` on the `search_calls` request. The pagination metadata (`matched`, `hasMore`, `nextPageSkip`) is surfaced in both the output schema and the response text so agents are aware when more results exist.
- **Make transcript optional**: `get_call_details` now accepts an optional `include_transcript` boolean (default: `false`). The turn-by-turn transcript is stripped from the response unless explicitly requested, reducing context size for the common case where only the AI summary/topics/action items are needed.

## Tests

Local

## Risk

Low. Changes are isolated to the Clari Copilot internal MCP server. Defaulting transcript to excluded is a behavioral change for existing agents using `get_call_details` — they will no longer receive the transcript unless they pass `include_transcript: true`.

## Deploy Plan

Deploy front.
