### PR TITLE
Treat client errors as 400s in unhandledErrorHandler

### DIFF
--- a/front-api/middlewares/utils.ts
+++ b/front-api/middlewares/utils.ts
@@ -5,10 +5,12 @@ import tracer from "@app/logger/tracer";
 import { getSequelizeErrorDetails } from "@app/logger/withlogging";
 import type {
   APIErrorResponse,
+  APIErrorType,
   APIErrorWithContentfulStatusCode,
 } from "@app/types/error";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { Context, ErrorHandler, TypedResponse } from "hono";
+import { HTTPException } from "hono/http-exception";
 
 /**
  * Return type for a Hono JSON handler. Wraps the success body type with the
@@ -79,6 +81,35 @@ export function apiError(
  * throughput / latency metrics.
  */
 export const unhandledErrorHandler: ErrorHandler = (err, ctx) => {
+  // Hono throws `HTTPException` for client-facing errors raised inside the app
+  // before our handlers run — most notably the JSON body parse failure in
+  // `@hono/zod-validator` ("Malformed JSON in request body"). These are client
+  // mistakes (4xx), not server errors: log them at `info` and return their
+  // intended status instead of treating them as an unhandled 500.
+  if (err instanceof HTTPException) {
+    const type: APIErrorType =
+      err.status >= 500 ? "internal_server_error" : "invalid_request_error";
+
+    logger.info(
+      {
+        method: ctx.req.method,
+        route: ctx.req.routePath ?? ctx.req.path,
+        url: ctx.req.url,
+        statusCode: err.status,
+        error: { name: err.name, message: err.message },
+      },
+      "Client API Error"
+    );
+
+    getStatsDClient().increment("api_errors.count", 1, [
+      `method:${ctx.req.method}`,
+      `status_code:${err.status}`,
+      `error_type:${type}`,
+    ]);
+
+    return ctx.json({ error: { type, message: err.message } }, err.status);
+  }
+
   const error = normalizeError(err);
   const sequelizeDetails = getSequelizeErrorDetails(error);
 


### PR DESCRIPTION
## Description

  In front-api/middlewares/utils.ts, unhandledErrorHandler now special-cases HTTPException before the generic unhandled-error path:

  - Malformed JSON (and any other Hono HTTPException) no longer logs at error level. 4xx cases log at info as "Client API Error"; only genuine 5xx HTTPExceptions would keep the server-error type.
  - Returns the exception's intended status (e.g. 400 for malformed JSON) instead of forcing a 500.
  - statsd api_errors.count is emitted with the correct status_code and error_type (invalid_request_error for 4xx).

  So the /api/w/:wId/mcp/register malformed-body requests will now surface as info-level 400s rather than error-level 500s — matching the intent of the validator and keeping client mistakes out of your error stream.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
