### PR TITLE
[front] chore: drop `selectedSkillIds` skill fallback

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -168,7 +168,6 @@ app.post(
     const conversation = conversationRes.value;
 
     const selectedSkillIds = extractUniqueSkillIds(content);
-
     if (selectedSkillIds.length > 0) {
       const skills = await SkillResource.fetchByIds(auth, selectedSkillIds);
 

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -168,6 +168,7 @@ app.post(
     const conversation = conversationRes.value;
 
     const selectedSkillIds = extractUniqueSkillIds(content);
+
     if (selectedSkillIds.length > 0) {
       const skills = await SkillResource.fetchByIds(auth, selectedSkillIds);
 

--- a/front-api/routes/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/index.ts
@@ -246,13 +246,8 @@ app.post(
         }
       }
 
-      const inlineSelectedSkillIds = extractUniqueSkillIds(message.content);
-      // TODO(2026-05-04 aubin): Remove this fallback once all clients submit
-      // inline <skill ... /> tags instead of the legacy selectedSkillIds field.
-      const selectedSkillIds =
-        inlineSelectedSkillIds.length > 0
-          ? inlineSelectedSkillIds
-          : (message.context.selectedSkillIds ?? []);
+      const selectedSkillIds = extractUniqueSkillIds(message.content);
+
       if (selectedSkillIds.length > 0) {
         const skills = await SkillResource.fetchByIds(auth, selectedSkillIds);
 

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -371,13 +371,8 @@ async function handler(
           }
         }
 
-        const inlineSelectedSkillIds = extractUniqueSkillIds(message.content);
-        // TODO(2026-05-04 aubin): Remove this fallback once all clients submit
-        // inline <skill ... /> tags instead of the legacy selectedSkillIds field.
-        const selectedSkillIds =
-          inlineSelectedSkillIds.length > 0
-            ? inlineSelectedSkillIds
-            : (message.context.selectedSkillIds ?? []);
+        const selectedSkillIds = extractUniqueSkillIds(message.content);
+
         if (selectedSkillIds.length > 0) {
           const skills = await SkillResource.fetchByIds(auth, selectedSkillIds);
 

--- a/front/types/api/internal/assistant.ts
+++ b/front/types/api/internal/assistant.ts
@@ -30,7 +30,6 @@ export const MessageBaseSchema = z.object({
     profilePictureUrl: z.string().nullable(),
     clientSideMCPServerIds: z.array(z.string()).optional(),
     selectedMCPServerViewIds: z.array(z.string()).optional(),
-    selectedSkillIds: z.array(z.string()).optional(),
     originMessageId: z.string().optional(),
     origin: UserMessageOriginSchema.optional(),
   }),

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -136,7 +136,6 @@ export type UserMessageContext = {
   lastTriggerRunAt?: number | null;
   clientSideMCPServerIds?: string[];
   selectedMCPServerViewIds?: string[];
-  selectedSkillIds?: string[];
   apiKeyId?: number | null;
   authMethod?: string | null;
 };


### PR DESCRIPTION
## Description

This PR removes the legacy skill selection fallback that read `message.context.selectedSkillIds` when creating conversations.
Follow up on https://github.com/dust-tt/dust/pull/25140
Skills are now resolved only from inline `<skill ... />` tags in the message content, and the legacy `selectedSkillIds` field is removed from the internal message schema and `UserMessageContext` type.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
