### PR TITLE
[GDrive Sync] Filter incremental sync to due drives

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities/get_drives_to_sync.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/get_drives_to_sync.ts
@@ -2,9 +2,16 @@ import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/go
 import type { LightGoogleDrive } from "@connectors/connectors/google_drive/temporal/activities/common/types";
 import { getDrives } from "@connectors/connectors/google_drive/temporal/activities/common/utils";
 import { getAuthObject } from "@connectors/connectors/google_drive/temporal/utils";
-import { GoogleDriveFoldersModel } from "@connectors/lib/models/google_drive";
+import {
+  GoogleDriveFoldersModel,
+  GoogleDriveSyncTokenModel,
+} from "@connectors/lib/models/google_drive";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
+
+const GDRIVE_BASE_INCREMENTAL_SYNC_INTERVAL_MS = 5 * 60 * 1000;
+const GDRIVE_MAX_INCREMENTAL_SYNC_INTERVAL_MS = 20 * 60 * 1000;
+const GDRIVE_QUIET_DRIVE_BACKOFF_MULTIPLIER = 2;
 
 // Get the list of drives that have folders selected for sync.
 export async function getDrivesToSync(
@@ -46,5 +53,41 @@ export async function getDrivesToSync(
     }
   }
 
-  return Object.values(drives);
+  const drivesToSync = Object.values(drives);
+  if (drivesToSync.length === 0) {
+    return drivesToSync;
+  }
+
+  // Uses the existing unique (connectorId, driveId) index and only fetches
+  // sync tokens for selected drives.
+  const syncTokens = await GoogleDriveSyncTokenModel.findAll({
+    attributes: ["driveId", "lastSyncAt", "lastRelevantChangeAt"],
+    where: {
+      connectorId,
+      driveId: drivesToSync.map((drive) => drive.id),
+    },
+  });
+  const syncTokenByDriveId = new Map(
+    syncTokens.map((syncToken) => [syncToken.driveId, syncToken])
+  );
+  const nowMs = Date.now();
+
+  return drivesToSync.filter((drive) => {
+    const syncToken = syncTokenByDriveId.get(drive.id);
+    if (!syncToken?.lastSyncAt || !syncToken.lastRelevantChangeAt) {
+      return true;
+    }
+
+    const intervalMs = Math.min(
+      Math.max(
+        GDRIVE_QUIET_DRIVE_BACKOFF_MULTIPLIER *
+          (syncToken.lastSyncAt.getTime() -
+            syncToken.lastRelevantChangeAt.getTime()),
+        GDRIVE_BASE_INCREMENTAL_SYNC_INTERVAL_MS
+      ),
+      GDRIVE_MAX_INCREMENTAL_SYNC_INTERVAL_MS
+    );
+
+    return nowMs - syncToken.lastSyncAt.getTime() >= intervalMs;
+  });
 }

--- a/connectors/src/connectors/google_drive/temporal/activities/get_drives_to_sync.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/get_drives_to_sync.ts
@@ -28,7 +28,7 @@ export async function getDrivesToSync(
   }
   const allSharedDrives = await getDrives(connectorId);
   const authCredentials = await getAuthObject(connector.connectionId);
-  const drives: Record<string, LightGoogleDrive> = {};
+  const drivesById: Record<string, LightGoogleDrive> = {};
 
   for (const folder of selectedFolders) {
     const remoteFolder = await getGoogleDriveObject({
@@ -44,7 +44,7 @@ export async function getDrivesToSync(
       // so we need to filter them out.
       // This is the case for files "shared with me" for example.
       if (allSharedDrives.find((d) => d.id === remoteFolder.driveId)) {
-        drives[remoteFolder.driveId] = {
+        drivesById[remoteFolder.driveId] = {
           id: remoteFolder.driveId,
           name: remoteFolder.name,
           isSharedDrive: remoteFolder.isInSharedDrive,
@@ -53,41 +53,52 @@ export async function getDrivesToSync(
     }
   }
 
-  const drivesToSync = Object.values(drives);
-  if (drivesToSync.length === 0) {
-    return drivesToSync;
-  }
+  const drives = Object.values(drivesById);
 
-  // Uses the existing unique (connectorId, driveId) index and only fetches
-  // sync tokens for selected drives.
-  const syncTokens = await GoogleDriveSyncTokenModel.findAll({
-    attributes: ["driveId", "lastSyncAt", "lastRelevantChangeAt"],
-    where: {
-      connectorId,
-      driveId: drivesToSync.map((drive) => drive.id),
-    },
-  });
-  const syncTokenByDriveId = new Map(
-    syncTokens.map((syncToken) => [syncToken.driveId, syncToken])
-  );
-  const nowMs = Date.now();
+  return filterDrivesByRecentChanges(drives);
 
-  return drivesToSync.filter((drive) => {
-    const syncToken = syncTokenByDriveId.get(drive.id);
-    if (!syncToken?.lastSyncAt || !syncToken.lastRelevantChangeAt) {
-      return true;
+  async function filterDrivesByRecentChanges(
+    drives: LightGoogleDrive[]
+  ): Promise<LightGoogleDrive[]> {
+    if (drives.length === 0) {
+      return drives;
     }
 
-    const intervalMs = Math.min(
-      Math.max(
-        GDRIVE_QUIET_DRIVE_BACKOFF_MULTIPLIER *
-          (syncToken.lastSyncAt.getTime() -
-            syncToken.lastRelevantChangeAt.getTime()),
-        GDRIVE_BASE_INCREMENTAL_SYNC_INTERVAL_MS
-      ),
-      GDRIVE_MAX_INCREMENTAL_SYNC_INTERVAL_MS
+    // Drives with no adaptive state must sync once. Otherwise, quiet drives
+    // back off to twice the age of their last relevant change, clamped between
+    // the base and max intervals. A relevant change resets both timestamps, so
+    // the next interval returns to the base cadence.
+    const syncTokens = await GoogleDriveSyncTokenModel.findAll({
+      attributes: ["driveId", "lastSyncAt", "lastRelevantChangeAt"],
+      where: {
+        connectorId,
+        driveId: drives.map((drive) => drive.id),
+      },
+    });
+    const syncTokenByDriveId = new Map(
+      syncTokens.map((syncToken) => [syncToken.driveId, syncToken])
     );
+    const nowMs = Date.now();
 
-    return nowMs - syncToken.lastSyncAt.getTime() >= intervalMs;
-  });
+    const isDriveDueForIncrementalSync = (drive: LightGoogleDrive) => {
+      const syncToken = syncTokenByDriveId.get(drive.id);
+      if (!syncToken?.lastSyncAt || !syncToken.lastRelevantChangeAt) {
+        return true;
+      }
+
+      const intervalMs = Math.min(
+        Math.max(
+          GDRIVE_QUIET_DRIVE_BACKOFF_MULTIPLIER *
+            (syncToken.lastSyncAt.getTime() -
+              syncToken.lastRelevantChangeAt.getTime()),
+          GDRIVE_BASE_INCREMENTAL_SYNC_INTERVAL_MS
+        ),
+        GDRIVE_MAX_INCREMENTAL_SYNC_INTERVAL_MS
+      );
+
+      return nowMs - syncToken.lastSyncAt.getTime() >= intervalMs;
+    };
+
+    return drives.filter(isDriveDueForIncrementalSync);
+  }
 }

--- a/connectors/src/connectors/google_drive/temporal/activities/get_drives_to_sync.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/get_drives_to_sync.ts
@@ -1,6 +1,7 @@
 import { getGoogleDriveObject } from "@connectors/connectors/google_drive/lib/google_drive_api";
 import type { LightGoogleDrive } from "@connectors/connectors/google_drive/temporal/activities/common/types";
 import { getDrives } from "@connectors/connectors/google_drive/temporal/activities/common/utils";
+import { GDRIVE_INCREMENTAL_SYNC_INTERVAL_MS } from "@connectors/connectors/google_drive/temporal/config";
 import { getAuthObject } from "@connectors/connectors/google_drive/temporal/utils";
 import {
   GoogleDriveFoldersModel,
@@ -9,9 +10,11 @@ import {
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
 
-const GDRIVE_BASE_INCREMENTAL_SYNC_INTERVAL_MS = 5 * 60 * 1000;
-const GDRIVE_MAX_INCREMENTAL_SYNC_INTERVAL_MS = 20 * 60 * 1000;
 const GDRIVE_QUIET_DRIVE_BACKOFF_MULTIPLIER = 2;
+const GDRIVE_MAX_INCREMENTAL_SYNC_INTERVAL_MULTIPLIER = 4;
+const GDRIVE_MAX_INCREMENTAL_SYNC_INTERVAL_MS =
+  GDRIVE_MAX_INCREMENTAL_SYNC_INTERVAL_MULTIPLIER *
+  GDRIVE_INCREMENTAL_SYNC_INTERVAL_MS;
 
 // Get the list of drives that have folders selected for sync.
 export async function getDrivesToSync(
@@ -57,12 +60,12 @@ export async function getDrivesToSync(
 
   return filterDrivesByRecentChanges(drives);
 
+  // Drive syncs are adaptive: drives with few changes sync less often. For
+  // example, if a drive synced 5 minutes ago and had no relevant changes, we
+  // skip it this time. The maximum wait is still bounded.
   async function filterDrivesByRecentChanges(
     drives: LightGoogleDrive[]
   ): Promise<LightGoogleDrive[]> {
-    // Drive syncs are adaptive: drives with few changes sync less often. For
-    // example, if a drive synced 5 minutes ago and had no relevant changes, we
-    // skip it this time. The maximum wait is still bounded.
     if (drives.length === 0) {
       return drives;
     }
@@ -90,7 +93,7 @@ export async function getDrivesToSync(
           GDRIVE_QUIET_DRIVE_BACKOFF_MULTIPLIER *
             (syncToken.lastSyncAt.getTime() -
               syncToken.lastRelevantChangeAt.getTime()),
-          GDRIVE_BASE_INCREMENTAL_SYNC_INTERVAL_MS
+          GDRIVE_INCREMENTAL_SYNC_INTERVAL_MS
         ),
         GDRIVE_MAX_INCREMENTAL_SYNC_INTERVAL_MS
       );

--- a/connectors/src/connectors/google_drive/temporal/activities/get_drives_to_sync.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/get_drives_to_sync.ts
@@ -60,14 +60,13 @@ export async function getDrivesToSync(
   async function filterDrivesByRecentChanges(
     drives: LightGoogleDrive[]
   ): Promise<LightGoogleDrive[]> {
+    // Drive syncs are adaptive: drives with few changes sync less often. For
+    // example, if a drive synced 5 minutes ago and had no relevant changes, we
+    // skip it this time. The maximum wait is still bounded.
     if (drives.length === 0) {
       return drives;
     }
 
-    // Drives with no adaptive state must sync once. Otherwise, quiet drives
-    // back off to twice the age of their last relevant change, clamped between
-    // the base and max intervals. A relevant change resets both timestamps, so
-    // the next interval returns to the base cadence.
     const syncTokens = await GoogleDriveSyncTokenModel.findAll({
       attributes: ["driveId", "lastSyncAt", "lastRelevantChangeAt"],
       where: {

--- a/connectors/src/connectors/google_drive/temporal/config.ts
+++ b/connectors/src/connectors/google_drive/temporal/config.ts
@@ -3,5 +3,7 @@ const GDRIVE_INCREMENTAL_SYNC_QUEUE_VERSION = 9;
 export const GDRIVE_FULL_SYNC_QUEUE_NAME = `google-queue-fullsync-v${GDRIVE_FULL_SYNC_QUEUE_VERSION}`;
 export const GDRIVE_INCREMENTAL_SYNC_QUEUE_NAME = `google-queue-incremental-v${GDRIVE_INCREMENTAL_SYNC_QUEUE_VERSION}`;
 
+export const GDRIVE_INCREMENTAL_SYNC_INTERVAL_MS = 5 * 60 * 1000;
+
 // Maximum number of folders to sync in parallel for parallel sync workflows.
 export const GDRIVE_MAX_CONCURRENT_FOLDER_SYNCS = 5;

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -18,7 +18,10 @@ import uniq from "lodash/uniq";
 
 import { concurrentExecutor } from "../../../lib/async_utils";
 import { GOOGLE_DRIVE_USER_SPACE_VIRTUAL_DRIVE_ID } from "../lib/consts";
-import { GDRIVE_MAX_CONCURRENT_FOLDER_SYNCS } from "./config";
+import {
+  GDRIVE_INCREMENTAL_SYNC_INTERVAL_MS,
+  GDRIVE_MAX_CONCURRENT_FOLDER_SYNCS,
+} from "./config";
 import { folderUpdatesSignal } from "./signals";
 
 const {
@@ -297,7 +300,7 @@ export async function googleDriveIncrementalSync(
 
   await syncSucceeded(connectorId);
 
-  await sleep("10 minutes");
+  await sleep(GDRIVE_INCREMENTAL_SYNC_INTERVAL_MS);
   await continueAsNew<typeof googleDriveIncrementalSync>(connectorId);
 }
 
@@ -799,6 +802,6 @@ export async function googleDriveIncrementalSyncV2(
   await syncSucceeded(connectorId);
 
   // Sleep and continue
-  await sleep("10 minutes");
+  await sleep(GDRIVE_INCREMENTAL_SYNC_INTERVAL_MS);
   await continueAsNew<typeof googleDriveIncrementalSyncV2>(connectorId);
 }


### PR DESCRIPTION
## Description
Related to https://github.com/dust-tt/tasks/issues/8240.
Design: https://github.com/dust-tt/tasks/issues/8240#issuecomment-4553591132
Design update: https://github.com/dust-tt/tasks/issues/8240#issuecomment-4553695325
Follows https://github.com/dust-tt/dust/pull/26259

Adds adaptive due-drive filtering inside `getDrivesToSync`. The activity still builds the selected shared-drive list as before, then fetches the corresponding `google_drive_sync_tokens` rows and filters out drives that are still inside their adaptive quiet interval.

The workflow cadence is now a shared 5-minute constant used by both the workflow sleep and the activity filter. The adaptive interval is `2 * (lastSyncAt - lastRelevantChangeAt)`, clamped between one workflow interval and four workflow intervals. Missing timestamps still mean sync now.

This intentionally leaves a few edge cases unchanged to keep the PR small:
- Userspace is still appended by the workflow after `getDrivesToSync`, so it remains synced every coordinator cycle. Userspace is a minority case and can be handled separately if it matters.
- If no selected shared drive is due, the workflow still starts/completes a sync cycle and syncs userspace. This creates a little status churn, but keeps behavior close to today.
- GC still runs when `shouldGarbageCollect` says to run. That is acceptable because GC does not blindly delete stale `lastSeenTs` rows: it refetches each candidate from Google, deletes only 404/trashed/no-longer-selected files, and refreshes `lastSeenTs` for files that still exist in selected folders. The downside is possible extra scan work on rare GC cycles, not incorrect deletion.
- V1 also uses `getDrivesToSync`, so it gets the same filtering. We are leaving that as-is because V1 is unused and will be removed in a follow-up PR.

## Risks
Blast radius: Google Drive selected shared-drive incremental sync cadence.
Risk: standard

## Deploy Plan
- pmrr
- deploy connectors

## Test
- [x] `npx biome ci connectors/src/connectors/google_drive/temporal/activities/get_drives_to_sync.ts connectors/src/connectors/google_drive/temporal/workflows.ts connectors/src/connectors/google_drive/temporal/config.ts`
- [x] local test, see below