### PR TITLE
[front] fix: guard against undefined regionalAvailability

### DIFF
--- a/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
+++ b/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
@@ -121,7 +121,7 @@ export function ModelSelectionSubmenu({ models }: ModelSelectionSubmenuProps) {
                   isDark={isDark}
                   onModelSelection={handleModelSelection}
                   regionalComponent={
-                    selectedModel.regionalAvailability[regionInfo.name]
+                    selectedModel.regionalAvailability?.[regionInfo.name]
                       ? flag
                       : null
                   }
@@ -139,7 +139,7 @@ export function ModelSelectionSubmenu({ models }: ModelSelectionSubmenuProps) {
                 isDark={isDark}
                 onModelSelection={handleModelSelection}
                 regionalComponent={
-                  modelConfig.regionalAvailability[regionInfo.name]
+                  modelConfig.regionalAvailability?.[regionInfo.name]
                     ? flag
                     : null
                 }
@@ -169,7 +169,7 @@ export function ModelSelectionSubmenu({ models }: ModelSelectionSubmenuProps) {
                               isDark={isDark}
                               onModelSelection={handleModelSelection}
                               regionalComponent={
-                                modelConfig.regionalAvailability[
+                                modelConfig.regionalAvailability?.[
                                   regionInfo.name
                                 ]
                                   ? flag
@@ -195,7 +195,7 @@ export function ModelSelectionSubmenu({ models }: ModelSelectionSubmenuProps) {
                               isDark={isDark}
                               onModelSelection={handleModelSelection}
                               regionalComponent={
-                                modelConfig.regionalAvailability[
+                                modelConfig.regionalAvailability?.[
                                   regionInfo.name
                                 ]
                                   ? flag

--- a/front/lib/api/assistant/workspace_capabilities.ts
+++ b/front/lib/api/assistant/workspace_capabilities.ts
@@ -74,7 +74,7 @@ export async function listActiveAgentsUsingNonRegionalModels(
   // still-supported models no longer surfaced in the picker.
   const regionalModelKeys = new Set<string>();
   for (const m of SUPPORTED_MODEL_CONFIGS) {
-    if (m.regionalAvailability[region] === true) {
+    if (m.regionalAvailability?.[region] === true) {
       regionalModelKeys.add(`${m.providerId}:${m.modelId}`);
     }
   }

--- a/front/lib/assistant.test.ts
+++ b/front/lib/assistant.test.ts
@@ -2,6 +2,7 @@ import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
 import type { RegionType } from "@app/lib/api/regions/config";
 import {
   filterCustomAvailableAndWhitelistedModels,
+  isModelAvailable,
   isModelCustomAvailable,
 } from "@app/lib/assistant";
 import { Authenticator } from "@app/lib/auth";
@@ -365,6 +366,78 @@ describe("isModelCustomAvailable", () => {
         region: TEST_REGION,
       })
     ).toBe(false);
+  });
+});
+
+describe("isModelAvailable regional availability", () => {
+  it("returns false (instead of throwing) when regionalModelsOnly is set and the model has no regionalAvailability", () => {
+    // Custom models loaded from GCS are parsed with ModelConfigurationSchema,
+    // which omits regionalAvailability, so the field is undefined at runtime.
+    const model = createMockModel({
+      regionalAvailability: undefined,
+      availableIfOneOf: undefined,
+    });
+    const owner = LightWorkspaceFactory.build({ regionalModelsOnly: true });
+
+    expect(
+      isModelAvailable(model, {
+        featureFlags: [],
+        plan: null,
+        owner,
+        region: TEST_REGION,
+      })
+    ).toBe(false);
+  });
+
+  it("returns true when regionalModelsOnly is set and the model is available in the region", () => {
+    const model = createMockModel({
+      regionalAvailability: { "us-central1": true, "europe-west1": false },
+      availableIfOneOf: undefined,
+    });
+    const owner = LightWorkspaceFactory.build({ regionalModelsOnly: true });
+
+    expect(
+      isModelAvailable(model, {
+        featureFlags: [],
+        plan: null,
+        owner,
+        region: TEST_REGION,
+      })
+    ).toBe(true);
+  });
+
+  it("returns false when regionalModelsOnly is set and the model is not available in the region", () => {
+    const model = createMockModel({
+      regionalAvailability: { "us-central1": false, "europe-west1": true },
+      availableIfOneOf: undefined,
+    });
+    const owner = LightWorkspaceFactory.build({ regionalModelsOnly: true });
+
+    expect(
+      isModelAvailable(model, {
+        featureFlags: [],
+        plan: null,
+        owner,
+        region: TEST_REGION,
+      })
+    ).toBe(false);
+  });
+
+  it("ignores regional availability when regionalModelsOnly is not set", () => {
+    const model = createMockModel({
+      regionalAvailability: undefined,
+      availableIfOneOf: undefined,
+    });
+    const owner = LightWorkspaceFactory.build({ regionalModelsOnly: false });
+
+    expect(
+      isModelAvailable(model, {
+        featureFlags: [],
+        plan: null,
+        owner,
+        region: TEST_REGION,
+      })
+    ).toBe(true);
   });
 });
 

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -39,7 +39,7 @@ export function isModelAvailable(
     return false;
   }
 
-  if (owner.regionalModelsOnly && m.regionalAvailability[region] !== true) {
+  if (owner.regionalModelsOnly && m.regionalAvailability?.[region] !== true) {
     return false;
   }
 

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -80,7 +80,7 @@ export type ModelConfigurationType = Omit<
   modelId: ModelIdType;
   defaultReasoningEffort: ReasoningEffort;
   // Specify if the model is available in specific regions.
-  regionalAvailability: Record<RegionType, boolean>;
+  regionalAvailability?: Record<RegionType, boolean>;
   // If undefined, model is available.
   // If object is empty, model is not available.
   // If defined, model must satisfy one of the conditions to be available.


### PR DESCRIPTION
## Description

Make regionalAvailability optional on ModelConfigurationType so the type reflects reality, and guard all readers with optional chaining. Add tests covering the regional availability branch of isModelAvailable.
## Tests

Unit
## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

front
