### PR TITLE
Fix invalid URL from members-usage endpoint

### DIFF
--- a/front/pages/api/w/[wId]/credits/members-usage.ts
+++ b/front/pages/api/w/[wId]/credits/members-usage.ts
@@ -44,7 +44,7 @@ async function handler(
       const body = await getMembersUsage({
         auth,
         paginationParams: paginationRes.data,
-        currentUrl: req.url ?? "/",
+        currentUrl: `https://${req.headers.host}${req.url ?? "/"}`,
       });
 
       return res.status(200).json(body);


### PR DESCRIPTION
## Description

In the (legacy) Next.js handler for `GET /api/w/[wId]/credits/members-usage`, `req.url` only contains the path portion (e.g. `/api/w/.../credits/members-usage?...`), so `buildUrlWithParams` was building a relative `nextPageUrl` that the client couldn't follow as an absolute URL. This fixes the issue by constructing a full URL using `req.headers.host`.

Note: the Hono version of this endpoint (`front-api/routes/...`) already handles this correctly since `ctx.req.url` is a full absolute URL.

## Tests

Tested by verifying the `nextPageUrl` in the response is a valid absolute URL when paginating through the members usage table.

## Risk

Low — one-line fix in a recently added endpoint; no schema or API contract changes.

## Deploy Plan

Deploy `front`.