### PR TITLE
[LLM] Merge parallel Gemini function responses into one turn

### DIFF
--- a/front/lib/api/llm/clients/google/index.ts
+++ b/front/lib/api/llm/clients/google/index.ts
@@ -5,7 +5,7 @@ import {
   overwriteLLMParameters,
 } from "@app/lib/api/llm/clients/google/types";
 import {
-  toContent,
+  toContents,
   toTool,
 } from "@app/lib/api/llm/clients/google/utils/conversation_to_google";
 import {
@@ -123,10 +123,9 @@ export class GoogleLLM extends LLM<GoogleGenerateContentRequestParams> {
     payload: GoogleGenerateContentRequestParams
   ): AsyncGenerator<LLMEvent> {
     try {
-      const contents = await Promise.all(
-        payload.conversation.messages.map((message) =>
-          toContent(message, this.modelId)
-        )
+      const contents = await toContents(
+        payload.conversation.messages,
+        this.modelId
       );
 
       const generateContentResponses =
@@ -194,10 +193,7 @@ export class GoogleLLM extends LLM<GoogleGenerateContentRequestParams> {
       specifications,
       forceToolCall,
     } of params) {
-      const contents = [];
-      for (const message of conversation.messages) {
-        contents.push(await toContent(message, this.modelId));
-      }
+      const contents = await toContents(conversation.messages, this.modelId);
       inlinedRequests.push({
         contents,
         config: this.buildGenerateContentConfig(

--- a/front/lib/api/llm/clients/google/utils/conversation_to_google.ts
+++ b/front/lib/api/llm/clients/google/utils/conversation_to_google.ts
@@ -2,6 +2,7 @@ import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { EventError } from "@app/lib/api/llm/types/events";
 import { extractEncryptedContentFromMetadata } from "@app/lib/api/llm/utils";
 import { parseToolArguments } from "@app/lib/api/llm/utils/tool_arguments";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type {
   AgentFunctionCallContentType,
   AgentReasoningContentType,
@@ -20,6 +21,8 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import { trustedFetchImageBase64 } from "@app/types/shared/utils/image_utils";
 import type { Content, FunctionResponse, Part, Tool } from "@google/genai";
 import assert from "assert";
+
+const MESSAGE_CONVERSION_CONCURRENCY = 10;
 
 const GOOGLE_AI_STUDIO_SUPPORTED_MIME_TYPES = [
   "image/png",
@@ -190,6 +193,45 @@ export function toTool(specification: AgentActionSpecification): Tool {
       },
     ],
   };
+}
+
+function isFunctionResponseContent(content: Content): boolean {
+  const parts = content.parts ?? [];
+  return (
+    content.role === "user" &&
+    parts.length > 0 &&
+    parts.every((part) => part.functionResponse !== undefined)
+  );
+}
+
+// Merge consecutive function-response Contents into one user turn: Gemini requires the
+// functionResponse part count to match the functionCall count of the preceding model turn.
+export async function toContents(
+  messages: ModelMessageTypeMultiActionsWithoutContentFragment[],
+  modelId: ModelIdType
+): Promise<Content[]> {
+  const contents = await concurrentExecutor(
+    messages,
+    (message) => toContent(message, modelId),
+    { concurrency: MESSAGE_CONVERSION_CONCURRENCY }
+  );
+
+  return contents.reduce<Content[]>((merged, content) => {
+    const previous = merged[merged.length - 1];
+    if (
+      previous &&
+      isFunctionResponseContent(previous) &&
+      isFunctionResponseContent(content)
+    ) {
+      merged[merged.length - 1] = {
+        ...previous,
+        parts: [...(previous.parts ?? []), ...(content.parts ?? [])],
+      };
+      return merged;
+    }
+
+    return [...merged, content];
+  }, []);
 }
 
 /**

--- a/front/lib/api/llm/clients/google/utils/test/conversation_to_google.test.ts
+++ b/front/lib/api/llm/clients/google/utils/test/conversation_to_google.test.ts
@@ -1,4 +1,7 @@
-import { toContent } from "@app/lib/api/llm/clients/google/utils/conversation_to_google";
+import {
+  toContent,
+  toContents,
+} from "@app/lib/api/llm/clients/google/utils/conversation_to_google";
 import type { ModelMessageTypeMultiActionsWithoutContentFragment } from "@app/types/assistant/generation";
 import { GEMINI_2_5_PRO_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
 import { trustedFetchImageBase64 } from "@app/types/shared/utils/image_utils";
@@ -17,6 +20,113 @@ describe("toContent", () => {
 
       expect(messages).toEqual(expectedGoogleMessages);
     });
+  });
+});
+
+describe("toContents", () => {
+  it("should merge parallel tool results into a single user turn.", async () => {
+    const messages: ModelMessageTypeMultiActionsWithoutContentFragment[] = [
+      {
+        role: "assistant",
+        function_calls: [
+          { id: "call_1", name: "tool_a", arguments: "{}" },
+          { id: "call_2", name: "tool_b", arguments: "{}" },
+        ],
+        content: "",
+        contents: [
+          {
+            type: "function_call",
+            value: { id: "call_1", name: "tool_a", arguments: "{}" },
+          },
+          {
+            type: "function_call",
+            value: { id: "call_2", name: "tool_b", arguments: "{}" },
+          },
+        ],
+      },
+      {
+        role: "function",
+        name: "tool_a",
+        function_call_id: "call_1",
+        content: "result a",
+      },
+      {
+        role: "function",
+        name: "tool_b",
+        function_call_id: "call_2",
+        content: "result b",
+      },
+    ];
+
+    const result = await toContents(messages, GEMINI_2_5_PRO_MODEL_ID);
+
+    // The model turn has 2 functionCall parts, so the following user turn must
+    // hold both functionResponse parts (Gemini enforces equal counts).
+    expect(result).toEqual([
+      {
+        role: "model",
+        parts: [
+          { functionCall: { id: "call_1", name: "tool_a", args: {} } },
+          { functionCall: { id: "call_2", name: "tool_b", args: {} } },
+        ],
+      },
+      {
+        role: "user",
+        parts: [
+          {
+            functionResponse: {
+              response: { output: "result a" },
+              name: "tool_a",
+              id: "call_1",
+            },
+          },
+          {
+            functionResponse: {
+              response: { output: "result b" },
+              name: "tool_b",
+              id: "call_2",
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("should not merge a regular user message into function responses.", async () => {
+    const messages: ModelMessageTypeMultiActionsWithoutContentFragment[] = [
+      {
+        role: "function",
+        name: "tool_a",
+        function_call_id: "call_1",
+        content: "result a",
+      },
+      {
+        role: "user",
+        name: "Someone",
+        content: [{ type: "text", text: "follow-up" }],
+      },
+    ];
+
+    const result = await toContents(messages, GEMINI_2_5_PRO_MODEL_ID);
+
+    expect(result).toEqual([
+      {
+        role: "user",
+        parts: [
+          {
+            functionResponse: {
+              response: { output: "result a" },
+              name: "tool_a",
+              id: "call_1",
+            },
+          },
+        ],
+      },
+      {
+        role: "user",
+        parts: [{ text: "follow-up" }],
+      },
+    ]);
   });
 });
 


### PR DESCRIPTION
## Description

Fix Gemini `400 INVALID_ARGUMENT` on parallel tool calls by merging consecutive
function-response Contents into a single user turn.

## Tests

Unit tests added; suite passes.

## Risk

Low, isolated to Google client. Safe to roll back.

## Deploy Plan

- Standard deploy, no migration needed