### PR TITLE
Allow switch from stripe to metronome

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
@@ -9,7 +9,10 @@ import {
   CREDIT_PRICED_BUSINESS_PLAN_CODE,
   PRO_PLAN_SEAT_29_CODE,
 } from "@app/lib/plans/plan_codes";
-import { getStripeCustomer } from "@app/lib/plans/stripe";
+import {
+  getStripeCustomer,
+  scheduleSubscriptionCancellation,
+} from "@app/lib/plans/stripe";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
@@ -59,6 +62,7 @@ vi.mock("@app/lib/plans/stripe", async () => {
   return {
     ...actual,
     getStripeCustomer: vi.fn(),
+    scheduleSubscriptionCancellation: vi.fn(),
   };
 });
 
@@ -488,19 +492,36 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — guards", () => {
     expect(data.error.message).toContain("does not match");
   });
 
-  it("rejects when the workspace is Stripe-billed", async () => {
+  it("schedules the Stripe subscription to cancel at the swap moment when the workspace is Stripe-billed", async () => {
+    const STRIPE_SUB_ID = "sub_stripe_xxx";
     const { workspace } = await createPrivateApiMockRequest({
       isSuperUser: true,
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID, {
-      stripeSubscriptionId: "sub_stripe_xxx",
+      stripeSubscriptionId: STRIPE_SUB_ID,
     });
 
     const response = await postSwitchContract(workspace.sId, proBody());
 
-    expect(response.status).toBe(400);
-    const data = await response.json();
-    expect(data.error.message).toContain("Metronome-billed");
+    expect(response.status).toBe(200);
+    expect(scheduleSubscriptionCancellation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stripeSubscriptionId: STRIPE_SUB_ID,
+        cancelAt: expect.any(Date),
+      })
+    );
+  });
+
+  it("does not call scheduleSubscriptionCancellation when the workspace has no Stripe subscription", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
+
+    const response = await postSwitchContract(workspace.sId, proBody());
+
+    expect(response.status).toBe(200);
+    expect(scheduleSubscriptionCancellation).not.toHaveBeenCalled();
   });
 });
 

--- a/front-api/routes/poke/workspaces/[wId]/switch_contract.ts
+++ b/front-api/routes/poke/workspaces/[wId]/switch_contract.ts
@@ -27,7 +27,10 @@ import {
   isProPlanPrefix,
   PRO_PLAN_SEAT_39_CODE,
 } from "@app/lib/plans/plan_codes";
-import { getStripeCustomer } from "@app/lib/plans/stripe";
+import {
+  getStripeCustomer,
+  scheduleSubscriptionCancellation,
+} from "@app/lib/plans/stripe";
 import { PluginRunResource } from "@app/lib/resources/plugin_run_resource";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
@@ -138,14 +141,14 @@ app.post(
     const body = validation.data;
 
     // Workspace must be Metronome-billed (current sub Metronome-only) or
-    // freshly Metronome-eligible (Metronome billing enabled + no Stripe sub).
+    // Metronome-eligible (Metronome billing enabled). Stripe-billed workspaces
+    // that have opted into Metronome billing land here too — their Stripe sub
+    // is scheduled to end at the swap time further down.
     const currentSubscription = auth.subscriptionResource();
     const isCurrentlyMetronomeOnlyBilled =
       currentSubscription?.isMetronomeOnlyBilled ?? false;
     const metronomeBillingEnabled = await isMetronomeBillingEnabled(auth);
-    const canStartFreshMetronomeContract =
-      metronomeBillingEnabled && !currentSubscription?.stripeSubscriptionId;
-    if (!isCurrentlyMetronomeOnlyBilled && !canStartFreshMetronomeContract) {
+    if (!isCurrentlyMetronomeOnlyBilled && !metronomeBillingEnabled) {
       const errorMessage =
         "switch_contract is only available for Metronome-billed workspaces. " +
         "Migrate the workspace to Metronome billing before invoking this flow.";
@@ -338,6 +341,33 @@ app.post(
         status_code: 502,
         api_error: { type: "internal_server_error", message: errorMessage },
       });
+    }
+
+    // If the workspace is currently Stripe-billed (incl. shadow-Metronome),
+    // schedule the Stripe sub to cancel at the swap moment so the two rails
+    // don't double-bill.
+    const stripeSubscriptionIdToCancel =
+      currentSubscription?.stripeSubscriptionId ?? null;
+    if (stripeSubscriptionIdToCancel) {
+      try {
+        await scheduleSubscriptionCancellation({
+          stripeSubscriptionId: stripeSubscriptionIdToCancel,
+          cancelAt: alignedStart,
+        });
+      } catch (err) {
+        const errorMessage =
+          `Provisioned Metronome contract ${metronomeContractId} and pending ` +
+          `subscription, but failed to schedule cancellation of Stripe ` +
+          `subscription ${stripeSubscriptionIdToCancel}: ` +
+          `${err instanceof Error ? err.message : String(err)}. ` +
+          `URGENT: cancel the Stripe subscription manually at ${alignedStart.toISOString()} ` +
+          "to avoid double-billing.";
+        await pluginRun.recordError(errorMessage);
+        return apiError(ctx, {
+          status_code: 502,
+          api_error: { type: "internal_server_error", message: errorMessage },
+        });
+      }
     }
 
     // Ensure the workspace has a WorkOS organization for any paid tier.

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -890,6 +890,28 @@ export async function cancelSubscriptionImmediatelyNoInvoice({
 }
 
 /**
+ * Schedule a subscription to cancel at a future timestamp. Used by the
+ * switch_contract flow when migrating a Stripe-billed workspace to Metronome:
+ * the Stripe sub stops at the new Metronome contract's start time, so the two
+ * rails don't double-bill. Prorations at cancellation follow the subscription's
+ * existing proration settings (default: a credit for the unused portion).
+ */
+export async function scheduleSubscriptionCancellation({
+  stripeSubscriptionId,
+  cancelAt,
+}: {
+  stripeSubscriptionId: string;
+  cancelAt: Date;
+}) {
+  const stripe = getStripeClient();
+  await stripe.subscriptions.update(stripeSubscriptionId, {
+    cancel_at: Math.floor(cancelAt.getTime() / 1000),
+  });
+
+  return true;
+}
+
+/**
  * Creates a new Stripe Business subscription for upgrading Pro → Business.
  * The old subscription is cancelled separately after the DB flip.
  */

--- a/front/pages/api/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front/pages/api/poke/workspaces/[wId]/switch_contract.test.ts
@@ -9,7 +9,10 @@ import {
   CREDIT_PRICED_BUSINESS_PLAN_CODE,
   PRO_PLAN_SEAT_29_CODE,
 } from "@app/lib/plans/plan_codes";
-import { getStripeCustomer } from "@app/lib/plans/stripe";
+import {
+  getStripeCustomer,
+  scheduleSubscriptionCancellation,
+} from "@app/lib/plans/stripe";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
@@ -62,6 +65,7 @@ vi.mock("@app/lib/plans/stripe", async () => {
   return {
     ...actual,
     getStripeCustomer: vi.fn(),
+    scheduleSubscriptionCancellation: vi.fn(),
   };
 });
 
@@ -206,6 +210,7 @@ beforeEach(() => {
   vi.mocked(provisionMetronomeContract).mockResolvedValue(
     new Ok({ metronomeContractId: NEW_CONTRACT_ID })
   );
+  vi.mocked(scheduleSubscriptionCancellation).mockResolvedValue(true);
 });
 
 describe("POST /api/poke/workspaces/[wId]/switch_contract — Enterprise", () => {
@@ -514,13 +519,14 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — guards", () => {
     expect(res._getJSONData().error.message).toContain("does not match");
   });
 
-  it("rejects when the workspace is Stripe-billed", async () => {
+  it("schedules the Stripe subscription to cancel at the swap moment when the workspace is Stripe-billed", async () => {
+    const STRIPE_SUB_ID = "sub_stripe_xxx";
     const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "POST",
       isSuperUser: true,
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID, {
-      stripeSubscriptionId: "sub_stripe_xxx",
+      stripeSubscriptionId: STRIPE_SUB_ID,
     });
 
     req.body = proBody();
@@ -528,8 +534,29 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — guards", () => {
 
     await handler(req, res);
 
-    expect(res._getStatusCode()).toBe(400);
-    expect(res._getJSONData().error.message).toContain("Metronome-billed");
+    expect(res._getStatusCode()).toBe(200);
+    expect(scheduleSubscriptionCancellation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stripeSubscriptionId: STRIPE_SUB_ID,
+        cancelAt: expect.any(Date),
+      })
+    );
+  });
+
+  it("does not call scheduleSubscriptionCancellation when the workspace has no Stripe subscription", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
+
+    req.body = proBody();
+    req.query.wId = workspace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(scheduleSubscriptionCancellation).not.toHaveBeenCalled();
   });
 });
 

--- a/front/pages/api/poke/workspaces/[wId]/switch_contract.ts
+++ b/front/pages/api/poke/workspaces/[wId]/switch_contract.ts
@@ -32,7 +32,10 @@ import {
   isProPlanPrefix,
   PRO_PLAN_SEAT_39_CODE,
 } from "@app/lib/plans/plan_codes";
-import { getStripeCustomer } from "@app/lib/plans/stripe";
+import {
+  getStripeCustomer,
+  scheduleSubscriptionCancellation,
+} from "@app/lib/plans/stripe";
 import { PluginRunResource } from "@app/lib/resources/plugin_run_resource";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
@@ -172,14 +175,14 @@ async function handler(
   const body = validation.data;
 
   // Workspace must be Metronome-billed (current sub Metronome-only) or
-  // freshly Metronome-eligible (Metronome billing enabled + no Stripe sub).
+  // Metronome-eligible (Metronome billing enabled). Stripe-billed workspaces
+  // that have opted into Metronome billing land here too — their Stripe sub
+  // is scheduled to end at the swap time further down.
   const currentSubscription = auth.subscriptionResource();
   const isCurrentlyMetronomeOnlyBilled =
     currentSubscription?.isMetronomeOnlyBilled ?? false;
   const metronomeBillingEnabled = await isMetronomeBillingEnabled(auth);
-  const canStartFreshMetronomeContract =
-    metronomeBillingEnabled && !currentSubscription?.stripeSubscriptionId;
-  if (!isCurrentlyMetronomeOnlyBilled && !canStartFreshMetronomeContract) {
+  if (!isCurrentlyMetronomeOnlyBilled && !metronomeBillingEnabled) {
     const errorMessage =
       "switch_contract is only available for Metronome-billed workspaces. " +
       "Migrate the workspace to Metronome billing before invoking this flow.";
@@ -383,6 +386,33 @@ async function handler(
       status_code: 502,
       api_error: { type: "internal_server_error", message: errorMessage },
     });
+  }
+
+  // If the workspace is currently Stripe-billed (incl. shadow-Metronome),
+  // schedule the Stripe sub to cancel at the swap moment so the two rails
+  // don't double-bill.
+  const stripeSubscriptionIdToCancel =
+    currentSubscription?.stripeSubscriptionId ?? null;
+  if (stripeSubscriptionIdToCancel) {
+    try {
+      await scheduleSubscriptionCancellation({
+        stripeSubscriptionId: stripeSubscriptionIdToCancel,
+        cancelAt: alignedStart,
+      });
+    } catch (err) {
+      const errorMessage =
+        `Provisioned Metronome contract ${metronomeContractId} and pending ` +
+        `subscription, but failed to schedule cancellation of Stripe ` +
+        `subscription ${stripeSubscriptionIdToCancel}: ` +
+        `${err instanceof Error ? err.message : String(err)}. ` +
+        `URGENT: cancel the Stripe subscription manually at ${alignedStart.toISOString()} ` +
+        "to avoid double-billing.";
+      await pluginRun.recordError(errorMessage);
+      return apiError(req, res, {
+        status_code: 502,
+        api_error: { type: "internal_server_error", message: errorMessage },
+      });
+    }
   }
 
   // Ensure the workspace has a WorkOS organization for any paid tier.


### PR DESCRIPTION
## Description

Allows `switch_contract` (poke) to be invoked on Stripe-billed workspaces — including shadow-Metronome — and schedules the Stripe subscription to cancel at the new contract's start time, so the two billing rails don't double-bill the customer.

Previously the endpoint refused any caller whose current subscription had a `stripeSubscriptionId`, which blocked the natural migration path: enterprise customer on Stripe + shadow Metronome → credit-priced Metronome only.

Changes:
- **Gate relaxed** in `front-api/routes/poke/workspaces/[wId]/switch_contract.ts`: a workspace is eligible whenever it's already Metronome-only billed OR `isMetronomeBillingEnabled(auth)` returns true. The previous `!stripeSubscriptionId` guard is gone.
- **New helper** `scheduleSubscriptionCancellation({ stripeSubscriptionId, cancelAt })` in `front/lib/plans/stripe.ts` that sets `cancel_at` on the Stripe subscription. Prorations at cancellation follow the subscription's existing settings (Stripe default: credit for the unused portion).
- **Endpoint** calls the helper after the pending subscription row is created, when the current sub has a `stripeSubscriptionId`. On Stripe API failure: returns 502 with an URGENT operator message naming the Stripe sub ID and the swap timestamp so manual cleanup can happen — the contract and pending row are already provisioned at that point, so the operator can recover without a half-rolled-back state.

Pairs with #26238 (UI gate change that surfaced `SwitchContractDialog` for shadow-billed workspaces). With this PR, those operator clicks now actually work end-to-end.

## Tests

Updated `front/pages/api/poke/workspaces/[wId]/switch_contract.test.ts`:
- Mocked `scheduleSubscriptionCancellation`.
- Replaced the prior "rejects when Stripe-billed" test with "schedules the Stripe subscription to cancel at the swap moment when the workspace is Stripe-billed" — asserts 200 + `scheduleSubscriptionCancellation` called with `{ stripeSubscriptionId, cancelAt: Date }`.
- Added "does not call scheduleSubscriptionCancellation when the workspace has no Stripe subscription" — guards against accidental Stripe calls on Metronome-only workspaces.

Typecheck clean. Functional tests run in CI (local test DB not available in this branch).

## Risk

Medium — touches production billing.

- **Stripe API failure mid-flight**: contract + pending row are already provisioned, but Stripe is still active. The endpoint returns 502 with a message naming the Stripe sub ID and the timestamp; operator must cancel manually. Considered acceptable because the alternative (auto-rollback of Metronome contract + pending row) is more complex and itself can fail.
- **Proration semantics**: defaults to Stripe's normal behavior at cancellation (credit for unused portion). If we later want to suppress prorations entirely, that's a one-line follow-up on the helper.
- **Backward compatibility**: pure-Metronome and fresh-no-billing flows go through the same code path and are unaffected (the new branch only runs when `stripeSubscriptionId` is set on the current sub).

Rollback: revert the commit. New helper is unused outside this endpoint so it's safe to leave or revert with the rest.

## Deploy Plan

Standard front deploy. No DB migrations, no config changes.

Post-deploy sanity check on a real migration:
1. Pick a Stripe-billed + shadow-Metronome workspace with the `metronome_billing` flag (or globally enabled via kill-switch off).
2. From Poke → Subscriptions tab → Switch Contract.
3. Confirm 200, the Metronome contract is provisioned at `startingAt`, and the linked Stripe sub now shows `cancel_at` set to the same moment in the Stripe dashboard.
4. At `contract.start` time, the pending subscription should activate and the Stripe sub should stop billing.