### PR TITLE
[front] fix: allow runtime skill enablement without agent config check

### DIFF
--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -29,18 +29,12 @@ const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
       );
     }
 
-    const enableResult = await skill.enableForAgent(auth, {
+    const { wasAlreadyEnabled } = await skill.enableForAgent(auth, {
       agentConfiguration,
       conversation,
     });
 
-    if (enableResult.isErr()) {
-      return new Err(
-        new MCPError(enableResult.error.message, { tracked: false })
-      );
-    }
-
-    if (enableResult.value.alreadyEnabled) {
+    if (wasAlreadyEnabled) {
       return new Ok([
         {
           type: "text" as const,

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -1118,16 +1118,14 @@ describe("SkillResource", () => {
         );
 
       // Enable skillA on conv1 and skillB on conv2
-      const enableA = await skillA.enableForAgent(testContext.authenticator, {
+      await skillA.enableForAgent(testContext.authenticator, {
         agentConfiguration: agent,
         conversation: conv1,
       });
-      expect(enableA.isOk()).toBe(true);
-      const enableB = await skillB.enableForAgent(testContext.authenticator, {
+      await skillB.enableForAgent(testContext.authenticator, {
         agentConfiguration: agent,
         conversation: conv2,
       });
-      expect(enableB.isOk()).toBe(true);
 
       await SkillResource.snapshotConversationSkillsForMessage(
         testContext.authenticator,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2430,7 +2430,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       agentConfiguration: AgentConfigurationType;
       conversation: ConversationType;
     }
-  ): Promise<Result<{ alreadyEnabled: boolean }, Error>> {
+  ): Promise<{ wasAlreadyEnabled: boolean }> {
     const workspace = auth.getNonNullableWorkspace();
 
     const conversationSkillBlob: ConversationSkillCreationAttributes = {
@@ -2447,12 +2447,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     });
 
     if (existingConversationSkill) {
-      return new Ok({ alreadyEnabled: true });
+      return { wasAlreadyEnabled: true };
     }
 
     await ConversationSkillModel.create(conversationSkillBlob);
 
-    return new Ok({ alreadyEnabled: false });
+    return { wasAlreadyEnabled: false };
   }
 
   static async snapshotConversationSkillsForMessage(

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2438,6 +2438,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       workspaceId: workspace.id,
       conversationId: conversation.id,
       addedByUserId: null,
+      source: "agent_enabled",
       agentConfigurationId: agentConfiguration.sId,
     };
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2438,7 +2438,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       workspaceId: workspace.id,
       conversationId: conversation.id,
       addedByUserId: null,
-      source: "agent_enabled",
       agentConfigurationId: agentConfiguration.sId,
     };
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2433,30 +2433,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   ): Promise<Result<{ alreadyEnabled: boolean }, Error>> {
     const workspace = auth.getNonNullableWorkspace();
 
-    const refs = await SkillResource.getSkillReferencesForAgent(
-      auth,
-      agentConfiguration
-    );
-
-    const hasSkill = refs.some(
-      (ref) =>
-        (ref.globalSkillId !== null && ref.globalSkillId === this.globalSId) ||
-        (ref.customSkillId !== null && ref.customSkillId === this.id)
-    );
-
-    // Allow enabling default skills if the agent has the discover_skills skill.
-    const hasDiscoverSkills =
-      this.isDefault &&
-      refs.some((ref) => ref.globalSkillId === "discover_skills");
-
-    if (!hasSkill && !hasDiscoverSkills) {
-      return new Err(
-        new Error(
-          `Skill ${this.name} is not equipped by agent ${agentConfiguration.name}.`
-        )
-      );
-    }
-
     const conversationSkillBlob: ConversationSkillCreationAttributes = {
       ...this.skillReference,
       workspaceId: workspace.id,


### PR DESCRIPTION
## Description

- This PR removes the `enable_skill` requirement that the target skill must already be attached to the agent configuration.
- Rationale: the permission check relies on spaces, not on the skill having been added to Agent Builder. The agent should have the same rights as the user via the input bar.
- `enableForAgent` now only handles the conversation-skill enablement path: it idempotently creates the conversation skill row, preserves the `agent_enabled` source, and reports whether the skill was already enabled.

## Tests

- Updated existing tests.

## Risk

- Medium, affects the agent skill enablement path.

## Deploy Plan

- Deploy front.