### PR TITLE
Fix subscription check on deserialization

### DIFF
--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -82,13 +82,7 @@ export async function ensureConversationTitleFromAgentLoop(
 
   const { conversation, userMessage } = runAgentDataRes.value;
 
-  const authResult = await Authenticator.fromJSON(authType);
-  if (authResult.isErr()) {
-    throw new Error(
-      `Failed to deserialize authenticator: ${authResult.error.code}`
-    );
-  }
-  const auth = authResult.value;
+  const auth = await Authenticator.fromJSON(authType);
 
   return ensureConversationTitle(auth, { conversation, userMessage });
 }

--- a/front/lib/auth.fromjson.test.ts
+++ b/front/lib/auth.fromjson.test.ts
@@ -1,0 +1,118 @@
+import type { CacheableFunction, JsonSerializable } from "@app/lib/utils/cache";
+import { describe, expect, it, vi } from "vitest";
+
+// Replace the Redis-backed subscription cache with an in-memory map so the
+// post-swap rehydrate observes the new subscription synchronously, regardless
+// of Redis. Mirrors the pattern in subscription_resource.test.ts.
+const inMemoryCache = vi.hoisted(() => new Map<string, string>());
+
+vi.mock("@app/lib/utils/cache", () => ({
+  cacheWithRedis: vi
+    .fn()
+    .mockImplementation(
+      <T, Args extends unknown[]>(
+        fn: CacheableFunction<JsonSerializable<T>, Args>,
+        resolver: (...args: Args) => string
+      ) => {
+        return async (...args: Args): Promise<JsonSerializable<T>> => {
+          const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
+          const cached = inMemoryCache.get(key);
+          if (cached) {
+            return JSON.parse(cached) as JsonSerializable<T>;
+          }
+          const result = await fn(...args);
+          inMemoryCache.set(key, JSON.stringify(result));
+          return result;
+        };
+      }
+    ),
+  invalidateCacheWithRedis: vi
+    .fn()
+    .mockImplementation(
+      <T, Args extends unknown[]>(
+        fn: CacheableFunction<JsonSerializable<T>, Args>,
+        resolver: (...args: Args) => string
+      ) => {
+        return (...args: Args): Promise<void> => {
+          const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
+          inMemoryCache.delete(key);
+          return Promise.resolve();
+        };
+      }
+    ),
+  batchInvalidateCacheWithRedis: vi
+    .fn()
+    .mockImplementation(
+      <T, Args extends unknown[]>(
+        fn: CacheableFunction<JsonSerializable<T>, Args>,
+        resolver: (...args: Args) => string
+      ) => {
+        return async (argsList: Args[]): Promise<void> => {
+          for (const args of argsList) {
+            const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
+            inMemoryCache.delete(key);
+          }
+        };
+      }
+    ),
+  invalidateCacheAfterCommit: vi
+    .fn()
+    .mockImplementation(
+      (_transaction: unknown, invalidateFn: () => Promise<void>): void => {
+        void invalidateFn();
+      }
+    ),
+}));
+
+import { Authenticator } from "@app/lib/auth";
+import { renderPlanFromModel } from "@app/lib/plans/renderers";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { PlanFactory } from "@app/tests/utils/PlanFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+
+async function swapSubscription(workspaceId: string): Promise<string> {
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  if (!workspace) {
+    throw new Error("Test setup: workspace not found");
+  }
+  const active = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+    workspace.id
+  );
+  if (!active) {
+    throw new Error("Test setup: workspace has no active subscription");
+  }
+  await active.markAsEnded("ended");
+
+  const plan = await PlanFactory.enterprise();
+  const newSubId = generateRandomModelSId();
+  await SubscriptionResource.makeNew(
+    {
+      sId: newSubId,
+      workspaceId: workspace.id,
+      planId: plan.id,
+      status: "active",
+      startDate: new Date(),
+      endDate: null,
+      stripeSubscriptionId: null,
+    },
+    renderPlanFromModel({ plan })
+  );
+  return newSubId;
+}
+
+describe("Authenticator.fromJSON", () => {
+  it("returns an Authenticator bound to the workspace's current active subscription, even when the serialized subscriptionId is stale", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const authJson = auth.toJSON();
+    expect(authJson.subscriptionId).not.toBeNull();
+
+    const newSubId = await swapSubscription(workspace.sId);
+
+    const fresh = await Authenticator.fromJSON(authJson);
+    expect(fresh.plan()).not.toBeNull();
+    expect(fresh.subscription()?.sId).toBe(newSubId);
+  });
+});

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1206,9 +1206,7 @@ export class Authenticator {
     };
   }
 
-  static async fromJSON(
-    authType: AuthenticatorType
-  ): Promise<Result<Authenticator, { code: "subscription_mismatch" }>> {
+  static async fromJSON(authType: AuthenticatorType): Promise<Authenticator> {
     const [workspace, user] = await Promise.all([
       authType.workspaceId
         ? WorkspaceResource.fetchById(authType.workspaceId)
@@ -1216,16 +1214,9 @@ export class Authenticator {
       authType.userId ? UserResource.fetchById(authType.userId) : null,
     ]);
 
-    const lightWorkspace = workspace
-      ? renderLightWorkspaceType({ workspace })
+    const subscription = workspace
+      ? await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id)
       : null;
-
-    const subscription =
-      authType.subscriptionId && lightWorkspace
-        ? await SubscriptionResource.fetchActiveByWorkspaceModelId(
-            lightWorkspace.id
-          )
-        : null;
 
     // Skip mismatch check for no-plan subscriptions: they have ephemeral random sIds
     // that change on every fetch, so they can never match the original.
@@ -1235,7 +1226,14 @@ export class Authenticator {
       subscription.sId !== authType.subscriptionId &&
       !subscription.isLegacyFreeNoPlan()
     ) {
-      return new Err({ code: "subscription_mismatch" });
+      logger.info(
+        {
+          workspaceId: authType.workspaceId,
+          originalSubscriptionId: authType.subscriptionId,
+          currentSubscriptionId: subscription.sId,
+        },
+        "Subscription changed since auth was serialized, using current active subscription"
+      );
     }
 
     const groupIds = removeNulls(
@@ -1247,19 +1245,17 @@ export class Authenticator {
       subscription
     );
 
-    return new Ok(
-      new Authenticator({
-        authMethod: authType.authMethod,
-        workspace,
-        user,
-        role: authType.role,
-        groupModelIds: groupIds,
-        subscription,
-        key: authType.key,
-        providersHealth,
-        clientIp: authType.clientIp,
-      })
-    );
+    return new Authenticator({
+      authMethod: authType.authMethod,
+      workspace,
+      user,
+      role: authType.role,
+      groupModelIds: groupIds,
+      subscription,
+      key: authType.key,
+      providersHealth,
+      clientIp: authType.clientIp,
+    });
   }
 }
 

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -446,32 +446,7 @@ export async function notifyWorkflowError(
   { conversationId, agentMessageId, agentMessageVersion }: AgentLoopArgs,
   error: { message: string; name: string }
 ): Promise<void> {
-  let authResult = await AuthenticatorClass.fromJSON(authType);
-
-  // If subscription changed while the message was running, get a fresh auth with the current
-  // subscription and continue gracefully.
-  if (authResult.isErr() && authResult.error.code === "subscription_mismatch") {
-    logger.info(
-      {
-        workspaceId: authType.workspaceId,
-        originalSubscriptionId: authType.subscriptionId,
-      },
-      "Subscription changed while message was running, using fresh auth in notifyWorkflowError"
-    );
-
-    // Retry without the subscriptionId constraint to get the current subscription.
-    authResult = await AuthenticatorClass.fromJSON({
-      ...authType,
-      subscriptionId: null,
-    });
-  }
-
-  if (authResult.isErr()) {
-    throw new Error(
-      `Failed to deserialize authenticator: ${authResult.error.code}`
-    );
-  }
-  const auth = authResult.value;
+  const auth = await AuthenticatorClass.fromJSON(authType);
 
   // Use lighter fetchConversationWithoutContent
   const conversation = await ConversationResource.fetchById(

--- a/front/temporal/agent_loop/activities/compaction.ts
+++ b/front/temporal/agent_loop/activities/compaction.ts
@@ -22,13 +22,7 @@ export async function compactionActivity(
     sourceConversation?: CompactionSourceConversation;
   }
 ): Promise<void> {
-  const authResult = await Authenticator.fromJSON(authType);
-  if (authResult.isErr()) {
-    throw new Error(
-      `Failed to deserialize authenticator: ${authResult.error.code}`
-    );
-  }
-  const auth = authResult.value;
+  const auth = await Authenticator.fromJSON(authType);
   const compactionRes = await runCompaction(auth, {
     conversationId,
     compactionMessageId,
@@ -54,13 +48,7 @@ export async function compactionCleanupActivity(
     compactionMessageVersion: number;
   }
 ): Promise<void> {
-  const authResult = await Authenticator.fromJSON(authType);
-  if (authResult.isErr()) {
-    throw new Error(
-      `Failed to deserialize authenticator: ${authResult.error.code}`
-    );
-  }
-  const auth = authResult.value;
+  const auth = await Authenticator.fromJSON(authType);
   await failCompactionMessage(auth, {
     conversationId,
     compactionMessageId,

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -23,11 +23,7 @@ export async function finalizeSuccessfulAgentLoopActivity(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
-  const authResult = await Authenticator.fromJSON(authType);
-  if (authResult.isErr()) {
-    return;
-  }
-  const auth = authResult.value;
+  const auth = await Authenticator.fromJSON(authType);
 
   await Promise.all([
     snapshotAgentMessageSkills(auth, agentLoopArgs),
@@ -52,11 +48,7 @@ export async function finalizeGracefullyStoppedAgentLoopActivity(
 ): Promise<void> {
   await finalizeGracefulStop(authType, agentLoopArgs);
 
-  const authResult = await Authenticator.fromJSON(authType);
-  if (authResult.isErr()) {
-    return;
-  }
-  const auth = authResult.value;
+  const auth = await Authenticator.fromJSON(authType);
 
   await Promise.all([
     snapshotAgentMessageSkills(auth, agentLoopArgs),
@@ -83,11 +75,7 @@ export async function finalizeInterruptedAgentLoopActivity(
 ): Promise<void> {
   await finalizeInterruption(authType, agentLoopArgs);
 
-  const authResult = await Authenticator.fromJSON(authType);
-  if (authResult.isErr()) {
-    return;
-  }
-  const auth = authResult.value;
+  const auth = await Authenticator.fromJSON(authType);
 
   await Promise.all([
     snapshotAgentMessageSkills(auth, agentLoopArgs),
@@ -105,11 +93,7 @@ export async function finalizeCancelledAgentLoopActivity(
 ): Promise<void> {
   await finalizeCancellation(authType, agentLoopArgs);
 
-  const authResult = await Authenticator.fromJSON(authType);
-  if (authResult.isErr()) {
-    return;
-  }
-  const auth = authResult.value;
+  const auth = await Authenticator.fromJSON(authType);
 
   await Promise.all([
     snapshotAgentMessageSkills(auth, agentLoopArgs),
@@ -131,11 +115,7 @@ export async function finalizeErroredAgentLoopActivity(
 ): Promise<void> {
   await notifyWorkflowError(authType, agentLoopArgs, error);
 
-  const authResult = await Authenticator.fromJSON(authType);
-  if (authResult.isErr()) {
-    return;
-  }
-  const auth = authResult.value;
+  const auth = await Authenticator.fromJSON(authType);
 
   await Promise.all([
     snapshotAgentMessageSkills(auth, agentLoopArgs),

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -83,13 +83,7 @@ export async function runToolActivity(
     runIds?: string[];
   }
 ): Promise<ToolExecutionResult> {
-  const authResult = await Authenticator.fromJSON(authType);
-  if (authResult.isErr()) {
-    throw new Error(
-      `Failed to deserialize authenticator: ${authResult.error.code}`
-    );
-  }
-  const auth = authResult.value;
+  const auth = await Authenticator.fromJSON(authType);
   const deferredEvents: ToolExecutionResult["deferredEvents"] = [];
 
   const [runAgentDataRes, action] = await startActiveObservation(

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -65,13 +65,7 @@ export async function storeAgentAnalyticsActivity(
     agentLoopArgs: AgentLoopArgs;
   }
 ): Promise<void> {
-  const authResult = await Authenticator.fromJSON(authType);
-  if (authResult.isErr()) {
-    throw new Error(
-      `Failed to deserialize authenticator: ${authResult.error.code}`
-    );
-  }
-  const auth = authResult.value;
+  const auth = await Authenticator.fromJSON(authType);
   const workspace = auth.getNonNullableWorkspace();
 
   const { agentMessageId, userMessageId } = agentLoopArgs;
@@ -761,13 +755,7 @@ export async function storeAgentMessageFeedbackActivity(
     message: AgentMessageRef;
   }
 ): Promise<void> {
-  const authResult = await Authenticator.fromJSON(authType);
-  if (authResult.isErr()) {
-    throw new Error(
-      `Failed to deserialize authenticator: ${authResult.error.code}`
-    );
-  }
-  const auth = authResult.value;
+  const auth = await Authenticator.fromJSON(authType);
 
   const workspace = auth.getNonNullableWorkspace();
 

--- a/front/temporal/mentions_queue/activities.ts
+++ b/front/temporal/mentions_queue/activities.ts
@@ -14,13 +14,7 @@ export async function handleMentionsActivity(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
-  const authResult = await Authenticator.fromJSON(authType);
-  if (authResult.isErr()) {
-    throw new Error(
-      `Failed to deserialize authenticator: ${authResult.error.code}`
-    );
-  }
-  const auth = authResult.value;
+  const auth = await Authenticator.fromJSON(authType);
 
   const conversation = await ConversationResource.fetchById(
     auth,

--- a/front/temporal/notifications_queue/activities.ts
+++ b/front/temporal/notifications_queue/activities.ts
@@ -12,13 +12,7 @@ export async function sendUnreadConversationNotificationActivity(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
-  const authResult = await Authenticator.fromJSON(authType);
-  if (authResult.isErr()) {
-    throw new Error(
-      `Failed to deserialize authenticator: ${authResult.error.code}`
-    );
-  }
-  const auth = authResult.value;
+  const auth = await Authenticator.fromJSON(authType);
 
   // Get conversation participants
   const conversation = await ConversationResource.fetchById(

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -111,13 +111,7 @@ export async function trackProgrammaticUsageActivity(
   authType: AuthenticatorType,
   { agentLoopArgs }: { agentLoopArgs: AgentLoopArgs }
 ): Promise<{ tracked: boolean; origin: UserMessageOrigin }> {
-  const authResult = await Authenticator.fromJSON(authType);
-  if (authResult.isErr()) {
-    throw new Error(
-      `Failed to deserialize authenticator: ${authResult.error.code}`
-    );
-  }
-  const auth = authResult.value;
+  const auth = await Authenticator.fromJSON(authType);
   const workspace = auth.getNonNullableWorkspace();
 
   const { agentMessageId, userMessageId } = agentLoopArgs;
@@ -208,15 +202,7 @@ export async function emitMetronomeUsageEventsActivity(
   authType: AuthenticatorType,
   { agentLoopArgs }: { agentLoopArgs: AgentLoopArgs }
 ): Promise<void> {
-  const authResult = await Authenticator.fromJSON(authType);
-  if (authResult.isErr()) {
-    logger.warn(
-      { error: authResult.error.code },
-      "[Metronome] Failed to deserialize authenticator for usage events"
-    );
-    return;
-  }
-  const auth = authResult.value;
+  const auth = await Authenticator.fromJSON(authType);
   const workspace = auth.getNonNullableWorkspace();
   const isByok = auth.getNonNullablePlan().isByok;
   const { agentMessageId, conversationId, userMessageId } = agentLoopArgs;

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -9,7 +9,6 @@ import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { cacheWithRedis } from "@app/lib/utils/cache";
-import logger from "@app/logger/logger";
 import type {
   AgentConfigurationType,
   GlobalAgentContext,
@@ -150,33 +149,9 @@ export async function getAgentLoopData(
     AgentLoopDataError | Error
   >
 > {
-  let authResult = await Authenticator.fromJSON(authType);
+  const auth = await Authenticator.fromJSON(authType);
 
-  // If subscription changed while the message was running, get a fresh auth with the current
-  // subscription and continue gracefully.
-  if (authResult.isErr() && authResult.error.code === "subscription_mismatch") {
-    logger.info(
-      {
-        workspaceId: authType.workspaceId,
-        originalSubscriptionId: authType.subscriptionId,
-      },
-      "Subscription changed while message was running, using fresh auth"
-    );
-
-    // Retry without the subscriptionId constraint to get the current subscription.
-    authResult = await Authenticator.fromJSON({
-      ...authType,
-      subscriptionId: null,
-    });
-  }
-
-  if (authResult.isErr()) {
-    return new Err(
-      new Error(`Failed to deserialize authenticator: ${authResult.error.code}`)
-    );
-  }
-
-  return getAgentLoopDataWithAuth(authResult.value, agentLoopArgs);
+  return getAgentLoopDataWithAuth(auth, agentLoopArgs);
 }
 
 /**


### PR DESCRIPTION
## Description

`Authenticator.fromJSON` previously had a "subscription mismatch" check that returned `Err({ code: "subscription_mismatch" })` when the serialized `subscriptionId` didn't match the workspace's current active subscription. This PR deletes the check entirely. `fromJSON` now always loads the active subscription and logs on drift for observability, but never fails.

### Why drop the check rather than patch it

The check was introduced in #14369 as a defensive `assert(...)` during the Durable Agents serialization work, with no documented use case for what should happen on mismatch. When it started firing in production, #19044 converted the crash into a `Result + retry` (treating mismatch as "shouldn't happen, but recover if it does"). philipperolet flagged the inconsistent application across call sites in that PR's review and suggested centralizing the recovery — that was never acted on.

Five months in, no caller actually acts on the mismatch in a meaningful way:

- `getAgentLoopData` and `notifyWorkflowError` retry with `subscriptionId: null` to land on the current active sub.
- All other callers (finalize wrappers, title.ts, run_tool, mentions, notification, usage_tracking, analytics, compaction, feedback) either throw or silently bail out — both wrong outcomes when the only "drift" is a benign mid-flight subscription switch.

The check generates failures the code immediately works around. The right design — what philipperolet's review pointed at — is to make `fromJSON` always return a usable auth bound to the current sub. Doing that inside `fromJSON` is simpler than asking 10+ call sites to remember to use a recovery helper.

### The bug this fixes

When a workspace subscription is swapped while an agent loop is running (e.g. `switch_contract`, `activatePending`, `swapMetronomeContract`), the finalize activities exhibited two failure modes over time:

1. **Loud crash**: `"Unexpected `auth` without `plan`."` from `global_agents.ts` after the recovery path returned `subscription = null` (the broken ternary inside `fromJSON`).
2. **Silent data loss** (the issue @rfrenoy flagged in initial review): even if we fix the ternary so the recovery returns a real auth, the finalize wrappers also call `Authenticator.fromJSON(authType)` a second time with the **original** `authType`, which still has the stale `subscriptionId`. That second call hits the mismatch, returns `Err`, and the wrapper `return`s — silently dropping all post-finalize side-effects (snapshot, analytics, programmatic usage, Metronome events, unread notification, mentions, email reply).

Both modes are eliminated by construction: `fromJSON` can no longer fail on a mismatch, so no caller can silently drop work because of one.

### Changes

- `front/lib/auth.ts` — `fromJSON` returns `Promise<Authenticator>` (no more `Result`), always loads the active subscription, logs at `info` on drift.
- `front/types/assistant/agent_run.ts` — recovery branch in `getAgentLoopData` deleted.
- `front/temporal/agent_loop/activities/common.ts` — recovery branch in `notifyWorkflowError` deleted.
- All other `fromJSON` callers — `isErr()` handling removed (finalize × 5, title.ts, run_tool, compaction × 2, mentions, notification, usage tracking × 2, analytics × 2).

Net: **+48 / −217 lines**.

### Tests

Replaced the previous mismatch-detection test with one that directly asserts the new contract: serialize an auth, swap the workspace's subscription, deserialize → expect an `Authenticator` bound to the new active sub with `auth.plan()` non-null and `auth.subscription().sId` equal to the new sub's id.

Uses the in-memory cache mock from `subscription_resource.test.ts` so the post-swap rehydrate is deterministic regardless of Redis state.

### Risk

Low.

- The only behavioral change is for callers that previously got `Err({ code: "subscription_mismatch" })`. No such caller acted on the error in a way that would be missed: the two "smart" callers (`getAgentLoopData`, `notifyWorkflowError`) were doing exactly the recovery `fromJSON` now does internally; the rest were either throwing or silently bailing — both wrong outcomes.
- No DB writes. One subscription fetch per `fromJSON` call (already the case in the common path).
- Observability is preserved via the new log line on drift.

### Deploy Plan

Standard front deploy. No migrations, no config changes.

Rollback: revert the commit.