### PR TITLE
Change bars height and gap + count balances to the hour

### DIFF
--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -110,7 +110,7 @@ function AwuUsageBar({
           <span>{limit === null ? "∞" : formatCredits(limit)}</span>
         </div>
         <div
-          className={`h-0.5 w-full overflow-hidden rounded-full ${MUTED_BAR_CLASSES.track}`}
+          className={`h-1 w-full overflow-hidden rounded-full ${MUTED_BAR_CLASSES.track}`}
         >
           <div
             className={`h-full ${MUTED_BAR_CLASSES.fill} transition-all`}
@@ -148,7 +148,7 @@ function AwuUsageBar({
         <span>{formatCredits(consumed)}</span>
         <span>{limit === null ? "∞" : formatCredits(limit)}</span>
       </div>
-      <div className="flex w-full items-center gap-0.5">
+      <div className="flex w-full items-center gap-px">
         <Tooltip
           tooltipTriggerAsChild
           label={`${formatCredits(seatConsumed)} credits consumed over ${formatCredits(memberUsageLimit)} seat limit`}
@@ -158,7 +158,7 @@ function AwuUsageBar({
               style={{ width: `${seatWidthPercent}%` }}
             >
               <div
-                className={`h-0.5 w-full overflow-hidden rounded-full ${seatColors.track}`}
+                className={`h-1 w-full overflow-hidden rounded-full ${seatColors.track}`}
               >
                 <div
                   className={`h-full ${seatColors.fill} transition-all`}
@@ -177,7 +177,7 @@ function AwuUsageBar({
               style={{ width: `${overflowWidthPercent}%` }}
             >
               <div
-                className={`h-0.5 w-full overflow-hidden rounded-full ${MUTED_BAR_CLASSES.track}`}
+                className={`h-1 w-full overflow-hidden rounded-full ${MUTED_BAR_CLASSES.track}`}
               >
                 <div
                   className={`h-full ${MUTED_BAR_CLASSES.fill} transition-all`}

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -1,7 +1,7 @@
 import type { Authenticator } from "@app/lib/auth";
 import {
-  ceilToMidnightUTC,
-  floorToMidnightUTC,
+  ceilToHourISO,
+  floorToHourISO,
   listMetronomeBalances,
   listMetronomeDraftInvoices,
   listMetronomeUsageWithGroups,
@@ -107,9 +107,7 @@ export async function handleAwuPoolSummaryRequest(
         });
       }
 
-      const resetDate = ceilToMidnightUTC(
-        new Date(currentInvoice.end_timestamp)
-      ).toISOString();
+      const resetDate = ceilToHourISO(new Date(currentInvoice.end_timestamp));
 
       // Filter to active, non-seat AWU pool credits and commits. The set of
       // seat product IDs is derived from the contract's tagged subscriptions
@@ -157,12 +155,12 @@ export async function handleAwuPoolSummaryRequest(
         }
       }
 
-      const startingOn = floorToMidnightUTC(
+      const startingOn = floorToHourISO(
         new Date(currentInvoice.start_timestamp)
-      ).toISOString();
-      const endingBefore = ceilToMidnightUTC(
+      );
+      const endingBefore = ceilToHourISO(
         new Date(currentInvoice.end_timestamp)
-      ).toISOString();
+      );
 
       // Query usage per user and seat allocations in parallel.
       // Per-user breakdown is needed to compute pool overflow correctly:

--- a/front/lib/metronome/per_user_usage.ts
+++ b/front/lib/metronome/per_user_usage.ts
@@ -1,6 +1,6 @@
 import {
-  ceilToMidnightUTC,
-  floorToMidnightUTC,
+  ceilToHourISO,
+  floorToHourISO,
   listMetronomeDraftInvoices,
   listMetronomeUsageWithGroups,
 } from "@app/lib/metronome/client";
@@ -37,12 +37,8 @@ export async function fetchPerUserAwuUsage({
     return new Ok(new Map());
   }
 
-  const startingOn = floorToMidnightUTC(
-    new Date(currentInvoice.start_timestamp)
-  ).toISOString();
-  const endingBefore = ceilToMidnightUTC(
-    new Date(currentInvoice.end_timestamp)
-  ).toISOString();
+  const startingOn = floorToHourISO(new Date(currentInvoice.start_timestamp));
+  const endingBefore = ceilToHourISO(new Date(currentInvoice.end_timestamp));
 
   const usageResult = await listMetronomeUsageWithGroups({
     customerId: metronomeCustomerId,


### PR DESCRIPTION
## Description

Small visual polish on the `AwuUsageBar` component in `MembersUsageTable`: adjusts the height and gap between bar segments to better match the intended design.

<img width="264" height="84" alt="image" src="https://github.com/user-attachments/assets/a50f2faf-cdbd-484f-ad75-568fcf453329" />

This PR also fixes the calculation of the consumed credits. They used to be counted from midnight to midnight.

## Tests

Tested manually on the Usage page.

## Risk

None — purely cosmetic change.

## Deploy Plan

Deploy `front`.