### PR TITLE
batch fetch skill usage, editors, and editedBy

### DIFF
--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -5,7 +5,6 @@ import { DataSourceViewResource } from "@app/lib/resources/data_source_view_reso
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type {
   SkillType,
@@ -139,40 +138,44 @@ app.get(
     });
 
     if (withRelations === "true") {
-      const extendedSkills = await SkillResource.fetchByIds(
-        auth,
-        removeNulls(uniq(skills.map((s) => s.extendedSkillId)))
-      );
+      const [extendedSkills, usageMap, editorsMap, editedByUsersMap] =
+        await Promise.all([
+          SkillResource.fetchByIds(
+            auth,
+            removeNulls(uniq(skills.map((s) => s.extendedSkillId)))
+          ),
+          SkillResource.batchFetchUsage(auth, skills),
+          SkillResource.batchListEditors(auth, skills),
+          SkillResource.batchFetchEditedByUsers(auth, skills),
+        ]);
+
       const extendedSkillsMap = new Map(extendedSkills.map((s) => [s.sId, s]));
 
-      const skillsWithRelations = await concurrentExecutor(
-        skills,
-        async (sc) => {
-          const {
-            instructions,
-            instructionsHtml,
-            tools,
-            ...skillWithoutInstructionsAndTools
-          } = sc.toJSON(auth);
-          const usage = await sc.fetchUsage(auth);
-          const editors = await sc.listEditors(auth);
-          const editedByUser = await sc.fetchEditedByUser(auth);
+      const skillsWithRelations = skills.map((sc) => {
+        const {
+          instructions,
+          instructionsHtml,
+          tools,
+          ...skillWithoutInstructionsAndTools
+        } = sc.toJSON(auth);
 
-          return {
-            ...skillWithoutInstructionsAndTools,
-            relations: {
-              usage,
-              editors: editors ? editors.map((e) => e.toJSON()) : null,
-              editedByUser: editedByUser ? editedByUser.toJSON() : null,
-              extendedSkill: sc.extendedSkillId
-                ? (extendedSkillsMap.get(sc.extendedSkillId)?.toJSON(auth) ??
-                  null)
-                : null,
-            },
-          } satisfies SkillWithoutInstructionsAndToolsWithRelationsType;
-        },
-        { concurrency: 10 }
-      );
+        const usage = usageMap.get(sc.sId) ?? { count: 0, agents: [] };
+        const editors = editorsMap.get(sc.sId) ?? null;
+        const editedByUser = editedByUsersMap.get(sc.sId) ?? null;
+
+        return {
+          ...skillWithoutInstructionsAndTools,
+          relations: {
+            usage,
+            editors: editors ? editors.map((e) => e.toJSON()) : null,
+            editedByUser: editedByUser ? editedByUser.toJSON() : null,
+            extendedSkill: sc.extendedSkillId
+              ? (extendedSkillsMap.get(sc.extendedSkillId)?.toJSON(auth) ??
+                null)
+              : null,
+          },
+        } satisfies SkillWithoutInstructionsAndToolsWithRelationsType;
+      });
 
       return ctx.json({ skills: skillsWithRelations });
     }

--- a/front/lib/api/user.ts
+++ b/front/lib/api/user.ts
@@ -80,6 +80,71 @@ export async function getUserForWorkspace(
 }
 
 /**
+ * Batch version of hasSharedMembership: filters users that share at least one
+ * workspace with the authenticated user and have a membership in the auth workspace.
+ * Returns the subset of `users` that pass the privacy check.
+ */
+export async function filterUsersWithSharedMembership(
+  auth: Authenticator,
+  users: UserResource[]
+): Promise<UserResource[]> {
+  if (users.length === 0) {
+    return [];
+  }
+
+  const workspace = auth.workspace();
+  const authUser = auth.user();
+  if (!workspace || !authUser) {
+    return [];
+  }
+
+  // Check which users have a membership in the auth workspace.
+  const { memberships: workspaceMemberships } =
+    await MembershipResource.getActiveMemberships({
+      users,
+      workspace,
+    });
+  const usersInWorkspace = new Set(workspaceMemberships.map((m) => m.userId));
+
+  const usersWithWorkspaceMembership = users.filter((u) =>
+    usersInWorkspace.has(u.id)
+  );
+
+  if (usersWithWorkspaceMembership.length === 0) {
+    return [];
+  }
+
+  // Superusers can see all users that have a workspace membership.
+  if (auth.isDustSuperUser()) {
+    return usersWithWorkspaceMembership;
+  }
+
+  // For regular users: check shared workspaces.
+  const { memberships: authUserMemberships } =
+    await MembershipResource.getActiveMemberships({
+      users: [authUser],
+    });
+  const authUserWorkspaceIds = new Set(
+    authUserMemberships.map((m) => m.workspaceId)
+  );
+
+  const { memberships: candidateMemberships } =
+    await MembershipResource.getActiveMemberships({
+      users: usersWithWorkspaceMembership,
+    });
+
+  // Collect user IDs that share at least one workspace with the auth user.
+  const visibleUserIds = new Set<number>();
+  for (const m of candidateMemberships) {
+    if (authUserWorkspaceIds.has(m.workspaceId)) {
+      visibleUserIds.add(m.userId);
+    }
+  }
+
+  return usersWithWorkspaceMembership.filter((u) => visibleUserIds.has(u.id));
+}
+
+/**
  * This function checks that both the auth user and the requested user share at least one
  * workspace membership, and that the requested user had at least one membership in the past
  * for the auth workspace. Returns false otherwise.

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -1157,4 +1157,176 @@ describe("SkillResource", () => {
       expect(results[0].agentConfigurationId).toEqual(agent.sId);
     });
   });
+
+  describe("batchFetchUsage", () => {
+    it("returns empty usage for skills with no agents", async () => {
+      const skill = await SkillFactory.create(testContext.authenticator, {
+        name: "Unused Skill",
+      });
+
+      const usageMap = await SkillResource.batchFetchUsage(
+        testContext.authenticator,
+        [skill]
+      );
+
+      expect(usageMap.get(skill.sId)).toEqual({ count: 0, agents: [] });
+    });
+
+    it("returns correct usage for skills linked to agents", async () => {
+      const skillA = await SkillFactory.create(testContext.authenticator, {
+        name: "Skill A",
+      });
+      const skillB = await SkillFactory.create(testContext.authenticator, {
+        name: "Skill B",
+      });
+
+      const agent1 = await AgentConfigurationFactory.createTestAgent(
+        testContext.authenticator,
+        { name: "Agent 1" }
+      );
+      const agent2 = await AgentConfigurationFactory.createTestAgent(
+        testContext.authenticator,
+        { name: "Agent 2" }
+      );
+
+      // Link both skills to agent1, only skillA to agent2.
+      await SkillFactory.linkToAgent(testContext.authenticator, {
+        skillId: skillA.id,
+        agentConfigurationId: agent1.id,
+      });
+      await SkillFactory.linkToAgent(testContext.authenticator, {
+        skillId: skillB.id,
+        agentConfigurationId: agent1.id,
+      });
+      await SkillFactory.linkToAgent(testContext.authenticator, {
+        skillId: skillA.id,
+        agentConfigurationId: agent2.id,
+      });
+
+      const usageMap = await SkillResource.batchFetchUsage(
+        testContext.authenticator,
+        [skillA, skillB]
+      );
+
+      const usageA = usageMap.get(skillA.sId)!;
+      expect(usageA.count).toBe(2);
+      expect(usageA.agents.map((a) => a.name).sort()).toEqual([
+        "Agent 1",
+        "Agent 2",
+      ]);
+
+      const usageB = usageMap.get(skillB.sId)!;
+      expect(usageB.count).toBe(1);
+      expect(usageB.agents[0].name).toBe("Agent 1");
+    });
+
+    it("returns empty map for empty input", async () => {
+      const usageMap = await SkillResource.batchFetchUsage(
+        testContext.authenticator,
+        []
+      );
+      expect(usageMap.size).toBe(0);
+    });
+  });
+
+  describe("batchListEditors", () => {
+    it("returns editors for skills with editor groups", async () => {
+      const skill = await SkillFactory.create(testContext.authenticator, {
+        name: "Skill With Editor",
+      });
+
+      const editorsMap = await SkillResource.batchListEditors(
+        testContext.authenticator,
+        [skill]
+      );
+
+      const editors = editorsMap.get(skill.sId);
+      expect(editors).not.toBeNull();
+      // The creating user is added as editor by default.
+      expect(editors!.length).toBeGreaterThanOrEqual(1);
+      expect(editors!.some((e) => e.id === testContext.user.id)).toBe(true);
+    });
+
+    it("returns editors for multiple skills in batch", async () => {
+      const skillA = await SkillFactory.create(testContext.authenticator, {
+        name: "Skill A Editors",
+      });
+      const skillB = await SkillFactory.create(testContext.authenticator, {
+        name: "Skill B Editors",
+      });
+
+      const editorsMap = await SkillResource.batchListEditors(
+        testContext.authenticator,
+        [skillA, skillB]
+      );
+
+      expect(editorsMap.get(skillA.sId)).not.toBeNull();
+      expect(editorsMap.get(skillB.sId)).not.toBeNull();
+    });
+
+    it("returns empty map for empty input", async () => {
+      const editorsMap = await SkillResource.batchListEditors(
+        testContext.authenticator,
+        []
+      );
+      expect(editorsMap.size).toBe(0);
+    });
+  });
+
+  describe("batchFetchEditedByUsers", () => {
+    it("returns edited-by users for skills", async () => {
+      const skill = await SkillFactory.create(testContext.authenticator, {
+        name: "Edited Skill",
+      });
+
+      const editedByMap = await SkillResource.batchFetchEditedByUsers(
+        testContext.authenticator,
+        [skill]
+      );
+
+      const editedByUser = editedByMap.get(skill.sId);
+      expect(editedByUser).not.toBeNull();
+      expect(editedByUser!.id).toBe(testContext.user.id);
+    });
+
+    it("returns null for skills with no editedBy", async () => {
+      const skill = await SkillFactory.create(testContext.authenticator, {
+        name: "Suggested Skill",
+        status: "suggested",
+      });
+
+      const editedByMap = await SkillResource.batchFetchEditedByUsers(
+        testContext.authenticator,
+        [skill]
+      );
+
+      expect(editedByMap.get(skill.sId)).toBeNull();
+    });
+
+    it("returns correct users for multiple skills", async () => {
+      const skillA = await SkillFactory.create(testContext.authenticator, {
+        name: "Skill A EditedBy",
+      });
+      const skillB = await SkillFactory.create(testContext.authenticator, {
+        name: "Skill B EditedBy",
+      });
+
+      const editedByMap = await SkillResource.batchFetchEditedByUsers(
+        testContext.authenticator,
+        [skillA, skillB]
+      );
+
+      // Both skills edited by the same user (testContext.user).
+      expect(editedByMap.get(skillA.sId)?.id).toBe(testContext.user.id);
+      expect(editedByMap.get(skillB.sId)?.id).toBe(testContext.user.id);
+    });
+
+    it("returns empty map for empty input", async () => {
+      const editedByMap = await SkillResource.batchFetchEditedByUsers(
+        testContext.authenticator,
+        []
+      );
+      expect(editedByMap.size).toBe(0);
+    });
+  });
 });

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1935,19 +1935,19 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     const result = new Map<string, AgentConfigurationModel[]>();
     for (const as of agentSkills) {
-      const skillSId = as.customSkillId
+      const skillId = as.customSkillId
         ? sIdByCustomId.get(as.customSkillId)
         : (as.globalSkillId ?? undefined);
-      if (!skillSId) {
+      if (!skillId) {
         continue;
       }
       const agent = agentConfigById.get(as.agentConfigurationId);
       if (!agent) {
         continue;
       }
-      const list = result.get(skillSId) ?? [];
+      const list = result.get(skillId) ?? [];
       list.push(agent);
-      result.set(skillSId, list);
+      result.set(skillId, list);
     }
 
     return result;
@@ -1961,11 +1961,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     auth: Authenticator,
     skills: SkillResource[]
   ): Promise<Map<string, AgentsUsageType>> {
-    const agentsBySkillSId = await this.batchListActiveAgents(auth, skills);
+    const agentsBySkillId = await this.batchListActiveAgents(auth, skills);
 
     const result = new Map<string, AgentsUsageType>();
     for (const skill of skills) {
-      const agents = (agentsBySkillSId.get(skill.sId) ?? [])
+      const agents = (agentsBySkillId.get(skill.sId) ?? [])
         .map((agent) => ({
           sId: agent.sId,
           name: agent.name,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -29,6 +29,7 @@ import { DataSourceViewResource } from "@app/lib/resources/data_source_view_reso
 import { FileResource } from "@app/lib/resources/file_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import {
   createResourcePermissionsFromSpacesWithMap,
   createSpaceIdToGroupsMap,
@@ -2004,11 +2005,29 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     const allUserIds = [...new Set(Object.values(membershipsByGroupId).flat())];
 
-    const allUsers =
-      allUserIds.length > 0
-        ? await UserResource.fetchByModelIds(allUserIds)
-        : [];
-    const userById = new Map(allUsers.map((u) => [u.id, u]));
+    if (allUserIds.length === 0) {
+      return result;
+    }
+
+    const allUsers = await UserResource.fetchByModelIds(allUserIds);
+
+    // Filter to only keep users with an active workspace membership,
+    // matching the behavior of getActiveMembers.
+    const workspace = auth.getNonNullableWorkspace();
+    const { memberships: workspaceMemberships } =
+      await MembershipResource.getActiveMemberships({
+        users: allUsers,
+        workspace,
+      });
+    const activeWorkspaceUserIds = new Set(
+      workspaceMemberships.map((m) => m.userId)
+    );
+
+    const userById = new Map(
+      allUsers
+        .filter((u) => activeWorkspaceUserIds.has(u.id))
+        .map((u) => [u.id, u])
+    );
 
     for (const skill of skillsWithEditorGroups) {
       const groupId = skill.editorGroup!.id;

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -3,7 +3,10 @@ import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
 import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import { updateAgentRequirements } from "@app/lib/api/assistant/configuration/agent_requirements";
 import { getAgentConfigurationRequirementsFromCapabilities } from "@app/lib/api/assistant/permissions";
-import { hasSharedMembership } from "@app/lib/api/user";
+import {
+  filterUsersWithSharedMembership,
+  hasSharedMembership,
+} from "@app/lib/api/user";
 import type { Authenticator } from "@app/lib/auth";
 import { hasAll } from "@app/lib/matcher/operators/array";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
@@ -1871,6 +1874,189 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     });
 
     return shouldReturnEditedByUser ? editedByUser : null;
+  }
+
+  /**
+   * Batch version of listActiveAgents, returns active agents grouped by skill sId.
+   */
+  private static async batchListActiveAgents(
+    auth: Authenticator,
+    skills: SkillResource[]
+  ): Promise<Map<string, AgentConfigurationModel[]>> {
+    if (skills.length === 0) {
+      return new Map();
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+
+    // Separate custom skills from global skills.
+    const customSkillIds = removeNulls(
+      skills.map((s) => (s.globalSId ? null : s.id))
+    );
+    const globalSkillIds = removeNulls(skills.map((s) => s.globalSId));
+
+    // Single query: all agent-skill associations for the given skills.
+    const agentSkills = await AgentSkillModel.findAll({
+      where: {
+        workspaceId: workspace.id,
+        [Op.or]: removeNulls([
+          customSkillIds.length > 0
+            ? { customSkillId: { [Op.in]: customSkillIds } }
+            : null,
+          globalSkillIds.length > 0
+            ? { globalSkillId: { [Op.in]: globalSkillIds } }
+            : null,
+        ]),
+      },
+    });
+
+    if (agentSkills.length === 0) {
+      return new Map();
+    }
+
+    // Single query: all referenced agent configurations.
+    const uniqueAgentConfigIds = [
+      ...new Set(agentSkills.map((as) => as.agentConfigurationId)),
+    ];
+    const agentConfigs = await AgentConfigurationModel.findAll({
+      where: {
+        id: { [Op.in]: uniqueAgentConfigIds },
+        workspaceId: workspace.id,
+        status: "active",
+      },
+    });
+
+    const agentConfigById = new Map(agentConfigs.map((a) => [a.id, a]));
+
+    // Map AgentSkillModel references back to skill sId.
+    const sIdByCustomId = new Map(
+      skills.filter((s) => !s.globalSId).map((s) => [s.id, s.sId])
+    );
+
+    const result = new Map<string, AgentConfigurationModel[]>();
+    for (const as of agentSkills) {
+      const skillSId = as.customSkillId
+        ? sIdByCustomId.get(as.customSkillId)
+        : (as.globalSkillId ?? undefined);
+      if (!skillSId) {
+        continue;
+      }
+      const agent = agentConfigById.get(as.agentConfigurationId);
+      if (!agent) {
+        continue;
+      }
+      const list = result.get(skillSId) ?? [];
+      list.push(agent);
+      result.set(skillSId, list);
+    }
+
+    return result;
+  }
+
+  /**
+   * Batch fetch usage (agents using each skill) for multiple skills.
+   * Keyed by skill sId to avoid collisions (global skills share id: -1).
+   */
+  static async batchFetchUsage(
+    auth: Authenticator,
+    skills: SkillResource[]
+  ): Promise<Map<string, AgentsUsageType>> {
+    const agentsBySkillSId = await this.batchListActiveAgents(auth, skills);
+
+    const result = new Map<string, AgentsUsageType>();
+    for (const skill of skills) {
+      const agents = (agentsBySkillSId.get(skill.sId) ?? [])
+        .map((agent) => ({
+          sId: agent.sId,
+          name: agent.name,
+          pictureUrl: agent.pictureUrl,
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name));
+      result.set(skill.sId, { count: agents.length, agents });
+    }
+
+    return result;
+  }
+
+  /**
+   * Batch list editors for multiple skills. Keyed by skill sId.
+   */
+  static async batchListEditors(
+    auth: Authenticator,
+    skills: SkillResource[]
+  ): Promise<Map<string, UserResource[] | null>> {
+    const result = new Map<string, UserResource[] | null>(
+      skills.map((s) => [s.sId, null])
+    );
+
+    const skillsWithEditorGroups = skills.filter((s) => s.editorGroup !== null);
+
+    if (skillsWithEditorGroups.length === 0) {
+      return result;
+    }
+
+    const editorGroups = removeNulls(
+      skillsWithEditorGroups.map((s) => s.editorGroup)
+    );
+
+    const membershipsByGroupId =
+      await GroupResource.getActiveMembershipsForGroups(auth, editorGroups);
+
+    const allUserIds = [...new Set(Object.values(membershipsByGroupId).flat())];
+
+    const allUsers =
+      allUserIds.length > 0
+        ? await UserResource.fetchByModelIds(allUserIds)
+        : [];
+    const userById = new Map(allUsers.map((u) => [u.id, u]));
+
+    for (const skill of skillsWithEditorGroups) {
+      const groupId = skill.editorGroup!.id;
+      const userIds = membershipsByGroupId[groupId] ?? [];
+      const users = removeNulls(userIds.map((id) => userById.get(id) ?? null));
+      result.set(skill.sId, users);
+    }
+
+    return result;
+  }
+
+  /**
+   * Batch fetch edited-by users for multiple skills.
+   */
+  static async batchFetchEditedByUsers(
+    auth: Authenticator,
+    skills: SkillResource[]
+  ): Promise<Map<string, UserResource | null>> {
+    const result = new Map<string, UserResource | null>(
+      skills.map((s) => [s.sId, null])
+    );
+
+    const uniqueEditedByIds = [
+      ...new Set(removeNulls(skills.map((s) => s.editedBy))),
+    ];
+
+    if (uniqueEditedByIds.length === 0) {
+      return result;
+    }
+
+    // Single query: fetch all edited-by users.
+    const editedByUsers = await UserResource.fetchByModelIds(uniqueEditedByIds);
+
+    // Batch privacy filter: keep only users visible to the auth user.
+    const visibleUsers = await filterUsersWithSharedMembership(
+      auth,
+      editedByUsers
+    );
+    const visibleUserIds = new Set(visibleUsers.map((u) => u.id));
+    const userById = new Map(visibleUsers.map((u) => [u.id, u]));
+
+    for (const skill of skills) {
+      if (skill.editedBy !== null && visibleUserIds.has(skill.editedBy)) {
+        result.set(skill.sId, userById.get(skill.editedBy) ?? null);
+      }
+    }
+
+    return result;
   }
 
   async archive(auth: Authenticator): Promise<{ affectedCount: number }> {

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -8,7 +8,6 @@ import { DataSourceViewResource } from "@app/lib/resources/data_source_view_reso
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type {
@@ -131,42 +130,46 @@ async function handler(
       });
 
       if (withRelations === "true") {
-        const extendedSkills = await SkillResource.fetchByIds(
-          auth,
-          removeNulls(uniq(skills.map((skill) => skill.extendedSkillId)))
-        );
+        const [extendedSkills, usageMap, editorsMap, editedByUsersMap] =
+          await Promise.all([
+            SkillResource.fetchByIds(
+              auth,
+              removeNulls(uniq(skills.map((skill) => skill.extendedSkillId)))
+            ),
+            SkillResource.batchFetchUsage(auth, skills),
+            SkillResource.batchListEditors(auth, skills),
+            SkillResource.batchFetchEditedByUsers(auth, skills),
+          ]);
+
         const extendedSkillsMap = new Map(
           extendedSkills.map((skill) => [skill.sId, skill])
         );
 
-        const skillsWithRelations = await concurrentExecutor(
-          skills,
-          async (sc) => {
-            const {
-              instructions,
-              instructionsHtml,
-              tools,
-              ...skillWithoutInstructionsAndTools
-            } = sc.toJSON(auth);
-            const usage = await sc.fetchUsage(auth);
-            const editors = await sc.listEditors(auth);
-            const editedByUser = await sc.fetchEditedByUser(auth);
+        const skillsWithRelations = skills.map((sc) => {
+          const {
+            instructions,
+            instructionsHtml,
+            tools,
+            ...skillWithoutInstructionsAndTools
+          } = sc.toJSON(auth);
 
-            return {
-              ...skillWithoutInstructionsAndTools,
-              relations: {
-                usage,
-                editors: editors ? editors.map((e) => e.toJSON()) : null,
-                editedByUser: editedByUser ? editedByUser.toJSON() : null,
-                extendedSkill: sc.extendedSkillId
-                  ? (extendedSkillsMap.get(sc.extendedSkillId)?.toJSON(auth) ??
-                    null)
-                  : null,
-              },
-            } satisfies SkillWithoutInstructionsAndToolsWithRelationsType;
-          },
-          { concurrency: 10 }
-        );
+          const usage = usageMap.get(sc.sId) ?? { count: 0, agents: [] };
+          const editors = editorsMap.get(sc.sId) ?? null;
+          const editedByUser = editedByUsersMap.get(sc.sId) ?? null;
+
+          return {
+            ...skillWithoutInstructionsAndTools,
+            relations: {
+              usage,
+              editors: editors ? editors.map((e) => e.toJSON()) : null,
+              editedByUser: editedByUser ? editedByUser.toJSON() : null,
+              extendedSkill: sc.extendedSkillId
+                ? (extendedSkillsMap.get(sc.extendedSkillId)?.toJSON(auth) ??
+                  null)
+                : null,
+            },
+          } satisfies SkillWithoutInstructionsAndToolsWithRelationsType;
+        });
 
         return res.status(200).json({ skills: skillsWithRelations });
       }


### PR DESCRIPTION
## Description

related to https://github.com/dust-tt/tasks/issues/8101

It should speed up retrieving the skills info as we will do way less queries.
For our workspace with 250+ skills we currently do more than 1K queries to DB

## Tests

added unit tests

## Risk

low, can be reverted

## Deploy Plan

normal front deployement
