### PR TITLE
[front] chore: cleanup logs in Notion workflow production check

### DIFF
--- a/front/lib/production_checks/checks/check_notion_active_workflows.ts
+++ b/front/lib/production_checks/checks/check_notion_active_workflows.ts
@@ -128,8 +128,6 @@ async function areTemporalWorkflowsRunning(
     logger,
   });
 
-  logger.info("Workflow descriptions retrieved");
-
   if (!descriptions) {
     return {
       isRunning: false,
@@ -154,8 +152,6 @@ async function areTemporalWorkflowsRunning(
       getLatestWorkflowEventDate({ client, description, logger })
     )
   );
-
-  logger.info("Workflow latest events retrieved");
 
   const now = new Date().getTime();
 


### PR DESCRIPTION
## Description

- Quick follow up on https://github.com/dust-tt/dust/pull/26070
- The logs for a production check run ([link](https://app.datadoghq.eu/logs?query=region%3Aus-central1%20%40all_check_uuid%3A954cfbc6-89a8-4294-8a1d-91dba0c5d42d&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40checkName&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1779879552987&to_ts=1779886112799&live=false)) are currently flooded by two logs that are removed by this PR, requiring an additional filtering.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
