### PR TITLE
feat: handle cases where user is null in pod manager tools

### DIFF
--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -816,7 +816,7 @@ export function createProjectManagerTools(
         }
 
         const { space } = contextRes.value;
-        const user = auth.getNonNullableUser();
+        const user = auth.user();
         const owner = auth.getNonNullableWorkspace();
 
         // Get origin and timezone from the current conversation
@@ -871,7 +871,9 @@ export function createProjectManagerTools(
           mentions,
           context: {
             username: agentName,
-            fullName: `@${agentName} on behalf of ${user.fullName()}`,
+            fullName: user
+              ? `@${agentName} on behalf of ${user.fullName()}`
+              : `@${agentName}`,
             email: null,
             profilePictureUrl: agentProfilePictureUrl,
             timezone,
@@ -1072,7 +1074,7 @@ export function createProjectManagerTools(
         }
 
         const { space } = contextRes.value;
-        const user = auth.getNonNullableUser();
+        const user = auth.user();
         const owner = auth.getNonNullableWorkspace();
 
         const conversationId =
@@ -1151,7 +1153,9 @@ export function createProjectManagerTools(
           mentions,
           context: {
             username: agentName,
-            fullName: `@${agentName} on behalf of ${user.fullName()}`,
+            fullName: user
+              ? `@${agentName} on behalf of ${user.fullName()}`
+              : `@${agentName}`,
             email: null,
             profilePictureUrl: agentProfilePictureUrl,
             timezone,


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8270

Fixes a crash in pod manager tools when invoked from a Slack bot context (no authenticated user).

Root cause: When an agent workflow is triggered with a Slack bot, there is no authenticated user in the execution context. Two tool handlers in `pod_manager/tools/index.ts` were calling `auth.getNonNullableUser()`, which throws `Unexpected unauthenticated call to getNonNullableUser` in that scenario, crashing the tool call before it could create a Pod conversation.

- Replace `auth.getNonNullableUser()` with the nullable `auth.user()` in two tool handlers.
- Fall back to `@${agentName}` when user is null, instead of `@${agentName} on behalf of ${user.fullName()}`.


## Tests


## Risk

Low. 

## Deploy Plan

Standard deployment.