### PR TITLE
[front] AgentSingleActionPanel: force remount on actionId change

### DIFF
--- a/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
@@ -578,6 +578,7 @@ export function AgentActionsPanel({
   if (actionId) {
     return (
       <AgentSingleActionPanel
+        key={actionId}
         conversation={conversation}
         owner={owner}
         messageId={messageId}


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8291
Force remount of AgentSingleActionPanel when actionId changes using "key" prop
(similar to what is done for AgentActionsPanelContent)

## Tests

Not tested, simple prop addition

## Risk

Low, simple prop addition

## Deploy Plan

Deploy front