### PR TITLE
Reverting usage time slots

### DIFF
--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -1,7 +1,7 @@
 import type { Authenticator } from "@app/lib/auth";
 import {
-  ceilToHourISO,
-  floorToHourISO,
+  ceilToMidnightUTC,
+  floorToMidnightUTC,
   listMetronomeBalances,
   listMetronomeDraftInvoices,
   listMetronomeUsageWithGroups,
@@ -107,7 +107,9 @@ export async function handleAwuPoolSummaryRequest(
         });
       }
 
-      const resetDate = ceilToHourISO(new Date(currentInvoice.end_timestamp));
+      const resetDate = ceilToMidnightUTC(
+        new Date(currentInvoice.end_timestamp)
+      ).toISOString();
 
       // Filter to active, non-seat AWU pool credits and commits. The set of
       // seat product IDs is derived from the contract's tagged subscriptions
@@ -155,12 +157,12 @@ export async function handleAwuPoolSummaryRequest(
         }
       }
 
-      const startingOn = floorToHourISO(
+      const startingOn = floorToMidnightUTC(
         new Date(currentInvoice.start_timestamp)
-      );
-      const endingBefore = ceilToHourISO(
+      ).toISOString();
+      const endingBefore = ceilToMidnightUTC(
         new Date(currentInvoice.end_timestamp)
-      );
+      ).toISOString();
 
       // Query usage per user and seat allocations in parallel.
       // Per-user breakdown is needed to compute pool overflow correctly:

--- a/front/lib/metronome/per_user_usage.ts
+++ b/front/lib/metronome/per_user_usage.ts
@@ -1,6 +1,6 @@
 import {
-  ceilToHourISO,
-  floorToHourISO,
+  ceilToMidnightUTC,
+  floorToMidnightUTC,
   listMetronomeDraftInvoices,
   listMetronomeUsageWithGroups,
 } from "@app/lib/metronome/client";
@@ -37,8 +37,12 @@ export async function fetchPerUserAwuUsage({
     return new Ok(new Map());
   }
 
-  const startingOn = floorToHourISO(new Date(currentInvoice.start_timestamp));
-  const endingBefore = ceilToHourISO(new Date(currentInvoice.end_timestamp));
+  const startingOn = floorToMidnightUTC(
+    new Date(currentInvoice.start_timestamp)
+  ).toISOString();
+  const endingBefore = ceilToMidnightUTC(
+    new Date(currentInvoice.end_timestamp)
+  ).toISOString();
 
   const usageResult = await listMetronomeUsageWithGroups({
     customerId: metronomeCustomerId,


### PR DESCRIPTION
## Description

Reverts a previous change that switched Metronome usage query time boundaries from midnight-UTC aligned (`floorToMidnightUTC` / `ceilToMidnightUTC`) to hour-aligned (`floorToHourISO` / `ceilToHourISO`) in `awu_pool_summary.ts` and `per_user_usage.ts`. This restores the daily granularity for `startingOn` / `endingBefore` parameters passed to Metronome when fetching AWU pool and per-user usage, which is consistent with how the rest of the codebase (e.g. `metronome_usage.ts`) queries Metronome.

## Tests

Manually verified by reverting; no test changes needed as the logic is a straightforward function swap.

## Risk

Low. Restores previously working behavior. The only effect is the time boundary alignment used in Metronome API calls — daily instead of hourly.

## Deploy Plan

Deploy front.