### PR TITLE
[metronome] feat: add workspace default spend-limit API endpoint

### DIFF
--- a/front/pages/api/w/[wId]/usage_settings/default_user_spend_limit.test.ts
+++ b/front/pages/api/w/[wId]/usage_settings/default_user_spend_limit.test.ts
@@ -1,0 +1,256 @@
+import * as businessLayer from "@app/lib/api/workspace/default_user_spend_limit";
+import { DefaultUserSpendLimitError } from "@app/lib/api/workspace/default_user_spend_limit";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Err, Ok } from "@app/types/shared/result";
+import type { WorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import handler from "./default_user_spend_limit";
+
+vi.mock("@app/lib/api/workspace/default_user_spend_limit", async () => {
+  const actual = await vi.importActual<typeof businessLayer>(
+    "@app/lib/api/workspace/default_user_spend_limit"
+  );
+  return {
+    ...actual,
+    getDefaultUserSpendLimit: vi.fn(),
+    setDefaultUserSpendLimit: vi.fn(),
+  };
+});
+
+const TEST_METRONOME_CUSTOMER_ID = "cust_test_xxx";
+
+async function makeMetronomeWorkspace(): Promise<WorkspaceType> {
+  return WorkspaceFactory.metronome({
+    metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(businessLayer.getDefaultUserSpendLimit).mockResolvedValue(
+    new Ok({ awuCredits: 1000 })
+  );
+  vi.mocked(businessLayer.setDefaultUserSpendLimit).mockResolvedValue(
+    new Ok({ awuCredits: 1000 })
+  );
+});
+
+describe("/api/w/[wId]/usage_settings/default_user_spend_limit", () => {
+  describe("auth", () => {
+    it("returns 403 when caller is not an admin", async () => {
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "user",
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(403);
+      expect(res._getJSONData().error.type).toBe("workspace_auth_error");
+    });
+
+    it("returns 403 when workspace is not Metronome-billed", async () => {
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(403);
+      expect(res._getJSONData().error.type).toBe("plan_limit_error");
+    });
+  });
+
+  describe("method validation", () => {
+    it("returns 405 for unsupported methods", async () => {
+      const workspace = await makeMetronomeWorkspace();
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "admin",
+        workspace,
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(405);
+    });
+  });
+
+  describe("GET", () => {
+    it("returns the configured threshold", async () => {
+      vi.mocked(businessLayer.getDefaultUserSpendLimit).mockResolvedValueOnce(
+        new Ok({ awuCredits: 25_000 })
+      );
+
+      const workspace = await makeMetronomeWorkspace();
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData()).toEqual({ awuCredits: 25_000 });
+    });
+
+    it("returns 200 with awuCredits=null when no default is configured", async () => {
+      vi.mocked(businessLayer.getDefaultUserSpendLimit).mockResolvedValueOnce(
+        new Err(new DefaultUserSpendLimitError("not_found", "no default"))
+      );
+
+      const workspace = await makeMetronomeWorkspace();
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData()).toEqual({ awuCredits: null });
+    });
+
+    it("returns 502 on Metronome errors", async () => {
+      vi.mocked(businessLayer.getDefaultUserSpendLimit).mockResolvedValueOnce(
+        new Err(new DefaultUserSpendLimitError("metronome_error", "boom"))
+      );
+
+      const workspace = await makeMetronomeWorkspace();
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(502);
+    });
+  });
+
+  describe("PUT", () => {
+    it("updates the threshold and returns the new value", async () => {
+      vi.mocked(businessLayer.setDefaultUserSpendLimit).mockResolvedValueOnce(
+        new Ok({ awuCredits: 5000 })
+      );
+
+      const workspace = await makeMetronomeWorkspace();
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+      req.body = { awuCredits: 5000 };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData()).toEqual({ awuCredits: 5000 });
+      expect(businessLayer.setDefaultUserSpendLimit).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ awuCredits: 5000 })
+      );
+    });
+
+    it("returns 400 when awuCredits is missing", async () => {
+      const workspace = await makeMetronomeWorkspace();
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+      req.body = {};
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+      expect(res._getJSONData().error.type).toBe("invalid_request_error");
+      expect(businessLayer.setDefaultUserSpendLimit).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when awuCredits is negative", async () => {
+      const workspace = await makeMetronomeWorkspace();
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+      req.body = { awuCredits: -1 };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+    });
+
+    it("returns 400 when awuCredits is non-integer", async () => {
+      const workspace = await makeMetronomeWorkspace();
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+      req.body = { awuCredits: 1.5 };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+    });
+
+    it("returns 400 when awuCredits exceeds the max", async () => {
+      const workspace = await makeMetronomeWorkspace();
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+      req.body = { awuCredits: 100_000_000 };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+    });
+
+    it("maps invalid_threshold from the business layer to 400", async () => {
+      vi.mocked(businessLayer.setDefaultUserSpendLimit).mockResolvedValueOnce(
+        new Err(
+          new DefaultUserSpendLimitError("invalid_threshold", "out of range")
+        )
+      );
+
+      const workspace = await makeMetronomeWorkspace();
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+      req.body = { awuCredits: 1000 };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+    });
+
+    it("returns 502 when the business layer reports a Metronome error", async () => {
+      vi.mocked(businessLayer.setDefaultUserSpendLimit).mockResolvedValueOnce(
+        new Err(new DefaultUserSpendLimitError("metronome_error", "boom"))
+      );
+
+      const workspace = await makeMetronomeWorkspace();
+      const { req, res } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+      req.body = { awuCredits: 1000 };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(502);
+    });
+  });
+});

--- a/front/pages/api/w/[wId]/usage_settings/default_user_spend_limit.ts
+++ b/front/pages/api/w/[wId]/usage_settings/default_user_spend_limit.ts
@@ -1,0 +1,160 @@
+/** @ignoreswagger */
+
+import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import {
+  type DefaultUserSpendLimit,
+  type DefaultUserSpendLimitError,
+  getDefaultUserSpendLimit,
+  MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
+  MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
+  setDefaultUserSpendLimit,
+} from "@app/lib/api/workspace/default_user_spend_limit";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+const UpdateDefaultUserSpendLimitBodySchema = z.object({
+  awuCredits: z
+    .number()
+    .int()
+    .min(MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS)
+    .max(MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS),
+});
+
+export type GetDefaultUserSpendLimitResponseBody = {
+  awuCredits: number | null;
+};
+
+export type PutDefaultUserSpendLimitResponseBody = DefaultUserSpendLimit;
+
+function mapErrorToHttp(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  error: DefaultUserSpendLimitError
+): void {
+  switch (error.type) {
+    case "workspace_not_metronome_billed":
+      return apiError(req, res, {
+        status_code: 403,
+        api_error: {
+          type: "plan_limit_error",
+          message: error.message,
+        },
+      });
+    case "not_found":
+      return apiError(req, res, {
+        status_code: 404,
+        api_error: {
+          type: "workspace_not_found",
+          message: error.message,
+        },
+      });
+    case "invalid_threshold":
+      return apiError(req, res, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: error.message,
+        },
+      });
+    case "metronome_error":
+      return apiError(req, res, {
+        status_code: 502,
+        api_error: {
+          type: "internal_server_error",
+          message:
+            "Failed to read or update the default spend limit in billing system.",
+        },
+      });
+    default:
+      assertNever(error.type);
+  }
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<
+      | GetDefaultUserSpendLimitResponseBody
+      | PutDefaultUserSpendLimitResponseBody
+    >
+  >,
+  auth: Authenticator
+): Promise<void> {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can manage the default user spend limit.",
+      },
+    });
+  }
+
+  if (!auth.getNonNullableSubscriptionResource().isMetronomeOnlyBilled) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "plan_limit_error",
+        message:
+          "The default user spend limit is only available on Metronome-billed workspaces.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const result = await getDefaultUserSpendLimit(auth);
+      if (result.isErr()) {
+        if (result.error.type === "not_found") {
+          return res.status(200).json({ awuCredits: null });
+        }
+        return mapErrorToHttp(req, res, result.error);
+      }
+      return res.status(200).json(result.value);
+    }
+
+    case "PUT": {
+      const bodyValidation = UpdateDefaultUserSpendLimitBodySchema.safeParse(
+        req.body
+      );
+      if (!bodyValidation.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${fromError(bodyValidation.error).toString()}`,
+          },
+        });
+      }
+
+      const auditContext = getAuditLogContext(auth, req);
+      const result = await setDefaultUserSpendLimit(auth, {
+        awuCredits: bodyValidation.data.awuCredits,
+        auditContext,
+      });
+      if (result.isErr()) {
+        return mapErrorToHttp(req, res, result.error);
+      }
+      return res.status(200).json(result.value);
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, GET or PUT is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

Adds the admin-only GET/PUT private API endpoint for the workspace default spend limit, including request validation and domain-error-to-HTTP mapping.

## Tests

unit

## Risk

low

## Deploy Plan

front