### PR TITLE
Polish mobile compact input bar

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -555,19 +555,9 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
       <div
         className={classNames(
           "relative w-full",
-          effectiveIsCompact && "flex justify-center"
+          effectiveIsCompact && "flex items-center gap-2"
         )}
       >
-        {effectiveIsCompact && showNavigationContainer && (
-          <div className="absolute right-0 top-1/2 z-10 -translate-y-1/2">
-            <div className={INPUT_BAR_COMPACT_NAV_ENTER_ANIMATION_CLASSES}>
-              <InputBarMessageNavigation
-                variant="compact"
-                {...messageNavigationProps}
-              />
-            </div>
-          </div>
-        )}
         <InputBar
           owner={context.owner}
           user={context.user}
@@ -587,6 +577,16 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
           onOverlayOpenChange={onOverlayOpenChange}
           onVoiceActiveChange={onVoiceActiveChange}
         />
+        {effectiveIsCompact && showNavigationContainer && (
+          <div className="shrink-0">
+            <div className={INPUT_BAR_COMPACT_NAV_ENTER_ANIMATION_CLASSES}>
+              <InputBarMessageNavigation
+                variant="compact"
+                {...messageNavigationProps}
+              />
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -404,7 +404,7 @@ export const InputBar = React.memo(function InputBar({
     <div
       className={classNames(
         "flex w-full flex-col",
-        effectiveIsCompact && "items-center"
+        effectiveIsCompact && "min-w-0 flex-1"
       )}
     >
       <PlanCard

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -4,6 +4,7 @@ import { InputBarButtons } from "@app/components/assistant/conversation/input_ba
 import {
   INPUT_BAR_COMPACT_CONTENT_ENTER_ANIMATION_CLASSES,
   INPUT_BAR_COMPACT_PILL_INNER_CLASSES,
+  INPUT_BAR_COMPACT_PREVIEW_CLASSES,
 } from "@app/components/assistant/conversation/input_bar/inputBarCompactStyles";
 import {
   getDisplayNameFromPastedFileId,
@@ -52,10 +53,8 @@ import type { UserType, WorkspaceType } from "@app/types/user";
 import {
   ArrowUpIcon,
   AttachmentIcon,
-  Avatar,
   Button,
   CameraIcon,
-  ChevronUpDownIcon,
   Chip,
   cn,
   DropdownMenu,
@@ -65,7 +64,6 @@ import {
   DropdownMenuTrigger,
   GlobeAltIcon,
   PlusIcon,
-  RobotIcon,
   TextIcon,
   Toolbar,
   TooltipContent,
@@ -1050,6 +1048,9 @@ const InputBarContainer = ({
 
   const isRecording = voiceTranscriberService.status === "recording";
   const isVoiceActive = voiceTranscriberService.status !== "idle";
+  const compactPreviewText = editorService.getTrimmedText();
+  const compactDisplayPlaceholder =
+    (disableInput ? submitBlockMessage : placeholder) ?? "Get work done";
 
   useEffect(() => {
     onVoiceActiveChange?.(isVoiceActive);
@@ -1096,43 +1097,30 @@ const InputBarContainer = ({
           className={cn(
             INPUT_BAR_COMPACT_PILL_INNER_CLASSES,
             INPUT_BAR_COMPACT_CONTENT_ENTER_ANIMATION_CLASSES,
-            "relative w-auto gap-0 sm:pt-0",
-            isVoiceActive ? "px-0.5" : "px-1"
+            "relative min-w-0 w-full gap-1 px-1 sm:pt-0"
           )}
         >
           {!isVoiceActive && (
-            <div className="flex min-w-0 flex-1 items-center gap-1 px-1">
-              <div
-                aria-hidden
-                className="inline-flex min-w-0 max-w-24 items-center gap-1"
-              >
-                {selectedSingleAgent ? (
-                  <>
-                    <Avatar
-                      size="xxs"
-                      visual={selectedSingleAgent.pictureUrl}
-                    />
-                    <span className="truncate copy-xs text-muted-foreground dark:text-muted-foreground-night">
-                      {selectedSingleAgent.label}
-                    </span>
-                  </>
-                ) : (
-                  <>
-                    <RobotIcon className="h-3.5 w-3.5 shrink-0 text-faint dark:text-faint-night" />
-                    <span className="truncate copy-xs text-faint dark:text-faint-night">
-                      Agent
-                    </span>
-                  </>
-                )}
-              </div>
-              <ChevronUpDownIcon className="h-3.5 w-3.5 shrink-0 text-faint dark:text-faint-night" />
+            <div
+              aria-hidden
+              className={cn(
+                INPUT_BAR_COMPACT_PREVIEW_CLASSES,
+                compactPreviewText
+                  ? "text-foreground dark:text-foreground-night"
+                  : "text-faint dark:text-faint-night"
+              )}
+            >
+              {compactPreviewText || compactDisplayPlaceholder}
             </div>
           )}
           {!subscription.plan.isByok &&
             owner.metadata?.allowVoiceTranscription !== false &&
             actions.includes("voice") && (
               <div
-                className="flex shrink-0 flex-row items-center"
+                className={cn(
+                  "flex shrink-0 flex-row items-center",
+                  isVoiceActive && "ml-auto"
+                )}
                 data-compact-voice
               >
                 <VoicePicker

--- a/front/components/assistant/conversation/input_bar/inputBarCompactStyles.ts
+++ b/front/components/assistant/conversation/input_bar/inputBarCompactStyles.ts
@@ -1,8 +1,11 @@
 export const INPUT_BAR_COMPACT_PILL_CLASSES =
-  "w-fit shrink-0 rounded-full border border-border/30 bg-muted-background/70 px-1 py-0.5 dark:border-border-night/30 dark:bg-muted-background-night/70";
+  "min-w-0 w-full rounded-full border border-border/30 bg-muted-background/60 px-1 py-0.5 backdrop-blur-sm dark:border-border-night/30 dark:bg-muted-background-night/60";
 
 export const INPUT_BAR_COMPACT_PILL_INNER_CLASSES =
-  "flex h-8 flex-row items-center gap-1";
+  "flex h-8 min-w-0 flex-row items-center gap-1";
+
+export const INPUT_BAR_COMPACT_PREVIEW_CLASSES =
+  "min-w-0 flex-1 truncate rounded-full px-2.5 copy-xs leading-8";
 
 export const INPUT_BAR_COMPACT_ENTER_ANIMATION_CLASSES =
   "motion-safe:origin-bottom motion-safe:animate-input-bar-compact-in";


### PR DESCRIPTION
## Description

Several visual fixes to the mobile compact input bar:

- The compact pill now stretches full-width (`min-w-0 w-full`) instead of being a fixed-width centered pill, making better use of mobile screen real estate.
- The agent avatar + name + `ChevronUpDownIcon` combo in the pill is replaced with a live text preview via `editorService.getTrimmedText()`, falling back to the placeholder or `submitBlockMessage`. This gives users a glanceable summary of their draft.
- `InputBarMessageNavigation` in compact mode moves from absolute positioning (overlapping the pill) to natural flex layout (`shrink-0`) to the right of the pill, eliminating z-index stacking issues.
- `backdrop-blur-sm` added to `INPUT_BAR_COMPACT_PILL_CLASSES` for polish; opacity nudged from 70% to 60%.

<img width="395" height="730" alt="image" src="https://github.com/user-attachments/assets/bb4949cf-c485-4455-bd12-8ad5b08b20a9" />

(seen with @Duncid)

## Tests

Tested locally on mobile viewport.

## Risk

Low. Pure CSS/layout changes scoped to compact mode on mobile; no logic, no data, no API changes. Safe to rollback by reverting the front deploy.

## Deploy Plan

Deploy front.
