### PR TITLE
fix(core): attach OTEL resource to log provider so region appears in Datadog

### DIFF
--- a/core/src/open_telemetry.rs
+++ b/core/src/open_telemetry.rs
@@ -143,7 +143,9 @@ pub fn init_subscribers_and_loglevel(log_directives: &str) -> Result<TracingGuar
             .with_tonic()
             .build()
             .expect("failed to install logging");
+        let log_rsrc = init_tracing_opentelemetry::resource::DetectResource::default().build();
         let provider: SdkLoggerProvider = opentelemetry_sdk::logs::SdkLoggerProvider::builder()
+            .with_resource(log_rsrc)
             .with_batch_exporter(exporter)
             .build();
         let otel_layer = EnrichedOtelLayer::new(&provider);


### PR DESCRIPTION
## Description

The `SdkLoggerProvider` in `core/src/open_telemetry.rs` was built without an OTEL resource, so resource attributes (including `region`) were never attached to logs. The tracer provider already used `DetectResource::default().build()` correctly — logs were just missing the same call.

Fix: call `DetectResource::default().build()` a second time and pass the result to `.with_resource()` on the log provider. Both calls read the same environment variables (`OTEL_RESOURCE_ATTRIBUTES`, K8s metadata, etc.) so the result is identical. This is startup-time-only code so the extra env-var read is harmless.

## Tests


