### PR TITLE
[front] fix: defer skill file uploads until save

### DIFF
--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -155,13 +155,21 @@ export default function SkillBuilder({
       type: "success",
     });
 
+    for (const warning of result.value.warnings) {
+      sendNotification({
+        title: "Skill editors not updated",
+        description: warning.message,
+        type: "info",
+      });
+    }
+
     onSaved();
 
-    if (isCreatingNew && result.value.sId) {
-      const newUrl = `/w/${owner.sId}/builder/skills/${result.value.sId}`;
+    if (isCreatingNew && result.value.skill.sId) {
+      const newUrl = `/w/${owner.sId}/builder/skills/${result.value.skill.sId}`;
       await router.replace(newUrl, undefined, { shallow: true });
     } else {
-      form.reset(form.getValues(), { keepValues: true });
+      form.reset(result.value.formData);
     }
 
     setIsSaving(false);

--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -1,8 +1,19 @@
-import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
-import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
+import type {
+  PendingSkillBuilderFileAttachment,
+  SkillBuilderFormData,
+} from "@app/components/skill_builder/SkillBuilderFormContext";
 import { useSkillVersionComparisonContext } from "@app/components/skill_builder/SkillBuilderVersionContext";
-import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useSendNotification } from "@app/hooks/useNotification";
+import {
+  contentTypeFromFileName,
+  DEFAULT_FILE_CONTENT_TYPE,
+  type FileFormatCategory,
+  fileSizeToHumanReadable,
+  getFileFormatCategory,
+  isSupportedFileContentType,
+  resolveFileContentType,
+  resolveMaxFileSizes,
+} from "@app/types/files";
 import {
   ArrowGoBackIcon,
   Button,
@@ -11,14 +22,50 @@ import {
   DocumentIcon,
   EmptyCTA,
   PlusIcon,
-  Spinner,
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
 
+const SKILL_ATTACHMENT_FILE_UPLOAD_OPTIONS = {
+  hasSandboxTools: false,
+  useCase: "skill_attachment",
+} as const;
+
+const SKILL_ATTACHMENT_MAX_FILE_SIZES = resolveMaxFileSizes(
+  SKILL_ATTACHMENT_FILE_UPLOAD_OPTIONS
+);
+
+function resolveSkillAttachmentContentType(file: File): string {
+  const resolvedContentType = resolveFileContentType(file.type, file.name);
+  if (isSupportedFileContentType(resolvedContentType)) {
+    return resolvedContentType;
+  }
+
+  return (
+    contentTypeFromFileName(file.name) ??
+    (resolvedContentType || DEFAULT_FILE_CONTENT_TYPE)
+  );
+}
+
+function getSkillAttachmentSizeLimitError({
+  contentType,
+  file,
+}: {
+  contentType: string;
+  file: File;
+}): { category: FileFormatCategory; maxFileSize: number } | null {
+  const category = getFileFormatCategory(contentType) ?? "data";
+  const maxFileSize = SKILL_ATTACHMENT_MAX_FILE_SIZES[category];
+
+  if (file.size <= maxFileSize) {
+    return null;
+  }
+
+  return { category, maxFileSize };
+}
+
 export function SkillBuilderFilesSection() {
-  const { owner, skillId } = useSkillBuilderContext();
   const sendNotification = useSendNotification();
   const { setValue } = useFormContext<SkillBuilderFormData>();
   const { compareVersion, isDiffMode } = useSkillVersionComparisonContext();
@@ -36,13 +83,6 @@ export function SkillBuilderFilesSection() {
   const fileListRef = useRef<HTMLDivElement>(null);
   const fileListBottomSentinelRef = useRef<HTMLDivElement>(null);
 
-  const { handleFilesUpload, isProcessingFiles } = useFileUploaderService({
-    hasSandboxTools: false,
-    owner,
-    useCase: "skill_attachment",
-    useCaseMetadata: skillId ? { skillId } : undefined,
-  });
-
   const existingFileNames = useMemo(
     () => new Set(fields.map((f) => f.fileName)),
     [fields]
@@ -57,15 +97,17 @@ export function SkillBuilderFilesSection() {
   );
 
   const currentFileIds = useMemo(
-    () => new Set(fields.map((f) => f.fileId)),
+    () => new Set<string | null>(fields.map((f) => f.fileId)),
     [fields]
   );
 
   const compareFileIds = useMemo(
     () =>
       compareVersion
-        ? new Set(compareVersion.fileAttachments.map((f) => f.fileId))
-        : new Set<string>(),
+        ? new Set<string | null>(
+            compareVersion.fileAttachments.map((f) => f.fileId)
+          )
+        : new Set<string | null>(),
     [compareVersion]
   );
 
@@ -112,15 +154,55 @@ export function SkillBuilderFilesSection() {
   };
 
   const onFileInputChange = useCallback(
-    async (e: React.ChangeEvent<HTMLInputElement>) => {
+    (e: React.ChangeEvent<HTMLInputElement>) => {
       const files = e.target.files;
       if (!files || files.length === 0) {
         return;
       }
 
       const allFiles = Array.from(files);
-      const newFiles = allFiles.filter((f) => !existingFileNames.has(f.name));
-      const duplicates = allFiles.filter((f) => existingFileNames.has(f.name));
+      const seenFileNames = new Set(existingFileNames);
+      const duplicates: File[] = [];
+      const newAttachments: PendingSkillBuilderFileAttachment[] = [];
+
+      for (const file of allFiles) {
+        if (seenFileNames.has(file.name)) {
+          duplicates.push(file);
+          continue;
+        }
+
+        seenFileNames.add(file.name);
+
+        const contentType = resolveSkillAttachmentContentType(file);
+        if (!isSupportedFileContentType(contentType)) {
+          sendNotification({
+            type: "error",
+            title: "Unsupported file skipped.",
+            description: `File "${file.name}" is not supported (${contentType}).`,
+          });
+          continue;
+        }
+
+        const sizeLimitError = getSkillAttachmentSizeLimitError({
+          file,
+          contentType,
+        });
+        if (sizeLimitError) {
+          sendNotification({
+            type: "error",
+            title: "File too large.",
+            description: `File "${file.name}" (${fileSizeToHumanReadable(file.size)}) exceeds the ${sizeLimitError.category} limit of ${fileSizeToHumanReadable(sizeLimitError.maxFileSize)}. Please upload a smaller file.`,
+          });
+          continue;
+        }
+
+        newAttachments.push({
+          fileId: null,
+          fileName: file.name,
+          file,
+          contentType,
+        });
+      }
 
       if (duplicates.length > 0) {
         sendNotification({
@@ -130,21 +212,14 @@ export function SkillBuilderFilesSection() {
         });
       }
 
-      if (newFiles.length > 0) {
-        const uploaded = await handleFilesUpload(newFiles);
-        if (uploaded) {
-          for (const blob of uploaded) {
-            if (blob.fileId) {
-              append({ fileId: blob.fileId, fileName: blob.filename });
-            }
-          }
-        }
+      if (newAttachments.length > 0) {
+        append(newAttachments);
       }
 
       // Reset input so re-uploading the same file triggers onChange.
       e.target.value = "";
     },
-    [handleFilesUpload, append, existingFileNames, sendNotification]
+    [append, existingFileNames, sendNotification]
   );
 
   const headerActions = !isDiffMode && hasFileAttachments && (
@@ -152,9 +227,8 @@ export function SkillBuilderFilesSection() {
       type="button"
       onClick={onUploadClick}
       label="Upload files"
-      icon={isProcessingFiles ? Spinner : PlusIcon}
+      icon={PlusIcon}
       variant="outline"
-      disabled={isProcessingFiles}
     />
   );
 
@@ -195,11 +269,7 @@ export function SkillBuilderFilesSection() {
       )}
 
       {!hasFileAttachments ? (
-        isDiffMode ? null : isProcessingFiles ? (
-          <div className="flex h-40 w-full items-center justify-center">
-            <Spinner />
-          </div>
-        ) : (
+        isDiffMode ? null : (
           <EmptyCTA
             action={
               <Button
@@ -208,7 +278,6 @@ export function SkillBuilderFilesSection() {
                 label="Upload files"
                 icon={PlusIcon}
                 variant="outline"
-                disabled={isProcessingFiles}
               />
             }
             className="py-8"
@@ -222,7 +291,9 @@ export function SkillBuilderFilesSection() {
           >
             <ContextItem.List>
               {sortedFields.map(({ field, originalIndex }) => {
-                const isAdded = isDiffMode && !compareFileIds.has(field.fileId);
+                const isAdded =
+                  isDiffMode &&
+                  (field.fileId === null || !compareFileIds.has(field.fileId));
                 return (
                   <ContextItem
                     key={field.id}

--- a/front/components/skill_builder/SkillBuilderFormContext.tsx
+++ b/front/components/skill_builder/SkillBuilderFormContext.tsx
@@ -1,6 +1,10 @@
 import { actionSchema } from "@app/components/shared/tools_picker/types";
 import { SKILL_REINFORCEMENT_MODES } from "@app/types/assistant/skill_configuration";
 import { editorUserSchema } from "@app/types/editors";
+import {
+  isSupportedFileContentType,
+  type SupportedFileContentType,
+} from "@app/types/files";
 import { createContext } from "react";
 import type { UseFormReturn } from "react-hook-form";
 import { z } from "zod";
@@ -15,10 +19,28 @@ export const attachedKnowledgeSchema = z.object({
 });
 export type AttachedKnowledgeFormData = z.infer<typeof attachedKnowledgeSchema>;
 
-const fileAttachmentSchema = z.object({
+const persistedFileAttachmentSchema = z.object({
   fileId: z.string(),
   fileName: z.string(),
 });
+
+const pendingFileAttachmentSchema = z.object({
+  fileId: z.null(),
+  fileName: z.string(),
+  file: z.custom<File>(
+    (value) => typeof File !== "undefined" && value instanceof File,
+    "File is required"
+  ),
+  contentType: z.custom<SupportedFileContentType>(
+    (value) => typeof value === "string" && isSupportedFileContentType(value),
+    "Unsupported file type"
+  ),
+});
+
+const fileAttachmentSchema = z.union([
+  persistedFileAttachmentSchema,
+  pendingFileAttachmentSchema,
+]);
 
 export const skillBuilderFormSchema = z.object({
   name: z
@@ -47,6 +69,25 @@ export const skillBuilderFormSchema = z.object({
 });
 
 export type SkillBuilderFormData = z.infer<typeof skillBuilderFormSchema>;
+
+export type SkillBuilderFileAttachment =
+  SkillBuilderFormData["fileAttachments"][number];
+
+export type PendingSkillBuilderFileAttachment = Extract<
+  SkillBuilderFileAttachment,
+  { fileId: null }
+>;
+
+export type PersistedSkillBuilderFileAttachment = Extract<
+  SkillBuilderFileAttachment,
+  { fileId: string }
+>;
+
+export function isPendingSkillBuilderFileAttachment(
+  attachment: SkillBuilderFileAttachment
+): attachment is PendingSkillBuilderFileAttachment {
+  return attachment.fileId === null;
+}
 
 export const SkillBuilderFormContext =
   createContext<UseFormReturn<SkillBuilderFormData> | null>(null);

--- a/front/components/skill_builder/submitSkillBuilderForm.ts
+++ b/front/components/skill_builder/submitSkillBuilderForm.ts
@@ -1,11 +1,50 @@
-import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
+import {
+  isPendingSkillBuilderFileAttachment,
+  type PendingSkillBuilderFileAttachment,
+  type PersistedSkillBuilderFileAttachment,
+  type SkillBuilderFileAttachment,
+  type SkillBuilderFormData,
+} from "@app/components/skill_builder/SkillBuilderFormContext";
 import { clientFetch } from "@app/lib/egress/client";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { FileUploadRequestResponseBody } from "@app/pages/api/w/[wId]/files";
+import type { FileUploadedRequestResponseBody } from "@app/pages/api/w/[wId]/files/[fileId]";
 import type { PostSkillResponseBody } from "@app/pages/api/w/[wId]/skills";
 import type { PatchSkillResponseBody } from "@app/pages/api/w/[wId]/skills/[sId]";
+import { type APIErrorType, isAPIErrorResponse } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { UserType, WorkspaceType } from "@app/types/user";
+
+const SKILL_FILE_UPLOAD_CONCURRENCY = 4;
+const PRE_COMMIT_SKILL_SAVE_ERROR_TYPES = new Set<APIErrorType>([
+  "app_auth_error",
+  "invalid_request_error",
+  "skill_not_found",
+]);
+const JSON_HEADERS = { "Content-Type": "application/json" };
+
+type SkillSaveResponseBody = PostSkillResponseBody | PatchSkillResponseBody;
+
+type SubmitSkillBuilderFormResult = {
+  formData: SkillBuilderFormData;
+  skill: SkillSaveResponseBody["skill"];
+  warnings: {
+    message: string;
+    type: "editors_update_failed";
+  }[];
+};
+
+type UploadSkillFileAttachmentsResult = {
+  attachments: PersistedSkillBuilderFileAttachment[];
+  uploadedFileIds: string[];
+};
+
+type UploadedSkillFileAttachment = {
+  attachment: PersistedSkillBuilderFileAttachment;
+  uploadedFileId: string | null;
+};
 
 export async function submitSkillBuilderForm({
   formData,
@@ -17,24 +56,35 @@ export async function submitSkillBuilderForm({
   owner: WorkspaceType;
   skillId?: string;
   currentEditors?: UserType[];
-}): Promise<
-  Result<
-    PostSkillResponseBody["skill"] | PatchSkillResponseBody["skill"],
-    Error
-  >
-> {
+}): Promise<Result<SubmitSkillBuilderFormResult, Error>> {
+  const uploadedAttachmentsRes = await uploadPendingSkillFileAttachments({
+    attachments: formData.fileAttachments,
+    owner,
+    skillId,
+  });
+  if (uploadedAttachmentsRes.isErr()) {
+    return new Err(uploadedAttachmentsRes.error);
+  }
+
+  const { attachments: persistedFileAttachments, uploadedFileIds } =
+    uploadedAttachmentsRes.value;
+
+  let persistedFormData: SkillBuilderFormData = {
+    ...formData,
+    fileAttachments: persistedFileAttachments,
+  };
+
+  const endpoint = skillId
+    ? `/api/w/${owner.sId}/skills/${skillId}`
+    : `/api/w/${owner.sId}/skills`;
+
+  const method = skillId ? "PATCH" : "POST";
+
+  let result: SkillSaveResponseBody;
   try {
-    const endpoint = skillId
-      ? `/api/w/${owner.sId}/skills/${skillId}`
-      : `/api/w/${owner.sId}/skills`;
-
-    const method = skillId ? "PATCH" : "POST";
-
     const response = await clientFetch(endpoint, {
       method,
-      headers: {
-        "Content-Type": "application/json",
-      },
+      headers: JSON_HEADERS,
       body: JSON.stringify({
         name: formData.name,
         agentFacingDescription: formData.agentFacingDescription,
@@ -51,79 +101,37 @@ export async function submitSkillBuilderForm({
         tools: formData.tools.map((tool) => ({
           mcpServerViewId: tool.configuration.mcpServerViewId,
         })),
-        fileAttachments: formData.fileAttachments.map((f) => ({
+        fileAttachments: persistedFileAttachments.map((f) => ({
           fileId: f.fileId,
         })),
         attachedKnowledge: formData.attachedKnowledge ?? [],
         additionalRequestedSpaceIds: formData.additionalSpaces,
       }),
     });
-
     if (!response.ok) {
-      const errorData = await response.json();
-      return new Err(
-        new Error(
-          errorData.error?.message ??
-            (skillId ? "Failed to update skill" : "Failed to create skill")
-        )
-      );
-    }
+      let errorMessage = `Failed to ${skillId ? "update" : "create"} skill`;
+      let shouldCleanupUploadedFiles = false;
 
-    const result: PostSkillResponseBody | PatchSkillResponseBody =
-      await response.json();
-
-    const { skill } = result;
-
-    // Only sync editors for existing skills (updates), not for newly created skills
-    // When creating a skill, the backend automatically adds the creator to the editors group
-    if (skillId) {
-      const desiredEditorIds = new Set(formData.editors.map((e) => e.sId));
-      const currentEditorIds = new Set(currentEditors.map((e) => e.sId));
-
-      const addEditorIds: string[] = [];
-      const removeEditorIds: string[] = [];
-
-      // Add editors who are in desired but not in current
-      for (const editor of formData.editors) {
-        if (!currentEditorIds.has(editor.sId)) {
-          addEditorIds.push(editor.sId);
-        }
-      }
-
-      // Remove editors who are in current but not in desired
-      for (const editor of currentEditors) {
-        if (!desiredEditorIds.has(editor.sId)) {
-          removeEditorIds.push(editor.sId);
-        }
-      }
-
-      if (addEditorIds.length > 0 || removeEditorIds.length > 0) {
-        const editorsResponse = await clientFetch(
-          `/api/w/${owner.sId}/skills/${skill.sId}/editors`,
-          {
-            method: "PATCH",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              addEditorIds,
-              removeEditorIds,
-            }),
-          }
-        );
-
-        if (!editorsResponse.ok) {
-          const errorData = await editorsResponse.json();
-          return new Err(
-            new Error(
-              errorData.error?.message ?? "Failed to update skill editors"
-            )
+      try {
+        const errorData: unknown = await response.json();
+        if (isAPIErrorResponse(errorData)) {
+          errorMessage = errorData.error.message;
+          shouldCleanupUploadedFiles = PRE_COMMIT_SKILL_SAVE_ERROR_TYPES.has(
+            errorData.error.type
           );
         }
+      } catch {
+        // Keep the generic error message.
       }
+
+      if (shouldCleanupUploadedFiles) {
+        await cleanupUploadedFiles({ fileIds: uploadedFileIds, owner });
+      }
+
+      return new Err(new Error(errorMessage));
     }
 
-    return new Ok(skill);
+    result = await response.json();
   } catch (error) {
     const normalizedError = normalizeError(error);
     return new Err(
@@ -132,4 +140,261 @@ export async function submitSkillBuilderForm({
       )
     );
   }
+
+  const { skill } = result;
+  const warnings: SubmitSkillBuilderFormResult["warnings"] = [];
+
+  // Only sync editors for existing skills (updates), not for newly created skills.
+  // When creating a skill, the backend automatically adds the creator to the editors group.
+  if (skillId) {
+    const desiredEditorIds = new Set(formData.editors.map((e) => e.sId));
+    const currentEditorIds = new Set(currentEditors.map((e) => e.sId));
+
+    const addEditorIds = formData.editors
+      .filter((editor) => !currentEditorIds.has(editor.sId))
+      .map((editor) => editor.sId);
+    const removeEditorIds = currentEditors
+      .filter((editor) => !desiredEditorIds.has(editor.sId))
+      .map((editor) => editor.sId);
+
+    if (addEditorIds.length > 0 || removeEditorIds.length > 0) {
+      try {
+        const editorsResponse = await clientFetch(
+          `/api/w/${owner.sId}/skills/${skill.sId}/editors`,
+          {
+            method: "PATCH",
+            headers: JSON_HEADERS,
+            body: JSON.stringify({
+              addEditorIds,
+              removeEditorIds,
+            }),
+          }
+        );
+        if (!editorsResponse.ok) {
+          let errorMessage = "Failed to update skill editors";
+          try {
+            const errorData: unknown = await editorsResponse.json();
+            if (isAPIErrorResponse(errorData)) {
+              errorMessage = errorData.error.message;
+            }
+          } catch {
+            // Keep the generic error message.
+          }
+
+          throw new Error(errorMessage);
+        }
+      } catch (error) {
+        const normalizedError = normalizeError(error);
+        persistedFormData = {
+          ...persistedFormData,
+          editors: currentEditors,
+        };
+        warnings.push({
+          type: "editors_update_failed",
+          message: normalizedError.message || "Failed to update skill editors",
+        });
+      }
+    }
+  }
+
+  return new Ok({ formData: persistedFormData, skill, warnings });
+}
+
+async function uploadPendingSkillFileAttachments({
+  attachments,
+  owner,
+  skillId,
+}: {
+  attachments: SkillBuilderFileAttachment[];
+  owner: WorkspaceType;
+  skillId?: string;
+}): Promise<Result<UploadSkillFileAttachmentsResult, Error>> {
+  const uploadResults = await concurrentExecutor(
+    attachments,
+    async (attachment): Promise<Result<UploadedSkillFileAttachment, Error>> => {
+      if (!isPendingSkillBuilderFileAttachment(attachment)) {
+        return new Ok({
+          attachment: {
+            fileId: attachment.fileId,
+            fileName: attachment.fileName,
+          },
+          uploadedFileId: null,
+        });
+      }
+
+      const uploadRes = await uploadSkillFileAttachment({
+        attachment,
+        owner,
+        skillId,
+      });
+      if (uploadRes.isErr()) {
+        return uploadRes;
+      }
+
+      return new Ok({
+        attachment: uploadRes.value,
+        uploadedFileId: uploadRes.value.fileId,
+      });
+    },
+    { concurrency: SKILL_FILE_UPLOAD_CONCURRENCY }
+  );
+
+  const persistedAttachments: PersistedSkillBuilderFileAttachment[] = [];
+  const uploadedFileIds: string[] = [];
+  const errors: Error[] = [];
+
+  for (const result of uploadResults) {
+    if (result.isErr()) {
+      errors.push(result.error);
+      continue;
+    }
+
+    persistedAttachments.push(result.value.attachment);
+    if (result.value.uploadedFileId) {
+      uploadedFileIds.push(result.value.uploadedFileId);
+    }
+  }
+
+  if (errors.length > 0) {
+    await cleanupUploadedFiles({ fileIds: uploadedFileIds, owner });
+
+    const firstError = errors[0];
+    if (!firstError) {
+      return new Err(new Error("Failed to upload skill files."));
+    }
+
+    return new Err(
+      new Error(
+        errors.length === 1
+          ? firstError.message
+          : `${firstError.message} (${errors.length} files failed)`
+      )
+    );
+  }
+
+  return new Ok({ attachments: persistedAttachments, uploadedFileIds });
+}
+
+async function uploadSkillFileAttachment({
+  attachment,
+  owner,
+  skillId,
+}: {
+  attachment: PendingSkillBuilderFileAttachment;
+  owner: WorkspaceType;
+  skillId?: string;
+}): Promise<Result<PersistedSkillBuilderFileAttachment, Error>> {
+  let fileIdToCleanup: string | null = null;
+
+  try {
+    const uploadRequestResponse = await clientFetch(
+      `/api/w/${owner.sId}/files`,
+      {
+        method: "POST",
+        headers: JSON_HEADERS,
+        body: JSON.stringify({
+          contentType: attachment.contentType,
+          fileName: attachment.fileName,
+          fileSize: attachment.file.size,
+          useCase: "skill_attachment",
+          useCaseMetadata: skillId ? { skillId } : undefined,
+        }),
+      }
+    );
+    if (!uploadRequestResponse.ok) {
+      let errorMessage = "Failed to create file upload";
+      try {
+        const errorData: unknown = await uploadRequestResponse.json();
+        if (isAPIErrorResponse(errorData)) {
+          errorMessage = errorData.error.message;
+        }
+      } catch {
+        // Keep the generic error message.
+      }
+
+      throw new Error(errorMessage);
+    }
+
+    const uploadRequestBody: FileUploadRequestResponseBody =
+      await uploadRequestResponse.json();
+    const { file: fileUploadRequest } = uploadRequestBody;
+    fileIdToCleanup = fileUploadRequest.sId;
+
+    const uploadFormData = new FormData();
+    uploadFormData.append("file", attachment.file);
+
+    const uploadResponse = await clientFetch(fileUploadRequest.uploadUrl, {
+      method: "POST",
+      body: uploadFormData,
+    });
+    if (!uploadResponse.ok) {
+      let errorMessage = "Failed to upload file content";
+      try {
+        const errorData: unknown = await uploadResponse.json();
+        if (isAPIErrorResponse(errorData)) {
+          errorMessage = errorData.error.message;
+        }
+      } catch {
+        // Keep the generic error message.
+      }
+
+      throw new Error(errorMessage);
+    }
+
+    const uploadBody: FileUploadedRequestResponseBody =
+      await uploadResponse.json();
+    const { file: uploadedFile } = uploadBody;
+
+    return new Ok({
+      fileId: fileUploadRequest.sId,
+      fileName: uploadedFile.fileName,
+    });
+  } catch (error) {
+    if (fileIdToCleanup) {
+      await cleanupUploadedFiles({
+        fileIds: [fileIdToCleanup],
+        owner,
+      });
+    }
+
+    const normalizedError = normalizeError(error);
+    return new Err(
+      new Error(
+        `Failed to upload file "${attachment.fileName}": ${normalizedError.message || "Unknown error"}`
+      )
+    );
+  }
+}
+
+async function cleanupUploadedFiles({
+  fileIds,
+  owner,
+}: {
+  fileIds: string[];
+  owner: WorkspaceType;
+}): Promise<void> {
+  if (fileIds.length === 0) {
+    return;
+  }
+
+  await concurrentExecutor(
+    fileIds,
+    async (fileId) => {
+      try {
+        const response = await clientFetch(
+          `/api/w/${owner.sId}/files/${fileId}`,
+          {
+            method: "DELETE",
+            headers: JSON_HEADERS,
+          }
+        );
+        if (!response.ok) {
+          throw new Error("Failed to delete file");
+        }
+      } catch {
+        // Best-effort cleanup only. Preserve the original save/upload error.
+      }
+    },
+    { concurrency: SKILL_FILE_UPLOAD_CONCURRENCY }
+  );
 }


### PR DESCRIPTION
## Description

- This PR changes Skill Builder file attachments so selected files stay pending in the form until the skill is saved, instead of uploading immediately on selection (which can cause dangling files if the user ends up not saving and navigating out).
- On save, pending files are uploaded, persisted file ids are sent in the skill create/update payload, and the form is reset with the persisted attachments.
- Upload failures and known pre-commit save failures clean up uploaded files best-effort to avoid orphan attachments. Editor sync failures after a successful skill update are surfaced as warnings instead of failing the whole save.

## Tests

- Added submitSkillBuilderForm tests covering deferred uploads, cleanup paths, unknown save outcomes, and editor sync failures.

## Risk

- Low, scoped to Skill Builder file attachments and editor sync errors.

## Deploy Plan

- Deploy front.
