### PR TITLE
[sandbox] fix: block agent-proxied from reaching local sshd

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/src/commands/healthcheck.rs
+++ b/cli/dust-sandbox/src/commands/healthcheck.rs
@@ -36,11 +36,12 @@ struct EgressHealthcheck {
     nft_dns_udp_redirect_ok: bool,
     nft_dns_tcp_redirect_ok: bool,
     nft_dns_udp_accept_ok: bool,
-    // Broader no-UDP / no-IPv6 / TCP-via-forwarder invariant. Validating only
-    // the DNS rules would let a partially damaged ruleset pass health while
-    // reopening non-53 UDP or IPv6 egress, so the runtime check mirrors the
-    // full enforcement set.
+    // Broader no-loopback-SSH / no-UDP / no-IPv6 / TCP-via-forwarder invariant.
+    // Validating only the DNS rules would let a partially damaged ruleset pass
+    // health while reopening non-53 UDP, IPv6, or local sshd access, so the
+    // runtime check mirrors the full enforcement set.
     nft_tcp_forward_redirect_ok: bool,
+    nft_loopback_ssh_drop_ok: bool,
     nft_udp_drop_ok: bool,
     nft_icmp_drop_ok: bool,
     nft_ipv6_drop_ok: bool,
@@ -87,6 +88,7 @@ fn run_healthcheck(args: &HealthcheckArgs) -> EgressHealthcheck {
         &ipv4_rules,
         &format!("tcp dport != 0 redirect to :{forwarder_port}"),
     );
+    let nft_loopback_ssh_drop_ok = uid_rule(&ipv4_rules, "ip daddr 127.0.0.0/8 tcp dport 22 drop");
     // `nft list` may print `meta l4proto` matches either by name (`udp`,
     // `icmp`) or by IANA protocol number (17, 1). Accept both so the check
     // works regardless of how nft prints the ruleset on a given kernel/nft
@@ -106,6 +108,7 @@ fn run_healthcheck(args: &HealthcheckArgs) -> EgressHealthcheck {
         && nft_dns_tcp_redirect_ok
         && nft_dns_udp_accept_ok
         && nft_tcp_forward_redirect_ok
+        && nft_loopback_ssh_drop_ok
         && nft_udp_drop_ok
         && nft_icmp_drop_ok
         && nft_ipv6_drop_ok
@@ -119,6 +122,7 @@ fn run_healthcheck(args: &HealthcheckArgs) -> EgressHealthcheck {
         nft_dns_tcp_redirect_ok,
         nft_dns_udp_accept_ok,
         nft_tcp_forward_redirect_ok,
+        nft_loopback_ssh_drop_ok,
         nft_udp_drop_ok,
         nft_icmp_drop_ok,
         nft_ipv6_drop_ok,
@@ -239,6 +243,10 @@ table ip dust-egress {
     meta skuid 1003 udp dport 53 redirect to :1053
     meta skuid 1003 tcp dport 53 redirect to :1053
   }
+  chain filter_output {
+    type filter hook output priority 0; policy accept;
+    meta skuid 1003 ip daddr 127.0.0.0/8 tcp dport 22 drop
+  }
 }
 "#;
 
@@ -251,6 +259,11 @@ table ip dust-egress {
             rules,
             1004,
             "udp dport 53 redirect to :1053"
+        ));
+        assert!(contains_uid_rule(
+            rules,
+            1003,
+            "ip daddr 127.0.0.0/8 tcp dport 22 drop"
         ));
     }
 

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -88,6 +88,7 @@ type HealthcheckOutput = {
   nft_dns_tcp_redirect_ok: boolean;
   nft_dns_udp_accept_ok: boolean;
   nft_tcp_forward_redirect_ok: boolean;
+  nft_loopback_ssh_drop_ok: boolean;
   nft_udp_drop_ok: boolean;
   nft_icmp_drop_ok: boolean;
   nft_ipv6_drop_ok: boolean;
@@ -103,6 +104,7 @@ function healthStdout(overrides: Partial<HealthcheckOutput> = {}): string {
     nft_dns_tcp_redirect_ok: true,
     nft_dns_udp_accept_ok: true,
     nft_tcp_forward_redirect_ok: true,
+    nft_loopback_ssh_drop_ok: true,
     nft_udp_drop_ok: true,
     nft_icmp_drop_ok: true,
     nft_ipv6_drop_ok: true,
@@ -585,10 +587,11 @@ describe("sandbox egress helpers", () => {
 
   it.each([
     "nft_tcp_forward_redirect_ok" as const,
+    "nft_loopback_ssh_drop_ok" as const,
     "nft_udp_drop_ok" as const,
     "nft_icmp_drop_ok" as const,
     "nft_ipv6_drop_ok" as const,
-  ])("fails closed when %s is false (broader no-UDP/no-IPv6 invariant)", async (missing) => {
+  ])("fails closed when %s is false (broader nftables invariant)", async (missing) => {
     const sandbox = {
       providerId: "provider-sandbox-id",
       sId: "sandbox-id",

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -153,6 +153,7 @@ const EgressHealthcheckOutputSchema = z.object({
   nft_dns_tcp_redirect_ok: z.boolean(),
   nft_dns_udp_accept_ok: z.boolean(),
   nft_tcp_forward_redirect_ok: z.boolean(),
+  nft_loopback_ssh_drop_ok: z.boolean(),
   nft_udp_drop_ok: z.boolean(),
   nft_icmp_drop_ok: z.boolean(),
   nft_ipv6_drop_ok: z.boolean(),
@@ -192,14 +193,16 @@ function parseEgressHealthcheckOutput(
 
   const data = validation.data;
   // nftablesOk mirrors the full enforcement boundary, not just the DNS rules:
-  // DNS interception alone isn't load-bearing without the generic UDP/ICMP/
-  // IPv6 drops and the broad TCP redirect to the forwarder. Treating a
-  // partially damaged table as healthy would silently reopen non-53 UDP.
+  // DNS interception alone isn't load-bearing without the loopback SSH block,
+  // generic UDP/ICMP/IPv6 drops, and broad TCP redirect to the forwarder.
+  // Treating a partially damaged table as healthy would silently reopen part
+  // of the agent escape or egress surface.
   const nftablesOk =
     data.nft_dns_udp_redirect_ok &&
     data.nft_dns_tcp_redirect_ok &&
     data.nft_dns_udp_accept_ok &&
     data.nft_tcp_forward_redirect_ok &&
+    data.nft_loopback_ssh_drop_ok &&
     data.nft_udp_drop_ok &&
     data.nft_icmp_drop_ok &&
     data.nft_ipv6_drop_ok;

--- a/front/lib/api/sandbox/image/egress/egress-nftables.sh
+++ b/front/lib/api/sandbox/image/egress/egress-nftables.sh
@@ -28,6 +28,7 @@ nft add rule ip dust-egress nat_output meta skuid $PROXIED_UID ip daddr 192.168.
 nft add rule ip dust-egress nat_output meta skuid $PROXIED_UID tcp dport != 0 redirect to :9990
 
 nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 127.0.0.1 udp dport $DNS_STUB_PORT accept
+nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 127.0.0.0/8 tcp dport 22 drop
 nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 169.254.169.254 drop
 nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 10.0.0.0/8 drop
 nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 172.16.0.0/12 drop

--- a/front/lib/api/sandbox/image/egress/egress-nftables.sh
+++ b/front/lib/api/sandbox/image/egress/egress-nftables.sh
@@ -19,7 +19,9 @@ nft add rule ip dust-egress nat_output meta skuid $PROXIED_UID udp dport 53 redi
 nft add rule ip dust-egress nat_output meta skuid $PROXIED_UID tcp dport 53 redirect to :$DNS_STUB_PORT
 
 # Other exemptions must land in nat before the broad TCP redirect so filter
-# drops still see the original destination.
+# drops still see the original destination. The 127.0.0.0/8 return is
+# load-bearing for the loopback SSH drop below: without it the broad TCP
+# redirect would rewrite dport to 9990 before filter_output ever sees port 22.
 nft add rule ip dust-egress nat_output meta skuid $PROXIED_UID ip daddr 127.0.0.0/8 return
 nft add rule ip dust-egress nat_output meta skuid $PROXIED_UID ip daddr 169.254.169.254 return
 nft add rule ip dust-egress nat_output meta skuid $PROXIED_UID ip daddr 10.0.0.0/8 return
@@ -28,6 +30,9 @@ nft add rule ip dust-egress nat_output meta skuid $PROXIED_UID ip daddr 192.168.
 nft add rule ip dust-egress nat_output meta skuid $PROXIED_UID tcp dport != 0 redirect to :9990
 
 nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 127.0.0.1 udp dport $DNS_STUB_PORT accept
+# Loopback SSH kill switch: the image masks sshd, this drops uid 1003 to local
+# tcp/22 in case anything restores it. IPv6 ::1:22 is covered by the catch-all
+# ip6 drop below. Relies on the 127.0.0.0/8 return in nat_output above.
 nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 127.0.0.0/8 tcp dport 22 drop
 nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 169.254.169.254 drop
 nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 10.0.0.0/8 drop

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -113,7 +113,6 @@ describe("sandbox image registry", () => {
     expect(hardeningCommand).toContain("AllowUsers agent");
     expect(hardeningCommand).toContain("DenyUsers root agent-proxied");
     expect(hardeningCommand).toContain("pam_permit\\.so");
-    expect(hardeningCommand).toContain("pkill -KILL -x sshd");
     expect(hardeningCommand).toContain(
       "systemctl disable --now ssh.service sshd.service"
     );

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -68,7 +68,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.25",
+      tag: "0.8.26",
     });
   });
 
@@ -93,6 +93,32 @@ describe("sandbox image registry", () => {
           "useradd --system --no-create-home --gid dust-egress-resolver --shell /usr/sbin/nologin dust-egress-resolver"
         ),
       ])
+    );
+  });
+
+  test("disables and hardens sshd in the base image", () => {
+    const runCommands = getRunCommands(getDustBaseImageOperations());
+    const hardeningCommand = runCommands.find((command) =>
+      command.includes("00-dust-sandbox-hardening.conf")
+    );
+
+    expect(hardeningCommand).toBeDefined();
+    expect(hardeningCommand).toContain("Include /etc/ssh/sshd_config.d/*.conf");
+    expect(hardeningCommand).toContain("PermitRootLogin no");
+    expect(hardeningCommand).toContain("UsePAM no");
+    expect(hardeningCommand).toContain("AuthorizedKeysCommand none");
+    expect(hardeningCommand).toContain(
+      "AuthorizedKeysFile /etc/ssh/authorized_keys/%u"
+    );
+    expect(hardeningCommand).toContain("AllowUsers agent");
+    expect(hardeningCommand).toContain("DenyUsers root agent-proxied");
+    expect(hardeningCommand).toContain("pam_permit\\.so");
+    expect(hardeningCommand).toContain("pkill -KILL -x sshd");
+    expect(hardeningCommand).toContain(
+      "systemctl disable --now ssh.service sshd.service"
+    );
+    expect(hardeningCommand).toContain(
+      "systemctl mask ssh.service sshd.service"
     );
   });
 
@@ -175,6 +201,9 @@ describe("sandbox image registry", () => {
       "nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 127.0.0.1 udp dport $DNS_STUB_PORT accept"
     );
     expect(nftablesScript).toContain(
+      "nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 127.0.0.0/8 tcp dport 22 drop"
+    );
+    expect(nftablesScript).toContain(
       "nft add rule ip dust-egress filter_output meta skuid $PROXIED_UID ip daddr 169.254.169.254 drop"
     );
     expect(nftablesScript).toContain(
@@ -196,7 +225,24 @@ describe("sandbox image registry", () => {
     expectContentInOrder(
       nftablesScript,
       "udp dport $DNS_STUB_PORT accept",
+      "tcp dport 22 drop"
+    );
+    expectContentInOrder(
+      nftablesScript,
+      "tcp dport 22 drop",
       "meta l4proto udp drop"
+    );
+  });
+
+  test("installs the current dsbx CLI release", () => {
+    const runCommands = getRunCommands(getDustBaseImageOperations());
+
+    expect(runCommands).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.22/dsbx-linux-x86_64"
+        ),
+      ])
     );
   });
 

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -114,11 +114,9 @@ describe("sandbox image registry", () => {
     expect(hardeningCommand).toContain("DenyUsers root agent-proxied");
     expect(hardeningCommand).toContain("pam_permit\\.so");
     expect(hardeningCommand).toContain(
-      "systemctl disable --now ssh.service sshd.service"
+      "systemctl disable --now ssh.service ssh.socket"
     );
-    expect(hardeningCommand).toContain(
-      "systemctl mask ssh.service sshd.service"
-    );
+    expect(hardeningCommand).toContain("systemctl mask ssh.service ssh.socket");
   });
 
   test("copies the egress boot assets and enables the systemd units", () => {

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -15,8 +15,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.7.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.25";
-const DSBX_CLI_VERSION = "0.1.21";
+const DUST_BASE_IMAGE_VERSION = "0.8.26";
+const DSBX_CLI_VERSION = "0.1.22";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that
 // list must not silently change this user's UID.
@@ -179,6 +179,50 @@ function getEgressResolverUserSetupCommand(): string {
   ].join(" && ");
 }
 
+function getSshHardeningCommand(): string {
+  const sshdConfig = [
+    "# Managed by Dust. Untrusted sandbox code must not reach root through sshd.",
+    "PermitRootLogin no",
+    "PasswordAuthentication no",
+    "KbdInteractiveAuthentication no",
+    "ChallengeResponseAuthentication no",
+    "PermitEmptyPasswords no",
+    "UsePAM no",
+    "AuthorizedKeysCommand none",
+    "AuthorizedKeysFile /etc/ssh/authorized_keys/%u",
+    "AllowUsers agent",
+    "DenyUsers root agent-proxied",
+  ];
+
+  const ensureSshdConfigInclude =
+    "if ! grep -Eq '^[[:space:]]*Include[[:space:]]+/etc/ssh/sshd_config.d/\\*.conf([[:space:]]|$)' /etc/ssh/sshd_config; then " +
+    "sed -i '1i Include /etc/ssh/sshd_config.d/*.conf' /etc/ssh/sshd_config; fi";
+  const writeSshdConfig = [
+    "printf '%s\\n'",
+    ...sshdConfig.map(formatShellValue),
+    "> /etc/ssh/sshd_config.d/00-dust-sandbox-hardening.conf",
+  ].join(" ");
+  const disableSshdServices =
+    "if command -v systemctl >/dev/null 2>&1; then " +
+    "systemctl disable --now ssh.service sshd.service ssh.socket sshd.socket >/dev/null 2>&1 || true; fi";
+  const maskSshdServices =
+    "if command -v systemctl >/dev/null 2>&1; then " +
+    "systemctl mask ssh.service sshd.service ssh.socket sshd.socket >/dev/null 2>&1 || true; fi";
+
+  return [
+    "mkdir -p /etc/ssh/sshd_config.d /etc/ssh/authorized_keys",
+    "chmod 755 /etc/ssh /etc/ssh/sshd_config.d /etc/ssh/authorized_keys",
+    "touch /etc/ssh/sshd_config",
+    ensureSshdConfigInclude,
+    writeSshdConfig,
+    "chmod 644 /etc/ssh/sshd_config /etc/ssh/sshd_config.d/00-dust-sandbox-hardening.conf",
+    "if [ -f /etc/pam.d/sshd ]; then sed -i -E '/^[[:space:]]*auth[[:space:]].*pam_permit\\.so/s/^/# Disabled by Dust sandbox SSH hardening: /' /etc/pam.d/sshd; fi",
+    "if command -v pkill >/dev/null 2>&1; then pkill -KILL -x sshd >/dev/null 2>&1 || true; fi",
+    disableSshdServices,
+    maskSshdServices,
+  ].join(" && ");
+}
+
 const DUST_BASE_IMAGE = SandboxImage.fromDocker(
   `dust-sbx-bedrock:${DUST_BEDROCK_IMAGE_VERSION}`
 )
@@ -195,6 +239,7 @@ const DUST_BASE_IMAGE = SandboxImage.fromDocker(
     }
   )
   .runCmd(getAgentProxiedSetupCommand(), { user: "root" })
+  .runCmd(getSshHardeningCommand(), { user: "root" })
   // Create simple netcat-based token server script.
   .runCmd("mkdir -p /home/agent/.bin", { user: "root" })
   // TODO(2026-03-06 SANDBOX): .copy is broken, use file once fixed.

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -180,6 +180,11 @@ function getEgressResolverUserSetupCommand(): string {
 }
 
 function getSshHardeningCommand(): string {
+  // Layered on purpose, not redundant. `AllowUsers agent` is the load-bearing
+  // lock (whitelist). The other lines defend the case where a future bedrock
+  // bump reorders the Include directive, re-enables PAM, or restores a
+  // permissive AuthorizedKeysCommand from the base image. Don't "clean up"
+  // any of these without checking what happens if exactly one of them flips.
   const sshdConfig = [
     "# Managed by Dust. Untrusted sandbox code must not reach root through sshd.",
     "PermitRootLogin no",
@@ -217,7 +222,6 @@ function getSshHardeningCommand(): string {
     writeSshdConfig,
     "chmod 644 /etc/ssh/sshd_config /etc/ssh/sshd_config.d/00-dust-sandbox-hardening.conf",
     "if [ -f /etc/pam.d/sshd ]; then sed -i -E '/^[[:space:]]*auth[[:space:]].*pam_permit\\.so/s/^/# Disabled by Dust sandbox SSH hardening: /' /etc/pam.d/sshd; fi",
-    "if command -v pkill >/dev/null 2>&1; then pkill -KILL -x sshd >/dev/null 2>&1 || true; fi",
     disableSshdServices,
     maskSshdServices,
   ].join(" && ");

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -207,12 +207,16 @@ function getSshHardeningCommand(): string {
     ...sshdConfig.map(formatShellValue),
     "> /etc/ssh/sshd_config.d/00-dust-sandbox-hardening.conf",
   ].join(" ");
+  // In the bedrock image `sshd.service` is a symlink alias to `ssh.service`
+  // and `sshd.socket` does not exist. Masking only the canonical units covers
+  // both and keeps the build log free of the spurious "already a symlink" /
+  // "does not exist" warnings that would otherwise mask real failures.
   const disableSshdServices =
     "if command -v systemctl >/dev/null 2>&1; then " +
-    "systemctl disable --now ssh.service sshd.service ssh.socket sshd.socket >/dev/null 2>&1 || true; fi";
+    "systemctl disable --now ssh.service ssh.socket >/dev/null 2>&1 || true; fi";
   const maskSshdServices =
     "if command -v systemctl >/dev/null 2>&1; then " +
-    "systemctl mask ssh.service sshd.service ssh.socket sshd.socket >/dev/null 2>&1 || true; fi";
+    "systemctl mask ssh.service ssh.socket >/dev/null 2>&1 || true; fi";
 
   return [
     "mkdir -p /etc/ssh/sshd_config.d /etc/ssh/authorized_keys",


### PR DESCRIPTION
## Description

In-sandbox sshd accepts any key for `root@localhost`, so any process running as `agent-proxied` (uid 1003) can SSH in as root and read `/run/dust/egress-secrets.json` (all DSEC secrets in plaintext).

Three-layer fix:

1. **Image (`dust-base` 0.8.25 -> 0.8.26):** disable and mask `ssh.service` (and `ssh.socket`) in the base image build. Write `/etc/ssh/sshd_config.d/00-dust-sandbox-hardening.conf` with `PermitRootLogin no`, `UsePAM no`, `AuthorizedKeysCommand none`, `AllowUsers agent`, `DenyUsers root agent-proxied`. Comment out `auth ... pam_permit.so` in `/etc/pam.d/sshd` as a backstop. Prepend the `Include` directive to `sshd_config` if missing.
2. **nftables:** drop uid 1003 -> `127.0.0.0/8` tcp/22 in `filter_output`. IPv6 is already dropped wholesale for uid 1003. Load-bearing on the existing `nat_output` `127.0.0.0/8 return` (now commented as such).
3. **Healthcheck (`dsbx` 0.1.21 -> 0.1.22):** assert the new rule is present so a partially damaged ruleset fails closed at boot.

## Tests

- `registry.test.ts` pins the hardening drop-in contents, the masked services, the new nftables rule, and rule ordering.
- `egress.test.ts` covers the new `nft_loopback_ssh_drop_ok` field flipping the healthcheck to unhealthy.
- Rust healthcheck unit test asserts the rule is matched in a representative fixture.
- Verified empirically against a live e2b sandbox that the SDK control plane is `envd` (port 49983), not `sshd`. After `systemctl stop ssh.service` + `pkill -9 sshd`, `sbx.commands.run`, `sbx.files.write`, and `sbx.files.read` all keep working. Masking ssh is safe.
- Exploit one-liner from the audit report (`ssh-keygen ... ssh root@localhost`) still needs to run against an image built from this branch before promotion.

## Risk

The `systemctl mask` of `ssh.service` is the biggest blast-radius change. Empirically verified the e2b SDK does not depend on the in-image sshd (control plane is envd over HTTP on 49983), so the mask is safe in our template. The nftables drop and the hardening drop-in are individually safe to roll back; the image tag bump is reversible.

## Deploy Plan

- [ ] Cut and publish `dsbx-v0.1.22` so the image build can fetch the binary.
- [ ] Build `dust-base:0.8.26`, smoke test on a staging sandbox: exec, file upload, egress through the forwarder, the exploit one-liner, `dsbx healthcheck` output.
- [ ] Promote.
- [ ] Rotate the DSEC secrets listed in the warning above, out of band.