### PR TITLE
[Agent Loop] Handle provider timeout workflow failures

### DIFF
--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -17,7 +17,9 @@ import {
   DEFAULT_EVENT_FLUSH_INTERVAL_MS,
   globalCoalescer,
 } from "@app/temporal/agent_loop/lib/event_coalescer";
+import { RUN_MODEL_AND_CREATE_ACTIONS_ACTIVITY_NAME } from "@app/temporal/agent_loop/lib/workflow_failures";
 import type {
+  GenericErrorContent,
   LightAgentConfigurationType,
   ToolErrorEvent,
 } from "@app/types/assistant/agent";
@@ -424,27 +426,73 @@ export async function updateResourceAndPublishEvent(
 
 const DEFAULT_WORKFLOW_ERROR_MESSAGE =
   "An unexpected error occurred while generating the agent response. Please try again.";
+const MODEL_TIMEOUT_ERROR_MESSAGE =
+  "The AI provider is taking longer than expected. Please try again.";
+const MODEL_TIMEOUT_ERROR_TITLE = "AI provider timeout";
 
-function toUserFriendlyMessage(error: {
+export type WorkflowErrorInfo = {
   message: string;
   name: string;
-}): string {
+  activityType?: string;
+  timeoutType?: string;
+};
+
+type RunModelTimeoutWorkflowErrorInfo = WorkflowErrorInfo & {
+  activityType: typeof RUN_MODEL_AND_CREATE_ACTIONS_ACTIVITY_NAME;
+  timeoutType: "START_TO_CLOSE" | "HEARTBEAT";
+};
+
+function isRunModelTimeout(
+  error: WorkflowErrorInfo
+): error is RunModelTimeoutWorkflowErrorInfo {
+  return (
+    error.activityType === RUN_MODEL_AND_CREATE_ACTIONS_ACTIVITY_NAME &&
+    (error.timeoutType === "START_TO_CLOSE" ||
+      error.timeoutType === "HEARTBEAT")
+  );
+}
+
+function toWorkflowErrorContent(error: WorkflowErrorInfo): GenericErrorContent {
+  if (isRunModelTimeout(error)) {
+    return {
+      code: "multi_actions_error",
+      message: MODEL_TIMEOUT_ERROR_MESSAGE,
+      metadata: {
+        category: "retryable_model_error",
+        errorTitle: MODEL_TIMEOUT_ERROR_TITLE,
+        errorName: error.name || "UnknownError",
+        timeoutType: error.timeoutType,
+      },
+    };
+  }
+
+  let message = error.message;
   if (!error.message) {
-    return DEFAULT_WORKFLOW_ERROR_MESSAGE;
+    message = DEFAULT_WORKFLOW_ERROR_MESSAGE;
   }
   if (
     error.message === "Activity task timed out" &&
     error.name === "ActivityFailure"
   ) {
-    return "The agent took too long to respond. Please try again.";
+    message = "The agent took too long to respond. Please try again.";
   }
-  return error.message;
+
+  return {
+    code: "workflow_error",
+    message,
+    metadata: {
+      category: "critical_failure",
+      errorTitle: "Agent response generation failed",
+      // Ensure errorName is a string (not an Error object or undefined)
+      errorName: error.name || "UnknownError",
+    },
+  };
 }
 
 export async function notifyWorkflowError(
   authType: AuthenticatorType,
   { conversationId, agentMessageId, agentMessageVersion }: AgentLoopArgs,
-  error: { message: string; name: string }
+  error: WorkflowErrorInfo
 ): Promise<void> {
   let authResult = await AuthenticatorClass.fromJSON(authType);
 
@@ -504,16 +552,7 @@ export async function notifyWorkflowError(
     created: Date.now(),
     configurationId: messageRow.agentMessage.agentConfigurationId || "",
     messageId: agentMessageId,
-    error: {
-      code: "workflow_error",
-      message: toUserFriendlyMessage(error),
-      metadata: {
-        category: "critical_failure",
-        errorTitle: "Agent response generation failed",
-        // Ensure errorName is a string (not an Error object or undefined)
-        errorName: error.name || "UnknownError",
-      },
-    },
+    error: toWorkflowErrorContent(error),
     // Workflow errors occur outside of LLM execution, so use existing runIds from DB
     runIds: messageRow.agentMessage.runIds ?? [],
   };

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -452,7 +452,9 @@ function isRunModelTimeout(
   );
 }
 
-function toWorkflowErrorContent(error: WorkflowErrorInfo): GenericErrorContent {
+export function getWorkflowErrorContent(
+  error: WorkflowErrorInfo
+): GenericErrorContent {
   if (isRunModelTimeout(error)) {
     return {
       code: "multi_actions_error",
@@ -552,7 +554,7 @@ export async function notifyWorkflowError(
     created: Date.now(),
     configurationId: messageRow.agentMessage.agentConfigurationId || "",
     messageId: agentMessageId,
-    error: toWorkflowErrorContent(error),
+    error: getWorkflowErrorContent(error),
     // Workflow errors occur outside of LLM execution, so use existing runIds from DB
     runIds: messageRow.agentMessage.runIds ?? [],
   };

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -9,6 +9,7 @@ import {
   finalizeGracefulStop,
   finalizeInterruption,
   notifyWorkflowError,
+  type WorkflowErrorInfo,
 } from "@app/temporal/agent_loop/activities/common";
 import { handleMentions } from "@app/temporal/agent_loop/activities/mentions";
 import { conversationUnreadNotification } from "@app/temporal/agent_loop/activities/notification";
@@ -127,7 +128,7 @@ export async function finalizeCancelledAgentLoopActivity(
 export async function finalizeErroredAgentLoopActivity(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs,
-  error: { message: string; name: string }
+  error: WorkflowErrorInfo
 ): Promise<void> {
   await notifyWorkflowError(authType, agentLoopArgs, error);
 

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -8,6 +8,7 @@ import {
   finalizeCancellation,
   finalizeGracefulStop,
   finalizeInterruption,
+  getWorkflowErrorContent,
   notifyWorkflowError,
   type WorkflowErrorInfo,
 } from "@app/temporal/agent_loop/activities/common";
@@ -130,6 +131,8 @@ export async function finalizeErroredAgentLoopActivity(
   agentLoopArgs: AgentLoopArgs,
   error: WorkflowErrorInfo
 ): Promise<void> {
+  const errorContent = getWorkflowErrorContent(error);
+
   await notifyWorkflowError(authType, agentLoopArgs, error);
 
   const authResult = await Authenticator.fromJSON(authType);
@@ -146,7 +149,7 @@ export async function finalizeErroredAgentLoopActivity(
     sendEmailReplyOnError(
       auth,
       agentLoopArgs,
-      `Agent execution failed: ${error.message}`
+      `Agent execution failed: ${errorContent.message}`
     ),
   ]);
 }

--- a/front/temporal/agent_loop/lib/workflow_failures.test.ts
+++ b/front/temporal/agent_loop/lib/workflow_failures.test.ts
@@ -1,0 +1,85 @@
+import {
+  ActivityFailure,
+  RetryState,
+  TimeoutFailure,
+  TimeoutType,
+} from "@temporalio/common";
+import { describe, expect, it } from "vitest";
+
+import {
+  getTerminalRunModelAndCreateActionsTimeout,
+  isTerminalRunModelAndCreateActionsTimeout,
+  RUN_MODEL_AND_CREATE_ACTIONS_ACTIVITY_NAME,
+} from "./workflow_failures";
+
+function makeActivityFailure({
+  activityType = RUN_MODEL_AND_CREATE_ACTIONS_ACTIVITY_NAME,
+  retryState = RetryState.MAXIMUM_ATTEMPTS_REACHED,
+  timeoutType = TimeoutType.START_TO_CLOSE,
+}: {
+  activityType?: string;
+  retryState?: RetryState;
+  timeoutType?: TimeoutType;
+} = {}) {
+  return new ActivityFailure(
+    "Activity task timed out",
+    activityType,
+    "activity-id",
+    retryState,
+    "worker-id",
+    new TimeoutFailure("activity timed out", undefined, timeoutType)
+  );
+}
+
+describe("getTerminalRunModelAndCreateActionsTimeout", () => {
+  it("matches terminal StartToClose timeouts for the model activity", () => {
+    const failure = makeActivityFailure();
+
+    expect(getTerminalRunModelAndCreateActionsTimeout(failure)).toEqual({
+      activityType: RUN_MODEL_AND_CREATE_ACTIONS_ACTIVITY_NAME,
+      timeoutType: TimeoutType.START_TO_CLOSE,
+    });
+    expect(isTerminalRunModelAndCreateActionsTimeout(failure)).toBe(true);
+  });
+
+  it("matches terminal heartbeat timeouts for the model activity", () => {
+    const failure = makeActivityFailure({
+      timeoutType: TimeoutType.HEARTBEAT,
+    });
+
+    expect(getTerminalRunModelAndCreateActionsTimeout(failure)).toEqual({
+      activityType: RUN_MODEL_AND_CREATE_ACTIONS_ACTIVITY_NAME,
+      timeoutType: TimeoutType.HEARTBEAT,
+    });
+    expect(isTerminalRunModelAndCreateActionsTimeout(failure)).toBe(true);
+  });
+
+  it("matches activity timeout retry states from Temporal", () => {
+    const failure = makeActivityFailure({
+      retryState: RetryState.TIMEOUT,
+      timeoutType: TimeoutType.HEARTBEAT,
+    });
+
+    expect(isTerminalRunModelAndCreateActionsTimeout(failure)).toBe(true);
+  });
+
+  it("ignores non-terminal model activity failures", () => {
+    const failure = makeActivityFailure({
+      retryState: RetryState.IN_PROGRESS,
+      timeoutType: TimeoutType.HEARTBEAT,
+    });
+
+    expect(getTerminalRunModelAndCreateActionsTimeout(failure)).toBeNull();
+    expect(isTerminalRunModelAndCreateActionsTimeout(failure)).toBe(false);
+  });
+
+  it("ignores timeout failures from other activities", () => {
+    const failure = makeActivityFailure({
+      activityType: "runToolActivity",
+      timeoutType: TimeoutType.HEARTBEAT,
+    });
+
+    expect(getTerminalRunModelAndCreateActionsTimeout(failure)).toBeNull();
+    expect(isTerminalRunModelAndCreateActionsTimeout(failure)).toBe(false);
+  });
+});

--- a/front/temporal/agent_loop/lib/workflow_failures.ts
+++ b/front/temporal/agent_loop/lib/workflow_failures.ts
@@ -5,27 +5,57 @@ import {
   TimeoutType,
 } from "@temporalio/common";
 
-const RUN_MODEL_AND_CREATE_ACTIONS_ACTIVITY_NAME =
+export const RUN_MODEL_AND_CREATE_ACTIONS_ACTIVITY_NAME =
   "runModelAndCreateActionsActivity";
 
-export function isTerminalRunModelAndCreateActionsTimeout(
+function isRunModelAndCreateActionsActivityFailure(
   error: unknown
 ): error is ActivityFailure {
   if (!(error instanceof ActivityFailure)) {
     return false;
   }
 
-  if (error.activityType !== RUN_MODEL_AND_CREATE_ACTIONS_ACTIVITY_NAME) {
-    return false;
+  return error.activityType === RUN_MODEL_AND_CREATE_ACTIONS_ACTIVITY_NAME;
+}
+
+function isTerminalRetryState(retryState: RetryState): boolean {
+  return (
+    retryState === RetryState.MAXIMUM_ATTEMPTS_REACHED ||
+    retryState === RetryState.TIMEOUT
+  );
+}
+
+export function getTerminalRunModelAndCreateActionsTimeout(error: unknown): {
+  activityType: typeof RUN_MODEL_AND_CREATE_ACTIONS_ACTIVITY_NAME;
+  timeoutType: TimeoutType;
+} | null {
+  if (!isRunModelAndCreateActionsActivityFailure(error)) {
+    return null;
   }
 
-  if (error.retryState !== RetryState.MAXIMUM_ATTEMPTS_REACHED) {
-    return false;
+  if (!isTerminalRetryState(error.retryState)) {
+    return null;
   }
 
   if (!(error.cause instanceof TimeoutFailure)) {
-    return false;
+    return null;
   }
 
-  return error.cause.timeoutType === TimeoutType.START_TO_CLOSE;
+  if (
+    error.cause.timeoutType !== TimeoutType.START_TO_CLOSE &&
+    error.cause.timeoutType !== TimeoutType.HEARTBEAT
+  ) {
+    return null;
+  }
+
+  return {
+    activityType: RUN_MODEL_AND_CREATE_ACTIONS_ACTIVITY_NAME,
+    timeoutType: error.cause.timeoutType,
+  };
+}
+
+export function isTerminalRunModelAndCreateActionsTimeout(
+  error: unknown
+): error is ActivityFailure {
+  return getTerminalRunModelAndCreateActionsTimeout(error) !== null;
 }

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -15,7 +15,7 @@ import {
   RUN_MODEL_MAX_RETRIES,
   TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS,
 } from "@app/temporal/agent_loop/config";
-import { isTerminalRunModelAndCreateActionsTimeout } from "@app/temporal/agent_loop/lib/workflow_failures";
+import { getTerminalRunModelAndCreateActionsTimeout } from "@app/temporal/agent_loop/lib/workflow_failures";
 import { makeAgentLoopConversationTitleWorkflowId } from "@app/temporal/agent_loop/lib/workflow_ids";
 import {
   cancelAgentLoopSignal,
@@ -332,11 +332,11 @@ export async function agentLoopWorkflow({
     });
   } catch (err) {
     const workflowError = err instanceof Error ? err : new Error(String(err));
-    // This activity already turns terminal model/provider failures into a user-facing agent error
-    // when our code regains control. We swallow only the final Temporal StartToClose timeout so the
-    // workflow does not surface that infrastructure timeout as a separate workflow failure.
-    const shouldSwallowWorkflowFailure =
-      isTerminalRunModelAndCreateActionsTimeout(err);
+    const terminalRunModelTimeout =
+      getTerminalRunModelAndCreateActionsTimeout(err);
+    // Terminal model activity timeouts are expected when providers are unresponsive. The
+    // finalization activity publishes the agent error, so the workflow itself should complete.
+    const shouldSwallowWorkflowFailure = terminalRunModelTimeout !== null;
 
     // Notify error in a non-cancellable scope to ensure it runs even if the workflow is canceled.
     // Pass this execution's runIds and startStep to finalize so tracking
@@ -367,6 +367,12 @@ export async function agentLoopWorkflow({
         // before passing to the activity.
         message: workflowError.message,
         name: workflowError.name,
+        ...(terminalRunModelTimeout
+          ? {
+              activityType: terminalRunModelTimeout.activityType,
+              timeoutType: terminalRunModelTimeout.timeoutType,
+            }
+          : {}),
       })
     );
 


### PR DESCRIPTION
## Description
Temporal can surface provider stalls in `runModelAndCreateActionsActivity` as terminal heartbeat timeouts. Those are expected model/provider failures, not workflow failures.

This PR treats terminal model activity `StartToClose` and `Heartbeat` timeouts as retryable agent errors, lets finalization publish a user-facing `multi_actions_error`, reuses that message for email error replies, and completes the workflow instead of rethrowing the Temporal failure.

## Risks
Blast radius: agent loop finalization for terminal model activity timeouts.
Risk: low

## Deploy Plan
- deploy front workers

## Tests
- [x] `NODE_ENV=test npm -w front run test -- ./temporal/agent_loop/lib/workflow_failures.test.ts`