### PR TITLE
[front] poke: fix popover for additional info for a data_source

### DIFF
--- a/front/components/poke/PokeConnectorPermissionsTree.tsx
+++ b/front/components/poke/PokeConnectorPermissionsTree.tsx
@@ -10,7 +10,7 @@ import {
   ExternalLinkIcon,
   IconButton,
   InformationCircleIcon,
-  Tooltip,
+  Popover,
 } from "@dust-tt/sparkle";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
 import React, { useCallback } from "react";
@@ -57,8 +57,8 @@ export function PokePermissionTree({
         onDocumentViewClick={onDocumentViewClick}
         useResourcesHook={useResourcesHook}
         additionalActionsForContentNode={(contentNode) => (
-          <Tooltip
-            label={
+          <Popover
+            content={
               <div className="flex flex-col gap-2 p-2">
                 <div className="text-xs">
                   <div className="font-semibold">Title:</div>


### PR DESCRIPTION
## Description

In poke, we can browse the data in a specific datasource.
PokePermissionTree component provided additional info about a data content
=> before we could not click on the content displayed as it used Tooltip, with Popover we now can :)

## Tests

Tested locally, we can click on the links!!!

## Risk

None, poke + small UI change

## Deploy Plan

Deploy front