### PR TITLE
Fix Poke credits matching

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/credits/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/credits/index.ts
@@ -64,6 +64,7 @@ app.get("/", async (ctx): HandlerResult<PokeListCreditsResponseBody> => {
             // contracts are excluded by Metronome itself.
             coveringDate: null,
             effectiveBefore: now,
+            onlyPoolCredits: false,
           })
         : null,
     ]);

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -1554,6 +1554,7 @@ export async function listMetronomeBalances(
     includeArchived = false,
     coveringDate = new Date(),
     effectiveBefore,
+    onlyPoolCredits = true,
   }: {
     // Pass `null` to drop the `covering_date` filter and return balances of any
     // date (including expired and, depending on `effectiveBefore`, future ones).
@@ -1562,6 +1563,8 @@ export async function listMetronomeBalances(
     // future-dated balances while still returning expired ones.
     effectiveBefore?: Date;
     includeArchived?: boolean;
+    // Restrict to balances related to pool credits
+    onlyPoolCredits?: boolean;
   } = {}
 ): Promise<Result<MetronomeBalance[], Error>> {
   if (!config.getMetronomeApiKey()) {
@@ -1590,6 +1593,7 @@ export async function listMetronomeBalances(
       // excluded — they're not part of the workspace pool balance the
       // alert tracks. Commits are not stamped and pass through unchanged.
       if (
+        onlyPoolCredits &&
         entry.type === "CREDIT" &&
         entry.custom_fields?.[CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY] !==
           CONTRACT_CREDIT_TYPE_POOL

--- a/front/pages/api/poke/workspaces/[wId]/credits/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/credits/index.ts
@@ -95,6 +95,7 @@ async function handler(
                 // contracts are excluded by Metronome itself.
                 coveringDate: null,
                 effectiveBefore: now,
+                onlyPoolCredits: false,
               })
             : null,
         ]);


### PR DESCRIPTION
## Description

The `listMetronomeBalances` function filters out non-pool credits by default (entries where `custom_fields[CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY] !== CONTRACT_CREDIT_TYPE_POOL`), which is the right behaviour for the pool balance check used by credit gating. However, the Poke admin credits endpoint needs **all** Metronome balances — pool and non-pool alike — to correctly match and display them side-by-side against internal DB credit records. This PR adds an `onlyPoolCredits` flag to `listMetronomeBalances` (defaulting to `true` to preserve existing behaviour) and passes `onlyPoolCredits: false` at both Poke credits call sites (`front-api` and `front/pages/api`).

## Tests

Manual verification via Poke: credits table should now show all Metronome entries (including non-pool credits) and correctly match them against DB records.

## Risk

Low. The change is scoped to the admin-facing Poke credits view. The default value of `onlyPoolCredits` is `true`, so all other callers of `listMetronomeBalances` (pool balance cache, alerts) are unaffected.

## Deploy Plan

Deploy front.