### PR TITLE
feat(metronome): add success and error logs to ingestMetronomeEvents

### DIFF
--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -134,10 +134,22 @@ export async function ingestMetronomeEvents(
   }
 
   const client = getMetronomeClient();
-  for (let i = 0; i < validEvents.length; i += METRONOME_INGEST_BATCH_SIZE) {
-    const batch = validEvents.slice(i, i + METRONOME_INGEST_BATCH_SIZE);
-    await client.v1.usage.ingest({ usage: batch });
+  try {
+    for (let i = 0; i < validEvents.length; i += METRONOME_INGEST_BATCH_SIZE) {
+      const batch = validEvents.slice(i, i + METRONOME_INGEST_BATCH_SIZE);
+      await client.v1.usage.ingest({ usage: batch });
+    }
+  } catch (err) {
+    logger.error(
+      { error: normalizeError(err), eventCount: validEvents.length },
+      "[Metronome] Failed to ingest usage events"
+    );
+    throw err;
   }
+  logger.info(
+    { eventCount: validEvents.length },
+    "[Metronome] Ingested usage events"
+  );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Wrap the Metronome usage event ingest loop in a try/catch and add structured log lines so the ingestion pipeline is observable via Datadog log-based metrics:

- `[Metronome] Ingested usage events` (info) — emitted on success with `eventCount` for counting successfully sent batches
- `[Metronome] Failed to ingest usage events` (error) — emitted on failure with `eventCount` and `error` before re-throwing so Temporal still retries

Previously, ingest failures propagated silently into Temporal with no Metronome-tagged log, making it impossible to distinguish ingest errors from other activity failures in Datadog.

This will fill up this dashboard => https://app.datadoghq.eu/dashboard/9bk-qb6-ara/metronome--technical?fromUser=true&refresh_mode=sliding&tpl_var_env%5B0%5D=prod&from_ts=1779724488402&to_ts=1779897288402&live=true

### What we measure

#### Event Ingestion
* Events ingested — This is the heartbeat of the billing pipeline. Every agent message loop that completes on a Metronome-enabled workspace should produce at least one event.
* Stale events dropped — This fires when Temporal retries a workflow that was queued more than 34 days ago (Metronome's hard rejection limit). It should never happen in steady state. 
* Ingest errors — The ingest call throws and Temporal retries, so a single error isn't fatal. But a sustained rate means events are bouncing repeatedly and the retry backoff is widening

####  Webhook Processing
  
*  Webhooks received by type — Metronome drives contract activations, credit exhaustion, and payment outcomes entirely through webhooks. This chart shows the webhook volume is healthy and lets us correlate spikes
  
*  Webhook processing errors — A failed activity is retried by Temporal, but persistent failures mean the credit state machine is stuck: a workspace that hit its cap stays blocked, or a contract that started never activates the
  subscription. 

*  Signature failures — Should be zero in normal operation. A non-zero value means either a misconfigured secret (infra issue) or someone is probing the endpoint. It needs immediate attention

####  Credit States
  
*   Pool exhausted events — This is the most operationally significant credit event: a workspace has consumed all its AWU credits and is now blocked. 
  

####  MAU Sync
  
*  Workspaces synced — The daily MAU sync updates subscription quantities in Metronome, which feeds into invoices. If this gauge drops, it means some contracts are being invoiced with stale MAU counts — incorrect billing.
  
*  MAU sync errors — Per-workspace failures are swallowed (logged but not re-thrown) so the overall sync continues. 
  
