### PR TITLE
[metronome] feat: wire workspace default spend-limit settings UI

### DIFF
--- a/front/components/workspace/usage/UsageSettingsCard.tsx
+++ b/front/components/workspace/usage/UsageSettingsCard.tsx
@@ -1,7 +1,13 @@
 import {
+  useDefaultUserSpendLimit,
+  useUpdateDefaultUserSpendLimit,
   useUpdateUsageSettings,
   useUsageSettings,
 } from "@app/lib/swr/usage_settings";
+import {
+  MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
+  MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
+} from "@app/types/credits";
 import {
   ActionCreditCoinsIcon,
   Icon,
@@ -20,14 +26,24 @@ export function UsageSettingsCard({ workspaceId }: UsageSettingsCardProps) {
   const { usageSettings } = useUsageSettings({ workspaceId });
   const { doUpdateUsageSettings } = useUpdateUsageSettings({ workspaceId });
 
-  const [defaultLimitInput, setDefaultLimitInput] = useState<string>(
-    String(usageSettings.defaultUsageLimitCredits)
-  );
+  const { defaultUserSpendLimit, isDefaultUserSpendLimitLoading } =
+    useDefaultUserSpendLimit({ workspaceId });
+  const { doUpdateDefaultUserSpendLimit } = useUpdateDefaultUserSpendLimit({
+    workspaceId,
+  });
+
+  const [defaultLimitInput, setDefaultLimitInput] = useState<string>("");
   const [isSavingLimit, setIsSavingLimit] = useState(false);
 
   useEffect(() => {
-    setDefaultLimitInput(String(usageSettings.defaultUsageLimitCredits));
-  }, [usageSettings.defaultUsageLimitCredits]);
+    if (defaultUserSpendLimit?.awuCredits !== undefined) {
+      setDefaultLimitInput(
+        defaultUserSpendLimit.awuCredits !== null
+          ? String(defaultUserSpendLimit.awuCredits)
+          : ""
+      );
+    }
+  }, [defaultUserSpendLimit]);
 
   const [isSavingAutoUpgrade, setIsSavingAutoUpgrade] = useState(false);
 
@@ -44,21 +60,29 @@ export function UsageSettingsCard({ workspaceId }: UsageSettingsCardProps) {
 
   const handleCommitDefaultLimit = async () => {
     const parsed = Number(defaultLimitInput);
+    const current = defaultUserSpendLimit?.awuCredits ?? null;
     if (
       !Number.isInteger(parsed) ||
-      parsed < 0 ||
-      parsed === usageSettings.defaultUsageLimitCredits
+      parsed < MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS ||
+      parsed > MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS ||
+      parsed === current
     ) {
-      setDefaultLimitInput(String(usageSettings.defaultUsageLimitCredits));
+      setDefaultLimitInput(current !== null ? String(current) : "");
       return;
     }
     setIsSavingLimit(true);
     try {
-      await doUpdateUsageSettings({ defaultUsageLimitCredits: parsed });
+      const result = await doUpdateDefaultUserSpendLimit(parsed);
+      if (!result) {
+        setDefaultLimitInput(current !== null ? String(current) : "");
+      }
     } finally {
       setIsSavingLimit(false);
     }
   };
+
+  const isDefaultLimitInputDisabled =
+    isSavingLimit || isDefaultUserSpendLimitLoading;
 
   return (
     <Page.Vertical gap="sm" align="stretch">
@@ -94,7 +118,7 @@ export function UsageSettingsCard({ workspaceId }: UsageSettingsCardProps) {
                   setDefaultLimitInput(e.target.value.replace(/[^\d]/g, ""))
                 }
                 onBlur={() => void handleCommitDefaultLimit()}
-                disabled={isSavingLimit}
+                disabled={isDefaultLimitInputDisabled}
                 className="pl-8 text-right"
               />
             </div>

--- a/front/lib/api/workspace/default_user_spend_limit.ts
+++ b/front/lib/api/workspace/default_user_spend_limit.ts
@@ -8,11 +8,12 @@ import {
   getMetronomeDefaultUserCapAlert,
   upsertMetronomeDefaultUserCapAlert,
 } from "@app/lib/metronome/alerts/spend_limits";
+import {
+  MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
+  MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
+} from "@app/types/credits";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-
-export const MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS = 1000;
-export const MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS = 1_000_000;
 
 export type DefaultUserSpendLimit = {
   awuCredits: number;

--- a/front/lib/swr/usage_settings.ts
+++ b/front/lib/swr/usage_settings.ts
@@ -6,14 +6,27 @@ import {
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type { GetCreditUsageConfigurationResponseBody } from "@app/pages/api/w/[wId]/credits/usage-configuration";
+import type {
+  GetDefaultUserSpendLimitResponseBody,
+  PutDefaultUserSpendLimitResponseBody,
+} from "@app/pages/api/w/[wId]/usage_settings/default_user_spend_limit";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { useCallback, useSyncExternalStore } from "react";
 import type { Fetcher } from "swr";
+import { mutate } from "swr";
+import { z } from "zod";
+
+const GetDefaultUserSpendLimitResponseSchema = z.object({
+  awuCredits: z.number().int().nullable(),
+});
+
+const PutDefaultUserSpendLimitResponseSchema = z.object({
+  awuCredits: z.number().int(),
+});
 
 export interface UsageSettings {
   allowUpgradeRequest: boolean;
   autoUpgradeFreeToPro: boolean;
-  defaultUsageLimitCredits: number;
 }
 
 export interface UsageNotifications {
@@ -25,7 +38,6 @@ export interface UsageNotifications {
 const DEFAULT_USAGE_SETTINGS: UsageSettings = {
   allowUpgradeRequest: false,
   autoUpgradeFreeToPro: false,
-  defaultUsageLimitCredits: 1000,
 };
 
 const DEFAULT_USAGE_NOTIFICATIONS: UsageNotifications = {
@@ -194,4 +206,101 @@ export function useUpdateUsageNotifications({
   );
 
   return { doUpdateUsageNotifications };
+}
+
+function defaultUserSpendLimitUrl(workspaceId: string): string {
+  return `/api/w/${workspaceId}/usage_settings/default_user_spend_limit`;
+}
+
+function membersUsageUrl(workspaceId: string): string {
+  return `/api/w/${workspaceId}/credits/members-usage`;
+}
+
+export function useDefaultUserSpendLimit({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const defaultFetcher: Fetcher<GetDefaultUserSpendLimitResponseBody> = async (
+    url: string
+  ) => {
+    const result = await fetcher(url);
+    return GetDefaultUserSpendLimitResponseSchema.parse(result);
+  };
+  const { data, error, mutate } = useSWRWithDefaults(
+    defaultUserSpendLimitUrl(workspaceId),
+    defaultFetcher,
+    { disabled }
+  );
+
+  return {
+    defaultUserSpendLimit: data,
+    isDefaultUserSpendLimitLoading: !error && !data && !disabled,
+    isDefaultUserSpendLimitError: !!error,
+    mutateDefaultUserSpendLimit: mutate,
+  };
+}
+
+export function useUpdateDefaultUserSpendLimit({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const sendNotification = useSendNotification();
+
+  const doUpdateDefaultUserSpendLimit = useCallback(
+    async (
+      awuCredits: number
+    ): Promise<PutDefaultUserSpendLimitResponseBody | null> => {
+      try {
+        const res = await clientFetch(defaultUserSpendLimitUrl(workspaceId), {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ awuCredits }),
+        });
+
+        if (!res.ok) {
+          const errorData = await getErrorFromResponse(res);
+          sendNotification({
+            type: "error",
+            title: "Failed to update default spend limit",
+            description: errorData.message,
+          });
+          return null;
+        }
+
+        const body = PutDefaultUserSpendLimitResponseSchema.parse(
+          await res.json()
+        );
+        sendNotification({
+          type: "success",
+          title: "Default spend limit updated",
+          description: `The default per-user spend limit has been set to ${body.awuCredits.toLocaleString(
+            "en-US"
+          )} credits.`,
+        });
+
+        await mutate(defaultUserSpendLimitUrl(workspaceId));
+        await mutate(
+          (key) =>
+            typeof key === "string" &&
+            key.startsWith(membersUsageUrl(workspaceId))
+        );
+        return body;
+      } catch (e) {
+        sendNotification({
+          type: "error",
+          title: "Failed to update default spend limit",
+          description: normalizeError(e).message,
+        });
+        return null;
+      }
+    },
+    [workspaceId, sendNotification]
+  );
+
+  return { doUpdateDefaultUserSpendLimit };
 }

--- a/front/pages/api/w/[wId]/usage_settings/default_user_spend_limit.ts
+++ b/front/pages/api/w/[wId]/usage_settings/default_user_spend_limit.ts
@@ -6,12 +6,14 @@ import {
   type DefaultUserSpendLimit,
   type DefaultUserSpendLimitError,
   getDefaultUserSpendLimit,
-  MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
-  MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
   setDefaultUserSpendLimit,
 } from "@app/lib/api/workspace/default_user_spend_limit";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
+import {
+  MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
+  MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
+} from "@app/types/credits";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { NextApiRequest, NextApiResponse } from "next";

--- a/front/types/credits.ts
+++ b/front/types/credits.ts
@@ -47,6 +47,9 @@ export function isCreditType(value: unknown): value is CreditType {
 // Credit expiration duration in days (default: 1 year)
 export const CREDIT_EXPIRATION_DAYS = 365;
 
+export const MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS = 1000;
+export const MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS = 1_000_000;
+
 export type CreditDisplayData = {
   sId: string;
   type: CreditType;


### PR DESCRIPTION
## Description

Connects the usage settings card to the new workspace default spend-limit endpoint via SWR hooks, handles the unset () state, and refreshes members-usage caches after updates.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
