### PR TITLE
[LLM] Simplify model availability for a workspace

### DIFF
--- a/extension/shared/services/auth.ts
+++ b/extension/shared/services/auth.ts
@@ -1,4 +1,4 @@
-import type { RegionInfo } from "@app/lib/api/regions/config";
+import type { RegionInfo } from "@app/types/region";
 import type { Result } from "@app/types/shared/result";
 import { DUST_EU_URL, DUST_US_URL } from "@extension/shared/lib/config";
 import type { StorageService } from "@extension/shared/services/storage";

--- a/front-api/routes/poke/region.ts
+++ b/front-api/routes/poke/region.ts
@@ -1,5 +1,6 @@
-import type { RegionType } from "@app/lib/api/regions/config";
-import { config, SUPPORTED_REGIONS } from "@app/lib/api/regions/config";
+import { config } from "@app/lib/api/regions/config";
+import type { RegionType } from "@app/types/region";
+import { SUPPORTED_REGIONS } from "@app/types/region";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 

--- a/front-api/routes/w/[wId]/models.ts
+++ b/front-api/routes/w/[wId]/models.ts
@@ -1,7 +1,7 @@
 import { USED_MODEL_CONFIGS } from "@app/components/providers/model_configs";
 import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
 import { config as regionConfig } from "@app/lib/api/regions/config";
-import { filterCustomAvailableAndWhitelistedModels } from "@app/lib/assistant";
+import { filterEnabledModels } from "@app/lib/assistant";
 import { getFeatureFlags } from "@app/lib/auth";
 import { CUSTOM_MODEL_CONFIGS } from "@app/types/assistant/models/custom_models.generated";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
@@ -26,10 +26,10 @@ app.get("/", async (ctx): HandlerResult<GetEnabledModelsResponseType> => {
 
   // Include both standard models and custom models (from GCS at build time).
   const allUsedModels = [...USED_MODEL_CONFIGS, ...CUSTOM_MODEL_CONFIGS];
-  const models = filterCustomAvailableAndWhitelistedModels(allUsedModels, {
+  const models = filterEnabledModels(allUsedModels, {
     featureFlags,
     plan,
-    owner,
+    regionalModelsOnly: owner.regionalModelsOnly,
     region,
     whitelistedProviders,
   });

--- a/front-api/routes/w/[wId]/models.ts
+++ b/front-api/routes/w/[wId]/models.ts
@@ -8,14 +8,14 @@ import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
-export type GetAvailableModelsResponseType = {
+export type GetEnabledModelsResponseType = {
   models: ModelConfigurationType[];
 };
 
 // Mounted at /api/w/:wId/models.
 const app = workspaceApp();
 
-app.get("/", async (ctx): HandlerResult<GetAvailableModelsResponseType> => {
+app.get("/", async (ctx): HandlerResult<GetEnabledModelsResponseType> => {
   const auth = ctx.get("auth");
 
   const featureFlags = await getFeatureFlags(auth);

--- a/front-api/routes/workos/[action].ts
+++ b/front-api/routes/workos/[action].ts
@@ -5,11 +5,7 @@ import {
 } from "@app/lib/api/audit/workos_audit";
 import config from "@app/lib/api/config";
 import { performLogin } from "@app/lib/api/login";
-import type { RegionType } from "@app/lib/api/regions/config";
-import {
-  config as multiRegionsConfig,
-  SUPPORTED_REGIONS,
-} from "@app/lib/api/regions/config";
+import { config as multiRegionsConfig } from "@app/lib/api/regions/config";
 import { checkUserRegionAffinity } from "@app/lib/api/regions/lookup";
 import { authenticateWithWorkOSCode } from "@app/lib/api/workos/authenticate";
 import { getWorkOS } from "@app/lib/api/workos/client";
@@ -28,6 +24,8 @@ import { getStatsDClient } from "@app/lib/utils/statsd";
 import { extractUTMParams } from "@app/lib/utils/utm";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
+import type { RegionType } from "@app/types/region";
+import { SUPPORTED_REGIONS } from "@app/types/region";
 import { isDevelopment } from "@app/types/shared/env";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";

--- a/front/admin/relocate_users.ts
+++ b/front/admin/relocate_users.ts
@@ -1,8 +1,8 @@
-import type { RegionType } from "@app/lib/api/regions/config";
 import { getWorkOS } from "@app/lib/api/workos/client";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
 import type { Logger } from "@app/logger/logger";
+import type { RegionType } from "@app/types/region";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 

--- a/front/components/actions/mcp/forms/submitConnectMCPServerDialogForm.ts
+++ b/front/components/actions/mcp/forms/submitConnectMCPServerDialogForm.ts
@@ -2,9 +2,9 @@ import type { MCPServerOAuthFormValues } from "@app/components/actions/mcp/forms
 import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import type { RegionInfo } from "@app/lib/api/regions/config";
 import { setupOAuthConnection } from "@app/types/oauth/client/setup";
 import type { OAuthProvider } from "@app/types/oauth/lib";
+import type { RegionInfo } from "@app/types/region";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";

--- a/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.ts
+++ b/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.ts
@@ -2,7 +2,6 @@ import type { CreateMCPServerDialogFormValues } from "@app/components/actions/mc
 import { requiresBearerTokenConfiguration } from "@app/lib/actions/mcp_helper";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction";
 import type { MCPServerType } from "@app/lib/api/mcp";
-import type { RegionInfo } from "@app/lib/api/regions/config";
 import {
   isMCPCreateServerError,
   type MCPConnectionType,
@@ -11,6 +10,7 @@ import type { CreateMCPServerResponseBody } from "@app/pages/api/w/[wId]/mcp";
 import type { DiscoverOAuthMetadataResponseBody } from "@app/pages/api/w/[wId]/mcp/discover_oauth_metadata";
 import { setupOAuthConnection } from "@app/types/oauth/client/setup";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
+import type { RegionInfo } from "@app/types/region";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { sanitizeHeadersArray } from "@app/types/shared/utils/http_headers";

--- a/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
+++ b/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
@@ -6,11 +6,11 @@ import {
 import { getModelProviderLogo } from "@app/components/providers/types";
 import { RegionalFlag } from "@app/components/shared/RegionalFlag";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
-import type { RegionType } from "@app/lib/api/regions/config";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import { getProviderDisplayName } from "@app/types/assistant/models/providers";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+import type { RegionType } from "@app/types/region";
 import {
   DropdownMenuLabel,
   DropdownMenuPortal,

--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -12,7 +12,6 @@ import { AdvancedNotionManagement } from "@app/components/spaces/AdvancedNotionM
 import { ConnectorDataUpdatedModal } from "@app/components/spaces/ConnectorDataUpdatedModal";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useSendNotification } from "@app/hooks/useNotification";
-import type { RegionInfo } from "@app/lib/api/regions/config";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
@@ -49,6 +48,7 @@ import type {
 import type { DataSourceViewType } from "@app/types/data_source_view";
 import type { APIError } from "@app/types/error";
 import { isOAuthProvider } from "@app/types/oauth/lib";
+import type { RegionInfo } from "@app/types/region";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType, WorkspaceType } from "@app/types/user";

--- a/front/components/pages/onboarding/InviteChoosePage.tsx
+++ b/front/components/pages/onboarding/InviteChoosePage.tsx
@@ -1,8 +1,8 @@
 import config from "@app/lib/api/config";
-import type { RegionType } from "@app/lib/api/regions/config";
 import { getRegionUrl } from "@app/lib/auth/RegionContext";
 import { useUser } from "@app/lib/swr/user";
 import { usePendingInvitations } from "@app/lib/swr/workspaces";
+import type { RegionType } from "@app/types/region";
 import {
   BarHeader,
   Button,

--- a/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
+++ b/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
@@ -44,7 +44,7 @@ export function ModelProvidersPageContent({
       isModelAvailable(model, {
         featureFlags,
         plan,
-        owner: workspace,
+        regionalModelsOnly: workspace.regionalModelsOnly,
         region: regionInfo.name,
       })
   );

--- a/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
+++ b/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
@@ -4,7 +4,7 @@ import { ProvidersConfigurationList } from "@app/components/pages/workspace/mode
 import { ProvidersToggleList } from "@app/components/pages/workspace/model_providers/ProvidersToggleList";
 import { RegionalModelsOnlyToggle } from "@app/components/pages/workspace/model_providers/RegionalModelsOnlyToggle";
 import { USED_MODEL_CONFIGS } from "@app/components/providers/types";
-import { isModelCustomAvailable } from "@app/lib/assistant";
+import { isModelAvailable } from "@app/lib/assistant";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import type {
@@ -41,7 +41,7 @@ export function ModelProvidersPageContent({
   const filteredModels = uniqBy(USED_MODEL_CONFIGS, (m) => m.modelId).filter(
     (model) =>
       !model.isLegacy &&
-      isModelCustomAvailable(model, {
+      isModelAvailable(model, {
         featureFlags,
         plan,
         owner: workspace,

--- a/front/components/pages/workspace/model_providers/RegionalModelsOnlyToggle.tsx
+++ b/front/components/pages/workspace/model_providers/RegionalModelsOnlyToggle.tsx
@@ -1,8 +1,8 @@
 import { RegionalFlag } from "@app/components/shared/RegionalFlag";
-import type { RegionType } from "@app/lib/api/regions/config";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import { useUpdateWorkspaceRegionalModelsOnly } from "@app/lib/swr/workspaces";
+import type { RegionType } from "@app/types/region";
 import type { LightWorkspaceType } from "@app/types/user";
 import { ContextItem, SliderToggle } from "@dust-tt/sparkle";
 

--- a/front/components/poke/PokeLayout.tsx
+++ b/front/components/poke/PokeLayout.tsx
@@ -1,12 +1,12 @@
 import PokeNavbar from "@app/components/poke/PokeNavbar";
 import { ThemeProvider } from "@app/components/sparkle/ThemeContext";
-import type { RegionType } from "@app/lib/api/regions/config";
 import type {
   AuthContextNoWorkspaceValue,
   AuthContextValue,
 } from "@app/lib/auth/AuthContext";
 import { AuthContext, AuthContextNoWorkspace } from "@app/lib/auth/AuthContext";
 import { usePokeRegion } from "@app/lib/swr/poke";
+import type { RegionType } from "@app/types/region";
 import type React from "react";
 
 export interface PokeLayoutProps {

--- a/front/components/poke/PokeNavbar.tsx
+++ b/front/components/poke/PokeNavbar.tsx
@@ -6,13 +6,13 @@ import {
   PokeCommandItem,
   PokeCommandList,
 } from "@app/components/poke/shadcn/ui/command";
-import type { RegionType } from "@app/lib/api/regions/config";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import { getRegionChipColor, getRegionDisplay } from "@app/lib/poke/regions";
 import { usePokeRegion } from "@app/lib/swr/poke";
 import { classNames } from "@app/lib/utils";
 import { usePokeSearchAllRegions } from "@app/poke/swr/search";
 import type { PokeItemBase } from "@app/types/poke";
+import type { RegionType } from "@app/types/region";
 import { isDevelopment } from "@app/types/shared/env";
 import {
   Button,

--- a/front/components/poke/PokeRegionDropdown.tsx
+++ b/front/components/poke/PokeRegionDropdown.tsx
@@ -1,7 +1,7 @@
-import type { RegionType } from "@app/lib/api/regions/config";
-import { SUPPORTED_REGIONS } from "@app/lib/api/regions/config";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import { getRegionDisplay } from "@app/lib/poke/regions";
+import type { RegionType } from "@app/types/region";
+import { SUPPORTED_REGIONS } from "@app/types/region";
 import {
   Button,
   DropdownMenu,

--- a/front/components/shared/RegionalFlag.tsx
+++ b/front/components/shared/RegionalFlag.tsx
@@ -1,5 +1,5 @@
 // biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
-import type { RegionType } from "@app/lib/api/regions/config";
+import type { RegionType } from "@app/types/region";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import Image from "next/image";
 

--- a/front/components/spaces/AddConnectionMenu.tsx
+++ b/front/components/spaces/AddConnectionMenu.tsx
@@ -3,7 +3,6 @@ import { CreateOrUpdateConnectionBigQueryModal } from "@app/components/data_sour
 import { CreateOrUpdateConnectionSnowflakeModal } from "@app/components/data_source/CreateOrUpdateConnectionSnowflakeModal";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useSendNotification } from "@app/hooks/useNotification";
-import type { RegionInfo } from "@app/lib/api/regions/config";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import {
@@ -34,6 +33,7 @@ import { setupOAuthConnection } from "@app/types/oauth/client/setup";
 import type { OAuthUseCase } from "@app/types/oauth/lib";
 import { isOAuthProvider } from "@app/types/oauth/lib";
 import type { PlanType } from "@app/types/plan";
+import type { RegionInfo } from "@app/types/region";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -757,7 +757,7 @@ export async function postUserMessage(
       !isModelAvailable(supportedModelConfig, {
         featureFlags,
         plan,
-        owner,
+        regionalModelsOnly: owner.regionalModelsOnly,
         region: regionConfig.getCurrentRegion(),
       })
     ) {

--- a/front/lib/api/assistant/models.ts
+++ b/front/lib/api/assistant/models.ts
@@ -1,3 +1,5 @@
+import { config as regionConfig } from "@app/lib/api/regions/config";
+import { isModelEnabled } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { isByokTransitioningPlan } from "@app/lib/plans/plan_codes";
 import {
@@ -78,17 +80,38 @@ export function isProviderWhitelisted(
   return whitelistedProviders.has(providerId);
 }
 
+type ModelEnablementContext = Parameters<typeof isModelEnabled>[1];
+
+function getModelEnablementContextWithoutFeatureFlag(
+  auth: Authenticator,
+  excludeProviders: ReadonlySet<ModelProviderIdType> = new Set()
+): ModelEnablementContext {
+  const owner = auth.getNonNullableWorkspace();
+
+  return {
+    featureFlags: [],
+    plan: auth.plan(),
+    regionalModelsOnly: owner.regionalModelsOnly,
+    region: regionConfig.getCurrentRegion(),
+    whitelistedProviders:
+      getWhitelistedProviders(auth).difference(excludeProviders),
+  };
+}
+
+const ORDERED_FAST_MODEL_CONFIGS: ModelConfigurationType[] = [
+  MISTRAL_SMALL_MODEL_CONFIG,
+  GEMINI_2_5_FLASH_MODEL_CONFIG,
+];
+
 export function getFastestWhitelistedModel(
   auth: Authenticator
 ): ModelConfigurationType | null {
-  const whitelistedProviders = getWhitelistedProviders(auth);
-  if (whitelistedProviders.has("mistral")) {
-    return MISTRAL_SMALL_MODEL_CONFIG;
-  }
-  if (whitelistedProviders.has("google_ai_studio")) {
-    return GEMINI_2_5_FLASH_MODEL_CONFIG;
-  }
-  return _getSmallWhitelistedModel(whitelistedProviders);
+  const context = getModelEnablementContextWithoutFeatureFlag(auth);
+
+  return (
+    ORDERED_FAST_MODEL_CONFIGS.find((m) => isModelEnabled(m, context)) ??
+    _getSmallWhitelistedModel(context)
+  );
 }
 
 export function getSmallWhitelistedModel(
@@ -96,7 +119,7 @@ export function getSmallWhitelistedModel(
   excludeProviders: ReadonlySet<ModelProviderIdType> = new Set()
 ): ModelConfigurationType | null {
   return _getSmallWhitelistedModel(
-    getWhitelistedProviders(auth).difference(excludeProviders)
+    getModelEnablementContextWithoutFeatureFlag(auth, excludeProviders)
   );
 }
 
@@ -106,33 +129,28 @@ export function getLargeWhitelistedModel(
   { forBatch = false }: { forBatch?: boolean } = {}
 ): ModelConfigurationType | null {
   return _getLargeWhitelistedModel(
-    getWhitelistedProviders(auth).difference(excludeProviders),
+    getModelEnablementContextWithoutFeatureFlag(auth, excludeProviders),
     { forBatch }
   );
 }
 
+const ORDERED_SMALL_MODEL_CONFIGS: ModelConfigurationType[] = [
+  GPT_5_MINI_MODEL_CONFIG,
+  CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
+  GEMINI_3_FLASH_MODEL_CONFIG,
+  MISTRAL_SMALL_MODEL_CONFIG,
+  GROK_4_1_FAST_NON_REASONING_MODEL_CONFIG,
+];
+
 function _getSmallWhitelistedModel(
-  whitelistedProviders: Set<ModelProviderIdType>
+  context: ModelEnablementContext
 ): ModelConfigurationType | null {
-  if (whitelistedProviders.has("openai")) {
-    return GPT_5_MINI_MODEL_CONFIG;
-  }
-  if (whitelistedProviders.has("anthropic")) {
-    return CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG;
-  }
-  if (whitelistedProviders.has("google_ai_studio")) {
-    return GEMINI_3_FLASH_MODEL_CONFIG;
-  }
-  if (whitelistedProviders.has("mistral")) {
-    return MISTRAL_SMALL_MODEL_CONFIG;
-  }
-  if (whitelistedProviders.has("xai")) {
-    return GROK_4_1_FAST_NON_REASONING_MODEL_CONFIG;
-  }
-  return null;
+  return (
+    ORDERED_SMALL_MODEL_CONFIGS.find((m) => isModelEnabled(m, context)) ?? null
+  );
 }
 
-const LARGE_MODEL_CONFIGS: ModelConfigurationType[] = [
+const ORDERED_LARGE_MODEL_CONFIGS: ModelConfigurationType[] = [
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
   GPT_5_5_MODEL_CONFIG,
   GEMINI_3_PRO_MODEL_CONFIG,
@@ -141,14 +159,13 @@ const LARGE_MODEL_CONFIGS: ModelConfigurationType[] = [
 ];
 
 function _getLargeWhitelistedModel(
-  whitelistedProviders: Set<ModelProviderIdType>,
+  context: ModelEnablementContext,
   { forBatch: hasBatch }: { forBatch?: boolean } = {}
 ): ModelConfigurationType | null {
-  const compatibleModels = LARGE_MODEL_CONFIGS.filter(
-    (m) =>
-      whitelistedProviders.has(m.providerId) &&
-      (!hasBatch || m.supportsBatchProcessing)
+  return (
+    ORDERED_LARGE_MODEL_CONFIGS.find(
+      (m) =>
+        isModelEnabled(m, context) && (!hasBatch || m.supportsBatchProcessing)
+    ) ?? null
   );
-
-  return compatibleModels[0] ?? null;
 }

--- a/front/lib/api/assistant/workspace_capabilities.ts
+++ b/front/lib/api/assistant/workspace_capabilities.ts
@@ -53,7 +53,7 @@ export async function getAvailableModelsForWorkspace(
   return filterEnabledModels(allUsedModels, {
     featureFlags,
     plan,
-    owner,
+    regionalModelsOnly: owner.regionalModelsOnly,
     region,
     whitelistedProviders,
   });

--- a/front/lib/api/assistant/workspace_capabilities.ts
+++ b/front/lib/api/assistant/workspace_capabilities.ts
@@ -7,7 +7,7 @@ import {
 import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
 import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
 import { config as regionConfig } from "@app/lib/api/regions/config";
-import { filterCustomAvailableAndWhitelistedModels } from "@app/lib/assistant";
+import { filterEnabledModels } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
@@ -50,7 +50,7 @@ export async function getAvailableModelsForWorkspace(
   const whitelistedProviders = getWhitelistedProviders(auth);
 
   const allUsedModels = [...USED_MODEL_CONFIGS, ...CUSTOM_MODEL_CONFIGS];
-  return filterCustomAvailableAndWhitelistedModels(allUsedModels, {
+  return filterEnabledModels(allUsedModels, {
     featureFlags,
     plan,
     owner,

--- a/front/lib/api/llm/utils/openai_like/responses/conversation_to_openai.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/conversation_to_openai.ts
@@ -10,7 +10,6 @@ import {
   extractIdFromMetadata,
   parseResponseFormatSchema,
 } from "@app/lib/api/llm/utils";
-import type { RegionType } from "@app/lib/api/regions/config";
 import { config } from "@app/lib/api/regions/config";
 import type { AgentContentItemType } from "@app/types/assistant/agent_message_content";
 import type {
@@ -23,6 +22,7 @@ import type {
   ModelProviderIdType,
   ReasoningEffort,
 } from "@app/types/assistant/models/types";
+import type { RegionType } from "@app/types/region";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import compact from "lodash/compact";
 import type {

--- a/front/lib/api/poke/plugins/global/relocate_user.ts
+++ b/front/lib/api/poke/plugins/global/relocate_user.ts
@@ -3,14 +3,12 @@ import {
   emitAuditLogEvent,
 } from "@app/lib/api/audit/workos_audit";
 import { createPlugin } from "@app/lib/api/poke/types";
-import type { RegionType } from "@app/lib/api/regions/config";
-import {
-  config as multiRegionsConfig,
-  SUPPORTED_REGIONS,
-} from "@app/lib/api/regions/config";
+import { config as multiRegionsConfig } from "@app/lib/api/regions/config";
 import { getWorkOS } from "@app/lib/api/workos/client";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { mapToEnumValues } from "@app/types/poke/plugins";
+import type { RegionType } from "@app/types/region";
+import { SUPPORTED_REGIONS } from "@app/types/region";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 

--- a/front/lib/api/regions/config.ts
+++ b/front/lib/api/regions/config.ts
@@ -1,22 +1,11 @@
+import type { RegionInfo, RegionType } from "@app/types/region";
 import { isDevelopment } from "@app/types/shared/env";
 import { EnvironmentConfig } from "@app/types/shared/utils/config";
-
-export const SUPPORTED_REGIONS = ["europe-west1", "us-central1"] as const;
-export type RegionType = (typeof SUPPORTED_REGIONS)[number];
 
 export const REGION_TIMEZONES: Record<RegionType, string> = {
   "europe-west1": "Europe/Paris",
   "us-central1": "America/New_York",
 };
-
-export interface RegionInfo {
-  name: RegionType;
-  url: string;
-}
-
-export function isRegionType(region: string): region is RegionType {
-  return SUPPORTED_REGIONS.includes(region as RegionType);
-}
 
 export const config = {
   getCurrentRegion: (): RegionType => {

--- a/front/lib/api/regions/lookup.ts
+++ b/front/lib/api/regions/lookup.ts
@@ -1,5 +1,4 @@
 import { getMembershipInvitationToken } from "@app/lib/api/invitation";
-import type { RegionType } from "@app/lib/api/regions/config";
 import { config } from "@app/lib/api/regions/config";
 import { isWorkspaceRelocationDone } from "@app/lib/api/workspace";
 import { findWorkspaceWithVerifiedDomain } from "@app/lib/iam/workspaces";
@@ -20,6 +19,7 @@ import type {
 import type { RegionRedirectError } from "@app/types/error";
 import { isAPIErrorResponse } from "@app/types/error";
 import type { PendingInvitationOption } from "@app/types/membership_invitation";
+import type { RegionType } from "@app/types/region";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";

--- a/front/lib/api/status/index.ts
+++ b/front/lib/api/status/index.ts
@@ -1,9 +1,9 @@
 import config from "@app/lib/api/config";
-import type { RegionType } from "@app/lib/api/regions/config";
 import { config as regionConfig } from "@app/lib/api/regions/config";
 import type { StatusPageIncidentType } from "@app/lib/api/status/status_page";
 import { getUnresolvedIncidents } from "@app/lib/api/status/status_page";
 import { cacheWithRedis } from "@app/lib/utils/cache";
+import type { RegionType } from "@app/types/region";
 import { isDevelopment } from "@app/types/shared/env";
 
 interface AppStatusComponent {

--- a/front/lib/api/workos/user.ts
+++ b/front/lib/api/workos/user.ts
@@ -1,5 +1,4 @@
 import config from "@app/lib/api/config";
-import type { RegionType } from "@app/lib/api/regions/config";
 import { config as multiRegionsConfig } from "@app/lib/api/regions/config";
 import { getWorkOS } from "@app/lib/api/workos/client";
 import { invalidateWorkOSOrganizationsCacheForUserId } from "@app/lib/api/workos/organization_membership";
@@ -8,6 +7,7 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { cacheWithRedis } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
+import type { RegionType } from "@app/types/region";
 import { isDevelopment } from "@app/types/shared/env";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";

--- a/front/lib/assistant.test.ts
+++ b/front/lib/assistant.test.ts
@@ -134,40 +134,6 @@ describe("isModelCustomAvailable", () => {
     ).toBe(false);
   });
 
-  it("should return true when customAssistantFeatureFlag is enabled", () => {
-    const model = createMockModel({
-      customAvailableIf: { featureFlag: "openai_o1_feature" },
-      largeModel: false,
-    });
-    const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE);
-
-    expect(
-      isModelCustomAvailable(model, {
-        featureFlags: ["openai_o1_feature"],
-        plan,
-        owner,
-        region: TEST_REGION,
-      })
-    ).toBe(true);
-  });
-
-  it("should return false when customAssistantFeatureFlag is not enabled", () => {
-    const model = createMockModel({
-      customAvailableIf: { featureFlag: "openai_o1_feature" },
-      largeModel: false,
-    });
-    const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE);
-
-    expect(
-      isModelCustomAvailable(model, {
-        featureFlags: [],
-        plan,
-        owner,
-        region: TEST_REGION,
-      })
-    ).toBe(false);
-  });
-
   it("should return true for large model with upgraded plan", () => {
     const model = createMockModel({ largeModel: true });
     const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE);
@@ -227,42 +193,6 @@ describe("isModelCustomAvailable", () => {
         region: TEST_REGION,
       })
     ).toBe(false);
-  });
-
-  it("should return false when both featureFlag and customAssistantFeatureFlag are required but only one is enabled", () => {
-    const model = createMockModel({
-      availableIfOneOf: { featureFlag: "deepseek_feature" },
-      customAvailableIf: { featureFlag: "openai_o1_feature" },
-      largeModel: false,
-    });
-    const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE);
-
-    expect(
-      isModelCustomAvailable(model, {
-        featureFlags: ["deepseek_feature"],
-        plan,
-        owner,
-        region: TEST_REGION,
-      })
-    ).toBe(false);
-  });
-
-  it("should return true when both featureFlag and customAssistantFeatureFlag are required and both are enabled", () => {
-    const model = createMockModel({
-      availableIfOneOf: { featureFlag: "deepseek_feature" },
-      customAvailableIf: { featureFlag: "openai_o1_feature" },
-      largeModel: false,
-    });
-    const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE);
-
-    expect(
-      isModelCustomAvailable(model, {
-        featureFlags: ["deepseek_feature", "openai_o1_feature"],
-        plan,
-        owner,
-        region: TEST_REGION,
-      })
-    ).toBe(true);
   });
 
   it("should return false when large model requires upgraded plan but featureFlag is missing", () => {

--- a/front/lib/assistant.test.ts
+++ b/front/lib/assistant.test.ts
@@ -1,9 +1,6 @@
 import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
 import type { RegionType } from "@app/lib/api/regions/config";
-import {
-  filterCustomAvailableAndWhitelistedModels,
-  isModelAvailable,
-} from "@app/lib/assistant";
+import { filterEnabledModels, isModelAvailable } from "@app/lib/assistant";
 import { Authenticator } from "@app/lib/auth";
 import {
   DUST_COMPANY_PLAN_CODE,
@@ -298,13 +295,13 @@ describe("isModelAvailable", () => {
   });
 });
 
-describe("filterCustomAvailableAndWhitelistedModels", () => {
+describe("filterEnabledModels", () => {
   it("should include model when available and provider is whitelisted", async () => {
     const workspace = await WorkspaceFactory.basic();
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
     const model = createMockModel({ providerId: "openai", largeModel: false });
 
-    const result = filterCustomAvailableAndWhitelistedModels([model], {
+    const result = filterEnabledModels([model], {
       featureFlags: [],
       plan: auth.plan(),
       owner: auth.getNonNullableWorkspace(),
@@ -324,7 +321,7 @@ describe("filterCustomAvailableAndWhitelistedModels", () => {
       largeModel: false,
     });
 
-    const result = filterCustomAvailableAndWhitelistedModels([model], {
+    const result = filterEnabledModels([model], {
       featureFlags: [],
       plan: auth.plan(),
       owner: auth.getNonNullableWorkspace(),
@@ -343,7 +340,7 @@ describe("filterCustomAvailableAndWhitelistedModels", () => {
       largeModel: false,
     });
 
-    const result = filterCustomAvailableAndWhitelistedModels([model], {
+    const result = filterEnabledModels([model], {
       featureFlags: [],
       plan: auth.plan(),
       owner: auth.getNonNullableWorkspace(),
@@ -362,7 +359,7 @@ describe("filterCustomAvailableAndWhitelistedModels", () => {
       largeModel: false,
     });
 
-    const result = filterCustomAvailableAndWhitelistedModels([model], {
+    const result = filterEnabledModels([model], {
       featureFlags: ["deepseek_feature"],
       plan: auth.plan(),
       owner: auth.getNonNullableWorkspace(),
@@ -386,16 +383,13 @@ describe("filterCustomAvailableAndWhitelistedModels", () => {
       largeModel: false,
     });
 
-    const result = filterCustomAvailableAndWhitelistedModels(
-      [openaiModel, xaiModel],
-      {
-        featureFlags: [],
-        plan: auth.plan(),
-        owner: auth.getNonNullableWorkspace(),
-        region: TEST_REGION,
-        whitelistedProviders: getWhitelistedProviders(auth),
-      }
-    );
+    const result = filterEnabledModels([openaiModel, xaiModel], {
+      featureFlags: [],
+      plan: auth.plan(),
+      owner: auth.getNonNullableWorkspace(),
+      region: TEST_REGION,
+      whitelistedProviders: getWhitelistedProviders(auth),
+    });
     expect(result).toEqual([openaiModel]);
   });
 
@@ -407,7 +401,7 @@ describe("filterCustomAvailableAndWhitelistedModels", () => {
       largeModel: false,
     });
 
-    const result = filterCustomAvailableAndWhitelistedModels([model], {
+    const result = filterEnabledModels([model], {
       featureFlags: [],
       plan: auth.plan(),
       owner: auth.getNonNullableWorkspace(),

--- a/front/lib/assistant.test.ts
+++ b/front/lib/assistant.test.ts
@@ -2,7 +2,7 @@ import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
 import type { RegionType } from "@app/lib/api/regions/config";
 import {
   filterCustomAvailableAndWhitelistedModels,
-  isModelCustomAvailable,
+  isModelAvailable,
 } from "@app/lib/assistant";
 import { Authenticator } from "@app/lib/auth";
 import {
@@ -31,7 +31,7 @@ function createMockModel(
   };
 }
 
-// createMockPlan is only used by isModelCustomAvailable tests (pure sync, no factory available).
+// createMockPlan is only used by isModelAvailable tests (pure sync, no factory available).
 function createMockPlan(code: string): PlanType {
   return {
     code,
@@ -83,7 +83,7 @@ function createMockPlan(code: string): PlanType {
   };
 }
 
-describe("isModelCustomAvailable", () => {
+describe("isModelAvailable", () => {
   const owner: WorkspaceType = LightWorkspaceFactory.build();
 
   it("should return true for a basic model without restrictions", () => {
@@ -91,7 +91,7 @@ describe("isModelCustomAvailable", () => {
     const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE);
 
     expect(
-      isModelCustomAvailable(model, {
+      isModelAvailable(model, {
         featureFlags: [],
         plan,
         owner,
@@ -108,7 +108,7 @@ describe("isModelCustomAvailable", () => {
     const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE);
 
     expect(
-      isModelCustomAvailable(model, {
+      isModelAvailable(model, {
         featureFlags: ["deepseek_feature"],
         plan,
         owner,
@@ -125,7 +125,7 @@ describe("isModelCustomAvailable", () => {
     const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE);
 
     expect(
-      isModelCustomAvailable(model, {
+      isModelAvailable(model, {
         featureFlags: [],
         plan,
         owner,
@@ -139,7 +139,7 @@ describe("isModelCustomAvailable", () => {
     const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE);
 
     expect(
-      isModelCustomAvailable(model, {
+      isModelAvailable(model, {
         featureFlags: [],
         plan,
         owner,
@@ -153,7 +153,7 @@ describe("isModelCustomAvailable", () => {
     const plan = createMockPlan(FREE_UPGRADED_PLAN_CODE);
 
     expect(
-      isModelCustomAvailable(model, {
+      isModelAvailable(model, {
         featureFlags: [],
         plan,
         owner,
@@ -170,7 +170,7 @@ describe("isModelCustomAvailable", () => {
     const plan = createMockPlan(FREE_NO_PLAN_CODE);
 
     expect(
-      isModelCustomAvailable(model, {
+      isModelAvailable(model, {
         featureFlags: [],
         plan,
         owner,
@@ -186,7 +186,7 @@ describe("isModelCustomAvailable", () => {
     });
 
     expect(
-      isModelCustomAvailable(model, {
+      isModelAvailable(model, {
         featureFlags: [],
         plan: null,
         owner,
@@ -203,7 +203,7 @@ describe("isModelCustomAvailable", () => {
     const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE);
 
     expect(
-      isModelCustomAvailable(model, {
+      isModelAvailable(model, {
         featureFlags: [],
         plan,
         owner,
@@ -220,7 +220,7 @@ describe("isModelCustomAvailable", () => {
     const plan = createMockPlan(DUST_COMPANY_PLAN_CODE);
 
     expect(
-      isModelCustomAvailable(model, {
+      isModelAvailable(model, {
         featureFlags: [],
         plan,
         owner,
@@ -237,7 +237,7 @@ describe("isModelCustomAvailable", () => {
     const plan = createMockPlan("ENT_CUSTOM_PLAN");
 
     expect(
-      isModelCustomAvailable(model, {
+      isModelAvailable(model, {
         featureFlags: [],
         plan,
         owner,
@@ -254,7 +254,7 @@ describe("isModelCustomAvailable", () => {
     const plan = createMockPlan(DUST_COMPANY_PLAN_CODE);
 
     expect(
-      isModelCustomAvailable(model, {
+      isModelAvailable(model, {
         featureFlags: [],
         plan,
         owner,
@@ -271,7 +271,7 @@ describe("isModelCustomAvailable", () => {
     const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE);
 
     expect(
-      isModelCustomAvailable(model, {
+      isModelAvailable(model, {
         featureFlags: ["deepseek_feature"],
         plan,
         owner,
@@ -288,7 +288,7 @@ describe("isModelCustomAvailable", () => {
     const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE);
 
     expect(
-      isModelCustomAvailable(model, {
+      isModelAvailable(model, {
         featureFlags: [],
         plan,
         owner,

--- a/front/lib/assistant.test.ts
+++ b/front/lib/assistant.test.ts
@@ -1,5 +1,4 @@
 import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
-import type { RegionType } from "@app/lib/api/regions/config";
 import { filterEnabledModels, isModelAvailable } from "@app/lib/assistant";
 import { Authenticator } from "@app/lib/auth";
 import {
@@ -13,6 +12,7 @@ import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { SUPPORTED_MODEL_CONFIGS } from "@app/types/assistant/models/models";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { PlanType } from "@app/types/plan";
+import type { RegionType } from "@app/types/region";
 import type { WorkspaceType } from "@app/types/user";
 import { describe, expect, it } from "vitest";
 

--- a/front/lib/assistant.test.ts
+++ b/front/lib/assistant.test.ts
@@ -91,7 +91,7 @@ describe("isModelAvailable", () => {
       isModelAvailable(model, {
         featureFlags: [],
         plan,
-        owner,
+        regionalModelsOnly: owner.regionalModelsOnly,
         region: TEST_REGION,
       })
     ).toBe(true);
@@ -108,7 +108,7 @@ describe("isModelAvailable", () => {
       isModelAvailable(model, {
         featureFlags: ["deepseek_feature"],
         plan,
-        owner,
+        regionalModelsOnly: owner.regionalModelsOnly,
         region: TEST_REGION,
       })
     ).toBe(true);
@@ -125,7 +125,7 @@ describe("isModelAvailable", () => {
       isModelAvailable(model, {
         featureFlags: [],
         plan,
-        owner,
+        regionalModelsOnly: owner.regionalModelsOnly,
         region: TEST_REGION,
       })
     ).toBe(false);
@@ -139,7 +139,7 @@ describe("isModelAvailable", () => {
       isModelAvailable(model, {
         featureFlags: [],
         plan,
-        owner,
+        regionalModelsOnly: owner.regionalModelsOnly,
         region: TEST_REGION,
       })
     ).toBe(true);
@@ -153,7 +153,7 @@ describe("isModelAvailable", () => {
       isModelAvailable(model, {
         featureFlags: [],
         plan,
-        owner,
+        regionalModelsOnly: owner.regionalModelsOnly,
         region: TEST_REGION,
       })
     ).toBe(true);
@@ -170,7 +170,7 @@ describe("isModelAvailable", () => {
       isModelAvailable(model, {
         featureFlags: [],
         plan,
-        owner,
+        regionalModelsOnly: owner.regionalModelsOnly,
         region: TEST_REGION,
       })
     ).toBe(false);
@@ -186,7 +186,7 @@ describe("isModelAvailable", () => {
       isModelAvailable(model, {
         featureFlags: [],
         plan: null,
-        owner,
+        regionalModelsOnly: owner.regionalModelsOnly,
         region: TEST_REGION,
       })
     ).toBe(false);
@@ -203,7 +203,7 @@ describe("isModelAvailable", () => {
       isModelAvailable(model, {
         featureFlags: [],
         plan,
-        owner,
+        regionalModelsOnly: owner.regionalModelsOnly,
         region: TEST_REGION,
       })
     ).toBe(false);
@@ -220,7 +220,7 @@ describe("isModelAvailable", () => {
       isModelAvailable(model, {
         featureFlags: [],
         plan,
-        owner,
+        regionalModelsOnly: owner.regionalModelsOnly,
         region: TEST_REGION,
       })
     ).toBe(true);
@@ -237,7 +237,7 @@ describe("isModelAvailable", () => {
       isModelAvailable(model, {
         featureFlags: [],
         plan,
-        owner,
+        regionalModelsOnly: owner.regionalModelsOnly,
         region: TEST_REGION,
       })
     ).toBe(true);
@@ -254,7 +254,7 @@ describe("isModelAvailable", () => {
       isModelAvailable(model, {
         featureFlags: [],
         plan,
-        owner,
+        regionalModelsOnly: owner.regionalModelsOnly,
         region: TEST_REGION,
       })
     ).toBe(true);
@@ -271,7 +271,7 @@ describe("isModelAvailable", () => {
       isModelAvailable(model, {
         featureFlags: ["deepseek_feature"],
         plan,
-        owner,
+        regionalModelsOnly: owner.regionalModelsOnly,
         region: TEST_REGION,
       })
     ).toBe(true);
@@ -288,7 +288,7 @@ describe("isModelAvailable", () => {
       isModelAvailable(model, {
         featureFlags: [],
         plan,
-        owner,
+        regionalModelsOnly: owner.regionalModelsOnly,
         region: TEST_REGION,
       })
     ).toBe(false);
@@ -304,7 +304,7 @@ describe("filterEnabledModels", () => {
     const result = filterEnabledModels([model], {
       featureFlags: [],
       plan: auth.plan(),
-      owner: auth.getNonNullableWorkspace(),
+      regionalModelsOnly: auth.getNonNullableWorkspace().regionalModelsOnly,
       region: TEST_REGION,
       whitelistedProviders: getWhitelistedProviders(auth),
     });
@@ -324,7 +324,7 @@ describe("filterEnabledModels", () => {
     const result = filterEnabledModels([model], {
       featureFlags: [],
       plan: auth.plan(),
-      owner: auth.getNonNullableWorkspace(),
+      regionalModelsOnly: auth.getNonNullableWorkspace().regionalModelsOnly,
       region: TEST_REGION,
       whitelistedProviders: getWhitelistedProviders(auth),
     });
@@ -343,7 +343,7 @@ describe("filterEnabledModels", () => {
     const result = filterEnabledModels([model], {
       featureFlags: [],
       plan: auth.plan(),
-      owner: auth.getNonNullableWorkspace(),
+      regionalModelsOnly: auth.getNonNullableWorkspace().regionalModelsOnly,
       region: TEST_REGION,
       whitelistedProviders: getWhitelistedProviders(auth),
     });
@@ -362,7 +362,7 @@ describe("filterEnabledModels", () => {
     const result = filterEnabledModels([model], {
       featureFlags: ["deepseek_feature"],
       plan: auth.plan(),
-      owner: auth.getNonNullableWorkspace(),
+      regionalModelsOnly: auth.getNonNullableWorkspace().regionalModelsOnly,
       region: TEST_REGION,
       whitelistedProviders: getWhitelistedProviders(auth),
     });
@@ -386,7 +386,7 @@ describe("filterEnabledModels", () => {
     const result = filterEnabledModels([openaiModel, xaiModel], {
       featureFlags: [],
       plan: auth.plan(),
-      owner: auth.getNonNullableWorkspace(),
+      regionalModelsOnly: auth.getNonNullableWorkspace().regionalModelsOnly,
       region: TEST_REGION,
       whitelistedProviders: getWhitelistedProviders(auth),
     });
@@ -404,7 +404,7 @@ describe("filterEnabledModels", () => {
     const result = filterEnabledModels([model], {
       featureFlags: [],
       plan: auth.plan(),
-      owner: auth.getNonNullableWorkspace(),
+      regionalModelsOnly: auth.getNonNullableWorkspace().regionalModelsOnly,
       region: TEST_REGION,
       whitelistedProviders: getWhitelistedProviders(auth),
     });

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -64,7 +64,30 @@ export function isModelAvailable(
   return false;
 }
 
-export function filterCustomAvailableAndWhitelistedModels(
+// Returns true if the model is enabled for the workspace.
+export function isModelEnabled(
+  m: ModelConfigurationType,
+  {
+    featureFlags,
+    plan,
+    owner,
+    region,
+    whitelistedProviders,
+  }: {
+    featureFlags: WhitelistableFeature[];
+    plan: PlanType | null;
+    owner: WorkspaceType;
+    region: RegionType;
+    whitelistedProviders: Set<ModelProviderIdType>;
+  }
+) {
+  return (
+    isModelAvailable(m, { featureFlags, plan, owner, region }) &&
+    whitelistedProviders.has(m.providerId)
+  );
+}
+
+export function filterEnabledModels(
   models: ModelConfigurationType[],
   {
     featureFlags,
@@ -80,9 +103,13 @@ export function filterCustomAvailableAndWhitelistedModels(
     whitelistedProviders: Set<ModelProviderIdType>;
   }
 ): ModelConfigurationType[] {
-  return models.filter(
-    (m) =>
-      isModelAvailable(m, { featureFlags, plan, owner, region }) &&
-      whitelistedProviders.has(m.providerId)
+  return models.filter((m) =>
+    isModelEnabled(m, {
+      featureFlags,
+      plan,
+      owner,
+      region,
+      whitelistedProviders,
+    })
   );
 }

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -1,4 +1,3 @@
-import type { RegionType } from "@app/lib/api/regions/config";
 import {
   isDustCompanyPlan,
   isEntreprisePlanPrefix,
@@ -10,6 +9,7 @@ import type {
   ModelProviderIdType,
 } from "@app/types/assistant/models/types";
 import type { PlanType } from "@app/types/plan";
+import type { RegionType } from "@app/types/region";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 
 export function isEnterpriseOrDust(plan: PlanType | null): boolean {

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -20,7 +20,7 @@ export function isEnterpriseOrDust(plan: PlanType | null): boolean {
   );
 }
 
-// Returns true if the model is available to the workspace for use.
+// Returns true if the model is available to the workspace for build.
 export function isModelAvailable(
   m: ModelConfigurationType,
   {
@@ -35,6 +35,10 @@ export function isModelAvailable(
     region: RegionType;
   }
 ) {
+  if (m.largeModel && !isUpgraded(plan)) {
+    return false;
+  }
+
   if (plan?.isByok && !isByokProviderId(m.providerId)) {
     return false;
   }
@@ -60,32 +64,6 @@ export function isModelAvailable(
   return false;
 }
 
-// Returns true if the model is available to the workspace for build.
-export function isModelCustomAvailable(
-  m: ModelConfigurationType,
-  {
-    featureFlags,
-    plan,
-    owner,
-    region,
-  }: {
-    featureFlags: WhitelistableFeature[];
-    plan: PlanType | null;
-    owner: WorkspaceType;
-    region: RegionType;
-  }
-) {
-  if (!isModelAvailable(m, { featureFlags, plan, owner, region })) {
-    return false;
-  }
-
-  if (m.largeModel && !isUpgraded(plan)) {
-    return false;
-  }
-
-  return true;
-}
-
 export function filterCustomAvailableAndWhitelistedModels(
   models: ModelConfigurationType[],
   {
@@ -104,7 +82,7 @@ export function filterCustomAvailableAndWhitelistedModels(
 ): ModelConfigurationType[] {
   return models.filter(
     (m) =>
-      isModelCustomAvailable(m, { featureFlags, plan, owner, region }) &&
+      isModelAvailable(m, { featureFlags, plan, owner, region }) &&
       whitelistedProviders.has(m.providerId)
   );
 }

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -11,7 +11,6 @@ import type {
 } from "@app/types/assistant/models/types";
 import type { PlanType } from "@app/types/plan";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
-import type { WorkspaceType } from "@app/types/user";
 
 export function isEnterpriseOrDust(plan: PlanType | null): boolean {
   return (
@@ -26,12 +25,12 @@ export function isModelAvailable(
   {
     featureFlags,
     plan,
-    owner,
+    regionalModelsOnly,
     region,
   }: {
     featureFlags: WhitelistableFeature[];
     plan: PlanType | null;
-    owner: WorkspaceType;
+    regionalModelsOnly: boolean;
     region: RegionType;
   }
 ) {
@@ -43,7 +42,7 @@ export function isModelAvailable(
     return false;
   }
 
-  if (owner.regionalModelsOnly && m.regionalAvailability[region] !== true) {
+  if (regionalModelsOnly && m.regionalAvailability[region] !== true) {
     return false;
   }
 
@@ -70,19 +69,19 @@ export function isModelEnabled(
   {
     featureFlags,
     plan,
-    owner,
+    regionalModelsOnly,
     region,
     whitelistedProviders,
   }: {
     featureFlags: WhitelistableFeature[];
     plan: PlanType | null;
-    owner: WorkspaceType;
+    regionalModelsOnly: boolean;
     region: RegionType;
     whitelistedProviders: Set<ModelProviderIdType>;
   }
 ) {
   return (
-    isModelAvailable(m, { featureFlags, plan, owner, region }) &&
+    isModelAvailable(m, { featureFlags, plan, regionalModelsOnly, region }) &&
     whitelistedProviders.has(m.providerId)
   );
 }
@@ -92,13 +91,13 @@ export function filterEnabledModels(
   {
     featureFlags,
     plan,
-    owner,
+    regionalModelsOnly,
     region,
     whitelistedProviders,
   }: {
     featureFlags: WhitelistableFeature[];
     plan: PlanType | null;
-    owner: WorkspaceType;
+    regionalModelsOnly: boolean;
     region: RegionType;
     whitelistedProviders: Set<ModelProviderIdType>;
   }
@@ -107,7 +106,7 @@ export function filterEnabledModels(
     isModelEnabled(m, {
       featureFlags,
       plan,
-      owner,
+      regionalModelsOnly,
       region,
       whitelistedProviders,
     })

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -79,13 +79,6 @@ export function isModelCustomAvailable(
     return false;
   }
 
-  if (m.customAvailableIf) {
-    return (
-      m.customAvailableIf.featureFlag &&
-      featureFlags.includes(m.customAvailableIf.featureFlag)
-    );
-  }
-
   if (m.largeModel && !isUpgraded(plan)) {
     return false;
   }

--- a/front/lib/auth/RegionContext.tsx
+++ b/front/lib/auth/RegionContext.tsx
@@ -1,6 +1,6 @@
 import { setBaseUrlResolver } from "@app/lib/api/config";
-import type { RegionInfo, RegionType } from "@app/lib/api/regions/config";
-import { isRegionType } from "@app/lib/api/regions/config";
+import type { RegionInfo, RegionType } from "@app/types/region";
+import { isRegionType } from "@app/types/region";
 import {
   createContext,
   useCallback,

--- a/front/lib/iam/provider.ts
+++ b/front/lib/iam/provider.ts
@@ -1,4 +1,4 @@
-import type { RegionType } from "@app/lib/api/regions/config";
+import type { RegionType } from "@app/types/region";
 
 export interface ExternalUser {
   email: string;

--- a/front/lib/poke/regions.ts
+++ b/front/lib/poke/regions.ts
@@ -1,4 +1,4 @@
-import type { RegionType } from "@app/lib/api/regions/config";
+import type { RegionType } from "@app/types/region";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export const getRegionDisplay = (region: RegionType): string => {

--- a/front/lib/swr/models.ts
+++ b/front/lib/swr/models.ts
@@ -1,11 +1,11 @@
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { GetAvailableModelsResponseType } from "@app/pages/api/w/[wId]/models";
+import type { GetEnabledModelsResponseType } from "@app/pages/api/w/[wId]/models";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
 
 export function useModels({ owner }: { owner: LightWorkspaceType }) {
   const { fetcher } = useFetcher();
-  const modelsFetcher: Fetcher<GetAvailableModelsResponseType> = fetcher;
+  const modelsFetcher: Fetcher<GetEnabledModelsResponseType> = fetcher;
 
   const { data, error } = useSWRWithDefaults(
     `/api/w/${owner.sId}/models`,

--- a/front/pages/api/poke/region.ts
+++ b/front/pages/api/poke/region.ts
@@ -1,12 +1,13 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
-import type { RegionType } from "@app/lib/api/regions/config";
-import { config, SUPPORTED_REGIONS } from "@app/lib/api/regions/config";
+import { config } from "@app/lib/api/regions/config";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import type { RegionType } from "@app/types/region";
+import { SUPPORTED_REGIONS } from "@app/types/region";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export type GetRegionResponseType = {

--- a/front/pages/api/w/[wId]/models.ts
+++ b/front/pages/api/w/[wId]/models.ts
@@ -5,7 +5,7 @@ import { USED_MODEL_CONFIGS } from "@app/components/providers/model_configs";
 import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { config as regionConfig } from "@app/lib/api/regions/config";
-import { filterCustomAvailableAndWhitelistedModels } from "@app/lib/assistant";
+import { filterEnabledModels } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
@@ -33,7 +33,7 @@ async function handler(
 
       // Include both standard models and custom models (from GCS at build time)
       const allUsedModels = [...USED_MODEL_CONFIGS, ...CUSTOM_MODEL_CONFIGS];
-      const models = filterCustomAvailableAndWhitelistedModels(allUsedModels, {
+      const models = filterEnabledModels(allUsedModels, {
         featureFlags,
         plan,
         owner,

--- a/front/pages/api/w/[wId]/models.ts
+++ b/front/pages/api/w/[wId]/models.ts
@@ -14,13 +14,13 @@ import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export type GetAvailableModelsResponseType = {
+export type GetEnabledModelsResponseType = {
   models: ModelConfigurationType[];
 };
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetAvailableModelsResponseType>>,
+  res: NextApiResponse<WithAPIErrorResponse<GetEnabledModelsResponseType>>,
   auth: Authenticator
 ): Promise<void> {
   switch (req.method) {

--- a/front/pages/api/w/[wId]/models.ts
+++ b/front/pages/api/w/[wId]/models.ts
@@ -36,7 +36,7 @@ async function handler(
       const models = filterEnabledModels(allUsedModels, {
         featureFlags,
         plan,
-        owner,
+        regionalModelsOnly: owner.regionalModelsOnly,
         region,
         whitelistedProviders,
       });

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -118,11 +118,7 @@ import {
 } from "@app/lib/api/audit/workos_audit";
 import config from "@app/lib/api/config";
 import { performLogin } from "@app/lib/api/login";
-import type { RegionType } from "@app/lib/api/regions/config";
-import {
-  config as multiRegionsConfig,
-  SUPPORTED_REGIONS,
-} from "@app/lib/api/regions/config";
+import { config as multiRegionsConfig } from "@app/lib/api/regions/config";
 import { checkUserRegionAffinity } from "@app/lib/api/regions/lookup";
 import { authenticateWithWorkOSCode } from "@app/lib/api/workos/authenticate";
 import { getWorkOS } from "@app/lib/api/workos/client";
@@ -140,6 +136,8 @@ import { extractUTMParams } from "@app/lib/utils/utm";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
+import type { RegionType } from "@app/types/region";
+import { SUPPORTED_REGIONS } from "@app/types/region";
 
 import { isDevelopment } from "@app/types/shared/env";
 import { assertNever } from "@app/types/shared/utils/assert_never";

--- a/front/poke/swr/search.ts
+++ b/front/poke/swr/search.ts
@@ -1,5 +1,3 @@
-import type { RegionType } from "@app/lib/api/regions/config";
-import { SUPPORTED_REGIONS } from "@app/lib/api/regions/config";
 import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetPokeSearchItemsResponseBody } from "@app/pages/api/poke/search";
@@ -8,6 +6,8 @@ import type {
   PokeWorkspaceType,
 } from "@app/pages/api/poke/workspaces";
 import type { PokeItemBase } from "@app/types/poke";
+import type { RegionType } from "@app/types/region";
+import { SUPPORTED_REGIONS } from "@app/types/region";
 import { useEffect, useState } from "react";
 import type { Fetcher } from "swr";
 

--- a/front/scripts/relocation/get_data_source_documents.ts
+++ b/front/scripts/relocation/get_data_source_documents.ts
@@ -1,7 +1,7 @@
-import { isRegionType, SUPPORTED_REGIONS } from "@app/lib/api/regions/config";
 import { makeScript } from "@app/scripts/helpers";
 import { getDataSourceDocuments } from "@app/temporal/relocation/activities/source_region/core";
 import { CORE_API_LIST_NODES_BATCH_SIZE } from "@app/temporal/relocation/activities/types";
+import { isRegionType, SUPPORTED_REGIONS } from "@app/types/region";
 
 makeScript(
   {

--- a/front/scripts/relocation/get_data_source_tables.ts
+++ b/front/scripts/relocation/get_data_source_tables.ts
@@ -1,7 +1,7 @@
-import { isRegionType, SUPPORTED_REGIONS } from "@app/lib/api/regions/config";
 import { makeScript } from "@app/scripts/helpers";
 import { getDataSourceTables } from "@app/temporal/relocation/activities/source_region/core/tables";
 import { CORE_API_LIST_TABLES_BATCH_SIZE } from "@app/temporal/relocation/activities/types";
+import { isRegionType, SUPPORTED_REGIONS } from "@app/types/region";
 
 makeScript(
   {

--- a/front/scripts/relocation/read_front_table_chunk.ts
+++ b/front/scripts/relocation/read_front_table_chunk.ts
@@ -1,12 +1,9 @@
-import type { RegionType } from "@app/lib/api/regions/config";
-import {
-  config,
-  isRegionType,
-  SUPPORTED_REGIONS,
-} from "@app/lib/api/regions/config";
+import { config } from "@app/lib/api/regions/config";
 import logger from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import { readFrontTableChunk } from "@app/temporal/relocation/activities/source_region/front";
+import type { RegionType } from "@app/types/region";
+import { isRegionType, SUPPORTED_REGIONS } from "@app/types/region";
 
 function assertCorrectRegion(region: RegionType) {
   if (config.getCurrentRegion() !== region) {

--- a/front/scripts/relocation/relocate_app_workflow.ts
+++ b/front/scripts/relocation/relocate_app_workflow.ts
@@ -1,8 +1,8 @@
-import { isRegionType, SUPPORTED_REGIONS } from "@app/lib/api/regions/config";
 import { makeScript } from "@app/scripts/helpers";
 import { RELOCATION_QUEUES_PER_REGION } from "@app/temporal/relocation/config";
 import { getTemporalRelocationClient } from "@app/temporal/relocation/temporal";
 import { workspaceRelocateAppWorkflow } from "@app/temporal/relocation/workflows";
+import { isRegionType, SUPPORTED_REGIONS } from "@app/types/region";
 import { WorkflowNotFoundError } from "@temporalio/common";
 
 makeScript(

--- a/front/scripts/relocation/relocate_apps_workflow.ts
+++ b/front/scripts/relocation/relocate_apps_workflow.ts
@@ -1,8 +1,8 @@
-import { isRegionType, SUPPORTED_REGIONS } from "@app/lib/api/regions/config";
 import { makeScript } from "@app/scripts/helpers";
 import { RELOCATION_QUEUES_PER_REGION } from "@app/temporal/relocation/config";
 import { getTemporalRelocationClient } from "@app/temporal/relocation/temporal";
 import { workspaceRelocateAppsWorkflow } from "@app/temporal/relocation/workflows";
+import { isRegionType, SUPPORTED_REGIONS } from "@app/types/region";
 import { WorkflowNotFoundError } from "@temporalio/common";
 
 makeScript(

--- a/front/scripts/relocation/relocate_core_data_source.ts
+++ b/front/scripts/relocation/relocate_core_data_source.ts
@@ -1,11 +1,8 @@
-import {
-  config,
-  isRegionType,
-  SUPPORTED_REGIONS,
-} from "@app/lib/api/regions/config";
+import { config } from "@app/lib/api/regions/config";
 import { Authenticator } from "@app/lib/auth";
 import { makeScript } from "@app/scripts/helpers";
 import { launchCoreDataSourceRelocationWorkflow } from "@app/temporal/relocation/client";
+import { isRegionType, SUPPORTED_REGIONS } from "@app/types/region";
 import assert from "assert";
 
 makeScript(

--- a/front/scripts/relocation/relocate_data_source.ts
+++ b/front/scripts/relocation/relocate_data_source.ts
@@ -1,14 +1,11 @@
-import {
-  config,
-  isRegionType,
-  SUPPORTED_REGIONS,
-} from "@app/lib/api/regions/config";
+import { config } from "@app/lib/api/regions/config";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { makeScript } from "@app/scripts/helpers";
 import { RELOCATION_QUEUES_PER_REGION } from "@app/temporal/relocation/config";
 import { getTemporalRelocationClient } from "@app/temporal/relocation/temporal";
 import { workspaceRelocateDataSourceCoreWorkflow } from "@app/temporal/relocation/workflows";
+import { isRegionType, SUPPORTED_REGIONS } from "@app/types/region";
 import assert from "assert";
 
 makeScript(

--- a/front/scripts/relocation/relocate_workspace.ts
+++ b/front/scripts/relocation/relocate_workspace.ts
@@ -7,12 +7,7 @@ import {
   pauseAllLabsWorkflows,
   unpauseAllLabsWorkflows,
 } from "@app/lib/api/labs";
-import type { RegionType } from "@app/lib/api/regions/config";
-import {
-  config,
-  isRegionType,
-  SUPPORTED_REGIONS,
-} from "@app/lib/api/regions/config";
+import { config } from "@app/lib/api/regions/config";
 import { invalidateWorkspaceRegionCache } from "@app/lib/api/regions/lookup";
 import {
   deleteWorkspace,
@@ -27,6 +22,8 @@ import { Authenticator } from "@app/lib/auth";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { makeScript } from "@app/scripts/helpers";
 import { launchWorkspaceRelocationWorkflow } from "@app/temporal/relocation/client";
+import type { RegionType } from "@app/types/region";
+import { isRegionType, SUPPORTED_REGIONS } from "@app/types/region";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const RELOCATION_STEPS = [

--- a/front/scripts/update_workspace_region_metadata.ts
+++ b/front/scripts/update_workspace_region_metadata.ts
@@ -1,8 +1,8 @@
 import { updateWorkspaceRegionMetadata } from "@app/admin/relocate_users";
-import type { RegionType } from "@app/lib/api/regions/config";
-import { isRegionType, SUPPORTED_REGIONS } from "@app/lib/api/regions/config";
 import { Authenticator } from "@app/lib/auth";
 import { makeScript } from "@app/scripts/helpers";
+import type { RegionType } from "@app/types/region";
+import { isRegionType, SUPPORTED_REGIONS } from "@app/types/region";
 
 makeScript(
   {

--- a/front/scripts/warm_workspace_region_cache.ts
+++ b/front/scripts/warm_workspace_region_cache.ts
@@ -1,6 +1,6 @@
 import { getRedisCacheClient } from "@app/lib/api/redis";
-import { isRegionType, SUPPORTED_REGIONS } from "@app/lib/api/regions/config";
 import { makeScript } from "@app/scripts/helpers";
+import { isRegionType, SUPPORTED_REGIONS } from "@app/types/region";
 import * as fs from "fs";
 
 const WORKSPACE_REGION_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours.

--- a/front/temporal/relocation/activities/destination_region/core/apps.ts
+++ b/front/temporal/relocation/activities/destination_region/core/apps.ts
@@ -1,11 +1,11 @@
 import config from "@app/lib/api/config";
-import type { RegionType } from "@app/lib/api/regions/config";
 import { AppModel } from "@app/lib/resources/storage/models/apps";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { CoreAppAPIRelocationBlob } from "@app/temporal/relocation/activities/types";
 import { readFromRelocationStorage } from "@app/temporal/relocation/lib/file_storage/relocation";
 import { CoreAPI } from "@app/types/core/core_api";
+import type { RegionType } from "@app/types/region";
 
 export async function processApp({
   dustAPIProjectId,

--- a/front/temporal/relocation/activities/destination_region/core/data_sources.ts
+++ b/front/temporal/relocation/activities/destination_region/core/data_sources.ts
@@ -1,6 +1,5 @@
 import config from "@app/lib/api/config";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
-import type { RegionType } from "@app/lib/api/regions/config";
 import { Authenticator } from "@app/lib/auth";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import logger from "@app/logger/logger";
@@ -10,6 +9,7 @@ import type {
 } from "@app/temporal/relocation/activities/types";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { CoreAPIDataSource } from "@app/types/core/data_source";
+import type { RegionType } from "@app/types/region";
 
 export async function createDataSourceProject({
   destRegion,

--- a/front/temporal/relocation/activities/destination_region/core/documents.ts
+++ b/front/temporal/relocation/activities/destination_region/core/documents.ts
@@ -1,7 +1,6 @@
 import config from "@app/lib/api/config";
 import { UNTITLED_TITLE } from "@app/lib/api/content_nodes";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
-import type { RegionType } from "@app/lib/api/regions/config";
 import { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -15,6 +14,7 @@ import {
   readFromRelocationStorage,
 } from "@app/temporal/relocation/lib/file_storage/relocation";
 import { CoreAPI } from "@app/types/core/core_api";
+import type { RegionType } from "@app/types/region";
 
 export async function processDataSourceDocuments({
   destIds,

--- a/front/temporal/relocation/activities/destination_region/core/folders.ts
+++ b/front/temporal/relocation/activities/destination_region/core/folders.ts
@@ -1,5 +1,4 @@
 import config from "@app/lib/api/config";
-import type { RegionType } from "@app/lib/api/regions/config";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type {
@@ -12,6 +11,7 @@ import {
   readFromRelocationStorage,
 } from "@app/temporal/relocation/lib/file_storage/relocation";
 import { CoreAPI } from "@app/types/core/core_api";
+import type { RegionType } from "@app/types/region";
 
 export async function processDataSourceFolders({
   destIds,

--- a/front/temporal/relocation/activities/destination_region/core/tables.ts
+++ b/front/temporal/relocation/activities/destination_region/core/tables.ts
@@ -1,6 +1,5 @@
 import config from "@app/lib/api/config";
 import { UNTITLED_TITLE } from "@app/lib/api/content_nodes";
-import type { RegionType } from "@app/lib/api/regions/config";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type {
@@ -13,6 +12,7 @@ import {
   readFromRelocationStorage,
 } from "@app/temporal/relocation/lib/file_storage/relocation";
 import { CoreAPI } from "@app/types/core/core_api";
+import type { RegionType } from "@app/types/region";
 
 export async function processDataSourceTables({
   destIds,

--- a/front/temporal/relocation/activities/destination_region/front/sql.ts
+++ b/front/temporal/relocation/activities/destination_region/front/sql.ts
@@ -1,5 +1,5 @@
 // biome-ignore-all lint/plugin/noRawSql: relocation SQL file requires raw SQL
-import type { RegionType } from "@app/lib/api/regions/config";
+
 import { frontSequelize } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { withTransaction } from "@app/lib/utils/sql_utils";
@@ -13,6 +13,7 @@ import {
   readFromRelocationStorage,
   writeToRelocationStorage,
 } from "@app/temporal/relocation/lib/file_storage/relocation";
+import type { RegionType } from "@app/types/region";
 import type { ModelId } from "@app/types/shared/model_id";
 import { removeNulls } from "@app/types/shared/utils/general";
 import assert from "assert";

--- a/front/temporal/relocation/activities/source_region/core/apps.ts
+++ b/front/temporal/relocation/activities/source_region/core/apps.ts
@@ -1,5 +1,4 @@
 import config from "@app/lib/api/config";
-import type { RegionType } from "@app/lib/api/regions/config";
 import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import { AppModel } from "@app/lib/resources/storage/models/apps";
 import type { SpaceModel } from "@app/lib/resources/storage/models/spaces";
@@ -8,6 +7,7 @@ import type { CoreAppAPIRelocationBlob } from "@app/temporal/relocation/activiti
 import { writeToRelocationStorage } from "@app/temporal/relocation/lib/file_storage/relocation";
 import type { CoreAPIDataset } from "@app/types/core/core_api";
 import { CoreAPI } from "@app/types/core/core_api";
+import type { RegionType } from "@app/types/region";
 import type { ModelId } from "@app/types/shared/model_id";
 import assert from "assert";
 import type { WhereOptions } from "sequelize";

--- a/front/temporal/relocation/activities/source_region/core/documents.ts
+++ b/front/temporal/relocation/activities/source_region/core/documents.ts
@@ -1,5 +1,4 @@
 import config from "@app/lib/api/config";
-import type { RegionType } from "@app/lib/api/regions/config";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type {
@@ -17,6 +16,7 @@ import type {
 } from "@app/types/core/core_api";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { CoreAPIDocumentBlob } from "@app/types/core/data_source";
+import type { RegionType } from "@app/types/region";
 import type { Ok } from "@app/types/shared/result";
 
 export async function getDataSourceDocuments({

--- a/front/temporal/relocation/activities/source_region/core/folders.ts
+++ b/front/temporal/relocation/activities/source_region/core/folders.ts
@@ -1,5 +1,4 @@
 import config from "@app/lib/api/config";
-import type { RegionType } from "@app/lib/api/regions/config";
 import logger from "@app/logger/logger";
 import type {
   CoreFolderAPIRelocationBlob,
@@ -12,6 +11,7 @@ import type {
   CoreAPISearchCursorRequest,
 } from "@app/types/core/core_api";
 import { CoreAPI } from "@app/types/core/core_api";
+import type { RegionType } from "@app/types/region";
 
 export async function getDataSourceFolders({
   dataSourceCoreIds,

--- a/front/temporal/relocation/activities/source_region/core/tables.ts
+++ b/front/temporal/relocation/activities/source_region/core/tables.ts
@@ -1,5 +1,4 @@
 import config from "@app/lib/api/config";
-import type { RegionType } from "@app/lib/api/regions/config";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type {
@@ -20,6 +19,7 @@ import type {
 } from "@app/types/core/core_api";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { CoreAPITableBlob } from "@app/types/core/data_source";
+import type { RegionType } from "@app/types/region";
 import type { Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
 

--- a/front/temporal/relocation/activities/source_region/front/file_storage.ts
+++ b/front/temporal/relocation/activities/source_region/front/file_storage.ts
@@ -1,5 +1,4 @@
 import { getBaseMountPathForWorkspace } from "@app/lib/api/files/mount_path";
-import type { RegionType } from "@app/lib/api/regions/config";
 import fileStorageConfig from "@app/lib/file_storage/config";
 import { getContentFragmentBaseCloudStorageForWorkspace } from "@app/lib/resources/content_fragment_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -10,6 +9,7 @@ import type {
   DataSourceCoreIds,
 } from "@app/temporal/relocation/activities/types";
 import { StorageTransferService } from "@app/temporal/relocation/lib/file_storage/transfer";
+import type { RegionType } from "@app/types/region";
 
 export async function startTransferFrontPublicFiles({
   destBucket,

--- a/front/temporal/relocation/activities/source_region/front/sql.ts
+++ b/front/temporal/relocation/activities/source_region/front/sql.ts
@@ -1,5 +1,5 @@
 // biome-ignore-all lint/plugin/noRawSql: relocation SQL file requires raw SQL
-import type { RegionType } from "@app/lib/api/regions/config";
+
 import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
@@ -25,6 +25,7 @@ import { getTopologicalOrder } from "@app/temporal/relocation/lib/sql/schema/dep
 import { getUserReferencingColumns } from "@app/temporal/relocation/lib/sql/schema/introspection";
 import type { UserIdMapping } from "@app/temporal/relocation/lib/sql/user_mappings";
 import { mapUserIdsInRows } from "@app/temporal/relocation/lib/sql/user_mappings";
+import type { RegionType } from "@app/types/region";
 import type { ModelId } from "@app/types/shared/model_id";
 import assert from "assert";
 import { Op, QueryTypes } from "sequelize";

--- a/front/temporal/relocation/activities/types.ts
+++ b/front/temporal/relocation/activities/types.ts
@@ -1,10 +1,10 @@
-import type { RegionType } from "@app/lib/api/regions/config";
 import type { CoreAPIContentNode } from "@app/types/core/content_node";
 import type { CoreAPIDataset } from "@app/types/core/core_api";
 import type {
   CoreAPIDocumentBlob,
   CoreAPITableBlob,
 } from "@app/types/core/data_source";
+import type { RegionType } from "@app/types/region";
 import type { ModelId } from "@app/types/shared/model_id";
 import isPlainObject from "lodash/isPlainObject";
 

--- a/front/temporal/relocation/client.ts
+++ b/front/temporal/relocation/client.ts
@@ -1,4 +1,3 @@
-import type { RegionType } from "@app/lib/api/regions/config";
 import type {
   CreateDataSourceProjectResult,
   DataSourceCoreIds,
@@ -9,6 +8,7 @@ import {
   workspaceRelocateCoreDataSourceResourcesWorkflow,
   workspaceRelocationWorkflow,
 } from "@app/temporal/relocation/workflows";
+import type { RegionType } from "@app/types/region";
 
 export async function launchWorkspaceRelocationWorkflow({
   workspaceId,

--- a/front/temporal/relocation/config.ts
+++ b/front/temporal/relocation/config.ts
@@ -1,4 +1,4 @@
-import type { RegionType } from "@app/lib/api/regions/config";
+import type { RegionType } from "@app/types/region";
 
 const QUEUE_VERSION = 1;
 

--- a/front/temporal/relocation/lib/file_storage/transfer.ts
+++ b/front/temporal/relocation/lib/file_storage/transfer.ts
@@ -1,5 +1,5 @@
 import config from "@app/lib/api/config";
-import type { RegionType } from "@app/lib/api/regions/config";
+import type { RegionType } from "@app/types/region";
 import { isDevelopment } from "@app/types/shared/env";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";

--- a/front/temporal/relocation/workflows.ts
+++ b/front/temporal/relocation/workflows.ts
@@ -1,4 +1,3 @@
-import type { RegionType } from "@app/lib/api/regions/config";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type * as connectorsDestinationActivities from "@app/temporal/relocation/activities/destination_region/connectors/sql";
 import type * as coreDestinationActivities from "@app/temporal/relocation/activities/destination_region/core";
@@ -15,6 +14,7 @@ import {
   CORE_API_LIST_TABLES_BATCH_SIZE,
 } from "@app/temporal/relocation/activities/types";
 import { RELOCATION_QUEUES_PER_REGION } from "@app/temporal/relocation/config";
+import type { RegionType } from "@app/types/region";
 import type { ModelId } from "@app/types/shared/model_id";
 import {
   continueAsNew,

--- a/front/types/assistant/models/openai.ts
+++ b/front/types/assistant/models/openai.ts
@@ -515,9 +515,6 @@ export const O1_MODEL_CONFIG: ModelConfigurationType = {
   availableIfOneOf: {
     featureFlag: "openai_o1_feature",
   },
-  customAvailableIf: {
-    featureFlag: "openai_o1_custom_assistants_feature",
-  },
   supportsResponseFormat: false,
   tokenizer: { type: "tiktoken", base: "o200k_base" },
   regionalAvailability: {
@@ -547,9 +544,6 @@ export const O1_MINI_MODEL_CONFIG: ModelConfigurationType = {
     high: false,
   },
   defaultReasoningEffort: "none",
-  customAvailableIf: {
-    featureFlag: "openai_o1_custom_assistants_feature",
-  },
   supportsResponseFormat: false,
   tokenizer: { type: "tiktoken", base: "o200k_base" },
   regionalAvailability: {

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -1,4 +1,4 @@
-import { SUPPORTED_REGIONS } from "@app/lib/api/regions/config";
+import { SUPPORTED_REGIONS } from "@app/types/region";
 import { z } from "zod";
 import type { WhitelistableFeature } from "../../shared/feature_flags";
 import type { ExtractSpecificKeys } from "../../shared/typescipt_utils";

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -91,10 +91,6 @@ export type ModelConfigurationType = Omit<
     featureFlag?: WhitelistableFeature;
   };
   // Pre-requisite: must be available.
-  // If object is empty, model is not custom available.
-  customAvailableIf?: {
-    featureFlag?: WhitelistableFeature;
-  };
   tokenizer: TokenizerConfig;
 };
 

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -1,8 +1,8 @@
 // Okay to use public API types because it's front/connectors communication.
 
-import type { RegionType } from "@app/lib/api/regions/config";
 import { CONVERSATION_ERROR_TYPES } from "@app/types/assistant/conversation";
 import type { CoreAPIError } from "@app/types/core/core_api";
+import type { RegionType } from "@app/types/region";
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
 import type { ConnectorsAPIError } from "@dust-tt/client";
 import type { ContentfulStatusCode } from "hono/utils/http-status";

--- a/front/types/membership_invitation.ts
+++ b/front/types/membership_invitation.ts
@@ -1,4 +1,4 @@
-import type { RegionType } from "@app/lib/api/regions/config";
+import type { RegionType } from "@app/types/region";
 import { z } from "zod";
 
 import type { ModelId } from "./shared/model_id";

--- a/front/types/oauth/client/setup.ts
+++ b/front/types/oauth/client/setup.ts
@@ -1,5 +1,5 @@
 import config from "@app/lib/api/config";
-import type { RegionInfo } from "@app/lib/api/regions/config";
+import type { RegionInfo } from "@app/types/region";
 import type {
   OAuthConnectionType,
   OAuthCredentials,

--- a/front/types/poke/index.ts
+++ b/front/types/poke/index.ts
@@ -1,6 +1,6 @@
 import type { ActionGeneratedFileType } from "@app/lib/actions/types";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import type { RegionType } from "@app/lib/api/regions/config";
+import type { RegionType } from "@app/types/region";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 import type {

--- a/front/types/region.ts
+++ b/front/types/region.ts
@@ -1,0 +1,11 @@
+export const SUPPORTED_REGIONS = ["europe-west1", "us-central1"] as const;
+export type RegionType = (typeof SUPPORTED_REGIONS)[number];
+
+export interface RegionInfo {
+  name: RegionType;
+  url: string;
+}
+
+export function isRegionType(region: string): region is RegionType {
+  return SUPPORTED_REGIONS.includes(region as RegionType);
+}

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -92,10 +92,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Transcript feature (Labs)",
     stage: "on_demand",
   },
-  openai_o1_custom_assistants_feature: {
-    description: "OpenAI o1 model for custom assistants",
-    stage: "on_demand",
-  },
   openai_o1_feature: {
     description: "Access to OpenAI o1 model",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -721,7 +721,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "noop_model_feature"
   | "notion_private_integration"
   | "allow_old_notion_mcp"
-  | "openai_o1_custom_assistants_feature"
   | "openai_o1_feature"
   | "openai_o1_high_reasoning_feature"
   | "openai_usage_mcp"


### PR DESCRIPTION
## Description

This PR paves the way for simplified and centralized model filtering. Now that we introduce Vertex and region availability, we can't assess models availability only by their providers. Simple fictive example:
- we move dust on claude-sonnet-100 that has been released
- claude-sonnet-100 is not yet available in EU
- before: workspace with regionalModelOnly would break when querying dust ❌
- now: model falls back on gpt ✅


**Summary of the changes:**
- Removes the `customAvailableIf` model configuration concept and folds its logic into a clearer model-availability API. 
- `isModelCustomAvailable` is merged into `isModelAvailable`, and `filterCustomAvailableAndWhitelistedModels` becomes `filterEnabledModels` backed by a new `isModelEnabled` helper. 
- Default model selection (`getSmall/Large/FastestWhitelistedModel`) now goes through `isModelEnabled` instead of checking whitelisted providers directly, so plan/region/feature-flag gating is applied consistently. 
- Also drops the now-unused `openai_o1_custom_assistants_feature` flag, 
- passes `regionalModelsOnly` instead of the full `owner` object to availability checks, 
- moves region type definitions to `front/types/region.ts`, 
- and renames `GetAvailableModelsResponseType` to `GetEnabledModelsResponseType`.

Intentionally left model filtering logic untouched for global agents

## Tests

Local

## Risk

Medium, supposed to be mainly refactoring but with a quite large blast radius. Can be reverted.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`