### PR TITLE
Pricing: add limit events to know when we are close to workspace pool limit

### DIFF
--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -123,10 +123,15 @@ export async function dispatchPaygCapReached({
 
 export async function dispatchCreditsAdded({
   workspace,
+  newBalance,
 }: {
   workspace: WorkspaceResource;
+  newBalance: number;
 }): Promise<void> {
-  await transitionWorkspacePool(workspace, { type: "credits_added" });
+  await transitionWorkspacePool(workspace, {
+    type: "credits_added",
+    balance: newBalance,
+  });
 }
 
 export async function dispatchPaygDisabled({
@@ -143,6 +148,22 @@ export async function dispatchPaygEnabled({
   workspace: WorkspaceResource;
 }): Promise<void> {
   await transitionWorkspacePool(workspace, { type: "payg_enabled" });
+}
+
+export async function dispatchLowBalance100({
+  workspace,
+}: {
+  workspace: WorkspaceResource;
+}): Promise<void> {
+  await transitionWorkspacePool(workspace, { type: "low_balance_100" });
+}
+
+export async function dispatchLowBalance10({
+  workspace,
+}: {
+  workspace: WorkspaceResource;
+}): Promise<void> {
+  await transitionWorkspacePool(workspace, { type: "low_balance_10" });
 }
 
 async function transitionWorkspacePool(
@@ -199,7 +220,7 @@ export async function syncPoolCreditStateFromBalance({
   }, 0);
 
   if (awuBalance > 0) {
-    await dispatchCreditsAdded({ workspace });
+    await dispatchCreditsAdded({ workspace, newBalance: awuBalance });
   } else {
     await dispatchPoolExhausted({ workspace });
   }

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -123,14 +123,14 @@ export async function dispatchPaygCapReached({
 
 export async function dispatchCreditsAdded({
   workspace,
-  newBalance,
+  newBalanceAwu,
 }: {
   workspace: WorkspaceResource;
-  newBalance: number;
+  newBalanceAwu: number;
 }): Promise<void> {
   await transitionWorkspacePool(workspace, {
     type: "credits_added",
-    balance: newBalance,
+    balanceAwu: newBalanceAwu,
   });
 }
 
@@ -220,7 +220,7 @@ export async function syncPoolCreditStateFromBalance({
   }, 0);
 
   if (awuBalance > 0) {
-    await dispatchCreditsAdded({ workspace, newBalance: awuBalance });
+    await dispatchCreditsAdded({ workspace, newBalanceAwu: awuBalance });
   } else {
     await dispatchPoolExhausted({ workspace });
   }

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -150,20 +150,17 @@ export async function dispatchPaygEnabled({
   await transitionWorkspacePool(workspace, { type: "payg_enabled" });
 }
 
-export async function dispatchLowBalance100({
+export async function dispatchLowBalance({
   workspace,
+  balanceAwu,
 }: {
   workspace: WorkspaceResource;
+  balanceAwu: number;
 }): Promise<void> {
-  await transitionWorkspacePool(workspace, { type: "low_balance_100" });
-}
-
-export async function dispatchLowBalance10({
-  workspace,
-}: {
-  workspace: WorkspaceResource;
-}): Promise<void> {
-  await transitionWorkspacePool(workspace, { type: "low_balance_10" });
+  await transitionWorkspacePool(workspace, {
+    type: "low_balance",
+    balanceAwu,
+  });
 }
 
 async function transitionWorkspacePool(

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -1,5 +1,7 @@
 import {
   dispatchCreditsAdded,
+  dispatchLowBalance10,
+  dispatchLowBalance100,
   dispatchPaygCapReached,
   dispatchPerUserCapReached,
   dispatchPerUserCapResolved,
@@ -437,13 +439,10 @@ export async function processMetronomeWebhook({
       break;
     }
     case "alerts.low_remaining_contract_credit_and_commit_balance_reached": {
-      // Pool-exhaustion signal: total remaining (contract credits + commit balance)
-      // hit zero. The commit-only and contract-credit-only alerts fire too early
-      // when only one side is exhausted, so we listen to this combined alert
-      // exclusively.
-      //
-      // Gate on `remaining_balance` defensively in case a non-zero warning threshold
-      // is added under the same alert type later (e.g. early warning notification).
+      // Pool-exhaustion / low-balance signal: total remaining (contract credits
+      // + commit balance) crossed a threshold. Multiple alerts are configured at
+      // different thresholds (100, 10, 0 credits). Route to the appropriate
+      // dispatcher based on the remaining balance reported by Metronome.
       const remaining = event.properties.remaining_balance;
       if (remaining == null || remaining <= 0) {
         await dispatchPoolExhausted({ workspace });
@@ -455,11 +454,34 @@ export async function processMetronomeWebhook({
           },
           "[Metronome Webhook] low_remaining_contract_credit_and_commit_balance_reached: pool exhausted dispatched"
         );
+      } else if (remaining <= 10) {
+        await dispatchLowBalance10({ workspace });
+        logger.info(
+          {
+            eventId: event.id,
+            workspaceId: workspace.sId,
+            remaining,
+          },
+          "[Metronome Webhook] low_remaining_contract_credit_and_commit_balance_reached: low balance 10 dispatched"
+        );
+      } else if (remaining <= 100) {
+        await dispatchLowBalance100({ workspace });
+        logger.info(
+          {
+            eventId: event.id,
+            workspaceId: workspace.sId,
+            remaining,
+          },
+          "[Metronome Webhook] low_remaining_contract_credit_and_commit_balance_reached: low balance 100 dispatched"
+        );
       }
       break;
     }
     case "alerts.low_remaining_contract_credit_and_commit_balance_resolved": {
-      await dispatchCreditsAdded({ workspace });
+      await dispatchCreditsAdded({
+        workspace,
+        newBalance: event.properties.remaining_balance ?? 0,
+      });
       logger.info(
         {
           eventId: event.id,

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -1,7 +1,6 @@
 import {
   dispatchCreditsAdded,
-  dispatchLowBalance10,
-  dispatchLowBalance100,
+  dispatchLowBalance,
   dispatchPaygCapReached,
   dispatchPerUserCapReached,
   dispatchPerUserCapResolved,
@@ -454,25 +453,15 @@ export async function processMetronomeWebhook({
           },
           "[Metronome Webhook] low_remaining_contract_credit_and_commit_balance_reached: pool exhausted dispatched"
         );
-      } else if (remaining <= 10) {
-        await dispatchLowBalance10({ workspace });
+      } else {
+        await dispatchLowBalance({ workspace, balanceAwu: remaining });
         logger.info(
           {
             eventId: event.id,
             workspaceId: workspace.sId,
             remaining,
           },
-          "[Metronome Webhook] low_remaining_contract_credit_and_commit_balance_reached: low balance 10 dispatched"
-        );
-      } else if (remaining <= 100) {
-        await dispatchLowBalance100({ workspace });
-        logger.info(
-          {
-            eventId: event.id,
-            workspaceId: workspace.sId,
-            remaining,
-          },
-          "[Metronome Webhook] low_remaining_contract_credit_and_commit_balance_reached: low balance 100 dispatched"
+          "[Metronome Webhook] low_remaining_contract_credit_and_commit_balance_reached: low balance dispatched"
         );
       }
       break;

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -480,7 +480,7 @@ export async function processMetronomeWebhook({
     case "alerts.low_remaining_contract_credit_and_commit_balance_resolved": {
       await dispatchCreditsAdded({
         workspace,
-        newBalance: event.properties.remaining_balance ?? 0,
+        newBalanceAwu: event.properties.remaining_balance ?? 0,
       });
       logger.info(
         {

--- a/front/lib/metronome/user_block.test.ts
+++ b/front/lib/metronome/user_block.test.ts
@@ -1,4 +1,7 @@
-import { isUserBlocked } from "@app/lib/metronome/user_block";
+import {
+  getWorkspaceCreditPoolStatus,
+  isUserBlocked,
+} from "@app/lib/metronome/user_block";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
@@ -120,5 +123,62 @@ describe("isUserBlocked", () => {
     expect(blocked).toBe(true);
     expect(redisValues.get("metronome:user_cap:ws_test:u_test")).toBe("0");
     expect(redisValues.get("metronome:pool_depleted:ws_test")).toBe("1");
+  });
+});
+
+describe("getWorkspaceCreditPoolStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    redisValues.clear();
+  });
+
+  it("returns cached status from Redis when present", async () => {
+    redisValues.set(
+      "metronome:pool_credit_status:ws_test",
+      "active_low_balance"
+    );
+
+    const status = await getWorkspaceCreditPoolStatus("ws_test");
+
+    expect(status).toBe("active_low_balance");
+    expect(mockFetchWorkspaceById).not.toHaveBeenCalled();
+  });
+
+  it("falls back to DB on cache miss and populates Redis", async () => {
+    mockFetchWorkspaceById.mockResolvedValue({
+      sId: "ws_test",
+      id: 42,
+      poolCreditState: "depleted",
+    });
+
+    const status = await getWorkspaceCreditPoolStatus("ws_test");
+
+    expect(status).toBe("depleted");
+    expect(redisValues.get("metronome:pool_credit_status:ws_test")).toBe(
+      "depleted"
+    );
+  });
+
+  it("returns 'active' when workspace not found in DB fallback", async () => {
+    mockFetchWorkspaceById.mockResolvedValue(null);
+
+    const status = await getWorkspaceCreditPoolStatus("ws_test");
+
+    expect(status).toBe("active");
+  });
+
+  it("falls back to DB when Redis has invalid value", async () => {
+    redisValues.set("metronome:pool_credit_status:ws_test", "invalid_state");
+
+    mockFetchWorkspaceById.mockResolvedValue({
+      sId: "ws_test",
+      id: 42,
+      poolCreditState: "depleted",
+    });
+
+    const status = await getWorkspaceCreditPoolStatus("ws_test");
+
+    expect(status).toBe("depleted");
+    expect(mockFetchWorkspaceById).toHaveBeenCalled();
   });
 });

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -20,6 +20,8 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
+import type { WorkspacePoolCreditState } from "@app/types/credits";
+import { isWorkspacePoolCreditState } from "@app/types/credits";
 
 const REDIS_ORIGIN = "metronome_limit" as const;
 const BLOCKED_FLAG = "1";
@@ -33,11 +35,15 @@ function buildWorkspacePoolDepletedKey(workspaceId: string): string {
   return `metronome:pool_depleted:${workspaceId}`;
 }
 
+function buildWorkspaceCreditPoolStatusKey(workspaceId: string): string {
+  return `metronome:pool_credit_status:${workspaceId}`;
+}
+
 function isBlockFlag(value: string | null): value is "0" | "1" {
   return value === BLOCKED_FLAG || value === NOT_BLOCKED_FLAG;
 }
 
-async function setFlag(key: string, value: "0" | "1"): Promise<void> {
+async function setFlag(key: string, value: string): Promise<void> {
   await runOnRedis({ origin: REDIS_ORIGIN }, async (client) => {
     await client.set(key, value);
   });
@@ -174,6 +180,48 @@ export async function isUserBlocked(
   });
 
   return state.userCapBlocked || state.workspacePoolDepleted;
+}
+
+// Workspace credit pool status (fine-grained state for UI/notifications).
+
+export async function setWorkspaceCreditPoolStatus(
+  workspaceId: string,
+  status: WorkspacePoolCreditState
+): Promise<void> {
+  await setFlag(buildWorkspaceCreditPoolStatusKey(workspaceId), status);
+}
+
+export async function getWorkspaceCreditPoolStatus(
+  workspaceId: string
+): Promise<WorkspacePoolCreditState> {
+  const cached = await runOnRedis({ origin: REDIS_ORIGIN }, async (client) =>
+    client.get(buildWorkspaceCreditPoolStatusKey(workspaceId))
+  );
+
+  if (cached && isWorkspacePoolCreditState(cached)) {
+    return cached;
+  }
+
+  logger.info(
+    {
+      workspaceId,
+      workspaceCreditPoolStatusCacheHit: false,
+    },
+    "[MetronomeUserBlock] Cache miss during credit pool status check, falling back to DB"
+  );
+
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  if (!workspace) {
+    logger.warn(
+      { workspaceId },
+      "[MetronomeUserBlock] Workspace not found during credit pool status cache read-through fallback"
+    );
+    return "active";
+  }
+
+  const status = workspace.poolCreditState;
+  await setFlag(buildWorkspaceCreditPoolStatusKey(workspaceId), status);
+  return status;
 }
 
 // Workspace-pool-only read for API calls (no per-user cap).

--- a/front/lib/metronome/workspace_credit_state_machine.test.ts
+++ b/front/lib/metronome/workspace_credit_state_machine.test.ts
@@ -267,11 +267,11 @@ describe("WorkspaceCreditStateMachine — transitions", () => {
 // ---------------------------------------------------------------------------
 
 describe("WorkspaceCreditStateMachine — low balance transitions", () => {
-  it("active + low_balance_100 (no PAYG) → active_low_balance", async () => {
+  it("active + low_balance (bal=50, no PAYG) → active_low_balance", async () => {
     const workspace = makeWorkspace("active");
     const result = await transitionWorkspaceCreditState(
       workspace,
-      { type: "low_balance_100" },
+      { type: "low_balance", balanceAwu: 50 },
       baseCtxNoPayg
     );
     expect(result.isOk()).toBe(true);
@@ -289,11 +289,11 @@ describe("WorkspaceCreditStateMachine — low balance transitions", () => {
     );
   });
 
-  it("active + low_balance_100 (PAYG enabled) → active (no-op)", async () => {
+  it("active + low_balance (PAYG enabled) → active (no-op)", async () => {
     const workspace = makeWorkspace("active");
     const result = await transitionWorkspaceCreditState(
       workspace,
-      { type: "low_balance_100" },
+      { type: "low_balance", balanceAwu: 50 },
       baseCtxPayg
     );
     expect(result.isOk()).toBe(true);
@@ -303,11 +303,11 @@ describe("WorkspaceCreditStateMachine — low balance transitions", () => {
     expect(workspace.updatePoolCreditState).not.toHaveBeenCalled();
   });
 
-  it("active + low_balance_10 (no PAYG) → active_critical_balance", async () => {
+  it("active + low_balance (bal=5, no PAYG) → active_critical_balance", async () => {
     const workspace = makeWorkspace("active");
     const result = await transitionWorkspaceCreditState(
       workspace,
-      { type: "low_balance_10" },
+      { type: "low_balance", balanceAwu: 5 },
       baseCtxNoPayg
     );
     expect(result.isOk()).toBe(true);
@@ -324,25 +324,11 @@ describe("WorkspaceCreditStateMachine — low balance transitions", () => {
     );
   });
 
-  it("active + low_balance_10 (PAYG enabled) → active (no-op)", async () => {
-    const workspace = makeWorkspace("active");
-    const result = await transitionWorkspaceCreditState(
-      workspace,
-      { type: "low_balance_10" },
-      baseCtxPayg
-    );
-    expect(result.isOk()).toBe(true);
-    if (result.isOk()) {
-      expect(result.value).toBe("active");
-    }
-    expect(workspace.updatePoolCreditState).not.toHaveBeenCalled();
-  });
-
-  it("active_low_balance + low_balance_10 (no PAYG) → active_critical_balance", async () => {
+  it("active_low_balance + low_balance (bal=5, no PAYG) → active_critical_balance", async () => {
     const workspace = makeWorkspace("active_low_balance");
     const result = await transitionWorkspaceCreditState(
       workspace,
-      { type: "low_balance_10" },
+      { type: "low_balance", balanceAwu: 5 },
       baseCtxNoPayg
     );
     expect(result.isOk()).toBe(true);
@@ -355,11 +341,11 @@ describe("WorkspaceCreditStateMachine — low balance transitions", () => {
     );
   });
 
-  it("active_low_balance + low_balance_10 (PAYG enabled) → active_low_balance (no-op)", async () => {
+  it("active_low_balance + low_balance (PAYG enabled) → active_low_balance (no-op)", async () => {
     const workspace = makeWorkspace("active_low_balance");
     const result = await transitionWorkspaceCreditState(
       workspace,
-      { type: "low_balance_10" },
+      { type: "low_balance", balanceAwu: 5 },
       baseCtxPayg
     );
     expect(result.isOk()).toBe(true);
@@ -369,11 +355,11 @@ describe("WorkspaceCreditStateMachine — low balance transitions", () => {
     expect(workspace.updatePoolCreditState).not.toHaveBeenCalled();
   });
 
-  it("active_low_balance + low_balance_100 is idempotent", async () => {
+  it("active_low_balance + low_balance (bal=50) is idempotent", async () => {
     const workspace = makeWorkspace("active_low_balance");
     const result = await transitionWorkspaceCreditState(
       workspace,
-      { type: "low_balance_100" },
+      { type: "low_balance", balanceAwu: 50 },
       baseCtxNoPayg
     );
     expect(result.isOk()).toBe(true);
@@ -383,25 +369,11 @@ describe("WorkspaceCreditStateMachine — low balance transitions", () => {
     expect(workspace.updatePoolCreditState).not.toHaveBeenCalled();
   });
 
-  it("active_critical_balance + low_balance_10 is idempotent", async () => {
+  it("active_critical_balance + low_balance is idempotent", async () => {
     const workspace = makeWorkspace("active_critical_balance");
     const result = await transitionWorkspaceCreditState(
       workspace,
-      { type: "low_balance_10" },
-      baseCtxNoPayg
-    );
-    expect(result.isOk()).toBe(true);
-    if (result.isOk()) {
-      expect(result.value).toBe("active_critical_balance");
-    }
-    expect(workspace.updatePoolCreditState).not.toHaveBeenCalled();
-  });
-
-  it("active_critical_balance + low_balance_100 stays in active_critical_balance", async () => {
-    const workspace = makeWorkspace("active_critical_balance");
-    const result = await transitionWorkspaceCreditState(
-      workspace,
-      { type: "low_balance_100" },
+      { type: "low_balance", balanceAwu: 5 },
       baseCtxNoPayg
     );
     expect(result.isOk()).toBe(true);

--- a/front/lib/metronome/workspace_credit_state_machine.test.ts
+++ b/front/lib/metronome/workspace_credit_state_machine.test.ts
@@ -15,10 +15,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const {
   mockSetWorkspacePoolDepleted,
   mockClearWorkspacePoolDepleted,
+  mockSetWorkspaceCreditPoolStatus,
   mockInvalidateCacheAfterCommit,
 } = vi.hoisted(() => ({
   mockSetWorkspacePoolDepleted: vi.fn(),
   mockClearWorkspacePoolDepleted: vi.fn(),
+  mockSetWorkspaceCreditPoolStatus: vi.fn(),
   mockInvalidateCacheAfterCommit: vi.fn(
     (_tx: Transaction | undefined, fn: () => Promise<void>) => {
       void fn();
@@ -29,6 +31,7 @@ const {
 vi.mock("@app/lib/metronome/user_block", () => ({
   setWorkspacePoolDepleted: mockSetWorkspacePoolDepleted,
   clearWorkspacePoolDepleted: mockClearWorkspacePoolDepleted,
+  setWorkspaceCreditPoolStatus: mockSetWorkspaceCreditPoolStatus,
 }));
 
 vi.mock("@app/lib/utils/cache", () => ({
@@ -127,11 +130,11 @@ describe("WorkspaceCreditStateMachine — transitions", () => {
     expect(mockSetWorkspacePoolDepleted).toHaveBeenCalledWith("ws_test");
   });
 
-  it("overage + credits_added → active (clears depleted cache)", async () => {
+  it("overage + credits_added (high balance) → active (clears depleted cache)", async () => {
     const workspace = makeWorkspace("overage");
     const result = await transitionWorkspaceCreditState(
       workspace,
-      { type: "credits_added" },
+      { type: "credits_added", balance: 500 },
       baseCtxPayg
     );
     expect(result.isOk()).toBe(true);
@@ -141,11 +144,11 @@ describe("WorkspaceCreditStateMachine — transitions", () => {
     expect(mockClearWorkspacePoolDepleted).toHaveBeenCalledWith("ws_test");
   });
 
-  it("depleted + credits_added → active (clears depleted flag)", async () => {
+  it("depleted + credits_added (high balance) → active (clears depleted flag)", async () => {
     const workspace = makeWorkspace("depleted");
     const result = await transitionWorkspaceCreditState(
       workspace,
-      { type: "credits_added" },
+      { type: "credits_added", balance: 500 },
       baseCtxNoPayg
     );
     expect(result.isOk()).toBe(true);
@@ -256,6 +259,351 @@ describe("WorkspaceCreditStateMachine — transitions", () => {
       expect(result.value).toBe(from);
     }
     expect(workspace.updatePoolCreditState).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Low balance transitions
+// ---------------------------------------------------------------------------
+
+describe("WorkspaceCreditStateMachine — low balance transitions", () => {
+  it("active + low_balance_100 (no PAYG) → active_low_balance", async () => {
+    const workspace = makeWorkspace("active");
+    const result = await transitionWorkspaceCreditState(
+      workspace,
+      { type: "low_balance_100" },
+      baseCtxNoPayg
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("active_low_balance");
+    }
+    expect(workspace.updatePoolCreditState).toHaveBeenCalledWith(
+      "active_low_balance",
+      undefined
+    );
+    expect(mockClearWorkspacePoolDepleted).toHaveBeenCalledWith("ws_test");
+    expect(mockSetWorkspaceCreditPoolStatus).toHaveBeenCalledWith(
+      "ws_test",
+      "active_low_balance"
+    );
+  });
+
+  it("active + low_balance_100 (PAYG enabled) → active (no-op)", async () => {
+    const workspace = makeWorkspace("active");
+    const result = await transitionWorkspaceCreditState(
+      workspace,
+      { type: "low_balance_100" },
+      baseCtxPayg
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("active");
+    }
+    expect(workspace.updatePoolCreditState).not.toHaveBeenCalled();
+  });
+
+  it("active + low_balance_10 (no PAYG) → active_critical_balance", async () => {
+    const workspace = makeWorkspace("active");
+    const result = await transitionWorkspaceCreditState(
+      workspace,
+      { type: "low_balance_10" },
+      baseCtxNoPayg
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("active_critical_balance");
+    }
+    expect(workspace.updatePoolCreditState).toHaveBeenCalledWith(
+      "active_critical_balance",
+      undefined
+    );
+    expect(mockSetWorkspaceCreditPoolStatus).toHaveBeenCalledWith(
+      "ws_test",
+      "active_critical_balance"
+    );
+  });
+
+  it("active + low_balance_10 (PAYG enabled) → active (no-op)", async () => {
+    const workspace = makeWorkspace("active");
+    const result = await transitionWorkspaceCreditState(
+      workspace,
+      { type: "low_balance_10" },
+      baseCtxPayg
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("active");
+    }
+    expect(workspace.updatePoolCreditState).not.toHaveBeenCalled();
+  });
+
+  it("active_low_balance + low_balance_10 (no PAYG) → active_critical_balance", async () => {
+    const workspace = makeWorkspace("active_low_balance");
+    const result = await transitionWorkspaceCreditState(
+      workspace,
+      { type: "low_balance_10" },
+      baseCtxNoPayg
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("active_critical_balance");
+    }
+    expect(workspace.updatePoolCreditState).toHaveBeenCalledWith(
+      "active_critical_balance",
+      undefined
+    );
+  });
+
+  it("active_low_balance + low_balance_10 (PAYG enabled) → active_low_balance (no-op)", async () => {
+    const workspace = makeWorkspace("active_low_balance");
+    const result = await transitionWorkspaceCreditState(
+      workspace,
+      { type: "low_balance_10" },
+      baseCtxPayg
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("active_low_balance");
+    }
+    expect(workspace.updatePoolCreditState).not.toHaveBeenCalled();
+  });
+
+  it("active_low_balance + low_balance_100 is idempotent", async () => {
+    const workspace = makeWorkspace("active_low_balance");
+    const result = await transitionWorkspaceCreditState(
+      workspace,
+      { type: "low_balance_100" },
+      baseCtxNoPayg
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("active_low_balance");
+    }
+    expect(workspace.updatePoolCreditState).not.toHaveBeenCalled();
+  });
+
+  it("active_critical_balance + low_balance_10 is idempotent", async () => {
+    const workspace = makeWorkspace("active_critical_balance");
+    const result = await transitionWorkspaceCreditState(
+      workspace,
+      { type: "low_balance_10" },
+      baseCtxNoPayg
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("active_critical_balance");
+    }
+    expect(workspace.updatePoolCreditState).not.toHaveBeenCalled();
+  });
+
+  it("active_critical_balance + low_balance_100 stays in active_critical_balance", async () => {
+    const workspace = makeWorkspace("active_critical_balance");
+    const result = await transitionWorkspaceCreditState(
+      workspace,
+      { type: "low_balance_100" },
+      baseCtxNoPayg
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("active_critical_balance");
+    }
+    expect(workspace.updatePoolCreditState).not.toHaveBeenCalled();
+  });
+
+  it("active_low_balance + pool_exhausted (no PAYG) → depleted", async () => {
+    const workspace = makeWorkspace("active_low_balance");
+    const result = await transitionWorkspaceCreditState(
+      workspace,
+      { type: "pool_exhausted" },
+      baseCtxNoPayg
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("depleted");
+    }
+    expect(mockSetWorkspacePoolDepleted).toHaveBeenCalledWith("ws_test");
+  });
+
+  it("active_low_balance + pool_exhausted (PAYG) → overage", async () => {
+    const workspace = makeWorkspace("active_low_balance");
+    const result = await transitionWorkspaceCreditState(
+      workspace,
+      { type: "pool_exhausted" },
+      baseCtxPayg
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("overage");
+    }
+    expect(mockClearWorkspacePoolDepleted).toHaveBeenCalledWith("ws_test");
+  });
+
+  it("active_critical_balance + pool_exhausted (no PAYG) → depleted", async () => {
+    const workspace = makeWorkspace("active_critical_balance");
+    const result = await transitionWorkspaceCreditState(
+      workspace,
+      { type: "pool_exhausted" },
+      baseCtxNoPayg
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("depleted");
+    }
+    expect(mockSetWorkspacePoolDepleted).toHaveBeenCalledWith("ws_test");
+  });
+
+  it("active_critical_balance + pool_exhausted (PAYG) → overage", async () => {
+    const workspace = makeWorkspace("active_critical_balance");
+    const result = await transitionWorkspaceCreditState(
+      workspace,
+      { type: "pool_exhausted" },
+      baseCtxPayg
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("overage");
+    }
+    expect(mockClearWorkspacePoolDepleted).toHaveBeenCalledWith("ws_test");
+  });
+
+  it("active_low_balance + credits_added (high balance) → active", async () => {
+    const workspace = makeWorkspace("active_low_balance");
+    const result = await transitionWorkspaceCreditState(
+      workspace,
+      { type: "credits_added", balance: 500 },
+      baseCtxNoPayg
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("active");
+    }
+    expect(workspace.updatePoolCreditState).toHaveBeenCalledWith(
+      "active",
+      undefined
+    );
+  });
+
+  it("active_critical_balance + credits_added (high balance) → active", async () => {
+    const workspace = makeWorkspace("active_critical_balance");
+    const result = await transitionWorkspaceCreditState(
+      workspace,
+      { type: "credits_added", balance: 500 },
+      baseCtxNoPayg
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("active");
+    }
+    expect(workspace.updatePoolCreditState).toHaveBeenCalledWith(
+      "active",
+      undefined
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Balance-based routing for credits_added
+// ---------------------------------------------------------------------------
+
+describe("WorkspaceCreditStateMachine — credits_added balance routing", () => {
+  it("depleted + credits_added (balance=50) → active_low_balance", async () => {
+    const workspace = makeWorkspace("depleted");
+    const result = await transitionWorkspaceCreditState(
+      workspace,
+      { type: "credits_added", balance: 50 },
+      baseCtxNoPayg
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("active_low_balance");
+    }
+    expect(workspace.updatePoolCreditState).toHaveBeenCalledWith(
+      "active_low_balance",
+      undefined
+    );
+  });
+
+  it("depleted + credits_added (balance=5) → active_critical_balance", async () => {
+    const workspace = makeWorkspace("depleted");
+    const result = await transitionWorkspaceCreditState(
+      workspace,
+      { type: "credits_added", balance: 5 },
+      baseCtxNoPayg
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("active_critical_balance");
+    }
+    expect(workspace.updatePoolCreditState).toHaveBeenCalledWith(
+      "active_critical_balance",
+      undefined
+    );
+  });
+
+  it("depleted + credits_added (balance=100) → active_low_balance (boundary)", async () => {
+    const workspace = makeWorkspace("depleted");
+    const result = await transitionWorkspaceCreditState(
+      workspace,
+      { type: "credits_added", balance: 100 },
+      baseCtxNoPayg
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("active_low_balance");
+    }
+  });
+
+  it("depleted + credits_added (balance=10) → active_critical_balance (boundary)", async () => {
+    const workspace = makeWorkspace("depleted");
+    const result = await transitionWorkspaceCreditState(
+      workspace,
+      { type: "credits_added", balance: 10 },
+      baseCtxNoPayg
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("active_critical_balance");
+    }
+  });
+
+  it("depleted + credits_added (balance=101) → active", async () => {
+    const workspace = makeWorkspace("depleted");
+    const result = await transitionWorkspaceCreditState(
+      workspace,
+      { type: "credits_added", balance: 101 },
+      baseCtxNoPayg
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("active");
+    }
+  });
+
+  it("overage + credits_added (balance=50) → active_low_balance", async () => {
+    const workspace = makeWorkspace("overage");
+    const result = await transitionWorkspaceCreditState(
+      workspace,
+      { type: "credits_added", balance: 50 },
+      baseCtxPayg
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("active_low_balance");
+    }
+  });
+
+  it("active_critical_balance + credits_added (balance=50) → active_low_balance", async () => {
+    const workspace = makeWorkspace("active_critical_balance");
+    const result = await transitionWorkspaceCreditState(
+      workspace,
+      { type: "credits_added", balance: 50 },
+      baseCtxNoPayg
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("active_low_balance");
+    }
   });
 });
 

--- a/front/lib/metronome/workspace_credit_state_machine.test.ts
+++ b/front/lib/metronome/workspace_credit_state_machine.test.ts
@@ -134,7 +134,7 @@ describe("WorkspaceCreditStateMachine — transitions", () => {
     const workspace = makeWorkspace("overage");
     const result = await transitionWorkspaceCreditState(
       workspace,
-      { type: "credits_added", balance: 500 },
+      { type: "credits_added", balanceAwu: 500 },
       baseCtxPayg
     );
     expect(result.isOk()).toBe(true);
@@ -148,7 +148,7 @@ describe("WorkspaceCreditStateMachine — transitions", () => {
     const workspace = makeWorkspace("depleted");
     const result = await transitionWorkspaceCreditState(
       workspace,
-      { type: "credits_added", balance: 500 },
+      { type: "credits_added", balanceAwu: 500 },
       baseCtxNoPayg
     );
     expect(result.isOk()).toBe(true);
@@ -471,7 +471,7 @@ describe("WorkspaceCreditStateMachine — low balance transitions", () => {
     const workspace = makeWorkspace("active_low_balance");
     const result = await transitionWorkspaceCreditState(
       workspace,
-      { type: "credits_added", balance: 500 },
+      { type: "credits_added", balanceAwu: 500 },
       baseCtxNoPayg
     );
     expect(result.isOk()).toBe(true);
@@ -488,7 +488,7 @@ describe("WorkspaceCreditStateMachine — low balance transitions", () => {
     const workspace = makeWorkspace("active_critical_balance");
     const result = await transitionWorkspaceCreditState(
       workspace,
-      { type: "credits_added", balance: 500 },
+      { type: "credits_added", balanceAwu: 500 },
       baseCtxNoPayg
     );
     expect(result.isOk()).toBe(true);
@@ -511,7 +511,7 @@ describe("WorkspaceCreditStateMachine — credits_added balance routing", () => 
     const workspace = makeWorkspace("depleted");
     const result = await transitionWorkspaceCreditState(
       workspace,
-      { type: "credits_added", balance: 50 },
+      { type: "credits_added", balanceAwu: 50 },
       baseCtxNoPayg
     );
     expect(result.isOk()).toBe(true);
@@ -528,7 +528,7 @@ describe("WorkspaceCreditStateMachine — credits_added balance routing", () => 
     const workspace = makeWorkspace("depleted");
     const result = await transitionWorkspaceCreditState(
       workspace,
-      { type: "credits_added", balance: 5 },
+      { type: "credits_added", balanceAwu: 5 },
       baseCtxNoPayg
     );
     expect(result.isOk()).toBe(true);
@@ -545,7 +545,7 @@ describe("WorkspaceCreditStateMachine — credits_added balance routing", () => 
     const workspace = makeWorkspace("depleted");
     const result = await transitionWorkspaceCreditState(
       workspace,
-      { type: "credits_added", balance: 100 },
+      { type: "credits_added", balanceAwu: 100 },
       baseCtxNoPayg
     );
     expect(result.isOk()).toBe(true);
@@ -558,7 +558,7 @@ describe("WorkspaceCreditStateMachine — credits_added balance routing", () => 
     const workspace = makeWorkspace("depleted");
     const result = await transitionWorkspaceCreditState(
       workspace,
-      { type: "credits_added", balance: 10 },
+      { type: "credits_added", balanceAwu: 10 },
       baseCtxNoPayg
     );
     expect(result.isOk()).toBe(true);
@@ -571,7 +571,7 @@ describe("WorkspaceCreditStateMachine — credits_added balance routing", () => 
     const workspace = makeWorkspace("depleted");
     const result = await transitionWorkspaceCreditState(
       workspace,
-      { type: "credits_added", balance: 101 },
+      { type: "credits_added", balanceAwu: 101 },
       baseCtxNoPayg
     );
     expect(result.isOk()).toBe(true);
@@ -584,7 +584,7 @@ describe("WorkspaceCreditStateMachine — credits_added balance routing", () => 
     const workspace = makeWorkspace("overage");
     const result = await transitionWorkspaceCreditState(
       workspace,
-      { type: "credits_added", balance: 50 },
+      { type: "credits_added", balanceAwu: 50 },
       baseCtxPayg
     );
     expect(result.isOk()).toBe(true);
@@ -597,7 +597,7 @@ describe("WorkspaceCreditStateMachine — credits_added balance routing", () => 
     const workspace = makeWorkspace("active_critical_balance");
     const result = await transitionWorkspaceCreditState(
       workspace,
-      { type: "credits_added", balance: 50 },
+      { type: "credits_added", balanceAwu: 50 },
       baseCtxNoPayg
     );
     expect(result.isOk()).toBe(true);

--- a/front/lib/metronome/workspace_credit_state_machine.ts
+++ b/front/lib/metronome/workspace_credit_state_machine.ts
@@ -43,10 +43,8 @@ export type WorkspaceCreditEvent =
    * unaffected.
    */
   | { type: "payg_enabled" }
-  /** Pool balance dropped to ≤100 credits remaining. */
-  | { type: "low_balance_100" }
-  /** Pool balance dropped to ≤10 credits remaining. */
-  | { type: "low_balance_10" };
+  /** Pool balance dropped below a warning threshold. */
+  | { type: "low_balance"; balanceAwu: number };
 
 // Thresholds for low-balance state routing (in AWU credits).
 const LOW_BALANCE_THRESHOLD_AWU = 100;
@@ -64,11 +62,9 @@ type WorkspaceCreditTransition = {
   to: WorkspacePoolCreditState;
 };
 
-function balanceAtMost(
-  threshold: number
-): WorkspaceCreditGuard {
+function balanceAtMost(threshold: number): WorkspaceCreditGuard {
   return (_ctx, event) =>
-    event.type === "credits_added" && event.balanceAwu <= threshold;
+    "balanceAwu" in event && event.balanceAwu <= threshold;
 }
 
 function syncWorkspacePoolCacheForState(
@@ -175,7 +171,29 @@ const TRANSITIONS: WorkspaceCreditTransition[] = [
     to: "depleted",
   },
 
+  // Low balance alerts. No throttling when PAYG is enabled.
+  // Order matters: first match wins, so critical < low < no-op.
+  {
+    from: ["active", "active_low_balance"],
+    event: "low_balance",
+    guard: (ctx, event) =>
+      !ctx.paygEnabled &&
+      balanceAtMost(CRITICAL_BALANCE_THRESHOLD_AWU)(ctx, event),
+    to: "active_critical_balance",
+  },
+
   // active -> ...
+  {
+    from: "active",
+    event: "low_balance", // critical balance already matched
+    guard: (ctx) => !ctx.paygEnabled,
+    to: "active_low_balance",
+  },
+  {
+    from: "active",
+    event: "low_balance",
+    to: "active",
+  },
   {
     from: "active",
     event: "payg_enabled",
@@ -186,50 +204,11 @@ const TRANSITIONS: WorkspaceCreditTransition[] = [
     event: "payg_disabled",
     to: "active",
   },
-  // No throttling due to low balance when PAYG is enabled.
-  {
-    from: "active",
-    event: "low_balance_100",
-    guard: (ctx) => !ctx.paygEnabled,
-    to: "active_low_balance",
-  },
-  {
-    from: "active",
-    event: "low_balance_100",
-    guard: (ctx) => ctx.paygEnabled,
-    to: "active",
-  },
-  // If the 10-credit alert fires before the 100-credit one (race), jump
-  // directly to active_critical_balance.
-  {
-    from: "active",
-    event: "low_balance_10",
-    guard: (ctx) => !ctx.paygEnabled,
-    to: "active_critical_balance",
-  },
-  {
-    from: "active",
-    event: "low_balance_10",
-    guard: (ctx) => ctx.paygEnabled,
-    to: "active",
-  },
 
   // active_low_balance -> ...
   {
     from: "active_low_balance",
-    event: "low_balance_100",
-    to: "active_low_balance",
-  },
-  {
-    from: "active_low_balance",
-    event: "low_balance_10",
-    guard: (ctx) => !ctx.paygEnabled,
-    to: "active_critical_balance",
-  },
-  {
-    from: "active_low_balance",
-    event: "low_balance_10",
-    guard: (ctx) => ctx.paygEnabled, // should not happen
+    event: "low_balance", // critical balance already matched before
     to: "active_low_balance",
   },
   {
@@ -246,12 +225,7 @@ const TRANSITIONS: WorkspaceCreditTransition[] = [
   // active_critical_balance -> ...
   {
     from: "active_critical_balance",
-    event: "low_balance_10", // should not happen
-    to: "active_critical_balance",
-  },
-  {
-    from: "active_critical_balance",
-    event: "low_balance_100", // should not happen
+    event: "low_balance",
     to: "active_critical_balance",
   },
   {

--- a/front/lib/metronome/workspace_credit_state_machine.ts
+++ b/front/lib/metronome/workspace_credit_state_machine.ts
@@ -48,42 +48,27 @@ export type WorkspaceCreditEvent =
   /** Pool balance dropped to ≤10 credits remaining. */
   | { type: "low_balance_10" };
 
-// Thresholds for low-balance state routing (in credits).
-const LOW_BALANCE_THRESHOLD = 100;
-const CRITICAL_BALANCE_THRESHOLD = 10;
+// Thresholds for low-balance state routing (in AWU credits).
+const LOW_BALANCE_THRESHOLD_AWU = 100;
+const CRITICAL_BALANCE_THRESHOLD_AWU = 10;
+
+type WorkspaceCreditGuard = (
+  ctx: WorkspaceCreditContext,
+  event: WorkspaceCreditEvent
+) => boolean;
 
 type WorkspaceCreditTransition = {
   from: WorkspacePoolCreditState | WorkspacePoolCreditState[];
   event: WorkspaceCreditEvent["type"];
-  guard?: (ctx: WorkspaceCreditContext) => boolean;
-  to:
-    | WorkspacePoolCreditState
-    | ((event: WorkspaceCreditEvent) => WorkspacePoolCreditState);
+  guard?: WorkspaceCreditGuard;
+  to: WorkspacePoolCreditState;
 };
 
-function resolveTargetState(
-  to: WorkspaceCreditTransition["to"],
-  event: WorkspaceCreditEvent
-): WorkspacePoolCreditState {
-  return typeof to === "function" ? to(event) : to;
-}
-
-function activeStateForBalance(
-  event: WorkspaceCreditEvent
-): WorkspacePoolCreditState {
-  // Only valid for credits_added events, enforced by transition table
-  if (event.type !== "credits_added") {
-    throw new Error(
-      `[WorkspaceCreditStateMachine] activeStateForBalance called with unexpected event: ${event.type}`
-    );
-  }
-  if (event.balanceAwu <= CRITICAL_BALANCE_THRESHOLD) {
-    return "active_critical_balance";
-  }
-  if (event.balanceAwu <= LOW_BALANCE_THRESHOLD) {
-    return "active_low_balance";
-  }
-  return "active";
+function balanceAtMost(
+  threshold: number
+): WorkspaceCreditGuard {
+  return (_ctx, event) =>
+    event.type === "credits_added" && event.balanceAwu <= threshold;
 }
 
 function syncWorkspacePoolCacheForState(
@@ -130,7 +115,8 @@ const TRANSITIONS: WorkspaceCreditTransition[] = [
   // Common transitions
 
   // A new commit segment starting (admin top-up or billing-cycle renewal of
-  // the recurring pool commit) always set the state back to active (with potential low balance)
+  // the recurring pool commit) always set the state back to active (with potential low balance).
+  // Order matters: first match wins, so critical < low < default.
   {
     from: [
       "active",
@@ -140,7 +126,31 @@ const TRANSITIONS: WorkspaceCreditTransition[] = [
       "overage",
     ],
     event: "credits_added",
-    to: activeStateForBalance,
+    guard: balanceAtMost(CRITICAL_BALANCE_THRESHOLD_AWU),
+    to: "active_critical_balance",
+  },
+  {
+    from: [
+      "active",
+      "active_low_balance",
+      "active_critical_balance",
+      "depleted",
+      "overage",
+    ],
+    event: "credits_added",
+    guard: balanceAtMost(LOW_BALANCE_THRESHOLD_AWU),
+    to: "active_low_balance",
+  },
+  {
+    from: [
+      "active",
+      "active_low_balance",
+      "active_critical_balance",
+      "depleted",
+      "overage",
+    ],
+    event: "credits_added",
+    to: "active",
   },
   {
     from: [
@@ -299,7 +309,9 @@ function findTransition(
     const fromMatch = Array.isArray(t.from)
       ? t.from.includes(current)
       : t.from === current;
-    return fromMatch && t.event === event.type && (!t.guard || t.guard(ctx));
+    return (
+      fromMatch && t.event === event.type && (!t.guard || t.guard(ctx, event))
+    );
   });
 }
 
@@ -328,22 +340,20 @@ export async function transitionWorkspaceCreditState(
     );
   }
 
-  const targetState = resolveTargetState(match.to, event);
-
-  if (currentState !== targetState) {
-    await workspace.updatePoolCreditState(targetState, transaction);
+  if (currentState !== match.to) {
+    await workspace.updatePoolCreditState(match.to, transaction);
   }
-  syncWorkspacePoolCacheForState(targetState, ctx, transaction);
+  syncWorkspacePoolCacheForState(match.to, ctx, transaction);
   logger.info(
     {
       workspaceId: ctx.workspaceId,
       fromState: currentState,
-      toState: targetState,
+      toState: match.to,
       eventType: event.type,
-      wasStateChanged: currentState !== targetState,
+      wasStateChanged: currentState !== match.to,
     },
     "[WorkspaceCreditStateMachine] Transition applied"
   );
 
-  return new Ok(targetState);
+  return new Ok(match.to);
 }

--- a/front/lib/metronome/workspace_credit_state_machine.ts
+++ b/front/lib/metronome/workspace_credit_state_machine.ts
@@ -28,7 +28,7 @@ export type WorkspaceCreditEvent =
    * machine's point of view these are indistinguishable and both bring the
    * pool back online.
    */
-  | { type: "credits_added"; balance: number }
+  | { type: "credits_added"; balanceAwu: number }
   /**
    * PAYG was turned off by an operator. Workspaces in `overage` were
    * surviving on PAYG: with PAYG gone they have nothing left to spend, so
@@ -77,10 +77,10 @@ function activeStateForBalance(
       `[WorkspaceCreditStateMachine] activeStateForBalance called with unexpected event: ${event.type}`
     );
   }
-  if (event.balance <= CRITICAL_BALANCE_THRESHOLD) {
+  if (event.balanceAwu <= CRITICAL_BALANCE_THRESHOLD) {
     return "active_critical_balance";
   }
-  if (event.balance <= LOW_BALANCE_THRESHOLD) {
+  if (event.balanceAwu <= LOW_BALANCE_THRESHOLD) {
     return "active_low_balance";
   }
   return "active";

--- a/front/lib/metronome/workspace_credit_state_machine.ts
+++ b/front/lib/metronome/workspace_credit_state_machine.ts
@@ -1,5 +1,6 @@
 import {
   clearWorkspacePoolDepleted,
+  setWorkspaceCreditPoolStatus,
   setWorkspacePoolDepleted,
 } from "@app/lib/metronome/user_block";
 import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -27,7 +28,7 @@ export type WorkspaceCreditEvent =
    * machine's point of view these are indistinguishable and both bring the
    * pool back online.
    */
-  | { type: "credits_added" }
+  | { type: "credits_added"; balance: number }
   /**
    * PAYG was turned off by an operator. Workspaces in `overage` were
    * surviving on PAYG: with PAYG gone they have nothing left to spend, so
@@ -41,14 +42,49 @@ export type WorkspaceCreditEvent =
    * so they move to `overage`. `active` and `overage` workspaces are
    * unaffected.
    */
-  | { type: "payg_enabled" };
+  | { type: "payg_enabled" }
+  /** Pool balance dropped to ≤100 credits remaining. */
+  | { type: "low_balance_100" }
+  /** Pool balance dropped to ≤10 credits remaining. */
+  | { type: "low_balance_10" };
+
+// Thresholds for low-balance state routing (in credits).
+const LOW_BALANCE_THRESHOLD = 100;
+const CRITICAL_BALANCE_THRESHOLD = 10;
 
 type WorkspaceCreditTransition = {
   from: WorkspacePoolCreditState | WorkspacePoolCreditState[];
   event: WorkspaceCreditEvent["type"];
   guard?: (ctx: WorkspaceCreditContext) => boolean;
-  to: WorkspacePoolCreditState;
+  to:
+    | WorkspacePoolCreditState
+    | ((event: WorkspaceCreditEvent) => WorkspacePoolCreditState);
 };
+
+function resolveTargetState(
+  to: WorkspaceCreditTransition["to"],
+  event: WorkspaceCreditEvent
+): WorkspacePoolCreditState {
+  return typeof to === "function" ? to(event) : to;
+}
+
+function activeStateForBalance(
+  event: WorkspaceCreditEvent
+): WorkspacePoolCreditState {
+  // Only valid for credits_added events, enforced by transition table
+  if (event.type !== "credits_added") {
+    throw new Error(
+      `[WorkspaceCreditStateMachine] activeStateForBalance called with unexpected event: ${event.type}`
+    );
+  }
+  if (event.balance <= CRITICAL_BALANCE_THRESHOLD) {
+    return "active_critical_balance";
+  }
+  if (event.balance <= LOW_BALANCE_THRESHOLD) {
+    return "active_low_balance";
+  }
+  return "active";
+}
 
 function syncWorkspacePoolCacheForState(
   state: WorkspacePoolCreditState,
@@ -61,11 +97,27 @@ function syncWorkspacePoolCacheForState(
       invalidateCacheAfterCommit(transaction, () =>
         clearWorkspacePoolDepleted(ctx.workspaceId)
       );
+      invalidateCacheAfterCommit(transaction, () =>
+        setWorkspaceCreditPoolStatus(ctx.workspaceId, state)
+      );
+      return;
+
+    case "active_low_balance":
+    case "active_critical_balance":
+      invalidateCacheAfterCommit(transaction, () =>
+        clearWorkspacePoolDepleted(ctx.workspaceId)
+      );
+      invalidateCacheAfterCommit(transaction, () =>
+        setWorkspaceCreditPoolStatus(ctx.workspaceId, state)
+      );
       return;
 
     case "depleted":
       invalidateCacheAfterCommit(transaction, () =>
         setWorkspacePoolDepleted(ctx.workspaceId)
+      );
+      invalidateCacheAfterCommit(transaction, () =>
+        setWorkspaceCreditPoolStatus(ctx.workspaceId, state)
       );
       return;
 
@@ -75,24 +127,45 @@ function syncWorkspacePoolCacheForState(
 }
 
 const TRANSITIONS: WorkspaceCreditTransition[] = [
-  // active -> ...
+  // Common transitions
+
+  // A new commit segment starting (admin top-up or billing-cycle renewal of
+  // the recurring pool commit) always set the state back to active (with potential low balance)
   {
-    from: "active",
+    from: [
+      "active",
+      "active_low_balance",
+      "active_critical_balance",
+      "depleted",
+      "overage",
+    ],
+    event: "credits_added",
+    to: activeStateForBalance,
+  },
+  {
+    from: [
+      "active",
+      "active_low_balance",
+      "active_critical_balance",
+      "overage",
+    ],
     event: "pool_exhausted",
     guard: (ctx) => ctx.paygEnabled,
     to: "overage",
   },
   {
-    from: "active",
+    from: [
+      "active",
+      "active_low_balance",
+      "active_critical_balance",
+      "depleted",
+    ],
     event: "pool_exhausted",
     guard: (ctx) => !ctx.paygEnabled,
     to: "depleted",
   },
-  {
-    from: "active",
-    event: "credits_added",
-    to: "active",
-  },
+
+  // active -> ...
   {
     from: "active",
     event: "payg_enabled",
@@ -103,26 +176,90 @@ const TRANSITIONS: WorkspaceCreditTransition[] = [
     event: "payg_disabled",
     to: "active",
   },
+  // No throttling due to low balance when PAYG is enabled.
+  {
+    from: "active",
+    event: "low_balance_100",
+    guard: (ctx) => !ctx.paygEnabled,
+    to: "active_low_balance",
+  },
+  {
+    from: "active",
+    event: "low_balance_100",
+    guard: (ctx) => ctx.paygEnabled,
+    to: "active",
+  },
+  // If the 10-credit alert fires before the 100-credit one (race), jump
+  // directly to active_critical_balance.
+  {
+    from: "active",
+    event: "low_balance_10",
+    guard: (ctx) => !ctx.paygEnabled,
+    to: "active_critical_balance",
+  },
+  {
+    from: "active",
+    event: "low_balance_10",
+    guard: (ctx) => ctx.paygEnabled,
+    to: "active",
+  },
+
+  // active_low_balance -> ...
+  {
+    from: "active_low_balance",
+    event: "low_balance_100",
+    to: "active_low_balance",
+  },
+  {
+    from: "active_low_balance",
+    event: "low_balance_10",
+    guard: (ctx) => !ctx.paygEnabled,
+    to: "active_critical_balance",
+  },
+  {
+    from: "active_low_balance",
+    event: "low_balance_10",
+    guard: (ctx) => ctx.paygEnabled, // should not happen
+    to: "active_low_balance",
+  },
+  {
+    from: "active_low_balance",
+    event: "payg_enabled",
+    to: "active",
+  },
+  {
+    from: "active_low_balance",
+    event: "payg_disabled",
+    to: "active_low_balance",
+  },
+
+  // active_critical_balance -> ...
+  {
+    from: "active_critical_balance",
+    event: "low_balance_10", // should not happen
+    to: "active_critical_balance",
+  },
+  {
+    from: "active_critical_balance",
+    event: "low_balance_100", // should not happen
+    to: "active_critical_balance",
+  },
+  {
+    from: "active_critical_balance",
+    event: "payg_enabled",
+    to: "active",
+  },
+  {
+    from: "active_critical_balance",
+    event: "payg_disabled",
+    to: "active_critical_balance",
+  },
 
   // overage -> ...
   {
     from: "overage",
-    event: "pool_exhausted",
-    guard: (ctx) => ctx.paygEnabled,
-    to: "overage",
-  },
-  {
-    from: "overage",
     event: "payg_cap_reached",
     to: "depleted",
-  },
-  // A new commit segment starting (admin top-up or billing-cycle renewal of
-  // the recurring pool commit) while in PAYG mode brings the pool back online
-  // no need to keep spending against PAYG
-  {
-    from: "overage",
-    event: "credits_added",
-    to: "active",
   },
   {
     from: "overage",
@@ -138,19 +275,8 @@ const TRANSITIONS: WorkspaceCreditTransition[] = [
   // depleted -> ...
   {
     from: "depleted",
-    event: "pool_exhausted",
-    guard: (ctx) => !ctx.paygEnabled,
-    to: "depleted",
-  },
-  {
-    from: "depleted",
     event: "payg_cap_reached",
     to: "depleted",
-  },
-  {
-    from: "depleted",
-    event: "credits_added",
-    to: "active",
   },
   {
     from: "depleted",
@@ -202,20 +328,22 @@ export async function transitionWorkspaceCreditState(
     );
   }
 
-  if (currentState !== match.to) {
-    await workspace.updatePoolCreditState(match.to, transaction);
+  const targetState = resolveTargetState(match.to, event);
+
+  if (currentState !== targetState) {
+    await workspace.updatePoolCreditState(targetState, transaction);
   }
-  syncWorkspacePoolCacheForState(match.to, ctx, transaction);
+  syncWorkspacePoolCacheForState(targetState, ctx, transaction);
   logger.info(
     {
       workspaceId: ctx.workspaceId,
       fromState: currentState,
-      toState: match.to,
+      toState: targetState,
       eventType: event.type,
-      wasStateChanged: currentState !== match.to,
+      wasStateChanged: currentState !== targetState,
     },
     "[WorkspaceCreditStateMachine] Transition applied"
   );
 
-  return new Ok(match.to);
+  return new Ok(targetState);
 }

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -3156,7 +3156,7 @@ const POOL_CONTRACT_CREDIT_FILTER: NonNullable<
 };
 
 // Default alerts applied to all customers (no `customer_id` set on create):
-// fire when AWU credit / contract-credit / commit balance reaches 0.
+// fire when AWU credit / contract-credit / commit balance reaches thresholds.
 const ALERTS: AlertDef[] = [
   {
     name: "Default: Empty contract credit + commit balance (AWU)",
@@ -3164,6 +3164,24 @@ const ALERTS: AlertDef[] = [
     threshold: 0,
     uniqueness_key:
       "default-low-contract-credit-and-commit-balance-zero-awu-pooled",
+    credit_type: "AWU",
+    custom_field_filters: [POOL_CONTRACT_CREDIT_FILTER],
+  },
+  {
+    name: "Default: Low balance 100 credits (AWU)",
+    alert_type: "low_remaining_contract_credit_and_commit_balance_reached",
+    threshold: 100,
+    uniqueness_key:
+      "default-low-contract-credit-and-commit-balance-100-awu-pooled",
+    credit_type: "AWU",
+    custom_field_filters: [POOL_CONTRACT_CREDIT_FILTER],
+  },
+  {
+    name: "Default: Critical balance 10 credits (AWU)",
+    alert_type: "low_remaining_contract_credit_and_commit_balance_reached",
+    threshold: 10,
+    uniqueness_key:
+      "default-low-contract-credit-and-commit-balance-10-awu-pooled",
     credit_type: "AWU",
     custom_field_filters: [POOL_CONTRACT_CREDIT_FILTER],
   },

--- a/front/types/credits.ts
+++ b/front/types/credits.ts
@@ -4,13 +4,17 @@ import type { EditedByUser } from "@app/types/user";
 // on `workspaces.poolCreditState`, driven by the workspace credit state
 // machine in `front/lib/metronome/workspace_credit_state_machine.ts`;
 //
-//   active:    pool has remaining commit balance
-//   overage:   pool exhausted, workspace is in PAYG mode
-//   depleted:  pool exhausted and PAYG unavailable (or PAYG cap reached);
-//              all users in the workspace blocked until next billing period
-//              or admin pool top-up.
+//   active:                pool has remaining commit balance
+//   active_low_balance:  pool has ≤100 credits remaining (low balance warning)
+//   active_critical_balance:   pool has ≤10 credits remaining (critical low balance)
+//   overage:               pool exhausted, workspace is in PAYG mode
+//   depleted:              pool exhausted and PAYG unavailable (or PAYG cap reached);
+//                          all users in the workspace blocked until next billing period
+//                          or admin pool top-up.
 export const WORKSPACE_POOL_CREDIT_STATES = [
   "active",
+  "active_low_balance",
+  "active_critical_balance",
   "overage",
   "depleted",
 ] as const;


### PR DESCRIPTION
## Description

- Add 2 new limits on metronome:
  - when we reach 100 AWU in the credit pool
  - when we reach 10 AWU in the credit pool
- Add 2 new credit states for the workspace state machine
  - active_low_balance (100-10 credits remaining)
  - active_critical_balance (0-10 credits remaining)
- Dispatching the credit_added event now also dispatch the value to know the state

There are 2 possible implementations here:
 - Add new state in the state machine
 - Add a new "low limit config" with the value.
If we want to keep 2 limits I think the machine is OK, othewise if we plan to have many possible limits we should move to storing the value in another field and correctly update it when we update the state. 

<img width="1760" height="1244" alt="image" src="https://github.com/user-attachments/assets/20dc4f9b-e500-4248-8b51-fafa3bea04c2" />


## Tests

Added state machine unit tests

## Risk

low

## Deploy Plan

deploy front