### PR TITLE
fix(custom-models): avoid sparse array when no models for a provider

### DIFF
--- a/front/scripts/fetch-custom-models.ts
+++ b/front/scripts/fetch-custom-models.ts
@@ -107,19 +107,19 @@ ${modelConstants}
 
 // Cast needed because ModelConfigurationType.modelId is the union type
 export const CUSTOM_MODEL_CONFIGS = [
-${configsArray},
+${configsArray}
 ] as unknown as ModelConfigurationType[];
 
 export const CUSTOM_MODEL_IDS = [
-${idsArray},
+${idsArray}
 ] as const;
 
 export const CUSTOM_OPENAI_MODEL_IDS = [
-${openaiIdsArray},
+${openaiIdsArray}
 ] as const;
 
 export const CUSTOM_ANTHROPIC_MODEL_IDS = [
-${anthropicIdsArray},
+${anthropicIdsArray}
 ] as const;
 `;
 }


### PR DESCRIPTION
## Description

The generated `custom_models.generated.ts` was producing a sparse array when a provider had zero custom models, breaking the front build.

`fetch-custom-models.ts` emitted:

```ts
export const CUSTOM_ANTHROPIC_MODEL_IDS = [
${anthropicIdsArray},
] as const;
```

When `anthropicIdsArray` was empty (e.g. GCS config only had OpenAI models), the template rendered `[\n,\n]`, a sparse array of length 1 whose `as const` type is `readonly [undefined]`. Spreading it into `ANTHROPIC_WHITELISTED_MODEL_IDS` poisoned the union with `undefined`, which then violated the `string | number | symbol` constraint on `Record<AnthropicWhitelistedModelId, ...>` in `lib/api/llm/clients/anthropic/types.ts:48`.

Dropping the trailing comma is enough since `join(",\n")` already separates entries. Applied to all four generated arrays for consistency.

This is what broke deploy run https://github.com/dust-tt/dust/actions/runs/26522133421 (first failure was on commit `0fa240683f`, "Add custom EAP Dust agents" #26248). The committed empty stub uses `[] as const` so it does not repro locally, only in CI where the script regenerates the file from GCS.

## Tests

Mentally re-ran the template with both empty and non-empty arrays. Output is valid TS in both cases (`[\n]` and `[\n  "a",\n  "b"\n]`). Will be confirmed by the next deploy run.

## Risk

Low. Only changes the formatting of the generated file (no trailing comma inside the array literal), which is still valid TypeScript.

## Deploy Plan

Merge, then re-run the failing deploy.