### PR TITLE
[front] chore: batch calls to Temporal in `check_active_workflows_for_connectors` check

### DIFF
--- a/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
+++ b/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
@@ -181,55 +181,60 @@ export const checkActiveWorkflows: CheckFunction = async (
       (connector) => !connector.pausedAt
     );
 
-    if (info.type === "workflow") {
-      const workflowIdsByConnector = activeConnectors.map((connector) => ({
-        connector,
-        workflowIds: info.makeIdsFn(connector),
-      }));
-      const workflowIds = workflowIdsByConnector.flatMap(
-        ({ workflowIds }) => workflowIds
-      );
-      const runningWorkflowIds = await listRunningWorkflowIds(
-        client,
-        workflowIds,
-        logger,
-        heartbeat
-      );
-
-      missingActiveWorkflows = removeNulls(
-        workflowIdsByConnector.map(({ connector, workflowIds }) => {
-          const missingEntities = workflowIds.filter(
-            (workflowId) => !runningWorkflowIds.has(workflowId)
-          );
-
-          return missingEntities.length > 0
-            ? {
-                connectorId: connector.id,
-                workspaceId: connector.workspaceId,
-                dataSourceId: connector.dataSourceId,
-                missingEntities,
-              }
-            : null;
-        })
-      );
-    } else {
-      for (const connector of activeConnectors) {
-        heartbeat();
-
-        const missingEntities = await getMissingTemporalSchedulesActive(
-          client,
+    switch (info.type) {
+      case "workflow": {
+        const workflowIdsByConnector = activeConnectors.map((connector) => ({
           connector,
-          info
+          workflowIds: info.makeIdsFn(connector),
+        }));
+        const workflowIds = workflowIdsByConnector.flatMap(
+          ({ workflowIds }) => workflowIds
+        );
+        const runningWorkflowIds = await listRunningWorkflowIds(
+          client,
+          workflowIds,
+          logger,
+          heartbeat
         );
 
-        if (missingEntities.length > 0) {
-          missingActiveWorkflows.push({
-            connectorId: connector.id,
-            workspaceId: connector.workspaceId,
-            dataSourceId: connector.dataSourceId,
-            missingEntities,
-          });
+        missingActiveWorkflows = removeNulls(
+          workflowIdsByConnector.map(({ connector, workflowIds }) => {
+            const missingEntities = workflowIds.filter(
+              (workflowId) => !runningWorkflowIds.has(workflowId)
+            );
+
+            return missingEntities.length > 0
+              ? {
+                  connectorId: connector.id,
+                  workspaceId: connector.workspaceId,
+                  dataSourceId: connector.dataSourceId,
+                  missingEntities,
+                }
+              : null;
+          })
+        );
+        break;
+      }
+      case "schedule": {
+        for (const connector of activeConnectors) {
+          heartbeat();
+
+          const missingEntities = await getMissingTemporalSchedulesActive(
+            client,
+            connector,
+            info
+          );
+
+          if (missingEntities.length > 0) {
+            missingActiveWorkflows.push({
+              connectorId: connector.id,
+              workspaceId: connector.workspaceId,
+              dataSourceId: connector.dataSourceId,
+              missingEntities,
+            });
+          }
         }
+        break;
       }
     }
 

--- a/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
+++ b/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
@@ -177,7 +177,7 @@ export const checkActiveWorkflows: CheckFunction = async (
 
     const client = await getTemporalClientForConnectorsNamespace();
 
-    const missingActiveWorkflows: MissingActiveWorkflow[] = [];
+    let missingActiveWorkflows: MissingActiveWorkflow[] = [];
 
     const activeConnectors = connectors.filter(
       (connector) => !connector.pausedAt
@@ -198,22 +198,22 @@ export const checkActiveWorkflows: CheckFunction = async (
         heartbeat
       );
 
-      for (const { connector, workflowIds } of workflowIdsByConnector) {
-        heartbeat();
+      missingActiveWorkflows = workflowIdsByConnector.flatMap(
+        ({ connector, workflowIds }): MissingActiveWorkflow[] => {
+          const missingEntities = workflowIds.filter(
+            (workflowId) => !runningWorkflowIds.has(workflowId)
+          );
 
-        const missingEntities = workflowIds.filter(
-          (workflowId) => !runningWorkflowIds.has(workflowId)
-        );
-
-        if (missingEntities.length > 0) {
-          missingActiveWorkflows.push({
-            connectorId: connector.id,
-            workspaceId: connector.workspaceId,
-            dataSourceId: connector.dataSourceId,
-            missingEntities,
-          });
+          return missingEntities.length > 0
+            ? {
+                connectorId: connector.id,
+                workspaceId: connector.workspaceId,
+                dataSourceId: connector.dataSourceId,
+                missingEntities,
+              }
+            : null;
         }
-      }
+      );
     } else {
       for (const connector of activeConnectors) {
         heartbeat();

--- a/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
+++ b/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
@@ -14,14 +14,16 @@ import {
 } from "@app/types/connectors/workflows";
 import type { ConnectorProvider } from "@app/types/data_source";
 import type { ActionLink, CheckFunction } from "@app/types/production_checks";
+import type { ModelId } from "@app/types/shared/model_id";
+import { removeNulls } from "@app/types/shared/utils/general";
 import type { Client, ScheduleHandle } from "@temporalio/client";
 import chunk from "lodash/chunk";
 import { QueryTypes } from "sequelize";
 
-const TEMPORAL_WORKFLOW_LIST_BATCH_SIZE = 100;
+const WORKFLOW_LIST_BATCH_SIZE = 100;
 
 interface ConnectorBlob {
-  id: number;
+  id: ModelId;
   dataSourceId: string;
   workspaceId: string;
   pausedAt: Date | null;
@@ -33,7 +35,7 @@ interface ProviderCheck {
 }
 
 interface MissingActiveWorkflow {
-  connectorId: number;
+  connectorId: ModelId;
   workspaceId: string;
   dataSourceId: string;
   missingEntities: string[];
@@ -111,10 +113,9 @@ async function listRunningWorkflowIds(
 ) {
   const runningWorkflowIds = new Set<string>();
 
-  for (const workflowIdBatch of chunk(
-    workflowIds,
-    TEMPORAL_WORKFLOW_LIST_BATCH_SIZE
-  )) {
+  // Chunking to avoid having a huge IN (id1, id2, ..., idx).
+  const workflowIdBatches = chunk(workflowIds, WORKFLOW_LIST_BATCH_SIZE);
+  for (const workflowIdBatch of workflowIdBatches) {
     heartbeat();
 
     try {
@@ -123,11 +124,8 @@ async function listRunningWorkflowIds(
       })) {
         runningWorkflowIds.add(workflow.workflowId);
       }
-    } catch (err) {
-      logger.error(
-        { err, workflowIds: workflowIdBatch },
-        "Failed to list running Temporal workflows."
-      );
+    } catch (error) {
+      logger.error({ error }, "Failed to list running Temporal workflows.");
     }
   }
 
@@ -198,8 +196,8 @@ export const checkActiveWorkflows: CheckFunction = async (
         heartbeat
       );
 
-      missingActiveWorkflows = workflowIdsByConnector.flatMap(
-        ({ connector, workflowIds }): MissingActiveWorkflow[] => {
+      missingActiveWorkflows = removeNulls(
+        workflowIdsByConnector.map(({ connector, workflowIds }) => {
           const missingEntities = workflowIds.filter(
             (workflowId) => !runningWorkflowIds.has(workflowId)
           );
@@ -212,7 +210,7 @@ export const checkActiveWorkflows: CheckFunction = async (
                 missingEntities,
               }
             : null;
-        }
+        })
       );
     } else {
       for (const connector of activeConnectors) {

--- a/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
+++ b/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
@@ -14,12 +14,11 @@ import {
 } from "@app/types/connectors/workflows";
 import type { ConnectorProvider } from "@app/types/data_source";
 import type { ActionLink, CheckFunction } from "@app/types/production_checks";
-import type {
-  Client,
-  ScheduleHandle,
-  WorkflowHandle,
-} from "@temporalio/client";
+import type { Client, ScheduleHandle } from "@temporalio/client";
+import chunk from "lodash/chunk";
 import { QueryTypes } from "sequelize";
+
+const TEMPORAL_WORKFLOW_LIST_BATCH_SIZE = 100;
 
 interface ConnectorBlob {
   id: number;
@@ -31,6 +30,13 @@ interface ConnectorBlob {
 interface ProviderCheck {
   type: "workflow" | "schedule";
   makeIdsFn: (connector: ConnectorBlob) => string[];
+}
+
+interface MissingActiveWorkflow {
+  connectorId: number;
+  workspaceId: string;
+  dataSourceId: string;
+  missingEntities: string[];
 }
 
 const providersToCheck: Partial<Record<ConnectorProvider, ProviderCheck>> = {
@@ -91,51 +97,64 @@ async function listAllConnectorsForProvider(provider: ConnectorProvider) {
   return connectors;
 }
 
-async function getMissingTemporalEntitiesActive(
+function makeWorkflowIdsListQuery(workflowIds: string[]): string {
+  return `WorkflowId IN (${workflowIds
+    .map((workflowId) => `"${workflowId}"`)
+    .join(",")}) AND ExecutionStatus = "Running"`;
+}
+
+async function listRunningWorkflowIds(
+  client: Client,
+  workflowIds: string[],
+  logger: Parameters<CheckFunction>[1],
+  heartbeat: Parameters<CheckFunction>[4]
+) {
+  const runningWorkflowIds = new Set<string>();
+
+  for (const workflowIdBatch of chunk(
+    workflowIds,
+    TEMPORAL_WORKFLOW_LIST_BATCH_SIZE
+  )) {
+    heartbeat();
+
+    try {
+      for await (const workflow of client.workflow.list({
+        query: makeWorkflowIdsListQuery(workflowIdBatch),
+      })) {
+        runningWorkflowIds.add(workflow.workflowId);
+      }
+    } catch (err) {
+      logger.error(
+        { err, workflowIds: workflowIdBatch },
+        "Failed to list running Temporal workflows."
+      );
+    }
+  }
+
+  return runningWorkflowIds;
+}
+
+async function getMissingTemporalSchedulesActive(
   client: Client,
   connector: ConnectorBlob,
   info: ProviderCheck
 ) {
-  const ids = info.makeIdsFn(connector);
+  const missingEntities: string[] = [];
 
-  const missingEntities = [];
-  switch (info.type) {
-    case "workflow": {
-      for (const workflowId of ids) {
-        try {
-          const workflowHandle: WorkflowHandle =
-            client.workflow.getHandle(workflowId);
+  for (const scheduleId of info.makeIdsFn(connector)) {
+    try {
+      const scheduleHandle: ScheduleHandle =
+        client.schedule.getHandle(scheduleId);
 
-          const descriptions = await Promise.all([workflowHandle.describe()]);
+      const description = await scheduleHandle.describe();
 
-          if (descriptions.some(({ status: { name } }) => name !== "RUNNING")) {
-            missingEntities.push(workflowId);
-          }
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          // biome-ignore lint/correctness/noUnusedVariables: ignored using `--suppress`
-        } catch (err) {
-          missingEntities.push(workflowId);
-        }
+      if (description.state.paused) {
+        missingEntities.push(scheduleId);
       }
-      break;
-    }
-    case "schedule": {
-      for (const scheduleId of ids) {
-        try {
-          const scheduleHandle: ScheduleHandle =
-            client.schedule.getHandle(scheduleId);
-
-          const description = await scheduleHandle.describe();
-
-          if (description.state.paused) {
-            missingEntities.push(scheduleId);
-          }
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          // biome-ignore lint/correctness/noUnusedVariables: ignored using `--suppress`
-        } catch (err) {
-          missingEntities.push(scheduleId);
-        }
-      }
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      // biome-ignore lint/correctness/noUnusedVariables: ignored using `--suppress`
+    } catch (err) {
+      missingEntities.push(scheduleId);
     }
   }
 
@@ -158,26 +177,61 @@ export const checkActiveWorkflows: CheckFunction = async (
 
     const client = await getTemporalClientForConnectorsNamespace();
 
-    const missingActiveWorkflows: any[] = [];
-    for (const connector of connectors) {
-      if (connector.pausedAt) {
-        continue;
-      }
-      heartbeat();
+    const missingActiveWorkflows: MissingActiveWorkflow[] = [];
 
-      const missingEntities = await getMissingTemporalEntitiesActive(
-        client,
+    const activeConnectors = connectors.filter(
+      (connector) => !connector.pausedAt
+    );
+
+    if (info.type === "workflow") {
+      const workflowIdsByConnector = activeConnectors.map((connector) => ({
         connector,
-        info
+        workflowIds: info.makeIdsFn(connector),
+      }));
+      const workflowIds = workflowIdsByConnector.flatMap(
+        ({ workflowIds }) => workflowIds
+      );
+      const runningWorkflowIds = await listRunningWorkflowIds(
+        client,
+        workflowIds,
+        logger,
+        heartbeat
       );
 
-      if (missingEntities.length > 0) {
-        missingActiveWorkflows.push({
-          connectorId: connector.id,
-          workspaceId: connector.workspaceId,
-          dataSourceId: connector.dataSourceId,
-          missingEntities,
-        });
+      for (const { connector, workflowIds } of workflowIdsByConnector) {
+        heartbeat();
+
+        const missingEntities = workflowIds.filter(
+          (workflowId) => !runningWorkflowIds.has(workflowId)
+        );
+
+        if (missingEntities.length > 0) {
+          missingActiveWorkflows.push({
+            connectorId: connector.id,
+            workspaceId: connector.workspaceId,
+            dataSourceId: connector.dataSourceId,
+            missingEntities,
+          });
+        }
+      }
+    } else {
+      for (const connector of activeConnectors) {
+        heartbeat();
+
+        const missingEntities = await getMissingTemporalSchedulesActive(
+          client,
+          connector,
+          info
+        );
+
+        if (missingEntities.length > 0) {
+          missingActiveWorkflows.push({
+            connectorId: connector.id,
+            workspaceId: connector.workspaceId,
+            dataSourceId: connector.dataSourceId,
+            missingEntities,
+          });
+        }
       }
     }
 


### PR DESCRIPTION
## Description

- Batch connector workflow checks through Temporal visibility queries instead of describing each workflow one by one (1 call per connector).
- Workflow-based providers now list running executions with `WorkflowId IN (...) AND ExecutionStatus = "Running"` in bounded chunks, then compute missing workflows from the returned ids.
- Schedule-based providers keep the existing schedule `describe()` path, since they use a different Temporal API.
- Also turned an if-else into a switch case as per dust agent's review.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.