### PR TITLE
Harden sandbox local root escalation

### DIFF
--- a/.github/workflows/sandbox-img-registry.yml
+++ b/.github/workflows/sandbox-img-registry.yml
@@ -120,6 +120,20 @@ jobs:
               $REBUILD_FLAG
           done < <(jq -c '.[]' "$GITHUB_WORKSPACE/build-matrix.json")
 
+      - name: Run sandbox security regression checks
+        if: steps.check.outputs.has-missing == 'true'
+        working-directory: front
+        run: |
+          set -eo pipefail
+          while IFS= read -r row; do
+            image=$(echo "$row" | jq -r '.image')
+            tag=$(echo "$row" | jq -r '.tag')
+            echo "Checking ${image}:${tag} (${{ matrix.region }})"
+            npx tsx scripts/sandbox_security_check.ts \
+              --image "$image" \
+              --tag "$tag"
+          done < <(jq -c '.[]' "$GITHUB_WORKSPACE/build-matrix.json")
+
       - name: Cleanup service account JSON
         if: always() && steps.check.outputs.has-missing == 'true'
         run: rm -f /tmp/service-account.json

--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.22"
+version = "0.1.23"
 edition = "2021"
 
 [[bin]]

--- a/dockerfiles/sandbox-bedrock.Dockerfile
+++ b/dockerfiles/sandbox-bedrock.Dockerfile
@@ -50,12 +50,16 @@ RUN ARCH=$(dpkg --print-architecture) && \
   rm node.tar.xz SHASUMS256.txt
 
 
-# Set permissions for venv, npm global, and bin directories
-RUN chmod -R 777 /opt/venv && mkdir -p /opt/npm-global /opt/bin && chmod -R 777 /opt/npm-global /opt/bin
+# Set permissions for user-installable runtimes and root-owned bin directories.
+RUN chmod -R 777 /opt/venv \
+  && mkdir -p /opt/npm-global /opt/bin \
+  && chmod -R 777 /opt/npm-global \
+  && chown root:root /opt/bin /usr/local/bin \
+  && chmod 755 /opt/bin /usr/local/bin
 
 # Set up environment via profile.d
 RUN printf '%s\n' \
-  'export PATH="/opt/bin:/opt/venv/bin:/opt/npm-global/bin:$PATH"' \
+  'export PATH="$HOME/.local/bin:/opt/bin:/opt/venv/bin:/opt/npm-global/bin:$PATH"' \
   'export VIRTUAL_ENV="/opt/venv"' \
   'export NPM_CONFIG_PREFIX="/opt/npm-global"' \
   > /etc/profile.d/dust-env.sh

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -68,7 +68,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.26",
+      tag: "0.8.27",
     });
   });
 
@@ -79,19 +79,69 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
+          "install -d -o agent -g agent -m 2775 /home/agent/.local /home/agent/.local/bin"
+        ),
+        expect.stringContaining(
           "useradd --create-home --uid 1003 --gid agent --shell /bin/bash agent-proxied"
         ),
-        expect.stringContaining("chgrp agent /home/agent /files/conversation"),
-        expect.stringContaining("chmod g+ws /home/agent /files/conversation"),
         expect.stringContaining(
-          "setfacl -R -d -m g::rwx /home/agent /files/conversation"
+          "chgrp agent /home/agent /home/agent/.local /home/agent/.local/bin /files/conversation"
         ),
         expect.stringContaining(
-          "setfacl -R -m g::rwx /home/agent /files/conversation"
+          "chmod g+ws /home/agent /home/agent/.local /home/agent/.local/bin /files/conversation"
+        ),
+        expect.stringContaining(
+          "setfacl -R -d -m g::rwx /home/agent /home/agent/.local /home/agent/.local/bin /files/conversation"
+        ),
+        expect.stringContaining(
+          "setfacl -R -m g::rwx /home/agent /home/agent/.local /home/agent/.local/bin /files/conversation"
         ),
         expect.stringContaining(
           "useradd --system --no-create-home --gid dust-egress-resolver --shell /usr/sbin/nologin dust-egress-resolver"
         ),
+      ])
+    );
+  });
+
+  test("hardens provider-created local accounts and sudo before agent code exists", () => {
+    const runCommands = getRunCommands(getDustBaseImageOperations());
+    const hardeningCommands = runCommands.filter((command) =>
+      command.includes("sudo must not be installed in sandbox images")
+    );
+    const firstHardeningIndex = runCommands.findIndex((command) =>
+      command.includes("sudo must not be installed in sandbox images")
+    );
+    const agentProxiedIndex = runCommands.findIndex((command) =>
+      command.includes("useradd --create-home --uid 1003")
+    );
+
+    expect(hardeningCommands.length).toBeGreaterThanOrEqual(2);
+    for (const command of hardeningCommands) {
+      expect(command).toContain("passwd -l root");
+      expect(command).toContain("awk -F: '$2 == \"\" {print $1}'");
+      expect(command).toContain('passwd -l "$account"');
+      expect(command).toContain(
+        "usermod --lock --expiredate 1 --shell /usr/sbin/nologin user"
+      );
+      expect(command).toContain("gpasswd -d user");
+      expect(command).toContain("for member in $members");
+      expect(command).toContain("NOPASSWD");
+      expect(command).toContain("apt-get purge -y sudo");
+      expect(command).toContain("sudo_path.disabled-by-dust");
+      expect(command).toContain("/usr/bin/su");
+      expect(command).toContain("/usr/bin/passwd");
+      expect(command).toContain("chmod u-s");
+    }
+    expect(firstHardeningIndex).toBeGreaterThanOrEqual(0);
+    expect(agentProxiedIndex).toBeGreaterThan(firstHardeningIndex);
+  });
+
+  test("keeps privileged executable directories root-owned", () => {
+    const runCommands = getRunCommands(getDustBaseImageOperations());
+
+    expect(runCommands).toEqual(
+      expect.arrayContaining([
+        "install -d -o root -g root -m 755 /opt/bin /usr/local/bin && chown root:root /opt/bin /usr/local/bin && chmod 755 /opt/bin /usr/local/bin",
       ])
     );
   });
@@ -237,7 +287,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.22/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.23/dsbx-linux-x86_64"
         ),
       ])
     );

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -131,6 +131,11 @@ describe("sandbox image registry", () => {
       expect(command).toContain("/usr/bin/su");
       expect(command).toContain("/usr/bin/passwd");
       expect(command).toContain("chmod u-s");
+      expect(command).toContain("empty-password local accounts must not exist");
+      expect(command).toContain(
+        "passwordless unrestricted sudoers entries must not exist"
+      );
+      expect(command).toContain("local auth helper must not be setuid");
     }
     expect(firstHardeningIndex).toBeGreaterThanOrEqual(0);
     expect(agentProxiedIndex).toBeGreaterThan(firstHardeningIndex);

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -14,9 +14,9 @@ import { Err, Ok } from "@app/types/shared/result";
 import fs from "fs";
 import path from "path";
 
-const DUST_BEDROCK_IMAGE_VERSION = "1.7.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.26";
-const DSBX_CLI_VERSION = "0.1.22";
+const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
+const DUST_BASE_IMAGE_VERSION = "0.8.27";
+const DSBX_CLI_VERSION = "0.1.23";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that
 // list must not silently change this user's UID.
@@ -164,11 +164,81 @@ function getAgentProxiedSetupCommand(): string {
   // group-writable, regardless of the creating process's umask — avoids
   // a perms handoff footgun during the PR1→PR2 rollout window.
   return [
+    "install -d -o agent -g agent -m 2775 /home/agent/.local /home/agent/.local/bin",
     `useradd --create-home --uid ${AGENT_PROXIED_UID} --gid agent --shell /bin/bash agent-proxied`,
-    "chgrp agent /home/agent /files/conversation /files/project",
-    "chmod g+ws /home/agent /files/conversation /files/project",
-    "setfacl -R -d -m g::rwx /home/agent /files/conversation /files/project",
-    "setfacl -R -m g::rwx /home/agent /files/conversation /files/project",
+    "chgrp agent /home/agent /home/agent/.local /home/agent/.local/bin /files/conversation /files/project",
+    "chmod g+ws /home/agent /home/agent/.local /home/agent/.local/bin /files/conversation /files/project",
+    "setfacl -R -d -m g::rwx /home/agent /home/agent/.local /home/agent/.local/bin /files/conversation /files/project",
+    "setfacl -R -m g::rwx /home/agent /home/agent/.local /home/agent/.local/bin /files/conversation /files/project",
+  ].join(" && ");
+}
+
+function getLocalAccountPrivilegeHardeningCommand(): string {
+  const lockRootPassword = [
+    "if getent passwd root >/dev/null 2>&1; then",
+    "passwd -l root >/dev/null 2>&1 || usermod --lock root >/dev/null 2>&1 || true;",
+    "fi",
+  ].join(" ");
+  const lockEmptyPasswordAccounts = [
+    "if getent shadow >/dev/null 2>&1; then",
+    `getent shadow | awk -F: '$2 == "" {print $1}' | while IFS= read -r account; do`,
+    '[ -z "$account" ] && continue;',
+    'passwd -l "$account" >/dev/null 2>&1 || usermod --lock "$account" >/dev/null 2>&1 || true;',
+    "done;",
+    "fi",
+  ].join(" ");
+  const lockProviderUser = [
+    "if getent passwd user >/dev/null 2>&1; then",
+    "usermod --lock --expiredate 1 --shell /usr/sbin/nologin user",
+    "&& for group in sudo admin wheel; do",
+    'if getent group "$group" >/dev/null 2>&1; then',
+    'gpasswd -d user "$group" >/dev/null 2>&1 || true;',
+    "fi;",
+    "done;",
+    "fi",
+  ].join(" ");
+  const removePrivilegedGroupMembers = [
+    "for group in sudo admin wheel; do",
+    "members=$(getent group \"$group\" | awk -F: '{print $4}') || continue;",
+    'old_ifs="$IFS";',
+    "IFS=,;",
+    "for member in $members; do",
+    '[ -z "$member" ] || [ "$member" = root ] || gpasswd -d "$member" "$group" >/dev/null 2>&1 || true;',
+    "done;",
+    'IFS="$old_ifs";',
+    "done",
+  ].join(" ");
+  const removePasswordlessSudoersRules = [
+    "if [ -f /etc/sudoers ]; then",
+    "sed -i -E '/^[[:space:]]*#/!{/NOPASSWD[[:space:]]*:[[:space:]]*ALL/d;}' /etc/sudoers;",
+    "fi",
+    "&& if [ -d /etc/sudoers.d ]; then",
+    "find /etc/sudoers.d -maxdepth 1 -type f",
+    "-exec sed -i -E '/^[[:space:]]*#/!{/NOPASSWD[[:space:]]*:[[:space:]]*ALL/d;}' {} +;",
+    "fi",
+  ].join(" ");
+  const removeSudoBinary = [
+    "if command -v sudo >/dev/null 2>&1; then",
+    "DEBIAN_FRONTEND=noninteractive apt-get purge -y sudo >/dev/null 2>&1",
+    '|| { sudo_path=$(command -v sudo); chmod u-s "$sudo_path"; mv "$sudo_path" "$sudo_path.disabled-by-dust"; };',
+    "hash -r 2>/dev/null || true;",
+    "fi",
+  ].join(" ");
+  const hardenLocalAuthHelpers = [
+    "for path in /bin/su /usr/bin/su /bin/sg /usr/bin/sg /usr/bin/newgrp /usr/bin/passwd /usr/bin/chsh /usr/bin/chfn /usr/bin/gpasswd; do",
+    'if [ -e "$path" ]; then chmod u-s "$path"; fi;',
+    "done",
+  ].join(" ");
+
+  return [
+    lockRootPassword,
+    lockEmptyPasswordAccounts,
+    lockProviderUser,
+    removePrivilegedGroupMembers,
+    removePasswordlessSudoersRules,
+    removeSudoBinary,
+    hardenLocalAuthHelpers,
+    "if command -v sudo >/dev/null 2>&1; then echo 'sudo must not be installed in sandbox images' >&2; exit 1; fi",
   ].join(" && ");
 }
 
@@ -176,6 +246,14 @@ function getEgressResolverUserSetupCommand(): string {
   return [
     "groupadd --system dust-egress-resolver",
     "useradd --system --no-create-home --gid dust-egress-resolver --shell /usr/sbin/nologin dust-egress-resolver",
+  ].join(" && ");
+}
+
+function getPrivilegedExecutablePathHardeningCommand(): string {
+  return [
+    "install -d -o root -g root -m 755 /opt/bin /usr/local/bin",
+    "chown root:root /opt/bin /usr/local/bin",
+    "chmod 755 /opt/bin /usr/local/bin",
   ].join(" && ");
 }
 
@@ -246,6 +324,7 @@ const DUST_BASE_IMAGE = SandboxImage.fromDocker(
       user: "root",
     }
   )
+  .runCmd(getLocalAccountPrivilegeHardeningCommand(), { user: "root" })
   .runCmd(getAgentProxiedSetupCommand(), { user: "root" })
   .runCmd(getSshHardeningCommand(), { user: "root" })
   // Create simple netcat-based token server script.
@@ -484,6 +563,10 @@ SHELLEOF`,
     "systemctl daemon-reload && systemctl enable dust-egress-resolver.service dust-egress-nftables.service",
     { user: "root" }
   )
+  // Run after all apt/npm installs as a final guard against a dependency
+  // reintroducing sudo or privileged account state.
+  .runCmd(getLocalAccountPrivilegeHardeningCommand(), { user: "root" })
+  .runCmd(getPrivilegedExecutablePathHardeningCommand(), { user: "root" })
   // Profile functions (no install needed, provided by profile scripts)
   // --- read_file: anthropic/openai use offset/limit, gemini uses start/end ---
   .registerTool({

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -229,6 +229,34 @@ function getLocalAccountPrivilegeHardeningCommand(): string {
     'if [ -e "$path" ]; then chmod u-s "$path"; fi;',
     "done",
   ].join(" ");
+  const assertNoEmptyPasswordAccounts = [
+    `if getent shadow | awk -F: '$2 == "" {print $1}' | grep -q .; then`,
+    "echo 'empty-password local accounts must not exist' >&2;",
+    "exit 1;",
+    "fi",
+  ].join(" ");
+  const assertNoPrivilegedGroupMembers = [
+    "for group in sudo admin wheel; do",
+    "members=$(getent group \"$group\" | awk -F: '{print $4}') || continue;",
+    'old_ifs="$IFS";',
+    "IFS=,;",
+    "for member in $members; do",
+    'if [ -n "$member" ] && [ "$member" != root ]; then echo "privileged group $group must not include $member" >&2; exit 1; fi;',
+    "done;",
+    'IFS="$old_ifs";',
+    "done",
+  ].join(" ");
+  const assertNoPasswordlessSudoers = [
+    "if grep -RIsnE '^[[:space:]]*[^#].*NOPASSWD[[:space:]]*:[[:space:]]*ALL' /etc/sudoers /etc/sudoers.d 2>/dev/null | grep -q .; then",
+    "echo 'passwordless unrestricted sudoers entries must not exist' >&2;",
+    "exit 1;",
+    "fi",
+  ].join(" ");
+  const assertLocalAuthHelpersNotSetuid = [
+    "for path in /bin/su /usr/bin/su /bin/sg /usr/bin/sg /usr/bin/newgrp /usr/bin/passwd /usr/bin/chsh /usr/bin/chfn /usr/bin/gpasswd; do",
+    'if [ -e "$path" ] && [ -u "$path" ]; then echo "local auth helper must not be setuid: $path" >&2; exit 1; fi;',
+    "done",
+  ].join(" ");
 
   return [
     lockRootPassword,
@@ -238,6 +266,10 @@ function getLocalAccountPrivilegeHardeningCommand(): string {
     removePasswordlessSudoersRules,
     removeSudoBinary,
     hardenLocalAuthHelpers,
+    assertNoEmptyPasswordAccounts,
+    assertNoPrivilegedGroupMembers,
+    assertNoPasswordlessSudoers,
+    assertLocalAuthHelpersNotSetuid,
     "if command -v sudo >/dev/null 2>&1; then echo 'sudo must not be installed in sandbox images' >&2; exit 1; fi",
   ].join(" && ");
 }

--- a/front/scripts/sandbox_security_check.test.ts
+++ b/front/scripts/sandbox_security_check.test.ts
@@ -1,0 +1,95 @@
+import {
+  assertLocalAuthHelpersNotSetuid,
+  assertNoEmptyPasswordAccounts,
+  assertNoPasswordlessSudoers,
+  assertNoPrivilegedGroupMembers,
+  assertPrivilegedDirsSafe,
+  assertSudoAbsent,
+  containsUnrestrictedSudo,
+} from "@app/scripts/sandbox_security_check";
+import { describe, expect, test } from "vitest";
+
+describe("sandbox security check assertions", () => {
+  test("detects unrestricted passwordless sudo while ignoring comments", () => {
+    expect(
+      containsUnrestrictedSudo("/etc/sudoers:10:user ALL=(ALL) NOPASSWD: ALL")
+    ).toBe(true);
+    expect(
+      containsUnrestrictedSudo("/etc/sudoers:10:# user ALL=(ALL) NOPASSWD: ALL")
+    ).toBe(false);
+    expect(
+      containsUnrestrictedSudo(
+        "/etc/sudoers:10:user ALL=(ALL) NOPASSWD: /usr/bin/id"
+      )
+    ).toBe(false);
+  });
+
+  test("detects non-root privileged group members", () => {
+    expect(() =>
+      assertNoPrivilegedGroupMembers("sudo:x:27:\nwheel:x:10:root\n")
+    ).not.toThrow();
+    expect(() =>
+      assertNoPrivilegedGroupMembers("sudo:x:27:user,agent\n")
+    ).toThrow("privileged group sudo still has non-root members");
+  });
+
+  test("detects passwordless sudoers entries", () => {
+    expect(() =>
+      assertNoPasswordlessSudoers(
+        "/etc/sudoers:10:# user ALL=(ALL) NOPASSWD: ALL\n"
+      )
+    ).not.toThrow();
+    expect(() =>
+      assertNoPasswordlessSudoers(
+        "/etc/sudoers:10:user ALL=(ALL) NOPASSWD: ALL\n"
+      )
+    ).toThrow("passwordless unrestricted sudoers entries remain");
+  });
+
+  test("detects remaining sudo binary", () => {
+    expect(() => assertSudoAbsent("SUDO_ABSENT=1")).not.toThrow();
+    expect(() => assertSudoAbsent("SUDO_BINARY=/usr/bin/sudo")).toThrow(
+      "sudo binary is still installed"
+    );
+  });
+
+  test("detects empty-password accounts", () => {
+    expect(() =>
+      assertNoEmptyPasswordAccounts("--- empty-password-accounts ---")
+    ).not.toThrow();
+    expect(() =>
+      assertNoEmptyPasswordAccounts("EMPTY_PASSWORD_ACCOUNT=root")
+    ).toThrow("local accounts with empty passwords remain");
+  });
+
+  test("detects setuid local auth helpers", () => {
+    expect(() =>
+      assertLocalAuthHelpersNotSetuid(
+        "LOCAL_AUTH_HELPER=/usr/bin/su 755 -rwxr-xr-x root:root"
+      )
+    ).not.toThrow();
+    expect(() =>
+      assertLocalAuthHelpersNotSetuid(
+        "LOCAL_AUTH_HELPER=/usr/bin/su 4755 -rwsr-xr-x root:root"
+      )
+    ).toThrow("local auth helpers are still setuid");
+  });
+
+  test("detects unsafe privileged directory ownership or modes", () => {
+    expect(() =>
+      assertPrivilegedDirsSafe(
+        "/opt/bin root:root 755 drwxr-xr-x\n/usr/local/bin root:root 755 drwxr-xr-x"
+      )
+    ).not.toThrow();
+    expect(() =>
+      assertPrivilegedDirsSafe(
+        "/opt/bin agent:agent 755 drwxr-xr-x\n/usr/local/bin root:root 755 drwxr-xr-x"
+      )
+    ).toThrow("privileged directory /opt/bin is not root-owned");
+    expect(() =>
+      assertPrivilegedDirsSafe(
+        "/opt/bin root:root 777 drwxrwxrwx\n/usr/local/bin root:root 755 drwxr-xr-x"
+      )
+    ).toThrow("privileged directory /opt/bin is not root-owned");
+  });
+});

--- a/front/scripts/sandbox_security_check.ts
+++ b/front/scripts/sandbox_security_check.ts
@@ -1,0 +1,671 @@
+import config from "@app/lib/api/config";
+import {
+  formatSandboxImageId,
+  getRegisteredImages,
+  getSandboxImageFromRegistry,
+  type SandboxImage,
+} from "@app/lib/api/sandbox/image";
+import type { ExecResult } from "@app/lib/api/sandbox/provider";
+import { E2BSandboxProvider } from "@app/lib/api/sandbox/providers/e2b";
+import logger from "@app/logger/logger";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isString } from "@app/types/shared/utils/general";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+const TRACE_OPTS = { workspaceId: "sandbox-image-security-check" };
+const AGENT_PROXIED_USER = "agent-proxied";
+const COMMAND_TIMEOUT_MS = 15_000;
+const ROOT_ID_PATTERN = /\buid=0\(root\)\b/;
+const UNRESTRICTED_SUDO_PATTERN =
+  /\([^)]*ALL[^)]*\)\s*NOPASSWD:\s*ALL|NOPASSWD:\s*ALL/;
+const PRIVILEGED_GROUP_PATTERN = /\b\d+\((sudo|wheel|admin)\)/;
+const LOCAL_AUTH_HELPER_PATHS = [
+  "/bin/su",
+  "/usr/bin/su",
+  "/bin/sg",
+  "/usr/bin/sg",
+  "/usr/bin/newgrp",
+  "/usr/bin/passwd",
+  "/usr/bin/chsh",
+  "/usr/bin/chfn",
+  "/usr/bin/gpasswd",
+] as const;
+
+interface CheckArgs {
+  image?: string;
+  tag?: string;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function combinedOutput(result: ExecResult): string {
+  return [result.stdout, result.stderr].filter((s) => s.length > 0).join("\n");
+}
+
+async function runCommand(
+  provider: E2BSandboxProvider,
+  providerId: string,
+  command: string,
+  options: { user: string; timeoutMs?: number }
+): Promise<ExecResult> {
+  const result = await provider.exec(
+    providerId,
+    command,
+    {
+      timeoutMs: options.timeoutMs ?? COMMAND_TIMEOUT_MS,
+      user: options.user,
+    },
+    TRACE_OPTS
+  );
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
+}
+
+async function runBashScript(
+  provider: E2BSandboxProvider,
+  providerId: string,
+  script: string,
+  options: { user: string; timeoutMs?: number }
+): Promise<ExecResult> {
+  return runCommand(
+    provider,
+    providerId,
+    `/bin/bash -lc ${shellQuote(script)}`,
+    {
+      timeoutMs: options.timeoutMs,
+      user: options.user,
+    }
+  );
+}
+
+function assertNoRootIdentity(label: string, result: ExecResult): void {
+  const output = combinedOutput(result);
+  if (ROOT_ID_PATTERN.test(output)) {
+    throw new Error(`${label} yielded root identity:\n${output}`);
+  }
+}
+
+function assertCommandSucceeded(label: string, result: ExecResult): void {
+  if (result.exitCode !== 0) {
+    throw new Error(`${label} failed:\n${combinedOutput(result)}`);
+  }
+}
+
+function containsUnrestrictedSudo(output: string): boolean {
+  return output
+    .split("\n")
+    .map((line) => {
+      const firstColon = line.indexOf(":");
+      const secondColon =
+        firstColon >= 0 ? line.indexOf(":", firstColon + 1) : -1;
+      return line.startsWith("/etc/") && secondColon >= 0
+        ? line.slice(secondColon + 1).trim()
+        : line.trim();
+    })
+    .filter((line) => !line.startsWith("#"))
+    .some((line) => UNRESTRICTED_SUDO_PATTERN.test(line));
+}
+
+async function checkOriginalExploitPath(
+  provider: E2BSandboxProvider,
+  providerId: string
+): Promise<void> {
+  const identity = await runCommand(provider, providerId, "id", {
+    user: AGENT_PROXIED_USER,
+  });
+  assertCommandSucceeded("workload identity check", identity);
+  if (ROOT_ID_PATTERN.test(combinedOutput(identity))) {
+    throw new Error(
+      `workload user unexpectedly runs as root:\n${combinedOutput(identity)}`
+    );
+  }
+
+  const escalation = await runCommand(
+    provider,
+    providerId,
+    "timeout 5s su -s /bin/bash user -c 'sudo -n /usr/bin/id' < /dev/null",
+    { user: AGENT_PROXIED_USER }
+  );
+  assertNoRootIdentity("original user/sudo escalation", escalation);
+
+  const marker = `root-proof-regression-test-${Date.now()}`;
+  const rootWriteScript = [
+    "umask 077",
+    `printf %s ${shellQuote(marker)} > /root/${marker}`,
+    "/usr/bin/id",
+    `/usr/bin/stat -c ${shellQuote("%n %U:%G %a")} /root/${marker}`,
+    `/bin/rm -f /root/${marker}`,
+  ].join("; ");
+  const markerProof = await runCommand(
+    provider,
+    providerId,
+    `timeout 5s su -s /bin/bash user -c ${shellQuote(
+      `sudo -n /bin/sh -c ${shellQuote(rootWriteScript)}`
+    )} < /dev/null`,
+    { user: AGENT_PROXIED_USER }
+  );
+  const markerOutput = combinedOutput(markerProof);
+  if (
+    markerProof.exitCode === 0 ||
+    ROOT_ID_PATTERN.test(markerOutput) ||
+    markerOutput.includes(marker)
+  ) {
+    throw new Error(
+      `root marker proof unexpectedly succeeded or leaked root output:\n${markerOutput}`
+    );
+  }
+}
+
+async function checkPamEscalationPaths(
+  provider: E2BSandboxProvider,
+  providerId: string
+): Promise<void> {
+  const probes = [
+    {
+      label: "su login root",
+      command: "timeout 5s su - root -c '/usr/bin/id' < /dev/null",
+    },
+    {
+      label: "su root",
+      command: "timeout 5s su root -c '/usr/bin/id' < /dev/null",
+    },
+    {
+      label: "su shell root",
+      command: "timeout 5s su -s /bin/bash root -c '/usr/bin/id' < /dev/null",
+    },
+    {
+      label: "runuser root",
+      command: "timeout 5s runuser -u root -- /usr/bin/id < /dev/null",
+    },
+    {
+      label: "sg sudo",
+      command: "timeout 5s sg sudo -c /usr/bin/id < /dev/null",
+    },
+    {
+      label: "newgrp sudo",
+      command: "timeout 5s newgrp sudo < /dev/null",
+    },
+    {
+      label: "chsh root",
+      command:
+        "current_shell=$(getent passwd root | awk -F: '{print $7}'); timeout 5s chsh -s \"$current_shell\" root < /dev/null",
+    },
+  ] as const;
+
+  for (const probe of probes) {
+    const result = await runCommand(provider, providerId, probe.command, {
+      user: AGENT_PROXIED_USER,
+    });
+    const output = combinedOutput(result);
+    if (result.exitCode === 0 || ROOT_ID_PATTERN.test(output)) {
+      throw new Error(
+        `${probe.label} unexpectedly succeeded or yielded root identity:\n${output}`
+      );
+    }
+  }
+}
+
+async function checkBasicSandboxFunctionality(
+  provider: E2BSandboxProvider,
+  providerId: string
+): Promise<void> {
+  const smoke = await runBashScript(
+    provider,
+    providerId,
+    `
+set -euo pipefail
+echo "shell-ok"
+/opt/bin/dsbx version >/dev/null
+for dir in /files/conversation /files/project; do
+  test -d "$dir"
+  proof="$dir/dust-security-smoke-$$"
+  printf 'file-ok' > "$proof"
+  test "$(cat "$proof")" = "file-ok"
+  rm -f "$proof"
+done
+`,
+    { user: AGENT_PROXIED_USER }
+  );
+
+  assertCommandSucceeded("basic shell and file operations", smoke);
+}
+
+async function checkTargetUserState(
+  provider: E2BSandboxProvider,
+  providerId: string
+): Promise<void> {
+  const audit = await runBashScript(
+    provider,
+    providerId,
+    `
+set -euo pipefail
+if getent passwd user >/dev/null; then
+  echo "USER_EXISTS=1"
+  id user
+  passwd -S user || true
+  for group in sudo wheel admin; do
+    getent group "$group" || true
+  done
+  if command -v sudo >/dev/null 2>&1; then
+    sudo -n -l -U user || true
+  else
+    echo "SUDO_ABSENT=1"
+  fi
+else
+  echo "USER_EXISTS=0"
+fi
+`,
+    { user: "root" }
+  );
+  const output = combinedOutput(audit);
+
+  const userIdLine = output.split("\n").find((line) => line.startsWith("uid="));
+  if (userIdLine && PRIVILEGED_GROUP_PATTERN.test(userIdLine)) {
+    throw new Error(
+      `local user still belongs to a privileged group:\n${output}`
+    );
+  }
+
+  const passwordStatus = /^user\s+(\S+)/m.exec(output);
+  if (
+    passwordStatus &&
+    (passwordStatus[1] === "P" || passwordStatus[1] === "NP")
+  ) {
+    throw new Error(`local user account is not locked:\n${output}`);
+  }
+
+  if (containsUnrestrictedSudo(output)) {
+    throw new Error(`local user still has unrestricted sudo:\n${output}`);
+  }
+}
+
+async function checkEquivalentAccountEscalation(
+  provider: E2BSandboxProvider,
+  providerId: string
+): Promise<void> {
+  const audit = await runBashScript(
+    provider,
+    providerId,
+    `
+set -euo pipefail
+bad=0
+while IFS=: read -r name _uid _gid _gecos _home _shell; do
+  if [ "$name" = "${AGENT_PROXIED_USER}" ]; then
+    continue
+  fi
+
+  out="$(mktemp)"
+  if timeout 3s su -s /bin/sh "$name" -c '/usr/bin/id' < /dev/null > "$out" 2>&1; then
+    if grep -q 'uid=0(root)' "$out"; then
+      echo "CRITICAL: ${AGENT_PROXIED_USER} can enter $name as root"
+      cat "$out"
+      bad=1
+    fi
+    if timeout 3s su -s /bin/sh "$name" -c 'if command -v sudo >/dev/null 2>&1; then sudo -n /usr/bin/id; fi' < /dev/null > "$out" 2>&1; then
+      if grep -q 'uid=0(root)' "$out"; then
+        echo "CRITICAL: ${AGENT_PROXIED_USER} can reach root through $name"
+        cat "$out"
+        bad=1
+      fi
+    fi
+  fi
+  rm -f "$out"
+done < <(getent passwd)
+exit "$bad"
+`,
+    { timeoutMs: 60_000, user: AGENT_PROXIED_USER }
+  );
+
+  if (audit.exitCode !== 0 || ROOT_ID_PATTERN.test(combinedOutput(audit))) {
+    throw new Error(
+      `equivalent account-based escalation audit failed:\n${combinedOutput(audit)}`
+    );
+  }
+}
+
+function assertNoPrivilegedGroupMembers(output: string): void {
+  const groupPattern = /^(sudo|wheel|admin):[^:]*:[^:]*:(.*)$/gm;
+  let match = groupPattern.exec(output);
+
+  while (match) {
+    const members = match[2]
+      .split(",")
+      .map((member) => member.trim())
+      .filter((member) => member.length > 0 && member !== "root");
+
+    if (members.length > 0) {
+      throw new Error(
+        `privileged group ${match[1]} still has non-root members (${members.join(
+          ", "
+        )}):\n${output}`
+      );
+    }
+
+    match = groupPattern.exec(output);
+  }
+}
+
+function assertNoPasswordlessSudoers(output: string): void {
+  const passwordlessSudoers = output
+    .split("\n")
+    .filter((line) => line.includes("/etc/sudoers"))
+    .filter((line) => {
+      const firstColon = line.indexOf(":");
+      const secondColon =
+        firstColon >= 0 ? line.indexOf(":", firstColon + 1) : -1;
+      const content =
+        secondColon >= 0 ? line.slice(secondColon + 1).trim() : line.trim();
+      return (
+        !content.startsWith("#") && UNRESTRICTED_SUDO_PATTERN.test(content)
+      );
+    });
+
+  if (passwordlessSudoers.length > 0) {
+    throw new Error(
+      `passwordless unrestricted sudoers entries remain:\n${passwordlessSudoers.join(
+        "\n"
+      )}`
+    );
+  }
+}
+
+function assertSudoAbsent(output: string): void {
+  if (output.split("\n").some((line) => line.startsWith("SUDO_BINARY="))) {
+    throw new Error(`sudo binary is still installed:\n${output}`);
+  }
+}
+
+function assertNoEmptyPasswordAccounts(output: string): void {
+  const emptyPasswordAccounts = output
+    .split("\n")
+    .filter((line) => line.startsWith("EMPTY_PASSWORD_ACCOUNT="));
+
+  if (emptyPasswordAccounts.length > 0) {
+    throw new Error(
+      `local accounts with empty passwords remain:\n${emptyPasswordAccounts.join(
+        "\n"
+      )}`
+    );
+  }
+}
+
+function assertLocalAuthHelpersNotSetuid(output: string): void {
+  const setuidHelpers = output
+    .split("\n")
+    .filter((line) => line.startsWith("LOCAL_AUTH_HELPER="))
+    .filter((line) => {
+      const fields = line.replace("LOCAL_AUTH_HELPER=", "").split(/\s+/);
+      const mode = Number.parseInt(fields[1], 8);
+      return !Number.isNaN(mode) && (mode & 0o4000) !== 0;
+    });
+
+  if (setuidHelpers.length > 0) {
+    throw new Error(
+      `local auth helpers are still setuid:\n${setuidHelpers.join("\n")}`
+    );
+  }
+}
+
+function assertPrivilegedDirsSafe(output: string): void {
+  for (const dir of ["/opt/bin", "/usr/local/bin"]) {
+    const line = output
+      .split("\n")
+      .find((candidate) => candidate.startsWith(`${dir} `));
+    if (!line) {
+      throw new Error(
+        `missing privileged directory audit for ${dir}:\n${output}`
+      );
+    }
+
+    const fields = line.split(/\s+/);
+    const owner = fields[1];
+    const modeText = fields[2];
+    const mode = Number.parseInt(modeText, 8);
+
+    if (owner !== "root:root" || Number.isNaN(mode) || (mode & 0o022) !== 0) {
+      throw new Error(
+        `privileged directory ${dir} is not root-owned and non-writable by group/other:\n${line}`
+      );
+    }
+  }
+}
+
+async function checkSystemAccountAudit(
+  provider: E2BSandboxProvider,
+  providerId: string
+): Promise<void> {
+  const audit = await runBashScript(
+    provider,
+    providerId,
+    `
+set -euo pipefail
+echo "--- passwd ---"
+getent passwd
+echo "--- privileged-groups ---"
+for group in sudo wheel admin; do
+  getent group "$group" || true
+done
+echo "--- sudo-binary ---"
+if command -v sudo >/dev/null 2>&1; then
+  sudo_path="$(command -v sudo)"
+  echo "SUDO_BINARY=$sudo_path"
+  stat -c '%n %U:%G %a %A' "$sudo_path"
+else
+  echo "SUDO_ABSENT=1"
+fi
+echo "--- sudoers ---"
+grep -RInE 'NOPASSWD|ALL.*ALL' /etc/sudoers /etc/sudoers.d 2>/dev/null || true
+echo "--- empty-password-accounts ---"
+getent shadow | awk -F: '$2 == "" {print "EMPTY_PASSWORD_ACCOUNT=" $1}'
+echo "--- local-auth-setuid ---"
+for path in ${LOCAL_AUTH_HELPER_PATHS.map((path) => shellQuote(path)).join(
+      " "
+    )}; do
+  if [ -e "$path" ]; then
+    stat -c 'LOCAL_AUTH_HELPER=%n %a %A %U:%G' "$path"
+  fi
+done
+echo "--- privileged-dirs ---"
+for dir in /opt/bin /usr/local/bin; do
+  stat -c '%n %U:%G %a %A' "$dir"
+done
+`,
+    { user: "root" }
+  );
+  const output = combinedOutput(audit);
+
+  assertNoPrivilegedGroupMembers(output);
+  assertSudoAbsent(output);
+  assertNoPasswordlessSudoers(output);
+  assertNoEmptyPasswordAccounts(output);
+  assertLocalAuthHelpersNotSetuid(output);
+  assertPrivilegedDirsSafe(output);
+}
+
+function assertSshAndDnsHardening(output: string): void {
+  if (!output.includes("SSH_PORT_22_LISTENING=0")) {
+    throw new Error(`sshd appears to be listening on port 22:\n${output}`);
+  }
+
+  for (const expected of [
+    "PermitRootLogin no",
+    "PasswordAuthentication no",
+    "UsePAM no",
+    "AllowUsers agent",
+    "DenyUsers root agent-proxied",
+  ]) {
+    if (!output.includes(expected)) {
+      throw new Error(
+        `missing SSH hardening directive "${expected}":\n${output}`
+      );
+    }
+  }
+
+  for (const expected of [
+    "DNS_RESOLVER_ACTIVE=1",
+    "DNS_NFTABLES_ACTIVE=1",
+    "udp dport 53 redirect",
+    "tcp dport 53 redirect",
+    "tcp dport 22 drop",
+    "meta l4proto",
+  ]) {
+    if (!output.includes(expected)) {
+      throw new Error(
+        `missing DNS/egress hardening evidence "${expected}":\n${output}`
+      );
+    }
+  }
+}
+
+async function checkSshAndDnsHardening(
+  provider: E2BSandboxProvider,
+  providerId: string
+): Promise<void> {
+  const audit = await runBashScript(
+    provider,
+    providerId,
+    `
+set -euo pipefail
+if awk '$2 ~ /:0016$/ && $4 == "0A" { found=1 } END { exit found ? 0 : 1 }' /proc/net/tcp /proc/net/tcp6; then
+  echo "SSH_PORT_22_LISTENING=1"
+else
+  echo "SSH_PORT_22_LISTENING=0"
+fi
+echo "--- sshd-hardening ---"
+cat /etc/ssh/sshd_config.d/00-dust-sandbox-hardening.conf
+echo "--- dns-systemd ---"
+if systemctl is-active --quiet dust-egress-resolver.service; then
+  echo "DNS_RESOLVER_ACTIVE=1"
+else
+  systemctl status dust-egress-resolver.service --no-pager || true
+  echo "DNS_RESOLVER_ACTIVE=0"
+fi
+if systemctl is-active --quiet dust-egress-nftables.service; then
+  echo "DNS_NFTABLES_ACTIVE=1"
+else
+  systemctl status dust-egress-nftables.service --no-pager || true
+  echo "DNS_NFTABLES_ACTIVE=0"
+fi
+echo "--- nft-ip ---"
+nft -n list table ip dust-egress
+echo "--- nft-ip6 ---"
+nft -n list table ip6 dust-egress
+`,
+    { user: "root" }
+  );
+
+  assertCommandSucceeded("SSH and DNS hardening audit", audit);
+  assertSshAndDnsHardening(combinedOutput(audit));
+}
+
+async function checkImage(image: SandboxImage): Promise<void> {
+  if (!image.imageId) {
+    throw new Error(
+      "Cannot run security check for unregistered sandbox image."
+    );
+  }
+
+  const imageId = formatSandboxImageId(image.imageId);
+  const provider = new E2BSandboxProvider(config.getE2BSandboxConfig());
+  let providerId: string | undefined;
+
+  logger.info({ imageId }, "Creating sandbox for security regression check");
+
+  try {
+    const createResult = await provider.create(
+      image.toCreateConfig(),
+      TRACE_OPTS
+    );
+    if (createResult.isErr()) {
+      throw createResult.error;
+    }
+    providerId = createResult.value.providerId;
+
+    await checkOriginalExploitPath(provider, providerId);
+    await checkPamEscalationPaths(provider, providerId);
+    await checkBasicSandboxFunctionality(provider, providerId);
+    await checkTargetUserState(provider, providerId);
+    await checkEquivalentAccountEscalation(provider, providerId);
+    await checkSystemAccountAudit(provider, providerId);
+    await checkSshAndDnsHardening(provider, providerId);
+
+    logger.info(
+      { imageId, providerId },
+      "Sandbox security regression check passed"
+    );
+  } finally {
+    if (providerId) {
+      const destroyResult = await provider.destroy(providerId, TRACE_OPTS);
+      if (destroyResult.isErr()) {
+        logger.error(
+          { err: destroyResult.error, imageId, providerId },
+          "Failed to destroy sandbox after security regression check"
+        );
+      }
+    }
+  }
+}
+
+async function parseCheckArgs(): Promise<CheckArgs> {
+  const argv = await yargs(hideBin(process.argv))
+    .option("image", {
+      type: "string",
+      describe: "Image name to check. Defaults to all registered images.",
+    })
+    .option("tag", {
+      type: "string",
+      describe: "Image tag to check. Requires --image.",
+    })
+    .strict()
+    .help("h")
+    .alias("h", "help")
+    .parseAsync();
+
+  const image = isString(argv.image) ? argv.image : undefined;
+  const tag = isString(argv.tag) ? argv.tag : undefined;
+
+  if (tag && !image) {
+    throw new Error("--tag requires --image");
+  }
+
+  return { image, tag };
+}
+
+function getImagesToCheck(args: CheckArgs): readonly SandboxImage[] {
+  if (args.image) {
+    const result = getSandboxImageFromRegistry({
+      name: args.image,
+      tag: args.tag,
+    });
+    if (result.isErr()) {
+      throw result.error;
+    }
+    return [result.value];
+  }
+
+  return getRegisteredImages();
+}
+
+async function main(): Promise<void> {
+  const args = await parseCheckArgs();
+  const images = getImagesToCheck(args);
+
+  for (const image of images) {
+    await checkImage(image);
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err: unknown) => {
+    logger.error(
+      { err: normalizeError(err) },
+      "Sandbox security regression check failed"
+    );
+    process.exit(1);
+  });

--- a/front/scripts/sandbox_security_check.ts
+++ b/front/scripts/sandbox_security_check.ts
@@ -96,7 +96,7 @@ function assertCommandSucceeded(label: string, result: ExecResult): void {
   }
 }
 
-function containsUnrestrictedSudo(output: string): boolean {
+export function containsUnrestrictedSudo(output: string): boolean {
   return output
     .split("\n")
     .map((line) => {
@@ -328,7 +328,7 @@ exit "$bad"
   }
 }
 
-function assertNoPrivilegedGroupMembers(output: string): void {
+export function assertNoPrivilegedGroupMembers(output: string): void {
   const groupPattern = /^(sudo|wheel|admin):[^:]*:[^:]*:(.*)$/gm;
   let match = groupPattern.exec(output);
 
@@ -350,7 +350,7 @@ function assertNoPrivilegedGroupMembers(output: string): void {
   }
 }
 
-function assertNoPasswordlessSudoers(output: string): void {
+export function assertNoPasswordlessSudoers(output: string): void {
   const passwordlessSudoers = output
     .split("\n")
     .filter((line) => line.includes("/etc/sudoers"))
@@ -374,13 +374,13 @@ function assertNoPasswordlessSudoers(output: string): void {
   }
 }
 
-function assertSudoAbsent(output: string): void {
+export function assertSudoAbsent(output: string): void {
   if (output.split("\n").some((line) => line.startsWith("SUDO_BINARY="))) {
     throw new Error(`sudo binary is still installed:\n${output}`);
   }
 }
 
-function assertNoEmptyPasswordAccounts(output: string): void {
+export function assertNoEmptyPasswordAccounts(output: string): void {
   const emptyPasswordAccounts = output
     .split("\n")
     .filter((line) => line.startsWith("EMPTY_PASSWORD_ACCOUNT="));
@@ -394,7 +394,7 @@ function assertNoEmptyPasswordAccounts(output: string): void {
   }
 }
 
-function assertLocalAuthHelpersNotSetuid(output: string): void {
+export function assertLocalAuthHelpersNotSetuid(output: string): void {
   const setuidHelpers = output
     .split("\n")
     .filter((line) => line.startsWith("LOCAL_AUTH_HELPER="))
@@ -411,7 +411,7 @@ function assertLocalAuthHelpersNotSetuid(output: string): void {
   }
 }
 
-function assertPrivilegedDirsSafe(output: string): void {
+export function assertPrivilegedDirsSafe(output: string): void {
   for (const dir of ["/opt/bin", "/usr/local/bin"]) {
     const line = output
       .split("\n")
@@ -651,7 +651,7 @@ function getImagesToCheck(args: CheckArgs): readonly SandboxImage[] {
   return getRegisteredImages();
 }
 
-async function main(): Promise<void> {
+export async function main(): Promise<void> {
   const args = await parseCheckArgs();
   const images = getImagesToCheck(args);
 
@@ -660,12 +660,14 @@ async function main(): Promise<void> {
   }
 }
 
-main()
-  .then(() => process.exit(0))
-  .catch((err: unknown) => {
-    logger.error(
-      { err: normalizeError(err) },
-      "Sandbox security regression check failed"
-    );
-    process.exit(1);
-  });
+if (process.argv[1]?.endsWith("sandbox_security_check.ts")) {
+  main()
+    .then(() => process.exit(0))
+    .catch((err: unknown) => {
+      logger.error(
+        { err: normalizeError(err) },
+        "Sandbox security regression check failed"
+      );
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Description

Fix sandbox local privilege escalation where provider-created accounts with empty passwords let `agent-proxied` reach root through `su` and sudo. Locks empty-password accounts, removes sudo and unrestricted sudoers rules, strips setuid from local auth helpers, keeps privileged bin dirs root-owned, and runs an E2B security regression check after sandbox image builds.

Reference: private vuln report shared out of band.

Bumps `dsbx` to `0.1.23` and the sandbox images to `dust-base:0.8.27` and `dust-sbx-bedrock:1.10.0`.

## Tests

Reproduced on existing E2B `dust-base_0-8-26`: `su - root` returned `uid=0(root)`. Applied the generated hardening commands in the same sandbox: direct `su`, `su user && sudo`, `runuser`, `sg`, and `newgrp` failed; empty-password accounts were gone; sudo was absent; local auth helpers were not setuid. Destroyed the sandbox after the check.

Also ran `registry.test.ts`, `sandbox_security_check.test.ts`, `sandbox_security_check.ts --help`, `cargo test --locked`, and `tsc --noEmit` locally.

## Risk

Main risk is image rollout ordering. The new base image downloads `dsbx-v0.1.23` and starts from `dust-sbx-bedrock:1.10.0`, so both must exist before building `dust-base:0.8.27`. Safe to roll back by pinning front back to the previous sandbox image tag.

## Deploy Plan

- [ ] Release `dsbx-v0.1.23`.
- [ ] Merge this PR.
- [ ] Wait for `Sandbox Bedrock Release` to publish `dust-sbx-bedrock:1.10.0`.
- [ ] Build/register `dust-base:0.8.27` with the sandbox image registry workflow.
- [ ] Verify the sandbox security regression check passes in EU and US.
- [ ] Deploy front once the new image exists in the target E2B regions.