### PR TITLE
Harden E2B runtime sandbox accounts

### DIFF
--- a/front/lib/api/sandbox/hardening.ts
+++ b/front/lib/api/sandbox/hardening.ts
@@ -1,0 +1,115 @@
+export function getLocalAccountPrivilegeHardeningCommand(): string {
+  const lockRootPassword = [
+    "if getent passwd root >/dev/null 2>&1; then",
+    "passwd -l root >/dev/null 2>&1 || usermod --lock root >/dev/null 2>&1 || true;",
+    "fi",
+  ].join(" ");
+  const lockEmptyPasswordAccounts = [
+    "if getent shadow >/dev/null 2>&1; then",
+    `getent shadow | awk -F: '$2 == "" {print $1}' | while IFS= read -r account; do`,
+    '[ -z "$account" ] && continue;',
+    'passwd -l "$account" >/dev/null 2>&1 || usermod --lock "$account" >/dev/null 2>&1 || true;',
+    "done;",
+    "fi",
+  ].join(" ");
+  const lockProviderUser = [
+    "if getent passwd user >/dev/null 2>&1; then",
+    "usermod --lock --expiredate 1 --shell /usr/sbin/nologin user",
+    "&& for group in sudo admin wheel; do",
+    'if getent group "$group" >/dev/null 2>&1; then',
+    'gpasswd -d user "$group" >/dev/null 2>&1 || true;',
+    "fi;",
+    "done;",
+    "fi",
+  ].join(" ");
+  const removePrivilegedGroupMembers = [
+    "for group in sudo admin wheel; do",
+    "members=$(getent group \"$group\" | awk -F: '{print $4}') || continue;",
+    'old_ifs="$IFS";',
+    "IFS=,;",
+    "for member in $members; do",
+    '[ -z "$member" ] || [ "$member" = root ] || gpasswd -d "$member" "$group" >/dev/null 2>&1 || true;',
+    "done;",
+    'IFS="$old_ifs";',
+    "done",
+  ].join(" ");
+  const removePasswordlessSudoersRules = [
+    "if [ -f /etc/sudoers ]; then",
+    "sed -i -E '/^[[:space:]]*#/!{/NOPASSWD[[:space:]]*:[[:space:]]*ALL/d;}' /etc/sudoers;",
+    "fi",
+    "&& if [ -d /etc/sudoers.d ]; then",
+    "find /etc/sudoers.d -maxdepth 1 -type f",
+    "-exec sed -i -E '/^[[:space:]]*#/!{/NOPASSWD[[:space:]]*:[[:space:]]*ALL/d;}' {} +;",
+    "fi",
+  ].join(" ");
+  const removeSudoBinary = [
+    "if command -v sudo >/dev/null 2>&1; then",
+    "DEBIAN_FRONTEND=noninteractive apt-get purge -y sudo >/dev/null 2>&1",
+    '|| { sudo_path=$(command -v sudo); chmod u-s "$sudo_path"; mv "$sudo_path" "$sudo_path.disabled-by-dust"; };',
+    "hash -r 2>/dev/null || true;",
+    "fi",
+  ].join(" ");
+  const hardenLocalAuthHelpers = [
+    "for path in /bin/su /usr/bin/su /bin/sg /usr/bin/sg /usr/bin/newgrp /usr/bin/passwd /usr/bin/chsh /usr/bin/chfn /usr/bin/gpasswd; do",
+    'if [ -e "$path" ]; then chmod u-s "$path"; fi;',
+    "done",
+  ].join(" ");
+  const hardenPrivilegedExecutableDirs = [
+    "install -d -o root -g root -m 755 /opt/bin /usr/local/bin",
+    "chown root:root /opt/bin /usr/local/bin",
+    "chmod 755 /opt/bin /usr/local/bin",
+  ].join(" && ");
+  const assertNoEmptyPasswordAccounts = [
+    `if getent shadow | awk -F: '$2 == "" {print $1}' | grep -q .; then`,
+    "echo 'empty-password local accounts must not exist' >&2;",
+    "exit 1;",
+    "fi",
+  ].join(" ");
+  const assertNoPrivilegedGroupMembers = [
+    "for group in sudo admin wheel; do",
+    "members=$(getent group \"$group\" | awk -F: '{print $4}') || continue;",
+    'old_ifs="$IFS";',
+    "IFS=,;",
+    "for member in $members; do",
+    'if [ -n "$member" ] && [ "$member" != root ]; then echo "privileged group $group must not include $member" >&2; exit 1; fi;',
+    "done;",
+    'IFS="$old_ifs";',
+    "done",
+  ].join(" ");
+  const assertNoPasswordlessSudoers = [
+    "if grep -RIsnE '^[[:space:]]*[^#].*NOPASSWD[[:space:]]*:[[:space:]]*ALL' /etc/sudoers /etc/sudoers.d 2>/dev/null | grep -q .; then",
+    "echo 'passwordless unrestricted sudoers entries must not exist' >&2;",
+    "exit 1;",
+    "fi",
+  ].join(" ");
+  const assertLocalAuthHelpersNotSetuid = [
+    "for path in /bin/su /usr/bin/su /bin/sg /usr/bin/sg /usr/bin/newgrp /usr/bin/passwd /usr/bin/chsh /usr/bin/chfn /usr/bin/gpasswd; do",
+    'if [ -e "$path" ] && [ -u "$path" ]; then echo "local auth helper must not be setuid: $path" >&2; exit 1; fi;',
+    "done",
+  ].join(" ");
+  const assertPrivilegedExecutableDirsSafe = [
+    "for dir in /opt/bin /usr/local/bin; do",
+    'if [ "$(stat -c \'%U:%G\' "$dir")" != root:root ] || find "$dir" -maxdepth 0 -perm /022 | grep -q .; then',
+    'echo "privileged executable directory must be root-owned and not group/other writable: $dir" >&2;',
+    "exit 1;",
+    "fi;",
+    "done",
+  ].join(" ");
+
+  return [
+    lockRootPassword,
+    lockEmptyPasswordAccounts,
+    lockProviderUser,
+    removePrivilegedGroupMembers,
+    removePasswordlessSudoersRules,
+    removeSudoBinary,
+    hardenLocalAuthHelpers,
+    hardenPrivilegedExecutableDirs,
+    assertNoEmptyPasswordAccounts,
+    assertNoPrivilegedGroupMembers,
+    assertNoPasswordlessSudoers,
+    assertLocalAuthHelpersNotSetuid,
+    assertPrivilegedExecutableDirsSafe,
+    "if command -v sudo >/dev/null 2>&1; then echo 'sudo must not be installed in sandbox images' >&2; exit 1; fi",
+  ].join(" && ");
+}

--- a/front/lib/api/sandbox/hardening.ts
+++ b/front/lib/api/sandbox/hardening.ts
@@ -76,6 +76,14 @@ export function getLocalAccountPrivilegeHardeningCommand(): string {
     'IFS="$old_ifs";',
     "done",
   ].join(" ");
+  const assertNoPrivilegedPrimaryGroups = [
+    "for group in sudo admin wheel; do",
+    "gid=$(getent group \"$group\" | awk -F: '{print $3}') || continue;",
+    '[ -z "$gid" ] && continue;',
+    "primary_members=$(getent passwd | awk -F: -v gid=\"$gid\" '$3 != 0 && $4 == gid {print $1}');",
+    'if [ -n "$primary_members" ]; then echo "privileged primary group $group must not include $primary_members" >&2; exit 1; fi;',
+    "done",
+  ].join(" ");
   const assertNoPasswordlessSudoers = [
     "if grep -RIsnE '^[[:space:]]*[^#].*NOPASSWD[[:space:]]*:[[:space:]]*ALL' /etc/sudoers /etc/sudoers.d 2>/dev/null | grep -q .; then",
     "echo 'passwordless unrestricted sudoers entries must not exist' >&2;",
@@ -107,6 +115,7 @@ export function getLocalAccountPrivilegeHardeningCommand(): string {
     hardenPrivilegedExecutableDirs,
     assertNoEmptyPasswordAccounts,
     assertNoPrivilegedGroupMembers,
+    assertNoPrivilegedPrimaryGroups,
     assertNoPasswordlessSudoers,
     assertLocalAuthHelpersNotSetuid,
     assertPrivilegedExecutableDirsSafe,

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -68,7 +68,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.27",
+      tag: "0.8.28",
     });
   });
 
@@ -135,6 +135,7 @@ describe("sandbox image registry", () => {
         "install -d -o root -g root -m 755 /opt/bin /usr/local/bin"
       );
       expect(command).toContain("empty-password local accounts must not exist");
+      expect(command).toContain("privileged primary group");
       expect(command).toContain(
         "passwordless unrestricted sudoers entries must not exist"
       );

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -131,11 +131,17 @@ describe("sandbox image registry", () => {
       expect(command).toContain("/usr/bin/su");
       expect(command).toContain("/usr/bin/passwd");
       expect(command).toContain("chmod u-s");
+      expect(command).toContain(
+        "install -d -o root -g root -m 755 /opt/bin /usr/local/bin"
+      );
       expect(command).toContain("empty-password local accounts must not exist");
       expect(command).toContain(
         "passwordless unrestricted sudoers entries must not exist"
       );
       expect(command).toContain("local auth helper must not be setuid");
+      expect(command).toContain(
+        "privileged executable directory must be root-owned"
+      );
     }
     expect(firstHardeningIndex).toBeGreaterThanOrEqual(0);
     expect(agentProxiedIndex).toBeGreaterThan(firstHardeningIndex);

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -16,7 +16,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.27";
+const DUST_BASE_IMAGE_VERSION = "0.8.28";
 const DSBX_CLI_VERSION = "0.1.23";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -1,3 +1,4 @@
+import { getLocalAccountPrivilegeHardeningCommand } from "@app/lib/api/sandbox/hardening";
 import { PROFILE_DIR } from "@app/lib/api/sandbox/image/profile";
 import { buildDustToolsBinary } from "@app/lib/api/sandbox/image/profile/build";
 import { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
@@ -170,107 +171,6 @@ function getAgentProxiedSetupCommand(): string {
     "chmod g+ws /home/agent /home/agent/.local /home/agent/.local/bin /files/conversation /files/project",
     "setfacl -R -d -m g::rwx /home/agent /home/agent/.local /home/agent/.local/bin /files/conversation /files/project",
     "setfacl -R -m g::rwx /home/agent /home/agent/.local /home/agent/.local/bin /files/conversation /files/project",
-  ].join(" && ");
-}
-
-function getLocalAccountPrivilegeHardeningCommand(): string {
-  const lockRootPassword = [
-    "if getent passwd root >/dev/null 2>&1; then",
-    "passwd -l root >/dev/null 2>&1 || usermod --lock root >/dev/null 2>&1 || true;",
-    "fi",
-  ].join(" ");
-  const lockEmptyPasswordAccounts = [
-    "if getent shadow >/dev/null 2>&1; then",
-    `getent shadow | awk -F: '$2 == "" {print $1}' | while IFS= read -r account; do`,
-    '[ -z "$account" ] && continue;',
-    'passwd -l "$account" >/dev/null 2>&1 || usermod --lock "$account" >/dev/null 2>&1 || true;',
-    "done;",
-    "fi",
-  ].join(" ");
-  const lockProviderUser = [
-    "if getent passwd user >/dev/null 2>&1; then",
-    "usermod --lock --expiredate 1 --shell /usr/sbin/nologin user",
-    "&& for group in sudo admin wheel; do",
-    'if getent group "$group" >/dev/null 2>&1; then',
-    'gpasswd -d user "$group" >/dev/null 2>&1 || true;',
-    "fi;",
-    "done;",
-    "fi",
-  ].join(" ");
-  const removePrivilegedGroupMembers = [
-    "for group in sudo admin wheel; do",
-    "members=$(getent group \"$group\" | awk -F: '{print $4}') || continue;",
-    'old_ifs="$IFS";',
-    "IFS=,;",
-    "for member in $members; do",
-    '[ -z "$member" ] || [ "$member" = root ] || gpasswd -d "$member" "$group" >/dev/null 2>&1 || true;',
-    "done;",
-    'IFS="$old_ifs";',
-    "done",
-  ].join(" ");
-  const removePasswordlessSudoersRules = [
-    "if [ -f /etc/sudoers ]; then",
-    "sed -i -E '/^[[:space:]]*#/!{/NOPASSWD[[:space:]]*:[[:space:]]*ALL/d;}' /etc/sudoers;",
-    "fi",
-    "&& if [ -d /etc/sudoers.d ]; then",
-    "find /etc/sudoers.d -maxdepth 1 -type f",
-    "-exec sed -i -E '/^[[:space:]]*#/!{/NOPASSWD[[:space:]]*:[[:space:]]*ALL/d;}' {} +;",
-    "fi",
-  ].join(" ");
-  const removeSudoBinary = [
-    "if command -v sudo >/dev/null 2>&1; then",
-    "DEBIAN_FRONTEND=noninteractive apt-get purge -y sudo >/dev/null 2>&1",
-    '|| { sudo_path=$(command -v sudo); chmod u-s "$sudo_path"; mv "$sudo_path" "$sudo_path.disabled-by-dust"; };',
-    "hash -r 2>/dev/null || true;",
-    "fi",
-  ].join(" ");
-  const hardenLocalAuthHelpers = [
-    "for path in /bin/su /usr/bin/su /bin/sg /usr/bin/sg /usr/bin/newgrp /usr/bin/passwd /usr/bin/chsh /usr/bin/chfn /usr/bin/gpasswd; do",
-    'if [ -e "$path" ]; then chmod u-s "$path"; fi;',
-    "done",
-  ].join(" ");
-  const assertNoEmptyPasswordAccounts = [
-    `if getent shadow | awk -F: '$2 == "" {print $1}' | grep -q .; then`,
-    "echo 'empty-password local accounts must not exist' >&2;",
-    "exit 1;",
-    "fi",
-  ].join(" ");
-  const assertNoPrivilegedGroupMembers = [
-    "for group in sudo admin wheel; do",
-    "members=$(getent group \"$group\" | awk -F: '{print $4}') || continue;",
-    'old_ifs="$IFS";',
-    "IFS=,;",
-    "for member in $members; do",
-    'if [ -n "$member" ] && [ "$member" != root ]; then echo "privileged group $group must not include $member" >&2; exit 1; fi;',
-    "done;",
-    'IFS="$old_ifs";',
-    "done",
-  ].join(" ");
-  const assertNoPasswordlessSudoers = [
-    "if grep -RIsnE '^[[:space:]]*[^#].*NOPASSWD[[:space:]]*:[[:space:]]*ALL' /etc/sudoers /etc/sudoers.d 2>/dev/null | grep -q .; then",
-    "echo 'passwordless unrestricted sudoers entries must not exist' >&2;",
-    "exit 1;",
-    "fi",
-  ].join(" ");
-  const assertLocalAuthHelpersNotSetuid = [
-    "for path in /bin/su /usr/bin/su /bin/sg /usr/bin/sg /usr/bin/newgrp /usr/bin/passwd /usr/bin/chsh /usr/bin/chfn /usr/bin/gpasswd; do",
-    'if [ -e "$path" ] && [ -u "$path" ]; then echo "local auth helper must not be setuid: $path" >&2; exit 1; fi;',
-    "done",
-  ].join(" ");
-
-  return [
-    lockRootPassword,
-    lockEmptyPasswordAccounts,
-    lockProviderUser,
-    removePrivilegedGroupMembers,
-    removePasswordlessSudoersRules,
-    removeSudoBinary,
-    hardenLocalAuthHelpers,
-    assertNoEmptyPasswordAccounts,
-    assertNoPrivilegedGroupMembers,
-    assertNoPasswordlessSudoers,
-    assertLocalAuthHelpersNotSetuid,
-    "if command -v sudo >/dev/null 2>&1; then echo 'sudo must not be installed in sandbox images' >&2; exit 1; fi",
   ].join(" && ");
 }
 

--- a/front/lib/api/sandbox/providers/e2b.test.ts
+++ b/front/lib/api/sandbox/providers/e2b.test.ts
@@ -4,6 +4,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const {
   mockCommandHandleWait,
   mockConnect,
+  mockCreate,
+  mockCreateCommandRun,
+  mockKill,
+  mockLoggerError,
   mockLoggerInfo,
   mockRun,
   mockSendStdin,
@@ -12,6 +16,10 @@ const {
 } = vi.hoisted(() => ({
   mockCommandHandleWait: vi.fn(),
   mockConnect: vi.fn(),
+  mockCreate: vi.fn(),
+  mockCreateCommandRun: vi.fn(),
+  mockKill: vi.fn(),
+  mockLoggerError: vi.fn(),
   mockLoggerInfo: vi.fn(),
   mockRun: vi.fn(),
   mockSendStdin: vi.fn(),
@@ -21,6 +29,7 @@ const {
 
 vi.mock("@app/logger/logger", () => ({
   default: {
+    error: mockLoggerError,
     info: mockLoggerInfo,
   },
 }));
@@ -60,8 +69,8 @@ vi.mock("e2b", () => {
     NotFoundError,
     Sandbox: {
       connect: mockConnect,
-      create: vi.fn(),
-      kill: vi.fn(),
+      create: mockCreate,
+      kill: mockKill,
     },
   };
 });
@@ -89,12 +98,89 @@ describe("E2BSandboxProvider", () => {
     });
     mockSendStdin.mockResolvedValue(undefined);
     mockCloseStdin.mockResolvedValue(undefined);
+    mockCreateCommandRun.mockResolvedValue({
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+    });
+    mockCreate.mockResolvedValue({
+      sandboxId: "sandbox-id",
+      commands: {
+        run: mockCreateCommandRun,
+      },
+    });
+    mockKill.mockResolvedValue(undefined);
     mockConnect.mockResolvedValue({
       commands: {
         run: mockRun,
         sendStdin: mockSendStdin,
         closeStdin: mockCloseStdin,
       },
+    });
+  });
+
+  it("hardens E2B-created local accounts before returning a sandbox", async () => {
+    const provider = new E2BSandboxProvider({
+      apiKey: "api-key",
+      domain: undefined,
+    });
+
+    const result = await provider.create(
+      {
+        imageId: { imageName: "dust-base", tag: "0.8.27" },
+        network: { mode: "deny_all" },
+        resources: { vcpu: 2, memoryMb: 2048 },
+      },
+      { workspaceId: "workspace-id" }
+    );
+
+    expect(result).toEqual(new Ok({ providerId: "sandbox-id" }));
+    expect(mockCreateCommandRun).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "usermod --lock --expiredate 1 --shell /usr/sbin/nologin user"
+      ),
+      {
+        timeoutMs: 120_000,
+        user: "root",
+      }
+    );
+    expect(mockCreateCommandRun.mock.calls[0][0]).toContain(
+      "sudo must not be installed in sandbox images"
+    );
+    expect(mockCreateCommandRun.mock.calls[0][0]).toContain(
+      "install -d -o root -g root -m 755 /opt/bin /usr/local/bin"
+    );
+    expect(mockKill).not.toHaveBeenCalled();
+  });
+
+  it("kills a sandbox if local account hardening fails after create", async () => {
+    mockCreateCommandRun.mockResolvedValueOnce({
+      exitCode: 1,
+      stdout: "",
+      stderr: "user still in sudo",
+    });
+    const provider = new E2BSandboxProvider({
+      apiKey: "api-key",
+      domain: undefined,
+    });
+
+    const result = await provider.create(
+      {
+        imageId: { imageName: "dust-base", tag: "0.8.27" },
+        network: { mode: "deny_all" },
+        resources: { vcpu: 2, memoryMb: 2048 },
+      },
+      { workspaceId: "workspace-id" }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain(
+        "E2B sandbox local account hardening failed"
+      );
+    }
+    expect(mockKill).toHaveBeenCalledWith("sandbox-id", {
+      apiKey: "api-key",
     });
   });
 

--- a/front/lib/api/sandbox/providers/e2b.test.ts
+++ b/front/lib/api/sandbox/providers/e2b.test.ts
@@ -75,6 +75,8 @@ vi.mock("e2b", () => {
   };
 });
 
+import { CommandExitError } from "e2b";
+
 import { E2BSandboxProvider } from "./e2b";
 
 describe("E2BSandboxProvider", () => {
@@ -127,7 +129,7 @@ describe("E2BSandboxProvider", () => {
 
     const result = await provider.create(
       {
-        imageId: { imageName: "dust-base", tag: "0.8.27" },
+        imageId: { imageName: "dust-base", tag: "0.8.28" },
         network: { mode: "deny_all" },
         resources: { vcpu: 2, memoryMb: 2048 },
       },
@@ -150,6 +152,9 @@ describe("E2BSandboxProvider", () => {
     expect(mockCreateCommandRun.mock.calls[0][0]).toContain(
       "install -d -o root -g root -m 755 /opt/bin /usr/local/bin"
     );
+    expect(mockCreateCommandRun.mock.calls[0][0]).toContain(
+      "privileged primary group"
+    );
     expect(mockKill).not.toHaveBeenCalled();
   });
 
@@ -166,7 +171,7 @@ describe("E2BSandboxProvider", () => {
 
     const result = await provider.create(
       {
-        imageId: { imageName: "dust-base", tag: "0.8.27" },
+        imageId: { imageName: "dust-base", tag: "0.8.28" },
         network: { mode: "deny_all" },
         resources: { vcpu: 2, memoryMb: 2048 },
       },
@@ -177,6 +182,42 @@ describe("E2BSandboxProvider", () => {
     if (result.isErr()) {
       expect(result.error.message).toContain(
         "E2B sandbox local account hardening failed"
+      );
+    }
+    expect(mockKill).toHaveBeenCalledWith("sandbox-id", {
+      apiKey: "api-key",
+    });
+  });
+
+  it("preserves hardening context when the E2B SDK throws a command exit error", async () => {
+    mockCreateCommandRun.mockRejectedValueOnce(
+      new CommandExitError({
+        exitCode: 1,
+        stdout: "",
+        stderr: "privileged primary group sudo must not include user",
+      })
+    );
+    const provider = new E2BSandboxProvider({
+      apiKey: "api-key",
+      domain: undefined,
+    });
+
+    const result = await provider.create(
+      {
+        imageId: { imageName: "dust-base", tag: "0.8.28" },
+        network: { mode: "deny_all" },
+        resources: { vcpu: 2, memoryMb: 2048 },
+      },
+      { workspaceId: "workspace-id" }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain(
+        "E2B sandbox local account hardening failed with exit code 1"
+      );
+      expect(result.error.message).toContain(
+        "privileged primary group sudo must not include user"
       );
     }
     expect(mockKill).toHaveBeenCalledWith("sandbox-id", {

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -1,3 +1,4 @@
+import { getLocalAccountPrivilegeHardeningCommand } from "@app/lib/api/sandbox/hardening";
 import {
   formatSandboxImageId,
   type NetworkPolicy,
@@ -33,6 +34,7 @@ const SANDBOX_LIFETIME_MS = 24 * ONE_HOUR_MS;
 
 /** Timeout for individual API calls to E2B (create, connect, etc.). */
 const REQUEST_TIMEOUT_MS = 30_000;
+const LOCAL_ACCOUNT_HARDENING_TIMEOUT_MS = 120_000;
 
 const ALL_TRAFFIC = "0.0.0.0/0";
 
@@ -163,6 +165,35 @@ export class E2BSandboxProvider implements SandboxProvider {
               : { allowPublicTraffic: false },
           });
         } catch (err) {
+          return new Err(normalizeError(err));
+        }
+
+        try {
+          const hardeningResult = await sandbox.commands.run(
+            getLocalAccountPrivilegeHardeningCommand(),
+            {
+              timeoutMs: LOCAL_ACCOUNT_HARDENING_TIMEOUT_MS,
+              user: "root",
+            }
+          );
+          if (hardeningResult.exitCode !== 0) {
+            throw new Error(
+              `E2B sandbox local account hardening failed: ${hardeningResult.stderr}`
+            );
+          }
+        } catch (err) {
+          try {
+            await Sandbox.kill(sandbox.sandboxId, this.connectionOpts());
+          } catch (killErr) {
+            logger.error(
+              {
+                err: normalizeError(killErr),
+                sandboxId: sandbox.sandboxId,
+                templateId,
+              },
+              "Failed to kill E2B sandbox after local account hardening failure"
+            );
+          }
           return new Err(normalizeError(err));
         }
 

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -38,6 +38,22 @@ const LOCAL_ACCOUNT_HARDENING_TIMEOUT_MS = 120_000;
 
 const ALL_TRAFFIC = "0.0.0.0/0";
 
+function formatCommandOutput(stdout: string, stderr: string): string {
+  return [stderr, stdout].filter((output) => output.length > 0).join("\n");
+}
+
+function getLocalAccountHardeningError(result: ExecResult): Error {
+  const output = formatCommandOutput(result.stdout, result.stderr);
+  return new Error(
+    [
+      `E2B sandbox local account hardening failed with exit code ${result.exitCode}`,
+      output,
+    ]
+      .filter((message) => message.length > 0)
+      .join(":\n")
+  );
+}
+
 interface E2BNetworkOpts {
   allowOut?: string[];
   denyOut?: string[];
@@ -130,6 +146,24 @@ export class E2BSandboxProvider implements SandboxProvider {
     };
   }
 
+  private async killSandboxAfterLocalAccountHardeningFailure(
+    sandboxId: string,
+    templateId: string
+  ): Promise<void> {
+    try {
+      await Sandbox.kill(sandboxId, this.connectionOpts());
+    } catch (killErr) {
+      logger.error(
+        {
+          err: normalizeError(killErr),
+          sandboxId,
+          templateId,
+        },
+        "Failed to kill E2B sandbox after local account hardening failure"
+      );
+    }
+  }
+
   async create(
     config: SandboxCreateConfig,
     tracingOpts: { workspaceId: string }
@@ -168,33 +202,43 @@ export class E2BSandboxProvider implements SandboxProvider {
           return new Err(normalizeError(err));
         }
 
+        let hardeningResult: ExecResult;
         try {
-          const hardeningResult = await sandbox.commands.run(
+          const result = await sandbox.commands.run(
             getLocalAccountPrivilegeHardeningCommand(),
             {
               timeoutMs: LOCAL_ACCOUNT_HARDENING_TIMEOUT_MS,
               user: "root",
             }
           );
-          if (hardeningResult.exitCode !== 0) {
-            throw new Error(
-              `E2B sandbox local account hardening failed: ${hardeningResult.stderr}`
-            );
-          }
+          hardeningResult = {
+            exitCode: result.exitCode,
+            stdout: result.stdout,
+            stderr: result.stderr,
+          };
         } catch (err) {
-          try {
-            await Sandbox.kill(sandbox.sandboxId, this.connectionOpts());
-          } catch (killErr) {
-            logger.error(
-              {
-                err: normalizeError(killErr),
-                sandboxId: sandbox.sandboxId,
-                templateId,
-              },
-              "Failed to kill E2B sandbox after local account hardening failure"
-            );
-          }
-          return new Err(normalizeError(err));
+          const createError =
+            err instanceof CommandExitError
+              ? getLocalAccountHardeningError({
+                  exitCode: err.exitCode,
+                  stdout: err.stdout,
+                  stderr: err.stderr,
+                })
+              : normalizeError(err);
+
+          await this.killSandboxAfterLocalAccountHardeningFailure(
+            sandbox.sandboxId,
+            templateId
+          );
+          return new Err(createError);
+        }
+
+        if (hardeningResult.exitCode !== 0) {
+          await this.killSandboxAfterLocalAccountHardeningFailure(
+            sandbox.sandboxId,
+            templateId
+          );
+          return new Err(getLocalAccountHardeningError(hardeningResult));
         }
 
         logger.info(

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -38,12 +38,10 @@ const LOCAL_ACCOUNT_HARDENING_TIMEOUT_MS = 120_000;
 
 const ALL_TRAFFIC = "0.0.0.0/0";
 
-function formatCommandOutput(stdout: string, stderr: string): string {
-  return [stderr, stdout].filter((output) => output.length > 0).join("\n");
-}
-
 function getLocalAccountHardeningError(result: ExecResult): Error {
-  const output = formatCommandOutput(result.stdout, result.stderr);
+  const output = [result.stderr, result.stdout]
+    .filter((text) => text.length > 0)
+    .join("\n");
   return new Error(
     [
       `E2B sandbox local account hardening failed with exit code ${result.exitCode}`,

--- a/front/scripts/sandbox_security_check.test.ts
+++ b/front/scripts/sandbox_security_check.test.ts
@@ -38,6 +38,11 @@ describe("sandbox security check assertions", () => {
     expect(() =>
       assertNoPrivilegedGroupMembers("sudo:x:27:user,agent\n")
     ).toThrow("privileged group sudo still has non-root members");
+    expect(() =>
+      assertNoPrivilegedGroupMembers(
+        "user:x:1001:27::/home/user:/bin/bash\nsudo:x:27:\n"
+      )
+    ).toThrow("privileged group sudo is the primary group");
   });
 
   test("detects passwordless sudoers entries", () => {

--- a/front/scripts/sandbox_security_check.test.ts
+++ b/front/scripts/sandbox_security_check.test.ts
@@ -5,11 +5,18 @@ import {
   assertNoPrivilegedGroupMembers,
   assertPrivilegedDirsSafe,
   assertSudoAbsent,
+  buildBashCommand,
   containsUnrestrictedSudo,
 } from "@app/scripts/sandbox_security_check";
 import { describe, expect, test } from "vitest";
 
 describe("sandbox security check assertions", () => {
+  test("runs audit scripts in a non-login bash shell", () => {
+    expect(buildBashCommand("echo 'ok'")).toBe(
+      "/bin/bash -c 'echo '\\''ok'\\'''"
+    );
+  });
+
   test("detects unrestricted passwordless sudo while ignoring comments", () => {
     expect(
       containsUnrestrictedSudo("/etc/sudoers:10:user ALL=(ALL) NOPASSWD: ALL")

--- a/front/scripts/sandbox_security_check.ts
+++ b/front/scripts/sandbox_security_check.ts
@@ -45,6 +45,10 @@ function combinedOutput(result: ExecResult): string {
   return [result.stdout, result.stderr].filter((s) => s.length > 0).join("\n");
 }
 
+export function buildBashCommand(script: string): string {
+  return `/bin/bash -c ${shellQuote(script)}`;
+}
+
 async function runCommand(
   provider: E2BSandboxProvider,
   providerId: string,
@@ -72,15 +76,10 @@ async function runBashScript(
   script: string,
   options: { user: string; timeoutMs?: number }
 ): Promise<ExecResult> {
-  return runCommand(
-    provider,
-    providerId,
-    `/bin/bash -lc ${shellQuote(script)}`,
-    {
-      timeoutMs: options.timeoutMs,
-      user: options.user,
-    }
-  );
+  return runCommand(provider, providerId, buildBashCommand(script), {
+    timeoutMs: options.timeoutMs,
+    user: options.user,
+  });
 }
 
 function assertNoRootIdentity(label: string, result: ExecResult): void {
@@ -315,7 +314,7 @@ while IFS=: read -r name _uid _gid _gecos _home _shell; do
     fi
   fi
   rm -f "$out"
-done < <(getent passwd)
+done < <(getent passwd | awk -F: '$3 == 0 || $3 >= 1000')
 exit "$bad"
 `,
     { timeoutMs: 60_000, user: AGENT_PROXIED_USER }

--- a/front/scripts/sandbox_security_check.ts
+++ b/front/scripts/sandbox_security_check.ts
@@ -328,11 +328,14 @@ exit "$bad"
 }
 
 export function assertNoPrivilegedGroupMembers(output: string): void {
-  const groupPattern = /^(sudo|wheel|admin):[^:]*:[^:]*:(.*)$/gm;
+  const privilegedGroupIds = new Map<string, string>();
+  const groupPattern = /^(sudo|wheel|admin):[^:]*:([^:]*):(.*)$/gm;
   let match = groupPattern.exec(output);
 
   while (match) {
-    const members = match[2]
+    privilegedGroupIds.set(match[2], match[1]);
+
+    const members = match[3]
       .split(",")
       .map((member) => member.trim())
       .filter((member) => member.length > 0 && member !== "root");
@@ -346,6 +349,25 @@ export function assertNoPrivilegedGroupMembers(output: string): void {
     }
 
     match = groupPattern.exec(output);
+  }
+
+  for (const line of output.split("\n")) {
+    const fields = line.split(":");
+    if (fields.length < 4) {
+      continue;
+    }
+
+    const [name, , uid, gid] = fields;
+    if (name === "root" || uid === "0") {
+      continue;
+    }
+
+    const privilegedGroup = privilegedGroupIds.get(gid);
+    if (privilegedGroup) {
+      throw new Error(
+        `privileged group ${privilegedGroup} is the primary group for non-root account ${name}:\n${output}`
+      );
+    }
   }
 }
 


### PR DESCRIPTION
## Description

Follow-up to #26316 after the sandbox image CI check showed E2B recreates local account state at sandbox start. Run local account hardening immediately after `Sandbox.create` and kill the sandbox if hardening fails.

The shared hardening command also resets `/opt/bin` and `/usr/local/bin` to root-owned `755`, asserts non-root accounts cannot use privileged primary groups, and keeps the image build guard in sync. `dust-base` is bumped to `0.8.28`; `dsbx` stays at `0.1.23` because the CLI did not change.

The security check now runs audit scripts with non-login bash so `.bash_logout` cannot flip a clean probe to exit 1.

## Tests

Added provider and security-check coverage. Ran a real E2B runtime check against existing `dust-base_0-8-27`: `user` was locked and out of `sudo`, `/opt/bin` and `/usr/local/bin` were `root:root 755`, `su - root` failed, `su user -> sudo` failed, and the sandbox was destroyed.

Also ran `sandbox_image_check --json`, which reports `dust-base_0-8-28` in the missing-image build matrix for CI to build.

## Risk

Low. Runtime hardening happens before returning a provider id; if it fails, the sandbox is killed and create returns an error with the hardening command output.

## Deploy Plan

Standard deploy. The sandbox image workflow should build `dust-base_0-8-28` after merge.