### PR TITLE
Introduce DustFileSystem: canonical path abstraction for file operations

### DIFF
--- a/front/lib/api/file_system/backends/file_system_backend.ts
+++ b/front/lib/api/file_system/backends/file_system_backend.ts
@@ -19,7 +19,6 @@ export type { FileSystemEntry } from "@app/lib/api/file_system/types";
  * Every method that can fail returns `Result<T, DustFileSystemError>` so callers never need
  * try/catch. The backend owns the catch and maps storage exceptions to the appropriate code.
  */
-// TODO: Harmonize return types?
 export interface FileSystemBackend {
   /**
    * List entries under `scopedPath` (should end with `/` to list a prefix).
@@ -41,12 +40,17 @@ export interface FileSystemBackend {
   ): Promise<Result<Readable | null, DustFileSystemError>>;
 
   /**
-   * Returns metadata for the file at `scopedPath`, or `null` when the file does not exist.
-   * Does not throw; returns `null` on unexpected errors after logging.
+   * Returns `Ok(null)` when the file does not exist, `Ok(metadata)` on success.
+   * Returns `Err` on path or permission errors (including `invalid_path`).
    */
   stat(
     scopedPath: string
-  ): Promise<{ contentType: string; sizeBytes: number } | null>;
+  ): Promise<
+    Result<
+      { contentType: string; sizeBytes: number } | null,
+      DustFileSystemError
+    >
+  >;
 
   write(
     scopedPath: string,

--- a/front/lib/api/file_system/backends/file_system_backend.ts
+++ b/front/lib/api/file_system/backends/file_system_backend.ts
@@ -1,8 +1,11 @@
 import type { SandboxMountAdapter } from "@app/lib/api/file_system/sandbox/sandbox_mount_adapter";
 import type {
+  DustFileSystemError,
   FileSystemEntry,
   FileSystemMount,
 } from "@app/lib/api/file_system/types";
+import type { Result } from "@app/types/shared/result";
+import type { Readable } from "stream";
 
 export type { FileSystemEntry } from "@app/lib/api/file_system/types";
 
@@ -12,7 +15,11 @@ export type { FileSystemEntry } from "@app/lib/api/file_system/types";
  * All paths are scoped paths (`{scopedPrefix}/{relPath}`, e.g. `conversation-{cId}/report.pdf`).
  * Storage-specific translation is a private detail of each concrete backend.
  * A backend instance is workspace-scoped and created once per `DustFileSystem` factory call.
+ *
+ * Every method that can fail returns `Result<T, DustFileSystemError>` so callers never need
+ * try/catch. The backend owns the catch and maps storage exceptions to the appropriate code.
  */
+// TODO: Harmonize return types?
 export interface FileSystemBackend {
   /**
    * List entries under `scopedPath` (should end with `/` to list a prefix).
@@ -24,23 +31,46 @@ export interface FileSystemBackend {
     opts?: { maxFiles?: number; includeProcessed?: boolean }
   ): Promise<FileSystemEntry[]>;
 
-  /** Returns `null` when the file does not exist rather than throwing. */
-  read(scopedPath: string): Promise<Buffer | null>;
+  /**
+   * Returns `Ok(null)` when the file does not exist, `Ok(Readable)` on success.
+   * The caller is responsible for consuming and destroying the stream.
+   * Returns `Err` on path or permission errors.
+   */
+  read(
+    scopedPath: string
+  ): Promise<Result<Readable | null, DustFileSystemError>>;
+
+  /**
+   * Returns metadata for the file at `scopedPath`, or `null` when the file does not exist.
+   * Does not throw; returns `null` on unexpected errors after logging.
+   */
+  stat(
+    scopedPath: string
+  ): Promise<{ contentType: string; sizeBytes: number } | null>;
 
   write(
     scopedPath: string,
     content: Buffer | string,
     contentType: string
-  ): Promise<void>;
+  ): Promise<Result<void, DustFileSystemError>>;
 
-  /** Throws when the path does not exist unless `ignoreNotFound: true`. */
+  /**
+   * Returns `Err("not_found")` when the path does not exist and `ignoreNotFound` is false.
+   * Returns `Err("internal")` on unexpected storage errors.
+   */
   delete(
     scopedPath: string,
     opts?: { ignoreNotFound?: boolean }
-  ): Promise<void>;
+  ): Promise<Result<void, DustFileSystemError>>;
 
   /** Server-side copy. Does not delete the source. */
-  copy(src: string, dest: string): Promise<void>;
+  copy({
+    src,
+    dest,
+  }: {
+    src: string;
+    dest: string;
+  }): Promise<Result<void, DustFileSystemError>>;
 
   /**
    * Returns a short-lived signed URL for unauthenticated download.
@@ -49,7 +79,7 @@ export interface FileSystemBackend {
   getDownloadUrl(
     scopedPath: string,
     opts?: { expiresInMs?: number; fileName?: string }
-  ): Promise<string>;
+  ): Promise<Result<string, DustFileSystemError>>;
 
   /**
    * Create a sandbox mount adapter for the given mounts.

--- a/front/lib/api/file_system/backends/file_system_backend.ts
+++ b/front/lib/api/file_system/backends/file_system_backend.ts
@@ -1,0 +1,58 @@
+import type { FileSystemEntry, FileSystemMount } from "@app/lib/api/file_system/types";
+import type { SandboxMountAdapter } from "@app/lib/api/file_system/sandbox/sandbox_mount_adapter";
+
+export type { FileSystemEntry } from "@app/lib/api/file_system/types";
+
+/**
+ * Backend-agnostic file system interface.
+ *
+ * All paths are scoped paths (`{scopedPrefix}/{relPath}`, e.g. `conversation-{cId}/report.pdf`).
+ * Storage-specific translation is a private detail of each concrete backend.
+ * A backend instance is workspace-scoped and created once per `DustFileSystem` factory call.
+ */
+export interface FileSystemBackend {
+  /**
+   * List entries under `scopedPath` (should end with `/` to list a prefix).
+   * Returns an empty array when nothing exists under that path.
+   * `.processed.*` siblings are filtered out unless `includeProcessed` is true.
+   */
+  list(
+    scopedPath: string,
+    opts?: { maxFiles?: number; includeProcessed?: boolean }
+  ): Promise<FileSystemEntry[]>;
+
+  /** Returns `null` when the file does not exist rather than throwing. */
+  read(scopedPath: string): Promise<Buffer | null>;
+
+  write(
+    scopedPath: string,
+    content: Buffer | string,
+    contentType: string
+  ): Promise<void>;
+
+  /** Throws when the path does not exist unless `ignoreNotFound: true`. */
+  delete(
+    scopedPath: string,
+    opts?: { ignoreNotFound?: boolean }
+  ): Promise<void>;
+
+  /** Server-side copy. Does not delete the source. */
+  copy(src: string, dest: string): Promise<void>;
+
+  /**
+   * Returns a short-lived signed URL for unauthenticated download.
+   * `fileName` overrides the Content-Disposition filename hint.
+   */
+  getDownloadUrl(
+    scopedPath: string,
+    opts?: { expiresInMs?: number; fileName?: string }
+  ): Promise<string>;
+
+  /**
+   * Create a sandbox mount adapter for the given mounts.
+   * The adapter holds all backend-specific context so callers never see storage paths.
+   */
+  createSandboxAdapter(
+    mounts: ReadonlyArray<FileSystemMount>
+  ): SandboxMountAdapter;
+}

--- a/front/lib/api/file_system/backends/file_system_backend.ts
+++ b/front/lib/api/file_system/backends/file_system_backend.ts
@@ -1,5 +1,8 @@
-import type { FileSystemEntry, FileSystemMount } from "@app/lib/api/file_system/types";
 import type { SandboxMountAdapter } from "@app/lib/api/file_system/sandbox/sandbox_mount_adapter";
+import type {
+  FileSystemEntry,
+  FileSystemMount,
+} from "@app/lib/api/file_system/types";
 
 export type { FileSystemEntry } from "@app/lib/api/file_system/types";
 

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.test.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.test.ts
@@ -1,6 +1,7 @@
 import { GCSFileSystemBackend } from "@app/lib/api/file_system/backends/gcs_file_system_backend";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import logger from "@app/logger/logger";
+import { Readable } from "stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/api/config", () => ({
@@ -86,10 +87,16 @@ describe("GCSFileSystemBackend.list", () => {
     const prefix = `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/`;
     getAllFilesByPrefixMock.mockResolvedValue({
       files: [
-        gcsFile({ name: `${prefix}report.pdf`, contentType: "application/pdf" }),
+        gcsFile({
+          name: `${prefix}report.pdf`,
+          contentType: "application/pdf",
+        }),
         gcsFile({ name: `${prefix}report.processed.txt` }),
         gcsFile({ name: `${prefix}photo.jpg`, contentType: "image/jpeg" }),
-        gcsFile({ name: `${prefix}photo.processed.jpg`, contentType: "image/jpeg" }),
+        gcsFile({
+          name: `${prefix}photo.processed.jpg`,
+          contentType: "image/jpeg",
+        }),
       ],
       pageFetchCount: 1,
     });
@@ -107,7 +114,10 @@ describe("GCSFileSystemBackend.list", () => {
     const prefix = `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/`;
     getAllFilesByPrefixMock.mockResolvedValue({
       files: [
-        gcsFile({ name: `${prefix}report.pdf`, contentType: "application/pdf" }),
+        gcsFile({
+          name: `${prefix}report.pdf`,
+          contentType: "application/pdf",
+        }),
         gcsFile({ name: `${prefix}report.processed.txt` }),
       ],
       pageFetchCount: 1,
@@ -135,54 +145,23 @@ describe("GCSFileSystemBackend.list", () => {
     expect(entries[0].fileName).toBe("data.csv");
   });
 
-  it("sets thumbnailUrl for image content types (conversation)", async () => {
+  it("always leaves thumbnailUrl null (URL construction is a DustFileSystem concern)", async () => {
     const prefix = `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/`;
     getAllFilesByPrefixMock.mockResolvedValue({
-      files: [gcsFile({ name: `${prefix}photo.png`, contentType: "image/png" })],
+      files: [
+        gcsFile({ name: `${prefix}photo.png`, contentType: "image/png" }),
+        gcsFile({ name: `${prefix}data.csv`, contentType: "text/csv" }),
+      ],
       pageFetchCount: 1,
     });
 
     const entries = await makeBackend().list(`conversation-${CONV_ID}/`);
-    const entry = entries[0];
 
-    expect(entry.isDirectory).toBe(false);
-    if (!entry.isDirectory) {
-      expect(entry.thumbnailUrl).toBe(
-        `https://dust.tt/api/w/${WORKSPACE_ID}/assistant/conversations/${CONV_ID}/files/thumbnail` +
-          `?filePath=${encodeURIComponent(`conversation-${CONV_ID}/photo.png`)}`
-      );
-    }
-  });
-
-  it("leaves thumbnailUrl null for non-image content types", async () => {
-    const prefix = `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/`;
-    getAllFilesByPrefixMock.mockResolvedValue({
-      files: [gcsFile({ name: `${prefix}data.csv`, contentType: "text/csv" })],
-      pageFetchCount: 1,
-    });
-
-    const entries = await makeBackend().list(`conversation-${CONV_ID}/`);
-    const entry = entries[0];
-
-    expect(entry.isDirectory).toBe(false);
-    if (!entry.isDirectory) {
-      expect(entry.thumbnailUrl).toBeNull();
-    }
-  });
-
-  it("leaves thumbnailUrl null for pod entries", async () => {
-    const prefix = `w/${WORKSPACE_ID}/pods/${POD_ID}/files/`;
-    getAllFilesByPrefixMock.mockResolvedValue({
-      files: [gcsFile({ name: `${prefix}photo.png`, contentType: "image/png" })],
-      pageFetchCount: 1,
-    });
-
-    const entries = await makeBackend().list(`pod-${POD_ID}/`);
-    const entry = entries[0];
-
-    expect(entry.isDirectory).toBe(false);
-    if (!entry.isDirectory) {
-      expect(entry.thumbnailUrl).toBeNull();
+    for (const entry of entries) {
+      expect(entry.isDirectory).toBe(false);
+      if (!entry.isDirectory) {
+        expect(entry.thumbnailUrl).toBeNull();
+      }
     }
   });
 
@@ -209,7 +188,12 @@ describe("GCSFileSystemBackend.list", () => {
   it("sets fileId to null (pre-migration)", async () => {
     const prefix = `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/`;
     getAllFilesByPrefixMock.mockResolvedValue({
-      files: [gcsFile({ name: `${prefix}report.pdf`, contentType: "application/pdf" })],
+      files: [
+        gcsFile({
+          name: `${prefix}report.pdf`,
+          contentType: "application/pdf",
+        }),
+      ],
       pageFetchCount: 1,
     });
 
@@ -251,27 +235,48 @@ describe("GCSFileSystemBackend.list", () => {
 
 describe("GCSFileSystemBackend.read", () => {
   let existsMock: ReturnType<typeof vi.fn>;
-  let downloadMock: ReturnType<typeof vi.fn>;
+  let createReadStreamMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     existsMock = vi.fn().mockResolvedValue([true]);
-    downloadMock = vi.fn().mockResolvedValue([Buffer.from("hello")]);
+    createReadStreamMock = vi.fn(() => Readable.from(["hello"]));
     vi.mocked(getPrivateUploadBucket).mockReturnValue({
-      file: vi.fn(() => ({ exists: existsMock, download: downloadMock })),
+      file: vi.fn(() => ({
+        exists: existsMock,
+        createReadStream: createReadStreamMock,
+      })),
     } as unknown as ReturnType<typeof getPrivateUploadBucket>);
   });
 
-  it("returns file content for a valid conversation path", async () => {
-    const result = await makeBackend().read(`conversation-${CONV_ID}/report.pdf`);
-    expect(result).toEqual(Buffer.from("hello"));
+  async function collectStream(stream: NodeJS.ReadableStream): Promise<string> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) {
+      chunks.push(
+        Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string)
+      );
+    }
+    return Buffer.concat(chunks).toString("utf8");
+  }
+
+  it("returns a readable stream for a valid conversation path", async () => {
+    const result = await makeBackend().read(
+      `conversation-${CONV_ID}/report.pdf`
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk() && result.value !== null) {
+      expect(await collectStream(result.value)).toBe("hello");
+    }
   });
 
-  it("returns file content for a valid pod path", async () => {
+  it("returns a readable stream for a valid pod path", async () => {
     const result = await makeBackend().read(`pod-${POD_ID}/data.csv`);
-    expect(result).toEqual(Buffer.from("hello"));
+    expect(result.isOk()).toBe(true);
+    if (result.isOk() && result.value !== null) {
+      expect(await collectStream(result.value)).toBe("hello");
+    }
   });
 
-  it("reads from the correct GCS path", async () => {
+  it("opens the stream at the correct GCS path", async () => {
     const bucket = vi.mocked(getPrivateUploadBucket)();
     await makeBackend().read(`conversation-${CONV_ID}/nested/file.txt`);
 
@@ -280,15 +285,23 @@ describe("GCSFileSystemBackend.read", () => {
     );
   });
 
-  it("returns null when the file does not exist", async () => {
+  it("returns Ok(null) when the file does not exist", async () => {
     existsMock.mockResolvedValue([false]);
-    const result = await makeBackend().read(`conversation-${CONV_ID}/missing.txt`);
-    expect(result).toBeNull();
+    const result = await makeBackend().read(
+      `conversation-${CONV_ID}/missing.txt`
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBeNull();
+    }
   });
 
-  it("returns null for an unrecognised scoped path", async () => {
+  it("returns Err(invalid_path) for an unrecognised scoped path", async () => {
     const result = await makeBackend().read("unknown/file.txt");
-    expect(result).toBeNull();
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("invalid_path");
+    }
   });
 });
 
@@ -310,12 +323,18 @@ describe("GCSFileSystemBackend.write", () => {
     const content = Buffer.from("data");
     const bucket = vi.mocked(getPrivateUploadBucket)();
 
-    await makeBackend().write(`conversation-${CONV_ID}/report.txt`, content, "text/plain");
+    await makeBackend().write(
+      `conversation-${CONV_ID}/report.txt`,
+      content,
+      "text/plain"
+    );
 
     expect(bucket.file).toHaveBeenCalledWith(
       `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/report.txt`
     );
-    expect(saveMock).toHaveBeenCalledWith(content, { contentType: "text/plain" });
+    expect(saveMock).toHaveBeenCalledWith(content, {
+      contentType: "text/plain",
+    });
   });
 
   it("writes to the correct GCS path for a pod", async () => {
@@ -331,14 +350,26 @@ describe("GCSFileSystemBackend.write", () => {
   });
 
   it("converts string content to a Buffer", async () => {
-    await makeBackend().write(`conversation-${CONV_ID}/notes.txt`, "hello", "text/plain");
-    expect(saveMock).toHaveBeenCalledWith(Buffer.from("hello"), { contentType: "text/plain" });
+    await makeBackend().write(
+      `conversation-${CONV_ID}/notes.txt`,
+      "hello",
+      "text/plain"
+    );
+    expect(saveMock).toHaveBeenCalledWith(Buffer.from("hello"), {
+      contentType: "text/plain",
+    });
   });
 
-  it("throws for an unrecognised scoped path", async () => {
-    await expect(
-      makeBackend().write("unknown/file.txt", Buffer.from("x"), "text/plain")
-    ).rejects.toThrow();
+  it("returns Err(invalid_path) for an unrecognised scoped path", async () => {
+    const result = await makeBackend().write(
+      "unknown/file.txt",
+      Buffer.from("x"),
+      "text/plain"
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("invalid_path");
+    }
   });
 });
 
@@ -356,7 +387,9 @@ describe("GCSFileSystemBackend.delete", () => {
     existsMock = vi.fn().mockResolvedValue([true]);
     deleteMock = vi.fn().mockResolvedValue(undefined);
     deleteByPrefixMock = vi.fn().mockResolvedValue(undefined);
-    getAllFilesByPrefixMock = vi.fn().mockResolvedValue({ files: [], pageFetchCount: 1 });
+    getAllFilesByPrefixMock = vi
+      .fn()
+      .mockResolvedValue({ files: [], pageFetchCount: 1 });
     vi.mocked(getPrivateUploadBucket).mockReturnValue({
       file: vi.fn(() => ({ exists: existsMock })),
       delete: deleteMock,
@@ -394,22 +427,30 @@ describe("GCSFileSystemBackend.delete", () => {
     );
   });
 
-  it("does not throw when ignoreNotFound is true and path is missing", async () => {
+  it("returns Ok when ignoreNotFound is true and path is missing", async () => {
     existsMock.mockResolvedValue([false]);
     getAllFilesByPrefixMock.mockResolvedValue({ files: [], pageFetchCount: 1 });
 
-    await expect(
-      makeBackend().delete(`conversation-${CONV_ID}/missing.txt`, { ignoreNotFound: true })
-    ).resolves.not.toThrow();
+    const result = await makeBackend().delete(
+      `conversation-${CONV_ID}/missing.txt`,
+      {
+        ignoreNotFound: true,
+      }
+    );
+    expect(result.isOk()).toBe(true);
   });
 
-  it("throws when path is not found and ignoreNotFound is false", async () => {
+  it("returns Err(not_found) when path is missing and ignoreNotFound is false", async () => {
     existsMock.mockResolvedValue([false]);
     getAllFilesByPrefixMock.mockResolvedValue({ files: [], pageFetchCount: 1 });
 
-    await expect(
-      makeBackend().delete(`conversation-${CONV_ID}/missing.txt`)
-    ).rejects.toThrow();
+    const result = await makeBackend().delete(
+      `conversation-${CONV_ID}/missing.txt`
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("not_found");
+    }
   });
 });
 
@@ -429,10 +470,10 @@ describe("GCSFileSystemBackend.copy", () => {
 
   it("copies from conversation to conversation with correct GCS paths", async () => {
     const destConvId = "conv-dest";
-    await makeBackend().copy(
-      `conversation-${CONV_ID}/report.pdf`,
-      `conversation-${destConvId}/report.pdf`
-    );
+    await makeBackend().copy({
+      src: `conversation-${CONV_ID}/report.pdf`,
+      dest: `conversation-${destConvId}/report.pdf`,
+    });
 
     expect(copyFileMock).toHaveBeenCalledWith(
       `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/report.pdf`,
@@ -441,10 +482,10 @@ describe("GCSFileSystemBackend.copy", () => {
   });
 
   it("copies from conversation to pod with correct GCS paths", async () => {
-    await makeBackend().copy(
-      `conversation-${CONV_ID}/report.pdf`,
-      `pod-${POD_ID}/report.pdf`
-    );
+    await makeBackend().copy({
+      src: `conversation-${CONV_ID}/report.pdf`,
+      dest: `pod-${POD_ID}/report.pdf`,
+    });
 
     expect(copyFileMock).toHaveBeenCalledWith(
       `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/report.pdf`,
@@ -452,16 +493,26 @@ describe("GCSFileSystemBackend.copy", () => {
     );
   });
 
-  it("throws for unrecognised source path", async () => {
-    await expect(
-      makeBackend().copy("unknown/src.pdf", `conversation-${CONV_ID}/dest.pdf`)
-    ).rejects.toThrow();
+  it("returns Err(invalid_path) for unrecognised source path", async () => {
+    const result = await makeBackend().copy({
+      src: "unknown/src.pdf",
+      dest: `conversation-${CONV_ID}/dest.pdf`,
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("invalid_path");
+    }
   });
 
-  it("throws for unrecognised destination path", async () => {
-    await expect(
-      makeBackend().copy(`conversation-${CONV_ID}/src.pdf`, "unknown/dest.pdf")
-    ).rejects.toThrow();
+  it("returns Err(invalid_path) for unrecognised destination path", async () => {
+    const result = await makeBackend().copy({
+      src: `conversation-${CONV_ID}/src.pdf`,
+      dest: "unknown/dest.pdf",
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("invalid_path");
+    }
   });
 });
 
@@ -473,29 +524,43 @@ describe("GCSFileSystemBackend.getDownloadUrl", () => {
   let getSignedUrlMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    getSignedUrlMock = vi.fn().mockResolvedValue("https://signed.example.com/file.pdf");
+    getSignedUrlMock = vi
+      .fn()
+      .mockResolvedValue("https://signed.example.com/file.pdf");
     vi.mocked(getPrivateUploadBucket).mockReturnValue({
       getSignedUrl: getSignedUrlMock,
     } as unknown as ReturnType<typeof getPrivateUploadBucket>);
   });
 
-  it("returns the signed URL for a conversation file", async () => {
-    const url = await makeBackend().getDownloadUrl(`conversation-${CONV_ID}/report.pdf`);
-    expect(url).toBe("https://signed.example.com/file.pdf");
+  it("returns Ok with the signed URL for a conversation file", async () => {
+    const result = await makeBackend().getDownloadUrl(
+      `conversation-${CONV_ID}/report.pdf`
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("https://signed.example.com/file.pdf");
+    }
     expect(getSignedUrlMock).toHaveBeenCalledWith(
       `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/report.pdf`
     );
   });
 
-  it("returns the signed URL for a pod file", async () => {
-    const url = await makeBackend().getDownloadUrl(`pod-${POD_ID}/data.csv`);
-    expect(url).toBe("https://signed.example.com/file.pdf");
+  it("returns Ok with the signed URL for a pod file", async () => {
+    const result = await makeBackend().getDownloadUrl(`pod-${POD_ID}/data.csv`);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("https://signed.example.com/file.pdf");
+    }
     expect(getSignedUrlMock).toHaveBeenCalledWith(
       `w/${WORKSPACE_ID}/pods/${POD_ID}/files/data.csv`
     );
   });
 
-  it("throws for an unrecognised scoped path", async () => {
-    await expect(makeBackend().getDownloadUrl("unknown/file.pdf")).rejects.toThrow();
+  it("returns Err(invalid_path) for an unrecognised scoped path", async () => {
+    const result = await makeBackend().getDownloadUrl("unknown/file.pdf");
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("invalid_path");
+    }
   });
 });

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.test.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.test.ts
@@ -1,0 +1,501 @@
+import { GCSFileSystemBackend } from "@app/lib/api/file_system/backends/gcs_file_system_backend";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import logger from "@app/logger/logger";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/config", () => ({
+  default: {
+    getApiBaseUrl: vi.fn(() => "https://dust.tt"),
+  },
+}));
+
+const WORKSPACE_ID = "ws123";
+const BUCKET = "test-bucket";
+const CONV_ID = "conv456";
+const POD_ID = "pod789";
+
+function makeBackend() {
+  return new GCSFileSystemBackend(WORKSPACE_ID, BUCKET);
+}
+
+function gcsFile({
+  name,
+  contentType = "text/plain",
+  size = 100,
+  updated,
+}: {
+  name: string;
+  contentType?: string;
+  size?: number;
+  updated?: string;
+}) {
+  return {
+    name,
+    metadata: {
+      contentType,
+      size: String(size),
+      updated: updated ?? new Date().toISOString(),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// list
+// ---------------------------------------------------------------------------
+
+describe("GCSFileSystemBackend.list", () => {
+  let getAllFilesByPrefixMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    getAllFilesByPrefixMock = vi.fn().mockResolvedValue({
+      files: [],
+      pageFetchCount: 1,
+    });
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      getAllFilesByPrefix: getAllFilesByPrefixMock,
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("queries the correct GCS prefix for a conversation mount", async () => {
+    const backend = makeBackend();
+    await backend.list(`conversation-${CONV_ID}/`);
+
+    expect(getAllFilesByPrefixMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prefix: `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/`,
+      })
+    );
+  });
+
+  it("queries the correct GCS prefix for a pod mount", async () => {
+    const backend = makeBackend();
+    await backend.list(`pod-${POD_ID}/`);
+
+    expect(getAllFilesByPrefixMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prefix: `w/${WORKSPACE_ID}/pods/${POD_ID}/files/`,
+      })
+    );
+  });
+
+  it("excludes .processed. siblings by default", async () => {
+    const prefix = `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/`;
+    getAllFilesByPrefixMock.mockResolvedValue({
+      files: [
+        gcsFile({ name: `${prefix}report.pdf`, contentType: "application/pdf" }),
+        gcsFile({ name: `${prefix}report.processed.txt` }),
+        gcsFile({ name: `${prefix}photo.jpg`, contentType: "image/jpeg" }),
+        gcsFile({ name: `${prefix}photo.processed.jpg`, contentType: "image/jpeg" }),
+      ],
+      pageFetchCount: 1,
+    });
+
+    const entries = await makeBackend().list(`conversation-${CONV_ID}/`);
+
+    const paths = entries.filter((e) => !e.isDirectory).map((e) => e.path);
+    expect(paths).toContain(`conversation-${CONV_ID}/report.pdf`);
+    expect(paths).toContain(`conversation-${CONV_ID}/photo.jpg`);
+    expect(paths).not.toContain(`conversation-${CONV_ID}/report.processed.txt`);
+    expect(paths).not.toContain(`conversation-${CONV_ID}/photo.processed.jpg`);
+  });
+
+  it("includes .processed. siblings when includeProcessed is true", async () => {
+    const prefix = `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/`;
+    getAllFilesByPrefixMock.mockResolvedValue({
+      files: [
+        gcsFile({ name: `${prefix}report.pdf`, contentType: "application/pdf" }),
+        gcsFile({ name: `${prefix}report.processed.txt` }),
+      ],
+      pageFetchCount: 1,
+    });
+
+    const entries = await makeBackend().list(`conversation-${CONV_ID}/`, {
+      includeProcessed: true,
+    });
+
+    const paths = entries.filter((e) => !e.isDirectory).map((e) => e.path);
+    expect(paths).toContain(`conversation-${CONV_ID}/report.pdf`);
+    expect(paths).toContain(`conversation-${CONV_ID}/report.processed.txt`);
+  });
+
+  it("returns canonical scoped paths in entries", async () => {
+    const prefix = `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/`;
+    getAllFilesByPrefixMock.mockResolvedValue({
+      files: [gcsFile({ name: `${prefix}subdir/data.csv` })],
+      pageFetchCount: 1,
+    });
+
+    const entries = await makeBackend().list(`conversation-${CONV_ID}/`);
+
+    expect(entries[0].path).toBe(`conversation-${CONV_ID}/subdir/data.csv`);
+    expect(entries[0].fileName).toBe("data.csv");
+  });
+
+  it("sets thumbnailUrl for image content types (conversation)", async () => {
+    const prefix = `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/`;
+    getAllFilesByPrefixMock.mockResolvedValue({
+      files: [gcsFile({ name: `${prefix}photo.png`, contentType: "image/png" })],
+      pageFetchCount: 1,
+    });
+
+    const entries = await makeBackend().list(`conversation-${CONV_ID}/`);
+    const entry = entries[0];
+
+    expect(entry.isDirectory).toBe(false);
+    if (!entry.isDirectory) {
+      expect(entry.thumbnailUrl).toBe(
+        `https://dust.tt/api/w/${WORKSPACE_ID}/assistant/conversations/${CONV_ID}/files/thumbnail` +
+          `?filePath=${encodeURIComponent(`conversation-${CONV_ID}/photo.png`)}`
+      );
+    }
+  });
+
+  it("leaves thumbnailUrl null for non-image content types", async () => {
+    const prefix = `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/`;
+    getAllFilesByPrefixMock.mockResolvedValue({
+      files: [gcsFile({ name: `${prefix}data.csv`, contentType: "text/csv" })],
+      pageFetchCount: 1,
+    });
+
+    const entries = await makeBackend().list(`conversation-${CONV_ID}/`);
+    const entry = entries[0];
+
+    expect(entry.isDirectory).toBe(false);
+    if (!entry.isDirectory) {
+      expect(entry.thumbnailUrl).toBeNull();
+    }
+  });
+
+  it("leaves thumbnailUrl null for pod entries", async () => {
+    const prefix = `w/${WORKSPACE_ID}/pods/${POD_ID}/files/`;
+    getAllFilesByPrefixMock.mockResolvedValue({
+      files: [gcsFile({ name: `${prefix}photo.png`, contentType: "image/png" })],
+      pageFetchCount: 1,
+    });
+
+    const entries = await makeBackend().list(`pod-${POD_ID}/`);
+    const entry = entries[0];
+
+    expect(entry.isDirectory).toBe(false);
+    if (!entry.isDirectory) {
+      expect(entry.thumbnailUrl).toBeNull();
+    }
+  });
+
+  it("separates folder placeholder entries from file entries", async () => {
+    const prefix = `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/`;
+    getAllFilesByPrefixMock.mockResolvedValue({
+      files: [
+        gcsFile({ name: `${prefix}subdir/` }),
+        gcsFile({ name: `${prefix}subdir/file.txt` }),
+      ],
+      pageFetchCount: 1,
+    });
+
+    const entries = await makeBackend().list(`conversation-${CONV_ID}/`);
+
+    const dirs = entries.filter((e) => e.isDirectory);
+    const files = entries.filter((e) => !e.isDirectory);
+    expect(dirs).toHaveLength(1);
+    expect(dirs[0].fileName).toBe("subdir");
+    expect(dirs[0].path).toBe(`conversation-${CONV_ID}/subdir`);
+    expect(files).toHaveLength(1);
+  });
+
+  it("sets fileId to null (pre-migration)", async () => {
+    const prefix = `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/`;
+    getAllFilesByPrefixMock.mockResolvedValue({
+      files: [gcsFile({ name: `${prefix}report.pdf`, contentType: "application/pdf" })],
+      pageFetchCount: 1,
+    });
+
+    const entries = await makeBackend().list(`conversation-${CONV_ID}/`);
+    const entry = entries[0];
+
+    expect(entry.isDirectory).toBe(false);
+    if (!entry.isDirectory) {
+      expect(entry.fileId).toBeNull();
+    }
+  });
+
+  it("logs a warning when GCS listing required multiple pages", async () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const prefix = `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/`;
+    getAllFilesByPrefixMock.mockResolvedValue({
+      files: [gcsFile({ name: `${prefix}report.pdf` })],
+      pageFetchCount: 3,
+    });
+
+    await makeBackend().list(`conversation-${CONV_ID}/`);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ pageFetchCount: 3 }),
+      expect.any(String)
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("returns empty array for unrecognised scoped path prefix", async () => {
+    const entries = await makeBackend().list("unknown-prefix/foo");
+    expect(entries).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// read
+// ---------------------------------------------------------------------------
+
+describe("GCSFileSystemBackend.read", () => {
+  let existsMock: ReturnType<typeof vi.fn>;
+  let downloadMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    existsMock = vi.fn().mockResolvedValue([true]);
+    downloadMock = vi.fn().mockResolvedValue([Buffer.from("hello")]);
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      file: vi.fn(() => ({ exists: existsMock, download: downloadMock })),
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+  });
+
+  it("returns file content for a valid conversation path", async () => {
+    const result = await makeBackend().read(`conversation-${CONV_ID}/report.pdf`);
+    expect(result).toEqual(Buffer.from("hello"));
+  });
+
+  it("returns file content for a valid pod path", async () => {
+    const result = await makeBackend().read(`pod-${POD_ID}/data.csv`);
+    expect(result).toEqual(Buffer.from("hello"));
+  });
+
+  it("reads from the correct GCS path", async () => {
+    const bucket = vi.mocked(getPrivateUploadBucket)();
+    await makeBackend().read(`conversation-${CONV_ID}/nested/file.txt`);
+
+    expect(bucket.file).toHaveBeenCalledWith(
+      `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/nested/file.txt`
+    );
+  });
+
+  it("returns null when the file does not exist", async () => {
+    existsMock.mockResolvedValue([false]);
+    const result = await makeBackend().read(`conversation-${CONV_ID}/missing.txt`);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for an unrecognised scoped path", async () => {
+    const result = await makeBackend().read("unknown/file.txt");
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// write
+// ---------------------------------------------------------------------------
+
+describe("GCSFileSystemBackend.write", () => {
+  let saveMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    saveMock = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      file: vi.fn(() => ({ save: saveMock })),
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+  });
+
+  it("writes to the correct GCS path for a conversation", async () => {
+    const content = Buffer.from("data");
+    const bucket = vi.mocked(getPrivateUploadBucket)();
+
+    await makeBackend().write(`conversation-${CONV_ID}/report.txt`, content, "text/plain");
+
+    expect(bucket.file).toHaveBeenCalledWith(
+      `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/report.txt`
+    );
+    expect(saveMock).toHaveBeenCalledWith(content, { contentType: "text/plain" });
+  });
+
+  it("writes to the correct GCS path for a pod", async () => {
+    const content = Buffer.from("csv data");
+    const bucket = vi.mocked(getPrivateUploadBucket)();
+
+    await makeBackend().write(`pod-${POD_ID}/data.csv`, content, "text/csv");
+
+    expect(bucket.file).toHaveBeenCalledWith(
+      `w/${WORKSPACE_ID}/pods/${POD_ID}/files/data.csv`
+    );
+    expect(saveMock).toHaveBeenCalledWith(content, { contentType: "text/csv" });
+  });
+
+  it("converts string content to a Buffer", async () => {
+    await makeBackend().write(`conversation-${CONV_ID}/notes.txt`, "hello", "text/plain");
+    expect(saveMock).toHaveBeenCalledWith(Buffer.from("hello"), { contentType: "text/plain" });
+  });
+
+  it("throws for an unrecognised scoped path", async () => {
+    await expect(
+      makeBackend().write("unknown/file.txt", Buffer.from("x"), "text/plain")
+    ).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// delete
+// ---------------------------------------------------------------------------
+
+describe("GCSFileSystemBackend.delete", () => {
+  let existsMock: ReturnType<typeof vi.fn>;
+  let deleteMock: ReturnType<typeof vi.fn>;
+  let deleteByPrefixMock: ReturnType<typeof vi.fn>;
+  let getAllFilesByPrefixMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    existsMock = vi.fn().mockResolvedValue([true]);
+    deleteMock = vi.fn().mockResolvedValue(undefined);
+    deleteByPrefixMock = vi.fn().mockResolvedValue(undefined);
+    getAllFilesByPrefixMock = vi.fn().mockResolvedValue({ files: [], pageFetchCount: 1 });
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      file: vi.fn(() => ({ exists: existsMock })),
+      delete: deleteMock,
+      deleteByPrefix: deleteByPrefixMock,
+      getAllFilesByPrefix: getAllFilesByPrefixMock,
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+  });
+
+  it("deletes a regular file at the correct GCS path", async () => {
+    await makeBackend().delete(`conversation-${CONV_ID}/report.txt`);
+
+    expect(deleteMock).toHaveBeenCalledWith(
+      `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/report.txt`,
+      { ignoreNotFound: false }
+    );
+  });
+
+  it("deletes a directory via deleteByPrefix when no direct file exists but dir entries do", async () => {
+    existsMock
+      .mockResolvedValueOnce([false]) // file itself does not exist
+      .mockResolvedValueOnce([false]); // dir placeholder does not exist either
+    getAllFilesByPrefixMock.mockResolvedValue({
+      files: [
+        gcsFile({
+          name: `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/subdir/file.txt`,
+        }),
+      ],
+      pageFetchCount: 1,
+    });
+
+    await makeBackend().delete(`conversation-${CONV_ID}/subdir`);
+
+    expect(deleteByPrefixMock).toHaveBeenCalledWith(
+      `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/subdir/`
+    );
+  });
+
+  it("does not throw when ignoreNotFound is true and path is missing", async () => {
+    existsMock.mockResolvedValue([false]);
+    getAllFilesByPrefixMock.mockResolvedValue({ files: [], pageFetchCount: 1 });
+
+    await expect(
+      makeBackend().delete(`conversation-${CONV_ID}/missing.txt`, { ignoreNotFound: true })
+    ).resolves.not.toThrow();
+  });
+
+  it("throws when path is not found and ignoreNotFound is false", async () => {
+    existsMock.mockResolvedValue([false]);
+    getAllFilesByPrefixMock.mockResolvedValue({ files: [], pageFetchCount: 1 });
+
+    await expect(
+      makeBackend().delete(`conversation-${CONV_ID}/missing.txt`)
+    ).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// copy
+// ---------------------------------------------------------------------------
+
+describe("GCSFileSystemBackend.copy", () => {
+  let copyFileMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    copyFileMock = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      copyFile: copyFileMock,
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+  });
+
+  it("copies from conversation to conversation with correct GCS paths", async () => {
+    const destConvId = "conv-dest";
+    await makeBackend().copy(
+      `conversation-${CONV_ID}/report.pdf`,
+      `conversation-${destConvId}/report.pdf`
+    );
+
+    expect(copyFileMock).toHaveBeenCalledWith(
+      `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/report.pdf`,
+      `w/${WORKSPACE_ID}/conversations/${destConvId}/files/report.pdf`
+    );
+  });
+
+  it("copies from conversation to pod with correct GCS paths", async () => {
+    await makeBackend().copy(
+      `conversation-${CONV_ID}/report.pdf`,
+      `pod-${POD_ID}/report.pdf`
+    );
+
+    expect(copyFileMock).toHaveBeenCalledWith(
+      `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/report.pdf`,
+      `w/${WORKSPACE_ID}/pods/${POD_ID}/files/report.pdf`
+    );
+  });
+
+  it("throws for unrecognised source path", async () => {
+    await expect(
+      makeBackend().copy("unknown/src.pdf", `conversation-${CONV_ID}/dest.pdf`)
+    ).rejects.toThrow();
+  });
+
+  it("throws for unrecognised destination path", async () => {
+    await expect(
+      makeBackend().copy(`conversation-${CONV_ID}/src.pdf`, "unknown/dest.pdf")
+    ).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getDownloadUrl
+// ---------------------------------------------------------------------------
+
+describe("GCSFileSystemBackend.getDownloadUrl", () => {
+  let getSignedUrlMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    getSignedUrlMock = vi.fn().mockResolvedValue("https://signed.example.com/file.pdf");
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      getSignedUrl: getSignedUrlMock,
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+  });
+
+  it("returns the signed URL for a conversation file", async () => {
+    const url = await makeBackend().getDownloadUrl(`conversation-${CONV_ID}/report.pdf`);
+    expect(url).toBe("https://signed.example.com/file.pdf");
+    expect(getSignedUrlMock).toHaveBeenCalledWith(
+      `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/report.pdf`
+    );
+  });
+
+  it("returns the signed URL for a pod file", async () => {
+    const url = await makeBackend().getDownloadUrl(`pod-${POD_ID}/data.csv`);
+    expect(url).toBe("https://signed.example.com/file.pdf");
+    expect(getSignedUrlMock).toHaveBeenCalledWith(
+      `w/${WORKSPACE_ID}/pods/${POD_ID}/files/data.csv`
+    );
+  });
+
+  it("throws for an unrecognised scoped path", async () => {
+    await expect(makeBackend().getDownloadUrl("unknown/file.pdf")).rejects.toThrow();
+  });
+});

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.ts
@@ -1,8 +1,11 @@
 import config from "@app/lib/api/config";
-import type { FileSystemEntry, FileSystemMount } from "@app/lib/api/file_system/types";
 import type { GCSMountTarget } from "@app/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter";
 import { GCSSandboxMountAdapter } from "@app/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter";
 import type { SandboxMountAdapter } from "@app/lib/api/file_system/sandbox/sandbox_mount_adapter";
+import type {
+  FileSystemEntry,
+  FileSystemMount,
+} from "@app/lib/api/file_system/types";
 import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import fileStorageConfig from "@app/lib/file_storage/config";
@@ -134,9 +137,15 @@ export class GCSFileSystemBackend implements FileSystemBackend {
     let rawFiles: { name: string; metadata: Record<string, unknown> }[];
 
     if (maxFiles !== undefined) {
-      rawFiles = await bucket.getFiles({ prefix: gcsPrefix, maxResults: maxFiles });
+      rawFiles = await bucket.getFiles({
+        prefix: gcsPrefix,
+        maxResults: maxFiles,
+      });
     } else {
-      const result = await bucket.getAllFilesByPrefix({ prefix: gcsPrefix, pageSize: 200 });
+      const result = await bucket.getAllFilesByPrefix({
+        prefix: gcsPrefix,
+        pageSize: 200,
+      });
       if (result.pageFetchCount > 1) {
         logger.warn(
           {
@@ -169,7 +178,10 @@ export class GCSFileSystemBackend implements FileSystemBackend {
     const folderEntries: FileSystemEntry[] = folderPlaceholders.flatMap((f) => {
       const trimmed = f.name.replace(/\/$/, "");
       const name = trimmed.split("/").pop() ?? "";
-      if (!name || (name.startsWith(".") && name !== TOOL_OUTPUTS_FOLDER_NAME)) {
+      if (
+        !name ||
+        (name.startsWith(".") && name !== TOOL_OUTPUTS_FOLDER_NAME)
+      ) {
         return [];
       }
       const scopedFilePath = this.fromGCSPath(trimmed);
@@ -214,7 +226,10 @@ export class GCSFileSystemBackend implements FileSystemBackend {
     return [...folderEntries, ...fileEntries];
   }
 
-  private buildThumbnailUrl(contentType: string, scopedFilePath: string): string | null {
+  private buildThumbnailUrl(
+    contentType: string,
+    scopedFilePath: string
+  ): string | null {
     if (!isSupportedImageContentType(contentType)) {
       return null;
     }
@@ -268,7 +283,9 @@ export class GCSFileSystemBackend implements FileSystemBackend {
   ): Promise<void> {
     const gcsPath = this.toGCSPath(scopedPath);
     if (!gcsPath) {
-      throw new Error(`GCSFileSystemBackend.write: unrecognised scoped path: ${scopedPath}`);
+      throw new Error(
+        `GCSFileSystemBackend.write: unrecognised scoped path: ${scopedPath}`
+      );
     }
     const buf = typeof content === "string" ? Buffer.from(content) : content;
     await getPrivateUploadBucket().file(gcsPath).save(buf, { contentType });
@@ -283,7 +300,9 @@ export class GCSFileSystemBackend implements FileSystemBackend {
       if (ignoreNotFound) {
         return;
       }
-      throw new Error(`GCSFileSystemBackend.delete: unrecognised scoped path: ${scopedPath}`);
+      throw new Error(
+        `GCSFileSystemBackend.delete: unrecognised scoped path: ${scopedPath}`
+      );
     }
 
     const bucket = getPrivateUploadBucket();
@@ -295,7 +314,10 @@ export class GCSFileSystemBackend implements FileSystemBackend {
 
     const dirPrefix = gcsPath.endsWith("/") ? gcsPath : `${gcsPath}/`;
     const [dirExists] = await bucket.file(dirPrefix).exists();
-    const { files: sample } = await bucket.getAllFilesByPrefix({ prefix: dirPrefix, pageSize: 1 });
+    const { files: sample } = await bucket.getAllFilesByPrefix({
+      prefix: dirPrefix,
+      pageSize: 1,
+    });
 
     if (dirExists || sample.length > 0) {
       await bucket.deleteByPrefix(dirPrefix);
@@ -303,7 +325,9 @@ export class GCSFileSystemBackend implements FileSystemBackend {
     }
 
     if (!ignoreNotFound) {
-      throw new Error(`GCSFileSystemBackend.delete: path not found: ${scopedPath}`);
+      throw new Error(
+        `GCSFileSystemBackend.delete: path not found: ${scopedPath}`
+      );
     }
   }
 
@@ -311,10 +335,14 @@ export class GCSFileSystemBackend implements FileSystemBackend {
     const srcGCS = this.toGCSPath(src);
     const destGCS = this.toGCSPath(dest);
     if (!srcGCS) {
-      throw new Error(`GCSFileSystemBackend.copy: unrecognised source path: ${src}`);
+      throw new Error(
+        `GCSFileSystemBackend.copy: unrecognised source path: ${src}`
+      );
     }
     if (!destGCS) {
-      throw new Error(`GCSFileSystemBackend.copy: unrecognised destination path: ${dest}`);
+      throw new Error(
+        `GCSFileSystemBackend.copy: unrecognised destination path: ${dest}`
+      );
     }
     await getPrivateUploadBucket().copyFile(srcGCS, destGCS);
   }
@@ -332,7 +360,9 @@ export class GCSFileSystemBackend implements FileSystemBackend {
     return getPrivateUploadBucket().getSignedUrl(gcsPath);
   }
 
-  createSandboxAdapter(mounts: ReadonlyArray<FileSystemMount>): SandboxMountAdapter {
+  createSandboxAdapter(
+    mounts: ReadonlyArray<FileSystemMount>
+  ): SandboxMountAdapter {
     const bucket = fileStorageConfig.getGcsPrivateUploadsBucket();
     const targets: GCSMountTarget[] = mounts.map((mount) => ({
       gcsPrefix: this.mountRootGCSPrefix(mount),

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.ts
@@ -1,4 +1,3 @@
-import config from "@app/lib/api/config";
 import type { GCSMountTarget } from "@app/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter";
 import { GCSSandboxMountAdapter } from "@app/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter";
 import type { SandboxMountAdapter } from "@app/lib/api/file_system/sandbox/sandbox_mount_adapter";
@@ -6,16 +5,21 @@ import type {
   FileSystemEntry,
   FileSystemMount,
 } from "@app/lib/api/file_system/types";
+import {
+  DustFileSystemError,
+  SCOPED_PREFIX_CONVERSATION,
+  SCOPED_PREFIX_POD,
+} from "@app/lib/api/file_system/types";
 import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import fileStorageConfig from "@app/lib/file_storage/config";
 import logger from "@app/logger/logger";
-import {
-  isSupportedImageContentType,
-  stripMimeParameters,
-} from "@app/types/files";
+import { stripMimeParameters } from "@app/types/files";
+import { Err, Ok, type Result } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
+import type { Readable } from "stream";
 
 import type { FileSystemBackend } from "./file_system_backend";
 
@@ -43,20 +47,25 @@ function parseScopedPath(scopedPath: string): ParsedScopedPath | null {
   const prefix = slashIdx >= 0 ? scopedPath.slice(0, slashIdx) : scopedPath;
   const rel = slashIdx >= 0 ? scopedPath.slice(slashIdx + 1) : "";
 
-  if (prefix.startsWith("conversation-")) {
-    const id = prefix.slice("conversation-".length);
+  if (prefix.startsWith(SCOPED_PREFIX_CONVERSATION)) {
+    const id = prefix.slice(SCOPED_PREFIX_CONVERSATION.length);
     return id ? { kind: "conversation", id, rel } : null;
   }
-  if (prefix.startsWith("pod-")) {
-    const id = prefix.slice("pod-".length);
+
+  if (prefix.startsWith(SCOPED_PREFIX_POD)) {
+    const id = prefix.slice(SCOPED_PREFIX_POD.length);
     return id ? { kind: "pod", id, rel } : null;
   }
+
   return null;
 }
 
 // ---------------------------------------------------------------------------
 // GCSFileSystemBackend
 // ---------------------------------------------------------------------------
+
+/** Number of GCS objects fetched per list page. Warn when more than one page is needed. */
+const GCS_LIST_PAGE_SIZE = 200;
 
 /**
  * GCS-backed FileSystemBackend.
@@ -80,11 +89,16 @@ export class GCSFileSystemBackend implements FileSystemBackend {
     if (!p) {
       return null;
     }
+
     switch (p.kind) {
       case "conversation":
         return `w/${this.workspaceId}/conversations/${p.id}/files/${p.rel}`;
+
       case "pod":
         return `w/${this.workspaceId}/pods/${p.id}/files/${p.rel}`;
+
+      default:
+        assertNever(p.kind);
     }
   }
 
@@ -93,15 +107,18 @@ export class GCSFileSystemBackend implements FileSystemBackend {
     if (!gcsPath.startsWith(base)) {
       return null;
     }
+
     const rest = gcsPath.slice(base.length);
     const conv = rest.match(/^conversations\/([^/]+)\/files\/(.*)$/);
     if (conv) {
-      return `conversation-${conv[1]}/${conv[2]}`;
+      return `${SCOPED_PREFIX_CONVERSATION}${conv[1]}/${conv[2]}`;
     }
+
     const pod = rest.match(/^pods\/([^/]+)\/files\/(.*)$/);
     if (pod) {
-      return `pod-${pod[1]}/${pod[2]}`;
+      return `${SCOPED_PREFIX_POD}${pod[1]}/${pod[2]}`;
     }
+
     return null;
   }
 
@@ -110,8 +127,12 @@ export class GCSFileSystemBackend implements FileSystemBackend {
     switch (mount.kind) {
       case "conversation":
         return `w/${this.workspaceId}/conversations/${mount.id}/files`;
+
       case "pod":
         return `w/${this.workspaceId}/pods/${mount.id}/files`;
+
+      default:
+        assertNever(mount.kind);
     }
   }
 
@@ -130,6 +151,7 @@ export class GCSFileSystemBackend implements FileSystemBackend {
         { scopedPath, workspaceId: this.workspaceId },
         "GCSFileSystemBackend.list: unrecognised scoped path"
       );
+
       return [];
     }
 
@@ -144,8 +166,9 @@ export class GCSFileSystemBackend implements FileSystemBackend {
     } else {
       const result = await bucket.getAllFilesByPrefix({
         prefix: gcsPrefix,
-        pageSize: 200,
+        pageSize: GCS_LIST_PAGE_SIZE,
       });
+
       if (result.pageFetchCount > 1) {
         logger.warn(
           {
@@ -157,6 +180,7 @@ export class GCSFileSystemBackend implements FileSystemBackend {
           "GCSFileSystemBackend.list: multiple GCS list requests, prefix has many objects"
         );
       }
+
       rawFiles = result.files;
     }
 
@@ -165,9 +189,11 @@ export class GCSFileSystemBackend implements FileSystemBackend {
       if (f.name.endsWith("/")) {
         return false;
       }
+
       if (includeProcessed) {
         return true;
       }
+
       const name = f.name.split("/").pop() ?? "";
       return !name.includes(".processed.");
     });
@@ -184,10 +210,12 @@ export class GCSFileSystemBackend implements FileSystemBackend {
       ) {
         return [];
       }
+
       const scopedFilePath = this.fromGCSPath(trimmed);
       if (!scopedFilePath) {
         return [];
       }
+
       return [
         {
           isDirectory: true as const,
@@ -219,59 +247,63 @@ export class GCSFileSystemBackend implements FileSystemBackend {
           ? new Date(meta["updated"] as string).getTime()
           : 0,
         fileId: null,
-        thumbnailUrl: this.buildThumbnailUrl(contentType, scopedFilePath),
+        // Thumbnail URLs are application-layer concerns (they point to our API).
+        // DustFileSystem.list() populates this after receiving entries from the backend.
+        thumbnailUrl: null,
       };
     });
 
     return [...folderEntries, ...fileEntries];
   }
 
-  private buildThumbnailUrl(
-    contentType: string,
-    scopedFilePath: string
-  ): string | null {
-    if (!isSupportedImageContentType(contentType)) {
-      return null;
-    }
-    const parsed = parseScopedPath(scopedFilePath);
-    if (!parsed) {
-      return null;
-    }
-    switch (parsed.kind) {
-      case "conversation":
-        return (
-          `${config.getApiBaseUrl()}/api/w/${this.workspaceId}` +
-          `/assistant/conversations/${parsed.id}/files/thumbnail` +
-          `?filePath=${encodeURIComponent(scopedFilePath)}`
-        );
-      case "pod":
-        // TODO(FILE SYSTEM): expose a pod-files thumbnail endpoint.
-        return null;
-    }
-  }
-
-  async read(scopedPath: string): Promise<Buffer | null> {
+  async read(
+    scopedPath: string
+  ): Promise<Result<Readable | null, DustFileSystemError>> {
     const gcsPath = this.toGCSPath(scopedPath);
     if (!gcsPath) {
-      logger.warn(
-        { scopedPath, workspaceId: this.workspaceId },
-        "GCSFileSystemBackend.read: unrecognised scoped path"
+      return new Err(
+        new DustFileSystemError(
+          "invalid_path",
+          `GCSFileSystemBackend.read: unrecognised scoped path: ${scopedPath}`
+        )
       );
-      return null;
     }
+
     const bucket = getPrivateUploadBucket();
     try {
       const [exists] = await bucket.file(gcsPath).exists();
       if (!exists) {
-        return null;
+        return new Ok(null);
       }
-      const [content] = await bucket.file(gcsPath).download();
-      return content;
+
+      return new Ok(bucket.file(gcsPath).createReadStream());
     } catch (err) {
-      logger.error(
-        { err: normalizeError(err), gcsPath, workspaceId: this.workspaceId },
-        "GCSFileSystemBackend.read: download failed"
+      return new Err(
+        new DustFileSystemError("internal", normalizeError(err).message)
       );
+    }
+  }
+
+  async stat(
+    scopedPath: string
+  ): Promise<{ contentType: string; sizeBytes: number } | null> {
+    const gcsPath = this.toGCSPath(scopedPath);
+    if (!gcsPath) {
+      return null;
+    }
+
+    const bucket = getPrivateUploadBucket();
+    try {
+      const [metadata] = await bucket.file(gcsPath).getMetadata();
+      const rawCT = isString(metadata.contentType)
+        ? metadata.contentType
+        : "application/octet-stream";
+
+      return {
+        contentType: stripMimeParameters(rawCT),
+        sizeBytes: Number(metadata.size ?? 0),
+      };
+    } catch {
       return null;
     }
   }
@@ -280,84 +312,143 @@ export class GCSFileSystemBackend implements FileSystemBackend {
     scopedPath: string,
     content: Buffer | string,
     contentType: string
-  ): Promise<void> {
+  ): Promise<Result<void, DustFileSystemError>> {
     const gcsPath = this.toGCSPath(scopedPath);
     if (!gcsPath) {
-      throw new Error(
-        `GCSFileSystemBackend.write: unrecognised scoped path: ${scopedPath}`
+      return new Err(
+        new DustFileSystemError(
+          "invalid_path",
+          `GCSFileSystemBackend.write: unrecognised scoped path: ${scopedPath}`
+        )
       );
     }
-    const buf = typeof content === "string" ? Buffer.from(content) : content;
-    await getPrivateUploadBucket().file(gcsPath).save(buf, { contentType });
+
+    try {
+      const buf = isString(content) ? Buffer.from(content) : content;
+      await getPrivateUploadBucket().file(gcsPath).save(buf, { contentType });
+
+      return new Ok(undefined);
+    } catch (err) {
+      return new Err(
+        new DustFileSystemError("internal", normalizeError(err).message)
+      );
+    }
   }
 
   async delete(
     scopedPath: string,
     { ignoreNotFound = false }: { ignoreNotFound?: boolean } = {}
-  ): Promise<void> {
+  ): Promise<Result<void, DustFileSystemError>> {
     const gcsPath = this.toGCSPath(scopedPath);
     if (!gcsPath) {
       if (ignoreNotFound) {
-        return;
+        return new Ok(undefined);
       }
-      throw new Error(
-        `GCSFileSystemBackend.delete: unrecognised scoped path: ${scopedPath}`
+
+      return new Err(
+        new DustFileSystemError(
+          "not_found",
+          `GCSFileSystemBackend.delete: unrecognised scoped path: ${scopedPath}`
+        )
       );
     }
 
-    const bucket = getPrivateUploadBucket();
-    const [fileExists] = await bucket.file(gcsPath).exists();
-    if (fileExists) {
-      await bucket.delete(gcsPath, { ignoreNotFound });
-      return;
-    }
+    try {
+      const bucket = getPrivateUploadBucket();
+      const [fileExists] = await bucket.file(gcsPath).exists();
+      if (fileExists) {
+        await bucket.delete(gcsPath, { ignoreNotFound });
 
-    const dirPrefix = gcsPath.endsWith("/") ? gcsPath : `${gcsPath}/`;
-    const [dirExists] = await bucket.file(dirPrefix).exists();
-    const { files: sample } = await bucket.getAllFilesByPrefix({
-      prefix: dirPrefix,
-      pageSize: 1,
-    });
+        return new Ok(undefined);
+      }
 
-    if (dirExists || sample.length > 0) {
-      await bucket.deleteByPrefix(dirPrefix);
-      return;
-    }
+      const dirPrefix = gcsPath.endsWith("/") ? gcsPath : `${gcsPath}/`;
+      const [dirExists] = await bucket.file(dirPrefix).exists();
+      const { files: sample } = await bucket.getAllFilesByPrefix({
+        prefix: dirPrefix,
+        pageSize: 1,
+      });
 
-    if (!ignoreNotFound) {
-      throw new Error(
-        `GCSFileSystemBackend.delete: path not found: ${scopedPath}`
+      if (dirExists || sample.length > 0) {
+        await bucket.deleteByPrefix(dirPrefix);
+        return new Ok(undefined);
+      }
+
+      if (!ignoreNotFound) {
+        return new Err(
+          new DustFileSystemError("not_found", `Path not found: ${scopedPath}`)
+        );
+      }
+
+      return new Ok(undefined);
+    } catch (err) {
+      return new Err(
+        new DustFileSystemError("internal", normalizeError(err).message)
       );
     }
   }
 
-  async copy(src: string, dest: string): Promise<void> {
+  async copy({
+    src,
+    dest,
+  }: {
+    src: string;
+    dest: string;
+  }): Promise<Result<void, DustFileSystemError>> {
     const srcGCS = this.toGCSPath(src);
     const destGCS = this.toGCSPath(dest);
     if (!srcGCS) {
-      throw new Error(
-        `GCSFileSystemBackend.copy: unrecognised source path: ${src}`
+      return new Err(
+        new DustFileSystemError(
+          "invalid_path",
+          `GCSFileSystemBackend.copy: unrecognised source path: ${src}`
+        )
       );
     }
+
     if (!destGCS) {
-      throw new Error(
-        `GCSFileSystemBackend.copy: unrecognised destination path: ${dest}`
+      return new Err(
+        new DustFileSystemError(
+          "invalid_path",
+          `GCSFileSystemBackend.copy: unrecognised destination path: ${dest}`
+        )
       );
     }
-    await getPrivateUploadBucket().copyFile(srcGCS, destGCS);
+
+    try {
+      await getPrivateUploadBucket().copyFile(srcGCS, destGCS);
+
+      return new Ok(undefined);
+    } catch (err) {
+      return new Err(
+        new DustFileSystemError("internal", normalizeError(err).message)
+      );
+    }
   }
 
   async getDownloadUrl(
     scopedPath: string,
     _opts?: { expiresInMs?: number; fileName?: string }
-  ): Promise<string> {
+  ): Promise<Result<string, DustFileSystemError>> {
     const gcsPath = this.toGCSPath(scopedPath);
     if (!gcsPath) {
-      throw new Error(
-        `GCSFileSystemBackend.getDownloadUrl: unrecognised scoped path: ${scopedPath}`
+      return new Err(
+        new DustFileSystemError(
+          "invalid_path",
+          `GCSFileSystemBackend.getDownloadUrl: unrecognised scoped path: ${scopedPath}`
+        )
       );
     }
-    return getPrivateUploadBucket().getSignedUrl(gcsPath);
+
+    try {
+      const url = await getPrivateUploadBucket().getSignedUrl(gcsPath);
+
+      return new Ok(url);
+    } catch (err) {
+      return new Err(
+        new DustFileSystemError("internal", normalizeError(err).message)
+      );
+    }
   }
 
   createSandboxAdapter(
@@ -369,6 +460,7 @@ export class GCSFileSystemBackend implements FileSystemBackend {
       sandboxMountPoint: mount.sandboxMountPoint,
       legacySandboxMountPoint: mount.legacySandboxMountPoint,
     }));
+
     return new GCSSandboxMountAdapter(bucket, targets);
   }
 }

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.ts
@@ -73,10 +73,6 @@ const GCS_LIST_PAGE_SIZE = 200;
  * Path translation (internal, never exposed):
  *   `conversation-{cId}/{rel}` -> `w/{wId}/conversations/{cId}/files/{rel}`
  *   `pod-{pId}/{rel}`          -> `w/{wId}/pods/{pId}/files/{rel}`
- *
- * `fileId` is always null in listing entries until the DB migration converts
- * `FileResource.mountFilePath` from raw GCS paths to scoped paths.
- * See TODO(FILE SYSTEM MIGRATION) in `list`.
  */
 export class GCSFileSystemBackend implements FileSystemBackend {
   constructor(
@@ -198,8 +194,8 @@ export class GCSFileSystemBackend implements FileSystemBackend {
       return !name.includes(".processed.");
     });
 
-    // TODO(FILE SYSTEM MIGRATION): once FileResource.mountFilePath stores scoped paths,
-    // look up FileResource records here by scoped path to populate fileId.
+    // TODO(FILE SYSTEM MIGRATION): use FileResource.mountFilePath to look up FileResource records
+    // here by scoped path to populate fileId.
 
     const folderEntries: FileSystemEntry[] = folderPlaceholders.flatMap((f) => {
       const trimmed = f.name.replace(/\/$/, "");
@@ -286,25 +282,42 @@ export class GCSFileSystemBackend implements FileSystemBackend {
 
   async stat(
     scopedPath: string
-  ): Promise<{ contentType: string; sizeBytes: number } | null> {
+  ): Promise<
+    Result<
+      { contentType: string; sizeBytes: number } | null,
+      DustFileSystemError
+    >
+  > {
     const gcsPath = this.toGCSPath(scopedPath);
     if (!gcsPath) {
-      return null;
+      return new Err(
+        new DustFileSystemError(
+          "invalid_path",
+          `GCSFileSystemBackend.stat: unrecognised scoped path: ${scopedPath}`
+        )
+      );
     }
 
     const bucket = getPrivateUploadBucket();
     try {
+      const [exists] = await bucket.file(gcsPath).exists();
+      if (!exists) {
+        return new Ok(null);
+      }
+
       const [metadata] = await bucket.file(gcsPath).getMetadata();
       const rawCT = isString(metadata.contentType)
         ? metadata.contentType
         : "application/octet-stream";
 
-      return {
+      return new Ok({
         contentType: stripMimeParameters(rawCT),
         sizeBytes: Number(metadata.size ?? 0),
-      };
-    } catch {
-      return null;
+      });
+    } catch (err) {
+      return new Err(
+        new DustFileSystemError("internal", normalizeError(err).message)
+      );
     }
   }
 

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.ts
@@ -354,13 +354,9 @@ export class GCSFileSystemBackend implements FileSystemBackend {
   ): Promise<Result<void, DustFileSystemError>> {
     const gcsPath = this.toGCSPath(scopedPath);
     if (!gcsPath) {
-      if (ignoreNotFound) {
-        return new Ok(undefined);
-      }
-
       return new Err(
         new DustFileSystemError(
-          "not_found",
+          "invalid_path",
           `GCSFileSystemBackend.delete: unrecognised scoped path: ${scopedPath}`
         )
       );

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.ts
@@ -1,0 +1,344 @@
+import config from "@app/lib/api/config";
+import type { FileSystemEntry, FileSystemMount } from "@app/lib/api/file_system/types";
+import type { GCSMountTarget } from "@app/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter";
+import { GCSSandboxMountAdapter } from "@app/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter";
+import type { SandboxMountAdapter } from "@app/lib/api/file_system/sandbox/sandbox_mount_adapter";
+import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import fileStorageConfig from "@app/lib/file_storage/config";
+import logger from "@app/logger/logger";
+import {
+  isSupportedImageContentType,
+  stripMimeParameters,
+} from "@app/types/files";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isString } from "@app/types/shared/utils/general";
+
+import type { FileSystemBackend } from "./file_system_backend";
+
+// ---------------------------------------------------------------------------
+// Scoped-path helpers
+// ---------------------------------------------------------------------------
+
+type ParsedScopedPath = {
+  kind: "conversation" | "pod";
+  id: string;
+  /** Path component after `<kind>-<id>/`, empty string for a root listing. */
+  rel: string;
+};
+
+/**
+ * Parse the scoped prefix from a scoped path.
+ *
+ * `"conversation-{cId}/report.pdf"` -> `{ kind: "conversation", id: "{cId}", rel: "report.pdf" }`
+ * `"pod-{pId}/data/"`               -> `{ kind: "pod", id: "{pId}", rel: "data/" }`
+ *
+ * Returns `null` for unrecognised prefixes.
+ */
+function parseScopedPath(scopedPath: string): ParsedScopedPath | null {
+  const slashIdx = scopedPath.indexOf("/");
+  const prefix = slashIdx >= 0 ? scopedPath.slice(0, slashIdx) : scopedPath;
+  const rel = slashIdx >= 0 ? scopedPath.slice(slashIdx + 1) : "";
+
+  if (prefix.startsWith("conversation-")) {
+    const id = prefix.slice("conversation-".length);
+    return id ? { kind: "conversation", id, rel } : null;
+  }
+  if (prefix.startsWith("pod-")) {
+    const id = prefix.slice("pod-".length);
+    return id ? { kind: "pod", id, rel } : null;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// GCSFileSystemBackend
+// ---------------------------------------------------------------------------
+
+/**
+ * GCS-backed FileSystemBackend.
+ *
+ * Path translation (internal, never exposed):
+ *   `conversation-{cId}/{rel}` -> `w/{wId}/conversations/{cId}/files/{rel}`
+ *   `pod-{pId}/{rel}`          -> `w/{wId}/pods/{pId}/files/{rel}`
+ *
+ * `fileId` is always null in listing entries until the DB migration converts
+ * `FileResource.mountFilePath` from raw GCS paths to scoped paths.
+ * See TODO(FILE SYSTEM MIGRATION) in `list`.
+ */
+export class GCSFileSystemBackend implements FileSystemBackend {
+  constructor(
+    private readonly workspaceId: string,
+    private readonly bucketName: string
+  ) {}
+
+  private toGCSPath(scopedPath: string): string | null {
+    const p = parseScopedPath(scopedPath);
+    if (!p) {
+      return null;
+    }
+    switch (p.kind) {
+      case "conversation":
+        return `w/${this.workspaceId}/conversations/${p.id}/files/${p.rel}`;
+      case "pod":
+        return `w/${this.workspaceId}/pods/${p.id}/files/${p.rel}`;
+    }
+  }
+
+  private fromGCSPath(gcsPath: string): string | null {
+    const base = `w/${this.workspaceId}/`;
+    if (!gcsPath.startsWith(base)) {
+      return null;
+    }
+    const rest = gcsPath.slice(base.length);
+    const conv = rest.match(/^conversations\/([^/]+)\/files\/(.*)$/);
+    if (conv) {
+      return `conversation-${conv[1]}/${conv[2]}`;
+    }
+    const pod = rest.match(/^pods\/([^/]+)\/files\/(.*)$/);
+    if (pod) {
+      return `pod-${pod[1]}/${pod[2]}`;
+    }
+    return null;
+  }
+
+  /** GCS prefix for a mount's root, no trailing slash. Used in CAB and gcsfuse --only-dir. */
+  private mountRootGCSPrefix(mount: FileSystemMount): string {
+    switch (mount.kind) {
+      case "conversation":
+        return `w/${this.workspaceId}/conversations/${mount.id}/files`;
+      case "pod":
+        return `w/${this.workspaceId}/pods/${mount.id}/files`;
+    }
+  }
+
+  async list(
+    scopedPath: string,
+    {
+      maxFiles,
+      includeProcessed = false,
+    }: { maxFiles?: number; includeProcessed?: boolean } = {}
+  ): Promise<FileSystemEntry[]> {
+    const normalised = scopedPath.endsWith("/") ? scopedPath : `${scopedPath}/`;
+    const gcsPrefix = this.toGCSPath(normalised);
+
+    if (!gcsPrefix) {
+      logger.warn(
+        { scopedPath, workspaceId: this.workspaceId },
+        "GCSFileSystemBackend.list: unrecognised scoped path"
+      );
+      return [];
+    }
+
+    const bucket = getPrivateUploadBucket();
+    let rawFiles: { name: string; metadata: Record<string, unknown> }[];
+
+    if (maxFiles !== undefined) {
+      rawFiles = await bucket.getFiles({ prefix: gcsPrefix, maxResults: maxFiles });
+    } else {
+      const result = await bucket.getAllFilesByPrefix({ prefix: gcsPrefix, pageSize: 200 });
+      if (result.pageFetchCount > 1) {
+        logger.warn(
+          {
+            workspaceId: this.workspaceId,
+            prefix: gcsPrefix,
+            pageFetchCount: result.pageFetchCount,
+            objectCount: result.files.length,
+          },
+          "GCSFileSystemBackend.list: multiple GCS list requests, prefix has many objects"
+        );
+      }
+      rawFiles = result.files;
+    }
+
+    const folderPlaceholders = rawFiles.filter((f) => f.name.endsWith("/"));
+    const regularFiles = rawFiles.filter((f) => {
+      if (f.name.endsWith("/")) {
+        return false;
+      }
+      if (includeProcessed) {
+        return true;
+      }
+      const name = f.name.split("/").pop() ?? "";
+      return !name.includes(".processed.");
+    });
+
+    // TODO(FILE SYSTEM MIGRATION): once FileResource.mountFilePath stores scoped paths,
+    // look up FileResource records here by scoped path to populate fileId.
+
+    const folderEntries: FileSystemEntry[] = folderPlaceholders.flatMap((f) => {
+      const trimmed = f.name.replace(/\/$/, "");
+      const name = trimmed.split("/").pop() ?? "";
+      if (!name || (name.startsWith(".") && name !== TOOL_OUTPUTS_FOLDER_NAME)) {
+        return [];
+      }
+      const scopedFilePath = this.fromGCSPath(trimmed);
+      if (!scopedFilePath) {
+        return [];
+      }
+      return [
+        {
+          isDirectory: true as const,
+          fileName: name,
+          path: scopedFilePath,
+          sizeBytes: 0,
+          lastModifiedMs: isString(f.metadata["updated"])
+            ? new Date(f.metadata["updated"] as string).getTime()
+            : 0,
+        },
+      ];
+    });
+
+    const fileEntries: FileSystemEntry[] = regularFiles.map((gcsFile) => {
+      const meta = gcsFile.metadata;
+      const rawCT = isString(meta["contentType"])
+        ? (meta["contentType"] as string)
+        : "application/octet-stream";
+      const contentType = stripMimeParameters(rawCT);
+      const scopedFilePath = this.fromGCSPath(gcsFile.name) ?? gcsFile.name;
+
+      return {
+        isDirectory: false as const,
+        fileName: gcsFile.name.split("/").pop() ?? gcsFile.name,
+        path: scopedFilePath,
+        sizeBytes: Number(meta["size"] ?? 0),
+        contentType,
+        lastModifiedMs: isString(meta["updated"])
+          ? new Date(meta["updated"] as string).getTime()
+          : 0,
+        fileId: null,
+        thumbnailUrl: this.buildThumbnailUrl(contentType, scopedFilePath),
+      };
+    });
+
+    return [...folderEntries, ...fileEntries];
+  }
+
+  private buildThumbnailUrl(contentType: string, scopedFilePath: string): string | null {
+    if (!isSupportedImageContentType(contentType)) {
+      return null;
+    }
+    const parsed = parseScopedPath(scopedFilePath);
+    if (!parsed) {
+      return null;
+    }
+    switch (parsed.kind) {
+      case "conversation":
+        return (
+          `${config.getApiBaseUrl()}/api/w/${this.workspaceId}` +
+          `/assistant/conversations/${parsed.id}/files/thumbnail` +
+          `?filePath=${encodeURIComponent(scopedFilePath)}`
+        );
+      case "pod":
+        // TODO(FILE SYSTEM): expose a pod-files thumbnail endpoint.
+        return null;
+    }
+  }
+
+  async read(scopedPath: string): Promise<Buffer | null> {
+    const gcsPath = this.toGCSPath(scopedPath);
+    if (!gcsPath) {
+      logger.warn(
+        { scopedPath, workspaceId: this.workspaceId },
+        "GCSFileSystemBackend.read: unrecognised scoped path"
+      );
+      return null;
+    }
+    const bucket = getPrivateUploadBucket();
+    try {
+      const [exists] = await bucket.file(gcsPath).exists();
+      if (!exists) {
+        return null;
+      }
+      const [content] = await bucket.file(gcsPath).download();
+      return content;
+    } catch (err) {
+      logger.error(
+        { err: normalizeError(err), gcsPath, workspaceId: this.workspaceId },
+        "GCSFileSystemBackend.read: download failed"
+      );
+      return null;
+    }
+  }
+
+  async write(
+    scopedPath: string,
+    content: Buffer | string,
+    contentType: string
+  ): Promise<void> {
+    const gcsPath = this.toGCSPath(scopedPath);
+    if (!gcsPath) {
+      throw new Error(`GCSFileSystemBackend.write: unrecognised scoped path: ${scopedPath}`);
+    }
+    const buf = typeof content === "string" ? Buffer.from(content) : content;
+    await getPrivateUploadBucket().file(gcsPath).save(buf, { contentType });
+  }
+
+  async delete(
+    scopedPath: string,
+    { ignoreNotFound = false }: { ignoreNotFound?: boolean } = {}
+  ): Promise<void> {
+    const gcsPath = this.toGCSPath(scopedPath);
+    if (!gcsPath) {
+      if (ignoreNotFound) {
+        return;
+      }
+      throw new Error(`GCSFileSystemBackend.delete: unrecognised scoped path: ${scopedPath}`);
+    }
+
+    const bucket = getPrivateUploadBucket();
+    const [fileExists] = await bucket.file(gcsPath).exists();
+    if (fileExists) {
+      await bucket.delete(gcsPath, { ignoreNotFound });
+      return;
+    }
+
+    const dirPrefix = gcsPath.endsWith("/") ? gcsPath : `${gcsPath}/`;
+    const [dirExists] = await bucket.file(dirPrefix).exists();
+    const { files: sample } = await bucket.getAllFilesByPrefix({ prefix: dirPrefix, pageSize: 1 });
+
+    if (dirExists || sample.length > 0) {
+      await bucket.deleteByPrefix(dirPrefix);
+      return;
+    }
+
+    if (!ignoreNotFound) {
+      throw new Error(`GCSFileSystemBackend.delete: path not found: ${scopedPath}`);
+    }
+  }
+
+  async copy(src: string, dest: string): Promise<void> {
+    const srcGCS = this.toGCSPath(src);
+    const destGCS = this.toGCSPath(dest);
+    if (!srcGCS) {
+      throw new Error(`GCSFileSystemBackend.copy: unrecognised source path: ${src}`);
+    }
+    if (!destGCS) {
+      throw new Error(`GCSFileSystemBackend.copy: unrecognised destination path: ${dest}`);
+    }
+    await getPrivateUploadBucket().copyFile(srcGCS, destGCS);
+  }
+
+  async getDownloadUrl(
+    scopedPath: string,
+    _opts?: { expiresInMs?: number; fileName?: string }
+  ): Promise<string> {
+    const gcsPath = this.toGCSPath(scopedPath);
+    if (!gcsPath) {
+      throw new Error(
+        `GCSFileSystemBackend.getDownloadUrl: unrecognised scoped path: ${scopedPath}`
+      );
+    }
+    return getPrivateUploadBucket().getSignedUrl(gcsPath);
+  }
+
+  createSandboxAdapter(mounts: ReadonlyArray<FileSystemMount>): SandboxMountAdapter {
+    const bucket = fileStorageConfig.getGcsPrivateUploadsBucket();
+    const targets: GCSMountTarget[] = mounts.map((mount) => ({
+      gcsPrefix: this.mountRootGCSPrefix(mount),
+      sandboxMountPoint: mount.sandboxMountPoint,
+      legacySandboxMountPoint: mount.legacySandboxMountPoint,
+    }));
+    return new GCSSandboxMountAdapter(bucket, targets);
+  }
+}

--- a/front/lib/api/file_system/dust_file_system.test.ts
+++ b/front/lib/api/file_system/dust_file_system.test.ts
@@ -1,0 +1,457 @@
+import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
+import { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import assert from "assert";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/file_storage/config", () => ({
+  default: {
+    getGcsPrivateUploadsBucket: vi.fn(() => "test-bucket"),
+  },
+}));
+
+vi.mock("@app/lib/api/config", () => ({
+  default: {
+    getApiBaseUrl: vi.fn(() => "https://dust.tt"),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// forConversation
+// ---------------------------------------------------------------------------
+
+describe("DustFileSystem.forConversation", () => {
+  beforeEach(() => {
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      file: vi.fn(() => ({ save: vi.fn().mockResolvedValue(undefined) })),
+      getAllFilesByPrefix: vi.fn().mockResolvedValue({ files: [], pageFetchCount: 1 }),
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+  });
+
+  it("creates a single conversation mount for a regular conversation", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent",
+    });
+    // No spaceId: regular (non-project) conversation has spaceId null.
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+
+    const result = await DustFileSystem.forConversation(auth, conversation);
+
+    assert(result.isOk());
+    const mounts = result.value.getMounts();
+    expect(mounts).toHaveLength(1);
+    expect(mounts[0].kind).toBe("conversation");
+    expect(mounts[0].id).toBe(conversation.sId);
+    expect(mounts[0].scopedPrefix).toBe(`conversation-${conversation.sId}`);
+    expect(mounts[0].sandboxMountPoint).toBe(`/files/conversation-${conversation.sId}`);
+    expect(mounts[0].legacyPrefix).toBe("conversation");
+    expect(mounts[0].legacySandboxMountPoint).toBe("/files/conversation");
+    expect(mounts[0].permissions.canRead).toBe(true);
+    expect(mounts[0].permissions.canWrite).toBe(true);
+  });
+
+  it("adds a pod mount when the conversation belongs to a project space", async () => {
+    const { workspace, user } = await createResourceTest({ role: "admin" });
+
+    // Create the project space, then re-fetch auth so it knows about the new editor group.
+    const projectSpace = await SpaceFactory.project(workspace, user.id);
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(user.sId, workspace.sId);
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+      spaceId: projectSpace.id,
+    });
+
+    const result = await DustFileSystem.forConversation(auth, conversation);
+
+    assert(result.isOk());
+    const mounts = result.value.getMounts();
+    expect(mounts).toHaveLength(2);
+
+    const convMount = mounts.find((m) => m.kind === "conversation");
+    const podMount = mounts.find((m) => m.kind === "pod");
+
+    expect(convMount).toBeDefined();
+    expect(convMount!.id).toBe(conversation.sId);
+
+    expect(podMount).toBeDefined();
+    expect(podMount!.id).toBe(projectSpace.sId);
+    expect(podMount!.scopedPrefix).toBe(`pod-${projectSpace.sId}`);
+    expect(podMount!.sandboxMountPoint).toBe(`/files/pod-${projectSpace.sId}`);
+    expect(podMount!.legacyPrefix).toBe("project");
+    expect(podMount!.legacySandboxMountPoint).toBe("/files/project");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// forPod
+// ---------------------------------------------------------------------------
+
+describe("DustFileSystem.forPod", () => {
+  it("returns Err(unauthorized) when the user has no membership in the space", async () => {
+    // Create two separate workspaces; the regular user has no access to the admin's space.
+    const { authenticator: regularAuth } = await createResourceTest({ role: "user" });
+    const { workspace: adminWorkspace } = await createResourceTest({ role: "admin" });
+
+    // Create a project space in the admin workspace with no members.
+    const projectSpace = await SpaceFactory.project(adminWorkspace);
+
+    // regularAuth belongs to a different workspace — canRead will be false.
+    const result = await DustFileSystem.forPod(regularAuth, projectSpace);
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("unauthorized");
+    }
+  });
+
+  it("returns Ok with a pod mount when the user is in the editor group", async () => {
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      getAllFilesByPrefix: vi.fn().mockResolvedValue({ files: [], pageFetchCount: 1 }),
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+
+    const { workspace, user } = await createResourceTest({ role: "admin" });
+
+    // Pass user.id so the user is added to the editorGroup by SpaceFactory.
+    const projectSpace = await SpaceFactory.project(workspace, user.id);
+
+    // Re-fetch auth so _groupModelIds includes the newly created editor group.
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(user.sId, workspace.sId);
+
+    const result = await DustFileSystem.forPod(auth, projectSpace);
+
+    assert(result.isOk());
+    const mounts = result.value.getMounts();
+    expect(mounts).toHaveLength(1);
+    expect(mounts[0].kind).toBe("pod");
+    expect(mounts[0].id).toBe(projectSpace.sId);
+    expect(mounts[0].scopedPrefix).toBe(`pod-${projectSpace.sId}`);
+    expect(mounts[0].permissions.canRead).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fromScopedPath
+// ---------------------------------------------------------------------------
+
+describe("DustFileSystem.fromScopedPath", () => {
+  it("returns Err(invalid_path) for an unrecognised prefix", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const result = await DustFileSystem.fromScopedPath(auth, "unknown-prefix/file.txt");
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("invalid_path");
+    }
+  });
+
+  it("returns Err(not_found) when conversation does not exist", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const result = await DustFileSystem.fromScopedPath(auth, "conversation-nonexistent/file.txt");
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("not_found");
+    }
+  });
+
+  it("returns Err(not_found) when pod space does not exist", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const result = await DustFileSystem.fromScopedPath(auth, "pod-nonexistent/file.txt");
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("not_found");
+    }
+  });
+
+  it("returns Ok with a conversation-scoped fs for a conversation- prefix", async () => {
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      getAllFilesByPrefix: vi.fn().mockResolvedValue({ files: [], pageFetchCount: 1 }),
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+
+    const { authenticator: auth, conversationsSpace } = await createResourceTest({});
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+      spaceId: conversationsSpace.id,
+    });
+
+    const result = await DustFileSystem.fromScopedPath(
+      auth,
+      `conversation-${conversation.sId}/report.pdf`
+    );
+
+    assert(result.isOk());
+    const mounts = result.value.getMounts();
+    expect(mounts.some((m) => m.kind === "conversation" && m.id === conversation.sId)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Legacy path canonicalization
+// ---------------------------------------------------------------------------
+
+describe("DustFileSystem legacy path compatibility", () => {
+  let auth: Authenticator;
+  let conversationId: string;
+  let saveMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    saveMock = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      file: vi.fn(() => ({ save: saveMock })),
+      getAllFilesByPrefix: vi.fn().mockResolvedValue({ files: [], pageFetchCount: 1 }),
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+
+    const { authenticator, conversationsSpace } = await createResourceTest({});
+    auth = authenticator;
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+      spaceId: conversationsSpace.id,
+    });
+    conversationId = conversation.sId;
+  });
+
+  it("accepts a legacy 'conversation/...' path for write", async () => {
+    const convRes = await ConversationResource.fetchById(auth, conversationId);
+    assert(convRes !== null);
+    const fs = await DustFileSystem.forConversation(auth, convRes.toJSON());
+    assert(fs.isOk());
+
+    const result = await fs.value.write(
+      "conversation/report.txt",
+      Buffer.from("hello"),
+      "text/plain"
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(saveMock).toHaveBeenCalledOnce();
+  });
+
+  it("treats legacy 'conversation/...' and canonical 'conversation-{cId}/...' as equivalent", async () => {
+    const convRes = await ConversationResource.fetchById(auth, conversationId);
+    assert(convRes !== null);
+    const fs = await DustFileSystem.forConversation(auth, convRes.toJSON());
+    assert(fs.isOk());
+
+    const legacyResult = await fs.value.write(
+      "conversation/notes.txt",
+      Buffer.from("a"),
+      "text/plain"
+    );
+    const canonicalResult = await fs.value.write(
+      `conversation-${conversationId}/notes.txt`,
+      Buffer.from("a"),
+      "text/plain"
+    );
+
+    expect(legacyResult.isOk()).toBe(true);
+    expect(canonicalResult.isOk()).toBe(true);
+    // Both writes should reach GCS.
+    expect(saveMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permission enforcement
+// ---------------------------------------------------------------------------
+
+describe("DustFileSystem permission enforcement", () => {
+  let auth: Authenticator;
+  let conversationId: string;
+
+  beforeEach(async () => {
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      getAllFilesByPrefix: vi.fn().mockResolvedValue({ files: [], pageFetchCount: 1 }),
+      file: vi.fn(() => ({
+        save: vi.fn().mockResolvedValue(undefined),
+        exists: vi.fn().mockResolvedValue([false]),
+      })),
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+
+    const { authenticator, conversationsSpace } = await createResourceTest({});
+    auth = authenticator;
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+      spaceId: conversationsSpace.id,
+    });
+    conversationId = conversation.sId;
+  });
+
+  it("returns Err(invalid_path) when writing to a path not in any mount", async () => {
+    const convRes = await ConversationResource.fetchById(auth, conversationId);
+    assert(convRes !== null);
+    const fs = await DustFileSystem.forConversation(auth, convRes.toJSON());
+    assert(fs.isOk());
+
+    const result = await fs.value.write("pod-unknown/file.txt", Buffer.from("x"), "text/plain");
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("invalid_path");
+    }
+  });
+
+  it("returns Err(invalid_path) when reading from a path not in any mount", async () => {
+    const convRes = await ConversationResource.fetchById(auth, conversationId);
+    assert(convRes !== null);
+    const fs = await DustFileSystem.forConversation(auth, convRes.toJSON());
+    assert(fs.isOk());
+
+    const result = await fs.value.read("pod-unknown/file.txt");
+    expect(result).toBeNull();
+  });
+
+  it("conversation mount always has canRead and canWrite", async () => {
+    const convRes = await ConversationResource.fetchById(auth, conversationId);
+    assert(convRes !== null);
+    const fs = await DustFileSystem.forConversation(auth, convRes.toJSON());
+    assert(fs.isOk());
+
+    const mount = fs.value.getMounts()[0];
+    expect(mount.permissions.canRead).toBe(true);
+    expect(mount.permissions.canWrite).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// move (non-atomicity)
+// ---------------------------------------------------------------------------
+
+describe("DustFileSystem.move", () => {
+  let auth: Authenticator;
+  let conversationId: string;
+  let copyFileMock: ReturnType<typeof vi.fn>;
+  let existsMock: ReturnType<typeof vi.fn>;
+  let deleteMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    copyFileMock = vi.fn().mockResolvedValue(undefined);
+    existsMock = vi.fn().mockResolvedValue([true]);
+    deleteMock = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      copyFile: copyFileMock,
+      file: vi.fn(() => ({ exists: existsMock })),
+      delete: deleteMock,
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+
+    const { authenticator, conversationsSpace } = await createResourceTest({});
+    auth = authenticator;
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+      spaceId: conversationsSpace.id,
+    });
+    conversationId = conversation.sId;
+  });
+
+  it("returns Ok with sourceDeletionFailed false on a clean move", async () => {
+    const convRes = await ConversationResource.fetchById(auth, conversationId);
+    assert(convRes !== null);
+    const fs = await DustFileSystem.forConversation(auth, convRes.toJSON());
+    assert(fs.isOk());
+
+    const result = await fs.value.move(
+      `conversation-${conversationId}/src.txt`,
+      `conversation-${conversationId}/dest.txt`
+    );
+
+    assert(result.isOk());
+    expect(result.value.sourceDeletionFailed).toBe(false);
+    expect(copyFileMock).toHaveBeenCalledOnce();
+    expect(deleteMock).toHaveBeenCalledOnce();
+  });
+
+  it("returns Ok with sourceDeletionFailed true when delete fails after a successful copy", async () => {
+    deleteMock.mockRejectedValue(new Error("GCS delete failed"));
+
+    const convRes = await ConversationResource.fetchById(auth, conversationId);
+    assert(convRes !== null);
+    const fs = await DustFileSystem.forConversation(auth, convRes.toJSON());
+    assert(fs.isOk());
+
+    const result = await fs.value.move(
+      `conversation-${conversationId}/src.txt`,
+      `conversation-${conversationId}/dest.txt`
+    );
+
+    // The destination copy succeeded, so we return Ok instead of Err.
+    assert(result.isOk());
+    expect(result.value.sourceDeletionFailed).toBe(true);
+  });
+
+  it("returns Err when the copy itself fails", async () => {
+    copyFileMock.mockRejectedValue(new Error("GCS copy failed"));
+
+    const convRes = await ConversationResource.fetchById(auth, conversationId);
+    assert(convRes !== null);
+    const fs = await DustFileSystem.forConversation(auth, convRes.toJSON());
+    assert(fs.isOk());
+
+    const result = await fs.value.move(
+      `conversation-${conversationId}/src.txt`,
+      `conversation-${conversationId}/dest.txt`
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("internal");
+    }
+    // Delete must not be called when the copy failed.
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it("returns Err(invalid_path) when source path is not in any mount", async () => {
+    const convRes = await ConversationResource.fetchById(auth, conversationId);
+    assert(convRes !== null);
+    const fs = await DustFileSystem.forConversation(auth, convRes.toJSON());
+    assert(fs.isOk());
+
+    const result = await fs.value.move(
+      "pod-unknown/src.txt",
+      `conversation-${conversationId}/dest.txt`
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("invalid_path");
+    }
+  });
+});

--- a/front/lib/api/file_system/dust_file_system.test.ts
+++ b/front/lib/api/file_system/dust_file_system.test.ts
@@ -29,7 +29,9 @@ describe("DustFileSystem.forConversation", () => {
   beforeEach(() => {
     vi.mocked(getPrivateUploadBucket).mockReturnValue({
       file: vi.fn(() => ({ save: vi.fn().mockResolvedValue(undefined) })),
-      getAllFilesByPrefix: vi.fn().mockResolvedValue({ files: [], pageFetchCount: 1 }),
+      getAllFilesByPrefix: vi
+        .fn()
+        .mockResolvedValue({ files: [], pageFetchCount: 1 }),
     } as unknown as ReturnType<typeof getPrivateUploadBucket>);
   });
 
@@ -53,7 +55,9 @@ describe("DustFileSystem.forConversation", () => {
     expect(mounts[0].kind).toBe("conversation");
     expect(mounts[0].id).toBe(conversation.sId);
     expect(mounts[0].scopedPrefix).toBe(`conversation-${conversation.sId}`);
-    expect(mounts[0].sandboxMountPoint).toBe(`/files/conversation-${conversation.sId}`);
+    expect(mounts[0].sandboxMountPoint).toBe(
+      `/files/conversation-${conversation.sId}`
+    );
     expect(mounts[0].legacyPrefix).toBe("conversation");
     expect(mounts[0].legacySandboxMountPoint).toBe("/files/conversation");
     expect(mounts[0].permissions.canRead).toBe(true);
@@ -65,7 +69,10 @@ describe("DustFileSystem.forConversation", () => {
 
     // Create the project space, then re-fetch auth so it knows about the new editor group.
     const projectSpace = await SpaceFactory.project(workspace, user.id);
-    const auth = await Authenticator.fromUserIdAndWorkspaceId(user.sId, workspace.sId);
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
 
     const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
       name: "Test Agent",
@@ -105,8 +112,12 @@ describe("DustFileSystem.forConversation", () => {
 describe("DustFileSystem.forPod", () => {
   it("returns Err(unauthorized) when the user has no membership in the space", async () => {
     // Create two separate workspaces; the regular user has no access to the admin's space.
-    const { authenticator: regularAuth } = await createResourceTest({ role: "user" });
-    const { workspace: adminWorkspace } = await createResourceTest({ role: "admin" });
+    const { authenticator: regularAuth } = await createResourceTest({
+      role: "user",
+    });
+    const { workspace: adminWorkspace } = await createResourceTest({
+      role: "admin",
+    });
 
     // Create a project space in the admin workspace with no members.
     const projectSpace = await SpaceFactory.project(adminWorkspace);
@@ -122,7 +133,9 @@ describe("DustFileSystem.forPod", () => {
 
   it("returns Ok with a pod mount when the user is in the editor group", async () => {
     vi.mocked(getPrivateUploadBucket).mockReturnValue({
-      getAllFilesByPrefix: vi.fn().mockResolvedValue({ files: [], pageFetchCount: 1 }),
+      getAllFilesByPrefix: vi
+        .fn()
+        .mockResolvedValue({ files: [], pageFetchCount: 1 }),
     } as unknown as ReturnType<typeof getPrivateUploadBucket>);
 
     const { workspace, user } = await createResourceTest({ role: "admin" });
@@ -131,7 +144,10 @@ describe("DustFileSystem.forPod", () => {
     const projectSpace = await SpaceFactory.project(workspace, user.id);
 
     // Re-fetch auth so _groupModelIds includes the newly created editor group.
-    const auth = await Authenticator.fromUserIdAndWorkspaceId(user.sId, workspace.sId);
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
 
     const result = await DustFileSystem.forPod(auth, projectSpace);
 
@@ -152,7 +168,10 @@ describe("DustFileSystem.forPod", () => {
 describe("DustFileSystem.fromScopedPath", () => {
   it("returns Err(invalid_path) for an unrecognised prefix", async () => {
     const { authenticator: auth } = await createResourceTest({});
-    const result = await DustFileSystem.fromScopedPath(auth, "unknown-prefix/file.txt");
+    const result = await DustFileSystem.fromScopedPath(
+      auth,
+      "unknown-prefix/file.txt"
+    );
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
@@ -162,7 +181,10 @@ describe("DustFileSystem.fromScopedPath", () => {
 
   it("returns Err(not_found) when conversation does not exist", async () => {
     const { authenticator: auth } = await createResourceTest({});
-    const result = await DustFileSystem.fromScopedPath(auth, "conversation-nonexistent/file.txt");
+    const result = await DustFileSystem.fromScopedPath(
+      auth,
+      "conversation-nonexistent/file.txt"
+    );
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
@@ -172,7 +194,10 @@ describe("DustFileSystem.fromScopedPath", () => {
 
   it("returns Err(not_found) when pod space does not exist", async () => {
     const { authenticator: auth } = await createResourceTest({});
-    const result = await DustFileSystem.fromScopedPath(auth, "pod-nonexistent/file.txt");
+    const result = await DustFileSystem.fromScopedPath(
+      auth,
+      "pod-nonexistent/file.txt"
+    );
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
@@ -182,10 +207,13 @@ describe("DustFileSystem.fromScopedPath", () => {
 
   it("returns Ok with a conversation-scoped fs for a conversation- prefix", async () => {
     vi.mocked(getPrivateUploadBucket).mockReturnValue({
-      getAllFilesByPrefix: vi.fn().mockResolvedValue({ files: [], pageFetchCount: 1 }),
+      getAllFilesByPrefix: vi
+        .fn()
+        .mockResolvedValue({ files: [], pageFetchCount: 1 }),
     } as unknown as ReturnType<typeof getPrivateUploadBucket>);
 
-    const { authenticator: auth, conversationsSpace } = await createResourceTest({});
+    const { authenticator: auth, conversationsSpace } =
+      await createResourceTest({});
     const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
       name: "Test Agent",
       description: "Test Agent",
@@ -203,24 +231,169 @@ describe("DustFileSystem.fromScopedPath", () => {
 
     assert(result.isOk());
     const mounts = result.value.getMounts();
-    expect(mounts.some((m) => m.kind === "conversation" && m.id === conversation.sId)).toBe(true);
+    expect(
+      mounts.some((m) => m.kind === "conversation" && m.id === conversation.sId)
+    ).toBe(true);
   });
 });
 
 // ---------------------------------------------------------------------------
-// Legacy path canonicalization
+// list() - thumbnail URL construction
 // ---------------------------------------------------------------------------
 
-describe("DustFileSystem legacy path compatibility", () => {
+describe("DustFileSystem.list thumbnail URLs", () => {
+  let getAllFilesByPrefixMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    getAllFilesByPrefixMock = vi
+      .fn()
+      .mockResolvedValue({ files: [], pageFetchCount: 1 });
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      getAllFilesByPrefix: getAllFilesByPrefixMock,
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+  });
+
+  it("sets thumbnailUrl for image entries in a conversation mount", async () => {
+    const { authenticator: auth, conversationsSpace } =
+      await createResourceTest({});
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+      spaceId: conversationsSpace.id,
+    });
+
+    const workspaceId = auth.getNonNullableWorkspace().sId;
+    const prefix = `w/${workspaceId}/conversations/${conversation.sId}/files/`;
+    getAllFilesByPrefixMock.mockResolvedValue({
+      files: [
+        {
+          name: `${prefix}photo.png`,
+          metadata: {
+            contentType: "image/png",
+            size: "1024",
+            updated: new Date().toISOString(),
+          },
+        },
+      ],
+      pageFetchCount: 1,
+    });
+
+    const fsResult = await DustFileSystem.forConversation(auth, conversation);
+    assert(fsResult.isOk());
+    const entries = await fsResult.value.list();
+
+    const file = entries.find((e) => !e.isDirectory);
+    assert(file !== undefined && !file.isDirectory);
+    expect(file.thumbnailUrl).toBe(
+      `https://dust.tt/api/w/${workspaceId}` +
+        `/assistant/conversations/${conversation.sId}/files/thumbnail` +
+        `?filePath=${encodeURIComponent(`conversation-${conversation.sId}/photo.png`)}`
+    );
+  });
+
+  it("leaves thumbnailUrl null for non-image entries", async () => {
+    const { authenticator: auth, conversationsSpace } =
+      await createResourceTest({});
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+      spaceId: conversationsSpace.id,
+    });
+
+    const workspaceId = auth.getNonNullableWorkspace().sId;
+    const prefix = `w/${workspaceId}/conversations/${conversation.sId}/files/`;
+    getAllFilesByPrefixMock.mockResolvedValue({
+      files: [
+        {
+          name: `${prefix}report.pdf`,
+          metadata: {
+            contentType: "application/pdf",
+            size: "2048",
+            updated: new Date().toISOString(),
+          },
+        },
+      ],
+      pageFetchCount: 1,
+    });
+
+    const fsResult = await DustFileSystem.forConversation(auth, conversation);
+    assert(fsResult.isOk());
+    const entries = await fsResult.value.list();
+
+    const file = entries.find((e) => !e.isDirectory);
+    assert(file !== undefined && !file.isDirectory);
+    expect(file.thumbnailUrl).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Path normalization and traversal prevention
+// ---------------------------------------------------------------------------
+
+describe("DustFileSystem.normalizeScopedPath", () => {
+  it("returns the path unchanged for a clean canonical path", () => {
+    expect(
+      DustFileSystem.normalizeScopedPath("conversation-abc/report.pdf")
+    ).toBe("conversation-abc/report.pdf");
+  });
+
+  it("collapses redundant dot segments", () => {
+    expect(
+      DustFileSystem.normalizeScopedPath("conversation-abc/./report.pdf")
+    ).toBe("conversation-abc/report.pdf");
+  });
+
+  it("collapses double slashes", () => {
+    expect(
+      DustFileSystem.normalizeScopedPath("conversation-abc//report.pdf")
+    ).toBe("conversation-abc/report.pdf");
+  });
+
+  it("returns null for a path that escapes via ..", () => {
+    expect(
+      DustFileSystem.normalizeScopedPath("conversation-abc/../../etc/passwd")
+    ).toBeNull();
+  });
+
+  it("returns null for a bare .. segment", () => {
+    expect(DustFileSystem.normalizeScopedPath("..")).toBeNull();
+  });
+
+  it("returns null for an absolute path", () => {
+    expect(DustFileSystem.normalizeScopedPath("/etc/passwd")).toBeNull();
+  });
+
+  it("returns null when .. escapes a subdirectory but leaves the mount", () => {
+    // conversation-abc/../pod-xyz/file.txt normalises to pod-xyz/file.txt,
+    // which does not start with .. so normalizeScopedPath returns it.
+    // The mount check then rejects it as not belonging to any mount.
+    expect(
+      DustFileSystem.normalizeScopedPath("conversation-abc/../pod-xyz/file.txt")
+    ).toBe("pod-xyz/file.txt");
+  });
+});
+
+describe("DustFileSystem path traversal rejection (integration)", () => {
   let auth: Authenticator;
   let conversationId: string;
-  let saveMock: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
-    saveMock = vi.fn().mockResolvedValue(undefined);
     vi.mocked(getPrivateUploadBucket).mockReturnValue({
-      file: vi.fn(() => ({ save: saveMock })),
-      getAllFilesByPrefix: vi.fn().mockResolvedValue({ files: [], pageFetchCount: 1 }),
+      file: vi.fn(() => ({
+        save: vi.fn().mockResolvedValue(undefined),
+        exists: vi.fn().mockResolvedValue([false]),
+      })),
+      getAllFilesByPrefix: vi
+        .fn()
+        .mockResolvedValue({ files: [], pageFetchCount: 1 }),
     } as unknown as ReturnType<typeof getPrivateUploadBucket>);
 
     const { authenticator, conversationsSpace } = await createResourceTest({});
@@ -238,7 +411,109 @@ describe("DustFileSystem legacy path compatibility", () => {
     conversationId = conversation.sId;
   });
 
-  it("accepts a legacy 'conversation/...' path for write", async () => {
+  async function makeFs() {
+    const convRes = await ConversationResource.fetchById(auth, conversationId);
+    assert(convRes !== null);
+    const fs = await DustFileSystem.forConversation(auth, convRes.toJSON());
+    assert(fs.isOk());
+    return fs.value;
+  }
+
+  it("rejects a write with a .. escape attempt", async () => {
+    const fs = await makeFs();
+    const result = await fs.write(
+      `conversation-${conversationId}/../../etc/passwd`,
+      Buffer.from("x"),
+      "text/plain"
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("invalid_path");
+      expect(result.error.message).toContain("traversal");
+    }
+  });
+
+  it("rejects a read with a .. escape attempt", async () => {
+    const fs = await makeFs();
+    const result = await fs.read(
+      `conversation-${conversationId}/../../etc/passwd`
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("invalid_path");
+      expect(result.error.message).toContain("traversal");
+    }
+  });
+
+  it("rejects a write with an absolute path", async () => {
+    const fs = await makeFs();
+    const result = await fs.write(
+      "/etc/passwd",
+      Buffer.from("x"),
+      "text/plain"
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("invalid_path");
+    }
+  });
+
+  it("normalises harmless dot segments and accepts the path", async () => {
+    const fs = await makeFs();
+    // ./report.txt inside the mount normalises to conversation-{id}/report.txt — valid.
+    const result = await fs.write(
+      `conversation-${conversationId}/./report.txt`,
+      Buffer.from("hello"),
+      "text/plain"
+    );
+    expect(result.isOk()).toBe(true);
+  });
+
+  it("rejects cross-mount traversal (.. to a different scoped prefix)", async () => {
+    const fs = await makeFs();
+    // Normalises to pod-other/file.txt — not in any mount for this FS.
+    const result = await fs.read(
+      `conversation-${conversationId}/../pod-other/file.txt`
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("invalid_path");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Legacy path rejection
+// ---------------------------------------------------------------------------
+
+describe("DustFileSystem legacy path rejection", () => {
+  let auth: Authenticator;
+  let conversationId: string;
+
+  beforeEach(async () => {
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      file: vi.fn(() => ({ save: vi.fn().mockResolvedValue(undefined) })),
+      getAllFilesByPrefix: vi
+        .fn()
+        .mockResolvedValue({ files: [], pageFetchCount: 1 }),
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+
+    const { authenticator, conversationsSpace } = await createResourceTest({});
+    auth = authenticator;
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+      spaceId: conversationsSpace.id,
+    });
+    conversationId = conversation.sId;
+  });
+
+  it("returns Err(legacy_path) for a 'conversation/...' write", async () => {
     const convRes = await ConversationResource.fetchById(auth, conversationId);
     assert(convRes !== null);
     const fs = await DustFileSystem.forConversation(auth, convRes.toJSON());
@@ -250,31 +525,43 @@ describe("DustFileSystem legacy path compatibility", () => {
       "text/plain"
     );
 
-    expect(result.isOk()).toBe(true);
-    expect(saveMock).toHaveBeenCalledOnce();
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("legacy_path");
+    }
   });
 
-  it("treats legacy 'conversation/...' and canonical 'conversation-{cId}/...' as equivalent", async () => {
+  it("returns Err(legacy_path) for a 'project/...' write", async () => {
     const convRes = await ConversationResource.fetchById(auth, conversationId);
     assert(convRes !== null);
     const fs = await DustFileSystem.forConversation(auth, convRes.toJSON());
     assert(fs.isOk());
 
-    const legacyResult = await fs.value.write(
-      "conversation/notes.txt",
-      Buffer.from("a"),
-      "text/plain"
+    const result = await fs.value.write(
+      "project/data.csv",
+      Buffer.from("a,b"),
+      "text/csv"
     );
-    const canonicalResult = await fs.value.write(
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("legacy_path");
+    }
+  });
+
+  it("accepts the canonical 'conversation-{cId}/...' path for write", async () => {
+    const convRes = await ConversationResource.fetchById(auth, conversationId);
+    assert(convRes !== null);
+    const fs = await DustFileSystem.forConversation(auth, convRes.toJSON());
+    assert(fs.isOk());
+
+    const result = await fs.value.write(
       `conversation-${conversationId}/notes.txt`,
       Buffer.from("a"),
       "text/plain"
     );
 
-    expect(legacyResult.isOk()).toBe(true);
-    expect(canonicalResult.isOk()).toBe(true);
-    // Both writes should reach GCS.
-    expect(saveMock).toHaveBeenCalledTimes(2);
+    expect(result.isOk()).toBe(true);
   });
 });
 
@@ -288,7 +575,9 @@ describe("DustFileSystem permission enforcement", () => {
 
   beforeEach(async () => {
     vi.mocked(getPrivateUploadBucket).mockReturnValue({
-      getAllFilesByPrefix: vi.fn().mockResolvedValue({ files: [], pageFetchCount: 1 }),
+      getAllFilesByPrefix: vi
+        .fn()
+        .mockResolvedValue({ files: [], pageFetchCount: 1 }),
       file: vi.fn(() => ({
         save: vi.fn().mockResolvedValue(undefined),
         exists: vi.fn().mockResolvedValue([false]),
@@ -316,7 +605,11 @@ describe("DustFileSystem permission enforcement", () => {
     const fs = await DustFileSystem.forConversation(auth, convRes.toJSON());
     assert(fs.isOk());
 
-    const result = await fs.value.write("pod-unknown/file.txt", Buffer.from("x"), "text/plain");
+    const result = await fs.value.write(
+      "pod-unknown/file.txt",
+      Buffer.from("x"),
+      "text/plain"
+    );
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
@@ -331,7 +624,10 @@ describe("DustFileSystem permission enforcement", () => {
     assert(fs.isOk());
 
     const result = await fs.value.read("pod-unknown/file.txt");
-    expect(result).toBeNull();
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("invalid_path");
+    }
   });
 
   it("conversation mount always has canRead and canWrite", async () => {
@@ -388,10 +684,10 @@ describe("DustFileSystem.move", () => {
     const fs = await DustFileSystem.forConversation(auth, convRes.toJSON());
     assert(fs.isOk());
 
-    const result = await fs.value.move(
-      `conversation-${conversationId}/src.txt`,
-      `conversation-${conversationId}/dest.txt`
-    );
+    const result = await fs.value.move({
+      src: `conversation-${conversationId}/src.txt`,
+      dest: `conversation-${conversationId}/dest.txt`,
+    });
 
     assert(result.isOk());
     expect(result.value.sourceDeletionFailed).toBe(false);
@@ -400,17 +696,17 @@ describe("DustFileSystem.move", () => {
   });
 
   it("returns Ok with sourceDeletionFailed true when delete fails after a successful copy", async () => {
-    deleteMock.mockRejectedValue(new Error("GCS delete failed"));
+    deleteMock.mockRejectedValue(new Error("storage delete failed"));
 
     const convRes = await ConversationResource.fetchById(auth, conversationId);
     assert(convRes !== null);
     const fs = await DustFileSystem.forConversation(auth, convRes.toJSON());
     assert(fs.isOk());
 
-    const result = await fs.value.move(
-      `conversation-${conversationId}/src.txt`,
-      `conversation-${conversationId}/dest.txt`
-    );
+    const result = await fs.value.move({
+      src: `conversation-${conversationId}/src.txt`,
+      dest: `conversation-${conversationId}/dest.txt`,
+    });
 
     // The destination copy succeeded, so we return Ok instead of Err.
     assert(result.isOk());
@@ -418,17 +714,17 @@ describe("DustFileSystem.move", () => {
   });
 
   it("returns Err when the copy itself fails", async () => {
-    copyFileMock.mockRejectedValue(new Error("GCS copy failed"));
+    copyFileMock.mockRejectedValue(new Error("storage copy failed"));
 
     const convRes = await ConversationResource.fetchById(auth, conversationId);
     assert(convRes !== null);
     const fs = await DustFileSystem.forConversation(auth, convRes.toJSON());
     assert(fs.isOk());
 
-    const result = await fs.value.move(
-      `conversation-${conversationId}/src.txt`,
-      `conversation-${conversationId}/dest.txt`
-    );
+    const result = await fs.value.move({
+      src: `conversation-${conversationId}/src.txt`,
+      dest: `conversation-${conversationId}/dest.txt`,
+    });
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
@@ -444,10 +740,10 @@ describe("DustFileSystem.move", () => {
     const fs = await DustFileSystem.forConversation(auth, convRes.toJSON());
     assert(fs.isOk());
 
-    const result = await fs.value.move(
-      "pod-unknown/src.txt",
-      `conversation-${conversationId}/dest.txt`
-    );
+    const result = await fs.value.move({
+      src: "pod-unknown/src.txt",
+      dest: `conversation-${conversationId}/dest.txt`,
+    });
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -1,0 +1,464 @@
+/**
+ * DustFileSystem is the single entry point for all file system operations in the Dust platform.
+ *
+ * Scoped path: the agent/API-visible path format, e.g. `conversation-{cId}/report.pdf` or
+ * `pod-{pId}/data.csv`. Every public method accepts and returns scoped paths.
+ * Legacy paths (`conversation/...`, `project/...`) are accepted for backward compat.
+ *
+ * Factories:
+ *   DustFileSystem.forConversation(auth, conversation)  conversation mount (+pod if project space)
+ *   DustFileSystem.forPod(auth, space)                  pod (project-space) mount only
+ *   DustFileSystem.fromScopedPath(auth, scopedPath)     infers context from the path prefix
+ */
+
+import { GCSFileSystemBackend } from "@app/lib/api/file_system/backends/gcs_file_system_backend";
+import type { FileSystemBackend } from "@app/lib/api/file_system/backends/file_system_backend";
+import type {
+  FileSystemEntry,
+  FileSystemMount,
+} from "@app/lib/api/file_system/types";
+import { DustFileSystemError } from "@app/lib/api/file_system/types";
+import type { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
+import type { Authenticator } from "@app/lib/auth";
+import fileStorageConfig from "@app/lib/file_storage/config";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import logger from "@app/logger/logger";
+import { isProjectConversation } from "@app/types/assistant/conversation";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import { Err, Ok, type Result } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+export type { FileSystemEntry, FileSystemMount } from "@app/lib/api/file_system/types";
+export { DustFileSystemError } from "@app/lib/api/file_system/types";
+
+// ---------------------------------------------------------------------------
+// Scoped-path prefix parsing
+// ---------------------------------------------------------------------------
+
+type ParsedScopedPrefix =
+  | { kind: "conversation"; id: string }
+  | { kind: "pod"; id: string };
+
+function parseScopedPrefix(scopedPath: string): ParsedScopedPrefix | null {
+  const prefix = scopedPath.includes("/")
+    ? scopedPath.slice(0, scopedPath.indexOf("/"))
+    : scopedPath;
+
+  if (prefix.startsWith("conversation-")) {
+    const id = prefix.slice("conversation-".length);
+    return id ? { kind: "conversation", id } : null;
+  }
+  if (prefix.startsWith("pod-")) {
+    const id = prefix.slice("pod-".length);
+    return id ? { kind: "pod", id } : null;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// DustFileSystem
+// ---------------------------------------------------------------------------
+
+export class DustFileSystem {
+  private constructor(
+    private readonly auth: Authenticator,
+    private readonly mounts: ReadonlyArray<FileSystemMount>,
+    private readonly backend: FileSystemBackend
+  ) {}
+
+  // --------------------------------------------------------------------------
+  // Factories
+  // --------------------------------------------------------------------------
+
+  /**
+   * Build a DustFileSystem scoped to a conversation.
+   *
+   * Always includes the conversation mount. When the conversation belongs to a project space,
+   * the pod mount is added with permissions derived from the space's canRead/canWrite checks.
+   */
+  static async forConversation(
+    auth: Authenticator,
+    conversation: ConversationWithoutContentType
+  ): Promise<Result<DustFileSystem, DustFileSystemError>> {
+    const owner = auth.getNonNullableWorkspace();
+
+    const convMount: FileSystemMount = {
+      kind: "conversation",
+      id: conversation.sId,
+      scopedPrefix: `conversation-${conversation.sId}`,
+      sandboxMountPoint: `/files/conversation-${conversation.sId}`,
+      legacyPrefix: "conversation",
+      legacySandboxMountPoint: "/files/conversation",
+      // Conversation access is always read+write when the caller holds a valid auth for it.
+      // The handler is responsible for verifying conversation access before calling this factory.
+      permissions: { canRead: true, canWrite: true },
+    };
+
+    const mounts: FileSystemMount[] = [convMount];
+
+    if (isProjectConversation(conversation)) {
+      const space = await SpaceResource.fetchById(auth, conversation.spaceId);
+      if (space) {
+        mounts.push({
+          kind: "pod",
+          id: space.sId,
+          scopedPrefix: `pod-${space.sId}`,
+          sandboxMountPoint: `/files/pod-${space.sId}`,
+          legacyPrefix: "project",
+          legacySandboxMountPoint: "/files/project",
+          permissions: {
+            canRead: space.canRead(auth),
+            canWrite: space.canWrite(auth),
+          },
+        });
+      }
+    }
+
+    const backend = new GCSFileSystemBackend(
+      owner.sId,
+      fileStorageConfig.getGcsPrivateUploadsBucket()
+    );
+
+    return new Ok(new DustFileSystem(auth, mounts, backend));
+  }
+
+  /**
+   * Build a DustFileSystem scoped to a pod (project space).
+   * Returns `Err("unauthorized")` when the caller does not have read access to the space.
+   */
+  static async forPod(
+    auth: Authenticator,
+    space: SpaceResource
+  ): Promise<Result<DustFileSystem, DustFileSystemError>> {
+    if (!space.canRead(auth)) {
+      return new Err(
+        new DustFileSystemError("unauthorized", "You do not have read access to this space.")
+      );
+    }
+
+    const owner = auth.getNonNullableWorkspace();
+    const mount: FileSystemMount = {
+      kind: "pod",
+      id: space.sId,
+      scopedPrefix: `pod-${space.sId}`,
+      sandboxMountPoint: `/files/pod-${space.sId}`,
+      legacyPrefix: "project",
+      legacySandboxMountPoint: "/files/project",
+      permissions: {
+        canRead: true,
+        canWrite: space.canWrite(auth),
+      },
+    };
+
+    const backend = new GCSFileSystemBackend(
+      owner.sId,
+      fileStorageConfig.getGcsPrivateUploadsBucket()
+    );
+
+    return new Ok(new DustFileSystem(auth, [mount], backend));
+  }
+
+  /**
+   * Build a DustFileSystem by inferring context from the scoped path prefix.
+   *
+   * `conversation-{cId}/...` fetches the conversation and delegates to forConversation.
+   * `pod-{pId}/...`          fetches the space and delegates to forPod.
+   *
+   * Returns `Err("not_found")` when the resource is missing,
+   * `Err("invalid_path")` for unrecognised prefixes.
+   */
+  static async fromScopedPath(
+    auth: Authenticator,
+    scopedPath: string
+  ): Promise<Result<DustFileSystem, DustFileSystemError>> {
+    const parsed = parseScopedPrefix(scopedPath);
+    if (!parsed) {
+      return new Err(
+        new DustFileSystemError(
+          "invalid_path",
+          `Cannot infer file system context from path: ${scopedPath}`
+        )
+      );
+    }
+
+    switch (parsed.kind) {
+      case "conversation": {
+        const conversation = await ConversationResource.fetchById(auth, parsed.id);
+        if (!conversation) {
+          return new Err(
+            new DustFileSystemError("not_found", `Conversation not found: ${parsed.id}`)
+          );
+        }
+        return DustFileSystem.forConversation(auth, conversation.toJSON());
+      }
+
+      case "pod": {
+        const space = await SpaceResource.fetchById(auth, parsed.id);
+        if (!space) {
+          return new Err(
+            new DustFileSystemError("not_found", `Space not found: ${parsed.id}`)
+          );
+        }
+        return DustFileSystem.forPod(auth, space);
+      }
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Internal helpers
+  // --------------------------------------------------------------------------
+
+  /** Returns the mount the path belongs to, checking both canonical and legacy prefixes. */
+  private findMount(scopedPath: string): FileSystemMount | null {
+    for (const mount of this.mounts) {
+      if (
+        scopedPath === mount.scopedPrefix ||
+        scopedPath.startsWith(`${mount.scopedPrefix}/`)
+      ) {
+        return mount;
+      }
+      if (
+        mount.legacyPrefix &&
+        (scopedPath === mount.legacyPrefix ||
+          scopedPath.startsWith(`${mount.legacyPrefix}/`))
+      ) {
+        return mount;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Rewrite a legacy path to its canonical form.
+   * `"conversation/report.pdf"` with the conversation mount -> `"conversation-{cId}/report.pdf"`.
+   */
+  private canonicalizePath(scopedPath: string, mount: FileSystemMount): string {
+    if (mount.legacyPrefix && scopedPath.startsWith(`${mount.legacyPrefix}/`)) {
+      return `${mount.scopedPrefix}/${scopedPath.slice(mount.legacyPrefix.length + 1)}`;
+    }
+    if (scopedPath === mount.legacyPrefix) {
+      return mount.scopedPrefix;
+    }
+    return scopedPath;
+  }
+
+  private requireReadMount(
+    scopedPath: string
+  ): Result<{ mount: FileSystemMount; path: string }, DustFileSystemError> {
+    const mount = this.findMount(scopedPath);
+    if (!mount) {
+      return new Err(
+        new DustFileSystemError(
+          "invalid_path",
+          `Path does not belong to any known mount: ${scopedPath}`
+        )
+      );
+    }
+    if (!mount.permissions.canRead) {
+      return new Err(
+        new DustFileSystemError(
+          "unauthorized",
+          `Read access denied for mount: ${mount.scopedPrefix}`
+        )
+      );
+    }
+    return new Ok({ mount, path: this.canonicalizePath(scopedPath, mount) });
+  }
+
+  private requireWriteMount(
+    scopedPath: string
+  ): Result<{ mount: FileSystemMount; path: string }, DustFileSystemError> {
+    const mount = this.findMount(scopedPath);
+    if (!mount) {
+      return new Err(
+        new DustFileSystemError(
+          "invalid_path",
+          `Path does not belong to any known mount: ${scopedPath}`
+        )
+      );
+    }
+    if (!mount.permissions.canWrite) {
+      return new Err(
+        new DustFileSystemError(
+          "unauthorized",
+          `Write access denied for mount: ${mount.scopedPrefix}`
+        )
+      );
+    }
+    return new Ok({ mount, path: this.canonicalizePath(scopedPath, mount) });
+  }
+
+  // --------------------------------------------------------------------------
+  // Public API
+  // --------------------------------------------------------------------------
+
+  getMounts(): ReadonlyArray<FileSystemMount> {
+    return this.mounts;
+  }
+
+  /**
+   * List entries under `scopedPath`.
+   * When `scopedPath` is omitted, lists across all readable mounts.
+   */
+  async list(
+    scopedPath?: string,
+    opts?: { maxFiles?: number; includeProcessed?: boolean }
+  ): Promise<FileSystemEntry[]> {
+    if (scopedPath !== undefined) {
+      const resolved = this.requireReadMount(scopedPath);
+      if (resolved.isErr()) {
+        logger.warn({ err: resolved.error, scopedPath }, "DustFileSystem.list: access check failed");
+        return [];
+      }
+      return this.backend.list(resolved.value.path, opts);
+    }
+
+    const results: FileSystemEntry[] = [];
+    for (const mount of this.mounts) {
+      if (!mount.permissions.canRead) {
+        continue;
+      }
+      const entries = await this.backend.list(`${mount.scopedPrefix}/`, opts);
+      results.push(...entries);
+    }
+    return results;
+  }
+
+  /** Returns `null` when not found rather than throwing. */
+  async read(scopedPath: string): Promise<Buffer | null> {
+    const resolved = this.requireReadMount(scopedPath);
+    if (resolved.isErr()) {
+      return null;
+    }
+    return this.backend.read(resolved.value.path);
+  }
+
+  async write(
+    scopedPath: string,
+    content: Buffer | string,
+    contentType: string
+  ): Promise<Result<void, DustFileSystemError>> {
+    const resolved = this.requireWriteMount(scopedPath);
+    if (resolved.isErr()) {
+      return resolved;
+    }
+    try {
+      await this.backend.write(resolved.value.path, content, contentType);
+      return new Ok(undefined);
+    } catch (err) {
+      return new Err(new DustFileSystemError("internal", normalizeError(err).message));
+    }
+  }
+
+  async delete(
+    scopedPath: string,
+    opts?: { ignoreNotFound?: boolean }
+  ): Promise<Result<void, DustFileSystemError>> {
+    const resolved = this.requireWriteMount(scopedPath);
+    if (resolved.isErr()) {
+      return resolved;
+    }
+    try {
+      await this.backend.delete(resolved.value.path, opts);
+      return new Ok(undefined);
+    } catch (err) {
+      return new Err(new DustFileSystemError("internal", normalizeError(err).message));
+    }
+  }
+
+  /** `src` requires read access, `dest` requires write access. */
+  async copy(
+    src: string,
+    dest: string
+  ): Promise<Result<void, DustFileSystemError>> {
+    const resolvedSrc = this.requireReadMount(src);
+    if (resolvedSrc.isErr()) {
+      return resolvedSrc;
+    }
+    const resolvedDest = this.requireWriteMount(dest);
+    if (resolvedDest.isErr()) {
+      return resolvedDest;
+    }
+    try {
+      await this.backend.copy(resolvedSrc.value.path, resolvedDest.value.path);
+      return new Ok(undefined);
+    } catch (err) {
+      return new Err(new DustFileSystemError("internal", normalizeError(err).message));
+    }
+  }
+
+  /**
+   * Move `src` to `dest` (copy then delete source).
+   *
+   * GCS has no atomic rename so this is copy-then-delete. When the source deletion fails
+   * after a successful copy, returns `Ok({ sourceDeletionFailed: true })` rather than
+   * `Err` because the destination is already the authoritative copy.
+   */
+  async move(
+    src: string,
+    dest: string
+  ): Promise<Result<{ sourceDeletionFailed: boolean }, DustFileSystemError>> {
+    const resolvedSrc = this.requireWriteMount(src);
+    if (resolvedSrc.isErr()) {
+      return resolvedSrc;
+    }
+    const resolvedDest = this.requireWriteMount(dest);
+    if (resolvedDest.isErr()) {
+      return resolvedDest;
+    }
+
+    try {
+      await this.backend.copy(resolvedSrc.value.path, resolvedDest.value.path);
+    } catch (err) {
+      return new Err(new DustFileSystemError("internal", normalizeError(err).message));
+    }
+
+    try {
+      await this.backend.delete(resolvedSrc.value.path);
+    } catch (err) {
+      logger.error(
+        { err: normalizeError(err), src: resolvedSrc.value.path, dest: resolvedDest.value.path },
+        "DustFileSystem.move: source delete failed after successful copy"
+      );
+      return new Ok({ sourceDeletionFailed: true });
+    }
+
+    return new Ok({ sourceDeletionFailed: false });
+  }
+
+  async getDownloadUrl(
+    scopedPath: string,
+    opts?: { expiresInMs?: number; fileName?: string }
+  ): Promise<Result<string, DustFileSystemError>> {
+    const resolved = this.requireReadMount(scopedPath);
+    if (resolved.isErr()) {
+      return resolved;
+    }
+    try {
+      const url = await this.backend.getDownloadUrl(resolved.value.path, opts);
+      return new Ok(url);
+    } catch (err) {
+      return new Err(new DustFileSystemError("internal", normalizeError(err).message));
+    }
+  }
+
+  /** No-ops when the sandbox image does not support the required capability. */
+  async setupSandboxMount(
+    sandbox: SandboxResource,
+    image: SandboxImage
+  ): Promise<Result<void, Error>> {
+    const adapter = this.backend.createSandboxAdapter(this.mounts);
+    return adapter.setup(this.auth, sandbox, image);
+  }
+
+  /** Refresh the storage credential in an already-mounted sandbox. */
+  async refreshSandboxMount(
+    sandbox: SandboxResource,
+    image: SandboxImage
+  ): Promise<Result<void, Error>> {
+    const adapter = this.backend.createSandboxAdapter(this.mounts);
+    return adapter.refreshCredential(this.auth, sandbox, image);
+  }
+}

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -11,13 +11,21 @@
  *   DustFileSystem.fromScopedPath(auth, scopedPath)     infers context from the path prefix
  */
 
+import config from "@app/lib/api/config";
 import type { FileSystemBackend } from "@app/lib/api/file_system/backends/file_system_backend";
 import { GCSFileSystemBackend } from "@app/lib/api/file_system/backends/gcs_file_system_backend";
 import type {
   FileSystemEntry,
+  FileSystemFileEntry,
   FileSystemMount,
 } from "@app/lib/api/file_system/types";
-import { DustFileSystemError } from "@app/lib/api/file_system/types";
+import {
+  DustFileSystemError,
+  LEGACY_PREFIX_CONVERSATION,
+  LEGACY_PREFIX_PROJECT,
+  SCOPED_PREFIX_CONVERSATION,
+  SCOPED_PREFIX_POD,
+} from "@app/lib/api/file_system/types";
 import type { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
 import type { Authenticator } from "@app/lib/auth";
 import fileStorageConfig from "@app/lib/file_storage/config";
@@ -27,8 +35,11 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { isProjectConversation } from "@app/types/assistant/conversation";
+import { isSupportedImageContentType } from "@app/types/files";
 import { Err, Ok, type Result } from "@app/types/shared/result";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import * as path from "path";
+import type { Readable } from "stream";
 
 export type {
   FileSystemEntry,
@@ -49,13 +60,15 @@ function parseScopedPrefix(scopedPath: string): ParsedScopedPrefix | null {
     ? scopedPath.slice(0, scopedPath.indexOf("/"))
     : scopedPath;
 
-  if (prefix.startsWith("conversation-")) {
-    const id = prefix.slice("conversation-".length);
+  if (prefix.startsWith(SCOPED_PREFIX_CONVERSATION)) {
+    const id = prefix.slice(SCOPED_PREFIX_CONVERSATION.length);
+
     return id ? { kind: "conversation", id } : null;
   }
 
-  if (prefix.startsWith("pod-")) {
-    const id = prefix.slice("pod-".length);
+  if (prefix.startsWith(SCOPED_PREFIX_POD)) {
+    const id = prefix.slice(SCOPED_PREFIX_POD.length);
+
     return id ? { kind: "pod", id } : null;
   }
 
@@ -93,10 +106,10 @@ export class DustFileSystem {
     const convMount: FileSystemMount = {
       kind: "conversation",
       id: conversation.sId,
-      scopedPrefix: `conversation-${conversation.sId}`,
-      sandboxMountPoint: `/files/conversation-${conversation.sId}`,
-      legacyPrefix: "conversation",
-      legacySandboxMountPoint: "/files/conversation",
+      scopedPrefix: `${SCOPED_PREFIX_CONVERSATION}${conversation.sId}`,
+      sandboxMountPoint: `/files/${SCOPED_PREFIX_CONVERSATION}${conversation.sId}`,
+      legacyPrefix: LEGACY_PREFIX_CONVERSATION,
+      legacySandboxMountPoint: `/files/${LEGACY_PREFIX_CONVERSATION}`,
       // Conversation access is always read+write when the caller holds a valid auth for it.
       // The handler is responsible for verifying conversation access before calling this factory.
       permissions: { canRead: true, canWrite: true },
@@ -110,10 +123,10 @@ export class DustFileSystem {
         mounts.push({
           kind: "pod",
           id: space.sId,
-          scopedPrefix: `pod-${space.sId}`,
-          sandboxMountPoint: `/files/pod-${space.sId}`,
-          legacyPrefix: "project",
-          legacySandboxMountPoint: "/files/project",
+          scopedPrefix: `${SCOPED_PREFIX_POD}${space.sId}`,
+          sandboxMountPoint: `/files/${SCOPED_PREFIX_POD}${space.sId}`,
+          legacyPrefix: LEGACY_PREFIX_PROJECT,
+          legacySandboxMountPoint: `/files/${LEGACY_PREFIX_PROJECT}`,
           permissions: {
             canRead: space.canRead(auth),
             canWrite: space.canWrite(auth),
@@ -151,10 +164,10 @@ export class DustFileSystem {
     const mount: FileSystemMount = {
       kind: "pod",
       id: space.sId,
-      scopedPrefix: `pod-${space.sId}`,
-      sandboxMountPoint: `/files/pod-${space.sId}`,
-      legacyPrefix: "project",
-      legacySandboxMountPoint: "/files/project",
+      scopedPrefix: `${SCOPED_PREFIX_POD}${space.sId}`,
+      sandboxMountPoint: `/files/${SCOPED_PREFIX_POD}${space.sId}`,
+      legacyPrefix: LEGACY_PREFIX_PROJECT,
+      legacySandboxMountPoint: `/files/${LEGACY_PREFIX_PROJECT}`,
       permissions: {
         canRead: true,
         canWrite: space.canWrite(auth),
@@ -223,6 +236,9 @@ export class DustFileSystem {
 
         return DustFileSystem.forPod(auth, space);
       }
+
+      default:
+        assertNever(parsed);
     }
   }
 
@@ -230,7 +246,7 @@ export class DustFileSystem {
   // Internal helpers
   // --------------------------------------------------------------------------
 
-  /** Returns the mount the path belongs to, checking both canonical and legacy prefixes. */
+  /** Returns the mount the path belongs to by canonical prefix only. */
   private findMount(scopedPath: string): FileSystemMount | null {
     for (const mount of this.mounts) {
       if (
@@ -239,43 +255,76 @@ export class DustFileSystem {
       ) {
         return mount;
       }
-      if (
-        mount.legacyPrefix &&
-        (scopedPath === mount.legacyPrefix ||
-          scopedPath.startsWith(`${mount.legacyPrefix}/`))
-      ) {
-        return mount;
-      }
     }
     return null;
   }
 
   /**
-   * Rewrite a legacy path to its canonical form.
-   * `"conversation/report.pdf"` with the conversation mount -> `"conversation-{cId}/report.pdf"`.
+   * Returns true when `scopedPath` uses the old agent-visible format
+   * (`conversation/...` or `project/...`). Used to produce a helpful error
+   * instead of a generic invalid_path when the model passes a stale path.
    */
-  private canonicalizePath(scopedPath: string, mount: FileSystemMount): string {
-    if (mount.legacyPrefix && scopedPath.startsWith(`${mount.legacyPrefix}/`)) {
-      return `${mount.scopedPrefix}/${scopedPath.slice(mount.legacyPrefix.length + 1)}`;
+  private static isLegacyPath(scopedPath: string): boolean {
+    return (
+      scopedPath === LEGACY_PREFIX_CONVERSATION ||
+      scopedPath.startsWith(`${LEGACY_PREFIX_CONVERSATION}/`) ||
+      scopedPath === LEGACY_PREFIX_PROJECT ||
+      scopedPath.startsWith(`${LEGACY_PREFIX_PROJECT}/`)
+    );
+  }
+
+  /**
+   * Normalizes a caller-supplied scoped path using POSIX rules (resolves `.` and `..`).
+   *
+   * Returns `null` when the result would escape the scoped namespace : i.e. when the
+   * normalized path starts with `..` (path traversal) or `/` (absolute path injection).
+   * This is the primary defense against path-traversal attacks.
+   */
+  static normalizeScopedPath(scopedPath: string): string | null {
+    const normalized = path.posix.normalize(scopedPath);
+    if (
+      normalized === ".." ||
+      normalized.startsWith("../") ||
+      normalized.startsWith("/")
+    ) {
+      return null;
     }
-    if (scopedPath === mount.legacyPrefix) {
-      return mount.scopedPrefix;
-    }
-    return scopedPath;
+
+    return normalized;
   }
 
   private requireReadMount(
     scopedPath: string
   ): Result<{ mount: FileSystemMount; path: string }, DustFileSystemError> {
-    const mount = this.findMount(scopedPath);
-    if (!mount) {
+    const normalized = DustFileSystem.normalizeScopedPath(scopedPath);
+    if (!normalized) {
       return new Err(
         new DustFileSystemError(
           "invalid_path",
-          `Path does not belong to any known mount: ${scopedPath}`
+          `Path traversal detected: \`${scopedPath}\` is not allowed.`
         )
       );
     }
+
+    const mount = this.findMount(normalized);
+    if (!mount) {
+      if (DustFileSystem.isLegacyPath(normalized)) {
+        return new Err(
+          new DustFileSystemError(
+            "legacy_path",
+            `Path \`${normalized}\` uses an outdated format. Call \`files__list\` to get current paths.`
+          )
+        );
+      }
+
+      return new Err(
+        new DustFileSystemError(
+          "invalid_path",
+          `Path does not belong to any known mount: ${normalized}`
+        )
+      );
+    }
+
     if (!mount.permissions.canRead) {
       return new Err(
         new DustFileSystemError(
@@ -284,21 +333,42 @@ export class DustFileSystem {
         )
       );
     }
-    return new Ok({ mount, path: this.canonicalizePath(scopedPath, mount) });
+
+    return new Ok({ mount, path: normalized });
   }
 
   private requireWriteMount(
     scopedPath: string
   ): Result<{ mount: FileSystemMount; path: string }, DustFileSystemError> {
-    const mount = this.findMount(scopedPath);
-    if (!mount) {
+    const normalized = DustFileSystem.normalizeScopedPath(scopedPath);
+    if (!normalized) {
       return new Err(
         new DustFileSystemError(
           "invalid_path",
-          `Path does not belong to any known mount: ${scopedPath}`
+          `Path traversal detected: \`${scopedPath}\` is not allowed.`
         )
       );
     }
+
+    const mount = this.findMount(normalized);
+    if (!mount) {
+      if (DustFileSystem.isLegacyPath(normalized)) {
+        return new Err(
+          new DustFileSystemError(
+            "legacy_path",
+            `Path \`${normalized}\` uses an outdated format. Call \`files__list\` to get current paths.`
+          )
+        );
+      }
+
+      return new Err(
+        new DustFileSystemError(
+          "invalid_path",
+          `Path does not belong to any known mount: ${normalized}`
+        )
+      );
+    }
+
     if (!mount.permissions.canWrite) {
       return new Err(
         new DustFileSystemError(
@@ -307,7 +377,8 @@ export class DustFileSystem {
         )
       );
     }
-    return new Ok({ mount, path: this.canonicalizePath(scopedPath, mount) });
+
+    return new Ok({ mount, path: normalized });
   }
 
   // --------------------------------------------------------------------------
@@ -319,13 +390,53 @@ export class DustFileSystem {
   }
 
   /**
+   * Constructs the thumbnail API URL for an image file entry.
+   * Lives here because the URL points to our application API, not to GCS.
+   */
+  private buildThumbnailUrl(
+    entry: FileSystemFileEntry,
+    workspaceId: string
+  ): string | null {
+    if (!isSupportedImageContentType(entry.contentType)) {
+      return null;
+    }
+    const mount = this.findMount(entry.path);
+    if (!mount) {
+      return null;
+    }
+    switch (mount.kind) {
+      case "conversation":
+        return (
+          `${config.getApiBaseUrl()}/api/w/${workspaceId}` +
+          `/assistant/conversations/${mount.id}/files/thumbnail` +
+          `?filePath=${encodeURIComponent(entry.path)}`
+        );
+      case "pod":
+        // TODO(FILE SYSTEM): expose a pod-files thumbnail endpoint.
+        return null;
+    }
+  }
+
+  /**
    * List entries under `scopedPath`.
    * When `scopedPath` is omitted, lists across all readable mounts.
+   * Thumbnail URLs are populated here (not in the backend) since they point to our API.
    */
   async list(
     scopedPath?: string,
     opts?: { maxFiles?: number; includeProcessed?: boolean }
   ): Promise<FileSystemEntry[]> {
+    const workspaceId = this.auth.getNonNullableWorkspace().sId;
+    const withThumbnails = (entries: FileSystemEntry[]): FileSystemEntry[] =>
+      entries.map((entry) =>
+        entry.isDirectory
+          ? entry
+          : {
+              ...entry,
+              thumbnailUrl: this.buildThumbnailUrl(entry, workspaceId),
+            }
+      );
+
     if (scopedPath !== undefined) {
       const resolved = this.requireReadMount(scopedPath);
       if (resolved.isErr()) {
@@ -335,7 +446,7 @@ export class DustFileSystem {
         );
         return [];
       }
-      return this.backend.list(resolved.value.path, opts);
+      return withThumbnails(await this.backend.list(resolved.value.path, opts));
     }
 
     const results: FileSystemEntry[] = [];
@@ -344,18 +455,45 @@ export class DustFileSystem {
         continue;
       }
       const entries = await this.backend.list(`${mount.scopedPrefix}/`, opts);
-      results.push(...entries);
+      results.push(...withThumbnails(entries));
     }
     return results;
   }
 
-  /** Returns `null` when not found rather than throwing. */
-  async read(scopedPath: string): Promise<Buffer | null> {
+  /**
+   * Returns `Ok(null)` when the file does not exist, `Ok(Readable)` on success.
+   * The caller owns the stream and must consume or destroy it.
+   * Returns `Err` for path/permission errors (including `legacy_path`).
+   */
+  async read(
+    scopedPath: string
+  ): Promise<Result<Readable | null, DustFileSystemError>> {
     const resolved = this.requireReadMount(scopedPath);
     if (resolved.isErr()) {
-      return null;
+      return resolved;
     }
     return this.backend.read(resolved.value.path);
+  }
+
+  /**
+   * Returns metadata for the file at `scopedPath`, or `Ok(null)` when not found.
+   * Returns `Err` for path/permission errors (including `legacy_path`).
+   */
+  async stat(
+    scopedPath: string
+  ): Promise<
+    Result<
+      { contentType: string; sizeBytes: number } | null,
+      DustFileSystemError
+    >
+  > {
+    const resolved = this.requireReadMount(scopedPath);
+    if (resolved.isErr()) {
+      return resolved;
+    }
+
+    const stat = await this.backend.stat(resolved.value.path);
+    return new Ok(stat);
   }
 
   async write(
@@ -367,14 +505,8 @@ export class DustFileSystem {
     if (resolved.isErr()) {
       return resolved;
     }
-    try {
-      await this.backend.write(resolved.value.path, content, contentType);
-      return new Ok(undefined);
-    } catch (err) {
-      return new Err(
-        new DustFileSystemError("internal", normalizeError(err).message)
-      );
-    }
+
+    return this.backend.write(resolved.value.path, content, contentType);
   }
 
   async delete(
@@ -385,21 +517,17 @@ export class DustFileSystem {
     if (resolved.isErr()) {
       return resolved;
     }
-    try {
-      await this.backend.delete(resolved.value.path, opts);
-      return new Ok(undefined);
-    } catch (err) {
-      return new Err(
-        new DustFileSystemError("internal", normalizeError(err).message)
-      );
-    }
+    return this.backend.delete(resolved.value.path, opts);
   }
 
   /** `src` requires read access, `dest` requires write access. */
-  async copy(
-    src: string,
-    dest: string
-  ): Promise<Result<void, DustFileSystemError>> {
+  async copy({
+    src,
+    dest,
+  }: {
+    src: string;
+    dest: string;
+  }): Promise<Result<void, DustFileSystemError>> {
     const resolvedSrc = this.requireReadMount(src);
     if (resolvedSrc.isErr()) {
       return resolvedSrc;
@@ -408,14 +536,10 @@ export class DustFileSystem {
     if (resolvedDest.isErr()) {
       return resolvedDest;
     }
-    try {
-      await this.backend.copy(resolvedSrc.value.path, resolvedDest.value.path);
-      return new Ok(undefined);
-    } catch (err) {
-      return new Err(
-        new DustFileSystemError("internal", normalizeError(err).message)
-      );
-    }
+    return this.backend.copy({
+      src: resolvedSrc.value.path,
+      dest: resolvedDest.value.path,
+    });
   }
 
   /**
@@ -425,10 +549,13 @@ export class DustFileSystem {
    * after a successful copy, returns `Ok({ sourceDeletionFailed: true })` rather than
    * `Err` because the destination is already the authoritative copy.
    */
-  async move(
-    src: string,
-    dest: string
-  ): Promise<Result<{ sourceDeletionFailed: boolean }, DustFileSystemError>> {
+  async move({
+    src,
+    dest,
+  }: {
+    src: string;
+    dest: string;
+  }): Promise<Result<{ sourceDeletionFailed: boolean }, DustFileSystemError>> {
     const resolvedSrc = this.requireWriteMount(src);
     if (resolvedSrc.isErr()) {
       return resolvedSrc;
@@ -438,20 +565,19 @@ export class DustFileSystem {
       return resolvedDest;
     }
 
-    try {
-      await this.backend.copy(resolvedSrc.value.path, resolvedDest.value.path);
-    } catch (err) {
-      return new Err(
-        new DustFileSystemError("internal", normalizeError(err).message)
-      );
+    const copyResult = await this.backend.copy({
+      src: resolvedSrc.value.path,
+      dest: resolvedDest.value.path,
+    });
+    if (copyResult.isErr()) {
+      return copyResult;
     }
 
-    try {
-      await this.backend.delete(resolvedSrc.value.path);
-    } catch (err) {
+    const deleteResult = await this.backend.delete(resolvedSrc.value.path);
+    if (deleteResult.isErr()) {
       logger.error(
         {
-          err: normalizeError(err),
+          err: deleteResult.error,
           src: resolvedSrc.value.path,
           dest: resolvedDest.value.path,
         },
@@ -471,14 +597,7 @@ export class DustFileSystem {
     if (resolved.isErr()) {
       return resolved;
     }
-    try {
-      const url = await this.backend.getDownloadUrl(resolved.value.path, opts);
-      return new Ok(url);
-    } catch (err) {
-      return new Err(
-        new DustFileSystemError("internal", normalizeError(err).message)
-      );
-    }
+    return this.backend.getDownloadUrl(resolved.value.path, opts);
   }
 
   /** No-ops when the sandbox image does not support the required capability. */

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -492,8 +492,7 @@ export class DustFileSystem {
       return resolved;
     }
 
-    const stat = await this.backend.stat(resolved.value.path);
-    return new Ok(stat);
+    return this.backend.stat(resolved.value.path);
   }
 
   async write(

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -11,8 +11,8 @@
  *   DustFileSystem.fromScopedPath(auth, scopedPath)     infers context from the path prefix
  */
 
-import { GCSFileSystemBackend } from "@app/lib/api/file_system/backends/gcs_file_system_backend";
 import type { FileSystemBackend } from "@app/lib/api/file_system/backends/file_system_backend";
+import { GCSFileSystemBackend } from "@app/lib/api/file_system/backends/gcs_file_system_backend";
 import type {
   FileSystemEntry,
   FileSystemMount,
@@ -22,15 +22,18 @@ import type { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
 import type { Authenticator } from "@app/lib/auth";
 import fileStorageConfig from "@app/lib/file_storage/config";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
-import { isProjectConversation } from "@app/types/assistant/conversation";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import { isProjectConversation } from "@app/types/assistant/conversation";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
-export type { FileSystemEntry, FileSystemMount } from "@app/lib/api/file_system/types";
+export type {
+  FileSystemEntry,
+  FileSystemMount,
+} from "@app/lib/api/file_system/types";
 export { DustFileSystemError } from "@app/lib/api/file_system/types";
 
 // ---------------------------------------------------------------------------
@@ -50,10 +53,12 @@ function parseScopedPrefix(scopedPath: string): ParsedScopedPrefix | null {
     const id = prefix.slice("conversation-".length);
     return id ? { kind: "conversation", id } : null;
   }
+
   if (prefix.startsWith("pod-")) {
     const id = prefix.slice("pod-".length);
     return id ? { kind: "pod", id } : null;
   }
+
   return null;
 }
 
@@ -84,6 +89,7 @@ export class DustFileSystem {
   ): Promise<Result<DustFileSystem, DustFileSystemError>> {
     const owner = auth.getNonNullableWorkspace();
 
+    // TODO: Can't we use conversation resource so we can check the canWrite or canRead?!
     const convMount: FileSystemMount = {
       kind: "conversation",
       id: conversation.sId,
@@ -134,7 +140,10 @@ export class DustFileSystem {
   ): Promise<Result<DustFileSystem, DustFileSystemError>> {
     if (!space.canRead(auth)) {
       return new Err(
-        new DustFileSystemError("unauthorized", "You do not have read access to this space.")
+        new DustFileSystemError(
+          "unauthorized",
+          "You do not have read access to this space."
+        )
       );
     }
 
@@ -185,12 +194,19 @@ export class DustFileSystem {
 
     switch (parsed.kind) {
       case "conversation": {
-        const conversation = await ConversationResource.fetchById(auth, parsed.id);
+        const conversation = await ConversationResource.fetchById(
+          auth,
+          parsed.id
+        );
         if (!conversation) {
           return new Err(
-            new DustFileSystemError("not_found", `Conversation not found: ${parsed.id}`)
+            new DustFileSystemError(
+              "not_found",
+              `Conversation not found: ${parsed.id}`
+            )
           );
         }
+
         return DustFileSystem.forConversation(auth, conversation.toJSON());
       }
 
@@ -198,9 +214,13 @@ export class DustFileSystem {
         const space = await SpaceResource.fetchById(auth, parsed.id);
         if (!space) {
           return new Err(
-            new DustFileSystemError("not_found", `Space not found: ${parsed.id}`)
+            new DustFileSystemError(
+              "not_found",
+              `Space not found: ${parsed.id}`
+            )
           );
         }
+
         return DustFileSystem.forPod(auth, space);
       }
     }
@@ -309,7 +329,10 @@ export class DustFileSystem {
     if (scopedPath !== undefined) {
       const resolved = this.requireReadMount(scopedPath);
       if (resolved.isErr()) {
-        logger.warn({ err: resolved.error, scopedPath }, "DustFileSystem.list: access check failed");
+        logger.warn(
+          { err: resolved.error, scopedPath },
+          "DustFileSystem.list: access check failed"
+        );
         return [];
       }
       return this.backend.list(resolved.value.path, opts);
@@ -348,7 +371,9 @@ export class DustFileSystem {
       await this.backend.write(resolved.value.path, content, contentType);
       return new Ok(undefined);
     } catch (err) {
-      return new Err(new DustFileSystemError("internal", normalizeError(err).message));
+      return new Err(
+        new DustFileSystemError("internal", normalizeError(err).message)
+      );
     }
   }
 
@@ -364,7 +389,9 @@ export class DustFileSystem {
       await this.backend.delete(resolved.value.path, opts);
       return new Ok(undefined);
     } catch (err) {
-      return new Err(new DustFileSystemError("internal", normalizeError(err).message));
+      return new Err(
+        new DustFileSystemError("internal", normalizeError(err).message)
+      );
     }
   }
 
@@ -385,7 +412,9 @@ export class DustFileSystem {
       await this.backend.copy(resolvedSrc.value.path, resolvedDest.value.path);
       return new Ok(undefined);
     } catch (err) {
-      return new Err(new DustFileSystemError("internal", normalizeError(err).message));
+      return new Err(
+        new DustFileSystemError("internal", normalizeError(err).message)
+      );
     }
   }
 
@@ -412,14 +441,20 @@ export class DustFileSystem {
     try {
       await this.backend.copy(resolvedSrc.value.path, resolvedDest.value.path);
     } catch (err) {
-      return new Err(new DustFileSystemError("internal", normalizeError(err).message));
+      return new Err(
+        new DustFileSystemError("internal", normalizeError(err).message)
+      );
     }
 
     try {
       await this.backend.delete(resolvedSrc.value.path);
     } catch (err) {
       logger.error(
-        { err: normalizeError(err), src: resolvedSrc.value.path, dest: resolvedDest.value.path },
+        {
+          err: normalizeError(err),
+          src: resolvedSrc.value.path,
+          dest: resolvedDest.value.path,
+        },
         "DustFileSystem.move: source delete failed after successful copy"
       );
       return new Ok({ sourceDeletionFailed: true });
@@ -440,7 +475,9 @@ export class DustFileSystem {
       const url = await this.backend.getDownloadUrl(resolved.value.path, opts);
       return new Ok(url);
     } catch (err) {
-      return new Err(new DustFileSystemError("internal", normalizeError(err).message));
+      return new Err(
+        new DustFileSystemError("internal", normalizeError(err).message)
+      );
     }
   }
 

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -98,11 +98,11 @@ export class DustFileSystem {
    */
   static async forConversation(
     auth: Authenticator,
+    // TODO(FILE SYSTEM MIGRATION): Ideally, we accept a ConversationResource directly.
     conversation: ConversationWithoutContentType
   ): Promise<Result<DustFileSystem, DustFileSystemError>> {
     const owner = auth.getNonNullableWorkspace();
 
-    // TODO: Can't we use conversation resource so we can check the canWrite or canRead?!
     const convMount: FileSystemMount = {
       kind: "conversation",
       id: conversation.sId,

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -411,9 +411,13 @@ export class DustFileSystem {
           `/assistant/conversations/${mount.id}/files/thumbnail` +
           `?filePath=${encodeURIComponent(entry.path)}`
         );
+
       case "pod":
         // TODO(FILE SYSTEM): expose a pod-files thumbnail endpoint.
         return null;
+
+      default:
+        assertNever(mount.kind);
     }
   }
 

--- a/front/lib/api/file_system/index.ts
+++ b/front/lib/api/file_system/index.ts
@@ -7,3 +7,9 @@ export type {
   FileSystemEntry,
   FileSystemMount,
 } from "@app/lib/api/file_system/types";
+export {
+  LEGACY_PREFIX_CONVERSATION,
+  LEGACY_PREFIX_PROJECT,
+  SCOPED_PREFIX_CONVERSATION,
+  SCOPED_PREFIX_POD,
+} from "@app/lib/api/file_system/types";

--- a/front/lib/api/file_system/index.ts
+++ b/front/lib/api/file_system/index.ts
@@ -1,0 +1,9 @@
+export {
+  DustFileSystem,
+  DustFileSystemError,
+} from "@app/lib/api/file_system/dust_file_system";
+export type {
+  FileSystemEntry,
+  FileSystemMount,
+} from "@app/lib/api/file_system/types";
+export type { DustFileSystemErrorCode } from "@app/lib/api/file_system/types";

--- a/front/lib/api/file_system/index.ts
+++ b/front/lib/api/file_system/index.ts
@@ -3,7 +3,7 @@ export {
   DustFileSystemError,
 } from "@app/lib/api/file_system/dust_file_system";
 export type {
+  DustFileSystemErrorCode,
   FileSystemEntry,
   FileSystemMount,
 } from "@app/lib/api/file_system/types";
-export type { DustFileSystemErrorCode } from "@app/lib/api/file_system/types";

--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
@@ -1,0 +1,253 @@
+import {
+  buildAccessBoundaryRules,
+  mintDownscopedGcsToken,
+} from "@app/lib/api/sandbox/gcs/token";
+import type { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
+import type { Authenticator } from "@app/lib/auth";
+import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import logger from "@app/logger/logger";
+import { Err, Ok, type Result } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { concurrentExecutor } from "@app/temporal/workflow_utils";
+
+import type { SandboxMountAdapter } from "./sandbox_mount_adapter";
+
+const MOUNT_TIMEOUT_MS = 30_000;
+
+export type GCSMountTarget = {
+  /**
+   * GCS object prefix, no trailing slash, e.g. `w/{wId}/conversations/{cId}/files`.
+   * Used in CAB conditions and as the `gcsfuse --only-dir` argument.
+   */
+  gcsPrefix: string;
+  sandboxMountPoint: string;
+  /**
+   * When set, a symlink is created from this path to `sandboxMountPoint` after mounting
+   * so that old hardcoded paths (`/files/conversation`, `/files/project`) keep working.
+   */
+  legacySandboxMountPoint: string | null;
+};
+
+/**
+ * GCS-specific SandboxMountAdapter.
+ *
+ * Mounts one GCS prefix per target via gcsfuse using a CAB-scoped downscoped token
+ * served by a lightweight HTTP token server baked into the sandbox image.
+ *
+ * Token budget: 1 unconditional rule + 2 rules per prefix, max 10 CAB rules total,
+ * so at most 4 targets are supported.
+ */
+export class GCSSandboxMountAdapter implements SandboxMountAdapter {
+  constructor(
+    private readonly bucket: string,
+    private readonly targets: ReadonlyArray<GCSMountTarget>
+  ) {
+    if (targets.length > 4) {
+      throw new Error(
+        `GCSSandboxMountAdapter: too many targets (${targets.length}), CAB rule limit is 4.`
+      );
+    }
+  }
+
+  async setup(
+    auth: Authenticator,
+    sandbox: SandboxResource,
+    image: SandboxImage
+  ): Promise<Result<void, Error>> {
+    if (!image.hasCapability("gcsfuse")) {
+      return new Ok(undefined);
+    }
+
+    const { bucket, targets } = this;
+    const prefixes = targets.map((t) => t.gcsPrefix);
+    const workspaceId = auth.getNonNullableWorkspace().sId;
+
+    const childLogger = logger.child({ sandboxId: sandbox.sId, workspaceId, bucket, prefixes });
+
+    // 1. Mint a CAB-scoped token covering every prefix.
+    const tokenResult = await mintDownscopedGcsToken({ bucket, prefixes });
+    if (tokenResult.isErr()) {
+      childLogger.error({ err: tokenResult.error }, "GCS sandbox mount: failed to mint token");
+      return tokenResult;
+    }
+
+    // 2. Write token file into the sandbox.
+    const tokenJson = buildTokenJson(tokenResult.value);
+    const writeResult = await sandbox.exec(
+      auth,
+      `printf '%s' '${escapeSingleQuotes(tokenJson)}' > /tmp/token.json`
+    );
+    if (writeResult.isErr()) {
+      childLogger.error({ err: writeResult.error }, "GCS sandbox mount: failed to write token file");
+      return writeResult;
+    }
+
+    // 3. Start the token HTTP server (baked into the image at token-server.sh) and wait for :9876.
+    const startResult = await sandbox.exec(
+      auth,
+      "bash /home/agent/.bin/token-server.sh > /tmp/server.log 2>&1 &"
+    );
+    if (startResult.isErr()) {
+      childLogger.error({ err: startResult.error }, "GCS sandbox mount: failed to start token server");
+      return startResult;
+    }
+
+    const checkResult = await sandbox.exec(
+      auth,
+      "sleep 1 && curl -sf http://127.0.0.1:9876 > /dev/null 2>&1"
+    );
+    if (checkResult.isErr() || checkResult.value.exitCode !== 0) {
+      const msg = "GCS token server not ready after 1s";
+      childLogger.error({}, msg);
+      return new Err(new Error(msg));
+    }
+
+    // 4. Create mount directories and run gcsfuse concurrently for each target.
+    const mountResults = await concurrentExecutor(
+      [...targets],
+      async (target) => {
+        const mkdirResult = await sandbox.exec(
+          auth,
+          `mkdir -p ${target.sandboxMountPoint}`,
+          { user: "root" }
+        );
+        if (mkdirResult.isErr()) {
+          return mkdirResult;
+        }
+
+        const mountResult = await sandbox.exec(
+          auth,
+          buildMountCommand({ bucket, prefix: target.gcsPrefix, mountPoint: target.sandboxMountPoint }),
+          { timeoutMs: MOUNT_TIMEOUT_MS, user: "root" }
+        );
+
+        if (mountResult.isErr()) {
+          childLogger.error(
+            { err: mountResult.error, mountPoint: target.sandboxMountPoint },
+            "GCS sandbox mount: gcsfuse failed"
+          );
+          return mountResult;
+        }
+
+        if (mountResult.value.exitCode !== 0) {
+          const msg = `gcsfuse exited with code ${mountResult.value.exitCode} for ${target.sandboxMountPoint}: ${mountResult.value.stderr}`;
+          childLogger.error({ stderr: mountResult.value.stderr, mountPoint: target.sandboxMountPoint }, msg);
+          return new Err(new Error(msg));
+        }
+
+        // 5. Backward-compat symlink so old paths keep working.
+        if (target.legacySandboxMountPoint) {
+          const symlinkResult = await sandbox.exec(
+            auth,
+            `ln -sfn ${target.sandboxMountPoint} ${target.legacySandboxMountPoint}`,
+            { user: "root" }
+          );
+          if (symlinkResult.isErr()) {
+            // Non-fatal: canonical path works, old code hitting the legacy path will just fail.
+            childLogger.warn(
+              { err: symlinkResult.error, legacyMountPoint: target.legacySandboxMountPoint },
+              "GCS sandbox mount: legacy symlink failed (non-fatal)"
+            );
+          }
+        }
+
+        return new Ok(undefined);
+      },
+      { concurrency: targets.length }
+    );
+
+    const firstError = mountResults.find((r) => r.isErr());
+    if (firstError) {
+      childLogger.error({}, "GCS sandbox mount: one or more targets failed");
+      return firstError;
+    }
+
+    childLogger.info(
+      { mountPoints: targets.map((t) => t.sandboxMountPoint) },
+      "GCS sandbox mount: all targets mounted successfully"
+    );
+
+    return new Ok(undefined);
+  }
+
+  async refreshCredential(
+    auth: Authenticator,
+    sandbox: SandboxResource,
+    image: SandboxImage
+  ): Promise<Result<void, Error>> {
+    if (!image.hasCapability("gcsfuse")) {
+      return new Ok(undefined);
+    }
+
+    const prefixes = this.targets.map((t) => t.gcsPrefix);
+    const tokenResult = await mintDownscopedGcsToken({ bucket: this.bucket, prefixes });
+    if (tokenResult.isErr()) {
+      return tokenResult;
+    }
+
+    const writeResult = await sandbox.exec(
+      auth,
+      `printf '%s' '${escapeSingleQuotes(buildTokenJson(tokenResult.value))}' > /tmp/token.json`
+    );
+    if (writeResult.isErr()) {
+      return writeResult;
+    }
+
+    logger.info(
+      { sandboxId: sandbox.sId, workspaceId: auth.getNonNullableWorkspace().sId, prefixes },
+      "GCS sandbox mount: credential refreshed"
+    );
+
+    return new Ok(undefined);
+  }
+
+  /** Exposed for testing and diagnostics. */
+  getAccessBoundaryRules() {
+    return buildAccessBoundaryRules(this.bucket, this.targets.map((t) => t.gcsPrefix));
+  }
+}
+
+function buildMountCommand({
+  bucket,
+  prefix,
+  mountPoint,
+}: {
+  bucket: string;
+  prefix: string;
+  mountPoint: string;
+}): string {
+  const flags = [
+    "--token-url http://127.0.0.1:9876",
+    // Disable token caching so gcsfuse fetches a fresh credential on every GCS API request.
+    "--reuse-token-from-url=false",
+    `--only-dir ${prefix}`,
+    "--implicit-dirs",
+    "-o allow_other",
+    "--file-mode=666",
+    "--dir-mode=777",
+    "--kernel-list-cache-ttl-secs=60",
+    // Disable HNS: GetStorageLayout requires unrestricted objects.list which CAB cannot grant
+    // per-prefix. With HNS disabled we scope list access via objectListPrefix conditions.
+    "--enable-hns=false",
+  ].join(" ");
+
+  return `timeout 30 gcsfuse ${flags} ${bucket} ${mountPoint} 2>&1`;
+}
+
+function buildTokenJson({
+  accessToken,
+  expiresInSeconds,
+}: {
+  accessToken: string;
+  expiresInSeconds: number;
+}): string {
+  return JSON.stringify({
+    access_token: accessToken,
+    token_type: "Bearer",
+    expires_in: expiresInSeconds,
+  });
+}
+
+function escapeSingleQuotes(s: string): string {
+  return s.replace(/'/g, "'\\''");
+}

--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
@@ -6,9 +6,8 @@ import type { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
 import type { Authenticator } from "@app/lib/auth";
 import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import logger from "@app/logger/logger";
-import { Err, Ok, type Result } from "@app/types/shared/result";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { concurrentExecutor } from "@app/temporal/workflow_utils";
+import { Err, Ok, type Result } from "@app/types/shared/result";
 
 import type { SandboxMountAdapter } from "./sandbox_mount_adapter";
 
@@ -62,12 +61,20 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
     const prefixes = targets.map((t) => t.gcsPrefix);
     const workspaceId = auth.getNonNullableWorkspace().sId;
 
-    const childLogger = logger.child({ sandboxId: sandbox.sId, workspaceId, bucket, prefixes });
+    const childLogger = logger.child({
+      sandboxId: sandbox.sId,
+      workspaceId,
+      bucket,
+      prefixes,
+    });
 
     // 1. Mint a CAB-scoped token covering every prefix.
     const tokenResult = await mintDownscopedGcsToken({ bucket, prefixes });
     if (tokenResult.isErr()) {
-      childLogger.error({ err: tokenResult.error }, "GCS sandbox mount: failed to mint token");
+      childLogger.error(
+        { err: tokenResult.error },
+        "GCS sandbox mount: failed to mint token"
+      );
       return tokenResult;
     }
 
@@ -78,7 +85,10 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
       `printf '%s' '${escapeSingleQuotes(tokenJson)}' > /tmp/token.json`
     );
     if (writeResult.isErr()) {
-      childLogger.error({ err: writeResult.error }, "GCS sandbox mount: failed to write token file");
+      childLogger.error(
+        { err: writeResult.error },
+        "GCS sandbox mount: failed to write token file"
+      );
       return writeResult;
     }
 
@@ -88,7 +98,10 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
       "bash /home/agent/.bin/token-server.sh > /tmp/server.log 2>&1 &"
     );
     if (startResult.isErr()) {
-      childLogger.error({ err: startResult.error }, "GCS sandbox mount: failed to start token server");
+      childLogger.error(
+        { err: startResult.error },
+        "GCS sandbox mount: failed to start token server"
+      );
       return startResult;
     }
 
@@ -117,7 +130,11 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
 
         const mountResult = await sandbox.exec(
           auth,
-          buildMountCommand({ bucket, prefix: target.gcsPrefix, mountPoint: target.sandboxMountPoint }),
+          buildMountCommand({
+            bucket,
+            prefix: target.gcsPrefix,
+            mountPoint: target.sandboxMountPoint,
+          }),
           { timeoutMs: MOUNT_TIMEOUT_MS, user: "root" }
         );
 
@@ -131,7 +148,13 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
 
         if (mountResult.value.exitCode !== 0) {
           const msg = `gcsfuse exited with code ${mountResult.value.exitCode} for ${target.sandboxMountPoint}: ${mountResult.value.stderr}`;
-          childLogger.error({ stderr: mountResult.value.stderr, mountPoint: target.sandboxMountPoint }, msg);
+          childLogger.error(
+            {
+              stderr: mountResult.value.stderr,
+              mountPoint: target.sandboxMountPoint,
+            },
+            msg
+          );
           return new Err(new Error(msg));
         }
 
@@ -145,7 +168,10 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
           if (symlinkResult.isErr()) {
             // Non-fatal: canonical path works, old code hitting the legacy path will just fail.
             childLogger.warn(
-              { err: symlinkResult.error, legacyMountPoint: target.legacySandboxMountPoint },
+              {
+                err: symlinkResult.error,
+                legacyMountPoint: target.legacySandboxMountPoint,
+              },
               "GCS sandbox mount: legacy symlink failed (non-fatal)"
             );
           }
@@ -180,7 +206,10 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
     }
 
     const prefixes = this.targets.map((t) => t.gcsPrefix);
-    const tokenResult = await mintDownscopedGcsToken({ bucket: this.bucket, prefixes });
+    const tokenResult = await mintDownscopedGcsToken({
+      bucket: this.bucket,
+      prefixes,
+    });
     if (tokenResult.isErr()) {
       return tokenResult;
     }
@@ -194,7 +223,11 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
     }
 
     logger.info(
-      { sandboxId: sandbox.sId, workspaceId: auth.getNonNullableWorkspace().sId, prefixes },
+      {
+        sandboxId: sandbox.sId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        prefixes,
+      },
       "GCS sandbox mount: credential refreshed"
     );
 
@@ -203,7 +236,10 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
 
   /** Exposed for testing and diagnostics. */
   getAccessBoundaryRules() {
-    return buildAccessBoundaryRules(this.bucket, this.targets.map((t) => t.gcsPrefix));
+    return buildAccessBoundaryRules(
+      this.bucket,
+      this.targets.map((t) => t.gcsPrefix)
+    );
   }
 }
 

--- a/front/lib/api/file_system/sandbox/sandbox_mount_adapter.ts
+++ b/front/lib/api/file_system/sandbox/sandbox_mount_adapter.ts
@@ -1,0 +1,34 @@
+import type { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
+import type { Authenticator } from "@app/lib/auth";
+import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import type { Result } from "@app/types/shared/result";
+
+/**
+ * Abstracts storage-backend-specific logic for mounting a file system into a sandbox.
+ * Always produced by `FileSystemBackend.createSandboxAdapter(mounts)` so the adapter
+ * carries all backend-specific context internally. Callers never touch storage paths.
+ */
+export interface SandboxMountAdapter {
+  /**
+   * Full mount sequence: mint credential, write it to the sandbox, start the credential
+   * server, create mount directories, run the mount tool for each target, and create
+   * backward-compat symlinks.
+   *
+   * Returns `Ok(undefined)` when the image does not support the required capability.
+   */
+  setup(
+    auth: Authenticator,
+    sandbox: SandboxResource,
+    image: SandboxImage
+  ): Promise<Result<void, Error>>;
+
+  /**
+   * Refresh the credential in an already-mounted sandbox without remounting.
+   * Overwrites the credential file that the credential server reads on the next request.
+   */
+  refreshCredential(
+    auth: Authenticator,
+    sandbox: SandboxResource,
+    image: SandboxImage
+  ): Promise<Result<void, Error>>;
+}

--- a/front/lib/api/file_system/types.ts
+++ b/front/lib/api/file_system/types.ts
@@ -1,0 +1,85 @@
+/**
+ * Shared types for the DustFileSystem abstraction.
+ *
+ * Scoped path: the agent/API-visible path format, e.g. `conversation-{cId}/report.pdf`
+ * or `pod-{pId}/data.csv`. Every public interface accepts and returns scoped paths.
+ *
+ * FileSystemMount: one logical namespace (conversation or pod) with its scoped prefix,
+ * sandbox mount point, backward-compat aliases, and per-mount permissions.
+ */
+
+export type FileSystemMountKind = "conversation" | "pod";
+
+export type FileSystemMount = {
+  kind: FileSystemMountKind;
+
+  /** sId of the conversation or space this mount is scoped to. */
+  id: string;
+
+  /** Prefix of every scoped path in this mount, e.g. `conversation-{cId}` or `pod-{pId}`. */
+  scopedPrefix: string;
+
+  /** Absolute sandbox path, e.g. `/files/conversation-{cId}`. */
+  sandboxMountPoint: string;
+
+  /**
+   * Legacy scoped prefix (`"conversation"` or `"project"`) accepted for backward compat.
+   * Null for mounts with no legacy counterpart.
+   */
+  legacyPrefix: string | null;
+
+  /**
+   * Legacy sandbox mount point (`/files/conversation` or `/files/project`).
+   * The sandbox adapter symlinks this to `sandboxMountPoint` after mounting.
+   * Null when there is no legacy counterpart.
+   */
+  legacySandboxMountPoint: string | null;
+
+  /** Resolved eagerly at factory time. */
+  permissions: {
+    canRead: boolean;
+    canWrite: boolean;
+  };
+};
+
+type FileSystemEntryBase = {
+  fileName: string;
+  /** Full scoped path, e.g. `conversation-{cId}/folder/report.pdf`. Always canonical. */
+  path: string;
+  sizeBytes: number;
+  lastModifiedMs: number;
+};
+
+export type FileSystemDirectoryEntry = FileSystemEntryBase & {
+  isDirectory: true;
+};
+
+export type FileSystemFileEntry = FileSystemEntryBase & {
+  isDirectory: false;
+  contentType: string;
+  /** sId of the corresponding FileResource record, or null when none exists. */
+  fileId: string | null;
+  thumbnailUrl: string | null;
+  /** Present when the caller requested signed URLs. */
+  signedDownloadUrl?: string | null;
+};
+
+export type FileSystemEntry = FileSystemDirectoryEntry | FileSystemFileEntry;
+
+export type DustFileSystemErrorCode =
+  | "unauthorized"
+  | "not_found"
+  | "invalid_path"
+  | "too_many_mounts"
+  | "already_exists"
+  | "internal";
+
+export class DustFileSystemError extends Error {
+  constructor(
+    readonly code: DustFileSystemErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = "DustFileSystemError";
+  }
+}

--- a/front/lib/api/file_system/types.ts
+++ b/front/lib/api/file_system/types.ts
@@ -10,6 +10,14 @@
 
 export type FileSystemMountKind = "conversation" | "pod";
 
+/** Canonical scoped-path prefixes (include the trailing dash). */
+export const SCOPED_PREFIX_CONVERSATION = "conversation-" as const;
+export const SCOPED_PREFIX_POD = "pod-" as const;
+
+/** Legacy agent-visible path prefixes (no trailing dash/slash). */
+export const LEGACY_PREFIX_CONVERSATION = "conversation" as const;
+export const LEGACY_PREFIX_PROJECT = "project" as const;
+
 export type FileSystemMount = {
   kind: FileSystemMountKind;
 
@@ -70,6 +78,7 @@ export type DustFileSystemErrorCode =
   | "unauthorized"
   | "not_found"
   | "invalid_path"
+  | "legacy_path"
   | "too_many_mounts"
   | "already_exists"
   | "internal";

--- a/front/lib/resources/storage/models/files.ts
+++ b/front/lib/resources/storage/models/files.ts
@@ -82,6 +82,11 @@ FileModel.init(
       allowNull: true,
       defaultValue: null,
     },
+    // TODO: migrate mountFilePath from raw GCS paths (e.g. `w/{wId}/conversations/{cId}/files/report.pdf`)
+    // to DustFileSystem scoped paths (e.g. `conversation-{cId}/report.pdf`).
+    // Once done, update FileResource.fetchByMountFilePaths to accept scoped paths, remove
+    // GCS path derivation in move.ts and resolve.ts, and enable fileId population in
+    // GCSFileSystemBackend.list.
     mountFilePath: {
       type: DataTypes.STRING(4096),
       allowNull: true,

--- a/front/lib/resources/storage/models/files.ts
+++ b/front/lib/resources/storage/models/files.ts
@@ -82,11 +82,6 @@ FileModel.init(
       allowNull: true,
       defaultValue: null,
     },
-    // TODO: migrate mountFilePath from raw GCS paths (e.g. `w/{wId}/conversations/{cId}/files/report.pdf`)
-    // to DustFileSystem scoped paths (e.g. `conversation-{cId}/report.pdf`).
-    // Once done, update FileResource.fetchByMountFilePaths to accept scoped paths, remove
-    // GCS path derivation in move.ts and resolve.ts, and enable fileId population in
-    // GCSFileSystemBackend.list.
     mountFilePath: {
       type: DataTypes.STRING(4096),
       allowNull: true,


### PR DESCRIPTION
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Extracted from: https://github.com/dust-tt/dust/pull/26318

## Context: Why the current file handling falls short

File handling today is built around two notions: a scoped path (e.g. `conversation/report.pdf`) and a raw GCS object path that encodes workspace, conversation, and filename as separate segments. These two representations live in different layers, and the code stitching them together. Mount point resolution, bucket operations, path helpers has leaked into nearly every place that touches files: agent tool handlers, viz rendering, the sandbox, conversation rendering, pods, and more.

The core problem is that a scoped path carries no context by itself. To act on `conversation/report.pdf` you must already hold a conversation object, know the workspace ID, and look up the project space if the path is project-scoped. This ambient context requirement made the file system feel like a thin naming convention rather than a coherent boundary, and it became visible as a real limitation when files needed to be accessed from outside a conversation (e.g. in pods). Each new access pattern required threading more state down the call stack and added yet another dependency on GCS internals.

## What this PR introduces

A canonical scoped path that captures the full context:
- `conversation-{conversationId}/report.pdf`
- `pod-{spaceId}/shared/data.csv`

The ID is embedded directly in the path prefix. Any layer that has the path has everything it needs to resolve it. No separate conversation object, no workspace threading, no project space lookup. The paths are opaque to callers: the abstraction knows how to parse and route them. Consumers just pass them through.

A clean file system abstraction (`DustFileSystem`) built on that path format:

- A single entry point constructed from an Authenticator + Conversation pair. It builds all mount points internally
(conversation scope always, pod scope when the conversation belongs to a project) and enforces access control.
- Operations: stat, read, write, copy, move, delete, list, getDownloadUrl. All accept and return canonical scoped paths. No
GCS paths, no bucket names, no workspace IDs visible at the call site.
- A typed error vocabulary (`DustFileSystemError`) with codes for every expected failure mode: invalid_path, legacy_path,
unauthorized, not_found, already_exists, too_many_mounts, internal. Callers switch on the code rather than parsing error
messages.

## Legacy path rejection at the boundary:

Paths in the old format (`conversation/`, `project/`) are detected and returned as "legacy_path" errors. This gives future
callers an unambiguous signal to look up a migration guide rather than silently misrouting.

## A pluggable backend:

The `DustFileSystem` class delegates to a `FileSystemBackend` interface. The only concrete implementation today is GCS-backed, but the interface means the storage layer is an implementation detail. It doesn't appear in any type signature or error message visible to callers.

## A sandbox mount adapter:

A separate adapter translates canonical scoped paths to the filesystem paths visible inside a sandbox process. This is also
zero-caller today but establishes the contract for the sandbox integration PR.

## What this PR does NOT do

No existing callers are changed. The current agent tools, viz runtime, API endpoints, and sandbox mounts all continue to work exactly as before through the existing legacy layer. This PR is purely additive, new module, new tests, no behaviour
change.

## Plan

1. This PR — Foundation: the abstraction, the canonical path format, the backend interface, the sandbox adapter contract.
2. Next — Serving layer + viz: a new API endpoint that resolves canonical paths to bytes, and viz runtime updated to accept
both old and new path formats side-by-side. After this it is safe for anything to emit canonical paths without breaking
rendering.
3. Then — Agent tools: migrate all MCP file tools and `run_agent` file forwarding to `DustFileSystem`. Agents will see canonical paths from list and pass them through all other tools correctly.
4. Then — User-facing: upload pipeline, thumbnails, signed download URLs.
5. Then — Sandbox: wire the sandbox mount adapter to replace the current gcsfuse glue.

The reason for this order is the dependency: the viz/serving layer must be able to handle canonical paths before tools start
emitting them. Flipping tools before the serving layer is ready would break frame rendering for any path that looked like
`conversation-{id}/chart.html`.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
