### PR TITLE
Fix run_agent side panel streaming: store conversationId and agentMessageId in query resource

### DIFF
--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -83,7 +83,8 @@ export function MCPRunAgentActionDetails({
     disabled: addedMCPServerViewIds.length === 0,
   });
 
-  const queryResource = toolOutput?.find(isRunAgentQueryResourceType) ?? null;
+  const queryResource =
+    toolOutput?.findLast(isRunAgentQueryResourceType) ?? null;
   const resultResource = toolOutput?.find(isRunAgentResultResourceType) ?? null;
   const handoverResource =
     toolOutput?.find(isAgentPauseOutputResourceType) ?? null;
@@ -91,40 +92,62 @@ export function MCPRunAgentActionDetails({
   const generatedFiles =
     toolOutput?.filter(isToolGeneratedFile).map((o) => o.resource) ?? [];
 
-  const [query, setQuery] = useState<string | null>(null);
-  const [childAgentId, setChildAgentId] = useState<string | null>(null);
-  const [childStreamIds, setChildStreamIds] = useState<{
+  const [query, setQuery] = useState<string | null>(
+    () => queryResource?.resource.text ?? null
+  );
+  const [childAgentId, setChildAgentId] = useState<string | null>(
+    () => queryResource?.resource.childAgentId ?? null
+  );
+
+  useEffect(() => {
+    if (queryResource?.resource.text) {
+      setQuery(queryResource.resource.text);
+    }
+    if (queryResource?.resource.childAgentId) {
+      setChildAgentId(queryResource.resource.childAgentId);
+    }
+  }, [queryResource]);
+
+  // Primary path: IDs are stored in the query resource once the child agent message exists.
+  const childStreamIds = useMemo(() => {
+    const { conversationId, agentMessageId } = queryResource?.resource ?? {};
+    if (conversationId && agentMessageId) {
+      return { conversationId, agentMessageId };
+    }
+    return null;
+  }, [queryResource]);
+
+  // Fast path: IDs from the live notification when the panel is open during streaming.
+  const [streamIdsFromNotification, setStreamIdsFromNotification] = useState<{
     conversationId: string;
     agentMessageId: string;
   } | null>(null);
 
-  // Extract query, childAgentId, conversationId, and agentMessageId from
-  // notifications and tool output.
   useEffect(() => {
-    if (queryResource) {
-      setQuery(queryResource.resource.text);
-      setChildAgentId(queryResource.resource.childAgentId);
+    const output = lastNotification?._meta.data.output;
+    if (!output) {
+      return;
     }
-    if (lastNotification?._meta.data.output) {
-      const output = lastNotification._meta.data.output;
-      if (isStoreResourceProgressOutput(output)) {
-        const runAgentQueryResource = output.contents.find(
-          isRunAgentQueryResourceType
-        );
-        if (runAgentQueryResource) {
-          setQuery(runAgentQueryResource.resource.text);
-          setChildAgentId(runAgentQueryResource.resource.childAgentId);
-        }
+    // Populate query/childAgentId from the store_resource notification (fast path for live runs,
+    // since toolOutput is null until agent_action_success fires).
+    if (isStoreResourceProgressOutput(output)) {
+      const r = output.contents.find(isRunAgentQueryResourceType);
+      if (r?.resource.text) {
+        setQuery(r.resource.text);
       }
-      // Extract stream connection IDs from run_agent progress notification.
-      if (isRunAgentQueryProgressOutput(output) && output.agentMessageId) {
-        setChildStreamIds({
-          conversationId: output.conversationId,
-          agentMessageId: output.agentMessageId,
-        });
+      if (r?.resource.childAgentId) {
+        setChildAgentId(r.resource.childAgentId);
       }
     }
-  }, [queryResource, lastNotification]);
+    if (isRunAgentQueryProgressOutput(output) && output.agentMessageId) {
+      setStreamIdsFromNotification({
+        conversationId: output.conversationId,
+        agentMessageId: output.agentMessageId,
+      });
+    }
+  }, [lastNotification]);
+
+  const resolvedStreamIds = childStreamIds ?? streamIdsFromNotification;
 
   // Subscribe to the child agent's event stream.
   const {
@@ -136,7 +159,7 @@ export function MCPRunAgentActionDetails({
     isDone: isStreamDone,
     isError: isStreamError,
   } = useChildAgentStream({
-    childStreamIds,
+    childStreamIds: resolvedStreamIds,
     owner,
     // We only stream when we are in the sidebar, in the conversation we only show the query.
     disabled: displayContext === "conversation",
@@ -153,11 +176,11 @@ export function MCPRunAgentActionDetails({
     if (resultResource) {
       return resultResource.resource.uri;
     }
-    if (childStreamIds) {
-      return `/w/${owner.sId}/conversation/${childStreamIds.conversationId}`;
+    if (resolvedStreamIds) {
+      return `/w/${owner.sId}/conversation/${resolvedStreamIds.conversationId}`;
     }
     return null;
-  }, [resultResource, childStreamIds, owner.sId]);
+  }, [resultResource, resolvedStreamIds, owner.sId]);
 
   const references = useMemo(() => {
     if (!resultResource?.resource.refs) {

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -98,12 +98,17 @@ export async function processToolNotification(
     conversation: ConversationType;
     agentMessage: AgentMessageType;
   }
-): Promise<ToolNotificationEvent> {
+): Promise<{
+  event: ToolNotificationEvent;
+  storedItems: AgentMCPActionOutputItemModel[];
+}> {
   const output = notification.params._meta.data.output;
+
+  let storedItems: AgentMCPActionOutputItemModel[] = [];
 
   // Handle store_resource notifications by creating output items immediately (fire-and-forget GCS).
   if (isStoreResourceProgressOutput(output)) {
-    await action.createOutputItems(
+    storedItems = await action.createOutputItems(
       auth,
       output.contents.map((content) => ({
         content: sanitizeStringsDeep(content),
@@ -125,17 +130,20 @@ export async function processToolNotification(
 
   // Regular notifications, we yield them as is with the type "tool_notification".
   return {
-    type: "tool_notification",
-    created: Date.now(),
-    configurationId: agentConfiguration.sId,
-    conversationId: conversation.sId,
-    messageId: agentMessage.sId,
-    action: {
-      ...action.toJSON(),
-      output: null,
-      generatedFiles: [],
+    event: {
+      type: "tool_notification",
+      created: Date.now(),
+      configurationId: agentConfiguration.sId,
+      conversationId: conversation.sId,
+      messageId: agentMessage.sId,
+      action: {
+        ...action.toJSON(),
+        output: null,
+        generatedFiles: [],
+      },
+      notification: notification.params,
     },
-    notification: notification.params,
+    storedItems,
   };
 }
 

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -495,6 +495,8 @@ export const RunAgentQueryResourceSchema = z.object({
   text: z.string(),
   childAgentId: z.string(),
   uri: z.literal(""),
+  conversationId: z.string().optional(),
+  agentMessageId: z.string().optional(),
 });
 
 export type RunAgentQueryResourceType = z.infer<

--- a/front/lib/api/actions/servers/run_agent/index.ts
+++ b/front/lib/api/actions/servers/run_agent/index.ts
@@ -262,9 +262,12 @@ const runAgent = async (
 
   const instructions =
     agentLoopContext.runContext.agentConfiguration.instructions;
+
+  // Store the query resource early so the UI can show it immediately while the child
+  // conversation is being created. A second store fires below once conversationId and
+  // agentMessageId are known, so the panel can connect to the child stream on replay.
   if (_meta?.progressToken && sendNotification) {
-    // Store the query resource immediately so it's available in the UI while the action is running.
-    const storeResourceNotification: MCPProgressNotificationType = {
+    await sendNotification({
       method: "notifications/progress",
       params: {
         progress: 0,
@@ -290,8 +293,7 @@ const runAgent = async (
           },
         },
       },
-    };
-    await sendNotification(storeResourceNotification);
+    });
   }
 
   const convRes = await getOrCreateConversation(
@@ -346,6 +348,38 @@ const runAgent = async (
     return finalizeAndReturn(
       new Err(makeChildAgentUnavailableError(childAgentBlob.name))
     );
+  }
+
+  if (_meta?.progressToken && sendNotification) {
+    await sendNotification({
+      method: "notifications/progress",
+      params: {
+        progress: 0,
+        total: 1,
+        progressToken: _meta.progressToken,
+        _meta: {
+          data: {
+            label: `Storing query resource`,
+            output: {
+              type: "store_resource",
+              contents: [
+                {
+                  type: "resource",
+                  resource: {
+                    mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.RUN_AGENT_QUERY,
+                    text: query,
+                    childAgentId: parsedChildAgentId,
+                    uri: "",
+                    conversationId: conversation.sId,
+                    agentMessageId: agentMessage.sId,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
   }
 
   const requestChildCancellation = () => {

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -22,6 +22,7 @@ import { hideFileFromActionOutput } from "@app/lib/actions/mcp_utils";
 import type { AgentLoopRunContextType } from "@app/lib/actions/types";
 import { handleMCPActionError } from "@app/lib/api/mcp/error";
 import type { Authenticator } from "@app/lib/auth";
+import type { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { withPeriodicHeartbeat } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -96,19 +97,23 @@ export async function* runToolWithStreaming(
   await action.updateStatus("running");
   const startDate = performance.now();
 
+  const intermediateOutputItems: AgentMCPActionOutputItemModel[] = [];
+
   const toolCallResult = yield* tryCallMCPTool(
     auth,
     inputs,
     agentLoopRunContext,
     {
       progressToken: action.id,
-      makeToolNotificationEvent: (notification) =>
-        processToolNotification(auth, notification, {
-          action,
-          agentConfiguration,
-          conversation,
-          agentMessage,
-        }),
+      makeToolNotificationEvent: async (notification) => {
+        const { event, storedItems } = await processToolNotification(
+          auth,
+          notification,
+          { action, agentConfiguration, conversation, agentMessage }
+        );
+        intermediateOutputItems.push(...storedItems);
+        return event;
+      },
       signal,
     }
   );
@@ -176,7 +181,11 @@ export async function* runToolWithStreaming(
     messageId: agentMessage.sId,
     action: {
       ...action.toJSON(),
-      output: removeNulls(outputItems.map(hideFileFromActionOutput)),
+      output: removeNulls(
+        [...intermediateOutputItems, ...outputItems].map(
+          hideFileFromActionOutput
+        )
+      ),
       generatedFiles,
     },
   };


### PR DESCRIPTION
## Description

### The bug

The `run_agent` side panel needs `conversationId` and `agentMessageId` to subscribe to the child agent's event stream. These IDs were only delivered through a one-shot `RunAgentQueryProgressOutput` notification that fires once at the start of a new run. If the panel opened after that notification had already fired (mid-run reload, second tab, replayed action), the IDs were gone and the panel showed nothing.

A second problem: the persisted query resource (stored via `StoreResourceProgressOutput`) was not included in the `agent_action_success` event, so closing and reopening the panel after the run completed also produced a blank panel.

### The fix

**Backend**

The store notification now fires twice. An early notification fires immediately (before conversation creation) to show the query text in the UI as fast as possible. A late notification fires after `getLatestVersionByParentMessageId` succeeds and includes `conversationId` and `agentMessageId`. It fires unconditionally, not gated on `isNewConversation`, so IDs are re-stored correctly on resumed runs too.

`processToolNotification` now returns the stored output items alongside the notification event. `runToolWithStreaming` accumulates these intermediate items and merges them into the `tool_success` payload, so `agent_action_success` carries the full output including the query resource.

**Frontend**

The component reads stream IDs from the persisted query resource as the primary path (`findLast` to pick the latest record, which carries the IDs). The `RunAgentQueryProgressOutput` fast path is kept for the brief window between the late store firing and SWR refreshing.

`query` and `childAgentId` use sticky `useState` instead of direct derivation: populated from the `StoreResourceProgressOutput` notification during live runs (when `toolOutput` is null), and from the persisted query resource for completed or replayed actions.

Old stored records without the new fields parse fine (`optional()`). Streaming is simply unavailable for those historical actions, same as before.

## Tests

Locally.

## Risk

Can be rolled back.

## Deploy Plan

Deploy front.