### PR TITLE
[front] ProfileTriggersTab: remove manage button

### DIFF
--- a/front/components/me/ProfileTriggersTab.tsx
+++ b/front/components/me/ProfileTriggersTab.tsx
@@ -1,9 +1,7 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useDeleteTrigger, useUserTriggers } from "@app/lib/swr/agent_triggers";
 import { classNames } from "@app/lib/utils";
-import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import { describeScheduleConfig } from "@app/lib/utils/schedule_description";
-import { isGlobalAgentId } from "@app/types/assistant/assistant";
 import type { TriggerType } from "@app/types/assistant/triggers";
 import type { WorkspaceType } from "@app/types/user";
 import {
@@ -20,13 +18,12 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  PencilSquareIcon,
   SearchInput,
   Spinner,
   TrashIcon,
 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
-import { useCallback, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 
 interface ProfileTriggersTabProps {
   owner: WorkspaceType;
@@ -38,13 +35,6 @@ export function ProfileTriggersTab({ owner }: ProfileTriggersTabProps) {
   });
 
   const [searchQuery, setSearchQuery] = useState("");
-
-  const getEditionURL = useCallback(
-    (agentConfigurationId: string) => {
-      return getAgentBuilderRoute(owner.sId, agentConfigurationId);
-    },
-    [owner.sId]
-  );
 
   const [triggerToDelete, setTriggerToDelete] = useState<TriggerType | null>(
     null
@@ -158,17 +148,11 @@ export function ProfileTriggersTab({ owner }: ProfileTriggersTabProps) {
         header: "Action",
         accessorKey: "actions",
         cell: ({ row }) => {
-          const buttonProps = isGlobalAgentId(row.original.agentConfigurationId)
-            ? {
-                onClick: () => setTriggerToDelete(row.original),
-                icon: TrashIcon,
-                label: "Delete",
-              }
-            : {
-                href: getEditionURL(row.original.agentConfigurationId),
-                icon: PencilSquareIcon,
-                label: "Manage",
-              };
+          const buttonProps = {
+            onClick: () => setTriggerToDelete(row.original),
+            icon: TrashIcon,
+            label: "Delete",
+          };
 
           return (
             <DataTable.CellContent>
@@ -181,7 +165,7 @@ export function ProfileTriggersTab({ owner }: ProfileTriggersTabProps) {
         },
       },
     ],
-    [getEditionURL]
+    []
   );
 
   return (


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8292
Currently, the ProfileTriggersTab in the personal page displayed a "Manage" button that would redirect to the agent builder page. However, this is actually misleading as the agent builder page does not correspond to the trigger edition and all the users might not even have access to this agent builder page if they don't have the rights on the agent.

Opening a specific issue in Olympus for proper redirection to the trigger edition tab of the agent (that would need some changes in the tab management for routing) => 
In the meantime, keeping only the "delete" button in this ProfileTriggersTab.

## Tests

Tested locally

## Risk

Low, only frontend and UX

## Deploy Plan

Deploy front