### PR TITLE
[front] file_system: sanitize file names with "/"

### DIFF
--- a/front/lib/api/file_system/dust_file_system.test.ts
+++ b/front/lib/api/file_system/dust_file_system.test.ts
@@ -1548,6 +1548,12 @@ describe("sanitizeFileSystemName", () => {
     const nfc = "café".normalize("NFC");
     expect(sanitizeFileSystemName(nfd)).toBe(nfc);
   });
+
+  it("replaces slashes with underscores", () => {
+    expect(sanitizeFileSystemName("q1/2024 report.pdf")).toBe(
+      "q1_2024 report.pdf"
+    );
+  });
 });
 
 describe("DustFileSystem.normalizeScopedPath strips control characters", () => {

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -55,10 +55,16 @@ export type { FileSystemEntry } from "@app/types/api/file_system/types";
 // eslint-disable-next-line no-control-regex
 const CONTROL_CHAR_RE = /[\x00-\x1F\x7F-\x9F]/g;
 
-// Strip control characters, trim whitespace, and NFC-normalize. macOS uploads commonly arrive
-// in NFD; NFC normalization keeps paths stable when consumers echo them back.
+// Strip control characters, replace path separators, trim whitespace, and NFC-normalize.
+// macOS uploads commonly arrive in NFD; NFC normalization keeps paths stable when consumers
+// echo them back. "/" is replaced with "_" since it would otherwise be interpreted as a path
+// separator when the name is used as a path segment.
 export function sanitizeFileSystemName(name: string): string {
-  return name.replace(CONTROL_CHAR_RE, "").trim().normalize("NFC");
+  return name
+    .replace(CONTROL_CHAR_RE, "")
+    .replace(/\//g, "_")
+    .trim()
+    .normalize("NFC");
 }
 
 type ParsedScopedPrefix =


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8203
Making sure that filenames never include some "/" that could be mistaken by GCS (this can happen in specific cases, for ex when a file is retrieved from Google drive directly as described in the ticket above)

## Tests

Added test for / in [front/lib/api/file_system/dust_file_system.test.ts](https://github.com/dust-tt/dust/pull/26324/changes#diff-1d8a833b3e3c32690d947c4faee838e8c148b1b69dbaea0d5e689659e4e438ad)

## Risk

Low,improve sanitize of filename

## Deploy Plan

Deploy front