### PR TITLE
Harden root sandbox command execution

### DIFF
--- a/CODING_RULES.md
+++ b/CODING_RULES.md
@@ -423,6 +423,53 @@ Example:
 /api/w/[wId]/resource/[sId]
 ```
 
+### [SEC3] Sandbox root commands must not resolve executables through PATH
+
+Any command that runs in a sandbox as `root` must invoke executables through absolute paths. This
+applies to `sandbox.exec(..., { user: "root" })`, provider-level E2B command execution as root,
+image lifecycle commands, wake/resume hooks, egress setup, log readers, and root-invoked helper
+scripts.
+
+Do not rely on the sandbox `PATH` for root commands. Sandbox workloads may control writable
+directories that appear in a default root PATH on some images, so bare commands like `cat`,
+`chmod`, `nohup`, `systemctl`, `tail`, `head`, `env`, or project helper names can become root code
+execution if an unprivileged sandbox user can plant a matching file earlier in PATH.
+
+If root invokes a helper by absolute path, the helper and every parent directory that makes it
+reachable must be root-owned and not group/other writable before the helper is trusted. Prefer
+root-owned locations such as `/opt/bin` for Dust-managed sandbox helpers, and add image/runtime
+hardening plus tests for their ownership and mode.
+
+Reviewer: If you detect a sandbox command running as `root` that uses a bare executable name,
+require the author to switch to an absolute path. If you detect a root-invoked helper in a path
+that sandbox users can write to, require ownership/mode hardening or a safer location before
+approving.
+
+Example:
+
+```
+// BAD: `cat`, `wc`, `tr`, `tail`, and `head` are resolved through root's PATH.
+await sandbox.exec(auth, "cat /tmp/deny.log | wc -l | tr -d ' '", {
+  user: "root",
+});
+
+// GOOD: every root-executed binary is absolute.
+await sandbox.exec(
+  auth,
+  "/bin/cat /tmp/deny.log | /usr/bin/wc -l | /usr/bin/tr -d ' '",
+  { user: "root" }
+);
+
+// BAD: root invokes a helper from a path whose ownership/mode is not enforced.
+await sandbox.exec(auth, "dust-install-trust-bundle", { user: "root" });
+
+// GOOD: root invokes an absolute helper path that image/runtime hardening keeps root-owned and
+// non-writable by sandbox workloads.
+await sandbox.exec(auth, "/opt/bin/dust-install-trust-bundle", {
+  user: "root",
+});
+```
+
 ## ERROR
 
 ### [ERR1] Do not rely on throw + catch

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -224,6 +224,8 @@ describe("sandbox egress helpers", () => {
     // exports on the agent process. Pinning the strip list to the canonical
     // SANDBOX_TRUST_ENV_VARS keys here catches drift between the two sites.
     const spawnCall = sandbox.exec.mock.calls[1][1] as string;
+    expect(spawnCall).toContain("/usr/bin/nohup /usr/bin/env");
+    expect(spawnCall).not.toContain("nohup env");
     for (const key of Object.keys(SANDBOX_TRUST_ENV_VARS)) {
       expect(spawnCall).toContain(`-u ${key}`);
     }
@@ -259,6 +261,7 @@ describe("sandbox egress helpers", () => {
       "if [ -x '/usr/local/bin/dust-install-trust-bundle' ]"
     );
     expect(installCall).toContain("update-ca-certificates");
+    expect(installCall).toContain("/bin/cat");
     expect(installCall).toContain("/etc/ssl/certs/ca-certificates.crt");
     expect(mockLoggerInfo).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -830,10 +833,10 @@ describe("sandbox egress helpers", () => {
       expect(sandbox.exec).toHaveBeenCalledTimes(1);
       const command = sandbox.exec.mock.calls[0][1] as string;
       expect(command).toContain(
-        "systemctl disable --now dust-egress-resolver.service dust-egress-nftables.service"
+        "/usr/bin/systemctl disable --now dust-egress-resolver.service dust-egress-nftables.service"
       );
-      expect(command).toContain("nft delete table ip dust-egress");
-      expect(command).toContain("nft delete table ip6 dust-egress");
+      expect(command).toContain("/usr/sbin/nft delete table ip dust-egress");
+      expect(command).toContain("/usr/sbin/nft delete table ip6 dust-egress");
       expect(sandbox.exec).toHaveBeenCalledWith(auth, expect.any(String), {
         user: "root",
       });

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -400,9 +400,9 @@ export async function teardownInSandboxEgressRedirect(
   }
 
   const command =
-    "systemctl disable --now dust-egress-resolver.service dust-egress-nftables.service >/dev/null 2>&1 || true; " +
-    "nft delete table ip dust-egress >/dev/null 2>&1 || true; " +
-    "nft delete table ip6 dust-egress >/dev/null 2>&1 || true";
+    "/usr/bin/systemctl disable --now dust-egress-resolver.service dust-egress-nftables.service >/dev/null 2>&1 || true; " +
+    "/usr/sbin/nft delete table ip dust-egress >/dev/null 2>&1 || true; " +
+    "/usr/sbin/nft delete table ip6 dust-egress >/dev/null 2>&1 || true";
 
   return runSuccessfulSandboxCommand(auth, sandbox, command, "root");
 }
@@ -441,7 +441,7 @@ export async function setupEgressForwarder(
   const prepareTokenResult = await runSuccessfulSandboxCommand(
     auth,
     sandbox,
-    `chmod 600 ${shellEscape(EGRESS_TOKEN_PATH)}`,
+    `/usr/bin/chmod 600 ${shellEscape(EGRESS_TOKEN_PATH)}`,
     "root"
   );
   if (prepareTokenResult.isErr()) {
@@ -478,7 +478,7 @@ export async function setupEgressForwarder(
     .map((k) => `-u ${k}`)
     .join(" ");
   const startForwarderCommand =
-    `nohup env ${trustEnvStripFlags} ` +
+    `/usr/bin/nohup /usr/bin/env ${trustEnvStripFlags} ` +
     "/opt/bin/dsbx forward " +
     `--token-file ${shellEscape(EGRESS_TOKEN_PATH)} ` +
     `--proxy-addr ${shellEscape(`${proxyAddr}:${config.getEgressProxyPort()}`)} ` +
@@ -533,7 +533,7 @@ async function killEgressForwarder(
   return runSuccessfulSandboxCommand(
     auth,
     sandbox,
-    "pkill -KILL -f '^/opt/bin/dsbx forward( |$)' >/dev/null 2>&1 || true",
+    "/usr/bin/pkill -KILL -f '^/opt/bin/dsbx forward( |$)' >/dev/null 2>&1 || true",
     "root"
   );
 }
@@ -559,12 +559,12 @@ async function installMitmTrustBundle(
   // TODO(2026-08-01 SANDBOX): remove the fallback once all pre-0.8.8
   // sandboxes have aged out.
   const inlineFallback =
-    `mkdir -p ${shellEscape("/etc/dust")} ${shellEscape("/usr/local/share/ca-certificates")} && ` +
-    `((cp ${shellEscape(MITM_CA_PATH)} ${shellEscape(MITM_SYSTEM_CA_DEST)} && update-ca-certificates >/dev/null 2>&1) || true) && ` +
-    `_bundle_tmp=$(mktemp ${shellEscape("/etc/dust/.ca-bundle.pem.XXXXXX")}) && ` +
-    `{ cat ${shellEscape(MITM_SYSTEM_CA_BUNDLE)}; printf '\\n'; cat ${shellEscape(MITM_CA_PATH)}; } > "$_bundle_tmp" && ` +
-    `chmod 644 "$_bundle_tmp" && ` +
-    `mv "$_bundle_tmp" ${shellEscape(MITM_CA_BUNDLE_PATH)}`;
+    `/usr/bin/mkdir -p ${shellEscape("/etc/dust")} ${shellEscape("/usr/local/share/ca-certificates")} && ` +
+    `((/usr/bin/cp ${shellEscape(MITM_CA_PATH)} ${shellEscape(MITM_SYSTEM_CA_DEST)} && /usr/sbin/update-ca-certificates >/dev/null 2>&1) || true) && ` +
+    `_bundle_tmp=$(/usr/bin/mktemp ${shellEscape("/etc/dust/.ca-bundle.pem.XXXXXX")}) && ` +
+    `{ /bin/cat ${shellEscape(MITM_SYSTEM_CA_BUNDLE)}; printf '\\n'; /bin/cat ${shellEscape(MITM_CA_PATH)}; } > "$_bundle_tmp" && ` +
+    `/usr/bin/chmod 644 "$_bundle_tmp" && ` +
+    `/usr/bin/mv "$_bundle_tmp" ${shellEscape(MITM_CA_BUNDLE_PATH)}`;
 
   const command =
     `[ -s ${shellEscape(MITM_CA_PATH)} ] || ` +
@@ -587,18 +587,18 @@ export async function readNewDenyLogEntries(
   sandbox: SandboxResource
 ): Promise<Result<string[], Error>> {
   const command =
-    `_state=$(cat ${shellEscape(EGRESS_DENY_LOG_OFFSET_PATH)} 2>/dev/null || true); ` +
+    `_state=$(/bin/cat ${shellEscape(EGRESS_DENY_LOG_OFFSET_PATH)} 2>/dev/null || true); ` +
     `set -- $_state; ` +
     `_off=\${1:-0}; _size_off=\${2:-0}; ` +
     `case "$_off" in ''|*[!0-9]*) _off=0;; esac; ` +
     `case "$_size_off" in ''|*[!0-9]*) _size_off=0;; esac; ` +
     `if [ -f ${shellEscape(EGRESS_DENY_LOG_PATH)} ]; then ` +
-    `_total=$(wc -l < ${shellEscape(EGRESS_DENY_LOG_PATH)} | tr -d ' '); ` +
-    `_size=$(wc -c < ${shellEscape(EGRESS_DENY_LOG_PATH)} | tr -d ' '); ` +
+    `_total=$(/usr/bin/wc -l < ${shellEscape(EGRESS_DENY_LOG_PATH)} | /usr/bin/tr -d ' '); ` +
+    `_size=$(/usr/bin/wc -c < ${shellEscape(EGRESS_DENY_LOG_PATH)} | /usr/bin/tr -d ' '); ` +
     `else _total=0; _size=0; fi; ` +
     `if [ "$_total" -lt "$_off" ] || [ "$_size" -lt "$_size_off" ]; then _off=0; fi; ` +
     `if [ "$_total" -gt "$_off" ]; then ` +
-    `tail -n +$((_off + 1)) ${shellEscape(EGRESS_DENY_LOG_PATH)} | head -n ${MAX_DENY_LOG_LINES_PER_EXEC}; ` +
+    `/usr/bin/tail -n +$((_off + 1)) ${shellEscape(EGRESS_DENY_LOG_PATH)} | /usr/bin/head -n ${MAX_DENY_LOG_LINES_PER_EXEC}; ` +
     `fi; ` +
     `echo "$_total $_size" > ${shellEscape(EGRESS_DENY_LOG_OFFSET_PATH)}`;
 

--- a/front/lib/api/sandbox/egress_secrets.test.ts
+++ b/front/lib/api/sandbox/egress_secrets.test.ts
@@ -102,7 +102,9 @@ describe("egress secrets file", () => {
       stdin: string;
       user: string;
     };
-    expect(command).toContain("install -o root -g root -m 600 /dev/stdin");
+    expect(command).toContain(
+      "/usr/bin/install -o root -g root -m 600 /dev/stdin"
+    );
     expect(command).toContain("/run/dust/egress-secrets.json");
     expect(command).not.toContain("api-secret");
     expect(opts.user).toBe("root");

--- a/front/lib/api/sandbox/egress_secrets.ts
+++ b/front/lib/api/sandbox/egress_secrets.ts
@@ -90,9 +90,9 @@ export async function writeEgressSecretsFile(
   // dsbx's call.
   const tmpPath = `${EGRESS_SECRETS_DIR}/.egress-secrets.json.${randomBytes(8).toString("hex")}.tmp`;
   const command =
-    `mkdir -p ${shellEscape(EGRESS_SECRETS_DIR)} && ` +
-    `install -o root -g root -m 600 /dev/stdin ${shellEscape(tmpPath)} && ` +
-    `mv ${shellEscape(tmpPath)} ${shellEscape(EGRESS_SECRETS_PATH)}`;
+    `/usr/bin/mkdir -p ${shellEscape(EGRESS_SECRETS_DIR)} && ` +
+    `/usr/bin/install -o root -g root -m 600 /dev/stdin ${shellEscape(tmpPath)} && ` +
+    `/usr/bin/mv ${shellEscape(tmpPath)} ${shellEscape(EGRESS_SECRETS_PATH)}`;
 
   const result = await sandbox.exec(auth, command, {
     stdin: JSON.stringify(entriesResult.value),

--- a/front/lib/api/sandbox/env_manifest.test.ts
+++ b/front/lib/api/sandbox/env_manifest.test.ts
@@ -182,7 +182,9 @@ describe("sandbox environment manifest", () => {
     };
     // Pin the exact install flags so a future drift to a tighter mode (or a
     // different owner) does not silently pass.
-    expect(command).toMatch(/install -o root -g root -m 644 \/dev\/stdin/);
+    expect(command).toMatch(
+      /\/usr\/bin\/install -o root -g root -m 644 \/dev\/stdin/
+    );
     expect(command).toContain(SANDBOX_ENV_MANIFEST_PATH);
     expect(command).not.toContain("api-secret");
     expect(opts.user).toBe("root");

--- a/front/lib/api/sandbox/env_manifest.ts
+++ b/front/lib/api/sandbox/env_manifest.ts
@@ -94,9 +94,9 @@ export async function writeSandboxEnvManifestFile(
 
   const tmpPath = `${SANDBOX_ENV_MANIFEST_DIR}/.sandbox-env-manifest.json.${randomBytes(8).toString("hex")}.tmp`;
   const command =
-    `mkdir -p ${shellEscape(SANDBOX_ENV_MANIFEST_DIR)} && ` +
-    `install -o root -g root -m 644 /dev/stdin ${shellEscape(tmpPath)} && ` +
-    `mv ${shellEscape(tmpPath)} ${shellEscape(SANDBOX_ENV_MANIFEST_PATH)}`;
+    `/usr/bin/mkdir -p ${shellEscape(SANDBOX_ENV_MANIFEST_DIR)} && ` +
+    `/usr/bin/install -o root -g root -m 644 /dev/stdin ${shellEscape(tmpPath)} && ` +
+    `/usr/bin/mv ${shellEscape(tmpPath)} ${shellEscape(SANDBOX_ENV_MANIFEST_PATH)}`;
 
   const result = await sandbox.exec(auth, command, {
     stdin: JSON.stringify(manifestResult.value),

--- a/front/lib/api/sandbox/gcs/mount.test.ts
+++ b/front/lib/api/sandbox/gcs/mount.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "vitest";
+
+import { buildMountCommand } from "./mount";
+
+describe("GCS mount command", () => {
+  test("uses absolute root-owned binaries for root gcsfuse mounts", () => {
+    const command = buildMountCommand({
+      bucket: "dust-bucket",
+      prefix: "w/workspace/conversations/conversation/files",
+      mountPoint: "/files/conversation",
+    });
+
+    expect(command).toContain("/usr/bin/timeout 30 /usr/bin/gcsfuse");
+    expect(command).toContain(
+      "--only-dir 'w/workspace/conversations/conversation/files'"
+    );
+    expect(command).toContain("'dust-bucket' '/files/conversation'");
+    expect(command).not.toContain("timeout 30 gcsfuse");
+  });
+});

--- a/front/lib/api/sandbox/gcs/mount.ts
+++ b/front/lib/api/sandbox/gcs/mount.ts
@@ -4,6 +4,7 @@ import {
 } from "@app/lib/api/files/mount_path";
 import { mintDownscopedGcsToken } from "@app/lib/api/sandbox/gcs/token";
 import type { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
+import { shellEscape } from "@app/lib/api/sandbox/shell";
 import type { Authenticator } from "@app/lib/auth";
 import fileStorageConfig from "@app/lib/file_storage/config";
 import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
@@ -264,7 +265,7 @@ export async function refreshGcsToken(
   return new Ok(undefined);
 }
 
-function buildMountCommand({
+export function buildMountCommand({
   bucket,
   prefix,
   mountPoint,
@@ -278,7 +279,7 @@ function buildMountCommand({
     // Disable token caching so gcsfuse fetches fresh token from server on every GCS API request.
     // This ensures gcsfuse never uses stale credentials, eliminating 401 errors after token expiry.
     `--reuse-token-from-url=false`,
-    `--only-dir ${prefix}`,
+    `--only-dir ${shellEscape(prefix)}`,
     `--implicit-dirs`,
     `-o allow_other`,
     `--file-mode=666`,
@@ -290,7 +291,7 @@ function buildMountCommand({
     `--enable-hns=false`,
   ].join(" ");
 
-  return `timeout 30 gcsfuse ${flags} ${bucket} ${mountPoint} 2>&1`;
+  return `/usr/bin/timeout 30 /usr/bin/gcsfuse ${flags} ${shellEscape(bucket)} ${shellEscape(mountPoint)} 2>&1`;
 }
 
 function escapeSingleQuotes(s: string): string {

--- a/front/lib/api/sandbox/hardening.ts
+++ b/front/lib/api/sandbox/hardening.ts
@@ -1,4 +1,26 @@
+import { shellEscape } from "@app/lib/api/sandbox/shell";
+
+export const SANDBOX_ROOT_SAFE_PATH = "/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin";
+const ROOT_SAFE_PATH_PROFILE = "/etc/profile.d/zz-dust-root-safe-path.sh";
+
 export function getLocalAccountPrivilegeHardeningCommand(): string {
+  const installRootSafePathProfile = [
+    "/usr/bin/mkdir -p /etc/profile.d",
+    [
+      "printf '%s\\n'",
+      shellEscape(
+        "# Managed by Dust. Root must not resolve agent-writable paths."
+      ),
+      shellEscape('if [ "$(/usr/bin/id -u)" = "0" ]; then'),
+      shellEscape(`  export PATH=${shellEscape(SANDBOX_ROOT_SAFE_PATH)}`),
+      shellEscape("  export HOME=/root"),
+      shellEscape("  export BASH_ENV=/dev/null"),
+      shellEscape("  export ENV=/dev/null"),
+      shellEscape("fi"),
+      `> ${shellEscape(ROOT_SAFE_PATH_PROFILE)}`,
+    ].join(" "),
+    `/usr/bin/chmod 644 ${shellEscape(ROOT_SAFE_PATH_PROFILE)}`,
+  ].join(" && ");
   const lockRootPassword = [
     "if getent passwd root >/dev/null 2>&1; then",
     "passwd -l root >/dev/null 2>&1 || usermod --lock root >/dev/null 2>&1 || true;",
@@ -105,6 +127,7 @@ export function getLocalAccountPrivilegeHardeningCommand(): string {
   ].join(" ");
 
   return [
+    installRootSafePathProfile,
     lockRootPassword,
     lockEmptyPasswordAccounts,
     lockProviderUser,

--- a/front/lib/api/sandbox/hardening.ts
+++ b/front/lib/api/sandbox/hardening.ts
@@ -2,6 +2,10 @@ import { shellEscape } from "@app/lib/api/sandbox/shell";
 
 export const SANDBOX_ROOT_SAFE_PATH = "/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin";
 const ROOT_SAFE_PATH_PROFILE = "/etc/profile.d/zz-dust-root-safe-path.sh";
+const PRIVILEGED_EXECUTABLE_DIRS =
+  "/opt/bin /usr/local /usr/local/sbin /usr/local/bin";
+const ROOT_INVOKED_HELPERS =
+  "/opt/bin/dsbx /usr/local/bin/dust-install-trust-bundle";
 
 export function getLocalAccountPrivilegeHardeningCommand(): string {
   const installRootSafePathProfile = [
@@ -77,10 +81,15 @@ export function getLocalAccountPrivilegeHardeningCommand(): string {
     "done",
   ].join(" ");
   const hardenPrivilegedExecutableDirs = [
-    "install -d -o root -g root -m 755 /opt/bin /usr/local/bin",
-    "chown root:root /opt/bin /usr/local/bin",
-    "chmod 755 /opt/bin /usr/local/bin",
+    `install -d -o root -g root -m 755 ${PRIVILEGED_EXECUTABLE_DIRS}`,
+    `chown root:root ${PRIVILEGED_EXECUTABLE_DIRS}`,
+    `chmod 755 ${PRIVILEGED_EXECUTABLE_DIRS}`,
   ].join(" && ");
+  const hardenRootInvokedHelpers = [
+    `for path in ${ROOT_INVOKED_HELPERS}; do`,
+    'if [ -e "$path" ]; then chown root:root "$path"; chmod 755 "$path"; fi;',
+    "done",
+  ].join(" ");
   const assertNoEmptyPasswordAccounts = [
     `if getent shadow | awk -F: '$2 == "" {print $1}' | grep -q .; then`,
     "echo 'empty-password local accounts must not exist' >&2;",
@@ -118,9 +127,18 @@ export function getLocalAccountPrivilegeHardeningCommand(): string {
     "done",
   ].join(" ");
   const assertPrivilegedExecutableDirsSafe = [
-    "for dir in /opt/bin /usr/local/bin; do",
+    `for dir in ${PRIVILEGED_EXECUTABLE_DIRS}; do`,
     'if [ "$(stat -c \'%U:%G\' "$dir")" != root:root ] || find "$dir" -maxdepth 0 -perm /022 | grep -q .; then',
     'echo "privileged executable directory must be root-owned and not group/other writable: $dir" >&2;',
+    "exit 1;",
+    "fi;",
+    "done",
+  ].join(" ");
+  const assertRootInvokedHelpersSafe = [
+    `for path in ${ROOT_INVOKED_HELPERS}; do`,
+    '[ -e "$path" ] || continue;',
+    'if [ "$(stat -c \'%U:%G\' "$path")" != root:root ] || find "$path" -maxdepth 0 -perm /022 | grep -q .; then',
+    'echo "root-invoked helper must be root-owned and not group/other writable: $path" >&2;',
     "exit 1;",
     "fi;",
     "done",
@@ -136,12 +154,14 @@ export function getLocalAccountPrivilegeHardeningCommand(): string {
     removeSudoBinary,
     hardenLocalAuthHelpers,
     hardenPrivilegedExecutableDirs,
+    hardenRootInvokedHelpers,
     assertNoEmptyPasswordAccounts,
     assertNoPrivilegedGroupMembers,
     assertNoPrivilegedPrimaryGroups,
     assertNoPasswordlessSudoers,
     assertLocalAuthHelpersNotSetuid,
     assertPrivilegedExecutableDirsSafe,
+    assertRootInvokedHelpersSafe,
     "if command -v sudo >/dev/null 2>&1; then echo 'sudo must not be installed in sandbox images' >&2; exit 1; fi",
   ].join(" && ");
 }

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -135,7 +135,10 @@ describe("sandbox image registry", () => {
       expect(command).toContain("/usr/bin/passwd");
       expect(command).toContain("chmod u-s");
       expect(command).toContain(
-        "install -d -o root -g root -m 755 /opt/bin /usr/local/bin"
+        "install -d -o root -g root -m 755 /opt/bin /usr/local /usr/local/sbin /usr/local/bin"
+      );
+      expect(command).toContain(
+        "for path in /opt/bin/dsbx /usr/local/bin/dust-install-trust-bundle"
       );
       expect(command).toContain("empty-password local accounts must not exist");
       expect(command).toContain("privileged primary group");
@@ -156,7 +159,7 @@ describe("sandbox image registry", () => {
 
     expect(runCommands).toEqual(
       expect.arrayContaining([
-        "install -d -o root -g root -m 755 /opt/bin /usr/local/bin && chown root:root /opt/bin /usr/local/bin && chmod 755 /opt/bin /usr/local/bin",
+        "install -d -o root -g root -m 755 /opt/bin /usr/local /usr/local/sbin /usr/local/bin && chown root:root /opt/bin /usr/local /usr/local/sbin /usr/local/bin && chmod 755 /opt/bin /usr/local /usr/local/sbin /usr/local/bin",
       ])
     );
   });
@@ -304,6 +307,9 @@ describe("sandbox image registry", () => {
         expect.stringContaining(
           "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.23/dsbx-linux-x86_64"
         ),
+        expect.stringContaining(
+          "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"
+        ),
       ])
     );
   });
@@ -347,7 +353,7 @@ describe("sandbox image registry", () => {
           "cat /etc/dust/dust-trust.environment >> /etc/environment"
         ),
         "chmod 644 /etc/profile.d/dust-trust.sh",
-        "chmod 755 /usr/local/bin/dust-install-trust-bundle",
+        "chown root:root /usr/local/bin/dust-install-trust-bundle && chmod 755 /usr/local/bin/dust-install-trust-bundle",
       ])
     );
 

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -1,3 +1,4 @@
+import { SANDBOX_ROOT_SAFE_PATH } from "@app/lib/api/sandbox/hardening";
 import { getSandboxImageFromRegistry } from "@app/lib/api/sandbox/image/registry";
 import {
   type Operation,
@@ -68,7 +69,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.28",
+      tag: "0.8.29",
     });
   });
 
@@ -118,6 +119,8 @@ describe("sandbox image registry", () => {
     expect(hardeningCommands.length).toBeGreaterThanOrEqual(2);
     for (const command of hardeningCommands) {
       expect(command).toContain("passwd -l root");
+      expect(command).toContain("zz-dust-root-safe-path.sh");
+      expect(command).toContain(SANDBOX_ROOT_SAFE_PATH);
       expect(command).toContain("awk -F: '$2 == \"\" {print $1}'");
       expect(command).toContain('passwd -l "$account"');
       expect(command).toContain(

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -183,9 +183,9 @@ function getEgressResolverUserSetupCommand(): string {
 
 function getPrivilegedExecutablePathHardeningCommand(): string {
   return [
-    "install -d -o root -g root -m 755 /opt/bin /usr/local/bin",
-    "chown root:root /opt/bin /usr/local/bin",
-    "chmod 755 /opt/bin /usr/local/bin",
+    "install -d -o root -g root -m 755 /opt/bin /usr/local /usr/local/sbin /usr/local/bin",
+    "chown root:root /opt/bin /usr/local /usr/local/sbin /usr/local/bin",
+    "chmod 755 /opt/bin /usr/local /usr/local/sbin /usr/local/bin",
   ].join(" && ");
 }
 
@@ -357,7 +357,8 @@ SHELLEOF`,
       `curl -fsSL https://github.com/dust-tt/dust/releases/download/dsbx-v${DSBX_CLI_VERSION}/checksums-sha256.txt -o /tmp/checksums-sha256.txt && ` +
       "grep dsbx-linux-x86_64 /tmp/checksums-sha256.txt | awk '{print $1 \"  /tmp/dsbx\"}' | sha256sum -c - && " +
       "chmod +x /tmp/dsbx && " +
-      "mv /tmp/dsbx /opt/bin/dsbx",
+      "mv /tmp/dsbx /opt/bin/dsbx && " +
+      "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx",
     { user: "root" }
   )
   .registerTool({
@@ -472,9 +473,12 @@ SHELLEOF`,
     "/usr/local/bin/dust-install-trust-bundle",
     { user: "root" }
   )
-  .runCmd("chmod 755 /usr/local/bin/dust-install-trust-bundle", {
-    user: "root",
-  })
+  .runCmd(
+    "chown root:root /usr/local/bin/dust-install-trust-bundle && chmod 755 /usr/local/bin/dust-install-trust-bundle",
+    {
+      user: "root",
+    }
+  )
   .copy(
     getLocalContent(EGRESS_LOCAL_DIR, "egress-nftables.sh"),
     "/etc/dust/egress-nftables.sh",

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -16,7 +16,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.28";
+const DUST_BASE_IMAGE_VERSION = "0.8.29";
 const DSBX_CLI_VERSION = "0.1.23";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that

--- a/front/lib/api/sandbox/providers/e2b.test.ts
+++ b/front/lib/api/sandbox/providers/e2b.test.ts
@@ -160,7 +160,10 @@ describe("E2BSandboxProvider", () => {
       "sudo must not be installed in sandbox images"
     );
     expect(hardeningCommand).toContain(
-      "install -d -o root -g root -m 755 /opt/bin /usr/local/bin"
+      "install -d -o root -g root -m 755 /opt/bin /usr/local /usr/local/sbin /usr/local/bin"
+    );
+    expect(hardeningCommand).toContain(
+      "for path in /opt/bin/dsbx /usr/local/bin/dust-install-trust-bundle"
     );
     expect(hardeningCommand).toContain("privileged primary group");
     expect(mockKill).not.toHaveBeenCalled();

--- a/front/lib/api/sandbox/providers/e2b.test.ts
+++ b/front/lib/api/sandbox/providers/e2b.test.ts
@@ -77,6 +77,7 @@ vi.mock("e2b", () => {
 
 import { CommandExitError } from "e2b";
 
+import { SANDBOX_ROOT_SAFE_PATH } from "../hardening";
 import { E2BSandboxProvider } from "./e2b";
 
 describe("E2BSandboxProvider", () => {
@@ -129,7 +130,7 @@ describe("E2BSandboxProvider", () => {
 
     const result = await provider.create(
       {
-        imageId: { imageName: "dust-base", tag: "0.8.28" },
+        imageId: { imageName: "dust-base", tag: "0.8.29" },
         network: { mode: "deny_all" },
         resources: { vcpu: 2, memoryMb: 2048 },
       },
@@ -137,6 +138,12 @@ describe("E2BSandboxProvider", () => {
     );
 
     expect(result).toEqual(new Ok({ providerId: "sandbox-id" }));
+    const hardeningCommand = mockCreateCommandRun.mock.calls[0][0] as string;
+    expect(hardeningCommand).toContain(
+      `PATH='${SANDBOX_ROOT_SAFE_PATH}' HOME=/root`
+    );
+    expect(hardeningCommand).toContain("/bin/bash --noprofile --norc -c");
+    expect(hardeningCommand).toContain("zz-dust-root-safe-path.sh");
     expect(mockCreateCommandRun).toHaveBeenCalledWith(
       expect.stringContaining(
         "usermod --lock --expiredate 1 --shell /usr/sbin/nologin user"
@@ -146,16 +153,69 @@ describe("E2BSandboxProvider", () => {
         user: "root",
       }
     );
-    expect(mockCreateCommandRun.mock.calls[0][0]).toContain(
+    expect(hardeningCommand).toContain(
       "sudo must not be installed in sandbox images"
     );
-    expect(mockCreateCommandRun.mock.calls[0][0]).toContain(
+    expect(hardeningCommand).toContain(
       "install -d -o root -g root -m 755 /opt/bin /usr/local/bin"
     );
-    expect(mockCreateCommandRun.mock.calls[0][0]).toContain(
-      "privileged primary group"
-    );
+    expect(hardeningCommand).toContain("privileged primary group");
     expect(mockKill).not.toHaveBeenCalled();
+  });
+
+  it("runs root commands with a safe PATH that excludes agent-writable directories", async () => {
+    mockRun.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: "ok",
+      stderr: "",
+    });
+    const provider = new E2BSandboxProvider({
+      apiKey: "api-key",
+      domain: undefined,
+    });
+
+    const result = await provider.exec(
+      "provider-id",
+      "nohup /bin/true",
+      { user: "root" },
+      { workspaceId: "workspace-id" }
+    );
+
+    expect(result).toEqual(new Ok({ exitCode: 0, stdout: "ok", stderr: "" }));
+    const command = mockRun.mock.calls[0][0] as string;
+    expect(command).toContain(`PATH='${SANDBOX_ROOT_SAFE_PATH}'`);
+    expect(command).toContain("HOME=/root");
+    expect(command).toContain("BASH_ENV=/dev/null");
+    expect(command).toContain("ENV=/dev/null");
+    expect(command).toContain("/bin/bash --noprofile --norc -c");
+    expect(command).toContain("nohup /bin/true");
+    expect(command).not.toContain("/opt/venv/bin");
+    expect(command).not.toContain("/home/agent/.local/bin");
+  });
+
+  it("does not wrap non-root commands", async () => {
+    mockRun.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: "ok",
+      stderr: "",
+    });
+    const provider = new E2BSandboxProvider({
+      apiKey: "api-key",
+      domain: undefined,
+    });
+
+    const result = await provider.exec(
+      "provider-id",
+      "echo ok",
+      { user: "agent-proxied" },
+      { workspaceId: "workspace-id" }
+    );
+
+    expect(result).toEqual(new Ok({ exitCode: 0, stdout: "ok", stderr: "" }));
+    expect(mockRun).toHaveBeenCalledWith(
+      "echo ok",
+      expect.objectContaining({ user: "agent-proxied" })
+    );
   });
 
   it("kills a sandbox if local account hardening fails after create", async () => {
@@ -171,7 +231,7 @@ describe("E2BSandboxProvider", () => {
 
     const result = await provider.create(
       {
-        imageId: { imageName: "dust-base", tag: "0.8.28" },
+        imageId: { imageName: "dust-base", tag: "0.8.29" },
         network: { mode: "deny_all" },
         resources: { vcpu: 2, memoryMb: 2048 },
       },
@@ -204,7 +264,7 @@ describe("E2BSandboxProvider", () => {
 
     const result = await provider.create(
       {
-        imageId: { imageName: "dust-base", tag: "0.8.28" },
+        imageId: { imageName: "dust-base", tag: "0.8.29" },
         network: { mode: "deny_all" },
         resources: { vcpu: 2, memoryMb: 2048 },
       },
@@ -245,8 +305,12 @@ describe("E2BSandboxProvider", () => {
     );
 
     expect(result).toEqual(new Ok({ exitCode: 0, stdout: "ok", stderr: "" }));
+    const wrappedCommand = mockRun.mock.calls[0][0] as string;
+    expect(wrappedCommand).toContain(`PATH='${SANDBOX_ROOT_SAFE_PATH}'`);
+    expect(wrappedCommand).toContain("/bin/bash --noprofile --norc -c");
+    expect(wrappedCommand).toContain(command);
     expect(mockRun).toHaveBeenCalledWith(
-      command,
+      wrappedCommand,
       expect.objectContaining({
         background: true,
         stdin: true,
@@ -254,7 +318,7 @@ describe("E2BSandboxProvider", () => {
         user: "root",
       })
     );
-    expect(mockRun.mock.calls[0][0]).not.toContain(stdin);
+    expect(wrappedCommand).not.toContain(stdin);
     expect(JSON.stringify(mockRun.mock.calls[0][1])).not.toContain(stdin);
     expect(mockSendStdin).toHaveBeenCalledWith(123, stdin, {
       requestTimeoutMs: 30_000,

--- a/front/lib/api/sandbox/providers/e2b.test.ts
+++ b/front/lib/api/sandbox/providers/e2b.test.ts
@@ -138,7 +138,10 @@ describe("E2BSandboxProvider", () => {
     );
 
     expect(result).toEqual(new Ok({ providerId: "sandbox-id" }));
-    const hardeningCommand = mockCreateCommandRun.mock.calls[0][0] as string;
+    const hardeningCommand = mockCreateCommandRun.mock.calls[0][0];
+    if (typeof hardeningCommand !== "string") {
+      throw new Error("expected hardeningCommand to be a string");
+    }
     expect(hardeningCommand).toContain(
       `PATH='${SANDBOX_ROOT_SAFE_PATH}' HOME=/root`
     );
@@ -182,7 +185,10 @@ describe("E2BSandboxProvider", () => {
     );
 
     expect(result).toEqual(new Ok({ exitCode: 0, stdout: "ok", stderr: "" }));
-    const command = mockRun.mock.calls[0][0] as string;
+    const command = mockRun.mock.calls[0][0];
+    if (typeof command !== "string") {
+      throw new Error("expected command to be a string");
+    }
     expect(command).toContain(`PATH='${SANDBOX_ROOT_SAFE_PATH}'`);
     expect(command).toContain("HOME=/root");
     expect(command).toContain("BASH_ENV=/dev/null");
@@ -305,7 +311,10 @@ describe("E2BSandboxProvider", () => {
     );
 
     expect(result).toEqual(new Ok({ exitCode: 0, stdout: "ok", stderr: "" }));
-    const wrappedCommand = mockRun.mock.calls[0][0] as string;
+    const wrappedCommand = mockRun.mock.calls[0][0];
+    if (typeof wrappedCommand !== "string") {
+      throw new Error("expected wrappedCommand to be a string");
+    }
     expect(wrappedCommand).toContain(`PATH='${SANDBOX_ROOT_SAFE_PATH}'`);
     expect(wrappedCommand).toContain("/bin/bash --noprofile --norc -c");
     expect(wrappedCommand).toContain(command);

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -1,4 +1,7 @@
-import { getLocalAccountPrivilegeHardeningCommand } from "@app/lib/api/sandbox/hardening";
+import {
+  getLocalAccountPrivilegeHardeningCommand,
+  SANDBOX_ROOT_SAFE_PATH,
+} from "@app/lib/api/sandbox/hardening";
 import {
   formatSandboxImageId,
   type NetworkPolicy,
@@ -15,6 +18,7 @@ import {
   SandboxNotFoundError,
   traceSandboxOperation,
 } from "@app/lib/api/sandbox/provider";
+import { shellEscape } from "@app/lib/api/sandbox/shell";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -37,6 +41,17 @@ const REQUEST_TIMEOUT_MS = 30_000;
 const LOCAL_ACCOUNT_HARDENING_TIMEOUT_MS = 120_000;
 
 const ALL_TRAFFIC = "0.0.0.0/0";
+
+function getRootSafeSandboxCommand(command: string): string {
+  return [
+    `PATH=${shellEscape(SANDBOX_ROOT_SAFE_PATH)}`,
+    "HOME=/root",
+    "BASH_ENV=/dev/null",
+    "ENV=/dev/null",
+    "/bin/bash --noprofile --norc -c",
+    shellEscape(command),
+  ].join(" ");
+}
 
 function getLocalAccountHardeningError(result: ExecResult): Error {
   const output = [result.stderr, result.stdout]
@@ -203,7 +218,9 @@ export class E2BSandboxProvider implements SandboxProvider {
         let hardeningResult: ExecResult;
         try {
           const result = await sandbox.commands.run(
-            getLocalAccountPrivilegeHardeningCommand(),
+            getRootSafeSandboxCommand(
+              getLocalAccountPrivilegeHardeningCommand()
+            ),
             {
               timeoutMs: LOCAL_ACCOUNT_HARDENING_TIMEOUT_MS,
               user: "root",
@@ -384,10 +401,14 @@ export class E2BSandboxProvider implements SandboxProvider {
             user: execOpts?.user,
           };
           const stdin = execOpts?.stdin;
+          const commandToRun =
+            execOpts?.user === "root"
+              ? getRootSafeSandboxCommand(command)
+              : command;
           const result =
             stdin === undefined
-              ? await sandbox.commands.run(command, commandOpts)
-              : await runWithStdin(sandbox, command, commandOpts, stdin);
+              ? await sandbox.commands.run(commandToRun, commandOpts)
+              : await runWithStdin(sandbox, commandToRun, commandOpts, stdin);
 
           return new Ok({
             exitCode: result.exitCode,

--- a/front/lib/api/sandbox/telemetry/index.ts
+++ b/front/lib/api/sandbox/telemetry/index.ts
@@ -32,7 +32,7 @@ export async function startTelemetry(
   // journalctl logs argv. Always interpolate from the envVars below.
   const result = await sandbox.exec(
     auth,
-    `systemctl set-environment DD_HOST="$DD_HOST" DD_API_KEY="$DD_API_KEY" E2B_SANDBOX_ID="$E2B_SANDBOX_ID" CONVERSATION_ID="$CONVERSATION_ID" WORKSPACE_ID="$WORKSPACE_ID" && systemctl start fluent-bit`,
+    `/usr/bin/systemctl set-environment DD_HOST="$DD_HOST" DD_API_KEY="$DD_API_KEY" E2B_SANDBOX_ID="$E2B_SANDBOX_ID" CONVERSATION_ID="$CONVERSATION_ID" WORKSPACE_ID="$WORKSPACE_ID" && /usr/bin/systemctl start fluent-bit`,
     {
       user: "root",
       envVars: {

--- a/front/scripts/sandbox_security_check.test.ts
+++ b/front/scripts/sandbox_security_check.test.ts
@@ -5,6 +5,7 @@ import {
   assertNoPasswordlessSudoers,
   assertNoPrivilegedGroupMembers,
   assertPrivilegedDirsSafe,
+  assertRootInvokedHelpersSafe,
   assertRootPathSafe,
   assertSudoAbsent,
   buildBashCommand,
@@ -92,19 +93,37 @@ describe("sandbox security check assertions", () => {
   test("detects unsafe privileged directory ownership or modes", () => {
     expect(() =>
       assertPrivilegedDirsSafe(
-        "/opt/bin root:root 755 drwxr-xr-x\n/usr/local/bin root:root 755 drwxr-xr-x"
+        "/opt/bin root:root 755 drwxr-xr-x\n/usr/local root:root 755 drwxr-xr-x\n/usr/local/sbin root:root 755 drwxr-xr-x\n/usr/local/bin root:root 755 drwxr-xr-x"
       )
     ).not.toThrow();
     expect(() =>
       assertPrivilegedDirsSafe(
-        "/opt/bin agent:agent 755 drwxr-xr-x\n/usr/local/bin root:root 755 drwxr-xr-x"
+        "/opt/bin agent:agent 755 drwxr-xr-x\n/usr/local root:root 755 drwxr-xr-x\n/usr/local/sbin root:root 755 drwxr-xr-x\n/usr/local/bin root:root 755 drwxr-xr-x"
       )
     ).toThrow("privileged directory /opt/bin is not root-owned");
     expect(() =>
       assertPrivilegedDirsSafe(
-        "/opt/bin root:root 777 drwxrwxrwx\n/usr/local/bin root:root 755 drwxr-xr-x"
+        "/opt/bin root:root 777 drwxrwxrwx\n/usr/local root:root 755 drwxr-xr-x\n/usr/local/sbin root:root 755 drwxr-xr-x\n/usr/local/bin root:root 755 drwxr-xr-x"
       )
     ).toThrow("privileged directory /opt/bin is not root-owned");
+  });
+
+  test("detects unsafe root-invoked helper ownership or modes", () => {
+    expect(() =>
+      assertRootInvokedHelpersSafe(
+        "/opt/bin/dsbx root:root 755 -rwxr-xr-x\n/usr/local/bin/dust-install-trust-bundle root:root 755 -rwxr-xr-x"
+      )
+    ).not.toThrow();
+    expect(() =>
+      assertRootInvokedHelpersSafe(
+        "/opt/bin/dsbx root:root 777 -rwxrwxrwx\n/usr/local/bin/dust-install-trust-bundle root:root 755 -rwxr-xr-x"
+      )
+    ).toThrow("root-invoked helper is not root-owned");
+    expect(() =>
+      assertRootInvokedHelpersSafe("/opt/bin/dsbx root:root 755 -rwxr-xr-x")
+    ).toThrow(
+      "missing root-invoked helper audit for /usr/local/bin/dust-install-trust-bundle"
+    );
   });
 
   test("detects root PATH entries that can resolve agent-writable binaries", () => {

--- a/front/scripts/sandbox_security_check.test.ts
+++ b/front/scripts/sandbox_security_check.test.ts
@@ -1,9 +1,11 @@
+import { SANDBOX_ROOT_SAFE_PATH } from "@app/lib/api/sandbox/hardening";
 import {
   assertLocalAuthHelpersNotSetuid,
   assertNoEmptyPasswordAccounts,
   assertNoPasswordlessSudoers,
   assertNoPrivilegedGroupMembers,
   assertPrivilegedDirsSafe,
+  assertRootPathSafe,
   assertSudoAbsent,
   buildBashCommand,
   containsUnrestrictedSudo,
@@ -103,5 +105,18 @@ describe("sandbox security check assertions", () => {
         "/opt/bin root:root 777 drwxrwxrwx\n/usr/local/bin root:root 755 drwxr-xr-x"
       )
     ).toThrow("privileged directory /opt/bin is not root-owned");
+  });
+
+  test("detects root PATH entries that can resolve agent-writable binaries", () => {
+    expect(() =>
+      assertRootPathSafe(
+        `ROOT_EXEC_PATH=${SANDBOX_ROOT_SAFE_PATH}\nROOT_LOGIN_PATH=${SANDBOX_ROOT_SAFE_PATH}`
+      )
+    ).not.toThrow();
+    expect(() =>
+      assertRootPathSafe(
+        `ROOT_EXEC_PATH=${SANDBOX_ROOT_SAFE_PATH}\nROOT_LOGIN_PATH=/root/.local/bin:/opt/bin:/opt/venv/bin:/usr/bin`
+      )
+    ).toThrow("root PATH must only contain root-owned executable directories");
   });
 });

--- a/front/scripts/sandbox_security_check.ts
+++ b/front/scripts/sandbox_security_check.ts
@@ -435,7 +435,12 @@ export function assertLocalAuthHelpersNotSetuid(output: string): void {
 }
 
 export function assertPrivilegedDirsSafe(output: string): void {
-  for (const dir of ["/opt/bin", "/usr/local/bin"]) {
+  for (const dir of [
+    "/opt/bin",
+    "/usr/local",
+    "/usr/local/sbin",
+    "/usr/local/bin",
+  ]) {
     const line = output
       .split("\n")
       .find((candidate) => candidate.startsWith(`${dir} `));
@@ -453,6 +458,31 @@ export function assertPrivilegedDirsSafe(output: string): void {
     if (owner !== "root:root" || Number.isNaN(mode) || (mode & 0o022) !== 0) {
       throw new Error(
         `privileged directory ${dir} is not root-owned and non-writable by group/other:\n${line}`
+      );
+    }
+  }
+}
+
+export function assertRootInvokedHelpersSafe(output: string): void {
+  for (const path of [
+    "/opt/bin/dsbx",
+    "/usr/local/bin/dust-install-trust-bundle",
+  ]) {
+    const line = output
+      .split("\n")
+      .find((candidate) => candidate.startsWith(`${path} `));
+    if (!line) {
+      throw new Error(`missing root-invoked helper audit for ${path}`);
+    }
+
+    const fields = line.split(/\s+/);
+    const owner = fields[1];
+    const modeText = fields[2];
+    const mode = Number.parseInt(modeText, 8);
+
+    if (owner !== "root:root" || Number.isNaN(mode) || (mode & 0o022) !== 0) {
+      throw new Error(
+        `root-invoked helper is not root-owned and non-writable by group/other:\n${line}`
       );
     }
   }
@@ -515,8 +545,14 @@ for path in ${LOCAL_AUTH_HELPER_PATHS.map((path) => shellQuote(path)).join(
   fi
 done
 echo "--- privileged-dirs ---"
-for dir in /opt/bin /usr/local/bin; do
+for dir in /opt/bin /usr/local /usr/local/sbin /usr/local/bin; do
   stat -c '%n %U:%G %a %A' "$dir"
+done
+echo "--- root-invoked-helpers ---"
+for path in /opt/bin/dsbx /usr/local/bin/dust-install-trust-bundle; do
+  if [ -e "$path" ]; then
+    stat -c '%n %U:%G %a %A' "$path"
+  fi
 done
 echo "--- root-path ---"
 printf 'ROOT_EXEC_PATH=%s\n' "$PATH"
@@ -532,6 +568,7 @@ printf 'ROOT_EXEC_PATH=%s\n' "$PATH"
   assertNoEmptyPasswordAccounts(output);
   assertLocalAuthHelpersNotSetuid(output);
   assertPrivilegedDirsSafe(output);
+  assertRootInvokedHelpersSafe(output);
   assertRootPathSafe(output);
 }
 

--- a/front/scripts/sandbox_security_check.ts
+++ b/front/scripts/sandbox_security_check.ts
@@ -1,4 +1,5 @@
 import config from "@app/lib/api/config";
+import { SANDBOX_ROOT_SAFE_PATH } from "@app/lib/api/sandbox/hardening";
 import {
   formatSandboxImageId,
   getRegisteredImages,
@@ -20,6 +21,7 @@ const ROOT_ID_PATTERN = /\buid=0\(root\)\b/;
 const UNRESTRICTED_SUDO_PATTERN =
   /\([^)]*ALL[^)]*\)\s*NOPASSWD:\s*ALL|NOPASSWD:\s*ALL/;
 const PRIVILEGED_GROUP_PATTERN = /\b\d+\((sudo|wheel|admin)\)/;
+const ROOT_PATH_PREFIXES = ["ROOT_EXEC_PATH=", "ROOT_LOGIN_PATH="] as const;
 const LOCAL_AUTH_HELPER_PATHS = [
   "/bin/su",
   "/usr/bin/su",
@@ -456,6 +458,27 @@ export function assertPrivilegedDirsSafe(output: string): void {
   }
 }
 
+export function assertRootPathSafe(output: string): void {
+  const rootPathLines = output
+    .split("\n")
+    .filter((line) =>
+      ROOT_PATH_PREFIXES.some((prefix) => line.startsWith(prefix))
+    );
+
+  if (rootPathLines.length !== ROOT_PATH_PREFIXES.length) {
+    throw new Error(`missing root PATH audit lines:\n${output}`);
+  }
+
+  for (const line of rootPathLines) {
+    const [, path] = line.split("=", 2);
+    if (path !== SANDBOX_ROOT_SAFE_PATH) {
+      throw new Error(
+        `root PATH must only contain root-owned executable directories (${SANDBOX_ROOT_SAFE_PATH}):\n${line}`
+      );
+    }
+  }
+}
+
 async function checkSystemAccountAudit(
   provider: E2BSandboxProvider,
   providerId: string
@@ -495,6 +518,9 @@ echo "--- privileged-dirs ---"
 for dir in /opt/bin /usr/local/bin; do
   stat -c '%n %U:%G %a %A' "$dir"
 done
+echo "--- root-path ---"
+printf 'ROOT_EXEC_PATH=%s\n' "$PATH"
+/bin/bash --noprofile --norc -c 'source /etc/profile; printf "ROOT_LOGIN_PATH=%s\n" "$PATH"'
 `,
     { user: "root" }
   );
@@ -506,6 +532,111 @@ done
   assertNoEmptyPasswordAccounts(output);
   assertLocalAuthHelpersNotSetuid(output);
   assertPrivilegedDirsSafe(output);
+  assertRootPathSafe(output);
+}
+
+async function checkRootExecPathHijack(
+  provider: E2BSandboxProvider,
+  providerId: string
+): Promise<void> {
+  const marker = `root-exec-path-proof-${Date.now()}`;
+  const secretPath = `/run/dust/${marker}.secret`;
+  const leakDir = `/tmp/${marker}`;
+  const plantedPath = "/opt/venv/bin/nohup";
+
+  try {
+    const seed = await runBashScript(
+      provider,
+      providerId,
+      `
+set -euo pipefail
+/usr/bin/mkdir -p /run/dust
+printf %s ${shellQuote(marker)} > ${shellQuote(secretPath)}
+/usr/bin/chown root:root ${shellQuote(secretPath)}
+/usr/bin/chmod 600 ${shellQuote(secretPath)}
+/usr/bin/rm -rf ${shellQuote(leakDir)}
+`,
+      { user: "root" }
+    );
+    assertCommandSucceeded("root exec path hijack seed", seed);
+
+    const plant = await runBashScript(
+      provider,
+      providerId,
+      `
+set -euo pipefail
+/usr/bin/cat > ${shellQuote(plantedPath)} <<'DUST_HIJACK_EOF'
+#!/bin/sh
+/bin/mkdir -p ${leakDir}
+/usr/bin/id > ${leakDir}/id
+/bin/cat ${secretPath} > ${leakDir}/leaked 2>${leakDir}/cat.err || true
+/bin/chmod -R a+rX ${leakDir}
+exec /usr/bin/nohup "$@"
+DUST_HIJACK_EOF
+/usr/bin/chmod 755 ${shellQuote(plantedPath)}
+`,
+      { user: AGENT_PROXIED_USER }
+    );
+    assertCommandSucceeded("root exec path hijack plant", plant);
+
+    const trigger = await runBashScript(
+      provider,
+      providerId,
+      `
+set -euo pipefail
+/usr/bin/rm -rf ${shellQuote(leakDir)}
+nohup /bin/true >/tmp/dust-root-path-hijack-nohup.log 2>&1 &
+/usr/bin/sleep 1
+if [ -f ${shellQuote(`${leakDir}/leaked`)} ]; then
+  echo "CRITICAL: root command resolved agent-writable ${plantedPath}"
+  cat ${shellQuote(`${leakDir}/id`)} || true
+  exit 1
+fi
+command -v nohup
+`,
+      { user: "root" }
+    );
+    assertCommandSucceeded("root exec path hijack trigger", trigger);
+    if (combinedOutput(trigger).trim() !== "/usr/bin/nohup") {
+      throw new Error(
+        `root nohup did not resolve to /usr/bin/nohup:\n${combinedOutput(
+          trigger
+        )}`
+      );
+    }
+
+    const readback = await runBashScript(
+      provider,
+      providerId,
+      `
+set -euo pipefail
+if [ -f ${shellQuote(`${leakDir}/leaked`)} ]; then
+  echo "CRITICAL: agent can read leaked root file"
+  cat ${shellQuote(`${leakDir}/leaked`)}
+  exit 1
+fi
+`,
+      { user: AGENT_PROXIED_USER }
+    );
+    assertCommandSucceeded("root exec path hijack readback", readback);
+  } finally {
+    try {
+      await runBashScript(
+        provider,
+        providerId,
+        `
+/usr/bin/rm -f ${shellQuote(plantedPath)} ${shellQuote(secretPath)}
+/usr/bin/rm -rf ${shellQuote(leakDir)}
+`,
+        { user: "root" }
+      );
+    } catch (error) {
+      logger.warn(
+        { err: normalizeError(error), providerId },
+        "Failed to clean up root exec path hijack regression probe"
+      );
+    }
+  }
 }
 
 function assertSshAndDnsHardening(output: string): void {
@@ -552,30 +683,30 @@ async function checkSshAndDnsHardening(
     providerId,
     `
 set -euo pipefail
-if awk '$2 ~ /:0016$/ && $4 == "0A" { found=1 } END { exit found ? 0 : 1 }' /proc/net/tcp /proc/net/tcp6; then
+if /usr/bin/awk '$2 ~ /:0016$/ && $4 == "0A" { found=1 } END { exit found ? 0 : 1 }' /proc/net/tcp /proc/net/tcp6; then
   echo "SSH_PORT_22_LISTENING=1"
 else
   echo "SSH_PORT_22_LISTENING=0"
 fi
 echo "--- sshd-hardening ---"
-cat /etc/ssh/sshd_config.d/00-dust-sandbox-hardening.conf
+/usr/bin/cat /etc/ssh/sshd_config.d/00-dust-sandbox-hardening.conf
 echo "--- dns-systemd ---"
-if systemctl is-active --quiet dust-egress-resolver.service; then
+if /usr/bin/systemctl is-active --quiet dust-egress-resolver.service; then
   echo "DNS_RESOLVER_ACTIVE=1"
 else
-  systemctl status dust-egress-resolver.service --no-pager || true
+  /usr/bin/systemctl status dust-egress-resolver.service --no-pager || true
   echo "DNS_RESOLVER_ACTIVE=0"
 fi
-if systemctl is-active --quiet dust-egress-nftables.service; then
+if /usr/bin/systemctl is-active --quiet dust-egress-nftables.service; then
   echo "DNS_NFTABLES_ACTIVE=1"
 else
-  systemctl status dust-egress-nftables.service --no-pager || true
+  /usr/bin/systemctl status dust-egress-nftables.service --no-pager || true
   echo "DNS_NFTABLES_ACTIVE=0"
 fi
 echo "--- nft-ip ---"
-nft -n list table ip dust-egress
+/usr/sbin/nft -n list table ip dust-egress
 echo "--- nft-ip6 ---"
-nft -n list table ip6 dust-egress
+/usr/sbin/nft -n list table ip6 dust-egress
 `,
     { user: "root" }
   );
@@ -614,6 +745,7 @@ async function checkImage(image: SandboxImage): Promise<void> {
     await checkEquivalentAccountEscalation(provider, providerId);
     await checkSystemAccountAudit(provider, providerId);
     await checkSshAndDnsHardening(provider, providerId);
+    await checkRootExecPathHijack(provider, providerId);
 
     logger.info(
       { imageId, providerId },


### PR DESCRIPTION
## Description

Context: private security report with a real E2B reproduction of agent-writable binaries being resolved by root lifecycle commands.

Harden root sandbox commands against agent-writable PATH hijacks. Root E2B execs now run with a safe PATH, root profile shells get the same PATH, and root lifecycle commands use absolute system binaries where we control the command string.

Also bumps `dust-base` to `0.8.29` and adds a regression check that plants `/opt/venv/bin/nohup` as `agent-proxied` and verifies root still resolves `/usr/bin/nohup`.

## Tests

- Added focused provider, GCS mount, registry, and sandbox security regression tests.
- Verified in a real E2B sandbox: the old `/opt/venv/bin/nohup` hijack no longer leaks the fake root-only secret, and the sandbox was destroyed afterwards.
- `sandbox_image_check --json` reports `dust-base_0-8-29` missing and build-needed, as expected before the image workflow runs.

## Risk

Low to moderate. This changes the root command environment, but keeps `/opt/bin` in PATH for `dsbx` and preserves non-root agent PATH behavior.

## Deploy Plan

- [ ] Build and roll out `dust-base_0-8-29`.
- [ ] Trigger a kill request for older `dust-base` sandboxes so existing conversations recreate against the hardened image.