### PR TITLE
fix(usage-page): pagination, search debounce, and total AWU credits display

### DIFF
--- a/front-api/routes/w/[wId]/credits/awu-pool-summary.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-summary.ts
@@ -118,7 +118,7 @@ app.get("/", async (ctx): HandlerResult<AwuPoolSummaryResponseBody> => {
     (entry) =>
       entry.access_schedule?.credit_type?.id === awuCreditTypeId &&
       !seatProductIds.has(entry.product.id) &&
-      entry.contract?.id === metronomeContractId
+      (entry.contract?.id === metronomeContractId || !entry.contract)
   );
 
   let totalRemainingCredits = 0;

--- a/front-api/routes/w/[wId]/credits/awu-pool-summary.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-summary.ts
@@ -1,28 +1,21 @@
 import {
   ceilToMidnightUTC,
-  floorToMidnightUTC,
   listMetronomeBalances,
   listMetronomeDraftInvoices,
-  listMetronomeUsageWithGroups,
 } from "@app/lib/metronome/client";
-import {
-  getCreditTypeAwuId,
-  getMetricLlmProviderCostAwuId,
-} from "@app/lib/metronome/constants";
+import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import {
   getProductSeatTypes,
   getSeatTypesByProductIdFromContract,
 } from "@app/lib/metronome/seat_types";
-import { buildSeatDataByUserId } from "@app/lib/metronome/seats";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 
 export type AwuPoolSummaryResponseBody = {
   totalRemainingCredits: number;
-  consumedByUsersCredits: number;
-  consumedByProgrammaticCredits: number;
+  totalActiveCredits: number;
   resetDate: string;
 };
 
@@ -98,8 +91,7 @@ app.get("/", async (ctx): HandlerResult<AwuPoolSummaryResponseBody> => {
   if (!currentInvoice?.start_timestamp || !currentInvoice.end_timestamp) {
     return ctx.json({
       totalRemainingCredits: 0,
-      consumedByUsersCredits: 0,
-      consumedByProgrammaticCredits: 0,
+      totalActiveCredits: 0,
       resetDate: "",
     });
   }
@@ -125,81 +117,30 @@ app.get("/", async (ctx): HandlerResult<AwuPoolSummaryResponseBody> => {
   const awuBalances = balancesResult.value.filter(
     (entry) =>
       entry.access_schedule?.credit_type?.id === awuCreditTypeId &&
-      !seatProductIds.has(entry.product.id)
+      !seatProductIds.has(entry.product.id) &&
+      entry.contract?.id === metronomeContractId
   );
 
   let totalRemainingCredits = 0;
+  let totalActiveCredits = 0;
   for (const entry of awuBalances) {
-    const isActive = (entry.access_schedule?.schedule_items ?? []).some(
-      (item) => {
-        const itemStartMs = new Date(item.starting_at).getTime();
-        const itemEndMs = new Date(item.ending_before).getTime();
-        return itemStartMs <= now && now < itemEndMs;
-      }
-    );
+    const scheduleItems = entry.access_schedule?.schedule_items ?? [];
+    const isActive = scheduleItems.some((item) => {
+      const itemStartMs = new Date(item.starting_at).getTime();
+      const itemEndMs = new Date(item.ending_before).getTime();
+      return itemStartMs <= now && now < itemEndMs;
+    });
     if (isActive) {
       totalRemainingCredits += entry.balance ?? 0;
-    }
-  }
-
-  const startingOn = floorToMidnightUTC(
-    new Date(currentInvoice.start_timestamp)
-  ).toISOString();
-  const endingBefore = ceilToMidnightUTC(
-    new Date(currentInvoice.end_timestamp)
-  ).toISOString();
-
-  const [usageResult, seatDataByUserId] = await Promise.all([
-    listMetronomeUsageWithGroups({
-      customerId: metronomeCustomerId,
-      billableMetricId: getMetricLlmProviderCostAwuId(),
-      startingOn,
-      endingBefore,
-      windowSize: "NONE",
-      groupKey: ["user_id", "usage_type"],
-    }),
-    buildSeatDataByUserId({
-      metronomeCustomerId,
-      contractId: metronomeContractId,
-    }),
-  ]);
-
-  if (usageResult.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: `Failed to retrieve Metronome usage: ${usageResult.error.message}`,
-      },
-    });
-  }
-
-  const perUserCredits = new Map<string, number>();
-  let consumedByProgrammaticCredits = 0;
-
-  for (const row of usageResult.value) {
-    const credits = row.value ?? 0;
-    const usageType = row.group?.["usage_type"];
-    if (usageType === "programmatic") {
-      consumedByProgrammaticCredits += credits;
-    } else {
-      const userId = row.group?.["user_id"];
-      if (userId) {
-        perUserCredits.set(userId, (perUserCredits.get(userId) ?? 0) + credits);
+      for (const item of scheduleItems) {
+        totalActiveCredits += item.amount;
       }
     }
-  }
-
-  let consumedByUsersCredits = 0;
-  for (const [userId, userCredits] of perUserCredits) {
-    const seatAllocation = seatDataByUserId.get(userId)?.awuAllocation ?? 0;
-    consumedByUsersCredits += Math.max(0, userCredits - seatAllocation);
   }
 
   return ctx.json({
     totalRemainingCredits,
-    consumedByUsersCredits,
-    consumedByProgrammaticCredits,
+    totalActiveCredits,
     resetDate,
   });
 });

--- a/front-api/routes/w/[wId]/credits/members-usage.ts
+++ b/front-api/routes/w/[wId]/credits/members-usage.ts
@@ -30,7 +30,6 @@ app.get(
     const body = await getMembersUsage({
       auth,
       paginationParams: ctx.req.valid("query"),
-      currentUrl: ctx.req.url,
     });
     return ctx.json(body);
   }

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -133,10 +133,6 @@ export function UsagePage() {
     pageSize: DEFAULT_PAGE_SIZE,
   });
 
-  // Reset to first page whenever the search term changes.
-  useEffect(() => {
-    setPagination({ pageIndex: 0, pageSize: DEFAULT_PAGE_SIZE });
-  }, [searchTerm]);
   const [showBuyCreditDialog, setShowBuyCreditDialog] = useState(false);
   const [changeSeatMember, setChangeSeatMember] =
     useState<MemberUsageType | null>(null);

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -41,6 +41,7 @@ import {
   Spinner,
   Tooltip,
 } from "@dust-tt/sparkle";
+import type { PaginationState } from "@tanstack/react-table";
 import { useCallback, useEffect, useState } from "react";
 
 function formatCredits(credits: number): string {
@@ -77,29 +78,21 @@ function getResetDateLabel(resetDate: string): string {
   return `Resets on the ${resetDay}${suffix} of each month. Next reset: ${resetMonth} ${resetDay}${suffix}.`;
 }
 
+const DEFAULT_PAGE_SIZE = 25;
+
 interface CreditPoolUsageBarProps {
   totalCredits: number;
-  consumedByUsersCredits: number;
-  consumedByProgrammaticCredits: number;
+  consumedCredits: number;
 }
 
 function CreditPoolUsageBar({
   totalCredits,
-  consumedByUsersCredits,
-  consumedByProgrammaticCredits,
+  consumedCredits,
 }: CreditPoolUsageBarProps) {
-  const usersPercentage =
+  const consumedPercentage =
     totalCredits > 0
-      ? Math.min((consumedByUsersCredits / totalCredits) * 100, 100)
+      ? Math.min((consumedCredits / totalCredits) * 100, 100)
       : 0;
-  const programmaticPercentage =
-    totalCredits > 0
-      ? Math.min(
-          (consumedByProgrammaticCredits / totalCredits) * 100,
-          100 - usersPercentage
-        )
-      : 0;
-  const totalConsumedPercentage = usersPercentage + programmaticPercentage;
 
   return (
     <Page.Vertical gap="xs" align="stretch">
@@ -107,40 +100,20 @@ function CreditPoolUsageBar({
         className="flex h-2 w-full overflow-hidden rounded-full bg-muted-foreground/10 dark:bg-muted-foreground-night/10"
         role="progressbar"
         aria-label="Workspace Credits Pool usage"
-        aria-valuenow={Math.round(totalConsumedPercentage)}
+        aria-valuenow={Math.round(consumedPercentage)}
         aria-valuemin={0}
         aria-valuemax={100}
       >
         <Tooltip
           tooltipTriggerAsChild
-          label={`Users: ${formatCredits(consumedByUsersCredits)} credits`}
+          label={`${formatCredits(consumedCredits)} credits consumed`}
           trigger={
             <div
-              className="h-full shrink-0 bg-yellow-400 transition-all"
-              style={{ width: `${usersPercentage}%` }}
+              className="h-full shrink-0 bg-highlight transition-all dark:bg-highlight-night"
+              style={{ width: `${consumedPercentage}%` }}
             />
           }
         />
-        <Tooltip
-          tooltipTriggerAsChild
-          label={`Programmatic usage: ${formatCredits(consumedByProgrammaticCredits)} credits`}
-          trigger={
-            <div
-              className="h-full shrink-0 bg-purple-500 transition-all"
-              style={{ width: `${programmaticPercentage}%` }}
-            />
-          }
-        />
-      </div>
-      <div className="flex gap-4 text-xs text-muted-foreground dark:text-muted-foreground-night">
-        <span className="flex items-center gap-1.5">
-          <span className="h-2 w-2 bg-yellow-400" />
-          Users
-        </span>
-        <span className="flex items-center gap-1.5">
-          <span className="h-2 w-2 bg-purple-500" />
-          Programmatic usage
-        </span>
       </div>
     </Page.Vertical>
   );
@@ -155,6 +128,15 @@ export function UsagePage() {
   const [seatTypeFilter, setSeatTypeFilter] = useState<
     MembershipSeatType | "none" | null
   >(null);
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: DEFAULT_PAGE_SIZE,
+  });
+
+  // Reset to first page whenever the search term changes.
+  useEffect(() => {
+    setPagination({ pageIndex: 0, pageSize: DEFAULT_PAGE_SIZE });
+  }, [searchTerm]);
   const [showBuyCreditDialog, setShowBuyCreditDialog] = useState(false);
   const [changeSeatMember, setChangeSeatMember] =
     useState<MemberUsageType | null>(null);
@@ -170,8 +152,7 @@ export function UsagePage() {
 
   const {
     totalRemainingCredits,
-    consumedByUsersCredits,
-    consumedByProgrammaticCredits,
+    totalActiveCredits,
     resetDate,
     isAwuPoolSummaryLoading,
     isAwuPoolSummaryError,
@@ -185,9 +166,13 @@ export function UsagePage() {
       disabled: !showBuyCreditDialog,
     });
 
-  const { membersUsage, isMembersUsageLoading } = useMembersUsage({
-    workspaceId: owner.sId,
-  });
+  const { membersUsage, isMembersUsageLoading, totalMembersUsage } =
+    useMembersUsage({
+      workspaceId: owner.sId,
+      searchTerm,
+      pageIndex: pagination.pageIndex,
+      pageSize: pagination.pageSize,
+    });
 
   const { hasAvailableSeats } = useWorkspaceSeatAvailability({
     workspaceId: owner.sId,
@@ -223,11 +208,11 @@ export function UsagePage() {
     [plan, subscription.paymentFailingSince, hasAvailableSeats]
   );
 
-  const totalConsumedCredits =
-    consumedByUsersCredits + consumedByProgrammaticCredits;
-  const initialTotalCredits = Math.round(
-    totalRemainingCredits + totalConsumedCredits
+  const totalConsumedCredits = Math.max(
+    0,
+    totalActiveCredits - totalRemainingCredits
   );
+  const initialTotalCredits = totalActiveCredits;
 
   const resetDateLabel = getResetDateLabel(resetDate);
 
@@ -307,8 +292,7 @@ export function UsagePage() {
           {!isAwuPoolSummaryLoading && !isAwuPoolSummaryError && (
             <CreditPoolUsageBar
               totalCredits={initialTotalCredits}
-              consumedByUsersCredits={consumedByUsersCredits}
-              consumedByProgrammaticCredits={consumedByProgrammaticCredits}
+              consumedCredits={totalConsumedCredits}
             />
           )}
 
@@ -329,7 +313,7 @@ export function UsagePage() {
           </span>
           <div className="flex flex-row gap-2">
             <SearchInput
-              placeholder="Search members (email)"
+              placeholder="Search members"
               value={searchTerm}
               name="search"
               onChange={setSearchTerm}
@@ -390,11 +374,13 @@ export function UsagePage() {
           <MembersUsageTable
             members={membersUsage}
             isLoading={isMembersUsageLoading}
-            searchTerm={searchTerm}
             seatTypeFilter={seatTypeFilter}
             isSeatBased={isSeatBased}
             onChangeSeat={setChangeSeatMember}
             onEditSpendLimit={setEditSpendLimitMember}
+            pagination={pagination}
+            setPagination={setPagination}
+            totalRowCount={totalMembersUsage}
           />
         </Page.Vertical>
 

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -5,6 +5,7 @@ import {
   type MembershipSeatType,
 } from "@app/types/memberships";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { ANONYMOUS_USER_IMAGE_URL } from "@app/types/user";
 import {
   ActionCreditCoinsIcon,
   DataTable,
@@ -16,8 +17,13 @@ import {
   SeatProIcon,
   Tooltip,
 } from "@dust-tt/sparkle";
-import type { CellContext, ColumnDef } from "@tanstack/react-table";
+import type {
+  CellContext,
+  ColumnDef,
+  PaginationState,
+} from "@tanstack/react-table";
 import type React from "react";
+import { useMemo } from "react";
 
 type RowData = {
   sId: string;
@@ -212,7 +218,7 @@ const nameColumn: ColumnDef<RowData, string> = {
   accessorFn: (row) => row.name,
   cell: (info: Info) => (
     <DataTable.CellContent
-      avatarUrl={info.row.original.image ?? undefined}
+      avatarUrl={info.row.original.image ?? ANONYMOUS_USER_IMAGE_URL}
       roundedAvatar
     >
       <div>
@@ -361,22 +367,90 @@ function buildColumns({
 interface MembersUsageTableProps {
   members: MemberUsageType[];
   isLoading: boolean;
-  searchTerm: string;
   seatTypeFilter: MembershipSeatType | "none" | null;
   isSeatBased: boolean;
   onChangeSeat: (member: MemberUsageType) => void;
   onEditSpendLimit: (member: MemberUsageType) => void;
+  pagination: PaginationState;
+  setPagination: (pagination: PaginationState) => void;
+  totalRowCount: number;
 }
 
 export function MembersUsageTable({
   members,
   isLoading,
-  searchTerm,
   seatTypeFilter,
   isSeatBased,
   onChangeSeat,
   onEditSpendLimit,
+  pagination,
+  setPagination,
+  totalRowCount,
 }: MembersUsageTableProps) {
+  // Name/email search is handled server-side; only filter by seat type here.
+  const filtered = useMemo(
+    () =>
+      members.filter((m) => {
+        if (seatTypeFilter === "none" && m.seatType !== null) {
+          return false;
+        }
+        if (
+          seatTypeFilter !== null &&
+          seatTypeFilter !== "none" &&
+          m.seatType &&
+          !m.seatType.startsWith(seatTypeFilter)
+        ) {
+          return false;
+        }
+        return true;
+      }),
+    [members, seatTypeFilter]
+  );
+
+  const rows: RowData[] = useMemo(
+    () =>
+      filtered.map((m) => ({
+        sId: m.sId,
+        name: m.name,
+        email: m.email,
+        image: m.image,
+        seatType: m.seatType,
+        memberUsageLimit: m.memberUsageLimit,
+        consumedAwuCredits: m.consumedAwuCredits,
+        spendLimitAwuCredits: m.spendLimitAwuCredits,
+        billingFrequency: m.billingFrequency,
+        scheduledSeatType: m.scheduledSeatType,
+        scheduledSeatChangeAt: m.scheduledSeatChangeAt,
+        menuItems: [
+          ...(isSeatBased
+            ? [
+                {
+                  kind: "item" as const,
+                  label: "Change seat type",
+                  onClick: () => onChangeSeat(m),
+                },
+              ]
+            : []),
+          {
+            kind: "item" as const,
+            label: "Edit spend limit",
+            onClick: () => onEditSpendLimit(m),
+          },
+        ],
+      })),
+    [filtered, isSeatBased, onChangeSeat, onEditSpendLimit]
+  );
+
+  const displayPeriodColumn = useMemo(
+    () => rows.some((row) => !!row.billingFrequency),
+    [rows]
+  );
+
+  const columns = useMemo(
+    () => buildColumns({ isSeatBased, displayPeriodColumn }),
+    [isSeatBased, displayPeriodColumn]
+  );
+
   if (isLoading) {
     return (
       <div className="flex w-full flex-col space-y-2">
@@ -387,65 +461,13 @@ export function MembersUsageTable({
     );
   }
 
-  const lowerSearch = searchTerm.toLowerCase();
-  const filtered = members.filter((m) => {
-    if (
-      searchTerm &&
-      !m.name.toLowerCase().includes(lowerSearch) &&
-      !(m.email ?? "").toLowerCase().includes(lowerSearch)
-    ) {
-      return false;
-    }
-    if (seatTypeFilter === "none" && m.seatType !== null) {
-      return false;
-    }
-    if (
-      seatTypeFilter !== null &&
-      seatTypeFilter !== "none" &&
-      m.seatType &&
-      !m.seatType.startsWith(seatTypeFilter)
-    ) {
-      return false;
-    }
-    return true;
-  });
-
-  const rows: RowData[] = filtered.map((m) => ({
-    sId: m.sId,
-    name: m.name,
-    email: m.email,
-    image: m.image,
-    seatType: m.seatType,
-    memberUsageLimit: m.memberUsageLimit,
-    consumedAwuCredits: m.consumedAwuCredits,
-    spendLimitAwuCredits: m.spendLimitAwuCredits,
-    billingFrequency: m.billingFrequency,
-    scheduledSeatType: m.scheduledSeatType,
-    scheduledSeatChangeAt: m.scheduledSeatChangeAt,
-    menuItems: [
-      ...(isSeatBased
-        ? [
-            {
-              kind: "item" as const,
-              label: "Change seat type",
-              onClick: () => onChangeSeat(m),
-            },
-          ]
-        : []),
-      {
-        kind: "item" as const,
-        label: "Edit spend limit",
-        onClick: () => onEditSpendLimit(m),
-      },
-    ],
-  }));
-
-  const displayPeriodColumn = rows.some((row) => !!row.billingFrequency);
-
   return (
     <DataTable
       data={rows}
-      columns={buildColumns({ isSeatBased, displayPeriodColumn })}
+      columns={columns}
+      pagination={pagination}
+      setPagination={setPagination}
+      totalRowCount={totalRowCount}
     />
   );
 }

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -1,29 +1,22 @@
 import type { Authenticator } from "@app/lib/auth";
 import {
   ceilToMidnightUTC,
-  floorToMidnightUTC,
   listMetronomeBalances,
   listMetronomeDraftInvoices,
-  listMetronomeUsageWithGroups,
 } from "@app/lib/metronome/client";
-import {
-  getCreditTypeAwuId,
-  getMetricLlmProviderCostAwuId,
-} from "@app/lib/metronome/constants";
+import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import {
   getProductSeatTypes,
   getSeatTypesByProductIdFromContract,
 } from "@app/lib/metronome/seat_types";
-import { buildSeatDataByUserId } from "@app/lib/metronome/seats";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export type AwuPoolSummaryResponseBody = {
   totalRemainingCredits: number;
-  consumedByUsersCredits: number;
-  consumedByProgrammaticCredits: number;
+  totalActiveCredits: number;
   resetDate: string;
 };
 
@@ -101,8 +94,7 @@ export async function handleAwuPoolSummaryRequest(
       if (!currentInvoice?.start_timestamp || !currentInvoice.end_timestamp) {
         return res.status(200).json({
           totalRemainingCredits: 0,
-          consumedByUsersCredits: 0,
-          consumedByProgrammaticCredits: 0,
+          totalActiveCredits: 0,
           resetDate: "",
         });
       }
@@ -114,117 +106,46 @@ export async function handleAwuPoolSummaryRequest(
       // Filter to active, non-seat AWU pool credits and commits. The set of
       // seat product IDs is derived from the contract's tagged subscriptions
       // (via the `DUST_SEAT_TYPE` custom field) rather than a hardcoded list.
+      // The contract filter prevents sandbox prepaid commits on other contracts
+      // from inflating the balance.
       const awuCreditTypeId = getCreditTypeAwuId();
       const activeContract = await getActiveContract(workspace.sId);
-      if (!activeContract) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: "Workspace is not configured for Metronome billing.",
-          },
-        });
-      }
       const productSeatTypes = await getProductSeatTypes();
-      const seatProductIds = new Set(
-        getSeatTypesByProductIdFromContract(
-          activeContract,
-          productSeatTypes
-        ).keys()
-      );
+      const seatProductIds = activeContract
+        ? new Set(
+            getSeatTypesByProductIdFromContract(
+              activeContract,
+              productSeatTypes
+            ).keys()
+          )
+        : new Set<string>();
       const awuBalances = balancesResult.value.filter(
         (entry) =>
           entry.access_schedule?.credit_type?.id === awuCreditTypeId &&
-          !seatProductIds.has(entry.product.id)
+          !seatProductIds.has(entry.product.id) &&
+          entry.contract?.id === metronomeContractId
       );
 
-      // Sum the remaining balance of each active pool credit.
-      // entry.balance accounts for prior-period consumption (e.g. a carried-over prepaid
-      // top-off that was partially consumed in a previous billing cycle). Upcoming and
-      // expired schedule segments contribute 0 to the balance, so this is safe for
-      // multi-period recurring credits too.
       let totalRemainingCredits = 0;
+      let totalActiveCredits = 0;
       for (const entry of awuBalances) {
-        const isActive = (entry.access_schedule?.schedule_items ?? []).some(
-          (item) => {
-            const itemStartMs = new Date(item.starting_at).getTime();
-            const itemEndMs = new Date(item.ending_before).getTime();
-            return itemStartMs <= now && now < itemEndMs;
-          }
-        );
+        const scheduleItems = entry.access_schedule?.schedule_items ?? [];
+        const isActive = scheduleItems.some((item) => {
+          const itemStartMs = new Date(item.starting_at).getTime();
+          const itemEndMs = new Date(item.ending_before).getTime();
+          return itemStartMs <= now && now < itemEndMs;
+        });
         if (isActive) {
           totalRemainingCredits += entry.balance ?? 0;
-        }
-      }
-
-      const startingOn = floorToMidnightUTC(
-        new Date(currentInvoice.start_timestamp)
-      ).toISOString();
-      const endingBefore = ceilToMidnightUTC(
-        new Date(currentInvoice.end_timestamp)
-      ).toISOString();
-
-      // Query usage per user and seat allocations in parallel.
-      // Per-user breakdown is needed to compute pool overflow correctly:
-      // seat credits cover each user up to their allocation; only the excess
-      // draws from the workspace pool.
-      const [usageResult, seatDataByUserId] = await Promise.all([
-        listMetronomeUsageWithGroups({
-          customerId: metronomeCustomerId,
-          billableMetricId: getMetricLlmProviderCostAwuId(),
-          startingOn,
-          endingBefore,
-          windowSize: "NONE",
-          groupKey: ["user_id", "usage_type"],
-        }),
-        buildSeatDataByUserId({
-          metronomeCustomerId,
-          contractId: metronomeContractId,
-        }),
-      ]);
-
-      if (usageResult.isErr()) {
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: `Failed to retrieve Metronome usage: ${usageResult.error.message}`,
-          },
-        });
-      }
-
-      // Aggregate per-user consumption from the usage metric.
-      const perUserCredits = new Map<string, number>();
-      let consumedByProgrammaticCredits = 0;
-
-      for (const row of usageResult.value) {
-        const credits = row.value ?? 0;
-        const usageType = row.group?.["usage_type"];
-        if (usageType === "programmatic") {
-          consumedByProgrammaticCredits += credits;
-        } else {
-          const userId = row.group?.["user_id"];
-          if (userId) {
-            perUserCredits.set(
-              userId,
-              (perUserCredits.get(userId) ?? 0) + credits
-            );
+          for (const item of scheduleItems) {
+            totalActiveCredits += item.amount;
           }
         }
-      }
-
-      // Pool user consumption = sum of each user's overflow beyond their seat allocation.
-      // Users without a seat: all their usage is pool consumption.
-      let consumedByUsersCredits = 0;
-      for (const [userId, userCredits] of perUserCredits) {
-        const seatAllocation = seatDataByUserId.get(userId)?.awuAllocation ?? 0;
-        consumedByUsersCredits += Math.max(0, userCredits - seatAllocation);
       }
 
       return res.status(200).json({
         totalRemainingCredits,
-        consumedByUsersCredits,
-        consumedByProgrammaticCredits,
+        totalActiveCredits,
         resetDate,
       });
     }

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -123,7 +123,7 @@ export async function handleAwuPoolSummaryRequest(
         (entry) =>
           entry.access_schedule?.credit_type?.id === awuCreditTypeId &&
           !seatProductIds.has(entry.product.id) &&
-          entry.contract?.id === metronomeContractId
+          (entry.contract?.id === metronomeContractId || !entry.contract)
       );
 
       let totalRemainingCredits = 0;

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -6,10 +6,8 @@ import {
 import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
 import { buildSeatDataByUserId, type SeatData } from "@app/lib/metronome/seats";
 import type { BillingFrequency } from "@app/lib/metronome/types";
-import {
-  MembershipResource,
-  type MembershipsPaginationParams,
-} from "@app/lib/resources/membership_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import { resolveEffectiveSpendLimitAwuCredits } from "@app/lib/spend_limits/effective";
 import type { MembershipSeatType } from "@app/types/memberships";
 import { z } from "zod";
@@ -39,7 +37,6 @@ export type MemberUsageType = {
 export type GetMembersUsageResponseBody = {
   members: MemberUsageType[];
   total: number;
-  nextPageUrl?: string;
 };
 
 export const DEFAULT_MEMBERS_USAGE_PAGE_LIMIT = 50;
@@ -52,32 +49,13 @@ export const MembersUsagePaginationSchema = z.object({
     .min(0)
     .max(MAX_MEMBERS_USAGE_PAGE_LIMIT)
     .catch(DEFAULT_MEMBERS_USAGE_PAGE_LIMIT),
-  orderColumn: z.literal("createdAt").catch("createdAt"),
-  orderDirection: z.enum(["asc", "desc"]).catch("desc"),
-  lastValue: z.coerce.number().optional().catch(undefined),
+  offset: z.coerce.number().int().min(0).catch(0),
+  search: z.string().optional().catch(undefined),
 });
 
 export type MembersUsagePaginationInput = z.infer<
   typeof MembersUsagePaginationSchema
 >;
-
-function buildUrlWithParams(
-  currentUrl: string,
-  newParams: MembershipsPaginationParams | undefined
-) {
-  if (!newParams) {
-    return undefined;
-  }
-  const url = new URL(currentUrl);
-  Object.entries(newParams).forEach(([key, value]) => {
-    if (value === null || value === undefined) {
-      url.searchParams.delete(key);
-    } else {
-      url.searchParams.set(key, value.toString());
-    }
-  });
-  return url.pathname + url.search;
-}
 
 async function fetchPerUserUsageCreditsForMembersTable({
   metronomeCustomerId,
@@ -167,27 +145,40 @@ async function fetchEffectivePerUserSpendLimits({
 export async function getMembersUsage({
   auth,
   paginationParams,
-  currentUrl,
 }: {
   auth: Authenticator;
   paginationParams: MembersUsagePaginationInput;
-  currentUrl: string;
 }): Promise<GetMembersUsageResponseBody> {
   const workspace = auth.getNonNullableWorkspace();
   const subscription = auth.subscription();
   const { metronomeCustomerId } = workspace;
   const metronomeContractId = subscription?.metronomeContractId ?? null;
 
+  const usersResult = await UserResource.searchUsers(auth, {
+    searchTerm: paginationParams.search ?? "",
+    offset: paginationParams.offset,
+    limit: paginationParams.limit,
+  });
+
+  if (usersResult.isErr()) {
+    return { members: [], total: 0 };
+  }
+
+  const { users, total } = usersResult.value;
+
+  if (users.length === 0) {
+    return { members: [], total };
+  }
+
+  // Fetch membership details and Metronome data in parallel for the
+  // current page of users.
   const [
     membershipsResult,
     perUserTotalConsumedCredits,
     seatDataByUserId,
     perUserSpendLimits,
   ] = await Promise.all([
-    MembershipResource.getActiveMemberships({
-      workspace,
-      paginationParams,
-    }),
+    MembershipResource.getActiveMemberships({ workspace, users }),
     fetchPerUserUsageCreditsForMembersTable({
       metronomeCustomerId: metronomeCustomerId ?? null,
       metronomeContractId,
@@ -203,7 +194,7 @@ export async function getMembersUsage({
   ]);
   const { perUserOverrides, defaultAwuCredits } = perUserSpendLimits;
 
-  const { memberships, total, nextPageParams } = membershipsResult;
+  const { memberships } = membershipsResult;
 
   const scheduledByUserId =
     await MembershipResource.getScheduledMembershipsByUserIdInWorkspace({
@@ -211,24 +202,25 @@ export async function getMembersUsage({
       userIds: memberships.map((m) => m.userId),
     });
 
-  const membersUsage: MemberUsageType[] = memberships.flatMap((m) => {
-    if (!m.user) {
+  const membershipByUserId = new Map(memberships.map((m) => [m.userId, m]));
+  const membersUsage: MemberUsageType[] = users.flatMap((u) => {
+    const membership = membershipByUserId.get(u.id);
+    if (!membership) {
       return [];
     }
-    const userId = m.user.sId;
+    const userId = u.sId;
     const totalConsumedCredits = perUserTotalConsumedCredits.get(userId) ?? 0;
     const seatData = seatDataByUserId.get(userId);
     const awuAllocation = seatData?.awuAllocation ?? 0;
-
-    const scheduled = scheduledByUserId.get(m.userId);
+    const scheduled = scheduledByUserId.get(membership.userId);
 
     return [
       {
         sId: userId,
-        name: m.user.name,
-        email: m.user.email ?? null,
-        image: m.user.imageUrl ?? null,
-        seatType: m.seatType ?? null,
+        name: u.name,
+        email: u.email ?? null,
+        image: u.imageUrl ?? null,
+        seatType: membership.seatType ?? null,
         memberUsageLimit: awuAllocation > 0 ? awuAllocation : null,
         consumedAwuCredits: totalConsumedCredits,
         billingFrequency: seatData?.billingFrequency ?? null,
@@ -245,6 +237,5 @@ export async function getMembersUsage({
   return {
     members: membersUsage,
     total,
-    nextPageUrl: buildUrlWithParams(currentUrl, nextPageParams),
   };
 }

--- a/front/lib/metronome/per_user_usage.ts
+++ b/front/lib/metronome/per_user_usage.ts
@@ -3,16 +3,6 @@ import { getProductAiUsageId } from "@app/lib/metronome/constants";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
-/**
- * Fetch per-user AWU consumption for the current billing period by reading
- * the draft invoice's line items directly.
- *
- * The "AI Usage" product is configured with presentation_group_key: ["user_id"],
- * so each line item has presentation_group_values.user_id set to the user's sId
- * when the usage is user-attributed. Summing `quantity` per user_id gives total
- * AWU consumed per user, regardless of which credit type (pool, seat, etc.)
- * funded the usage.
- */
 export async function fetchPerUserAwuUsage({
   metronomeCustomerId,
   metronomeContractId,

--- a/front/lib/metronome/per_user_usage.ts
+++ b/front/lib/metronome/per_user_usage.ts
@@ -1,13 +1,18 @@
-import {
-  ceilToMidnightUTC,
-  floorToMidnightUTC,
-  listMetronomeDraftInvoices,
-  listMetronomeUsageWithGroups,
-} from "@app/lib/metronome/client";
-import { getMetricLlmProviderCostAwuId } from "@app/lib/metronome/constants";
+import { listMetronomeDraftInvoices } from "@app/lib/metronome/client";
+import { getProductAiUsageId } from "@app/lib/metronome/constants";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
+/**
+ * Fetch per-user AWU consumption for the current billing period by reading
+ * the draft invoice's line items directly.
+ *
+ * The "AI Usage" product is configured with presentation_group_key: ["user_id"],
+ * so each line item has presentation_group_values.user_id set to the user's sId
+ * when the usage is user-attributed. Summing `quantity` per user_id gives total
+ * AWU consumed per user, regardless of which credit type (pool, seat, etc.)
+ * funded the usage.
+ */
 export async function fetchPerUserAwuUsage({
   metronomeCustomerId,
   metronomeContractId,
@@ -33,39 +38,23 @@ export async function fetchPerUserAwuUsage({
     return startMs <= now && now < endMs;
   });
 
-  if (!currentInvoice?.start_timestamp || !currentInvoice.end_timestamp) {
+  if (!currentInvoice?.line_items) {
     return new Ok(new Map());
   }
 
-  const startingOn = floorToMidnightUTC(
-    new Date(currentInvoice.start_timestamp)
-  ).toISOString();
-  const endingBefore = ceilToMidnightUTC(
-    new Date(currentInvoice.end_timestamp)
-  ).toISOString();
-
-  const usageResult = await listMetronomeUsageWithGroups({
-    customerId: metronomeCustomerId,
-    billableMetricId: getMetricLlmProviderCostAwuId(),
-    startingOn,
-    endingBefore,
-    windowSize: "NONE",
-    groupKey: ["user_id", "usage_type"],
-  });
-
-  if (usageResult.isErr()) {
-    return new Err(usageResult.error);
-  }
-
+  const aiUsageProductId = getProductAiUsageId();
   const perUser = new Map<string, number>();
-  for (const entry of usageResult.value) {
-    const userId = entry.group?.["user_id"];
-    const usageType = entry.group?.["usage_type"];
-    if (!userId || usageType !== "user" || entry.value === null) {
+
+  for (const lineItem of currentInvoice.line_items) {
+    if (lineItem.type !== "usage" || lineItem.product_id !== aiUsageProductId) {
       continue;
     }
-    const existing = perUser.get(userId) ?? 0;
-    perUser.set(userId, existing + entry.value);
+    const userId = lineItem.presentation_group_values?.["user_id"];
+    if (!userId) {
+      continue;
+    }
+    perUser.set(userId, (perUser.get(userId) ?? 0) + (lineItem.quantity ?? 0));
   }
+
   return new Ok(perUser);
 }

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -254,8 +254,7 @@ export function useAwuPoolSummary({
 
   return {
     totalRemainingCredits: data?.totalRemainingCredits ?? 0,
-    consumedByUsersCredits: data?.consumedByUsersCredits ?? 0,
-    consumedByProgrammaticCredits: data?.consumedByProgrammaticCredits ?? 0,
+    totalActiveCredits: data?.totalActiveCredits ?? 0,
     resetDate: data?.resetDate ?? "",
     isAwuPoolSummaryLoading: !error && !data && !disabled,
     isAwuPoolSummaryError: error,

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -215,30 +215,53 @@ export function useMembersLookup({
 
 export function useMembersUsage({
   workspaceId,
+  searchTerm = "",
+  pageIndex,
+  pageSize,
   disabled,
 }: {
   workspaceId: string;
+  searchTerm?: string;
+  pageIndex: number;
+  pageSize: number;
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
-  const defaultUrl = `/api/w/${workspaceId}/credits/members-usage`;
-  const [url, setUrl] = useState(defaultUrl);
-
   const membersUsageFetcher: Fetcher<GetMembersUsageResponseBody> = fetcher;
-  const { data, error } = useSWRWithDefaults(url, membersUsageFetcher, {
-    disabled,
+  const debounceHandle = useRef<NodeJS.Timeout | undefined>(undefined);
+  const [debouncedSearchTerm, setDebouncedSearchTerm] = useState(searchTerm);
+
+  useEffect(() => {
+    const debouncedSearch = () => {
+      setDebouncedSearchTerm(searchTerm);
+    };
+
+    debounce(debounceHandle, debouncedSearch, 300);
+  }, [searchTerm]);
+
+  const searchParams = new URLSearchParams({
+    offset: (pageIndex * pageSize).toString(),
+    limit: pageSize.toString(),
   });
+  if (debouncedSearchTerm.trim().length > 0) {
+    searchParams.set("search", debouncedSearchTerm.trim());
+  }
+
+  const { data, error } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/credits/members-usage?${searchParams.toString()}`,
+    membersUsageFetcher,
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      disabled,
+    }
+  );
 
   return {
     membersUsage: data?.members ?? emptyArray(),
     isMembersUsageLoading: !error && !data && !disabled,
     isMembersUsageError: !!error,
     totalMembersUsage: data?.total ?? 0,
-    hasNextPage: !!data?.nextPageUrl,
-    loadNextPage: useCallback(
-      () => data?.nextPageUrl && setUrl(data.nextPageUrl),
-      [data?.nextPageUrl]
-    ),
   };
 }
 

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -228,15 +228,11 @@ export function useMembersUsage({
 }) {
   const { fetcher } = useFetcher();
   const membersUsageFetcher: Fetcher<GetMembersUsageResponseBody> = fetcher;
-  const debounceHandle = useRef<NodeJS.Timeout | undefined>(undefined);
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState(searchTerm);
 
   useEffect(() => {
-    const debouncedSearch = () => {
-      setDebouncedSearchTerm(searchTerm);
-    };
-
-    debounce(debounceHandle, debouncedSearch, 300);
+    const id = setTimeout(() => setDebouncedSearchTerm(searchTerm), 300);
+    return () => clearTimeout(id);
   }, [searchTerm]);
 
   const searchParams = new URLSearchParams({

--- a/front/pages/api/w/[wId]/credits/members-usage.ts
+++ b/front/pages/api/w/[wId]/credits/members-usage.ts
@@ -44,7 +44,6 @@ async function handler(
       const body = await getMembersUsage({
         auth,
         paginationParams: paginationRes.data,
-        currentUrl: `https://${req.headers.host}${req.url ?? "/"}`,
       });
 
       return res.status(200).json(body);


### PR DESCRIPTION
## Summary
* For pool consumption bar, use ListBalances. Will no longer segment by programmatic/user since we can't reliably do that outside the period closure (in a future PR, we can look into surfacing more of this data if unclear)
* Using invoice draft to determine user usage in period
* Fix pagination for member table
* For member table search, use same logic as the /member path -> Query Elasticsearch for user match, then join with membership table
* Use placeholder if member does not have a profile picture

## Testing
<img width="985" height="716" alt="Screenshot 2026-05-27 at 8 38 20 PM" src="https://github.com/user-attachments/assets/7e79852f-c501-4f55-a10b-95164633a5d5" />


## Risk
* Low, not user facing yet

## Deployment steps
1. Deploy front