### PR TITLE
 [front] enh: resume production checks from heartbeats

### DIFF
--- a/front/temporal/production_checks/activities.ts
+++ b/front/temporal/production_checks/activities.ts
@@ -22,6 +22,7 @@ import type {
 } from "@app/types/production_checks";
 import { Context } from "@temporalio/activity";
 import { v4 as uuidv4 } from "uuid";
+import {normalizeError} from "@app/types/shared/utils/error_utils";
 
 export const REGISTERED_CHECKS: Check[] = [
   {
@@ -134,7 +135,10 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
   for (const check of checks) {
     if (previouslyCompletedCheckNames.has(check.name)) {
       mainLogger.info(
-        { all_check_uuid: allCheckUuid, checkName: check.name },
+        {
+          all_check_uuid: allCheckUuid,
+          checkName: check.name
+        },
         "Check already completed in previous attempt, skipping",
       );
       continue;
@@ -169,96 +173,100 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
           heartbeat: { type: "skip", name: check.name, uuid },
           completedCheckNames,
         });
-      } else {
-        logger.info("Check starting");
 
-        let checkSucceeded = true;
-        let lastSuccessPayload: CheckSuccessPayload | undefined;
-        const errorMessages: string[] = [];
-        const allActionLinks: ActionLink[] = [];
-        const allFailurePayloads: CheckFailurePayload[] = [];
-
-        const reportSuccess = (payload?: CheckSuccessPayload) => {
-          logger.info({ payload }, "Check succeeded");
-          lastSuccessPayload = payload;
-        };
-        const reportFailure = (
-          payload: CheckFailurePayload,
-          message: string,
-        ) => {
-          logger.error(
-            { payload, errorMessage: message },
-            "Production check failed",
-          );
-          checkSucceeded = false;
-          allFailurePayloads.push({ ...payload, errorMessage: message });
-          errorMessages.push(message);
-          allActionLinks.push(...(payload.actionLinks ?? []));
-        };
-
-        sendCheckHeartbeat({
-          context,
-          heartbeat: { type: "start", name: check.name, uuid },
-          completedCheckNames,
-        });
-
-        await check.check(
-          check.name,
-          logger,
-          reportSuccess,
-          reportFailure,
-          async () => sendCheckHeartbeat({
-              context,
-              heartbeat: {
-                type: "processing",
-                name: check.name,
-                uuid,
-              },
-              completedCheckNames,
-            })
-        );
-
-        results.push({
-          checkName: check.name,
-          status: checkSucceeded ? "success" : "failure",
-          timestamp: new Date().toISOString(),
-          payload: checkSucceeded
-            ? (lastSuccessPayload ?? null)
-            : allFailurePayloads.length > 0
-              ? allFailurePayloads
-              : null,
-          errorMessage:
-            errorMessages.length > 0
-              ? [...new Set(errorMessages)].join("; ")
-              : null,
-          actionLinks: allActionLinks,
-        });
-
-        completedCheckNames.push(check.name);
-        sendCheckHeartbeat({
-          context,
-          heartbeat: {
-            type: checkSucceeded ? "success" : "failure",
-            name: check.name,
-            uuid,
-          },
-          completedCheckNames,
-        });
-
-        logger.info("Check done");
+        continue;
       }
-    } catch (e) {
-      logger.error({ error: e }, "Production check failed");
+
+      logger.info("Check starting");
+
+      let checkSucceeded = true;
+      let lastSuccessPayload: CheckSuccessPayload | undefined;
+      const errorMessages: string[] = [];
+      const allActionLinks: ActionLink[] = [];
+      const allFailurePayloads: CheckFailurePayload[] = [];
+
+      const reportSuccess = (payload?: CheckSuccessPayload) => {
+        logger.info({ payload }, "Check succeeded");
+        lastSuccessPayload = payload;
+      };
+      const reportFailure = (
+        payload: CheckFailurePayload,
+        message: string,
+      ) => {
+        logger.error(
+          { payload, errorMessage: message },
+          "Production check failed",
+        );
+        checkSucceeded = false;
+        allFailurePayloads.push({ ...payload, errorMessage: message });
+        errorMessages.push(message);
+        allActionLinks.push(...(payload.actionLinks ?? []));
+      };
+
+      sendCheckHeartbeat({
+        context,
+        heartbeat: { type: "start", name: check.name, uuid },
+        completedCheckNames,
+      });
+
+      await check.check(
+        check.name,
+        logger,
+        reportSuccess,
+        reportFailure,
+        async () => sendCheckHeartbeat({
+            context,
+            heartbeat: {
+              type: "processing",
+              name: check.name,
+              uuid,
+            },
+            completedCheckNames,
+          })
+      );
+
+      logger.info("Check done");
+
+      results.push({
+        checkName: check.name,
+        status: checkSucceeded ? "success" : "failure",
+        timestamp: new Date().toISOString(),
+        payload: checkSucceeded
+          ? (lastSuccessPayload ?? null)
+          : allFailurePayloads.length > 0
+            ? allFailurePayloads
+            : null,
+        errorMessage:
+          errorMessages.length > 0
+            ? [...new Set(errorMessages)].join("; ")
+            : null,
+        actionLinks: allActionLinks,
+      });
+      completedCheckNames.push(check.name);
+
+      sendCheckHeartbeat({
+        context,
+        heartbeat: {
+          type: checkSucceeded ? "success" : "failure",
+          name: check.name,
+          uuid,
+        },
+        completedCheckNames,
+      });
+
+    } catch (error) {
+      logger.error({ error }, "Production check failed");
+
       results.push({
         checkName: check.name,
         status: "failure",
         timestamp: new Date().toISOString(),
         payload: null,
-        errorMessage: e instanceof Error ? e.message : "Unknown error",
+        errorMessage: normalizeError(error).message,
         actionLinks: [],
       });
-
       completedCheckNames.push(check.name);
+
       sendCheckHeartbeat({
         context,
         heartbeat: { type: "failure", name: check.name, uuid },

--- a/front/temporal/production_checks/activities.ts
+++ b/front/temporal/production_checks/activities.ts
@@ -215,7 +215,7 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
 
       logger.info("Check done");
 
-      const result: CheckActivityResult = {
+      results.push({
         checkName: check.name,
         status: checkSucceeded ? "success" : "failure",
         timestamp: new Date().toISOString(),
@@ -229,8 +229,7 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
             ? [...new Set(errorMessages)].join("; ")
             : null,
         actionLinks: allActionLinks,
-      };
-      results.push(result);
+      });
 
       sendCheckHeartbeat(
         {

--- a/front/temporal/production_checks/activities.ts
+++ b/front/temporal/production_checks/activities.ts
@@ -132,6 +132,14 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
   );
 
   for (const check of checks) {
+    if (previouslyCompletedCheckNames.has(check.name)) {
+      mainLogger.info(
+        { all_check_uuid: allCheckUuid, checkName: check.name },
+        "Check already completed in previous attempt, skipping",
+      );
+      continue;
+    }
+
     const uuid = uuidv4();
     const logger = mainLogger.child({
       all_check_uuid: allCheckUuid,

--- a/front/temporal/production_checks/activities.ts
+++ b/front/temporal/production_checks/activities.ts
@@ -196,18 +196,6 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
           allActionLinks.push(...(payload.actionLinks ?? []));
         };
 
-        const heartbeat = async () => {
-          return sendCheckHeartbeat({
-            context,
-            heartbeat: {
-              type: "processing",
-              name: check.name,
-              uuid,
-            },
-            completedCheckNames,
-          });
-        };
-
         sendCheckHeartbeat({
           context,
           heartbeat: { type: "start", name: check.name, uuid },
@@ -219,7 +207,15 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
           logger,
           reportSuccess,
           reportFailure,
-          heartbeat,
+          async () => sendCheckHeartbeat({
+              context,
+              heartbeat: {
+                type: "processing",
+                name: check.name,
+                uuid,
+              },
+              completedCheckNames,
+            })
         );
 
         results.push({

--- a/front/temporal/production_checks/activities.ts
+++ b/front/temporal/production_checks/activities.ts
@@ -21,7 +21,7 @@ import type {
 } from "@app/types/production_checks";
 import { CheckHeartbeatDetailsSchema } from "@app/types/production_checks";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { Context } from "@temporalio/activity";
+import {activityInfo, heartbeat} from "@temporalio/activity";
 import { v4 as uuidv4 } from "uuid";
 
 export const REGISTERED_CHECKS: Check[] = [
@@ -97,26 +97,21 @@ function getCompletedCheckNamesFromHeartbeatDetails(
     : [];
 }
 
-function sendCheckHeartbeat({
-  context,
-  heartbeat,
+function sendCheckHeartbeat(heartbeatData: CheckHeartbeat,{
   completedCheckNames,
 }: {
-  context: Context;
-  heartbeat: CheckHeartbeat;
   completedCheckNames: string[];
 }) {
-  context.heartbeat({
-    ...heartbeat,
+  heartbeat({
+    ...heartbeatData,
     completedCheckNames: [...new Set(completedCheckNames)],
   });
 }
 
 async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
   const allCheckUuid = uuidv4();
-  const context = Context.current();
   const completedCheckNames = getCompletedCheckNamesFromHeartbeatDetails(
-    context.info.heartbeatDetails
+    activityInfo().heartbeatDetails
   );
   const currentHour = new Date().getHours();
   const results: CheckActivityResult[] = [];
@@ -168,9 +163,7 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
         });
 
         completedCheckNames.push(check.name);
-        sendCheckHeartbeat({
-          context,
-          heartbeat: { type: "skip", name: check.name, uuid },
+        sendCheckHeartbeat({ type: "skip", name: check.name, uuid },{
           completedCheckNames,
         });
 
@@ -200,9 +193,7 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
         allActionLinks.push(...(payload.actionLinks ?? []));
       };
 
-      sendCheckHeartbeat({
-        context,
-        heartbeat: { type: "start", name: check.name, uuid },
+      sendCheckHeartbeat({ type: "start", name: check.name, uuid },{
         completedCheckNames,
       });
 
@@ -212,13 +203,12 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
         reportSuccess,
         reportFailure,
         async () =>
-          sendCheckHeartbeat({
-            context,
-            heartbeat: {
+          sendCheckHeartbeat(
+            {
               type: "processing",
               name: check.name,
               uuid,
-            },
+            },{
             completedCheckNames,
           })
       );
@@ -242,13 +232,12 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
       });
       completedCheckNames.push(check.name);
 
-      sendCheckHeartbeat({
-        context,
-        heartbeat: {
+      sendCheckHeartbeat(
+        {
           type: checkSucceeded ? "success" : "failure",
           name: check.name,
           uuid,
-        },
+        },{
         completedCheckNames,
       });
     } catch (error) {
@@ -264,9 +253,8 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
       });
       completedCheckNames.push(check.name);
 
-      sendCheckHeartbeat({
-        context,
-        heartbeat: { type: "failure", name: check.name, uuid },
+      sendCheckHeartbeat(
+        { type: "failure", name: check.name, uuid },{
         completedCheckNames,
       });
     }
@@ -311,30 +299,26 @@ export async function runSingleCheckActivity(
     allActionLinks.push(...(payload.actionLinks ?? []));
   };
 
-  const heartbeat = async () => {
-    return Context.current().heartbeat({
-      type: "processing",
-      name: check.name,
-      uuid,
-    });
-  };
-
-  Context.current().heartbeat({ type: "start", name: check.name, uuid });
+  heartbeat({ type: "start", name: check.name, uuid });
 
   await check.check(
     check.name,
     logger,
     reportSuccess,
     reportFailure,
-    heartbeat
+    async () => heartbeat({
+        type: "processing",
+        name: check.name,
+        uuid,
+      })
   );
 
-  Context.current().heartbeat({
+  heartbeat({
     type: checkSucceeded ? "success" : "failure",
     name: check.name,
     uuid,
   });
-  Context.current().heartbeat({ type: "finish", name: check.name, uuid });
+  heartbeat({ type: "finish", name: check.name, uuid });
 
   logger.info("Manual check done");
 

--- a/front/temporal/production_checks/activities.ts
+++ b/front/temporal/production_checks/activities.ts
@@ -21,7 +21,7 @@ import type {
 } from "@app/types/production_checks";
 import { CheckHeartbeatDetailsSchema } from "@app/types/production_checks";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import {activityInfo, heartbeat} from "@temporalio/activity";
+import { activityInfo, heartbeat } from "@temporalio/activity";
 import { v4 as uuidv4 } from "uuid";
 
 export const REGISTERED_CHECKS: Check[] = [
@@ -97,11 +97,14 @@ function getCompletedCheckNamesFromHeartbeatDetails(
     : [];
 }
 
-function sendCheckHeartbeat(heartbeatData: CheckHeartbeat,{
-  completedCheckNames,
-}: {
-  completedCheckNames: string[];
-}) {
+function sendCheckHeartbeat(
+  heartbeatData: CheckHeartbeat,
+  {
+    completedCheckNames,
+  }: {
+    completedCheckNames: string[];
+  }
+) {
   heartbeat({
     ...heartbeatData,
     completedCheckNames: [...new Set(completedCheckNames)],
@@ -163,9 +166,10 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
         });
 
         completedCheckNames.push(check.name);
-        sendCheckHeartbeat({ type: "skip", name: check.name, uuid },{
-          completedCheckNames,
-        });
+        sendCheckHeartbeat(
+          { type: "skip", name: check.name, uuid },
+          {completedCheckNames}
+        );
 
         continue;
       }
@@ -193,9 +197,10 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
         allActionLinks.push(...(payload.actionLinks ?? []));
       };
 
-      sendCheckHeartbeat({ type: "start", name: check.name, uuid },{
-        completedCheckNames,
-      });
+      sendCheckHeartbeat(
+        { type: "start", name: check.name, uuid },
+        {completedCheckNames}
+      );
 
       await check.check(
         check.name,
@@ -204,13 +209,9 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
         reportFailure,
         async () =>
           sendCheckHeartbeat(
-            {
-              type: "processing",
-              name: check.name,
-              uuid,
-            },{
-            completedCheckNames,
-          })
+            { type: "processing",name: check.name, uuid },
+            {completedCheckNames}
+          )
       );
 
       logger.info("Check done");
@@ -237,9 +238,9 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
           type: checkSucceeded ? "success" : "failure",
           name: check.name,
           uuid,
-        },{
-        completedCheckNames,
-      });
+        },
+        {completedCheckNames}
+      );
     } catch (error) {
       logger.error({ error }, "Production check failed");
 
@@ -254,9 +255,9 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
       completedCheckNames.push(check.name);
 
       sendCheckHeartbeat(
-        { type: "failure", name: check.name, uuid },{
-        completedCheckNames,
-      });
+        { type: "failure", name: check.name, uuid },
+        {completedCheckNames}
+      );
     }
   }
   mainLogger.info({ all_check_uuid: allCheckUuid }, "Done running all checks");
@@ -306,7 +307,8 @@ export async function runSingleCheckActivity(
     logger,
     reportSuccess,
     reportFailure,
-    async () => heartbeat({
+    async () =>
+      heartbeat({
         type: "processing",
         name: check.name,
         uuid,

--- a/front/temporal/production_checks/activities.ts
+++ b/front/temporal/production_checks/activities.ts
@@ -11,11 +11,13 @@ import { checkPausedConnectors } from "@app/lib/production_checks/checks/check_p
 import { checkWebcrawlerSchedulerActiveWorkflow } from "@app/lib/production_checks/checks/check_webcrawler_scheduler_active_workflow";
 import { managedDataSourceGCGdriveCheck } from "@app/lib/production_checks/checks/managed_data_source_gdrive_gc";
 import mainLogger from "@app/logger/logger";
+import { CheckHeartbeatDetailsSchema } from "@app/types/production_checks";
 import type {
   ActionLink,
   Check,
   CheckActivityResult,
   CheckFailurePayload,
+  CheckHeartbeat,
   CheckSuccessPayload,
 } from "@app/types/production_checks";
 import { Context } from "@temporalio/activity";
@@ -83,10 +85,51 @@ export async function runAllChecksActivity(): Promise<CheckActivityResult[]> {
   return runAllChecks(REGISTERED_CHECKS);
 }
 
+function getCompletedCheckNamesFromHeartbeatDetails(
+  heartbeatDetails: unknown,
+): string[] {
+  const parsedHeartbeatDetails =
+    CheckHeartbeatDetailsSchema.safeParse(heartbeatDetails);
+
+  return parsedHeartbeatDetails.success
+    ? parsedHeartbeatDetails.data.completedCheckNames
+    : [];
+}
+
+function sendCheckHeartbeat({
+  context,
+  heartbeat,
+  completedCheckNames,
+}: {
+  context: Context;
+  heartbeat: CheckHeartbeat;
+  completedCheckNames: string[];
+}) {
+  context.heartbeat({
+    ...heartbeat,
+    completedCheckNames: [...new Set(completedCheckNames)],
+  });
+}
+
 async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
   const allCheckUuid = uuidv4();
+  const context = Context.current();
+  const completedCheckNames = getCompletedCheckNamesFromHeartbeatDetails(
+    context.info.heartbeatDetails,
+  );
+  const currentHour = new Date().getHours();
   const results: CheckActivityResult[] = [];
-  mainLogger.info({ all_check_uuid: allCheckUuid }, "Running all checks");
+  const previouslyCompletedCheckNames = new Set(completedCheckNames);
+
+  mainLogger.info(
+    {
+      all_check_uuid: allCheckUuid,
+      resumingFrom:
+        completedCheckNames.length > 0 ? completedCheckNames.length : undefined,
+      currentHour,
+    },
+    "Running all checks",
+  );
 
   for (const check of checks) {
     const uuid = uuidv4();

--- a/front/temporal/production_checks/activities.ts
+++ b/front/temporal/production_checks/activities.ts
@@ -86,48 +86,48 @@ export async function runAllChecksActivity(): Promise<CheckActivityResult[]> {
   return runAllChecks(REGISTERED_CHECKS);
 }
 
-function getCompletedCheckNamesFromHeartbeatDetails(
-  heartbeatDetails: unknown
-): string[] {
+function getResultsFromHeartbeatDetails(
+  heartbeatDetails: unknown,
+): CheckActivityResult[] {
   const parsedHeartbeatDetails =
     CheckHeartbeatDetailsSchema.safeParse(heartbeatDetails);
 
   return parsedHeartbeatDetails.success
-    ? parsedHeartbeatDetails.data.completedCheckNames
+    ? parsedHeartbeatDetails.data.results
     : [];
 }
 
 function sendCheckHeartbeat(
   heartbeatData: CheckHeartbeat,
   {
-    completedCheckNames,
+    results,
   }: {
-    completedCheckNames: string[];
-  }
+    results: CheckActivityResult[];
+  },
 ) {
   heartbeat({
     ...heartbeatData,
-    completedCheckNames: [...new Set(completedCheckNames)],
+    results: [...results],
   });
 }
 
 async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
   const allCheckUuid = uuidv4();
-  const completedCheckNames = getCompletedCheckNamesFromHeartbeatDetails(
-    activityInfo().heartbeatDetails
+  const results = getResultsFromHeartbeatDetails(
+    activityInfo().heartbeatDetails,
   );
   const currentHour = new Date().getHours();
-  const results: CheckActivityResult[] = [];
-  const previouslyCompletedCheckNames = new Set(completedCheckNames);
+  const previouslyCompletedCheckNames = new Set(
+    results.map((result) => result.checkName),
+  );
 
   mainLogger.info(
     {
       all_check_uuid: allCheckUuid,
-      resumingFrom:
-        completedCheckNames.length > 0 ? completedCheckNames.length : undefined,
+      resumingFrom: results.length > 0 ? results.length : undefined,
       currentHour,
     },
-    "Running all checks"
+    "Running all checks",
   );
 
   for (const check of checks) {
@@ -137,7 +137,7 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
           all_check_uuid: allCheckUuid,
           checkName: check.name,
         },
-        "Check already completed in previous attempt, skipping"
+        "Check already completed in previous attempt, skipping",
       );
       continue;
     }
@@ -165,10 +165,9 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
           actionLinks: [],
         });
 
-        completedCheckNames.push(check.name);
         sendCheckHeartbeat(
           { type: "skip", name: check.name, uuid },
-          { completedCheckNames }
+          { results },
         );
 
         continue;
@@ -189,7 +188,7 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
       const reportFailure = (payload: CheckFailurePayload, message: string) => {
         logger.error(
           { payload, errorMessage: message },
-          "Production check failed"
+          "Production check failed",
         );
         checkSucceeded = false;
         allFailurePayloads.push({ ...payload, errorMessage: message });
@@ -199,7 +198,7 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
 
       sendCheckHeartbeat(
         { type: "start", name: check.name, uuid },
-        { completedCheckNames }
+        { results },
       );
 
       await check.check(
@@ -210,13 +209,13 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
         async () =>
           sendCheckHeartbeat(
             { type: "processing", name: check.name, uuid },
-            { completedCheckNames }
-          )
+            { results },
+          ),
       );
 
       logger.info("Check done");
 
-      results.push({
+      const result: CheckActivityResult = {
         checkName: check.name,
         status: checkSucceeded ? "success" : "failure",
         timestamp: new Date().toISOString(),
@@ -230,8 +229,8 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
             ? [...new Set(errorMessages)].join("; ")
             : null,
         actionLinks: allActionLinks,
-      });
-      completedCheckNames.push(check.name);
+      };
+      results.push(result);
 
       sendCheckHeartbeat(
         {
@@ -239,7 +238,7 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
           name: check.name,
           uuid,
         },
-        { completedCheckNames }
+        { results },
       );
     } catch (error) {
       logger.error({ error }, "Production check failed");
@@ -252,20 +251,20 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
         errorMessage: normalizeError(error).message,
         actionLinks: [],
       });
-      completedCheckNames.push(check.name);
 
       sendCheckHeartbeat(
         { type: "failure", name: check.name, uuid },
-        { completedCheckNames }
+        { results },
       );
     }
   }
   mainLogger.info({ all_check_uuid: allCheckUuid }, "Done running all checks");
+
   return results;
 }
 
 export async function runSingleCheckActivity(
-  checkName: string
+  checkName: string,
 ): Promise<CheckActivityResult> {
   const check = REGISTERED_CHECKS.find((c) => c.name === checkName);
   if (!check) {
@@ -312,7 +311,7 @@ export async function runSingleCheckActivity(
         type: "processing",
         name: check.name,
         uuid,
-      })
+      }),
   );
 
   heartbeat({

--- a/front/temporal/production_checks/activities.ts
+++ b/front/temporal/production_checks/activities.ts
@@ -11,7 +11,6 @@ import { checkPausedConnectors } from "@app/lib/production_checks/checks/check_p
 import { checkWebcrawlerSchedulerActiveWorkflow } from "@app/lib/production_checks/checks/check_webcrawler_scheduler_active_workflow";
 import { managedDataSourceGCGdriveCheck } from "@app/lib/production_checks/checks/managed_data_source_gdrive_gc";
 import mainLogger from "@app/logger/logger";
-import { CheckHeartbeatDetailsSchema } from "@app/types/production_checks";
 import type {
   ActionLink,
   Check,
@@ -20,9 +19,10 @@ import type {
   CheckHeartbeat,
   CheckSuccessPayload,
 } from "@app/types/production_checks";
+import { CheckHeartbeatDetailsSchema } from "@app/types/production_checks";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { Context } from "@temporalio/activity";
 import { v4 as uuidv4 } from "uuid";
-import {normalizeError} from "@app/types/shared/utils/error_utils";
 
 export const REGISTERED_CHECKS: Check[] = [
   {
@@ -87,7 +87,7 @@ export async function runAllChecksActivity(): Promise<CheckActivityResult[]> {
 }
 
 function getCompletedCheckNamesFromHeartbeatDetails(
-  heartbeatDetails: unknown,
+  heartbeatDetails: unknown
 ): string[] {
   const parsedHeartbeatDetails =
     CheckHeartbeatDetailsSchema.safeParse(heartbeatDetails);
@@ -116,7 +116,7 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
   const allCheckUuid = uuidv4();
   const context = Context.current();
   const completedCheckNames = getCompletedCheckNamesFromHeartbeatDetails(
-    context.info.heartbeatDetails,
+    context.info.heartbeatDetails
   );
   const currentHour = new Date().getHours();
   const results: CheckActivityResult[] = [];
@@ -129,7 +129,7 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
         completedCheckNames.length > 0 ? completedCheckNames.length : undefined,
       currentHour,
     },
-    "Running all checks",
+    "Running all checks"
   );
 
   for (const check of checks) {
@@ -137,9 +137,9 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
       mainLogger.info(
         {
           all_check_uuid: allCheckUuid,
-          checkName: check.name
+          checkName: check.name,
         },
-        "Check already completed in previous attempt, skipping",
+        "Check already completed in previous attempt, skipping"
       );
       continue;
     }
@@ -189,13 +189,10 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
         logger.info({ payload }, "Check succeeded");
         lastSuccessPayload = payload;
       };
-      const reportFailure = (
-        payload: CheckFailurePayload,
-        message: string,
-      ) => {
+      const reportFailure = (payload: CheckFailurePayload, message: string) => {
         logger.error(
           { payload, errorMessage: message },
-          "Production check failed",
+          "Production check failed"
         );
         checkSucceeded = false;
         allFailurePayloads.push({ ...payload, errorMessage: message });
@@ -214,7 +211,8 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
         logger,
         reportSuccess,
         reportFailure,
-        async () => sendCheckHeartbeat({
+        async () =>
+          sendCheckHeartbeat({
             context,
             heartbeat: {
               type: "processing",
@@ -253,7 +251,6 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
         },
         completedCheckNames,
       });
-
     } catch (error) {
       logger.error({ error }, "Production check failed");
 
@@ -279,7 +276,7 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
 }
 
 export async function runSingleCheckActivity(
-  checkName: string,
+  checkName: string
 ): Promise<CheckActivityResult> {
   const check = REGISTERED_CHECKS.find((c) => c.name === checkName);
   if (!check) {
@@ -329,7 +326,7 @@ export async function runSingleCheckActivity(
     logger,
     reportSuccess,
     reportFailure,
-    heartbeat,
+    heartbeat
   );
 
   Context.current().heartbeat({

--- a/front/temporal/production_checks/activities.ts
+++ b/front/temporal/production_checks/activities.ts
@@ -138,14 +138,13 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
       checkName: check.name,
       uuid,
     });
+
     try {
-      const currentHour = new Date().getHours();
       if (currentHour % check.everyHour !== 0) {
         logger.info("Check skipped", {
           currentHour,
           everyHour: check.everyHour,
         });
-        Context.current().heartbeat({ type: "skip", name: check.name, uuid });
 
         results.push({
           checkName: check.name,
@@ -155,8 +154,16 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
           errorMessage: null,
           actionLinks: [],
         });
+
+        completedCheckNames.push(check.name);
+        sendCheckHeartbeat({
+          context,
+          heartbeat: { type: "skip", name: check.name, uuid },
+          completedCheckNames,
+        });
       } else {
         logger.info("Check starting");
+
         let checkSucceeded = true;
         let lastSuccessPayload: CheckSuccessPayload | undefined;
         const errorMessages: string[] = [];
@@ -169,39 +176,43 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
         };
         const reportFailure = (
           payload: CheckFailurePayload,
-          message: string
+          message: string,
         ) => {
           logger.error(
             { payload, errorMessage: message },
-            "Production check failed"
+            "Production check failed",
           );
           checkSucceeded = false;
           allFailurePayloads.push({ ...payload, errorMessage: message });
           errorMessages.push(message);
           allActionLinks.push(...(payload.actionLinks ?? []));
         };
+
         const heartbeat = async () => {
-          return Context.current().heartbeat({
-            type: "processing",
-            name: check.name,
-            uuid,
+          return sendCheckHeartbeat({
+            context,
+            heartbeat: {
+              type: "processing",
+              name: check.name,
+              uuid,
+            },
+            completedCheckNames,
           });
         };
-        Context.current().heartbeat({ type: "start", name: check.name, uuid });
+
+        sendCheckHeartbeat({
+          context,
+          heartbeat: { type: "start", name: check.name, uuid },
+          completedCheckNames,
+        });
+
         await check.check(
           check.name,
           logger,
           reportSuccess,
           reportFailure,
-          heartbeat
+          heartbeat,
         );
-
-        Context.current().heartbeat({
-          type: checkSucceeded ? "success" : "failure",
-          name: check.name,
-          uuid,
-        });
-        Context.current().heartbeat({ type: "finish", name: check.name, uuid });
 
         results.push({
           checkName: check.name,
@@ -219,6 +230,17 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
           actionLinks: allActionLinks,
         });
 
+        completedCheckNames.push(check.name);
+        sendCheckHeartbeat({
+          context,
+          heartbeat: {
+            type: checkSucceeded ? "success" : "failure",
+            name: check.name,
+            uuid,
+          },
+          completedCheckNames,
+        });
+
         logger.info("Check done");
       }
     } catch (e) {
@@ -231,6 +253,13 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
         errorMessage: e instanceof Error ? e.message : "Unknown error",
         actionLinks: [],
       });
+
+      completedCheckNames.push(check.name);
+      sendCheckHeartbeat({
+        context,
+        heartbeat: { type: "failure", name: check.name, uuid },
+        completedCheckNames,
+      });
     }
   }
   mainLogger.info({ all_check_uuid: allCheckUuid }, "Done running all checks");
@@ -238,7 +267,7 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
 }
 
 export async function runSingleCheckActivity(
-  checkName: string
+  checkName: string,
 ): Promise<CheckActivityResult> {
   const check = REGISTERED_CHECKS.find((c) => c.name === checkName);
   if (!check) {
@@ -288,7 +317,7 @@ export async function runSingleCheckActivity(
     logger,
     reportSuccess,
     reportFailure,
-    heartbeat
+    heartbeat,
   );
 
   Context.current().heartbeat({

--- a/front/temporal/production_checks/activities.ts
+++ b/front/temporal/production_checks/activities.ts
@@ -168,7 +168,7 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
         completedCheckNames.push(check.name);
         sendCheckHeartbeat(
           { type: "skip", name: check.name, uuid },
-          {completedCheckNames}
+          { completedCheckNames }
         );
 
         continue;
@@ -199,7 +199,7 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
 
       sendCheckHeartbeat(
         { type: "start", name: check.name, uuid },
-        {completedCheckNames}
+        { completedCheckNames }
       );
 
       await check.check(
@@ -209,8 +209,8 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
         reportFailure,
         async () =>
           sendCheckHeartbeat(
-            { type: "processing",name: check.name, uuid },
-            {completedCheckNames}
+            { type: "processing", name: check.name, uuid },
+            { completedCheckNames }
           )
       );
 
@@ -239,7 +239,7 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
           name: check.name,
           uuid,
         },
-        {completedCheckNames}
+        { completedCheckNames }
       );
     } catch (error) {
       logger.error({ error }, "Production check failed");
@@ -256,7 +256,7 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
 
       sendCheckHeartbeat(
         { type: "failure", name: check.name, uuid },
-        {completedCheckNames}
+        { completedCheckNames }
       );
     }
   }

--- a/front/temporal/production_checks/activities.ts
+++ b/front/temporal/production_checks/activities.ts
@@ -87,7 +87,7 @@ export async function runAllChecksActivity(): Promise<CheckActivityResult[]> {
 }
 
 function getResultsFromHeartbeatDetails(
-  heartbeatDetails: unknown,
+  heartbeatDetails: unknown
 ): CheckActivityResult[] {
   const parsedHeartbeatDetails =
     CheckHeartbeatDetailsSchema.safeParse(heartbeatDetails);
@@ -103,7 +103,7 @@ function sendCheckHeartbeat(
     results,
   }: {
     results: CheckActivityResult[];
-  },
+  }
 ) {
   heartbeat({
     ...heartbeatData,
@@ -114,11 +114,11 @@ function sendCheckHeartbeat(
 async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
   const allCheckUuid = uuidv4();
   const results = getResultsFromHeartbeatDetails(
-    activityInfo().heartbeatDetails,
+    activityInfo().heartbeatDetails
   );
   const currentHour = new Date().getHours();
   const previouslyCompletedCheckNames = new Set(
-    results.map((result) => result.checkName),
+    results.map((result) => result.checkName)
   );
 
   mainLogger.info(
@@ -127,7 +127,7 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
       resumingFrom: results.length > 0 ? results.length : undefined,
       currentHour,
     },
-    "Running all checks",
+    "Running all checks"
   );
 
   for (const check of checks) {
@@ -137,7 +137,7 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
           all_check_uuid: allCheckUuid,
           checkName: check.name,
         },
-        "Check already completed in previous attempt, skipping",
+        "Check already completed in previous attempt, skipping"
       );
       continue;
     }
@@ -167,7 +167,7 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
 
         sendCheckHeartbeat(
           { type: "skip", name: check.name, uuid },
-          { results },
+          { results }
         );
 
         continue;
@@ -188,7 +188,7 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
       const reportFailure = (payload: CheckFailurePayload, message: string) => {
         logger.error(
           { payload, errorMessage: message },
-          "Production check failed",
+          "Production check failed"
         );
         checkSucceeded = false;
         allFailurePayloads.push({ ...payload, errorMessage: message });
@@ -198,7 +198,7 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
 
       sendCheckHeartbeat(
         { type: "start", name: check.name, uuid },
-        { results },
+        { results }
       );
 
       await check.check(
@@ -209,8 +209,8 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
         async () =>
           sendCheckHeartbeat(
             { type: "processing", name: check.name, uuid },
-            { results },
-          ),
+            { results }
+          )
       );
 
       logger.info("Check done");
@@ -238,7 +238,7 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
           name: check.name,
           uuid,
         },
-        { results },
+        { results }
       );
     } catch (error) {
       logger.error({ error }, "Production check failed");
@@ -254,7 +254,7 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
 
       sendCheckHeartbeat(
         { type: "failure", name: check.name, uuid },
-        { results },
+        { results }
       );
     }
   }
@@ -264,7 +264,7 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
 }
 
 export async function runSingleCheckActivity(
-  checkName: string,
+  checkName: string
 ): Promise<CheckActivityResult> {
   const check = REGISTERED_CHECKS.find((c) => c.name === checkName);
   if (!check) {
@@ -311,7 +311,7 @@ export async function runSingleCheckActivity(
         type: "processing",
         name: check.name,
         uuid,
-      }),
+      })
   );
 
   heartbeat({

--- a/front/types/production_checks.ts
+++ b/front/types/production_checks.ts
@@ -1,4 +1,5 @@
 import type pino from "pino";
+import { z } from "zod";
 
 // Action links for check results
 export interface ActionLink {
@@ -20,7 +21,7 @@ export type CheckFunction = (
   logger: pino.Logger,
   reportSuccess: (payload?: CheckSuccessPayload) => void,
   reportFailure: (payload: CheckFailurePayload, message: string) => void,
-  heartbeat: () => void
+  heartbeat: () => void,
 ) => Promise<void>;
 
 export type Check = {
@@ -29,20 +30,16 @@ export type Check = {
   everyHour: number;
 };
 
-// Heartbeat types for Temporal activity
-export type CheckHeartbeatType =
-  | "start"
-  | "processing"
-  | "skip"
-  | "finish"
-  | "success"
-  | "failure";
+export const CheckHeartbeatDetailsSchema = z.object({
+  type: z.enum(["start", "processing", "skip", "success", "failure"]),
+  name: z.string(),
+  uuid: z.string(),
+  completedCheckNames: z.array(z.string()),
+});
 
-export interface CheckHeartbeat {
-  type: CheckHeartbeatType;
-  name: string;
-  uuid: string;
-}
+export type CheckHeartbeatDetails = z.infer<typeof CheckHeartbeatDetailsSchema>;
+
+export type CheckHeartbeat = Omit<CheckHeartbeatDetails, "completedCheckNames">;
 
 // Result types for API responses
 export type CheckResultStatus = "success" | "failure" | "skipped" | "running";

--- a/front/types/production_checks.ts
+++ b/front/types/production_checks.ts
@@ -23,7 +23,7 @@ export type CheckFunction = (
   logger: pino.Logger,
   reportSuccess: (payload?: CheckSuccessPayload) => void,
   reportFailure: (payload: CheckFailurePayload, message: string) => void,
-  heartbeat: () => void,
+  heartbeat: () => void
 ) => Promise<void>;
 
 export type Check = {

--- a/front/types/production_checks.ts
+++ b/front/types/production_checks.ts
@@ -2,10 +2,12 @@ import type pino from "pino";
 import { z } from "zod";
 
 // Action links for check results
-export interface ActionLink {
-  label: string;
-  url: string;
-}
+const ActionLinkSchema = z.object({
+  label: z.string(),
+  url: z.string(),
+});
+
+export type ActionLink = z.infer<typeof ActionLinkSchema>;
 
 // Payload types for check functions
 export interface CheckFailurePayload {
@@ -21,7 +23,7 @@ export type CheckFunction = (
   logger: pino.Logger,
   reportSuccess: (payload?: CheckSuccessPayload) => void,
   reportFailure: (payload: CheckFailurePayload, message: string) => void,
-  heartbeat: () => void
+  heartbeat: () => void,
 ) => Promise<void>;
 
 export type Check = {
@@ -30,16 +32,33 @@ export type Check = {
   everyHour: number;
 };
 
+const CheckActivityResultStatusSchema = z.enum([
+  "success",
+  "failure",
+  "skipped",
+]);
+
+export const CheckActivityResultSchema = z.object({
+  checkName: z.string(),
+  status: CheckActivityResultStatusSchema,
+  timestamp: z.string(),
+  payload: z
+    .union([z.record(z.unknown()), z.array(z.record(z.unknown()))])
+    .nullable(),
+  errorMessage: z.string().nullable(),
+  actionLinks: z.array(ActionLinkSchema),
+});
+
 export const CheckHeartbeatDetailsSchema = z.object({
   type: z.enum(["start", "processing", "skip", "success", "failure"]),
   name: z.string(),
   uuid: z.string(),
-  completedCheckNames: z.array(z.string()),
+  results: z.array(CheckActivityResultSchema),
 });
 
 export type CheckHeartbeatDetails = z.infer<typeof CheckHeartbeatDetailsSchema>;
 
-export type CheckHeartbeat = Omit<CheckHeartbeatDetails, "completedCheckNames">;
+export type CheckHeartbeat = Omit<CheckHeartbeatDetails, "results">;
 
 // Result types for API responses
 export type CheckResultStatus = "success" | "failure" | "skipped" | "running";
@@ -57,20 +76,7 @@ export interface CheckResult {
   actionLinks: ActionLink[];
 }
 
-export type CheckActivityResultStatus = "success" | "failure" | "skipped";
-
-export interface CheckActivityResult {
-  checkName: string;
-  status: CheckActivityResultStatus;
-  timestamp: string;
-  payload:
-    | CheckSuccessPayload
-    | CheckFailurePayload
-    | CheckFailurePayload[]
-    | null;
-  errorMessage: string | null;
-  actionLinks: ActionLink[];
-}
+export type CheckActivityResult = z.infer<typeof CheckActivityResultSchema>;
 
 export type CheckSummaryStatus = "ok" | "alert" | "no-data";
 

--- a/front/types/production_checks.ts
+++ b/front/types/production_checks.ts
@@ -21,7 +21,7 @@ export type CheckFunction = (
   logger: pino.Logger,
   reportSuccess: (payload?: CheckSuccessPayload) => void,
   reportFailure: (payload: CheckFailurePayload, message: string) => void,
-  heartbeat: () => void,
+  heartbeat: () => void
 ) => Promise<void>;
 
 export type Check = {


### PR DESCRIPTION
## Description

We have a monitor raising from time to time indicating that the production checks did not complete in the last 90 minutes. After further inspection, the checks restarting from scratch on deploys contributes largely to that.

This PR is not completely crucial per se; it's more of an opportunity to introduce this pattern in the codebase on a low blast radius workflow.

- Prevent scheduled production checks from restarting from scratch after a worker restart or deploy.
- Production-check heartbeats now include the names of completed checks, and retries read those heartbeat details to skip checks that already reached a terminal state.
- Keep heartbeat details small: only `type`, `name`, `uuid`, and `completedCheckNames` are stored.

## Tests

- Tested locally.

## Risk

- Low. Affects only the scheduled production-check activity retry path.

## Deploy Plan

- Deploy front.
