### PR TITLE
[front] refactor: use Discover Knowledge in Dust global agent

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -9,10 +9,6 @@ import {
   AGENT_ROUTER_SERVER_NAME,
   SUGGEST_AGENTS_TOOL_NAME,
 } from "@app/lib/api/actions/servers/agent_router/metadata";
-import {
-  getCompanyDataAction,
-  getCompanyDataWarehousesAction,
-} from "@app/lib/api/assistant/global_agents/configurations/dust/shared";
 import { globalAgentGuidelines } from "@app/lib/api/assistant/global_agents/guidelines";
 import type {
   MCPServerViewsForGlobalAgentsMap,
@@ -30,6 +26,10 @@ import {
   isProviderWhitelisted,
 } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
+import {
+  isIncludedInDefaultCompanyData,
+  isRemoteDatabase,
+} from "@app/lib/data_sources";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import {
   isDustCompanyPlan,
@@ -115,37 +115,6 @@ Only use the ${AGENT_ROUTER_SERVER_NAME}${TOOL_NAME_SEPARATOR}${SUGGEST_AGENTS_T
 </instructions>`,
 
   goDeepInstructions: `If a request is particularly complex (requires deep exploration of company data, multiple web searches, SQL queries, or 3+ steps of tool use), or if the user explicitly asks for a "deep dive", "deep research", or "comprehensive analysis", enable the "Go Deep" skill to delegate work across sub-agents for more thorough research.`,
-
-  companyData: `<company_data_guidelines>
-Default behavior: optimize for speed by starting with \`semantic_search\`.
-Provide \`nodeIds\` only when you already know the relevant folder(s) or document(s) to target;
-otherwise, search across all available content and refine your query before exploring the tree.
-
-Use tree-navigation tools when thoroughness is required:
-- Use \`list\` to enumerate direct children of a node (folders and documents). If no node is provided, list from data source roots.
-- Use \`find\` to locate nodes by title recursively from a given node (partial titles are OK). Helpful to narrow scope when search is too broad.
-- Use \`locate_in_tree\` to display the full path from a node up to its data source root when you need to understand or show where it sits.
-
-Search and reading:
-- Use \`semantic_search\` to retrieve relevant content quickly. Pass \`nodeIds\` to limit scope only when needed; otherwise search globally.
-- Use \`cat\` sparingly to extract short, relevant snippets you need to quote or verify facts. Prefer searching over reading large files end-to-end.
-
-<cat_tool_guidelines>
-ALWAYS provide a \`limit\` when using \`cat\`. The maximum \`limit\` is 10,000 characters. For long documents, read in chunks using \`offset\` and \`limit\`. Optionally use \`grep\` to narrow to relevant lines.
-</cat_tool_guidelines>
-</company_data_guidelines>`,
-
-  warehouses: `<data_warehouses_guidelines>
-You can use the Data Warehouses tools to:
-- explore what tables are available in the user's data warehouses
-- describe the tables structure
-- execute a SQL query against a set of tables
-
-In order to properly use the data warehouses, it is useful to also search through company data in case there is some documentation available about the tables, some additional semantic layer, or some code that may define how the tables are built in the first place.
-Tables are identified by ids in the format 'table-<dataSourceId>-<nodeId>'.
-The dataSourceId can typically be found by exploring the warehouse, each warehouse is identified by an id in the format 'warehouse-<dataSourceId>'.
-A dataSourceId typically starts with the prefix "dts_".
-</data_warehouses_guidelines>`,
 
   help: `<dust_platform_support_guidelines>
 Follow these guidelines when the user unambiguously asks support questions specifically about how to use Dust features, or needs help understanding Dust.
@@ -282,26 +251,48 @@ Toolsets remain valuable for **write operations** (posting a Slack message, crea
 
 function buildInstructions({
   hasDeepDive,
-  hasFilesystemTools,
-  hasDataWarehouses,
   hasAgentMemory,
 }: {
   hasDeepDive: boolean;
-  hasFilesystemTools: boolean;
-  hasDataWarehouses: boolean;
   hasAgentMemory: boolean;
 }): string {
   const parts: string[] = [
     INSTRUCTION_SECTIONS.primary,
     INSTRUCTION_SECTIONS.instructions,
     hasDeepDive && INSTRUCTION_SECTIONS.goDeepInstructions,
-    hasFilesystemTools && INSTRUCTION_SECTIONS.companyData,
-    hasDataWarehouses && INSTRUCTION_SECTIONS.warehouses,
     INSTRUCTION_SECTIONS.help,
     hasAgentMemory && INSTRUCTION_SECTIONS.memory,
   ].filter((part): part is string => typeof part === "string");
 
   return parts.join("\n\n");
+}
+
+function shouldEnableDiscoverKnowledge({
+  preFetchedDataSources,
+  mcpServerViews,
+}: {
+  preFetchedDataSources: PrefetchedDataSourcesType | null;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
+}): boolean {
+  if (!preFetchedDataSources) {
+    return false;
+  }
+
+  const hasCompanyData =
+    mcpServerViews.data_sources_file_system !== null &&
+    preFetchedDataSources.dataSourceViews.some(
+      (dsView) =>
+        dsView.isInGlobalSpace &&
+        isIncludedInDefaultCompanyData(dsView.dataSource)
+    );
+
+  const hasDataWarehouses =
+    mcpServerViews.data_warehouses !== null &&
+    preFetchedDataSources.dataSourceViews.some(
+      (dsView) => dsView.isInGlobalSpace && isRemoteDatabase(dsView.dataSource)
+    );
+
+  return hasCompanyData || hasDataWarehouses;
 }
 
 function _getDustLikeGlobalAgent(
@@ -384,21 +375,13 @@ function _getDustLikeGlobalAgent(
     : dummyModelConfiguration;
 
   const hasAgentMemory = agentMemoryMCPServerView !== null;
-
-  const companyDataAction = getCompanyDataAction(
+  const hasDiscoverKnowledge = shouldEnableDiscoverKnowledge({
     preFetchedDataSources,
-    mcpServerViews
-  );
-
-  const dataWarehousesAction = getCompanyDataWarehousesAction(
-    preFetchedDataSources,
-    mcpServerViews
-  );
+    mcpServerViews,
+  });
 
   const instructions = buildInstructions({
     hasDeepDive,
-    hasFilesystemTools: companyDataAction !== null,
-    hasDataWarehouses: dataWarehousesAction !== null,
     hasAgentMemory,
   });
 
@@ -452,14 +435,6 @@ function _getDustLikeGlobalAgent(
   }
 
   const actions: MCPServerConfigurationType[] = [];
-
-  if (companyDataAction) {
-    actions.push(companyDataAction);
-  }
-
-  if (dataWarehousesAction) {
-    actions.push(dataWarehousesAction);
-  }
 
   actions.push(
     ..._getDefaultWebActionsForGlobalAgent({
@@ -528,6 +503,7 @@ function _getDustLikeGlobalAgent(
     status: "active",
     actions,
     skills: [
+      ...(hasDiscoverKnowledge ? ["discover_knowledge"] : []),
       "discover_skills",
       "frames",
       "go-deep",

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -26,10 +26,6 @@ import {
   isProviderWhitelisted,
 } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
-import {
-  isIncludedInDefaultCompanyData,
-  isRemoteDatabase,
-} from "@app/lib/data_sources";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import {
   isDustCompanyPlan,

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -267,34 +267,6 @@ function buildInstructions({
   return parts.join("\n\n");
 }
 
-function shouldEnableDiscoverKnowledge({
-  preFetchedDataSources,
-  mcpServerViews,
-}: {
-  preFetchedDataSources: PrefetchedDataSourcesType | null;
-  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
-}): boolean {
-  if (!preFetchedDataSources) {
-    return false;
-  }
-
-  const hasCompanyData =
-    mcpServerViews.data_sources_file_system !== null &&
-    preFetchedDataSources.dataSourceViews.some(
-      (dsView) =>
-        dsView.isInGlobalSpace &&
-        isIncludedInDefaultCompanyData(dsView.dataSource)
-    );
-
-  const hasDataWarehouses =
-    mcpServerViews.data_warehouses !== null &&
-    preFetchedDataSources.dataSourceViews.some(
-      (dsView) => dsView.isInGlobalSpace && isRemoteDatabase(dsView.dataSource)
-    );
-
-  return hasCompanyData || hasDataWarehouses;
-}
-
 function _getDustLikeGlobalAgent(
   auth: Authenticator,
   {
@@ -375,10 +347,6 @@ function _getDustLikeGlobalAgent(
     : dummyModelConfiguration;
 
   const hasAgentMemory = agentMemoryMCPServerView !== null;
-  const hasDiscoverKnowledge = shouldEnableDiscoverKnowledge({
-    preFetchedDataSources,
-    mcpServerViews,
-  });
 
   const instructions = buildInstructions({
     hasDeepDive,
@@ -503,7 +471,7 @@ function _getDustLikeGlobalAgent(
     status: "active",
     actions,
     skills: [
-      ...(hasDiscoverKnowledge ? ["discover_knowledge"] : []),
+      "discover_knowledge",
       "discover_skills",
       "frames",
       "go-deep",

--- a/front/lib/resources/skill/code_defined/discover_knowledge.ts
+++ b/front/lib/resources/skill/code_defined/discover_knowledge.ts
@@ -39,7 +39,7 @@ export const discoverKnowledgeSkill = {
     "Search documents, browse folder hierarchies, read file contents, and query data warehouse tables with SQL.",
   instructions: DISCOVER_KNOWLEDGE_INSTRUCTIONS,
   mcpServers: [
-    { name: "data_sources_file_system" },
+    { name: "data_sources_file_system", serverNameOverride: "company_data" },
     { name: "data_warehouses" },
   ],
   version: 1,

--- a/front/lib/resources/skill/code_defined/discover_knowledge.ts
+++ b/front/lib/resources/skill/code_defined/discover_knowledge.ts
@@ -3,23 +3,32 @@ import type { SystemSkillDefinition } from "@app/lib/resources/skill/code_define
 const DISCOVER_KNOWLEDGE_INSTRUCTIONS =
   "Default behavior: optimize for speed by starting with `semantic_search`.\n" +
   "Provide `nodeIds` only when you already know the relevant folder(s) or document(s) to target;\n" +
-  "otherwise, search across all available content and refine your query before exploring the tree.\n\n" +
+  "otherwise, search across all available content and refine your query before exploring the tree.\n" +
+  "\n" +
   "Data sources (documents and folders):\n" +
   "Use tree-navigation tools when thoroughness is required:\n" +
   "- Use `list` to enumerate direct children of a node (folders and documents). If no node is provided, list from data source roots.\n" +
   "- Use `find` to locate nodes by title recursively from a given node (partial titles are OK). Helpful to narrow scope when search is too broad.\n" +
-  "- Use `locate_in_tree` to display the full path from a node up to its data source root when you need to understand or show where it sits.\n\n" +
+  "- Use `locate_in_tree` to display the full path from a node up to its data source root when you need to understand or show where it sits.\n" +
+  "\n" +
   "Search and reading:\n" +
   "- Use `semantic_search` to retrieve relevant content quickly. Pass `nodeIds` to limit scope only when needed; otherwise search globally.\n" +
-  "- Use `cat` sparingly to extract short, relevant snippets you need to quote or verify facts. Prefer searching over reading large files end-to-end. ALWAYS provide a `limit` when using `cat`. The maximum `limit` is 10,000 characters. For long documents, read in chunks using `offset` and `limit`. Optionally use `grep` to narrow to relevant lines.\n\n" +
+  "- Use `cat` sparingly to extract short, relevant snippets you need to quote or verify facts. Prefer searching over reading large files end-to-end.\n" +
+  "\n" +
+  "Cat tool guidelines:\n" +
+  "Always provide a `limit` when using `cat`. The maximum `limit` is 10,000 characters. For long documents, read in chunks using `offset` and `limit`. Optionally use `grep` to narrow to relevant lines.\n" +
+  "\n" +
   "Data warehouses (tables and schemas):\n" +
   "- Content is organized hierarchically: warehouse → database → schema → tables. Schemas can be arbitrarily nested.\n" +
   "- Use `list` to enumerate direct contents of a warehouse, database, or schema. If no nodeId is provided, lists all available warehouses.\n" +
   "- Use `find` to search for tables, schemas, and databases by name. Supports partial matching (e.g., 'sales' finds 'sales_2024', 'monthly_sales_report').\n" +
   "- Use `describe_tables` to get detailed schema information (DBML definitions, SQL dialect guidelines, example rows) before writing queries. All tables must be from the same warehouse.\n" +
   "- Use `query` to execute SQL queries. You MUST call `describe_tables` first. The query must respect the SQL dialect and guidelines provided. All tables in a query must be from the same warehouse.\n" +
-  "- Tables are identified as 'table-<dataSourceId>-<nodeId>'. Warehouses are identified as 'warehouse-<dataSourceId>'. A dataSourceId typically starts with \"dts_\".\n" +
-  "- Search through company data for documentation about tables, semantic layers, or code that defines how tables are built.";
+  "\n" +
+  "In order to properly use the data warehouses, it is useful to also search through company data in case there is some documentation available about the tables, some additional semantic layer, or some code that may define how the tables are built in the first place.\n" +
+  "Tables are identified by ids in the format 'table-<dataSourceId>-<nodeId>'.\n" +
+  "Warehouses are identified as 'warehouse-<dataSourceId>'.\n" +
+  'A dataSourceId typically starts with the prefix "dts_".\n';
 
 export const discoverKnowledgeSkill = {
   sId: "discover_knowledge",


### PR DESCRIPTION
## Description

This PR removes the Dust global agent's knowledge instructions and direct company data / data warehouse actions, and relies on the existing `Discover Knowledge` system skill instead.

To keep prompt drift (and more importantly changes in tool names, which could break existing conversations) limited, `Discover Knowledge` now carries the Dust knowledge guidance directly and exposes the filesystem server with the legacy `company_data` tool prefix.

Toolsets / Discover Tools are intentionally left unchanged as it is much higher entropy (varies on the workspace) and its exact location in the prompt was optimized for caching.

Full prompt diff
```diff
--- before
+++ after
@@ -43,25 +43,6 @@

 If a request is particularly complex (requires deep exploration of company data, multiple web searches, SQL queries, or 3+ steps of tool use), or if the
user explicitly asks for a "deep dive", "deep research", or "comprehensive analysis", enable the "Go Deep" skill to delegate work across sub-agents for more
thorough research.

-<company_data_guidelines>
-Default behavior: optimize for speed by starting with `semantic_search`.
-Provide `nodeIds` only when you already know the relevant folder(s) or document(s) to target;
-otherwise, search across all available content and refine your query before exploring the tree.
-
-Use tree-navigation tools when thoroughness is required:
-- Use `list` to enumerate direct children of a node (folders and documents). If no node is provided, list from data source roots.
-- Use `find` to locate nodes by title recursively from a given node (partial titles are OK). Helpful to narrow scope when search is too broad.
-- Use `locate_in_tree` to display the full path from a node up to its data source root when you need to understand or show where it sits.
-
-Search and reading:
-- Use `semantic_search` to retrieve relevant content quickly. Pass `nodeIds` to limit scope only when needed; otherwise search globally.
-- Use `cat` sparingly to extract short, relevant snippets you need to quote or verify facts. Prefer searching over reading large files end-to-end.
-
-<cat_tool_guidelines>
-ALWAYS provide a `limit` when using `cat`. The maximum `limit` is 10,000 characters. For long documents, read in chunks using `offset` and `limit`.
Optionally use `grep` to narrow to relevant lines.
-</cat_tool_guidelines>
-</company_data_guidelines>
-
 <dust_platform_support_guidelines>
 Follow these guidelines when the user unambiguously asks support questions specifically about how to use Dust features, or needs help understanding Dust.
 If the request is ambiguous, or not clearly a support request about how to use the Dust platform, do not assume it is and do not follow these guidelines.
@@ -146,6 +127,25 @@
 ## AVAILABLE TOOL SERVERS
 Each server provides a list of tools made available to the agent.

+### SERVER NAME: web_search_&_browse
+Tools available on this server (names only):
+  - web_search_browse__websearch
+  - web_search_browse__webbrowser
+
+### SERVER NAME: toolsets
+Tools available on this server (names only):
+  - toolsets__list
+  - toolsets__enable
+
+### SERVER NAME: agent_router
+Tools available on this server (names only):
+  - agent_router__list_all_published_agents
+  - agent_router__suggest_agents_for_content
+
+### SERVER NAME: agent_memory
+Tools available on this server (names only):
+  - agent_memory__memory_not_available
+
 ### SERVER NAME: company_data
 Server instructions: This server contains tools to browse and search data in the space denoted by the server name, with a filesystem-like navigation.
 The space's contents are structured in nodes, similar to a filesystem. Nodes are identified by a unique ID called `nodeId`.
@@ -164,25 +164,13 @@
   - company_data__find
   - company_data__locate_in_tree

-### SERVER NAME: web_search_&_browse
+### SERVER NAME: data_warehouses
 Tools available on this server (names only):
-  - web_search_browse__websearch
-  - web_search_browse__webbrowser
-
-### SERVER NAME: toolsets
-Tools available on this server (names only):
-  - toolsets__list
-  - toolsets__enable
+  - data_warehouses__list
+  - data_warehouses__find
+  - data_warehouses__describe_tables
+  - data_warehouses__query

-### SERVER NAME: agent_router
-Tools available on this server (names only):
-  - agent_router__list_all_published_agents
-  - agent_router__suggest_agents_for_content
-
-### SERVER NAME: agent_memory
-Tools available on this server (names only):
-  - agent_memory__memory_not_available
-
 ### SERVER NAME: common_utilities
 Tools available on this server (names only):
   - common_utilities__generate_random_number
@@ -225,6 +213,37 @@

 ### ENABLED SKILLS
 The following skills are currently enabled:
+<Discover Knowledge>
+Default behavior: optimize for speed by starting with `semantic_search`.
+Provide `nodeIds` only when you already know the relevant folder(s) or document(s) to target;
+otherwise, search across all available content and refine your query before exploring the tree.
+
+Data sources (documents and folders):
+Use tree-navigation tools when thoroughness is required:
+- Use `list` to enumerate direct children of a node (folders and documents). If no node is provided, list from data source roots.
+- Use `find` to locate nodes by title recursively from a given node (partial titles are OK). Helpful to narrow scope when search is too broad.
+- Use `locate_in_tree` to display the full path from a node up to its data source root when you need to understand or show where it sits.
+
+Search and reading:
+- Use `semantic_search` to retrieve relevant content quickly. Pass `nodeIds` to limit scope only when needed; otherwise search globally.
+- Use `cat` sparingly to extract short, relevant snippets you need to quote or verify facts. Prefer searching over reading large files end-to-end.
+
+Cat tool guidelines:
+Always provide a `limit` when using `cat`. The maximum `limit` is 10,000 characters. For long documents, read in chunks using `offset` and `limit`.
Optionally use `grep` to narrow to relevant lines.
+
+Data warehouses (tables and schemas):
+- Content is organized hierarchically: warehouse → database → schema → tables. Schemas can be arbitrarily nested.
+- Use `list` to enumerate direct contents of a warehouse, database, or schema. If no nodeId is provided, lists all available warehouses.
+- Use `find` to search for tables, schemas, and databases by name. Supports partial matching (e.g., 'sales' finds 'sales_2024', 'monthly_sales_report').
+- Use `describe_tables` to get detailed schema information (DBML definitions, SQL dialect guidelines, example rows) before writing queries. All tables must
be from the same warehouse.
+- Use `query` to execute SQL queries. You MUST call `describe_tables` first. The query must respect the SQL dialect and guidelines provided. All tables in a
query must be from the same warehouse.
+
+In order to properly use the data warehouses, it is useful to also search through company data in case there is some documentation available about the
tables, some additional semantic layer, or some code that may define how the tables are built in the first place.
+Tables are identified by ids in the format 'table-<dataSourceId>-<nodeId>'.
+Warehouses are identified as 'warehouse-<dataSourceId>'.
+A dataSourceId typically starts with the prefix "dts_".
+
+</Discover Knowledge>
 <Discover Skills>
 Some of the available skills come from the workspace rather than this agent's configuration. They can be enabled exactly like any other available skill.
 </Discover Skills>

```

## Tests

- Validated locally and compared before/after LLM traces.

## Risk

- Medium. Changes prompt slightly, while preserving tool names.

## Deploy Plan

- Deploy front.

