### PR TITLE
[LLM] fix Gemini 2.5 flash thinking config on Vertex AI

### DIFF
--- a/front/lib/api/llm/clients/google/types.ts
+++ b/front/lib/api/llm/clients/google/types.ts
@@ -105,13 +105,13 @@ export const GOOGLE_AI_STUDIO_MODEL_CONFIGS: Record<
   [GEMINI_2_5_FLASH_MODEL_ID]: {
     thinkingConfig: {
       ...PRE_GEMINI_3_THINKING_CONFIG_MAPPING,
-      none: { thinkingBudget: 0, includeThoughts: true },
+      none: { thinkingBudget: 0, includeThoughts: false },
     },
   },
   [GEMINI_2_5_FLASH_LITE_MODEL_ID]: {
     thinkingConfig: {
       ...PRE_GEMINI_3_THINKING_CONFIG_MAPPING,
-      none: { thinkingBudget: 0, includeThoughts: true },
+      none: { thinkingBudget: 0, includeThoughts: false },
     },
   },
   [GEMINI_2_5_PRO_MODEL_ID]: {


### PR DESCRIPTION
## Description

Vertex AI rejects `includeThoughts: true` when `thinkingBudget` is 0. Fix the `none` reasoning config for `gemini-2.5-flash` and `gemini-2.5-flash-lite`.

## Tests

Tested locally.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`