### PR TITLE
chore(ci): fix deploy workflow warnings

### DIFF
--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -157,10 +157,12 @@ runs:
         JSON_PAYLOAD=$(jq -c -n \
           --arg channel "${{ inputs.channel }}" \
           --arg ts "${{ inputs.thread_ts }}" \
+          --arg text "$HEADER_TEXT" \
           --argjson blocks "$BLOCKS" \
           '{
             channel: $channel,
             thread_ts: $ts,
+            text: $text,
             blocks: $blocks,
             method: "chat.postMessage"
           }')

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -231,7 +231,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.INFRA_DISPATCH_APP_ID }}
+          client-id: ${{ secrets.INFRA_DISPATCH_APP_ID }}
           private-key: ${{ secrets.INFRA_DISPATCH_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: dust-infra

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -166,7 +166,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.INFRA_DISPATCH_APP_ID }}
+          client-id: ${{ secrets.INFRA_DISPATCH_APP_ID }}
           private-key: ${{ secrets.INFRA_DISPATCH_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: dust-infra

--- a/.github/workflows/sandbox-bedrock-release.yml
+++ b/.github/workflows/sandbox-bedrock-release.yml
@@ -28,7 +28,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.SPARKLE_RELEASE_BOT_APP_ID }}
+          client-id: ${{ secrets.SPARKLE_RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.SPARKLE_RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Checkout


### PR DESCRIPTION
## Description

Fix two categories of warnings in CI workflows:

- **Slack `text` field**: `chat.postMessage` calls using only `blocks` were missing the required top-level `text` fallback (used by push notifications and screen readers). Added it to the `build_success` payload in `slack-notify/action.yml`.
- **`app-id` deprecation**: `actions/create-github-app-token` deprecated the `app-id` input in favour of `client-id`. Updated in `deploy.yml`, `revert.yml`, and `sandbox-bedrock-release.yml`.
