### PR TITLE
Create Hono() in non-strict mode to match Next behavior for trailing slash

### DIFF
--- a/front-api/app.ts
+++ b/front-api/app.ts
@@ -1,4 +1,4 @@
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
 import { cors } from "./middlewares/cors";
 import { requestLogger } from "./middlewares/request_logger";
@@ -36,7 +36,7 @@ import workspaceJoinApp from "./routes/w/[wId]/join";
 import workosApp from "./routes/workos";
 import { workspaceLookupApp } from "./routes/workspace-lookup";
 
-const apiApp = new Hono();
+const apiApp = createHono();
 apiApp.route("/healthz", healthzApp);
 apiApp.route("/app-status", appStatusApp);
 apiApp.route("/auth/login", loginApp);
@@ -78,7 +78,7 @@ apiApp.route("/v1/w/:wId", publicWorkspaceApp);
 // above.
 apiApp.route("/:preStopSecret", preStopApp);
 
-export const honoApp = new Hono();
+export const honoApp = createHono();
 honoApp.use("*", requestLogger);
 honoApp.use("*", cors);
 honoApp.route("/api", apiApp);

--- a/front-api/lib/hono.ts
+++ b/front-api/lib/hono.ts
@@ -1,0 +1,14 @@
+import type { Env } from "hono";
+import { Hono } from "hono";
+
+// `strict: false` makes Hono treat `/foo` and `/foo/` as the same route,
+// matching Next.js routing behavior (front). Hono is strict by default, which
+// would cause requests with trailing slashes to fall through to catch-all
+// 404s.
+const HONO_OPTIONS = {
+  strict: false,
+} as const;
+
+export function createHono<E extends Env = Env>(): Hono<E> {
+  return new Hono<E>(HONO_OPTIONS);
+}

--- a/front-api/middlewares/ctx.ts
+++ b/front-api/middlewares/ctx.ts
@@ -4,7 +4,7 @@ import type { DataSourceResource } from "@app/lib/resources/data_source_resource
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
 export type SessionCtx = {
   Variables: {
@@ -54,9 +54,9 @@ export type SkillCtx = WorkspaceAwareCtx & {
   };
 };
 
-export const unauthedApp = () => new Hono();
-export const sessionApp = () => new Hono<SessionCtx>();
-export const workspaceApp = () => new Hono<WorkspaceAwareCtx>();
-export const pokeApp = () => new Hono<PokeCtx>();
-export const publicApiApp = () => new Hono<PublicApiCtx>();
-export const skillApp = () => new Hono<SkillCtx>();
+export const unauthedApp = () => createHono();
+export const sessionApp = () => createHono<SessionCtx>();
+export const workspaceApp = () => createHono<WorkspaceAwareCtx>();
+export const pokeApp = () => createHono<PokeCtx>();
+export const publicApiApp = () => createHono<PublicApiCtx>();
+export const skillApp = () => createHono<SkillCtx>();

--- a/front-api/routes/[preStopSecret]/index.ts
+++ b/front-api/routes/[preStopSecret]/index.ts
@@ -1,8 +1,8 @@
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
 import prestop from "./prestop";
 
-const app = new Hono();
+const app = createHono();
 app.route("/prestop", prestop);
 
 export default app;

--- a/front-api/routes/[preStopSecret]/prestop.ts
+++ b/front-api/routes/[preStopSecret]/prestop.ts
@@ -1,8 +1,8 @@
 import { runPreStop } from "@app/lib/api/prestop";
 import logger from "@app/logger/logger";
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
-const app = new Hono();
+const app = createHono();
 
 app.post("/", async (ctx) => {
   const preStopSecret = ctx.req.param("preStopSecret");

--- a/front-api/routes/app-status.ts
+++ b/front-api/routes/app-status.ts
@@ -2,9 +2,9 @@ import {
   getDustStatusMemoized,
   getProviderStatusMemoized,
 } from "@app/lib/api/status";
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
-export const appStatusApp = new Hono();
+export const appStatusApp = createHono();
 
 appStatusApp.get("/", async (ctx) => {
   const [providersStatus, dustStatus] = await Promise.all([

--- a/front-api/routes/auth/login.ts
+++ b/front-api/routes/auth/login.ts
@@ -1,6 +1,6 @@
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
-export const loginApp = new Hono();
+export const loginApp = createHono();
 
 // Default Hono redirect is 302; Next's res.redirect() defaults to 307. Match.
 loginApp.get("/", (ctx) => ctx.redirect("/api/workos/login", 307));

--- a/front-api/routes/debug/index.ts
+++ b/front-api/routes/debug/index.ts
@@ -1,9 +1,9 @@
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
 import profiler from "./profiler";
 
 // Mounted at /api/debug.
-const app = new Hono();
+const app = createHono();
 
 app.route("/profiler", profiler);
 

--- a/front-api/routes/debug/profiler.ts
+++ b/front-api/routes/debug/profiler.ts
@@ -2,8 +2,8 @@ import config from "@app/lib/api/config";
 import { profileCPU, profileHeap } from "@app/lib/api/debug/profiler";
 import logger from "@app/logger/logger";
 import { isString } from "@app/types/shared/utils/general";
+import { createHono } from "@front-api/lib/hono";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
-import { Hono } from "hono";
 
 export interface GetProfilerResponse {
   cpu: string;
@@ -11,7 +11,7 @@ export interface GetProfilerResponse {
 }
 
 // Mounted at /api/debug/profiler.
-const app = new Hono();
+const app = createHono();
 
 app.get("/", async (ctx): HandlerResult<GetProfilerResponse> => {
   const secret = ctx.req.query("secret");

--- a/front-api/routes/doc.ts
+++ b/front-api/routes/doc.ts
@@ -1,8 +1,8 @@
 import logger from "@app/logger/logger";
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 import { createSwaggerSpec } from "next-swagger-doc";
 
-const app = new Hono();
+const app = createHono();
 
 // `next-swagger-doc` resolves `apiFolder` against `process.cwd()`. The
 // Hono server runs from `front-api/`, so we point at the sibling `front`

--- a/front-api/routes/email/index.ts
+++ b/front-api/routes/email/index.ts
@@ -1,10 +1,10 @@
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
 import validateAction from "./validate-action";
 import webhook from "./webhook";
 
 // Mounted at /api/email.
-const app = new Hono();
+const app = createHono();
 
 app.route("/validate-action", validateAction);
 app.route("/webhook", webhook);

--- a/front-api/routes/email/validate-action.ts
+++ b/front-api/routes/email/validate-action.ts
@@ -7,11 +7,11 @@ import { verifyValidationToken } from "@app/lib/api/email/validation_token";
 import { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { isString } from "@app/types/shared/utils/general";
+import { createHono } from "@front-api/lib/hono";
 import { apiError } from "@front-api/middlewares/utils";
-import { Hono } from "hono";
 
 // Mounted at /api/email/validate-action.
-const app = new Hono();
+const app = createHono();
 
 app.post("/", async (ctx) => {
   const body = await ctx.req.json().catch(() => ({}));

--- a/front-api/routes/email/webhook.ts
+++ b/front-api/routes/email/webhook.ts
@@ -30,8 +30,8 @@ import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { isDevelopment } from "@app/types/shared/env";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
+import { createHono } from "@front-api/lib/hono";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
-import { Hono } from "hono";
 
 export type PostResponseBody = {
   success: boolean;
@@ -50,7 +50,7 @@ function headersToNodeHeaders(webHeaders: Headers): EmailWebhookHeaders {
 }
 
 // Mounted at /api/email/webhook.
-const app = new Hono();
+const app = createHono();
 
 app.post("/", async (ctx): HandlerResult<PostResponseBody> => {
   const headers = headersToNodeHeaders(ctx.req.raw.headers);

--- a/front-api/routes/enrichment/company.ts
+++ b/front-api/routes/enrichment/company.ts
@@ -9,8 +9,8 @@ import { isPersonalEmailDomain } from "@app/lib/utils/personal_email_domains";
 import logger from "@app/logger/logger";
 import { sendUserOperationMessage } from "@app/types/shared/user_operation";
 import { isString } from "@app/types/shared/utils/general";
+import { createHono } from "@front-api/lib/hono";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-import { Hono } from "hono";
 
 interface EnrichmentResponse {
   success: boolean;
@@ -23,7 +23,7 @@ interface EnrichmentResponse {
 const GTM_LEADS_SLACK_CHANNEL_ID = "C0A1XKES0JY";
 
 // Mounted at /api/enrichment/company.
-const app = new Hono();
+const app = createHono();
 
 app.post("/", async (ctx): HandlerResult<EnrichmentResponse> => {
   const body = await ctx.req.json().catch(() => ({}));

--- a/front-api/routes/enrichment/index.ts
+++ b/front-api/routes/enrichment/index.ts
@@ -1,9 +1,9 @@
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
 import company from "./company";
 
 // Mounted at /api/enrichment.
-const app = new Hono();
+const app = createHono();
 
 app.route("/company", company);
 

--- a/front-api/routes/geo/index.ts
+++ b/front-api/routes/geo/index.ts
@@ -1,9 +1,9 @@
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
 import location from "./location";
 
 // Mounted under /api/geo.
-const app = new Hono();
+const app = createHono();
 
 app.route("/location", location);
 

--- a/front-api/routes/healthz.ts
+++ b/front-api/routes/healthz.ts
@@ -1,11 +1,11 @@
 import { getStatsDClient } from "@app/lib/utils/statsd";
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
 import ready from "./healthz/ready";
 import startup from "./healthz/startup";
 
 // Mounted at /api/healthz.
-export const healthzApp = new Hono();
+export const healthzApp = createHono();
 
 healthzApp.get("/", (ctx) => {
   const startMs = performance.now();

--- a/front-api/routes/healthz/ready.ts
+++ b/front-api/routes/healthz/ready.ts
@@ -1,7 +1,7 @@
 import { COMMIT_HASH } from "@app/lib/commit-hash";
 import { isInShutdown } from "@app/lib/shutdown_signal";
 import { getStatsDClient } from "@app/lib/utils/statsd";
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
 /**
  * Readiness probe endpoint.
@@ -15,7 +15,7 @@ import { Hono } from "hono";
  *
  * The startup probe (/api/healthz/startup) handles dependency checking at pod startup.
  */
-const app = new Hono();
+const app = createHono();
 
 app.get("/", (ctx) => {
   const startMs = performance.now();

--- a/front-api/routes/healthz/startup.ts
+++ b/front-api/routes/healthz/startup.ts
@@ -3,7 +3,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
 const DEPENDENCY_CHECK_TIMEOUT_MS = 2000;
 
@@ -49,7 +49,7 @@ async function checkDependency(
  * accepting traffic. It's called during pod startup only.
  *
  */
-const app = new Hono();
+const app = createHono();
 
 app.get("/", async (ctx) => {
   const startMs = performance.now();

--- a/front-api/routes/kill.ts
+++ b/front-api/routes/kill.ts
@@ -1,7 +1,7 @@
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
-export const killApp = new Hono();
+export const killApp = createHono();
 
 killApp.get("/", async (ctx) => {
   const killSwitches = await KillSwitchResource.listEnabledKillSwitches();

--- a/front-api/routes/lookup/[resource]/index.ts
+++ b/front-api/routes/lookup/[resource]/index.ts
@@ -8,10 +8,10 @@ import { getBearerToken } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import type { PendingInvitationOption } from "@app/types/membership_invitation";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { createHono } from "@front-api/lib/hono";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import { Hono } from "hono";
 import { z } from "zod";
 
 export type WorkspaceLookupResponse = {
@@ -81,7 +81,7 @@ const BodySchema = z.union([
   ShareTokenLookupSchema,
 ]);
 
-const app = new Hono();
+const app = createHono();
 
 app.post(
   "/",

--- a/front-api/routes/lookup/index.ts
+++ b/front-api/routes/lookup/index.ts
@@ -1,8 +1,8 @@
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
 import resource from "./[resource]";
 
-const app = new Hono();
+const app = createHono();
 app.route("/:resource", resource);
 
 export default app;

--- a/front-api/routes/metronome/index.ts
+++ b/front-api/routes/metronome/index.ts
@@ -1,9 +1,9 @@
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
 import webhook from "./webhook";
 
 // Mounted at /api/metronome.
-const app = new Hono();
+const app = createHono();
 
 app.route("/webhook", webhook);
 

--- a/front-api/routes/metronome/webhook.ts
+++ b/front-api/routes/metronome/webhook.ts
@@ -8,8 +8,8 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
 import { launchMetronomeEventsWorkflow } from "@app/temporal/metronome_events_queue/client";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { createHono } from "@front-api/lib/hono";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
-import { Hono } from "hono";
 import { z } from "zod";
 
 type ResponseBody = {
@@ -18,7 +18,7 @@ type ResponseBody = {
 };
 
 // Mounted at /api/metronome/webhook.
-const app = new Hono();
+const app = createHono();
 
 app.get(
   "/",

--- a/front-api/routes/novu/index.ts
+++ b/front-api/routes/novu/index.ts
@@ -4,8 +4,8 @@ import { conversationUnreadWorkflow } from "@app/lib/notifications/workflows/con
 import { projectAddedAsMemberWorkflow } from "@app/lib/notifications/workflows/project-added-as-member";
 import { providerCredentialsHealthUpdatedWorkflow } from "@app/lib/notifications/workflows/provider-credential-updated";
 import { skillSuggestionsReadyWorkflow } from "@app/lib/notifications/workflows/skill-suggestions-ready";
+import { createHono } from "@front-api/lib/hono";
 import { serve } from "@novu/framework/next";
-import { Hono } from "hono";
 
 // This endpoint exposes our code-based notification workflows to the Novu
 // platform. The Novu platform calls this endpoint to execute workflow steps.
@@ -31,7 +31,7 @@ const novu = serve({
   ],
 }) as unknown as Record<"GET" | "POST" | "OPTIONS", FetchHandler>;
 
-const app = new Hono();
+const app = createHono();
 
 app.get("/", (ctx) => novu.GET(ctx.req.raw, ctx));
 app.post("/", (ctx) => novu.POST(ctx.req.raw, ctx));

--- a/front-api/routes/oauth/[provider]/index.ts
+++ b/front-api/routes/oauth/[provider]/index.ts
@@ -1,8 +1,8 @@
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
 import finalize from "./finalize";
 
-const app = new Hono();
+const app = createHono();
 app.route("/finalize", finalize);
 
 export default app;

--- a/front-api/routes/oauth/index.ts
+++ b/front-api/routes/oauth/index.ts
@@ -1,8 +1,8 @@
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
 import provider from "./[provider]";
 
-const app = new Hono();
+const app = createHono();
 app.route("/:provider", provider);
 
 export default app;

--- a/front-api/routes/poke/plugins/[pluginId]/run.ts
+++ b/front-api/routes/poke/plugins/[pluginId]/run.ts
@@ -9,12 +9,12 @@ import {
   supportedResourceTypes,
 } from "@app/types/poke/plugins";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { createHono } from "@front-api/lib/hono";
 import type { PokeCtx } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { HttpBindings } from "@hono/node-server";
 import { IncomingForm } from "formidable";
-import { Hono } from "hono";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
@@ -33,7 +33,7 @@ export interface PokeRunPluginResponseBody {
 // We extend the poke context with `HttpBindings` so we can hand the raw Node
 // `IncomingMessage` (exposed by `@hono/node-server` on `ctx.env.incoming`) to
 // `formidable.parse(...)` — matching the Next handler.
-const app = new Hono<PokeCtx & { Bindings: HttpBindings }>();
+const app = createHono<PokeCtx & { Bindings: HttpBindings }>();
 
 app.post(
   "/",

--- a/front-api/routes/share/frame/[token].ts
+++ b/front-api/routes/share/frame/[token].ts
@@ -5,9 +5,9 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
 import { isInteractiveContentType } from "@app/types/files";
+import { createHono } from "@front-api/lib/hono";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
-import { Hono } from "hono";
 
 export interface GetShareFrameMetadataResponseBody {
   requiresEmailVerification: boolean;
@@ -18,7 +18,7 @@ export interface GetShareFrameMetadataResponseBody {
   workspaceName: string;
 }
 
-const app = new Hono();
+const app = createHono();
 
 app.get("/", async (ctx): HandlerResult<GetShareFrameMetadataResponseBody> => {
   const token = ctx.req.param("token");

--- a/front-api/routes/share/frame/index.ts
+++ b/front-api/routes/share/frame/index.ts
@@ -1,8 +1,8 @@
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
 import token from "./[token]";
 
-const app = new Hono();
+const app = createHono();
 app.route("/:token", token);
 
 export default app;

--- a/front-api/routes/share/index.ts
+++ b/front-api/routes/share/index.ts
@@ -1,8 +1,8 @@
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
 import frame from "./frame";
 
-const app = new Hono();
+const app = createHono();
 app.route("/frame", frame);
 
 export default app;

--- a/front-api/routes/stripe/index.ts
+++ b/front-api/routes/stripe/index.ts
@@ -1,10 +1,10 @@
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
 import portal from "./portal";
 import webhook from "./webhook";
 
 // Mounted at /api/stripe.
-const app = new Hono();
+const app = createHono();
 
 app.route("/portal", portal);
 app.route("/webhook", webhook);

--- a/front-api/routes/stripe/webhook.ts
+++ b/front-api/routes/stripe/webhook.ts
@@ -2,8 +2,8 @@ import apiConfig from "@app/lib/api/config";
 import { processStripeWebhookEvent } from "@app/lib/api/stripe/webhook_handler";
 import { getStripeClient } from "@app/lib/plans/stripe";
 import logger from "@app/logger/logger";
+import { createHono } from "@front-api/lib/hono";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
-import { Hono } from "hono";
 import type Stripe from "stripe";
 
 export type GetResponseBody = {
@@ -12,7 +12,7 @@ export type GetResponseBody = {
 };
 
 // Mounted at /api/stripe/webhook.
-const app = new Hono();
+const app = createHono();
 
 app.get(
   "/",

--- a/front-api/routes/t/index.ts
+++ b/front-api/routes/t/index.ts
@@ -1,9 +1,9 @@
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
 import pv from "./pv";
 
 // Mounted at /api/t.
-const app = new Hono();
+const app = createHono();
 
 app.route("/pv", pv);
 

--- a/front-api/routes/templates/[tId]/index.ts
+++ b/front-api/routes/templates/[tId]/index.ts
@@ -1,11 +1,11 @@
 import { TemplateResource } from "@app/lib/resources/template_resource";
+import { createHono } from "@front-api/lib/hono";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
-import { Hono } from "hono";
 
 export type FetchAgentTemplateResponse = ReturnType<TemplateResource["toJSON"]>;
 
 // Mounted at /api/templates/:tId.
-const app = new Hono();
+const app = createHono();
 
 app.get("/", async (ctx): HandlerResult<FetchAgentTemplateResponse> => {
   const templateId = ctx.req.param("tId");

--- a/front-api/routes/templates/index.ts
+++ b/front-api/routes/templates/index.ts
@@ -1,6 +1,6 @@
 import { TemplateResource } from "@app/lib/resources/template_resource";
+import { createHono } from "@front-api/lib/hono";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-import { Hono } from "hono";
 
 import template from "./[tId]";
 
@@ -13,7 +13,7 @@ export interface FetchAssistantTemplatesResponse {
 }
 
 // Mounted at /api/templates.
-const app = new Hono();
+const app = createHono();
 
 app.get("/", async (ctx): HandlerResult<FetchAssistantTemplatesResponse> => {
   const templates = await TemplateResource.listAll({

--- a/front-api/routes/user/metadata/index.ts
+++ b/front-api/routes/user/metadata/index.ts
@@ -1,9 +1,9 @@
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
 import key from "./[key]";
 
 // Mounted under /api/user/metadata.
-const app = new Hono();
+const app = createHono();
 
 app.route("/:key", key);
 

--- a/front-api/routes/v1/w/[wId]/files/[fileId].ts
+++ b/front-api/routes/v1/w/[wId]/files/[fileId].ts
@@ -15,12 +15,12 @@ import {
   isConversationFileUseCase,
   isPubliclySupportedUseCase,
 } from "@app/types/files";
+import { createHono } from "@front-api/lib/hono";
 import type { PublicApiCtx } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { HttpBindings } from "@hono/node-server";
 import type { Context } from "hono";
-import { Hono } from "hono";
 import { z } from "zod";
 
 const ParamsSchema = z.object({
@@ -67,7 +67,7 @@ function getSecureFileAction(
 // We extend the public API context with `HttpBindings` so we can reach the
 // underlying Node `IncomingMessage` via `ctx.env.incoming` and hand it to
 // `processAndStoreFile` for multipart parsing.
-const app = new Hono<PublicApiCtx & { Bindings: HttpBindings }>();
+const app = createHono<PublicApiCtx & { Bindings: HttpBindings }>();
 
 /**
  * @ignoreswagger

--- a/front-api/routes/v1/w/[wId]/skills/index.ts
+++ b/front-api/routes/v1/w/[wId]/skills/index.ts
@@ -6,13 +6,13 @@ import { MAX_ZIP_SIZE_BYTES } from "@app/lib/api/skills/detection/zip/detect_ski
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { createHono } from "@front-api/lib/hono";
 import type { PublicApiCtx } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { HttpBindings } from "@hono/node-server";
 import formidable from "formidable";
-import { Hono } from "hono";
 import { z } from "zod";
 
 export type GetPublicSkillsResponseBody = {
@@ -34,7 +34,7 @@ const GetSkillsQuerySchema = z.object({
 // We extend the public API context with `HttpBindings` so we can reach the
 // underlying Node `IncomingMessage` via `ctx.env.incoming` and hand it to
 // `formidable.parse(...)` for multipart parsing in the POST handler.
-const app = new Hono<PublicApiCtx & { Bindings: HttpBindings }>();
+const app = createHono<PublicApiCtx & { Bindings: HttpBindings }>();
 
 /**
  * @swagger

--- a/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts
@@ -11,10 +11,10 @@ import {
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import { isString } from "@app/types/shared/utils/general";
 import type { PostWebhookTriggerResponseType } from "@dust-tt/client";
+import { createHono } from "@front-api/lib/hono";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import { Hono } from "hono";
 import { z } from "zod";
 
 const ParamsSchema = z.object({
@@ -67,7 +67,7 @@ const WEBHOOK_REQUEST_MAX_SIZE_BYTES = 2 * 1024 * 1024;
 // Mounted at /api/v1/w/:wId/triggers/hooks/:webhookSourceId/:webhookSourceUrlSecret.
 // This route is mounted outside `publicApiAuth` because it uses its own
 // authentication scheme based on the URL secret.
-const app = new Hono();
+const app = createHono();
 
 app.post(
   "/",

--- a/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/index.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/index.ts
@@ -1,9 +1,9 @@
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
 import webhookSourceUrlSecret from "./[webhookSourceUrlSecret]";
 
 // Mounted at /api/v1/w/:wId/triggers/hooks/:webhookSourceId.
-const app = new Hono();
+const app = createHono();
 
 app.route("/:webhookSourceUrlSecret", webhookSourceUrlSecret);
 

--- a/front-api/routes/v1/w/[wId]/triggers/hooks/index.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/hooks/index.ts
@@ -1,9 +1,9 @@
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
 import webhookSourceId from "./[webhookSourceId]";
 
 // Mounted at /api/v1/w/:wId/triggers/hooks.
-const app = new Hono();
+const app = createHono();
 
 app.route("/:webhookSourceId", webhookSourceId);
 

--- a/front-api/routes/v1/w/[wId]/triggers/index.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/index.ts
@@ -1,4 +1,4 @@
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
 import hooks from "./hooks";
 
@@ -6,7 +6,7 @@ import hooks from "./hooks";
 // `publicWorkspaceApp` in `routes/v1/index.ts` so it does not inherit
 // `publicApiAuth` — the webhook endpoint uses its own URL secret-based
 // authentication.
-const app = new Hono();
+const app = createHono();
 
 app.route("/hooks", hooks);
 

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/raw_content_fragment/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/raw_content_fragment/index.ts
@@ -4,11 +4,11 @@ import { fileAttachmentLocation } from "@app/lib/resources/content_fragment_reso
 import { isContentFragmentType } from "@app/types/content_fragment";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
+import { createHono } from "@front-api/lib/hono";
 import type { WorkspaceAwareCtx } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import type { HttpBindings } from "@hono/node-server";
 import { IncomingForm } from "formidable";
-import { Hono } from "hono";
 
 const privateUploadGcs = getPrivateUploadBucket();
 
@@ -29,7 +29,7 @@ function isValidContentFormat(
 // POST consumes multipart via formidable on the raw Node `IncomingMessage`
 // exposed by `@hono/node-server` (`ctx.env.incoming`) — matching the Next
 // handler.
-const app = new Hono<WorkspaceAwareCtx & { Bindings: HttpBindings }>();
+const app = createHono<WorkspaceAwareCtx & { Bindings: HttpBindings }>();
 
 app.get("/", async (ctx) => {
   const auth = ctx.get("auth");

--- a/front-api/routes/w/[wId]/files/[fileId]/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.ts
@@ -14,11 +14,11 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { isConversationFileUseCase } from "@app/types/files";
+import { createHono } from "@front-api/lib/hono";
 import type { WorkspaceAwareCtx } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import type { HttpBindings } from "@hono/node-server";
 import type { Context } from "hono";
-import { Hono } from "hono";
 
 import editText from "./edit-text";
 import exportApp from "./export";
@@ -63,7 +63,7 @@ function getSecureFileAction(
 }
 
 // Mounted at /api/w/:wId/files/:fileId.
-const app = new Hono<WorkspaceAwareCtx & { Bindings: HttpBindings }>();
+const app = createHono<WorkspaceAwareCtx & { Bindings: HttpBindings }>();
 
 app.get("/", async (ctx) => {
   const auth = ctx.get("auth");

--- a/front-api/routes/w/[wId]/join.ts
+++ b/front-api/routes/w/[wId]/join.ts
@@ -7,8 +7,8 @@ import { getSignInUrl } from "@app/lib/signup";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { isString } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType } from "@app/types/user";
+import { createHono } from "@front-api/lib/hono";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
-import { Hono } from "hono";
 
 type OnboardingType =
   | "email_invite"
@@ -27,7 +27,7 @@ interface GetJoinErrorBody {
 }
 
 // Mounted at /api/w/:wId/join (no workspace auth — public endpoint).
-const app = new Hono();
+const app = createHono();
 
 app.get(
   "/",

--- a/front-api/routes/w/[wId]/services/transcribe/index.ts
+++ b/front-api/routes/w/[wId]/services/transcribe/index.ts
@@ -4,12 +4,12 @@ import { transcribeStream } from "@app/lib/utils/transcribe_service";
 import logger from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { createHono } from "@front-api/lib/hono";
 import type { WorkspaceAwareCtx } from "@front-api/middlewares/ctx";
 import { setSSEHeaders } from "@front-api/middlewares/streaming";
 import { apiError } from "@front-api/middlewares/utils";
 import type { HttpBindings } from "@hono/node-server";
 import formidable from "formidable";
-import { Hono } from "hono";
 import { stream } from "hono/streaming";
 
 export type PostTranscribeResponseBody = { text: string };
@@ -20,7 +20,7 @@ export type PostTranscribeResponseBody = { text: string };
 // underlying Node `IncomingMessage` via `ctx.env.incoming` and hand it to
 // `formidable.parse(...)` — matching the Next handler exactly, which also
 // streamed the multipart body through formidable from the raw request.
-const app = new Hono<WorkspaceAwareCtx & { Bindings: HttpBindings }>();
+const app = createHono<WorkspaceAwareCtx & { Bindings: HttpBindings }>();
 
 app.post("/", async (ctx) => {
   const auth = ctx.get("auth");

--- a/front-api/routes/w/[wId]/skills/detect/upload.ts
+++ b/front-api/routes/w/[wId]/skills/detect/upload.ts
@@ -3,18 +3,18 @@ import { MAX_ZIP_SIZE_BYTES } from "@app/lib/api/skills/detection/zip/detect_ski
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { DetectedSkillSummary } from "@app/lib/skill_detection";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { createHono } from "@front-api/lib/hono";
 import type { WorkspaceAwareCtx } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import type { HttpBindings } from "@hono/node-server";
 import formidable from "formidable";
-import { Hono } from "hono";
 
 // Mounted at /api/w/:wId/skills/detect/upload.
 //
 // We extend the workspace context with `HttpBindings` so we can hand the
 // underlying Node `IncomingMessage` (exposed by `@hono/node-server` on
 // `ctx.env.incoming`) to `formidable.parse(...)` — matching the Next handler.
-const app = new Hono<WorkspaceAwareCtx & { Bindings: HttpBindings }>();
+const app = createHono<WorkspaceAwareCtx & { Bindings: HttpBindings }>();
 
 app.post("/", async (ctx) => {
   const auth = ctx.get("auth");

--- a/front-api/routes/w/[wId]/skills/import/upload.ts
+++ b/front-api/routes/w/[wId]/skills/import/upload.ts
@@ -1,19 +1,19 @@
 import { importSkillsFromFiles } from "@app/lib/api/skills/detection/files/import_skills";
 import { MAX_ZIP_SIZE_BYTES } from "@app/lib/api/skills/detection/zip/detect_skills";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { createHono } from "@front-api/lib/hono";
 import type { WorkspaceAwareCtx } from "@front-api/middlewares/ctx";
 import { ensureIsBuilder } from "@front-api/middlewares/ensure_role";
 import { apiError } from "@front-api/middlewares/utils";
 import type { HttpBindings } from "@hono/node-server";
 import formidable from "formidable";
-import { Hono } from "hono";
 
 // Mounted at /api/w/:wId/skills/import/upload.
 //
 // We extend the workspace context with `HttpBindings` so we can hand the
 // underlying Node `IncomingMessage` (exposed by `@hono/node-server` on
 // `ctx.env.incoming`) to `formidable.parse(...)` — matching the Next handler.
-const app = new Hono<WorkspaceAwareCtx & { Bindings: HttpBindings }>();
+const app = createHono<WorkspaceAwareCtx & { Bindings: HttpBindings }>();
 
 app.post("/", ensureIsBuilder(), async (ctx) => {
   const auth = ctx.get("auth");

--- a/front-api/routes/workos/[action].ts
+++ b/front-api/routes/workos/[action].ts
@@ -33,10 +33,10 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
 import { validateRelativePath } from "@app/types/shared/utils/url_utils";
+import { createHono } from "@front-api/lib/hono";
 import { apiError } from "@front-api/middlewares/utils";
 import { OauthException } from "@workos-inc/node";
 import type { Context } from "hono";
-import { Hono } from "hono";
 import { getCookie } from "hono/cookie";
 import { sealData } from "iron-session";
 
@@ -62,7 +62,7 @@ function redirectTo(ctx: Context, sanitizedReturnTo: string) {
   return redirect(ctx, `${config.getAppUrl()}${sanitizedReturnTo}`);
 }
 
-const app = new Hono();
+const app = createHono();
 
 app.all("/", async (ctx) => {
   const action = ctx.req.param("action");

--- a/front-api/routes/workos/actions/[actionSecret].ts
+++ b/front-api/routes/workos/actions/[actionSecret].ts
@@ -8,6 +8,7 @@ import {
 import { isBlacklistedEmailDomain } from "@app/lib/utils/blacklisted_email_domains";
 import logger from "@app/logger/logger";
 import { isString } from "@app/types/shared/utils/general";
+import { createHono } from "@front-api/lib/hono";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import type {
@@ -15,7 +16,6 @@ import type {
   ResponsePayload,
   UserRegistrationActionResponseData,
 } from "@workos-inc/node";
-import { Hono } from "hono";
 
 type ActionResponseBody = {
   object: string;
@@ -23,7 +23,7 @@ type ActionResponseBody = {
   signature: string;
 };
 
-const app = new Hono();
+const app = createHono();
 
 app.post("/", async (ctx): HandlerResult<ActionResponseBody> => {
   const actionSecret = ctx.req.param("actionSecret");

--- a/front-api/routes/workos/actions/index.ts
+++ b/front-api/routes/workos/actions/index.ts
@@ -1,8 +1,8 @@
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
 import actionSecret from "./[actionSecret]";
 
-const app = new Hono();
+const app = createHono();
 app.route("/:actionSecret", actionSecret);
 
 export default app;

--- a/front-api/routes/workos/index.ts
+++ b/front-api/routes/workos/index.ts
@@ -1,10 +1,10 @@
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
 import action from "./[action]";
 import actions from "./actions";
 import webhooks from "./webhooks";
 
-const app = new Hono();
+const app = createHono();
 // Literal-prefixed routes must be registered before the catch-all `:action`
 // param, since Hono matches in registration order.
 app.route("/actions", actions);

--- a/front-api/routes/workos/webhooks/[webhookSecret].ts
+++ b/front-api/routes/workos/webhooks/[webhookSecret].ts
@@ -6,10 +6,10 @@ import {
 } from "@app/lib/api/workos/webhook_helpers";
 import logger from "@app/logger/logger";
 import { launchWorkOSEventsWorkflow } from "@app/temporal/workos_events_queue/client";
+import { createHono } from "@front-api/lib/hono";
 import { apiError } from "@front-api/middlewares/utils";
-import { Hono } from "hono";
 
-const app = new Hono();
+const app = createHono();
 
 app.post("/", async (ctx) => {
   const webhookSecret = ctx.req.param("webhookSecret");

--- a/front-api/routes/workos/webhooks/index.ts
+++ b/front-api/routes/workos/webhooks/index.ts
@@ -1,8 +1,8 @@
-import { Hono } from "hono";
+import { createHono } from "@front-api/lib/hono";
 
 import webhookSecret from "./[webhookSecret]";
 
-const app = new Hono();
+const app = createHono();
 app.route("/:webhookSecret", webhookSecret);
 
 export default app;


### PR DESCRIPTION
## Description

  Root cause: Hono treats /tables and /tables/ as different routes; Next.js doesn't.

  The handler is registered as app.get("/", ...) in front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts:144, and mounted via .route("/tables", app). Hono's default routing is strict — that mount only matches /tables (no trailing slash). With a trailing slash, the path falls through to the catch-all /api/v1/w/:wId/* and returns 404.

  In front, this is pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts. Next.js's Pages router locates the same file for both /tables and /tables/ regardless of skipTrailingSlashRedirect (that setting only controls redirects, not which file matches). So front happily serves both forms.

  My isolated repro confirms:
  - /.../tables → 200 (INDEX HIT)
  - /.../tables/ → 404 (CATCHALL)
  - /.../tables/csv → 200 (CSV)

  Fix: Use `new Hono({ strict: false })`. Do it via a new wrapper to centralize.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
