### PR TITLE
fix: rename and delete pod folders

### DIFF
--- a/front/components/file_explorer/FileExplorerContent.tsx
+++ b/front/components/file_explorer/FileExplorerContent.tsx
@@ -56,7 +56,7 @@ export function FileExplorerContent({
     if (node.isDirectory) {
       const folderEntry: FolderEntry = {
         kind: "folder",
-        path: `project/${node.path}`,
+        path: `pod/${node.path}`,
         name: node.name,
       };
       return (


### PR DESCRIPTION
## Description

This PR fixes the folder path prefix in `FileExplorerContent.tsx` when building folder entries, replacing `project/` with `pod/` so that rename and delete operations on pod folders work correctly.

## Tests

Manually.

## Risks

<!-- Discuss potential risks and how they will be mitigated. -->

## Deploy Plan

<!-- Outline the deployment steps. -->

