### PR TITLE
[front] perf: cache workspace-wide metronome aggregates for members-usage

### DIFF
--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1,15 +1,26 @@
 import type { Authenticator } from "@app/lib/auth";
 import {
+  getCachedDefaultCapThreshold,
+  getCachedPerUserCapThresholds,
   getMetronomeDefaultUserCapAlert,
   listMetronomePerUserCapsForWorkspace,
 } from "@app/lib/metronome/alerts/spend_limits";
-import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
-import { buildSeatDataByUserId, type SeatData } from "@app/lib/metronome/seats";
+import {
+  fetchPerUserAwuUsage,
+  getCachedPerUserAwuUsage,
+} from "@app/lib/metronome/per_user_usage";
+import {
+  buildSeatDataByUserId,
+  getCachedSeatDataByUserId,
+  type SeatData,
+} from "@app/lib/metronome/seats";
 import type { BillingFrequency } from "@app/lib/metronome/types";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { resolveEffectiveSpendLimitAwuCredits } from "@app/lib/spend_limits/effective";
+import logger from "@app/logger/logger";
 import type { MembershipSeatType } from "@app/types/memberships";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { z } from "zod";
 
 export type MemberUsageType = {
@@ -57,6 +68,27 @@ export type MembersUsagePaginationInput = z.infer<
   typeof MembersUsagePaginationSchema
 >;
 
+async function fetchPerUserUsageCreditsForMembersTableUncached({
+  metronomeCustomerId,
+  metronomeContractId,
+}: {
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+}): Promise<Map<string, number>> {
+  const result = await fetchPerUserAwuUsage({
+    metronomeCustomerId,
+    metronomeContractId,
+  });
+  if (result.isErr()) {
+    logger.warn(
+      { err: result.error, metronomeCustomerId },
+      "[MembersUsage] Failed to fetch per-user usage"
+    );
+    return new Map();
+  }
+  return result.value;
+}
+
 async function fetchPerUserUsageCreditsForMembersTable({
   metronomeCustomerId,
   metronomeContractId,
@@ -67,14 +99,38 @@ async function fetchPerUserUsageCreditsForMembersTable({
   if (!metronomeCustomerId || !metronomeContractId) {
     return new Map();
   }
-  const result = await fetchPerUserAwuUsage({
-    metronomeCustomerId,
-    metronomeContractId,
-  });
-  if (result.isErr()) {
-    return new Map();
+  try {
+    return new Map(
+      Object.entries(
+        await getCachedPerUserAwuUsage({
+          metronomeCustomerId,
+          metronomeContractId,
+        })
+      )
+    );
+  } catch (err) {
+    logger.warn(
+      { err: normalizeError(err), metronomeCustomerId },
+      "[MembersUsage] Failed to read cached per-user usage, falling back to uncached fetch"
+    );
+    return fetchPerUserUsageCreditsForMembersTableUncached({
+      metronomeCustomerId,
+      metronomeContractId,
+    });
   }
-  return result.value;
+}
+
+async function fetchSeatDataForMembersTableUncached({
+  metronomeCustomerId,
+  metronomeContractId,
+}: {
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+}): Promise<Map<string, SeatData>> {
+  return buildSeatDataByUserId({
+    metronomeCustomerId,
+    contractId: metronomeContractId,
+  });
 }
 
 async function fetchSeatDataForMembersTable({
@@ -87,10 +143,74 @@ async function fetchSeatDataForMembersTable({
   if (!metronomeCustomerId || !metronomeContractId) {
     return new Map();
   }
-  return buildSeatDataByUserId({
+  try {
+    return new Map(
+      Object.entries(
+        await getCachedSeatDataByUserId({
+          metronomeCustomerId,
+          contractId: metronomeContractId,
+        })
+      )
+    );
+  } catch (err) {
+    logger.warn(
+      { err: normalizeError(err), metronomeCustomerId },
+      "[MembersUsage] Failed to read cached seat data, falling back to uncached fetch"
+    );
+    return fetchSeatDataForMembersTableUncached({
+      metronomeCustomerId,
+      metronomeContractId,
+    });
+  }
+}
+
+async function fetchPerUserCapOverridesUncached({
+  metronomeCustomerId,
+  workspaceId,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+}): Promise<Map<string, number>> {
+  const result = await listMetronomePerUserCapsForWorkspace({
     metronomeCustomerId,
-    contractId: metronomeContractId,
+    workspaceId,
   });
+  if (result.isErr()) {
+    logger.warn(
+      { err: result.error, workspaceId },
+      "[MembersUsage] Failed to fetch per-user spend caps"
+    );
+    return new Map();
+  }
+
+  const thresholds = new Map<string, number>();
+  for (const [userId, entry] of result.value) {
+    thresholds.set(userId, entry.alert.threshold);
+  }
+
+  return thresholds;
+}
+
+async function fetchDefaultCapUncached({
+  metronomeCustomerId,
+  workspaceId,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+}): Promise<number | null> {
+  const result = await getMetronomeDefaultUserCapAlert({
+    metronomeCustomerId,
+    workspaceId,
+  });
+  if (result.isErr()) {
+    logger.warn(
+      { err: result.error, workspaceId },
+      "[MembersUsage] Failed to fetch default spend cap"
+    );
+    return null;
+  }
+
+  return result.value?.alert.threshold ?? null;
 }
 
 /**
@@ -117,29 +237,65 @@ async function fetchEffectivePerUserSpendLimits({
     return { perUserOverrides: new Map(), defaultAwuCredits: null };
   }
 
-  const [overridesResult, defaultResult] = await Promise.all([
-    listMetronomePerUserCapsForWorkspace({
-      metronomeCustomerId,
-      workspaceId,
-    }),
-    getMetronomeDefaultUserCapAlert({
-      metronomeCustomerId,
-      workspaceId,
-    }),
+  const [perUserOverrides, defaultAwuCredits] = await Promise.all([
+    fetchPerUserCapOverrides({ metronomeCustomerId, workspaceId }),
+    fetchDefaultCap({ metronomeCustomerId, workspaceId }),
   ]);
 
-  const perUserOverrides = new Map<string, number>();
-  if (overridesResult.isOk()) {
-    for (const [userId, entry] of overridesResult.value) {
-      perUserOverrides.set(userId, entry.alert.threshold);
-    }
-  }
-
-  const defaultAwuCredits = defaultResult.isOk()
-    ? (defaultResult.value?.alert.threshold ?? null)
-    : null;
-
   return { perUserOverrides, defaultAwuCredits };
+}
+
+async function fetchPerUserCapOverrides({
+  metronomeCustomerId,
+  workspaceId,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+}): Promise<Map<string, number>> {
+  try {
+    return new Map(
+      Object.entries(
+        await getCachedPerUserCapThresholds({
+          metronomeCustomerId,
+          workspaceId,
+        })
+      )
+    );
+  } catch (err) {
+    logger.warn(
+      { err: normalizeError(err), workspaceId },
+      "[MembersUsage] Failed to read cached per-user spend caps, falling back to uncached fetch"
+    );
+    return fetchPerUserCapOverridesUncached({
+      metronomeCustomerId,
+      workspaceId,
+    });
+  }
+}
+
+async function fetchDefaultCap({
+  metronomeCustomerId,
+  workspaceId,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+}): Promise<number | null> {
+  try {
+    const { threshold } = await getCachedDefaultCapThreshold({
+      metronomeCustomerId,
+      workspaceId,
+    });
+    return threshold;
+  } catch (err) {
+    logger.warn(
+      { err: normalizeError(err), workspaceId },
+      "[MembersUsage] Failed to read cached default spend cap, falling back to uncached fetch"
+    );
+    return fetchDefaultCapUncached({
+      metronomeCustomerId,
+      workspaceId,
+    });
+  }
 }
 
 export async function getMembersUsage({

--- a/front/lib/metronome/alerts/spend_limits.ts
+++ b/front/lib/metronome/alerts/spend_limits.ts
@@ -5,6 +5,10 @@ import {
 } from "@app/lib/metronome/alerts";
 import { listMetronomeAlerts } from "@app/lib/metronome/client";
 import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import {
+  bestEffortInvalidateCacheWithRedis,
+  cacheWithRedis,
+} from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -90,6 +94,10 @@ export async function upsertMetronomeDefaultUserCapAlert({
     },
     "[Metronome DefaultUserCap] Synced default per-user cap alert"
   );
+  await invalidateCachedDefaultCapThreshold({
+    metronomeCustomerId,
+    workspaceId,
+  });
   return new Ok({ alertId: upsertResult.value.alertId });
 }
 
@@ -148,6 +156,66 @@ export async function listMetronomePerUserCapsForWorkspace({
   }
 }
 
+const SPEND_LIMIT_CACHE_TTL_MS = 60 * 1000;
+
+const spendLimitCacheResolver = ({
+  metronomeCustomerId,
+  workspaceId,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+}) => `${metronomeCustomerId}-${workspaceId}`;
+
+async function fetchPerUserCapThresholds(args: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+}): Promise<Record<string, number>> {
+  const result = await listMetronomePerUserCapsForWorkspace(args);
+  if (result.isErr()) {
+    throw result.error;
+  }
+  const thresholds: Record<string, number> = {};
+  for (const [userId, entry] of result.value) {
+    thresholds[userId] = entry.alert.threshold;
+  }
+  return thresholds;
+}
+
+export const getCachedPerUserCapThresholds = cacheWithRedis(
+  fetchPerUserCapThresholds,
+  spendLimitCacheResolver,
+  { ttlMs: SPEND_LIMIT_CACHE_TTL_MS }
+);
+
+const invalidateCachedPerUserCapThresholds = bestEffortInvalidateCacheWithRedis(
+  fetchPerUserCapThresholds,
+  spendLimitCacheResolver,
+  "members-usage per-user spend caps"
+);
+
+async function fetchDefaultCapThreshold(args: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+}): Promise<{ threshold: number | null }> {
+  const result = await getMetronomeDefaultUserCapAlert(args);
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return { threshold: result.value?.alert.threshold ?? null };
+}
+
+export const getCachedDefaultCapThreshold = cacheWithRedis(
+  fetchDefaultCapThreshold,
+  spendLimitCacheResolver,
+  { ttlMs: SPEND_LIMIT_CACHE_TTL_MS }
+);
+
+const invalidateCachedDefaultCapThreshold = bestEffortInvalidateCacheWithRedis(
+  fetchDefaultCapThreshold,
+  spendLimitCacheResolver,
+  "members-usage default spend cap"
+);
+
 /**
  * Idempotently ensure a Metronome `spend_threshold_reached` alert exists on
  * the customer for this user, with the given AWU threshold. If an alert
@@ -188,6 +256,10 @@ export async function upsertMetronomePerUserCapAlert({
     },
     "[Metronome PerUserCap] Synced per-user cap alert"
   );
+  await invalidateCachedPerUserCapThresholds({
+    metronomeCustomerId,
+    workspaceId,
+  });
   return new Ok({ alertId: upsertResult.value.alertId });
 }
 
@@ -223,5 +295,9 @@ export async function clearMetronomePerUserCapAlert({
       "[Metronome PerUserCap] Cleared per-user cap alert"
     );
   }
+  await invalidateCachedPerUserCapThresholds({
+    metronomeCustomerId,
+    workspaceId,
+  });
   return new Ok(undefined);
 }

--- a/front/lib/metronome/per_user_usage.ts
+++ b/front/lib/metronome/per_user_usage.ts
@@ -1,5 +1,6 @@
 import { listMetronomeDraftInvoices } from "@app/lib/metronome/client";
 import { getProductAiUsageId } from "@app/lib/metronome/constants";
+import { cacheWithRedis } from "@app/lib/utils/cache";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -48,3 +49,23 @@ export async function fetchPerUserAwuUsage({
 
   return new Ok(perUser);
 }
+
+const MEMBERS_USAGE_PER_USER_CACHE_TTL_MS = 60 * 1000;
+
+async function fetchPerUserAwuUsageRecord(args: {
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+}): Promise<Record<string, number>> {
+  const result = await fetchPerUserAwuUsage(args);
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return Object.fromEntries(result.value);
+}
+
+export const getCachedPerUserAwuUsage = cacheWithRedis(
+  fetchPerUserAwuUsageRecord,
+  ({ metronomeCustomerId, metronomeContractId }) =>
+    `${metronomeCustomerId}-${metronomeContractId}`,
+  { ttlMs: MEMBERS_USAGE_PER_USER_CACHE_TTL_MS }
+);

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -14,6 +14,10 @@ import {
 import type { BillingFrequency } from "@app/lib/metronome/types";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import {
+  bestEffortInvalidateCacheWithRedis,
+  cacheWithRedis,
+} from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import type { MembershipSeatType } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
@@ -214,212 +218,226 @@ export async function syncSeatCount({
   startingAt?: string;
   contract?: CachedContract;
 }): Promise<Result<undefined, Error>> {
-  let resolvedContract: CachedContract;
-  if (contract) {
-    resolvedContract = contract;
-  } else {
-    const fetched = await fetchCachedContract({
-      metronomeCustomerId,
-      metronomeContractId: contractId,
-    });
-    if (fetched.isErr()) {
-      return new Err(fetched.error);
-    }
-    resolvedContract = fetched.value;
-  }
+  let didMutateSeatData = false;
 
-  const productSeatTypes = await getProductSeatTypes();
-  const seatSubscriptions = (resolvedContract.subscriptions ?? []).flatMap(
-    (sub) => {
-      if (!sub.id) {
-        return [];
-      }
-      const seatType = getSeatTypeForSubscription(sub, productSeatTypes);
-      if (!seatType) {
-        return [];
-      }
-      return [{ sub, seatType }];
-    }
-  );
-
-  if (seatSubscriptions.length === 0) {
-    logger.warn(
-      { workspaceId: workspace.sId, contractId },
-      "[Metronome] No seat subscription found on contract — cannot sync seats"
-    );
-    return new Err(new Error("No seat subscription found on contract"));
-  }
-
-  // Read current + future DB state. Future memberships are scheduled seat
-  // transitions: each row has `startAt > now` and represents the seat
-  // type the user will be on from `startAt` forward. The companion "current"
-  // row (with `endAt = startAt`) still appears in `getActiveMemberships`.
-  const [{ memberships: activeMemberships }, futureMemberships] =
-    await Promise.all([
-      MembershipResource.getActiveMemberships({ workspace }),
-      MembershipResource.getScheduledFutureMemberships({ workspace }),
-    ]);
-
-  // userSId → current seat type (the seat they are on right now).
-  const currentSeatByUserSId = new Map<string, MembershipSeatType>();
-  for (const m of activeMemberships) {
-    const userSId = m.user?.sId;
-    if (userSId) {
-      currentSeatByUserSId.set(userSId, m.seatType);
-    }
-  }
-
-  type ScheduledChange = {
-    userSId: string;
-    newSeatType: MembershipSeatType;
-    at: Date;
-  };
-  const scheduledChanges: ScheduledChange[] = [];
-  for (const m of futureMemberships) {
-    const userSId = m.user?.sId;
-    if (userSId) {
-      scheduledChanges.push({
-        userSId,
-        newSeatType: m.seatType,
-        at: m.startAt,
-      });
-    }
-  }
-
-  // Surface memberships whose seat type has no matching subscription on the
-  // contract — those users will not be billed.
-  const coveredSeatTypes = new Set(
-    seatSubscriptions.map(({ seatType }) => seatType)
-  );
-  const uncoveredUsersBySeatType = new Map<MembershipSeatType, string[]>();
-  for (const [userSId, seatType] of currentSeatByUserSId) {
-    if (!coveredSeatTypes.has(seatType)) {
-      const bucket = uncoveredUsersBySeatType.get(seatType) ?? [];
-      bucket.push(userSId);
-      uncoveredUsersBySeatType.set(seatType, bucket);
-    }
-  }
-  for (const [seatType, userSIds] of uncoveredUsersBySeatType) {
-    logger.warn(
-      {
-        workspaceId: workspace.sId,
-        contractId,
-        seatType,
-        memberCount: userSIds.length,
-        userIds: userSIds,
-      },
-      "[Metronome] Memberships with seat type not covered by any contract subscription — they will not be billed"
-    );
-  }
-
-  // Compute the set of timestamps we need to reconcile: "now" plus each
-  // unique scheduled `at` (in ascending order, so we never overwrite a
-  // later segment with an earlier one).
-  const scheduledTimestampsMs = Array.from(
-    new Set(scheduledChanges.map((c) => c.at.getTime()))
-  ).sort((a, b) => a - b);
-
-  // Compute the desired seat type per user at a given timestamp, by walking
-  // scheduled changes from earliest up to (and including) `tMs`.
-  const seatTypeAt = (
-    userSId: string,
-    tMs: number
-  ): MembershipSeatType | undefined => {
-    let seatType = currentSeatByUserSId.get(userSId);
-    for (const c of scheduledChanges) {
-      if (c.userSId === userSId && c.at.getTime() <= tMs) {
-        seatType = c.newSeatType;
-      }
-    }
-    return seatType;
-  };
-
-  // Returns desired sIds for `subSeatType` at `tMs`. Includes users whose
-  // currently-active row maps to `subSeatType` AND who have not (yet)
-  // scheduled themselves off it by `tMs`, plus users who scheduled
-  // themselves onto it.
-  const allUserSIds = new Set<string>([
-    ...currentSeatByUserSId.keys(),
-    ...scheduledChanges.map((c) => c.userSId),
-  ]);
-  const desiredSIdsAt = (
-    subSeatType: MembershipSeatType,
-    tMs: number
-  ): string[] => {
-    const sIds: string[] = [];
-    for (const userSId of allUserSIds) {
-      if (seatTypeAt(userSId, tMs) === subSeatType) {
-        sIds.push(userSId);
-      }
-    }
-    return sIds;
-  };
-
-  for (const { sub, seatType } of seatSubscriptions) {
-    const subscriptionId = sub.id!;
-    const quantityMode = sub.quantity_management_mode ?? "QUANTITY_ONLY";
-
-    if (quantityMode === "SEAT_BASED") {
-      // Now segment.
-      const nowResult = await reconcileSeatBasedSegment({
+  try {
+    let resolvedContract: CachedContract;
+    if (contract) {
+      resolvedContract = contract;
+    } else {
+      const fetched = await fetchCachedContract({
         metronomeCustomerId,
-        contractId,
-        subscriptionId,
-        seatType,
-        desiredSIds: desiredSIdsAt(seatType, Date.now()),
-        startingAt,
-        workspaceId: workspace.sId,
+        metronomeContractId: contractId,
       });
-      if (nowResult.isErr()) {
-        return new Err(nowResult.error);
+      if (fetched.isErr()) {
+        return new Err(fetched.error);
       }
+      resolvedContract = fetched.value;
+    }
 
-      // Future segments, one per unique scheduled timestamp.
-      for (const tMs of scheduledTimestampsMs) {
-        const at = new Date(tMs);
-        const futureResult = await reconcileSeatBasedSegment({
+    const productSeatTypes = await getProductSeatTypes();
+    const seatSubscriptions = (resolvedContract.subscriptions ?? []).flatMap(
+      (sub) => {
+        if (!sub.id) {
+          return [];
+        }
+        const seatType = getSeatTypeForSubscription(sub, productSeatTypes);
+        if (!seatType) {
+          return [];
+        }
+        return [{ sub, seatType }];
+      }
+    );
+
+    if (seatSubscriptions.length === 0) {
+      logger.warn(
+        { workspaceId: workspace.sId, contractId },
+        "[Metronome] No seat subscription found on contract — cannot sync seats"
+      );
+      return new Err(new Error("No seat subscription found on contract"));
+    }
+
+    // Read current + future DB state. Future memberships are scheduled seat
+    // transitions: each row has `startAt > now` and represents the seat
+    // type the user will be on from `startAt` forward. The companion "current"
+    // row (with `endAt = startAt`) still appears in `getActiveMemberships`.
+    const [{ memberships: activeMemberships }, futureMemberships] =
+      await Promise.all([
+        MembershipResource.getActiveMemberships({ workspace }),
+        MembershipResource.getScheduledFutureMemberships({ workspace }),
+      ]);
+
+    // userSId → current seat type (the seat they are on right now).
+    const currentSeatByUserSId = new Map<string, MembershipSeatType>();
+    for (const m of activeMemberships) {
+      const userSId = m.user?.sId;
+      if (userSId) {
+        currentSeatByUserSId.set(userSId, m.seatType);
+      }
+    }
+
+    type ScheduledChange = {
+      userSId: string;
+      newSeatType: MembershipSeatType;
+      at: Date;
+    };
+    const scheduledChanges: ScheduledChange[] = [];
+    for (const m of futureMemberships) {
+      const userSId = m.user?.sId;
+      if (userSId) {
+        scheduledChanges.push({
+          userSId,
+          newSeatType: m.seatType,
+          at: m.startAt,
+        });
+      }
+    }
+
+    // Surface memberships whose seat type has no matching subscription on the
+    // contract — those users will not be billed.
+    const coveredSeatTypes = new Set(
+      seatSubscriptions.map(({ seatType }) => seatType)
+    );
+    const uncoveredUsersBySeatType = new Map<MembershipSeatType, string[]>();
+    for (const [userSId, seatType] of currentSeatByUserSId) {
+      if (!coveredSeatTypes.has(seatType)) {
+        const bucket = uncoveredUsersBySeatType.get(seatType) ?? [];
+        bucket.push(userSId);
+        uncoveredUsersBySeatType.set(seatType, bucket);
+      }
+    }
+    for (const [seatType, userSIds] of uncoveredUsersBySeatType) {
+      logger.warn(
+        {
+          workspaceId: workspace.sId,
+          contractId,
+          seatType,
+          memberCount: userSIds.length,
+          userIds: userSIds,
+        },
+        "[Metronome] Memberships with seat type not covered by any contract subscription — they will not be billed"
+      );
+    }
+
+    // Compute the set of timestamps we need to reconcile: "now" plus each
+    // unique scheduled `at` (in ascending order, so we never overwrite a
+    // later segment with an earlier one).
+    const scheduledTimestampsMs = Array.from(
+      new Set(scheduledChanges.map((c) => c.at.getTime()))
+    ).sort((a, b) => a - b);
+
+    // Compute the desired seat type per user at a given timestamp, by walking
+    // scheduled changes from earliest up to (and including) `tMs`.
+    const seatTypeAt = (
+      userSId: string,
+      tMs: number
+    ): MembershipSeatType | undefined => {
+      let seatType = currentSeatByUserSId.get(userSId);
+      for (const c of scheduledChanges) {
+        if (c.userSId === userSId && c.at.getTime() <= tMs) {
+          seatType = c.newSeatType;
+        }
+      }
+      return seatType;
+    };
+
+    // Returns desired sIds for `subSeatType` at `tMs`. Includes users whose
+    // currently-active row maps to `subSeatType` AND who have not (yet)
+    // scheduled themselves off it by `tMs`, plus users who scheduled
+    // themselves onto it.
+    const allUserSIds = new Set<string>([
+      ...currentSeatByUserSId.keys(),
+      ...scheduledChanges.map((c) => c.userSId),
+    ]);
+    const desiredSIdsAt = (
+      subSeatType: MembershipSeatType,
+      tMs: number
+    ): string[] => {
+      const sIds: string[] = [];
+      for (const userSId of allUserSIds) {
+        if (seatTypeAt(userSId, tMs) === subSeatType) {
+          sIds.push(userSId);
+        }
+      }
+      return sIds;
+    };
+
+    for (const { sub, seatType } of seatSubscriptions) {
+      const subscriptionId = sub.id!;
+      const quantityMode = sub.quantity_management_mode ?? "QUANTITY_ONLY";
+
+      if (quantityMode === "SEAT_BASED") {
+        // Now segment.
+        const nowResult = await reconcileSeatBasedSegment({
           metronomeCustomerId,
           contractId,
           subscriptionId,
           seatType,
-          desiredSIds: desiredSIdsAt(seatType, tMs),
-          startingAt: at.toISOString(),
-          coveringDate: at,
+          desiredSIds: desiredSIdsAt(seatType, Date.now()),
+          startingAt,
           workspaceId: workspace.sId,
         });
-        if (futureResult.isErr()) {
-          return new Err(futureResult.error);
+        if (nowResult.isErr()) {
+          return new Err(nowResult.error);
         }
-      }
-    } else {
-      // QUANTITY_ONLY: only sync the "now" total. Scheduled changes within
-      // a quantity-only seat tier are not modeled — they're rare in practice
-      // (free / unlimited tiers) and Metronome doesn't bill them per-seat.
-      const nowQuantity = desiredSIdsAt(seatType, Date.now()).length;
-      logger.info(
-        {
-          workspaceId: workspace.sId,
+        didMutateSeatData = didMutateSeatData || nowResult.value;
+
+        // Future segments, one per unique scheduled timestamp.
+        for (const tMs of scheduledTimestampsMs) {
+          const at = new Date(tMs);
+          const futureResult = await reconcileSeatBasedSegment({
+            metronomeCustomerId,
+            contractId,
+            subscriptionId,
+            seatType,
+            desiredSIds: desiredSIdsAt(seatType, tMs),
+            startingAt: at.toISOString(),
+            coveringDate: at,
+            workspaceId: workspace.sId,
+          });
+          if (futureResult.isErr()) {
+            return new Err(futureResult.error);
+          }
+          didMutateSeatData = didMutateSeatData || futureResult.value;
+        }
+      } else {
+        // QUANTITY_ONLY: only sync the "now" total. Scheduled changes within
+        // a quantity-only seat tier are not modeled — they're rare in practice
+        // (free / unlimited tiers) and Metronome doesn't bill them per-seat.
+        const nowQuantity = desiredSIdsAt(seatType, Date.now()).length;
+        logger.info(
+          {
+            workspaceId: workspace.sId,
+            contractId,
+            subscriptionId,
+            seatType,
+            quantity: nowQuantity,
+          },
+          "[Metronome] Updating seat quantity"
+        );
+        const updateResult = await updateSubscriptionQuantity({
+          metronomeCustomerId,
           contractId,
           subscriptionId,
-          seatType,
           quantity: nowQuantity,
-        },
-        "[Metronome] Updating seat quantity"
-      );
-      const updateResult = await updateSubscriptionQuantity({
-        metronomeCustomerId,
-        contractId,
-        subscriptionId,
-        quantity: nowQuantity,
-        startingAt,
-      });
-      if (updateResult.isErr()) {
-        return new Err(updateResult.error);
+          startingAt,
+        });
+        if (updateResult.isErr()) {
+          return new Err(updateResult.error);
+        }
+        didMutateSeatData = true;
       }
     }
-  }
 
-  return new Ok(undefined);
+    return new Ok(undefined);
+  } finally {
+    if (didMutateSeatData) {
+      await invalidateCachedSeatDataByUserId({
+        metronomeCustomerId,
+        contractId,
+      });
+    }
+  }
 }
 
 /**
@@ -445,7 +463,7 @@ async function reconcileSeatBasedSegment({
   startingAt?: string;
   coveringDate?: Date;
   workspaceId: string;
-}): Promise<Result<void, Error>> {
+}): Promise<Result<boolean, Error>> {
   const currentResult = await getMetronomeSubscriptionAssignedSeatIds({
     metronomeCustomerId,
     contractId,
@@ -462,7 +480,7 @@ async function reconcileSeatBasedSegment({
   const removeSeatIds = currentResult.value.filter((id) => !desired.has(id));
 
   if (addSeatIds.length === 0 && removeSeatIds.length === 0) {
-    return new Ok(undefined);
+    return new Ok(false);
   }
 
   logger.info(
@@ -489,7 +507,7 @@ async function reconcileSeatBasedSegment({
   if (updateResult.isErr()) {
     return new Err(updateResult.error);
   }
-  return new Ok(undefined);
+  return new Ok(true);
 }
 
 export type SeatData = {
@@ -507,9 +525,11 @@ export type SeatData = {
 export async function buildSeatDataByUserId({
   metronomeCustomerId,
   contractId,
+  throwOnError = false,
 }: {
   metronomeCustomerId: string;
   contractId: string;
+  throwOnError?: boolean;
 }): Promise<Map<string, SeatData>> {
   const contractResult = await getMetronomeContractById({
     metronomeCustomerId,
@@ -520,6 +540,9 @@ export async function buildSeatDataByUserId({
       { error: contractResult.error, metronomeCustomerId, contractId },
       "[Metronome] Failed to fetch contract"
     );
+    if (throwOnError) {
+      throw contractResult.error;
+    }
     return new Map();
   }
 
@@ -562,6 +585,9 @@ export async function buildSeatDataByUserId({
           },
           "[Metronome] Failed to fetch seat IDs"
         );
+        if (throwOnError) {
+          throw seatIdsResult.error;
+        }
         return null;
       }
 
@@ -589,3 +615,37 @@ export async function buildSeatDataByUserId({
 
   return seatDataByUserId;
 }
+
+const SEAT_DATA_CACHE_TTL_MS = 60 * 1000;
+
+const seatDataCacheResolver = ({
+  metronomeCustomerId,
+  contractId,
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+}) => `${metronomeCustomerId}-${contractId}`;
+
+async function fetchSeatDataRecord(args: {
+  metronomeCustomerId: string;
+  contractId: string;
+}): Promise<Record<string, SeatData>> {
+  return Object.fromEntries(
+    await buildSeatDataByUserId({
+      ...args,
+      throwOnError: true,
+    })
+  );
+}
+
+export const getCachedSeatDataByUserId = cacheWithRedis(
+  fetchSeatDataRecord,
+  seatDataCacheResolver,
+  { ttlMs: SEAT_DATA_CACHE_TTL_MS }
+);
+
+const invalidateCachedSeatDataByUserId = bestEffortInvalidateCacheWithRedis(
+  fetchSeatDataRecord,
+  seatDataCacheResolver,
+  "members-usage seat data"
+);

--- a/front/lib/resources/key_resource.test.ts
+++ b/front/lib/resources/key_resource.test.ts
@@ -38,6 +38,19 @@ vi.mock("@app/lib/utils/cache", () => ({
         };
       }
     ),
+  bestEffortInvalidateCacheWithRedis: vi
+    .fn()
+    .mockImplementation(
+      <T, Args extends unknown[]>(
+        fn: CacheableFunction<JsonSerializable<T>, Args>,
+        resolver: (...args: Args) => string
+      ) => {
+        return async (...args: Args): Promise<void> => {
+          const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
+          inMemoryCache.delete(key);
+        };
+      }
+    ),
   batchInvalidateCacheWithRedis: vi
     .fn()
     .mockImplementation(

--- a/front/lib/resources/membership_resource.test.ts
+++ b/front/lib/resources/membership_resource.test.ts
@@ -38,6 +38,20 @@ vi.mock("@app/lib/utils/cache", () => ({
         };
       }
     ),
+  bestEffortInvalidateCacheWithRedis: vi
+    .fn()
+    .mockImplementation(
+      <T, Args extends unknown[]>(
+        fn: CacheableFunction<JsonSerializable<T>, Args>,
+        resolver: (...args: Args) => string
+      ) => {
+        return async (...args: Args): Promise<void> => {
+          const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
+          inMemoryCache.delete(key);
+          deletedKeys.push(key);
+        };
+      }
+    ),
   batchInvalidateCacheWithRedis: vi
     .fn()
     .mockImplementation(

--- a/front/lib/resources/subscription_resource.test.ts
+++ b/front/lib/resources/subscription_resource.test.ts
@@ -39,6 +39,21 @@ vi.mock("@app/lib/utils/cache", () => ({
         };
       }
     ),
+  bestEffortInvalidateCacheWithRedis: vi
+    .fn()
+    .mockImplementation(
+      <T, Args extends unknown[]>(
+        fn: CacheableFunction<JsonSerializable<T>, Args>,
+        resolver: (...args: Args) => string
+      ) => {
+        return (...args: Args): Promise<void> => {
+          const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
+          inMemoryCache.delete(key);
+          deletedKeys.push(key);
+          return Promise.resolve();
+        };
+      }
+    ),
   batchInvalidateCacheWithRedis: vi
     .fn()
     .mockImplementation(

--- a/front/lib/resources/user_resource.test.ts
+++ b/front/lib/resources/user_resource.test.ts
@@ -39,6 +39,21 @@ vi.mock("@app/lib/utils/cache", () => ({
         };
       }
     ),
+  bestEffortInvalidateCacheWithRedis: vi
+    .fn()
+    .mockImplementation(
+      <T, Args extends unknown[]>(
+        fn: CacheableFunction<JsonSerializable<T>, Args>,
+        resolver: (...args: Args) => string
+      ) => {
+        return (...args: Args): Promise<void> => {
+          const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
+          inMemoryCache.delete(key);
+          deletedKeys.push(key);
+          return Promise.resolve();
+        };
+      }
+    ),
   batchInvalidateCacheWithRedis: vi
     .fn()
     .mockImplementation(

--- a/front/lib/resources/workspace_resource.test.ts
+++ b/front/lib/resources/workspace_resource.test.ts
@@ -40,6 +40,21 @@ vi.mock("@app/lib/utils/cache", () => ({
         };
       }
     ),
+  bestEffortInvalidateCacheWithRedis: vi
+    .fn()
+    .mockImplementation(
+      <T, Args extends unknown[]>(
+        fn: CacheableFunction<JsonSerializable<T>, Args>,
+        resolver: (...args: Args) => string
+      ) => {
+        return (...args: Args): Promise<void> => {
+          const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
+          inMemoryCache.delete(key);
+          deletedKeys.push(key);
+          return Promise.resolve();
+        };
+      }
+    ),
   batchInvalidateCacheWithRedis: vi
     .fn()
     .mockImplementation(

--- a/front/lib/utils/cache.ts
+++ b/front/lib/utils/cache.ts
@@ -1,6 +1,7 @@
 import { getRedisCacheClient } from "@app/lib/api/redis";
 import { distributedLock, distributedUnlock } from "@app/lib/lock";
 import logger from "@app/logger/logger";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { Transaction } from "sequelize";
 
 const SPIN_WAIT_INTERVAL_MS = 100;
@@ -218,6 +219,24 @@ export function batchInvalidateCacheWithRedis<T, Args extends unknown[]>(
 
     const keys = argsList.map((args) => getCacheKey(fn, resolver, args));
     await redisCli.del(keys);
+  };
+}
+
+export function bestEffortInvalidateCacheWithRedis<T, Args extends unknown[]>(
+  fn: CacheableFunction<JsonSerializable<T>, Args>,
+  resolver: KeyResolver<Args>,
+  label: string
+): (...args: Args) => Promise<void> {
+  const invalidate = invalidateCacheWithRedis(fn, resolver);
+  return async function (...args: Args): Promise<void> {
+    try {
+      await invalidate(...args);
+    } catch (err) {
+      logger.warn(
+        { err: normalizeError(err), cacheKey: resolver(...args) },
+        `Failed to invalidate cache: ${label}`
+      );
+    }
   };
 }
 

--- a/front/vite.setup.ts
+++ b/front/vite.setup.ts
@@ -146,6 +146,9 @@ vi.mock("@app/lib/utils/cache", () => ({
   invalidateCacheWithRedis: vi.fn().mockImplementation(() => {
     return async () => {};
   }),
+  bestEffortInvalidateCacheWithRedis: vi.fn().mockImplementation(() => {
+    return async () => {};
+  }),
   batchInvalidateCacheWithRedis: vi.fn().mockImplementation(() => {
     return async () => {};
   }),


### PR DESCRIPTION
## Description

The members-usage endpoint fetches three workspace-wide Metronome aggregates (per-user usage, seat data, per-user/default spend caps) on every request, re-scanning all of a customer's alerts and usage each time. This is O(N^2) external work.

Cache each aggregate in Redis (60s TTL) via cacheWithRedis, scoped to the display path only — the spend-limit enforcement and webhook paths keep reading fresh. Seat-data and cap caches self-invalidate at their mutation chokepoints (syncSeatCount, the cap upsert/clear functions) so config changes reflect immediately; usage is TTL-only.

Add bestEffortInvalidateCacheWithRedis to the cache utility family so invalidation failures never break a billing mutation, and use it for the three invalidatable caches.

## Tests

Locally

## Risk

Low

## Deploy Plan

front