### PR TITLE
fix: use pod in pod manager tool descriptions

### DIFF
--- a/front/lib/api/actions/servers/pod_manager/metadata.ts
+++ b/front/lib/api/actions/servers/pod_manager/metadata.ts
@@ -70,7 +70,7 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
     description:
       "Edit Pod information: title, description, and/or pinned frame. " +
       "Provide at least one field to update. Descriptions must be plain text only (no markdown, HTML, or formatting). " +
-      "The pinned frame must be an existing Pod file path under `project/` (use null to unpin).",
+      "The pinned frame must be an existing Pod file path under `pod/` (use null to unpin).",
     schema: {
       title: z.string().optional().describe("New Pod title"),
       description: z
@@ -84,7 +84,7 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
         .nullable()
         .optional()
         .describe(
-          "Path to a Pod file to pin as the Pod banner frame (e.g. project/banner.html). Pass null to unpin."
+          "Path to a Pod file to pin as the Pod banner frame (e.g. pod/banner.html). Pass null to unpin."
         ),
       dustPod: ConfigurableToolInputSchemas[
         INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT


### PR DESCRIPTION
## Description
This PR updates the pod manager tool descriptions to use pod instead of projects
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
