### PR TITLE
[front] fix: use wake-up wording in schedule confirmation

### DIFF
--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -18,6 +18,7 @@ import {
   isPodTasksCreateTasksInput,
   isPodTasksUpdateTasksInput,
 } from "@app/lib/api/actions/servers/pod_tasks/types";
+import { WAKEUPS_SERVER_NAME } from "@app/lib/api/actions/servers/wakeups/metadata";
 import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
@@ -117,6 +118,12 @@ const MCP_TOOL_OVERRIDES: Partial<
       },
       alwaysAllowLabel: (agentName) =>
         `Always allow ${asDisplayName(agentName)} to update Pod members`,
+    },
+  },
+  [WAKEUPS_SERVER_NAME]: {
+    schedule_wakeup: {
+      title: (agentName) =>
+        `Allow ${asDisplayName(agentName)} to schedule a wake-up?`,
     },
   },
 };

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -125,6 +125,14 @@ const MCP_TOOL_OVERRIDES: Partial<
       title: (agentName) =>
         `Allow ${asDisplayName(agentName)} to schedule a wake-up?`,
     },
+    list_wakeups: {
+      title: (agentName) =>
+        `Allow ${asDisplayName(agentName)} to list wake-ups?`,
+    },
+    cancel_wakeup: {
+      title: (agentName) =>
+        `Allow ${asDisplayName(agentName)} to cancel a wake-up?`,
+    },
   },
 };
 


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8331

This PR fixes the high-stake tool confirmation title for the wake-up scheduler. The generic `asDisplayName("schedule_wakeup")` fallback rendered `Schedule Wakeup`, so the dialog read `Allow @Agent to Schedule Wakeup?`.

It adds a `wakeups` MCP tool override for `schedule_wakeup`, matching the existing override pattern for other MCP servers, so the confirmation now reads `Allow @Agent to schedule a wake-up?`.

## Tests

- Tested locally with a `schedule_wakeup` tool call.

## Risk

- Low. Isolated to the confirmation dialog title for the wake-up scheduler.

## Deploy Plan

- Deploy front.