### PR TITLE
Outlook MCP tool: move email in folders

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -453,6 +453,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_contacts": "never_ask",
     "get_drafts": "never_ask",
     "get_messages": "never_ask",
+    "move_messages": "medium",
     "send_mail": "high",
     "update_contact": "high",
   },

--- a/front/lib/api/actions/servers/outlook/mail_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/mail_metadata.ts
@@ -232,6 +232,35 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
       done: "Send email",
     },
   },
+  move_messages: {
+    description:
+      'Move one or more messages to a destination folder in Outlook. The destination is given as a path of folder names from the top level (e.g. ["Archive", "2026", "Receipts"]). Any folders along the path that do not exist are created automatically. Prefer passing all messages destined for the same folder in a single call rather than calling this tool in parallel. Note: Microsoft Graph assigns a new message ID after a move.',
+    schema: {
+      messageIds: z
+        .array(z.string())
+        .min(1)
+        .describe("The IDs of the messages to move"),
+      destinationFolderPath: z
+        .array(z.string())
+        .min(1)
+        .describe(
+          'Path to the destination folder as a list of folder names from the top level (e.g. ["Archive", "2026", "Receipts"]). Pass a single-element array for a top-level folder. Any missing folders along the path are created automatically.'
+        ),
+      sharedMailboxAddress: z
+        .string()
+        .optional()
+        .describe(
+          "The email address of the shared mailbox to access (e.g. 'support@company.com'). " +
+            "Leave empty to access your own mailbox. " +
+            "Note: the shared mailbox address must be known in advance — there is no API to auto-discover it."
+        ),
+    },
+    stake: "medium",
+    displayLabels: {
+      running: "Moving messages",
+      done: "Move messages",
+    },
+  },
   get_contacts: {
     description:
       "Get contacts from Outlook. Supports search queries to filter contacts.",

--- a/front/lib/api/actions/servers/outlook/tools/mail.ts
+++ b/front/lib/api/actions/servers/outlook/tools/mail.ts
@@ -54,6 +54,26 @@ const getMailboxBasePath = (sharedMailboxAddress?: string): string => {
   return "/me";
 };
 
+// Parses the `Retry-After` header from a 429/503 response. Microsoft Graph
+// typically returns a number of seconds, but per RFC 9110 the value may also
+// be an HTTP-date.
+const parseRetryAfterSeconds = (
+  retryAfter: string | null | undefined
+): number | undefined => {
+  if (!retryAfter) {
+    return undefined;
+  }
+  const seconds = Number(retryAfter);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.ceil(seconds);
+  }
+  const dateMs = Date.parse(retryAfter);
+  if (!Number.isNaN(dateMs)) {
+    return Math.max(0, Math.ceil((dateMs - Date.now()) / 1000));
+  }
+  return undefined;
+};
+
 const getErrorText = async (response: Response): Promise<string> => {
   try {
     const errorData = await response.json();
@@ -150,6 +170,125 @@ interface OutlookFolder {
   unreadItemCount?: number;
   totalItemCount?: number;
 }
+
+const foldersEndpoint = (
+  basePath: string,
+  parentFolderId: string | null
+): string =>
+  parentFolderId
+    ? `${basePath}/mailFolders/${parentFolderId}/childFolders`
+    : `${basePath}/mailFolders`;
+
+const findFolderIdByName = async (
+  folderName: string,
+  parentFolderId: string | null,
+  basePath: string,
+  accessToken: string
+): Promise<{ folderId: string | null } | { error: MCPError }> => {
+  const response = await fetchFromOutlook(
+    `${foldersEndpoint(basePath, parentFolderId)}?$top=250`,
+    accessToken,
+    { method: "GET" }
+  );
+  if (!response.ok) {
+    const errorText = await getErrorText(response);
+    return {
+      error: new MCPError(
+        `Failed to fetch folders: ${response.status} ${response.statusText} - ${errorText}`
+      ),
+    };
+  }
+  const result = await response.json();
+  const folders = (result.value ?? []) as OutlookFolder[];
+  const folder = folders.find(
+    (f) => f.displayName.toLowerCase() === folderName.toLowerCase()
+  );
+  return { folderId: folder?.id ?? null };
+};
+
+const createFolder = async (
+  displayName: string,
+  parentFolderId: string | null,
+  basePath: string,
+  accessToken: string
+): Promise<{ folderId: string } | { error: MCPError }> => {
+  const response = await fetchFromOutlook(
+    foldersEndpoint(basePath, parentFolderId),
+    accessToken,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ displayName }),
+    }
+  );
+  if (!response.ok) {
+    const errorText = await getErrorText(response);
+    return {
+      error: new MCPError(
+        `Failed to create folder: ${response.status} ${response.statusText} - ${errorText}`
+      ),
+    };
+  }
+  const result = (await response.json()) as OutlookFolder;
+  return { folderId: result.id };
+};
+
+const resolveFolderPath = async (
+  folderPath: string[],
+  basePath: string,
+  accessToken: string
+): Promise<
+  { folderId: string; createdSegments: string[] } | { error: MCPError }
+> => {
+  let parentFolderId: string | null = null;
+  const createdSegments: string[] = [];
+
+  for (const segment of folderPath) {
+    const lookup = await findFolderIdByName(
+      segment,
+      parentFolderId,
+      basePath,
+      accessToken
+    );
+    if ("error" in lookup) {
+      return { error: lookup.error };
+    }
+
+    if (lookup.folderId) {
+      parentFolderId = lookup.folderId;
+      continue;
+    }
+
+    const created = await createFolder(
+      segment,
+      parentFolderId,
+      basePath,
+      accessToken
+    );
+    if (!("error" in created)) {
+      parentFolderId = created.folderId;
+      createdSegments.push(segment);
+      continue;
+    }
+
+    // Create failed. This commonly happens when a concurrent move_message call
+    // created the same folder between our lookup and our create (Graph returns
+    // ErrorFolderExists / 409). Re-lookup; if the folder now exists, use it.
+    // Otherwise the create error was a real failure — propagate it.
+    const retry = await findFolderIdByName(
+      segment,
+      parentFolderId,
+      basePath,
+      accessToken
+    );
+    if ("error" in retry || !retry.folderId) {
+      return { error: created.error };
+    }
+    parentFolderId = retry.folderId;
+  }
+
+  return { folderId: parentFolderId as string, createdSegments };
+};
 
 const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
   get_messages: async (
@@ -870,6 +1009,116 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
     }
 
     return new Ok([{ type: "text" as const, text: "Email sent successfully" }]);
+  },
+
+  move_messages: async (
+    { messageIds, destinationFolderPath, sharedMailboxAddress },
+    { authInfo }
+  ) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Authentication required"));
+    }
+
+    const basePath = getMailboxBasePath(sharedMailboxAddress);
+
+    const resolved = await resolveFolderPath(
+      destinationFolderPath,
+      basePath,
+      accessToken
+    );
+    if ("error" in resolved) {
+      return new Err(resolved.error);
+    }
+
+    const moveResults = await concurrentExecutor(
+      messageIds,
+      async (
+        messageId
+      ): Promise<
+        | { messageId: string; ok: true; newMessageId: string }
+        | {
+            messageId: string;
+            ok: false;
+            error: string;
+            retryAfterSeconds?: number;
+          }
+      > => {
+        const encodedMessageId = encodeURIComponent(messageId);
+        const response = await fetchFromOutlook(
+          `${basePath}/messages/${encodedMessageId}/move`,
+          accessToken,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ destinationId: resolved.folderId }),
+          }
+        );
+
+        if (!response.ok) {
+          const errorText = await getErrorText(response);
+          const error =
+            response.status === 404
+              ? "Message not found"
+              : `${response.status} ${response.statusText} - ${errorText}`;
+          const retryAfterSeconds =
+            response.status === 429 || response.status === 503
+              ? parseRetryAfterSeconds(response.headers.get("Retry-After"))
+              : undefined;
+          return retryAfterSeconds !== undefined
+            ? { messageId, ok: false, error, retryAfterSeconds }
+            : { messageId, ok: false, error };
+        }
+
+        const result = await response.json();
+        return { messageId, ok: true, newMessageId: result.id };
+      },
+      { concurrency: 3 }
+    );
+
+    const succeeded = moveResults.filter((r) => r.ok);
+    const failed = moveResults.filter((r) => !r.ok);
+    const throttled = failed.filter((r) => r.retryAfterSeconds !== undefined);
+    const maxRetryAfterSeconds = throttled.reduce(
+      (max, r) => Math.max(max, r.retryAfterSeconds ?? 0),
+      0
+    );
+    const pathLabel = destinationFolderPath.join(" / ");
+
+    const summaryParts: string[] = [];
+    summaryParts.push(
+      `Moved ${succeeded.length}/${messageIds.length} message(s) to "${pathLabel}".`
+    );
+    if (resolved.createdSegments.length > 0) {
+      summaryParts.push(
+        `New folder segments created: ${resolved.createdSegments.join(", ")}.`
+      );
+    }
+    if (failed.length > 0) {
+      summaryParts.push(`${failed.length} failed.`);
+    }
+    if (throttled.length > 0) {
+      summaryParts.push(
+        `${throttled.length} throttled by Microsoft Graph — retry after ${maxRetryAfterSeconds} second(s).`
+      );
+    }
+
+    return new Ok([
+      { type: "text" as const, text: summaryParts.join(" ") },
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          {
+            destinationFolderPath,
+            createdSegments: resolved.createdSegments,
+            succeeded,
+            failed,
+          },
+          null,
+          2
+        ),
+      },
+    ]);
   },
 
   get_contacts: async (


### PR DESCRIPTION
## Description

Adds a `move_messages` tool to the Outlook MCP server, allowing agents to move one or more emails to a destination folder specified as a folder-name path (e.g. `["Archive", "2026", "Receipts"]`). Missing folders along the path are created automatically. The tool supports shared mailboxes and handles a Microsoft Graph quirk where a message gets a new ID after being moved (new IDs are returned in the response).

Key implementation details:
- `resolveFolderPath` walks the folder path depth-first, creating missing segments on the fly, with a race-condition guard: if a concurrent call created the same folder between our lookup and our `POST`, the resulting 409 triggers a re-lookup rather than an error.
- Moves are executed concurrently (concurrency: 3) via `concurrentExecutor`.
- `parseRetryAfterSeconds` parses the `Retry-After` header from 429/503 responses (supporting both numeric seconds and HTTP-date formats) so throttled messages are surfaced to the agent with a retry hint.
- Stake is set to `"medium"`, requiring user confirmation before execution.

## Tests

Manually tested. No automated tests added.

## Risk

Low — new tool only; no existing behavior is modified. The auto-create logic could create unintended folders if the model supplies an incorrect path, but the medium stake mitigates acc
```