### PR TITLE
fix: cap image generation quality at 2K

### DIFF
--- a/front/components/actions/mcp/details/MCPImageGenerationActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPImageGenerationActionDetails.tsx
@@ -11,9 +11,12 @@ import type { LightWorkspaceType } from "@app/types/user";
 import { ActionImageIcon, Chip, cn, Separator } from "@dust-tt/sparkle";
 import React from "react";
 
+// "high" is retained for historical actions generated before the 4K tier was
+// removed from the agent-facing tool; the write path is now capped at "medium".
 const QUALITY_LABELS: Record<string, string> = {
   low: "1K",
   medium: "2K",
+  high: "4K",
 };
 
 interface ReferenceImageChipProps {

--- a/front/components/actions/mcp/details/MCPImageGenerationActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPImageGenerationActionDetails.tsx
@@ -14,7 +14,6 @@ import React from "react";
 const QUALITY_LABELS: Record<string, string> = {
   low: "1K",
   medium: "2K",
-  high: "4K",
 };
 
 interface ReferenceImageChipProps {

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1134,7 +1134,7 @@ export function AgentSidebarMenu({
             {!hideInAppBanner && (
               <StackedInAppBanners
                 owner={owner}
-                onCreatePod={() => setIsCreateProjectModalOpen(true)}
+                onCreatePod={() => setIsCreatePodModalOpen(true)}
               />
             )}
           </div>

--- a/front/lib/actions/mcp_internal_actions/types.ts
+++ b/front/lib/actions/mcp_internal_actions/types.ts
@@ -354,12 +354,10 @@ export const GenerateImageInputSchema = z.object({
       "The aspect ratio of the generated image. Must be one of 1:1, 3:2, 2:3, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, or 21:9."
     ),
   quality: z
-    .enum(["low", "medium", "high"])
+    .enum(["low", "medium"])
     .optional()
     .default("low")
-    .describe(
-      "Output resolution: low (1K/1024px), medium (2K/2048px), or high (4K/4096px)."
-    ),
+    .describe("Output resolution: low (1K/1024px) or medium (2K/2048px)."),
 });
 
 export type GenerateImageInputType = z.infer<typeof GenerateImageInputSchema>;

--- a/front/lib/actions/mcp_internal_actions/types.ts
+++ b/front/lib/actions/mcp_internal_actions/types.ts
@@ -353,11 +353,16 @@ export const GenerateImageInputSchema = z.object({
     .describe(
       "The aspect ratio of the generated image. Must be one of 1:1, 3:2, 2:3, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, or 21:9."
     ),
+  // Display/parse path for stored actions. Kept permissive (still accepts the
+  // legacy "high"/4K tier) so historical conversations render correctly. The
+  // agent-facing write path is capped at "medium" in image_generation/metadata.ts.
   quality: z
-    .enum(["low", "medium"])
+    .enum(["low", "medium", "high"])
     .optional()
     .default("low")
-    .describe("Output resolution: low (1K/1024px) or medium (2K/2048px)."),
+    .describe(
+      "Output resolution: low (1K/1024px), medium (2K/2048px), or high (4K/4096px)."
+    ),
 });
 
 export type GenerateImageInputType = z.infer<typeof GenerateImageInputSchema>;

--- a/front/lib/api/actions/servers/image_generation/helpers.ts
+++ b/front/lib/api/actions/servers/image_generation/helpers.ts
@@ -55,7 +55,6 @@ const MICRO_USD_PER_USD = 1_000_000;
 export const QUALITY_TO_IMAGE_SIZE: Record<string, string> = {
   low: "1K",
   medium: "2K",
-  high: "4K",
 };
 
 export type Base64ImageData = {

--- a/front/lib/api/actions/servers/image_generation/metadata.ts
+++ b/front/lib/api/actions/servers/image_generation/metadata.ts
@@ -45,12 +45,10 @@ export const imageGenerationToolInputSchema = z.object({
       "The aspect ratio of the generated image. Must be one of 1:1, 3:2, 2:3, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, or 21:9."
     ),
   quality: z
-    .enum(["low", "medium", "high"])
+    .enum(["low", "medium"])
     .optional()
     .default("low")
-    .describe(
-      "Output resolution: low (1K/1024px), medium (2K/2048px), or high (4K/4096px)."
-    ),
+    .describe("Output resolution: low (1K/1024px) or medium (2K/2048px)."),
 });
 
 export type ImageGenerationToolInput = z.infer<
@@ -89,7 +87,7 @@ const IMAGE_GENERATION_SERVER_INSTRUCTIONS =
   "- Images from previous tool calls can be used as reference for subsequent generations\n" +
   "- Example: generate a character portrait, then use it as reference for different poses\n\n" +
   "OUTPUT OPTIONS:\n" +
-  "- Quality: 'low', 'medium', or 'high'\n" +
+  "- Quality: 'low' or 'medium'\n" +
   "- Aspect ratios: 1:1, 3:2, 2:3, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9";
 
 export const IMAGE_GENERATION_SERVER = {


### PR DESCRIPTION
## Description

GPT image 2 at the 4K (high) quality setting consistently times out or returns nothing after a long wait. Cap the agent-facing image generation tool at medium (2K) so the agent can only request low (1K) or medium (2K).

- Agent-facing tool schema (`imageGenerationToolInputSchema`) and the Google size map drop the `high`/4K tier.
- The display/parse paths (`GenerateImageInputSchema`, `QUALITY_LABELS`) keep `high` so conversations that generated 4K images before this change still render correctly. Same rationale as the existing legacy `EditImageInputSchema`.

Also fixes an unrelated typecheck break already on main: a stale `setIsCreateProjectModalOpen` in `SidebarMenu.tsx` left over from the project to pod rename (#26340). Without it CI typecheck is red.

## Tests

Typecheck clean, lint/format clean, `mcp_servers_metadata` test passes. Verified the two schemas are wired as expected: the tool handler validates against the capped metadata schema (write path), while `isGenerateImageInputType` only drives rendering of stored actions (display path).

## Risk

Low. Agents can no longer pick 4K, which is the intended fix. Historical actions still parse and render via the permissive display schema.

## Deploy Plan

Standard deploy.