### PR TITLE
Share code between front/front-api

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/switch_contract.ts
+++ b/front-api/routes/poke/workspaces/[wId]/switch_contract.ts
@@ -1,110 +1,35 @@
-import {
-  dispatchPaygDisabled,
-  dispatchPaygEnabled,
-} from "@app/lib/api/metronome/credit_state_dispatcher";
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
-import { MAX_PAYG_CAP_DOLLARS } from "@app/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration";
-import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
-import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
+import type { SwitchContractErrorKind } from "@app/lib/api/poke/switch_contract";
 import {
-  ceilToHourISO,
-  floorToHourISO,
-  listMetronomePackages,
-} from "@app/lib/metronome/client";
-import {
-  ensureMetronomeCustomerForWorkspace,
-  provisionMetronomeContract,
-} from "@app/lib/metronome/contracts";
-import {
-  isPaygEligibleTier,
-  type MetronomePackageTier,
-  PAYG_ELIGIBLE_TIERS,
-} from "@app/lib/metronome/types";
-import { resolveCurrencyFromStripe } from "@app/lib/plans/billing_currency";
-import {
-  CREDIT_PRICED_BUSINESS_PLAN_CODE,
-  isEntreprisePlanPrefix,
-  isProPlanPrefix,
-  PRO_PLAN_SEAT_39_CODE,
-} from "@app/lib/plans/plan_codes";
-import {
-  getStripeCustomer,
-  scheduleSubscriptionCancellation,
-} from "@app/lib/plans/stripe";
+  SwitchContractBodySchema,
+  type SwitchContractError,
+  switchContract,
+} from "@app/lib/api/poke/switch_contract";
 import { PluginRunResource } from "@app/lib/resources/plugin_run_resource";
-import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
-import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
-import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import { renderLightWorkspaceType } from "@app/lib/workspace";
-import logger from "@app/logger/logger";
-import type { SupportedCurrency } from "@app/types/currency";
-import type { Result } from "@app/types/shared/result";
-import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
 export interface PokeSwitchContractSuccessResponseBody {
   success: boolean;
 }
 
-const SwitchContractBodySchema = z
-  .object({
-    planCode: z.string().min(1),
-    metronomePackageId: z.string().min(1),
-    // ISO timestamp. Required and validated to be ≥1h in the future when the
-    // selected package is enterprise-tier; forbidden otherwise (Pro/Business
-    // swap at the current hour).
-    startingAt: z.string().optional(),
-    // Optional: required for paid tiers (pro/business/enterprise), omitted
-    // for free-tier switches where Metronome contracts have no Stripe link.
-    stripeCustomerId: z.string().min(1).optional(),
-    paygEnabled: z.boolean().default(false),
-    paygCapDollars: z
-      .number()
-      .min(1, "PAYG cap must be at least $1")
-      .max(
-        MAX_PAYG_CAP_DOLLARS,
-        `PAYG cap cannot exceed $${MAX_PAYG_CAP_DOLLARS.toLocaleString()}`
-      )
-      .optional(),
-  })
-  .refine((data) => !data.paygEnabled || data.paygCapDollars !== undefined, {
-    message: "PAYG cap is required when Pay-as-you-go is enabled.",
-    path: ["paygCapDollars"],
-  });
-
-function classifyPlanCode(planCode: string): MetronomePackageTier {
-  if (isEntreprisePlanPrefix(planCode)) {
-    return "enterprise";
+function statusForKind(kind: SwitchContractErrorKind): {
+  status_code: 400 | 500 | 502;
+  type: "invalid_request_error" | "internal_server_error";
+} {
+  switch (kind) {
+    case "invalid_request":
+      return { status_code: 400, type: "invalid_request_error" };
+    case "metronome_api_error":
+    case "provision_inconsistent":
+      return { status_code: 502, type: "internal_server_error" };
+    case "payg_config_failed":
+      return { status_code: 500, type: "internal_server_error" };
+    default:
+      assertNever(kind);
   }
-  if (
-    planCode === CREDIT_PRICED_BUSINESS_PLAN_CODE ||
-    planCode === PRO_PLAN_SEAT_39_CODE
-  ) {
-    return "business";
-  }
-  if (isProPlanPrefix(planCode)) {
-    return "pro";
-  }
-  return "free";
-}
-
-function validatePlanPackageCompat(
-  planCode: string,
-  packageTier: MetronomePackageTier
-): Result<void, Error> {
-  const planTier = classifyPlanCode(planCode);
-  if (planTier !== packageTier) {
-    return new Err(
-      new Error(
-        `Plan ${planCode} (tier "${planTier}") does not match the selected ` +
-          `Metronome package (tier "${packageTier}").`
-      )
-    );
-  }
-  return new Ok(undefined);
 }
 
 // Mounted at /api/poke/workspaces/:wId/switch_contract.
@@ -132,312 +57,23 @@ app.post(
       await pluginRun.recordError(errorMessage);
       return apiError(ctx, {
         status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: errorMessage,
-        },
+        api_error: { type: "invalid_request_error", message: errorMessage },
       });
     }
     const body = validation.data;
 
-    // Workspace must be Metronome-billed (current sub Metronome-only) or
-    // Metronome-eligible (Metronome billing enabled). Stripe-billed workspaces
-    // that have opted into Metronome billing land here too — their Stripe sub
-    // is scheduled to end at the swap time further down.
-    const currentSubscription = auth.subscriptionResource();
-    const isCurrentlyMetronomeOnlyBilled =
-      currentSubscription?.isMetronomeOnlyBilled ?? false;
-    const metronomeBillingEnabled = await isMetronomeBillingEnabled(auth);
-    if (!isCurrentlyMetronomeOnlyBilled && !metronomeBillingEnabled) {
-      const errorMessage =
-        "switch_contract is only available for Metronome-billed workspaces. " +
-        "Migrate the workspace to Metronome billing before invoking this flow.";
-      await pluginRun.recordError(errorMessage);
+    const result = await switchContract({ auth, body });
+    if (result.isErr()) {
+      const err: SwitchContractError = result.error;
+      await pluginRun.recordError(err.message);
+      const { status_code, type } = statusForKind(err.kind);
       return apiError(ctx, {
-        status_code: 400,
-        api_error: { type: "invalid_request_error", message: errorMessage },
+        status_code,
+        api_error: { type, message: err.message },
       });
     }
 
-    const programmaticConfig =
-      await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
-
-    // Validate the Stripe customer exists before we touch Metronome.
-    // For free-tier switches the operator may omit the Stripe customer entirely
-    // — the contract is created without Stripe billing wired in.
-    let resolvedCurrency: SupportedCurrency | null = null;
-    if (body.stripeCustomerId) {
-      const stripeCustomer = await getStripeCustomer(body.stripeCustomerId);
-      if (!stripeCustomer) {
-        const errorMessage = `Stripe customer not found: ${body.stripeCustomerId}.`;
-        await pluginRun.recordError(errorMessage);
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: { type: "invalid_request_error", message: errorMessage },
-        });
-      }
-      resolvedCurrency = resolveCurrencyFromStripe({ stripeCustomer });
-    }
-
-    const customerResult = await ensureMetronomeCustomerForWorkspace({
-      workspace: renderLightWorkspaceType({ workspace: owner }),
-      stripeCustomerId: body.stripeCustomerId,
-    });
-    if (customerResult.isErr()) {
-      const errorMessage = `Failed to ensure Metronome customer: ${customerResult.error.message}`;
-      await pluginRun.recordError(errorMessage);
-      return apiError(ctx, {
-        status_code: 502,
-        api_error: { type: "internal_server_error", message: errorMessage },
-      });
-    }
-    const { metronomeCustomerId } = customerResult.value;
-
-    const packagesResult = await listMetronomePackages();
-    if (packagesResult.isErr()) {
-      const errorMessage = `Failed to list Metronome packages: ${packagesResult.error.message}`;
-      await pluginRun.recordError(errorMessage);
-      return apiError(ctx, {
-        status_code: 502,
-        api_error: { type: "internal_server_error", message: errorMessage },
-      });
-    }
-    const pkg = packagesResult.value.find(
-      (p) => p.id === body.metronomePackageId
-    );
-    if (!pkg) {
-      const errorMessage = `Metronome package not found: ${body.metronomePackageId}`;
-      await pluginRun.recordError(errorMessage);
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: { type: "invalid_request_error", message: errorMessage },
-      });
-    }
-    // Free packages are currency-agnostic (price is 0) — skip the currency
-    // match check. For paid tiers, the resolved Stripe currency must match the
-    // package's currency.
-    if (
-      pkg.tier !== "free" &&
-      resolvedCurrency &&
-      pkg.currency !== resolvedCurrency
-    ) {
-      const errorMessage =
-        `Metronome package ${body.metronomePackageId} is ${pkg.currency.toUpperCase()}, ` +
-        `but Stripe customer ${body.stripeCustomerId} resolves to ` +
-        `${resolvedCurrency.toUpperCase()}. Pick a ${resolvedCurrency.toUpperCase()} package.`;
-      await pluginRun.recordError(errorMessage);
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: { type: "invalid_request_error", message: errorMessage },
-      });
-    }
-    const compatResult = validatePlanPackageCompat(body.planCode, pkg.tier);
-    if (compatResult.isErr()) {
-      await pluginRun.recordError(compatResult.error.message);
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: compatResult.error.message,
-        },
-      });
-    }
-
-    if (body.paygEnabled && !isPaygEligibleTier(pkg.tier)) {
-      const errorMessage = `Pay-as-you-go can only be enabled for ${PAYG_ELIGIBLE_TIERS.join(
-        " or "
-      )} contracts.`;
-      await pluginRun.recordError(errorMessage);
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: { type: "invalid_request_error", message: errorMessage },
-      });
-    }
-
-    // Resolve when the swap happens.
-    //  - startingAt provided: schedule at the requested moment, ceiled to the
-    //    next hour boundary. Must be ≥1h in the future.
-    //  - startingAt omitted: swap immediately at the current hour boundary
-    //    (supported for all tiers, including enterprise via the operator's
-    //    explicit "start immediately" opt-in).
-    let startingAtDate: Date;
-    let swapAt: "current-hour" | "next-hour";
-    if (body.startingAt) {
-      const requestedStartMs = Date.parse(body.startingAt);
-      if (Number.isNaN(requestedStartMs)) {
-        const errorMessage = "startingAt is not a valid ISO timestamp.";
-        await pluginRun.recordError(errorMessage);
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: { type: "invalid_request_error", message: errorMessage },
-        });
-      }
-      const ONE_HOUR_MS = 60 * 60 * 1000;
-      if (requestedStartMs < Date.now() + ONE_HOUR_MS) {
-        const errorMessage =
-          "startingAt must be at least one hour in the future.";
-        await pluginRun.recordError(errorMessage);
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: { type: "invalid_request_error", message: errorMessage },
-        });
-      }
-      startingAtDate = new Date(requestedStartMs);
-      swapAt = "next-hour";
-    } else {
-      startingAtDate = new Date();
-      swapAt = "current-hour";
-    }
-
-    const packageAlias = pkg.aliases[0];
-    if (!packageAlias) {
-      const errorMessage = `Package ${pkg.id} has no alias to switch to.`;
-      await pluginRun.recordError(errorMessage);
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: { type: "invalid_request_error", message: errorMessage },
-      });
-    }
-
-    const provisionResult = await provisionMetronomeContract({
-      metronomeCustomerId,
-      workspace: renderLightWorkspaceType({ workspace: owner }),
-      packageAlias,
-      startingAt: startingAtDate,
-      swapAt,
-      enableStripeBilling: body.stripeCustomerId !== undefined,
-      planCode: body.planCode,
-    });
-    if (provisionResult.isErr()) {
-      const errorMessage = `Failed to provision Metronome contract: ${provisionResult.error.message}`;
-      await pluginRun.recordError(errorMessage);
-      return apiError(ctx, {
-        status_code: 502,
-        api_error: { type: "internal_server_error", message: errorMessage },
-      });
-    }
-    const { metronomeContractId } = provisionResult.value;
-
-    const alignedStart = new Date(
-      swapAt === "current-hour"
-        ? floorToHourISO(startingAtDate)
-        : ceilToHourISO(startingAtDate)
-    );
-
-    try {
-      await SubscriptionResource.createPendingMetronomeContract({
-        workspaceModelId: owner.id,
-        planCode: body.planCode,
-        metronomeContractId,
-        startDate: alignedStart,
-      });
-    } catch (err) {
-      const errorMessage =
-        `Provisioned Metronome contract ${metronomeContractId} but failed to ` +
-        `create pending subscription: ${err instanceof Error ? err.message : String(err)}. ` +
-        "Manual cleanup may be required.";
-      await pluginRun.recordError(errorMessage);
-      return apiError(ctx, {
-        status_code: 502,
-        api_error: { type: "internal_server_error", message: errorMessage },
-      });
-    }
-
-    // If the workspace is currently Stripe-billed (incl. shadow-Metronome),
-    // schedule the Stripe sub to cancel at the swap moment so the two rails
-    // don't double-bill.
-    const stripeSubscriptionIdToCancel =
-      currentSubscription?.stripeSubscriptionId ?? null;
-    if (stripeSubscriptionIdToCancel) {
-      try {
-        await scheduleSubscriptionCancellation({
-          stripeSubscriptionId: stripeSubscriptionIdToCancel,
-          cancelAt: alignedStart,
-        });
-      } catch (err) {
-        const errorMessage =
-          `Provisioned Metronome contract ${metronomeContractId} and pending ` +
-          `subscription, but failed to schedule cancellation of Stripe ` +
-          `subscription ${stripeSubscriptionIdToCancel}: ` +
-          `${err instanceof Error ? err.message : String(err)}. ` +
-          `URGENT: cancel the Stripe subscription manually at ${alignedStart.toISOString()} ` +
-          "to avoid double-billing.";
-        await pluginRun.recordError(errorMessage);
-        return apiError(ctx, {
-          status_code: 502,
-          api_error: { type: "internal_server_error", message: errorMessage },
-        });
-      }
-    }
-
-    // Ensure the workspace has a WorkOS organization for any paid tier.
-    // Idempotent — `contract.start` webhook re-runs this as a safety net.
-    if (pkg.tier !== "free") {
-      const workosResult = await getOrCreateWorkOSOrganization(
-        renderLightWorkspaceType({ workspace: owner })
-      );
-      if (workosResult.isErr()) {
-        logger.error(
-          {
-            workspaceId: owner.sId,
-            metronomeContractId,
-            err: workosResult.error,
-          },
-          "[switch_contract] Failed to provision WorkOS organization"
-        );
-      }
-    }
-
-    const paygCapMicroUsd =
-      body.paygEnabled && body.paygCapDollars !== undefined
-        ? Math.round(body.paygCapDollars * 1_000_000)
-        : null;
-    if (programmaticConfig) {
-      const updateResult = await programmaticConfig.updateConfiguration(auth, {
-        paygCapMicroUsd,
-      });
-      if (updateResult.isErr()) {
-        const errorMessage = `Failed to update PAYG configuration: ${updateResult.error.message}`;
-        await pluginRun.recordError(errorMessage);
-        return apiError(ctx, {
-          status_code: 500,
-          api_error: { type: "internal_server_error", message: errorMessage },
-        });
-      }
-    } else if (paygCapMicroUsd !== null) {
-      const createResult = await ProgrammaticUsageConfigurationResource.makeNew(
-        auth,
-        {
-          freeCreditMicroUsd: null,
-          defaultDiscountPercent: 0,
-          paygCapMicroUsd,
-          dailyCapMicroUsd: null,
-        }
-      );
-      if (createResult.isErr()) {
-        const errorMessage = `Failed to create PAYG configuration: ${createResult.error.message}`;
-        await pluginRun.recordError(errorMessage);
-        return apiError(ctx, {
-          status_code: 500,
-          api_error: { type: "internal_server_error", message: errorMessage },
-        });
-      }
-    }
-
-    // Note: the Metronome AWU PAYG cap alert is no longer synced from this
-    // endpoint. AWU concerns (discount, AWU PAYG cap) live on
-    // `credit_usage_configuration` and are managed via the
-    // "Manage Credit Usage Configuration" poke plugin.
-
-    const workspaceResource = await WorkspaceResource.fetchById(owner.sId);
-    if (workspaceResource) {
-      if (body.paygEnabled) {
-        await dispatchPaygEnabled({ workspace: workspaceResource });
-      } else {
-        await dispatchPaygDisabled({ workspace: workspaceResource });
-      }
-    }
-
+    const { metronomeContractId } = result.value;
     const paygStatus = body.paygEnabled
       ? ` PAYG enabled with $${body.paygCapDollars} cap.`
       : "";

--- a/front-api/routes/w/[wId]/credits/awu-pool-summary.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-summary.ts
@@ -1,23 +1,44 @@
-import {
-  ceilToMidnightUTC,
-  listMetronomeBalances,
-  listMetronomeDraftInvoices,
-} from "@app/lib/metronome/client";
-import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
-import { getActiveContract } from "@app/lib/metronome/plan_type";
-import {
-  getProductSeatTypes,
-  getSeatTypesByProductIdFromContract,
-} from "@app/lib/metronome/seat_types";
+import type {
+  AwuPoolSummaryError,
+  AwuPoolSummaryResponseBody,
+} from "@app/lib/api/credits/awu_pool_summary";
+import { getAwuPoolSummary } from "@app/lib/api/credits/awu_pool_summary";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import type { Context } from "hono";
 
-export type AwuPoolSummaryResponseBody = {
-  totalRemainingCredits: number;
-  totalActiveCredits: number;
-  resetDate: string;
-};
+function summaryErrorToApi(ctx: Context, err: AwuPoolSummaryError) {
+  switch (err.type) {
+    case "not_configured":
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Workspace is not configured for Metronome billing.",
+        },
+      });
+    case "balances_fetch_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome balances: ${err.cause?.message ?? ""}`,
+        },
+      });
+    case "invoices_fetch_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome invoices: ${err.cause?.message ?? ""}`,
+        },
+      });
+    default:
+      assertNever(err.type);
+  }
+}
 
 // Mounted at /api/w/:wId/credits/awu-pool-summary.
 const app = workspaceApp();
@@ -36,113 +57,11 @@ app.get("/", async (ctx): HandlerResult<AwuPoolSummaryResponseBody> => {
     });
   }
 
-  const workspace = auth.getNonNullableWorkspace();
-  const subscription = auth.subscription();
-  const { metronomeCustomerId } = workspace;
-  if (!metronomeCustomerId || !subscription?.metronomeContractId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Workspace is not configured for Metronome billing.",
-      },
-    });
+  const result = await getAwuPoolSummary(auth);
+  if (result.isErr()) {
+    return summaryErrorToApi(ctx, result.error);
   }
-  const { metronomeContractId } = subscription;
-
-  const [balancesResult, invoicesResult] = await Promise.all([
-    listMetronomeBalances(metronomeCustomerId),
-    listMetronomeDraftInvoices(metronomeCustomerId),
-  ]);
-
-  if (balancesResult.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: `Failed to retrieve Metronome balances: ${balancesResult.error.message}`,
-      },
-    });
-  }
-  if (invoicesResult.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: `Failed to retrieve Metronome invoices: ${invoicesResult.error.message}`,
-      },
-    });
-  }
-
-  const now = Date.now();
-
-  const currentInvoice = invoicesResult.value.find((inv) => {
-    if (inv.contract_id !== metronomeContractId) {
-      return false;
-    }
-    if (!inv.start_timestamp || !inv.end_timestamp) {
-      return false;
-    }
-    const startMs = new Date(inv.start_timestamp).getTime();
-    const endMs = new Date(inv.end_timestamp).getTime();
-    return startMs <= now && now < endMs;
-  });
-
-  if (!currentInvoice?.start_timestamp || !currentInvoice.end_timestamp) {
-    return ctx.json({
-      totalRemainingCredits: 0,
-      totalActiveCredits: 0,
-      resetDate: "",
-    });
-  }
-
-  const resetDate = ceilToMidnightUTC(
-    new Date(currentInvoice.end_timestamp)
-  ).toISOString();
-
-  // Filter to active, non-seat AWU pool credits and commits. The set of
-  // seat product IDs is derived from the contract's tagged subscriptions
-  // (via the `DUST_SEAT_TYPE` custom field) rather than a hardcoded list.
-  const awuCreditTypeId = getCreditTypeAwuId();
-  const activeContract = await getActiveContract(workspace.sId);
-  const productSeatTypes = await getProductSeatTypes();
-  const seatProductIds = activeContract
-    ? new Set(
-        getSeatTypesByProductIdFromContract(
-          activeContract,
-          productSeatTypes
-        ).keys()
-      )
-    : new Set<string>();
-  const awuBalances = balancesResult.value.filter(
-    (entry) =>
-      entry.access_schedule?.credit_type?.id === awuCreditTypeId &&
-      !seatProductIds.has(entry.product.id) &&
-      (entry.contract?.id === metronomeContractId || !entry.contract)
-  );
-
-  let totalRemainingCredits = 0;
-  let totalActiveCredits = 0;
-  for (const entry of awuBalances) {
-    const scheduleItems = entry.access_schedule?.schedule_items ?? [];
-    const isActive = scheduleItems.some((item) => {
-      const itemStartMs = new Date(item.starting_at).getTime();
-      const itemEndMs = new Date(item.ending_before).getTime();
-      return itemStartMs <= now && now < itemEndMs;
-    });
-    if (isActive) {
-      totalRemainingCredits += entry.balance ?? 0;
-      for (const item of scheduleItems) {
-        totalActiveCredits += item.amount;
-      }
-    }
-  }
-
-  return ctx.json({
-    totalRemainingCredits,
-    totalActiveCredits,
-    resetDate,
-  });
+  return ctx.json(result.value);
 });
 
 export default app;

--- a/front-api/routes/w/[wId]/credits/metronome-balances.ts
+++ b/front-api/routes/w/[wId]/credits/metronome-balances.ts
@@ -1,18 +1,39 @@
-import { metronomeBalanceToDisplayData } from "@app/lib/api/credits/metronome_balances";
-import { listMetronomeBalances } from "@app/lib/metronome/client";
-import { getCreditTypeProgrammaticUsdId } from "@app/lib/metronome/constants";
-import { isMetronomeExcessCredit } from "@app/lib/metronome/types";
-import type {
-  CreditDisplayData,
-  GetCreditsResponseBody,
-} from "@app/types/credits";
+import type { MetronomeBalancesError } from "@app/lib/api/credits/metronome_balances";
+import { getMetronomeBalances } from "@app/lib/api/credits/metronome_balances";
+import type { GetCreditsResponseBody } from "@app/types/credits";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import type { Context } from "hono";
+
+function balancesErrorToApi(ctx: Context, err: MetronomeBalancesError) {
+  switch (err.type) {
+    case "not_configured":
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Workspace is not configured for Metronome billing.",
+        },
+      });
+    case "balances_fetch_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome balances: ${err.cause?.message ?? ""}`,
+        },
+      });
+    default:
+      assertNever(err.type);
+  }
+}
 
 // Mounted at /api/w/:wId/credits/metronome-balances.
 const app = workspaceApp();
 
-app.get("/", async (ctx) => {
+app.get("/", async (ctx): HandlerResult<GetCreditsResponseBody> => {
   const auth = ctx.get("auth");
 
   if (!auth.isAdmin()) {
@@ -26,40 +47,11 @@ app.get("/", async (ctx) => {
     });
   }
 
-  const workspace = auth.getNonNullableWorkspace();
-  const { metronomeCustomerId } = workspace;
-  if (!metronomeCustomerId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Workspace is not configured for Metronome billing.",
-      },
-    });
-  }
-
-  const result = await listMetronomeBalances(metronomeCustomerId);
+  const result = await getMetronomeBalances(auth);
   if (result.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: `Failed to retrieve Metronome balances: ${result.error.message}`,
-      },
-    });
+    return balancesErrorToApi(ctx, result.error);
   }
-
-  const programmaticUsdCreditTypeId = getCreditTypeProgrammaticUsdId();
-  const credits: CreditDisplayData[] = result.value
-    .filter(
-      (entry) =>
-        entry.access_schedule?.credit_type?.id ===
-          programmaticUsdCreditTypeId && !isMetronomeExcessCredit(entry)
-    )
-    .map(metronomeBalanceToDisplayData);
-
-  const body: GetCreditsResponseBody = { credits };
-  return ctx.json(body);
+  return ctx.json(result.value);
 });
 
 export default app;

--- a/front-api/routes/w/[wId]/metronome/contract.ts
+++ b/front-api/routes/w/[wId]/metronome/contract.ts
@@ -1,31 +1,15 @@
-import { getMetronomeContractById } from "@app/lib/metronome/client";
+import type { MetronomeContractSummary } from "@app/lib/api/credits/metronome_contract";
 import {
-  cancelWorkspaceContractAtPeriodEnd,
-  reactivateWorkspaceContract,
-} from "@app/lib/metronome/contract_lifecycle";
-import { parseMauTiers } from "@app/lib/metronome/mau_sync";
-import { hasContractSeatSubscription } from "@app/lib/metronome/seats";
-import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+  applyContractLifecycleAction,
+  getMetronomeContractSummary,
+} from "@app/lib/api/credits/metronome_contract";
+import type { ContractLifecycleError } from "@app/lib/metronome/contract_lifecycle";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import type { Context } from "hono";
 import { z } from "zod";
-
-export type MetronomeContractSummary = {
-  planFamily: "pro" | "enterprise";
-  /**
-   * MAU tier boundaries parsed from the MAU_TIERS contract custom field.
-   * `null` for simple MAU (no tiering) or non-enterprise.
-   * Each tier has `start` (inclusive, 1-indexed) and `end` (exclusive, null = unlimited).
-   */
-  mauTiers: Array<{ start: number; end: number | null }> | null;
-  /** ms epoch — set when the contract is scheduled to end (cancellation or fixed term). */
-  contractEndingAtMs: number | null;
-  /** True if the contract has at least one seat-billed subscription */
-  hasSeatSubscription: boolean;
-};
 
 export type GetMetronomeContractResponseBody = {
   contract: MetronomeContractSummary | null;
@@ -39,6 +23,19 @@ export const PatchMetronomeContractRequestBody = z.object({
   action: z.enum(["cancel", "reactivate"]),
 });
 
+function lifecycleErrorToApi(ctx: Context, err: ContractLifecycleError) {
+  return apiError(ctx, {
+    status_code: err.kind === "invalid_state" ? 400 : 502,
+    api_error: {
+      type:
+        err.kind === "invalid_state"
+          ? "subscription_state_invalid"
+          : "internal_server_error",
+      message: err.message,
+    },
+  });
+}
+
 // Mounted at /api/w/:wId/metronome/contract.
 const app = workspaceApp();
 
@@ -48,58 +45,17 @@ app.get(
   async (ctx): HandlerResult<GetMetronomeContractResponseBody> => {
     const auth = ctx.get("auth");
 
-    const subscription = auth.subscription();
-    const owner = auth.workspace();
-    if (!subscription || !owner) {
-      return ctx.json({ contract: null });
-    }
-
-    const { metronomeContractId } = subscription;
-    const { metronomeCustomerId } = owner;
-    if (!metronomeContractId || !metronomeCustomerId) {
-      return ctx.json({ contract: null });
-    }
-
-    const contractResult = await getMetronomeContractById({
-      metronomeCustomerId,
-      metronomeContractId,
-    });
-    if (contractResult.isErr()) {
+    const result = await getMetronomeContractSummary(auth);
+    if (result.isErr()) {
       return apiError(ctx, {
         status_code: 502,
         api_error: {
           type: "internal_server_error",
-          message: `Failed to fetch Metronome contract: ${contractResult.error.message}`,
+          message: `Failed to fetch Metronome contract: ${result.error.message}`,
         },
       });
     }
-
-    const contract = contractResult.value;
-
-    const planFamily: "pro" | "enterprise" = isEntreprisePlanPrefix(
-      subscription.plan.code
-    )
-      ? "enterprise"
-      : "pro";
-
-    const mauTiersField = contract.custom_fields?.MAU_TIERS;
-    const parsed = parseMauTiers(mauTiersField);
-    const mauTiers = parsed
-      ? parsed.map((t) => ({ start: t.start, end: t.end ?? null }))
-      : null;
-
-    const contractEndingAtMs = contract.ending_before
-      ? new Date(contract.ending_before).getTime()
-      : null;
-
-    return ctx.json({
-      contract: {
-        planFamily,
-        mauTiers,
-        contractEndingAtMs,
-        hasSeatSubscription: await hasContractSeatSubscription(contract),
-      },
-    });
+    return ctx.json({ contract: result.value });
   }
 );
 
@@ -111,43 +67,10 @@ app.patch(
     const auth = ctx.get("auth");
     const { action } = ctx.req.valid("json");
 
-    switch (action) {
-      case "cancel": {
-        const result = await cancelWorkspaceContractAtPeriodEnd(auth);
-        if (result.isErr()) {
-          return apiError(ctx, {
-            status_code: result.error.kind === "invalid_state" ? 400 : 502,
-            api_error: {
-              type:
-                result.error.kind === "invalid_state"
-                  ? "subscription_state_invalid"
-                  : "internal_server_error",
-              message: result.error.message,
-            },
-          });
-        }
-        break;
-      }
-      case "reactivate": {
-        const result = await reactivateWorkspaceContract(auth);
-        if (result.isErr()) {
-          return apiError(ctx, {
-            status_code: result.error.kind === "invalid_state" ? 400 : 502,
-            api_error: {
-              type:
-                result.error.kind === "invalid_state"
-                  ? "subscription_state_invalid"
-                  : "internal_server_error",
-              message: result.error.message,
-            },
-          });
-        }
-        break;
-      }
-      default:
-        assertNever(action);
+    const result = await applyContractLifecycleAction(auth, action);
+    if (result.isErr()) {
+      return lifecycleErrorToApi(ctx, result.error);
     }
-
     return ctx.json({ success: true });
   }
 );

--- a/front-api/routes/w/[wId]/seats/plan.ts
+++ b/front-api/routes/w/[wId]/seats/plan.ts
@@ -1,183 +1,56 @@
 import type {
-  SeatBillingFrequency,
+  SeatPlanError,
   SeatPlanResponseBody,
-  SeatTypeInfo,
 } from "@app/lib/api/credits/seat_plan";
-import { getSeatBillingFrequency } from "@app/lib/api/credits/seat_plan";
-import { amountCents } from "@app/lib/metronome/amounts";
-import { getMetronomeClient } from "@app/lib/metronome/client";
-import { getCreditTypeFromContract } from "@app/lib/metronome/coupons";
-import { getActiveContract } from "@app/lib/metronome/plan_type";
-import {
-  getAwuAllocationInfoForSeatType,
-  getProductSeatTypes,
-  getSeatSubscriptionsFromContract,
-  getSeatTypesByProductIdFromContract,
-  isMauContract,
-} from "@app/lib/metronome/seat_types";
-import logger from "@app/logger/logger";
-import type { MembershipSeatType } from "@app/types/memberships";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { getSeatPlan } from "@app/lib/api/credits/seat_plan";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import type { Context } from "hono";
 
-// Mounted at /api/w/:wId/seats/plan.
-const app = workspaceApp();
-
-app.get("/", async (ctx) => {
-  const auth = ctx.get("auth");
-
-  const workspace = auth.getNonNullableWorkspace();
-  const contract = await getActiveContract(workspace.sId);
-
-  if (!contract || !contract.rate_card_id) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "internal_server_error",
-        message: "Workspace is not configured for Metronome billing.",
-      },
-    });
-  }
-
-  const creditTypeResult = await getCreditTypeFromContract(contract);
-  if (creditTypeResult.isErr()) {
-    logger.warn(
-      {
-        workspaceId: workspace.sId,
-        rateCardId: contract.rate_card_id,
-        err: creditTypeResult.error,
-      },
-      "[Metronome] Failed to resolve contract currency for seat plan"
-    );
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Failed to resolve currency for seat plan.",
-      },
-    });
-  }
-  const { currency } = creditTypeResult.value;
-
-  // MAU contracts don't bill per-seat — return an empty seat plan up-front.
-  if (isMauContract(contract)) {
-    const empty: SeatPlanResponseBody = {};
-    return ctx.json(empty);
-  }
-
-  // Build `productId → seatType` from contract subscriptions so we can resolve
-  // rate-schedule entries without comparing product names or IDs.
-  const productSeatTypes = await getProductSeatTypes();
-  const seatTypesByProductId = getSeatTypesByProductIdFromContract(
-    contract,
-    productSeatTypes
-  );
-  if (seatTypesByProductId.size === 0) {
-    const empty: SeatPlanResponseBody = {};
-    return ctx.json(empty);
-  }
-
-  // Resolve each seat's billing frequency from the matching subscription on
-  // the contract. Keep the full Metronome cadence in the response so callers
-  // don't need to assume that all non-annual seats are monthly.
-  const billingFrequencyBySeatType = new Map<
-    MembershipSeatType,
-    SeatBillingFrequency
-  >();
-  const seatSubscriptions = getSeatSubscriptionsFromContract(
-    contract,
-    productSeatTypes
-  );
-  for (const [seatType, sub] of seatSubscriptions) {
-    billingFrequencyBySeatType.set(
-      seatType,
-      getSeatBillingFrequency(sub.subscription_rate.billing_frequency)
-    );
-  }
-
-  const monthlyPriceCentsBySeatType = new Map<MembershipSeatType, number>();
-  const nameBySeatType = new Map<MembershipSeatType, string>();
-  try {
-    const startingAt = new Date().toISOString();
-    let nextPage: string | null | undefined = undefined;
-    do {
-      const rateSchedule =
-        await getMetronomeClient().v1.contracts.rateCards.retrieveRateSchedule({
-          rate_card_id: contract.rate_card_id,
-          starting_at: startingAt,
-          ...(nextPage ? { next_page: nextPage } : {}),
-        });
-
-      for (const entry of rateSchedule.data ?? []) {
-        if (!entry.entitled || entry.rate.price === undefined) {
-          continue;
-        }
-        const seatType = seatTypesByProductId.get(entry.product_id);
-        if (!seatType) {
-          continue;
-        }
-        // Metronome quotes prices in its per-currency native unit (USD in
-        // cents, others in whole units); normalize to actual cents here.
-        // TODO (https://github.com/dust-tt/tasks/issues/8072): Add annual pricing
-        monthlyPriceCentsBySeatType.set(
-          seatType,
-          amountCents(entry.rate.price, currency)
-        );
-        nameBySeatType.set(seatType, entry.product_name);
-      }
-
-      nextPage = rateSchedule.next_page;
-    } while (
-      nextPage &&
-      monthlyPriceCentsBySeatType.size < seatTypesByProductId.size
-    );
-  } catch (err) {
-    const normalized = normalizeError(err);
-    logger.warn(
-      {
-        workspaceId: workspace.sId,
-        rateCardId: contract.rate_card_id,
-        err: normalized,
-      },
-      "[Metronome] Failed to fetch rate schedule for seat products"
-    );
-    return apiError(
-      ctx,
-      {
+function seatPlanErrorToApi(ctx: Context, err: SeatPlanError) {
+  switch (err.type) {
+    case "not_configured":
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "internal_server_error",
+          message: "Workspace is not configured for Metronome billing.",
+        },
+      });
+    case "currency_resolution_failed":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to resolve currency for seat plan.",
+        },
+      });
+    case "rate_schedule_fetch_failed":
+      return apiError(ctx, {
         status_code: 500,
         api_error: {
           type: "internal_server_error",
           message: "Failed to fetch rate schedule for seat products.",
         },
-      },
-      normalized
-    );
+      });
+    default:
+      assertNever(err.type);
   }
+}
 
-  const response: SeatPlanResponseBody = {};
-  for (const seatType of seatTypesByProductId.values()) {
-    const priceCents = monthlyPriceCentsBySeatType.get(seatType);
-    const name = nameBySeatType.get(seatType);
-    if (priceCents === undefined || name === undefined) {
-      continue;
-    }
-    const awuAllocation = getAwuAllocationInfoForSeatType(
-      contract,
-      seatType,
-      productSeatTypes
-    );
-    const info: SeatTypeInfo = {
-      name,
-      awuCredits: awuAllocation.credits,
-      awuCreditsPeriod: awuAllocation.period,
-      priceCents,
-      currency,
-      billingFrequency: billingFrequencyBySeatType.get(seatType) ?? "monthly",
-    };
-    response[seatType] = info;
+// Mounted at /api/w/:wId/seats/plan.
+const app = workspaceApp();
+
+app.get("/", async (ctx): HandlerResult<SeatPlanResponseBody> => {
+  const auth = ctx.get("auth");
+
+  const result = await getSeatPlan(auth);
+  if (result.isErr()) {
+    return seatPlanErrorToApi(ctx, result.error);
   }
-  return ctx.json(response);
+  return ctx.json(result.value);
 });
 
 export default app;

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -10,9 +10,8 @@ import {
   getProductSeatTypes,
   getSeatTypesByProductIdFromContract,
 } from "@app/lib/metronome/seat_types";
-import { apiError } from "@app/logger/withlogging";
-import type { WithAPIErrorResponse } from "@app/types/error";
-import type { NextApiRequest, NextApiResponse } from "next";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 
 export type AwuPoolSummaryResponseBody = {
   totalRemainingCredits: number;
@@ -20,142 +19,115 @@ export type AwuPoolSummaryResponseBody = {
   resetDate: string;
 };
 
-export async function handleAwuPoolSummaryRequest(
-  req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<AwuPoolSummaryResponseBody>>,
+export class AwuPoolSummaryError extends Error {
+  constructor(
+    readonly type:
+      | "not_configured"
+      | "balances_fetch_failed"
+      | "invoices_fetch_failed",
+    readonly cause?: Error
+  ) {
+    super(type);
+  }
+}
+
+export async function getAwuPoolSummary(
   auth: Authenticator
-): Promise<void> {
-  if (!auth.isAdmin()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users that are `admins` for the current workspace can view credits.",
-      },
+): Promise<Result<AwuPoolSummaryResponseBody, AwuPoolSummaryError>> {
+  const workspace = auth.getNonNullableWorkspace();
+  const subscription = auth.subscription();
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId || !subscription?.metronomeContractId) {
+    return new Err(new AwuPoolSummaryError("not_configured"));
+  }
+  const { metronomeContractId } = subscription;
+
+  const [balancesResult, invoicesResult] = await Promise.all([
+    listMetronomeBalances(metronomeCustomerId),
+    listMetronomeDraftInvoices(metronomeCustomerId),
+  ]);
+
+  if (balancesResult.isErr()) {
+    return new Err(
+      new AwuPoolSummaryError("balances_fetch_failed", balancesResult.error)
+    );
+  }
+  if (invoicesResult.isErr()) {
+    return new Err(
+      new AwuPoolSummaryError("invoices_fetch_failed", invoicesResult.error)
+    );
+  }
+
+  const now = Date.now();
+
+  // Find the canonical billing period end from the current draft invoice.
+  const currentInvoice = invoicesResult.value.find((inv) => {
+    if (inv.contract_id !== metronomeContractId) {
+      return false;
+    }
+    if (!inv.start_timestamp || !inv.end_timestamp) {
+      return false;
+    }
+    const startMs = new Date(inv.start_timestamp).getTime();
+    const endMs = new Date(inv.end_timestamp).getTime();
+    return startMs <= now && now < endMs;
+  });
+
+  if (!currentInvoice?.start_timestamp || !currentInvoice.end_timestamp) {
+    return new Ok({
+      totalRemainingCredits: 0,
+      totalActiveCredits: 0,
+      resetDate: "",
     });
   }
 
-  switch (req.method) {
-    case "GET": {
-      const workspace = auth.getNonNullableWorkspace();
-      const subscription = auth.subscription();
-      const { metronomeCustomerId } = workspace;
-      if (!metronomeCustomerId || !subscription?.metronomeContractId) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: "Workspace is not configured for Metronome billing.",
-          },
-        });
+  const resetDate = ceilToMidnightUTC(
+    new Date(currentInvoice.end_timestamp)
+  ).toISOString();
+
+  // Filter to active, non-seat AWU pool credits and commits. The set of
+  // seat product IDs is derived from the contract's tagged subscriptions
+  // (via the `DUST_SEAT_TYPE` custom field) rather than a hardcoded list.
+  // The contract filter prevents sandbox prepaid commits on other contracts
+  // from inflating the balance.
+  const awuCreditTypeId = getCreditTypeAwuId();
+  const activeContract = await getActiveContract(workspace.sId);
+  const productSeatTypes = await getProductSeatTypes();
+  const seatProductIds = activeContract
+    ? new Set(
+        getSeatTypesByProductIdFromContract(
+          activeContract,
+          productSeatTypes
+        ).keys()
+      )
+    : new Set<string>();
+  const awuBalances = balancesResult.value.filter(
+    (entry) =>
+      entry.access_schedule?.credit_type?.id === awuCreditTypeId &&
+      !seatProductIds.has(entry.product.id) &&
+      (entry.contract?.id === metronomeContractId || !entry.contract)
+  );
+
+  let totalRemainingCredits = 0;
+  let totalActiveCredits = 0;
+  for (const entry of awuBalances) {
+    const scheduleItems = entry.access_schedule?.schedule_items ?? [];
+    const isActive = scheduleItems.some((item) => {
+      const itemStartMs = new Date(item.starting_at).getTime();
+      const itemEndMs = new Date(item.ending_before).getTime();
+      return itemStartMs <= now && now < itemEndMs;
+    });
+    if (isActive) {
+      totalRemainingCredits += entry.balance ?? 0;
+      for (const item of scheduleItems) {
+        totalActiveCredits += item.amount;
       }
-      const { metronomeContractId } = subscription;
-
-      const [balancesResult, invoicesResult] = await Promise.all([
-        listMetronomeBalances(metronomeCustomerId),
-        listMetronomeDraftInvoices(metronomeCustomerId),
-      ]);
-
-      if (balancesResult.isErr()) {
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: `Failed to retrieve Metronome balances: ${balancesResult.error.message}`,
-          },
-        });
-      }
-      if (invoicesResult.isErr()) {
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: `Failed to retrieve Metronome invoices: ${invoicesResult.error.message}`,
-          },
-        });
-      }
-
-      const now = Date.now();
-
-      // Find the canonical billing period end from the current draft invoice.
-      const currentInvoice = invoicesResult.value.find((inv) => {
-        if (inv.contract_id !== metronomeContractId) {
-          return false;
-        }
-        if (!inv.start_timestamp || !inv.end_timestamp) {
-          return false;
-        }
-        const startMs = new Date(inv.start_timestamp).getTime();
-        const endMs = new Date(inv.end_timestamp).getTime();
-        return startMs <= now && now < endMs;
-      });
-
-      if (!currentInvoice?.start_timestamp || !currentInvoice.end_timestamp) {
-        return res.status(200).json({
-          totalRemainingCredits: 0,
-          totalActiveCredits: 0,
-          resetDate: "",
-        });
-      }
-
-      const resetDate = ceilToMidnightUTC(
-        new Date(currentInvoice.end_timestamp)
-      ).toISOString();
-
-      // Filter to active, non-seat AWU pool credits and commits. The set of
-      // seat product IDs is derived from the contract's tagged subscriptions
-      // (via the `DUST_SEAT_TYPE` custom field) rather than a hardcoded list.
-      // The contract filter prevents sandbox prepaid commits on other contracts
-      // from inflating the balance.
-      const awuCreditTypeId = getCreditTypeAwuId();
-      const activeContract = await getActiveContract(workspace.sId);
-      const productSeatTypes = await getProductSeatTypes();
-      const seatProductIds = activeContract
-        ? new Set(
-            getSeatTypesByProductIdFromContract(
-              activeContract,
-              productSeatTypes
-            ).keys()
-          )
-        : new Set<string>();
-      const awuBalances = balancesResult.value.filter(
-        (entry) =>
-          entry.access_schedule?.credit_type?.id === awuCreditTypeId &&
-          !seatProductIds.has(entry.product.id) &&
-          (entry.contract?.id === metronomeContractId || !entry.contract)
-      );
-
-      let totalRemainingCredits = 0;
-      let totalActiveCredits = 0;
-      for (const entry of awuBalances) {
-        const scheduleItems = entry.access_schedule?.schedule_items ?? [];
-        const isActive = scheduleItems.some((item) => {
-          const itemStartMs = new Date(item.starting_at).getTime();
-          const itemEndMs = new Date(item.ending_before).getTime();
-          return itemStartMs <= now && now < itemEndMs;
-        });
-        if (isActive) {
-          totalRemainingCredits += entry.balance ?? 0;
-          for (const item of scheduleItems) {
-            totalActiveCredits += item.amount;
-          }
-        }
-      }
-
-      return res.status(200).json({
-        totalRemainingCredits,
-        totalActiveCredits,
-        resetDate,
-      });
     }
-    default:
-      return apiError(req, res, {
-        status_code: 405,
-        api_error: {
-          type: "method_not_supported_error",
-          message: "The method passed is not supported, GET is expected.",
-        },
-      });
   }
+
+  return new Ok({
+    totalRemainingCredits,
+    totalActiveCredits,
+    resetDate,
+  });
 }

--- a/front/lib/api/credits/metronome_balances.ts
+++ b/front/lib/api/credits/metronome_balances.ts
@@ -9,15 +9,14 @@ import {
   isMetronomeExcessCredit,
   METRONOME_PROGRAMMATIC_USAGE_CREDIT_TO_MICRO_USD,
 } from "@app/lib/metronome/types";
-import { apiError } from "@app/logger/withlogging";
 import type {
   CreditDisplayData,
   CreditType,
   GetCreditsResponseBody,
 } from "@app/types/credits";
-import type { WithAPIErrorResponse } from "@app/types/error";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
-import type { NextApiRequest, NextApiResponse } from "next";
 
 function mapMetronomeType(
   entry: MetronomeCommit | MetronomeCredit
@@ -97,65 +96,39 @@ export function metronomeBalanceToDisplayData(
   };
 }
 
-export async function handleMetronomeBalancesRequest(
-  req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetCreditsResponseBody>>,
+export class MetronomeBalancesError extends Error {
+  constructor(
+    readonly type: "not_configured" | "balances_fetch_failed",
+    readonly cause?: Error
+  ) {
+    super(type);
+  }
+}
+
+export async function getMetronomeBalances(
   auth: Authenticator
-): Promise<void> {
-  if (!auth.isAdmin()) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users that are `admins` for the current workspace can view credits.",
-      },
-    });
+): Promise<Result<GetCreditsResponseBody, MetronomeBalancesError>> {
+  const workspace = auth.getNonNullableWorkspace();
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId) {
+    return new Err(new MetronomeBalancesError("not_configured"));
   }
 
-  switch (req.method) {
-    case "GET": {
-      const workspace = auth.getNonNullableWorkspace();
-      const { metronomeCustomerId } = workspace;
-      if (!metronomeCustomerId) {
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: "Workspace is not configured for Metronome billing.",
-          },
-        });
-      }
-
-      const result = await listMetronomeBalances(metronomeCustomerId);
-      if (result.isErr()) {
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: `Failed to retrieve Metronome balances: ${result.error.message}`,
-          },
-        });
-      }
-
-      const programmaticUsdCreditTypeId = getCreditTypeProgrammaticUsdId();
-      const credits: CreditDisplayData[] = result.value
-        .filter(
-          (entry) =>
-            entry.access_schedule?.credit_type?.id ===
-              programmaticUsdCreditTypeId && !isMetronomeExcessCredit(entry)
-        )
-        .map(metronomeBalanceToDisplayData);
-
-      return res.status(200).json({ credits });
-    }
-    default:
-      return apiError(req, res, {
-        status_code: 405,
-        api_error: {
-          type: "method_not_supported_error",
-          message: "The method passed is not supported, GET is expected.",
-        },
-      });
+  const result = await listMetronomeBalances(metronomeCustomerId);
+  if (result.isErr()) {
+    return new Err(
+      new MetronomeBalancesError("balances_fetch_failed", result.error)
+    );
   }
+
+  const programmaticUsdCreditTypeId = getCreditTypeProgrammaticUsdId();
+  const credits: CreditDisplayData[] = result.value
+    .filter(
+      (entry) =>
+        entry.access_schedule?.credit_type?.id ===
+          programmaticUsdCreditTypeId && !isMetronomeExcessCredit(entry)
+    )
+    .map(metronomeBalanceToDisplayData);
+
+  return new Ok({ credits });
 }

--- a/front/lib/api/credits/metronome_contract.ts
+++ b/front/lib/api/credits/metronome_contract.ts
@@ -1,0 +1,101 @@
+import type { Authenticator } from "@app/lib/auth";
+import { getMetronomeContractById } from "@app/lib/metronome/client";
+import type { ContractLifecycleError } from "@app/lib/metronome/contract_lifecycle";
+import {
+  cancelWorkspaceContractAtPeriodEnd,
+  reactivateWorkspaceContract,
+} from "@app/lib/metronome/contract_lifecycle";
+import { parseMauTiers } from "@app/lib/metronome/mau_sync";
+import { hasContractSeatSubscription } from "@app/lib/metronome/seats";
+import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+export type MetronomeContractSummary = {
+  planFamily: "pro" | "enterprise";
+  /**
+   * MAU tier boundaries parsed from the MAU_TIERS contract custom field.
+   * `null` for simple MAU (no tiering) or non-enterprise.
+   * Each tier has `start` (inclusive, 1-indexed) and `end` (exclusive, null = unlimited).
+   */
+  mauTiers: Array<{ start: number; end: number | null }> | null;
+  /** ms epoch — set when the contract is scheduled to end (cancellation or fixed term). */
+  contractEndingAtMs: number | null;
+  /** True if the contract has at least one seat-billed subscription */
+  hasSeatSubscription: boolean;
+};
+
+/**
+ * Fetch the workspace's Metronome contract summary.
+ *
+ * Returns `Ok(null)` when the workspace has no Metronome contract data to
+ * surface (no subscription, no workspace, or no Metronome IDs). Returns `Err`
+ * only when the Metronome API call itself fails.
+ */
+export async function getMetronomeContractSummary(
+  auth: Authenticator
+): Promise<Result<MetronomeContractSummary | null, Error>> {
+  const subscription = auth.subscription();
+  const owner = auth.workspace();
+  if (!subscription || !owner) {
+    return new Ok(null);
+  }
+
+  const { metronomeContractId } = subscription;
+  const { metronomeCustomerId } = owner;
+  if (!metronomeContractId || !metronomeCustomerId) {
+    return new Ok(null);
+  }
+
+  const contractResult = await getMetronomeContractById({
+    metronomeCustomerId,
+    metronomeContractId,
+  });
+  if (contractResult.isErr()) {
+    return new Err(contractResult.error);
+  }
+
+  const contract = contractResult.value;
+
+  const planFamily: "pro" | "enterprise" = isEntreprisePlanPrefix(
+    subscription.plan.code
+  )
+    ? "enterprise"
+    : "pro";
+
+  const mauTiersField = contract.custom_fields?.MAU_TIERS;
+  const parsed = parseMauTiers(mauTiersField);
+  const mauTiers = parsed
+    ? parsed.map((t) => ({ start: t.start, end: t.end ?? null }))
+    : null;
+
+  const contractEndingAtMs = contract.ending_before
+    ? new Date(contract.ending_before).getTime()
+    : null;
+
+  return new Ok({
+    planFamily,
+    mauTiers,
+    contractEndingAtMs,
+    hasSeatSubscription: await hasContractSeatSubscription(contract),
+  });
+}
+
+export type ContractLifecycleAction = "cancel" | "reactivate";
+
+export async function applyContractLifecycleAction(
+  auth: Authenticator,
+  action: ContractLifecycleAction
+): Promise<Result<void, ContractLifecycleError>> {
+  switch (action) {
+    case "cancel": {
+      const r = await cancelWorkspaceContractAtPeriodEnd(auth);
+      return r.isErr() ? new Err(r.error) : new Ok(undefined);
+    }
+    case "reactivate":
+      return reactivateWorkspaceContract(auth);
+    default:
+      assertNever(action);
+  }
+}

--- a/front/lib/api/credits/seat_plan.ts
+++ b/front/lib/api/credits/seat_plan.ts
@@ -12,12 +12,11 @@ import {
   type SeatAwuCreditsPeriod,
 } from "@app/lib/metronome/seat_types";
 import logger from "@app/logger/logger";
-import { apiError } from "@app/logger/withlogging";
 import type { SupportedCurrency } from "@app/types/currency";
-import type { WithAPIErrorResponse } from "@app/types/error";
 import type { MembershipSeatType } from "@app/types/memberships";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import type { NextApiRequest, NextApiResponse } from "next";
 
 export type SeatBillingFrequency =
   | "weekly"
@@ -61,32 +60,26 @@ export function getSeatBillingFrequency(
   }
 }
 
-export async function handleSeatPlanRequest(
-  req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<SeatPlanResponseBody>>,
-  auth: Authenticator
-): Promise<void> {
-  if (req.method !== "GET") {
-    return apiError(req, res, {
-      status_code: 405,
-      api_error: {
-        type: "method_not_supported_error",
-        message: "Only GET is supported.",
-      },
-    });
+export class SeatPlanError extends Error {
+  constructor(
+    readonly type:
+      | "not_configured"
+      | "currency_resolution_failed"
+      | "rate_schedule_fetch_failed",
+    readonly cause?: Error
+  ) {
+    super(type);
   }
+}
 
+export async function getSeatPlan(
+  auth: Authenticator
+): Promise<Result<SeatPlanResponseBody, SeatPlanError>> {
   const workspace = auth.getNonNullableWorkspace();
   const contract = await getActiveContract(workspace.sId);
 
   if (!contract || !contract.rate_card_id) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "internal_server_error",
-        message: "Workspace is not configured for Metronome billing.",
-      },
-    });
+    return new Err(new SeatPlanError("not_configured"));
   }
 
   const creditTypeResult = await getCreditTypeFromContract(contract);
@@ -99,19 +92,15 @@ export async function handleSeatPlanRequest(
       },
       "[Metronome] Failed to resolve contract currency for seat plan"
     );
-    return apiError(req, res, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Failed to resolve currency for seat plan.",
-      },
-    });
+    return new Err(
+      new SeatPlanError("currency_resolution_failed", creditTypeResult.error)
+    );
   }
   const { currency } = creditTypeResult.value;
 
   // MAU contracts don't bill per-seat — return an empty seat plan up-front.
   if (isMauContract(contract)) {
-    return res.status(200).json({});
+    return new Ok({});
   }
 
   // Build `productId → seatType` from contract subscriptions so we can resolve
@@ -122,7 +111,7 @@ export async function handleSeatPlanRequest(
     productSeatTypes
   );
   if (seatTypesByProductId.size === 0) {
-    return res.status(200).json({});
+    return new Ok({});
   }
 
   // Resolve each seat's billing frequency from the matching subscription on
@@ -178,21 +167,16 @@ export async function handleSeatPlanRequest(
       }
     }
   } catch (err) {
+    const normalized = normalizeError(err);
     logger.warn(
       {
         workspaceId: workspace.sId,
         rateCardId: contract.rate_card_id,
-        err: normalizeError(err),
+        err: normalized,
       },
       "[Metronome] Failed to fetch rate schedule for seat products"
     );
-    return apiError(req, res, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Failed to fetch rate schedule for seat products.",
-      },
-    });
+    return new Err(new SeatPlanError("rate_schedule_fetch_failed", normalized));
   }
 
   const response: SeatPlanResponseBody = {};
@@ -216,5 +200,5 @@ export async function handleSeatPlanRequest(
       billingFrequency: billingFrequencyBySeatType.get(seatType) ?? "monthly",
     };
   }
-  return res.status(200).json(response);
+  return new Ok(response);
 }

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -1,0 +1,449 @@
+import {
+  dispatchPaygDisabled,
+  dispatchPaygEnabled,
+} from "@app/lib/api/metronome/credit_state_dispatcher";
+import { MAX_PAYG_CAP_DOLLARS } from "@app/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration";
+import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
+import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  ceilToHourISO,
+  floorToHourISO,
+  listMetronomePackages,
+} from "@app/lib/metronome/client";
+import {
+  ensureMetronomeCustomerForWorkspace,
+  provisionMetronomeContract,
+} from "@app/lib/metronome/contracts";
+import {
+  isPaygEligibleTier,
+  type MetronomePackageTier,
+  PAYG_ELIGIBLE_TIERS,
+} from "@app/lib/metronome/types";
+import { resolveCurrencyFromStripe } from "@app/lib/plans/billing_currency";
+import {
+  CREDIT_PRICED_BUSINESS_PLAN_CODE,
+  isEntreprisePlanPrefix,
+  isProPlanPrefix,
+  PRO_PLAN_SEAT_39_CODE,
+} from "@app/lib/plans/plan_codes";
+import {
+  getStripeCustomer,
+  scheduleSubscriptionCancellation,
+} from "@app/lib/plans/stripe";
+import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import logger from "@app/logger/logger";
+import type { SupportedCurrency } from "@app/types/currency";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { z } from "zod";
+
+export const SwitchContractBodySchema = z
+  .object({
+    planCode: z.string().min(1),
+    metronomePackageId: z.string().min(1),
+    // ISO timestamp. Required and validated to be ≥1h in the future when the
+    // selected package is enterprise-tier; forbidden otherwise (Pro/Business
+    // swap at the current hour).
+    startingAt: z.string().optional(),
+    // Optional: required for paid tiers (pro/business/enterprise), omitted
+    // for free-tier switches where Metronome contracts have no Stripe link.
+    stripeCustomerId: z.string().min(1).optional(),
+    paygEnabled: z.boolean().default(false),
+    paygCapDollars: z
+      .number()
+      .min(1, "PAYG cap must be at least $1")
+      .max(
+        MAX_PAYG_CAP_DOLLARS,
+        `PAYG cap cannot exceed $${MAX_PAYG_CAP_DOLLARS.toLocaleString()}`
+      )
+      .optional(),
+  })
+  .refine((data) => !data.paygEnabled || data.paygCapDollars !== undefined, {
+    message: "PAYG cap is required when Pay-as-you-go is enabled.",
+    path: ["paygCapDollars"],
+  });
+
+export type SwitchContractBody = z.infer<typeof SwitchContractBodySchema>;
+
+export type SwitchContractErrorKind =
+  // Bad input or precondition not met — handler should return 400.
+  | "invalid_request"
+  // Metronome (or other upstream) API failure before any state was changed.
+  | "metronome_api_error"
+  // Provisioned the Metronome contract but a follow-up step failed. Manual
+  // cleanup may be required; the message documents what's left to undo.
+  | "provision_inconsistent"
+  // PAYG configuration update/create failed after provisioning completed.
+  | "payg_config_failed";
+
+export class SwitchContractError extends Error {
+  constructor(
+    readonly kind: SwitchContractErrorKind,
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+export type SwitchContractSuccess = {
+  metronomeContractId: string;
+};
+
+function classifyPlanCode(planCode: string): MetronomePackageTier {
+  if (isEntreprisePlanPrefix(planCode)) {
+    return "enterprise";
+  }
+  if (
+    planCode === CREDIT_PRICED_BUSINESS_PLAN_CODE ||
+    planCode === PRO_PLAN_SEAT_39_CODE
+  ) {
+    return "business";
+  }
+  if (isProPlanPrefix(planCode)) {
+    return "pro";
+  }
+  return "free";
+}
+
+function validatePlanPackageCompat(
+  planCode: string,
+  packageTier: MetronomePackageTier
+): { ok: true } | { ok: false; message: string } {
+  const planTier = classifyPlanCode(planCode);
+  if (planTier !== packageTier) {
+    return {
+      ok: false,
+      message:
+        `Plan ${planCode} (tier "${planTier}") does not match the selected ` +
+        `Metronome package (tier "${packageTier}").`,
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * Provision a Metronome contract for the workspace and align local state
+ * (pending subscription, Stripe cancellation schedule, WorkOS org, PAYG
+ * configuration, PAYG dispatcher).
+ *
+ * Side-effects that must succeed for the result to be `Ok`:
+ *   - Ensure Metronome customer
+ *   - Provision the Metronome contract
+ *   - Create the pending local subscription
+ *   - Schedule Stripe cancellation (if a Stripe sub exists)
+ *   - PAYG configuration update / create (if applicable)
+ *
+ * Best-effort (failures are logged but do not fail the operation):
+ *   - WorkOS organization provisioning
+ *   - PAYG state dispatcher
+ */
+export async function switchContract({
+  auth,
+  body,
+}: {
+  auth: Authenticator;
+  body: SwitchContractBody;
+}): Promise<Result<SwitchContractSuccess, SwitchContractError>> {
+  const owner = auth.getNonNullableWorkspace();
+  const currentSubscription = auth.subscriptionResource();
+
+  // Workspace must be Metronome-billed (current sub Metronome-only) or
+  // Metronome-eligible (Metronome billing enabled). Stripe-billed workspaces
+  // that have opted into Metronome billing land here too — their Stripe sub
+  // is scheduled to end at the swap time further down.
+  const isCurrentlyMetronomeOnlyBilled =
+    currentSubscription?.isMetronomeOnlyBilled ?? false;
+  const metronomeBillingEnabled = await isMetronomeBillingEnabled(auth);
+  if (!isCurrentlyMetronomeOnlyBilled && !metronomeBillingEnabled) {
+    return new Err(
+      new SwitchContractError(
+        "invalid_request",
+        "switch_contract is only available for Metronome-billed workspaces. " +
+          "Migrate the workspace to Metronome billing before invoking this flow."
+      )
+    );
+  }
+
+  const programmaticConfig =
+    await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
+
+  // Validate the Stripe customer exists before we touch Metronome.
+  // For free-tier switches the operator may omit the Stripe customer entirely
+  // — the contract is created without Stripe billing wired in.
+  let resolvedCurrency: SupportedCurrency | null = null;
+  if (body.stripeCustomerId) {
+    const stripeCustomer = await getStripeCustomer(body.stripeCustomerId);
+    if (!stripeCustomer) {
+      return new Err(
+        new SwitchContractError(
+          "invalid_request",
+          `Stripe customer not found: ${body.stripeCustomerId}.`
+        )
+      );
+    }
+    resolvedCurrency = resolveCurrencyFromStripe({ stripeCustomer });
+  }
+
+  // Resolve the Metronome customer.
+  const customerResult = await ensureMetronomeCustomerForWorkspace({
+    workspace: renderLightWorkspaceType({ workspace: owner }),
+    stripeCustomerId: body.stripeCustomerId,
+  });
+  if (customerResult.isErr()) {
+    return new Err(
+      new SwitchContractError(
+        "metronome_api_error",
+        `Failed to ensure Metronome customer: ${customerResult.error.message}`
+      )
+    );
+  }
+  const { metronomeCustomerId } = customerResult.value;
+
+  // Resolve the package and classify its tier.
+  const packagesResult = await listMetronomePackages();
+  if (packagesResult.isErr()) {
+    return new Err(
+      new SwitchContractError(
+        "metronome_api_error",
+        `Failed to list Metronome packages: ${packagesResult.error.message}`
+      )
+    );
+  }
+  const pkg = packagesResult.value.find(
+    (p) => p.id === body.metronomePackageId
+  );
+  if (!pkg) {
+    return new Err(
+      new SwitchContractError(
+        "invalid_request",
+        `Metronome package not found: ${body.metronomePackageId}`
+      )
+    );
+  }
+  // Free packages are currency-agnostic (price is 0) — skip the currency
+  // match check. For paid tiers, the resolved Stripe currency must match the
+  // package's currency.
+  if (
+    pkg.tier !== "free" &&
+    resolvedCurrency &&
+    pkg.currency !== resolvedCurrency
+  ) {
+    return new Err(
+      new SwitchContractError(
+        "invalid_request",
+        `Metronome package ${body.metronomePackageId} is ${pkg.currency.toUpperCase()}, ` +
+          `but Stripe customer ${body.stripeCustomerId} resolves to ` +
+          `${resolvedCurrency.toUpperCase()}. Pick a ${resolvedCurrency.toUpperCase()} package.`
+      )
+    );
+  }
+  // Plan ↔ package tier compatibility.
+  const compat = validatePlanPackageCompat(body.planCode, pkg.tier);
+  if (!compat.ok) {
+    return new Err(new SwitchContractError("invalid_request", compat.message));
+  }
+
+  if (body.paygEnabled && !isPaygEligibleTier(pkg.tier)) {
+    return new Err(
+      new SwitchContractError(
+        "invalid_request",
+        `Pay-as-you-go can only be enabled for ${PAYG_ELIGIBLE_TIERS.join(
+          " or "
+        )} contracts.`
+      )
+    );
+  }
+
+  // Resolve when the swap happens.
+  //  - startingAt provided: schedule at the requested moment, ceiled to the
+  //    next hour boundary. Must be ≥1h in the future.
+  //  - startingAt omitted: swap immediately at the current hour boundary
+  //    (supported for all tiers, including enterprise via the operator's
+  //    explicit "start immediately" opt-in).
+  let startingAtDate: Date;
+  let swapAt: "current-hour" | "next-hour";
+  if (body.startingAt) {
+    const requestedStartMs = Date.parse(body.startingAt);
+    if (Number.isNaN(requestedStartMs)) {
+      return new Err(
+        new SwitchContractError(
+          "invalid_request",
+          "startingAt is not a valid ISO timestamp."
+        )
+      );
+    }
+    const ONE_HOUR_MS = 60 * 60 * 1000;
+    if (requestedStartMs < Date.now() + ONE_HOUR_MS) {
+      return new Err(
+        new SwitchContractError(
+          "invalid_request",
+          "startingAt must be at least one hour in the future."
+        )
+      );
+    }
+    startingAtDate = new Date(requestedStartMs);
+    swapAt = "next-hour";
+  } else {
+    startingAtDate = new Date();
+    swapAt = "current-hour";
+  }
+
+  const packageAlias = pkg.aliases[0];
+  if (!packageAlias) {
+    return new Err(
+      new SwitchContractError(
+        "invalid_request",
+        `Package ${pkg.id} has no alias to switch to.`
+      )
+    );
+  }
+
+  const provisionResult = await provisionMetronomeContract({
+    metronomeCustomerId,
+    workspace: renderLightWorkspaceType({ workspace: owner }),
+    packageAlias,
+    startingAt: startingAtDate,
+    swapAt,
+    enableStripeBilling: body.stripeCustomerId !== undefined,
+    planCode: body.planCode,
+  });
+  if (provisionResult.isErr()) {
+    return new Err(
+      new SwitchContractError(
+        "metronome_api_error",
+        `Failed to provision Metronome contract: ${provisionResult.error.message}`
+      )
+    );
+  }
+  const { metronomeContractId } = provisionResult.value;
+
+  // Match `provisionMetronomeContract`'s internal alignment so the pending
+  // subscription's startDate matches the Metronome contract's starting_at.
+  const alignedStart = new Date(
+    swapAt === "current-hour"
+      ? floorToHourISO(startingAtDate)
+      : ceilToHourISO(startingAtDate)
+  );
+
+  // Persist the future-state subscription in `created_backend_only`; the
+  // `contract.start` webhook flips it to `active` (and ends the current one).
+  // Any prior pending sub for this workspace is ended in the same txn.
+  try {
+    await SubscriptionResource.createPendingMetronomeContract({
+      workspaceModelId: owner.id,
+      planCode: body.planCode,
+      metronomeContractId,
+      startDate: alignedStart,
+    });
+  } catch (err) {
+    return new Err(
+      new SwitchContractError(
+        "provision_inconsistent",
+        `Provisioned Metronome contract ${metronomeContractId} but failed to ` +
+          `create pending subscription: ${normalizeError(err).message}. ` +
+          "Manual cleanup may be required."
+      )
+    );
+  }
+
+  // If the workspace is currently Stripe-billed (incl. shadow-Metronome),
+  // schedule the Stripe sub to cancel at the swap moment so the two rails
+  // don't double-bill.
+  const stripeSubscriptionIdToCancel =
+    currentSubscription?.stripeSubscriptionId ?? null;
+  if (stripeSubscriptionIdToCancel) {
+    try {
+      await scheduleSubscriptionCancellation({
+        stripeSubscriptionId: stripeSubscriptionIdToCancel,
+        cancelAt: alignedStart,
+      });
+    } catch (err) {
+      return new Err(
+        new SwitchContractError(
+          "provision_inconsistent",
+          `Provisioned Metronome contract ${metronomeContractId} and pending ` +
+            `subscription, but failed to schedule cancellation of Stripe ` +
+            `subscription ${stripeSubscriptionIdToCancel}: ` +
+            `${normalizeError(err).message}. ` +
+            `URGENT: cancel the Stripe subscription manually at ${alignedStart.toISOString()} ` +
+            "to avoid double-billing."
+        )
+      );
+    }
+  }
+
+  // Ensure the workspace has a WorkOS organization for any paid tier.
+  // Idempotent — `contract.start` webhook re-runs this as a safety net.
+  if (pkg.tier !== "free") {
+    const workosResult = await getOrCreateWorkOSOrganization(
+      renderLightWorkspaceType({ workspace: owner })
+    );
+    if (workosResult.isErr()) {
+      logger.error(
+        {
+          workspaceId: owner.sId,
+          metronomeContractId,
+          err: workosResult.error,
+        },
+        "[switch_contract] Failed to provision WorkOS organization"
+      );
+    }
+  }
+
+  const paygCapMicroUsd =
+    body.paygEnabled && body.paygCapDollars !== undefined
+      ? Math.round(body.paygCapDollars * 1_000_000)
+      : null;
+  if (programmaticConfig) {
+    const updateResult = await programmaticConfig.updateConfiguration(auth, {
+      paygCapMicroUsd,
+    });
+    if (updateResult.isErr()) {
+      return new Err(
+        new SwitchContractError(
+          "payg_config_failed",
+          `Failed to update PAYG configuration: ${updateResult.error.message}`
+        )
+      );
+    }
+  } else if (paygCapMicroUsd !== null) {
+    const createResult = await ProgrammaticUsageConfigurationResource.makeNew(
+      auth,
+      {
+        freeCreditMicroUsd: null,
+        defaultDiscountPercent: 0,
+        paygCapMicroUsd,
+        dailyCapMicroUsd: null,
+      }
+    );
+    if (createResult.isErr()) {
+      return new Err(
+        new SwitchContractError(
+          "payg_config_failed",
+          `Failed to create PAYG configuration: ${createResult.error.message}`
+        )
+      );
+    }
+  }
+
+  // Note: the Metronome AWU PAYG cap alert is no longer synced from this
+  // endpoint. AWU concerns (discount, AWU PAYG cap) live on
+  // `credit_usage_configuration` and are managed via the
+  // "Manage Credit Usage Configuration" poke plugin.
+
+  const workspaceResource = await WorkspaceResource.fetchById(owner.sId);
+  if (workspaceResource) {
+    if (body.paygEnabled) {
+      await dispatchPaygEnabled({ workspace: workspaceResource });
+    } else {
+      await dispatchPaygDisabled({ workspace: workspaceResource });
+    }
+  }
+
+  return new Ok({ metronomeContractId });
+}

--- a/front/pages/api/poke/workspaces/[wId]/switch_contract.ts
+++ b/front/pages/api/poke/workspaces/[wId]/switch_contract.ts
@@ -1,116 +1,41 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
-import {
-  dispatchPaygDisabled,
-  dispatchPaygEnabled,
-} from "@app/lib/api/metronome/credit_state_dispatcher";
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
-import { MAX_PAYG_CAP_DOLLARS } from "@app/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration";
-import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
-import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
+import type { SwitchContractErrorKind } from "@app/lib/api/poke/switch_contract";
+import {
+  SwitchContractBodySchema,
+  type SwitchContractError,
+  switchContract,
+} from "@app/lib/api/poke/switch_contract";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import {
-  ceilToHourISO,
-  floorToHourISO,
-  listMetronomePackages,
-} from "@app/lib/metronome/client";
-import {
-  ensureMetronomeCustomerForWorkspace,
-  provisionMetronomeContract,
-} from "@app/lib/metronome/contracts";
-import {
-  isPaygEligibleTier,
-  type MetronomePackageTier,
-  PAYG_ELIGIBLE_TIERS,
-} from "@app/lib/metronome/types";
-import { resolveCurrencyFromStripe } from "@app/lib/plans/billing_currency";
-import {
-  CREDIT_PRICED_BUSINESS_PLAN_CODE,
-  isEntreprisePlanPrefix,
-  isProPlanPrefix,
-  PRO_PLAN_SEAT_39_CODE,
-} from "@app/lib/plans/plan_codes";
-import {
-  getStripeCustomer,
-  scheduleSubscriptionCancellation,
-} from "@app/lib/plans/stripe";
 import { PluginRunResource } from "@app/lib/resources/plugin_run_resource";
-import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
-import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
-import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import { renderLightWorkspaceType } from "@app/lib/workspace";
-import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
-import type { SupportedCurrency } from "@app/types/currency";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { Result } from "@app/types/shared/result";
-import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
 export interface SwitchContractSuccessResponseBody {
   success: boolean;
 }
 
-const SwitchContractBodySchema = z
-  .object({
-    planCode: z.string().min(1),
-    metronomePackageId: z.string().min(1),
-    // ISO timestamp. Required and validated to be ≥1h in the future when the
-    // selected package is enterprise-tier; forbidden otherwise (Pro/Business
-    // swap at the current hour).
-    startingAt: z.string().optional(),
-    // Optional: required for paid tiers (pro/business/enterprise), omitted
-    // for free-tier switches where Metronome contracts have no Stripe link.
-    stripeCustomerId: z.string().min(1).optional(),
-    paygEnabled: z.boolean().default(false),
-    paygCapDollars: z
-      .number()
-      .min(1, "PAYG cap must be at least $1")
-      .max(
-        MAX_PAYG_CAP_DOLLARS,
-        `PAYG cap cannot exceed $${MAX_PAYG_CAP_DOLLARS.toLocaleString()}`
-      )
-      .optional(),
-  })
-  .refine((data) => !data.paygEnabled || data.paygCapDollars !== undefined, {
-    message: "PAYG cap is required when Pay-as-you-go is enabled.",
-    path: ["paygCapDollars"],
-  });
-
-function classifyPlanCode(planCode: string): MetronomePackageTier {
-  if (isEntreprisePlanPrefix(planCode)) {
-    return "enterprise";
+function statusForKind(kind: SwitchContractErrorKind): {
+  status_code: 400 | 500 | 502;
+  type: "invalid_request_error" | "internal_server_error";
+} {
+  switch (kind) {
+    case "invalid_request":
+      return { status_code: 400, type: "invalid_request_error" };
+    case "metronome_api_error":
+    case "provision_inconsistent":
+      return { status_code: 502, type: "internal_server_error" };
+    case "payg_config_failed":
+      return { status_code: 500, type: "internal_server_error" };
+    default:
+      assertNever(kind);
   }
-  if (
-    planCode === CREDIT_PRICED_BUSINESS_PLAN_CODE ||
-    planCode === PRO_PLAN_SEAT_39_CODE
-  ) {
-    return "business";
-  }
-  if (isProPlanPrefix(planCode)) {
-    return "pro";
-  }
-  return "free";
-}
-
-function validatePlanPackageCompat(
-  planCode: string,
-  packageTier: MetronomePackageTier
-): Result<void, Error> {
-  const planTier = classifyPlanCode(planCode);
-  if (planTier !== packageTier) {
-    return new Err(
-      new Error(
-        `Plan ${planCode} (tier "${planTier}") does not match the selected ` +
-          `Metronome package (tier "${packageTier}").`
-      )
-    );
-  }
-  return new Ok(undefined);
 }
 
 async function handler(
@@ -174,315 +99,18 @@ async function handler(
   }
   const body = validation.data;
 
-  // Workspace must be Metronome-billed (current sub Metronome-only) or
-  // Metronome-eligible (Metronome billing enabled). Stripe-billed workspaces
-  // that have opted into Metronome billing land here too — their Stripe sub
-  // is scheduled to end at the swap time further down.
-  const currentSubscription = auth.subscriptionResource();
-  const isCurrentlyMetronomeOnlyBilled =
-    currentSubscription?.isMetronomeOnlyBilled ?? false;
-  const metronomeBillingEnabled = await isMetronomeBillingEnabled(auth);
-  if (!isCurrentlyMetronomeOnlyBilled && !metronomeBillingEnabled) {
-    const errorMessage =
-      "switch_contract is only available for Metronome-billed workspaces. " +
-      "Migrate the workspace to Metronome billing before invoking this flow.";
-    await pluginRun.recordError(errorMessage);
+  const result = await switchContract({ auth, body });
+  if (result.isErr()) {
+    const err: SwitchContractError = result.error;
+    await pluginRun.recordError(err.message);
+    const { status_code, type } = statusForKind(err.kind);
     return apiError(req, res, {
-      status_code: 400,
-      api_error: { type: "invalid_request_error", message: errorMessage },
+      status_code,
+      api_error: { type, message: err.message },
     });
   }
 
-  const programmaticConfig =
-    await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
-
-  // Validate the Stripe customer exists before we touch Metronome.
-  // For free-tier switches the operator may omit the Stripe customer entirely
-  // — the contract is created without Stripe billing wired in.
-  let resolvedCurrency: SupportedCurrency | null = null;
-  if (body.stripeCustomerId) {
-    const stripeCustomer = await getStripeCustomer(body.stripeCustomerId);
-    if (!stripeCustomer) {
-      const errorMessage = `Stripe customer not found: ${body.stripeCustomerId}.`;
-      await pluginRun.recordError(errorMessage);
-      return apiError(req, res, {
-        status_code: 400,
-        api_error: { type: "invalid_request_error", message: errorMessage },
-      });
-    }
-    resolvedCurrency = resolveCurrencyFromStripe({ stripeCustomer });
-  }
-
-  // Resolve the Metronome customer.
-  const customerResult = await ensureMetronomeCustomerForWorkspace({
-    workspace: renderLightWorkspaceType({ workspace: owner }),
-    stripeCustomerId: body.stripeCustomerId,
-  });
-  if (customerResult.isErr()) {
-    const errorMessage = `Failed to ensure Metronome customer: ${customerResult.error.message}`;
-    await pluginRun.recordError(errorMessage);
-    return apiError(req, res, {
-      status_code: 502,
-      api_error: { type: "internal_server_error", message: errorMessage },
-    });
-  }
-  const { metronomeCustomerId } = customerResult.value;
-
-  // Resolve the package and classify its tier.
-  const packagesResult = await listMetronomePackages();
-  if (packagesResult.isErr()) {
-    const errorMessage = `Failed to list Metronome packages: ${packagesResult.error.message}`;
-    await pluginRun.recordError(errorMessage);
-    return apiError(req, res, {
-      status_code: 502,
-      api_error: { type: "internal_server_error", message: errorMessage },
-    });
-  }
-  const pkg = packagesResult.value.find(
-    (p) => p.id === body.metronomePackageId
-  );
-  if (!pkg) {
-    const errorMessage = `Metronome package not found: ${body.metronomePackageId}`;
-    await pluginRun.recordError(errorMessage);
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: { type: "invalid_request_error", message: errorMessage },
-    });
-  }
-  // Free packages are currency-agnostic (price is 0) — skip the currency
-  // match check. For paid tiers, the resolved Stripe currency must match the
-  // package's currency.
-  if (
-    pkg.tier !== "free" &&
-    resolvedCurrency &&
-    pkg.currency !== resolvedCurrency
-  ) {
-    const errorMessage =
-      `Metronome package ${body.metronomePackageId} is ${pkg.currency.toUpperCase()}, ` +
-      `but Stripe customer ${body.stripeCustomerId} resolves to ` +
-      `${resolvedCurrency.toUpperCase()}. Pick a ${resolvedCurrency.toUpperCase()} package.`;
-    await pluginRun.recordError(errorMessage);
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: errorMessage,
-      },
-    });
-  }
-  // Plan ↔ package tier compatibility.
-  const compatResult = validatePlanPackageCompat(body.planCode, pkg.tier);
-  if (compatResult.isErr()) {
-    await pluginRun.recordError(compatResult.error.message);
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: compatResult.error.message,
-      },
-    });
-  }
-
-  if (body.paygEnabled && !isPaygEligibleTier(pkg.tier)) {
-    const errorMessage = `Pay-as-you-go can only be enabled for ${PAYG_ELIGIBLE_TIERS.join(
-      " or "
-    )} contracts.`;
-    await pluginRun.recordError(errorMessage);
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: { type: "invalid_request_error", message: errorMessage },
-    });
-  }
-
-  // Resolve when the swap happens.
-  //  - startingAt provided: schedule at the requested moment, ceiled to the
-  //    next hour boundary. Must be ≥1h in the future.
-  //  - startingAt omitted: swap immediately at the current hour boundary
-  //    (supported for all tiers, including enterprise via the operator's
-  //    explicit "start immediately" opt-in).
-  let startingAtDate: Date;
-  let swapAt: "current-hour" | "next-hour";
-  if (body.startingAt) {
-    const requestedStartMs = Date.parse(body.startingAt);
-    if (Number.isNaN(requestedStartMs)) {
-      const errorMessage = "startingAt is not a valid ISO timestamp.";
-      await pluginRun.recordError(errorMessage);
-      return apiError(req, res, {
-        status_code: 400,
-        api_error: { type: "invalid_request_error", message: errorMessage },
-      });
-    }
-    const ONE_HOUR_MS = 60 * 60 * 1000;
-    if (requestedStartMs < Date.now() + ONE_HOUR_MS) {
-      const errorMessage =
-        "startingAt must be at least one hour in the future.";
-      await pluginRun.recordError(errorMessage);
-      return apiError(req, res, {
-        status_code: 400,
-        api_error: { type: "invalid_request_error", message: errorMessage },
-      });
-    }
-    startingAtDate = new Date(requestedStartMs);
-    swapAt = "next-hour";
-  } else {
-    startingAtDate = new Date();
-    swapAt = "current-hour";
-  }
-
-  const packageAlias = pkg.aliases[0];
-  if (!packageAlias) {
-    const errorMessage = `Package ${pkg.id} has no alias to switch to.`;
-    await pluginRun.recordError(errorMessage);
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: { type: "invalid_request_error", message: errorMessage },
-    });
-  }
-
-  const provisionResult = await provisionMetronomeContract({
-    metronomeCustomerId,
-    workspace: renderLightWorkspaceType({ workspace: owner }),
-    packageAlias,
-    startingAt: startingAtDate,
-    swapAt,
-    enableStripeBilling: body.stripeCustomerId !== undefined,
-    planCode: body.planCode,
-  });
-  if (provisionResult.isErr()) {
-    const errorMessage = `Failed to provision Metronome contract: ${provisionResult.error.message}`;
-    await pluginRun.recordError(errorMessage);
-    return apiError(req, res, {
-      status_code: 502,
-      api_error: { type: "internal_server_error", message: errorMessage },
-    });
-  }
-  const { metronomeContractId } = provisionResult.value;
-
-  // Match `provisionMetronomeContract`'s internal alignment so the pending
-  // subscription's startDate matches the Metronome contract's starting_at.
-  const alignedStart = new Date(
-    swapAt === "current-hour"
-      ? floorToHourISO(startingAtDate)
-      : ceilToHourISO(startingAtDate)
-  );
-
-  // Persist the future-state subscription in `created_backend_only`; the
-  // `contract.start` webhook flips it to `active` (and ends the current one).
-  // Any prior pending sub for this workspace is ended in the same txn.
-  try {
-    await SubscriptionResource.createPendingMetronomeContract({
-      workspaceModelId: owner.id,
-      planCode: body.planCode,
-      metronomeContractId,
-      startDate: alignedStart,
-    });
-  } catch (err) {
-    const errorMessage =
-      `Provisioned Metronome contract ${metronomeContractId} but failed to ` +
-      `create pending subscription: ${err instanceof Error ? err.message : String(err)}. ` +
-      "Manual cleanup may be required.";
-    await pluginRun.recordError(errorMessage);
-    return apiError(req, res, {
-      status_code: 502,
-      api_error: { type: "internal_server_error", message: errorMessage },
-    });
-  }
-
-  // If the workspace is currently Stripe-billed (incl. shadow-Metronome),
-  // schedule the Stripe sub to cancel at the swap moment so the two rails
-  // don't double-bill.
-  const stripeSubscriptionIdToCancel =
-    currentSubscription?.stripeSubscriptionId ?? null;
-  if (stripeSubscriptionIdToCancel) {
-    try {
-      await scheduleSubscriptionCancellation({
-        stripeSubscriptionId: stripeSubscriptionIdToCancel,
-        cancelAt: alignedStart,
-      });
-    } catch (err) {
-      const errorMessage =
-        `Provisioned Metronome contract ${metronomeContractId} and pending ` +
-        `subscription, but failed to schedule cancellation of Stripe ` +
-        `subscription ${stripeSubscriptionIdToCancel}: ` +
-        `${err instanceof Error ? err.message : String(err)}. ` +
-        `URGENT: cancel the Stripe subscription manually at ${alignedStart.toISOString()} ` +
-        "to avoid double-billing.";
-      await pluginRun.recordError(errorMessage);
-      return apiError(req, res, {
-        status_code: 502,
-        api_error: { type: "internal_server_error", message: errorMessage },
-      });
-    }
-  }
-
-  // Ensure the workspace has a WorkOS organization for any paid tier.
-  // Idempotent — `contract.start` webhook re-runs this as a safety net.
-  if (pkg.tier !== "free") {
-    const workosResult = await getOrCreateWorkOSOrganization(
-      renderLightWorkspaceType({ workspace: owner })
-    );
-    if (workosResult.isErr()) {
-      logger.error(
-        {
-          workspaceId: owner.sId,
-          metronomeContractId,
-          err: workosResult.error,
-        },
-        "[switch_contract] Failed to provision WorkOS organization"
-      );
-    }
-  }
-
-  const paygCapMicroUsd =
-    body.paygEnabled && body.paygCapDollars !== undefined
-      ? Math.round(body.paygCapDollars * 1_000_000)
-      : null;
-  if (programmaticConfig) {
-    const updateResult = await programmaticConfig.updateConfiguration(auth, {
-      paygCapMicroUsd,
-    });
-    if (updateResult.isErr()) {
-      const errorMessage = `Failed to update PAYG configuration: ${updateResult.error.message}`;
-      await pluginRun.recordError(errorMessage);
-      return apiError(req, res, {
-        status_code: 500,
-        api_error: { type: "internal_server_error", message: errorMessage },
-      });
-    }
-  } else if (paygCapMicroUsd !== null) {
-    const createResult = await ProgrammaticUsageConfigurationResource.makeNew(
-      auth,
-      {
-        freeCreditMicroUsd: null,
-        defaultDiscountPercent: 0,
-        paygCapMicroUsd,
-        dailyCapMicroUsd: null,
-      }
-    );
-    if (createResult.isErr()) {
-      const errorMessage = `Failed to create PAYG configuration: ${createResult.error.message}`;
-      await pluginRun.recordError(errorMessage);
-      return apiError(req, res, {
-        status_code: 500,
-        api_error: { type: "internal_server_error", message: errorMessage },
-      });
-    }
-  }
-
-  // Note: the Metronome AWU PAYG cap alert is no longer synced from this
-  // endpoint. AWU concerns (discount, AWU PAYG cap) live on
-  // `credit_usage_configuration` and are managed via the
-  // "Manage Credit Usage Configuration" poke plugin.
-
-  const workspaceResource = await WorkspaceResource.fetchById(owner.sId);
-  if (workspaceResource) {
-    if (body.paygEnabled) {
-      await dispatchPaygEnabled({ workspace: workspaceResource });
-    } else {
-      await dispatchPaygDisabled({ workspace: workspaceResource });
-    }
-  }
-
+  const { metronomeContractId } = result.value;
   const paygStatus = body.paygEnabled
     ? ` PAYG enabled with $${body.paygCapDollars} cap.`
     : "";

--- a/front/pages/api/w/[wId]/credits/awu-pool-summary.ts
+++ b/front/pages/api/w/[wId]/credits/awu-pool-summary.ts
@@ -3,18 +3,85 @@
 /** @ignoreswagger */
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import type { AwuPoolSummaryResponseBody } from "@app/lib/api/credits/awu_pool_summary";
-import { handleAwuPoolSummaryRequest } from "@app/lib/api/credits/awu_pool_summary";
+import type {
+  AwuPoolSummaryError,
+  AwuPoolSummaryResponseBody,
+} from "@app/lib/api/credits/awu_pool_summary";
+import { getAwuPoolSummary } from "@app/lib/api/credits/awu_pool_summary";
 import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { NextApiRequest, NextApiResponse } from "next";
+
+function summaryErrorToApi(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  err: AwuPoolSummaryError
+) {
+  switch (err.type) {
+    case "not_configured":
+      return apiError(req, res, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Workspace is not configured for Metronome billing.",
+        },
+      });
+    case "balances_fetch_failed":
+      return apiError(req, res, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome balances: ${err.cause?.message ?? ""}`,
+        },
+      });
+    case "invoices_fetch_failed":
+      return apiError(req, res, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome invoices: ${err.cause?.message ?? ""}`,
+        },
+      });
+    default:
+      assertNever(err.type);
+  }
+}
 
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<AwuPoolSummaryResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  return handleAwuPoolSummaryRequest(req, res, auth);
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can view credits.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const result = await getAwuPoolSummary(auth);
+      if (result.isErr()) {
+        return summaryErrorToApi(req, res, result.error);
+      }
+      return res.status(200).json(result.value);
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
 }
 
 export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/credits/metronome-balances.ts
+++ b/front/pages/api/w/[wId]/credits/metronome-balances.ts
@@ -3,18 +3,75 @@
 /** @ignoreswagger */
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { handleMetronomeBalancesRequest } from "@app/lib/api/credits/metronome_balances";
+import type { MetronomeBalancesError } from "@app/lib/api/credits/metronome_balances";
+import { getMetronomeBalances } from "@app/lib/api/credits/metronome_balances";
 import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
 import type { GetCreditsResponseBody } from "@app/types/credits";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { NextApiRequest, NextApiResponse } from "next";
+
+function balancesErrorToApi(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  err: MetronomeBalancesError
+) {
+  switch (err.type) {
+    case "not_configured":
+      return apiError(req, res, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Workspace is not configured for Metronome billing.",
+        },
+      });
+    case "balances_fetch_failed":
+      return apiError(req, res, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome balances: ${err.cause?.message ?? ""}`,
+        },
+      });
+    default:
+      assertNever(err.type);
+  }
+}
 
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<GetCreditsResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  return handleMetronomeBalancesRequest(req, res, auth);
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can view credits.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const result = await getMetronomeBalances(auth);
+      if (result.isErr()) {
+        return balancesErrorToApi(req, res, result.error);
+      }
+      return res.status(200).json(result.value);
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
 }
 
 export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/metronome/contract.ts
+++ b/front/pages/api/w/[wId]/metronome/contract.ts
@@ -1,35 +1,20 @@
 // @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import type { Authenticator } from "@app/lib/auth";
-import { getMetronomeContractById } from "@app/lib/metronome/client";
+import type { MetronomeContractSummary } from "@app/lib/api/credits/metronome_contract";
 import {
-  cancelWorkspaceContractAtPeriodEnd,
-  reactivateWorkspaceContract,
-} from "@app/lib/metronome/contract_lifecycle";
-import { parseMauTiers } from "@app/lib/metronome/mau_sync";
-import { hasContractSeatSubscription } from "@app/lib/metronome/seats";
-import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
+  applyContractLifecycleAction,
+  getMetronomeContractSummary,
+} from "@app/lib/api/credits/metronome_contract";
+import type { Authenticator } from "@app/lib/auth";
+import type { ContractLifecycleError } from "@app/lib/metronome/contract_lifecycle";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
-export type MetronomeContractSummary = {
-  planFamily: "pro" | "enterprise";
-  /**
-   * MAU tier boundaries parsed from the MAU_TIERS contract custom field.
-   * `null` for simple MAU (no tiering) or non-enterprise.
-   * Each tier has `start` (inclusive, 1-indexed) and `end` (exclusive, null = unlimited).
-   */
-  mauTiers: Array<{ start: number; end: number | null }> | null;
-  /** ms epoch — set when the contract is scheduled to end (cancellation or fixed term). */
-  contractEndingAtMs: number | null;
-  /** True if the contract has at least one seat-billed subscription */
-  hasSeatSubscription: boolean;
-};
+export type { MetronomeContractSummary };
 
 export type GetMetronomeContractResponseBody = {
   contract: MetronomeContractSummary | null;
@@ -42,6 +27,23 @@ type PatchMetronomeContractResponseBody = {
 export const PatchMetronomeContractRequestBody = z.object({
   action: z.enum(["cancel", "reactivate"]),
 });
+
+function lifecycleErrorToApi(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  err: ContractLifecycleError
+) {
+  return apiError(req, res, {
+    status_code: err.kind === "invalid_state" ? 400 : 502,
+    api_error: {
+      type:
+        err.kind === "invalid_state"
+          ? "subscription_state_invalid"
+          : "internal_server_error",
+      message: err.message,
+    },
+  });
+}
 
 async function handler(
   req: NextApiRequest,
@@ -64,10 +66,43 @@ async function handler(
   }
 
   switch (req.method) {
-    case "GET":
-      return handleGet(req, res, auth);
-    case "PATCH":
-      return handlePatch(req, res, auth);
+    case "GET": {
+      const result = await getMetronomeContractSummary(auth);
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 502,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to fetch Metronome contract: ${result.error.message}`,
+          },
+        });
+      }
+      return res.status(200).json({ contract: result.value });
+    }
+    case "PATCH": {
+      const bodyValidation = PatchMetronomeContractRequestBody.safeParse(
+        req.body
+      );
+      if (!bodyValidation.success) {
+        const pathError = fromError(bodyValidation.error).toString();
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${pathError}`,
+          },
+        });
+      }
+
+      const result = await applyContractLifecycleAction(
+        auth,
+        bodyValidation.data.action
+      );
+      if (result.isErr()) {
+        return lifecycleErrorToApi(req, res, result.error);
+      }
+      return res.status(200).json({ success: true });
+    }
     default:
       return apiError(req, res, {
         status_code: 405,
@@ -78,126 +113,6 @@ async function handler(
         },
       });
   }
-}
-
-async function handleGet(
-  req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetMetronomeContractResponseBody>>,
-  auth: Authenticator
-): Promise<void> {
-  const subscription = auth.subscription();
-  const owner = auth.workspace();
-  if (!subscription || !owner) {
-    return res.status(200).json({ contract: null });
-  }
-
-  const { metronomeContractId } = subscription;
-  const { metronomeCustomerId } = owner;
-  if (!metronomeContractId || !metronomeCustomerId) {
-    return res.status(200).json({ contract: null });
-  }
-
-  const contractResult = await getMetronomeContractById({
-    metronomeCustomerId,
-    metronomeContractId,
-  });
-  if (contractResult.isErr()) {
-    return apiError(req, res, {
-      status_code: 502,
-      api_error: {
-        type: "internal_server_error",
-        message: `Failed to fetch Metronome contract: ${contractResult.error.message}`,
-      },
-    });
-  }
-
-  const contract = contractResult.value;
-
-  const planFamily: "pro" | "enterprise" = isEntreprisePlanPrefix(
-    subscription.plan.code
-  )
-    ? "enterprise"
-    : "pro";
-
-  const mauTiersField = contract.custom_fields?.MAU_TIERS;
-  const parsed = parseMauTiers(mauTiersField);
-  const mauTiers = parsed
-    ? parsed.map((t) => ({ start: t.start, end: t.end ?? null }))
-    : null;
-
-  const contractEndingAtMs = contract.ending_before
-    ? new Date(contract.ending_before).getTime()
-    : null;
-
-  return res.status(200).json({
-    contract: {
-      planFamily,
-      mauTiers,
-      contractEndingAtMs,
-      hasSeatSubscription: await hasContractSeatSubscription(contract),
-    },
-  });
-}
-
-async function handlePatch(
-  req: NextApiRequest,
-  res: NextApiResponse<
-    WithAPIErrorResponse<PatchMetronomeContractResponseBody>
-  >,
-  auth: Authenticator
-): Promise<void> {
-  const bodyValidation = PatchMetronomeContractRequestBody.safeParse(req.body);
-  if (!bodyValidation.success) {
-    const pathError = fromError(bodyValidation.error).toString();
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: `Invalid request body: ${pathError}`,
-      },
-    });
-  }
-
-  const { action } = bodyValidation.data;
-
-  switch (action) {
-    case "cancel": {
-      const result = await cancelWorkspaceContractAtPeriodEnd(auth);
-      if (result.isErr()) {
-        return apiError(req, res, {
-          status_code: result.error.kind === "invalid_state" ? 400 : 502,
-          api_error: {
-            type:
-              result.error.kind === "invalid_state"
-                ? "subscription_state_invalid"
-                : "internal_server_error",
-            message: result.error.message,
-          },
-        });
-      }
-      break;
-    }
-    case "reactivate": {
-      const result = await reactivateWorkspaceContract(auth);
-      if (result.isErr()) {
-        return apiError(req, res, {
-          status_code: result.error.kind === "invalid_state" ? 400 : 502,
-          api_error: {
-            type:
-              result.error.kind === "invalid_state"
-                ? "subscription_state_invalid"
-                : "internal_server_error",
-            message: result.error.message,
-          },
-        });
-      }
-      break;
-    }
-    default:
-      assertNever(action);
-  }
-
-  return res.status(200).json({ success: true });
 }
 
 export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/seats/plan.ts
+++ b/front/pages/api/w/[wId]/seats/plan.ts
@@ -3,20 +3,72 @@
 /** @ignoreswagger */
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import type { SeatPlanResponseBody } from "@app/lib/api/credits/seat_plan";
-import { handleSeatPlanRequest } from "@app/lib/api/credits/seat_plan";
+import type {
+  SeatPlanError,
+  SeatPlanResponseBody,
+} from "@app/lib/api/credits/seat_plan";
+import { getSeatPlan } from "@app/lib/api/credits/seat_plan";
 import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { NextApiRequest, NextApiResponse } from "next";
+
+function seatPlanErrorToApi(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  err: SeatPlanError
+) {
+  switch (err.type) {
+    case "not_configured":
+      return apiError(req, res, {
+        status_code: 400,
+        api_error: {
+          type: "internal_server_error",
+          message: "Workspace is not configured for Metronome billing.",
+        },
+      });
+    case "currency_resolution_failed":
+      return apiError(req, res, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to resolve currency for seat plan.",
+        },
+      });
+    case "rate_schedule_fetch_failed":
+      return apiError(req, res, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to fetch rate schedule for seat products.",
+        },
+      });
+    default:
+      assertNever(err.type);
+  }
+}
 
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<SeatPlanResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  // Seat plan behavior lives in the shared handler so this legacy route stays
-  // aligned with the Hono route while migration is in progress.
-  return handleSeatPlanRequest(req, res, auth);
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "Only GET is supported.",
+      },
+    });
+  }
+
+  const result = await getSeatPlan(auth);
+  if (result.isErr()) {
+    return seatPlanErrorToApi(req, res, result.error);
+  }
+  return res.status(200).json(result.value);
 }
 
 export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Summary

Deduplicates Metronome-touching endpoint pairs (Next under `front/pages/api/` ↔ Hono under `front-api/routes/`) by pushing the business logic into transport-agnostic helpers in `front/lib/api/credits/` and `front/lib/api/poke/`. Each helper returns a `Result<Body, DomainError>` per [BACK16]/[BACK18]; both handlers map the domain error to HTTP and call the same helper for the happy path.

## Endpoints consolidated

| Endpoint | Shared helper | Notes |
| --- | --- | --- |
| `GET /w/:wId/credits/awu-pool-summary` | `getAwuPoolSummary(auth)` | Identical logic before; pure dedup. |
| `GET /w/:wId/credits/metronome-balances` | `getMetronomeBalances(auth)` | Identical logic before; pure dedup. |
| `GET /w/:wId/seats/plan` | `getSeatPlan(auth)` | **Behavioral fix — see below.** |
| `GET/PATCH /w/:wId/metronome/contract` | `getMetronomeContractSummary(auth)`, `applyContractLifecycleAction(auth, action)` | GET body + PATCH dispatch extracted; error mapping stays in handlers per [BACK18]. |
| `POST /poke/workspaces/:wId/switch_contract` | `switchContract({ auth, body })` + `SwitchContractBodySchema` | ~380 lines of duplicated business logic extracted; pluginRun side-effects stay in handlers. |

## Behavioral fix — `seats/plan`

The two implementations were **not equivalent**:
- **Next** called the **contract-level** rate schedule (`v1.contracts.retrieveRateSchedule`) and read `entry.override_rate?.price ?? entry.list_rate.price` — contract price overrides applied.
- **Hono** called the **rate-card-level** rate schedule (`v1.contracts.rateCards.retrieveRateSchedule`) and read `entry.rate.price` — overrides ignored.

For a workspace with a contract override, `priceCents` differed depending on which handler answered. The shared helper now uses the contract-level path (the Next behavior, which is the intended one per the inline comment). Workspaces with overrides will start seeing the overridden price on the Hono side.

## What was checked but left alone

Audited the remaining Metronome pairs (`credits/index`, `members-seats`, `members-usage`, `purchase`, `usage-configuration`, `poke/credits/index`). No behavioral divergence found across them — only the seats/plan split was a real bug. Some duplication remains (`metronome/invoice` line-item parsing, `poke/credits/index` unified-row matching, `subscriptions/index` `cancel_free_trial` branch) but is left for follow-up to keep this PR focused.

## Risk

- **Medium**: `seats/plan` Hono now returns override-aware prices. Workspaces with no override see identical responses; workspaces with an override will see the corrected (lower or higher) price. This matches what `front/pages/api/.../seats/plan.ts` has been returning all along.
- **Low**: other helpers preserve byte-identical response shapes, status codes and error messages.
- **Low**: `switch_contract` keeps the same `pluginRun.recordError(message)` + same status code per failure path; the error message strings are preserved verbatim.

Rollback: revert the PR — all changes are local to handler files and three new helper files (`lib/api/credits/metronome_contract.ts`, `lib/api/poke/switch_contract.ts`, plus refactors to existing `lib/api/credits/{awu_pool_summary,metronome_balances,seat_plan}.ts`).

## Test plan

- [ ] `tsgo --noEmit` clean on `front` and `front-api` (verified locally — only pre-existing `@temporalio/*` / `openai` / `@notionhq/client` module-resolution noise remains).
- [ ] Hit each of the 5 endpoint pairs on a dev workspace via both `front` and `front-api`; confirm identical responses.
- [ ] On a workspace with a Metronome **contract price override**, confirm `GET /w/:wId/seats/plan` returns the override price (not list price) on both sides.
- [ ] Run a `switch_contract` flow via poke against a test workspace (free-tier swap is safest); confirm pluginRun records both success and failure cases with the same messages as before.
- [ ] `GET /w/:wId/metronome/contract` returns `contract: null` for workspaces with no Metronome IDs (no 502).
- [ ] PATCH `cancel` then `reactivate` round-trip still returns 400 `subscription_state_invalid` for trialing subs and 502 `internal_server_error` for upstream failures.

## Deploy plan

Standard deploy. No DB migrations, no feature flags, no client-side coordination required. The Hono-side seats/plan price change is a bugfix toward the Next-side behavior — clients won't see a shape change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)