### PR TITLE
fix: use setIsCreatePodModalOpen in StackedInAppBanners onCreatePod

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1134,7 +1134,7 @@ export function AgentSidebarMenu({
             {!hideInAppBanner && (
               <StackedInAppBanners
                 owner={owner}
-                onCreatePod={() => setIsCreateProjectModalOpen(true)}
+                onCreatePod={() => setIsCreatePodModalOpen(true)}
               />
             )}
           </div>


### PR DESCRIPTION
## Description

Missed rename from the project → pod sidebar refactor (#26340): `onCreatePod` in `StackedInAppBanners` (`SidebarMenu.tsx`) still called `setIsCreateProjectModalOpen`, which no longer exists after the refactor. This broke the `main` build with `Type error: Cannot find name 'setIsCreateProjectModalOpen'`.

Failing run: https://github.com/dust-tt/dust/actions/runs/26570178077/job/78275084297

## Tests

`npx tsc --noEmit` passes in `front`. Manually verified no remaining `setIsCreateProjectModalOpen` references in `front/`.

## Risk

None. One-line fix pointing a callback at the already-declared `setIsCreatePodModalOpen` state setter. Reverts cleanly.

## Deploy Plan

Standard merge to `main`; no migrations or coordination needed.