### PR TITLE
Add sandbox root command API

### DIFF
--- a/CODING_RULES.md
+++ b/CODING_RULES.md
@@ -423,12 +423,30 @@ Example:
 /api/w/[wId]/resource/[sId]
 ```
 
-### [SEC3] Sandbox root commands must not resolve executables through PATH
+### [SEC3] Runtime sandbox root commands must not resolve executables through PATH
 
-Any command that runs in a sandbox as `root` must invoke executables through absolute paths. This
-applies to `sandbox.exec(..., { user: "root" })`, provider-level E2B command execution as root,
-image lifecycle commands, wake/resume hooks, egress setup, log readers, and root-invoked helper
-scripts.
+Any runtime command that runs in an already-built sandbox as `root` must invoke executables through
+absolute paths. This applies to `sandbox.execRoot(...)`, provider-level E2B command execution as
+root, wake/resume hooks, egress setup, log readers, and root-invoked helper scripts.
+
+Image build DSL commands in `front/lib/api/sandbox/image/registry.ts` are out of scope for this
+runtime PATH-hijack rule because they run while building the image, before untrusted sandbox
+workloads can plant files in the sandbox filesystem. Prefer absolute paths there when practical,
+but review them as image build reproducibility/hardening issues rather than runtime workload
+escape issues.
+
+Runtime sandbox root commands must use `execRoot(...)` with a `RootCommand`. Do not pass
+`{ user: "root" }` to generic `sandbox.exec(...)` / `provider.exec(...)`; that path is reserved for
+non-root sandbox workloads. Do not bypass the provider with direct E2B SDK root execution
+(`sandbox.commands.run(..., { user: "root" })`, `sandbox.pty.create(..., { user: "root" })`) outside
+the provider implementation or explicitly operator-only scripts. Prefer
+`rootCommand.exec("/absolute/path", args)` and the small `rootCommand` combinators. Use
+`rootCommand.unsafeShell(command, reason)` only for compound shell flows that cannot reasonably be
+expressed with the builder, and include a specific reason.
+
+When passing positional operands that can be influenced by sandbox workload data or other untrusted
+input, account for option injection. If the target executable supports it, insert `--` before those
+operands so values beginning with `-` cannot be interpreted as flags.
 
 Do not rely on the sandbox `PATH` for root commands. Sandbox workloads may control writable
 directories that appear in a default root PATH on some images, so bare commands like `cat`,
@@ -440,34 +458,38 @@ reachable must be root-owned and not group/other writable before the helper is t
 root-owned locations such as `/opt/bin` for Dust-managed sandbox helpers, and add image/runtime
 hardening plus tests for their ownership and mode.
 
-Reviewer: If you detect a sandbox command running as `root` that uses a bare executable name,
-require the author to switch to an absolute path. If you detect a root-invoked helper in a path
-that sandbox users can write to, require ownership/mode hardening or a safer location before
-approving.
+Reviewer: If you detect a runtime sandbox command using `sandbox.exec(..., { user: "root" })` or
+`provider.exec(..., { user: "root" })`, require `execRoot(...)` and a `RootCommand`. If you detect
+direct E2B SDK root execution outside the provider or operator-only scripts, require routing
+through the provider. If you detect `rootCommand.unsafeShell(...)`, check that the reason is
+concrete and that simple absolute-executable builder calls would not be clearer. If root command
+args include untrusted positional operands without a `--` separator, check whether the target
+executable can interpret them as options. If you detect a root-invoked helper in a path that sandbox
+users can write to, require ownership/mode hardening or a safer location before approving.
 
 Example:
 
 ```
-// BAD: `cat`, `wc`, `tr`, `tail`, and `head` are resolved through root's PATH.
+// BAD: runtime root through generic exec, with commands resolved through PATH.
 await sandbox.exec(auth, "cat /tmp/deny.log | wc -l | tr -d ' '", {
   user: "root",
 });
 
-// GOOD: every root-executed binary is absolute.
-await sandbox.exec(
+// GOOD: root execution uses execRoot and a RootCommand.
+await sandbox.execRoot(
   auth,
-  "/bin/cat /tmp/deny.log | /usr/bin/wc -l | /usr/bin/tr -d ' '",
-  { user: "root" }
+  rootCommand.and([
+    rootCommand.exec("/usr/bin/install", ["-o", "root", "-g", "root", "-m", "600", "/dev/stdin", path]),
+    rootCommand.exec("/usr/bin/mv", [path, finalPath]),
+  ])
 );
 
 // BAD: root invokes a helper from a path whose ownership/mode is not enforced.
-await sandbox.exec(auth, "dust-install-trust-bundle", { user: "root" });
+await sandbox.execRoot(auth, rootCommand.unsafeShell("dust-install-trust-bundle", "bad example"));
 
 // GOOD: root invokes an absolute helper path that image/runtime hardening keeps root-owned and
 // non-writable by sandbox workloads.
-await sandbox.exec(auth, "/opt/bin/dust-install-trust-bundle", {
-  user: "root",
-});
+await sandbox.execRoot(auth, rootCommand.exec("/opt/bin/dust-install-trust-bundle"));
 ```
 
 ### [SEC4] Sandbox root-consumed lookup directories must not be workload-writable

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -1134,7 +1134,7 @@ export function AgentSidebarMenu({
             {!hideInAppBanner && (
               <StackedInAppBanners
                 owner={owner}
-                onCreatePod={() => setIsCreateProjectModalOpen(true)}
+                onCreatePod={() => setIsCreatePodModalOpen(true)}
               />
             )}
           </div>

--- a/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
+++ b/front/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter.ts
@@ -3,6 +3,10 @@ import {
   mintDownscopedGcsToken,
 } from "@app/lib/api/sandbox/gcs/token";
 import type { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
+import {
+  type RootCommand,
+  rootCommand,
+} from "@app/lib/api/sandbox/root_command";
 import type { Authenticator } from "@app/lib/auth";
 import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import logger from "@app/logger/logger";
@@ -119,23 +123,22 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
     const mountResults = await concurrentExecutor(
       [...targets],
       async (target) => {
-        const mkdirResult = await sandbox.exec(
+        const mkdirResult = await sandbox.execRoot(
           auth,
-          `mkdir -p ${target.sandboxMountPoint}`,
-          { user: "root" }
+          rootCommand.exec("/usr/bin/mkdir", ["-p", target.sandboxMountPoint])
         );
         if (mkdirResult.isErr()) {
           return mkdirResult;
         }
 
-        const mountResult = await sandbox.exec(
+        const mountResult = await sandbox.execRoot(
           auth,
           buildMountCommand({
             bucket,
             prefix: target.gcsPrefix,
             mountPoint: target.sandboxMountPoint,
           }),
-          { timeoutMs: MOUNT_TIMEOUT_MS, user: "root" }
+          { timeoutMs: MOUNT_TIMEOUT_MS }
         );
 
         if (mountResult.isErr()) {
@@ -160,10 +163,13 @@ export class GCSSandboxMountAdapter implements SandboxMountAdapter {
 
         // 5. Backward-compat symlink so old paths keep working.
         if (target.legacySandboxMountPoint) {
-          const symlinkResult = await sandbox.exec(
+          const symlinkResult = await sandbox.execRoot(
             auth,
-            `ln -sfn ${target.sandboxMountPoint} ${target.legacySandboxMountPoint}`,
-            { user: "root" }
+            rootCommand.exec("/usr/bin/ln", [
+              "-sfn",
+              target.sandboxMountPoint,
+              target.legacySandboxMountPoint,
+            ])
           );
           if (symlinkResult.isErr()) {
             // Non-fatal: canonical path works, old code hitting the legacy path will just fail.
@@ -251,23 +257,31 @@ function buildMountCommand({
   bucket: string;
   prefix: string;
   mountPoint: string;
-}): string {
+}): RootCommand {
   const flags = [
-    "--token-url http://127.0.0.1:9876",
+    "--token-url",
+    "http://127.0.0.1:9876",
     // Disable token caching so gcsfuse fetches a fresh credential on every GCS API request.
     "--reuse-token-from-url=false",
-    `--only-dir ${prefix}`,
+    "--only-dir",
+    prefix,
     "--implicit-dirs",
-    "-o allow_other",
+    "-o",
+    "allow_other",
     "--file-mode=666",
     "--dir-mode=777",
     "--kernel-list-cache-ttl-secs=60",
     // Disable HNS: GetStorageLayout requires unrestricted objects.list which CAB cannot grant
     // per-prefix. With HNS disabled we scope list access via objectListPrefix conditions.
     "--enable-hns=false",
-  ].join(" ");
+  ];
 
-  return `timeout 30 gcsfuse ${flags} ${bucket} ${mountPoint} 2>&1`;
+  return rootCommand.stderrToStdout(
+    rootCommand.timeout(
+      rootCommand.exec("/usr/bin/gcsfuse", [...flags, bucket, mountPoint]),
+      MOUNT_TIMEOUT_MS / 1_000
+    )
+  );
 }
 
 function buildTokenJson({

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -2,6 +2,10 @@ import { spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import {
+  type RootCommand,
+  renderRootCommand,
+} from "@app/lib/api/sandbox/root_command";
 import { Err, Ok } from "@app/types/shared/result";
 import jwt from "jsonwebtoken";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -114,6 +118,13 @@ function healthStdout(overrides: Partial<HealthcheckOutput> = {}): string {
   });
 }
 
+function getRootCommandCall(
+  mock: { mock: { calls: unknown[][] } },
+  callIndex: number
+): string {
+  return renderRootCommand(mock.mock.calls[callIndex][1] as RootCommand);
+}
+
 describe("sandbox egress helpers", () => {
   const auth = {
     getNonNullableWorkspace: () => ({ sId: "workspace-id" }),
@@ -159,7 +170,7 @@ describe("sandbox egress helpers", () => {
       providerId: "provider-sandbox-id",
       sId: "sandbox-id",
       writeFile: vi.fn().mockResolvedValue(new Ok(undefined)),
-      exec: vi
+      execRoot: vi
         .fn()
         .mockResolvedValueOnce(new Ok({ exitCode: 0, stdout: "", stderr: "" }))
         .mockResolvedValueOnce(new Ok({ exitCode: 0, stdout: "", stderr: "" }))
@@ -194,61 +205,45 @@ describe("sandbox egress helpers", () => {
       "/etc/dust/egress-token",
       expect.anything()
     );
-    expect(sandbox.exec).toHaveBeenNthCalledWith(
+    expect(sandbox.execRoot).toHaveBeenNthCalledWith(
       1,
       auth,
-      expect.stringContaining("chmod 600 '/etc/dust/egress-token'"),
-      { user: "root" }
+      expect.any(Object)
+    );
+    expect(getRootCommandCall(sandbox.execRoot, 0)).toContain(
+      "chmod 600 /etc/dust/egress-token"
     );
     expect(mockWriteEgressSecretsFile).toHaveBeenCalledWith(auth, sandbox);
     expect(mockWriteSandboxEnvManifestFile).toHaveBeenCalledWith(auth, sandbox);
-    expect(sandbox.exec).toHaveBeenNthCalledWith(
-      2,
-      auth,
-      expect.stringContaining("--proxy-addr '203.0.113.10:4443'"),
-      { user: "root" }
-    );
-    expect(sandbox.exec).toHaveBeenNthCalledWith(
-      2,
-      auth,
-      expect.stringContaining("--proxy-tls-name 'eu.sandbox-egress.dust.tt'"),
-      { user: "root" }
-    );
-    expect(sandbox.exec).toHaveBeenNthCalledWith(
-      2,
-      auth,
-      expect.stringContaining("--secrets-file '/run/dust/egress-secrets.json'"),
-      { user: "root" }
-    );
+    const spawnCall = getRootCommandCall(sandbox.execRoot, 1);
+    expect(spawnCall).toContain("--proxy-addr 203.0.113.10:4443");
+    expect(spawnCall).toContain("--proxy-tls-name eu.sandbox-egress.dust.tt");
+    expect(spawnCall).toContain("--secrets-file /run/dust/egress-secrets.json");
     // The dsbx spawn must strip every trust env var that buildSandboxEnvVars
     // exports on the agent process. Pinning the strip list to the canonical
     // SANDBOX_TRUST_ENV_VARS keys here catches drift between the two sites.
-    const spawnCall = sandbox.exec.mock.calls[1][1] as string;
     expect(spawnCall).toContain("/usr/bin/nohup /usr/bin/env");
     expect(spawnCall).not.toContain("nohup env");
     for (const key of Object.keys(SANDBOX_TRUST_ENV_VARS)) {
       expect(spawnCall).toContain(`-u ${key}`);
     }
-    expect(sandbox.exec).toHaveBeenNthCalledWith(
-      5,
-      auth,
-      expect.stringContaining("/run/dust/egress-ca.pem"),
-      { user: "root" }
+    expect(getRootCommandCall(sandbox.execRoot, 4)).toContain(
+      "/run/dust/egress-ca.pem"
     );
-    const healthCall = sandbox.exec.mock.calls[2][1] as string;
+    const healthCall = getRootCommandCall(sandbox.execRoot, 2);
     expect(healthCall).toContain("/opt/bin/dsbx healthcheck");
-    expect(healthCall).toContain("--forwarder-listen '127.0.0.1:9990'");
-    expect(healthCall).toContain("--resolver-listen '127.0.0.1:1053'");
+    expect(healthCall).toContain("--forwarder-listen 127.0.0.1:9990");
+    expect(healthCall).toContain("--resolver-listen 127.0.0.1:1053");
     expect(healthCall).toContain("--proxied-uid 1003");
     // The healthcheck inspects nftables, which requires CAP_NET_ADMIN, so it
     // must run as root. Pin the exec options to prevent silent regression.
-    expect(sandbox.exec).toHaveBeenNthCalledWith(
+    expect(sandbox.execRoot).toHaveBeenNthCalledWith(
       3,
       auth,
-      expect.stringContaining("/opt/bin/dsbx healthcheck"),
-      { user: "root", timeoutMs: 1_000 }
+      expect.any(Object),
+      { timeoutMs: 1_000 }
     );
-    const installCall = sandbox.exec.mock.calls[4][1] as string;
+    const installCall = getRootCommandCall(sandbox.execRoot, 4);
     expect(installCall).toContain("/usr/local/bin/dust-install-trust-bundle");
     expect(installCall).toContain("/etc/dust/.ca-bundle.merged");
     expect(
@@ -281,7 +276,7 @@ describe("sandbox egress helpers", () => {
       providerId: "provider-sandbox-id",
       sId: "sandbox-id",
       writeFile: vi.fn().mockResolvedValue(new Ok(undefined)),
-      exec: vi
+      execRoot: vi
         .fn()
         // First call: health probe with empty stdout.
         .mockResolvedValueOnce(new Ok({ exitCode: 0, stdout: "", stderr: "" }))
@@ -311,7 +306,7 @@ describe("sandbox egress helpers", () => {
 
   it("returns new deny log entries and advances the offset", async () => {
     const sandbox = {
-      exec: vi.fn().mockResolvedValue(
+      execRoot: vi.fn().mockResolvedValue(
         new Ok({
           exitCode: 0,
           stdout: "google.com:443 denied\nevil.com:80 denied\n",
@@ -329,16 +324,17 @@ describe("sandbox egress helpers", () => {
         "evil.com:80 denied",
       ]);
     }
-    expect(sandbox.exec).toHaveBeenCalledWith(
-      auth,
-      expect.stringContaining("dust-egress-denied.log"),
-      { user: "root", timeoutMs: 2_000 }
+    expect(sandbox.execRoot).toHaveBeenCalledWith(auth, expect.any(Object), {
+      timeoutMs: 2_000,
+    });
+    expect(getRootCommandCall(sandbox.execRoot, 0)).toContain(
+      "dust-egress-denied.log"
     );
   });
 
   it("resets the deny log offset when the log shrinks", async () => {
     const sandbox = {
-      exec: vi
+      execRoot: vi
         .fn()
         .mockResolvedValue(new Ok({ exitCode: 0, stdout: "", stderr: "" })),
     };
@@ -346,7 +342,7 @@ describe("sandbox egress helpers", () => {
     const result = await readNewDenyLogEntries(auth, sandbox as never);
 
     expect(result.isOk()).toBe(true);
-    const command = sandbox.exec.mock.calls[0][1];
+    const command = getRootCommandCall(sandbox.execRoot, 0);
     expect(command).toContain("set -- $_state;");
     expect(command).toContain(
       `if [ "$_total" -lt "$_off" ] || [ "$_size" -lt "$_size_off" ]; then _off=0; fi;`
@@ -358,7 +354,7 @@ describe("sandbox egress helpers", () => {
 
   it("returns empty array when there are no new deny log entries", async () => {
     const sandbox = {
-      exec: vi
+      execRoot: vi
         .fn()
         .mockResolvedValue(new Ok({ exitCode: 0, stdout: "", stderr: "" })),
     };
@@ -376,7 +372,7 @@ describe("sandbox egress helpers", () => {
       providerId: "provider-sandbox-id",
       sId: "sandbox-id",
       writeFile: vi.fn().mockResolvedValue(new Ok(undefined)),
-      exec: vi
+      execRoot: vi
         .fn()
         .mockResolvedValue(new Err(new Error("sandbox command failed"))),
     };
@@ -398,7 +394,7 @@ describe("sandbox egress helpers", () => {
       providerId: "provider-sandbox-id",
       sId: "sandbox-id",
       writeFile: vi.fn().mockResolvedValue(new Ok(undefined)),
-      exec: vi
+      execRoot: vi
         .fn()
         .mockResolvedValue(new Ok({ exitCode: 0, stdout: "", stderr: "" })),
     };
@@ -409,7 +405,7 @@ describe("sandbox egress helpers", () => {
     if (result.isErr()) {
       expect(result.error.message).toContain("secrets write failed");
     }
-    expect(sandbox.exec).toHaveBeenCalledTimes(1);
+    expect(sandbox.execRoot).toHaveBeenCalledTimes(1);
   });
 
   it("surfaces failures from writing the environment manifest file", async () => {
@@ -421,7 +417,7 @@ describe("sandbox egress helpers", () => {
       providerId: "provider-sandbox-id",
       sId: "sandbox-id",
       writeFile: vi.fn().mockResolvedValue(new Ok(undefined)),
-      exec: vi
+      execRoot: vi
         .fn()
         .mockResolvedValue(new Ok({ exitCode: 0, stdout: "", stderr: "" })),
     };
@@ -432,7 +428,7 @@ describe("sandbox egress helpers", () => {
     if (result.isErr()) {
       expect(result.error.message).toContain("manifest write failed");
     }
-    expect(sandbox.exec).toHaveBeenCalledTimes(1);
+    expect(sandbox.execRoot).toHaveBeenCalledTimes(1);
   });
 
   it("surfaces failures from the MITM trust bundle install", async () => {
@@ -440,7 +436,7 @@ describe("sandbox egress helpers", () => {
       providerId: "provider-sandbox-id",
       sId: "sandbox-id",
       writeFile: vi.fn().mockResolvedValue(new Ok(undefined)),
-      exec: vi
+      execRoot: vi
         .fn()
         .mockResolvedValueOnce(new Ok({ exitCode: 0, stdout: "", stderr: "" }))
         .mockResolvedValueOnce(new Ok({ exitCode: 0, stdout: "", stderr: "" }))
@@ -469,7 +465,7 @@ describe("sandbox egress helpers", () => {
       providerId: "provider-sandbox-id",
       sId: "sandbox-id",
       writeFile: vi.fn().mockResolvedValue(new Ok(undefined)),
-      exec: vi
+      execRoot: vi
         .fn()
         .mockResolvedValueOnce(new Ok({ exitCode: 0, stdout: "", stderr: "" }))
         .mockResolvedValueOnce(new Ok({ exitCode: 0, stdout: "", stderr: "" }))
@@ -489,17 +485,9 @@ describe("sandbox egress helpers", () => {
     expect(result).toEqual(new Ok(undefined));
     expect(mockWriteEgressSecretsFile).toHaveBeenCalledWith(auth, sandbox);
     expect(mockWriteSandboxEnvManifestFile).toHaveBeenCalledWith(auth, sandbox);
-    expect(sandbox.exec).toHaveBeenNthCalledWith(
-      2,
-      auth,
-      expect.stringContaining("dsbx forward"),
-      { user: "root" }
-    );
-    expect(sandbox.exec).toHaveBeenNthCalledWith(
-      3,
-      auth,
-      expect.stringContaining("/opt/bin/dsbx forward"),
-      { user: "root" }
+    expect(getRootCommandCall(sandbox.execRoot, 1)).toContain("dsbx forward");
+    expect(getRootCommandCall(sandbox.execRoot, 2)).toContain(
+      "/opt/bin/dsbx forward"
     );
   });
 
@@ -507,7 +495,7 @@ describe("sandbox egress helpers", () => {
     const sandbox = {
       providerId: "provider-sandbox-id",
       sId: "sandbox-id",
-      exec: vi
+      execRoot: vi
         .fn()
         .mockResolvedValueOnce(
           new Ok({
@@ -522,8 +510,8 @@ describe("sandbox egress helpers", () => {
     const result = await ensure(sandbox, { wokeFromSleep: false });
 
     expect(result).toEqual(new Ok(undefined));
-    expect(sandbox.exec).toHaveBeenCalledTimes(2);
-    const installCall = sandbox.exec.mock.calls[1][1] as string;
+    expect(sandbox.execRoot).toHaveBeenCalledTimes(2);
+    const installCall = getRootCommandCall(sandbox.execRoot, 1);
     expect(installCall).toContain("/usr/local/bin/dust-install-trust-bundle");
     expect(installCall).toContain("/etc/dust/.ca-bundle.merged");
     expect(installCall).not.toContain("pkill");
@@ -538,7 +526,7 @@ describe("sandbox egress helpers", () => {
     const sandbox = {
       providerId: "provider-sandbox-id",
       sId: "sandbox-id",
-      exec: vi.fn().mockResolvedValueOnce(
+      execRoot: vi.fn().mockResolvedValueOnce(
         new Ok({
           exitCode: 0,
           stdout: healthStdout({ nft_dns_udp_redirect_ok: false }),
@@ -563,7 +551,7 @@ describe("sandbox egress helpers", () => {
     const sandbox = {
       providerId: "provider-sandbox-id",
       sId: "sandbox-id",
-      exec: vi.fn().mockResolvedValueOnce(
+      execRoot: vi.fn().mockResolvedValueOnce(
         new Ok({
           exitCode: 0,
           stdout: healthStdout({ resolver_udp_ok: false }),
@@ -578,7 +566,7 @@ describe("sandbox egress helpers", () => {
     if (result.isErr()) {
       expect(result.error.message).toContain("DNS enforcement");
     }
-    expect(sandbox.exec).toHaveBeenCalledTimes(1);
+    expect(sandbox.execRoot).toHaveBeenCalledTimes(1);
     expect(mockLoggerWarn).toHaveBeenCalledWith(
       expect.objectContaining({
         event: "egress.enforcement_health_fail",
@@ -599,7 +587,7 @@ describe("sandbox egress helpers", () => {
     const sandbox = {
       providerId: "provider-sandbox-id",
       sId: "sandbox-id",
-      exec: vi.fn().mockResolvedValueOnce(
+      execRoot: vi.fn().mockResolvedValueOnce(
         new Ok({
           exitCode: 0,
           stdout: healthStdout({ [missing]: false }),
@@ -625,7 +613,7 @@ describe("sandbox egress helpers", () => {
       providerId: "provider-sandbox-id",
       sId: "sandbox-id",
       writeFile: vi.fn().mockResolvedValue(new Ok(undefined)),
-      exec: vi
+      execRoot: vi
         .fn()
         .mockResolvedValueOnce(
           new Ok({
@@ -653,12 +641,7 @@ describe("sandbox egress helpers", () => {
     const result = await ensure(sandbox, { wokeFromSleep: false });
 
     expect(result).toEqual(new Ok(undefined));
-    expect(sandbox.exec).toHaveBeenNthCalledWith(
-      3,
-      auth,
-      expect.stringContaining("dsbx forward"),
-      { user: "root" }
-    );
+    expect(getRootCommandCall(sandbox.execRoot, 2)).toContain("dsbx forward");
     expect(mockLoggerWarn).toHaveBeenCalledWith(
       expect.objectContaining({ event: "egress.health_fail" }),
       expect.any(String)
@@ -669,7 +652,7 @@ describe("sandbox egress helpers", () => {
     const sandbox = {
       providerId: "provider-sandbox-id",
       sId: "sandbox-id",
-      exec: vi
+      execRoot: vi
         .fn()
         .mockResolvedValueOnce(
           new Ok({ exitCode: 0, stdout: healthStdout(), stderr: "" })
@@ -679,7 +662,7 @@ describe("sandbox egress helpers", () => {
     const result = await ensure(sandbox, { wokeFromSleep: false });
 
     expect(result).toEqual(new Ok(undefined));
-    expect(sandbox.exec).toHaveBeenCalledTimes(1);
+    expect(sandbox.execRoot).toHaveBeenCalledTimes(1);
     expect(mockLoggerInfo).toHaveBeenCalledWith(
       expect.objectContaining({ event: "egress.health_ok" }),
       expect.any(String)
@@ -712,8 +695,8 @@ describe("sandbox egress helpers", () => {
     // drop blank lines, persist the new offset state.
     async function runReader(): Promise<string[]> {
       const sandbox = {
-        exec: vi.fn(async (_auth: unknown, command: string) => {
-          const rewritten = command
+        execRoot: vi.fn(async (_auth: unknown, command: RootCommand) => {
+          const rewritten = renderRootCommand(command)
             .replace(/'\/tmp\/dust-egress-denied\.log'/g, `'${logPath}'`)
             .replace(/'\/tmp\/\.dust-egress-deny-offset'/g, `'${offsetPath}'`);
           const result = spawnSync("sh", ["-c", rewritten], {
@@ -819,7 +802,7 @@ describe("sandbox egress helpers", () => {
       const sandbox = {
         providerId: "provider-sandbox-id",
         sId: "sandbox-id",
-        exec: vi
+        execRoot: vi
           .fn()
           .mockResolvedValue(new Ok({ exitCode: 0, stdout: "", stderr: "" })),
       };
@@ -830,23 +813,21 @@ describe("sandbox egress helpers", () => {
       );
 
       expect(result).toEqual(new Ok(undefined));
-      expect(sandbox.exec).toHaveBeenCalledTimes(1);
-      const command = sandbox.exec.mock.calls[0][1] as string;
+      expect(sandbox.execRoot).toHaveBeenCalledTimes(1);
+      const command = getRootCommandCall(sandbox.execRoot, 0);
       expect(command).toContain(
         "/usr/bin/systemctl disable --now dust-egress-resolver.service dust-egress-nftables.service"
       );
       expect(command).toContain("/usr/sbin/nft delete table ip dust-egress");
       expect(command).toContain("/usr/sbin/nft delete table ip6 dust-egress");
-      expect(sandbox.exec).toHaveBeenCalledWith(auth, expect.any(String), {
-        user: "root",
-      });
+      expect(sandbox.execRoot).toHaveBeenCalledWith(auth, expect.any(Object));
     });
 
     it("propagates exec failures as Err", async () => {
       const sandbox = {
         providerId: "provider-sandbox-id",
         sId: "sandbox-id",
-        exec: vi
+        execRoot: vi
           .fn()
           .mockResolvedValue(new Err(new Error("sandbox command failed"))),
       };
@@ -868,7 +849,7 @@ describe("sandbox egress helpers", () => {
       const sandbox = {
         providerId: "provider-sandbox-id",
         sId: "sandbox-id",
-        exec: vi.fn(),
+        execRoot: vi.fn(),
       };
 
       const result = await teardownInSandboxEgressRedirect(
@@ -880,7 +861,7 @@ describe("sandbox egress helpers", () => {
       if (result.isErr()) {
         expect(result.error.message).toContain("dev-only");
       }
-      expect(sandbox.exec).not.toHaveBeenCalled();
+      expect(sandbox.execRoot).not.toHaveBeenCalled();
     });
   });
 });

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -7,6 +7,11 @@ import {
 } from "@app/lib/api/sandbox/egress_secrets";
 import { writeSandboxEnvManifestFile } from "@app/lib/api/sandbox/env_manifest";
 import { SANDBOX_AGENT_PROXIED_UID } from "@app/lib/api/sandbox/image/types";
+import {
+  type RootCommand,
+  renderRootCommand,
+  rootCommand,
+} from "@app/lib/api/sandbox/root_command";
 import { shellEscape } from "@app/lib/api/sandbox/shell";
 import { SANDBOX_TRUST_ENV_VARS } from "@app/lib/api/sandbox/trust_env";
 import type { Authenticator } from "@app/lib/auth";
@@ -75,13 +80,12 @@ async function resolveProxyAddr(): Promise<string> {
   return address;
 }
 
-async function runSuccessfulSandboxCommand(
+async function runSuccessfulRootCommand(
   auth: Authenticator,
   sandbox: SandboxResource,
-  command: string,
-  user?: string
+  command: RootCommand
 ): Promise<Result<void, Error>> {
-  const result = await sandbox.exec(auth, command, user ? { user } : undefined);
+  const result = await sandbox.execRoot(auth, command);
   if (result.isErr()) {
     return result;
   }
@@ -89,7 +93,7 @@ async function runSuccessfulSandboxCommand(
   if (result.value.exitCode !== 0) {
     return new Err(
       new Error(
-        `Sandbox command failed with exit code ${result.value.exitCode}: ${result.value.stderr || result.value.stdout || command}`
+        `Sandbox root command failed with exit code ${result.value.exitCode}: ${result.value.stderr || result.value.stdout || renderRootCommand(command)}`
       )
     );
   }
@@ -240,15 +244,22 @@ export async function checkEgressForwarderHealth(
 
   // Root is required: `nft list table` needs CAP_NET_ADMIN, and the probe also
   // reads /proc/net/{tcp,udp} which is fine non-root but pointless to split.
-  const result = await sandbox.exec(
+  const result = await sandbox.execRoot(
     auth,
-    `/opt/bin/dsbx healthcheck ` +
-      `--forwarder-listen ${shellEscape(EGRESS_FORWARDER_LISTEN_ADDR)} ` +
-      `--resolver-listen ${shellEscape(EGRESS_RESOLVER_LISTEN_ADDR)} ` +
-      `--proxied-uid ${EGRESS_PROXIED_UID} ` +
-      `--ca-bundle ${shellEscape(MITM_CA_BUNDLE_PATH)} ` +
-      `--ca-bundle-marker ${shellEscape(MITM_CA_BUNDLE_MARKER_PATH)}`,
-    { user: "root", timeoutMs: 1_000 }
+    rootCommand.exec("/opt/bin/dsbx", [
+      "healthcheck",
+      "--forwarder-listen",
+      EGRESS_FORWARDER_LISTEN_ADDR,
+      "--resolver-listen",
+      EGRESS_RESOLVER_LISTEN_ADDR,
+      "--proxied-uid",
+      EGRESS_PROXIED_UID,
+      "--ca-bundle",
+      MITM_CA_BUNDLE_PATH,
+      "--ca-bundle-marker",
+      MITM_CA_BUNDLE_MARKER_PATH,
+    ]),
+    { timeoutMs: 1_000 }
   );
 
   if (result.isErr()) {
@@ -399,12 +410,14 @@ export async function teardownInSandboxEgressRedirect(
     );
   }
 
-  const command =
+  const command = rootCommand.unsafeShell(
     "/usr/bin/systemctl disable --now dust-egress-resolver.service dust-egress-nftables.service >/dev/null 2>&1 || true; " +
-    "/usr/sbin/nft delete table ip dust-egress >/dev/null 2>&1 || true; " +
-    "/usr/sbin/nft delete table ip6 dust-egress >/dev/null 2>&1 || true";
+      "/usr/sbin/nft delete table ip dust-egress >/dev/null 2>&1 || true; " +
+      "/usr/sbin/nft delete table ip6 dust-egress >/dev/null 2>&1 || true",
+    "dev-only teardown needs best-effort shell fallbacks"
+  );
 
-  return runSuccessfulSandboxCommand(auth, sandbox, command, "root");
+  return runSuccessfulRootCommand(auth, sandbox, command);
 }
 
 export async function setupEgressForwarder(
@@ -438,11 +451,10 @@ export async function setupEgressForwarder(
     return tokenWriteResult;
   }
 
-  const prepareTokenResult = await runSuccessfulSandboxCommand(
+  const prepareTokenResult = await runSuccessfulRootCommand(
     auth,
     sandbox,
-    `/usr/bin/chmod 600 ${shellEscape(EGRESS_TOKEN_PATH)}`,
-    "root"
+    rootCommand.exec("/usr/bin/chmod", ["600", EGRESS_TOKEN_PATH])
   );
   if (prepareTokenResult.isErr()) {
     return prepareTokenResult;
@@ -474,25 +486,37 @@ export async function setupEgressForwarder(
   // (which contains its own CA, opening a forge-and-tunnel loop). The strip
   // list is derived from SANDBOX_TRUST_ENV_VARS so adding a new trust env
   // var can't drift the two sites out of sync.
-  const trustEnvStripFlags = Object.keys(SANDBOX_TRUST_ENV_VARS)
-    .map((k) => `-u ${k}`)
-    .join(" ");
-  const startForwarderCommand =
-    `/usr/bin/nohup /usr/bin/env ${trustEnvStripFlags} ` +
-    "/opt/bin/dsbx forward " +
-    `--token-file ${shellEscape(EGRESS_TOKEN_PATH)} ` +
-    `--proxy-addr ${shellEscape(`${proxyAddr}:${config.getEgressProxyPort()}`)} ` +
-    `--proxy-tls-name ${shellEscape(getProxyTlsName())} ` +
-    `--listen ${shellEscape(EGRESS_FORWARDER_LISTEN_ADDR)} ` +
-    `--deny-log ${shellEscape(EGRESS_DENY_LOG_PATH)} ` +
-    `--secrets-file ${shellEscape(EGRESS_SECRETS_PATH)} ` +
-    `>${shellEscape(EGRESS_FORWARDER_LOG_PATH)} 2>&1 &`;
+  const startForwarderCommand = rootCommand.background(
+    rootCommand.redirectStdout(
+      rootCommand.nohup(
+        rootCommand.env(
+          rootCommand.exec("/opt/bin/dsbx", [
+            "forward",
+            "--token-file",
+            EGRESS_TOKEN_PATH,
+            "--proxy-addr",
+            `${proxyAddr}:${config.getEgressProxyPort()}`,
+            "--proxy-tls-name",
+            getProxyTlsName(),
+            "--listen",
+            EGRESS_FORWARDER_LISTEN_ADDR,
+            "--deny-log",
+            EGRESS_DENY_LOG_PATH,
+            "--secrets-file",
+            EGRESS_SECRETS_PATH,
+          ]),
+          { unset: Object.keys(SANDBOX_TRUST_ENV_VARS) }
+        )
+      ),
+      EGRESS_FORWARDER_LOG_PATH,
+      { stderrToStdout: true }
+    )
+  );
 
-  const startResult = await runSuccessfulSandboxCommand(
+  const startResult = await runSuccessfulRootCommand(
     auth,
     sandbox,
-    startForwarderCommand,
-    "root"
+    startForwarderCommand
   );
   if (startResult.isErr()) {
     return startResult;
@@ -530,11 +554,13 @@ async function killEgressForwarder(
   //
   // The regex is anchored to `/opt/bin/dsbx forward` to avoid killing the
   // co-resident `dsbx resolve` subcommand that runs the DNS stub.
-  return runSuccessfulSandboxCommand(
+  return runSuccessfulRootCommand(
     auth,
     sandbox,
-    "/usr/bin/pkill -KILL -f '^/opt/bin/dsbx forward( |$)' >/dev/null 2>&1 || true",
-    "root"
+    rootCommand.unsafeShell(
+      "/usr/bin/pkill -KILL -f '^/opt/bin/dsbx forward( |$)' >/dev/null 2>&1 || true",
+      "best-effort process cleanup intentionally ignores missing dsbx"
+    )
   );
 }
 
@@ -566,17 +592,19 @@ async function installMitmTrustBundle(
     `/usr/bin/chmod 644 "$_bundle_tmp" && ` +
     `/usr/bin/mv "$_bundle_tmp" ${shellEscape(MITM_CA_BUNDLE_PATH)}`;
 
-  const command =
+  const command = rootCommand.unsafeShell(
     `[ -s ${shellEscape(MITM_CA_PATH)} ] || ` +
-    `{ echo "dsbx CA file ${MITM_CA_PATH} missing or empty" >&2; exit 1; }; ` +
-    `if [ -x ${shellEscape(MITM_TRUST_BUNDLE_INSTALLER_PATH)} ]; then ` +
-    `${shellEscape(MITM_TRUST_BUNDLE_INSTALLER_PATH)}; ` +
-    `else ` +
-    `${inlineFallback}; ` +
-    `fi && ` +
-    `: > ${shellEscape(MITM_CA_BUNDLE_MARKER_PATH)}`;
+      `{ echo "dsbx CA file ${MITM_CA_PATH} missing or empty" >&2; exit 1; }; ` +
+      `if [ -x ${shellEscape(MITM_TRUST_BUNDLE_INSTALLER_PATH)} ]; then ` +
+      `${shellEscape(MITM_TRUST_BUNDLE_INSTALLER_PATH)}; ` +
+      `else ` +
+      `${inlineFallback}; ` +
+      `fi && ` +
+      `: > ${shellEscape(MITM_CA_BUNDLE_MARKER_PATH)}`,
+    "MITM trust bundle repair needs a pre-0.8.8 compound fallback"
+  );
 
-  return runSuccessfulSandboxCommand(auth, sandbox, command, "root");
+  return runSuccessfulRootCommand(auth, sandbox, command);
 }
 
 // Best-effort, sandbox-global deny log surfacing. The offset tracks lines
@@ -586,24 +614,25 @@ export async function readNewDenyLogEntries(
   auth: Authenticator,
   sandbox: SandboxResource
 ): Promise<Result<string[], Error>> {
-  const command =
+  const command = rootCommand.unsafeShell(
     `_state=$(/bin/cat ${shellEscape(EGRESS_DENY_LOG_OFFSET_PATH)} 2>/dev/null || true); ` +
-    `set -- $_state; ` +
-    `_off=\${1:-0}; _size_off=\${2:-0}; ` +
-    `case "$_off" in ''|*[!0-9]*) _off=0;; esac; ` +
-    `case "$_size_off" in ''|*[!0-9]*) _size_off=0;; esac; ` +
-    `if [ -f ${shellEscape(EGRESS_DENY_LOG_PATH)} ]; then ` +
-    `_total=$(/usr/bin/wc -l < ${shellEscape(EGRESS_DENY_LOG_PATH)} | /usr/bin/tr -d ' '); ` +
-    `_size=$(/usr/bin/wc -c < ${shellEscape(EGRESS_DENY_LOG_PATH)} | /usr/bin/tr -d ' '); ` +
-    `else _total=0; _size=0; fi; ` +
-    `if [ "$_total" -lt "$_off" ] || [ "$_size" -lt "$_size_off" ]; then _off=0; fi; ` +
-    `if [ "$_total" -gt "$_off" ]; then ` +
-    `/usr/bin/tail -n +$((_off + 1)) ${shellEscape(EGRESS_DENY_LOG_PATH)} | /usr/bin/head -n ${MAX_DENY_LOG_LINES_PER_EXEC}; ` +
-    `fi; ` +
-    `echo "$_total $_size" > ${shellEscape(EGRESS_DENY_LOG_OFFSET_PATH)}`;
+      `set -- $_state; ` +
+      `_off=\${1:-0}; _size_off=\${2:-0}; ` +
+      `case "$_off" in ''|*[!0-9]*) _off=0;; esac; ` +
+      `case "$_size_off" in ''|*[!0-9]*) _size_off=0;; esac; ` +
+      `if [ -f ${shellEscape(EGRESS_DENY_LOG_PATH)} ]; then ` +
+      `_total=$(/usr/bin/wc -l < ${shellEscape(EGRESS_DENY_LOG_PATH)} | /usr/bin/tr -d ' '); ` +
+      `_size=$(/usr/bin/wc -c < ${shellEscape(EGRESS_DENY_LOG_PATH)} | /usr/bin/tr -d ' '); ` +
+      `else _total=0; _size=0; fi; ` +
+      `if [ "$_total" -lt "$_off" ] || [ "$_size" -lt "$_size_off" ]; then _off=0; fi; ` +
+      `if [ "$_total" -gt "$_off" ]; then ` +
+      `/usr/bin/tail -n +$((_off + 1)) ${shellEscape(EGRESS_DENY_LOG_PATH)} | /usr/bin/head -n ${MAX_DENY_LOG_LINES_PER_EXEC}; ` +
+      `fi; ` +
+      `echo "$_total $_size" > ${shellEscape(EGRESS_DENY_LOG_OFFSET_PATH)}`,
+    "deny log reader needs offset arithmetic and rotation handling"
+  );
 
-  const result = await sandbox.exec(auth, command, {
-    user: "root",
+  const result = await sandbox.execRoot(auth, command, {
     timeoutMs: 2_000,
   });
 

--- a/front/lib/api/sandbox/egress_secrets.test.ts
+++ b/front/lib/api/sandbox/egress_secrets.test.ts
@@ -1,3 +1,7 @@
+import {
+  type RootCommand,
+  renderRootCommand,
+} from "@app/lib/api/sandbox/root_command";
 import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { Ok } from "@app/types/shared/result";
@@ -85,7 +89,7 @@ describe("egress secrets file", () => {
     expect(secretResult.isOk()).toBe(true);
 
     const sandbox = {
-      exec: vi
+      execRoot: vi
         .fn()
         .mockResolvedValue(new Ok({ exitCode: 0, stdout: "", stderr: "" })),
     };
@@ -96,18 +100,18 @@ describe("egress secrets file", () => {
     );
 
     expect(result).toEqual(new Ok(undefined));
-    expect(sandbox.exec).toHaveBeenCalledTimes(1);
-    const command = sandbox.exec.mock.calls[0][1] as string;
-    const opts = sandbox.exec.mock.calls[0][2] as {
+    expect(sandbox.execRoot).toHaveBeenCalledTimes(1);
+    const command = renderRootCommand(
+      sandbox.execRoot.mock.calls[0][1] as RootCommand
+    );
+    const opts = sandbox.execRoot.mock.calls[0][2] as {
       stdin: string;
-      user: string;
     };
     expect(command).toContain(
       "/usr/bin/install -o root -g root -m 600 /dev/stdin"
     );
     expect(command).toContain("/run/dust/egress-secrets.json");
     expect(command).not.toContain("api-secret");
-    expect(opts.user).toBe("root");
     expect(JSON.parse(opts.stdin)).toEqual([
       expect.objectContaining({
         name: "API_TOKEN",

--- a/front/lib/api/sandbox/egress_secrets.ts
+++ b/front/lib/api/sandbox/egress_secrets.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from "node:crypto";
 
 import { renderEgressSecretPlaceholder } from "@app/lib/api/sandbox/env_vars";
-import { shellEscape } from "@app/lib/api/sandbox/shell";
+import { rootCommand } from "@app/lib/api/sandbox/root_command";
 import type { Authenticator } from "@app/lib/auth";
 import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
@@ -89,14 +89,23 @@ export async function writeEgressSecretsFile(
   // hardened. install -m 600 sets the file's perms; the directory's perms are
   // dsbx's call.
   const tmpPath = `${EGRESS_SECRETS_DIR}/.egress-secrets.json.${randomBytes(8).toString("hex")}.tmp`;
-  const command =
-    `/usr/bin/mkdir -p ${shellEscape(EGRESS_SECRETS_DIR)} && ` +
-    `/usr/bin/install -o root -g root -m 600 /dev/stdin ${shellEscape(tmpPath)} && ` +
-    `/usr/bin/mv ${shellEscape(tmpPath)} ${shellEscape(EGRESS_SECRETS_PATH)}`;
+  const command = rootCommand.and([
+    rootCommand.exec("/usr/bin/mkdir", ["-p", EGRESS_SECRETS_DIR]),
+    rootCommand.exec("/usr/bin/install", [
+      "-o",
+      "root",
+      "-g",
+      "root",
+      "-m",
+      "600",
+      "/dev/stdin",
+      tmpPath,
+    ]),
+    rootCommand.exec("/usr/bin/mv", [tmpPath, EGRESS_SECRETS_PATH]),
+  ]);
 
-  const result = await sandbox.exec(auth, command, {
+  const result = await sandbox.execRoot(auth, command, {
     stdin: JSON.stringify(entriesResult.value),
-    user: "root",
   });
   if (result.isErr()) {
     return result;

--- a/front/lib/api/sandbox/env_manifest.test.ts
+++ b/front/lib/api/sandbox/env_manifest.test.ts
@@ -1,3 +1,7 @@
+import {
+  type RootCommand,
+  renderRootCommand,
+} from "@app/lib/api/sandbox/root_command";
 import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { Ok } from "@app/types/shared/result";
@@ -163,7 +167,7 @@ describe("sandbox environment manifest", () => {
     }
 
     const sandbox = {
-      exec: vi
+      execRoot: vi
         .fn()
         .mockResolvedValue(new Ok({ exitCode: 0, stdout: "", stderr: "" })),
     };
@@ -174,11 +178,12 @@ describe("sandbox environment manifest", () => {
     );
 
     expect(result).toEqual(new Ok(undefined));
-    expect(sandbox.exec).toHaveBeenCalledTimes(1);
-    const command = sandbox.exec.mock.calls[0][1] as string;
-    const opts = sandbox.exec.mock.calls[0][2] as {
+    expect(sandbox.execRoot).toHaveBeenCalledTimes(1);
+    const command = renderRootCommand(
+      sandbox.execRoot.mock.calls[0][1] as RootCommand
+    );
+    const opts = sandbox.execRoot.mock.calls[0][2] as {
       stdin: string;
-      user: string;
     };
     // Pin the exact install flags so a future drift to a tighter mode (or a
     // different owner) does not silently pass.
@@ -187,7 +192,6 @@ describe("sandbox environment manifest", () => {
     );
     expect(command).toContain(SANDBOX_ENV_MANIFEST_PATH);
     expect(command).not.toContain("api-secret");
-    expect(opts.user).toBe("root");
     expect(JSON.stringify(JSON.parse(opts.stdin))).not.toContain("api-secret");
   });
 });

--- a/front/lib/api/sandbox/env_manifest.ts
+++ b/front/lib/api/sandbox/env_manifest.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from "node:crypto";
 
 import { renderEgressSecretPlaceholder } from "@app/lib/api/sandbox/env_vars";
-import { shellEscape } from "@app/lib/api/sandbox/shell";
+import { rootCommand } from "@app/lib/api/sandbox/root_command";
 import type { Authenticator } from "@app/lib/auth";
 import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
@@ -93,14 +93,23 @@ export async function writeSandboxEnvManifestFile(
   }
 
   const tmpPath = `${SANDBOX_ENV_MANIFEST_DIR}/.sandbox-env-manifest.json.${randomBytes(8).toString("hex")}.tmp`;
-  const command =
-    `/usr/bin/mkdir -p ${shellEscape(SANDBOX_ENV_MANIFEST_DIR)} && ` +
-    `/usr/bin/install -o root -g root -m 644 /dev/stdin ${shellEscape(tmpPath)} && ` +
-    `/usr/bin/mv ${shellEscape(tmpPath)} ${shellEscape(SANDBOX_ENV_MANIFEST_PATH)}`;
+  const command = rootCommand.and([
+    rootCommand.exec("/usr/bin/mkdir", ["-p", SANDBOX_ENV_MANIFEST_DIR]),
+    rootCommand.exec("/usr/bin/install", [
+      "-o",
+      "root",
+      "-g",
+      "root",
+      "-m",
+      "644",
+      "/dev/stdin",
+      tmpPath,
+    ]),
+    rootCommand.exec("/usr/bin/mv", [tmpPath, SANDBOX_ENV_MANIFEST_PATH]),
+  ]);
 
-  const result = await sandbox.exec(auth, command, {
+  const result = await sandbox.execRoot(auth, command, {
     stdin: JSON.stringify(manifestResult.value),
-    user: "root",
   });
   if (result.isErr()) {
     return result;

--- a/front/lib/api/sandbox/gcs/mount.test.ts
+++ b/front/lib/api/sandbox/gcs/mount.test.ts
@@ -1,20 +1,23 @@
+import { renderRootCommand } from "@app/lib/api/sandbox/root_command";
 import { describe, expect, test } from "vitest";
 
 import { buildMountCommand } from "./mount";
 
 describe("GCS mount command", () => {
   test("uses absolute root-owned binaries for root gcsfuse mounts", () => {
-    const command = buildMountCommand({
-      bucket: "dust-bucket",
-      prefix: "w/workspace/conversations/conversation/files",
-      mountPoint: "/files/conversation",
-    });
+    const command = renderRootCommand(
+      buildMountCommand({
+        bucket: "dust-bucket",
+        prefix: "w/workspace/conversations/conversation/files",
+        mountPoint: "/files/conversation",
+      })
+    );
 
     expect(command).toContain("/usr/bin/timeout 30 /usr/bin/gcsfuse");
     expect(command).toContain(
-      "--only-dir 'w/workspace/conversations/conversation/files'"
+      "--only-dir w/workspace/conversations/conversation/files"
     );
-    expect(command).toContain("'dust-bucket' '/files/conversation'");
+    expect(command).toContain("dust-bucket /files/conversation");
     expect(command).not.toContain("timeout 30 gcsfuse");
   });
 });

--- a/front/lib/api/sandbox/gcs/mount.ts
+++ b/front/lib/api/sandbox/gcs/mount.ts
@@ -4,7 +4,10 @@ import {
 } from "@app/lib/api/files/mount_path";
 import { mintDownscopedGcsToken } from "@app/lib/api/sandbox/gcs/token";
 import type { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
-import { shellEscape } from "@app/lib/api/sandbox/shell";
+import {
+  type RootCommand,
+  rootCommand,
+} from "@app/lib/api/sandbox/root_command";
 import type { Authenticator } from "@app/lib/auth";
 import fileStorageConfig from "@app/lib/file_storage/config";
 import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
@@ -166,9 +169,8 @@ export async function mountConversationFiles(
     targets,
     async (target) => {
       const mountCmd = buildMountCommand({ bucket, ...target });
-      const mountResult = await sandbox.exec(auth, mountCmd, {
+      const mountResult = await sandbox.execRoot(auth, mountCmd, {
         timeoutMs: MOUNT_TIMEOUT_MS,
-        user: "root",
       });
 
       if (mountResult.isErr()) {
@@ -273,25 +275,36 @@ export function buildMountCommand({
   bucket: string;
   prefix: string;
   mountPoint: string;
-}): string {
-  const flags = [
-    `--token-url http://127.0.0.1:9876`,
-    // Disable token caching so gcsfuse fetches fresh token from server on every GCS API request.
-    // This ensures gcsfuse never uses stale credentials, eliminating 401 errors after token expiry.
-    `--reuse-token-from-url=false`,
-    `--only-dir ${shellEscape(prefix)}`,
-    `--implicit-dirs`,
-    `-o allow_other`,
-    `--file-mode=666`,
-    `--dir-mode=777`,
-    `--kernel-list-cache-ttl-secs=60`,
-    // Disable HNS (Hierarchical Namespace) support. gcsfuse calls GetStorageLayout at mount time
-    // when HNS is enabled, which requires unrestricted `objects.list` on the bucket. Disabling it
-    // lets us condition `objects.list` via the objectListPrefix CAB attribute.
-    `--enable-hns=false`,
-  ].join(" ");
-
-  return `/usr/bin/timeout 30 /usr/bin/gcsfuse ${flags} ${shellEscape(bucket)} ${shellEscape(mountPoint)} 2>&1`;
+}): RootCommand {
+  // Disable token caching so gcsfuse fetches fresh token from server on every
+  // GCS API request. This ensures gcsfuse never uses stale credentials,
+  // eliminating 401 errors after token expiry.
+  //
+  // Disable HNS (Hierarchical Namespace) support. gcsfuse calls
+  // GetStorageLayout at mount time when HNS is enabled, which requires
+  // unrestricted `objects.list` on the bucket. Disabling it lets us condition
+  // `objects.list` via the objectListPrefix CAB attribute.
+  return rootCommand.stderrToStdout(
+    rootCommand.timeout(
+      rootCommand.exec("/usr/bin/gcsfuse", [
+        "--token-url",
+        "http://127.0.0.1:9876",
+        "--reuse-token-from-url=false",
+        "--only-dir",
+        prefix,
+        "--implicit-dirs",
+        "-o",
+        "allow_other",
+        "--file-mode=666",
+        "--dir-mode=777",
+        "--kernel-list-cache-ttl-secs=60",
+        "--enable-hns=false",
+        bucket,
+        mountPoint,
+      ]),
+      MOUNT_TIMEOUT_MS / 1_000
+    )
+  );
 }
 
 function escapeSingleQuotes(s: string): string {

--- a/front/lib/api/sandbox/provider.ts
+++ b/front/lib/api/sandbox/provider.ts
@@ -12,6 +12,7 @@ import type {
   SandboxImageId,
   SandboxResources,
 } from "@app/lib/api/sandbox/image/types";
+import type { RootCommand } from "@app/lib/api/sandbox/root_command";
 import tracer from "@app/logger/tracer";
 import type { Result } from "@app/types/shared/result";
 
@@ -52,6 +53,14 @@ export interface ExecResult {
   stderr: string;
 }
 
+export const SANDBOX_EXEC_USERS = ["agent", "agent-proxied"] as const;
+
+export type SandboxExecUser = (typeof SANDBOX_EXEC_USERS)[number];
+
+export function isSandboxExecUser(user: string): user is SandboxExecUser {
+  return SANDBOX_EXEC_USERS.some((execUser) => execUser === user);
+}
+
 export interface ExecOptions {
   /** Working directory for command execution. */
   workingDirectory?: string;
@@ -61,9 +70,11 @@ export interface ExecOptions {
   envVars?: Record<string, string>;
   /** Data to send to the command over stdin. Never encoded into argv. */
   stdin?: string | Uint8Array;
-  /** User to run the command as (e.g., "root" for privileged tasks). */
-  user?: string;
+  /** Optional non-root user to run the command as. Use execRoot for root. */
+  user?: SandboxExecUser;
 }
+
+export type RootExecOptions = Omit<ExecOptions, "user">;
 
 // ---------------------------------------------------------------------------
 // Filesystem
@@ -123,6 +134,13 @@ export interface SandboxProvider {
     providerId: string,
     command: string,
     execOpts: ExecOptions | undefined,
+    tracingOpts: { workspaceId: string }
+  ): Promise<Result<ExecResult, Error>>;
+
+  execRoot(
+    providerId: string,
+    command: RootCommand,
+    execOpts: RootExecOptions | undefined,
     tracingOpts: { workspaceId: string }
   ): Promise<Result<ExecResult, Error>>;
 

--- a/front/lib/api/sandbox/providers/e2b.test.ts
+++ b/front/lib/api/sandbox/providers/e2b.test.ts
@@ -78,6 +78,7 @@ vi.mock("e2b", () => {
 import { CommandExitError } from "e2b";
 
 import { SANDBOX_ROOT_SAFE_PATH } from "../hardening";
+import { rootCommand } from "../root_command";
 import { E2BSandboxProvider } from "./e2b";
 
 describe("E2BSandboxProvider", () => {
@@ -182,10 +183,10 @@ describe("E2BSandboxProvider", () => {
       domain: undefined,
     });
 
-    const result = await provider.exec(
+    const result = await provider.execRoot(
       "provider-id",
-      "nohup /bin/true",
-      { user: "root" },
+      rootCommand.nohup(rootCommand.exec("/bin/true")),
+      undefined,
       { workspaceId: "workspace-id" }
     );
 
@@ -202,6 +203,65 @@ describe("E2BSandboxProvider", () => {
     expect(command).toContain("nohup /bin/true");
     expect(command).not.toContain("/opt/venv/bin");
     expect(command).not.toContain("/home/agent/.local/bin");
+  });
+
+  it("rejects raw root commands on the generic exec path", async () => {
+    const provider = new E2BSandboxProvider({
+      apiKey: "api-key",
+      domain: undefined,
+    });
+
+    const result = await provider.exec(
+      "provider-id",
+      "cat /tmp/deny.log",
+      // @ts-expect-error Root commands must use execRoot.
+      { user: "root" },
+      { workspaceId: "workspace-id" }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("Use execRoot()");
+    }
+    expect(mockConnect).not.toHaveBeenCalled();
+    expect(mockRun).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsupported users on the generic exec path", async () => {
+    const provider = new E2BSandboxProvider({
+      apiKey: "api-key",
+      domain: undefined,
+    });
+
+    const uidResult = await provider.exec(
+      "provider-id",
+      "id",
+      // @ts-expect-error Only SandboxExecUser values are allowed.
+      { user: "0" },
+      { workspaceId: "workspace-id" }
+    );
+
+    expect(uidResult.isErr()).toBe(true);
+    if (uidResult.isErr()) {
+      expect(uidResult.error.message).toContain("Invalid sandbox exec user: 0");
+    }
+
+    const localUserResult = await provider.exec(
+      "provider-id",
+      "id",
+      // @ts-expect-error The legacy local user account must not be a runtime exec target.
+      { user: "user" },
+      { workspaceId: "workspace-id" }
+    );
+
+    expect(localUserResult.isErr()).toBe(true);
+    if (localUserResult.isErr()) {
+      expect(localUserResult.error.message).toContain(
+        "Invalid sandbox exec user: user"
+      );
+    }
+    expect(mockConnect).not.toHaveBeenCalled();
+    expect(mockRun).not.toHaveBeenCalled();
   });
 
   it("does not wrap non-root commands", async () => {
@@ -304,13 +364,12 @@ describe("E2BSandboxProvider", () => {
     const stdin = "super-secret-json";
     const command = "install -m 600 /dev/stdin /run/dust/egress-secrets.json";
 
-    const result = await provider.exec(
+    const result = await provider.execRoot(
       "provider-id",
-      command,
+      rootCommand.unsafeShell(command, "test legacy stdin root command"),
       {
         stdin,
         timeoutMs: 5_000,
-        user: "root",
       },
       { workspaceId: "workspace-id" }
     );
@@ -357,10 +416,13 @@ describe("E2BSandboxProvider", () => {
       domain: undefined,
     });
 
-    const result = await provider.exec(
+    const result = await provider.execRoot(
       "provider-id",
-      "install -m 600 /dev/stdin /run/dust/egress-secrets.json",
-      { stdin: "secret-json", timeoutMs: 5_000, user: "root" },
+      rootCommand.unsafeShell(
+        "install -m 600 /dev/stdin /run/dust/egress-secrets.json",
+        "test legacy stdin root command"
+      ),
+      { stdin: "secret-json", timeoutMs: 5_000 },
       { workspaceId: "workspace-id" }
     );
 

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -10,14 +10,21 @@ import type {
   ExecOptions,
   ExecResult,
   FileEntry,
+  RootExecOptions,
   SandboxCreateConfig,
   SandboxHandle,
   SandboxProvider,
 } from "@app/lib/api/sandbox/provider";
 import {
+  isSandboxExecUser,
   SandboxNotFoundError,
   traceSandboxOperation,
 } from "@app/lib/api/sandbox/provider";
+import {
+  type RootCommand,
+  renderRootCommand,
+  rootCommand,
+} from "@app/lib/api/sandbox/root_command";
 import { shellEscape } from "@app/lib/api/sandbox/shell";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
@@ -42,14 +49,14 @@ const LOCAL_ACCOUNT_HARDENING_TIMEOUT_MS = 120_000;
 
 const ALL_TRAFFIC = "0.0.0.0/0";
 
-function getRootSafeSandboxCommand(command: string): string {
+function getRootSafeSandboxCommand(command: RootCommand): string {
   return [
     `PATH=${shellEscape(SANDBOX_ROOT_SAFE_PATH)}`,
     "HOME=/root",
     "BASH_ENV=/dev/null",
     "ENV=/dev/null",
     "/bin/bash --noprofile --norc -c",
-    shellEscape(command),
+    shellEscape(renderRootCommand(command)),
   ].join(" ");
 }
 
@@ -95,6 +102,14 @@ interface E2BConfig {
   domain: string | undefined;
 }
 
+interface E2BCommandOpts {
+  cwd?: string;
+  envs?: Record<string, string>;
+  stdin?: string | Uint8Array;
+  timeoutMs?: number;
+  user?: string;
+}
+
 // Send command stdin via the E2B Commands API rather than baking it into argv.
 // The command is started in the background with stdin open; if anything goes
 // wrong on the SDK round-trip, we kill the handle so we don't leak a running
@@ -102,12 +117,7 @@ interface E2BConfig {
 async function runWithStdin(
   sandbox: Sandbox,
   command: string,
-  commandOpts: {
-    cwd?: string;
-    envs?: Record<string, string>;
-    timeoutMs?: number;
-    user?: string;
-  },
+  commandOpts: E2BCommandOpts,
   stdin: string | Uint8Array
 ) {
   const handle = await sandbox.commands.run(command, {
@@ -177,6 +187,66 @@ export class E2BSandboxProvider implements SandboxProvider {
     }
   }
 
+  private async runCommand(
+    providerId: string,
+    command: string,
+    commandOpts: E2BCommandOpts,
+    tracingOpts: { workspaceId: string }
+  ): Promise<Result<ExecResult, Error>> {
+    return traceSandboxOperation(
+      "exec",
+      async () => {
+        let sandbox: Sandbox;
+        try {
+          sandbox = await Sandbox.connect(providerId, {
+            ...this.connectionOpts(),
+            timeoutMs: SANDBOX_LIFETIME_MS,
+          });
+        } catch (err) {
+          if (err instanceof NotFoundError) {
+            return new Err(new SandboxNotFoundError(providerId));
+          }
+          return new Err(normalizeError(err));
+        }
+
+        try {
+          const stdin = commandOpts.stdin;
+          const e2bCommandOpts = {
+            cwd: commandOpts.cwd,
+            envs: commandOpts.envs,
+            timeoutMs: commandOpts.timeoutMs,
+            user: commandOpts.user,
+          };
+          const result =
+            stdin === undefined
+              ? await sandbox.commands.run(command, e2bCommandOpts)
+              : await runWithStdin(sandbox, command, e2bCommandOpts, stdin);
+
+          return new Ok({
+            exitCode: result.exitCode,
+            stdout: result.stdout,
+            stderr: result.stderr,
+          });
+        } catch (err) {
+          // The E2B SDK throws CommandExitError on non-zero exit codes.
+          // Normalize into a regular ExecResult so callers never see E2B types.
+          if (err instanceof CommandExitError) {
+            return new Ok({
+              exitCode: err.exitCode,
+              stdout: err.stdout,
+              stderr: err.stderr,
+            });
+          }
+          return new Err(normalizeError(err));
+        }
+      },
+      {
+        provider_id: providerId,
+        workspace_id: tracingOpts.workspaceId,
+      }
+    );
+  }
+
   async create(
     config: SandboxCreateConfig,
     tracingOpts: { workspaceId: string }
@@ -219,7 +289,10 @@ export class E2BSandboxProvider implements SandboxProvider {
         try {
           const result = await sandbox.commands.run(
             getRootSafeSandboxCommand(
-              getLocalAccountPrivilegeHardeningCommand()
+              rootCommand.unsafeShell(
+                getLocalAccountPrivilegeHardeningCommand(),
+                "create-time sandbox local account hardening"
+              )
             ),
             {
               timeoutMs: LOCAL_ACCOUNT_HARDENING_TIMEOUT_MS,
@@ -377,61 +450,51 @@ export class E2BSandboxProvider implements SandboxProvider {
     execOpts: ExecOptions | undefined,
     tracingOpts: { workspaceId: string }
   ): Promise<Result<ExecResult, Error>> {
-    return traceSandboxOperation(
-      "exec",
-      async () => {
-        let sandbox: Sandbox;
-        try {
-          sandbox = await Sandbox.connect(providerId, {
-            ...this.connectionOpts(),
-            timeoutMs: SANDBOX_LIFETIME_MS,
-          });
-        } catch (err) {
-          if (err instanceof NotFoundError) {
-            return new Err(new SandboxNotFoundError(providerId));
-          }
-          return new Err(normalizeError(err));
-        }
+    const user: unknown = execOpts?.user;
+    if (
+      user !== undefined &&
+      (typeof user !== "string" || !isSandboxExecUser(user))
+    ) {
+      return new Err(
+        new Error(
+          user === "root"
+            ? "Use execRoot() for sandbox root commands."
+            : `Invalid sandbox exec user: ${String(user)}`
+        )
+      );
+    }
 
-        try {
-          const commandOpts = {
-            cwd: execOpts?.workingDirectory,
-            envs: execOpts?.envVars,
-            timeoutMs: execOpts?.timeoutMs,
-            user: execOpts?.user,
-          };
-          const stdin = execOpts?.stdin;
-          const commandToRun =
-            execOpts?.user === "root"
-              ? getRootSafeSandboxCommand(command)
-              : command;
-          const result =
-            stdin === undefined
-              ? await sandbox.commands.run(commandToRun, commandOpts)
-              : await runWithStdin(sandbox, commandToRun, commandOpts, stdin);
-
-          return new Ok({
-            exitCode: result.exitCode,
-            stdout: result.stdout,
-            stderr: result.stderr,
-          });
-        } catch (err) {
-          // The E2B SDK throws CommandExitError on non-zero exit codes.
-          // Normalize into a regular ExecResult so callers never see E2B types.
-          if (err instanceof CommandExitError) {
-            return new Ok({
-              exitCode: err.exitCode,
-              stdout: err.stdout,
-              stderr: err.stderr,
-            });
-          }
-          return new Err(normalizeError(err));
-        }
-      },
+    return this.runCommand(
+      providerId,
+      command,
       {
-        provider_id: providerId,
-        workspace_id: tracingOpts.workspaceId,
-      }
+        cwd: execOpts?.workingDirectory,
+        envs: execOpts?.envVars,
+        timeoutMs: execOpts?.timeoutMs,
+        stdin: execOpts?.stdin,
+        user: execOpts?.user,
+      },
+      tracingOpts
+    );
+  }
+
+  async execRoot(
+    providerId: string,
+    command: RootCommand,
+    execOpts: RootExecOptions | undefined,
+    tracingOpts: { workspaceId: string }
+  ): Promise<Result<ExecResult, Error>> {
+    return this.runCommand(
+      providerId,
+      getRootSafeSandboxCommand(command),
+      {
+        cwd: execOpts?.workingDirectory,
+        envs: execOpts?.envVars,
+        timeoutMs: execOpts?.timeoutMs,
+        stdin: execOpts?.stdin,
+        user: "root",
+      },
+      tracingOpts
     );
   }
 

--- a/front/lib/api/sandbox/root_command.test.ts
+++ b/front/lib/api/sandbox/root_command.test.ts
@@ -1,0 +1,97 @@
+import {
+  renderRootCommand,
+  rootCommand,
+} from "@app/lib/api/sandbox/root_command";
+import { describe, expect, test } from "vitest";
+
+describe("rootCommand", () => {
+  test("requires absolute executables", () => {
+    expect(() => rootCommand.exec("cat", ["/tmp/file"])).toThrow(
+      "Root command executable must be absolute"
+    );
+  });
+
+  test("requires non-empty command lists", () => {
+    expect(() => rootCommand.and([])).toThrow(
+      "Root command list must not be empty"
+    );
+  });
+
+  test("requires positive integer timeouts", () => {
+    expect(() => rootCommand.timeout(rootCommand.exec("/bin/true"), 0)).toThrow(
+      "Root command timeout must be a positive integer"
+    );
+    expect(() =>
+      rootCommand.timeout(rootCommand.exec("/bin/true"), 1.5)
+    ).toThrow("Root command timeout must be a positive integer");
+  });
+
+  test("quotes command arguments", () => {
+    expect(
+      renderRootCommand(rootCommand.exec("/usr/bin/cat", ["/tmp/a file"]))
+    ).toBe("/usr/bin/cat '/tmp/a file'");
+  });
+
+  test("composes root commands without parsing shell", () => {
+    const command = rootCommand.background(
+      rootCommand.redirectStdout(
+        rootCommand.nohup(
+          rootCommand.env(rootCommand.exec("/opt/bin/dsbx", ["forward"]), {
+            unset: ["SSL_CERT_FILE"],
+          })
+        ),
+        "/tmp/dsbx.log",
+        { stderrToStdout: true }
+      )
+    );
+
+    expect(renderRootCommand(command)).toBe(
+      "/usr/bin/nohup /usr/bin/env -u SSL_CERT_FILE /opt/bin/dsbx forward >'/tmp/dsbx.log' 2>&1 &"
+    );
+  });
+
+  test("groups compound commands before applying wrappers", () => {
+    const command = rootCommand.timeout(
+      rootCommand.and([
+        rootCommand.exec("/bin/echo", ["first"]),
+        rootCommand.exec("/bin/echo", ["second"]),
+      ]),
+      5
+    );
+
+    expect(renderRootCommand(command)).toBe(
+      "/usr/bin/timeout 5 /bin/bash --noprofile --norc -c '/bin/echo first && /bin/echo second'"
+    );
+  });
+
+  test("groups compound commands before joining with and", () => {
+    const command = rootCommand.and([
+      rootCommand.unsafeShell(
+        "/bin/echo first; /bin/echo still-first",
+        "compound test command"
+      ),
+      rootCommand.background(rootCommand.exec("/bin/echo", ["second"])),
+    ]);
+
+    expect(renderRootCommand(command)).toBe(
+      "/bin/bash --noprofile --norc -c '/bin/echo first; /bin/echo still-first' && /bin/bash --noprofile --norc -c '/bin/echo second &'"
+    );
+  });
+
+  test("makes unsafe shell explicit", () => {
+    expect(() => rootCommand.unsafeShell("", "empty command")).toThrow(
+      "Unsafe root shell commands must not be empty"
+    );
+    expect(() =>
+      rootCommand.unsafeShell("if true; then echo ok; fi", "")
+    ).toThrow("Unsafe root shell commands must include a reason");
+
+    const command = rootCommand.unsafeShell(
+      "if true; then echo ok; fi",
+      "compound shell flow"
+    );
+
+    expect(renderRootCommand(command)).toBe("if true; then echo ok; fi");
+    expect(command.unsafeReason).toBe("compound shell flow");
+  });
+});

--- a/front/lib/api/sandbox/root_command.ts
+++ b/front/lib/api/sandbox/root_command.ts
@@ -1,0 +1,166 @@
+import { shellEscape } from "@app/lib/api/sandbox/shell";
+
+const ROOT_COMMAND_BRAND: unique symbol = Symbol("RootCommand");
+
+export type RootCommandArg = string | number;
+type RootCommandShellForm = "simple" | "compound";
+
+export interface RootCommand {
+  readonly [ROOT_COMMAND_BRAND]: true;
+  readonly command: string;
+  readonly shellForm: RootCommandShellForm;
+  readonly unsafeReason?: string;
+}
+
+function makeRootCommand(
+  command: string,
+  shellForm: RootCommandShellForm,
+  unsafeReason?: string
+): RootCommand {
+  return {
+    [ROOT_COMMAND_BRAND]: true,
+    command,
+    shellForm,
+    ...(unsafeReason ? { unsafeReason } : {}),
+  };
+}
+
+function renderArg(arg: RootCommandArg): string {
+  if (typeof arg === "number") {
+    return String(arg);
+  }
+
+  return /^[A-Za-z0-9_./:,@%+=-]+$/.test(arg) ? arg : shellEscape(arg);
+}
+
+function assertAbsoluteExecutable(executable: string): void {
+  if (!executable.startsWith("/")) {
+    throw new Error(`Root command executable must be absolute: ${executable}`);
+  }
+  if (!/^\/[A-Za-z0-9_./+-]+$/.test(executable)) {
+    throw new Error(`Root command executable path is not safe: ${executable}`);
+  }
+}
+
+function assertNonEmptyReason(reason: string): void {
+  if (reason.trim().length === 0) {
+    throw new Error("Unsafe root shell commands must include a reason.");
+  }
+}
+
+function assertNonEmptyShellCommand(command: string): void {
+  if (command.trim().length === 0) {
+    throw new Error("Unsafe root shell commands must not be empty.");
+  }
+}
+
+function assertPositiveIntegerTimeout(timeoutSeconds: number): void {
+  if (!Number.isSafeInteger(timeoutSeconds) || timeoutSeconds <= 0) {
+    throw new Error(
+      `Root command timeout must be a positive integer: ${timeoutSeconds}`
+    );
+  }
+}
+
+function mergeUnsafeReasons(
+  commands: readonly RootCommand[]
+): string | undefined {
+  const reasons = commands
+    .flatMap((command) => (command.unsafeReason ? [command.unsafeReason] : []))
+    .filter((reason, index, reasons) => reasons.indexOf(reason) === index);
+
+  return reasons.length > 0 ? reasons.join("; ") : undefined;
+}
+
+function renderCommandOperand(command: RootCommand): string {
+  if (command.shellForm === "simple") {
+    return command.command;
+  }
+
+  return `/bin/bash --noprofile --norc -c ${shellEscape(command.command)}`;
+}
+
+function commandWithPrefix(prefix: string, command: RootCommand): RootCommand {
+  return makeRootCommand(
+    `${prefix} ${renderCommandOperand(command)}`,
+    "simple",
+    command.unsafeReason
+  );
+}
+
+export function renderRootCommand(command: RootCommand): string {
+  return command.command;
+}
+
+export const rootCommand = {
+  exec(executable: string, args: readonly RootCommandArg[] = []): RootCommand {
+    assertAbsoluteExecutable(executable);
+    return makeRootCommand(
+      [executable, ...args.map(renderArg)].join(" "),
+      "simple"
+    );
+  },
+
+  and(commands: readonly RootCommand[]): RootCommand {
+    if (commands.length === 0) {
+      throw new Error("Root command list must not be empty.");
+    }
+
+    return makeRootCommand(
+      commands.map(renderCommandOperand).join(" && "),
+      "compound",
+      mergeUnsafeReasons(commands)
+    );
+  },
+
+  env(command: RootCommand, opts: { unset: readonly string[] }): RootCommand {
+    const unsetArgs = opts.unset.flatMap((key) => ["-u", key]);
+    return commandWithPrefix(
+      renderRootCommand(rootCommand.exec("/usr/bin/env", unsetArgs)),
+      command
+    );
+  },
+
+  nohup(command: RootCommand): RootCommand {
+    return commandWithPrefix("/usr/bin/nohup", command);
+  },
+
+  timeout(command: RootCommand, timeoutSeconds: number): RootCommand {
+    assertPositiveIntegerTimeout(timeoutSeconds);
+    return commandWithPrefix(`/usr/bin/timeout ${timeoutSeconds}`, command);
+  },
+
+  redirectStdout(
+    command: RootCommand,
+    path: string,
+    opts: { stderrToStdout?: boolean } = {}
+  ): RootCommand {
+    return makeRootCommand(
+      `${renderCommandOperand(command)} >${shellEscape(path)}${opts.stderrToStdout ? " 2>&1" : ""}`,
+      "simple",
+      command.unsafeReason
+    );
+  },
+
+  stderrToStdout(command: RootCommand): RootCommand {
+    return makeRootCommand(
+      `${renderCommandOperand(command)} 2>&1`,
+      "simple",
+      command.unsafeReason
+    );
+  },
+
+  background(command: RootCommand): RootCommand {
+    return makeRootCommand(
+      `${renderCommandOperand(command)} &`,
+      "compound",
+      command.unsafeReason
+    );
+  },
+
+  unsafeShell(command: string, reason: string): RootCommand {
+    assertNonEmptyShellCommand(command);
+    assertNonEmptyReason(reason);
+    return makeRootCommand(command, "compound", reason);
+  },
+};

--- a/front/lib/api/sandbox/telemetry/index.ts
+++ b/front/lib/api/sandbox/telemetry/index.ts
@@ -1,4 +1,5 @@
 import config from "@app/lib/api/config";
+import { rootCommand } from "@app/lib/api/sandbox/root_command";
 import type { Authenticator } from "@app/lib/auth";
 import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import logger from "@app/logger/logger";
@@ -30,11 +31,13 @@ export async function startTelemetry(
 
   // /!\ DD_API_KEY must never appear literally in the command string;
   // journalctl logs argv. Always interpolate from the envVars below.
-  const result = await sandbox.exec(
+  const result = await sandbox.execRoot(
     auth,
-    `/usr/bin/systemctl set-environment DD_HOST="$DD_HOST" DD_API_KEY="$DD_API_KEY" E2B_SANDBOX_ID="$E2B_SANDBOX_ID" CONVERSATION_ID="$CONVERSATION_ID" WORKSPACE_ID="$WORKSPACE_ID" && /usr/bin/systemctl start fluent-bit`,
+    rootCommand.unsafeShell(
+      `/usr/bin/systemctl set-environment DD_HOST="$DD_HOST" DD_API_KEY="$DD_API_KEY" E2B_SANDBOX_ID="$E2B_SANDBOX_ID" CONVERSATION_ID="$CONVERSATION_ID" WORKSPACE_ID="$WORKSPACE_ID" && /usr/bin/systemctl start fluent-bit`,
+      "systemctl environment command expands sandbox env vars without embedding secrets in the TypeScript command string"
+    ),
     {
-      user: "root",
       envVars: {
         DD_HOST: "http-intake.logs.datadoghq.eu",
         DD_API_KEY: config.getDatadogApiKey() ?? "",

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -10,9 +10,11 @@ import type {
   ExecOptions,
   ExecResult,
   FileEntry,
+  RootExecOptions,
   SandboxProvider,
 } from "@app/lib/api/sandbox/provider";
 import { SandboxNotFoundError } from "@app/lib/api/sandbox/provider";
+import type { RootCommand } from "@app/lib/api/sandbox/root_command";
 import { SANDBOX_TRUST_ENV_VARS } from "@app/lib/api/sandbox/trust_env";
 import type { Authenticator } from "@app/lib/auth";
 import { executeWithLock } from "@app/lib/lock";
@@ -929,6 +931,41 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       logger.error(
         { sandbox: this.toLogJSON() },
         "Sandbox not found at provider during exec — marking as deleted"
+      );
+      await this.updateStatus("deleted");
+    }
+
+    return result;
+  }
+
+  /**
+   * Execute a privileged command in this sandbox.
+   *
+   * Root commands must be built as RootCommand so callers cannot accidentally
+   * pass raw shell strings through the generic exec path.
+   */
+  async execRoot(
+    auth: Authenticator,
+    command: RootCommand,
+    opts?: RootExecOptions
+  ): Promise<Result<ExecResult, Error>> {
+    const provider = getSandboxProvider();
+    if (!provider) {
+      return new Err(new Error("Sandbox provider not configured."));
+    }
+
+    const tracingOpts = { workspaceId: auth.getNonNullableWorkspace().sId };
+    const result = await provider.execRoot(
+      this.providerId,
+      command,
+      opts,
+      tracingOpts
+    );
+
+    if (result.isErr() && result.error instanceof SandboxNotFoundError) {
+      logger.error(
+        { sandbox: this.toLogJSON() },
+        "Sandbox not found at provider during root exec — marking as deleted"
       );
       await this.updateStatus("deleted");
     }

--- a/front/scripts/sandbox_exec.ts
+++ b/front/scripts/sandbox_exec.ts
@@ -4,6 +4,8 @@ import config from "@app/lib/api/config";
 import logger from "@app/logger/logger";
 import { Sandbox } from "e2b";
 
+// Operator-only escape hatch for manual sandbox debugging. Runtime app code must
+// route sandbox root execution through SandboxProvider.execRoot.
 async function main() {
   // Find the -- separator
   const separatorIndex = process.argv.indexOf("--");

--- a/front/scripts/sandbox_security_check.ts
+++ b/front/scripts/sandbox_security_check.ts
@@ -10,8 +10,16 @@ import {
   getSandboxImageFromRegistry,
   type SandboxImage,
 } from "@app/lib/api/sandbox/image";
-import type { ExecResult } from "@app/lib/api/sandbox/provider";
+import type {
+  ExecResult,
+  RootExecOptions,
+  SandboxExecUser,
+} from "@app/lib/api/sandbox/provider";
 import { E2BSandboxProvider } from "@app/lib/api/sandbox/providers/e2b";
+import {
+  type RootCommand,
+  rootCommand,
+} from "@app/lib/api/sandbox/root_command";
 import logger from "@app/logger/logger";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
@@ -59,7 +67,7 @@ async function runCommand(
   provider: E2BSandboxProvider,
   providerId: string,
   command: string,
-  options: { user: string; timeoutMs?: number }
+  options: { user: SandboxExecUser; timeoutMs?: number }
 ): Promise<ExecResult> {
   const result = await provider.exec(
     providerId,
@@ -76,16 +84,51 @@ async function runCommand(
   return result.value;
 }
 
+async function runRootCommand(
+  provider: E2BSandboxProvider,
+  providerId: string,
+  command: RootCommand,
+  options: RootExecOptions = {}
+): Promise<ExecResult> {
+  const result = await provider.execRoot(
+    providerId,
+    command,
+    options,
+    TRACE_OPTS
+  );
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
+}
+
 async function runBashScript(
   provider: E2BSandboxProvider,
   providerId: string,
   script: string,
-  options: { user: string; timeoutMs?: number }
+  options: { user: SandboxExecUser; timeoutMs?: number }
 ): Promise<ExecResult> {
   return runCommand(provider, providerId, buildBashCommand(script), {
     timeoutMs: options.timeoutMs,
     user: options.user,
   });
+}
+
+async function runRootBashScript(
+  provider: E2BSandboxProvider,
+  providerId: string,
+  script: string,
+  options: RootExecOptions = {}
+): Promise<ExecResult> {
+  return runRootCommand(
+    provider,
+    providerId,
+    rootCommand.unsafeShell(
+      buildBashCommand(script),
+      "sandbox security check root bash probe"
+    ),
+    options
+  );
 }
 
 function assertNoRootIdentity(label: string, result: ExecResult): void {
@@ -244,7 +287,7 @@ async function checkTargetUserState(
   provider: E2BSandboxProvider,
   providerId: string
 ): Promise<void> {
-  const audit = await runBashScript(
+  const audit = await runRootBashScript(
     provider,
     providerId,
     `
@@ -264,8 +307,7 @@ if getent passwd user >/dev/null; then
 else
   echo "USER_EXISTS=0"
 fi
-`,
-    { user: "root" }
+`
   );
   const output = combinedOutput(audit);
 
@@ -547,7 +589,7 @@ async function checkSystemAccountAudit(
   provider: E2BSandboxProvider,
   providerId: string
 ): Promise<void> {
-  const audit = await runBashScript(
+  const audit = await runRootBashScript(
     provider,
     providerId,
     `
@@ -612,8 +654,7 @@ done
 echo "--- root-path ---"
 printf 'ROOT_EXEC_PATH=%s\n' "$PATH"
 /bin/bash --noprofile --norc -c 'source /etc/profile; printf "ROOT_LOGIN_PATH=%s\n" "$PATH"'
-`,
-    { user: "root" }
+`
   );
   const output = combinedOutput(audit);
 
@@ -638,7 +679,7 @@ async function checkRootExecPathHijack(
   const plantedPath = "/opt/venv/bin/nohup";
 
   try {
-    const seed = await runBashScript(
+    const seed = await runRootBashScript(
       provider,
       providerId,
       `
@@ -648,8 +689,7 @@ printf %s ${shellQuote(marker)} > ${shellQuote(secretPath)}
 /usr/bin/chown root:root ${shellQuote(secretPath)}
 /usr/bin/chmod 600 ${shellQuote(secretPath)}
 /usr/bin/rm -rf ${shellQuote(leakDir)}
-`,
-      { user: "root" }
+`
     );
     assertCommandSucceeded("root exec path hijack seed", seed);
 
@@ -672,7 +712,7 @@ DUST_HIJACK_EOF
     );
     assertCommandSucceeded("root exec path hijack plant", plant);
 
-    const trigger = await runBashScript(
+    const trigger = await runRootBashScript(
       provider,
       providerId,
       `
@@ -686,8 +726,7 @@ if [ -f ${shellQuote(`${leakDir}/leaked`)} ]; then
   exit 1
 fi
 command -v nohup
-`,
-      { user: "root" }
+`
     );
     assertCommandSucceeded("root exec path hijack trigger", trigger);
     if (combinedOutput(trigger).trim() !== "/usr/bin/nohup") {
@@ -714,14 +753,13 @@ fi
     assertCommandSucceeded("root exec path hijack readback", readback);
   } finally {
     try {
-      await runBashScript(
+      await runRootBashScript(
         provider,
         providerId,
         `
 /usr/bin/rm -f ${shellQuote(plantedPath)} ${shellQuote(secretPath)}
 /usr/bin/rm -rf ${shellQuote(leakDir)}
-`,
-        { user: "root" }
+`
       );
     } catch (error) {
       logger.warn(
@@ -783,7 +821,7 @@ fi
     }
   } finally {
     try {
-      await runBashScript(
+      await runRootBashScript(
         provider,
         providerId,
         `
@@ -791,8 +829,7 @@ fi
 /bin/rm -rf ${shellQuote(proofDir)}
 /usr/bin/systemctl daemon-reload >/dev/null 2>&1 || true
 /usr/bin/systemctl reset-failed dbus-org.freedesktop.hostname1.service systemd-hostnamed.service >/dev/null 2>&1 || true
-`,
-        { user: "root" }
+`
       );
     } catch (error) {
       logger.warn(
@@ -842,7 +879,7 @@ async function checkSshAndDnsHardening(
   provider: E2BSandboxProvider,
   providerId: string
 ): Promise<void> {
-  const audit = await runBashScript(
+  const audit = await runRootBashScript(
     provider,
     providerId,
     `
@@ -871,8 +908,7 @@ echo "--- nft-ip ---"
 /usr/sbin/nft -n list table ip dust-egress
 echo "--- nft-ip6 ---"
 /usr/sbin/nft -n list table ip6 dust-egress
-`,
-    { user: "root" }
+`
   );
 
   assertCommandSucceeded("SSH and DNS hardening audit", audit);


### PR DESCRIPTION
## Description

Adds a `RootCommand` API and `execRoot(...)` path for sandbox root execution. Generic sandbox `exec(...)` is now non-root only, with a runtime allowlist before E2B sees the user value.

Also converts current runtime root callsites, updates sandbox reviewer rules, and keeps the operator-only `sandbox_exec.ts` escape hatch documented.

## Tests

Added focused tests for `RootCommand`, E2B root execution wrapping, generic root rejection, and sandbox security checks.

Manually validated in a real E2B `dust-base:0.8.29` sandbox: `execRoot` runs as root, compound root commands are grouped correctly, generic `root` and `0` users are rejected, `agent-proxied` cannot plant `/usr/local/sbin/cat`, `agent-proxied` can still run `/opt/bin/dsbx`, and the created sandbox was destroyed.

## Risk

Moderate. This touches sandbox root command plumbing. Rollback is straightforward, but callers added before this PR should use `execRoot(...)` for root work.

## Deploy Plan

Standard deploy. Old sandboxes can be killed