### PR TITLE
feat(billing): notify users when their per-user AWU cap is reached

### DIFF
--- a/front-api/routes/novu/index.ts
+++ b/front-api/routes/novu/index.ts
@@ -4,6 +4,7 @@ import { conversationUnreadWorkflow } from "@app/lib/notifications/workflows/con
 import { projectAddedAsMemberWorkflow } from "@app/lib/notifications/workflows/project-added-as-member";
 import { providerCredentialsHealthUpdatedWorkflow } from "@app/lib/notifications/workflows/provider-credential-updated";
 import { skillSuggestionsReadyWorkflow } from "@app/lib/notifications/workflows/skill-suggestions-ready";
+import { userAwuCapReachedWorkflow } from "@app/lib/notifications/workflows/user-awu-cap-reached";
 import { serve } from "@novu/framework/next";
 import { Hono } from "hono";
 
@@ -28,6 +29,7 @@ const novu = serve({
     skillSuggestionsReadyWorkflow,
     projectAddedAsMemberWorkflow,
     providerCredentialsHealthUpdatedWorkflow,
+    userAwuCapReachedWorkflow,
   ],
 }) as unknown as Record<"GET" | "POST" | "OPTIONS", FetchHandler>;
 

--- a/front/lib/api/email.ts
+++ b/front/lib/api/email.ts
@@ -177,6 +177,27 @@ export async function sendProactiveTrialCancelledEmail(
   });
 }
 
+export async function sendUserAwuCapReachedEmail({
+  email,
+  workspace,
+  capAwuCredits,
+}: {
+  email: string;
+  workspace: WorkspaceType;
+  capAwuCredits: number;
+}): Promise<Result<void, Error>> {
+  return sendEmailWithTemplate({
+    to: email,
+    from: config.getSupportEmailAddress(),
+    subject: `[Dust] You've reached your usage limit in ${escape(workspace.name)}`,
+    body: `
+      <p>You have reached your <strong>${capAwuCredits} AWU</strong> usage limit in the Dust workspace <strong>${escape(workspace.name)}</strong>.</p>
+      <p>You won't be able to run agents until your limit is increased. Please contact your workspace admin.</p>`,
+    buttonLabel: "Go to workspace",
+    buttonUrl: `https://dust.tt/w/${workspace.sId}`,
+  });
+}
+
 export async function sendCreditUsageAlertEmail({
   email,
   workspace,

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -1,3 +1,4 @@
+import { sendUserAwuCapReachedEmail } from "@app/lib/api/email";
 import {
   dispatchCreditsAdded,
   dispatchPaygCapReached,
@@ -42,9 +43,11 @@ import { invalidateContractCache } from "@app/lib/metronome/plan_type";
 import { isMetronomeFreeCredit } from "@app/lib/metronome/types";
 import type { MetronomeWebhookEvent } from "@app/lib/metronome/webhook_events";
 import { PlanModel } from "@app/lib/models/plan";
+import { notifyUserAwuCapReached } from "@app/lib/notifications/workflows/user-awu-cap-reached";
 import { isFreePlan } from "@app/lib/plans/plan_codes";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
@@ -243,8 +246,10 @@ async function handlePerUserSpendThresholdEvent({
 
   let effectiveState: MetronomeAlertState;
   let source: "override" | "default" | "none";
+  let capThreshold: number | null | undefined;
   if (overrideResult.value) {
     effectiveState = overrideResult.value.customer_status;
+    capThreshold = overrideResult.value.alert.threshold;
     source = "override";
   } else {
     const defaultResult = await getMetronomeDefaultUserCapAlert({
@@ -261,6 +266,7 @@ async function handlePerUserSpendThresholdEvent({
     }
     if (defaultResult.value) {
       effectiveState = defaultResult.value.customer_status;
+      capThreshold = defaultResult.value.alert.threshold;
       source = "default";
     } else {
       effectiveState = "ok";
@@ -292,6 +298,27 @@ async function handlePerUserSpendThresholdEvent({
             `Error dispatching per-user cap reached: ${dispatchResult.error.message}`
           )
         );
+      }
+      // Notify the user (email + in-app) that they've hit their AWU cap.
+      // Runs after the dispatch so the block is already in place.
+      const capAwuCredits = capThreshold ?? 0;
+      const user = await UserResource.fetchById(userId);
+      if (user) {
+        const lightWorkspace = renderLightWorkspaceType({ workspace });
+        void sendUserAwuCapReachedEmail({
+          email: user.email,
+          workspace: lightWorkspace,
+          capAwuCredits,
+        });
+        notifyUserAwuCapReached({
+          userSId: user.sId,
+          userEmail: user.email,
+          userFirstName: user.firstName,
+          userLastName: user.lastName,
+          workspaceId: workspace.sId,
+          workspaceName: lightWorkspace.name,
+          capAwuCredits,
+        });
       }
       break;
     }
@@ -470,6 +497,12 @@ export async function processMetronomeWebhook({
       );
       break;
     }
+    case "alerts.low_remaining_seat_balance_reached": {
+      break;
+    }
+    case "alerts.low_remaining_seat_balance_resolved": {
+      break;
+    }
     case "alerts.invoice_total_reached":
     case "alerts.invoice_total_resolved":
     case "alerts.low_remaining_commit_balance_reached":
@@ -478,8 +511,6 @@ export async function processMetronomeWebhook({
     case "alerts.low_remaining_contract_credit_balance_resolved":
     case "alerts.low_remaining_credit_balance_reached":
     case "alerts.low_remaining_credit_balance_resolved":
-    case "alerts.low_remaining_seat_balance_reached":
-    case "alerts.low_remaining_seat_balance_resolved":
     case "alerts.usage_threshold_reached":
     case "alerts.usage_threshold_resolved":
     case "commit.archive":

--- a/front/lib/metronome/webhook_events.ts
+++ b/front/lib/metronome/webhook_events.ts
@@ -176,17 +176,19 @@ const InvoiceTotalResolvedSchema = z.object({
 });
 
 // alerts.low_remaining_seat_balance_*
-// Undocumented in the public webhook docs but emitted today. Assume the same
-// base alert envelope (other alerts.* all share `baseAlertPropertiesSchema`).
+// Undocumented in the public webhook docs but emitted today.
+const lowRemainingSeatBalanceProps = baseAlertPropertiesSchema.extend({
+  remaining_balance: z.number().nullish(),
+});
 const LowRemainingSeatBalanceReachedSchema = z.object({
   id: z.string(),
   type: z.literal("alerts.low_remaining_seat_balance_reached"),
-  properties: baseAlertPropertiesSchema,
+  properties: lowRemainingSeatBalanceProps,
 });
 const LowRemainingSeatBalanceResolvedSchema = z.object({
   id: z.string(),
   type: z.literal("alerts.low_remaining_seat_balance_resolved"),
-  properties: baseAlertPropertiesSchema,
+  properties: lowRemainingSeatBalanceProps,
 });
 
 // ============================================================================

--- a/front/pages/api/novu/index.ts
+++ b/front/pages/api/novu/index.ts
@@ -7,6 +7,7 @@ import { conversationUnreadWorkflow } from "@app/lib/notifications/workflows/con
 import { projectAddedAsMemberWorkflow } from "@app/lib/notifications/workflows/project-added-as-member";
 import { providerCredentialsHealthUpdatedWorkflow } from "@app/lib/notifications/workflows/provider-credential-updated";
 import { skillSuggestionsReadyWorkflow } from "@app/lib/notifications/workflows/skill-suggestions-ready";
+import { userAwuCapReachedWorkflow } from "@app/lib/notifications/workflows/user-awu-cap-reached";
 import { serve } from "@novu/framework/next";
 
 // This endpoint exposes our code-based notifications workflows to the Novu platform.
@@ -22,5 +23,6 @@ export default serve({
     skillSuggestionsReadyWorkflow,
     projectAddedAsMemberWorkflow,
     providerCredentialsHealthUpdatedWorkflow,
+    userAwuCapReachedWorkflow,
   ],
 });

--- a/front/types/notification_preferences.ts
+++ b/front/types/notification_preferences.ts
@@ -106,9 +106,13 @@ export const PROVIDER_CREDENTIALS_HEALTH_UPDATED_TRIGGER_ID =
 export const PROVIDER_CREDENTIALS_HEALTH_UPDATED_TAG =
   "provider-credentials-health" as const;
 
+export const USER_AWU_CAP_REACHED_TRIGGER_ID = "user-awu-cap-reached" as const;
+export const USER_AWU_CAP_REACHED_TAG = "user-awu-cap-reached" as const;
+
 export type WorkflowTriggerId =
   | typeof CONVERSATION_UNREAD_TRIGGER_ID
   | typeof PROJECT_ADDED_AS_MEMBER_TRIGGER_ID
   | typeof AGENT_SUGGESTIONS_READY_TRIGGER_ID
   | typeof SKILL_SUGGESTIONS_READY_TRIGGER_ID
-  | typeof PROVIDER_CREDENTIALS_HEALTH_UPDATED_TRIGGER_ID;
+  | typeof PROVIDER_CREDENTIALS_HEALTH_UPDATED_TRIGGER_ID
+  | typeof USER_AWU_CAP_REACHED_TRIGGER_ID;


### PR DESCRIPTION
## Description

When a workspace admin configures a per-user AWU spend cap (via `setDefaultUserSpendLimit` or per-user override), Metronome fires a `spend_threshold_reached` webhook when a user hits that cap. Previously, the cap silently blocked the user (403 on next agent call) with no proactive notification.

This PR adds two notifications sent to the **capped user** (not admins) when the Metronome webhook fires:
- **Email** (`sendUserAwuCapReachedEmail`): tells the user they've hit their limit, shows the cap value, and links back to the workspace.
- **In-app Novu notification** (`user-awu-cap-reached` workflow): shows a persistent in-app message so they see it the next time they open Dust.

Also extends the `low_remaining_seat_balance_*` webhook event schemas to capture `remaining_balance`, and moves those cases out of the silent catch-all into explicit no-op cases for clarity.

## Tests

Manual: the `handlePerUserSpendThresholdEvent` path is exercised by the existing Metronome webhook flow. The new email and Novu calls are fire-and-forget so they don't affect webhook ack.

## Risk

Low — the two new calls are fire-and-forget (`void`) and only run when `effectiveState === "in_alarm"`, which is the existing cap-reached path. Failures are logged but don't affect the blocking behaviour already in place.
