### PR TITLE
fix: display save to pod erros

### DIFF
--- a/front-api/routes/w/[wId]/files/[fileId]/save-in-project.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/save-in-project.ts
@@ -116,11 +116,20 @@ app.post(
       });
     }
 
-    await addFileToProject(auth, {
+    const result = await addFileToProject(auth, {
       file,
       space,
       sourceConversationId: file.useCaseMetadata?.conversationId,
     });
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: result.error.message,
+        },
+      });
+    }
 
     return ctx.json({ file: file.toJSONWithMetadata(auth) });
   }

--- a/front/pages/api/w/[wId]/files/[fileId]/save-in-project.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/save-in-project.ts
@@ -147,11 +147,20 @@ async function handler(
 
   switch (req.method) {
     case "POST": {
-      await addFileToProject(auth, {
+      const result = await addFileToProject(auth, {
         file,
         space,
         sourceConversationId: file.useCaseMetadata?.conversationId,
       });
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: result.error.message,
+          },
+        });
+      }
 
       return res.status(200).json({
         file: file.toJSONWithMetadata(auth),


### PR DESCRIPTION
## Description

This PR fixes the "save to pod" API endpoints to properly surface errors when `addFileToProject` fails, instead of silently ignoring them and returning a success response.

## Tests

Manually.

## Risks

<!-- Discuss potential risks and how they will be mitigated. -->

## Deploy Plan

<!-- Outline the deployment steps if needed. -->
