### PR TITLE
feat(billing): notify users when their per-user AWU cap is reached

### DIFF
--- a/front-api/routes/novu/index.ts
+++ b/front-api/routes/novu/index.ts
@@ -4,6 +4,7 @@ import { conversationUnreadWorkflow } from "@app/lib/notifications/workflows/con
 import { projectAddedAsMemberWorkflow } from "@app/lib/notifications/workflows/project-added-as-member";
 import { providerCredentialsHealthUpdatedWorkflow } from "@app/lib/notifications/workflows/provider-credential-updated";
 import { skillSuggestionsReadyWorkflow } from "@app/lib/notifications/workflows/skill-suggestions-ready";
+import { userAwuCapReachedWorkflow } from "@app/lib/notifications/workflows/user-awu-cap-reached";
 import { createHono } from "@front-api/lib/hono";
 import type { ServeHandlerOptions } from "@novu/framework";
 import { NovuRequestHandler } from "@novu/framework";
@@ -27,6 +28,7 @@ const options: ServeHandlerOptions = {
     skillSuggestionsReadyWorkflow,
     projectAddedAsMemberWorkflow,
     providerCredentialsHealthUpdatedWorkflow,
+    userAwuCapReachedWorkflow,
   ],
 };
 

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -22,7 +22,9 @@ import {
 } from "@app/lib/credits/free";
 import {
   getMetronomeDefaultUserCapAlert,
+  getMetronomeDefaultUserWarningAlert,
   getMetronomePerUserCap,
+  getMetronomePerUserWarningAlert,
 } from "@app/lib/metronome/alerts/spend_limits";
 import { emitSubscriptionChangedAuditEvent } from "@app/lib/metronome/audit";
 import {
@@ -45,9 +47,11 @@ import { invalidateContractCache } from "@app/lib/metronome/plan_type";
 import { isMetronomeFreeCredit } from "@app/lib/metronome/types";
 import type { MetronomeWebhookEvent } from "@app/lib/metronome/webhook_events";
 import { PlanModel } from "@app/lib/models/plan";
+import { notifyUserAwuCapReached } from "@app/lib/notifications/workflows/user-awu-cap-reached";
 import { isFreePlan } from "@app/lib/plans/plan_codes";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
@@ -450,25 +454,49 @@ async function handlePerUserSpendThresholdEvent({
     return new Ok(undefined);
   }
 
-  const overrideResult = await getMetronomePerUserCap({
+  const userCapResult = await getMetronomePerUserCap({
     metronomeCustomerId,
     workspaceId: workspace.sId,
     userId,
   });
-  if (overrideResult.isErr()) {
+  if (userCapResult.isErr()) {
     return new Err(
       new ProcessMetronomeWebhookError(
         "processing_failed",
-        `Error reading per-user cap override: ${overrideResult.error.message}`
+        `Error reading per-user cap override: ${userCapResult.error.message}`
       )
     );
   }
 
-  let effectiveState: MetronomeAlertState;
+  let effectiveCapState: MetronomeAlertState;
+  let effectiveWarningState: MetronomeAlertState;
   let source: "override" | "default" | "none";
-  if (overrideResult.value) {
-    effectiveState = overrideResult.value.customer_status;
+  let capThreshold: number | null | undefined;
+
+  if (userCapResult.value) {
+    effectiveCapState = userCapResult.value.customer_status;
+    capThreshold = userCapResult.value.alert.threshold;
     source = "override";
+
+    const userWarningResult = await getMetronomePerUserWarningAlert({
+      metronomeCustomerId,
+      workspaceId: workspace.sId,
+      userId,
+    });
+    if (userWarningResult.isErr()) {
+      logger.warn(
+        {
+          eventId: event.id,
+          workspaceId: workspace.sId,
+          userId,
+          err: userWarningResult.error,
+        },
+        "[Metronome Webhook] per-user spend threshold: failed to read warning alert, skipping notification"
+      );
+      effectiveWarningState = "ok";
+    } else {
+      effectiveWarningState = userWarningResult.value?.customer_status ?? "ok";
+    }
   } else {
     const defaultResult = await getMetronomeDefaultUserCapAlert({
       metronomeCustomerId,
@@ -483,15 +511,36 @@ async function handlePerUserSpendThresholdEvent({
       );
     }
     if (defaultResult.value) {
-      effectiveState = defaultResult.value.customer_status;
+      effectiveCapState = defaultResult.value.customer_status;
+      capThreshold = defaultResult.value.alert.threshold;
       source = "default";
+
+      const warningResult = await getMetronomeDefaultUserWarningAlert({
+        metronomeCustomerId,
+        workspaceId: workspace.sId,
+      });
+      if (warningResult.isErr()) {
+        logger.warn(
+          {
+            eventId: event.id,
+            workspaceId: workspace.sId,
+            userId,
+            err: warningResult.error,
+          },
+          "[Metronome Webhook] per-user spend threshold: failed to read default warning alert, skipping notification"
+        );
+        effectiveWarningState = "ok";
+      } else {
+        effectiveWarningState = warningResult.value?.customer_status ?? "ok";
+      }
     } else {
-      effectiveState = "ok";
+      effectiveCapState = "ok";
+      effectiveWarningState = "ok";
       source = "none";
     }
   }
 
-  switch (effectiveState) {
+  switch (effectiveCapState) {
     case "in_alarm": {
       const dispatchResult = await dispatchPerUserCapReached({
         workspace,
@@ -515,6 +564,22 @@ async function handlePerUserSpendThresholdEvent({
             `Error dispatching per-user cap reached: ${dispatchResult.error.message}`
           )
         );
+      }
+      // Notify the user (email + in-app) that they are now hard-blocked.
+      const capAwuCreditsBlocked = capThreshold ?? 0;
+      const blockedUser = await UserResource.fetchById(userId);
+      if (blockedUser) {
+        const lightWorkspace = renderLightWorkspaceType({ workspace });
+        notifyUserAwuCapReached({
+          userSId: blockedUser.sId,
+          userEmail: blockedUser.email,
+          userFirstName: blockedUser.firstName,
+          userLastName: blockedUser.lastName,
+          workspaceId: workspace.sId,
+          workspaceName: lightWorkspace.name,
+          capAwuCredits: capAwuCreditsBlocked,
+          isBlocked: true,
+        });
       }
       break;
     }
@@ -551,7 +616,34 @@ async function handlePerUserSpendThresholdEvent({
       // already set the right state; a follow-up event will reconcile.
       break;
     default:
-      assertNever(effectiveState);
+      assertNever(effectiveCapState);
+  }
+
+  // Notify the user (email + in-app) when they've crossed 80% of their AWU cap
+  // but have not yet been hard-blocked. The cap alert fires at 100% and is
+  // handled above; the warning alert fires at 80% and triggers notifications only.
+  if (
+    effectiveWarningState === "in_alarm" &&
+    effectiveCapState !== "in_alarm"
+  ) {
+    logger.info(
+      "[Metronome Webhook] per-user spend threshold warning: handling..."
+    );
+    const capAwuCredits = capThreshold ?? 0;
+    const user = await UserResource.fetchById(userId);
+    if (user) {
+      const lightWorkspace = renderLightWorkspaceType({ workspace });
+      notifyUserAwuCapReached({
+        userSId: user.sId,
+        userEmail: user.email,
+        userFirstName: user.firstName,
+        userLastName: user.lastName,
+        workspaceId: workspace.sId,
+        workspaceName: lightWorkspace.name,
+        capAwuCredits,
+        isBlocked: false,
+      });
+    }
   }
 
   logger.info(
@@ -560,7 +652,8 @@ async function handlePerUserSpendThresholdEvent({
       eventType: event.type,
       workspaceId: workspace.sId,
       userId,
-      effectiveState,
+      effectiveCapState,
+      effectiveWarningState,
       source,
     },
     "[Metronome Webhook] per-user spend threshold: handled"
@@ -703,6 +796,11 @@ export async function processMetronomeWebhook({
       );
       break;
     }
+    // Handled by custom alerts above
+    case "alerts.low_remaining_seat_balance_reached":
+    case "alerts.low_remaining_seat_balance_resolved":
+      break;
+
     case "alerts.invoice_total_reached":
     case "alerts.invoice_total_resolved":
     case "alerts.low_remaining_commit_balance_reached":
@@ -711,8 +809,6 @@ export async function processMetronomeWebhook({
     case "alerts.low_remaining_contract_credit_balance_resolved":
     case "alerts.low_remaining_credit_balance_reached":
     case "alerts.low_remaining_credit_balance_resolved":
-    case "alerts.low_remaining_seat_balance_reached":
-    case "alerts.low_remaining_seat_balance_resolved":
     case "alerts.usage_threshold_reached":
     case "alerts.usage_threshold_resolved":
     case "commit.archive":

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -11,9 +11,11 @@ import type { AuditLogContext } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
 import {
   clearMetronomePerUserCapAlert,
+  clearMetronomePerUserWarningAlert,
   getMetronomeDefaultUserCapAlert,
   getMetronomePerUserCap,
   upsertMetronomePerUserCapAlert,
+  upsertMetronomePerUserWarningAlert,
 } from "@app/lib/metronome/alerts/spend_limits";
 import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -222,6 +224,23 @@ export async function setUserSpendLimit(
         );
       }
 
+      // Best-effort: also clear the companion 80% warning alert.
+      const clearWarningResult = await clearMetronomePerUserWarningAlert({
+        metronomeCustomerId: workspace.metronomeCustomerId,
+        workspaceId: workspace.sId,
+        userId: user.sId,
+      });
+      if (clearWarningResult.isErr()) {
+        logger.warn(
+          {
+            workspaceId: workspace.sId,
+            userId: user.sId,
+            err: clearWarningResult.error,
+          },
+          "[Metronome PerUserCap] Failed to clear warning alert; continuing"
+        );
+      }
+
       const defaultResult = await getMetronomeDefaultUserCapAlert({
         metronomeCustomerId: workspace.metronomeCustomerId,
         workspaceId: workspace.sId,
@@ -269,6 +288,26 @@ export async function setUserSpendLimit(
           new UserSpendLimitError("metronome_error", upsertResult.error.message)
         );
       }
+
+      // Best-effort: also upsert the companion 80% warning alert.
+      const upsertWarningResult = await upsertMetronomePerUserWarningAlert({
+        metronomeCustomerId: workspace.metronomeCustomerId,
+        workspaceId: workspace.sId,
+        userId: user.sId,
+        capAwuCredits: limit.awuCredits,
+      });
+      if (upsertWarningResult.isErr()) {
+        logger.warn(
+          {
+            workspaceId: workspace.sId,
+            userId: user.sId,
+            awuCredits: limit.awuCredits,
+            err: upsertWarningResult.error,
+          },
+          "[Metronome PerUserCap] Failed to upsert warning alert; continuing"
+        );
+      }
+
       transitionedTo = await resolveLocalCapState({
         metronomeCustomerId: workspace.metronomeCustomerId,
         metronomeContractId: auth.subscription()?.metronomeContractId ?? null,

--- a/front/lib/api/workspace/default_user_spend_limit.ts
+++ b/front/lib/api/workspace/default_user_spend_limit.ts
@@ -7,7 +7,9 @@ import type { Authenticator } from "@app/lib/auth";
 import {
   getMetronomeDefaultUserCapAlert,
   upsertMetronomeDefaultUserCapAlert,
+  upsertMetronomeDefaultUserWarningAlert,
 } from "@app/lib/metronome/alerts/spend_limits";
+import logger from "@app/logger/logger";
 import {
   MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
   MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
@@ -132,6 +134,25 @@ export async function setDefaultUserSpendLimit(
         "metronome_error",
         upsertResult.error.message
       )
+    );
+  }
+
+  // Upsert a companion 80% warning alert so users get advance notice before
+  // the hard block fires. Errors are logged but don't fail the whole operation.
+  const warningResult = await upsertMetronomeDefaultUserWarningAlert({
+    metronomeCustomerId,
+    workspaceId: workspace.sId,
+    capAwuCredits: awuCredits,
+  });
+  if (warningResult.isErr()) {
+    logger.warn(
+      {
+        workspaceId: workspace.sId,
+        metronomeCustomerId,
+        awuCredits,
+        err: warningResult.error,
+      },
+      "[DefaultUserSpendLimit] Failed to upsert warning alert; continuing"
     );
   }
 

--- a/front/lib/metronome/alerts/spend_limits.ts
+++ b/front/lib/metronome/alerts/spend_limits.ts
@@ -17,6 +17,14 @@ import type { CustomerAlert } from "@metronome/sdk/resources/v1/customers";
 
 const USER_ID_GROUP_KEY = "user_id";
 
+// The warning alert fires at this fraction of the cap, giving users advance
+// notice before they are hard-blocked at 100%.
+export const USER_AWU_WARNING_PERCENTAGE = 0.8;
+
+function warningAwuCredits(capAwuCredits: number): number {
+  return Math.floor(capAwuCredits * USER_AWU_WARNING_PERCENTAGE);
+}
+
 function defaultUserCapAlertUniquenessKey(workspaceId: string): string {
   return `default-user-cap-${workspaceId}`;
 }
@@ -30,6 +38,21 @@ function perUserAlertUniquenessKey(
   userId: string
 ): string {
   return `${perUserAlertUniquenessKeyPrefix(workspaceId)}${userId}`;
+}
+
+function defaultUserWarningAlertUniquenessKey(workspaceId: string): string {
+  return `default-user-warning-${workspaceId}`;
+}
+
+function perUserWarningAlertUniquenessKeyPrefix(workspaceId: string): string {
+  return `per-user-warning-${workspaceId}-`;
+}
+
+function perUserWarningAlertUniquenessKey(
+  workspaceId: string,
+  userId: string
+): string {
+  return `${perUserWarningAlertUniquenessKeyPrefix(workspaceId)}${userId}`;
 }
 
 /**
@@ -299,5 +322,166 @@ export async function clearMetronomePerUserCapAlert({
     metronomeCustomerId,
     workspaceId,
   });
+  return new Ok(undefined);
+}
+
+// ============================================================================
+// 80% warning alerts — same shape as cap alerts, but at USER_AWU_WARNING_PERCENTAGE
+// of the cap. They fire before the hard block to give users advance notice.
+// ============================================================================
+
+/**
+ * Look up the workspace-wide default per-user 80% warning alert.
+ */
+export async function getMetronomeDefaultUserWarningAlert({
+  metronomeCustomerId,
+  workspaceId,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+}): Promise<Result<CustomerAlert | null, Error>> {
+  return findMetronomeAlert({
+    metronomeCustomerId,
+    uniquenessKey: defaultUserWarningAlertUniquenessKey(workspaceId),
+  });
+}
+
+/**
+ * Idempotently ensure a workspace-wide default per-user 80% warning alert
+ * exists. The threshold is floor(capAwuCredits * 0.8). Skipped if the result
+ * would be zero.
+ */
+export async function upsertMetronomeDefaultUserWarningAlert({
+  metronomeCustomerId,
+  workspaceId,
+  capAwuCredits,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+  capAwuCredits: number;
+}): Promise<Result<{ alertId: string } | null, Error>> {
+  const threshold = warningAwuCredits(capAwuCredits);
+  if (threshold <= 0) {
+    return new Ok(null);
+  }
+  const upsertResult = await upsertMetronomeAlert({
+    alert_type: "spend_threshold_reached",
+    name: `Default per-user warning ${workspaceId} (${threshold} AWU / ${Math.round(USER_AWU_WARNING_PERCENTAGE * 100)}% of ${capAwuCredits})`,
+    threshold,
+    credit_type_id: getCreditTypeAwuId(),
+    customer_id: metronomeCustomerId,
+    group_values: [{ key: USER_ID_GROUP_KEY }],
+    uniqueness_key: defaultUserWarningAlertUniquenessKey(workspaceId),
+  });
+  if (upsertResult.isErr()) {
+    return new Err(upsertResult.error);
+  }
+  logger.info(
+    {
+      workspaceId,
+      metronomeCustomerId,
+      alertId: upsertResult.value.alertId,
+      threshold,
+      capAwuCredits,
+    },
+    "[Metronome DefaultUserWarning] Synced default per-user warning alert"
+  );
+  return new Ok({ alertId: upsertResult.value.alertId });
+}
+
+/**
+ * Look up the per-user 80% warning alert for a specific user.
+ */
+export async function getMetronomePerUserWarningAlert({
+  metronomeCustomerId,
+  workspaceId,
+  userId,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+  userId: string;
+}): Promise<Result<CustomerAlert | null, Error>> {
+  return findMetronomeAlert({
+    metronomeCustomerId,
+    uniquenessKey: perUserWarningAlertUniquenessKey(workspaceId, userId),
+  });
+}
+
+/**
+ * Idempotently ensure a per-user 80% warning alert exists for this
+ * workspace/user pair. The threshold is floor(capAwuCredits * 0.8).
+ */
+export async function upsertMetronomePerUserWarningAlert({
+  metronomeCustomerId,
+  workspaceId,
+  userId,
+  capAwuCredits,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+  userId: string;
+  capAwuCredits: number;
+}): Promise<Result<{ alertId: string } | null, Error>> {
+  const threshold = warningAwuCredits(capAwuCredits);
+  if (threshold <= 0) {
+    return new Ok(null);
+  }
+  const upsertResult = await upsertMetronomeAlert({
+    alert_type: "spend_threshold_reached",
+    name: `Per-user warning ${workspaceId}-${userId} (${threshold} AWU / ${Math.round(USER_AWU_WARNING_PERCENTAGE * 100)}% of ${capAwuCredits})`,
+    threshold,
+    credit_type_id: getCreditTypeAwuId(),
+    customer_id: metronomeCustomerId,
+    group_values: [{ key: USER_ID_GROUP_KEY, value: userId }],
+    uniqueness_key: perUserWarningAlertUniquenessKey(workspaceId, userId),
+  });
+  if (upsertResult.isErr()) {
+    return new Err(upsertResult.error);
+  }
+  logger.info(
+    {
+      workspaceId,
+      userId,
+      metronomeCustomerId,
+      alertId: upsertResult.value.alertId,
+      threshold,
+      capAwuCredits,
+    },
+    "[Metronome PerUserWarning] Synced per-user warning alert"
+  );
+  return new Ok({ alertId: upsertResult.value.alertId });
+}
+
+/**
+ * Archive the per-user warning alert for this workspace/user pair, if any.
+ * Idempotent — no-op when no matching alert exists.
+ */
+export async function clearMetronomePerUserWarningAlert({
+  metronomeCustomerId,
+  workspaceId,
+  userId,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+  userId: string;
+}): Promise<Result<void, Error>> {
+  const result = await clearMetronomeAlert({
+    metronomeCustomerId,
+    uniquenessKey: perUserWarningAlertUniquenessKey(workspaceId, userId),
+  });
+  if (result.isErr()) {
+    return new Err(result.error);
+  }
+  if (result.value) {
+    logger.info(
+      {
+        workspaceId,
+        userId,
+        metronomeCustomerId,
+        alertId: result.value.alertId,
+      },
+      "[Metronome PerUserWarning] Cleared per-user warning alert"
+    );
+  }
   return new Ok(undefined);
 }

--- a/front/lib/metronome/webhook_events.ts
+++ b/front/lib/metronome/webhook_events.ts
@@ -176,17 +176,19 @@ const InvoiceTotalResolvedSchema = z.object({
 });
 
 // alerts.low_remaining_seat_balance_*
-// Undocumented in the public webhook docs but emitted today. Assume the same
-// base alert envelope (other alerts.* all share `baseAlertPropertiesSchema`).
+// Undocumented in the public webhook docs but emitted today.
+const lowRemainingSeatBalanceProps = baseAlertPropertiesSchema.extend({
+  remaining_balance: z.number().nullish(),
+});
 const LowRemainingSeatBalanceReachedSchema = z.object({
   id: z.string(),
   type: z.literal("alerts.low_remaining_seat_balance_reached"),
-  properties: baseAlertPropertiesSchema,
+  properties: lowRemainingSeatBalanceProps,
 });
 const LowRemainingSeatBalanceResolvedSchema = z.object({
   id: z.string(),
   type: z.literal("alerts.low_remaining_seat_balance_resolved"),
-  properties: baseAlertPropertiesSchema,
+  properties: lowRemainingSeatBalanceProps,
 });
 
 // ============================================================================

--- a/front/lib/notifications/workflows/user-awu-cap-reached.ts
+++ b/front/lib/notifications/workflows/user-awu-cap-reached.ts
@@ -1,0 +1,136 @@
+import config from "@app/lib/api/config";
+import { renderEmail } from "@app/lib/notifications/email-templates/default";
+import { getNovuClient } from "@app/lib/notifications/novu-client";
+import logger from "@app/logger/logger";
+import {
+  USER_AWU_CAP_REACHED_TAG,
+  USER_AWU_CAP_REACHED_TRIGGER_ID,
+} from "@app/types/notification_preferences";
+import { workflow } from "@novu/framework";
+import z from "zod";
+
+const UserAwuCapReachedPayloadSchema = z.object({
+  workspaceId: z.string(),
+  workspaceName: z.string(),
+  capAwuCredits: z.number(),
+  // true → user has hit 100% and is now blocked; false → 80% warning.
+  isBlocked: z.boolean(),
+});
+
+type UserAwuCapReachedPayloadType = z.infer<
+  typeof UserAwuCapReachedPayloadSchema
+>;
+
+export const userAwuCapReachedWorkflow = workflow(
+  USER_AWU_CAP_REACHED_TRIGGER_ID,
+  async ({ step, payload, subscriber }) => {
+    await step.inApp("user-awu-cap-reached-in-app", async () => {
+      const subject = payload.isBlocked
+        ? "You've reached your usage limit"
+        : "You've used 80% of your usage limit";
+      const body = payload.isBlocked
+        ? `You have reached your ${payload.capAwuCredits} AWU limit in workspace "${payload.workspaceName}" and can no longer run agents. Contact your admin to increase your limit.`
+        : `You have used 80% of your ${payload.capAwuCredits} AWU limit in workspace "${payload.workspaceName}". Contact your admin to increase your limit before you are blocked.`;
+      return {
+        subject,
+        body,
+        data: {
+          workspaceId: payload.workspaceId,
+          capAwuCredits: payload.capAwuCredits,
+          isBlocked: payload.isBlocked,
+        },
+      };
+    });
+
+    await step.email("user-awu-cap-reached-email", async () => {
+      const subject = payload.isBlocked
+        ? `[Dust] You've reached your usage limit in ${payload.workspaceName}`
+        : `[Dust] You've used 80% of your usage limit in ${payload.workspaceName}`;
+      const content = payload.isBlocked
+        ? `You have reached your ${payload.capAwuCredits} AWU usage limit in the Dust workspace ${payload.workspaceName} and can no longer run agents.\nPlease contact your workspace admin to increase your limit.`
+        : `You have used 80% of your ${payload.capAwuCredits} AWU usage limit in the Dust workspace ${payload.workspaceName}.\nOnce you reach 100%, you won't be able to run agents until your limit is increased. Please contact your workspace admin.`;
+      const body = await renderEmail({
+        name: subscriber.firstName ?? "there",
+        workspace: {
+          id: payload.workspaceId,
+          name: payload.workspaceName,
+        },
+        content,
+        action: {
+          label: "Go to workspace",
+          url: `${config.getAppUrl()}/w/${payload.workspaceId}`,
+        },
+      });
+      return { subject, body };
+    });
+  },
+  {
+    payloadSchema: UserAwuCapReachedPayloadSchema,
+    tags: [USER_AWU_CAP_REACHED_TAG],
+  }
+);
+
+/**
+ * Send an in-app Novu notification about AWU usage.
+ * isBlocked=true → user hit 100% and is now blocked.
+ * isBlocked=false → 80% warning.
+ * Fire-and-forget — errors are logged but don't block the caller.
+ */
+export function notifyUserAwuCapReached({
+  userSId,
+  userEmail,
+  userFirstName,
+  userLastName,
+  workspaceId,
+  workspaceName,
+  capAwuCredits,
+  isBlocked,
+}: {
+  userSId: string;
+  userEmail: string;
+  userFirstName: string | null;
+  userLastName: string | null;
+  workspaceId: string;
+  workspaceName: string;
+  capAwuCredits: number;
+  isBlocked: boolean;
+}): void {
+  const payload: UserAwuCapReachedPayloadType = {
+    workspaceId,
+    workspaceName,
+    capAwuCredits,
+    isBlocked,
+  };
+
+  void getNovuClient()
+    .then((novuClient) =>
+      novuClient.triggerBulk({
+        events: [
+          {
+            workflowId: USER_AWU_CAP_REACHED_TRIGGER_ID,
+            to: {
+              subscriberId: userSId,
+              email: userEmail,
+              firstName: userFirstName ?? undefined,
+              lastName: userLastName ?? undefined,
+            },
+            payload,
+          },
+        ],
+      })
+    )
+    .then((r) => {
+      if (r.result.some((res) => !!res.error?.length)) {
+        logger.error(
+          { workspaceId, userSId, capAwuCredits },
+          "Failed to trigger user AWU cap reached notification"
+        );
+      }
+    })
+    .catch((err) => {
+      logger.error(
+        { err, workspaceId, userSId, capAwuCredits },
+        "Failed to trigger user AWU cap reached notification"
+      );
+    });
+}

--- a/front/pages/api/novu/index.ts
+++ b/front/pages/api/novu/index.ts
@@ -7,6 +7,7 @@ import { conversationUnreadWorkflow } from "@app/lib/notifications/workflows/con
 import { projectAddedAsMemberWorkflow } from "@app/lib/notifications/workflows/project-added-as-member";
 import { providerCredentialsHealthUpdatedWorkflow } from "@app/lib/notifications/workflows/provider-credential-updated";
 import { skillSuggestionsReadyWorkflow } from "@app/lib/notifications/workflows/skill-suggestions-ready";
+import { userAwuCapReachedWorkflow } from "@app/lib/notifications/workflows/user-awu-cap-reached";
 import { serve } from "@novu/framework/next";
 
 // This endpoint exposes our code-based notifications workflows to the Novu platform.
@@ -22,5 +23,6 @@ export default serve({
     skillSuggestionsReadyWorkflow,
     projectAddedAsMemberWorkflow,
     providerCredentialsHealthUpdatedWorkflow,
+    userAwuCapReachedWorkflow,
   ],
 });

--- a/front/types/notification_preferences.ts
+++ b/front/types/notification_preferences.ts
@@ -106,9 +106,13 @@ export const PROVIDER_CREDENTIALS_HEALTH_UPDATED_TRIGGER_ID =
 export const PROVIDER_CREDENTIALS_HEALTH_UPDATED_TAG =
   "provider-credentials-health" as const;
 
+export const USER_AWU_CAP_REACHED_TRIGGER_ID = "user-awu-cap-reached" as const;
+export const USER_AWU_CAP_REACHED_TAG = "user-awu-cap-reached" as const;
+
 export type WorkflowTriggerId =
   | typeof CONVERSATION_UNREAD_TRIGGER_ID
   | typeof PROJECT_ADDED_AS_MEMBER_TRIGGER_ID
   | typeof AGENT_SUGGESTIONS_READY_TRIGGER_ID
   | typeof SKILL_SUGGESTIONS_READY_TRIGGER_ID
-  | typeof PROVIDER_CREDENTIALS_HEALTH_UPDATED_TRIGGER_ID;
+  | typeof PROVIDER_CREDENTIALS_HEALTH_UPDATED_TRIGGER_ID
+  | typeof USER_AWU_CAP_REACHED_TRIGGER_ID;


### PR DESCRIPTION
## Description

When a workspace admin configures a per-user AWU spend cap, Metronome fires a `spend_threshold_reached` webhook when a user hits that cap. Previously the cap silently blocked the user with no proactive notification.

This PR wires up two notification points triggered by Metronome alerts:

**80% warning** (`alerting.spend_threshold_reached` on the warning alert):
- Email `sendUserAwuCapReachedEmail`: "You've used 80% of your X AWU limit — contact your admin before you're blocked."
- In-app Novu notification (`user-awu-cap-reached`, `isBlocked: false`): same message.

**100% blocked** (`alerts.spend_threshold_reached` on the cap alert, after `dispatchPerUserCapReached`):
- Email `sendUserAwuCapBlockedEmail`: "You've reached your X AWU limit and can no longer run agents."
- In-app Novu notification (`user-awu-cap-reached`, `isBlocked: true`): same message.

To enable the 80% webhook signal, a companion **warning alert** is created in Metronome at `floor(cap × 0.8)` AWU whenever a cap is set — for both the workspace-wide default (`setDefaultUserSpendLimit`) and per-user overrides (`setUserSpendLimit`). The alert is cleared when the cap is removed. Both operations are best-effort (failure logged, not fatal).

The webhook handler now re-derives two independent states: `effectiveCapState` (100% alert) and `effectiveWarningState` (80% alert). Blocking logic is driven by `effectiveCapState` as before; notifications fire from the respective state transitions.

Also moves `low_remaining_seat_balance_*` cases out of the silent catch-all into explicit no-ops.

## Tests

Manual: the two `spend_threshold_reached` paths (warning vs cap) are exercised by the existing Metronome webhook flow. Email and Novu calls are fire-and-forget and don't affect webhook ack.

## Risk

Low — all notification calls are `void` (fire-and-forget). The warning alert creation/deletion is best-effort and won't block cap operations if it fails. The blocking behaviour at 100% is unchanged.
