### PR TITLE
feat: align logs attributes

### DIFF
--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -57,8 +57,13 @@ export class ActivityInboundLogInterceptor
     this.context = ctx;
     this.provider = provider;
     this.logger = logger.child({
+      activityType: ctx.info.activityType,
+      workflowType: ctx.info.workflowType,
+
+      // to remove, it's confusing
       activityName: ctx.info.activityType,
       workflowName: ctx.info.workflowType,
+
       workflowId: ctx.info.workflowExecution.workflowId,
       workflowRunId: ctx.info.workflowExecution.runId,
       activityId: ctx.info.activityId,
@@ -78,8 +83,13 @@ export class ActivityInboundLogInterceptor
     let error: Error | any = undefined;
     const startTime = new Date();
     const tags = [
+      `activity_type:${this.context.info.activityType}`,
+      `workflow_type:${this.context.info.workflowType}`,
+
+      // to remove, it's confusing
       `activity_name:${this.context.info.activityType}`,
       `workflow_name:${this.context.info.workflowType}`,
+
       `attempt:${this.context.info.attempt}`,
       `provider:${this.provider}`,
     ];
@@ -135,6 +145,9 @@ export class ActivityInboundLogInterceptor
     if (this.context.info.attempt > 25) {
       this.logger.error(
         {
+          activity_type: this.context.info.activityType,
+          workflow_type: this.context.info.workflowType,
+          // to remove, it's confusing
           activity_name: this.context.info.activityType,
           workflow_name: this.context.info.workflowType,
           attempt: this.context.info.attempt,

--- a/connectors/src/logger/logger.ts
+++ b/connectors/src/logger/logger.ts
@@ -92,8 +92,13 @@ export function getLoggerArgs(
   try {
     const ctx = Context.current();
     Object.assign(effectiveArgs, {
+      activityType: ctx.info.activityType,
+      workflowType: ctx.info.workflowType,
+
+      // to remove, it's confusing
       activityName: ctx.info.activityType,
       workflowName: ctx.info.workflowType,
+
       workflowId: ctx.info.workflowExecution.workflowId,
       workflowRunId: ctx.info.workflowExecution.runId,
       activityId: ctx.info.activityId,

--- a/front/lib/temporal_monitoring.ts
+++ b/front/lib/temporal_monitoring.ts
@@ -36,8 +36,13 @@ export class ActivityInboundLogInterceptor
   constructor(ctx: Context, logger: Logger) {
     this.context = ctx;
     this.logger = logger.child({
+      activityType: ctx.info.activityType,
+      workflowType: ctx.info.workflowType,
+
+      // to remove, it's confusing
       activityName: ctx.info.activityType,
       workflowName: ctx.info.workflowType,
+
       workflowId: ctx.info.workflowExecution.workflowId,
       workflowRunId: ctx.info.workflowExecution.runId,
       activityId: ctx.info.activityId,
@@ -55,6 +60,10 @@ export class ActivityInboundLogInterceptor
     let error: any = undefined;
     const startTime = new Date();
     const tags = [
+      `activity_type:${this.context.info.activityType}`,
+      `workflow_type:${this.context.info.workflowType}`,
+
+      // to remove, it's confusing
       `activity_name:${this.context.info.activityType}`,
       `workflow_name:${this.context.info.workflowType}`,
       `attempt:${this.context.info.attempt}`,


### PR DESCRIPTION
## Description

We have 2 attributes for the same thing. `workflowName` vs `workflowId`

This PR aligns. I'm not sure on how the previous attributes were used, so I'm keeping them

ex in those 2 logs:
* [log 1](https://app.datadoghq.eu/logs?query=%40hostname%3Afront-project-journal-worker-deployment-%2A&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZ2wn76rgo_RHQAAABhBWjJ3bjdfekFBRFktQkhGaWdGbDZnTW4AAAAkMDE5ZGIwOWYtYzQxNC00Zjg4LWI5YmEtM2M5ZWQ1OWE3NjNjAAAdmw&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1776782637273&to_ts=1776783537273&live=true)
* [log 2](https://app.datadoghq.eu/logs?query=%40hostname%3Afront-project-journal-worker-deployment-%2A&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZ2wn76rgo_RHgAAABhBWjJ3bjdfekFBRFktQkhGaWdGbDZnTW8AAAAkMDE5ZGIwOWYtYzQxNC00Zjg4LWI5YmEtM2M5ZWQ1OWE3NjNjAAAhKw&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1776782637273&to_ts=1776783537273&live=true)
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
