### PR TITLE
List folder children in Sharepoint

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -362,6 +362,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   "microsoft_drive": {
     "copy_file": "never_ask",
     "get_file_content": "never_ask",
+    "list_drive_items": "never_ask",
     "search_drive_items": "never_ask",
     "search_in_files": "never_ask",
     "update_word_document": "high",

--- a/front/lib/api/actions/servers/microsoft_drive/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/metadata.ts
@@ -49,6 +49,55 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
       done: "Search OneDrive/SharePoint items",
     },
   },
+  list_drive_items: {
+    description:
+      "List items (folders and/or files) in a OneDrive/SharePoint drive, SharePoint site, or under a specific parent folder. Use parentFolderId to drill into a specific folder; otherwise lists items at the root of the drive/site. Filter the result with itemType. Supports pagination via skipToken.",
+    schema: {
+      driveId: z
+        .string()
+        .optional()
+        .describe(
+          "The ID of the drive to list items from. Takes priority over siteId if provided."
+        ),
+      siteId: z
+        .string()
+        .optional()
+        .describe(
+          "The ID of the SharePoint site to list items from. Used if driveId is not provided."
+        ),
+      parentFolderId: z
+        .string()
+        .optional()
+        .describe(
+          "ID of the parent folder to list items from. If omitted, lists items at the root of the drive/site."
+        ),
+      itemType: z
+        .enum(["all", "folder", "file"])
+        .optional()
+        .default("all")
+        .describe(
+          "Filter to apply to the listed items. 'all' returns both folders and files (default), 'folder' returns folders only, 'file' returns files only."
+        ),
+      top: z
+        .number()
+        .optional()
+        .default(50)
+        .describe(
+          "Maximum number of items to fetch per page (default 50, capped at 200). When itemType is not 'all', items are filtered client-side, so fewer than `top` items may be returned per page."
+        ),
+      skipToken: z
+        .string()
+        .optional()
+        .describe(
+          "Pagination token returned as `nextSkipToken` from a previous call. Pass it back to retrieve the next page."
+        ),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Listing OneDrive/SharePoint items",
+      done: "List OneDrive/SharePoint items",
+    },
+  },
   update_word_document: {
     description:
       "Update an existing Word document on OneDrive/SharePoint by providing a new document.xml content. Uses driveId if provided, otherwise falls back to siteId.",

--- a/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
@@ -24,6 +24,18 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type AdmZip from "adm-zip";
 
+interface DriveChildItem {
+  id: string;
+  name: string;
+  webUrl?: string;
+  size?: number;
+  folder?: { childCount?: number };
+  file?: { mimeType?: string };
+  parentReference?: { driveId?: string; id?: string; path?: string };
+  createdDateTime?: string;
+  lastModifiedDateTime?: string;
+}
+
 const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
   search_in_files: async (
     { query, dataSource, maximumResults },
@@ -96,6 +108,96 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           normalizeError(err).message || "Failed to search drive items"
+        )
+      );
+    }
+  },
+
+  list_drive_items: async (
+    { driveId, siteId, parentFolderId, itemType = "all", top, skipToken },
+    { authInfo }
+  ) => {
+    const client = await getGraphClient(authInfo);
+    if (!client) {
+      return new Err(
+        new MCPError("Failed to authenticate with Microsoft Graph")
+      );
+    }
+
+    try {
+      const baseEndpoint = await getDriveItemEndpoint(
+        parentFolderId,
+        driveId,
+        siteId
+      );
+      const endpoint = parentFolderId
+        ? `${baseEndpoint}/children`
+        : `${baseEndpoint}/root/children`;
+
+      const pageSize = Math.min(Math.max(top ?? 50, 1), 200);
+
+      let request = client
+        .api(endpoint)
+        .select(
+          "id,name,webUrl,folder,file,size,parentReference,createdDateTime,lastModifiedDateTime"
+        )
+        .top(pageSize);
+      if (skipToken) {
+        request = request.query({ $skiptoken: skipToken });
+      }
+
+      const response = await request.get();
+
+      const items = ((response.value ?? []) as DriveChildItem[])
+        .filter(
+          (item) =>
+            itemType === "all" ||
+            (itemType === "folder" && item.folder) ||
+            (itemType === "file" && item.file)
+        )
+        .map((item) => ({
+          id: item.id,
+          name: item.name,
+          type: item.folder ? "folder" : "file",
+          webUrl: item.webUrl,
+          size: item.size,
+          childCount: item.folder?.childCount,
+          mimeType: item.file?.mimeType,
+          parentReference: item.parentReference,
+          createdDateTime: item.createdDateTime,
+          lastModifiedDateTime: item.lastModifiedDateTime,
+        }));
+
+      const nextLink: string | undefined = response["@odata.nextLink"];
+      let nextSkipToken: string | undefined;
+      if (nextLink) {
+        try {
+          nextSkipToken =
+            new URL(nextLink).searchParams.get("$skiptoken") ?? undefined;
+        } catch {
+          // Unparseable nextLink — leave undefined; caller can re-list.
+        }
+      }
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              items,
+              count: items.length,
+              nextSkipToken,
+              hasMore: !!nextSkipToken,
+            },
+            null,
+            2
+          ),
+        },
+      ]);
+    } catch (err) {
+      return new Err(
+        new MCPError(
+          normalizeError(err).message || "Failed to list drive items"
         )
       );
     }

--- a/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
@@ -23,18 +23,25 @@ import { MICROSOFT_DRIVE_TOOLS_METADATA } from "@app/lib/api/actions/servers/mic
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type AdmZip from "adm-zip";
+import { z } from "zod";
 
-interface DriveChildItem {
-  id: string;
-  name: string;
-  webUrl?: string;
-  size?: number;
-  folder?: { childCount?: number };
-  file?: { mimeType?: string };
-  parentReference?: { driveId?: string; id?: string; path?: string };
-  createdDateTime?: string;
-  lastModifiedDateTime?: string;
-}
+const driveChildItemSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  webUrl: z.string().optional(),
+  size: z.number().optional(),
+  folder: z.object({ childCount: z.number().optional() }).optional(),
+  file: z.object({ mimeType: z.string().optional() }).optional(),
+  parentReference: z
+    .object({
+      driveId: z.string().optional(),
+      id: z.string().optional(),
+      path: z.string().optional(),
+    })
+    .optional(),
+  createdDateTime: z.string().optional(),
+  lastModifiedDateTime: z.string().optional(),
+});
 
 const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
   search_in_files: async (
@@ -148,7 +155,18 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
 
       const response = await request.get();
 
-      const items = ((response.value ?? []) as DriveChildItem[])
+      const parsedItems = z
+        .array(driveChildItemSchema)
+        .safeParse(response.value ?? []);
+      if (!parsedItems.success) {
+        return new Err(
+          new MCPError(
+            `Unexpected response shape from Microsoft Graph: ${parsedItems.error.message}`
+          )
+        );
+      }
+
+      const items = parsedItems.data
         .filter(
           (item) =>
             itemType === "all" ||


### PR DESCRIPTION
## Description

Adds a new `list_drive_items` MCP tool to the Microsoft Drive server that lets agents browse the contents of a OneDrive/SharePoint drive or folder without relying on search. The tool accepts a `driveId` or `siteId`, an optional `parentFolderId` to drill into a subfolder (defaults to drive root), an `itemType` filter (`all` / `folder` / `file`), a configurable page size (`top`, capped at 200), and a `skipToken` for cursor-based pagination. Results include item metadata (id, name, type, size, childCount, mimeType, parentReference, timestamps) and a `nextSkipToken` when more pages are available. Filtering by `itemType` is applied client-side after fetching, so fewer than `top` items may be returned per page when filtering.

## Tests

Tested manually by calling the tool against a SharePoint site, verifying folder-only and file-only filtering and pagination via `skipToken`.

## Risk

Low — read-only, `stake: "never_ask"`. No schema migrations or infrastructure changes.

## Deploy Plan

Deploy front.