### PR TITLE
[front] feat: version workspace resource cache key

### DIFF
--- a/front/lib/resources/workspace_resource.test.ts
+++ b/front/lib/resources/workspace_resource.test.ts
@@ -84,10 +84,11 @@ vi.mock("@app/lib/resources/kill_switch_resource", () => ({
 
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { WORKSPACE_CACHE_KEY_VERSION } from "@app/types/shared/cache_resource_registry";
 import type { WorkspaceType } from "@app/types/user";
 
 function getCacheKeyForWorkspace(workspaceId: string): string {
-  return `cacheWithRedis-_fetchByIdUncached-workspace:sid:${workspaceId}`;
+  return `cacheWithRedis-_fetchByIdUncached-workspace:v${WORKSPACE_CACHE_KEY_VERSION}:${workspaceId}`;
 }
 
 const INVALID_RETENTION_DAYS = CONVERSATIONS_RETENTION_MIN_DAYS - 1;

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -27,6 +27,7 @@ import { terminateAllAgentLoopWorkflowsForConversation } from "@app/temporal/age
 import { MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
 import type { EmbeddingProviderIdType } from "@app/types/assistant/models/types";
 import type { WorkspacePoolCreditState } from "@app/types/credits";
+import { WORKSPACE_CACHE_KEY_VERSION } from "@app/types/shared/cache_resource_registry";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -118,7 +119,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
   }
 
   private static readonly workspaceCacheKeyResolver = (wId: string) =>
-    `workspace:sid:${wId}`;
+    `workspace:sid:${wId}:v${WORKSPACE_CACHE_KEY_VERSION}`;
 
   static isWorkspaceConversationKillSwitchValue(
     killSwitched: unknown

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -119,7 +119,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
   }
 
   private static readonly workspaceCacheKeyResolver = (wId: string) =>
-    `workspace:sid:${wId}:v${WORKSPACE_CACHE_KEY_VERSION}`;
+    `workspace:v${WORKSPACE_CACHE_KEY_VERSION}:${wId}`;
 
   static isWorkspaceConversationKillSwitchValue(
     killSwitched: unknown

--- a/front/types/shared/cache_resource_registry.ts
+++ b/front/types/shared/cache_resource_registry.ts
@@ -29,6 +29,8 @@ export function buildCacheKey(
   return `cacheWithRedis-${resource.fnName}-${resource.buildResolverKey(params)}`;
 }
 
+export const WORKSPACE_CACHE_KEY_VERSION = 1;
+
 export const CACHE_RESOURCE_REGISTRY: CacheResourceDefinition[] = [
   {
     id: "workspace_by_sid",
@@ -42,7 +44,8 @@ export const CACHE_RESOURCE_REGISTRY: CacheResourceDefinition[] = [
         placeholder: "e.g. abc123",
       },
     ],
-    buildResolverKey: (p) => `workspace:sid:${p.wId}`,
+    buildResolverKey: (p) =>
+      `workspace:sid:${p.wId}:v${WORKSPACE_CACHE_KEY_VERSION}`,
   },
   {
     id: "user_by_workos_id",

--- a/front/types/shared/cache_resource_registry.ts
+++ b/front/types/shared/cache_resource_registry.ts
@@ -45,7 +45,7 @@ export const CACHE_RESOURCE_REGISTRY: CacheResourceDefinition[] = [
       },
     ],
     buildResolverKey: (p) =>
-      `workspace:sid:${p.wId}:v${WORKSPACE_CACHE_KEY_VERSION}`,
+      `workspace:v${WORKSPACE_CACHE_KEY_VERSION}:${p.wId}`,
   },
   {
     id: "user_by_workos_id",


### PR DESCRIPTION
## Description

Add WORKSPACE_CACHE_KEY_VERSION to the workspace cache key resolver so existing Redis entries are invalidated on deploy whenever the cached shape changes.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
