### PR TITLE
[front] feat: add reminderSentAt to membership invitations

### DIFF
--- a/front/lib/models/membership_invitation.ts
+++ b/front/lib/models/membership_invitation.ts
@@ -15,6 +15,7 @@ export class MembershipInvitationModel extends WorkspaceAwareModel<MembershipInv
   declare initialRole: Exclude<RoleType, "none">;
 
   declare invitedUserId: ForeignKey<UserModel["id"]> | null;
+  declare reminderSentAt: CreationOptional<Date> | null;
 }
 MembershipInvitationModel.init(
   {
@@ -45,6 +46,11 @@ MembershipInvitationModel.init(
       type: DataTypes.STRING,
       allowNull: false,
       defaultValue: "user",
+    },
+    reminderSentAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      defaultValue: null,
     },
   },
   {

--- a/front/lib/resources/membership_invitation_resource.ts
+++ b/front/lib/resources/membership_invitation_resource.ts
@@ -441,6 +441,10 @@ export class MembershipInvitationResource extends BaseResource<MembershipInvitat
     });
   }
 
+  async markReminderSent() {
+    return this.update({ reminderSentAt: new Date() });
+  }
+
   async revoke(transaction?: Transaction) {
     return this.update(
       {

--- a/front/migrations/pre-deploy/20260528153539_invitation_resent_at.sql
+++ b/front/migrations/pre-deploy/20260528153539_invitation_resent_at.sql
@@ -1,0 +1,8 @@
+/*
+We want to auto send a reminder for un-consumed invitations > this is to track which one was already resent. 
+*/
+SET SESSION statement_timeout = 3000;
+
+SET SESSION lock_timeout = 3000;
+
+ALTER TABLE "public"."membership_invitations" ADD COLUMN "reminderSentAt" timestamp with time zone;


### PR DESCRIPTION
## Description

## Context

Part 1 of the ENT invitation reminder feature: automatically re-send pending invitations that haven't been consumed after 7 days (follow-up PRs will add the 14-day expiry extension and the Temporal workflow).

## Changes

- `MembershipInvitationModel`: add `reminderSentAt` nullable timestamp column
- `MembershipInvitationResource`: add `markReminderSent()` instance method
- Migration: `ADD COLUMN reminderSentAt TIMESTAMP NULL` on `membership_invitations`

The field will be set by the Temporal reminder workflow after sending the automated reminder email, and also when a workspace admin manually re-sends an existing (non-expired) invitation, to prevent the automated reminder from firing shortly after a manual one.

## Test plan

- [ ] Migration runs cleanly
- [ ] Existing invitation flows (create, resend, revoke, consume) are unaffected

## Tests

Not tested yet. 
Will test that the invite flow still works locally. 

## Risk

New column is nullable and unused yet so should be safe (famous last words).

## Deploy Plan

Run migration. 
Deploy front.