### PR TITLE
[front] fix: harden Temporal workflow ID list queries

### DIFF
--- a/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
+++ b/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
@@ -113,8 +113,8 @@ function makeWorkflowIdsListQuery(workflowIds: string[]): string | null {
 async function listRunningWorkflowIds(
   client: Client,
   workflowIds: string[],
-  logger: Parameters<CheckFunction>[1],
-  heartbeat: Parameters<CheckFunction>[4]
+  logger: Logger,
+  heartbeat: () => void
 ) {
   const runningWorkflowIds = new Set<string>();
 

--- a/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
+++ b/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
@@ -105,7 +105,9 @@ function makeWorkflowIdsListQuery(workflowIds: string[]): string | null {
     return null;
   }
 
-  const workflowIdLiterals = workflowIds.map(JSON.stringify(value)).join(",");
+  const workflowIdLiterals = workflowIds
+    .map((value) => JSON.stringify(value))
+    .join(",");
 
   return `WorkflowId IN (${workflowIdLiterals}) AND ExecutionStatus = "Running"`;
 }

--- a/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
+++ b/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
@@ -1,6 +1,7 @@
 import config from "@app/lib/api/config";
 import { getConnectorsPrimaryDbConnection } from "@app/lib/production_checks/utils";
 import { getTemporalClientForConnectorsNamespace } from "@app/lib/temporal";
+import type { Logger } from "@app/logger/logger";
 import {
   getZendeskGarbageCollectionWorkflowId,
   getZendeskSyncWorkflowId,
@@ -99,10 +100,14 @@ async function listAllConnectorsForProvider(provider: ConnectorProvider) {
   return connectors;
 }
 
-function makeWorkflowIdsListQuery(workflowIds: string[]): string {
-  return `WorkflowId IN (${workflowIds
-    .map((workflowId) => `"${workflowId}"`)
-    .join(",")}) AND ExecutionStatus = "Running"`;
+function makeWorkflowIdsListQuery(workflowIds: string[]): string | null {
+  if (workflowIds.length === 0) {
+    return null;
+  }
+
+  const workflowIdLiterals = workflowIds.map(JSON.stringify(value)).join(",");
+
+  return `WorkflowId IN (${workflowIdLiterals}) AND ExecutionStatus = "Running"`;
 }
 
 async function listRunningWorkflowIds(
@@ -119,8 +124,13 @@ async function listRunningWorkflowIds(
     heartbeat();
 
     try {
+      const query = makeWorkflowIdsListQuery(workflowIdBatch);
+      if (query === null) {
+        continue;
+      }
+
       for await (const workflow of client.workflow.list({
-        query: makeWorkflowIdsListQuery(workflowIdBatch),
+        query,
       })) {
         runningWorkflowIds.add(workflow.workflowId);
       }


### PR DESCRIPTION
## Description

- Harden the active connector workflow production check query construction.
- `makeWorkflowIdsListQuery` now escapes Workflow IDs, and avoids building an invalid WorkflowId IN () filter for empty inputs.
- This keeps Temporal visibility list filters valid if IDs contain query-special characters or if the helper is reused with an empty list.

## Tests

- Tested locally.

## Risk

- Low. Limited to the active connector workflow production check.

## Deploy Plan

- Deploy front.