### PR TITLE
[front] fix: invalidate paginated members-usage caches after mutations

### DIFF
--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -213,6 +213,19 @@ export function useMembersLookup({
   };
 }
 
+function membersUsageUrl(workspaceId: string): string {
+  return `/api/w/${workspaceId}/credits/members-usage`;
+}
+
+export async function invalidateMembersUsage(
+  workspaceId: string
+): Promise<void> {
+  await mutate(
+    (key) =>
+      typeof key === "string" && key.startsWith(membersUsageUrl(workspaceId))
+  );
+}
+
 export function useMembersUsage({
   workspaceId,
   searchTerm = "",
@@ -244,7 +257,7 @@ export function useMembersUsage({
   }
 
   const { data, error } = useSWRWithDefaults(
-    `/api/w/${workspaceId}/credits/members-usage?${searchParams.toString()}`,
+    `${membersUsageUrl(workspaceId)}?${searchParams.toString()}`,
     membersUsageFetcher,
     {
       revalidateOnFocus: false,
@@ -311,7 +324,7 @@ export function useUpdateMemberSeatType({
             : `${memberName}'s seat has been updated to ${seatType}.`,
       });
 
-      await mutate(`/api/w/${workspaceId}/credits/members-usage`);
+      await invalidateMembersUsage(workspaceId);
       return true;
     },
     [workspaceId, sendNotification]
@@ -402,7 +415,7 @@ export function useUpdateUserSpendLimit({
       });
 
       await mutate(spendLimitUrl(workspaceId, memberId));
-      await mutate(`/api/w/${workspaceId}/credits/members-usage`);
+      await invalidateMembersUsage(workspaceId);
       return body;
     },
     [workspaceId, sendNotification]

--- a/front/lib/swr/usage_settings.ts
+++ b/front/lib/swr/usage_settings.ts
@@ -1,5 +1,6 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
+import { invalidateMembersUsage } from "@app/lib/swr/memberships";
 import {
   getErrorFromResponse,
   useFetcher,
@@ -212,10 +213,6 @@ function defaultUserSpendLimitUrl(workspaceId: string): string {
   return `/api/w/${workspaceId}/usage_settings/default_user_spend_limit`;
 }
 
-function membersUsageUrl(workspaceId: string): string {
-  return `/api/w/${workspaceId}/credits/members-usage`;
-}
-
 export function useDefaultUserSpendLimit({
   workspaceId,
   disabled,
@@ -284,11 +281,7 @@ export function useUpdateDefaultUserSpendLimit({
         });
 
         await mutate(defaultUserSpendLimitUrl(workspaceId));
-        await mutate(
-          (key) =>
-            typeof key === "string" &&
-            key.startsWith(membersUsageUrl(workspaceId))
-        );
+        await invalidateMembersUsage(workspaceId);
         return body;
       } catch (e) {
         sendNotification({


### PR DESCRIPTION
## Description

Since the members-usage SWR hook switched to offset-based pagination, its cache keys always carry query params (`?offset=0&limit=50[&search=…]`), but useUpdateMemberSeatType and useUpdateUserSpendLimit were still invalidating the bare URL. mutate(string) is exact-match, so no cached key was hit and the table no longer refreshed after a seat or per-user spend-limit change. Admins had to reload manually to see the result of their action.

Add an exported invalidateMembersUsage helper using a startsWith filter (matches every paginated/searched variant), wire both mutation hooks through it, and reuse it from usage_settings.ts so the inline duplication in the default-spend-limit hook goes away.

## Tests

Locally

## Risk

Low

## Deploy Plan

Front