### PR TITLE
 Support canonical scoped paths in conversation file utils

### DIFF
--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.test.ts
@@ -15,8 +15,9 @@ import {
   resolveConversationFileRef,
 } from "./file_utils";
 
-const { mockResolveFile } = vi.hoisted(() => ({
+const { mockResolveFile, mockFromScopedPath } = vi.hoisted(() => ({
   mockResolveFile: vi.fn(),
+  mockFromScopedPath: vi.fn(),
 }));
 
 vi.mock(
@@ -32,6 +33,18 @@ vi.mock(
     };
   }
 );
+
+vi.mock("@app/lib/api/file_system", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/file_system")>();
+  return {
+    ...actual,
+    DustFileSystem: {
+      ...actual.DustFileSystem,
+      fromScopedPath: mockFromScopedPath,
+    },
+  };
+});
 
 function makeAgentLoopContext(
   conversation: ConversationType
@@ -53,6 +66,105 @@ function makeReadableStream(content: string): Readable {
 describe("getFileFromConversationAttachment", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe("canonical scoped path (conversation-{id}/...)", () => {
+    it("reads the file content via DustFileSystem", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const conversation = await createConversation(auth, {
+        title: "Test",
+        visibility: "unlisted",
+        spaceId: null,
+      });
+
+      const canonicalPath = `conversation-${conversation.sId}/report.csv`;
+      const expectedContent = "col1,col2\nval1,val2";
+
+      mockFromScopedPath.mockResolvedValue(
+        new Ok({
+          stat: vi
+            .fn()
+            .mockResolvedValue(
+              new Ok({ contentType: "text/csv", sizeBytes: 19 })
+            ),
+          read: vi
+            .fn()
+            .mockResolvedValue(new Ok(makeReadableStream(expectedContent))),
+        })
+      );
+
+      const result = await getFileFromConversationAttachment(
+        auth,
+        canonicalPath,
+        makeAgentLoopContext({ ...conversation, content: [] })
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
+      expect(result.value.buffer.toString()).toBe(expectedContent);
+      expect(result.value.contentType).toBe("text/csv");
+      expect(result.value.filename).toBe("report.csv");
+    });
+
+    it("returns Err when the file is not found", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const conversation = await createConversation(auth, {
+        title: "Test",
+        visibility: "unlisted",
+        spaceId: null,
+      });
+
+      mockFromScopedPath.mockResolvedValue(
+        new Ok({
+          stat: vi.fn().mockResolvedValue(new Ok(null)),
+          read: vi.fn(),
+        })
+      );
+
+      const result = await getFileFromConversationAttachment(
+        auth,
+        `conversation-${conversation.sId}/missing.pdf`,
+        makeAgentLoopContext({ ...conversation, content: [] })
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (!result.isErr()) {
+        return;
+      }
+      expect(result.error).toContain("not found");
+    });
+
+    it("returns Err when fromScopedPath fails", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const conversation = await createConversation(auth, {
+        title: "Test",
+        visibility: "unlisted",
+        spaceId: null,
+      });
+
+      mockFromScopedPath.mockResolvedValue(
+        new Err({ message: "Conversation not found" })
+      );
+
+      const result = await getFileFromConversationAttachment(
+        auth,
+        `conversation-${conversation.sId}/file.txt`,
+        makeAgentLoopContext({ ...conversation, content: [] })
+      );
+
+      expect(result.isErr()).toBe(true);
+    });
   });
 
   describe("legacy fileId path", () => {
@@ -213,6 +325,117 @@ describe("getFileFromConversationAttachment", () => {
 describe("resolveConversationFileRef", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe("canonical scoped path (conversation-{id}/...)", () => {
+    it("returns metadata, getSignedUrl, and createReadStream via DustFileSystem", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const conversation = await createConversation(auth, {
+        title: "Test",
+        visibility: "unlisted",
+        spaceId: null,
+      });
+
+      const canonicalPath = `conversation-${conversation.sId}/photo.png`;
+      const signedUrl = "https://storage.example.com/signed";
+
+      mockFromScopedPath.mockResolvedValue(
+        new Ok({
+          stat: vi
+            .fn()
+            .mockResolvedValue(
+              new Ok({ contentType: "image/png", sizeBytes: 512 })
+            ),
+          read: vi
+            .fn()
+            .mockResolvedValue(new Ok(makeReadableStream("img bytes"))),
+          getDownloadUrl: vi.fn().mockResolvedValue(new Ok(signedUrl)),
+        })
+      );
+
+      const result = await resolveConversationFileRef(
+        auth,
+        canonicalPath,
+        undefined // canonical paths do not need agentLoopContext
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
+      expect(result.value.contentType).toBe("image/png");
+      expect(result.value.sizeBytes).toBe(512);
+      expect(result.value.fileName).toBe("photo.png");
+      expect(await result.value.getSignedUrl()).toBe(signedUrl);
+    });
+
+    it("does not require agentLoopContext", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const conversation = await createConversation(auth, {
+        title: "Test",
+        visibility: "unlisted",
+        spaceId: null,
+      });
+
+      mockFromScopedPath.mockResolvedValue(
+        new Ok({
+          stat: vi
+            .fn()
+            .mockResolvedValue(
+              new Ok({ contentType: "text/plain", sizeBytes: 10 })
+            ),
+          read: vi.fn().mockResolvedValue(new Ok(makeReadableStream("hello"))),
+          getDownloadUrl: vi
+            .fn()
+            .mockResolvedValue(new Ok("https://example.com/url")),
+        })
+      );
+
+      // Pass undefined — should succeed for canonical paths.
+      const result = await resolveConversationFileRef(
+        auth,
+        `conversation-${conversation.sId}/file.txt`,
+        undefined
+      );
+
+      expect(result.isOk()).toBe(true);
+    });
+
+    it("returns Err when the file is not found", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const conversation = await createConversation(auth, {
+        title: "Test",
+        visibility: "unlisted",
+        spaceId: null,
+      });
+
+      mockFromScopedPath.mockResolvedValue(
+        new Ok({
+          stat: vi.fn().mockResolvedValue(new Ok(null)),
+        })
+      );
+
+      const result = await resolveConversationFileRef(
+        auth,
+        `conversation-${conversation.sId}/missing.png`,
+        undefined
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (!result.isErr()) {
+        return;
+      }
+      expect(result.error).toContain("not found");
+    });
   });
 
   it("returns Err when agentLoopContext has no runContext", async () => {

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -7,6 +7,11 @@ import {
   isFileAttachmentType,
   makeFileAttachment,
 } from "@app/lib/api/assistant/conversation/attachments";
+import {
+  DustFileSystem,
+  SCOPED_PREFIX_CONVERSATION,
+  SCOPED_PREFIX_POD,
+} from "@app/lib/api/file_system";
 import { parseScopedFilePath } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
@@ -16,6 +21,20 @@ import { isAgentMessageType } from "@app/types/assistant/conversation";
 import { isContentFragmentType } from "@app/types/content_fragment";
 import type { Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
+import { PassThrough } from "stream";
+
+/**
+ * Returns true for canonical scoped paths produced by the new DustFileSystem
+ * (e.g. `conversation-{id}/file.txt`, `pod-{id}/data.csv`).
+ * These are distinct from legacy paths (`conversation/file.txt`, `pod/file.txt`)
+ * and from raw file IDs (`fil_xxx`).
+ */
+function isCanonicalScopedPath(fileId: string): boolean {
+  return (
+    fileId.startsWith(SCOPED_PREFIX_CONVERSATION) ||
+    fileId.startsWith(SCOPED_PREFIX_POD)
+  );
+}
 
 export function sanitizeFilename(filename: string): string {
   return filename
@@ -46,6 +65,55 @@ export async function resolveConversationFileRef(
   fileId: string,
   agentLoopContext: AgentLoopContextType | undefined
 ): Promise<Result<ConversationFileRef, string>> {
+  // Canonical scoped paths (conversation-{id}/..., pod-{id}/...) produced by the new
+  // DustFileSystem layer. Resolved directly — no conversation context needed.
+  if (isCanonicalScopedPath(fileId)) {
+    const fsResult = await DustFileSystem.fromScopedPath(auth, fileId);
+    if (fsResult.isErr()) {
+      return new Err(fsResult.error.message);
+    }
+    const fs = fsResult.value;
+
+    const statResult = await fs.stat(fileId);
+    if (statResult.isErr()) {
+      return new Err(statResult.error.message);
+    }
+    if (!statResult.value) {
+      return new Err(`File not found: \`${fileId}\`.`);
+    }
+
+    const { contentType, sizeBytes } = statResult.value;
+    const filename = fileId.split("/").pop() ?? fileId;
+
+    return new Ok({
+      contentType,
+      sizeBytes,
+      fileName: sanitizeFilename(filename),
+      getSignedUrl: async () => {
+        const urlResult = await fs.getDownloadUrl(fileId);
+        if (urlResult.isErr()) {
+          throw new Error(urlResult.error.message);
+        }
+        return urlResult.value;
+      },
+      createReadStream: () => {
+        const pass = new PassThrough();
+        void fs.read(fileId).then((result) => {
+          if (result.isErr() || !result.value) {
+            pass.destroy(
+              result.isErr()
+                ? new Error(result.error.message)
+                : new Error(`File not found: \`${fileId}\``)
+            );
+          } else {
+            result.value.pipe(pass);
+          }
+        });
+        return pass;
+      },
+    });
+  }
+
   if (!agentLoopContext?.runContext) {
     return new Err("No conversation context available");
   }
@@ -115,6 +183,43 @@ export async function getFileFromConversationAttachment(
 > {
   if (!agentLoopContext?.runContext) {
     return new Err("No conversation context available");
+  }
+
+  // Canonical scoped paths (conversation-{id}/..., pod-{id}/...) — resolve via DustFileSystem.
+  if (isCanonicalScopedPath(fileId)) {
+    const fsResult = await DustFileSystem.fromScopedPath(auth, fileId);
+    if (fsResult.isErr()) {
+      return new Err(fsResult.error.message);
+    }
+    const fs = fsResult.value;
+
+    const statResult = await fs.stat(fileId);
+    if (statResult.isErr()) {
+      return new Err(statResult.error.message);
+    }
+    if (!statResult.value) {
+      return new Err(`File not found: \`${fileId}\`.`);
+    }
+
+    const readResult = await fs.read(fileId);
+    if (readResult.isErr()) {
+      return new Err(readResult.error.message);
+    }
+    if (!readResult.value) {
+      return new Err(`File not found: \`${fileId}\`.`);
+    }
+
+    const bufferResult = await streamToBuffer(readResult.value);
+    if (bufferResult.isErr()) {
+      return new Err(bufferResult.error);
+    }
+
+    const filename = fileId.split("/").pop() ?? fileId;
+    return new Ok({
+      buffer: bufferResult.value,
+      filename: sanitizeFilename(filename),
+      contentType: statResult.value.contentType,
+    });
   }
 
   // Scoped paths resolve through mount path.

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -29,10 +29,10 @@ import { PassThrough } from "stream";
  * These are distinct from legacy paths (`conversation/file.txt`, `pod/file.txt`)
  * and from raw file IDs (`fil_xxx`).
  */
-function isCanonicalScopedPath(fileId: string): boolean {
+function isCanonicalScopedPath(scopedPath: string): boolean {
   return (
-    fileId.startsWith(SCOPED_PREFIX_CONVERSATION) ||
-    fileId.startsWith(SCOPED_PREFIX_POD)
+    scopedPath.startsWith(SCOPED_PREFIX_CONVERSATION) ||
+    scopedPath.startsWith(SCOPED_PREFIX_POD)
   );
 }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
External MCP tools (GDrive, Slack, image generation, Jira, etc.) that need to read conversation files call `resolveConversationFileRef` and `getFileFromConversationAttachment`. These functions currently only handle legacy scoped paths (`conversation/file.txt`) and raw file IDs (fil_xxx).

As the files MCP server migrates its tools to `DustFileSystem`, it will start producing canonical scoped paths (`conversation-{id}/file.txt`, `pod-{id}/file.txt`). Without this change, external tools receiving those paths from the agent would fail silently or return errors.

This PR adds a fast-path for canonical scoped paths in both functions. Canonical paths are routed through `DustFileSystem.fromScopedPath`, which resolves the conversation or pod by ID directly. No ambient conversation context required. The existing legacy path and file ID resolution paths are unchanged.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
