### PR TITLE
Track the monthly programmatic usage consumption (capped or close to cap)

### DIFF
--- a/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
@@ -18,7 +18,10 @@ import {
   addBackwardCompatibleConversationWithoutContentFields,
   normalizeConversationVisibility,
 } from "@app/lib/api/v1/backward_compatibility";
-import { isApiBlocked } from "@app/lib/metronome/user_block";
+import {
+  isApiBlocked,
+  isProgrammaticApiBlocked,
+} from "@app/lib/metronome/user_block";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -159,6 +162,19 @@ app.post(
                 type: "rate_limit_error",
                 message:
                   "Your workspace has run out of credits. Please purchase more credits to continue.",
+              },
+            });
+          }
+          if (
+            workspace.metronomeCustomerId &&
+            (await isProgrammaticApiBlocked(workspace.sId))
+          ) {
+            return apiError(ctx, {
+              status_code: 429,
+              api_error: {
+                type: "rate_limit_error",
+                message:
+                  "Your workspace has reached its programmatic monthly spending cap.",
               },
             });
           }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -65,6 +65,7 @@ import { extractFromString, serializeMention } from "@app/lib/mentions/format";
 import {
   getWorkspaceCreditPoolStatus,
   isApiBlocked,
+  isProgrammaticApiBlocked,
   isUserBlocked,
 } from "@app/lib/metronome/user_block";
 import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
@@ -2450,6 +2451,21 @@ async function checkMessagesLimit(
           }),
         },
       });
+    }
+
+    // Programmatic monthly cap: block programmatic calls when the cap is reached.
+    if (isProgrammaticUsage(auth, { userMessageOrigin: context.origin })) {
+      const programmaticBlocked = await isProgrammaticApiBlocked(owner.sId);
+      if (programmaticBlocked) {
+        return new Err({
+          status_code: 429,
+          api_error: {
+            type: "rate_limit_error",
+            message:
+              "Your workspace has reached its programmatic monthly spending cap. Please contact support to increase it.",
+          },
+        });
+      }
     }
   } else if (isProgrammaticUsage(auth, { userMessageOrigin: context.origin })) {
     const limitsResult = await checkProgrammaticUsageLimits(auth);

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -3,6 +3,7 @@ import { isPAYGEnabled } from "@app/lib/credits/credit_payg";
 import { listMetronomeBalances } from "@app/lib/metronome/client";
 import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
 import { invalidateWorkspacePoolCredits } from "@app/lib/metronome/credit_balance";
+import { transitionProgrammaticCreditState } from "@app/lib/metronome/programmatic_credit_state_machine";
 import { clearUserCapBlocked } from "@app/lib/metronome/user_block";
 import { transitionUserCreditState } from "@app/lib/metronome/user_credit_state_machine";
 import type { WorkspaceCreditEvent } from "@app/lib/metronome/workspace_credit_state_machine";
@@ -167,6 +168,43 @@ async function transitionWorkspacePool(
   await transitionWorkspaceCreditState(workspace, event, {
     workspaceId: workspace.sId,
     paygEnabled,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Programmatic credit state dispatchers
+// ---------------------------------------------------------------------------
+
+export async function dispatchProgrammaticLowBalance({
+  workspace,
+  remainingCredits,
+}: {
+  workspace: WorkspaceResource;
+  remainingCredits: number;
+}): Promise<void> {
+  await transitionProgrammaticCreditState(workspace, {
+    type: "programmatic_low_balance",
+    remainingCredits,
+  });
+}
+
+export async function dispatchProgrammaticCapReached({
+  workspace,
+}: {
+  workspace: WorkspaceResource;
+}): Promise<void> {
+  await transitionProgrammaticCreditState(workspace, {
+    type: "programmatic_cap_reached",
+  });
+}
+
+export async function dispatchProgrammaticCapReset({
+  workspace,
+}: {
+  workspace: WorkspaceResource;
+}): Promise<void> {
+  await transitionProgrammaticCreditState(workspace, {
+    type: "programmatic_cap_reset",
   });
 }
 

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -5,6 +5,9 @@ import {
   dispatchPerUserCapReached,
   dispatchPerUserCapResolved,
   dispatchPoolExhausted,
+  dispatchProgrammaticCapReached,
+  dispatchProgrammaticCapReset,
+  dispatchProgrammaticLowBalance,
   syncPoolCreditStateFromBalance,
 } from "@app/lib/api/metronome/credit_state_dispatcher";
 import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
@@ -20,6 +23,11 @@ import {
   grantFreeCreditFromMetronomeSegment,
   YEARLY_MULTIPLIER,
 } from "@app/lib/credits/free";
+import {
+  PROGRAMMATIC_CAP_ALERT_NAME,
+  PROGRAMMATIC_CRITICAL_BALANCE_ALERT_NAME,
+  PROGRAMMATIC_LOW_BALANCE_ALERT_NAME,
+} from "@app/lib/metronome/alerts/programmatic_cap";
 import {
   getMetronomeDefaultUserCapAlert,
   getMetronomePerUserCap,
@@ -38,6 +46,7 @@ import {
   CONTRACT_CREDIT_TYPE_EXCESS,
   CONTRACT_CREDIT_TYPE_POOL,
   getCreditTypeAwuId,
+  getCreditTypeProgrammaticUsdId,
   getProductExcessCreditsId,
   PLAN_CODE_CUSTOM_FIELD_KEY,
 } from "@app/lib/metronome/constants";
@@ -607,6 +616,36 @@ export async function processMetronomeWebhook({
         if (handleResult.isErr()) {
           return handleResult;
         }
+      } else if (
+        event.properties.credit_type_id === getCreditTypeProgrammaticUsdId()
+      ) {
+        // Programmatic monthly cap alerts. Three alerts exist per workspace
+        // with distinct names; route to the matching dispatcher.
+        const alertName = event.properties.alert_name ?? "";
+        if (alertName.startsWith(PROGRAMMATIC_CAP_ALERT_NAME)) {
+          await dispatchProgrammaticCapReached({ workspace });
+        } else if (
+          alertName.startsWith(PROGRAMMATIC_CRITICAL_BALANCE_ALERT_NAME)
+        ) {
+          await dispatchProgrammaticLowBalance({
+            workspace,
+            remainingCredits: 10,
+          });
+        } else if (alertName.startsWith(PROGRAMMATIC_LOW_BALANCE_ALERT_NAME)) {
+          await dispatchProgrammaticLowBalance({
+            workspace,
+            remainingCredits: 100,
+          });
+        }
+        logger.info(
+          {
+            eventId: event.id,
+            workspaceId: workspace.sId,
+            alertName,
+            currentSpend: event.properties.current_spend,
+          },
+          "[Metronome Webhook] spend_threshold_reached: programmatic alert dispatched"
+        );
       } else {
         await dispatchPaygCapReached({ workspace });
         logger.info(
@@ -651,6 +690,14 @@ export async function processMetronomeWebhook({
         if (handleResult.isErr()) {
           return handleResult;
         }
+      } else if (
+        event.properties.credit_type_id === getCreditTypeProgrammaticUsdId()
+      ) {
+        await dispatchProgrammaticCapReset({ workspace });
+        logger.info(
+          { eventId: event.id, workspaceId: workspace.sId },
+          "[Metronome Webhook] spend_threshold_resolved: programmatic cap reset dispatched"
+        );
       } else {
         logger.info(
           { eventId: event.id, workspaceId: workspace.sId },

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -46,7 +46,6 @@ import {
   CONTRACT_CREDIT_TYPE_EXCESS,
   CONTRACT_CREDIT_TYPE_POOL,
   getCreditTypeAwuId,
-  getCreditTypeProgrammaticUsdId,
   getProductExcessCreditsId,
   PLAN_CODE_CUSTOM_FIELD_KEY,
 } from "@app/lib/metronome/constants";
@@ -616,9 +615,7 @@ export async function processMetronomeWebhook({
         if (handleResult.isErr()) {
           return handleResult;
         }
-      } else if (
-        event.properties.credit_type_id === getCreditTypeProgrammaticUsdId()
-      ) {
+      } else if (event.properties.credit_type_id === getCreditTypeAwuId()) {
         // Programmatic monthly cap alerts. Three alerts exist per workspace
         // with distinct names; route to the matching dispatcher.
         const alertName = event.properties.alert_name ?? "";
@@ -690,9 +687,7 @@ export async function processMetronomeWebhook({
         if (handleResult.isErr()) {
           return handleResult;
         }
-      } else if (
-        event.properties.credit_type_id === getCreditTypeProgrammaticUsdId()
-      ) {
+      } else if (event.properties.credit_type_id === getCreditTypeAwuId()) {
         await dispatchProgrammaticCapReset({ workspace });
         logger.info(
           { eventId: event.id, workspaceId: workspace.sId },

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -24,6 +24,8 @@ import {
   YEARLY_MULTIPLIER,
 } from "@app/lib/credits/free";
 import {
+  CRITICAL_BALANCE_OFFSET,
+  LOW_BALANCE_OFFSET,
   PROGRAMMATIC_CAP_ALERT_NAME,
   PROGRAMMATIC_CRITICAL_BALANCE_ALERT_NAME,
   PROGRAMMATIC_LOW_BALANCE_ALERT_NAME,
@@ -50,6 +52,7 @@ import {
   PLAN_CODE_CUSTOM_FIELD_KEY,
 } from "@app/lib/metronome/constants";
 import { invalidateContractCache } from "@app/lib/metronome/plan_type";
+import type { ProgrammaticCreditEvent } from "@app/lib/metronome/programmatic_credit_state_machine";
 import { isMetronomeFreeCredit } from "@app/lib/metronome/types";
 import type { MetronomeWebhookEvent } from "@app/lib/metronome/webhook_events";
 import { PlanModel } from "@app/lib/models/plan";
@@ -67,6 +70,31 @@ import type { Commit, Credit } from "@metronome/sdk/resources";
 import type { CustomerAlert } from "@metronome/sdk/resources/v1/customers";
 
 type MetronomeAlertState = CustomerAlert["customer_status"];
+
+// Map a programmatic cap alert name to the state-machine event it should
+// dispatch. Returns null when the alert name doesn't match any of the three
+// programmatic alerts (defensive — Metronome shouldn't fire anything else
+// under the AWU credit type on this code path).
+function programmaticEventFromAlertName(
+  alertName: string
+): ProgrammaticCreditEvent | null {
+  if (alertName.startsWith(PROGRAMMATIC_CAP_ALERT_NAME)) {
+    return { type: "programmatic_cap_reached" };
+  }
+  if (alertName.startsWith(PROGRAMMATIC_CRITICAL_BALANCE_ALERT_NAME)) {
+    return {
+      type: "programmatic_low_balance",
+      remainingCredits: CRITICAL_BALANCE_OFFSET,
+    };
+  }
+  if (alertName.startsWith(PROGRAMMATIC_LOW_BALANCE_ALERT_NAME)) {
+    return {
+      type: "programmatic_low_balance",
+      remainingCredits: LOW_BALANCE_OFFSET,
+    };
+  }
+  return null;
+}
 
 export class ProcessMetronomeWebhookError extends Error {
   constructor(
@@ -619,20 +647,23 @@ export async function processMetronomeWebhook({
         // Programmatic monthly cap alerts. Three alerts exist per workspace
         // with distinct names; route to the matching dispatcher.
         const alertName = event.properties.alert_name ?? "";
-        if (alertName.startsWith(PROGRAMMATIC_CAP_ALERT_NAME)) {
-          await dispatchProgrammaticCapReached({ workspace });
-        } else if (
-          alertName.startsWith(PROGRAMMATIC_CRITICAL_BALANCE_ALERT_NAME)
-        ) {
-          await dispatchProgrammaticLowBalance({
-            workspace,
-            remainingCredits: 10,
-          });
-        } else if (alertName.startsWith(PROGRAMMATIC_LOW_BALANCE_ALERT_NAME)) {
-          await dispatchProgrammaticLowBalance({
-            workspace,
-            remainingCredits: 100,
-          });
+        const programmaticEvent = programmaticEventFromAlertName(alertName);
+        if (programmaticEvent) {
+          switch (programmaticEvent.type) {
+            case "programmatic_cap_reached":
+              await dispatchProgrammaticCapReached({ workspace });
+              break;
+            case "programmatic_low_balance":
+              await dispatchProgrammaticLowBalance({
+                workspace,
+                remainingCredits: programmaticEvent.remainingCredits,
+              });
+              break;
+            case "programmatic_cap_reset":
+              break;
+            default:
+              assertNever(programmaticEvent);
+          }
         }
         logger.info(
           {

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -71,6 +71,28 @@ import type { CustomerAlert } from "@metronome/sdk/resources/v1/customers";
 
 type MetronomeAlertState = CustomerAlert["customer_status"];
 
+// Programmatic cap alerts share the AWU credit type with PAYG cap alerts;
+// the `usage_type=programmatic` group filter is what distinguishes them.
+function isProgrammaticMonthlyCap(
+  event: Extract<
+    MetronomeWebhookEvent,
+    {
+      type:
+        | "alerts.spend_threshold_reached"
+        | "alerts.spend_threshold_resolved";
+    }
+  >
+): boolean {
+  if (event.properties.credit_type_id !== getCreditTypeAwuId()) {
+    return false;
+  }
+  return (
+    event.properties.group_values?.some(
+      (g) => g.key === "usage_type" && g.value === "programmatic"
+    ) ?? false
+  );
+}
+
 // Map a programmatic cap alert name to the state-machine event it should
 // dispatch. Returns null when the alert name doesn't match any of the three
 // programmatic alerts (defensive — Metronome shouldn't fire anything else
@@ -643,7 +665,7 @@ export async function processMetronomeWebhook({
         if (handleResult.isErr()) {
           return handleResult;
         }
-      } else if (event.properties.credit_type_id === getCreditTypeAwuId()) {
+      } else if (isProgrammaticMonthlyCap(event)) {
         // Programmatic monthly cap alerts. Three alerts exist per workspace
         // with distinct names; route to the matching dispatcher.
         const alertName = event.properties.alert_name ?? "";
@@ -660,6 +682,8 @@ export async function processMetronomeWebhook({
               });
               break;
             case "programmatic_cap_reset":
+              // never happens in spend_threshold_reached
+              // dispatch below by spend_threshold_resolved case
               break;
             default:
               assertNever(programmaticEvent);
@@ -718,7 +742,7 @@ export async function processMetronomeWebhook({
         if (handleResult.isErr()) {
           return handleResult;
         }
-      } else if (event.properties.credit_type_id === getCreditTypeAwuId()) {
+      } else if (isProgrammaticMonthlyCap(event)) {
         await dispatchProgrammaticCapReset({ workspace });
         logger.info(
           { eventId: event.id, workspaceId: workspace.sId },

--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -21,6 +21,7 @@ export * from "./manage_audit_logs_kill_switch";
 export * from "./manage_authorized_domains";
 export * from "./manage_conversation_kill_switch";
 export * from "./manage_credit_usage_configuration";
+export * from "./manage_programmatic_monthly_cap";
 export * from "./manage_programmatic_usage_configuration";
 export * from "./manage_seat_limits";
 export * from "./manage_workspace_kill_switch";

--- a/front/lib/api/poke/plugins/workspaces/manage_programmatic_monthly_cap.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_programmatic_monthly_cap.ts
@@ -5,38 +5,20 @@ import {
   getMetronomeProgrammaticCap,
   upsertMetronomeProgrammaticCapAlerts,
 } from "@app/lib/metronome/alerts/programmatic_cap";
-import {
-  METRONOME_PROGRAMMATIC_USAGE_CREDIT_TO_MICRO_USD,
-  MICRO_USD_PER_DOLLAR,
-} from "@app/lib/metronome/types";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { Err, Ok } from "@app/types/shared/result";
 import { z } from "zod";
 
-function creditsToDollars(credits: number): number {
-  return (
-    (credits * METRONOME_PROGRAMMATIC_USAGE_CREDIT_TO_MICRO_USD) /
-    MICRO_USD_PER_DOLLAR
-  );
-}
-
-function dollarsToCredits(dollars: number): number {
-  return (
-    (dollars * MICRO_USD_PER_DOLLAR) /
-    METRONOME_PROGRAMMATIC_USAGE_CREDIT_TO_MICRO_USD
-  );
-}
-
 const ProgrammaticMonthlyCapSchema = z
   .object({
     enabled: z.boolean(),
-    monthlyCapDollars: z.number().min(1).max(100_000).optional(),
+    monthlyCapAwu: z.number().min(1).max(10_000_000).optional(),
   })
   .refine(
     (data) =>
       !data.enabled ||
-      (data.monthlyCapDollars !== undefined && data.monthlyCapDollars >= 1),
-    { message: "monthlyCapDollars must be >= $1 when enabled" }
+      (data.monthlyCapAwu !== undefined && data.monthlyCapAwu >= 1),
+    { message: "monthlyCapAwu must be >= 1 when enabled" }
   );
 
 export const manageProgrammaticMonthlyCapPlugin = createPlugin({
@@ -54,10 +36,10 @@ export const manageProgrammaticMonthlyCapPlugin = createPlugin({
         async: true,
         asyncDescription: true,
       },
-      monthlyCapDollars: {
+      monthlyCapAwu: {
         type: "number",
-        label: "Monthly cap ($)",
-        description: "Monthly spending cap in dollars (1-100,000).",
+        label: "Monthly cap (AWU credits)",
+        description: "Monthly spending cap in AWU credits.",
         async: true,
       },
     },
@@ -68,7 +50,7 @@ export const manageProgrammaticMonthlyCapPlugin = createPlugin({
       return new Ok({
         enabled: false,
         enabledDescription: "No workspace found.",
-        monthlyCapDollars: 0,
+        monthlyCapAwu: 0,
       });
     }
 
@@ -77,7 +59,7 @@ export const manageProgrammaticMonthlyCapPlugin = createPlugin({
       return new Ok({
         enabled: false,
         enabledDescription: "Workspace is not provisioned in Metronome.",
-        monthlyCapDollars: 0,
+        monthlyCapAwu: 0,
       });
     }
 
@@ -96,15 +78,14 @@ export const manageProgrammaticMonthlyCapPlugin = createPlugin({
       return new Ok({
         enabled: false,
         enabledDescription: `No cap set. State: ${currentState}.`,
-        monthlyCapDollars: 0,
+        monthlyCapAwu: 0,
       });
     }
 
-    const capDollars = creditsToDollars(capCredits);
     return new Ok({
       enabled: true,
-      enabledDescription: `Current cap: $${capDollars} (${capCredits} credits). State: ${currentState}.`,
-      monthlyCapDollars: capDollars,
+      enabledDescription: `Current cap: ${capCredits} AWU. State: ${currentState}.`,
+      monthlyCapAwu: capCredits,
     });
   },
 
@@ -131,15 +112,13 @@ export const manageProgrammaticMonthlyCapPlugin = createPlugin({
     if (!parsed.success) {
       return new Err(new Error(parsed.error.message));
     }
-    const { enabled, monthlyCapDollars } = parsed.data;
+    const { enabled, monthlyCapAwu } = parsed.data;
 
-    if (enabled && monthlyCapDollars) {
-      const monthlyCapCredits = dollarsToCredits(monthlyCapDollars);
-
+    if (enabled && monthlyCapAwu) {
       const result = await upsertMetronomeProgrammaticCapAlerts({
         metronomeCustomerId,
         workspaceId: workspace.sId,
-        monthlyCapCredits,
+        monthlyCapCredits: monthlyCapAwu,
       });
       if (result.isErr()) {
         return new Err(result.error);
@@ -150,7 +129,7 @@ export const manageProgrammaticMonthlyCapPlugin = createPlugin({
 
       return new Ok({
         display: "text",
-        value: `Programmatic monthly cap set to $${monthlyCapDollars} for workspace "${workspace.name}".`,
+        value: `Programmatic monthly cap set to ${monthlyCapAwu} AWU for workspace "${workspace.name}".`,
       });
     }
 

--- a/front/lib/api/poke/plugins/workspaces/manage_programmatic_monthly_cap.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_programmatic_monthly_cap.ts
@@ -1,0 +1,172 @@
+import { dispatchProgrammaticCapReset } from "@app/lib/api/metronome/credit_state_dispatcher";
+import { createPlugin } from "@app/lib/api/poke/types";
+import {
+  clearMetronomeProgrammaticCapAlerts,
+  getMetronomeProgrammaticCap,
+  upsertMetronomeProgrammaticCapAlerts,
+} from "@app/lib/metronome/alerts/programmatic_cap";
+import {
+  METRONOME_PROGRAMMATIC_USAGE_CREDIT_TO_MICRO_USD,
+  MICRO_USD_PER_DOLLAR,
+} from "@app/lib/metronome/types";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { Err, Ok } from "@app/types/shared/result";
+import { z } from "zod";
+
+function creditsToDollars(credits: number): number {
+  return (
+    (credits * METRONOME_PROGRAMMATIC_USAGE_CREDIT_TO_MICRO_USD) /
+    MICRO_USD_PER_DOLLAR
+  );
+}
+
+function dollarsToCredits(dollars: number): number {
+  return (
+    (dollars * MICRO_USD_PER_DOLLAR) /
+    METRONOME_PROGRAMMATIC_USAGE_CREDIT_TO_MICRO_USD
+  );
+}
+
+const ProgrammaticMonthlyCapSchema = z
+  .object({
+    enabled: z.boolean(),
+    monthlyCapDollars: z.number().min(1).max(100_000).optional(),
+  })
+  .refine(
+    (data) =>
+      !data.enabled ||
+      (data.monthlyCapDollars !== undefined && data.monthlyCapDollars >= 1),
+    { message: "monthlyCapDollars must be >= $1 when enabled" }
+  );
+
+export const manageProgrammaticMonthlyCapPlugin = createPlugin({
+  manifest: {
+    id: "manage-programmatic-monthly-cap",
+    name: "Manage Programmatic Monthly Cap",
+    description:
+      "Set or remove the monthly spending cap for programmatic (API) usage.",
+    resourceTypes: ["workspaces"],
+    args: {
+      enabled: {
+        type: "boolean",
+        label: "Enable monthly cap",
+        description: "Toggle the programmatic monthly cap on or off.",
+        async: true,
+        asyncDescription: true,
+      },
+      monthlyCapDollars: {
+        type: "number",
+        label: "Monthly cap ($)",
+        description: "Monthly spending cap in dollars (1-100,000).",
+        async: true,
+      },
+    },
+  },
+
+  populateAsyncArgs: async (_auth, workspace) => {
+    if (!workspace) {
+      return new Ok({
+        enabled: false,
+        enabledDescription: "No workspace found.",
+        monthlyCapDollars: 0,
+      });
+    }
+
+    const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
+    if (!workspaceResource?.metronomeCustomerId) {
+      return new Ok({
+        enabled: false,
+        enabledDescription: "Workspace is not provisioned in Metronome.",
+        monthlyCapDollars: 0,
+      });
+    }
+
+    const capResult = await getMetronomeProgrammaticCap({
+      metronomeCustomerId: workspaceResource.metronomeCustomerId,
+      workspaceId: workspace.sId,
+    });
+    if (capResult.isErr()) {
+      return new Err(capResult.error);
+    }
+
+    const capCredits = capResult.value;
+    const currentState = workspaceResource.programmaticCreditState;
+
+    if (capCredits === null) {
+      return new Ok({
+        enabled: false,
+        enabledDescription: `No cap set. State: ${currentState}.`,
+        monthlyCapDollars: 0,
+      });
+    }
+
+    const capDollars = creditsToDollars(capCredits);
+    return new Ok({
+      enabled: true,
+      enabledDescription: `Current cap: $${capDollars} (${capCredits} credits). State: ${currentState}.`,
+      monthlyCapDollars: capDollars,
+    });
+  },
+
+  execute: async (_auth, workspace, rawArgs) => {
+    if (!workspace) {
+      return new Err(new Error("Cannot find workspace."));
+    }
+
+    const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
+    if (!workspaceResource) {
+      return new Err(new Error(`Workspace not found: wId='${workspace.sId}'`));
+    }
+
+    const metronomeCustomerId = workspaceResource.metronomeCustomerId;
+    if (!metronomeCustomerId) {
+      return new Err(
+        new Error(
+          `Workspace "${workspace.name}" is not provisioned in Metronome.`
+        )
+      );
+    }
+
+    const parsed = ProgrammaticMonthlyCapSchema.safeParse(rawArgs);
+    if (!parsed.success) {
+      return new Err(new Error(parsed.error.message));
+    }
+    const { enabled, monthlyCapDollars } = parsed.data;
+
+    if (enabled && monthlyCapDollars) {
+      const monthlyCapCredits = dollarsToCredits(monthlyCapDollars);
+
+      const result = await upsertMetronomeProgrammaticCapAlerts({
+        metronomeCustomerId,
+        workspaceId: workspace.sId,
+        monthlyCapCredits,
+      });
+      if (result.isErr()) {
+        return new Err(result.error);
+      }
+
+      // Reset the state machine — thresholds may have changed.
+      await dispatchProgrammaticCapReset({ workspace: workspaceResource });
+
+      return new Ok({
+        display: "text",
+        value: `Programmatic monthly cap set to $${monthlyCapDollars} for workspace "${workspace.name}".`,
+      });
+    }
+
+    // Disable: clear alerts and reset state.
+    const clearResult = await clearMetronomeProgrammaticCapAlerts({
+      metronomeCustomerId,
+      workspaceId: workspace.sId,
+    });
+    if (clearResult.isErr()) {
+      return new Err(clearResult.error);
+    }
+    await dispatchProgrammaticCapReset({ workspace: workspaceResource });
+
+    return new Ok({
+      display: "text",
+      value: `Programmatic monthly cap removed for workspace "${workspace.name}".`,
+    });
+  },
+});

--- a/front/lib/metronome/alerts/programmatic_cap.ts
+++ b/front/lib/metronome/alerts/programmatic_cap.ts
@@ -3,7 +3,7 @@ import {
   findMetronomeAlert,
   upsertMetronomeAlert,
 } from "@app/lib/metronome/alerts";
-import { getCreditTypeProgrammaticUsdId } from "@app/lib/metronome/constants";
+import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -69,7 +69,7 @@ export async function upsertMetronomeProgrammaticCapAlerts({
   workspaceId: string;
   monthlyCapCredits: number;
 }): Promise<Result<void, Error>> {
-  const creditTypeId = getCreditTypeProgrammaticUsdId();
+  const creditTypeId = getCreditTypeAwuId();
 
   // Main cap alert.
   const capResult = await upsertMetronomeAlert({

--- a/front/lib/metronome/alerts/programmatic_cap.ts
+++ b/front/lib/metronome/alerts/programmatic_cap.ts
@@ -1,0 +1,163 @@
+import {
+  clearMetronomeAlert,
+  findMetronomeAlert,
+  upsertMetronomeAlert,
+} from "@app/lib/metronome/alerts";
+import { getCreditTypeProgrammaticUsdId } from "@app/lib/metronome/constants";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+function programmaticCapUniquenessKey(workspaceId: string): string {
+  return `programmatic-cap-${workspaceId}`;
+}
+
+function programmaticCapLowUniquenessKey(workspaceId: string): string {
+  return `programmatic-cap-low-${workspaceId}`;
+}
+
+function programmaticCapCriticalUniquenessKey(workspaceId: string): string {
+  return `programmatic-cap-critical-${workspaceId}`;
+}
+
+// Warning thresholds: fire alerts this many credits before the cap.
+const LOW_BALANCE_OFFSET = 100;
+const CRITICAL_BALANCE_OFFSET = 10;
+
+// Alert name prefixes used to identify which alert fired in webhook routing.
+export const PROGRAMMATIC_CAP_ALERT_NAME = "Programmatic cap";
+export const PROGRAMMATIC_LOW_BALANCE_ALERT_NAME = "Programmatic low balance";
+export const PROGRAMMATIC_CRITICAL_BALANCE_ALERT_NAME =
+  "Programmatic critical balance";
+
+/**
+ * Read the current programmatic monthly cap from Metronome. Returns the cap
+ * alert threshold (in Programmatic USD credits), or null if no cap is set.
+ */
+export async function getMetronomeProgrammaticCap({
+  metronomeCustomerId,
+  workspaceId,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+}): Promise<Result<number | null, Error>> {
+  const result = await findMetronomeAlert({
+    metronomeCustomerId,
+    uniquenessKey: programmaticCapUniquenessKey(workspaceId),
+  });
+  if (result.isErr()) {
+    return new Err(result.error);
+  }
+  return new Ok(result.value?.alert.threshold ?? null);
+}
+
+/**
+ * Idempotently create or update the three programmatic cap alerts:
+ *   1. Main cap alert (depleted when reached)
+ *   2. Low balance alert (cap - 100)
+ *   3. Critical balance alert (cap - 10)
+ *
+ * All three use the Programmatic USD credit type so they can be distinguished
+ * from AWU pool alerts in webhook routing.
+ */
+export async function upsertMetronomeProgrammaticCapAlerts({
+  metronomeCustomerId,
+  workspaceId,
+  monthlyCapCredits,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+  monthlyCapCredits: number;
+}): Promise<Result<void, Error>> {
+  const creditTypeId = getCreditTypeProgrammaticUsdId();
+
+  // Main cap alert.
+  const capResult = await upsertMetronomeAlert({
+    alert_type: "spend_threshold_reached",
+    name: `${PROGRAMMATIC_CAP_ALERT_NAME} ${workspaceId} (${monthlyCapCredits} credits)`,
+    threshold: monthlyCapCredits,
+    credit_type_id: creditTypeId,
+    customer_id: metronomeCustomerId,
+    uniqueness_key: programmaticCapUniquenessKey(workspaceId),
+  });
+  if (capResult.isErr()) {
+    return new Err(capResult.error);
+  }
+
+  // Low balance alert (100 credits before cap).
+  const lowThreshold = Math.max(0, monthlyCapCredits - LOW_BALANCE_OFFSET);
+  const lowResult = await upsertMetronomeAlert({
+    alert_type: "spend_threshold_reached",
+    name: `${PROGRAMMATIC_LOW_BALANCE_ALERT_NAME} ${workspaceId} (${lowThreshold} credits)`,
+    threshold: lowThreshold,
+    credit_type_id: creditTypeId,
+    customer_id: metronomeCustomerId,
+    uniqueness_key: programmaticCapLowUniquenessKey(workspaceId),
+  });
+  if (lowResult.isErr()) {
+    return new Err(lowResult.error);
+  }
+
+  // Critical balance alert (10 credits before cap).
+  const criticalThreshold = Math.max(
+    0,
+    monthlyCapCredits - CRITICAL_BALANCE_OFFSET
+  );
+  const criticalResult = await upsertMetronomeAlert({
+    alert_type: "spend_threshold_reached",
+    name: `${PROGRAMMATIC_CRITICAL_BALANCE_ALERT_NAME} ${workspaceId} (${criticalThreshold} credits)`,
+    threshold: criticalThreshold,
+    credit_type_id: creditTypeId,
+    customer_id: metronomeCustomerId,
+    uniqueness_key: programmaticCapCriticalUniquenessKey(workspaceId),
+  });
+  if (criticalResult.isErr()) {
+    return new Err(criticalResult.error);
+  }
+
+  logger.info(
+    {
+      workspaceId,
+      metronomeCustomerId,
+      monthlyCapCredits,
+      lowThreshold,
+      criticalThreshold,
+    },
+    "[Metronome ProgrammaticCap] Synced programmatic cap alerts"
+  );
+  return new Ok(undefined);
+}
+
+/**
+ * Archive all three programmatic cap alerts. Idempotent — no-op when no
+ * matching alerts exist.
+ */
+export async function clearMetronomeProgrammaticCapAlerts({
+  metronomeCustomerId,
+  workspaceId,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+}): Promise<Result<void, Error>> {
+  const keys = [
+    programmaticCapUniquenessKey(workspaceId),
+    programmaticCapLowUniquenessKey(workspaceId),
+    programmaticCapCriticalUniquenessKey(workspaceId),
+  ];
+
+  for (const uniquenessKey of keys) {
+    const result = await clearMetronomeAlert({
+      metronomeCustomerId,
+      uniquenessKey,
+    });
+    if (result.isErr()) {
+      return new Err(result.error);
+    }
+  }
+
+  logger.info(
+    { workspaceId, metronomeCustomerId },
+    "[Metronome ProgrammaticCap] Cleared programmatic cap alerts"
+  );
+  return new Ok(undefined);
+}

--- a/front/lib/metronome/alerts/programmatic_cap.ts
+++ b/front/lib/metronome/alerts/programmatic_cap.ts
@@ -71,6 +71,12 @@ export async function upsertMetronomeProgrammaticCapAlerts({
 }): Promise<Result<void, Error>> {
   const creditTypeId = getCreditTypeAwuId();
 
+  // Scope every alert to programmatic AWU usage only, so contract/pool spend
+  // doesn't contribute to the cap thresholds.
+  const programmaticGroupValues = [
+    { key: "usage_type", value: "programmatic" },
+  ];
+
   // Main cap alert.
   const capResult = await upsertMetronomeAlert({
     alert_type: "spend_threshold_reached",
@@ -78,6 +84,7 @@ export async function upsertMetronomeProgrammaticCapAlerts({
     threshold: monthlyCapCredits,
     credit_type_id: creditTypeId,
     customer_id: metronomeCustomerId,
+    group_values: programmaticGroupValues,
     uniqueness_key: programmaticCapUniquenessKey(workspaceId),
   });
   if (capResult.isErr()) {
@@ -92,6 +99,7 @@ export async function upsertMetronomeProgrammaticCapAlerts({
     threshold: lowThreshold,
     credit_type_id: creditTypeId,
     customer_id: metronomeCustomerId,
+    group_values: programmaticGroupValues,
     uniqueness_key: programmaticCapLowUniquenessKey(workspaceId),
   });
   if (lowResult.isErr()) {
@@ -109,6 +117,7 @@ export async function upsertMetronomeProgrammaticCapAlerts({
     threshold: criticalThreshold,
     credit_type_id: creditTypeId,
     customer_id: metronomeCustomerId,
+    group_values: programmaticGroupValues,
     uniqueness_key: programmaticCapCriticalUniquenessKey(workspaceId),
   });
   if (criticalResult.isErr()) {

--- a/front/lib/metronome/alerts/programmatic_cap.ts
+++ b/front/lib/metronome/alerts/programmatic_cap.ts
@@ -21,8 +21,8 @@ function programmaticCapCriticalUniquenessKey(workspaceId: string): string {
 }
 
 // Warning thresholds: fire alerts this many credits before the cap.
-const LOW_BALANCE_OFFSET = 100;
-const CRITICAL_BALANCE_OFFSET = 10;
+export const LOW_BALANCE_OFFSET = 100;
+export const CRITICAL_BALANCE_OFFSET = 10;
 
 // Alert name prefixes used to identify which alert fired in webhook routing.
 export const PROGRAMMATIC_CAP_ALERT_NAME = "Programmatic cap";

--- a/front/lib/metronome/programmatic_credit_state_machine.test.ts
+++ b/front/lib/metronome/programmatic_credit_state_machine.test.ts
@@ -1,0 +1,251 @@
+import { transitionProgrammaticCreditState } from "@app/lib/metronome/programmatic_credit_state_machine";
+import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import type { WorkspaceProgrammaticCreditState } from "@app/types/credits";
+import type { Transaction } from "sequelize";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const {
+  mockSetWorkspaceProgrammaticDepleted,
+  mockClearWorkspaceProgrammaticDepleted,
+  mockSetWorkspaceProgrammaticCreditStatus,
+  mockInvalidateCacheAfterCommit,
+} = vi.hoisted(() => ({
+  mockSetWorkspaceProgrammaticDepleted: vi.fn(),
+  mockClearWorkspaceProgrammaticDepleted: vi.fn(),
+  mockSetWorkspaceProgrammaticCreditStatus: vi.fn(),
+  mockInvalidateCacheAfterCommit: vi.fn(
+    (_tx: Transaction | undefined, fn: () => Promise<void>) => {
+      void fn();
+    }
+  ),
+}));
+
+vi.mock("@app/lib/metronome/user_block", () => ({
+  setWorkspaceProgrammaticDepleted: mockSetWorkspaceProgrammaticDepleted,
+  clearWorkspaceProgrammaticDepleted: mockClearWorkspaceProgrammaticDepleted,
+  setWorkspaceProgrammaticCreditStatus:
+    mockSetWorkspaceProgrammaticCreditStatus,
+}));
+
+vi.mock("@app/lib/utils/cache", () => ({
+  invalidateCacheAfterCommit: mockInvalidateCacheAfterCommit,
+}));
+
+vi.mock("@app/logger/logger", () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type WorkspaceDouble = WorkspaceResource & {
+  updateProgrammaticCreditState: ReturnType<typeof vi.fn>;
+};
+
+function makeWorkspace(
+  programmaticCreditState: WorkspaceProgrammaticCreditState
+): WorkspaceDouble {
+  return {
+    programmaticCreditState,
+    sId: "ws_test",
+    updateProgrammaticCreditState: vi.fn().mockResolvedValue(undefined),
+  } as unknown as WorkspaceDouble;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Low balance transitions
+// ---------------------------------------------------------------------------
+
+describe("ProgrammaticCreditStateMachine — low balance", () => {
+  it("active + low_balance (remaining=100) → active_low_balance", async () => {
+    const workspace = makeWorkspace("active");
+    const result = await transitionProgrammaticCreditState(workspace, {
+      type: "programmatic_low_balance",
+      remainingCredits: 100,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("active_low_balance");
+    }
+    expect(workspace.updateProgrammaticCreditState).toHaveBeenCalledWith(
+      "active_low_balance",
+      undefined
+    );
+    expect(mockClearWorkspaceProgrammaticDepleted).toHaveBeenCalledWith(
+      "ws_test"
+    );
+  });
+
+  it("active + low_balance (remaining=10) → active_critical_balance", async () => {
+    const workspace = makeWorkspace("active");
+    const result = await transitionProgrammaticCreditState(workspace, {
+      type: "programmatic_low_balance",
+      remainingCredits: 10,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("active_critical_balance");
+    }
+    expect(workspace.updateProgrammaticCreditState).toHaveBeenCalledWith(
+      "active_critical_balance",
+      undefined
+    );
+  });
+
+  it("active_low_balance + low_balance (remaining=100) is idempotent", async () => {
+    const workspace = makeWorkspace("active_low_balance");
+    const result = await transitionProgrammaticCreditState(workspace, {
+      type: "programmatic_low_balance",
+      remainingCredits: 100,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("active_low_balance");
+    }
+    expect(workspace.updateProgrammaticCreditState).not.toHaveBeenCalled();
+  });
+
+  it("active_low_balance + low_balance (remaining=10) → active_critical_balance", async () => {
+    const workspace = makeWorkspace("active_low_balance");
+    const result = await transitionProgrammaticCreditState(workspace, {
+      type: "programmatic_low_balance",
+      remainingCredits: 10,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("active_critical_balance");
+    }
+    expect(workspace.updateProgrammaticCreditState).toHaveBeenCalledWith(
+      "active_critical_balance",
+      undefined
+    );
+  });
+
+  it("active_critical_balance + low_balance stays critical", async () => {
+    const workspace = makeWorkspace("active_critical_balance");
+    const result = await transitionProgrammaticCreditState(workspace, {
+      type: "programmatic_low_balance",
+      remainingCredits: 10,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("active_critical_balance");
+    }
+    expect(workspace.updateProgrammaticCreditState).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cap reached transitions
+// ---------------------------------------------------------------------------
+
+describe("ProgrammaticCreditStateMachine — cap reached", () => {
+  it.each([
+    "active" as const,
+    "active_low_balance" as const,
+    "active_critical_balance" as const,
+  ])("%s + cap_reached → depleted", async (from) => {
+    const workspace = makeWorkspace(from);
+    const result = await transitionProgrammaticCreditState(workspace, {
+      type: "programmatic_cap_reached",
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("depleted");
+    }
+    expect(mockSetWorkspaceProgrammaticDepleted).toHaveBeenCalledWith(
+      "ws_test"
+    );
+  });
+
+  it("depleted + cap_reached is idempotent", async () => {
+    const workspace = makeWorkspace("depleted");
+    const result = await transitionProgrammaticCreditState(workspace, {
+      type: "programmatic_cap_reached",
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("depleted");
+    }
+    expect(workspace.updateProgrammaticCreditState).not.toHaveBeenCalled();
+    expect(mockSetWorkspaceProgrammaticDepleted).toHaveBeenCalledWith(
+      "ws_test"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cap reset transitions
+// ---------------------------------------------------------------------------
+
+describe("ProgrammaticCreditStateMachine — cap reset", () => {
+  it.each([
+    "active" as const,
+    "active_low_balance" as const,
+    "active_critical_balance" as const,
+    "depleted" as const,
+  ])("%s + cap_reset → active", async (from) => {
+    const workspace = makeWorkspace(from);
+    const result = await transitionProgrammaticCreditState(workspace, {
+      type: "programmatic_cap_reset",
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("active");
+    }
+    if (from !== "active") {
+      expect(workspace.updateProgrammaticCreditState).toHaveBeenCalledWith(
+        "active",
+        undefined
+      );
+    }
+    expect(mockClearWorkspaceProgrammaticDepleted).toHaveBeenCalledWith(
+      "ws_test"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Side-effect ordering
+// ---------------------------------------------------------------------------
+
+describe("ProgrammaticCreditStateMachine — side effects", () => {
+  it("invokes DB update before registering the Redis side-effect", async () => {
+    const workspace = makeWorkspace("active");
+    await transitionProgrammaticCreditState(workspace, {
+      type: "programmatic_cap_reached",
+    });
+    const dbOrder =
+      workspace.updateProgrammaticCreditState.mock.invocationCallOrder[0];
+    const cacheOrder =
+      mockInvalidateCacheAfterCommit.mock.invocationCallOrder[0];
+    expect(dbOrder).toBeLessThan(cacheOrder);
+  });
+
+  it("forwards the provided transaction", async () => {
+    const tx = { __mock: "transaction" } as unknown as Transaction;
+    const workspace = makeWorkspace("active");
+    await transitionProgrammaticCreditState(
+      workspace,
+      { type: "programmatic_low_balance", remainingCredits: 100 },
+      { transaction: tx }
+    );
+    expect(workspace.updateProgrammaticCreditState).toHaveBeenCalledWith(
+      "active_low_balance",
+      tx
+    );
+    expect(mockInvalidateCacheAfterCommit).toHaveBeenCalledWith(
+      tx,
+      expect.any(Function)
+    );
+  });
+});

--- a/front/lib/metronome/programmatic_credit_state_machine.ts
+++ b/front/lib/metronome/programmatic_credit_state_machine.ts
@@ -1,3 +1,4 @@
+import { CRITICAL_BALANCE_OFFSET } from "@app/lib/metronome/alerts/programmatic_cap";
 import {
   clearWorkspaceProgrammaticDepleted,
   setWorkspaceProgrammaticCreditStatus,
@@ -20,8 +21,6 @@ export type ProgrammaticCreditEvent =
   | { type: "programmatic_cap_reached" }
   /** Cap reset (new billing period or cap removed/raised). */
   | { type: "programmatic_cap_reset" };
-
-const CRITICAL_BALANCE_THRESHOLD = 10;
 
 type ProgrammaticCreditGuard = (event: ProgrammaticCreditEvent) => boolean;
 
@@ -98,7 +97,7 @@ const TRANSITIONS: ProgrammaticCreditTransition[] = [
   {
     from: ["active", "active_low_balance"],
     event: "programmatic_low_balance",
-    guard: remainingAtMost(CRITICAL_BALANCE_THRESHOLD),
+    guard: remainingAtMost(CRITICAL_BALANCE_OFFSET),
     to: "active_critical_balance",
   },
 

--- a/front/lib/metronome/programmatic_credit_state_machine.ts
+++ b/front/lib/metronome/programmatic_credit_state_machine.ts
@@ -1,0 +1,180 @@
+import {
+  clearWorkspaceProgrammaticDepleted,
+  setWorkspaceProgrammaticCreditStatus,
+  setWorkspaceProgrammaticDepleted,
+} from "@app/lib/metronome/user_block";
+import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { invalidateCacheAfterCommit } from "@app/lib/utils/cache";
+import logger from "@app/logger/logger";
+import type { WorkspaceProgrammaticCreditState } from "@app/types/credits";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import type { Transaction } from "sequelize";
+
+export type ProgrammaticCreditEvent =
+  /** Spending approaching the cap. `remainingCredits` is how many credits
+   *  remain before the cap (e.g. 100 or 10). */
+  | { type: "programmatic_low_balance"; remainingCredits: number }
+  /** Spending reached the monthly cap. */
+  | { type: "programmatic_cap_reached" }
+  /** Cap reset (new billing period or cap removed/raised). */
+  | { type: "programmatic_cap_reset" };
+
+const CRITICAL_BALANCE_THRESHOLD = 10;
+
+type ProgrammaticCreditGuard = (event: ProgrammaticCreditEvent) => boolean;
+
+type ProgrammaticCreditTransition = {
+  from: WorkspaceProgrammaticCreditState | WorkspaceProgrammaticCreditState[];
+  event: ProgrammaticCreditEvent["type"];
+  guard?: ProgrammaticCreditGuard;
+  to: WorkspaceProgrammaticCreditState;
+};
+
+function remainingAtMost(threshold: number): ProgrammaticCreditGuard {
+  return (event) =>
+    event.type === "programmatic_low_balance" &&
+    event.remainingCredits <= threshold;
+}
+
+function syncProgrammaticCacheForState(
+  state: WorkspaceProgrammaticCreditState,
+  workspaceId: string,
+  transaction: Transaction | undefined
+): void {
+  switch (state) {
+    case "active":
+    case "active_low_balance":
+    case "active_critical_balance":
+      invalidateCacheAfterCommit(transaction, () =>
+        clearWorkspaceProgrammaticDepleted(workspaceId)
+      );
+      invalidateCacheAfterCommit(transaction, () =>
+        setWorkspaceProgrammaticCreditStatus(workspaceId, state)
+      );
+      return;
+
+    case "depleted":
+      invalidateCacheAfterCommit(transaction, () =>
+        setWorkspaceProgrammaticDepleted(workspaceId)
+      );
+      invalidateCacheAfterCommit(transaction, () =>
+        setWorkspaceProgrammaticCreditStatus(workspaceId, state)
+      );
+      return;
+
+    default:
+      assertNever(state);
+  }
+}
+
+const TRANSITIONS: ProgrammaticCreditTransition[] = [
+  // Any state + cap_reset → active
+  {
+    from: [
+      "active",
+      "active_low_balance",
+      "active_critical_balance",
+      "depleted",
+    ],
+    event: "programmatic_cap_reset",
+    to: "active",
+  },
+
+  // cap_reached → depleted from any active state
+  {
+    from: ["active", "active_low_balance", "active_critical_balance"],
+    event: "programmatic_cap_reached",
+    to: "depleted",
+  },
+  {
+    from: "depleted",
+    event: "programmatic_cap_reached",
+    to: "depleted",
+  },
+
+  // low_balance: critical < low < no-op (first match wins)
+  {
+    from: ["active", "active_low_balance"],
+    event: "programmatic_low_balance",
+    guard: remainingAtMost(CRITICAL_BALANCE_THRESHOLD),
+    to: "active_critical_balance",
+  },
+
+  // active -> ...
+  {
+    from: "active",
+    event: "programmatic_low_balance",
+    to: "active_low_balance",
+  },
+
+  // active_low_balance -> ...
+  {
+    from: "active_low_balance",
+    event: "programmatic_low_balance",
+    to: "active_low_balance",
+  },
+
+  // active_critical_balance -> ...
+  {
+    from: "active_critical_balance",
+    event: "programmatic_low_balance",
+    to: "active_critical_balance",
+  },
+];
+
+function findTransition(
+  current: WorkspaceProgrammaticCreditState,
+  event: ProgrammaticCreditEvent
+): ProgrammaticCreditTransition | undefined {
+  return TRANSITIONS.find((t) => {
+    const fromMatch = Array.isArray(t.from)
+      ? t.from.includes(current)
+      : t.from === current;
+    return fromMatch && t.event === event.type && (!t.guard || t.guard(event));
+  });
+}
+
+export async function transitionProgrammaticCreditState(
+  workspace: WorkspaceResource,
+  event: ProgrammaticCreditEvent,
+  { transaction }: { transaction?: Transaction } = {}
+): Promise<Result<WorkspaceProgrammaticCreditState, Error>> {
+  const workspaceId = workspace.sId;
+  const currentState = workspace.programmaticCreditState;
+  const match = findTransition(currentState, event);
+
+  if (!match) {
+    logger.warn(
+      {
+        workspaceId,
+        currentState,
+        event,
+      },
+      "[ProgrammaticCreditStateMachine] No matching transition: skipping"
+    );
+    return new Err(
+      new Error(
+        `[ProgrammaticCreditStateMachine] Illegal transition: ${currentState} + ${event.type}`
+      )
+    );
+  }
+
+  if (currentState !== match.to) {
+    await workspace.updateProgrammaticCreditState(match.to, transaction);
+  }
+  syncProgrammaticCacheForState(match.to, workspaceId, transaction);
+  logger.info(
+    {
+      workspaceId,
+      fromState: currentState,
+      toState: match.to,
+      eventType: event.type,
+      wasStateChanged: currentState !== match.to,
+    },
+    "[ProgrammaticCreditStateMachine] Transition applied"
+  );
+
+  return new Ok(match.to);
+}

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -356,7 +356,7 @@ export async function isProgrammaticApiBlocked(
   const programmaticDepleted = workspace.programmaticCreditState === "depleted";
   await setFlag(
     buildWorkspaceProgrammaticDepletedKey(workspaceId),
-    programmaticDepleted ? "1" : "0"
+    programmaticDepleted ? BLOCKED_FLAG : NOT_BLOCKED_FLAG
   );
   return programmaticDepleted;
 }

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -24,8 +24,14 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
-import type { WorkspacePoolCreditState } from "@app/types/credits";
-import { isWorkspacePoolCreditState } from "@app/types/credits";
+import type {
+  WorkspacePoolCreditState,
+  WorkspaceProgrammaticCreditState,
+} from "@app/types/credits";
+import {
+  isWorkspacePoolCreditState,
+  isWorkspaceProgrammaticCreditState,
+} from "@app/types/credits";
 
 export type UserBlockedReason = "credits_exhausted" | "user_cap_reached";
 
@@ -43,6 +49,16 @@ function buildWorkspacePoolDepletedKey(workspaceId: string): string {
 
 function buildWorkspaceCreditPoolStatusKey(workspaceId: string): string {
   return `metronome:pool_credit_status:${workspaceId}`;
+}
+
+function buildWorkspaceProgrammaticDepletedKey(workspaceId: string): string {
+  return `metronome:programmatic_depleted:${workspaceId}`;
+}
+
+function buildWorkspaceProgrammaticCreditStatusKey(
+  workspaceId: string
+): string {
+  return `metronome:programmatic_credit_status:${workspaceId}`;
 }
 
 function isBlockFlag(value: string | null): value is "0" | "1" {
@@ -247,6 +263,102 @@ export async function getWorkspaceCreditPoolStatus(
   const status = workspace.poolCreditState;
   await setFlag(buildWorkspaceCreditPoolStatusKey(workspaceId), status);
   return status;
+}
+
+// Workspace programmatic credit state (monthly cap).
+
+export async function setWorkspaceProgrammaticDepleted(
+  workspaceId: string
+): Promise<void> {
+  await setFlag(
+    buildWorkspaceProgrammaticDepletedKey(workspaceId),
+    BLOCKED_FLAG
+  );
+}
+
+export async function clearWorkspaceProgrammaticDepleted(
+  workspaceId: string
+): Promise<void> {
+  await setFlag(
+    buildWorkspaceProgrammaticDepletedKey(workspaceId),
+    NOT_BLOCKED_FLAG
+  );
+}
+
+export async function setWorkspaceProgrammaticCreditStatus(
+  workspaceId: string,
+  status: WorkspaceProgrammaticCreditState
+): Promise<void> {
+  await setFlag(buildWorkspaceProgrammaticCreditStatusKey(workspaceId), status);
+}
+
+export async function getWorkspaceProgrammaticCreditStatus(
+  workspaceId: string
+): Promise<WorkspaceProgrammaticCreditState> {
+  const cached = await runOnRedis({ origin: REDIS_ORIGIN }, async (client) =>
+    client.get(buildWorkspaceProgrammaticCreditStatusKey(workspaceId))
+  );
+
+  if (cached && isWorkspaceProgrammaticCreditState(cached)) {
+    return cached;
+  }
+
+  logger.info(
+    {
+      workspaceId,
+      workspaceProgrammaticCreditStatusCacheHit: false,
+    },
+    "[MetronomeUserBlock] Cache miss during programmatic credit status check, falling back to DB"
+  );
+
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  if (!workspace) {
+    logger.warn(
+      { workspaceId },
+      "[MetronomeUserBlock] Workspace not found during programmatic credit status cache read-through fallback"
+    );
+    return "active";
+  }
+
+  const status = workspace.programmaticCreditState;
+  await setFlag(buildWorkspaceProgrammaticCreditStatusKey(workspaceId), status);
+  return status;
+}
+
+export async function isProgrammaticApiBlocked(
+  workspaceId: string
+): Promise<boolean> {
+  const depleted = await runOnRedis({ origin: REDIS_ORIGIN }, async (client) =>
+    client.get(buildWorkspaceProgrammaticDepletedKey(workspaceId))
+  );
+
+  if (isBlockFlag(depleted)) {
+    return depleted === BLOCKED_FLAG;
+  }
+
+  logger.info(
+    {
+      workspaceId,
+      workspaceProgrammaticCacheHit: false,
+    },
+    "[MetronomeUserBlock] Cache miss during programmatic API blocked check, falling back to DB"
+  );
+
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  if (!workspace) {
+    logger.warn(
+      { workspaceId },
+      "[MetronomeUserBlock] Workspace not found during programmatic API blocked cache read-through fallback"
+    );
+    return false;
+  }
+
+  const programmaticDepleted = workspace.programmaticCreditState === "depleted";
+  await setFlag(
+    buildWorkspaceProgrammaticDepletedKey(workspaceId),
+    programmaticDepleted ? "1" : "0"
+  );
+  return programmaticDepleted;
 }
 
 // Workspace-pool-only read for API calls (no per-user cap).

--- a/front/lib/resources/storage/models/workspace.ts
+++ b/front/lib/resources/storage/models/workspace.ts
@@ -3,7 +3,10 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { BaseModel } from "@app/lib/resources/storage/wrappers/base";
 import { MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
 import type { EmbeddingProviderIdType } from "@app/types/assistant/models/types";
-import type { WorkspacePoolCreditState } from "@app/types/credits";
+import type {
+  WorkspacePoolCreditState,
+  WorkspaceProgrammaticCreditState,
+} from "@app/types/credits";
 import type {
   WorkspaceSegmentationType,
   WorkspaceSharingPolicy,
@@ -36,6 +39,7 @@ export class WorkspaceModel extends BaseModel<WorkspaceModel> {
   declare conversationsRetentionDays: number | null;
   declare metronomeCustomerId: string | null;
   declare poolCreditState: CreationOptional<WorkspacePoolCreditState>;
+  declare programmaticCreditState: CreationOptional<WorkspaceProgrammaticCreditState>;
 }
 WorkspaceModel.init(
   {
@@ -117,6 +121,11 @@ WorkspaceModel.init(
       defaultValue: DEFAULT_SHARING_POLICY,
     },
     poolCreditState: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "active",
+    },
+    programmaticCreditState: {
       type: DataTypes.STRING,
       allowNull: false,
       defaultValue: "active",

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -27,7 +27,10 @@ import logger from "@app/logger/logger";
 import { terminateAllAgentLoopWorkflowsForConversation } from "@app/temporal/agent_loop/terminate";
 import { MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
 import type { EmbeddingProviderIdType } from "@app/types/assistant/models/types";
-import type { WorkspacePoolCreditState } from "@app/types/credits";
+import type {
+  WorkspacePoolCreditState,
+  WorkspaceProgrammaticCreditState,
+} from "@app/types/credits";
 import { WORKSPACE_CACHE_KEY_VERSION } from "@app/types/shared/cache_resource_registry";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -76,6 +79,7 @@ type CachedWorkspaceData = {
   conversationsRetentionDays: number | null;
   metronomeCustomerId: string | null;
   poolCreditState: WorkspacePoolCreditState;
+  programmaticCreditState: WorkspaceProgrammaticCreditState;
   createdAt: number;
   updatedAt: number;
 };
@@ -207,6 +211,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
       conversationsRetentionDays: workspace.conversationsRetentionDays,
       metronomeCustomerId: workspace.metronomeCustomerId ?? null,
       poolCreditState: workspace.poolCreditState,
+      programmaticCreditState: workspace.programmaticCreditState,
       createdAt: workspace.createdAt.getTime(),
       updatedAt: workspace.updatedAt.getTime(),
     };
@@ -249,6 +254,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
       conversationsRetentionDays: data.conversationsRetentionDays,
       metronomeCustomerId: data.metronomeCustomerId ?? null,
       poolCreditState: data.poolCreditState,
+      programmaticCreditState: data.programmaticCreditState,
       createdAt: new Date(data.createdAt),
       updatedAt: new Date(data.updatedAt),
     };
@@ -489,6 +495,13 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     transaction?: Transaction
   ): Promise<void> {
     await this.update({ poolCreditState }, transaction);
+  }
+
+  async updateProgrammaticCreditState(
+    programmaticCreditState: WorkspaceProgrammaticCreditState,
+    transaction?: Transaction
+  ): Promise<void> {
+    await this.update({ programmaticCreditState }, transaction);
   }
 
   async updateWorkspaceSettings(

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -268,28 +268,23 @@ async function checkWorkspaceRateLimit({
   // Credit-priced pool gate: applies to any execution mode. If the pool is
   // depleted, no downstream message can be posted, so reject early instead of
   // spinning up the trigger workflow only to fail in `checkMessagesLimit`.
-  if (
-    plan &&
-    isCreditPricedPlan(plan) &&
-    owner.metronomeCustomerId &&
-    (await isApiBlocked(owner.sId))
-  ) {
-    errorMessage =
-      "Your workspace has run out of credits. Please purchase more credits to continue.";
-  }
+  if (plan && isCreditPricedPlan(plan)) {
+    if (owner.metronomeCustomerId && (await isApiBlocked(owner.sId))) {
+      errorMessage =
+        "Your workspace has run out of credits. Please purchase more credits to continue.";
+    }
 
-  // Programmatic monthly cap gate: if the programmatic cap is reached, reject
-  // early for programmatic triggers.
-  if (
-    !errorMessage &&
-    plan &&
-    isCreditPricedPlan(plan) &&
-    owner.metronomeCustomerId &&
-    trigger.executionMode === "programmatic" &&
-    (await isProgrammaticApiBlocked(owner.sId))
-  ) {
-    errorMessage =
-      "Your workspace has reached its programmatic monthly spending cap.";
+    // Programmatic monthly cap gate: if the programmatic cap is reached, reject
+    // early for programmatic triggers.
+    if (
+      !errorMessage &&
+      owner.metronomeCustomerId &&
+      trigger.executionMode === "programmatic" &&
+      (await isProgrammaticApiBlocked(owner.sId))
+    ) {
+      errorMessage =
+        "Your workspace has reached its programmatic monthly spending cap.";
+    }
   }
 
   /**

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -5,7 +5,10 @@ import type { DustError } from "@app/lib/error";
 import { getWebhookRequestsBucket } from "@app/lib/file_storage";
 import { isGCSPreconditionFailedError } from "@app/lib/file_storage/types";
 import { matchPayload, parseMatcherExpression } from "@app/lib/matcher";
-import { isApiBlocked } from "@app/lib/metronome/user_block";
+import {
+  isApiBlocked,
+  isProgrammaticApiBlocked,
+} from "@app/lib/metronome/user_block";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
 import type { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
@@ -273,6 +276,20 @@ async function checkWorkspaceRateLimit({
   ) {
     errorMessage =
       "Your workspace has run out of credits. Please purchase more credits to continue.";
+  }
+
+  // Programmatic monthly cap gate: if the programmatic cap is reached, reject
+  // early for programmatic triggers.
+  if (
+    !errorMessage &&
+    plan &&
+    isCreditPricedPlan(plan) &&
+    owner.metronomeCustomerId &&
+    trigger.executionMode === "programmatic" &&
+    (await isProgrammaticApiBlocked(owner.sId))
+  ) {
+    errorMessage =
+      "Your workspace has reached its programmatic monthly spending cap.";
   }
 
   /**

--- a/front/migrations/db/migration_660.sql
+++ b/front/migrations/db/migration_660.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jun 01, 2026
+ALTER TABLE "workspaces" ADD COLUMN "programmaticCreditState" VARCHAR(255) NOT NULL DEFAULT 'active';

--- a/front/migrations/pre-deploy/20260528154425_Add_programmatic_usage_state_column_in_workspaces.sql
+++ b/front/migrations/pre-deploy/20260528154425_Add_programmatic_usage_state_column_in_workspaces.sql
@@ -1,0 +1,4 @@
+/*
+Statement 0
+*/
+ALTER TABLE "public"."workspaces" ADD COLUMN "programmaticCreditState" character varying(255) COLLATE "pg_catalog"."default" DEFAULT 'active'::character varying NOT NULL;

--- a/front/migrations/pre-deploy/20260528154425_Add_programmatic_usage_state_column_in_workspaces.sql
+++ b/front/migrations/pre-deploy/20260528154425_Add_programmatic_usage_state_column_in_workspaces.sql
@@ -1,4 +1,0 @@
-/*
-Statement 0
-*/
-ALTER TABLE "public"."workspaces" ADD COLUMN "programmaticCreditState" character varying(255) COLLATE "pg_catalog"."default" DEFAULT 'active'::character varying NOT NULL;

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -25,7 +25,10 @@ import {
   normalizeConversationVisibility,
 } from "@app/lib/api/v1/backward_compatibility";
 import type { Authenticator } from "@app/lib/auth";
-import { isApiBlocked } from "@app/lib/metronome/user_block";
+import {
+  isApiBlocked,
+  isProgrammaticApiBlocked,
+} from "@app/lib/metronome/user_block";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -196,6 +199,19 @@ async function handler(
                   type: "rate_limit_error",
                   message:
                     "Your workspace has run out of credits. Please purchase more credits to continue.",
+                },
+              });
+            }
+            if (
+              workspace.metronomeCustomerId &&
+              (await isProgrammaticApiBlocked(workspace.sId))
+            ) {
+              return apiError(req, res, {
+                status_code: 429,
+                api_error: {
+                  type: "rate_limit_error",
+                  message:
+                    "Your workspace has reached its programmatic monthly spending cap.",
                 },
               });
             }

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -13,7 +13,10 @@ import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import { getRemainingDailyCapMicroUsd } from "@app/lib/api/programmatic_usage/daily_cap";
 import { checkProgrammaticUsageLimits } from "@app/lib/api/programmatic_usage/tracking";
 import { type Authenticator, hasFeatureFlag } from "@app/lib/auth";
-import { isApiBlocked } from "@app/lib/metronome/user_block";
+import {
+  isApiBlocked,
+  isProgrammaticApiBlocked,
+} from "@app/lib/metronome/user_block";
 import {
   AgentMessageModel,
   MessageModel,
@@ -582,13 +585,20 @@ export async function getReinforcementSettingsActivity({
     );
   const globalCapMicroUsd = getReinforcementMonthlyCapMicroUsd(workspace);
 
+  // Credit-priced plans check pool + programmatic cap via Metronome state;
+  // legacy plans check programmatic credits via CreditResource.
   const plan = auth.subscription()?.plan;
-  const programmaticUsageLimitReached =
-    !!plan && isCreditPricedPlan(plan) && !!workspace.metronomeCustomerId
-      ? // If the workspace pool is depleted, no downstream message can be posted.
-        await isApiBlocked(workspace.sId)
-      : // Legacy check
-        (await checkProgrammaticUsageLimits(auth)).isErr();
+  let programmaticUsageLimitReached: boolean;
+  if (plan && isCreditPricedPlan(plan) && workspace.metronomeCustomerId) {
+    programmaticUsageLimitReached =
+      (await isApiBlocked(workspace.sId)) ||
+      (await isProgrammaticApiBlocked(workspace.sId));
+  } else {
+    // Legacy check for not metronome workspaces
+    programmaticUsageLimitReached = (
+      await checkProgrammaticUsageLimits(auth)
+    ).isErr();
+  }
 
   // Compute remaining programmatic budget: total remaining credits capped by
   // the daily usage allowance.

--- a/front/types/credits.ts
+++ b/front/types/credits.ts
@@ -31,6 +31,35 @@ export function isWorkspacePoolCreditState(
   );
 }
 
+// Workspace-level programmatic credit state. Persisted on
+// `workspaces.programmaticCreditState`, driven by the programmatic credit
+// state machine in `front/lib/metronome/programmatic_credit_state_machine.ts`.
+//
+//   active:                  monthly cap has ample headroom
+//   active_low_balance:      ≤100 credits remaining before cap
+//   active_critical_balance: ≤10 credits remaining before cap
+//   depleted:                monthly cap reached; programmatic API calls blocked
+export const WORKSPACE_PROGRAMMATIC_CREDIT_STATES = [
+  "active",
+  "active_low_balance",
+  "active_critical_balance",
+  "depleted",
+] as const;
+
+export type WorkspaceProgrammaticCreditState =
+  (typeof WORKSPACE_PROGRAMMATIC_CREDIT_STATES)[number];
+
+export function isWorkspaceProgrammaticCreditState(
+  value: unknown
+): value is WorkspaceProgrammaticCreditState {
+  return (
+    typeof value === "string" &&
+    WORKSPACE_PROGRAMMATIC_CREDIT_STATES.includes(
+      value as WorkspaceProgrammaticCreditState
+    )
+  );
+}
+
 export const CREDIT_TYPES = ["free", "payg", "committed", "excess"] as const;
 
 export type CreditType = (typeof CREDIT_TYPES)[number];

--- a/front/types/shared/cache_resource_registry.ts
+++ b/front/types/shared/cache_resource_registry.ts
@@ -29,7 +29,7 @@ export function buildCacheKey(
   return `cacheWithRedis-${resource.fnName}-${resource.buildResolverKey(params)}`;
 }
 
-export const WORKSPACE_CACHE_KEY_VERSION = 1;
+export const WORKSPACE_CACHE_KEY_VERSION = 2;
 
 export const CACHE_RESOURCE_REGISTRY: CacheResourceDefinition[] = [
   {


### PR DESCRIPTION
## Description

Add new limits for programmatic usage
These limits can only be generated from a poke plugin for now
When these limit are reached (cap, cap - 10 credits, cap - 100 credits) we update the state of the programmatic usage for the workspace (store in DB and cached in redis)

This adds a migration to add the new column in the workspaces table and update the workspace cached version to 3

Migration generated with
```
npm run migration:generate:pre-deploy -- message
```

The state of the programmatic usage is currently used to stop programmatic usage when it is capped (normal conv, early in webhook and in reinforcement).

So far, we don't throttle when getting close to end of programmatic usage.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

lock front
merge
```
npm run migration:apply:pre-deploy
```
deploy
unlock front 
