### PR TITLE
Fix bug preventing webhook triggers from getting disabled

### DIFF
--- a/front/components/assistant/details/useTriggerSheetState.ts
+++ b/front/components/assistant/details/useTriggerSheetState.ts
@@ -213,6 +213,7 @@ export function useTriggerSheetState({
             webhookSourceViewId: triggerData.webhookSourceViewId ?? "",
             executionPerDayLimitOverride:
               triggerData.executionPerDayLimitOverride ?? 0,
+            status: triggerData.status,
           };
 
           if (triggerData.sId) {


### PR DESCRIPTION
## Description

  - When editing a webhook trigger from the agent details sheet, toggling the Enabled/Disabled switch had no effect because the PATCH payload was missing the status field.
  - The schedule trigger payload already included status, but the webhook payload omitted it (likely an oversight when the field was added). The server defaults missing status to "enabled", silently dropping the user's change.
  - Added status: triggerData.status to the webhook payload in useTriggerSheetState.ts, matching the schedule path.

Fixes https://github.com/dust-tt/tasks/issues/8390

## Tests

Verified before/after locally

## Risk

Low

## Deploy Plan

Front