### PR TITLE
fix: tolerate NaN timestamps in Clari call details response

### DIFF
--- a/front/lib/api/actions/servers/clari_copilot/types.ts
+++ b/front/lib/api/actions/servers/clari_copilot/types.ts
@@ -60,6 +60,13 @@ export type ClariCallsResponse = z.infer<typeof ClariCallsResponseSchema>;
 
 // call-details response
 
+// Clari sometimes returns "NaN" for timestamp fields on certain calls.
+// Coerce to number and treat NaN as absent rather than failing validation.
+const nanSafeTimestamp = z.preprocess((v) => {
+  const n = Number(v);
+  return isNaN(n) ? undefined : n;
+}, z.number().optional());
+
 const ClariTranscriptTurnSchema = z
   .object({
     text: z.string(),
@@ -72,8 +79,8 @@ const ClariTranscriptTurnSchema = z
 const ClariTopicSchema = z
   .object({
     name: z.string().optional(),
-    start_timestamp: z.coerce.number().optional(),
-    end_timestamp: z.coerce.number().optional(),
+    start_timestamp: nanSafeTimestamp,
+    end_timestamp: nanSafeTimestamp,
     summary: z.string().optional(),
   })
   .passthrough();
@@ -82,8 +89,8 @@ const ClariActionItemSchema = z
   .object({
     action_item: z.string().optional(),
     speaker_name: z.string().optional(),
-    start_timestamp: z.coerce.number().optional(),
-    end_timestamp: z.coerce.number().optional(),
+    start_timestamp: nanSafeTimestamp,
+    end_timestamp: nanSafeTimestamp,
   })
   .passthrough();
 


### PR DESCRIPTION
## Description

The Clari API occasionally returns `"NaN"` as a string value for `start_timestamp` and `end_timestamp` fields in topics and action items within the call-details response. The previous fix (PR #26252) used `z.coerce.number()`, which coerces `"NaN"` to the JavaScript `NaN` value rather than failing — but this still produces an invalid number that can cause downstream issues. This PR introduces a custom `nanSafeTimestamp` Zod preprocessor that explicitly converts the value to a number and, if the result is `NaN`, returns `undefined` instead, treating the field as absent.

## Tests

Local

## Risk


## Deploy Plan

Deploy front.