### PR TITLE
[front] Rename spend limit UI kind to default/override

### DIFF
--- a/front/components/workspace/EditSpendLimitModal.tsx
+++ b/front/components/workspace/EditSpendLimitModal.tsx
@@ -235,12 +235,12 @@ export function EditSpendLimitModal({
               <RadioGroupItem
                 value="default"
                 id="spend-limit-default"
-                label="Use default usage limit"
+                label="Use workspace default"
               />
               <RadioGroupItem
                 value="override"
                 id="spend-limit-override"
-                label="Set credit amount"
+                label="Use custom limit"
               />
 
               {kind === "override" && (

--- a/front/components/workspace/EditSpendLimitModal.tsx
+++ b/front/components/workspace/EditSpendLimitModal.tsx
@@ -27,10 +27,10 @@ import { useEffect, useRef, useState } from "react";
 const MIN_AWU_CREDITS = 1;
 const MAX_AWU_CREDITS = 1_000_000;
 
-type SpendLimitKind = "unlimited" | "limited";
+type SpendLimitKind = "default" | "override";
 
 function isSpendLimitKind(value: string): value is SpendLimitKind {
-  return value === "unlimited" || value === "limited";
+  return value === "default" || value === "override";
 }
 
 interface EditSpendLimitModalProps {
@@ -68,7 +68,7 @@ export function EditSpendLimitModal({
     workspaceId: owner.sId,
   });
 
-  const [kind, setKind] = useState<SpendLimitKind>("limited");
+  const [kind, setKind] = useState<SpendLimitKind>("override");
   const [creditsInput, setCreditsInput] = useState<string>("");
   const [isSaving, setIsSaving] = useState(false);
   const [validationMessage, setValidationMessage] = useState<string | null>(
@@ -86,11 +86,11 @@ export function EditSpendLimitModal({
     }
     switch (spendLimit.kind) {
       case "limited":
-        setKind("limited");
+        setKind("override");
         setCreditsInput(String(spendLimit.awuCredits));
         break;
       case "unlimited":
-        setKind("unlimited");
+        setKind("default");
         setCreditsInput("");
         break;
       default:
@@ -113,9 +113,9 @@ export function EditSpendLimitModal({
 
   function validate(): { ok: true; awuCredits: number } | { ok: false } {
     switch (kind) {
-      case "unlimited":
+      case "default":
         return { ok: true, awuCredits: 0 };
-      case "limited": {
+      case "override": {
         const parsed = Number(creditsInput);
         if (!Number.isInteger(parsed) || parsed < MIN_AWU_CREDITS) {
           setValidationMessage(
@@ -153,10 +153,10 @@ export function EditSpendLimitModal({
         | { kind: "unlimited" }
         | { kind: "limited"; awuCredits: number };
       switch (kind) {
-        case "unlimited":
+        case "default":
           limit = { kind: "unlimited" };
           break;
-        case "limited":
+        case "override":
           limit = { kind: "limited", awuCredits: result.awuCredits };
           break;
         default:
@@ -179,7 +179,7 @@ export function EditSpendLimitModal({
   const validateDisabled =
     isSaving ||
     isSpendLimitLoading ||
-    (kind === "limited" && creditsInput.length === 0);
+    (kind === "override" && creditsInput.length === 0);
   const primaryDisabled = isSpendLimitError
     ? isSaving || isSpendLimitLoading
     : validateDisabled;
@@ -233,17 +233,17 @@ export function EditSpendLimitModal({
               className="flex flex-col gap-3"
             >
               <RadioGroupItem
-                value="unlimited"
-                id="spend-limit-unlimited"
-                label="Unlimited spend"
+                value="default"
+                id="spend-limit-default"
+                label="Use default usage limit"
               />
               <RadioGroupItem
-                value="limited"
-                id="spend-limit-limited"
+                value="override"
+                id="spend-limit-override"
                 label="Set credit amount"
               />
 
-              {kind === "limited" && (
+              {kind === "override" && (
                 <div className="flex flex-col gap-1.5 pl-6">
                   <div className="relative">
                     <div className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground dark:text-muted-foreground-night">


### PR DESCRIPTION
## Description

Renames the EditSpendLimitModal radio options from unlimited/limited to default/override.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
