### PR TITLE
[front] mcp_actions: structuredContent in tool result

### DIFF
--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -1,12 +1,14 @@
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type {
   LightServerSideMCPToolConfigurationType,
+  MCPToolConfigurationType,
   ServerSideMCPServerConfigurationType,
   ToolNotificationEvent,
 } from "@app/lib/actions/mcp";
 import {
   getToolExtraFields,
   listToolsForServerSideMCPServer,
+  postProcessMCPToolResult,
   tryCallMCPTool,
 } from "@app/lib/actions/mcp_actions";
 import {
@@ -37,6 +39,7 @@ import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type { AgentMessageType } from "@app/types/assistant/conversation";
 import { Ok } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { assert, describe, expect, it, vi } from "vitest";
 
 // Mock Temporal activity context and heartbeat
@@ -733,5 +736,56 @@ describe("tryCallMCPTool", () => {
       withToolResultProcessingSpy,
       "withToolResultProcessing was not called — tool result path may not use wrappers"
     ).toHaveBeenCalled();
+  });
+});
+
+describe("postProcessMCPToolResult - structuredContent", () => {
+  // Minimal client-side tool config: only needs type + clientSideMcpServerId for the guards.
+  const clientConfig = {
+    type: "mcp_configuration",
+    clientSideMcpServerId: "client-server-id",
+  } as unknown as MCPToolConfigurationType;
+
+  type ToolCallResult = Awaited<ReturnType<Client["callTool"]>>;
+
+  it("appends structuredContent as a text item when content is empty", () => {
+    const result = postProcessMCPToolResult(
+      {
+        content: [],
+        structuredContent: { tables: [{ id: "tbl1", name: "Bugs" }] },
+      } as ToolCallResult,
+      clientConfig
+    );
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]).toEqual({
+      type: "text",
+      text: JSON.stringify({ tables: [{ id: "tbl1", name: "Bugs" }] }),
+    });
+  });
+
+  it("does not append structuredContent when content is non-empty", () => {
+    const result = postProcessMCPToolResult(
+      {
+        content: [{ type: "text", text: "existing result" }],
+        structuredContent: { tables: [] },
+      } as ToolCallResult,
+      clientConfig
+    );
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]).toEqual({
+      type: "text",
+      text: "existing result",
+    });
+  });
+
+  it("leaves content empty when structuredContent is absent", () => {
+    const result = postProcessMCPToolResult(
+      { content: [] } as ToolCallResult,
+      clientConfig
+    );
+
+    expect(result.content).toHaveLength(0);
   });
 });

--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -1,7 +1,7 @@
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type {
+  ClientSideMCPToolConfigurationType,
   LightServerSideMCPToolConfigurationType,
-  MCPToolConfigurationType,
   ServerSideMCPServerConfigurationType,
   ToolNotificationEvent,
 } from "@app/lib/actions/mcp";
@@ -740,11 +740,19 @@ describe("tryCallMCPTool", () => {
 });
 
 describe("postProcessMCPToolResult - structuredContent", () => {
-  // Minimal client-side tool config: only needs type + clientSideMcpServerId for the guards.
-  const clientConfig = {
+  const clientConfig: ClientSideMCPToolConfigurationType = {
+    id: -1,
+    sId: "test-sid",
     type: "mcp_configuration",
+    name: "test_tool",
+    description: null,
     clientSideMcpServerId: "client-server-id",
-  } as unknown as MCPToolConfigurationType;
+    inputSchema: { type: "object", properties: {} },
+    permission: "never_ask",
+    toolServerId: "client-server-id",
+    originalName: "test_tool",
+    mcpServerName: "test_server",
+  };
 
   type ToolCallResult = Awaited<ReturnType<Client["callTool"]>>;
 

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -744,14 +744,16 @@ export function postProcessMCPToolResult(
   toolConfiguration: MCPToolConfigurationType
 ): CallToolResult {
   // Type inference is not working here because of them using passthrough in the zod schema.
-  const content: CallToolResult["content"] = (toolCallResult.content ??
+  let content: CallToolResult["content"] = (toolCallResult.content ??
     []) as CallToolResult["content"];
 
   if (content.length === 0 && toolCallResult.structuredContent) {
-    content.push({
-      type: "text",
-      text: JSON.stringify(toolCallResult.structuredContent),
-    });
+    content = [
+      {
+        type: "text",
+        text: JSON.stringify(toolCallResult.structuredContent),
+      },
+    ];
   }
 
   let serverType;

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -739,13 +739,20 @@ async function connectServerSideMCP(
  * metadata. Shared between the Temporal agent-loop path and the sandbox REST
  * endpoint.
  */
-function postProcessMCPToolResult(
+export function postProcessMCPToolResult(
   toolCallResult: Awaited<ReturnType<Client["callTool"]>>,
   toolConfiguration: MCPToolConfigurationType
 ): CallToolResult {
   // Type inference is not working here because of them using passthrough in the zod schema.
   const content: CallToolResult["content"] = (toolCallResult.content ??
     []) as CallToolResult["content"];
+
+  if (content.length === 0 && toolCallResult.structuredContent) {
+    content.push({
+      type: "text",
+      text: JSON.stringify(toolCallResult.structuredContent),
+    });
+  }
 
   let serverType;
   if (isClientSideMCPToolConfiguration(toolConfiguration)) {


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8259

### Context

Some mcp tools might only return "structuredContent" field in their response (ex for Airtable tools, such as `list_tables_for_base` that returns `{"toolCallResult":{"content":[],"structuredContent":{"tables":[{"id":"tblnas6n9x5fibKig","name) .... }}}`, cause of the bug observed)

For info, from [MCP specs](https://modelcontextprotocol.io/specification/draft/server/tools#structured-content), it should not happen with properly implemented MCP
> For backwards compatibility, a tool that returns structured content SHOULD also return the serialized JSON in a TextContent block.

### Solution

Add the structuredContent to the content in the case where the returned content was empty but the structuredContent was not.


## Tests

* Tested locally with Airtable tool that has the issue => the agent retrieves the result from the structuredContent
* Added tests for structuredContent

## Risk

Medium as it impacts all the MCP tools but happens in very specific case (content empty but not structuredContent)

## Deploy Plan

Deploy front