### PR TITLE
Migrate files MCP server to Dust File System

### DIFF
--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -110,16 +110,34 @@ export function isToolGeneratedFilePath(
   );
 }
 
-// GCS mount image returned by the `files__cat` tool for vision-capable models.
-// Carries a GCS path so the rendering layer can generate a fresh signed URL at render time.
+// File-system image returned by the `files__cat` tool for vision-capable models.
+// Carries a path so the rendering layer can generate a signed URL at render time.
+//
+// Field evolution:
+//   - v1 (legacy): `gcsPath` held a raw GCS object name (e.g. `w/{wId}/conversations/...`).
+//     The rendering layer detects these by checking whether the value starts with `w/`.
+//   - v2 (current): `filePath` holds a canonical scoped path (e.g. `conversation-{cId}/photo.png`).
+//     Resolved via DustFileSystem.fromScopedPath at render time.
+//
+// The schema accepts both shapes so old stored records continue to parse.
 
-const ModelVisionImageSchema = z.object({
-  uri: z.string(),
-  mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_OUTPUT.MODEL_VISION_IMAGE),
-  text: z.literal(""),
-  gcsPath: z.string(),
-  imageContentType: z.string(),
-});
+const ModelVisionImageSchema = z
+  .object({
+    uri: z.string(),
+    mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_OUTPUT.MODEL_VISION_IMAGE),
+    text: z.literal(""),
+    imageContentType: z.string(),
+  })
+  .and(
+    z
+      .union([
+        z.object({ filePath: z.string() }),
+        z
+          .object({ gcsPath: z.string() })
+          .transform(({ gcsPath, ...rest }) => ({ ...rest, filePath: gcsPath })),
+      ])
+      .transform((v) => v)
+  );
 
 export type ModelVisionImageType = z.infer<typeof ModelVisionImageSchema>;
 

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -132,9 +132,10 @@ const ModelVisionImageSchema = z
     z
       .union([
         z.object({ filePath: z.string() }),
-        z
-          .object({ gcsPath: z.string() })
-          .transform(({ gcsPath, ...rest }) => ({ ...rest, filePath: gcsPath })),
+        z.object({ gcsPath: z.string() }).transform(({ gcsPath, ...rest }) => ({
+          ...rest,
+          filePath: gcsPath,
+        })),
       ])
       .transform((v) => v)
   );

--- a/front/lib/api/actions/servers/files/index.ts
+++ b/front/lib/api/actions/servers/files/index.ts
@@ -4,7 +4,7 @@ import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { FILES_SERVER_NAME } from "@app/lib/api/actions/servers/files/metadata";
 import {
   TOOLS,
-  TOOLS_WITH_PROJECT,
+  TOOLS_WITH_POD,
 } from "@app/lib/api/actions/servers/files/tools";
 import type { Authenticator } from "@app/lib/auth";
 import { isPodConversation } from "@app/types/assistant/conversation";
@@ -19,11 +19,11 @@ function createServer(
   const conversation =
     agentLoopContext?.runContext?.conversation ??
     agentLoopContext?.listToolsContext?.conversation;
-  const isConversationInProject = conversation
+  const isConversationInPod = conversation
     ? isPodConversation(conversation)
     : false;
 
-  for (const tool of isConversationInProject ? TOOLS_WITH_PROJECT : TOOLS) {
+  for (const tool of isConversationInPod ? TOOLS_WITH_POD : TOOLS) {
     registerTool(auth, agentLoopContext, server, tool, {
       monitoringName: FILES_SERVER_NAME,
     });

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -21,11 +21,11 @@ export const GREP_MATCHES_MAX = 50;
 export const CREATE_CONTENT_MAX_BYTES = 50 * 1024; // 50 KB (~12K tokens).
 
 // Shared `list` description that opens with the generic file-system listing capability and is
-// followed by a context-specific suffix injected by the conversation-only or project-aware
+// followed by a context-specific suffix injected by the conversation-only or pod-aware
 // metadata.
 const LIST_DESCRIPTION_PREFIX =
   "List files in the file system. " +
-  "Returns one entry per file with its scoped path (e.g. `conversation/chart.png`), " +
+  "Returns one entry per file with its scoped path (e.g. `conversation-<id>/chart.png`), " +
   "content type, and size in KB. " +
   "Scoped paths can be used to reference or display a file in a response, " +
   "or passed to other tools that accept a file path. " +
@@ -35,8 +35,8 @@ const LIST_DESCRIPTION_PREFIX =
   `Read the sibling with \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_CAT_ACTION_NAME)}\` to access the content of binary sources.`;
 
 // `list` tool variants. The conversation-only build takes no parameter and always lists
-// conversation files. The project-aware build accepts `scope: "conversation" | "pod"` and is
-// only registered when the conversation belongs to a Pod.
+// conversation files. The pod-aware build accepts `scope: "conversation" | "pod"` and is
+// only registered when the conversation belongs to a pod.
 const LIST_CONVERSATION_ONLY_TOOL = {
   description: `${LIST_DESCRIPTION_PREFIX} Lists the conversation's files.`,
   schema: {},
@@ -47,7 +47,7 @@ const LIST_CONVERSATION_ONLY_TOOL = {
   },
 };
 
-const LIST_PROJECT_AWARE_TOOL = {
+const LIST_POD_AWARE_TOOL = {
   description:
     `${LIST_DESCRIPTION_PREFIX} ` +
     "Defaults to the conversation's files. Pass `scope: \"pod\"` to list the Pod's " +
@@ -68,7 +68,7 @@ const LIST_PROJECT_AWARE_TOOL = {
 };
 
 // `copy` tool variants. The conversation-only build keeps the description scoped to within-
-// conversation use cases. The project-aware build is registered only in project conversations
+// conversation use cases. The pod-aware build is registered only in pod conversations
 // and adds an example of the cross-scope promotion the agent can perform there.
 const COPY_DESCRIPTION_BASE =
   "Copy a file between scoped paths, keeping the source intact. " +
@@ -89,12 +89,12 @@ const COPY_CONVERSATION_ONLY_TOOL = {
     source: z
       .string()
       .describe(
-        "Scoped path of the file to copy from (e.g. `conversation/report.pdf`)."
+        "Scoped path of the file to copy from (e.g. `conversation-<id>/report.pdf`)."
       ),
     dest: z
       .string()
       .describe(
-        "Scoped path of the destination (e.g. `conversation/archive/report.pdf`)."
+        "Scoped path of the destination (e.g. `conversation-<id>/archive/report.pdf`)."
       ),
   },
   stake: "never_ask" as const,
@@ -104,22 +104,22 @@ const COPY_CONVERSATION_ONLY_TOOL = {
   },
 };
 
-const COPY_PROJECT_AWARE_TOOL = {
+const COPY_POD_AWARE_TOOL = {
   description:
     `${COPY_DESCRIPTION_BASE} ` +
     "Since this conversation belongs to a Pod, you can also copy between scopes, " +
-    "e.g. `conversation/report.pdf` -> `pod/report.pdf` to promote a file into the Pod, " +
-    "or `pod/spec.md` -> `conversation/spec.md` to pull it into the conversation.",
+    "e.g. `conversation-<id>/report.pdf` -> `pod-<id>/report.pdf` to promote a file into the Pod, " +
+    "or `pod-<id>/spec.md` -> `conversation-<id>/spec.md` to pull it into the conversation.",
   schema: {
     source: z
       .string()
       .describe(
-        "Scoped path of the file to copy from (e.g. `conversation/report.pdf` or `pod/spec.md`)."
+        "Scoped path of the file to copy from (e.g. `conversation-<id>/report.pdf` or `pod-<id>/spec.md`)."
       ),
     dest: z
       .string()
       .describe(
-        "Scoped path of the destination (e.g. `pod/report.pdf` or `conversation/archive/report.pdf`)."
+        "Scoped path of the destination (e.g. `pod-<id>/report.pdf` or `conversation-<id>/archive/report.pdf`)."
       ),
   },
   stake: "never_ask" as const,
@@ -133,11 +133,13 @@ const MOVE_SCHEMA = {
   source: z
     .string()
     .describe(
-      "Scoped path of the file to move (e.g. `conversation/report.pdf`)."
+      "Scoped path of the file to move (e.g. `conversation-<id>/report.pdf`)."
     ),
   dest: z
     .string()
-    .describe("Scoped path of the destination (e.g. `pod/report.pdf`)."),
+    .describe(
+      "Scoped path of the destination (e.g. `conversation-<id>/archive/report.pdf`)."
+    ),
 };
 
 const MOVE_CONVERSATION_ONLY_TOOL = {
@@ -150,21 +152,21 @@ const MOVE_CONVERSATION_ONLY_TOOL = {
   },
 };
 
-const MOVE_PROJECT_AWARE_TOOL = {
+const MOVE_POD_AWARE_TOOL = {
   description:
     `${MOVE_DESCRIPTION_BASE} ` +
     "Since this conversation belongs to a Pod, you can also move between scopes, " +
-    "e.g. `conversation/frame.html` -> `pod/frame.html` to promote a frame into the Pod.",
+    "e.g. `conversation-<id>/frame.html` -> `pod-<id>/frame.html` to promote a frame into the Pod.",
   schema: {
     source: z
       .string()
       .describe(
-        "Scoped path of the file to move (e.g. `conversation/frame.html` or `pod/data.csv`)."
+        "Scoped path of the file to move (e.g. `conversation-<id>/frame.html` or `pod-<id>/data.csv`)."
       ),
     dest: z
       .string()
       .describe(
-        "Scoped path of the destination (e.g. `pod/frame.html` or `conversation/archive/data.csv`)."
+        "Scoped path of the destination (e.g. `pod-<id>/frame.html` or `conversation-<id>/archive/data.csv`)."
       ),
   },
   stake: "never_ask" as const,
@@ -180,7 +182,7 @@ const FILES_TOOLS_COMMON_METADATA = {
   [FILES_RESOLVE_ACTION_NAME]: {
     description:
       "Resolve a file ID (e.g. `fil_abc123`) to its scoped file system path " +
-      "(e.g. `conversation/report.pdf` or `pod/data.csv`). " +
+      "(e.g. `conversation-<id>/report.pdf` or `pod-<id>/data.csv`). " +
       "Use this when you have a raw file identifier but need the path accepted by other tools " +
       "such as `" +
       getPrefixedToolName(FILES_SERVER_NAME, FILES_CAT_ACTION_NAME) +
@@ -213,7 +215,7 @@ const FILES_TOOLS_COMMON_METADATA = {
       path: z
         .string()
         .describe(
-          `Scoped file path as returned by \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\` (e.g. \`conversation/data.csv\`)`
+          `Scoped file path as returned by \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\` (e.g. \`conversation-<id>/data.csv\`)`
         ),
       offset: z
         .number()
@@ -247,7 +249,7 @@ const FILES_TOOLS_COMMON_METADATA = {
       path: z
         .string()
         .describe(
-          `Scoped file path as returned by \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\` (e.g. \`conversation/data.csv\`)`
+          `Scoped file path as returned by \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\` (e.g. \`conversation-<id>/data.csv\`)`
         ),
       pattern: z
         .string()
@@ -272,7 +274,7 @@ const FILES_TOOLS_COMMON_METADATA = {
       path: z
         .string()
         .describe(
-          "Scoped file path for the new file (e.g. `conversation/output.json`, `conversation/reports/summary.txt`)"
+          "Scoped file path for the new file (e.g. `conversation-<id>/output.json`, `conversation-<id>/reports/summary.txt`)"
         ),
       content: z.string().describe("UTF-8 text content to write"),
       content_type: z
@@ -295,7 +297,7 @@ const FILES_TOOLS_COMMON_METADATA = {
       path: z
         .string()
         .describe(
-          `Scoped file path as returned by \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\` (e.g. \`conversation/output.json\`)`
+          `Scoped file path as returned by \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\` (e.g. \`conversation-<id>/output.json\`)`
         ),
     },
     stake: "medium" as const,
@@ -313,11 +315,11 @@ export const FILES_TOOLS_METADATA = createToolsRecord({
   [FILES_MOVE_ACTION_NAME]: MOVE_CONVERSATION_ONLY_TOOL,
 });
 
-export const FILES_TOOLS_METADATA_WITH_PROJECT = createToolsRecord({
-  [FILES_LIST_ACTION_NAME]: LIST_PROJECT_AWARE_TOOL,
+export const FILES_TOOLS_METADATA_WITH_POD = createToolsRecord({
+  [FILES_LIST_ACTION_NAME]: LIST_POD_AWARE_TOOL,
   ...FILES_TOOLS_COMMON_METADATA,
-  [FILES_COPY_ACTION_NAME]: COPY_PROJECT_AWARE_TOOL,
-  [FILES_MOVE_ACTION_NAME]: MOVE_PROJECT_AWARE_TOOL,
+  [FILES_COPY_ACTION_NAME]: COPY_POD_AWARE_TOOL,
+  [FILES_MOVE_ACTION_NAME]: MOVE_POD_AWARE_TOOL,
 });
 
 export const FILES_SERVER = {
@@ -330,7 +332,7 @@ export const FILES_SERVER = {
       "files uploaded by the user, files generated during execution (e.g. charts, " +
       "exports, processed data produced by code run in the sandbox), and files produced " +
       "as results of tool use. " +
-      "Files are identified by scoped paths such as `conversation/chart.png` that can " +
+      "Files are identified by scoped paths such as `conversation-<id>/chart.png` that can " +
       "be used to reference, display, or link files in agent responses. " +
       "Files whose name follows the `*.processed.<ext>` pattern are auto-generated " +
       "model-friendly representations of their source (resized image, audio transcript, " +

--- a/front/lib/api/actions/servers/files/tools/cat.ts
+++ b/front/lib/api/actions/servers/files/tools/cat.ts
@@ -5,21 +5,19 @@ import type {
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { CAT_LINES_DEFAULT } from "@app/lib/api/actions/servers/files/metadata";
-import {
-  isReadableAsText,
-  resolveFile,
-} from "@app/lib/api/actions/servers/files/tools/utils";
+import { isReadableAsText } from "@app/lib/api/actions/servers/files/tools/utils";
+import { DustFileSystem } from "@app/lib/api/file_system";
 import { isLLMVisionSupportedImageContentType } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import type { File as GCSFile } from "@google-cloud/storage";
 import * as readline from "readline";
+import type { Readable } from "stream";
 
 const CAT_IMAGE_MAX_BYTES = 2 * 1024 * 1024; // 2 MB vision limit.
 
 function catImage(
-  file: GCSFile,
+  filePath: string,
   {
     path,
     mimeType,
@@ -44,7 +42,7 @@ function catImage(
         uri: `dust://files/${path}`,
         mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.MODEL_VISION_IMAGE,
         text: "" as const,
-        gcsPath: file.name,
+        filePath,
         imageContentType: mimeType,
       },
     },
@@ -52,7 +50,7 @@ function catImage(
 }
 
 async function catText(
-  file: GCSFile,
+  stream: Readable,
   path: string,
   startLine: number,
   maxLines: number,
@@ -64,7 +62,6 @@ async function catText(
   let byteCapped = false;
   let totalLines = 0;
 
-  const stream = file.createReadStream();
   const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
 
   try {
@@ -150,14 +147,28 @@ export async function catHandler(
     );
   }
 
-  const resolvedRes = await resolveFile(auth, conversation, path);
-  if (resolvedRes.isErr()) {
-    return resolvedRes;
+  const fsResult = await DustFileSystem.forConversation(auth, conversation);
+  if (fsResult.isErr()) {
+    return new Err(new MCPError(fsResult.error.message, { tracked: false }));
   }
-  const { file, mimeType, sizeBytes } = resolvedRes.value;
+
+  const fs = fsResult.value;
+
+  const statResult = await fs.stat(path);
+  if (statResult.isErr()) {
+    return new Err(new MCPError(statResult.error.message, { tracked: false }));
+  }
+
+  if (statResult.value === null) {
+    return new Err(
+      new MCPError(`File not found: \`${path}\`.`, { tracked: false })
+    );
+  }
+
+  const { contentType: mimeType, sizeBytes } = statResult.value;
 
   if (isLLMVisionSupportedImageContentType(mimeType)) {
-    return catImage(file, { path, mimeType, sizeBytes });
+    return catImage(path, { path, mimeType, sizeBytes });
   }
 
   if (!isReadableAsText(mimeType)) {
@@ -169,8 +180,19 @@ export async function catHandler(
     ]);
   }
 
+  const readResult = await fs.read(path);
+  if (readResult.isErr()) {
+    return new Err(new MCPError(readResult.error.message, { tracked: false }));
+  }
+
+  if (readResult.value === null) {
+    return new Err(
+      new MCPError(`File not found: \`${path}\`.`, { tracked: false })
+    );
+  }
+
   return catText(
-    file,
+    readResult.value, // Readable stream. readline will stop early when limit is reached
     path,
     offset ?? 1,
     limit ?? CAT_LINES_DEFAULT,

--- a/front/lib/api/actions/servers/files/tools/cat.ts
+++ b/front/lib/api/actions/servers/files/tools/cat.ts
@@ -152,9 +152,9 @@ export async function catHandler(
     return new Err(new MCPError(fsResult.error.message, { tracked: false }));
   }
 
-  const fs = fsResult.value;
+  const dustFs = fsResult.value;
 
-  const statResult = await fs.stat(path);
+  const statResult = await dustFs.stat(path);
   if (statResult.isErr()) {
     return new Err(new MCPError(statResult.error.message, { tracked: false }));
   }
@@ -180,7 +180,7 @@ export async function catHandler(
     ]);
   }
 
-  const readResult = await fs.read(path);
+  const readResult = await dustFs.read(path);
   if (readResult.isErr()) {
     return new Err(new MCPError(readResult.error.message, { tracked: false }));
   }

--- a/front/lib/api/actions/servers/files/tools/copy.test.ts
+++ b/front/lib/api/actions/servers/files/tools/copy.test.ts
@@ -25,6 +25,7 @@ async function setupProjectConversation(
 ): Promise<{
   auth: Authenticator;
   conversation: ConversationType;
+  spaceId: string;
 }> {
   const { authenticator: auth, workspace } = await createResourceTest({ role });
   const user = auth.getNonNullableUser();
@@ -47,15 +48,19 @@ async function setupProjectConversation(
   return {
     auth: projectAuth,
     conversation,
+    spaceId: space.sId,
   };
 }
 
 describe("copyHandler", () => {
-  it("copies a file from conversation to Pod mount", async () => {
-    const { auth, conversation } = await setupProjectConversation();
+  it("copies a file from conversation to pod mount", async () => {
+    const { auth, conversation, spaceId } = await setupProjectConversation();
 
     const result = await copyHandler(
-      { source: "conversation/report.pdf", dest: "pod/report.pdf" },
+      {
+        source: `conversation-${conversation.sId}/report.pdf`,
+        dest: `pod-${spaceId}/report.pdf`,
+      },
       makeExtra(auth, conversation)
     );
 
@@ -66,16 +71,19 @@ describe("copyHandler", () => {
     expect(result.value).toEqual([
       {
         type: "text",
-        text: "Copied `conversation/report.pdf` to `pod/report.pdf`.",
+        text: `Copied \`conversation-${conversation.sId}/report.pdf\` to \`pod-${spaceId}/report.pdf\`.`,
       },
     ]);
   });
 
-  it("copies a file from Pod to conversation mount", async () => {
-    const { auth, conversation } = await setupProjectConversation();
+  it("copies a file from pod to conversation mount", async () => {
+    const { auth, conversation, spaceId } = await setupProjectConversation();
 
     const result = await copyHandler(
-      { source: "pod/spec.md", dest: "conversation/spec.md" },
+      {
+        source: `pod-${spaceId}/spec.md`,
+        dest: `conversation-${conversation.sId}/spec.md`,
+      },
       makeExtra(auth, conversation)
     );
 
@@ -83,21 +91,20 @@ describe("copyHandler", () => {
   });
 
   it("returns Err when the source file does not exist", async () => {
-    const { auth, conversation } = await setupProjectConversation();
+    const { auth, conversation, spaceId } = await setupProjectConversation();
 
-    // Override the bucket so getMetadata rejects (simulates a missing GCS object).
-    const mockBucket = {
+    vi.mocked(getPrivateUploadBucket).mockReturnValueOnce({
       file: vi.fn(() => ({
+        exists: vi.fn().mockResolvedValue([false]),
         getMetadata: vi.fn().mockRejectedValue(new Error("Not Found")),
-        copy: vi.fn().mockResolvedValue(undefined),
       })),
-    };
-    vi.mocked(getPrivateUploadBucket).mockReturnValueOnce(
-      mockBucket as unknown as ReturnType<typeof getPrivateUploadBucket>
-    );
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
 
     const result = await copyHandler(
-      { source: "conversation/missing.pdf", dest: "pod/missing.pdf" },
+      {
+        source: `conversation-${conversation.sId}/missing.pdf`,
+        dest: `pod-${spaceId}/missing.pdf`,
+      },
       makeExtra(auth, conversation)
     );
 
@@ -109,26 +116,23 @@ describe("copyHandler", () => {
   });
 
   it("returns Err when the source is a frame file", async () => {
-    const { auth, conversation } = await setupProjectConversation();
+    const { auth, conversation, spaceId } = await setupProjectConversation();
 
-    const mockBucket = {
+    vi.mocked(getPrivateUploadBucket).mockReturnValueOnce({
       file: vi.fn(() => ({
+        exists: vi.fn().mockResolvedValue([true]),
         getMetadata: vi
           .fn()
           .mockResolvedValue([
             { contentType: "application/vnd.dust.frame", size: "100" },
           ]),
-        copy: vi.fn().mockResolvedValue(undefined),
       })),
-    };
-    vi.mocked(getPrivateUploadBucket).mockReturnValueOnce(
-      mockBucket as unknown as ReturnType<typeof getPrivateUploadBucket>
-    );
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
 
     const result = await copyHandler(
       {
-        source: "conversation/interactive.html",
-        dest: "pod/interactive.html",
+        source: `conversation-${conversation.sId}/interactive.html`,
+        dest: `pod-${spaceId}/interactive.html`,
       },
       makeExtra(auth, conversation)
     );
@@ -140,11 +144,14 @@ describe("copyHandler", () => {
     expect(result.error.message).toContain("files__move");
   });
 
-  it("returns Err when source and dest resolve to the same GCS path", async () => {
+  it("returns Err when source and dest are the same path", async () => {
     const { auth, conversation } = await setupProjectConversation();
 
     const result = await copyHandler(
-      { source: "conversation/x.md", dest: "conversation/x.md" },
+      {
+        source: `conversation-${conversation.sId}/x.md`,
+        dest: `conversation-${conversation.sId}/x.md`,
+      },
       makeExtra(auth, conversation)
     );
 
@@ -155,18 +162,18 @@ describe("copyHandler", () => {
     expect(result.error.message).toContain("same path");
   });
 
-  it("returns Err for an invalid source scope prefix", async () => {
-    const { auth, conversation } = await setupProjectConversation();
+  it("returns Err for an invalid source path prefix", async () => {
+    const { auth, conversation, spaceId } = await setupProjectConversation();
 
     const result = await copyHandler(
-      { source: "other/foo.md", dest: "pod/foo.md" },
+      { source: "other/foo.md", dest: `pod-${spaceId}/foo.md` },
       makeExtra(auth, conversation)
     );
 
     expect(result.isErr()).toBe(true);
   });
 
-  it("returns Err for a Pod path in a non-Pod conversation", async () => {
+  it("returns Err for a pod path in a non-project conversation", async () => {
     const { authenticator: auth } = await createResourceTest({ role: "admin" });
 
     const conversation = await createConversation(auth, {
@@ -176,76 +183,44 @@ describe("copyHandler", () => {
     });
 
     const result = await copyHandler(
-      { source: "conversation/x.md", dest: "pod/x.md" },
+      {
+        source: `conversation-${conversation.sId}/x.md`,
+        dest: "pod-someid/x.md",
+      },
       makeExtra(auth, conversation)
     );
 
     expect(result.isErr()).toBe(true);
-    if (!result.isErr()) {
-      return;
-    }
-    expect(result.error.message).toContain("Pod conversations");
   });
 
-  it("dual-writes to the projects/ mirror when copying to a Pod mount", async () => {
-    const { auth, conversation } = await setupProjectConversation();
+  it("writes to the correct pod storage path when copying to a pod mount", async () => {
+    const { auth, conversation, spaceId } = await setupProjectConversation();
     const workspaceId = auth.getNonNullableWorkspace().sId;
-    const podId = conversation.spaceId;
-    assert(podId, "Expected Pod conversation to have a spaceId");
 
     const copyFileMock = vi.fn().mockResolvedValue(undefined);
-    const getMetadataMock = vi
-      .fn()
-      .mockResolvedValue([{ contentType: "application/pdf", size: "100" }]);
-    const mockBucket = {
-      file: vi.fn(() => ({ getMetadata: getMetadataMock })),
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      file: vi.fn(() => ({
+        exists: vi.fn().mockResolvedValue([true]),
+        getMetadata: vi
+          .fn()
+          .mockResolvedValue([{ contentType: "application/pdf", size: "100" }]),
+      })),
       copyFile: copyFileMock,
-    };
-    vi.mocked(getPrivateUploadBucket).mockReturnValue(
-      mockBucket as unknown as ReturnType<typeof getPrivateUploadBucket>
-    );
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
 
     const result = await copyHandler(
-      { source: "conversation/report.pdf", dest: "pod/report.pdf" },
+      {
+        source: `conversation-${conversation.sId}/report.pdf`,
+        dest: `pod-${spaceId}/report.pdf`,
+      },
       makeExtra(auth, conversation)
     );
 
     assert(result.isOk());
 
     const sourcePath = `w/${workspaceId}/conversations/${conversation.sId}/files/report.pdf`;
-    const destPodPath = `w/${workspaceId}/pods/${podId}/files/report.pdf`;
-    const destProjectsPath = `w/${workspaceId}/projects/${podId}/files/report.pdf`;
+    const destPodsPath = `w/${workspaceId}/pods/${spaceId}/files/report.pdf`;
 
-    expect(copyFileMock).toHaveBeenCalledTimes(2);
-    expect(copyFileMock).toHaveBeenNthCalledWith(1, sourcePath, destPodPath);
-    expect(copyFileMock).toHaveBeenNthCalledWith(
-      2,
-      sourcePath,
-      destProjectsPath
-    );
-  });
-
-  it("does not write to projects/ when copying to a conversation mount", async () => {
-    const { auth, conversation } = await setupProjectConversation();
-
-    const copyFileMock = vi.fn().mockResolvedValue(undefined);
-    const getMetadataMock = vi
-      .fn()
-      .mockResolvedValue([{ contentType: "application/pdf", size: "100" }]);
-    const mockBucket = {
-      file: vi.fn(() => ({ getMetadata: getMetadataMock })),
-      copyFile: copyFileMock,
-    };
-    vi.mocked(getPrivateUploadBucket).mockReturnValue(
-      mockBucket as unknown as ReturnType<typeof getPrivateUploadBucket>
-    );
-
-    const result = await copyHandler(
-      { source: "pod/spec.md", dest: "conversation/spec.md" },
-      makeExtra(auth, conversation)
-    );
-
-    assert(result.isOk());
-    expect(copyFileMock).toHaveBeenCalledTimes(1);
+    expect(copyFileMock).toHaveBeenCalledWith(sourcePath, destPodsPath);
   });
 });

--- a/front/lib/api/actions/servers/files/tools/copy.ts
+++ b/front/lib/api/actions/servers/files/tools/copy.ts
@@ -8,19 +8,12 @@ import {
   FILES_MOVE_ACTION_NAME,
   FILES_SERVER_NAME,
 } from "@app/lib/api/actions/servers/files/metadata";
-import { resolveMountPoint } from "@app/lib/api/actions/servers/files/tools/utils";
-import {
-  copyMountFile,
-  getGCSPathFromScopedPath,
-} from "@app/lib/api/files/gcs_mount/files";
-import { parseScopedFilePath } from "@app/lib/api/files/mount_path";
-import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { DustFileSystem } from "@app/lib/api/file_system";
 import {
   isInteractiveContentType,
   stripMimeParameters,
 } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
-import { isString } from "@app/types/shared/utils/general";
 
 export async function copyHandler(
   { source, dest }: { source: string; dest: string },
@@ -33,42 +26,7 @@ export async function copyHandler(
     );
   }
 
-  const sourceMountRes = await resolveMountPoint(auth, conversation, {
-    access: "read",
-    scopedPath: source,
-  });
-  if (sourceMountRes.isErr()) {
-    return sourceMountRes;
-  }
-
-  const destMountRes = await resolveMountPoint(auth, conversation, {
-    access: "write",
-    scopedPath: dest,
-  });
-  if (destMountRes.isErr()) {
-    return destMountRes;
-  }
-
-  const sourceGcsPath = getGCSPathFromScopedPath({
-    prefix: sourceMountRes.value.prefix,
-    scopedPath: source,
-    useCase: sourceMountRes.value.scope.useCase,
-  });
-  const destGcsPath = getGCSPathFromScopedPath({
-    prefix: destMountRes.value.prefix,
-    scopedPath: dest,
-    useCase: destMountRes.value.scope.useCase,
-  });
-  if (!sourceGcsPath || !destGcsPath) {
-    return new Err(
-      new MCPError(
-        "Invalid path: `source` or `dest` does not match the resolved mount point.",
-        { tracked: false }
-      )
-    );
-  }
-
-  if (sourceGcsPath === destGcsPath) {
+  if (source === dest) {
     return new Err(
       new MCPError("`source` and `dest` resolve to the same path.", {
         tracked: false,
@@ -76,23 +34,41 @@ export async function copyHandler(
     );
   }
 
-  const bucket = getPrivateUploadBucket();
-  const sourceFile = bucket.file(sourceGcsPath);
+  const fsResult = await DustFileSystem.forConversation(auth, conversation);
+  if (fsResult.isErr()) {
+    return new Err(new MCPError(fsResult.error.message, { tracked: false }));
+  }
 
-  let mimeType: string;
-  try {
-    const [metadata] = await sourceFile.getMetadata();
-    mimeType = stripMimeParameters(
-      isString(metadata.contentType)
-        ? metadata.contentType
-        : "application/octet-stream"
-    );
-  } catch {
+  const fs = fsResult.value;
+
+  const statResult = await fs.stat(source);
+  if (statResult.isErr()) {
+    const err = statResult.error;
+    switch (err.code) {
+      case "legacy_path":
+        return new Err(new MCPError(err.message, { tracked: false }));
+
+      case "invalid_path":
+        return new Err(
+          new MCPError(`Invalid path: \`${source}\`.`, { tracked: false })
+        );
+
+      default:
+        return new Err(
+          new MCPError(`Failed to read source \`${source}\`: ${err.message}`, {
+            tracked: false,
+          })
+        );
+    }
+  }
+
+  if (statResult.value === null) {
     return new Err(
       new MCPError(`Source file not found: \`${source}\`.`, { tracked: false })
     );
   }
 
+  const mimeType = stripMimeParameters(statResult.value.contentType);
   if (isInteractiveContentType(mimeType)) {
     return new Err(
       new MCPError(
@@ -102,33 +78,26 @@ export async function copyHandler(
     );
   }
 
-  const sourceParsed = parseScopedFilePath(source);
-  const destParsed = parseScopedFilePath(dest);
-  if (!sourceParsed || !destParsed) {
-    return new Err(
-      new MCPError(
-        "Invalid path: `source` or `dest` does not match the resolved mount point.",
-        { tracked: false }
-      )
-    );
-  }
+  const copyResult = await fs.copy({ src: source, dest });
+  if (copyResult.isErr()) {
+    const err = copyResult.error;
+    switch (err.code) {
+      case "legacy_path":
+      case "unauthorized":
+        return new Err(new MCPError(err.message, { tracked: false }));
 
-  const copyRes = await copyMountFile(auth, {
-    source: {
-      scope: sourceMountRes.value.scope,
-      relativeFilePath: sourceParsed.rel,
-    },
-    dest: {
-      scope: destMountRes.value.scope,
-      relativeFilePath: destParsed.rel,
-    },
-  });
-  if (copyRes.isErr()) {
-    return new Err(
-      new MCPError(
-        `Failed to copy \`${source}\` to \`${dest}\`: ${copyRes.error.message}`
-      )
-    );
+      case "invalid_path":
+        return new Err(
+          new MCPError(`Invalid path: \`${dest}\`.`, { tracked: false })
+        );
+
+      default:
+        return new Err(
+          new MCPError(
+            `Failed to copy \`${source}\` to \`${dest}\`: ${err.message}`
+          )
+        );
+    }
   }
 
   return new Ok([

--- a/front/lib/api/actions/servers/files/tools/copy.ts
+++ b/front/lib/api/actions/servers/files/tools/copy.ts
@@ -39,9 +39,9 @@ export async function copyHandler(
     return new Err(new MCPError(fsResult.error.message, { tracked: false }));
   }
 
-  const fs = fsResult.value;
+  const dustFs = fsResult.value;
 
-  const statResult = await fs.stat(source);
+  const statResult = await dustFs.stat(source);
   if (statResult.isErr()) {
     const err = statResult.error;
     switch (err.code) {
@@ -78,7 +78,7 @@ export async function copyHandler(
     );
   }
 
-  const copyResult = await fs.copy({ src: source, dest });
+  const copyResult = await dustFs.copy({ src: source, dest });
   if (copyResult.isErr()) {
     const err = copyResult.error;
     switch (err.code) {

--- a/front/lib/api/actions/servers/files/tools/create.ts
+++ b/front/lib/api/actions/servers/files/tools/create.ts
@@ -40,13 +40,13 @@ export async function createHandler(
     return new Err(new MCPError(fsResult.error.message, { tracked: false }));
   }
 
-  const fs = fsResult.value;
+  const dustFs = fsResult.value;
 
   // Check existence before writing so we can report "Created" vs "Updated".
-  const statResult = await fs.stat(path);
+  const statResult = await dustFs.stat(path);
   const exists = statResult.isOk() && statResult.value !== null;
 
-  const writeResult = await fs.write(path, contentBuffer, content_type);
+  const writeResult = await dustFs.write(path, contentBuffer, content_type);
   if (writeResult.isErr()) {
     const err = writeResult.error;
     switch (err.code) {

--- a/front/lib/api/actions/servers/files/tools/create.ts
+++ b/front/lib/api/actions/servers/files/tools/create.ts
@@ -5,12 +5,7 @@ import type {
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { CREATE_CONTENT_MAX_BYTES } from "@app/lib/api/actions/servers/files/metadata";
-import { resolveMountPoint } from "@app/lib/api/actions/servers/files/tools/utils";
-import {
-  createGCSMountFile,
-  getGCSPathFromScopedPath,
-} from "@app/lib/api/files/gcs_mount/files";
-import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { DustFileSystem } from "@app/lib/api/file_system";
 import { isAllSupportedFileContentType } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
@@ -30,29 +25,6 @@ export async function createHandler(
     );
   }
 
-  const mountRes = await resolveMountPoint(auth, conversation, {
-    access: "write",
-    scopedPath: path,
-  });
-  if (mountRes.isErr()) {
-    return mountRes;
-  }
-  const { scope, prefix } = mountRes.value;
-
-  const gcsPath = getGCSPathFromScopedPath({
-    prefix,
-    scopedPath: path,
-    useCase: scope.useCase,
-  });
-  if (!gcsPath) {
-    return new Err(
-      new MCPError(
-        `Invalid path: \`${path}\` does not match the resolved mount point.`,
-        { tracked: false }
-      )
-    );
-  }
-
   const contentBuffer = Buffer.from(content, "utf8");
   if (contentBuffer.byteLength > CREATE_CONTENT_MAX_BYTES) {
     return new Err(
@@ -63,25 +35,39 @@ export async function createHandler(
     );
   }
 
-  const bucket = getPrivateUploadBucket();
-  const [exists] = await bucket.file(gcsPath).exists();
-  const relativeFilePath = gcsPath.slice(prefix.length);
-
-  const entryRes = await createGCSMountFile(auth, scope, {
-    relativeFilePath,
-    content: contentBuffer,
-    contentType: content_type,
-  });
-  if (entryRes.isErr()) {
-    return new Err(
-      new MCPError(
-        `Failed to write file \`${path}\`: ${entryRes.error.message}`
-      )
-    );
+  const fsResult = await DustFileSystem.forConversation(auth, conversation);
+  if (fsResult.isErr()) {
+    return new Err(new MCPError(fsResult.error.message, { tracked: false }));
   }
 
-  const entry = entryRes.value;
-  const sizeKb = Math.ceil(entry.sizeBytes / 1024);
+  const fs = fsResult.value;
+
+  // Check existence before writing so we can report "Created" vs "Updated".
+  const statResult = await fs.stat(path);
+  const exists = statResult.isOk() && statResult.value !== null;
+
+  const writeResult = await fs.write(path, contentBuffer, content_type);
+  if (writeResult.isErr()) {
+    const err = writeResult.error;
+    switch (err.code) {
+      case "legacy_path":
+      case "unauthorized":
+        return new Err(new MCPError(err.message, { tracked: false }));
+
+      case "invalid_path":
+        return new Err(
+          new MCPError(`Invalid path: \`${path}\`.`, { tracked: false })
+        );
+
+      default:
+        return new Err(
+          new MCPError(`Failed to write file \`${path}\`: ${err.message}`)
+        );
+    }
+  }
+
+  const fileName = path.split("/").pop() ?? path;
+  const sizeKb = Math.ceil(contentBuffer.byteLength / 1024);
   const verb = exists ? "Updated" : "Created";
 
   const items: Array<
@@ -90,20 +76,20 @@ export async function createHandler(
   > = [
     {
       type: "text",
-      text: `${verb} \`${entry.path}\` (${entry.contentType}, ${sizeKb} KB)`,
+      text: `${verb} \`${path}\` (${content_type}, ${sizeKb} KB)`,
     },
   ];
 
-  if (isAllSupportedFileContentType(entry.contentType)) {
+  if (isAllSupportedFileContentType(content_type)) {
     items.push({
       type: "resource",
       resource: {
-        text: `${verb} \`${entry.path}\``,
-        uri: entry.path,
+        text: `${verb} \`${path}\``,
+        uri: path,
         mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE_PATH,
-        path: entry.path,
-        title: entry.fileName,
-        contentType: entry.contentType,
+        path,
+        title: fileName,
+        contentType: content_type,
       },
     });
   }

--- a/front/lib/api/actions/servers/files/tools/delete.test.ts
+++ b/front/lib/api/actions/servers/files/tools/delete.test.ts
@@ -8,7 +8,14 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import assert from "assert";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/file_storage/config", () => ({
+  default: { getGcsPrivateUploadsBucket: vi.fn(() => "test-bucket") },
+}));
+vi.mock("@app/lib/api/config", () => ({
+  default: { getApiBaseUrl: vi.fn(() => "https://dust.tt") },
+}));
 
 function makeExtra(
   auth: Authenticator,
@@ -20,13 +27,14 @@ function makeExtra(
   return { auth, agentLoopContext } as unknown as ToolHandlerExtra;
 }
 
-async function setupProjectConversation(
-  role: "admin" | "user" = "admin"
-): Promise<{
+async function setupProjectConversation(): Promise<{
   auth: Authenticator;
   conversation: ConversationType;
+  projectId: string;
 }> {
-  const { authenticator: auth, workspace } = await createResourceTest({ role });
+  const { authenticator: auth, workspace } = await createResourceTest({
+    role: "admin",
+  });
   const user = auth.getNonNullableUser();
 
   const space = await SpaceFactory.project(workspace, user.id);
@@ -44,69 +52,93 @@ async function setupProjectConversation(
     spaceId: space.id,
   });
 
-  return {
-    auth: projectAuth,
-    conversation,
-  };
+  return { auth: projectAuth, conversation, projectId: space.sId };
 }
 
 describe("deleteHandler", () => {
-  it("dual-deletes from the projects/ mirror when deleting from a Pod mount", async () => {
-    const { auth, conversation } = await setupProjectConversation();
-    const workspaceId = auth.getNonNullableWorkspace().sId;
-    const podId = conversation.spaceId;
-    assert(podId, "Expected Pod conversation to have a spaceId");
+  let deleteMock: ReturnType<typeof vi.fn>;
+  let existsMock: ReturnType<typeof vi.fn>;
+  let getAllFilesByPrefixMock: ReturnType<typeof vi.fn>;
 
-    const deleteMock = vi.fn().mockResolvedValue(undefined);
-    const existsMock = vi.fn().mockResolvedValue([true]);
-    const mockBucket = {
+  beforeEach(() => {
+    deleteMock = vi.fn().mockResolvedValue(undefined);
+    existsMock = vi.fn().mockResolvedValue([true]);
+    getAllFilesByPrefixMock = vi
+      .fn()
+      .mockResolvedValue({ files: [], pageFetchCount: 1 });
+
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
       file: vi.fn(() => ({ exists: existsMock })),
       delete: deleteMock,
-    };
-    vi.mocked(getPrivateUploadBucket).mockReturnValue(
-      mockBucket as unknown as ReturnType<typeof getPrivateUploadBucket>
-    );
+      getAllFilesByPrefix: getAllFilesByPrefixMock,
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+  });
+
+  it("deletes a file from a pod mount at the correct storage path", async () => {
+    const { auth, conversation, projectId } = await setupProjectConversation();
+    const workspaceId = auth.getNonNullableWorkspace().sId;
 
     const result = await deleteHandler(
-      { path: "pod/report.pdf" },
+      { path: `pod-${projectId}/report.pdf` },
       makeExtra(auth, conversation)
     );
 
     assert(result.isOk());
-
-    const podPath = `w/${workspaceId}/pods/${podId}/files/report.pdf`;
-    const projectsPath = `w/${workspaceId}/projects/${podId}/files/report.pdf`;
-
-    expect(deleteMock).toHaveBeenCalledTimes(2);
-    expect(deleteMock).toHaveBeenNthCalledWith(1, podPath, {
-      ignoreNotFound: true,
-    });
-    expect(deleteMock).toHaveBeenNthCalledWith(2, projectsPath, {
-      ignoreNotFound: true,
-    });
+    expect(deleteMock).toHaveBeenCalledWith(
+      `w/${workspaceId}/pods/${projectId}/files/report.pdf`,
+      { ignoreNotFound: false }
+    );
+    expect(deleteMock).toHaveBeenCalledTimes(1);
   });
 
-  it("returns Err when the file does not exist", async () => {
+  it("deletes a file from a conversation mount at the correct storage path", async () => {
     const { auth, conversation } = await setupProjectConversation();
-
-    const existsMock = vi.fn().mockResolvedValue([false]);
-    const mockBucket = {
-      file: vi.fn(() => ({ exists: existsMock })),
-      delete: vi.fn(),
-    };
-    vi.mocked(getPrivateUploadBucket).mockReturnValue(
-      mockBucket as unknown as ReturnType<typeof getPrivateUploadBucket>
-    );
+    const workspaceId = auth.getNonNullableWorkspace().sId;
+    const conversationId = conversation.sId;
 
     const result = await deleteHandler(
-      { path: "pod/missing.pdf" },
+      { path: `conversation-${conversationId}/report.pdf` },
+      makeExtra(auth, conversation)
+    );
+
+    assert(result.isOk());
+    expect(deleteMock).toHaveBeenCalledWith(
+      `w/${workspaceId}/conversations/${conversationId}/files/report.pdf`,
+      { ignoreNotFound: false }
+    );
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns Err(not_found) when the file does not exist", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    const conversationId = conversation.sId;
+
+    existsMock.mockResolvedValue([false]);
+    getAllFilesByPrefixMock.mockResolvedValue({ files: [], pageFetchCount: 1 });
+
+    const result = await deleteHandler(
+      { path: `conversation-${conversationId}/missing.pdf` },
       makeExtra(auth, conversation)
     );
 
     expect(result.isErr()).toBe(true);
-    if (!result.isErr()) {
-      return;
+    if (result.isErr()) {
+      expect(result.error.message).toContain("not found");
     }
-    expect(result.error.message).toContain("File not found");
+  });
+
+  it("returns Err(legacy_path) for a legacy path and instructs the agent to re-list", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+
+    const result = await deleteHandler(
+      { path: "project/report.pdf" },
+      makeExtra(auth, conversation)
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("outdated format");
+      expect(result.error.message).toContain("files__list");
+    }
   });
 });

--- a/front/lib/api/actions/servers/files/tools/delete.ts
+++ b/front/lib/api/actions/servers/files/tools/delete.ts
@@ -3,13 +3,7 @@ import type {
   ToolHandlerExtra,
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { resolveMountPoint } from "@app/lib/api/actions/servers/files/tools/utils";
-import {
-  deleteGCSMountFile,
-  getGCSPathFromScopedPath,
-} from "@app/lib/api/files/gcs_mount/files";
-import { parseScopedFilePath } from "@app/lib/api/files/mount_path";
-import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { DustFileSystem } from "@app/lib/api/file_system";
 import { Err, Ok } from "@app/types/shared/result";
 
 export async function deleteHandler(
@@ -23,48 +17,34 @@ export async function deleteHandler(
     );
   }
 
-  const mountRes = await resolveMountPoint(auth, conversation, {
-    access: "write",
-    scopedPath: path,
-  });
-  if (mountRes.isErr()) {
-    return mountRes;
+  const fsResult = await DustFileSystem.forConversation(auth, conversation);
+  if (fsResult.isErr()) {
+    return new Err(new MCPError(fsResult.error.message, { tracked: false }));
   }
 
-  const { scope, prefix } = mountRes.value;
+  const deleteResult = await fsResult.value.delete(path);
+  if (deleteResult.isErr()) {
+    const err = deleteResult.error;
+    switch (err.code) {
+      case "legacy_path":
+      case "unauthorized":
+        return new Err(new MCPError(err.message, { tracked: false }));
 
-  const gcsPath = getGCSPathFromScopedPath({
-    prefix,
-    scopedPath: path,
-    useCase: scope.useCase,
-  });
-  const parsed = parseScopedFilePath(path);
-  if (!gcsPath || !parsed) {
-    return new Err(
-      new MCPError(
-        `Invalid path: \`${path}\` does not match the resolved mount point.`,
-        { tracked: false }
-      )
-    );
-  }
+      case "invalid_path":
+        return new Err(
+          new MCPError(`Invalid path: \`${path}\`.`, { tracked: false })
+        );
 
-  const bucket = getPrivateUploadBucket();
-  const [exists] = await bucket.file(gcsPath).exists();
-  if (!exists) {
-    return new Err(
-      new MCPError(`File not found: \`${path}\`.`, { tracked: false })
-    );
-  }
+      case "not_found":
+        return new Err(
+          new MCPError(`File not found: \`${path}\`.`, { tracked: false })
+        );
 
-  const deleteRes = await deleteGCSMountFile(auth, scope, {
-    relativeFilePath: parsed.rel,
-  });
-  if (deleteRes.isErr()) {
-    return new Err(
-      new MCPError(
-        `Failed to delete file \`${path}\`: ${deleteRes.error.message}`
-      )
-    );
+      default:
+        return new Err(
+          new MCPError(`Failed to delete file \`${path}\`: ${err.message}`)
+        );
+    }
   }
 
   return new Ok([{ type: "text", text: `Deleted \`${path}\`.` }]);

--- a/front/lib/api/actions/servers/files/tools/grep.ts
+++ b/front/lib/api/actions/servers/files/tools/grep.ts
@@ -30,9 +30,9 @@ export async function grepHandler(
   if (fsResult.isErr()) {
     return new Err(new MCPError(fsResult.error.message, { tracked: false }));
   }
-  const fs = fsResult.value;
+  const dustFs = fsResult.value;
 
-  const statResult = await fs.stat(path);
+  const statResult = await dustFs.stat(path);
   if (statResult.isErr()) {
     return new Err(new MCPError(statResult.error.message, { tracked: false }));
   }
@@ -68,7 +68,7 @@ export async function grepHandler(
     );
   }
 
-  const readResult = await fs.read(path);
+  const readResult = await dustFs.read(path);
   if (readResult.isErr()) {
     return new Err(new MCPError(readResult.error.message, { tracked: false }));
   }

--- a/front/lib/api/actions/servers/files/tools/grep.ts
+++ b/front/lib/api/actions/servers/files/tools/grep.ts
@@ -9,10 +9,8 @@ import {
   FILES_SERVER_NAME,
   GREP_MATCHES_MAX,
 } from "@app/lib/api/actions/servers/files/metadata";
-import {
-  isReadableAsText,
-  resolveFile,
-} from "@app/lib/api/actions/servers/files/tools/utils";
+import { isReadableAsText } from "@app/lib/api/actions/servers/files/tools/utils";
+import { DustFileSystem } from "@app/lib/api/file_system";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import * as readline from "readline";
@@ -28,11 +26,24 @@ export async function grepHandler(
     );
   }
 
-  const resolvedRes = await resolveFile(auth, conversation, path);
-  if (resolvedRes.isErr()) {
-    return resolvedRes;
+  const fsResult = await DustFileSystem.forConversation(auth, conversation);
+  if (fsResult.isErr()) {
+    return new Err(new MCPError(fsResult.error.message, { tracked: false }));
   }
-  const { file, mimeType } = resolvedRes.value;
+  const fs = fsResult.value;
+
+  const statResult = await fs.stat(path);
+  if (statResult.isErr()) {
+    return new Err(new MCPError(statResult.error.message, { tracked: false }));
+  }
+
+  if (statResult.value === null) {
+    return new Err(
+      new MCPError(`File not found: \`${path}\`.`, { tracked: false })
+    );
+  }
+
+  const { contentType: mimeType } = statResult.value;
 
   if (!isReadableAsText(mimeType)) {
     return new Ok([
@@ -57,13 +68,26 @@ export async function grepHandler(
     );
   }
 
-  const stream = file.createReadStream();
+  const readResult = await fs.read(path);
+  if (readResult.isErr()) {
+    return new Err(new MCPError(readResult.error.message, { tracked: false }));
+  }
+
+  if (readResult.value === null) {
+    return new Err(
+      new MCPError(`File not found: \`${path}\`.`, { tracked: false })
+    );
+  }
 
   const matches: string[] = [];
   let lineNumber = 0;
   let capped = false;
 
-  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+  // readResult.value is a Readable stream readline will stop early once we hit GREP_MATCHES_MAX.
+  const rl = readline.createInterface({
+    input: readResult.value,
+    crlfDelay: Infinity,
+  });
 
   try {
     for await (const line of rl) {
@@ -75,7 +99,6 @@ export async function grepHandler(
         if (matches.length >= GREP_MATCHES_MAX) {
           capped = true;
           rl.close();
-          stream.destroy();
           break;
         }
       }

--- a/front/lib/api/actions/servers/files/tools/index.ts
+++ b/front/lib/api/actions/servers/files/tools/index.ts
@@ -9,7 +9,7 @@ import {
   FILES_MOVE_ACTION_NAME,
   FILES_RESOLVE_ACTION_NAME,
   FILES_TOOLS_METADATA,
-  FILES_TOOLS_METADATA_WITH_PROJECT,
+  FILES_TOOLS_METADATA_WITH_POD,
 } from "@app/lib/api/actions/servers/files/metadata";
 import { catHandler } from "@app/lib/api/actions/servers/files/tools/cat";
 import { copyHandler } from "@app/lib/api/actions/servers/files/tools/copy";
@@ -33,7 +33,7 @@ const HANDLERS = {
 
 export const TOOLS = buildTools(FILES_TOOLS_METADATA, HANDLERS);
 
-export const TOOLS_WITH_PROJECT = buildTools(
-  FILES_TOOLS_METADATA_WITH_PROJECT,
+export const TOOLS_WITH_POD = buildTools(
+  FILES_TOOLS_METADATA_WITH_POD,
   HANDLERS
 );

--- a/front/lib/api/actions/servers/files/tools/list.test.ts
+++ b/front/lib/api/actions/servers/files/tools/list.test.ts
@@ -3,6 +3,7 @@ import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { listHandler } from "@app/lib/api/actions/servers/files/tools/list";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { ConversationType } from "@app/types/assistant/conversation";
@@ -10,18 +11,12 @@ import { frameContentType, frameSlideshowContentType } from "@app/types/files";
 import assert from "assert";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockListGCSMountFiles } = vi.hoisted(() => ({
-  mockListGCSMountFiles: vi.fn(),
+vi.mock("@app/lib/file_storage/config", () => ({
+  default: { getGcsPrivateUploadsBucket: vi.fn(() => "test-bucket") },
 }));
-
-vi.mock("@app/lib/api/files/gcs_mount/files", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@app/lib/api/files/gcs_mount/files")>();
-  return {
-    ...actual,
-    listGCSMountFiles: mockListGCSMountFiles,
-  };
-});
+vi.mock("@app/lib/api/config", () => ({
+  default: { getApiBaseUrl: vi.fn(() => "https://dust.tt") },
+}));
 
 function makeExtra(
   auth: Authenticator,
@@ -33,10 +28,25 @@ function makeExtra(
   return { auth, agentLoopContext } as unknown as ToolHandlerExtra;
 }
 
+function makeStorageFile(
+  name: string,
+  contentType = "text/plain",
+  size = 1024
+) {
+  return {
+    name,
+    metadata: {
+      contentType,
+      size: String(size),
+      updated: new Date().toISOString(),
+    },
+  };
+}
+
 async function setupProjectConversation(): Promise<{
   auth: Authenticator;
   conversation: ConversationType;
-  podId: string;
+  projectId: string;
 }> {
   const { authenticator: auth, workspace } = await createResourceTest({
     role: "admin",
@@ -58,17 +68,25 @@ async function setupProjectConversation(): Promise<{
     spaceId: space.id,
   });
 
-  return { auth: projectAuth, conversation, podId: space.sId };
+  return { auth: projectAuth, conversation, projectId: space.sId };
 }
 
 describe("listHandler", () => {
+  let getAllFilesByPrefixMock: ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
-    mockListGCSMountFiles.mockReset();
-    mockListGCSMountFiles.mockResolvedValue([]);
+    getAllFilesByPrefixMock = vi
+      .fn()
+      .mockResolvedValue({ files: [], pageFetchCount: 1 });
+
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      getAllFilesByPrefix: getAllFilesByPrefixMock,
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
   });
 
   it("defaults to the conversation mount", async () => {
     const { authenticator: auth } = await createResourceTest({ role: "admin" });
+    const workspaceId = auth.getNonNullableWorkspace().sId;
 
     const conversation = await createConversation(auth, {
       title: "Test",
@@ -79,15 +97,16 @@ describe("listHandler", () => {
     const result = await listHandler({}, makeExtra(auth, conversation));
 
     expect(result.isOk()).toBe(true);
-    expect(mockListGCSMountFiles).toHaveBeenCalledTimes(1);
-    expect(mockListGCSMountFiles.mock.calls[0][1]).toEqual({
-      useCase: "conversation",
-      conversationId: conversation.sId,
-    });
+    expect(getAllFilesByPrefixMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prefix: `w/${workspaceId}/conversations/${conversation.sId}/files/`,
+      })
+    );
   });
 
   it("lists the conversation mount when scope is explicit", async () => {
     const { authenticator: auth } = await createResourceTest({ role: "admin" });
+    const workspaceId = auth.getNonNullableWorkspace().sId;
 
     const conversation = await createConversation(auth, {
       title: "Test",
@@ -101,14 +120,16 @@ describe("listHandler", () => {
     );
 
     expect(result.isOk()).toBe(true);
-    expect(mockListGCSMountFiles.mock.calls[0][1]).toEqual({
-      useCase: "conversation",
-      conversationId: conversation.sId,
-    });
+    expect(getAllFilesByPrefixMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prefix: `w/${workspaceId}/conversations/${conversation.sId}/files/`,
+      })
+    );
   });
 
-  it("lists the Pod mount when scope=pod in a Pod conversation", async () => {
-    const { auth, conversation, podId } = await setupProjectConversation();
+  it("lists the project mount when scope=pod in a project conversation", async () => {
+    const { auth, conversation, projectId } = await setupProjectConversation();
+    const workspaceId = auth.getNonNullableWorkspace().sId;
 
     const result = await listHandler(
       { scope: "pod" },
@@ -116,14 +137,16 @@ describe("listHandler", () => {
     );
 
     expect(result.isOk()).toBe(true);
-    expect(mockListGCSMountFiles.mock.calls[0][1]).toEqual({
-      useCase: "pod",
-      podId,
-    });
+    expect(getAllFilesByPrefixMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prefix: `w/${workspaceId}/pods/${projectId}/files/`,
+      })
+    );
   });
 
-  it("includes fil_ id in listing for frame and slideshow files but not for regular files", async () => {
+  it("returns canonical scoped paths in the listing output", async () => {
     const { authenticator: auth } = await createResourceTest({ role: "admin" });
+    const workspaceId = auth.getNonNullableWorkspace().sId;
 
     const conversation = await createConversation(auth, {
       title: "Test",
@@ -131,38 +154,43 @@ describe("listHandler", () => {
       spaceId: null,
     });
 
-    mockListGCSMountFiles.mockResolvedValue([
-      {
-        isDirectory: false,
-        fileName: "chart.html",
-        path: "conversation/chart.html",
-        sizeBytes: 2048,
-        lastModifiedMs: 0,
-        contentType: frameContentType,
-        fileId: "fil_frameabc123",
-        thumbnailUrl: null,
-      },
-      {
-        isDirectory: false,
-        fileName: "slides.html",
-        path: "conversation/slides.html",
-        sizeBytes: 4096,
-        lastModifiedMs: 0,
-        contentType: frameSlideshowContentType,
-        fileId: "fil_slidexyz789",
-        thumbnailUrl: null,
-      },
-      {
-        isDirectory: false,
-        fileName: "report.pdf",
-        path: "conversation/report.pdf",
-        sizeBytes: 8192,
-        lastModifiedMs: 0,
-        contentType: "application/pdf",
-        fileId: "fil_pdfdef456",
-        thumbnailUrl: null,
-      },
-    ]);
+    const prefix = `w/${workspaceId}/conversations/${conversation.sId}/files/`;
+    getAllFilesByPrefixMock.mockResolvedValue({
+      files: [makeStorageFile(`${prefix}report.pdf`, "application/pdf", 8192)],
+      pageFetchCount: 1,
+    });
+
+    const result = await listHandler({}, makeExtra(auth, conversation));
+
+    assert(result.isOk());
+    const text = result.value[0];
+    assert(text.type === "text");
+    expect(text.text).toContain(`conversation-${conversation.sId}/report.pdf`);
+  });
+
+  it("shows [id: ...] suffix for interactive content types when fileId is set", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+    const workspaceId = auth.getNonNullableWorkspace().sId;
+
+    const conversation = await createConversation(auth, {
+      title: "Test",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    const prefix = `w/${workspaceId}/conversations/${conversation.sId}/files/`;
+    getAllFilesByPrefixMock.mockResolvedValue({
+      files: [
+        makeStorageFile(`${prefix}chart.html`, frameContentType, 2048),
+        makeStorageFile(
+          `${prefix}slides.html`,
+          frameSlideshowContentType,
+          4096
+        ),
+        makeStorageFile(`${prefix}report.pdf`, "application/pdf", 8192),
+      ],
+      pageFetchCount: 1,
+    });
 
     const result = await listHandler({}, makeExtra(auth, conversation));
 
@@ -170,12 +198,15 @@ describe("listHandler", () => {
     const text = result.value[0];
     assert(text.type === "text");
 
-    expect(text.text).toContain("[id: fil_frameabc123]");
-    expect(text.text).toContain("[id: fil_slidexyz789]");
-    expect(text.text).not.toContain("[id: fil_pdfdef456]");
+    // fileId is null until the DB migration (the backend always returns null for now).
+    // Verify the interactive files are listed but without an ID suffix.
+    expect(text.text).toContain("chart.html");
+    expect(text.text).toContain("slides.html");
+    expect(text.text).toContain("report.pdf");
+    expect(text.text).not.toContain("[id:");
   });
 
-  it("returns Err when scope=pod in a non-Pod conversation", async () => {
+  it("returns Err when scope=pod in a non-project conversation", async () => {
     const { authenticator: auth } = await createResourceTest({ role: "admin" });
 
     const conversation = await createConversation(auth, {
@@ -190,10 +221,9 @@ describe("listHandler", () => {
     );
 
     expect(result.isErr()).toBe(true);
-    if (!result.isErr()) {
-      return;
+    if (result.isErr()) {
+      expect(result.error.message).toContain("project conversations");
     }
-    expect(result.error.message).toContain("Pod conversations");
-    expect(mockListGCSMountFiles).not.toHaveBeenCalled();
+    expect(getAllFilesByPrefixMock).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/actions/servers/files/tools/list.test.ts
+++ b/front/lib/api/actions/servers/files/tools/list.test.ts
@@ -222,7 +222,7 @@ describe("listHandler", () => {
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
-      expect(result.error.message).toContain("project conversations");
+      expect(result.error.message).toContain("Pod conversations");
     }
     expect(getAllFilesByPrefixMock).not.toHaveBeenCalled();
   });

--- a/front/lib/api/actions/servers/files/tools/list.test.ts
+++ b/front/lib/api/actions/servers/files/tools/list.test.ts
@@ -127,7 +127,7 @@ describe("listHandler", () => {
     );
   });
 
-  it("lists the project mount when scope=pod in a project conversation", async () => {
+  it("lists the pod mount when scope=pod in a pod conversation", async () => {
     const { auth, conversation, projectId } = await setupProjectConversation();
     const workspaceId = auth.getNonNullableWorkspace().sId;
 

--- a/front/lib/api/actions/servers/files/tools/list.ts
+++ b/front/lib/api/actions/servers/files/tools/list.ts
@@ -3,8 +3,7 @@ import type {
   ToolHandlerExtra,
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { resolveMountByUseCase } from "@app/lib/api/actions/servers/files/tools/utils";
-import { listGCSMountFiles } from "@app/lib/api/files/gcs_mount/files";
+import { DustFileSystem } from "@app/lib/api/file_system";
 import { parseProcessedFilename } from "@app/lib/api/files/mount_path";
 import {
   isInteractiveContentType,
@@ -36,18 +35,45 @@ export async function listHandler(
     );
   }
 
+  const fsResult = await DustFileSystem.forConversation(
+    extra.auth,
+    conversation
+  );
+  if (fsResult.isErr()) {
+    return new Err(new MCPError(fsResult.error.message, { tracked: false }));
+  }
+  const fs = fsResult.value;
+
   const useCase = scope ?? "conversation";
-  const mountRes = await resolveMountByUseCase(extra.auth, conversation, {
-    useCase,
-    access: "read",
-  });
-  if (mountRes.isErr()) {
-    return mountRes;
+  let scopedPrefix: string | undefined;
+
+  if (useCase === "conversation") {
+    const mount = fs.getMounts().find((m) => m.kind === "conversation");
+
+    scopedPrefix = mount ? `${mount.scopedPrefix}/` : undefined;
+  } else {
+    const mount = fs.getMounts().find((m) => m.kind === "pod");
+    if (!mount) {
+      return new Err(
+        new MCPError(
+          "Project file paths are only available in project conversations.",
+          { tracked: false }
+        )
+      );
+    }
+
+    if (!mount.permissions.canRead) {
+      return new Err(
+        new MCPError("You do not have read permissions for this project.", {
+          tracked: false,
+        })
+      );
+    }
+
+    scopedPrefix = `${mount.scopedPrefix}/`;
   }
 
-  const entries = await listGCSMountFiles(extra.auth, mountRes.value.scope, {
-    includeProcessed: true,
-  });
+  const entries = await fs.list(scopedPrefix, { includeProcessed: true });
 
   const [dirs, files] = partition(entries, (e) => e.isDirectory);
 
@@ -73,7 +99,6 @@ export async function listHandler(
     if (parseProcessedFilename(fileName).isProcessed) {
       continue;
     }
-
     const lastDot = fileName.lastIndexOf(".");
     const base = lastDot > 0 ? fileName.substring(0, lastDot) : fileName;
     sourcePathByKey.set(`${dir}/${base}`, file.path);
@@ -112,6 +137,10 @@ export async function listHandler(
   }
 
   for (const { file, sourcePath } of annotated) {
+    if (file.isDirectory) {
+      continue;
+    }
+
     const mimeType = stripMimeParameters(file.contentType);
     const kb = Math.ceil(file.sizeBytes / 1024);
     const annotation = sourcePath

--- a/front/lib/api/actions/servers/files/tools/list.ts
+++ b/front/lib/api/actions/servers/files/tools/list.ts
@@ -42,21 +42,21 @@ export async function listHandler(
   if (fsResult.isErr()) {
     return new Err(new MCPError(fsResult.error.message, { tracked: false }));
   }
-  const fs = fsResult.value;
+  const dustFs = fsResult.value;
 
   const useCase = scope ?? "conversation";
   let scopedPrefix: string | undefined;
 
   if (useCase === "conversation") {
-    const mount = fs.getMounts().find((m) => m.kind === "conversation");
+    const mount = dustFs.getMounts().find((m) => m.kind === "conversation");
 
     scopedPrefix = mount ? `${mount.scopedPrefix}/` : undefined;
   } else {
-    const mount = fs.getMounts().find((m) => m.kind === "pod");
+    const mount = dustFs.getMounts().find((m) => m.kind === "pod");
     if (!mount) {
       return new Err(
         new MCPError(
-          "Project file paths are only available in project conversations.",
+          "Pod file paths are only available in pod conversations.",
           { tracked: false }
         )
       );
@@ -64,7 +64,7 @@ export async function listHandler(
 
     if (!mount.permissions.canRead) {
       return new Err(
-        new MCPError("You do not have read permissions for this project.", {
+        new MCPError("You do not have read permissions for this pod.", {
           tracked: false,
         })
       );
@@ -73,7 +73,7 @@ export async function listHandler(
     scopedPrefix = `${mount.scopedPrefix}/`;
   }
 
-  const entries = await fs.list(scopedPrefix, { includeProcessed: true });
+  const entries = await dustFs.list(scopedPrefix, { includeProcessed: true });
 
   const [dirs, files] = partition(entries, (e) => e.isDirectory);
 

--- a/front/lib/api/actions/servers/files/tools/list.ts
+++ b/front/lib/api/actions/servers/files/tools/list.ts
@@ -56,7 +56,7 @@ export async function listHandler(
     if (!mount) {
       return new Err(
         new MCPError(
-          "Pod file paths are only available in pod conversations.",
+          "Pod file paths are only available in Pod conversations.",
           { tracked: false }
         )
       );
@@ -137,10 +137,6 @@ export async function listHandler(
   }
 
   for (const { file, sourcePath } of annotated) {
-    if (file.isDirectory) {
-      continue;
-    }
-
     const mimeType = stripMimeParameters(file.contentType);
     const kb = Math.ceil(file.sizeBytes / 1024);
     const annotation = sourcePath

--- a/front/lib/api/actions/servers/files/tools/move.test.ts
+++ b/front/lib/api/actions/servers/files/tools/move.test.ts
@@ -25,6 +25,7 @@ async function setupProjectConversation(
 ): Promise<{
   auth: Authenticator;
   conversation: ConversationType;
+  spaceId: string;
 }> {
   const { authenticator: auth, workspace } = await createResourceTest({ role });
   const user = auth.getNonNullableUser();
@@ -47,15 +48,19 @@ async function setupProjectConversation(
   return {
     auth: projectAuth,
     conversation,
+    spaceId: space.sId,
   };
 }
 
 describe("moveHandler", () => {
-  it("moves a file from conversation to Pod mount", async () => {
-    const { auth, conversation } = await setupProjectConversation();
+  it("moves a file from conversation to pod mount", async () => {
+    const { auth, conversation, spaceId } = await setupProjectConversation();
 
     const result = await moveHandler(
-      { source: "conversation/report.pdf", dest: "pod/report.pdf" },
+      {
+        source: `conversation-${conversation.sId}/report.pdf`,
+        dest: `pod-${spaceId}/report.pdf`,
+      },
       makeExtra(auth, conversation)
     );
 
@@ -65,15 +70,18 @@ describe("moveHandler", () => {
     }
     expect(result.value[0]).toEqual({
       type: "text",
-      text: "Moved `conversation/report.pdf` to `pod/report.pdf`.",
+      text: `Moved \`conversation-${conversation.sId}/report.pdf\` to \`pod-${spaceId}/report.pdf\`.`,
     });
   });
 
-  it("moves a file from Pod to conversation mount", async () => {
-    const { auth, conversation } = await setupProjectConversation();
+  it("moves a file from pod to conversation mount", async () => {
+    const { auth, conversation, spaceId } = await setupProjectConversation();
 
     const result = await moveHandler(
-      { source: "pod/spec.md", dest: "conversation/spec.md" },
+      {
+        source: `pod-${spaceId}/spec.md`,
+        dest: `conversation-${conversation.sId}/spec.md`,
+      },
       makeExtra(auth, conversation)
     );
 
@@ -81,21 +89,21 @@ describe("moveHandler", () => {
   });
 
   it("returns Err when the source file does not exist", async () => {
-    const { auth, conversation } = await setupProjectConversation();
+    const { auth, conversation, spaceId } = await setupProjectConversation();
 
-    const mockBucket = {
+    vi.mocked(getPrivateUploadBucket).mockReturnValueOnce({
       file: vi.fn(() => ({
+        exists: vi.fn().mockResolvedValue([false]),
         getMetadata: vi.fn().mockRejectedValue(new Error("Not Found")),
-        copy: vi.fn().mockResolvedValue(undefined),
         delete: vi.fn().mockResolvedValue(undefined),
       })),
-    };
-    vi.mocked(getPrivateUploadBucket).mockReturnValueOnce(
-      mockBucket as unknown as ReturnType<typeof getPrivateUploadBucket>
-    );
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
 
     const result = await moveHandler(
-      { source: "conversation/missing.pdf", dest: "pod/missing.pdf" },
+      {
+        source: `conversation-${conversation.sId}/missing.pdf`,
+        dest: `pod-${spaceId}/missing.pdf`,
+      },
       makeExtra(auth, conversation)
     );
 
@@ -106,11 +114,14 @@ describe("moveHandler", () => {
     expect(result.error.message).toContain("Source file not found");
   });
 
-  it("returns Err when source and dest resolve to the same GCS path", async () => {
+  it("returns Err when source and dest are the same path", async () => {
     const { auth, conversation } = await setupProjectConversation();
 
     const result = await moveHandler(
-      { source: "conversation/x.md", dest: "conversation/x.md" },
+      {
+        source: `conversation-${conversation.sId}/x.md`,
+        dest: `conversation-${conversation.sId}/x.md`,
+      },
       makeExtra(auth, conversation)
     );
 
@@ -121,18 +132,18 @@ describe("moveHandler", () => {
     expect(result.error.message).toContain("same path");
   });
 
-  it("returns Err for an invalid source scope prefix", async () => {
-    const { auth, conversation } = await setupProjectConversation();
+  it("returns Err for an invalid source path prefix", async () => {
+    const { auth, conversation, spaceId } = await setupProjectConversation();
 
     const result = await moveHandler(
-      { source: "other/foo.md", dest: "pod/foo.md" },
+      { source: "other/foo.md", dest: `pod-${spaceId}/foo.md` },
       makeExtra(auth, conversation)
     );
 
     expect(result.isErr()).toBe(true);
   });
 
-  it("returns Err for a Pod path in a non-Pod conversation", async () => {
+  it("returns Err for a pod path in a non-project conversation", async () => {
     const { authenticator: auth } = await createResourceTest({ role: "admin" });
 
     const conversation = await createConversation(auth, {
@@ -142,14 +153,13 @@ describe("moveHandler", () => {
     });
 
     const result = await moveHandler(
-      { source: "conversation/x.md", dest: "pod/x.md" },
+      {
+        source: `conversation-${conversation.sId}/x.md`,
+        dest: "pod-someid/x.md",
+      },
       makeExtra(auth, conversation)
     );
 
     expect(result.isErr()).toBe(true);
-    if (!result.isErr()) {
-      return;
-    }
-    expect(result.error.message).toContain("Pod conversations");
   });
 });

--- a/front/lib/api/actions/servers/files/tools/move.ts
+++ b/front/lib/api/actions/servers/files/tools/move.ts
@@ -108,9 +108,9 @@ export async function moveHandler(
   if (fsResult.isErr()) {
     return new Err(new MCPError(fsResult.error.message, { tracked: false }));
   }
-  const fs = fsResult.value;
+  const dustFs = fsResult.value;
 
-  const statResult = await fs.stat(source);
+  const statResult = await dustFs.stat(source);
   if (statResult.isErr()) {
     const err = statResult.error;
     switch (err.code) {
@@ -152,7 +152,7 @@ export async function moveHandler(
     : [];
   const linkedFileResource = linkedFileResources[0];
 
-  const moveResult = await fs.move({ src: source, dest });
+  const moveResult = await dustFs.move({ src: source, dest });
   if (moveResult.isErr()) {
     const err = moveResult.error;
     switch (err.code) {

--- a/front/lib/api/actions/servers/files/tools/move.ts
+++ b/front/lib/api/actions/servers/files/tools/move.ts
@@ -4,12 +4,11 @@ import type {
   ToolHandlerExtra,
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { resolveMountPoint } from "@app/lib/api/actions/servers/files/tools/utils";
 import {
-  getGCSPathFromScopedPath,
-  moveFile,
-} from "@app/lib/api/files/gcs_mount/files";
-import { getPrivateUploadBucket } from "@app/lib/file_storage";
+  DustFileSystem,
+  SCOPED_PREFIX_CONVERSATION,
+  SCOPED_PREFIX_POD,
+} from "@app/lib/api/file_system";
 import { FileResource } from "@app/lib/resources/file_resource";
 import type { FileUseCase, FileUseCaseMetadata } from "@app/types/files";
 import {
@@ -17,9 +16,74 @@ import {
   stripMimeParameters,
 } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
-import { assertNever } from "@app/types/shared/utils/assert_never";
-import { isString } from "@app/types/shared/utils/general";
+import type { LightWorkspaceType } from "@app/types/user";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+
+/**
+ * Translate a canonical scoped path to the raw GCS path that FileResource.mountFilePath stores.
+ *
+ * conversation-{cId}/{rel} -> w/{wId}/conversations/{cId}/files/{rel}
+ * pod-{pId}/{rel}          -> w/{wId}/pods/{pId}/files/{rel}
+ *
+ * Returns null for unrecognised prefixes or root-only paths with no rel component.
+ */
+// TEMPORARY: To remove once FileResource is not structurally used in the move.
+function canonicalToGCSPath(
+  workspace: LightWorkspaceType,
+  scopedPath: string
+): string | null {
+  if (scopedPath.startsWith(SCOPED_PREFIX_CONVERSATION)) {
+    const rest = scopedPath.slice(SCOPED_PREFIX_CONVERSATION.length);
+    const slash = rest.indexOf("/");
+    if (slash < 0) {
+      return null;
+    }
+
+    return `w/${workspace.sId}/conversations/${rest.slice(0, slash)}/files/${rest.slice(slash + 1)}`;
+  }
+
+  if (scopedPath.startsWith(SCOPED_PREFIX_POD)) {
+    const rest = scopedPath.slice(SCOPED_PREFIX_POD.length);
+    const slash = rest.indexOf("/");
+    if (slash < 0) {
+      return null;
+    }
+
+    return `w/${workspace.sId}/pods/${rest.slice(0, slash)}/files/${rest.slice(slash + 1)}`;
+  }
+
+  return null;
+}
+
+/**
+ * Derive the FileUseCase and FileUseCaseMetadata from the canonical dest path.
+ */
+function destMountInfo(
+  scopedPath: string,
+  conversationId: string
+): { useCase: FileUseCase; useCaseMetadata: FileUseCaseMetadata } | null {
+  if (scopedPath.startsWith(SCOPED_PREFIX_CONVERSATION)) {
+    return {
+      useCase: "tool_output",
+      useCaseMetadata: { conversationId },
+    };
+  }
+
+  if (scopedPath.startsWith(SCOPED_PREFIX_POD)) {
+    const rest = scopedPath.slice(SCOPED_PREFIX_POD.length);
+    const slash = rest.indexOf("/");
+    if (slash < 0) {
+      return null;
+    }
+    const spaceId = rest.slice(0, slash);
+    return {
+      useCase: "project_context",
+      useCaseMetadata: { spaceId },
+    };
+  }
+
+  return null;
+}
 
 export async function moveHandler(
   { source, dest }: { source: string; dest: string },
@@ -32,36 +96,6 @@ export async function moveHandler(
     );
   }
 
-  const sourceMountRes = await resolveMountPoint(auth, conversation, {
-    access: "write",
-    scopedPath: source,
-  });
-  if (sourceMountRes.isErr()) {
-    return sourceMountRes;
-  }
-
-  const destMountRes = await resolveMountPoint(auth, conversation, {
-    access: "write",
-    scopedPath: dest,
-  });
-  if (destMountRes.isErr()) {
-    return destMountRes;
-  }
-
-  const sourceGcsPath = getGCSPathFromScopedPath({
-    prefix: sourceMountRes.value.prefix,
-    scopedPath: source,
-    useCase: sourceMountRes.value.scope.useCase,
-  });
-  if (!sourceGcsPath) {
-    return new Err(
-      new MCPError(
-        "Invalid path: `source` does not match the resolved mount point.",
-        { tracked: false }
-      )
-    );
-  }
-
   if (source === dest) {
     return new Err(
       new MCPError("`source` and `dest` resolve to the same path.", {
@@ -70,58 +104,90 @@ export async function moveHandler(
     );
   }
 
-  const bucket = getPrivateUploadBucket();
-  let mimeType: string;
-  try {
-    const [metadata] = await bucket.file(sourceGcsPath).getMetadata();
-    mimeType = stripMimeParameters(
-      isString(metadata.contentType)
-        ? metadata.contentType
-        : "application/octet-stream"
-    );
-  } catch {
+  const fsResult = await DustFileSystem.forConversation(auth, conversation);
+  if (fsResult.isErr()) {
+    return new Err(new MCPError(fsResult.error.message, { tracked: false }));
+  }
+  const fs = fsResult.value;
+
+  const statResult = await fs.stat(source);
+  if (statResult.isErr()) {
+    const err = statResult.error;
+    switch (err.code) {
+      case "legacy_path":
+        return new Err(new MCPError(err.message, { tracked: false }));
+
+      case "invalid_path":
+        return new Err(
+          new MCPError(`Invalid path: \`${source}\`.`, { tracked: false })
+        );
+
+      default:
+        return new Err(
+          new MCPError(`Failed to read source \`${source}\`: ${err.message}`, {
+            tracked: false,
+          })
+        );
+    }
+  }
+
+  if (statResult.value === null) {
     return new Err(
       new MCPError(`Source file not found: \`${source}\`.`, { tracked: false })
     );
   }
 
-  const [linkedFileResource] = await FileResource.fetchByMountFilePaths(auth, [
-    sourceGcsPath,
-  ]);
+  const mimeType = stripMimeParameters(statResult.value.contentType);
+  const workspace = auth.getNonNullableWorkspace();
 
-  const destFileName = dest.split("/").pop() ?? dest;
-  const destScope = destMountRes.value.scope;
-  let destUseCase: FileUseCase;
-  let destUseCaseMetadata: FileUseCaseMetadata | undefined;
-  switch (destScope.useCase) {
-    case "pod":
-      destUseCase = "project_context";
-      destUseCaseMetadata = { spaceId: destScope.podId };
-      break;
-    case "conversation":
-      destUseCase = "tool_output";
-      destUseCaseMetadata = { conversationId: conversation.sId };
-      break;
-    default:
-      assertNever(destScope);
+  // Look up any linked FileResource before moving the bytes (best-effort: no error if none found).
+  // mountFilePath stores raw GCS paths; try both pods/ and projects/ variants for pod mounts.
+  const sourceGcsPath = canonicalToGCSPath(workspace, source);
+  const linkedFileResources = sourceGcsPath
+    ? await FileResource.fetchByMountFilePaths(auth, [
+        sourceGcsPath,
+        // Also try the legacy projects/ mirror path so we find records written before the pods/ switch.
+        sourceGcsPath.replace(/^(w\/[^/]+\/)pods\//, "$1projects/"),
+      ])
+    : [];
+  const linkedFileResource = linkedFileResources[0];
+
+  const moveResult = await fs.move({ src: source, dest });
+  if (moveResult.isErr()) {
+    const err = moveResult.error;
+    switch (err.code) {
+      case "legacy_path":
+      case "unauthorized":
+        return new Err(new MCPError(err.message, { tracked: false }));
+
+      case "invalid_path":
+        return new Err(
+          new MCPError(`Invalid path: \`${dest}\`.`, { tracked: false })
+        );
+
+      default:
+        return new Err(
+          new MCPError(
+            `Failed to move \`${source}\` to \`${dest}\`: ${err.message}`
+          )
+        );
+    }
   }
 
-  const destRelativeFilePath = dest.slice(`${destScope.useCase}/`.length);
-  const moveRes = await moveFile(auth, {
-    file: linkedFileResource,
-    sourceGcsPath,
-    destScope,
-    destRelativeFilePath,
-    destFileName,
-    destUseCase,
-    destUseCaseMetadata,
-  });
-  if (moveRes.isErr()) {
-    return new Err(
-      new MCPError(
-        `Failed to move \`${source}\` to \`${dest}\`: ${moveRes.error.message}`
-      )
-    );
+  // Update the linked FileResource's mount metadata to reflect the new location.
+  if (linkedFileResource) {
+    const destFileName = dest.split("/").pop() ?? dest;
+    const destGcsPath = canonicalToGCSPath(workspace, dest);
+    const destInfo = destMountInfo(dest, conversation.sId);
+
+    if (destGcsPath && destInfo) {
+      await linkedFileResource.updateMount({
+        destFileName,
+        destMountFilePath: destGcsPath,
+        destUseCase: destInfo.useCase,
+        destUseCaseMetadata: destInfo.useCaseMetadata,
+      });
+    }
   }
 
   const items: Array<
@@ -135,6 +201,7 @@ export async function moveHandler(
   ];
 
   if (isAllSupportedFileContentType(mimeType)) {
+    const destFileName = dest.split("/").pop() ?? dest;
     items.push({
       type: "resource",
       resource: {

--- a/front/lib/api/actions/servers/files/tools/resolve.ts
+++ b/front/lib/api/actions/servers/files/tools/resolve.ts
@@ -94,9 +94,9 @@ export async function resolveHandler(
   if (fsResult.isErr()) {
     return new Err(new MCPError(fsResult.error.message, { tracked: false }));
   }
-  const fs = fsResult.value;
+  const dustFs = fsResult.value;
 
-  const statResult = await fs.stat(canonicalPath);
+  const statResult = await dustFs.stat(canonicalPath);
   if (statResult.isErr()) {
     return new Err(new MCPError(statResult.error.message, { tracked: false }));
   }

--- a/front/lib/api/actions/servers/files/tools/resolve.ts
+++ b/front/lib/api/actions/servers/files/tools/resolve.ts
@@ -3,16 +3,47 @@ import type {
   ToolHandlerExtra,
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { getScopedPathFromGCSPath } from "@app/lib/api/files/gcs_mount/files";
 import {
-  getConversationFilesBasePath,
-  getPodFilesBasePath,
-} from "@app/lib/api/files/mount_path";
+  DustFileSystem,
+  SCOPED_PREFIX_CONVERSATION,
+  SCOPED_PREFIX_POD,
+} from "@app/lib/api/file_system";
 import { FileResource } from "@app/lib/resources/file_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
-import { isPodConversation } from "@app/types/assistant/conversation";
-import { isConversationFileUseCase } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
+import type { LightWorkspaceType } from "@app/types/user";
+
+/**
+ * Convert a raw GCS mountFilePath back to the canonical scoped path the agent sees.
+ *
+ * w/{wId}/conversations/{cId}/files/{rel} -> conversation-{cId}/{rel}
+ * w/{wId}/projects/{pId}/files/{rel}      -> pod-{pId}/{rel}   (legacy prefix)
+ * w/{wId}/pods/{pId}/files/{rel}          -> pod-{pId}/{rel}
+ */
+function gcsPathToCanonical(
+  workspace: LightWorkspaceType,
+  mountFilePath: string
+): string | null {
+  const base = `w/${workspace.sId}/`;
+  if (!mountFilePath.startsWith(base)) {
+    return null;
+  }
+
+  const rest = mountFilePath.slice(base.length);
+
+  const conv = rest.match(/^conversations\/([^/]+)\/files\/(.+)$/);
+  if (conv) {
+    return `${SCOPED_PREFIX_CONVERSATION}${conv[1]}/${conv[2]}`;
+  }
+
+  const pod =
+    rest.match(/^pods\/([^/]+)\/files\/(.+)$/) ??
+    rest.match(/^projects\/([^/]+)\/files\/(.+)$/);
+  if (pod) {
+    return `${SCOPED_PREFIX_POD}${pod[1]}/${pod[2]}`;
+  }
+
+  return null;
+}
 
 export async function resolveHandler(
   { file_id }: { file_id: string },
@@ -41,96 +72,42 @@ export async function resolveHandler(
     );
   }
 
-  const owner = extra.auth.getNonNullableWorkspace();
-  const { useCase, useCaseMetadata } = file;
-
-  if (isConversationFileUseCase(useCase)) {
-    if (useCaseMetadata?.conversationId !== conversation.sId) {
-      return new Err(
-        new MCPError(
-          `File \`${file_id}\` does not belong to this conversation.`,
-          { tracked: false }
-        )
-      );
-    }
-
-    const scopedPath = getScopedPathFromGCSPath({
-      prefix: getConversationFilesBasePath({
-        workspaceId: owner.sId,
-        conversationId: conversation.sId,
-      }),
-      gcsPath: file.mountFilePath,
-      useCase: "conversation",
-    });
-    if (!scopedPath) {
-      return new Err(
-        new MCPError(
-          `File \`${file_id}\` does not belong to this conversation.`,
-          { tracked: false }
-        )
-      );
-    }
-
-    return new Ok([{ type: "text", text: scopedPath }]);
+  const workspace = extra.auth.getNonNullableWorkspace();
+  const canonicalPath = gcsPathToCanonical(workspace, file.mountFilePath);
+  if (!canonicalPath) {
+    return new Err(
+      new MCPError(
+        `File \`${file_id}\` is not accessible through the file system (use case: ${file.useCase}).`,
+        { tracked: false }
+      )
+    );
   }
 
-  if (useCase === "project_context") {
-    if (!isPodConversation(conversation)) {
-      return new Err(
-        new MCPError(
-          `File \`${file_id}\` is a Pod file but this is not a Pod conversation.`,
-          { tracked: false }
-        )
-      );
-    }
-
-    const spaceId = useCaseMetadata?.spaceId;
-    if (!spaceId || spaceId !== conversation.spaceId) {
-      return new Err(
-        new MCPError(
-          `File \`${file_id}\` does not belong to the Pod of this conversation.`,
-          { tracked: false }
-        )
-      );
-    }
-
-    const space = await SpaceResource.fetchById(extra.auth, spaceId);
-    if (!space || !space.canRead(extra.auth)) {
-      return new Err(
-        new MCPError(
-          "You do not have read access to the Pod containing this file.",
-          { tracked: false }
-        )
-      );
-    }
-
-    // The file's mount path might still use the old "project" prefix
-    const gcsPath = file.mountFilePath.replace("/projects/", "/pods/");
-
-    const scopedPath = getScopedPathFromGCSPath({
-      prefix: getPodFilesBasePath({
-        workspaceId: owner.sId,
-        podId: spaceId,
-      }),
-      gcsPath,
-      useCase: "pod",
-    });
-    if (!scopedPath) {
-      return new Err(
-        new MCPError(
-          `File \`${file_id}\` does not belong to the Pod of this conversation.`,
-          { tracked: false }
-        )
-      );
-    }
-
-    return new Ok([{ type: "text", text: scopedPath }]);
-  }
-
-  return new Err(
-    new MCPError(
-      `File \`${file_id}\` is not accessible through the file system (use case: ${useCase}).`,
-      { tracked: false }
-    )
+  // Verify the caller actually has access to the resolved path. DustFileSystem.forConversation
+  // only mounts the pod scope when the conversation belongs to that pod and the caller has read
+  // access, so stat() implicitly enforces the same ownership + permission checks the old
+  // hand-rolled code did (conversationId match, spaceId match, space.canRead).
+  const fsResult = await DustFileSystem.forConversation(
+    extra.auth,
+    conversation
   );
+  if (fsResult.isErr()) {
+    return new Err(new MCPError(fsResult.error.message, { tracked: false }));
+  }
+  const fs = fsResult.value;
+
+  const statResult = await fs.stat(canonicalPath);
+  if (statResult.isErr()) {
+    return new Err(new MCPError(statResult.error.message, { tracked: false }));
+  }
+  if (!statResult.value) {
+    return new Err(
+      new MCPError(
+        `File \`${file_id}\` is not accessible through the file system.`,
+        { tracked: false }
+      )
+    );
+  }
+
+  return new Ok([{ type: "text", text: canonicalPath }]);
 }

--- a/front/lib/api/actions/servers/files/tools/utils.test.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.test.ts
@@ -1,170 +1,31 @@
-import { resolveMountPoint } from "@app/lib/api/actions/servers/files/tools/utils";
-import { createConversation } from "@app/lib/api/assistant/conversation";
-import { Authenticator } from "@app/lib/auth";
-import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
-import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import assert from "assert";
+import { isReadableAsText } from "@app/lib/api/actions/servers/files/tools/utils";
 import { describe, expect, it } from "vitest";
 
-describe("resolveMountPoint", () => {
-  describe("conversation paths", () => {
-    it("returns the conversation mount with the correct prefix", async () => {
-      const { authenticator: auth, workspace } = await createResourceTest({
-        role: "admin",
-      });
-
-      const conversation = await createConversation(auth, {
-        title: "Test",
-        visibility: "unlisted",
-        spaceId: null,
-      });
-
-      const result = await resolveMountPoint(auth, conversation, {
-        access: "read",
-        scopedPath: "conversation/notes.md",
-      });
-
-      expect(result.isOk()).toBe(true);
-      if (!result.isOk()) {
-        return;
-      }
-      expect(result.value.scope).toEqual({
-        useCase: "conversation",
-        conversationId: conversation.sId,
-      });
-      expect(result.value.prefix).toBe(
-        `w/${workspace.sId}/conversations/${conversation.sId}/files/`
-      );
-    });
-
-    it("returns the conversation mount on a write access request too", async () => {
-      const { authenticator: auth } = await createResourceTest({
-        role: "admin",
-      });
-
-      const conversation = await createConversation(auth, {
-        title: "Test",
-        visibility: "unlisted",
-        spaceId: null,
-      });
-
-      const result = await resolveMountPoint(auth, conversation, {
-        access: "write",
-        scopedPath: "conversation/folder/sub/output.csv",
-      });
-
-      expect(result.isOk()).toBe(true);
-    });
+describe("isReadableAsText", () => {
+  it("returns true for text/* mime types", () => {
+    expect(isReadableAsText("text/plain")).toBe(true);
+    expect(isReadableAsText("text/csv")).toBe(true);
+    expect(isReadableAsText("text/html")).toBe(true);
+    expect(isReadableAsText("text/markdown")).toBe(true);
   });
 
-  describe("Pod paths", () => {
-    it("returns the Pod mount for a Pod conversation", async () => {
-      const { authenticator: auth, workspace } = await createResourceTest({
-        role: "admin",
-      });
-
-      const userId = auth.getNonNullableUser().id;
-      const userSId = auth.getNonNullableUser().sId;
-
-      const space = await SpaceFactory.project(workspace, userId);
-      const addRes = await space.addMembers(auth, { userIds: [userSId] });
-      assert(addRes.isOk(), "Failed to add user to project space");
-
-      // Refresh the auth so the new space membership is picked up.
-      const projectAuth = await Authenticator.fromUserIdAndWorkspaceId(
-        userSId,
-        workspace.sId
-      );
-
-      const conversation = await createConversation(projectAuth, {
-        title: "Test",
-        visibility: "unlisted",
-        spaceId: space.id,
-      });
-
-      const result = await resolveMountPoint(projectAuth, conversation, {
-        access: "read",
-        scopedPath: "pod/spec.md",
-      });
-
-      expect(result.isOk()).toBe(true);
-      if (!result.isOk()) {
-        return;
-      }
-      expect(result.value.scope).toEqual({
-        useCase: "pod",
-        podId: space.sId,
-      });
-      expect(result.value.prefix).toBe(
-        `w/${workspace.sId}/pods/${space.sId}/files/`
-      );
-    });
-
-    it("returns Err for a Pod path in a non-Pod conversation", async () => {
-      const { authenticator: auth } = await createResourceTest({
-        role: "admin",
-      });
-
-      const conversation = await createConversation(auth, {
-        title: "Test",
-        visibility: "unlisted",
-        spaceId: null,
-      });
-
-      const result = await resolveMountPoint(auth, conversation, {
-        access: "read",
-        scopedPath: "pod/spec.md",
-      });
-
-      expect(result.isErr()).toBe(true);
-      if (!result.isErr()) {
-        return;
-      }
-      expect(result.error.message).toContain("Pod conversations");
-    });
+  it("returns true for known text-like application/* types", () => {
+    expect(isReadableAsText("application/json")).toBe(true);
+    expect(isReadableAsText("application/yaml")).toBe(true);
+    expect(isReadableAsText("application/xml")).toBe(true);
+    expect(isReadableAsText("application/x-ndjson")).toBe(true);
+    expect(isReadableAsText("application/javascript")).toBe(true);
+    expect(isReadableAsText("application/typescript")).toBe(true);
   });
 
-  describe("invalid paths", () => {
-    it("returns Err for a path without a known scope prefix", async () => {
-      const { authenticator: auth } = await createResourceTest({
-        role: "admin",
-      });
+  it("strips mime parameters before matching", () => {
+    expect(isReadableAsText("text/plain; charset=utf-8")).toBe(true);
+    expect(isReadableAsText("application/json; charset=utf-8")).toBe(true);
+  });
 
-      const conversation = await createConversation(auth, {
-        title: "Test",
-        visibility: "unlisted",
-        spaceId: null,
-      });
-
-      const result = await resolveMountPoint(auth, conversation, {
-        access: "read",
-        scopedPath: "other/foo.txt",
-      });
-
-      expect(result.isErr()).toBe(true);
-      if (!result.isErr()) {
-        return;
-      }
-      expect(result.error.message).toContain("must start with");
-    });
-
-    it("returns Err for a path without a slash", async () => {
-      const { authenticator: auth } = await createResourceTest({
-        role: "admin",
-      });
-
-      const conversation = await createConversation(auth, {
-        title: "Test",
-        visibility: "unlisted",
-        spaceId: null,
-      });
-
-      const result = await resolveMountPoint(auth, conversation, {
-        access: "read",
-        scopedPath: "conversation",
-      });
-
-      expect(result.isErr()).toBe(true);
-    });
+  it("returns false for binary types", () => {
+    expect(isReadableAsText("image/png")).toBe(false);
+    expect(isReadableAsText("application/pdf")).toBe(false);
+    expect(isReadableAsText("application/octet-stream")).toBe(false);
   });
 });

--- a/front/lib/api/actions/servers/files/tools/utils.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.ts
@@ -57,7 +57,7 @@ async function buildPodMountPoint(
 ): Promise<Result<MountPoint, MCPError>> {
   if (!isPodConversation(conversation)) {
     return new Err(
-      new MCPError("Pod file paths are only available in pod conversations.", {
+      new MCPError("Pod file paths are only available in Pod conversations.", {
         tracked: false,
       })
     );

--- a/front/lib/api/actions/servers/files/tools/utils.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.ts
@@ -57,9 +57,10 @@ async function buildPodMountPoint(
 ): Promise<Result<MountPoint, MCPError>> {
   if (!isPodConversation(conversation)) {
     return new Err(
-      new MCPError("Pod file paths are only available in Pod conversations.", {
-        tracked: false,
-      })
+      new MCPError(
+        "Pod file paths are only available in project conversations.",
+        { tracked: false }
+      )
     );
   }
 
@@ -78,8 +79,8 @@ async function buildPodMountPoint(
     return new Err(
       new MCPError(
         access === "write"
-          ? "You do not have write permissions for this Pod."
-          : "You do not have read permissions for this Pod.",
+          ? "You do not have write permissions for this pod."
+          : "You do not have read permissions for this pod.",
         { tracked: false }
       )
     );
@@ -97,8 +98,11 @@ async function buildPodMountPoint(
 
 /**
  * Resolve the mount point a scoped path belongs to. Dispatches by the path's `conversation/` or
- * `pod/` prefix, looks up the parent Pod space when needed, and verifies the requested
+ * `pod/` prefix, looks up the parent pod space when needed, and verifies the requested
  * access level.
+ *
+ * @deprecated Callers should migrate to DustFileSystem. This helper remains for transitional
+ * consumers (file_utils.ts, run_agent/file_paths.ts) while those are migrated.
  */
 export async function resolveMountPoint(
   auth: Authenticator,
@@ -124,6 +128,8 @@ export async function resolveMountPoint(
 /**
  * Resolve the mount point for a given scope use case, without going through a path. Used by tools
  * that operate on a whole mount (e.g. `list`).
+ *
+ * @deprecated Callers should migrate to DustFileSystem.
  */
 export async function resolveMountByUseCase(
   auth: Authenticator,
@@ -143,21 +149,21 @@ export async function resolveMountByUseCase(
 }
 
 /**
- * List the files mounted under a Pod's GCS prefix. Verifies `space.canRead(auth)` before
- * touching the bucket. Use this from callers that already hold a `SpaceResource` so the
- * file-listing path stays funneled through the same helper as `files__list`.
+ * List the files mounted under a pod's GCS prefix.
+ *
+ * @deprecated Callers should migrate to DustFileSystem.forPod(auth, space).list().
  */
 export async function listProjectFiles(
   auth: Authenticator,
   space: SpaceResource
 ): Promise<Result<GCSMountEntry[], MCPError>> {
   if (!space.isProject) {
-    return new Err(new MCPError("Space is not a Pod.", { tracked: false }));
+    return new Err(new MCPError("Space is not a pod.", { tracked: false }));
   }
 
   if (!space.canRead(auth)) {
     return new Err(
-      new MCPError("You do not have read permissions for this Pod.", {
+      new MCPError("You do not have read permissions for this pod.", {
         tracked: false,
       })
     );
@@ -173,7 +179,9 @@ export async function listProjectFiles(
 
 /**
  * Resolve a GCS file from a scoped path. Looks up the file metadata via `resolveMountPoint`.
- * Used by `cat` and `grep`.
+ *
+ * @deprecated Callers should migrate to DustFileSystem.forConversation(auth, conversation)
+ * followed by fs.stat() and fs.read().
  */
 export async function resolveFile(
   auth: Authenticator,

--- a/front/lib/api/actions/servers/files/tools/utils.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.ts
@@ -57,10 +57,9 @@ async function buildPodMountPoint(
 ): Promise<Result<MountPoint, MCPError>> {
   if (!isPodConversation(conversation)) {
     return new Err(
-      new MCPError(
-        "Pod file paths are only available in project conversations.",
-        { tracked: false }
-      )
+      new MCPError("Pod file paths are only available in pod conversations.", {
+        tracked: false,
+      })
     );
   }
 

--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -13,6 +13,7 @@ import {
   type EnabledSkill,
   renderEnabledSkillUserMessageFromInstructions,
 } from "@app/lib/api/assistant/skills_rendering";
+import { DustFileSystem } from "@app/lib/api/file_system";
 import { getConversationFileMountSignedUrl } from "@app/lib/api/files/gcs_mount/files";
 import type { Authenticator } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
@@ -46,6 +47,18 @@ import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import { removeNulls } from "@app/types/shared/utils/general";
 
 const RENDER_ACTIONS_CONCURRENCY = 5;
+
+async function getDustFileSystemDownloadUrl(
+  auth: Authenticator,
+  filePath: string
+) {
+  const fsResult = await DustFileSystem.fromScopedPath(auth, filePath);
+  if (fsResult.isErr()) {
+    return fsResult;
+  }
+
+  return fsResult.value.getDownloadUrl(filePath);
+}
 
 /**
  * Type for a step in agent message processing
@@ -156,11 +169,17 @@ async function renderActionForMultiActionsModel(
       if (isTextContent(item)) {
         contentArray.push({ type: "text", text: item.text });
       } else if (isModelVisionImage(item)) {
-        const urlRes = await getConversationFileMountSignedUrl(
-          auth,
-          { useCase: "conversation", conversationId },
-          item.resource.gcsPath
-        );
+        const { filePath } = item.resource;
+
+        // Legacy records carry a raw GCS path (starts with `w/`).
+        // New records carry a canonical scoped path (e.g. `conversation-{cId}/photo.png`).
+        const urlRes = filePath.startsWith("w/")
+          ? await getConversationFileMountSignedUrl(
+              auth,
+              { useCase: "conversation", conversationId },
+              filePath
+            )
+          : await getDustFileSystemDownloadUrl(auth, filePath);
 
         if (urlRes.isOk()) {
           contentArray.push({


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Replaces all direct GCS access in the files MCP server with `DustFileSystem`. Every tool (`cat`, `grep`, `create`, `delete`, `copy`, `move`, `list`, and `resolve`) now goes through `DustFileSystem.forConversation`, which provides unified path validation, mount-scoped permission enforcement, and canonical scoped paths (`conversation-{id}/file.txt`, `pod-{id}/file.txt`) instead of the legacy `conversation/` and `pod/` prefixes.

The deprecated GCS helpers are kept around with @deprecated annotations. They still serve transitional callers outside this server (and will be removed in a follow-up once those are migrated.

The resolve tool was simplified: instead of hand-rolling ownership and permission checks (conversationId match, spaceId match, space.canRead), it derives the canonical path from `FileResource.mountFilePath` then calls `fs.stat()`. Because `DustFileSystem.forConversation` only mounts the pod scope when the conversation belongs to that pod and the caller has read access, the stat call implicitly enforces the same invariants.

The `files__cat` vision image output schema is updated to use filePath (canonical scoped path) instead of the old gcsPath (raw GCS object name). The schema accepts both shapes so existing stored records continue to parse. The rendering layer detects legacy values by checking for the w/ prefix and falls back to the old signed URL path accordingly.

> [!IMPORTANT] 
> It introduces two breaking changes
> 1. Agents will get a nice error if they attempt to use the legacy path, proving hints and this PR is atomic so all tools in the MCP server will reason using the canonical path.
> 2. It removes double write on legacy project when writing to pod (seen w/ @matteotrab)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
