### PR TITLE
Improve error message

### DIFF
--- a/front/components/app/ReachedLimitPopup.tsx
+++ b/front/components/app/ReachedLimitPopup.tsx
@@ -23,7 +23,9 @@ export type WorkspaceLimit =
   | "cant_invite_free_plan"
   | "cant_invite_payment_failure"
   | "message_limit"
-  | "credits_exhausted";
+  | "credits_exhausted"
+  | "pool_credits_exhausted"
+  | "user_credits_exhausted";
 
 function getLimitPromptForCode(
   router: AppRouter,
@@ -173,12 +175,13 @@ function getLimitPromptForCode(
       }
     }
 
-    case "credits_exhausted": {
+    case "credits_exhausted":
+    case "pool_credits_exhausted": {
       const creditsManagementHref = isCreditPricedPlan(subscription.plan)
         ? `/w/${owner.sId}/usage`
         : `/w/${owner.sId}/developers/credits-usage`;
       return {
-        title: "Out of credits",
+        title: "Workspace out of credits",
         validateLabel: isAdmin ? "Manage credits" : "Ok",
         onValidate: isAdmin
           ? () => {
@@ -188,10 +191,30 @@ function getLimitPromptForCode(
         children: (
           <>
             <Page.P>
-              You have run out of credits.
               {isAdmin
-                ? " Please purchase more credits to continue using Dust."
-                : " Please contact your administrator to purchase more credits."}
+                ? "Your workspace has run out of credits. Please purchase more credits to continue using Dust."
+                : "Your workspace has run out of credits. Please contact your administrator to purchase more credits."}
+            </Page.P>
+          </>
+        ),
+      };
+    }
+
+    case "user_credits_exhausted": {
+      return {
+        title: "Usage cap reached",
+        validateLabel: isAdmin ? "Go to Usage" : "Ok",
+        onValidate: isAdmin
+          ? () => {
+              void router.push(`/w/${owner.sId}/usage`);
+            }
+          : undefined,
+        children: (
+          <>
+            <Page.P>
+              {isAdmin
+                ? "You have reached your personal usage cap. You can adjust user caps from the usage page."
+                : "You have reached your personal usage cap. Please contact your administrator to increase it."}
             </Page.P>
           </>
         ),

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -112,7 +112,9 @@ export function ConversationContainerVirtuoso({
         if (conversationRes.error.type === "plan_limit_reached_error") {
           setLimitReachedCode("message_limit");
         } else if (conversationRes.error.type === "credits_exhausted_error") {
-          setLimitReachedCode("credits_exhausted");
+          setLimitReachedCode("pool_credits_exhausted");
+        } else if (conversationRes.error.type === "user_cap_reached_error") {
+          setLimitReachedCode("user_credits_exhausted");
         } else {
           sendNotification({
             title: conversationRes.error.title,

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -1126,7 +1126,9 @@ export const ConversationViewer = ({
           if (result.error.type === "plan_limit_reached_error") {
             setLimitReachedCode?.("message_limit");
           } else if (result.error.type === "credits_exhausted_error") {
-            setLimitReachedCode?.("credits_exhausted");
+            setLimitReachedCode?.("pool_credits_exhausted");
+          } else if (result.error.type === "user_cap_reached_error") {
+            setLimitReachedCode?.("user_credits_exhausted");
           } else {
             sendNotification({
               title: result.error.title,

--- a/front/hooks/useCreateConversationWithMessage.ts
+++ b/front/hooks/useCreateConversationWithMessage.ts
@@ -145,7 +145,9 @@ export function useCreateConversationWithMessage({
               ? "plan_limit_reached_error"
               : isApiError && e.error.type === "credits_exhausted"
                 ? "credits_exhausted_error"
-                : "message_send_error",
+                : isApiError && e.error.type === "user_cap_reached"
+                  ? "user_cap_reached_error"
+                  : "message_send_error",
           title: "Your message could not be sent.",
           message: isApiError
             ? // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing

--- a/front/hooks/useSubmitMessage.ts
+++ b/front/hooks/useSubmitMessage.ts
@@ -154,7 +154,9 @@ export function useSubmitMessage({
               ? "plan_limit_reached_error"
               : data.error.type === "credits_exhausted"
                 ? "credits_exhausted_error"
-                : "message_send_error",
+                : data.error.type === "user_cap_reached"
+                  ? "user_cap_reached_error"
+                  : "message_send_error",
           title: "Your message could not be sent.",
           // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           message: data.error.message || "Please try again or contact us.",

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2411,16 +2411,26 @@ async function checkMessagesLimit(
   const plan = auth.subscription()?.plan;
   const user = auth.user();
   if (owner.metronomeCustomerId && plan && isCreditPricedPlan(plan)) {
-    const blocked = user
+    const blockedReason = user
       ? await isUserBlocked(owner.sId, user.sId)
-      : await isApiBlocked(owner.sId);
-    if (blocked) {
+      : (await isApiBlocked(owner.sId))
+        ? ("credits_exhausted" as const)
+        : null;
+    if (blockedReason === "user_cap_reached") {
+      return new Err({
+        status_code: 403,
+        api_error: {
+          type: "user_cap_reached",
+          message: "You have reached your personal usage cap.",
+        },
+      });
+    }
+    if (blockedReason === "credits_exhausted") {
       return new Err({
         status_code: 403,
         api_error: {
           type: "credits_exhausted",
-          message:
-            "Your workspace has run out of credits. Please purchase more credits to continue.",
+          message: "Your workspace has run out of credits.",
         },
       });
     }

--- a/front/lib/metronome/user_block.test.ts
+++ b/front/lib/metronome/user_block.test.ts
@@ -75,16 +75,34 @@ describe("isUserBlocked", () => {
     redisValues.clear();
   });
 
-  it("returns from Redis when both cached flags are present", async () => {
+  it("returns 'user_cap_reached' from Redis when only the user-cap flag is set", async () => {
     redisValues.set("metronome:user_cap:ws_test:u_test", "1");
     redisValues.set("metronome:pool_depleted:ws_test", "0");
 
     const blocked = await isUserBlocked("ws_test", "u_test");
 
-    expect(blocked).toBe(true);
+    expect(blocked).toBe("user_cap_reached");
     expect(mockFetchWorkspaceById).not.toHaveBeenCalled();
     expect(mockFetchUserById).not.toHaveBeenCalled();
     expect(mockGetActiveMembershipOfUserInWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("returns 'credits_exhausted' when the pool is depleted, even if user is also capped", async () => {
+    redisValues.set("metronome:user_cap:ws_test:u_test", "1");
+    redisValues.set("metronome:pool_depleted:ws_test", "1");
+
+    const blocked = await isUserBlocked("ws_test", "u_test");
+
+    expect(blocked).toBe("credits_exhausted");
+  });
+
+  it("returns null when neither flag is set", async () => {
+    redisValues.set("metronome:user_cap:ws_test:u_test", "0");
+    redisValues.set("metronome:pool_depleted:ws_test", "0");
+
+    const blocked = await isUserBlocked("ws_test", "u_test");
+
+    expect(blocked).toBeNull();
   });
 
   it("falls back to DB on cold cache and repopulates both flags", async () => {
@@ -100,7 +118,7 @@ describe("isUserBlocked", () => {
 
     const blocked = await isUserBlocked("ws_test", "u_test");
 
-    expect(blocked).toBe(true);
+    expect(blocked).toBe("user_cap_reached");
     expect(redisValues.get("metronome:user_cap:ws_test:u_test")).toBe("1");
     expect(redisValues.get("metronome:pool_depleted:ws_test")).toBe("0");
   });
@@ -120,7 +138,7 @@ describe("isUserBlocked", () => {
 
     const blocked = await isUserBlocked("ws_test", "u_test");
 
-    expect(blocked).toBe(true);
+    expect(blocked).toBe("credits_exhausted");
     expect(redisValues.get("metronome:user_cap:ws_test:u_test")).toBe("0");
     expect(redisValues.get("metronome:pool_depleted:ws_test")).toBe("1");
   });

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -9,10 +9,14 @@
 //   - `"0"`: not blocked / not depleted
 //
 // `isUserBlocked` is the unified read: a user is blocked iff either cached flag
-// is `"1"`. The DB columns (`memberships.creditState`,
-// `workspaces.poolCreditState`) remain the source of truth. Cache writes are
-// gated on DB transaction commit via `invalidateCacheAfterCommit`, and cache
-// misses fall back to DB and repopulate both flags.
+// is `"1"`, and it returns the reason ("credits_exhausted" for a depleted
+// workspace pool, or "user_cap_reached" for a per-user cap) so callers can
+// surface a tailored message. When both flags are set, `credits_exhausted`
+// wins since the pool shadows the per-user state. The DB columns
+// (`memberships.creditState`, `workspaces.poolCreditState`) remain the source
+// of truth. Cache writes are gated on DB transaction commit via
+// `invalidateCacheAfterCommit`, and cache misses fall back to DB and
+// repopulate both flags.
 //
 import { runOnRedis } from "@app/lib/api/redis";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
@@ -22,6 +26,8 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import type { WorkspacePoolCreditState } from "@app/types/credits";
 import { isWorkspacePoolCreditState } from "@app/types/credits";
+
+export type UserBlockedReason = "credits_exhausted" | "user_cap_reached";
 
 const REDIS_ORIGIN = "metronome_limit" as const;
 const BLOCKED_FLAG = "1";
@@ -144,10 +150,26 @@ export async function clearWorkspacePoolDepleted(
 
 // Unified read
 
+function deriveBlockedReason({
+  userCapBlocked,
+  workspacePoolDepleted,
+}: {
+  userCapBlocked: boolean;
+  workspacePoolDepleted: boolean;
+}): UserBlockedReason | null {
+  if (workspacePoolDepleted) {
+    return "credits_exhausted";
+  }
+  if (userCapBlocked) {
+    return "user_cap_reached";
+  }
+  return null;
+}
+
 export async function isUserBlocked(
   workspaceId: string,
   userId: string
-): Promise<boolean> {
+): Promise<UserBlockedReason | null> {
   const [userCap, poolDepleted] = await runOnRedis(
     { origin: REDIS_ORIGIN },
     async (client) =>
@@ -158,7 +180,10 @@ export async function isUserBlocked(
   );
 
   if (isBlockFlag(userCap) && isBlockFlag(poolDepleted)) {
-    return userCap === BLOCKED_FLAG || poolDepleted === BLOCKED_FLAG;
+    return deriveBlockedReason({
+      userCapBlocked: userCap === BLOCKED_FLAG,
+      workspacePoolDepleted: poolDepleted === BLOCKED_FLAG,
+    });
   }
 
   logger.info(
@@ -179,7 +204,7 @@ export async function isUserBlocked(
     workspacePoolDepleted: state.workspacePoolDepleted,
   });
 
-  return state.userCapBlocked || state.workspacePoolDepleted;
+  return deriveBlockedReason(state);
 }
 
 // Workspace credit pool status (fine-grained state for UI/notifications).

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -293,6 +293,7 @@ export async function runTriggeredAgentsActivity({
     const isNonRetryable =
       errorType === "plan_message_limit_exceeded" ||
       errorType === "credits_exhausted" ||
+      errorType === "user_cap_reached" ||
       errorType === "model_disabled" ||
       errorType === "invalid_request_error" ||
       errorType === "agent_inaccessible" ||

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -671,6 +671,7 @@ export type SubmitMessageError = {
     | "message_send_error"
     | "plan_limit_reached_error"
     | "credits_exhausted_error"
+    | "user_cap_reached_error"
     | "content_too_large";
   title: string;
   message: string;

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -73,6 +73,7 @@ const API_ERROR_TYPES = [
   "message_not_found",
   "plan_message_limit_exceeded",
   "credits_exhausted",
+  "user_cap_reached",
   "model_disabled",
   "global_agent_error",
   "stripe_invalid_product_id_error",

--- a/sdks/js/src/errors/errors.ts
+++ b/sdks/js/src/errors/errors.ts
@@ -219,6 +219,7 @@ const errorTypeMapping: Record<
   plan_limit_error: DustPermissionError,
   plan_message_limit_exceeded: DustPermissionError,
   credits_exhausted: DustPermissionError,
+  user_cap_reached: DustPermissionError,
   subscription_required: DustPermissionError,
   content_too_large: DustContentTooLargeError,
   internal_server_error: DustServerError,

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1742,6 +1742,7 @@ const APIErrorTypeSchema = FlexibleEnumSchema<
   | "plan_limit_error"
   | "plan_message_limit_exceeded"
   | "credits_exhausted"
+  | "user_cap_reached"
   | "plugin_execution_failed"
   | "plugin_not_found"
   | "provider_auth_error"


### PR DESCRIPTION
## Description

Splits the credit-exhaustion error UX between **workspace pool depletion** and **per-user usage cap** so we can show the right message to the right person.

Previously both cases collapsed into a single \"Out of credits\" dialog with no way for the user to know whose limit they hit. After this PR:

- **Workspace pool depleted** (`credits_exhausted`, existing semantics) → \"Workspace out of credits\" dialog directing admins to purchase more credits.
- **Per-user usage cap** (`user_cap_reached`, new) → \"Usage cap reached\" dialog directing admins to `/usage` to adjust the cap, and users to contact their admin.

### Changes

- **`front/lib/metronome/user_block.ts`**: `isUserBlocked` now returns `UserBlockedReason | null` instead of `boolean`. Reason values are `\"credits_exhausted\" | \"user_cap_reached\"`, matching the API error type names so callers don't need a translation table. When both flags are set, pool depletion wins (shadows the per-user state).
- **`front/types/error.ts`**: new API error type `user_cap_reached`. `credits_exhausted` keeps its historical meaning (pool depleted).
- **`front/lib/api/assistant/conversation.ts`**: `checkMessagesLimit` branches on the reason and returns the matching 403 error.
- **`front/types/assistant/conversation.ts`**: `SubmitMessageError.type` gets `\"user_cap_reached_error\"`.
- **`front/hooks/{useCreateConversationWithMessage,useSubmitMessage}.ts`**: map API `user_cap_reached` → frontend `user_cap_reached_error`.
- **`front/components/assistant/conversation/{ConversationContainer,ConversationViewer}.tsx`**: branch on `error.type` directly to set the right `WorkspaceLimit` code.
- **`front/components/app/ReachedLimitPopup.tsx`**: new `user_credits_exhausted` UI code with its own dialog content. Pool dialog copy clarified (\"Your workspace has run out of credits.\").
- **`front/temporal/triggers/activities.ts`**: `user_cap_reached` added to non-retryable error types.
- **`sdks/js/src/{types,errors/errors}.ts`**: new error type registered in the SDK, mapped to `DustPermissionError`.

### Tests

`front/lib/metronome/user_block.test.ts` updated to assert the new return type, including the three branches:
- only user-cap flag set → `\"user_cap_reached\"`
- both flags set → `\"credits_exhausted\"` (pool wins)
- neither set → `null`

### Risk

Low.

- **No breaking changes to the public API.** `credits_exhausted` keeps its current value and meaning; `user_cap_reached` is purely additive. Existing SDK clients that catch `credits_exhausted` continue to work and now correctly see only pool-depletion errors there.
- Internal Redis cache keys (`metronome:pool_depleted:<ws>`, `metronome:user_cap:<ws>:<u>`) are unchanged — no cache invalidation required on deploy.
- The legacy `credits_exhausted` UI code in `WorkspaceLimit` remains as a fallthrough case in `ReachedLimitPopup` but is no longer emitted by the conversation flow; safe to remove in a follow-up.

Rollback: revert the commit.

### Deploy Plan

Standard front deploy. No migrations, no config changes.