### PR TITLE
useMetronomeContractLifecycleAction hooks

### DIFF
--- a/front/components/pages/workspace/subscription/MetronomeSubscriptionPanel.tsx
+++ b/front/components/pages/workspace/subscription/MetronomeSubscriptionPanel.tsx
@@ -1,4 +1,8 @@
 import { SubscriptionPlanCards } from "@app/components/plans/SubscriptionPlanCards";
+import {
+  useCancelMetronomeContract,
+  useReactivateMetronomeContract,
+} from "@app/hooks/useMetronomeContractLifecycleAction";
 import { useSendNotification } from "@app/hooks/useNotification";
 import config from "@app/lib/api/config";
 import { getPriceAsString } from "@app/lib/client/subscription";
@@ -17,7 +21,6 @@ import {
   useWorkspaceSeatsCount,
 } from "@app/lib/swr/workspaces";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
-import type { PatchMetronomeContractRequestBody } from "@app/pages/api/w/[wId]/metronome/contract";
 import type { PatchSubscriptionRequestBody } from "@app/pages/api/w/[wId]/subscriptions";
 import type { BillingPeriod, SubscriptionType } from "@app/types/plan";
 import { isSubscriptionMetronomeBilled } from "@app/types/plan";
@@ -196,6 +199,14 @@ export function MetronomeSubscriptionPanel({
     workspaceId: owner.sId,
     disabled: !isMetronomeBilled,
   });
+  const { cancelMetronomeContract, isCancellingMetronomeContract } =
+    useCancelMetronomeContract({
+      workspaceId: owner.sId,
+    });
+  const { reactivateMetronomeContract, isReactivatingMetronomeContract } =
+    useReactivateMetronomeContract({
+      workspaceId: owner.sId,
+    });
 
   const { submit: handleSubscribePlan, isSubmitting: isSubscribingPlan } =
     useSubmitFunction(async () => {
@@ -207,30 +218,10 @@ export function MetronomeSubscriptionPanel({
   const { submit: cancelSubscription, isSubmitting: isCancelling } =
     useSubmitFunction(async () => {
       try {
-        const res = await clientFetch(
-          `/api/w/${owner.sId}/metronome/contract`,
-          {
-            method: "PATCH",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              action: "cancel",
-            } satisfies z.infer<typeof PatchMetronomeContractRequestBody>),
-          }
-        );
-        if (!res.ok) {
-          sendNotification({
-            type: "error",
-            title: "Cancellation failed",
-            description: "Failed to cancel your subscription.",
-          });
-          return;
+        const success = await cancelMetronomeContract();
+        if (success) {
+          router.reload();
         }
-        sendNotification({
-          type: "success",
-          title: "Subscription cancelled",
-          description: "Your subscription will end at the end of the period.",
-        });
-        router.reload();
       } finally {
         setShowCancelDialog(false);
       }
@@ -238,28 +229,16 @@ export function MetronomeSubscriptionPanel({
 
   const { submit: reactivateSubscription, isSubmitting: isReactivating } =
     useSubmitFunction(async () => {
-      const res = await clientFetch(`/api/w/${owner.sId}/metronome/contract`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          action: "reactivate",
-        } satisfies z.infer<typeof PatchMetronomeContractRequestBody>),
-      });
-      if (!res.ok) {
-        sendNotification({
-          type: "error",
-          title: "Reactivation failed",
-          description: "Failed to reactivate your subscription.",
-        });
-        return;
+      const success = await reactivateMetronomeContract();
+      if (success) {
+        router.reload();
       }
-      sendNotification({
-        type: "success",
-        title: "Subscription reactivated",
-        description: "Your subscription will continue normally.",
-      });
-      router.reload();
     });
+
+  const isCancellingSubscription =
+    isCancelling || isCancellingMetronomeContract;
+  const isReactivatingSubscription =
+    isReactivating || isReactivatingMetronomeContract;
 
   const {
     submit: handleUpgradeToBusiness,
@@ -352,7 +331,7 @@ export function MetronomeSubscriptionPanel({
         show={showCancelDialog}
         onClose={() => setShowCancelDialog(false)}
         onValidate={cancelSubscription}
-        isSaving={isCancelling}
+        isSaving={isCancellingSubscription}
         periodEndLabel={periodEndLabel}
       />
       <UpgradeToBusinessDialog
@@ -372,7 +351,7 @@ export function MetronomeSubscriptionPanel({
                   size="sm"
                   label="Resume subscription"
                   variant="highlight"
-                  disabled={isReactivating}
+                  disabled={isReactivatingSubscription}
                   onClick={withTracking(
                     TRACKING_AREAS.AUTH,
                     "subscription_reactivate",
@@ -386,7 +365,7 @@ export function MetronomeSubscriptionPanel({
                   size="sm"
                   label="Cancel subscription"
                   variant="warning"
-                  disabled={isCancelling}
+                  disabled={isCancellingSubscription}
                   onClick={withTracking(
                     TRACKING_AREAS.AUTH,
                     "subscription_cancel",

--- a/front/hooks/useMetronomeContractLifecycleAction.ts
+++ b/front/hooks/useMetronomeContractLifecycleAction.ts
@@ -1,0 +1,124 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import type { PatchMetronomeContractRequestBody } from "@app/pages/api/w/[wId]/metronome/contract";
+import { useCallback, useState } from "react";
+import type { z } from "zod";
+
+type MetronomeContractLifecycleAction = "cancel" | "reactivate";
+
+function useMetronomeContractLifecycleAction({
+  workspaceId,
+  action,
+  errorTitle,
+  errorDescription,
+  successTitle,
+  successDescription,
+}: {
+  workspaceId: string;
+  action: MetronomeContractLifecycleAction;
+  errorTitle: string;
+  errorDescription: string;
+  successTitle: string;
+  successDescription: string;
+}) {
+  const sendNotification = useSendNotification();
+  const [isApplying, setIsApplying] = useState(false);
+
+  const applyMetronomeContractLifecycleAction = useCallback(async () => {
+    if (isApplying) {
+      return false;
+    }
+
+    setIsApplying(true);
+    try {
+      const res = await clientFetch(
+        `/api/w/${workspaceId}/metronome/contract`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            action,
+          } satisfies z.infer<typeof PatchMetronomeContractRequestBody>),
+        }
+      );
+
+      if (!res.ok) {
+        sendNotification({
+          type: "error",
+          title: errorTitle,
+          description: errorDescription,
+        });
+        return false;
+      }
+
+      sendNotification({
+        type: "success",
+        title: successTitle,
+        description: successDescription,
+      });
+      return true;
+    } finally {
+      setIsApplying(false);
+    }
+  }, [
+    action,
+    errorDescription,
+    errorTitle,
+    isApplying,
+    sendNotification,
+    successDescription,
+    successTitle,
+    workspaceId,
+  ]);
+
+  return {
+    applyMetronomeContractLifecycleAction,
+    isApplyingMetronomeContractLifecycleAction: isApplying,
+  };
+}
+
+export function useCancelMetronomeContract({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const {
+    applyMetronomeContractLifecycleAction,
+    isApplyingMetronomeContractLifecycleAction,
+  } = useMetronomeContractLifecycleAction({
+    workspaceId,
+    action: "cancel",
+    errorTitle: "Cancellation failed",
+    errorDescription: "Failed to cancel your subscription.",
+    successTitle: "Subscription cancelled",
+    successDescription: "Your subscription will end at the end of the period.",
+  });
+
+  return {
+    cancelMetronomeContract: applyMetronomeContractLifecycleAction,
+    isCancellingMetronomeContract: isApplyingMetronomeContractLifecycleAction,
+  };
+}
+
+export function useReactivateMetronomeContract({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const {
+    applyMetronomeContractLifecycleAction,
+    isApplyingMetronomeContractLifecycleAction,
+  } = useMetronomeContractLifecycleAction({
+    workspaceId,
+    action: "reactivate",
+    errorTitle: "Reactivation failed",
+    errorDescription: "Failed to reactivate your subscription.",
+    successTitle: "Subscription reactivated",
+    successDescription: "Your subscription will continue normally.",
+  });
+
+  return {
+    reactivateMetronomeContract: applyMetronomeContractLifecycleAction,
+    isReactivatingMetronomeContract: isApplyingMetronomeContractLifecycleAction,
+  };
+}


### PR DESCRIPTION
## Description

Move Metronome contract lifecycle to hooks for reuse in Billing page.

## Tests

Tested locally

## Risk

Low

## Deploy Plan

- deploy `front`