### PR TITLE
Harden sandbox CA trust bundle install

### DIFF
--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -255,6 +255,21 @@ describe("sandbox egress helpers", () => {
     expect(installCall).toContain(
       "if [ -x '/usr/local/bin/dust-install-trust-bundle' ]"
     );
+    expect(installCall).toContain(
+      "/usr/bin/install -d -o root -g root -m 755 '/usr/local/share/ca-certificates'"
+    );
+    expect(installCall).toContain(
+      "/usr/bin/find '/usr/local/share/ca-certificates' -mindepth 1 -maxdepth 1 -exec /bin/rm -rf"
+    );
+    expect(installCall).toContain(
+      "/bin/rm -f '/usr/local/share/ca-certificates/dust-egress.crt'"
+    );
+    expect(installCall).toContain(
+      "/usr/bin/openssl x509 -in '/run/dust/egress-ca.pem' -noout"
+    );
+    expect(installCall).toContain(
+      "/usr/bin/install -o root -g root -m 644 '/run/dust/egress-ca.pem' '/usr/local/share/ca-certificates/dust-egress.crt'"
+    );
     expect(installCall).toContain("update-ca-certificates");
     expect(installCall).toContain("/bin/cat");
     expect(installCall).toContain("/etc/ssl/certs/ca-certificates.crt");

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -259,17 +259,21 @@ describe("sandbox egress helpers", () => {
       "/usr/bin/install -d -o root -g root -m 755 '/usr/local/share/ca-certificates'"
     );
     expect(installCall).toContain(
+      "[ ! -L '/usr/local/share/ca-certificates' ]"
+    );
+    expect(installCall).toContain(
       "/usr/bin/find '/usr/local/share/ca-certificates' -mindepth 1 -maxdepth 1 -exec /bin/rm -rf"
     );
     expect(installCall).toContain(
       "/bin/rm -f '/usr/local/share/ca-certificates/dust-egress.crt'"
     );
     expect(installCall).toContain(
-      "/usr/bin/openssl x509 -in '/run/dust/egress-ca.pem' -noout"
+      "/usr/bin/openssl x509 -in '/run/dust/egress-ca.pem' -out \"$_ca_tmp\" -outform PEM"
     );
     expect(installCall).toContain(
-      "/usr/bin/install -o root -g root -m 644 '/run/dust/egress-ca.pem' '/usr/local/share/ca-certificates/dust-egress.crt'"
+      "/usr/bin/install -o root -g root -m 644 \"$_ca_tmp\" '/usr/local/share/ca-certificates/dust-egress.crt'"
     );
+    expect(installCall).toContain('/bin/cat "$_ca_tmp"');
     expect(installCall).toContain("update-ca-certificates");
     expect(installCall).toContain("/bin/cat");
     expect(installCall).toContain("/etc/ssl/certs/ca-certificates.crt");

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -44,6 +44,7 @@ const MITM_TRUST_BUNDLE_INSTALLER_PATH =
   "/usr/local/bin/dust-install-trust-bundle";
 // Constants used by the pre-0.8.8 fallback path. Remove with the fallback
 // once all dust-base:0.8.7 sandboxes have aged out.
+const MITM_SYSTEM_CA_DIR = "/usr/local/share/ca-certificates";
 const MITM_SYSTEM_CA_DEST = "/usr/local/share/ca-certificates/dust-egress.crt";
 const MITM_SYSTEM_CA_BUNDLE = "/etc/ssl/certs/ca-certificates.crt";
 // Sentinel written atomically alongside the merged bundle so the health probe
@@ -585,8 +586,15 @@ async function installMitmTrustBundle(
   // TODO(2026-08-01 SANDBOX): remove the fallback once all pre-0.8.8
   // sandboxes have aged out.
   const inlineFallback =
-    `/usr/bin/mkdir -p ${shellEscape("/etc/dust")} ${shellEscape("/usr/local/share/ca-certificates")} && ` +
-    `((/usr/bin/cp ${shellEscape(MITM_CA_PATH)} ${shellEscape(MITM_SYSTEM_CA_DEST)} && /usr/sbin/update-ca-certificates >/dev/null 2>&1) || true) && ` +
+    `/usr/bin/mkdir -p ${shellEscape("/etc/dust")} && ` +
+    `/usr/bin/install -d -o root -g root -m 755 ${shellEscape(MITM_SYSTEM_CA_DIR)} && ` +
+    `/usr/bin/chown root:root ${shellEscape(MITM_SYSTEM_CA_DIR)} && ` +
+    `/usr/bin/chmod 755 ${shellEscape(MITM_SYSTEM_CA_DIR)} && ` +
+    `/usr/bin/find ${shellEscape(MITM_SYSTEM_CA_DIR)} -mindepth 1 -maxdepth 1 -exec /bin/rm -rf -- {} + && ` +
+    `/bin/rm -f ${shellEscape(MITM_SYSTEM_CA_DEST)} && ` +
+    `/usr/bin/openssl x509 -in ${shellEscape(MITM_CA_PATH)} -noout >/dev/null 2>&1 && ` +
+    `/usr/bin/install -o root -g root -m 644 ${shellEscape(MITM_CA_PATH)} ${shellEscape(MITM_SYSTEM_CA_DEST)} && ` +
+    `(/usr/sbin/update-ca-certificates >/dev/null 2>&1 || true) && ` +
     `_bundle_tmp=$(/usr/bin/mktemp ${shellEscape("/etc/dust/.ca-bundle.pem.XXXXXX")}) && ` +
     `{ /bin/cat ${shellEscape(MITM_SYSTEM_CA_BUNDLE)}; printf '\\n'; /bin/cat ${shellEscape(MITM_CA_PATH)}; } > "$_bundle_tmp" && ` +
     `/usr/bin/chmod 644 "$_bundle_tmp" && ` +

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -587,18 +587,21 @@ async function installMitmTrustBundle(
   // sandboxes have aged out.
   const inlineFallback =
     `/usr/bin/mkdir -p ${shellEscape("/etc/dust")} && ` +
+    `_ca_tmp=$(/usr/bin/mktemp ${shellEscape("/etc/dust/.egress-ca.pem.XXXXXX")}) && ` +
+    `([ ! -L ${shellEscape(MITM_SYSTEM_CA_DIR)} ] && { [ ! -e ${shellEscape(MITM_SYSTEM_CA_DIR)} ] || [ -d ${shellEscape(MITM_SYSTEM_CA_DIR)} ]; } || /bin/rm -f ${shellEscape(MITM_SYSTEM_CA_DIR)}) && ` +
     `/usr/bin/install -d -o root -g root -m 755 ${shellEscape(MITM_SYSTEM_CA_DIR)} && ` +
     `/usr/bin/chown root:root ${shellEscape(MITM_SYSTEM_CA_DIR)} && ` +
     `/usr/bin/chmod 755 ${shellEscape(MITM_SYSTEM_CA_DIR)} && ` +
     `/usr/bin/find ${shellEscape(MITM_SYSTEM_CA_DIR)} -mindepth 1 -maxdepth 1 -exec /bin/rm -rf -- {} + && ` +
     `/bin/rm -f ${shellEscape(MITM_SYSTEM_CA_DEST)} && ` +
-    `/usr/bin/openssl x509 -in ${shellEscape(MITM_CA_PATH)} -noout >/dev/null 2>&1 && ` +
-    `/usr/bin/install -o root -g root -m 644 ${shellEscape(MITM_CA_PATH)} ${shellEscape(MITM_SYSTEM_CA_DEST)} && ` +
+    `/usr/bin/openssl x509 -in ${shellEscape(MITM_CA_PATH)} -out "$_ca_tmp" -outform PEM >/dev/null 2>&1 && ` +
+    `/usr/bin/install -o root -g root -m 644 "$_ca_tmp" ${shellEscape(MITM_SYSTEM_CA_DEST)} && ` +
     `(/usr/sbin/update-ca-certificates >/dev/null 2>&1 || true) && ` +
     `_bundle_tmp=$(/usr/bin/mktemp ${shellEscape("/etc/dust/.ca-bundle.pem.XXXXXX")}) && ` +
-    `{ /bin/cat ${shellEscape(MITM_SYSTEM_CA_BUNDLE)}; printf '\\n'; /bin/cat ${shellEscape(MITM_CA_PATH)}; } > "$_bundle_tmp" && ` +
+    `{ /bin/cat ${shellEscape(MITM_SYSTEM_CA_BUNDLE)}; printf '\\n'; /bin/cat "$_ca_tmp"; } > "$_bundle_tmp" && ` +
     `/usr/bin/chmod 644 "$_bundle_tmp" && ` +
-    `/usr/bin/mv "$_bundle_tmp" ${shellEscape(MITM_CA_BUNDLE_PATH)}`;
+    `/usr/bin/mv "$_bundle_tmp" ${shellEscape(MITM_CA_BUNDLE_PATH)} && ` +
+    `/bin/rm -f "$_ca_tmp"`;
 
   const command = rootCommand.unsafeShell(
     `[ -s ${shellEscape(MITM_CA_PATH)} ] || ` +

--- a/front/lib/api/sandbox/hardening.ts
+++ b/front/lib/api/sandbox/hardening.ts
@@ -11,6 +11,7 @@ export const SANDBOX_STATIC_ROOT_CONSUMED_DIRS = [
   "/usr/local/lib/systemd/system-generators",
   "/usr/local/lib/tmpfiles.d",
   "/usr/local/share",
+  "/usr/local/share/ca-certificates",
   "/usr/local/share/dbus-1",
   "/usr/local/share/dbus-1/system-services",
   "/etc/dbus-1",

--- a/front/lib/api/sandbox/image/egress/dust-install-trust-bundle.sh
+++ b/front/lib/api/sandbox/image/egress/dust-install-trust-bundle.sh
@@ -12,17 +12,25 @@ if [ ! -s "$CA_PATH" ]; then
   exit 1
 fi
 
+mkdir -p /etc/dust /etc/ssl/certs/java
+
+normalized_ca_tmp="$(mktemp /etc/dust/.egress-ca.pem.XXXXXX)"
+bundle_tmp=""
+keytool_output=""
+cleanup() {
+  rm -f "$normalized_ca_tmp" "$bundle_tmp" "$keytool_output"
+}
+trap cleanup EXIT
+
 if ! command -v openssl >/dev/null 2>&1; then
   echo "openssl is required to validate $CA_PATH" >&2
   exit 1
 fi
 
-if ! openssl x509 -in "$CA_PATH" -noout >/dev/null 2>&1; then
+if ! openssl x509 -in "$CA_PATH" -out "$normalized_ca_tmp" -outform PEM >/dev/null 2>&1; then
   echo "dsbx CA file $CA_PATH is not a valid X.509 PEM certificate" >&2
   exit 1
 fi
-
-mkdir -p /etc/dust /etc/ssl/certs/java
 
 if [ -L "$SYSTEM_CA_DIR" ] || { [ -e "$SYSTEM_CA_DIR" ] && [ ! -d "$SYSTEM_CA_DIR" ]; }; then
   rm -f "$SYSTEM_CA_DIR"
@@ -39,7 +47,7 @@ find "$SYSTEM_CA_DIR" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
 rm -f "$SYSTEM_CA_DEST"
 
 if command -v update-ca-certificates >/dev/null 2>&1; then
-  install -o root -g root -m 644 "$CA_PATH" "$SYSTEM_CA_DEST"
+  install -o root -g root -m 644 "$normalized_ca_tmp" "$SYSTEM_CA_DEST"
   if ! update-ca-certificates >/dev/null 2>&1; then
     echo "update-ca-certificates failed; continuing with explicit bundle" >&2
   fi
@@ -48,10 +56,6 @@ else
 fi
 
 bundle_tmp="$(mktemp /etc/dust/.ca-bundle.pem.XXXXXX)"
-cleanup() {
-  rm -f "$bundle_tmp" "${keytool_output:-}"
-}
-trap cleanup EXIT
 
 # Concatenate with an explicit newline so the join point can never glue the
 # last cert footer to the next BEGIN line if ca-certificates.crt drops its
@@ -59,7 +63,7 @@ trap cleanup EXIT
 # already in $SYSTEM_CA_BUNDLE; the explicit second copy is harmless (OpenSSL
 # dedupes by subject) and keeps the merged bundle correct even when update-ca-
 # certificates is missing or fails.
-{ cat "$SYSTEM_CA_BUNDLE"; printf '\n'; cat "$CA_PATH"; } > "$bundle_tmp"
+{ cat "$SYSTEM_CA_BUNDLE"; printf '\n'; cat "$normalized_ca_tmp"; } > "$bundle_tmp"
 chmod 644 "$bundle_tmp"
 mv "$bundle_tmp" "$MERGED_BUNDLE"
 
@@ -114,7 +118,7 @@ if command -v keytool >/dev/null 2>&1; then
       keytool_output="$(mktemp)"
       if keytool -importcert -noprompt -trustcacerts \
         -alias dust-egress \
-        -file "$CA_PATH" \
+        -file "$normalized_ca_tmp" \
         -keystore "$java_cacerts" \
         -storepass changeit >"$keytool_output" 2>&1; then
         :

--- a/front/lib/api/sandbox/image/egress/dust-install-trust-bundle.sh
+++ b/front/lib/api/sandbox/image/egress/dust-install-trust-bundle.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 CA_PATH="/run/dust/egress-ca.pem"
-SYSTEM_CA_DEST="/usr/local/share/ca-certificates/dust-egress.crt"
+SYSTEM_CA_DIR="/usr/local/share/ca-certificates"
+SYSTEM_CA_DEST="${SYSTEM_CA_DIR}/dust-egress.crt"
 SYSTEM_CA_BUNDLE="/etc/ssl/certs/ca-certificates.crt"
 MERGED_BUNDLE="/etc/dust/ca-bundle.pem"
 
@@ -11,10 +12,34 @@ if [ ! -s "$CA_PATH" ]; then
   exit 1
 fi
 
-mkdir -p /etc/dust /usr/local/share/ca-certificates /etc/ssl/certs/java
+if ! command -v openssl >/dev/null 2>&1; then
+  echo "openssl is required to validate $CA_PATH" >&2
+  exit 1
+fi
+
+if ! openssl x509 -in "$CA_PATH" -noout >/dev/null 2>&1; then
+  echo "dsbx CA file $CA_PATH is not a valid X.509 PEM certificate" >&2
+  exit 1
+fi
+
+mkdir -p /etc/dust /etc/ssl/certs/java
+
+if [ -L "$SYSTEM_CA_DIR" ] || { [ -e "$SYSTEM_CA_DIR" ] && [ ! -d "$SYSTEM_CA_DIR" ]; }; then
+  rm -f "$SYSTEM_CA_DIR"
+fi
+
+install -d -o root -g root -m 755 "$SYSTEM_CA_DIR"
+chown root:root "$SYSTEM_CA_DIR"
+chmod 755 "$SYSTEM_CA_DIR"
+
+# update-ca-certificates follows symlinks under this directory. Treat it as
+# Dust-owned staging and keep only the CA we install below before root asks it
+# to rebuild the world-readable system bundle.
+find "$SYSTEM_CA_DIR" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
+rm -f "$SYSTEM_CA_DEST"
 
 if command -v update-ca-certificates >/dev/null 2>&1; then
-  cp "$CA_PATH" "$SYSTEM_CA_DEST"
+  install -o root -g root -m 644 "$CA_PATH" "$SYSTEM_CA_DEST"
   if ! update-ca-certificates >/dev/null 2>&1; then
     echo "update-ca-certificates failed; continuing with explicit bundle" >&2
   fi

--- a/front/lib/api/sandbox/image/egress/dust-install-trust-bundle.sh
+++ b/front/lib/api/sandbox/image/egress/dust-install-trust-bundle.sh
@@ -12,50 +12,50 @@ if [ ! -s "$CA_PATH" ]; then
   exit 1
 fi
 
-mkdir -p /etc/dust /etc/ssl/certs/java
+/usr/bin/mkdir -p /etc/dust /etc/ssl/certs/java
 
-normalized_ca_tmp="$(mktemp /etc/dust/.egress-ca.pem.XXXXXX)"
+normalized_ca_tmp="$(/usr/bin/mktemp /etc/dust/.egress-ca.pem.XXXXXX)"
 bundle_tmp=""
 keytool_output=""
 cleanup() {
-  rm -f "$normalized_ca_tmp" "$bundle_tmp" "$keytool_output"
+  /bin/rm -f "$normalized_ca_tmp" "$bundle_tmp" "$keytool_output"
 }
 trap cleanup EXIT
 
-if ! command -v openssl >/dev/null 2>&1; then
+if [ ! -x /usr/bin/openssl ]; then
   echo "openssl is required to validate $CA_PATH" >&2
   exit 1
 fi
 
-if ! openssl x509 -in "$CA_PATH" -out "$normalized_ca_tmp" -outform PEM >/dev/null 2>&1; then
+if ! /usr/bin/openssl x509 -in "$CA_PATH" -out "$normalized_ca_tmp" -outform PEM >/dev/null 2>&1; then
   echo "dsbx CA file $CA_PATH is not a valid X.509 PEM certificate" >&2
   exit 1
 fi
 
 if [ -L "$SYSTEM_CA_DIR" ] || { [ -e "$SYSTEM_CA_DIR" ] && [ ! -d "$SYSTEM_CA_DIR" ]; }; then
-  rm -f "$SYSTEM_CA_DIR"
+  /bin/rm -f "$SYSTEM_CA_DIR"
 fi
 
-install -d -o root -g root -m 755 "$SYSTEM_CA_DIR"
-chown root:root "$SYSTEM_CA_DIR"
-chmod 755 "$SYSTEM_CA_DIR"
+/usr/bin/install -d -o root -g root -m 755 "$SYSTEM_CA_DIR"
+/usr/bin/chown root:root "$SYSTEM_CA_DIR"
+/usr/bin/chmod 755 "$SYSTEM_CA_DIR"
 
 # update-ca-certificates follows symlinks under this directory. Treat it as
 # Dust-owned staging and keep only the CA we install below before root asks it
 # to rebuild the world-readable system bundle.
-find "$SYSTEM_CA_DIR" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
-rm -f "$SYSTEM_CA_DEST"
+/usr/bin/find "$SYSTEM_CA_DIR" -mindepth 1 -maxdepth 1 -exec /bin/rm -rf -- {} +
+/bin/rm -f "$SYSTEM_CA_DEST"
 
-if command -v update-ca-certificates >/dev/null 2>&1; then
-  install -o root -g root -m 644 "$normalized_ca_tmp" "$SYSTEM_CA_DEST"
-  if ! update-ca-certificates >/dev/null 2>&1; then
+if [ -x /usr/sbin/update-ca-certificates ]; then
+  /usr/bin/install -o root -g root -m 644 "$normalized_ca_tmp" "$SYSTEM_CA_DEST"
+  if ! /usr/sbin/update-ca-certificates >/dev/null 2>&1; then
     echo "update-ca-certificates failed; continuing with explicit bundle" >&2
   fi
 else
   echo "update-ca-certificates not found; continuing with explicit bundle" >&2
 fi
 
-bundle_tmp="$(mktemp /etc/dust/.ca-bundle.pem.XXXXXX)"
+bundle_tmp="$(/usr/bin/mktemp /etc/dust/.ca-bundle.pem.XXXXXX)"
 
 # Concatenate with an explicit newline so the join point can never glue the
 # last cert footer to the next BEGIN line if ca-certificates.crt drops its
@@ -63,28 +63,28 @@ bundle_tmp="$(mktemp /etc/dust/.ca-bundle.pem.XXXXXX)"
 # already in $SYSTEM_CA_BUNDLE; the explicit second copy is harmless (OpenSSL
 # dedupes by subject) and keeps the merged bundle correct even when update-ca-
 # certificates is missing or fails.
-{ cat "$SYSTEM_CA_BUNDLE"; printf '\n'; cat "$normalized_ca_tmp"; } > "$bundle_tmp"
-chmod 644 "$bundle_tmp"
-mv "$bundle_tmp" "$MERGED_BUNDLE"
+{ /bin/cat "$SYSTEM_CA_BUNDLE"; printf '\n'; /bin/cat "$normalized_ca_tmp"; } > "$bundle_tmp"
+/usr/bin/chmod 644 "$bundle_tmp"
+/usr/bin/mv "$bundle_tmp" "$MERGED_BUNDLE"
 
 # No JDK is installed in the base image today. When one is added later or
 # installed at runtime, cover both JAVA_HOME and Debian's system Java keystore.
-if command -v keytool >/dev/null 2>&1; then
+if [ -x /usr/bin/keytool ]; then
   java_cacerts_candidates=()
   if [ -n "${JAVA_HOME:-}" ]; then
     java_cacerts_candidates+=("$JAVA_HOME/lib/security/cacerts")
   fi
   java_cacerts_candidates+=("/etc/ssl/certs/java/cacerts")
-  if command -v java >/dev/null 2>&1; then
-    java_bin="$(readlink -f "$(command -v java)")"
-    java_home="$(dirname "$(dirname "$java_bin")")"
+  if [ -x /usr/bin/java ]; then
+    java_bin="$(/usr/bin/readlink -f /usr/bin/java)"
+    java_home="$(/usr/bin/dirname "$(/usr/bin/dirname "$java_bin")")"
     java_cacerts_candidates+=("$java_home/lib/security/cacerts")
   fi
 
   java_cacerts_can_write() {
     local java_cacerts="$1"
     local java_cacerts_dir
-    java_cacerts_dir="$(dirname "$java_cacerts")"
+    java_cacerts_dir="$(/usr/bin/dirname "$java_cacerts")"
 
     [ -w "$java_cacerts" ] || {
       [ "$java_cacerts" = "/etc/ssl/certs/java/cacerts" ] &&
@@ -112,23 +112,23 @@ if command -v keytool >/dev/null 2>&1; then
       esac
       java_cacerts_seen="$java_cacerts_seen:$java_cacerts"
       if [ -e "$java_cacerts" ] && [ ! -s "$java_cacerts" ]; then
-        rm -f "$java_cacerts"
+        /bin/rm -f "$java_cacerts"
       fi
 
-      keytool_output="$(mktemp)"
-      if keytool -importcert -noprompt -trustcacerts \
+      keytool_output="$(/usr/bin/mktemp)"
+      if /usr/bin/keytool -importcert -noprompt -trustcacerts \
         -alias dust-egress \
         -file "$normalized_ca_tmp" \
         -keystore "$java_cacerts" \
         -storepass changeit >"$keytool_output" 2>&1; then
         :
-      elif grep -qi "already exists" "$keytool_output"; then
+      elif /usr/bin/grep -qi "already exists" "$keytool_output"; then
         :
       else
-        cat "$keytool_output" >&2
+        /bin/cat "$keytool_output" >&2
         exit 1
       fi
-      rm -f "$keytool_output"
+      /bin/rm -f "$keytool_output"
       keytool_output=""
     done
 
@@ -138,9 +138,9 @@ if command -v keytool >/dev/null 2>&1; then
       fi
       if [ ! -e "$java_cacerts" ] &&
         [ -s "/etc/ssl/certs/java/cacerts" ] &&
-        [ -w "$(dirname "$java_cacerts")" ]; then
-        cp /etc/ssl/certs/java/cacerts "$java_cacerts"
-        chmod 644 "$java_cacerts"
+        [ -w "$(/usr/bin/dirname "$java_cacerts")" ]; then
+        /usr/bin/cp /etc/ssl/certs/java/cacerts "$java_cacerts"
+        /usr/bin/chmod 644 "$java_cacerts"
       fi
     done
   fi

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -85,7 +85,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.31",
+      tag: "0.8.32",
     });
   });
 

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -161,6 +161,9 @@ describe("sandbox image registry", () => {
     const runCommands = getRunCommands(getDustBaseImageOperations());
     const staticRootConsumedDirs = SANDBOX_STATIC_ROOT_CONSUMED_DIRS.join(" ");
 
+    expect(SANDBOX_STATIC_ROOT_CONSUMED_DIRS).toContain(
+      "/usr/local/share/ca-certificates"
+    );
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
@@ -388,6 +391,17 @@ describe("sandbox image registry", () => {
     );
 
     expect(tmpfilesConfig).toBe("d /run/dust 0755 root root -\n");
+    expect(installer).toContain('openssl x509 -in "$CA_PATH" -noout');
+    expect(installer).toContain(
+      'install -d -o root -g root -m 755 "$SYSTEM_CA_DIR"'
+    );
+    expect(installer).toContain(
+      'find "$SYSTEM_CA_DIR" -mindepth 1 -maxdepth 1 -exec rm -rf'
+    );
+    expect(installer).toContain('rm -f "$SYSTEM_CA_DEST"');
+    expect(installer).toContain(
+      'install -o root -g root -m 644 "$CA_PATH" "$SYSTEM_CA_DEST"'
+    );
     expect(installer).toContain("update-ca-certificates");
     expect(installer).toContain('cat "$SYSTEM_CA_BUNDLE"');
     expect(installer).toContain('cat "$CA_PATH"');

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -81,6 +81,15 @@ function expectContentInOrder(
   expect(firstIndex).toBeLessThan(secondIndex);
 }
 
+function getCommandPath(command: string): string {
+  const result = spawnSync("sh", ["-c", `command -v ${command}`], {
+    encoding: "utf8",
+  });
+
+  expect(result.status).toBe(0);
+  return result.stdout.trim();
+}
+
 describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
@@ -405,24 +414,26 @@ describe("sandbox image registry", () => {
 
     expect(tmpfilesConfig).toBe("d /run/dust 0755 root root -\n");
     expect(installer).toContain(
-      'openssl x509 -in "$CA_PATH" -out "$normalized_ca_tmp" -outform PEM'
+      '/usr/bin/openssl x509 -in "$CA_PATH" -out "$normalized_ca_tmp" -outform PEM'
     );
     expect(installer).toContain(
-      'install -d -o root -g root -m 755 "$SYSTEM_CA_DIR"'
+      '/usr/bin/install -d -o root -g root -m 755 "$SYSTEM_CA_DIR"'
     );
     expect(installer).toContain(
-      'find "$SYSTEM_CA_DIR" -mindepth 1 -maxdepth 1 -exec rm -rf'
+      '/usr/bin/find "$SYSTEM_CA_DIR" -mindepth 1 -maxdepth 1 -exec /bin/rm -rf'
     );
-    expect(installer).toContain('rm -f "$SYSTEM_CA_DEST"');
+    expect(installer).toContain('/bin/rm -f "$SYSTEM_CA_DEST"');
     expect(installer).toContain(
-      'install -o root -g root -m 644 "$normalized_ca_tmp" "$SYSTEM_CA_DEST"'
+      '/usr/bin/install -o root -g root -m 644 "$normalized_ca_tmp" "$SYSTEM_CA_DEST"'
     );
-    expect(installer).toContain("update-ca-certificates");
-    expect(installer).toContain('cat "$SYSTEM_CA_BUNDLE"');
-    expect(installer).toContain('cat "$normalized_ca_tmp"');
+    expect(installer).toContain("/usr/sbin/update-ca-certificates");
+    expect(installer).toContain('/bin/cat "$SYSTEM_CA_BUNDLE"');
+    expect(installer).toContain('/bin/cat "$normalized_ca_tmp"');
     expect(installer).toContain("/etc/ssl/certs/java/cacerts");
-    expect(installer).toContain("if command -v keytool >/dev/null 2>&1");
-    expect(installer).toContain("keytool -importcert -noprompt -trustcacerts");
+    expect(installer).toContain("if [ -x /usr/bin/keytool ]; then");
+    expect(installer).toContain(
+      "/usr/bin/keytool -importcert -noprompt -trustcacerts"
+    );
     expect(installer).toContain("already exists");
   });
 
@@ -455,6 +466,18 @@ describe("sandbox image registry", () => {
     const caPath = join(runDustDir, "egress-ca.pem");
     const keyPath = join(runDustDir, "egress-ca.key");
     const leakedSecretPath = join(runDustDir, "egress-secrets.json");
+    const commandPaths = {
+      cat: getCommandPath("cat"),
+      chmod: getCommandPath("chmod"),
+      chown: getCommandPath("chown"),
+      find: getCommandPath("find"),
+      install: getCommandPath("install"),
+      mkdir: getCommandPath("mkdir"),
+      mktemp: getCommandPath("mktemp"),
+      mv: getCommandPath("mv"),
+      openssl: getCommandPath("openssl"),
+      rm: getCommandPath("rm"),
+    };
 
     try {
       mkdirSync(runDustDir, { recursive: true });
@@ -479,7 +502,7 @@ describe("sandbox image registry", () => {
       );
 
       const opensslResult = spawnSync(
-        "openssl",
+        commandPaths.openssl,
         [
           "req",
           "-x509",
@@ -514,13 +537,30 @@ describe("sandbox image registry", () => {
         )
         .replaceAll("/etc/dust", etcDustDir)
         .replaceAll("/etc/ssl/certs/java", javaCertsDir)
-        .replaceAll("install -d -o root -g root -m 755", "install -d -m 755")
-        .replaceAll("install -o root -g root -m 644", "install -m 644")
-        .replace('chown root:root "$SYSTEM_CA_DIR"', ":")
-        .replace(
-          "if command -v keytool >/dev/null 2>&1; then",
-          "if false; then"
-        );
+        .replaceAll(
+          "/usr/sbin/update-ca-certificates",
+          updateCaCertificatesStub
+        )
+        .replaceAll(
+          "/usr/bin/install -d -o root -g root -m 755",
+          "/usr/bin/install -d -m 755"
+        )
+        .replaceAll(
+          "/usr/bin/install -o root -g root -m 644",
+          "/usr/bin/install -m 644"
+        )
+        .replace('/usr/bin/chown root:root "$SYSTEM_CA_DIR"', ":")
+        .replace("if [ -x /usr/bin/keytool ]; then", "if false; then")
+        .replaceAll("/bin/cat", commandPaths.cat)
+        .replaceAll("/usr/bin/chmod", commandPaths.chmod)
+        .replaceAll("/usr/bin/chown", commandPaths.chown)
+        .replaceAll("/usr/bin/find", commandPaths.find)
+        .replaceAll("/usr/bin/install", commandPaths.install)
+        .replaceAll("/usr/bin/mkdir", commandPaths.mkdir)
+        .replaceAll("/usr/bin/mktemp", commandPaths.mktemp)
+        .replaceAll("/usr/bin/mv", commandPaths.mv)
+        .replaceAll("/usr/bin/openssl", commandPaths.openssl)
+        .replaceAll("/bin/rm", commandPaths.rm);
       const scriptPath = join(sandboxRoot, "install-trust-bundle.sh");
       writeFileSync(scriptPath, rewrittenInstaller);
 

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -1,3 +1,16 @@
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   SANDBOX_ROOT_SAFE_PATH,
   SANDBOX_STATIC_ROOT_CONSUMED_DIRS,
@@ -391,7 +404,9 @@ describe("sandbox image registry", () => {
     );
 
     expect(tmpfilesConfig).toBe("d /run/dust 0755 root root -\n");
-    expect(installer).toContain('openssl x509 -in "$CA_PATH" -noout');
+    expect(installer).toContain(
+      'openssl x509 -in "$CA_PATH" -out "$normalized_ca_tmp" -outform PEM'
+    );
     expect(installer).toContain(
       'install -d -o root -g root -m 755 "$SYSTEM_CA_DIR"'
     );
@@ -400,15 +415,144 @@ describe("sandbox image registry", () => {
     );
     expect(installer).toContain('rm -f "$SYSTEM_CA_DEST"');
     expect(installer).toContain(
-      'install -o root -g root -m 644 "$CA_PATH" "$SYSTEM_CA_DEST"'
+      'install -o root -g root -m 644 "$normalized_ca_tmp" "$SYSTEM_CA_DEST"'
     );
     expect(installer).toContain("update-ca-certificates");
     expect(installer).toContain('cat "$SYSTEM_CA_BUNDLE"');
-    expect(installer).toContain('cat "$CA_PATH"');
+    expect(installer).toContain('cat "$normalized_ca_tmp"');
     expect(installer).toContain("/etc/ssl/certs/java/cacerts");
     expect(installer).toContain("if command -v keytool >/dev/null 2>&1");
     expect(installer).toContain("keytool -importcert -noprompt -trustcacerts");
     expect(installer).toContain("already exists");
+  });
+
+  test("trust helper drops staged symlinks and normalizes the installed CA", () => {
+    const copyOperations = getCopyOperations(getDustBaseImageOperations());
+    const installer = getCopiedContent(
+      copyOperations,
+      "/usr/local/bin/dust-install-trust-bundle"
+    );
+    const sandboxRoot = mkdtempSync(join(tmpdir(), "dust-trust-helper-"));
+    const runDustDir = join(sandboxRoot, "run", "dust");
+    const etcDustDir = join(sandboxRoot, "etc", "dust");
+    const javaCertsDir = join(sandboxRoot, "etc", "ssl", "certs", "java");
+    const stubBinDir = join(sandboxRoot, "bin");
+    const systemCaDir = join(
+      sandboxRoot,
+      "usr",
+      "local",
+      "share",
+      "ca-certificates"
+    );
+    const systemCaBundle = join(
+      sandboxRoot,
+      "etc",
+      "ssl",
+      "certs",
+      "ca-certificates.crt"
+    );
+    const mergedBundle = join(etcDustDir, "ca-bundle.pem");
+    const caPath = join(runDustDir, "egress-ca.pem");
+    const keyPath = join(runDustDir, "egress-ca.key");
+    const leakedSecretPath = join(runDustDir, "egress-secrets.json");
+
+    try {
+      mkdirSync(runDustDir, { recursive: true });
+      mkdirSync(stubBinDir, { recursive: true });
+      mkdirSync(systemCaDir, { recursive: true });
+      mkdirSync(join(sandboxRoot, "etc", "ssl", "certs"), {
+        recursive: true,
+      });
+      chmodSync(systemCaDir, 0o777);
+      writeFileSync(systemCaBundle, "system-root\n");
+      const updateCaCertificatesStub = join(
+        stubBinDir,
+        "update-ca-certificates"
+      );
+      writeFileSync(updateCaCertificatesStub, "#!/bin/sh\nexit 0\n");
+      chmodSync(updateCaCertificatesStub, 0o755);
+      writeFileSync(leakedSecretPath, "DSEC_SECRET=should-not-leak\n");
+      symlinkSync(leakedSecretPath, join(systemCaDir, "secrets.crt"));
+      writeFileSync(
+        join(systemCaDir, "garbage.crt"),
+        "not a cert\nDSEC_GARBAGE=should-not-leak\n"
+      );
+
+      const opensslResult = spawnSync(
+        "openssl",
+        [
+          "req",
+          "-x509",
+          "-newkey",
+          "rsa:2048",
+          "-nodes",
+          "-keyout",
+          keyPath,
+          "-out",
+          caPath,
+          "-subj",
+          "/CN=dust-test",
+          "-days",
+          "1",
+        ],
+        { encoding: "utf8" }
+      );
+      expect(opensslResult.status).toBe(0);
+      writeFileSync(caPath, "\nDSEC_APPENDED=should-not-leak\n", {
+        flag: "a",
+      });
+
+      const rewrittenInstaller = installer
+        .replace('CA_PATH="/run/dust/egress-ca.pem"', `CA_PATH="${caPath}"`)
+        .replace(
+          'SYSTEM_CA_DIR="/usr/local/share/ca-certificates"',
+          `SYSTEM_CA_DIR="${systemCaDir}"`
+        )
+        .replace(
+          'SYSTEM_CA_BUNDLE="/etc/ssl/certs/ca-certificates.crt"',
+          `SYSTEM_CA_BUNDLE="${systemCaBundle}"`
+        )
+        .replaceAll("/etc/dust", etcDustDir)
+        .replaceAll("/etc/ssl/certs/java", javaCertsDir)
+        .replaceAll("install -d -o root -g root -m 755", "install -d -m 755")
+        .replaceAll("install -o root -g root -m 644", "install -m 644")
+        .replace('chown root:root "$SYSTEM_CA_DIR"', ":")
+        .replace(
+          "if command -v keytool >/dev/null 2>&1; then",
+          "if false; then"
+        );
+      const scriptPath = join(sandboxRoot, "install-trust-bundle.sh");
+      writeFileSync(scriptPath, rewrittenInstaller);
+
+      const runResult = spawnSync("bash", [scriptPath], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${stubBinDir}:${process.env.PATH ?? ""}`,
+        },
+      });
+
+      if (runResult.status !== 0) {
+        throw new Error(
+          `trust helper failed:\nstdout:\n${runResult.stdout}\nstderr:\n${runResult.stderr}`
+        );
+      }
+      const mergedBundleContent = readFileSync(mergedBundle, "utf8");
+      const installedCaContent = readFileSync(
+        join(systemCaDir, "dust-egress.crt"),
+        "utf8"
+      );
+
+      expect(readdirSync(systemCaDir)).toEqual(["dust-egress.crt"]);
+      expect(mergedBundleContent).toContain("system-root");
+      expect(mergedBundleContent).toContain("BEGIN CERTIFICATE");
+      expect(mergedBundleContent).not.toContain("DSEC_SECRET");
+      expect(mergedBundleContent).not.toContain("DSEC_GARBAGE");
+      expect(mergedBundleContent).not.toContain("DSEC_APPENDED");
+      expect(installedCaContent).not.toContain("DSEC_APPENDED");
+    } finally {
+      rmSync(sandboxRoot, { recursive: true, force: true });
+    }
   });
 });
 

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -19,7 +19,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.31";
+const DUST_BASE_IMAGE_VERSION = "0.8.32";
 const DSBX_CLI_VERSION = "0.1.23";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that


### PR DESCRIPTION
## Description

Harden the sandbox trust bundle install against the CA-dir symlink leak reported in the sandbox security work.

**Root cause:** `/usr/local/share/ca-certificates` could be writable by the sandbox user, and `update-ca-certificates` follows symlinks before rebuilding the world-readable `/etc/ssl/certs/ca-certificates.crt` bundle. A sandbox user could plant a symlink to `/run/dust/egress-secrets.json`, wait for resume, then read the secrets from the CA bundle.

**What changed:**
1. Reset `/usr/local/share/ca-certificates` to `root:root 755` before trust repair.
2. Clear staged entries before invoking `update-ca-certificates`.
3. Normalize the Dust egress CA through `openssl x509` before installing or concatenating it.
4. Apply the same hardening to the pre-0.8.8 inline fallback.
5. Add the CA staging dir to root-consumed path audits.
6. Bump `dust-base` from `0.8.31` to `0.8.32` so new sandboxes get the baked helper fix.

`dsbx` stays at `0.1.23`; this PR does not change the Rust CLI or require a new `dsbx` release.

> [!WARNING]
> `/usr/local/share/ca-certificates` is now Dust-owned staging. Custom entries there are removed when the trust bundle is repaired.

## Tests

Added regression coverage for the helper/fallback command generation, root-consumed directory audit, and helper behavior with staged symlinks, garbage files, and appended non-cert bytes. Tested locally:

- `bash -n front/lib/api/sandbox/image/egress/dust-install-trust-bundle.sh`
- `NODE_ENV=test npm test -- lib/api/sandbox/egress.test.ts`
- `NODE_ENV=test npm test -- lib/api/sandbox/image/registry.test.ts`
- `NODE_ENV=test npm test -- scripts/sandbox_security_check.test.ts`

## Risk

Worst case, a sandbox relying on custom local CA entries in `/usr/local/share/ca-certificates` loses them on resume. Safe to rollback, but rollback reopens the symlink leak.

## Deploy Plan

After merge to `main`:

1. Run GitHub workflow `Sandbox Image Registry` on `main` with `rebuild=false`. This should build the missing `dust-base:0.8.32` image in both EU and US E2B and run `sandbox_security_check.ts` against it.
2. Wait for `Sandbox Image Registry` to finish successfully.
3. Run GitHub workflow `Deploy` for component `front` and regions `all`. The deploy workflow also calls `Sandbox Image Registry`, but running the image workflow first makes the image build and security check explicit.

Do not run `Release dsbx CLI`; `DSBX_CLI_VERSION` is unchanged.