### PR TITLE
[front] add admin guard to programmatic-cost analytics endpoint

### DIFF
--- a/front-api/routes/w/[wId]/analytics/programmatic-cost.ts
+++ b/front-api/routes/w/[wId]/analytics/programmatic-cost.ts
@@ -4,6 +4,7 @@ import {
   ProgrammaticCostQuerySchema,
 } from "@app/lib/api/analytics/programmatic_cost";
 import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 
@@ -12,21 +13,26 @@ export type { GetWorkspaceProgrammaticCostResponse };
 // Mounted at /api/w/:wId/analytics/programmatic-cost.
 const app = workspaceApp();
 
-app.get("/", validate("query", ProgrammaticCostQuerySchema), async (ctx) => {
-  const auth = ctx.get("auth");
+app.get(
+  "/",
+  ensureIsAdmin(),
+  validate("query", ProgrammaticCostQuerySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
 
-  const result = await getProgrammaticCost(auth, ctx.req.valid("query"));
-  if (result.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: result.error.message,
-      },
-    });
+    const result = await getProgrammaticCost(auth, ctx.req.valid("query"));
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: result.error.message,
+        },
+      });
+    }
+
+    return ctx.json(result.value);
   }
-
-  return ctx.json(result.value);
-});
+);
 
 export default app;

--- a/front/pages/api/w/[wId]/analytics/programmatic-cost.ts
+++ b/front/pages/api/w/[wId]/analytics/programmatic-cost.ts
@@ -29,6 +29,16 @@ async function handler(
     });
   }
 
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
+      },
+    });
+  }
+
   const q = ProgrammaticCostQuerySchema.safeParse(req.query);
   if (!q.success) {
     return apiError(req, res, {


### PR DESCRIPTION
## Description

`GET /api/w/[wId]/analytics/programmatic-cost` had no authorization check beyond
session authentication, so any workspace member could call it directly and read
cost analytics surfaced only under admin UI tabs. Reported in
[this Slack thread](https://dust4ai.slack.com/archives/C06JQU5LFKM/p1779894508777449?thread_ts=1779894508.777449&cid=C06JQU5LFKM)
by @davidebbo.

Adds `auth.isAdmin()` (Next handler) and `ensureIsAdmin()` middleware (Hono
mirror) so non-admin callers now get a 403 `workspace_auth_error`, matching the
guard already in place on the other workspace analytics endpoints.

## Tests

- As a non-admin member, calling `GET /api/w/<wId>/analytics/programmatic-cost`
  returns 403.
- As an admin, the same call still returns the cost data.

## Risk

Low. The admin tabs in the UI already require admin role, so legitimate users
are unaffected. Behavior change is limited to non-admins, who now receive a 403
instead of analytics data.

## Deploy Plan

Standard deploy.
