### PR TITLE
[front] feat: add data model for skill references

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -64,6 +64,7 @@ import {
 } from "@app/lib/models/skill/conversation_skill";
 import { GroupSkillModel } from "@app/lib/models/skill/group_skill";
 import { SelfImprovingSkillsUsageModel } from "@app/lib/models/skill/self_improving_skills_usage";
+import { SkillReferenceModel } from "@app/lib/models/skill/skill_reference";
 import { SkillSuggestionModel } from "@app/lib/models/skill/skill_suggestion";
 import { TagModel } from "@app/lib/models/tags";
 import { WorkspaceSensitivityLabelConfigModel } from "@app/lib/models/workspace_sensitivity_label_config";
@@ -230,6 +231,7 @@ export function loadAllModels() {
     SkillDataSourceConfigurationModel,
     SkillVersionModel,
     GroupSkillModel,
+    SkillReferenceModel,
     AgentSkillModel,
     ConversationSkillModel,
     AgentMessageSkillModel,

--- a/front/lib/models/skill/skill_reference.ts
+++ b/front/lib/models/skill/skill_reference.ts
@@ -1,0 +1,88 @@
+import { SkillConfigurationModel } from "@app/lib/models/skill";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+import { DataTypes } from "sequelize";
+
+export class SkillReferenceModel extends WorkspaceAwareModel<SkillReferenceModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare parentSkillId: ForeignKey<SkillConfigurationModel["id"]>;
+  declare childSkillId: ForeignKey<SkillConfigurationModel["id"]>;
+}
+
+SkillReferenceModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    parentSkillId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      references: {
+        model: SkillConfigurationModel,
+        key: "id",
+      },
+    },
+    childSkillId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      references: {
+        model: SkillConfigurationModel,
+        key: "id",
+      },
+    },
+  },
+  {
+    modelName: "skill_reference",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        name: "skill_references_workspace_parent_child_idx",
+        fields: ["workspaceId", "parentSkillId", "childSkillId"],
+        unique: true,
+        concurrently: true,
+      },
+      {
+        name: "skill_references_parent_skill_id_idx",
+        fields: ["parentSkillId"],
+        concurrently: true,
+      },
+      {
+        name: "skill_references_child_skill_id_idx",
+        fields: ["childSkillId"],
+        concurrently: true,
+      },
+    ],
+  }
+);
+
+SkillReferenceModel.belongsTo(SkillConfigurationModel, {
+  foreignKey: { name: "parentSkillId", allowNull: false },
+  as: "parentSkill",
+  onDelete: "RESTRICT",
+});
+SkillConfigurationModel.hasMany(SkillReferenceModel, {
+  foreignKey: { name: "parentSkillId", allowNull: false },
+  as: "childSkillReferences",
+  onDelete: "RESTRICT",
+});
+
+SkillReferenceModel.belongsTo(SkillConfigurationModel, {
+  foreignKey: { name: "childSkillId", allowNull: false },
+  as: "childSkill",
+  onDelete: "RESTRICT",
+});
+SkillConfigurationModel.hasMany(SkillReferenceModel, {
+  foreignKey: { name: "childSkillId", allowNull: false },
+  as: "parentSkillReferences",
+  onDelete: "RESTRICT",
+});

--- a/front/migrations/pre-deploy/20260529094105_add_skill_references_table.sql
+++ b/front/migrations/pre-deploy/20260529094105_add_skill_references_table.sql
@@ -1,0 +1,109 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+CREATE SEQUENCE "public"."skill_references_id_seq"
+	AS bigint
+	INCREMENT BY 1
+	MINVALUE 1 MAXVALUE 9223372036854775807
+	START WITH 1 CACHE 1 NO CYCLE
+;
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+CREATE TABLE "public"."skill_references" (
+	"createdAt" timestamp with time zone NOT NULL,
+	"updatedAt" timestamp with time zone NOT NULL,
+	"parentSkillId" bigint NOT NULL,
+	"childSkillId" bigint NOT NULL,
+	"workspaceId" bigint NOT NULL,
+	"id" bigint DEFAULT nextval('skill_references_id_seq'::regclass) NOT NULL
+);
+
+/*
+Statement 2
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."skill_references" ADD CONSTRAINT "skill_references_childSkillId_fkey" FOREIGN KEY ("childSkillId") REFERENCES skill_configurations(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 3
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."skill_references" VALIDATE CONSTRAINT "skill_references_childSkillId_fkey";
+
+/*
+Statement 4
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."skill_references" ADD CONSTRAINT "skill_references_parentSkillId_fkey" FOREIGN KEY ("parentSkillId") REFERENCES skill_configurations(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 5
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."skill_references" VALIDATE CONSTRAINT "skill_references_parentSkillId_fkey";
+
+/*
+Statement 6
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY skill_references_pkey ON public.skill_references USING btree (id);
+
+/*
+Statement 7
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."skill_references" ADD CONSTRAINT "skill_references_pkey" PRIMARY KEY USING INDEX "skill_references_pkey";
+
+/*
+Statement 8
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY skill_references_child_skill_id_idx ON public.skill_references USING btree ("childSkillId");
+
+/*
+Statement 9
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY skill_references_parent_skill_id_idx ON public.skill_references USING btree ("parentSkillId");
+
+/*
+Statement 10
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY skill_references_workspace_parent_child_idx ON public.skill_references USING btree ("workspaceId", "parentSkillId", "childSkillId");
+
+/*
+Statement 11
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER SEQUENCE "public"."skill_references_id_seq" OWNED BY "public"."skill_references"."id";
+
+/*
+Statement 12
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."skill_references" ADD CONSTRAINT "skill_references_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES workspaces(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 13
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."skill_references" VALIDATE CONSTRAINT "skill_references_workspaceId_fkey";


### PR DESCRIPTION
## Description

- See design doc [here](https://app.notion.com/p/dust-tt/Design-doc-skill-cross-referencing-34228599d94180058e0ae958e70e6ee4?source=copy_link#34228599d9418002be1ac34aa8f0e5d5).
- This PR adds the data model for nested skills.

## Tests

- Migration ran locally.

## Risk

- Low, unused for now.

## Deploy Plan

- Run migration.
- Deploy front.
