### PR TITLE
feat: update initial members task and return error when user not found

### DIFF
--- a/front-api/routes/w/[wId]/pods/[podId]/tasks/seed.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/tasks/seed.test.ts
@@ -1,5 +1,5 @@
 import { Authenticator } from "@app/lib/auth";
-import { INITIAL_PROJECT_TASKS } from "@app/lib/project_task/initial_project_tasks";
+import { INITIAL_POD_TASKS } from "@app/lib/project_task/initial_project_tasks";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { honoApp } from "@front-api/app";
@@ -22,9 +22,9 @@ describe("POST /api/w/:wId/pods/:podId/tasks/seed", () => {
 
     expect(response.status).toBe(201);
     const body = await response.json();
-    expect(body.tasks).toHaveLength(INITIAL_PROJECT_TASKS.length);
+    expect(body.tasks).toHaveLength(INITIAL_POD_TASKS.length);
     expect(body.tasks.map((task: { text: string }) => task.text)).toEqual(
-      INITIAL_PROJECT_TASKS.map((seed) => seed.text)
+      INITIAL_POD_TASKS.map((seed) => seed.text)
     );
   });
 

--- a/front/lib/api/actions/servers/pod_manager/metadata.ts
+++ b/front/lib/api/actions/servers/pod_manager/metadata.ts
@@ -14,6 +14,7 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const POD_MANAGER_SERVER_NAME = "pod_manager" as const;
 export const UPDATE_MEMBERS_TOOL_NAME = "update_members" as const;
+export const LIST_MEMBERS_TOOL_NAME = "list_members" as const;
 
 export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
   add_content_node: {
@@ -100,7 +101,7 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
       done: "Edit Pod information",
     },
   },
-  update_members: {
+  [UPDATE_MEMBERS_TOOL_NAME]: {
     description:
       "Add or remove Pod members by user sId. Requires Pod editor permissions.",
     schema: {
@@ -146,7 +147,7 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
       done: "Get Pod information",
     },
   },
-  list_members: {
+  [LIST_MEMBERS_TOOL_NAME]: {
     description:
       "List members of the Pod. Each entry includes user ID, name, email and status within the Pod.",
     schema: {

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -20,7 +20,11 @@ import {
   makeSuccessResponse,
   withErrorHandling,
 } from "@app/lib/api/actions/servers/pod_manager/helpers";
-import { POD_MANAGER_TOOLS_METADATA } from "@app/lib/api/actions/servers/pod_manager/metadata";
+import {
+  LIST_MEMBERS_TOOL_NAME,
+  POD_MANAGER_TOOLS_METADATA,
+  UPDATE_MEMBERS_TOOL_NAME,
+} from "@app/lib/api/actions/servers/pod_manager/metadata";
 import { resolveAgentConfigurationIdByName } from "@app/lib/api/assistant/configuration/agent";
 import {
   createConversation,
@@ -317,7 +321,7 @@ export function createProjectManagerTools(
       }, "Failed to edit Pod information");
     },
 
-    update_members: async (params) => {
+    [UPDATE_MEMBERS_TOOL_NAME]: async (params) => {
       return withErrorHandling(async () => {
         const contextRes = await getProjectSpace(auth, {
           agentLoopContext,
@@ -462,7 +466,7 @@ export function createProjectManagerTools(
         );
       }, "Failed to get Pod information");
     },
-    list_members: async (params) => {
+    [LIST_MEMBERS_TOOL_NAME]: async (params) => {
       return withErrorHandling(async () => {
         const contextRes = await getProjectSpace(auth, {
           agentLoopContext,

--- a/front/lib/api/actions/servers/pod_tasks/metadata.ts
+++ b/front/lib/api/actions/servers/pod_tasks/metadata.ts
@@ -13,6 +13,7 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 export const POD_TASKS_SERVER_NAME = "pod_tasks" as const;
 export const CREATE_TASKS_TOOL_NAME = "create_tasks" as const;
 export const UPDATE_TASKS_TOOL_NAME = "update_tasks" as const;
+export const START_TASK_AGENT_TOOL_NAME = "start_task_agent" as const;
 
 export const POD_TASKS_TOOLS_METADATA = createToolsRecord({
   list_tasks: {
@@ -56,7 +57,7 @@ export const POD_TASKS_TOOLS_METADATA = createToolsRecord({
       done: "List tasks",
     },
   },
-  create_tasks: {
+  [CREATE_TASKS_TOOL_NAME]: {
     description:
       "Create one or more new tasks at once in the Pod. Omitting userId (or null) creates an unassigned task unless the Pod has exactly one assignable member, in which case that member is assigned. Pass userId when a specific person should own the task.",
     schema: PodTasksCreateTasksInputSchema.shape,
@@ -93,7 +94,7 @@ export const POD_TASKS_TOOLS_METADATA = createToolsRecord({
       done: "Mark tasks as done",
     },
   },
-  update_tasks: {
+  [UPDATE_TASKS_TOOL_NAME]: {
     description: "Update one or more existing tasks at once in the Pod.",
     schema: PodTasksUpdateTasksInputSchema.shape,
     stake: "low",
@@ -102,7 +103,7 @@ export const POD_TASKS_TOOLS_METADATA = createToolsRecord({
       done: "Update tasks",
     },
   },
-  start_task_agent: {
+  [START_TASK_AGENT_TOOL_NAME]: {
     description:
       "Start an agent conversation to work on one of your open tasks with status 'todo'. " +
       "If already started, it reuses the existing linked conversation.",

--- a/front/lib/api/actions/servers/pod_tasks/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_tasks/tools/index.ts
@@ -9,7 +9,12 @@ import {
   getProjectSpace,
   withErrorHandling,
 } from "@app/lib/api/actions/servers/pod_manager/helpers";
-import { POD_TASKS_TOOLS_METADATA } from "@app/lib/api/actions/servers/pod_tasks/metadata";
+import {
+  CREATE_TASKS_TOOL_NAME,
+  POD_TASKS_TOOLS_METADATA,
+  START_TASK_AGENT_TOOL_NAME,
+  UPDATE_TASKS_TOOL_NAME,
+} from "@app/lib/api/actions/servers/pod_tasks/metadata";
 import { inferProjectTaskSourceFromUrl } from "@app/lib/api/actions/servers/pod_tasks/source_utils";
 import { resolveAgentConfigurationIdByName } from "@app/lib/api/assistant/configuration/agent";
 import config from "@app/lib/api/config";
@@ -168,7 +173,7 @@ export function createProjectTasksTools(
       }, "Failed to list tasks");
     },
 
-    create_tasks: async ({ creatorType, tasks, dustPod }) => {
+    [CREATE_TASKS_TOOL_NAME]: async ({ creatorType, tasks, dustPod }) => {
       return withErrorHandling(async () => {
         const contextRes = await getProjectSpace(auth, {
           agentLoopContext,
@@ -336,7 +341,7 @@ export function createProjectTasksTools(
       }, "Failed to mark task as done");
     },
 
-    update_tasks: async ({ tasks, dustPod }) => {
+    [UPDATE_TASKS_TOOL_NAME]: async ({ tasks, dustPod }) => {
       return withErrorHandling(async () => {
         const contextRes = await getProjectSpace(auth, {
           agentLoopContext,
@@ -389,7 +394,12 @@ export function createProjectTasksTools(
       }, "Failed to update tasks");
     },
 
-    start_task_agent: async ({ taskId, agentName, customMessage, dustPod }) => {
+    [START_TASK_AGENT_TOOL_NAME]: async ({
+      taskId,
+      agentName,
+      customMessage,
+      dustPod,
+    }) => {
       return withErrorHandling(async () => {
         const contextRes = await getProjectSpace(auth, {
           agentLoopContext,

--- a/front/lib/project_task/initial_project_tasks.ts
+++ b/front/lib/project_task/initial_project_tasks.ts
@@ -23,7 +23,7 @@ export const INITIAL_PROJECT_TASKS: {
   {
     text: "👥 Search for and add Pod members",
     agentInstructions:
-      "Help the user identify the right collaborators for this Pod. Use people search or directory tools to find candidates by name, role, team, or expertise. Once you have good candidates, mention them by name in the conversation using @mention — this will show the user a dialog to add them to the Pod directly from the conversation. If the user needs an alternative, link them to the Pod settings page by appending `#settings` to the Pod URL.\n\n" +
+      "Help the user identify the right collaborators for this Pod. Use people search or directory tools to find candidates by name, role, team, or expertise. Present the shortlist to the user and, once they confirm, add the selected people to the Pod using the Pod `update_members` tool. Use `list_members` first if you need to check who is already on the Pod.\n\n" +
       NEXT_TASK_PROMPT,
   },
   {

--- a/front/lib/project_task/initial_project_tasks.ts
+++ b/front/lib/project_task/initial_project_tasks.ts
@@ -1,10 +1,20 @@
+import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
+import {
+  LIST_MEMBERS_TOOL_NAME,
+  POD_MANAGER_SERVER_NAME,
+  UPDATE_MEMBERS_TOOL_NAME,
+} from "@app/lib/api/actions/servers/pod_manager/metadata";
+import {
+  POD_TASKS_SERVER_NAME,
+  START_TASK_AGENT_TOOL_NAME,
+} from "@app/lib/api/actions/servers/pod_tasks/metadata";
+
 /** Seeded via POST /pods/:podId/tasks/seed (editors only). */
 export const PROJECT_MANAGER_AGENT_SID = "project_manager" as const;
 
-const NEXT_TASK_PROMPT =
-  "After the user agrees to mark this task done, check what other tasks are still open in the project. Propose tackling the most relevant next open one to the user. If they agree, use start_task_agent to kick off a conversation for it and share the conversation link in your reply.";
+const NEXT_TASK_PROMPT = `After the user agrees to mark this task done, check what other tasks are still open in the Pod. Propose tackling the most relevant next open one to the user. If they agree, use \`${getPrefixedToolName(POD_TASKS_SERVER_NAME, START_TASK_AGENT_TOOL_NAME)}\` to kick off a conversation for it and share the conversation link in your reply.`;
 
-export const INITIAL_PROJECT_TASKS: {
+export const INITIAL_POD_TASKS: {
   text: string;
   agentInstructions: string;
 }[] = [
@@ -23,7 +33,7 @@ export const INITIAL_PROJECT_TASKS: {
   {
     text: "👥 Search for and add Pod members",
     agentInstructions:
-      "Help the user identify the right collaborators for this Pod. Use people search or directory tools to find candidates by name, role, team, or expertise. Present the shortlist to the user and, once they confirm, add the selected people to the Pod using the Pod `update_members` tool. Use `list_members` first if you need to check who is already on the Pod.\n\n" +
+      `Help the user identify the right collaborators for this Pod. Use people search or directory tools to find candidates by name, role, team, or expertise. Present the shortlist to the user and, once they confirm, add the selected people to the Pod using the Pod \`${getPrefixedToolName(POD_MANAGER_SERVER_NAME, UPDATE_MEMBERS_TOOL_NAME)}\` tool. Use \`${getPrefixedToolName(POD_MANAGER_SERVER_NAME, LIST_MEMBERS_TOOL_NAME)}\` first if you need to check who is already on the Pod.\n\n` +
       NEXT_TASK_PROMPT,
   },
   {

--- a/front/lib/project_task/seed_initial_pod_tasks.ts
+++ b/front/lib/project_task/seed_initial_pod_tasks.ts
@@ -1,6 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import {
-  INITIAL_PROJECT_TASKS,
+  INITIAL_POD_TASKS,
   PROJECT_MANAGER_AGENT_SID,
 } from "@app/lib/project_task/initial_project_tasks";
 import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
@@ -33,7 +33,7 @@ export async function seedInitialPodTasks(
   }
 
   const assignee = auth.getNonNullableUser();
-  const initialTexts = new Set(INITIAL_PROJECT_TASKS.map((seed) => seed.text));
+  const initialTexts = new Set(INITIAL_POD_TASKS.map((seed) => seed.text));
   const existingTasks = await ProjectTaskResource.fetchBySpace(auth, {
     spaceId: space.id,
     timeScope: "active",
@@ -50,7 +50,7 @@ export async function seedInitialPodTasks(
   try {
     // Insert in reverse array order so the first-defined task is saved last and sorts
     // to the top under default client ordering (`updatedAt` desc).
-    for (const seed of INITIAL_PROJECT_TASKS.slice().reverse()) {
+    for (const seed of INITIAL_POD_TASKS.slice().reverse()) {
       const task = await ProjectTaskResource.makeNew(auth, {
         spaceId: space.id,
         userId: assignee.id,

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -968,9 +968,16 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     );
 
     const users = await UserResource.fetchByIds(userIds);
+    const foundIds = new Set(users.map((user) => user.sId));
+    const missingIds = userIds.filter((id) => !foundIds.has(id));
 
-    if (!users) {
-      return new Err(new DustError("user_not_found", "User not found."));
+    if (missingIds.length > 0) {
+      return new Err(
+        new DustError(
+          "user_not_found",
+          `User(s) not found: ${missingIds.join(", ")}`
+        )
+      );
     }
 
     const memberGroupSpaces = await GroupSpaceMemberResource.fetchBySpace({
@@ -1025,7 +1032,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     const users = await UserResource.fetchByIds(userIds);
 
     if (!users) {
-      return new Err(new DustError("user_not_found", "User not found."));
+      return new Err(new DustError("user_not_found", "User not found"));
     }
 
     // Get the GroupSpaceMemberResource for the member group


### PR DESCRIPTION
## Description

This PR updates the "Add Pod members" initial task agent instructions and fixes the user-not-found error handling in `SpaceResource`.

- Updates the agent instructions for the members task to use the `update_members` tool directly and `list_members` to check existing members, instead of relying on mentions.
- Fixes the user-not-found check in `addMembers`: replaces the incorrect `if (!users)` check (which was never triggered since `fetchByIds` always returns an array) with a diff-based check that identifies and reports missing user IDs.

## Tests

Manually.

## Risks

<!-- Discuss potential risks and how they will be mitigated. -->

## Deploy Plan

<!-- Outline the deployment steps. -->

