### PR TITLE
Subscription cancellation / resume UI

### DIFF
--- a/front/components/pages/workspace/subscription/MetronomeSubscriptionPanel.tsx
+++ b/front/components/pages/workspace/subscription/MetronomeSubscriptionPanel.tsx
@@ -62,7 +62,7 @@ interface CancelMetronomeSubscriptionDialogProps {
   periodEndLabel: string | null;
 }
 
-function CancelMetronomeSubscriptionDialog({
+export function CancelMetronomeSubscriptionDialog({
   show,
   onClose,
   onValidate,

--- a/front/components/workspace/billing/BillingOverview.tsx
+++ b/front/components/workspace/billing/BillingOverview.tsx
@@ -1,15 +1,24 @@
+import { CancelMetronomeSubscriptionDialog } from "@app/components/pages/workspace/subscription/MetronomeSubscriptionPanel";
+import { useCancelMetronomeContract } from "@app/hooks/useMetronomeContractLifecycleAction";
 import { getPriceAsString } from "@app/lib/client/subscription";
+import { useSubmitFunction } from "@app/lib/client/utils";
+import { isBusinessPlanPrefix } from "@app/lib/plans/plan_codes";
+import { useAppRouter } from "@app/lib/platform";
 import { useMetronomeInvoice } from "@app/lib/swr/workspaces";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { SubscriptionType } from "@app/types/plan";
+import { isSubscriptionMetronomeBilled } from "@app/types/plan";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   ActionCalendarIcon,
   ArrowUpOnSquareIcon,
+  Button,
   HistoryIcon,
   Icon,
   Spinner,
 } from "@dust-tt/sparkle";
+import { useState } from "react";
 
 interface BillingOverviewProps {
   owner: LightWorkspaceType;
@@ -21,10 +30,39 @@ function formatBillingPeriod(period: string): string {
 }
 
 export function BillingOverview({ owner, subscription }: BillingOverviewProps) {
+  const router = useAppRouter();
+  const [showCancelDialog, setShowCancelDialog] = useState(false);
+
   const { invoice, isMetronomeInvoiceLoading } = useMetronomeInvoice({
     workspaceId: owner.sId,
     disabled: !subscription.metronomeContractId,
   });
+  const { cancelMetronomeContract, isCancellingMetronomeContract } =
+    useCancelMetronomeContract({
+      workspaceId: owner.sId,
+    });
+  const { submit: cancelSubscription, isSubmitting: isCancelling } =
+    useSubmitFunction(async () => {
+      try {
+        const success = await cancelMetronomeContract();
+        if (success) {
+          router.reload();
+        }
+      } finally {
+        setShowCancelDialog(false);
+      }
+    });
+
+  const canCancelSubscription =
+    isSubscriptionMetronomeBilled(subscription) &&
+    isBusinessPlanPrefix(subscription.plan.code) &&
+    subscription.endDate === null &&
+    subscription.requestCancelAt === null;
+  const isCancellingSubscription =
+    isCancelling || isCancellingMetronomeContract;
+  const periodEndLabel = invoice
+    ? formatTimestampToFriendlyDate(invoice.currentPeriodEndMs, "short")
+    : null;
 
   if (isMetronomeInvoiceLoading) {
     return (
@@ -35,48 +73,77 @@ export function BillingOverview({ owner, subscription }: BillingOverviewProps) {
   }
 
   return (
-    <div className="flex flex-col gap-4 rounded-lg bg-muted-background p-4 dark:bg-muted-background-night">
-      <div className="flex items-center gap-2">
-        <div className="truncate text-base font-semibold text-foreground dark:text-foreground-night">
-          {subscription.plan.name}
-        </div>
-        <div className="rounded-md bg-gray-100 px-2 py-1 text-xs text-gray-900 dark:bg-gray-100-night dark:text-gray-900-night">
-          Current
-        </div>
-      </div>
+    <>
+      <CancelMetronomeSubscriptionDialog
+        show={showCancelDialog}
+        onClose={() => setShowCancelDialog(false)}
+        onValidate={cancelSubscription}
+        isSaving={isCancellingSubscription}
+        periodEndLabel={periodEndLabel}
+      />
 
-      {invoice ? (
-        <div className="flex flex-col gap-2 text-xs text-muted-foreground dark:text-muted-foreground-night">
-          <div className="flex items-center gap-2">
-            <Icon visual={HistoryIcon} size="xs" />
-            <span>Frequency: {formatBillingPeriod(invoice.billingPeriod)}</span>
+      <div className="flex flex-col gap-4 rounded-lg bg-muted-background p-4 dark:bg-muted-background-night">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex min-w-0 items-center gap-2">
+            <div className="truncate text-base font-semibold text-foreground dark:text-foreground-night">
+              {subscription.plan.name}
+            </div>
+            <div className="rounded-md bg-gray-100 px-2 py-1 text-xs text-gray-900 dark:bg-gray-100-night dark:text-gray-900-night">
+              Current
+            </div>
           </div>
-          <div className="flex items-center gap-2">
-            <Icon visual={ActionCalendarIcon} size="xs" />
-            <span>
-              Next billing date:{" "}
-              {formatTimestampToFriendlyDate(
-                invoice.currentPeriodEndMs,
-                "short"
+          {canCancelSubscription && (
+            <Button
+              label="Cancel subscription"
+              size="sm"
+              variant="outline"
+              disabled={isCancellingSubscription}
+              onClick={withTracking(
+                TRACKING_AREAS.AUTH,
+                "subscription_cancel",
+                () => {
+                  setShowCancelDialog(true);
+                }
               )}
-            </span>
-          </div>
-          <div className="flex items-center gap-2">
-            <Icon visual={ArrowUpOnSquareIcon} size="xs" />
-            <span>
-              Amount:{" "}
-              {getPriceAsString({
-                currency: invoice.currency,
-                priceInCents: invoice.estimatedAmountCents,
-              })}
-            </span>
-          </div>
+            />
+          )}
         </div>
-      ) : (
-        <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-          No billing information available for this period yet.
-        </div>
-      )}
-    </div>
+
+        {invoice ? (
+          <div className="flex flex-col gap-2 text-xs text-muted-foreground dark:text-muted-foreground-night">
+            <div className="flex items-center gap-2">
+              <Icon visual={HistoryIcon} size="xs" />
+              <span>
+                Frequency: {formatBillingPeriod(invoice.billingPeriod)}
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Icon visual={ActionCalendarIcon} size="xs" />
+              <span>
+                Next billing date:{" "}
+                {formatTimestampToFriendlyDate(
+                  invoice.currentPeriodEndMs,
+                  "short"
+                )}
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Icon visual={ArrowUpOnSquareIcon} size="xs" />
+              <span>
+                Amount:{" "}
+                {getPriceAsString({
+                  currency: invoice.currency,
+                  priceInCents: invoice.estimatedAmountCents,
+                })}
+              </span>
+            </div>
+          </div>
+        ) : (
+          <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+            No billing information available for this period yet.
+          </div>
+        )}
+      </div>
+    </>
   );
 }

--- a/front/components/workspace/billing/BillingOverview.tsx
+++ b/front/components/workspace/billing/BillingOverview.tsx
@@ -1,5 +1,8 @@
 import { CancelMetronomeSubscriptionDialog } from "@app/components/pages/workspace/subscription/MetronomeSubscriptionPanel";
-import { useCancelMetronomeContract } from "@app/hooks/useMetronomeContractLifecycleAction";
+import {
+  useCancelMetronomeContract,
+  useReactivateMetronomeContract,
+} from "@app/hooks/useMetronomeContractLifecycleAction";
 import { getPriceAsString } from "@app/lib/client/subscription";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { isBusinessPlanPrefix } from "@app/lib/plans/plan_codes";
@@ -41,6 +44,10 @@ export function BillingOverview({ owner, subscription }: BillingOverviewProps) {
     useCancelMetronomeContract({
       workspaceId: owner.sId,
     });
+  const { reactivateMetronomeContract, isReactivatingMetronomeContract } =
+    useReactivateMetronomeContract({
+      workspaceId: owner.sId,
+    });
   const { submit: cancelSubscription, isSubmitting: isCancelling } =
     useSubmitFunction(async () => {
       try {
@@ -52,14 +59,26 @@ export function BillingOverview({ owner, subscription }: BillingOverviewProps) {
         setShowCancelDialog(false);
       }
     });
+  const { submit: reactivateSubscription, isSubmitting: isReactivating } =
+    useSubmitFunction(async () => {
+      const success = await reactivateMetronomeContract();
+      if (success) {
+        router.reload();
+      }
+    });
 
-  const canCancelSubscription =
+  const isCancellablePlan =
     isSubscriptionMetronomeBilled(subscription) &&
-    isBusinessPlanPrefix(subscription.plan.code) &&
-    subscription.endDate === null &&
-    subscription.requestCancelAt === null;
+    isBusinessPlanPrefix(subscription.plan.code);
+  const isCancellationScheduled =
+    subscription.endDate !== null || subscription.requestCancelAt !== null;
+  const canCancelSubscription = isCancellablePlan && !isCancellationScheduled;
+  const canReactivateSubscription =
+    isCancellablePlan && isCancellationScheduled;
   const isCancellingSubscription =
     isCancelling || isCancellingMetronomeContract;
+  const isReactivatingSubscription =
+    isReactivating || isReactivatingMetronomeContract;
   const periodEndLabel = invoice
     ? formatTimestampToFriendlyDate(invoice.currentPeriodEndMs, "short")
     : null;
@@ -92,7 +111,21 @@ export function BillingOverview({ owner, subscription }: BillingOverviewProps) {
               Current
             </div>
           </div>
-          {canCancelSubscription && (
+          {canReactivateSubscription ? (
+            <Button
+              label="Resume subscription"
+              size="sm"
+              variant="highlight"
+              disabled={isReactivatingSubscription}
+              onClick={withTracking(
+                TRACKING_AREAS.AUTH,
+                "subscription_reactivate",
+                () => {
+                  void reactivateSubscription();
+                }
+              )}
+            />
+          ) : canCancelSubscription ? (
             <Button
               label="Cancel subscription"
               size="sm"
@@ -106,7 +139,7 @@ export function BillingOverview({ owner, subscription }: BillingOverviewProps) {
                 }
               )}
             />
-          )}
+          ) : null}
         </div>
 
         {invoice ? (

--- a/front/components/workspace/billing/BillingOverview.tsx
+++ b/front/components/workspace/billing/BillingOverview.tsx
@@ -72,15 +72,24 @@ export function BillingOverview({ owner, subscription }: BillingOverviewProps) {
     isBusinessPlanPrefix(subscription.plan.code);
   const isCancellationScheduled =
     subscription.endDate !== null || subscription.requestCancelAt !== null;
+  const subscriptionEndsAtMs =
+    subscription.endDate ??
+    (isCancellationScheduled ? (invoice?.currentPeriodEndMs ?? null) : null);
   const canCancelSubscription = isCancellablePlan && !isCancellationScheduled;
   const canReactivateSubscription =
-    isCancellablePlan && isCancellationScheduled;
+    isCancellablePlan &&
+    isCancellationScheduled &&
+    subscriptionEndsAtMs !== null &&
+    subscriptionEndsAtMs > Date.now();
   const isCancellingSubscription =
     isCancelling || isCancellingMetronomeContract;
   const isReactivatingSubscription =
     isReactivating || isReactivatingMetronomeContract;
   const periodEndLabel = invoice
     ? formatTimestampToFriendlyDate(invoice.currentPeriodEndMs, "short")
+    : null;
+  const subscriptionEndLabel = subscriptionEndsAtMs
+    ? formatTimestampToFriendlyDate(subscriptionEndsAtMs, "short")
     : null;
 
   if (isMetronomeInvoiceLoading) {
@@ -107,8 +116,14 @@ export function BillingOverview({ owner, subscription }: BillingOverviewProps) {
             <div className="truncate text-base font-semibold text-foreground dark:text-foreground-night">
               {subscription.plan.name}
             </div>
-            <div className="rounded-md bg-gray-100 px-2 py-1 text-xs text-gray-900 dark:bg-gray-100-night dark:text-gray-900-night">
-              Current
+            <div
+              className={
+                isCancellationScheduled
+                  ? "rounded-md bg-warning-100 px-2 py-1 text-xs text-warning-900 dark:bg-warning-100-night dark:text-warning-900-night"
+                  : "rounded-md bg-gray-100 px-2 py-1 text-xs text-gray-900 dark:bg-gray-100-night dark:text-gray-900-night"
+              }
+            >
+              {isCancellationScheduled ? "Cancelled" : "Current"}
             </div>
           </div>
           {canReactivateSubscription ? (
@@ -144,22 +159,30 @@ export function BillingOverview({ owner, subscription }: BillingOverviewProps) {
 
         {invoice ? (
           <div className="flex flex-col gap-2 text-xs text-muted-foreground dark:text-muted-foreground-night">
+            {subscriptionEndLabel && (
+              <div className="flex items-center gap-2 font-semibold text-foreground dark:text-foreground-night">
+                <Icon visual={ActionCalendarIcon} size="xs" />
+                <span>Subscription end: {subscriptionEndLabel}</span>
+              </div>
+            )}
             <div className="flex items-center gap-2">
               <Icon visual={HistoryIcon} size="xs" />
               <span>
                 Frequency: {formatBillingPeriod(invoice.billingPeriod)}
               </span>
             </div>
-            <div className="flex items-center gap-2">
-              <Icon visual={ActionCalendarIcon} size="xs" />
-              <span>
-                Next billing date:{" "}
-                {formatTimestampToFriendlyDate(
-                  invoice.currentPeriodEndMs,
-                  "short"
-                )}
-              </span>
-            </div>
+            {!isCancellationScheduled && (
+              <div className="flex items-center gap-2">
+                <Icon visual={ActionCalendarIcon} size="xs" />
+                <span>
+                  Next billing date:{" "}
+                  {formatTimestampToFriendlyDate(
+                    invoice.currentPeriodEndMs,
+                    "short"
+                  )}
+                </span>
+              </div>
+            )}
             <div className="flex items-center gap-2">
               <Icon visual={ArrowUpOnSquareIcon} size="xs" />
               <span>

--- a/front/lib/plans/plan_codes.ts
+++ b/front/lib/plans/plan_codes.ts
@@ -58,6 +58,9 @@ export const isFriendsAndFamilyPlan = (planCode: string) =>
 export const isCreditPricedBusinessPlan = (planCode: string) =>
   planCode === CREDIT_PRICED_BUSINESS_PLAN_CODE;
 
+export const isBusinessPlanPrefix = (planCode: string) =>
+  planCode.startsWith("CP_BUSINESS_");
+
 // Everything else is free
 export const isFreePlan = (planCode: string) =>
   !isEntreprisePlanPrefix(planCode) &&


### PR DESCRIPTION
## Description

Subscription cancellation (and resume) UI. Only available for `isBusinessPlanPrefix`. Resume only available if `now < endDate`.

Work for https://github.com/dust-tt/tasks/issues/7481

<img width="1223" height="1322" alt="Screenshot 2026-05-28 at 18 04 26" src="https://github.com/user-attachments/assets/aeb26816-57bf-40a7-bada-453b4b951601" />
<img width="1223" height="1322" alt="Screenshot 2026-05-28 at 18 04 31" src="https://github.com/user-attachments/assets/2400d62f-cf04-4091-9ec5-dcdb613984cf" />
<img width="1223" height="1322" alt="Screenshot 2026-05-28 at 18 04 41" src="https://github.com/user-attachments/assets/b9ae77a9-f7a3-46cd-a49d-1ebf390ecfee" />

Note: the state post cancellation was not designed. Pending a design from @ClementAupiais 

## Tests

Tested locally

## Risk

None

## Deploy Plan

- deploy `front`