### PR TITLE
feat: update migrate project to pods mountpath to check fetaure flag initially

### DIFF
--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -8,6 +8,7 @@ import {
   CONVERSATIONS_RETENTION_MIN_DAYS,
   isValidConversationsRetentionDays,
 } from "@app/lib/conversations_retention";
+import { FeatureFlagModel } from "@app/lib/models/feature_flag";
 import type { ResourceLogJSON } from "@app/lib/resources/base_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
@@ -28,6 +29,7 @@ import { MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
 import type { EmbeddingProviderIdType } from "@app/types/assistant/models/types";
 import type { WorkspacePoolCreditState } from "@app/types/credits";
 import { WORKSPACE_CACHE_KEY_VERSION } from "@app/types/shared/cache_resource_registry";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -451,6 +453,31 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
       },
     });
     return workspaces.map((w) => w.id);
+  }
+
+  static async listWithFeatureFlag(
+    name: WhitelistableFeature
+  ): Promise<WorkspaceResource[]> {
+    const flagRows = await FeatureFlagModel.findAll({
+      attributes: ["workspaceId"],
+      where: {
+        name,
+      },
+      // WORKSPACE_ISOLATION_BYPASS: cross-workspace listing of workspaces with a given feature flag enabled.
+      // @ts-expect-error -- Cross-workspace query by design.
+      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
+    });
+    const workspaceModelIds = Array.from(
+      new Set(flagRows.map((f) => f.workspaceId))
+    );
+    if (workspaceModelIds.length === 0) {
+      return [];
+    }
+    const workspaces = await this.model.findAll({
+      where: { id: { [Op.in]: workspaceModelIds } },
+    });
+    return workspaces.map((w) => new this(this.model, w.get()));
   }
 
   async updateSegmentation(segmentation: WorkspaceSegmentationType) {

--- a/front/scripts/migrate_project_mount_paths_to_pods.ts
+++ b/front/scripts/migrate_project_mount_paths_to_pods.ts
@@ -89,7 +89,9 @@ makeScript(
       const resources = await WorkspaceResource.fetchByModelIds(
         enabledWorkspaceModelIds
       );
-      workspaces = resources.map((w) => ({ id: w.id, sId: w.sId }));
+      workspaces = resources
+        .map((w) => ({ id: w.id, sId: w.sId }))
+        .sort((a, b) => a.id - b.id);
     }
 
     logger.info(

--- a/front/scripts/migrate_project_mount_paths_to_pods.ts
+++ b/front/scripts/migrate_project_mount_paths_to_pods.ts
@@ -7,7 +7,7 @@
 // carries the /projects/ prefix, rewrite it to /pods/.
 
 import { toPodMountFilePath } from "@app/lib/api/files/mount_path";
-import { FeatureFlagModel } from "@app/lib/models/feature_flag";
+import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
 import { FileModel } from "@app/lib/resources/storage/models/files";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -25,10 +25,6 @@ makeScript(
       type: "string",
       describe: "Workspace sId to migrate. Omit to run on all workspaces.",
     },
-    fromWorkspaceModelId: {
-      type: "number",
-      describe: "Skip workspaces with model id below this value, for resuming.",
-    },
     batchSize: {
       type: "number",
       default: BATCH_SIZE_DEFAULT,
@@ -40,12 +36,9 @@ makeScript(
       describe: "Concurrent DB updates per batch.",
     },
   },
-  async (
-    { execute, wId, fromWorkspaceModelId, batchSize, concurrency },
-    logger
-  ) => {
+  async ({ execute, wId, batchSize, concurrency }, logger) => {
     logger.info(
-      { execute, wId, fromWorkspaceModelId, batchSize, concurrency },
+      { execute, wId, batchSize, concurrency },
       "[migrate_project_mount_paths_to_pods] Starting"
     );
 
@@ -57,10 +50,10 @@ makeScript(
       if (!workspace) {
         throw new Error(`Workspace not found: ${wId}`);
       }
-      const hasProjectsFlag = await FeatureFlagModel.findOne({
-        attributes: ["workspaceId"],
-        where: { name: "projects", workspaceId: workspace.id },
-      });
+      const hasProjectsFlag = await FeatureFlagResource.isEnabledForWorkspace(
+        workspace,
+        "projects"
+      );
       if (!hasProjectsFlag) {
         logger.info(
           { workspaceId: workspace.sId },
@@ -70,28 +63,8 @@ makeScript(
       }
       workspaces = [{ id: workspace.id, sId: workspace.sId }];
     } else {
-      const flagRows = await FeatureFlagModel.findAll({
-        attributes: ["workspaceId"],
-        where: {
-          name: "projects",
-          ...(fromWorkspaceModelId
-            ? { workspaceId: { [Op.gte]: fromWorkspaceModelId } }
-            : {}),
-        },
-        // WORKSPACE_ISOLATION_BYPASS: cross-workspace migration script that lists workspace IDs with the `projects` flag.
-        // @ts-expect-error -- Script operates across all workspaces.
-        // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
-        dangerouslyBypassWorkspaceIsolationSecurity: true,
-      });
-      const enabledWorkspaceModelIds = Array.from(
-        new Set(flagRows.map((f) => f.workspaceId))
-      );
-      const resources = await WorkspaceResource.fetchByModelIds(
-        enabledWorkspaceModelIds
-      );
-      workspaces = resources
-        .map((w) => ({ id: w.id, sId: w.sId }))
-        .sort((a, b) => a.id - b.id);
+      const resources = await WorkspaceResource.listWithFeatureFlag("projects");
+      workspaces = resources.map((w) => ({ id: w.id, sId: w.sId }));
     }
 
     logger.info(

--- a/front/scripts/migrate_project_mount_paths_to_pods.ts
+++ b/front/scripts/migrate_project_mount_paths_to_pods.ts
@@ -7,11 +7,11 @@
 // carries the /projects/ prefix, rewrite it to /pods/.
 
 import { toPodMountFilePath } from "@app/lib/api/files/mount_path";
-import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
+import { FeatureFlagModel } from "@app/lib/models/feature_flag";
 import { FileModel } from "@app/lib/resources/storage/models/files";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { makeScript } from "@app/scripts/helpers";
-import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 import type { ModelId } from "@app/types/shared/model_id";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { Op } from "sequelize";
@@ -49,21 +49,57 @@ makeScript(
       "[migrate_project_mount_paths_to_pods] Starting"
     );
 
-    await runOnAllWorkspaces(
-      async (workspace) => {
-        const auth = await Authenticator.internalBuilderForWorkspace(
-          workspace.sId
+    // Pre-filter to workspaces that have the `projects` feature flag enabled.
+    // Most workspaces do not, so this avoids paying per-workspace overhead for them.
+    let workspaces: { id: ModelId; sId: string }[];
+    if (wId) {
+      const workspace = await WorkspaceResource.fetchById(wId);
+      if (!workspace) {
+        throw new Error(`Workspace not found: ${wId}`);
+      }
+      const hasProjectsFlag = await FeatureFlagModel.findOne({
+        attributes: ["workspaceId"],
+        where: { name: "projects", workspaceId: workspace.id },
+      });
+      if (!hasProjectsFlag) {
+        logger.info(
+          { workspaceId: workspace.sId },
+          "[migrate_project_mount_paths_to_pods] Workspace does not have `projects` FF enabled, nothing to do"
         );
+        return;
+      }
+      workspaces = [{ id: workspace.id, sId: workspace.sId }];
+    } else {
+      const flagRows = await FeatureFlagModel.findAll({
+        attributes: ["workspaceId"],
+        where: {
+          name: "projects",
+          ...(fromWorkspaceModelId
+            ? { workspaceId: { [Op.gte]: fromWorkspaceModelId } }
+            : {}),
+        },
+        // WORKSPACE_ISOLATION_BYPASS: cross-workspace migration script that lists workspace IDs with the `projects` flag.
+        // @ts-expect-error -- Script operates across all workspaces.
+        // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+        dangerouslyBypassWorkspaceIsolationSecurity: true,
+      });
+      const enabledWorkspaceModelIds = Array.from(
+        new Set(flagRows.map((f) => f.workspaceId))
+      );
+      const resources = await WorkspaceResource.fetchByModelIds(
+        enabledWorkspaceModelIds
+      );
+      workspaces = resources.map((w) => ({ id: w.id, sId: w.sId }));
+    }
 
-        const hasProjectEnabled = await hasFeatureFlag(auth, "projects");
-        if (!hasProjectEnabled) {
-          logger.info(
-            { workspaceId: workspace.sId },
-            "[migrate_project_mount_paths_to_pods] Workspace does not have `projects` FF enabled, skipping"
-          );
-          return;
-        }
+    logger.info(
+      { workspaceCount: workspaces.length },
+      "[migrate_project_mount_paths_to_pods] Workspaces with `projects` FF enabled"
+    );
 
+    await concurrentExecutor(
+      workspaces,
+      async (workspace) => {
         logger.info(
           { workspaceId: workspace.sId, execute },
           "[migrate_project_mount_paths_to_pods] Starting workspace"
@@ -180,7 +216,7 @@ makeScript(
           "[migrate_project_mount_paths_to_pods] Workspace files done"
         );
       },
-      { wId, fromWorkspaceId: fromWorkspaceModelId }
+      { concurrency }
     );
 
     logger.info(


### PR DESCRIPTION
## Description

This PR updates the `migrate_project_mount_paths_to_pods` script to pre-filter workspaces by the `projects` feature flag at the start, avoiding unnecessary per-workspace processing for workspaces that don't have the flag enabled.

- Queries `FeatureFlagModel` upfront to get only workspaces with the `projects` flag, then runs the migration only on those instead of checking the flag per workspace inside `runOnAllWorkspaces`.
- Handles both single-workspace (`wId`) and all-workspaces cases with the pre-filter logic.

## Tests

Manually.

## Risks

<!-- Discuss potential risks and how they will be mitigated. -->

## Deploy Plan

<!-- Outline the deployment steps. -->
