### PR TITLE
fix: prevent conversation SSE replay from wiping streamed message content

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -23,6 +23,7 @@ import {
   convertLightMessageTypeToVirtuosoMessages,
   getPredicateForRankAndBranch,
   isAgentMessageWithStreaming,
+  isAtInitialStreamState,
   isCompactionMessage,
   isConversationForkNotice,
   isUserMessage,
@@ -60,7 +61,6 @@ import {
   type ConversationForkedChildType,
   type ConversationListItemType,
   isLightAgentMessageType,
-  isTerminalAgentMessageStatus,
   isUserMessageTypeWithContentFragments,
 } from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
@@ -732,21 +732,30 @@ export const ConversationViewer = ({
                 virtuosoMessageListRef.current.data.find(predicate);
 
               if (exists) {
-                // On replay (e.g. after navigating away and coming back), the
-                // existing message may already reflect the final state from
-                // the SWR snapshot. The replayed event always carries the
-                // initial "created" payload, so replacing would downgrade the
-                // status (re-activating shouldStream and the message-events
-                // stream) and wipe inlineActivitySteps. Skip the replace only
-                // when the existing message is the same logical message (same
-                // sId) and already terminal. A retry creates a new sId at the
-                // same rank/branch, so it must still go through the replace.
-                const isReplayOfTerminalMessage =
+                // Guard against conversation SSE replays overwriting a message
+                // that the message-level SSE has already partially or fully
+                // streamed.
+                //
+                // Two independent SSE streams feed each message:
+                //   1. Conversation stream — carries agent_message_new (structural events)
+                //   2. Message stream      — carries generation_tokens, tool_* (content events)
+                //
+                // When the conversation stream drops and reconnects, the server
+                // replays agent_message_new with the message's original "created"
+                // payload: null content, agentState = "thinking", empty steps.
+                // Replacing the Virtuoso entry with that stale payload would wipe
+                // whatever the message stream already delivered, so we skip the
+                // replace when the existing entry is the same logical message
+                // (same sId) and has already progressed past its initial state.
+                //
+                // Retries carry a new sId at the same rank/branch, so they
+                // always fall through to the replace path.
+                const shouldSkipReplace =
                   isAgentMessageWithStreaming(exists) &&
                   exists.sId === agentMessage.sId &&
-                  isTerminalAgentMessageStatus(exists.status);
+                  !isAtInitialStreamState(exists);
 
-                if (!isReplayOfTerminalMessage) {
+                if (!shouldSkipReplace) {
                   virtuosoMessageListRef.current.data.map((m) =>
                     predicate(m) ? agentMessage : m
                   );

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -21,6 +21,7 @@ import {
   isHiddenMessageOrigin,
   isLightAgentMessageType,
   isLightAgentMessageWithActionsType,
+  isTerminalAgentMessageStatus,
   isUserMessageTypeWithContentFragments,
 } from "@app/types/assistant/conversation";
 
@@ -213,6 +214,39 @@ export const makeInitialMessageStreamState = (
       pendingToolCalls: [],
     },
   };
+};
+
+// Returns true when the message still matches the output of makeInitialMessageStreamState —
+// i.e. no SSE event has moved it beyond the initial "thinking" state yet.
+// The rest-spread exhaustiveness check below ensures that adding a new field to
+// AgentMessageWithStreaming["streaming"] without handling it here is a compile error.
+export const isAtInitialStreamState = (
+  msg: AgentMessageWithStreaming
+): boolean => {
+  const {
+    agentState,
+    isRetrying,
+    pendingToolCalls,
+    inlineActivitySteps,
+    actionProgress,
+    lastUpdated: _lastUpdated, // always "now" at creation; not comparable
+    ...rest
+  } = msg.streaming;
+
+  // Fails to compile if a new streaming field is added without an explicit
+  // decision about whether to check it here.
+  void (rest satisfies Record<PropertyKey, never>);
+
+  return (
+    !isTerminalAgentMessageStatus(msg.status) &&
+    msg.content === null &&
+    msg.chainOfThought === null &&
+    agentState === "thinking" &&
+    !isRetrying &&
+    pendingToolCalls.length === 0 &&
+    inlineActivitySteps.length === 0 &&
+    actionProgress.size === 0
+  );
 };
 
 export const isSidekickBootstrapMessage = (


### PR DESCRIPTION
## Description

Each conversation has two independent SSE streams: the **conversation stream** (structural events like `agent_message_new`) and the **message stream** (content events like `generation_tokens`, `tool_*`). When the conversation stream reconnects, the server replays `agent_message_new` with the message's original `"created"` payload. Replacing the Virtuoso entry with that stale payload wipes whatever the message stream already delivered.

**Fix:** skip the replace when the existing entry is the same logical message (same `sId`) and has already progressed past its initial state, via the new `isAtInitialStreamState` helper. At initial state the replace would be a no-op anyway — both the SSE payload and the existing Virtuoso entry derive from the same creation-time record. Retries always carry a new `sId` at the same rank/branch, so they still go through the replace path.

`isAtInitialStreamState` uses a rest-spread exhaustiveness check to ensure any future field added to `AgentMessageWithStreaming["streaming"]` produces a compile error if not explicitly handled.

## Tests

Locally it seems to work but I could not reproduce the issue. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 