### PR TITLE
Renamed paygCap, allow to enable payg without setting any cap

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
@@ -526,7 +526,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — guards", () => {
 });
 
 describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
-  it("persists paygCapCredits and syncs the Metronome alert when switching to enterprise with PAYG enabled", async () => {
+  it("persists usageCapCredits and syncs the Metronome alert when switching to enterprise with PAYG enabled", async () => {
     await ensureEnterprisePlan();
     const { workspace } = await createPrivateApiMockRequest({
       isSuperUser: true,
@@ -535,7 +535,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
 
     const response = await postSwitchContract(
       workspace.sId,
-      enterpriseBody({ paygEnabled: true, paygCapCredits: 50_000 })
+      enterpriseBody({ paygEnabled: true, usageCapCredits: 50_000 })
     );
 
     expect(response.status).toBe(200);
@@ -545,10 +545,10 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
     );
     const config =
       await CreditUsageConfigurationResource.fetchByWorkspaceId(adminAuth);
-    expect(config?.paygCapCredits).toBe(50_000);
+    expect(config?.usageCapCredits).toBe(50_000);
   });
 
-  it("persists paygCapCredits when switching to business with PAYG enabled", async () => {
+  it("persists usageCapCredits when switching to business with PAYG enabled", async () => {
     const { workspace } = await createPrivateApiMockRequest({
       isSuperUser: true,
     });
@@ -556,7 +556,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
 
     const response = await postSwitchContract(
       workspace.sId,
-      businessBody({ paygEnabled: true, paygCapCredits: 25_000 })
+      businessBody({ paygEnabled: true, usageCapCredits: 25_000 })
     );
 
     expect(response.status).toBe(200);
@@ -566,7 +566,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
     );
     const config =
       await CreditUsageConfigurationResource.fetchByWorkspaceId(adminAuth);
-    expect(config?.paygCapCredits).toBe(25_000);
+    expect(config?.usageCapCredits).toBe(25_000);
   });
 
   it("rejects PAYG on a pro contract", async () => {
@@ -577,7 +577,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
 
     const response = await postSwitchContract(
       workspace.sId,
-      proBody({ paygEnabled: true, paygCapCredits: 10_000 })
+      proBody({ paygEnabled: true, usageCapCredits: 10_000 })
     );
 
     expect(response.status).toBe(400);
@@ -586,7 +586,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
     expect(provisionMetronomeContract).not.toHaveBeenCalled();
   });
 
-  it("rejects when paygEnabled is true but paygCapCredits is missing", async () => {
+  it("accepts paygEnabled without a usage cap (no alert)", async () => {
     await ensureEnterprisePlan();
     const { workspace } = await createPrivateApiMockRequest({
       isSuperUser: true,
@@ -598,12 +598,18 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
       enterpriseBody({ paygEnabled: true })
     );
 
-    expect(response.status).toBe(400);
-    const data = await response.json();
-    expect(data.error.message).toContain("PAYG cap");
+    expect(response.status).toBe(200);
+
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const config =
+      await CreditUsageConfigurationResource.fetchByWorkspaceId(adminAuth);
+    expect(config?.paygEnabled).toBe(true);
+    expect(config?.usageCapCredits).toBeNull();
   });
 
-  it("clears paygCapCredits when paygEnabled is false", async () => {
+  it("preserves usageCapCredits when paygEnabled is toggled off", async () => {
     const { workspace } = await createPrivateApiMockRequest({
       isSuperUser: true,
     });
@@ -614,16 +620,21 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
     );
     await CreditUsageConfigurationResource.makeNew(adminAuth, {
       defaultDiscountPercent: 0,
-      paygCapCredits: 100_000,
+      paygEnabled: true,
+      usageCapCredits: 100_000,
       disableCreditCapWarning: false,
     });
 
-    const response = await postSwitchContract(workspace.sId, proBody());
+    const response = await postSwitchContract(
+      workspace.sId,
+      proBody({ usageCapCredits: 100_000 })
+    );
 
     expect(response.status).toBe(200);
 
     const config =
       await CreditUsageConfigurationResource.fetchByWorkspaceId(adminAuth);
-    expect(config?.paygCapCredits).toBeNull();
+    expect(config?.paygEnabled).toBe(false);
+    expect(config?.usageCapCredits).toBe(100_000);
   });
 });

--- a/front-api/routes/poke/workspaces/[wId]/switch_contract.ts
+++ b/front-api/routes/poke/workspaces/[wId]/switch_contract.ts
@@ -74,9 +74,12 @@ app.post(
     }
 
     const { metronomeContractId } = result.value;
-    const paygStatus = body.paygEnabled
-      ? ` PAYG enabled with a ${body.paygCapCredits} credit cap.`
-      : "";
+    const paygSummary = body.paygEnabled ? " PAYG enabled." : "";
+    const capSummary =
+      body.usageCapCredits !== undefined
+        ? ` Usage cap: ${body.usageCapCredits} credits.`
+        : "";
+    const paygStatus = `${paygSummary}${capSummary}`;
     await pluginRun.recordResult({
       display: "text",
       value:

--- a/front-api/routes/w/[wId]/credits/usage-configuration.ts
+++ b/front-api/routes/w/[wId]/credits/usage-configuration.ts
@@ -80,7 +80,8 @@ app.patch(
         auth,
         {
           defaultDiscountPercent: 0,
-          paygCapCredits: null,
+          paygEnabled: false,
+          usageCapCredits: null,
           disableCreditCapWarning: false,
           ...patch,
         }

--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -40,34 +40,19 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
-// PAYG cap is denominated in AWU credits and stored verbatim on
-// `credit_usage_configuration.paygCapCredits` — no fiat conversion.
-// Keep this in sync with `MAX_PAYG_CAP_CREDITS` in
-// `front/lib/api/poke/switch_contract.ts`.
-const MAX_PAYG_CAP_CREDITS = 2_000_000;
-
-const SwitchContractFormSchema = z
-  .object({
-    metronomePackageId: z.string().min(1, "Required"),
-    planCode: z.string().min(1, "Required"),
-    startingAt: z.string().optional(),
-    startImmediately: z.boolean().default(false),
-    stripeCustomerId: z.string(),
-    paygEnabled: z.boolean().default(false),
-    paygCapCredits: z
-      .number()
-      .int("PAYG cap must be an integer number of credits")
-      .min(1, "PAYG cap must be at least 1 credit")
-      .max(
-        MAX_PAYG_CAP_CREDITS,
-        `PAYG cap cannot exceed ${MAX_PAYG_CAP_CREDITS.toLocaleString()} credits`
-      )
-      .optional(),
-  })
-  .refine((data) => !data.paygEnabled || data.paygCapCredits !== undefined, {
-    message: "PAYG cap is required when Pay-as-you-go is enabled.",
-    path: ["paygCapCredits"],
-  });
+const SwitchContractFormSchema = z.object({
+  metronomePackageId: z.string().min(1, "Required"),
+  planCode: z.string().min(1, "Required"),
+  startingAt: z.string().optional(),
+  startImmediately: z.boolean().default(false),
+  stripeCustomerId: z.string(),
+  paygEnabled: z.boolean().default(false),
+  usageCapCredits: z
+    .number()
+    .int("Usage cap must be an integer number of credits")
+    .min(1, "Usage cap must be at least 1 credit")
+    .optional(),
+});
 type SwitchContractFormValues = z.infer<typeof SwitchContractFormSchema>;
 
 function snapDatetimeLocalToHour(value: string): string {
@@ -127,9 +112,9 @@ export default function SwitchContractDialog({
     );
   }, []);
 
-  // No prefilled PAYG cap: the legacy `programmatic_usage_configuration.paygCapMicroUsd`
+  // No prefilled usage cap: the legacy `programmatic_usage_configuration.paygCapMicroUsd`
   // is for the programmatic-usage / Stripe flow and must not be read here.
-  // The credit-priced PAYG cap lives on `credit_usage_configuration.paygCapCredits`
+  // The credit-priced usage cap lives on `credit_usage_configuration.usageCapCredits`
   // and is managed via the "Manage Credit Usage Configuration" plugin — operators
   // enter the desired cap (in AWU credits) fresh when switching contracts.
   const form = useForm<SwitchContractFormValues>({
@@ -141,7 +126,7 @@ export default function SwitchContractDialog({
       startImmediately: false,
       stripeCustomerId: stripeCustomerId ?? "",
       paygEnabled: false,
-      paygCapCredits: undefined,
+      usageCapCredits: undefined,
     },
   });
 
@@ -240,7 +225,7 @@ export default function SwitchContractDialog({
     }
     if (selectedTier && !isPaygEligibleTier(selectedTier)) {
       form.setValue("paygEnabled", false);
-      form.setValue("paygCapCredits", undefined);
+      form.setValue("usageCapCredits", undefined);
     }
   }, [selectedTier, selectedName, form, minStartingAtLocal]);
 
@@ -277,8 +262,8 @@ export default function SwitchContractDialog({
       if (trimmedStripe) {
         cleaned.stripeCustomerId = trimmedStripe;
       }
-      if (values.paygEnabled && values.paygCapCredits !== undefined) {
-        cleaned.paygCapCredits = values.paygCapCredits;
+      if (values.usageCapCredits !== undefined) {
+        cleaned.usageCapCredits = values.usageCapCredits;
       }
       if (
         selectedTier === "enterprise" &&
@@ -440,8 +425,8 @@ export default function SwitchContractDialog({
                   </div>
                 )}
                 {paygEligible && (
-                  <div className="border-t pt-4">
-                    <div className="mb-4 flex items-center gap-2">
+                  <div className="space-y-4 border-t pt-4">
+                    <div className="flex items-center gap-2">
                       <SliderToggle
                         selected={paygEnabled}
                         onClick={() =>
@@ -450,17 +435,13 @@ export default function SwitchContractDialog({
                       />
                       <Label className="text-sm">Pay-as-you-go</Label>
                     </div>
-                    {paygEnabled && (
-                      <div className="ml-6">
-                        <InputField
-                          control={form.control}
-                          name="paygCapCredits"
-                          title="PAYG Spending Cap (AWU credits)"
-                          type="number"
-                          placeholder="e.g., 100000"
-                        />
-                      </div>
-                    )}
+                    <InputField
+                      control={form.control}
+                      name="usageCapCredits"
+                      title="Usage Cap (AWU credits, optional)"
+                      type="number"
+                      placeholder="e.g., 100000 — leave empty for no alert"
+                    />
                   </div>
                 )}
                 <DialogFooter>

--- a/front/lib/api/credits/credit_based_payg.ts
+++ b/front/lib/api/credits/credit_based_payg.ts
@@ -1,8 +1,8 @@
 import type { Authenticator } from "@app/lib/auth";
 import {
-  clearMetronomePaygCapAlert,
-  upsertMetronomePaygCapAlert,
-} from "@app/lib/metronome/payg_alerts";
+  clearMetronomeUsageCapAlert,
+  upsertMetronomeUsageCapAlert,
+} from "@app/lib/metronome/alerts/usage_cap";
 import { setAwuContractExcessCreditsAmount } from "@app/lib/metronome/payg_excess_credits";
 import { DEFAULT_AWU_EXCESS_RECURRING_AMOUNT } from "@app/lib/metronome/types";
 import type { Result } from "@app/types/shared/result";
@@ -11,47 +11,48 @@ import { Err, Ok } from "@app/types/shared/result";
 /**
  * Apply the credit-based PAYG state to a workspace's Metronome customer.
  *
- * `paygCapCredits === null` means PAYG is disabled; any strictly-positive
- * value means PAYG is enabled at that cap. The function:
+ * `paygEnabled` and `usageCapCredits` are independent:
  *
- *  - upserts (enabled) or clears (disabled) the Metronome
- *    `spend_threshold_reached` alert,
- *  - zeroes (enabled) or restores (disabled) the AWU recurring "Excess
- *    Credits" credit on every active Metronome contract — when enabled
- *    overage past the workspace's free credit pool bills as PAYG instead
- *    of being absorbed silently.
+ *  - `paygEnabled` controls the AWU recurring "Excess Credits" credit on
+ *    every active Metronome contract — zeroed when PAYG is on so overage past
+ *    the workspace's free credit pool bills as PAYG instead of being absorbed
+ *    silently, restored to the default amount when PAYG is off.
+ *  - `usageCapCredits` (strictly positive when set) drives the Metronome
+ *    `spend_threshold_reached` alert: upserted when set, cleared when null.
+ *    Can be set with or without PAYG enabled.
  *
  * No-op when the workspace has no Metronome customer. The underlying
  * Metronome calls are idempotent.
  */
 export async function syncCreditBasedPayg({
   auth,
-  paygCapCredits,
+  paygEnabled,
+  usageCapCredits,
 }: {
   auth: Authenticator;
-  paygCapCredits: number | null;
+  paygEnabled: boolean;
+  usageCapCredits: number | null;
 }): Promise<Result<undefined, Error>> {
   const workspace = auth.getNonNullableWorkspace();
   if (!workspace.metronomeCustomerId) {
     return new Ok(undefined);
   }
 
-  const enabled = paygCapCredits !== null;
-
-  const alertResult = enabled
-    ? await upsertMetronomePaygCapAlert({
-        metronomeCustomerId: workspace.metronomeCustomerId,
-        paygCapCredits,
-        workspaceId: workspace.sId,
-      })
-    : await clearMetronomePaygCapAlert({
-        metronomeCustomerId: workspace.metronomeCustomerId,
-        workspaceId: workspace.sId,
-      });
+  const alertResult =
+    usageCapCredits !== null
+      ? await upsertMetronomeUsageCapAlert({
+          metronomeCustomerId: workspace.metronomeCustomerId,
+          usageCapCredits,
+          workspaceId: workspace.sId,
+        })
+      : await clearMetronomeUsageCapAlert({
+          metronomeCustomerId: workspace.metronomeCustomerId,
+          workspaceId: workspace.sId,
+        });
   if (alertResult.isErr()) {
     return new Err(
       new Error(
-        `Failed to sync Metronome PAYG cap alert: ${alertResult.error.message}`
+        `Failed to sync Metronome usage cap alert: ${alertResult.error.message}`
       )
     );
   }
@@ -59,12 +60,12 @@ export async function syncCreditBasedPayg({
   const excessResult = await setAwuContractExcessCreditsAmount({
     metronomeCustomerId: workspace.metronomeCustomerId,
     workspaceId: workspace.sId,
-    amount: enabled ? 0 : DEFAULT_AWU_EXCESS_RECURRING_AMOUNT,
+    amount: paygEnabled ? 0 : DEFAULT_AWU_EXCESS_RECURRING_AMOUNT,
   });
   if (excessResult.isErr()) {
     return new Err(
       new Error(
-        `Failed to ${enabled ? "disable" : "restore"} AWU recurring excess credits: ${excessResult.error.message}`
+        `Failed to ${paygEnabled ? "disable" : "restore"} AWU recurring excess credits: ${excessResult.error.message}`
       )
     );
   }

--- a/front/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration.ts
@@ -4,45 +4,30 @@ import { MAX_AWU_DISCOUNT_PERCENT } from "@app/lib/credits/awu_purchase_constant
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { isCreditPricedPlan } from "@app/types/plan";
 import { Err, Ok } from "@app/types/shared/result";
-import assert from "assert";
 import { z } from "zod";
 
-export const MAX_AWU_PAYG_CAP_CREDITS = 2_000_000;
+export const MAX_AWU_USAGE_CAP_CREDITS = 2_000_000;
 
-const CreditUsageConfigurationSchema = z
-  .object({
-    defaultDiscountPercent: z
-      .number()
-      .min(0, "Discount percentage must be at least 0")
-      .max(
-        MAX_AWU_DISCOUNT_PERCENT,
-        `Discount cannot exceed ${MAX_AWU_DISCOUNT_PERCENT}% for AWU credit purchases`
-      )
-      .default(0),
-    paygCapEnabled: z.boolean(),
-    // Lower bound is 0 (not 1) because the poke form sends `0` when the
-    // toggle is off; the refine below enforces `>= 1` only when enabled.
-    paygCapCredits: z
-      .number()
-      .int("AWU PAYG cap must be an integer number of credits")
-      .min(0, "AWU PAYG cap must be non-negative")
-      .max(
-        MAX_AWU_PAYG_CAP_CREDITS,
-        `AWU PAYG cap cannot exceed ${MAX_AWU_PAYG_CAP_CREDITS.toLocaleString()} credits`
-      )
-      .optional(),
-  })
-  .refine(
-    (data) =>
-      !(
-        data.paygCapEnabled &&
-        (data.paygCapCredits === undefined || data.paygCapCredits < 1)
-      ),
-    {
-      message: "AWU PAYG cap must be at least 1 credit when the cap is enabled",
-      path: ["paygCapCredits"],
-    }
-  );
+const CreditUsageConfigurationSchema = z.object({
+  defaultDiscountPercent: z
+    .number()
+    .min(0, "Discount percentage must be at least 0")
+    .max(
+      MAX_AWU_DISCOUNT_PERCENT,
+      `Discount cannot exceed ${MAX_AWU_DISCOUNT_PERCENT}% for AWU credit purchases`
+    )
+    .default(0),
+  paygEnabled: z.boolean(),
+  usageCapCredits: z
+    .number()
+    .int("AWU usage cap must be an integer number of credits")
+    .min(0, "AWU usage cap must be non-negative")
+    .max(
+      MAX_AWU_USAGE_CAP_CREDITS,
+      `AWU usage cap cannot exceed ${MAX_AWU_USAGE_CAP_CREDITS.toLocaleString()} credits`
+    )
+    .default(0),
+});
 
 export const manageCreditUsageConfigurationPlugin = createPlugin({
   manifest: {
@@ -50,8 +35,10 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
     name: "Manage Credit Usage Configuration",
     description:
       "Configure AWU credit usage settings for this workspace: the default " +
-      "discount applied to AWU credit purchases and the PAYG cap on AWU " +
-      "consumption (in credits) used to drive the Metronome spend-threshold alert.",
+      "discount applied to AWU credit purchases, whether PAYG is enabled, " +
+      "and the workspace usage cap (in AWU credits) used to drive the " +
+      "Metronome spend-threshold alert. PAYG and the usage cap are " +
+      "independent: either can be set without the other.",
     resourceTypes: ["workspaces"],
     args: {
       defaultDiscountPercent: {
@@ -61,22 +48,21 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
         description: `Discount applied to AWU credit purchases (0-${MAX_AWU_DISCOUNT_PERCENT}%).`,
         async: true,
       },
-      paygCapEnabled: {
+      paygEnabled: {
         type: "boolean",
         variant: "toggle",
-        label: "AWU PAYG Cap",
+        label: "PAYG Enabled",
         description:
-          "Enable a Metronome spend-threshold alert when AWU consumption " +
-          "reaches the configured cap (Metronome-billed workspaces only).",
+          "Enable Pay-as-you-go for this workspace (Metronome-billed " +
+          "workspaces only). Independent from the usage cap below.",
         async: true,
       },
-      paygCapCredits: {
+      usageCapCredits: {
         type: "number",
         variant: "text",
-        label: "AWU PAYG Cap (credits)",
-        description: `Maximum AWU consumption (in credits) before the spend-threshold alert fires. Range: 1-${MAX_AWU_PAYG_CAP_CREDITS.toLocaleString()}.`,
+        label: "AWU Usage Cap (credits)",
+        description: `Workspace usage cap (in AWU credits) at which the Metronome spend-threshold alert fires. Set to 0 to disable the alert. Range: 0-${MAX_AWU_USAGE_CAP_CREDITS.toLocaleString()}.`,
         async: true,
-        dependsOn: { field: "paygCapEnabled", value: true },
       },
     },
   },
@@ -93,15 +79,15 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
     if (!config) {
       return new Ok({
         defaultDiscountPercent: 0,
-        paygCapEnabled: false,
-        paygCapCredits: 0,
+        paygEnabled: false,
+        usageCapCredits: 0,
       });
     }
 
     return new Ok({
       defaultDiscountPercent: config.defaultDiscountPercent,
-      paygCapEnabled: config.paygCapCredits !== null,
-      paygCapCredits: config.paygCapCredits ?? 0,
+      paygEnabled: config.paygEnabled,
+      usageCapCredits: config.usageCapCredits ?? 0,
     });
   },
 
@@ -127,18 +113,11 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
       );
     }
 
-    const { defaultDiscountPercent, paygCapEnabled, paygCapCredits } =
+    const { defaultDiscountPercent, paygEnabled, usageCapCredits } =
       parseResult.data;
 
-    const resolvedPaygCapCredits = paygCapEnabled
-      ? (() => {
-          assert(
-            paygCapCredits !== undefined,
-            "[Unreachable] paygCapEnabled but paygCapCredits undefined"
-          );
-          return paygCapCredits;
-        })()
-      : null;
+    const resolvedUsageCapCredits =
+      usageCapCredits > 0 ? usageCapCredits : null;
 
     const existingConfig =
       await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
@@ -146,7 +125,8 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
     if (existingConfig) {
       const updateResult = await existingConfig.updateConfiguration(auth, {
         defaultDiscountPercent,
-        paygCapCredits: resolvedPaygCapCredits,
+        paygEnabled,
+        usageCapCredits: resolvedUsageCapCredits,
       });
       if (updateResult.isErr()) {
         return updateResult;
@@ -156,7 +136,8 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
         auth,
         {
           defaultDiscountPercent,
-          paygCapCredits: resolvedPaygCapCredits,
+          paygEnabled,
+          usageCapCredits: resolvedUsageCapCredits,
           disableCreditCapWarning: false,
         }
       );
@@ -167,21 +148,23 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
 
     const paygResult = await syncCreditBasedPayg({
       auth,
-      paygCapCredits: resolvedPaygCapCredits,
+      paygEnabled,
+      usageCapCredits: resolvedUsageCapCredits,
     });
     if (paygResult.isErr()) {
       return paygResult;
     }
 
     const discountStatus = `Discount: ${defaultDiscountPercent}%`;
-    const paygStatus =
-      resolvedPaygCapCredits !== null
-        ? `AWU PAYG cap: ${resolvedPaygCapCredits.toLocaleString()} credits`
-        : "AWU PAYG cap: disabled";
+    const paygStatus = `PAYG: ${paygEnabled ? "enabled" : "disabled"}`;
+    const capStatus =
+      resolvedUsageCapCredits !== null
+        ? `Usage cap: ${resolvedUsageCapCredits.toLocaleString()} credits`
+        : "Usage cap: disabled";
 
     return new Ok({
       display: "text",
-      value: `${existingConfig ? "Changes saved" : "Configuration created"}. ${discountStatus}. ${paygStatus}.`,
+      value: `${existingConfig ? "Changes saved" : "Configuration created"}. ${discountStatus}. ${paygStatus}. ${capStatus}.`,
     });
   },
 });

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -41,40 +41,24 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { z } from "zod";
 
-// PAYG cap for credit-priced contracts is denominated in AWU credits, written
-// to `credit_usage_configuration.paygCapCredits` verbatim. We deliberately do
-// NOT accept dollars/euros here and do NOT convert from any fiat unit —
-// `programmatic_usage_configuration.paygCapMicroUsd` (micro_usd) is a legacy
-// concern of the programmatic-usage flow and must stay out of this path.
-export const MAX_PAYG_CAP_CREDITS = 2_000_000;
-
-export const SwitchContractBodySchema = z
-  .object({
-    planCode: z.string().min(1),
-    metronomePackageId: z.string().min(1),
-    // ISO timestamp. Required and validated to be ≥1h in the future when the
-    // selected package is enterprise-tier; forbidden otherwise (Pro/Business
-    // swap at the current hour).
-    startingAt: z.string().optional(),
-    // Optional: required for paid tiers (pro/business/enterprise), omitted
-    // for free-tier switches where Metronome contracts have no Stripe link.
-    stripeCustomerId: z.string().min(1).optional(),
-    paygEnabled: z.boolean().default(false),
-    // AWU credits — written directly to `credit_usage_configuration.paygCapCredits`.
-    paygCapCredits: z
-      .number()
-      .int("PAYG cap must be an integer number of credits")
-      .min(1, "PAYG cap must be at least 1 credit")
-      .max(
-        MAX_PAYG_CAP_CREDITS,
-        `PAYG cap cannot exceed ${MAX_PAYG_CAP_CREDITS.toLocaleString()} credits`
-      )
-      .optional(),
-  })
-  .refine((data) => !data.paygEnabled || data.paygCapCredits !== undefined, {
-    message: "PAYG cap is required when Pay-as-you-go is enabled.",
-    path: ["paygCapCredits"],
-  });
+export const SwitchContractBodySchema = z.object({
+  planCode: z.string().min(1),
+  metronomePackageId: z.string().min(1),
+  // ISO timestamp. Required and validated to be ≥1h in the future when the
+  // selected package is enterprise-tier; forbidden otherwise (Pro/Business
+  // swap at the current hour).
+  startingAt: z.string().optional(),
+  // Optional: required for paid tiers (pro/business/enterprise), omitted
+  // for free-tier switches where Metronome contracts have no Stripe link.
+  stripeCustomerId: z.string().min(1).optional(),
+  paygEnabled: z.boolean().default(false),
+  // AWU credits — written directly to `credit_usage_configuration.usageCapCredits`.
+  usageCapCredits: z
+    .number()
+    .int("Usage cap must be an integer number of credits")
+    .min(1, "Usage cap must be at least 1 credit")
+    .optional(),
+});
 
 export type SwitchContractBody = z.infer<typeof SwitchContractBodySchema>;
 
@@ -403,16 +387,15 @@ export async function switchContract({
     }
   }
 
-  // The operator supplies the PAYG cap in AWU credits directly — no fiat
+  // The operator supplies the AWU usage cap in credits directly — no fiat
   // conversion. The value is written verbatim to
-  // `credit_usage_configuration.paygCapCredits` (see `MAX_PAYG_CAP_CREDITS`).
-  const paygCapCredits =
-    body.paygEnabled && body.paygCapCredits !== undefined
-      ? body.paygCapCredits
-      : null;
+  // `credit_usage_configuration.usageCapCredits` (see `MAX_USAGE_CAP_CREDITS`).
+  // `paygEnabled` and `usageCapCredits` are stored independently.
+  const usageCapCredits = body.usageCapCredits ?? null;
   if (creditConfig) {
     const updateResult = await creditConfig.updateConfiguration(auth, {
-      paygCapCredits,
+      paygEnabled: body.paygEnabled,
+      usageCapCredits,
     });
     if (updateResult.isErr()) {
       return new Err(
@@ -422,10 +405,11 @@ export async function switchContract({
         )
       );
     }
-  } else if (paygCapCredits !== null) {
+  } else if (body.paygEnabled || usageCapCredits !== null) {
     const createResult = await CreditUsageConfigurationResource.makeNew(auth, {
       defaultDiscountPercent: 0,
-      paygCapCredits,
+      paygEnabled: body.paygEnabled,
+      usageCapCredits,
       disableCreditCapWarning: false,
     });
     if (createResult.isErr()) {

--- a/front/lib/credits/credit_payg.ts
+++ b/front/lib/credits/credit_payg.ts
@@ -3,8 +3,8 @@ import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usag
 
 /**
  * PAYG status for credit-priced (Metronome) workspaces. PAYG is considered
- * enabled when the workspace has a `credit_usage_configuration` row with a
- * non-null `paygCapCredits` cap.
+ * enabled when the workspace has a `credit_usage_configuration` row with
+ * `paygEnabled = true`.
  *
  * NOTE: this is the credit-pricing counterpart of
  * `front/lib/credits/payg.ts:isPAYGEnabled`, which serves the legacy
@@ -15,5 +15,5 @@ import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usag
 export async function isPAYGEnabled(auth: Authenticator): Promise<boolean> {
   const config =
     await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
-  return config !== null && config.paygCapCredits !== null;
+  return config?.paygEnabled ?? false;
 }

--- a/front/lib/metronome/alerts/usage_cap.ts
+++ b/front/lib/metronome/alerts/usage_cap.ts
@@ -7,33 +7,37 @@ import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
-function paygAlertUniquenessKey(workspaceId: string): string {
+// Keep the literal `payg-cap-` prefix: this value is persisted on Metronome's
+// side as the alert uniqueness key. Changing it would orphan any existing
+// alert (the new key wouldn't match, so `clearMetronomeUsageCapAlert` would
+// silently no-op for workspaces that have a pre-rename alert).
+function usageCapAlertUniquenessKey(workspaceId: string): string {
   return `payg-cap-${workspaceId}`;
 }
 
 /**
  * Idempotently ensure a Metronome `spend_threshold_reached` alert exists on
- * the customer matching the workspace's AWU PAYG cap. If an alert with a
+ * the customer matching the workspace's AWU usage cap. If an alert with a
  * different threshold already exists, it's archived (with key release) and
  * recreated. The cap is expressed in AWU credits (the same unit Metronome
  * tracks AWU consumption in).
  */
-export async function upsertMetronomePaygCapAlert({
+export async function upsertMetronomeUsageCapAlert({
   metronomeCustomerId,
-  paygCapCredits,
+  usageCapCredits,
   workspaceId,
 }: {
   metronomeCustomerId: string;
-  paygCapCredits: number;
+  usageCapCredits: number;
   workspaceId: string;
 }): Promise<Result<{ alertId: string }, Error>> {
   const upsertResult = await upsertMetronomeAlert({
     alert_type: "spend_threshold_reached",
-    name: `PAYG cap workspace ${workspaceId} (${paygCapCredits} AWU)`,
-    threshold: paygCapCredits,
+    name: `Usage cap workspace ${workspaceId} (${usageCapCredits} AWU)`,
+    threshold: usageCapCredits,
     credit_type_id: getCreditTypeAwuId(),
     customer_id: metronomeCustomerId,
-    uniqueness_key: paygAlertUniquenessKey(workspaceId),
+    uniqueness_key: usageCapAlertUniquenessKey(workspaceId),
   });
   if (upsertResult.isErr()) {
     return new Err(upsertResult.error);
@@ -44,18 +48,18 @@ export async function upsertMetronomePaygCapAlert({
       workspaceId,
       metronomeCustomerId,
       alertId: upsertResult.value.alertId,
-      paygCapCredits,
+      usageCapCredits,
     },
-    "[Metronome PAYG] Synced PAYG cap alert"
+    "[Metronome UsageCap] Synced usage cap alert"
   );
   return new Ok({ alertId: upsertResult.value.alertId });
 }
 
 /**
- * Archive the workspace's PAYG cap alert, if any. Idempotent — no-op when
+ * Archive the workspace's usage cap alert, if any. Idempotent — no-op when
  * no matching alert exists.
  */
-export async function clearMetronomePaygCapAlert({
+export async function clearMetronomeUsageCapAlert({
   metronomeCustomerId,
   workspaceId,
 }: {
@@ -64,7 +68,7 @@ export async function clearMetronomePaygCapAlert({
 }): Promise<Result<void, Error>> {
   const result = await clearMetronomeAlert({
     metronomeCustomerId,
-    uniquenessKey: paygAlertUniquenessKey(workspaceId),
+    uniquenessKey: usageCapAlertUniquenessKey(workspaceId),
   });
   if (result.isErr()) {
     return new Err(result.error);
@@ -77,7 +81,7 @@ export async function clearMetronomePaygCapAlert({
         metronomeCustomerId,
         alertId: result.value.alertId,
       },
-      "[Metronome PAYG] Cleared PAYG cap alert"
+      "[Metronome UsageCap] Cleared usage cap alert"
     );
   }
   return new Ok(undefined);

--- a/front/lib/resources/credit_usage_configuration_resource.ts
+++ b/front/lib/resources/credit_usage_configuration_resource.ts
@@ -105,7 +105,8 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
     auth: Authenticator,
     blob: Partial<{
       defaultDiscountPercent: number;
-      paygCapCredits: number | null;
+      paygEnabled: boolean;
+      usageCapCredits: number | null;
       disableCreditCapWarning: boolean;
     }>,
     { transaction }: { transaction?: Transaction } = {}
@@ -149,7 +150,8 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       sId: this.sId,
       createdAt: this.createdAt.getTime(),
       defaultDiscountPercent: this.defaultDiscountPercent,
-      paygCapCredits: this.paygCapCredits,
+      paygEnabled: this.paygEnabled,
+      usageCapCredits: this.usageCapCredits,
       disableCreditCapWarning: this.disableCreditCapWarning,
     };
   }
@@ -159,7 +161,8 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       sId: this.sId,
       workspaceId: this.workspaceId,
       defaultDiscountPercent: this.defaultDiscountPercent,
-      paygCapCredits: this.paygCapCredits,
+      paygEnabled: String(this.paygEnabled),
+      usageCapCredits: this.usageCapCredits,
       disableCreditCapWarning: String(this.disableCreditCapWarning),
     };
   }

--- a/front/lib/resources/storage/models/credit_usage_configurations.ts
+++ b/front/lib/resources/storage/models/credit_usage_configurations.ts
@@ -12,9 +12,14 @@ import { DataTypes } from "sequelize";
  *
  * Fields:
  * - defaultDiscountPercent: Discount applied to AWU credit purchases (0-100%)
- * - paygCapCredits: PAYG cap on AWU consumption, in AWU credits. NULL means
- *   PAYG is disabled; any strictly-positive value enables it and drives the
+ * - paygEnabled: Whether PAYG mode is enabled for the workspace. Drives the
+ *   AWU contract excess-credits recurring credit (zeroed when enabled, restored
+ *   to the default amount when disabled).
+ * - usageCapCredits: Workspace-level usage cap on AWU consumption, in AWU
+ *   credits. NULL means no cap; any strictly-positive value drives the
  *   Metronome `spend_threshold_reached` alert on the workspace's customer.
+ *   Independent from `paygEnabled` — the cap can be set even when PAYG is
+ *   disabled, and PAYG can be enabled without a cap.
  * - disableCreditCapWarning: When true, the credit cap warning email to
  *   workspace admins is suppressed. Default false (warning is sent).
  */
@@ -22,7 +27,8 @@ export class CreditUsageConfigurationModel extends WorkspaceAwareModel<CreditUsa
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
   declare defaultDiscountPercent: number;
-  declare paygCapCredits: number | null;
+  declare paygEnabled: CreationOptional<boolean>;
+  declare usageCapCredits: number | null;
   declare disableCreditCapWarning: boolean;
 }
 
@@ -47,7 +53,12 @@ CreditUsageConfigurationModel.init(
         max: 100,
       },
     },
-    paygCapCredits: {
+    paygEnabled: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    usageCapCredits: {
       type: DataTypes.INTEGER,
       allowNull: true,
       defaultValue: null,
@@ -55,7 +66,7 @@ CreditUsageConfigurationModel.init(
         isPositive(value: number | null) {
           if (value !== null && value <= 0) {
             throw new Error(
-              "paygCapCredits must be strictly positive when set"
+              "usageCapCredits must be strictly positive when set"
             );
           }
         },

--- a/front/migrations/db/migration_655.sql
+++ b/front/migrations/db/migration_655.sql
@@ -1,0 +1,21 @@
+-- Migration created on May 28, 2026
+-- Decouple the AWU usage cap from the PAYG-enabled flag on
+-- credit_usage_configurations:
+--   1. Rename "paygCapCredits" to "usageCapCredits". The column is a
+--      workspace-level usage cap (in AWU credits) that drives the Metronome
+--      spend_threshold_reached alert; it is not specific to PAYG and can be
+--      set even when PAYG is not enabled.
+--   2. Add "paygEnabled" boolean so PAYG mode (which controls the AWU
+--      contract excess-credits recurring credit) is independent from the
+--      usage cap. Backfill to true wherever a cap was previously set, since
+--      under the old model that was the only way PAYG could be enabled.
+
+ALTER TABLE "public"."credit_usage_configurations"
+  RENAME COLUMN "paygCapCredits" TO "usageCapCredits";
+
+ALTER TABLE "public"."credit_usage_configurations"
+  ADD COLUMN "paygEnabled" BOOLEAN NOT NULL DEFAULT false;
+
+UPDATE "public"."credit_usage_configurations"
+  SET "paygEnabled" = true
+  WHERE "usageCapCredits" IS NOT NULL;

--- a/front/pages/api/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front/pages/api/poke/workspaces/[wId]/switch_contract.test.ts
@@ -561,7 +561,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — guards", () => {
 });
 
 describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
-  it("persists paygCapCredits and syncs the Metronome alert when switching to enterprise with PAYG enabled", async () => {
+  it("persists usageCapCredits and syncs the Metronome alert when switching to enterprise with PAYG enabled", async () => {
     await ensureEnterprisePlan();
     const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "POST",
@@ -569,7 +569,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
 
-    req.body = enterpriseBody({ paygEnabled: true, paygCapCredits: 50_000 });
+    req.body = enterpriseBody({ paygEnabled: true, usageCapCredits: 50_000 });
     req.query.wId = workspace.sId;
 
     await handler(req, res);
@@ -581,17 +581,17 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
     );
     const config =
       await CreditUsageConfigurationResource.fetchByWorkspaceId(adminAuth);
-    expect(config?.paygCapCredits).toBe(50_000);
+    expect(config?.usageCapCredits).toBe(50_000);
   });
 
-  it("persists paygCapCredits when switching to business with PAYG enabled", async () => {
+  it("persists usageCapCredits when switching to business with PAYG enabled", async () => {
     const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "POST",
       isSuperUser: true,
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
 
-    req.body = businessBody({ paygEnabled: true, paygCapCredits: 25_000 });
+    req.body = businessBody({ paygEnabled: true, usageCapCredits: 25_000 });
     req.query.wId = workspace.sId;
 
     await handler(req, res);
@@ -603,7 +603,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
     );
     const config =
       await CreditUsageConfigurationResource.fetchByWorkspaceId(adminAuth);
-    expect(config?.paygCapCredits).toBe(25_000);
+    expect(config?.usageCapCredits).toBe(25_000);
   });
 
   it("rejects PAYG on a pro contract", async () => {
@@ -613,7 +613,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
     });
     await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
 
-    req.body = proBody({ paygEnabled: true, paygCapCredits: 10_000 });
+    req.body = proBody({ paygEnabled: true, usageCapCredits: 10_000 });
     req.query.wId = workspace.sId;
 
     await handler(req, res);
@@ -625,7 +625,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
     expect(provisionMetronomeContract).not.toHaveBeenCalled();
   });
 
-  it("rejects when paygEnabled is true but paygCapCredits is missing", async () => {
+  it("accepts paygEnabled without a usage cap (no alert)", async () => {
     await ensureEnterprisePlan();
     const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "POST",
@@ -638,11 +638,18 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
 
     await handler(req, res);
 
-    expect(res._getStatusCode()).toBe(400);
-    expect(res._getJSONData().error.message).toContain("PAYG cap");
+    expect(res._getStatusCode()).toBe(200);
+
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const config =
+      await CreditUsageConfigurationResource.fetchByWorkspaceId(adminAuth);
+    expect(config?.paygEnabled).toBe(true);
+    expect(config?.usageCapCredits).toBeNull();
   });
 
-  it("clears paygCapCredits when paygEnabled is false", async () => {
+  it("preserves usageCapCredits when paygEnabled is toggled off", async () => {
     const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "POST",
       isSuperUser: true,
@@ -654,11 +661,12 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
     );
     await CreditUsageConfigurationResource.makeNew(adminAuth, {
       defaultDiscountPercent: 0,
-      paygCapCredits: 100_000,
+      paygEnabled: true,
+      usageCapCredits: 100_000,
       disableCreditCapWarning: false,
     });
 
-    req.body = proBody();
+    req.body = proBody({ usageCapCredits: 100_000 });
     req.query.wId = workspace.sId;
 
     await handler(req, res);
@@ -667,6 +675,7 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
 
     const config =
       await CreditUsageConfigurationResource.fetchByWorkspaceId(adminAuth);
-    expect(config?.paygCapCredits).toBeNull();
+    expect(config?.paygEnabled).toBe(false);
+    expect(config?.usageCapCredits).toBe(100_000);
   });
 });

--- a/front/pages/api/poke/workspaces/[wId]/switch_contract.ts
+++ b/front/pages/api/poke/workspaces/[wId]/switch_contract.ts
@@ -111,9 +111,12 @@ async function handler(
   }
 
   const { metronomeContractId } = result.value;
-  const paygStatus = body.paygEnabled
-    ? ` PAYG enabled with a ${body.paygCapCredits} credit cap.`
-    : "";
+  const paygSummary = body.paygEnabled ? " PAYG enabled." : "";
+  const capSummary =
+    body.usageCapCredits !== undefined
+      ? ` Usage cap: ${body.usageCapCredits} credits.`
+      : "";
+  const paygStatus = `${paygSummary}${capSummary}`;
   await pluginRun.recordResult({
     display: "text",
     value:

--- a/front/pages/api/w/[wId]/credits/usage-configuration.ts
+++ b/front/pages/api/w/[wId]/credits/usage-configuration.ts
@@ -131,7 +131,8 @@ async function handlePatch(
   } else {
     const createResult = await CreditUsageConfigurationResource.makeNew(auth, {
       defaultDiscountPercent: 0,
-      paygCapCredits: null,
+      paygEnabled: false,
+      usageCapCredits: null,
       disableCreditCapWarning: false,
       ...patch,
     });


### PR DESCRIPTION
## Description

Decouple the AWU usage cap from the PAYG-enabled flag on `credit_usage_configurations`, and rename `paygCapCredits` → `usageCapCredits` (it is a workspace usage cap that drives the Metronome `spend_threshold_reached` alert, not a PAYG-specific concept).

After this change:

- `paygEnabled` (new boolean column) controls PAYG mode — i.e. zeroing the AWU contract recurring "Excess Credits" credit so overage past the workspace's free credit pool bills as PAYG instead of being absorbed silently. Drives `isPAYGEnabled`.
- `usageCapCredits` (renamed column) is the threshold passed to the Metronome `spend_threshold_reached` alert. Set independently from `paygEnabled`; `null` means no alert.

The "Manage Credit Usage Configuration" poke plugin now exposes both knobs independently:

- PAYG toggle behaves as before.
- The usage cap field is always visible and accepts `0` / unset — when 0, the Metronome alert is not created (the existing one is cleared).

The `lib/metronome/payg_alerts.ts` module is renamed to `usage_cap_alerts.ts` (the alert is about a workspace usage cap, not PAYG). The Metronome-side `uniqueness_key` value is intentionally preserved (`payg-cap-${workspaceId}`) so that pre-rename alerts can still be cleared by the new code — changing the key would orphan them. A code comment documents this.

`switch_contract` (Next + Hono) was updated for the rename: body field `paygCapCredits` → `usageCapCredits`, and the "clear cap when PAYG disabled" coupling is dropped — the two are now stored independently. The `SwitchContractDialog` poke UI was updated accordingly.

### Open question (not addressed in this PR)

It is unclear from Metronome's public docs whether `spend_threshold_reached` measures **gross AWU consumption** (in which case the alert can fire while seat-based credit grants still fully cover usage) or **net invoiceable spend after credit grants are applied** (in which case it only fires on overage). The existence of separate `low_remaining_credit_balance` style alert types hints at the latter, but the docs do not state this explicitly. Worth confirming with Metronome support or via an empirical test before relying on the cap for seat-based contracts.

## Tests

- `front/pages/api/poke/workspaces/[wId]/switch_contract.test.ts` and the Hono mirror updated: replaced "rejects PAYG without cap" with "accepts PAYG without a usage cap (no alert)" and added "preserves usageCapCredits when paygEnabled is toggled off" to cover the decoupled semantics.
- `npx tsgo --noEmit` clean on `front` and `front-api` (only pre-existing unrelated OpenAI SDK errors remain).
- Manual run of the test suite requires a live test DB and was not executed.

## Risk

- **Migration**: `migration_655.sql` does a column rename + adds a `paygEnabled` boolean with a backfill (`paygEnabled = true` where `usageCapCredits IS NOT NULL`). The rename is atomic in Postgres but invalidates any deployed older code paths that still read `paygCapCredits` — old code must not be running against the migrated DB.
- **Metronome state**: alert uniqueness key value is unchanged, so existing alerts continue to be addressable by the new code. No Metronome-side cleanup needed.
- **Switch-contract behaviour change**: previously, calling `switch_contract` with `paygEnabled = false` forcibly cleared `paygCapCredits` in the DB. After this PR, the cap is preserved unless the body explicitly unsets it. Operators that relied on "toggle PAYG off to clear the cap" will need to clear the cap explicitly via the poke plugin. Low risk (the poke plugin is the canonical place for this anyway).
- Rollback: revert the PR + roll the migration back (drop `paygEnabled`, rename `usageCapCredits` → `paygCapCredits`). Existing `paygCapCredits` values survive the round-trip; `paygEnabled` data is lost but is derivable from `paygCapCredits IS NOT NULL`.

## Deploy Plan

1. Merge + deploy. `migration_655.sql` runs as part of normal deploy.
2. After deploy, sanity-check via poke "Manage Credit Usage Configuration" on a Metronome-billed workspace: verify the toggle + cap fields are independent and that setting cap = 0 with PAYG on does not create a Metronome alert (the existing one, if any, is cleared).
3. No coordinated client release needed — `switch_contract` is poke-internal and the matching dialog ships in the same PR.