### PR TITLE
[File System] Fix legacy vision image rendering

### DIFF
--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -129,15 +129,10 @@ const ModelVisionImageSchema = z
     imageContentType: z.string(),
   })
   .and(
-    z
-      .union([
-        z.object({ filePath: z.string() }),
-        z.object({ gcsPath: z.string() }).transform(({ gcsPath, ...rest }) => ({
-          ...rest,
-          filePath: gcsPath,
-        })),
-      ])
-      .transform((v) => v)
+    z.union([
+      z.object({ filePath: z.string() }),
+      z.object({ gcsPath: z.string() }),
+    ])
   );
 
 export type ModelVisionImageType = z.infer<typeof ModelVisionImageSchema>;

--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -163,17 +163,20 @@ async function renderActionForMultiActionsModel(
       if (isTextContent(item)) {
         contentArray.push({ type: "text", text: item.text });
       } else if (isModelVisionImage(item)) {
-        const { filePath } = item.resource;
+        const imagePath =
+          "filePath" in item.resource
+            ? item.resource.filePath
+            : item.resource.gcsPath;
 
         // Legacy records carry a raw GCS path (starts with `w/`).
         // New records carry a canonical scoped path (e.g. `conversation-{cId}/photo.png`).
-        const urlRes = filePath.startsWith("w/")
+        const urlRes = imagePath.startsWith("w/")
           ? await getConversationFileMountSignedUrl(
               auth,
               { useCase: "conversation", conversationId },
-              filePath
+              imagePath
             )
-          : await getDustFileSystemDownloadUrl(auth, filePath);
+          : await getDustFileSystemDownloadUrl(auth, imagePath);
 
         if (urlRes.isOk()) {
           contentArray.push({


### PR DESCRIPTION
## Description
Fixes a regression in https://github.com/dust-tt/dust/pull/26389.

Legacy `files__cat` vision-image outputs persisted `gcsPath`, while the renderer now reads `filePath` for Dust File System paths. Zod accepted the legacy shape, but the transform did not mutate the stored action output, so rendering old conversations crashed on `filePath.startsWith(...)`. This keeps the schema type aligned with both stored shapes and chooses the right path at render time.

## Risks
Blast radius: rendering model context for prior tool outputs containing vision images.
Risk: low

## Deploy Plan
- deploy front

## Tests
- [x] `NODE_ENV=test npm test -- lib/api/assistant/conversation_rendering/helpers.test.ts`