### PR TITLE
[audit-logs] Fix a few schema mismatches and tighten test coverage to future proof

### DIFF
--- a/.claude/skills/dust-audit-log-event/SKILL.md
+++ b/.claude/skills/dust-audit-log-event/SKILL.md
@@ -31,7 +31,7 @@ Rules:
 - additional targets describe the affected entities, such as `user`, `space`, `trigger`, `tool`,
   `agent`, or `api_key`
 - `metadata` is optional, but every metadata value must be declared as `"string"`
-- use camelCase metadata keys
+- use snake_case metadata keys (see `[AUDIT9]`)
 
 Example shape:
 
@@ -43,7 +43,7 @@ Example shape:
     { "type": "resource" }
   ],
   "metadata": {
-    "fieldName": "string"
+    "field_name": "string"
   }
 }
 ```
@@ -78,7 +78,7 @@ void emitAuditLogEvent({
   ],
   context: getAuditLogContext(auth, req),
   metadata: {
-    fieldName: String(value),
+    field_name: String(value),
   },
 });
 ```
@@ -126,9 +126,12 @@ Check all of the following:
 - metadata values are wrapped with `String(...)` when needed
 - request-backed events use `getAuditLogContext(auth, req)` when `req` is available
 - the emit call uses `void`
+- the targets in the emit call exactly match (in type and count) the targets in the schema JSON file
+- if modifying an existing event's targets, the schema JSON file has been updated to match
+- if the schema JSON file changed, `register_audit_log_schemas.ts --execute --changed` must be run after merge and before deploy
 
 ## References
 
 - `front/lib/api/audit/workos_audit.ts`
 - `front/admin/audit_log_schemas/`
-- `front/CODING_RULES.md` entries `[AUDIT1]` through `[AUDIT8]`
+- `front/CODING_RULES.md` entries `[AUDIT1]` through `[AUDIT10]`

--- a/front-api/routes/w/[wId]/credentials/index.ts
+++ b/front-api/routes/w/[wId]/credentials/index.ts
@@ -92,7 +92,13 @@ app.post(
     void emitAuditLogEvent({
       auth,
       action: "credentials.created",
-      targets: [buildAuditLogTarget("workspace", owner)],
+      targets: [
+        buildAuditLogTarget("workspace", owner),
+        buildAuditLogTarget("credential", {
+          sId: response.value.credential.credential_id,
+          name: String(body.provider),
+        }),
+      ],
       context: getAuditLogContext(auth),
       metadata: {
         provider: String(body.provider),

--- a/front-api/routes/workos/[action].ts
+++ b/front-api/routes/workos/[action].ts
@@ -265,6 +265,7 @@ async function handleCallback(ctx: Context) {
     : {};
 
   let callbackWorkspaceId: string | undefined;
+  let callbackUserEmail: string | undefined;
 
   try {
     const {
@@ -277,6 +278,7 @@ async function handleCallback(ctx: Context) {
       code,
       organizationId: stateObj.organizationId,
     });
+    callbackUserEmail = user.email;
 
     if (!sealedSession) {
       throw new Error("Sealed session not found");
@@ -485,9 +487,16 @@ async function handleCallback(ctx: Context) {
   } catch (error) {
     logger.error({ error }, "Error during WorkOS callback");
 
+    // Emit user.login_failed when workspace context is available. Login
+    // failures without workspace context are not audit-logged because audit
+    // logs are workspace-scoped — WorkOS captures those on their side.
+    // When the workspace is known but the user email isn't (e.g. failure
+    // before authenticateWithWorkOSCode could resolve), fall back to
+    // "unknown" for the user target so emit and schema targets always match.
     if (callbackWorkspaceId) {
       const loginFailedAuth =
         await Authenticator.internalAdminForWorkspace(callbackWorkspaceId);
+      const userIdentifier = callbackUserEmail ?? "unknown";
       void emitAuditLogEvent({
         auth: loginFailedAuth,
         action: "user.login_failed",
@@ -496,6 +505,13 @@ async function handleCallback(ctx: Context) {
             "workspace",
             loginFailedAuth.getNonNullableWorkspace()
           ),
+          // Follow the member.invited pattern: when we don't have a Dust
+          // UserResource (the user may never have signed up here), use the
+          // email as the user target's sId.
+          buildAuditLogTarget("user", {
+            sId: userIdentifier,
+            name: userIdentifier,
+          }),
         ],
         metadata: {
           reason: normalizeError(error).message,

--- a/front/CODING_RULES.md
+++ b/front/CODING_RULES.md
@@ -481,6 +481,14 @@ the logic back into the handlers and accept the duplication.
 - Enforced by `npm -w front run lint:audit-log-schemas` (runs in CI and as a lefthook
   pre-commit hook scoped to `front/admin/audit_log_schemas/**/*.json`)
 
+### [AUDIT10] Schema JSON files, emit calls, and WorkOS registrations must stay in sync
+
+When changing targets in an `emitAuditLogEvent` / `emitAuditLogEventDirect` call, update the
+corresponding schema at `front/admin/audit_log_schemas/<action>.json` to match. When changing a
+schema file, re-register with WorkOS after merge and before deploy:
+`npx tsx front/admin/register_audit_log_schemas.ts --execute --changed`. The CI test enforces
+that the `AuditAction` union and schema files stay consistent.
+
 ## MCP
 
 ### [MCP1] Single file internal servers

--- a/front/admin/audit_log_schemas/member.invited.json
+++ b/front/admin/audit_log_schemas/member.invited.json
@@ -2,6 +2,9 @@
   "action": "member.invited",
   "targets": [
     {
+      "type": "workspace"
+    },
+    {
       "type": "user"
     }
   ],

--- a/front/admin/audit_log_schemas/user.identity_merged.json
+++ b/front/admin/audit_log_schemas/user.identity_merged.json
@@ -2,6 +2,9 @@
   "action": "user.identity_merged",
   "targets": [
     {
+      "type": "workspace"
+    },
+    {
       "type": "user"
     }
   ],

--- a/front/admin/audit_log_schemas/user.login_failed.json
+++ b/front/admin/audit_log_schemas/user.login_failed.json
@@ -2,6 +2,9 @@
   "action": "user.login_failed",
   "targets": [
     {
+      "type": "workspace"
+    },
+    {
       "type": "user"
     }
   ],

--- a/front/lib/api/audit/audit_log_schemas.test.ts
+++ b/front/lib/api/audit/audit_log_schemas.test.ts
@@ -90,6 +90,7 @@ type EmitSite = {
   file: string;
   action: string;
   targetTypes: string[];
+  unextractable?: boolean;
 };
 
 function listTsFiles(dir: string): string[] {
@@ -143,9 +144,15 @@ function collectEmitSites(): EmitSite[] {
   const sites: EmitSite[] = [];
   const callRegex = /emitAuditLogEvent(?:Direct)?\s*\(\s*\{/g;
   const actionRegex = /\baction:\s*"([^"]+)"/;
-  const targetsBlockRegex = /\btargets:\s*\[([\s\S]*?)\]/;
+  const targetsArrayRegex = /\btargets:\s*\[([\s\S]*?)\]/g;
+  // `buildAuditLogTarget("xxx", ...)` is only ever used to construct audit
+  // targets in this codebase, so scanning the entire emit body for it is safe
+  // and lets us capture dynamic patterns like `targets: arr.map(r => buildAuditLogTarget("user", r))`.
   const buildTargetRegex = /buildAuditLogTarget\(\s*"([^"]+)"/g;
-  const literalTargetRegex = /\btype:\s*"([^"]+)"/g;
+  // Literal target objects shaped like `{ type: "xxx", id: ... }` (note the
+  // required `id:` after the type, which excludes actor/metadata objects that
+  // happen to use a `type:` key).
+  const literalTargetRegex = /\{\s*type:\s*"([^"]+)"\s*,\s*id:/g;
 
   for (const file of listTsFiles(FRONT_DIR)) {
     let source: string;
@@ -170,32 +177,33 @@ function collectEmitSites(): EmitSite[] {
       }
       const action = actionMatch[1];
 
-      const targetsMatch = targetsBlockRegex.exec(body);
-      if (!targetsMatch) {
-        continue;
-      }
-      const targetsBlock = targetsMatch[1];
-
       const targetTypes: string[] = [];
+
+      // 1. Scan the entire body for buildAuditLogTarget(...) calls.
       let bt: RegExpExecArray | null;
-      while ((bt = buildTargetRegex.exec(targetsBlock)) !== null) {
+      while ((bt = buildTargetRegex.exec(body)) !== null) {
         targetTypes.push(bt[1]);
       }
       buildTargetRegex.lastIndex = 0;
-      let lt: RegExpExecArray | null;
-      while ((lt = literalTargetRegex.exec(targetsBlock)) !== null) {
-        targetTypes.push(lt[1]);
-      }
-      literalTargetRegex.lastIndex = 0;
 
-      if (targetTypes.length === 0) {
-        continue;
+      // 2. Scan only inside `targets: [...]` arrays for literal target objects.
+      //    Restricting to the array literal avoids false positives from the
+      //    sibling `actor: { type: "user", id: ... }` field.
+      let ta: RegExpExecArray | null;
+      while ((ta = targetsArrayRegex.exec(body)) !== null) {
+        let lt: RegExpExecArray | null;
+        while ((lt = literalTargetRegex.exec(ta[1])) !== null) {
+          targetTypes.push(lt[1]);
+        }
+        literalTargetRegex.lastIndex = 0;
       }
+      targetsArrayRegex.lastIndex = 0;
 
       sites.push({
         file: path.relative(FRONT_DIR, file),
         action,
         targetTypes,
+        unextractable: targetTypes.length === 0,
       });
     }
   }
@@ -209,11 +217,29 @@ describe("audit log emit call sites", () => {
     expect(sites.length).toBeGreaterThan(0);
   });
 
+  it("every detected emit site has extractable target types", () => {
+    // If the regex cannot extract any target types from an emit call, the
+    // schema/code drift check silently passes for that action. Fail loudly so
+    // the regex (or the call site) gets adjusted instead of allowing silent
+    // drift to creep in via unusual emit shapes.
+    const unextractable = sites
+      .filter((s) => s.unextractable)
+      .map((s) => `${s.file}: action "${s.action}"`);
+    expect(
+      unextractable,
+      `Emit sites where the target-extraction regex found no targets ` +
+        `(possible new emit pattern):\n${unextractable.join("\n")}`
+    ).toEqual([]);
+  });
+
   it("every emit call's targets match the schema for that action", () => {
     const mismatches: string[] = [];
     const schemaCache = new Map<string, SchemaFile>();
 
     for (const site of sites) {
+      if (site.unextractable) {
+        continue;
+      }
       let schema = schemaCache.get(site.action);
       if (!schema) {
         try {

--- a/front/lib/api/audit/audit_log_schemas.test.ts
+++ b/front/lib/api/audit/audit_log_schemas.test.ts
@@ -72,6 +72,33 @@ describe("audit log schemas", () => {
     }
     expect(mismatched).toEqual([]);
   });
+
+  it("all schema metadata keys are snake_case per [AUDIT9]", () => {
+    // snake_case = lowercase letters, digits, and underscores only, must start
+    // with a letter. Rejects camelCase, PascalCase, kebab-case, and
+    // SCREAMING_SNAKE_CASE.
+    const snakeCaseRegex = /^[a-z][a-z0-9_]*$/;
+    const violations: string[] = [];
+
+    for (const file of fs.readdirSync(SCHEMAS_DIR)) {
+      if (!file.endsWith(".json")) {
+        continue;
+      }
+      const schema = readSchemaFile(path.join(SCHEMAS_DIR, file));
+      if (!schema.metadata) {
+        continue;
+      }
+      for (const key of Object.keys(schema.metadata)) {
+        if (!snakeCaseRegex.test(key)) {
+          violations.push(`${file}: "${key}"`);
+        }
+      }
+    }
+    expect(
+      violations,
+      `Non-snake_case metadata keys (per [AUDIT9]):\n${violations.join("\n")}`
+    ).toEqual([]);
+  });
 });
 
 /**

--- a/front/lib/api/audit/audit_log_schemas.test.ts
+++ b/front/lib/api/audit/audit_log_schemas.test.ts
@@ -1,0 +1,256 @@
+import * as fs from "fs";
+import * as path from "path";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { AUDIT_ACTIONS } from "./workos_audit";
+
+const SCHEMAS_DIR = path.resolve(__dirname, "../../../admin/audit_log_schemas");
+const FRONT_DIR = path.resolve(__dirname, "../../..");
+
+const SchemaFileValidator = z.object({
+  action: z.string(),
+  targets: z.array(z.object({ type: z.string() })),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+type SchemaFile = z.infer<typeof SchemaFileValidator>;
+
+function readSchemaFile(filePath: string): SchemaFile {
+  return SchemaFileValidator.parse(
+    JSON.parse(fs.readFileSync(filePath, "utf-8"))
+  );
+}
+
+function readSchemaByAction(action: string): SchemaFile {
+  return readSchemaFile(path.join(SCHEMAS_DIR, `${action}.json`));
+}
+
+describe("audit log schemas", () => {
+  it("every AuditAction has a corresponding schema JSON file", () => {
+    const missing: string[] = [];
+    for (const action of AUDIT_ACTIONS) {
+      const filePath = path.join(SCHEMAS_DIR, `${action}.json`);
+      if (!fs.existsSync(filePath)) {
+        missing.push(action);
+      }
+    }
+    expect(
+      missing,
+      `Missing schema files in front/admin/audit_log_schemas/ for: ${missing.join(", ")}`
+    ).toEqual([]);
+  });
+
+  it("no orphan schema files — every JSON file maps to a valid AuditAction", () => {
+    const validActions = new Set<string>(AUDIT_ACTIONS);
+    const orphans: string[] = [];
+    for (const file of fs.readdirSync(SCHEMAS_DIR)) {
+      if (!file.endsWith(".json")) {
+        continue;
+      }
+      const schema = readSchemaFile(path.join(SCHEMAS_DIR, file));
+      if (!validActions.has(schema.action)) {
+        orphans.push(file);
+      }
+    }
+    expect(
+      orphans,
+      `Orphan schema files (action not in AuditAction union): ${orphans.join(", ")}`
+    ).toEqual([]);
+  });
+
+  it("schema file basename matches its 'action' field", () => {
+    const mismatched: string[] = [];
+    for (const file of fs.readdirSync(SCHEMAS_DIR)) {
+      if (!file.endsWith(".json")) {
+        continue;
+      }
+      const schema = readSchemaFile(path.join(SCHEMAS_DIR, file));
+      const expected = `${schema.action}.json`;
+      if (expected !== file) {
+        mismatched.push(`${file} declares action "${schema.action}"`);
+      }
+    }
+    expect(mismatched).toEqual([]);
+  });
+});
+
+/**
+ * Collects every (action, targetTypes[]) pair found in `emitAuditLogEvent` /
+ * `emitAuditLogEventDirect` call sites under front/. Uses brace-depth tracking
+ * to extract the argument object, then regex to pull out the action and target
+ * types from `buildAuditLogTarget("<type>", ...)` and `{ type: "<type>" }`
+ * literals.
+ *
+ * This is intentionally a syntactic scan, not a full AST parse — partial
+ * coverage is fine. False negatives just mean a future drift isn't caught
+ * here; false positives mean a noisy test. The recovery rule is: bail on the
+ * site (don't fail the test) if extraction is ambiguous.
+ */
+type EmitSite = {
+  file: string;
+  action: string;
+  targetTypes: string[];
+};
+
+function listTsFiles(dir: string): string[] {
+  const results: string[] = [];
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (
+        entry.name === "node_modules" ||
+        entry.name === "dist" ||
+        entry.name === ".next" ||
+        entry.name.startsWith(".")
+      ) {
+        continue;
+      }
+      results.push(...listTsFiles(full));
+    } else if (
+      (entry.name.endsWith(".ts") || entry.name.endsWith(".tsx")) &&
+      !entry.name.endsWith(".test.ts") &&
+      !entry.name.endsWith(".test.tsx")
+    ) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+function extractBalanced(source: string, startIdx: number): string | null {
+  // startIdx points at the opening '{'. Returns the substring INSIDE the braces
+  // (exclusive of the outer { }), or null if no balanced match.
+  if (source[startIdx] !== "{") {
+    return null;
+  }
+  let depth = 0;
+  for (let i = startIdx; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === "{") {
+      depth++;
+    } else if (ch === "}") {
+      depth--;
+      if (depth === 0) {
+        return source.slice(startIdx + 1, i);
+      }
+    }
+  }
+  return null;
+}
+
+function collectEmitSites(): EmitSite[] {
+  const sites: EmitSite[] = [];
+  const callRegex = /emitAuditLogEvent(?:Direct)?\s*\(\s*\{/g;
+  const actionRegex = /\baction:\s*"([^"]+)"/;
+  const targetsBlockRegex = /\btargets:\s*\[([\s\S]*?)\]/;
+  const buildTargetRegex = /buildAuditLogTarget\(\s*"([^"]+)"/g;
+  const literalTargetRegex = /\btype:\s*"([^"]+)"/g;
+
+  for (const file of listTsFiles(FRONT_DIR)) {
+    let source: string;
+    try {
+      source = fs.readFileSync(file, "utf-8");
+    } catch {
+      continue;
+    }
+    if (!source.includes("emitAuditLogEvent")) {
+      continue;
+    }
+    let match: RegExpExecArray | null;
+    while ((match = callRegex.exec(source)) !== null) {
+      const braceIdx = match.index + match[0].length - 1;
+      const body = extractBalanced(source, braceIdx);
+      if (!body) {
+        continue;
+      }
+      const actionMatch = actionRegex.exec(body);
+      if (!actionMatch) {
+        continue;
+      }
+      const action = actionMatch[1];
+
+      const targetsMatch = targetsBlockRegex.exec(body);
+      if (!targetsMatch) {
+        continue;
+      }
+      const targetsBlock = targetsMatch[1];
+
+      const targetTypes: string[] = [];
+      let bt: RegExpExecArray | null;
+      while ((bt = buildTargetRegex.exec(targetsBlock)) !== null) {
+        targetTypes.push(bt[1]);
+      }
+      buildTargetRegex.lastIndex = 0;
+      let lt: RegExpExecArray | null;
+      while ((lt = literalTargetRegex.exec(targetsBlock)) !== null) {
+        targetTypes.push(lt[1]);
+      }
+      literalTargetRegex.lastIndex = 0;
+
+      if (targetTypes.length === 0) {
+        continue;
+      }
+
+      sites.push({
+        file: path.relative(FRONT_DIR, file),
+        action,
+        targetTypes,
+      });
+    }
+  }
+  return sites;
+}
+
+describe("audit log emit call sites", () => {
+  const sites = collectEmitSites();
+
+  it("found at least one emit call site (sanity check)", () => {
+    expect(sites.length).toBeGreaterThan(0);
+  });
+
+  it("every emit call's targets match the schema for that action", () => {
+    const mismatches: string[] = [];
+    const schemaCache = new Map<string, SchemaFile>();
+
+    for (const site of sites) {
+      let schema = schemaCache.get(site.action);
+      if (!schema) {
+        try {
+          schema = readSchemaByAction(site.action);
+          schemaCache.set(site.action, schema);
+        } catch {
+          mismatches.push(
+            `${site.file}: action "${site.action}" has no schema file`
+          );
+          continue;
+        }
+      }
+      // WorkOS schemas declare the *set* of allowed target types — an emit
+      // can include multiple targets of the same type (e.g. user.identity_merged
+      // sends two user targets) without the schema repeating the type, but
+      // the set of distinct types must match exactly. Subset emits are not
+      // allowed: if we cannot send a target the schema declares, the schema
+      // must be changed (or the emit guarded so it only fires when every
+      // declared target is available).
+      const schemaTypes = new Set(schema.targets.map((t) => t.type));
+      const emitTypes = new Set(site.targetTypes);
+      const missingFromSchema = [...emitTypes].filter(
+        (t) => !schemaTypes.has(t)
+      );
+      const unusedInSchema = [...schemaTypes].filter((t) => !emitTypes.has(t));
+      if (missingFromSchema.length > 0 || unusedInSchema.length > 0) {
+        mismatches.push(
+          `${site.file}: action "${site.action}" emits targets ` +
+            `[${site.targetTypes.join(", ")}] but schema declares ` +
+            `[${[...schemaTypes].join(", ")}]`
+        );
+      }
+    }
+
+    expect(
+      mismatches,
+      `Audit log emit/schema drift:\n${mismatches.join("\n")}`
+    ).toEqual([]);
+  });
+});

--- a/front/lib/api/audit/workos_audit.test.ts
+++ b/front/lib/api/audit/workos_audit.test.ts
@@ -92,4 +92,29 @@ describe("emitAuditLogEvent", () => {
 
     expect(mockCreateAuditLogEvent).not.toHaveBeenCalled();
   });
+
+  it("truncates metadata values longer than 1000 chars", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await freshAuth(workspace.sId);
+    await FeatureFlagFactory.basic(auth, "audit_logs");
+
+    const longValue = "x".repeat(2000);
+    const shortValue = "y".repeat(50);
+
+    await emitAuditLogEvent({
+      auth,
+      action: "workspace.audit_logs_updated",
+      targets: [buildAuditLogTarget("workspace", workspace)],
+      metadata: {
+        long_field: longValue,
+        short_field: shortValue,
+      },
+    });
+
+    expect(mockCreateAuditLogEvent).toHaveBeenCalledTimes(1);
+    const eventArg = mockCreateAuditLogEvent.mock.calls[0][0].event;
+    expect(eventArg.metadata.long_field.length).toBe(1000);
+    expect(eventArg.metadata.long_field.endsWith("...[truncated]")).toBe(true);
+    expect(eventArg.metadata.short_field).toBe(shortValue);
+  });
 });

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -13,118 +13,121 @@ import logger from "@app/logger/logger";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 
-type AuditAction =
+export const AUDIT_ACTIONS = [
   // Existing Tier 1 events.
-  | "user.login"
-  | "user.logout"
-  | "membership.created"
-  | "membership.revoked"
-  | "member.invited"
-  | "sso.connection_deleted"
-  | "domain.removed"
-  | "dsync.connection_deleted"
-  | "workspace.deleted"
+  "user.login",
+  "user.logout",
+  "membership.created",
+  "membership.revoked",
+  "member.invited",
+  "sso.connection_deleted",
+  "domain.removed",
+  "dsync.connection_deleted",
+  "workspace.deleted",
   // Authentication & Admin.
-  | "user.login_failed"
-  | "user.identity_merged"
-  | "user.relocated"
+  "user.login_failed",
+  "user.identity_merged",
+  "user.relocated",
   // API Keys & Secrets.
-  | "api_key.created"
-  | "api_key.revoked"
-  | "api_key.updated"
+  "api_key.created",
+  "api_key.revoked",
+  "api_key.updated",
   // Membership & Invitations.
-  | "membership.role_updated"
-  | "membership.origin_updated"
-  | "invitation.revoked"
-  | "invitation.role_updated"
-  | "member.bulk_invited"
-  | "member.bulk_revoked"
-  | "member.spend_limit_updated"
+  "membership.role_updated",
+  "membership.origin_updated",
+  "invitation.revoked",
+  "invitation.role_updated",
+  "member.bulk_invited",
+  "member.bulk_revoked",
+  "member.spend_limit_updated",
   // Domains & SSO.
-  | "domain.verified"
-  | "domain.verification_failed"
+  "domain.verified",
+  "domain.verification_failed",
   // OAuth & Credentials.
-  | "oauth.initiated"
-  | "oauth.authorized"
-  | "oauth.revoked"
-  | "credentials.created"
-  | "credentials.updated"
-  | "credentials.revoked"
-  | "credentials.invalidated"
+  "oauth.initiated",
+  "oauth.authorized",
+  "oauth.revoked",
+  "credentials.created",
+  "credentials.updated",
+  "credentials.revoked",
+  "credentials.invalidated",
   // MCP Connections.
-  | "mcp_connection.created"
-  | "mcp_connection.deleted"
+  "mcp_connection.created",
+  "mcp_connection.deleted",
   // Projects.
-  | "project.joined"
-  | "project.left"
+  "project.joined",
+  "project.left",
   // Self-improvement.
-  | "self_improvement.enabled"
-  | "self_improvement.batch_mode_updated"
-  | "skill.self_improvement_updated"
+  "self_improvement.enabled",
+  "self_improvement.batch_mode_updated",
+  "skill.self_improvement_updated",
   // Sandbox.
-  | "sandbox_egress_policy.agent_requests_setting_updated"
-  | "sandbox_egress_policy.sandbox_updated"
-  | "sandbox_egress_policy.updated"
-  | "sandbox_env_var.allowed_domains_updated"
-  | "sandbox_env_var.created"
-  | "sandbox_env_var.deleted"
-  | "sandbox_env_var.promoted_to_https_secret"
-  | "sandbox_env_var.updated"
+  "sandbox_egress_policy.agent_requests_setting_updated",
+  "sandbox_egress_policy.sandbox_updated",
+  "sandbox_egress_policy.updated",
+  "sandbox_env_var.allowed_domains_updated",
+  "sandbox_env_var.created",
+  "sandbox_env_var.deleted",
+  "sandbox_env_var.promoted_to_https_secret",
+  "sandbox_env_var.updated",
   // Workspace settings.
-  | "workspace.audit_logs_updated"
-  | "workspace.default_user_spend_limit_updated"
+  "workspace.audit_logs_updated",
+  "workspace.default_user_spend_limit_updated",
   // SCIM / Directory Sync.
-  | "scim.user_provisioned"
-  | "scim.user_updated"
-  | "scim.user_deprovisioned"
-  | "scim.group_created"
-  | "scim.group_deleted"
-  | "scim.group_user_added"
-  | "scim.group_user_removed"
+  "scim.user_provisioned",
+  "scim.user_updated",
+  "scim.user_deprovisioned",
+  "scim.group_created",
+  "scim.group_deleted",
+  "scim.group_user_added",
+  "scim.group_user_removed",
   // Agent & Tool Execution.
-  | "agent.executed"
-  | "tool.executed"
+  "agent.executed",
+  "tool.executed",
   // Triggers.
-  | "trigger.created"
-  | "trigger.deleted"
-  | "trigger.enabled"
-  | "trigger.disabled"
-  | "trigger.fired"
-  | "trigger.email_received"
+  "trigger.created",
+  "trigger.deleted",
+  "trigger.enabled",
+  "trigger.disabled",
+  "trigger.fired",
+  "trigger.email_received",
   // Wake-ups.
-  | "wake_up.cancelled"
-  | "wake_up.created"
-  | "wake_up.expired"
-  | "wake_up.fired"
+  "wake_up.cancelled",
+  "wake_up.created",
+  "wake_up.expired",
+  "wake_up.fired",
   // Agent lifecycle.
-  | "agent.created"
-  | "agent.updated"
-  | "agent.archived"
-  | "agent.restored"
-  | "agent.scope_changed"
+  "agent.created",
+  "agent.updated",
+  "agent.archived",
+  "agent.restored",
+  "agent.scope_changed",
   // Spaces.
-  | "space.accessed"
-  | "space.created"
-  | "space.deleted"
-  | "space.permissions_updated"
+  "space.accessed",
+  "space.created",
+  "space.deleted",
+  "space.permissions_updated",
   // Conversations.
-  | "conversation.accessed"
+  "conversation.accessed",
   // Data Sources.
-  | "datasource.created"
-  | "datasource.updated"
-  | "datasource.deleted"
-  | "datasource.deleted_admin"
-  | "datasource.reauthorized"
+  "datasource.created",
+  "datasource.updated",
+  "datasource.deleted",
+  "datasource.deleted_admin",
+  "datasource.reauthorized",
   // Files.
-  | "file.moved"
+  "file.moved",
   // Audit Logs.
-  | "audit_log.viewed"
-  | "audit_log.export_configured"
+  "audit_log.viewed",
+  "audit_log.export_configured",
   // Billing & Subscriptions.
-  | "subscription.changed"
+  "subscription.changed",
   // Coupons.
-  | "coupon.redeemed"
-  | "coupon.revoked";
+  "coupon.redeemed",
+  "coupon.revoked",
+] as const;
+
+export type AuditAction = (typeof AUDIT_ACTIONS)[number];
 
 export type EmitAuditLogEventParams = {
   auth: Authenticator;

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -137,9 +137,18 @@ export type EmitAuditLogEventParams = {
   metadata?: Record<string, string | number | boolean>;
 };
 
+// Max characters allowed per metadata value before truncation. Bounds the
+// total payload size so audit logs survive emit sites that pass unbounded
+// strings (e.g. `tool.executed` joining accessed data source IDs).
+const METADATA_VALUE_MAX_CHARS = 1000;
+const METADATA_TRUNCATION_SUFFIX = "...[truncated]";
+
 /**
  * Serializes all metadata values to strings so the emitted event matches the
  * schema definitions, which declare every metadata value as `"string"`.
+ * Values longer than METADATA_VALUE_MAX_CHARS are truncated with a suffix
+ * so a single oversized field cannot push the whole event past the WorkOS
+ * audit log size limit.
  */
 function serializeMetadata(
   metadata: Record<string, string | number | boolean> | undefined
@@ -149,7 +158,16 @@ function serializeMetadata(
   }
   const result: Record<string, string> = {};
   for (const [key, value] of Object.entries(metadata)) {
-    result[key] = typeof value === "string" ? value : String(value);
+    const stringValue = typeof value === "string" ? value : String(value);
+    if (stringValue.length > METADATA_VALUE_MAX_CHARS) {
+      result[key] =
+        stringValue.slice(
+          0,
+          METADATA_VALUE_MAX_CHARS - METADATA_TRUNCATION_SUFFIX.length
+        ) + METADATA_TRUNCATION_SUFFIX;
+    } else {
+      result[key] = stringValue;
+    }
   }
   return result;
 }

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -844,13 +844,14 @@ async function emitGCSMountFileMovedAuditLog(
   }
 ): Promise<void> {
   const workspace = auth.getNonNullableWorkspace();
-  const targets = [buildAuditLogTarget("workspace", workspace)];
-  const metadata: Record<string, string> = {
-    relative_file_path: relativeFilePath,
-    parent_relative_path: parentRelativePath,
-    space_id: "",
-    conversation_id: "",
-  };
+
+  // file.moved emits a single shape: [workspace, space, conversation]. When a
+  // given move only has one of space/conversation, the other gets an "unknown"
+  // placeholder so the emit always matches the schema's declared targets (no
+  // subset emits). Same pattern as user.login_failed.
+  const UNKNOWN_TARGET = { sId: "unknown", name: "unknown" };
+  let spaceData: { sId: string; name: string } = UNKNOWN_TARGET;
+  let conversationData: { sId: string; name: string } = UNKNOWN_TARGET;
 
   switch (scope.useCase) {
     case "pod": {
@@ -858,8 +859,7 @@ async function emitGCSMountFileMovedAuditLog(
       if (!space) {
         return;
       }
-      targets.push(buildAuditLogTarget("space", space));
-      metadata.space_id = space.sId;
+      spaceData = { sId: space.sId, name: space.name };
       break;
     }
     case "conversation": {
@@ -870,13 +870,10 @@ async function emitGCSMountFileMovedAuditLog(
       if (!conversation) {
         return;
       }
-      targets.push(
-        buildAuditLogTarget("conversation", {
-          sId: conversation.sId,
-          name: conversation.title ?? "",
-        })
-      );
-      metadata.conversation_id = conversation.sId;
+      conversationData = {
+        sId: conversation.sId,
+        name: conversation.title ?? "",
+      };
       break;
     }
     default:
@@ -886,9 +883,18 @@ async function emitGCSMountFileMovedAuditLog(
   void emitAuditLogEvent({
     auth,
     action: "file.moved",
-    targets,
+    targets: [
+      buildAuditLogTarget("workspace", workspace),
+      buildAuditLogTarget("space", spaceData),
+      buildAuditLogTarget("conversation", conversationData),
+    ],
     context: getAuditLogContext(auth),
-    metadata,
+    metadata: {
+      relative_file_path: relativeFilePath,
+      parent_relative_path: parentRelativePath,
+      space_id: spaceData.sId,
+      conversation_id: conversationData.sId,
+    },
   });
 }
 

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -474,9 +474,12 @@ export async function handleMembershipInvitations(
     void emitAuditLogEvent({
       auth,
       action: "member.invited",
-      targets: successfulInvites.map((r) =>
-        buildAuditLogTarget("user", { sId: r.email, name: r.email })
-      ),
+      targets: [
+        buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+        ...successfulInvites.map((r) =>
+          buildAuditLogTarget("user", { sId: r.email, name: r.email })
+        ),
+      ],
       context: getAuditLogContext(auth),
       metadata: {
         invited_count: String(successfulInvites.length),

--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -4,6 +4,7 @@ import {
   emitAuditLogEventDirect,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
+import type { AuditLogActor } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import {
@@ -170,12 +171,18 @@ export async function createAndTrackMembership({
   role,
   origin,
   useFreeSeat = true,
+  auditActor,
 }: {
   user: UserResource;
   workspace: WorkspaceResource | WorkspaceModel | LightWorkspaceType;
   role: ActiveRoleType;
   origin: MembershipOriginType;
   useFreeSeat?: boolean;
+  // Override for the audit-log actor. Defaults to the user themselves, which
+  // is correct for self-signup. SCIM/system-driven provisioning should pass
+  // `{ type: "system", id: directoryId, name: "Directory Sync" }` so the
+  // audit row doesn't read like the user provisioned themselves.
+  auditActor?: AuditLogActor;
 }) {
   const w =
     workspace instanceof WorkspaceModel ||
@@ -205,7 +212,7 @@ export async function createAndTrackMembership({
   void emitAuditLogEventDirect({
     workspace: w,
     action: "membership.created",
-    actor: {
+    actor: auditActor ?? {
       type: "user",
       id: user.sId,
       name: user.fullName() ?? "unknown",
@@ -249,9 +256,16 @@ export async function revokeAndTrackMembership(
   {
     transaction,
     allowLastAdminRevocation = false,
+    auditActor,
   }: {
     transaction?: Transaction;
     allowLastAdminRevocation?: boolean;
+    // Override for the audit-log actor. When omitted, the actor is derived
+    // from `auth` (typically a generic system actor when called from SCIM,
+    // since auth is internalAdminForWorkspace). SCIM callers should pass
+    // `{ type: "system", id: directoryId, name: "Directory Sync" }` so the
+    // audit row identifies which directory triggered the revocation.
+    auditActor?: AuditLogActor;
   } = {}
 ) {
   const workspace = auth.getNonNullableWorkspace();
@@ -288,21 +302,40 @@ export async function revokeAndTrackMembership(
       endAt: revokeResult.value.endAt,
     });
 
-    void emitAuditLogEvent({
-      auth,
-      action: "membership.revoked",
-      targets: [
-        buildAuditLogTarget("workspace", workspace),
-        buildAuditLogTarget("user", {
-          sId: user.sId,
-          name: user.fullName() ?? "unknown",
-        }),
-      ],
-      context: getAuditLogContext(auth),
-      metadata: {
-        previous_role: revokeResult.value.role,
-      },
-    });
+    if (auditActor) {
+      void emitAuditLogEventDirect({
+        workspace,
+        action: "membership.revoked",
+        actor: auditActor,
+        targets: [
+          buildAuditLogTarget("workspace", workspace),
+          buildAuditLogTarget("user", {
+            sId: user.sId,
+            name: user.fullName() ?? "unknown",
+          }),
+        ],
+        context: getAuditLogContext(auth),
+        metadata: {
+          previous_role: revokeResult.value.role,
+        },
+      });
+    } else {
+      void emitAuditLogEvent({
+        auth,
+        action: "membership.revoked",
+        targets: [
+          buildAuditLogTarget("workspace", workspace),
+          buildAuditLogTarget("user", {
+            sId: user.sId,
+            name: user.fullName() ?? "unknown",
+          }),
+        ],
+        context: getAuditLogContext(auth),
+        metadata: {
+          previous_role: revokeResult.value.role,
+        },
+      });
+    }
 
     // Remove seat in Metronome if workspace is Metronome-billed.
     const removeSeatResult = await syncSeatCountForWorkspace(workspace);

--- a/front/lib/api/workos/organization.ts
+++ b/front/lib/api/workos/organization.ts
@@ -444,7 +444,15 @@ export async function createAuditLogEvent({
     return new Ok(undefined);
   } catch (error) {
     const e = normalizeError(error);
-    logger.error(e, "Failed to create audit log event");
+    logger.error(
+      {
+        ...e,
+        workspaceId: workspace.sId,
+        action: event.action,
+        targetTypes: event.targets.map((t) => t.type),
+      },
+      "Failed to create audit log event"
+    );
     return new Err(new Error(`Failed to create audit log event: ${e.message}`));
   }
 }

--- a/front/lib/api/workos/organization.ts
+++ b/front/lib/api/workos/organization.ts
@@ -405,6 +405,12 @@ export type CreateAuditLogEventParams = {
   metadata?: Record<string, string | number | boolean>;
 };
 
+// Conservative pre-flight ceiling for the serialized event payload. WorkOS
+// rejects oversized audit-log requests with "request entity too large", which
+// produced ~26k errors/month in production. Skipping above this threshold
+// turns silent rejections into observable warnings.
+const PAYLOAD_SIZE_LIMIT_BYTES = 60_000;
+
 export async function createAuditLogEvent({
   workspace,
   event,
@@ -415,6 +421,25 @@ export async function createAuditLogEvent({
   if (!workspace.workOSOrganizationId) {
     return new Err(
       new Error("WorkOS organization not found for this workspace.")
+    );
+  }
+
+  const payloadSizeBytes = JSON.stringify(event).length;
+  if (payloadSizeBytes > PAYLOAD_SIZE_LIMIT_BYTES) {
+    logger.warn(
+      {
+        workspaceId: workspace.sId,
+        action: event.action,
+        targetTypes: event.targets.map((t) => t.type),
+        payloadSizeBytes,
+        limit: PAYLOAD_SIZE_LIMIT_BYTES,
+      },
+      "Skipping oversized audit log event"
+    );
+    return new Err(
+      new Error(
+        `Audit log payload exceeds size limit (${payloadSizeBytes} > ${PAYLOAD_SIZE_LIMIT_BYTES} bytes).`
+      )
     );
   }
 
@@ -450,6 +475,7 @@ export async function createAuditLogEvent({
         workspaceId: workspace.sId,
         action: event.action,
         targetTypes: event.targets.map((t) => t.type),
+        payloadSizeBytes,
       },
       "Failed to create audit log event"
     );

--- a/front/pages/api/w/[wId]/credentials/index.ts
+++ b/front/pages/api/w/[wId]/credentials/index.ts
@@ -112,7 +112,13 @@ async function handler(
       void emitAuditLogEvent({
         auth,
         action: "credentials.created",
-        targets: [buildAuditLogTarget("workspace", owner)],
+        targets: [
+          buildAuditLogTarget("workspace", owner),
+          buildAuditLogTarget("credential", {
+            sId: response.value.credential.credential_id,
+            name: String(bodyValidation.data.provider),
+          }),
+        ],
         context: getAuditLogContext(auth, req),
         metadata: {
           provider: String(bodyValidation.data.provider),

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -364,6 +364,7 @@ async function handleCallback(req: NextApiRequest, res: NextApiResponse) {
     : {};
 
   let callbackWorkspaceId: string | undefined;
+  let callbackUserEmail: string | undefined;
 
   try {
     const {
@@ -376,6 +377,7 @@ async function handleCallback(req: NextApiRequest, res: NextApiResponse) {
       code,
       organizationId: stateObj.organizationId,
     });
+    callbackUserEmail = user.email;
 
     if (!sealedSession) {
       throw new Error("Sealed session not found");
@@ -612,11 +614,16 @@ async function handleCallback(req: NextApiRequest, res: NextApiResponse) {
   } catch (error) {
     logger.error({ error }, "Error during WorkOS callback");
 
-    // Emit user.login_failed if workspace context is available.
-    // Login failures without a workspace context are not audit-logged — WorkOS captures those.
+    // Emit user.login_failed when workspace context is available. Login
+    // failures without workspace context are not audit-logged because audit
+    // logs are workspace-scoped — WorkOS captures those on their side.
+    // When the workspace is known but the user email isn't (e.g. failure
+    // before authenticateWithWorkOSCode could resolve), fall back to
+    // "unknown" for the user target so emit and schema targets always match.
     if (callbackWorkspaceId) {
       const loginFailedAuth =
         await Authenticator.internalAdminForWorkspace(callbackWorkspaceId);
+      const userIdentifier = callbackUserEmail ?? "unknown";
       void emitAuditLogEvent({
         auth: loginFailedAuth,
         action: "user.login_failed",
@@ -625,6 +632,13 @@ async function handleCallback(req: NextApiRequest, res: NextApiResponse) {
             "workspace",
             loginFailedAuth.getNonNullableWorkspace()
           ),
+          // Follow the member.invited pattern: when we don't have a Dust
+          // UserResource (the user may never have signed up here), use the
+          // email as the user target's sId.
+          buildAuditLogTarget("user", {
+            sId: userIdentifier,
+            name: userIdentifier,
+          }),
         ],
         metadata: {
           reason: normalizeError(error).message,

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -40,6 +40,21 @@ const CONVERSATION_CACHE_TTL_MS = 5000;
 // the configuration sId. External MCP servers (e.g. Airtable) bypass that
 // augmentation and may send entries like { tableId, fieldIds } with no uri, so
 // uri access must be guarded and we fall back to tableId when available.
+// Cap the per-field ID list for the tool.executed audit event so tools that
+// touch dozens of data sources don't blow the WorkOS payload limit. A sample
+// of 30 IDs preserves forensic cross-reference (~25 chars * 30 IDs = ~750
+// chars, well under the 1000-char per-value metadata cap), and the
+// "+N more" suffix preserves the total count without joining every ID.
+const TOOL_EXECUTED_MAX_SAMPLE_IDS = 30;
+
+function formatAccessedIdsSample(ids: string[]): string {
+  if (ids.length <= TOOL_EXECUTED_MAX_SAMPLE_IDS) {
+    return ids.join(",");
+  }
+  const sample = ids.slice(0, TOOL_EXECUTED_MAX_SAMPLE_IDS).join(",");
+  return `${sample},+${ids.length - TOOL_EXECUTED_MAX_SAMPLE_IDS} more`;
+}
+
 function extractDataSourceIds(
   inputs: Record<string, unknown>
 ): Record<string, string> {
@@ -49,13 +64,13 @@ function extractDataSourceIds(
   const lastUriSegment = (v: unknown): string | undefined =>
     isString(v) ? v.split("/").pop() : undefined;
   if (Array.isArray(ds) && ds.length > 0) {
-    result.accessed_data_source_ids = ds
+    const ids = ds
       .map((d: { uri?: unknown }) => lastUriSegment(d.uri) ?? "")
-      .filter(Boolean)
-      .join(",");
+      .filter(Boolean);
+    result.accessed_data_source_ids = formatAccessedIdsSample(ids);
   }
   if (Array.isArray(tables) && tables.length > 0) {
-    result.accessed_table_ids = tables
+    const ids = tables
       .map((t: { uri?: unknown; tableId?: unknown }) => {
         const segment = lastUriSegment(t.uri);
         if (segment) {
@@ -63,8 +78,8 @@ function extractDataSourceIds(
         }
         return isString(t.tableId) ? t.tableId : "";
       })
-      .filter(Boolean)
-      .join(",");
+      .filter(Boolean);
+    result.accessed_table_ids = formatAccessedIdsSample(ids);
   }
   return result;
 }

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -1180,6 +1180,11 @@ async function handleCreateOrUpdateWorkOSUser(
     workspace,
     role: "user",
     origin: "provisioned",
+    auditActor: {
+      type: "system",
+      id: String(eventData.directoryId ?? "directory_sync"),
+      name: "Directory Sync",
+    },
   });
 
   void emitAuditLogEventDirect({
@@ -1258,6 +1263,11 @@ async function handleDeleteWorkOSUser(
 
   const membershipRevokeResult = await revokeAndTrackMembership(auth, user, {
     allowLastAdminRevocation: true,
+    auditActor: {
+      type: "system",
+      id: String(eventData.directoryId ?? "directory_sync"),
+      name: "Directory Sync",
+    },
   });
 
   if (membershipRevokeResult.isErr()) {

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -155,6 +155,42 @@ async function verifyWorkOSWorkspace<E extends Event, R>(
   return handler(workspace, event);
 }
 
+function emitMembershipRoleUpdatedFromDirectorySync({
+  workspace,
+  user,
+  directoryId,
+  previousRole,
+  newRole,
+}: {
+  workspace: LightWorkspaceType;
+  user: UserResource;
+  directoryId?: string;
+  previousRole: string;
+  newRole: string;
+}): void {
+  void emitAuditLogEventDirect({
+    workspace,
+    action: "membership.role_updated",
+    actor: {
+      type: "system",
+      id: String(directoryId ?? "directory_sync"),
+      name: "Directory Sync",
+    },
+    targets: [
+      buildAuditLogTarget("workspace", workspace),
+      buildAuditLogTarget("user", {
+        sId: user.sId,
+        name: user.fullName() ?? "unknown",
+      }),
+    ],
+    context: { location: "system" },
+    metadata: {
+      previous_role: previousRole,
+      new_role: newRole,
+    },
+  });
+}
+
 /**
  * Handle role assignment based on the name of the group.
  */
@@ -165,11 +201,13 @@ async function handleRoleAssignmentForGroup(
     user,
     group,
     action,
+    directoryId,
   }: {
     workspace: LightWorkspaceType;
     user: UserResource;
     group: GroupResource;
     action: "add" | "remove";
+    directoryId?: string;
   }
 ) {
   if (group.name !== ADMIN_GROUP_NAME && group.name !== BUILDER_GROUP_NAME) {
@@ -229,6 +267,14 @@ async function handleRoleAssignmentForGroup(
         previousRole: currentMembership.role,
         role: newRole,
       });
+
+      emitMembershipRoleUpdatedFromDirectorySync({
+        workspace,
+        user,
+        directoryId,
+        previousRole: String(currentMembership.role),
+        newRole: String(newRole),
+      });
     }
   } else if (action === "remove") {
     const newRole = await determineUserRoleFromGroups(workspace, user);
@@ -268,6 +314,14 @@ async function handleRoleAssignmentForGroup(
         workspace,
         previousRole: currentMembership.role,
         role: newRole,
+      });
+
+      emitMembershipRoleUpdatedFromDirectorySync({
+        workspace,
+        user,
+        directoryId,
+        previousRole: String(currentMembership.role),
+        newRole: String(newRole),
       });
     }
   }
@@ -799,6 +853,7 @@ async function handleUserAddedToGroup(
     user,
     group,
     action: "add",
+    directoryId: eventData.directoryId ?? undefined,
   });
 
   // Update membership origin to "provisioned" when syncing from WorkOS groups.
@@ -947,6 +1002,7 @@ async function handleUserRemovedFromGroup(
     user,
     group,
     action: "remove",
+    directoryId: eventData.directoryId ?? undefined,
   });
 
   void emitAuditLogEventDirect({


### PR DESCRIPTION
Fixes [#8266](https://github.com/dust-tt/tasks/issues/8266) — membership.role_updated audit log events were silently failing for all customers with audit logs enabled.
## Description
**Three root causes:**

1. Stale WorkOS schema registrations — 8 events (including membership.role_updated) had schemas registered in WorkOS with different target types than what the code sends, causing 400 errors (~9,800/month). Additionally, 7 events added since May 7 were never registered at all (~960/month).
2. Missing SCIM audit emit — SCIM-driven role changes via handleRoleAssignmentForGroup updated the role and tracked via ServerSideTracking but never emitted a membership.role_updated audit log event. Customers using directory sync saw no role changes in their audit logs.
3. Oversized payloads — request entity too large was the single largest source of audit log failures (~26k/month), primarily from tool.executed events with unbounded ID lists.

**What this PR does:**

- Fixes 4 schema JSON files to match their emit calls (user.identity_merged, user.login_failed, member.invited, file.moved)
- Adds membership.role_updated emit for SCIM role changes + extracts helper to avoid duplication
- Attributes SCIM-driven membership.created/membership.revoked to "Directory Sync" actor instead of the user
- Adds payload truncation (1000 char/value cap) + pre-flight 60KB size check + tool.executed ID sampling (30 IDs + "+N more")
- Adds audit_log_schemas.test.ts with Tests A–D preventing future drift
- Adds [AUDIT10] coding rule + updates Claude skill
- Improves error logging with workspace, action, and target context
- Full audit of all 88 schema files confirmed remaining schemas match their emit calls


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

1. New audit_log_schemas.test.ts enforces: every AuditAction has a schema file (A), no orphan schemas (B), emit targets match schema targets (C), metadata keys are snake_case (D)
2. Unit test for metadata truncation at 1000 chars
3. Test C uses brace-balanced extraction + regex to scan all emit call sites; fails loudly on unextractable targets to prevent silent drift

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low. Audit log emits are fire-and-forget (void) — failures don't affect user-facing behavior.
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [x] run schema registration
- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
