### PR TITLE
Escape full xml block with attributes in agent instructions

### DIFF
--- a/front/components/editor/extensions/agent_builder/InstructionBlockExtension.test.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionBlockExtension.test.ts
@@ -2,10 +2,25 @@ import { InstructionBlockExtension } from "@app/components/editor/extensions/age
 import { InstructionsDocumentExtension } from "@app/components/editor/extensions/instructions/InstructionsDocumentExtension";
 import { InstructionsRootExtension } from "@app/components/editor/extensions/instructions/InstructionsRootExtension";
 import { EditorFactory } from "@app/components/editor/extensions/tests/utils";
-import type { Editor } from "@tiptap/core";
+import { preprocessMarkdownForEditor } from "@app/components/editor/lib/preprocessMarkdownForEditor";
+import type { Editor, JSONContent } from "@tiptap/core";
 import type { Slice } from "@tiptap/pm/model";
 import { TextSelection } from "@tiptap/pm/state";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+function collectInstructionBlocks(node: JSONContent): JSONContent[] {
+  const blocks: JSONContent[] = [];
+
+  if (node.type === "instructionBlock") {
+    blocks.push(node);
+  }
+
+  for (const child of node.content ?? []) {
+    blocks.push(...collectInstructionBlocks(child));
+  }
+
+  return blocks;
+}
 
 describe("InstructionBlockExtension", () => {
   let editor: Editor;
@@ -456,6 +471,50 @@ This rule has no attributes
 </prompt>
 
 &nbsp;`);
+  });
+
+  it("loads attributed XML-like tags as text", () => {
+    editor.destroy();
+    editor = EditorFactory(
+      [
+        InstructionsDocumentExtension,
+        InstructionsRootExtension,
+        InstructionBlockExtension,
+      ],
+      { starterKit: { document: false } }
+    );
+
+    editor.commands.setContent(
+      preprocessMarkdownForEditor(`<system_prompt>
+You are a helpful assistant.
+</system_prompt>
+
+1 <section title="Overview">
+<do>
+Summarize the account.
+<do>Use public data only.
+</section>
+
+2. <section title="Next Steps">
+<do>List the next steps.</do>
+</section>`),
+      {
+        emitUpdate: false,
+        contentType: "markdown",
+      }
+    );
+
+    const sectionBlocks = collectInstructionBlocks(editor.getJSON()).filter(
+      (block) => block.attrs?.type === "section"
+    );
+    const doBlocks = collectInstructionBlocks(editor.getJSON()).filter(
+      (block) => block.attrs?.type === "do"
+    );
+
+    expect(sectionBlocks).toHaveLength(0);
+    expect(doBlocks).toHaveLength(0);
+    expect(editor.getText()).toContain('section title="Overview"');
+    expect(editor.getText()).toContain("Use public data only.");
   });
 });
 

--- a/front/components/editor/lib/preprocessMarkdownForEditor.ts
+++ b/front/components/editor/lib/preprocessMarkdownForEditor.ts
@@ -91,12 +91,32 @@ export function preprocessMarkdownForEditor(markdown: string): string {
   );
   const openCount = new Map<string, number>();
   const validNestedPositions = new Set<number>();
+  const escapedContainerStack: string[] = [];
 
   processed = processed.replace(
     escapedTagRegex,
     (match, slash, tagName, rest, offset) => {
       const normalized = tagName.toLowerCase();
       const isClosing = slash === "/";
+
+      // Attribute-bearing containers stay text-only; otherwise their nested
+      // XML-like tags can be partially unescaped into invalid instruction blocks.
+      if (escapedContainerStack.length > 0) {
+        if (
+          isClosing &&
+          normalized === escapedContainerStack[escapedContainerStack.length - 1]
+        ) {
+          escapedContainerStack.pop();
+        } else if (!isClosing && rest !== "" && matchedPairs.has(normalized)) {
+          escapedContainerStack.push(normalized);
+        }
+        return match;
+      }
+
+      if (!isClosing && rest !== "" && matchedPairs.has(normalized)) {
+        escapedContainerStack.push(normalized);
+        return match;
+      }
 
       if (isClosing) {
         const count = openCount.get(normalized) ?? 0;
@@ -115,12 +135,6 @@ export function preprocessMarkdownForEditor(markdown: string): string {
       const isNestedChild = validNestedPositions.has(offset);
 
       if (matchedPairs.has(normalized) && (isAtLineStart || isNestedChild)) {
-        // Don't un-escape if the tag has attributes — those cause schema violations.
-        // When we skip un-escaping, openCount is NOT incremented, so the closing tag
-        // also stays escaped automatically.
-        if (rest !== "") {
-          return match;
-        }
         openCount.set(normalized, (openCount.get(normalized) ?? 0) + 1);
         validNestedPositions.add(offset + match.length);
         return `<${slash}${tagName}${rest}>`;


### PR DESCRIPTION
## Description

* https://github.com/dust-tt/tasks/issues/8209
* User was seeing agent load failure because opening xml tag was escaped when it had an attribute, but he closing block was not escaped

## Tests

* Replicated instructions that caused issue. Saw fix after implmentation

## Risk

* Low (intended to fix issue)

## Deploy Plan

* Deploy front