### PR TITLE
Fix: prompt Frame to use the canonical sccoped path.

### DIFF
--- a/front/components/assistant/conversation/InAppBanner.tsx
+++ b/front/components/assistant/conversation/InAppBanner.tsx
@@ -139,11 +139,11 @@ function PodBanner({
       </div>
       <div className="relative px-4 py-3">
         <div className="mb-1 text-sm font-medium text-foreground dark:text-foreground-night">
-          Collaboration just got an upgrade: Introducing Pods!
+          Introducing Pods: bring everyone into the room
         </div>
         <h4 className="mb-3 text-xs leading-tight text-primary dark:text-primary-night">
-          Pods bring humans and agents together in one shared workspace, so
-          nothing gets lost between them.
+          Pods bring your team of humans and agents into one place with the
+          context, tools and goals to move faster on complex work
         </h4>
         <div className="flex flex-wrap items-center gap-2">
           <Button

--- a/front/lib/api/actions/servers/common/viz/instructions.ts
+++ b/front/lib/api/actions/servers/common/viz/instructions.ts
@@ -60,7 +60,10 @@ export const VIZ_FILE_HANDLING_GUIDELINES = `
   - Files attached to the conversation can be accessed using the \`useFile()\` React hook (all files can be accessed by the hook irrespective of their status).
   - \`useFile\` has to be imported from \`"@dust/react-hooks"\`.
   - Like any React hook, \`useFile\` must be called inside a React component at the top level (not in event handlers, loops, or conditions).
-  - \`useFile()\` accepts either a file ID (e.g. \`"fil_abc123"\`, as found in \`<attachment id="fil_..." ...>\` tags) or a scoped file path (e.g. \`"conversation/report.csv"\`). Pass whichever you already have.
+  - \`useFile()\` accepts either a file ID (e.g. \`"fil_abc123"\`, as found in \`<attachment id="fil_..." ...>\` tags) or a scoped file path. Supported scoped path formats:
+    - \`"conversation-{conversationId}/report.csv"\` — a file in a specific conversation (portable)
+    - \`"pod-{podId}/filename.md"\` — a file in a specific pod (portable)
+    - **Never use bare \`"conversation/filename"\` or \`"pod/filename"\` (without their respective ID)** — these paths are context-dependent: they only resolve correctly when the frame is rendered inside that exact conversation or pod. They are non-portable and will silently load the wrong file or fail in any other context. Always use the explicit \`"conversation-{conversationId}/filename"\` or \`"pod-{podId}/filename"\` forms instead.
   - File IDs, that will be used with \`useFile()\`, should be stored as non-breaking strings in the code, e.g store and use \`"fil_..."\` and NOT concatenation \`"fil_" + file.id\`
   - Once/if the file is available, \`useFile()\` will return a non-null \`File\` object. The \`File\` object is a browser File object. Examples of using \`useFile\` are available below.
   - \`file.text()\` is ASYNC - Always use await \`file.text()\` inside useEffect with async function. Never call \`file.text()\` directly in render logic as it returns a Promise, not a string.

--- a/front/lib/api/actions/servers/pod_manager/metadata.ts
+++ b/front/lib/api/actions/servers/pod_manager/metadata.ts
@@ -130,7 +130,7 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
     description:
       "Get information about the Pod: URL, title, description, pinned frame, and linked content nodes " +
       "attached to the Pod context. Does NOT list Pod files. Pod files live under " +
-      `\`pod/<rel>\` scoped paths and are discovered through the \`${FILES_SERVER_NAME}\` MCP server.`,
+      `\`pod-{podId}/<rel>\` scoped paths and are discovered through the \`${FILES_SERVER_NAME}\` MCP server.`,
     schema: {
       dustPod: ConfigurableToolInputSchemas[
         INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_POD
@@ -360,7 +360,7 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
 
 const POD_MANAGER_INSTRUCTIONS =
   "Pod files and metadata are shared across all conversations in this Pod. " +
-  `Pod files are managed through the \`${FILES_SERVER_NAME}\` MCP server using \`pod/<rel>\` scoped paths ` +
+  `Pod files are managed through the \`${FILES_SERVER_NAME}\` MCP server using \`pod-{podId}/<rel>\` scoped paths ` +
   "(create, cat, grep, list, delete), not through this server. " +
   "Use `add_content_node` to reference a Company Data node in the Pod context, and " +
   "`remove_content_node` to remove such a reference. " +
@@ -379,7 +379,7 @@ export const POD_MANAGER_SERVER = {
     description:
       "Manage Pod metadata, members, conversations, and Company Data references. " +
       `Raw Pod file operations (create, read, search, write, delete) live in the \`${FILES_SERVER_NAME}\` MCP ` +
-      "server under `pod/<rel>` scoped paths.",
+      "server under `pod-{podId}/<rel>` scoped paths.",
     icon: "ActionDocumentTextIcon",
     authorization: null,
     documentationUrl: null,

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -419,7 +419,7 @@ export function createProjectManagerTools(
         );
 
         // Linked content nodes (Company Data references) have no other discovery surface, so we
-        // surface them here. Pod files do (they live under `pod/<rel>` scoped paths and are
+        // surface them here. Pod files do (they live under `pod-{podId}/<rel>` scoped paths and are
         // discovered through the `files` MCP server), so we only report a count plus a hint.
         const attachments = await listProjectContextAttachments(auth, space);
         const contentNodes = attachments

--- a/front/lib/api/actions/servers/run_agent/conversation.ts
+++ b/front/lib/api/actions/servers/run_agent/conversation.ts
@@ -114,9 +114,9 @@ export async function getOrCreateConversation(
   }
 
   // Resolve scoped file paths in the parent's auth/conversation scope. Any failure here surfaces
-  // cleanly before the sub-conversation is created. `pod/<rel>` paths are validated but not
+  // cleanly before the sub-conversation is created. `pod-{podId}/<rel>` paths are validated but not
   // copied (the Pod mount is shared across the Pod's conversations).
-  // `conversation/<rel>` paths are copied to the sub-conversation's mount once the sub exists.
+  // `conversation-{conversationId}/<rel>` paths are copied to the sub-conversation's mount once the sub exists.
   // A short hint is appended to the sub's first message so it knows which paths were forwarded;
   // the sub reads them through the files MCP server.
   let resolvedFilePaths: ResolvedScopedFilePath[] = [];

--- a/front/lib/resources/skill/code_defined/projects.ts
+++ b/front/lib/resources/skill/code_defined/projects.ts
@@ -29,15 +29,15 @@ Note: Pods were previously called "Projects". Some users may still refer to them
 
 ## Persistent Knowledge
 
-Can be also referred to as the "Pod Context". Pod files live under \`pod/<rel>\`
+Can be also referred to as the "Pod Context". Pod files live under \`pod-{podId}/<rel>\`
 scoped paths and persist across every conversation in the Pod. Conversation-only files live
-under \`conversation/<rel>\` and are visible to this conversation only. Both surfaces are reached
+under \`conversation-{conversationId}/<rel>\` and are visible to this conversation only. Both surfaces are reached
 through the same file system; prefer the sandbox when it's available (see the sandbox skill for
 the mount layout), and fall back to the \`${FILES_SERVER_NAME}\` MCP tools when it isn't. The Pod also accepts
 references to connected data nodes (Company Data); those are managed through the
 \`${POD_MANAGER_SERVER_NAME}\` server.
 
-To keep something for later Pod-wide use, write it under a \`pod/<rel>\` path. To duplicate
+To keep something for later Pod-wide use, write it under a \`pod-{podId}/<rel>\` path. To duplicate
 binary content (PDFs, images, audio) between scopes, use the dedicated copy tool rather than
 reading and rewriting, because the round-trip through the agent loses the bytes.
 
@@ -53,7 +53,7 @@ Use the \`sId\` from \`pod_tasks\` tools (e.g. \`list_tasks\`, \`create_tasks\`)
 
 When you need to find information, use this order (skip steps if the relevant tools are not in your tool list):
 1. **Pod overview**: \`${POD_MANAGER_SERVER_NAME}\` \`get_information\` returns the Pod URL, description, and what is attached to the Pod.
-2. **Pod files**: read and search \`pod/<rel>\` files through the sandbox or the \`${FILES_SERVER_NAME}\` MCP tools.
+2. **Pod files**: read and search \`pod-{podId}/<rel>\` files through the sandbox or the \`${FILES_SERVER_NAME}\` MCP tools.
 3. **Company-wide**: If still insufficient, use \`company_data_*\` tools and \`${SEARCH_SERVER_NAME}\` for broader company data sources.
 `,
 

--- a/front/lib/resources/skill/code_defined/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.ts
@@ -112,7 +112,7 @@ deliverables to \`/files/conversation\` unless the user has asked you to
 update the Pod's files specifically.
 
 The same files are also exposed by the \`files\` MCP server under scoped
-paths like \`pod/<rel>\`. Sandbox writes and MCP writes are two views on
+paths like \`pod-{podId}/<rel>\`. Sandbox writes and MCP writes are two views on
 the same underlying storage.`;
 }
 


### PR DESCRIPTION
## Description

`VIZ_FILE_HANDLING_GUIDELINES` previously documented only the bare `"conversation/filename"` scoped path format for `useFile()` in visualization frames. Bare paths are context-dependent — they only resolve correctly when the frame is rendered inside the exact conversation or pod it was generated in, and silently load the wrong file or fail anywhere else.

This updates the prompt instructions to:
- Document the portable forms: `"conversation-{conversationId}/filename"` and `"pod-{podId}/filename"`
- Add an explicit warning against using bare `"conversation/filename"` or `"pod/filename"`

Also updates the `PodBanner` copy in `InAppBanner.tsx`.

## Tests

Tested manually by verifying frames rendered in different contexts resolve files correctly using the canonical scoped paths.

## Risk

Low. The change is additive to the LLM prompt — it clarifies the correct path format and adds a guardrail. Previously generated frames using bare paths remain unaffected; new frames will produce portable paths. No runtime logic changed.

## Deploy Plan

Deploy front.
