### PR TITLE
Remove projects FF and release Pods :)

### DIFF
--- a/front-api/routes/w/[wId]/files/[fileId]/index.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.test.ts
@@ -42,14 +42,6 @@ vi.mock("@app/lib/api/files/upsert", () => ({
   }),
 }));
 
-vi.mock("@app/lib/auth", async () => {
-  const actual: any = await vi.importActual("@app/lib/auth");
-  return {
-    ...actual,
-    getFeatureFlags: vi.fn(async () => ["projects"]),
-  };
-});
-
 function fileUrl(workspace: { sId: string }, fileId: string, query = "") {
   return `/api/w/${workspace.sId}/files/${fileId}${query}`;
 }

--- a/front-api/routes/w/[wId]/files/[fileId]/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.ts
@@ -7,7 +7,6 @@ import {
 } from "@app/lib/api/files/upsert";
 import { addFileToProject } from "@app/lib/api/projects/context";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { FileVersion } from "@app/lib/resources/file_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -373,19 +372,6 @@ async function checkFileAccess(
   file: FileResource
 ): Promise<Response | null> {
   const auth = ctx.get("auth");
-
-  if (file.useCaseMetadata?.spaceId && file.useCase === "project_context") {
-    const featureFlags = await getFeatureFlags(auth);
-    if (!featureFlags.includes("projects")) {
-      return apiError(ctx, {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: "Feature not supported",
-        },
-      });
-    }
-  }
 
   const space = await getSpaceForFile(auth, file);
 

--- a/front-api/routes/w/[wId]/files/[fileId]/rename.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/rename.test.ts
@@ -1,4 +1,3 @@
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
@@ -140,8 +139,6 @@ describe("PATCH /api/w/:wId/files/:fileId/rename", () => {
         role: "user",
       });
 
-      await FeatureFlagFactory.basic(auth, "projects");
-
       const projectSpace = await SpaceFactory.project(workspace, user.id);
 
       const file = await FileFactory.create(auth, user, {
@@ -168,8 +165,6 @@ describe("PATCH /api/w/:wId/files/:fileId/rename", () => {
         method: "PATCH",
         role: "user",
       });
-
-      await FeatureFlagFactory.basic(auth, "projects");
 
       const space = await SpaceFactory.regular(workspace);
 

--- a/front-api/routes/w/[wId]/files/[fileId]/rename.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/rename.ts
@@ -1,4 +1,3 @@
-import { getFeatureFlags } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { FileType } from "@app/types/files";
@@ -32,19 +31,6 @@ app.patch(
         status_code: 404,
         api_error: { type: "file_not_found", message: "File not found." },
       });
-    }
-
-    if (file.useCase === "project_context") {
-      const featureFlags = await getFeatureFlags(auth);
-      if (!featureFlags.includes("projects")) {
-        return apiError(ctx, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: "Feature not supported",
-          },
-        });
-      }
     }
 
     // Plan-mode files are agent-owned; users cannot rename them.

--- a/front-api/routes/w/[wId]/files/[fileId]/save-in-project.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/save-in-project.test.ts
@@ -1,5 +1,4 @@
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
@@ -22,12 +21,10 @@ function postSave(workspace: { sId: string }, fileId: string, body: unknown) {
 
 describe("POST /api/w/:wId/files/:fileId/save-in-project", () => {
   it("should return 404 when file does not exist", async () => {
-    const { auth, workspace } = await createPrivateApiMockRequest({
+    const { workspace } = await createPrivateApiMockRequest({
       method: "POST",
       role: "user",
     });
-
-    await FeatureFlagFactory.basic(auth, "projects");
 
     const response = await postSave(workspace, "non-existent-file", {
       projectId: "some-project-id",
@@ -42,46 +39,11 @@ describe("POST /api/w/:wId/files/:fileId/save-in-project", () => {
     });
   });
 
-  it("should return 403 when projects feature flag is not enabled", async () => {
-    const { auth, user, workspace } = await createPrivateApiMockRequest({
-      method: "POST",
-      role: "user",
-    });
-
-    const conversation = await ConversationFactory.create(auth, {
-      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
-      messagesCreatedAt: [new Date()],
-    });
-
-    const file = await FileFactory.create(auth, user, {
-      contentType: frameContentType,
-      fileName: "test.frame",
-      fileSize: 1024,
-      status: "ready",
-      useCase: "tool_output",
-      useCaseMetadata: { conversationId: conversation.sId },
-    });
-
-    const response = await postSave(workspace, file.sId, {
-      projectId: "some-project-id",
-    });
-
-    expect(response.status).toBe(403);
-    expect(await response.json()).toEqual({
-      error: {
-        type: "invalid_request_error",
-        message: "Projects feature is not enabled for this workspace.",
-      },
-    });
-  });
-
   it("should return 400 when file is not a frame", async () => {
     const { auth, user, workspace } = await createPrivateApiMockRequest({
       method: "POST",
       role: "user",
     });
-
-    await FeatureFlagFactory.basic(auth, "projects");
 
     const conversation = await ConversationFactory.create(auth, {
       agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
@@ -116,8 +78,6 @@ describe("POST /api/w/:wId/files/:fileId/save-in-project", () => {
       role: "user",
     });
 
-    await FeatureFlagFactory.basic(auth, "projects");
-
     const project = await SpaceFactory.project(workspace, user.id);
 
     const file = await FileFactory.create(auth, user, {
@@ -149,8 +109,6 @@ describe("POST /api/w/:wId/files/:fileId/save-in-project", () => {
       role: "user",
     });
 
-    await FeatureFlagFactory.basic(auth, "projects");
-
     const conversation = await ConversationFactory.create(auth, {
       agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
       messagesCreatedAt: [new Date()],
@@ -178,8 +136,6 @@ describe("POST /api/w/:wId/files/:fileId/save-in-project", () => {
       method: "POST",
       role: "user",
     });
-
-    await FeatureFlagFactory.basic(auth, "projects");
 
     const conversation = await ConversationFactory.create(auth, {
       agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
@@ -213,8 +169,6 @@ describe("POST /api/w/:wId/files/:fileId/save-in-project", () => {
       method: "POST",
       role: "user",
     });
-
-    await FeatureFlagFactory.basic(auth, "projects");
 
     const regularSpace = await SpaceFactory.regular(workspace);
     const conversation = await ConversationFactory.create(auth, {
@@ -250,8 +204,6 @@ describe("POST /api/w/:wId/files/:fileId/save-in-project", () => {
       role: "user",
     });
 
-    await FeatureFlagFactory.basic(auth, "projects");
-
     const project = await SpaceFactory.project(workspace);
 
     const conversation = await ConversationFactory.create(auth, {
@@ -286,8 +238,6 @@ describe("POST /api/w/:wId/files/:fileId/save-in-project", () => {
       method: "POST",
       role: "user",
     });
-
-    await FeatureFlagFactory.basic(auth, "projects");
 
     const project = await SpaceFactory.project(workspace, user.id);
 

--- a/front-api/routes/w/[wId]/files/[fileId]/save-in-project.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/save-in-project.ts
@@ -1,5 +1,4 @@
 import { addFileToProject } from "@app/lib/api/projects/context";
-import { getFeatureFlags } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -28,17 +27,6 @@ app.post(
   async (ctx): HandlerResult<SaveInProjectResponseBody> => {
     const auth = ctx.get("auth");
     const fileId = ctx.req.param("fileId") ?? "";
-
-    const featureFlags = await getFeatureFlags(auth);
-    if (!featureFlags.includes("projects")) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Projects feature is not enabled for this workspace.",
-        },
-      });
-    }
 
     const file = await FileResource.fetchById(auth, fileId);
     if (!file) {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_context/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_context/index.ts
@@ -3,7 +3,6 @@ import {
   addContentNodeToProject,
   listProjectContextAttachments,
 } from "@app/lib/api/projects/context";
-import { getFeatureFlags } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { ContentNodeType } from "@app/types/core/content_node";
@@ -96,17 +95,6 @@ app.post(
   async (ctx): HandlerResult<PostProjectContextContentNodeResponseBody> => {
     const auth = ctx.get("auth");
     const space = ctx.get("space");
-
-    const featureFlags = await getFeatureFlags(auth);
-    if (!featureFlags.includes("projects")) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Projects feature is not enabled for this workspace.",
-        },
-      });
-    }
 
     if (!space.isProject()) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -18,7 +18,6 @@ vi.mock("@app/temporal/project_task/client", () => ({
 }));
 
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 
@@ -122,8 +121,6 @@ describe("PATCH /api/w/:wId/spaces/:spaceId/project_metadata", () => {
       role: "admin",
     });
 
-    await FeatureFlagFactory.basic(auth, "projects");
-
     const projectSpace = await SpaceFactory.project(workspace);
     await ProjectMetadataResource.makeNew(auth, projectSpace, {
       description: "Test description",
@@ -147,8 +144,6 @@ describe("PATCH /api/w/:wId/spaces/:spaceId/project_metadata", () => {
       role: "admin",
     });
 
-    await FeatureFlagFactory.basic(auth, "projects");
-
     const projectSpace = await SpaceFactory.project(workspace);
     await ProjectMetadataResource.makeNew(auth, projectSpace, {
       description: "Test",
@@ -170,8 +165,6 @@ describe("PATCH /api/w/:wId/spaces/:spaceId/project_metadata", () => {
     const { workspace, auth } = await createPrivateApiMockRequest({
       role: "admin",
     });
-
-    await FeatureFlagFactory.basic(auth, "projects");
 
     const projectSpace = await SpaceFactory.project(workspace);
     await ProjectMetadataResource.makeNew(auth, projectSpace, {

--- a/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
+++ b/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
@@ -6,7 +6,6 @@ import { useRemoveSpaceConfirm } from "@app/components/shared/RemoveSpaceDialog"
 import { SpaceChips } from "@app/components/shared/SpaceChips";
 import { useSkillsContext } from "@app/components/shared/skills/SkillsContext";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useSpaceProjectsLookup } from "@app/lib/swr/spaces";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { SpaceType } from "@app/types/space";
@@ -46,10 +45,6 @@ export function AgentBuilderSpacesBlock({
   const allSpaces = useMemo(() => {
     return [...spaces, ...missingSpaces];
   }, [spaces, missingSpaces]);
-
-  const { hasFeature } = useFeatureFlags();
-
-  const isProjectsEnabled = hasFeature("projects");
 
   const [isSheetOpen, setIsSheetOpen] = useState(false);
   const [draftSelectedSpaces, setDraftSelectedSpaces] = useState<string[]>([]);
@@ -177,7 +172,7 @@ export function AgentBuilderSpacesBlock({
       <div className="flex items-start justify-between">
         <div>
           <h2 className="heading-lg text-foreground dark:text-foreground-night">
-            {isProjectsEnabled ? "Spaces and Pods" : "Spaces"}
+            Spaces and Pods
           </h2>
           <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
             Set what knowledge and capabilities the agent can access.

--- a/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
@@ -1,5 +1,4 @@
 import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { getSpaceIcon, getSpaceName } from "@app/lib/spaces";
 import { useSpaceProjectsLookup } from "@app/lib/swr/spaces";
 import type { PodType, SpaceType } from "@app/types/space";
@@ -63,8 +62,6 @@ export function SpaceSelectionSheet({
   setSelectedSpaces,
 }: SpaceSelectionSheetProps) {
   const [searchQuery, setSearchQuery] = useState("");
-  const { hasFeature } = useFeatureFlags();
-  const isProjectsEnabled = includeProjects && hasFeature("projects");
 
   const handleClose = () => {
     setSearchQuery("");
@@ -87,21 +84,16 @@ export function SpaceSelectionSheet({
     >
       <SheetContent>
         <SheetHeader>
-          <SheetTitle>
-            {isProjectsEnabled ? "Add Spaces and Pods" : "Add Spaces"}
-          </SheetTitle>
+          <SheetTitle>Add Spaces and Pods</SheetTitle>
           <SheetDescription>
-            {isProjectsEnabled
-              ? `Choose the spaces and Pods you want the ${entityName} to have access to.`
-              : `Choose the spaces you want the ${entityName} to have access to.`}
+            Choose the spaces and Pods you want the {entityName} to have access
+            to.
           </SheetDescription>
           <SearchInput
             name="space"
             onChange={(query) => setSearchQuery(query)}
             value={searchQuery}
-            placeholder={
-              isProjectsEnabled ? "Search spaces and Pods" : "Search spaces"
-            }
+            placeholder="Search spaces and Pods"
             className="mt-4"
           />
         </SheetHeader>
@@ -149,10 +141,6 @@ export function SpaceSelectionPageContent({
   const allSpaces = useMemo(() => {
     return [...spaces, ...missingSpaces];
   }, [spaces, missingSpaces]);
-
-  const { hasFeature } = useFeatureFlags();
-
-  const isProjectsEnabled = includeProjects && hasFeature("projects");
 
   const selectableSpaces = useMemo(() => {
     return allSpaces
@@ -288,70 +276,64 @@ export function SpaceSelectionPageContent({
               return rowContent;
             })}
           </ListGroup>
-          {isProjectsEnabled && (
-            <>
-              <ListItemSection size="sm">Pods</ListItemSection>
-              <ListGroup>
-                {projectsTableData.map((row) => {
-                  const ProjectIcon = getSpaceIcon(row.space);
-                  const rowContent = (
-                    <ListItem
+          <>
+            <ListItemSection size="sm">Pods</ListItemSection>
+            <ListGroup>
+              {projectsTableData.map((row) => {
+                const ProjectIcon = getSpaceIcon(row.space);
+                const rowContent = (
+                  <ListItem
+                    key={row.sId}
+                    itemsAlignment="center"
+                    onClick={row.isAlreadyRequested ? undefined : row.onToggle}
+                    className={cn(
+                      row.isSelected
+                        ? "bg-primary-50 dark:bg-primary-50-night"
+                        : "",
+                      row.isAlreadyRequested
+                        ? "cursor-not-allowed opacity-60"
+                        : "cursor-pointer"
+                    )}
+                  >
+                    <ProjectIcon className="w-5 h-5 min-w-5 min-h-5" />
+                    <div className="flex min-w-0 flex-1 flex-col items-start">
+                      <span className="heading-sm max-w-full truncate text-foreground dark:text-foreground-night">
+                        {row.name}
+                      </span>
+                      <span className="truncate max-w-full text-xs text-muted-foreground dark:text-muted-foreground-night">
+                        {row.description}
+                      </span>
+                    </div>
+                    <Checkbox
+                      checked={row.isSelected}
+                      onCheckedChange={row.onToggle}
+                      disabled={row.isAlreadyRequested}
+                      onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                    />
+                  </ListItem>
+                );
+
+                if (row.isAlreadyRequested) {
+                  return (
+                    <Tooltip
                       key={row.sId}
-                      itemsAlignment="center"
-                      onClick={
-                        row.isAlreadyRequested ? undefined : row.onToggle
-                      }
-                      className={cn(
-                        row.isSelected
-                          ? "bg-primary-50 dark:bg-primary-50-night"
-                          : "",
-                        row.isAlreadyRequested
-                          ? "cursor-not-allowed opacity-60"
-                          : "cursor-pointer"
-                      )}
-                    >
-                      <ProjectIcon className="w-5 h-5 min-w-5 min-h-5" />
-                      <div className="flex min-w-0 flex-1 flex-col items-start">
-                        <span className="heading-sm max-w-full truncate text-foreground dark:text-foreground-night">
-                          {row.name}
-                        </span>
-                        <span className="truncate max-w-full text-xs text-muted-foreground dark:text-muted-foreground-night">
-                          {row.description}
-                        </span>
-                      </div>
-                      <Checkbox
-                        checked={row.isSelected}
-                        onCheckedChange={row.onToggle}
-                        disabled={row.isAlreadyRequested}
-                        onClick={(e: React.MouseEvent) => e.stopPropagation()}
-                      />
-                    </ListItem>
+                      label="Used by other resources"
+                      side="right"
+                      trigger={rowContent}
+                    />
                   );
+                }
 
-                  if (row.isAlreadyRequested) {
-                    return (
-                      <Tooltip
-                        key={row.sId}
-                        label="Used by other resources"
-                        side="right"
-                        trigger={rowContent}
-                      />
-                    );
-                  }
-
-                  return rowContent;
-                })}
-              </ListGroup>
-            </>
-          )}
+                return rowContent;
+              })}
+            </ListGroup>
+          </>
         </div>
       ) : (
         <div className="py-4 text-center text-sm text-muted-foreground dark:text-muted-foreground-night">
           {searchQuery.length > 0
             ? "No results found for your search"
-            : isProjectsEnabled
-              ? "No spaces and Pods available"
-              : "No spaces available"}
+            : "No spaces and Pods available"}
         </div>
       )}
     </div>

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -164,7 +164,7 @@ export function ConversationMenu({
   openDetailsInNewTab,
 }: ConversationMenuProps) {
   const { user, providersHealth } = useAuth();
-  const { hasFeature, featureFlags } = useFeatureFlags();
+  const { featureFlags } = useFeatureFlags();
   const confirm = useContext(ConfirmContext);
 
   const clientType = useClientType();
@@ -239,7 +239,7 @@ export function ConversationMenu({
 
   const { summary } = usePodConversationsSummary({
     workspaceId: owner.sId,
-    options: { disabled: shouldWaitBeforeFetching || !hasFeature("projects") },
+    options: { disabled: shouldWaitBeforeFetching },
   });
 
   const filteredPods = summary
@@ -415,48 +415,46 @@ export function ConversationMenu({
             disabled={isBranching}
           />
           <DropdownMenuSeparator />
-          {hasFeature("projects") && (
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger
-                icon={ArrowRightIcon}
-                label={canMoveOutOfPod ? "Move to..." : "Move to Pod"}
-                disabled={canMoveOutOfPod ? false : !filteredPods.length}
-              />
-              <DropdownMenuPortal>
-                <DropdownMenuSubContent
-                  collisionPadding={16}
-                  className="max-w-60"
-                >
-                  {canMoveOutOfPod && (
-                    <>
-                      <DropdownMenuItem
-                        icon={ChatBubbleBottomCenterTextIcon}
-                        label="Personal conversations"
-                        onClick={async () =>
-                          moveConversationOutOfPod(conversation)
-                        }
-                      />
-                      <DropdownMenuSeparator />
-                      <DropdownMenuLabel label="Pods" />
-                    </>
-                  )}
-                  {filteredPods.map((pod) => (
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger
+              icon={ArrowRightIcon}
+              label={canMoveOutOfPod ? "Move to..." : "Move to Pod"}
+              disabled={canMoveOutOfPod ? false : !filteredPods.length}
+            />
+            <DropdownMenuPortal>
+              <DropdownMenuSubContent
+                collisionPadding={16}
+                className="max-w-60"
+              >
+                {canMoveOutOfPod && (
+                  <>
                     <DropdownMenuItem
-                      key={pod.sId}
-                      icon={getSpaceIcon(pod)}
-                      label={pod.name}
-                      truncateText
+                      icon={ChatBubbleBottomCenterTextIcon}
+                      label="Personal conversations"
                       onClick={async () =>
-                        conversation
-                          ? moveConversationToPod(conversation, pod)
-                          : Promise.resolve(false)
+                        moveConversationOutOfPod(conversation)
                       }
                     />
-                  ))}
-                </DropdownMenuSubContent>
-              </DropdownMenuPortal>
-            </DropdownMenuSub>
-          )}
+                    <DropdownMenuSeparator />
+                    <DropdownMenuLabel label="Pods" />
+                  </>
+                )}
+                {filteredPods.map((pod) => (
+                  <DropdownMenuItem
+                    key={pod.sId}
+                    icon={getSpaceIcon(pod)}
+                    label={pod.name}
+                    truncateText
+                    onClick={async () =>
+                      conversation
+                        ? moveConversationToPod(conversation, pod)
+                        : Promise.resolve(false)
+                    }
+                  />
+                ))}
+              </DropdownMenuSubContent>
+            </DropdownMenuPortal>
+          </DropdownMenuSub>
           <DropdownMenuSub>
             <DropdownMenuSubTrigger
               icon={ContactsUserIcon}

--- a/front/components/assistant/conversation/InAppBanner.tsx
+++ b/front/components/assistant/conversation/InAppBanner.tsx
@@ -1,4 +1,3 @@
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { Button, PlusIcon, XMarkIcon } from "@dust-tt/sparkle";
 import { AnimatePresence, motion } from "framer-motion";
@@ -182,9 +181,6 @@ export function StackedInAppBanners({
   owner: _owner,
   onCreatePod,
 }: StackedInAppBannersProps) {
-  const { hasFeature } = useFeatureFlags();
-  const isPodsEnabled = hasFeature("projects");
-
   const [showSteeringBanner, setShowSteeringBanner] = useState(
     () => localStorage.getItem(STEERING_BANNER_LOCAL_STORAGE_KEY) !== "true"
   );
@@ -199,14 +195,12 @@ export function StackedInAppBanners({
         showSteeringBanner={showSteeringBanner}
         onShowSteeringBanner={setShowSteeringBanner}
       />
-      {isPodsEnabled && (
-        <PodBanner
-          key="pod-banner"
-          showPodBanner={showPodBanner}
-          onShowPodBanner={setShowPodBanner}
-          onCreatePod={onCreatePod}
-        />
-      )}
+      <PodBanner
+        key="pod-banner"
+        showPodBanner={showPodBanner}
+        onShowPodBanner={setShowPodBanner}
+        onCreatePod={onCreatePod}
+      />
     </AnimatePresence>
   );
 }

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -95,7 +95,6 @@ import {
   PencilSquareIcon,
   PlusIcon,
   RobotIcon,
-  SearchInput,
   Spinner,
   StarIcon,
   TrashIcon,
@@ -423,7 +422,6 @@ export function AgentSidebarMenu({
   const noHealthyProviders = !hasHealthyProviders(providersHealth);
 
   const agentsSearchInputRef = useRef<HTMLInputElement>(null);
-  const searchInputRef = useRef<HTMLInputElement>(null);
   const [searchText, setSearchText] = useState("");
   const { agentConfigurations } = useUnifiedAgentConfigurations({
     workspaceId: owner.sId,
@@ -453,23 +451,18 @@ export function AgentSidebarMenu({
     isLoadingMore,
   } = useConversations({ workspaceId: owner.sId });
 
-  const hasPodConversations = hasFeature("projects");
-
   const {
     summary,
     isLoading: isSummaryLoading,
     mutate: mutatePodConversationSummary,
   } = usePodConversationsSummary({
     workspaceId: owner.sId,
-    options: { disabled: !hasPodConversations },
   });
 
   useEffect(() => {
     const handleConversationsUpdated = () => {
       void mutateConversations();
-      if (hasPodConversations) {
-        void mutatePodConversationSummary();
-      }
+      void mutatePodConversationSummary();
     };
     window.addEventListener(
       CONVERSATIONS_UPDATED_EVENT,
@@ -481,7 +474,7 @@ export function AgentSidebarMenu({
         handleConversationsUpdated
       );
     };
-  }, [hasPodConversations, mutateConversations, mutatePodConversationSummary]);
+  }, [mutateConversations, mutatePodConversationSummary]);
 
   const [isMultiSelect, setIsMultiSelect] = useState(false);
   const [selectedConversations, setSelectedConversations] = useState<
@@ -518,7 +511,7 @@ export function AgentSidebarMenu({
   } = useSearchPods({
     workspaceId: owner.sId,
     query: titleFilter,
-    enabled: hasPodConversations && titleFilter.trim().length > 0,
+    enabled: titleFilter.trim().length > 0,
   });
 
   const {
@@ -527,7 +520,7 @@ export function AgentSidebarMenu({
   } = useSearchPodConversations({
     workspaceId: owner.sId,
     query: titleFilter,
-    enabled: hasPodConversations && titleFilter.trim().length > 0,
+    enabled: titleFilter.trim().length > 0,
   });
 
   const {
@@ -539,7 +532,7 @@ export function AgentSidebarMenu({
   } = useSearchPrivateConversations({
     workspaceId: owner.sId,
     query: titleFilter,
-    enabled: hasPodConversations && titleFilter.trim().length > 0,
+    enabled: titleFilter.trim().length > 0,
   });
 
   const { isUploading: isUploadingYAML, triggerYAMLUpload } = useYAMLUpload({
@@ -668,14 +661,11 @@ export function AgentSidebarMenu({
     );
   }, [conversations, hideTriggeredConversations]);
 
-  const isSearchActive = hasPodConversations && titleFilter.trim().length > 0;
+  const isSearchActive = titleFilter.trim().length > 0;
 
-  const sidebarTitleFilter = hasPodConversations ? "" : titleFilter;
+  const sidebarTitleFilter = titleFilter;
 
   const starredSection = useMemo(() => {
-    if (!hasPodConversations) {
-      return null;
-    }
     const starredSummary = summary.filter(({ space }) => space.isStarred);
     const starredCountInSummary = starredSummary.length;
 
@@ -720,7 +710,6 @@ export function AgentSidebarMenu({
       </NavigationList>
     );
   }, [
-    hasPodConversations,
     summary,
     owner,
     sidebarTitleFilter,
@@ -731,9 +720,6 @@ export function AgentSidebarMenu({
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   const podsSection = useMemo(() => {
-    if (!hasPodConversations) {
-      return null;
-    }
     const nonStarredSummary = summary.filter((pod) => !pod.space.isStarred);
     const podCountInSummary = nonStarredSummary.length;
     const showCount = isPodsSectionCollapsed && podCountInSummary > 0;
@@ -801,7 +787,6 @@ export function AgentSidebarMenu({
       </NavigationList>
     );
   }, [
-    hasPodConversations,
     owner,
     summary,
     setIsCreatePodModalOpen,
@@ -900,24 +885,12 @@ export function AgentSidebarMenu({
               </div>
             ) : (
               <div className="z-50 flex justify-end gap-2 p-2">
-                {hasPodConversations ? (
-                  <div className="flex-1">
-                    <SidebarSearch
-                      titleFilter={titleFilter}
-                      onTitleFilterChange={setTitleFilter}
-                    />
-                  </div>
-                ) : (
-                  <div className="flex-1">
-                    <SearchInput
-                      ref={searchInputRef}
-                      name="search"
-                      placeholder="Search"
-                      value={titleFilter}
-                      onChange={setTitleFilter}
-                    />
-                  </div>
-                )}
+                <div className="flex-1">
+                  <SidebarSearch
+                    titleFilter={titleFilter}
+                    onTitleFilterChange={setTitleFilter}
+                  />
+                </div>
                 <div className="flex gap-2">
                   <Button
                     label="New"

--- a/front/components/me/NotificationPreferences.tsx
+++ b/front/components/me/NotificationPreferences.tsx
@@ -101,8 +101,6 @@ export const NotificationPreferences = forwardRef<
 
   const displaySlackOption = hasSlackNotificationsFeature && canConfigureSlack;
 
-  const isProjectsFeatureEnabled = hasFeature("projects");
-
   // Novu workflow-specific channel preferences for conversation-unread
   const [conversationPreferences, setConversationPreferences] = useState<
     Preference | undefined
@@ -422,28 +420,20 @@ export const NotificationPreferences = forwardRef<
                 <DropdownMenuItem
                   label={NOTIFICATION_CONDITION_LABELS["all_messages"]}
                   description={
-                    isProjectsFeatureEnabled
-                      ? NOTIFICATION_CONDITION_DESCRIPTIONS["all_messages"]
-                      : undefined
+                    NOTIFICATION_CONDITION_DESCRIPTIONS["all_messages"]
                   }
                   onClick={() => setNotifyCondition("all_messages")}
                 />
                 <DropdownMenuItem
                   label={NOTIFICATION_CONDITION_LABELS["only_mentions"]}
                   description={
-                    isProjectsFeatureEnabled
-                      ? NOTIFICATION_CONDITION_DESCRIPTIONS["only_mentions"]
-                      : undefined
+                    NOTIFICATION_CONDITION_DESCRIPTIONS["only_mentions"]
                   }
                   onClick={() => setNotifyCondition("only_mentions")}
                 />
                 <DropdownMenuItem
                   label={NOTIFICATION_CONDITION_LABELS["never"]}
-                  description={
-                    isProjectsFeatureEnabled
-                      ? NOTIFICATION_CONDITION_DESCRIPTIONS["never"]
-                      : undefined
-                  }
+                  description={NOTIFICATION_CONDITION_DESCRIPTIONS["never"]}
                   onClick={() => setNotifyCondition("never")}
                 />
               </DropdownMenuContent>

--- a/front/components/workspace/settings/OpenProjectsPolicy.tsx
+++ b/front/components/workspace/settings/OpenProjectsPolicy.tsx
@@ -1,5 +1,4 @@
 import { useOpenProjectsPolicy } from "@app/hooks/useOpenProjectsPolicy";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -31,13 +30,8 @@ const OPEN_PROJECTS_POLICIES = [
 ] as const;
 
 export function OpenProjectsPolicy({ owner }: { owner: WorkspaceType }) {
-  const { featureFlags } = useFeatureFlags();
   const { allowOpenProjects, isChanging, doUpdateOpenProjectsPolicy } =
     useOpenProjectsPolicy({ owner });
-
-  if (!featureFlags.includes("projects")) {
-    return null;
-  }
 
   const selectedPolicy = OPEN_PROJECTS_POLICIES.find(
     (policy) => policy.allowOpenProjects === allowOpenProjects

--- a/front/components/workspace/settings/ProjectKnowledgePolicy.tsx
+++ b/front/components/workspace/settings/ProjectKnowledgePolicy.tsx
@@ -1,5 +1,4 @@
 import { useProjectKnowledgePolicy } from "@app/hooks/useProjectKnowledgePolicy";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { WorkspaceType } from "@app/types/user";
 import {
   BookOpenIcon,
@@ -31,16 +30,11 @@ const PROJECT_KNOWLEDGE_POLICIES = [
 ] as const;
 
 export function ProjectKnowledgePolicy({ owner }: { owner: WorkspaceType }) {
-  const { featureFlags } = useFeatureFlags();
   const {
     allowManualProjectKnowledgeManagement,
     isChanging,
     doUpdateProjectKnowledgePolicy,
   } = useProjectKnowledgePolicy({ owner });
-
-  if (!featureFlags.includes("projects")) {
-    return null;
-  }
 
   const selectedPolicy = PROJECT_KNOWLEDGE_POLICIES.find(
     (policy) =>

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1002,9 +1002,7 @@ export const INTERNAL_MCP_SERVERS = {
     availability: "auto_hidden_builder",
     allowMultipleInstances: false,
     isPreview: false,
-    isRestricted: ({ featureFlags }) => {
-      return !featureFlags.includes("projects");
-    },
+    isRestricted: undefined,
     tools_arguments_requiring_approval: {
       create_conversation: ["dustPod"],
       add_message_to_conversation: ["dustPod"],
@@ -1018,9 +1016,7 @@ export const INTERNAL_MCP_SERVERS = {
     availability: "auto_hidden_builder",
     allowMultipleInstances: false,
     isPreview: false,
-    isRestricted: ({ featureFlags }) => {
-      return !featureFlags.includes("projects");
-    },
+    isRestricted: undefined,
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -94,7 +94,6 @@ import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 // Mock rateLimiter from the utils module
 import * as rateLimiterModule from "@app/lib/utils/rate_limiter";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 
 const TEST_PROGRAMMATIC_CREDIT_AMOUNT_MICRO_USD = 100_000_000;
 const TEST_CREDIT_START_DELAY_MS = 1000;
@@ -2683,7 +2682,6 @@ describe("postUserMessage", () => {
     describe("with projects feature flag enabled regarding branches", () => {
       beforeEach(async () => {
         await setupProjectWithRestrictedAgent();
-        await FeatureFlagFactory.basic(auth, "projects");
       });
 
       it("should create a branch and put first message in branch when posting with restricted agent", async () => {
@@ -2838,7 +2836,6 @@ describe("postUserMessage", () => {
     describe("with empty conversation and projects feature flag enabled", () => {
       beforeEach(async () => {
         await setupProjectWithRestrictedAgent({ messagesCreatedAt: [] });
-        await FeatureFlagFactory.basic(auth, "projects");
       });
 
       it("should create a branch with an anchor message when first message mentions a restricted agent", async () => {

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -12,7 +12,6 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
@@ -206,7 +205,6 @@ describe("getJITServers", () => {
 
   describe("projects feature", () => {
     it("should not include legacy project_context_and_conversations JIT server (search is on pod_manager)", async () => {
-      await FeatureFlagFactory.basic(auth, "projects");
       await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
 
       await DataSourceViewFactory.fromConnector(
@@ -233,8 +231,6 @@ describe("getJITServers", () => {
     });
 
     it("should enable projects skill in listForAgentLoop when feature flag is enabled and conversation is in a project", async () => {
-      // Enable projects feature flag.
-      await FeatureFlagFactory.basic(auth, "projects");
       await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
 
       const conversationInProject = {
@@ -256,22 +252,7 @@ describe("getJITServers", () => {
       expect(viewNames).toContain("pod_manager");
     });
 
-    it("should not enable projects skill in listForAgentLoop when feature flag is disabled", async () => {
-      const { enabledSkills } = await SkillResource.listForAgentLoop(auth, {
-        agentConfiguration: agentConfig,
-        conversation: {
-          ...conversation,
-          spaceId: conversationsSpace.sId,
-        },
-      });
-
-      expect(enabledSkills.some((s) => s.sId === "projects")).toBe(false);
-    });
-
     it("should not enable projects skill in listForAgentLoop when conversation is not in a project", async () => {
-      // Enable projects feature flag.
-      await FeatureFlagFactory.basic(auth, "projects");
-
       const { enabledSkills } = await SkillResource.listForAgentLoop(auth, {
         agentConfiguration: agentConfig,
         conversation,

--- a/front/lib/resources/skill/code_defined/projects.ts
+++ b/front/lib/resources/skill/code_defined/projects.ts
@@ -2,7 +2,6 @@ import { SEARCH_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/consta
 import { FILES_SERVER_NAME } from "@app/lib/api/actions/servers/files/metadata";
 import { POD_MANAGER_SERVER_NAME } from "@app/lib/api/actions/servers/pod_manager/metadata";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import {
@@ -60,11 +59,7 @@ When you need to find information, use this order (skip steps if the relevant to
   mcpServers: [{ name: "pod_manager" }, { name: "pod_tasks" }],
   version: 3,
   icon: "ActionFolderIcon",
-  isRestricted: async (auth: Authenticator) => {
-    const flags = await getFeatureFlags(auth);
-
-    return !flags.includes("projects");
-  },
+  isRestricted: undefined,
   // Note: we auto enabled in listForAgentLoop for project conversations.
 } as const satisfies GlobalSkillDefinition;
 

--- a/front/migrations/20260414_sunset_project_conversation_mcp_server.ts
+++ b/front/migrations/20260414_sunset_project_conversation_mcp_server.ts
@@ -1,238 +1,238 @@
-import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
-import { Authenticator } from "@app/lib/auth";
-import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";
-import { FeatureFlagModel } from "@app/lib/models/feature_flag";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import {
-  dangerouslyMakeSIdWithCustomFirstPrefix,
-  LEGACY_REGION_BIT,
-} from "@app/lib/resources/string_ids";
-import { UserToolApprovalModel } from "@app/lib/resources/storage/models/user";
-import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import { renderLightWorkspaceType } from "@app/lib/workspace";
-import { makeScript } from "@app/scripts/helpers";
-import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
-import type { LightWorkspaceType } from "@app/types/user";
+// import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+// import { Authenticator } from "@app/lib/auth";
+// import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";
+// import { FeatureFlagModel } from "@app/lib/models/feature_flag";
+// import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+// import {
+//   dangerouslyMakeSIdWithCustomFirstPrefix,
+//   LEGACY_REGION_BIT,
+// } from "@app/lib/resources/string_ids";
+// import { UserToolApprovalModel } from "@app/lib/resources/storage/models/user";
+// import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+// import { concurrentExecutor } from "@app/lib/utils/async_utils";
+// import { renderLightWorkspaceType } from "@app/lib/workspace";
+// import { makeScript } from "@app/scripts/helpers";
+// import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+// import type { LightWorkspaceType } from "@app/types/user";
 
-const TARGET_SERVER_NAME: AutoInternalMCPServerNameType =
-  "project_conversation" as AutoInternalMCPServerNameType;
-const TARGET_SERVER_ID = 1025;
-const PROJECTS_FEATURE_FLAG: WhitelistableFeature = "projects";
+// const TARGET_SERVER_NAME: AutoInternalMCPServerNameType =
+//   "project_conversation" as AutoInternalMCPServerNameType;
+// const TARGET_SERVER_ID = 1025;
+// const PROJECTS_FEATURE_FLAG: WhitelistableFeature = "projects";
 
-async function deleteProjectConversationViewsFromWorkspace(
-  workspaceId: string,
-  { execute }: { execute: boolean }
-) {
-  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
-  const mcpServerId = dangerouslyMakeSIdWithCustomFirstPrefix(
-    "internal_mcp_server",
-    {
-      id: TARGET_SERVER_ID,
-      workspaceId: auth.getNonNullableWorkspace().id,
-      firstPrefix: LEGACY_REGION_BIT,
-    }
-  );
+// async function deleteProjectConversationViewsFromWorkspace(
+//   workspaceId: string,
+//   { execute }: { execute: boolean }
+// ) {
+//   const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+//   const mcpServerId = dangerouslyMakeSIdWithCustomFirstPrefix(
+//     "internal_mcp_server",
+//     {
+//       id: TARGET_SERVER_ID,
+//       workspaceId: auth.getNonNullableWorkspace().id,
+//       firstPrefix: LEGACY_REGION_BIT,
+//     }
+//   );
 
-  const mcpServerViews = await MCPServerViewResource.listByMCPServer(
-    auth,
-    mcpServerId
-  );
-  const foundViewCount = mcpServerViews.length;
+//   const mcpServerViews = await MCPServerViewResource.listByMCPServer(
+//     auth,
+//     mcpServerId
+//   );
+//   const foundViewCount = mcpServerViews.length;
 
-  const foundToolMetadataCount = await RemoteMCPServerToolMetadataModel.count({
-    where: {
-      workspaceId: auth.getNonNullableWorkspace().id,
-      internalMCPServerId: mcpServerId,
-    },
-  });
+//   const foundToolMetadataCount = await RemoteMCPServerToolMetadataModel.count({
+//     where: {
+//       workspaceId: auth.getNonNullableWorkspace().id,
+//       internalMCPServerId: mcpServerId,
+//     },
+//   });
 
-  const foundUserToolApprovalCount = await UserToolApprovalModel.count({
-    where: {
-      workspaceId: auth.getNonNullableWorkspace().id,
-      mcpServerId,
-    },
-  });
+//   const foundUserToolApprovalCount = await UserToolApprovalModel.count({
+//     where: {
+//       workspaceId: auth.getNonNullableWorkspace().id,
+//       mcpServerId,
+//     },
+//   });
 
-  let deletedViewCount = 0;
-  let deletedToolMetadataCount = 0;
-  let deletedUserToolApprovalCount = 0;
-  if (execute) {
-    for (const view of mcpServerViews) {
-      await view.hardDelete(auth);
-    }
-    deletedViewCount = foundViewCount;
+//   let deletedViewCount = 0;
+//   let deletedToolMetadataCount = 0;
+//   let deletedUserToolApprovalCount = 0;
+//   if (execute) {
+//     for (const view of mcpServerViews) {
+//       await view.hardDelete(auth);
+//     }
+//     deletedViewCount = foundViewCount;
 
-    deletedToolMetadataCount = await RemoteMCPServerToolMetadataModel.destroy({
-      where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        internalMCPServerId: mcpServerId,
-      },
-    });
+//     deletedToolMetadataCount = await RemoteMCPServerToolMetadataModel.destroy({
+//       where: {
+//         workspaceId: auth.getNonNullableWorkspace().id,
+//         internalMCPServerId: mcpServerId,
+//       },
+//     });
 
-    deletedUserToolApprovalCount = await UserToolApprovalModel.destroy({
-      where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        mcpServerId,
-      },
-    });
-  }
+//     deletedUserToolApprovalCount = await UserToolApprovalModel.destroy({
+//       where: {
+//         workspaceId: auth.getNonNullableWorkspace().id,
+//         mcpServerId,
+//       },
+//     });
+//   }
 
-  return {
-    foundViewCount,
-    deletedViewCount,
-    foundToolMetadataCount,
-    deletedToolMetadataCount,
-    foundUserToolApprovalCount,
-    deletedUserToolApprovalCount,
-    mcpServerId,
-  };
-}
+//   return {
+//     foundViewCount,
+//     deletedViewCount,
+//     foundToolMetadataCount,
+//     deletedToolMetadataCount,
+//     foundUserToolApprovalCount,
+//     deletedUserToolApprovalCount,
+//     mcpServerId,
+//   };
+// }
 
-async function listWorkspacesWithProjectsFeatureFlag(): Promise<
-  LightWorkspaceType[]
-> {
-  const flags = await FeatureFlagModel.findAll({
-    where: { name: PROJECTS_FEATURE_FLAG },
-    attributes: ["workspaceId"],
-    // @ts-expect-error -- Migration script needs to operate across all workspaces.
-    dangerouslyBypassWorkspaceIsolationSecurity: true,
-  });
+// async function listWorkspacesWithProjectsFeatureFlag(): Promise<
+//   LightWorkspaceType[]
+// > {
+//   const flags = await FeatureFlagModel.findAll({
+//     where: { name: PROJECTS_FEATURE_FLAG },
+//     attributes: ["workspaceId"],
+//     // @ts-expect-error -- Migration script needs to operate across all workspaces.
+//     dangerouslyBypassWorkspaceIsolationSecurity: true,
+//   });
 
-  const workspaceIds = [...new Set(flags.map((f) => f.workspaceId))];
-  if (workspaceIds.length === 0) {
-    return [];
-  }
+//   const workspaceIds = [...new Set(flags.map((f) => f.workspaceId))];
+//   if (workspaceIds.length === 0) {
+//     return [];
+//   }
 
-  const workspaces = await WorkspaceResource.fetchByModelIds(workspaceIds);
-  return workspaces.map((workspace) => renderLightWorkspaceType({ workspace }));
-}
+//   const workspaces = await WorkspaceResource.fetchByModelIds(workspaceIds);
+//   return workspaces.map((workspace) => renderLightWorkspaceType({ workspace }));
+// }
 
-makeScript(
-  {
-    wId: {
-      type: "string",
-      describe: "Workspace sId to run against a single workspace.",
-    },
-    fromWorkspaceId: {
-      type: "number",
-      describe: "Resume from this workspace model id (inclusive).",
-    },
-  },
-  async ({ execute, wId, fromWorkspaceId }, logger) => {
-    logger.info(
-      {
-        targetServerName: TARGET_SERVER_NAME,
-        targetServerId: TARGET_SERVER_ID,
-        execute,
-      },
-      execute
-        ? "Deleting project_conversation MCP server views across workspaces"
-        : "Dry run: listing project_conversation MCP server views across workspaces"
-    );
+// makeScript(
+//   {
+//     wId: {
+//       type: "string",
+//       describe: "Workspace sId to run against a single workspace.",
+//     },
+//     fromWorkspaceId: {
+//       type: "number",
+//       describe: "Resume from this workspace model id (inclusive).",
+//     },
+//   },
+//   async ({ execute, wId, fromWorkspaceId }, logger) => {
+//     logger.info(
+//       {
+//         targetServerName: TARGET_SERVER_NAME,
+//         targetServerId: TARGET_SERVER_ID,
+//         execute,
+//       },
+//       execute
+//         ? "Deleting project_conversation MCP server views across workspaces"
+//         : "Dry run: listing project_conversation MCP server views across workspaces"
+//     );
 
-    let totalFoundViews = 0;
-    let totalDeletedViews = 0;
-    let totalFoundToolMetadata = 0;
-    let totalDeletedToolMetadata = 0;
-    let totalFoundUserToolApprovals = 0;
-    let totalDeletedUserToolApprovals = 0;
-    let touchedWorkspaceCount = 0;
+//     let totalFoundViews = 0;
+//     let totalDeletedViews = 0;
+//     let totalFoundToolMetadata = 0;
+//     let totalDeletedToolMetadata = 0;
+//     let totalFoundUserToolApprovals = 0;
+//     let totalDeletedUserToolApprovals = 0;
+//     let touchedWorkspaceCount = 0;
 
-    const processWorkspace = async (workspace: LightWorkspaceType) => {
-      const result = await deleteProjectConversationViewsFromWorkspace(
-        workspace.sId,
-        { execute }
-      );
+//     const processWorkspace = async (workspace: LightWorkspaceType) => {
+//       const result = await deleteProjectConversationViewsFromWorkspace(
+//         workspace.sId,
+//         { execute }
+//       );
 
-      if (
-        result.foundViewCount === 0 &&
-        result.foundToolMetadataCount === 0 &&
-        result.foundUserToolApprovalCount === 0
-      ) {
-        return;
-      }
+//       if (
+//         result.foundViewCount === 0 &&
+//         result.foundToolMetadataCount === 0 &&
+//         result.foundUserToolApprovalCount === 0
+//       ) {
+//         return;
+//       }
 
-      touchedWorkspaceCount += 1;
-      totalFoundViews += result.foundViewCount;
-      totalDeletedViews += result.deletedViewCount;
-      totalFoundToolMetadata += result.foundToolMetadataCount;
-      totalDeletedToolMetadata += result.deletedToolMetadataCount;
-      totalFoundUserToolApprovals += result.foundUserToolApprovalCount;
-      totalDeletedUserToolApprovals += result.deletedUserToolApprovalCount;
+//       touchedWorkspaceCount += 1;
+//       totalFoundViews += result.foundViewCount;
+//       totalDeletedViews += result.deletedViewCount;
+//       totalFoundToolMetadata += result.foundToolMetadataCount;
+//       totalDeletedToolMetadata += result.deletedToolMetadataCount;
+//       totalFoundUserToolApprovals += result.foundUserToolApprovalCount;
+//       totalDeletedUserToolApprovals += result.deletedUserToolApprovalCount;
 
-      logger.info(
-        {
-          workspaceId: workspace.sId,
-          mcpServerId: result.mcpServerId,
-          foundViewCount: result.foundViewCount,
-          deletedViewCount: result.deletedViewCount,
-          foundToolMetadataCount: result.foundToolMetadataCount,
-          deletedToolMetadataCount: result.deletedToolMetadataCount,
-          foundUserToolApprovalCount: result.foundUserToolApprovalCount,
-          deletedUserToolApprovalCount: result.deletedUserToolApprovalCount,
-        },
-        execute
-          ? "Deleted project_conversation server data for workspace"
-          : "Dry run: would delete project_conversation server data for workspace"
-      );
-    };
+//       logger.info(
+//         {
+//           workspaceId: workspace.sId,
+//           mcpServerId: result.mcpServerId,
+//           foundViewCount: result.foundViewCount,
+//           deletedViewCount: result.deletedViewCount,
+//           foundToolMetadataCount: result.foundToolMetadataCount,
+//           deletedToolMetadataCount: result.deletedToolMetadataCount,
+//           foundUserToolApprovalCount: result.foundUserToolApprovalCount,
+//           deletedUserToolApprovalCount: result.deletedUserToolApprovalCount,
+//         },
+//         execute
+//           ? "Deleted project_conversation server data for workspace"
+//           : "Dry run: would delete project_conversation server data for workspace"
+//       );
+//     };
 
-    if (wId) {
-      const workspace = await WorkspaceResource.fetchById(wId);
-      if (!workspace) {
-        throw new Error(`Workspace not found: ${wId}`);
-      }
+//     if (wId) {
+//       const workspace = await WorkspaceResource.fetchById(wId);
+//       if (!workspace) {
+//         throw new Error(`Workspace not found: ${wId}`);
+//       }
 
-      const hasProjectsFlag = await FeatureFlagModel.findOne({
-        where: {
-          workspaceId: workspace.id,
-          name: PROJECTS_FEATURE_FLAG,
-        },
-      });
+//       const hasProjectsFlag = await FeatureFlagModel.findOne({
+//         where: {
+//           workspaceId: workspace.id,
+//           name: PROJECTS_FEATURE_FLAG,
+//         },
+//       });
 
-      if (!hasProjectsFlag) {
-        throw new Error(
-          `Workspace ${wId} does not have the workspace-level "${PROJECTS_FEATURE_FLAG}" feature flag.`
-        );
-      }
+//       if (!hasProjectsFlag) {
+//         throw new Error(
+//           `Workspace ${wId} does not have the workspace-level "${PROJECTS_FEATURE_FLAG}" feature flag.`
+//         );
+//       }
 
-      await processWorkspace(renderLightWorkspaceType({ workspace }));
-    } else {
-      let workspaces = await listWorkspacesWithProjectsFeatureFlag();
-      if (fromWorkspaceId) {
-        workspaces = workspaces.filter(
-          (workspace) => workspace.id >= fromWorkspaceId
-        );
-      }
+//       await processWorkspace(renderLightWorkspaceType({ workspace }));
+//     } else {
+//       let workspaces = await listWorkspacesWithProjectsFeatureFlag();
+//       if (fromWorkspaceId) {
+//         workspaces = workspaces.filter(
+//           (workspace) => workspace.id >= fromWorkspaceId
+//         );
+//       }
 
-      logger.info(
-        { workspaceCount: workspaces.length, fromWorkspaceId },
-        "Running on workspaces with projects feature flag"
-      );
+//       logger.info(
+//         { workspaceCount: workspaces.length, fromWorkspaceId },
+//         "Running on workspaces with projects feature flag"
+//       );
 
-      if (workspaces.length > 0) {
-        await concurrentExecutor(workspaces, processWorkspace, {
-          concurrency: 1,
-        });
-      }
-    }
+//       if (workspaces.length > 0) {
+//         await concurrentExecutor(workspaces, processWorkspace, {
+//           concurrency: 1,
+//         });
+//       }
+//     }
 
-    logger.info(
-      {
-        targetServerName: TARGET_SERVER_NAME,
-        targetServerId: TARGET_SERVER_ID,
-        touchedWorkspaceCount,
-        totalFoundViews,
-        totalDeletedViews,
-        totalFoundToolMetadata,
-        totalDeletedToolMetadata,
-        totalFoundUserToolApprovals,
-        totalDeletedUserToolApprovals,
-      },
-      execute
-        ? "Finished deleting project_conversation server data"
-        : "Dry run complete for project_conversation server data deletion"
-    );
-  }
-);
+//     logger.info(
+//       {
+//         targetServerName: TARGET_SERVER_NAME,
+//         targetServerId: TARGET_SERVER_ID,
+//         touchedWorkspaceCount,
+//         totalFoundViews,
+//         totalDeletedViews,
+//         totalFoundToolMetadata,
+//         totalDeletedToolMetadata,
+//         totalFoundUserToolApprovals,
+//         totalDeletedUserToolApprovals,
+//       },
+//       execute
+//         ? "Finished deleting project_conversation server data"
+//         : "Dry run complete for project_conversation server data deletion"
+//     );
+//   }
+// );

--- a/front/pages/api/w/[wId]/files/[fileId]/index.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/index.ts
@@ -135,7 +135,6 @@ import {
 } from "@app/lib/api/files/upsert";
 import { addFileToProject } from "@app/lib/api/projects/context";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { FileVersion } from "@app/lib/resources/file_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -276,19 +275,6 @@ async function handler(
 
   let space: SpaceResource | null = null;
   if (file.useCaseMetadata?.spaceId) {
-    if (file.useCase === "project_context") {
-      const featureFlags = await getFeatureFlags(auth);
-      if (!featureFlags.includes("projects")) {
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: "Feature not supported",
-          },
-        });
-      }
-    }
-
     space = await SpaceResource.fetchById(auth, file.useCaseMetadata.spaceId);
   }
   if (

--- a/front/pages/api/w/[wId]/files/[fileId]/rename.test.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/rename.test.ts
@@ -1,4 +1,3 @@
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
@@ -178,9 +177,6 @@ describe("PATCH /api/w/[wId]/files/[fileId]/rename", () => {
         role: "user",
       });
 
-      // Enable the projects feature flag
-      await FeatureFlagFactory.basic(auth, "projects");
-
       // Create a project space where the user is an editor (has write access)
       const projectSpace = await SpaceFactory.project(workspace, user.id);
 
@@ -218,9 +214,6 @@ describe("PATCH /api/w/[wId]/files/[fileId]/rename", () => {
         method: "PATCH",
         role: "user",
       });
-
-      // Enable the projects feature flag
-      await FeatureFlagFactory.basic(auth, "projects");
 
       // Create a regular space (user has no access)
       const space = await SpaceFactory.regular(workspace);

--- a/front/pages/api/w/[wId]/files/[fileId]/rename.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/rename.ts
@@ -2,7 +2,6 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
@@ -40,20 +39,6 @@ async function handler(
         message: "File not found.",
       },
     });
-  }
-
-  // Check feature flag for project_context files
-  if (file.useCase === "project_context") {
-    const featureFlags = await getFeatureFlags(auth);
-    if (!featureFlags.includes("projects")) {
-      return apiError(req, res, {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: "Feature not supported",
-        },
-      });
-    }
   }
 
   // Get space for permission checks

--- a/front/pages/api/w/[wId]/files/[fileId]/save-in-project.test.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/save-in-project.test.ts
@@ -1,5 +1,4 @@
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
@@ -11,12 +10,10 @@ import handler from "./save-in-project";
 
 describe("POST /api/w/[wId]/files/[fileId]/save-in-project", () => {
   it("should return 404 when file does not exist", async () => {
-    const { req, res, auth } = await createPrivateApiMockRequest({
+    const { req, res } = await createPrivateApiMockRequest({
       method: "POST",
       role: "user",
     });
-
-    await FeatureFlagFactory.basic(auth, "projects");
 
     req.query = {
       ...req.query,
@@ -35,56 +32,11 @@ describe("POST /api/w/[wId]/files/[fileId]/save-in-project", () => {
     });
   });
 
-  it("should return 403 when projects feature flag is not enabled", async () => {
-    const {
-      req,
-      res,
-
-      user,
-      auth,
-    } = await createPrivateApiMockRequest({
-      method: "POST",
-      role: "user",
-    });
-
-    const conversation = await ConversationFactory.create(auth, {
-      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
-      messagesCreatedAt: [new Date()],
-    });
-
-    const file = await FileFactory.create(auth, user, {
-      contentType: frameContentType,
-      fileName: "test.frame",
-      fileSize: 1024,
-      status: "ready",
-      useCase: "tool_output",
-      useCaseMetadata: { conversationId: conversation.sId },
-    });
-
-    req.query = {
-      ...req.query,
-      fileId: file.sId,
-    };
-    req.body = { projectId: "some-project-id" };
-
-    await handler(req, res);
-
-    expect(res._getStatusCode()).toBe(403);
-    expect(res._getJSONData()).toEqual({
-      error: {
-        type: "invalid_request_error",
-        message: "Projects feature is not enabled for this workspace.",
-      },
-    });
-  });
-
   it("should return 400 when file is not a frame", async () => {
     const { auth, req, res, user } = await createPrivateApiMockRequest({
       method: "POST",
       role: "user",
     });
-
-    await FeatureFlagFactory.basic(auth, "projects");
 
     const conversation = await ConversationFactory.create(auth, {
       agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
@@ -129,8 +81,6 @@ describe("POST /api/w/[wId]/files/[fileId]/save-in-project", () => {
       role: "user",
     });
 
-    await FeatureFlagFactory.basic(auth, "projects");
-
     const project = await SpaceFactory.project(workspace, user.id);
 
     const file = await FileFactory.create(auth, user, {
@@ -172,8 +122,6 @@ describe("POST /api/w/[wId]/files/[fileId]/save-in-project", () => {
       role: "user",
     });
 
-    await FeatureFlagFactory.basic(auth, "projects");
-
     const conversation = await ConversationFactory.create(auth, {
       agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
       messagesCreatedAt: [new Date()],
@@ -206,8 +154,6 @@ describe("POST /api/w/[wId]/files/[fileId]/save-in-project", () => {
       method: "POST",
       role: "user",
     });
-
-    await FeatureFlagFactory.basic(auth, "projects");
 
     const conversation = await ConversationFactory.create(auth, {
       agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
@@ -247,8 +193,6 @@ describe("POST /api/w/[wId]/files/[fileId]/save-in-project", () => {
         role: "user",
       });
 
-    await FeatureFlagFactory.basic(auth, "projects");
-
     const regularSpace = await SpaceFactory.regular(workspace);
     const conversation = await ConversationFactory.create(auth, {
       agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
@@ -287,8 +231,6 @@ describe("POST /api/w/[wId]/files/[fileId]/save-in-project", () => {
         method: "POST",
         role: "user",
       });
-
-    await FeatureFlagFactory.basic(auth, "projects");
 
     // Create project without adding the user (user has no access)
     const project = await SpaceFactory.project(workspace);
@@ -330,8 +272,6 @@ describe("POST /api/w/[wId]/files/[fileId]/save-in-project", () => {
         method: "POST",
         role: "user",
       });
-
-    await FeatureFlagFactory.basic(auth, "projects");
 
     const project = await SpaceFactory.project(workspace, user.id);
 
@@ -375,8 +315,6 @@ describe("POST /api/w/[wId]/files/[fileId]/save-in-project", () => {
         method: "GET",
         role: "user",
       });
-
-    await FeatureFlagFactory.basic(auth, "projects");
 
     const project = await SpaceFactory.project(workspace, user.id);
 

--- a/front/pages/api/w/[wId]/files/[fileId]/save-in-project.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/save-in-project.ts
@@ -3,7 +3,6 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { addFileToProject } from "@app/lib/api/projects/context";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -35,17 +34,6 @@ async function handler(
       api_error: {
         type: "invalid_request_error",
         message: "Missing fileId query parameter.",
-      },
-    });
-  }
-
-  const featureFlags = await getFeatureFlags(auth);
-  if (!featureFlags.includes("projects")) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Projects feature is not enabled for this workspace.",
       },
     });
   }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_context/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_context/index.test.ts
@@ -2,7 +2,6 @@ import * as projectsApi from "@app/lib/api/projects/context";
 import { Authenticator } from "@app/lib/auth";
 import type { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { ProjectFileFactory } from "@app/tests/utils/ProjectFileFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
@@ -192,14 +191,10 @@ describe("/api/w/[wId]/spaces/[spaceId]/project_context", () => {
 
   describe("POST (content node)", () => {
     it("returns 400 when space is not a project", async () => {
-      const { req, res, globalSpace, auth } = await createPrivateApiMockRequest(
-        {
-          method: "POST",
-          role: "user",
-        }
-      );
-
-      await FeatureFlagFactory.basic(auth, "projects");
+      const { req, res, globalSpace } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "user",
+      });
 
       req.query.spaceId = globalSpace.sId;
       req.body = {
@@ -219,13 +214,12 @@ describe("/api/w/[wId]/spaces/[spaceId]/project_context", () => {
         .mockReturnValue(false);
 
       try {
-        const { req, res, workspace, user, auth } =
-          await createPrivateApiMockRequest({
+        const { req, res, workspace, user } = await createPrivateApiMockRequest(
+          {
             method: "POST",
             role: "user",
-          });
-
-        await FeatureFlagFactory.basic(auth, "projects");
+          }
+        );
 
         const project = await SpaceFactory.project(workspace, user.id);
         req.query.spaceId = project.sId;
@@ -244,13 +238,10 @@ describe("/api/w/[wId]/spaces/[spaceId]/project_context", () => {
     });
 
     it("returns 201 and content fragment payload when add succeeds", async () => {
-      const { req, res, workspace, user, auth } =
-        await createPrivateApiMockRequest({
-          method: "POST",
-          role: "user",
-        });
-
-      await FeatureFlagFactory.basic(auth, "projects");
+      const { req, res, workspace, user } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "user",
+      });
 
       const project = await SpaceFactory.project(workspace, user.id);
 
@@ -301,13 +292,10 @@ describe("/api/w/[wId]/spaces/[spaceId]/project_context", () => {
     });
 
     it("returns 400 for invalid JSON body", async () => {
-      const { req, res, workspace, user, auth } =
-        await createPrivateApiMockRequest({
-          method: "POST",
-          role: "user",
-        });
-
-      await FeatureFlagFactory.basic(auth, "projects");
+      const { req, res, workspace, user } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "user",
+      });
 
       const project = await SpaceFactory.project(workspace, user.id);
       req.query.spaceId = project.sId;

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_context/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_context/index.ts
@@ -7,7 +7,6 @@ import {
   listProjectContextAttachments,
 } from "@app/lib/api/projects/context";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -122,17 +121,6 @@ async function handler(
     }
 
     case "POST": {
-      const featureFlags = await getFeatureFlags(auth);
-      if (!featureFlags.includes("projects")) {
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "invalid_request_error",
-            message: "Projects feature is not enabled for this workspace.",
-          },
-        });
-      }
-
       if (!space.isProject()) {
         return apiError(req, res, {
           status_code: 400,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -1,6 +1,5 @@
 import { Authenticator } from "@app/lib/auth";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -115,8 +114,6 @@ describe("PATCH /api/w/[wId]/spaces/[spaceId]/project_metadata", () => {
       role: "admin",
     });
 
-    await FeatureFlagFactory.basic(auth, "projects");
-
     const projectSpace = await SpaceFactory.project(workspace);
     await ProjectMetadataResource.makeNew(auth, projectSpace, {
       description: "Test description",
@@ -144,8 +141,6 @@ describe("PATCH /api/w/[wId]/spaces/[spaceId]/project_metadata", () => {
       role: "admin",
     });
 
-    await FeatureFlagFactory.basic(auth, "projects");
-
     const projectSpace = await SpaceFactory.project(workspace);
     await ProjectMetadataResource.makeNew(auth, projectSpace, {
       description: "Test",
@@ -170,8 +165,6 @@ describe("PATCH /api/w/[wId]/spaces/[spaceId]/project_metadata", () => {
       method: "PATCH",
       role: "admin",
     });
-
-    await FeatureFlagFactory.basic(auth, "projects");
 
     const projectSpace = await SpaceFactory.project(workspace);
     await ProjectMetadataResource.makeNew(auth, projectSpace, {

--- a/front/scripts/backfill_project_context_mount_paths.ts
+++ b/front/scripts/backfill_project_context_mount_paths.ts
@@ -1,4 +1,4 @@
-import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { FileModel } from "@app/lib/resources/storage/models/files";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -41,11 +41,6 @@ makeScript(
 
         const auth =
           await Authenticator.internalBuilderForWorkspace(workspaceId);
-
-        const hasProjectEnabled = await hasFeatureFlag(auth, "projects");
-        if (!hasProjectEnabled) {
-          throw new Error("Workspace does not have `projects` FF enabled.");
-        }
 
         logger.info(
           { workspaceId, execute },

--- a/front/scripts/backfill_project_gcs_mount_paths_to_pods.ts
+++ b/front/scripts/backfill_project_gcs_mount_paths_to_pods.ts
@@ -1,5 +1,4 @@
 import { toPodMountFilePath } from "@app/lib/api/files/mount_path";
-import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import assert from "@app/lib/utils/assert";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -64,19 +63,6 @@ makeScript(
 
     await runOnAllWorkspaces(
       async (workspace) => {
-        const auth = await Authenticator.internalBuilderForWorkspace(
-          workspace.sId
-        );
-
-        const hasProjectEnabled = await hasFeatureFlag(auth, "projects");
-        if (!hasProjectEnabled) {
-          logger.info(
-            { workspaceId: workspace.sId },
-            "[backfill_project_gcs_mount_paths_to_pods] Workspace does not have `projects` FF enabled, skipping"
-          );
-          return;
-        }
-
         let totalProcessed = 0;
         let totalCopied = 0;
         let totalWouldCopy = 0;

--- a/front/scripts/cleanup_duplicate_project_mount_paths.ts
+++ b/front/scripts/cleanup_duplicate_project_mount_paths.ts
@@ -7,7 +7,7 @@ import {
   getProcessedContentType,
   hasProcessedVersion,
 } from "@app/lib/api/files/processing";
-import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { FileModel } from "@app/lib/resources/storage/models/files";
@@ -57,11 +57,6 @@ makeScript(
 
         const auth =
           await Authenticator.internalBuilderForWorkspace(workspaceId);
-
-        const hasProjectEnabled = await hasFeatureFlag(auth, "projects");
-        if (!hasProjectEnabled) {
-          return;
-        }
 
         logger.info(
           { workspaceId, execute },

--- a/front/scripts/migrate_project_mount_paths_to_pods.ts
+++ b/front/scripts/migrate_project_mount_paths_to_pods.ts
@@ -7,7 +7,6 @@
 // carries the /projects/ prefix, rewrite it to /pods/.
 
 import { toPodMountFilePath } from "@app/lib/api/files/mount_path";
-import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
 import { FileModel } from "@app/lib/resources/storage/models/files";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -50,20 +49,9 @@ makeScript(
       if (!workspace) {
         throw new Error(`Workspace not found: ${wId}`);
       }
-      const hasProjectsFlag = await FeatureFlagResource.isEnabledForWorkspace(
-        workspace,
-        "projects"
-      );
-      if (!hasProjectsFlag) {
-        logger.info(
-          { workspaceId: workspace.sId },
-          "[migrate_project_mount_paths_to_pods] Workspace does not have `projects` FF enabled, nothing to do"
-        );
-        return;
-      }
       workspaces = [{ id: workspace.id, sId: workspace.sId }];
     } else {
-      const resources = await WorkspaceResource.listWithFeatureFlag("projects");
+      const resources = await WorkspaceResource.listAll();
       workspaces = resources.map((w) => ({ id: w.id, sId: w.sId }));
     }
 

--- a/front/scripts/start_project_task_workflows_for_projects_workspaces.ts
+++ b/front/scripts/start_project_task_workflows_for_projects_workspaces.ts
@@ -7,17 +7,13 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { makeScript } from "@app/scripts/helpers";
 import { launchOrSignalProjectTodoWorkflow } from "@app/temporal/project_task/client";
-import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { LightWorkspaceType } from "@app/types/user";
-
-const PROJECTS_FEATURE_FLAG =
-  "projects" as const satisfies WhitelistableFeature;
 
 async function listWorkspacesWithProjectsFeatureFlag(): Promise<
   LightWorkspaceType[]
 > {
   const flags = await FeatureFlagModel.findAll({
-    where: { name: PROJECTS_FEATURE_FLAG },
+    where: { name: "projects" },
     attributes: ["workspaceId"],
     // WORKSPACE_ISOLATION_BYPASS: list workspace IDs with the projects flag for this admin-only backfill script.
     // @ts-expect-error -- Script operates across all workspaces.
@@ -97,13 +93,13 @@ makeScript(
       const hasProjectsFlag = await FeatureFlagModel.findOne({
         where: {
           workspaceId: workspace.id,
-          name: PROJECTS_FEATURE_FLAG,
+          name: "projects",
         },
       });
 
       if (!hasProjectsFlag) {
         throw new Error(
-          `Workspace ${wId} does not have the workspace-level "${PROJECTS_FEATURE_FLAG}" feature flag.`
+          `Workspace ${wId} does not have the workspace-level "projects" feature flag.`
         );
       }
 

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -179,10 +179,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Discord bot integration for workspace-level Discord integration",
     stage: "dust_only",
   },
-  projects: {
-    description: "Enable the Projects feature",
-    stage: "on_demand",
-  },
   databricks_tool: {
     description: "Databricks MCP tool",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -694,7 +694,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "claude_4_5_opus_feature"
   | "claude_4_opus_feature"
   | "sessions_branching"
-  | "projects"
   | "databricks_tool"
   | "deepseek_feature"
   | "deepseek_r1_global_agent_feature"


### PR DESCRIPTION
## Description

Removes the `"projects"` feature flag and releases Pods to all workspaces. All `hasFeature("projects")` / `isProjectsEnabled` / `hasPodConversations` guards are stripped across the frontend (agent builder, sidebar, conversation menu, in-app banner, notification preferences, workspace settings) and the backend (`save-in-project`, `rename`, `project_context`, `files/[fileId]` API routes). The `pod_manager` and `pod_tasks` MCP servers and the Pods `GlobalSkillDefinition` drop their `isRestricted` checks. Tests no longer require `FeatureFlagFactory.basic(auth, "projects")` in their setup. The `"projects"` entry is removed from `WHITELISTABLE_FEATURES_CONFIG`. The `20260414_sunset_project_conversation_mcp_server.ts` migration script is commented out (already executed).

## Tests

- Existing unit and integration tests updated to remove the FF dependency — they now cover the always-on code paths.
- Manually tested Pods UI (sidebar, conversation menu, agent builder space selection) without the FF.

## Risk

Medium. This is a global release — Pods features activate for **all workspaces**, including those that never had the FF. The primary risk is workspaces encountering Pod-related UI or API endpoints they haven't opted into before. Rollback requires re-adding the FF gate, which is a code change. Backend routes previously gated by the FF are now open to all authenticated workspace members with appropriate space permissions — the underlying permission checks (`space.isProject()`, `canAdministrate`) are unchanged.

## Deploy Plan

Deploy front. No DB migrations.
Run the script to add the pods mcp tools to every workspaces.
