### PR TITLE
Add: function to mounts from multiple scopes

### DIFF
--- a/front/lib/api/file_system/dust_file_system.test.ts
+++ b/front/lib/api/file_system/dust_file_system.test.ts
@@ -1,13 +1,52 @@
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
+import { createSpaceAndGroup } from "@app/lib/api/spaces";
 import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { Ok } from "@app/types/shared/result";
+import type { LightWorkspaceType } from "@app/types/user";
 import assert from "assert";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+async function sessionAuthForUser(
+  user: UserResource,
+  workspace: LightWorkspaceType
+): Promise<Authenticator> {
+  assert(
+    user.workOSUserId,
+    "Expected user to have a WorkOS user ID for session auth"
+  );
+
+  return Authenticator.fromSession(
+    {
+      type: "workos",
+      sessionId: `test-session-${user.sId}`,
+      user: {
+        workOSUserId: user.workOSUserId,
+        email: user.email ?? "user@dust.tt",
+        email_verified: true,
+        name: user.username ?? "user",
+        nickname: user.username ?? "user",
+      },
+      authenticationMethod: "GoogleOAuth",
+      isSSO: false,
+      workspaceId: workspace.sId,
+      organizationId: workspace.workOSOrganizationId ?? undefined,
+      region: "us-central1",
+    },
+    workspace.sId
+  );
+}
 
 vi.mock("@app/lib/file_storage/config", () => ({
   default: {
@@ -234,6 +273,558 @@ describe("DustFileSystem.fromScopedPath", () => {
     expect(
       mounts.some((m) => m.kind === "conversation" && m.id === conversation.sId)
     ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// forAgentLoop
+// ---------------------------------------------------------------------------
+
+describe("DustFileSystem.forAgentLoop", () => {
+  const defaultMockBucket = {
+    file: vi.fn(() => ({ save: vi.fn().mockResolvedValue(undefined) })),
+    getAllFilesByPrefix: vi
+      .fn()
+      .mockResolvedValue({ files: [], pageFetchCount: 1 }),
+  } as unknown as ReturnType<typeof getPrivateUploadBucket>;
+
+  beforeEach(() => {
+    vi.mocked(getPrivateUploadBucket).mockReturnValue(defaultMockBucket);
+  });
+
+  it("matches forConversation mounts when scopedPaths is empty", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+
+    const [forConversation, forAgentLoop] = await Promise.all([
+      DustFileSystem.forConversation(auth, conversation),
+      DustFileSystem.forAgentLoop(auth, { conversation }),
+    ]);
+
+    assert(forConversation.isOk());
+    assert(forAgentLoop.isOk());
+
+    expect(forAgentLoop.value.getMounts()).toEqual(
+      forConversation.value.getMounts()
+    );
+  });
+
+  it("adds a second conversation mount when scopedPaths references another accessible conversation", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent",
+    });
+
+    const currentConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+    const otherConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+
+    const result = await DustFileSystem.forAgentLoop(auth, {
+      conversation: currentConversation,
+      scopedPaths: [
+        `conversation-${otherConversation.sId}/report.pdf`,
+        `conversation-${currentConversation.sId}/notes.txt`,
+      ],
+    });
+
+    assert(result.isOk());
+    const mounts = result.value.getMounts();
+    expect(mounts).toHaveLength(2);
+    expect(
+      mounts.some(
+        (m) => m.kind === "conversation" && m.id === currentConversation.sId
+      )
+    ).toBe(true);
+    expect(
+      mounts.some(
+        (m) => m.kind === "conversation" && m.id === otherConversation.sId
+      )
+    ).toBe(true);
+  });
+
+  it("returns Err(not_found) when scopedPaths references an inaccessible conversation", async () => {
+    const { workspace, user } = await createResourceTest({ role: "admin" });
+    const { authenticator: otherAuth } = await createResourceTest({
+      role: "user",
+    });
+
+    const projectSpace = await SpaceFactory.project(workspace, user.id);
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent",
+    });
+    const currentConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+      spaceId: projectSpace.id,
+    });
+
+    const otherAgentConfig = await AgentConfigurationFactory.createTestAgent(
+      otherAuth,
+      { name: "Other Agent", description: "Other Agent" }
+    );
+    const privateConversation = await ConversationFactory.create(otherAuth, {
+      agentConfigurationId: otherAgentConfig.sId,
+      messagesCreatedAt: [],
+    });
+
+    const result = await DustFileSystem.forAgentLoop(auth, {
+      conversation: currentConversation,
+      scopedPaths: [`conversation-${privateConversation.sId}/secret.pdf`],
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("not_found");
+    }
+  });
+
+  it("adds a pod mount from scopedPaths even when the loop conversation is not in a pod", async () => {
+    const { workspace, user } = await createResourceTest({ role: "admin" });
+
+    // Create the project space, then re-fetch auth so it knows about the new editor group.
+    const projectSpace = await SpaceFactory.project(workspace, user.id);
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent",
+    });
+    const regularConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+
+    const result = await DustFileSystem.forAgentLoop(auth, {
+      conversation: regularConversation,
+      scopedPaths: [`pod-${projectSpace.sId}/shared.md`],
+    });
+
+    assert(result.isOk());
+    const mounts = result.value.getMounts();
+    expect(mounts).toHaveLength(2);
+    expect(mounts.some((m) => m.kind === "conversation")).toBe(true);
+    expect(
+      mounts.some((m) => m.kind === "pod" && m.id === projectSpace.sId)
+    ).toBe(true);
+    const podMount = mounts.find((m) => m.kind === "pod");
+    expect(podMount!.permissions.canRead).toBe(true);
+  });
+
+  it("returns Err(unauthorized) when scopedPaths references a pod the user cannot read", async () => {
+    const { workspace, user } = await createResourceTest({ role: "user" });
+
+    // Project space with no editor membership for `user`.
+    const projectSpace = await SpaceFactory.project(workspace);
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+
+    const result = await DustFileSystem.forAgentLoop(auth, {
+      conversation,
+      scopedPaths: [`pod-${projectSpace.sId}/data.csv`],
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("unauthorized");
+    }
+  });
+
+  it("accepts stat on a dest path in another conversation mount but not with forConversation alone", async () => {
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      ...defaultMockBucket,
+      file: vi.fn(() => ({
+        exists: vi.fn().mockResolvedValue([false]),
+      })),
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+
+    const { authenticator: auth } = await createResourceTest({});
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent",
+    });
+
+    const currentConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+    const otherConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+
+    const destPath = `conversation-${otherConversation.sId}/dest.txt`;
+
+    const conversationOnlyFs = await DustFileSystem.forConversation(
+      auth,
+      currentConversation
+    );
+    assert(conversationOnlyFs.isOk());
+    const conversationOnlyStat = await conversationOnlyFs.value.stat(destPath);
+    expect(conversationOnlyStat.isErr()).toBe(true);
+    if (conversationOnlyStat.isErr()) {
+      expect(conversationOnlyStat.error.code).toBe("invalid_path");
+    }
+
+    const agentLoopFs = await DustFileSystem.forAgentLoop(auth, {
+      conversation: currentConversation,
+      scopedPaths: [destPath],
+    });
+    assert(agentLoopFs.isOk());
+    const agentLoopStat = await agentLoopFs.value.stat(destPath);
+    expect(agentLoopStat.isOk()).toBe(true);
+    if (agentLoopStat.isOk()) {
+      expect(agentLoopStat.value).toBe(null);
+    }
+  });
+
+  it("deduplicates mounts when scopedPaths only reference the current conversation and pod", async () => {
+    const { workspace, user } = await createResourceTest({ role: "admin" });
+    const projectSpace = await SpaceFactory.project(workspace, user.id);
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+      spaceId: projectSpace.id,
+    });
+
+    const result = await DustFileSystem.forAgentLoop(auth, {
+      conversation,
+      scopedPaths: [
+        `conversation-${conversation.sId}/a.txt`,
+        `pod-${projectSpace.sId}/b.txt`,
+      ],
+    });
+
+    assert(result.isOk());
+    expect(result.value.getMounts()).toHaveLength(2);
+  });
+
+  describe("access control", () => {
+    beforeEach(async () => {
+      vi.spyOn(
+        await import("@app/lib/api/projects/connector"),
+        "createDataSourceAndConnectorForProject"
+      ).mockResolvedValue(new Ok(undefined));
+    });
+
+    it("returns Err(not_found) for another conversation when privateConversationUrlsByDefault is enabled and the user is not a participant", async () => {
+      const {
+        workspace,
+        globalSpace,
+        authenticator: adminAuth,
+      } = await createResourceTest({ role: "admin" });
+
+      const regularUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, regularUser, {
+        role: "user",
+      });
+
+      const adminConversation = await ConversationFactory.create(adminAuth, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        requestedSpaceIds: [globalSpace.id],
+        messagesCreatedAt: [new Date()],
+      });
+
+      const updateResult = await WorkspaceResource.updateMetadata(
+        workspace.id,
+        { privateConversationUrlsByDefault: true }
+      );
+      assert(updateResult.isOk(), "Failed to enable private conversation URLs");
+
+      const userSessionAuth = await sessionAuthForUser(regularUser, workspace);
+
+      const access = await ConversationResource.canAccess(
+        userSessionAuth,
+        adminConversation.sId
+      );
+      expect(access).toBe(
+        "conversation_access_restricted_by_private_by_default_url_restriction"
+      );
+
+      expect(
+        await ConversationResource.fetchById(
+          userSessionAuth,
+          adminConversation.sId
+        )
+      ).toBeNull();
+
+      const userAgentConfig = await AgentConfigurationFactory.createTestAgent(
+        userSessionAuth,
+        { name: "User Agent", description: "User Agent" }
+      );
+      const userConversation = await ConversationFactory.create(
+        userSessionAuth,
+        {
+          agentConfigurationId: userAgentConfig.sId,
+          messagesCreatedAt: [],
+        }
+      );
+
+      const result = await DustFileSystem.forAgentLoop(userSessionAuth, {
+        conversation: userConversation,
+        scopedPaths: [`conversation-${adminConversation.sId}/secret.pdf`],
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.code).toBe("not_found");
+      }
+    });
+
+    it("adds a pod conversation mount when the user is a pod member", async () => {
+      const {
+        workspace,
+        user,
+        authenticator: adminAuth,
+      } = await createResourceTest({ role: "admin" });
+
+      const regularUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, regularUser, {
+        role: "user",
+      });
+
+      const projectSpace = await SpaceFactory.project(workspace, user.id);
+      const addMemberResult = await projectSpace.addMembers(adminAuth, {
+        userIds: [user.sId, regularUser.sId],
+      });
+      assert(addMemberResult.isOk(), "Failed to add users to project space");
+
+      const refreshedAdminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+      const refreshedUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        regularUser.sId,
+        workspace.sId
+      );
+
+      const podConversation = await ConversationFactory.create(
+        refreshedAdminAuth,
+        {
+          agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+          requestedSpaceIds: [projectSpace.id],
+          spaceId: projectSpace.id,
+          messagesCreatedAt: [new Date()],
+        }
+      );
+
+      const access = await ConversationResource.canAccess(
+        refreshedUserAuth,
+        podConversation.sId
+      );
+      expect(access).toBe("allowed");
+
+      const userAgentConfig = await AgentConfigurationFactory.createTestAgent(
+        refreshedUserAuth,
+        { name: "User Agent", description: "User Agent" }
+      );
+      const userConversation = await ConversationFactory.create(
+        refreshedUserAuth,
+        {
+          agentConfigurationId: userAgentConfig.sId,
+          messagesCreatedAt: [],
+        }
+      );
+
+      const result = await DustFileSystem.forAgentLoop(refreshedUserAuth, {
+        conversation: userConversation,
+        scopedPaths: [`conversation-${podConversation.sId}/shared.pdf`],
+      });
+
+      assert(result.isOk());
+      expect(
+        result.value
+          .getMounts()
+          .some(
+            (m) => m.kind === "conversation" && m.id === podConversation.sId
+          )
+      ).toBe(true);
+    });
+
+    it("adds a pod conversation mount when the pod is open and the user is not a pod member", async () => {
+      const {
+        workspace,
+        user,
+        authenticator: adminAuth,
+      } = await createResourceTest({ role: "admin" });
+
+      const regularUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, regularUser, {
+        role: "user",
+      });
+      const userSessionAuth = await sessionAuthForUser(regularUser, workspace);
+
+      const openProjectRes = await createSpaceAndGroup(adminAuth, {
+        name: `open pod ${Date.now()}`,
+        isRestricted: false,
+        spaceKind: "project",
+        managementMode: "manual",
+        memberIds: [],
+      });
+      assert(
+        openProjectRes.isOk(),
+        openProjectRes.isErr()
+          ? openProjectRes.error.message
+          : "Failed to create open project"
+      );
+      const refreshedAdminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+
+      const openProject = await SpaceResource.fetchById(
+        refreshedAdminAuth,
+        openProjectRes.value.sId
+      );
+      assert(openProject, "Open project not found after creation");
+      expect(openProject.isOpen()).toBe(true);
+
+      const podConversation = await ConversationFactory.create(
+        refreshedAdminAuth,
+        {
+          agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+          requestedSpaceIds: [openProject.id],
+          spaceId: openProject.id,
+          messagesCreatedAt: [new Date()],
+        }
+      );
+
+      const access = await ConversationResource.canAccess(
+        userSessionAuth,
+        podConversation.sId
+      );
+      expect(access).toBe("allowed");
+
+      const userAgentConfig = await AgentConfigurationFactory.createTestAgent(
+        userSessionAuth,
+        { name: "User Agent", description: "User Agent" }
+      );
+      const userConversation = await ConversationFactory.create(
+        userSessionAuth,
+        {
+          agentConfigurationId: userAgentConfig.sId,
+          messagesCreatedAt: [],
+        }
+      );
+
+      const result = await DustFileSystem.forAgentLoop(userSessionAuth, {
+        conversation: userConversation,
+        scopedPaths: [`conversation-${podConversation.sId}/open.pdf`],
+      });
+
+      assert(result.isOk());
+      expect(
+        result.value
+          .getMounts()
+          .some(
+            (m) => m.kind === "conversation" && m.id === podConversation.sId
+          )
+      ).toBe(true);
+    });
+
+    it("returns Err(not_found) for a conversation in a restricted pod the user cannot access", async () => {
+      const { workspace, user } = await createResourceTest({ role: "admin" });
+
+      const regularUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, regularUser, {
+        role: "user",
+      });
+      const userSessionAuth = await sessionAuthForUser(regularUser, workspace);
+
+      const restrictedProject = await SpaceFactory.project(workspace, user.id);
+      expect(restrictedProject.isOpen()).toBe(false);
+
+      const refreshedAdminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+
+      const podConversation = await ConversationFactory.create(
+        refreshedAdminAuth,
+        {
+          agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+          requestedSpaceIds: [restrictedProject.id],
+          spaceId: restrictedProject.id,
+          messagesCreatedAt: [new Date()],
+        }
+      );
+
+      const access = await ConversationResource.canAccess(
+        userSessionAuth,
+        podConversation.sId
+      );
+      expect(access).toBe("conversation_access_restricted");
+
+      expect(
+        await ConversationResource.fetchById(
+          userSessionAuth,
+          podConversation.sId
+        )
+      ).toBeNull();
+
+      const userAgentConfig = await AgentConfigurationFactory.createTestAgent(
+        userSessionAuth,
+        { name: "User Agent", description: "User Agent" }
+      );
+      const userConversation = await ConversationFactory.create(
+        userSessionAuth,
+        {
+          agentConfigurationId: userAgentConfig.sId,
+          messagesCreatedAt: [],
+        }
+      );
+
+      const result = await DustFileSystem.forAgentLoop(userSessionAuth, {
+        conversation: userConversation,
+        scopedPaths: [`conversation-${podConversation.sId}/restricted.pdf`],
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.code).toBe("not_found");
+      }
+    });
   });
 });
 

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -8,8 +8,10 @@
  * Factories:
  *   DustFileSystem.forConversation(auth, conversation)   single conversation mount (+pod if project space)
  *   DustFileSystem.forConversations(auth, conversations) multiple conversation mounts (+pod if project space)
- *   DustFileSystem.forPod(auth, space)                   pod (project-space) mount only
- *   DustFileSystem.fromScopedPath(auth, scopedPath)      infers context from the path prefix
+ *   DustFileSystem.fromScopedPath(auth, scopedPath)     infers context from the path prefix
+ *   DustFileSystem.forAgentLoop(auth, { conversation, scopedPaths })
+ *       defaults to the agent loop conversation (+ its pod when applicable), plus any
+ *       conversation/pod mounts referenced in scopedPaths that the user can access
  */
 
 import config from "@app/lib/api/config";
@@ -76,6 +78,73 @@ function parseScopedPrefix(scopedPath: string): ParsedScopedPrefix | null {
   return null;
 }
 
+function createConversationMount(
+  conversation: ConversationWithoutContentType,
+  { includeLegacy }: { includeLegacy: boolean }
+): FileSystemMount {
+  return {
+    kind: "conversation",
+    id: conversation.sId,
+    scopedPrefix: `${SCOPED_PREFIX_CONVERSATION}${conversation.sId}`,
+    sandboxMountPoint: `/files/${SCOPED_PREFIX_CONVERSATION}${conversation.sId}`,
+    legacyPrefix: includeLegacy ? LEGACY_PREFIX_CONVERSATION : null,
+    legacySandboxMountPoint: includeLegacy
+      ? `/files/${LEGACY_PREFIX_CONVERSATION}`
+      : null,
+    // Conversation access is always read+write when fetchById returned the resource.
+    permissions: { canRead: true, canWrite: true },
+  };
+}
+
+function createPodMount(
+  auth: Authenticator,
+  space: SpaceResource
+): FileSystemMount {
+  return {
+    kind: "pod",
+    id: space.sId,
+    scopedPrefix: `${SCOPED_PREFIX_POD}${space.sId}`,
+    sandboxMountPoint: `/files/${SCOPED_PREFIX_POD}${space.sId}`,
+    legacyPrefix: LEGACY_PREFIX_PROJECT,
+    legacySandboxMountPoint: `/files/${LEGACY_PREFIX_PROJECT}`,
+    permissions: {
+      canRead: space.canRead(auth),
+      canWrite: space.canWrite(auth),
+    },
+  };
+}
+
+function collectScopedPrefixesFromPaths(scopedPaths: string[]): {
+  conversationIds: Set<string>;
+  podIds: Set<string>;
+} {
+  const conversationIds = new Set<string>();
+  const podIds = new Set<string>();
+
+  for (const scopedPath of scopedPaths) {
+    const parsed = parseScopedPrefix(scopedPath);
+    if (!parsed) {
+      continue;
+    }
+    switch (parsed.kind) {
+      case "conversation":
+        conversationIds.add(parsed.id);
+        break;
+      case "pod":
+        podIds.add(parsed.id);
+        break;
+      default:
+        assertNever(parsed);
+    }
+  }
+
+  return { conversationIds, podIds };
+}
+
+function hasMount(mounts: FileSystemMount[], scopedPrefix: string): boolean {
+  return mounts.some((m) => m.scopedPrefix === scopedPrefix);
+}
+
 // ---------------------------------------------------------------------------
 // DustFileSystem
 // ---------------------------------------------------------------------------
@@ -113,19 +182,7 @@ export class DustFileSystem {
     const includeLegacy = conversations.length === 1;
 
     for (const conversation of conversations) {
-      mounts.push({
-        kind: "conversation",
-        id: conversation.sId,
-        scopedPrefix: `${SCOPED_PREFIX_CONVERSATION}${conversation.sId}`,
-        sandboxMountPoint: `/files/${SCOPED_PREFIX_CONVERSATION}${conversation.sId}`,
-        legacyPrefix: includeLegacy ? LEGACY_PREFIX_CONVERSATION : null,
-        legacySandboxMountPoint: includeLegacy
-          ? `/files/${LEGACY_PREFIX_CONVERSATION}`
-          : null,
-        // Conversation access is always read+write when the caller holds a valid auth for it.
-        // The handler is responsible for verifying conversation access before calling this factory.
-        permissions: { canRead: true, canWrite: true },
-      });
+      mounts.push(createConversationMount(conversation, { includeLegacy }));
     }
 
     // Collect unique pod space IDs, then batch-fetch to avoid N+1 queries.
@@ -139,18 +196,7 @@ export class DustFileSystem {
       for (const spaceId of uniqueSpaceIds) {
         const space = spaceById.get(spaceId);
         if (space) {
-          mounts.push({
-            kind: "pod",
-            id: space.sId,
-            scopedPrefix: `${SCOPED_PREFIX_POD}${space.sId}`,
-            sandboxMountPoint: `/files/${SCOPED_PREFIX_POD}${space.sId}`,
-            legacyPrefix: LEGACY_PREFIX_PROJECT,
-            legacySandboxMountPoint: `/files/${LEGACY_PREFIX_PROJECT}`,
-            permissions: {
-              canRead: space.canRead(auth),
-              canWrite: space.canWrite(auth),
-            },
-          });
+          mounts.push(createPodMount(auth, space));
         }
       }
     }
@@ -194,18 +240,7 @@ export class DustFileSystem {
     }
 
     const owner = auth.getNonNullableWorkspace();
-    const mount: FileSystemMount = {
-      kind: "pod",
-      id: space.sId,
-      scopedPrefix: `${SCOPED_PREFIX_POD}${space.sId}`,
-      sandboxMountPoint: `/files/${SCOPED_PREFIX_POD}${space.sId}`,
-      legacyPrefix: LEGACY_PREFIX_PROJECT,
-      legacySandboxMountPoint: `/files/${LEGACY_PREFIX_PROJECT}`,
-      permissions: {
-        canRead: true,
-        canWrite: space.canWrite(auth),
-      },
-    };
+    const mount = createPodMount(auth, space);
 
     const backend = new GCSFileSystemBackend(
       owner.sId,
@@ -213,6 +248,102 @@ export class DustFileSystem {
     );
 
     return new Ok(new DustFileSystem(auth, [mount], backend));
+  }
+
+  /**
+   * Build a DustFileSystem for an agent loop.
+   *
+   * Always includes the agent loop conversation mount and, when applicable, its Pod mount
+   * (same as {@link forConversation}). Additionally mounts any conversation or Pod referenced
+   * in `scopedPaths` that the caller can access, so cross-scope operations (e.g. copy between
+   * two conversations) can resolve both endpoints in a single filesystem instance.
+   */
+  static async forAgentLoop(
+    auth: Authenticator,
+    {
+      conversation,
+      scopedPaths = [],
+    }: {
+      conversation: ConversationWithoutContentType;
+      scopedPaths?: string[];
+    }
+  ): Promise<Result<DustFileSystem, DustFileSystemError>> {
+    const baseResult = await DustFileSystem.forConversation(auth, conversation);
+    if (baseResult.isErr()) {
+      return baseResult;
+    }
+
+    const { conversationIds, podIds } =
+      collectScopedPrefixesFromPaths(scopedPaths);
+    const mounts = [...baseResult.value.getMounts()];
+
+    const conversationIdsToFetch = [...conversationIds].filter(
+      (conversationId) =>
+        !hasMount(mounts, `${SCOPED_PREFIX_CONVERSATION}${conversationId}`)
+    );
+
+    if (conversationIdsToFetch.length > 0) {
+      const conversations = await ConversationResource.fetchByIds(
+        auth,
+        conversationIdsToFetch
+      );
+      const conversationById = new Map(conversations.map((c) => [c.sId, c]));
+
+      for (const conversationId of conversationIdsToFetch) {
+        const conversation = conversationById.get(conversationId);
+        if (!conversation) {
+          return new Err(
+            new DustFileSystemError(
+              "not_found",
+              `Conversation not found: ${conversationId}`
+            )
+          );
+        }
+
+        mounts.push(
+          createConversationMount(conversation.toJSON(), {
+            includeLegacy: false,
+          })
+        );
+      }
+    }
+
+    const podIdsToFetch = [...podIds].filter(
+      (podId) => !hasMount(mounts, `${SCOPED_PREFIX_POD}${podId}`)
+    );
+
+    if (podIdsToFetch.length > 0) {
+      const spaces = await SpaceResource.fetchByIds(auth, podIdsToFetch);
+      const spaceById = new Map(spaces.map((s) => [s.sId, s]));
+
+      for (const podId of podIdsToFetch) {
+        const space = spaceById.get(podId);
+        if (!space) {
+          return new Err(
+            new DustFileSystemError("not_found", `Space not found: ${podId}`)
+          );
+        }
+
+        if (!space.canRead(auth)) {
+          return new Err(
+            new DustFileSystemError(
+              "unauthorized",
+              "You do not have read access to this space."
+            )
+          );
+        }
+
+        mounts.push(createPodMount(auth, space));
+      }
+    }
+
+    const owner = auth.getNonNullableWorkspace();
+    const backend = new GCSFileSystemBackend(
+      owner.sId,
+      fileStorageConfig.getGcsPrivateUploadsBucket()
+    );
+
+    return new Ok(new DustFileSystem(auth, mounts, backend));
   }
 
   /**


### PR DESCRIPTION
## Description

Adds `DustFileSystem.forAgentLoop()`, a new static factory on `DustFileSystem` that builds a multi-scope filesystem for agent loop use cases (e.g. cross-conversation file copy). It starts from `forConversation` mounts (current conversation + its pod when applicable), then parses any extra `scopedPaths` to mount additional conversations or pods the caller can access — deduplicating by `scopedPrefix`. Access control is enforced eagerly: inaccessible conversations return `Err(not_found)` (respects `privateConversationUrlsByDefault`), pods the user can't read return `Err(unauthorized)`.

Also extracts `createConversationMount()`, `createPodMount()`, and `collectScopedPrefixesFromPaths()` helpers, eliminating duplicated inline mount object literals across `forConversation`, `forPod`, and the new factory.

## Tests

Added a comprehensive `DustFileSystem.forAgentLoop` test suite in `dust_file_system.test.ts` covering: empty `scopedPaths` (matches `forConversation`), cross-conversation mounts, inaccessible conversation rejection, pod mounts from `scopedPaths` when the loop conversation is not in a pod, unauthorized pod rejection, deduplication, `privateConversationUrlsByDefault` enforcement, open pod access for non-members, and restricted pod rejection.

## Risk

Low. `forAgentLoop` is a new factory — no changes to existing call sites or mount resolution logic for `forConversation` / `forPod`. The inline mount literal refactor is behaviour-preserving (same fields, same values).

## Deploy Plan

Deploy front.
