### PR TITLE
[front] chore: add nested skills feature flag

### DIFF
--- a/front/lib/models/skill/skill_reference.ts
+++ b/front/lib/models/skill/skill_reference.ts
@@ -1,7 +1,7 @@
 import { SkillConfigurationModel } from "@app/lib/models/skill";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
-import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+import type { CreationOptional, ForeignKey } from "sequelize";
 import { DataTypes } from "sequelize";
 
 export class SkillReferenceModel extends WorkspaceAwareModel<SkillReferenceModel> {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -165,6 +165,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Access to legacy Dust Apps (editor and associated tools)",
     stage: "on_demand",
   },
+  nested_skills: {
+    description: "Enable nested skills",
+    stage: "dust_only",
+  },
   power_bi_mcp: {
     description: "Power BI MCP tool for querying semantic models and DAX",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -718,6 +718,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "labs_transcripts"
   | "legacy_dust_apps"
   | "netsuite_mcp"
+  | "nested_skills"
   | "noop_model_feature"
   | "notion_private_integration"
   | "allow_old_notion_mcp"


### PR DESCRIPTION
## Description

- This PR adds a feature flag `nested_skills` in preparation for the upcoming feature of the same name.
- Doing this separately to allow working in parallel from there.
- Also fixes the lint on main.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
