### PR TITLE
chore(ci): upgrade cloudflare/wrangler-action to ebbaa158

### DIFF
--- a/.github/workflows/deploy-spa-production.yaml
+++ b/.github/workflows/deploy-spa-production.yaml
@@ -53,7 +53,7 @@ jobs:
           echo "Promoting version: ${VERSION_ID}"
 
       - name: Promote version to production
-        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/deploy-spa.yaml
+++ b/.github/workflows/deploy-spa.yaml
@@ -185,7 +185,7 @@ jobs:
 
       - name: Upload version
         id: upload_version
-        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -218,7 +218,7 @@ jobs:
       # Bleeding-edge promotion is inline (no need to wait for API rollout, unlike prod).
       - name: Promote bleeding-edge to 100%
         if: ${{ inputs.env == 'bleeding-edge' && github.ref_name == 'main' }}
-        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Description

Pin `cloudflare/wrangler-action` to commit `ebbaa1584979971c8614a24965b4405ff95890e0` (v4.0.0) across both SPA deploy workflows.

## Tests

No functional changes — CI-only pin update.

## Risk

Low. 

## Deploy Plan

No deploy steps needed.
