### PR TITLE
 Fix folder rename by adding directory support to GCS copy

### DIFF
--- a/front/lib/api/file_system/backends/gcs_file_system_backend.test.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.test.ts
@@ -460,15 +460,24 @@ describe("GCSFileSystemBackend.delete", () => {
 
 describe("GCSFileSystemBackend.copy", () => {
   let copyFileMock: ReturnType<typeof vi.fn>;
+  let existsMock: ReturnType<typeof vi.fn>;
+  let getAllFilesByPrefixMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     copyFileMock = vi.fn().mockResolvedValue(undefined);
+    // By default, the source resolves as a regular file.
+    existsMock = vi.fn().mockResolvedValue([true]);
+    getAllFilesByPrefixMock = vi
+      .fn()
+      .mockResolvedValue({ files: [], pageFetchCount: 1 });
     vi.mocked(getPrivateUploadBucket).mockReturnValue({
       copyFile: copyFileMock,
+      file: vi.fn().mockReturnValue({ exists: existsMock }),
+      getAllFilesByPrefix: getAllFilesByPrefixMock,
     } as unknown as ReturnType<typeof getPrivateUploadBucket>);
   });
 
-  it("copies from conversation to conversation with correct GCS paths", async () => {
+  it("copies a file from conversation to conversation with correct GCS paths", async () => {
     const destConvId = "conv-dest";
     await makeBackend().copy({
       src: `conversation-${CONV_ID}/report.pdf`,
@@ -481,7 +490,7 @@ describe("GCSFileSystemBackend.copy", () => {
     );
   });
 
-  it("copies from conversation to pod with correct GCS paths", async () => {
+  it("copies a file from conversation to pod with correct GCS paths", async () => {
     await makeBackend().copy({
       src: `conversation-${CONV_ID}/report.pdf`,
       dest: `pod-${POD_ID}/report.pdf`,
@@ -491,6 +500,49 @@ describe("GCSFileSystemBackend.copy", () => {
       `w/${WORKSPACE_ID}/conversations/${CONV_ID}/files/report.pdf`,
       `w/${WORKSPACE_ID}/pods/${POD_ID}/files/report.pdf`
     );
+  });
+
+  it("copies all files under a directory prefix when source is a directory", async () => {
+    existsMock.mockResolvedValue([false]); // not a direct file
+    getAllFilesByPrefixMock.mockResolvedValue({
+      files: [
+        gcsFile({
+          name: `w/${WORKSPACE_ID}/pods/${POD_ID}/files/reports/q1.pdf`,
+        }),
+        gcsFile({
+          name: `w/${WORKSPACE_ID}/pods/${POD_ID}/files/reports/q2.pdf`,
+        }),
+      ],
+      pageFetchCount: 1,
+    });
+
+    await makeBackend().copy({
+      src: `pod-${POD_ID}/reports`,
+      dest: `pod-${POD_ID}/renamed-reports`,
+    });
+
+    expect(copyFileMock).toHaveBeenCalledWith(
+      `w/${WORKSPACE_ID}/pods/${POD_ID}/files/reports/q1.pdf`,
+      `w/${WORKSPACE_ID}/pods/${POD_ID}/files/renamed-reports/q1.pdf`
+    );
+    expect(copyFileMock).toHaveBeenCalledWith(
+      `w/${WORKSPACE_ID}/pods/${POD_ID}/files/reports/q2.pdf`,
+      `w/${WORKSPACE_ID}/pods/${POD_ID}/files/renamed-reports/q2.pdf`
+    );
+  });
+
+  it("returns Err(not_found) when source is neither a file nor a directory", async () => {
+    existsMock.mockResolvedValue([false]);
+    getAllFilesByPrefixMock.mockResolvedValue({ files: [], pageFetchCount: 1 });
+
+    const result = await makeBackend().copy({
+      src: `pod-${POD_ID}/missing`,
+      dest: `pod-${POD_ID}/dest`,
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("not_found");
+    }
   });
 
   it("returns Err(invalid_path) for unrecognised source path", async () => {

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.ts
@@ -394,6 +394,37 @@ export class GCSFileSystemBackend implements FileSystemBackend {
     }
   }
 
+  /**
+   * Copy every GCS object whose name starts with `srcPrefix` to the corresponding name under
+   * `destPrefix`.  GCS has no native directory rename, so this is the only way to move a "folder".
+   */
+  private async copyDir({
+    destPrefix,
+    srcPrefix,
+  }: {
+    destPrefix: string;
+    srcPrefix: string;
+  }): Promise<Result<void, DustFileSystemError>> {
+    const bucket = getPrivateUploadBucket();
+    const { files } = await bucket.getAllFilesByPrefix({ prefix: srcPrefix });
+
+    if (files.length === 0) {
+      return new Err(
+        new DustFileSystemError(
+          "not_found",
+          `Directory not found or empty: ${srcPrefix}`
+        )
+      );
+    }
+
+    for (const file of files) {
+      const relative = file.name.slice(srcPrefix.length);
+      await bucket.copyFile(file.name, `${destPrefix}${relative}`);
+    }
+
+    return new Ok(undefined);
+  }
+
   async copy({
     src,
     dest,
@@ -422,9 +453,20 @@ export class GCSFileSystemBackend implements FileSystemBackend {
     }
 
     try {
-      await getPrivateUploadBucket().copyFile(srcGCS, destGCS);
+      const bucket = getPrivateUploadBucket();
 
-      return new Ok(undefined);
+      // Try as a regular file first.
+      const [fileExists] = await bucket.file(srcGCS).exists();
+      if (fileExists) {
+        await bucket.copyFile(srcGCS, destGCS);
+        return new Ok(undefined);
+      }
+
+      // Fall back to directory copy.
+      return this.copyDir({
+        srcPrefix: `${srcGCS}/`,
+        destPrefix: `${destGCS}/`,
+      });
     } catch (err) {
       return new Err(
         new DustFileSystemError("internal", normalizeError(err).message)


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Renaming a folder was silently failing because the copy operation only handled single GCS objects. Since GCS has no native rename primitive, a folder rename is implemented as copy-then-delete across all objects sharing the source prefix. The copy half now detects when the source path is a directory, lists every object under it, and copies each one to the destination prefix before the existing delete-by-prefix cleans up the source.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
