### PR TITLE
 Use DustFileSystem in pod manager tool and clean up deprecated file utilities

### DIFF
--- a/front/lib/api/actions/servers/files/tools/utils.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.ts
@@ -55,9 +55,12 @@ export async function resolveFile(
   } else {
     if (!isPodConversation(conversation)) {
       return new Err(
-        new MCPError("Pod file paths are only available in Pod conversations.", {
-          tracked: false,
-        })
+        new MCPError(
+          "Pod file paths are only available in Pod conversations.",
+          {
+            tracked: false,
+          }
+        )
       );
     }
     const space = await SpaceResource.fetchById(auth, conversation.spaceId);

--- a/front/lib/api/actions/servers/files/tools/utils.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.ts
@@ -1,10 +1,5 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import {
-  type GCSMountEntry,
-  type GCSMountPoint,
-  getGCSPathFromScopedPath,
-  listGCSMountFiles,
-} from "@app/lib/api/files/gcs_mount/files";
+import { getGCSPathFromScopedPath } from "@app/lib/api/files/gcs_mount/files";
 import {
   getConversationFilesBasePath,
   getPodFilesBasePath,
@@ -18,7 +13,6 @@ import { isPodConversation } from "@app/types/assistant/conversation";
 import { stripMimeParameters } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
 import type { File as GCSFile } from "@google-cloud/storage";
@@ -29,155 +23,8 @@ interface ResolvedFile {
   sizeBytes: number;
 }
 
-export interface MountPoint {
-  prefix: string;
-  scope: GCSMountPoint;
-}
-
-type Access = "read" | "write";
-
-function buildConversationMountPoint(
-  auth: Authenticator,
-  conversation: ConversationWithoutContentType
-): MountPoint {
-  const owner = auth.getNonNullableWorkspace();
-  return {
-    scope: { useCase: "conversation", conversationId: conversation.sId },
-    prefix: getConversationFilesBasePath({
-      workspaceId: owner.sId,
-      conversationId: conversation.sId,
-    }),
-  };
-}
-
-async function buildPodMountPoint(
-  auth: Authenticator,
-  conversation: ConversationWithoutContentType,
-  { access }: { access: Access }
-): Promise<Result<MountPoint, MCPError>> {
-  if (!isPodConversation(conversation)) {
-    return new Err(
-      new MCPError("Pod file paths are only available in Pod conversations.", {
-        tracked: false,
-      })
-    );
-  }
-
-  const space = await SpaceResource.fetchById(auth, conversation.spaceId);
-  if (!space) {
-    return new Err(
-      new MCPError("Pod not found for this conversation.", {
-        tracked: false,
-      })
-    );
-  }
-
-  const allowed =
-    access === "write" ? space.canWrite(auth) : space.canRead(auth);
-  if (!allowed) {
-    return new Err(
-      new MCPError(
-        access === "write"
-          ? "You do not have write permissions for this pod."
-          : "You do not have read permissions for this pod.",
-        { tracked: false }
-      )
-    );
-  }
-
-  const owner = auth.getNonNullableWorkspace();
-  return new Ok({
-    scope: { useCase: "pod", podId: space.sId },
-    prefix: getPodFilesBasePath({
-      workspaceId: owner.sId,
-      podId: space.sId,
-    }),
-  });
-}
-
 /**
- * Resolve the mount point a scoped path belongs to. Dispatches by the path's `conversation/` or
- * `pod/` prefix, looks up the parent pod space when needed, and verifies the requested
- * access level.
- *
- * @deprecated Callers should migrate to DustFileSystem. This helper remains for transitional
- * consumers (file_utils.ts, run_agent/file_paths.ts) while those are migrated.
- */
-export async function resolveMountPoint(
-  auth: Authenticator,
-  conversation: ConversationWithoutContentType,
-  { access, scopedPath }: { access: Access; scopedPath: string }
-): Promise<Result<MountPoint, MCPError>> {
-  const parsed = parseScopedFilePath(scopedPath);
-  if (!parsed) {
-    return new Err(
-      new MCPError(
-        `Invalid path: \`${scopedPath}\` must start with \`conversation/\` or \`pod/\`.`,
-        { tracked: false }
-      )
-    );
-  }
-
-  return resolveMountByUseCase(auth, conversation, {
-    useCase: parsed.prefix,
-    access,
-  });
-}
-
-/**
- * Resolve the mount point for a given scope use case, without going through a path. Used by tools
- * that operate on a whole mount (e.g. `list`).
- *
- * @deprecated Callers should migrate to DustFileSystem.
- */
-export async function resolveMountByUseCase(
-  auth: Authenticator,
-  conversation: ConversationWithoutContentType,
-  { useCase, access }: { useCase: GCSMountPoint["useCase"]; access: Access }
-): Promise<Result<MountPoint, MCPError>> {
-  switch (useCase) {
-    case "conversation":
-      return new Ok(buildConversationMountPoint(auth, conversation));
-
-    case "pod":
-      return buildPodMountPoint(auth, conversation, { access });
-
-    default:
-      assertNever(useCase);
-  }
-}
-
-/**
- * List the files mounted under a pod's GCS prefix.
- *
- * @deprecated Callers should migrate to DustFileSystem.forPod(auth, space).list().
- */
-export async function listProjectFiles(
-  auth: Authenticator,
-  space: SpaceResource
-): Promise<Result<GCSMountEntry[], MCPError>> {
-  if (!space.isProject) {
-    return new Err(new MCPError("Space is not a pod.", { tracked: false }));
-  }
-
-  if (!space.canRead(auth)) {
-    return new Err(
-      new MCPError("You do not have read permissions for this pod.", {
-        tracked: false,
-      })
-    );
-  }
-
-  const entries = await listGCSMountFiles(auth, {
-    useCase: "pod",
-    podId: space.sId,
-  });
-
-  return new Ok(entries);
-}
-
-/**
- * Resolve a GCS file from a scoped path. Looks up the file metadata via `resolveMountPoint`.
+ * Resolve a GCS file from a scoped path.
  *
  * @deprecated Callers should migrate to DustFileSystem.forConversation(auth, conversation)
  * followed by fs.stat() and fs.read().
@@ -187,19 +34,47 @@ export async function resolveFile(
   conversation: ConversationWithoutContentType,
   path: string
 ): Promise<Result<ResolvedFile, MCPError>> {
-  const mountRes = await resolveMountPoint(auth, conversation, {
-    access: "read",
-    scopedPath: path,
-  });
-  if (mountRes.isErr()) {
-    return mountRes;
+  const parsed = parseScopedFilePath(path);
+  if (!parsed) {
+    return new Err(
+      new MCPError(
+        `Invalid path: \`${path}\` must start with \`conversation/\` or \`pod/\`.`,
+        { tracked: false }
+      )
+    );
   }
 
-  const { scope, prefix } = mountRes.value;
+  const owner = auth.getNonNullableWorkspace();
+  let prefix: string;
+
+  if (parsed.prefix === "conversation") {
+    prefix = getConversationFilesBasePath({
+      workspaceId: owner.sId,
+      conversationId: conversation.sId,
+    });
+  } else {
+    if (!isPodConversation(conversation)) {
+      return new Err(
+        new MCPError("Pod file paths are only available in Pod conversations.", {
+          tracked: false,
+        })
+      );
+    }
+    const space = await SpaceResource.fetchById(auth, conversation.spaceId);
+    if (!space || !space.canRead(auth)) {
+      return new Err(
+        new MCPError("You do not have read permissions for this pod.", {
+          tracked: false,
+        })
+      );
+    }
+    prefix = getPodFilesBasePath({ workspaceId: owner.sId, podId: space.sId });
+  }
+
   const gcsPath = getGCSPathFromScopedPath({
     prefix,
     scopedPath: path,
-    useCase: scope.useCase,
+    useCase: parsed.prefix,
   });
   if (!gcsPath) {
     return new Err(

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -11,7 +11,6 @@ import {
   FILES_LIST_ACTION_NAME,
   FILES_SERVER_NAME,
 } from "@app/lib/api/actions/servers/files/metadata";
-import { DustFileSystem, SCOPED_PREFIX_POD } from "@app/lib/api/file_system";
 import { runIncludeDataRetrieval } from "@app/lib/api/actions/servers/include_data/include_function";
 import {
   buildProjectRetrieveDataSources,
@@ -32,6 +31,7 @@ import {
   getLightConversation,
 } from "@app/lib/api/assistant/conversation/fetch";
 import config from "@app/lib/api/config";
+import { DustFileSystem, SCOPED_PREFIX_POD } from "@app/lib/api/file_system";
 import {
   addContentNodeToProject,
   listProjectContextAttachments,

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -11,7 +11,7 @@ import {
   FILES_LIST_ACTION_NAME,
   FILES_SERVER_NAME,
 } from "@app/lib/api/actions/servers/files/metadata";
-import { listProjectFiles } from "@app/lib/api/actions/servers/files/tools/utils";
+import { DustFileSystem, SCOPED_PREFIX_POD } from "@app/lib/api/file_system";
 import { runIncludeDataRetrieval } from "@app/lib/api/actions/servers/include_data/include_function";
 import {
   buildProjectRetrieveDataSources,
@@ -430,13 +430,18 @@ export function createProjectManagerTools(
             dataSourceViewId: node.nodeDataSourceViewId,
           }));
 
-        const projectFilesRes = await listProjectFiles(auth, space);
-        if (projectFilesRes.isErr()) {
-          return projectFilesRes;
+        const fsResult = await DustFileSystem.forPod(auth, space);
+        if (fsResult.isErr()) {
+          return new Err(
+            new MCPError("Failed to initialise file system for this Pod.", {
+              tracked: true,
+            })
+          );
         }
-        const projectFileCount = projectFilesRes.value.filter(
-          (e) => !e.isDirectory
-        ).length;
+        const podFiles = await fsResult.value.list(
+          `${SCOPED_PREFIX_POD}${space.sId}`
+        );
+        const projectFileCount = podFiles.filter((e) => !e.isDirectory).length;
 
         // Construct project URL
         const projectPath = getPodRoute(owner.sId, space.sId);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The pod manager's project files tool was still going through a deprecated path that bypassed the unified file system abstraction. It now uses `DustFileSystem.forPod` directly, consistent with how the rest of the codebase accesses pod files.

As part of this, the deprecated helpers that bridged the old GCS mount layer and the new file system were removed. The only remaining function in that module is resolveFile, which still has callers in the agent run path and is left with its deprecation notice for a follow-up migration.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
