### PR TITLE
[front] fix: add fallback icon on skill icon suggestion error

### DIFF
--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -388,6 +388,7 @@ app.post(
           { error: iconResult.error },
           "Failed to generate icon suggestion for skill"
         );
+        icon = "ActionListIcon";
       }
     }
 

--- a/front/migrations/20260529_backfill_empty_skill_icons.sql
+++ b/front/migrations/20260529_backfill_empty_skill_icons.sql
@@ -1,0 +1,1 @@
+UPDATE skill_configurations SET icon = 'ActionListIcon' WHERE icon IS NULL;

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -389,6 +389,7 @@ async function handler(
             { error: iconResult.error },
             "Failed to generate icon suggestion for skill"
           );
+          icon = "ActionListIcon";
         }
       }
 


### PR DESCRIPTION
## Description

- This PR adds a fallback icon for skills when the LLM call to suggest one fails.
- Context [here](https://dust4ai.slack.com/archives/C0A04EWRV0E/p1780000841059429).
- Skills with an empty icon cannot be used in the input bar as they are dropped in the serialization path.
- This PR hotfixes the issue, we can consider typing strongly this requirement in a follow up PR.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
- Run backfill.