### PR TITLE
fix: missing renaming for projects and todos

### DIFF
--- a/front/components/pod/tasks/TaskSubComponents.tsx
+++ b/front/components/pod/tasks/TaskSubComponents.tsx
@@ -3,6 +3,7 @@ import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import { useUser } from "@app/lib/swr/user";
 import { timeAgoFrom } from "@app/lib/utils";
 import {
+  POD_MANAGER_AGENT_SID,
   POD_TASK_NO_ASSIGNEE_LABEL,
   type PodTaskActorType,
   type PodTaskAssigneeType,
@@ -45,7 +46,7 @@ function formatActorLabel(
   }
   switch (type) {
     case "agent":
-      if (agentId === "butler") {
+      if (agentId === POD_MANAGER_AGENT_SID || agentId === "project_manager") {
         return "Dust";
       }
       const name = agentId ? agentNameById.get(agentId) : null;
@@ -102,7 +103,7 @@ export function TaskMetadataTooltip({
     <div className="flex flex-col gap-1">
       {isAssistantWorkInProgress && (
         <div className="text-xs font-medium text-foreground dark:text-foreground-night">
-          An Agent is working on this todo.
+          An agent is working on this task.
         </div>
       )}
       <div className="text-xs">

--- a/front/lib/project_task/initial_project_tasks.ts
+++ b/front/lib/project_task/initial_project_tasks.ts
@@ -9,9 +9,6 @@ import {
   START_TASK_AGENT_TOOL_NAME,
 } from "@app/lib/api/actions/servers/pod_tasks/metadata";
 
-/** Seeded via POST /pods/:podId/tasks/seed (editors only). */
-export const PROJECT_MANAGER_AGENT_SID = "project_manager" as const;
-
 const NEXT_TASK_PROMPT = `After the user agrees to mark this task done, check what other tasks are still open in the Pod. Propose tackling the most relevant next open one to the user. If they agree, use \`${getPrefixedToolName(POD_TASKS_SERVER_NAME, START_TASK_AGENT_TOOL_NAME)}\` to kick off a conversation for it and share the conversation link in your reply.`;
 
 export const INITIAL_POD_TASKS: {

--- a/front/lib/project_task/seed_initial_pod_tasks.ts
+++ b/front/lib/project_task/seed_initial_pod_tasks.ts
@@ -1,12 +1,12 @@
 import type { Authenticator } from "@app/lib/auth";
-import {
-  INITIAL_POD_TASKS,
-  PROJECT_MANAGER_AGENT_SID,
-} from "@app/lib/project_task/initial_project_tasks";
+import { INITIAL_POD_TASKS } from "@app/lib/project_task/initial_project_tasks";
 import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
-import type { PodTaskType } from "@app/types/project_task";
+import {
+  POD_MANAGER_AGENT_SID,
+  type PodTaskType,
+} from "@app/types/project_task";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
@@ -56,7 +56,7 @@ export async function seedInitialPodTasks(
         userId: assignee.id,
         createdByType: "agent",
         createdByUserId: null,
-        createdByAgentConfigurationId: PROJECT_MANAGER_AGENT_SID,
+        createdByAgentConfigurationId: POD_MANAGER_AGENT_SID,
         markedAsDoneByType: null,
         markedAsDoneByUserId: null,
         markedAsDoneByAgentConfigurationId: null,

--- a/front/lib/project_task/start_agent.ts
+++ b/front/lib/project_task/start_agent.ts
@@ -86,7 +86,7 @@ function buildTaskKickoffPrompt({
   });
 
   return [
-    "Assist with the following project task. Repeating the full title is not necessary unless helpful for clarity.",
+    "Assist with the following Pod task. Repeating the full title is not necessary unless helpful for clarity.",
     "",
     "For tools requiring a task reference, use:",
     "",
@@ -97,14 +97,14 @@ function buildTaskKickoffPrompt({
     "## Instructions",
     "",
     "1. Clarify initial assumptions and planning; independently use available tools or context as needed.",
-    "2. Leverage project context and accessible tools to complete the task end-to-end.",
+    "2. Leverage Pod context and accessible tools to complete the task end-to-end.",
     "3. Provide a summary of actions taken and highlight anything that should be verified.",
     "",
     "## Completion Criteria",
     "",
     "After the initial delivery, avoid marking the task as done solely based on your own judgment—provide a clear summary for user review and response.",
     "",
-    'Once there is explicit acceptance in this chat (e.g. "ok good for me", "looks good", "perfect", "works for me", "thanks that\'s what I needed", or any unequivocal statement of satisfaction or task completion), mark the task as done in the same turn using the project task management tools. Verbal approval in chat is required; do not assume closure will only happen via the UI. A prompt acknowledgment is sufficient, but always mark the task as done upon clear approval.',
+    'Once there is explicit acceptance in this chat (e.g. "ok good for me", "looks good", "perfect", "works for me", "thanks that\'s what I needed", or any unequivocal statement of satisfaction or task completion), mark the task as done in the same turn using the Pod task management tools. Verbal approval in chat is required; do not assume closure will only happen via the UI. A prompt acknowledgment is sufficient, but always mark the task as done upon clear approval.',
     "",
     "If further changes are requested, if feedback indicates the work is not complete, or if the user instructs to keep the task open, do not mark it as done.",
     ...(trimmedAgentInstructions
@@ -141,7 +141,7 @@ export async function startAgentForProjectTask(
     return new Err({
       statusCode: 400,
       type: "invalid_request_error",
-      message: "Tasks are only available for project spaces.",
+      message: "Tasks are only available for Pod spaces.",
     });
   }
 

--- a/front/types/project_task.ts
+++ b/front/types/project_task.ts
@@ -67,6 +67,9 @@ export const POD_TASK_UNASSIGNED_GROUP_KEY = "__unassigned__";
 /** Header and menu copy for tasks with no assignee. */
 export const POD_TASK_NO_ASSIGNEE_LABEL = "No assignee";
 
+/** Seeded via POST /pods/:podId/tasks/seed (editors only). */
+export const POD_MANAGER_AGENT_SID = "pod_manager" as const;
+
 export type PodTaskType = {
   id: ModelId;
   sId: string;


### PR DESCRIPTION
## Description

This PR fixes missing renamings from "project" to "Pod" terminology across tasks-related files.

- Renames "project" to "Pod" in agent kickoff prompts and error messages in `start_agent.ts`
- Updates UI copy from "todo" to "task" (`"An Agent is working on this todo."` → `"An agent is working on this task."`)
- Makes sure that we display "Created by Dust" in initial tasks tooltips

## Tests

Manually.

## Risks

<!-- Discuss potential risks and how they will be mitigated. -->

## Deploy Plan

<!-- Outline the deployment steps. -->

