### PR TITLE
Update mcp files system to work outside of the current scope.

### DIFF
--- a/front/lib/api/actions/servers/files/index.ts
+++ b/front/lib/api/actions/servers/files/index.ts
@@ -2,12 +2,8 @@ import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/uti
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { FILES_SERVER_NAME } from "@app/lib/api/actions/servers/files/metadata";
-import {
-  TOOLS,
-  TOOLS_WITH_POD,
-} from "@app/lib/api/actions/servers/files/tools";
+import { TOOLS } from "@app/lib/api/actions/servers/files/tools";
 import type { Authenticator } from "@app/lib/auth";
-import { isPodConversation } from "@app/types/assistant/conversation";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 function createServer(
@@ -16,14 +12,7 @@ function createServer(
 ): McpServer {
   const server = makeInternalMCPServer(FILES_SERVER_NAME);
 
-  const conversation =
-    agentLoopContext?.runContext?.conversation ??
-    agentLoopContext?.listToolsContext?.conversation;
-  const isConversationInPod = conversation
-    ? isPodConversation(conversation)
-    : false;
-
-  for (const tool of isConversationInPod ? TOOLS_WITH_POD : TOOLS) {
+  for (const tool of TOOLS) {
     registerTool(auth, agentLoopContext, server, tool, {
       monitoringName: FILES_SERVER_NAME,
     });

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -34,31 +34,41 @@ const LIST_DESCRIPTION_PREFIX =
   "a transcript for audio, or extracted text for PDFs and other documents. " +
   `Read the sibling with \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_CAT_ACTION_NAME)}\` to access the content of binary sources.`;
 
-// `list` tool variants. The conversation-only build takes no parameter and always lists
-// conversation files. The pod-aware build accepts `scope: "conversation" | "pod"` and is
-// only registered when the conversation belongs to a pod.
-const LIST_CONVERSATION_ONLY_TOOL = {
-  description: `${LIST_DESCRIPTION_PREFIX} Lists the conversation's files.`,
-  schema: {},
-  stake: "never_ask" as const,
-  displayLabels: {
-    running: "Listing available files",
-    done: "Listed available files",
-  },
-};
+const SCOPED_PATH_HINT =
+  "Paths use `conversation-<id>/...` or `pod-<id>/...` for any conversation or Pod you can access; " +
+  "defaults target the current conversation and its Pod when applicable.";
 
-const LIST_POD_AWARE_TOOL = {
-  description:
-    `${LIST_DESCRIPTION_PREFIX} ` +
-    "Defaults to the conversation's files. Pass `scope: \"pod\"` to list the Pod's " +
-    "shared files (visible to every conversation in the same Pod) instead.",
-  schema: {
-    scope: z
-      .enum(["conversation", "pod"])
+const LIST_SCOPE_SCHEMA = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("conversation"),
+    conversation_id: z
+      .string()
       .optional()
       .describe(
-        "Which file system to list. Defaults to `conversation`. Pass `pod` to list the Pod's shared files."
+        "Conversation id to list. Defaults to the current conversation."
       ),
+  }),
+  z.object({
+    type: z.literal("pod"),
+    pod_id: z
+      .string()
+      .optional()
+      .describe(
+        "Pod id to list. Defaults to the current conversation's Pod when it has one."
+      ),
+  }),
+]);
+
+const LIST_TOOL = {
+  description:
+    `${LIST_DESCRIPTION_PREFIX} ` +
+    'Defaults to the current conversation\'s files. Omit `scope` or pass `{ type: "conversation" }`. ' +
+    'Pass `{ type: "pod" }` to list a Pod\'s shared files. ' +
+    "Optional `conversation_id` or `pod_id` on the matching variant list another accessible scope.",
+  schema: {
+    scope: LIST_SCOPE_SCHEMA.optional().describe(
+      "Which file system to list. Omit to list the current conversation."
+    ),
   },
   stake: "never_ask" as const,
   displayLabels: {
@@ -83,33 +93,10 @@ const MOVE_DESCRIPTION_BASE =
   "Move a file from one scoped path to another, removing the source after a successful transfer. " +
   "Frame files (`application/vnd.dust.frame`) must be moved rather than copied.";
 
-const COPY_CONVERSATION_ONLY_TOOL = {
-  description: COPY_DESCRIPTION_BASE,
-  schema: {
-    source: z
-      .string()
-      .describe(
-        "Scoped path of the file to copy from (e.g. `conversation-<id>/report.pdf`)."
-      ),
-    dest: z
-      .string()
-      .describe(
-        "Scoped path of the destination (e.g. `conversation-<id>/archive/report.pdf`)."
-      ),
-  },
-  stake: "never_ask" as const,
-  displayLabels: {
-    running: "Copying file",
-    done: "Copied file",
-  },
-};
-
-const COPY_POD_AWARE_TOOL = {
+const COPY_TOOL = {
   description:
-    `${COPY_DESCRIPTION_BASE} ` +
-    "Since this conversation belongs to a Pod, you can also copy between scopes, " +
-    "e.g. `conversation-<id>/report.pdf` -> `pod-<id>/report.pdf` to promote a file into the Pod, " +
-    "or `pod-<id>/spec.md` -> `conversation-<id>/spec.md` to pull it into the conversation.",
+    `${COPY_DESCRIPTION_BASE} ${SCOPED_PATH_HINT} ` +
+    "You can copy across scopes, e.g. `conversation-<id>/report.pdf` -> `pod-<id>/report.pdf` to promote a file into a Pod.",
   schema: {
     source: z
       .string()
@@ -129,34 +116,8 @@ const COPY_POD_AWARE_TOOL = {
   },
 };
 
-const MOVE_SCHEMA = {
-  source: z
-    .string()
-    .describe(
-      "Scoped path of the file to move (e.g. `conversation-<id>/report.pdf`)."
-    ),
-  dest: z
-    .string()
-    .describe(
-      "Scoped path of the destination (e.g. `conversation-<id>/archive/report.pdf`)."
-    ),
-};
-
-const MOVE_CONVERSATION_ONLY_TOOL = {
-  description: MOVE_DESCRIPTION_BASE,
-  schema: MOVE_SCHEMA,
-  stake: "never_ask" as const,
-  displayLabels: {
-    running: "Moving file",
-    done: "Moved file",
-  },
-};
-
-const MOVE_POD_AWARE_TOOL = {
-  description:
-    `${MOVE_DESCRIPTION_BASE} ` +
-    "Since this conversation belongs to a Pod, you can also move between scopes, " +
-    "e.g. `conversation-<id>/frame.html` -> `pod-<id>/frame.html` to promote a frame into the Pod.",
+const MOVE_TOOL = {
+  description: `${MOVE_DESCRIPTION_BASE} ${SCOPED_PATH_HINT}`,
   schema: {
     source: z
       .string()
@@ -265,7 +226,7 @@ const FILES_TOOLS_COMMON_METADATA = {
   },
   [FILES_CREATE_ACTION_NAME]: {
     description:
-      "Create or overwrite a file in the conversation file system. " +
+      "Create or overwrite a file in a conversation or Pod file system. " +
       "Accepts UTF-8 text content only. Binary files cannot be created via this tool. " +
       `Content is capped at ${CREATE_CONTENT_MAX_BYTES / 1024} KB. ` +
       "If the file already exists it is silently overwritten (shell \`>\` semantics). " +
@@ -291,7 +252,7 @@ const FILES_TOOLS_COMMON_METADATA = {
   },
   [FILES_DELETE_ACTION_NAME]: {
     description:
-      "Delete a file from the conversation file system. " +
+      "Delete a file from a conversation or Pod file system. " +
       "Returns an error if the file does not exist. Deletion is permanent.",
     schema: {
       path: z
@@ -309,17 +270,10 @@ const FILES_TOOLS_COMMON_METADATA = {
 };
 
 export const FILES_TOOLS_METADATA = createToolsRecord({
-  [FILES_LIST_ACTION_NAME]: LIST_CONVERSATION_ONLY_TOOL,
+  [FILES_LIST_ACTION_NAME]: LIST_TOOL,
   ...FILES_TOOLS_COMMON_METADATA,
-  [FILES_COPY_ACTION_NAME]: COPY_CONVERSATION_ONLY_TOOL,
-  [FILES_MOVE_ACTION_NAME]: MOVE_CONVERSATION_ONLY_TOOL,
-});
-
-export const FILES_TOOLS_METADATA_WITH_POD = createToolsRecord({
-  [FILES_LIST_ACTION_NAME]: LIST_POD_AWARE_TOOL,
-  ...FILES_TOOLS_COMMON_METADATA,
-  [FILES_COPY_ACTION_NAME]: COPY_POD_AWARE_TOOL,
-  [FILES_MOVE_ACTION_NAME]: MOVE_POD_AWARE_TOOL,
+  [FILES_COPY_ACTION_NAME]: COPY_TOOL,
+  [FILES_MOVE_ACTION_NAME]: MOVE_TOOL,
 });
 
 export const FILES_SERVER = {
@@ -327,13 +281,11 @@ export const FILES_SERVER = {
     name: FILES_SERVER_NAME,
     version: "1.0.0",
     description:
-      "File system interface scoped to the current conversation. " +
-      "Gives the agent visibility into all files present in the conversation: " +
-      "files uploaded by the user, files generated during execution (e.g. charts, " +
-      "exports, processed data produced by code run in the sandbox), and files produced " +
-      "as results of tool use. " +
-      "Files are identified by scoped paths such as `conversation-<id>/chart.png` that can " +
-      "be used to reference, display, or link files in agent responses. " +
+      "File system interface for the agent loop conversation and any accessible conversation or Pod. " +
+      "Defaults to the current conversation (and its Pod when applicable). " +
+      "Files include user uploads, sandbox outputs, and tool results. " +
+      "Scoped paths such as `conversation-<id>/chart.png` or `pod-<id>/spec.md` identify files " +
+      "and can be used to reference, display, or link them in responses. " +
       "Files whose name follows the `*.processed.<ext>` pattern are auto-generated " +
       "model-friendly representations of their source (resized image, audio transcript, " +
       "or text extracted from a document). Read those siblings to access the content " +

--- a/front/lib/api/actions/servers/files/tools/agent_loop_fs.ts
+++ b/front/lib/api/actions/servers/files/tools/agent_loop_fs.ts
@@ -1,0 +1,48 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+
+import { DustFileSystem } from "@app/lib/api/file_system";
+import type { Authenticator } from "@app/lib/auth";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+type AgentLoopConversationExtra = Pick<ToolHandlerExtra, "agentLoopContext">;
+
+export function requireAgentLoopConversation(
+  extra: AgentLoopConversationExtra
+): Result<ConversationWithoutContentType, MCPError> {
+  const conversation = extra.agentLoopContext?.runContext?.conversation;
+  if (!conversation) {
+    return new Err(
+      new MCPError("No conversation context available.", { tracked: false })
+    );
+  }
+
+  return new Ok(conversation);
+}
+
+/** Collects non-empty scoped paths from tool arguments for {@link DustFileSystem.forAgentLoop}. */
+export function scopedPathsFromArgs(
+  ...paths: Array<string | undefined>
+): string[] {
+  return paths.filter(
+    (path): path is string => typeof path === "string" && path.length > 0
+  );
+}
+
+export async function getDustFileSystemForAgentLoop(
+  auth: Authenticator,
+  conversation: ConversationWithoutContentType,
+  scopedPaths: string[]
+): Promise<Result<DustFileSystem, MCPError>> {
+  const fsResult = await DustFileSystem.forAgentLoop(auth, {
+    conversation,
+    scopedPaths,
+  });
+  if (fsResult.isErr()) {
+    return new Err(new MCPError(fsResult.error.message, { tracked: false }));
+  }
+
+  return new Ok(fsResult.value);
+}

--- a/front/lib/api/actions/servers/files/tools/cat.ts
+++ b/front/lib/api/actions/servers/files/tools/cat.ts
@@ -5,8 +5,12 @@ import type {
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { CAT_LINES_DEFAULT } from "@app/lib/api/actions/servers/files/metadata";
+import {
+  getDustFileSystemForAgentLoop,
+  requireAgentLoopConversation,
+  scopedPathsFromArgs,
+} from "@app/lib/api/actions/servers/files/tools/agent_loop_fs";
 import { isReadableAsText } from "@app/lib/api/actions/servers/files/tools/utils";
-import { DustFileSystem } from "@app/lib/api/file_system";
 import { isLLMVisionSupportedImageContentType } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -140,16 +144,18 @@ export async function catHandler(
   { path, offset, limit }: { path: string; offset?: number; limit?: number },
   { auth, agentLoopContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const conversation = agentLoopContext?.runContext?.conversation;
-  if (!conversation) {
-    return new Err(
-      new MCPError("No conversation context available.", { tracked: false })
-    );
+  const conversationRes = requireAgentLoopConversation({ agentLoopContext });
+  if (conversationRes.isErr()) {
+    return conversationRes;
   }
 
-  const fsResult = await DustFileSystem.forConversation(auth, conversation);
+  const fsResult = await getDustFileSystemForAgentLoop(
+    auth,
+    conversationRes.value,
+    scopedPathsFromArgs(path)
+  );
   if (fsResult.isErr()) {
-    return new Err(new MCPError(fsResult.error.message, { tracked: false }));
+    return fsResult;
   }
 
   const dustFs = fsResult.value;

--- a/front/lib/api/actions/servers/files/tools/copy.ts
+++ b/front/lib/api/actions/servers/files/tools/copy.ts
@@ -8,7 +8,11 @@ import {
   FILES_MOVE_ACTION_NAME,
   FILES_SERVER_NAME,
 } from "@app/lib/api/actions/servers/files/metadata";
-import { DustFileSystem } from "@app/lib/api/file_system";
+import {
+  getDustFileSystemForAgentLoop,
+  requireAgentLoopConversation,
+  scopedPathsFromArgs,
+} from "@app/lib/api/actions/servers/files/tools/agent_loop_fs";
 import {
   isInteractiveContentType,
   stripMimeParameters,
@@ -19,11 +23,9 @@ export async function copyHandler(
   { source, dest }: { source: string; dest: string },
   { auth, agentLoopContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const conversation = agentLoopContext?.runContext?.conversation;
-  if (!conversation) {
-    return new Err(
-      new MCPError("No conversation context available.", { tracked: false })
-    );
+  const conversationRes = requireAgentLoopConversation({ agentLoopContext });
+  if (conversationRes.isErr()) {
+    return conversationRes;
   }
 
   if (source === dest) {
@@ -34,9 +36,13 @@ export async function copyHandler(
     );
   }
 
-  const fsResult = await DustFileSystem.forConversation(auth, conversation);
+  const fsResult = await getDustFileSystemForAgentLoop(
+    auth,
+    conversationRes.value,
+    scopedPathsFromArgs(source, dest)
+  );
   if (fsResult.isErr()) {
-    return new Err(new MCPError(fsResult.error.message, { tracked: false }));
+    return fsResult;
   }
 
   const dustFs = fsResult.value;

--- a/front/lib/api/actions/servers/files/tools/create.ts
+++ b/front/lib/api/actions/servers/files/tools/create.ts
@@ -5,7 +5,11 @@ import type {
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { CREATE_CONTENT_MAX_BYTES } from "@app/lib/api/actions/servers/files/metadata";
-import { DustFileSystem } from "@app/lib/api/file_system";
+import {
+  getDustFileSystemForAgentLoop,
+  requireAgentLoopConversation,
+  scopedPathsFromArgs,
+} from "@app/lib/api/actions/servers/files/tools/agent_loop_fs";
 import { isAllSupportedFileContentType } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
@@ -18,11 +22,9 @@ export async function createHandler(
   }: { path: string; content: string; content_type: string },
   { auth, agentLoopContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const conversation = agentLoopContext?.runContext?.conversation;
-  if (!conversation) {
-    return new Err(
-      new MCPError("No conversation context available.", { tracked: false })
-    );
+  const conversationRes = requireAgentLoopConversation({ agentLoopContext });
+  if (conversationRes.isErr()) {
+    return conversationRes;
   }
 
   const contentBuffer = Buffer.from(content, "utf8");
@@ -35,9 +37,13 @@ export async function createHandler(
     );
   }
 
-  const fsResult = await DustFileSystem.forConversation(auth, conversation);
+  const fsResult = await getDustFileSystemForAgentLoop(
+    auth,
+    conversationRes.value,
+    scopedPathsFromArgs(path)
+  );
   if (fsResult.isErr()) {
-    return new Err(new MCPError(fsResult.error.message, { tracked: false }));
+    return fsResult;
   }
 
   const dustFs = fsResult.value;

--- a/front/lib/api/actions/servers/files/tools/delete.ts
+++ b/front/lib/api/actions/servers/files/tools/delete.ts
@@ -3,23 +3,29 @@ import type {
   ToolHandlerExtra,
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { DustFileSystem } from "@app/lib/api/file_system";
+import {
+  getDustFileSystemForAgentLoop,
+  requireAgentLoopConversation,
+  scopedPathsFromArgs,
+} from "@app/lib/api/actions/servers/files/tools/agent_loop_fs";
 import { Err, Ok } from "@app/types/shared/result";
 
 export async function deleteHandler(
   { path }: { path: string },
   { auth, agentLoopContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const conversation = agentLoopContext?.runContext?.conversation;
-  if (!conversation) {
-    return new Err(
-      new MCPError("No conversation context available.", { tracked: false })
-    );
+  const conversationRes = requireAgentLoopConversation({ agentLoopContext });
+  if (conversationRes.isErr()) {
+    return conversationRes;
   }
 
-  const fsResult = await DustFileSystem.forConversation(auth, conversation);
+  const fsResult = await getDustFileSystemForAgentLoop(
+    auth,
+    conversationRes.value,
+    scopedPathsFromArgs(path)
+  );
   if (fsResult.isErr()) {
-    return new Err(new MCPError(fsResult.error.message, { tracked: false }));
+    return fsResult;
   }
 
   const deleteResult = await fsResult.value.delete(path);

--- a/front/lib/api/actions/servers/files/tools/grep.ts
+++ b/front/lib/api/actions/servers/files/tools/grep.ts
@@ -9,8 +9,12 @@ import {
   FILES_SERVER_NAME,
   GREP_MATCHES_MAX,
 } from "@app/lib/api/actions/servers/files/metadata";
+import {
+  getDustFileSystemForAgentLoop,
+  requireAgentLoopConversation,
+  scopedPathsFromArgs,
+} from "@app/lib/api/actions/servers/files/tools/agent_loop_fs";
 import { isReadableAsText } from "@app/lib/api/actions/servers/files/tools/utils";
-import { DustFileSystem } from "@app/lib/api/file_system";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import * as readline from "readline";
@@ -19,16 +23,18 @@ export async function grepHandler(
   { path, pattern }: { path: string; pattern: string },
   { auth, agentLoopContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const conversation = agentLoopContext?.runContext?.conversation;
-  if (!conversation) {
-    return new Err(
-      new MCPError("No conversation context available.", { tracked: false })
-    );
+  const conversationRes = requireAgentLoopConversation({ agentLoopContext });
+  if (conversationRes.isErr()) {
+    return conversationRes;
   }
 
-  const fsResult = await DustFileSystem.forConversation(auth, conversation);
+  const fsResult = await getDustFileSystemForAgentLoop(
+    auth,
+    conversationRes.value,
+    scopedPathsFromArgs(path)
+  );
   if (fsResult.isErr()) {
-    return new Err(new MCPError(fsResult.error.message, { tracked: false }));
+    return fsResult;
   }
   const dustFs = fsResult.value;
 

--- a/front/lib/api/actions/servers/files/tools/index.ts
+++ b/front/lib/api/actions/servers/files/tools/index.ts
@@ -9,7 +9,6 @@ import {
   FILES_MOVE_ACTION_NAME,
   FILES_RESOLVE_ACTION_NAME,
   FILES_TOOLS_METADATA,
-  FILES_TOOLS_METADATA_WITH_POD,
 } from "@app/lib/api/actions/servers/files/metadata";
 import { catHandler } from "@app/lib/api/actions/servers/files/tools/cat";
 import { copyHandler } from "@app/lib/api/actions/servers/files/tools/copy";
@@ -32,8 +31,3 @@ const HANDLERS = {
 };
 
 export const TOOLS = buildTools(FILES_TOOLS_METADATA, HANDLERS);
-
-export const TOOLS_WITH_POD = buildTools(
-  FILES_TOOLS_METADATA_WITH_POD,
-  HANDLERS
-);

--- a/front/lib/api/actions/servers/files/tools/list.test.ts
+++ b/front/lib/api/actions/servers/files/tools/list.test.ts
@@ -4,10 +4,15 @@ import { listHandler } from "@app/lib/api/actions/servers/files/tools/list";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import { frameContentType, frameSlideshowContentType } from "@app/types/files";
+import type { LightWorkspaceType } from "@app/types/user";
 import assert from "assert";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -17,6 +22,36 @@ vi.mock("@app/lib/file_storage/config", () => ({
 vi.mock("@app/lib/api/config", () => ({
   default: { getApiBaseUrl: vi.fn(() => "https://dust.tt") },
 }));
+
+async function sessionAuthForUser(
+  user: UserResource,
+  workspace: LightWorkspaceType
+): Promise<Authenticator> {
+  assert(
+    user.workOSUserId,
+    "Expected user to have a WorkOS user ID for session auth"
+  );
+
+  return Authenticator.fromSession(
+    {
+      type: "workos",
+      sessionId: `test-session-${user.sId}`,
+      user: {
+        workOSUserId: user.workOSUserId,
+        email: user.email ?? "user@dust.tt",
+        email_verified: true,
+        name: user.username ?? "user",
+        nickname: user.username ?? "user",
+      },
+      authenticationMethod: "GoogleOAuth",
+      isSSO: false,
+      workspaceId: workspace.sId,
+      organizationId: workspace.workOSOrganizationId ?? undefined,
+      region: "us-central1",
+    },
+    workspace.sId
+  );
+}
 
 function makeExtra(
   auth: Authenticator,
@@ -71,6 +106,40 @@ async function setupProjectConversation(): Promise<{
   return { auth: projectAuth, conversation, projectId: space.sId };
 }
 
+async function setupProjectWithRegularConversation(): Promise<{
+  auth: Authenticator;
+  conversation: ConversationType;
+  projectId: string;
+  workspaceId: string;
+}> {
+  const { authenticator: auth, workspace } = await createResourceTest({
+    role: "admin",
+  });
+  const user = auth.getNonNullableUser();
+
+  const space = await SpaceFactory.project(workspace, user.id);
+  const addRes = await space.addMembers(auth, { userIds: [user.sId] });
+  assert(addRes.isOk(), "Failed to add user to project space");
+
+  const projectAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+
+  const conversation = await createConversation(projectAuth, {
+    title: "Regular",
+    visibility: "unlisted",
+    spaceId: null,
+  });
+
+  return {
+    auth: projectAuth,
+    conversation,
+    projectId: space.sId,
+    workspaceId: workspace.sId,
+  };
+}
+
 describe("listHandler", () => {
   let getAllFilesByPrefixMock: ReturnType<typeof vi.fn>;
 
@@ -115,7 +184,7 @@ describe("listHandler", () => {
     });
 
     const result = await listHandler(
-      { scope: "conversation" },
+      { scope: { type: "conversation" } },
       makeExtra(auth, conversation)
     );
 
@@ -132,7 +201,7 @@ describe("listHandler", () => {
     const workspaceId = auth.getNonNullableWorkspace().sId;
 
     const result = await listHandler(
-      { scope: "pod" },
+      { scope: { type: "pod" } },
       makeExtra(auth, conversation)
     );
 
@@ -206,6 +275,199 @@ describe("listHandler", () => {
     expect(text.text).not.toContain("[id:");
   });
 
+  it("lists another conversation when conversation_id is set", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+    const workspaceId = auth.getNonNullableWorkspace().sId;
+
+    const loopConversation = await createConversation(auth, {
+      title: "Loop",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+    const otherConversation = await createConversation(auth, {
+      title: "Other",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    const result = await listHandler(
+      {
+        scope: {
+          type: "conversation",
+          conversation_id: otherConversation.sId,
+        },
+      },
+      makeExtra(auth, loopConversation)
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(getAllFilesByPrefixMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prefix: `w/${workspaceId}/conversations/${otherConversation.sId}/files/`,
+      })
+    );
+  });
+
+  it("lists a pod by explicit pod_id from a non-pod conversation", async () => {
+    const { auth, conversation, projectId, workspaceId } =
+      await setupProjectWithRegularConversation();
+
+    const result = await listHandler(
+      { scope: { type: "pod", pod_id: projectId } },
+      makeExtra(auth, conversation)
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(getAllFilesByPrefixMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prefix: `w/${workspaceId}/pods/${projectId}/files/`,
+      })
+    );
+  });
+
+  it("lists a pod by explicit pod_id in a pod conversation", async () => {
+    const { auth, conversation, projectId } = await setupProjectConversation();
+    const workspaceId = auth.getNonNullableWorkspace().sId;
+
+    const result = await listHandler(
+      { scope: { type: "pod", pod_id: projectId } },
+      makeExtra(auth, conversation)
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(getAllFilesByPrefixMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prefix: `w/${workspaceId}/pods/${projectId}/files/`,
+      })
+    );
+  });
+
+  it("returns canonical pod scoped paths when listing a pod", async () => {
+    const { auth, conversation, projectId, workspaceId } =
+      await setupProjectWithRegularConversation();
+
+    const prefix = `w/${workspaceId}/pods/${projectId}/files/`;
+    getAllFilesByPrefixMock.mockResolvedValue({
+      files: [makeStorageFile(`${prefix}shared.pdf`, "application/pdf", 4096)],
+      pageFetchCount: 1,
+    });
+
+    const result = await listHandler(
+      { scope: { type: "pod", pod_id: projectId } },
+      makeExtra(auth, conversation)
+    );
+
+    assert(result.isOk());
+    const text = result.value[0];
+    assert(text.type === "text");
+    expect(text.text).toContain(`pod-${projectId}/shared.pdf`);
+  });
+
+  it("returns Err when conversation_id is not in the caller workspace", async () => {
+    const { authenticator: authA } = await createResourceTest({
+      role: "admin",
+    });
+    const { authenticator: authB } = await createResourceTest({
+      role: "admin",
+    });
+
+    const foreignConversation = await createConversation(authA, {
+      title: "Foreign",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+    const loopConversation = await createConversation(authB, {
+      title: "Loop",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    const result = await listHandler(
+      {
+        scope: {
+          type: "conversation",
+          conversation_id: foreignConversation.sId,
+        },
+      },
+      makeExtra(authB, loopConversation)
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("Conversation not found");
+    }
+    expect(getAllFilesByPrefixMock).not.toHaveBeenCalled();
+  });
+
+  it("returns Err when pod_id references a pod without read access", async () => {
+    const { workspace, user } = await createResourceTest({ role: "user" });
+    const projectSpace = await SpaceFactory.project(workspace);
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    const conversation = await createConversation(auth, {
+      title: "Test",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    const result = await listHandler(
+      { scope: { type: "pod", pod_id: projectSpace.sId } },
+      makeExtra(auth, conversation)
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("read access");
+    }
+    expect(getAllFilesByPrefixMock).not.toHaveBeenCalled();
+  });
+
+  it("returns Err when conversation_id is private to another participant", async () => {
+    const { workspace, authenticator: adminAuth } = await createResourceTest({
+      role: "admin",
+    });
+
+    const regularUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, regularUser, { role: "user" });
+
+    const updateResult = await WorkspaceResource.updateMetadata(workspace.id, {
+      privateConversationUrlsByDefault: true,
+    });
+    assert(updateResult.isOk(), "Failed to enable private conversation URLs");
+
+    const adminConversation = await createConversation(adminAuth, {
+      title: "Admin private",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    const userSessionAuth = await sessionAuthForUser(regularUser, workspace);
+    const loopConversation = await createConversation(userSessionAuth, {
+      title: "User loop",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    const result = await listHandler(
+      {
+        scope: {
+          type: "conversation",
+          conversation_id: adminConversation.sId,
+        },
+      },
+      makeExtra(userSessionAuth, loopConversation)
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("Conversation not found");
+    }
+    expect(getAllFilesByPrefixMock).not.toHaveBeenCalled();
+  });
+
   it("returns Err when scope=pod in a non-project conversation", async () => {
     const { authenticator: auth } = await createResourceTest({ role: "admin" });
 
@@ -216,13 +478,13 @@ describe("listHandler", () => {
     });
 
     const result = await listHandler(
-      { scope: "pod" },
+      { scope: { type: "pod" } },
       makeExtra(auth, conversation)
     );
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
-      expect(result.error.message).toContain("Pod conversations");
+      expect(result.error.message).toContain("pod_id");
     }
     expect(getAllFilesByPrefixMock).not.toHaveBeenCalled();
   });

--- a/front/lib/api/actions/servers/files/tools/list.ts
+++ b/front/lib/api/actions/servers/files/tools/list.ts
@@ -3,14 +3,28 @@ import type {
   ToolHandlerExtra,
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { DustFileSystem } from "@app/lib/api/file_system";
+import {
+  getDustFileSystemForAgentLoop,
+  requireAgentLoopConversation,
+  scopedPathsFromArgs,
+} from "@app/lib/api/actions/servers/files/tools/agent_loop_fs";
+import type { FileSystemMount } from "@app/lib/api/file_system/types";
+import {
+  SCOPED_PREFIX_CONVERSATION,
+  SCOPED_PREFIX_POD,
+} from "@app/lib/api/file_system/types";
 import { enrichListWithFileResourceIds } from "@app/lib/api/files/file_system_ops";
 import { parseProcessedFilename } from "@app/lib/api/files/mount_path";
+import {
+  type ConversationWithoutContentType,
+  isPodConversation,
+} from "@app/types/assistant/conversation";
 import {
   isInteractiveContentType,
   stripMimeParameters,
 } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import partition from "lodash/partition";
 
 function getDirAndFileName(path: string): { dir: string; fileName: string } {
@@ -25,53 +39,117 @@ function getDirAndFileName(path: string): { dir: string; fileName: string } {
   };
 }
 
+function findConversationMount(
+  mounts: ReadonlyArray<FileSystemMount>,
+  conversationId: string
+): FileSystemMount | undefined {
+  return mounts.find(
+    (m) => m.kind === "conversation" && m.id === conversationId
+  );
+}
+
+function findPodMount(
+  mounts: ReadonlyArray<FileSystemMount>,
+  podId: string
+): FileSystemMount | undefined {
+  return mounts.find((m) => m.kind === "pod" && m.id === podId);
+}
+
+function defaultPodIdFromMounts(
+  mounts: ReadonlyArray<FileSystemMount>,
+  conversation: ConversationWithoutContentType
+): string | undefined {
+  if (!isPodConversation(conversation)) {
+    return undefined;
+  }
+
+  const podMounts = mounts.filter((m) => m.kind === "pod");
+  if (podMounts.length === 1) {
+    return podMounts[0].id;
+  }
+
+  return podMounts[0]?.id;
+}
+
+type ListScope =
+  | { type: "conversation"; conversation_id?: string }
+  | { type: "pod"; pod_id?: string };
+
 export async function listHandler(
-  { scope }: { scope?: "conversation" | "pod" },
+  { scope }: { scope?: ListScope },
   extra: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const conversation = extra.agentLoopContext?.runContext?.conversation;
-  if (!conversation) {
-    return new Err(
-      new MCPError("No conversation context available.", { tracked: false })
-    );
+  const conversationRes = requireAgentLoopConversation(extra);
+  if (conversationRes.isErr()) {
+    return conversationRes;
   }
+  const conversation = conversationRes.value;
 
-  const fsResult = await DustFileSystem.forConversation(
+  const listScope: ListScope = scope ?? { type: "conversation" };
+  const scopedPaths = scopedPathsFromArgs(
+    listScope.type === "conversation" && listScope.conversation_id
+      ? `${SCOPED_PREFIX_CONVERSATION}${listScope.conversation_id}/`
+      : undefined,
+    listScope.type === "pod" && listScope.pod_id
+      ? `${SCOPED_PREFIX_POD}${listScope.pod_id}/`
+      : undefined
+  );
+
+  const fsResult = await getDustFileSystemForAgentLoop(
     extra.auth,
-    conversation
+    conversation,
+    scopedPaths
   );
   if (fsResult.isErr()) {
-    return new Err(new MCPError(fsResult.error.message, { tracked: false }));
+    return fsResult;
   }
   const dustFs = fsResult.value;
+  const mounts = dustFs.getMounts();
 
-  const useCase = scope ?? "conversation";
-  let scopedPrefix: string | undefined;
+  let scopedPrefix: string;
 
-  if (useCase === "conversation") {
-    const mount = dustFs.getMounts().find((m) => m.kind === "conversation");
+  switch (listScope.type) {
+    case "conversation": {
+      const conversationId = listScope.conversation_id ?? conversation.sId;
+      const mount = findConversationMount(mounts, conversationId);
+      if (!mount) {
+        return new Err(
+          new MCPError(
+            `Conversation not found or not accessible: ${conversationId}`,
+            { tracked: false }
+          )
+        );
+      }
 
-    scopedPrefix = mount ? `${mount.scopedPrefix}/` : undefined;
-  } else {
-    const mount = dustFs.getMounts().find((m) => m.kind === "pod");
-    if (!mount) {
-      return new Err(
-        new MCPError(
-          "Pod file paths are only available in Pod conversations.",
-          { tracked: false }
-        )
-      );
+      scopedPrefix = `${mount.scopedPrefix}/`;
+      break;
     }
+    case "pod": {
+      const resolvedPodId =
+        listScope.pod_id ?? defaultPodIdFromMounts(mounts, conversation);
+      if (!resolvedPodId) {
+        return new Err(
+          new MCPError(
+            'Pass `scope: { type: "pod", pod_id: "..." }` to list a Pod you can access, or run this from a Pod conversation.',
+            { tracked: false }
+          )
+        );
+      }
 
-    if (!mount.permissions.canRead) {
-      return new Err(
-        new MCPError("You do not have read permissions for this pod.", {
-          tracked: false,
-        })
-      );
+      const mount = findPodMount(mounts, resolvedPodId);
+      if (!mount) {
+        return new Err(
+          new MCPError(`Pod not found or not accessible: ${resolvedPodId}`, {
+            tracked: false,
+          })
+        );
+      }
+
+      scopedPrefix = `${mount.scopedPrefix}/`;
+      break;
     }
-
-    scopedPrefix = `${mount.scopedPrefix}/`;
+    default:
+      assertNever(listScope);
   }
 
   // Enrich, so we can expose ids for interactive content files.

--- a/front/lib/api/actions/servers/files/tools/move.ts
+++ b/front/lib/api/actions/servers/files/tools/move.ts
@@ -4,7 +4,11 @@ import type {
   ToolHandlerExtra,
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { DustFileSystem } from "@app/lib/api/file_system";
+import {
+  getDustFileSystemForAgentLoop,
+  requireAgentLoopConversation,
+  scopedPathsFromArgs,
+} from "@app/lib/api/actions/servers/files/tools/agent_loop_fs";
 import { moveCanonicalFile } from "@app/lib/api/files/file_system_ops";
 import {
   isAllSupportedFileContentType,
@@ -17,11 +21,9 @@ export async function moveHandler(
   { source, dest }: { source: string; dest: string },
   { auth, agentLoopContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const conversation = agentLoopContext?.runContext?.conversation;
-  if (!conversation) {
-    return new Err(
-      new MCPError("No conversation context available.", { tracked: false })
-    );
+  const conversationRes = requireAgentLoopConversation({ agentLoopContext });
+  if (conversationRes.isErr()) {
+    return conversationRes;
   }
 
   if (source === dest) {
@@ -32,9 +34,13 @@ export async function moveHandler(
     );
   }
 
-  const fsResult = await DustFileSystem.forConversation(auth, conversation);
+  const fsResult = await getDustFileSystemForAgentLoop(
+    auth,
+    conversationRes.value,
+    scopedPathsFromArgs(source, dest)
+  );
   if (fsResult.isErr()) {
-    return new Err(new MCPError(fsResult.error.message, { tracked: false }));
+    return fsResult;
   }
   const dustFs = fsResult.value;
 

--- a/front/lib/api/actions/servers/files/tools/resolve.ts
+++ b/front/lib/api/actions/servers/files/tools/resolve.ts
@@ -4,7 +4,11 @@ import type {
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
-  DustFileSystem,
+  getDustFileSystemForAgentLoop,
+  requireAgentLoopConversation,
+  scopedPathsFromArgs,
+} from "@app/lib/api/actions/servers/files/tools/agent_loop_fs";
+import {
   SCOPED_PREFIX_CONVERSATION,
   SCOPED_PREFIX_POD,
 } from "@app/lib/api/file_system";
@@ -49,11 +53,9 @@ export async function resolveHandler(
   { file_id }: { file_id: string },
   extra: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const conversation = extra.agentLoopContext?.runContext?.conversation;
-  if (!conversation) {
-    return new Err(
-      new MCPError("No conversation context available.", { tracked: false })
-    );
+  const conversationRes = requireAgentLoopConversation(extra);
+  if (conversationRes.isErr()) {
+    return conversationRes;
   }
 
   const file = await FileResource.fetchById(extra.auth, file_id);
@@ -83,16 +85,13 @@ export async function resolveHandler(
     );
   }
 
-  // Verify the caller actually has access to the resolved path. DustFileSystem.forConversation
-  // only mounts the pod scope when the conversation belongs to that pod and the caller has read
-  // access, so stat() implicitly enforces the same ownership + permission checks the old
-  // hand-rolled code did (conversationId match, spaceId match, space.canRead).
-  const fsResult = await DustFileSystem.forConversation(
+  const fsResult = await getDustFileSystemForAgentLoop(
     extra.auth,
-    conversation
+    conversationRes.value,
+    scopedPathsFromArgs(canonicalPath)
   );
   if (fsResult.isErr()) {
-    return new Err(new MCPError(fsResult.error.message, { tracked: false }));
+    return fsResult;
   }
   const dustFs = fsResult.value;
 

--- a/front/lib/api/actions/servers/pod_manager/metadata.ts
+++ b/front/lib/api/actions/servers/pod_manager/metadata.ts
@@ -334,7 +334,7 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
         .string()
         .optional()
         .describe(
-          "Conversation sId to post to; defaults to the conversation this agent run is in when omitted"
+          "Conversation id to post to; defaults to the conversation this agent run is in when omitted"
         ),
       message: z
         .string()

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -452,7 +452,7 @@ export function createProjectManagerTools(
               contentNodes,
               files: {
                 count: projectFileCount,
-                hint: `Use \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\` with \`scope: "pod"\` to enumerate.`,
+                hint: `Use \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\` with \`scope: { type: "pod" }\` to enumerate.`,
               },
             },
             message: "Successfully retrieved Pod information",

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -145,6 +145,25 @@ function hasMount(mounts: FileSystemMount[], scopedPrefix: string): boolean {
   return mounts.some((m) => m.scopedPrefix === scopedPrefix);
 }
 
+function assertAllMountsReadable(
+  mounts: FileSystemMount[]
+): Result<void, DustFileSystemError> {
+  for (const mount of mounts) {
+    if (!mount.permissions.canRead) {
+      return new Err(
+        new DustFileSystemError(
+          "unauthorized",
+          mount.kind === "pod"
+            ? "You do not have read access to this pod."
+            : `Read access denied for mount: ${mount.scopedPrefix}`
+        )
+      );
+    }
+  }
+
+  return new Ok(undefined);
+}
+
 // ---------------------------------------------------------------------------
 // DustFileSystem
 // ---------------------------------------------------------------------------
@@ -268,30 +287,26 @@ export class DustFileSystem {
       scopedPaths?: string[];
     }
   ): Promise<Result<DustFileSystem, DustFileSystemError>> {
-    const baseResult = await DustFileSystem.forConversation(auth, conversation);
-    if (baseResult.isErr()) {
-      return baseResult;
-    }
-
     const { conversationIds, podIds } =
       collectScopedPrefixesFromPaths(scopedPaths);
-    const mounts = [...baseResult.value.getMounts()];
 
-    const conversationIdsToFetch = [...conversationIds].filter(
-      (conversationId) =>
-        !hasMount(mounts, `${SCOPED_PREFIX_CONVERSATION}${conversationId}`)
+    const additionalConversationIds = [...conversationIds].filter(
+      (conversationId) => conversationId !== conversation.sId
     );
 
-    if (conversationIdsToFetch.length > 0) {
-      const conversations = await ConversationResource.fetchByIds(
+    const additionalConversations: ConversationWithoutContentType[] = [];
+    if (additionalConversationIds.length > 0) {
+      const fetchedConversations = await ConversationResource.fetchByIds(
         auth,
-        conversationIdsToFetch
+        additionalConversationIds
       );
-      const conversationById = new Map(conversations.map((c) => [c.sId, c]));
+      const conversationById = new Map(
+        fetchedConversations.map((c) => [c.sId, c])
+      );
 
-      for (const conversationId of conversationIdsToFetch) {
-        const conversation = conversationById.get(conversationId);
-        if (!conversation) {
+      for (const conversationId of additionalConversationIds) {
+        const fetchedConversation = conversationById.get(conversationId);
+        if (!fetchedConversation) {
           return new Err(
             new DustFileSystemError(
               "not_found",
@@ -300,13 +315,19 @@ export class DustFileSystem {
           );
         }
 
-        mounts.push(
-          createConversationMount(conversation.toJSON(), {
-            includeLegacy: false,
-          })
-        );
+        additionalConversations.push(fetchedConversation.toJSON());
       }
     }
+
+    const fsResult = await DustFileSystem.forConversations(auth, [
+      conversation,
+      ...additionalConversations,
+    ]);
+    if (fsResult.isErr()) {
+      return fsResult;
+    }
+
+    const mounts = [...fsResult.value.getMounts()];
 
     const podIdsToFetch = [...podIds].filter(
       (podId) => !hasMount(mounts, `${SCOPED_PREFIX_POD}${podId}`)
@@ -324,17 +345,17 @@ export class DustFileSystem {
           );
         }
 
-        if (!space.canRead(auth)) {
-          return new Err(
-            new DustFileSystemError(
-              "unauthorized",
-              "You do not have read access to this space."
-            )
-          );
-        }
-
         mounts.push(createPodMount(auth, space));
       }
+    }
+
+    const readableResult = assertAllMountsReadable(mounts);
+    if (readableResult.isErr()) {
+      return readableResult;
+    }
+
+    if (podIdsToFetch.length === 0) {
+      return fsResult;
     }
 
     const owner = auth.getNonNullableWorkspace();


### PR DESCRIPTION
## Description

Removes the pod-aware/non-pod-aware split in the MCP files server so all file tools can operate on any accessible conversation or Pod, not just the current one. Aligned with universal harness as the user can do it too.

Previously, `createServer` conditionally registered `TOOLS_WITH_POD` vs `TOOLS` based on `isPodConversation`. Now there's a single `TOOLS` set, and all handlers (`cat`, `copy`, `create`, `delete`, `grep`, `list`, `move`, `resolve`) switch from `DustFileSystem.forConversation` to `DustFileSystem.forAgentLoop`, which resolves mounts dynamically from the scoped paths in each call's arguments.

The `list` tool's `scope` parameter is upgraded from `"conversation" | "pod"` enum to a discriminated union with optional `conversation_id` / `pod_id` fields, letting agents target any accessible scope explicitly. A shared `agent_loop_fs.ts` helper (`requireAgentLoopConversation`, `scopedPathsFromArgs`, `getDustFileSystemForAgentLoop`) centralises the boilerplate that was duplicated across every handler.

## Tests

Updated `list.test.ts` with new integration tests: listing another conversation by `conversation_id`, listing a pod by explicit `pod_id` from a non-pod conversation, canonical path assertions, and access-control rejection cases (cross-workspace conversation, pod without read access, private conversation owned by another user).

## Risk

Low–medium. All file tool handlers change the FS factory they use (`forConversation` → `forAgentLoop`). Access enforcement moves into `DustFileSystem.forAgentLoop` (validated by the new tests). The `list` scope schema change is a breaking schema change for any agent already passing `scope: "pod"` — those calls will now fail validation until the agent adapts. Rollback is a one-line revert in `createServer` and the handler files.

## Deploy Plan

Deploy front.
