### PR TITLE
fix: order of tasks after approve all

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_tasks/bulk-actions.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_tasks/bulk-actions.ts
@@ -86,7 +86,10 @@ app.post(
 
       case "approve_agent_suggestion": {
         const user = auth.getNonNullableUser();
-        for (const sId of body.taskIds) {
+        // Approve in reverse so the first-listed task is saved last and keeps
+        // the latest `updatedAt`, preserving display order under the client's
+        // `updatedAt desc` initial sort (matches `seedInitialPodTasks`).
+        for (const sId of [...body.taskIds].reverse()) {
           const todo = await ProjectTaskResource.fetchBySId(auth, sId);
           if (
             !todo ||

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/bulk-actions.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/bulk-actions.ts
@@ -114,7 +114,10 @@ async function handler(
 
     case "approve_agent_suggestion": {
       const user = auth.getNonNullableUser();
-      for (const sId of body.taskIds) {
+      // Approve in reverse so the first-listed task is saved last and keeps
+      // the latest `updatedAt`, preserving display order under the client's
+      // `updatedAt desc` initial sort (matches `seedInitialPodTasks`).
+      for (const sId of [...body.taskIds].reverse()) {
         const todo = await ProjectTaskResource.fetchBySId(auth, sId);
         if (
           !todo ||


### PR DESCRIPTION
## Description

This PR fixes the display order of tasks after using "approve all" on agent-suggested tasks.
This is useful to make initial pod tasks appear in the correct order after clicking on accept all.

- When approving multiple tasks in bulk, tasks are now processed in reverse order so the first-listed task is saved last and retains the latest `updatedAt` timestamp, preserving the expected display order under the client's `updatedAt desc` sort.
- The fix is applied to both the `front` and `front-api` bulk-actions route handlers.

## Tests

Manually.

## Risks

<!-- Discuss potential risks and how they will be mitigated. -->

## Deploy Plan

<!-- Outline the deployment steps. -->
