### PR TITLE
Set up the global error handler in the Hono front-api server

### DIFF
--- a/front-api/server.ts
+++ b/front-api/server.ts
@@ -4,10 +4,13 @@ import { Server } from "node:http";
 import { performance } from "node:perf_hooks";
 import logger from "@app/logger/logger";
 import { isDevelopment } from "@app/types/shared/env";
+import { setupGlobalErrorHandler } from "@app/types/shared/utils/global_error_handler";
 import { serve } from "@hono/node-server";
 import { honoApp } from "./app";
 
 const KEEP_ALIVE_TIMEOUT_MS = 5000;
+
+setupGlobalErrorHandler(logger);
 
 const dev = isDevelopment();
 const port = parseInt(process.env.PORT ?? "3000", 10);


### PR DESCRIPTION
## Description

  The front-api Hono server had no process-level error handling. Uncaught exceptions and unhandled promise rejections that escaped a request's lifecycle (timers, background promises, stream callbacks) were not routed through our logger, so they never produced the panic log entries we rely on for alerting.

  This wires setupGlobalErrorHandler(logger) into front-api/server.ts, registering the process.on("uncaughtException") / process.on("unhandledRejection") handlers as the server module loads — bringing the Hono process to parity with the Temporal worker
  (front/start_worker.ts), which already does this.

  What this is not

  This is distinct from the existing per-request error handling, which stays in place:
  - honoApp.onError(unhandledErrorHandler) — request-scoped; catches errors thrown inside middleware/handlers and returns a 500 to the client.
  - server.on("error", ...) — HTTP server-level errors only (e.g. listen failures).

  Those only see errors tied to a request or the server socket. The process-level handlers added here cover everything else.

  Notes

  - setupGlobalErrorHandler is idempotent (internal once guard), so the call is safe regardless of load order.
  - The function is reused as-is from @app/types/shared/utils/global_error_handler — no new logic introduced.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
