### PR TITLE
Migrate sub-agent file copy to DustFileSystem

### DIFF
--- a/front/lib/api/actions/servers/run_agent/conversation.ts
+++ b/front/lib/api/actions/servers/run_agent/conversation.ts
@@ -1,6 +1,5 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { AgentLoopRunContextType } from "@app/lib/actions/types";
-import type { ResolvedScopedFilePath } from "@app/lib/api/actions/servers/run_agent/file_paths";
 import {
   appendFilePathsHintToQuery,
   copyConversationFilesIntoSub,
@@ -119,7 +118,7 @@ export async function getOrCreateConversation(
   // `conversation-{conversationId}/<rel>` paths are copied to the sub-conversation's mount once the sub exists.
   // A short hint is appended to the sub's first message so it knows which paths were forwarded;
   // the sub reads them through the files MCP server.
-  let resolvedFilePaths: ResolvedScopedFilePath[] = [];
+  let resolvedFilePaths: string[] = [];
   if (filePaths && filePaths.length > 0) {
     const resolvedFilePathsRes = await resolveFilePathsInParentScope(
       auth,
@@ -310,7 +309,7 @@ export async function getOrCreateConversation(
   const copyRes = await copyConversationFilesIntoSub(auth, {
     parentConversation: mainConversation,
     subConversationId: conversation.sId,
-    resolvedFilePaths,
+    filePaths: resolvedFilePaths,
   });
   if (copyRes.isErr()) {
     return copyRes;

--- a/front/lib/api/actions/servers/run_agent/file_paths.test.ts
+++ b/front/lib/api/actions/servers/run_agent/file_paths.test.ts
@@ -3,11 +3,11 @@ import {
   copyConversationFilesIntoSub,
   resolveFilePathsInParentScope,
 } from "@app/lib/api/actions/servers/run_agent/file_paths";
+import { createConversation } from "@app/lib/api/assistant/conversation";
 import {
   SCOPED_PREFIX_CONVERSATION,
   SCOPED_PREFIX_POD,
 } from "@app/lib/api/file_system";
-import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";

--- a/front/lib/api/actions/servers/run_agent/file_paths.test.ts
+++ b/front/lib/api/actions/servers/run_agent/file_paths.test.ts
@@ -3,6 +3,10 @@ import {
   copyConversationFilesIntoSub,
   resolveFilePathsInParentScope,
 } from "@app/lib/api/actions/servers/run_agent/file_paths";
+import {
+  SCOPED_PREFIX_CONVERSATION,
+  SCOPED_PREFIX_POD,
+} from "@app/lib/api/file_system";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
@@ -56,31 +60,24 @@ async function setupPlainConversation(): Promise<{
 describe("resolveFilePathsInParentScope", () => {
   it("resolves a conversation-scoped path in a plain conversation", async () => {
     const { auth, conversation } = await setupPlainConversation();
+    const path = `${SCOPED_PREFIX_CONVERSATION}${conversation.sId}/foo.md`;
 
-    const res = await resolveFilePathsInParentScope(auth, conversation, [
-      "conversation/foo.md",
-    ]);
+    const res = await resolveFilePathsInParentScope(auth, conversation, [path]);
 
     assert(res.isOk());
-    expect(res.value).toHaveLength(1);
-    expect(res.value[0].useCase).toBe("conversation");
-    expect(res.value[0].rel).toBe("foo.md");
-    expect(res.value[0].scopedPath).toBe("conversation/foo.md");
+    expect(res.value).toEqual([path]);
   });
 
   it("resolves both conversation and Pod paths in a Pod conversation", async () => {
-    const { auth, conversation } = await setupProjectConversation();
+    const { auth, conversation, projectId } = await setupProjectConversation();
 
     const res = await resolveFilePathsInParentScope(auth, conversation, [
-      "conversation/a.txt",
-      "pod/b.txt",
+      `${SCOPED_PREFIX_CONVERSATION}${conversation.sId}/a.txt`,
+      `${SCOPED_PREFIX_POD}${projectId}/b.txt`,
     ]);
 
     assert(res.isOk());
     expect(res.value).toHaveLength(2);
-    expect(res.value[0].useCase).toBe("conversation");
-    expect(res.value[1].useCase).toBe("pod");
-    expect(res.value[1].rel).toBe("b.txt");
   });
 
   it("returns Err for a path with no scope prefix", async () => {
@@ -100,28 +97,26 @@ describe("resolveFilePathsInParentScope", () => {
     const { auth, conversation } = await setupPlainConversation();
 
     const res = await resolveFilePathsInParentScope(auth, conversation, [
-      "pod/spec.md",
+      `${SCOPED_PREFIX_POD}somepodid/spec.md`,
     ]);
 
     expect(res.isErr()).toBe(true);
     if (res.isErr()) {
-      expect(res.error.message).toContain("Pod conversations");
+      expect(res.error.message).toContain("File not found");
     }
   });
 
   it("returns Err when the source file is missing", async () => {
     const { auth, conversation } = await setupPlainConversation();
 
-    // The global mock's `getMetadata` resolves successfully; override here so the file lookup
-    // fails and surfaces the missing-file error path.
     vi.mocked(getPrivateUploadBucket).mockReturnValueOnce({
       file: vi.fn(() => ({
-        getMetadata: vi.fn().mockRejectedValue(new Error("404")),
+        exists: vi.fn().mockResolvedValue([false]),
       })),
     } as unknown as ReturnType<typeof getPrivateUploadBucket>);
 
     const res = await resolveFilePathsInParentScope(auth, conversation, [
-      "conversation/missing.md",
+      `${SCOPED_PREFIX_CONVERSATION}${conversation.sId}/missing.md`,
     ]);
 
     expect(res.isErr()).toBe(true);
@@ -132,17 +127,13 @@ describe("resolveFilePathsInParentScope", () => {
 });
 
 describe("appendFilePathsHintToQuery", () => {
-  it("returns the query unchanged when no paths are resolved", () => {
+  it("returns the query unchanged when no paths are provided", () => {
     expect(appendFilePathsHintToQuery("hello", [])).toBe("hello");
   });
 
-  it("appends a one-line nudge when at least one path is resolved", () => {
+  it("appends a one-line nudge when at least one path is provided", () => {
     const result = appendFilePathsHintToQuery("hello", [
-      {
-        scopedPath: "conversation/a.md",
-        useCase: "conversation",
-        rel: "a.md",
-      },
+      "conversation-abc123/a.md",
     ]);
 
     expect(result).toBe(
@@ -153,65 +144,57 @@ describe("appendFilePathsHintToQuery", () => {
 
 describe("copyConversationFilesIntoSub", () => {
   it("is a no-op when no paths are conversation-scoped", async () => {
-    const { auth, conversation } = await setupPlainConversation();
+    const { auth, conversation, projectId } = await setupProjectConversation();
 
     const res = await copyConversationFilesIntoSub(auth, {
       parentConversation: conversation,
       subConversationId: "sub_sid",
-      resolvedFilePaths: [
-        {
-          scopedPath: "pod/spec.md",
-          useCase: "pod",
-          rel: "spec.md",
-        },
+      filePaths: [`${SCOPED_PREFIX_POD}${projectId}/spec.md`],
+    });
+
+    assert(res.isOk());
+  });
+
+  it("copies conversation-scoped files into the sub-conversation", async () => {
+    const { auth, conversation } = await setupPlainConversation();
+    const subConversation = await createConversation(auth, {
+      title: "Sub",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    const res = await copyConversationFilesIntoSub(auth, {
+      parentConversation: conversation,
+      subConversationId: subConversation.sId,
+      filePaths: [
+        `${SCOPED_PREFIX_CONVERSATION}${conversation.sId}/a.md`,
+        `${SCOPED_PREFIX_POD}somepod/skipped.md`,
       ],
     });
 
     assert(res.isOk());
   });
 
-  it("dispatches conversation-scoped paths through the GCS mount copy primitive", async () => {
+  it("returns Err when the GCS copy fails", async () => {
     const { auth, conversation } = await setupPlainConversation();
-
-    const res = await copyConversationFilesIntoSub(auth, {
-      parentConversation: conversation,
-      subConversationId: "sub_sid",
-      resolvedFilePaths: [
-        {
-          scopedPath: "conversation/a.md",
-          useCase: "conversation",
-          rel: "a.md",
-        },
-        {
-          scopedPath: "pod/skipped.md",
-          useCase: "pod",
-          rel: "skipped.md",
-        },
-      ],
+    const subConversation = await createConversation(auth, {
+      title: "Sub",
+      visibility: "unlisted",
+      spaceId: null,
     });
 
-    assert(res.isOk());
-  });
-
-  it("returns Err when the parent auth check fails on a path", async () => {
-    const { auth, conversation } = await setupPlainConversation();
-
-    // Force `resolveFile` to fail by making the source object look missing.
     vi.mocked(getPrivateUploadBucket).mockReturnValueOnce({
       file: vi.fn(() => ({
-        getMetadata: vi.fn().mockRejectedValue(new Error("404")),
+        copy: vi.fn().mockRejectedValue(new Error("GCS copy failed")),
       })),
+      copyFile: vi.fn().mockRejectedValue(new Error("GCS copy failed")),
     } as unknown as ReturnType<typeof getPrivateUploadBucket>);
 
     const res = await copyConversationFilesIntoSub(auth, {
       parentConversation: conversation,
-      subConversationId: "sub_sid",
-      resolvedFilePaths: [
-        {
-          scopedPath: "conversation/missing.md",
-          useCase: "conversation",
-          rel: "missing.md",
-        },
+      subConversationId: subConversation.sId,
+      filePaths: [
+        `${SCOPED_PREFIX_CONVERSATION}${conversation.sId}/missing.md`,
       ],
     });
 

--- a/front/lib/api/actions/servers/run_agent/file_paths.ts
+++ b/front/lib/api/actions/servers/run_agent/file_paths.ts
@@ -1,52 +1,67 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import { FILES_SERVER_NAME } from "@app/lib/api/actions/servers/files/metadata";
-import { resolveFile } from "@app/lib/api/actions/servers/files/tools/utils";
-import { copyMountFile } from "@app/lib/api/files/gcs_mount/files";
-import { parseScopedFilePath } from "@app/lib/api/files/mount_path";
+import {
+  DustFileSystem,
+  SCOPED_PREFIX_CONVERSATION,
+  SCOPED_PREFIX_POD,
+} from "@app/lib/api/file_system";
 import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
-export type ResolvedScopedFilePath = {
-  scopedPath: string;
-  useCase: "conversation" | "pod";
-  rel: string;
-};
-
+/**
+ * Validate that every path in `filePaths` is accessible in the parent conversation's scope and
+ * return the validated paths unchanged.
+ *
+ * `pod-<id>/...` paths are validated but not copied — the pod mount is shared across all
+ * conversations in a pod. `conversation-<id>/...` paths are copied into the sub-conversation by
+ * `copyConversationFilesIntoSub` once the sub-conversation exists.
+ */
 export async function resolveFilePathsInParentScope(
   auth: Authenticator,
   mainConversation: ConversationType,
   filePaths: string[]
-): Promise<Result<ResolvedScopedFilePath[], MCPError>> {
-  const resolved: ResolvedScopedFilePath[] = [];
+): Promise<Result<string[], MCPError>> {
+  const fsResult = await DustFileSystem.forConversation(auth, mainConversation);
+  if (fsResult.isErr()) {
+    return new Err(
+      new MCPError("Failed to initialize file system.", { tracked: true })
+    );
+  }
+  const fs = fsResult.value;
 
   for (const scopedPath of filePaths) {
-    const parsed = parseScopedFilePath(scopedPath);
-    if (!parsed) {
+    if (
+      !scopedPath.startsWith(SCOPED_PREFIX_CONVERSATION) &&
+      !scopedPath.startsWith(SCOPED_PREFIX_POD)
+    ) {
       return new Err(
         new MCPError(
-          `Invalid path: \`${scopedPath}\` must start with \`conversation/\` or \`pod/\`.`,
+          `Invalid path: \`${scopedPath}\` must start with \`${SCOPED_PREFIX_CONVERSATION}\` or \`${SCOPED_PREFIX_POD}\`.`,
           { tracked: false }
         )
       );
     }
 
-    // `resolveFile` resolves the mount point internally (with auth check) and confirms the
-    // object exists in GCS.
-    const fileRes = await resolveFile(auth, mainConversation, scopedPath);
-    if (fileRes.isErr()) {
-      return fileRes;
+    const statResult = await fs.stat(scopedPath);
+    if (statResult.isErr()) {
+      return new Err(
+        new MCPError(
+          `File not found: \`${scopedPath}\`. ${statResult.error.message}`,
+          { tracked: false }
+        )
+      );
     }
-
-    resolved.push({
-      scopedPath,
-      useCase: parsed.prefix,
-      rel: parsed.rel,
-    });
+    if (!statResult.value) {
+      return new Err(
+        new MCPError(`File not found: \`${scopedPath}\`.`, { tracked: false })
+      );
+    }
   }
 
-  return new Ok(resolved);
+  return new Ok(filePaths);
 }
 
 /**
@@ -55,9 +70,9 @@ export async function resolveFilePathsInParentScope(
  */
 export function appendFilePathsHintToQuery(
   query: string,
-  resolved: ResolvedScopedFilePath[]
+  filePaths: string[]
 ): string {
-  if (resolved.length === 0) {
+  if (filePaths.length === 0) {
     return query;
   }
   return `${query}\n\nSome files have been made available to you through the \`${FILES_SERVER_NAME}\` MCP server.`;
@@ -68,44 +83,49 @@ export async function copyConversationFilesIntoSub(
   {
     parentConversation,
     subConversationId,
-    resolvedFilePaths,
+    filePaths,
   }: {
     parentConversation: ConversationType;
     subConversationId: string;
-    resolvedFilePaths: ResolvedScopedFilePath[];
+    filePaths: string[];
   }
 ): Promise<Result<void, MCPError>> {
-  const conversationScoped = resolvedFilePaths.filter(
-    (p) => p.useCase === "conversation"
+  const conversationPaths = filePaths.filter((p) =>
+    p.startsWith(SCOPED_PREFIX_CONVERSATION)
   );
-  if (conversationScoped.length === 0) {
+  if (conversationPaths.length === 0) {
     return new Ok(undefined);
   }
 
-  for (const p of conversationScoped) {
-    // Re-validate auth and existence on every source.
-    const fileRes = await resolveFile(auth, parentConversation, p.scopedPath);
-    if (fileRes.isErr()) {
-      return fileRes;
-    }
+  const subConversation = await ConversationResource.fetchById(
+    auth,
+    subConversationId
+  );
+  if (!subConversation) {
+    return new Err(
+      new MCPError("Sub-conversation not found.", { tracked: true })
+    );
+  }
 
-    const copyRes = await copyMountFile(auth, {
-      source: {
-        scope: {
-          useCase: "conversation",
-          conversationId: parentConversation.sId,
-        },
-        relativeFilePath: p.rel,
-      },
-      dest: {
-        scope: { useCase: "conversation", conversationId: subConversationId },
-        relativeFilePath: p.rel,
-      },
-    });
-    if (copyRes.isErr()) {
+  const fsResult = await DustFileSystem.forConversations(auth, [
+    parentConversation,
+    subConversation.toJSON(),
+  ]);
+  if (fsResult.isErr()) {
+    return new Err(
+      new MCPError("Failed to initialize file system.", { tracked: true })
+    );
+  }
+  const fs = fsResult.value;
+
+  for (const src of conversationPaths) {
+    const rel = src.slice(src.indexOf("/") + 1);
+    const dest = `${SCOPED_PREFIX_CONVERSATION}${subConversationId}/${rel}`;
+    const copyResult = await fs.copy({ src, dest });
+    if (copyResult.isErr()) {
       return new Err(
         new MCPError(
-          `Failed to copy \`${p.scopedPath}\` into the sub-conversation: ${copyRes.error.message}`
+          `Failed to copy \`${src}\` into the sub-conversation: ${copyResult.error.message}`
         )
       );
     }

--- a/front/lib/api/actions/servers/run_agent/metadata.ts
+++ b/front/lib/api/actions/servers/run_agent/metadata.ts
@@ -1,5 +1,10 @@
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
+import {
+  FILES_LIST_ACTION_NAME,
+  FILES_SERVER_NAME,
+} from "@app/lib/api/actions/servers/files/metadata";
 import { getResourcePrefix } from "@app/lib/resources/string_ids";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
@@ -86,11 +91,11 @@ export const RUN_AGENT_TOOL_SCHEMA = {
   filePaths: z
     .array(z.string())
     .describe(
-      "Scoped file paths (e.g. `conversation/foo.md`, `pod/spec.md`) to forward to the " +
-        "sub-agent. Use when you have a scoped path from a file-listing tool or that you " +
-        "produced yourself in this conversation. `conversation/...` paths are copied into " +
-        "the sub-conversation; `pod/...` paths are passed through (the Pod file " +
-        "system is shared across the Pod's conversations). " +
+      `Scoped file paths (e.g. \`conversation-<id>/foo.md\`, \`pod-<id>/spec.md\`) to forward ` +
+        `to the sub-agent. Use paths as returned by \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\`. ` +
+        "`conversation-<id>/...` paths are copied into the sub-conversation; " +
+        "`pod-<id>/...` paths are passed through (the Pod file system is shared across " +
+        "the Pod's conversations). " +
         "For binary sources (PDFs, images, audio), also include their `*.processed.<ext>` " +
         "sibling so the sub-agent can read the model-friendly representation."
     )

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -109,21 +109,24 @@ export class DustFileSystem {
     const owner = auth.getNonNullableWorkspace();
     const mounts: FileSystemMount[] = [];
 
-    conversations.forEach((conversation, idx) => {
+    // Legacy mount points are only meaningful for sandbox use, which is always single-conversation.
+    const includeLegacy = conversations.length === 1;
+
+    for (const conversation of conversations) {
       mounts.push({
         kind: "conversation",
         id: conversation.sId,
         scopedPrefix: `${SCOPED_PREFIX_CONVERSATION}${conversation.sId}`,
         sandboxMountPoint: `/files/${SCOPED_PREFIX_CONVERSATION}${conversation.sId}`,
-        // Only the first conversation gets the legacy mount for backward-compat sandbox symlinks.
-        legacyPrefix: idx === 0 ? LEGACY_PREFIX_CONVERSATION : null,
-        legacySandboxMountPoint:
-          idx === 0 ? `/files/${LEGACY_PREFIX_CONVERSATION}` : null,
+        legacyPrefix: includeLegacy ? LEGACY_PREFIX_CONVERSATION : null,
+        legacySandboxMountPoint: includeLegacy
+          ? `/files/${LEGACY_PREFIX_CONVERSATION}`
+          : null,
         // Conversation access is always read+write when the caller holds a valid auth for it.
         // The handler is responsible for verifying conversation access before calling this factory.
         permissions: { canRead: true, canWrite: true },
       });
-    });
+    }
 
     // Collect unique pod spaces from pod conversations, preserving order.
     const seenSpaceIds = new Set<string>();

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -128,28 +128,30 @@ export class DustFileSystem {
       });
     }
 
-    // Collect unique pod spaces from pod conversations, preserving order.
-    const seenSpaceIds = new Set<string>();
-    for (const conversation of conversations.filter(isPodConversation)) {
-      if (seenSpaceIds.has(conversation.spaceId)) {
-        continue;
-      }
-      seenSpaceIds.add(conversation.spaceId);
+    // Collect unique pod space IDs, then batch-fetch to avoid N+1 queries.
+    const podConversations = conversations.filter(isPodConversation);
+    const uniqueSpaceIds = [...new Set(podConversations.map((c) => c.spaceId))];
 
-      const space = await SpaceResource.fetchById(auth, conversation.spaceId);
-      if (space) {
-        mounts.push({
-          kind: "pod",
-          id: space.sId,
-          scopedPrefix: `${SCOPED_PREFIX_POD}${space.sId}`,
-          sandboxMountPoint: `/files/${SCOPED_PREFIX_POD}${space.sId}`,
-          legacyPrefix: LEGACY_PREFIX_PROJECT,
-          legacySandboxMountPoint: `/files/${LEGACY_PREFIX_PROJECT}`,
-          permissions: {
-            canRead: space.canRead(auth),
-            canWrite: space.canWrite(auth),
-          },
-        });
+    if (uniqueSpaceIds.length > 0) {
+      const spaces = await SpaceResource.fetchByIds(auth, uniqueSpaceIds);
+      const spaceById = new Map(spaces.map((s) => [s.sId, s]));
+
+      for (const spaceId of uniqueSpaceIds) {
+        const space = spaceById.get(spaceId);
+        if (space) {
+          mounts.push({
+            kind: "pod",
+            id: space.sId,
+            scopedPrefix: `${SCOPED_PREFIX_POD}${space.sId}`,
+            sandboxMountPoint: `/files/${SCOPED_PREFIX_POD}${space.sId}`,
+            legacyPrefix: LEGACY_PREFIX_PROJECT,
+            legacySandboxMountPoint: `/files/${LEGACY_PREFIX_PROJECT}`,
+            permissions: {
+              canRead: space.canRead(auth),
+              canWrite: space.canWrite(auth),
+            },
+          });
+        }
       }
     }
 

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -6,9 +6,10 @@
  * Legacy paths (`conversation/...`, `project/...`) are accepted for backward compat.
  *
  * Factories:
- *   DustFileSystem.forConversation(auth, conversation)  conversation mount (+pod if project space)
- *   DustFileSystem.forPod(auth, space)                  pod (project-space) mount only
- *   DustFileSystem.fromScopedPath(auth, scopedPath)     infers context from the path prefix
+ *   DustFileSystem.forConversation(auth, conversation)   single conversation mount (+pod if project space)
+ *   DustFileSystem.forConversations(auth, conversations) multiple conversation mounts (+pod if project space)
+ *   DustFileSystem.forPod(auth, space)                   pod (project-space) mount only
+ *   DustFileSystem.fromScopedPath(auth, scopedPath)      infers context from the path prefix
  */
 
 import config from "@app/lib/api/config";
@@ -91,33 +92,47 @@ export class DustFileSystem {
   // --------------------------------------------------------------------------
 
   /**
-   * Build a DustFileSystem scoped to a conversation.
+   * Build a DustFileSystem scoped to one or more conversations.
    *
-   * Always includes the conversation mount. When the conversation belongs to a project space,
-   * the pod mount is added with permissions derived from the space's canRead/canWrite checks.
+   * Each conversation gets its own read+write mount. When a conversation belongs to a project
+   * space, the pod mount is added (deduplicated when multiple conversations share the same space).
+   *
+   * The first conversation in the list receives the legacy sandbox mount point for backward
+   * compatibility. Additional conversations get null legacy paths (they are only used when
+   * mounting a sandbox, which is always a single-conversation context).
    */
-  static async forConversation(
+  static async forConversations(
     auth: Authenticator,
-    // TODO(FILE SYSTEM MIGRATION): Ideally, we accept a ConversationResource directly.
-    conversation: ConversationWithoutContentType
+    // TODO(FILE SYSTEM MIGRATION): Ideally, we accept ConversationResource directly.
+    conversations: ConversationWithoutContentType[]
   ): Promise<Result<DustFileSystem, DustFileSystemError>> {
     const owner = auth.getNonNullableWorkspace();
+    const mounts: FileSystemMount[] = [];
 
-    const convMount: FileSystemMount = {
-      kind: "conversation",
-      id: conversation.sId,
-      scopedPrefix: `${SCOPED_PREFIX_CONVERSATION}${conversation.sId}`,
-      sandboxMountPoint: `/files/${SCOPED_PREFIX_CONVERSATION}${conversation.sId}`,
-      legacyPrefix: LEGACY_PREFIX_CONVERSATION,
-      legacySandboxMountPoint: `/files/${LEGACY_PREFIX_CONVERSATION}`,
-      // Conversation access is always read+write when the caller holds a valid auth for it.
-      // The handler is responsible for verifying conversation access before calling this factory.
-      permissions: { canRead: true, canWrite: true },
-    };
+    conversations.forEach((conversation, idx) => {
+      mounts.push({
+        kind: "conversation",
+        id: conversation.sId,
+        scopedPrefix: `${SCOPED_PREFIX_CONVERSATION}${conversation.sId}`,
+        sandboxMountPoint: `/files/${SCOPED_PREFIX_CONVERSATION}${conversation.sId}`,
+        // Only the first conversation gets the legacy mount for backward-compat sandbox symlinks.
+        legacyPrefix: idx === 0 ? LEGACY_PREFIX_CONVERSATION : null,
+        legacySandboxMountPoint:
+          idx === 0 ? `/files/${LEGACY_PREFIX_CONVERSATION}` : null,
+        // Conversation access is always read+write when the caller holds a valid auth for it.
+        // The handler is responsible for verifying conversation access before calling this factory.
+        permissions: { canRead: true, canWrite: true },
+      });
+    });
 
-    const mounts: FileSystemMount[] = [convMount];
+    // Collect unique pod spaces from pod conversations, preserving order.
+    const seenSpaceIds = new Set<string>();
+    for (const conversation of conversations.filter(isPodConversation)) {
+      if (seenSpaceIds.has(conversation.spaceId)) {
+        continue;
+      }
+      seenSpaceIds.add(conversation.spaceId);
 
-    if (isPodConversation(conversation)) {
       const space = await SpaceResource.fetchById(auth, conversation.spaceId);
       if (space) {
         mounts.push({
@@ -141,6 +156,19 @@ export class DustFileSystem {
     );
 
     return new Ok(new DustFileSystem(auth, mounts, backend));
+  }
+
+  /**
+   * Build a DustFileSystem scoped to a single conversation.
+   *
+   * Always includes the conversation mount. When the conversation belongs to a project space,
+   * the pod mount is added with permissions derived from the space's canRead/canWrite checks.
+   */
+  static async forConversation(
+    auth: Authenticator,
+    conversation: ConversationWithoutContentType
+  ): Promise<Result<DustFileSystem, DustFileSystemError>> {
+    return DustFileSystem.forConversations(auth, [conversation]);
   }
 
   /**


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The sub-agent file forwarding path was still using deprecated helpers that bypassed the unified file system abstraction. Validation and copying now go through `DustFileSystem`, consistent with the rest of the codebase.

To support copying across two conversations in a single operation, `forConversation` is now a thin wrapper over a new `forConversations` factory that mounts an arbitrary list of conversations. Each gets its own scoped mount, pod spaces are deduplicated, and the existing `copy()` method handles cross-conversation copies naturally since both mounts are declared on the same instance.

The intermediate type that threaded useCase and rel through the call chain was dropped entirely — both are trivially derivable from the scoped path itself, and were only ever needed as an artefact of the old copyMountFile API shape. The validated paths are now passed as plain strings. The tool description is also updated to reflect the canonical scoped path format that agents already see from files__list.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
