### PR TITLE
fix: pulse animation on first initial task

### DIFF
--- a/front/components/assistant/conversation/space/conversations/project_tasks/useProjectTasksPanelState.ts
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/useProjectTasksPanelState.ts
@@ -170,13 +170,29 @@ export function usePodTasksPanelState({
     );
   }, [assigneeScopedTasks, normalizedTaskSearchNeedle]);
 
+  // `seedInitialPodTasks` inserts INITIAL_POD_TASKS in reverse, so the largest
+  // `createdAt` among the seeded onboarding rows is the first onboarding task.
+  // Unlike `updatedAt`, `createdAt` never changes, so the pulse target stays
+  // stable as users approve/edit/complete tasks out of order.
   const getFirstOnboardingTaskId = (tasks: PodTaskType[]): string | null => {
+    let firstOnboardingTask: PodTaskType | null = null;
     for (const task of tasks) {
-      if (isOnboardingTask(task) && task.status !== "done") {
-        return task.sId;
+      if (
+        !isOnboardingTask(task) ||
+        task.status === "done" ||
+        task.agentSuggestionStatus === "pending"
+      ) {
+        continue;
+      }
+      if (
+        firstOnboardingTask === null ||
+        new Date(task.createdAt).getTime() >
+          new Date(firstOnboardingTask.createdAt).getTime()
+      ) {
+        firstOnboardingTask = task;
       }
     }
-    return null;
+    return firstOnboardingTask?.sId ?? null;
   };
   const firstOnboardingTaskId = getFirstOnboardingTaskId(filteredTasks);
 


### PR DESCRIPTION
## Description

This PR fixes the pulse animation incorrectly targeting the wrong task when displaying the first initial onboarding task.

If approving suggested initial tasks one by one, we would have the pulsing animation on the last approved task, which might not be the first one that we want the user to do.

- The previous `getFirstOnboardingTaskId` function returned the first non-done onboarding task found during iteration, which could be any task depending on order.
- Since `seedInitialPodTasks` inserts tasks in reverse, the "first" onboarding task is actually the one with the largest `createdAt` timestamp.
- Tasks with `agentSuggestionStatus === "pending"` are also now excluded from the pulse target.

## Tests

Manually.

## Risks

<!-- Discuss potential risks and how they will be mitigated. -->

## Deploy Plan

<!-- Outline the deployment steps. -->

