### PR TITLE
[front-api] add tests for programmatic-cost admin guard, restore analytics route mount

### DIFF
--- a/front-api/routes/w/[wId]/analytics/programmatic-cost.test.ts
+++ b/front-api/routes/w/[wId]/analytics/programmatic-cost.test.ts
@@ -1,0 +1,79 @@
+import { getProgrammaticCost } from "@app/lib/api/analytics/programmatic_cost";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import type { MembershipRoleType } from "@app/types/memberships";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it, vi } from "vitest";
+
+// devModeConstants reads localStorage at module load. jsdom does not always
+// have localStorage initialized when mock factories evaluate, which crashes
+// any test whose mocked lib transitively imports AuthContext. Stub it here.
+vi.mock("@app/components/dev/devModeConstants", () => ({
+  DEV_MODE_STORAGE_KEY: "dust_dev_mode",
+  DEV_MODE_ACTIVE: false,
+}));
+
+vi.mock(import("@app/lib/api/analytics/programmatic_cost"), async (orig) => {
+  const mod = await orig();
+  return {
+    ...mod,
+    getProgrammaticCost: vi.fn(),
+  };
+});
+
+async function setupTest({ role = "admin" as MembershipRoleType } = {}) {
+  const { workspace, ...rest } = await createPrivateApiMockRequest({
+    role,
+  });
+  return { workspace, ...rest };
+}
+
+function getProgrammaticCostRequest(
+  wId: string,
+  query: Record<string, string> = { billingCycleStartDay: "1" }
+) {
+  const qs = new URLSearchParams(query).toString();
+  return honoApp.request(
+    `/api/w/${wId}/analytics/programmatic-cost${qs ? `?${qs}` : ""}`
+  );
+}
+
+describe("GET /api/w/:wId/analytics/programmatic-cost", () => {
+  it("returns 403 for non-admin users", async () => {
+    const { workspace } = await setupTest({ role: "user" });
+
+    const response = await getProgrammaticCostRequest(workspace.sId);
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      error: { type: "workspace_auth_error" },
+    });
+    expect(vi.mocked(getProgrammaticCost)).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 with cost data for admin users", async () => {
+    vi.mocked(getProgrammaticCost).mockResolvedValue(
+      new Ok({ points: [], availableGroups: [] })
+    );
+    const { workspace } = await setupTest();
+
+    const response = await getProgrammaticCostRequest(workspace.sId);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      points: [],
+      availableGroups: [],
+    });
+  });
+
+  it("returns 400 when billingCycleStartDay is missing", async () => {
+    const { workspace } = await setupTest();
+
+    const response = await getProgrammaticCostRequest(workspace.sId, {});
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: { type: "invalid_request_error" },
+    });
+  });
+});

--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -17,6 +17,7 @@ import { validate } from "@front-api/middlewares/validator";
 import { workspaceAuth } from "@front-api/middlewares/workspace_auth";
 import { escape } from "html-escaper";
 import { z } from "zod";
+import analytics from "./analytics";
 import assistant from "./assistant";
 import auditLogs from "./audit-logs";
 import authContext from "./auth-context";
@@ -562,6 +563,7 @@ app.post(
 
 // Sub-apps using the catch-all default + the partial-subtree exception
 // targets declared above.
+app.route("/analytics", analytics);
 app.route("/assistant", assistant);
 app.route("/audit-logs", auditLogs);
 app.route("/billing", billing);

--- a/front/pages/api/w/[wId]/analytics/programmatic-cost.test.ts
+++ b/front/pages/api/w/[wId]/analytics/programmatic-cost.test.ts
@@ -1,0 +1,80 @@
+import { getProgrammaticCost } from "@app/lib/api/analytics/programmatic_cost";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import type { MembershipRoleType } from "@app/types/memberships";
+import { Ok } from "@app/types/shared/result";
+import { describe, expect, it, vi } from "vitest";
+
+import handler from "./programmatic-cost";
+
+// devModeConstants reads localStorage at module load. jsdom does not always
+// have localStorage initialized when mock factories evaluate, which crashes
+// any test whose mocked lib transitively imports AuthContext. Stub it here.
+vi.mock("@app/components/dev/devModeConstants", () => ({
+  DEV_MODE_STORAGE_KEY: "dust_dev_mode",
+  DEV_MODE_ACTIVE: false,
+}));
+
+vi.mock(import("@app/lib/api/analytics/programmatic_cost"), async (orig) => {
+  const mod = await orig();
+  return {
+    ...mod,
+    getProgrammaticCost: vi.fn(),
+  };
+});
+
+async function setupTest({ role = "admin" as MembershipRoleType } = {}) {
+  const { req, res, workspace, ...rest } = await createPrivateApiMockRequest({
+    role,
+    method: "GET",
+  });
+  req.query.wId = workspace.sId;
+  req.query.billingCycleStartDay = "1";
+  return { req, res, workspace, ...rest };
+}
+
+describe("GET /api/w/[wId]/analytics/programmatic-cost", () => {
+  it("returns 403 for non-admin users", async () => {
+    const { req, res } = await setupTest({ role: "user" });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData().error.type).toBe("workspace_auth_error");
+    expect(vi.mocked(getProgrammaticCost)).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 with cost data for admin users", async () => {
+    vi.mocked(getProgrammaticCost).mockResolvedValue(
+      new Ok({ points: [], availableGroups: [] })
+    );
+    const { req, res } = await setupTest();
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ points: [], availableGroups: [] });
+  });
+
+  it("returns 400 when billingCycleStartDay is missing", async () => {
+    const { req, res } = await setupTest();
+    delete req.query.billingCycleStartDay;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 405 for non-GET methods", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      role: "admin",
+      method: "POST",
+    });
+    req.query.wId = workspace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+    expect(res._getJSONData().error.type).toBe("method_not_supported_error");
+  });
+});


### PR DESCRIPTION
## Description

Follow-up to #26396 (admin guard on `GET /api/w/:wId/analytics/programmatic-cost`):

- Adds endpoint tests for both the Next handler and its Hono mirror covering
  the admin guard (403 for non-admin), the happy path (200 for admin), and
  query validation (400 when `billingCycleStartDay` is missing).
- Restores the `app.route("/analytics", analytics)` mount on the workspace
  router in `front-api/routes/w/[wId]/index.ts`. The mount was originally
  added when the analytics routes were migrated to Hono (#25731) but was
  accidentally dropped in the workspace-auth refactor (#25911), leaving
  every Hono analytics route unreachable since. The Next handlers kept
  serving traffic so nothing 500'd, but the Hono migration for analytics
  was effectively dead code.

Both test files include a `vi.mock` stub for `@app/components/dev/devModeConstants`
to dodge a localStorage read at module load that crashes the Vitest mock
factory (transitive import via `programmatic_cost.ts` → `subscription.ts` →
`AuthContext.tsx` → `devModeConstants.ts`).

## Tests

- `cd front-api && NODE_ENV=test npm test -- programmatic-cost.test` — 3/3 pass
- `cd front && NODE_ENV=test npm test -- programmatic-cost.test` — 4/4 pass

## Risk

Low for the tests. The mount restore re-enables ~20 Hono analytics routes
that have been unreachable since #25911 — production traffic for those paths
has been served by the Next handlers, which remain in place. The Hono
handlers were authored alongside the Next ones in #25731 and are pair-mirrored
under [BACK17], so behavior parity should hold; flag any divergence post-deploy.

## Deploy Plan

Standard deploy.
