### PR TITLE
Microsoft Drive tool: fix file upload

### DIFF
--- a/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
@@ -515,10 +515,25 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
         const folders = folderPath
           .split("/")
           .filter((f: string) => f.length > 0);
-        let currentPath = "";
-        let parentItemId = "root";
 
-        for (const folder of folders) {
+        // Fetch the drive root so we can strip the library name if the user
+        // included it in folderPath (e.g. "Documents partages/Sub"), which
+        // would otherwise cause a 403 when trying to create a folder named
+        // after the library root.
+        const root = await client
+          .api(`${endpoint}/root`)
+          .select("name,id")
+          .get();
+        let parentItemId: string = root.id;
+
+        const effectiveFolders =
+          root.name && folders[0]?.toLowerCase() === root.name.toLowerCase()
+            ? folders.slice(1)
+            : folders;
+
+        let currentPath = "";
+
+        for (const folder of effectiveFolders) {
           currentPath = currentPath
             ? `${currentPath}/${encodeURIComponent(folder)}`
             : encodeURIComponent(folder);
@@ -549,11 +564,30 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
                 // Update parent item ID for next iteration
                 parentItemId = createdFolder.id;
               } catch (createErr) {
-                return new Err(
-                  new MCPError(
-                    `Failed to create folder '${folder}': ${normalizeError(createErr).message}`
-                  )
-                );
+                const createError = normalizeError(createErr);
+                const alreadyExists =
+                  createError.message
+                    .toLowerCase()
+                    .includes("namealreadyexists") ||
+                  createError.message
+                    .toLowerCase()
+                    .includes("name already exists");
+
+                if (alreadyExists) {
+                  // Folder was created concurrently between our GET and POST
+                  // (or the GET error didn't match isNotFound). Fetch the
+                  // existing folder's ID and continue.
+                  const existingFolder = await client
+                    .api(`${endpoint}/root:/${currentPath}`)
+                    .get();
+                  parentItemId = existingFolder.id;
+                } else {
+                  return new Err(
+                    new MCPError(
+                      `Failed to create folder '${folder}': ${createError.message}`
+                    )
+                  );
+                }
               }
             } else {
               return new Err(
@@ -581,7 +615,14 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
         : uploadFileName;
 
       // Upload using PUT /drive/root:/{path}:/content
-      const uploadEndpoint = `${endpoint}/root:/${encodeURIComponent(uploadPath)}:/content`;
+      // Encode each path segment individually so "/" separators in nested
+      // paths are preserved (encoding the whole path would turn them into
+      // %2F and Graph would treat the result as a single flat filename).
+      const encodedUploadPath = uploadPath
+        .split("/")
+        .map(encodeURIComponent)
+        .join("/");
+      const uploadEndpoint = `${endpoint}/root:/${encodedUploadPath}:/content`;
 
       const response = await client
         .api(uploadEndpoint)


### PR DESCRIPTION
## Description

Fixes two bugs in the `microsoft_drive__upload_file` tool that caused uploads to SharePoint to fail in common scenarios:

1. **Library root name in `folderPath`**: When users passed a path starting with the drive's root library name (e.g. `"Documents partages/Sub"`), the tool tried to create a folder named after the root — triggering a 403. The fix fetches the drive root and strips the leading segment if it matches.
2. **`nameAlreadyExists` error on concurrent/existing folders**: If a folder already exists and the GET check missed it, the POST to create it returned `nameAlreadyExists`. The fix catches this error, fetches the existing folder's ID, and continues rather than failing.
3. **Wrong `encodeURIComponent` on upload path**: The full path (e.g. `FolderA/FolderB/file.pdf`) was encoded as a whole, turning `/` into `%2F` and making Graph API treat it as a single flat filename. The fix encodes each path segment individually.

## Tests

Manual testing against the failing customer conversation (SharePoint invoice classification agent). The root cause was confirmed via issue analysis.

## Risk

Low — changes are scoped to the `upload_file` handler in the Microsoft Drive MCP tool. The logic change is additive (more graceful error handling and better path encoding).

## Deploy Plan

Deploy front.