### PR TITLE
[front-api] add missing analytics route

### DIFF
--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -17,6 +17,7 @@ import { validate } from "@front-api/middlewares/validator";
 import { workspaceAuth } from "@front-api/middlewares/workspace_auth";
 import { escape } from "html-escaper";
 import { z } from "zod";
+import analytics from "./analytics";
 import assistant from "./assistant";
 import auditLogs from "./audit-logs";
 import authContext from "./auth-context";
@@ -562,6 +563,7 @@ app.post(
 
 // Sub-apps using the catch-all default + the partial-subtree exception
 // targets declared above.
+app.route("/analytics", analytics);
 app.route("/assistant", assistant);
 app.route("/audit-logs", auditLogs);
 app.route("/billing", billing);


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8418
front-api was missing the analytics route => added it

## Tests

Tested locally with  front-api => the Analytics page displays the data :)

## Risk

Low, just a missing route

## Deploy Plan

Deploy front-api ? (I don't know yet how it works)
