### PR TITLE
Opt: avoid loading all tables schemas in the context all the time with table_query_v2

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -535,6 +535,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   "query_tables_v2": {
     "execute_database_query": "never_ask",
     "get_database_schema": "never_ask",
+    "list_tables": "never_ask",
   },
   "run_agent": {
     "run_agent": "never_ask",

--- a/front/lib/api/actions/servers/query_tables_v2/metadata.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/metadata.ts
@@ -1,4 +1,7 @@
-import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import {
+  ConfigurableToolInputSchemas,
+  TABLE_CONFIGURATION_URI_PATTERN,
+} from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
@@ -7,16 +10,48 @@ import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const TABLE_QUERY_V2_SERVER_NAME = "query_tables_v2" as const; // Do not change the name until we fixed the extension
+export const LIST_TABLES_TOOL_NAME = "list_tables";
 export const GET_DATABASE_SCHEMA_TOOL_NAME = "get_database_schema";
 export const EXECUTE_DATABASE_QUERY_TOOL_NAME = "execute_database_query";
 
+const tableUriSchema = z
+  .string()
+  .regex(TABLE_CONFIGURATION_URI_PATTERN)
+  .describe(
+    "A table URI in the format returned by list_tables, e.g. " +
+      "'table_configuration://dust/w/{workspaceId}/data_source_views/{viewId}/tables/{tableId}'."
+  );
+
+const tableUrisSchema = z
+  .array(tableUriSchema)
+  .min(1)
+  .describe(
+    "Table URIs to retrieve schema for. Use URIs returned by list_tables."
+  );
+
 export const QUERY_TABLES_V2_TOOLS_METADATA = createToolsRecord({
-  [GET_DATABASE_SCHEMA_TOOL_NAME]: {
+  [LIST_TABLES_TOOL_NAME]: {
     description:
-      "Retrieves the database schema. You MUST call this tool at least once before attempting to query tables to understand their structure. This tool provides essential information about table columns, types, and relationships needed to write accurate SQL queries.",
+      "List all tables available to this agent. Returns lightweight table metadata and URIs. " +
+      "Call this first to discover tables, then pass selected URIs to get_database_schema.",
     schema: {
       tables:
         ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE],
+    },
+    stake: "never_ask",
+    enableAlerting: true,
+    displayLabels: {
+      running: "Listing available tables",
+      done: "List available tables",
+    },
+  },
+  [GET_DATABASE_SCHEMA_TOOL_NAME]: {
+    description:
+      "Retrieves the database schema for a subset of tables. You MUST call list_tables first to discover " +
+      "available tables, then call this tool with the URIs of the tables you need before attempting to query. " +
+      "This tool provides essential information about table columns, types, and relationships needed to write accurate SQL queries.",
+    schema: {
+      tableUris: tableUrisSchema,
     },
     stake: "never_ask",
     enableAlerting: true,
@@ -27,7 +62,9 @@ export const QUERY_TABLES_V2_TOOLS_METADATA = createToolsRecord({
   },
   [EXECUTE_DATABASE_QUERY_TOOL_NAME]: {
     description:
-      "Executes a query on the database. You MUST call the get_database_schema tool for that database at least once before attempting to execute a query. The query must respect the guidelines and schema provided by the get_database_schema tool.",
+      "Executes a query on the database. You MUST call get_database_schema for the tables involved in your query " +
+      "at least once before attempting to execute a query. The query must respect the guidelines and schema " +
+      "provided by the get_database_schema tool.",
     schema: {
       tables:
         ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE],
@@ -60,7 +97,8 @@ export const QUERY_TABLES_V2_SERVER = {
     name: TABLE_QUERY_V2_SERVER_NAME,
     version: "1.0.0",
     description:
-      "Query structured data like a spreadsheet or database for data analyses.",
+      "Query structured data like a spreadsheet or database. Use list_tables to discover available tables, " +
+      "get_database_schema for the tables you need, then execute_database_query to run SQL analyses.",
     icon: "ActionTableIcon",
     authorization: null,
     documentationUrl: null,

--- a/front/lib/api/actions/servers/query_tables_v2/tools/index.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/tools/index.ts
@@ -1,4 +1,5 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { TablesConfigurationToolType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { GET_DATABASE_SCHEMA_MARKER } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
@@ -10,6 +11,7 @@ import {
 import {
   EXECUTE_DATABASE_QUERY_TOOL_NAME,
   GET_DATABASE_SCHEMA_TOOL_NAME,
+  LIST_TABLES_TOOL_NAME,
   QUERY_TABLES_V2_TOOLS_METADATA,
 } from "@app/lib/api/actions/servers/query_tables_v2/metadata";
 import {
@@ -18,27 +20,71 @@ import {
   getSchemaContent,
 } from "@app/lib/api/actions/servers/tables_query/schema";
 import config from "@app/lib/api/config";
+import type { Authenticator } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { CoreAPI } from "@app/types/core/core_api";
 import { Err, Ok } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
-const handlers: ToolHandlers<typeof QUERY_TABLES_V2_TOOLS_METADATA> = {
-  [GET_DATABASE_SCHEMA_TOOL_NAME]: async ({ tables }, { auth }) => {
-    // Fetch table configurations
-    const tableConfigurationsRes = await fetchTableDataSourceConfigurations(
-      auth,
-      tables
+function tablesFromUris(tableUris: string[]): TablesConfigurationToolType {
+  return tableUris.map((uri) => ({
+    uri,
+    mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE,
+  }));
+}
+
+async function resolveTableConfigurations(
+  auth: Authenticator,
+  tables: TablesConfigurationToolType
+) {
+  const tableConfigurationsRes = await fetchTableDataSourceConfigurations(
+    auth,
+    tables
+  );
+  if (tableConfigurationsRes.isErr()) {
+    return new Err(
+      new MCPError(
+        `Error fetching table configurations: ${tableConfigurationsRes.error.message}`
+      )
     );
-    if (tableConfigurationsRes.isErr()) {
-      return new Err(
-        new MCPError(
-          `Error fetching table configurations: ${tableConfigurationsRes.error.message}`
-        )
-      );
+  }
+
+  const tableConfigurations = tableConfigurationsRes.value;
+  if (tableConfigurations.length === 0) {
+    return new Ok({
+      tableConfigurations: [],
+      dataSourceViewsMap: new Map<
+        string,
+        Awaited<ReturnType<typeof DataSourceViewResource.fetchByIds>>[number]
+      >(),
+    });
+  }
+
+  const dataSourceViews = await DataSourceViewResource.fetchByIds(auth, [
+    ...new Set(tableConfigurations.map((t) => t.dataSourceViewId)),
+  ]);
+
+  const accessError = verifyDataSourceViewReadAccess(auth, dataSourceViews);
+  if (accessError) {
+    return new Err(accessError);
+  }
+
+  return new Ok({
+    tableConfigurations,
+    dataSourceViewsMap: new Map(dataSourceViews.map((dsv) => [dsv.sId, dsv])),
+  });
+}
+
+const handlers: ToolHandlers<typeof QUERY_TABLES_V2_TOOLS_METADATA> = {
+  [LIST_TABLES_TOOL_NAME]: async ({ tables }, { auth }) => {
+    const resolvedRes = await resolveTableConfigurations(auth, tables);
+    if (resolvedRes.isErr()) {
+      return resolvedRes;
     }
-    const tableConfigurations = tableConfigurationsRes.value;
+
+    const { tableConfigurations, dataSourceViewsMap } = resolvedRes.value;
     if (tableConfigurations.length === 0) {
       return new Ok([
         {
@@ -47,19 +93,76 @@ const handlers: ToolHandlers<typeof QUERY_TABLES_V2_TOOLS_METADATA> = {
         },
       ]);
     }
-    const dataSourceViews = await DataSourceViewResource.fetchByIds(auth, [
-      ...new Set(tableConfigurations.map((t) => t.dataSourceViewId)),
-    ]);
 
-    // Security check: Verify user has canRead access to all data source views
-    const accessError = verifyDataSourceViewReadAccess(auth, dataSourceViews);
-    if (accessError) {
-      return new Err(accessError);
+    const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+    const listedTables = await concurrentExecutor(
+      tables.map((tableInput, index) => ({
+        uri: tableInput.uri,
+        tableConfiguration: tableConfigurations[index],
+      })),
+      async ({ uri, tableConfiguration }) => {
+        const dataSourceView = dataSourceViewsMap.get(
+          tableConfiguration.dataSourceViewId
+        );
+        if (!dataSourceView || !dataSourceView.dataSource.dustAPIDataSourceId) {
+          return {
+            uri,
+            tableId: tableConfiguration.tableId,
+            error: "Table configuration is outdated or inaccessible.",
+          };
+        }
+
+        const tableResult = await coreAPI.getTable({
+          projectId: dataSourceView.dataSource.dustAPIProjectId,
+          dataSourceId: dataSourceView.dataSource.dustAPIDataSourceId,
+          tableId: tableConfiguration.tableId,
+          viewFilter: dataSourceView.toViewFilter(),
+        });
+
+        if (tableResult.isErr()) {
+          return {
+            uri,
+            tableId: tableConfiguration.tableId,
+            error: tableResult.error.message,
+          };
+        }
+
+        const { table } = tableResult.value;
+        return {
+          uri,
+          tableId: table.table_id,
+          name: table.name,
+          title: table.title,
+          description: table.description,
+        };
+      },
+      { concurrency: 10 }
+    );
+
+    return new Ok([
+      {
+        type: "text",
+        text: JSON.stringify({ tables: listedTables }, null, 2),
+      },
+    ]);
+  },
+
+  [GET_DATABASE_SCHEMA_TOOL_NAME]: async ({ tableUris }, { auth }) => {
+    const tables = tablesFromUris(tableUris);
+    const resolvedRes = await resolveTableConfigurations(auth, tables);
+    if (resolvedRes.isErr()) {
+      return resolvedRes;
     }
 
-    const dataSourceViewsMap = new Map(
-      dataSourceViews.map((dsv) => [dsv.sId, dsv])
-    );
+    const { tableConfigurations, dataSourceViewsMap } = resolvedRes.value;
+    if (tableConfigurations.length === 0) {
+      return new Ok([
+        {
+          type: "text",
+          text: "The agent does not have access to any tables. Please edit the agent's Query Tables tool to add tables, or remove the tool.",
+        },
+      ]);
+    }
 
     // Build table list, filtering out invalid configurations
     const validTables: Array<{
@@ -142,19 +245,12 @@ const handlers: ToolHandlers<typeof QUERY_TABLES_V2_TOOLS_METADATA> = {
 
     const agentLoopRunContext = agentLoopContext.runContext;
 
-    // Fetch table configurations
-    const tableConfigurationsRes = await fetchTableDataSourceConfigurations(
-      auth,
-      tables
-    );
-    if (tableConfigurationsRes.isErr()) {
-      return new Err(
-        new MCPError(
-          `Error fetching table configurations: ${tableConfigurationsRes.error.message}`
-        )
-      );
+    const resolvedRes = await resolveTableConfigurations(auth, tables);
+    if (resolvedRes.isErr()) {
+      return resolvedRes;
     }
-    const tableConfigurations = tableConfigurationsRes.value;
+
+    const { tableConfigurations, dataSourceViewsMap } = resolvedRes.value;
     if (tableConfigurations.length === 0) {
       return new Err(
         new MCPError(
@@ -163,19 +259,7 @@ const handlers: ToolHandlers<typeof QUERY_TABLES_V2_TOOLS_METADATA> = {
         )
       );
     }
-    const dataSourceViews = await DataSourceViewResource.fetchByIds(auth, [
-      ...new Set(tableConfigurations.map((t) => t.dataSourceViewId)),
-    ]);
 
-    // Security check: Verify user has canRead access to all data source views
-    const accessError = verifyDataSourceViewReadAccess(auth, dataSourceViews);
-    if (accessError) {
-      return new Err(accessError);
-    }
-
-    const dataSourceViewsMap = new Map(
-      dataSourceViews.map((dsv) => [dsv.sId, dsv])
-    );
     const dataSourceView = await DataSourceViewResource.fetchById(
       auth,
       tableConfigurations[0].dataSourceViewId


### PR DESCRIPTION
## Description

Splits the `query_tables_v2` MCP server's `get_database_schema` tool into a two-step flow to avoid loading all table schemas into the agent context on every run.

- New `list_tables` tool: returns lightweight metadata (name, title, description, URI) for all configured tables via `coreAPI.getTable` with concurrency 10. Agents call this first to discover tables.
- `get_database_schema` now accepts `tableUris: string[]` instead of the full `tables` config, fetching schema only for the tables the agent selects. This is a **breaking input schema change** — existing agents using `get_database_schema` will read the updated tool definition at the start of each new agent loop and adapt automatically.
- `resolveTableConfigurations` extracted as a shared helper eliminating duplicated fetch + access-check logic across all three tool handlers.

## Tests

Tested locally. Updated `mcp_servers_metadata.test.ts.snap` to include `list_tables: "never_ask"`.

## Risk

Medium. `get_database_schema`'s input schema changes from `tables` (full config) to `tableUris` (URI strings) — agents re-read tool definitions each loop so new conversations adapt immediately, but any in-flight agent loop mid-query-tables flow could fail on the schema mismatch. The new `list_tables` tool is additive and safe.

## Deploy Plan

Deploy front.
