### PR TITLE
Fix attachment path format to use canonical scoped paths

### DIFF
--- a/front/lib/resources/content_fragment_resource.test.ts
+++ b/front/lib/resources/content_fragment_resource.test.ts
@@ -193,7 +193,7 @@ describe("renderLightContentFragmentForModel", () => {
   });
 
   describe("useFileSystem: true", () => {
-    it("renders a regular file as <file> without snippet", async () => {
+    it("renders a regular file as <file> without snippet and without path when path is null", async () => {
       const result = await renderLightContentFragmentForModel(
         authenticator,
         makeFileFragment("application/pdf"),
@@ -202,11 +202,11 @@ describe("renderLightContentFragmentForModel", () => {
       );
       expect(result?.content[0]).toMatchObject({
         type: "text",
-        text: `<file name="file" path="conversation/file"/>`,
+        text: `<file name="file"/>`,
       });
     });
 
-    it("renders a regular file as <file> with snippet", async () => {
+    it("renders a regular file as <file> with snippet and without path when path is null", async () => {
       const result = await renderLightContentFragmentForModel(
         authenticator,
         makeFileFragment("text/plain", { snippet: "First 256 chars..." }),
@@ -215,15 +215,15 @@ describe("renderLightContentFragmentForModel", () => {
       );
       expect(result?.content[0]).toMatchObject({
         type: "text",
-        text: `<file name="file" path="conversation/file">First 256 chars...\n</file>`,
+        text: `<file name="file">First 256 chars...\n</file>`,
       });
     });
 
-    it("renders a slim file reference using the mount path when available", async () => {
+    it("renders a slim file reference using the canonical scoped path when available", async () => {
       const result = await renderLightContentFragmentForModel(
         authenticator,
         makeFileFragment("application/pdf", {
-          path: "conversation/report_fil_abc123.pdf",
+          path: "conversation-conv123/report_fil_abc123.pdf",
         }),
         visionModel,
         { excludeImages: false, useFileSystem: true }
@@ -231,7 +231,7 @@ describe("renderLightContentFragmentForModel", () => {
       expect(result).not.toBeNull();
       expect(result?.content[0]).toMatchObject({
         type: "text",
-        text: `<file name="file" path="conversation/report_fil_abc123.pdf"/>`,
+        text: `<file name="file" path="conversation-conv123/report_fil_abc123.pdf"/>`,
       });
     });
 
@@ -277,12 +277,16 @@ describe("renderLightContentFragmentForModel", () => {
     it("renders an image with excludeImages as <file> with description", async () => {
       const result = await renderLightContentFragmentForModel(
         authenticator,
-        makeFileFragment("image/png"),
+        makeFileFragment("image/png", {
+          path: "conversation-conv123/image.png",
+        }),
         visionModel,
         { excludeImages: true, useFileSystem: true }
       );
       const text = (result?.content[0] as { text: string }).text;
-      expect(text).toContain(`<file name="file" path="conversation/file">`);
+      expect(text).toContain(
+        `<file name="file" path="conversation-conv123/image.png">`
+      );
       expect(text).toContain(
         "Image content interpreted by a vision-enabled model"
       );
@@ -291,12 +295,16 @@ describe("renderLightContentFragmentForModel", () => {
     it("renders an image with non-vision model as <file> with description", async () => {
       const result = await renderLightContentFragmentForModel(
         authenticator,
-        makeFileFragment("image/png"),
+        makeFileFragment("image/png", {
+          path: "conversation-conv123/image.png",
+        }),
         nonVisionModel,
         { excludeImages: false, useFileSystem: true }
       );
       const text = (result?.content[0] as { text: string }).text;
-      expect(text).toContain(`<file name="file" path="conversation/file">`);
+      expect(text).toContain(
+        `<file name="file" path="conversation-conv123/image.png">`
+      );
       expect(text).toContain(
         "Image content interpreted by a vision-enabled model"
       );
@@ -305,7 +313,9 @@ describe("renderLightContentFragmentForModel", () => {
     it("renders an image with vision model as image_url + <file> tag", async () => {
       const result = await renderLightContentFragmentForModel(
         authenticator,
-        makeFileFragment("image/png"),
+        makeFileFragment("image/png", {
+          path: "conversation-conv123/image.png",
+        }),
         visionModel,
         { excludeImages: false, useFileSystem: true }
       );
@@ -313,7 +323,7 @@ describe("renderLightContentFragmentForModel", () => {
       expect(result?.content[0]).toMatchObject({ type: "image_url" });
       expect(result?.content[1]).toMatchObject({
         type: "text",
-        text: `<file name="file" path="conversation/file"/>`,
+        text: `<file name="file" path="conversation-conv123/image.png"/>`,
       });
     });
   });

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -10,8 +10,8 @@ import {
 } from "@app/lib/api/assistant/conversation/attachments";
 import appConfig from "@app/lib/api/config";
 import config from "@app/lib/api/config";
-import { getScopedPathFromGCSPath } from "@app/lib/api/files/gcs_mount/files";
 import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
+import { SCOPED_PREFIX_CONVERSATION } from "@app/lib/api/file_system";
 import {
   PASTED_CONTENT_MAX_CHARACTERS,
   TRUNCATED_SNIPPET_SIZE,
@@ -94,11 +94,13 @@ function getConversationFilePath({
     return null;
   }
 
-  return getScopedPathFromGCSPath({
-    prefix: getConversationFilesBasePath({ workspaceId, conversationId }),
-    gcsPath: mountFilePath,
-    useCase: "conversation",
-  });
+  const prefix = getConversationFilesBasePath({ workspaceId, conversationId });
+  if (!mountFilePath.startsWith(prefix)) {
+    return null;
+  }
+
+  const rel = mountFilePath.slice(prefix.length);
+  return `${SCOPED_PREFIX_CONVERSATION}${conversationId}/${rel}`;
 }
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
@@ -1048,7 +1050,6 @@ export async function getContentFragmentFromAttachmentFile(
 ): Promise<Result<ContentFragmentMessageTypeModel, Error>> {
   // At time of writing, passed resourceId can be either a file or a content fragment.
   // TODO(durable agents): check if this is actually true (seems false)
-
   const { resourceName } = getResourceNameAndIdFromSId(
     conversationAttachmentId(attachment)
   ) ?? {
@@ -1175,11 +1176,10 @@ export async function getContentFragmentFromAttachmentFile(
               content: truncatedContent,
               truncated,
               // Show path only when truncated so the model can read the full file.
-              path: truncated
-                ? ((isFileAttachmentType(attachment)
-                    ? attachment.path
-                    : null) ?? `conversation/${attachment.title}`)
-                : undefined,
+              path:
+                truncated && isFileAttachmentType(attachment)
+                  ? (attachment.path ?? undefined)
+                  : undefined,
             }),
           },
         ],
@@ -1217,20 +1217,11 @@ function renderFileOrAttachmentXml(
   }
 ): string {
   if (isNewFileExplorer) {
-    const explicitPath = "path" in attachment ? attachment.path : null;
-    const path = explicitPath ?? `conversation/${attachment.title}`;
-    if (!explicitPath) {
-      logger.warn(
-        {
-          fileId: "fileId" in attachment ? attachment.fileId : null,
-          title: attachment.title,
-        },
-        "Falling back to file title for new file explorer path."
-      );
-    }
+    const path = "path" in attachment ? attachment.path : null;
+    const pathAttr = path ? ` path="${path}"` : "";
     return content
-      ? `<file name="${attachment.title}" path="${path}">${content}\n</file>`
-      : `<file name="${attachment.title}" path="${path}"/>`;
+      ? `<file name="${attachment.title}"${pathAttr}>${content}\n</file>`
+      : `<file name="${attachment.title}"${pathAttr}/>`;
   }
 
   return renderAttachmentXml({ attachment, content: content ?? null });
@@ -1293,10 +1284,10 @@ export async function renderLightContentFragmentForModel(
             content: snippet,
             truncated,
             // Show path only when truncated so the model can read the full file.
-            path: truncated
-              ? ((isFileAttachmentType(attachment) ? attachment.path : null) ??
-                `conversation/${attachment.title}`)
-              : undefined,
+            path:
+              truncated && isFileAttachmentType(attachment)
+                ? (attachment.path ?? undefined)
+                : undefined,
           }),
         },
       ],

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -10,8 +10,8 @@ import {
 } from "@app/lib/api/assistant/conversation/attachments";
 import appConfig from "@app/lib/api/config";
 import config from "@app/lib/api/config";
-import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
 import { SCOPED_PREFIX_CONVERSATION } from "@app/lib/api/file_system";
+import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
 import {
   PASTED_CONTENT_MAX_CHARACTERS,
   TRUNCATED_SNIPPET_SIZE,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
File attachments embedded in conversation messages were carrying the legacy `conversation/<filename>` path format . While this worked it required the model to do an extra round trip. This PR moves to the canonical `conversation-<id>/<filename>` format.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
