### PR TITLE
 Emit canonical scoped paths for pinned frames

### DIFF
--- a/front/lib/api/projects/pinned_frame.test.ts
+++ b/front/lib/api/projects/pinned_frame.test.ts
@@ -1,0 +1,72 @@
+import { SCOPED_PREFIX_POD } from "@app/lib/api/file_system";
+import { validatePinnedFramePath } from "@app/lib/api/projects/pinned_frame";
+import { Authenticator } from "@app/lib/auth";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import assert from "assert";
+import { describe, expect, it } from "vitest";
+
+async function setupProjectSpace(): Promise<{
+  auth: Authenticator;
+  space: SpaceResource;
+}> {
+  const { authenticator: auth, workspace } = await createResourceTest({
+    role: "admin",
+  });
+  const user = auth.getNonNullableUser();
+  const space = await SpaceFactory.project(workspace, user.id);
+  const addRes = await space.addMembers(auth, { userIds: [user.sId] });
+  assert(addRes.isOk(), "Failed to add user to project space");
+  // Re-fetch auth so it picks up the new group memberships required by forPod's canRead check.
+  const projectAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+  return { auth: projectAuth, space };
+}
+
+describe("validatePinnedFramePath", () => {
+  it("returns Ok(null) when path is null", async () => {
+    const { auth, space } = await setupProjectSpace();
+    const res = await validatePinnedFramePath(auth, space, null);
+    assert(res.isOk());
+    expect(res.value).toBeNull();
+  });
+
+  it("accepts a canonical pod-{spaceId}/... path and returns it unchanged", async () => {
+    const { auth, space } = await setupProjectSpace();
+    const canonicalPath = `${SCOPED_PREFIX_POD}${space.sId}/frame.md`;
+
+    const res = await validatePinnedFramePath(auth, space, canonicalPath);
+
+    assert(res.isOk());
+    expect(res.value).toBe(canonicalPath);
+  });
+
+  it("normalizes a legacy 'project/...' path to the canonical format", async () => {
+    const { auth, space } = await setupProjectSpace();
+
+    const res = await validatePinnedFramePath(auth, space, "project/frame.md");
+
+    assert(res.isOk());
+    expect(res.value).toBe(`${SCOPED_PREFIX_POD}${space.sId}/frame.md`);
+  });
+
+  it("normalizes a legacy 'pod/...' path to the canonical format", async () => {
+    const { auth, space } = await setupProjectSpace();
+
+    const res = await validatePinnedFramePath(auth, space, "pod/frame.md");
+
+    assert(res.isOk());
+    expect(res.value).toBe(`${SCOPED_PREFIX_POD}${space.sId}/frame.md`);
+  });
+
+  it("returns Err for a path with an unrecognised prefix", async () => {
+    const { auth, space } = await setupProjectSpace();
+
+    const res = await validatePinnedFramePath(auth, space, "other/frame.md");
+
+    expect(res.isErr()).toBe(true);
+  });
+});

--- a/front/lib/api/projects/pinned_frame.ts
+++ b/front/lib/api/projects/pinned_frame.ts
@@ -1,13 +1,17 @@
-import { getGCSPathFromScopedPath } from "@app/lib/api/files/gcs_mount/files";
-import { getPodFilesBasePath } from "@app/lib/api/files/mount_path";
+import {
+  DustFileSystem,
+  LEGACY_PREFIX_PROJECT,
+  SCOPED_PREFIX_POD,
+} from "@app/lib/api/file_system";
 import type { Authenticator } from "@app/lib/auth";
-import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 
 /**
- * Validate a pinned frame path for a project space.
- * Path must be scoped under `pod/` and resolve to an existing GCS object.
+ * Validate a pinned frame path for a project space and return the canonical scoped path.
+ *
+ * Accepts the canonical `pod-{spaceId}/...` format and silently normalizes the legacy
+ * `project/...` and `pod/...` formats that may still exist in the DB.
  */
 export async function validatePinnedFramePath(
   auth: Authenticator,
@@ -18,34 +22,24 @@ export async function validatePinnedFramePath(
     return new Ok(null);
   }
 
-  const owner = auth.getNonNullableWorkspace();
-  const prefix = getPodFilesBasePath({
-    workspaceId: owner.sId,
-    podId: space.sId,
-  });
-
-  // Some DB rows still carry the legacy `project/` scope prefix; as they have not been
-  // migrated to the new `pod/` scope, treat them as `pod/`
-  const normalizedScopedPath = pinnedFramePath.startsWith("project/")
-    ? `pod/${pinnedFramePath.slice("project/".length)}`
-    : pinnedFramePath;
-
-  const gcsPath = getGCSPathFromScopedPath({
-    prefix,
-    scopedPath: normalizedScopedPath,
-    useCase: "pod",
-  });
-  if (!gcsPath) {
-    return new Err(
-      new Error("Path must start with pod/ and be a valid file path.")
-    );
+  // Normalize legacy path formats to the canonical pod-{spaceId}/... format.
+  let normalizedPath = pinnedFramePath;
+  if (pinnedFramePath.startsWith(`${LEGACY_PREFIX_PROJECT}/`)) {
+    normalizedPath = `${SCOPED_PREFIX_POD}${space.sId}/${pinnedFramePath.slice(`${LEGACY_PREFIX_PROJECT}/`.length)}`;
+  } else if (pinnedFramePath.startsWith("pod/")) {
+    normalizedPath = `${SCOPED_PREFIX_POD}${space.sId}/${pinnedFramePath.slice("pod/".length)}`;
   }
 
-  const bucket = getPrivateUploadBucket();
-  const contentTypeResult = await bucket.getFileContentType(gcsPath);
-  if (contentTypeResult.isErr()) {
+  const fsResult = await DustFileSystem.forPod(auth, space);
+  if (fsResult.isErr()) {
+    return new Err(new Error("Failed to initialize file system."));
+  }
+  const fs = fsResult.value;
+
+  const statResult = await fs.stat(normalizedPath);
+  if (statResult.isErr() || !statResult.value) {
     return new Err(new Error("Pinned frame file not found."));
   }
 
-  return new Ok(pinnedFramePath);
+  return new Ok(normalizedPath);
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR rewrites `validatePinnedFramePath` to use `DustFileSystem.forPod` for validation instead of reaching into the GCS
layer directly through the deprecated `getGCSPathFromScopedPath`. Legacy `project/...` and `pod/...` paths already present in the DB are silently normalized to the canonical pod-{spaceId}/... format before validation, and the canonical
path is returned to the caller.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
