### PR TITLE
Return canonical scoped path from file upload API

### DIFF
--- a/front-api/routes/w/[wId]/files/[fileId]/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.ts
@@ -341,7 +341,12 @@ app.post("/", async (ctx) => {
     }
   }
 
-  return ctx.json({ file: file.toJSON(auth) });
+  return ctx.json({
+    file: {
+      ...file.toJSON(auth),
+      path: resolveUploadMountScopedPath(auth, file),
+    },
+  });
 });
 
 app.route("/edit-text", editText);

--- a/front-api/routes/w/[wId]/files/[fileId]/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.ts
@@ -344,7 +344,7 @@ app.post("/", async (ctx) => {
   return ctx.json({
     file: {
       ...file.toJSON(auth),
-      path: resolveUploadMountScopedPath(auth, file),
+      path: file.toScopedPath(auth),
     },
   });
 });

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -819,6 +819,93 @@ describe("FileResource", () => {
     });
   });
 
+  describe("toScopedPath", () => {
+    it("returns null when mountFilePath is not set", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const file = await FileFactory.create(auth, null, {
+        contentType: "text/plain",
+        fileName: "orphan.txt",
+        fileSize: 100,
+        status: "ready",
+        useCase: "conversation",
+        // no conversationId → no mountFilePath
+      });
+
+      expect(file.toScopedPath(auth)).toBeNull();
+    });
+
+    it("returns the canonical conversation-{cId}/filename path for a conversation file", async () => {
+      const { authenticator: auth, workspace } = await createResourceTest({
+        role: "admin",
+      });
+
+      const file = await FileFactory.create(auth, null, {
+        contentType: "text/plain",
+        fileName: "notes.txt",
+        fileSize: 100,
+        status: "created",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: "conv-scoped-1" },
+      });
+      await file.markAsReady(auth);
+
+      const ready = await FileResource.fetchById(auth, file.sId);
+      assert(ready, "File should exist after markAsReady");
+
+      expect(ready.toScopedPath(auth)).toBe(
+        `conversation-conv-scoped-1/notes.txt`
+      );
+      // Verify the GCS mount path that backs it.
+      expect(ready.mountFilePath).toBe(
+        `w/${workspace.sId}/conversations/conv-scoped-1/files/notes.txt`
+      );
+    });
+
+    it("returns the canonical pod-{spaceId}/filename path for a project_context file", async () => {
+      const { authenticator: auth, workspace } = await createResourceTest({
+        role: "admin",
+      });
+
+      const file = await FileFactory.create(auth, null, {
+        contentType: "text/markdown",
+        fileName: "spec.md",
+        fileSize: 200,
+        status: "created",
+        useCase: "project_context",
+        useCaseMetadata: { spaceId: "spc-scoped-1" },
+      });
+      await file.markAsReady(auth);
+
+      const ready = await FileResource.fetchById(auth, file.sId);
+      assert(ready, "File should exist after markAsReady");
+
+      expect(ready.toScopedPath(auth)).toBe(`pod-spc-scoped-1/spec.md`);
+      // Verify the GCS mount path that backs it.
+      expect(ready.mountFilePath).toBe(
+        `w/${workspace.sId}/pods/spc-scoped-1/files/spec.md`
+      );
+    });
+
+    it("returns null for a use case that does not produce a scoped path", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const file = await FileFactory.create(auth, null, {
+        contentType: "image/png",
+        fileName: "avatar.png",
+        fileSize: 500,
+        status: "ready",
+        useCase: "avatar",
+      });
+
+      expect(file.toScopedPath(auth)).toBeNull();
+    });
+  });
+
   describe("getContentBucketAndPath", () => {
     it("should resolve to 'original' version for plain text files", async () => {
       const { authenticator: auth } = await createResourceTest({

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -9,8 +9,8 @@ import {
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import {
   disambiguateFileName,
-  getConversationFilesBasePath,
   getConversationFilePath,
+  getConversationFilesBasePath,
   getPodFilesBasePath,
   makeProcessedMountFileName,
   toProjectMountFilePath,

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -2,9 +2,14 @@
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 
 import config from "@app/lib/api/config";
+import {
+  SCOPED_PREFIX_CONVERSATION,
+  SCOPED_PREFIX_POD,
+} from "@app/lib/api/file_system";
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import {
   disambiguateFileName,
+  getConversationFilesBasePath,
   getConversationFilePath,
   getPodFilesBasePath,
   makeProcessedMountFileName,
@@ -1085,6 +1090,54 @@ export class FileResource extends BaseResource<FileModel> {
     const isTaken = await this.isMountFilePathTaken(desiredPath);
 
     return isTaken ? `${basePath}${disambiguateFileName(this)}` : desiredPath;
+  }
+
+  /**
+   * Returns the canonical scoped path for this file (e.g. `pod-{spaceId}/report.pdf` or
+   * `conversation-{cId}/file.txt`), or `null` when the file has no mount path or its use
+   * case does not produce a scoped path.
+   *
+   * This is the shape that gcsfuse consumers (agents, file explorer) expect, and what the
+   * file upload API returns in the `path` field.
+   */
+  // TODO(FILE SYSTEM MIGRATION): Temporary until file is not tighted for file system anymore.
+  toScopedPath(auth: Authenticator): string | null {
+    if (!this.mountFilePath) {
+      return null;
+    }
+
+    const owner = auth.getNonNullableWorkspace();
+
+    if (this.useCase === "project_context" && this.useCaseMetadata?.spaceId) {
+      const spaceId = this.useCaseMetadata.spaceId;
+      const prefix = getPodFilesBasePath({
+        workspaceId: owner.sId,
+        podId: spaceId,
+      });
+      if (!this.mountFilePath.startsWith(prefix)) {
+        return null;
+      }
+
+      return `${SCOPED_PREFIX_POD}${spaceId}/${this.mountFilePath.slice(prefix.length)}`;
+    }
+
+    if (
+      isConversationFileUseCase(this.useCase) &&
+      this.useCaseMetadata?.conversationId
+    ) {
+      const conversationId = this.useCaseMetadata.conversationId;
+      const prefix = getConversationFilesBasePath({
+        workspaceId: owner.sId,
+        conversationId,
+      });
+      if (!this.mountFilePath.startsWith(prefix)) {
+        return null;
+      }
+
+      return `${SCOPED_PREFIX_CONVERSATION}${conversationId}/${this.mountFilePath.slice(prefix.length)}`;
+    }
+
+    return null;
   }
 
   /**

--- a/front/pages/api/w/[wId]/files/[fileId]/index.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/index.ts
@@ -122,11 +122,6 @@
  */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getOrCreateConversationDataSourceFromFile } from "@app/lib/api/data_sources";
-import { getScopedPathFromGCSPath } from "@app/lib/api/files/gcs_mount/files";
-import {
-  getConversationFilesBasePath,
-  getPodFilesBasePath,
-} from "@app/lib/api/files/mount_path";
 import { processAndStoreFile } from "@app/lib/api/files/processing";
 import { isSandboxRawDelimitedConversationFile } from "@app/lib/api/files/sandbox_raw";
 import {
@@ -151,44 +146,6 @@ export interface FileUploadedRequestResponseBody {
     /** Scoped mount path when the file is on GCS (same shape as `GCSMountEntryBase.path`). */
     path: string | null;
   };
-}
-
-function resolveUploadMountScopedPath(
-  auth: Authenticator,
-  file: FileResource
-): string | null {
-  if (!file.mountFilePath) {
-    return null;
-  }
-
-  const owner = auth.getNonNullableWorkspace();
-
-  if (file.useCase === "project_context" && file.useCaseMetadata?.spaceId) {
-    return getScopedPathFromGCSPath({
-      prefix: getPodFilesBasePath({
-        workspaceId: owner.sId,
-        podId: file.useCaseMetadata.spaceId,
-      }),
-      gcsPath: file.mountFilePath,
-      useCase: "pod",
-    });
-  }
-
-  if (
-    isConversationFileUseCase(file.useCase) &&
-    file.useCaseMetadata?.conversationId
-  ) {
-    return getScopedPathFromGCSPath({
-      prefix: getConversationFilesBasePath({
-        workspaceId: owner.sId,
-        conversationId: file.useCaseMetadata.conversationId,
-      }),
-      gcsPath: file.mountFilePath,
-      useCase: "conversation",
-    });
-  }
-
-  return null;
 }
 
 export const config = {
@@ -542,7 +499,7 @@ async function handler(
       return res.status(200).json({
         file: {
           ...file.toJSON(auth),
-          path: resolveUploadMountScopedPath(auth, file),
+          path: file.toScopedPath(auth),
         },
       });
     }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Uploading a file to a pod space returned `"path": "pod/<filename>"` in the response. The legacy format that the file system layer no longer accepts. The root cause was `resolveUploadMountScopedPath` in the upload endpoint, which called `getScopedPathFromGCSPath` with useCase: "pod" and "conversation", always producing the old prefix-only format.

The conversion logic is a temporary `FileResource.toScopedPath(auth)` method. It strips the GCS base path from `mountFilePath` and prepends the canonical `pod-{spaceId}/` or `conversation-{cId}/` prefix. Both the Next.js handler and its Hono mirror call it directly, replacing the duplicated free function and its now-unused imports.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
