### PR TITLE
Route file previews through the global /files/path endpoint

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -181,27 +181,26 @@ function buildMountFilePreviewHref({
   spaceId: string | null;
   filePath: string;
 }): string | undefined {
+  // Canonical paths go straight to the global file-path endpoint.
+  if (filePath.startsWith("conversation-") || filePath.startsWith("pod-")) {
+    return `${apiBaseUrl}/api/w/${ownerId}/files/path/${filePath}`;
+  }
+
+  // Normalize legacy "conversation/<rel>" to canonical before routing.
   if (filePath.startsWith("conversation/")) {
-    return `${apiBaseUrl}/api/w/${ownerId}/assistant/conversations/${conversationId}/files/${filePath}`;
+    const rel = filePath.slice("conversation/".length);
+    return `${apiBaseUrl}/api/w/${ownerId}/files/path/conversation-${conversationId}/${rel}`;
   }
 
-  if (filePath.startsWith("pod/")) {
+  // Normalize legacy "pod/<rel>" and "project/<rel>" to canonical before routing.
+  if (filePath.startsWith("pod/") || filePath.startsWith("project/")) {
     if (!spaceId) {
       return undefined;
     }
-
-    return `${apiBaseUrl}/api/w/${ownerId}/spaces/${spaceId}/files/${filePath}`;
-  }
-
-  // Legacy "project/" scope maps to the same Pod files endpoint; rewrite the prefix.
-  if (filePath.startsWith("project/")) {
-    if (!spaceId) {
-      return undefined;
-    }
-
-    const podFilePath = `pod/${filePath.slice("project/".length)}`;
-
-    return `${apiBaseUrl}/api/w/${ownerId}/spaces/${spaceId}/files/${podFilePath}`;
+    const rel = filePath.startsWith("pod/")
+      ? filePath.slice("pod/".length)
+      : filePath.slice("project/".length);
+    return `${apiBaseUrl}/api/w/${ownerId}/files/path/pod-${spaceId}/${rel}`;
   }
 
   return undefined;

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -313,37 +313,26 @@ export const VisualizationActionIframe = forwardRef<
     async (fileId: string) => {
       let url: string;
 
-      if (fileId.startsWith("conversation/")) {
+      if (fileId.startsWith("conversation-") || fileId.startsWith("pod-")) {
+        // Canonical scoped paths — the global endpoint resolves auth from the prefix.
+        const encodedPath = fileId.split("/").map(encodeURIComponent).join("/");
+        url = `/api/w/${workspaceId}/files/path/${encodedPath}`;
+      } else if (fileId.startsWith("conversation/")) {
+        // Legacy path: normalize to canonical using context conversationId.
         if (!conversationId) {
           return null;
         }
-        url = `/api/w/${workspaceId}/assistant/conversations/${conversationId}/files/${fileId}`;
-      } else if (fileId.startsWith("pod/")) {
+        const rel = fileId.slice("conversation/".length);
+        url = `/api/w/${workspaceId}/files/path/conversation-${conversationId}/${rel}`;
+      } else if (fileId.startsWith("pod/") || fileId.startsWith("project/")) {
+        // Legacy paths: normalize to canonical using context spaceId.
         if (!spaceId) {
           return null;
         }
-        url = `/api/w/${workspaceId}/spaces/${spaceId}/files/${fileId}`;
-      } else if (fileId.startsWith("project/")) {
-        // Legacy "project/" scope. The Pod files endpoint only accepts the
-        // "pod/" prefix and resolves everything under the pods/ base path, so
-        // we rewrite the prefix. Log remaining usage so we can drop this branch
-        // once no clients emit "project/" paths anymore.
-        if (!spaceId) {
-          return null;
-        }
-        datadogLogger.info("Legacy project/ file scope used in visualization", {
-          fileId,
-        });
-        const podFileId = `pod/${fileId.slice("project/".length)}`;
-        url = `/api/w/${workspaceId}/spaces/${spaceId}/files/${podFileId}`;
-      } else if (
-        fileId.startsWith("conversation-") ||
-        fileId.startsWith("pod-")
-      ) {
-        // Canonical scoped paths (e.g. conversation-{cId}/file.txt, pod-{pId}/data.csv).
-        // The new /files/path endpoint resolves auth from the path prefix itself.
-        const encodedPath = fileId.split("/").map(encodeURIComponent).join("/");
-        url = `/api/w/${workspaceId}/files/path/${encodedPath}`;
+        const rel = fileId.startsWith("pod/")
+          ? fileId.slice("pod/".length)
+          : fileId.slice("project/".length);
+        url = `/api/w/${workspaceId}/files/path/pod-${spaceId}/${rel}`;
       } else {
         url = `/api/w/${workspaceId}/files/${fileId}?action=view`;
       }

--- a/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
@@ -37,8 +37,8 @@ export function ConversationFileExplorer({
 
   const getFileUrl = useCallback(
     (path: string) =>
-      `${config.getApiBaseUrl()}/api/w/${owner.sId}/assistant/conversations/${conversation.sId}/files/${path}`,
-    [conversation.sId, owner.sId]
+      `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/path/${path}`,
+    [owner.sId]
   );
 
   const getFileResponse = useCallback(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Some front-end components were routing file access through the legacy conversation- and space-scoped endpoints, which only accept the old bare-prefix path format. They now call /api/w/:wId/files/path/<canonicalPath> directly. The same endpoint PodFileExplorer already uses. Legacy conversation/, pod/, and project/ prefixes are normalised to their canonical counterparts using the context conversationId or spaceId before routing through the same endpoint. The legacy branches will be removed in a few days once we are confident no client is still emitting them.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
