### PR TITLE
[front] feat: list skills in Skill Builder slash dropdown

### DIFF
--- a/front/components/editor/SkillInstructionsEditor.tsx
+++ b/front/components/editor/SkillInstructionsEditor.tsx
@@ -7,6 +7,7 @@ import {
   INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT,
 } from "@app/lib/editor/build_skill_instructions_extensions";
 import { preprocessMarkdownForEditor } from "@app/lib/editor/skill_instructions_preprocessing";
+import type { LightWorkspaceType } from "@app/types/user";
 import { cn } from "@dust-tt/sparkle";
 import { CharacterCount, Placeholder } from "@tiptap/extensions";
 import type { Transaction } from "@tiptap/pm/state";
@@ -94,7 +95,9 @@ function useEditorService(
 }
 
 interface SkillInstructionsSkillReferencesOptions {
+  currentSkillId?: string | null;
   enableSkillReferences: boolean;
+  owner?: LightWorkspaceType;
 }
 
 interface UseSkillInstructionsEditorProps {
@@ -107,18 +110,32 @@ interface UseSkillInstructionsEditorProps {
   onDelete?: (editor: Editor) => void;
 }
 
-const skillInstructionsEditableExtensions = [
-  SlashCommandExtension,
-  AgentInstructionDiffExtension,
-  Placeholder.configure({
-    placeholder: "What does this skill do? How should it behave?",
-    emptyNodeClass:
-      "first:before:text-gray-400 first:before:italic first:before:content-[attr(data-placeholder)] first:before:pointer-events-none first:before:absolute",
-  }),
-  CharacterCount.configure({
-    limit: INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT,
-  }),
-];
+function buildSkillInstructionsEditableExtensions({
+  currentSkillId,
+  includeSkillSuggestions,
+  owner,
+}: {
+  currentSkillId?: string | null;
+  includeSkillSuggestions: boolean;
+  owner?: LightWorkspaceType;
+}) {
+  return [
+    SlashCommandExtension.configure({
+      currentSkillId: currentSkillId ?? null,
+      includeSkillSuggestions,
+      owner,
+    }),
+    AgentInstructionDiffExtension,
+    Placeholder.configure({
+      placeholder: "What does this skill do? How should it behave?",
+      emptyNodeClass:
+        "first:before:text-gray-400 first:before:italic first:before:content-[attr(data-placeholder)] first:before:pointer-events-none first:before:absolute",
+    }),
+    CharacterCount.configure({
+      limit: INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT,
+    }),
+  ];
+}
 
 export function useSkillInstructionsEditor({
   content,
@@ -130,16 +147,25 @@ export function useSkillInstructionsEditor({
   onDelete,
 }: UseSkillInstructionsEditorProps) {
   const enableSkillReferences = skillReferences?.enableSkillReferences === true;
+  const currentSkillId = skillReferences?.currentSkillId ?? null;
+  const owner = skillReferences?.owner;
+  const includeSkillSuggestions = enableSkillReferences && !!owner;
+  const editableExtensions = useMemo(
+    () =>
+      buildSkillInstructionsEditableExtensions({
+        currentSkillId,
+        includeSkillSuggestions,
+        owner,
+      }),
+    [currentSkillId, includeSkillSuggestions, owner]
+  );
+
   const extensions = useMemo(
     () =>
-      buildSkillInstructionsExtensions(
-        isReadOnly,
-        skillInstructionsEditableExtensions,
-        {
-          enableSkillReferences,
-        }
-      ),
-    [enableSkillReferences, isReadOnly]
+      buildSkillInstructionsExtensions(isReadOnly, editableExtensions, {
+        enableSkillReferences,
+      }),
+    [editableExtensions, enableSkillReferences, isReadOnly]
   );
 
   // Track if initial content has been set

--- a/front/components/editor/extensions/shared/SlashCommandSkillItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandSkillItems.ts
@@ -69,14 +69,23 @@ export function filterSkillsForSlashSuggestions({
 }
 
 export function getSkillSlashCommandItem(
-  skill: SlashCommandSkillSuggestion
+  skill: SlashCommandSkillSuggestion,
+  { sectionLabel }: { sectionLabel?: string } = {}
 ): SlashCommand {
   return {
     action: SELECT_SKILL_SLASH_COMMAND_ACTION,
+    data: {
+      skill: {
+        icon: skill.icon,
+        id: skill.sId,
+        name: skill.name,
+      },
+    },
     description: skill.userFacingDescription,
     icon: getSkillAvatarIcon(skill.icon),
     id: skill.sId,
     label: skill.name,
+    sectionLabel,
     tooltip: skill.userFacingDescription
       ? {
           description: skill.userFacingDescription,

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -9,6 +9,7 @@ import {
 import type { SuggestionProps } from "@tiptap/suggestion";
 import type React from "react";
 import {
+  Fragment,
   forwardRef,
   useCallback,
   useEffect,
@@ -38,10 +39,18 @@ const EMPTY_SCROLL_FADE_STATE: ScrollFadeState = {
 
 export interface SlashCommand {
   action: string;
+  data?: {
+    skill?: {
+      icon?: string | null;
+      id: string;
+      name: string;
+    };
+  };
   description?: string;
   icon: React.ComponentType<any>;
   id: string;
   label: string;
+  sectionLabel?: string;
   tooltip?: SlashCommandTooltip;
 }
 
@@ -269,9 +278,13 @@ export const SlashCommandDropdown = forwardRef<
                     aria-hidden
                   />
                   {items.map((item, index) => {
+                    const sectionLabel =
+                      item.sectionLabel &&
+                      items[index - 1]?.sectionLabel !== item.sectionLabel
+                        ? item.sectionLabel
+                        : undefined;
                     const menuItem = (
                       <DropdownMenuItem
-                        key={item.id}
                         icon={item.icon}
                         itemId={item.id}
                         label={item.label}
@@ -288,21 +301,29 @@ export const SlashCommandDropdown = forwardRef<
                     );
 
                     // Wrap with DropdownTooltipTrigger if command has tooltip property.
-                    if (item.tooltip) {
-                      return (
-                        <DropdownTooltipTrigger
-                          key={item.id}
-                          description={item.tooltip.description}
-                          media={item.tooltip.media}
-                          side="right"
-                          sideOffset={8}
-                        >
-                          {menuItem}
-                        </DropdownTooltipTrigger>
-                      );
-                    }
+                    const itemContent = item.tooltip ? (
+                      <DropdownTooltipTrigger
+                        description={item.tooltip.description}
+                        media={item.tooltip.media}
+                        side="right"
+                        sideOffset={8}
+                      >
+                        {menuItem}
+                      </DropdownTooltipTrigger>
+                    ) : (
+                      menuItem
+                    );
 
-                    return menuItem;
+                    return (
+                      <Fragment key={item.id}>
+                        {sectionLabel ? (
+                          <div className="px-3 py-2 text-xs font-semibold text-muted-foreground dark:text-muted-foreground-night">
+                            {sectionLabel}
+                          </div>
+                        ) : null}
+                        {itemContent}
+                      </Fragment>
+                    );
                   })}
                 </div>
               </div>

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.test.ts
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.test.ts
@@ -1,0 +1,82 @@
+import type { SlashCommandSkillSuggestion } from "@app/components/editor/extensions/shared/SlashCommandSkillItems";
+import { describe, expect, it } from "vitest";
+
+import type { SlashCommand } from "./SlashCommandDropdown";
+import { buildSkillBuilderSlashCommandItems } from "./SlashCommandExtension";
+
+const attachKnowledgeItem: SlashCommand = {
+  action: "insert-knowledge-node",
+  icon: () => null,
+  id: "add-knowledge",
+  label: "Attach knowledge",
+};
+
+const skillSuggestion = ({
+  icon = null,
+  userFacingDescription = "",
+  ...skill
+}: Pick<SlashCommandSkillSuggestion, "name" | "sId"> &
+  Partial<SlashCommandSkillSuggestion>): SlashCommandSkillSuggestion => ({
+  icon,
+  userFacingDescription,
+  ...skill,
+});
+
+describe("buildSkillBuilderSlashCommandItems", () => {
+  it("keeps the existing command when skill suggestions are disabled", () => {
+    const result = buildSkillBuilderSlashCommandItems({
+      baseItems: [attachKnowledgeItem],
+      includeSkillSuggestions: false,
+      query: "",
+      skills: [
+        skillSuggestion({
+          name: "Create memo",
+          sId: "skill_create_memo",
+        }),
+      ],
+    });
+
+    expect(result).toEqual([attachKnowledgeItem]);
+  });
+
+  it("adds filtered skills under the capabilities section", () => {
+    const result = buildSkillBuilderSlashCommandItems({
+      baseItems: [attachKnowledgeItem],
+      currentSkillId: "skill_current",
+      includeSkillSuggestions: true,
+      query: "memo",
+      skills: [
+        skillSuggestion({
+          name: "Create memo",
+          sId: "skill_create_memo",
+          userFacingDescription: "Draft structured memos.",
+        }),
+        skillSuggestion({
+          name: "Issue triage",
+          sId: "skill_issue_triage",
+        }),
+        skillSuggestion({
+          name: "Current skill",
+          sId: "skill_current",
+        }),
+      ],
+    });
+
+    expect(result.map((item) => item.id)).toEqual([
+      "add-knowledge",
+      "skill_create_memo",
+    ]);
+    expect(result[1]).toMatchObject({
+      action: "select-skill",
+      data: {
+        skill: {
+          icon: null,
+          id: "skill_create_memo",
+          name: "Create memo",
+        },
+      },
+      description: "Draft structured memos.",
+      sectionLabel: "Capabilities",
+    });
+  });
+});

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
@@ -18,7 +18,7 @@ import type { EditorView } from "@tiptap/pm/view";
 import { ReactRenderer } from "@tiptap/react";
 import type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
 import { exitSuggestion, Suggestion } from "@tiptap/suggestion";
-import { forwardRef, useMemo } from "react";
+import { forwardRef, useImperativeHandle, useMemo, useRef } from "react";
 
 const slashCommandPluginKey = new PluginKey("slashCommand");
 
@@ -96,6 +96,7 @@ const SkillBuilderSlashCommandDropdownWithSkills = forwardRef<
     { clientRect, command, currentSkillId, items, onClose, owner, query },
     ref
   ) => {
+    const dropdownRef = useRef<SlashCommandDropdownRef>(null);
     const isOpen = Boolean(clientRect);
     const { skills, isSkillsLoading } = useSkills({
       disabled: !isOpen,
@@ -115,10 +116,28 @@ const SkillBuilderSlashCommandDropdownWithSkills = forwardRef<
       [currentSkillId, items, query, skills]
     );
 
+    useImperativeHandle(
+      ref,
+      () => ({
+        onKeyDown: ({ event }) => {
+          if (
+            (event.key === "Enter" || event.key === "Tab") &&
+            (isSkillsLoading || slashCommandItems.length === 0)
+          ) {
+            event.preventDefault();
+            return true;
+          }
+
+          return dropdownRef.current?.onKeyDown({ event }) ?? false;
+        },
+      }),
+      [isSkillsLoading, slashCommandItems.length]
+    );
+
     return (
       <SlashCommandDropdown
         key={isSkillsLoading ? "loading" : "loaded"}
-        ref={ref}
+        ref={dropdownRef}
         items={slashCommandItems}
         command={command}
         clientRect={clientRect}

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
@@ -1,8 +1,16 @@
+import {
+  filterSkillsForSlashSuggestions,
+  getSkillSlashCommandItem,
+  SELECT_SKILL_SLASH_COMMAND_ACTION,
+  type SlashCommandSkillSuggestion,
+} from "@app/components/editor/extensions/shared/SlashCommandSkillItems";
 import type {
   SlashCommand,
   SlashCommandDropdownRef,
 } from "@app/components/editor/extensions/skill_builder/SlashCommandDropdown";
 import { SlashCommandDropdown } from "@app/components/editor/extensions/skill_builder/SlashCommandDropdown";
+import { useSkills } from "@app/lib/swr/skill_configurations";
+import type { LightWorkspaceType } from "@app/types/user";
 import { AttachmentIcon } from "@dust-tt/sparkle";
 import { Extension } from "@tiptap/core";
 import { PluginKey } from "@tiptap/pm/state";
@@ -10,6 +18,7 @@ import type { EditorView } from "@tiptap/pm/view";
 import { ReactRenderer } from "@tiptap/react";
 import type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
 import { exitSuggestion, Suggestion } from "@tiptap/suggestion";
+import { forwardRef, useMemo } from "react";
 
 const slashCommandPluginKey = new PluginKey("slashCommand");
 
@@ -35,7 +44,129 @@ const SLASH_COMMANDS: SlashCommand[] = [
   },
 ];
 
+export function buildSkillBuilderSlashCommandItems({
+  baseItems,
+  currentSkillId,
+  includeSkillSuggestions,
+  query,
+  skills,
+}: {
+  baseItems: SlashCommand[];
+  currentSkillId?: string | null;
+  includeSkillSuggestions: boolean;
+  query: string;
+  skills: SlashCommandSkillSuggestion[];
+}): SlashCommand[] {
+  if (!includeSkillSuggestions) {
+    return baseItems;
+  }
+
+  const skillItems = filterSkillsForSlashSuggestions({ query, skills })
+    .filter((skill) => skill.sId !== currentSkillId)
+    .map((skill, index) =>
+      getSkillSlashCommandItem(skill, {
+        sectionLabel: index === 0 ? "Capabilities" : undefined,
+      })
+    );
+
+  return [...baseItems, ...skillItems];
+}
+
+interface SkillBuilderSlashCommandDropdownProps
+  extends Pick<
+    SuggestionProps<SlashCommand>,
+    "clientRect" | "command" | "items" | "query"
+  > {
+  currentSkillId?: string | null;
+  includeSkillSuggestions: boolean;
+  onClose: () => void;
+  owner?: LightWorkspaceType;
+}
+
+interface SkillBuilderSlashCommandDropdownWithSkillsProps
+  extends SkillBuilderSlashCommandDropdownProps {
+  owner: LightWorkspaceType;
+}
+
+const SkillBuilderSlashCommandDropdownWithSkills = forwardRef<
+  SlashCommandDropdownRef,
+  SkillBuilderSlashCommandDropdownWithSkillsProps
+>(
+  (
+    { clientRect, command, currentSkillId, items, onClose, owner, query },
+    ref
+  ) => {
+    const isOpen = Boolean(clientRect);
+    const { skills, isSkillsLoading } = useSkills({
+      disabled: !isOpen,
+      owner,
+      status: "active",
+    });
+
+    const slashCommandItems = useMemo(
+      () =>
+        buildSkillBuilderSlashCommandItems({
+          baseItems: items,
+          currentSkillId,
+          includeSkillSuggestions: true,
+          query,
+          skills,
+        }),
+      [currentSkillId, items, query, skills]
+    );
+
+    return (
+      <SlashCommandDropdown
+        key={isSkillsLoading ? "loading" : "loaded"}
+        ref={ref}
+        items={slashCommandItems}
+        command={command}
+        clientRect={clientRect}
+        emptyMessage={
+          isSkillsLoading ? "Loading capabilities…" : "No commands found"
+        }
+        onClose={onClose}
+        size="wide"
+      />
+    );
+  }
+);
+
+SkillBuilderSlashCommandDropdownWithSkills.displayName =
+  "SkillBuilderSlashCommandDropdownWithSkills";
+
+const SkillBuilderSlashCommandDropdown = forwardRef<
+  SlashCommandDropdownRef,
+  SkillBuilderSlashCommandDropdownProps
+>((props, ref) => {
+  if (props.includeSkillSuggestions && props.owner) {
+    return (
+      <SkillBuilderSlashCommandDropdownWithSkills
+        {...props}
+        owner={props.owner}
+        ref={ref}
+      />
+    );
+  }
+
+  return (
+    <SlashCommandDropdown
+      ref={ref}
+      items={props.items}
+      command={props.command}
+      clientRect={props.clientRect}
+      onClose={props.onClose}
+    />
+  );
+});
+
+SkillBuilderSlashCommandDropdown.displayName =
+  "SkillBuilderSlashCommandDropdown";
+
 export interface SlashCommandExtensionOptions {
+  currentSkillId?: string | null;
+  includeSkillSuggestions: boolean;
+  owner?: LightWorkspaceType;
   suggestion: Partial<SuggestionOptions>;
 }
 
@@ -58,6 +189,9 @@ export const SlashCommandExtension =
 
     addOptions() {
       return {
+        currentSkillId: null,
+        includeSkillSuggestions: false,
+        owner: undefined,
         suggestion: {
           char: "/",
           pluginKey: slashCommandPluginKey,
@@ -81,6 +215,7 @@ export const SlashCommandExtension =
     },
 
     addProseMirrorPlugins() {
+      const extensionOptions = this.options;
       const extensionStorage = this.storage;
 
       return [
@@ -96,6 +231,20 @@ export const SlashCommandExtension =
                 .deleteRange(range)
                 .insertKnowledgeNode()
                 .run();
+            } else if (props.action === SELECT_SKILL_SLASH_COMMAND_ACTION) {
+              const skill = props.data?.skill;
+              if (skill) {
+                editor
+                  .chain()
+                  .focus()
+                  .deleteRange(range)
+                  .insertSkillNode({
+                    skillId: skill.id,
+                    skillIcon: skill.icon,
+                    skillName: skill.name,
+                  })
+                  .run();
+              }
             }
           },
           render: () => {
@@ -113,13 +262,20 @@ export const SlashCommandExtension =
             return {
               onStart: (props: SuggestionProps) => {
                 activeEditorView = props.editor.view;
-                component = new ReactRenderer(SlashCommandDropdown, {
-                  props: {
-                    ...props,
-                    onClose: closeSuggestionDropdown,
-                  },
-                  editor: props.editor,
-                });
+                component = new ReactRenderer(
+                  SkillBuilderSlashCommandDropdown,
+                  {
+                    props: {
+                      ...props,
+                      currentSkillId: extensionOptions.currentSkillId,
+                      includeSkillSuggestions:
+                        extensionOptions.includeSkillSuggestions,
+                      onClose: closeSuggestionDropdown,
+                      owner: extensionOptions.owner,
+                    },
+                    editor: props.editor,
+                  }
+                );
 
                 if (!props.clientRect) {
                   return;
@@ -132,7 +288,11 @@ export const SlashCommandExtension =
                 activeEditorView = props.editor.view;
                 component?.updateProps({
                   ...props,
+                  currentSkillId: extensionOptions.currentSkillId,
+                  includeSkillSuggestions:
+                    extensionOptions.includeSkillSuggestions,
                   onClose: closeSuggestionDropdown,
+                  owner: extensionOptions.owner,
                 });
 
                 if (!props.clientRect) {

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -202,7 +202,9 @@ export function SkillBuilderInstructionsEditor({
     htmlContent: instructionsHtmlField.value ?? undefined,
     isReadOnly: hasSuggestions,
     skillReferences: {
+      currentSkillId: skillId,
       enableSkillReferences,
+      owner,
     },
     onUpdate: handleUpdate,
     onBlur: handleBlur,


### PR DESCRIPTION
## Description

Add the Skill Builder slash dropdown UX for inserting nested skill references behind the `nested_skills` feature flag.

<img width="899" height="304" alt="Screenshot 2026-05-29 at 11 41 41 AM" src="https://github.com/user-attachments/assets/911fed09-d7d3-4d80-b6c2-5969af445477" />

When enabled, the dropdown keeps the existing Attach knowledge item and lists active skills underneath it. Selecting a skill inserts the shared `SkillNode`, reusing the skill reference rendering and serialization support from the previous PRs.

## Tests

- Added coverage for Skill Builder slash skill filtering.

## Risk

- Low. Behind feature flag.

## Deploy Plan

- Deploy front.

