### PR TITLE
[front] feat: support skill references in Skill Builder instructions

### DIFF
--- a/front/components/editor/SkillInstructionsEditor.tsx
+++ b/front/components/editor/SkillInstructionsEditor.tsx
@@ -14,7 +14,10 @@ import type { Editor } from "@tiptap/react";
 import { EditorContent, useEditor } from "@tiptap/react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
-function useEditorService(editor: Editor | null) {
+function useEditorService(
+  editor: Editor | null,
+  { enableSkillReferences }: { enableSkillReferences: boolean }
+) {
   return useMemo(() => {
     return {
       getMarkdown() {
@@ -41,10 +44,15 @@ function useEditorService(editor: Editor | null) {
       setContent(content: string) {
         // Safety check for Safari: ensure editor and docView are available
         if (editor && !editor.isDestroyed) {
-          editor.commands.setContent(preprocessMarkdownForEditor(content), {
-            emitUpdate: false,
-            contentType: "markdown",
-          });
+          editor.commands.setContent(
+            preprocessMarkdownForEditor(content, {
+              enableSkillReferences,
+            }),
+            {
+              emitUpdate: false,
+              contentType: "markdown",
+            }
+          );
         }
       },
 
@@ -82,13 +90,18 @@ function useEditorService(editor: Editor | null) {
         return editor?.isDestroyed ?? true;
       },
     };
-  }, [editor]);
+  }, [editor, enableSkillReferences]);
+}
+
+interface SkillInstructionsSkillReferencesOptions {
+  enableSkillReferences: boolean;
 }
 
 interface UseSkillInstructionsEditorProps {
   content: string;
   htmlContent?: string;
   isReadOnly: boolean;
+  skillReferences?: SkillInstructionsSkillReferencesOptions;
   onUpdate?: (props: { editor: Editor; transaction: Transaction }) => void;
   onBlur?: () => void;
   onDelete?: (editor: Editor) => void;
@@ -111,17 +124,22 @@ export function useSkillInstructionsEditor({
   content,
   htmlContent,
   isReadOnly,
+  skillReferences,
   onUpdate,
   onBlur,
   onDelete,
 }: UseSkillInstructionsEditorProps) {
+  const enableSkillReferences = skillReferences?.enableSkillReferences === true;
   const extensions = useMemo(
     () =>
       buildSkillInstructionsExtensions(
         isReadOnly,
-        skillInstructionsEditableExtensions
+        skillInstructionsEditableExtensions,
+        {
+          enableSkillReferences,
+        }
       ),
-    [isReadOnly]
+    [enableSkillReferences, isReadOnly]
   );
 
   // Track if initial content has been set
@@ -140,7 +158,7 @@ export function useSkillInstructionsEditor({
     [extensions, isReadOnly]
   );
 
-  const editorService = useEditorService(editor);
+  const editorService = useEditorService(editor, { enableSkillReferences });
 
   // Set initial content after editor is created
   useEffect(() => {
@@ -158,17 +176,22 @@ export function useSkillInstructionsEditor({
           if (htmlContent) {
             editor.commands.setContent(htmlContent, { emitUpdate: false });
           } else {
-            editor.commands.setContent(preprocessMarkdownForEditor(content), {
-              emitUpdate: false,
-              contentType: "markdown",
-            });
+            editor.commands.setContent(
+              preprocessMarkdownForEditor(content, {
+                enableSkillReferences,
+              }),
+              {
+                emitUpdate: false,
+                contentType: "markdown",
+              }
+            );
           }
           initialContentSetRef.current = true;
           setIsContentReady(true);
         }
       });
     }
-  }, [editor, content, htmlContent]);
+  }, [editor, content, htmlContent, enableSkillReferences]);
 
   return { editor, editorService, isContentReady };
 }

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -27,6 +27,26 @@ import { useController, useFormContext } from "react-hook-form";
 const INSTRUCTIONS_FIELD_NAME = "instructions";
 const INSTRUCTIONS_HTML_FIELD_NAME = "instructionsHtml";
 const ATTACHED_KNOWLEDGE_FIELD_NAME = "attachedKnowledge";
+const BASE_ALLOWED_INSTRUCTIONS_TAGS = ["knowledge"];
+const BASE_ALLOWED_INSTRUCTIONS_ATTRS = ["space", "dsv", "hasChildren"];
+const SKILL_REFERENCE_ALLOWED_TAGS = ["skill"];
+const SKILL_REFERENCE_ALLOWED_ATTRS = ["id", "name", "icon"];
+
+function getSkillInstructionsSanitizeConfig({
+  enableSkillReferences,
+}: {
+  enableSkillReferences: boolean;
+}): Config {
+  return {
+    ADD_TAGS: enableSkillReferences
+      ? [...BASE_ALLOWED_INSTRUCTIONS_TAGS, ...SKILL_REFERENCE_ALLOWED_TAGS]
+      : [...BASE_ALLOWED_INSTRUCTIONS_TAGS],
+    ADD_ATTR: enableSkillReferences
+      ? [...BASE_ALLOWED_INSTRUCTIONS_ATTRS, ...SKILL_REFERENCE_ALLOWED_ATTRS]
+      : [...BASE_ALLOWED_INSTRUCTIONS_ATTRS],
+    FORBID_ATTR: ["style", "class"],
+  };
+}
 
 function collectKnowledgeItems(editor: Editor): KnowledgeItem[] {
   const items: KnowledgeItem[] = [];
@@ -50,14 +70,15 @@ function toAttachedKnowledge(
   }));
 }
 
-function sanitizeSkillInstructionsHtml(html: string): string {
+function sanitizeSkillInstructionsHtml(
+  html: string,
+  { enableSkillReferences = false }: { enableSkillReferences?: boolean } = {}
+): string {
   try {
-    const config: Config = {
-      ADD_TAGS: ["knowledge"],
-      ADD_ATTR: ["space", "dsv", "hasChildren"],
-      FORBID_ATTR: ["style", "class"],
-    };
-    return DOMPurify.sanitize(html, config);
+    return DOMPurify.sanitize(
+      html,
+      getSkillInstructionsSanitizeConfig({ enableSkillReferences })
+    );
   } catch {
     return html;
   }
@@ -75,6 +96,12 @@ export function SkillBuilderInstructionsEditor({
   const { compareVersion, isDiffMode } = useSkillVersionComparisonContext();
   const { resetField } = useFormContext<SkillBuilderFormData>();
   const initializedAttachedKnowledgeEditorRef = useRef<Editor | null>(null);
+  const { owner, skillId, selectedSuggestionId, setAcceptInstructionEdits } =
+    useSkillBuilderContext();
+  const { hasFeature } = useFeatureFlags();
+  const hasReinforcementFeature =
+    hasFeature("reinforced_agents") && hasFeature("reinforcement_ui");
+  const enableSkillReferences = hasFeature("nested_skills");
 
   const { field: instructionsField, fieldState: instructionsFieldState } =
     useController<SkillBuilderFormData, typeof INSTRUCTIONS_FIELD_NAME>({
@@ -115,11 +142,14 @@ export function SkillBuilderInstructionsEditor({
         postProcessMarkdown(editor.getMarkdown()).trim()
       );
       instructionsHtmlField.onChange(
-        sanitizeSkillInstructionsHtml(editor.getHTML())
+        sanitizeSkillInstructionsHtml(editor.getHTML(), {
+          enableSkillReferences,
+        })
       );
       syncAttachedKnowledgeFromEditor(editor);
     },
     [
+      enableSkillReferences,
       instructionsField.onChange,
       instructionsHtmlField.onChange,
       syncAttachedKnowledgeFromEditor,
@@ -158,11 +188,6 @@ export function SkillBuilderInstructionsEditor({
     [syncAttachedKnowledgeFromEditor]
   );
 
-  const { owner, skillId, selectedSuggestionId, setAcceptInstructionEdits } =
-    useSkillBuilderContext();
-  const { hasFeature } = useFeatureFlags();
-  const hasReinforcementFeature =
-    hasFeature("reinforced_agents") && hasFeature("reinforcement_ui");
   const { suggestions, isSuggestionsLoading } = useSkillSuggestions({
     skillId,
     states: ["pending"],
@@ -176,6 +201,9 @@ export function SkillBuilderInstructionsEditor({
     content: instructionsField.value ?? "",
     htmlContent: instructionsHtmlField.value ?? undefined,
     isReadOnly: hasSuggestions,
+    skillReferences: {
+      enableSkillReferences,
+    },
     onUpdate: handleUpdate,
     onBlur: handleBlur,
     onDelete: handleDelete,
@@ -377,11 +405,13 @@ export function SkillBuilderInstructionsEditor({
     }
 
     const incomingHtml = instructionsHtmlField.value;
-    const currentHtml = sanitizeSkillInstructionsHtml(editor.getHTML());
+    const currentHtml = sanitizeSkillInstructionsHtml(editor.getHTML(), {
+      enableSkillReferences,
+    });
     if (currentHtml !== incomingHtml) {
       editor.commands.setContent(incomingHtml, { emitUpdate: false });
     }
-  }, [editor, isDiffMode, instructionsHtmlField.value]);
+  }, [editor, enableSkillReferences, isDiffMode, instructionsHtmlField.value]);
 
   useEffect(() => {
     if (!editor || editor.isDestroyed) {
@@ -401,13 +431,22 @@ export function SkillBuilderInstructionsEditor({
         const compareText = compareVersion.instructions ?? "";
         const currentText = instructionsField.value ?? "";
 
-        editor.commands.setContent(preprocessMarkdownForEditor(currentText), {
-          emitUpdate: false,
-          contentType: "markdown",
-        });
+        editor.commands.setContent(
+          preprocessMarkdownForEditor(currentText, {
+            enableSkillReferences,
+          }),
+          {
+            emitUpdate: false,
+            contentType: "markdown",
+          }
+        );
         editor.commands.applyDiff(
-          preprocessMarkdownForEditor(compareText),
-          preprocessMarkdownForEditor(currentText)
+          preprocessMarkdownForEditor(compareText, {
+            enableSkillReferences,
+          }),
+          preprocessMarkdownForEditor(currentText, {
+            enableSkillReferences,
+          })
         );
         editor.setEditable(false);
       } else if (editor.storage.agentInstructionDiff?.isDiffMode) {
@@ -420,7 +459,9 @@ export function SkillBuilderInstructionsEditor({
           });
         } else {
           editor.commands.setContent(
-            preprocessMarkdownForEditor(instructionsField.value ?? ""),
+            preprocessMarkdownForEditor(instructionsField.value ?? "", {
+              enableSkillReferences,
+            }),
             {
               emitUpdate: false,
               contentType: "markdown",
@@ -438,6 +479,7 @@ export function SkillBuilderInstructionsEditor({
   }, [
     compareVersion,
     editor,
+    enableSkillReferences,
     instructionsField.value,
     instructionsHtmlField.value,
   ]);

--- a/front/components/skill_builder/SkillSuggestionCard.tsx
+++ b/front/components/skill_builder/SkillSuggestionCard.tsx
@@ -1,6 +1,7 @@
 import { useMaybeMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import { getBlockOuterHtml } from "@app/components/shared/utils";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { buildSkillInstructionsExtensions } from "@app/lib/editor/build_skill_instructions_extensions";
 import type {
   SkillAgentFacingDescriptionEditType,
@@ -122,6 +123,8 @@ function InstructionEditDiffBlock({
   getSkillInstructionsHtml,
 }: InstructionEditDiffBlockProps) {
   const { targetBlockId, content } = edit;
+  const { hasFeature } = useFeatureFlags();
+  const enableSkillReferences = hasFeature("nested_skills");
 
   const blockHtml = useMemo(() => {
     const instructionsHtml = getSkillInstructionsHtml();
@@ -133,7 +136,11 @@ function InstructionEditDiffBlock({
 
   const editor = useEditor(
     {
-      extensions: [...buildSkillInstructionsExtensions(true)],
+      extensions: [
+        ...buildSkillInstructionsExtensions(true, [], {
+          enableSkillReferences,
+        }),
+      ],
       editable: false,
       content: blockHtml,
       immediatelyRender: false,
@@ -149,7 +156,7 @@ function InstructionEditDiffBlock({
         e.commands.setHighlightedSuggestion(targetBlockId);
       },
     },
-    [blockHtml]
+    [blockHtml, enableSkillReferences]
   );
 
   return <DiffBlock>{editor && <EditorContent editor={editor} />}</DiffBlock>;

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -114,6 +114,7 @@ export function SkillInfoTab({
           <SkillInstructionsReadOnlyEditor
             content={skill.instructions}
             htmlContent={skill.instructionsHtml ?? ""}
+            enableSkillReferences={hasFeature("nested_skills")}
             owner={owner}
             onKnowledgeItemsChange={handleKnowledgeItemsChange}
             className="max-h-150 overflow-y-auto"

--- a/front/components/skills/SkillInstructionsReadOnlyEditor.tsx
+++ b/front/components/skills/SkillInstructionsReadOnlyEditor.tsx
@@ -10,6 +10,7 @@ import { useEffect } from "react";
 interface SkillInstructionsReadOnlyEditorProps {
   content: string;
   htmlContent?: string;
+  enableSkillReferences?: boolean;
   owner: LightWorkspaceType;
   onKnowledgeItemsChange?: (items: KnowledgeItem[]) => void;
   className?: string;
@@ -18,6 +19,7 @@ interface SkillInstructionsReadOnlyEditorProps {
 export function SkillInstructionsReadOnlyEditor({
   content,
   htmlContent,
+  enableSkillReferences = false,
   owner,
   onKnowledgeItemsChange,
   className,
@@ -29,6 +31,9 @@ export function SkillInstructionsReadOnlyEditor({
     content,
     htmlContent: htmlForEditor,
     isReadOnly: true,
+    skillReferences: {
+      enableSkillReferences,
+    },
   });
 
   useEffect(() => {

--- a/front/lib/editor/build_skill_instructions_extensions.ts
+++ b/front/lib/editor/build_skill_instructions_extensions.ts
@@ -1,6 +1,7 @@
 import { InstructionSuggestionExtension } from "@app/components/editor/extensions/agent_builder/InstructionSuggestionExtension";
 import { CodeExtension } from "@app/components/editor/extensions/CodeExtension";
 import { HeadingExtension } from "@app/components/editor/extensions/HeadingExtension";
+import { SkillNode } from "@app/components/editor/extensions/input_bar/SkillNode";
 import { BlockIdExtension } from "@app/components/editor/extensions/instructions/BlockIdExtension";
 import { InstructionsDocumentExtension } from "@app/components/editor/extensions/instructions/InstructionsDocumentExtension";
 import { InstructionsRootExtension } from "@app/components/editor/extensions/instructions/InstructionsRootExtension";
@@ -18,6 +19,10 @@ import { StarterKit } from "@tiptap/starter-kit";
 
 export const INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT = 120_000;
 
+interface BuildSkillInstructionsExtensionsOptions {
+  enableSkillReferences?: boolean;
+}
+
 /**
  * Build the TipTap extension list for the skill instructions editor.
  *
@@ -26,7 +31,10 @@ export const INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT = 120_000;
  */
 export function buildSkillInstructionsExtensions(
   isReadOnly: boolean,
-  editableExtensions: Extensions = []
+  editableExtensions: Extensions = [],
+  {
+    enableSkillReferences = false,
+  }: BuildSkillInstructionsExtensionsOptions = {}
 ): Extensions {
   const baseExtensions: Extensions = [
     InstructionsDocumentExtension,
@@ -90,6 +98,10 @@ export function buildSkillInstructionsExtensions(
     RawMarkdownBlock,
     ...rawMarkdownBlockParsers,
   ];
+
+  if (enableSkillReferences) {
+    baseExtensions.push(SkillNode);
+  }
 
   if (!isReadOnly) {
     baseExtensions.push(...editableExtensions);

--- a/front/lib/editor/skill_instructions_preprocessing.test.ts
+++ b/front/lib/editor/skill_instructions_preprocessing.test.ts
@@ -1,0 +1,47 @@
+import { buildSkillInstructionsExtensions } from "@app/lib/editor/build_skill_instructions_extensions";
+import { preprocessMarkdownForEditor } from "@app/lib/editor/skill_instructions_preprocessing";
+import { Editor } from "@tiptap/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+describe("skill instructions preprocessing", () => {
+  let editor: Editor | null = null;
+
+  afterEach(() => {
+    editor?.destroy();
+    editor = null;
+  });
+
+  it("escapes skill tags by default", () => {
+    expect(
+      preprocessMarkdownForEditor(
+        'Use <skill id="skill_123" name="Create memo" /> here.'
+      )
+    ).toContain("<\u200Bskill");
+  });
+
+  it("preserves skill tags when skill references are enabled", () => {
+    editor = new Editor({
+      extensions: buildSkillInstructionsExtensions(false, [], {
+        enableSkillReferences: true,
+      }),
+    });
+
+    editor.commands.setContent(
+      preprocessMarkdownForEditor(
+        'Use <skill id="skill_123" name="Create memo" /> here.',
+        { enableSkillReferences: true }
+      ),
+      {
+        contentType: "markdown",
+      }
+    );
+
+    const json = editor.getJSON();
+    expect(JSON.stringify(json)).toContain('"type":"skill"');
+    expect(JSON.stringify(json)).toContain('"skillId":"skill_123"');
+    expect(JSON.stringify(json)).toContain('"skillName":"Create memo"');
+    expect(editor.getMarkdown()).toContain(
+      '<skill id="skill_123" name="Create memo" />'
+    );
+  });
+});

--- a/front/lib/editor/skill_instructions_preprocessing.ts
+++ b/front/lib/editor/skill_instructions_preprocessing.ts
@@ -15,9 +15,17 @@ function escapeMathEmphasis(markdown: string): string {
 /**
  * Preprocess markdown before loading it into the TipTap editor.
  */
-export function preprocessMarkdownForEditor(markdown: string): string {
+export function preprocessMarkdownForEditor(
+  markdown: string,
+  { enableSkillReferences = false }: { enableSkillReferences?: boolean } = {}
+): string {
+  const preservedTags = enableSkillReferences ? "knowledge|skill" : "knowledge";
+
   return escapeMathEmphasis(
-    markdown.replace(/<(?!\/?knowledge[\s>/])(\/?\w)/g, `<${ZWS}$1`)
+    markdown.replace(
+      new RegExp(`<(?!(?:/?(?:${preservedTags}))[\\s>/])(/?\\w)`, "g"),
+      `<${ZWS}$1`
+    )
   );
 }
 


### PR DESCRIPTION
## Description

Add support for rendering and preserving nested skill references in Skill Builder instructions behind the `nested_skills` feature flag.

This wires the shared `SkillNode` into the Skill Builder instructions editor and preserves `<skill />` tags through preprocessing, sanitized instruction HTML, read-only rendering, and suggestion diff rendering. It does not add the slash dropdown insertion UX yet; that is handled in the next PR.

## Tests

- Added coverage for skill tag preprocessing and editor round-tripping.

## Risk

- Low. Behind feature flag.

## Deploy Plan

- Deploy front.

