### PR TITLE
[front] fix: support iconless skill references

### DIFF
--- a/front/components/assistant/UserMessageMarkdown.tsx
+++ b/front/components/assistant/UserMessageMarkdown.tsx
@@ -55,7 +55,7 @@ export const UserMessageMarkdown = ({
       skill: ({ skillIcon, skillId, skillName }: SkillDirectiveProps) => (
         <SkillBlock
           owner={owner}
-          skillIcon={skillIcon}
+          skillIcon={skillIcon ?? null}
           skillId={skillId}
           skillName={skillName}
         />

--- a/front/components/editor/extensions/input_bar/SkillNode.tsx
+++ b/front/components/editor/extensions/input_bar/SkillNode.tsx
@@ -125,12 +125,10 @@ export const SkillNode = Node.create({
   }),
 
   renderMarkdown: (node) =>
-    isString(node.attrs?.skillId) &&
-    isString(node.attrs?.skillIcon) &&
-    isString(node.attrs?.skillName)
+    isString(node.attrs?.skillId) && isString(node.attrs?.skillName)
       ? serializeSkillTag({
           id: node.attrs.skillId,
-          icon: node.attrs.skillIcon,
+          icon: isString(node.attrs.skillIcon) ? node.attrs.skillIcon : null,
           name: node.attrs.skillName,
         })
       : "",

--- a/front/components/markdown/SkillBlock.tsx
+++ b/front/components/markdown/SkillBlock.tsx
@@ -7,7 +7,7 @@ import { visit } from "unist-util-visit";
 
 export interface SkillDirectiveProps {
   skillId: string;
-  skillIcon: string;
+  skillIcon: string | null;
   skillName: string;
 }
 

--- a/front/lib/mentions/format.ts
+++ b/front/lib/mentions/format.ts
@@ -151,15 +151,15 @@ export function extractFromEditorJSON(node?: JSONContent): {
     const skillIcon = node.attrs?.skillIcon;
     const skillName = node.attrs?.skillName;
 
-    if (isString(skillId) && isString(skillIcon) && isString(skillName)) {
+    if (isString(skillId) && isString(skillName)) {
       skills.push({
         id: skillId,
-        icon: skillIcon,
+        icon: isString(skillIcon) ? skillIcon : null,
         name: skillName,
       });
       textContent += serializeSkillTag({
         id: skillId,
-        icon: skillIcon,
+        icon: isString(skillIcon) ? skillIcon : null,
         name: skillName,
       });
     }

--- a/front/lib/skills/format.ts
+++ b/front/lib/skills/format.ts
@@ -1,6 +1,6 @@
 export type SkillReference = {
   id: string;
-  icon?: string | null;
+  icon: string | null;
   name: string;
 };
 
@@ -20,7 +20,7 @@ function parseSkillTagAttributes(attributes: string): SkillReference | null {
 
   return {
     id,
-    icon,
+    icon: icon ?? null,
     name,
   };
 }

--- a/front/lib/skills/format.ts
+++ b/front/lib/skills/format.ts
@@ -1,6 +1,6 @@
 export type SkillReference = {
   id: string;
-  icon: string;
+  icon?: string | null;
   name: string;
 };
 
@@ -14,7 +14,7 @@ function parseSkillTagAttributes(attributes: string): SkillReference | null {
   const name = attributes.match(/\bname="([^"]+)"/)?.[1];
   const icon = attributes.match(/\bicon="([^"]+)"/)?.[1];
 
-  if (!id || !name || !icon) {
+  if (!id || !name) {
     return null;
   }
 
@@ -46,5 +46,7 @@ export function extractUniqueSkillIds(content: string): string[] {
 }
 
 export function serializeSkillTag({ id, name, icon }: SkillReference): string {
-  return `<${SKILL_TAG_NAME} id="${id}" name="${name}" icon="${icon}" />`;
+  const iconAttribute = icon ? ` icon="${icon}"` : "";
+
+  return `<${SKILL_TAG_NAME} id="${id}" name="${name}"${iconAttribute} />`;
 }


### PR DESCRIPTION
## Description

Allow skill references to round-trip when the referenced skill has no icon. This normalizes skill mention formatting/parsing and rendering so `icon` can be `null`.

This is foundation work for nested skill references and does not add new Skill Builder behavior.

## Tests

- Covered by existing skill mention rendering/editor coverage.

## Risk

- Low.

## Deploy Plan

- Deploy front.
