### PR TITLE
[front] feat: sync nested skill references on save

### DIFF
--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -3,8 +3,10 @@ import {
   SkillFileAttachmentModel,
   SkillVersionModel,
 } from "@app/lib/models/skill";
+import { SkillReferenceModel } from "@app/lib/models/skill/skill_reference";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import { serializeSkillTag } from "@app/lib/skills/format";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
@@ -289,6 +291,80 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
     );
     expect(updatedSkill).not.toBeNull();
     expect(updatedSkill?.agentFacingDescription).toBe(newDescription);
+  });
+
+  it("syncs nested skill references when the feature is enabled", async () => {
+    const { workspace, skill, requestUserAuth } = await setupTest({
+      requestUserRole: "admin",
+    });
+
+    const childSkill = await SkillFactory.create(requestUserAuth, {
+      name: "Referenced Skill",
+    });
+    const skillReferenceTag = serializeSkillTag({
+      id: childSkill.sId,
+      icon: null,
+      name: childSkill.name,
+    });
+    const instructionsWithReference = `Use ${skillReferenceTag} for deeper analysis.`;
+    const buildBody = (instructions: string) => ({
+      name: skill.name,
+      agentFacingDescription: skill.agentFacingDescription,
+      userFacingDescription: skill.userFacingDescription,
+      instructions,
+      icon: null,
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: null,
+    });
+
+    const disabledResponse = await patchSkill(
+      workspace,
+      skill.sId,
+      buildBody(instructionsWithReference)
+    );
+    expect(disabledResponse.status).toBe(200);
+    await expect(
+      SkillReferenceModel.count({
+        where: {
+          workspaceId: workspace.id,
+          parentSkillId: skill.id,
+        },
+      })
+    ).resolves.toBe(0);
+
+    await FeatureFlagFactory.basic(requestUserAuth, "nested_skills");
+
+    const enabledResponse = await patchSkill(
+      workspace,
+      skill.sId,
+      buildBody(instructionsWithReference)
+    );
+    expect(enabledResponse.status).toBe(200);
+    await expect(
+      SkillReferenceModel.count({
+        where: {
+          workspaceId: workspace.id,
+          parentSkillId: skill.id,
+          childSkillId: childSkill.id,
+        },
+      })
+    ).resolves.toBe(1);
+
+    const removeResponse = await patchSkill(
+      workspace,
+      skill.sId,
+      buildBody("No nested skill references here.")
+    );
+    expect(removeResponse.status).toBe(200);
+    await expect(
+      SkillReferenceModel.count({
+        where: {
+          workspaceId: workspace.id,
+          parentSkillId: skill.id,
+        },
+      })
+    ).resolves.toBe(0);
   });
 
   it("should update requestedSpaceIds when adding a tool from a new space", async () => {

--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -367,6 +367,42 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
     ).resolves.toBe(0);
   });
 
+  it("returns 400 for out-of-workspace nested skill references", async () => {
+    const { workspace, skill, requestUserAuth } = await setupTest({
+      requestUserRole: "admin",
+    });
+
+    await FeatureFlagFactory.basic(requestUserAuth, "nested_skills");
+    const outOfWorkspaceSkillId = SkillResource.modelIdToSId({
+      id: skill.id + 1,
+      workspaceId: workspace.id + 1,
+    });
+    const outOfWorkspaceSkillReferenceTag = serializeSkillTag({
+      id: outOfWorkspaceSkillId,
+      icon: null,
+      name: "Other Workspace Skill",
+    });
+
+    const response = await patchSkill(workspace, skill.sId, {
+      name: skill.name,
+      agentFacingDescription: skill.agentFacingDescription,
+      userFacingDescription: skill.userFacingDescription,
+      instructions: `Use ${outOfWorkspaceSkillReferenceTag}.`,
+      icon: null,
+      tools: [],
+      attachedKnowledge: [],
+      instructionsHtml: null,
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: `Skill reference ID does not belong to this workspace: ${outOfWorkspaceSkillId}`,
+      },
+    });
+  });
+
   it("should update requestedSpaceIds when adding a tool from a new space", async () => {
     const { workspace, skill, requestUser, requestUserAuth } = await setupTest({
       requestUserRole: "admin",

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -323,13 +323,11 @@ app.patch(
     const featureFlags = await getFeatureFlags(auth);
     const enableSkillReferences = featureFlags.includes("nested_skills");
     if (enableSkillReferences) {
-      const skillReferenceValidation = SkillResource.validateSkillReferenceIds(
-        auth,
-        {
+      const skillReferenceValidation =
+        SkillResource.getValidatedSkillReferenceModelIds(auth, {
           instructions: body.instructions,
           parentSkillId: skill.id,
-        }
-      );
+        });
 
       if (skillReferenceValidation.isErr()) {
         return apiError(ctx, {

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -321,6 +321,26 @@ app.patch(
     ]);
 
     const featureFlags = await getFeatureFlags(auth);
+    const enableSkillReferences = featureFlags.includes("nested_skills");
+    if (enableSkillReferences) {
+      const skillReferenceValidation = SkillResource.validateSkillReferenceIds(
+        auth,
+        {
+          instructions: body.instructions,
+          parentSkillId: skill.id,
+        }
+      );
+
+      if (skillReferenceValidation.isErr()) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: skillReferenceValidation.error.message,
+          },
+        });
+      }
+    }
 
     // Validate file attachments if provided (gated behind sandbox_tools).
     let files: FileResource[] | undefined;
@@ -388,7 +408,7 @@ app.patch(
       name,
       reinforcement: body.reinforcement,
       requestedSpaceIds,
-      enableSkillReferences: featureFlags.includes("nested_skills"),
+      enableSkillReferences,
       userFacingDescription: body.userFacingDescription,
       ...(shouldActivate ? { status: "active" as const } : {}),
     });

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -320,10 +320,11 @@ app.patch(
       ...additionalRequestedSpaceIds,
     ]);
 
+    const featureFlags = await getFeatureFlags(auth);
+
     // Validate file attachments if provided (gated behind sandbox_tools).
     let files: FileResource[] | undefined;
     if (fileAttachments) {
-      const featureFlags = await getFeatureFlags(auth);
       if (
         !featureFlags.includes("sandbox_tools") &&
         fileAttachments.length > 0
@@ -387,6 +388,7 @@ app.patch(
       name,
       reinforcement: body.reinforcement,
       requestedSpaceIds,
+      enableSkillReferences: featureFlags.includes("nested_skills"),
       userFacingDescription: body.userFacingDescription,
       ...(shouldActivate ? { status: "active" as const } : {}),
     });

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -1,8 +1,10 @@
 import { Authenticator } from "@app/lib/auth";
 import { SkillMCPServerConfigurationModel } from "@app/lib/models/skill";
+import { SkillReferenceModel } from "@app/lib/models/skill/skill_reference";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { discoverToolsSkill } from "@app/lib/resources/skill/code_defined/discover_tools";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { serializeSkillTag } from "@app/lib/skills/format";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
@@ -523,6 +525,50 @@ describe("POST /api/w/:wId/skills", () => {
       responseData.skill.sId
     );
     expect(createdSkill).not.toBeNull();
+  });
+
+  it("creates skill references when nested skills is enabled", async () => {
+    const { auth, workspace } = await setupTest("admin");
+
+    await FeatureFlagFactory.basic(auth, "nested_skills");
+    const childSkill = await SkillFactory.create(auth, {
+      name: "Referenced Skill",
+    });
+    const skillReferenceTag = serializeSkillTag({
+      id: childSkill.sId,
+      icon: null,
+      name: childSkill.name,
+    });
+
+    const response = await postSkill(workspace, {
+      name: "Parent Skill",
+      agentFacingDescription: "To use with another skill",
+      userFacingDescription: "A skill with a nested reference",
+      instructions: `Start with ${skillReferenceTag}.`,
+      icon: "PuzzleIcon",
+      tools: [],
+      extendedSkillId: null,
+      attachedKnowledge: [],
+      instructionsHtml: null,
+    });
+
+    expect(response.status).toBe(200);
+
+    const createdSkill = await SkillResource.fetchById(
+      auth,
+      (await response.json()).skill.sId
+    );
+    expect(createdSkill).not.toBeNull();
+
+    await expect(
+      SkillReferenceModel.count({
+        where: {
+          workspaceId: workspace.id,
+          parentSkillId: createdSkill!.id,
+          childSkillId: childSkill.id,
+        },
+      })
+    ).resolves.toBe(1);
   });
 
   it("creates a skill configuration with additional requested spaces", async () => {

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -571,6 +571,37 @@ describe("POST /api/w/:wId/skills", () => {
     ).resolves.toBe(1);
   });
 
+  it("returns 400 for invalid nested skill references", async () => {
+    const { auth, workspace } = await setupTest("admin");
+
+    await FeatureFlagFactory.basic(auth, "nested_skills");
+    const invalidSkillReferenceTag = serializeSkillTag({
+      id: "not-a-skill-reference",
+      icon: null,
+      name: "Invalid Skill Reference",
+    });
+
+    const response = await postSkill(workspace, {
+      name: "Parent Skill",
+      agentFacingDescription: "To use with another skill",
+      userFacingDescription: "A skill with an invalid nested reference",
+      instructions: `Start with ${invalidSkillReferenceTag}.`,
+      icon: "PuzzleIcon",
+      tools: [],
+      extendedSkillId: null,
+      attachedKnowledge: [],
+      instructionsHtml: null,
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "Invalid skill reference ID: not-a-skill-reference",
+      },
+    });
+  });
+
   it("creates a skill configuration with additional requested spaces", async () => {
     const { auth, workspace, globalGroup } = await setupTest("admin");
 

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -334,12 +334,10 @@ app.post(
     const featureFlags = await getFeatureFlags(auth);
     const enableSkillReferences = featureFlags.includes("nested_skills");
     if (enableSkillReferences) {
-      const skillReferenceValidation = SkillResource.validateSkillReferenceIds(
-        auth,
-        {
+      const skillReferenceValidation =
+        SkillResource.getValidatedSkillReferenceModelIds(auth, {
           instructions: body.instructions,
-        }
-      );
+        });
 
       if (skillReferenceValidation.isErr()) {
         return apiError(ctx, {

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -331,10 +331,11 @@ app.post(
       });
     }
 
+    const featureFlags = await getFeatureFlags(auth);
+
     // Validate file attachments if provided (gated behind sandbox_tools).
     let files: FileResource[] | undefined;
     if (fileAttachments) {
-      const featureFlags = await getFeatureFlags(auth);
       if (
         !featureFlags.includes("sandbox_tools") &&
         fileAttachments.length > 0
@@ -414,6 +415,7 @@ app.post(
         mcpServerViews,
         attachedKnowledge: attachedKnowledgeWithDataSourceViews,
         fileAttachments: files,
+        enableSkillReferences: featureFlags.includes("nested_skills"),
       }
     );
 

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -332,6 +332,25 @@ app.post(
     }
 
     const featureFlags = await getFeatureFlags(auth);
+    const enableSkillReferences = featureFlags.includes("nested_skills");
+    if (enableSkillReferences) {
+      const skillReferenceValidation = SkillResource.validateSkillReferenceIds(
+        auth,
+        {
+          instructions: body.instructions,
+        }
+      );
+
+      if (skillReferenceValidation.isErr()) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: skillReferenceValidation.error.message,
+          },
+        });
+      }
+    }
 
     // Validate file attachments if provided (gated behind sandbox_tools).
     let files: FileResource[] | undefined;
@@ -415,7 +434,7 @@ app.post(
         mcpServerViews,
         attachedKnowledge: attachedKnowledgeWithDataSourceViews,
         fileAttachments: files,
-        enableSkillReferences: featureFlags.includes("nested_skills"),
+        enableSkillReferences,
       }
     );
 

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -666,6 +666,37 @@ describe("SkillResource", () => {
         })
       ).rejects.toThrow("Invalid skill reference ID: not-a-skill-reference");
     });
+
+    it("throws when syncing an out-of-workspace nested skill reference", async () => {
+      const skill = await SkillFactory.create(testContext.authenticator, {
+        name: "Skill With Out Of Workspace Reference",
+      });
+      const outOfWorkspaceSkillId = SkillResource.modelIdToSId({
+        id: skill.id + 1,
+        workspaceId: testContext.workspace.id + 1,
+      });
+      const outOfWorkspaceSkillReferenceTag = serializeSkillTag({
+        id: outOfWorkspaceSkillId,
+        icon: null,
+        name: "Out Of Workspace Skill Reference",
+      });
+
+      await expect(
+        skill.updateSkill(testContext.authenticator, {
+          name: skill.name,
+          agentFacingDescription: skill.agentFacingDescription,
+          userFacingDescription: skill.userFacingDescription,
+          instructions: `Use ${outOfWorkspaceSkillReferenceTag}.`,
+          icon: skill.icon,
+          mcpServerViews: [],
+          attachedKnowledge: [],
+          requestedSpaceIds: [],
+          enableSkillReferences: true,
+        })
+      ).rejects.toThrow(
+        `Skill reference ID does not belong to this workspace: ${outOfWorkspaceSkillId}`
+      );
+    });
   });
 
   describe("archive and restore", () => {

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -6,6 +6,7 @@ import { GroupResource } from "@app/lib/resources/group_resource";
 import type { SkillAttachedKnowledge } from "@app/lib/resources/skill/skill_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
+import { serializeSkillTag } from "@app/lib/skills/format";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
@@ -639,6 +640,31 @@ describe("SkillResource", () => {
       // sharedSpace kept because skill2 still requires it.
       expect(spaceIds).toContain(sharedSpace.id);
       expect(spaceIds).toContain(skill1OnlySpace.id);
+    });
+
+    it("throws when syncing an invalid nested skill reference", async () => {
+      const skill = await SkillFactory.create(testContext.authenticator, {
+        name: "Skill With Invalid Reference",
+      });
+      const invalidSkillReferenceTag = serializeSkillTag({
+        id: "not-a-skill-reference",
+        icon: null,
+        name: "Invalid Skill Reference",
+      });
+
+      await expect(
+        skill.updateSkill(testContext.authenticator, {
+          name: skill.name,
+          agentFacingDescription: skill.agentFacingDescription,
+          userFacingDescription: skill.userFacingDescription,
+          instructions: `Use ${invalidSkillReferenceTag}.`,
+          icon: skill.icon,
+          mcpServerViews: [],
+          attachedKnowledge: [],
+          requestedSpaceIds: [],
+          enableSkillReferences: true,
+        })
+      ).rejects.toThrow("Invalid skill reference ID: not-a-skill-reference");
     });
   });
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2328,7 +2328,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       return;
     }
 
-    const referencedSkills = await SkillConfigurationModel.findAll({
+    const referencedSkills = await this.model.findAll({
       where: {
         id: { [Op.in]: [...childSkillModelIds] },
         workspaceId: workspace.id,
@@ -3004,7 +3004,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       where: { workspaceId },
     });
 
-    await SkillConfigurationModel.destroy({
+    await this.model.destroy({
       where: { workspaceId },
     });
   }

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -424,18 +424,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           transaction,
         });
 
-      if (enableSkillReferences) {
-        await this.syncSkillReferences(
-          auth,
-          {
-            instructions: blob.instructions,
-            parentSkillId: skill.id,
-          },
-          { transaction }
-        );
-      }
-
-      return new this(this.model, skill.get(), {
+      const resource = new this(this.model, skill.get(), {
         dataSourceConfigurations,
         editorGroup,
         fileAttachments,
@@ -443,6 +432,16 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           view,
         })),
       });
+
+      if (enableSkillReferences) {
+        await resource.syncSkillReferences(
+          auth,
+          { instructions: blob.instructions },
+          { transaction }
+        );
+      }
+
+      return resource;
     });
   }
 
@@ -2220,14 +2219,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       );
 
       if (enableSkillReferences) {
-        await SkillResource.syncSkillReferences(
-          auth,
-          {
-            instructions,
-            parentSkillId: this.id,
-          },
-          { transaction }
-        );
+        await this.syncSkillReferences(auth, { instructions }, { transaction });
       }
 
       await this.updateMCPServerViews(auth, mcpServerViews, { transaction });
@@ -2277,18 +2269,17 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   /**
    * Persist the custom skills referenced by the skill instructions.
    */
-  private static async syncSkillReferences(
+  private async syncSkillReferences(
     auth: Authenticator,
     {
       instructions,
-      parentSkillId,
     }: {
       instructions: string;
-      parentSkillId: ModelId;
     },
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<void> {
     const workspace = auth.getNonNullableWorkspace();
+    const parentSkillId = this.id;
     const childSkillModelIds = new Set<ModelId>();
 
     for (const skillId of extractUniqueSkillIds(instructions)) {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -42,13 +42,13 @@ import type { SkillConfigurationFindOptions } from "@app/lib/resources/skill/typ
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import {
-  getResourceNameAndIdFromSId,
   getResourceIdFromSId,
+  getResourceNameAndIdFromSId,
   isResourceSId,
   makeSId,
 } from "@app/lib/resources/string_ids";
-import { extractUniqueSkillIds } from "@app/lib/skills/format";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { extractUniqueSkillIds } from "@app/lib/skills/format";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2266,7 +2266,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     await this.update({ lastReinforcementAnalysisAt: new Date() });
   }
 
-  private static getValidatedSkillReferenceModelIds(
+  static getValidatedSkillReferenceModelIds(
     auth: Authenticator,
     {
       instructions,
@@ -2302,28 +2302,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }
 
     return new Ok([...childSkillModelIds]);
-  }
-
-  static validateSkillReferenceIds(
-    auth: Authenticator,
-    {
-      instructions,
-      parentSkillId,
-    }: {
-      instructions: string;
-      parentSkillId?: ModelId;
-    }
-  ): Result<undefined, Error> {
-    const validation = this.getValidatedSkillReferenceModelIds(auth, {
-      instructions,
-      parentSkillId,
-    });
-
-    if (validation.isErr()) {
-      return validation;
-    }
-
-    return new Ok(undefined);
   }
 
   /**

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2266,6 +2266,66 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     await this.update({ lastReinforcementAnalysisAt: new Date() });
   }
 
+  private static getValidatedSkillReferenceModelIds(
+    auth: Authenticator,
+    {
+      instructions,
+      parentSkillId,
+    }: {
+      instructions: string;
+      parentSkillId?: ModelId;
+    }
+  ): Result<ModelId[], Error> {
+    const workspace = auth.getNonNullableWorkspace();
+    const childSkillModelIds = new Set<ModelId>();
+
+    for (const skillId of extractUniqueSkillIds(instructions)) {
+      const parsed = getResourceNameAndIdFromSId(skillId);
+
+      if (!parsed || parsed.resourceName !== "skill") {
+        return new Err(new Error(`Invalid skill reference ID: ${skillId}`));
+      }
+
+      if (parsed.workspaceModelId !== workspace.id) {
+        return new Err(
+          new Error(
+            `Skill reference ID does not belong to this workspace: ${skillId}`
+          )
+        );
+      }
+
+      if (parsed.resourceModelId === parentSkillId) {
+        continue;
+      }
+
+      childSkillModelIds.add(parsed.resourceModelId);
+    }
+
+    return new Ok([...childSkillModelIds]);
+  }
+
+  static validateSkillReferenceIds(
+    auth: Authenticator,
+    {
+      instructions,
+      parentSkillId,
+    }: {
+      instructions: string;
+      parentSkillId?: ModelId;
+    }
+  ): Result<undefined, Error> {
+    const validation = this.getValidatedSkillReferenceModelIds(auth, {
+      instructions,
+      parentSkillId,
+    });
+
+    if (validation.isErr()) {
+      return validation;
+    }
+
+    return new Ok(undefined);
+  }
+
   /**
    * Persist the custom skills referenced by the skill instructions.
    */
@@ -2280,24 +2340,17 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   ): Promise<void> {
     const workspace = auth.getNonNullableWorkspace();
     const parentSkillId = this.id;
-    const childSkillModelIds = new Set<ModelId>();
+    const childSkillModelIdsRes =
+      SkillResource.getValidatedSkillReferenceModelIds(auth, {
+        instructions,
+        parentSkillId,
+      });
 
-    for (const skillId of extractUniqueSkillIds(instructions)) {
-      const parsed = getResourceNameAndIdFromSId(skillId);
-
-      if (!parsed || parsed.resourceName !== "skill") {
-        throw new Error(`Invalid skill reference ID: ${skillId}`);
-      }
-
-      if (
-        parsed.workspaceModelId !== workspace.id ||
-        parsed.resourceModelId === parentSkillId
-      ) {
-        continue;
-      }
-
-      childSkillModelIds.add(parsed.resourceModelId);
+    if (childSkillModelIdsRes.isErr()) {
+      throw childSkillModelIdsRes.error;
     }
+
+    const childSkillModelIds = childSkillModelIdsRes.value;
 
     const existingReferences = await SkillReferenceModel.findAll({
       where: {
@@ -2307,7 +2360,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       transaction,
     });
 
-    if (childSkillModelIds.size === 0) {
+    if (childSkillModelIds.length === 0) {
       if (existingReferences.length > 0) {
         await SkillReferenceModel.destroy({
           where: {
@@ -2323,7 +2376,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     const referencedSkills = await this.model.findAll({
       where: {
-        id: { [Op.in]: [...childSkillModelIds] },
+        id: { [Op.in]: childSkillModelIds },
         workspaceId: workspace.id,
       },
       attributes: ["id"],

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2687,14 +2687,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           transaction,
         });
 
-        await SkillReferenceModel.destroy({
-          where: {
-            workspaceId: workspace.id,
-            [Op.or]: [{ parentSkillId: this.id }, { childSkillId: this.id }],
-          },
-          transaction,
-        });
-
         await SkillSuggestionModel.destroy({
           where: whereWorkspaceIdAndSkillId,
           transaction,
@@ -2997,10 +2989,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     });
 
     await SkillSuggestionModel.destroy({
-      where: { workspaceId },
-    });
-
-    await SkillReferenceModel.destroy({
       where: { workspaceId },
     });
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -138,10 +138,6 @@ type ConversationSkillCreationAttributes =
         }
     );
 
-type SkillReferenceSyncOptions = {
-  enabled: boolean;
-};
-
 function isSkillResourceWithVersion(
   skill: SkillResource
 ): skill is SkillResource & { version: number } {
@@ -367,13 +363,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       addCurrentUserAsEditor = true,
       attachedKnowledge = [],
       fileAttachments = [],
-      skillReferences,
+      enableSkillReferences = false,
     }: {
       mcpServerViews: MCPServerViewResource[];
       addCurrentUserAsEditor?: boolean;
       attachedKnowledge?: SkillAttachedKnowledge[];
       fileAttachments?: FileResource[];
-      skillReferences?: SkillReferenceSyncOptions;
+      enableSkillReferences?: boolean;
     }
   ): Promise<SkillResource> {
     const owner = auth.getNonNullableWorkspace();
@@ -428,7 +424,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           transaction,
         });
 
-      if (skillReferences?.enabled) {
+      if (enableSkillReferences) {
         await this.syncSkillReferences(
           auth,
           {
@@ -2170,7 +2166,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       source,
       sourceMetadata,
       status,
-      skillReferences,
+      enableSkillReferences = false,
       userFacingDescription,
     }: {
       agentFacingDescription: string;
@@ -2187,7 +2183,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       source?: SkillSourceType;
       sourceMetadata?: SkillSourceMetadata;
       status?: SkillStatus;
-      skillReferences?: SkillReferenceSyncOptions;
+      enableSkillReferences?: boolean;
       userFacingDescription: string;
     }
   ): Promise<void> {
@@ -2223,7 +2219,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         transaction
       );
 
-      if (skillReferences?.enabled) {
+      if (enableSkillReferences) {
         await SkillResource.syncSkillReferences(
           auth,
           {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2323,7 +2323,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       where: {
         id: { [Op.in]: [...childSkillModelIds] },
         workspaceId: workspace.id,
-        status: ["active", "archived", "suggested"],
       },
       attributes: ["id"],
       transaction,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2285,9 +2285,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     for (const skillId of extractUniqueSkillIds(instructions)) {
       const parsed = getResourceNameAndIdFromSId(skillId);
 
+      if (!parsed || parsed.resourceName !== "skill") {
+        throw new Error(`Invalid skill reference ID: ${skillId}`);
+      }
+
       if (
-        !parsed ||
-        parsed.resourceName !== "skill" ||
         parsed.workspaceModelId !== workspace.id ||
         parsed.resourceModelId === parentSkillId
       ) {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -424,7 +424,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           transaction,
         });
 
-      const resource = new this(this.model, skill.get(), {
+      const skillResource = new this(this.model, skill.get(), {
         dataSourceConfigurations,
         editorGroup,
         fileAttachments,
@@ -434,14 +434,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       });
 
       if (enableSkillReferences) {
-        await resource.syncSkillReferences(
+        await skillResource.syncSkillReferences(
           auth,
           { instructions: blob.instructions },
           { transaction }
         );
       }
 
-      return resource;
+      return skillResource;
     });
   }
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -42,10 +42,12 @@ import type { SkillConfigurationFindOptions } from "@app/lib/resources/skill/typ
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import {
+  getResourceNameAndIdFromSId,
   getResourceIdFromSId,
   isResourceSId,
   makeSId,
 } from "@app/lib/resources/string_ids";
+import { extractUniqueSkillIds } from "@app/lib/skills/format";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -135,6 +137,10 @@ type ConversationSkillCreationAttributes =
           agentConfigurationId: string;
         }
     );
+
+type SkillReferenceSyncOptions = {
+  enabled: boolean;
+};
 
 function isSkillResourceWithVersion(
   skill: SkillResource
@@ -361,11 +367,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       addCurrentUserAsEditor = true,
       attachedKnowledge = [],
       fileAttachments = [],
+      skillReferences,
     }: {
       mcpServerViews: MCPServerViewResource[];
       addCurrentUserAsEditor?: boolean;
       attachedKnowledge?: SkillAttachedKnowledge[];
       fileAttachments?: FileResource[];
+      skillReferences?: SkillReferenceSyncOptions;
     }
   ): Promise<SkillResource> {
     const owner = auth.getNonNullableWorkspace();
@@ -419,6 +427,17 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         await SkillDataSourceConfigurationModel.bulkCreate(toUpsert, {
           transaction,
         });
+
+      if (skillReferences?.enabled) {
+        await this.syncSkillReferences(
+          auth,
+          {
+            instructions: blob.instructions,
+            parentSkillId: skill.id,
+          },
+          { transaction }
+        );
+      }
 
       return new this(this.model, skill.get(), {
         dataSourceConfigurations,
@@ -2151,6 +2170,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       source,
       sourceMetadata,
       status,
+      skillReferences,
       userFacingDescription,
     }: {
       agentFacingDescription: string;
@@ -2167,6 +2187,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       source?: SkillSourceType;
       sourceMetadata?: SkillSourceMetadata;
       status?: SkillStatus;
+      skillReferences?: SkillReferenceSyncOptions;
       userFacingDescription: string;
     }
   ): Promise<void> {
@@ -2201,6 +2222,17 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         },
         transaction
       );
+
+      if (skillReferences?.enabled) {
+        await SkillResource.syncSkillReferences(
+          auth,
+          {
+            instructions,
+            parentSkillId: this.id,
+          },
+          { transaction }
+        );
+      }
 
       await this.updateMCPServerViews(auth, mcpServerViews, { transaction });
 
@@ -2244,6 +2276,105 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   async recordReinforcementAnalysisCompletion(): Promise<void> {
     await this.update({ lastReinforcementAnalysisAt: new Date() });
+  }
+
+  /**
+   * Persist the custom skills referenced by the skill instructions.
+   */
+  private static async syncSkillReferences(
+    auth: Authenticator,
+    {
+      instructions,
+      parentSkillId,
+    }: {
+      instructions: string;
+      parentSkillId: ModelId;
+    },
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<void> {
+    const workspace = auth.getNonNullableWorkspace();
+    const childSkillModelIds = new Set<ModelId>();
+
+    for (const skillId of extractUniqueSkillIds(instructions)) {
+      const parsed = getResourceNameAndIdFromSId(skillId);
+
+      if (
+        !parsed ||
+        parsed.resourceName !== "skill" ||
+        parsed.workspaceModelId !== workspace.id ||
+        parsed.resourceModelId === parentSkillId
+      ) {
+        continue;
+      }
+
+      childSkillModelIds.add(parsed.resourceModelId);
+    }
+
+    const existingReferences = await SkillReferenceModel.findAll({
+      where: {
+        workspaceId: workspace.id,
+        parentSkillId,
+      },
+      transaction,
+    });
+
+    if (childSkillModelIds.size === 0) {
+      if (existingReferences.length > 0) {
+        await SkillReferenceModel.destroy({
+          where: {
+            id: { [Op.in]: existingReferences.map((ref) => ref.id) },
+            workspaceId: workspace.id,
+          },
+          transaction,
+        });
+      }
+
+      return;
+    }
+
+    const referencedSkills = await SkillConfigurationModel.findAll({
+      where: {
+        id: { [Op.in]: [...childSkillModelIds] },
+        workspaceId: workspace.id,
+        status: ["active", "archived", "suggested"],
+      },
+      attributes: ["id"],
+      transaction,
+    });
+
+    const desiredChildSkillIds = new Set(
+      referencedSkills.map((skill) => skill.id)
+    );
+    const existingChildSkillIds = new Set(
+      existingReferences.map((ref) => ref.childSkillId)
+    );
+
+    const referencesToDelete = existingReferences.filter(
+      (ref) => !desiredChildSkillIds.has(ref.childSkillId)
+    );
+    if (referencesToDelete.length > 0) {
+      await SkillReferenceModel.destroy({
+        where: {
+          id: { [Op.in]: referencesToDelete.map((ref) => ref.id) },
+          workspaceId: workspace.id,
+        },
+        transaction,
+      });
+    }
+
+    const childSkillIdsToCreate = [...desiredChildSkillIds].filter(
+      (childSkillId) => !existingChildSkillIds.has(childSkillId)
+    );
+    if (childSkillIdsToCreate.length > 0) {
+      await SkillReferenceModel.bulkCreate(
+        childSkillIdsToCreate.map((childSkillId) => ({
+          workspaceId: workspace.id,
+          parentSkillId,
+          childSkillId,
+        })),
+        { transaction }
+      );
+    }
   }
 
   /**
@@ -2556,6 +2687,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           transaction,
         });
 
+        await SkillReferenceModel.destroy({
+          where: {
+            workspaceId: workspace.id,
+            [Op.or]: [{ parentSkillId: this.id }, { childSkillId: this.id }],
+          },
+          transaction,
+        });
+
         await SkillSuggestionModel.destroy({
           where: whereWorkspaceIdAndSkillId,
           transaction,
@@ -2858,6 +2997,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     });
 
     await SkillSuggestionModel.destroy({
+      where: { workspaceId },
+    });
+
+    await SkillReferenceModel.destroy({
       where: { workspaceId },
     });
 

--- a/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
@@ -430,6 +430,37 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
     ).resolves.toBe(0);
   });
 
+  it("returns 400 for out-of-workspace nested skill references", async () => {
+    const { req, res, skill, requestUserAuth, workspace } = await setupTest({
+      requestUserRole: "admin",
+      method: "PATCH",
+    });
+
+    await FeatureFlagFactory.basic(requestUserAuth, "nested_skills");
+    const outOfWorkspaceSkillId = SkillResource.modelIdToSId({
+      id: skill.id + 1,
+      workspaceId: workspace.id + 1,
+    });
+    const outOfWorkspaceSkillReferenceTag = serializeSkillTag({
+      id: outOfWorkspaceSkillId,
+      icon: null,
+      name: "Other Workspace Skill",
+    });
+
+    req.body = makePatchSkillBody(skill, {
+      instructions: `Use ${outOfWorkspaceSkillReferenceTag}.`,
+    });
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: `Skill reference ID does not belong to this workspace: ${outOfWorkspaceSkillId}`,
+      },
+    });
+  });
+
   it("should update requestedSpaceIds when adding a tool from a new space", async () => {
     const { req, res, skill, workspace, requestUser, requestUserAuth } =
       await setupTest({

--- a/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
@@ -5,8 +5,8 @@ import {
 } from "@app/lib/models/skill";
 import { SkillReferenceModel } from "@app/lib/models/skill/skill_reference";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import { serializeSkillTag } from "@app/lib/skills/format";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import { serializeSkillTag } from "@app/lib/skills/format";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";

--- a/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
@@ -3,7 +3,9 @@ import {
   SkillFileAttachmentModel,
   SkillVersionModel,
 } from "@app/lib/models/skill";
+import { SkillReferenceModel } from "@app/lib/models/skill/skill_reference";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { serializeSkillTag } from "@app/lib/skills/format";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
@@ -16,7 +18,9 @@ import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory"
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { NextApiRequest, NextApiResponse } from "next";
 import type { RequestMethod } from "node-mocks-http";
+import { createMocks } from "node-mocks-http";
 import type { WhereOptions } from "sequelize";
 import { describe, expect, it } from "vitest";
 
@@ -125,6 +129,42 @@ async function setupTest(
     globalGroup,
     workspace,
   };
+}
+
+function makePatchSkillBody(
+  skill: SkillResource,
+  overrides: Partial<{
+    instructions: string;
+    instructionsHtml: string | null;
+  }> = {}
+) {
+  return {
+    name: skill.name,
+    agentFacingDescription: skill.agentFacingDescription,
+    userFacingDescription: skill.userFacingDescription,
+    instructions: skill.instructions,
+    icon: skill.icon,
+    tools: [],
+    attachedKnowledge: [],
+    instructionsHtml: skill.instructionsHtml,
+    ...overrides,
+  };
+}
+
+function createPatchSkillRequest({
+  body,
+  skillId,
+  workspaceId,
+}: {
+  body: ReturnType<typeof makePatchSkillBody>;
+  skillId: string;
+  workspaceId: string;
+}) {
+  return createMocks<NextApiRequest, NextApiResponse>({
+    method: "PATCH",
+    query: { wId: workspaceId, sId: skillId },
+    body,
+  });
 }
 
 describe("GET /api/w/[wId]/skills/[sId]", () => {
@@ -316,6 +356,78 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
     );
     expect(updatedSkill).not.toBeNull();
     expect(updatedSkill?.agentFacingDescription).toBe(newDescription);
+  });
+
+  it("syncs nested skill references when the feature is enabled", async () => {
+    const { req, res, skill, requestUserAuth, workspace } = await setupTest({
+      requestUserRole: "admin",
+      method: "PATCH",
+    });
+
+    const childSkill = await SkillFactory.create(requestUserAuth, {
+      name: "Referenced Skill",
+    });
+    const skillReferenceTag = serializeSkillTag({
+      id: childSkill.sId,
+      icon: null,
+      name: childSkill.name,
+    });
+    const instructionsWithReference = `Use ${skillReferenceTag} for deeper analysis.`;
+
+    req.body = makePatchSkillBody(skill, {
+      instructions: instructionsWithReference,
+    });
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    await expect(
+      SkillReferenceModel.count({
+        where: {
+          workspaceId: workspace.id,
+          parentSkillId: skill.id,
+        },
+      })
+    ).resolves.toBe(0);
+
+    await FeatureFlagFactory.basic(requestUserAuth, "nested_skills");
+
+    const { req: enabledReq, res: enabledRes } = createPatchSkillRequest({
+      workspaceId: workspace.sId,
+      skillId: skill.sId,
+      body: makePatchSkillBody(skill, {
+        instructions: instructionsWithReference,
+      }),
+    });
+
+    await handler(enabledReq, enabledRes);
+    expect(enabledRes._getStatusCode()).toBe(200);
+    await expect(
+      SkillReferenceModel.count({
+        where: {
+          workspaceId: workspace.id,
+          parentSkillId: skill.id,
+          childSkillId: childSkill.id,
+        },
+      })
+    ).resolves.toBe(1);
+
+    const { req: removeReq, res: removeRes } = createPatchSkillRequest({
+      workspaceId: workspace.sId,
+      skillId: skill.sId,
+      body: makePatchSkillBody(skill, {
+        instructions: "No nested skill references here.",
+      }),
+    });
+
+    await handler(removeReq, removeRes);
+    expect(removeRes._getStatusCode()).toBe(200);
+    await expect(
+      SkillReferenceModel.count({
+        where: {
+          workspaceId: workspace.id,
+          parentSkillId: skill.id,
+        },
+      })
+    ).resolves.toBe(0);
   });
 
   it("should update requestedSpaceIds when adding a tool from a new space", async () => {

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -298,10 +298,11 @@ async function handler(
         ...additionalRequestedSpaceIds,
       ]);
 
+      const featureFlags = await getFeatureFlags(auth);
+
       // Validate file attachments if provided (gated behind sandbox_tools).
       let files: FileResource[] | undefined;
       if (fileAttachments) {
-        const featureFlags = await getFeatureFlags(auth);
         if (
           !featureFlags.includes("sandbox_tools") &&
           fileAttachments.length > 0
@@ -365,6 +366,9 @@ async function handler(
         name,
         reinforcement: body.reinforcement,
         requestedSpaceIds,
+        skillReferences: {
+          enabled: featureFlags.includes("nested_skills"),
+        },
         userFacingDescription: body.userFacingDescription,
         ...(shouldActivate ? { status: "active" as const } : {}),
       });

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -302,7 +302,7 @@ async function handler(
       const enableSkillReferences = featureFlags.includes("nested_skills");
       if (enableSkillReferences) {
         const skillReferenceValidation =
-          SkillResource.validateSkillReferenceIds(auth, {
+          SkillResource.getValidatedSkillReferenceModelIds(auth, {
             instructions: body.instructions,
             parentSkillId: skill.id,
           });

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -366,9 +366,7 @@ async function handler(
         name,
         reinforcement: body.reinforcement,
         requestedSpaceIds,
-        skillReferences: {
-          enabled: featureFlags.includes("nested_skills"),
-        },
+        enableSkillReferences: featureFlags.includes("nested_skills"),
         userFacingDescription: body.userFacingDescription,
         ...(shouldActivate ? { status: "active" as const } : {}),
       });

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -299,6 +299,24 @@ async function handler(
       ]);
 
       const featureFlags = await getFeatureFlags(auth);
+      const enableSkillReferences = featureFlags.includes("nested_skills");
+      if (enableSkillReferences) {
+        const skillReferenceValidation =
+          SkillResource.validateSkillReferenceIds(auth, {
+            instructions: body.instructions,
+            parentSkillId: skill.id,
+          });
+
+        if (skillReferenceValidation.isErr()) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: skillReferenceValidation.error.message,
+            },
+          });
+        }
+      }
 
       // Validate file attachments if provided (gated behind sandbox_tools).
       let files: FileResource[] | undefined;
@@ -366,7 +384,7 @@ async function handler(
         name,
         reinforcement: body.reinforcement,
         requestedSpaceIds,
-        enableSkillReferences: featureFlags.includes("nested_skills"),
+        enableSkillReferences,
         userFacingDescription: body.userFacingDescription,
         ...(shouldActivate ? { status: "active" as const } : {}),
       });

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -637,6 +637,38 @@ describe("POST /api/w/[wId]/skills", () => {
     ).resolves.toBe(1);
   });
 
+  it("returns 400 for invalid nested skill references", async () => {
+    const { auth, req, res } = await setupTest("POST", "admin");
+
+    await FeatureFlagFactory.basic(auth, "nested_skills");
+    const invalidSkillReferenceTag = serializeSkillTag({
+      id: "not-a-skill-reference",
+      icon: null,
+      name: "Invalid Skill Reference",
+    });
+
+    req.body = {
+      name: "Parent Skill",
+      agentFacingDescription: "To use with another skill",
+      userFacingDescription: "A skill with an invalid nested reference",
+      instructions: `Start with ${invalidSkillReferenceTag}.`,
+      icon: "PuzzleIcon",
+      tools: [],
+      extendedSkillId: null,
+      attachedKnowledge: [],
+      instructionsHtml: null,
+    };
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "Invalid skill reference ID: not-a-skill-reference",
+      },
+    });
+  });
+
   it("creates a skill configuration with additional requested spaces", async () => {
     const { auth, req, res, workspace, globalGroup } = await setupTest(
       "POST",

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -1,8 +1,10 @@
 import { Authenticator } from "@app/lib/auth";
 import { SkillMCPServerConfigurationModel } from "@app/lib/models/skill";
+import { SkillReferenceModel } from "@app/lib/models/skill/skill_reference";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { discoverToolsSkill } from "@app/lib/resources/skill/code_defined/discover_tools";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { serializeSkillTag } from "@app/lib/skills/format";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
@@ -588,6 +590,51 @@ describe("POST /api/w/[wId]/skills", () => {
       responseData.skill.sId
     );
     expect(createdSkill).not.toBeNull();
+  });
+
+  it("creates skill references when nested skills is enabled", async () => {
+    const { auth, req, res, workspace } = await setupTest("POST", "admin");
+
+    await FeatureFlagFactory.basic(auth, "nested_skills");
+    const childSkill = await SkillFactory.create(auth, {
+      name: "Referenced Skill",
+    });
+    const skillReferenceTag = serializeSkillTag({
+      id: childSkill.sId,
+      icon: null,
+      name: childSkill.name,
+    });
+
+    req.body = {
+      name: "Parent Skill",
+      agentFacingDescription: "To use with another skill",
+      userFacingDescription: "A skill with a nested reference",
+      instructions: `Start with ${skillReferenceTag}.`,
+      icon: "PuzzleIcon",
+      tools: [],
+      extendedSkillId: null,
+      attachedKnowledge: [],
+      instructionsHtml: null,
+    };
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+
+    const createdSkill = await SkillResource.fetchById(
+      auth,
+      res._getJSONData().skill.sId
+    );
+    expect(createdSkill).not.toBeNull();
+
+    await expect(
+      SkillReferenceModel.count({
+        where: {
+          workspaceId: workspace.id,
+          parentSkillId: createdSkill!.id,
+          childSkillId: childSkill.id,
+        },
+      })
+    ).resolves.toBe(1);
   });
 
   it("creates a skill configuration with additional requested spaces", async () => {

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -333,6 +333,23 @@ async function handler(
       }
 
       const featureFlags = await getFeatureFlags(auth);
+      const enableSkillReferences = featureFlags.includes("nested_skills");
+      if (enableSkillReferences) {
+        const skillReferenceValidation =
+          SkillResource.validateSkillReferenceIds(auth, {
+            instructions: body.instructions,
+          });
+
+        if (skillReferenceValidation.isErr()) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: skillReferenceValidation.error.message,
+            },
+          });
+        }
+      }
 
       // Validate file attachments if provided (gated behind sandbox_tools).
       let files: FileResource[] | undefined;
@@ -416,7 +433,7 @@ async function handler(
           mcpServerViews,
           attachedKnowledge: attachedKnowledgeWithDataSourceViews,
           fileAttachments: files,
-          enableSkillReferences: featureFlags.includes("nested_skills"),
+          enableSkillReferences,
         }
       );
 

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -332,10 +332,11 @@ async function handler(
         });
       }
 
+      const featureFlags = await getFeatureFlags(auth);
+
       // Validate file attachments if provided (gated behind sandbox_tools).
       let files: FileResource[] | undefined;
       if (fileAttachments) {
-        const featureFlags = await getFeatureFlags(auth);
         if (
           !featureFlags.includes("sandbox_tools") &&
           fileAttachments.length > 0
@@ -415,6 +416,9 @@ async function handler(
           mcpServerViews,
           attachedKnowledge: attachedKnowledgeWithDataSourceViews,
           fileAttachments: files,
+          skillReferences: {
+            enabled: featureFlags.includes("nested_skills"),
+          },
         }
       );
 

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -336,7 +336,7 @@ async function handler(
       const enableSkillReferences = featureFlags.includes("nested_skills");
       if (enableSkillReferences) {
         const skillReferenceValidation =
-          SkillResource.validateSkillReferenceIds(auth, {
+          SkillResource.getValidatedSkillReferenceModelIds(auth, {
             instructions: body.instructions,
           });
 

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -416,9 +416,7 @@ async function handler(
           mcpServerViews,
           attachedKnowledge: attachedKnowledgeWithDataSourceViews,
           fileAttachments: files,
-          skillReferences: {
-            enabled: featureFlags.includes("nested_skills"),
-          },
+          enableSkillReferences: featureFlags.includes("nested_skills"),
         }
       );
 


### PR DESCRIPTION
## Description

This PR makes saved Skill Builder instructions populate `SkillReferenceModel` for nested skill references, behind `nested_skills`.

On skill create/update, we parse serialized `<skill ... />` tags from the instructions and sync the reference rows so they are created, deduped, and removed as instructions change. The scope is persistence only: rendering and slash-dropdown insertion stay in the surrounding PRs.

## Tests

- Updated skill create/update API tests.

## Risk

- Low. Behind feature flag and limited to maintaining reference rows from saved skill instructions.

## Deploy Plan

- Deploy front.