### PR TITLE
[front] feat: show skill references in Manage Skills

### DIFF
--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -188,6 +188,28 @@ export function ManageSkillsPage() {
     [setSkillIdParam]
   );
 
+  const knownSkillsById = useMemo(
+    () =>
+      new Map(
+        [...activeSkills, ...archivedSkills, ...suggestedSkills].map(
+          (skill) => [skill.sId, skill]
+        )
+      ),
+    [activeSkills, archivedSkills, suggestedSkills]
+  );
+
+  const handleUsedBySkillSelect = useCallback(
+    (skillId: string) => {
+      const skill = knownSkillsById.get(skillId);
+      if (skill) {
+        handleSkillSelect(skill);
+      } else {
+        setSkillIdParam(skillId);
+      }
+    },
+    [handleSkillSelect, knownSkillsById, setSkillIdParam]
+  );
+
   const visibleTabs = useMemo(() => {
     return !isEmptyString(skillSearch)
       ? [SKILL_SEARCH_TAB]
@@ -322,6 +344,7 @@ export function ManageSkillsPage() {
                   skills={skillsByTab[activeTab]}
                   onSkillClick={handleSkillSelect}
                   onAgentClick={setAgentId}
+                  onUsedBySkillClick={handleUsedBySkillSelect}
                 />
               </>
             )}

--- a/front/components/skills/ArchiveSkillDialog.tsx
+++ b/front/components/skills/ArchiveSkillDialog.tsx
@@ -1,5 +1,6 @@
 import { useArchiveSkill } from "@app/lib/swr/skill_configurations";
 import type { SkillWithoutInstructionsAndToolsWithRelationsType } from "@app/types/assistant/skill_configuration";
+import { removeNulls } from "@app/types/shared/utils/general";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
@@ -29,6 +30,15 @@ export function ArchiveSkillDialog({
   const [isArchiving, setIsArchiving] = useState(false);
   const doArchive = useArchiveSkill({ owner, skill: skill });
   const agentsUsageCount = skill.relations.usage.agents.length;
+  const skillsUsageCount = skill.relations.usage.skills?.length ?? 0;
+  const usageLabels = removeNulls([
+    agentsUsageCount > 0
+      ? `${agentsUsageCount} agent${pluralize(agentsUsageCount)}`
+      : null,
+    skillsUsageCount > 0
+      ? `${skillsUsageCount} skill${pluralize(skillsUsageCount)}`
+      : null,
+  ]);
 
   return (
     <Dialog
@@ -46,9 +56,9 @@ export function ArchiveSkillDialog({
             <div>
               This will archive the skill{" "}
               <span className="font-bold">{skill?.name}</span>{" "}
-              {agentsUsageCount === 0
+              {usageLabels.length === 0
                 ? "for everyone."
-                : `used by ${agentsUsageCount} agent${pluralize(agentsUsageCount)}.`}
+                : `used by ${usageLabels.join(" and ")}.`}
             </div>
           </DialogDescription>
         </DialogHeader>

--- a/front/components/skills/ArchiveSkillDialog.tsx
+++ b/front/components/skills/ArchiveSkillDialog.tsx
@@ -28,6 +28,7 @@ export function ArchiveSkillDialog({
 }: DeleteSkillDialogProps) {
   const [isArchiving, setIsArchiving] = useState(false);
   const doArchive = useArchiveSkill({ owner, skill: skill });
+  const agentsUsageCount = skill.relations.usage.agents.length;
 
   return (
     <Dialog
@@ -45,9 +46,9 @@ export function ArchiveSkillDialog({
             <div>
               This will archive the skill{" "}
               <span className="font-bold">{skill?.name}</span>{" "}
-              {skill.relations.usage.count === 0
+              {agentsUsageCount === 0
                 ? "for everyone."
-                : `used by ${skill.relations.usage.count} agent${pluralize(skill.relations.usage.count)}.`}
+                : `used by ${agentsUsageCount} agent${pluralize(agentsUsageCount)}.`}
             </div>
           </DialogDescription>
         </DialogHeader>

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -19,7 +19,7 @@ import {
   PencilSquareIcon,
   TrashIcon,
 } from "@dust-tt/sparkle";
-import type { CellContext } from "@tanstack/react-table";
+import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 
 type RowData = {
@@ -92,20 +92,21 @@ const editorsColumn = {
 const usedByColumn = (
   onAgentClick: (agentId: string) => void,
   onUsedBySkillClick: (skillId: string) => void
-) => ({
-  header: "Used by",
+): ColumnDef<RowData, number> => ({
+  id: "usedBy",
+  header: () => <div className="flex w-full justify-center">Used by</div>,
   accessorFn: (row: RowData) => row.usage?.count ?? 0,
   cell: (info: CellContext<RowData, number>) => (
-    <DataTable.CellContent className="justify-center">
+    <div className="flex h-12 w-full items-center justify-center">
       <UsedByButton
         usage={info.row.original.usage}
         onItemClick={onAgentClick}
         onSkillClick={onUsedBySkillClick}
       />
-    </DataTable.CellContent>
+    </div>
   ),
   meta: {
-    className: "hidden text-center @sm:w-24 @sm:table-cell",
+    className: "hidden px-0 @sm:w-24 @sm:table-cell",
   },
 });
 

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -6,8 +6,10 @@ import { getSkillAvatarIcon } from "@app/lib/skill";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
-import type { SkillWithoutInstructionsAndToolsWithRelationsType } from "@app/types/assistant/skill_configuration";
-import type { AgentsUsageType } from "@app/types/data_source";
+import type {
+  SkillUsageType,
+  SkillWithoutInstructionsAndToolsWithRelationsType,
+} from "@app/types/assistant/skill_configuration";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import type { MenuItem } from "@dust-tt/sparkle";
 import {
@@ -25,7 +27,7 @@ type RowData = {
   icon: string | null;
   description: string;
   editors: UserType[] | null;
-  usage: AgentsUsageType;
+  usage: SkillUsageType;
   updatedAt: number | null;
   createdAt: number | null;
   onClick: () => void;
@@ -87,14 +89,19 @@ const editorsColumn = {
   },
 };
 
-const usedByColumn = (onAgentClick: (agentId: string) => void) => ({
+const usedByColumn = (
+  onAgentClick: (agentId: string) => void,
+  onUsedBySkillClick: (skillId: string) => void
+) => ({
   header: "Used by",
-  accessorFn: (row: RowData) => row.usage?.count ?? 0,
+  accessorFn: (row: RowData) =>
+    (row.usage?.count ?? 0) + (row.usage.skills?.length ?? 0),
   cell: (info: CellContext<RowData, number>) => (
     <DataTable.CellContent>
       <UsedByButton
         usage={info.row.original.usage}
         onItemClick={onAgentClick}
+        onSkillClick={onUsedBySkillClick}
       />
     </DataTable.CellContent>
   ),
@@ -129,7 +136,10 @@ const menuColumn = {
   },
 };
 
-const getTableColumns = (onAgentClick: (agentId: string) => void) => {
+const getTableColumns = (
+  onAgentClick: (agentId: string) => void,
+  onUsedBySkillClick: (skillId: string) => void
+) => {
   /**
    * Columns order:
    * - Name (always)
@@ -141,7 +151,7 @@ const getTableColumns = (onAgentClick: (agentId: string) => void) => {
 
   return [
     nameColumn,
-    usedByColumn(onAgentClick),
+    usedByColumn(onAgentClick, onUsedBySkillClick),
     editorsColumn,
     lastEditedColumn,
     menuColumn,
@@ -155,6 +165,7 @@ type SkillsTableProps = {
     skill: SkillWithoutInstructionsAndToolsWithRelationsType
   ) => void;
   onAgentClick: (agentId: string) => void;
+  onUsedBySkillClick: (skillId: string) => void;
 };
 
 export function SkillsTable({
@@ -162,6 +173,7 @@ export function SkillsTable({
   owner,
   onSkillClick,
   onAgentClick,
+  onUsedBySkillClick,
 }: SkillsTableProps) {
   const router = useAppRouter();
   const { pagination, setPagination } = usePaginationFromUrl({});
@@ -237,7 +249,7 @@ export function SkillsTable({
             : [],
       })),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- router is not stable, mutating the skills list which prevent pagination to work
-    [skills, onSkillClick, owner.sId]
+    [skills, onSkillClick, onUsedBySkillClick, owner.sId]
   );
 
   if (rows.length === 0) {
@@ -259,7 +271,7 @@ export function SkillsTable({
       <DataTable
         className="relative"
         data={rows}
-        columns={getTableColumns(onAgentClick)}
+        columns={getTableColumns(onAgentClick, onUsedBySkillClick)}
         pagination={pagination}
         setPagination={setPagination}
       />

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -96,7 +96,7 @@ const usedByColumn = (
   header: "Used by",
   accessorFn: (row: RowData) => row.usage?.count ?? 0,
   cell: (info: CellContext<RowData, number>) => (
-    <DataTable.CellContent>
+    <DataTable.CellContent className="justify-center">
       <UsedByButton
         usage={info.row.original.usage}
         onItemClick={onAgentClick}
@@ -105,7 +105,7 @@ const usedByColumn = (
     </DataTable.CellContent>
   ),
   meta: {
-    className: "hidden @sm:w-24 @sm:table-cell",
+    className: "hidden text-center @sm:w-24 @sm:table-cell",
   },
 });
 

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -94,8 +94,7 @@ const usedByColumn = (
   onUsedBySkillClick: (skillId: string) => void
 ) => ({
   header: "Used by",
-  accessorFn: (row: RowData) =>
-    (row.usage?.count ?? 0) + (row.usage.skills?.length ?? 0),
+  accessorFn: (row: RowData) => row.usage?.count ?? 0,
   cell: (info: CellContext<RowData, number>) => (
     <DataTable.CellContent>
       <UsedByButton

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -106,7 +106,7 @@ const usedByColumn = (
     </div>
   ),
   meta: {
-    className: "hidden px-0 @sm:w-24 @sm:table-cell",
+    className: "hidden px-0 @sm:w-32 @sm:table-cell",
   },
 });
 

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -52,9 +52,6 @@ function UsedByButtonIcon({
           </span>
         </span>
       )}
-      {hasAgents && hasSkills && (
-        <span className="h-1 w-1 rounded-full bg-muted-foreground/30" />
-      )}
       {hasSkills && (
         <span className="inline-flex h-5 items-center gap-1">
           <PuzzleIcon className="h-4 w-4 shrink-0" />

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -8,6 +8,7 @@ import { removeNulls } from "@app/types/shared/utils/general";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import {
   Avatar,
+  Button,
   ChevronDownIcon,
   DropdownMenu,
   DropdownMenuContent,
@@ -108,9 +109,6 @@ interface UsedByButtonProps {
   onSkillClick?: (skillId: string) => void;
 }
 
-const USED_BY_TRIGGER_CLASS_NAME =
-  "inline-flex h-7 select-none items-center justify-center whitespace-nowrap rounded-full px-2.5 text-muted-foreground transition-colors hover:bg-muted-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset disabled:cursor-default disabled:text-primary-400 disabled:hover:bg-transparent dark:text-muted-foreground-night dark:hover:bg-muted-background-night dark:hover:text-foreground-night dark:disabled:text-primary-400-night";
-
 export const UsedByButton = ({
   usage,
   onItemClick,
@@ -133,14 +131,17 @@ export const UsedByButton = ({
 
   if (totalCount === 0) {
     return (
-      <button
-        type="button"
-        className={USED_BY_TRIGGER_CLASS_NAME}
+      <Button
+        icon={
+          <UsedByButtonIcon agentCount={0} skillCount={0} showChevron={false} />
+        }
+        variant="ghost-secondary"
+        isSelect={false}
+        size="xs"
+        isRounded
         aria-label="Used by 0 agents"
         disabled
-      >
-        <UsedByButtonIcon agentCount={0} skillCount={0} showChevron={false} />
-      </button>
+      />
     );
   }
 
@@ -206,20 +207,23 @@ export const UsedByButton = ({
       }}
     >
       <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          className={USED_BY_TRIGGER_CLASS_NAME}
+        <Button
+          icon={
+            <UsedByButtonIcon
+              agentCount={agentCount}
+              skillCount={skillCount}
+              showChevron
+            />
+          }
+          variant="ghost-secondary"
+          isSelect={false}
+          size="xs"
+          isRounded
           aria-label={`Used by ${usageLabel}`}
           onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
             e.stopPropagation();
           }}
-        >
-          <UsedByButtonIcon
-            agentCount={agentCount}
-            skillCount={skillCount}
-            showChevron
-          />
-        </button>
+        />
       </DropdownMenuTrigger>
       <DropdownMenuContent
         className="h-96 w-72"

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -6,6 +6,7 @@ import type {
 import {
   Avatar,
   Button,
+  ChevronDownIcon,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -29,21 +30,31 @@ function SkillDropdownIcon({ icon }: SkillDropdownIconProps) {
 
 interface UsedByButtonIconProps {
   count: number;
+  showChevron: boolean;
 }
 
-function UsedByButtonIcon({ count }: UsedByButtonIconProps) {
+function UsedByButtonIcon({ count, showChevron }: UsedByButtonIconProps) {
   return (
-    <span className="inline-flex h-4 items-center justify-center gap-1 leading-none">
-      <span className="inline-flex h-4 items-center gap-0.5">
-        <RobotIcon className="h-3.5 w-3.5 shrink-0" />
-        <span className="inline-flex h-3.5 items-center text-xs leading-none">
-          /
+    <span className="relative inline-flex h-4 w-20 items-center justify-center leading-none">
+      <span className="inline-flex h-4 items-center justify-center gap-1 leading-none">
+        <span className="inline-flex h-4 items-center gap-0.5">
+          <RobotIcon className="h-3.5 w-3.5 shrink-0" />
+          <span className="inline-flex h-3.5 items-center text-xs leading-none">
+            /
+          </span>
+          <PuzzleIcon className="h-3.5 w-3.5 shrink-0" />
         </span>
-        <PuzzleIcon className="h-3.5 w-3.5 shrink-0" />
+        <span className="inline-flex h-4 items-center text-xs leading-none tabular-nums">
+          {count}
+        </span>
       </span>
-      <span className="inline-flex h-4 items-center text-xs leading-none tabular-nums">
-        {count}
-      </span>
+      <ChevronDownIcon
+        className={
+          showChevron
+            ? "absolute right-0 h-4 w-4 shrink-0"
+            : "invisible absolute right-0 h-4 w-4 shrink-0"
+        }
+      />
     </span>
   );
 }
@@ -67,10 +78,11 @@ export const UsedByButton = ({
   if (totalCount === 0) {
     return (
       <Button
-        icon={<UsedByButtonIcon count={0} />}
+        icon={<UsedByButtonIcon count={0} showChevron={false} />}
         variant="ghost-secondary"
         isSelect={false}
         size="xs"
+        className="px-1"
         aria-label="0 uses"
         disabled
       />
@@ -121,10 +133,11 @@ export const UsedByButton = ({
     >
       <DropdownMenuTrigger asChild>
         <Button
-          icon={<UsedByButtonIcon count={totalCount} />}
+          icon={<UsedByButtonIcon count={totalCount} showChevron />}
           variant="ghost-secondary"
-          isSelect
+          isSelect={false}
           size="xs"
+          className="px-1"
           aria-label={`${totalCount} uses`}
           onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
             e.stopPropagation();

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -43,7 +43,7 @@ function UsedByButtonIcon({
   const hasSkills = skillCount > 0;
 
   return (
-    <span className="inline-flex h-5 items-center justify-center gap-1.5 leading-none">
+    <span className="mx-0.5 inline-flex h-5 items-center justify-center gap-1.5 leading-none">
       {(hasAgents || !hasSkills) && (
         <span className="inline-flex h-5 items-center gap-1">
           <RobotIcon className="h-4 w-4 shrink-0" />
@@ -105,7 +105,6 @@ export const UsedByButton = ({
         variant="ghost-secondary"
         isSelect={false}
         size="xs"
-        className="px-2"
         aria-label="Used by 0 agents"
         disabled
       />
@@ -164,7 +163,6 @@ export const UsedByButton = ({
           variant="ghost-secondary"
           isSelect={false}
           size="xs"
-          className="px-2"
           aria-label={`Used by ${usageLabel}`}
           onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
             e.stopPropagation();

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -77,7 +77,7 @@ function UsedByButtonIcon({
   const hasSkills = skillCount > 0;
 
   return (
-    <span className="inline-flex h-5 items-center justify-center gap-1.5 leading-none">
+    <span className="mx-0.5 flex h-5 items-center justify-center gap-1.5 leading-none">
       {(hasAgents || !hasSkills) && (
         <span className="inline-flex h-5 items-center gap-1">
           <RobotIcon className="h-4 w-4 shrink-0" />
@@ -96,7 +96,9 @@ function UsedByButtonIcon({
       )}
       <ChevronDownIcon
         className={
-          showChevron ? "h-4 w-4 shrink-0" : "invisible h-4 w-4 shrink-0"
+          showChevron
+            ? "-mr-px h-4 w-4 shrink-0 text-faint"
+            : "invisible -mr-px h-4 w-4 shrink-0 text-faint"
         }
       />
     </span>
@@ -139,6 +141,7 @@ export const UsedByButton = ({
         isSelect={false}
         size="xs"
         isRounded
+        className="border-0 hover:bg-muted-background hover:text-foreground dark:hover:bg-muted-background-night dark:hover:text-foreground-night"
         aria-label="Used by 0 agents"
         disabled
       />
@@ -219,6 +222,7 @@ export const UsedByButton = ({
           isSelect={false}
           size="xs"
           isRounded
+          className="border-0 hover:bg-muted-background hover:text-foreground dark:hover:bg-muted-background-night dark:hover:text-foreground-night"
           aria-label={`Used by ${usageLabel}`}
           onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
             e.stopPropagation();

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -3,6 +3,7 @@ import type {
   SkillUsageType,
   UsedBySkillType,
 } from "@app/types/assistant/skill_configuration";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import {
   Avatar,
   Button,
@@ -17,6 +18,38 @@ import {
   RobotIcon,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
+
+type UsedByDropdownItem =
+  | {
+      kind: "agent";
+      agent: SkillUsageType["agents"][number];
+    }
+  | {
+      kind: "skill";
+      skill: UsedBySkillType;
+    };
+
+function getUsedByDropdownItemName(item: UsedByDropdownItem) {
+  switch (item.kind) {
+    case "agent":
+      return item.agent.name;
+    case "skill":
+      return item.skill.name;
+    default:
+      return assertNever(item);
+  }
+}
+
+function getUsedByDropdownItemId(item: UsedByDropdownItem) {
+  switch (item.kind) {
+    case "agent":
+      return item.agent.sId;
+    case "skill":
+      return item.skill.sId;
+    default:
+      return assertNever(item);
+  }
+}
 
 interface SkillDropdownIconProps {
   icon: string | null;
@@ -112,14 +145,30 @@ export const UsedByButton = ({
   }
 
   const query = searchText.toLowerCase();
-  const filteredAgents =
-    query.length === 0
-      ? agents
-      : agents.filter((a) => a.name.toLowerCase().includes(query));
-  const filteredSkills =
-    query.length === 0
-      ? skills
-      : skills.filter((skill) => skill.name.toLowerCase().includes(query));
+  const dropdownItems: UsedByDropdownItem[] = [
+    ...agents.map((agent) => ({ kind: "agent" as const, agent })),
+    ...skills.map((skill) => ({ kind: "skill" as const, skill })),
+  ]
+    .filter(
+      (item) =>
+        query.length === 0 ||
+        getUsedByDropdownItemName(item).toLowerCase().includes(query)
+    )
+    .sort((a, b) => {
+      const nameComparison = getUsedByDropdownItemName(a).localeCompare(
+        getUsedByDropdownItemName(b),
+        undefined,
+        { sensitivity: "base" }
+      );
+
+      if (nameComparison !== 0) {
+        return nameComparison;
+      }
+
+      return getUsedByDropdownItemId(a).localeCompare(
+        getUsedByDropdownItemId(b)
+      );
+    });
 
   const closeMenu = () => {
     setSearchText("");
@@ -127,17 +176,22 @@ export const UsedByButton = ({
   };
 
   const onFirstItemClick = () => {
-    const firstAgent = filteredAgents[0];
-    if (firstAgent) {
-      onItemClick(firstAgent.sId);
-      closeMenu();
+    const firstItem = dropdownItems[0];
+    if (!firstItem) {
       return;
     }
 
-    const firstSkill = filteredSkills[0];
-    if (firstSkill && onSkillClick) {
-      onSkillClick(firstSkill.sId);
-      closeMenu();
+    switch (firstItem.kind) {
+      case "agent":
+        onItemClick(firstItem.agent.sId);
+        closeMenu();
+        return;
+      case "skill":
+        onSkillClick?.(firstItem.skill.sId);
+        closeMenu();
+        return;
+      default:
+        assertNever(firstItem);
     }
   };
 
@@ -194,43 +248,45 @@ export const UsedByButton = ({
           </>
         }
       >
-        {filteredAgents.length > 0 ? (
-          <>
-            {filteredAgents.map((agent) => (
-              <DropdownMenuItem
-                key={`assistant-picker-${agent.sId}`}
-                icon={() => <Avatar size="xs" visual={agent.pictureUrl} />}
-                label={agent.name}
-                truncateText
-                className="py-1"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onItemClick(agent.sId);
-                  closeMenu();
-                }}
-              />
-            ))}
-          </>
-        ) : null}
-        {filteredSkills.length > 0 && (
-          <>
-            {filteredSkills.map((skill: UsedBySkillType) => (
-              <DropdownMenuItem
-                key={`skill-picker-${skill.sId}`}
-                icon={() => <SkillDropdownIcon icon={skill.icon} />}
-                label={skill.name}
-                truncateText
-                className="py-1"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onSkillClick?.(skill.sId);
-                  closeMenu();
-                }}
-              />
-            ))}
-          </>
-        )}
-        {filteredAgents.length === 0 && filteredSkills.length === 0 && (
+        {dropdownItems.map((item) => {
+          switch (item.kind) {
+            case "agent":
+              return (
+                <DropdownMenuItem
+                  key={`assistant-picker-${item.agent.sId}`}
+                  icon={() => (
+                    <Avatar size="xs" visual={item.agent.pictureUrl} />
+                  )}
+                  label={item.agent.name}
+                  truncateText
+                  className="py-1"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onItemClick(item.agent.sId);
+                    closeMenu();
+                  }}
+                />
+              );
+            case "skill":
+              return (
+                <DropdownMenuItem
+                  key={`skill-picker-${item.skill.sId}`}
+                  icon={() => <SkillDropdownIcon icon={item.skill.icon} />}
+                  label={item.skill.name}
+                  truncateText
+                  className="py-1"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onSkillClick?.(item.skill.sId);
+                    closeMenu();
+                  }}
+                />
+              );
+            default:
+              return assertNever(item);
+          }
+        })}
+        {dropdownItems.length === 0 && (
           <div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
             {skills.length > 0 ? "No matches found" : "No agents found"}
           </div>

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -140,7 +140,6 @@ export const UsedByButton = ({
         variant="ghost-secondary"
         isSelect={false}
         size="xs"
-        isRounded
         className="border-0 hover:bg-muted-background hover:text-foreground dark:hover:bg-muted-background-night dark:hover:text-foreground-night"
         aria-label="Used by 0 agents"
         disabled
@@ -221,7 +220,6 @@ export const UsedByButton = ({
           variant="ghost-secondary"
           isSelect={false}
           size="xs"
-          isRounded
           className="border-0 hover:bg-muted-background hover:text-foreground dark:hover:bg-muted-background-night dark:hover:text-foreground-night"
           aria-label={`Used by ${usageLabel}`}
           onClick={(e: React.MouseEvent<HTMLButtonElement>) => {

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -108,7 +108,7 @@ export const UsedByButton = ({
         variant="ghost-secondary"
         isSelect={false}
         size="xs"
-        className="px-0"
+        className="px-2"
         aria-label="Used by 0 agents"
         disabled
       />
@@ -167,7 +167,7 @@ export const UsedByButton = ({
           variant="ghost-secondary"
           isSelect={false}
           size="xs"
-          className="px-0"
+          className="px-2"
           aria-label={`Used by ${usageLabel}`}
           onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
             e.stopPropagation();

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -4,6 +4,7 @@ import type {
   UsedBySkillType,
 } from "@app/types/assistant/skill_configuration";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { pluralize } from "@app/types/shared/utils/string_utils";
 import {
   Avatar,
   Button,
@@ -122,11 +123,12 @@ export const UsedByButton = ({
   const totalCount = agentCount + skillCount;
 
   const usageLabel =
-    agentCount > 0 && skillCount > 0
-      ? `${agentCount} agent${agentCount === 1 ? "" : "s"} and ${skillCount} skill${skillCount === 1 ? "" : "s"}`
-      : skillCount > 0
-        ? `${skillCount} skill${skillCount === 1 ? "" : "s"}`
-        : `${agentCount} agent${agentCount === 1 ? "" : "s"}`;
+    [
+      agentCount > 0 ? `${agentCount} agent${pluralize(agentCount)}` : null,
+      skillCount > 0 ? `${skillCount} skill${pluralize(skillCount)}` : null,
+    ]
+      .filter((label): label is string => label !== null)
+      .join(" and ") || "0 agents";
 
   if (totalCount === 0) {
     return (

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -10,7 +10,6 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
   DropdownMenuSearchbar,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
@@ -197,7 +196,6 @@ export const UsedByButton = ({
       >
         {filteredAgents.length > 0 ? (
           <>
-            {skills.length > 0 && <DropdownMenuLabel label="Agents" />}
             {filteredAgents.map((agent) => (
               <DropdownMenuItem
                 key={`assistant-picker-${agent.sId}`}
@@ -214,12 +212,8 @@ export const UsedByButton = ({
             ))}
           </>
         ) : null}
-        {filteredAgents.length > 0 && filteredSkills.length > 0 && (
-          <DropdownMenuSeparator />
-        )}
         {filteredSkills.length > 0 && (
           <>
-            {agents.length > 0 && <DropdownMenuLabel label="Skills" />}
             {filteredSkills.map((skill: UsedBySkillType) => (
               <DropdownMenuItem
                 key={`skill-picker-${skill.sId}`}

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -1,31 +1,58 @@
-import type { AgentsUsageType } from "@app/types/data_source";
+import { getSkillAvatarIcon } from "@app/lib/skill";
+import type {
+  SkillUsageType,
+  UsedBySkillType,
+} from "@app/types/assistant/skill_configuration";
 import {
   Avatar,
   Button,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSearchbar,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  PuzzleIcon,
   RobotIcon,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
+function SkillDropdownIcon({ icon }: { icon: string | null }) {
+  const SkillAvatar = getSkillAvatarIcon(icon);
+  return <SkillAvatar size="xs" />;
+}
+
+function UsedByButtonIcon() {
+  return (
+    <span className="flex items-center gap-0.5">
+      <RobotIcon className="h-3 w-3" />
+      <span className="text-[10px] leading-none">/</span>
+      <PuzzleIcon className="h-3 w-3" />
+    </span>
+  );
+}
+
 export const UsedByButton = ({
   usage,
   onItemClick,
+  onSkillClick,
 }: {
-  usage: AgentsUsageType | null;
+  usage: SkillUsageType | null;
   onItemClick: (assistantSid: string) => void;
+  onSkillClick?: (skillId: string) => void;
 }) => {
   const [searchText, setSearchText] = useState("");
   const [isOpen, setIsOpen] = useState(false);
 
-  if (!usage || usage.count === 0) {
+  const agentCount = usage?.count ?? 0;
+  const skillCount = usage?.skills?.length ?? 0;
+  const totalCount = agentCount + skillCount;
+
+  if (totalCount === 0) {
     return (
       <Button
-        icon={RobotIcon}
+        icon={<UsedByButtonIcon />}
         variant="ghost-secondary"
         isSelect={false}
         size="xs"
@@ -36,10 +63,36 @@ export const UsedByButton = ({
   }
 
   const query = searchText.toLowerCase();
+  const agents = usage?.agents ?? [];
+  const skills = usage?.skills ?? [];
   const filteredAgents =
     query.length === 0
-      ? usage.agents
-      : usage.agents.filter((a) => a.name.toLowerCase().includes(query));
+      ? agents
+      : agents.filter((a) => a.name.toLowerCase().includes(query));
+  const filteredSkills =
+    query.length === 0
+      ? skills
+      : skills.filter((skill) => skill.name.toLowerCase().includes(query));
+
+  const closeMenu = () => {
+    setSearchText("");
+    setIsOpen(false);
+  };
+
+  const onFirstItemClick = () => {
+    const firstAgent = filteredAgents[0];
+    if (firstAgent) {
+      onItemClick(firstAgent.sId);
+      closeMenu();
+      return;
+    }
+
+    const firstSkill = filteredSkills[0];
+    if (firstSkill && onSkillClick) {
+      onSkillClick(firstSkill.sId);
+      closeMenu();
+    }
+  };
 
   return (
     <DropdownMenu
@@ -53,11 +106,11 @@ export const UsedByButton = ({
     >
       <DropdownMenuTrigger asChild>
         <Button
-          icon={RobotIcon}
+          icon={<UsedByButtonIcon />}
           variant="ghost-secondary"
           isSelect
           size="xs"
-          label={`${usage.count}`}
+          label={`${totalCount}`}
           onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
             e.stopPropagation();
           }}
@@ -72,14 +125,14 @@ export const UsedByButton = ({
             <DropdownMenuSearchbar
               autoFocus
               name="search-used-by-agents"
-              placeholder="Search agents"
+              placeholder={
+                skills.length > 0 ? "Search agents and skills" : "Search agents"
+              }
               value={searchText}
               onChange={setSearchText}
               onKeyDown={(e) => {
-                if (e.key === "Enter" && filteredAgents.length > 0) {
-                  onItemClick(filteredAgents[0].sId);
-                  setSearchText("");
-                  setIsOpen(false);
+                if (e.key === "Enter") {
+                  onFirstItemClick();
                 }
               }}
             />
@@ -88,23 +141,49 @@ export const UsedByButton = ({
         }
       >
         {filteredAgents.length > 0 ? (
-          filteredAgents.map((agent) => (
-            <DropdownMenuItem
-              key={`assistant-picker-${agent.sId}`}
-              icon={() => <Avatar size="xs" visual={agent.pictureUrl} />}
-              label={agent.name}
-              truncateText
-              className="py-1"
-              onClick={(e) => {
-                e.stopPropagation();
-                onItemClick(agent.sId);
-                setIsOpen(false);
-              }}
-            />
-          ))
-        ) : (
+          <>
+            {skills.length > 0 && <DropdownMenuLabel label="Agents" />}
+            {filteredAgents.map((agent) => (
+              <DropdownMenuItem
+                key={`assistant-picker-${agent.sId}`}
+                icon={() => <Avatar size="xs" visual={agent.pictureUrl} />}
+                label={agent.name}
+                truncateText
+                className="py-1"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onItemClick(agent.sId);
+                  closeMenu();
+                }}
+              />
+            ))}
+          </>
+        ) : null}
+        {filteredAgents.length > 0 && filteredSkills.length > 0 && (
+          <DropdownMenuSeparator />
+        )}
+        {filteredSkills.length > 0 && (
+          <>
+            {agents.length > 0 && <DropdownMenuLabel label="Skills" />}
+            {filteredSkills.map((skill: UsedBySkillType) => (
+              <DropdownMenuItem
+                key={`skill-picker-${skill.sId}`}
+                icon={() => <SkillDropdownIcon icon={skill.icon} />}
+                label={skill.name}
+                truncateText
+                className="py-1"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onSkillClick?.(skill.sId);
+                  closeMenu();
+                }}
+              />
+            ))}
+          </>
+        )}
+        {filteredAgents.length === 0 && filteredSkills.length === 0 && (
           <div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
-            No agents found
+            {skills.length > 0 ? "No matches found" : "No agents found"}
           </div>
         )}
       </DropdownMenuContent>

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -25,10 +25,12 @@ function SkillDropdownIcon({ icon }: { icon: string | null }) {
 
 function UsedByButtonIcon() {
   return (
-    <span className="flex items-center gap-0.5">
-      <RobotIcon className="h-3 w-3" />
-      <span className="text-[10px] leading-none">/</span>
-      <PuzzleIcon className="h-3 w-3" />
+    <span className="inline-flex h-4 items-center justify-center gap-0.5 leading-none">
+      <RobotIcon className="h-3.5 w-3.5 shrink-0" />
+      <span className="inline-flex h-3.5 items-center text-xs leading-none">
+        /
+      </span>
+      <PuzzleIcon className="h-3.5 w-3.5 shrink-0" />
     </span>
   );
 }

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -10,6 +10,7 @@ import {
   Avatar,
   Button,
   ChevronDownIcon,
+  cn,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -140,7 +141,10 @@ export const UsedByButton = ({
         variant="ghost-secondary"
         isSelect={false}
         size="xs"
-        className="border-0 hover:bg-muted-background hover:text-foreground dark:hover:bg-muted-background-night dark:hover:text-foreground-night"
+        className={cn(
+          "border-0 hover:bg-muted-background hover:text-foreground",
+          "dark:hover:bg-muted-background-night dark:hover:text-foreground-night"
+        )}
         aria-label="Used by 0 agents"
         disabled
       />
@@ -220,7 +224,10 @@ export const UsedByButton = ({
           variant="ghost-secondary"
           isSelect={false}
           size="xs"
-          className="border-0 hover:bg-muted-background hover:text-foreground dark:hover:bg-muted-background-night dark:hover:text-foreground-night"
+          className={cn(
+            "border-0 hover:bg-muted-background hover:text-foreground",
+            "dark:hover:bg-muted-background-night dark:hover:text-foreground-night"
+          )}
           aria-label={`Used by ${usageLabel}`}
           onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
             e.stopPropagation();

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -8,7 +8,6 @@ import { removeNulls } from "@app/types/shared/utils/general";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import {
   Avatar,
-  Button,
   ChevronDownIcon,
   DropdownMenu,
   DropdownMenuContent,
@@ -77,7 +76,7 @@ function UsedByButtonIcon({
   const hasSkills = skillCount > 0;
 
   return (
-    <span className="mx-0.5 inline-flex h-5 items-center justify-center gap-1.5 leading-none">
+    <span className="inline-flex h-5 items-center justify-center gap-1.5 leading-none">
       {(hasAgents || !hasSkills) && (
         <span className="inline-flex h-5 items-center gap-1">
           <RobotIcon className="h-4 w-4 shrink-0" />
@@ -109,6 +108,9 @@ interface UsedByButtonProps {
   onSkillClick?: (skillId: string) => void;
 }
 
+const USED_BY_TRIGGER_CLASS_NAME =
+  "inline-flex h-7 select-none items-center justify-center whitespace-nowrap rounded-full px-2.5 text-muted-foreground transition-colors hover:bg-muted-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset disabled:cursor-default disabled:text-primary-400 disabled:hover:bg-transparent dark:text-muted-foreground-night dark:hover:bg-muted-background-night dark:hover:text-foreground-night dark:disabled:text-primary-400-night";
+
 export const UsedByButton = ({
   usage,
   onItemClick,
@@ -131,17 +133,14 @@ export const UsedByButton = ({
 
   if (totalCount === 0) {
     return (
-      <Button
-        icon={
-          <UsedByButtonIcon agentCount={0} skillCount={0} showChevron={false} />
-        }
-        variant="ghost-secondary"
-        isSelect={false}
-        size="xs"
-        isRounded
+      <button
+        type="button"
+        className={USED_BY_TRIGGER_CLASS_NAME}
         aria-label="Used by 0 agents"
         disabled
-      />
+      >
+        <UsedByButtonIcon agentCount={0} skillCount={0} showChevron={false} />
+      </button>
     );
   }
 
@@ -207,23 +206,20 @@ export const UsedByButton = ({
       }}
     >
       <DropdownMenuTrigger asChild>
-        <Button
-          icon={
-            <UsedByButtonIcon
-              agentCount={agentCount}
-              skillCount={skillCount}
-              showChevron
-            />
-          }
-          variant="ghost-secondary"
-          isSelect={false}
-          size="xs"
-          isRounded
+        <button
+          type="button"
+          className={USED_BY_TRIGGER_CLASS_NAME}
           aria-label={`Used by ${usageLabel}`}
           onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
             e.stopPropagation();
           }}
-        />
+        >
+          <UsedByButtonIcon
+            agentCount={agentCount}
+            skillCount={skillCount}
+            showChevron
+          />
+        </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
         className="h-96 w-72"

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -105,6 +105,7 @@ export const UsedByButton = ({
         variant="ghost-secondary"
         isSelect={false}
         size="xs"
+        isRounded
         aria-label="Used by 0 agents"
         disabled
       />
@@ -163,6 +164,7 @@ export const UsedByButton = ({
           variant="ghost-secondary"
           isSelect={false}
           size="xs"
+          isRounded
           aria-label={`Used by ${usageLabel}`}
           onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
             e.stopPropagation();

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -47,9 +47,7 @@ export const UsedByButton = ({
   const [searchText, setSearchText] = useState("");
   const [isOpen, setIsOpen] = useState(false);
 
-  const agentCount = usage?.count ?? 0;
-  const skillCount = usage?.skills?.length ?? 0;
-  const totalCount = agentCount + skillCount;
+  const totalCount = usage?.count ?? 0;
 
   if (totalCount === 0) {
     return (

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -18,12 +18,20 @@ import {
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
-function SkillDropdownIcon({ icon }: { icon: string | null }) {
+interface SkillDropdownIconProps {
+  icon: string | null;
+}
+
+function SkillDropdownIcon({ icon }: SkillDropdownIconProps) {
   const SkillAvatar = getSkillAvatarIcon(icon);
   return <SkillAvatar size="xs" />;
 }
 
-function UsedByButtonIcon({ count }: { count: number }) {
+interface UsedByButtonIconProps {
+  count: number;
+}
+
+function UsedByButtonIcon({ count }: UsedByButtonIconProps) {
   return (
     <span className="inline-flex h-4 items-center justify-center gap-1 leading-none">
       <span className="inline-flex h-4 items-center gap-0.5">
@@ -40,15 +48,17 @@ function UsedByButtonIcon({ count }: { count: number }) {
   );
 }
 
+interface UsedByButtonProps {
+  usage: SkillUsageType | null;
+  onItemClick: (assistantSid: string) => void;
+  onSkillClick?: (skillId: string) => void;
+}
+
 export const UsedByButton = ({
   usage,
   onItemClick,
   onSkillClick,
-}: {
-  usage: SkillUsageType | null;
-  onItemClick: (assistantSid: string) => void;
-  onSkillClick?: (skillId: string) => void;
-}) => {
+}: UsedByButtonProps) => {
   const [searchText, setSearchText] = useState("");
   const [isOpen, setIsOpen] = useState(false);
 

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -23,14 +23,19 @@ function SkillDropdownIcon({ icon }: { icon: string | null }) {
   return <SkillAvatar size="xs" />;
 }
 
-function UsedByButtonIcon() {
+function UsedByButtonIcon({ count }: { count: number }) {
   return (
-    <span className="inline-flex h-4 items-center justify-center gap-0.5 leading-none">
-      <RobotIcon className="h-3.5 w-3.5 shrink-0" />
-      <span className="inline-flex h-3.5 items-center text-xs leading-none">
-        /
+    <span className="inline-flex h-4 items-center justify-center gap-1 leading-none">
+      <span className="inline-flex h-4 items-center gap-0.5">
+        <RobotIcon className="h-3.5 w-3.5 shrink-0" />
+        <span className="inline-flex h-3.5 items-center text-xs leading-none">
+          /
+        </span>
+        <PuzzleIcon className="h-3.5 w-3.5 shrink-0" />
       </span>
-      <PuzzleIcon className="h-3.5 w-3.5 shrink-0" />
+      <span className="inline-flex h-4 items-center text-xs leading-none tabular-nums">
+        {count}
+      </span>
     </span>
   );
 }
@@ -52,11 +57,11 @@ export const UsedByButton = ({
   if (totalCount === 0) {
     return (
       <Button
-        icon={<UsedByButtonIcon />}
+        icon={<UsedByButtonIcon count={0} />}
         variant="ghost-secondary"
         isSelect={false}
         size="xs"
-        label="0"
+        aria-label="0 uses"
         disabled
       />
     );
@@ -106,11 +111,11 @@ export const UsedByButton = ({
     >
       <DropdownMenuTrigger asChild>
         <Button
-          icon={<UsedByButtonIcon />}
+          icon={<UsedByButtonIcon count={totalCount} />}
           variant="ghost-secondary"
           isSelect
           size="xs"
-          label={`${totalCount}`}
+          aria-label={`${totalCount} uses`}
           onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
             e.stopPropagation();
           }}

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -6,7 +6,6 @@ import type {
 import {
   Avatar,
   Button,
-  ChevronDownIcon,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -29,32 +28,35 @@ function SkillDropdownIcon({ icon }: SkillDropdownIconProps) {
 }
 
 interface UsedByButtonIconProps {
-  count: number;
-  showChevron: boolean;
+  agentCount: number;
+  skillCount: number;
 }
 
-function UsedByButtonIcon({ count, showChevron }: UsedByButtonIconProps) {
+function UsedByButtonIcon({ agentCount, skillCount }: UsedByButtonIconProps) {
+  const hasAgents = agentCount > 0;
+  const hasSkills = skillCount > 0;
+
   return (
-    <span className="relative inline-flex h-4 w-20 items-center justify-center leading-none">
-      <span className="inline-flex h-4 items-center justify-center gap-1 leading-none">
-        <span className="inline-flex h-4 items-center gap-0.5">
-          <RobotIcon className="h-3.5 w-3.5 shrink-0" />
-          <span className="inline-flex h-3.5 items-center text-xs leading-none">
-            /
+    <span className="inline-flex h-5 items-center justify-center gap-2 leading-none">
+      {(hasAgents || !hasSkills) && (
+        <span className="inline-flex h-5 items-center gap-1">
+          <RobotIcon className="h-4 w-4 shrink-0" />
+          <span className="inline-flex h-5 items-center text-sm leading-none tabular-nums">
+            {agentCount}
           </span>
-          <PuzzleIcon className="h-3.5 w-3.5 shrink-0" />
         </span>
-        <span className="inline-flex h-4 items-center text-xs leading-none tabular-nums">
-          {count}
+      )}
+      {hasAgents && hasSkills && (
+        <span className="h-1 w-1 rounded-full bg-muted-foreground/30" />
+      )}
+      {hasSkills && (
+        <span className="inline-flex h-5 items-center gap-1">
+          <PuzzleIcon className="h-4 w-4 shrink-0" />
+          <span className="inline-flex h-5 items-center text-sm leading-none tabular-nums">
+            {skillCount}
+          </span>
         </span>
-      </span>
-      <ChevronDownIcon
-        className={
-          showChevron
-            ? "absolute right-0 h-4 w-4 shrink-0"
-            : "invisible absolute right-0 h-4 w-4 shrink-0"
-        }
-      />
+      )}
     </span>
   );
 }
@@ -73,25 +75,34 @@ export const UsedByButton = ({
   const [searchText, setSearchText] = useState("");
   const [isOpen, setIsOpen] = useState(false);
 
-  const totalCount = usage?.count ?? 0;
+  const agents = usage?.agents ?? [];
+  const skills = usage?.skills ?? [];
+  const agentCount = agents.length;
+  const skillCount = skills.length;
+  const totalCount = agentCount + skillCount;
+
+  const usageLabel =
+    agentCount > 0 && skillCount > 0
+      ? `${agentCount} agent${agentCount === 1 ? "" : "s"} and ${skillCount} skill${skillCount === 1 ? "" : "s"}`
+      : skillCount > 0
+        ? `${skillCount} skill${skillCount === 1 ? "" : "s"}`
+        : `${agentCount} agent${agentCount === 1 ? "" : "s"}`;
 
   if (totalCount === 0) {
     return (
       <Button
-        icon={<UsedByButtonIcon count={0} showChevron={false} />}
+        icon={<UsedByButtonIcon agentCount={0} skillCount={0} />}
         variant="ghost-secondary"
         isSelect={false}
         size="xs"
         className="px-1"
-        aria-label="0 uses"
+        aria-label="Used by 0 agents"
         disabled
       />
     );
   }
 
   const query = searchText.toLowerCase();
-  const agents = usage?.agents ?? [];
-  const skills = usage?.skills ?? [];
   const filteredAgents =
     query.length === 0
       ? agents
@@ -133,12 +144,14 @@ export const UsedByButton = ({
     >
       <DropdownMenuTrigger asChild>
         <Button
-          icon={<UsedByButtonIcon count={totalCount} showChevron />}
+          icon={
+            <UsedByButtonIcon agentCount={agentCount} skillCount={skillCount} />
+          }
           variant="ghost-secondary"
           isSelect={false}
           size="xs"
           className="px-1"
-          aria-label={`${totalCount} uses`}
+          aria-label={`Used by ${usageLabel}`}
           onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
             e.stopPropagation();
           }}

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -6,6 +6,7 @@ import type {
 import {
   Avatar,
   Button,
+  ChevronDownIcon,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -30,14 +31,19 @@ function SkillDropdownIcon({ icon }: SkillDropdownIconProps) {
 interface UsedByButtonIconProps {
   agentCount: number;
   skillCount: number;
+  showChevron: boolean;
 }
 
-function UsedByButtonIcon({ agentCount, skillCount }: UsedByButtonIconProps) {
+function UsedByButtonIcon({
+  agentCount,
+  skillCount,
+  showChevron,
+}: UsedByButtonIconProps) {
   const hasAgents = agentCount > 0;
   const hasSkills = skillCount > 0;
 
   return (
-    <span className="inline-flex h-5 items-center justify-center gap-2 leading-none">
+    <span className="inline-flex h-5 items-center justify-center gap-1.5 leading-none">
       {(hasAgents || !hasSkills) && (
         <span className="inline-flex h-5 items-center gap-1">
           <RobotIcon className="h-4 w-4 shrink-0" />
@@ -57,6 +63,11 @@ function UsedByButtonIcon({ agentCount, skillCount }: UsedByButtonIconProps) {
           </span>
         </span>
       )}
+      <ChevronDownIcon
+        className={
+          showChevron ? "h-4 w-4 shrink-0" : "invisible h-4 w-4 shrink-0"
+        }
+      />
     </span>
   );
 }
@@ -91,11 +102,13 @@ export const UsedByButton = ({
   if (totalCount === 0) {
     return (
       <Button
-        icon={<UsedByButtonIcon agentCount={0} skillCount={0} />}
+        icon={
+          <UsedByButtonIcon agentCount={0} skillCount={0} showChevron={false} />
+        }
         variant="ghost-secondary"
         isSelect={false}
         size="xs"
-        className="px-1"
+        className="px-0"
         aria-label="Used by 0 agents"
         disabled
       />
@@ -145,12 +158,16 @@ export const UsedByButton = ({
       <DropdownMenuTrigger asChild>
         <Button
           icon={
-            <UsedByButtonIcon agentCount={agentCount} skillCount={skillCount} />
+            <UsedByButtonIcon
+              agentCount={agentCount}
+              skillCount={skillCount}
+              showChevron
+            />
           }
           variant="ghost-secondary"
           isSelect={false}
           size="xs"
-          className="px-1"
+          className="px-0"
           aria-label={`Used by ${usageLabel}`}
           onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
             e.stopPropagation();

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -4,6 +4,7 @@ import type {
   UsedBySkillType,
 } from "@app/types/assistant/skill_configuration";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { removeNulls } from "@app/types/shared/utils/general";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import {
   Avatar,
@@ -123,12 +124,10 @@ export const UsedByButton = ({
   const totalCount = agentCount + skillCount;
 
   const usageLabel =
-    [
+    removeNulls([
       agentCount > 0 ? `${agentCount} agent${pluralize(agentCount)}` : null,
       skillCount > 0 ? `${skillCount} skill${pluralize(skillCount)}` : null,
-    ]
-      .filter((label): label is string => label !== null)
-      .join(" and ") || "0 agents";
+    ]).join(" and ") || "0 agents";
 
   if (totalCount === 0) {
     return (


### PR DESCRIPTION
## Description

This PR updates the Manage Skills Used by column to include skills that reference the listed skill, on top of the nested skill usage API PR.

The table now displays the API-provided total usage count. The dropdown separates agents and skills, supports searching both, and lets users open either the agent or the referencing skill. The trigger uses the combined agent/skill icon so the column reflects both usage sources.

<img width="1475" height="803" alt="image" src="https://github.com/user-attachments/assets/82acde58-c315-4ce1-8391-ecf24b411fdf" />

## Tests

- Tested locally with seeded skill references.

## Risk

- Low. Behind feature flag.

## Deploy Plan

- Deploy front.