### PR TITLE
chore: freeze migrations/db/ dirs in favour of phased migration system

### DIFF
--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -1,0 +1,37 @@
+name: Check connectors/migrations/db/ is frozen
+
+on:
+  push:
+    paths:
+      - "connectors/migrations/db/**"
+      - ".github/workflows/check-migrations.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  check-frozen-migration-dirs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Check no new files added to frozen migration dir
+        run: |
+          NEW_FILES=$(git diff --diff-filter=A --name-only origin/main...HEAD \
+            -- 'connectors/migrations/db/')
+
+          if [ -n "$NEW_FILES" ]; then
+            echo ""
+            echo "ERROR: connectors/migrations/db/ is frozen. New files detected:"
+            echo "$NEW_FILES" | sed 's/^/  /'
+            echo ""
+            echo "Use the new phased migration system instead:"
+            echo "  npm run -w connectors migration:generate:pre-deploy <description>"
+            echo "  npm run -w connectors migration:generate:post-deploy <description>"
+            echo ""
+            echo "See: https://app.notion.com/p/dust-tt/Runbook-Deploy-Run-migrations-5669e328475d489ba16298a77f2aa45c?source=copy_link#36728599d94180898358cf59a8725740"
+            exit 1
+          fi
+
+          echo "OK: no new files in frozen migration dir."

--- a/connectors/create_db_migration_file.sh
+++ b/connectors/create_db_migration_file.sh
@@ -1,96 +1,18 @@
 #!/bin/bash
 
-# Ensure NODE_ENV is not set to production.
-if [ "$NODE_ENV" == "production" ]; then
-  echo "Error: NODE_ENV is set to production. Aborting script."
-  exit 1
-fi
+echo ""
+echo "ERROR: migrations/db/ is frozen. Do not add files here."
+echo ""
+echo "Use the new phased migration system instead:"
+echo ""
+echo "  Safe schema additions (add column, table, index):"
+echo "    npm run migration:generate:pre-deploy <description words>"
+echo ""
+echo "  Breaking schema changes (drop column, tighten constraint):"
+echo "    npm run migration:generate:post-deploy <description words>"
+echo ""
+echo "See the runbook for full instructions:"
+echo "  https://app.notion.com/p/dust-tt/Runbook-Deploy-Run-migrations-5669e328475d489ba16298a77f2aa45c?source=copy_link#36728599d94180898358cf59a8725740"
+echo ""
 
-cleanup() {
-    echo "Cleaning up temporary files..."
-    rm -f main_output.txt current_output.txt
-    exit 0
-}
-
-# CLEANUP TEMP FILES ON EXIT
-trap 'cleanup' SIGINT SIGTERM EXIT
-
-# Get current date in a human-readable format (e.g., May 28, 2024)
-current_date=$(date +"%b %d, %Y")
-current_unix_timestamp=$(date +"%s")
-# Use a unique message to identify the stash in case the script fails before popping the stash.
-stash_commit_message="Temp stash for running diff $current_unix_timestamp"
-
-# Stash any uncommitted changes.
-echo "Stashing uncommitted changes..."
-git stash push -m "$stash_commit_message" --quiet
-
-# Get the current branch name.
-original_branch=$(git symbolic-ref --short HEAD)
-echo "Original branch: $original_branch"
-
-# Checkout main branch and reset DB state to main.
-echo "Checking out main branch and resetting DB state..."
-git checkout main --quiet
-echo "First run: Resetting DB to main branch state..."
-NODE_ENV=development DB_LOGGING_ENABLED=true ./admin/init_db.sh --unsafe > main_output.txt
-
-# Run the command a second time to capture the stable production state.
-echo "Second run: Capturing stable production state..."
-NODE_ENV=development DB_LOGGING_ENABLED=true ./admin/init_db.sh --unsafe > main_output.txt
-
-# Checkout original branch.
-echo "Checking out $original_branch branch..."
-git checkout $original_branch --quiet
-# Determine if there were any stashed changes and apply them.
-stash_list=$(git stash list)
-if [[ $stash_list == *"$stash_commit_message"* ]]; then
-  # Pop the stash if it exists.
-  echo "Restoring uncommited changes..."
-  git stash pop --quiet
-fi
-
-# Run the command on original branch.
-echo "Running command on $original_branch branch..."
-NODE_ENV=development DB_LOGGING_ENABLED=true ./admin/init_db.sh --unsafe > current_output.txt
-
-# Run diff.
-echo "Running diff..."
-diff --unified=0 --color=always main_output.txt current_output.txt
-
-# Run diff and extract only SQL statements, ensuring they end with a semicolon.
-echo "Running diff and extracting SQL statements..."
-diff_output=$(diff --unified=0 main_output.txt current_output.txt | awk '/^\+[^+]/ {print substr($0, 2)}' | sed 's/;*$/;/')
-if [ -n "$diff_output" ]; then
-  echo "-- Migration created on $current_date" > diff_output.txt
-  echo "$diff_output" >> diff_output.txt
-else
-    echo "No migration necessary."
-    exit 0
-fi
-
-# Find the last migration version.
-last_version=$(ls ./migrations/db | grep -oE 'migration_([0-9]+).sql' | grep -oE '([0-9]+)\.sql$' | sed s/\.sql// | sort -n | tail -n1)
-# 10# ensures the number is interpreted as base-10, preventing errors with leading zeros.
-next_version=$(printf "%02d" $((10#$last_version + 1)))
-echo "Creating SQL migration $next_version."
-
-OUTPUT_FILE="./migrations/db/migration_${next_version}.sql"
-
-# Save the latest changes to a new migration file.
-mv diff_output.txt "$OUTPUT_FILE"
-
-# Ask for user Y/n input wether this migration is dependant on a backfill
-read -p "Does this migration depends on a backfill script ? (y/n): " backfill_dependant
-if [ "$backfill_dependant" == "y" ]; then
-  # Ask for user input for backfill script name
-  read -p "Please enter the name of the backfill script: " backfill_script_name
-  
-  TEMPLATE_FILE="./migration_with_backfill_template.sql"
-
-  # Create an sql command that will fail when executed and put it at the TOP of the migration file before the rest of the sql commands
-  sed -e "/MIGRATION_STATEMENTS/r $OUTPUT_FILE" \
-    -e "/MIGRATION_STATEMENTS/d" \
-    -e "s/BACKFILL_SCRIPT_NAME/$backfill_script_name/g" \
-    "$TEMPLATE_FILE" > temp_output.sql && mv temp_output.sql "$OUTPUT_FILE"
-fi
+exit 1

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -127,6 +127,21 @@ pre-commit:
       run: cargo fmt -- {staged_files}
       stage_fixed: true
 
+    # Guard against adding files to frozen migrations/db/ directories
+    no-legacy-db-migration-connectors:
+      glob: "connectors/migrations/db/*.sql"
+      run: |
+        echo ""
+        echo "ERROR: connectors/migrations/db/ is frozen. Do not add files here."
+        echo ""
+        echo "Use the new phased migration system instead:"
+        echo "  npm run -w connectors migration:generate:pre-deploy <description>"
+        echo "  npm run -w connectors migration:generate:post-deploy <description>"
+        echo ""
+        echo "See: https://app.notion.com/p/dust-tt/Runbook-Deploy-Run-migrations-5669e328475d489ba16298a77f2aa45c?source=copy_link#36728599d94180898358cf59a8725740"
+        exit 1
+      priority: 1
+
     # Biome checks (all JS/TS files in monorepo)
     biome:
       glob: "*.{js,jsx,ts,tsx,css,scss}"


### PR DESCRIPTION
## Description

`connectors/migrations/db/` is now frozen — the new phased migration system (`migrations/pre-deploy/` and `migrations/post-deploy/`) replaces it.

This PR adds three layers of protection against accidentally adding files to the old directory:

1. **`connectors/create_db_migration_file.sh`** — replaced with an error message that points to the new `migration:generate:pre-deploy` / `migration:generate:post-deploy` scripts and the runbook.
2. **Lefthook pre-commit hook** (`no-legacy-db-migration-connectors`) — blocks staging any `.sql` file under `connectors/migrations/db/`.
3. **CI workflow** (`.github/workflows/check-migrations.yml`) — fails the build if a PR introduces new files under `connectors/migrations/db/`.

Runbook: https://app.notion.com/p/dust-tt/Runbook-Deploy-Run-migrations-5669e328475d489ba16298a77f2aa45c?source=copy_link#36728599d94180898358cf59a8725740

## Tests

The lefthook hook was verified to trigger correctly during this commit (`no-legacy-db-migration-connectors` appeared in the pre-commit output, skipped because no `.sql` files in that path were staged).
