### PR TITLE
[front] feat: expose nested skill used by relations

### DIFF
--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -414,7 +414,7 @@ describe("GET /api/w/:wId/skills?withRelations=true", () => {
     });
   });
 
-  it("should return child skills when nested_skills is enabled", async () => {
+  it("should not return used-by skills without the nested_skills feature flag", async () => {
     const { workspace, user } = await setupTest();
 
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
@@ -422,16 +422,14 @@ describe("GET /api/w/:wId/skills?withRelations=true", () => {
       workspace.sId
     );
 
-    await FeatureFlagFactory.basic(auth, "nested_skills");
-
+    const childSkill = await SkillFactory.create(auth, {
+      name: "Referenced Skill",
+    });
     const parentSkill = await SkillFactory.create(auth, {
       name: "Parent Skill",
     });
-    const childSkill = await SkillFactory.create(auth, {
-      name: "Child Skill",
-    });
-    await SkillReferenceModel.create({
-      workspaceId: workspace.id,
+
+    await SkillFactory.linkSkillToSkill(auth, {
       parentSkillId: parentSkill.id,
       childSkillId: childSkill.id,
     });
@@ -440,13 +438,42 @@ describe("GET /api/w/:wId/skills?withRelations=true", () => {
 
     expect(response.status).toBe(200);
 
-    const parentSkillId = SkillResource.modelIdToSId({
-      id: parentSkill.id,
-      workspaceId: workspace.id,
-    });
     const skillResult = (await response.json()).skills.find(
       (s: SkillWithoutInstructionsAndToolsWithRelationsType) =>
-        s.sId === parentSkillId
+        s.sId === childSkill.sId
+    );
+
+    expect(skillResult.relations.usage).not.toHaveProperty("skills");
+  });
+
+  it("should return child skills when nested_skills is enabled", async () => {
+    const { workspace, user } = await setupTest();
+
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(auth, "nested_skills");
+
+    const parentSkill = await SkillFactory.create(auth, {
+      name: "Parent Skill",
+    });
+    const childSkill = await SkillFactory.create(auth, {
+      name: "Child Skill",
+    });
+
+    await SkillFactory.linkSkillToSkill(auth, {
+      parentSkillId: parentSkill.id,
+      childSkillId: childSkill.id,
+    });
+
+    const response = await getSkills(workspace, { withRelations: "true" });
+
+    expect(response.status).toBe(200);
+
+    const skillResult = (await response.json()).skills.find(
+      (s: SkillWithoutInstructionsAndToolsWithRelationsType) =>
+        s.sId === parentSkill.sId
     );
 
     expect(skillResult).toMatchObject({
@@ -462,6 +489,53 @@ describe("GET /api/w/:wId/skills?withRelations=true", () => {
     expect(skillResult.relations.childSkills?.[0]).not.toHaveProperty(
       "instructions"
     );
+  });
+
+  it("should return skills that reference a skill when nested_skills is enabled", async () => {
+    const { workspace, user } = await setupTest();
+
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(auth, "nested_skills");
+
+    const childSkill = await SkillFactory.create(auth, {
+      name: "Referenced Skill",
+    });
+    const parentSkill = await SkillFactory.create(auth, {
+      name: "Parent Skill",
+    });
+
+    await SkillFactory.linkSkillToSkill(auth, {
+      parentSkillId: parentSkill.id,
+      childSkillId: childSkill.id,
+    });
+
+    const response = await getSkills(workspace, { withRelations: "true" });
+
+    expect(response.status).toBe(200);
+
+    const skillResult = (await response.json()).skills.find(
+      (s: SkillWithoutInstructionsAndToolsWithRelationsType) =>
+        s.sId === childSkill.sId
+    );
+
+    expect(skillResult).toMatchObject({
+      relations: {
+        usage: {
+          count: 0,
+          agents: [],
+          skills: [
+            {
+              sId: parentSkill.sId,
+              name: "Parent Skill",
+              icon: parentSkill.icon,
+            },
+          ],
+        },
+      },
+    });
   });
 
   it("should return skills without usage when withRelations is not set", async () => {

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -524,7 +524,7 @@ describe("GET /api/w/:wId/skills?withRelations=true", () => {
     expect(skillResult).toMatchObject({
       relations: {
         usage: {
-          count: 0,
+          count: 1,
           agents: [],
           skills: [
             {

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -178,10 +178,12 @@ app.get(
         const usage = usageMap.get(sc.sId) ?? { count: 0, agents: [] };
         const editors = editorsMap.get(sc.sId) ?? null;
         const editedByUser = editedByUsersMap.get(sc.sId) ?? null;
+        const usedBySkills = usedBySkillsMap.get(sc.sId) ?? [];
         const usageWithSkills = includeNestedSkills
           ? {
               ...usage,
-              skills: usedBySkillsMap.get(sc.sId) ?? [],
+              count: usage.count + usedBySkills.length,
+              skills: usedBySkills,
             }
           : usage;
 

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -11,6 +11,7 @@ import {
   type SkillType,
   type SkillWithoutInstructionsAndToolsType,
   type SkillWithoutInstructionsAndToolsWithRelationsType,
+  type UsedBySkillType,
 } from "@app/types/assistant/skill_configuration";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { isBuilder } from "@app/types/user";
@@ -141,7 +142,7 @@ app.get(
 
     if (withRelations === "true") {
       const featureFlags = await getFeatureFlags(auth);
-      const includeChildSkills = featureFlags.includes("nested_skills");
+      const includeNestedSkills = featureFlags.includes("nested_skills");
 
       const extendedSkills = await SkillResource.fetchByIds(
         auth,
@@ -154,12 +155,15 @@ app.get(
         skills
       );
       let childSkillsMap = new Map<string, SkillResource[]>();
-      if (includeChildSkills) {
+      if (includeNestedSkills) {
         childSkillsMap = await SkillResource.batchFetchChildSkills(
           auth,
           skills
         );
       }
+      const usedBySkillsMap = includeNestedSkills
+        ? await SkillResource.batchFetchUsedBySkills(auth, skills)
+        : new Map<string, UsedBySkillType[]>();
 
       const extendedSkillsMap = new Map(extendedSkills.map((s) => [s.sId, s]));
 
@@ -174,18 +178,24 @@ app.get(
         const usage = usageMap.get(sc.sId) ?? { count: 0, agents: [] };
         const editors = editorsMap.get(sc.sId) ?? null;
         const editedByUser = editedByUsersMap.get(sc.sId) ?? null;
+        const usageWithSkills = includeNestedSkills
+          ? {
+              ...usage,
+              skills: usedBySkillsMap.get(sc.sId) ?? [],
+            }
+          : usage;
 
         return {
           ...skillWithoutInstructionsAndTools,
           relations: {
-            usage,
+            usage: usageWithSkills,
             editors: editors ? editors.map((e) => e.toJSON()) : null,
             editedByUser: editedByUser ? editedByUser.toJSON() : null,
             extendedSkill: sc.extendedSkillId
               ? (extendedSkillsMap.get(sc.extendedSkillId)?.toJSON(auth) ??
                 null)
               : null,
-            ...(includeChildSkills
+            ...(includeNestedSkills
               ? {
                   childSkills: (childSkillsMap.get(sc.sId) ?? []).map(
                     (childSkill) => {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -69,6 +69,7 @@ import type {
   SkillSourceType,
   SkillStatus,
   SkillType,
+  UsedBySkillType,
 } from "@app/types/assistant/skill_configuration";
 import type { AgentsUsageType } from "@app/types/data_source";
 import { SKILL_GROUP_PREFIX } from "@app/types/groups";
@@ -2037,6 +2038,79 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         }))
         .sort((a, b) => a.name.localeCompare(b.name));
       result.set(skill.sId, { count: agents.length, agents });
+    }
+
+    return result;
+  }
+
+  /**
+   * Batch fetch skill references for multiple child skills.
+   * Keyed by child skill sId to avoid collisions with global skills.
+   */
+  static async batchFetchUsedBySkills(
+    auth: Authenticator,
+    skills: SkillResource[]
+  ): Promise<Map<string, UsedBySkillType[]>> {
+    const result = new Map<string, UsedBySkillType[]>(
+      skills.map((skill) => [skill.sId, []])
+    );
+
+    const customSkills = skills.filter((skill) => !skill.globalSId);
+    if (customSkills.length === 0) {
+      return result;
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+    const childSkillModelIds = customSkills.map((skill) => skill.id);
+
+    const skillReferences = await SkillReferenceModel.findAll({
+      attributes: ["childSkillId", "parentSkillId"],
+      where: {
+        workspaceId: workspace.id,
+        childSkillId: {
+          [Op.in]: childSkillModelIds,
+        },
+      },
+    });
+
+    if (skillReferences.length === 0) {
+      return result;
+    }
+
+    const parentSkills = await this.fetchByModelIds(
+      auth,
+      uniq(skillReferences.map((reference) => reference.parentSkillId))
+    );
+
+    const parentSkillByModelId = new Map(
+      parentSkills.map((skill) => [skill.id, skill])
+    );
+    const childSkillIdToSkillId = new Map(
+      customSkills.map((skill) => [skill.id, skill.sId])
+    );
+
+    const usedBySkillsByChildSkillId = new Map<string, UsedBySkillType[]>();
+    for (const reference of skillReferences) {
+      const childSkillId = childSkillIdToSkillId.get(reference.childSkillId);
+      const parentSkill = parentSkillByModelId.get(reference.parentSkillId);
+      if (!childSkillId || !parentSkill) {
+        continue;
+      }
+
+      const usedBySkills = usedBySkillsByChildSkillId.get(childSkillId) ?? [];
+      usedBySkills.push({
+        sId: parentSkill.sId,
+        name: parentSkill.name,
+        icon: parentSkill.icon,
+      });
+      usedBySkillsByChildSkillId.set(childSkillId, usedBySkills);
+    }
+
+    for (const [childSkillId, usedBySkills] of usedBySkillsByChildSkillId) {
+      const sortedUsedBySkills = [...usedBySkills].sort((a, b) =>
+        a.name.localeCompare(b.name)
+      );
+      result.set(childSkillId, sortedUsedBySkills);
     }
 
     return result;

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -590,7 +590,7 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
     expect(skillResult).toMatchObject({
       relations: {
         usage: {
-          count: 0,
+          count: 1,
           agents: [],
           skills: [
             {

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -468,7 +468,7 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
     });
   });
 
-  it("should return child skills when nested_skills is enabled", async () => {
+  it("should not return used-by skills without the nested_skills feature flag", async () => {
     const { req, res, workspace, user } = await setupTest();
 
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
@@ -476,16 +476,14 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
       workspace.sId
     );
 
-    await FeatureFlagFactory.basic(auth, "nested_skills");
-
+    const childSkill = await SkillFactory.create(auth, {
+      name: "Referenced Skill",
+    });
     const parentSkill = await SkillFactory.create(auth, {
       name: "Parent Skill",
     });
-    const childSkill = await SkillFactory.create(auth, {
-      name: "Child Skill",
-    });
-    await SkillReferenceModel.create({
-      workspaceId: workspace.id,
+
+    await SkillFactory.linkSkillToSkill(auth, {
       parentSkillId: parentSkill.id,
       childSkillId: childSkill.id,
     });
@@ -496,15 +494,48 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
 
     expect(res._getStatusCode()).toBe(200);
 
-    const parentSkillId = SkillResource.modelIdToSId({
-      id: parentSkill.id,
-      workspaceId: workspace.id,
-    });
     const skillResult = res
       ._getJSONData()
       .skills.find(
         (s: SkillWithoutInstructionsAndToolsWithRelationsType) =>
-          s.sId === parentSkillId
+          s.sId === childSkill.sId
+      );
+
+    expect(skillResult.relations.usage).not.toHaveProperty("skills");
+  });
+
+  it("should return child skills when nested_skills is enabled", async () => {
+    const { req, res, workspace, user } = await setupTest();
+
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(auth, "nested_skills");
+
+    const parentSkill = await SkillFactory.create(auth, {
+      name: "Parent Skill",
+    });
+    const childSkill = await SkillFactory.create(auth, {
+      name: "Child Skill",
+    });
+
+    await SkillFactory.linkSkillToSkill(auth, {
+      parentSkillId: parentSkill.id,
+      childSkillId: childSkill.id,
+    });
+
+    req.query = { ...req.query, wId: workspace.sId, withRelations: "true" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const skillResult = res
+      ._getJSONData()
+      .skills.find(
+        (s: SkillWithoutInstructionsAndToolsWithRelationsType) =>
+          s.sId === parentSkill.sId
       );
 
     expect(skillResult).toMatchObject({
@@ -520,6 +551,57 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
     expect(skillResult.relations.childSkills?.[0]).not.toHaveProperty(
       "instructions"
     );
+  });
+
+  it("should return skills that reference a skill when nested_skills is enabled", async () => {
+    const { req, res, workspace, user } = await setupTest();
+
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(auth, "nested_skills");
+
+    const childSkill = await SkillFactory.create(auth, {
+      name: "Referenced Skill",
+    });
+    const parentSkill = await SkillFactory.create(auth, {
+      name: "Parent Skill",
+    });
+
+    await SkillFactory.linkSkillToSkill(auth, {
+      parentSkillId: parentSkill.id,
+      childSkillId: childSkill.id,
+    });
+
+    req.query = { ...req.query, wId: workspace.sId, withRelations: "true" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const skillResult = res
+      ._getJSONData()
+      .skills.find(
+        (s: SkillWithoutInstructionsAndToolsWithRelationsType) =>
+          s.sId === childSkill.sId
+      );
+
+    expect(skillResult).toMatchObject({
+      relations: {
+        usage: {
+          count: 0,
+          agents: [],
+          skills: [
+            {
+              sId: parentSkill.sId,
+              name: "Parent Skill",
+              icon: parentSkill.icon,
+            },
+          ],
+        },
+      },
+    });
   });
 
   it("should return skills without usage when withRelations is not set", async () => {

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -15,6 +15,7 @@ import {
   type SkillType,
   type SkillWithoutInstructionsAndToolsType,
   type SkillWithoutInstructionsAndToolsWithRelationsType,
+  type UsedBySkillType,
 } from "@app/types/assistant/skill_configuration";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -133,7 +134,7 @@ async function handler(
 
       if (withRelations === "true") {
         const featureFlags = await getFeatureFlags(auth);
-        const includeChildSkills = featureFlags.includes("nested_skills");
+        const includeNestedSkills = featureFlags.includes("nested_skills");
 
         const extendedSkills = await SkillResource.fetchByIds(
           auth,
@@ -146,12 +147,15 @@ async function handler(
           skills
         );
         let childSkillsMap = new Map<string, SkillResource[]>();
-        if (includeChildSkills) {
+        if (includeNestedSkills) {
           childSkillsMap = await SkillResource.batchFetchChildSkills(
             auth,
             skills
           );
         }
+        const usedBySkillsMap = includeNestedSkills
+          ? await SkillResource.batchFetchUsedBySkills(auth, skills)
+          : new Map<string, UsedBySkillType[]>();
 
         const extendedSkillsMap = new Map(
           extendedSkills.map((skill) => [skill.sId, skill])
@@ -168,18 +172,24 @@ async function handler(
           const usage = usageMap.get(sc.sId) ?? { count: 0, agents: [] };
           const editors = editorsMap.get(sc.sId) ?? null;
           const editedByUser = editedByUsersMap.get(sc.sId) ?? null;
+          const usageWithSkills = includeNestedSkills
+            ? {
+                ...usage,
+                skills: usedBySkillsMap.get(sc.sId) ?? [],
+              }
+            : usage;
 
           return {
             ...skillWithoutInstructionsAndTools,
             relations: {
-              usage,
+              usage: usageWithSkills,
               editors: editors ? editors.map((e) => e.toJSON()) : null,
               editedByUser: editedByUser ? editedByUser.toJSON() : null,
               extendedSkill: sc.extendedSkillId
                 ? (extendedSkillsMap.get(sc.extendedSkillId)?.toJSON(auth) ??
                   null)
                 : null,
-              ...(includeChildSkills
+              ...(includeNestedSkills
                 ? {
                     childSkills: (childSkillsMap.get(sc.sId) ?? []).map(
                       (childSkill) => {

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -172,10 +172,12 @@ async function handler(
           const usage = usageMap.get(sc.sId) ?? { count: 0, agents: [] };
           const editors = editorsMap.get(sc.sId) ?? null;
           const editedByUser = editedByUsersMap.get(sc.sId) ?? null;
+          const usedBySkills = usedBySkillsMap.get(sc.sId) ?? [];
           const usageWithSkills = includeNestedSkills
             ? {
                 ...usage,
-                skills: usedBySkillsMap.get(sc.sId) ?? [],
+                count: usage.count + usedBySkills.length,
+                skills: usedBySkills,
               }
             : usage;
 

--- a/front/tests/utils/SkillFactory.ts
+++ b/front/tests/utils/SkillFactory.ts
@@ -1,5 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
+import { SkillReferenceModel } from "@app/lib/models/skill/skill_reference";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { GlobalSkillId } from "@app/lib/resources/skill/code_defined/global_registry";
 import type { SystemSkillId } from "@app/lib/resources/skill/code_defined/system_registry";
@@ -113,5 +114,25 @@ export class SkillFactory {
     });
 
     return agentSkill;
+  }
+
+  // TODO(2026-05-29 aubin): replace with resource methods.
+  static async linkSkillToSkill(
+    auth: Authenticator,
+    {
+      parentSkillId,
+      childSkillId,
+    }: {
+      parentSkillId: ModelId;
+      childSkillId: ModelId;
+    }
+  ): Promise<SkillReferenceModel> {
+    const workspace = auth.getNonNullableWorkspace();
+
+    return SkillReferenceModel.create({
+      workspaceId: workspace.id,
+      parentSkillId,
+      childSkillId,
+    });
   }
 }

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -70,8 +70,18 @@ export const SkillSchema = SkillWithoutInstructionsAndToolsSchema.extend({
 
 export type SkillType = z.infer<typeof SkillSchema>;
 
+export type UsedBySkillType = {
+  sId: string;
+  name: string;
+  icon: string | null;
+};
+
+export type SkillUsageType = AgentsUsageType & {
+  skills?: UsedBySkillType[];
+};
+
 export type SkillRelations = {
-  usage: AgentsUsageType;
+  usage: SkillUsageType;
   editors: UserType[] | null;
   editedByUser: UserType | null;
   extendedSkill: SkillType | null;


### PR DESCRIPTION
## Description

This PR exposes skills that reference a given skill through the skills list relations payload, behind the nested_skills feature flag.

The API now reads `skill_references` and returns referencing skills through the existing `relations.usage` object. When nested_skills is enabled, `usage.count` is the total usage count across agents and referencing skills, while `usage.agents` and `usage.skills` keep the two lists available separately. This is the API/type/test base for the Manage Skills UI follow-up (show the parent skills in the Used by colum).

## Tests

- Updated Next and Hono skills route tests to cover nested_skills flag-on and flag-off behavior.

## Risk

- Low. Behind feature flag.

## Deploy Plan

- Deploy front.
