### PR TITLE
fix: do not mention space id in pod tools results

### DIFF
--- a/front/lib/api/actions/servers/pod_manager/helpers.ts
+++ b/front/lib/api/actions/servers/pod_manager/helpers.ts
@@ -22,8 +22,8 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
-export interface ProjectSpaceContext {
-  space: SpaceResource;
+interface PodContext {
+  pod: SpaceResource;
 }
 
 export async function buildProjectRetrieveDataSources(
@@ -97,12 +97,12 @@ export async function buildProjectRetrieveDataSources(
  * If dustPod is provided, uses that to fetch all spaces. Otherwise, gets from conversation.
  * The conversation must be in a project (space) if dustPod is not provided.
  */
-export async function getProjectSpace(
+export async function getPod(
   auth: Authenticator,
   from:
     | { agentLoopContext?: AgentLoopContextType }
     | { dustPod?: DustPodConfigurationType }
-): Promise<Result<ProjectSpaceContext, MCPError>> {
+): Promise<Result<PodContext, MCPError>> {
   if ("dustPod" in from && from.dustPod) {
     const { dustPod } = from;
     const authWorkspaceId = auth.getNonNullableWorkspace().sId;
@@ -130,14 +130,14 @@ export async function getProjectSpace(
     }
 
     // Fetch the space by podId.
-    const space = await SpaceResource.fetchById(auth, podId);
-    if (!space) {
+    const pod = await SpaceResource.fetchById(auth, podId);
+    if (!pod) {
       return new Err(
         new MCPError(`Pod not found: ${podId}`, { tracked: false })
       );
     }
 
-    return new Ok({ space });
+    return new Ok({ pod });
   }
 
   // Otherwise, use the existing logic to get space from conversation context.
@@ -182,7 +182,7 @@ export async function getProjectSpace(
       return new Err(new MCPError("Pod not found", { tracked: false }));
     }
 
-    return new Ok({ space });
+    return new Ok({ pod: space });
   }
 
   return new Err(new MCPError("No Pod context available", { tracked: false }));
@@ -210,21 +210,21 @@ export function checkWritePermission(
  * Gets the space context and verifies write permissions for all spaces.
  * This is a convenience function that combines getProjectSpace and checkWritePermission.
  */
-export async function getWritableProjectContext(
+export async function getWritablePodContext(
   auth: Authenticator,
   from:
     | { agentLoopContext?: AgentLoopContextType }
     | { dustPod?: DustPodConfigurationType }
-): Promise<Result<ProjectSpaceContext, MCPError>> {
-  const contextRes = await getProjectSpace(auth, from);
+): Promise<Result<PodContext, MCPError>> {
+  const contextRes = await getPod(auth, from);
   if (contextRes.isErr()) {
     return contextRes;
   }
 
-  const { space } = contextRes.value;
+  const { pod } = contextRes.value;
 
   // Check write permissions for all spaces.
-  const permissionRes = checkWritePermission(auth, space);
+  const permissionRes = checkWritePermission(auth, pod);
   if (permissionRes.isErr()) {
     return permissionRes;
   }

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -14,8 +14,8 @@ import {
 import { runIncludeDataRetrieval } from "@app/lib/api/actions/servers/include_data/include_function";
 import {
   buildProjectRetrieveDataSources,
-  getProjectSpace,
-  getWritableProjectContext,
+  getPod,
+  getWritablePodContext,
   makeSuccessResponse,
   withErrorHandling,
 } from "@app/lib/api/actions/servers/pod_manager/helpers";
@@ -96,7 +96,7 @@ export function createProjectManagerTools(
   const handlers: ToolHandlers<typeof POD_MANAGER_TOOLS_METADATA> = {
     add_content_node: async (params) => {
       return withErrorHandling(async () => {
-        const contextRes = await getWritableProjectContext(auth, {
+        const contextRes = await getWritablePodContext(auth, {
           agentLoopContext,
           dustPod: params.dustPod,
         });
@@ -104,7 +104,7 @@ export function createProjectManagerTools(
           return contextRes;
         }
 
-        const { space } = contextRes.value;
+        const { pod } = contextRes.value;
 
         const dataSourceId = extractDataSourceIdFromNodeId(
           params.dataSourceNodeId
@@ -151,7 +151,7 @@ export function createProjectManagerTools(
         }
 
         const upsertRes = await addContentNodeToProject(auth, {
-          space,
+          space: pod,
           contentFragment: {
             title: params.title,
             url: params.url,
@@ -186,7 +186,7 @@ export function createProjectManagerTools(
 
     remove_content_node: async (params) => {
       return withErrorHandling(async () => {
-        const contextRes = await getWritableProjectContext(auth, {
+        const contextRes = await getWritablePodContext(auth, {
           agentLoopContext,
           dustPod: params.dustPod,
         });
@@ -194,10 +194,10 @@ export function createProjectManagerTools(
           return contextRes;
         }
 
-        const { space } = contextRes.value;
+        const { pod } = contextRes.value;
 
         const removeRes = await removeContentNodesFromProject(auth, {
-          space,
+          space: pod,
           nodes: [
             {
               nodeId: params.nodeId,
@@ -225,7 +225,7 @@ export function createProjectManagerTools(
 
     edit_information: async (params) => {
       return withErrorHandling(async () => {
-        const contextRes = await getProjectSpace(auth, {
+        const contextRes = await getPod(auth, {
           agentLoopContext,
           dustPod: params.dustPod,
         });
@@ -233,9 +233,9 @@ export function createProjectManagerTools(
           return contextRes;
         }
 
-        const { space } = contextRes.value;
+        const { pod } = contextRes.value;
 
-        if (!space.canAdministrate(auth)) {
+        if (!pod.canAdministrate(auth)) {
           return new Err(
             new MCPError(
               "You do not have permission to edit this Pod's information",
@@ -261,7 +261,7 @@ export function createProjectManagerTools(
         const updates: Record<string, unknown> = {};
 
         if (title !== undefined) {
-          const updateNameRes = await space.updateName(auth, title);
+          const updateNameRes = await pod.updateName(auth, title);
           if (updateNameRes.isErr()) {
             return new Err(
               new MCPError(updateNameRes.error.message, { tracked: false })
@@ -274,7 +274,7 @@ export function createProjectManagerTools(
           if (pinnedFramePath !== undefined) {
             const validation = await validatePinnedFramePath(
               auth,
-              space,
+              pod,
               pinnedFramePath
             );
             if (validation.isErr()) {
@@ -284,13 +284,10 @@ export function createProjectManagerTools(
             }
           }
 
-          let metadata = await ProjectMetadataResource.fetchBySpace(
-            auth,
-            space
-          );
+          let metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
 
           if (!metadata) {
-            metadata = await ProjectMetadataResource.makeNew(auth, space, {
+            metadata = await ProjectMetadataResource.makeNew(auth, pod, {
               description: description ?? null,
               pinnedFramePath: pinnedFramePath ?? null,
             });
@@ -323,7 +320,7 @@ export function createProjectManagerTools(
 
     [UPDATE_MEMBERS_TOOL_NAME]: async (params) => {
       return withErrorHandling(async () => {
-        const contextRes = await getProjectSpace(auth, {
+        const contextRes = await getPod(auth, {
           agentLoopContext,
           dustPod: params.dustPod,
         });
@@ -331,9 +328,9 @@ export function createProjectManagerTools(
           return contextRes;
         }
 
-        const { space } = contextRes.value;
+        const { pod } = contextRes.value;
 
-        if (!space.canAdministrate(auth)) {
+        if (!pod.canAdministrate(auth)) {
           return new Err(
             new MCPError("You do not have permission to update Pod members", {
               tracked: false,
@@ -358,7 +355,7 @@ export function createProjectManagerTools(
 
         if (addMemberIds.length > 0) {
           const uniqueAddIds = [...new Set(addMemberIds)];
-          const addMembersRes = await space.addMembers(auth, {
+          const addMembersRes = await pod.addMembers(auth, {
             userIds: uniqueAddIds,
           });
           if (addMembersRes.isErr()) {
@@ -371,14 +368,14 @@ export function createProjectManagerTools(
           }
           added.push(...addMembersRes.value.map((user) => user.sId));
           notifyProjectMembersAdded(auth, {
-            project: space.toJSON(),
+            project: pod.toJSON(),
             addedUserIds: uniqueAddIds,
           });
         }
 
         if (removeMemberIds.length > 0) {
           const uniqueRemoveIds = [...new Set(removeMemberIds)];
-          const removeMembersRes = await space.removeMembers(auth, {
+          const removeMembersRes = await pod.removeMembers(auth, {
             userIds: uniqueRemoveIds,
           });
           if (removeMembersRes.isErr()) {
@@ -405,7 +402,7 @@ export function createProjectManagerTools(
 
     get_information: async (params) => {
       return withErrorHandling(async () => {
-        const contextRes = await getProjectSpace(auth, {
+        const contextRes = await getPod(auth, {
           agentLoopContext,
           dustPod: params.dustPod,
         });
@@ -413,19 +410,16 @@ export function createProjectManagerTools(
           return contextRes;
         }
 
-        const { space } = contextRes.value;
+        const { pod: pod } = contextRes.value;
         const owner = auth.getNonNullableWorkspace();
 
         // Fetch project metadata
-        const metadata = await ProjectMetadataResource.fetchBySpace(
-          auth,
-          space
-        );
+        const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
 
         // Linked content nodes (Company Data references) have no other discovery surface, so we
         // surface them here. Pod files do (they live under `pod-{podId}/<rel>` scoped paths and are
         // discovered through the `files` MCP server), so we only report a count plus a hint.
-        const attachments = await listProjectContextAttachments(auth, space);
+        const attachments = await listProjectContextAttachments(auth, pod);
         const contentNodes = attachments
           .filter(isContentNodeAttachmentType)
           .map((node) => ({
@@ -434,7 +428,7 @@ export function createProjectManagerTools(
             dataSourceViewId: node.nodeDataSourceViewId,
           }));
 
-        const fsResult = await DustFileSystem.forPod(auth, space);
+        const fsResult = await DustFileSystem.forPod(auth, pod);
         if (fsResult.isErr()) {
           return new Err(
             new MCPError("Failed to initialise file system for this Pod.", {
@@ -443,20 +437,20 @@ export function createProjectManagerTools(
           );
         }
         const podFiles = await fsResult.value.list(
-          `${SCOPED_PREFIX_POD}${space.sId}`
+          `${SCOPED_PREFIX_POD}${pod.sId}`
         );
         const projectFileCount = podFiles.filter((e) => !e.isDirectory).length;
 
         // Construct project URL
-        const projectPath = getPodRoute(owner.sId, space.sId);
+        const projectPath = getPodRoute(owner.sId, pod.sId);
         const projectUrl = `${config.getAppUrl()}${projectPath}`;
 
         return new Ok(
           makeSuccessResponse({
             success: true,
             pod: {
-              spaceId: space.sId,
-              name: space.name,
+              id: pod.sId,
+              name: pod.name,
               url: projectUrl,
               description: metadata?.description ?? null,
               pinnedFramePath: metadata?.pinnedFramePath ?? null,
@@ -473,7 +467,7 @@ export function createProjectManagerTools(
     },
     [LIST_MEMBERS_TOOL_NAME]: async (params) => {
       return withErrorHandling(async () => {
-        const contextRes = await getProjectSpace(auth, {
+        const contextRes = await getPod(auth, {
           agentLoopContext,
           dustPod: params.dustPod,
         });
@@ -481,7 +475,7 @@ export function createProjectManagerTools(
           return contextRes;
         }
 
-        const { space } = contextRes.value;
+        const { pod } = contextRes.value;
         const { limit = 20, pageCursor } = params;
 
         const decodedPageOffset = pageCursor
@@ -502,7 +496,7 @@ export function createProjectManagerTools(
         }
 
         const { groupsToProcess, allGroupMemberships } =
-          await space.fetchManualGroupsMemberships(auth, {
+          await pod.fetchManualGroupsMemberships(auth, {
             shouldIncludeAllMembers: true,
           });
 
@@ -580,7 +574,7 @@ export function createProjectManagerTools(
               hasMore: false,
               nextPageCursor: null,
               members: [],
-              message: `No members found in Pod "${space.name}".`,
+              message: `No members found in Pod "${pod.name}".`,
             })
           );
         }
@@ -598,7 +592,7 @@ export function createProjectManagerTools(
             hasMore,
             nextPageCursor,
             members: pageMembers,
-            message: `Found ${pageMembers.length} member(s) in Pod "${space.name}" (page)${hasMore ? ". Pass nextPageCursor to fetch more members." : ""}.`,
+            message: `Found ${pageMembers.length} member(s) in Pod "${pod.name}" (page)${hasMore ? ". Pass nextPageCursor to fetch more members." : ""}.`,
           })
         );
       }, "Failed to list Pod members");
@@ -695,17 +689,17 @@ export function createProjectManagerTools(
           }
         }
 
-        const projectSpace = createSpaceRes.value;
+        const pod = createSpaceRes.value;
 
         if (params.description) {
           const metadata = await ProjectMetadataResource.fetchBySpace(
             auth,
-            projectSpace
+            pod
           );
           if (metadata) {
             await metadata.updateDescription(params.description);
           } else {
-            await ProjectMetadataResource.makeNew(auth, projectSpace, {
+            await ProjectMetadataResource.makeNew(auth, pod, {
               description: params.description,
             });
           }
@@ -713,7 +707,7 @@ export function createProjectManagerTools(
 
         if (params.memberIds && params.memberIds.length > 0) {
           const uniqueMemberIds = [...new Set(params.memberIds)];
-          const addMembersRes = await projectSpace.addMembers(auth, {
+          const addMembersRes = await pod.addMembers(auth, {
             userIds: uniqueMemberIds,
           });
           if (addMembersRes.isErr()) {
@@ -727,7 +721,7 @@ export function createProjectManagerTools(
         }
 
         if (params.seedInitialTasks) {
-          const seedResult = await seedInitialPodTasks(auth, projectSpace);
+          const seedResult = await seedInitialPodTasks(auth, pod);
           if (
             seedResult.isErr() &&
             seedResult.error.code === "internal_error"
@@ -742,23 +736,23 @@ export function createProjectManagerTools(
 
         const projectUrl = `${config.getAppUrl()}${getPodRoute(
           owner.sId,
-          projectSpace.sId
+          pod.sId
         )}`;
 
         return new Ok(
           makeSuccessResponse({
             success: true,
             pod: {
-              spaceId: projectSpace.sId,
-              title: projectSpace.name,
-              visibility: projectSpace.isOpen() ? "open" : "private",
+              id: pod.sId,
+              title: pod.name,
+              visibility: pod.isOpen() ? "open" : "private",
               dustPod: {
-                uri: makePodConfigurationURI(owner.sId, projectSpace.sId),
+                uri: makePodConfigurationURI(owner.sId, pod.sId),
                 mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_POD,
               },
               url: projectUrl,
             },
-            message: `Pod "${projectSpace.name}" created successfully.`,
+            message: `Pod "${pod.name}" created successfully.`,
           })
         );
       }, "Failed to create Pod");
@@ -774,7 +768,7 @@ export function createProjectManagerTools(
           );
         }
 
-        const contextRes = await getProjectSpace(auth, {
+        const contextRes = await getPod(auth, {
           agentLoopContext,
           dustPod: params.dustPod,
         });
@@ -782,9 +776,9 @@ export function createProjectManagerTools(
           return contextRes;
         }
 
-        const { space } = contextRes.value;
+        const { pod } = contextRes.value;
         const dataSources = await buildProjectRetrieveDataSources(auth, {
-          space,
+          space: pod,
           onlyGroupConversationsAndConnectedData: false,
         });
 
@@ -816,7 +810,7 @@ export function createProjectManagerTools(
 
     create_conversation: async (params) => {
       return withErrorHandling(async () => {
-        const contextRes = await getWritableProjectContext(auth, {
+        const contextRes = await getWritablePodContext(auth, {
           agentLoopContext,
           dustPod: params.dustPod,
         });
@@ -824,7 +818,7 @@ export function createProjectManagerTools(
           return contextRes;
         }
 
-        const { space } = contextRes.value;
+        const { pod } = contextRes.value;
         const user = auth.user();
         const owner = auth.getNonNullableWorkspace();
 
@@ -870,7 +864,7 @@ export function createProjectManagerTools(
         const conversation = await createConversation(auth, {
           title: params.title,
           visibility: "unlisted",
-          spaceId: space.id,
+          spaceId: pod.id,
         });
 
         // Post user message
@@ -918,7 +912,7 @@ export function createProjectManagerTools(
             conversationId: conversation.sId,
             conversationUrl,
             userMessageId: messageRes.value.userMessage.sId,
-            message: `Conversation created successfully in Pod "${space.name}"`,
+            message: `Conversation created successfully in Pod "${pod.name}"`,
           })
         );
       }, "Failed to create conversation");
@@ -926,7 +920,7 @@ export function createProjectManagerTools(
 
     list_conversations: async (params) => {
       return withErrorHandling(async () => {
-        const contextRes = await getProjectSpace(auth, {
+        const contextRes = await getPod(auth, {
           agentLoopContext,
           dustPod: params.dustPod,
         });
@@ -934,7 +928,7 @@ export function createProjectManagerTools(
           return contextRes;
         }
 
-        const { space } = contextRes.value;
+        const { pod } = contextRes.value;
         const {
           unreadOnly = false,
           limit = 20,
@@ -959,7 +953,7 @@ export function createProjectManagerTools(
           } = await ConversationResource.listConversationsInSpacePaginated(
             auth,
             {
-              spaceId: space.sId,
+              spaceId: pod.sId,
               options: listOptions,
               pagination: {
                 limit,
@@ -972,7 +966,7 @@ export function createProjectManagerTools(
             return new Ok([
               {
                 type: "text" as const,
-                text: `No conversations found in Pod "${space.name}" updated on or after ${new Date(updatedSinceMs).toISOString()}.`,
+                text: `No conversations found in Pod "${pod.name}" updated on or after ${new Date(updatedSinceMs).toISOString()}.`,
               },
             ]);
           }
@@ -1010,14 +1004,14 @@ export function createProjectManagerTools(
               hasMore,
               nextPageCursor,
               conversations: conversationsPayload,
-              message: `Found ${conversationsPayload.length} conversation(s) in Pod "${space.name}" (page)${hasMore ? ". Pass nextPageCursor to fetch older updates in this window." : ""}.`,
+              message: `Found ${conversationsPayload.length} conversation(s) in Pod "${pod.name}" (page)${hasMore ? ". Pass nextPageCursor to fetch older updates in this window." : ""}.`,
             })
           );
         }
 
         const spaceConversations =
           await ConversationResource.listConversationsInSpace(auth, {
-            spaceId: space.sId,
+            spaceId: pod.sId,
             options: listOptions,
           });
 
@@ -1030,7 +1024,7 @@ export function createProjectManagerTools(
           return new Ok([
             {
               type: "text" as const,
-              text: `No unread conversations found in Pod "${space.name}" updated on or after ${new Date(updatedSinceMs).toISOString()}.`,
+              text: `No unread conversations found in Pod "${pod.name}" updated on or after ${new Date(updatedSinceMs).toISOString()}.`,
             },
           ]);
         }
@@ -1066,7 +1060,7 @@ export function createProjectManagerTools(
             includeMessages,
             updatedSince: updatedSinceMs,
             conversations: conversationsPayload,
-            message: `Found ${pageResources.length} unread conversation(s) in Pod "${space.name}"${unreadResources.length > limit ? ` (showing first ${limit} of ${unreadResources.length})` : ""}.`,
+            message: `Found ${pageResources.length} unread conversation(s) in Pod "${pod.name}"${unreadResources.length > limit ? ` (showing first ${limit} of ${unreadResources.length})` : ""}.`,
           })
         );
       }, "Failed to list Pod conversations");
@@ -1074,7 +1068,7 @@ export function createProjectManagerTools(
 
     add_message_to_conversation: async (params) => {
       return withErrorHandling(async () => {
-        const contextRes = await getWritableProjectContext(auth, {
+        const contextRes = await getWritablePodContext(auth, {
           agentLoopContext,
           dustPod: params.dustPod,
         });
@@ -1082,7 +1076,7 @@ export function createProjectManagerTools(
           return contextRes;
         }
 
-        const { space } = contextRes.value;
+        const { pod } = contextRes.value;
         const user = auth.user();
         const owner = auth.getNonNullableWorkspace();
 
@@ -1113,7 +1107,7 @@ export function createProjectManagerTools(
         }
 
         const conversation = conversationRes.value;
-        if (conversation.spaceId !== space.sId) {
+        if (conversation.spaceId !== pod.sId) {
           return new Err(
             new MCPError("Conversation is not in this Pod", {
               tracked: false,
@@ -1200,7 +1194,7 @@ export function createProjectManagerTools(
             conversationId: conversation.sId,
             conversationUrl,
             userMessageId: messageRes.value.userMessage.sId,
-            message: `Message posted to conversation in Pod "${space.name}".`,
+            message: `Message posted to conversation in Pod "${pod.name}".`,
           })
         );
       }, "Failed to add message to conversation");

--- a/front/lib/api/actions/servers/pod_tasks/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_tasks/tools/index.ts
@@ -6,7 +6,7 @@ import type {
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import {
-  getProjectSpace,
+  getPod,
   withErrorHandling,
 } from "@app/lib/api/actions/servers/pod_manager/helpers";
 import {
@@ -103,24 +103,24 @@ export function createProjectTasksTools(
       dustPod,
     }) => {
       return withErrorHandling(async () => {
-        const contextRes = await getProjectSpace(auth, {
+        const contextRes = await getPod(auth, {
           agentLoopContext,
           dustPod,
         });
         if (contextRes.isErr()) {
           return contextRes;
         }
-        const { space } = contextRes.value;
+        const { pod } = contextRes.value;
 
         let rows: ProjectTaskResource[] = [];
 
         if (assigneeFilter === "mine") {
           rows = await ProjectTaskResource.fetchLatestBySpace(auth, {
-            spaceId: space.id,
+            spaceId: pod.id,
           });
         } else if (assigneeFilter === "all") {
           rows = await ProjectTaskResource.fetchBySpace(auth, {
-            spaceId: space.id,
+            spaceId: pod.id,
             timeScope: "all",
           });
         }
@@ -175,17 +175,17 @@ export function createProjectTasksTools(
 
     [CREATE_TASKS_TOOL_NAME]: async ({ creatorType, tasks, dustPod }) => {
       return withErrorHandling(async () => {
-        const contextRes = await getProjectSpace(auth, {
+        const contextRes = await getPod(auth, {
           agentLoopContext,
           dustPod,
         });
         if (contextRes.isErr()) {
           return contextRes;
         }
-        const { space } = contextRes.value;
+        const { pod } = contextRes.value;
 
         const assignmentPool =
-          await space.fetchDistinctActiveManualGroupMembers(auth);
+          await pod.fetchDistinctActiveManualGroupMembers(auth);
         const soleAssigneeModelId =
           assignmentPool.length === 1 ? assignmentPool[0]!.id : null;
 
@@ -202,7 +202,7 @@ export function createProjectTasksTools(
               item.userId,
               owner.sId
             );
-            if (!contextRes.value.space.isMember(userAuth)) {
+            if (!contextRes.value.pod.isMember(userAuth)) {
               errors.push(
                 `Could not create task ${item.text} for user ${item.userId} because they are not a member of the Pod.`
               );
@@ -217,7 +217,7 @@ export function createProjectTasksTools(
           }
 
           const row = await ProjectTaskResource.makeNew(auth, {
-            spaceId: space.id,
+            spaceId: pod.id,
             userId: newUserId,
             createdByType: creatorType,
             createdByAgentConfigurationId:
@@ -275,7 +275,7 @@ export function createProjectTasksTools(
 
     mark_task_done: async ({ actorType, taskIds, dustPod }) => {
       return withErrorHandling(async () => {
-        const contextRes = await getProjectSpace(auth, {
+        const contextRes = await getPod(auth, {
           agentLoopContext,
           dustPod,
         });
@@ -343,14 +343,14 @@ export function createProjectTasksTools(
 
     [UPDATE_TASKS_TOOL_NAME]: async ({ tasks, dustPod }) => {
       return withErrorHandling(async () => {
-        const contextRes = await getProjectSpace(auth, {
+        const contextRes = await getPod(auth, {
           agentLoopContext,
           dustPod,
         });
         if (contextRes.isErr()) {
           return contextRes;
         }
-        const { space } = contextRes.value;
+        const { pod } = contextRes.value;
 
         const updated: string[] = [];
         const errors: string[] = [];
@@ -364,7 +364,7 @@ export function createProjectTasksTools(
           }
 
           const payloadRes = await buildTaskUpdatePayload(
-            space,
+            pod,
             owner.sId,
             row,
             item
@@ -401,7 +401,7 @@ export function createProjectTasksTools(
       dustPod,
     }) => {
       return withErrorHandling(async () => {
-        const contextRes = await getProjectSpace(auth, {
+        const contextRes = await getPod(auth, {
           agentLoopContext,
           dustPod,
         });
@@ -409,7 +409,7 @@ export function createProjectTasksTools(
           return contextRes;
         }
 
-        const { space } = contextRes.value;
+        const { pod } = contextRes.value;
         let agentConfigurationId: string | undefined;
         if (agentName) {
           const matchedAgentId = await resolveAgentConfigurationIdByName(
@@ -427,7 +427,7 @@ export function createProjectTasksTools(
         }
 
         const startRes = await startAgentForProjectTask(auth, {
-          space,
+          space: pod,
           taskId,
           agentConfigurationId,
           customMessage,


### PR DESCRIPTION
## Description

This PR removes the `spaceId` field from pod tool results in favor of `id`.
Additionally it renames internal pod manager helper functions and types from space-oriented to pod-oriented naming.

## Tests

Manually.

## Risks

## Deploy Plan

