### PR TITLE
chore(docker): remove COMMIT_HASH ARG from base-deps to fix cache busting

### DIFF
--- a/dockerfiles/front.Dockerfile
+++ b/dockerfiles/front.Dockerfile
@@ -4,10 +4,6 @@ FROM node:24.14.0-slim AS base-deps
 RUN apt-get update && \
   apt-get install -y libjemalloc2 libjemalloc-dev
 
-# Only non-Next.js build args needed for base deps
-ARG COMMIT_HASH
-ARG COMMIT_HASH_LONG
-
 RUN npm install -g npm@11.11.0
 
 WORKDIR /app


### PR DESCRIPTION
## Description

`ARG COMMIT_HASH` and `ARG COMMIT_HASH_LONG` were declared in the `base-deps` stage _before_ `RUN npm install -g npm@11.11.0`, causing Docker to invalidate the npm global install layer (and all subsequent `npm ci` / SDK / Sparkle build layers) on every single build, since COMMIT_HASH changes with every commit.

These ARGs are never referenced in `base-deps` — they're re-declared in every child stage that actually uses them. Removing them lets the `npm install -g npm` + `npm ci` layers cache across commits, saving ~70s per build.

[With this PR](https://github.com/dust-tt/dust/actions/runs/26638352526/job/78505932441): `9m 12s`
[Without this PR](https://github.com/dust-tt/dust/actions/runs/26637685384/job/78502941368): `10m 25s`

## Tests

No functional change — build output is identical.
