### PR TITLE
[front] feat: support tool references in Skill Builder instructions

### DIFF
--- a/front/components/editor/extensions/skill_builder/ToolChip.tsx
+++ b/front/components/editor/extensions/skill_builder/ToolChip.tsx
@@ -1,0 +1,63 @@
+import {
+  getIcon,
+  isCustomResourceIconType,
+  isInternalAllowedIcon,
+} from "@app/components/resources/resources_icons";
+import {
+  AttachmentChip,
+  ExclamationCircleIcon,
+  ToolsIcon,
+} from "@dust-tt/sparkle";
+import type React from "react";
+
+function getToolIcon(toolIcon: string | null) {
+  if (
+    toolIcon &&
+    (isCustomResourceIconType(toolIcon) || isInternalAllowedIcon(toolIcon))
+  ) {
+    return getIcon(toolIcon);
+  }
+
+  return ToolsIcon;
+}
+
+interface ToolChipProps {
+  color?: React.ComponentProps<typeof AttachmentChip>["color"];
+  onRemove?: () => void;
+  title: string;
+  toolIcon: string | null;
+}
+
+export function ToolChip({
+  color = "white",
+  onRemove,
+  title,
+  toolIcon,
+}: ToolChipProps) {
+  return (
+    <AttachmentChip
+      label={title}
+      icon={{ visual: getToolIcon(toolIcon) }}
+      color={color}
+      onRemove={onRemove}
+      size="xs"
+    />
+  );
+}
+
+interface ToolErrorChipProps {
+  onRemove?: () => void;
+  title: string;
+}
+
+export function ToolErrorChip({ onRemove, title }: ToolErrorChipProps) {
+  return (
+    <AttachmentChip
+      label={title}
+      icon={{ visual: ExclamationCircleIcon }}
+      color="white"
+      onRemove={onRemove}
+      size="xs"
+    />
+  );
+}

--- a/front/components/editor/extensions/skill_builder/ToolNode.test.ts
+++ b/front/components/editor/extensions/skill_builder/ToolNode.test.ts
@@ -1,0 +1,160 @@
+import { ToolNode } from "@app/components/editor/extensions/skill_builder/ToolNode";
+import type { ToolNodeAttributes } from "@app/components/editor/extensions/skill_builder/ToolNodeTypes";
+import { EditorFactory } from "@app/components/editor/extensions/tests/utils";
+import {
+  extractToolTags,
+  parseToolTag,
+  serializeToolTag,
+  stripToolTagPresentationAttributes,
+} from "@app/lib/tools/format";
+import type { Editor } from "@tiptap/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const TOOL_ATTRS: ToolNodeAttributes = {
+  mcpServerViewId: "mcp_server_view_123",
+  toolIcon: "GithubLogo",
+  toolName: "GitHub Search",
+};
+
+function toolNodes(editor: Editor) {
+  const nodes: { attrs?: ToolNodeAttributes; type: string }[] = [];
+  editor.state.doc.descendants((node) => {
+    if (node.type.name === "toolNode") {
+      nodes.push({
+        attrs: {
+          mcpServerViewId: node.attrs.mcpServerViewId,
+          toolIcon: node.attrs.toolIcon,
+          toolName: node.attrs.toolName,
+        },
+        type: node.type.name,
+      });
+    }
+  });
+  return nodes;
+}
+
+describe("ToolNode tag helpers", () => {
+  it("serializes and parses tool tags with XML escaping", () => {
+    const attrs = {
+      icon: "GithubLogo",
+      id: "mcp_server_view_123",
+      name: 'GitHub & "Issues" <Prod>',
+    };
+
+    const tag = serializeToolTag(attrs);
+
+    expect(tag).toContain("GitHub &amp; &quot;Issues&quot; &lt;Prod&gt;");
+    expect(parseToolTag(tag)).toEqual(attrs);
+  });
+
+  it("parses missing icon as null", () => {
+    expect(
+      parseToolTag('<tool id="mcp_server_view_123" name="GitHub Search" />')
+    ).toEqual({
+      icon: null,
+      id: "mcp_server_view_123",
+      name: "GitHub Search",
+    });
+  });
+
+  it("extracts valid tool tags from content", () => {
+    expect(
+      extractToolTags(
+        'Use <tool id="mcp_server_view_1" name="A" /> and <tool id="mcp_server_view_2" name="B" icon="ToolsIcon" />.'
+      )
+    ).toEqual([
+      {
+        icon: null,
+        id: "mcp_server_view_1",
+        name: "A",
+      },
+      {
+        icon: "ToolsIcon",
+        id: "mcp_server_view_2",
+        name: "B",
+      },
+    ]);
+  });
+
+  it("strips icon presentation attributes from tool tags", () => {
+    expect(
+      stripToolTagPresentationAttributes(
+        '<tool id="mcp_server_view_123" name="GitHub Search" icon="GithubLogo" />'
+      )
+    ).toBe('<tool id="mcp_server_view_123" name="GitHub Search" />');
+
+    expect(
+      stripToolTagPresentationAttributes(
+        '<tool id="mcp_server_view_123" name="GitHub Search" icon="GithubLogo"><span>GitHub Search</span></tool>'
+      )
+    ).toBe('<tool id="mcp_server_view_123" name="GitHub Search" />');
+  });
+});
+
+describe("ToolNode", () => {
+  let editor: Editor;
+
+  beforeEach(() => {
+    editor = EditorFactory([ToolNode]);
+  });
+
+  afterEach(() => {
+    editor.destroy();
+  });
+
+  it("round-trips markdown tool tags", () => {
+    editor.commands.setContent(
+      `Use ${serializeToolTag({
+        icon: TOOL_ATTRS.toolIcon,
+        id: TOOL_ATTRS.mcpServerViewId,
+        name: TOOL_ATTRS.toolName,
+      })} now.`,
+      {
+        contentType: "markdown",
+      }
+    );
+
+    expect(toolNodes(editor)).toEqual([
+      {
+        attrs: TOOL_ATTRS,
+        type: "toolNode",
+      },
+    ]);
+    expect(editor.getMarkdown()).toContain(
+      serializeToolTag({
+        icon: TOOL_ATTRS.toolIcon,
+        id: TOOL_ATTRS.mcpServerViewId,
+        name: TOOL_ATTRS.toolName,
+      })
+    );
+  });
+
+  it("round-trips stored HTML tool tags", () => {
+    editor.commands.setContent(
+      '<p>Use <tool id="mcp_server_view_123" name="GitHub Search" icon="GithubLogo"></tool>.</p>'
+    );
+
+    expect(toolNodes(editor)).toEqual([
+      {
+        attrs: TOOL_ATTRS,
+        type: "toolNode",
+      },
+    ]);
+    expect(editor.getHTML()).toContain("<tool");
+    expect(editor.getHTML()).toContain('id="mcp_server_view_123"');
+    expect(editor.getHTML()).toContain('name="GitHub Search"');
+    expect(editor.getHTML()).toContain('icon="GithubLogo"');
+  });
+
+  it("inserts a tool node followed by a space", () => {
+    editor.commands.insertToolNode(TOOL_ATTRS);
+
+    expect(toolNodes(editor)).toEqual([
+      {
+        attrs: TOOL_ATTRS,
+        type: "toolNode",
+      },
+    ]);
+    expect(editor.getText()).toBe("/GitHub Search ");
+  });
+});

--- a/front/components/editor/extensions/skill_builder/ToolNode.test.ts
+++ b/front/components/editor/extensions/skill_builder/ToolNode.test.ts
@@ -2,6 +2,10 @@ import { ToolNode } from "@app/components/editor/extensions/skill_builder/ToolNo
 import type { ToolNodeAttributes } from "@app/components/editor/extensions/skill_builder/ToolNodeTypes";
 import { EditorFactory } from "@app/components/editor/extensions/tests/utils";
 import {
+  postProcessMarkdown,
+  preprocessMarkdownForEditor,
+} from "@app/lib/editor/skill_instructions_preprocessing";
+import {
   extractToolTags,
   parseToolTag,
   serializeToolTag,
@@ -57,6 +61,16 @@ describe("ToolNode tag helpers", () => {
     });
   });
 
+  it("rejects malformed tool tags", () => {
+    expect(parseToolTag('<tool name="GitHub Search" />')).toBeNull();
+    expect(parseToolTag('<tool id="mcp_server_view_123" />')).toBeNull();
+    expect(
+      parseToolTag(
+        '<tool id="mcp_server_view_123" name="GitHub Search"></tool>'
+      )
+    ).toBeNull();
+  });
+
   it("extracts valid tool tags from content", () => {
     expect(
       extractToolTags(
@@ -103,16 +117,15 @@ describe("ToolNode", () => {
   });
 
   it("round-trips markdown tool tags", () => {
-    editor.commands.setContent(
-      `Use ${serializeToolTag({
-        icon: TOOL_ATTRS.toolIcon,
-        id: TOOL_ATTRS.mcpServerViewId,
-        name: TOOL_ATTRS.toolName,
-      })} now.`,
-      {
-        contentType: "markdown",
-      }
-    );
+    const markdown = `Use ${serializeToolTag({
+      icon: TOOL_ATTRS.toolIcon,
+      id: TOOL_ATTRS.mcpServerViewId,
+      name: TOOL_ATTRS.toolName,
+    })} now.`;
+
+    editor.commands.setContent(preprocessMarkdownForEditor(markdown), {
+      contentType: "markdown",
+    });
 
     expect(toolNodes(editor)).toEqual([
       {
@@ -127,6 +140,18 @@ describe("ToolNode", () => {
         name: TOOL_ATTRS.toolName,
       })
     );
+  });
+
+  it("keeps malformed markdown tool tags as text", () => {
+    const markdown =
+      'Literal <tool name="GitHub Search">example</tool> and <tool id="mcp_server_view_123" />.';
+
+    editor.commands.setContent(preprocessMarkdownForEditor(markdown), {
+      contentType: "markdown",
+    });
+
+    expect(toolNodes(editor)).toEqual([]);
+    expect(postProcessMarkdown(editor.getMarkdown())).toContain(markdown);
   });
 
   it("round-trips stored HTML tool tags", () => {
@@ -144,6 +169,15 @@ describe("ToolNode", () => {
     expect(editor.getHTML()).toContain('id="mcp_server_view_123"');
     expect(editor.getHTML()).toContain('name="GitHub Search"');
     expect(editor.getHTML()).toContain('icon="GithubLogo"');
+  });
+
+  it("does not parse malformed stored HTML tool tags", () => {
+    editor.commands.setContent(
+      '<p>Literal <tool name="GitHub Search">example</tool>.</p>'
+    );
+
+    expect(toolNodes(editor)).toEqual([]);
+    expect(editor.getText()).toContain("Literal example.");
   });
 
   it("inserts a tool node followed by a space", () => {

--- a/front/components/editor/extensions/skill_builder/ToolNode.ts
+++ b/front/components/editor/extensions/skill_builder/ToolNode.ts
@@ -55,7 +55,20 @@ export const ToolNode = Node.create({
   },
 
   parseHTML() {
-    return [{ tag: TOOL_TAG_NAME }];
+    return [
+      {
+        tag: TOOL_TAG_NAME,
+        getAttrs: (node) => {
+          if (!(node instanceof HTMLElement)) {
+            return false;
+          }
+
+          return node.getAttribute("id") && node.getAttribute("name")
+            ? null
+            : false;
+        },
+      },
+    ];
   },
 
   renderHTML({ node, HTMLAttributes }) {

--- a/front/components/editor/extensions/skill_builder/ToolNode.ts
+++ b/front/components/editor/extensions/skill_builder/ToolNode.ts
@@ -1,0 +1,140 @@
+import type { ToolNodeAttributes } from "@app/components/editor/extensions/skill_builder/ToolNodeTypes";
+import {
+  parseToolTag,
+  serializeToolTag,
+  TOOL_TAG_NAME,
+  TOOL_TAG_REGEX_BEGINNING,
+} from "@app/lib/tools/format";
+import { isString } from "@app/types/shared/utils/general";
+import { Node } from "@tiptap/core";
+
+export const TOOL_NODE_TYPE = "toolNode";
+
+const TOOL_CHIP_CLASS =
+  "inline-flex items-center gap-0.5 border border-current/40 rounded px-0.5 text-xs leading-tight";
+const TOOL_LABEL_PREFIX = "Tool";
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    toolNode: {
+      insertToolNode: (attrs: ToolNodeAttributes) => ReturnType;
+    };
+  }
+}
+
+export const ToolNode = Node.create({
+  name: TOOL_NODE_TYPE,
+  group: "inline",
+  inline: true,
+  atom: true,
+  selectable: false,
+
+  addAttributes() {
+    return {
+      mcpServerViewId: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("id"),
+        renderHTML: (attributes) =>
+          isString(attributes.mcpServerViewId)
+            ? { id: attributes.mcpServerViewId }
+            : {},
+      },
+      toolName: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("name"),
+        renderHTML: (attributes) =>
+          isString(attributes.toolName) ? { name: attributes.toolName } : {},
+      },
+      toolIcon: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("icon"),
+        renderHTML: (attributes) =>
+          isString(attributes.toolIcon) ? { icon: attributes.toolIcon } : {},
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: TOOL_TAG_NAME }];
+  },
+
+  renderHTML({ node, HTMLAttributes }) {
+    const { toolName } = node.attrs;
+    if (!isString(toolName)) {
+      return ["span", {}];
+    }
+
+    return [
+      TOOL_TAG_NAME,
+      HTMLAttributes,
+      [
+        "span",
+        { class: TOOL_CHIP_CLASS },
+        ["span", {}, TOOL_LABEL_PREFIX],
+        ["span", {}, ` ${toolName}`],
+      ],
+    ];
+  },
+
+  renderText({ node }) {
+    return `/${node.attrs.toolName ?? "tool"}`;
+  },
+
+  addCommands() {
+    return {
+      insertToolNode:
+        (attrs: ToolNodeAttributes) =>
+        ({ commands }) =>
+          commands.insertContent([
+            {
+              type: TOOL_NODE_TYPE,
+              attrs,
+            },
+            { type: "text", text: " " },
+          ]),
+    };
+  },
+
+  markdownTokenizer: {
+    name: TOOL_NODE_TYPE,
+    level: "inline",
+    start: (src) => src.indexOf(`<${TOOL_TAG_NAME}`),
+    tokenize: (src) => {
+      const match = TOOL_TAG_REGEX_BEGINNING.exec(src);
+      if (!match) {
+        return undefined;
+      }
+
+      const tool = parseToolTag(match[0]);
+      if (!tool) {
+        return undefined;
+      }
+
+      return {
+        type: TOOL_NODE_TYPE,
+        raw: match[0],
+        mcpServerViewId: tool.id,
+        toolIcon: tool.icon,
+        toolName: tool.name,
+      };
+    },
+  },
+
+  parseMarkdown: (token) => ({
+    type: TOOL_NODE_TYPE,
+    attrs: {
+      mcpServerViewId: token.mcpServerViewId,
+      toolIcon: token.toolIcon,
+      toolName: token.toolName,
+    },
+  }),
+
+  renderMarkdown: (node) =>
+    isString(node.attrs?.mcpServerViewId) && isString(node.attrs?.toolName)
+      ? serializeToolTag({
+          icon: isString(node.attrs.toolIcon) ? node.attrs.toolIcon : null,
+          id: node.attrs.mcpServerViewId,
+          name: node.attrs.toolName,
+        })
+      : "",
+});

--- a/front/components/editor/extensions/skill_builder/ToolNodeTypes.ts
+++ b/front/components/editor/extensions/skill_builder/ToolNodeTypes.ts
@@ -1,0 +1,5 @@
+export interface ToolNodeAttributes {
+  mcpServerViewId: string;
+  toolIcon: string | null;
+  toolName: string;
+}

--- a/front/components/editor/extensions/skill_builder/ToolNodeWithView.tsx
+++ b/front/components/editor/extensions/skill_builder/ToolNodeWithView.tsx
@@ -1,0 +1,86 @@
+import {
+  ToolChip,
+  ToolErrorChip,
+} from "@app/components/editor/extensions/skill_builder/ToolChip";
+import { ToolNode } from "@app/components/editor/extensions/skill_builder/ToolNode";
+import type { ToolNodeAttributes } from "@app/components/editor/extensions/skill_builder/ToolNodeTypes";
+import { useMaybeMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
+import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
+import type { NodeViewProps } from "@tiptap/react";
+import { NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
+import type React from "react";
+import { useCallback, useMemo } from "react";
+
+function useToolNodeDisplay(attrs: ToolNodeAttributes) {
+  const ctx = useMaybeMCPServerViewsContext();
+
+  return useMemo(() => {
+    if (!ctx || ctx.isMCPServerViewsLoading) {
+      return {
+        kind: "tool" as const,
+        title: attrs.toolName,
+        toolIcon: attrs.toolIcon,
+      };
+    }
+
+    const view = ctx.mcpServerViews.find(
+      (v) => v.sId === attrs.mcpServerViewId
+    );
+
+    if (!view || ctx.isMCPServerViewsError) {
+      return {
+        kind: "error" as const,
+        title: attrs.toolName,
+      };
+    }
+
+    return {
+      kind: "tool" as const,
+      title: getMcpServerViewDisplayName(view),
+      toolIcon: view.server.icon,
+    };
+  }, [attrs.mcpServerViewId, attrs.toolIcon, attrs.toolName, ctx]);
+}
+
+const ToolNodeView: React.FC<NodeViewProps> = ({
+  deleteNode,
+  editor,
+  node,
+}) => {
+  const attrs: ToolNodeAttributes = {
+    mcpServerViewId: node.attrs.mcpServerViewId,
+    toolIcon: node.attrs.toolIcon,
+    toolName: node.attrs.toolName,
+  };
+  const display = useToolNodeDisplay(attrs);
+
+  const handleRemove = useCallback(
+    (e?: React.MouseEvent) => {
+      e?.stopPropagation();
+      deleteNode();
+    },
+    [deleteNode]
+  );
+
+  const onRemove = editor.isEditable ? handleRemove : undefined;
+
+  return (
+    <NodeViewWrapper className="inline">
+      {display.kind === "error" ? (
+        <ToolErrorChip title={display.title} onRemove={onRemove} />
+      ) : (
+        <ToolChip
+          title={display.title}
+          toolIcon={display.toolIcon}
+          onRemove={onRemove}
+        />
+      )}
+    </NodeViewWrapper>
+  );
+};
+
+export const ToolNodeWithView = ToolNode.extend({
+  addNodeView() {
+    return ReactNodeViewRenderer(ToolNodeView);
+  },
+});

--- a/front/components/editor/extensions/skill_builder/ToolNodeWithView.tsx
+++ b/front/components/editor/extensions/skill_builder/ToolNodeWithView.tsx
@@ -65,7 +65,7 @@ const ToolNodeView: React.FC<NodeViewProps> = ({
   const onRemove = editor.isEditable ? handleRemove : undefined;
 
   return (
-    <NodeViewWrapper className="inline">
+    <NodeViewWrapper as="span" className="inline">
       {display.kind === "error" ? (
         <ToolErrorChip title={display.title} onRemove={onRemove} />
       ) : (

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -27,6 +27,23 @@ import { useController, useFormContext } from "react-hook-form";
 const INSTRUCTIONS_FIELD_NAME = "instructions";
 const INSTRUCTIONS_HTML_FIELD_NAME = "instructionsHtml";
 const ATTACHED_KNOWLEDGE_FIELD_NAME = "attachedKnowledge";
+const ALLOWED_INSTRUCTIONS_TAGS = ["knowledge", "tool"];
+const ALLOWED_INSTRUCTIONS_ATTRS = [
+  "space",
+  "dsv",
+  "hasChildren",
+  "id",
+  "name",
+  "icon",
+];
+
+function getSkillInstructionsSanitizeConfig(): Config {
+  return {
+    ADD_TAGS: [...ALLOWED_INSTRUCTIONS_TAGS],
+    ADD_ATTR: [...ALLOWED_INSTRUCTIONS_ATTRS],
+    FORBID_ATTR: ["style", "class"],
+  };
+}
 
 function collectKnowledgeItems(editor: Editor): KnowledgeItem[] {
   const items: KnowledgeItem[] = [];
@@ -52,12 +69,7 @@ function toAttachedKnowledge(
 
 function sanitizeSkillInstructionsHtml(html: string): string {
   try {
-    const config: Config = {
-      ADD_TAGS: ["knowledge"],
-      ADD_ATTR: ["space", "dsv", "hasChildren"],
-      FORBID_ATTR: ["style", "class"],
-    };
-    return DOMPurify.sanitize(html, config);
+    return DOMPurify.sanitize(html, getSkillInstructionsSanitizeConfig());
   } catch {
     return html;
   }

--- a/front/components/skills/SkillInstructionsReadOnlyEditor.tsx
+++ b/front/components/skills/SkillInstructionsReadOnlyEditor.tsx
@@ -4,6 +4,7 @@ import {
   SkillInstructionsEditorContent,
   useSkillInstructionsEditor,
 } from "@app/components/editor/SkillInstructionsEditor";
+import { MCPServerViewsProvider } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useEffect } from "react";
 
@@ -51,11 +52,13 @@ export function SkillInstructionsReadOnlyEditor({
 
   return (
     <SpacesProvider owner={owner}>
-      <SkillInstructionsEditorContent
-        editor={editor}
-        isReadOnly
-        className={className}
-      />
+      <MCPServerViewsProvider owner={owner}>
+        <SkillInstructionsEditorContent
+          editor={editor}
+          isReadOnly
+          className={className}
+        />
+      </MCPServerViewsProvider>
     </SpacesProvider>
   );
 }

--- a/front/lib/api/assistant/skills_rendering.test.ts
+++ b/front/lib/api/assistant/skills_rendering.test.ts
@@ -1,0 +1,33 @@
+import { getEnabledSkillInstructions } from "@app/lib/api/assistant/skills_rendering";
+import { describe, expect, it } from "vitest";
+
+type SkillInstructionsSource = Parameters<
+  typeof getEnabledSkillInstructions
+>[0];
+
+function makeEnabledSkill(
+  overrides: Partial<SkillInstructionsSource>
+): SkillInstructionsSource {
+  return {
+    name: "ResearchSkill",
+    instructions: "",
+    extendedSkill: null,
+    ...overrides,
+  };
+}
+
+describe("getEnabledSkillInstructions", () => {
+  it("strips tool icon attributes from model-facing skill instructions", () => {
+    const skill = makeEnabledSkill({
+      instructions:
+        'Use <tool id="mcp_server_view_1" name="GitHub Search" icon="GithubLogo" />.',
+    });
+
+    expect(getEnabledSkillInstructions(skill)).toContain(
+      '<tool id="mcp_server_view_1" name="GitHub Search" />'
+    );
+    expect(getEnabledSkillInstructions(skill)).not.toContain(
+      'icon="GithubLogo"'
+    );
+  });
+});

--- a/front/lib/api/assistant/skills_rendering.ts
+++ b/front/lib/api/assistant/skills_rendering.ts
@@ -4,10 +4,15 @@ import {
 } from "@app/lib/actions/constants";
 import { SKILL_MANAGEMENT_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { stripToolTagPresentationAttributes } from "@app/lib/tools/format";
 import type { UserMessageTypeModel } from "@app/types/assistant/generation";
 
 export type EnabledSkill = SkillResource & {
   extendedSkill: SkillResource | null;
+};
+
+type SkillInstructionsSource = Pick<SkillResource, "name" | "instructions"> & {
+  extendedSkill: Pick<SkillResource, "instructions"> | null;
 };
 
 function renderSystemSkillMessage(text: string): UserMessageTypeModel {
@@ -18,18 +23,25 @@ function renderSystemSkillMessage(text: string): UserMessageTypeModel {
   };
 }
 
-export function getEnabledSkillInstructions(skill: EnabledSkill): string {
+export function getEnabledSkillInstructions(
+  skill: SkillInstructionsSource
+): string {
   const { name, instructions, extendedSkill } = skill;
+  const modelInstructions = stripToolTagPresentationAttributes(instructions);
 
   if (!extendedSkill) {
-    return `<${name}>\n${instructions}\n</${name}>`;
+    return `<${name}>\n${modelInstructions}\n</${name}>`;
   }
+
+  const extendedModelInstructions = stripToolTagPresentationAttributes(
+    extendedSkill.instructions
+  );
 
   return [
     `<${name}>`,
-    extendedSkill.instructions,
+    extendedModelInstructions,
     "<additional_guidelines>",
-    instructions,
+    modelInstructions,
     "</additional_guidelines>",
     `</${name}>`,
   ].join("\n");

--- a/front/lib/editor/build_skill_instructions_extensions.ts
+++ b/front/lib/editor/build_skill_instructions_extensions.ts
@@ -10,6 +10,7 @@ import {
   RawMarkdownBlock,
   rawMarkdownBlockParsers,
 } from "@app/components/editor/extensions/skill_builder/RawMarkdownBlock";
+import { ToolNodeWithView } from "@app/components/editor/extensions/skill_builder/ToolNodeWithView";
 import { LinkExtension } from "@app/components/editor/input_bar/LinkExtension";
 import { markdownStyles } from "@dust-tt/sparkle";
 import type { Extensions } from "@tiptap/core";
@@ -17,6 +18,10 @@ import { Markdown } from "@tiptap/markdown";
 import { StarterKit } from "@tiptap/starter-kit";
 
 export const INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT = 120_000;
+
+interface BuildSkillInstructionsExtensionsOptions {
+  enableToolReferences?: boolean;
+}
 
 /**
  * Build the TipTap extension list for the skill instructions editor.
@@ -26,7 +31,8 @@ export const INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT = 120_000;
  */
 export function buildSkillInstructionsExtensions(
   isReadOnly: boolean,
-  editableExtensions: Extensions = []
+  editableExtensions: Extensions = [],
+  { enableToolReferences = true }: BuildSkillInstructionsExtensionsOptions = {}
 ): Extensions {
   const baseExtensions: Extensions = [
     InstructionsDocumentExtension,
@@ -86,10 +92,17 @@ export function buildSkillInstructionsExtensions(
     }),
     BlockIdExtension,
     KnowledgeNodeWithView.configure({ readOnly: isReadOnly }),
+  ];
+
+  if (enableToolReferences) {
+    baseExtensions.push(ToolNodeWithView);
+  }
+
+  baseExtensions.push(
     InstructionSuggestionExtension.configure({ showBlockHighlight: false }),
     RawMarkdownBlock,
-    ...rawMarkdownBlockParsers,
-  ];
+    ...rawMarkdownBlockParsers
+  );
 
   if (!isReadOnly) {
     baseExtensions.push(...editableExtensions);

--- a/front/lib/editor/build_skill_instructions_extensions_server.ts
+++ b/front/lib/editor/build_skill_instructions_extensions_server.ts
@@ -14,6 +14,7 @@ import {
   RawMarkdownBlock,
   rawMarkdownBlockParsers,
 } from "@app/components/editor/extensions/skill_builder/RawMarkdownBlock";
+import { ToolNode } from "@app/components/editor/extensions/skill_builder/ToolNode";
 import { LinkExtension } from "@app/components/editor/input_bar/LinkExtension";
 import type { Extensions } from "@tiptap/core";
 import { Markdown } from "@tiptap/markdown";
@@ -51,6 +52,7 @@ export function buildSkillInstructionsExtensionsForServer(): Extensions {
     }),
     BlockIdExtension,
     KnowledgeNode.configure({ readOnly: true }),
+    ToolNode,
     InstructionSuggestionExtension.configure({ showBlockHighlight: false }),
     RawMarkdownBlock,
     ...rawMarkdownBlockParsers,

--- a/front/lib/editor/skill_instructions_preprocessing.ts
+++ b/front/lib/editor/skill_instructions_preprocessing.ts
@@ -15,9 +15,21 @@ function escapeMathEmphasis(markdown: string): string {
 /**
  * Preprocess markdown before loading it into the TipTap editor.
  */
-export function preprocessMarkdownForEditor(markdown: string): string {
+export function preprocessMarkdownForEditor(
+  markdown: string,
+  { enableSkillReferences = false }: { enableSkillReferences?: boolean } = {}
+): string {
+  const preservedTags = ["knowledge", "tool"];
+  if (enableSkillReferences) {
+    preservedTags.push("skill");
+  }
+  const preservedTagsPattern = preservedTags.join("|");
+
   return escapeMathEmphasis(
-    markdown.replace(/<(?!\/?knowledge[\s>/])(\/?\w)/g, `<${ZWS}$1`)
+    markdown.replace(
+      new RegExp(`<(?!(?:/?(?:${preservedTagsPattern}))[\\s>/])(/?\\w)`, "g"),
+      `<${ZWS}$1`
+    )
   );
 }
 

--- a/front/lib/editor/skill_instructions_preprocessing.ts
+++ b/front/lib/editor/skill_instructions_preprocessing.ts
@@ -1,6 +1,9 @@
+import { parseToolTag, TOOL_TAG_REGEX } from "@app/lib/tools/format";
 import { unescape } from "html-escaper";
 
 const ZWS = "\u200B";
+const TOOL_TAG_PLACEHOLDER_PREFIX = "\uE000DUST_TOOL_TAG_";
+const TOOL_TAG_PLACEHOLDER_SUFFIX = "\uE001";
 
 /**
  * Escape emphasis delimiters (_ and *) inside $$ ... $$ math blocks so
@@ -19,17 +22,45 @@ export function preprocessMarkdownForEditor(
   markdown: string,
   { enableSkillReferences = false }: { enableSkillReferences?: boolean } = {}
 ): string {
-  const preservedTags = ["knowledge", "tool"];
+  const toolTags: string[] = [];
+  const markdownWithToolPlaceholders = markdown.replace(
+    TOOL_TAG_REGEX,
+    (tag) => {
+      if (!parseToolTag(tag)) {
+        return tag;
+      }
+
+      const placeholder = `${TOOL_TAG_PLACEHOLDER_PREFIX}${toolTags.length}${TOOL_TAG_PLACEHOLDER_SUFFIX}`;
+      toolTags.push(tag);
+      return placeholder;
+    }
+  );
+
+  const preservedTags = ["knowledge"];
   if (enableSkillReferences) {
     preservedTags.push("skill");
   }
   const preservedTagsPattern = preservedTags.join("|");
 
   return escapeMathEmphasis(
-    markdown.replace(
-      new RegExp(`<(?!(?:/?(?:${preservedTagsPattern}))[\\s>/])(/?\\w)`, "g"),
-      `<${ZWS}$1`
-    )
+    markdownWithToolPlaceholders
+      .replace(
+        new RegExp(`<(?!(?:/?(?:${preservedTagsPattern}))[\\s>/])(/?\\w)`, "g"),
+        `<${ZWS}$1`
+      )
+      .replace(
+        new RegExp(
+          `${TOOL_TAG_PLACEHOLDER_PREFIX}(\\d+)${TOOL_TAG_PLACEHOLDER_SUFFIX}`,
+          "g"
+        ),
+        (_, index: string) => {
+          const toolTag = toolTags[Number(index)];
+          if (!toolTag) {
+            throw new Error("Missing preserved tool tag placeholder.");
+          }
+          return toolTag;
+        }
+      )
   );
 }
 

--- a/front/lib/reinforcement/analyze_conversation.test.ts
+++ b/front/lib/reinforcement/analyze_conversation.test.ts
@@ -70,6 +70,19 @@ describe("buildSkillAnalysisPrompt", () => {
     expect(userMessage).toContain("Always verify data before responding.");
   });
 
+  it("strips tool icon attributes from instructionsHtml in the user message", () => {
+    const skill = makeSkill({
+      instructionsHtml:
+        '<p>Use <tool id="mcp_server_view_1" name="GitHub Search" icon="GithubLogo"></tool>.</p>',
+    });
+    const { userMessage } = buildSkillAnalysisPrompt("User: hello", [skill]);
+
+    expect(userMessage).toContain(
+      '<tool id="mcp_server_view_1" name="GitHub Search" />'
+    );
+    expect(userMessage).not.toContain('icon="GithubLogo"');
+  });
+
   it("omits instructions when null", () => {
     const skill = makeSkill({ instructions: null, instructionsHtml: null });
     const { userMessage } = buildSkillAnalysisPrompt("User: hello", [skill]);

--- a/front/lib/reinforcement/format_skill_context.ts
+++ b/front/lib/reinforcement/format_skill_context.ts
@@ -1,3 +1,4 @@
+import { stripToolTagPresentationAttributes } from "@app/lib/tools/format";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import { escapeXml } from "@app/types/shared/utils/string_utils";
 
@@ -17,7 +18,9 @@ export function formatSkillContext(skill: SkillType): string {
     : "";
 
   const instructionsBlock = skill.instructionsHtml
-    ? `<instructions format="html">${skill.instructionsHtml}</instructions>`
+    ? `<instructions format="html">${stripToolTagPresentationAttributes(
+        skill.instructionsHtml
+      )}</instructions>`
     : "";
 
   return `<skill ID="${escapeXml(skill.sId)}" name="${escapeXml(skill.name)}">${toolsBlock}${descBlock}${instructionsBlock}</skill>`;

--- a/front/lib/reinforcement/skill_instructions_html.test.ts
+++ b/front/lib/reinforcement/skill_instructions_html.test.ts
@@ -130,4 +130,22 @@ describe("convertMarkdownToBlockHtml", () => {
     expect(html).toContain('id="n1"');
     expect(html).toContain('title="My Doc"');
   });
+
+  it("recovers standalone <tool /> lines as tool nodes with id, name, and icon", () => {
+    const md = [
+      "Intro",
+      "",
+      '<tool id="mcp_server_view_1" name="GitHub Search" icon="GithubLogo" />',
+      "",
+      "Outro",
+    ].join("\n");
+
+    const html = convertMarkdownToBlockHtml(md);
+
+    expect(html).not.toContain("&lt;tool");
+    expect(html).toContain("<tool");
+    expect(html).toContain('id="mcp_server_view_1"');
+    expect(html).toContain('name="GitHub Search"');
+    expect(html).toContain('icon="GithubLogo"');
+  });
 });

--- a/front/lib/reinforcement/skill_instructions_html.ts
+++ b/front/lib/reinforcement/skill_instructions_html.ts
@@ -4,9 +4,11 @@ import {
 } from "@app/components/editor/extensions/instructions/BlockIdExtension";
 import { INSTRUCTIONS_ROOT_NODE_NAME } from "@app/components/editor/extensions/instructions/InstructionsRootExtension";
 import { KNOWLEDGE_TAG_REGEX } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeConstants";
+import { TOOL_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/ToolNode";
 import { buildSkillInstructionsExtensionsForServer } from "@app/lib/editor/build_skill_instructions_extensions_server";
 import { preprocessMarkdownForEditor } from "@app/lib/editor/skill_instructions_preprocessing";
 import { generateShortBlockId } from "@app/lib/generate_short_block_id";
+import { parseToolTag } from "@app/lib/tools/format";
 import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
 import type { JSONContent } from "@tiptap/core";
 import { MarkdownManager } from "@tiptap/markdown";
@@ -82,26 +84,26 @@ function stripPresentationAttributes(html: string): string {
   // the round-trip mechanism for recovering the language on generateJSON
   $("[class]").not("code").removeAttr("class");
   $("[style]").removeAttr("style");
-  // Must maintain id on <knowledge> elements for knowledgeNode parsing
-  $("[id]").not("knowledge").removeAttr("id");
+  // Must maintain id on custom inline elements for their parseHTML rules.
+  $("[id]").not("knowledge, tool").removeAttr("id");
   return $.html();
 }
 
 /**
  * TipTap's server-side parseHTMLToken has no DOM, so it converts block-level
- * HTML tokens (e.g. a standalone <knowledge .../> on its own line) to plain-
+ * HTML tokens (e.g. standalone <knowledge .../> or <tool .../> lines) to plain-
  * text paragraphs instead of calling generateJSON + parseHTML rules. Walk the
- * parsed JSON tree and restore any such nodes back to proper knowledgeNode
+ * parsed JSON tree and restore any such nodes back to proper inline-node
  * JSONContent before rendering to HTML.
  */
-function recoverKnowledgeNodes(node: JSONContent): JSONContent {
+function recoverCustomInlineNodes(node: JSONContent): JSONContent {
   if (node.type === "paragraph" && node.content?.length === 1) {
     const child = node.content[0];
     if (child.type === "text") {
       const text = (child.text ?? "").trim();
-      const match = KNOWLEDGE_TAG_REGEX.exec(text);
-      if (match) {
-        const attrs = match[1];
+      const knowledgeMatch = KNOWLEDGE_TAG_REGEX.exec(text);
+      if (knowledgeMatch) {
+        const attrs = knowledgeMatch[1];
         const id = /id="([^"]+)"/.exec(attrs)?.[1];
         const title = /title="([^"]+)"/.exec(attrs)?.[1];
         if (id && title) {
@@ -126,10 +128,27 @@ function recoverKnowledgeNodes(node: JSONContent): JSONContent {
           };
         }
       }
+
+      const tool = parseToolTag(text);
+      if (tool) {
+        return {
+          ...node,
+          content: [
+            {
+              type: TOOL_NODE_TYPE,
+              attrs: {
+                mcpServerViewId: tool.id,
+                toolIcon: tool.icon,
+                toolName: tool.name,
+              },
+            },
+          ],
+        };
+      }
     }
   }
   if (node.content) {
-    return { ...node, content: node.content.map(recoverKnowledgeNodes) };
+    return { ...node, content: node.content.map(recoverCustomInlineNodes) };
   }
   return node;
 }
@@ -151,7 +170,7 @@ export function convertMarkdownToBlockHtml(markdown: string): string {
     content: [
       {
         type: INSTRUCTIONS_ROOT_NODE_NAME,
-        content: rawContent.map(recoverKnowledgeNodes),
+        content: rawContent.map(recoverCustomInlineNodes),
       },
     ],
   };

--- a/front/lib/tools/format.ts
+++ b/front/lib/tools/format.ts
@@ -1,0 +1,95 @@
+import { escapeXml } from "@app/types/shared/utils/string_utils";
+import { unescape } from "html-escaper";
+
+export type ToolReference = {
+  icon: string | null;
+  id: string;
+  name: string;
+};
+
+export const TOOL_TAG_NAME = "tool";
+
+export const TOOL_TAG_REGEX = /<tool\s+([^>]*?)\s*\/>/g;
+export const TOOL_TAG_REGEX_BEGINNING = /^<tool\s+([^>]*?)\s*\/>/;
+
+const TOOL_ELEMENT_REGEX = /<tool\b([^>]*)>[\s\S]*?<\/tool>/g;
+
+function parseAttribute(attributes: string, name: string): string | null {
+  const value = new RegExp(`\\b${name}="([^"]*)"`).exec(attributes)?.[1];
+  if (value === undefined || value === "") {
+    return null;
+  }
+
+  return unescape(value);
+}
+
+function parseToolTagAttributes(attributes: string): ToolReference | null {
+  const id = parseAttribute(attributes, "id");
+  const name = parseAttribute(attributes, "name");
+
+  if (!id || !name) {
+    return null;
+  }
+
+  return {
+    icon: parseAttribute(attributes, "icon"),
+    id,
+    name,
+  };
+}
+
+export function parseToolTag(tag: string): ToolReference | null {
+  const attributes = TOOL_TAG_REGEX_BEGINNING.exec(tag)?.[1];
+
+  if (!attributes) {
+    return null;
+  }
+
+  return parseToolTagAttributes(attributes);
+}
+
+export function extractToolTags(content: string): ToolReference[] {
+  return [...content.matchAll(TOOL_TAG_REGEX)]
+    .map((match) => parseToolTag(match[0]))
+    .filter((tool): tool is ToolReference => tool !== null);
+}
+
+export function serializeToolTag({ icon, id, name }: ToolReference): string {
+  return `<${TOOL_TAG_NAME} ${serializeToolTagAttributes({
+    icon,
+    id,
+    name,
+  })} />`;
+}
+
+function serializeToolTagAttributes({ icon, id, name }: ToolReference): string {
+  const iconAttribute = icon ? ` icon="${escapeXml(icon)}"` : "";
+
+  return `id="${escapeXml(id)}" name="${escapeXml(name)}"${iconAttribute}`;
+}
+
+export function stripToolTagPresentationAttributes(content: string): string {
+  return content
+    .replace(TOOL_ELEMENT_REGEX, (tag, attributes: string) => {
+      const tool = parseToolTag(`<${TOOL_TAG_NAME}${attributes} />`);
+      if (!tool) {
+        return tag.replace(/(<tool\b[^>]*?)\s+icon="[^"]*"/, "$1");
+      }
+
+      return serializeToolTag({
+        ...tool,
+        icon: null,
+      });
+    })
+    .replace(TOOL_TAG_REGEX, (tag) => {
+      const tool = parseToolTag(tag);
+      if (!tool) {
+        return tag.replace(/\s+icon="[^"]*"/g, "");
+      }
+
+      return serializeToolTag({
+        ...tool,
+        icon: null,
+      });
+    });
+}


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/26448, https://github.com/dust-tt/dust/pull/26449, https://github.com/dust-tt/dust/pull/26451, and https://github.com/dust-tt/dust/pull/26452.

Adds the foundation for inline Skill Builder tool references using serialized `<tool id="..." name="..." icon="..." />` tags, following the same direction as nested skill references: shared tag formatting helpers, nullable presentation-only `icon`, editor preservation, and no dropdown insertion UI yet.

Tool chips render from MCP server view context when available and fall back to an error chip when the referenced view is no longer accessible. Model-facing rendering strips icon and chip presentation so prompts keep only semantic `id` and `name`.

## Risks

Blast radius: Skill Builder instructions editor rendering, stored instructions HTML conversion, and enabled-skill prompt rendering.
Risk: standard

## Deploy Plan

- Deploy front.

## Tests

- [x] `NODE_ENV=test npm test -- components/editor/extensions/skill_builder/ToolNode.test.ts lib/reinforcement/skill_instructions_html.test.ts lib/reinforcement/analyze_conversation.test.ts lib/api/assistant/skills_rendering.test.ts`
