### PR TITLE
Derive user consumption from usage metrics

### DIFF
--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -1713,13 +1713,22 @@ export async function listMetronomeUsageWithGroups({
   endingBefore,
   windowSize,
   groupKey,
+  groupFilters,
 }: {
   customerId: string;
   billableMetricId: string;
+  // Must be UTC midnight (Metronome requirement). To restrict to an
+  // hour-precise period, query midnight-aligned bounds with an HOUR window and
+  // trim the returned buckets to the exact range. (The API's `current_period`
+  // flag is not an option: it requires a legacy v1 Plan, which our
+  // contract-based customers don't have.)
   startingOn: string;
   endingBefore: string;
   windowSize: WindowSize;
   groupKey: string[];
+  // Restrict returned groups to these values per group key. Keys must be part
+  // of `groupKey`; an omitted key returns all of its values.
+  groupFilters?: Record<string, string[]>;
 }): Promise<Result<MetronomeUsageWithGroupsResponse[], Error>> {
   if (!config.getMetronomeApiKey()) {
     return new Ok([]);
@@ -1732,10 +1741,11 @@ export async function listMetronomeUsageWithGroups({
     for await (const entry of client.v1.usage.listWithGroups({
       customer_id: customerId,
       billable_metric_id: billableMetricId,
-      starting_on: startingOn,
-      ending_before: endingBefore,
       window_size: windowSize,
       group_key: groupKey,
+      starting_on: startingOn,
+      ending_before: endingBefore,
+      ...(groupFilters ? { group_filters: groupFilters } : {}),
     })) {
       results.push({
         startingOn: entry.starting_on,

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -46,7 +46,20 @@ function truncatePropertyValue(value: string): string {
 // Advanced: 3 AWU
 export const TOOL_CATEGORIES = ["basic", "advanced"] as const;
 
-type ToolCategory = (typeof TOOL_CATEGORIES)[number];
+export type ToolCategory = (typeof TOOL_CATEGORIES)[number];
+
+// AWU price per tool invocation by category (1 AWU = $0.01). Canonical source
+// for both the Tool Usage rate-card prices (scripts/metronome_setup.ts) and the
+// runtime per-user AWU spend computation (per_user_usage.ts) — keep both in
+// sync by importing from here rather than redefining.
+export const TOOL_CATEGORY_AWU_WEIGHTS: Record<ToolCategory, number> = {
+  basic: 1,
+  advanced: 3,
+};
+
+export function isToolCategory(value: string): value is ToolCategory {
+  return value in TOOL_CATEGORY_AWU_WEIGHTS;
+}
 
 // Exhaustive map — TypeScript will error if a new internal MCP server is added
 // without being categorized here.

--- a/front/lib/metronome/per_user_usage.ts
+++ b/front/lib/metronome/per_user_usage.ts
@@ -1,8 +1,52 @@
-import { listMetronomeDraftInvoices } from "@app/lib/metronome/client";
+import {
+  ceilToMidnightUTC,
+  floorToMidnightUTC,
+  listMetronomeUsageWithGroups,
+} from "@app/lib/metronome/client";
+import {
+  getMetricLlmProviderCostAwuId,
+  getMetricToolInvocationsId,
+} from "@app/lib/metronome/constants";
+import { getMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
+import {
+  isToolCategory,
+  TOOL_CATEGORY_AWU_WEIGHTS,
+} from "@app/lib/metronome/events";
 import { cacheWithRedis } from "@app/lib/utils/cache";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
+// usage_type slices that incur AWU spend. The "free" slice is priced at 0 AWU
+// on every rate card, so it's excluded to mirror the per-user
+// `spend_threshold_reached` alert (AWU credit type) that backs per-user caps.
+const PAID_USAGE_TYPES = ["user", "programmatic"];
+
+/**
+ * Per-user AWU consumption for the current billing period.
+ *
+ * Usage is now folded on the invoice (no per-user line item), so we read it
+ * straight from the grouped usage API instead of walking draft invoices.
+ *
+ * The billing period is hour-precise (contracts are anchored on hour
+ * boundaries, e.g. a period running 14:00→14:00), but the usage endpoint has
+ * two constraints we can't both satisfy directly:
+ *   - `current_period: true` is rejected ("must have an active plan") — that
+ *     flag keys off Metronome's legacy v1 Plan entity, and we provision
+ *     customers exclusively via Contracts, so no Plan exists.
+ *   - explicit `starting_on`/`ending_before` must be UTC midnight.
+ * So we query midnight-aligned bounds that *enclose* the period with
+ * `window_size: "HOUR"`, then keep only the hourly buckets that fall inside
+ * the exact `[cycleStart, cycleEnd)` window — hour-precise, matching the
+ * period the per-user spend cap alert evaluates. The request end is capped at
+ * the next midnight after `now` so we don't fetch the period's future days.
+ *
+ * AWU spend has two sources, both priced in the AWU credit type:
+ *   - AI Usage: the `cost_awu` metric, priced 1 AWU per unit, so the metric
+ *     value is already AWU spend.
+ *   - Tool Usage: an invocation count, priced per category (basic ×1,
+ *     advanced ×3), so the count is weighted by the category price.
+ * Free usage is excluded server-side via `group_filters`.
+ */
 export async function fetchPerUserAwuUsage({
   metronomeCustomerId,
   metronomeContractId,
@@ -10,42 +54,86 @@ export async function fetchPerUserAwuUsage({
   metronomeCustomerId: string;
   metronomeContractId: string;
 }): Promise<Result<Map<string, number>, Error>> {
-  const invoicesResult = await listMetronomeDraftInvoices(metronomeCustomerId);
-  if (invoicesResult.isErr()) {
-    return new Err(invoicesResult.error);
-  }
-
-  const now = Date.now();
-  const currentInvoice = invoicesResult.value.find((inv) => {
-    if (inv.contract_id !== metronomeContractId) {
-      return false;
-    }
-    if (!inv.start_timestamp || !inv.end_timestamp) {
-      return false;
-    }
-    const startMs = new Date(inv.start_timestamp).getTime();
-    const endMs = new Date(inv.end_timestamp).getTime();
-    return startMs <= now && now < endMs;
+  const periodResult = await getMetronomeCurrentBillingPeriod({
+    metronomeCustomerId,
+    metronomeContractId,
   });
-
-  if (!currentInvoice?.line_items) {
+  if (periodResult.isErr()) {
+    return new Err(periodResult.error);
+  }
+  if (!periodResult.value) {
     return new Ok(new Map());
   }
+  const { cycleStart, cycleEnd } = periodResult.value;
+  const cycleStartMs = cycleStart.getTime();
+  const cycleEndMs = cycleEnd.getTime();
+
+  // Midnight-aligned request bounds enclosing the period (API requirement).
+  // The hourly buckets outside [cycleStart, cycleEnd) are trimmed below.
+  const startingOn = floorToMidnightUTC(cycleStart).toISOString();
+  const requestEnd = new Date(Math.min(cycleEndMs, Date.now()));
+  const endingBefore = ceilToMidnightUTC(requestEnd).toISOString();
+
+  const [aiResult, toolResult] = await Promise.all([
+    listMetronomeUsageWithGroups({
+      customerId: metronomeCustomerId,
+      billableMetricId: getMetricLlmProviderCostAwuId(),
+      startingOn,
+      endingBefore,
+      windowSize: "HOUR",
+      groupKey: ["user_id", "usage_type"],
+      groupFilters: { usage_type: PAID_USAGE_TYPES },
+    }),
+    listMetronomeUsageWithGroups({
+      customerId: metronomeCustomerId,
+      billableMetricId: getMetricToolInvocationsId(),
+      startingOn,
+      endingBefore,
+      windowSize: "HOUR",
+      groupKey: ["user_id", "usage_type", "tool_category"],
+      groupFilters: { usage_type: PAID_USAGE_TYPES },
+    }),
+  ]);
+  if (aiResult.isErr()) {
+    return new Err(aiResult.error);
+  }
+  if (toolResult.isErr()) {
+    return new Err(toolResult.error);
+  }
+
+  // Keep only hourly buckets that fall within the exact billing period.
+  const isInPeriod = (startingOnIso: string): boolean => {
+    const ts = new Date(startingOnIso).getTime();
+    return ts >= cycleStartMs && ts < cycleEndMs;
+  };
 
   const perUser = new Map<string, number>();
 
-  for (const lineItem of currentInvoice.line_items) {
+  // AI usage: the value is already AWU spend (cost_awu, priced 1:1).
+  for (const entry of aiResult.value) {
+    const userId = entry.group?.["user_id"];
+    if (!userId || entry.value === null || !isInPeriod(entry.startingOn)) {
+      continue;
+    }
+    perUser.set(userId, (perUser.get(userId) ?? 0) + entry.value);
+  }
+
+  // Tool usage: the value is an invocation count — weight it by the
+  // per-category AWU price to convert it into AWU spend.
+  for (const entry of toolResult.value) {
+    const userId = entry.group?.["user_id"];
+    const category = entry.group?.["tool_category"];
     if (
-      lineItem.type !== "usage" ||
-      !lineItem.product_tags?.includes("usage")
+      !userId ||
+      entry.value === null ||
+      !category ||
+      !isToolCategory(category) ||
+      !isInPeriod(entry.startingOn)
     ) {
       continue;
     }
-    const userId = lineItem.presentation_group_values?.["user_id"];
-    if (!userId) {
-      continue;
-    }
-    perUser.set(userId, (perUser.get(userId) ?? 0) + (lineItem.quantity ?? 0));
+    const awuSpent = entry.value * TOOL_CATEGORY_AWU_WEIGHTS[category];
+    perUser.set(userId, (perUser.get(userId) ?? 0) + awuSpent);
   }
 
   return new Ok(perUser);


### PR DESCRIPTION
## Description

`fetchPerUserAwuUsage` used to walk the customer's **draft invoices** and sum the per-user usage line items. Usage is now **folded into the invoice** (no per-user line item), so that approach no longer works. This PR derives per-user AWU consumption directly from Metronome's **grouped usage API** instead.

- Per-user spend is read from `listMetronomeUsageWithGroups`, grouped by `user_id`, over the contract's **exact current billing period**.
- It combines both AWU-priced usage sources, so the result matches what the per-user `spend_threshold_reached` (AWU credit type) cap alert actually enforces:
  - **AI Usage** — `LLM Provider Cost AWU` metric (`cost_awu`, priced 1 AWU per unit, so the metric value is already AWU spend).
  - **Tool Usage** — `Tool Invocations` count, weighted by category price (basic ×1, advanced ×3).
  - **Free usage** (`usage_type: "free"`, priced at 0 AWU) is excluded server-side via `group_filters`.
- **Period is hour-precise.** Two Metronome constraints shaped the approach:
  - `current_period: true` is rejected for us ("must have an active plan") — that flag keys off Metronome's legacy v1 **Plan** entity, and we provision customers exclusively via **Contracts**, so no Plan exists.
  - explicit `starting_on`/`ending_before` must be **UTC midnight**.
  - So we query midnight-aligned bounds that *enclose* the period with `window_size: "HOUR"`, then keep only the hourly buckets inside the exact `[cycleStart, cycleEnd)` window (read from the contract's `billing_periods.current`). Request end is capped at the next midnight past `now` to avoid fetching the period's future days.
- Supporting changes:
  - `listMetronomeUsageWithGroups` gains an optional `groupFilters` param (to exclude free usage server-side).
  - Per-category tool AWU weights are now the single source of truth in `lib/metronome/events.ts` (`TOOL_CATEGORY_AWU_WEIGHTS`), consumed by both the runtime computation and the rate-card setup script.

### Per-user allowance vs. pool split

`MemberUsageType` gains `consumedFromAllowanceAwuCredits` and `consumedFromPoolAwuCredits` (summing to `consumedAwuCredits`): the portion of a user's consumption covered by their seat allowance vs. the portion that overflowed into the workspace pool (+ PAYG overage). Credits drain seat-allowance-first, so this is `min(usage, seatAllocation)` and the remainder.

An exact per-seat *ledger* split isn't possible: Metronome materializes the INDIVIDUAL seat allocation as a **single per-subscription credit** sized to the sum of all seats' (prorated) allocations, with no `user_id` and a `balance` that already bakes in the period-end deduction — so it exposes no per-user remaining. Since per-user *usage* is exact, the derived split is exact except when a mid-period-prorated user exceeds their prorated allocation.

The public signature of `fetchPerUserAwuUsage` is unchanged, so the members-usage table, the per-user spend-cap state machine, and the Redis cache wrapper are unaffected.

## Tests

- Type-checked (`tsgo`) and linted/formatted (biome).
- Validated against a dev workspace's members-usage endpoint; the two Metronome `400`s this surfaced (`current_period` "active plan" and "dates must be UTC midnight") drove the final midnight-bounds + `HOUR`-window + trim approach.
- No automated test changes: the consumers (`members_usage`, `spend_limit`) mock `fetchPerUserAwuUsage`, whose signature/return type are unchanged.

## Risk

Low–medium. Read-only path feeding the members-usage table and the per-user spend-cap immediate-state check. Degrades gracefully (returns an empty map → 0 consumption, with a warning) on any Metronome error, and is cached 60s for the table. The `HOUR` window returns more buckets than a single aggregate would, but Metronome only returns non-empty group-buckets. Safe to roll back (pure revert).

## Deploy Plan

Standard deploy — no migration, no env var changes. Depends on the `LLM Provider Cost AWU` and `Tool Invocations` metrics carrying the composite group keys (`["user_id","usage_type"]` and `["user_id","usage_type","tool_category"]`), which are already configured in `scripts/metronome_setup.ts`.
