### PR TITLE
[front] feat: show nested skill references in Skill info page

### DIFF
--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -181,9 +181,9 @@ export function SkillInfoTab({
                   key={childSkill.sId}
                   label={childSkill.userFacingDescription || childSkill.name}
                   trigger={
-                    <div className="flex flex-row items-center gap-2">
+                    <div className="flex min-w-0 flex-row items-center gap-2">
                       <SkillAvatar size="xs" />
-                      <div className="truncate">{childSkill.name}</div>
+                      <div className="min-w-0 truncate">{childSkill.name}</div>
                     </div>
                   }
                   tooltipTriggerAsChild

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -13,7 +13,10 @@ import { getSkillAvatarIcon } from "@app/lib/skill";
 import { getSpaceIcon, getSpaceName } from "@app/lib/spaces";
 import { useSkills } from "@app/lib/swr/skill_configurations";
 import { useSpaces } from "@app/lib/swr/spaces";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
+import type {
+  SkillRelations,
+  SkillType,
+} from "@app/types/assistant/skill_configuration";
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
@@ -28,7 +31,7 @@ import sortBy from "lodash/sortBy";
 import { useCallback, useMemo, useState } from "react";
 
 interface SkillInfoTabProps {
-  skill: SkillType;
+  skill: SkillType & { relations?: Pick<SkillRelations, "childSkills"> };
   owner: LightWorkspaceType;
   spaces?: SpaceType[];
   showDescription?: boolean;
@@ -84,6 +87,13 @@ export function SkillInfoTab({
     [requestedSpaces]
   );
 
+  const childSkills = useMemo(
+    () => sortBy(skill.relations?.childSkills ?? [], "name"),
+    [skill.relations?.childSkills]
+  );
+
+  const showChildSkills = hasFeature("nested_skills") && childSkills.length > 0;
+
   const handleKnowledgeItemsChange = useCallback((items: KnowledgeItem[]) => {
     setKnowledgeItems(items);
   }, []);
@@ -93,6 +103,7 @@ export function SkillInfoTab({
     knowledgeItems.length > 0 ||
     (hasFeature("sandbox_tools") && skill.fileAttachments.length > 0) ||
     sortedMCPServerViews.length > 0 ||
+    showChildSkills ||
     showDiscoverableSkills ||
     shouldLoadSpaces;
 
@@ -153,6 +164,32 @@ export function SkillInfoTab({
                 size="xs"
               />
             ))}
+          </div>
+        </div>
+      )}
+      {showChildSkills && (
+        <div className="flex flex-col gap-4">
+          <div className="heading-lg text-foreground dark:text-foreground-night">
+            Skills
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            {childSkills.map((childSkill) => {
+              const SkillAvatar = getSkillAvatarIcon(childSkill.icon);
+
+              return (
+                <Tooltip
+                  key={childSkill.sId}
+                  label={childSkill.userFacingDescription || childSkill.name}
+                  trigger={
+                    <div className="flex flex-row items-center gap-2">
+                      <SkillAvatar size="xs" />
+                      <div className="truncate">{childSkill.name}</div>
+                    </div>
+                  }
+                  tooltipTriggerAsChild
+                />
+              );
+            })}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Description

This PR makes nested skill references visible from the skill info tab.

When `nested_skills` is enabled and the backend relation payload includes child skills, `SkillInfoTab` renders them as avatar-and-label rows in the `Skills` section, sorted by name. This is display-only; creating and editing references remains handled elsewhere.

<img width="556" height="659" alt="image" src="https://github.com/user-attachments/assets/7b762a10-6d36-401f-9934-435325f6ec33" />

## Tests

- Tested locally.

## Risk

- Low. Behind `nested_skills` and display-only.

## Deploy Plan

- Deploy front.
