### PR TITLE
Simplified overage display

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -9,7 +9,6 @@ import { UsageNotificationsCard } from "@app/components/workspace/usage/UsageNot
 import { UsageSettingsCard } from "@app/components/workspace/usage/UsageSettingsCard";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
-import { getPriceAsString } from "@app/lib/client/subscription";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
 import {
@@ -152,8 +151,6 @@ export function UsagePage() {
     totalActiveCredits,
     resetDate,
     overageCredits,
-    overageAmountCents,
-    overageCurrency,
     isAwuPoolSummaryLoading,
     isAwuPoolSummaryError,
   } = useAwuPoolSummary({
@@ -261,13 +258,20 @@ export function UsagePage() {
                   {formatCredits(totalConsumedCredits)} /{" "}
                   {formatCredits(initialTotalCredits)}
                 </span>
-                <button
-                  className="flex cursor-pointer items-center gap-1 text-xs font-medium text-highlight-500 dark:text-highlight-500-night"
-                  onClick={() => setShowBuyCreditDialog(true)}
-                >
-                  <Icon visual={ArrowUpIcon} size="xs" />
-                  Top up
-                </button>
+                <div className="flex items-center gap-2">
+                  {overageCredits !== null && overageCredits > 0 && (
+                    <span className="text-xs font-medium text-muted-foreground dark:text-muted-foreground-night">
+                      {formatCredits(overageCredits)} Overage
+                    </span>
+                  )}
+                  <button
+                    className="flex cursor-pointer items-center gap-1 text-xs font-medium text-highlight-500 dark:text-highlight-500-night"
+                    onClick={() => setShowBuyCreditDialog(true)}
+                  >
+                    <Icon visual={ArrowUpIcon} size="xs" />
+                    Top up
+                  </button>
+                </div>
               </div>
             )}
           </div>
@@ -295,26 +299,6 @@ export function UsagePage() {
               consumedCredits={totalConsumedCredits}
             />
           )}
-
-          {!isAwuPoolSummaryLoading &&
-            !isAwuPoolSummaryError &&
-            overageCredits !== null &&
-            overageCredits > 0 &&
-            overageAmountCents !== null &&
-            overageCurrency !== null && (
-              <div className="flex items-center justify-between text-sm">
-                <span className="text-muted-foreground dark:text-muted-foreground-night">
-                  Overage this period
-                </span>
-                <span className="font-medium text-foreground dark:text-foreground-night">
-                  {formatCredits(overageCredits)} credits ·{" "}
-                  {getPriceAsString({
-                    currency: overageCurrency,
-                    priceInCents: overageAmountCents,
-                  })}
-                </span>
-              </div>
-            )}
 
           {isAwuPoolSummaryLoading && (
             <div className="flex justify-center py-8">


### PR DESCRIPTION
## Description

Simplifies how PAYG overage is shown on the Workspace **Usage** page.

Previously, overage was rendered as its own row below the credits pool bar
("Overage this period — {credits} credits · {fiat price}").

Now it's a compact label shown inline, right next to the **Top up** link:

> `1,234 Overage`  ·  `↑ Top up`

Changes:
- Drop the standalone overage row and its fiat price from the UI. The price
  (`overageAmountCents` / `overageCurrency`) is still returned by the
  `awu-pool-summary` endpoint — it's just no longer rendered here.
- Show only the overage credits amount with an "Overage" label, beside the
  Top up button (only when `overageCredits > 0`).
- Remove the now-unused `getPriceAsString` import and the
  `overageAmountCents` / `overageCurrency` destructuring.

Net: 14 insertions, 30 deletions in `front/components/pages/workspace/UsagePage.tsx`.

## Tests

Manual / visual check on the Usage page:
- No overage → only the Top up link is shown.
- Overage present → "{credits} Overage" appears beside Top up.

`npx tsgo --noEmit` passes (no new type errors).

## Risk

Low. Frontend-only, display-only change scoped to a single component. The
underlying endpoint and data are untouched, so it's trivially rollback-safe.

## Deploy Plan

Standard `front` deploy. No migrations, no API/contract changes.
