### PR TITLE
[front] feat: expose child skills in skill relations

### DIFF
--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -3,6 +3,7 @@ import {
   SkillFileAttachmentModel,
   SkillVersionModel,
 } from "@app/lib/models/skill";
+import { SkillReferenceModel } from "@app/lib/models/skill/skill_reference";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
@@ -109,6 +110,12 @@ function getSkill(workspace: { sId: string }, sId: string) {
   return honoApp.request(`/api/w/${workspace.sId}/skills/${sId}`);
 }
 
+function getSkillWithRelations(workspace: { sId: string }, sId: string) {
+  return honoApp.request(
+    `/api/w/${workspace.sId}/skills/${sId}?withRelations=true`
+  );
+}
+
 function patchSkill(workspace: { sId: string }, sId: string, body: unknown) {
   return honoApp.request(`/api/w/${workspace.sId}/skills/${sId}`, {
     method: "PATCH",
@@ -134,6 +141,60 @@ describe("GET /api/w/:wId/skills/:sId", () => {
     expect(data).toHaveProperty("skill");
     expect(data.skill.sId).toBe(skill.sId);
     expect(data.skill.name).toBe("Test Skill");
+  });
+
+  it("should return child skills when nested_skills is enabled", async () => {
+    const { workspace, skill, skillOwnerAuth } = await setupTest({
+      requestUserRole: "admin",
+    });
+
+    await FeatureFlagFactory.basic(skillOwnerAuth, "nested_skills");
+
+    const childSkill = await SkillFactory.create(skillOwnerAuth, {
+      name: "Child Skill",
+    });
+    await SkillReferenceModel.create({
+      workspaceId: workspace.id,
+      parentSkillId: skill.id,
+      childSkillId: childSkill.id,
+    });
+
+    const response = await getSkillWithRelations(workspace, skill.sId);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(data.skill.relations.childSkills).toEqual([
+      expect.objectContaining({
+        sId: childSkill.sId,
+        name: "Child Skill",
+      }),
+    ]);
+    expect(data.skill.relations.childSkills[0]).not.toHaveProperty(
+      "instructions"
+    );
+  });
+
+  it("should not return child skills when nested_skills is disabled", async () => {
+    const { workspace, skill, skillOwnerAuth } = await setupTest({
+      requestUserRole: "admin",
+    });
+
+    const childSkill = await SkillFactory.create(skillOwnerAuth, {
+      name: "Hidden Child Skill",
+    });
+    await SkillReferenceModel.create({
+      workspaceId: workspace.id,
+      parentSkillId: skill.id,
+      childSkillId: childSkill.id,
+    });
+
+    const response = await getSkillWithRelations(workspace, skill.sId);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(data.skill.relations).not.toHaveProperty("childSkills");
   });
 
   it("should return 404 for non-existent skill", async () => {

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -138,12 +138,18 @@ app.get(
     const serializedSkill = skill.toJSON(auth);
 
     if (withRelations === "true") {
+      const featureFlags = await getFeatureFlags(auth);
+      const includeChildSkills = featureFlags.includes("nested_skills");
+
       const usage = await skill.fetchUsage(auth);
       const editors = await skill.listEditors(auth);
       const editedByUser = await skill.fetchEditedByUser(auth);
       const extendedSkill = serializedSkill.extendedSkillId
         ? await SkillResource.fetchById(auth, serializedSkill.extendedSkillId)
         : null;
+      const childSkills = includeChildSkills
+        ? await skill.fetchChildSkills(auth)
+        : [];
 
       const skillWithRelations: SkillWithRelationsType = {
         ...serializedSkill,
@@ -152,6 +158,20 @@ app.get(
           editors: editors ? editors.map((e) => e.toJSON()) : null,
           editedByUser: editedByUser ? editedByUser.toJSON() : null,
           extendedSkill: extendedSkill ? extendedSkill.toJSON(auth) : null,
+          ...(includeChildSkills
+            ? {
+                childSkills: childSkills.map((childSkill) => {
+                  const {
+                    instructions,
+                    instructionsHtml,
+                    tools,
+                    ...childSkillWithoutInstructionsAndTools
+                  } = childSkill.toJSON(auth);
+
+                  return childSkillWithoutInstructionsAndTools;
+                }),
+              }
+            : {}),
         },
       };
 

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -1,5 +1,6 @@
 import { Authenticator } from "@app/lib/auth";
 import { SkillMCPServerConfigurationModel } from "@app/lib/models/skill";
+import { SkillReferenceModel } from "@app/lib/models/skill/skill_reference";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { discoverToolsSkill } from "@app/lib/resources/skill/code_defined/discover_tools";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -410,6 +411,56 @@ describe("GET /api/w/:wId/skills?withRelations=true", () => {
         usage: { count: 0, agents: [] },
       },
     });
+  });
+
+  it("should return child skills when nested_skills is enabled", async () => {
+    const { workspace, user } = await setupTest();
+
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    await FeatureFlagFactory.basic(auth, "nested_skills");
+
+    const parentSkill = await SkillFactory.create(auth, {
+      name: "Parent Skill",
+    });
+    const childSkill = await SkillFactory.create(auth, {
+      name: "Child Skill",
+    });
+    await SkillReferenceModel.create({
+      workspaceId: workspace.id,
+      parentSkillId: parentSkill.id,
+      childSkillId: childSkill.id,
+    });
+
+    const response = await getSkills(workspace, { withRelations: "true" });
+
+    expect(response.status).toBe(200);
+
+    const parentSkillId = SkillResource.modelIdToSId({
+      id: parentSkill.id,
+      workspaceId: workspace.id,
+    });
+    const skillResult = (await response.json()).skills.find(
+      (s: SkillWithoutInstructionsAndToolsWithRelationsType) =>
+        s.sId === parentSkillId
+    );
+
+    expect(skillResult).toMatchObject({
+      relations: {
+        childSkills: [
+          {
+            sId: childSkill.sId,
+            name: "Child Skill",
+          },
+        ],
+      },
+    });
+    expect(skillResult.relations.childSkills?.[0]).not.toHaveProperty(
+      "instructions"
+    );
   });
 
   it("should return skills without usage when withRelations is not set", async () => {

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -140,16 +140,26 @@ app.get(
     });
 
     if (withRelations === "true") {
-      const [extendedSkills, usageMap, editorsMap, editedByUsersMap] =
-        await Promise.all([
-          SkillResource.fetchByIds(
-            auth,
-            removeNulls(uniq(skills.map((s) => s.extendedSkillId)))
-          ),
-          SkillResource.batchFetchUsage(auth, skills),
-          SkillResource.batchListEditors(auth, skills),
-          SkillResource.batchFetchEditedByUsers(auth, skills),
-        ]);
+      const featureFlags = await getFeatureFlags(auth);
+      const includeChildSkills = featureFlags.includes("nested_skills");
+
+      const extendedSkills = await SkillResource.fetchByIds(
+        auth,
+        removeNulls(uniq(skills.map((s) => s.extendedSkillId)))
+      );
+      const usageMap = await SkillResource.batchFetchUsage(auth, skills);
+      const editorsMap = await SkillResource.batchListEditors(auth, skills);
+      const editedByUsersMap = await SkillResource.batchFetchEditedByUsers(
+        auth,
+        skills
+      );
+      let childSkillsMap = new Map<string, SkillResource[]>();
+      if (includeChildSkills) {
+        childSkillsMap = await SkillResource.batchFetchChildSkills(
+          auth,
+          skills
+        );
+      }
 
       const extendedSkillsMap = new Map(extendedSkills.map((s) => [s.sId, s]));
 
@@ -175,6 +185,22 @@ app.get(
               ? (extendedSkillsMap.get(sc.extendedSkillId)?.toJSON(auth) ??
                 null)
               : null,
+            ...(includeChildSkills
+              ? {
+                  childSkills: (childSkillsMap.get(sc.sId) ?? []).map(
+                    (childSkill) => {
+                      const {
+                        instructions,
+                        instructionsHtml,
+                        tools,
+                        ...childSkillWithoutInstructionsAndTools
+                      } = childSkill.toJSON(auth);
+
+                      return childSkillWithoutInstructionsAndTools;
+                    }
+                  ),
+                }
+              : {}),
           },
         } satisfies SkillWithoutInstructionsAndToolsWithRelationsType;
       });
@@ -388,7 +414,6 @@ app.post(
           { error: iconResult.error },
           "Failed to generate icon suggestion for skill"
         );
-        icon = "ActionListIcon";
       }
     }
 

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -414,6 +414,7 @@ app.post(
           { error: iconResult.error },
           "Failed to generate icon suggestion for skill"
         );
+        icon = "ActionListIcon";
       }
     }
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -893,6 +893,54 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     });
   }
 
+  static async batchFetchChildSkills(
+    auth: Authenticator,
+    parentSkills: SkillResource[]
+  ): Promise<Map<string, SkillResource[]>> {
+    const workspace = auth.getNonNullableWorkspace();
+    const customParentSkills = parentSkills.filter((skill) => !skill.globalSId);
+
+    if (customParentSkills.length === 0) {
+      return new Map();
+    }
+
+    const skillReferences = await SkillReferenceModel.findAll({
+      where: {
+        workspaceId: workspace.id,
+        parentSkillId: customParentSkills.map((skill) => skill.id),
+      },
+    });
+
+    const childSkills = await this.fetchByModelIds(
+      auth,
+      uniq(skillReferences.map((reference) => reference.childSkillId))
+    );
+    const childSkillsByModelId = new Map(
+      childSkills.map((skill) => [skill.id, skill])
+    );
+    const referencesByParentSkillId = groupBy(skillReferences, "parentSkillId");
+
+    return new Map(
+      customParentSkills.map((parentSkill) => [
+        parentSkill.sId,
+        removeNulls(
+          (referencesByParentSkillId[parentSkill.id] ?? []).map(
+            (reference) =>
+              childSkillsByModelId.get(reference.childSkillId) ?? null
+          )
+        ),
+      ])
+    );
+  }
+
+  async fetchChildSkills(auth: Authenticator): Promise<SkillResource[]> {
+    const childSkillsMap = await SkillResource.batchFetchChildSkills(auth, [
+      this,
+    ]);
+
+    return childSkillsMap.get(this.sId) ?? [];
+  }
+
   /**
    * Fetches skills from rows that reference them via customSkillId or globalSkillId.
    */

--- a/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
@@ -3,6 +3,7 @@ import {
   SkillFileAttachmentModel,
   SkillVersionModel,
 } from "@app/lib/models/skill";
+import { SkillReferenceModel } from "@app/lib/models/skill/skill_reference";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
@@ -139,6 +140,64 @@ describe("GET /api/w/[wId]/skills/[sId]", () => {
     expect(data).toHaveProperty("skill");
     expect(data.skill.sId).toBe(skill.sId);
     expect(data.skill.name).toBe("Test Skill");
+  });
+
+  it("should return child skills when nested_skills is enabled", async () => {
+    const { req, res, skill, skillOwnerAuth, workspace } = await setupTest({
+      requestUserRole: "admin",
+    });
+
+    await FeatureFlagFactory.basic(skillOwnerAuth, "nested_skills");
+
+    const childSkill = await SkillFactory.create(skillOwnerAuth, {
+      name: "Child Skill",
+    });
+    await SkillReferenceModel.create({
+      workspaceId: workspace.id,
+      parentSkillId: skill.id,
+      childSkillId: childSkill.id,
+    });
+
+    req.query = { ...req.query, withRelations: "true" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+
+    expect(data.skill.relations.childSkills).toEqual([
+      expect.objectContaining({
+        sId: childSkill.sId,
+        name: "Child Skill",
+      }),
+    ]);
+    expect(data.skill.relations.childSkills[0]).not.toHaveProperty(
+      "instructions"
+    );
+  });
+
+  it("should not return child skills when nested_skills is disabled", async () => {
+    const { req, res, skill, skillOwnerAuth, workspace } = await setupTest({
+      requestUserRole: "admin",
+    });
+
+    const childSkill = await SkillFactory.create(skillOwnerAuth, {
+      name: "Hidden Child Skill",
+    });
+    await SkillReferenceModel.create({
+      workspaceId: workspace.id,
+      parentSkillId: skill.id,
+      childSkillId: childSkill.id,
+    });
+
+    req.query = { ...req.query, withRelations: "true" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData().skill.relations).not.toHaveProperty(
+      "childSkills"
+    );
   });
 
   it("should return 404 for non-existent skill", async () => {

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -113,12 +113,18 @@ async function handler(
       const serializedSkill = skill.toJSON(auth);
 
       if (withRelations === "true") {
+        const featureFlags = await getFeatureFlags(auth);
+        const includeChildSkills = featureFlags.includes("nested_skills");
+
         const usage = await skill.fetchUsage(auth);
         const editors = await skill.listEditors(auth);
         const editedByUser = await skill.fetchEditedByUser(auth);
         const extendedSkill = serializedSkill.extendedSkillId
           ? await SkillResource.fetchById(auth, serializedSkill.extendedSkillId)
           : null;
+        const childSkills = includeChildSkills
+          ? await skill.fetchChildSkills(auth)
+          : [];
 
         const skillWithRelations: SkillWithRelationsType = {
           ...serializedSkill,
@@ -127,6 +133,20 @@ async function handler(
             editors: editors ? editors.map((e) => e.toJSON()) : null,
             editedByUser: editedByUser ? editedByUser.toJSON() : null,
             extendedSkill: extendedSkill ? extendedSkill.toJSON(auth) : null,
+            ...(includeChildSkills
+              ? {
+                  childSkills: childSkills.map((childSkill) => {
+                    const {
+                      instructions,
+                      instructionsHtml,
+                      tools,
+                      ...childSkillWithoutInstructionsAndTools
+                    } = childSkill.toJSON(auth);
+
+                    return childSkillWithoutInstructionsAndTools;
+                  }),
+                }
+              : {}),
           },
         };
 

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -1,5 +1,6 @@
 import { Authenticator } from "@app/lib/auth";
 import { SkillMCPServerConfigurationModel } from "@app/lib/models/skill";
+import { SkillReferenceModel } from "@app/lib/models/skill/skill_reference";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { discoverToolsSkill } from "@app/lib/resources/skill/code_defined/discover_tools";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -464,6 +465,60 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
         },
       },
     });
+  });
+
+  it("should return child skills when nested_skills is enabled", async () => {
+    const { req, res, workspace, user } = await setupTest();
+
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    await FeatureFlagFactory.basic(auth, "nested_skills");
+
+    const parentSkill = await SkillFactory.create(auth, {
+      name: "Parent Skill",
+    });
+    const childSkill = await SkillFactory.create(auth, {
+      name: "Child Skill",
+    });
+    await SkillReferenceModel.create({
+      workspaceId: workspace.id,
+      parentSkillId: parentSkill.id,
+      childSkillId: childSkill.id,
+    });
+
+    req.query = { ...req.query, wId: workspace.sId, withRelations: "true" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const parentSkillId = SkillResource.modelIdToSId({
+      id: parentSkill.id,
+      workspaceId: workspace.id,
+    });
+    const skillResult = res
+      ._getJSONData()
+      .skills.find(
+        (s: SkillWithoutInstructionsAndToolsWithRelationsType) =>
+          s.sId === parentSkillId
+      );
+
+    expect(skillResult).toMatchObject({
+      relations: {
+        childSkills: [
+          {
+            sId: childSkill.sId,
+            name: "Child Skill",
+          },
+        ],
+      },
+    });
+    expect(skillResult.relations.childSkills?.[0]).not.toHaveProperty(
+      "instructions"
+    );
   });
 
   it("should return skills without usage when withRelations is not set", async () => {

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -415,6 +415,7 @@ async function handler(
             { error: iconResult.error },
             "Failed to generate icon suggestion for skill"
           );
+          icon = "ActionListIcon";
         }
       }
 

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -132,16 +132,26 @@ async function handler(
       });
 
       if (withRelations === "true") {
-        const [extendedSkills, usageMap, editorsMap, editedByUsersMap] =
-          await Promise.all([
-            SkillResource.fetchByIds(
-              auth,
-              removeNulls(uniq(skills.map((skill) => skill.extendedSkillId)))
-            ),
-            SkillResource.batchFetchUsage(auth, skills),
-            SkillResource.batchListEditors(auth, skills),
-            SkillResource.batchFetchEditedByUsers(auth, skills),
-          ]);
+        const featureFlags = await getFeatureFlags(auth);
+        const includeChildSkills = featureFlags.includes("nested_skills");
+
+        const extendedSkills = await SkillResource.fetchByIds(
+          auth,
+          removeNulls(uniq(skills.map((skill) => skill.extendedSkillId)))
+        );
+        const usageMap = await SkillResource.batchFetchUsage(auth, skills);
+        const editorsMap = await SkillResource.batchListEditors(auth, skills);
+        const editedByUsersMap = await SkillResource.batchFetchEditedByUsers(
+          auth,
+          skills
+        );
+        let childSkillsMap = new Map<string, SkillResource[]>();
+        if (includeChildSkills) {
+          childSkillsMap = await SkillResource.batchFetchChildSkills(
+            auth,
+            skills
+          );
+        }
 
         const extendedSkillsMap = new Map(
           extendedSkills.map((skill) => [skill.sId, skill])
@@ -169,6 +179,22 @@ async function handler(
                 ? (extendedSkillsMap.get(sc.extendedSkillId)?.toJSON(auth) ??
                   null)
                 : null,
+              ...(includeChildSkills
+                ? {
+                    childSkills: (childSkillsMap.get(sc.sId) ?? []).map(
+                      (childSkill) => {
+                        const {
+                          instructions,
+                          instructionsHtml,
+                          tools,
+                          ...childSkillWithoutInstructionsAndTools
+                        } = childSkill.toJSON(auth);
+
+                        return childSkillWithoutInstructionsAndTools;
+                      }
+                    ),
+                  }
+                : {}),
             },
           } satisfies SkillWithoutInstructionsAndToolsWithRelationsType;
         });
@@ -389,7 +415,6 @@ async function handler(
             { error: iconResult.error },
             "Failed to generate icon suggestion for skill"
           );
-          icon = "ActionListIcon";
         }
       }
 

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -75,6 +75,7 @@ export type SkillRelations = {
   editors: UserType[] | null;
   editedByUser: UserType | null;
   extendedSkill: SkillType | null;
+  childSkills?: SkillWithoutInstructionsAndToolsType[];
 };
 
 export type SkillWithRelationsType = SkillType & {


### PR DESCRIPTION
## Description

This PR exposes nested skill references through the private skill relation payloads.

When `nested_skills` is enabled, the skill detail and list endpoints now fetch child skills from `skill_references` and return them as summary-only `relations.childSkills`. The Next.js handlers and their Hono mirrors are kept in sync, and child skills intentionally omit instructions and tools.

This is the backend/API half of the Skill Info nested skills work; the UI rendering will be the topic of a follow up PR, it'll add these skills in the Skill Info page.

## Tests

- Added API coverage for child skills on skill detail and skill list relation responses.
- Covered both Next.js and Hono skill routes.

## Risk

- Low. Additive response field behind `nested_skills`.

## Deploy Plan

- Deploy front.
