### PR TITLE
Return undefined for redirectUrl for mcp as the client is not interactive.

### DIFF
--- a/front/lib/actions/mcp_oauth_provider.ts
+++ b/front/lib/actions/mcp_oauth_provider.ts
@@ -22,8 +22,8 @@ export class MCPOAuthProvider implements OAuthClientProvider {
   constructor(tokens?: OAuthTokens) {
     this.token = tokens;
   }
-  get redirectUrl(): string {
-    throw new MCPOAuthProviderError("redirectUrl");
+  get redirectUrl(): undefined {
+    return undefined;
   }
 
   get clientMetadata(): OAuthClientMetadata {


### PR DESCRIPTION
## Description

`MCPOAuthProvider.redirectUrl` previously threw a `MCPOAuthProviderError` when accessed. Since the MCP client is non-interactive (no browser redirect flow), returning `undefined` is the correct signal to the `OAuthClientProvider` interface — no redirect URL is expected or needed.

## Tests

Tested locally. The change is a 2-line fix with no logic branching — no new unit tests required.

## Risk

Low. The MCP OAuth client is non-interactive by design; this aligns the implementation with that contract instead of throwing an unexpected error at runtime.

## Deploy Plan

Deploy front.
