### PR TITLE
[front] feat: propagate skill renames to inline references

### DIFF
--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -18,6 +18,7 @@ import {
   SkillMCPServerConfigurationModel,
   SkillVersionModel,
 } from "@app/lib/models/skill";
+import { SkillReferenceModel } from "@app/lib/models/skill/skill_reference";
 import {
   AgentMessageSkillModel,
   ConversationSkillModel,
@@ -48,7 +49,10 @@ import {
   makeSId,
 } from "@app/lib/resources/string_ids";
 import { UserResource } from "@app/lib/resources/user_resource";
-import { extractUniqueSkillIds } from "@app/lib/skills/format";
+import {
+  extractUniqueSkillIds,
+  renameSkillReferencesInContent,
+} from "@app/lib/skills/format";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
@@ -2236,6 +2240,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   ): Promise<void> {
     assert(this.canWrite(auth), "User is not authorized to update this skill");
 
+    // Snapshot the previous name before updating to detect a rename below.
+    const previousName = this.name;
+
     await withTransaction(async (transaction) => {
       // Save the current version before updating.
       await this.saveVersion(auth, { transaction });
@@ -2268,6 +2275,16 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
       if (enableSkillReferences) {
         await this.syncSkillReferences(auth, { instructions }, { transaction });
+
+        // When the name changes, propagate it to the inline references that
+        // other skills hold to this skill in their instructions.
+        if (name !== previousName) {
+          await this.propagateRenameToReferencingSkills(
+            auth,
+            { newName: name },
+            { transaction }
+          );
+        }
       }
 
       await this.updateMCPServerViews(auth, mcpServerViews, { transaction });
@@ -2292,6 +2309,74 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }
 
     await this.upsertCurrentUserAsEditor(auth);
+  }
+
+  /**
+   * Rewrites the inline `<skill ... />` references to this skill in the
+   * instructions of every skill that references it to reflect the new name.
+   */
+  private async propagateRenameToReferencingSkills(
+    auth: Authenticator,
+    { newName }: { newName: string },
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<void> {
+    const workspace = auth.getNonNullableWorkspace();
+
+    const references = await SkillReferenceModel.findAll({
+      where: {
+        workspaceId: workspace.id,
+        childSkillId: this.id,
+      },
+      transaction,
+    });
+
+    // Exclude self-references: this skill's own instructions were just written
+    // from the request body and must not be overwritten here.
+    const referencingSkillIds = uniq(
+      references
+        .map((reference) => reference.parentSkillId)
+        .filter((parentSkillId) => parentSkillId !== this.id)
+    );
+
+    if (referencingSkillIds.length === 0) {
+      return;
+    }
+
+    const referencingSkills = await this.model.findAll({
+      where: {
+        workspaceId: workspace.id,
+        id: referencingSkillIds,
+      },
+      transaction,
+    });
+
+    // Each update carries distinct instructions content so it cannot be
+    // batched. Bounded by the number of skills referencing this one.
+    for (const referencingSkill of referencingSkills) {
+      const instructions = renameSkillReferencesInContent(
+        referencingSkill.instructions,
+        { skillId: this.sId, newName }
+      );
+      const instructionsHtml =
+        referencingSkill.instructionsHtml != null
+          ? renameSkillReferencesInContent(referencingSkill.instructionsHtml, {
+              skillId: this.sId,
+              newName,
+            })
+          : referencingSkill.instructionsHtml;
+
+      if (
+        instructions === referencingSkill.instructions &&
+        instructionsHtml === referencingSkill.instructionsHtml
+      ) {
+        continue;
+      }
+
+      await referencingSkill.update(
+        { instructions, instructionsHtml },
+        { transaction }
+      );
+    }
   }
 
   async updateReinforcement(

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -18,7 +18,6 @@ import {
   SkillMCPServerConfigurationModel,
   SkillVersionModel,
 } from "@app/lib/models/skill";
-import { SkillReferenceModel } from "@app/lib/models/skill/skill_reference";
 import {
   AgentMessageSkillModel,
   ConversationSkillModel,

--- a/front/lib/skills/format.ts
+++ b/front/lib/skills/format.ts
@@ -78,3 +78,35 @@ export function stripSkillTagPresentationAttributes(content: string): string {
       });
     });
 }
+
+// Matches a <skill ...> opening tag, whether self-closing (<skill ... />, the
+// form stored in the markdown `instructions`) or paired (<skill ...></skill>,
+// the form stored in the rendered `instructionsHtml`).
+const SKILL_OPEN_TAG_REGEX = /<skill\b[^>]*?\/?>/g;
+
+const SKILL_NAME_ATTRIBUTE_REGEX = /(\bname=")[^"]*(")/;
+
+/**
+ * Rewrites the `name` attribute of every inline reference to `skillId` from
+ * `previousName` to `newName`, leaving all other skill tags untouched. Used to
+ * propagate a skill rename into the instructions of skills that reference it
+ * inline. References are matched by `id` (always present in the Markdown
+ * `instructions` and in client-saved `instructionsHtml`).
+ */
+export function renameSkillReferencesInContent(
+  content: string,
+  {
+    skillId,
+    newName,
+  }: { skillId: string; newName: string }
+): string {
+  return content.replace(SKILL_OPEN_TAG_REGEX, (tag) => {
+    const id = tag.match(/\bid="([^"]+)"/)?.[1];
+
+    if (id === skillId) {
+      return tag.replace(SKILL_NAME_ATTRIBUTE_REGEX, `$1${newName}$2`);
+    }
+
+    return tag;
+  });
+}

--- a/front/lib/skills/format.ts
+++ b/front/lib/skills/format.ts
@@ -95,10 +95,7 @@ const SKILL_NAME_ATTRIBUTE_REGEX = /(\bname=")[^"]*(")/;
  */
 export function renameSkillReferencesInContent(
   content: string,
-  {
-    skillId,
-    newName,
-  }: { skillId: string; newName: string }
+  { skillId, newName }: { skillId: string; newName: string }
 ): string {
   return content.replace(SKILL_OPEN_TAG_REGEX, (tag) => {
     const id = tag.match(/\bid="([^"]+)"/)?.[1];


### PR DESCRIPTION
## Description

- Part of nested skills (`nested_skills` flag). When a skill is renamed, other skills that reference it inline in their instructions (`<skill id="…"  name="…" icon="…" />`) need to show the new name.
- On rename, `updateSkill` now uses `SkillReferenceModel` to find the skills that reference the renamed one, and rewrites the `name` attribute of the matching `<skill …>` tags in both their `instructions` and `instructionsHtml`. References are matched by `id`, so only the renamed skill's tags are touched.

## Tests

- Tested locally.

## Risk

- Low. Feature behind a feature flag. Table not populated currently.

## Deploy Plan

- Deploy front.
