### PR TITLE
feat(outlook-mcp): add subfolder support

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -454,6 +454,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_contacts": "never_ask",
     "get_drafts": "never_ask",
     "get_messages": "never_ask",
+    "list_folders": "never_ask",
     "move_messages": "medium",
     "send_mail": "high",
     "update_contact": "high",

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -1173,6 +1173,42 @@ export const isAgentPauseOutputResourceType = (
   );
 };
 
+// Outlook mail folder list tool output.
+
+export const OUTLOOK_MAIL_FOLDER_LIST_MIME_TYPE =
+  "application/vnd.dust.tool-output.outlook-mail-folder-list" as const;
+
+const OutlookFolderItemSchema = z.object({
+  name: z.string(),
+  childFolderCount: z.number().optional(),
+  unreadItemCount: z.number().optional(),
+  totalItemCount: z.number().optional(),
+});
+
+export const OutlookMailFolderListResourceSchema = z.object({
+  mimeType: z.literal(OUTLOOK_MAIL_FOLDER_LIST_MIME_TYPE),
+  uri: z.literal(""),
+  text: z.string(),
+  path: z.array(z.string()),
+  folders: z.array(OutlookFolderItemSchema),
+});
+
+export type OutlookMailFolderListResourceType = z.infer<
+  typeof OutlookMailFolderListResourceSchema
+>;
+
+export const isOutlookMailFolderListResource = (
+  outputBlock: CallToolResult["content"][number]
+): outputBlock is {
+  type: "resource";
+  resource: OutlookMailFolderListResourceType;
+} => {
+  return (
+    outputBlock.type === "resource" &&
+    OutlookMailFolderListResourceSchema.safeParse(outputBlock.resource).success
+  );
+};
+
 // Clari Copilot tool outputs.
 
 export const CLARI_CALL_LIST_MIME_TYPE =

--- a/front/lib/api/actions/servers/outlook/mail_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/mail_metadata.ts
@@ -21,7 +21,7 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
         .string()
         .optional()
         .describe(
-          'The name of the folder to get messages from. Examples: "Inbox", "Sent Items", "Drafts". The tool will search for a folder matching this name. Leave empty to get messages from all folders.'
+          'The folder to get messages from. Use a plain name for top-level folders (e.g. "Inbox", "Sent Items") or a "/" separated path to target a subfolder (e.g. "Inbox/Projects", "Inbox/test"). The lookup is case-insensitive. Leave empty to get messages from all folders. Use the list_folders tool to discover the available folder hierarchy.'
         ),
       top: z
         .number()
@@ -50,6 +50,31 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Fetching messages",
       done: "Fetch messages",
+    },
+  },
+  list_folders: {
+    description:
+      "List mail folders in an Outlook mailbox. Returns the immediate children of the specified folder path, or top-level folders when no path is given. Use this to discover the full folder hierarchy before calling get_messages with a subfolder path.",
+    schema: {
+      folderPath: z
+        .array(z.string())
+        .optional()
+        .describe(
+          'Path of the folder whose children to list, as an ordered list of folder names from the top level (e.g. ["Inbox"] to list subfolders of Inbox, ["Inbox", "Projects"] to go one level deeper). Omit or pass an empty array to list top-level folders.'
+        ),
+      sharedMailboxAddress: z
+        .string()
+        .optional()
+        .describe(
+          "The email address of the shared mailbox to access (e.g. 'support@company.com'). " +
+            "Leave empty to access your own mailbox. " +
+            "Note: the shared mailbox address must be known in advance — there is no API to auto-discover it."
+        ),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Listing folders",
+      done: "List folders",
     },
   },
   get_attachments: {

--- a/front/lib/api/actions/servers/outlook/tools/mail.ts
+++ b/front/lib/api/actions/servers/outlook/tools/mail.ts
@@ -13,6 +13,7 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { Err, Ok } from "@app/types/shared/result";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import sanitizeHtml from "sanitize-html";
+import { z } from "zod";
 
 const DEFAULT_MESSAGE_FIELDS = [
   "id",
@@ -163,14 +164,19 @@ interface OutlookFileAttachment {
   contentBytes?: string; // Standard base64-encoded content
 }
 
-interface OutlookFolder {
-  id: string;
-  displayName: string;
-  parentFolderId?: string;
-  childFolderCount?: number;
-  unreadItemCount?: number;
-  totalItemCount?: number;
-}
+const OutlookFolderSchema = z.object({
+  id: z.string(),
+  displayName: z.string(),
+  parentFolderId: z.string().optional(),
+  childFolderCount: z.number().optional(),
+  unreadItemCount: z.number().optional(),
+  totalItemCount: z.number().optional(),
+});
+type OutlookFolder = z.infer<typeof OutlookFolderSchema>;
+
+const GraphFolderListResponseSchema = z.object({
+  value: z.array(OutlookFolderSchema).default([]),
+});
 
 const foldersEndpoint = (
   basePath: string,
@@ -199,9 +205,11 @@ const findFolderIdByName = async (
       ),
     };
   }
-  const result = await response.json();
-  const folders = (result.value ?? []) as OutlookFolder[];
-  const folder = folders.find(
+  const parsed = GraphFolderListResponseSchema.safeParse(await response.json());
+  if (!parsed.success) {
+    return { error: new MCPError("Unexpected response format from Graph API") };
+  }
+  const folder = parsed.data.value.find(
     (f) => f.displayName.toLowerCase() === folderName.toLowerCase()
   );
   return { folderId: folder?.id ?? null };
@@ -313,8 +321,15 @@ const findFolderByPath = async (
         ),
       };
     }
-    const result = await response.json();
-    const folders = (result.value ?? []) as OutlookFolder[];
+    const parsed = GraphFolderListResponseSchema.safeParse(
+      await response.json()
+    );
+    if (!parsed.success) {
+      return {
+        error: new MCPError("Unexpected response format from Graph API"),
+      };
+    }
+    const folders = parsed.data.value;
     const folder = folders.find(
       (f) => f.displayName.toLowerCase() === segment.toLowerCase()
     );
@@ -593,8 +608,13 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
       );
     }
 
-    const result = await response.json();
-    const folders = (result.value ?? []) as OutlookFolder[];
+    const parsed = GraphFolderListResponseSchema.safeParse(
+      await response.json()
+    );
+    if (!parsed.success) {
+      return new Err(new MCPError("Unexpected response format from Graph API"));
+    }
+    const folders = parsed.data.value;
 
     const path = folderPath ?? [];
     return new Ok([

--- a/front/lib/api/actions/servers/outlook/tools/mail.ts
+++ b/front/lib/api/actions/servers/outlook/tools/mail.ts
@@ -331,7 +331,10 @@ const findFolderByPath = async (
     parentFolderId = folder.id;
   }
 
-  return { folderId: parentFolderId as string };
+  if (parentFolderId === null) {
+    return { error: new MCPError("No folder resolved from path") };
+  }
+  return { folderId: parentFolderId };
 };
 
 const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {

--- a/front/lib/api/actions/servers/outlook/tools/mail.ts
+++ b/front/lib/api/actions/servers/outlook/tools/mail.ts
@@ -290,6 +290,49 @@ const resolveFolderPath = async (
   return { folderId: parentFolderId as string, createdSegments };
 };
 
+const findFolderByPath = async (
+  pathSegments: string[],
+  basePath: string,
+  accessToken: string
+): Promise<{ folderId: string } | { error: MCPError }> => {
+  let parentFolderId: string | null = null;
+
+  for (let i = 0; i < pathSegments.length; i++) {
+    const segment = pathSegments[i];
+    const response = await fetchFromOutlook(
+      `${foldersEndpoint(basePath, parentFolderId)}?$top=250`,
+      accessToken,
+      { method: "GET" }
+    );
+    if (!response.ok) {
+      const errorText = await getErrorText(response);
+      return {
+        error: new MCPError(
+          `Failed to fetch folders: ${response.status} ${response.statusText} - ${errorText}`
+        ),
+      };
+    }
+    const result = await response.json();
+    const folders = (result.value ?? []) as OutlookFolder[];
+    const folder = folders.find(
+      (f) => f.displayName.toLowerCase() === segment.toLowerCase()
+    );
+    if (!folder) {
+      const parentPath = pathSegments.slice(0, i).join("/");
+      const locationHint = parentPath ? ` in "${parentPath}"` : "";
+      const available = folders.map((f) => f.displayName).join(", ");
+      return {
+        error: new MCPError(
+          `Folder "${segment}" not found${locationHint}. Available folders${locationHint}: ${available}`
+        ),
+      };
+    }
+    parentFolderId = folder.id;
+  }
+
+  return { folderId: parentFolderId as string };
+};
+
 const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
   get_messages: async (
     { search, folderName, top = 10, skip = 0, select, sharedMailboxAddress },
@@ -302,43 +345,22 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
 
     const basePath = getMailboxBasePath(sharedMailboxAddress);
 
-    // If folderName is provided, search for the folder and get its ID
+    // If folderName is provided, resolve it (supports "/" separated paths like "Inbox/Projects")
     let folderId: string | undefined;
     if (folderName) {
-      const foldersResponse = await fetchFromOutlook(
-        `${basePath}/mailFolders`,
-        accessToken,
-        {
-          method: "GET",
-        }
+      const pathSegments = folderName
+        .split("/")
+        .map((s) => s.trim())
+        .filter(Boolean);
+      const resolved = await findFolderByPath(
+        pathSegments,
+        basePath,
+        accessToken
       );
-
-      if (!foldersResponse.ok) {
-        const errorText = await getErrorText(foldersResponse);
-        return new Err(
-          new MCPError(
-            `Failed to fetch folders: ${foldersResponse.status} ${foldersResponse.statusText} - ${errorText}`
-          )
-        );
+      if ("error" in resolved) {
+        return new Err(resolved.error);
       }
-
-      const foldersResult = await foldersResponse.json();
-      const folders = (foldersResult.value ?? []) as OutlookFolder[];
-
-      // Search for the folder by name (case-insensitive)
-      const folder = folders.find(
-        (f) => f.displayName.toLowerCase() === folderName.toLowerCase()
-      );
-
-      if (!folder) {
-        return new Err(
-          new MCPError(
-            `Folder "${folderName}" not found. Available folders: ${folders.map((f) => f.displayName).join(", ")}`
-          )
-        );
-      }
-
-      folderId = folder.id;
+      folderId = resolved.folderId;
     }
 
     const allowedLabels = await getAllowedLabelsForMCPServer(
@@ -523,6 +545,66 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
             messages: (result.value || []) as OutlookMessage[],
             nextLink: result["@odata.nextLink"],
             totalCount: result["@odata.count"],
+          },
+          null,
+          2
+        ),
+      },
+    ]);
+  },
+
+  list_folders: async ({ folderPath, sharedMailboxAddress }, { authInfo }) => {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return new Err(new MCPError("Authentication required"));
+    }
+
+    const basePath = getMailboxBasePath(sharedMailboxAddress);
+    let parentFolderId: string | null = null;
+
+    if (folderPath && folderPath.length > 0) {
+      const resolved = await findFolderByPath(
+        folderPath,
+        basePath,
+        accessToken
+      );
+      if ("error" in resolved) {
+        return new Err(resolved.error);
+      }
+      parentFolderId = resolved.folderId;
+    }
+
+    const response = await fetchFromOutlook(
+      `${foldersEndpoint(basePath, parentFolderId)}?$top=250`,
+      accessToken,
+      { method: "GET" }
+    );
+
+    if (!response.ok) {
+      const errorText = await getErrorText(response);
+      return new Err(
+        new MCPError(
+          `Failed to fetch folders: ${response.status} ${response.statusText} - ${errorText}`
+        )
+      );
+    }
+
+    const result = await response.json();
+    const folders = (result.value ?? []) as OutlookFolder[];
+
+    return new Ok([
+      { type: "text" as const, text: "Folders listed successfully" },
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          {
+            path: folderPath ?? [],
+            folders: folders.map((f) => ({
+              name: f.displayName,
+              childFolderCount: f.childFolderCount,
+              unreadItemCount: f.unreadItemCount,
+              totalItemCount: f.totalItemCount,
+            })),
           },
           null,
           2

--- a/front/lib/api/actions/servers/outlook/tools/mail.ts
+++ b/front/lib/api/actions/servers/outlook/tools/mail.ts
@@ -1,4 +1,5 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
+import { OUTLOOK_MAIL_FOLDER_LIST_MIME_TYPE } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
@@ -592,23 +593,22 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
     const result = await response.json();
     const folders = (result.value ?? []) as OutlookFolder[];
 
+    const path = folderPath ?? [];
     return new Ok([
-      { type: "text" as const, text: "Folders listed successfully" },
       {
-        type: "text" as const,
-        text: JSON.stringify(
-          {
-            path: folderPath ?? [],
-            folders: folders.map((f) => ({
-              name: f.displayName,
-              childFolderCount: f.childFolderCount,
-              unreadItemCount: f.unreadItemCount,
-              totalItemCount: f.totalItemCount,
-            })),
-          },
-          null,
-          2
-        ),
+        type: "resource" as const,
+        resource: {
+          mimeType: OUTLOOK_MAIL_FOLDER_LIST_MIME_TYPE,
+          uri: "",
+          text: `${folders.length} folder(s) listed${path.length > 0 ? ` in "${path.join("/")}"` : ""}`,
+          path,
+          folders: folders.map((f) => ({
+            name: f.displayName,
+            childFolderCount: f.childFolderCount,
+            unreadItemCount: f.unreadItemCount,
+            totalItemCount: f.totalItemCount,
+          })),
+        },
       },
     ]);
   },


### PR DESCRIPTION
## Description

Adds subfolder support to the Outlook MCP server's `get_messages` tool and introduces a new `list_folders` tool for folder discovery.

Previously, `get_messages` could only target top-level folders by exact name. It now accepts `/`-separated paths (e.g. `"Inbox/Projects"`) to reach subfolders, using a new `findFolderByPath` helper that walks the hierarchy level by level via the Graph API (case-insensitive matching). The new `list_folders` tool lets agents discover the folder hierarchy before calling `get_messages` — it accepts an optional `folderPath` array to list children of a specific folder and returns a typed `OutlookMailFolderListResource` with folder names and counts. Both tools support shared mailboxes.

Fixes https://github.com/dust-tt/tasks/issues/7700

## Tests

Manually tested.

## Risk

Low. The existing `get_messages` folder resolution is replaced by a more capable path-walking implementation, but the behavior for simple top-level folder names is unchanged (single-segment paths resolve identically to before).

## Deploy Plan

Deploy front.