### PR TITLE
Improve user spend info

### DIFF
--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -33,6 +33,8 @@ type RowData = {
   seatType: MembershipSeatType | null;
   memberUsageLimit: number | null;
   consumedAwuCredits: number;
+  consumedFromAllowanceAwuCredits: number;
+  consumedFromPoolAwuCredits: number;
   spendLimitAwuCredits: number | null;
   billingFrequency: BillingFrequency | null;
   scheduledSeatType: MembershipSeatType | null;
@@ -82,6 +84,11 @@ function formatCredits(credits: number): string {
 
 interface AwuUsageBarProps {
   consumed: number;
+  // Of `consumed`, the part drawn from the seat allowance vs. the workspace
+  // pool (+ overage). Provided by the API so the bar doesn't re-derive the
+  // split. `consumedFromAllowance + consumedFromPool === consumed`.
+  consumedFromAllowance: number;
+  consumedFromPool: number;
   memberUsageLimit: number | null;
   limit: number | null;
   seatType: MembershipSeatType | null;
@@ -110,58 +117,69 @@ function getSeatBarClasses(seatType: MembershipSeatType | null) {
 
 function AwuUsageBar({
   consumed,
+  consumedFromAllowance,
+  consumedFromPool,
   memberUsageLimit,
   limit,
   seatType,
 }: AwuUsageBarProps) {
-  const hasSeatAllocation = memberUsageLimit !== null && memberUsageLimit > 0;
+  const seatColors = getSeatBarClasses(seatType);
+  const allowance = memberUsageLimit ?? 0;
 
-  if (!hasSeatAllocation) {
-    const percent =
-      limit === null
-        ? 100
-        : limit > 0
-          ? Math.min((consumed / limit) * 100, 100)
-          : 0;
-    return (
-      <div className="flex w-full flex-col gap-1">
-        <div className="flex justify-between text-xs tabular-nums text-foreground dark:text-foreground-night">
-          <span>{formatCredits(consumed)}</span>
-          <span>{limit === null ? "∞" : formatCredits(limit)}</span>
-        </div>
-        <div
-          className={`h-1 w-full overflow-hidden rounded-full ${MUTED_BAR_CLASSES.track}`}
-        >
-          <div
-            className={`h-full ${MUTED_BAR_CLASSES.fill} transition-all`}
-            style={{ width: `${percent}%` }}
-          />
-        </div>
-      </div>
-    );
+  // The bar is up to four contiguous sections, each with its own tooltip:
+  //   seat consumed · seat remaining · pool consumed · pool remaining
+  // Zero-width sections are skipped, so in practice it renders as:
+  //   - within allowance:   seat consumed · seat remaining · pool remaining
+  //   - overflowed to pool: seat consumed · pool consumed · pool remaining
+  //   - no seat allowance:  pool consumed · pool remaining
+  // `pool remaining` is omitted when the user is uncapped (no finite headroom).
+  const seatConsumed = consumedFromAllowance;
+  const seatRemaining = Math.max(0, allowance - seatConsumed);
+  const poolConsumed = consumedFromPool;
+  const poolRemaining =
+    limit !== null ? Math.max(0, limit - allowance - poolConsumed) : null;
+
+  const sections: Array<{
+    key: string;
+    value: number;
+    className: string;
+    label: string;
+  }> = [];
+  if (seatConsumed > 0) {
+    sections.push({
+      key: "seat-consumed",
+      value: seatConsumed,
+      className: seatColors.fill,
+      label: `${formatCredits(seatConsumed)} of ${formatCredits(allowance)} seat allowance used`,
+    });
+  }
+  if (seatRemaining > 0) {
+    sections.push({
+      key: "seat-remaining",
+      value: seatRemaining,
+      className: seatColors.track,
+      label: `${formatCredits(seatRemaining)} of ${formatCredits(allowance)} seat allowance remaining`,
+    });
+  }
+  if (poolConsumed > 0) {
+    sections.push({
+      key: "pool-consumed",
+      value: poolConsumed,
+      className: MUTED_BAR_CLASSES.fill,
+      label: `${formatCredits(poolConsumed)} credits used from the workspace pool`,
+    });
+  }
+  if (poolRemaining !== null && poolRemaining > 0) {
+    sections.push({
+      key: "pool-remaining",
+      value: poolRemaining,
+      className: MUTED_BAR_CLASSES.track,
+      label: `${formatCredits(poolRemaining)} credits remaining before spend limit`,
+    });
   }
 
-  const seatColors = getSeatBarClasses(seatType);
-  const seatConsumed = Math.min(consumed, memberUsageLimit);
-  const overflow = Math.max(0, consumed - memberUsageLimit);
-  const overflowRange =
-    limit !== null ? Math.max(0, limit - memberUsageLimit) : null;
-  const seatFillPercent =
-    limit === null ? 100 : (seatConsumed / memberUsageLimit) * 100;
-  const overflowFillPercent =
-    limit === null
-      ? 100
-      : overflowRange !== null && overflowRange > 0
-        ? Math.min((overflow / overflowRange) * 100, 100)
-        : overflow > 0
-          ? 100
-          : 0;
-  const seatWidthPercent =
-    limit !== null && limit > memberUsageLimit
-      ? (memberUsageLimit / limit) * 100
-      : 50;
-  const overflowWidthPercent = 100 - seatWidthPercent;
-  const remaining = limit !== null ? Math.max(0, limit - consumed) : null;
+  const total = sections.reduce((sum, s) => sum + s.value, 0);
+
   return (
     <div className="flex w-full flex-col gap-1">
       <div className="flex justify-between text-xs tabular-nums text-foreground dark:text-foreground-night">
@@ -169,44 +187,29 @@ function AwuUsageBar({
         <span>{limit === null ? "∞" : formatCredits(limit)}</span>
       </div>
       <div className="flex w-full items-center gap-px">
-        <Tooltip
-          tooltipTriggerAsChild
-          label={`${formatCredits(seatConsumed)} credits consumed over ${formatCredits(memberUsageLimit)} seat limit`}
-          trigger={
-            <div
-              className="flex h-3 items-center"
-              style={{ width: `${seatWidthPercent}%` }}
-            >
-              <div
-                className={`h-1 w-full overflow-hidden rounded-full ${seatColors.track}`}
-              >
+        {total > 0 ? (
+          sections.map((s) => (
+            <Tooltip
+              key={s.key}
+              tooltipTriggerAsChild
+              label={s.label}
+              trigger={
                 <div
-                  className={`h-full ${seatColors.fill} transition-all`}
-                  style={{ width: `${seatFillPercent}%` }}
-                />
-              </div>
-            </div>
-          }
-        />
-        <Tooltip
-          tooltipTriggerAsChild
-          label={`${remaining === null ? "∞" : formatCredits(remaining)} credits remaining`}
-          trigger={
-            <div
-              className="flex h-3 items-center"
-              style={{ width: `${overflowWidthPercent}%` }}
-            >
-              <div
-                className={`h-1 w-full overflow-hidden rounded-full ${MUTED_BAR_CLASSES.track}`}
-              >
-                <div
-                  className={`h-full ${MUTED_BAR_CLASSES.fill} transition-all`}
-                  style={{ width: `${overflowFillPercent}%` }}
-                />
-              </div>
-            </div>
-          }
-        />
+                  className="flex h-3 items-center"
+                  style={{ width: `${(s.value / total) * 100}%` }}
+                >
+                  <div
+                    className={`h-1 w-full rounded-full ${s.className} transition-all`}
+                  />
+                </div>
+              }
+            />
+          ))
+        ) : (
+          <div
+            className={`h-1 w-full rounded-full ${MUTED_BAR_CLASSES.track}`}
+          />
+        )}
       </div>
     </div>
   );
@@ -316,6 +319,10 @@ const consumedAwuCreditsColumn: ColumnDef<RowData, string> = {
     <div className="w-full pr-3">
       <AwuUsageBar
         consumed={info.row.original.consumedAwuCredits}
+        consumedFromAllowance={
+          info.row.original.consumedFromAllowanceAwuCredits
+        }
+        consumedFromPool={info.row.original.consumedFromPoolAwuCredits}
         memberUsageLimit={info.row.original.memberUsageLimit}
         limit={info.row.original.spendLimitAwuCredits}
         seatType={info.row.original.seatType}
@@ -417,6 +424,8 @@ export function MembersUsageTable({
         seatType: m.seatType,
         memberUsageLimit: m.memberUsageLimit,
         consumedAwuCredits: m.consumedAwuCredits,
+        consumedFromAllowanceAwuCredits: m.consumedFromAllowanceAwuCredits,
+        consumedFromPoolAwuCredits: m.consumedFromPoolAwuCredits,
         spendLimitAwuCredits: m.spendLimitAwuCredits,
         billingFrequency: m.billingFrequency,
         scheduledSeatType: m.scheduledSeatType,

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -36,6 +36,16 @@ export type MemberUsageType = {
   // was covered by the seat allocation or overflowed into the workspace
   // pool.
   consumedAwuCredits: number;
+  // Breakdown of `consumedAwuCredits`: the portion covered by the user's seat
+  // allowance (credits drain seat-first) vs. the portion that overflowed into
+  // the workspace pool (plus any PAYG overage). Always sums to
+  // `consumedAwuCredits`. Derived from total usage capped at the seat
+  // allocation: Metronome materializes seat (INDIVIDUAL) credits as a single
+  // per-subscription pool with no per-user balance, so an exact ledger split
+  // isn't available — but per-user usage is exact, so this is exact except
+  // when a mid-period-prorated user exceeds their (prorated) allocation.
+  consumedFromAllowanceAwuCredits: number;
+  consumedFromPoolAwuCredits: number;
   // Billing cadence for the seat subscription the user is assigned to; null when unknown.
   billingFrequency: BillingFrequency | null;
   // Set when a future seat change is scheduled (e.g. at the next credit refresh).
@@ -370,6 +380,16 @@ export async function getMembersUsage({
     const awuAllocation = seatData?.awuAllocation ?? 0;
     const scheduled = scheduledByUserId.get(membership.userId);
 
+    // Credits drain seat-allowance-first, then the workspace pool, so the
+    // allowance covers up to the user's seat allocation and the remainder
+    // overflows to the pool.
+    const consumedFromAllowanceAwuCredits = Math.min(
+      totalConsumedCredits,
+      awuAllocation
+    );
+    const consumedFromPoolAwuCredits =
+      totalConsumedCredits - consumedFromAllowanceAwuCredits;
+
     return [
       {
         sId: userId,
@@ -379,6 +399,8 @@ export async function getMembersUsage({
         seatType: membership.seatType ?? null,
         memberUsageLimit: awuAllocation > 0 ? awuAllocation : null,
         consumedAwuCredits: totalConsumedCredits,
+        consumedFromAllowanceAwuCredits,
+        consumedFromPoolAwuCredits,
         billingFrequency: seatData?.billingFrequency ?? null,
         scheduledSeatType: scheduled?.seatType ?? null,
         scheduledSeatChangeAt: scheduled?.startAt.toISOString() ?? null,


### PR DESCRIPTION
## Description

Adds a per-user breakdown of AWU consumption — **seat allowance vs. workspace pool** — to the workspace members usage view, and reworks the usage bar to surface it with a tooltip on each section.

**Backend (`lib/api/credits/members_usage.ts`)**
- `MemberUsageType` gains `consumedFromAllowanceAwuCredits` and `consumedFromPoolAwuCredits`, which always sum to `consumedAwuCredits`.
- Computed in `getMembersUsage` from data already fetched: credits drain seat-allowance-first, so `fromAllowance = min(consumedAwuCredits, seatAllocation)` and `fromPool = consumedAwuCredits − fromAllowance`.
- Why derived rather than read from the credit ledger: Metronome materializes the INDIVIDUAL seat allocation as a **single per-subscription credit** (sized to the sum of all seats' prorated allocations) with no `user_id` and a `balance` that already bakes in the period-end deduction — so there's no per-user seat balance to read. Per-user *usage* is exact, so this split is exact except for the narrow case of a mid-period-prorated user who exceeds their prorated allocation (nominal vs. prorated cap).

**UI (`components/workspace/MembersUsageTable.tsx`)**
- `AwuUsageBar` is rebuilt as one proportional bar of up to four contiguous sections, each with its own tooltip: **seat consumed · seat remaining · pool consumed · pool remaining**. Zero-width sections are skipped, so it renders naturally per case:
  - within allowance → `seat consumed · seat remaining · pool remaining`
  - overflowed to pool → `seat consumed · pool consumed · pool remaining`
  - no seat allowance → `pool consumed · pool remaining`
- `pool remaining` is omitted when the user is uncapped (the header still shows `∞`). The bar reads the split from the API instead of re-deriving `min`/`max` locally, so it matches the reported numbers exactly.
- Tooltips are now explicit per section (e.g. "X of Y seat allowance used", "X credits used from the workspace pool", "X credits remaining before spend limit"), replacing the previous two ambiguous labels.

## Tests

- Type-checked (`tsgo`) and biome-formatted.
- Verified in the dev members-usage table with one and two seats (the per-section widths/tooltips and the within-allowance vs. overflowed vs. no-allowance renderings).
- No automated test changes: the new fields are derived in `getMembersUsage` from existing inputs and the table is presentational.

## Risk

Low. Additive field on an existing private endpoint (no breaking change) plus a presentational bar rework. Degrades gracefully — a user with no seat allocation shows the pool-only rendering, and `fromAllowance + fromPool` always equals the already-displayed `consumedAwuCredits`. Safe to roll back (pure revert).

## Deploy Plan

Standard deploy — no migration, no env var changes.
