### PR TITLE
Metronome: seat sync workflow and activity

### DIFF
--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -14,7 +14,6 @@ import {
 import {
   classifySeatChange,
   hasContractSeatSubscription,
-  syncSeatCount,
 } from "@app/lib/metronome/seats";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
@@ -25,7 +24,10 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
-import { launchUpdateUsageWorkflow } from "@app/temporal/usage_queue/client";
+import {
+  launchMetronomeSeatCountSyncWorkflow,
+  launchUpdateUsageWorkflow,
+} from "@app/temporal/usage_queue/client";
 import type {
   MembershipOriginType,
   MembershipRoleType,
@@ -39,40 +41,6 @@ import type {
   UserType,
 } from "@app/types/user";
 import type { Transaction } from "sequelize";
-
-async function syncSeatCountForWorkspace(
-  workspace: LightWorkspaceType
-): Promise<Result<void, Error>> {
-  if (!workspace.metronomeCustomerId) {
-    return new Ok(undefined);
-  }
-  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
-    workspace.id
-  );
-  if (!subscription?.metronomeContractId) {
-    return new Ok(undefined);
-  }
-
-  const contract = await getActiveContract(workspace.sId);
-  if (!contract) {
-    return new Ok(undefined);
-  }
-
-  const hasSeatSubscription = await hasContractSeatSubscription(contract);
-  // Gate on seat subscription presence — contracts without a seat product (e.g. enterprise)
-  // should not trigger a seat sync.
-  if (!hasSeatSubscription) {
-    return new Ok(undefined);
-  }
-
-  const result = await syncSeatCount({
-    metronomeCustomerId: workspace.metronomeCustomerId,
-    contractId: subscription.metronomeContractId,
-    workspace,
-    contract,
-  });
-  return result.isErr() ? new Err(result.error) : new Ok(undefined);
-}
 
 /**
  * Resolve the seat type for a brand-new membership. For seat-billed
@@ -235,7 +203,9 @@ export async function createAndTrackMembership({
   await launchUpdateUsageWorkflow({ workspaceId: workspace.sId });
 
   // Add seat in Metronome if workspace is Metronome-billed.
-  const addSeatResult = await syncSeatCountForWorkspace(w);
+  const addSeatResult = await launchMetronomeSeatCountSyncWorkflow({
+    workspaceId: w.sId,
+  });
   if (addSeatResult.isErr()) {
     logger.error(
       {
@@ -338,7 +308,9 @@ export async function revokeAndTrackMembership(
     }
 
     // Remove seat in Metronome if workspace is Metronome-billed.
-    const removeSeatResult = await syncSeatCountForWorkspace(workspace);
+    const removeSeatResult = await launchMetronomeSeatCountSyncWorkflow({
+      workspaceId: workspace.sId,
+    });
     if (removeSeatResult.isErr()) {
       logger.error(
         {
@@ -415,7 +387,9 @@ export async function updateMembershipRoleAndTrack({
 
     // If a revoked membership was re-activated, add a Metronome seat and update usage.
     if (wasRevoked) {
-      const addSeatResult = await syncSeatCountForWorkspace(workspace);
+      const addSeatResult = await launchMetronomeSeatCountSyncWorkflow({
+        workspaceId: workspace.sId,
+      });
       if (addSeatResult.isErr()) {
         logger.error(
           {
@@ -597,11 +571,8 @@ export async function updateMembershipSeatAndTrack({
       return assertNever(outcome);
   }
 
-  const syncResult = await syncSeatCount({
-    metronomeCustomerId: workspace.metronomeCustomerId,
-    contractId: contract.id,
-    workspace,
-    contract,
+  const syncResult = await launchMetronomeSeatCountSyncWorkflow({
+    workspaceId: workspace.sId,
   });
   if (syncResult.isErr()) {
     logger.error(

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -443,10 +443,18 @@ export async function syncMauCountToMetronomeForAllWorkspacesActivity(): Promise
  * Sync the Metronome seat count for a single workspace after membership changes were debounced.
  */
 export async function syncMetronomeSeatCountActivity(
-  authType: AuthenticatorType
+  workspaceId: string
 ): Promise<void> {
-  const auth = await Authenticator.fromJSON(authType);
-  const workspace = auth.getNonNullableWorkspace();
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  if (!workspace) {
+    logger.info(
+      {
+        workspaceId,
+      },
+      "[Metronome] Skipping seat count sync: workspace not found"
+    );
+    return;
+  }
 
   if (!workspace.metronomeCustomerId) {
     logger.info(
@@ -458,7 +466,9 @@ export async function syncMetronomeSeatCountActivity(
     return;
   }
 
-  const subscription = auth.subscriptionResource();
+  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+    workspace.id
+  );
   if (!subscription?.metronomeContractId) {
     logger.info(
       {
@@ -500,7 +510,7 @@ export async function syncMetronomeSeatCountActivity(
   const result = await syncSeatCount({
     metronomeCustomerId: workspace.metronomeCustomerId,
     contractId: subscription.metronomeContractId,
-    workspace,
+    workspace: renderLightWorkspaceType({ workspace }),
     contract,
   });
   if (result.isErr()) {

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -16,6 +16,10 @@ import {
 } from "@app/lib/metronome/mau_sync";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import {
+  hasContractSeatSubscription,
+  syncSeatCount,
+} from "@app/lib/metronome/seats";
+import {
   AgentMessageModel,
   MessageModel,
   UserMessageModel,
@@ -433,4 +437,77 @@ export async function syncMauCountToMetronomeForAllWorkspacesActivity(): Promise
     },
     { concurrency: 10 }
   );
+}
+
+/**
+ * Sync the Metronome seat count for a single workspace after membership changes were debounced.
+ */
+export async function syncMetronomeSeatCountActivity(
+  authType: AuthenticatorType
+): Promise<void> {
+  const auth = await Authenticator.fromJSON(authType);
+  const workspace = auth.getNonNullableWorkspace();
+
+  if (!workspace.metronomeCustomerId) {
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+      },
+      "[Metronome] Skipping seat count sync: workspace missing metronomeCustomerId"
+    );
+    return;
+  }
+
+  const subscription = auth.subscriptionResource();
+  if (!subscription?.metronomeContractId) {
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        metronomeCustomerId: workspace.metronomeCustomerId,
+      },
+      "[Metronome] Skipping seat count sync: workspace missing metronomeContractId"
+    );
+    return;
+  }
+
+  const contract = await getActiveContract(workspace.sId);
+  if (!contract) {
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        metronomeCustomerId: workspace.metronomeCustomerId,
+        metronomeContractId: subscription.metronomeContractId,
+      },
+      "[Metronome] Skipping seat count sync: no active contract found for workspace"
+    );
+    return;
+  }
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      metronomeCustomerId: workspace.metronomeCustomerId,
+      metronomeContractId: subscription.metronomeContractId,
+    },
+    "[Metronome] Executing debounced seat count sync"
+  );
+
+  const hasSeatSubscription = await hasContractSeatSubscription(contract);
+  if (!hasSeatSubscription) {
+    return;
+  }
+
+  const result = await syncSeatCount({
+    metronomeCustomerId: workspace.metronomeCustomerId,
+    contractId: subscription.metronomeContractId,
+    workspace,
+    contract,
+  });
+  if (result.isErr()) {
+    logger.error(
+      { workspaceId: workspace.sId, error: result.error },
+      "[Metronome] Failed to sync seat count for workspace"
+    );
+    throw result.error;
+  }
 }

--- a/front/temporal/usage_queue/client.ts
+++ b/front/temporal/usage_queue/client.ts
@@ -4,12 +4,15 @@ import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import { QUEUE_NAME } from "@app/temporal/usage_queue/config";
 import {
+  makeMetronomeSeatCountSyncWorkflowId,
   makeMetronomeUsageEventsWorkflowId,
   makeTrackProgrammaticUsageWorkflowId,
 } from "@app/temporal/usage_queue/helpers";
+import { syncMetronomeSeatCountSignal } from "@app/temporal/usage_queue/signals";
 import {
   emitMetronomeUsageEventsWorkflow,
   syncMauCountToMetronomeWorkflow,
+  syncMetronomeSeatCountWorkflow,
   trackProgrammaticUsageWorkflow,
   updateWorkspaceUsageWorkflow,
 } from "@app/temporal/usage_queue/workflows";
@@ -181,6 +184,39 @@ export async function launchEmitMetronomeUsageEventsWorkflow({
       );
     }
 
+    return new Err(normalizeError(e));
+  }
+}
+
+export async function launchMetronomeSeatCountSyncWorkflow({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): Promise<Result<undefined, Error>> {
+  const client = await getTemporalClientForFrontNamespace();
+  const workflowId = makeMetronomeSeatCountSyncWorkflowId({ workspaceId });
+
+  try {
+    await client.workflow.signalWithStart(syncMetronomeSeatCountWorkflow, {
+      args: [workspaceId],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+      signal: syncMetronomeSeatCountSignal,
+      signalArgs: undefined,
+      memo: {
+        workspaceId,
+      },
+    });
+    return new Ok(undefined);
+  } catch (e) {
+    logger.error(
+      {
+        workflowId,
+        workspaceId,
+        error: e,
+      },
+      "[Metronome] Failed to signal seat count sync workflow"
+    );
     return new Err(normalizeError(e));
   }
 }

--- a/front/temporal/usage_queue/helpers.ts
+++ b/front/temporal/usage_queue/helpers.ts
@@ -21,3 +21,11 @@ export function makeMetronomeUsageEventsWorkflowId({
 }): string {
   return `metronome-usage-${workspaceId}-${conversationId}-${agentMessageId}`;
 }
+
+export function makeMetronomeSeatCountSyncWorkflowId({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): string {
+  return `metronome-seat-count-sync-${workspaceId}`;
+}

--- a/front/temporal/usage_queue/signals.ts
+++ b/front/temporal/usage_queue/signals.ts
@@ -1,0 +1,5 @@
+import { defineSignal } from "@temporalio/workflow";
+
+export const syncMetronomeSeatCountSignal = defineSignal<[void]>(
+  "sync_metronome_seat_count_signal"
+);

--- a/front/temporal/usage_queue/worker.ts
+++ b/front/temporal/usage_queue/worker.ts
@@ -6,6 +6,7 @@ import * as activities from "@app/temporal/usage_queue/activities";
 import { launchMetronomeGaugeSchedule } from "@app/temporal/usage_queue/client";
 import type { Context } from "@temporalio/activity";
 import { Worker } from "@temporalio/worker";
+import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
 import { QUEUE_NAME } from "./config";
 
@@ -29,6 +30,15 @@ export async function runUpdateWorkspaceUsageWorker() {
           };
         },
       ],
+    },
+    bundlerOptions: {
+      // Update the webpack config to use aliases from our tsconfig.json.
+      webpackConfigHook: (config) => {
+        const plugins = config.resolve?.plugins ?? [];
+
+        config.resolve!.plugins = [...plugins, new TsconfigPathsPlugin({})];
+        return config;
+      },
     },
   });
 

--- a/front/temporal/usage_queue/workflows.ts
+++ b/front/temporal/usage_queue/workflows.ts
@@ -1,7 +1,10 @@
 import type { AuthenticatorType } from "@app/lib/auth";
 import type * as activities from "@app/temporal/usage_queue/activities";
+import { syncMetronomeSeatCountSignal } from "@app/temporal/usage_queue/signals";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
-import { proxyActivities, sleep } from "@temporalio/workflow";
+import { proxyActivities, setHandler, sleep } from "@temporalio/workflow";
+
+const METRONOME_SEAT_COUNT_DEBOUNCE_MS = 60 * 60 * 1000;
 
 const { recordUsageActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",
@@ -26,11 +29,31 @@ const { syncMauCountToMetronomeForAllWorkspacesActivity } = proxyActivities<
   startToCloseTimeout: "30 minutes",
 });
 
+const { syncMetronomeSeatCountActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "10 minutes",
+});
+
 export async function updateWorkspaceUsageWorkflow(workspaceId: string) {
   // Sleep for one hour before computing usage.
   await sleep(60 * 60 * 1000);
 
   await recordUsageActivity(workspaceId);
+}
+
+export async function syncMetronomeSeatCountWorkflow(
+  authType: AuthenticatorType
+): Promise<void> {
+  let pendingSync = true;
+
+  setHandler(syncMetronomeSeatCountSignal, () => {
+    pendingSync = true;
+  });
+
+  while (pendingSync) {
+    await sleep(METRONOME_SEAT_COUNT_DEBOUNCE_MS);
+    pendingSync = false;
+    await syncMetronomeSeatCountActivity(authType);
+  }
 }
 
 export async function trackProgrammaticUsageWorkflow(

--- a/front/temporal/usage_queue/workflows.ts
+++ b/front/temporal/usage_queue/workflows.ts
@@ -41,7 +41,7 @@ export async function updateWorkspaceUsageWorkflow(workspaceId: string) {
 }
 
 export async function syncMetronomeSeatCountWorkflow(
-  authType: AuthenticatorType
+  workspaceId: string
 ): Promise<void> {
   let pendingSync = true;
 
@@ -50,9 +50,9 @@ export async function syncMetronomeSeatCountWorkflow(
   });
 
   while (pendingSync) {
-    await sleep(METRONOME_SEAT_COUNT_DEBOUNCE_MS);
     pendingSync = false;
-    await syncMetronomeSeatCountActivity(authType);
+    await sleep(METRONOME_SEAT_COUNT_DEBOUNCE_MS);
+    await syncMetronomeSeatCountActivity(workspaceId);
   }
 }
 

--- a/front/temporal/usage_queue/workflows.ts
+++ b/front/temporal/usage_queue/workflows.ts
@@ -4,7 +4,7 @@ import { syncMetronomeSeatCountSignal } from "@app/temporal/usage_queue/signals"
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import { proxyActivities, setHandler, sleep } from "@temporalio/workflow";
 
-const METRONOME_SEAT_COUNT_DEBOUNCE_MS = 60 * 60 * 1000;
+const METRONOME_SEAT_COUNT_DEBOUNCE_MS = 15 * 60 * 1000;
 
 const { recordUsageActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",
@@ -50,8 +50,8 @@ export async function syncMetronomeSeatCountWorkflow(
   });
 
   while (pendingSync) {
-    pendingSync = false;
     await sleep(METRONOME_SEAT_COUNT_DEBOUNCE_MS);
+    pendingSync = false;
     await syncMetronomeSeatCountActivity(workspaceId);
   }
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/7722

Move seat count sync to a debounced activity (15mn).

- Introduce activity and debounced workflow + client. Activity takes `workspaceId` since many call site don't have an Authenticator unfortunately.
- Rewire calls to `syncSeatCountForWorkspace`

## Tests

Tested locally

## Risk

Low

## Deploy Plan

- deploy `front`