### PR TITLE
[front] Add tool reference tag foundation

### DIFF
--- a/front/components/editor/extensions/skill_builder/ToolNode.test.ts
+++ b/front/components/editor/extensions/skill_builder/ToolNode.test.ts
@@ -1,0 +1,178 @@
+import { ToolNode } from "@app/components/editor/extensions/skill_builder/ToolNode";
+import type { ToolNodeAttributes } from "@app/components/editor/extensions/skill_builder/ToolNodeTypes";
+import { EditorFactory } from "@app/components/editor/extensions/tests/utils";
+import {
+  extractToolTags,
+  parseToolTag,
+  serializeToolTag,
+  stripToolTagPresentationAttributes,
+} from "@app/lib/tools/format";
+import type { Editor } from "@tiptap/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const TOOL_ATTRS: ToolNodeAttributes = {
+  mcpServerViewId: "mcp_server_view_123",
+  toolIcon: "GithubLogo",
+  toolName: "GitHub Search",
+};
+
+function toolNodes(editor: Editor) {
+  const nodes: { attrs?: ToolNodeAttributes; type: string }[] = [];
+  editor.state.doc.descendants((node) => {
+    if (node.type.name === "toolNode") {
+      nodes.push({
+        attrs: {
+          mcpServerViewId: node.attrs.mcpServerViewId,
+          toolIcon: node.attrs.toolIcon,
+          toolName: node.attrs.toolName,
+        },
+        type: node.type.name,
+      });
+    }
+  });
+  return nodes;
+}
+
+describe("ToolNode tag helpers", () => {
+  it("serializes and parses tool tags with XML escaping", () => {
+    const attrs = {
+      icon: "GithubLogo",
+      id: "mcp_server_view_123",
+      name: 'GitHub & "Issues" <Prod>',
+    };
+
+    const tag = serializeToolTag(attrs);
+
+    expect(tag).toContain("GitHub &amp; &quot;Issues&quot; &lt;Prod&gt;");
+    expect(parseToolTag(tag)).toEqual(attrs);
+  });
+
+  it("parses missing icon as null", () => {
+    expect(
+      parseToolTag('<tool id="mcp_server_view_123" name="GitHub Search" />')
+    ).toEqual({
+      icon: null,
+      id: "mcp_server_view_123",
+      name: "GitHub Search",
+    });
+  });
+
+  it("rejects malformed tool tags", () => {
+    expect(parseToolTag('<tool name="GitHub Search" />')).toBeNull();
+    expect(parseToolTag('<tool id="mcp_server_view_123" />')).toBeNull();
+    expect(
+      parseToolTag(
+        '<tool id="mcp_server_view_123" name="GitHub Search"></tool>'
+      )
+    ).toBeNull();
+  });
+
+  it("extracts valid tool tags from content", () => {
+    expect(
+      extractToolTags(
+        'Use <tool id="mcp_server_view_1" name="A" /> and <tool id="mcp_server_view_2" name="B" icon="ToolsIcon" />.'
+      )
+    ).toEqual([
+      {
+        icon: null,
+        id: "mcp_server_view_1",
+        name: "A",
+      },
+      {
+        icon: "ToolsIcon",
+        id: "mcp_server_view_2",
+        name: "B",
+      },
+    ]);
+  });
+
+  it("strips icon presentation attributes from tool tags", () => {
+    expect(
+      stripToolTagPresentationAttributes(
+        '<tool id="mcp_server_view_123" name="GitHub Search" icon="GithubLogo" />'
+      )
+    ).toBe('<tool id="mcp_server_view_123" name="GitHub Search" />');
+
+    expect(
+      stripToolTagPresentationAttributes(
+        '<tool id="mcp_server_view_123" name="GitHub Search" icon="GithubLogo"><span>GitHub Search</span></tool>'
+      )
+    ).toBe('<tool id="mcp_server_view_123" name="GitHub Search" />');
+  });
+});
+
+describe("ToolNode", () => {
+  let editor: Editor;
+
+  beforeEach(() => {
+    editor = EditorFactory([ToolNode]);
+  });
+
+  afterEach(() => {
+    editor.destroy();
+  });
+
+  it("round-trips markdown tool tags", () => {
+    const markdown = `Use ${serializeToolTag({
+      icon: TOOL_ATTRS.toolIcon,
+      id: TOOL_ATTRS.mcpServerViewId,
+      name: TOOL_ATTRS.toolName,
+    })} now.`;
+
+    editor.commands.setContent(markdown, {
+      contentType: "markdown",
+    });
+
+    expect(toolNodes(editor)).toEqual([
+      {
+        attrs: TOOL_ATTRS,
+        type: "toolNode",
+      },
+    ]);
+    expect(editor.getMarkdown()).toContain(
+      serializeToolTag({
+        icon: TOOL_ATTRS.toolIcon,
+        id: TOOL_ATTRS.mcpServerViewId,
+        name: TOOL_ATTRS.toolName,
+      })
+    );
+  });
+
+  it("round-trips stored HTML tool tags", () => {
+    editor.commands.setContent(
+      '<p>Use <tool id="mcp_server_view_123" name="GitHub Search" icon="GithubLogo"></tool>.</p>'
+    );
+
+    expect(toolNodes(editor)).toEqual([
+      {
+        attrs: TOOL_ATTRS,
+        type: "toolNode",
+      },
+    ]);
+    expect(editor.getHTML()).toContain("<tool");
+    expect(editor.getHTML()).toContain('id="mcp_server_view_123"');
+    expect(editor.getHTML()).toContain('name="GitHub Search"');
+    expect(editor.getHTML()).toContain('icon="GithubLogo"');
+  });
+
+  it("does not parse malformed stored HTML tool tags", () => {
+    editor.commands.setContent(
+      '<p>Literal <tool name="GitHub Search">example</tool>.</p>'
+    );
+
+    expect(toolNodes(editor)).toEqual([]);
+    expect(editor.getText()).toContain("Literal example.");
+  });
+
+  it("inserts a tool node followed by a space", () => {
+    editor.commands.insertToolNode(TOOL_ATTRS);
+
+    expect(toolNodes(editor)).toEqual([
+      {
+        attrs: TOOL_ATTRS,
+        type: "toolNode",
+      },
+    ]);
+    expect(editor.getText()).toBe("/GitHub Search ");
+  });
+});

--- a/front/components/editor/extensions/skill_builder/ToolNode.test.ts
+++ b/front/components/editor/extensions/skill_builder/ToolNode.test.ts
@@ -67,6 +67,14 @@ describe("ToolNode tag helpers", () => {
     ).toBeNull();
   });
 
+  it("does not parse prefixed attributes as tool attributes", () => {
+    const tag =
+      '<tool data-id="mcp_server_view_123" data-name="GitHub Search" />';
+
+    expect(parseToolTag(tag)).toBeNull();
+    expect(extractToolTags(tag)).toEqual([]);
+  });
+
   it("extracts valid tool tags from content", () => {
     expect(
       extractToolTags(

--- a/front/components/editor/extensions/skill_builder/ToolNode.ts
+++ b/front/components/editor/extensions/skill_builder/ToolNode.ts
@@ -1,0 +1,153 @@
+import type { ToolNodeAttributes } from "@app/components/editor/extensions/skill_builder/ToolNodeTypes";
+import {
+  parseToolTag,
+  serializeToolTag,
+  TOOL_TAG_NAME,
+  TOOL_TAG_REGEX_BEGINNING,
+} from "@app/lib/tools/format";
+import { isString } from "@app/types/shared/utils/general";
+import { Node } from "@tiptap/core";
+
+export const TOOL_NODE_TYPE = "toolNode";
+
+const TOOL_CHIP_CLASS =
+  "inline-flex items-center gap-0.5 border border-current/40 rounded px-0.5 text-xs leading-tight";
+const TOOL_LABEL_PREFIX = "Tool";
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    toolNode: {
+      insertToolNode: (attrs: ToolNodeAttributes) => ReturnType;
+    };
+  }
+}
+
+export const ToolNode = Node.create({
+  name: TOOL_NODE_TYPE,
+  group: "inline",
+  inline: true,
+  atom: true,
+  selectable: false,
+
+  addAttributes() {
+    return {
+      mcpServerViewId: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("id"),
+        renderHTML: (attributes) =>
+          isString(attributes.mcpServerViewId)
+            ? { id: attributes.mcpServerViewId }
+            : {},
+      },
+      toolName: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("name"),
+        renderHTML: (attributes) =>
+          isString(attributes.toolName) ? { name: attributes.toolName } : {},
+      },
+      toolIcon: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("icon"),
+        renderHTML: (attributes) =>
+          isString(attributes.toolIcon) ? { icon: attributes.toolIcon } : {},
+      },
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: TOOL_TAG_NAME,
+        getAttrs: (node) => {
+          if (!(node instanceof HTMLElement)) {
+            return false;
+          }
+
+          return node.getAttribute("id") && node.getAttribute("name")
+            ? null
+            : false;
+        },
+      },
+    ];
+  },
+
+  renderHTML({ node, HTMLAttributes }) {
+    const { toolName } = node.attrs;
+    if (!isString(toolName)) {
+      return ["span", {}];
+    }
+
+    return [
+      TOOL_TAG_NAME,
+      HTMLAttributes,
+      [
+        "span",
+        { class: TOOL_CHIP_CLASS },
+        ["span", {}, TOOL_LABEL_PREFIX],
+        ["span", {}, ` ${toolName}`],
+      ],
+    ];
+  },
+
+  renderText({ node }) {
+    return `/${node.attrs.toolName ?? "tool"}`;
+  },
+
+  addCommands() {
+    return {
+      insertToolNode:
+        (attrs: ToolNodeAttributes) =>
+        ({ commands }) =>
+          commands.insertContent([
+            {
+              type: TOOL_NODE_TYPE,
+              attrs,
+            },
+            { type: "text", text: " " },
+          ]),
+    };
+  },
+
+  markdownTokenizer: {
+    name: TOOL_NODE_TYPE,
+    level: "inline",
+    start: (src) => src.indexOf(`<${TOOL_TAG_NAME}`),
+    tokenize: (src) => {
+      const match = TOOL_TAG_REGEX_BEGINNING.exec(src);
+      if (!match) {
+        return undefined;
+      }
+
+      const tool = parseToolTag(match[0]);
+      if (!tool) {
+        return undefined;
+      }
+
+      return {
+        type: TOOL_NODE_TYPE,
+        raw: match[0],
+        mcpServerViewId: tool.id,
+        toolIcon: tool.icon,
+        toolName: tool.name,
+      };
+    },
+  },
+
+  parseMarkdown: (token) => ({
+    type: TOOL_NODE_TYPE,
+    attrs: {
+      mcpServerViewId: token.mcpServerViewId,
+      toolIcon: token.toolIcon,
+      toolName: token.toolName,
+    },
+  }),
+
+  renderMarkdown: (node) =>
+    isString(node.attrs?.mcpServerViewId) && isString(node.attrs?.toolName)
+      ? serializeToolTag({
+          icon: isString(node.attrs.toolIcon) ? node.attrs.toolIcon : null,
+          id: node.attrs.mcpServerViewId,
+          name: node.attrs.toolName,
+        })
+      : "",
+});

--- a/front/components/editor/extensions/skill_builder/ToolNodeTypes.ts
+++ b/front/components/editor/extensions/skill_builder/ToolNodeTypes.ts
@@ -1,0 +1,5 @@
+export interface ToolNodeAttributes {
+  mcpServerViewId: string;
+  toolIcon: string | null;
+  toolName: string;
+}

--- a/front/lib/tools/format.ts
+++ b/front/lib/tools/format.ts
@@ -1,0 +1,95 @@
+import { escapeXml } from "@app/types/shared/utils/string_utils";
+import { unescape } from "html-escaper";
+
+export type ToolReference = {
+  icon: string | null;
+  id: string;
+  name: string;
+};
+
+export const TOOL_TAG_NAME = "tool";
+
+export const TOOL_TAG_REGEX = /<tool\s+([^>]*?)\s*\/>/g;
+export const TOOL_TAG_REGEX_BEGINNING = /^<tool\s+([^>]*?)\s*\/>/;
+
+const TOOL_ELEMENT_REGEX = /<tool\b([^>]*)>[\s\S]*?<\/tool>/g;
+
+function parseAttribute(attributes: string, name: string): string | null {
+  const value = new RegExp(`\\b${name}="([^"]*)"`).exec(attributes)?.[1];
+  if (value === undefined || value === "") {
+    return null;
+  }
+
+  return unescape(value);
+}
+
+function parseToolTagAttributes(attributes: string): ToolReference | null {
+  const id = parseAttribute(attributes, "id");
+  const name = parseAttribute(attributes, "name");
+
+  if (!id || !name) {
+    return null;
+  }
+
+  return {
+    icon: parseAttribute(attributes, "icon"),
+    id,
+    name,
+  };
+}
+
+export function parseToolTag(tag: string): ToolReference | null {
+  const attributes = TOOL_TAG_REGEX_BEGINNING.exec(tag)?.[1];
+
+  if (!attributes) {
+    return null;
+  }
+
+  return parseToolTagAttributes(attributes);
+}
+
+export function extractToolTags(content: string): ToolReference[] {
+  return [...content.matchAll(TOOL_TAG_REGEX)]
+    .map((match) => parseToolTag(match[0]))
+    .filter((tool): tool is ToolReference => tool !== null);
+}
+
+export function serializeToolTag({ icon, id, name }: ToolReference): string {
+  return `<${TOOL_TAG_NAME} ${serializeToolTagAttributes({
+    icon,
+    id,
+    name,
+  })} />`;
+}
+
+function serializeToolTagAttributes({ icon, id, name }: ToolReference): string {
+  const iconAttribute = icon ? ` icon="${escapeXml(icon)}"` : "";
+
+  return `id="${escapeXml(id)}" name="${escapeXml(name)}"${iconAttribute}`;
+}
+
+export function stripToolTagPresentationAttributes(content: string): string {
+  return content
+    .replace(TOOL_ELEMENT_REGEX, (tag, attributes: string) => {
+      const tool = parseToolTag(`<${TOOL_TAG_NAME}${attributes} />`);
+      if (!tool) {
+        return tag.replace(/(<tool\b[^>]*?)\s+icon="[^"]*"/, "$1");
+      }
+
+      return serializeToolTag({
+        ...tool,
+        icon: null,
+      });
+    })
+    .replace(TOOL_TAG_REGEX, (tag) => {
+      const tool = parseToolTag(tag);
+      if (!tool) {
+        return tag.replace(/\s+icon="[^"]*"/g, "");
+      }
+
+      return serializeToolTag({
+        ...tool,
+        icon: null,
+      });
+    });
+}

--- a/front/lib/tools/format.ts
+++ b/front/lib/tools/format.ts
@@ -15,7 +15,7 @@ export const TOOL_TAG_REGEX_BEGINNING = /^<tool\s+([^>]*?)\s*\/>/;
 const TOOL_ELEMENT_REGEX = /<tool\b([^>]*)>[\s\S]*?<\/tool>/g;
 
 function parseAttribute(attributes: string, name: string): string | null {
-  const value = new RegExp(`\\b${name}="([^"]*)"`).exec(attributes)?.[1];
+  const value = new RegExp(`(?:^|\\s)${name}="([^"]*)"`).exec(attributes)?.[1];
   if (value === undefined || value === "") {
     return null;
   }


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/26448, https://github.com/dust-tt/dust/pull/26449, https://github.com/dust-tt/dust/pull/26451, and https://github.com/dust-tt/dust/pull/26452. Splits the foundation out of https://github.com/dust-tt/dust/pull/26462.

Adds shared helpers for serialized `<tool id="..." name="..." icon="..." />` references plus a React-free TipTap `ToolNode` schema, insertion command, and direct markdown/HTML round-trip tests.

## Risks

Blast radius: no runtime wiring; new helper and editor schema only.
Risk: low

## Deploy Plan

- Deploy front.

## Tests

- [x] Run focused Skill Builder tool-reference tests on the final stack top.