### PR TITLE
[front] Render tool references in Skill Builder instructions

### DIFF
--- a/front/components/editor/extensions/skill_builder/ToolChip.tsx
+++ b/front/components/editor/extensions/skill_builder/ToolChip.tsx
@@ -1,0 +1,63 @@
+import {
+  getIcon,
+  isCustomResourceIconType,
+  isInternalAllowedIcon,
+} from "@app/components/resources/resources_icons";
+import {
+  AttachmentChip,
+  ExclamationCircleIcon,
+  ToolsIcon,
+} from "@dust-tt/sparkle";
+import type React from "react";
+
+function getToolIcon(toolIcon: string | null) {
+  if (
+    toolIcon &&
+    (isCustomResourceIconType(toolIcon) || isInternalAllowedIcon(toolIcon))
+  ) {
+    return getIcon(toolIcon);
+  }
+
+  return ToolsIcon;
+}
+
+interface ToolChipProps {
+  color?: React.ComponentProps<typeof AttachmentChip>["color"];
+  onRemove?: () => void;
+  title: string;
+  toolIcon: string | null;
+}
+
+export function ToolChip({
+  color = "white",
+  onRemove,
+  title,
+  toolIcon,
+}: ToolChipProps) {
+  return (
+    <AttachmentChip
+      label={title}
+      icon={{ visual: getToolIcon(toolIcon) }}
+      color={color}
+      onRemove={onRemove}
+      size="xs"
+    />
+  );
+}
+
+interface ToolErrorChipProps {
+  onRemove?: () => void;
+  title: string;
+}
+
+export function ToolErrorChip({ onRemove, title }: ToolErrorChipProps) {
+  return (
+    <AttachmentChip
+      label={title}
+      icon={{ visual: ExclamationCircleIcon }}
+      color="white"
+      onRemove={onRemove}
+      size="xs"
+    />
+  );
+}

--- a/front/components/editor/extensions/skill_builder/ToolNode.test.ts
+++ b/front/components/editor/extensions/skill_builder/ToolNode.test.ts
@@ -2,6 +2,10 @@ import { ToolNode } from "@app/components/editor/extensions/skill_builder/ToolNo
 import type { ToolNodeAttributes } from "@app/components/editor/extensions/skill_builder/ToolNodeTypes";
 import { EditorFactory } from "@app/components/editor/extensions/tests/utils";
 import {
+  postProcessMarkdown,
+  preprocessMarkdownForEditor,
+} from "@app/lib/editor/skill_instructions_preprocessing";
+import {
   extractToolTags,
   parseToolTag,
   serializeToolTag,
@@ -127,7 +131,7 @@ describe("ToolNode", () => {
       name: TOOL_ATTRS.toolName,
     })} now.`;
 
-    editor.commands.setContent(markdown, {
+    editor.commands.setContent(preprocessMarkdownForEditor(markdown), {
       contentType: "markdown",
     });
 
@@ -144,6 +148,18 @@ describe("ToolNode", () => {
         name: TOOL_ATTRS.toolName,
       })
     );
+  });
+
+  it("keeps malformed markdown tool tags as text", () => {
+    const markdown =
+      'Literal <tool name="GitHub Search">example</tool> and <tool id="mcp_server_view_123" />.';
+
+    editor.commands.setContent(preprocessMarkdownForEditor(markdown), {
+      contentType: "markdown",
+    });
+
+    expect(toolNodes(editor)).toEqual([]);
+    expect(postProcessMarkdown(editor.getMarkdown())).toContain(markdown);
   });
 
   it("round-trips stored HTML tool tags", () => {

--- a/front/components/editor/extensions/skill_builder/ToolNode.test.ts
+++ b/front/components/editor/extensions/skill_builder/ToolNode.test.ts
@@ -131,9 +131,14 @@ describe("ToolNode", () => {
       name: TOOL_ATTRS.toolName,
     })} now.`;
 
-    editor.commands.setContent(preprocessMarkdownForEditor(markdown), {
-      contentType: "markdown",
-    });
+    editor.commands.setContent(
+      preprocessMarkdownForEditor(markdown, {
+        enableSkillReferences: true,
+      }),
+      {
+        contentType: "markdown",
+      }
+    );
 
     expect(toolNodes(editor)).toEqual([
       {

--- a/front/components/editor/extensions/skill_builder/ToolNodeWithView.tsx
+++ b/front/components/editor/extensions/skill_builder/ToolNodeWithView.tsx
@@ -1,0 +1,86 @@
+import {
+  ToolChip,
+  ToolErrorChip,
+} from "@app/components/editor/extensions/skill_builder/ToolChip";
+import { ToolNode } from "@app/components/editor/extensions/skill_builder/ToolNode";
+import type { ToolNodeAttributes } from "@app/components/editor/extensions/skill_builder/ToolNodeTypes";
+import { useMaybeMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
+import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
+import type { NodeViewProps } from "@tiptap/react";
+import { NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
+import type React from "react";
+import { useCallback, useMemo } from "react";
+
+function useToolNodeDisplay(attrs: ToolNodeAttributes) {
+  const ctx = useMaybeMCPServerViewsContext();
+
+  return useMemo(() => {
+    if (!ctx || ctx.isMCPServerViewsLoading) {
+      return {
+        kind: "tool" as const,
+        title: attrs.toolName,
+        toolIcon: attrs.toolIcon,
+      };
+    }
+
+    const view = ctx.mcpServerViews.find(
+      (v) => v.sId === attrs.mcpServerViewId
+    );
+
+    if (!view || ctx.isMCPServerViewsError) {
+      return {
+        kind: "error" as const,
+        title: attrs.toolName,
+      };
+    }
+
+    return {
+      kind: "tool" as const,
+      title: getMcpServerViewDisplayName(view),
+      toolIcon: view.server.icon,
+    };
+  }, [attrs.mcpServerViewId, attrs.toolIcon, attrs.toolName, ctx]);
+}
+
+const ToolNodeView: React.FC<NodeViewProps> = ({
+  deleteNode,
+  editor,
+  node,
+}) => {
+  const attrs: ToolNodeAttributes = {
+    mcpServerViewId: node.attrs.mcpServerViewId,
+    toolIcon: node.attrs.toolIcon,
+    toolName: node.attrs.toolName,
+  };
+  const display = useToolNodeDisplay(attrs);
+
+  const handleRemove = useCallback(
+    (e?: React.MouseEvent) => {
+      e?.stopPropagation();
+      deleteNode();
+    },
+    [deleteNode]
+  );
+
+  const onRemove = editor.isEditable ? handleRemove : undefined;
+
+  return (
+    <NodeViewWrapper as="span" className="inline">
+      {display.kind === "error" ? (
+        <ToolErrorChip title={display.title} onRemove={onRemove} />
+      ) : (
+        <ToolChip
+          title={display.title}
+          toolIcon={display.toolIcon}
+          onRemove={onRemove}
+        />
+      )}
+    </NodeViewWrapper>
+  );
+};
+
+export const ToolNodeWithView = ToolNode.extend({
+  addNodeView() {
+    return ReactNodeViewRenderer(ToolNodeView);
+  },
+});

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -27,16 +27,9 @@ import { useController, useFormContext } from "react-hook-form";
 const INSTRUCTIONS_FIELD_NAME = "instructions";
 const INSTRUCTIONS_HTML_FIELD_NAME = "instructionsHtml";
 const ATTACHED_KNOWLEDGE_FIELD_NAME = "attachedKnowledge";
-const BASE_ALLOWED_INSTRUCTIONS_TAGS = ["knowledge", "tool"];
-const BASE_ALLOWED_INSTRUCTIONS_ATTRS = [
-  "space",
-  "dsv",
-  "hasChildren",
-  "id",
-  "name",
-  "icon",
-];
-const SKILL_REFERENCE_ALLOWED_TAGS = ["skill"];
+const BASE_ALLOWED_INSTRUCTIONS_TAGS = ["knowledge"];
+const BASE_ALLOWED_INSTRUCTIONS_ATTRS = ["space", "dsv", "hasChildren"];
+const SKILL_REFERENCE_ALLOWED_TAGS = ["skill", "tool"];
 const SKILL_REFERENCE_ALLOWED_ATTRS = ["id", "name", "icon"];
 
 function getSkillInstructionsSanitizeConfig({

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -27,8 +27,15 @@ import { useController, useFormContext } from "react-hook-form";
 const INSTRUCTIONS_FIELD_NAME = "instructions";
 const INSTRUCTIONS_HTML_FIELD_NAME = "instructionsHtml";
 const ATTACHED_KNOWLEDGE_FIELD_NAME = "attachedKnowledge";
-const BASE_ALLOWED_INSTRUCTIONS_TAGS = ["knowledge"];
-const BASE_ALLOWED_INSTRUCTIONS_ATTRS = ["space", "dsv", "hasChildren"];
+const BASE_ALLOWED_INSTRUCTIONS_TAGS = ["knowledge", "tool"];
+const BASE_ALLOWED_INSTRUCTIONS_ATTRS = [
+  "space",
+  "dsv",
+  "hasChildren",
+  "id",
+  "name",
+  "icon",
+];
 const SKILL_REFERENCE_ALLOWED_TAGS = ["skill"];
 const SKILL_REFERENCE_ALLOWED_ATTRS = ["id", "name", "icon"];
 

--- a/front/components/skills/SkillInstructionsReadOnlyEditor.tsx
+++ b/front/components/skills/SkillInstructionsReadOnlyEditor.tsx
@@ -4,6 +4,7 @@ import {
   SkillInstructionsEditorContent,
   useSkillInstructionsEditor,
 } from "@app/components/editor/SkillInstructionsEditor";
+import { MCPServerViewsProvider } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useEffect } from "react";
 
@@ -56,11 +57,13 @@ export function SkillInstructionsReadOnlyEditor({
 
   return (
     <SpacesProvider owner={owner}>
-      <SkillInstructionsEditorContent
-        editor={editor}
-        isReadOnly
-        className={className}
-      />
+      <MCPServerViewsProvider owner={owner}>
+        <SkillInstructionsEditorContent
+          editor={editor}
+          isReadOnly
+          className={className}
+        />
+      </MCPServerViewsProvider>
     </SpacesProvider>
   );
 }

--- a/front/lib/editor/build_skill_instructions_extensions.ts
+++ b/front/lib/editor/build_skill_instructions_extensions.ts
@@ -11,6 +11,7 @@ import {
   RawMarkdownBlock,
   rawMarkdownBlockParsers,
 } from "@app/components/editor/extensions/skill_builder/RawMarkdownBlock";
+import { ToolNodeWithView } from "@app/components/editor/extensions/skill_builder/ToolNodeWithView";
 import { LinkExtension } from "@app/components/editor/input_bar/LinkExtension";
 import { markdownStyles } from "@dust-tt/sparkle";
 import type { Extensions } from "@tiptap/core";
@@ -21,6 +22,7 @@ export const INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT = 120_000;
 
 interface BuildSkillInstructionsExtensionsOptions {
   enableSkillReferences?: boolean;
+  enableToolReferences?: boolean;
 }
 
 /**
@@ -34,6 +36,7 @@ export function buildSkillInstructionsExtensions(
   editableExtensions: Extensions = [],
   {
     enableSkillReferences = false,
+    enableToolReferences = true,
   }: BuildSkillInstructionsExtensionsOptions = {}
 ): Extensions {
   const baseExtensions: Extensions = [
@@ -94,10 +97,17 @@ export function buildSkillInstructionsExtensions(
     }),
     BlockIdExtension,
     KnowledgeNodeWithView.configure({ readOnly: isReadOnly }),
+  ];
+
+  if (enableToolReferences) {
+    baseExtensions.push(ToolNodeWithView);
+  }
+
+  baseExtensions.push(
     InstructionSuggestionExtension.configure({ showBlockHighlight: false }),
     RawMarkdownBlock,
-    ...rawMarkdownBlockParsers,
-  ];
+    ...rawMarkdownBlockParsers
+  );
 
   if (enableSkillReferences) {
     baseExtensions.push(SkillNode);

--- a/front/lib/editor/build_skill_instructions_extensions.ts
+++ b/front/lib/editor/build_skill_instructions_extensions.ts
@@ -22,7 +22,6 @@ export const INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT = 120_000;
 
 interface BuildSkillInstructionsExtensionsOptions {
   enableSkillReferences?: boolean;
-  enableToolReferences?: boolean;
 }
 
 /**
@@ -36,7 +35,6 @@ export function buildSkillInstructionsExtensions(
   editableExtensions: Extensions = [],
   {
     enableSkillReferences = false,
-    enableToolReferences = true,
   }: BuildSkillInstructionsExtensionsOptions = {}
 ): Extensions {
   const baseExtensions: Extensions = [
@@ -99,7 +97,7 @@ export function buildSkillInstructionsExtensions(
     KnowledgeNodeWithView.configure({ readOnly: isReadOnly }),
   ];
 
-  if (enableToolReferences) {
+  if (enableSkillReferences) {
     baseExtensions.push(ToolNodeWithView);
   }
 

--- a/front/lib/editor/skill_instructions_preprocessing.test.ts
+++ b/front/lib/editor/skill_instructions_preprocessing.test.ts
@@ -1,5 +1,9 @@
 import { buildSkillInstructionsExtensions } from "@app/lib/editor/build_skill_instructions_extensions";
-import { preprocessMarkdownForEditor } from "@app/lib/editor/skill_instructions_preprocessing";
+import {
+  postProcessMarkdown,
+  preprocessMarkdownForEditor,
+} from "@app/lib/editor/skill_instructions_preprocessing";
+import { serializeToolTag } from "@app/lib/tools/format";
 import { Editor } from "@tiptap/react";
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -43,5 +47,23 @@ describe("skill instructions preprocessing", () => {
     expect(editor.getMarkdown()).toContain(
       '<skill id="skill_123" name="Create memo" />'
     );
+  });
+
+  it("keeps escaped tool attributes when post-processing editor markdown", () => {
+    const toolTag = serializeToolTag({
+      icon: "GithubLogo",
+      id: "mcp_server_view_123",
+      name: 'GitHub & "Issues" <Prod>',
+    });
+
+    editor = new Editor({
+      extensions: buildSkillInstructionsExtensions(false),
+    });
+
+    editor.commands.setContent(preprocessMarkdownForEditor(`Use ${toolTag}.`), {
+      contentType: "markdown",
+    });
+
+    expect(postProcessMarkdown(editor.getMarkdown())).toContain(toolTag);
   });
 });

--- a/front/lib/editor/skill_instructions_preprocessing.test.ts
+++ b/front/lib/editor/skill_instructions_preprocessing.test.ts
@@ -23,6 +23,14 @@ describe("skill instructions preprocessing", () => {
     ).toContain("<\u200Bskill");
   });
 
+  it("escapes tool tags by default", () => {
+    expect(
+      preprocessMarkdownForEditor(
+        '<tool id="mcp_server_view_123" name="GitHub Search" />'
+      )
+    ).toContain("<\u200Btool");
+  });
+
   it("preserves skill tags when skill references are enabled", () => {
     editor = new Editor({
       extensions: buildSkillInstructionsExtensions(false, [], {
@@ -57,12 +65,19 @@ describe("skill instructions preprocessing", () => {
     });
 
     editor = new Editor({
-      extensions: buildSkillInstructionsExtensions(false),
+      extensions: buildSkillInstructionsExtensions(false, [], {
+        enableSkillReferences: true,
+      }),
     });
 
-    editor.commands.setContent(preprocessMarkdownForEditor(`Use ${toolTag}.`), {
-      contentType: "markdown",
-    });
+    editor.commands.setContent(
+      preprocessMarkdownForEditor(`Use ${toolTag}.`, {
+        enableSkillReferences: true,
+      }),
+      {
+        contentType: "markdown",
+      }
+    );
 
     expect(postProcessMarkdown(editor.getMarkdown())).toContain(toolTag);
   });

--- a/front/lib/editor/skill_instructions_preprocessing.ts
+++ b/front/lib/editor/skill_instructions_preprocessing.ts
@@ -1,6 +1,9 @@
+import { parseToolTag, TOOL_TAG_REGEX } from "@app/lib/tools/format";
 import { unescape } from "html-escaper";
 
 const ZWS = "\u200B";
+const TOOL_TAG_PLACEHOLDER_PREFIX = "\uE000DUST_TOOL_TAG_";
+const TOOL_TAG_PLACEHOLDER_SUFFIX = "\uE001";
 
 /**
  * Escape emphasis delimiters (_ and *) inside $$ ... $$ math blocks so
@@ -19,13 +22,45 @@ export function preprocessMarkdownForEditor(
   markdown: string,
   { enableSkillReferences = false }: { enableSkillReferences?: boolean } = {}
 ): string {
-  const preservedTags = enableSkillReferences ? "knowledge|skill" : "knowledge";
+  const toolTags: string[] = [];
+  const markdownWithToolPlaceholders = markdown.replace(
+    TOOL_TAG_REGEX,
+    (tag) => {
+      if (!parseToolTag(tag)) {
+        return tag;
+      }
+
+      const placeholder = `${TOOL_TAG_PLACEHOLDER_PREFIX}${toolTags.length}${TOOL_TAG_PLACEHOLDER_SUFFIX}`;
+      toolTags.push(tag);
+      return placeholder;
+    }
+  );
+
+  const preservedTags = ["knowledge"];
+  if (enableSkillReferences) {
+    preservedTags.push("skill");
+  }
+  const preservedTagsPattern = preservedTags.join("|");
 
   return escapeMathEmphasis(
-    markdown.replace(
-      new RegExp(`<(?!(?:/?(?:${preservedTags}))[\\s>/])(/?\\w)`, "g"),
-      `<${ZWS}$1`
-    )
+    markdownWithToolPlaceholders
+      .replace(
+        new RegExp(`<(?!(?:/?(?:${preservedTagsPattern}))[\\s>/])(/?\\w)`, "g"),
+        `<${ZWS}$1`
+      )
+      .replace(
+        new RegExp(
+          `${TOOL_TAG_PLACEHOLDER_PREFIX}(\\d+)${TOOL_TAG_PLACEHOLDER_SUFFIX}`,
+          "g"
+        ),
+        (_, index: string) => {
+          const toolTag = toolTags[Number(index)];
+          if (!toolTag) {
+            throw new Error("Missing preserved tool tag placeholder.");
+          }
+          return toolTag;
+        }
+      )
   );
 }
 

--- a/front/lib/editor/skill_instructions_preprocessing.ts
+++ b/front/lib/editor/skill_instructions_preprocessing.ts
@@ -60,15 +60,17 @@ export function preprocessMarkdownForEditor(
     preservedTags.push("skill");
   }
   const preservedTagsPattern = preservedTags.join("|");
-
-  return withPreservedToolTags(markdown, (markdownWithToolPlaceholders) =>
+  const escapeUnsupportedTags = (markdownToProcess: string) =>
     escapeMathEmphasis(
-      markdownWithToolPlaceholders.replace(
+      markdownToProcess.replace(
         new RegExp(`<(?!(?:/?(?:${preservedTagsPattern}))[\\s>/])(/?\\w)`, "g"),
         `<${ZWS}$1`
       )
-    )
-  );
+    );
+
+  return enableSkillReferences
+    ? withPreservedToolTags(markdown, escapeUnsupportedTags)
+    : escapeUnsupportedTags(markdown);
 }
 
 /**

--- a/front/lib/editor/skill_instructions_preprocessing.ts
+++ b/front/lib/editor/skill_instructions_preprocessing.ts
@@ -15,12 +15,9 @@ function escapeMathEmphasis(markdown: string): string {
   );
 }
 
-/**
- * Preprocess markdown before loading it into the TipTap editor.
- */
-export function preprocessMarkdownForEditor(
+function withPreservedToolTags(
   markdown: string,
-  { enableSkillReferences = false }: { enableSkillReferences?: boolean } = {}
+  transform: (markdownWithToolPlaceholders: string) => string
 ): string {
   const toolTags: string[] = [];
   const markdownWithToolPlaceholders = markdown.replace(
@@ -36,31 +33,41 @@ export function preprocessMarkdownForEditor(
     }
   );
 
+  return transform(markdownWithToolPlaceholders).replace(
+    new RegExp(
+      `${TOOL_TAG_PLACEHOLDER_PREFIX}(\\d+)${TOOL_TAG_PLACEHOLDER_SUFFIX}`,
+      "g"
+    ),
+    (_, index: string) => {
+      const toolTag = toolTags[Number(index)];
+      if (!toolTag) {
+        throw new Error("Missing preserved tool tag placeholder.");
+      }
+      return toolTag;
+    }
+  );
+}
+
+/**
+ * Preprocess markdown before loading it into the TipTap editor.
+ */
+export function preprocessMarkdownForEditor(
+  markdown: string,
+  { enableSkillReferences = false }: { enableSkillReferences?: boolean } = {}
+): string {
   const preservedTags = ["knowledge"];
   if (enableSkillReferences) {
     preservedTags.push("skill");
   }
   const preservedTagsPattern = preservedTags.join("|");
 
-  return escapeMathEmphasis(
-    markdownWithToolPlaceholders
-      .replace(
+  return withPreservedToolTags(markdown, (markdownWithToolPlaceholders) =>
+    escapeMathEmphasis(
+      markdownWithToolPlaceholders.replace(
         new RegExp(`<(?!(?:/?(?:${preservedTagsPattern}))[\\s>/])(/?\\w)`, "g"),
         `<${ZWS}$1`
       )
-      .replace(
-        new RegExp(
-          `${TOOL_TAG_PLACEHOLDER_PREFIX}(\\d+)${TOOL_TAG_PLACEHOLDER_SUFFIX}`,
-          "g"
-        ),
-        (_, index: string) => {
-          const toolTag = toolTags[Number(index)];
-          if (!toolTag) {
-            throw new Error("Missing preserved tool tag placeholder.");
-          }
-          return toolTag;
-        }
-      )
+    )
   );
 }
 
@@ -68,9 +75,11 @@ export function preprocessMarkdownForEditor(
  * Normalize markdown serialized out of the TipTap editor before saving.
  */
 export function postProcessMarkdown(markdown: string): string {
-  return unescape(markdown)
-    .replace(new RegExp(ZWS, "g"), "")
-    .replace(/\$\$([\s\S]*?)\$\$/g, (block) =>
-      block.replace(/\\_/g, "_").replace(/\\\*/g, "*")
-    );
+  return withPreservedToolTags(markdown, (markdownWithToolPlaceholders) =>
+    unescape(markdownWithToolPlaceholders)
+      .replace(new RegExp(ZWS, "g"), "")
+      .replace(/\$\$([\s\S]*?)\$\$/g, (block) =>
+        block.replace(/\\_/g, "_").replace(/\\\*/g, "*")
+      )
+  );
 }


### PR DESCRIPTION
## Description

Stacked on https://github.com/dust-tt/dust/pull/26479. Splits the editor rendering layer out of https://github.com/dust-tt/dust/pull/26462.

Registers the tool reference node in browser Skill Builder instruction extensions, renders chips from MCP server view context, preserves valid self-closing `<tool />` tags during markdown preprocessing, and allows `tool` tags/attributes through instruction sanitization. Read-only instructions are wrapped with `MCPServerViewsProvider` so existing references can render or show an error state.

## Risks

Blast radius: Skill Builder instruction editor and read-only instruction rendering.
Risk: standard

## Deploy Plan

- Deploy front.

## Tests

- [x] Run focused Skill Builder tool-reference tests on the final stack top.