### PR TITLE
[front] Strip tool presentation from skill prompts

### DIFF
--- a/front/lib/api/assistant/skills_rendering.test.ts
+++ b/front/lib/api/assistant/skills_rendering.test.ts
@@ -1,0 +1,33 @@
+import { getEnabledSkillInstructions } from "@app/lib/api/assistant/skills_rendering";
+import { describe, expect, it } from "vitest";
+
+type SkillInstructionsSource = Parameters<
+  typeof getEnabledSkillInstructions
+>[0];
+
+function makeEnabledSkill(
+  overrides: Partial<SkillInstructionsSource>
+): SkillInstructionsSource {
+  return {
+    name: "ResearchSkill",
+    instructions: "",
+    extendedSkill: null,
+    ...overrides,
+  };
+}
+
+describe("getEnabledSkillInstructions", () => {
+  it("strips tool icon attributes from model-facing skill instructions", () => {
+    const skill = makeEnabledSkill({
+      instructions:
+        'Use <tool id="mcp_server_view_1" name="GitHub Search" icon="GithubLogo" />.',
+    });
+
+    expect(getEnabledSkillInstructions(skill)).toContain(
+      '<tool id="mcp_server_view_1" name="GitHub Search" />'
+    );
+    expect(getEnabledSkillInstructions(skill)).not.toContain(
+      'icon="GithubLogo"'
+    );
+  });
+});

--- a/front/lib/api/assistant/skills_rendering.ts
+++ b/front/lib/api/assistant/skills_rendering.ts
@@ -4,10 +4,15 @@ import {
 } from "@app/lib/actions/constants";
 import { SKILL_MANAGEMENT_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { stripToolTagPresentationAttributes } from "@app/lib/tools/format";
 import type { UserMessageTypeModel } from "@app/types/assistant/generation";
 
 export type EnabledSkill = SkillResource & {
   extendedSkill: SkillResource | null;
+};
+
+type SkillInstructionsSource = Pick<SkillResource, "name" | "instructions"> & {
+  extendedSkill: Pick<SkillResource, "instructions"> | null;
 };
 
 function renderSystemSkillMessage(text: string): UserMessageTypeModel {
@@ -18,18 +23,25 @@ function renderSystemSkillMessage(text: string): UserMessageTypeModel {
   };
 }
 
-export function getEnabledSkillInstructions(skill: EnabledSkill): string {
+export function getEnabledSkillInstructions(
+  skill: SkillInstructionsSource
+): string {
   const { name, instructions, extendedSkill } = skill;
+  const modelInstructions = stripToolTagPresentationAttributes(instructions);
 
   if (!extendedSkill) {
-    return `<${name}>\n${instructions}\n</${name}>`;
+    return `<${name}>\n${modelInstructions}\n</${name}>`;
   }
+
+  const extendedModelInstructions = stripToolTagPresentationAttributes(
+    extendedSkill.instructions
+  );
 
   return [
     `<${name}>`,
-    extendedSkill.instructions,
+    extendedModelInstructions,
     "<additional_guidelines>",
-    instructions,
+    modelInstructions,
     "</additional_guidelines>",
     `</${name}>`,
   ].join("\n");

--- a/front/lib/api/assistant/skills_rendering.ts
+++ b/front/lib/api/assistant/skills_rendering.ts
@@ -11,10 +11,6 @@ export type EnabledSkill = SkillResource & {
   extendedSkill: SkillResource | null;
 };
 
-type SkillInstructionsSource = Pick<SkillResource, "name" | "instructions"> & {
-  extendedSkill: Pick<SkillResource, "instructions"> | null;
-};
-
 function renderSystemSkillMessage(text: string): UserMessageTypeModel {
   return {
     role: "user",
@@ -24,7 +20,9 @@ function renderSystemSkillMessage(text: string): UserMessageTypeModel {
 }
 
 export function getEnabledSkillInstructions(
-  skill: SkillInstructionsSource
+  skill: Pick<SkillResource, "name" | "instructions"> & {
+    extendedSkill: Pick<SkillResource, "instructions"> | null;
+  }
 ): string {
   const { name, instructions, extendedSkill } = skill;
   const modelInstructions = stripToolTagPresentationAttributes(instructions);

--- a/front/lib/editor/build_skill_instructions_extensions_server.ts
+++ b/front/lib/editor/build_skill_instructions_extensions_server.ts
@@ -14,6 +14,7 @@ import {
   RawMarkdownBlock,
   rawMarkdownBlockParsers,
 } from "@app/components/editor/extensions/skill_builder/RawMarkdownBlock";
+import { ToolNode } from "@app/components/editor/extensions/skill_builder/ToolNode";
 import { LinkExtension } from "@app/components/editor/input_bar/LinkExtension";
 import type { Extensions } from "@tiptap/core";
 import { Markdown } from "@tiptap/markdown";
@@ -51,6 +52,7 @@ export function buildSkillInstructionsExtensionsForServer(): Extensions {
     }),
     BlockIdExtension,
     KnowledgeNode.configure({ readOnly: true }),
+    ToolNode,
     InstructionSuggestionExtension.configure({ showBlockHighlight: false }),
     RawMarkdownBlock,
     ...rawMarkdownBlockParsers,

--- a/front/lib/reinforcement/analyze_conversation.test.ts
+++ b/front/lib/reinforcement/analyze_conversation.test.ts
@@ -70,6 +70,19 @@ describe("buildSkillAnalysisPrompt", () => {
     expect(userMessage).toContain("Always verify data before responding.");
   });
 
+  it("strips tool icon attributes from instructionsHtml in the user message", () => {
+    const skill = makeSkill({
+      instructionsHtml:
+        '<p>Use <tool id="mcp_server_view_1" name="GitHub Search" icon="GithubLogo"></tool>.</p>',
+    });
+    const { userMessage } = buildSkillAnalysisPrompt("User: hello", [skill]);
+
+    expect(userMessage).toContain(
+      '<tool id="mcp_server_view_1" name="GitHub Search" />'
+    );
+    expect(userMessage).not.toContain('icon="GithubLogo"');
+  });
+
   it("omits instructions when null", () => {
     const skill = makeSkill({ instructions: null, instructionsHtml: null });
     const { userMessage } = buildSkillAnalysisPrompt("User: hello", [skill]);

--- a/front/lib/reinforcement/format_skill_context.ts
+++ b/front/lib/reinforcement/format_skill_context.ts
@@ -1,3 +1,4 @@
+import { stripToolTagPresentationAttributes } from "@app/lib/tools/format";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import { escapeXml } from "@app/types/shared/utils/string_utils";
 
@@ -17,7 +18,9 @@ export function formatSkillContext(skill: SkillType): string {
     : "";
 
   const instructionsBlock = skill.instructionsHtml
-    ? `<instructions format="html">${skill.instructionsHtml}</instructions>`
+    ? `<instructions format="html">${stripToolTagPresentationAttributes(
+        skill.instructionsHtml
+      )}</instructions>`
     : "";
 
   return `<skill ID="${escapeXml(skill.sId)}" name="${escapeXml(skill.name)}">${toolsBlock}${descBlock}${instructionsBlock}</skill>`;

--- a/front/lib/reinforcement/skill_instructions_html.test.ts
+++ b/front/lib/reinforcement/skill_instructions_html.test.ts
@@ -130,4 +130,22 @@ describe("convertMarkdownToBlockHtml", () => {
     expect(html).toContain('id="n1"');
     expect(html).toContain('title="My Doc"');
   });
+
+  it("recovers standalone <tool /> lines as tool nodes with id, name, and icon", () => {
+    const md = [
+      "Intro",
+      "",
+      '<tool id="mcp_server_view_1" name="GitHub Search" icon="GithubLogo" />',
+      "",
+      "Outro",
+    ].join("\n");
+
+    const html = convertMarkdownToBlockHtml(md);
+
+    expect(html).not.toContain("&lt;tool");
+    expect(html).toContain("<tool");
+    expect(html).toContain('id="mcp_server_view_1"');
+    expect(html).toContain('name="GitHub Search"');
+    expect(html).toContain('icon="GithubLogo"');
+  });
 });

--- a/front/lib/reinforcement/skill_instructions_html.ts
+++ b/front/lib/reinforcement/skill_instructions_html.ts
@@ -4,9 +4,11 @@ import {
 } from "@app/components/editor/extensions/instructions/BlockIdExtension";
 import { INSTRUCTIONS_ROOT_NODE_NAME } from "@app/components/editor/extensions/instructions/InstructionsRootExtension";
 import { KNOWLEDGE_TAG_REGEX } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeConstants";
+import { TOOL_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/ToolNode";
 import { buildSkillInstructionsExtensionsForServer } from "@app/lib/editor/build_skill_instructions_extensions_server";
 import { preprocessMarkdownForEditor } from "@app/lib/editor/skill_instructions_preprocessing";
 import { generateShortBlockId } from "@app/lib/generate_short_block_id";
+import { parseToolTag } from "@app/lib/tools/format";
 import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
 import type { JSONContent } from "@tiptap/core";
 import { MarkdownManager } from "@tiptap/markdown";
@@ -82,26 +84,26 @@ function stripPresentationAttributes(html: string): string {
   // the round-trip mechanism for recovering the language on generateJSON
   $("[class]").not("code").removeAttr("class");
   $("[style]").removeAttr("style");
-  // Must maintain id on <knowledge> elements for knowledgeNode parsing
-  $("[id]").not("knowledge").removeAttr("id");
+  // Must maintain id on custom inline elements for their parseHTML rules.
+  $("[id]").not("knowledge, tool").removeAttr("id");
   return $.html();
 }
 
 /**
  * TipTap's server-side parseHTMLToken has no DOM, so it converts block-level
- * HTML tokens (e.g. a standalone <knowledge .../> on its own line) to plain-
+ * HTML tokens (e.g. standalone <knowledge .../> or <tool .../> lines) to plain-
  * text paragraphs instead of calling generateJSON + parseHTML rules. Walk the
- * parsed JSON tree and restore any such nodes back to proper knowledgeNode
+ * parsed JSON tree and restore any such nodes back to proper inline-node
  * JSONContent before rendering to HTML.
  */
-function recoverKnowledgeNodes(node: JSONContent): JSONContent {
+function recoverCustomInlineNodes(node: JSONContent): JSONContent {
   if (node.type === "paragraph" && node.content?.length === 1) {
     const child = node.content[0];
     if (child.type === "text") {
       const text = (child.text ?? "").trim();
-      const match = KNOWLEDGE_TAG_REGEX.exec(text);
-      if (match) {
-        const attrs = match[1];
+      const knowledgeMatch = KNOWLEDGE_TAG_REGEX.exec(text);
+      if (knowledgeMatch) {
+        const attrs = knowledgeMatch[1];
         const id = /id="([^"]+)"/.exec(attrs)?.[1];
         const title = /title="([^"]+)"/.exec(attrs)?.[1];
         if (id && title) {
@@ -126,10 +128,27 @@ function recoverKnowledgeNodes(node: JSONContent): JSONContent {
           };
         }
       }
+
+      const tool = parseToolTag(text);
+      if (tool) {
+        return {
+          ...node,
+          content: [
+            {
+              type: TOOL_NODE_TYPE,
+              attrs: {
+                mcpServerViewId: tool.id,
+                toolIcon: tool.icon,
+                toolName: tool.name,
+              },
+            },
+          ],
+        };
+      }
     }
   }
   if (node.content) {
-    return { ...node, content: node.content.map(recoverKnowledgeNodes) };
+    return { ...node, content: node.content.map(recoverCustomInlineNodes) };
   }
   return node;
 }
@@ -151,7 +170,7 @@ export function convertMarkdownToBlockHtml(markdown: string): string {
     content: [
       {
         type: INSTRUCTIONS_ROOT_NODE_NAME,
-        content: rawContent.map(recoverKnowledgeNodes),
+        content: rawContent.map(recoverCustomInlineNodes),
       },
     ],
   };

--- a/front/lib/reinforcement/skill_instructions_html.ts
+++ b/front/lib/reinforcement/skill_instructions_html.ts
@@ -158,7 +158,9 @@ function recoverCustomInlineNodes(node: JSONContent): JSONContent {
  * Uses the same extension schema as the browser editor, then strips CSS class attrs.
  */
 export function convertMarkdownToBlockHtml(markdown: string): string {
-  const preprocessed = preprocessMarkdownForEditor(markdown);
+  const preprocessed = preprocessMarkdownForEditor(markdown, {
+    enableSkillReferences: true,
+  });
   const parsedDoc = preprocessed.trim()
     ? MARKDOWN_MANAGER.parse(preprocessed)
     : null;


### PR DESCRIPTION
## Description

Stacked on https://github.com/dust-tt/dust/pull/26481. Splits the model-facing safety layer out of https://github.com/dust-tt/dust/pull/26462.

Removes presentation-only tool reference metadata before skill instructions are rendered into model prompts. `<tool id="..." name="..." icon="..." />` becomes `<tool id="..." name="..." />`, including chip HTML stored inside skill instruction HTML.

## Risks

Blast radius: model-facing rendering of enabled skill instructions and reinforcement skill context.
Risk: standard

## Deploy Plan

- Deploy front.

## Tests

- [x] `NODE_ENV=test npm test -- components/editor/extensions/skill_builder/ToolNode.test.ts lib/editor/skill_instructions_preprocessing.test.ts lib/reinforcement/skill_instructions_html.test.ts lib/reinforcement/analyze_conversation.test.ts lib/api/assistant/skills_rendering.test.ts`