### PR TITLE
Fix Hono shutdown behavior on dev machines

### DIFF
--- a/front-api/esbuild.dev.ts
+++ b/front-api/esbuild.dev.ts
@@ -265,7 +265,20 @@ async function watchAndServe() {
 
   const ctx = await esbuild.context(getDevBuildOptions(WATCH_TARGET));
 
+  let shuttingDown = false;
   const shutdown = async () => {
+    // Repeated SIGINT (mashing Ctrl+C) would otherwise re-enter and stack a new
+    // close listener on the proxy server each time, eventually tripping Node's
+    // MaxListenersExceededWarning.
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+
+    // Backstop: if anything below wedges, never leave the dev process hanging
+    // on Ctrl+C. unref so this timer alone can't keep the loop alive.
+    setTimeout(() => process.exit(0), SHUTDOWN_GRACE_MS).unref();
+
     const running = child;
     child = null;
     upstreamPort = null;
@@ -274,6 +287,10 @@ async function watchAndServe() {
       await waitForExit(running, SHUTDOWN_GRACE_MS);
     }
     if (proxyServer) {
+      // close() alone waits for existing connections to drain, but SSE streams
+      // and keep-alive sockets never close on their own — force them shut so
+      // the callback actually fires.
+      proxyServer.closeAllConnections();
       await new Promise<void>((resolve) => proxyServer?.close(() => resolve()));
       proxyServer = null;
     }


### PR DESCRIPTION
## Description

  Root cause: shutdown() awaited proxyServer.close(), whose callback only fires after all open connections drain. front-api's SSE streams and browser keep-alive sockets never close on their own, so the callback never fired and process.exit(0) was never reached. Every extra Ctrl+C re-entered shutdown (no guard) and stacked another close listener on the same server — hence the MaxListenersExceededWarning: 11 close listeners after ~11 presses. The [server exited code=1] / keeping previous upstream lines were a crashed child and a
  failed rebuild; they set the scene but weren't what blocked the exit.

  The fix (front-api/esbuild.dev.ts, shutdown):
  1. Re-entrancy guard (shuttingDown) — repeated Ctrl+C is a no-op instead of stacking listeners (kills the warning).
  2. proxyServer.closeAllConnections() before close() — force-shuts SSE/keep-alive sockets so the close callback actually fires.
  3. setTimeout(() => process.exit(0), SHUTDOWN_GRACE_MS).unref() backstop — even if something else wedges, the first Ctrl+C is now decisive within the grace window.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
