### PR TITLE
Allow stripe billing config update

### DIFF
--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -46,6 +46,9 @@ const SwitchContractFormSchema = z.object({
   startingAt: z.string().optional(),
   startImmediately: z.boolean().default(false),
   stripeCustomerId: z.string(),
+  stripeCollectionMethod: z
+    .enum(["charge_automatically", "send_invoice"])
+    .default("charge_automatically"),
   paygEnabled: z.boolean().default(false),
   usageCapCredits: z
     .number()
@@ -125,6 +128,7 @@ export default function SwitchContractDialog({
       startingAt: "",
       startImmediately: false,
       stripeCustomerId: stripeCustomerId ?? "",
+      stripeCollectionMethod: "charge_automatically",
       paygEnabled: false,
       usageCapCredits: undefined,
     },
@@ -258,9 +262,11 @@ export default function SwitchContractDialog({
         paygEnabled: values.paygEnabled,
       };
       // For free-tier switches, the operator can omit the Stripe customer —
-      // the resulting Metronome contract has no Stripe billing link.
+      // the resulting Metronome contract has no Stripe billing link. The
+      // collection method only matters when a Stripe customer is wired in.
       if (trimmedStripe) {
         cleaned.stripeCustomerId = trimmedStripe;
+        cleaned.stripeCollectionMethod = values.stripeCollectionMethod;
       }
       if (values.usageCapCredits !== undefined) {
         cleaned.usageCapCredits = values.usageCapCredits;
@@ -352,6 +358,24 @@ export default function SwitchContractDialog({
                     Failed to resolve currency from Stripe customer:{" "}
                     {currencyError.message}
                   </div>
+                )}
+                {trimmedStripeCustomerId && (
+                  <SelectField
+                    control={form.control}
+                    name="stripeCollectionMethod"
+                    title="Stripe Collection Method"
+                    mountPortalContainer={portalContainer}
+                    options={[
+                      {
+                        value: "charge_automatically",
+                        display: "Charge automatically (card on file)",
+                      },
+                      {
+                        value: "send_invoice",
+                        display: "Send invoice (manual payment)",
+                      },
+                    ]}
+                  />
                 )}
                 {isPackagesLoading && (
                   <div className="flex items-center gap-2 text-sm text-muted-foreground">

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -51,6 +51,12 @@ export const SwitchContractBodySchema = z.object({
   // Optional: required for paid tiers (pro/business/enterprise), omitted
   // for free-tier switches where Metronome contracts have no Stripe link.
   stripeCustomerId: z.string().min(1).optional(),
+  // How Metronome collects Stripe invoices for this customer. Only takes
+  // effect when a Stripe customer is wired in. `charge_automatically` charges
+  // the card on file; `send_invoice` emails the invoice for manual payment.
+  stripeCollectionMethod: z
+    .enum(["charge_automatically", "send_invoice"])
+    .default("charge_automatically"),
   paygEnabled: z.boolean().default(false),
   // AWU credits — written directly to `credit_usage_configuration.usageCapCredits`.
   usageCapCredits: z
@@ -185,6 +191,7 @@ export async function switchContract({
   const customerResult = await ensureMetronomeCustomerForWorkspace({
     workspace: renderLightWorkspaceType({ workspace: owner }),
     stripeCustomerId: body.stripeCustomerId,
+    stripeCollectionMethod: body.stripeCollectionMethod,
   });
   if (customerResult.isErr()) {
     return new Err(

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -26,12 +26,14 @@ import type {
   MetronomeEvent,
   MetronomePackageTier,
   MetronomeSeatBalance,
+  MetronomeStripeCollectionMethod,
   MetronomeUsageListResponse,
   MetronomeUsageWithGroupsResponse,
 } from "./types";
 import {
   classifyMetronomePackageByName,
   classifyMetronomePackageCurrencyByName,
+  DEFAULT_METRONOME_STRIPE_COLLECTION_METHOD,
   isMetronomeSeatBalance,
 } from "./types";
 
@@ -167,10 +169,12 @@ export async function createMetronomeCustomer({
   workspaceId,
   workspaceName,
   stripeCustomerId,
+  stripeCollectionMethod = DEFAULT_METRONOME_STRIPE_COLLECTION_METHOD,
 }: {
   workspaceId: string;
   workspaceName: string;
   stripeCustomerId?: string;
+  stripeCollectionMethod?: MetronomeStripeCollectionMethod;
 }): Promise<Result<{ metronomeCustomerId: string }, Error>> {
   try {
     const response = await getMetronomeClient().v1.customers.create({
@@ -184,7 +188,7 @@ export async function createMetronomeCustomer({
                 delivery_method: "direct_to_billing_provider",
                 configuration: {
                   stripe_customer_id: stripeCustomerId,
-                  stripe_collection_method: "charge_automatically",
+                  stripe_collection_method: stripeCollectionMethod,
                 },
               },
             ],
@@ -278,17 +282,20 @@ export async function getMetronomeCustomerStripeCustomerId(
  * configuration pointing to the given `stripeCustomerId`.
  *
  * - No active Stripe config: adds one.
- * - Active Stripe config already pointing to `stripeCustomerId`: no-op.
- * - Active Stripe config pointing to a different `stripeCustomerId`: archives
- *   the stale config(s) and adds a new one (defensive: should be rare, but
- *   covers cases like a recreated Stripe customer).
+ * - Active Stripe config already pointing to `stripeCustomerId` with the same
+ *   collection method: no-op.
+ * - Active Stripe config pointing to a different `stripeCustomerId` or using a
+ *   different collection method: archives the stale config(s) and adds a new
+ *   one (covers a recreated Stripe customer or a collection-method change).
  */
 export async function ensureMetronomeStripeBillingConfig({
   metronomeCustomerId,
   stripeCustomerId,
+  stripeCollectionMethod = DEFAULT_METRONOME_STRIPE_COLLECTION_METHOD,
 }: {
   metronomeCustomerId: string;
   stripeCustomerId: string;
+  stripeCollectionMethod?: MetronomeStripeCollectionMethod;
 }): Promise<Result<void, Error>> {
   try {
     const existing =
@@ -301,7 +308,9 @@ export async function ensureMetronomeStripeBillingConfig({
     );
 
     const alreadyCorrect = activeStripeConfigs.some(
-      (c) => c.configuration?.stripe_customer_id === stripeCustomerId
+      (c) =>
+        c.configuration?.stripe_customer_id === stripeCustomerId &&
+        c.configuration?.stripe_collection_method === stripeCollectionMethod
     );
     if (alreadyCorrect) {
       return new Ok(undefined);
@@ -334,14 +343,14 @@ export async function ensureMetronomeStripeBillingConfig({
           delivery_method: "direct_to_billing_provider",
           configuration: {
             stripe_customer_id: stripeCustomerId,
-            stripe_collection_method: "charge_automatically",
+            stripe_collection_method: stripeCollectionMethod,
           },
         },
       ],
     });
 
     logger.info(
-      { metronomeCustomerId, stripeCustomerId },
+      { metronomeCustomerId, stripeCustomerId, stripeCollectionMethod },
       "[Metronome] Stripe billing config added to customer"
     );
     return new Ok(undefined);

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -30,7 +30,10 @@ import {
   hasContractSeatSubscription,
   syncSeatCount,
 } from "@app/lib/metronome/seats";
-import { LEGACY_ENTERPRISE_PACKAGE_ALIAS } from "@app/lib/metronome/types";
+import {
+  LEGACY_ENTERPRISE_PACKAGE_ALIAS,
+  type MetronomeStripeCollectionMethod,
+} from "@app/lib/metronome/types";
 import {
   resolveCurrencyFromStripe,
   resolvePackageAliasForCurrency,
@@ -73,9 +76,11 @@ import { metronomeAmount } from "./amounts";
 export async function ensureMetronomeCustomerForWorkspace({
   workspace,
   stripeCustomerId,
+  stripeCollectionMethod,
 }: {
   workspace: LightWorkspaceType;
   stripeCustomerId?: string;
+  stripeCollectionMethod?: MetronomeStripeCollectionMethod;
 }): Promise<Result<{ metronomeCustomerId: string }, Error>> {
   let metronomeCustomerId: string | null = workspace.metronomeCustomerId;
 
@@ -91,6 +96,7 @@ export async function ensureMetronomeCustomerForWorkspace({
       workspaceId: workspace.sId,
       workspaceName: workspace.name,
       stripeCustomerId,
+      stripeCollectionMethod,
     });
     if (createResult.isErr()) {
       return new Err(createResult.error);
@@ -117,6 +123,7 @@ export async function ensureMetronomeCustomerForWorkspace({
     const billingResult = await ensureMetronomeStripeBillingConfig({
       metronomeCustomerId,
       stripeCustomerId,
+      stripeCollectionMethod,
     });
     if (billingResult.isErr()) {
       return new Err(billingResult.error);

--- a/front/lib/metronome/types.ts
+++ b/front/lib/metronome/types.ts
@@ -32,6 +32,17 @@ export const FREE_PACKAGE_ALIAS = "free-plan";
 
 export type MetronomePackageTier = "free" | "pro" | "business" | "enterprise";
 
+// Stripe collection method for a Metronome customer's Stripe billing
+// configuration. `charge_automatically` charges the card on file when an
+// invoice is finalized; `send_invoice` emails the invoice for the customer to
+// pay manually (used for enterprise N30-style billing).
+export type MetronomeStripeCollectionMethod =
+  | "charge_automatically"
+  | "send_invoice";
+
+export const DEFAULT_METRONOME_STRIPE_COLLECTION_METHOD: MetronomeStripeCollectionMethod =
+  "charge_automatically";
+
 export const PAYG_ELIGIBLE_TIERS: readonly MetronomePackageTier[] = [
   "enterprise",
   "business",


### PR DESCRIPTION
## Description

Adds an operator-selectable **Stripe collection method** to the Switch Contract poke flow, threaded down to the Metronome customer's Stripe billing configuration.

Until now the collection method was hard-coded to `charge_automatically` in both `createMetronomeCustomer` and `ensureMetronomeStripeBillingConfig`. This PR makes it configurable (`charge_automatically` | `send_invoice`) so enterprise customers billed by invoice (manual payment / N30) can be set up correctly when switching contracts.

Changes:
- New `MetronomeStripeCollectionMethod` type + `DEFAULT_METRONOME_STRIPE_COLLECTION_METHOD` const (`lib/metronome/types.ts`).
- `createMetronomeCustomer` and `ensureMetronomeStripeBillingConfig` accept an optional `stripeCollectionMethod` (default `charge_automatically`). The idempotency check in `ensureMetronomeStripeBillingConfig` now also compares the collection method, so changing it archives the stale config and re-sets a fresh one.
- `ensureMetronomeCustomerForWorkspace` threads the value through to both calls (`lib/metronome/contracts.ts`).
- `switchContract` accepts `stripeCollectionMethod` in its zod schema (default `charge_automatically`) and forwards it.
- `SwitchContractDialog` exposes a "Stripe Collection Method" select, shown only when a Stripe customer is set, forwarded in the POST body.

> Stacked PR — base of the chain (#26486 → #26487 build on top).

## Tests

- Existing `switch_contract` functional tests still pass (19).
- `npx tsgo --noEmit` and biome clean on the changed files.
- The collection method only takes effect when a Stripe customer is wired in; the default preserves current behavior.

## Risk

Low. The new field defaults to `charge_automatically` (today's behavior) and is only applied when a Stripe customer is present. The only behavioral change to existing paths is that `ensureMetronomeStripeBillingConfig` now re-sets the billing config when the collection method differs — previously it no-op'd on a `stripe_customer_id` match. Safe to roll back (revert the PR).

## Deploy Plan

Standard `front` deploy. No migration. Merge before #26486.
