### PR TITLE
Create initial commit

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/switch_contract.ts
+++ b/front-api/routes/poke/workspaces/[wId]/switch_contract.ts
@@ -79,7 +79,10 @@ app.post(
       body.usageCapCredits !== undefined
         ? ` Usage cap: ${body.usageCapCredits} credits.`
         : "";
-    const paygStatus = `${paygSummary}${capSummary}`;
+    const initialCreditsSummary = body.initialCredits
+      ? ` Initial credits: ${body.initialCredits.amountCredits} credits invoiced ${body.initialCredits.invoiceAmount}.`
+      : "";
+    const paygStatus = `${paygSummary}${capSummary}${initialCreditsSummary}`;
     await pluginRun.recordResult({
       display: "text",
       value:

--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -55,6 +55,19 @@ const SwitchContractFormSchema = z.object({
     .int("Usage cap must be an integer number of credits")
     .min(1, "Usage cap must be at least 1 credit")
     .optional(),
+  // One-off initial credits (contract-level prepaid commit). Toggled on via
+  // `showInitialCredits`; both fields are then required together and assembled
+  // into `initialCredits` on submit.
+  showInitialCredits: z.boolean().default(false),
+  initialCreditsAmount: z
+    .number()
+    .int("Initial credits must be an integer number of credits")
+    .min(1, "Initial credits must be at least 1 credit")
+    .optional(),
+  initialCreditsInvoiceAmount: z
+    .number()
+    .min(0, "Invoice amount must be zero or more")
+    .optional(),
 });
 type SwitchContractFormValues = z.infer<typeof SwitchContractFormSchema>;
 
@@ -131,6 +144,9 @@ export default function SwitchContractDialog({
       stripeCollectionMethod: "charge_automatically",
       paygEnabled: false,
       usageCapCredits: undefined,
+      showInitialCredits: false,
+      initialCreditsAmount: undefined,
+      initialCreditsInvoiceAmount: undefined,
     },
   });
 
@@ -253,6 +269,8 @@ export default function SwitchContractDialog({
   const paygEligible =
     selectedTier !== null && isPaygEligibleTier(selectedTier);
 
+  const showInitialCredits = form.watch("showInitialCredits");
+
   const onSubmit = useCallback(
     (values: SwitchContractFormValues) => {
       const trimmedStripe = values.stripeCustomerId.trim();
@@ -270,6 +288,28 @@ export default function SwitchContractDialog({
       }
       if (values.usageCapCredits !== undefined) {
         cleaned.usageCapCredits = values.usageCapCredits;
+      }
+      // Initial credits: only sent when the operator toggled the section on.
+      // Both the credit amount and the invoice amount are then required, and a
+      // Stripe customer must be present to invoice against.
+      if (values.showInitialCredits) {
+        if (
+          values.initialCreditsAmount === undefined ||
+          values.initialCreditsInvoiceAmount === undefined
+        ) {
+          setError(
+            "Initial credits require both a credit amount and an invoice amount."
+          );
+          return;
+        }
+        if (!trimmedStripe) {
+          setError("Initial credits require a Stripe customer to invoice.");
+          return;
+        }
+        cleaned.initialCredits = {
+          amountCredits: values.initialCreditsAmount,
+          invoiceAmount: values.initialCreditsInvoiceAmount,
+        };
       }
       if (
         selectedTier === "enterprise" &&
@@ -327,19 +367,20 @@ export default function SwitchContractDialog({
             Business packages swap at the current hour.
           </DialogDescription>
         </DialogHeader>
-        <DialogContainer>
-          {error && <div className="text-warning">{error}</div>}
-          {isSubmitting && (
+        {isSubmitting ? (
+          <DialogContainer>
             <div className="flex justify-center">
               <Spinner size="lg" />
             </div>
-          )}
-          {!isSubmitting && (
-            <PokeForm {...form}>
-              <form
-                onSubmit={form.handleSubmit(onSubmit)}
-                className="space-y-4"
-              >
+          </DialogContainer>
+        ) : (
+          <PokeForm {...form}>
+            <form
+              onSubmit={form.handleSubmit(onSubmit)}
+              className="flex flex-grow flex-col overflow-hidden"
+            >
+              <DialogContainer className="space-y-4">
+                {error && <div className="text-warning">{error}</div>}
                 <InputField
                   control={form.control}
                   name="stripeCustomerId"
@@ -468,21 +509,57 @@ export default function SwitchContractDialog({
                     />
                   </div>
                 )}
-                <DialogFooter>
-                  <Button
-                    type="submit"
-                    variant="warning"
-                    label="Switch"
-                    disabled={
-                      !selectedTier ||
-                      (selectedTier !== "free" && !resolvedCurrency)
-                    }
-                  />
-                </DialogFooter>
-              </form>
-            </PokeForm>
-          )}
-        </DialogContainer>
+                {trimmedStripeCustomerId && resolvedCurrency && (
+                  <div className="space-y-4 border-t pt-4">
+                    <div className="flex items-center gap-2">
+                      <SliderToggle
+                        selected={showInitialCredits}
+                        onClick={() =>
+                          form.setValue(
+                            "showInitialCredits",
+                            !showInitialCredits
+                          )
+                        }
+                      />
+                      <Label className="text-sm">
+                        Initial credits (one-off prepaid commit)
+                      </Label>
+                    </div>
+                    {showInitialCredits && (
+                      <>
+                        <InputField
+                          control={form.control}
+                          name="initialCreditsAmount"
+                          title="Initial Credits (AWU credits)"
+                          type="number"
+                          placeholder="e.g., 100000"
+                        />
+                        <InputField
+                          control={form.control}
+                          name="initialCreditsInvoiceAmount"
+                          title={`Amount to Invoice (${resolvedCurrency.toUpperCase()})`}
+                          type="number"
+                          placeholder="e.g., 5000 — amount billed to the customer"
+                        />
+                      </>
+                    )}
+                  </div>
+                )}
+              </DialogContainer>
+              <DialogFooter>
+                <Button
+                  type="submit"
+                  variant="warning"
+                  label="Switch"
+                  disabled={
+                    !selectedTier ||
+                    (selectedTier !== "free" && !resolvedCurrency)
+                  }
+                />
+              </DialogFooter>
+            </form>
+          </PokeForm>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/front/lib/api/poke/plugins/workspaces/grant_awu_credits.ts
+++ b/front/lib/api/poke/plugins/workspaces/grant_awu_credits.ts
@@ -164,7 +164,7 @@ export const grantAwuCreditsPlugin = createPlugin({
         endingBefore: expirationDate.toISOString(),
         name: `Credits granted from Poke: ${amountCredits.toLocaleString()} credits`,
         idempotencyKey,
-        priority: 1,
+        priority: AWU_PRIORITY_PURCHASED_COMMIT,
         applicableProductTags: ["usage"],
       });
 

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -5,11 +5,19 @@ import {
 import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
+import { metronomeAmount } from "@app/lib/metronome/amounts";
 import {
+  addPrepaidCommitToContract,
   ceilToHourISO,
   floorToHourISO,
   listMetronomePackages,
 } from "@app/lib/metronome/client";
+import {
+  AWU_PRIORITY_PURCHASED_COMMIT,
+  CURRENCY_TO_CREDIT_TYPE_ID,
+  getCreditTypeAwuId,
+  getProductPrepaidCommitId,
+} from "@app/lib/metronome/constants";
 import {
   ensureMetronomeCustomerForWorkspace,
   provisionMetronomeContract,
@@ -63,6 +71,19 @@ export const SwitchContractBodySchema = z.object({
     .number()
     .int("Usage cap must be an integer number of credits")
     .min(1, "Usage cap must be at least 1 credit")
+    .optional(),
+  // Optional one-off initial AWU credits granted alongside the switch as a
+  // contract-level prepaid commit (priority 300, same as purchased commits).
+  // Requires a Stripe customer so the commit can be invoiced. `invoiceAmount`
+  // is in the customer's billing currency major units (e.g. dollars / euros).
+  initialCredits: z
+    .object({
+      amountCredits: z
+        .number()
+        .int("Initial credits must be an integer number of credits")
+        .min(1, "Initial credits must be at least 1 credit"),
+      invoiceAmount: z.number().min(0, "Invoice amount must be zero or more"),
+    })
     .optional(),
 });
 
@@ -258,6 +279,18 @@ export async function switchContract({
     );
   }
 
+  // Initial credits are invoiced through the contract's Stripe billing config,
+  // so they require a Stripe customer (and therefore a resolved currency).
+  if (body.initialCredits && !resolvedCurrency) {
+    return new Err(
+      new SwitchContractError(
+        "invalid_request",
+        "Initial credits require a Stripe customer to invoice — provide a " +
+          "stripeCustomerId."
+      )
+    );
+  }
+
   // Resolve when the swap happens.
   //  - startingAt provided: schedule at the requested moment, ceiled to the
   //    next hour boundary. Must be ≥1h in the future.
@@ -328,6 +361,50 @@ export async function switchContract({
       ? floorToHourISO(startingAtDate)
       : ceilToHourISO(startingAtDate)
   );
+
+  // Optional one-off initial credits: a contract-level prepaid AWU commit
+  // starting with the contract and lasting one year. `invoiceAmount` is in the
+  // customer's currency major units; convert to Metronome fiat units (cents
+  // for USD, whole units for EUR) for the invoice unit price.
+  if (body.initialCredits && resolvedCurrency) {
+    const oneYearAfterStart = new Date(alignedStart);
+    oneYearAfterStart.setUTCFullYear(oneYearAfterStart.getUTCFullYear() + 1);
+
+    const invoiceAmountCents = Math.round(
+      body.initialCredits.invoiceAmount * 100
+    );
+    const invoiceUnitPrice = metronomeAmount(
+      invoiceAmountCents,
+      resolvedCurrency
+    );
+
+    const commitResult = await addPrepaidCommitToContract({
+      metronomeCustomerId,
+      metronomeContractId,
+      productId: getProductPrepaidCommitId(),
+      accessAmount: body.initialCredits.amountCredits,
+      accessCreditTypeId: getCreditTypeAwuId(),
+      accessStartingAt: alignedStart,
+      accessEndingBefore: oneYearAfterStart,
+      invoiceUnitPrice,
+      invoiceQuantity: 1,
+      invoiceCreditTypeId: CURRENCY_TO_CREDIT_TYPE_ID[resolvedCurrency],
+      invoiceTimestamp: alignedStart,
+      priority: AWU_PRIORITY_PURCHASED_COMMIT,
+      name: `Initial credits: ${body.initialCredits.amountCredits.toLocaleString()} credits`,
+      uniquenessKey: `initial-credits-${owner.sId}-${alignedStart.getTime()}-${body.initialCredits.amountCredits}`,
+    });
+    if (commitResult.isErr()) {
+      return new Err(
+        new SwitchContractError(
+          "provision_inconsistent",
+          `Provisioned Metronome contract ${metronomeContractId} but failed to ` +
+            `add the initial credits commit: ${commitResult.error.message}. ` +
+            "Manual cleanup may be required."
+        )
+      );
+    }
+  }
 
   // Persist the future-state subscription in `created_backend_only`; the
   // `contract.start` webhook flips it to `active` (and ends the current one).

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -1557,6 +1557,123 @@ export async function addPaymentGatedCommitToContract({
 }
 
 /**
+ * Add a plain (non-payment-gated) PREPAID commit to an existing contract via
+ * `v2.contracts.edit`. Unlike `addPaymentGatedCommitToContract`, the credits
+ * are available immediately (no Stripe payment gate); Metronome raises the
+ * invoice through the contract's billing configuration on its normal cadence,
+ * and collection follows the customer's Stripe collection method.
+ *
+ * `invoiceUnitPrice` is the per-unit fiat price in the invoice credit type's
+ * units — cents for USD, whole units for other fiat currencies (matches
+ * Metronome's fiat unit convention; see `metronomeAmount`). Passing
+ * `invoiceQuantity: 1` makes `invoiceUnitPrice` the full invoice total.
+ */
+export async function addPrepaidCommitToContract({
+  metronomeCustomerId,
+  metronomeContractId,
+  productId,
+  accessAmount,
+  accessCreditTypeId,
+  accessStartingAt,
+  accessEndingBefore,
+  invoiceUnitPrice,
+  invoiceQuantity,
+  invoiceCreditTypeId,
+  invoiceTimestamp,
+  priority,
+  name,
+  uniquenessKey,
+}: {
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+  productId: string;
+  accessAmount: number;
+  accessCreditTypeId: string;
+  accessStartingAt: Date;
+  accessEndingBefore: Date;
+  invoiceUnitPrice: number;
+  invoiceQuantity: number;
+  invoiceCreditTypeId: string;
+  invoiceTimestamp: Date;
+  priority: number;
+  name: string;
+  uniquenessKey: string;
+}): Promise<Result<{ editId: string }, Error>> {
+  try {
+    const response = await getMetronomeClient().v2.contracts.edit({
+      customer_id: metronomeCustomerId,
+      contract_id: metronomeContractId,
+      uniqueness_key: uniquenessKey,
+      add_commits: [
+        {
+          product_id: productId,
+          type: "PREPAID",
+          name,
+          priority,
+          applicable_product_tags: ["usage"],
+          access_schedule: {
+            credit_type_id: accessCreditTypeId,
+            schedule_items: [
+              {
+                amount: accessAmount,
+                starting_at: floorToHourISO(accessStartingAt),
+                ending_before: floorToHourISO(accessEndingBefore),
+              },
+            ],
+          },
+          invoice_schedule: {
+            credit_type_id: invoiceCreditTypeId,
+            schedule_items: [
+              {
+                unit_price: invoiceUnitPrice,
+                quantity: invoiceQuantity,
+                timestamp: floorToHourISO(invoiceTimestamp),
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    logger.info(
+      {
+        metronomeCustomerId,
+        metronomeContractId,
+        editId: response.data.id,
+        accessAmount,
+        invoiceUnitPrice,
+        invoiceQuantity,
+      },
+      "[Metronome] Prepaid commit added to contract"
+    );
+
+    return new Ok({ editId: response.data.id });
+  } catch (err) {
+    if (err instanceof ConflictError) {
+      logger.info(
+        { metronomeCustomerId, metronomeContractId, uniquenessKey },
+        "[Metronome] Prepaid commit edit already exists (idempotent)"
+      );
+      return new Ok({ editId: "" });
+    }
+
+    const error = normalizeError(err);
+    logger.error(
+      {
+        error,
+        metronomeCustomerId,
+        metronomeContractId,
+        accessAmount,
+        invoiceUnitPrice,
+        invoiceQuantity,
+      },
+      "[Metronome] Failed to add prepaid commit to contract"
+    );
+    return new Err(error);
+  }
+}
+
+/**
  * Find a customer-level commit by its uniqueness_key.
  * Used to recover the id after a 409 conflict on creation.
  * Scoped via covering_date so we don't paginate through expired commits.

--- a/front/pages/api/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front/pages/api/poke/workspaces/[wId]/switch_contract.test.ts
@@ -1,5 +1,12 @@
 import { Authenticator } from "@app/lib/auth";
-import { listMetronomePackages } from "@app/lib/metronome/client";
+import {
+  addPrepaidCommitToContract,
+  listMetronomePackages,
+} from "@app/lib/metronome/client";
+import {
+  AWU_PRIORITY_PURCHASED_COMMIT,
+  getProductPrepaidCommitId,
+} from "@app/lib/metronome/constants";
 import {
   ensureMetronomeCustomerForWorkspace,
   provisionMetronomeContract,
@@ -34,6 +41,7 @@ vi.mock("@app/lib/metronome/client", async () => {
   return {
     ...actual,
     listMetronomePackages: vi.fn(),
+    addPrepaidCommitToContract: vi.fn(),
   };
 });
 
@@ -211,6 +219,9 @@ beforeEach(() => {
     new Ok({ metronomeContractId: NEW_CONTRACT_ID })
   );
   vi.mocked(scheduleSubscriptionCancellation).mockResolvedValue(true);
+  vi.mocked(addPrepaidCommitToContract).mockResolvedValue(
+    new Ok({ editId: "edit_xxx" })
+  );
 });
 
 describe("POST /api/poke/workspaces/[wId]/switch_contract — Enterprise", () => {
@@ -677,5 +688,73 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
       await CreditUsageConfigurationResource.fetchByWorkspaceId(adminAuth);
     expect(config?.paygEnabled).toBe(false);
     expect(config?.usageCapCredits).toBe(100_000);
+  });
+});
+
+describe("POST /api/poke/workspaces/[wId]/switch_contract — initial credits", () => {
+  it("adds a contract-level prepaid commit with the converted invoice amount", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
+
+    // USD: $5000 invoice → 500000 cents → 500000 Metronome units (USD is cents).
+    req.body = businessBody({
+      initialCredits: { amountCredits: 100_000, invoiceAmount: 5000 },
+    });
+    req.query.wId = workspace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(addPrepaidCommitToContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metronomeContractId: NEW_CONTRACT_ID,
+        productId: getProductPrepaidCommitId(),
+        accessAmount: 100_000,
+        invoiceUnitPrice: 500_000,
+        invoiceQuantity: 1,
+        priority: AWU_PRIORITY_PURCHASED_COMMIT,
+      })
+    );
+  });
+
+  it("does not add a commit when initial credits are omitted", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
+
+    req.body = businessBody();
+    req.query.wId = workspace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(addPrepaidCommitToContract).not.toHaveBeenCalled();
+  });
+
+  it("rejects initial credits when no Stripe customer is provided", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
+
+    req.body = businessBody({
+      stripeCustomerId: undefined,
+      initialCredits: { amountCredits: 100_000, invoiceAmount: 5000 },
+    });
+    req.query.wId = workspace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.message).toContain(
+      "Initial credits require a Stripe customer"
+    );
+    expect(addPrepaidCommitToContract).not.toHaveBeenCalled();
   });
 });

--- a/front/pages/api/poke/workspaces/[wId]/switch_contract.ts
+++ b/front/pages/api/poke/workspaces/[wId]/switch_contract.ts
@@ -116,7 +116,10 @@ async function handler(
     body.usageCapCredits !== undefined
       ? ` Usage cap: ${body.usageCapCredits} credits.`
       : "";
-  const paygStatus = `${paygSummary}${capSummary}`;
+  const initialCreditsSummary = body.initialCredits
+    ? ` Initial credits: ${body.initialCredits.amountCredits} credits invoiced ${body.initialCredits.invoiceAmount}.`
+    : "";
+  const paygStatus = `${paygSummary}${capSummary}${initialCreditsSummary}`;
   await pluginRun.recordResult({
     display: "text",
     value:


### PR DESCRIPTION
## Description

Adds an optional **one-off initial AWU credits** grant to the Switch Contract poke flow, materialized as a **contract-level prepaid commit**.

When switching a workspace's contract, an operator can now grant initial credits by specifying the number of AWU credits and the amount to invoice. This creates a prepaid commit on the newly provisioned Metronome contract with a plain invoice schedule (credits available immediately; Metronome invoices through the contract's billing config, collected per the customer's Stripe collection method — see #26485).

Design choices:
- **Plain invoice schedule** (not payment-gated) — credits are available immediately, mirroring the `grant_awu_credits` commit path rather than the self-serve `awu_purchase` payment-gated path.
- **Priority 200** — consumed at the same tier as seat allocations, before purchased top-ups (300). New named constant `AWU_PRIORITY_INITIAL_CREDITS_COMMIT`.
- **1 year duration** from the contract start.
- **Invoice amount in major currency units** (dollars / euros, resolved from the Stripe customer), converted internally to Metronome fiat units.

Changes:
- New `addPrepaidCommitToContract` client helper (`lib/metronome/client.ts`) — mirrors `addPaymentGatedCommitToContract` without the Stripe payment gate.
- `AWU_PRIORITY_INITIAL_CREDITS_COMMIT = 200` (`lib/metronome/constants.ts`).
- `switchContract` accepts an optional `initialCredits: { amountCredits, invoiceAmount }`; after provisioning, adds the commit (AWU credit type, access from `alignedStart` for 1 year, `invoiceUnitPrice = metronomeAmount(round(invoiceAmount*100), currency)`, qty 1, priority 200). Guards that initial credits require a Stripe customer to invoice against.
- Next + Hono handlers updated in sync (result summary line).
- `SwitchContractDialog` gains an "Initial credits" section (credits amount + amount-to-invoice labelled with the resolved currency), shown only with a Stripe customer, with both-or-neither client validation.

> Stacked on #26485.

## Tests

- 3 new functional tests in `switch_contract.test.ts` (22 total, all passing):
  - adds a contract-level prepaid commit with the correctly converted invoice amount (USD $5000 → 500000 Metronome units) and priority 200;
  - does not add a commit when initial credits are omitted;
  - rejects initial credits when no Stripe customer is provided.
- `npx tsgo --noEmit` and biome clean.

## Risk

Low. Purely additive — `initialCredits` is optional, and no commit is created unless the operator supplies it. If adding the commit fails after the contract is provisioned, the operation returns `provision_inconsistent` with manual-cleanup guidance (consistent with the existing switch flow). Safe to roll back.

## Deploy Plan

Standard `front` deploy. No migration. Merge after #26485, before #26487.
