### PR TITLE
Cancel pending subscription

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/cancel_pending_contract.ts
+++ b/front-api/routes/poke/workspaces/[wId]/cancel_pending_contract.ts
@@ -1,0 +1,78 @@
+import type { CancelPendingContractErrorKind } from "@app/lib/api/poke/cancel_pending_contract";
+import {
+  type CancelPendingContractError,
+  cancelPendingContract,
+} from "@app/lib/api/poke/cancel_pending_contract";
+import { pluginManager } from "@app/lib/api/poke/plugin_manager";
+import { PluginRunResource } from "@app/lib/resources/plugin_run_resource";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { pokeApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+
+export interface PokeCancelPendingContractSuccessResponseBody {
+  success: boolean;
+}
+
+function statusForKind(kind: CancelPendingContractErrorKind): {
+  status_code: 400 | 500 | 502;
+  type: "invalid_request_error" | "internal_server_error";
+} {
+  switch (kind) {
+    case "invalid_request":
+      return { status_code: 400, type: "invalid_request_error" };
+    case "restore_failed":
+      return { status_code: 502, type: "internal_server_error" };
+    case "cleanup_inconsistent":
+      return { status_code: 500, type: "internal_server_error" };
+    default:
+      assertNever(kind);
+  }
+}
+
+// Mounted at /api/poke/workspaces/:wId/cancel_pending_contract.
+const app = pokeApp();
+
+app.post(
+  "/",
+  async (ctx): HandlerResult<PokeCancelPendingContractSuccessResponseBody> => {
+    const auth = ctx.get("auth");
+    const owner = auth.getNonNullableWorkspace();
+    const rawBody = await ctx.req.json().catch(() => ({}));
+
+    const plugin = pluginManager.getNonNullablePlugin(
+      "cancel-pending-contract"
+    );
+    const pluginRun = await PluginRunResource.makeNew(
+      plugin,
+      rawBody,
+      auth.getNonNullableUser(),
+      owner,
+      { resourceId: owner.sId, resourceType: "workspaces" }
+    );
+
+    const result = await cancelPendingContract({ auth });
+    if (result.isErr()) {
+      const err: CancelPendingContractError = result.error;
+      await pluginRun.recordError(err.message);
+      const { status_code, type } = statusForKind(err.kind);
+      return apiError(ctx, {
+        status_code,
+        api_error: { type, message: err.message },
+      });
+    }
+
+    const { cancelledMetronomeContractId } = result.value;
+    await pluginRun.recordResult({
+      display: "text",
+      value:
+        `Cancelled pending contract switch for ${owner.name}. ` +
+        (cancelledMetronomeContractId
+          ? `Archived Metronome contract ${cancelledMetronomeContractId}. `
+          : "") +
+        "The current subscription/contract was restored.",
+    });
+    return ctx.json({ success: true });
+  }
+);
+
+export default app;

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -21,7 +21,7 @@ import {
   isProPlanPrefix,
 } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
-import { usePokePlans } from "@app/lib/swr/poke";
+import { usePokeCancelPendingContract, usePokePlans } from "@app/lib/swr/poke";
 import type { PlanType, SubscriptionType } from "@app/types/plan";
 import { isSubscriptionMetronomeBilled } from "@app/types/plan";
 import type { ProgrammaticUsageConfigurationType } from "@app/types/programmatic_usage";
@@ -270,6 +270,42 @@ function SubscriptionDetailsTable({
   );
 }
 
+interface CancelPendingSubscriptionButtonProps {
+  owner: WorkspaceType;
+}
+
+function CancelPendingSubscriptionButton({
+  owner,
+}: CancelPendingSubscriptionButtonProps) {
+  const router = useAppRouter();
+  const cancelPendingContract = usePokeCancelPendingContract();
+
+  const { submit: onCancel, isSubmitting } = useSubmitFunction(async () => {
+    if (
+      !window.confirm(
+        `Cancel the pending subscription for ${owner.name} (${owner.sId})? ` +
+          "This archives the pending Metronome contract, deletes the pending " +
+          "subscription, and restores the current contract/subscription."
+      )
+    ) {
+      return;
+    }
+    const ok = await cancelPendingContract(owner);
+    if (ok) {
+      router.reload();
+    }
+  });
+
+  return (
+    <Button
+      variant="warning"
+      label="🗑️ Cancel pending"
+      onClick={onCancel}
+      disabled={isSubmitting}
+    />
+  );
+}
+
 interface ActiveSubscriptionTableProps {
   owner: WorkspaceType;
   metronomeCustomerId: string | null;
@@ -350,9 +386,12 @@ export function ActiveSubscriptionTable({
       {pendingSubscription && (
         <div className="flex justify-between gap-3">
           <div className="flex flex-grow flex-col rounded-lg border border-blue-200 bg-blue-50 p-4 pb-2 dark:border-blue-200-night dark:bg-blue-50-night">
-            <div className="flex items-center gap-2 pb-4">
-              <h2 className="text-md font-bold">Pending Subscription</h2>
-              <Chip color="blue" label="Pending activation" size="xs" />
+            <div className="flex items-center justify-between gap-2 pb-4">
+              <div className="flex items-center gap-2">
+                <h2 className="text-md font-bold">Pending Subscription</h2>
+                <Chip color="blue" label="Pending activation" size="xs" />
+              </div>
+              <CancelPendingSubscriptionButton owner={owner} />
             </div>
             <p className="pb-2 text-xs text-muted-foreground">
               Provisioned in DB. The `contract.start` Metronome webhook will

--- a/front/lib/api/poke/cancel_pending_contract.ts
+++ b/front/lib/api/poke/cancel_pending_contract.ts
@@ -1,0 +1,157 @@
+import type { Authenticator } from "@app/lib/auth";
+import {
+  archiveMetronomeContract,
+  reactivateMetronomeContract,
+} from "@app/lib/metronome/client";
+import { clearScheduledSubscriptionCancellation } from "@app/lib/plans/stripe";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export type CancelPendingContractErrorKind =
+  // Bad input or precondition not met — handler should return 400.
+  | "invalid_request"
+  // Metronome (or Stripe) API failure while restoring the current contract,
+  // before any irreversible local change.
+  | "restore_failed"
+  // The current contract/sub was restored but a follow-up step (archive the
+  // pending contract, delete the pending subscription) failed. Manual cleanup
+  // may be required; the message documents what's left to undo.
+  | "cleanup_inconsistent";
+
+export class CancelPendingContractError extends Error {
+  constructor(
+    readonly kind: CancelPendingContractErrorKind,
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+export type CancelPendingContractSuccess = {
+  cancelledMetronomeContractId: string | null;
+};
+
+/**
+ * Cancel a pending contract switch staged by `switchContract`, reverting the
+ * workspace to its current contract.
+ *
+ * The switch flow leaves three artifacts behind that this undoes:
+ *   - a future-dated Metronome contract (the pending one) → archived;
+ *   - a scheduled end on the current Metronome contract → end removed;
+ *   - a scheduled cancellation on the current Stripe subscription → cleared;
+ * plus the pending `created_backend_only` subscription row → deleted.
+ *
+ * The current contract/sub are restored FIRST so that a later failure can
+ * never leave the workspace billing-less (it would only leave an orphaned
+ * pending contract, which the operator can retry to archive).
+ */
+export async function cancelPendingContract({
+  auth,
+}: {
+  auth: Authenticator;
+}): Promise<Result<CancelPendingContractSuccess, CancelPendingContractError>> {
+  const owner = auth.getNonNullableWorkspace();
+  const { metronomeCustomerId } = owner;
+
+  const pending = await SubscriptionResource.fetchPendingByWorkspaceModelId(
+    owner.id
+  );
+  if (!pending) {
+    return new Err(
+      new CancelPendingContractError(
+        "invalid_request",
+        "No pending subscription to cancel for this workspace."
+      )
+    );
+  }
+
+  const currentSubscription = auth.subscriptionResource();
+
+  // 1. Restore the current Metronome contract: remove the scheduled end that
+  //    switch_contract set up so it no longer lapses at the swap time.
+  if (currentSubscription?.metronomeContractId && metronomeCustomerId) {
+    const reactivateResult = await reactivateMetronomeContract({
+      metronomeCustomerId,
+      contractId: currentSubscription.metronomeContractId,
+    });
+    if (reactivateResult.isErr()) {
+      return new Err(
+        new CancelPendingContractError(
+          "restore_failed",
+          "Failed to restore the current Metronome contract " +
+            `${currentSubscription.metronomeContractId}: ` +
+            `${reactivateResult.error.message}. No changes were applied.`
+        )
+      );
+    }
+  }
+
+  // 2. Restore the current Stripe subscription: clear the scheduled
+  //    cancellation so it keeps running.
+  if (currentSubscription?.stripeSubscriptionId) {
+    const clearResult = await clearScheduledSubscriptionCancellation({
+      stripeSubscriptionId: currentSubscription.stripeSubscriptionId,
+    });
+    if (clearResult.isErr()) {
+      return new Err(
+        new CancelPendingContractError(
+          "restore_failed",
+          "Restored the current Metronome contract but failed to clear the " +
+            `scheduled cancellation on Stripe subscription ` +
+            `${currentSubscription.stripeSubscriptionId}: ` +
+            `${clearResult.error.message}. ` +
+            "URGENT: clear cancel_at on the Stripe subscription manually."
+        )
+      );
+    }
+  }
+
+  // 3. Archive the pending Metronome contract (it has not started yet).
+  const pendingContractId = pending.metronomeContractId;
+  if (pendingContractId && metronomeCustomerId) {
+    const archiveResult = await archiveMetronomeContract({
+      metronomeCustomerId,
+      contractId: pendingContractId,
+    });
+    if (archiveResult.isErr()) {
+      return new Err(
+        new CancelPendingContractError(
+          "cleanup_inconsistent",
+          "Restored the current contract/subscription but failed to archive " +
+            `the pending Metronome contract ${pendingContractId}: ` +
+            `${archiveResult.error.message}. Archive it manually, then delete ` +
+            "the pending subscription."
+        )
+      );
+    }
+  }
+
+  // 4. Delete the pending subscription row.
+  const deleteResult = await pending.delete(auth);
+  if (deleteResult.isErr()) {
+    return new Err(
+      new CancelPendingContractError(
+        "cleanup_inconsistent",
+        "Restored the current contract and archived the pending Metronome " +
+          "contract, but failed to delete the pending subscription: " +
+          `${deleteResult.error.message}. Delete the pending subscription ` +
+          "row manually."
+      )
+    );
+  }
+
+  logger.info(
+    {
+      workspaceId: owner.sId,
+      pendingContractId,
+      restoredContractId: currentSubscription?.metronomeContractId ?? null,
+      restoredStripeSubscriptionId:
+        currentSubscription?.stripeSubscriptionId ?? null,
+    },
+    "[cancel_pending_contract] Cancelled pending contract switch"
+  );
+
+  return new Ok({ cancelledMetronomeContractId: pendingContractId });
+}

--- a/front/lib/api/poke/plugins/workspaces/upgrade_downgrade.ts
+++ b/front/lib/api/poke/plugins/workspaces/upgrade_downgrade.ts
@@ -107,6 +107,23 @@ export const downgradeNoPlan = createPlugin({
   },
 });
 
+export const cancelPendingContract = createPlugin({
+  manifest: {
+    id: "cancel-pending-contract",
+    name: "Cancel Pending Metronome Contract",
+    description:
+      "Cancel a pending contract switch: archive the pending Metronome " +
+      "contract, delete the pending subscription, and restore the current " +
+      "contract/subscription",
+    resourceTypes: ["workspaces"],
+    isHidden: true,
+    args: {},
+  },
+  execute: async () => {
+    return new Err(new Error("NO_OP"));
+  },
+});
+
 export const switchContract = createPlugin({
   manifest: {
     id: "switch-contract",

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -901,6 +901,43 @@ export async function reactivateMetronomeContract({
 }
 
 /**
+ * Permanently archive a Metronome contract along with its commits and credits.
+ * Used to undo a not-yet-started contract (e.g. cancelling a pending contract
+ * switch). `voidInvoices` voids any finalized invoices generated for the
+ * contract — safe to set for a future-dated contract that has not billed yet.
+ */
+export async function archiveMetronomeContract({
+  metronomeCustomerId,
+  contractId,
+  voidInvoices = true,
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+  voidInvoices?: boolean;
+}): Promise<Result<void, Error>> {
+  try {
+    await getMetronomeClient().v1.contracts.archive({
+      customer_id: metronomeCustomerId,
+      contract_id: contractId,
+      void_invoices: voidInvoices,
+    });
+
+    logger.info(
+      { metronomeCustomerId, contractId, voidInvoices },
+      "[Metronome] Contract archived"
+    );
+    return new Ok(undefined);
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      { error, metronomeCustomerId, contractId },
+      "[Metronome] Failed to archive contract"
+    );
+    return new Err(error);
+  }
+}
+
+/**
  * Generic wrapper around `v2.contracts.edit`. The Metronome edit endpoint is
  * an omnibus mutation (add subscriptions, commits, credits, overrides, billing
  * provider, etc.) — callers compose the body and we surface the resulting

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -912,6 +912,28 @@ export async function scheduleSubscriptionCancellation({
 }
 
 /**
+ * Clear a previously scheduled cancellation (the reverse of
+ * `scheduleSubscriptionCancellation`). Used when a pending contract switch is
+ * cancelled so the current Stripe subscription keeps running instead of
+ * stopping at the (now abandoned) swap time.
+ */
+export async function clearScheduledSubscriptionCancellation({
+  stripeSubscriptionId,
+}: {
+  stripeSubscriptionId: string;
+}): Promise<Result<void, Error>> {
+  try {
+    const stripe = getStripeClient();
+    await stripe.subscriptions.update(stripeSubscriptionId, {
+      cancel_at: null,
+    });
+    return new Ok(undefined);
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}
+
+/**
  * Creates a new Stripe Business subscription for upgrading Pro → Business.
  * The old subscription is cancelled separately after the DB flip.
  */

--- a/front/lib/swr/poke.ts
+++ b/front/lib/swr/poke.ts
@@ -150,6 +150,34 @@ export function usePokeArchiveCoupon() {
   };
 }
 
+export function usePokeCancelPendingContract() {
+  const sendNotification = useSendNotification();
+
+  return async (owner: LightWorkspaceType): Promise<boolean> => {
+    const r = await clientFetch(
+      `/api/poke/workspaces/${owner.sId}/cancel_pending_contract`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      }
+    );
+    if (!r.ok) {
+      sendNotification({
+        title: "Error cancelling pending subscription",
+        type: "error",
+        description: `Something went wrong: ${r.status} ${await r.text()}`,
+      });
+      return false;
+    }
+    sendNotification({
+      title: "Pending subscription cancelled",
+      type: "success",
+    });
+    return true;
+  };
+}
+
 export function usePokeMetronomePackages({
   disabled,
 }: {

--- a/front/pages/api/poke/workspaces/[wId]/cancel_pending_contract.test.ts
+++ b/front/pages/api/poke/workspaces/[wId]/cancel_pending_contract.test.ts
@@ -1,0 +1,169 @@
+import {
+  archiveMetronomeContract,
+  reactivateMetronomeContract,
+} from "@app/lib/metronome/client";
+import { clearScheduledSubscriptionCancellation } from "@app/lib/plans/stripe";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { Ok } from "@app/types/shared/result";
+import type { WorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import handler from "./cancel_pending_contract";
+
+vi.mock("@app/lib/metronome/client", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/client")
+  >("@app/lib/metronome/client");
+  return {
+    ...actual,
+    archiveMetronomeContract: vi.fn(),
+    reactivateMetronomeContract: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/plans/stripe", async () => {
+  const actual = await vi.importActual<typeof import("@app/lib/plans/stripe")>(
+    "@app/lib/plans/stripe"
+  );
+  return {
+    ...actual,
+    clearScheduledSubscriptionCancellation: vi.fn(),
+  };
+});
+
+const METRONOME_CUSTOMER_ID = "cust_test_xxx";
+const CURRENT_CONTRACT_ID = "contract_current_xxx";
+const PENDING_CONTRACT_ID = "contract_pending_yyy";
+const STRIPE_SUB_ID = "sub_stripe_xxx";
+
+async function makeSubscriptionMetronomeBilled(
+  workspace: WorkspaceType,
+  contractId: string | null,
+  { stripeSubscriptionId = null }: { stripeSubscriptionId?: string | null } = {}
+): Promise<number> {
+  const workspaceModelId = (await WorkspaceResource.fetchById(workspace.sId))!
+    .id;
+  await WorkspaceResource.updateMetronomeCustomerId(
+    workspaceModelId,
+    METRONOME_CUSTOMER_ID
+  );
+  const sub =
+    await SubscriptionResource.fetchActiveByWorkspaceModelId(workspaceModelId);
+  if (!sub) {
+    throw new Error("Test setup: workspace has no active subscription");
+  }
+  await sub.markAsEnded("ended");
+  await SubscriptionResource.makeNew(
+    {
+      sId: generateRandomModelSId(),
+      workspaceId: workspaceModelId,
+      planId: sub.planId,
+      status: "active",
+      startDate: new Date(),
+      endDate: null,
+      stripeSubscriptionId,
+      metronomeContractId: contractId,
+    },
+    sub.getPlan()
+  );
+  return workspaceModelId;
+}
+
+beforeEach(() => {
+  vi.mocked(archiveMetronomeContract).mockResolvedValue(new Ok(undefined));
+  vi.mocked(reactivateMetronomeContract).mockResolvedValue(new Ok(undefined));
+  vi.mocked(clearScheduledSubscriptionCancellation).mockResolvedValue(
+    new Ok(undefined)
+  );
+});
+
+describe("POST /api/poke/workspaces/[wId]/cancel_pending_contract", () => {
+  it("archives the pending contract, restores the current contract/sub, and deletes the pending subscription", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    const workspaceModelId = await makeSubscriptionMetronomeBilled(
+      workspace,
+      CURRENT_CONTRACT_ID,
+      { stripeSubscriptionId: STRIPE_SUB_ID }
+    );
+    await SubscriptionResource.createPendingMetronomeContract({
+      workspaceModelId,
+      planCode: "PRO_PLAN_SEAT_29",
+      metronomeContractId: PENDING_CONTRACT_ID,
+      startDate: new Date(Date.now() + 2 * 60 * 60 * 1000),
+    });
+
+    req.query.wId = workspace.sId;
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(reactivateMetronomeContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metronomeCustomerId: METRONOME_CUSTOMER_ID,
+        contractId: CURRENT_CONTRACT_ID,
+      })
+    );
+    expect(clearScheduledSubscriptionCancellation).toHaveBeenCalledWith({
+      stripeSubscriptionId: STRIPE_SUB_ID,
+    });
+    expect(archiveMetronomeContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metronomeCustomerId: METRONOME_CUSTOMER_ID,
+        contractId: PENDING_CONTRACT_ID,
+      })
+    );
+
+    const pending =
+      await SubscriptionResource.fetchPendingByWorkspaceModelId(
+        workspaceModelId
+      );
+    expect(pending).toBeNull();
+  });
+
+  it("does not touch Stripe when the current subscription is not Stripe-billed", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    const workspaceModelId = await makeSubscriptionMetronomeBilled(
+      workspace,
+      CURRENT_CONTRACT_ID
+    );
+    await SubscriptionResource.createPendingMetronomeContract({
+      workspaceModelId,
+      planCode: "PRO_PLAN_SEAT_29",
+      metronomeContractId: PENDING_CONTRACT_ID,
+      startDate: new Date(Date.now() + 2 * 60 * 60 * 1000),
+    });
+
+    req.query.wId = workspace.sId;
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(clearScheduledSubscriptionCancellation).not.toHaveBeenCalled();
+    expect(archiveMetronomeContract).toHaveBeenCalled();
+  });
+
+  it("returns 400 when there is no pending subscription", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, CURRENT_CONTRACT_ID);
+
+    req.query.wId = workspace.sId;
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.message).toContain(
+      "No pending subscription"
+    );
+    expect(archiveMetronomeContract).not.toHaveBeenCalled();
+    expect(reactivateMetronomeContract).not.toHaveBeenCalled();
+  });
+});

--- a/front/pages/api/poke/workspaces/[wId]/cancel_pending_contract.ts
+++ b/front/pages/api/poke/workspaces/[wId]/cancel_pending_contract.ts
@@ -1,0 +1,114 @@
+/** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { CancelPendingContractErrorKind } from "@app/lib/api/poke/cancel_pending_contract";
+import {
+  type CancelPendingContractError,
+  cancelPendingContract,
+} from "@app/lib/api/poke/cancel_pending_contract";
+import { pluginManager } from "@app/lib/api/poke/plugin_manager";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { PluginRunResource } from "@app/lib/resources/plugin_run_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export interface CancelPendingContractSuccessResponseBody {
+  success: boolean;
+}
+
+function statusForKind(kind: CancelPendingContractErrorKind): {
+  status_code: 400 | 500 | 502;
+  type: "invalid_request_error" | "internal_server_error";
+} {
+  switch (kind) {
+    case "invalid_request":
+      return { status_code: 400, type: "invalid_request_error" };
+    case "restore_failed":
+      return { status_code: 502, type: "internal_server_error" };
+    case "cleanup_inconsistent":
+      return { status_code: 500, type: "internal_server_error" };
+    default:
+      assertNever(kind);
+  }
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<CancelPendingContractSuccessResponseBody>
+  >,
+  session: SessionWithUser
+): Promise<void> {
+  const auth = await Authenticator.fromSuperUserSession(
+    session,
+    req.query.wId as string
+  );
+
+  if (!auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "user_not_found",
+        message: "Could not find the user.",
+      },
+    });
+  }
+
+  const owner = auth.workspace();
+  if (!owner) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Could not find the workspace.",
+      },
+    });
+  }
+
+  if (req.method !== "POST") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, POST is expected.",
+      },
+    });
+  }
+
+  const plugin = pluginManager.getNonNullablePlugin("cancel-pending-contract");
+  const pluginRun = await PluginRunResource.makeNew(
+    plugin,
+    req.body,
+    auth.getNonNullableUser(),
+    owner,
+    { resourceId: owner.sId, resourceType: "workspaces" }
+  );
+
+  const result = await cancelPendingContract({ auth });
+  if (result.isErr()) {
+    const err: CancelPendingContractError = result.error;
+    await pluginRun.recordError(err.message);
+    const { status_code, type } = statusForKind(err.kind);
+    return apiError(req, res, {
+      status_code,
+      api_error: { type, message: err.message },
+    });
+  }
+
+  const { cancelledMetronomeContractId } = result.value;
+  await pluginRun.recordResult({
+    display: "text",
+    value:
+      `Cancelled pending contract switch for ${owner.name}. ` +
+      (cancelledMetronomeContractId
+        ? `Archived Metronome contract ${cancelledMetronomeContractId}. `
+        : "") +
+      "The current subscription/contract was restored.",
+  });
+  res.status(200).json({ success: true });
+}
+
+export default withSessionAuthenticationForPoke(handler);


### PR DESCRIPTION
## Description

Adds a **"Cancel pending"** action in poke that reverts a staged contract switch, undoing every artifact `switchContract` leaves behind.

A switch stages: a future-dated Metronome contract (the pending one), a scheduled end on the current Metronome contract, a scheduled `cancel_at` on the current Stripe subscription, and a pending `created_backend_only` subscription row. This PR undoes all of them.

**Order of operations** — the current contract/sub are restored *first*, so a mid-way failure can never leave the workspace billing-less (worst case is an orphaned pending contract the operator can retry to archive):
1. **Reactivate the current Metronome contract** — remove the scheduled `ending_before` (`reactivateMetronomeContract`).
2. **Clear the Stripe `cancel_at`** on the current subscription (new `clearScheduledSubscriptionCancellation` helper).
3. **Archive the pending Metronome contract** (new `archiveMetronomeContract` → `v1.contracts.archive`, `void_invoices: true`).
4. **Delete the pending subscription** row.

Changes:
- `lib/api/poke/cancel_pending_contract.ts` — `cancelPendingContract` business fn + `CancelPendingContractError` (kinds: `invalid_request` → 400, `restore_failed` → 502, `cleanup_inconsistent` → 500, each with manual-cleanup guidance).
- Next endpoint `pages/api/poke/workspaces/[wId]/cancel_pending_contract.ts` + Hono mirror, kept in sync.
- `cancel-pending-contract` no-op poke plugin manifest (hidden) for PluginRunResource logging.
- `archiveMetronomeContract` (`lib/metronome/client.ts`) and `clearScheduledSubscriptionCancellation` (`lib/plans/stripe.ts`).
- `CancelPendingSubscriptionButton` in the Pending Subscription card (`components/poke/subscriptions/table.tsx`) — confirm dialog, loading state, error surfaced via alert.

Note: `switchContract` never writes an `endDate` to the current active subscription **row** (the `contract.start` webhook does that on activation), so there is no DB end date to restore — only the Metronome contract end and the Stripe `cancel_at`, both handled above.

> Stacked on #26486.

## Tests

- 3 new functional tests in `cancel_pending_contract.test.ts` (all passing):
  - full happy path: archives the pending contract, reactivates the current contract, clears the Stripe cancellation, and deletes the pending row;
  - skips the Stripe clear when the current subscription is not Stripe-billed;
  - returns 400 when there is no pending subscription.
- `npx tsgo --noEmit` and biome clean.

## Risk

Medium — the operation mutates Metronome (archive contract + remove end date) and Stripe (`cancel_at`) and deletes a DB row. Restricted to poke super-users. The restore-first ordering ensures the workspace keeps its current billing even on partial failure, and each failure mode returns an actionable error with the manual cleanup required. Archive uses `void_invoices: true`, which is safe for a future-dated contract that has not billed yet.

## Deploy Plan

Standard `front` deploy. No migration. Merge after #26486.
