### PR TITLE
[front] List tools in Skill Builder slash dropdown

### DIFF
--- a/front/components/editor/SkillInstructionsEditor.tsx
+++ b/front/components/editor/SkillInstructionsEditor.tsx
@@ -2,6 +2,7 @@ import { AgentInstructionDiffExtension } from "@app/components/editor/extensions
 import { KNOWLEDGE_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
 import type { KnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
 import { SlashCommandExtension } from "@app/components/editor/extensions/skill_builder/SlashCommandExtension";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
 import {
   buildSkillInstructionsExtensions,
   INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT,
@@ -97,6 +98,7 @@ function useEditorService(
 interface SkillInstructionsSkillReferencesOptions {
   currentSkillId?: string | null;
   enableSkillReferences: boolean;
+  onSelectTool?: (tool: MCPServerViewType) => void;
   owner?: LightWorkspaceType;
 }
 
@@ -113,16 +115,19 @@ interface UseSkillInstructionsEditorProps {
 function buildSkillInstructionsEditableExtensions({
   currentSkillId,
   includeSkillSuggestions,
+  onSelectTool,
   owner,
 }: {
   currentSkillId?: string | null;
   includeSkillSuggestions: boolean;
+  onSelectTool?: (tool: MCPServerViewType) => void;
   owner?: LightWorkspaceType;
 }) {
   return [
     SlashCommandExtension.configure({
       currentSkillId: currentSkillId ?? null,
       includeSkillSuggestions,
+      onSelectTool,
       owner,
     }),
     AgentInstructionDiffExtension,
@@ -148,6 +153,7 @@ export function useSkillInstructionsEditor({
 }: UseSkillInstructionsEditorProps) {
   const enableSkillReferences = skillReferences?.enableSkillReferences === true;
   const currentSkillId = skillReferences?.currentSkillId ?? null;
+  const onSelectTool = skillReferences?.onSelectTool;
   const owner = skillReferences?.owner;
   const includeSkillSuggestions = enableSkillReferences && !!owner;
   const editableExtensions = useMemo(
@@ -155,9 +161,10 @@ export function useSkillInstructionsEditor({
       buildSkillInstructionsEditableExtensions({
         currentSkillId,
         includeSkillSuggestions,
+        onSelectTool,
         owner,
       }),
-    [currentSkillId, includeSkillSuggestions, owner]
+    [currentSkillId, includeSkillSuggestions, onSelectTool, owner]
   );
 
   const extensions = useMemo(

--- a/front/components/editor/extensions/shared/SlashCommandToolItems.test.ts
+++ b/front/components/editor/extensions/shared/SlashCommandToolItems.test.ts
@@ -1,0 +1,113 @@
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { describe, expect, it } from "vitest";
+
+import {
+  filterToolsForSlashSuggestions,
+  getToolSlashCommandItem,
+  type SlashCommandToolSuggestion,
+} from "./SlashCommandToolItems";
+
+function toolSuggestion({
+  description = "Search data.",
+  label,
+  name = "search",
+  serverDescription = "Search workspace data.",
+  serverIcon = "ActionMagnifyingGlassIcon",
+  serverName = "search",
+  sId,
+}: {
+  description?: string | null;
+  label?: string;
+  name?: string | null;
+  serverDescription?: string;
+  serverIcon?: MCPServerViewType["server"]["icon"];
+  serverName?: string;
+  sId: string;
+}): SlashCommandToolSuggestion {
+  return {
+    id: 1,
+    sId,
+    name,
+    description,
+    createdAt: 0,
+    updatedAt: 0,
+    spaceId: "space_1",
+    serverType: "internal",
+    server: {
+      name: serverName,
+      version: "1.0.0",
+      description: serverDescription,
+      sId: `mcp_server_${serverName}`,
+      icon: serverIcon,
+      authorization: null,
+      tools: [],
+      availability: "manual",
+      allowMultipleInstances: false,
+      documentationUrl: null,
+    },
+    oAuthUseCase: null,
+    editedByUser: null,
+    label,
+  };
+}
+
+describe("filterToolsForSlashSuggestions", () => {
+  it("filters tools by their display label", () => {
+    const tools = [
+      toolSuggestion({
+        label: "Search docs",
+        name: null,
+        serverName: "search",
+        sId: "mcp_server_view_search",
+      }),
+      toolSuggestion({
+        name: "Create ticket",
+        serverName: "linear",
+        sId: "mcp_server_view_linear",
+      }),
+    ];
+
+    const result = filterToolsForSlashSuggestions({
+      query: "docs",
+      tools,
+    });
+
+    expect(result.map((tool) => tool.sId)).toEqual(["mcp_server_view_search"]);
+  });
+});
+
+describe("getToolSlashCommandItem", () => {
+  it("builds a slash command item that keeps the selected MCP server view", () => {
+    const tool = toolSuggestion({
+      description: "Draft a ticket.",
+      label: "Create ticket (Product)",
+      name: "Create ticket",
+      serverIcon: "ActionListIcon",
+      serverName: "linear",
+      sId: "mcp_server_view_linear",
+    });
+
+    const item = getToolSlashCommandItem(tool, {
+      sectionLabel: "Capabilities",
+    });
+
+    expect(item).toMatchObject({
+      action: "select-tool",
+      data: {
+        tool: {
+          icon: "ActionListIcon",
+          id: "mcp_server_view_linear",
+          name: "Create ticket (Product)",
+          view: tool,
+        },
+      },
+      description: "Draft a ticket.",
+      id: "mcp_server_view_linear",
+      label: "Create ticket (Product)",
+      sectionLabel: "Capabilities",
+      tooltip: {
+        description: "Draft a ticket.",
+      },
+    });
+  });
+});

--- a/front/components/editor/extensions/shared/SlashCommandToolItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandToolItems.ts
@@ -1,0 +1,77 @@
+import type { SlashCommand } from "@app/components/editor/extensions/skill_builder/SlashCommandDropdown";
+import {
+  getMcpServerViewDescription,
+  getMcpServerViewDisplayName,
+} from "@app/lib/actions/mcp_helper";
+import { getAvatar } from "@app/lib/actions/mcp_icons";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+
+import {
+  matchesSlashCommandQuery,
+  sortSlashCommandMatches,
+} from "./SlashCommandSkillItems";
+
+export const SELECT_TOOL_SLASH_COMMAND_ACTION = "select-tool";
+
+export type SlashCommandToolSuggestion = MCPServerViewType & {
+  label?: string;
+};
+
+function getToolLabel(tool: SlashCommandToolSuggestion) {
+  return tool.label ?? getMcpServerViewDisplayName(tool);
+}
+
+export function filterToolsForSlashSuggestions({
+  query,
+  tools,
+}: {
+  query: string;
+  tools: SlashCommandToolSuggestion[];
+}): SlashCommandToolSuggestion[] {
+  const normalizedQuery = query.trim().toLowerCase();
+
+  return sortSlashCommandMatches({
+    normalizedQuery,
+    items: tools
+      .filter((tool) =>
+        matchesSlashCommandQuery({
+          label: getToolLabel(tool),
+          query: normalizedQuery,
+        })
+      )
+      .map((tool) => ({
+        sortName: getToolLabel(tool).toLowerCase(),
+        tool,
+      })),
+  }).map(({ tool }) => tool);
+}
+
+export function getToolSlashCommandItem(
+  tool: SlashCommandToolSuggestion,
+  { sectionLabel }: { sectionLabel?: string } = {}
+): SlashCommand {
+  const name = getToolLabel(tool);
+  const description = getMcpServerViewDescription(tool);
+
+  return {
+    action: SELECT_TOOL_SLASH_COMMAND_ACTION,
+    data: {
+      tool: {
+        icon: tool.server.icon,
+        id: tool.sId,
+        name,
+        view: tool,
+      },
+    },
+    description,
+    icon: () => getAvatar(tool.server),
+    id: tool.sId,
+    label: name,
+    sectionLabel,
+    tooltip: description
+      ? {
+          description,
+        }
+      : undefined,
+  };
+}

--- a/front/components/editor/extensions/shared/SlashCommandToolItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandToolItems.ts
@@ -17,7 +17,7 @@ export type SlashCommandToolSuggestion = MCPServerViewType & {
   label?: string;
 };
 
-function getToolLabel(tool: SlashCommandToolSuggestion) {
+export function getToolSlashCommandLabel(tool: SlashCommandToolSuggestion) {
   return tool.label ?? getMcpServerViewDisplayName(tool);
 }
 
@@ -35,12 +35,12 @@ export function filterToolsForSlashSuggestions({
     items: tools
       .filter((tool) =>
         matchesSlashCommandQuery({
-          label: getToolLabel(tool),
+          label: getToolSlashCommandLabel(tool),
           query: normalizedQuery,
         })
       )
       .map((tool) => ({
-        sortName: getToolLabel(tool).toLowerCase(),
+        sortName: getToolSlashCommandLabel(tool).toLowerCase(),
         tool,
       })),
   }).map(({ tool }) => tool);
@@ -50,7 +50,7 @@ export function getToolSlashCommandItem(
   tool: SlashCommandToolSuggestion,
   { sectionLabel }: { sectionLabel?: string } = {}
 ): SlashCommand {
-  const name = getToolLabel(tool);
+  const name = getToolSlashCommandLabel(tool);
   const description = getMcpServerViewDescription(tool);
 
   return {

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -1,3 +1,4 @@
+import type { MCPServerViewType } from "@app/lib/api/mcp";
 import {
   cn,
   DropdownMenu,
@@ -44,6 +45,12 @@ export interface SlashCommand {
       icon?: string | null;
       id: string;
       name: string;
+    };
+    tool?: {
+      icon: string | null;
+      id: string;
+      name: string;
+      view: MCPServerViewType;
     };
   };
   description?: string;

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.test.ts
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.test.ts
@@ -122,9 +122,9 @@ describe("buildSkillBuilderSlashCommandItems", () => {
     });
   });
 
-  it("adds filtered tools after skills", () => {
+  it("sorts filtered skills and tools together", () => {
     const tool = toolSuggestion({
-      label: "Search docs",
+      label: "Alpha search",
       name: null,
       sId: "mcp_server_view_search",
     });
@@ -132,7 +132,7 @@ describe("buildSkillBuilderSlashCommandItems", () => {
     const result = buildSkillBuilderSlashCommandItems({
       baseItems: [attachKnowledgeItem],
       includeSkillSuggestions: true,
-      query: "search",
+      query: "",
       skills: [
         skillSuggestion({
           name: "Search checklist",
@@ -144,20 +144,20 @@ describe("buildSkillBuilderSlashCommandItems", () => {
 
     expect(result.map((item) => item.id)).toEqual([
       "add-knowledge",
-      "skill_search_checklist",
       "mcp_server_view_search",
+      "skill_search_checklist",
     ]);
     expect(result[1]?.sectionLabel).toBe("Capabilities");
-    expect(result[2]).toMatchObject({
+    expect(result[2]?.sectionLabel).toBeUndefined();
+    expect(result[1]).toMatchObject({
       action: "select-tool",
       data: {
         tool: {
           id: "mcp_server_view_search",
-          name: "Search docs",
+          name: "Alpha search",
           view: tool,
         },
       },
-      sectionLabel: undefined,
     });
   });
 

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.test.ts
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.test.ts
@@ -1,4 +1,6 @@
 import type { SlashCommandSkillSuggestion } from "@app/components/editor/extensions/shared/SlashCommandSkillItems";
+import type { SlashCommandToolSuggestion } from "@app/components/editor/extensions/shared/SlashCommandToolItems";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { describe, expect, it } from "vitest";
 
 import type { SlashCommand } from "./SlashCommandDropdown";
@@ -20,6 +22,46 @@ const skillSuggestion = ({
   icon,
   userFacingDescription,
   ...skill,
+});
+
+const toolSuggestion = ({
+  description = "Search data.",
+  label,
+  name = "search",
+  serverIcon = "ActionMagnifyingGlassIcon",
+  serverName = "search",
+  sId,
+}: {
+  description?: string | null;
+  label?: string;
+  name?: string | null;
+  serverIcon?: MCPServerViewType["server"]["icon"];
+  serverName?: string;
+  sId: string;
+}): SlashCommandToolSuggestion => ({
+  id: 1,
+  sId,
+  name,
+  description,
+  createdAt: 0,
+  updatedAt: 0,
+  spaceId: "space_1",
+  serverType: "internal",
+  server: {
+    name: serverName,
+    version: "1.0.0",
+    description: "Search workspace data.",
+    sId: `mcp_server_${serverName}`,
+    icon: serverIcon,
+    authorization: null,
+    tools: [],
+    availability: "manual",
+    allowMultipleInstances: false,
+    documentationUrl: null,
+  },
+  oAuthUseCase: null,
+  editedByUser: null,
+  label,
 });
 
 describe("buildSkillBuilderSlashCommandItems", () => {
@@ -76,6 +118,66 @@ describe("buildSkillBuilderSlashCommandItems", () => {
         },
       },
       description: "Draft structured memos.",
+      sectionLabel: "Capabilities",
+    });
+  });
+
+  it("adds filtered tools after skills", () => {
+    const tool = toolSuggestion({
+      label: "Search docs",
+      name: null,
+      sId: "mcp_server_view_search",
+    });
+
+    const result = buildSkillBuilderSlashCommandItems({
+      baseItems: [attachKnowledgeItem],
+      includeSkillSuggestions: true,
+      query: "search",
+      skills: [
+        skillSuggestion({
+          name: "Search checklist",
+          sId: "skill_search_checklist",
+        }),
+      ],
+      tools: [tool],
+    });
+
+    expect(result.map((item) => item.id)).toEqual([
+      "add-knowledge",
+      "skill_search_checklist",
+      "mcp_server_view_search",
+    ]);
+    expect(result[1]?.sectionLabel).toBe("Capabilities");
+    expect(result[2]).toMatchObject({
+      action: "select-tool",
+      data: {
+        tool: {
+          id: "mcp_server_view_search",
+          name: "Search docs",
+          view: tool,
+        },
+      },
+      sectionLabel: undefined,
+    });
+  });
+
+  it("labels the first tool section when there are no matching skills", () => {
+    const result = buildSkillBuilderSlashCommandItems({
+      baseItems: [],
+      includeSkillSuggestions: true,
+      query: "search",
+      skills: [],
+      tools: [
+        toolSuggestion({
+          label: "Search docs",
+          name: null,
+          sId: "mcp_server_view_search",
+        }),
+      ],
+    });
+
+    expect(result[0]).toMatchObject({
+      id: "mcp_server_view_search",
       sectionLabel: "Capabilities",
     });
   });

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
@@ -1,12 +1,13 @@
 import {
-  filterSkillsForSlashSuggestions,
   getSkillSlashCommandItem,
+  matchesSlashCommandQuery,
   SELECT_SKILL_SLASH_COMMAND_ACTION,
   type SlashCommandSkillSuggestion,
+  sortSlashCommandMatches,
 } from "@app/components/editor/extensions/shared/SlashCommandSkillItems";
 import {
-  filterToolsForSlashSuggestions,
   getToolSlashCommandItem,
+  getToolSlashCommandLabel,
   SELECT_TOOL_SLASH_COMMAND_ACTION,
   type SlashCommandToolSuggestion,
 } from "@app/components/editor/extensions/shared/SlashCommandToolItems";
@@ -15,7 +16,7 @@ import type {
   SlashCommandDropdownRef,
 } from "@app/components/editor/extensions/skill_builder/SlashCommandDropdown";
 import { SlashCommandDropdown } from "@app/components/editor/extensions/skill_builder/SlashCommandDropdown";
-import { useMaybeMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
+import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useSkills } from "@app/lib/swr/skill_configurations";
@@ -84,6 +85,63 @@ function filterSlashCommands(query: string): SlashCommand[] {
   );
 }
 
+type SkillBuilderSlashCommandCapability =
+  | {
+      kind: "skill";
+      skill: SlashCommandSkillSuggestion;
+      sortName: string;
+    }
+  | {
+      kind: "tool";
+      tool: SlashCommandToolSuggestion;
+      sortName: string;
+    };
+
+function filterSkillBuilderSlashCommandCapabilities({
+  currentSkillId,
+  query,
+  skills,
+  tools,
+}: {
+  currentSkillId?: string | null;
+  query: string;
+  skills: SlashCommandSkillSuggestion[];
+  tools: SlashCommandToolSuggestion[];
+}): SkillBuilderSlashCommandCapability[] {
+  const normalizedQuery = query.trim().toLowerCase();
+
+  return sortSlashCommandMatches({
+    normalizedQuery,
+    items: [
+      ...skills
+        .filter((skill) => skill.sId !== currentSkillId)
+        .filter((skill) =>
+          matchesSlashCommandQuery({
+            label: skill.name,
+            query: normalizedQuery,
+          })
+        )
+        .map((skill) => ({
+          kind: "skill" as const,
+          skill,
+          sortName: skill.name.toLowerCase(),
+        })),
+      ...tools
+        .filter((tool) =>
+          matchesSlashCommandQuery({
+            label: getToolSlashCommandLabel(tool),
+            query: normalizedQuery,
+          })
+        )
+        .map((tool) => ({
+          kind: "tool" as const,
+          tool,
+          sortName: getToolSlashCommandLabel(tool).toLowerCase(),
+        })),
+    ],
+  });
+}
+
 export function buildSkillBuilderSlashCommandItems({
   baseItems,
   currentSkillId,
@@ -103,23 +161,20 @@ export function buildSkillBuilderSlashCommandItems({
     return baseItems;
   }
 
-  const skillItems = filterSkillsForSlashSuggestions({ query, skills })
-    .filter((skill) => skill.sId !== currentSkillId)
-    .map((skill, index) =>
-      getSkillSlashCommandItem(skill, {
-        sectionLabel: index === 0 ? "Capabilities" : undefined,
-      })
-    );
+  const capabilityItems = filterSkillBuilderSlashCommandCapabilities({
+    currentSkillId,
+    query,
+    skills,
+    tools,
+  }).map((capability, index) => {
+    const sectionLabel = index === 0 ? "Capabilities" : undefined;
 
-  const toolItems = filterToolsForSlashSuggestions({ query, tools }).map(
-    (tool, index) =>
-      getToolSlashCommandItem(tool, {
-        sectionLabel:
-          skillItems.length === 0 && index === 0 ? "Capabilities" : undefined,
-      })
-  );
+    return capability.kind === "skill"
+      ? getSkillSlashCommandItem(capability.skill, { sectionLabel })
+      : getToolSlashCommandItem(capability.tool, { sectionLabel });
+  });
 
-  return [...baseItems, ...skillItems, ...toolItems];
+  return [...baseItems, ...capabilityItems];
 }
 
 interface SkillBuilderSlashCommandDropdownProps
@@ -158,17 +213,14 @@ const SkillBuilderSlashCommandDropdownWithSkills = forwardRef<
   ) => {
     const dropdownRef = useRef<SlashCommandDropdownRef>(null);
     const isOpen = Boolean(clientRect);
-    const mcpServerViewsContext = useMaybeMCPServerViewsContext();
+    const mcpServerViewsContext = useMCPServerViewsContext();
     const { skills, isSkillsLoading } = useSkills({
       disabled: !isOpen,
       owner,
       status: "active",
     });
     const tools = useMemo(() => {
-      if (
-        !mcpServerViewsContext ||
-        mcpServerViewsContext.isMCPServerViewsError
-      ) {
+      if (mcpServerViewsContext.isMCPServerViewsError) {
         return [];
       }
 
@@ -177,8 +229,7 @@ const SkillBuilderSlashCommandDropdownWithSkills = forwardRef<
       );
     }, [mcpServerViewsContext]);
     const isCapabilitiesLoading =
-      isSkillsLoading ||
-      (mcpServerViewsContext?.isMCPServerViewsLoading ?? false);
+      isSkillsLoading || mcpServerViewsContext.isMCPServerViewsLoading;
 
     const slashCommandItems = useMemo(
       () =>

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
@@ -4,11 +4,20 @@ import {
   SELECT_SKILL_SLASH_COMMAND_ACTION,
   type SlashCommandSkillSuggestion,
 } from "@app/components/editor/extensions/shared/SlashCommandSkillItems";
+import {
+  filterToolsForSlashSuggestions,
+  getToolSlashCommandItem,
+  SELECT_TOOL_SLASH_COMMAND_ACTION,
+  type SlashCommandToolSuggestion,
+} from "@app/components/editor/extensions/shared/SlashCommandToolItems";
 import type {
   SlashCommand,
   SlashCommandDropdownRef,
 } from "@app/components/editor/extensions/skill_builder/SlashCommandDropdown";
 import { SlashCommandDropdown } from "@app/components/editor/extensions/skill_builder/SlashCommandDropdown";
+import { useMaybeMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
+import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useSkills } from "@app/lib/swr/skill_configurations";
 import type { LightWorkspaceType } from "@app/types/user";
 import { AttachmentIcon } from "@dust-tt/sparkle";
@@ -81,12 +90,14 @@ export function buildSkillBuilderSlashCommandItems({
   includeSkillSuggestions,
   query,
   skills,
+  tools = [],
 }: {
   baseItems: SlashCommand[];
   currentSkillId?: string | null;
   includeSkillSuggestions: boolean;
   query: string;
   skills: SlashCommandSkillSuggestion[];
+  tools?: SlashCommandToolSuggestion[];
 }): SlashCommand[] {
   if (!includeSkillSuggestions) {
     return baseItems;
@@ -100,7 +111,15 @@ export function buildSkillBuilderSlashCommandItems({
       })
     );
 
-  return [...baseItems, ...skillItems];
+  const toolItems = filterToolsForSlashSuggestions({ query, tools }).map(
+    (tool, index) =>
+      getToolSlashCommandItem(tool, {
+        sectionLabel:
+          skillItems.length === 0 && index === 0 ? "Capabilities" : undefined,
+      })
+  );
+
+  return [...baseItems, ...skillItems, ...toolItems];
 }
 
 interface SkillBuilderSlashCommandDropdownProps
@@ -139,11 +158,27 @@ const SkillBuilderSlashCommandDropdownWithSkills = forwardRef<
   ) => {
     const dropdownRef = useRef<SlashCommandDropdownRef>(null);
     const isOpen = Boolean(clientRect);
+    const mcpServerViewsContext = useMaybeMCPServerViewsContext();
     const { skills, isSkillsLoading } = useSkills({
       disabled: !isOpen,
       owner,
       status: "active",
     });
+    const tools = useMemo(() => {
+      if (
+        !mcpServerViewsContext ||
+        mcpServerViewsContext.isMCPServerViewsError
+      ) {
+        return [];
+      }
+
+      return mcpServerViewsContext.mcpServerViewsWithoutKnowledge.filter(
+        (view) => getMCPServerRequirements(view).noRequirement
+      );
+    }, [mcpServerViewsContext]);
+    const isCapabilitiesLoading =
+      isSkillsLoading ||
+      (mcpServerViewsContext?.isMCPServerViewsLoading ?? false);
 
     const slashCommandItems = useMemo(
       () =>
@@ -153,8 +188,9 @@ const SkillBuilderSlashCommandDropdownWithSkills = forwardRef<
           includeSkillSuggestions: true,
           query,
           skills,
+          tools,
         }),
-      [currentSkillId, items, query, showCapabilitiesOnly, skills]
+      [currentSkillId, items, query, showCapabilitiesOnly, skills, tools]
     );
 
     useImperativeHandle(
@@ -163,7 +199,7 @@ const SkillBuilderSlashCommandDropdownWithSkills = forwardRef<
         onKeyDown: ({ event }) => {
           if (
             (event.key === "Enter" || event.key === "Tab") &&
-            (isSkillsLoading || slashCommandItems.length === 0)
+            (isCapabilitiesLoading || slashCommandItems.length === 0)
           ) {
             event.preventDefault();
             return true;
@@ -172,18 +208,18 @@ const SkillBuilderSlashCommandDropdownWithSkills = forwardRef<
           return dropdownRef.current?.onKeyDown({ event }) ?? false;
         },
       }),
-      [isSkillsLoading, slashCommandItems.length]
+      [isCapabilitiesLoading, slashCommandItems.length]
     );
 
     return (
       <SlashCommandDropdown
-        key={isSkillsLoading ? "loading" : "loaded"}
+        key={isCapabilitiesLoading ? "loading" : "loaded"}
         ref={dropdownRef}
         items={slashCommandItems}
         command={command}
         clientRect={clientRect}
         emptyMessage={
-          isSkillsLoading ? "Loading capabilities…" : "No commands found"
+          isCapabilitiesLoading ? "Loading capabilities…" : "No commands found"
         }
         onClose={onClose}
         size="wide"
@@ -226,6 +262,7 @@ SkillBuilderSlashCommandDropdown.displayName =
 export interface SlashCommandExtensionOptions {
   currentSkillId?: string | null;
   includeSkillSuggestions: boolean;
+  onSelectTool?: (tool: MCPServerViewType) => void;
   owner?: LightWorkspaceType;
   suggestion: Partial<SuggestionOptions>;
 }
@@ -260,6 +297,7 @@ export const SlashCommandExtension =
       return {
         currentSkillId: null,
         includeSkillSuggestions: false,
+        onSelectTool: undefined,
         owner: undefined,
         suggestion: {
           char: "/",
@@ -335,6 +373,21 @@ export const SlashCommandExtension =
                     skillName: skill.name,
                   })
                   .run();
+              }
+            } else if (props.action === SELECT_TOOL_SLASH_COMMAND_ACTION) {
+              const tool = props.data?.tool;
+              if (tool) {
+                editor
+                  .chain()
+                  .focus()
+                  .deleteRange(range)
+                  .insertToolNode({
+                    mcpServerViewId: tool.id,
+                    toolIcon: tool.icon,
+                    toolName: tool.name,
+                  })
+                  .run();
+                extensionOptions.onSelectTool?.(tool.view);
               }
             }
           },

--- a/front/components/editor/extensions/skill_builder/ToolNodeWithView.tsx
+++ b/front/components/editor/extensions/skill_builder/ToolNodeWithView.tsx
@@ -23,9 +23,16 @@ function useToolNodeDisplay(attrs: ToolNodeAttributes) {
       };
     }
 
-    const view = ctx.mcpServerViews.find(
-      (v) => v.sId === attrs.mcpServerViewId
-    );
+    const labeledView =
+      ctx.mcpServerViewsWithoutKnowledge.find(
+        (v) => v.sId === attrs.mcpServerViewId
+      ) ??
+      ctx.mcpServerViewsWithKnowledge.find(
+        (v) => v.sId === attrs.mcpServerViewId
+      );
+    const view =
+      labeledView ??
+      ctx.mcpServerViews.find((v) => v.sId === attrs.mcpServerViewId);
 
     if (!view || ctx.isMCPServerViewsError) {
       return {
@@ -36,7 +43,7 @@ function useToolNodeDisplay(attrs: ToolNodeAttributes) {
 
     return {
       kind: "tool" as const,
-      title: getMcpServerViewDisplayName(view),
+      title: labeledView?.label ?? getMcpServerViewDisplayName(view),
       toolIcon: view.server.icon,
     };
   }, [attrs.mcpServerViewId, attrs.toolIcon, attrs.toolName, ctx]);

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -25,7 +25,7 @@ import type { Config } from "dompurify";
 import DOMPurify from "dompurify";
 import debounce from "lodash/debounce";
 import { useCallback, useEffect, useMemo, useRef } from "react";
-import { useController, useFormContext, useWatch } from "react-hook-form";
+import { useController, useFormContext } from "react-hook-form";
 
 const INSTRUCTIONS_FIELD_NAME = "instructions";
 const INSTRUCTIONS_HTML_FIELD_NAME = "instructionsHtml";
@@ -99,8 +99,7 @@ export function SkillBuilderInstructionsEditor({
   onOpenCapabilities,
 }: SkillBuilderInstructionsEditorProps) {
   const { compareVersion, isDiffMode } = useSkillVersionComparisonContext();
-  const { control, getValues, resetField, setValue } =
-    useFormContext<SkillBuilderFormData>();
+  const { resetField } = useFormContext<SkillBuilderFormData>();
   const initializedAttachedKnowledgeEditorRef = useRef<Editor | null>(null);
   const { owner, skillId, selectedSuggestionId, setAcceptInstructionEdits } =
     useSkillBuilderContext();
@@ -129,7 +128,12 @@ export function SkillBuilderInstructionsEditor({
       name: ATTACHED_KNOWLEDGE_FIELD_NAME,
     }
   );
-  const tools = useWatch({ control, name: "tools" }) ?? [];
+
+  const {
+    field: { onChange: onToolsChange, value: tools },
+  } = useController<SkillBuilderFormData, "tools">({
+    name: "tools",
+  });
 
   const displayError =
     !!instructionsFieldState.error || !!attachedKnowledgeFieldState.error;
@@ -204,8 +208,7 @@ export function SkillBuilderInstructionsEditor({
 
   const handleSelectToolReference = useCallback(
     (view: MCPServerViewType) => {
-      const currentTools = getValues("tools");
-      const alreadyAdded = currentTools.some(
+      const alreadyAdded = tools.some(
         (tool) => tool.configuration.mcpServerViewId === view.sId
       );
 
@@ -213,12 +216,9 @@ export function SkillBuilderInstructionsEditor({
         return;
       }
 
-      setValue("tools", [...currentTools, getDefaultMCPAction(view)], {
-        shouldDirty: true,
-        shouldValidate: true,
-      });
+      onToolsChange([...tools, getDefaultMCPAction(view)]);
     },
-    [getValues, setValue]
+    [onToolsChange, tools]
   );
 
   const { suggestions, isSuggestionsLoading } = useSkillSuggestions({

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -1,3 +1,4 @@
+import { getDefaultMCPAction } from "@app/components/agent_builder/types";
 import { editorVariants } from "@app/components/editor/editorStyles";
 import { KNOWLEDGE_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
 import type { KnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
@@ -11,6 +12,7 @@ import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBu
 import { SkillBuilderInstructionsReferenceSummary } from "@app/components/skill_builder/SkillBuilderInstructionsReferenceSummary";
 import { useSkillVersionComparisonContext } from "@app/components/skill_builder/SkillBuilderVersionContext";
 import { useSkillSuggestions } from "@app/hooks/useSkillSuggestions";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import {
   postProcessMarkdown,
@@ -97,7 +99,8 @@ export function SkillBuilderInstructionsEditor({
   onOpenCapabilities,
 }: SkillBuilderInstructionsEditorProps) {
   const { compareVersion, isDiffMode } = useSkillVersionComparisonContext();
-  const { control, resetField } = useFormContext<SkillBuilderFormData>();
+  const { control, getValues, resetField, setValue } =
+    useFormContext<SkillBuilderFormData>();
   const initializedAttachedKnowledgeEditorRef = useRef<Editor | null>(null);
   const { owner, skillId, selectedSuggestionId, setAcceptInstructionEdits } =
     useSkillBuilderContext();
@@ -199,6 +202,25 @@ export function SkillBuilderInstructionsEditor({
     [syncAttachedKnowledgeFromEditor]
   );
 
+  const handleSelectToolReference = useCallback(
+    (view: MCPServerViewType) => {
+      const currentTools = getValues("tools");
+      const alreadyAdded = currentTools.some(
+        (tool) => tool.configuration.mcpServerViewId === view.sId
+      );
+
+      if (alreadyAdded) {
+        return;
+      }
+
+      setValue("tools", [...currentTools, getDefaultMCPAction(view)], {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
+    },
+    [getValues, setValue]
+  );
+
   const { suggestions, isSuggestionsLoading } = useSkillSuggestions({
     skillId,
     states: ["pending"],
@@ -215,6 +237,7 @@ export function SkillBuilderInstructionsEditor({
     skillReferences: {
       currentSkillId: skillId,
       enableSkillReferences,
+      onSelectTool: handleSelectToolReference,
       owner,
     },
     onUpdate: handleUpdate,


### PR DESCRIPTION
## Description


Adds tool capabilities to the existing Skill Builder slash dropdown and inserts a tool reference chip when one is selected. The dropdown reads labeled MCP server views from the existing Skill Builder context, only lists capabilities that do not require extra configuration, and appends the selected tool to the Skill Builder form if it is not already equipped.

## Risks

Blast radius: Skill Builder instructions slash dropdown and no-config tool selection.
Risk: standard

## Deploy Plan

- Deploy front.

## Tests

- [x] `NODE_ENV=test npm test -- components/editor/extensions/shared/SlashCommandToolItems.test.ts components/editor/extensions/skill_builder/ToolNode.test.ts lib/editor/skill_instructions_preprocessing.test.ts lib/reinforcement/skill_instructions_html.test.ts lib/reinforcement/analyze_conversation.test.ts lib/api/assistant/skills_rendering.test.ts`