### PR TITLE
Grant AWU plugin: Add purchase order + fixed price

### DIFF
--- a/front/components/poke/plugins/PluginForm.tsx
+++ b/front/components/poke/plugins/PluginForm.tsx
@@ -122,7 +122,11 @@ export function PluginForm({
       ...new Set(
         Object.values(manifest.args)
           .filter((arg) => arg.dependsOn)
-          .map((arg) => arg.dependsOn!.field)
+          .flatMap((arg) =>
+            Array.isArray(arg.dependsOn)
+              ? arg.dependsOn.map((c) => c.field)
+              : [arg.dependsOn!.field]
+          )
       ),
     ];
   }, [manifest]);
@@ -156,9 +160,14 @@ export function PluginForm({
       >
         <div className="max-h-[50vh] space-y-8 overflow-y-auto pr-2">
           {Object.entries(manifest.args).map(([key, arg]) => {
-            const isDependentFieldHidden =
-              arg.dependsOn &&
-              watchedValues[arg.dependsOn.field] !== arg.dependsOn.value;
+            const conditions = arg.dependsOn
+              ? Array.isArray(arg.dependsOn)
+                ? arg.dependsOn
+                : [arg.dependsOn]
+              : [];
+            const isDependentFieldHidden = conditions.some(
+              (c) => watchedValues[c.field] !== c.value
+            );
 
             if (isDependentFieldHidden) {
               return null;

--- a/front/lib/api/poke/plugins/workspaces/grant_awu_credits.ts
+++ b/front/lib/api/poke/plugins/workspaces/grant_awu_credits.ts
@@ -292,11 +292,14 @@ export const grantAwuCreditsPlugin = createPlugin({
       });
     }
 
-    const commitName = validatedArgs.setPrice
+    const commitNameBase = validatedArgs.setPrice
       ? `Commits granted from Poke: ${amountCredits.toLocaleString()} credits (manual price)`
       : discountPercent > 0
         ? `Commits granted from Poke: ${amountCredits.toLocaleString()} credits (${discountPercent}% discount)`
         : `Commits granted from Poke: ${amountCredits.toLocaleString()} credits`;
+    const commitName = validatedArgs.purchaseOrderId
+      ? `${commitNameBase} [PO: ${validatedArgs.purchaseOrderId}]`
+      : commitNameBase;
 
     const result = await createMetronomeCommit({
       metronomeCustomerId,

--- a/front/lib/api/poke/plugins/workspaces/grant_awu_credits.ts
+++ b/front/lib/api/poke/plugins/workspaces/grant_awu_credits.ts
@@ -16,7 +16,6 @@ import {
   getCreditTypeAwuId,
   getProductFreeCreditId,
   getProductPrepaidCommitId,
-  PURCHASE_ORDER_ID_CUSTOM_FIELD_KEY,
 } from "@app/lib/metronome/constants";
 import logger from "@app/logger/logger";
 import type { SupportedCurrency } from "@app/types/currency";
@@ -318,11 +317,6 @@ export const grantAwuCreditsPlugin = createPlugin({
         quantity: 1,
         timestamp: startDate,
       },
-      customFields: validatedArgs.purchaseOrderId
-        ? {
-            [PURCHASE_ORDER_ID_CUSTOM_FIELD_KEY]: validatedArgs.purchaseOrderId,
-          }
-        : undefined,
     });
 
     if (result.isErr()) {

--- a/front/lib/api/poke/plugins/workspaces/grant_awu_credits.ts
+++ b/front/lib/api/poke/plugins/workspaces/grant_awu_credits.ts
@@ -5,6 +5,7 @@ import {
   resolveAwuPurchaseDiscountPercent,
 } from "@app/lib/credits/awu_pricing";
 import { MAX_AWU_DISCOUNT_PERCENT } from "@app/lib/credits/awu_purchase_constants";
+import { metronomeAmount } from "@app/lib/metronome/amounts";
 import {
   createMetronomeCommit,
   createMetronomeCredit,
@@ -15,8 +16,10 @@ import {
   getCreditTypeAwuId,
   getProductFreeCreditId,
   getProductPrepaidCommitId,
+  PURCHASE_ORDER_ID_CUSTOM_FIELD_KEY,
 } from "@app/lib/metronome/constants";
 import logger from "@app/logger/logger";
+import type { SupportedCurrency } from "@app/types/currency";
 import { isCreditPricedPlan } from "@app/types/plan";
 import { Err, Ok } from "@app/types/shared/result";
 import { addYears, format } from "date-fns";
@@ -31,6 +34,12 @@ const GrantAwuCreditsArgsSchema = z
       .positive("Amount must be greater than 0")
       .finite("Amount must be a valid number"),
     isFreeCredit: z.boolean(),
+    setPrice: z.boolean(),
+    price: z
+      .number()
+      .positive("Price must be greater than 0")
+      .finite("Price must be a valid number")
+      .optional(),
     overrideDiscount: z.boolean(),
     discountPercent: z
       .number()
@@ -42,12 +51,23 @@ const GrantAwuCreditsArgsSchema = z
       .finite("Discount must be a valid number"),
     startDate: z.coerce.date(),
     expirationDate: z.coerce.date(),
+    purchaseOrderId: z
+      .string()
+      .max(140, "Purchase Order ID cannot exceed 140 characters")
+      .optional(),
     confirm: z.boolean(),
   })
   .refine((data) => data.confirm === true, {
     message: "Please confirm by checking the confirmation box",
     path: ["confirm"],
-  });
+  })
+  .refine(
+    (data) => !data.setPrice || (data.price !== undefined && data.price > 0),
+    {
+      message: "Price is required when 'Set Price' is enabled",
+      path: ["price"],
+    }
+  );
 
 export const grantAwuCreditsPlugin = createPlugin({
   manifest: {
@@ -72,13 +92,34 @@ export const grantAwuCreditsPlugin = createPlugin({
         description:
           "When enabled, grants free AWU credits. When disabled, grants a commit (the customer will be invoiced through Metronome).",
       },
+      setPrice: {
+        type: "boolean",
+        variant: "toggle",
+        label: "Set Price",
+        description:
+          "Enter the total invoice price and currency directly instead of computing them from AWU rates and the workspace discount. Bypasses any configured discount.",
+        dependsOn: { field: "isFreeCredit", value: false },
+      },
+      price: {
+        type: "number",
+        variant: "text",
+        async: true,
+        asyncDescription: true,
+        label: "Total invoice price",
+        description:
+          "Total invoice amount in the customer's billing currency (e.g. 1000 = 1,000 units).",
+        dependsOn: { field: "setPrice", value: true },
+      },
       overrideDiscount: {
         type: "boolean",
         variant: "toggle",
         label: "Override Default Discount",
         async: true,
         asyncDescription: true,
-        dependsOn: { field: "isFreeCredit", value: false },
+        dependsOn: [
+          { field: "isFreeCredit", value: false },
+          { field: "setPrice", value: false },
+        ],
       },
       discountPercent: {
         type: "number",
@@ -86,7 +127,10 @@ export const grantAwuCreditsPlugin = createPlugin({
         async: true,
         label: "AWU Discount (%)",
         description: "Discount applied to the AWU commit invoice.",
-        dependsOn: { field: "overrideDiscount", value: true },
+        dependsOn: [
+          { field: "overrideDiscount", value: true },
+          { field: "setPrice", value: false },
+        ],
       },
       startDate: {
         type: "date",
@@ -99,6 +143,14 @@ export const grantAwuCreditsPlugin = createPlugin({
         async: true,
         label: "Expiration Date",
         description: "When the credits expire.",
+      },
+      purchaseOrderId: {
+        type: "string",
+        variant: "text",
+        label: "Purchase Order ID (optional)",
+        description:
+          "Customer's PO number to include on the Metronome-generated Stripe invoice.",
+        dependsOn: { field: "isFreeCredit", value: false },
       },
       confirm: {
         type: "boolean",
@@ -116,11 +168,20 @@ export const grantAwuCreditsPlugin = createPlugin({
     const workspace = auth.getNonNullableWorkspace();
     const defaultDiscount = await resolveAwuPurchaseDiscountPercent(auth);
 
+    // Resolve currency for the price-field hint. Swallow errors here so the
+    // form still loads for workspaces without an active Metronome contract
+    // (e.g. when the operator only intends to grant a free credit).
+    const currencyResult = await resolveAwuPurchaseCurrency(workspace.sId);
+    const priceDescription = currencyResult.isOk()
+      ? `Total invoice amount in ${currencyResult.value.toUpperCase()} (e.g. 1000 = 1,000 ${currencyResult.value.toUpperCase()}).`
+      : "Total invoice amount in the customer's billing currency.";
+
     const today = new Date();
     const oneYearFromNow = addYears(today, 1);
     return new Ok({
-      overrideDiscountDescription: `Override the customer's default discount. Current default for ${workspace.name}: ${defaultDiscount}%`,
+      overrideDiscount_description: `Override the customer's default discount. Current default for ${workspace.name}: ${defaultDiscount}%`,
       discountPercent: defaultDiscount,
+      price_description: priceDescription,
       startDate: format(today, "yyyy-MM-dd"),
       expirationDate: format(oneYearFromNow, "yyyy-MM-dd"),
     });
@@ -207,20 +268,33 @@ export const grantAwuCreditsPlugin = createPlugin({
         )
       );
     }
-    const currency = currencyResult.value;
+    const currency: SupportedCurrency = currencyResult.value;
 
-    const discountPercent = validatedArgs.overrideDiscount
-      ? validatedArgs.discountPercent
-      : await resolveAwuPurchaseDiscountPercent(auth);
+    let invoiceUnitPrice: number;
+    let discountPercent = 0;
 
-    const invoiceUnitPrice = computeAwuInvoiceUnitPrice({
-      amountCredits,
-      currency,
-      discountPercent,
-    });
+    if (validatedArgs.setPrice) {
+      // Operator-supplied price wins — skip rate computation and any
+      // workspace discount.
+      invoiceUnitPrice = metronomeAmount(
+        Math.round(validatedArgs.price! * 100),
+        currency
+      );
+    } else {
+      discountPercent = validatedArgs.overrideDiscount
+        ? validatedArgs.discountPercent
+        : await resolveAwuPurchaseDiscountPercent(auth);
 
-    const commitName =
-      discountPercent > 0
+      invoiceUnitPrice = computeAwuInvoiceUnitPrice({
+        amountCredits,
+        currency,
+        discountPercent,
+      });
+    }
+
+    const commitName = validatedArgs.setPrice
+      ? `Commits granted from Poke: ${amountCredits.toLocaleString()} credits (manual price)`
+      : discountPercent > 0
         ? `Commits granted from Poke: ${amountCredits.toLocaleString()} credits (${discountPercent}% discount)`
         : `Commits granted from Poke: ${amountCredits.toLocaleString()} credits`;
 
@@ -241,6 +315,11 @@ export const grantAwuCreditsPlugin = createPlugin({
         quantity: 1,
         timestamp: startDate,
       },
+      customFields: validatedArgs.purchaseOrderId
+        ? {
+            [PURCHASE_ORDER_ID_CUSTOM_FIELD_KEY]: validatedArgs.purchaseOrderId,
+          }
+        : undefined,
     });
 
     if (result.isErr()) {
@@ -259,12 +338,15 @@ export const grantAwuCreditsPlugin = createPlugin({
       return new Err(result.error);
     }
 
-    const discountSuffix =
-      discountPercent > 0 ? ` with ${discountPercent}% discount` : "";
+    const pricingSuffix = validatedArgs.setPrice
+      ? ` at a manual price of ${validatedArgs.price!.toLocaleString()} ${currency.toUpperCase()}`
+      : discountPercent > 0
+        ? ` with ${discountPercent}% discount (${currency.toUpperCase()})`
+        : ` (${currency.toUpperCase()})`;
 
     return new Ok({
       display: "text",
-      value: `Successfully granted ${amountCredits.toLocaleString()} AWU credits as a prepaid commit${discountSuffix} (${formattedStart} to ${formattedEnd}). Metronome will invoice the customer.`,
+      value: `Successfully granted ${amountCredits.toLocaleString()} AWU credits as a prepaid commit${pricingSuffix} (${formattedStart} to ${formattedEnd}). Metronome will invoice the customer.`,
     });
   },
 });

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -1251,6 +1251,7 @@ export async function createMetronomeCommit({
   idempotencyKey,
   priority,
   invoiceSchedule,
+  customFields,
 }: {
   metronomeCustomerId: string;
   productId: string;
@@ -1268,6 +1269,7 @@ export async function createMetronomeCommit({
     quantity: number;
     timestamp: Date;
   };
+  customFields?: Record<string, string>;
 }): Promise<Result<{ id: string } | null, Error>> {
   // Metronome requires dates on hour boundaries — round down start, round up end.
   const roundedStartingAt = floorToHourISO(startingAt);
@@ -1317,6 +1319,9 @@ export async function createMetronomeCommit({
               ],
             },
           }
+        : {}),
+      ...(customFields && Object.keys(customFields).length > 0
+        ? { custom_fields: customFields }
         : {}),
       uniqueness_key: idempotencyKey,
     });

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -97,6 +97,11 @@ export const CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY =
 export const CONTRACT_CREDIT_TYPE_EXCESS = "excess";
 export const CONTRACT_CREDIT_TYPE_POOL = "pool";
 
+// Stamped on commits that were granted with a customer purchase order
+// reference (currently set by the `grant-awu-credits` Poke plugin). Lets the
+// PO number flow through to the Metronome-generated Stripe invoice.
+export const PURCHASE_ORDER_ID_CUSTOM_FIELD_KEY = "DUST_PURCHASE_ORDER_ID";
+
 // Suffix appended to the annual variant of each seat product name in
 // Metronome (e.g. "Pro Seat (Yearly)"). Used by the setup script when
 // declaring products and by the UI to strip the suffix from displayed seat

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -97,11 +97,6 @@ export const CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY =
 export const CONTRACT_CREDIT_TYPE_EXCESS = "excess";
 export const CONTRACT_CREDIT_TYPE_POOL = "pool";
 
-// Stamped on commits that were granted with a customer purchase order
-// reference (currently set by the `grant-awu-credits` Poke plugin). Lets the
-// PO number flow through to the Metronome-generated Stripe invoice.
-export const PURCHASE_ORDER_ID_CUSTOM_FIELD_KEY = "DUST_PURCHASE_ORDER_ID";
-
 // Suffix appended to the annual variant of each seat product name in
 // Metronome (e.g. "Pro Seat (Yearly)"). Used by the setup script when
 // declaring products and by the UI to strip the suffix from displayed seat

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -27,7 +27,6 @@ import {
   PLAN_CODE_CUSTOM_FIELD_KEY,
   PROD_CREDIT_TYPE_AWU_ID,
   PROD_CREDIT_TYPE_PROG_USD_ID,
-  PURCHASE_ORDER_ID_CUSTOM_FIELD_KEY,
   SEAT_PRODUCT_YEARLY_SUFFIX,
   SEAT_TYPE_CUSTOM_FIELD_KEY,
   STRIPE_PRODUCT_ID_CUSTOM_FIELD_KEY,
@@ -3056,10 +3055,6 @@ const CUSTOM_FIELD_KEYS: Array<{
     entity: "contract_credit",
     key: CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
   },
-  // Stamped on individual commits to carry the customer's purchase order
-  // reference through to the Metronome-generated Stripe invoice. Set by the
-  // `grant-awu-credits` Poke plugin when the operator fills in a PO number.
-  { entity: "commit", key: PURCHASE_ORDER_ID_CUSTOM_FIELD_KEY },
   // Stamped on each seat-style product (Workspace / Pro / Max / Free).
   // Runtime code reads `product.custom_fields.DUST_SEAT_TYPE` (cached in
   // Redis) instead of comparing product names/IDs, which change on every

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -27,6 +27,7 @@ import {
   PLAN_CODE_CUSTOM_FIELD_KEY,
   PROD_CREDIT_TYPE_AWU_ID,
   PROD_CREDIT_TYPE_PROG_USD_ID,
+  PURCHASE_ORDER_ID_CUSTOM_FIELD_KEY,
   SEAT_PRODUCT_YEARLY_SUFFIX,
   SEAT_TYPE_CUSTOM_FIELD_KEY,
   STRIPE_PRODUCT_ID_CUSTOM_FIELD_KEY,
@@ -3035,7 +3036,7 @@ async function syncPackages(): Promise<void> {
 // ---------------------------------------------------------------------------
 
 const CUSTOM_FIELD_KEYS: Array<{
-  entity: "contract" | "contract_product" | "contract_credit";
+  entity: "contract" | "contract_product" | "contract_credit" | "commit";
   key: string;
 }> = [
   { entity: "contract", key: "MAU_TIERS" },
@@ -3055,6 +3056,10 @@ const CUSTOM_FIELD_KEYS: Array<{
     entity: "contract_credit",
     key: CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
   },
+  // Stamped on individual commits to carry the customer's purchase order
+  // reference through to the Metronome-generated Stripe invoice. Set by the
+  // `grant-awu-credits` Poke plugin when the operator fills in a PO number.
+  { entity: "commit", key: PURCHASE_ORDER_ID_CUSTOM_FIELD_KEY },
   // Stamped on each seat-style product (Workspace / Pro / Max / Free).
   // Runtime code reads `product.custom_fields.DUST_SEAT_TYPE` (cached in
   // Redis) instead of comparing product names/IDs, which change on every

--- a/front/types/poke/plugins.ts
+++ b/front/types/poke/plugins.ts
@@ -2,16 +2,20 @@ import { z } from "zod";
 
 import type { LightWorkspaceType } from "../user";
 
+export interface DependsOnCondition {
+  field: string;
+  value: boolean;
+}
+
 interface BaseArgDefinition {
   description?: string;
   label: string;
   redact?: boolean;
   async?: boolean;
   asyncDescription?: boolean;
-  dependsOn?: {
-    field: string;
-    value: boolean;
-  };
+  // A single condition, or an array of conditions ANDed together — the field
+  // renders only when every condition matches.
+  dependsOn?: DependsOnCondition | DependsOnCondition[];
 }
 
 type AtLeastTwoElements<T> = readonly [T, T, ...T[]];


### PR DESCRIPTION
## Description

Follow-up to the `grant-awu-credits` Poke plugin (#26419), adding two operator-facing features:

1. **Purchase Order ID** – an optional PO number field that is stamped as a `DUST_PURCHASE_ORDER_ID` custom field on the Metronome commit and in the commit name.
2. **Fixed/manual price** – a `Set Price` toggle + `Total invoice price` field that lets operators bypass the standard AWU rate and discount computation and supply the invoice amount directly. When enabled, the `Override Default Discount` and `AWU Discount (%)` fields are hidden.

To support the new conditional visibility rules, the plugin form's `dependsOn` type is extended from a single condition to an array of conditions (ANDed together), and `createMetronomeCommit` gains an optional `customFields` parameter passed as `custom_fields` to the Metronome API. The new `DUST_PURCHASE_ORDER_ID` custom field key is also registered for the `commit` entity in the Metronome setup script.

## Tests

Manual testing via the Poke UI: verify PO number flows through to the Metronome commit custom fields on a Stripe invoice, and that the fixed-price toggle correctly hides discount fields and uses the operator-supplied amount.

## Risk

Low. The new fields are all optional and gated behind toggles. The `dependsOn` array extension is backward-compatible (a single-condition object is still accepted). The `customFields` parameter on `createMetronomeCommit` is optional and does not affect existing callers.

## Deploy Plan

- Run `metronome_setup.ts` to register the `DUST_PURCHASE_ORDER_ID` custom field on the `commit` entity in Metronome before or after deploying.
- Deploy `front`.