### PR TITLE
Prevent top-up for enterprises

### DIFF
--- a/front-api/routes/w/[wId]/subscriptions/awu-purchase.ts
+++ b/front-api/routes/w/[wId]/subscriptions/awu-purchase.ts
@@ -85,6 +85,15 @@ app.post(
                 "AWU credit purchases are not available for legacy plan workspaces.",
             },
           });
+        case "enterprise_plan":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "AWU credit purchases are not available for Enterprise workspaces. Please contact your Dust sales representative.",
+            },
+          });
         case "no_stripe_customer":
           return apiError(ctx, {
             status_code: 400,

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -9,7 +9,7 @@ import { UsageNotificationsCard } from "@app/components/workspace/usage/UsageNot
 import { UsageSettingsCard } from "@app/components/workspace/usage/UsageSettingsCard";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
-import { isUpgraded } from "@app/lib/plans/plan_codes";
+import { isEntreprisePlanPrefix, isUpgraded } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
 import {
   useAwuPoolSummary,
@@ -186,6 +186,7 @@ export function UsagePage() {
   const isSeatBased = Object.keys(seatPlans).length > 1;
 
   const plan = subscription.plan;
+  const isEnterprise = isEntreprisePlanPrefix(plan.code);
   const isManualInvitationsEnabled =
     owner.metadata?.disableManualInvitations !== true;
 
@@ -264,13 +265,29 @@ export function UsagePage() {
                       {formatCredits(overageCredits)} Overage
                     </span>
                   )}
-                  <button
-                    className="flex cursor-pointer items-center gap-1 text-xs font-medium text-highlight-500 dark:text-highlight-500-night"
-                    onClick={() => setShowBuyCreditDialog(true)}
-                  >
-                    <Icon visual={ArrowUpIcon} size="xs" />
-                    Top up
-                  </button>
+                  {isEnterprise ? (
+                    <Tooltip
+                      tooltipTriggerAsChild
+                      label="Contact your Dust sales representative to top up."
+                      trigger={
+                        <button
+                          className="flex items-center gap-1 text-xs font-medium text-highlight-500 opacity-50 dark:text-highlight-500-night"
+                          disabled
+                        >
+                          <Icon visual={ArrowUpIcon} size="xs" />
+                          Top up
+                        </button>
+                      }
+                    />
+                  ) : (
+                    <button
+                      className="flex cursor-pointer items-center gap-1 text-xs font-medium text-highlight-500 dark:text-highlight-500-night"
+                      onClick={() => setShowBuyCreditDialog(true)}
+                    >
+                      <Icon visual={ArrowUpIcon} size="xs" />
+                      Top up
+                    </button>
+                  )}
                 </div>
               </div>
             )}

--- a/front/lib/credits/awu_purchase.ts
+++ b/front/lib/credits/awu_purchase.ts
@@ -19,6 +19,7 @@ import {
   getCreditTypeAwuId,
   getProductPrepaidCommitId,
 } from "@app/lib/metronome/constants";
+import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
 import { getStripeClient } from "@app/lib/plans/stripe";
 import logger from "@app/logger/logger";
 import type { SupportedCurrency } from "@app/types/currency";
@@ -40,6 +41,7 @@ export type AwuPurchaseInfo =
       reason:
         | "not_metronome_billed"
         | "legacy_plan"
+        | "enterprise_plan"
         | "no_stripe_customer"
         | "pending_purchase";
     }
@@ -57,6 +59,7 @@ export type AwuPurchaseResult = {
 export type AwuPurchaseError =
   | { code: "not_metronome_billed" }
   | { code: "legacy_plan" }
+  | { code: "enterprise_plan" }
   | { code: "no_stripe_customer" }
   | { code: "pending_purchase" }
   | { code: "invalid_amount"; message: string }
@@ -109,6 +112,10 @@ async function checkAwuPurchaseEligibility(
 
   if (!isCreditPricedPlan(subscription.plan)) {
     return new Err({ code: "legacy_plan" });
+  }
+
+  if (isEntreprisePlanPrefix(subscription.plan.code)) {
+    return new Err({ code: "enterprise_plan" });
   }
 
   const stripeCustomerResult =

--- a/front/pages/api/w/[wId]/subscriptions/awu-purchase.ts
+++ b/front/pages/api/w/[wId]/subscriptions/awu-purchase.ts
@@ -106,6 +106,15 @@ async function handler(
                   "AWU credit purchases are not available for legacy plan workspaces.",
               },
             });
+          case "enterprise_plan":
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message:
+                  "AWU credit purchases are not available for Enterprise workspaces. Please contact your Dust sales representative.",
+              },
+            });
           case "no_stripe_customer":
             return apiError(req, res, {
               status_code: 400,


### PR DESCRIPTION
## Description

Enterprise workspaces have custom contracts managed through Metronome and Dust's sales team, so self-service AWU credit top-ups don't apply to them. This PR adds an `enterprise_plan` guard at both the API layer and the UI layer: the eligibility check in `awu_purchase.ts` now returns an `enterprise_plan` error for any plan matching `isEntreprisePlanPrefix`, the API routes (`front-api` and `pages/api`) handle this new error code with a 400 and a message redirecting users to their sales rep, and the "Top up" button on `UsagePage` is replaced by a disabled button with a tooltip for enterprise workspaces.


## Risk

Low. This is a purely additive guard — no schema changes, no behavioral impact on non-enterprise plans.

## Deploy Plan

Deploy front.