### PR TITLE
[front] feat: add Ashby openings MCP tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -51,6 +51,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_referral_form": "never_ask",
     "get_report_data": "never_ask",
     "list_job_postings": "never_ask",
+    "list_openings": "never_ask",
     "search_candidates": "never_ask",
     "update_job_posting": "high",
   },

--- a/front/lib/api/actions/servers/ashby/client.ts
+++ b/front/lib/api/actions/servers/ashby/client.ts
@@ -18,6 +18,8 @@ import type {
   AshbyOffer,
   AshbyOfferInfoRequest,
   AshbyOfferListRequest,
+  AshbyOpening,
+  AshbyOpeningListRequest,
   AshbyReferralCreateRequest,
   AshbyReportSynchronousRequest,
   AshbyUserSearchRequest,
@@ -37,6 +39,7 @@ import {
   AshbyJobSchema,
   AshbyOfferInfoResponseSchema,
   AshbyOfferListResponseSchema,
+  AshbyOpeningListResponseSchema,
   AshbyReferralCreateResponseSchema,
   AshbyReferralFormInfoResponseSchema,
   AshbyReportSynchronousResponseSchema,
@@ -243,6 +246,24 @@ export class AshbyClient {
       "application.info",
       request,
       AshbyApplicationInfoResponseSchema
+    );
+  }
+
+  async listOpenings(request: AshbyOpeningListRequest): Promise<
+    Result<
+      {
+        results: AshbyOpening[];
+        moreDataAvailable?: boolean;
+        nextCursor?: string;
+      },
+      Error
+    >
+  > {
+    return this.postRequest(
+      "opening.list",
+      request,
+      AshbyOpeningListResponseSchema,
+      { isPaginated: true }
     );
   }
 

--- a/front/lib/api/actions/servers/ashby/metadata.ts
+++ b/front/lib/api/actions/servers/ashby/metadata.ts
@@ -71,6 +71,35 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
       done: "Retrieve candidate notes from Ashby",
     },
   },
+  list_openings: {
+    description:
+      "List openings in Ashby. Returns a paginated page of openings with " +
+      "their state, archive status, latest version details, linked jobs, " +
+      "hiring team, and custom fields.",
+    schema: {
+      cursor: z
+        .string()
+        .optional()
+        .describe(
+          "Opaque cursor returned by a previous list_openings call. " +
+            "Use this to retrieve the next page."
+        ),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .optional()
+        .describe(
+          "Maximum number of openings to return. Defaults to 100, which is also Ashby's maximum."
+        ),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Listing openings from Ashby",
+      done: "List openings from Ashby",
+    },
+  },
   create_candidate_note: {
     description:
       "Create a note on a candidate's profile in Ashby. " +

--- a/front/lib/api/actions/servers/ashby/rendering.ts
+++ b/front/lib/api/actions/servers/ashby/rendering.ts
@@ -7,6 +7,7 @@ import type {
   AshbyJobInfo,
   AshbyJobPosting,
   AshbyOfferInfo,
+  AshbyOpening,
   AshbyReferralFormInfo,
   AshbyReportSynchronousResponse,
 } from "@app/lib/api/actions/servers/ashby/types";
@@ -222,6 +223,98 @@ export function renderJobPostingList(postings: AshbyJobPosting[]): string {
           ? `\n  Compensation: ${p.compensationTierSummary}`
           : "")
     )
+    .join("\n\n");
+}
+
+function truncateSingleLine(value: string, maxLength: number): string {
+  const singleLine = value.replace(/\s+/g, " ").trim();
+
+  if (singleLine.length <= maxLength) {
+    return singleLine;
+  }
+
+  return `${singleLine.slice(0, maxLength - 3)}...`;
+}
+
+function formatOpeningValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value.map(formatFieldValue).join(", ");
+  }
+
+  return formatFieldValue(value);
+}
+
+export function renderOpeningList(openings: AshbyOpening[]): string {
+  return openings
+    .map((opening) => {
+      const version = opening.latestVersion;
+      const title = version?.identifier ?? opening.id;
+      const lines = [
+        `- **${title}** (Opening ID: ${opening.id})`,
+        `  State: ${opening.openingState} | Archived: ${opening.isArchived}`,
+      ];
+
+      if (opening.openedAt) {
+        lines.push(`  Opened: ${new Date(opening.openedAt).toISOString()}`);
+      }
+      if (opening.closedAt) {
+        lines.push(`  Closed: ${new Date(opening.closedAt).toISOString()}`);
+      }
+      if (opening.closeReasonId) {
+        lines.push(`  Close reason ID: ${opening.closeReasonId}`);
+      }
+      if (version?.description) {
+        lines.push(
+          `  Description: ${truncateSingleLine(version.description, 300)}`
+        );
+      }
+      if (version?.jobIds && version.jobIds.length > 0) {
+        lines.push(`  Linked job IDs: ${version.jobIds.join(", ")}`);
+      }
+      if (version?.employmentType) {
+        lines.push(`  Employment type: ${version.employmentType}`);
+      }
+      if (version?.targetHireDate) {
+        lines.push(`  Target hire date: ${version.targetHireDate}`);
+      }
+      if (version?.targetStartDate) {
+        lines.push(`  Target start date: ${version.targetStartDate}`);
+      }
+      if (version?.isBackfill !== undefined) {
+        lines.push(`  Backfill: ${version.isBackfill}`);
+      }
+      if (version?.locationIds && version.locationIds.length > 0) {
+        lines.push(`  Location IDs: ${version.locationIds.join(", ")}`);
+      }
+      if (version?.hiringTeam && version.hiringTeam.length > 0) {
+        lines.push(
+          `  Hiring team: ${version.hiringTeam
+            .map((member) => {
+              const name = [member.firstName, member.lastName]
+                .filter(Boolean)
+                .join(" ");
+              const person = name || member.email || member.userId;
+
+              return [member.role, person].filter(Boolean).join(": ");
+            })
+            .join("; ")}`
+        );
+      }
+      if (version?.customFields && version.customFields.length > 0) {
+        lines.push(
+          `  Custom fields: ${version.customFields
+            .map((field) => {
+              const title = field.title ?? field.id ?? "Unknown";
+              const value = field.valueLabel ?? field.value;
+
+              return `${title}: ${formatOpeningValue(value)}`;
+            })
+            .join("; ")}`
+        );
+      }
+
+      return lines.join("\n");
+    })
     .join("\n\n");
 }
 

--- a/front/lib/api/actions/servers/ashby/tools/index.ts
+++ b/front/lib/api/actions/servers/ashby/tools/index.ts
@@ -25,6 +25,7 @@ import {
   renderHireData,
   renderInterviewFeedbackRecap,
   renderJobPostingList,
+  renderOpeningList,
   renderReferralForm,
   renderReport,
 } from "@app/lib/api/actions/servers/ashby/rendering";
@@ -311,6 +312,59 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
       {
         type: "text" as const,
         text: notesText,
+      },
+    ]);
+  },
+
+  list_openings: async ({ cursor, limit }, extra) => {
+    const clientResult = getAshbyClient(extra);
+    if (clientResult.isErr()) {
+      return clientResult;
+    }
+
+    const client = clientResult.value;
+
+    const result = await client.listOpenings({
+      cursor,
+      limit,
+    });
+
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(`Failed to list openings: ${result.error.message}`)
+      );
+    }
+
+    const { results: openings, moreDataAvailable, nextCursor } = result.value;
+
+    if (openings.length === 0) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: "No openings found.",
+        },
+      ]);
+    }
+
+    const lines = [
+      `Found ${openings.length} opening(s):`,
+      "",
+      renderOpeningList(openings),
+    ];
+
+    if (moreDataAvailable) {
+      lines.push(
+        "",
+        nextCursor
+          ? `More openings are available. Call list_openings with cursor: ${nextCursor}`
+          : "More openings are available, but Ashby did not return a next cursor."
+      );
+    }
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: lines.join("\n"),
       },
     ]);
   },

--- a/front/lib/api/actions/servers/ashby/types.ts
+++ b/front/lib/api/actions/servers/ashby/types.ts
@@ -265,6 +265,95 @@ export type AshbyApplicationInfoResponse = z.infer<
   typeof AshbyApplicationInfoResponseSchema
 >;
 
+// Opening list
+
+export const AshbyOpeningStateSchema = z.enum([
+  "Approved",
+  "Closed",
+  "Draft",
+  "Filled",
+  "Open",
+]);
+
+export type AshbyOpeningState = z.infer<typeof AshbyOpeningStateSchema>;
+
+export const AshbyOpeningLatestVersionSchema = z
+  .object({
+    id: z.string(),
+    identifier: z.string().optional(),
+    description: z.string().nullish(),
+    authorId: z.string().optional(),
+    createdAt: z.string().optional(),
+    teamId: z.string().nullish(),
+    jobIds: z.array(z.string()).optional(),
+    targetHireDate: z.string().nullish(),
+    targetStartDate: z.string().nullish(),
+    isBackfill: z.boolean().optional(),
+    employmentType: z.string().nullish(),
+    locationIds: z.array(z.string()).optional(),
+    hiringTeam: z
+      .array(
+        z
+          .object({
+            email: z.string().optional(),
+            firstName: z.string().optional(),
+            lastName: z.string().optional(),
+            role: z.string().optional(),
+            userId: z.string().optional(),
+          })
+          .passthrough()
+      )
+      .optional(),
+    customFields: z
+      .array(
+        z
+          .object({
+            id: z.string().optional(),
+            isPrivate: z.boolean().optional(),
+            title: z.string().optional(),
+            valueLabel: z.union([z.string(), z.array(z.string())]).optional(),
+            value: z.unknown().optional(),
+          })
+          .passthrough()
+      )
+      .optional(),
+  })
+  .passthrough();
+
+export type AshbyOpeningLatestVersion = z.infer<
+  typeof AshbyOpeningLatestVersionSchema
+>;
+
+export const AshbyOpeningSchema = z
+  .object({
+    id: z.string(),
+    openedAt: z.string().nullish(),
+    closedAt: z.string().nullish(),
+    isArchived: z.boolean(),
+    archivedAt: z.string().nullish(),
+    closeReasonId: z.string().nullish(),
+    openingState: AshbyOpeningStateSchema,
+    latestVersion: AshbyOpeningLatestVersionSchema.nullish(),
+  })
+  .passthrough();
+
+export type AshbyOpening = z.infer<typeof AshbyOpeningSchema>;
+
+export const AshbyOpeningListRequestSchema = z.object({
+  cursor: z.string().optional(),
+  limit: z.number().int().min(1).max(100).optional(),
+});
+
+export type AshbyOpeningListRequest = z.infer<
+  typeof AshbyOpeningListRequestSchema
+>;
+
+export const AshbyOpeningListResponseSchema = z.array(AshbyOpeningSchema);
+
+export type AshbyOpeningListResponse = z.infer<
+  typeof AshbyOpeningListResponseSchema
+>;
+
 // Job list
 
 export const AshbyJobSchema = z


### PR DESCRIPTION
## Description

- Goal is to let agents list Ashby openings directly from the Ashby MCP server.
- This adds typed client support for Ashby's paginated `opening.list` endpoint and exposes a read-only `list_openings` tool with `cursor` / `limit` pagination.
- The tool renders the key opening state, latest version details, linked jobs, hiring team, custom fields, and next cursor guidance when more pages are available.

## Tests

- Tested locally.

## Risk

- Low. Read-only Ashby MCP tool. Additive.

## Deploy Plan

- Deploy front.
