### PR TITLE
[front] enh: strip skill reference presentation from prompts

### DIFF
--- a/front/lib/api/assistant/skills_rendering.test.ts
+++ b/front/lib/api/assistant/skills_rendering.test.ts
@@ -1,9 +1,10 @@
 import { getEnabledSkillInstructions } from "@app/lib/api/assistant/skills_rendering";
+import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { describe, expect, it } from "vitest";
 
-type SkillInstructionsSource = Parameters<
-  typeof getEnabledSkillInstructions
->[0];
+type SkillInstructionsSource = Pick<SkillResource, "name" | "instructions"> & {
+  extendedSkill: Pick<SkillResource, "instructions"> | null;
+};
 
 function makeEnabledSkill(
   overrides: Partial<SkillInstructionsSource>
@@ -28,6 +29,20 @@ describe("getEnabledSkillInstructions", () => {
     );
     expect(getEnabledSkillInstructions(skill)).not.toContain(
       'icon="GithubLogo"'
+    );
+  });
+
+  it("strips skill icon attributes from model-facing skill instructions", () => {
+    const skill = makeEnabledSkill({
+      instructions:
+        'Use <skill id="skill_123" name="Create memo" icon="book_open" />.',
+    });
+
+    expect(getEnabledSkillInstructions(skill)).toContain(
+      '<skill id="skill_123" name="Create memo" />'
+    );
+    expect(getEnabledSkillInstructions(skill)).not.toContain(
+      'icon="book_open"'
     );
   });
 });

--- a/front/lib/api/assistant/skills_rendering.ts
+++ b/front/lib/api/assistant/skills_rendering.ts
@@ -4,6 +4,7 @@ import {
 } from "@app/lib/actions/constants";
 import { SKILL_MANAGEMENT_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { stripSkillTagPresentationAttributes } from "@app/lib/skills/format";
 import { stripToolTagPresentationAttributes } from "@app/lib/tools/format";
 import type { UserMessageTypeModel } from "@app/types/assistant/generation";
 
@@ -19,19 +20,26 @@ function renderSystemSkillMessage(text: string): UserMessageTypeModel {
   };
 }
 
+function stripInstructionPresentationAttributes(content: string): string {
+  return stripSkillTagPresentationAttributes(
+    stripToolTagPresentationAttributes(content)
+  );
+}
+
 export function getEnabledSkillInstructions(
   skill: Pick<SkillResource, "name" | "instructions"> & {
     extendedSkill: Pick<SkillResource, "instructions"> | null;
   }
 ): string {
   const { name, instructions, extendedSkill } = skill;
-  const modelInstructions = stripToolTagPresentationAttributes(instructions);
+  const modelInstructions =
+    stripInstructionPresentationAttributes(instructions);
 
   if (!extendedSkill) {
     return `<${name}>\n${modelInstructions}\n</${name}>`;
   }
 
-  const extendedModelInstructions = stripToolTagPresentationAttributes(
+  const extendedModelInstructions = stripInstructionPresentationAttributes(
     extendedSkill.instructions
   );
 

--- a/front/lib/reinforcement/analyze_conversation.test.ts
+++ b/front/lib/reinforcement/analyze_conversation.test.ts
@@ -83,6 +83,19 @@ describe("buildSkillAnalysisPrompt", () => {
     expect(userMessage).not.toContain('icon="GithubLogo"');
   });
 
+  it("strips skill icon attributes from instructionsHtml in the user message", () => {
+    const skill = makeSkill({
+      instructionsHtml:
+        '<p>Use <skill id="skill_123" name="Create memo" icon="book_open"></skill>.</p>',
+    });
+    const { userMessage } = buildSkillAnalysisPrompt("User: hello", [skill]);
+
+    expect(userMessage).toContain(
+      '<skill id="skill_123" name="Create memo" />'
+    );
+    expect(userMessage).not.toContain('icon="book_open"');
+  });
+
   it("omits instructions when null", () => {
     const skill = makeSkill({ instructions: null, instructionsHtml: null });
     const { userMessage } = buildSkillAnalysisPrompt("User: hello", [skill]);

--- a/front/lib/reinforcement/format_skill_context.ts
+++ b/front/lib/reinforcement/format_skill_context.ts
@@ -1,3 +1,4 @@
+import { stripSkillTagPresentationAttributes } from "@app/lib/skills/format";
 import { stripToolTagPresentationAttributes } from "@app/lib/tools/format";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import { escapeXml } from "@app/types/shared/utils/string_utils";
@@ -18,8 +19,8 @@ export function formatSkillContext(skill: SkillType): string {
     : "";
 
   const instructionsBlock = skill.instructionsHtml
-    ? `<instructions format="html">${stripToolTagPresentationAttributes(
-        skill.instructionsHtml
+    ? `<instructions format="html">${stripSkillTagPresentationAttributes(
+        stripToolTagPresentationAttributes(skill.instructionsHtml)
       )}</instructions>`
     : "";
 

--- a/front/lib/skills/format.ts
+++ b/front/lib/skills/format.ts
@@ -9,6 +9,8 @@ export const SKILL_TAG_NAME = "skill";
 export const SKILL_TAG_REGEX = /<skill\s+([^>]*?)\s*\/>/g;
 export const SKILL_TAG_REGEX_BEGINNING = /^<skill\s+([^>]*?)\s*\/>/;
 
+const SKILL_ELEMENT_REGEX = /<skill\b([^>]*)>[\s\S]*?<\/skill>/g;
+
 function parseSkillTagAttributes(attributes: string): SkillReference | null {
   const id = attributes.match(/\bid="([^"]+)"/)?.[1];
   const name = attributes.match(/\bname="([^"]+)"/)?.[1];
@@ -49,4 +51,30 @@ export function serializeSkillTag({ id, name, icon }: SkillReference): string {
   const iconAttribute = icon ? ` icon="${icon}"` : "";
 
   return `<${SKILL_TAG_NAME} id="${id}" name="${name}"${iconAttribute} />`;
+}
+
+export function stripSkillTagPresentationAttributes(content: string): string {
+  return content
+    .replace(SKILL_ELEMENT_REGEX, (tag, attributes: string) => {
+      const skill = parseSkillTag(`<${SKILL_TAG_NAME}${attributes} />`);
+      if (!skill) {
+        return tag.replace(/(<skill\b[^>]*?)\s+icon="[^"]*"/, "$1");
+      }
+
+      return serializeSkillTag({
+        ...skill,
+        icon: null,
+      });
+    })
+    .replace(SKILL_TAG_REGEX, (tag) => {
+      const skill = parseSkillTag(tag);
+      if (!skill) {
+        return tag.replace(/\s+icon="[^"]*"/g, "");
+      }
+
+      return serializeSkillTag({
+        ...skill,
+        icon: null,
+      });
+    });
 }


### PR DESCRIPTION
## Description

Follow up on the tool-reference prompt stripping for skill references. Skill chips serialize presentation-only `icon` metadata for UI display, but model-facing prompts only need the stable skill reference data.

This PR strips `icon` from `<skill ...>` tags when rendering enabled skill instructions and reinforcement skill context, while preserving `id` and `name`. It handles both self-closing skill tags and stored HTML skill elements.

## Tests

- Updated existing tests.
- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
