### PR TITLE
[front] enh: tweak skills prompt wrt skills in user messages

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -218,6 +218,8 @@ function constructSkillsSection({
     `If a user message contains a \`<skill id=\"...\" name=\"...\" />\` tag, treat it as a strong hint that the ` +
     "referenced skill is relevant: it means the user specifically mentioned this skill. If the skill is not already " +
     `enabled, and it would help, enable it with \`${toolDisplayName}\`.\n` +
+    "It is expected that these skills do not appear in the list of available skills, they are specifically requested " +
+    "by the user and can be enabled safely." +
     "Only enable skills you actually need, enabling a skill loads its full instructions into context.\n" +
     "If you need to enable multiple skills, enable them in parallel.\n\n" +
     "When in doubt about enabling a skill, prefer enabling it as it may give you a new " +


### PR DESCRIPTION
## Description

- This PR tweaks the prompt for skills to prevent situations where the model is reticent to enable a skill that was mentioned by a user, based on the observation that it is not listed in the available skills.
- More context [here](https://dust4ai.slack.com/archives/C0A04EWRV0E/p1780070068117709).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
