### PR TITLE
Refactored packages and reorganized setup file

### DIFF
--- a/front/lib/metronome/setup_common.ts
+++ b/front/lib/metronome/setup_common.ts
@@ -1,0 +1,503 @@
+/**
+ * Metronome setup — common building blocks shared by the legacy and new-pricing
+ * catalogs: the desired-state types, the resolved-environment credit accessors,
+ * shared constants, the metric/product catalog, and the generic factories.
+ *
+ * Pure description: no side effects, never talks to Metronome. The legacy plans
+ * live in `setup_legacy.ts`, the new-pricing plans in `setup_new_pricing.ts`,
+ * and the reconciliation logic in `scripts/metronome_setup.ts`.
+ *
+ * Environment: builders that need the AWU / Programmatic-USD credit type ids
+ * (which differ between sandbox and production) read the value set once by the
+ * setup script via `setMetronomeEnv`.
+ */
+
+import {
+  AWU_PRICE_PER_CREDIT,
+  metronomeAmount,
+} from "@app/lib/metronome/amounts";
+import {
+  DEV_CREDIT_TYPE_AWU_ID,
+  DEV_CREDIT_TYPE_PROG_USD_ID,
+  PROD_CREDIT_TYPE_AWU_ID,
+  PROD_CREDIT_TYPE_PROG_USD_ID,
+  SEAT_PRODUCT_YEARLY_SUFFIX,
+  SEAT_TYPE_CUSTOM_FIELD_KEY,
+} from "@app/lib/metronome/constants";
+import { EXCESS_CREDIT_NAME } from "@app/lib/metronome/types";
+import type { SupportedCurrency } from "@app/types/currency";
+
+// ---------------------------------------------------------------------------
+// Types for desired state definitions
+// ---------------------------------------------------------------------------
+
+export interface MetricDef {
+  name: string;
+  event_type_filter: { in_values: string[] };
+  property_filters: Array<{
+    name: string;
+    exists?: boolean;
+    in_values?: string[];
+  }>;
+  aggregation_type: "SUM" | "COUNT" | "max";
+  aggregation_key?: string;
+  group_keys?: string[][];
+}
+
+export interface ProductDef {
+  name: string;
+  type: "USAGE" | "SUBSCRIPTION" | "FIXED";
+  billable_metric_name?: string;
+  quantity_conversion?: {
+    conversion_factor: number;
+    operation: "DIVIDE" | "MULTIPLY";
+  };
+  quantity_rounding?: {
+    decimal_places: number;
+    rounding_method: "ROUND_UP" | "ROUND_DOWN" | "ROUND_HALF_UP";
+  };
+  pricing_group_key?: string[];
+  presentation_group_key?: string[];
+  tags?: string[];
+  /**
+   * Custom fields stamped on the product. Reconciled via `setValues` so a
+   * field change does NOT trigger a product recreate.
+   */
+  custom_fields?: Record<string, string>;
+}
+
+export interface RateDef {
+  product_name: string;
+  starting_at: string;
+  entitled: boolean;
+  rate_type: string;
+  price: number;
+  billing_frequency?: string;
+  credit_type_id?: string;
+  pricing_group_values?: Record<string, string>;
+}
+
+export interface RateCardDef {
+  name: string;
+  description: string;
+  aliases: Array<{ name: string }>;
+  fiat_credit_type_id: string;
+  credit_type_conversions?: Array<{
+    custom_credit_type_id: string;
+    fiat_per_custom_credit: number;
+  }>;
+  rates: RateDef[];
+}
+
+export interface PackageSubscription {
+  temporary_id: string;
+  product_name: string; // resolved to product ID at runtime
+  billing_frequency: "MONTHLY" | "QUARTERLY" | "ANNUAL" | "WEEKLY";
+  collection_schedule: "ADVANCE" | "ARREARS";
+  quantity_management_mode: "SEAT_BASED" | "QUANTITY_ONLY";
+  seat_config?: { seat_group_key: string };
+  /** Required for QUANTITY_ONLY mode — initial seat count (set at contract creation). */
+  initial_quantity?: number;
+  proration?: {
+    is_prorated: boolean;
+    invoice_behavior?: "BILL_IMMEDIATELY" | "BILL_ON_NEXT_COLLECTION_DATE";
+  };
+}
+
+export interface RecurringCreditDef {
+  product_name: string; // resolved to product ID at runtime
+  access_amount: {
+    credit_type_id: string; // evaluated after detectEnvironment()
+    unit_price: number;
+    quantity?: number;
+  };
+  commit_duration: { value: number; unit?: "PERIODS" };
+  priority: number;
+  starting_at_offset: {
+    unit: "DAYS" | "WEEKS" | "MONTHS" | "YEARS";
+    value: number;
+  };
+  applicable_product_tags?: string[];
+  // Mutually exclusive with applicable_product_tags. Filters drawdown by
+  // pricing/presentation group values (e.g. { is_free_usage: "true" }).
+  specifiers?: Array<{
+    presentation_group_values?: Record<string, string>;
+    pricing_group_values?: Record<string, string>;
+    product_tags?: string[];
+  }>;
+  recurrence_frequency?: "MONTHLY" | "QUARTERLY" | "ANNUAL" | "WEEKLY";
+  // Optional. Offset relative to the recurring credit start that determines
+  // when the contract will stop creating recurring commits. Use a very small
+  // value (e.g. 1 day) to make the credit one-shot — Metronome fires the
+  // first commit on contract start, then the duration expires before the
+  // next would be issued.
+  duration?: {
+    unit: "DAYS" | "WEEKS" | "MONTHS" | "YEARS";
+    value: number;
+  };
+  name?: string;
+  // Attach the credit to a SEAT_BASED subscription so each seat gets its own
+  // allocation (INDIVIDUAL) or all seats share one pool (POOLED).
+  // `subscription_temporary_id` references the `temporary_id` of a Subscription
+  // defined in the same package payload.
+  subscription_config?: {
+    subscription_temporary_id: string;
+    allocation: "INDIVIDUAL" | "POOLED";
+    apply_seat_increase_config: { is_prorated: boolean };
+  };
+}
+
+// Package-level entitlement override for a specific product on the package's
+// rate card, applied from contract start. All non-legacy rate cards carry every
+// seat product at `entitled: false` with a 0 baseline price; each package uses
+// overrides to flip on (entitled → true) the seats it sells and stamp their
+// flat rate. When `price` is set, an `overwrite_rate` is applied on top of the
+// rate-card rate (rate_type FLAT). When `price` is omitted, only `entitled` is
+// flipped.
+export interface PackageOverrideDef {
+  product_name: string;
+  entitled: boolean;
+  // Optional flat-rate override (in the rate card's fiat unit). Requires
+  // `credit_type_id` to identify the pricing unit.
+  price?: number;
+  credit_type_id?: string;
+  // Billing frequency of the targeted rate. Required when overwriting a
+  // SUBSCRIPTION product's rate — Metronome rejects a flat-rate overwrite on a
+  // subscription product without it.
+  billing_frequency?: "MONTHLY" | "ANNUAL";
+}
+
+export interface PackageDef {
+  // Base name without version suffix. Version is auto-computed at sync time.
+  name: string;
+  aliases: Array<{ name: string }>;
+  rate_card_name: string;
+  subscriptions?: PackageSubscription[];
+  // Billing cycle anchored to contract start date (matches Stripe subscription anniversary).
+  billing_anchor_date?: "contract_start_date" | "first_billing_period";
+  usage_statement_schedule?: {
+    frequency: "MONTHLY" | "QUARTERLY" | "ANNUAL" | "WEEKLY";
+    day?: "CONTRACT_START" | "FIRST_OF_MONTH";
+  };
+  // Consolidate scheduled/commit charges onto the usage invoice instead of separate invoices.
+  scheduled_charges_on_usage_invoices?: "ALL";
+  recurring_credits?: RecurringCreditDef[];
+  overrides?: PackageOverrideDef[];
+}
+// A seat type's monthly + annual subscriptions.
+export interface SeatSubscriptionPair {
+  monthly: PackageSubscription;
+  annual: PackageSubscription;
+}
+
+// Environment resolved by the setup script (sandbox vs production), set via
+// `setMetronomeEnv` before any builder that needs credit type ids is called.
+let ENV: "sandbox" | "production" = "sandbox";
+
+export function setMetronomeEnv(env: "sandbox" | "production"): void {
+  ENV = env;
+}
+
+// Credit type accessors based on the script-detected ENV (not NODE_ENV).
+export function getCreditTypeAwuId(): string {
+  return ENV === "sandbox" ? DEV_CREDIT_TYPE_AWU_ID : PROD_CREDIT_TYPE_AWU_ID;
+}
+
+export function getCreditTypeProgrammaticUsdId(): string {
+  return ENV === "sandbox"
+    ? DEV_CREDIT_TYPE_PROG_USD_ID
+    : PROD_CREDIT_TYPE_PROG_USD_ID;
+}
+
+// Number of pricing tiers for any tiered seat-style product (MAU, future).
+// Tier products and rates are derived from the prefix.
+const SEAT_TIER_COUNT = 6;
+
+export const getOverageAwuRate = (currency: SupportedCurrency) => {
+  return metronomeAmount(AWU_PRICE_PER_CREDIT[currency] * 100, currency) * 2;
+};
+
+// Setup-only display names. Runtime code identifies seat-style subscriptions
+// via the `DUST_SEAT_TYPE` custom field on the product (see
+// SEAT_TYPE_CUSTOM_FIELD_KEY), not by name comparison.
+export const WORKSPACE_SEAT_PRODUCT_NAME = "Workspace Seat";
+export const PRO_SEAT_PRODUCT_NAME = "Pro Seat";
+export const MAX_SEAT_PRODUCT_NAME = "Max Seat";
+export const FREE_SEAT_PRODUCT_NAME = "Free Seat";
+export const PRO_SEAT_CREDIT_NAME = "Pro Seat Credits";
+export const MAX_SEAT_CREDIT_NAME = "Max Seat Credits";
+export const FREE_SEAT_CREDIT_NAME = "Free Seat Credits";
+
+// Tag shared by all AI/Tool usage products — use `applicable_product_tags: ["usage"]`
+// on credits/commits to apply them to all usage products at once.
+export const USAGE_TAG = "usage";
+
+// Tag shared by all seat SUBSCRIPTION products (Workspace / Pro / Max / Free,
+// monthly + yearly).
+const SEAT_TAG = "seat";
+
+// Billing-frequency tags stamped on seat products alongside SEAT_TAG so credits
+// / commits can target a single cadence (e.g. `applicable_product_tags:
+// ["seat", "yearly"]`).
+const MONTHLY_TAG = "monthly";
+const YEARLY_TAG = "yearly";
+
+// Billing cycle config shared by all packages — anchored to contract start date.
+export const BILLING_CYCLE_CONFIG = {
+  billing_anchor_date: "contract_start_date" as const,
+  usage_statement_schedule: {
+    frequency: "MONTHLY" as const,
+    day: "CONTRACT_START" as const,
+  },
+};
+
+// "MAU Tier 1", …, "MAU Tier 6".
+function buildSeatTierProductNames(prefix: string): string[] {
+  return Array.from(
+    { length: SEAT_TIER_COUNT },
+    (_, i) => `${prefix} Tier ${i + 1}`
+  );
+}
+
+// SUBSCRIPTION product entries to inject into PRODUCTS for a tiered seat family.
+function buildSeatTierProducts(prefix: string): ProductDef[] {
+  return buildSeatTierProductNames(prefix).map(
+    (name): ProductDef => ({ name, type: "SUBSCRIPTION" })
+  );
+}
+
+// Default rate entries for a tiered seat family on a rate card. Not entitled
+// by default — enabled per contract via overrides with per-tier pricing.
+export function buildSeatTierRates({
+  prefix,
+  creditTypeId,
+}: {
+  prefix: string;
+  creditTypeId: string;
+}): RateDef[] {
+  return buildSeatTierProductNames(prefix).map(
+    (name): RateDef => ({
+      product_name: name,
+      starting_at: "2026-04-01T00:00:00.000Z",
+      entitled: false,
+      rate_type: "FLAT",
+      billing_frequency: "MONTHLY",
+      price: 0,
+      credit_type_id: creditTypeId,
+    })
+  );
+}
+
+export const PRODUCTS: ProductDef[] = [
+  // --- Legacy usage product (USD, 30% markup baked into quantity_conversion) ---
+  {
+    name: "Programmatic Usage",
+    type: "USAGE",
+    billable_metric_name: "LLM Provider Cost (Programmatic)",
+    // Convert cost_micro_usd to billable USD: multiply by 1.3 (30% markup) / 1_000_000 (micro→USD).
+    // The rate card prices at $1.00/unit so the final amount equals the marked-up cost.
+    quantity_conversion: {
+      conversion_factor: 1.3 / 1_000_000,
+      operation: "MULTIPLY",
+    },
+    // Round up to cents (2 decimal places) — never undercharge.
+    quantity_rounding: { decimal_places: 2, rounding_method: "ROUND_UP" },
+    tags: [USAGE_TAG],
+  },
+  // --- New pricing usage products (AWU) ---
+  // 1 AWU = $0.01. AI Usage is priced directly on the cost_awu event property
+  // (no quantity_conversion). Tool Usage: count × tool_weight = AWU (weight
+  // configured per tool category in rate card via pricing_group_values).
+  // Single product per usage type — the metric carries both `user_id` and
+  // `api_key_name` as group keys so per-seat credits and workspace pool credits
+  // are dispatched correctly by Metronome based on the event's properties.
+  {
+    name: "AI Usage",
+    type: "USAGE",
+    billable_metric_name: "LLM Provider Cost AWU",
+    pricing_group_key: ["usage_type"],
+    presentation_group_key: ["user_id"],
+    tags: [USAGE_TAG],
+  },
+  {
+    name: "Tool Usage",
+    type: "USAGE",
+    billable_metric_name: "Tool Invocations",
+    pricing_group_key: ["usage_type", "tool_category"],
+    presentation_group_key: ["user_id"],
+    tags: [USAGE_TAG],
+  },
+  // Workspace Seat — single SUBSCRIPTION product covering both legacy (ANNUAL)
+  // and new (MONTHLY) per-seat plans. Seats synced from membership create/revoke
+  // hooks; price/frequency differs between rate cards.
+  {
+    name: WORKSPACE_SEAT_PRODUCT_NAME,
+    type: "SUBSCRIPTION",
+    custom_fields: { [SEAT_TYPE_CUSTOM_FIELD_KEY]: "workspace" },
+    tags: [SEAT_TAG, MONTHLY_TAG],
+  },
+  {
+    name: WORKSPACE_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
+    type: "SUBSCRIPTION",
+    custom_fields: { [SEAT_TYPE_CUSTOM_FIELD_KEY]: "workspace_yearly" },
+    tags: [SEAT_TAG, YEARLY_TAG],
+  },
+  // Pro Seat / Max Seat — SUBSCRIPTION products for the new Business / Enterprise
+  // seat-based plans. Used as SEAT_BASED subscriptions in packages with per-seat
+  // INDIVIDUAL recurring credits (Pro: 8000 AWU/mo, Max: 40000 AWU/mo).
+  {
+    name: PRO_SEAT_PRODUCT_NAME,
+    type: "SUBSCRIPTION",
+    custom_fields: { [SEAT_TYPE_CUSTOM_FIELD_KEY]: "pro" },
+    tags: [SEAT_TAG, MONTHLY_TAG],
+  },
+  {
+    name: PRO_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
+    type: "SUBSCRIPTION",
+    custom_fields: { [SEAT_TYPE_CUSTOM_FIELD_KEY]: "pro_yearly" },
+    tags: [SEAT_TAG, YEARLY_TAG],
+  },
+  {
+    name: MAX_SEAT_PRODUCT_NAME,
+    type: "SUBSCRIPTION",
+    custom_fields: { [SEAT_TYPE_CUSTOM_FIELD_KEY]: "max" },
+    tags: [SEAT_TAG, MONTHLY_TAG],
+  },
+  {
+    name: MAX_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
+    type: "SUBSCRIPTION",
+    custom_fields: { [SEAT_TYPE_CUSTOM_FIELD_KEY]: "max_yearly" },
+    tags: [SEAT_TAG, YEARLY_TAG],
+  },
+
+  // Free Seat — SUBSCRIPTION product priced at $0/seat. Carries a one-shot
+  // lifetime AWU credit (300 AWU per seat) so free users have a small drawdown
+  // pool without being billed.
+  {
+    name: FREE_SEAT_PRODUCT_NAME,
+    type: "SUBSCRIPTION",
+    custom_fields: { [SEAT_TYPE_CUSTOM_FIELD_KEY]: "free" },
+    tags: [SEAT_TAG, MONTHLY_TAG],
+  },
+  // MAU product — single subscription for simple (non-tiered) enterprise contracts.
+  // Used when no MAU_TIERS custom field is set on the contract.
+  { name: "MAU", type: "SUBSCRIPTION" },
+  // Tiered seat products — one per pricing tier for contracts with graduated
+  // pricing. Not entitled by default; enabled per contract via overrides.
+  // Quantity managed by the MAU/seat sync flow based on the contract's tier
+  // custom field.
+  ...buildSeatTierProducts("MAU"),
+  // MAU Commit — appears as a line item on invoices for the monthly minimum charge.
+  { name: "MAU Commit", type: "FIXED" },
+  // FIXED products for credit grants — separate products for distinct invoice line items.
+  {
+    name: "Free Credits",
+    type: "FIXED",
+  },
+  {
+    name: "Excess Credits",
+    type: "FIXED",
+  },
+  {
+    name: "Prepaid Commit",
+    type: "FIXED",
+  },
+  {
+    name: "Seat Individual Credits",
+    type: "FIXED",
+  },
+  {
+    name: "Seat Subscription Credits",
+    type: "FIXED",
+  },
+];
+
+// Factory for a single seat subscription. All share the same ADVANCE collection
+// schedule and prorated billing; they differ only by product, billing
+// frequency, and quantity-management mode:
+//   - QUANTITY_ONLY (workspace / pooled): quantity set directly, starts at 0.
+//   - SEAT_BASED (pro / max / free): seats keyed by `user_id` so usage events
+//     draw down only the credits attached to the matching seat; the seat count
+//     is driven by add_seat_ids / remove_seat_ids via the contract edit API.
+export function makeSeatSubscription({
+  temporaryId,
+  productName,
+  billingFrequency,
+  mode,
+}: {
+  temporaryId: string;
+  productName: string;
+  billingFrequency: "MONTHLY" | "ANNUAL";
+  mode: "QUANTITY_ONLY" | "SEAT_BASED";
+}): PackageSubscription {
+  return {
+    temporary_id: temporaryId,
+    product_name: productName,
+    billing_frequency: billingFrequency,
+    collection_schedule: "ADVANCE",
+    quantity_management_mode: mode,
+    ...(mode === "QUANTITY_ONLY"
+      ? { initial_quantity: 0 }
+      : { seat_config: { seat_group_key: "user_id" } }),
+    proration: {
+      is_prorated: true,
+      invoice_behavior: "BILL_ON_NEXT_COLLECTION_DATE",
+    },
+  };
+}
+
+// Factory for a seat type's monthly + annual subscriptions in one call. Temp
+// ids are derived as `<base>-sub` / `<base>-annual-sub`. The annual variant
+// normally bills a distinct `*_yearly` product (monthly + annual coexist on one
+// rate card, so they must be separate products); legacy plans set
+// `annualUsesSameProduct` because each legacy rate card carries a single
+// frequency and reuses the same product. Free has no annual, so it uses
+// makeSeatSubscription directly.
+export function makeSeatSubscriptions({
+  baseTemporaryId,
+  productName,
+  mode,
+  annualUsesSameProduct = false,
+}: {
+  baseTemporaryId: string;
+  productName: string;
+  mode: "QUANTITY_ONLY" | "SEAT_BASED";
+  annualUsesSameProduct?: boolean;
+}): SeatSubscriptionPair {
+  return {
+    monthly: makeSeatSubscription({
+      temporaryId: `${baseTemporaryId}-sub`,
+      productName,
+      billingFrequency: "MONTHLY",
+      mode,
+    }),
+    annual: makeSeatSubscription({
+      temporaryId: `${baseTemporaryId}-annual-sub`,
+      productName: annualUsesSameProduct
+        ? productName
+        : productName + SEAT_PRODUCT_YEARLY_SUFFIX,
+      billingFrequency: "ANNUAL",
+      mode,
+    }),
+  };
+}
+
+export function getFreeExcessRecurringCredits(
+  creditTypeId: string,
+  quantity: number
+): RecurringCreditDef {
+  return {
+    product_name: "Excess Credits",
+    access_amount: {
+      credit_type_id: creditTypeId,
+      unit_price: quantity,
+      quantity: 1,
+    },
+    commit_duration: { value: 1, unit: "PERIODS" },
+    priority: 999,
+    starting_at_offset: { unit: "DAYS", value: 0 }, // starts immediately
+    applicable_product_tags: [USAGE_TAG],
+    recurrence_frequency: "MONTHLY",
+    name: EXCESS_CREDIT_NAME,
+  };
+}

--- a/front/lib/metronome/setup_legacy.ts
+++ b/front/lib/metronome/setup_legacy.ts
@@ -1,0 +1,501 @@
+/**
+ * Metronome setup — legacy (grandfathered) plans: their rate cards and packages,
+ * plus the bits used only by them (the Free-Credits recurring credits, the
+ * legacy Workspace-Seat subscription, and the programmatic-USD conversion
+ * constants). Shared types/factories come from `setup_common.ts`.
+ */
+
+import {
+  CREDIT_TYPE_EUR_ID,
+  CREDIT_TYPE_USD_ID,
+} from "@app/lib/metronome/constants";
+import {
+  BILLING_CYCLE_CONFIG,
+  buildSeatTierRates,
+  getCreditTypeProgrammaticUsdId,
+  getFreeExcessRecurringCredits,
+  type MetricDef,
+  makeSeatSubscriptions,
+  type PackageDef,
+  type RateCardDef,
+  type RecurringCreditDef,
+  USAGE_TAG,
+  WORKSPACE_SEAT_PRODUCT_NAME,
+} from "@app/lib/metronome/setup_common";
+import {
+  DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT,
+  FREE_ANNUAL_CREDIT_NAME,
+  FREE_MONTHLY_CREDIT_NAME,
+  LEGACY_BUSINESS_EUR_PACKAGE_ALIAS,
+  LEGACY_BUSINESS_PACKAGE_ALIAS,
+  LEGACY_ENTERPRISE_EUR_PACKAGE_ALIAS,
+  LEGACY_ENTERPRISE_PACKAGE_ALIAS,
+  LEGACY_PRO_ANNUAL_EUR_PACKAGE_ALIAS,
+  LEGACY_PRO_ANNUAL_PACKAGE_ALIAS,
+  LEGACY_PRO_MONTHLY_EUR_PACKAGE_ALIAS,
+  LEGACY_PRO_MONTHLY_PACKAGE_ALIAS,
+} from "@app/lib/metronome/types";
+
+const PROGRAMMATIC_USAGE_CREDITS_IN_USD_CENTS = 100;
+const PROGRAMMATIC_USAGE_CREDITS_IN_EUR = 0.87;
+
+export const LEGACY_METRICS: MetricDef[] = [
+  {
+    name: "LLM Provider Cost (Programmatic)",
+    event_type_filter: { in_values: ["llm_usage_v3"] },
+    property_filters: [
+      { name: "cost_micro_usd", exists: true },
+      { name: "is_programmatic_usage", in_values: ["true"] },
+      { name: "api_key_name", exists: true },
+      { name: "model_id", exists: true },
+      { name: "origin", exists: true },
+      { name: "agent_id", exists: true },
+    ],
+    aggregation_type: "SUM",
+    aggregation_key: "cost_micro_usd",
+    group_keys: [["api_key_name"], ["model_id"], ["origin"], ["agent_id"]],
+  },
+];
+
+// Recurring free credit definition shared by all legacy monthly packages.
+// Quantity starts at 0 — the credit.segment.start webhook updates it each period
+// to the actual user-based amount.
+function getFreeMonthlyRecurringCredits(): RecurringCreditDef {
+  return {
+    product_name: "Free Credits",
+    access_amount: {
+      credit_type_id: getCreditTypeProgrammaticUsdId(),
+      unit_price: 0,
+      quantity: 1,
+    },
+    commit_duration: { value: 1, unit: "PERIODS" },
+    priority: 1,
+    starting_at_offset: { unit: "DAYS", value: 0 }, // starts immediately
+    applicable_product_tags: [USAGE_TAG],
+    recurrence_frequency: "MONTHLY",
+    name: FREE_MONTHLY_CREDIT_NAME,
+  };
+}
+
+// Annual variant for legacy annual packages. Same product, but the credit is granted
+// once per year. The credit.segment.start webhook detects ANNUAL recurrence
+// and multiplies the monthly bracket amount by 12.
+function getFreeAnnualRecurringCredits(): RecurringCreditDef {
+  return {
+    product_name: "Free Credits",
+    access_amount: {
+      credit_type_id: getCreditTypeProgrammaticUsdId(),
+      unit_price: 0,
+      quantity: 1,
+    },
+    commit_duration: { value: 1, unit: "PERIODS" },
+    priority: 1,
+    starting_at_offset: { unit: "DAYS", value: 0 }, // starts immediately
+    applicable_product_tags: [USAGE_TAG],
+    recurrence_frequency: "ANNUAL",
+    name: FREE_ANNUAL_CREDIT_NAME,
+  };
+}
+
+// Legacy Workspace Seat (QUANTITY_ONLY); both frequencies bill the same product.
+const LEGACY_SEATS = makeSeatSubscriptions({
+  baseTemporaryId: "legacy-seat",
+  productName: WORKSPACE_SEAT_PRODUCT_NAME,
+  mode: "QUANTITY_ONLY",
+  annualUsesSameProduct: true,
+});
+
+// Function — evaluated after detectEnvironment() resolves ENV (needed for the
+// programmatic-USD credit type used in conversions).
+export function getLegacyRateCards(): RateCardDef[] {
+  return [
+    {
+      name: "Legacy Pro USD",
+      description:
+        "Grandfathered Pro plan. $29/seat via seat subscription. AI usage 30% markup.",
+      aliases: [{ name: "legacy-pro-monthly" }],
+      fiat_credit_type_id: CREDIT_TYPE_USD_ID,
+      credit_type_conversions: [
+        {
+          custom_credit_type_id: getCreditTypeProgrammaticUsdId(),
+          fiat_per_custom_credit: PROGRAMMATIC_USAGE_CREDITS_IN_USD_CENTS,
+        },
+      ],
+      rates: [
+        {
+          product_name: WORKSPACE_SEAT_PRODUCT_NAME,
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 2900,
+          billing_frequency: "MONTHLY",
+        },
+        {
+          product_name: "Programmatic Usage",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 1,
+          credit_type_id: getCreditTypeProgrammaticUsdId(),
+        },
+      ],
+    },
+    {
+      name: "Legacy Business USD",
+      description:
+        "Grandfathered Business plan. $45/seat via seat subscription. AI usage 30% markup.",
+      aliases: [{ name: "legacy-business" }],
+      fiat_credit_type_id: CREDIT_TYPE_USD_ID,
+      credit_type_conversions: [
+        {
+          custom_credit_type_id: getCreditTypeProgrammaticUsdId(),
+          fiat_per_custom_credit: PROGRAMMATIC_USAGE_CREDITS_IN_USD_CENTS,
+        },
+      ],
+      rates: [
+        {
+          product_name: WORKSPACE_SEAT_PRODUCT_NAME,
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 4500,
+          billing_frequency: "MONTHLY",
+        },
+        {
+          product_name: "Programmatic Usage",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 1,
+          credit_type_id: getCreditTypeProgrammaticUsdId(),
+        },
+      ],
+    },
+    {
+      name: "Legacy Pro Annual USD",
+      description:
+        "Grandfathered Pro plan (annual). $27/seat/month billed monthly. AI usage 30% markup.",
+      aliases: [{ name: "legacy-pro-annual" }],
+      fiat_credit_type_id: CREDIT_TYPE_USD_ID,
+      credit_type_conversions: [
+        {
+          custom_credit_type_id: getCreditTypeProgrammaticUsdId(),
+          fiat_per_custom_credit: PROGRAMMATIC_USAGE_CREDITS_IN_USD_CENTS,
+        },
+      ],
+      rates: [
+        {
+          product_name: WORKSPACE_SEAT_PRODUCT_NAME,
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 32400,
+          billing_frequency: "ANNUAL",
+        },
+        {
+          product_name: "Programmatic Usage",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 1,
+          credit_type_id: getCreditTypeProgrammaticUsdId(),
+        },
+      ],
+    },
+    // --- Enterprise plan: MAU-based billing + programmatic usage ---
+    // Default: MAU-1 at $45/MAU. MAU-5/MAU-10 not entitled by default but present
+    // on the rate card so they can be enabled per contract via overrides.
+    // Programmatic usage at $1 = $1 (30% markup baked into product).
+    {
+      name: "Legacy Enterprise MAU USD",
+      description:
+        "Enterprise plan. Per-MAU billing + programmatic usage at cost with 30% markup.",
+      aliases: [{ name: "legacy-enterprise" }],
+      fiat_credit_type_id: CREDIT_TYPE_USD_ID,
+      credit_type_conversions: [
+        {
+          custom_credit_type_id: getCreditTypeProgrammaticUsdId(),
+          fiat_per_custom_credit: PROGRAMMATIC_USAGE_CREDITS_IN_USD_CENTS,
+        },
+      ],
+      rates: [
+        {
+          product_name: "MAU",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          billing_frequency: "MONTHLY",
+          price: 4500,
+        },
+        {
+          product_name: "Programmatic Usage",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 1,
+          credit_type_id: getCreditTypeProgrammaticUsdId(),
+        },
+        ...buildSeatTierRates({
+          prefix: "MAU",
+          creditTypeId: CREDIT_TYPE_USD_ID,
+        }),
+      ],
+    },
+    // --- EUR variants: same seat prices, billed in EUR ---
+    // For Eurozone/EEA/Switzerland customers.
+    // Programmatic usage: same product (quantity_conversion converts cost_micro_usd to units),
+    // but priced at 87 (€0.87/unit) instead of 100 ($1.00/unit) to apply the USD→EUR FX rate.
+    // EUR prices are in whole euros (not cents) — Metronome EUR pricing unit is "EUR".
+    {
+      name: "Legacy Pro EUR",
+      description:
+        "Grandfathered Pro plan (EUR). 29€/seat via seat subscription. AI usage 30% markup.",
+      aliases: [{ name: "legacy-pro-monthly-eur" }],
+      fiat_credit_type_id: CREDIT_TYPE_EUR_ID,
+      credit_type_conversions: [
+        {
+          custom_credit_type_id: getCreditTypeProgrammaticUsdId(),
+          fiat_per_custom_credit: PROGRAMMATIC_USAGE_CREDITS_IN_EUR,
+        },
+      ],
+      rates: [
+        {
+          product_name: WORKSPACE_SEAT_PRODUCT_NAME,
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 29,
+          billing_frequency: "MONTHLY",
+          credit_type_id: CREDIT_TYPE_EUR_ID,
+        },
+        {
+          product_name: "Programmatic Usage",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 1,
+          credit_type_id: getCreditTypeProgrammaticUsdId(),
+        },
+      ],
+    },
+    {
+      name: "Legacy Business EUR",
+      description:
+        "Grandfathered Business plan (EUR). 45€/seat via seat subscription. AI usage 30% markup.",
+      aliases: [{ name: "legacy-business-eur" }],
+      fiat_credit_type_id: CREDIT_TYPE_EUR_ID,
+      credit_type_conversions: [
+        {
+          custom_credit_type_id: getCreditTypeProgrammaticUsdId(),
+          fiat_per_custom_credit: PROGRAMMATIC_USAGE_CREDITS_IN_EUR,
+        },
+      ],
+      rates: [
+        {
+          product_name: WORKSPACE_SEAT_PRODUCT_NAME,
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 45,
+          billing_frequency: "MONTHLY",
+          credit_type_id: CREDIT_TYPE_EUR_ID,
+        },
+        {
+          product_name: "Programmatic Usage",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 1,
+          credit_type_id: getCreditTypeProgrammaticUsdId(),
+        },
+      ],
+    },
+    {
+      name: "Legacy Pro Annual EUR",
+      description:
+        "Grandfathered Pro plan (EUR, annual). 27€/seat/month billed monthly. AI usage 30% markup.",
+      aliases: [{ name: "legacy-pro-annual-eur" }],
+      fiat_credit_type_id: CREDIT_TYPE_EUR_ID,
+      credit_type_conversions: [
+        {
+          custom_credit_type_id: getCreditTypeProgrammaticUsdId(),
+          fiat_per_custom_credit: PROGRAMMATIC_USAGE_CREDITS_IN_EUR,
+        },
+      ],
+      rates: [
+        {
+          product_name: WORKSPACE_SEAT_PRODUCT_NAME,
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 324,
+          billing_frequency: "ANNUAL",
+          credit_type_id: CREDIT_TYPE_EUR_ID,
+        },
+        {
+          product_name: "Programmatic Usage",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 1,
+          credit_type_id: getCreditTypeProgrammaticUsdId(),
+        },
+      ],
+    },
+    {
+      name: "Legacy Enterprise MAU EUR",
+      description:
+        "Enterprise plan (EUR). Per-MAU billing + programmatic usage at cost with 30% markup.",
+      aliases: [{ name: "legacy-enterprise-eur" }],
+      fiat_credit_type_id: CREDIT_TYPE_EUR_ID,
+      credit_type_conversions: [
+        {
+          custom_credit_type_id: getCreditTypeProgrammaticUsdId(),
+          fiat_per_custom_credit: PROGRAMMATIC_USAGE_CREDITS_IN_EUR,
+        },
+      ],
+      rates: [
+        {
+          product_name: "MAU",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          billing_frequency: "MONTHLY",
+          price: 45,
+          credit_type_id: CREDIT_TYPE_EUR_ID,
+        },
+        {
+          product_name: "Programmatic Usage",
+          starting_at: "2026-04-01T00:00:00.000Z",
+          entitled: true,
+          rate_type: "FLAT",
+          price: 1,
+          credit_type_id: getCreditTypeProgrammaticUsdId(),
+        },
+        ...buildSeatTierRates({
+          prefix: "MAU",
+          creditTypeId: CREDIT_TYPE_EUR_ID,
+        }),
+      ],
+    },
+  ];
+}
+
+export function getLegacyPackages(): PackageDef[] {
+  return [
+    {
+      name: "Legacy Pro USD",
+      aliases: [{ name: LEGACY_PRO_MONTHLY_PACKAGE_ALIAS }],
+      rate_card_name: "Legacy Pro USD",
+      subscriptions: [LEGACY_SEATS.monthly],
+      recurring_credits: [
+        getFreeMonthlyRecurringCredits(),
+        getFreeExcessRecurringCredits(
+          getCreditTypeProgrammaticUsdId(),
+          DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT
+        ),
+      ],
+      ...BILLING_CYCLE_CONFIG,
+    },
+    {
+      name: "Legacy Business USD",
+      aliases: [{ name: LEGACY_BUSINESS_PACKAGE_ALIAS }],
+      rate_card_name: "Legacy Business USD",
+      subscriptions: [LEGACY_SEATS.monthly],
+      recurring_credits: [
+        getFreeMonthlyRecurringCredits(),
+        getFreeExcessRecurringCredits(
+          getCreditTypeProgrammaticUsdId(),
+          DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT
+        ),
+      ],
+      ...BILLING_CYCLE_CONFIG,
+    },
+    {
+      name: "Legacy Pro Annual USD",
+      aliases: [{ name: LEGACY_PRO_ANNUAL_PACKAGE_ALIAS }],
+      rate_card_name: "Legacy Pro Annual USD",
+      subscriptions: [LEGACY_SEATS.annual],
+      recurring_credits: [
+        getFreeAnnualRecurringCredits(),
+        getFreeExcessRecurringCredits(
+          getCreditTypeProgrammaticUsdId(),
+          DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT
+        ),
+      ],
+      ...BILLING_CYCLE_CONFIG,
+    },
+    // Enterprise: MAU-based billing, no seat subscriptions.
+    {
+      name: "Legacy Enterprise USD",
+      aliases: [{ name: LEGACY_ENTERPRISE_PACKAGE_ALIAS }],
+      rate_card_name: "Legacy Enterprise MAU USD",
+      scheduled_charges_on_usage_invoices: "ALL",
+      recurring_credits: [
+        getFreeMonthlyRecurringCredits(),
+        getFreeExcessRecurringCredits(
+          getCreditTypeProgrammaticUsdId(),
+          DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT
+        ),
+      ],
+      ...BILLING_CYCLE_CONFIG,
+    },
+    // EUR variants
+    {
+      name: "Legacy Pro EUR",
+      aliases: [{ name: LEGACY_PRO_MONTHLY_EUR_PACKAGE_ALIAS }],
+      rate_card_name: "Legacy Pro EUR",
+      subscriptions: [LEGACY_SEATS.monthly],
+      recurring_credits: [
+        getFreeMonthlyRecurringCredits(),
+        getFreeExcessRecurringCredits(
+          getCreditTypeProgrammaticUsdId(),
+          DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT
+        ),
+      ],
+      ...BILLING_CYCLE_CONFIG,
+    },
+    {
+      name: "Legacy Business EUR",
+      aliases: [{ name: LEGACY_BUSINESS_EUR_PACKAGE_ALIAS }],
+      rate_card_name: "Legacy Business EUR",
+      subscriptions: [LEGACY_SEATS.monthly],
+      recurring_credits: [
+        getFreeMonthlyRecurringCredits(),
+        getFreeExcessRecurringCredits(
+          getCreditTypeProgrammaticUsdId(),
+          DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT
+        ),
+      ],
+      ...BILLING_CYCLE_CONFIG,
+    },
+    {
+      name: "Legacy Pro Annual EUR",
+      aliases: [{ name: LEGACY_PRO_ANNUAL_EUR_PACKAGE_ALIAS }],
+      rate_card_name: "Legacy Pro Annual EUR",
+      subscriptions: [LEGACY_SEATS.annual],
+      recurring_credits: [
+        getFreeAnnualRecurringCredits(),
+        getFreeExcessRecurringCredits(
+          getCreditTypeProgrammaticUsdId(),
+          DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT
+        ),
+      ],
+      ...BILLING_CYCLE_CONFIG,
+    },
+    {
+      name: "Legacy Enterprise EUR",
+      aliases: [{ name: LEGACY_ENTERPRISE_EUR_PACKAGE_ALIAS }],
+      rate_card_name: "Legacy Enterprise MAU EUR",
+      scheduled_charges_on_usage_invoices: "ALL",
+      recurring_credits: [
+        getFreeMonthlyRecurringCredits(),
+        getFreeExcessRecurringCredits(
+          getCreditTypeProgrammaticUsdId(),
+          DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT
+        ),
+      ],
+      ...BILLING_CYCLE_CONFIG,
+    },
+  ];
+}

--- a/front/lib/metronome/setup_new_pricing.ts
+++ b/front/lib/metronome/setup_new_pricing.ts
@@ -1,0 +1,610 @@
+/**
+ * Metronome setup — new-pricing plans (Standard USD/EUR + Free): their rate
+ * cards and packages, plus the bits used only by them (AWU usage rates, the
+ * seat subscription pairs, per-seat AWU credit allocations, and the seat
+ * entitlement overrides). Shared types/factories come from `setup_common.ts`.
+ */
+
+import {
+  AWU_PRIORITY_SEAT_ALLOCATION,
+  CREDIT_TYPE_EUR_ID,
+  CREDIT_TYPE_USD_ID,
+  SEAT_PRODUCT_YEARLY_SUFFIX,
+} from "@app/lib/metronome/constants";
+import { TOOL_CATEGORIES } from "@app/lib/metronome/events";
+import {
+  BILLING_CYCLE_CONFIG,
+  FREE_SEAT_CREDIT_NAME,
+  FREE_SEAT_PRODUCT_NAME,
+  getCreditTypeAwuId,
+  getFreeExcessRecurringCredits,
+  getOverageAwuRate,
+  MAX_SEAT_CREDIT_NAME,
+  MAX_SEAT_PRODUCT_NAME,
+  type MetricDef,
+  makeSeatSubscription,
+  makeSeatSubscriptions,
+  type PackageDef,
+  type PackageOverrideDef,
+  type PackageSubscription,
+  PRO_SEAT_CREDIT_NAME,
+  PRO_SEAT_PRODUCT_NAME,
+  type RateCardDef,
+  type RateDef,
+  type RecurringCreditDef,
+  type SeatSubscriptionPair,
+  USAGE_TAG,
+  WORKSPACE_SEAT_PRODUCT_NAME,
+} from "@app/lib/metronome/setup_common";
+import {
+  DEFAULT_AWU_EXCESS_RECURRING_AMOUNT,
+  FREE_PACKAGE_ALIAS,
+} from "@app/lib/metronome/types";
+
+// Per-seat AWU allocations stamped onto recurring credits at package creation.
+// Runtime code reads the allocation from the contract's `recurring_credits`,
+// so these values aren't referenced anywhere else.
+const PRO_SEAT_MONTHLY_AWU_CREDITS = 8000;
+const MAX_SEAT_MONTHLY_AWU_CREDITS = 40000;
+// Per-seat AWU grant carried by the Free Seat subscription. Granted once
+// per seat on contract start and valid for the lifetime of the contract.
+// Never refilled.
+const FREE_SEAT_LIFETIME_AWU_CREDITS = 300;
+
+export const NEW_METRICS: MetricDef[] = [
+  // Tool invocation metric — counts tool uses, group keys cover both user and
+  // programmatic events. `is_programmatic_usage` is the authoritative split
+  // signal: sentinel values like user_id="unknown" or api_key_name="unknown"
+  // are not reliable (programmatic callers without an API key still emit
+  // user_id="unknown" but must be classed as programmatic).
+  {
+    name: "Tool Invocations",
+    event_type_filter: { in_values: ["tool_use_v3"] },
+    property_filters: [
+      { name: "count", exists: true },
+      { name: "usage_type", exists: true },
+      { name: "tool_category", exists: true },
+      { name: "tool_group", exists: true },
+      { name: "user_id", exists: true },
+      { name: "api_key_name", exists: true },
+      { name: "origin", exists: true },
+      { name: "agent_id", exists: true },
+      { name: "mcp_server_id", exists: true },
+    ],
+    aggregation_type: "SUM",
+    aggregation_key: "count",
+    // 7 group keys — Metronome's default cap is 5; this metric needs an
+    // explicit limit increase (granted by Metronome support).
+    group_keys: [
+      ["user_id", "usage_type", "tool_category"],
+      ["user_id"],
+      ["api_key_name"],
+      ["tool_category"],
+      ["origin"],
+      ["agent_id"],
+      ["usage_type"],
+    ],
+  },
+  // AWU-based AI cost metric — sums cost_awu directly (no unit conversion).
+  // Powers the new AI Usage product on all AWU rate cards (Business, Enterprise).
+  // Group keys cover both user and programmatic events; per-seat credit drawdown
+  // only matches events whose `user_id` is assigned to a seat.
+  {
+    name: "LLM Provider Cost AWU",
+    event_type_filter: { in_values: ["llm_usage_v3"] },
+    property_filters: [
+      { name: "cost_awu", exists: true },
+      { name: "usage_type", exists: true },
+      { name: "user_id", exists: true },
+      { name: "api_key_name", exists: true },
+      { name: "model_id", exists: true },
+      { name: "origin", exists: true },
+      { name: "agent_id", exists: true },
+    ],
+    aggregation_type: "SUM",
+    aggregation_key: "cost_awu",
+    // 7 group keys — see note on Tool Invocations above.
+    group_keys: [
+      ["user_id", "usage_type"],
+      ["user_id"],
+      ["api_key_name"],
+      ["model_id"],
+      ["origin"],
+      ["agent_id"],
+      ["usage_type"],
+    ],
+  },
+  // Phase 2 token metrics removed — will be added when Pricing Index is ready.
+];
+
+// Per-tier AWU price for Tool Usage rates. Shared across all AWU-priced rate cards
+const TOOL_CATEGORY_PRICES_AWU: Record<
+  (typeof TOOL_CATEGORIES)[number],
+  number
+> = {
+  basic: 1,
+  advanced: 3,
+};
+
+// usage_type splits each AWU usage rate: "user" and "programmatic" use the
+// nominal price, "free" is priced at 0 (covers free-tagged events, replacing
+// the prior recurring-credit mechanism).
+const PAID_USAGE_TYPES = ["user", "programmatic"] as const;
+
+function buildAwuToolUsageRates(): RateDef[] {
+  return TOOL_CATEGORIES.flatMap((category): RateDef[] => [
+    ...PAID_USAGE_TYPES.map(
+      (usageType): RateDef => ({
+        product_name: "Tool Usage",
+        starting_at: "2026-04-01T00:00:00.000Z",
+        entitled: true,
+        rate_type: "FLAT",
+        price: TOOL_CATEGORY_PRICES_AWU[category],
+        credit_type_id: getCreditTypeAwuId(),
+        pricing_group_values: {
+          tool_category: category,
+          usage_type: usageType,
+        },
+      })
+    ),
+    {
+      product_name: "Tool Usage",
+      starting_at: "2026-04-01T00:00:00.000Z",
+      entitled: true,
+      rate_type: "FLAT",
+      price: 0,
+      credit_type_id: getCreditTypeAwuId(),
+      pricing_group_values: { tool_category: category, usage_type: "free" },
+    },
+  ]);
+}
+
+// AI Usage rates split by usage_type: paid types use the nominal 1 AWU price,
+// free is priced at 0.
+function buildAwuAiUsageRates(): RateDef[] {
+  return [
+    ...PAID_USAGE_TYPES.map(
+      (usageType): RateDef => ({
+        product_name: "AI Usage",
+        starting_at: "2026-04-01T00:00:00.000Z",
+        entitled: true,
+        rate_type: "FLAT",
+        price: 1,
+        credit_type_id: getCreditTypeAwuId(),
+        pricing_group_values: { usage_type: usageType },
+      })
+    ),
+    {
+      product_name: "AI Usage",
+      starting_at: "2026-04-01T00:00:00.000Z",
+      entitled: true,
+      rate_type: "FLAT",
+      price: 0,
+      credit_type_id: getCreditTypeAwuId(),
+      pricing_group_values: { usage_type: "free" },
+    },
+  ];
+}
+
+// All seat rates carried by every non-legacy rate card. Each seat (Workspace /
+// Pro / Max / Free, monthly + yearly where applicable) is added at
+// `entitled: false` with a 0 baseline price. Packages enable the seats they
+// sell and stamp their real price via overrides (see
+// buildSeatEntitlementOverrides). `creditTypeId` is the rate card's fiat unit.
+function buildAllSeatRates(creditTypeId: string): RateDef[] {
+  const seat = (
+    productName: string,
+    billingFrequency: "MONTHLY" | "ANNUAL"
+  ): RateDef => ({
+    product_name: productName,
+    starting_at: "2026-04-01T00:00:00.000Z",
+    entitled: false,
+    rate_type: "FLAT",
+    price: 0,
+    billing_frequency: billingFrequency,
+    credit_type_id: creditTypeId,
+  });
+  return [
+    seat(WORKSPACE_SEAT_PRODUCT_NAME, "MONTHLY"),
+    seat(WORKSPACE_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX, "ANNUAL"),
+    seat(PRO_SEAT_PRODUCT_NAME, "MONTHLY"),
+    seat(PRO_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX, "ANNUAL"),
+    seat(MAX_SEAT_PRODUCT_NAME, "MONTHLY"),
+    seat(MAX_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX, "ANNUAL"),
+    seat(FREE_SEAT_PRODUCT_NAME, "MONTHLY"),
+  ];
+}
+
+// Enables the given seats on a package's rate card. Every non-legacy rate card
+// carries all seats (Workspace / Pro / Max / Free) at entitled=false with a 0
+// baseline price; a package calls this to flip on (entitled=true) the seats it
+// sells and stamp each one's flat rate. `seats` is the list of seats to enable;
+// a seat with a `price` gets an `overwrite_rate` (rate_type FLAT) in the rate
+// card's fiat unit (`creditTypeId`). Omit `price` to flip entitlement only. The
+// billing frequency is derived from the product name (the `*_yearly` products
+// are ANNUAL) — Metronome requires it when overwriting a subscription rate.
+function buildSeatEntitlementOverrides(
+  creditTypeId: string,
+  seats: Array<{ product_name: string; price?: number }>
+): PackageOverrideDef[] {
+  return seats.map((seat) => ({
+    product_name: seat.product_name,
+    entitled: true,
+    billing_frequency: seat.product_name.endsWith(SEAT_PRODUCT_YEARLY_SUFFIX)
+      ? "ANNUAL"
+      : "MONTHLY",
+    ...(seat.price !== undefined
+      ? { price: seat.price, credit_type_id: creditTypeId }
+      : {}),
+  }));
+}
+
+// Non-legacy seats. Workspace is QUANTITY_ONLY (pooled); Pro / Max are
+// SEAT_BASED. Free has no annual variant.
+const WORKSPACE_SEATS = makeSeatSubscriptions({
+  baseTemporaryId: "workspace-seat",
+  productName: WORKSPACE_SEAT_PRODUCT_NAME,
+  mode: "QUANTITY_ONLY",
+});
+const PRO_SEATS = makeSeatSubscriptions({
+  baseTemporaryId: "pro-seat",
+  productName: PRO_SEAT_PRODUCT_NAME,
+  mode: "SEAT_BASED",
+});
+const MAX_SEATS = makeSeatSubscriptions({
+  baseTemporaryId: "max-seat",
+  productName: MAX_SEAT_PRODUCT_NAME,
+  mode: "SEAT_BASED",
+});
+// Free Seat SEAT_BASED subscription — priced at $0, used to track free users in
+// Metronome so each free seat carries its own lifetime AWU credit pool.
+const FREE_SEAT_SUBSCRIPTION = makeSeatSubscription({
+  temporaryId: "free-seat-sub",
+  productName: FREE_SEAT_PRODUCT_NAME,
+  billingFrequency: "MONTHLY",
+  mode: "SEAT_BASED",
+});
+
+// Per-seat INDIVIDUAL recurring AWU credit attached to a SEAT_BASED subscription.
+// Each seat gets its own AWU allocation refreshed every period. The credit
+// draws down against any usage product tagged `usage` for the matching
+// `user_id` seat.
+//
+// When `subscription_config` is set, Metronome rejects requests that include
+// `access_amount.quantity` (400 "must not specify a quantity if a subscription
+// is configured"). The per-seat allocation amount is encoded in
+// `access_amount.unit_price` and multiplied by the subscription's seat count
+// internally.
+function getPerSeatIndividualAwuCredits({
+  subscriptionTemporaryId,
+  quantityPerSeat,
+  name,
+}: {
+  subscriptionTemporaryId: string;
+  quantityPerSeat: number;
+  name: string;
+}): RecurringCreditDef {
+  return {
+    product_name: "Seat Individual Credits",
+    access_amount: {
+      credit_type_id: getCreditTypeAwuId(),
+      unit_price: quantityPerSeat,
+    },
+    commit_duration: { value: 1, unit: "PERIODS" },
+    priority: AWU_PRIORITY_SEAT_ALLOCATION,
+    starting_at_offset: { unit: "DAYS", value: 0 },
+    applicable_product_tags: [USAGE_TAG],
+    recurrence_frequency: "MONTHLY",
+    name,
+    subscription_config: {
+      subscription_temporary_id: subscriptionTemporaryId,
+      allocation: "INDIVIDUAL",
+      apply_seat_increase_config: { is_prorated: false },
+    },
+  };
+}
+
+// Full subscription set carried by every non-legacy package. Workspace seats are
+// QUANTITY_ONLY (pooled) while Pro / Max / Free are SEAT_BASED — packages share
+// this single mixed set and differ only in which seats they entitle (see the
+// per-package overrides). A seat that a package does not entitle stays dormant:
+// no seats are ever assigned to it, so it never bills.
+const ALL_SEAT_SUBSCRIPTIONS: PackageSubscription[] = [
+  WORKSPACE_SEATS.monthly,
+  WORKSPACE_SEATS.annual,
+  PRO_SEATS.monthly,
+  PRO_SEATS.annual,
+  MAX_SEATS.monthly,
+  MAX_SEATS.annual,
+  FREE_SEAT_SUBSCRIPTION,
+];
+
+// Per-seat INDIVIDUAL AWU credit attached to the Free Seat SEAT_BASED
+// subscription. Issued exactly once per seat:
+//   - `duration: { value: 1, unit: "DAYS" }` stops the recurrence after the
+//     first commit (which fires on contract start / seat assignment), so the
+//     credit is never re-issued.
+//   - `commit_duration: { value: 100, unit: "YEARS" }`... not supported by
+//     Metronome (`PERIODS` only), so we approximate with 100 ANNUAL periods
+//     — effectively the lifetime of any reasonable contract.
+//   - Not prorated on seat increase: a new free seat always gets the full
+//     300 AWU grant regardless of when in the period it was added.
+function getFreeSeatLifetimeAwuCredits(): RecurringCreditDef {
+  return {
+    product_name: "Seat Individual Credits",
+    access_amount: {
+      credit_type_id: getCreditTypeAwuId(),
+      unit_price: FREE_SEAT_LIFETIME_AWU_CREDITS,
+    },
+    commit_duration: { value: 100, unit: "PERIODS" },
+    priority: 200,
+    starting_at_offset: { unit: "DAYS", value: 0 },
+    applicable_product_tags: [USAGE_TAG],
+    recurrence_frequency: "ANNUAL",
+    duration: { value: 1, unit: "DAYS" },
+    name: FREE_SEAT_CREDIT_NAME,
+    subscription_config: {
+      subscription_temporary_id: FREE_SEAT_SUBSCRIPTION.temporary_id,
+      allocation: "INDIVIDUAL",
+      apply_seat_increase_config: { is_prorated: false },
+    },
+  };
+}
+
+// Per-seat INDIVIDUAL AWU credits for both the monthly and annual subscription
+// of a seat pair (same per-seat allocation regardless of billing frequency).
+function buildPerSeatCredits(
+  pair: SeatSubscriptionPair,
+  quantityPerSeat: number,
+  name: string
+): RecurringCreditDef[] {
+  return [pair.monthly, pair.annual].map((sub) =>
+    getPerSeatIndividualAwuCredits({
+      subscriptionTemporaryId: sub.temporary_id,
+      quantityPerSeat,
+      name,
+    })
+  );
+}
+
+// Full recurring-credit set tied to the seat subscriptions above, carried by
+// every non-legacy package: per-seat INDIVIDUAL AWU allocations for each Pro /
+// Max seat (monthly + annual), the one-shot Free Seat lifetime grant, and the
+// AWU excess credit. A credit attached to a dormant seat never materializes (the
+// subscription has no seats).
+function getAllSeatRecurringCredits(): RecurringCreditDef[] {
+  return [
+    ...buildPerSeatCredits(
+      PRO_SEATS,
+      PRO_SEAT_MONTHLY_AWU_CREDITS,
+      PRO_SEAT_CREDIT_NAME
+    ),
+    ...buildPerSeatCredits(
+      MAX_SEATS,
+      MAX_SEAT_MONTHLY_AWU_CREDITS,
+      MAX_SEAT_CREDIT_NAME
+    ),
+    getFreeSeatLifetimeAwuCredits(),
+    getFreeExcessRecurringCredits(
+      getCreditTypeAwuId(),
+      DEFAULT_AWU_EXCESS_RECURRING_AMOUNT
+    ),
+  ];
+}
+
+export function getNewRateCards(): RateCardDef[] {
+  return [
+    // --- Standard USD: single non-legacy rate card (USD) ---
+    // Shared by all non-legacy USD packages (Business + Enterprise, pooled and
+    // seat-based). Carries every seat at entitled=false / price 0 plus the
+    // AWU-based AI/Tool usage rates; each package enables and prices the seats
+    // it sells via overrides. The Business-vs-Enterprise distinction lives
+    // entirely in the package overrides, not here.
+    {
+      name: "Standard USD",
+      description:
+        "Standard non-legacy plan (USD). Seats priced per-package via overrides + AWU-based AI/Tool usage.",
+      aliases: [{ name: "standard-usd" }],
+      fiat_credit_type_id: CREDIT_TYPE_USD_ID,
+      credit_type_conversions: [
+        {
+          custom_credit_type_id: getCreditTypeAwuId(),
+          fiat_per_custom_credit: getOverageAwuRate("usd"),
+        },
+      ],
+      rates: [
+        ...buildAllSeatRates(CREDIT_TYPE_USD_ID),
+        ...buildAwuAiUsageRates(),
+        ...buildAwuToolUsageRates(),
+      ],
+    },
+    // --- Standard EUR: EUR variant of the single non-legacy rate card ---
+    {
+      name: "Standard EUR",
+      description:
+        "Standard non-legacy plan (EUR). Seats priced per-package via overrides + AWU-based AI/Tool usage.",
+      aliases: [{ name: "standard-eur" }],
+      fiat_credit_type_id: CREDIT_TYPE_EUR_ID,
+      credit_type_conversions: [
+        {
+          custom_credit_type_id: getCreditTypeAwuId(),
+          fiat_per_custom_credit: getOverageAwuRate("eur"),
+        },
+      ],
+      rates: [
+        ...buildAllSeatRates(CREDIT_TYPE_EUR_ID),
+        ...buildAwuAiUsageRates(),
+        ...buildAwuToolUsageRates(),
+      ],
+    },
+    // Free plan keeps its own rate card — its overage AWU conversion is 0 (free
+    // users are never charged for overage), unlike the Standard cards.
+    {
+      name: "Free plan",
+      description: "Free plan.",
+      aliases: [{ name: "free-plan" }],
+      fiat_credit_type_id: CREDIT_TYPE_USD_ID,
+      credit_type_conversions: [
+        {
+          custom_credit_type_id: getCreditTypeAwuId(),
+          fiat_per_custom_credit: 0,
+        },
+      ],
+      rates: [
+        ...buildAllSeatRates(CREDIT_TYPE_USD_ID),
+        ...buildAwuAiUsageRates(),
+        ...buildAwuToolUsageRates(),
+      ],
+    },
+  ];
+}
+
+export function getNewPackages(): PackageDef[] {
+  return [
+    // Non-legacy packages all carry the same full seat subscription set
+    // (ALL_SEAT_SUBSCRIPTIONS) and the same full recurring-credit set
+    // (getAllSeatRecurringCredits). They differ only in which seats they
+    // entitle — and at what price — via buildSeatEntitlementOverrides. Each
+    // rate card carries every seat at entitled=false / price 0, so a package
+    // must override to turn on (and price) the seats it sells. Seats a package
+    // does not entitle stay dormant (no seats assigned → never bill); their
+    // tied recurring credits never materialize.
+    {
+      name: "Enterprise Pooled USD",
+      aliases: [{ name: "enterprise-usd" }],
+      rate_card_name: "Standard USD",
+      subscriptions: ALL_SEAT_SUBSCRIPTIONS,
+      scheduled_charges_on_usage_invoices: "ALL",
+      recurring_credits: getAllSeatRecurringCredits(),
+      overrides: buildSeatEntitlementOverrides(CREDIT_TYPE_USD_ID, [
+        { product_name: WORKSPACE_SEAT_PRODUCT_NAME, price: 2000 },
+        {
+          product_name:
+            WORKSPACE_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
+          price: 24000,
+        },
+      ]),
+      ...BILLING_CYCLE_CONFIG,
+    },
+    {
+      name: "Enterprise Pooled EUR",
+      aliases: [{ name: "enterprise-eur" }],
+      rate_card_name: "Standard EUR",
+      subscriptions: ALL_SEAT_SUBSCRIPTIONS,
+      scheduled_charges_on_usage_invoices: "ALL",
+      recurring_credits: getAllSeatRecurringCredits(),
+      overrides: buildSeatEntitlementOverrides(CREDIT_TYPE_EUR_ID, [
+        { product_name: WORKSPACE_SEAT_PRODUCT_NAME, price: 20 },
+        {
+          product_name:
+            WORKSPACE_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
+          price: 240,
+        },
+      ]),
+      ...BILLING_CYCLE_CONFIG,
+    },
+    {
+      name: "Enterprise Seat-based USD",
+      aliases: [{ name: "enterprise-seat-based-usd" }],
+      rate_card_name: "Standard USD",
+      subscriptions: ALL_SEAT_SUBSCRIPTIONS,
+      scheduled_charges_on_usage_invoices: "ALL",
+      recurring_credits: getAllSeatRecurringCredits(),
+      overrides: buildSeatEntitlementOverrides(CREDIT_TYPE_USD_ID, [
+        { product_name: PRO_SEAT_PRODUCT_NAME, price: 4400 },
+        {
+          product_name: PRO_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
+          price: 52800,
+        },
+        { product_name: MAX_SEAT_PRODUCT_NAME, price: 14000 },
+        {
+          product_name: MAX_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
+          price: 168000,
+        },
+      ]),
+      ...BILLING_CYCLE_CONFIG,
+    },
+    {
+      name: "Enterprise Seat-based EUR",
+      aliases: [{ name: "enterprise-seat-based-eur" }],
+      rate_card_name: "Standard EUR",
+      subscriptions: ALL_SEAT_SUBSCRIPTIONS,
+      scheduled_charges_on_usage_invoices: "ALL",
+      recurring_credits: getAllSeatRecurringCredits(),
+      overrides: buildSeatEntitlementOverrides(CREDIT_TYPE_EUR_ID, [
+        { product_name: PRO_SEAT_PRODUCT_NAME, price: 44 },
+        {
+          product_name: PRO_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
+          price: 528,
+        },
+        { product_name: MAX_SEAT_PRODUCT_NAME, price: 140 },
+        {
+          product_name: MAX_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
+          price: 1680,
+        },
+      ]),
+      ...BILLING_CYCLE_CONFIG,
+    },
+    // Business USD / EUR — Pro and Max seats (plus the free starter seat) priced
+    // via overrides; per-seat INDIVIDUAL AWU credit allocations (Pro: 8000 /
+    // Max: 40000 AWU/month) live in the shared credit set. Customers can
+    // upgrade/downgrade between seat tiers via seat moves.
+    {
+      name: "Business USD",
+      aliases: [{ name: "business-usd" }],
+      rate_card_name: "Standard USD",
+      subscriptions: ALL_SEAT_SUBSCRIPTIONS,
+      scheduled_charges_on_usage_invoices: "ALL",
+      recurring_credits: getAllSeatRecurringCredits(),
+      overrides: buildSeatEntitlementOverrides(CREDIT_TYPE_USD_ID, [
+        { product_name: PRO_SEAT_PRODUCT_NAME, price: 3000 },
+        {
+          product_name: PRO_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
+          price: 28800,
+        },
+        { product_name: MAX_SEAT_PRODUCT_NAME, price: 15000 },
+        {
+          product_name: MAX_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
+          price: 144000,
+        },
+        { product_name: FREE_SEAT_PRODUCT_NAME, price: 0 },
+      ]),
+      ...BILLING_CYCLE_CONFIG,
+    },
+    {
+      name: "Business EUR",
+      aliases: [{ name: "business-eur" }],
+      rate_card_name: "Standard EUR",
+      subscriptions: ALL_SEAT_SUBSCRIPTIONS,
+      scheduled_charges_on_usage_invoices: "ALL",
+      recurring_credits: getAllSeatRecurringCredits(),
+      overrides: buildSeatEntitlementOverrides(CREDIT_TYPE_EUR_ID, [
+        { product_name: PRO_SEAT_PRODUCT_NAME, price: 30 },
+        {
+          product_name: PRO_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
+          price: 288,
+        },
+        { product_name: MAX_SEAT_PRODUCT_NAME, price: 150 },
+        {
+          product_name: MAX_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
+          price: 1440,
+        },
+        { product_name: FREE_SEAT_PRODUCT_NAME, price: 0 },
+      ]),
+      ...BILLING_CYCLE_CONFIG,
+    },
+    // Free plan — entitles only the Free Seat.
+    {
+      name: "Free plan",
+      aliases: [{ name: FREE_PACKAGE_ALIAS }],
+      rate_card_name: "Free plan",
+      subscriptions: ALL_SEAT_SUBSCRIPTIONS,
+      scheduled_charges_on_usage_invoices: "ALL",
+      recurring_credits: getAllSeatRecurringCredits(),
+      overrides: buildSeatEntitlementOverrides(CREDIT_TYPE_USD_ID, [
+        { product_name: FREE_SEAT_PRODUCT_NAME, price: 0 },
+      ]),
+      ...BILLING_CYCLE_CONFIG,
+    },
+  ];
+}

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -12,76 +12,36 @@
  * Requires: METRONOME_API_KEY env var
  */
 
-import {
-  AWU_PRICE_PER_CREDIT,
-  metronomeAmount,
-} from "@app/lib/metronome/amounts";
 import { getMetronomeClient } from "@app/lib/metronome/client";
 import {
-  AWU_PRIORITY_SEAT_ALLOCATION,
   CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
-  CREDIT_TYPE_EUR_ID,
   CREDIT_TYPE_USD_ID,
   DEV_CREDIT_TYPE_AWU_ID,
-  DEV_CREDIT_TYPE_PROG_USD_ID,
   PLAN_CODE_CUSTOM_FIELD_KEY,
   PROD_CREDIT_TYPE_AWU_ID,
-  PROD_CREDIT_TYPE_PROG_USD_ID,
-  SEAT_PRODUCT_YEARLY_SUFFIX,
   SEAT_TYPE_CUSTOM_FIELD_KEY,
   STRIPE_PRODUCT_ID_CUSTOM_FIELD_KEY,
 } from "@app/lib/metronome/constants";
-import { TOOL_CATEGORIES } from "@app/lib/metronome/events";
 import { invalidateProductSeatTypesCache } from "@app/lib/metronome/seat_types";
 import {
-  DEFAULT_AWU_EXCESS_RECURRING_AMOUNT,
-  DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT,
-  EXCESS_CREDIT_NAME,
-  FREE_ANNUAL_CREDIT_NAME,
-  FREE_MONTHLY_CREDIT_NAME,
-  FREE_PACKAGE_ALIAS,
-  LEGACY_BUSINESS_EUR_PACKAGE_ALIAS,
-  LEGACY_BUSINESS_PACKAGE_ALIAS,
-  LEGACY_ENTERPRISE_EUR_PACKAGE_ALIAS,
-  LEGACY_ENTERPRISE_PACKAGE_ALIAS,
-  LEGACY_PRO_ANNUAL_EUR_PACKAGE_ALIAS,
-  LEGACY_PRO_ANNUAL_PACKAGE_ALIAS,
-  LEGACY_PRO_MONTHLY_EUR_PACKAGE_ALIAS,
-  LEGACY_PRO_MONTHLY_PACKAGE_ALIAS,
-} from "@app/lib/metronome/types";
-import type { SupportedCurrency } from "@app/types/currency";
-
-// Number of pricing tiers for any tiered seat-style product (MAU, future).
-// Tier products and rates are derived from the prefix.
-const SEAT_TIER_COUNT = 6;
-
-const PROGRAMMATIC_USAGE_CREDITS_IN_USD_CENTS = 100;
-const PROGRAMMATIC_USAGE_CREDITS_IN_EUR = 0.87;
-
-const getOverageAwuRate = (currency: SupportedCurrency) => {
-  return metronomeAmount(AWU_PRICE_PER_CREDIT[currency] * 100, currency) * 2;
-};
-
-// Setup-only display names. Runtime code identifies seat-style subscriptions
-// via the `DUST_SEAT_TYPE` custom field on the product (see
-// SEAT_TYPE_CUSTOM_FIELD_KEY), not by name comparison.
-const WORKSPACE_SEAT_PRODUCT_NAME = "Workspace Seat";
-const PRO_SEAT_PRODUCT_NAME = "Pro Seat";
-const MAX_SEAT_PRODUCT_NAME = "Max Seat";
-const FREE_SEAT_PRODUCT_NAME = "Free Seat";
-const PRO_SEAT_CREDIT_NAME = "Pro Seat Credits";
-const MAX_SEAT_CREDIT_NAME = "Max Seat Credits";
-const FREE_SEAT_CREDIT_NAME = "Free Seat Credits";
-
-// Per-seat AWU allocations stamped onto recurring credits at package creation.
-// Runtime code reads the allocation from the contract's `recurring_credits`,
-// so these values aren't referenced anywhere else.
-const PRO_SEAT_MONTHLY_AWU_CREDITS = 8000;
-const MAX_SEAT_MONTHLY_AWU_CREDITS = 40000;
-// Per-seat AWU grant carried by the Free Seat subscription. Granted once
-// per seat on contract start and valid for the lifetime of the contract.
-// Never refilled.
-const FREE_SEAT_LIFETIME_AWU_CREDITS = 300;
+  getCreditTypeAwuId,
+  getCreditTypeProgrammaticUsdId,
+  type PackageDef,
+  PRODUCTS,
+  type ProductDef,
+  type RateCardDef,
+  setMetronomeEnv,
+} from "@app/lib/metronome/setup_common";
+import {
+  getLegacyPackages,
+  getLegacyRateCards,
+  LEGACY_METRICS,
+} from "@app/lib/metronome/setup_legacy";
+import {
+  getNewPackages,
+  getNewRateCards,
+  NEW_METRICS,
+} from "@app/lib/metronome/setup_new_pricing";
 
 if (!process.env.METRONOME_API_KEY) {
   console.error("METRONOME_API_KEY env var required");
@@ -112,1726 +72,6 @@ async function detectEnvironment(): Promise<"sandbox" | "production"> {
     "Cannot detect Metronome environment: AWU credit type not found. " +
       `Expected sandbox=${DEV_CREDIT_TYPE_AWU_ID} or production=${PROD_CREDIT_TYPE_AWU_ID}`
   );
-}
-
-// Resolved in main() before anything else runs.
-let ENV: "sandbox" | "production" = "sandbox";
-
-// Credit type accessors based on the script-detected ENV (not NODE_ENV).
-function getCreditTypeAwuId(): string {
-  return ENV === "sandbox" ? DEV_CREDIT_TYPE_AWU_ID : PROD_CREDIT_TYPE_AWU_ID;
-}
-
-function getCreditTypeProgrammaticUsdId(): string {
-  return ENV === "sandbox"
-    ? DEV_CREDIT_TYPE_PROG_USD_ID
-    : PROD_CREDIT_TYPE_PROG_USD_ID;
-}
-
-// ---------------------------------------------------------------------------
-// Types for desired state definitions
-// ---------------------------------------------------------------------------
-
-interface MetricDef {
-  name: string;
-  event_type_filter: { in_values: string[] };
-  property_filters: Array<{
-    name: string;
-    exists?: boolean;
-    in_values?: string[];
-  }>;
-  aggregation_type: "SUM" | "COUNT" | "max";
-  aggregation_key?: string;
-  group_keys?: string[][];
-}
-
-interface ProductDef {
-  name: string;
-  type: "USAGE" | "SUBSCRIPTION" | "FIXED";
-  billable_metric_name?: string;
-  quantity_conversion?: {
-    conversion_factor: number;
-    operation: "DIVIDE" | "MULTIPLY";
-  };
-  quantity_rounding?: {
-    decimal_places: number;
-    rounding_method: "ROUND_UP" | "ROUND_DOWN" | "ROUND_HALF_UP";
-  };
-  pricing_group_key?: string[];
-  presentation_group_key?: string[];
-  tags?: string[];
-  /**
-   * Custom fields stamped on the product. Reconciled via `setValues` so a
-   * field change does NOT trigger a product recreate.
-   */
-  custom_fields?: Record<string, string>;
-}
-
-interface RateDef {
-  product_name: string;
-  starting_at: string;
-  entitled: boolean;
-  rate_type: string;
-  price: number;
-  billing_frequency?: string;
-  credit_type_id?: string;
-  pricing_group_values?: Record<string, string>;
-}
-
-interface RateCardDef {
-  name: string;
-  description: string;
-  aliases: Array<{ name: string }>;
-  fiat_credit_type_id: string;
-  credit_type_conversions?: Array<{
-    custom_credit_type_id: string;
-    fiat_per_custom_credit: number;
-  }>;
-  rates: RateDef[];
-}
-
-interface PackageSubscription {
-  temporary_id: string;
-  product_name: string; // resolved to product ID at runtime
-  billing_frequency: "MONTHLY" | "QUARTERLY" | "ANNUAL" | "WEEKLY";
-  collection_schedule: "ADVANCE" | "ARREARS";
-  quantity_management_mode: "SEAT_BASED" | "QUANTITY_ONLY";
-  seat_config?: { seat_group_key: string };
-  /** Required for QUANTITY_ONLY mode — initial seat count (set at contract creation). */
-  initial_quantity?: number;
-  proration?: {
-    is_prorated: boolean;
-    invoice_behavior?: "BILL_IMMEDIATELY" | "BILL_ON_NEXT_COLLECTION_DATE";
-  };
-}
-
-interface RecurringCreditDef {
-  product_name: string; // resolved to product ID at runtime
-  access_amount: {
-    credit_type_id: string; // evaluated after detectEnvironment()
-    unit_price: number;
-    quantity?: number;
-  };
-  commit_duration: { value: number; unit?: "PERIODS" };
-  priority: number;
-  starting_at_offset: {
-    unit: "DAYS" | "WEEKS" | "MONTHS" | "YEARS";
-    value: number;
-  };
-  applicable_product_tags?: string[];
-  // Mutually exclusive with applicable_product_tags. Filters drawdown by
-  // pricing/presentation group values (e.g. { is_free_usage: "true" }).
-  specifiers?: Array<{
-    presentation_group_values?: Record<string, string>;
-    pricing_group_values?: Record<string, string>;
-    product_tags?: string[];
-  }>;
-  recurrence_frequency?: "MONTHLY" | "QUARTERLY" | "ANNUAL" | "WEEKLY";
-  // Optional. Offset relative to the recurring credit start that determines
-  // when the contract will stop creating recurring commits. Use a very small
-  // value (e.g. 1 day) to make the credit one-shot — Metronome fires the
-  // first commit on contract start, then the duration expires before the
-  // next would be issued.
-  duration?: {
-    unit: "DAYS" | "WEEKS" | "MONTHS" | "YEARS";
-    value: number;
-  };
-  name?: string;
-  // Attach the credit to a SEAT_BASED subscription so each seat gets its own
-  // allocation (INDIVIDUAL) or all seats share one pool (POOLED).
-  // `subscription_temporary_id` references the `temporary_id` of a Subscription
-  // defined in the same package payload.
-  subscription_config?: {
-    subscription_temporary_id: string;
-    allocation: "INDIVIDUAL" | "POOLED";
-    apply_seat_increase_config: { is_prorated: boolean };
-  };
-}
-
-// Package-level entitlement override for a specific product on the package's
-// rate card, applied from contract start. Used by the Enterprise Seat-based
-// packages to flip the default rate-card entitlements (Workspace true → false,
-// Pro/Max/Free false → true) without duplicating the rate card. Only flips
-// `entitled` — the rate-card's price/billing_frequency/credit_type are
-// preserved.
-interface PackageOverrideDef {
-  product_name: string;
-  entitled: boolean;
-}
-
-interface PackageDef {
-  // Base name without version suffix. Version is auto-computed at sync time.
-  name: string;
-  aliases: Array<{ name: string }>;
-  rate_card_name: string;
-  subscriptions?: PackageSubscription[];
-  // Billing cycle anchored to contract start date (matches Stripe subscription anniversary).
-  billing_anchor_date?: "contract_start_date" | "first_billing_period";
-  usage_statement_schedule?: {
-    frequency: "MONTHLY" | "QUARTERLY" | "ANNUAL" | "WEEKLY";
-    day?: "CONTRACT_START" | "FIRST_OF_MONTH";
-  };
-  // Consolidate scheduled/commit charges onto the usage invoice instead of separate invoices.
-  scheduled_charges_on_usage_invoices?: "ALL";
-  recurring_credits?: RecurringCreditDef[];
-  overrides?: PackageOverrideDef[];
-}
-
-// ---------------------------------------------------------------------------
-// Desired state
-// ---------------------------------------------------------------------------
-
-const METRICS: MetricDef[] = [
-  {
-    name: "LLM Provider Cost (Programmatic)",
-    event_type_filter: { in_values: ["llm_usage_v3"] },
-    property_filters: [
-      { name: "cost_micro_usd", exists: true },
-      { name: "is_programmatic_usage", in_values: ["true"] },
-      { name: "api_key_name", exists: true },
-      { name: "model_id", exists: true },
-      { name: "origin", exists: true },
-      { name: "agent_id", exists: true },
-    ],
-    aggregation_type: "SUM",
-    aggregation_key: "cost_micro_usd",
-    group_keys: [["api_key_name"], ["model_id"], ["origin"], ["agent_id"]],
-  },
-  // Tool invocation metric — counts tool uses, group keys cover both user and
-  // programmatic events. `is_programmatic_usage` is the authoritative split
-  // signal: sentinel values like user_id="unknown" or api_key_name="unknown"
-  // are not reliable (programmatic callers without an API key still emit
-  // user_id="unknown" but must be classed as programmatic).
-  {
-    name: "Tool Invocations",
-    event_type_filter: { in_values: ["tool_use_v3"] },
-    property_filters: [
-      { name: "count", exists: true },
-      { name: "usage_type", exists: true },
-      { name: "tool_category", exists: true },
-      { name: "tool_group", exists: true },
-      { name: "user_id", exists: true },
-      { name: "api_key_name", exists: true },
-      { name: "origin", exists: true },
-      { name: "agent_id", exists: true },
-      { name: "mcp_server_id", exists: true },
-    ],
-    aggregation_type: "SUM",
-    aggregation_key: "count",
-    // 7 group keys — Metronome's default cap is 5; this metric needs an
-    // explicit limit increase (granted by Metronome support).
-    group_keys: [
-      ["user_id", "usage_type", "tool_category"],
-      ["user_id"],
-      ["api_key_name"],
-      ["tool_category"],
-      ["origin"],
-      ["agent_id"],
-      ["usage_type"],
-    ],
-  },
-  // AWU-based AI cost metric — sums cost_awu directly (no unit conversion).
-  // Powers the new AI Usage product on all AWU rate cards (Business, Enterprise).
-  // Group keys cover both user and programmatic events; per-seat credit drawdown
-  // only matches events whose `user_id` is assigned to a seat.
-  {
-    name: "LLM Provider Cost AWU",
-    event_type_filter: { in_values: ["llm_usage_v3"] },
-    property_filters: [
-      { name: "cost_awu", exists: true },
-      { name: "usage_type", exists: true },
-      { name: "user_id", exists: true },
-      { name: "api_key_name", exists: true },
-      { name: "model_id", exists: true },
-      { name: "origin", exists: true },
-      { name: "agent_id", exists: true },
-    ],
-    aggregation_type: "SUM",
-    aggregation_key: "cost_awu",
-    // 7 group keys — see note on Tool Invocations above.
-    group_keys: [
-      ["user_id", "usage_type"],
-      ["user_id"],
-      ["api_key_name"],
-      ["model_id"],
-      ["origin"],
-      ["agent_id"],
-      ["usage_type"],
-    ],
-  },
-  // Phase 2 token metrics removed — will be added when Pricing Index is ready.
-];
-
-// Tag shared by all AI/Tool usage products — use `applicable_product_tags: ["usage"]`
-// on credits/commits to apply them to all usage products at once.
-const USAGE_TAG = "usage";
-
-const PRODUCTS: ProductDef[] = [
-  // --- Legacy usage product (USD, 30% markup baked into quantity_conversion) ---
-  {
-    name: "Programmatic Usage",
-    type: "USAGE",
-    billable_metric_name: "LLM Provider Cost (Programmatic)",
-    // Convert cost_micro_usd to billable USD: multiply by 1.3 (30% markup) / 1_000_000 (micro→USD).
-    // The rate card prices at $1.00/unit so the final amount equals the marked-up cost.
-    quantity_conversion: {
-      conversion_factor: 1.3 / 1_000_000,
-      operation: "MULTIPLY",
-    },
-    // Round up to cents (2 decimal places) — never undercharge.
-    quantity_rounding: { decimal_places: 2, rounding_method: "ROUND_UP" },
-    tags: [USAGE_TAG],
-  },
-  // --- New pricing usage products (AWU) ---
-  // 1 AWU = $0.01. AI Usage is priced directly on the cost_awu event property
-  // (no quantity_conversion). Tool Usage: count × tool_weight = AWU (weight
-  // configured per tool category in rate card via pricing_group_values).
-  // Single product per usage type — the metric carries both `user_id` and
-  // `api_key_name` as group keys so per-seat credits and workspace pool credits
-  // are dispatched correctly by Metronome based on the event's properties.
-  {
-    name: "AI Usage",
-    type: "USAGE",
-    billable_metric_name: "LLM Provider Cost AWU",
-    pricing_group_key: ["usage_type"],
-    presentation_group_key: ["user_id"],
-    tags: [USAGE_TAG],
-  },
-  {
-    name: "Tool Usage",
-    type: "USAGE",
-    billable_metric_name: "Tool Invocations",
-    pricing_group_key: ["usage_type", "tool_category"],
-    presentation_group_key: ["user_id"],
-    tags: [USAGE_TAG],
-  },
-  // Workspace Seat — single SUBSCRIPTION product covering both legacy (ANNUAL)
-  // and new (MONTHLY) per-seat plans. Seats synced from membership create/revoke
-  // hooks; price/frequency differs between rate cards.
-  {
-    name: WORKSPACE_SEAT_PRODUCT_NAME,
-    type: "SUBSCRIPTION",
-    custom_fields: { [SEAT_TYPE_CUSTOM_FIELD_KEY]: "workspace" },
-  },
-  {
-    name: WORKSPACE_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
-    type: "SUBSCRIPTION",
-    custom_fields: { [SEAT_TYPE_CUSTOM_FIELD_KEY]: "workspace_yearly" },
-  },
-  // Pro Seat / Max Seat — SUBSCRIPTION products for the new Business / Enterprise
-  // seat-based plans. Used as SEAT_BASED subscriptions in packages with per-seat
-  // INDIVIDUAL recurring credits (Pro: 8000 AWU/mo, Max: 40000 AWU/mo).
-  {
-    name: PRO_SEAT_PRODUCT_NAME,
-    type: "SUBSCRIPTION",
-    custom_fields: { [SEAT_TYPE_CUSTOM_FIELD_KEY]: "pro" },
-  },
-  {
-    name: PRO_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
-    type: "SUBSCRIPTION",
-    custom_fields: { [SEAT_TYPE_CUSTOM_FIELD_KEY]: "pro_yearly" },
-  },
-  {
-    name: MAX_SEAT_PRODUCT_NAME,
-    type: "SUBSCRIPTION",
-    custom_fields: { [SEAT_TYPE_CUSTOM_FIELD_KEY]: "max" },
-  },
-  {
-    name: MAX_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
-    type: "SUBSCRIPTION",
-    custom_fields: { [SEAT_TYPE_CUSTOM_FIELD_KEY]: "max_yearly" },
-  },
-
-  // Free Seat — SUBSCRIPTION product priced at $0/seat. Carries a one-shot
-  // lifetime AWU credit (300 AWU per seat) so free users have a small drawdown
-  // pool without being billed.
-  {
-    name: FREE_SEAT_PRODUCT_NAME,
-    type: "SUBSCRIPTION",
-    custom_fields: { [SEAT_TYPE_CUSTOM_FIELD_KEY]: "free" },
-  },
-  // MAU product — single subscription for simple (non-tiered) enterprise contracts.
-  // Used when no MAU_TIERS custom field is set on the contract.
-  { name: "MAU", type: "SUBSCRIPTION" },
-  // Tiered seat products — one per pricing tier for contracts with graduated
-  // pricing. Not entitled by default; enabled per contract via overrides.
-  // Quantity managed by the MAU/seat sync flow based on the contract's tier
-  // custom field.
-  ...buildSeatTierProducts("MAU"),
-  // MAU Commit — appears as a line item on invoices for the monthly minimum charge.
-  { name: "MAU Commit", type: "FIXED" },
-  // FIXED products for credit grants — separate products for distinct invoice line items.
-  {
-    name: "Free Credits",
-    type: "FIXED",
-  },
-  {
-    name: "Excess Credits",
-    type: "FIXED",
-  },
-  {
-    name: "Prepaid Commit",
-    type: "FIXED",
-  },
-  {
-    name: "Seat Individual Credits",
-    type: "FIXED",
-  },
-  {
-    name: "Seat Subscription Credits",
-    type: "FIXED",
-  },
-];
-
-// "MAU Tier 1", …, "MAU Tier 6".
-function buildSeatTierProductNames(prefix: string): string[] {
-  return Array.from(
-    { length: SEAT_TIER_COUNT },
-    (_, i) => `${prefix} Tier ${i + 1}`
-  );
-}
-
-// SUBSCRIPTION product entries to inject into PRODUCTS for a tiered seat family.
-function buildSeatTierProducts(prefix: string): ProductDef[] {
-  return buildSeatTierProductNames(prefix).map(
-    (name): ProductDef => ({ name, type: "SUBSCRIPTION" })
-  );
-}
-
-// Default rate entries for a tiered seat family on a rate card. Not entitled
-// by default — enabled per contract via overrides with per-tier pricing.
-function buildSeatTierRates({
-  prefix,
-  creditTypeId,
-}: {
-  prefix: string;
-  creditTypeId: string;
-}): RateDef[] {
-  return buildSeatTierProductNames(prefix).map(
-    (name): RateDef => ({
-      product_name: name,
-      starting_at: "2026-04-01T00:00:00.000Z",
-      entitled: false,
-      rate_type: "FLAT",
-      billing_frequency: "MONTHLY",
-      price: 0,
-      credit_type_id: creditTypeId,
-    })
-  );
-}
-
-// Per-tier AWU price for Tool Usage rates. Shared across all AWU-priced rate cards
-const TOOL_CATEGORY_PRICES_AWU: Record<
-  (typeof TOOL_CATEGORIES)[number],
-  number
-> = {
-  basic: 1,
-  advanced: 3,
-};
-
-// usage_type splits each AWU usage rate: "user" and "programmatic" use the
-// nominal price, "free" is priced at 0 (covers free-tagged events, replacing
-// the prior recurring-credit mechanism).
-const PAID_USAGE_TYPES = ["user", "programmatic"] as const;
-
-function buildAwuToolUsageRates(): RateDef[] {
-  return TOOL_CATEGORIES.flatMap((category): RateDef[] => [
-    ...PAID_USAGE_TYPES.map(
-      (usageType): RateDef => ({
-        product_name: "Tool Usage",
-        starting_at: "2026-04-01T00:00:00.000Z",
-        entitled: true,
-        rate_type: "FLAT",
-        price: TOOL_CATEGORY_PRICES_AWU[category],
-        credit_type_id: getCreditTypeAwuId(),
-        pricing_group_values: {
-          tool_category: category,
-          usage_type: usageType,
-        },
-      })
-    ),
-    {
-      product_name: "Tool Usage",
-      starting_at: "2026-04-01T00:00:00.000Z",
-      entitled: true,
-      rate_type: "FLAT",
-      price: 0,
-      credit_type_id: getCreditTypeAwuId(),
-      pricing_group_values: { tool_category: category, usage_type: "free" },
-    },
-  ]);
-}
-
-// AI Usage rates split by usage_type: paid types use the nominal 1 AWU price,
-// free is priced at 0.
-function buildAwuAiUsageRates(): RateDef[] {
-  return [
-    ...PAID_USAGE_TYPES.map(
-      (usageType): RateDef => ({
-        product_name: "AI Usage",
-        starting_at: "2026-04-01T00:00:00.000Z",
-        entitled: true,
-        rate_type: "FLAT",
-        price: 1,
-        credit_type_id: getCreditTypeAwuId(),
-        pricing_group_values: { usage_type: usageType },
-      })
-    ),
-    {
-      product_name: "AI Usage",
-      starting_at: "2026-04-01T00:00:00.000Z",
-      entitled: true,
-      rate_type: "FLAT",
-      price: 0,
-      credit_type_id: getCreditTypeAwuId(),
-      pricing_group_values: { usage_type: "free" },
-    },
-  ];
-}
-
-// Function — evaluated after detectEnvironment() resolves ENV (needed for AWU credit type).
-function getRateCards(): RateCardDef[] {
-  return [
-    {
-      name: "Legacy Pro USD",
-      description:
-        "Grandfathered Pro plan. $29/seat via seat subscription. AI usage 30% markup.",
-      aliases: [{ name: "legacy-pro-monthly" }],
-      fiat_credit_type_id: CREDIT_TYPE_USD_ID,
-      credit_type_conversions: [
-        {
-          custom_credit_type_id: getCreditTypeProgrammaticUsdId(),
-          fiat_per_custom_credit: PROGRAMMATIC_USAGE_CREDITS_IN_USD_CENTS,
-        },
-      ],
-      rates: [
-        {
-          product_name: WORKSPACE_SEAT_PRODUCT_NAME,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          price: 2900,
-          billing_frequency: "MONTHLY",
-        },
-        {
-          product_name: "Programmatic Usage",
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          price: 1,
-          credit_type_id: getCreditTypeProgrammaticUsdId(),
-        },
-      ],
-    },
-    {
-      name: "Legacy Business USD",
-      description:
-        "Grandfathered Business plan. $45/seat via seat subscription. AI usage 30% markup.",
-      aliases: [{ name: "legacy-business" }],
-      fiat_credit_type_id: CREDIT_TYPE_USD_ID,
-      credit_type_conversions: [
-        {
-          custom_credit_type_id: getCreditTypeProgrammaticUsdId(),
-          fiat_per_custom_credit: PROGRAMMATIC_USAGE_CREDITS_IN_USD_CENTS,
-        },
-      ],
-      rates: [
-        {
-          product_name: WORKSPACE_SEAT_PRODUCT_NAME,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          price: 4500,
-          billing_frequency: "MONTHLY",
-        },
-        {
-          product_name: "Programmatic Usage",
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          price: 1,
-          credit_type_id: getCreditTypeProgrammaticUsdId(),
-        },
-      ],
-    },
-    {
-      name: "Legacy Pro Annual USD",
-      description:
-        "Grandfathered Pro plan (annual). $27/seat/month billed monthly. AI usage 30% markup.",
-      aliases: [{ name: "legacy-pro-annual" }],
-      fiat_credit_type_id: CREDIT_TYPE_USD_ID,
-      credit_type_conversions: [
-        {
-          custom_credit_type_id: getCreditTypeProgrammaticUsdId(),
-          fiat_per_custom_credit: PROGRAMMATIC_USAGE_CREDITS_IN_USD_CENTS,
-        },
-      ],
-      rates: [
-        {
-          product_name: WORKSPACE_SEAT_PRODUCT_NAME,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          price: 32400,
-          billing_frequency: "ANNUAL",
-        },
-        {
-          product_name: "Programmatic Usage",
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          price: 1,
-          credit_type_id: getCreditTypeProgrammaticUsdId(),
-        },
-      ],
-    },
-    // --- Enterprise plan: MAU-based billing + programmatic usage ---
-    // Default: MAU-1 at $45/MAU. MAU-5/MAU-10 not entitled by default but present
-    // on the rate card so they can be enabled per contract via overrides.
-    // Programmatic usage at $1 = $1 (30% markup baked into product).
-    {
-      name: "Legacy Enterprise MAU USD",
-      description:
-        "Enterprise plan. Per-MAU billing + programmatic usage at cost with 30% markup.",
-      aliases: [{ name: "legacy-enterprise" }],
-      fiat_credit_type_id: CREDIT_TYPE_USD_ID,
-      credit_type_conversions: [
-        {
-          custom_credit_type_id: getCreditTypeProgrammaticUsdId(),
-          fiat_per_custom_credit: PROGRAMMATIC_USAGE_CREDITS_IN_USD_CENTS,
-        },
-      ],
-      rates: [
-        {
-          product_name: "MAU",
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          billing_frequency: "MONTHLY",
-          price: 4500,
-        },
-        {
-          product_name: "Programmatic Usage",
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          price: 1,
-          credit_type_id: getCreditTypeProgrammaticUsdId(),
-        },
-        ...buildSeatTierRates({
-          prefix: "MAU",
-          creditTypeId: CREDIT_TYPE_USD_ID,
-        }),
-      ],
-    },
-    // --- EUR variants: same seat prices, billed in EUR ---
-    // For Eurozone/EEA/Switzerland customers.
-    // Programmatic usage: same product (quantity_conversion converts cost_micro_usd to units),
-    // but priced at 87 (€0.87/unit) instead of 100 ($1.00/unit) to apply the USD→EUR FX rate.
-    // EUR prices are in whole euros (not cents) — Metronome EUR pricing unit is "EUR".
-    {
-      name: "Legacy Pro EUR",
-      description:
-        "Grandfathered Pro plan (EUR). 29€/seat via seat subscription. AI usage 30% markup.",
-      aliases: [{ name: "legacy-pro-monthly-eur" }],
-      fiat_credit_type_id: CREDIT_TYPE_EUR_ID,
-      credit_type_conversions: [
-        {
-          custom_credit_type_id: getCreditTypeProgrammaticUsdId(),
-          fiat_per_custom_credit: PROGRAMMATIC_USAGE_CREDITS_IN_EUR,
-        },
-      ],
-      rates: [
-        {
-          product_name: WORKSPACE_SEAT_PRODUCT_NAME,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          price: 29,
-          billing_frequency: "MONTHLY",
-          credit_type_id: CREDIT_TYPE_EUR_ID,
-        },
-        {
-          product_name: "Programmatic Usage",
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          price: 1,
-          credit_type_id: getCreditTypeProgrammaticUsdId(),
-        },
-      ],
-    },
-    {
-      name: "Legacy Business EUR",
-      description:
-        "Grandfathered Business plan (EUR). 45€/seat via seat subscription. AI usage 30% markup.",
-      aliases: [{ name: "legacy-business-eur" }],
-      fiat_credit_type_id: CREDIT_TYPE_EUR_ID,
-      credit_type_conversions: [
-        {
-          custom_credit_type_id: getCreditTypeProgrammaticUsdId(),
-          fiat_per_custom_credit: PROGRAMMATIC_USAGE_CREDITS_IN_EUR,
-        },
-      ],
-      rates: [
-        {
-          product_name: WORKSPACE_SEAT_PRODUCT_NAME,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          price: 45,
-          billing_frequency: "MONTHLY",
-          credit_type_id: CREDIT_TYPE_EUR_ID,
-        },
-        {
-          product_name: "Programmatic Usage",
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          price: 1,
-          credit_type_id: getCreditTypeProgrammaticUsdId(),
-        },
-      ],
-    },
-    {
-      name: "Legacy Pro Annual EUR",
-      description:
-        "Grandfathered Pro plan (EUR, annual). 27€/seat/month billed monthly. AI usage 30% markup.",
-      aliases: [{ name: "legacy-pro-annual-eur" }],
-      fiat_credit_type_id: CREDIT_TYPE_EUR_ID,
-      credit_type_conversions: [
-        {
-          custom_credit_type_id: getCreditTypeProgrammaticUsdId(),
-          fiat_per_custom_credit: PROGRAMMATIC_USAGE_CREDITS_IN_EUR,
-        },
-      ],
-      rates: [
-        {
-          product_name: WORKSPACE_SEAT_PRODUCT_NAME,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          price: 324,
-          billing_frequency: "ANNUAL",
-          credit_type_id: CREDIT_TYPE_EUR_ID,
-        },
-        {
-          product_name: "Programmatic Usage",
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          price: 1,
-          credit_type_id: getCreditTypeProgrammaticUsdId(),
-        },
-      ],
-    },
-    {
-      name: "Legacy Enterprise MAU EUR",
-      description:
-        "Enterprise plan (EUR). Per-MAU billing + programmatic usage at cost with 30% markup.",
-      aliases: [{ name: "legacy-enterprise-eur" }],
-      fiat_credit_type_id: CREDIT_TYPE_EUR_ID,
-      credit_type_conversions: [
-        {
-          custom_credit_type_id: getCreditTypeProgrammaticUsdId(),
-          fiat_per_custom_credit: PROGRAMMATIC_USAGE_CREDITS_IN_EUR,
-        },
-      ],
-      rates: [
-        {
-          product_name: "MAU",
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          billing_frequency: "MONTHLY",
-          price: 45,
-          credit_type_id: CREDIT_TYPE_EUR_ID,
-        },
-        {
-          product_name: "Programmatic Usage",
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          price: 1,
-          credit_type_id: getCreditTypeProgrammaticUsdId(),
-        },
-        ...buildSeatTierRates({
-          prefix: "MAU",
-          creditTypeId: CREDIT_TYPE_EUR_ID,
-        }),
-      ],
-    },
-    // --- Enterprise USD: new (non-legacy) enterprise rate card ---
-    // Same shape as Enterprise EUR, priced in USD.
-    // - Workspace Seat: $45/seat/month (price in cents).
-    // - AI Usage: 1 AWU per cost_awu unit for user/programmatic usage, 0 for free.
-    // - Tool Usage: per-category AWU price (×1/×2) for user/programmatic, 0 for free.
-    {
-      name: "Enterprise USD",
-      description:
-        "Enterprise plan (USD). Per-seat billing + AWU-based AI/Tool usage.",
-      aliases: [{ name: "enterprise-usd" }],
-      fiat_credit_type_id: CREDIT_TYPE_USD_ID,
-      credit_type_conversions: [
-        {
-          custom_credit_type_id: getCreditTypeAwuId(),
-          fiat_per_custom_credit: getOverageAwuRate("usd"),
-        },
-      ],
-      rates: [
-        {
-          product_name: WORKSPACE_SEAT_PRODUCT_NAME,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          billing_frequency: "MONTHLY",
-          price: 2000,
-          credit_type_id: CREDIT_TYPE_USD_ID,
-        },
-        {
-          product_name:
-            WORKSPACE_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          billing_frequency: "ANNUAL",
-          price: 24000,
-          credit_type_id: CREDIT_TYPE_USD_ID,
-        },
-        {
-          product_name: PRO_SEAT_PRODUCT_NAME,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: false,
-          rate_type: "FLAT",
-          billing_frequency: "MONTHLY",
-          price: 4400,
-          credit_type_id: CREDIT_TYPE_USD_ID,
-        },
-        {
-          product_name: PRO_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: false,
-          rate_type: "FLAT",
-          billing_frequency: "ANNUAL",
-          price: 528000,
-          credit_type_id: CREDIT_TYPE_USD_ID,
-        },
-        {
-          product_name: MAX_SEAT_PRODUCT_NAME,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: false,
-          rate_type: "FLAT",
-          billing_frequency: "MONTHLY",
-          price: 14000,
-          credit_type_id: CREDIT_TYPE_USD_ID,
-        },
-        {
-          product_name: MAX_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: false,
-          rate_type: "FLAT",
-          billing_frequency: "ANNUAL",
-          price: 168000,
-          credit_type_id: CREDIT_TYPE_USD_ID,
-        },
-        {
-          product_name: FREE_SEAT_PRODUCT_NAME,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: false,
-          rate_type: "FLAT",
-          billing_frequency: "MONTHLY",
-          price: 0,
-          credit_type_id: CREDIT_TYPE_USD_ID,
-        },
-        ...buildAwuAiUsageRates(),
-        ...buildAwuToolUsageRates(),
-      ],
-    },
-    // --- Enterprise EUR: new (non-legacy) enterprise rate card ---
-    // Per-seat billing in EUR + AWU-based AI/Tool usage.
-    // - Workspace Seat: €45/seat/month (subscription).
-    // - AI Usage: 1 AWU per cost_awu unit for user/programmatic usage, 0 for free.
-    // - Tool Usage: per-category AWU price (×1/×2) for user/programmatic, 0 for free.
-    {
-      name: "Enterprise EUR",
-      description:
-        "Enterprise plan (EUR). Per-seat billing + AWU-based AI/Tool usage.",
-      aliases: [{ name: "enterprise-eur" }],
-      fiat_credit_type_id: CREDIT_TYPE_EUR_ID,
-      credit_type_conversions: [
-        {
-          custom_credit_type_id: getCreditTypeAwuId(),
-          fiat_per_custom_credit: getOverageAwuRate("eur"),
-        },
-      ],
-      rates: [
-        {
-          product_name: WORKSPACE_SEAT_PRODUCT_NAME,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          billing_frequency: "MONTHLY",
-          price: 20,
-          credit_type_id: CREDIT_TYPE_EUR_ID,
-        },
-        {
-          product_name:
-            WORKSPACE_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          billing_frequency: "ANNUAL",
-          price: 240,
-          credit_type_id: CREDIT_TYPE_EUR_ID,
-        },
-        {
-          product_name: PRO_SEAT_PRODUCT_NAME,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: false,
-          rate_type: "FLAT",
-          billing_frequency: "MONTHLY",
-          price: 44,
-          credit_type_id: CREDIT_TYPE_EUR_ID,
-        },
-        {
-          product_name: PRO_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: false,
-          rate_type: "FLAT",
-          billing_frequency: "ANNUAL",
-          price: 528,
-          credit_type_id: CREDIT_TYPE_EUR_ID,
-        },
-        {
-          product_name: MAX_SEAT_PRODUCT_NAME,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: false,
-          rate_type: "FLAT",
-          billing_frequency: "MONTHLY",
-          price: 140,
-          credit_type_id: CREDIT_TYPE_EUR_ID,
-        },
-        {
-          product_name: MAX_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: false,
-          rate_type: "FLAT",
-          billing_frequency: "ANNUAL",
-          price: 1680,
-          credit_type_id: CREDIT_TYPE_EUR_ID,
-        },
-        {
-          product_name: FREE_SEAT_PRODUCT_NAME,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: false,
-          rate_type: "FLAT",
-          billing_frequency: "MONTHLY",
-          price: 0,
-          credit_type_id: CREDIT_TYPE_EUR_ID,
-        },
-        ...buildAwuAiUsageRates(),
-        ...buildAwuToolUsageRates(),
-      ],
-    },
-    // --- Business USD: new seat-based plan (Pro / Max seats) ---
-    // Pro Seat: $29/mo. Max Seat: $149/mo. Both billed MONTHLY.
-    // AI/Tool usage priced in AWU (1 AWU = 1 USD cent = $0.01).
-    // Per-seat credit allocation lives in the package (8000 / 40000 AWU/mo).
-    {
-      name: "Business USD",
-      description:
-        "Business plan (USD). Pro/Max seats with per-seat AWU credit allocation.",
-      aliases: [{ name: "business-usd" }],
-      // free for first-time joiners (one-shot starter), pro for re-joiners.
-      fiat_credit_type_id: CREDIT_TYPE_USD_ID,
-      credit_type_conversions: [
-        {
-          custom_credit_type_id: getCreditTypeAwuId(),
-          fiat_per_custom_credit: getOverageAwuRate("usd"),
-        },
-      ],
-      rates: [
-        {
-          product_name: PRO_SEAT_PRODUCT_NAME,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          billing_frequency: "MONTHLY",
-          price: 3000,
-          credit_type_id: CREDIT_TYPE_USD_ID,
-        },
-        {
-          product_name: PRO_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          billing_frequency: "ANNUAL",
-          price: 28800,
-          credit_type_id: CREDIT_TYPE_USD_ID,
-        },
-        {
-          product_name: MAX_SEAT_PRODUCT_NAME,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          billing_frequency: "MONTHLY",
-          price: 15000,
-          credit_type_id: CREDIT_TYPE_USD_ID,
-        },
-        {
-          product_name: MAX_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          billing_frequency: "ANNUAL",
-          price: 144000,
-          credit_type_id: CREDIT_TYPE_USD_ID,
-        },
-        {
-          product_name: FREE_SEAT_PRODUCT_NAME,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          billing_frequency: "MONTHLY",
-          price: 0,
-          credit_type_id: CREDIT_TYPE_USD_ID,
-        },
-        ...buildAwuAiUsageRates(),
-        ...buildAwuToolUsageRates(),
-      ],
-    },
-    // --- Business EUR: EUR variant of the seat-based plan ---
-    // Same shape as Business USD; EUR prices in whole euros.
-    {
-      name: "Business EUR",
-      description:
-        "Business plan (EUR). Pro/Max seats with per-seat AWU credit allocation.",
-      aliases: [{ name: "business-eur" }],
-      // free for first-time joiners (one-shot starter), pro for re-joiners.
-      fiat_credit_type_id: CREDIT_TYPE_EUR_ID,
-      credit_type_conversions: [
-        {
-          custom_credit_type_id: getCreditTypeAwuId(),
-          fiat_per_custom_credit: getOverageAwuRate("eur"),
-        },
-      ],
-      rates: [
-        {
-          product_name: PRO_SEAT_PRODUCT_NAME,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          billing_frequency: "MONTHLY",
-          price: 30,
-          credit_type_id: CREDIT_TYPE_EUR_ID,
-        },
-        {
-          product_name: PRO_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          billing_frequency: "ANNUAL",
-          price: 288,
-          credit_type_id: CREDIT_TYPE_EUR_ID,
-        },
-        {
-          product_name: MAX_SEAT_PRODUCT_NAME,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          billing_frequency: "MONTHLY",
-          price: 150,
-          credit_type_id: CREDIT_TYPE_EUR_ID,
-        },
-        {
-          product_name: MAX_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          billing_frequency: "ANNUAL",
-          price: 1440,
-          credit_type_id: CREDIT_TYPE_EUR_ID,
-        },
-        {
-          product_name: FREE_SEAT_PRODUCT_NAME,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          billing_frequency: "MONTHLY",
-          price: 0,
-          credit_type_id: CREDIT_TYPE_EUR_ID,
-        },
-        ...buildAwuAiUsageRates(),
-        ...buildAwuToolUsageRates(),
-      ],
-    },
-    {
-      name: "Free plan",
-      description: "Free plan.",
-      aliases: [{ name: "free-plan" }],
-      fiat_credit_type_id: CREDIT_TYPE_USD_ID,
-      credit_type_conversions: [
-        {
-          custom_credit_type_id: getCreditTypeAwuId(),
-          fiat_per_custom_credit: 0,
-        },
-      ],
-      rates: [
-        {
-          product_name: FREE_SEAT_PRODUCT_NAME,
-          starting_at: "2026-04-01T00:00:00.000Z",
-          entitled: true,
-          rate_type: "FLAT",
-          billing_frequency: "MONTHLY",
-          price: 0,
-          credit_type_id: CREDIT_TYPE_USD_ID,
-        },
-        ...buildAwuAiUsageRates(),
-        ...buildAwuToolUsageRates(),
-      ],
-    },
-  ];
-}
-
-// Entitlement-flip overrides for the Seat-based Enterprise packages. The
-// rate card carries the default Pooled-style entitlements (Workspace=true,
-// Pro/Max/Free=false); for the Seat-based variant we flip them (Workspace=
-// false, Pro/Max/Free=true). The rate-card's price / billing_frequency /
-// credit_type stay in effect — only entitled changes.
-function buildSeatEntitlementFlipOverrides(): PackageOverrideDef[] {
-  return [
-    { product_name: WORKSPACE_SEAT_PRODUCT_NAME, entitled: false },
-    {
-      product_name: WORKSPACE_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
-      entitled: false,
-    },
-    { product_name: PRO_SEAT_PRODUCT_NAME, entitled: true },
-    {
-      product_name: PRO_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
-      entitled: true,
-    },
-    { product_name: MAX_SEAT_PRODUCT_NAME, entitled: true },
-    {
-      product_name: MAX_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
-      entitled: true,
-    },
-  ];
-}
-
-// Recurring free credit definition shared by all legacy monthly packages.
-// Quantity starts at 0 — the credit.segment.start webhook updates it each period
-// to the actual user-based amount.
-function getFreeMonthlyRecurringCredits(): RecurringCreditDef {
-  return {
-    product_name: "Free Credits",
-    access_amount: {
-      credit_type_id: getCreditTypeProgrammaticUsdId(),
-      unit_price: 0,
-      quantity: 1,
-    },
-    commit_duration: { value: 1, unit: "PERIODS" },
-    priority: 1,
-    starting_at_offset: { unit: "DAYS", value: 0 }, // starts immediately
-    applicable_product_tags: [USAGE_TAG],
-    recurrence_frequency: "MONTHLY",
-    name: FREE_MONTHLY_CREDIT_NAME,
-  };
-}
-
-// Annual variant for legacy annual packages. Same product, but the credit is granted
-// once per year. The credit.segment.start webhook detects ANNUAL recurrence
-// and multiplies the monthly bracket amount by 12.
-function getFreeAnnualRecurringCredits(): RecurringCreditDef {
-  return {
-    product_name: "Free Credits",
-    access_amount: {
-      credit_type_id: getCreditTypeProgrammaticUsdId(),
-      unit_price: 0,
-      quantity: 1,
-    },
-    commit_duration: { value: 1, unit: "PERIODS" },
-    priority: 1,
-    starting_at_offset: { unit: "DAYS", value: 0 }, // starts immediately
-    applicable_product_tags: [USAGE_TAG],
-    recurrence_frequency: "ANNUAL",
-    name: FREE_ANNUAL_CREDIT_NAME,
-  };
-}
-
-function getFreeExcessRecurringCredits(
-  creditTypeId: string,
-  quantity: number
-): RecurringCreditDef {
-  return {
-    product_name: "Excess Credits",
-    access_amount: {
-      credit_type_id: creditTypeId,
-      unit_price: quantity,
-      quantity: 1,
-    },
-    commit_duration: { value: 1, unit: "PERIODS" },
-    priority: 999,
-    starting_at_offset: { unit: "DAYS", value: 0 }, // starts immediately
-    applicable_product_tags: [USAGE_TAG],
-    recurrence_frequency: "MONTHLY",
-    name: EXCESS_CREDIT_NAME,
-  };
-}
-
-// Seat subscription definition shared by all legacy packages.
-const LEGACY_SEAT_SUBSCRIPTION: PackageSubscription = {
-  temporary_id: "legacy-seat-sub",
-  product_name: WORKSPACE_SEAT_PRODUCT_NAME,
-  billing_frequency: "MONTHLY",
-  collection_schedule: "ADVANCE",
-  quantity_management_mode: "QUANTITY_ONLY",
-  initial_quantity: 0,
-  proration: {
-    is_prorated: true,
-    invoice_behavior: "BILL_ON_NEXT_COLLECTION_DATE",
-  },
-};
-
-// Seat subscription definition shared by all legacy packages.
-const LEGACY_SEAT_ANNUAL_SUBSCRIPTION: PackageSubscription = {
-  temporary_id: "legacy-seat-annual-sub",
-  product_name: WORKSPACE_SEAT_PRODUCT_NAME,
-  billing_frequency: "ANNUAL",
-  collection_schedule: "ADVANCE",
-  quantity_management_mode: "QUANTITY_ONLY",
-  initial_quantity: 0,
-  proration: {
-    is_prorated: true,
-    invoice_behavior: "BILL_ON_NEXT_COLLECTION_DATE",
-  },
-};
-
-// Seat subscription definition for new (non-legacy) per-seat packages.
-// Same shape as LEGACY_SEAT_ANNUAL_SUBSCRIPTION but billed MONTHLY. Reuses the
-// Workspace Seat product so legacy and new plans share a single seat product.
-const WORKSPACE_SEAT_MONTHLY_SUBSCRIPTION: PackageSubscription = {
-  temporary_id: "workspace-seat-monthly-sub",
-  product_name: WORKSPACE_SEAT_PRODUCT_NAME,
-  billing_frequency: "MONTHLY",
-  collection_schedule: "ADVANCE",
-  quantity_management_mode: "QUANTITY_ONLY",
-  initial_quantity: 0,
-  proration: {
-    is_prorated: true,
-    invoice_behavior: "BILL_ON_NEXT_COLLECTION_DATE",
-  },
-};
-const WORKSPACE_SEAT_ANNUAL_SUBSCRIPTION: PackageSubscription = {
-  temporary_id: "workspace-seat-annual-sub",
-  product_name: WORKSPACE_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
-  billing_frequency: "ANNUAL",
-  collection_schedule: "ADVANCE",
-  quantity_management_mode: "QUANTITY_ONLY",
-  initial_quantity: 0,
-  proration: {
-    is_prorated: true,
-    invoice_behavior: "BILL_ON_NEXT_COLLECTION_DATE",
-  },
-};
-
-// SEAT_BASED subscriptions for the Business (and seat-based Enterprise) plans.
-// Seat group key is `user_id` — usage events carrying that property draw down
-// only the credits attached to the matching seat. The seat count is controlled
-// by add_seat_ids / remove_seat_ids via the contract edit API.
-const PRO_SEAT_SUBSCRIPTION_TEMPORARY_ID = "pro-seat-sub";
-const PRO_SEAT_SUBSCRIPTION: PackageSubscription = {
-  temporary_id: PRO_SEAT_SUBSCRIPTION_TEMPORARY_ID,
-  product_name: PRO_SEAT_PRODUCT_NAME,
-  billing_frequency: "MONTHLY",
-  collection_schedule: "ADVANCE",
-  quantity_management_mode: "SEAT_BASED",
-  seat_config: { seat_group_key: "user_id" },
-  proration: {
-    is_prorated: true,
-    invoice_behavior: "BILL_ON_NEXT_COLLECTION_DATE",
-  },
-};
-
-const PRO_SEAT_ANNUAL_SUBSCRIPTION_TEMPORARY_ID = "pro-seat-annual-sub";
-const PRO_SEAT_ANNUAL_SUBSCRIPTION: PackageSubscription = {
-  temporary_id: PRO_SEAT_ANNUAL_SUBSCRIPTION_TEMPORARY_ID,
-  product_name: PRO_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
-  billing_frequency: "ANNUAL",
-  collection_schedule: "ADVANCE",
-  quantity_management_mode: "SEAT_BASED",
-  seat_config: { seat_group_key: "user_id" },
-  proration: {
-    is_prorated: true,
-    invoice_behavior: "BILL_ON_NEXT_COLLECTION_DATE",
-  },
-};
-
-const MAX_SEAT_SUBSCRIPTION_TEMPORARY_ID = "max-seat-sub";
-const MAX_SEAT_SUBSCRIPTION: PackageSubscription = {
-  temporary_id: MAX_SEAT_SUBSCRIPTION_TEMPORARY_ID,
-  product_name: MAX_SEAT_PRODUCT_NAME,
-  billing_frequency: "MONTHLY",
-  collection_schedule: "ADVANCE",
-  quantity_management_mode: "SEAT_BASED",
-  seat_config: { seat_group_key: "user_id" },
-  proration: {
-    is_prorated: true,
-    invoice_behavior: "BILL_ON_NEXT_COLLECTION_DATE",
-  },
-};
-
-const MAX_SEAT_ANNUAL_SUBSCRIPTION_TEMPORARY_ID = "max-seat-annual-sub";
-const MAX_SEAT_ANNUAL_SUBSCRIPTION: PackageSubscription = {
-  temporary_id: MAX_SEAT_ANNUAL_SUBSCRIPTION_TEMPORARY_ID,
-  product_name: MAX_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
-  billing_frequency: "ANNUAL",
-  collection_schedule: "ADVANCE",
-  quantity_management_mode: "SEAT_BASED",
-  seat_config: { seat_group_key: "user_id" },
-  proration: {
-    is_prorated: true,
-    invoice_behavior: "BILL_ON_NEXT_COLLECTION_DATE",
-  },
-};
-
-// Free Seat SEAT_BASED subscription — priced at $0, used to track free users
-// in Metronome so each free seat carries its own lifetime AWU credit pool.
-const FREE_SEAT_SUBSCRIPTION_TEMPORARY_ID = "free-seat-sub";
-
-const FREE_SEAT_SUBSCRIPTION: PackageSubscription = {
-  temporary_id: FREE_SEAT_SUBSCRIPTION_TEMPORARY_ID,
-  product_name: FREE_SEAT_PRODUCT_NAME,
-  billing_frequency: "MONTHLY",
-  collection_schedule: "ADVANCE",
-  quantity_management_mode: "SEAT_BASED",
-  seat_config: { seat_group_key: "user_id" },
-  proration: {
-    // Free seats cost $0 so proration is moot, but keep is_prorated: true to
-    // match the other SEAT_BASED subscriptions.
-    is_prorated: true,
-    invoice_behavior: "BILL_ON_NEXT_COLLECTION_DATE",
-  },
-};
-
-// Per-seat INDIVIDUAL recurring AWU credit attached to a SEAT_BASED subscription.
-// Each seat gets its own AWU allocation refreshed every period. The credit
-// draws down against any usage product tagged `usage` for the matching
-// `user_id` seat.
-//
-// When `subscription_config` is set, Metronome rejects requests that include
-// `access_amount.quantity` (400 "must not specify a quantity if a subscription
-// is configured"). The per-seat allocation amount is encoded in
-// `access_amount.unit_price` and multiplied by the subscription's seat count
-// internally.
-function getPerSeatIndividualAwuCredits({
-  subscriptionTemporaryId,
-  quantityPerSeat,
-  name,
-}: {
-  subscriptionTemporaryId: string;
-  quantityPerSeat: number;
-  name: string;
-}): RecurringCreditDef {
-  return {
-    product_name: "Seat Individual Credits",
-    access_amount: {
-      credit_type_id: getCreditTypeAwuId(),
-      unit_price: quantityPerSeat,
-    },
-    commit_duration: { value: 1, unit: "PERIODS" },
-    priority: AWU_PRIORITY_SEAT_ALLOCATION,
-    starting_at_offset: { unit: "DAYS", value: 0 },
-    applicable_product_tags: [USAGE_TAG],
-    recurrence_frequency: "MONTHLY",
-    name,
-    subscription_config: {
-      subscription_temporary_id: subscriptionTemporaryId,
-      allocation: "INDIVIDUAL",
-      apply_seat_increase_config: { is_prorated: true },
-    },
-  };
-}
-
-// Per-seat INDIVIDUAL AWU credit attached to the Free Seat SEAT_BASED
-// subscription. Issued exactly once per seat:
-//   - `duration: { value: 1, unit: "DAYS" }` stops the recurrence after the
-//     first commit (which fires on contract start / seat assignment), so the
-//     credit is never re-issued.
-//   - `commit_duration: { value: 100, unit: "YEARS" }`... not supported by
-//     Metronome (`PERIODS` only), so we approximate with 100 ANNUAL periods
-//     — effectively the lifetime of any reasonable contract.
-//   - Not prorated on seat increase: a new free seat always gets the full
-//     300 AWU grant regardless of when in the period it was added.
-function getFreeSeatLifetimeAwuCredits(): RecurringCreditDef {
-  return {
-    product_name: "Seat Individual Credits",
-    access_amount: {
-      credit_type_id: getCreditTypeAwuId(),
-      unit_price: FREE_SEAT_LIFETIME_AWU_CREDITS,
-    },
-    commit_duration: { value: 100, unit: "PERIODS" },
-    priority: 200,
-    starting_at_offset: { unit: "DAYS", value: 0 },
-    applicable_product_tags: [USAGE_TAG],
-    recurrence_frequency: "ANNUAL",
-    duration: { value: 1, unit: "DAYS" },
-    name: FREE_SEAT_CREDIT_NAME,
-    subscription_config: {
-      subscription_temporary_id: FREE_SEAT_SUBSCRIPTION_TEMPORARY_ID,
-      allocation: "INDIVIDUAL",
-      apply_seat_increase_config: { is_prorated: false },
-    },
-  };
-}
-
-// Billing cycle config shared by all packages — anchored to contract start date.
-const BILLING_CYCLE_CONFIG = {
-  billing_anchor_date: "contract_start_date" as const,
-  usage_statement_schedule: {
-    frequency: "MONTHLY" as const,
-    day: "CONTRACT_START" as const,
-  },
-};
-
-// Packages have NO billing_provider — billing provider is set at contract creation time.
-// Shadow mode: create contract without billing_provider_configuration → invoices stay in Metronome.
-// Real billing: create contract with billing_provider_configuration: { billing_provider: "stripe" }.
-// Package names are versioned (v1, v2, ...) to track pricing changes.
-// Aliases stay stable — code always references the alias, which points to the latest version.
-// Old versions are archived automatically when a new version is created with the same alias.
-// Package names and contract_name are auto-versioned at sync time (e.g., "Legacy Pro USD v3").
-// The version is derived from existing packages in Metronome: if the current package matches,
-// keep its version; if it needs recreation, increment by 1.
-function getPackages(): PackageDef[] {
-  return [
-    {
-      name: "Legacy Pro USD",
-      aliases: [{ name: LEGACY_PRO_MONTHLY_PACKAGE_ALIAS }],
-      rate_card_name: "Legacy Pro USD",
-      subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-      recurring_credits: [
-        getFreeMonthlyRecurringCredits(),
-        getFreeExcessRecurringCredits(
-          getCreditTypeProgrammaticUsdId(),
-          DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT
-        ),
-      ],
-      ...BILLING_CYCLE_CONFIG,
-    },
-    {
-      name: "Legacy Business USD",
-      aliases: [{ name: LEGACY_BUSINESS_PACKAGE_ALIAS }],
-      rate_card_name: "Legacy Business USD",
-      subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-      recurring_credits: [
-        getFreeMonthlyRecurringCredits(),
-        getFreeExcessRecurringCredits(
-          getCreditTypeProgrammaticUsdId(),
-          DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT
-        ),
-      ],
-      ...BILLING_CYCLE_CONFIG,
-    },
-    {
-      name: "Legacy Pro Annual USD",
-      aliases: [{ name: LEGACY_PRO_ANNUAL_PACKAGE_ALIAS }],
-      rate_card_name: "Legacy Pro Annual USD",
-      subscriptions: [LEGACY_SEAT_ANNUAL_SUBSCRIPTION],
-      recurring_credits: [
-        getFreeAnnualRecurringCredits(),
-        getFreeExcessRecurringCredits(
-          getCreditTypeProgrammaticUsdId(),
-          DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT
-        ),
-      ],
-      ...BILLING_CYCLE_CONFIG,
-    },
-    // Enterprise: MAU-based billing, no seat subscriptions.
-    {
-      name: "Legacy Enterprise USD",
-      aliases: [{ name: LEGACY_ENTERPRISE_PACKAGE_ALIAS }],
-      rate_card_name: "Legacy Enterprise MAU USD",
-      scheduled_charges_on_usage_invoices: "ALL",
-      recurring_credits: [
-        getFreeMonthlyRecurringCredits(),
-        getFreeExcessRecurringCredits(
-          getCreditTypeProgrammaticUsdId(),
-          DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT
-        ),
-      ],
-      ...BILLING_CYCLE_CONFIG,
-    },
-    // EUR variants
-    {
-      name: "Legacy Pro EUR",
-      aliases: [{ name: LEGACY_PRO_MONTHLY_EUR_PACKAGE_ALIAS }],
-      rate_card_name: "Legacy Pro EUR",
-      subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-      recurring_credits: [
-        getFreeMonthlyRecurringCredits(),
-        getFreeExcessRecurringCredits(
-          getCreditTypeProgrammaticUsdId(),
-          DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT
-        ),
-      ],
-      ...BILLING_CYCLE_CONFIG,
-    },
-    {
-      name: "Legacy Business EUR",
-      aliases: [{ name: LEGACY_BUSINESS_EUR_PACKAGE_ALIAS }],
-      rate_card_name: "Legacy Business EUR",
-      subscriptions: [LEGACY_SEAT_SUBSCRIPTION],
-      recurring_credits: [
-        getFreeMonthlyRecurringCredits(),
-        getFreeExcessRecurringCredits(
-          getCreditTypeProgrammaticUsdId(),
-          DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT
-        ),
-      ],
-      ...BILLING_CYCLE_CONFIG,
-    },
-    {
-      name: "Legacy Pro Annual EUR",
-      aliases: [{ name: LEGACY_PRO_ANNUAL_EUR_PACKAGE_ALIAS }],
-      rate_card_name: "Legacy Pro Annual EUR",
-      subscriptions: [LEGACY_SEAT_ANNUAL_SUBSCRIPTION],
-      recurring_credits: [
-        getFreeAnnualRecurringCredits(),
-        getFreeExcessRecurringCredits(
-          getCreditTypeProgrammaticUsdId(),
-          DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT
-        ),
-      ],
-      ...BILLING_CYCLE_CONFIG,
-    },
-    {
-      name: "Legacy Enterprise EUR",
-      aliases: [{ name: LEGACY_ENTERPRISE_EUR_PACKAGE_ALIAS }],
-      rate_card_name: "Legacy Enterprise MAU EUR",
-      scheduled_charges_on_usage_invoices: "ALL",
-      recurring_credits: [
-        getFreeMonthlyRecurringCredits(),
-        getFreeExcessRecurringCredits(
-          getCreditTypeProgrammaticUsdId(),
-          DEFAULT_PROGRAMMATIC_USD_EXCESS_RECURRING_AMOUNT
-        ),
-      ],
-      ...BILLING_CYCLE_CONFIG,
-    },
-    // New Enterprise USD / EUR — per-seat billing on Workspace Seat (MONTHLY)
-    // + AWU AI/Tool usage. Includes a recurring AWU credit that draws down on
-    // usage tagged as free via the `is_free_usage` presentation group.
-    {
-      name: "Enterprise Pooled USD",
-      aliases: [{ name: "enterprise-usd" }],
-      rate_card_name: "Enterprise USD",
-      subscriptions: [
-        WORKSPACE_SEAT_MONTHLY_SUBSCRIPTION,
-        WORKSPACE_SEAT_ANNUAL_SUBSCRIPTION,
-      ],
-      scheduled_charges_on_usage_invoices: "ALL",
-      recurring_credits: [
-        getFreeExcessRecurringCredits(
-          getCreditTypeAwuId(),
-          DEFAULT_AWU_EXCESS_RECURRING_AMOUNT
-        ),
-      ],
-      ...BILLING_CYCLE_CONFIG,
-    },
-    {
-      name: "Enterprise Pooled EUR",
-      aliases: [{ name: "enterprise-eur" }],
-      rate_card_name: "Enterprise EUR",
-      subscriptions: [
-        WORKSPACE_SEAT_MONTHLY_SUBSCRIPTION,
-        WORKSPACE_SEAT_ANNUAL_SUBSCRIPTION,
-      ],
-      scheduled_charges_on_usage_invoices: "ALL",
-      recurring_credits: [
-        getFreeExcessRecurringCredits(
-          getCreditTypeAwuId(),
-          DEFAULT_AWU_EXCESS_RECURRING_AMOUNT
-        ),
-      ],
-      ...BILLING_CYCLE_CONFIG,
-    },
-    {
-      name: "Enterprise Seat-based USD",
-      aliases: [{ name: "enterprise-seat-based-usd" }],
-      rate_card_name: "Enterprise USD",
-      subscriptions: [
-        PRO_SEAT_SUBSCRIPTION,
-        PRO_SEAT_ANNUAL_SUBSCRIPTION,
-        MAX_SEAT_SUBSCRIPTION,
-        MAX_SEAT_ANNUAL_SUBSCRIPTION,
-      ],
-      scheduled_charges_on_usage_invoices: "ALL",
-      recurring_credits: [
-        getPerSeatIndividualAwuCredits({
-          subscriptionTemporaryId: MAX_SEAT_SUBSCRIPTION_TEMPORARY_ID,
-          quantityPerSeat: MAX_SEAT_MONTHLY_AWU_CREDITS,
-          name: MAX_SEAT_CREDIT_NAME,
-        }),
-        getPerSeatIndividualAwuCredits({
-          subscriptionTemporaryId: PRO_SEAT_ANNUAL_SUBSCRIPTION_TEMPORARY_ID,
-          quantityPerSeat: PRO_SEAT_MONTHLY_AWU_CREDITS,
-          name: PRO_SEAT_CREDIT_NAME,
-        }),
-        getPerSeatIndividualAwuCredits({
-          subscriptionTemporaryId: PRO_SEAT_SUBSCRIPTION_TEMPORARY_ID,
-          quantityPerSeat: PRO_SEAT_MONTHLY_AWU_CREDITS,
-          name: PRO_SEAT_CREDIT_NAME,
-        }),
-        getPerSeatIndividualAwuCredits({
-          subscriptionTemporaryId: MAX_SEAT_ANNUAL_SUBSCRIPTION_TEMPORARY_ID,
-          quantityPerSeat: MAX_SEAT_MONTHLY_AWU_CREDITS,
-          name: MAX_SEAT_CREDIT_NAME,
-        }),
-        getFreeExcessRecurringCredits(
-          getCreditTypeAwuId(),
-          DEFAULT_AWU_EXCESS_RECURRING_AMOUNT
-        ),
-      ],
-      overrides: buildSeatEntitlementFlipOverrides(),
-      ...BILLING_CYCLE_CONFIG,
-    },
-    {
-      name: "Enterprise Seat-based EUR",
-      aliases: [{ name: "enterprise-seat-based-eur" }],
-      rate_card_name: "Enterprise EUR",
-      subscriptions: [
-        PRO_SEAT_SUBSCRIPTION,
-        PRO_SEAT_ANNUAL_SUBSCRIPTION,
-        MAX_SEAT_SUBSCRIPTION,
-        MAX_SEAT_ANNUAL_SUBSCRIPTION,
-      ],
-      scheduled_charges_on_usage_invoices: "ALL",
-      recurring_credits: [
-        getPerSeatIndividualAwuCredits({
-          subscriptionTemporaryId: PRO_SEAT_SUBSCRIPTION_TEMPORARY_ID,
-          quantityPerSeat: PRO_SEAT_MONTHLY_AWU_CREDITS,
-          name: PRO_SEAT_CREDIT_NAME,
-        }),
-        getPerSeatIndividualAwuCredits({
-          subscriptionTemporaryId: PRO_SEAT_ANNUAL_SUBSCRIPTION_TEMPORARY_ID,
-          quantityPerSeat: PRO_SEAT_MONTHLY_AWU_CREDITS,
-          name: PRO_SEAT_CREDIT_NAME,
-        }),
-        getPerSeatIndividualAwuCredits({
-          subscriptionTemporaryId: MAX_SEAT_SUBSCRIPTION_TEMPORARY_ID,
-          quantityPerSeat: MAX_SEAT_MONTHLY_AWU_CREDITS,
-          name: MAX_SEAT_CREDIT_NAME,
-        }),
-        getPerSeatIndividualAwuCredits({
-          subscriptionTemporaryId: MAX_SEAT_ANNUAL_SUBSCRIPTION_TEMPORARY_ID,
-          quantityPerSeat: MAX_SEAT_MONTHLY_AWU_CREDITS,
-          name: MAX_SEAT_CREDIT_NAME,
-        }),
-        getFreeExcessRecurringCredits(
-          getCreditTypeAwuId(),
-          DEFAULT_AWU_EXCESS_RECURRING_AMOUNT
-        ),
-      ],
-      overrides: buildSeatEntitlementFlipOverrides(),
-      ...BILLING_CYCLE_CONFIG,
-    },
-    // New Business USD / EUR — Pro and Max seats as SEAT_BASED subscriptions
-    // with per-seat INDIVIDUAL AWU credit allocations (Pro: 8000 / Max: 40000
-    // AWU/month). Both seat tiers live in the same package so customers can
-    // upgrade/downgrade between them via seat moves.
-    {
-      name: "Business USD",
-      aliases: [{ name: "business-usd" }],
-      rate_card_name: "Business USD",
-      subscriptions: [
-        PRO_SEAT_SUBSCRIPTION,
-        PRO_SEAT_ANNUAL_SUBSCRIPTION,
-        MAX_SEAT_SUBSCRIPTION,
-        MAX_SEAT_ANNUAL_SUBSCRIPTION,
-        FREE_SEAT_SUBSCRIPTION,
-      ],
-      scheduled_charges_on_usage_invoices: "ALL",
-      recurring_credits: [
-        getPerSeatIndividualAwuCredits({
-          subscriptionTemporaryId: PRO_SEAT_SUBSCRIPTION_TEMPORARY_ID,
-          quantityPerSeat: PRO_SEAT_MONTHLY_AWU_CREDITS,
-          name: PRO_SEAT_CREDIT_NAME,
-        }),
-        getPerSeatIndividualAwuCredits({
-          subscriptionTemporaryId: PRO_SEAT_ANNUAL_SUBSCRIPTION_TEMPORARY_ID,
-          quantityPerSeat: PRO_SEAT_MONTHLY_AWU_CREDITS,
-          name: PRO_SEAT_CREDIT_NAME,
-        }),
-        getPerSeatIndividualAwuCredits({
-          subscriptionTemporaryId: MAX_SEAT_SUBSCRIPTION_TEMPORARY_ID,
-          quantityPerSeat: MAX_SEAT_MONTHLY_AWU_CREDITS,
-          name: MAX_SEAT_CREDIT_NAME,
-        }),
-        getPerSeatIndividualAwuCredits({
-          subscriptionTemporaryId: MAX_SEAT_ANNUAL_SUBSCRIPTION_TEMPORARY_ID,
-          quantityPerSeat: MAX_SEAT_MONTHLY_AWU_CREDITS,
-          name: MAX_SEAT_CREDIT_NAME,
-        }),
-        getFreeSeatLifetimeAwuCredits(),
-        getFreeExcessRecurringCredits(
-          getCreditTypeAwuId(),
-          DEFAULT_AWU_EXCESS_RECURRING_AMOUNT
-        ),
-      ],
-      ...BILLING_CYCLE_CONFIG,
-    },
-    {
-      name: "Business EUR",
-      aliases: [{ name: "business-eur" }],
-      rate_card_name: "Business EUR",
-      subscriptions: [
-        PRO_SEAT_SUBSCRIPTION,
-        PRO_SEAT_ANNUAL_SUBSCRIPTION,
-        MAX_SEAT_SUBSCRIPTION,
-        MAX_SEAT_ANNUAL_SUBSCRIPTION,
-        FREE_SEAT_SUBSCRIPTION,
-      ],
-      scheduled_charges_on_usage_invoices: "ALL",
-      recurring_credits: [
-        getPerSeatIndividualAwuCredits({
-          subscriptionTemporaryId: PRO_SEAT_SUBSCRIPTION_TEMPORARY_ID,
-          quantityPerSeat: PRO_SEAT_MONTHLY_AWU_CREDITS,
-          name: PRO_SEAT_CREDIT_NAME,
-        }),
-        getPerSeatIndividualAwuCredits({
-          subscriptionTemporaryId: PRO_SEAT_ANNUAL_SUBSCRIPTION_TEMPORARY_ID,
-          quantityPerSeat: PRO_SEAT_MONTHLY_AWU_CREDITS,
-          name: PRO_SEAT_CREDIT_NAME,
-        }),
-        getPerSeatIndividualAwuCredits({
-          subscriptionTemporaryId: MAX_SEAT_SUBSCRIPTION_TEMPORARY_ID,
-          quantityPerSeat: MAX_SEAT_MONTHLY_AWU_CREDITS,
-          name: MAX_SEAT_CREDIT_NAME,
-        }),
-        getPerSeatIndividualAwuCredits({
-          subscriptionTemporaryId: MAX_SEAT_ANNUAL_SUBSCRIPTION_TEMPORARY_ID,
-          quantityPerSeat: MAX_SEAT_MONTHLY_AWU_CREDITS,
-          name: MAX_SEAT_CREDIT_NAME,
-        }),
-        getFreeSeatLifetimeAwuCredits(),
-        getFreeExcessRecurringCredits(
-          getCreditTypeAwuId(),
-          DEFAULT_AWU_EXCESS_RECURRING_AMOUNT
-        ),
-      ],
-      ...BILLING_CYCLE_CONFIG,
-    },
-    // Free plan — entitles only the Free Seat
-    {
-      name: "Free plan",
-      aliases: [{ name: FREE_PACKAGE_ALIAS }],
-      rate_card_name: "Free plan",
-      subscriptions: [FREE_SEAT_SUBSCRIPTION],
-      scheduled_charges_on_usage_invoices: "ALL",
-      recurring_credits: [getFreeSeatLifetimeAwuCredits()],
-      ...BILLING_CYCLE_CONFIG,
-    },
-  ];
 }
 
 // ---------------------------------------------------------------------------
@@ -1880,8 +120,10 @@ async function syncMetrics(): Promise<void> {
     existing.push(m as (typeof existing)[number]);
   }
 
+  const metrics = [...LEGACY_METRICS, ...NEW_METRICS];
+
   const byName = new Map(existing.map((m) => [m.name, m]));
-  const desiredNames = new Set(METRICS.map((m) => m.name));
+  const desiredNames = new Set(metrics.map((m) => m.name));
 
   for (const m of existing) {
     if (!desiredNames.has(m.name) && !isTestObject(m.name)) {
@@ -1894,7 +136,7 @@ async function syncMetrics(): Promise<void> {
     }
   }
 
-  for (const desired of METRICS) {
+  for (const desired of metrics) {
     const ex = byName.get(desired.name);
     const sortGroupKeys = (keys: string[][]) =>
       [...keys].sort((a, b) => a.join(",").localeCompare(b.join(",")));
@@ -2003,7 +245,6 @@ function productMatches(
       billable_metric_id?: string;
       pricing_group_key?: string[];
       presentation_group_key?: string[];
-      tags?: string[];
       quantity_conversion?: {
         conversion_factor: number;
         operation: string;
@@ -2099,14 +340,8 @@ function productMatches(
     return false;
   }
 
-  if (
-    !arraysEqual([...(cur.tags ?? [])].sort(), [...(desired.tags ?? [])].sort())
-  ) {
-    console.log(
-      `    [diff] ${desired.name}: tags [${cur.tags ?? ""}] → [${desired.tags ?? ""}]`
-    );
-    return false;
-  }
+  // NOTE: `tags` are intentionally NOT compared here — a tag-only change is
+  // reconciled in place via `reconcileProductTags` (no archive/recreate).
 
   return true;
 }
@@ -2128,6 +363,7 @@ async function syncProducts(): Promise<boolean> {
       billable_metric_id?: string;
       pricing_group_key?: string[];
       presentation_group_key?: string[];
+      tags?: string[];
       quantity_conversion?: {
         conversion_factor: number;
         operation: string;
@@ -2176,6 +412,9 @@ async function syncProducts(): Promise<boolean> {
       if (await reconcileProductCustomFields(ex, desired)) {
         mutated = true;
       }
+      // Tags are edited in place (no recreate); tag drift doesn't affect the
+      // product seat-type cache, so it doesn't flip `mutated`.
+      await reconcileProductTags(ex, desired);
     } else {
       if (ex) {
         console.log(
@@ -2260,6 +499,40 @@ async function reconcileProductCustomFields(
       entity: "contract_product",
       entity_id: ex.id,
       custom_fields: drift,
+    });
+    return true;
+  }
+  return false;
+}
+
+// Pricing-era start — matches the `starting_at` used for all rates, and is on
+// an hour boundary as required by the product update API.
+const PRODUCT_UPDATE_STARTING_AT = "2026-04-01T00:00:00.000Z";
+
+/**
+ * Reconcile `tags` on an existing product via `products.update` — tags are
+ * edited in place, so tag drift never triggers a product archive/recreate (and
+ * `productMatches` intentionally ignores them).
+ *
+ * Returns true when an update was actually applied (EXECUTE + drift detected).
+ */
+async function reconcileProductTags(
+  ex: { id: string; current?: { tags?: string[] } },
+  desired: ProductDef
+): Promise<boolean> {
+  const desiredTags = [...(desired.tags ?? [])].sort();
+  const existingTags = [...(ex.current?.tags ?? [])].sort();
+  if (arraysEqual(desiredTags, existingTags)) {
+    return false;
+  }
+  console.log(
+    `  ✎ ${EXECUTE ? "Updating" : "[DRYRUN] Would update"} ${desired.name} tags [${ex.current?.tags ?? ""}] → [${desired.tags ?? ""}]`
+  );
+  if (EXECUTE) {
+    await client.v1.contracts.products.update({
+      product_id: ex.id,
+      starting_at: PRODUCT_UPDATE_STARTING_AT,
+      tags: desired.tags ?? [],
     });
     return true;
   }
@@ -2421,7 +694,7 @@ interface ExistingRateCard {
 async function syncRateCards(): Promise<void> {
   console.log("\n=== Syncing Rate Cards ===");
 
-  const rateCards = getRateCards();
+  const rateCards = [...getLegacyRateCards(), ...getNewRateCards()];
 
   const existing: ExistingRateCard[] = [];
   for await (const r of client.v1.contracts.rateCards.list({ body: {} })) {
@@ -2826,6 +1099,24 @@ function packageMatches(ex: ExistingPackage, desired: PackageDef): boolean {
       );
       return false;
     }
+    // When the override stamps a flat rate, compare price and credit type.
+    if (desiredOverride.price !== undefined) {
+      if (match.overwrite_rate?.price !== desiredOverride.price) {
+        console.log(
+          `    [diff] ${desired.name}: override ${desiredOverride.product_name} price ${match.overwrite_rate?.price} → ${desiredOverride.price}`
+        );
+        return false;
+      }
+      if (
+        desiredOverride.credit_type_id &&
+        match.overwrite_rate?.credit_type?.id !== desiredOverride.credit_type_id
+      ) {
+        console.log(
+          `    [diff] ${desired.name}: override ${desiredOverride.product_name} credit_type ${match.overwrite_rate?.credit_type?.id} → ${desiredOverride.credit_type_id}`
+        );
+        return false;
+      }
+    }
   }
 
   return true;
@@ -2847,7 +1138,7 @@ async function syncPackages(): Promise<void> {
     }
   }
 
-  const packages = getPackages();
+  const packages = [...getLegacyPackages(), ...getNewPackages()];
 
   // Collect all desired aliases to identify stale packages.
   const desiredAliases = new Set(
@@ -2990,7 +1281,31 @@ async function syncPackages(): Promise<void> {
           return {
             starting_at_offset: { unit: "DAYS" as const, value: 0 },
             entitled: o.entitled,
-            override_specifiers: [{ product_id: productId }],
+            override_specifiers: [
+              {
+                product_id: productId,
+                // Required when overwriting a SUBSCRIPTION product's flat rate.
+                ...(o.billing_frequency
+                  ? { billing_frequency: o.billing_frequency }
+                  : {}),
+              },
+            ],
+            // Stamp a flat rate on top of the rate-card rate when the override
+            // carries a price (rate card defaults seats to a 0 baseline).
+            // `type: "OVERWRITE"` is required by Metronome whenever an
+            // `overwrite_rate` is present.
+            ...(o.price !== undefined
+              ? {
+                  type: "OVERWRITE" as const,
+                  overwrite_rate: {
+                    rate_type: "FLAT" as const,
+                    price: o.price,
+                    ...(o.credit_type_id
+                      ? { credit_type_id: o.credit_type_id }
+                      : {}),
+                  },
+                }
+              : {}),
           };
         });
 
@@ -3225,9 +1540,10 @@ async function syncAlerts(): Promise<void> {
 }
 
 async function main(): Promise<void> {
-  ENV = await detectEnvironment();
+  const env = await detectEnvironment();
+  setMetronomeEnv(env);
   console.log(
-    `Metronome Setup — environment: ${ENV}, mode: ${EXECUTE ? "EXECUTE" : "DRY-RUN (pass --execute to apply)"}\n`
+    `Metronome Setup — environment: ${env}, mode: ${EXECUTE ? "EXECUTE" : "DRY-RUN (pass --execute to apply)"}\n`
   );
 
   console.log(
@@ -3277,9 +1593,9 @@ async function main(): Promise<void> {
       .replace(/^_|_$/g, "")}`;
   }
 
-  const envPrefix = ENV === "production" ? "PROD" : "DEV";
+  const envPrefix = env === "production" ? "PROD" : "DEV";
   console.log(
-    `\n=== TypeScript constants (${ENV}) — paste into lib/metronome/constants.ts ===\n`
+    `\n=== TypeScript constants (${env}) — paste into lib/metronome/constants.ts ===\n`
   );
 
   console.log("// Metrics");


### PR DESCRIPTION
## Description

Refactor of the Metronome setup catalog (`front/scripts/metronome_setup.ts`) plus a reorganization of the file into a `lib/metronome/setup_*` module set. No runtime/app behavior changes — this only affects the idempotent provisioning script and the desired-state definitions it reconciles.

**Catalog / pricing changes**

- **All non-legacy rate cards carry every seat** (Workspace / Pro / Max / Free, monthly + yearly) at `entitled: false` with a `0` baseline price. Each package turns on and prices the seats it sells via overrides.
- **Seat prices moved into package overrides.** New `buildSeatEntitlementOverrides(creditTypeId, seats)` replaces the old fixed `buildSeatEntitlementFlipOverrides`; it flips `entitled: true` and stamps an optional flat rate (`overwrite_rate`). Existing per-plan prices are preserved exactly — they just live on the package now instead of the rate card.
- **Collapsed `Enterprise USD/EUR` + `Business USD/EUR` rate cards into a single `Standard USD` / `Standard EUR`** (Free plan keeps its own card — its overage AWU conversion is `0`). The Business-vs-Enterprise distinction now lives entirely in the package overrides.
- **Every non-legacy package shares the full subscription set + recurring-credit set** and differs only by its overrides. Workspace stays `QUANTITY_ONLY` (pooled); Pro / Max / Free are `SEAT_BASED` — all packages carry the mix.
- **Subscription factory.** `makeSeatSubscription` / `makeSeatSubscriptions` generate the monthly + annual pair in one call (Free has no annual); the per-variant `*_ANNUAL_SUBSCRIPTION` constants and `_ANNUAL` naming are gone.
- **Seat products tagged** `seat` + `monthly`/`yearly`.
- **Tags reconciled in place.** `productMatches` no longer treats a tag diff as drift; a new `reconcileProductTags` calls `products.update(...)` so tag changes no longer archive/recreate the product (and avoid cascading rate-card/package recreates).

**File reorganization**

The ~3.3k-line monolith is split into four files:

- `lib/metronome/setup_common.ts` — shared types, env credit accessors, constants, the `MetricDef`/product catalog (`PRODUCTS`), and the generic factories.
- `lib/metronome/setup_legacy.ts` — grandfathered plans: `getLegacyRateCards`, `getLegacyPackages`, `LEGACY_METRICS`, and legacy-only helpers.
- `lib/metronome/setup_new_pricing.ts` — Standard/Free plans: `getNewRateCards`, `getNewPackages`, `NEW_METRICS`, AWU usage-rate builders, seat subscriptions, and per-seat credit builders.
- `scripts/metronome_setup.ts` — now only orchestration (env detection, list → diff → create/archive/update reconcilers, `main`), composing the catalogs from the modules.

Metrics are split the same way: `LLM Provider Cost (Programmatic)` → legacy; `Tool Invocations` + `LLM Provider Cost AWU` → new.

## Tests

- `npx tsgo --noEmit` (type-check) and Biome lint pass on all four files.
- **Not yet run against Metronome.** Before `--execute`, run a dry-run (`npx tsx front/scripts/metronome_setup.ts`) against sandbox and review the planned diff. One thing to confirm on the dry-run: every non-legacy package now includes the `SEAT_BASED` Pro/Max/Free subscriptions even when those seats are not entitled (they stay dormant) — verify Metronome accepts the package template.

## Risk

- Provisioning-script only; no app runtime code paths change.
- On `--execute`: the stale `Enterprise/Business USD/EUR` rate cards are archived and `Standard USD/EUR` are created; non-legacy packages bump a version (they reference the recreated rate cards). Seat prices are preserved (moved to overrides), so billing amounts are unchanged.
- Tag additions on existing seat products are applied in place via `products.update` (no recreate / no cascade).
- Fixed a pre-existing typo in the `Enterprise` seat-based Pro-annual price (`528000` → `52800`, i.e. $528/yr = $44/mo × 12). Note: the Free plan now carries the AWU excess credit as part of the shared credit set.
- Rollback: re-run the previous version of the script (idempotent reconcile), or revert the PR — nothing here is consumed by the live app.

## Deploy Plan

1. Merge.
2. Run `npx tsx front/scripts/metronome_setup.ts` (dry-run) against **sandbox**, review the diff, then re-run with `--execute`.
3. Repeat dry-run → `--execute` against **production**.

No coordinated app deploy required — the script is run manually and the app doesn't import these definitions.

