### PR TITLE
feat: move to new pod

### DIFF
--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -1,3 +1,4 @@
+import { CreatePodModal } from "@app/components/assistant/conversation/CreatePodModal";
 import { DeleteConversationsDialog } from "@app/components/assistant/conversation/DeleteConversationsDialog";
 import { EditConversationTitleDialog } from "@app/components/assistant/conversation/EditConversationTitleDialog";
 import { LeaveConversationDialog } from "@app/components/assistant/conversation/LeaveConversationDialog";
@@ -60,6 +61,7 @@ import {
   LinkIcon,
   PencilSquareIcon,
   PlusCircleIcon,
+  PlusIcon,
   SidekickIcon,
   TrashIcon,
   XMarkIcon,
@@ -272,6 +274,8 @@ export function ConversationMenu({
   const [showDeleteDialog, setShowDeleteDialog] = useState<boolean>(false);
   const [showLeaveDialog, setShowLeaveDialog] = useState<boolean>(false);
   const [showRenameDialog, setShowRenameDialog] = useState<boolean>(false);
+  const [isCreatePodModalOpen, setIsCreatePodModalOpen] =
+    useState<boolean>(false);
   const handleConversationBranched = useCallback(() => {
     if (isConversationDisplayed) {
       void mutateConversation();
@@ -380,6 +384,17 @@ export function ConversationMenu({
           conversation ? getConversationDisplayTitle(conversation) : ""
         }
       />
+      <CreatePodModal
+        isOpen={isCreatePodModalOpen}
+        onClose={() => setIsCreatePodModalOpen(false)}
+        onCreated={async (pod) => {
+          if (conversation) {
+            await moveConversationToPod(conversation, pod);
+          }
+          void router.push(getPodRoute(owner.sId, pod.sId));
+        }}
+        owner={owner}
+      />
       <DropdownMenu modal={false} open={isOpen} onOpenChange={onOpenChange}>
         {triggerPosition ? (
           <>
@@ -419,15 +434,20 @@ export function ConversationMenu({
             <DropdownMenuSubTrigger
               icon={ArrowRightIcon}
               label={canMoveOutOfPod ? "Move to..." : "Move to Pod"}
-              disabled={canMoveOutOfPod ? false : !filteredPods.length}
             />
             <DropdownMenuPortal>
               <DropdownMenuSubContent
                 collisionPadding={16}
                 className="max-w-60"
               >
+                <DropdownMenuItem
+                  icon={PlusIcon}
+                  label="New Pod"
+                  onClick={() => setIsCreatePodModalOpen(true)}
+                />
                 {canMoveOutOfPod && (
                   <>
+                    <DropdownMenuSeparator />
                     <DropdownMenuItem
                       icon={ChatBubbleBottomCenterTextIcon}
                       label="Personal conversations"
@@ -435,23 +455,27 @@ export function ConversationMenu({
                         moveConversationOutOfPod(conversation)
                       }
                     />
-                    <DropdownMenuSeparator />
-                    <DropdownMenuLabel label="Pods" />
                   </>
                 )}
-                {filteredPods.map((pod) => (
-                  <DropdownMenuItem
-                    key={pod.sId}
-                    icon={getSpaceIcon(pod)}
-                    label={pod.name}
-                    truncateText
-                    onClick={async () =>
-                      conversation
-                        ? moveConversationToPod(conversation, pod)
-                        : Promise.resolve(false)
-                    }
-                  />
-                ))}
+                {filteredPods.length > 0 && (
+                  <>
+                    <DropdownMenuSeparator />
+                    {canMoveOutOfPod && <DropdownMenuLabel label="Pods" />}
+                    {filteredPods.map((pod) => (
+                      <DropdownMenuItem
+                        key={pod.sId}
+                        icon={getSpaceIcon(pod)}
+                        label={pod.name}
+                        truncateText
+                        onClick={async () =>
+                          conversation
+                            ? moveConversationToPod(conversation, pod)
+                            : Promise.resolve(false)
+                        }
+                      />
+                    ))}
+                  </>
+                )}
               </DropdownMenuSubContent>
             </DropdownMenuPortal>
           </DropdownMenuSub>

--- a/front/components/assistant/conversation/CreatePodModal.tsx
+++ b/front/components/assistant/conversation/CreatePodModal.tsx
@@ -1,9 +1,8 @@
 import { usePodConversationsSummary } from "@app/hooks/conversations";
-import { useAppRouter } from "@app/lib/platform";
 import { useCheckPodName } from "@app/lib/swr/pods";
 import { useCreateSpace } from "@app/lib/swr/spaces";
-import { getPodRoute } from "@app/lib/utils/router";
 import { areOpenPodsAllowed } from "@app/lib/workspace_policies";
+import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -26,7 +25,7 @@ import { useCallback, useEffect, useState } from "react";
 interface CreatePodModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onCreated: () => void;
+  onCreated: (pod: SpaceType) => void;
   owner: LightWorkspaceType;
 }
 
@@ -45,7 +44,6 @@ export function CreatePodModal({
   const [isPodOpen, setIsPodOpen] = useState(false);
 
   const doCreate = useCreateSpace({ owner });
-  const router = useAppRouter();
 
   const { mutate: mutateSpaceSummary } = usePodConversationsSummary({
     workspaceId: owner.sId,
@@ -110,9 +108,8 @@ export function CreatePodModal({
 
     if (createdSpace) {
       void mutateSpaceSummary();
-      onCreated();
+      onCreated(createdSpace);
       handleClose();
-      void router.push(getPodRoute(owner.sId, createdSpace.sId));
     }
   }, [
     podName,
@@ -122,8 +119,6 @@ export function CreatePodModal({
     onCreated,
     handleClose,
     mutateSpaceSummary,
-    router,
-    owner.sId,
   ]);
 
   const handleKeyPress = useCallback(

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -58,7 +58,7 @@ import {
   type ConversationListItemType,
   getConversationDisplayTitle,
 } from "@app/types/assistant/conversation";
-import type { PodType } from "@app/types/space";
+import type { PodType, SpaceType } from "@app/types/space";
 import type { WorkspaceType } from "@app/types/user";
 import { isBuilder } from "@app/types/user";
 import {
@@ -81,6 +81,7 @@ import {
   DropdownMenuLabel,
   DropdownMenuPortal,
   DropdownMenuSearchbar,
+  DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
@@ -506,6 +507,7 @@ export function AgentSidebarMenu({
   const [isMoving, setIsMoving] = useState(false);
   const [titleFilter, setTitleFilter] = useState<string>("");
   const [isCreatePodModalOpen, setIsCreatePodModalOpen] = useState(false);
+  const [pendingMoveToNewPod, setPendingMoveToNewPod] = useState(false);
   const [isImportSkillDialogOpen, setIsImportSkillDialogOpen] = useState(false);
 
   const {
@@ -609,7 +611,7 @@ export function AgentSidebarMenu({
   );
 
   const moveSelectionToPod = useCallback(
-    async (pod: PodType) => {
+    async (pod: PodType | SpaceType) => {
       setIsMoving(true);
       const successCount = await bulkMoveConversationsToPod(
         selectedConversations,
@@ -619,6 +621,7 @@ export function AgentSidebarMenu({
       if (successCount > 0) {
         toggleMultiSelect();
       }
+      return successCount;
     },
     [bulkMoveConversationsToPod, selectedConversations, toggleMultiSelect]
   );
@@ -880,8 +883,18 @@ export function AgentSidebarMenu({
       />
       <CreatePodModal
         isOpen={isCreatePodModalOpen}
-        onClose={() => setIsCreatePodModalOpen(false)}
-        onCreated={() => setSidebarOpen(false)}
+        onClose={() => {
+          setIsCreatePodModalOpen(false);
+          setPendingMoveToNewPod(false);
+        }}
+        onCreated={async (pod) => {
+          setSidebarOpen(false);
+          if (pendingMoveToNewPod) {
+            setPendingMoveToNewPod(false);
+            await moveSelectionToPod(pod);
+          }
+          void router.push(getPodRoute(owner.sId, pod.sId));
+        }}
         owner={owner}
       />
       {isImportSkillDialogOpen && (
@@ -902,10 +915,7 @@ export function AgentSidebarMenu({
                         variant="outline"
                         label="Move to Pod"
                         icon={ArrowRightIcon}
-                        disabled={
-                          selectedConversations.length === 0 ||
-                          availablePods.length === 0
-                        }
+                        disabled={selectedConversations.length === 0}
                         isLoading={isMoving}
                       />
                     </DropdownMenuTrigger>
@@ -913,16 +923,29 @@ export function AgentSidebarMenu({
                       className="max-w-60"
                       onFocusOutside={(e) => e.preventDefault()}
                     >
-                      <DropdownMenuLabel label="Pods" />
-                      {availablePods.map((pod) => (
-                        <DropdownMenuItem
-                          key={pod.sId}
-                          icon={getSpaceIcon(pod)}
-                          label={pod.name}
-                          truncateText
-                          onClick={() => moveSelectionToPod(pod)}
-                        />
-                      ))}
+                      <DropdownMenuItem
+                        icon={PlusIcon}
+                        label="New Pod"
+                        onClick={() => {
+                          setPendingMoveToNewPod(true);
+                          setIsCreatePodModalOpen(true);
+                        }}
+                      />
+                      {availablePods.length > 0 && (
+                        <>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuLabel label="Pods" />
+                          {availablePods.map((pod) => (
+                            <DropdownMenuItem
+                              key={pod.sId}
+                              icon={getSpaceIcon(pod)}
+                              label={pod.name}
+                              truncateText
+                              onClick={() => moveSelectionToPod(pod)}
+                            />
+                          ))}
+                        </>
+                      )}
                     </DropdownMenuContent>
                   </DropdownMenu>
                   <Button


### PR DESCRIPTION
## Description

This PR adds the ability to move a conversation to a newly created pod directly from the conversation menu and the sidebar's bulk-move action, without requiring the user to pre-create a pod first.

- Adds a "New Pod" option to the "Move to..." submenu in `ConversationMenu`, which opens `CreatePodModal` and immediately moves the conversation upon creation.
- Updates `CreatePodModal`'s `onCreated` callback to pass the created pod to the caller, moving navigation responsibility to the parent.
- Adds a "New Pod" option to the bulk "Move to Pod" dropdown in `SidebarMenu`, using a `pendingMoveToNewPod` flag to trigger the bulk move after pod creation.

## Tests

Manually.

## Risks

<!-- Discuss potential risks and how they will be mitigated. -->

## Deploy Plan

<!-- Outline the deployment steps if needed. -->

