### PR TITLE
[front] enh: render unavailable skill reference chips

### DIFF
--- a/front/components/editor/extensions/input_bar/SkillNode.tsx
+++ b/front/components/editor/extensions/input_bar/SkillNode.tsx
@@ -20,18 +20,6 @@ export type SkillNodeAttributes = {
 
 export const SKILL_NODE_TYPE = "skill";
 
-function findSkillReferenceTagStart(src: string): number {
-  const skillTagStart = src.indexOf(`<${SKILL_TAG_NAME}`);
-  const unavailableSkillTagStart = src.indexOf(
-    `<${UNAVAILABLE_SKILL_TAG_NAME}`
-  );
-  const starts = [skillTagStart, unavailableSkillTagStart].filter(
-    (start) => start >= 0
-  );
-
-  return starts.length > 0 ? Math.min(...starts) : -1;
-}
-
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
     skillNode: {
@@ -124,7 +112,17 @@ export const SkillNode = Node.create({
   markdownTokenizer: {
     name: SKILL_NODE_TYPE,
     level: "inline",
-    start: findSkillReferenceTagStart,
+    start: (src) => {
+      const skillTagStart = src.indexOf(`<${SKILL_TAG_NAME}`);
+      const unavailableSkillTagStart = src.indexOf(
+        `<${UNAVAILABLE_SKILL_TAG_NAME}`
+      );
+      const starts = [skillTagStart, unavailableSkillTagStart].filter(
+        (start) => start >= 0
+      );
+
+      return starts.length > 0 ? Math.min(...starts) : -1;
+    },
     tokenize: (src) => {
       const match = SKILL_REFERENCE_TAG_REGEX_BEGINNING.exec(src);
       if (!match) {

--- a/front/components/editor/extensions/input_bar/SkillNode.tsx
+++ b/front/components/editor/extensions/input_bar/SkillNode.tsx
@@ -1,9 +1,11 @@
 import { SkillNodeComponent } from "@app/components/editor/input_bar/SkillNodeComponent";
 import {
-  parseSkillTag,
+  parseSkillReferenceTag,
+  SKILL_REFERENCE_TAG_REGEX_BEGINNING,
   SKILL_TAG_NAME,
-  SKILL_TAG_REGEX_BEGINNING,
   serializeSkillTag,
+  serializeUnavailableSkillTag,
+  UNAVAILABLE_SKILL_TAG_NAME,
 } from "@app/lib/skills/format";
 import { isString } from "@app/types/shared/utils/general";
 import { Node } from "@tiptap/core";
@@ -13,9 +15,22 @@ export type SkillNodeAttributes = {
   skillId: string;
   skillIcon?: string | null;
   skillName: string;
+  skillUnavailable?: boolean;
 };
 
 export const SKILL_NODE_TYPE = "skill";
+
+function findSkillReferenceTagStart(src: string): number {
+  const skillTagStart = src.indexOf(`<${SKILL_TAG_NAME}`);
+  const unavailableSkillTagStart = src.indexOf(
+    `<${UNAVAILABLE_SKILL_TAG_NAME}`
+  );
+  const starts = [skillTagStart, unavailableSkillTagStart].filter(
+    (start) => start >= 0
+  );
+
+  return starts.length > 0 ? Math.min(...starts) : -1;
+}
 
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
@@ -54,19 +69,35 @@ export const SkillNode = Node.create({
         renderHTML: (attributes) =>
           isString(attributes.skillIcon) ? { icon: attributes.skillIcon } : {},
       },
+      skillUnavailable: {
+        default: false,
+        parseHTML: (element) =>
+          element.tagName.toLowerCase() === UNAVAILABLE_SKILL_TAG_NAME,
+      },
     };
   },
 
   // HTML serialization and deserialization.
   parseHTML() {
-    return [{ tag: SKILL_TAG_NAME }];
+    return [{ tag: SKILL_TAG_NAME }, { tag: UNAVAILABLE_SKILL_TAG_NAME }];
   },
 
-  renderHTML({ HTMLAttributes }) {
+  renderHTML({ node, HTMLAttributes }) {
+    if (node.attrs.skillUnavailable === true) {
+      return [
+        UNAVAILABLE_SKILL_TAG_NAME,
+        isString(node.attrs.skillId) ? { id: node.attrs.skillId } : {},
+      ];
+    }
+
     return [SKILL_TAG_NAME, HTMLAttributes];
   },
 
   renderText({ node }) {
+    if (node.attrs.skillUnavailable === true) {
+      return "/Unavailable skill";
+    }
+
     return `/${node.attrs.skillName ?? "skill"}`;
   },
 
@@ -93,14 +124,14 @@ export const SkillNode = Node.create({
   markdownTokenizer: {
     name: SKILL_NODE_TYPE,
     level: "inline",
-    start: (src) => src.indexOf(`<${SKILL_TAG_NAME}`),
+    start: findSkillReferenceTagStart,
     tokenize: (src) => {
-      const match = SKILL_TAG_REGEX_BEGINNING.exec(src);
+      const match = SKILL_REFERENCE_TAG_REGEX_BEGINNING.exec(src);
       if (!match) {
         return undefined;
       }
 
-      const skill = parseSkillTag(match[0]);
+      const skill = parseSkillReferenceTag(match[0]);
       if (!skill) {
         return undefined;
       }
@@ -111,6 +142,7 @@ export const SkillNode = Node.create({
         skillId: skill.id,
         skillIcon: skill.icon,
         skillName: skill.name,
+        skillUnavailable: skill.unavailable,
       };
     },
   },
@@ -121,15 +153,25 @@ export const SkillNode = Node.create({
       skillId: token.skillId,
       skillIcon: token.skillIcon,
       skillName: token.skillName,
+      skillUnavailable: token.skillUnavailable,
     },
   }),
 
-  renderMarkdown: (node) =>
-    isString(node.attrs?.skillId) && isString(node.attrs?.skillName)
+  renderMarkdown: (node) => {
+    if (!isString(node.attrs?.skillId)) {
+      return "";
+    }
+
+    if (node.attrs.skillUnavailable === true) {
+      return serializeUnavailableSkillTag({ id: node.attrs.skillId });
+    }
+
+    return isString(node.attrs?.skillName)
       ? serializeSkillTag({
           id: node.attrs.skillId,
           icon: isString(node.attrs.skillIcon) ? node.attrs.skillIcon : null,
           name: node.attrs.skillName,
         })
-      : "",
+      : "";
+  },
 });

--- a/front/components/editor/input_bar/SkillNodeComponent.tsx
+++ b/front/components/editor/input_bar/SkillNodeComponent.tsx
@@ -1,5 +1,6 @@
 import { getSkillIcon } from "@app/lib/skill";
-import { Chip } from "@dust-tt/sparkle";
+import { UNAVAILABLE_SKILL_LABEL } from "@app/lib/skills/format";
+import { Chip, ExclamationCircleIcon } from "@dust-tt/sparkle";
 import { NodeViewWrapper } from "@tiptap/react";
 
 interface SkillNodeComponentProps {
@@ -8,11 +9,25 @@ interface SkillNodeComponentProps {
       skillId?: string;
       skillIcon?: string | null;
       skillName?: string;
+      skillUnavailable?: boolean;
     };
   };
 }
 
 export function SkillNodeComponent({ node }: SkillNodeComponentProps) {
+  if (node.attrs.skillUnavailable === true) {
+    return (
+      <NodeViewWrapper className="inline-flex align-middle">
+        <Chip
+          label={UNAVAILABLE_SKILL_LABEL}
+          icon={ExclamationCircleIcon}
+          color="warning"
+          size="xs"
+        />
+      </NodeViewWrapper>
+    );
+  }
+
   const skillIcon = node.attrs.skillIcon ?? null;
   const skillName = node.attrs.skillName ?? "Skill";
 

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -19,6 +19,11 @@ import {
   postProcessMarkdown,
   preprocessMarkdownForEditor,
 } from "@app/lib/editor/skill_instructions_preprocessing";
+import {
+  SKILL_TAG_NAME,
+  UNAVAILABLE_SKILL_TAG_NAME,
+} from "@app/lib/skills/format";
+import { TOOL_TAG_NAME } from "@app/lib/tools/format";
 import { isString } from "@app/types/shared/utils/general";
 import { cn } from "@dust-tt/sparkle";
 import type { Transaction } from "@tiptap/pm/state";
@@ -34,8 +39,12 @@ const INSTRUCTIONS_HTML_FIELD_NAME = "instructionsHtml";
 const ATTACHED_KNOWLEDGE_FIELD_NAME = "attachedKnowledge";
 const BASE_ALLOWED_INSTRUCTIONS_TAGS = ["knowledge"];
 const BASE_ALLOWED_INSTRUCTIONS_ATTRS = ["space", "dsv", "hasChildren"];
-const SKILL_REFERENCE_ALLOWED_TAGS = ["skill", "tool"];
-const SKILL_REFERENCE_ALLOWED_ATTRS = ["id", "name", "icon"];
+const SKILL_REFERENCE_ALLOWED_TAGS = [
+  SKILL_TAG_NAME,
+  UNAVAILABLE_SKILL_TAG_NAME,
+  TOOL_TAG_NAME,
+];
+const SKILL_REFERENCE_ALLOWED_ATTRS = ["id", "name", "icon", "unavailable"];
 
 function getSkillInstructionsSanitizeConfig({
   enableSkillReferences,

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -44,7 +44,7 @@ const SKILL_REFERENCE_ALLOWED_TAGS = [
   UNAVAILABLE_SKILL_TAG_NAME,
   TOOL_TAG_NAME,
 ];
-const SKILL_REFERENCE_ALLOWED_ATTRS = ["id", "name", "icon", "unavailable"];
+const SKILL_REFERENCE_ALLOWED_ATTRS = ["id", "name", "icon"];
 
 function getSkillInstructionsSanitizeConfig({
   enableSkillReferences,

--- a/front/lib/editor/skill_instructions_preprocessing.test.ts
+++ b/front/lib/editor/skill_instructions_preprocessing.test.ts
@@ -81,4 +81,30 @@ describe("skill instructions preprocessing", () => {
 
     expect(postProcessMarkdown(editor.getMarkdown())).toContain(toolTag);
   });
+
+  it("preserves unavailable skill tags when skill references are enabled", () => {
+    editor = new Editor({
+      extensions: buildSkillInstructionsExtensions(false, [], {
+        enableSkillReferences: true,
+      }),
+    });
+
+    editor.commands.setContent(
+      preprocessMarkdownForEditor(
+        'Use <unavailable_skill id="skill_123" /> here.',
+        { enableSkillReferences: true }
+      ),
+      {
+        contentType: "markdown",
+      }
+    );
+
+    const json = editor.getJSON();
+    expect(JSON.stringify(json)).toContain('"type":"skill"');
+    expect(JSON.stringify(json)).toContain('"skillId":"skill_123"');
+    expect(JSON.stringify(json)).toContain('"skillUnavailable":true');
+    expect(editor.getMarkdown()).toContain(
+      '<unavailable_skill id="skill_123" />'
+    );
+  });
 });

--- a/front/lib/editor/skill_instructions_preprocessing.ts
+++ b/front/lib/editor/skill_instructions_preprocessing.ts
@@ -57,7 +57,7 @@ export function preprocessMarkdownForEditor(
 ): string {
   const preservedTags = ["knowledge"];
   if (enableSkillReferences) {
-    preservedTags.push("skill");
+    preservedTags.push("skill", "unavailable_skill");
   }
   const preservedTagsPattern = preservedTags.join("|");
   const escapeUnsupportedTags = (markdownToProcess: string) =>

--- a/front/lib/skills/format.ts
+++ b/front/lib/skills/format.ts
@@ -2,28 +2,39 @@ export type SkillReference = {
   id: string;
   icon: string | null;
   name: string;
+  unavailable?: boolean;
 };
 
 export const SKILL_TAG_NAME = "skill";
+export const UNAVAILABLE_SKILL_TAG_NAME = "unavailable_skill";
+export const UNAVAILABLE_SKILL_LABEL = "Unavailable skill";
 
-export const SKILL_TAG_REGEX = /<skill\s+([^>]*?)\s*\/>/g;
-export const SKILL_TAG_REGEX_BEGINNING = /^<skill\s+([^>]*?)\s*\/>/;
+export const SKILL_TAG_REGEX = /<skill\s+([^>]*?)\s*(?:\/>|><\/skill>)/g;
+export const SKILL_TAG_REGEX_BEGINNING =
+  /^<skill\s+([^>]*?)\s*(?:\/>|><\/skill>)/;
+export const SKILL_REFERENCE_TAG_REGEX_BEGINNING =
+  /^<(skill|unavailable_skill)\s+([^>]*?)\s*(?:\/>|><\/\1>)/;
 
 const SKILL_ELEMENT_REGEX = /<skill\b([^>]*)>[\s\S]*?<\/skill>/g;
 
-function parseSkillTagAttributes(attributes: string): SkillReference | null {
+function parseSkillTagAttributes(
+  attributes: string,
+  { unavailable = false }: { unavailable?: boolean } = {}
+): SkillReference | null {
   const id = attributes.match(/\bid="([^"]+)"/)?.[1];
   const name = attributes.match(/\bname="([^"]+)"/)?.[1];
   const icon = attributes.match(/\bicon="([^"]+)"/)?.[1];
+  const parsedName = unavailable ? UNAVAILABLE_SKILL_LABEL : name;
 
-  if (!id || !name) {
+  if (!id || !parsedName) {
     return null;
   }
 
   return {
     id,
     icon: icon ?? null,
-    name,
+    name: parsedName,
+    unavailable,
   };
 }
 
@@ -35,6 +46,20 @@ export function parseSkillTag(tag: string): SkillReference | null {
   }
 
   return parseSkillTagAttributes(attributes);
+}
+
+export function parseSkillReferenceTag(tag: string): SkillReference | null {
+  const match = SKILL_REFERENCE_TAG_REGEX_BEGINNING.exec(tag);
+
+  if (!match) {
+    return null;
+  }
+
+  const [, tagName, attributes] = match;
+
+  return parseSkillTagAttributes(attributes, {
+    unavailable: tagName === UNAVAILABLE_SKILL_TAG_NAME,
+  });
 }
 
 export function extractSkillTags(content: string): SkillReference[] {
@@ -51,6 +76,17 @@ export function serializeSkillTag({ id, name, icon }: SkillReference): string {
   const iconAttribute = icon ? ` icon="${icon}"` : "";
 
   return `<${SKILL_TAG_NAME} id="${id}" name="${name}"${iconAttribute} />`;
+}
+
+export function serializeUnavailableSkillTag(
+  { id }: { id: string },
+  { html = false }: { html?: boolean } = {}
+): string {
+  if (html) {
+    return `<${UNAVAILABLE_SKILL_TAG_NAME} id="${id}"></${UNAVAILABLE_SKILL_TAG_NAME}>`;
+  }
+
+  return `<${UNAVAILABLE_SKILL_TAG_NAME} id="${id}" />`;
 }
 
 export function stripSkillTagPresentationAttributes(content: string): string {


### PR DESCRIPTION
## Description

This PR adds frontend support for unavailable inline skill references in Skill Builder instructions.

Unavailable references are serialized with a dedicated marker and rendered as an error chip labelled `Unavailable skill`, so the editor can display inaccessible nested skills without dropping the surrounding instructions.

## Tests

- Updated existing editor preprocessing tests.

## Risk

- Low. Scoped to Skill Builder instruction rendering.

## Deploy Plan

- Deploy front.

