### PR TITLE
[dust-hive] Fix OAuth redirect forwarding

### DIFF
--- a/x/henry/dust-hive/src/lib/envgen.ts
+++ b/x/henry/dust-hive/src/lib/envgen.ts
@@ -39,6 +39,8 @@ export NEXT_PUBLIC_DUST_API_URL=http://localhost:${ports.front}
 export NEXT_PUBLIC_DUST_STATIC_WEBSITE_URL=http://localhost:${ports.front}
 export NEXT_PUBLIC_DUST_APP_URL=http://localhost:${ports.frontSpaApp}
 export POKE_APP_URL=http://localhost:${ports.frontSpaPoke}
+# OAuth providers are registered against the stable local front port. The
+# dust-hive forwarder maps 3000 to this environment's front/front-api port.
 export DUST_AUTH_REDIRECT_BASE_URL=http://localhost:3000
 export CONNECTORS_PUBLIC_URL=http://localhost:${ports.connectors}
 

--- a/x/henry/dust-hive/src/lib/envgen.ts
+++ b/x/henry/dust-hive/src/lib/envgen.ts
@@ -39,7 +39,7 @@ export NEXT_PUBLIC_DUST_API_URL=http://localhost:${ports.front}
 export NEXT_PUBLIC_DUST_STATIC_WEBSITE_URL=http://localhost:${ports.front}
 export NEXT_PUBLIC_DUST_APP_URL=http://localhost:${ports.frontSpaApp}
 export POKE_APP_URL=http://localhost:${ports.frontSpaPoke}
-export DUST_AUTH_REDIRECT_BASE_URL=http://localhost:${ports.front}
+export DUST_AUTH_REDIRECT_BASE_URL=http://localhost:3000
 export CONNECTORS_PUBLIC_URL=http://localhost:${ports.connectors}
 
 # === Database URIs ===

--- a/x/henry/dust-hive/tests/lib/envgen.test.ts
+++ b/x/henry/dust-hive/tests/lib/envgen.test.ts
@@ -58,7 +58,7 @@ describe("envgen", () => {
       expect(content).toContain(
         "export NEXT_PUBLIC_DUST_STATIC_WEBSITE_URL=http://localhost:10000"
       );
-      expect(content).toContain("export DUST_AUTH_REDIRECT_BASE_URL=http://localhost:10000");
+      expect(content).toContain("export DUST_AUTH_REDIRECT_BASE_URL=http://localhost:3000");
       expect(content).toContain("export CONNECTORS_PUBLIC_URL=http://localhost:10002");
     });
 


### PR DESCRIPTION
## Description
Fixes OAuth callback regression from https://github.com/dust-tt/dust/pull/25922.

Restores `DUST_AUTH_REDIRECT_BASE_URL` generation to `http://localhost:3000`, matching the stable OAuth callback URL used by local provider apps and the dust-hive forwarder. PR #25922 moved this to the per-hive front port to avoid a WorkOS hardcoded `localhost:3000`, but OAuth providers such as Google Drive are registered against the stable forwarded port and reject per-hive callback URLs such as `http://localhost:12000/oauth/google_drive/finalize`.

The generated env file now documents why this value intentionally differs from `ports.front`.

## Risks
Blast radius: dust-hive generated env files for local OAuth and WorkOS callbacks.
Risk: low

This keeps relying on the documented dust-hive forwarder (`3000 -> current hive front/front-api port`). OAuth flows can still fail if `dust-hive warm --no-forward` is used or if forwarding points to another hive, which is already the documented behavior.

## Deploy Plan
- No service deploy or migration.
- Regenerate or manually update existing hive `env.sh` files that were created with the per-hive redirect URL.

## Test
- [x] `bun run check` in `x/henry/dust-hive`