### PR TITLE
feat: restore semantic search tool for pods

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -487,6 +487,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "list_pods": "never_ask",
     "remove_content_node": "medium",
     "retrieve_recent_documents": "never_ask",
+    "semantic_search": "never_ask",
     "update_members": "medium",
   },
   "pod_tasks": {

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -36,6 +36,8 @@ export function getRetrievalTopK({
     (tool) =>
       isServerSideMCPToolConfigurationWithName(tool, "search") ||
       (isServerSideMCPToolConfigurationWithName(tool, "conversation_files") &&
+        tool.originalName === "semantic_search") ||
+      (isServerSideMCPToolConfigurationWithName(tool, "pod_manager") &&
         tool.originalName === "semantic_search")
   );
 

--- a/front/lib/api/actions/servers/pod_manager/build_pod_search_data_sources.ts
+++ b/front/lib/api/actions/servers/pod_manager/build_pod_search_data_sources.ts
@@ -1,0 +1,154 @@
+import { getDataSourceURI } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
+import type { ContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
+import {
+  isContentFragmentDataSourceNode,
+  isContentNodeAttachmentType,
+} from "@app/lib/api/assistant/conversation/attachments";
+import {
+  getProjectConversationFolderInternalId,
+  listProjectContextAttachments,
+} from "@app/lib/api/projects/context";
+import {
+  fetchProjectDataSource,
+  fetchProjectDataSourceView,
+} from "@app/lib/api/projects/data_sources";
+import type { Authenticator } from "@app/lib/auth";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+
+export type PodSemanticSearchScope = "files" | "conversations" | "all";
+
+function mergeContentNodeDataSourceConfigurations(
+  workspaceId: string,
+  nodes: ContentNodeAttachmentType[]
+): DataSourceConfiguration[] {
+  const byViewId = new Map<
+    string,
+    { hasFullView: boolean; parentIds: Set<string> }
+  >();
+
+  for (const node of nodes) {
+    const viewId = node.nodeDataSourceViewId;
+    let agg = byViewId.get(viewId);
+    if (!agg) {
+      agg = { hasFullView: false, parentIds: new Set() };
+      byViewId.set(viewId, agg);
+    }
+    if (isContentFragmentDataSourceNode(node)) {
+      agg.hasFullView = true;
+    } else {
+      agg.parentIds.add(node.nodeId);
+    }
+  }
+
+  return Array.from(byViewId.entries()).map(([dataSourceViewId, agg]) => ({
+    workspaceId,
+    dataSourceViewId,
+    filter: {
+      parents: agg.hasFullView
+        ? null
+        : {
+            in: Array.from(agg.parentIds),
+            not: [],
+          },
+      tags: null,
+    },
+  }));
+}
+
+function podDataSourceFilter(
+  scope: PodSemanticSearchScope,
+  conversationFolderInternalId: string | null
+): DataSourceConfiguration["filter"] {
+  switch (scope) {
+    case "all":
+      return { parents: null, tags: null };
+    case "files":
+      if (!conversationFolderInternalId) {
+        return { parents: null, tags: null };
+      }
+      return {
+        parents: {
+          in: null,
+          not: [conversationFolderInternalId],
+        },
+        tags: null,
+      };
+    case "conversations":
+      if (!conversationFolderInternalId) {
+        return { parents: null, tags: null };
+      }
+      return {
+        parents: {
+          in: [conversationFolderInternalId],
+          not: [],
+        },
+        tags: null,
+      };
+  }
+}
+
+/**
+ * Data sources for semantic search over a Pod, scoped to files (Pod files, metadata,
+ * searchable context nodes), conversations (transcripts in the dust_project connector), or
+ * both. The Pod data source view mixes files and conversations; scope selects via parents
+ * filters on that view.
+ */
+export async function buildPodSearchDataSources(
+  auth: Authenticator,
+  space: SpaceResource,
+  scope: PodSemanticSearchScope
+): Promise<DataSourcesToolConfigurationType> {
+  const owner = auth.getNonNullableWorkspace();
+  const dataSources: DataSourcesToolConfigurationType = [];
+
+  const podDsRes = await fetchProjectDataSource(auth, space);
+  const connectorId = podDsRes.isOk() ? podDsRes.value.connectorId : null;
+  const conversationFolderInternalId =
+    connectorId != null
+      ? getProjectConversationFolderInternalId(connectorId, space.sId)
+      : null;
+
+  const podDsViewRes = await fetchProjectDataSourceView(auth, space);
+  if (podDsViewRes.isOk()) {
+    const needsFolder = scope === "files" || scope === "conversations";
+    if (!needsFolder || conversationFolderInternalId != null) {
+      dataSources.push({
+        uri: getDataSourceURI({
+          workspaceId: owner.sId,
+          dataSourceViewId: podDsViewRes.value.sId,
+          filter: podDataSourceFilter(scope, conversationFolderInternalId),
+        }),
+        mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
+      });
+    }
+  }
+
+  if (scope === "conversations") {
+    return dataSources;
+  }
+
+  const podContextAttachments = await listProjectContextAttachments(
+    auth,
+    space
+  );
+  const searchableContentNodes = podContextAttachments.filter(
+    (a): a is ContentNodeAttachmentType =>
+      isContentNodeAttachmentType(a) && a.isSearchable
+  );
+  const contentNodeConfigs = mergeContentNodeDataSourceConfigurations(
+    owner.sId,
+    searchableContentNodes
+  );
+
+  for (const cfg of contentNodeConfigs) {
+    dataSources.push({
+      uri: getDataSourceURI(cfg),
+      mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
+    });
+  }
+
+  return dataSources;
+}

--- a/front/lib/api/actions/servers/pod_manager/metadata.ts
+++ b/front/lib/api/actions/servers/pod_manager/metadata.ts
@@ -5,6 +5,7 @@ import {
   IncludeInputSchema,
   SearchWithNodesInputSchema,
 } from "@app/lib/actions/mcp_internal_actions/types";
+import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import { FILES_SERVER_NAME } from "@app/lib/api/actions/servers/files/metadata";
 import { SCOPED_PREFIX_POD } from "@app/lib/api/file_system/types";
 import { DATA_SOURCE_NODE_ID } from "@app/types/core/content_node";
@@ -16,6 +17,7 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 export const POD_MANAGER_SERVER_NAME = "pod_manager" as const;
 export const UPDATE_MEMBERS_TOOL_NAME = "update_members" as const;
 export const LIST_MEMBERS_TOOL_NAME = "list_members" as const;
+export const SEMANTIC_SEARCH_TOOL_NAME = "semantic_search" as const;
 
 export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
   add_content_node: {
@@ -243,6 +245,43 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
       done: "Retrieve recent Pod documents",
     },
   },
+  [SEMANTIC_SEARCH_TOOL_NAME]: {
+    description:
+      "Semantic search over a Pod using the same retrieval pipeline as company data search. Scope selects the Pod data source slice (files vs conversation transcripts vs both) plus searchable context nodes for files/all.",
+    schema: {
+      query: z
+        .string()
+        .describe(
+          "Natural-language query; include enough context from the conversation for good retrieval."
+        ),
+      searchScope: z
+        .enum(["files", "conversations", "all"])
+        .optional()
+        .describe(
+          "files: Pod files, metadata, and linked searchable nodes (excludes conversation transcripts in the Pod data source); conversations: only those transcripts; all: entire Pod data source plus linked nodes (default when omitted)."
+        ),
+      relativeTimeFrame: z
+        .string()
+        .regex(/^(all|\d+[hdwmy])$/)
+        .optional()
+        .describe(
+          "Restrict matches by document time (same as company search): `all`, or `{k}h|d|w|m|y`. Omit for all time."
+        ),
+      nodeIds: SearchWithNodesInputSchema.shape.nodeIds,
+      dustPod: ConfigurableToolInputSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_POD
+      ]
+        .optional()
+        .describe(
+          "Optional Pod to search, will fallback to the conversation's Pod."
+        ),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Searching Pod",
+      done: "Search Pod",
+    },
+  },
   create_conversation: {
     description:
       "Create a new conversation in the Pod and post a user message. Default: always pass an agentName to delegate the task to an agent running inside the Pod. Do NOT do the work yourself. If work needs to be done, delegate it via agentName. Omit agentName only when posting a simple message that requires no intellectual work (e.g. a status update, a comment, a note) or when explicitly asked to post the final output.",
@@ -371,6 +410,8 @@ const POD_MANAGER_INSTRUCTIONS =
   "Use `list_pods` to discover Pods you can access and obtain the dustPod uri for other tools. " +
   "Use `retrieve_recent_documents` to load recent content from the Pod data source and from " +
   "knowledge nodes in the Pod context. " +
+  `Use \`${getPrefixedToolName(POD_MANAGER_SERVER_NAME, SEMANTIC_SEARCH_TOOL_NAME)}\` to find relevant chunks in Pod files and/or conversations ` +
+  "(scope: files, conversations, or all). " +
   "Requires write permissions on the Pod for state-changing operations.";
 
 export const POD_MANAGER_SERVER = {

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -12,6 +12,7 @@ import {
   FILES_SERVER_NAME,
 } from "@app/lib/api/actions/servers/files/metadata";
 import { runIncludeDataRetrieval } from "@app/lib/api/actions/servers/include_data/include_function";
+import { buildPodSearchDataSources } from "@app/lib/api/actions/servers/pod_manager/build_pod_search_data_sources";
 import {
   buildProjectRetrieveDataSources,
   getPod,
@@ -22,8 +23,10 @@ import {
 import {
   LIST_MEMBERS_TOOL_NAME,
   POD_MANAGER_TOOLS_METADATA,
+  SEMANTIC_SEARCH_TOOL_NAME,
   UPDATE_MEMBERS_TOOL_NAME,
 } from "@app/lib/api/actions/servers/pod_manager/metadata";
+import { searchFunction } from "@app/lib/api/actions/servers/search/tools";
 import { resolveAgentConfigurationIdByName } from "@app/lib/api/assistant/configuration/agent";
 import {
   createConversation,
@@ -801,6 +804,49 @@ export function createProjectManagerTools(
           retrievalTopK: agentLoopContext.runContext.stepContext.retrievalTopK,
         });
       }, "Failed to retrieve recent Pod documents");
+    },
+
+    [SEMANTIC_SEARCH_TOOL_NAME]: async (params) => {
+      return withErrorHandling(async () => {
+        if (!agentLoopContext?.runContext) {
+          return new Err(
+            new MCPError("No conversation context available", {
+              tracked: false,
+            })
+          );
+        }
+
+        const scope = params.searchScope ?? "all";
+        const contextRes = await getPod(auth, {
+          agentLoopContext,
+          dustPod: params.dustPod,
+        });
+        if (contextRes.isErr()) {
+          return contextRes;
+        }
+
+        const { pod } = contextRes.value;
+        const dataSources = await buildPodSearchDataSources(auth, pod, scope);
+
+        if (dataSources.length === 0) {
+          return new Err(
+            new MCPError(
+              scope === "conversations"
+                ? "No Pod data source available to search conversations, or the Pod connector is not linked (required to scope transcript documents)."
+                : "No Pod data sources available to search for this scope.",
+              { tracked: false }
+            )
+          );
+        }
+
+        return searchFunction(auth, {
+          query: params.query,
+          relativeTimeFrame: params.relativeTimeFrame ?? "all",
+          dataSources,
+          nodeIds: params.nodeIds,
+          agentLoopContext,
+        });
+      }, "Failed to search Pod");
     },
 
     create_conversation: async (params) => {


### PR DESCRIPTION
## Description

This PR restores the `semantic_search` tool to the `pod_manager` MCP server, enabling semantic search over Pod files, conversation transcripts, or both.

## Tests
Manually.

## Risks
Low.

## Deploy Plan
Standard deployment.
