### PR TITLE
feat: remove mark task as done tool and update update task tool

### DIFF
--- a/front/components/assistant/conversation/ToolValidationDetails.tsx
+++ b/front/components/assistant/conversation/ToolValidationDetails.tsx
@@ -144,6 +144,7 @@ export function ToolValidationDetails({
         input={blockedAction.inputs}
         owner={owner}
         user={user}
+        agentName={blockedAction.metadata.agentName}
         conversationId={conversationId}
       />
     );

--- a/front/components/assistant/conversation/tool_validation/PodTasksUpdateValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/PodTasksUpdateValidationDetails.tsx
@@ -280,7 +280,7 @@ function TaskUpdateRow({
                 </span>
                 <span className="text-sm font-medium text-foreground dark:text-foreground-night">
                   {taskInput.markAsDoneByType === "user"
-                    ? "you"
+                    ? "You"
                     : `@${agentName}`}
                 </span>
               </div>
@@ -351,7 +351,7 @@ function TaskUpdateRow({
                 </span>
                 <span className="text-sm font-medium text-foreground dark:text-foreground-night">
                   {taskInput.markAsDoneByType === "user"
-                    ? "you"
+                    ? "You"
                     : `@${agentName}`}
                 </span>
               </div>

--- a/front/components/assistant/conversation/tool_validation/PodTasksUpdateValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/PodTasksUpdateValidationDetails.tsx
@@ -21,6 +21,7 @@ interface PodTasksUpdateValidationDetailsProps {
   input: PodTasksUpdateTasksInput;
   owner: LightWorkspaceType;
   user: UserType;
+  agentName: string;
   conversationId?: string | null;
 }
 
@@ -42,6 +43,7 @@ interface TaskUpdateRowProps {
   workspaceId: string;
   taskInput: PodTasksUpdateTaskItemInput;
   user: UserType;
+  agentName: string;
 }
 
 interface FormatAssigneeLabelParams {
@@ -169,7 +171,12 @@ function AssigneeChangeRow({
   return <ChangeRow label="Assignee" before={beforeLabel} after={afterLabel} />;
 }
 
-function TaskUpdateRow({ workspaceId, taskInput, user }: TaskUpdateRowProps) {
+function TaskUpdateRow({
+  workspaceId,
+  taskInput,
+  user,
+  agentName,
+}: TaskUpdateRowProps) {
   const {
     task: currentTask,
     isWorkspacePodTaskLoading: isWorkspaceProjectTaskLoading,
@@ -183,16 +190,16 @@ function TaskUpdateRow({ workspaceId, taskInput, user }: TaskUpdateRowProps) {
     if (currentTask?.user?.sId) {
       ids.add(currentTask.user.sId);
     }
-    if (taskInput.userId !== undefined) {
+    if (taskInput.assigneeUserId !== undefined) {
       const normalizedNextAssigneeSId = normalizeAssigneeUserId(
-        taskInput.userId
+        taskInput.assigneeUserId
       );
       if (normalizedNextAssigneeSId) {
         ids.add(normalizedNextAssigneeSId);
       }
     }
     return [...ids];
-  }, [currentTask?.user?.sId, taskInput.userId]);
+  }, [currentTask?.user?.sId, taskInput.assigneeUserId]);
 
   const { membersBySId, isMembersLoading } = useMemberDetails({
     workspaceId,
@@ -205,14 +212,15 @@ function TaskUpdateRow({ workspaceId, taskInput, user }: TaskUpdateRowProps) {
 
   const currentAssigneeSId = currentTask?.user?.sId ?? null;
   const nextAssigneeSId =
-    taskInput.userId !== undefined
-      ? normalizeAssigneeUserId(taskInput.userId)
+    taskInput.assigneeUserId !== undefined
+      ? normalizeAssigneeUserId(taskInput.assigneeUserId)
       : currentAssigneeSId;
 
   const textChange =
     taskInput.text !== undefined && taskInput.text !== currentTask?.text;
   const assigneeChange =
-    taskInput.userId !== undefined && nextAssigneeSId !== currentAssigneeSId;
+    taskInput.assigneeUserId !== undefined &&
+    nextAssigneeSId !== currentAssigneeSId;
   const currentStatus = currentTask?.status;
   const statusChange =
     currentStatus !== undefined && effectiveStatus !== currentStatus;
@@ -265,6 +273,18 @@ function TaskUpdateRow({ workspaceId, taskInput, user }: TaskUpdateRowProps) {
                 after={formatTaskStatusLabel(effectiveStatus)}
               />
             )}
+            {statusChange && effectiveStatus === "done" && (
+              <div className="flex flex-col gap-0.5">
+                <span className="text-xs font-medium text-muted-foreground dark:text-muted-foreground-night">
+                  Marked done by
+                </span>
+                <span className="text-sm font-medium text-foreground dark:text-foreground-night">
+                  {taskInput.markAsDoneByType === "user"
+                    ? "you"
+                    : `@${agentName}`}
+                </span>
+              </div>
+            )}
             {taskInput.doneRationale && (
               <div className="flex flex-col gap-0.5">
                 <span className="text-xs font-medium text-muted-foreground dark:text-muted-foreground-night">
@@ -296,21 +316,21 @@ function TaskUpdateRow({ workspaceId, taskInput, user }: TaskUpdateRowProps) {
                 after={taskInput.text}
               />
             )}
-            {taskInput.userId !== undefined &&
-              normalizeAssigneeUserId(taskInput.userId) !== null && (
+            {taskInput.assigneeUserId !== undefined &&
+              normalizeAssigneeUserId(taskInput.assigneeUserId) !== null && (
                 <ChangeRow
                   label="Assignee"
                   before="—"
                   after={formatAssigneeLabel({
-                    userId: normalizeAssigneeUserId(taskInput.userId),
+                    userId: normalizeAssigneeUserId(taskInput.assigneeUserId),
                     currentUserSId: user.sId,
                     memberDisplayBySId: membersBySId,
                     isMembersLoading,
                   })}
                 />
               )}
-            {taskInput.userId !== undefined &&
-              normalizeAssigneeUserId(taskInput.userId) === null && (
+            {taskInput.assigneeUserId !== undefined &&
+              normalizeAssigneeUserId(taskInput.assigneeUserId) === null && (
                 <ChangeRow
                   label="Assignee"
                   before="—"
@@ -323,6 +343,18 @@ function TaskUpdateRow({ workspaceId, taskInput, user }: TaskUpdateRowProps) {
                 before="—"
                 after={formatTaskStatusLabel(taskInput.status)}
               />
+            )}
+            {(taskInput.status === "done" || taskInput.doneRationale) && (
+              <div className="flex flex-col gap-0.5">
+                <span className="text-xs font-medium text-muted-foreground dark:text-muted-foreground-night">
+                  Marked done by
+                </span>
+                <span className="text-sm font-medium text-foreground dark:text-foreground-night">
+                  {taskInput.markAsDoneByType === "user"
+                    ? "you"
+                    : `@${agentName}`}
+                </span>
+              </div>
             )}
             {taskInput.doneRationale && (
               <div className="flex flex-col gap-0.5">
@@ -345,6 +377,7 @@ export function PodTasksUpdateValidationDetails({
   input,
   owner,
   user,
+  agentName,
   conversationId,
 }: PodTasksUpdateValidationDetailsProps) {
   const { podLabel, isPodLabelLoading } = usePodLabel({
@@ -359,7 +392,7 @@ export function PodTasksUpdateValidationDetails({
   return (
     <div className="flex flex-col gap-3 pt-2">
       <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-        The agent wants to update{" "}
+        @{agentName} wants to update{" "}
         <span className="font-medium text-foreground dark:text-foreground-night">
           {taskCount}
         </span>{" "}
@@ -377,6 +410,7 @@ export function PodTasksUpdateValidationDetails({
             workspaceId={owner.sId}
             taskInput={taskInput}
             user={user}
+            agentName={agentName}
           />
         ))}
       </div>

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -495,7 +495,6 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   "pod_tasks": {
     "create_tasks": "low",
     "list_tasks": "never_ask",
-    "mark_task_done": "low",
     "start_task_agent": "low",
     "update_tasks": "low",
   },

--- a/front/lib/api/actions/servers/pod_tasks/metadata.ts
+++ b/front/lib/api/actions/servers/pod_tasks/metadata.ts
@@ -67,33 +67,6 @@ export const POD_TASKS_TOOLS_METADATA = createToolsRecord({
       done: "Create tasks",
     },
   },
-  mark_task_done: {
-    description: "Mark one or more tasks as done.",
-    schema: {
-      actorType: z
-        .enum(["user", "agent"])
-        .describe(
-          "Who is marking the task done? Use 'user' when the user explicitly asked for it."
-        ),
-      taskIds: z
-        .array(z.string())
-        .min(1)
-        .max(50)
-        .describe("List of task sIds to mark as done."),
-      dustPod: ConfigurableToolInputSchemas[
-        INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_POD
-      ]
-        .optional()
-        .describe(
-          "Optional Pod to resolve tasks in; falls back to the conversation's Pod."
-        ),
-    },
-    stake: "low",
-    displayLabels: {
-      running: "Marking tasks as done",
-      done: "Mark tasks as done",
-    },
-  },
   [UPDATE_TASKS_TOOL_NAME]: {
     description: "Update one or more existing tasks at once in the Pod.",
     schema: PodTasksUpdateTasksInputSchema.shape,

--- a/front/lib/api/actions/servers/pod_tasks/tools/index.test.ts
+++ b/front/lib/api/actions/servers/pod_tasks/tools/index.test.ts
@@ -397,11 +397,10 @@ describe("buildTaskUpdatePayload", () => {
       null
     );
 
-    expect("error" in result).toBe(true);
-    if (!("error" in result)) {
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) {
       return;
     }
-    expect(result.error).toContain(outsider.sId);
-    expect(result.error).toContain(row.sId);
+    expect(result.error.message).toContain(outsider.sId);
   });
 });

--- a/front/lib/api/actions/servers/pod_tasks/tools/index.test.ts
+++ b/front/lib/api/actions/servers/pod_tasks/tools/index.test.ts
@@ -1,0 +1,407 @@
+import {
+  buildTaskUpdatePayload,
+  doneAttribution,
+  rationaleUpdate,
+  statusTransitionUpdates,
+} from "@app/lib/api/actions/servers/pod_tasks/tools/index";
+import type { Authenticator } from "@app/lib/auth";
+import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type { ProjectTaskModel } from "@app/lib/resources/storage/models/project_task";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { CreationAttributes } from "sequelize";
+import { beforeEach, describe, expect, it } from "vitest";
+
+function makeTodoBlob(
+  spaceId: number,
+  userId: number,
+  overrides: Partial<CreationAttributes<ProjectTaskModel>> = {}
+): Omit<CreationAttributes<ProjectTaskModel>, "workspaceId"> {
+  return {
+    spaceId,
+    userId,
+    createdByType: "user",
+    createdByUserId: userId,
+    createdByAgentConfigurationId: null,
+    markedAsDoneByType: null,
+    markedAsDoneByUserId: null,
+    markedAsDoneByAgentConfigurationId: null,
+    category: "to_do",
+    text: "Test todo",
+    status: "todo",
+    doneAt: null,
+    actorRationale: null,
+    agentInstructions: null,
+    agentSuggestionStatus: null,
+    agentSuggestionReviewedAt: null,
+    agentSuggestionReviewedByUserId: null,
+    ...overrides,
+  };
+}
+
+describe("doneAttribution", () => {
+  it("returns user attribution when actor is a user", () => {
+    expect(doneAttribution("user", 42, "agt_xyz")).toEqual({
+      markedAsDoneByType: "user",
+      markedAsDoneByUserId: 42,
+      markedAsDoneByAgentConfigurationId: null,
+    });
+  });
+
+  it("returns agent attribution when actor is an agent", () => {
+    expect(doneAttribution("agent", 42, "agt_xyz")).toEqual({
+      markedAsDoneByType: "agent",
+      markedAsDoneByUserId: null,
+      markedAsDoneByAgentConfigurationId: "agt_xyz",
+    });
+  });
+
+  it("records null agentConfigId when actor is an agent with no config", () => {
+    expect(doneAttribution("agent", 42, null)).toEqual({
+      markedAsDoneByType: "agent",
+      markedAsDoneByUserId: null,
+      markedAsDoneByAgentConfigurationId: null,
+    });
+  });
+});
+
+describe("statusTransitionUpdates", () => {
+  it("sets doneAt and user attribution when transitioning to done", () => {
+    const result = statusTransitionUpdates("done", "user", 42, null);
+    expect(result.status).toBe("done");
+    expect(result.doneAt).toBeInstanceOf(Date);
+    expect(result.markedAsDoneByType).toBe("user");
+    expect(result.markedAsDoneByUserId).toBe(42);
+    expect(result.markedAsDoneByAgentConfigurationId).toBeNull();
+  });
+
+  it("sets doneAt and agent attribution when transitioning to done as agent", () => {
+    const result = statusTransitionUpdates("done", "agent", 42, "agt_xyz");
+    expect(result.markedAsDoneByType).toBe("agent");
+    expect(result.markedAsDoneByUserId).toBeNull();
+    expect(result.markedAsDoneByAgentConfigurationId).toBe("agt_xyz");
+  });
+
+  it("clears doneAt and attribution when transitioning to todo", () => {
+    const result = statusTransitionUpdates("todo", "user", 42, null);
+    expect(result).toEqual({
+      status: "todo",
+      doneAt: null,
+      markedAsDoneByType: null,
+      markedAsDoneByUserId: null,
+      markedAsDoneByAgentConfigurationId: null,
+    });
+  });
+
+  it("clears doneAt and attribution when transitioning to in_progress", () => {
+    const result = statusTransitionUpdates("in_progress", "user", 42, null);
+    expect(result).toEqual({
+      status: "in_progress",
+      doneAt: null,
+      markedAsDoneByType: null,
+      markedAsDoneByUserId: null,
+      markedAsDoneByAgentConfigurationId: null,
+    });
+  });
+});
+
+describe("rationaleUpdate", () => {
+  it("sets actorRationale when doneRationale is provided", () => {
+    expect(
+      rationaleUpdate(
+        { taskId: "ptd_1", doneRationale: "shipped it" },
+        "todo",
+        "done"
+      )
+    ).toEqual({ actorRationale: "shipped it" });
+  });
+
+  it("clears actorRationale when transitioning out of done without a rationale", () => {
+    expect(rationaleUpdate({ taskId: "ptd_1" }, "done", "todo")).toEqual({
+      actorRationale: null,
+    });
+  });
+
+  it("returns no update when status is unchanged and no rationale is provided", () => {
+    expect(rationaleUpdate({ taskId: "ptd_1" }, "todo", "todo")).toEqual({});
+    expect(rationaleUpdate({ taskId: "ptd_1" }, "done", "done")).toEqual({});
+  });
+});
+
+describe("buildTaskUpdatePayload", () => {
+  let workspace: LightWorkspaceType;
+  let user: UserResource;
+  let auth: Authenticator;
+  let space: SpaceResource;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({ role: "user" });
+    workspace = setup.workspace;
+    user = setup.user;
+    auth = setup.authenticator;
+    space = setup.globalSpace;
+  });
+
+  it("marks a todo as done with user attribution", async () => {
+    const row = await ProjectTaskResource.makeNew(
+      auth,
+      makeTodoBlob(space.id, user.id)
+    );
+
+    const result = await buildTaskUpdatePayload(
+      auth,
+      space,
+      row,
+      { taskId: row.sId, status: "done", markAsDoneByType: "user" },
+      null
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.taskUpdates.status).toBe("done");
+    expect(result.value.taskUpdates.doneAt).toBeInstanceOf(Date);
+    expect(result.value.taskUpdates.markedAsDoneByType).toBe("user");
+    expect(result.value.taskUpdates.markedAsDoneByUserId).toBe(user.id);
+    expect(
+      result.value.taskUpdates.markedAsDoneByAgentConfigurationId
+    ).toBeNull();
+  });
+
+  it("marks a todo as done with agent attribution", async () => {
+    const row = await ProjectTaskResource.makeNew(
+      auth,
+      makeTodoBlob(space.id, user.id)
+    );
+
+    const result = await buildTaskUpdatePayload(
+      auth,
+      space,
+      row,
+      {
+        taskId: row.sId,
+        doneRationale: "done by the agent",
+        markAsDoneByType: "agent",
+      },
+      "agt_xyz"
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.taskUpdates.status).toBe("done");
+    expect(result.value.taskUpdates.markedAsDoneByType).toBe("agent");
+    expect(result.value.taskUpdates.markedAsDoneByUserId).toBeNull();
+    expect(result.value.taskUpdates.markedAsDoneByAgentConfigurationId).toBe(
+      "agt_xyz"
+    );
+    expect(result.value.taskUpdates.actorRationale).toBe("done by the agent");
+  });
+
+  it("defaults to agent attribution when markAsDoneByType is omitted", async () => {
+    const row = await ProjectTaskResource.makeNew(
+      auth,
+      makeTodoBlob(space.id, user.id)
+    );
+
+    const result = await buildTaskUpdatePayload(
+      auth,
+      space,
+      row,
+      { taskId: row.sId, status: "done" },
+      "agt_xyz"
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.taskUpdates.markedAsDoneByType).toBe("agent");
+    expect(result.value.taskUpdates.markedAsDoneByUserId).toBeNull();
+    expect(result.value.taskUpdates.markedAsDoneByAgentConfigurationId).toBe(
+      "agt_xyz"
+    );
+  });
+
+  it("clears attribution and doneAt when transitioning out of done", async () => {
+    const doneAt = new Date();
+    const row = await ProjectTaskResource.makeNew(
+      auth,
+      makeTodoBlob(space.id, user.id, {
+        status: "done",
+        doneAt,
+        actorRationale: "earlier rationale",
+        markedAsDoneByType: "user",
+        markedAsDoneByUserId: user.id,
+      })
+    );
+
+    const result = await buildTaskUpdatePayload(
+      auth,
+      space,
+      row,
+      { taskId: row.sId, status: "todo" },
+      null
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.taskUpdates.status).toBe("todo");
+    expect(result.value.taskUpdates.doneAt).toBeNull();
+    expect(result.value.taskUpdates.actorRationale).toBeNull();
+    expect(result.value.taskUpdates.markedAsDoneByType).toBeNull();
+    expect(result.value.taskUpdates.markedAsDoneByUserId).toBeNull();
+    expect(
+      result.value.taskUpdates.markedAsDoneByAgentConfigurationId
+    ).toBeNull();
+  });
+
+  it("does not wipe doneAt when editing the text of an already-done task", async () => {
+    const doneAt = new Date("2025-01-15T10:00:00Z");
+    const row = await ProjectTaskResource.makeNew(
+      auth,
+      makeTodoBlob(space.id, user.id, {
+        status: "done",
+        doneAt,
+        markedAsDoneByType: "user",
+        markedAsDoneByUserId: user.id,
+      })
+    );
+
+    const result = await buildTaskUpdatePayload(
+      auth,
+      space,
+      row,
+      { taskId: row.sId, text: "Updated description goes here." },
+      null
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.taskUpdates).not.toHaveProperty("doneAt");
+    expect(result.value.taskUpdates).not.toHaveProperty("markedAsDoneByType");
+    expect(result.value.taskUpdates).not.toHaveProperty("markedAsDoneByUserId");
+    expect(result.value.taskUpdates).not.toHaveProperty("status");
+    expect(result.value.taskUpdates.text).toBe(
+      "Updated description goes here."
+    );
+  });
+
+  it("returns no updates when nothing in the item would change", async () => {
+    const row = await ProjectTaskResource.makeNew(
+      auth,
+      makeTodoBlob(space.id, user.id, { status: "done", doneAt: new Date() })
+    );
+
+    const result = await buildTaskUpdatePayload(
+      auth,
+      space,
+      row,
+      { taskId: row.sId, status: "done" },
+      null
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.taskUpdates).toEqual({});
+  });
+
+  it("updates actorRationale on an already-done task without re-setting doneAt or attribution", async () => {
+    const doneAt = new Date("2025-01-15T10:00:00Z");
+    const row = await ProjectTaskResource.makeNew(
+      auth,
+      makeTodoBlob(space.id, user.id, {
+        status: "done",
+        doneAt,
+        actorRationale: "original",
+        markedAsDoneByType: "user",
+        markedAsDoneByUserId: user.id,
+      })
+    );
+
+    const result = await buildTaskUpdatePayload(
+      auth,
+      space,
+      row,
+      { taskId: row.sId, doneRationale: "amended rationale" },
+      null
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.taskUpdates.actorRationale).toBe("amended rationale");
+    expect(result.value.taskUpdates).not.toHaveProperty("doneAt");
+    expect(result.value.taskUpdates).not.toHaveProperty("markedAsDoneByType");
+    expect(result.value.taskUpdates).not.toHaveProperty("markedAsDoneByUserId");
+  });
+
+  it("resolves a valid pod member as the new assignee", async () => {
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+
+    const row = await ProjectTaskResource.makeNew(
+      auth,
+      makeTodoBlob(space.id, user.id)
+    );
+
+    const result = await buildTaskUpdatePayload(
+      auth,
+      space,
+      row,
+      { taskId: row.sId, assigneeUserId: otherUser.sId },
+      null
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.taskUpdates.userId).toBe(otherUser.id);
+  });
+
+  // Pods are project spaces — membership is restricted to the project's
+  // member groups, unlike the workspace globalSpace which treats every
+  // workspace member as a member. Use a project space here so the
+  // non-member error path is reachable.
+  it("returns an error when assignee is not a member of the pod", async () => {
+    const projectSpace = await SpaceFactory.project(workspace, user.id);
+
+    const outsider = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, outsider, { role: "user" });
+
+    const row = await ProjectTaskResource.makeNew(
+      auth,
+      makeTodoBlob(projectSpace.id, user.id)
+    );
+
+    const result = await buildTaskUpdatePayload(
+      auth,
+      projectSpace,
+      row,
+      { taskId: row.sId, assigneeUserId: outsider.sId },
+      null
+    );
+
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) {
+      return;
+    }
+    expect(result.error).toContain(outsider.sId);
+    expect(result.error).toContain(row.sId);
+  });
+});

--- a/front/lib/api/actions/servers/pod_tasks/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_tasks/tools/index.ts
@@ -19,60 +19,169 @@ import { inferProjectTaskSourceFromUrl } from "@app/lib/api/actions/servers/pod_
 import { resolveAgentConfigurationIdByName } from "@app/lib/api/assistant/configuration/agent";
 import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
 import { startAgentForProjectTask } from "@app/lib/project_task/start_agent";
-import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
+import {
+  ProjectTaskResource,
+  type UpdateBlob,
+} from "@app/lib/resources/project_task_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { getConversationRoute } from "@app/lib/utils/router";
-import type { PodTaskStatus } from "@app/types/project_task";
+import type { PodTaskActorType, PodTaskStatus } from "@app/types/project_task";
 import { POD_TASK_NO_ASSIGNEE_LABEL } from "@app/types/project_task";
 import type { ModelId } from "@app/types/shared/model_id";
-import { Err, Ok } from "@app/types/shared/result";
+import { Err, Ok, type Result } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
-type PodTaskUpdateItem = {
+export type PodTaskUpdateItem = {
   taskId: string;
   text?: string;
-  userId?: string | null;
+  assigneeUserId?: string | null;
   doneRationale?: string;
   status?: PodTaskStatus;
+  markAsDoneByType?: PodTaskActorType;
 };
 
-async function buildTaskUpdatePayload(
+type DoneAttribution = Pick<
+  UpdateBlob,
+  | "markedAsDoneByType"
+  | "markedAsDoneByUserId"
+  | "markedAsDoneByAgentConfigurationId"
+>;
+
+export function doneAttribution(
+  actorType: PodTaskActorType,
+  actorUserId: ModelId | null,
+  agentConfigId: string | null
+): DoneAttribution {
+  switch (actorType) {
+    case "user":
+      return {
+        markedAsDoneByType: "user",
+        markedAsDoneByUserId: actorUserId,
+        markedAsDoneByAgentConfigurationId: null,
+      };
+    case "agent":
+      return {
+        markedAsDoneByType: "agent",
+        markedAsDoneByUserId: null,
+        markedAsDoneByAgentConfigurationId: agentConfigId,
+      };
+    default:
+      return assertNever(actorType);
+  }
+}
+
+export function statusTransitionUpdates(
+  nextStatus: PodTaskStatus,
+  actorType: PodTaskActorType,
+  actorUserId: ModelId | null,
+  agentConfigId: string | null
+): UpdateBlob {
+  switch (nextStatus) {
+    case "done":
+      return {
+        status: "done",
+        doneAt: new Date(),
+        ...doneAttribution(actorType, actorUserId, agentConfigId),
+      };
+    case "todo":
+    case "in_progress":
+      return {
+        status: nextStatus,
+        doneAt: null,
+        markedAsDoneByType: null,
+        markedAsDoneByUserId: null,
+        markedAsDoneByAgentConfigurationId: null,
+      };
+    default:
+      return assertNever(nextStatus);
+  }
+}
+
+async function resolveAssigneeUpdate(
   space: SpaceResource,
-  workspaceSId: string,
+  workspaceId: string,
+  itemUserId: string | null | undefined
+): Promise<Result<{ userId?: number | null }, DustError<"user_not_member">>> {
+  if (itemUserId === undefined) {
+    return new Ok({ userId: undefined });
+  }
+  if (itemUserId === null) {
+    return new Ok({ userId: null });
+  }
+  const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    itemUserId,
+    workspaceId
+  );
+  if (!space.isMember(userAuth)) {
+    return new Err(
+      new DustError(
+        "user_not_member",
+        `User ${itemUserId} is not a member of the Pod.`
+      )
+    );
+  }
+  return new Ok({ userId: userAuth.getNonNullableUser().id });
+}
+
+export function rationaleUpdate(
+  item: PodTaskUpdateItem,
+  prevStatus: PodTaskStatus,
+  nextStatus: PodTaskStatus
+): Pick<UpdateBlob, "actorRationale"> {
+  if (item.doneRationale !== undefined) {
+    return { actorRationale: item.doneRationale };
+  }
+  if (nextStatus !== "done" && prevStatus === "done") {
+    return { actorRationale: null };
+  }
+  return {};
+}
+
+export async function buildTaskUpdatePayload(
+  auth: Authenticator,
+  space: SpaceResource,
   row: ProjectTaskResource,
-  item: PodTaskUpdateItem
-): Promise<
-  | { updates: Parameters<ProjectTaskResource["updateWithVersion"]>[1] }
-  | { error: string }
-> {
-  const updates: Parameters<ProjectTaskResource["updateWithVersion"]>[1] = {
-    status: item.doneRationale ? "done" : (item.status ?? row.status),
-    doneAt: item.doneRationale ? new Date() : null,
-    actorRationale: item.doneRationale ?? row.actorRationale,
+  item: PodTaskUpdateItem,
+  agentConfigId: string | null
+): Promise<Result<{ taskUpdates: UpdateBlob }, DustError<"user_not_member">>> {
+  const actorUserId = auth.user()?.id ?? null;
+  const workspaceSId = auth.getNonNullableWorkspace().sId;
+
+  const nextStatus: PodTaskStatus = item.doneRationale
+    ? "done"
+    : (item.status ?? row.status);
+
+  const updates: UpdateBlob = {
+    ...(nextStatus !== row.status
+      ? statusTransitionUpdates(
+          nextStatus,
+          item.markAsDoneByType ?? "agent",
+          actorUserId,
+          agentConfigId
+        )
+      : {}),
+    ...rationaleUpdate(item, row.status, nextStatus),
+    ...(item.text !== undefined ? { text: item.text } : {}),
   };
 
-  if (item.text !== undefined) {
-    updates.text = item.text;
+  const assignee = await resolveAssigneeUpdate(
+    space,
+    workspaceSId,
+    item.assigneeUserId
+  );
+  if (assignee.isErr()) {
+    return assignee;
   }
 
-  if (item.userId === null) {
-    updates.userId = null;
-  } else if (typeof item.userId === "string") {
-    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
-      item.userId,
-      workspaceSId
-    );
-    if (!space.isMember(userAuth)) {
-      return {
-        error: `User ${item.userId} is not a member of the Pod for task ${item.taskId}.`,
-      };
-    }
-    updates.userId = userAuth.getNonNullableUser().id;
+  if (assignee.value.userId !== undefined) {
+    updates.userId = assignee.value.userId;
   }
 
-  return { updates };
+  return new Ok({ taskUpdates: updates });
 }
 
 function formatTaskListingLine(row: ProjectTaskResource): string {
@@ -273,74 +382,6 @@ export function createProjectTasksTools(
       }, "Failed to create tasks");
     },
 
-    mark_task_done: async ({ actorType, taskIds, dustPod }) => {
-      return withErrorHandling(async () => {
-        const contextRes = await getPod(auth, {
-          agentLoopContext,
-          dustPod,
-        });
-        if (contextRes.isErr()) {
-          return contextRes;
-        }
-
-        const marked: string[] = [];
-        const alreadyDone: string[] = [];
-        const notFound: string[] = [];
-
-        for (const taskId of taskIds) {
-          const row = await ProjectTaskResource.fetchBySId(auth, taskId);
-          if (!row) {
-            notFound.push(taskId);
-            continue;
-          }
-
-          if (row.status === "done") {
-            alreadyDone.push(taskId);
-            continue;
-          }
-
-          await row.updateWithVersion(auth, {
-            status: "done",
-            doneAt: new Date(),
-            markedAsDoneByType: actorType,
-            markedAsDoneByUserId: actorType === "user" ? row.userId : null,
-            markedAsDoneByAgentConfigurationId:
-              actorType === "agent"
-                ? (agentLoopContext?.runContext?.agentConfiguration?.sId ??
-                  null)
-                : null,
-          });
-          marked.push(`${taskId} ("${row.text}")`);
-        }
-
-        const lines: string[] = [];
-        if (marked.length > 0) {
-          lines.push(`Marked ${marked.length} task(s) as done:`);
-          for (const item of marked) {
-            lines.push(`- ${item}`);
-          }
-        }
-        if (alreadyDone.length > 0) {
-          lines.push(
-            `Already done (${alreadyDone.length}): ${alreadyDone.join(", ")}`
-          );
-        }
-        if (notFound.length > 0) {
-          lines.push(`Not found (${notFound.length}): ${notFound.join(", ")}`);
-        }
-        if (lines.length === 0) {
-          lines.push("No tasks were updated.");
-        }
-
-        return new Ok([
-          {
-            type: "text" as const,
-            text: lines.join("\n"),
-          },
-        ]);
-      }, "Failed to mark task as done");
-    },
-
     [UPDATE_TASKS_TOOL_NAME]: async ({ tasks, dustPod }) => {
       return withErrorHandling(async () => {
         const contextRes = await getPod(auth, {
@@ -351,6 +392,9 @@ export function createProjectTasksTools(
           return contextRes;
         }
         const { pod } = contextRes.value;
+
+        const agentConfigId =
+          agentLoopContext?.runContext?.agentConfiguration?.sId ?? null;
 
         const updated: string[] = [];
         const errors: string[] = [];
@@ -364,20 +408,25 @@ export function createProjectTasksTools(
           }
 
           const payloadRes = await buildTaskUpdatePayload(
+            auth,
             pod,
-            owner.sId,
             row,
-            item
+            item,
+            agentConfigId
           );
-          if ("error" in payloadRes) {
-            errors.push(payloadRes.error);
+          if (payloadRes.isErr()) {
+            errors.push(payloadRes.error.message);
             continue;
           }
 
-          const updatedRow = await row.updateWithVersion(
-            auth,
-            payloadRes.updates
-          );
+          const { taskUpdates } = payloadRes.value;
+
+          if (Object.keys(taskUpdates).length === 0) {
+            updated.push(formatTaskListingLine(row));
+            continue;
+          }
+
+          const updatedRow = await row.updateWithVersion(auth, taskUpdates);
           updated.push(formatTaskListingLine(updatedRow));
         }
 

--- a/front/lib/api/actions/servers/pod_tasks/types.ts
+++ b/front/lib/api/actions/servers/pod_tasks/types.ts
@@ -81,11 +81,11 @@ export const PodTasksUpdateTaskItemInputSchema = z.object({
     .max(256)
     .optional()
     .describe("The new task description."),
-  userId: z
+  assigneeUserId: z
     .union([z.string(), z.null()])
     .optional()
     .describe(
-      "The sId of the user to assign the task to; must be a member of the Pod. Pass null to unassign. Omit to keep the current assignee."
+      "The sId of the user to assign the task to (the task's new assignee); must be a member of the Pod. Pass null to unassign. Omit to keep the current assignee."
     ),
   doneRationale: z
     .string()
@@ -97,6 +97,12 @@ export const PodTasksUpdateTaskItemInputSchema = z.object({
     .enum(["todo", "in_progress", "done"])
     .optional()
     .describe("The new task status. Defaults to the current status."),
+  markAsDoneByType: z
+    .enum(["user", "agent"])
+    .optional()
+    .describe(
+      "Who should be recorded as having marked this task done. Use 'user' when the user explicitly asked for it; 'agent' when the agent is autonomously closing it. Only consulted when the task transitions to 'done'. Defaults to 'agent' if omitted."
+    ),
 });
 
 export const PodTasksUpdateTasksInputSchema = z.object({

--- a/front/lib/resources/project_task_resource.ts
+++ b/front/lib/resources/project_task_resource.ts
@@ -44,6 +44,26 @@ type ProjectTaskVersionCreationAttributes =
     version: number;
   };
 
+export type UpdateBlob = Partial<
+  Pick<
+    CreationAttributes<ProjectTaskModel>,
+    | "category"
+    | "userId"
+    | "text"
+    | "status"
+    | "doneAt"
+    | "actorRationale"
+    | "agentInstructions"
+    | "markedAsDoneByType"
+    | "markedAsDoneByUserId"
+    | "markedAsDoneByAgentConfigurationId"
+    | "deletedAt"
+    | "agentSuggestionStatus"
+    | "agentSuggestionReviewedAt"
+    | "agentSuggestionReviewedByUserId"
+  >
+>;
+
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface ProjectTaskResource
@@ -142,25 +162,7 @@ export class ProjectTaskResource extends BaseResource<ProjectTaskModel> {
   // snapshot count + 1.
   async updateWithVersion(
     auth: Authenticator,
-    updates: Partial<
-      Pick<
-        CreationAttributes<ProjectTaskModel>,
-        | "category"
-        | "userId"
-        | "text"
-        | "status"
-        | "doneAt"
-        | "actorRationale"
-        | "agentInstructions"
-        | "markedAsDoneByType"
-        | "markedAsDoneByUserId"
-        | "markedAsDoneByAgentConfigurationId"
-        | "deletedAt"
-        | "agentSuggestionStatus"
-        | "agentSuggestionReviewedAt"
-        | "agentSuggestionReviewedByUserId"
-      >
-    >,
+    updates: UpdateBlob,
     transaction?: Transaction
   ): Promise<ProjectTaskResource> {
     if (this.workspaceId !== auth.getNonNullableWorkspace().id) {


### PR DESCRIPTION

## Description

This PR removes the dedicated `mark_task_done` tool and folds its functionality into the `update_tasks` tool by adding a `markAsDoneByType` field to the update schema.

- Renames `userId` to `assigneeUserId` in `PodTasksUpdateTaskItemInput` for clarity.
- Updates the validation UI to show the agent's name (e.g. "@agentName wants to update...") and a "Marked done by You / @agentName" section when a task is marked done.
- Adds unit tests.

## Tests

Manually.

## Risks
Low.

## Deploy Plan
Standard deployment.