### PR TITLE
Add conversation <> pod toggle in File Explorer

### DIFF
--- a/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
@@ -1,18 +1,19 @@
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { FileExplorer } from "@app/components/file_explorer/FileExplorer";
-import type { FileEntry } from "@app/components/file_explorer/types";
 import { useFileDownload } from "@app/components/file_explorer/useFileDownload";
-import {
-  getScopedRelativePath,
-  joinMountRelativePath,
-} from "@app/components/file_explorer/utils";
 import { useConversationSandboxFiles } from "@app/hooks/conversations/useConversationSandboxFiles";
 import config from "@app/lib/api/config";
 import { downloadFile } from "@app/lib/swr/files";
-import { useMoveMountFile } from "@app/lib/swr/mount_files";
-import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import { usePodFiles } from "@app/lib/swr/pods";
+import {
+  isPodConversation,
+  type ConversationWithoutContentType,
+} from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
-import { useCallback } from "react";
+import { Button, ButtonGroup } from "@dust-tt/sparkle";
+import { useCallback, useMemo, useState } from "react";
+
+type FilesTab = "conversation" | "pod";
 
 interface ConversationFileExplorerProps {
   conversation: ConversationWithoutContentType;
@@ -24,20 +25,25 @@ export function ConversationFileExplorer({
   owner,
 }: ConversationFileExplorerProps) {
   const { closePanel, openPanel } = useConversationSidePanelContext();
+  const isPod = isPodConversation(conversation);
+  const [activeTab, setActiveTab] = useState<FilesTab>("conversation");
 
-  const { sandboxFiles, isSandboxFilesLoading, mutateSandboxFiles } =
-    useConversationSandboxFiles({
-      conversationId: conversation.sId,
-      owner,
-    });
+  const { sandboxFiles, isSandboxFilesLoading } = useConversationSandboxFiles({
+    conversationId: conversation.sId,
+    owner,
+  });
 
-  const moveMountFile = useMoveMountFile({
-    filesApiBasePath: `/api/w/${owner.sId}/assistant/conversations/${conversation.sId}/files`,
+  const { files: podFiles, isPodFilesLoading } = usePodFiles({
+    owner,
+    podId: isPod ? conversation.spaceId : "",
+    disabled: !isPod || activeTab !== "pod",
   });
 
   const getFileUrl = useCallback(
-    (path: string) =>
-      `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/path/${path}`,
+    (path: string) => {
+      const encoded = path.split("/").map(encodeURIComponent).join("/");
+      return `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/path/${encoded}`;
+    },
     [owner.sId]
   );
 
@@ -48,31 +54,42 @@ export function ConversationFileExplorer({
 
   const onFileDownload = useFileDownload({ getFileResponse });
 
-  // Pass to FileExplorer component to enable file moving.
-  const _onMoveFile = useCallback(
-    async (entry: FileEntry, parentRelativePath: string) => {
-      const result = await moveMountFile({
-        relativeFilePath: getScopedRelativePath(entry.path),
-        destRelativeFilePath: joinMountRelativePath(
-          parentRelativePath,
-          entry.fileName
-        ),
-      });
-      if (result.isOk()) {
-        await mutateSandboxFiles();
-      }
-      return result;
-    },
-    [moveMountFile, mutateSandboxFiles]
-  );
+  const rootTitle = useMemo(() => {
+    if (!isPod) {
+      return undefined;
+    }
+    return (
+      <ButtonGroup
+        removeGaps={false}
+        className="rounded-lg bg-muted dark:bg-muted-night p-0.5"
+      >
+        <Button
+          size="xs"
+          variant={activeTab === "conversation" ? "outline" : "ghost"}
+          label="Conversation Files"
+          onClick={() => setActiveTab("conversation")}
+        />
+        <Button
+          size="xs"
+          variant={activeTab === "pod" ? "outline" : "ghost"}
+          label="Pod Files"
+          onClick={() => setActiveTab("pod")}
+        />
+      </ButtonGroup>
+    );
+  }, [activeTab, isPod]);
+
+  const isOnPodTab = isPod && activeTab === "pod";
 
   return (
     <FileExplorer
-      files={sandboxFiles}
-      isLoading={isSandboxFilesLoading}
+      key={activeTab}
+      files={isOnPodTab ? podFiles : sandboxFiles}
+      isLoading={isOnPodTab ? isPodFilesLoading : isSandboxFilesLoading}
       getFileUrl={getFileUrl}
       onFileDownload={onFileDownload}
       onClose={closePanel}
+      rootTitle={rootTitle}
       onOpenInteractive={(entry) =>
         openPanel({ type: "interactive_content", fileId: entry.fileId })
       }

--- a/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
@@ -11,7 +11,7 @@ import {
 } from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Button, ButtonGroup } from "@dust-tt/sparkle";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 
 type FilesTab = "conversation" | "pod";
 
@@ -54,31 +54,6 @@ export function ConversationFileExplorer({
 
   const onFileDownload = useFileDownload({ getFileResponse });
 
-  const rootTitle = useMemo(() => {
-    if (!isPod) {
-      return undefined;
-    }
-    return (
-      <ButtonGroup
-        removeGaps={false}
-        className="rounded-lg bg-muted dark:bg-muted-night p-0.5"
-      >
-        <Button
-          size="xs"
-          variant={activeTab === "conversation" ? "outline" : "ghost"}
-          label="Conversation Files"
-          onClick={() => setActiveTab("conversation")}
-        />
-        <Button
-          size="xs"
-          variant={activeTab === "pod" ? "outline" : "ghost"}
-          label="Pod Files"
-          onClick={() => setActiveTab("pod")}
-        />
-      </ButtonGroup>
-    );
-  }, [activeTab, isPod]);
-
   const isOnPodTab = isPod && activeTab === "pod";
 
   return (
@@ -89,7 +64,27 @@ export function ConversationFileExplorer({
       getFileUrl={getFileUrl}
       onFileDownload={onFileDownload}
       onClose={closePanel}
-      rootTitle={rootTitle}
+      rootTitle={
+        isPod ? (
+          <ButtonGroup
+            removeGaps={false}
+            className="rounded-lg bg-muted dark:bg-muted-night p-0.5"
+          >
+            <Button
+              size="xs"
+              variant={activeTab === "conversation" ? "outline" : "ghost"}
+              label="Conversation Files"
+              onClick={() => setActiveTab("conversation")}
+            />
+            <Button
+              size="xs"
+              variant={activeTab === "pod" ? "outline" : "ghost"}
+              label="Pod Files"
+              onClick={() => setActiveTab("pod")}
+            />
+          </ButtonGroup>
+        ) : undefined
+      }
       onOpenInteractive={(entry) =>
         openPanel({ type: "interactive_content", fileId: entry.fileId })
       }

--- a/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
@@ -6,8 +6,8 @@ import config from "@app/lib/api/config";
 import { downloadFile } from "@app/lib/swr/files";
 import { usePodFiles } from "@app/lib/swr/pods";
 import {
-  isPodConversation,
   type ConversationWithoutContentType,
+  isPodConversation,
 } from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Button, ButtonGroup } from "@dust-tt/sparkle";

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -354,7 +354,7 @@ export function FileExplorer({
               onMoveFileDrop={fileDragEnabled ? handleMoveFileDrop : undefined}
             />
           )}
-          <div className={inPanel ? "px-4" : undefined}>
+          <div className="px-4">
             <FileExplorerToolbar
               searchQuery={searchQuery}
               onSearchQueryChange={setSearchQuery}
@@ -366,7 +366,7 @@ export function FileExplorer({
             />
           </div>
           {Object.keys(filterCounts).length > 1 && (
-            <div className={inPanel ? "px-4" : undefined}>
+            <div className="px-4">
               <FileExplorerFilters
                 active={activeFilter}
                 onActiveChange={setActiveFilter}

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -1,11 +1,11 @@
 import { FileExplorerBreadcrumb } from "@app/components/file_explorer/FileExplorerBreadcrumb";
 import { FileExplorerContent } from "@app/components/file_explorer/FileExplorerContent";
-import { canMoveFileToParentFolder } from "@app/components/file_explorer/fileExplorerDragDrop";
 import { FileExplorerFilters } from "@app/components/file_explorer/FileExplorerFilters";
 import type { ViewMode } from "@app/components/file_explorer/FileExplorerItem";
-import { getFileExplorerPipeline } from "@app/components/file_explorer/fileExplorerPipeline";
 import { FileExplorerToolbar } from "@app/components/file_explorer/FileExplorerToolbar";
 import { FilePreviewDialog } from "@app/components/file_explorer/FilePreviewDialog";
+import { canMoveFileToParentFolder } from "@app/components/file_explorer/fileExplorerDragDrop";
+import { getFileExplorerPipeline } from "@app/components/file_explorer/fileExplorerPipeline";
 import { MoveFileToFolderDialog } from "@app/components/file_explorer/MoveFileToFolderDialog";
 import type {
   ContentNodeEntry,

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -1,11 +1,11 @@
 import { FileExplorerBreadcrumb } from "@app/components/file_explorer/FileExplorerBreadcrumb";
 import { FileExplorerContent } from "@app/components/file_explorer/FileExplorerContent";
+import { canMoveFileToParentFolder } from "@app/components/file_explorer/fileExplorerDragDrop";
 import { FileExplorerFilters } from "@app/components/file_explorer/FileExplorerFilters";
 import type { ViewMode } from "@app/components/file_explorer/FileExplorerItem";
+import { getFileExplorerPipeline } from "@app/components/file_explorer/fileExplorerPipeline";
 import { FileExplorerToolbar } from "@app/components/file_explorer/FileExplorerToolbar";
 import { FilePreviewDialog } from "@app/components/file_explorer/FilePreviewDialog";
-import { canMoveFileToParentFolder } from "@app/components/file_explorer/fileExplorerDragDrop";
-import { getFileExplorerPipeline } from "@app/components/file_explorer/fileExplorerPipeline";
 import { MoveFileToFolderDialog } from "@app/components/file_explorer/MoveFileToFolderDialog";
 import type {
   ContentNodeEntry,
@@ -38,6 +38,7 @@ import {
   TrashIcon,
   XMarkIcon,
 } from "@dust-tt/sparkle";
+import { AnimatePresence, motion } from "framer-motion";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -49,6 +50,7 @@ interface FileExplorerProps {
   hideTitleBorder?: boolean;
   files: FileSystemEntry[];
   getFileUrl: (path: string) => string;
+  rootTitle?: React.ReactNode;
   toolbarExtraActions?: React.ReactNode;
   isLoading: boolean;
   navigationResetKey?: number;
@@ -74,6 +76,7 @@ export function FileExplorer({
   emptyState,
   files,
   getFileUrl,
+  rootTitle,
   toolbarExtraActions,
   hideTitleBorder = false,
   isLoading,
@@ -293,14 +296,40 @@ export function FileExplorer({
                 contentClassName
               )}
             >
-              <FileExplorerBreadcrumb
-                currentFolderPath={currentFolderPath}
-                onGoUp={handleGoUp}
-                onNavigate={handleBreadcrumbNavigate}
-                onMoveFileDrop={
-                  fileDragEnabled ? handleMoveFileDrop : undefined
-                }
-              />
+              <div className="relative flex h-full flex-1 min-w-0 items-center">
+                <AnimatePresence initial={false}>
+                  {currentFolderPath === "" && rootTitle !== undefined ? (
+                    <motion.div
+                      key="title"
+                      className="absolute inset-0 flex items-center"
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: 1 }}
+                      exit={{ opacity: 0 }}
+                      transition={{ duration: 0.15 }}
+                    >
+                      {rootTitle}
+                    </motion.div>
+                  ) : (
+                    <motion.div
+                      key="breadcrumb"
+                      className="absolute inset-0 flex items-center"
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: 1 }}
+                      exit={{ opacity: 0 }}
+                      transition={{ duration: 0.15 }}
+                    >
+                      <FileExplorerBreadcrumb
+                        currentFolderPath={currentFolderPath}
+                        onGoUp={handleGoUp}
+                        onNavigate={handleBreadcrumbNavigate}
+                        onMoveFileDrop={
+                          fileDragEnabled ? handleMoveFileDrop : undefined
+                        }
+                      />
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </div>
               <Button
                 variant="ghost"
                 size="sm"


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR implements design from [here](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=9914-141211&m=dev).

It adds a toggle to switch between conversation and pods files directly from the conversation file explorer.

<img width="1180" height="1682" alt="ConvPodToggle" src="https://github.com/user-attachments/assets/cf9391cf-a3eb-47d5-8e99-6dc0c9b72509" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
