### PR TITLE
[slim-api] use requireParam helper to type path params in Hono routes

### DIFF
--- a/front-api/routes/[preStopSecret]/prestop.ts
+++ b/front-api/routes/[preStopSecret]/prestop.ts
@@ -1,11 +1,17 @@
 import { runPreStop } from "@app/lib/api/prestop";
 import logger from "@app/logger/logger";
 import { createHono } from "@front-api/lib/hono";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  preStopSecret: z.string(),
+});
 
 const app = createHono();
 
-app.post("/", async (ctx) => {
-  const preStopSecret = ctx.req.param("preStopSecret");
+app.post("/", validate("param", ParamsSchema), async (ctx) => {
+  const { preStopSecret } = ctx.req.valid("param");
   const { PRESTOP_SECRET } = process.env;
   if (!PRESTOP_SECRET) {
     logger.error("PRESTOP_SECRET is not defined");

--- a/front-api/routes/oauth/[provider]/finalize.ts
+++ b/front-api/routes/oauth/[provider]/finalize.ts
@@ -6,42 +6,52 @@ import { sessionApp } from "@front-api/middlewares/ctx";
 import { sessionAuth } from "@front-api/middlewares/session_auth";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 export type GetOauthFinalizeResponseBody = { connection: OAuthConnectionType };
+
+const ParamsSchema = z.object({
+  provider: z.string(),
+});
 
 const app = sessionApp();
 
 app.use("*", sessionAuth);
 
-app.get("/", async (ctx): HandlerResult<GetOauthFinalizeResponseBody> => {
-  const provider = ctx.req.param("provider");
-  if (!isOAuthProvider(provider)) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "invalid_oauth_token_error",
-        message: "Unknown OAuth provider.",
-      },
-    });
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetOauthFinalizeResponseBody> => {
+    const { provider } = ctx.req.valid("param");
+    if (!isOAuthProvider(provider)) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "invalid_oauth_token_error",
+          message: "Unknown OAuth provider.",
+        },
+      });
+    }
+
+    const session = ctx.get("session");
+    const auth = session.workspaceId
+      ? await Authenticator.fromSession(session, session.workspaceId)
+      : null;
+
+    const cRes = await finalizeConnection(auth, provider, ctx.req.query());
+    if (!cRes.isOk()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: cRes.error.message,
+        },
+      });
+    }
+
+    return ctx.json({ connection: cRes.value });
   }
-
-  const session = ctx.get("session");
-  const auth = session.workspaceId
-    ? await Authenticator.fromSession(session, session.workspaceId)
-    : null;
-
-  const cRes = await finalizeConnection(auth, provider, ctx.req.query());
-  if (!cRes.isOk()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: cRes.error.message,
-      },
-    });
-  }
-
-  return ctx.json({ connection: cRes.value });
-});
+);
 
 export default app;

--- a/front-api/routes/poke/connectors/[connectorId]/redirect.ts
+++ b/front-api/routes/poke/connectors/[connectorId]/redirect.ts
@@ -4,48 +4,58 @@ import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 interface GetConnectorRedirectResponse {
   redirectUrl: string;
 }
 
+const ParamsSchema = z.object({
+  connectorId: z.string(),
+});
+
 // Mounted at /api/poke/connectors/:connectorId/redirect. pokeAuth is applied
 // by the parent poke sub-app.
 const app = pokeApp();
 
-app.get("/", async (ctx): HandlerResult<GetConnectorRedirectResponse> => {
-  const connectorId = ctx.req.param("connectorId") ?? "";
-  if (!connectorId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid connector ID.",
-      },
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetConnectorRedirectResponse> => {
+    const { connectorId } = ctx.req.valid("param");
+    if (!connectorId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid connector ID.",
+        },
+      });
+    }
+
+    const connectorsAPI = new ConnectorsAPI(
+      config.getConnectorsAPIConfig(),
+      logger
+    );
+    const cRes = await connectorsAPI.getConnector(connectorId);
+
+    if (cRes.isErr()) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "connector_not_found_error",
+          message: "Connector not found.",
+        },
+      });
+    }
+
+    const connector = cRes.value;
+
+    return ctx.json({
+      redirectUrl: `/poke/${connector.workspaceId}/data_sources/${connector.dataSourceId}`,
     });
   }
-
-  const connectorsAPI = new ConnectorsAPI(
-    config.getConnectorsAPIConfig(),
-    logger
-  );
-  const cRes = await connectorsAPI.getConnector(connectorId);
-
-  if (cRes.isErr()) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "connector_not_found_error",
-        message: "Connector not found.",
-      },
-    });
-  }
-
-  const connector = cRes.value;
-
-  return ctx.json({
-    redirectUrl: `/poke/${connector.workspaceId}/data_sources/${connector.dataSourceId}`,
-  });
-});
+);
 
 export default app;

--- a/front-api/routes/poke/connectors/[connectorId]/redirect.ts
+++ b/front-api/routes/poke/connectors/[connectorId]/redirect.ts
@@ -24,15 +24,6 @@ app.get(
   validate("param", ParamsSchema),
   async (ctx): HandlerResult<GetConnectorRedirectResponse> => {
     const { connectorId } = ctx.req.valid("param");
-    if (!connectorId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid connector ID.",
-        },
-      });
-    }
 
     const connectorsAPI = new ConnectorsAPI(
       config.getConnectorsAPIConfig(),

--- a/front-api/routes/poke/coupons/[couponId]/archive.ts
+++ b/front-api/routes/poke/coupons/[couponId]/archive.ts
@@ -3,6 +3,8 @@ import type { CouponDiscountType } from "@app/types/coupon";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 // `expirationDate` and `archivedAt` are `Date | null` in
 // `CouponResource.toJSON()` but JSON-serialize to ISO strings on the wire;
@@ -22,56 +24,64 @@ export type ArchivePokeCouponResponseBody = {
   };
 };
 
+const ParamsSchema = z.object({
+  couponId: z.string(),
+});
+
 // Mounted at /api/poke/coupons/:couponId/archive. pokeAuth is applied by the
 // parent poke sub-app.
 const app = pokeApp();
 
-app.post("/", async (ctx): HandlerResult<ArchivePokeCouponResponseBody> => {
-  const auth = ctx.get("auth");
-  const couponId = ctx.req.param("couponId") ?? "";
-  if (!couponId) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "coupon_not_found",
-        message: "Could not find the coupon.",
-      },
-    });
-  }
+app.post(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<ArchivePokeCouponResponseBody> => {
+    const auth = ctx.get("auth");
+    const { couponId } = ctx.req.valid("param");
+    if (!couponId) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "coupon_not_found",
+          message: "Could not find the coupon.",
+        },
+      });
+    }
 
-  const coupon = await CouponResource.fetchByCouponId(couponId);
-  if (!coupon) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "coupon_not_found",
-        message: "Could not find the coupon.",
-      },
-    });
-  }
+    const coupon = await CouponResource.fetchByCouponId(couponId);
+    if (!coupon) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "coupon_not_found",
+          message: "Could not find the coupon.",
+        },
+      });
+    }
 
-  if (coupon.archivedAt !== null) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Coupon is already archived.",
-      },
-    });
-  }
+    if (coupon.archivedAt !== null) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Coupon is already archived.",
+        },
+      });
+    }
 
-  const result = await coupon.archive(auth);
-  if (result.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: `Failed to archive coupon: ${result.error.message}`,
-      },
-    });
-  }
+    const result = await coupon.archive(auth);
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to archive coupon: ${result.error.message}`,
+        },
+      });
+    }
 
-  return ctx.json({ coupon: coupon.toJSON() });
-});
+    return ctx.json({ coupon: coupon.toJSON() });
+  }
+);
 
 export default app;

--- a/front-api/routes/poke/coupons/[couponId]/archive.ts
+++ b/front-api/routes/poke/coupons/[couponId]/archive.ts
@@ -38,15 +38,6 @@ app.post(
   async (ctx): HandlerResult<ArchivePokeCouponResponseBody> => {
     const auth = ctx.get("auth");
     const { couponId } = ctx.req.valid("param");
-    if (!couponId) {
-      return apiError(ctx, {
-        status_code: 404,
-        api_error: {
-          type: "coupon_not_found",
-          message: "Could not find the coupon.",
-        },
-      });
-    }
 
     const coupon = await CouponResource.fetchByCouponId(couponId);
     if (!coupon) {

--- a/front-api/routes/poke/coupons/[couponId]/redemptions.ts
+++ b/front-api/routes/poke/coupons/[couponId]/redemptions.ts
@@ -4,6 +4,8 @@ import type { CouponRedemptionStatus } from "@app/types/coupon";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 // `redeemedAt` is a `Date` in `CouponRedemptionResource.toJSON()` but
 // JSON-serializes to an ISO string on the wire; the response body type
@@ -20,14 +22,19 @@ export type GetPokeCouponRedemptionsResponseBody = {
   }>;
 };
 
+const ParamsSchema = z.object({
+  couponId: z.string(),
+});
+
 // Mounted at /api/poke/coupons/:couponId/redemptions. pokeAuth is applied by
 // the parent poke sub-app.
 const app = pokeApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   async (ctx): HandlerResult<GetPokeCouponRedemptionsResponseBody> => {
-    const couponId = ctx.req.param("couponId") ?? "";
+    const { couponId } = ctx.req.valid("param");
     if (!couponId) {
       return apiError(ctx, {
         status_code: 404,

--- a/front-api/routes/poke/coupons/[couponId]/redemptions.ts
+++ b/front-api/routes/poke/coupons/[couponId]/redemptions.ts
@@ -35,15 +35,6 @@ app.get(
   validate("param", ParamsSchema),
   async (ctx): HandlerResult<GetPokeCouponRedemptionsResponseBody> => {
     const { couponId } = ctx.req.valid("param");
-    if (!couponId) {
-      return apiError(ctx, {
-        status_code: 404,
-        api_error: {
-          type: "coupon_not_found",
-          message: "Could not find the coupon.",
-        },
-      });
-    }
 
     const coupon = await CouponResource.fetchByCouponId(couponId);
     if (!coupon) {

--- a/front-api/routes/poke/plugins/[pluginId]/async-args.ts
+++ b/front-api/routes/poke/plugins/[pluginId]/async-args.ts
@@ -21,14 +21,19 @@ const AsyncArgsQuerySchema = z.object({
   workspaceId: z.string().optional(),
 });
 
+const ParamsSchema = z.object({
+  pluginId: z.string(),
+});
+
 // Mounted at /api/poke/plugins/:pluginId/async-args.
 const app = pokeApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   validate("query", AsyncArgsQuerySchema),
   async (ctx): HandlerResult<PokeGetPluginAsyncArgsResponseBody> => {
-    const pluginId = ctx.req.param("pluginId");
+    const { pluginId } = ctx.req.valid("param");
     if (!pluginId) {
       return apiError(ctx, {
         status_code: 400,

--- a/front-api/routes/poke/plugins/[pluginId]/async-args.ts
+++ b/front-api/routes/poke/plugins/[pluginId]/async-args.ts
@@ -34,15 +34,6 @@ app.get(
   validate("query", AsyncArgsQuerySchema),
   async (ctx): HandlerResult<PokeGetPluginAsyncArgsResponseBody> => {
     const { pluginId } = ctx.req.valid("param");
-    if (!pluginId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Missing `pluginId` in path.",
-        },
-      });
-    }
 
     const { resourceType, resourceId, workspaceId } = ctx.req.valid("query");
 

--- a/front-api/routes/poke/plugins/[pluginId]/manifest.ts
+++ b/front-api/routes/poke/plugins/[pluginId]/manifest.ts
@@ -25,15 +25,6 @@ app.get(
   validate("param", ParamsSchema),
   async (ctx): HandlerResult<PokeGetPluginDetailsResponseBody> => {
     const { pluginId } = ctx.req.valid("param");
-    if (!pluginId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Missing `pluginId` in path.",
-        },
-      });
-    }
 
     const plugin = pluginManager.getPluginById(pluginId);
     if (!plugin) {

--- a/front-api/routes/poke/plugins/[pluginId]/manifest.ts
+++ b/front-api/routes/poke/plugins/[pluginId]/manifest.ts
@@ -6,38 +6,48 @@ import type {
 } from "@app/types/poke/plugins";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 export interface PokeGetPluginDetailsResponseBody {
   manifest: PluginManifest<PluginArgs, SupportedResourceType>;
 }
 
+const ParamsSchema = z.object({
+  pluginId: z.string(),
+});
+
 // Mounted at /api/poke/plugins/:pluginId/manifest.
 const app = pokeApp();
 
-app.get("/", async (ctx): HandlerResult<PokeGetPluginDetailsResponseBody> => {
-  const pluginId = ctx.req.param("pluginId");
-  if (!pluginId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Missing `pluginId` in path.",
-      },
-    });
-  }
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<PokeGetPluginDetailsResponseBody> => {
+    const { pluginId } = ctx.req.valid("param");
+    if (!pluginId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Missing `pluginId` in path.",
+        },
+      });
+    }
 
-  const plugin = pluginManager.getPluginById(pluginId);
-  if (!plugin) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "plugin_not_found",
-        message: "Could not find the plugin.",
-      },
-    });
-  }
+    const plugin = pluginManager.getPluginById(pluginId);
+    if (!plugin) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "plugin_not_found",
+          message: "Could not find the plugin.",
+        },
+      });
+    }
 
-  return ctx.json({ manifest: plugin.manifest });
-});
+    return ctx.json({ manifest: plugin.manifest });
+  }
+);
 
 export default app;

--- a/front-api/routes/poke/plugins/[pluginId]/run.ts
+++ b/front-api/routes/poke/plugins/[pluginId]/run.ts
@@ -45,15 +45,6 @@ app.post(
   validate("query", RunPluginQuerySchema),
   async (ctx): HandlerResult<PokeRunPluginResponseBody> => {
     const { pluginId } = ctx.req.valid("param");
-    if (!pluginId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Missing `pluginId` in path.",
-        },
-      });
-    }
 
     const { resourceType, resourceId, workspaceId } = ctx.req.valid("query");
 

--- a/front-api/routes/poke/plugins/[pluginId]/run.ts
+++ b/front-api/routes/poke/plugins/[pluginId]/run.ts
@@ -24,6 +24,10 @@ const RunPluginQuerySchema = z.object({
   workspaceId: z.string().optional(),
 });
 
+const ParamsSchema = z.object({
+  pluginId: z.string(),
+});
+
 export interface PokeRunPluginResponseBody {
   result: PluginResponse;
 }
@@ -37,9 +41,10 @@ const app = createHono<PokeCtx & { Bindings: HttpBindings }>();
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   validate("query", RunPluginQuerySchema),
   async (ctx): HandlerResult<PokeRunPluginResponseBody> => {
-    const pluginId = ctx.req.param("pluginId");
+    const { pluginId } = ctx.req.valid("param");
     if (!pluginId) {
       return apiError(ctx, {
         status_code: 400,

--- a/front-api/routes/poke/production-checks/[checkName]/history.ts
+++ b/front-api/routes/poke/production-checks/[checkName]/history.ts
@@ -5,40 +5,50 @@ import {
 import type { CheckHistoryRun } from "@app/types/production_checks";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 export type GetCheckHistoryResponseBody = {
   runs: CheckHistoryRun[];
 };
 
+const ParamsSchema = z.object({
+  checkName: z.string(),
+});
+
 // Mounted at /api/poke/production-checks/:checkName/history.
 const app = pokeApp();
 
-app.get("/", async (ctx): HandlerResult<GetCheckHistoryResponseBody> => {
-  const checkName = ctx.req.param("checkName");
-  if (!checkName) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "checkName is required.",
-      },
-    });
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetCheckHistoryResponseBody> => {
+    const { checkName } = ctx.req.valid("param");
+    if (!checkName) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "checkName is required.",
+        },
+      });
+    }
+
+    const registeredCheck = getRegisteredCheck(checkName);
+    if (!registeredCheck) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "action_not_found",
+          message: `Check "${checkName}" not found.`,
+        },
+      });
+    }
+
+    const runs = await getCheckHistoryRuns(checkName);
+
+    return ctx.json({ runs });
   }
-
-  const registeredCheck = getRegisteredCheck(checkName);
-  if (!registeredCheck) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "action_not_found",
-        message: `Check "${checkName}" not found.`,
-      },
-    });
-  }
-
-  const runs = await getCheckHistoryRuns(checkName);
-
-  return ctx.json({ runs });
-});
+);
 
 export default app;

--- a/front-api/routes/poke/production-checks/[checkName]/history.ts
+++ b/front-api/routes/poke/production-checks/[checkName]/history.ts
@@ -24,15 +24,6 @@ app.get(
   validate("param", ParamsSchema),
   async (ctx): HandlerResult<GetCheckHistoryResponseBody> => {
     const { checkName } = ctx.req.valid("param");
-    if (!checkName) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "checkName is required.",
-        },
-      });
-    }
 
     const registeredCheck = getRegisteredCheck(checkName);
     if (!registeredCheck) {

--- a/front-api/routes/poke/templates/[tId].ts
+++ b/front-api/routes/poke/templates/[tId].ts
@@ -10,8 +10,10 @@ import { isDevelopment } from "@app/types/shared/env";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
+import { z } from "zod";
 
 export type PokeFetchAssistantTemplateResponse = ReturnType<
   TemplateResource["toJSON"]
@@ -21,147 +23,164 @@ interface PokeCreateTemplateResponseBody {
   success: boolean;
 }
 
+const ParamsSchema = z.object({
+  tId: z.string(),
+});
+
 // Mounted at /api/poke/templates/:tId. pokeAuth is applied by the parent poke
 // sub-app.
 const app = pokeApp();
 
-app.get("/", async (ctx): HandlerResult<PokeFetchAssistantTemplateResponse> => {
-  const templateId = ctx.req.param("tId") ?? "";
-  if (!templateId) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "template_not_found",
-        message: "Could not find the template.",
-      },
-    });
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<PokeFetchAssistantTemplateResponse> => {
+    const { tId: templateId } = ctx.req.valid("param");
+    if (!templateId) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "template_not_found",
+          message: "Could not find the template.",
+        },
+      });
+    }
+
+    const template = await TemplateResource.fetchByExternalId(templateId);
+    if (!template) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "template_not_found",
+          message: "Could not find the template.",
+        },
+      });
+    }
+
+    return ctx.json(template.toJSON());
   }
+);
 
-  const template = await TemplateResource.fetchByExternalId(templateId);
-  if (!template) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "template_not_found",
-        message: "Could not find the template.",
-      },
+app.patch(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<PokeCreateTemplateResponseBody> => {
+    const { tId: templateId } = ctx.req.valid("param");
+    if (!templateId) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "template_not_found",
+          message: "Could not find the template.",
+        },
+      });
+    }
+
+    const body = await ctx.req.json().catch(() => null);
+    const bodyValidation = CreateTemplateFormSchema.decode(body);
+    if (isLeft(bodyValidation)) {
+      const pathError = reporter.formatValidationErrors(bodyValidation.left);
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `The request body is invalid: ${pathError}`,
+        },
+      });
+    }
+    const data = bodyValidation.right;
+
+    if (!isTemplateTagCodeArray(data.tags)) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "The request body is invalid: tags must be an array of template tag names.",
+        },
+      });
+    }
+
+    if (regionConfig.getDustRegionSyncEnabled() && !isDevelopment()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Cannot update templates in non-main regions.",
+        },
+      });
+    }
+
+    const model = USED_MODEL_CONFIGS.find(
+      (cfg) => cfg.modelId === data.presetModelId
+    );
+
+    if (!model) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "The request body is invalid: model not found.",
+        },
+      });
+    }
+
+    const existingTemplate =
+      await TemplateResource.fetchByExternalId(templateId);
+    if (!existingTemplate) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "template_not_found",
+          message: "Could not find the template.",
+        },
+      });
+    }
+
+    await existingTemplate.updateAttributes({
+      ...buildSharedTemplateAttributes({ ...data, tags: data.tags }, model),
+      timeFrameDuration: data.timeFrameDuration
+        ? parseInt(data.timeFrameDuration, 10)
+        : null,
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+      timeFrameUnit: data.timeFrameUnit || null,
     });
+
+    return ctx.json({ success: true });
   }
+);
 
-  return ctx.json(template.toJSON());
-});
+app.delete(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<PokeCreateTemplateResponseBody> => {
+    const auth = ctx.get("auth");
+    const { tId: templateId } = ctx.req.valid("param");
+    if (!templateId) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "template_not_found",
+          message: "Could not find the template.",
+        },
+      });
+    }
 
-app.patch("/", async (ctx): HandlerResult<PokeCreateTemplateResponseBody> => {
-  const templateId = ctx.req.param("tId") ?? "";
-  if (!templateId) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "template_not_found",
-        message: "Could not find the template.",
-      },
-    });
+    const template = await TemplateResource.fetchByExternalId(templateId);
+    if (!template) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "template_not_found",
+          message: "Could not find the template.",
+        },
+      });
+    }
+
+    await template.delete(auth);
+
+    return ctx.json({ success: true });
   }
-
-  const body = await ctx.req.json().catch(() => null);
-  const bodyValidation = CreateTemplateFormSchema.decode(body);
-  if (isLeft(bodyValidation)) {
-    const pathError = reporter.formatValidationErrors(bodyValidation.left);
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: `The request body is invalid: ${pathError}`,
-      },
-    });
-  }
-  const data = bodyValidation.right;
-
-  if (!isTemplateTagCodeArray(data.tags)) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message:
-          "The request body is invalid: tags must be an array of template tag names.",
-      },
-    });
-  }
-
-  if (regionConfig.getDustRegionSyncEnabled() && !isDevelopment()) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Cannot update templates in non-main regions.",
-      },
-    });
-  }
-
-  const model = USED_MODEL_CONFIGS.find(
-    (cfg) => cfg.modelId === data.presetModelId
-  );
-
-  if (!model) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "The request body is invalid: model not found.",
-      },
-    });
-  }
-
-  const existingTemplate = await TemplateResource.fetchByExternalId(templateId);
-  if (!existingTemplate) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "template_not_found",
-        message: "Could not find the template.",
-      },
-    });
-  }
-
-  await existingTemplate.updateAttributes({
-    ...buildSharedTemplateAttributes({ ...data, tags: data.tags }, model),
-    timeFrameDuration: data.timeFrameDuration
-      ? parseInt(data.timeFrameDuration, 10)
-      : null,
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    timeFrameUnit: data.timeFrameUnit || null,
-  });
-
-  return ctx.json({ success: true });
-});
-
-app.delete("/", async (ctx): HandlerResult<PokeCreateTemplateResponseBody> => {
-  const auth = ctx.get("auth");
-  const templateId = ctx.req.param("tId") ?? "";
-  if (!templateId) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "template_not_found",
-        message: "Could not find the template.",
-      },
-    });
-  }
-
-  const template = await TemplateResource.fetchByExternalId(templateId);
-  if (!template) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "template_not_found",
-        message: "Could not find the template.",
-      },
-    });
-  }
-
-  await template.delete(auth);
-
-  return ctx.json({ success: true });
-});
+);
 
 export default app;

--- a/front-api/routes/poke/templates/[tId].ts
+++ b/front-api/routes/poke/templates/[tId].ts
@@ -36,15 +36,6 @@ app.get(
   validate("param", ParamsSchema),
   async (ctx): HandlerResult<PokeFetchAssistantTemplateResponse> => {
     const { tId: templateId } = ctx.req.valid("param");
-    if (!templateId) {
-      return apiError(ctx, {
-        status_code: 404,
-        api_error: {
-          type: "template_not_found",
-          message: "Could not find the template.",
-        },
-      });
-    }
 
     const template = await TemplateResource.fetchByExternalId(templateId);
     if (!template) {
@@ -66,15 +57,6 @@ app.patch(
   validate("param", ParamsSchema),
   async (ctx): HandlerResult<PokeCreateTemplateResponseBody> => {
     const { tId: templateId } = ctx.req.valid("param");
-    if (!templateId) {
-      return apiError(ctx, {
-        status_code: 404,
-        api_error: {
-          type: "template_not_found",
-          message: "Could not find the template.",
-        },
-      });
-    }
 
     const body = await ctx.req.json().catch(() => null);
     const bodyValidation = CreateTemplateFormSchema.decode(body);
@@ -156,15 +138,6 @@ app.delete(
   async (ctx): HandlerResult<PokeCreateTemplateResponseBody> => {
     const auth = ctx.get("auth");
     const { tId: templateId } = ctx.req.valid("param");
-    if (!templateId) {
-      return apiError(ctx, {
-        status_code: 404,
-        api_error: {
-          type: "template_not_found",
-          message: "Could not find the template.",
-        },
-      });
-    }
 
     const template = await TemplateResource.fetchByExternalId(templateId);
     if (!template) {

--- a/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
@@ -9,6 +9,8 @@ import type { SpaceType } from "@app/types/space";
 import type { UserType } from "@app/types/user";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 export type PokeGetAgentDetails = {
   agentConfigurations: AgentConfigurationType[];
@@ -18,67 +20,75 @@ export type PokeGetAgentDetails = {
   skillsByVersion: Record<number, SkillType[]>;
 };
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 // Mounted at /api/poke/workspaces/:wId/agent_configurations/:aId/details.
 const app = pokeApp();
 
-app.get("/", async (ctx): HandlerResult<PokeGetAgentDetails> => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<PokeGetAgentDetails> => {
+    const auth = ctx.get("auth");
+    const { aId } = ctx.req.valid("param");
 
-  const agentConfigurations = await listsAgentConfigurationVersions(auth, {
-    agentId: aId,
-    variant: "full",
-  });
+    const agentConfigurations = await listsAgentConfigurationVersions(auth, {
+      agentId: aId,
+      variant: "full",
+    });
 
-  if (agentConfigurations.length === 0) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "Agent configuration not found.",
-      },
+    if (agentConfigurations.length === 0) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "Agent configuration not found.",
+        },
+      });
+    }
+
+    const lastVersionEditors = await getEditors(auth, agentConfigurations[0]);
+    const [latestAgentConfiguration] = agentConfigurations;
+
+    const spaces = await SpaceResource.fetchByIds(
+      auth,
+      latestAgentConfiguration.requestedSpaceIds
+    );
+    const authors = await getAuthors(agentConfigurations);
+
+    // `SkillResource.listByAgentConfigurations` only works for custom agents, as global agents are not versioned.
+    const skillsByVersion: Record<number, SkillType[]> = {};
+    if (isGlobalAgentId(aId)) {
+      const allSkills = await SkillResource.listByAgentConfiguration(
+        auth,
+        latestAgentConfiguration
+      );
+      skillsByVersion[latestAgentConfiguration.version] = allSkills.map((s) =>
+        s.toJSON(auth)
+      );
+    } else {
+      const skillsByAgent = await SkillResource.listByAgentConfigurations(
+        auth,
+        agentConfigurations
+      );
+      for (const config of agentConfigurations) {
+        skillsByVersion[config.version] = [];
+      }
+      for (const { agentConfiguration, skill } of skillsByAgent) {
+        skillsByVersion[agentConfiguration.version].push(skill.toJSON(auth));
+      }
+    }
+
+    return ctx.json({
+      agentConfigurations,
+      authors,
+      lastVersionEditors,
+      spaces: spaces.map((s) => s.toJSON()),
+      skillsByVersion,
     });
   }
-
-  const lastVersionEditors = await getEditors(auth, agentConfigurations[0]);
-  const [latestAgentConfiguration] = agentConfigurations;
-
-  const spaces = await SpaceResource.fetchByIds(
-    auth,
-    latestAgentConfiguration.requestedSpaceIds
-  );
-  const authors = await getAuthors(agentConfigurations);
-
-  // `SkillResource.listByAgentConfigurations` only works for custom agents, as global agents are not versioned.
-  const skillsByVersion: Record<number, SkillType[]> = {};
-  if (isGlobalAgentId(aId)) {
-    const allSkills = await SkillResource.listByAgentConfiguration(
-      auth,
-      latestAgentConfiguration
-    );
-    skillsByVersion[latestAgentConfiguration.version] = allSkills.map((s) =>
-      s.toJSON(auth)
-    );
-  } else {
-    const skillsByAgent = await SkillResource.listByAgentConfigurations(
-      auth,
-      agentConfigurations
-    );
-    for (const config of agentConfigurations) {
-      skillsByVersion[config.version] = [];
-    }
-    for (const { agentConfiguration, skill } of skillsByAgent) {
-      skillsByVersion[agentConfiguration.version].push(skill.toJSON(auth));
-    }
-  }
-
-  return ctx.json({
-    agentConfigurations,
-    authors,
-    lastVersionEditors,
-    spaces: spaces.map((s) => s.toJSON()),
-    skillsByVersion,
-  });
-});
+);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/export.ts
+++ b/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/export.ts
@@ -3,7 +3,13 @@ import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agen
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import assert from "assert";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
 
 export type PokeExportAgentConfigurationResponseBody = {
   assistant: Omit<
@@ -31,9 +37,10 @@ const app = pokeApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   async (ctx): HandlerResult<PokeExportAgentConfigurationResponseBody> => {
     const auth = ctx.get("auth");
-    const aId = ctx.req.param("aId") ?? "";
+    const { aId } = ctx.req.valid("param");
 
     const agentConfiguration = await getAgentConfiguration(auth, {
       agentId: aId,

--- a/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
@@ -4,38 +4,48 @@ import {
 } from "@app/lib/api/assistant/configuration/agent";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import type { SuccessResponseBody } from "@front-api/routes/types";
+import { z } from "zod";
 
 import details from "./details";
 import exportRoute from "./export";
 import observability from "./observability";
 import restore from "./restore";
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 // Mounted at /api/poke/workspaces/:wId/agent_configurations/:aId.
 const app = pokeApp();
 
-app.delete("/", async (ctx): HandlerResult<SuccessResponseBody> => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
+app.delete(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<SuccessResponseBody> => {
+    const auth = ctx.get("auth");
+    const { aId } = ctx.req.valid("param");
 
-  const agentConfiguration = await getAgentConfiguration(auth, {
-    agentId: aId,
-    variant: "light",
-  });
-  if (!agentConfiguration) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "Could not find the agent configuration.",
-      },
+    const agentConfiguration = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "light",
     });
+    if (!agentConfiguration) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "Could not find the agent configuration.",
+        },
+      });
+    }
+
+    await archiveAgentConfiguration(auth, agentConfiguration.sId);
+
+    return ctx.json({ success: true });
   }
-
-  await archiveAgentConfiguration(auth, agentConfiguration.sId);
-
-  return ctx.json({ success: true });
-});
+);
 
 app.route("/details", details);
 app.route("/export", exportRoute);

--- a/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/observability/datasource-retrieval.ts
+++ b/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/observability/datasource-retrieval.ts
@@ -12,6 +12,10 @@ const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
 });
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 export type PokeGetDatasourceRetrievalResponse = {
   datasources: DatasourceRetrievalData[];
   total: number;
@@ -22,10 +26,11 @@ const app = pokeApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   validate("query", QuerySchema),
   async (ctx): HandlerResult<PokeGetDatasourceRetrievalResponse> => {
     const auth = ctx.get("auth");
-    const aId = ctx.req.param("aId") ?? "";
+    const { aId } = ctx.req.valid("param");
     const { days } = ctx.req.valid("query");
 
     const assistant = await getAgentConfiguration(auth, {

--- a/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/restore.ts
+++ b/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/restore.ts
@@ -5,76 +5,86 @@ import {
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import type { SuccessResponseBody } from "@front-api/routes/types";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
 
 // Mounted at /api/poke/workspaces/:wId/agent_configurations/:aId/restore.
 const app = pokeApp();
 
-app.post("/", async (ctx): HandlerResult<SuccessResponseBody> => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
+app.post(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<SuccessResponseBody> => {
+    const auth = ctx.get("auth");
+    const { aId } = ctx.req.valid("param");
 
-  const agentConfiguration = await getAgentConfiguration(auth, {
-    agentId: aId,
-    variant: "light",
-  });
-  if (!agentConfiguration) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "Could not find the agent configuration.",
-      },
+    const agentConfiguration = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "light",
     });
-  }
-
-  const restoredResult = await restoreAgentConfiguration(
-    auth,
-    agentConfiguration.sId
-  );
-
-  if (restoredResult.isErr()) {
-    switch (restoredResult.error.code) {
-      case "name_conflict":
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: restoredResult.error.message,
-          },
-        });
-      case "unauthorized":
-        return apiError(ctx, {
-          status_code: 403,
-          api_error: {
-            type: "app_auth_error",
-            message: restoredResult.error.message,
-          },
-        });
-      case "internal_error":
-        return apiError(ctx, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: "Could not restore the agent configuration.",
-          },
-        });
-      default:
-        assertNever(restoredResult.error.code);
+    if (!agentConfiguration) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "Could not find the agent configuration.",
+        },
+      });
     }
-  }
 
-  if (!restoredResult.value.restored) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Could not restore the agent configuration.",
-      },
-    });
-  }
+    const restoredResult = await restoreAgentConfiguration(
+      auth,
+      agentConfiguration.sId
+    );
 
-  return ctx.json({ success: true });
-});
+    if (restoredResult.isErr()) {
+      switch (restoredResult.error.code) {
+        case "name_conflict":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: restoredResult.error.message,
+            },
+          });
+        case "unauthorized":
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: {
+              type: "app_auth_error",
+              message: restoredResult.error.message,
+            },
+          });
+        case "internal_error":
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: "Could not restore the agent configuration.",
+            },
+          });
+        default:
+          assertNever(restoredResult.error.code);
+      }
+    }
+
+    if (!restoredResult.value.restored) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Could not restore the agent configuration.",
+        },
+      });
+    }
+
+    return ctx.json({ success: true });
+  }
+);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/apps/[aId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/apps/[aId]/details.ts
@@ -34,15 +34,6 @@ app.get(
   async (ctx): HandlerResult<PokeGetAppDetails> => {
     const auth = ctx.get("auth");
     const { aId } = ctx.req.valid("param");
-    if (!aId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid app ID.",
-        },
-      });
-    }
 
     const { hash } = ctx.req.valid("query");
 

--- a/front-api/routes/poke/workspaces/[wId]/apps/[aId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/apps/[aId]/details.ts
@@ -20,15 +20,20 @@ const DetailsQuerySchema = z.object({
   hash: z.string().optional(),
 });
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 // Mounted at /api/poke/workspaces/:wId/apps/:aId/details.
 const app = pokeApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   validate("query", DetailsQuerySchema),
   async (ctx): HandlerResult<PokeGetAppDetails> => {
     const auth = ctx.get("auth");
-    const aId = ctx.req.param("aId");
+    const { aId } = ctx.req.valid("param");
     if (!aId) {
       return apiError(ctx, {
         status_code: 400,

--- a/front-api/routes/poke/workspaces/[wId]/apps/[aId]/export.ts
+++ b/front-api/routes/poke/workspaces/[wId]/apps/[aId]/export.ts
@@ -2,41 +2,51 @@ import { AppResource } from "@app/lib/resources/app_resource";
 import { type ExportedApp, exportAppWithDatasets } from "@app/lib/utils/apps";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 export type ExportAppResponseBody = {
   app: ExportedApp;
 };
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 // Mounted at /api/poke/workspaces/:wId/apps/:aId/export.
 const app = pokeApp();
 
-app.get("/", async (ctx): HandlerResult<ExportAppResponseBody> => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId");
-  if (!aId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid path parameters.",
-      },
-    });
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<ExportAppResponseBody> => {
+    const auth = ctx.get("auth");
+    const { aId } = ctx.req.valid("param");
+    if (!aId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid path parameters.",
+        },
+      });
+    }
+
+    const appResource = await AppResource.fetchById(auth, aId);
+    if (!appResource) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "app_not_found",
+          message: "The app you requested was not found.",
+        },
+      });
+    }
+
+    const exported = await exportAppWithDatasets(auth, appResource);
+
+    return ctx.json({ app: exported });
   }
-
-  const appResource = await AppResource.fetchById(auth, aId);
-  if (!appResource) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "app_not_found",
-        message: "The app you requested was not found.",
-      },
-    });
-  }
-
-  const exported = await exportAppWithDatasets(auth, appResource);
-
-  return ctx.json({ app: exported });
-});
+);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/apps/[aId]/export.ts
+++ b/front-api/routes/poke/workspaces/[wId]/apps/[aId]/export.ts
@@ -22,15 +22,6 @@ app.get(
   async (ctx): HandlerResult<ExportAppResponseBody> => {
     const auth = ctx.get("auth");
     const { aId } = ctx.req.valid("param");
-    if (!aId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid path parameters.",
-        },
-      });
-    }
 
     const appResource = await AppResource.fetchById(auth, aId);
     if (!appResource) {

--- a/front-api/routes/poke/workspaces/[wId]/apps/[aId]/state.ts
+++ b/front-api/routes/poke/workspaces/[wId]/apps/[aId]/state.ts
@@ -29,15 +29,6 @@ app.post(
   async (ctx): HandlerResult<PostStateResponseBody> => {
     const auth = ctx.get("auth");
     const { aId } = ctx.req.valid("param");
-    if (!aId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid path parameters.",
-        },
-      });
-    }
 
     const appResource = await AppResource.fetchById(auth, aId);
     if (!appResource) {

--- a/front-api/routes/poke/workspaces/[wId]/apps/[aId]/state.ts
+++ b/front-api/routes/poke/workspaces/[wId]/apps/[aId]/state.ts
@@ -11,6 +11,10 @@ const PostStateRequestBodySchema = z.object({
   run: z.string().optional(),
 });
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 type PostStateResponseBody = {
   app: AppType;
 };
@@ -20,10 +24,11 @@ const app = pokeApp();
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   validate("json", PostStateRequestBodySchema),
   async (ctx): HandlerResult<PostStateResponseBody> => {
     const auth = ctx.get("auth");
-    const aId = ctx.req.param("aId");
+    const { aId } = ctx.req.valid("param");
     if (!aId) {
       return apiError(ctx, {
         status_code: 400,

--- a/front-api/routes/poke/workspaces/[wId]/assistants/[aId]/suggestions.ts
+++ b/front-api/routes/poke/workspaces/[wId]/assistants/[aId]/suggestions.ts
@@ -26,15 +26,6 @@ app.get(
   async (ctx): HandlerResult<PokeListSuggestions> => {
     const auth = ctx.get("auth");
     const { aId } = ctx.req.valid("param");
-    if (!aId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid agent ID.",
-        },
-      });
-    }
 
     const suggestions =
       await AgentSuggestionResource.listByAgentConfigurationId(auth, aId);

--- a/front-api/routes/poke/workspaces/[wId]/assistants/[aId]/suggestions.ts
+++ b/front-api/routes/poke/workspaces/[wId]/assistants/[aId]/suggestions.ts
@@ -13,57 +13,68 @@ const DeleteSuggestionQuerySchema = z.object({
   sId: z.string(),
 });
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 // Mounted at /api/poke/workspaces/:wId/assistants/:aId/suggestions.
 const app = pokeApp();
 
-app.get("/", async (ctx): HandlerResult<PokeListSuggestions> => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId");
-  if (!aId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid agent ID.",
-      },
-    });
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<PokeListSuggestions> => {
+    const auth = ctx.get("auth");
+    const { aId } = ctx.req.valid("param");
+    if (!aId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid agent ID.",
+        },
+      });
+    }
+
+    const suggestions =
+      await AgentSuggestionResource.listByAgentConfigurationId(auth, aId);
+
+    return ctx.json({ suggestions: suggestions.map((s) => s.toJSON()) });
   }
+);
 
-  const suggestions = await AgentSuggestionResource.listByAgentConfigurationId(
-    auth,
-    aId
-  );
+app.delete(
+  "/",
+  validate("param", ParamsSchema),
+  validate("query", DeleteSuggestionQuerySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { sId } = ctx.req.valid("query");
 
-  return ctx.json({ suggestions: suggestions.map((s) => s.toJSON()) });
-});
+    const suggestion = await AgentSuggestionResource.fetchById(auth, sId);
+    if (!suggestion) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "The suggestion was not found.",
+        },
+      });
+    }
 
-app.delete("/", validate("query", DeleteSuggestionQuerySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const { sId } = ctx.req.valid("query");
+    const deleteResult = await suggestion.delete(auth);
+    if (deleteResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to delete suggestion.",
+        },
+      });
+    }
 
-  const suggestion = await AgentSuggestionResource.fetchById(auth, sId);
-  if (!suggestion) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "The suggestion was not found.",
-      },
-    });
+    return ctx.body(null, 204);
   }
-
-  const deleteResult = await suggestion.delete(auth);
-  if (deleteResult.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Failed to delete suggestion.",
-      },
-    });
-  }
-
-  return ctx.body(null, 204);
-});
+);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/auth-context.ts
+++ b/front-api/routes/poke/workspaces/[wId]/auth-context.ts
@@ -4,6 +4,8 @@ import type { SubscriptionType } from "@app/types/plan";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import { sessionApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 export type GetPokeWorkspaceAuthContextResponseType = {
   user: UserType;
@@ -13,6 +15,10 @@ export type GetPokeWorkspaceAuthContextResponseType = {
   isBuilder: true;
   isSuperUser: true;
 };
+
+const ParamsSchema = z.object({
+  wId: z.string(),
+});
 
 // Mounted at /api/poke/workspaces/:wId/auth-context.
 //
@@ -25,8 +31,9 @@ const app = sessionApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   async (ctx): HandlerResult<GetPokeWorkspaceAuthContextResponseType> => {
-    const wId = ctx.req.param("wId") ?? "";
+    const { wId } = ctx.req.valid("param");
     const session = ctx.get("session");
 
     const auth = await Authenticator.fromSuperUserSession(session, wId);

--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/config.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/config.ts
@@ -3,6 +3,8 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 export type PokeGetConversationConfig = {
   conversationDataSourceId: string | null;
@@ -10,38 +12,46 @@ export type PokeGetConversationConfig = {
   temporalWorkspace: string;
 };
 
+const ParamsSchema = z.object({
+  cId: z.string(),
+});
+
 // Mounted at /api/poke/workspaces/:wId/conversations/:cId/config.
 const app = pokeApp();
 
-app.get("/", async (ctx): HandlerResult<PokeGetConversationConfig> => {
-  const auth = ctx.get("auth");
-  const cId = ctx.req.param("cId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<PokeGetConversationConfig> => {
+    const auth = ctx.get("auth");
+    const { cId } = ctx.req.valid("param");
 
-  const cRes = await ConversationResource.fetchConversationWithoutContent(
-    auth,
-    cId,
-    { includeDeleted: true }
-  );
-  if (cRes.isErr()) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "Conversation not found.",
-      },
+    const cRes = await ConversationResource.fetchConversationWithoutContent(
+      auth,
+      cId,
+      { includeDeleted: true }
+    );
+    if (cRes.isErr()) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: "Conversation not found.",
+        },
+      });
+    }
+
+    const conversationDataSource = await DataSourceResource.fetchByConversation(
+      auth,
+      cRes.value
+    );
+
+    return ctx.json({
+      conversationDataSourceId: conversationDataSource?.sId ?? null,
+      langfuseUiBaseUrl: config.getLangfuseUiBaseUrl() ?? null,
+      temporalWorkspace: config.getTemporalAgentNamespace() ?? "",
     });
   }
-
-  const conversationDataSource = await DataSourceResource.fetchByConversation(
-    auth,
-    cRes.value
-  );
-
-  return ctx.json({
-    conversationDataSourceId: conversationDataSource?.sId ?? null,
-    langfuseUiBaseUrl: config.getLangfuseUiBaseUrl() ?? null,
-    temporalWorkspace: config.getTemporalAgentNamespace() ?? "",
-  });
-});
+);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/index.ts
@@ -3,6 +3,8 @@ import { getPokeConversation } from "@app/lib/poke/conversation";
 import type { PokeConversationType } from "@app/types/poke";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 import config from "./config";
 import reinforcementTestCase from "./reinforcement_test_case";
@@ -12,20 +14,28 @@ export type PokeGetConversationResponseBody = {
   conversation: PokeConversationType;
 };
 
+const ParamsSchema = z.object({
+  cId: z.string(),
+});
+
 // Mounted at /api/poke/workspaces/:wId/conversations/:cId.
 const app = pokeApp();
 
-app.get("/", async (ctx): HandlerResult<PokeGetConversationResponseBody> => {
-  const auth = ctx.get("auth");
-  const cId = ctx.req.param("cId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<PokeGetConversationResponseBody> => {
+    const auth = ctx.get("auth");
+    const { cId } = ctx.req.valid("param");
 
-  const conversationRes = await getPokeConversation(auth, cId, true);
-  if (conversationRes.isErr()) {
-    return apiError(ctx, getConversationApiError(conversationRes.error));
+    const conversationRes = await getPokeConversation(auth, cId, true);
+    if (conversationRes.isErr()) {
+      return apiError(ctx, getConversationApiError(conversationRes.error));
+    }
+
+    return ctx.json({ conversation: conversationRes.value });
   }
-
-  return ctx.json({ conversation: conversationRes.value });
-});
+);
 
 app.route("/config", config);
 app.route("/reinforcement_test_case", reinforcementTestCase);

--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/reinforcement_test_case.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/reinforcement_test_case.ts
@@ -11,6 +11,12 @@ import {
 import type { ModelId } from "@app/types/shared/model_id";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  cId: z.string(),
+});
 
 interface ReinforcementTestCaseMockAction {
   functionCallName: string;
@@ -82,9 +88,10 @@ const app = pokeApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   async (ctx): HandlerResult<PokeGetReinforcementTestCaseResponseBody> => {
     const auth = ctx.get("auth");
-    const cId = ctx.req.param("cId") ?? "";
+    const { cId } = ctx.req.valid("param");
 
     const conversationRes = await getConversation(auth, cId, true);
     if (conversationRes.isErr()) {

--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -38,6 +38,10 @@ const RenderConversationBodySchema = z.object({
   onMissingAction: z.enum(["inject-placeholder", "skip"]).optional(),
 });
 
+const ParamsSchema = z.object({
+  cId: z.string(),
+});
+
 export type PostRenderConversationResponseBody = {
   tokensUsed: number;
   modelConversation: unknown;
@@ -51,10 +55,11 @@ const app = pokeApp();
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   validate("json", RenderConversationBodySchema),
   async (ctx): HandlerResult<PostRenderConversationResponseBody> => {
     const auth = ctx.get("auth");
-    const cId = ctx.req.param("cId") ?? "";
+    const { cId } = ctx.req.valid("param");
     const {
       agentId,
       contextSizeOverride,

--- a/front-api/routes/poke/workspaces/[wId]/data_source_views/[dsvId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_source_views/[dsvId]/details.ts
@@ -23,15 +23,6 @@ app.get(
   async (ctx): HandlerResult<PokeGetDataSourceViewDetails> => {
     const auth = ctx.get("auth");
     const { dsvId } = ctx.req.valid("param");
-    if (!dsvId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid data source view ID.",
-        },
-      });
-    }
 
     const dataSourceView = await DataSourceViewResource.fetchById(auth, dsvId, {
       includeEditedBy: true,

--- a/front-api/routes/poke/workspaces/[wId]/data_source_views/[dsvId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_source_views/[dsvId]/details.ts
@@ -3,44 +3,54 @@ import { DataSourceViewResource } from "@app/lib/resources/data_source_view_reso
 import type { PokeDataSourceViewType } from "@app/types/poke";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 export type PokeGetDataSourceViewDetails = {
   dataSourceView: PokeDataSourceViewType;
 };
 
+const ParamsSchema = z.object({
+  dsvId: z.string(),
+});
+
 // Mounted at /api/poke/workspaces/:wId/data_source_views/:dsvId/details.
 const app = pokeApp();
 
-app.get("/", async (ctx): HandlerResult<PokeGetDataSourceViewDetails> => {
-  const auth = ctx.get("auth");
-  const dsvId = ctx.req.param("dsvId");
-  if (!dsvId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid data source view ID.",
-      },
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<PokeGetDataSourceViewDetails> => {
+    const auth = ctx.get("auth");
+    const { dsvId } = ctx.req.valid("param");
+    if (!dsvId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid data source view ID.",
+        },
+      });
+    }
+
+    const dataSourceView = await DataSourceViewResource.fetchById(auth, dsvId, {
+      includeEditedBy: true,
     });
+
+    if (!dataSourceView) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "data_source_view_not_found",
+          message: "Data source view not found.",
+        },
+      });
+    }
+
+    const dataSourceViewJSON = await dataSourceViewToPokeJSON(dataSourceView);
+
+    return ctx.json({ dataSourceView: dataSourceViewJSON });
   }
-
-  const dataSourceView = await DataSourceViewResource.fetchById(auth, dsvId, {
-    includeEditedBy: true,
-  });
-
-  if (!dataSourceView) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "data_source_view_not_found",
-        message: "Data source view not found.",
-      },
-    });
-  }
-
-  const dataSourceViewJSON = await dataSourceViewToPokeJSON(dataSourceView);
-
-  return ctx.json({ dataSourceView: dataSourceViewJSON });
-});
+);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/check-stuck.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/check-stuck.ts
@@ -3,32 +3,42 @@ import { checkConnectorStuckForDataSource } from "@app/lib/api/data_sources/chec
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 export type { CheckStuckResponseBody as PokeCheckStuckResponseBody };
+
+const ParamsSchema = z.object({
+  dsId: z.string(),
+});
 
 // Mounted at /api/poke/workspaces/:wId/data_sources/:dsId/check-stuck.
 const app = pokeApp();
 
-app.get("/", async (ctx): HandlerResult<CheckStuckResponseBody> => {
-  const auth = ctx.get("auth");
-  const dsId = ctx.req.param("dsId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<CheckStuckResponseBody> => {
+    const auth = ctx.get("auth");
+    const { dsId } = ctx.req.valid("param");
 
-  const dataSource = await DataSourceResource.fetchById(auth, dsId);
-  if (!dataSource) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "data_source_not_found",
-        message: "The data source you requested was not found.",
-      },
+    const dataSource = await DataSourceResource.fetchById(auth, dsId);
+    if (!dataSource) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "data_source_not_found",
+          message: "The data source you requested was not found.",
+        },
+      });
+    }
+
+    const result = await checkConnectorStuckForDataSource({
+      connectorId: dataSource.connectorId,
+      connectorProvider: dataSource.connectorProvider,
     });
+    return ctx.json(result);
   }
-
-  const result = await checkConnectorStuckForDataSource({
-    connectorId: dataSource.connectorId,
-    connectorProvider: dataSource.connectorProvider,
-  });
-  return ctx.json(result);
-});
+);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/config.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/config.ts
@@ -12,6 +12,10 @@ const PostConfigBodySchema = z.object({
   configValue: z.string(),
 });
 
+const ParamsSchema = z.object({
+  dsId: z.string(),
+});
+
 export type SetConfigResponseBody = {
   configKey: string;
   configValue: string;
@@ -22,10 +26,11 @@ const app = pokeApp();
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   validate("json", PostConfigBodySchema),
   async (ctx): HandlerResult<SetConfigResponseBody> => {
     const auth = ctx.get("auth");
-    const dsId = ctx.req.param("dsId");
+    const { dsId } = ctx.req.valid("param");
     if (!dsId) {
       return apiError(ctx, {
         status_code: 400,

--- a/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/config.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/config.ts
@@ -31,15 +31,6 @@ app.post(
   async (ctx): HandlerResult<SetConfigResponseBody> => {
     const auth = ctx.get("auth");
     const { dsId } = ctx.req.valid("param");
-    if (!dsId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid data source ID.",
-        },
-      });
-    }
 
     const dataSource = await DataSourceResource.fetchById(auth, dsId);
     if (!dataSource) {

--- a/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/details.ts
@@ -14,6 +14,12 @@ import type { DataSourceViewType } from "@app/types/data_source_view";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  dsId: z.string(),
+});
 
 export type FeaturesType = {
   slackBotEnabled: boolean;
@@ -45,245 +51,249 @@ export type PokeGetDataSourceDetails = {
 // Mounted at /api/poke/workspaces/:wId/data_sources/:dsId/details.
 const app = pokeApp();
 
-app.get("/", async (ctx): HandlerResult<PokeGetDataSourceDetails> => {
-  const auth = ctx.get("auth");
-  const dsId = ctx.req.param("dsId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<PokeGetDataSourceDetails> => {
+    const auth = ctx.get("auth");
+    const { dsId } = ctx.req.valid("param");
 
-  const dataSource = await DataSourceResource.fetchById(auth, dsId, {
-    includeEditedBy: true,
-  });
-  if (!dataSource) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "data_source_not_found",
-        message: "Data source not found.",
-      },
+    const dataSource = await DataSourceResource.fetchById(auth, dsId, {
+      includeEditedBy: true,
     });
-  }
+    if (!dataSource) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "data_source_not_found",
+          message: "Data source not found.",
+        },
+      });
+    }
 
-  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-  const coreDataSourceRes = await coreAPI.getDataSource({
-    projectId: dataSource.dustAPIProjectId,
-    dataSourceId: dataSource.dustAPIDataSourceId,
-  });
-
-  if (coreDataSourceRes.isErr()) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "data_source_not_found",
-        message: "Core data source not found.",
-      },
+    const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+    const coreDataSourceRes = await coreAPI.getDataSource({
+      projectId: dataSource.dustAPIProjectId,
+      dataSourceId: dataSource.dustAPIDataSourceId,
     });
-  }
 
-  const dataSourceViews = await DataSourceViewResource.listForDataSources(
-    auth,
-    [dataSource]
-  );
+    if (coreDataSourceRes.isErr()) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "data_source_not_found",
+          message: "Core data source not found.",
+        },
+      });
+    }
 
-  let connector: InternalConnectorType | null = null;
-  const workflowInfos: {
-    workflowId: string;
-    runId: string;
-    status: string;
-  }[] = [];
+    const dataSourceViews = await DataSourceViewResource.listForDataSources(
+      auth,
+      [dataSource]
+    );
 
-  if (dataSource.connectorId) {
+    let connector: InternalConnectorType | null = null;
+    const workflowInfos: {
+      workflowId: string;
+      runId: string;
+      status: string;
+    }[] = [];
+
+    if (dataSource.connectorId) {
+      const connectorsAPI = new ConnectorsAPI(
+        config.getConnectorsAPIConfig(),
+        logger
+      );
+      const connectorRes = await connectorsAPI.getConnector(
+        dataSource.connectorId
+      );
+      if (connectorRes.isOk()) {
+        connector = connectorRes.value;
+        const temporalClient = await getTemporalClientForConnectorsNamespace();
+
+        const workflowsIter = temporalClient.workflow.list({
+          query: `ExecutionStatus = 'Running' AND connectorId = ${connector.id}`,
+        });
+
+        for await (const infos of workflowsIter) {
+          workflowInfos.push({
+            workflowId: infos.workflowId,
+            runId: infos.runId,
+            status: infos.status.name,
+          });
+        }
+      } else {
+        logger.error(
+          { connectorId: dataSource.connectorId },
+          "Failed to get connector"
+        );
+      }
+    }
+
+    const features: FeaturesType = {
+      slackBotEnabled: false,
+      googleDrivePdfEnabled: false,
+      googleDriveLargeFilesEnabled: false,
+      microsoftPdfEnabled: false,
+      microsoftLargeFilesEnabled: false,
+      googleDriveCsvEnabled: false,
+      microsoftCsvEnabled: false,
+      githubCodeSyncEnabled: false,
+      githubUseProxyEnabled: false,
+      autoReadChannelPatterns: [],
+    };
+
     const connectorsAPI = new ConnectorsAPI(
       config.getConnectorsAPIConfig(),
       logger
     );
-    const connectorRes = await connectorsAPI.getConnector(
-      dataSource.connectorId
-    );
-    if (connectorRes.isOk()) {
-      connector = connectorRes.value;
-      const temporalClient = await getTemporalClientForConnectorsNamespace();
 
-      const workflowsIter = temporalClient.workflow.list({
-        query: `ExecutionStatus = 'Running' AND connectorId = ${connector.id}`,
-      });
-
-      for await (const infos of workflowsIter) {
-        workflowInfos.push({
-          workflowId: infos.workflowId,
-          runId: infos.runId,
-          status: infos.status.name,
-        });
-      }
-    } else {
-      logger.error(
-        { connectorId: dataSource.connectorId },
-        "Failed to get connector"
-      );
-    }
-  }
-
-  const features: FeaturesType = {
-    slackBotEnabled: false,
-    googleDrivePdfEnabled: false,
-    googleDriveLargeFilesEnabled: false,
-    microsoftPdfEnabled: false,
-    microsoftLargeFilesEnabled: false,
-    googleDriveCsvEnabled: false,
-    microsoftCsvEnabled: false,
-    githubCodeSyncEnabled: false,
-    githubUseProxyEnabled: false,
-    autoReadChannelPatterns: [],
-  };
-
-  const connectorsAPI = new ConnectorsAPI(
-    config.getConnectorsAPIConfig(),
-    logger
-  );
-
-  if (dataSource.connectorId) {
-    switch (dataSource.connectorProvider) {
-      case "slack_bot":
-      case "slack": {
-        const botEnabledRes = await connectorsAPI.getConnectorConfig(
-          dataSource.connectorId,
-          "botEnabled"
-        );
-        if (botEnabledRes.isErr()) {
-          throw botEnabledRes.error;
-        }
-        features.slackBotEnabled = botEnabledRes.value.configValue === "true";
-
-        const autoReadChannelPatternsRes =
-          await connectorsAPI.getConnectorConfig(
+    if (dataSource.connectorId) {
+      switch (dataSource.connectorProvider) {
+        case "slack_bot":
+        case "slack": {
+          const botEnabledRes = await connectorsAPI.getConnectorConfig(
             dataSource.connectorId,
-            "autoReadChannelPatterns"
+            "botEnabled"
           );
-        if (autoReadChannelPatternsRes.isErr()) {
-          throw autoReadChannelPatternsRes.error;
+          if (botEnabledRes.isErr()) {
+            throw botEnabledRes.error;
+          }
+          features.slackBotEnabled = botEnabledRes.value.configValue === "true";
+
+          const autoReadChannelPatternsRes =
+            await connectorsAPI.getConnectorConfig(
+              dataSource.connectorId,
+              "autoReadChannelPatterns"
+            );
+          if (autoReadChannelPatternsRes.isErr()) {
+            throw autoReadChannelPatternsRes.error;
+          }
+
+          const parsedAutoReadChannelPatternsRes = safeParseJSON(
+            autoReadChannelPatternsRes.value.configValue
+          );
+          if (parsedAutoReadChannelPatternsRes.isErr()) {
+            throw parsedAutoReadChannelPatternsRes.error;
+          }
+
+          if (
+            !parsedAutoReadChannelPatternsRes.value ||
+            !Array.isArray(parsedAutoReadChannelPatternsRes.value) ||
+            !isSlackAutoReadPatterns(parsedAutoReadChannelPatternsRes.value)
+          ) {
+            throw new Error("Invalid auto read channel patterns");
+          }
+
+          features.autoReadChannelPatterns =
+            parsedAutoReadChannelPatternsRes.value;
+          break;
         }
 
-        const parsedAutoReadChannelPatternsRes = safeParseJSON(
-          autoReadChannelPatternsRes.value.configValue
-        );
-        if (parsedAutoReadChannelPatternsRes.isErr()) {
-          throw parsedAutoReadChannelPatternsRes.error;
-        }
-
-        if (
-          !parsedAutoReadChannelPatternsRes.value ||
-          !Array.isArray(parsedAutoReadChannelPatternsRes.value) ||
-          !isSlackAutoReadPatterns(parsedAutoReadChannelPatternsRes.value)
-        ) {
-          throw new Error("Invalid auto read channel patterns");
-        }
-
-        features.autoReadChannelPatterns =
-          parsedAutoReadChannelPatternsRes.value;
-        break;
-      }
-
-      case "google_drive": {
-        const gdrivePdfEnabledRes = await connectorsAPI.getConnectorConfig(
-          dataSource.connectorId,
-          "pdfEnabled"
-        );
-        if (gdrivePdfEnabledRes.isErr()) {
-          throw gdrivePdfEnabledRes.error;
-        }
-        features.googleDrivePdfEnabled =
-          gdrivePdfEnabledRes.value.configValue === "true";
-
-        const gdriveCsvEnabledRes = await connectorsAPI.getConnectorConfig(
-          dataSource.connectorId,
-          "csvEnabled"
-        );
-        if (gdriveCsvEnabledRes.isErr()) {
-          throw gdriveCsvEnabledRes.error;
-        }
-        features.googleDriveCsvEnabled =
-          gdriveCsvEnabledRes.value.configValue === "true";
-
-        const gdriveLargeFilesEnabledRes =
-          await connectorsAPI.getConnectorConfig(
+        case "google_drive": {
+          const gdrivePdfEnabledRes = await connectorsAPI.getConnectorConfig(
             dataSource.connectorId,
-            "largeFilesEnabled"
+            "pdfEnabled"
           );
-        if (gdriveLargeFilesEnabledRes.isErr()) {
-          throw gdriveLargeFilesEnabledRes.error;
-        }
-        features.googleDriveLargeFilesEnabled =
-          gdriveLargeFilesEnabledRes.value.configValue === "true";
-        break;
-      }
+          if (gdrivePdfEnabledRes.isErr()) {
+            throw gdrivePdfEnabledRes.error;
+          }
+          features.googleDrivePdfEnabled =
+            gdrivePdfEnabledRes.value.configValue === "true";
 
-      case "microsoft": {
-        const microsoftPdfEnabledRes = await connectorsAPI.getConnectorConfig(
-          dataSource.connectorId,
-          "pdfEnabled"
-        );
-        if (microsoftPdfEnabledRes.isErr()) {
-          throw microsoftPdfEnabledRes.error;
-        }
-        features.microsoftPdfEnabled =
-          microsoftPdfEnabledRes.value.configValue === "true";
-
-        const microsoftCsvEnabledRes = await connectorsAPI.getConnectorConfig(
-          dataSource.connectorId,
-          "csvEnabled"
-        );
-        if (microsoftCsvEnabledRes.isErr()) {
-          throw microsoftCsvEnabledRes.error;
-        }
-        features.microsoftCsvEnabled =
-          microsoftCsvEnabledRes.value.configValue === "true";
-
-        const microsoftLargeFilesEnabledRes =
-          await connectorsAPI.getConnectorConfig(
+          const gdriveCsvEnabledRes = await connectorsAPI.getConnectorConfig(
             dataSource.connectorId,
-            "largeFilesEnabled"
+            "csvEnabled"
           );
-        if (microsoftLargeFilesEnabledRes.isErr()) {
-          throw microsoftLargeFilesEnabledRes.error;
-        }
-        features.microsoftLargeFilesEnabled =
-          microsoftLargeFilesEnabledRes.value.configValue === "true";
-        break;
-      }
+          if (gdriveCsvEnabledRes.isErr()) {
+            throw gdriveCsvEnabledRes.error;
+          }
+          features.googleDriveCsvEnabled =
+            gdriveCsvEnabledRes.value.configValue === "true";
 
-      case "github": {
-        const githubConnectorEnabledRes =
-          await connectorsAPI.getConnectorConfig(
+          const gdriveLargeFilesEnabledRes =
+            await connectorsAPI.getConnectorConfig(
+              dataSource.connectorId,
+              "largeFilesEnabled"
+            );
+          if (gdriveLargeFilesEnabledRes.isErr()) {
+            throw gdriveLargeFilesEnabledRes.error;
+          }
+          features.googleDriveLargeFilesEnabled =
+            gdriveLargeFilesEnabledRes.value.configValue === "true";
+          break;
+        }
+
+        case "microsoft": {
+          const microsoftPdfEnabledRes = await connectorsAPI.getConnectorConfig(
             dataSource.connectorId,
-            "codeSyncEnabled"
+            "pdfEnabled"
           );
-        if (githubConnectorEnabledRes.isErr()) {
-          throw githubConnectorEnabledRes.error;
-        }
-        features.githubCodeSyncEnabled =
-          githubConnectorEnabledRes.value.configValue === "true";
+          if (microsoftPdfEnabledRes.isErr()) {
+            throw microsoftPdfEnabledRes.error;
+          }
+          features.microsoftPdfEnabled =
+            microsoftPdfEnabledRes.value.configValue === "true";
 
-        const githubUseProxyRes = await connectorsAPI.getConnectorConfig(
-          dataSource.connectorId,
-          "useProxy"
-        );
-        if (githubUseProxyRes.isErr()) {
-          throw githubUseProxyRes.error;
+          const microsoftCsvEnabledRes = await connectorsAPI.getConnectorConfig(
+            dataSource.connectorId,
+            "csvEnabled"
+          );
+          if (microsoftCsvEnabledRes.isErr()) {
+            throw microsoftCsvEnabledRes.error;
+          }
+          features.microsoftCsvEnabled =
+            microsoftCsvEnabledRes.value.configValue === "true";
+
+          const microsoftLargeFilesEnabledRes =
+            await connectorsAPI.getConnectorConfig(
+              dataSource.connectorId,
+              "largeFilesEnabled"
+            );
+          if (microsoftLargeFilesEnabledRes.isErr()) {
+            throw microsoftLargeFilesEnabledRes.error;
+          }
+          features.microsoftLargeFilesEnabled =
+            microsoftLargeFilesEnabledRes.value.configValue === "true";
+          break;
         }
-        features.githubUseProxyEnabled =
-          githubUseProxyRes.value.configValue === "true";
-        break;
+
+        case "github": {
+          const githubConnectorEnabledRes =
+            await connectorsAPI.getConnectorConfig(
+              dataSource.connectorId,
+              "codeSyncEnabled"
+            );
+          if (githubConnectorEnabledRes.isErr()) {
+            throw githubConnectorEnabledRes.error;
+          }
+          features.githubCodeSyncEnabled =
+            githubConnectorEnabledRes.value.configValue === "true";
+
+          const githubUseProxyRes = await connectorsAPI.getConnectorConfig(
+            dataSource.connectorId,
+            "useProxy"
+          );
+          if (githubUseProxyRes.isErr()) {
+            throw githubUseProxyRes.error;
+          }
+          features.githubUseProxyEnabled =
+            githubUseProxyRes.value.configValue === "true";
+          break;
+        }
       }
     }
-  }
 
-  return ctx.json({
-    dataSource: dataSource.toJSON(),
-    dataSourceViews: dataSourceViews.map((view) => view.toJSON()),
-    coreDataSource: coreDataSourceRes.value.data_source,
-    connector,
-    features,
-    temporalWorkspace: config.getTemporalConnectorsNamespace() ?? "",
-    temporalRunningWorkflows: workflowInfos,
-  });
-});
+    return ctx.json({
+      dataSource: dataSource.toJSON(),
+      dataSourceViews: dataSourceViews.map((view) => view.toJSON()),
+      coreDataSource: coreDataSourceRes.value.data_source,
+      connector,
+      features,
+      temporalWorkspace: config.getTemporalConnectorsNamespace() ?? "",
+      temporalRunningWorkflows: workflowInfos,
+    });
+  }
+);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/document.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/document.ts
@@ -16,15 +16,20 @@ const QuerySchema = z.object({
   documentId: z.string(),
 });
 
+const ParamsSchema = z.object({
+  dsId: z.string(),
+});
+
 // Mounted at /api/poke/workspaces/:wId/data_sources/:dsId/document.
 const app = pokeApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   validate("query", QuerySchema),
   async (ctx): HandlerResult<PokeGetDocument> => {
     const auth = ctx.get("auth");
-    const dsId = ctx.req.param("dsId");
+    const { dsId } = ctx.req.valid("param");
     if (!dsId) {
       return apiError(ctx, {
         status_code: 400,

--- a/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/document.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/document.ts
@@ -30,15 +30,6 @@ app.get(
   async (ctx): HandlerResult<PokeGetDocument> => {
     const auth = ctx.get("auth");
     const { dsId } = ctx.req.valid("param");
-    if (!dsId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid data source ID.",
-        },
-      });
-    }
     const { documentId } = ctx.req.valid("query");
 
     const dataSource = await DataSourceResource.fetchById(auth, dsId, {

--- a/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/documents/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/documents/index.ts
@@ -13,6 +13,10 @@ const QuerySchema = z.object({
   offset: z.coerce.number().int().nonnegative().optional().default(0),
 });
 
+const ParamsSchema = z.object({
+  dsId: z.string(),
+});
+
 export type PokeGetDocumentsResponseBody = {
   documents: DocumentType[];
   total: number;
@@ -23,10 +27,11 @@ const app = pokeApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   validate("query", QuerySchema),
   async (ctx): HandlerResult<PokeGetDocumentsResponseBody> => {
     const auth = ctx.get("auth");
-    const dsId = ctx.req.param("dsId") ?? "";
+    const { dsId } = ctx.req.valid("param");
     const { limit, offset } = ctx.req.valid("query");
 
     const dataSource = await DataSourceResource.fetchById(auth, dsId);

--- a/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/index.ts
@@ -5,6 +5,8 @@ import type { DataSourceType } from "@app/types/data_source";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 import checkStuck from "./check-stuck";
 import config from "./config";
@@ -18,74 +20,82 @@ import tables from "./tables";
 
 export type DeleteDataSourceResponseBody = DataSourceType;
 
+const ParamsSchema = z.object({
+  dsId: z.string(),
+});
+
 // Mounted at /api/poke/workspaces/:wId/data_sources/:dsId.
 const app = pokeApp();
 
-app.delete("/", async (ctx): HandlerResult<DeleteDataSourceResponseBody> => {
-  const auth = ctx.get("auth");
-  const dsId = ctx.req.param("dsId") ?? "";
+app.delete(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<DeleteDataSourceResponseBody> => {
+    const auth = ctx.get("auth");
+    const { dsId } = ctx.req.valid("param");
 
-  const dataSource = await DataSourceResource.fetchById(auth, dsId);
-  if (!dataSource) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "data_source_not_found",
-        message: "The data source you requested was not found.",
-      },
-    });
-  }
-
-  const dataSourceViews = await DataSourceViewResource.listForDataSources(
-    auth,
-    [dataSource]
-  );
-  const viewsUsageByAgentsRes = await Promise.all(
-    dataSourceViews.map((view) => view.getUsagesByAgents(auth))
-  );
-
-  const viewsUsedByAgentsName = viewsUsageByAgentsRes.reduce(
-    (acc, usageRes) => {
-      if (usageRes.isOk() && usageRes.value.count > 0) {
-        usageRes.value.agents
-          .map((a) => a.name)
-          .forEach((name) => acc.add(name));
-      }
-      return acc;
-    },
-    new Set<string>()
-  );
-
-  if (viewsUsedByAgentsName.size > 0) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: `The data source is in use by ${viewsUsedByAgentsName.size} agent(s) [${Array.from(viewsUsedByAgentsName).join(", ")}].`,
-      },
-    });
-  }
-
-  const delRes = await softDeleteDataSourceAndLaunchScrubWorkflow(auth, {
-    dataSource,
-  });
-  if (delRes.isErr()) {
-    switch (delRes.error.code) {
-      case "unauthorized_deletion":
-        return apiError(ctx, {
-          status_code: 403,
-          api_error: {
-            type: "workspace_auth_error",
-            message: `You are not authorized to delete this data source: ${delRes.error.message}`,
-          },
-        });
-      default:
-        assertNever(delRes.error.code);
+    const dataSource = await DataSourceResource.fetchById(auth, dsId);
+    if (!dataSource) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "data_source_not_found",
+          message: "The data source you requested was not found.",
+        },
+      });
     }
-  }
 
-  return ctx.json(delRes.value);
-});
+    const dataSourceViews = await DataSourceViewResource.listForDataSources(
+      auth,
+      [dataSource]
+    );
+    const viewsUsageByAgentsRes = await Promise.all(
+      dataSourceViews.map((view) => view.getUsagesByAgents(auth))
+    );
+
+    const viewsUsedByAgentsName = viewsUsageByAgentsRes.reduce(
+      (acc, usageRes) => {
+        if (usageRes.isOk() && usageRes.value.count > 0) {
+          usageRes.value.agents
+            .map((a) => a.name)
+            .forEach((name) => acc.add(name));
+        }
+        return acc;
+      },
+      new Set<string>()
+    );
+
+    if (viewsUsedByAgentsName.size > 0) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `The data source is in use by ${viewsUsedByAgentsName.size} agent(s) [${Array.from(viewsUsedByAgentsName).join(", ")}].`,
+        },
+      });
+    }
+
+    const delRes = await softDeleteDataSourceAndLaunchScrubWorkflow(auth, {
+      dataSource,
+    });
+    if (delRes.isErr()) {
+      switch (delRes.error.code) {
+        case "unauthorized_deletion":
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
+              message: `You are not authorized to delete this data source: ${delRes.error.message}`,
+            },
+          });
+        default:
+          assertNever(delRes.error.code);
+      }
+    }
+
+    return ctx.json(delRes.value);
+  }
+);
 
 app.route("/check-stuck", checkStuck);
 app.route("/config", config);

--- a/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/managed/permissions.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/managed/permissions.ts
@@ -8,20 +8,26 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 export type {
   ManagedPermissionsResponse as PokeGetDataSourcePermissionsResponseBody,
 };
+
+const ParamsSchema = z.object({
+  dsId: z.string(),
+});
 
 // Mounted at /api/poke/workspaces/:wId/data_sources/:dsId/managed/permissions.
 const app = pokeApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   validate("query", ManagedPermissionsQuerySchema),
   async (ctx): HandlerResult<ManagedPermissionsResponse> => {
     const auth = ctx.get("auth");
-    const dsId = ctx.req.param("dsId") ?? "";
+    const { dsId } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchById(auth, dsId);
     if (!dataSource) {

--- a/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/query.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/query.ts
@@ -12,6 +12,10 @@ const QueryBodySchema = z.object({
   tableIds: z.array(z.string()).min(1),
 });
 
+const ParamsSchema = z.object({
+  dsId: z.string(),
+});
+
 export type PokeQueryResponseBody = {
   schema: Array<{
     name: string;
@@ -25,10 +29,11 @@ const app = pokeApp();
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   validate("json", QueryBodySchema),
   async (ctx): HandlerResult<PokeQueryResponseBody> => {
     const auth = ctx.get("auth");
-    const dsId = ctx.req.param("dsId") ?? "";
+    const { dsId } = ctx.req.valid("param");
     const { query, tableIds } = ctx.req.valid("json");
 
     const dataSource = await DataSourceResource.fetchById(auth, dsId);

--- a/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/search.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/search.ts
@@ -10,67 +10,77 @@ import type { DataSourceSearchResponseType } from "@dust-tt/client";
 import { DataSourceSearchQuerySchema } from "@dust-tt/client";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 import { fromError } from "zod-validation-error";
+
+const ParamsSchema = z.object({
+  dsId: z.string(),
+});
 
 // Mounted at /api/poke/workspaces/:wId/data_sources/:dsId/search.
 const app = pokeApp();
 
-app.get("/", async (ctx): HandlerResult<DataSourceSearchResponseType> => {
-  const auth = ctx.get("auth");
-  const dsId = ctx.req.param("dsId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<DataSourceSearchResponseType> => {
+    const auth = ctx.get("auth");
+    const { dsId } = ctx.req.valid("param");
 
-  const dataSource = await DataSourceResource.fetchById(auth, dsId);
-  if (!dataSource) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "data_source_not_found",
-        message: "The data source you requested was not found.",
-      },
-    });
-  }
-
-  // Allow tags_in / tags_not as either a single string or an array.
-  const rawQuery: Record<string, string | string[]> = {};
-  for (const [key, value] of Object.entries(ctx.req.query())) {
-    rawQuery[key] = value;
-  }
-  for (const key of ["tags_in", "tags_not"] as const) {
-    const all = ctx.req.queries(key);
-    if (all && all.length > 0) {
-      rawQuery[key] = all;
+    const dataSource = await DataSourceResource.fetchById(auth, dsId);
+    if (!dataSource) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "data_source_not_found",
+          message: "The data source you requested was not found.",
+        },
+      });
     }
-  }
 
-  const r = DataSourceSearchQuerySchema.safeParse(rawQuery);
-  if (r.error) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: fromError(r.error).toString(),
-      },
-    });
-  }
-
-  const searchQuery = r.data;
-  const s = await handleDataSourceSearch({ auth, searchQuery, dataSource });
-  if (s.isErr()) {
-    switch (s.error.code) {
-      case "data_source_error":
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: {
-            type: "data_source_error",
-            message: s.error.message,
-          },
-        });
-      default:
-        assertNever(s.error.code);
+    // Allow tags_in / tags_not as either a single string or an array.
+    const rawQuery: Record<string, string | string[]> = {};
+    for (const [key, value] of Object.entries(ctx.req.query())) {
+      rawQuery[key] = value;
     }
-  }
+    for (const key of ["tags_in", "tags_not"] as const) {
+      const all = ctx.req.queries(key);
+      if (all && all.length > 0) {
+        rawQuery[key] = all;
+      }
+    }
 
-  return ctx.json(s.value);
-});
+    const r = DataSourceSearchQuerySchema.safeParse(rawQuery);
+    if (r.error) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: fromError(r.error).toString(),
+        },
+      });
+    }
+
+    const searchQuery = r.data;
+    const s = await handleDataSourceSearch({ auth, searchQuery, dataSource });
+    if (s.isErr()) {
+      switch (s.error.code) {
+        case "data_source_error":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "data_source_error",
+              message: s.error.message,
+            },
+          });
+        default:
+          assertNever(s.error.code);
+      }
+    }
+
+    return ctx.json(s.value);
+  }
+);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/tables/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/tables/index.ts
@@ -18,15 +18,20 @@ const QuerySchema = z.object({
   offset: z.coerce.number().int().nonnegative().optional().default(0),
 });
 
+const ParamsSchema = z.object({
+  dsId: z.string(),
+});
+
 // Mounted at /api/poke/workspaces/:wId/data_sources/:dsId/tables.
 const app = pokeApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   validate("query", QuerySchema),
   async (ctx): HandlerResult<GetTablesResponseBody> => {
     const auth = ctx.get("auth");
-    const dsId = ctx.req.param("dsId");
+    const { dsId } = ctx.req.valid("param");
     if (!dsId) {
       return apiError(ctx, {
         status_code: 400,

--- a/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/tables/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/tables/index.ts
@@ -32,15 +32,6 @@ app.get(
   async (ctx): HandlerResult<GetTablesResponseBody> => {
     const auth = ctx.get("auth");
     const { dsId } = ctx.req.valid("param");
-    if (!dsId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid data source ID.",
-        },
-      });
-    }
 
     const dataSource = await DataSourceResource.fetchById(auth, dsId);
     if (!dataSource) {

--- a/front-api/routes/poke/workspaces/[wId]/files/[sId].ts
+++ b/front-api/routes/poke/workspaces/[wId]/files/[sId].ts
@@ -7,6 +7,8 @@ import type {
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 export interface GetPokeFileResponseBody {
   content: string;
@@ -19,50 +21,58 @@ export interface GetPokeFileResponseBody {
   sharingGrants: SharingGrantType[];
 }
 
+const ParamsSchema = z.object({
+  sId: z.string(),
+});
+
 // Mounted at /api/poke/workspaces/:wId/files/:sId.
 const app = pokeApp();
 
-app.get("/", async (ctx): HandlerResult<GetPokeFileResponseBody> => {
-  const auth = ctx.get("auth");
-  const sId = ctx.req.param("sId");
-  if (!sId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "The sId parameter is required.",
-      },
-    });
-  }
-
-  const result = await readInteractiveContentFile(auth, sId);
-  if (result.isErr()) {
-    const err = result.error;
-    switch (err) {
-      case "file_not_found":
-        return apiError(ctx, {
-          status_code: 404,
-          api_error: {
-            type: "file_not_found",
-            message: "File not found.",
-          },
-        });
-
-      case "not_interactive_content":
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: "Only interactive content files can be viewed.",
-          },
-        });
-
-      default:
-        return assertNever(err);
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetPokeFileResponseBody> => {
+    const auth = ctx.get("auth");
+    const { sId } = ctx.req.valid("param");
+    if (!sId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "The sId parameter is required.",
+        },
+      });
     }
-  }
 
-  return ctx.json(result.value);
-});
+    const result = await readInteractiveContentFile(auth, sId);
+    if (result.isErr()) {
+      const err = result.error;
+      switch (err) {
+        case "file_not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: {
+              type: "file_not_found",
+              message: "File not found.",
+            },
+          });
+
+        case "not_interactive_content":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "Only interactive content files can be viewed.",
+            },
+          });
+
+        default:
+          return assertNever(err);
+      }
+    }
+
+    return ctx.json(result.value);
+  }
+);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/files/[sId].ts
+++ b/front-api/routes/poke/workspaces/[wId]/files/[sId].ts
@@ -34,15 +34,6 @@ app.get(
   async (ctx): HandlerResult<GetPokeFileResponseBody> => {
     const auth = ctx.get("auth");
     const { sId } = ctx.req.valid("param");
-    if (!sId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "The sId parameter is required.",
-        },
-      });
-    }
 
     const result = await readInteractiveContentFile(auth, sId);
     if (result.isErr()) {

--- a/front-api/routes/poke/workspaces/[wId]/groups/[groupId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/groups/[groupId]/details.ts
@@ -25,15 +25,6 @@ app.get(
   async (ctx): HandlerResult<PokeGetGroupDetails> => {
     const auth = ctx.get("auth");
     const { groupId } = ctx.req.valid("param");
-    if (!groupId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid group ID.",
-        },
-      });
-    }
 
     const groupRes = await GroupResource.fetchById(auth, groupId);
     if (groupRes.isErr()) {

--- a/front-api/routes/poke/workspaces/[wId]/groups/[groupId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/groups/[groupId]/details.ts
@@ -4,46 +4,56 @@ import type { GroupType } from "@app/types/groups";
 import type { UserTypeWithWorkspaces } from "@app/types/user";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 export type PokeGetGroupDetails = {
   members: UserTypeWithWorkspaces[];
   group: GroupType;
 };
 
+const ParamsSchema = z.object({
+  groupId: z.string(),
+});
+
 // Mounted at /api/poke/workspaces/:wId/groups/:groupId/details.
 const app = pokeApp();
 
-app.get("/", async (ctx): HandlerResult<PokeGetGroupDetails> => {
-  const auth = ctx.get("auth");
-  const groupId = ctx.req.param("groupId");
-  if (!groupId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid group ID.",
-      },
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<PokeGetGroupDetails> => {
+    const auth = ctx.get("auth");
+    const { groupId } = ctx.req.valid("param");
+    if (!groupId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid group ID.",
+        },
+      });
+    }
+
+    const groupRes = await GroupResource.fetchById(auth, groupId);
+    if (groupRes.isErr()) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "group_not_found",
+          message: "Group not found.",
+        },
+      });
+    }
+
+    const group = groupRes.value;
+    const members = await getGroupMembersWithWorkspaces(auth, group);
+
+    return ctx.json({
+      members,
+      group: group.toJSON(),
     });
   }
-
-  const groupRes = await GroupResource.fetchById(auth, groupId);
-  if (groupRes.isErr()) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "group_not_found",
-        message: "Group not found.",
-      },
-    });
-  }
-
-  const group = groupRes.value;
-  const members = await getGroupMembersWithWorkspaces(auth, group);
-
-  return ctx.json({
-    members,
-    group: group.toJSON(),
-  });
-});
+);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/invitations/[iId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/invitations/[iId]/index.ts
@@ -32,15 +32,6 @@ app.patch(
     }
 
     const { iId: invitationId } = ctx.req.valid("param");
-    if (!invitationId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid query parameters, `iId` (string) is required.",
-        },
-      });
-    }
 
     const workspaceAdminAuth = await Authenticator.internalAdminForWorkspace(
       owner.sId

--- a/front-api/routes/poke/workspaces/[wId]/invitations/[iId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/invitations/[iId]/index.ts
@@ -4,83 +4,96 @@ import { Authenticator } from "@app/lib/auth";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  iId: z.string(),
+});
 
 // Mounted at /api/poke/workspaces/:wId/invitations/:iId.
 const app = pokeApp();
 
-app.patch("/", async (ctx): HandlerResult<HandleMembershipInvitationResult> => {
-  const auth = ctx.get("auth");
-  const owner = auth.getNonNullableWorkspace();
-  const user = auth.user();
-  if (!user) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The workspace was not found.",
-      },
-    });
+app.patch(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<HandleMembershipInvitationResult> => {
+    const auth = ctx.get("auth");
+    const owner = auth.getNonNullableWorkspace();
+    const user = auth.user();
+    if (!user) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "workspace_not_found",
+          message: "The workspace was not found.",
+        },
+      });
+    }
+
+    const { iId: invitationId } = ctx.req.valid("param");
+    if (!invitationId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid query parameters, `iId` (string) is required.",
+        },
+      });
+    }
+
+    const workspaceAdminAuth = await Authenticator.internalAdminForWorkspace(
+      owner.sId
+    );
+
+    const subscription = workspaceAdminAuth.subscription();
+    if (!subscription) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "workspace_not_found",
+          message: "The subscription was not found.",
+        },
+      });
+    }
+
+    const invitation = await MembershipInvitationResource.fetchById(
+      workspaceAdminAuth,
+      invitationId
+    );
+    if (!invitation) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "invitation_not_found",
+          message: "The invitation was not found.",
+        },
+      });
+    }
+
+    // Revoke the existing invitation so that a brand new one is created
+    // with a fresh createdAt (and therefore a fresh 7-day token).
+    await invitation.revoke();
+
+    const invitationRes = await handleMembershipInvitations(
+      workspaceAdminAuth,
+      {
+        owner,
+        user: user.toJSON(),
+        subscription,
+        invitationRequests: [
+          { email: invitation.inviteEmail, role: invitation.initialRole },
+        ],
+        force: true,
+      }
+    );
+
+    if (invitationRes.isErr()) {
+      return apiError(ctx, invitationRes.error);
+    }
+
+    return ctx.json(invitationRes.value[0]);
   }
-
-  const invitationId = ctx.req.param("iId");
-  if (!invitationId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid query parameters, `iId` (string) is required.",
-      },
-    });
-  }
-
-  const workspaceAdminAuth = await Authenticator.internalAdminForWorkspace(
-    owner.sId
-  );
-
-  const subscription = workspaceAdminAuth.subscription();
-  if (!subscription) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_not_found",
-        message: "The subscription was not found.",
-      },
-    });
-  }
-
-  const invitation = await MembershipInvitationResource.fetchById(
-    workspaceAdminAuth,
-    invitationId
-  );
-  if (!invitation) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "invitation_not_found",
-        message: "The invitation was not found.",
-      },
-    });
-  }
-
-  // Revoke the existing invitation so that a brand new one is created
-  // with a fresh createdAt (and therefore a fresh 7-day token).
-  await invitation.revoke();
-
-  const invitationRes = await handleMembershipInvitations(workspaceAdminAuth, {
-    owner,
-    user: user.toJSON(),
-    subscription,
-    invitationRequests: [
-      { email: invitation.inviteEmail, role: invitation.initialRole },
-    ],
-    force: true,
-  });
-
-  if (invitationRes.isErr()) {
-    return apiError(ctx, invitationRes.error);
-  }
-
-  return ctx.json(invitationRes.value[0]);
-});
+);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/llm-traces/[runId].ts
+++ b/front-api/routes/poke/workspaces/[wId]/llm-traces/[runId].ts
@@ -1,41 +1,51 @@
 import { fetchLLMTrace, isLLMTraceId } from "@app/lib/api/llm/traces/buffer";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 interface GetLLMTraceResponseBody {
   trace: unknown | null;
 }
 
+const ParamsSchema = z.object({
+  runId: z.string(),
+});
+
 // Mounted at /api/poke/workspaces/:wId/llm-traces/:runId.
 const app = pokeApp();
 
-app.get("/", async (ctx): HandlerResult<GetLLMTraceResponseBody> => {
-  const auth = ctx.get("auth");
-  const runId = ctx.req.param("runId");
-  if (!runId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "The runId parameter is required.",
-      },
-    });
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetLLMTraceResponseBody> => {
+    const auth = ctx.get("auth");
+    const { runId } = ctx.req.valid("param");
+    if (!runId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "The runId parameter is required.",
+        },
+      });
+    }
+
+    // Validate that this is actually an LLM runId.
+    if (!isLLMTraceId(runId)) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "RunId does not have the expected LLM prefix.",
+        },
+      });
+    }
+
+    const trace = await fetchLLMTrace(auth, { runId });
+
+    return ctx.json({ trace });
   }
-
-  // Validate that this is actually an LLM runId.
-  if (!isLLMTraceId(runId)) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "RunId does not have the expected LLM prefix.",
-      },
-    });
-  }
-
-  const trace = await fetchLLMTrace(auth, { runId });
-
-  return ctx.json({ trace });
-});
+);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/llm-traces/[runId].ts
+++ b/front-api/routes/poke/workspaces/[wId]/llm-traces/[runId].ts
@@ -21,15 +21,6 @@ app.get(
   async (ctx): HandlerResult<GetLLMTraceResponseBody> => {
     const auth = ctx.get("auth");
     const { runId } = ctx.req.valid("param");
-    if (!runId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "The runId parameter is required.",
-        },
-      });
-    }
 
     // Validate that this is actually an LLM runId.
     if (!isLLMTraceId(runId)) {

--- a/front-api/routes/poke/workspaces/[wId]/mcp_server_views/[svId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/mcp_server_views/[svId]/details.ts
@@ -23,15 +23,6 @@ app.get(
   async (ctx): HandlerResult<PokeGetMCPServerViewDetails> => {
     const auth = ctx.get("auth");
     const { svId } = ctx.req.valid("param");
-    if (!svId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid MCP server view ID.",
-        },
-      });
-    }
 
     const mcpServerView = await MCPServerViewResource.fetchById(auth, svId);
     if (!mcpServerView) {

--- a/front-api/routes/poke/workspaces/[wId]/mcp_server_views/[svId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/mcp_server_views/[svId]/details.ts
@@ -3,41 +3,54 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import type { PokeMCPServerViewType } from "@app/types/poke";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 export type PokeGetMCPServerViewDetails = {
   mcpServerView: PokeMCPServerViewType;
 };
 
+const ParamsSchema = z.object({
+  svId: z.string(),
+});
+
 // Mounted at /api/poke/workspaces/:wId/mcp_server_views/:svId/details.
 const app = pokeApp();
 
-app.get("/", async (ctx): HandlerResult<PokeGetMCPServerViewDetails> => {
-  const auth = ctx.get("auth");
-  const svId = ctx.req.param("svId");
-  if (!svId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid MCP server view ID.",
-      },
-    });
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<PokeGetMCPServerViewDetails> => {
+    const auth = ctx.get("auth");
+    const { svId } = ctx.req.valid("param");
+    if (!svId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid MCP server view ID.",
+        },
+      });
+    }
+
+    const mcpServerView = await MCPServerViewResource.fetchById(auth, svId);
+    if (!mcpServerView) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "mcp_server_view_not_found",
+          message: "MCP server view not found.",
+        },
+      });
+    }
+
+    const mcpServerViewJSON = await mcpServerViewToPokeJSON(
+      mcpServerView,
+      auth
+    );
+
+    return ctx.json({ mcpServerView: mcpServerViewJSON });
   }
-
-  const mcpServerView = await MCPServerViewResource.fetchById(auth, svId);
-  if (!mcpServerView) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "mcp_server_view_not_found",
-        message: "MCP server view not found.",
-      },
-    });
-  }
-
-  const mcpServerViewJSON = await mcpServerViewToPokeJSON(mcpServerView, auth);
-
-  return ctx.json({ mcpServerView: mcpServerViewJSON });
-});
+);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/connector-knowledge.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/connector-knowledge.ts
@@ -28,15 +28,6 @@ app.get(
   async (ctx): HandlerResult<PokeListProjectKnowledgeFromConnectors> => {
     const auth = ctx.get("auth");
     const { projectId } = ctx.req.valid("param");
-    if (!projectId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid project ID.",
-        },
-      });
-    }
 
     const space = await SpaceResource.fetchById(auth, projectId);
     if (!space || !space.isProject()) {

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/connector-knowledge.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/connector-knowledge.ts
@@ -5,6 +5,8 @@ import {
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 export type PokeProjectKnowledgeFromConnectorItem =
   ProjectKnowledgeFromConnectorItem;
@@ -13,14 +15,19 @@ export type PokeListProjectKnowledgeFromConnectors = {
   items: PokeProjectKnowledgeFromConnectorItem[];
 };
 
+const ParamsSchema = z.object({
+  projectId: z.string(),
+});
+
 // Mounted at /api/poke/workspaces/:wId/projects/:projectId/connector-knowledge.
 const app = pokeApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   async (ctx): HandlerResult<PokeListProjectKnowledgeFromConnectors> => {
     const auth = ctx.get("auth");
-    const projectId = ctx.req.param("projectId");
+    const { projectId } = ctx.req.valid("param");
     if (!projectId) {
       return apiError(ctx, {
         status_code: 400,

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/tasks-workflow.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/tasks-workflow.ts
@@ -39,15 +39,6 @@ app.get(
   async (ctx): HandlerResult<PokeGetProjectWorkflow> => {
     const auth = ctx.get("auth");
     const { projectId } = ctx.req.valid("param");
-    if (!projectId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid project ID.",
-        },
-      });
-    }
 
     const owner = auth.getNonNullableWorkspace();
 

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/tasks-workflow.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/tasks-workflow.ts
@@ -8,6 +8,8 @@ import {
 import type { PodMetadataType } from "@app/types/project_metadata";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 export type PokeProjectWorkflowInfo = {
   workflowId: string;
@@ -24,59 +26,67 @@ export type PokeGetProjectWorkflow = {
   latestWorkflow: PokeProjectWorkflowInfo | null;
 };
 
+const ParamsSchema = z.object({
+  projectId: z.string(),
+});
+
 // Mounted at /api/poke/workspaces/:wId/projects/:projectId/tasks-workflow.
 const app = pokeApp();
 
-app.get("/", async (ctx): HandlerResult<PokeGetProjectWorkflow> => {
-  const auth = ctx.get("auth");
-  const projectId = ctx.req.param("projectId");
-  if (!projectId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid project ID.",
-      },
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<PokeGetProjectWorkflow> => {
+    const auth = ctx.get("auth");
+    const { projectId } = ctx.req.valid("param");
+    if (!projectId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid project ID.",
+        },
+      });
+    }
+
+    const owner = auth.getNonNullableWorkspace();
+
+    const space = await SpaceResource.fetchById(auth, projectId);
+    if (!space || !space.isProject()) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "space_not_found",
+          message: "Project not found.",
+        },
+      });
+    }
+
+    const metadata = await ProjectMetadataResource.fetchBySpace(auth, space);
+    const workflowId = `project-todo-${owner.sId}-${space.sId}`;
+
+    const temporalClient = await getTemporalClientForFrontNamespace();
+
+    const description = await describeTemporalWorkflow(temporalClient, {
+      workflowId,
+    });
+    const latestWorkflow: PokeProjectWorkflowInfo | null = description
+      ? {
+          workflowId,
+          runId: description.runId,
+          status: description.status.name,
+          startTime: description.startTime?.getTime() ?? null,
+          closeTime: description.closeTime?.getTime() ?? null,
+        }
+      : null;
+
+    return ctx.json({
+      metadata: metadata ? metadata.toJSON() : null,
+      temporalNamespace: config.getTemporalFrontNamespace() ?? "",
+      workflowId,
+      latestWorkflow,
     });
   }
-
-  const owner = auth.getNonNullableWorkspace();
-
-  const space = await SpaceResource.fetchById(auth, projectId);
-  if (!space || !space.isProject()) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "space_not_found",
-        message: "Project not found.",
-      },
-    });
-  }
-
-  const metadata = await ProjectMetadataResource.fetchBySpace(auth, space);
-  const workflowId = `project-todo-${owner.sId}-${space.sId}`;
-
-  const temporalClient = await getTemporalClientForFrontNamespace();
-
-  const description = await describeTemporalWorkflow(temporalClient, {
-    workflowId,
-  });
-  const latestWorkflow: PokeProjectWorkflowInfo | null = description
-    ? {
-        workflowId,
-        runId: description.runId,
-        status: description.status.name,
-        startTime: description.startTime?.getTime() ?? null,
-        closeTime: description.closeTime?.getTime() ?? null,
-      }
-    : null;
-
-  return ctx.json({
-    metadata: metadata ? metadata.toJSON() : null,
-    temporalNamespace: config.getTemporalFrontNamespace() ?? "",
-    workflowId,
-    latestWorkflow,
-  });
-});
+);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/tasks.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/tasks.ts
@@ -37,15 +37,6 @@ app.get(
   async (ctx): HandlerResult<PokeListProjectTasks> => {
     const auth = ctx.get("auth");
     const { projectId } = ctx.req.valid("param");
-    if (!projectId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid project ID.",
-        },
-      });
-    }
 
     const space = await SpaceResource.fetchById(auth, projectId);
     if (!space || !space.isProject()) {

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/tasks.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/tasks.ts
@@ -3,6 +3,8 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { PodTaskType } from "@app/types/project_task";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 // `ProjectTaskType` declares several `Date` fields (`doneAt`,
 // `agentSuggestionReviewedAt`, `createdAt`, `updatedAt`). On the wire these
@@ -22,39 +24,47 @@ export type PokeListProjectTasks = {
   tasks: PokeProjectTaskWireType[];
 };
 
+const ParamsSchema = z.object({
+  projectId: z.string(),
+});
+
 // Mounted at /api/poke/workspaces/:wId/projects/:projectId/tasks.
 const app = pokeApp();
 
-app.get("/", async (ctx): HandlerResult<PokeListProjectTasks> => {
-  const auth = ctx.get("auth");
-  const projectId = ctx.req.param("projectId");
-  if (!projectId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid project ID.",
-      },
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<PokeListProjectTasks> => {
+    const auth = ctx.get("auth");
+    const { projectId } = ctx.req.valid("param");
+    if (!projectId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid project ID.",
+        },
+      });
+    }
+
+    const space = await SpaceResource.fetchById(auth, projectId);
+    if (!space || !space.isProject()) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "space_not_found",
+          message: "Project not found.",
+        },
+      });
+    }
+
+    const tasks = await ProjectTaskResource.fetchBySpace(auth, {
+      spaceId: space.id,
+      timeScope: "all",
     });
+
+    return ctx.json({ tasks: tasks.map((t) => t.toJSON()) });
   }
-
-  const space = await SpaceResource.fetchById(auth, projectId);
-  if (!space || !space.isProject()) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "space_not_found",
-        message: "Project not found.",
-      },
-    });
-  }
-
-  const tasks = await ProjectTaskResource.fetchBySpace(auth, {
-    spaceId: space.id,
-    timeScope: "all",
-  });
-
-  return ctx.json({ tasks: tasks.map((t) => t.toJSON()) });
-});
+);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/skill_suggestions/[suggestionId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skill_suggestions/[suggestionId]/details.ts
@@ -25,15 +25,6 @@ app.get(
   async (ctx): HandlerResult<PokeGetSkillSuggestionDetails> => {
     const auth = ctx.get("auth");
     const { suggestionId } = ctx.req.valid("param");
-    if (!suggestionId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid suggestion ID.",
-        },
-      });
-    }
 
     const suggestion = await SkillSuggestionResource.fetchById(
       auth,

--- a/front-api/routes/poke/workspaces/[wId]/skill_suggestions/[suggestionId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skill_suggestions/[suggestionId]/details.ts
@@ -3,6 +3,8 @@ import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_res
 import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 export type PokeGetSkillSuggestionDetails = {
   suggestion: SkillSuggestionType;
@@ -10,48 +12,56 @@ export type PokeGetSkillSuggestionDetails = {
   skillAgentFacingDescription: string | null;
 };
 
+const ParamsSchema = z.object({
+  suggestionId: z.string(),
+});
+
 // Mounted at /api/poke/workspaces/:wId/skill_suggestions/:suggestionId/details.
 const app = pokeApp();
 
-app.get("/", async (ctx): HandlerResult<PokeGetSkillSuggestionDetails> => {
-  const auth = ctx.get("auth");
-  const suggestionId = ctx.req.param("suggestionId");
-  if (!suggestionId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid suggestion ID.",
-      },
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<PokeGetSkillSuggestionDetails> => {
+    const auth = ctx.get("auth");
+    const { suggestionId } = ctx.req.valid("param");
+    if (!suggestionId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid suggestion ID.",
+        },
+      });
+    }
+
+    const suggestion = await SkillSuggestionResource.fetchById(
+      auth,
+      suggestionId,
+      { dangerouslyBypassConversationsVisibilityCheck: true }
+    );
+    if (!suggestion) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "skill_not_found",
+          message: "The suggestion was not found.",
+        },
+      });
+    }
+
+    const skill = await SkillResource.fetchById(
+      auth,
+      suggestion.skillConfigurationSId
+    );
+
+    const skillJson = skill?.toJSON(auth);
+    return ctx.json({
+      suggestion: suggestion.toJSON(),
+      skillInstructionsHtml: skillJson?.instructionsHtml ?? null,
+      skillAgentFacingDescription: skillJson?.agentFacingDescription ?? null,
     });
   }
-
-  const suggestion = await SkillSuggestionResource.fetchById(
-    auth,
-    suggestionId,
-    { dangerouslyBypassConversationsVisibilityCheck: true }
-  );
-  if (!suggestion) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "skill_not_found",
-        message: "The suggestion was not found.",
-      },
-    });
-  }
-
-  const skill = await SkillResource.fetchById(
-    auth,
-    suggestion.skillConfigurationSId
-  );
-
-  const skillJson = skill?.toJSON(auth);
-  return ctx.json({
-    suggestion: suggestion.toJSON(),
-    skillInstructionsHtml: skillJson?.instructionsHtml ?? null,
-    skillAgentFacingDescription: skillJson?.agentFacingDescription ?? null,
-  });
-});
+);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/skills/[sId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/[sId]/details.ts
@@ -27,15 +27,6 @@ app.get(
   async (ctx): HandlerResult<PokeGetSkillDetails> => {
     const auth = ctx.get("auth");
     const { sId } = ctx.req.valid("param");
-    if (!sId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid skill ID.",
-        },
-      });
-    }
 
     const skill = await SkillResource.fetchById(auth, sId);
     if (!skill) {

--- a/front-api/routes/poke/workspaces/[wId]/skills/[sId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/[sId]/details.ts
@@ -5,6 +5,8 @@ import type { SpaceType } from "@app/types/space";
 import type { UserType } from "@app/types/user";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 export type PokeGetSkillDetails = {
   skill: SkillType;
@@ -12,45 +14,53 @@ export type PokeGetSkillDetails = {
   spaces: SpaceType[];
 };
 
+const ParamsSchema = z.object({
+  sId: z.string(),
+});
+
 // Mounted at /api/poke/workspaces/:wId/skills/:sId/details.
 const app = pokeApp();
 
-app.get("/", async (ctx): HandlerResult<PokeGetSkillDetails> => {
-  const auth = ctx.get("auth");
-  const sId = ctx.req.param("sId");
-  if (!sId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid skill ID.",
-      },
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<PokeGetSkillDetails> => {
+    const auth = ctx.get("auth");
+    const { sId } = ctx.req.valid("param");
+    if (!sId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid skill ID.",
+        },
+      });
+    }
+
+    const skill = await SkillResource.fetchById(auth, sId);
+    if (!skill) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "skill_not_found",
+          message: "Skill not found.",
+        },
+      });
+    }
+
+    const serializedSkill = skill.toJSON(auth);
+    const editedByUser = await skill.fetchEditedByUser(auth);
+    const spaces = await SpaceResource.fetchByIds(
+      auth,
+      serializedSkill.requestedSpaceIds
+    );
+
+    return ctx.json({
+      skill: serializedSkill,
+      editedByUser: editedByUser ? editedByUser.toJSON() : null,
+      spaces: spaces.map((s) => s.toJSON()),
     });
   }
-
-  const skill = await SkillResource.fetchById(auth, sId);
-  if (!skill) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "skill_not_found",
-        message: "Skill not found.",
-      },
-    });
-  }
-
-  const serializedSkill = skill.toJSON(auth);
-  const editedByUser = await skill.fetchEditedByUser(auth);
-  const spaces = await SpaceResource.fetchByIds(
-    auth,
-    serializedSkill.requestedSpaceIds
-  );
-
-  return ctx.json({
-    skill: serializedSkill,
-    editedByUser: editedByUser ? editedByUser.toJSON() : null,
-    spaces: spaces.map((s) => s.toJSON()),
-  });
-});
+);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/skills/[sId]/suggestions.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/[sId]/suggestions.ts
@@ -14,64 +14,74 @@ const DeleteSuggestionQuerySchema = z.object({
   suggestionSId: z.string(),
 });
 
+const ParamsSchema = z.object({
+  sId: z.string(),
+});
+
 // Mounted at /api/poke/workspaces/:wId/skills/:sId/suggestions.
 const app = pokeApp();
 
-app.get("/", async (ctx): HandlerResult<PokeListSkillSuggestions> => {
-  const auth = ctx.get("auth");
-  const sId = ctx.req.param("sId");
-  if (!sId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid skill ID.",
-      },
-    });
-  }
-
-  const suggestions = await SkillSuggestionResource.listBySkillConfigurationId(
-    auth,
-    sId,
-    {
-      sources: [...SKILL_SUGGESTION_SOURCES],
-      dangerouslyBypassConversationsVisibilityCheck: true,
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<PokeListSkillSuggestions> => {
+    const auth = ctx.get("auth");
+    const { sId } = ctx.req.valid("param");
+    if (!sId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid skill ID.",
+        },
+      });
     }
-  );
 
-  return ctx.json({ suggestions: suggestions.map((s) => s.toJSON()) });
-});
+    const suggestions =
+      await SkillSuggestionResource.listBySkillConfigurationId(auth, sId, {
+        sources: [...SKILL_SUGGESTION_SOURCES],
+        dangerouslyBypassConversationsVisibilityCheck: true,
+      });
 
-app.delete("/", validate("query", DeleteSuggestionQuerySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const { suggestionSId } = ctx.req.valid("query");
-
-  const suggestion = await SkillSuggestionResource.fetchById(
-    auth,
-    suggestionSId
-  );
-  if (!suggestion) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "skill_not_found",
-        message: "The suggestion was not found.",
-      },
-    });
+    return ctx.json({ suggestions: suggestions.map((s) => s.toJSON()) });
   }
+);
 
-  const deleteResult = await suggestion.delete(auth);
-  if (deleteResult.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Failed to delete suggestion.",
-      },
-    });
+app.delete(
+  "/",
+  validate("param", ParamsSchema),
+  validate("query", DeleteSuggestionQuerySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { suggestionSId } = ctx.req.valid("query");
+
+    const suggestion = await SkillSuggestionResource.fetchById(
+      auth,
+      suggestionSId
+    );
+    if (!suggestion) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "skill_not_found",
+          message: "The suggestion was not found.",
+        },
+      });
+    }
+
+    const deleteResult = await suggestion.delete(auth);
+    if (deleteResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to delete suggestion.",
+        },
+      });
+    }
+
+    return ctx.body(null, 204);
   }
-
-  return ctx.body(null, 204);
-});
+);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/skills/[sId]/suggestions.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/[sId]/suggestions.ts
@@ -27,15 +27,6 @@ app.get(
   async (ctx): HandlerResult<PokeListSkillSuggestions> => {
     const auth = ctx.get("auth");
     const { sId } = ctx.req.valid("param");
-    if (!sId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid skill ID.",
-        },
-      });
-    }
 
     const suggestions =
       await SkillSuggestionResource.listBySkillConfigurationId(auth, sId, {

--- a/front-api/routes/poke/workspaces/[wId]/skills/[sId]/versions.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/[sId]/versions.ts
@@ -2,46 +2,56 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SkillWithVersionType } from "@app/types/assistant/skill_configuration";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 export type PokeGetSkillVersions = {
   versions: SkillWithVersionType[];
 };
 
+const ParamsSchema = z.object({
+  sId: z.string(),
+});
+
 // Mounted at /api/poke/workspaces/:wId/skills/:sId/versions.
 const app = pokeApp();
 
-app.get("/", async (ctx): HandlerResult<PokeGetSkillVersions> => {
-  const auth = ctx.get("auth");
-  const sId = ctx.req.param("sId");
-  if (!sId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid skill ID.",
-      },
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<PokeGetSkillVersions> => {
+    const auth = ctx.get("auth");
+    const { sId } = ctx.req.valid("param");
+    if (!sId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid skill ID.",
+        },
+      });
+    }
+
+    const skill = await SkillResource.fetchById(auth, sId);
+    if (!skill) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "skill_not_found",
+          message: "Skill not found.",
+        },
+      });
+    }
+
+    const versions = await skill.listVersions(auth);
+
+    return ctx.json({
+      versions: versions.map((v) => ({
+        ...v.toJSON(auth),
+        version: v.version,
+      })),
     });
   }
-
-  const skill = await SkillResource.fetchById(auth, sId);
-  if (!skill) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "skill_not_found",
-        message: "Skill not found.",
-      },
-    });
-  }
-
-  const versions = await skill.listVersions(auth);
-
-  return ctx.json({
-    versions: versions.map((v) => ({
-      ...v.toJSON(auth),
-      version: v.version,
-    })),
-  });
-});
+);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/skills/[sId]/versions.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/[sId]/versions.ts
@@ -22,15 +22,6 @@ app.get(
   async (ctx): HandlerResult<PokeGetSkillVersions> => {
     const auth = ctx.get("auth");
     const { sId } = ctx.req.valid("param");
-    if (!sId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid skill ID.",
-        },
-      });
-    }
 
     const skill = await SkillResource.fetchById(auth, sId);
     if (!skill) {

--- a/front-api/routes/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front-api/routes/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
@@ -27,6 +27,11 @@ const ContentNodesBodySchema = z
     message: "Cannot fetch with parentId and internalIds at the same time.",
   });
 
+const ParamsSchema = z.object({
+  dsvId: z.string(),
+  spaceId: z.string(),
+});
+
 export type PokeGetDataSourceViewContentNodes = {
   nodes: DataSourceViewContentNode[];
   total: number;
@@ -39,11 +44,11 @@ const app = pokeApp();
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   validate("json", ContentNodesBodySchema),
   async (ctx): HandlerResult<PokeGetDataSourceViewContentNodes> => {
     const auth = ctx.get("auth");
-    const dsvId = ctx.req.param("dsvId") ?? "";
-    const spaceId = ctx.req.param("spaceId") ?? "";
+    const { dsvId, spaceId } = ctx.req.valid("param");
 
     const dataSourceView = await DataSourceViewResource.fetchById(auth, dsvId);
     if (

--- a/front-api/routes/poke/workspaces/[wId]/spaces/[spaceId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/spaces/[spaceId]/details.ts
@@ -7,6 +7,8 @@ import type { PodMetadataType } from "@app/types/project_metadata";
 import type { UserTypeWithWorkspaces } from "@app/types/user";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 export type PokeGetSpaceDetails = {
   members: Record<string, UserTypeWithWorkspaces[]>;
@@ -14,52 +16,60 @@ export type PokeGetSpaceDetails = {
   space: PokeSpaceType;
 };
 
+const ParamsSchema = z.object({
+  spaceId: z.string(),
+});
+
 // Mounted at /api/poke/workspaces/:wId/spaces/:spaceId/details.
 const app = pokeApp();
 
-app.get("/", async (ctx): HandlerResult<PokeGetSpaceDetails> => {
-  const auth = ctx.get("auth");
-  const spaceId = ctx.req.param("spaceId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<PokeGetSpaceDetails> => {
+    const auth = ctx.get("auth");
+    const { spaceId } = ctx.req.valid("param");
 
-  const space = await SpaceResource.fetchById(auth, spaceId);
-  if (!space) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "space_not_found",
-        message: "Space not found.",
-      },
+    const space = await SpaceResource.fetchById(auth, spaceId);
+    if (!space) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "space_not_found",
+          message: "Space not found.",
+        },
+      });
+    }
+
+    const members: Record<string, UserTypeWithWorkspaces[]> = {};
+
+    const allGroups = space.groups.filter((g) =>
+      space.managementMode === "manual"
+        ? g.kind === "regular" || g.kind === "space_editors"
+        : g.kind === "provisioned"
+    );
+
+    const memberships = await getMembers(auth);
+    const memberById = new Map(memberships.members.map((m) => [m.sId, m]));
+
+    for (const group of allGroups) {
+      const groupMembers = await group.getActiveMembers(auth);
+      members[group.name] = groupMembers.flatMap((user) => {
+        const member = memberById.get(user.sId);
+        return member ? [member] : [];
+      });
+    }
+
+    const metadata = space.isProject()
+      ? await ProjectMetadataResource.fetchBySpace(auth, space)
+      : null;
+
+    return ctx.json({
+      members,
+      metadata: metadata ? metadata.toJSON() : null,
+      space: spaceToPokeJSON(space),
     });
   }
-
-  const members: Record<string, UserTypeWithWorkspaces[]> = {};
-
-  const allGroups = space.groups.filter((g) =>
-    space.managementMode === "manual"
-      ? g.kind === "regular" || g.kind === "space_editors"
-      : g.kind === "provisioned"
-  );
-
-  const memberships = await getMembers(auth);
-  const memberById = new Map(memberships.members.map((m) => [m.sId, m]));
-
-  for (const group of allGroups) {
-    const groupMembers = await group.getActiveMembers(auth);
-    members[group.name] = groupMembers.flatMap((user) => {
-      const member = memberById.get(user.sId);
-      return member ? [member] : [];
-    });
-  }
-
-  const metadata = space.isProject()
-    ? await ProjectMetadataResource.fetchBySpace(auth, space)
-    : null;
-
-  return ctx.json({
-    members,
-    metadata: metadata ? metadata.toJSON() : null,
-    space: spaceToPokeJSON(space),
-  });
-});
+);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/details.ts
@@ -28,15 +28,6 @@ app.get(
   async (ctx): HandlerResult<PokeGetTriggerDetails> => {
     const auth = ctx.get("auth");
     const { tId } = ctx.req.valid("param");
-    if (!tId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid trigger ID.",
-        },
-      });
-    }
 
     const trigger = await TriggerResource.fetchById(auth, tId);
     if (!trigger) {

--- a/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/details.ts
@@ -6,6 +6,8 @@ import type { TriggerType } from "@app/types/assistant/triggers";
 import type { UserType } from "@app/types/user";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 export type PokeGetTriggerDetails = {
   trigger: TriggerType;
@@ -13,57 +15,65 @@ export type PokeGetTriggerDetails = {
   editorUser: UserType | null;
 };
 
+const ParamsSchema = z.object({
+  tId: z.string(),
+});
+
 // Mounted at /api/poke/workspaces/:wId/triggers/:tId/details.
 const app = pokeApp();
 
-app.get("/", async (ctx): HandlerResult<PokeGetTriggerDetails> => {
-  const auth = ctx.get("auth");
-  const tId = ctx.req.param("tId");
-  if (!tId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid trigger ID.",
-      },
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<PokeGetTriggerDetails> => {
+    const auth = ctx.get("auth");
+    const { tId } = ctx.req.valid("param");
+    if (!tId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid trigger ID.",
+        },
+      });
+    }
+
+    const trigger = await TriggerResource.fetchById(auth, tId);
+    if (!trigger) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "trigger_not_found",
+          message: "Trigger not found.",
+        },
+      });
+    }
+
+    const agentConfiguration = await getAgentConfiguration(auth, {
+      agentId: trigger.agentConfigurationId,
+      variant: "full",
+    });
+    if (!agentConfiguration) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "Agent configuration not found.",
+        },
+      });
+    }
+
+    const editorUsers = trigger.editor
+      ? await UserResource.fetchByModelIds([trigger.editor])
+      : [];
+    const editorUser = editorUsers.length > 0 ? editorUsers[0].toJSON() : null;
+
+    return ctx.json({
+      trigger: trigger.toJSON(),
+      agent: agentConfiguration,
+      editorUser,
     });
   }
-
-  const trigger = await TriggerResource.fetchById(auth, tId);
-  if (!trigger) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "trigger_not_found",
-        message: "Trigger not found.",
-      },
-    });
-  }
-
-  const agentConfiguration = await getAgentConfiguration(auth, {
-    agentId: trigger.agentConfigurationId,
-    variant: "full",
-  });
-  if (!agentConfiguration) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "Agent configuration not found.",
-      },
-    });
-  }
-
-  const editorUsers = trigger.editor
-    ? await UserResource.fetchByModelIds([trigger.editor])
-    : [];
-  const editorUser = editorUsers.length > 0 ? editorUsers[0].toJSON() : null;
-
-  return ctx.json({
-    trigger: trigger.toJSON(),
-    agent: agentConfiguration,
-    editorUser,
-  });
-});
+);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/execution_stats.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/execution_stats.ts
@@ -2,6 +2,8 @@ import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 export type PokeGetTriggerExecutionStats = {
   statusBreakdown: Record<string, number>;
@@ -14,42 +16,50 @@ export type PokeGetTriggerExecutionStats = {
   }>;
 };
 
+const ParamsSchema = z.object({
+  tId: z.string(),
+});
+
 // Mounted at /api/poke/workspaces/:wId/triggers/:tId/execution_stats.
 const app = pokeApp();
 
-app.get("/", async (ctx): HandlerResult<PokeGetTriggerExecutionStats> => {
-  const auth = ctx.get("auth");
-  const tId = ctx.req.param("tId");
-  if (!tId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid trigger ID.",
-      },
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<PokeGetTriggerExecutionStats> => {
+    const auth = ctx.get("auth");
+    const { tId } = ctx.req.valid("param");
+    if (!tId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid trigger ID.",
+        },
+      });
+    }
+
+    const trigger = await TriggerResource.fetchById(auth, tId);
+    if (!trigger) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "trigger_not_found",
+          message: "Trigger not found.",
+        },
+      });
+    }
+
+    const stats = await WebhookRequestResource.getExecutionStatsForTrigger(
+      auth,
+      trigger.id
+    );
+
+    return ctx.json({
+      statusBreakdown: stats.statusBreakdown,
+      dailyVolume: stats.dailyVolume,
     });
   }
-
-  const trigger = await TriggerResource.fetchById(auth, tId);
-  if (!trigger) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "trigger_not_found",
-        message: "Trigger not found.",
-      },
-    });
-  }
-
-  const stats = await WebhookRequestResource.getExecutionStatsForTrigger(
-    auth,
-    trigger.id
-  );
-
-  return ctx.json({
-    statusBreakdown: stats.statusBreakdown,
-    dailyVolume: stats.dailyVolume,
-  });
-});
+);
 
 export default app;

--- a/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/execution_stats.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/execution_stats.ts
@@ -29,15 +29,6 @@ app.get(
   async (ctx): HandlerResult<PokeGetTriggerExecutionStats> => {
     const auth = ctx.get("auth");
     const { tId } = ctx.req.valid("param");
-    if (!tId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid trigger ID.",
-        },
-      });
-    }
 
     const trigger = await TriggerResource.fetchById(auth, tId);
     if (!trigger) {

--- a/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/webhook_requests.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/webhook_requests.ts
@@ -38,15 +38,6 @@ app.get(
   async (ctx): HandlerResult<PokeGetWebhookRequestsResponseBody> => {
     const auth = ctx.get("auth");
     const { tId } = ctx.req.valid("param");
-    if (!tId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid trigger ID.",
-        },
-      });
-    }
 
     const trigger = await TriggerResource.fetchById(auth, tId);
     if (!trigger) {

--- a/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/webhook_requests.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/webhook_requests.ts
@@ -24,15 +24,20 @@ const WebhookRequestsQuerySchema = z.object({
   status: z.enum(WEBHOOK_REQUEST_TRIGGER_STATUSES).optional(),
 });
 
+const ParamsSchema = z.object({
+  tId: z.string(),
+});
+
 // Mounted at /api/poke/workspaces/:wId/triggers/:tId/webhook_requests.
 const app = pokeApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   validate("query", WebhookRequestsQuerySchema),
   async (ctx): HandlerResult<PokeGetWebhookRequestsResponseBody> => {
     const auth = ctx.get("auth");
-    const tId = ctx.req.param("tId");
+    const { tId } = ctx.req.valid("param");
     if (!tId) {
       return apiError(ctx, {
         status_code: 400,

--- a/front-api/routes/poke/workspaces/[wId]/webhook_sources/[wsId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/webhook_sources/[wsId]/details.ts
@@ -31,15 +31,6 @@ app.get(
   async (ctx): HandlerResult<PokeGetWebhookSourceDetails> => {
     const auth = ctx.get("auth");
     const { wsId } = ctx.req.valid("param");
-    if (!wsId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid webhook source ID.",
-        },
-      });
-    }
 
     const source = await WebhookSourceResource.fetchById(auth, wsId);
     if (!source) {

--- a/front-api/routes/poke/workspaces/[wId]/webhook_sources/[wsId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/webhook_sources/[wsId]/details.ts
@@ -8,6 +8,8 @@ import type {
 import type { UserType } from "@app/types/user";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 export type PokeGetWebhookSourceDetails = {
   webhookSource: WebhookSourceForAdminType;
@@ -16,36 +18,44 @@ export type PokeGetWebhookSourceDetails = {
   requestStats: { last24h: number; last7d: number; last30d: number };
 };
 
+const ParamsSchema = z.object({
+  wsId: z.string(),
+});
+
 // Mounted at /api/poke/workspaces/:wId/webhook_sources/:wsId/details.
 const app = pokeApp();
 
-app.get("/", async (ctx): HandlerResult<PokeGetWebhookSourceDetails> => {
-  const auth = ctx.get("auth");
-  const wsId = ctx.req.param("wsId");
-  if (!wsId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid webhook source ID.",
-      },
-    });
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<PokeGetWebhookSourceDetails> => {
+    const auth = ctx.get("auth");
+    const { wsId } = ctx.req.valid("param");
+    if (!wsId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid webhook source ID.",
+        },
+      });
+    }
+
+    const source = await WebhookSourceResource.fetchById(auth, wsId);
+    if (!source) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "webhook_source_not_found",
+          message: "Webhook source not found.",
+        },
+      });
+    }
+
+    const details = await getWebhookSourceAdminDetails(auth, source);
+
+    return ctx.json(details);
   }
-
-  const source = await WebhookSourceResource.fetchById(auth, wsId);
-  if (!source) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "webhook_source_not_found",
-        message: "Webhook source not found.",
-      },
-    });
-  }
-
-  const details = await getWebhookSourceAdminDetails(auth, source);
-
-  return ctx.json(details);
-});
+);
 
 export default app;

--- a/front-api/routes/share/frame/[token].ts
+++ b/front-api/routes/share/frame/[token].ts
@@ -8,6 +8,8 @@ import { isInteractiveContentType } from "@app/types/files";
 import { createHono } from "@front-api/lib/hono";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 export interface GetShareFrameMetadataResponseBody {
   requiresEmailVerification: boolean;
@@ -18,115 +20,123 @@ export interface GetShareFrameMetadataResponseBody {
   workspaceName: string;
 }
 
+const ParamsSchema = z.object({
+  token: z.string(),
+});
+
 const app = createHono();
 
-app.get("/", async (ctx): HandlerResult<GetShareFrameMetadataResponseBody> => {
-  const token = ctx.req.param("token");
-  if (!token) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Missing token parameter.",
-      },
-    });
-  }
-
-  const result = await FileResource.fetchByShareToken(token);
-  if (result.isErr()) {
-    if (result.error.code === "file_not_found") {
-      // Not found locally — check other region.
-      const lookupResult = await lookupShareToken(token);
-      if (lookupResult.isErr()) {
-        logger.error(
-          { err: lookupResult.error },
-          "Failed to lookup share token in other region"
-        );
-      }
-      if (lookupResult.isOk() && lookupResult.value) {
-        const region = lookupResult.value;
-        return ctx.json(
-          {
-            error: {
-              type: "workspace_in_different_region",
-              message: "File is located in a different region",
-              redirect: {
-                region,
-                url: regionConfig.getRegionUrl(region),
-              },
-            },
-          },
-          400
-        );
-      }
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetShareFrameMetadataResponseBody> => {
+    const { token } = ctx.req.valid("param");
+    if (!token) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Missing token parameter.",
+        },
+      });
     }
 
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "file_not_found",
-        message: "File not found.",
-      },
+    const result = await FileResource.fetchByShareToken(token);
+    if (result.isErr()) {
+      if (result.error.code === "file_not_found") {
+        // Not found locally — check other region.
+        const lookupResult = await lookupShareToken(token);
+        if (lookupResult.isErr()) {
+          logger.error(
+            { err: lookupResult.error },
+            "Failed to lookup share token in other region"
+          );
+        }
+        if (lookupResult.isOk() && lookupResult.value) {
+          const region = lookupResult.value;
+          return ctx.json(
+            {
+              error: {
+                type: "workspace_in_different_region",
+                message: "File is located in a different region",
+                redirect: {
+                  region,
+                  url: regionConfig.getRegionUrl(region),
+                },
+              },
+            },
+            400
+          );
+        }
+      }
+
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "file_not_found",
+          message: "File not found.",
+        },
+      });
+    }
+
+    const { file, shareScope } = result.value;
+
+    // Only allow Frame files.
+    if (!isInteractiveContentType(file.contentType)) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Only Frame files can be shared.",
+        },
+      });
+    }
+
+    const workspace = await WorkspaceResource.fetchByModelId(file.workspaceId);
+    if (!workspace) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "file_not_found",
+          message: "File not found.",
+        },
+      });
+    }
+
+    // If file is shared publicly, ensure workspace allows it.
+    if (
+      shareScope === "public" &&
+      !workspace.canShareInteractiveContentPublicly
+    ) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "file_not_found",
+          message: "File not found.",
+        },
+      });
+    }
+
+    const shareUrl = `${config.getAppUrl()}/share/frame/${token}`;
+
+    // Only show the email verification form if the scope supports email
+    // invites AND there are active grants.
+    const isEmailScope =
+      shareScope === "emails_only" || shareScope === "workspace_and_emails";
+    const hasActiveGrants = isEmailScope
+      ? (await file.listActiveSharingGrants()).length > 0
+      : false;
+    const requiresEmailVerification = isEmailScope && hasActiveGrants;
+
+    return ctx.json({
+      requiresEmailVerification,
+      shareUrl,
+      title: file.fileName,
+      vizUrl: config.getVizPublicUrl(),
+      workspaceId: workspace.sId,
+      workspaceName: workspace.name,
     });
   }
-
-  const { file, shareScope } = result.value;
-
-  // Only allow Frame files.
-  if (!isInteractiveContentType(file.contentType)) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Only Frame files can be shared.",
-      },
-    });
-  }
-
-  const workspace = await WorkspaceResource.fetchByModelId(file.workspaceId);
-  if (!workspace) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "file_not_found",
-        message: "File not found.",
-      },
-    });
-  }
-
-  // If file is shared publicly, ensure workspace allows it.
-  if (
-    shareScope === "public" &&
-    !workspace.canShareInteractiveContentPublicly
-  ) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "file_not_found",
-        message: "File not found.",
-      },
-    });
-  }
-
-  const shareUrl = `${config.getAppUrl()}/share/frame/${token}`;
-
-  // Only show the email verification form if the scope supports email
-  // invites AND there are active grants.
-  const isEmailScope =
-    shareScope === "emails_only" || shareScope === "workspace_and_emails";
-  const hasActiveGrants = isEmailScope
-    ? (await file.listActiveSharingGrants()).length > 0
-    : false;
-  const requiresEmailVerification = isEmailScope && hasActiveGrants;
-
-  return ctx.json({
-    requiresEmailVerification,
-    shareUrl,
-    title: file.fileName,
-    vizUrl: config.getVizPublicUrl(),
-    workspaceId: workspace.sId,
-    workspaceName: workspace.name,
-  });
-});
+);
 
 export default app;

--- a/front-api/routes/share/frame/[token].ts
+++ b/front-api/routes/share/frame/[token].ts
@@ -31,15 +31,6 @@ app.get(
   validate("param", ParamsSchema),
   async (ctx): HandlerResult<GetShareFrameMetadataResponseBody> => {
     const { token } = ctx.req.valid("param");
-    if (!token) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Missing token parameter.",
-        },
-      });
-    }
 
     const result = await FileResource.fetchByShareToken(token);
     if (result.isErr()) {

--- a/front-api/routes/templates/[tId]/index.ts
+++ b/front-api/routes/templates/[tId]/index.ts
@@ -18,15 +18,6 @@ app.get(
   validate("param", ParamsSchema),
   async (ctx): HandlerResult<FetchAgentTemplateResponse> => {
     const { tId: templateId } = ctx.req.valid("param");
-    if (!templateId) {
-      return apiError(ctx, {
-        status_code: 404,
-        api_error: {
-          type: "template_not_found",
-          message: "Template not found.",
-        },
-      });
-    }
 
     const template = await TemplateResource.fetchByExternalId(templateId);
     if (!template || !template.isPublished()) {

--- a/front-api/routes/templates/[tId]/index.ts
+++ b/front-api/routes/templates/[tId]/index.ts
@@ -1,36 +1,46 @@
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import { createHono } from "@front-api/lib/hono";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 export type FetchAgentTemplateResponse = ReturnType<TemplateResource["toJSON"]>;
+
+const ParamsSchema = z.object({
+  tId: z.string(),
+});
 
 // Mounted at /api/templates/:tId.
 const app = createHono();
 
-app.get("/", async (ctx): HandlerResult<FetchAgentTemplateResponse> => {
-  const templateId = ctx.req.param("tId");
-  if (!templateId) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "template_not_found",
-        message: "Template not found.",
-      },
-    });
-  }
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<FetchAgentTemplateResponse> => {
+    const { tId: templateId } = ctx.req.valid("param");
+    if (!templateId) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "template_not_found",
+          message: "Template not found.",
+        },
+      });
+    }
 
-  const template = await TemplateResource.fetchByExternalId(templateId);
-  if (!template || !template.isPublished()) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "template_not_found",
-        message: "Template not found.",
-      },
-    });
-  }
+    const template = await TemplateResource.fetchByExternalId(templateId);
+    if (!template || !template.isPublished()) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "template_not_found",
+          message: "Template not found.",
+        },
+      });
+    }
 
-  return ctx.json(template.toJSON());
-});
+    return ctx.json(template.toJSON());
+  }
+);
 
 export default app;

--- a/front-api/routes/user/metadata/[key]/index.ts
+++ b/front-api/routes/user/metadata/[key]/index.ts
@@ -22,6 +22,10 @@ const PostUserMetadataBodySchema = z.object({
   value: z.string(),
 });
 
+const ParamsSchema = z.object({
+  key: z.string(),
+});
+
 // Mounted at /api/user/metadata/:key. sessionAuth is applied by the parent
 // `/api/user` sub-app.
 const app = sessionApp();
@@ -73,19 +77,24 @@ async function loadUserAndWorkspace(
   return { u, workspaceModelId };
 }
 
-app.get("/", async (ctx): HandlerResult<GetUserMetadataResponseBody> => {
-  const r = await loadUserAndWorkspace(ctx);
-  if ("err" in r) {
-    return r.err;
-  }
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetUserMetadataResponseBody> => {
+    const r = await loadUserAndWorkspace(ctx);
+    if ("err" in r) {
+      return r.err;
+    }
 
-  const key = ctx.req.param("key") ?? "";
-  const metadata = await r.u.getMetadata(key, r.workspaceModelId);
-  return ctx.json({ metadata });
-});
+    const { key } = ctx.req.valid("param");
+    const metadata = await r.u.getMetadata(key, r.workspaceModelId);
+    return ctx.json({ metadata });
+  }
+);
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   validate("json", PostUserMetadataBodySchema),
   async (ctx): HandlerResult<PostUserMetadataResponseBody> => {
     const r = await loadUserAndWorkspace(ctx);
@@ -93,20 +102,20 @@ app.post(
       return r.err;
     }
 
-    const key = ctx.req.param("key") ?? "";
+    const { key } = ctx.req.valid("param");
     const { value } = ctx.req.valid("json");
     await r.u.setMetadata(key, value, r.workspaceModelId);
     return ctx.json({ metadata: { key, value } });
   }
 );
 
-app.delete("/", async (ctx) => {
+app.delete("/", validate("param", ParamsSchema), async (ctx) => {
   const r = await loadUserAndWorkspace(ctx);
   if ("err" in r) {
     return r.err;
   }
 
-  const key = ctx.req.param("key") ?? "";
+  const { key } = ctx.req.valid("param");
   await r.u.deleteMetadata({
     key: {
       [Op.like]: `${key}%`,

--- a/front-api/routes/v1/viz/files/[...segments].ts
+++ b/front-api/routes/v1/viz/files/[...segments].ts
@@ -13,7 +13,14 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
 import { unauthedApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import path from "path";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  scope: z.string(),
+  rel: z.string(),
+});
 
 // Mounted at /api/v1/viz/files; serves multi-segment scoped paths only.
 const app = unauthedApp();
@@ -28,9 +35,8 @@ const app = unauthedApp();
  * Single-segment requests (fil_xxx) are routed to [fileId].ts.
  * This catch-all handles multi-segment scoped paths only.
  */
-app.get("/:scope/:rel{.+}", async (ctx) => {
-  const rawScope = ctx.req.param("scope");
-  const rel = ctx.req.param("rel");
+app.get("/:scope/:rel{.+}", validate("param", ParamsSchema), async (ctx) => {
+  const { scope: rawScope, rel } = ctx.req.valid("param");
 
   const scope = parseRawVizScope(rawScope);
   if (!scope) {

--- a/front-api/routes/v1/w/[wId]/assistant/agent_configurations/[sId]/export/yaml.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/agent_configurations/[sId]/export/yaml.ts
@@ -3,7 +3,13 @@ import logger from "@app/logger/logger";
 import type { APIErrorResponse } from "@app/types/error";
 import { publicApiApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import type { TypedResponse } from "hono";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  sId: z.string(),
+});
 
 /**
  * @swagger
@@ -55,13 +61,14 @@ const app = publicApiApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   async (
     ctx
   ): Promise<
     TypedResponse<string, 200, "body"> | TypedResponse<APIErrorResponse>
   > => {
     const auth = ctx.get("auth");
-    const sId = ctx.req.param("sId") ?? "";
+    const { sId } = ctx.req.valid("param");
     const allParams = ctx.req.param();
 
     logger.info(

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -39,6 +39,7 @@ import parents from "./parents";
 const ParamsSchema = z.object({
   dsId: z.string(),
   documentId: z.string(),
+  spaceId: z.string().optional(),
 });
 
 /**
@@ -274,7 +275,7 @@ app.get(
   validate("param", ParamsSchema),
   async (ctx): HandlerResult<GetDocumentResponseType> => {
     const auth = ctx.get("auth");
-    const { dsId, documentId } = ctx.req.valid("param");
+    const { dsId, documentId, spaceId: spaceIdParam } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchByNameOrId(
       auth,
@@ -285,7 +286,7 @@ app.get(
 
     const spaceId = await resolveLegacyDataSourceSpaceId(
       auth,
-      ctx.req.param("spaceId"),
+      spaceIdParam,
       dataSource
     );
 
@@ -350,7 +351,7 @@ app.post(
     UpsertDocumentResponseType | { document: { document_id: string } }
   > => {
     const auth = ctx.get("auth");
-    const { dsId, documentId } = ctx.req.valid("param");
+    const { dsId, documentId, spaceId: spaceIdParam } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchByNameOrId(
       auth,
@@ -361,7 +362,7 @@ app.post(
 
     const spaceId = await resolveLegacyDataSourceSpaceId(
       auth,
-      ctx.req.param("spaceId"),
+      spaceIdParam,
       dataSource
     );
 
@@ -726,7 +727,7 @@ app.delete(
   validate("param", ParamsSchema),
   async (ctx): HandlerResult<DeleteDocumentResponseType> => {
     const auth = ctx.get("auth");
-    const { dsId, documentId } = ctx.req.valid("param");
+    const { dsId, documentId, spaceId: spaceIdParam } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchByNameOrId(
       auth,
@@ -737,7 +738,7 @@ app.delete(
 
     const spaceId = await resolveLegacyDataSourceSpaceId(
       auth,
-      ctx.req.param("spaceId"),
+      spaceIdParam,
       dataSource
     );
 

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/parents.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/parents.ts
@@ -79,6 +79,7 @@ const app = publicApiApp();
 const ParamsSchema = z.object({
   dsId: z.string(),
   documentId: z.string(),
+  spaceId: z.string().optional(),
 });
 
 const PostParentsBodySchema = z.object({
@@ -92,7 +93,7 @@ app.post(
   validate("json", PostParentsBodySchema),
   async (ctx): HandlerResult<PostParentsResponseType> => {
     const auth = ctx.get("auth");
-    const { dsId, documentId } = ctx.req.valid("param");
+    const { dsId, documentId, spaceId: spaceIdParam } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchByNameOrId(
       auth,
@@ -103,7 +104,7 @@ app.post(
 
     const spaceId = await resolveLegacyDataSourceSpaceId(
       auth,
-      ctx.req.param("spaceId"),
+      spaceIdParam,
       dataSource
     );
 

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/index.ts
@@ -81,6 +81,7 @@ app.route("/:documentId", documentId);
 
 const ParamsSchema = z.object({
   dsId: z.string(),
+  spaceId: z.string().optional(),
 });
 
 const QuerySchema = z.object({
@@ -94,7 +95,7 @@ app.get(
   validate("query", QuerySchema),
   async (ctx): HandlerResult<GetDocumentsResponseType> => {
     const auth = ctx.get("auth");
-    const { dsId } = ctx.req.valid("param");
+    const { dsId, spaceId: spaceIdParam } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchByNameOrId(
       auth,
@@ -105,7 +106,7 @@ app.get(
 
     const spaceId = await resolveLegacyDataSourceSpaceId(
       auth,
-      ctx.req.param("spaceId"),
+      spaceIdParam,
       dataSource
     );
 

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
@@ -19,6 +19,7 @@ import { z } from "zod";
 const ParamsSchema = z.object({
   dsId: z.string(),
   fId: z.string(),
+  spaceId: z.string().optional(),
 });
 
 /**
@@ -33,12 +34,12 @@ app.get(
   validate("param", ParamsSchema),
   async (ctx): HandlerResult<GetFolderResponseType> => {
     const auth = ctx.get("auth");
-    const { dsId, fId } = ctx.req.valid("param");
+    const { dsId, fId, spaceId: spaceIdParam } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchById(auth, dsId);
     const spaceId = await resolveLegacyDataSourceSpaceId(
       auth,
-      ctx.req.param("spaceId"),
+      spaceIdParam,
       dataSource
     );
 
@@ -88,12 +89,12 @@ app.post(
   validate("json", UpsertDataSourceFolderRequestSchema),
   async (ctx): HandlerResult<UpsertFolderResponseType> => {
     const auth = ctx.get("auth");
-    const { dsId, fId } = ctx.req.valid("param");
+    const { dsId, fId, spaceId: spaceIdParam } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchById(auth, dsId);
     const spaceId = await resolveLegacyDataSourceSpaceId(
       auth,
-      ctx.req.param("spaceId"),
+      spaceIdParam,
       dataSource
     );
 
@@ -220,12 +221,12 @@ app.delete(
   validate("param", ParamsSchema),
   async (ctx): HandlerResult<DeleteFolderResponseType> => {
     const auth = ctx.get("auth");
-    const { dsId, fId } = ctx.req.valid("param");
+    const { dsId, fId, spaceId: spaceIdParam } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchById(auth, dsId);
     const spaceId = await resolveLegacyDataSourceSpaceId(
       auth,
-      ctx.req.param("spaceId"),
+      spaceIdParam,
       dataSource
     );
 

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/index.ts
@@ -23,6 +23,7 @@ app.route("/:fId", fId);
 
 const ParamsSchema = z.object({
   dsId: z.string(),
+  spaceId: z.string().optional(),
 });
 
 const QuerySchema = z.object({
@@ -37,12 +38,12 @@ app.get(
   validate("query", QuerySchema),
   async (ctx): HandlerResult<GetFoldersResponseType> => {
     const auth = ctx.get("auth");
-    const { dsId } = ctx.req.valid("param");
+    const { dsId, spaceId: spaceIdParam } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchById(auth, dsId);
     const spaceId = await resolveLegacyDataSourceSpaceId(
       auth,
-      ctx.req.param("spaceId"),
+      spaceIdParam,
       dataSource
     );
 

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/search.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/search.ts
@@ -15,6 +15,7 @@ import { fromError } from "zod-validation-error";
 
 const ParamsSchema = z.object({
   dsId: z.string(),
+  spaceId: z.string().optional(),
 });
 
 /**
@@ -157,7 +158,7 @@ app.get(
   validate("param", ParamsSchema),
   async (ctx): HandlerResult<DataSourceSearchResponseType> => {
     const auth = ctx.get("auth");
-    const { dsId } = ctx.req.valid("param");
+    const { dsId, spaceId: spaceIdParam } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchByNameOrId(
       auth,
@@ -168,7 +169,7 @@ app.get(
 
     const spaceId = await resolveLegacyDataSourceSpaceId(
       auth,
-      ctx.req.param("spaceId"),
+      spaceIdParam,
       dataSource
     );
 

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/index.ts
@@ -19,6 +19,7 @@ import rows from "./rows";
 const ParamsSchema = z.object({
   dsId: z.string(),
   tId: z.string(),
+  spaceId: z.string().optional(),
 });
 
 /**
@@ -115,7 +116,7 @@ app.get(
     const auth = ctx.get("auth");
     const owner = auth.getNonNullableWorkspace();
 
-    const { dsId, tId } = ctx.req.valid("param");
+    const { dsId, tId, spaceId: spaceIdParam } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchByNameOrId(
       auth,
@@ -126,7 +127,7 @@ app.get(
 
     const spaceId = await resolveLegacyDataSourceSpaceId(
       auth,
-      ctx.req.param("spaceId"),
+      spaceIdParam,
       dataSource
     );
 
@@ -214,7 +215,7 @@ app.delete(
     const auth = ctx.get("auth");
     const owner = auth.getNonNullableWorkspace();
 
-    const { dsId, tId } = ctx.req.valid("param");
+    const { dsId, tId, spaceId: spaceIdParam } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchByNameOrId(
       auth,
@@ -225,7 +226,7 @@ app.delete(
 
     const spaceId = await resolveLegacyDataSourceSpaceId(
       auth,
-      ctx.req.param("spaceId"),
+      spaceIdParam,
       dataSource
     );
 

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/parents.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/parents.ts
@@ -15,6 +15,7 @@ import { z } from "zod";
 const ParamsSchema = z.object({
   dsId: z.string(),
   tId: z.string(),
+  spaceId: z.string().optional(),
 });
 
 /**
@@ -30,7 +31,7 @@ app.post(
   validate("json", PostTableParentsRequestSchema),
   async (ctx): HandlerResult<PostParentsResponseType> => {
     const auth = ctx.get("auth");
-    const { dsId, tId } = ctx.req.valid("param");
+    const { dsId, tId, spaceId: spaceIdParam } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchByNameOrId(
       auth,
@@ -41,7 +42,7 @@ app.post(
 
     const spaceId = await resolveLegacyDataSourceSpaceId(
       auth,
-      ctx.req.param("spaceId"),
+      spaceIdParam,
       dataSource
     );
 

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/rows/[rId].ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/rows/[rId].ts
@@ -14,6 +14,7 @@ const ParamsSchema = z.object({
   dsId: z.string(),
   tId: z.string(),
   rId: z.string(),
+  spaceId: z.string().optional(),
 });
 
 /**
@@ -119,7 +120,7 @@ app.get(
     const auth = ctx.get("auth");
     const owner = auth.getNonNullableWorkspace();
 
-    const { dsId, tId, rId } = ctx.req.valid("param");
+    const { dsId, tId, rId, spaceId: spaceIdParam } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchByNameOrId(
       auth,
@@ -130,7 +131,7 @@ app.get(
 
     const spaceId = await resolveLegacyDataSourceSpaceId(
       auth,
-      ctx.req.param("spaceId"),
+      spaceIdParam,
       dataSource
     );
 
@@ -199,7 +200,7 @@ app.delete(
     const auth = ctx.get("auth");
     const owner = auth.getNonNullableWorkspace();
 
-    const { dsId, tId, rId } = ctx.req.valid("param");
+    const { dsId, tId, rId, spaceId: spaceIdParam } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchByNameOrId(
       auth,
@@ -210,7 +211,7 @@ app.delete(
 
     const spaceId = await resolveLegacyDataSourceSpaceId(
       auth,
-      ctx.req.param("spaceId"),
+      spaceIdParam,
       dataSource
     );
 

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/rows/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/rows/index.ts
@@ -21,6 +21,7 @@ import rId from "./[rId]";
 const ParamsSchema = z.object({
   dsId: z.string(),
   tId: z.string(),
+  spaceId: z.string().optional(),
 });
 
 /**
@@ -175,7 +176,7 @@ app.get(
     const auth = ctx.get("auth");
     const owner = auth.getNonNullableWorkspace();
 
-    const { dsId, tId } = ctx.req.valid("param");
+    const { dsId, tId, spaceId: spaceIdParam } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchByNameOrId(
       auth,
@@ -186,7 +187,7 @@ app.get(
 
     const spaceId = await resolveLegacyDataSourceSpaceId(
       auth,
-      ctx.req.param("spaceId"),
+      spaceIdParam,
       dataSource
     );
 
@@ -258,7 +259,7 @@ app.post(
     const auth = ctx.get("auth");
     const owner = auth.getNonNullableWorkspace();
 
-    const { dsId, tId } = ctx.req.valid("param");
+    const { dsId, tId, spaceId: spaceIdParam } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchByNameOrId(
       auth,
@@ -269,7 +270,7 @@ app.post(
 
     const spaceId = await resolveLegacyDataSourceSpaceId(
       auth,
-      ctx.req.param("spaceId"),
+      spaceIdParam,
       dataSource
     );
 

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.ts
@@ -17,6 +17,7 @@ import { z } from "zod";
 
 const ParamsSchema = z.object({
   dsId: z.string(),
+  spaceId: z.string().optional(),
 });
 
 /**
@@ -36,7 +37,7 @@ app.post(
     PostTableCSVAsyncResponseType | PostTableCSVResponseType
   > => {
     const auth = ctx.get("auth");
-    const { dsId } = ctx.req.valid("param");
+    const { dsId, spaceId: spaceIdParam } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchByNameOrId(
       auth,
@@ -47,7 +48,7 @@ app.post(
 
     const spaceId = await resolveLegacyDataSourceSpaceId(
       auth,
-      ctx.req.param("spaceId"),
+      spaceIdParam,
       dataSource
     );
 

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -25,6 +25,7 @@ import csv from "./csv";
 
 const ParamsSchema = z.object({
   dsId: z.string(),
+  spaceId: z.string().optional(),
 });
 
 /**
@@ -147,7 +148,7 @@ app.get(
     const auth = ctx.get("auth");
     const owner = auth.getNonNullableWorkspace();
 
-    const { dsId } = ctx.req.valid("param");
+    const { dsId, spaceId: spaceIdParam } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchByNameOrId(
       auth,
@@ -158,7 +159,7 @@ app.get(
 
     const spaceId = await resolveLegacyDataSourceSpaceId(
       auth,
-      ctx.req.param("spaceId"),
+      spaceIdParam,
       dataSource
     );
 
@@ -241,7 +242,7 @@ app.post(
     const auth = ctx.get("auth");
     const owner = auth.getNonNullableWorkspace();
 
-    const { dsId } = ctx.req.valid("param");
+    const { dsId, spaceId: spaceIdParam } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchByNameOrId(
       auth,
@@ -252,7 +253,7 @@ app.post(
 
     const spaceId = await resolveLegacyDataSourceSpaceId(
       auth,
-      ctx.req.param("spaceId"),
+      spaceIdParam,
       dataSource
     );
 

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tokenize.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tokenize.ts
@@ -20,6 +20,7 @@ const PostDatasourceTokenizeBodySchema = z.object({
 
 const ParamsSchema = z.object({
   dsId: z.string(),
+  spaceId: z.string().optional(),
 });
 
 /**
@@ -38,7 +39,7 @@ app.post(
   validate("json", PostDatasourceTokenizeBodySchema),
   async (ctx): HandlerResult<TokenizeResponseType> => {
     const auth = ctx.get("auth");
-    const { dsId } = ctx.req.valid("param");
+    const { dsId, spaceId: spaceIdParam } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchByNameOrId(
       auth,
@@ -49,7 +50,7 @@ app.post(
 
     const spaceId = await resolveLegacyDataSourceSpaceId(
       auth,
-      ctx.req.param("spaceId"),
+      spaceIdParam,
       dataSource
     );
 

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -4,8 +4,14 @@ import type { GetDataSourcesResponseType } from "@dust-tt/client";
 import { publicApiApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 import dsId from "./[dsId]";
+
+const ParamsSchema = z.object({
+  spaceId: z.string().optional(),
+});
 
 /**
  * @swagger
@@ -47,34 +53,42 @@ import dsId from "./[dsId]";
  */
 const app = publicApiApp();
 
-app.get("/", async (ctx): HandlerResult<GetDataSourcesResponseType> => {
-  const auth = ctx.get("auth");
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetDataSourcesResponseType> => {
+    const auth = ctx.get("auth");
 
-  // The same handler serves both `/spaces/:spaceId/data_sources` and the
-  // legacy `/data_sources` mount; in the legacy case `spaceId` is undefined
-  // and we fall back to the workspace's global space (matching the Next
-  // `withSpaceFromRoute` legacy behavior).
-  const spaceIdParam = ctx.req.param("spaceId");
-  const space = spaceIdParam
-    ? await SpaceResource.fetchById(auth, spaceIdParam)
-    : await SpaceResource.fetchWorkspaceGlobalSpace(auth);
+    // The same handler serves both `/spaces/:spaceId/data_sources` and the
+    // legacy `/data_sources` mount; in the legacy case `spaceId` is undefined
+    // and we fall back to the workspace's global space (matching the Next
+    // `withSpaceFromRoute` legacy behavior).
+    const { spaceId: spaceIdParam } = ctx.req.valid("param");
+    const space = spaceIdParam
+      ? await SpaceResource.fetchById(auth, spaceIdParam)
+      : await SpaceResource.fetchWorkspaceGlobalSpace(auth);
 
-  if (!space || space.isConversations() || !space.canReadOrAdministrate(auth)) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "space_not_found",
-        message: "The space you requested was not found.",
-      },
+    if (
+      !space ||
+      space.isConversations() ||
+      !space.canReadOrAdministrate(auth)
+    ) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "space_not_found",
+          message: "The space you requested was not found.",
+        },
+      });
+    }
+
+    const dataSources = await DataSourceResource.listBySpace(auth, space);
+
+    return ctx.json({
+      data_sources: dataSources.map((ds) => ds.toJSON()),
     });
   }
-
-  const dataSources = await DataSourceResource.listBySpace(auth, space);
-
-  return ctx.json({
-    data_sources: dataSources.map((ds) => ds.toJSON()),
-  });
-});
+);
 
 app.route("/:dsId", dsId);
 

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
@@ -12,6 +12,10 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 export type GetAgentEditorsResponseBody = {
   editors: UserType[];
 };
@@ -39,88 +43,93 @@ const PatchAgentEditorsRequestBodySchema = z
 // Mounted at /api/w/:wId/assistant/agent_configurations/:aId/editors.
 const app = workspaceApp();
 
-app.get("/", async (ctx): HandlerResult<GetAgentEditorsResponseBody> => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetAgentEditorsResponseBody> => {
+    const auth = ctx.get("auth");
+    const { aId } = ctx.req.valid("param");
 
-  const agent = await getAgentConfiguration(auth, {
-    agentId: aId,
-    variant: "light",
-  });
-  if (!agent) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "The agent configuration was not found.",
-      },
+    const agent = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "light",
     });
-  }
-
-  const editorGroupRes = await GroupResource.findEditorGroupForAgent(
-    auth,
-    agent
-  );
-  if (editorGroupRes.isErr()) {
-    switch (editorGroupRes.error.code) {
-      case "unauthorized":
-        return apiError(ctx, {
-          status_code: 401,
-          api_error: {
-            type: "workspace_auth_error",
-            message: "You are not authorized to update the agent editors.",
-          },
-        });
-      case "invalid_id":
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: "Some of the passed ids are invalid.",
-          },
-        });
-      case "group_not_found":
-        return apiError(ctx, {
-          status_code: 404,
-          api_error: {
-            type: "group_not_found",
-            message: "Unable to find the editor group for the agent.",
-          },
-        });
-      case "internal_error":
-        return apiError(ctx, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: editorGroupRes.error.message,
-          },
-        });
-      default:
-        assertNever(editorGroupRes.error.code);
+    if (!agent) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "The agent configuration was not found.",
+        },
+      });
     }
-  }
 
-  const editorGroup = editorGroupRes.value;
-  if (!editorGroup.canRead(auth)) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "agent_group_permission_error",
-        message: "User is not authorized to read the agent editors.",
-      },
-    });
-  }
+    const editorGroupRes = await GroupResource.findEditorGroupForAgent(
+      auth,
+      agent
+    );
+    if (editorGroupRes.isErr()) {
+      switch (editorGroupRes.error.code) {
+        case "unauthorized":
+          return apiError(ctx, {
+            status_code: 401,
+            api_error: {
+              type: "workspace_auth_error",
+              message: "You are not authorized to update the agent editors.",
+            },
+          });
+        case "invalid_id":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "Some of the passed ids are invalid.",
+            },
+          });
+        case "group_not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: {
+              type: "group_not_found",
+              message: "Unable to find the editor group for the agent.",
+            },
+          });
+        case "internal_error":
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: editorGroupRes.error.message,
+            },
+          });
+        default:
+          assertNever(editorGroupRes.error.code);
+      }
+    }
 
-  const members = await editorGroup.getActiveMembers(auth);
-  return ctx.json({ editors: members.map((m) => m.toJSON()) });
-});
+    const editorGroup = editorGroupRes.value;
+    if (!editorGroup.canRead(auth)) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "agent_group_permission_error",
+          message: "User is not authorized to read the agent editors.",
+        },
+      });
+    }
+
+    const members = await editorGroup.getActiveMembers(auth);
+    return ctx.json({ editors: members.map((m) => m.toJSON()) });
+  }
+);
 
 app.patch(
   "/",
+  validate("param", ParamsSchema),
   validate("json", PatchAgentEditorsRequestBodySchema),
   async (ctx): HandlerResult<PatchAgentEditorsResponseBody> => {
     const auth = ctx.get("auth");
-    const aId = ctx.req.param("aId") ?? "";
+    const { aId } = ctx.req.valid("param");
 
     const agent = await getAgentConfiguration(auth, {
       agentId: aId,

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/export/yaml.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/export/yaml.ts
@@ -2,6 +2,12 @@ import { exportAgentConfigurationAsYAML } from "@app/lib/api/assistant/configura
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
 
 export type GetAgentConfigurationYAMLExportResponseBody = {
   yamlContent: string;
@@ -13,9 +19,10 @@ const app = workspaceApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   async (ctx): HandlerResult<GetAgentConfigurationYAMLExportResponseBody> => {
     const auth = ctx.get("auth");
-    const aId = ctx.req.param("aId") ?? "";
+    const { aId } = ctx.req.valid("param");
 
     const result = await exportAgentConfigurationAsYAML(auth, aId);
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/feedbacks.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/feedbacks.ts
@@ -4,15 +4,21 @@ import { getPaginationParams } from "@app/lib/api/pagination";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 import fId from "./feedbacks/[fId]";
+
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
 
 // Mounted under /api/w/:wId/assistant/agent_configurations/:aId/feedbacks.
 const app = workspaceApp();
 
-app.get("/", async (ctx) => {
+app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
+  const { aId } = ctx.req.valid("param");
 
   // IMPORTANT: make sure the agent configuration is accessible by the user.
   const agentConfiguration = await getAgentConfiguration(auth, {

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/feedbacks/[fId].ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/feedbacks/[fId].ts
@@ -7,6 +7,11 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+  fId: z.string(),
+});
+
 const PatchBodySchema = z.object({
   dismissed: z.boolean(),
 });
@@ -14,69 +19,73 @@ const PatchBodySchema = z.object({
 // Mounted at /api/w/:wId/assistant/agent_configurations/:aId/feedbacks/:fId.
 const app = workspaceApp();
 
-app.patch("/", validate("json", PatchBodySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
-  const fId = ctx.req.param("fId") ?? "";
+app.patch(
+  "/",
+  validate("param", ParamsSchema),
+  validate("json", PatchBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { aId, fId } = ctx.req.valid("param");
 
-  const agentConfiguration = await getAgentConfiguration(auth, {
-    agentId: aId,
-    variant: "light",
-  });
-  if (!agentConfiguration) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "The agent configuration was not found.",
-      },
+    const agentConfiguration = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "light",
     });
-  }
+    if (!agentConfiguration) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "The agent configuration was not found.",
+        },
+      });
+    }
 
-  if (!agentConfiguration.canEdit && !auth.isBuilder()) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "Only editors can modify agent feedback.",
-      },
+    if (!agentConfiguration.canEdit && !auth.isBuilder()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "app_auth_error",
+          message: "Only editors can modify agent feedback.",
+        },
+      });
+    }
+
+    const feedback = await AgentMessageFeedbackResource.fetchById(auth, {
+      feedbackId: fId,
+      agentConfigurationId: aId,
     });
+    if (!feedback) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "The feedback was not found.",
+        },
+      });
+    }
+
+    const { dismissed } = ctx.req.valid("json");
+
+    if (dismissed) {
+      await feedback.dismiss();
+    } else {
+      await feedback.undismiss();
+    }
+
+    const { conversationId, messageId: agentMessageId } =
+      await getMessageConversationId(auth, {
+        messageId: feedback.agentMessageId,
+      });
+
+    if (conversationId && agentMessageId) {
+      await launchAgentMessageFeedbackWorkflow(auth, {
+        message: { conversationId, agentMessageId },
+      });
+    }
+
+    return ctx.json({ success: true });
   }
-
-  const feedback = await AgentMessageFeedbackResource.fetchById(auth, {
-    feedbackId: fId,
-    agentConfigurationId: aId,
-  });
-  if (!feedback) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "The feedback was not found.",
-      },
-    });
-  }
-
-  const { dismissed } = ctx.req.valid("json");
-
-  if (dismissed) {
-    await feedback.dismiss();
-  } else {
-    await feedback.undismiss();
-  }
-
-  const { conversationId, messageId: agentMessageId } =
-    await getMessageConversationId(auth, {
-      messageId: feedback.agentMessageId,
-    });
-
-  if (conversationId && agentMessageId) {
-    await launchAgentMessageFeedbackWorkflow(auth, {
-      message: { conversationId, agentMessageId },
-    });
-  }
-
-  return ctx.json({ success: true });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/history/index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/history/index.ts
@@ -7,7 +7,13 @@ import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 import { fromError } from "zod-validation-error";
+
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
 
 export type GetAgentConfigurationsResponseBody = {
   history: LightAgentConfigurationType[];
@@ -16,66 +22,70 @@ export type GetAgentConfigurationsResponseBody = {
 // Mounted at /api/w/:wId/assistant/agent_configurations/:aId/history.
 const app = workspaceApp();
 
-app.get("/", async (ctx): HandlerResult<GetAgentConfigurationsResponseBody> => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetAgentConfigurationsResponseBody> => {
+    const auth = ctx.get("auth");
+    const { aId } = ctx.req.valid("param");
 
-  const assistant = await getAgentConfiguration(auth, {
-    agentId: aId,
-    variant: "light",
-  });
-  if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "The agent you're trying to access was not found.",
-      },
+    const assistant = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "light",
     });
-  }
+    if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "The agent you're trying to access was not found.",
+        },
+      });
+    }
 
-  // The schema expects `limit` as a number; query params arrive as strings,
-  // so we parseInt before validation (matches the Next-side handler).
-  const queryRaw = ctx.req.query();
-  const queryValidation = GetAgentConfigurationsHistoryQuerySchema.safeParse({
-    ...queryRaw,
-    limit:
-      typeof queryRaw.limit === "string"
-        ? parseInt(queryRaw.limit, 10)
-        : undefined,
-  });
-  if (!queryValidation.success) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: `Invalid query parameters: ${fromError(queryValidation.error).toString()}`,
-      },
+    // The schema expects `limit` as a number; query params arrive as strings,
+    // so we parseInt before validation (matches the Next-side handler).
+    const queryRaw = ctx.req.query();
+    const queryValidation = GetAgentConfigurationsHistoryQuerySchema.safeParse({
+      ...queryRaw,
+      limit:
+        typeof queryRaw.limit === "string"
+          ? parseInt(queryRaw.limit, 10)
+          : undefined,
     });
-  }
+    if (!queryValidation.success) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `Invalid query parameters: ${fromError(queryValidation.error).toString()}`,
+        },
+      });
+    }
 
-  const { limit } = queryValidation.data;
+    const { limit } = queryValidation.data;
 
-  let agentConfigurations = await listsAgentConfigurationVersions(auth, {
-    agentId: aId,
-    variant: "light",
-  });
-
-  if (limit) {
-    agentConfigurations = agentConfigurations.slice(0, limit);
-  }
-
-  if (!agentConfigurations || !agentConfigurations[0].canRead) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "The agent you're trying to access was not found.",
-      },
+    let agentConfigurations = await listsAgentConfigurationVersions(auth, {
+      agentId: aId,
+      variant: "light",
     });
-  }
 
-  return ctx.json({ history: agentConfigurations });
-});
+    if (limit) {
+      agentConfigurations = agentConfigurations.slice(0, limit);
+    }
+
+    if (!agentConfigurations || !agentConfigurations[0].canRead) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "The agent you're trying to access was not found.",
+        },
+      });
+    }
+
+    return ctx.json({ history: agentConfigurations });
+  }
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/index.ts
@@ -11,6 +11,7 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 import editors from "./editors";
 import exportRoutes from "./export";
@@ -28,6 +29,10 @@ import tags from "./tags";
 import triggers from "./triggers";
 import usage from "./usage";
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 export type GetAgentConfigurationResponseBody = {
   agentConfiguration: AgentConfigurationType;
 };
@@ -40,38 +45,43 @@ export type DeleteAgentConfigurationResponseBody = {
 // `/` handles GET, PATCH, and DELETE on the agent itself.
 const app = workspaceApp();
 
-app.get("/", async (ctx): HandlerResult<GetAgentConfigurationResponseBody> => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetAgentConfigurationResponseBody> => {
+    const auth = ctx.get("auth");
+    const { aId } = ctx.req.valid("param");
 
-  const agent = await getAgentConfiguration(auth, {
-    agentId: aId,
-    variant: "full",
-  });
-  if (!agent || (!agent.canRead && !auth.isAdmin())) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "The Agent you're trying to access was not found.",
+    const agent = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "full",
+    });
+    if (!agent || (!agent.canRead && !auth.isAdmin())) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "The Agent you're trying to access was not found.",
+        },
+      });
+    }
+
+    return ctx.json({
+      agentConfiguration: {
+        ...agent,
+        lastAuthors: await getAgentRecentAuthors({ agent, auth }),
       },
     });
   }
-
-  return ctx.json({
-    agentConfiguration: {
-      ...agent,
-      lastAuthors: await getAgentRecentAuthors({ agent, auth }),
-    },
-  });
-});
+);
 
 app.patch(
   "/",
+  validate("param", ParamsSchema),
   validate("json", PostOrPatchAgentConfigurationRequestBodySchema),
   async (ctx): HandlerResult<GetAgentConfigurationResponseBody> => {
     const auth = ctx.get("auth");
-    const aId = ctx.req.param("aId") ?? "";
+    const { aId } = ctx.req.valid("param");
     const body = ctx.req.valid("json");
 
     const agent = await getAgentConfiguration(auth, {
@@ -137,9 +147,10 @@ app.patch(
 
 app.delete(
   "/",
+  validate("param", ParamsSchema),
   async (ctx): HandlerResult<DeleteAgentConfigurationResponseBody> => {
     const auth = ctx.get("auth");
-    const aId = ctx.req.param("aId") ?? "";
+    const { aId } = ctx.req.valid("param");
 
     const agent = await getAgentConfiguration(auth, {
       agentId: aId,

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/last_author.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/last_author.ts
@@ -4,6 +4,12 @@ import type { UserType } from "@app/types/user";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
 
 export type GetAgentLastAuthorResponseBody = {
   user: UserType | null;
@@ -12,35 +18,39 @@ export type GetAgentLastAuthorResponseBody = {
 // Mounted at /api/w/:wId/assistant/agent_configurations/:aId/last_author.
 const app = workspaceApp();
 
-app.get("/", async (ctx): HandlerResult<GetAgentLastAuthorResponseBody> => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetAgentLastAuthorResponseBody> => {
+    const auth = ctx.get("auth");
+    const { aId } = ctx.req.valid("param");
 
-  const agentConfiguration = await getAgentConfiguration(auth, {
-    agentId: aId,
-    variant: "light",
-  });
-  if (!agentConfiguration) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "The agent you're trying to access was not found.",
-      },
+    const agentConfiguration = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "light",
+    });
+    if (!agentConfiguration) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "The agent you're trying to access was not found.",
+        },
+      });
+    }
+
+    if (!agentConfiguration.versionAuthorId) {
+      return ctx.json({ user: null });
+    }
+
+    const agentLastAuthor = await UserResource.fetchByModelIds([
+      agentConfiguration.versionAuthorId,
+    ]);
+
+    return ctx.json({
+      user: agentLastAuthor[0] ? agentLastAuthor[0].toJSON() : null,
     });
   }
-
-  if (!agentConfiguration.versionAuthorId) {
-    return ctx.json({ user: null });
-  }
-
-  const agentLastAuthor = await UserResource.fetchByModelIds([
-    agentConfiguration.versionAuthorId,
-  ]);
-
-  return ctx.json({
-    user: agentLastAuthor[0] ? agentLastAuthor[0].toJSON() : null,
-  });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
@@ -12,6 +12,10 @@ import { validate } from "@front-api/middlewares/validator";
 import type { SuccessResponseBody } from "@front-api/routes/types";
 import { z } from "zod";
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 const PatchLinkedSlackChannelsRequestBodySchema = z.object({
   slack_channel_internal_ids: z.array(z.string()),
   provider: z.enum(["slack", "slack_bot"]),
@@ -23,11 +27,12 @@ const app = workspaceApp();
 
 app.patch(
   "/",
+  validate("param", ParamsSchema),
   ensureIsBuilder(),
   validate("json", PatchLinkedSlackChannelsRequestBodySchema),
   async (ctx): HandlerResult<SuccessResponseBody> => {
     const auth = ctx.get("auth");
-    const aId = ctx.req.param("aId") ?? "";
+    const { aId } = ctx.req.valid("param");
     const body = ctx.req.valid("json");
 
     if (body.auto_respond_without_mention) {

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/mcp_configurations.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/mcp_configurations.ts
@@ -4,6 +4,12 @@ import { listAgentMcpConfigurationsForAgent } from "@app/lib/api/assistant/mcp_c
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
 
 export type GetAgentMcpConfigurationsResponseBody = {
   configurations: AgentMcpConfigurationSummary[];
@@ -14,9 +20,10 @@ const app = workspaceApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   async (ctx): HandlerResult<GetAgentMcpConfigurationsResponseBody> => {
     const auth = ctx.get("auth");
-    const aId = ctx.req.param("aId") ?? "";
+    const { aId } = ctx.req.valid("param");
 
     const assistant = await getAgentConfiguration(auth, {
       agentId: aId,

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/memories/[mId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/memories/[mId]/index.ts
@@ -20,6 +20,11 @@ export type PatchAgentMemoryResponseBody = {
   };
 };
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+  mId: z.string(),
+});
+
 const PatchAgentMemoryRequestBodySchema = z.object({
   content: z.string(),
 });
@@ -28,14 +33,13 @@ const PatchAgentMemoryRequestBodySchema = z.object({
 const app = workspaceApp();
 
 async function loadAgentAndMemory(
-  ctx: Context
+  ctx: Context,
+  { aId, mId }: { aId: string; mId: string }
 ): Promise<
   | { ok: true; memory: AgentMemoryResource }
   | { ok: false; response: Response & TypedResponse<APIErrorResponse> }
 > {
   const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
-  const mId = ctx.req.param("mId") ?? "";
 
   const agentConfiguration = await getAgentConfiguration(auth, {
     agentId: aId,
@@ -91,9 +95,10 @@ async function loadAgentAndMemory(
 
 app.patch(
   "/",
+  validate("param", ParamsSchema),
   validate("json", PatchAgentMemoryRequestBodySchema),
   async (ctx): HandlerResult<PatchAgentMemoryResponseBody> => {
-    const r = await loadAgentAndMemory(ctx);
+    const r = await loadAgentAndMemory(ctx, ctx.req.valid("param"));
     if (!r.ok) {
       return r.response;
     }
@@ -106,8 +111,8 @@ app.patch(
   }
 );
 
-app.delete("/", async (ctx) => {
-  const r = await loadAgentAndMemory(ctx);
+app.delete("/", validate("param", ParamsSchema), async (ctx) => {
+  const r = await loadAgentAndMemory(ctx, ctx.req.valid("param"));
   if (!r.ok) {
     return r.response;
   }

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/memories/index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/memories/index.ts
@@ -3,8 +3,14 @@ import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 import mId from "./[mId]";
+
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
 
 // JSON-serializes Date fields to ISO strings on the wire; type reflects wire
 // format. The underlying `AgentMemoryResource.toJSON` returns `lastUpdated:
@@ -20,39 +26,43 @@ export type GetAgentMemoriesResponseBody = {
 // Mounted under /api/w/:wId/assistant/agent_configurations/:aId/memories.
 const app = workspaceApp();
 
-app.get("/", async (ctx): HandlerResult<GetAgentMemoriesResponseBody> => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetAgentMemoriesResponseBody> => {
+    const auth = ctx.get("auth");
+    const { aId } = ctx.req.valid("param");
 
-  const agentConfiguration = await getAgentConfiguration(auth, {
-    agentId: aId,
-    variant: "light",
-  });
-  if (!agentConfiguration || !agentConfiguration.canRead) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "The agent configuration was not found.",
-      },
+    const agentConfiguration = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "light",
     });
-  }
-
-  const user = auth.user();
-  if (!user) {
-    return ctx.json({ memories: [] });
-  }
-
-  const memories = await AgentMemoryResource.findByAgentConfigurationAndUser(
-    auth,
-    {
-      agentConfiguration,
-      user: user.toJSON(),
+    if (!agentConfiguration || !agentConfiguration.canRead) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "The agent configuration was not found.",
+        },
+      });
     }
-  );
 
-  return ctx.json({ memories: memories.map((memory) => memory.toJSON()) });
-});
+    const user = auth.user();
+    if (!user) {
+      return ctx.json({ memories: [] });
+    }
+
+    const memories = await AgentMemoryResource.findByAgentConfigurationAndUser(
+      auth,
+      {
+        agentConfiguration,
+        user: user.toJSON(),
+      }
+    );
+
+    return ctx.json({ memories: memories.map((memory) => memory.toJSON()) });
+  }
+);
 
 app.route("/:mId", mId);
 

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval-documents.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval-documents.ts
@@ -7,6 +7,10 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 const QuerySchema = z.object({
   days: z.coerce.number().positive().default(DEFAULT_PERIOD_DAYS),
   version: z.string().optional(),
@@ -24,53 +28,61 @@ const QuerySchema = z.object({
 // Mounted at /api/w/:wId/assistant/agent_configurations/:aId/observability/datasource-retrieval-documents.
 const app = workspaceApp();
 
-app.get("/", validate("query", QuerySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  validate("query", QuerySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { aId } = ctx.req.valid("param");
 
-  const assistant = await getAgentConfiguration(auth, {
-    agentId: aId,
-    variant: "light",
-  });
-  if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "The agent you're trying to access was not found.",
-      },
+    const assistant = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "light",
     });
+    if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "The agent you're trying to access was not found.",
+        },
+      });
+    }
+
+    const {
+      days,
+      version,
+      mcpServerConfigIds,
+      mcpServerName,
+      dataSourceId,
+      limit,
+    } = ctx.req.valid("query");
+
+    const documentsResult = await fetchDatasourceRetrievalDocumentsMetrics(
+      auth,
+      {
+        agentId: assistant.sId,
+        days,
+        version,
+        mcpServerConfigIds,
+        mcpServerName,
+        dataSourceId,
+        limit,
+      }
+    );
+    if (documentsResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve datasource retrieval documents metrics: ${fromError(documentsResult.error).toString()}`,
+        },
+      });
+    }
+
+    return ctx.json(documentsResult.value);
   }
-
-  const {
-    days,
-    version,
-    mcpServerConfigIds,
-    mcpServerName,
-    dataSourceId,
-    limit,
-  } = ctx.req.valid("query");
-
-  const documentsResult = await fetchDatasourceRetrievalDocumentsMetrics(auth, {
-    agentId: assistant.sId,
-    days,
-    version,
-    mcpServerConfigIds,
-    mcpServerName,
-    dataSourceId,
-    limit,
-  });
-  if (documentsResult.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: `Failed to retrieve datasource retrieval documents metrics: ${fromError(documentsResult.error).toString()}`,
-      },
-    });
-  }
-
-  return ctx.json(documentsResult.value);
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval.ts
@@ -7,6 +7,10 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
   version: z.string().optional(),
@@ -15,48 +19,53 @@ const QuerySchema = z.object({
 // Mounted at /api/w/:wId/assistant/agent_configurations/:aId/observability/datasource-retrieval.
 const app = workspaceApp();
 
-app.get("/", validate("query", QuerySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  validate("query", QuerySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { aId } = ctx.req.valid("param");
 
-  const assistant = await getAgentConfiguration(auth, {
-    agentId: aId,
-    variant: "light",
-  });
-  if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "The agent you're trying to access was not found.",
-      },
+    const assistant = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "light",
     });
-  }
-
-  const { days, version } = ctx.req.valid("query");
-
-  const datasourceRetrievalResult = await fetchDatasourceRetrievalMetrics(
-    auth,
-    {
-      agentId: assistant.sId,
-      days,
-      version,
+    if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "The agent you're trying to access was not found.",
+        },
+      });
     }
-  );
-  if (datasourceRetrievalResult.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: `Failed to retrieve datasource retrieval metrics: ${fromError(datasourceRetrievalResult.error).toString()}`,
-      },
-    });
+
+    const { days, version } = ctx.req.valid("query");
+
+    const datasourceRetrievalResult = await fetchDatasourceRetrievalMetrics(
+      auth,
+      {
+        agentId: assistant.sId,
+        days,
+        version,
+      }
+    );
+    if (datasourceRetrievalResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve datasource retrieval metrics: ${fromError(datasourceRetrievalResult.error).toString()}`,
+        },
+      });
+    }
+
+    const datasources = datasourceRetrievalResult.value;
+    const total = datasources.reduce((sum, ds) => sum + ds.count, 0);
+
+    return ctx.json({ datasources, total });
   }
-
-  const datasources = datasourceRetrievalResult.value;
-  const total = datasources.reduce((sum, ds) => sum + ds.count, 0);
-
-  return ctx.json({ datasources, total });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/error_rate.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/error_rate.ts
@@ -11,6 +11,10 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
   version: z.string().optional(),
@@ -20,51 +24,56 @@ const QuerySchema = z.object({
 // Mounted at /api/w/:wId/assistant/agent_configurations/:aId/observability/error_rate.
 const app = workspaceApp();
 
-app.get("/", validate("query", QuerySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  validate("query", QuerySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { aId } = ctx.req.valid("param");
 
-  const assistant = await getAgentConfiguration(auth, {
-    agentId: aId,
-    variant: "light",
-  });
-  if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "The agent you're trying to access was not found.",
-      },
+    const assistant = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "light",
     });
-  }
+    if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "The agent you're trying to access was not found.",
+        },
+      });
+    }
 
-  const { days, version, timezone } = ctx.req.valid("query");
-  const owner = auth.getNonNullableWorkspace();
+    const { days, version, timezone } = ctx.req.valid("query");
+    const owner = auth.getNonNullableWorkspace();
 
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
-    agentId: assistant.sId,
-    days,
-    version,
-  });
-
-  const errorRateResult = await fetchMessageMetrics(
-    baseQuery,
-    "day",
-    ["failedMessages", "errorRate"] as const,
-    timezone
-  );
-  if (errorRateResult.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: `Failed to retrieve error rate: ${fromError(errorRateResult.error).toString()}`,
-      },
+    const baseQuery = buildAgentAnalyticsBaseQuery({
+      workspaceId: owner.sId,
+      agentId: assistant.sId,
+      days,
+      version,
     });
-  }
 
-  return ctx.json({ points: errorRateResult.value });
-});
+    const errorRateResult = await fetchMessageMetrics(
+      baseQuery,
+      "day",
+      ["failedMessages", "errorRate"] as const,
+      timezone
+    );
+    if (errorRateResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve error rate: ${fromError(errorRateResult.error).toString()}`,
+        },
+      });
+    }
+
+    return ctx.json({ points: errorRateResult.value });
+  }
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/feedback-distribution.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/feedback-distribution.ts
@@ -8,6 +8,10 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
 });
@@ -15,48 +19,53 @@ const QuerySchema = z.object({
 // Mounted at /api/w/:wId/assistant/agent_configurations/:aId/observability/feedback-distribution.
 const app = workspaceApp();
 
-app.get("/", validate("query", QuerySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  validate("query", QuerySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { aId } = ctx.req.valid("param");
 
-  const assistant = await getAgentConfiguration(auth, {
-    agentId: aId,
-    variant: "light",
-  });
-  if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "The agent you're trying to access was not found.",
-      },
+    const assistant = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "light",
     });
-  }
+    if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "The agent you're trying to access was not found.",
+        },
+      });
+    }
 
-  const { days } = ctx.req.valid("query");
-  const owner = auth.getNonNullableWorkspace();
+    const { days } = ctx.req.valid("query");
+    const owner = auth.getNonNullableWorkspace();
 
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
-    agentId: assistant.sId,
-    days,
-  });
-
-  const feedbackDistributionResult = await fetchFeedbackDistribution(
-    baseQuery,
-    days
-  );
-  if (feedbackDistributionResult.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: `Failed to retrieve feedback distribution: ${fromError(feedbackDistributionResult.error).toString()}`,
-      },
+    const baseQuery = buildAgentAnalyticsBaseQuery({
+      workspaceId: owner.sId,
+      agentId: assistant.sId,
+      days,
     });
-  }
 
-  return ctx.json({ points: feedbackDistributionResult.value });
-});
+    const feedbackDistributionResult = await fetchFeedbackDistribution(
+      baseQuery,
+      days
+    );
+    if (feedbackDistributionResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve feedback distribution: ${fromError(feedbackDistributionResult.error).toString()}`,
+        },
+      });
+    }
+
+    return ctx.json({ points: feedbackDistributionResult.value });
+  }
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/latency.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/latency.ts
@@ -11,6 +11,10 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
   version: z.string().optional(),
@@ -20,51 +24,56 @@ const QuerySchema = z.object({
 // Mounted at /api/w/:wId/assistant/agent_configurations/:aId/observability/latency.
 const app = workspaceApp();
 
-app.get("/", validate("query", QuerySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  validate("query", QuerySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { aId } = ctx.req.valid("param");
 
-  const assistant = await getAgentConfiguration(auth, {
-    agentId: aId,
-    variant: "light",
-  });
-  if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "The agent you're trying to access was not found.",
-      },
+    const assistant = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "light",
     });
-  }
+    if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "The agent you're trying to access was not found.",
+        },
+      });
+    }
 
-  const { days, version, timezone } = ctx.req.valid("query");
-  const owner = auth.getNonNullableWorkspace();
+    const { days, version, timezone } = ctx.req.valid("query");
+    const owner = auth.getNonNullableWorkspace();
 
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
-    agentId: assistant.sId,
-    days,
-    version,
-  });
-
-  const latencyResult = await fetchMessageMetrics(
-    baseQuery,
-    "day",
-    ["avgLatencyMs", "percentilesLatencyMs"] as const,
-    timezone
-  );
-  if (latencyResult.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: `Failed to retrieve usage metrics: ${fromError(latencyResult.error).toString()}`,
-      },
+    const baseQuery = buildAgentAnalyticsBaseQuery({
+      workspaceId: owner.sId,
+      agentId: assistant.sId,
+      days,
+      version,
     });
-  }
 
-  return ctx.json({ points: latencyResult.value });
-});
+    const latencyResult = await fetchMessageMetrics(
+      baseQuery,
+      "day",
+      ["avgLatencyMs", "percentilesLatencyMs"] as const,
+      timezone
+    );
+    if (latencyResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve usage metrics: ${fromError(latencyResult.error).toString()}`,
+        },
+      });
+    }
+
+    return ctx.json({ points: latencyResult.value });
+  }
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/overview.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/overview.ts
@@ -23,6 +23,10 @@ export type GetAgentOverviewResponseBody = {
   };
 };
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
   version: z.string().optional(),
@@ -33,10 +37,11 @@ const app = workspaceApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   validate("query", QuerySchema),
   async (ctx): HandlerResult<GetAgentOverviewResponseBody> => {
     const auth = ctx.get("auth");
-    const aId = ctx.req.param("aId") ?? "";
+    const { aId } = ctx.req.valid("param");
 
     const assistant = await getAgentConfiguration(auth, {
       agentId: aId,

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/skill-execution.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/skill-execution.ts
@@ -8,6 +8,10 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
   version: z.string().optional(),
@@ -16,56 +20,61 @@ const QuerySchema = z.object({
 // Mounted at /api/w/:wId/assistant/agent_configurations/:aId/observability/skill-execution.
 const app = workspaceApp();
 
-app.get("/", validate("query", QuerySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  validate("query", QuerySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { aId } = ctx.req.valid("param");
 
-  const assistant = await getAgentConfiguration(auth, {
-    agentId: aId,
-    variant: "light",
-  });
-  if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "The agent you're trying to access was not found.",
-      },
+    const assistant = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "light",
     });
-  }
+    if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "The agent you're trying to access was not found.",
+        },
+      });
+    }
 
-  if (!assistant.canEdit && !auth.isAdmin()) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "Only editors can get agent observability.",
-      },
+    if (!assistant.canEdit && !auth.isAdmin()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "app_auth_error",
+          message: "Only editors can get agent observability.",
+        },
+      });
+    }
+
+    const { days, version } = ctx.req.valid("query");
+    const owner = auth.getNonNullableWorkspace();
+
+    const baseQuery = buildAgentAnalyticsBaseQuery({
+      workspaceId: owner.sId,
+      agentId: assistant.sId,
+      days,
+      version,
     });
+
+    const skillExecutionResult = await fetchSkillExecutionMetrics(baseQuery);
+    if (skillExecutionResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve skill execution metrics: ${fromError(skillExecutionResult.error).toString()}`,
+        },
+      });
+    }
+
+    return ctx.json(skillExecutionResult.value);
   }
-
-  const { days, version } = ctx.req.valid("query");
-  const owner = auth.getNonNullableWorkspace();
-
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
-    agentId: assistant.sId,
-    days,
-    version,
-  });
-
-  const skillExecutionResult = await fetchSkillExecutionMetrics(baseQuery);
-  if (skillExecutionResult.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: `Failed to retrieve skill execution metrics: ${fromError(skillExecutionResult.error).toString()}`,
-      },
-    });
-  }
-
-  return ctx.json(skillExecutionResult.value);
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/source.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/source.ts
@@ -8,6 +8,10 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
   version: z.string().optional(),
@@ -16,49 +20,54 @@ const QuerySchema = z.object({
 // Mounted at /api/w/:wId/assistant/agent_configurations/:aId/observability/source.
 const app = workspaceApp();
 
-app.get("/", validate("query", QuerySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  validate("query", QuerySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { aId } = ctx.req.valid("param");
 
-  const assistant = await getAgentConfiguration(auth, {
-    agentId: aId,
-    variant: "light",
-  });
-  if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "The agent you're trying to access was not found.",
-      },
+    const assistant = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "light",
     });
-  }
+    if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "The agent you're trying to access was not found.",
+        },
+      });
+    }
 
-  const { days, version } = ctx.req.valid("query");
-  const owner = auth.getNonNullableWorkspace();
+    const { days, version } = ctx.req.valid("query");
+    const owner = auth.getNonNullableWorkspace();
 
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
-    agentId: assistant.sId,
-    days,
-    version,
-  });
-
-  const result = await fetchContextOriginBreakdown(baseQuery);
-  if (result.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: `Failed to retrieve source breakdown: ${fromError(result.error).toString()}`,
-      },
+    const baseQuery = buildAgentAnalyticsBaseQuery({
+      workspaceId: owner.sId,
+      agentId: assistant.sId,
+      days,
+      version,
     });
+
+    const result = await fetchContextOriginBreakdown(baseQuery);
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve source breakdown: ${fromError(result.error).toString()}`,
+        },
+      });
+    }
+
+    const buckets = result.value;
+    const total = buckets.reduce((acc, b) => acc + b.count, 0);
+
+    return ctx.json({ total, buckets });
   }
-
-  const buckets = result.value;
-  const total = buckets.reduce((acc, b) => acc + b.count, 0);
-
-  return ctx.json({ total, buckets });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/summary.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/summary.ts
@@ -13,6 +13,10 @@ export type GetAgentSummaryResponseBody = {
   summaryText: string;
 };
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
 });
@@ -22,10 +26,11 @@ const app = workspaceApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   validate("query", QuerySchema),
   async (ctx): HandlerResult<GetAgentSummaryResponseBody> => {
     const auth = ctx.get("auth");
-    const aId = ctx.req.param("aId") ?? "";
+    const { aId } = ctx.req.valid("param");
     const owner = auth.getNonNullableWorkspace();
 
     const assistant = await getAgentConfiguration(auth, {

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-execution.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-execution.ts
@@ -8,6 +8,10 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
   version: z.string().optional(),
@@ -16,46 +20,54 @@ const QuerySchema = z.object({
 // Mounted at /api/w/:wId/assistant/agent_configurations/:aId/observability/tool-execution.
 const app = workspaceApp();
 
-app.get("/", validate("query", QuerySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  validate("query", QuerySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { aId } = ctx.req.valid("param");
 
-  const assistant = await getAgentConfiguration(auth, {
-    agentId: aId,
-    variant: "light",
-  });
-  if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "The agent you're trying to access was not found.",
-      },
+    const assistant = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "light",
     });
-  }
+    if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "The agent you're trying to access was not found.",
+        },
+      });
+    }
 
-  const { days, version } = ctx.req.valid("query");
-  const owner = auth.getNonNullableWorkspace();
+    const { days, version } = ctx.req.valid("query");
+    const owner = auth.getNonNullableWorkspace();
 
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
-    agentId: assistant.sId,
-    days,
-    version,
-  });
-
-  const toolExecutionResult = await fetchToolExecutionMetrics(auth, baseQuery);
-  if (toolExecutionResult.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: `Failed to retrieve tool execution metrics: ${fromError(toolExecutionResult.error).toString()}`,
-      },
+    const baseQuery = buildAgentAnalyticsBaseQuery({
+      workspaceId: owner.sId,
+      agentId: assistant.sId,
+      days,
+      version,
     });
-  }
 
-  return ctx.json({ byVersion: toolExecutionResult.value });
-});
+    const toolExecutionResult = await fetchToolExecutionMetrics(
+      auth,
+      baseQuery
+    );
+    if (toolExecutionResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve tool execution metrics: ${fromError(toolExecutionResult.error).toString()}`,
+        },
+      });
+    }
+
+    return ctx.json({ byVersion: toolExecutionResult.value });
+  }
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-latency.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-latency.ts
@@ -11,6 +11,10 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
   version: z.string().optional(),
@@ -21,50 +25,73 @@ const QuerySchema = z.object({
 // Mounted at /api/w/:wId/assistant/agent_configurations/:aId/observability/tool-latency.
 const app = workspaceApp();
 
-app.get("/", validate("query", QuerySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  validate("query", QuerySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { aId } = ctx.req.valid("param");
 
-  const assistant = await getAgentConfiguration(auth, {
-    agentId: aId,
-    variant: "light",
-  });
-  if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "The agent you're trying to access was not found.",
-      },
+    const assistant = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "light",
     });
-  }
-
-  const { days, version, view, serverName } = ctx.req.valid("query");
-  const owner = auth.getNonNullableWorkspace();
-
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
-    agentId: assistant.sId,
-    days,
-    version,
-  });
-
-  if (view) {
-    if (view === "tool" && !serverName) {
+    if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
       return apiError(ctx, {
-        status_code: 400,
+        status_code: 404,
         api_error: {
-          type: "invalid_request_error",
-          message: "serverName is required when view is tool.",
+          type: "agent_configuration_not_found",
+          message: "The agent you're trying to access was not found.",
         },
       });
     }
 
-    const toolLatencyResult = await fetchToolLatencyMetricsByName(
-      auth,
-      baseQuery,
-      { view, serverName }
-    );
+    const { days, version, view, serverName } = ctx.req.valid("query");
+    const owner = auth.getNonNullableWorkspace();
+
+    const baseQuery = buildAgentAnalyticsBaseQuery({
+      workspaceId: owner.sId,
+      agentId: assistant.sId,
+      days,
+      version,
+    });
+
+    if (view) {
+      if (view === "tool" && !serverName) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "serverName is required when view is tool.",
+          },
+        });
+      }
+
+      const toolLatencyResult = await fetchToolLatencyMetricsByName(
+        auth,
+        baseQuery,
+        { view, serverName }
+      );
+      if (toolLatencyResult.isErr()) {
+        return apiError(ctx, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve tool latency metrics: ${fromError(toolLatencyResult.error).toString()}`,
+          },
+        });
+      }
+
+      return ctx.json({
+        byVersion: [],
+        rows: toolLatencyResult.value,
+        view,
+        serverName,
+      });
+    }
+
+    const toolLatencyResult = await fetchToolLatencyMetrics(baseQuery);
     if (toolLatencyResult.isErr()) {
       return apiError(ctx, {
         status_code: 500,
@@ -75,26 +102,8 @@ app.get("/", validate("query", QuerySchema), async (ctx) => {
       });
     }
 
-    return ctx.json({
-      byVersion: [],
-      rows: toolLatencyResult.value,
-      view,
-      serverName,
-    });
+    return ctx.json({ byVersion: toolLatencyResult.value });
   }
-
-  const toolLatencyResult = await fetchToolLatencyMetrics(baseQuery);
-  if (toolLatencyResult.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: `Failed to retrieve tool latency metrics: ${fromError(toolLatencyResult.error).toString()}`,
-      },
-    });
-  }
-
-  return ctx.json({ byVersion: toolLatencyResult.value });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-step-index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-step-index.ts
@@ -8,6 +8,10 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
   version: z.string().optional(),
@@ -16,46 +20,51 @@ const QuerySchema = z.object({
 // Mounted at /api/w/:wId/assistant/agent_configurations/:aId/observability/tool-step-index.
 const app = workspaceApp();
 
-app.get("/", validate("query", QuerySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  validate("query", QuerySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { aId } = ctx.req.valid("param");
 
-  const assistant = await getAgentConfiguration(auth, {
-    agentId: aId,
-    variant: "light",
-  });
-  if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "The agent you're trying to access was not found.",
-      },
+    const assistant = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "light",
     });
-  }
+    if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "The agent you're trying to access was not found.",
+        },
+      });
+    }
 
-  const { days, version } = ctx.req.valid("query");
-  const owner = auth.getNonNullableWorkspace();
+    const { days, version } = ctx.req.valid("query");
+    const owner = auth.getNonNullableWorkspace();
 
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
-    agentId: assistant.sId,
-    days,
-    version,
-  });
-
-  const result = await fetchToolStepIndexDistribution(auth, baseQuery);
-  if (result.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: `Failed to retrieve tool step index distribution: ${fromError(result.error).toString()}`,
-      },
+    const baseQuery = buildAgentAnalyticsBaseQuery({
+      workspaceId: owner.sId,
+      agentId: assistant.sId,
+      days,
+      version,
     });
-  }
 
-  return ctx.json({ byStep: result.value });
-});
+    const result = await fetchToolStepIndexDistribution(auth, baseQuery);
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve tool step index distribution: ${fromError(result.error).toString()}`,
+        },
+      });
+    }
+
+    return ctx.json({ byStep: result.value });
+  }
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics.ts
@@ -11,6 +11,10 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
   interval: z.enum(["day", "week"]).optional().default("day"),
@@ -20,50 +24,55 @@ const QuerySchema = z.object({
 // Mounted at /api/w/:wId/assistant/agent_configurations/:aId/observability/usage-metrics.
 const app = workspaceApp();
 
-app.get("/", validate("query", QuerySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  validate("query", QuerySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { aId } = ctx.req.valid("param");
 
-  const assistant = await getAgentConfiguration(auth, {
-    agentId: aId,
-    variant: "light",
-  });
-  if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "The agent you're trying to access was not found.",
-      },
+    const assistant = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "light",
     });
-  }
+    if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "The agent you're trying to access was not found.",
+        },
+      });
+    }
 
-  const { days, interval, timezone } = ctx.req.valid("query");
-  const owner = auth.getNonNullableWorkspace();
+    const { days, interval, timezone } = ctx.req.valid("query");
+    const owner = auth.getNonNullableWorkspace();
 
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
-    agentId: assistant.sId,
-    days,
-  });
-
-  const usageMetricsResult = await fetchMessageMetrics(
-    baseQuery,
-    interval,
-    ["conversations", "activeUsers"] as const,
-    timezone
-  );
-  if (usageMetricsResult.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: `Failed to retrieve usage metrics: ${fromError(usageMetricsResult.error).toString()}`,
-      },
+    const baseQuery = buildAgentAnalyticsBaseQuery({
+      workspaceId: owner.sId,
+      agentId: assistant.sId,
+      days,
     });
-  }
 
-  return ctx.json({ interval, points: usageMetricsResult.value });
-});
+    const usageMetricsResult = await fetchMessageMetrics(
+      baseQuery,
+      interval,
+      ["conversations", "activeUsers"] as const,
+      timezone
+    );
+    if (usageMetricsResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve usage metrics: ${fromError(usageMetricsResult.error).toString()}`,
+        },
+      });
+    }
+
+    return ctx.json({ interval, points: usageMetricsResult.value });
+  }
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/version-markers.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/version-markers.ts
@@ -7,6 +7,10 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
 });
@@ -14,45 +18,50 @@ const QuerySchema = z.object({
 // Mounted at /api/w/:wId/assistant/agent_configurations/:aId/observability/version-markers.
 const app = workspaceApp();
 
-app.get("/", validate("query", QuerySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  validate("query", QuerySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { aId } = ctx.req.valid("param");
 
-  const assistant = await getAgentConfiguration(auth, {
-    agentId: aId,
-    variant: "light",
-  });
-  if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "The agent you're trying to access was not found.",
-      },
+    const assistant = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "light",
     });
-  }
+    if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "The agent you're trying to access was not found.",
+        },
+      });
+    }
 
-  const { days } = ctx.req.valid("query");
-  const owner = auth.getNonNullableWorkspace();
+    const { days } = ctx.req.valid("query");
+    const owner = auth.getNonNullableWorkspace();
 
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
-    agentId: assistant.sId,
-    days,
-  });
-
-  const versionMarkersResult = await fetchVersionMarkers(baseQuery);
-  if (versionMarkersResult.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: `Failed to retrieve version markers: ${versionMarkersResult.error.message}`,
-      },
+    const baseQuery = buildAgentAnalyticsBaseQuery({
+      workspaceId: owner.sId,
+      agentId: assistant.sId,
+      days,
     });
-  }
 
-  return ctx.json({ versionMarkers: versionMarkersResult.value });
-});
+    const versionMarkersResult = await fetchVersionMarkers(baseQuery);
+    if (versionMarkersResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve version markers: ${versionMarkersResult.error.message}`,
+        },
+      });
+    }
+
+    return ctx.json({ versionMarkers: versionMarkersResult.value });
+  }
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/restore.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/restore.ts
@@ -6,76 +6,89 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import type { SuccessResponseBody } from "@front-api/routes/types";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
 
 // Mounted at /api/w/:wId/assistant/agent_configurations/:aId/restore.
 const app = workspaceApp();
 
-app.post("/", async (ctx): HandlerResult<SuccessResponseBody> => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
+app.post(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<SuccessResponseBody> => {
+    const auth = ctx.get("auth");
+    const { aId } = ctx.req.valid("param");
 
-  const agentConfiguration = await getAgentConfiguration(auth, {
-    agentId: aId,
-    variant: "light",
-  });
-  if (!agentConfiguration || (!agentConfiguration.canEdit && !auth.isAdmin())) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "Could not find the agent configuration.",
-      },
+    const agentConfiguration = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "light",
     });
-  }
-
-  const restoredResult = await restoreAgentConfiguration(
-    auth,
-    agentConfiguration.sId
-  );
-
-  if (restoredResult.isErr()) {
-    switch (restoredResult.error.code) {
-      case "name_conflict":
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: restoredResult.error.message,
-          },
-        });
-      case "unauthorized":
-        return apiError(ctx, {
-          status_code: 403,
-          api_error: {
-            type: "app_auth_error",
-            message: restoredResult.error.message,
-          },
-        });
-      case "internal_error":
-        return apiError(ctx, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: "Could not restore the agent configuration.",
-          },
-        });
-      default:
-        assertNever(restoredResult.error.code);
+    if (
+      !agentConfiguration ||
+      (!agentConfiguration.canEdit && !auth.isAdmin())
+    ) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "Could not find the agent configuration.",
+        },
+      });
     }
-  }
 
-  if (!restoredResult.value.restored) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Could not restore the agent configuration.",
-      },
-    });
-  }
+    const restoredResult = await restoreAgentConfiguration(
+      auth,
+      agentConfiguration.sId
+    );
 
-  return ctx.json({ success: true });
-});
+    if (restoredResult.isErr()) {
+      switch (restoredResult.error.code) {
+        case "name_conflict":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: restoredResult.error.message,
+            },
+          });
+        case "unauthorized":
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: {
+              type: "app_auth_error",
+              message: restoredResult.error.message,
+            },
+          });
+        case "internal_error":
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: "Could not restore the agent configuration.",
+            },
+          });
+        default:
+          assertNever(restoredResult.error.code);
+      }
+    }
+
+    if (!restoredResult.value.restored) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Could not restore the agent configuration.",
+        },
+      });
+    }
+
+    return ctx.json({ success: true });
+  }
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/skills.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/skills.ts
@@ -4,6 +4,12 @@ import type { SkillType } from "@app/types/assistant/skill_configuration";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
 
 export type GetAgentSkillsResponseBody = {
   skills: SkillType[];
@@ -12,26 +18,30 @@ export type GetAgentSkillsResponseBody = {
 // Mounted at /api/w/:wId/assistant/agent_configurations/:aId/skills.
 const app = workspaceApp();
 
-app.get("/", async (ctx): HandlerResult<GetAgentSkillsResponseBody> => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetAgentSkillsResponseBody> => {
+    const auth = ctx.get("auth");
+    const { aId } = ctx.req.valid("param");
 
-  const agent = await getAgentConfiguration(auth, {
-    agentId: aId,
-    variant: "full",
-  });
-  if (!agent) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "The agent configuration was not found.",
-      },
+    const agent = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "full",
     });
-  }
+    if (!agent) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "The agent configuration was not found.",
+        },
+      });
+    }
 
-  const skills = await SkillResource.listByAgentConfiguration(auth, agent);
-  return ctx.json({ skills: skills.map((s) => s.toJSON(auth)) });
-});
+    const skills = await SkillResource.listByAgentConfiguration(auth, agent);
+    return ctx.json({ skills: skills.map((s) => s.toJSON(auth)) });
+  }
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/suggestions.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/suggestions.ts
@@ -33,15 +33,20 @@ const GetSuggestionsQuerySchema = z.object({
   limit: z.string().optional(),
 });
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 // Mounted at /api/w/:wId/assistant/agent_configurations/:aId/suggestions.
 const app = workspaceApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   validate("query", GetSuggestionsQuerySchema),
   async (ctx): HandlerResult<GetSuggestionsResponseBody> => {
     const auth = ctx.get("auth");
-    const aId = ctx.req.param("aId") ?? "";
+    const { aId } = ctx.req.valid("param");
 
     const agent = await getAgentConfiguration(auth, {
       agentId: aId,
@@ -93,10 +98,11 @@ app.get(
 
 app.patch(
   "/",
+  validate("param", ParamsSchema),
   validate("json", PatchSuggestionRequestBodySchema),
   async (ctx): HandlerResult<PatchSuggestionResponseBody> => {
     const auth = ctx.get("auth");
-    const aId = ctx.req.param("aId") ?? "";
+    const { aId } = ctx.req.valid("param");
 
     const agent = await getAgentConfiguration(auth, {
       agentId: aId,

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/tags.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/tags.ts
@@ -13,6 +13,10 @@ export type PatchAgentTagsResponseBody = {
   tags: TagType[];
 };
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 const PatchAgentTagsRequestBodySchema = z
   .object({
     addTagIds: z.array(z.string()).optional(),
@@ -32,10 +36,11 @@ const app = workspaceApp();
 
 app.patch(
   "/",
+  validate("param", ParamsSchema),
   validate("json", PatchAgentTagsRequestBodySchema),
   async (ctx): HandlerResult<PatchAgentTagsResponseBody> => {
     const auth = ctx.get("auth");
-    const aId = ctx.req.param("aId") ?? "";
+    const { aId } = ctx.req.valid("param");
 
     const agent = await getAgentConfiguration(auth, {
       agentId: aId,

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/webhook_requests.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/webhook_requests.ts
@@ -3,14 +3,20 @@ import { fetchRecentWebhookRequestTriggersWithPayload } from "@app/lib/triggers/
 import logger from "@app/logger/logger";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  aId: z.string(),
+  tId: z.string(),
+});
 
 // Mounted at /api/w/:wId/assistant/agent_configurations/:aId/triggers/:tId/webhook_requests.
 const app = workspaceApp();
 
-app.get("/", async (ctx) => {
+app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
-  const tId = ctx.req.param("tId") ?? "";
+  const { aId, tId } = ctx.req.valid("param");
 
   const trigger = await TriggerResource.fetchById(auth, tId);
   if (!trigger) {

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
@@ -13,6 +13,10 @@ import { z } from "zod";
 
 import tId from "./[tId]";
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 export type GetTriggersResponseBody = {
   triggers: (TriggerType & {
     isEditor: boolean;
@@ -45,50 +49,60 @@ function isWebhookTriggerData(trigger: {
 // Mounted under /api/w/:wId/assistant/agent_configurations/:aId/triggers.
 const app = workspaceApp();
 
-app.get("/", async (ctx): HandlerResult<GetTriggersResponseBody> => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetTriggersResponseBody> => {
+    const auth = ctx.get("auth");
+    const { aId } = ctx.req.valid("param");
 
-  const agentConfiguration = await getAgentConfiguration(auth, {
-    agentId: aId,
-    variant: "light",
-  });
-  if (!agentConfiguration || (!agentConfiguration.canRead && !auth.isAdmin())) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "The agent configuration was not found.",
-      },
+    const agentConfiguration = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "light",
     });
+    if (
+      !agentConfiguration ||
+      (!agentConfiguration.canRead && !auth.isAdmin())
+    ) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "The agent configuration was not found.",
+        },
+      });
+    }
+
+    const allTriggers = await TriggerResource.listByAgentConfigurationId(
+      auth,
+      aId
+    );
+
+    const editorIds = [
+      ...new Set(allTriggers.map((trigger) => trigger.editor)),
+    ];
+    const editorUsers = await UserResource.fetchByModelIds(editorIds);
+    const editorNamesMap = new Map(
+      editorUsers.map((user) => [user.id, user.fullName()])
+    );
+
+    const triggers = allTriggers.map((trigger) => ({
+      ...trigger.toJSON(),
+      isEditor: trigger.editor === auth.getNonNullableUser().id,
+      editorName: editorNamesMap.get(trigger.editor),
+    }));
+
+    return ctx.json({ triggers });
   }
-
-  const allTriggers = await TriggerResource.listByAgentConfigurationId(
-    auth,
-    aId
-  );
-
-  const editorIds = [...new Set(allTriggers.map((trigger) => trigger.editor))];
-  const editorUsers = await UserResource.fetchByModelIds(editorIds);
-  const editorNamesMap = new Map(
-    editorUsers.map((user) => [user.id, user.fullName()])
-  );
-
-  const triggers = allTriggers.map((trigger) => ({
-    ...trigger.toJSON(),
-    isEditor: trigger.editor === auth.getNonNullableUser().id,
-    editorName: editorNamesMap.get(trigger.editor),
-  }));
-
-  return ctx.json({ triggers });
-});
+);
 
 app.delete(
   "/",
+  validate("param", ParamsSchema),
   validate("json", DeleteTriggersRequestBodySchema),
   async (ctx) => {
     const auth = ctx.get("auth");
-    const aId = ctx.req.param("aId") ?? "";
+    const { aId } = ctx.req.valid("param");
 
     const agentConfiguration = await getAgentConfiguration(auth, {
       agentId: aId,
@@ -154,10 +168,11 @@ app.delete(
 
 app.patch(
   "/",
+  validate("param", ParamsSchema),
   validate("json", PatchTriggersRequestBodySchema),
   async (ctx) => {
     const auth = ctx.get("auth");
-    const aId = ctx.req.param("aId") ?? "";
+    const { aId } = ctx.req.valid("param");
 
     const agentConfiguration = await getAgentConfiguration(auth, {
       agentId: aId,
@@ -248,88 +263,96 @@ app.patch(
   }
 );
 
-app.post("/", validate("json", PostTriggersRequestBodySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
+app.post(
+  "/",
+  validate("param", ParamsSchema),
+  validate("json", PostTriggersRequestBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { aId } = ctx.req.valid("param");
 
-  const agentConfiguration = await getAgentConfiguration(auth, {
-    agentId: aId,
-    variant: "light",
-  });
-  if (!agentConfiguration || (!agentConfiguration.canRead && !auth.isAdmin())) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "The agent configuration was not found.",
-      },
+    const agentConfiguration = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "light",
     });
-  }
-
-  const { triggers } = ctx.req.valid("json");
-  const workspace = auth.getNonNullableWorkspace();
-
-  for (const triggerData of triggers) {
-    const triggerValidation = TriggerSchema.safeParse({
-      ...triggerData,
-      editor: auth.getNonNullableUser().id,
-    });
-    if (!triggerValidation.success) {
+    if (
+      !agentConfiguration ||
+      (!agentConfiguration.canRead && !auth.isAdmin())
+    ) {
       return apiError(ctx, {
-        status_code: 400,
+        status_code: 404,
         api_error: {
-          type: "invalid_request_error",
-          message: `Invalid trigger data: ${triggerValidation.error.message}`,
+          type: "agent_configuration_not_found",
+          message: "The agent configuration was not found.",
         },
       });
     }
 
-    const validatedTrigger = triggerValidation.data;
-    const webhookSourceViewId = isWebhookTriggerData(validatedTrigger)
-      ? getResourceIdFromSId(validatedTrigger.webhookSourceViewId)
-      : null;
-    const executionPerDay = isWebhookTriggerData(validatedTrigger)
-      ? validatedTrigger.executionPerDayLimitOverride
-      : null;
+    const { triggers } = ctx.req.valid("json");
+    const workspace = auth.getNonNullableWorkspace();
 
-    const newTrigger = await TriggerResource.makeNew(auth, {
-      workspaceId: workspace.id,
-      agentConfigurationId: aId,
-      name: validatedTrigger.name,
-      kind: validatedTrigger.kind,
-      status: validatedTrigger.status ?? "enabled",
-      configuration: validatedTrigger.configuration,
-      naturalLanguageDescription: validatedTrigger.naturalLanguageDescription,
-      customPrompt: validatedTrigger.customPrompt,
-      editor: auth.getNonNullableUser().id,
-      webhookSourceViewId,
-      executionPerDayLimitOverride: executionPerDay,
-      executionMode: validatedTrigger.kind === "webhook" ? "fair_use" : null,
-      origin: "user",
-    });
-
-    if (newTrigger.isErr()) {
-      logger.error(
-        {
-          workspaceId: workspace.sId,
-          agentConfigurationId: aId,
-          triggerName: validatedTrigger.name,
-          error: newTrigger.error,
-        },
-        "Failed to create trigger"
-      );
-      return apiError(ctx, {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: `Failed to create trigger ${validatedTrigger.name}.`,
-        },
+    for (const triggerData of triggers) {
+      const triggerValidation = TriggerSchema.safeParse({
+        ...triggerData,
+        editor: auth.getNonNullableUser().id,
       });
-    }
-  }
+      if (!triggerValidation.success) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid trigger data: ${triggerValidation.error.message}`,
+          },
+        });
+      }
 
-  return ctx.body(null, 204);
-});
+      const validatedTrigger = triggerValidation.data;
+      const webhookSourceViewId = isWebhookTriggerData(validatedTrigger)
+        ? getResourceIdFromSId(validatedTrigger.webhookSourceViewId)
+        : null;
+      const executionPerDay = isWebhookTriggerData(validatedTrigger)
+        ? validatedTrigger.executionPerDayLimitOverride
+        : null;
+
+      const newTrigger = await TriggerResource.makeNew(auth, {
+        workspaceId: workspace.id,
+        agentConfigurationId: aId,
+        name: validatedTrigger.name,
+        kind: validatedTrigger.kind,
+        status: validatedTrigger.status ?? "enabled",
+        configuration: validatedTrigger.configuration,
+        naturalLanguageDescription: validatedTrigger.naturalLanguageDescription,
+        customPrompt: validatedTrigger.customPrompt,
+        editor: auth.getNonNullableUser().id,
+        webhookSourceViewId,
+        executionPerDayLimitOverride: executionPerDay,
+        executionMode: validatedTrigger.kind === "webhook" ? "fair_use" : null,
+        origin: "user",
+      });
+
+      if (newTrigger.isErr()) {
+        logger.error(
+          {
+            workspaceId: workspace.sId,
+            agentConfigurationId: aId,
+            triggerName: validatedTrigger.name,
+            error: newTrigger.error,
+          },
+          "Failed to create trigger"
+        );
+        return apiError(ctx, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to create trigger ${validatedTrigger.name}.`,
+          },
+        });
+      }
+    }
+
+    return ctx.body(null, 204);
+  }
+);
 
 app.route("/:tId", tId);
 

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
@@ -4,6 +4,12 @@ import type { AgentUsageType } from "@app/types/assistant/agent";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
 
 export type GetAgentUsageResponseBody = {
   agentUsage: AgentUsageType | null;
@@ -12,31 +18,35 @@ export type GetAgentUsageResponseBody = {
 // Mounted at /api/w/:wId/assistant/agent_configurations/:aId/usage.
 const app = workspaceApp();
 
-app.get("/", async (ctx): HandlerResult<GetAgentUsageResponseBody> => {
-  const auth = ctx.get("auth");
-  const owner = auth.getNonNullableWorkspace();
-  const aId = ctx.req.param("aId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetAgentUsageResponseBody> => {
+    const auth = ctx.get("auth");
+    const owner = auth.getNonNullableWorkspace();
+    const { aId } = ctx.req.valid("param");
 
-  const agentConfiguration = await getAgentConfiguration(auth, {
-    agentId: aId,
-    variant: "light",
-  });
-  if (!agentConfiguration) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "The agent you're trying to access was not found.",
-      },
+    const agentConfiguration = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "light",
     });
+    if (!agentConfiguration) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "agent_configuration_not_found",
+          message: "The agent you're trying to access was not found.",
+        },
+      });
+    }
+
+    const agentUsage = await getAgentUsage(auth, {
+      agentConfiguration,
+      workspaceId: owner.sId,
+    });
+
+    return ctx.json({ agentUsage });
   }
-
-  const agentUsage = await getAgentUsage(auth, {
-    agentConfiguration,
-    workspaceId: owner.sId,
-  });
-
-  return ctx.json({ agentUsage });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/actions/blocked.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/actions/blocked.ts
@@ -2,13 +2,19 @@ import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_reso
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  cId: z.string(),
+});
 
 // Mounted at /api/w/:wId/assistant/conversations/:cId/actions/blocked.
 const app = workspaceApp();
 
-app.get("/", async (ctx) => {
+app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const cId = ctx.req.param("cId") ?? "";
+  const { cId } = ctx.req.valid("param");
 
   const conversation = await ConversationResource.fetchById(auth, cId);
 

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/attachments.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/attachments.ts
@@ -4,6 +4,12 @@ import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  cId: z.string(),
+});
 
 export type GetConversationAttachmentsResponseBody = {
   attachments: ConversationAttachmentType[];
@@ -14,9 +20,10 @@ const app = workspaceApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   async (ctx): HandlerResult<GetConversationAttachmentsResponseBody> => {
     const auth = ctx.get("auth");
-    const conversationId = ctx.req.param("cId") ?? "";
+    const { cId: conversationId } = ctx.req.valid("param");
 
     const conversationRes = await getConversation(auth, conversationId);
     if (conversationRes.isErr()) {

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/branches/[bId]/close.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/branches/[bId]/close.ts
@@ -2,14 +2,20 @@ import { closeConversationBranch } from "@app/lib/api/assistant/conversation/bra
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  cId: z.string(),
+  bId: z.string(),
+});
 
 // Mounted at /api/w/:wId/assistant/conversations/:cId/branches/:bId/close.
 const app = workspaceApp();
 
-app.post("/", async (ctx) => {
+app.post("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const cId = ctx.req.param("cId") ?? "";
-  const bId = ctx.req.param("bId") ?? "";
+  const { cId, bId } = ctx.req.valid("param");
 
   const closeRes = await closeConversationBranch(auth, {
     branchId: bId,

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/branches/[bId]/merge.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/branches/[bId]/merge.ts
@@ -2,14 +2,20 @@ import { mergeConversationBranch } from "@app/lib/api/assistant/conversation/bra
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  cId: z.string(),
+  bId: z.string(),
+});
 
 // Mounted at /api/w/:wId/assistant/conversations/:cId/branches/:bId/merge.
 const app = workspaceApp();
 
-app.post("/", async (ctx) => {
+app.post("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const cId = ctx.req.param("cId") ?? "";
-  const bId = ctx.req.param("bId") ?? "";
+  const { cId, bId } = ctx.req.valid("param");
 
   const mergeRes = await mergeConversationBranch(auth, {
     branchId: bId,

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/branches/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/branches/index.ts
@@ -2,15 +2,21 @@ import { getMostRecentOpenBranchForConversation } from "@app/lib/api/assistant/c
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 import branch from "./[bId]";
+
+const ParamsSchema = z.object({
+  cId: z.string(),
+});
 
 // Mounted at /api/w/:wId/assistant/conversations/:cId/branches.
 const app = workspaceApp();
 
-app.get("/", async (ctx) => {
+app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const cId = ctx.req.param("cId") ?? "";
+  const { cId } = ctx.req.valid("param");
 
   const branchRes = await getMostRecentOpenBranchForConversation(auth, {
     conversationId: cId,

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -10,6 +10,10 @@ import { validate } from "@front-api/middlewares/validator";
 import type { SuccessResponseBody } from "@front-api/routes/types";
 import { z } from "zod";
 
+const ParamsSchema = z.object({
+  cId: z.string(),
+});
+
 const PostMessageEventBodySchema = z.object({
   action: z.enum(["cancel", "gracefully_stop", "interrupt"]),
   messageIds: z.array(z.string()),
@@ -22,10 +26,11 @@ app.use("*", streamingTag);
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   validate("json", PostMessageEventBodySchema),
   async (ctx): HandlerResult<SuccessResponseBody> => {
     const auth = ctx.get("auth");
-    const conversationId = ctx.req.param("cId") ?? "";
+    const { cId: conversationId } = ctx.req.valid("param");
 
     const conversationRes =
       await ConversationResource.fetchConversationWithoutContent(

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/compactions.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/compactions.ts
@@ -14,6 +14,10 @@ export type PostConversationCompactResponseBody = {
   compactionMessage: CompactionMessageType;
 };
 
+const ParamsSchema = z.object({
+  cId: z.string(),
+});
+
 const PostConversationCompactionsBodySchema = z.object({
   model: z.object({
     providerId: z.string(),
@@ -26,10 +30,11 @@ const app = workspaceApp();
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   validate("json", PostConversationCompactionsBodySchema),
   async (ctx): HandlerResult<PostConversationCompactResponseBody> => {
     const auth = ctx.get("auth");
-    const conversationId = ctx.req.param("cId") ?? "";
+    const { cId: conversationId } = ctx.req.valid("param");
 
     const conversationRes = await getConversation(auth, conversationId);
     if (conversationRes.isErr()) {

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
@@ -7,6 +7,11 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  cId: z.string(),
+});
 
 export type PostContentFragmentResponseBody = {
   contentFragment: ContentFragmentType;
@@ -17,11 +22,12 @@ const app = workspaceApp();
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   validate("json", InternalPostContentFragmentRequestBodySchema),
   async (ctx): HandlerResult<PostContentFragmentResponseBody> => {
     const auth = ctx.get("auth");
     const user = auth.getNonNullableUser();
-    const cId = ctx.req.param("cId") ?? "";
+    const { cId } = ctx.req.valid("param");
 
     const conversationRes =
       await ConversationResource.fetchConversationWithoutContent(auth, cId);

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/context-usage.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/context-usage.ts
@@ -3,6 +3,12 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { SupportedModel } from "@app/types/assistant/models/types";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  cId: z.string(),
+});
 
 export type GetConversationContextUsageResponse = {
   model: SupportedModel | null;
@@ -19,9 +25,9 @@ const PENDING_CONTEXT_USAGE_RESPONSE: GetConversationContextUsageResponse = {
 // Mounted at /api/w/:wId/assistant/conversations/:cId/context-usage.
 const app = workspaceApp();
 
-app.get("/", async (ctx) => {
+app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const conversationId = ctx.req.param("cId") ?? "";
+  const { cId: conversationId } = ctx.req.valid("param");
 
   const conversation = await ConversationResource.fetchById(
     auth,

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/feedbacks.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/feedbacks.ts
@@ -2,13 +2,19 @@ import { getConversationFeedbacksForUser } from "@app/lib/api/assistant/feedback
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { workspaceApp } from "@front-api/middlewares/ctx";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  cId: z.string(),
+});
 
 // Mounted at /api/w/:wId/assistant/conversations/:cId/feedbacks.
 const app = workspaceApp();
 
-app.get("/", async (ctx) => {
+app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const conversationId = ctx.req.param("cId") ?? "";
+  const { cId: conversationId } = ctx.req.valid("param");
 
   const conversationRes =
     await ConversationResource.fetchConversationWithoutContent(

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/[...rel].ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/[...rel].ts
@@ -14,6 +14,12 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  cId: z.string(),
+  rel: z.string().optional(),
+});
 
 export type ConversationFileRelResponseBody = Record<string, never>;
 
@@ -21,10 +27,9 @@ export type ConversationFileRelResponseBody = Record<string, never>;
 // Mounted from files/index.ts at the root path.
 const app = workspaceApp();
 
-app.get("/:rel{.+}", async (ctx) => {
+app.get("/:rel{.+}", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const cId = ctx.req.param("cId") ?? "";
-  const rel = ctx.req.param("rel");
+  const { cId, rel } = ctx.req.valid("param");
 
   if (!isString(rel) || rel.length === 0) {
     return apiError(ctx, {
@@ -114,11 +119,11 @@ app.get("/:rel{.+}", async (ctx) => {
 
 app.post(
   "/:rel{.+}",
+  validate("param", ParamsSchema),
   validate("json", MoveMountFileRequestBodySchema),
   async (ctx): HandlerResult<ConversationFileRelResponseBody> => {
     const auth = ctx.get("auth");
-    const cId = ctx.req.param("cId") ?? "";
-    const rel = ctx.req.param("rel");
+    const { cId, rel } = ctx.req.valid("param");
 
     if (!isString(rel) || rel.length === 0) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/download.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/download.ts
@@ -11,6 +11,10 @@ import { validate } from "@front-api/middlewares/validator";
 import path from "path";
 import { z } from "zod";
 
+const ParamsSchema = z.object({
+  cId: z.string(),
+});
+
 const PostDownloadBodySchema = z.object({
   filePath: z.string(),
 });
@@ -18,93 +22,100 @@ const PostDownloadBodySchema = z.object({
 // Mounted at /api/w/:wId/assistant/conversations/:cId/files/download.
 const app = workspaceApp();
 
-app.post("/", validate("json", PostDownloadBodySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const cId = ctx.req.param("cId") ?? "";
+app.post(
+  "/",
+  validate("param", ParamsSchema),
+  validate("json", PostDownloadBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { cId } = ctx.req.valid("param");
 
-  const { filePath } = ctx.req.valid("json");
+    const { filePath } = ctx.req.valid("json");
 
-  const scopedPath = parseScopedFilePath(filePath);
-  if (!scopedPath || scopedPath.prefix !== "conversation") {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message:
-          "Invalid filePath: must be a scoped path (e.g. conversation/file.png).",
-      },
-    });
-  }
-
-  const conversation = await ConversationResource.fetchById(auth, cId);
-  if (!conversation) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "Conversation not found.",
-      },
-    });
-  }
-
-  const owner = auth.getNonNullableWorkspace();
-  const expectedPrefix = getConversationFilesBasePath({
-    workspaceId: owner.sId,
-    conversationId: cId,
-  });
-  const normalizedPath = path.posix.normalize(expectedPrefix + scopedPath.rel);
-  if (!normalizedPath.startsWith(expectedPrefix)) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message: "Access denied: path is outside conversation scope.",
-      },
-    });
-  }
-
-  const bucket = getPrivateUploadBucket();
-
-  const contentTypeResult = await bucket.getFileContentType(normalizedPath);
-  if (contentTypeResult.isErr()) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "file_not_found",
-        message: "File not found.",
-      },
-    });
-  }
-
-  const headers: Record<string, string> = {};
-  if (contentTypeResult.isOk() && contentTypeResult.value) {
-    headers["Content-Type"] = contentTypeResult.value;
-  }
-
-  const fileName = path.posix.basename(normalizedPath);
-  headers["Content-Disposition"] =
-    `attachment; filename="${encodeURIComponent(fileName)}"`;
-
-  const readStream = bucket.file(normalizedPath).createReadStream();
-
-  const webStream = new ReadableStream({
-    start(controller) {
-      readStream.on("data", (chunk) => controller.enqueue(chunk));
-      readStream.on("end", () => controller.close());
-      readStream.on("error", (err) => {
-        logger.error(
-          { err, filePath: normalizedPath },
-          "Error streaming conversation file"
-        );
-        controller.error(err);
+    const scopedPath = parseScopedFilePath(filePath);
+    if (!scopedPath || scopedPath.prefix !== "conversation") {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "Invalid filePath: must be a scoped path (e.g. conversation/file.png).",
+        },
       });
-    },
-    cancel() {
-      readStream.destroy();
-    },
-  });
+    }
 
-  return new Response(webStream, { status: 200, headers });
-});
+    const conversation = await ConversationResource.fetchById(auth, cId);
+    if (!conversation) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: "Conversation not found.",
+        },
+      });
+    }
+
+    const owner = auth.getNonNullableWorkspace();
+    const expectedPrefix = getConversationFilesBasePath({
+      workspaceId: owner.sId,
+      conversationId: cId,
+    });
+    const normalizedPath = path.posix.normalize(
+      expectedPrefix + scopedPath.rel
+    );
+    if (!normalizedPath.startsWith(expectedPrefix)) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message: "Access denied: path is outside conversation scope.",
+        },
+      });
+    }
+
+    const bucket = getPrivateUploadBucket();
+
+    const contentTypeResult = await bucket.getFileContentType(normalizedPath);
+    if (contentTypeResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "file_not_found",
+          message: "File not found.",
+        },
+      });
+    }
+
+    const headers: Record<string, string> = {};
+    if (contentTypeResult.isOk() && contentTypeResult.value) {
+      headers["Content-Type"] = contentTypeResult.value;
+    }
+
+    const fileName = path.posix.basename(normalizedPath);
+    headers["Content-Disposition"] =
+      `attachment; filename="${encodeURIComponent(fileName)}"`;
+
+    const readStream = bucket.file(normalizedPath).createReadStream();
+
+    const webStream = new ReadableStream({
+      start(controller) {
+        readStream.on("data", (chunk) => controller.enqueue(chunk));
+        readStream.on("end", () => controller.close());
+        readStream.on("error", (err) => {
+          logger.error(
+            { err, filePath: normalizedPath },
+            "Error streaming conversation file"
+          );
+          controller.error(err);
+        });
+      },
+      cancel() {
+        readStream.destroy();
+      },
+    });
+
+    return new Response(webStream, { status: 200, headers });
+  }
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/index.ts
@@ -8,9 +8,15 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 import rel from "./[...rel]";
 import download from "./download";
 import thumbnail from "./thumbnail";
+
+const ParamsSchema = z.object({
+  cId: z.string(),
+});
 
 export type GetConversationFilesResponseBody = {
   files: FileSystemEntry[];
@@ -19,46 +25,50 @@ export type GetConversationFilesResponseBody = {
 // Mounted at /api/w/:wId/assistant/conversations/:cId/files.
 const app = workspaceApp();
 
-app.get("/", async (ctx): HandlerResult<GetConversationFilesResponseBody> => {
-  const auth = ctx.get("auth");
-  const cId = ctx.req.param("cId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetConversationFilesResponseBody> => {
+    const auth = ctx.get("auth");
+    const { cId } = ctx.req.valid("param");
 
-  const conversation = await ConversationResource.fetchById(auth, cId);
-  if (!conversation) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "Conversation not found.",
-      },
-    });
+    const conversation = await ConversationResource.fetchById(auth, cId);
+    if (!conversation) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: "Conversation not found.",
+        },
+      });
+    }
+
+    const fsResult = await DustFileSystem.forConversation(
+      auth,
+      conversation.toJSON()
+    );
+    if (fsResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to initialise file system.",
+        },
+      });
+    }
+
+    // Scope the listing to the conversation mount only. For pod conversations the
+    // DustFileSystem also has a pod mount and we do not want to expose pod files here.
+    const dustFs = fsResult.value;
+    const files = await enrichListWithFileResourceIds(
+      auth,
+      dustFs,
+      await dustFs.list(`${SCOPED_PREFIX_CONVERSATION}${cId}`)
+    );
+
+    return ctx.json({ files });
   }
-
-  const fsResult = await DustFileSystem.forConversation(
-    auth,
-    conversation.toJSON()
-  );
-  if (fsResult.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Failed to initialise file system.",
-      },
-    });
-  }
-
-  // Scope the listing to the conversation mount only. For pod conversations the
-  // DustFileSystem also has a pod mount and we do not want to expose pod files here.
-  const dustFs = fsResult.value;
-  const files = await enrichListWithFileResourceIds(
-    auth,
-    dustFs,
-    await dustFs.list(`${SCOPED_PREFIX_CONVERSATION}${cId}`)
-  );
-
-  return ctx.json({ files });
-});
+);
 
 app.route("/download", download);
 app.route("/thumbnail", thumbnail);

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/thumbnail.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/thumbnail.ts
@@ -11,14 +11,20 @@ import { isString } from "@app/types/shared/utils/general";
 import { readableToReadableStream } from "@app/types/shared/utils/streams";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import path from "path";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  cId: z.string(),
+});
 
 // Mounted at /api/w/:wId/assistant/conversations/:cId/files/thumbnail.
 const app = workspaceApp();
 
-app.get("/", async (ctx) => {
+app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const cId = ctx.req.param("cId") ?? "";
+  const { cId } = ctx.req.valid("param");
   const filePath = ctx.req.query("filePath");
 
   if (!isString(filePath)) {

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/forks/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/forks/index.ts
@@ -6,6 +6,10 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
+const ParamsSchema = z.object({
+  cId: z.string(),
+});
+
 const PostConversationForkBodySchema = z.object({
   sourceMessageId: z.string().optional(),
 });
@@ -21,10 +25,11 @@ const app = workspaceApp();
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   validate("json", PostConversationForkBodySchema),
   async (ctx): HandlerResult<PostConversationForkResponseBody> => {
     const auth = ctx.get("auth");
-    const cId = ctx.req.param("cId") ?? "";
+    const { cId } = ctx.req.valid("param");
 
     const { sourceMessageId } = ctx.req.valid("json");
 

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -50,6 +50,10 @@ import suggest from "./suggest";
 import tools from "./tools";
 import wakeups from "./wakeups";
 
+const ParamsSchema = z.object({
+  cId: z.string(),
+});
+
 const PatchConversationsRequestBodySchema = z.union([
   z.object({ title: z.string() }),
   z.object({ read: z.boolean() }),
@@ -64,49 +68,53 @@ const PatchConversationsRequestBodySchema = z.union([
 // handles GET, DELETE, and PATCH on the conversation resource itself.
 const app = workspaceApp();
 
-app.get("/", async (ctx): HandlerResult<GetConversationResponseBody> => {
-  const auth = ctx.get("auth");
-  const cId = ctx.req.param("cId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetConversationResponseBody> => {
+    const auth = ctx.get("auth");
+    const { cId } = ctx.req.valid("param");
 
-  const conversationRes =
-    await ConversationResource.fetchConversationWithoutContent(auth, cId, {
-      includeForkingData: true,
+    const conversationRes =
+      await ConversationResource.fetchConversationWithoutContent(auth, cId, {
+        includeForkingData: true,
+      });
+
+    if (conversationRes.isErr()) {
+      // Distinguish between "not found" and "access restricted" for the UI.
+      const canAccess = await ConversationResource.canAccess(auth, cId);
+      const error =
+        canAccess === "conversation_access_restricted"
+          ? new ConversationError("conversation_access_restricted")
+          : conversationRes.error;
+      return apiErrorForConversation(ctx, error);
+    }
+
+    const conversation = conversationRes.value;
+
+    void emitAuditLogEvent({
+      auth,
+      action: "conversation.accessed",
+      targets: [
+        buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+        buildAuditLogTarget("conversation", {
+          sId: conversation.sId,
+          name: conversation.title ?? "",
+        }),
+      ],
+      context: getAuditLogContext(auth),
+      metadata: {
+        conversation_id: conversation.sId,
+      },
     });
 
-  if (conversationRes.isErr()) {
-    // Distinguish between "not found" and "access restricted" for the UI.
-    const canAccess = await ConversationResource.canAccess(auth, cId);
-    const error =
-      canAccess === "conversation_access_restricted"
-        ? new ConversationError("conversation_access_restricted")
-        : conversationRes.error;
-    return apiErrorForConversation(ctx, error);
+    return ctx.json({ conversation });
   }
+);
 
-  const conversation = conversationRes.value;
-
-  void emitAuditLogEvent({
-    auth,
-    action: "conversation.accessed",
-    targets: [
-      buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
-      buildAuditLogTarget("conversation", {
-        sId: conversation.sId,
-        name: conversation.title ?? "",
-      }),
-    ],
-    context: getAuditLogContext(auth),
-    metadata: {
-      conversation_id: conversation.sId,
-    },
-  });
-
-  return ctx.json({ conversation });
-});
-
-app.delete("/", async (ctx) => {
+app.delete("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const cId = ctx.req.param("cId") ?? "";
+  const { cId } = ctx.req.valid("param");
   const forceDelete = ctx.req.query("forceDelete") === "true";
 
   const result = await deleteOrLeaveConversation(auth, {
@@ -122,10 +130,11 @@ app.delete("/", async (ctx) => {
 
 app.patch(
   "/",
+  validate("param", ParamsSchema),
   validate("json", PatchConversationsRequestBodySchema),
   async (ctx): HandlerResult<PatchConversationResponseBody> => {
     const auth = ctx.get("auth");
-    const cId = ctx.req.param("cId") ?? "";
+    const { cId } = ctx.req.valid("param");
 
     const conversationRes =
       await ConversationResource.fetchConversationWithoutContent(auth, cId);

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.ts
@@ -12,6 +12,10 @@ export type MentionSuggestionsResponseBody = {
   suggestions: RichMention[];
 };
 
+const ParamsSchema = z.object({
+  cId: z.string(),
+});
+
 const MentionSuggestionsQuerySchema = z.object({
   query: z.string().optional().default(""),
   select: z.union([z.string(), z.array(z.string())]).optional(),
@@ -23,10 +27,11 @@ const app = workspaceApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   validate("query", MentionSuggestionsQuerySchema),
   async (ctx): HandlerResult<MentionSuggestionsResponseBody> => {
     const auth = ctx.get("auth");
-    const cId = ctx.req.param("cId") ?? "";
+    const { cId } = ctx.req.valid("param");
 
     const conversationRes = await ConversationResource.fetchById(auth, cId);
     if (!conversationRes) {

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/actions/[aId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/actions/[aId]/index.ts
@@ -2,15 +2,21 @@ import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_reso
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  cId: z.string(),
+  mId: z.string(),
+  aId: z.string(),
+});
 
 // Mounted at /api/w/:wId/assistant/conversations/:cId/messages/:mId/actions/:aId.
 const app = workspaceApp();
 
-app.get("/", async (ctx) => {
+app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const cId = ctx.req.param("cId") ?? "";
-  const mId = ctx.req.param("mId") ?? "";
-  const aId = ctx.req.param("aId") ?? "";
+  const { cId, mId, aId } = ctx.req.valid("param");
 
   const conversation = await ConversationResource.fetchById(auth, cId);
   if (!conversation) {

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/answer-question.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/answer-question.ts
@@ -6,6 +6,11 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
+const ParamsSchema = z.object({
+  cId: z.string(),
+  mId: z.string(),
+});
+
 const AnswerQuestionRequestSchema = z.object({
   actionId: z.string(),
   answer: UserQuestionAnswerSchema,
@@ -14,72 +19,76 @@ const AnswerQuestionRequestSchema = z.object({
 // Mounted at /api/w/:wId/assistant/conversations/:cId/messages/:mId/answer-question.
 const app = workspaceApp();
 
-app.post("/", validate("json", AnswerQuestionRequestSchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const cId = ctx.req.param("cId") ?? "";
-  const mId = ctx.req.param("mId") ?? "";
+app.post(
+  "/",
+  validate("param", ParamsSchema),
+  validate("json", AnswerQuestionRequestSchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { cId, mId } = ctx.req.valid("param");
 
-  const conversation = await ConversationResource.fetchById(auth, cId);
-  if (!conversation) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "Conversation not found.",
-      },
-    });
-  }
-
-  const { actionId, answer } = ctx.req.valid("json");
-
-  const result = await registerUserAnswer(auth, conversation, {
-    actionId,
-    messageId: mId,
-    answer,
-  });
-
-  if (result.isErr()) {
-    switch (result.error.code) {
-      case "unauthorized":
-        return apiError(ctx, {
-          status_code: 403,
-          api_error: {
-            type: "workspace_auth_error",
-            message: result.error.message,
-          },
-        });
-      case "action_not_blocked":
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: {
-            type: "action_not_blocked",
-            message: result.error.message,
-          },
-        });
-      case "action_not_found":
-        return apiError(ctx, {
-          status_code: 404,
-          api_error: {
-            type: "action_not_found",
-            message: result.error.message,
-          },
-        });
-      default:
-        return apiError(
-          ctx,
-          {
-            status_code: 500,
-            api_error: {
-              type: "internal_server_error",
-              message: "Failed to answer question",
-            },
-          },
-          result.error
-        );
+    const conversation = await ConversationResource.fetchById(auth, cId);
+    if (!conversation) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: "Conversation not found.",
+        },
+      });
     }
-  }
 
-  return ctx.json({ success: true });
-});
+    const { actionId, answer } = ctx.req.valid("json");
+
+    const result = await registerUserAnswer(auth, conversation, {
+      actionId,
+      messageId: mId,
+      answer,
+    });
+
+    if (result.isErr()) {
+      switch (result.error.code) {
+        case "unauthorized":
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
+              message: result.error.message,
+            },
+          });
+        case "action_not_blocked":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "action_not_blocked",
+              message: result.error.message,
+            },
+          });
+        case "action_not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: {
+              type: "action_not_found",
+              message: result.error.message,
+            },
+          });
+        default:
+          return apiError(
+            ctx,
+            {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
+                message: "Failed to answer question",
+              },
+            },
+            result.error
+          );
+      }
+    }
+
+    return ctx.json({ success: true });
+  }
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -16,6 +16,11 @@ const UserMentionSchema = z.object({
   userId: z.string(),
 });
 
+const ParamsSchema = z.object({
+  cId: z.string(),
+  mId: z.string(),
+});
+
 const PostEditRequestBodySchema = z.object({
   content: z.string(),
   mentions: z.array(z.union([AgentMentionSchema, UserMentionSchema])),
@@ -24,80 +29,89 @@ const PostEditRequestBodySchema = z.object({
 // Mounted at /api/w/:wId/assistant/conversations/:cId/messages/:mId/edit.
 const app = workspaceApp();
 
-app.post("/", validate("json", PostEditRequestBodySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const conversationId = ctx.req.param("cId") ?? "";
-  const messageId = ctx.req.param("mId") ?? "";
+app.post(
+  "/",
+  validate("param", ParamsSchema),
+  validate("json", PostEditRequestBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { cId: conversationId, mId: messageId } = ctx.req.valid("param");
 
-  const conversationResource = await ConversationResource.fetchById(
-    auth,
-    conversationId
-  );
+    const conversationResource = await ConversationResource.fetchById(
+      auth,
+      conversationId
+    );
 
-  if (!conversationResource) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "Conversation not found.",
-      },
+    if (!conversationResource) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: "Conversation not found.",
+        },
+      });
+    }
+
+    const messageRes = await conversationResource.getMessageById(
+      auth,
+      messageId
+    );
+    if (messageRes.isErr()) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "message_not_found",
+          message:
+            "The message you're trying to edit does not exist or is not accessible.",
+        },
+      });
+    }
+
+    const branchId = messageRes.value.getBranchId() ?? null;
+
+    const conversationRes = await getConversation(
+      auth,
+      conversationId,
+      false,
+      branchId
+    );
+
+    if (conversationRes.isErr()) {
+      return apiErrorForConversation(ctx, conversationRes.error);
+    }
+
+    const conversation = conversationRes.value;
+
+    const message = conversation.content
+      .flat()
+      .find((m) => m.sId === messageId);
+    if (!message || !isUserMessageType(message)) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "The message you're trying to edit does not exist or is not an user message.",
+        },
+      });
+    }
+
+    const { content, mentions } = ctx.req.valid("json");
+
+    const editedMessageRes = await editUserMessage(auth, {
+      conversation,
+      message,
+      content,
+      mentions,
+      // For now we never skip tools when interacting with agents from the web client.
+      skipToolsValidation: false,
     });
+    if (editedMessageRes.isErr()) {
+      return apiError(ctx, editedMessageRes.error);
+    }
+
+    return ctx.json({ message: editedMessageRes.value.userMessage });
   }
-
-  const messageRes = await conversationResource.getMessageById(auth, messageId);
-  if (messageRes.isErr()) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "message_not_found",
-        message:
-          "The message you're trying to edit does not exist or is not accessible.",
-      },
-    });
-  }
-
-  const branchId = messageRes.value.getBranchId() ?? null;
-
-  const conversationRes = await getConversation(
-    auth,
-    conversationId,
-    false,
-    branchId
-  );
-
-  if (conversationRes.isErr()) {
-    return apiErrorForConversation(ctx, conversationRes.error);
-  }
-
-  const conversation = conversationRes.value;
-
-  const message = conversation.content.flat().find((m) => m.sId === messageId);
-  if (!message || !isUserMessageType(message)) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message:
-          "The message you're trying to edit does not exist or is not an user message.",
-      },
-    });
-  }
-
-  const { content, mentions } = ctx.req.valid("json");
-
-  const editedMessageRes = await editUserMessage(auth, {
-    conversation,
-    message,
-    content,
-    mentions,
-    // For now we never skip tools when interacting with agents from the web client.
-    skipToolsValidation: false,
-  });
-  if (editedMessageRes.isErr()) {
-    return apiError(ctx, editedMessageRes.error);
-  }
-
-  return ctx.json({ message: editedMessageRes.value.userMessage });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks/index.ts
@@ -11,6 +11,11 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
+const ParamsSchema = z.object({
+  cId: z.string(),
+  mId: z.string(),
+});
+
 const MessageFeedbackRequestBodySchema = z.object({
   thumbDirection: z.string(),
   feedbackContent: z.string().nullish(),
@@ -22,12 +27,12 @@ const app = workspaceApp();
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   validate("json", MessageFeedbackRequestBodySchema),
   async (ctx) => {
     const auth = ctx.get("auth");
     const user = auth.getNonNullableUser();
-    const conversationId = ctx.req.param("cId") ?? "";
-    const messageId = ctx.req.param("mId") ?? "";
+    const { cId: conversationId, mId: messageId } = ctx.req.valid("param");
 
     const conversationResource = await ConversationResource.fetchById(
       auth,
@@ -100,11 +105,10 @@ app.post(
   }
 );
 
-app.delete("/", async (ctx) => {
+app.delete("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
   const user = auth.getNonNullableUser();
-  const conversationId = ctx.req.param("cId") ?? "";
-  const messageId = ctx.req.param("mId") ?? "";
+  const { cId: conversationId, mId: messageId } = ctx.req.valid("param");
 
   const conversationResource = await ConversationResource.fetchById(
     auth,

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
@@ -16,6 +16,8 @@ import {
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 import actions from "./actions";
 import answerQuestion from "./answer-question";
@@ -31,13 +33,17 @@ import retry from "./retry";
 import skills from "./skills";
 import validateAction from "./validate-action";
 
+const ParamsSchema = z.object({
+  cId: z.string(),
+  mId: z.string(),
+});
+
 // Mounted under /api/w/:wId/assistant/conversations/:cId/messages/:mId.
 const app = workspaceApp();
 
-app.get("/", async (ctx) => {
+app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const cId = ctx.req.param("cId") ?? "";
-  const mId = ctx.req.param("mId") ?? "";
+  const { cId, mId } = ctx.req.valid("param");
 
   const conversation = await ConversationResource.fetchById(auth, cId);
   if (!conversation) {
@@ -92,10 +98,9 @@ app.get("/", async (ctx) => {
   }
 });
 
-app.delete("/", async (ctx) => {
+app.delete("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const cId = ctx.req.param("cId") ?? "";
-  const mId = ctx.req.param("mId") ?? "";
+  const { cId, mId } = ctx.req.valid("param");
 
   const conversation = await ConversationResource.fetchById(auth, cId);
   if (!conversation) {

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/mentions.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/mentions.ts
@@ -13,6 +13,11 @@ export type PostMentionActionResponseBody = {
   success: boolean;
 };
 
+const ParamsSchema = z.object({
+  cId: z.string(),
+  mId: z.string(),
+});
+
 const PostMentionActionRequestBodySchema = z.object({
   type: z.enum(["agent", "user"]),
   id: z.string(),
@@ -24,11 +29,11 @@ const app = workspaceApp();
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   validate("json", PostMentionActionRequestBodySchema),
   async (ctx): HandlerResult<PostMentionActionResponseBody> => {
     const auth = ctx.get("auth");
-    const cId = ctx.req.param("cId") ?? "";
-    const mId = ctx.req.param("mId") ?? "";
+    const { cId, mId } = ctx.req.valid("param");
 
     const conversation = await ConversationResource.fetchById(auth, cId);
     if (!conversation) {

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/raw_content_fragment/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/raw_content_fragment/index.ts
@@ -7,8 +7,15 @@ import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversati
 import { createHono } from "@front-api/lib/hono";
 import type { WorkspaceAwareCtx } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import type { HttpBindings } from "@hono/node-server";
 import { IncomingForm } from "formidable";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  cId: z.string(),
+  mId: z.string(),
+});
 
 const privateUploadGcs = getPrivateUploadBucket();
 
@@ -31,11 +38,10 @@ function isValidContentFormat(
 // handler.
 const app = createHono<WorkspaceAwareCtx & { Bindings: HttpBindings }>();
 
-app.get("/", async (ctx) => {
+app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
   const owner = auth.getNonNullableWorkspace();
-  const conversationId = ctx.req.param("cId") ?? "";
-  const messageId = ctx.req.param("mId") ?? "";
+  const { cId: conversationId, mId: messageId } = ctx.req.valid("param");
 
   const conversationRes = await getConversation(auth, conversationId);
   if (conversationRes.isErr()) {
@@ -78,11 +84,10 @@ app.get("/", async (ctx) => {
 });
 
 // TODO(2024-07-02 flav) Remove this endpoint.
-app.post("/", async (ctx) => {
+app.post("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
   const owner = auth.getNonNullableWorkspace();
-  const conversationId = ctx.req.param("cId") ?? "";
-  const messageId = ctx.req.param("mId") ?? "";
+  const { cId: conversationId, mId: messageId } = ctx.req.valid("param");
 
   const conversationRes = await getConversation(auth, conversationId);
   if (conversationRes.isErr()) {

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/reactions/index.ts
@@ -13,6 +13,11 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
+const ParamsSchema = z.object({
+  cId: z.string(),
+  mId: z.string(),
+});
+
 const MessageReactionRequestBodySchema = z.object({
   reaction: z.string(),
 });
@@ -22,12 +27,12 @@ const app = workspaceApp();
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   validate("json", MessageReactionRequestBodySchema),
   async (ctx) => {
     const auth = ctx.get("auth");
     const user = auth.getNonNullableUser();
-    const conversationId = ctx.req.param("cId") ?? "";
-    const messageId = ctx.req.param("mId") ?? "";
+    const { cId: conversationId, mId: messageId } = ctx.req.valid("param");
 
     const conversation = await ConversationResource.fetchById(
       auth,
@@ -126,12 +131,12 @@ app.post(
 
 app.delete(
   "/",
+  validate("param", ParamsSchema),
   validate("json", MessageReactionRequestBodySchema),
   async (ctx) => {
     const auth = ctx.get("auth");
     const user = auth.getNonNullableUser();
-    const conversationId = ctx.req.param("cId") ?? "";
-    const messageId = ctx.req.param("mId") ?? "";
+    const { cId: conversationId, mId: messageId } = ctx.req.valid("param");
 
     const conversation = await ConversationResource.fetchById(
       auth,

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
@@ -7,14 +7,20 @@ import { isAgentMessageType } from "@app/types/assistant/conversation";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  cId: z.string(),
+  mId: z.string(),
+});
 
 // Mounted at /api/w/:wId/assistant/conversations/:cId/messages/:mId/retry.
 const app = workspaceApp();
 
-app.post("/", async (ctx) => {
+app.post("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const conversationId = ctx.req.param("cId") ?? "";
-  const messageId = ctx.req.param("mId") ?? "";
+  const { cId: conversationId, mId: messageId } = ctx.req.valid("param");
 
   const conversationResource = await ConversationResource.fetchById(
     auth,

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/skills.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/skills.ts
@@ -4,6 +4,13 @@ import type { SkillType } from "@app/types/assistant/skill_configuration";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  cId: z.string(),
+  mId: z.string(),
+});
 
 export type GetAgentMessageSkillsResponseBody = {
   skills: SkillType[];
@@ -12,51 +19,54 @@ export type GetAgentMessageSkillsResponseBody = {
 // Mounted at /api/w/:wId/assistant/conversations/:cId/messages/:mId/skills.
 const app = workspaceApp();
 
-app.get("/", async (ctx): HandlerResult<GetAgentMessageSkillsResponseBody> => {
-  const auth = ctx.get("auth");
-  const cId = ctx.req.param("cId") ?? "";
-  const mId = ctx.req.param("mId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetAgentMessageSkillsResponseBody> => {
+    const auth = ctx.get("auth");
+    const { cId, mId } = ctx.req.valid("param");
 
-  const conversation = await ConversationResource.fetchById(auth, cId);
-  if (!conversation) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "Conversation not found.",
-      },
+    const conversation = await ConversationResource.fetchById(auth, cId);
+    if (!conversation) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: "Conversation not found.",
+        },
+      });
+    }
+
+    const messageRes = await conversation.getMessageById(auth, mId);
+    if (messageRes.isErr()) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "message_not_found",
+          message: "Message not found.",
+        },
+      });
+    }
+
+    if (!messageRes.value.agentMessageId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Message is not an agent message.",
+        },
+      });
+    }
+
+    const skills = await SkillResource.listByAgentMessageId(
+      auth,
+      messageRes.value.agentMessageId
+    );
+
+    return ctx.json({
+      skills: skills.map((skill) => skill.toJSON(auth)),
     });
   }
-
-  const messageRes = await conversation.getMessageById(auth, mId);
-  if (messageRes.isErr()) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "message_not_found",
-        message: "Message not found.",
-      },
-    });
-  }
-
-  if (!messageRes.value.agentMessageId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Message is not an agent message.",
-      },
-    });
-  }
-
-  const skills = await SkillResource.listByAgentMessageId(
-    auth,
-    messageRes.value.agentMessageId
-  );
-
-  return ctx.json({
-    skills: skills.map((skill) => skill.toJSON(auth)),
-  });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
@@ -5,6 +5,11 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
+const ParamsSchema = z.object({
+  cId: z.string(),
+  mId: z.string(),
+});
+
 const ValidateActionSchema = z.object({
   actionId: z.string(),
   approved: z.enum(["approved", "rejected", "always_approved"]),
@@ -14,66 +19,70 @@ const ValidateActionSchema = z.object({
 // Mounted at /api/w/:wId/assistant/conversations/:cId/messages/:mId/validate-action.
 const app = workspaceApp();
 
-app.post("/", validate("json", ValidateActionSchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const cId = ctx.req.param("cId") ?? "";
-  const mId = ctx.req.param("mId") ?? "";
+app.post(
+  "/",
+  validate("param", ParamsSchema),
+  validate("json", ValidateActionSchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { cId, mId } = ctx.req.valid("param");
 
-  const conversation = await ConversationResource.fetchById(auth, cId);
-  if (!conversation) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "Conversation not found.",
-      },
-    });
-  }
-
-  const { actionId, approved, resumeAncestorConversations } =
-    ctx.req.valid("json");
-
-  const result = await validateAction(auth, conversation, {
-    actionId,
-    approvalState: approved,
-    messageId: mId,
-    resumeAncestorConversations,
-  });
-
-  if (result.isErr()) {
-    switch (result.error.code) {
-      case "action_not_blocked":
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: {
-            type: "action_not_blocked",
-            message: result.error.message,
-          },
-        });
-      case "action_not_found":
-        return apiError(ctx, {
-          status_code: 404,
-          api_error: {
-            type: "action_not_found",
-            message: result.error.message,
-          },
-        });
-      default:
-        return apiError(
-          ctx,
-          {
-            status_code: 500,
-            api_error: {
-              type: "internal_server_error",
-              message: "Failed to validate action",
-            },
-          },
-          result.error
-        );
+    const conversation = await ConversationResource.fetchById(auth, cId);
+    if (!conversation) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: "Conversation not found.",
+        },
+      });
     }
-  }
 
-  return ctx.json({ success: true });
-});
+    const { actionId, approved, resumeAncestorConversations } =
+      ctx.req.valid("json");
+
+    const result = await validateAction(auth, conversation, {
+      actionId,
+      approvalState: approved,
+      messageId: mId,
+      resumeAncestorConversations,
+    });
+
+    if (result.isErr()) {
+      switch (result.error.code) {
+        case "action_not_blocked":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "action_not_blocked",
+              message: result.error.message,
+            },
+          });
+        case "action_not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: {
+              type: "action_not_found",
+              message: result.error.message,
+            },
+          });
+        default:
+          return apiError(
+            ctx,
+            {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
+                message: "Failed to validate action",
+              },
+            },
+            result.error
+          );
+      }
+    }
+
+    return ctx.json({ success: true });
+  }
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -24,8 +24,13 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 import message from "./[mId]";
+
+const ParamsSchema = z.object({
+  cId: z.string(),
+});
 
 export type PostMessagesResponseBody = {
   message: UserMessageType;
@@ -51,13 +56,14 @@ const app = workspaceApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   async (
     ctx
   ): HandlerResult<
     LegacyFetchConversationMessagesResponse | FetchConversationMessagesResponse
   > => {
     const auth = ctx.get("auth");
-    const conversationId = ctx.req.param("cId") ?? "";
+    const { cId: conversationId } = ctx.req.valid("param");
 
     const messageStartTime = performance.now();
 
@@ -120,11 +126,12 @@ app.get(
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   validate("json", InternalPostMessagesRequestBodySchema),
   async (ctx): HandlerResult<PostMessagesResponseBody> => {
     const auth = ctx.get("auth");
     const user = auth.getNonNullableUser();
-    const conversationId = ctx.req.param("cId") ?? "";
+    const { cId: conversationId } = ctx.req.valid("param");
 
     const { content, context, mentions, skipToolsValidation } =
       ctx.req.valid("json");

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/onboarding-followup.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/onboarding-followup.ts
@@ -9,6 +9,12 @@ import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversati
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  cId: z.string(),
+});
 
 export type PostOnboardingFollowupResponseBody = {
   agentMessages: AgentMessageType[];
@@ -19,10 +25,11 @@ const app = workspaceApp();
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   async (ctx): HandlerResult<PostOnboardingFollowupResponseBody> => {
     const auth = ctx.get("auth");
     const user = auth.getNonNullableUser();
-    const conversationId = ctx.req.param("cId") ?? "";
+    const { cId: conversationId } = ctx.req.valid("param");
 
     const body = await ctx.req.json().catch(() => ({}));
     const { toolId } = body;

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/participants.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/participants.ts
@@ -4,13 +4,19 @@ import { ConversationError } from "@app/types/assistant/conversation";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  cId: z.string(),
+});
 
 // Mounted at /api/w/:wId/assistant/conversations/:cId/participants.
 const app = workspaceApp();
 
-app.get("/", async (ctx) => {
+app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const conversationId = ctx.req.param("cId") ?? "";
+  const { cId: conversationId } = ctx.req.valid("param");
 
   const conversationRes =
     await ConversationResource.fetchConversationWithoutContent(
@@ -38,9 +44,9 @@ app.get("/", async (ctx) => {
   return ctx.json({ participants: participantsRes.value });
 });
 
-app.post("/", async (ctx) => {
+app.post("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const conversationId = ctx.req.param("cId") ?? "";
+  const { cId: conversationId } = ctx.req.valid("param");
 
   const conversationRes =
     await ConversationResource.fetchConversationWithoutContent(

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/plan_mode.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/plan_mode.ts
@@ -11,6 +11,12 @@ import type { FileType } from "@app/types/files";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  cId: z.string(),
+});
 
 export type PlanApprovalState = "draft" | "pending" | "approved";
 
@@ -25,9 +31,10 @@ const app = workspaceApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   async (ctx): HandlerResult<GetConversationPlanModeResponseBody> => {
     const auth = ctx.get("auth");
-    const cId = ctx.req.param("cId") ?? "";
+    const { cId } = ctx.req.valid("param");
 
     // Ensure the caller has access to the conversation.
     const conversationRes = await getLightConversation(auth, cId);

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/sandbox/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/sandbox/index.ts
@@ -4,6 +4,12 @@ import type { SandboxStatus } from "@app/lib/resources/storage/models/sandbox";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  cId: z.string(),
+});
 
 export type GetConversationSandboxResponseBody = {
   sandboxStatus: SandboxStatus | null;
@@ -12,26 +18,30 @@ export type GetConversationSandboxResponseBody = {
 // Mounted at /api/w/:wId/assistant/conversations/:cId/sandbox.
 const app = workspaceApp();
 
-app.get("/", async (ctx): HandlerResult<GetConversationSandboxResponseBody> => {
-  const auth = ctx.get("auth");
-  const cId = ctx.req.param("cId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetConversationSandboxResponseBody> => {
+    const auth = ctx.get("auth");
+    const { cId } = ctx.req.valid("param");
 
-  const conversation = await ConversationResource.fetchById(auth, cId);
-  if (!conversation) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "conversation_not_found",
-        message: "The conversation you're trying to access was not found.",
-      },
+    const conversation = await ConversationResource.fetchById(auth, cId);
+    if (!conversation) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "conversation_not_found",
+          message: "The conversation you're trying to access was not found.",
+        },
+      });
+    }
+
+    const sandbox = await SandboxResource.fetchByConversationId(auth, cId);
+
+    return ctx.json({
+      sandboxStatus: sandbox?.status ?? null,
     });
   }
-
-  const sandbox = await SandboxResource.fetchByConversationId(auth, cId);
-
-  return ctx.json({
-    sandboxStatus: sandbox?.status ?? null,
-  });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/skills.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/skills.ts
@@ -7,6 +7,10 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
+const ParamsSchema = z.object({
+  cId: z.string(),
+});
+
 const ConversationSkillActionRequestSchema = z.object({
   action: z.enum(["add", "delete"]),
   skillId: z.string(),
@@ -15,9 +19,9 @@ const ConversationSkillActionRequestSchema = z.object({
 // Mounted at /api/w/:wId/assistant/conversations/:cId/skills.
 const app = workspaceApp();
 
-app.get("/", async (ctx) => {
+app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const conversationId = ctx.req.param("cId") ?? "";
+  const { cId: conversationId } = ctx.req.valid("param");
 
   const conversationRes =
     await ConversationResource.fetchConversationWithoutContent(
@@ -38,10 +42,11 @@ app.get("/", async (ctx) => {
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   validate("json", ConversationSkillActionRequestSchema),
   async (ctx) => {
     const auth = ctx.get("auth");
-    const conversationId = ctx.req.param("cId") ?? "";
+    const { cId: conversationId } = ctx.req.valid("param");
 
     const conversationRes =
       await ConversationResource.fetchConversationWithoutContent(

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/tools.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/tools.ts
@@ -7,6 +7,10 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
+const ParamsSchema = z.object({
+  cId: z.string(),
+});
+
 const ConversationToolActionRequestSchema = z.object({
   action: z.enum(["add", "delete"]),
   mcp_server_view_id: z.string(),
@@ -15,9 +19,9 @@ const ConversationToolActionRequestSchema = z.object({
 // Mounted at /api/w/:wId/assistant/conversations/:cId/tools.
 const app = workspaceApp();
 
-app.get("/", async (ctx) => {
+app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const conversationId = ctx.req.param("cId") ?? "";
+  const { cId: conversationId } = ctx.req.valid("param");
 
   const conversationRes =
     await ConversationResource.fetchConversationWithoutContent(
@@ -56,10 +60,11 @@ app.get("/", async (ctx) => {
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   validate("json", ConversationToolActionRequestSchema),
   async (ctx) => {
     const auth = ctx.get("auth");
-    const conversationId = ctx.req.param("cId") ?? "";
+    const { cId: conversationId } = ctx.req.valid("param");
 
     const conversationRes =
       await ConversationResource.fetchConversationWithoutContent(

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/wakeups/[wuId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/wakeups/[wuId]/index.ts
@@ -5,6 +5,13 @@ import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversati
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  cId: z.string(),
+  wuId: z.string(),
+});
 
 export type DeleteConversationWakeUpResponseBody = {
   wakeUp: WakeUpType;
@@ -15,10 +22,10 @@ const app = workspaceApp();
 
 app.delete(
   "/",
+  validate("param", ParamsSchema),
   async (ctx): HandlerResult<DeleteConversationWakeUpResponseBody> => {
     const auth = ctx.get("auth");
-    const cId = ctx.req.param("cId") ?? "";
-    const wuId = ctx.req.param("wuId") ?? "";
+    const { cId, wuId } = ctx.req.valid("param");
 
     // The fetchConversationWithoutContent method checks for conversation
     // accessibility (inside the resource through `baseFetchWithAuthorization`).

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/wakeups/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/wakeups/index.ts
@@ -4,8 +4,14 @@ import type { WakeUpType } from "@app/types/assistant/wakeups";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 import wakeup from "./[wuId]";
+
+const ParamsSchema = z.object({
+  cId: z.string(),
+});
 
 export type GetConversationWakeUpsResponseBody = {
   wakeUps: WakeUpType[];
@@ -14,22 +20,26 @@ export type GetConversationWakeUpsResponseBody = {
 // Mounted at /api/w/:wId/assistant/conversations/:cId/wakeups.
 const app = workspaceApp();
 
-app.get("/", async (ctx): HandlerResult<GetConversationWakeUpsResponseBody> => {
-  const auth = ctx.get("auth");
-  const cId = ctx.req.param("cId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetConversationWakeUpsResponseBody> => {
+    const auth = ctx.get("auth");
+    const { cId } = ctx.req.valid("param");
 
-  // The fetchConversationWithoutContent method checks for conversation
-  // accessibility (inside the resource through `baseFetchWithAuthorization`).
-  const conversationRes =
-    await ConversationResource.fetchConversationWithoutContent(auth, cId);
-  if (conversationRes.isErr()) {
-    return apiErrorForConversation(ctx, conversationRes.error);
+    // The fetchConversationWithoutContent method checks for conversation
+    // accessibility (inside the resource through `baseFetchWithAuthorization`).
+    const conversationRes =
+      await ConversationResource.fetchConversationWithoutContent(auth, cId);
+    if (conversationRes.isErr()) {
+      return apiErrorForConversation(ctx, conversationRes.error);
+    }
+    const conversation = conversationRes.value;
+
+    const wakeUps = await WakeUpResource.listByConversation(auth, conversation);
+    return ctx.json({ wakeUps: wakeUps.map((w) => w.toJSON()) });
   }
-  const conversation = conversationRes.value;
-
-  const wakeUps = await WakeUpResource.listByConversation(auth, conversation);
-  return ctx.json({ wakeUps: wakeUps.map((w) => w.toJSON()) });
-});
+);
 
 app.route("/:wuId", wakeup);
 

--- a/front-api/routes/w/[wId]/assistant/conversations/spaces/[spaceId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/spaces/[spaceId]/index.ts
@@ -8,6 +8,12 @@ import { removeNulls } from "@app/types/shared/utils/general";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  spaceId: z.string(),
+});
 
 export type GetSpaceConversationsResponseBody = {
   conversations: LightConversationType[];
@@ -34,87 +40,91 @@ import unread from "./unread";
 // Mounted at /api/w/:wId/assistant/conversations/spaces/:spaceId.
 const app = workspaceApp();
 
-app.get("/", async (ctx): HandlerResult<GetSpaceConversationsResponseBody> => {
-  const auth = ctx.get("auth");
-  const spaceId = ctx.req.param("spaceId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetSpaceConversationsResponseBody> => {
+    const auth = ctx.get("auth");
+    const { spaceId } = ctx.req.valid("param");
 
-  const paginationRes = getPaginationParams(ctx.req.query(), {
-    defaultLimit: 20,
-    defaultOrderColumn: "updatedAt",
-    defaultOrderDirection: "desc",
-    supportedOrderColumn: ["updatedAt"],
-  });
-
-  if (paginationRes.isErr()) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: paginationRes.error.reason,
-      },
+    const paginationRes = getPaginationParams(ctx.req.query(), {
+      defaultLimit: 20,
+      defaultOrderColumn: "updatedAt",
+      defaultOrderDirection: "desc",
+      supportedOrderColumn: ["updatedAt"],
     });
-  }
 
-  const pagination = paginationRes.value;
-  const conversationFilter = parseFilter(ctx.req.query("filter"));
+    if (paginationRes.isErr()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: paginationRes.error.reason,
+        },
+      });
+    }
 
-  // Fetch and verify space access.
-  const space = await SpaceResource.fetchById(auth, spaceId);
-  if (!space || !space.canReadOrAdministrate(auth)) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "space_not_found",
-        message: "Space not found or access denied",
-      },
-    });
-  }
+    const pagination = paginationRes.value;
+    const conversationFilter = parseFilter(ctx.req.query("filter"));
 
-  // Get paginated conversations for the space.
-  const {
-    conversations: spaceConversations,
-    hasMore,
-    lastValue,
-  } = await ConversationResource.listConversationsInSpacePaginated(auth, {
-    spaceId,
-    options: { excludeTest: true },
-    pagination: {
-      limit: pagination.limit,
-      lastValue: pagination.lastValue,
-      orderDirection: pagination.orderDirection,
-    },
-    filter: conversationFilter,
-  });
+    // Fetch and verify space access.
+    const space = await SpaceResource.fetchById(auth, spaceId);
+    if (!space || !space.canReadOrAdministrate(auth)) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "space_not_found",
+          message: "Space not found or access denied",
+        },
+      });
+    }
 
-  const { conversations: allConversations } =
-    await ConversationResource.listConversationsInSpacePaginated(auth, {
+    // Get paginated conversations for the space.
+    const {
+      conversations: spaceConversations,
+      hasMore,
+      lastValue,
+    } = await ConversationResource.listConversationsInSpacePaginated(auth, {
       spaceId,
       options: { excludeTest: true },
       pagination: {
-        limit: 1,
+        limit: pagination.limit,
+        lastValue: pagination.lastValue,
         orderDirection: pagination.orderDirection,
       },
-      filter: "all",
+      filter: conversationFilter,
     });
-  const isEmpty = allConversations.length === 0;
 
-  // Fetch full conversation details for the paginated results.
-  // N+1 queries here, bad for scaling — TODO(@jd) find a better way.
-  const spaceConversationsFull = await concurrentExecutor(
-    spaceConversations,
-    async (conv) => getLightConversation(auth, conv.sId),
-    { concurrency: 10 }
-  );
+    const { conversations: allConversations } =
+      await ConversationResource.listConversationsInSpacePaginated(auth, {
+        spaceId,
+        options: { excludeTest: true },
+        pagination: {
+          limit: 1,
+          orderDirection: pagination.orderDirection,
+        },
+        filter: "all",
+      });
+    const isEmpty = allConversations.length === 0;
 
-  return ctx.json({
-    conversations: removeNulls(
-      spaceConversationsFull.map((res) => (res.isOk() ? res.value : null))
-    ),
-    hasMore,
-    lastValue,
-    isEmpty,
-  });
-});
+    // Fetch full conversation details for the paginated results.
+    // N+1 queries here, bad for scaling — TODO(@jd) find a better way.
+    const spaceConversationsFull = await concurrentExecutor(
+      spaceConversations,
+      async (conv) => getLightConversation(auth, conv.sId),
+      { concurrency: 10 }
+    );
+
+    return ctx.json({
+      conversations: removeNulls(
+        spaceConversationsFull.map((res) => (res.isOk() ? res.value : null))
+      ),
+      hasMore,
+      lastValue,
+      isEmpty,
+    });
+  }
+);
 
 app.route("/unread", unread);
 

--- a/front-api/routes/w/[wId]/assistant/conversations/spaces/[spaceId]/unread.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/spaces/[spaceId]/unread.ts
@@ -3,6 +3,12 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  spaceId: z.string(),
+});
 
 export type GetSpaceUnreadConversationsResponseBody = {
   unreadConversationIds: string[];
@@ -13,9 +19,10 @@ const app = workspaceApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   async (ctx): HandlerResult<GetSpaceUnreadConversationsResponseBody> => {
     const auth = ctx.get("auth");
-    const spaceId = ctx.req.param("spaceId") ?? "";
+    const { spaceId } = ctx.req.valid("param");
 
     const space = await SpaceResource.fetchById(auth, spaceId);
     if (!space || !space.canReadOrAdministrate(auth)) {

--- a/front-api/routes/w/[wId]/assistant/global_agents/[aId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/global_agents/[aId]/index.ts
@@ -6,6 +6,10 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 const PatchGlobalAgentSettingsRequestBodySchema = z.object({
   status: z.enum(["active", "disabled_by_admin"]),
 });
@@ -19,11 +23,12 @@ const app = workspaceApp();
 
 app.patch(
   "/",
+  validate("param", ParamsSchema),
   ensureIsBuilder(),
   validate("json", PatchGlobalAgentSettingsRequestBodySchema),
   async (ctx): HandlerResult<PatchGlobalAgentSettingResponseBody> => {
     const auth = ctx.get("auth");
-    const agentId = ctx.req.param("aId") ?? "";
+    const { aId: agentId } = ctx.req.valid("param");
     const body = ctx.req.valid("json");
 
     const created = await upsertGlobalAgentSettings(auth, {

--- a/front-api/routes/w/[wId]/auth-context.ts
+++ b/front-api/routes/w/[wId]/auth-context.ts
@@ -8,6 +8,12 @@ import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import { sessionApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  wId: z.string(),
+});
 
 export type GetWorkspaceAuthContextResponseType = {
   user: UserType;
@@ -31,9 +37,10 @@ const app = sessionApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   async (ctx): HandlerResult<GetWorkspaceAuthContextResponseType> => {
     const session = ctx.get("session");
-    const wId = ctx.req.param("wId") ?? "";
+    const { wId } = ctx.req.valid("param");
 
     const auth = await Authenticator.fromSession(session, wId);
 

--- a/front-api/routes/w/[wId]/builder/assistants/[aId]/actions.ts
+++ b/front-api/routes/w/[wId]/builder/assistants/[aId]/actions.ts
@@ -7,6 +7,12 @@ import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agen
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
 
 export type GetActionsResponseBody = {
   actions: AgentBuilderMCPConfiguration[];
@@ -15,52 +21,56 @@ export type GetActionsResponseBody = {
 // Mounted at /api/w/:wId/builder/assistants/:aId/actions.
 const app = workspaceApp();
 
-app.get("/", async (ctx): HandlerResult<GetActionsResponseBody> => {
-  const auth = ctx.get("auth");
-  const aId = ctx.req.param("aId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetActionsResponseBody> => {
+    const auth = ctx.get("auth");
+    const { aId } = ctx.req.valid("param");
 
-  try {
-    const agentConfiguration = await getAgentConfiguration(auth, {
-      agentId: aId,
-      variant: "full",
-    });
-    if (!agentConfiguration) {
+    try {
+      const agentConfiguration = await getAgentConfiguration(auth, {
+        agentId: aId,
+        variant: "full",
+      });
+      if (!agentConfiguration) {
+        return apiError(ctx, {
+          status_code: 404,
+          api_error: {
+            type: "agent_configuration_not_found",
+            message: "Agent configuration not found.",
+          },
+        });
+      }
+
+      const { dataSourceViews, mcpServerViews } =
+        await getAccessibleSourcesAndAppsForActions(auth);
+      const mcpServerViewsJSON = mcpServerViews.map((v) => v.toJSON());
+
+      const actions = await buildInitialActions({
+        dataSourceViews,
+        configuration: agentConfiguration,
+        mcpServerViews: mcpServerViewsJSON,
+      });
+
+      if (
+        agentConfiguration.scope !== "visible" &&
+        agentConfiguration.scope !== "hidden"
+      ) {
+        throw new Error("Invalid agent scope");
+      }
+
+      return ctx.json({ actions });
+    } catch {
       return apiError(ctx, {
-        status_code: 404,
+        status_code: 500,
         api_error: {
-          type: "agent_configuration_not_found",
-          message: "Agent configuration not found.",
+          type: "internal_server_error",
+          message: "Failed to fetch builder state.",
         },
       });
     }
-
-    const { dataSourceViews, mcpServerViews } =
-      await getAccessibleSourcesAndAppsForActions(auth);
-    const mcpServerViewsJSON = mcpServerViews.map((v) => v.toJSON());
-
-    const actions = await buildInitialActions({
-      dataSourceViews,
-      configuration: agentConfiguration,
-      mcpServerViews: mcpServerViewsJSON,
-    });
-
-    if (
-      agentConfiguration.scope !== "visible" &&
-      agentConfiguration.scope !== "hidden"
-    ) {
-      throw new Error("Invalid agent scope");
-    }
-
-    return ctx.json({ actions });
-  } catch {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Failed to fetch builder state.",
-      },
-    });
   }
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/data_sources/[dsId]/files.ts
+++ b/front-api/routes/w/[wId]/data_sources/[dsId]/files.ts
@@ -4,13 +4,19 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import type { APIErrorType } from "@app/types/error";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  dsId: z.string(),
+});
 
 // Mounted at /api/w/:wId/data_sources/:dsId/files.
 const app = workspaceApp();
 
-app.post("/", async (ctx) => {
+app.post("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const dsId = ctx.req.param("dsId") ?? "";
+  const { dsId } = ctx.req.valid("param");
 
   const body = await ctx.req.json().catch(() => ({}));
   const { fileId, upsertArgs } = body;

--- a/front-api/routes/w/[wId]/data_sources/[dsId]/index.ts
+++ b/front-api/routes/w/[wId]/data_sources/[dsId]/index.ts
@@ -20,16 +20,21 @@ const PostDataSourceBodySchema = z
   })
   .strict();
 
+const ParamsSchema = z.object({
+  dsId: z.string(),
+});
+
 // Mounted under /api/w/:wId/data_sources/:dsId. The bare `/` handles POST to
 // update the data source settings.
 const app = workspaceApp();
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   validate("json", PostDataSourceBodySchema),
   async (ctx): HandlerResult<GetOrPostDataSourceResponseBody> => {
     const auth = ctx.get("auth");
-    const dsId = ctx.req.param("dsId") ?? "";
+    const { dsId } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchById(auth, dsId);
     if (!dataSource) {

--- a/front-api/routes/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
+++ b/front-api/routes/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
@@ -16,6 +16,11 @@ const PostManagedDataSourceConfigRequestBodySchema = z.object({
   configValue: z.string(),
 });
 
+const ParamsSchema = z.object({
+  dsId: z.string(),
+  key: z.string(),
+});
+
 const ALLOWED_CONFIG_KEYS = new Set<string>([
   "botEnabled",
   "pdfEnabled",
@@ -46,10 +51,10 @@ const app = workspaceApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   async (ctx): HandlerResult<GetOrPostManagedDataSourceConfigResponseBody> => {
     const auth = ctx.get("auth");
-    const dsId = ctx.req.param("dsId") ?? "";
-    const configKey = ctx.req.param("key") ?? "";
+    const { dsId, key: configKey } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchById(auth, dsId);
     if (!dataSource) {
@@ -106,11 +111,11 @@ app.get(
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   validate("json", PostManagedDataSourceConfigRequestBodySchema),
   async (ctx): HandlerResult<GetOrPostManagedDataSourceConfigResponseBody> => {
     const auth = ctx.get("auth");
-    const dsId = ctx.req.param("dsId") ?? "";
-    const configKey = ctx.req.param("key") ?? "";
+    const { dsId, key: configKey } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchById(auth, dsId);
     if (!dataSource) {

--- a/front-api/routes/w/[wId]/data_sources/[dsId]/managed/notion/webhook_config.ts
+++ b/front-api/routes/w/[wId]/data_sources/[dsId]/managed/notion/webhook_config.ts
@@ -5,6 +5,12 @@ import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  dsId: z.string(),
+});
 
 export type GetNotionWebhookConfigResponseBody = {
   webhookUrl: string;
@@ -14,98 +20,102 @@ export type GetNotionWebhookConfigResponseBody = {
 // Mounted at /api/w/:wId/data_sources/:dsId/managed/notion/webhook_config.
 const app = workspaceApp();
 
-app.get("/", async (ctx): HandlerResult<GetNotionWebhookConfigResponseBody> => {
-  const auth = ctx.get("auth");
-  const dsId = ctx.req.param("dsId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetNotionWebhookConfigResponseBody> => {
+    const auth = ctx.get("auth");
+    const { dsId } = ctx.req.valid("param");
 
-  const dataSource = await DataSourceResource.fetchById(auth, dsId);
-  if (!dataSource) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "data_source_not_found",
-        message: "The data source you requested was not found.",
-      },
-    });
-  }
-
-  if (!dataSource.connectorId || dataSource.connectorProvider !== "notion") {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "data_source_error",
-        message:
-          "The data source you requested is not a managed Notion data source.",
-      },
-    });
-  }
-
-  const connectorAPIConfig = config.getConnectorsAPIConfig();
-  const connectorsAPI = new ConnectorsAPI(connectorAPIConfig, logger);
-
-  // Get the Notion workspace ID.
-  const workspaceIdRes = await connectorsAPI.getNotionWorkspaceId(
-    dataSource.connectorId
-  );
-
-  if (workspaceIdRes.isErr()) {
-    logger.error(
-      {
-        connectorId: dataSource.connectorId,
-        error: workspaceIdRes.error,
-      },
-      "Failed to get Notion workspace ID"
-    );
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Failed to get Notion workspace ID",
-        connectors_error: workspaceIdRes.error,
-      },
-    });
-  }
-
-  const notionWorkspaceId = workspaceIdRes.value.notionWorkspaceId;
-  const webhookUrl = `https://webhook-router.dust.tt/notion/${notionWorkspaceId}`;
-
-  // Try to get the verification token from the webhooks router.
-  const webhookRouterRes = await connectorsAPI.getWebhookRouterEntry({
-    provider: "notion",
-    providerWorkspaceId: notionWorkspaceId,
-    webhookSecret: connectorAPIConfig.webhookSecret,
-  });
-
-  if (webhookRouterRes.isErr()) {
-    // 404 is expected when the webhook hasn't been set up yet.
-    if (
-      webhookRouterRes.error.type === "not_found" ||
-      webhookRouterRes.error.type === "connector_not_found"
-    ) {
-      return ctx.json({ webhookUrl, verificationToken: null });
+    const dataSource = await DataSourceResource.fetchById(auth, dsId);
+    if (!dataSource) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "data_source_not_found",
+          message: "The data source you requested was not found.",
+        },
+      });
     }
 
-    logger.error(
-      {
-        error: webhookRouterRes.error,
-        notionWorkspaceId,
-      },
-      "Failed to get webhook router entry"
+    if (!dataSource.connectorId || dataSource.connectorProvider !== "notion") {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "data_source_error",
+          message:
+            "The data source you requested is not a managed Notion data source.",
+        },
+      });
+    }
+
+    const connectorAPIConfig = config.getConnectorsAPIConfig();
+    const connectorsAPI = new ConnectorsAPI(connectorAPIConfig, logger);
+
+    // Get the Notion workspace ID.
+    const workspaceIdRes = await connectorsAPI.getNotionWorkspaceId(
+      dataSource.connectorId
     );
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Failed to get webhook router entry",
-        connectors_error: webhookRouterRes.error,
-      },
+
+    if (workspaceIdRes.isErr()) {
+      logger.error(
+        {
+          connectorId: dataSource.connectorId,
+          error: workspaceIdRes.error,
+        },
+        "Failed to get Notion workspace ID"
+      );
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to get Notion workspace ID",
+          connectors_error: workspaceIdRes.error,
+        },
+      });
+    }
+
+    const notionWorkspaceId = workspaceIdRes.value.notionWorkspaceId;
+    const webhookUrl = `https://webhook-router.dust.tt/notion/${notionWorkspaceId}`;
+
+    // Try to get the verification token from the webhooks router.
+    const webhookRouterRes = await connectorsAPI.getWebhookRouterEntry({
+      provider: "notion",
+      providerWorkspaceId: notionWorkspaceId,
+      webhookSecret: connectorAPIConfig.webhookSecret,
+    });
+
+    if (webhookRouterRes.isErr()) {
+      // 404 is expected when the webhook hasn't been set up yet.
+      if (
+        webhookRouterRes.error.type === "not_found" ||
+        webhookRouterRes.error.type === "connector_not_found"
+      ) {
+        return ctx.json({ webhookUrl, verificationToken: null });
+      }
+
+      logger.error(
+        {
+          error: webhookRouterRes.error,
+          notionWorkspaceId,
+        },
+        "Failed to get webhook router entry"
+      );
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to get webhook router entry",
+          connectors_error: webhookRouterRes.error,
+        },
+      });
+    }
+
+    return ctx.json({
+      webhookUrl,
+      verificationToken: webhookRouterRes.value.signingSecret,
     });
   }
-
-  return ctx.json({
-    webhookUrl,
-    verificationToken: webhookRouterRes.value.signingSecret,
-  });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/data_sources/[dsId]/managed/notion_url_status.ts
+++ b/front-api/routes/w/[wId]/data_sources/[dsId]/managed/notion_url_status.ts
@@ -31,18 +31,23 @@ const PostNotionUrlStatusBodySchema = z.object({
   url: z.string(),
 });
 
+const ParamsSchema = z.object({
+  dsId: z.string(),
+});
+
 // Mounted at /api/w/:wId/data_sources/:dsId/managed/notion_url_status.
 const app = workspaceApp();
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   ensureIsAdmin(),
   validate("json", PostNotionUrlStatusBodySchema),
   async (ctx): HandlerResult<PostNotionUrlStatusResponseBody> => {
     const auth = ctx.get("auth");
     const owner = auth.getNonNullableWorkspace();
 
-    const dsId = ctx.req.param("dsId") ?? "";
+    const { dsId } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchById(auth, dsId);
     if (!dataSource) {

--- a/front-api/routes/w/[wId]/data_sources/[dsId]/managed/notion_url_sync.ts
+++ b/front-api/routes/w/[wId]/data_sources/[dsId]/managed/notion_url_sync.ts
@@ -10,6 +10,11 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { Context } from "hono";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  dsId: z.string(),
+});
 
 const RECENT_URLS_COUNT = 100;
 
@@ -78,9 +83,9 @@ function errorJson(
 // Mounted at /api/w/:wId/data_sources/:dsId/managed/notion_url_sync.
 const app = workspaceApp();
 
-app.get("/", async (ctx) => {
+app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const dsId = ctx.req.param("dsId") ?? "";
+  const { dsId } = ctx.req.valid("param");
 
   const result = await fetchManagedNotionDataSource(auth, dsId);
   if (result.kind === "err") {
@@ -100,56 +105,61 @@ app.get("/", async (ctx) => {
   return ctx.json({ syncResults: lastSyncedUrls });
 });
 
-app.post("/", validate("json", PostNotionSyncPayloadSchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const dsId = ctx.req.param("dsId") ?? "";
+app.post(
+  "/",
+  validate("param", ParamsSchema),
+  validate("json", PostNotionSyncPayloadSchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { dsId } = ctx.req.valid("param");
 
-  const result = await fetchManagedNotionDataSource(auth, dsId);
-  if (result.kind === "err") {
-    return errorJson(ctx, result);
-  }
-
-  const owner = auth.getNonNullableWorkspace();
-  const { urls, method } = ctx.req.valid("json");
-
-  const syncResults = (
-    await syncNotionUrls({
-      urlsArray: urls,
-      dataSourceId: dsId,
-      workspaceId: owner.sId,
-      method,
-    })
-  ).map((urlResult) => ({
-    url: urlResult.url,
-    method,
-    timestamp: urlResult.timestamp,
-    success: urlResult.success,
-    ...(urlResult.error && { error_message: urlResult.error.message }),
-  }));
-
-  // Store the last RECENT_URLS_COUNT synced urls (expires in 1 day if no URL is synced).
-  await runOnRedis({ origin: "notion_url_sync" }, async (redis) => {
-    const redisKey = getRedisKeyForNotionUrlSync(owner.sId);
-
-    await redis.zAdd(
-      redisKey,
-      syncResults.map((urlResult) => ({
-        method,
-        score: urlResult.timestamp,
-        value: JSON.stringify(urlResult),
-      }))
-    );
-
-    await redis.expire(redisKey, 24 * 60 * 60);
-
-    // Delete the oldest URL if the list has more than RECENT_URLS_COUNT items.
-    const count = await redis.zCard(redisKey);
-    if (count > RECENT_URLS_COUNT) {
-      await redis.zRemRangeByRank(redisKey, 0, count - RECENT_URLS_COUNT);
+    const result = await fetchManagedNotionDataSource(auth, dsId);
+    if (result.kind === "err") {
+      return errorJson(ctx, result);
     }
-  });
 
-  return ctx.json({ syncResults });
-});
+    const owner = auth.getNonNullableWorkspace();
+    const { urls, method } = ctx.req.valid("json");
+
+    const syncResults = (
+      await syncNotionUrls({
+        urlsArray: urls,
+        dataSourceId: dsId,
+        workspaceId: owner.sId,
+        method,
+      })
+    ).map((urlResult) => ({
+      url: urlResult.url,
+      method,
+      timestamp: urlResult.timestamp,
+      success: urlResult.success,
+      ...(urlResult.error && { error_message: urlResult.error.message }),
+    }));
+
+    // Store the last RECENT_URLS_COUNT synced urls (expires in 1 day if no URL is synced).
+    await runOnRedis({ origin: "notion_url_sync" }, async (redis) => {
+      const redisKey = getRedisKeyForNotionUrlSync(owner.sId);
+
+      await redis.zAdd(
+        redisKey,
+        syncResults.map((urlResult) => ({
+          method,
+          score: urlResult.timestamp,
+          value: JSON.stringify(urlResult),
+        }))
+      );
+
+      await redis.expire(redisKey, 24 * 60 * 60);
+
+      // Delete the oldest URL if the list has more than RECENT_URLS_COUNT items.
+      const count = await redis.zCard(redisKey);
+      if (count > RECENT_URLS_COUNT) {
+        await redis.zRemRangeByRank(redisKey, 0, count - RECENT_URLS_COUNT);
+      }
+    });
+
+    return ctx.json({ syncResults });
+  }
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/data_sources/[dsId]/managed/oauth-metadata.ts
+++ b/front-api/routes/w/[wId]/data_sources/[dsId]/managed/oauth-metadata.ts
@@ -6,6 +6,12 @@ import { OAuthAPI } from "@app/types/oauth/oauth_api";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  dsId: z.string(),
+});
 
 export type GetOAuthMetadataResponseBody = {
   metadata: Record<string, unknown>;
@@ -14,106 +20,111 @@ export type GetOAuthMetadataResponseBody = {
 // Mounted at /api/w/:wId/data_sources/:dsId/managed/oauth-metadata.
 const app = workspaceApp();
 
-app.get("/", async (ctx): HandlerResult<GetOAuthMetadataResponseBody> => {
-  const auth = ctx.get("auth");
-  const dsId = ctx.req.param("dsId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetOAuthMetadataResponseBody> => {
+    const auth = ctx.get("auth");
+    const { dsId } = ctx.req.valid("param");
 
-  const dataSource = await DataSourceResource.fetchById(auth, dsId);
-  if (!dataSource) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "data_source_not_found",
-        message: "The data source you requested was not found.",
-      },
-    });
-  }
+    const dataSource = await DataSourceResource.fetchById(auth, dsId);
+    if (!dataSource) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "data_source_not_found",
+          message: "The data source you requested was not found.",
+        },
+      });
+    }
 
-  if (!dataSource.connectorId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "data_source_not_managed",
-        message: "The data source you requested is not managed.",
-      },
-    });
-  }
+    if (!dataSource.connectorId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "data_source_not_managed",
+          message: "The data source you requested is not managed.",
+        },
+      });
+    }
 
-  if (!dataSource.canAdministrate(auth)) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "data_source_auth_error",
-        message: "Only workspace admins can access data source OAuth metadata.",
-      },
-    });
-  }
+    if (!dataSource.canAdministrate(auth)) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "data_source_auth_error",
+          message:
+            "Only workspace admins can access data source OAuth metadata.",
+        },
+      });
+    }
 
-  const connectorsAPI = new ConnectorsAPI(
-    config.getConnectorsAPIConfig(),
-    logger
-  );
-
-  const connectorRes = await connectorsAPI.getConnector(
-    dataSource.connectorId.toString()
-  );
-
-  if (connectorRes.isErr()) {
-    logger.error(
-      {
-        connectorId: dataSource.connectorId,
-        error: connectorRes.error,
-      },
-      "Failed to fetch connector details"
+    const connectorsAPI = new ConnectorsAPI(
+      config.getConnectorsAPIConfig(),
+      logger
     );
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Failed to fetch connector details.",
-      },
-    });
-  }
 
-  const connectionId = connectorRes.value.connectionId;
-  if (!connectionId) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "connector_oauth_connection_not_found",
-        message: "No OAuth connection found for this connector.",
-      },
-    });
-  }
-
-  const oauthAPI = new OAuthAPI(config.getOAuthAPIConfig(), logger);
-  const metadataRes = await oauthAPI.getConnectionMetadata({ connectionId });
-
-  if (metadataRes.isErr()) {
-    logger.error(
-      {
-        connectionId,
-        error: metadataRes.error,
-      },
-      "Failed to fetch OAuth connection metadata"
+    const connectorRes = await connectorsAPI.getConnector(
+      dataSource.connectorId.toString()
     );
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Failed to fetch OAuth connection metadata.",
-      },
-    });
+
+    if (connectorRes.isErr()) {
+      logger.error(
+        {
+          connectorId: dataSource.connectorId,
+          error: connectorRes.error,
+        },
+        "Failed to fetch connector details"
+      );
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to fetch connector details.",
+        },
+      });
+    }
+
+    const connectionId = connectorRes.value.connectionId;
+    if (!connectionId) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "connector_oauth_connection_not_found",
+          message: "No OAuth connection found for this connector.",
+        },
+      });
+    }
+
+    const oauthAPI = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+    const metadataRes = await oauthAPI.getConnectionMetadata({ connectionId });
+
+    if (metadataRes.isErr()) {
+      logger.error(
+        {
+          connectionId,
+          error: metadataRes.error,
+        },
+        "Failed to fetch OAuth connection metadata"
+      );
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to fetch OAuth connection metadata.",
+        },
+      });
+    }
+
+    // Extract relevant metadata fields, excluding sensitive system fields.
+    const { connection } = metadataRes.value;
+    const metadata = connection.metadata || {};
+
+    delete metadata.client_secret;
+    delete metadata.refresh_token;
+
+    return ctx.json({ metadata });
   }
-
-  // Extract relevant metadata fields, excluding sensitive system fields.
-  const { connection } = metadataRes.value;
-  const metadata = connection.metadata || {};
-
-  delete metadata.client_secret;
-  delete metadata.refresh_token;
-
-  return ctx.json({ metadata });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
+++ b/front-api/routes/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
@@ -34,15 +34,20 @@ const SetConnectorPermissionsRequestBodySchema = z.object({
   ),
 });
 
+const ParamsSchema = z.object({
+  dsId: z.string(),
+});
+
 // Mounted at /api/w/:wId/data_sources/:dsId/managed/permissions.
 const app = workspaceApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   validate("query", ManagedPermissionsQuerySchema),
   async (ctx): HandlerResult<GetDataSourcePermissionsResponseBody> => {
     const auth = ctx.get("auth");
-    const dsId = ctx.req.param("dsId") ?? "";
+    const { dsId } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchById(auth, dsId);
     if (!dataSource) {
@@ -157,10 +162,11 @@ app.get(
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   validate("json", SetConnectorPermissionsRequestBodySchema),
   async (ctx): HandlerResult<SuccessResponseBody> => {
     const auth = ctx.get("auth");
-    const dsId = ctx.req.param("dsId") ?? "";
+    const { dsId } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchById(auth, dsId);
     if (!dataSource) {

--- a/front-api/routes/w/[wId]/data_sources/[dsId]/managed/update.ts
+++ b/front-api/routes/w/[wId]/data_sources/[dsId]/managed/update.ts
@@ -22,6 +22,11 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  dsId: z.string(),
+});
 
 export type GetDataSourceUpdateResponseBody = {
   connectorId: string;
@@ -32,12 +37,13 @@ const app = workspaceApp();
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   validate("json", UpdateConnectorRequestBodySchema),
   async (ctx): HandlerResult<GetDataSourceUpdateResponseBody> => {
     const auth = ctx.get("auth");
     const owner = auth.getNonNullableWorkspace();
     const user = auth.getNonNullableUser();
-    const dsId = ctx.req.param("dsId") ?? "";
+    const { dsId } = ctx.req.valid("param");
 
     const dataSource = await DataSourceResource.fetchById(auth, dsId);
     if (!dataSource) {

--- a/front-api/routes/w/[wId]/data_sources/[dsId]/usage.ts
+++ b/front-api/routes/w/[wId]/data_sources/[dsId]/usage.ts
@@ -4,6 +4,12 @@ import type { AgentsUsageType } from "@app/types/data_source";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  dsId: z.string(),
+});
 
 export type GetDataSourceUsageResponseBody = {
   usage: AgentsUsageType;
@@ -12,33 +18,37 @@ export type GetDataSourceUsageResponseBody = {
 // Mounted at /api/w/:wId/data_sources/:dsId/usage.
 const app = workspaceApp();
 
-app.get("/", async (ctx): HandlerResult<GetDataSourceUsageResponseBody> => {
-  const auth = ctx.get("auth");
-  const dsId = ctx.req.param("dsId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetDataSourceUsageResponseBody> => {
+    const auth = ctx.get("auth");
+    const { dsId } = ctx.req.valid("param");
 
-  const dataSource = await DataSourceResource.fetchById(auth, dsId);
-  if (!dataSource || !dataSource.canRead(auth)) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "data_source_not_found",
-        message: "The data source you requested was not found.",
-      },
-    });
+    const dataSource = await DataSourceResource.fetchById(auth, dsId);
+    if (!dataSource || !dataSource.canRead(auth)) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "data_source_not_found",
+          message: "The data source you requested was not found.",
+        },
+      });
+    }
+
+    const usage = await getDataSourceUsage({ auth, dataSource });
+    if (usage.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to get data source usage.",
+        },
+      });
+    }
+
+    return ctx.json({ usage: usage.value });
   }
-
-  const usage = await getDataSourceUsage({ auth, dataSource });
-  if (usage.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Failed to get data source usage.",
-      },
-    });
-  }
-
-  return ctx.json({ usage: usage.value });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/dust_app_secrets/[name]/destroy.ts
+++ b/front-api/routes/w/[wId]/dust_app_secrets/[name]/destroy.ts
@@ -1,5 +1,4 @@
 import { getDustAppSecret } from "@app/lib/api/dust_app_secrets";
-import { isString } from "@app/types/shared/utils/general";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError } from "@front-api/middlewares/utils";
@@ -21,15 +20,6 @@ app.delete(
     const auth = ctx.get("auth");
 
     const { name } = ctx.req.valid("param");
-    if (!isString(name)) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid path parameters.",
-        },
-      });
-    }
 
     const secret = await getDustAppSecret(auth, name);
 

--- a/front-api/routes/w/[wId]/dust_app_secrets/[name]/destroy.ts
+++ b/front-api/routes/w/[wId]/dust_app_secrets/[name]/destroy.ts
@@ -3,38 +3,49 @@ import { isString } from "@app/types/shared/utils/general";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  name: z.string(),
+});
 
 // Mounted at /api/w/:wId/dust_app_secrets/:name/destroy.
 const app = workspaceApp();
 
-app.delete("/", ensureIsAdmin(), async (ctx) => {
-  const auth = ctx.get("auth");
+app.delete(
+  "/",
+  validate("param", ParamsSchema),
+  ensureIsAdmin(),
+  async (ctx) => {
+    const auth = ctx.get("auth");
 
-  const name = ctx.req.param("name");
-  if (!isString(name)) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid path parameters.",
-      },
-    });
+    const { name } = ctx.req.valid("param");
+    if (!isString(name)) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid path parameters.",
+        },
+      });
+    }
+
+    const secret = await getDustAppSecret(auth, name);
+
+    if (secret == null) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "dust_app_secret_not_found",
+          message: "Workspace not found.",
+        },
+      });
+    }
+
+    await secret.destroy();
+    return ctx.body(null, 204);
   }
-
-  const secret = await getDustAppSecret(auth, name);
-
-  if (secret == null) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "dust_app_secret_not_found",
-        message: "Workspace not found.",
-      },
-    });
-  }
-
-  await secret.destroy();
-  return ctx.body(null, 204);
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/files/[fileId]/edit-text.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/edit-text.ts
@@ -16,82 +16,91 @@ const EditTextRequestBodySchema = z.object({
   oldText: z.string().min(1, "oldText must be a non-empty string"),
 });
 
+const ParamsSchema = z.object({
+  fileId: z.string(),
+});
+
 // Mounted at /api/w/:wId/files/:fileId/edit-text.
 const app = workspaceApp();
 
-app.post("/", validate("json", EditTextRequestBodySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const fileId = ctx.req.param("fileId") ?? "";
+app.post(
+  "/",
+  validate("param", ParamsSchema),
+  validate("json", EditTextRequestBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { fileId } = ctx.req.valid("param");
 
-  const file = await FileResource.fetchById(auth, fileId);
-  if (!file) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: { type: "file_not_found", message: "File not found." },
-    });
-  }
-
-  if (!isInteractiveContentType(file.contentType)) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Only Frame files support inline text editing.",
-      },
-    });
-  }
-
-  if (
-    isConversationFileUseCase(file.useCase) &&
-    file.useCaseMetadata?.conversationId
-  ) {
-    const conversation = await ConversationResource.fetchById(
-      auth,
-      file.useCaseMetadata.conversationId
-    );
-    if (!conversation) {
+    const file = await FileResource.fetchById(auth, fileId);
+    if (!file) {
       return apiError(ctx, {
         status_code: 404,
         api_error: { type: "file_not_found", message: "File not found." },
       });
     }
-  } else if (file.useCaseMetadata?.spaceId) {
-    const space = await SpaceResource.fetchById(
-      auth,
-      file.useCaseMetadata.spaceId
-    );
-    if (!space || !space.canWrite(auth)) {
+
+    if (!isInteractiveContentType(file.contentType)) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Only Frame files support inline text editing.",
+        },
+      });
+    }
+
+    if (
+      isConversationFileUseCase(file.useCase) &&
+      file.useCaseMetadata?.conversationId
+    ) {
+      const conversation = await ConversationResource.fetchById(
+        auth,
+        file.useCaseMetadata.conversationId
+      );
+      if (!conversation) {
+        return apiError(ctx, {
+          status_code: 404,
+          api_error: { type: "file_not_found", message: "File not found." },
+        });
+      }
+    } else if (file.useCaseMetadata?.spaceId) {
+      const space = await SpaceResource.fetchById(
+        auth,
+        file.useCaseMetadata.spaceId
+      );
+      if (!space || !space.canWrite(auth)) {
+        return apiError(ctx, {
+          status_code: 404,
+          api_error: { type: "file_not_found", message: "File not found." },
+        });
+      }
+    } else {
       return apiError(ctx, {
         status_code: 404,
         api_error: { type: "file_not_found", message: "File not found." },
       });
     }
-  } else {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: { type: "file_not_found", message: "File not found." },
+
+    const { oldText, newText } = ctx.req.valid("json");
+
+    const editResult = await editClientExecutableFile(auth, {
+      fileId,
+      oldString: oldText,
+      newString: newText,
     });
+
+    if (editResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: editResult.error.message,
+        },
+      });
+    }
+
+    return ctx.json({ success: true });
   }
-
-  const { oldText, newText } = ctx.req.valid("json");
-
-  const editResult = await editClientExecutableFile(auth, {
-    fileId,
-    oldString: oldText,
-    newString: newText,
-  });
-
-  if (editResult.isErr()) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: editResult.error.message,
-      },
-    });
-  }
-
-  return ctx.json({ success: true });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/files/[fileId]/export/pdf.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/export/pdf.ts
@@ -9,57 +9,72 @@ const PostPdfExportBodySchema = z.object({
   orientation: z.enum(["portrait", "landscape"]).optional(),
 });
 
+const ParamsSchema = z.object({
+  fileId: z.string(),
+});
+
 // Mounted at /api/w/:wId/files/:fileId/export/pdf.
 const app = workspaceApp();
 
-app.post("/", validate("json", PostPdfExportBodySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const fileId = ctx.req.param("fileId") ?? "";
-  const { orientation } = ctx.req.valid("json");
+app.post(
+  "/",
+  validate("param", ParamsSchema),
+  validate("json", PostPdfExportBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { fileId } = ctx.req.valid("param");
+    const { orientation } = ctx.req.valid("json");
 
-  const result = await exportInteractiveContentFileAsPdf(auth, {
-    fileId,
-    orientation,
-  });
+    const result = await exportInteractiveContentFileAsPdf(auth, {
+      fileId,
+      orientation,
+    });
 
-  if (result.isErr()) {
-    const { error } = result;
-    switch (error.type) {
-      case "file_not_found":
-        return apiError(ctx, {
-          status_code: 404,
-          api_error: { type: "file_not_found", message: error.message },
-        });
-      case "invalid_request":
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: { type: "invalid_request_error", message: error.message },
-        });
-      case "render_failed":
-        return apiError(ctx, {
-          status_code: 500,
-          api_error: { type: "internal_server_error", message: error.message },
-        });
-      default:
-        assertNever(error.type);
+    if (result.isErr()) {
+      const { error } = result;
+      switch (error.type) {
+        case "file_not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: { type: "file_not_found", message: error.message },
+          });
+        case "invalid_request":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: error.message,
+            },
+          });
+        case "render_failed":
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: error.message,
+            },
+          });
+        default:
+          assertNever(error.type);
+      }
     }
+
+    const { buffer, fileName } = result.value;
+    // Sanitize filename for Content-Disposition: use ASCII-only fallback for
+    // `filename` and RFC 5987 `filename*` for the full UTF-8 name.
+    const asciiFallback = fileName.replace(/[^\x20-\x7E]/g, "_");
+    const encodedName = encodeURIComponent(fileName);
+
+    // Convert Node `Buffer` to `Uint8Array` so it satisfies `BodyInit`.
+    return new Response(new Uint8Array(buffer), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `attachment; filename="${asciiFallback}"; filename*=UTF-8''${encodedName}`,
+        "Content-Length": String(buffer.length),
+      },
+    });
   }
-
-  const { buffer, fileName } = result.value;
-  // Sanitize filename for Content-Disposition: use ASCII-only fallback for
-  // `filename` and RFC 5987 `filename*` for the full UTF-8 name.
-  const asciiFallback = fileName.replace(/[^\x20-\x7E]/g, "_");
-  const encodedName = encodeURIComponent(fileName);
-
-  // Convert Node `Buffer` to `Uint8Array` so it satisfies `BodyInit`.
-  return new Response(new Uint8Array(buffer), {
-    status: 200,
-    headers: {
-      "Content-Type": "application/pdf",
-      "Content-Disposition": `attachment; filename="${asciiFallback}"; filename*=UTF-8''${encodedName}`,
-      "Content-Length": String(buffer.length),
-    },
-  });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/files/[fileId]/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.ts
@@ -16,8 +16,14 @@ import { isConversationFileUseCase } from "@app/types/files";
 import { createHono } from "@front-api/lib/hono";
 import type { WorkspaceAwareCtx } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import type { HttpBindings } from "@hono/node-server";
 import type { Context } from "hono";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  fileId: z.string(),
+});
 
 import editText from "./edit-text";
 import exportApp from "./export";
@@ -64,9 +70,9 @@ function getSecureFileAction(
 // Mounted at /api/w/:wId/files/:fileId.
 const app = createHono<WorkspaceAwareCtx & { Bindings: HttpBindings }>();
 
-app.get("/", async (ctx) => {
+app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const fileId = ctx.req.param("fileId") ?? "";
+  const { fileId } = ctx.req.valid("param");
 
   const file = await FileResource.fetchById(auth, fileId);
   if (!file) {
@@ -110,9 +116,9 @@ app.get("/", async (ctx) => {
   return ctx.redirect(url);
 });
 
-app.delete("/", async (ctx) => {
+app.delete("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const fileId = ctx.req.param("fileId") ?? "";
+  const { fileId } = ctx.req.valid("param");
 
   const file = await FileResource.fetchById(auth, fileId);
   if (!file) {
@@ -183,9 +189,9 @@ app.delete("/", async (ctx) => {
   return ctx.body(null, 204);
 });
 
-app.post("/", async (ctx) => {
+app.post("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const fileId = ctx.req.param("fileId") ?? "";
+  const { fileId } = ctx.req.valid("param");
 
   const file = await FileResource.fetchById(auth, fileId);
   if (!file) {

--- a/front-api/routes/w/[wId]/files/[fileId]/metadata.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/metadata.ts
@@ -4,13 +4,19 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { isConversationFileUseCase } from "@app/types/files";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  fileId: z.string(),
+});
 
 // Mounted at /api/w/:wId/files/:fileId/metadata.
 const app = workspaceApp();
 
-app.get("/", async (ctx) => {
+app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const fileId = ctx.req.param("fileId") ?? "";
+  const { fileId } = ctx.req.valid("param");
 
   const fileResource = await FileResource.fetchById(auth, fileId);
   if (!fileResource) {

--- a/front-api/routes/w/[wId]/files/[fileId]/rename.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/rename.ts
@@ -15,15 +15,20 @@ const RenameRequestBodySchema = z.object({
   fileName: z.string().trim().min(1, "fileName must be a non-empty string"),
 });
 
+const ParamsSchema = z.object({
+  fileId: z.string(),
+});
+
 // Mounted at /api/w/:wId/files/:fileId/rename.
 const app = workspaceApp();
 
 app.patch(
   "/",
+  validate("param", ParamsSchema),
   validate("json", RenameRequestBodySchema),
   async (ctx): HandlerResult<RenameFileResponseBody> => {
     const auth = ctx.get("auth");
-    const fileId = ctx.req.param("fileId") ?? "";
+    const { fileId } = ctx.req.valid("param");
 
     const file = await FileResource.fetchById(auth, fileId);
     if (!file) {

--- a/front-api/routes/w/[wId]/files/[fileId]/save-in-project.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/save-in-project.ts
@@ -18,15 +18,20 @@ const SaveInProjectRequestBodySchema = z.object({
   projectId: z.string().min(1, "projectId is required"),
 });
 
+const ParamsSchema = z.object({
+  fileId: z.string(),
+});
+
 // Mounted at /api/w/:wId/files/:fileId/save-in-project.
 const app = workspaceApp();
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   validate("json", SaveInProjectRequestBodySchema),
   async (ctx): HandlerResult<SaveInProjectResponseBody> => {
     const auth = ctx.get("auth");
-    const fileId = ctx.req.param("fileId") ?? "";
+    const { fileId } = ctx.req.valid("param");
 
     const file = await FileResource.fetchById(auth, fileId);
     if (!file) {

--- a/front-api/routes/w/[wId]/files/[fileId]/share/grants.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/share/grants.ts
@@ -22,12 +22,16 @@ const RevokeGrantRequestBodySchema = z.object({
   grantId: z.number(),
 });
 
+const ParamsSchema = z.object({
+  fileId: z.string(),
+});
+
 // Mounted at /api/w/:wId/files/:fileId/share/grants.
 const app = workspaceApp();
 
-app.get("/", async (ctx) => {
+app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const fileId = ctx.req.param("fileId") ?? "";
+  const { fileId } = ctx.req.valid("param");
 
   const file = await fetchShareableFile(ctx, auth, fileId);
   if (file instanceof Response) {
@@ -65,76 +69,86 @@ app.get("/", async (ctx) => {
   return ctx.json({ grants });
 });
 
-app.post("/", validate("json", AddGrantsRequestBodySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const fileId = ctx.req.param("fileId") ?? "";
+app.post(
+  "/",
+  validate("param", ParamsSchema),
+  validate("json", AddGrantsRequestBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { fileId } = ctx.req.valid("param");
 
-  const file = await fetchShareableFile(ctx, auth, fileId);
-  if (file instanceof Response) {
-    return file;
+    const file = await fetchShareableFile(ctx, auth, fileId);
+    if (file instanceof Response) {
+      return file;
+    }
+
+    const { emails: rawEmails } = ctx.req.valid("json");
+
+    const workspace = auth.getNonNullableWorkspace();
+    if (workspace.sharingPolicy === "workspace_only") {
+      const emails = rawEmails.map((e) => e.toLowerCase());
+      const users = await UserResource.fetchByEmails(emails);
+
+      const userIdToEmail = new Map(
+        users.map((u) => [u.id, u.email.toLowerCase()])
+      );
+
+      const { memberships } = await MembershipResource.getActiveMemberships({
+        users,
+        workspace,
+      });
+
+      const memberEmails = new Set(
+        memberships.map((m) => userIdToEmail.get(m.userId)).filter(Boolean)
+      );
+
+      const hasNonMemberEmails = emails.some((e) => !memberEmails.has(e));
+      if (hasNonMemberEmails) {
+        return apiError(ctx, {
+          status_code: 403,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "Only workspace members can be invited when external sharing is disabled.",
+          },
+        });
+      }
+    }
+
+    const grants = await file.addSharingGrants(auth, { emails: rawEmails });
+    return ctx.json({ grants });
   }
+);
 
-  const { emails: rawEmails } = ctx.req.valid("json");
+app.delete(
+  "/",
+  validate("param", ParamsSchema),
+  validate("json", RevokeGrantRequestBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { fileId } = ctx.req.valid("param");
 
-  const workspace = auth.getNonNullableWorkspace();
-  if (workspace.sharingPolicy === "workspace_only") {
-    const emails = rawEmails.map((e) => e.toLowerCase());
-    const users = await UserResource.fetchByEmails(emails);
+    const file = await fetchShareableFile(ctx, auth, fileId);
+    if (file instanceof Response) {
+      return file;
+    }
 
-    const userIdToEmail = new Map(
-      users.map((u) => [u.id, u.email.toLowerCase()])
-    );
+    const { grantId } = ctx.req.valid("json");
+    const result = await file.revokeSharingGrant({ grantId });
 
-    const { memberships } = await MembershipResource.getActiveMemberships({
-      users,
-      workspace,
-    });
-
-    const memberEmails = new Set(
-      memberships.map((m) => userIdToEmail.get(m.userId)).filter(Boolean)
-    );
-
-    const hasNonMemberEmails = emails.some((e) => !memberEmails.has(e));
-    if (hasNonMemberEmails) {
+    if (result.isErr()) {
       return apiError(ctx, {
-        status_code: 403,
+        status_code: 404,
         api_error: {
-          type: "invalid_request_error",
-          message:
-            "Only workspace members can be invited when external sharing is disabled.",
+          type: "file_not_found",
+          message: result.error.message,
         },
       });
     }
+
+    return ctx.body(null, 204);
   }
-
-  const grants = await file.addSharingGrants(auth, { emails: rawEmails });
-  return ctx.json({ grants });
-});
-
-app.delete("/", validate("json", RevokeGrantRequestBodySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const fileId = ctx.req.param("fileId") ?? "";
-
-  const file = await fetchShareableFile(ctx, auth, fileId);
-  if (file instanceof Response) {
-    return file;
-  }
-
-  const { grantId } = ctx.req.valid("json");
-  const result = await file.revokeSharingGrant({ grantId });
-
-  if (result.isErr()) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "file_not_found",
-        message: result.error.message,
-      },
-    });
-  }
-
-  return ctx.body(null, 204);
-});
+);
 
 async function fetchShareableFile(
   ctx: Context,

--- a/front-api/routes/w/[wId]/files/[fileId]/share/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/share/index.ts
@@ -27,6 +27,10 @@ const ShareFileRequestBodySchema = z.object({
   shareScope: fileShareScopeSchema,
 });
 
+const ParamsSchema = z.object({
+  fileId: z.string(),
+});
+
 // Mounted at /api/w/:wId/files/:fileId/share.
 const app = workspaceApp();
 
@@ -35,32 +39,37 @@ const app = workspaceApp();
 // keeping mounts before leaf handlers matches the convention used elsewhere).
 app.route("/grants", grants);
 
-app.get("/", async (ctx): HandlerResult<ShareFileResponseBody> => {
-  const auth = ctx.get("auth");
-  const fileId = ctx.req.param("fileId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<ShareFileResponseBody> => {
+    const auth = ctx.get("auth");
+    const { fileId } = ctx.req.valid("param");
 
-  const file = await fetchShareableFile(ctx, auth, fileId);
-  if (file instanceof Response) {
-    return file;
+    const file = await fetchShareableFile(ctx, auth, fileId);
+    if (file instanceof Response) {
+      return file;
+    }
+
+    const shareInfo = await file.getShareInfo();
+    if (!shareInfo) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: { type: "file_not_found", message: "File not found." },
+      });
+    }
+
+    return ctx.json(shareInfo);
   }
-
-  const shareInfo = await file.getShareInfo();
-  if (!shareInfo) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: { type: "file_not_found", message: "File not found." },
-    });
-  }
-
-  return ctx.json(shareInfo);
-});
+);
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   validate("json", ShareFileRequestBodySchema),
   async (ctx): HandlerResult<ShareFileResponseBody> => {
     const auth = ctx.get("auth");
-    const fileId = ctx.req.param("fileId") ?? "";
+    const { fileId } = ctx.req.valid("param");
 
     const file = await fetchShareableFile(ctx, auth, fileId);
     if (file instanceof Response) {

--- a/front-api/routes/w/[wId]/files/[fileId]/signed-url.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/signed-url.ts
@@ -2,13 +2,19 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  fileId: z.string(),
+});
 
 // Mounted at /api/w/:wId/files/:fileId/signed-url.
 const app = workspaceApp();
 
-app.get("/", async (ctx) => {
+app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const fileId = ctx.req.param("fileId") ?? "";
+  const { fileId } = ctx.req.valid("param");
 
   const fileResource = await FileResource.fetchById(auth, fileId);
   if (!fileResource) {

--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
@@ -11,10 +11,15 @@ import { readableToReadableStream } from "@app/types/shared/utils/streams";
 import type { WorkspaceAwareCtx } from "@front-api/middlewares/ctx";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import type { Context } from "hono";
 import path from "path";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
+
+const ParamsSchema = z.object({
+  canonicalPath: z.string(),
+});
 
 /**
  * Unified file system API by canonical scoped path.
@@ -76,9 +81,9 @@ async function resolveFs(
   return { fs: fsResult.value, err: null };
 }
 
-app.get("/:canonicalPath{.+}", async (ctx) => {
+app.get("/:canonicalPath{.+}", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const canonicalPath = ctx.req.param("canonicalPath");
+  const { canonicalPath } = ctx.req.valid("param");
   const { fs: dustFs, err } = await resolveFs(ctx, canonicalPath);
   if (err) {
     return err;
@@ -175,118 +180,131 @@ app.get("/:canonicalPath{.+}", async (ctx) => {
   return new Response(webStream, { status: 200, headers });
 });
 
-app.on("HEAD", "/:canonicalPath{.+}", async (ctx) => {
-  const canonicalPath = ctx.req.param("canonicalPath");
-  const { fs: dustFs, err } = await resolveFs(ctx, canonicalPath);
-  if (err) {
-    return err;
-  }
+app.on(
+  "HEAD",
+  "/:canonicalPath{.+}",
+  validate("param", ParamsSchema),
+  async (ctx) => {
+    const { canonicalPath } = ctx.req.valid("param");
+    const { fs: dustFs, err } = await resolveFs(ctx, canonicalPath);
+    if (err) {
+      return err;
+    }
 
-  const statResult = await dustFs.stat(canonicalPath);
-  if (statResult.isErr()) {
-    return apiError(ctx, mapDustFsError(statResult.error));
-  }
-  if (!statResult.value) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: { type: "file_not_found", message: "File not found." },
-    });
-  }
+    const statResult = await dustFs.stat(canonicalPath);
+    if (statResult.isErr()) {
+      return apiError(ctx, mapDustFsError(statResult.error));
+    }
+    if (!statResult.value) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: { type: "file_not_found", message: "File not found." },
+      });
+    }
 
-  return new Response(null, {
-    status: 200,
-    headers: {
-      "Content-Type": statResult.value.contentType,
-      "Content-Length": String(statResult.value.sizeBytes),
-    },
-  });
-});
-
-app.patch("/:canonicalPath{.+}", async (ctx) => {
-  const auth = ctx.get("auth");
-  const canonicalPath = ctx.req.param("canonicalPath");
-  const { fs: dustFs, err } = await resolveFs(ctx, canonicalPath);
-  if (err) {
-    return err;
-  }
-
-  let body: unknown;
-  try {
-    body = await ctx.req.json();
-  } catch {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid JSON body.",
+    return new Response(null, {
+      status: 200,
+      headers: {
+        "Content-Type": statResult.value.contentType,
+        "Content-Length": String(statResult.value.sizeBytes),
       },
     });
   }
+);
 
-  const parsed = PatchBodySchema.safeParse(body);
-  if (!parsed.success) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: fromError(parsed.error).toString(),
-      },
-    });
-  }
-
-  const data = parsed.data;
-
-  switch (data.action) {
-    case "rename": {
-      const renameResult = await renameCanonicalFile(
-        auth,
-        dustFs,
-        canonicalPath,
-        data.fileName
-      );
-      if (renameResult.isErr()) {
-        return apiError(ctx, mapDustFsError(renameResult.error));
-      }
-      break;
+app.patch(
+  "/:canonicalPath{.+}",
+  validate("param", ParamsSchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { canonicalPath } = ctx.req.valid("param");
+    const { fs: dustFs, err } = await resolveFs(ctx, canonicalPath);
+    if (err) {
+      return err;
     }
 
-    case "move": {
-      if (data.dest === canonicalPath) {
-        return new Response(null, { status: 200 });
-      }
-      const moveResult = await moveCanonicalFile(
-        auth,
-        dustFs,
-        canonicalPath,
-        data.dest
-      );
-      if (moveResult.isErr()) {
-        return apiError(ctx, mapDustFsError(moveResult.error));
-      }
-      break;
+    let body: unknown;
+    try {
+      body = await ctx.req.json();
+    } catch {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid JSON body.",
+        },
+      });
     }
 
-    default:
-      assertNever(data);
+    const parsed = PatchBodySchema.safeParse(body);
+    if (!parsed.success) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: fromError(parsed.error).toString(),
+        },
+      });
+    }
+
+    const data = parsed.data;
+
+    switch (data.action) {
+      case "rename": {
+        const renameResult = await renameCanonicalFile(
+          auth,
+          dustFs,
+          canonicalPath,
+          data.fileName
+        );
+        if (renameResult.isErr()) {
+          return apiError(ctx, mapDustFsError(renameResult.error));
+        }
+        break;
+      }
+
+      case "move": {
+        if (data.dest === canonicalPath) {
+          return new Response(null, { status: 200 });
+        }
+        const moveResult = await moveCanonicalFile(
+          auth,
+          dustFs,
+          canonicalPath,
+          data.dest
+        );
+        if (moveResult.isErr()) {
+          return apiError(ctx, mapDustFsError(moveResult.error));
+        }
+        break;
+      }
+
+      default:
+        assertNever(data);
+    }
+
+    return new Response(null, { status: 200 });
   }
+);
 
-  return new Response(null, { status: 200 });
-});
+app.delete(
+  "/:canonicalPath{.+}",
+  validate("param", ParamsSchema),
+  async (ctx) => {
+    const { canonicalPath } = ctx.req.valid("param");
+    const { fs: dustFs, err } = await resolveFs(ctx, canonicalPath);
+    if (err) {
+      return err;
+    }
 
-app.delete("/:canonicalPath{.+}", async (ctx) => {
-  const canonicalPath = ctx.req.param("canonicalPath");
-  const { fs: dustFs, err } = await resolveFs(ctx, canonicalPath);
-  if (err) {
-    return err;
+    const deleteResult = await dustFs.delete(canonicalPath);
+    if (deleteResult.isErr()) {
+      return apiError(ctx, mapDustFsError(deleteResult.error));
+    }
+
+    return new Response(null, { status: 204 });
   }
-
-  const deleteResult = await dustFs.delete(canonicalPath);
-  if (deleteResult.isErr()) {
-    return apiError(ctx, mapDustFsError(deleteResult.error));
-  }
-
-  return new Response(null, { status: 204 });
-});
+);
 
 function mapDustFsError(err: DustFileSystemError) {
   switch (err.code) {

--- a/front-api/routes/w/[wId]/invitations/[iId]/index.ts
+++ b/front-api/routes/w/[wId]/invitations/[iId]/index.ts
@@ -29,16 +29,6 @@ app.post(
     const auth = ctx.get("auth");
     const { iId: invitationId } = ctx.req.valid("param");
 
-    if (!invitationId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid query parameters, `iId` (string) is required.",
-        },
-      });
-    }
-
     const invitation = await MembershipInvitationResource.fetchById(
       auth,
       invitationId

--- a/front-api/routes/w/[wId]/invitations/[iId]/index.ts
+++ b/front-api/routes/w/[wId]/invitations/[iId]/index.ts
@@ -10,6 +10,11 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  iId: z.string(),
+});
 
 // Mounted under /api/w/:wId/invitations/:iId.
 const app = workspaceApp();
@@ -18,10 +23,11 @@ app.use("*", ensureIsAdmin());
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   validate("json", PostMemberInvitationBodySchema),
   async (ctx): HandlerResult<PostMemberInvitationsResponseBody> => {
     const auth = ctx.get("auth");
-    const invitationId = ctx.req.param("iId");
+    const { iId: invitationId } = ctx.req.valid("param");
 
     if (!invitationId) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/join.ts
+++ b/front-api/routes/w/[wId]/join.ts
@@ -9,6 +9,12 @@ import { isString } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType } from "@app/types/user";
 import { createHono } from "@front-api/lib/hono";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  wId: z.string(),
+});
 
 type OnboardingType =
   | "email_invite"
@@ -31,8 +37,9 @@ const app = createHono();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   async (ctx): HandlerResult<GetJoinResponseBody | GetJoinErrorBody> => {
-    const wId = ctx.req.param("wId");
+    const { wId } = ctx.req.valid("param");
     const { t, cId } = ctx.req.query();
 
     if (!isString(wId)) {

--- a/front-api/routes/w/[wId]/join.ts
+++ b/front-api/routes/w/[wId]/join.ts
@@ -42,16 +42,6 @@ app.get(
     const { wId } = ctx.req.valid("param");
     const { t, cId } = ctx.req.query();
 
-    if (!isString(wId)) {
-      return apiError(ctx, {
-        status_code: 404,
-        api_error: {
-          type: "workspace_not_found",
-          message: "The workspace was not found.",
-        },
-      });
-    }
-
     const workspaceResource = await WorkspaceResource.fetchById(wId);
     const maintenance = workspaceResource?.metadata?.maintenance;
 

--- a/front-api/routes/w/[wId]/labs/transcripts/[tId].ts
+++ b/front-api/routes/w/[wId]/labs/transcripts/[tId].ts
@@ -39,15 +39,15 @@ type LoadResult =
   | { ok: true; configuration: LabsTranscriptsConfigurationResource }
   | { ok: false; response: ReturnType<typeof apiError> };
 
+const ParamsSchema = z.object({
+  tId: z.string(),
+});
+
 async function loadOwnedConfiguration(
   ctx: Context,
-  auth: Authenticator
+  auth: Authenticator,
+  transcriptsConfigurationId: string
 ): Promise<LoadResult> {
-  const transcriptsConfigurationId = ctx.req.param("tId");
-  if (!transcriptsConfigurationId) {
-    return { ok: false, response: apiError(ctx, NOT_FOUND_ERROR) };
-  }
-
   const transcriptsConfiguration =
     await LabsTranscriptsConfigurationResource.fetchById(
       auth,
@@ -69,24 +69,31 @@ async function loadOwnedConfiguration(
 // Mounted at /api/w/:wId/labs/transcripts/:tId.
 const app = workspaceApp();
 
-app.get("/", async (ctx): HandlerResult<GetResponseBody> => {
-  const auth = ctx.get("auth");
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetResponseBody> => {
+    const auth = ctx.get("auth");
+    const { tId } = ctx.req.valid("param");
 
-  const loadRes = await loadOwnedConfiguration(ctx, auth);
-  if (!loadRes.ok) {
-    return loadRes.response;
+    const loadRes = await loadOwnedConfiguration(ctx, auth, tId);
+    if (!loadRes.ok) {
+      return loadRes.response;
+    }
+
+    return ctx.json({ configuration: loadRes.configuration.toJSON() });
   }
-
-  return ctx.json({ configuration: loadRes.configuration.toJSON() });
-});
+);
 
 app.patch(
   "/",
+  validate("param", ParamsSchema),
   validate("json", PatchLabsTranscriptsConfigurationBodySchema),
   async (ctx): HandlerResult<GetResponseBody> => {
     const auth = ctx.get("auth");
+    const { tId } = ctx.req.valid("param");
 
-    const loadRes = await loadOwnedConfiguration(ctx, auth);
+    const loadRes = await loadOwnedConfiguration(ctx, auth, tId);
     if (!loadRes.ok) {
       return loadRes.response;
     }
@@ -188,19 +195,24 @@ app.patch(
   }
 );
 
-app.delete("/", async (ctx): HandlerResult<GetResponseBody> => {
-  const auth = ctx.get("auth");
+app.delete(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetResponseBody> => {
+    const auth = ctx.get("auth");
+    const { tId } = ctx.req.valid("param");
 
-  const loadRes = await loadOwnedConfiguration(ctx, auth);
-  if (!loadRes.ok) {
-    return loadRes.response;
+    const loadRes = await loadOwnedConfiguration(ctx, auth, tId);
+    if (!loadRes.ok) {
+      return loadRes.response;
+    }
+    const transcriptsConfiguration = loadRes.configuration;
+
+    await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);
+    await transcriptsConfiguration.delete(auth);
+
+    return ctx.json({ configuration: null });
   }
-  const transcriptsConfiguration = loadRes.configuration;
-
-  await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);
-  await transcriptsConfiguration.delete(auth);
-
-  return ctx.json({ configuration: null });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/mcp/[serverId]/index.ts
+++ b/front-api/routes/w/[wId]/mcp/[serverId]/index.ts
@@ -66,15 +66,20 @@ export type DeleteMCPServerResponseBody = {
   deleted: boolean;
 };
 
+const ParamsSchema = z.object({
+  serverId: z.string(),
+});
+
 // Mounted under /api/w/:wId/mcp/:serverId.
 const app = workspaceApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   ensureIsUser(),
   async (ctx): HandlerResult<GetMCPServerResponseBody> => {
     const auth = ctx.get("auth");
-    const serverId = ctx.req.param("serverId") ?? "";
+    const { serverId } = ctx.req.valid("param");
 
     const { serverType, id } = getServerTypeAndIdFromSId(serverId);
     switch (serverType) {
@@ -121,11 +126,12 @@ app.get(
 
 app.patch(
   "/",
+  validate("param", ParamsSchema),
   ensureIsUser(),
   validate("json", PatchMCPServerBodySchema),
   async (ctx): HandlerResult<PatchMCPServerResponseBody> => {
     const auth = ctx.get("auth");
-    const serverId = ctx.req.param("serverId") ?? "";
+    const { serverId } = ctx.req.valid("param");
     const body = ctx.req.valid("json");
 
     const { serverType } = getServerTypeAndIdFromSId(serverId);
@@ -168,10 +174,11 @@ app.patch(
 
 app.delete(
   "/",
+  validate("param", ParamsSchema),
   ensureIsUser(),
   async (ctx): HandlerResult<DeleteMCPServerResponseBody> => {
     const auth = ctx.get("auth");
-    const serverId = ctx.req.param("serverId") ?? "";
+    const { serverId } = ctx.req.valid("param");
 
     const { serverType } = getServerTypeAndIdFromSId(serverId);
 

--- a/front-api/routes/w/[wId]/mcp/[serverId]/sync.ts
+++ b/front-api/routes/w/[wId]/mcp/[serverId]/sync.ts
@@ -5,6 +5,12 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  serverId: z.string(),
+});
 
 export type SyncMCPServerResponseBody = {
   success: boolean;
@@ -17,10 +23,11 @@ const app = workspaceApp();
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   ensureIsAdmin(),
   async (ctx): HandlerResult<SyncMCPServerResponseBody> => {
     const auth = ctx.get("auth");
-    const serverId = ctx.req.param("serverId") ?? "";
+    const { serverId } = ctx.req.valid("param");
 
     const server = await RemoteMCPServerResource.fetchById(auth, serverId);
     if (!server) {

--- a/front-api/routes/w/[wId]/mcp/[serverId]/tools/[toolName]/index.ts
+++ b/front-api/routes/w/[wId]/mcp/[serverId]/tools/[toolName]/index.ts
@@ -28,17 +28,22 @@ export type PatchMCPServerToolsPermissionsResponseBody = {
   success: boolean;
 };
 
+const ParamsSchema = z.object({
+  serverId: z.string(),
+  toolName: z.string(),
+});
+
 // Mounted at /api/w/:wId/mcp/:serverId/tools/:toolName.
 const app = workspaceApp();
 
 app.patch(
   "/",
+  validate("param", ParamsSchema),
   ensureIsUser(),
   validate("json", UpdateMCPToolSettingsBodySchema),
   async (ctx): HandlerResult<PatchMCPServerToolsPermissionsResponseBody> => {
     const auth = ctx.get("auth");
-    const serverId = ctx.req.param("serverId") ?? "";
-    const toolName = ctx.req.param("toolName") ?? "";
+    const { serverId, toolName } = ctx.req.valid("param");
 
     const { id } = getServerTypeAndIdFromSId(serverId);
     if (!id) {

--- a/front-api/routes/w/[wId]/mcp/connections/[connectionType]/[cId]/index.ts
+++ b/front-api/routes/w/[wId]/mcp/connections/[connectionType]/[cId]/index.ts
@@ -2,19 +2,25 @@ import type { MCPServerConnectionType } from "@app/lib/resources/mcp_server_conn
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import type { Context } from "hono";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  cId: z.string(),
+});
 
 // Mounted at /api/w/:wId/mcp/connections/:connectionType/:cId.
 const app = workspaceApp();
 
-async function loadConnection(ctx: Context) {
+async function loadConnection(ctx: Context, cId: string) {
   const auth = ctx.get("auth");
-  const cId = ctx.req.param("cId") ?? "";
   return MCPServerConnectionResource.fetchById(auth, cId);
 }
 
-app.get("/", async (ctx) => {
-  const connectionRes = await loadConnection(ctx);
+app.get("/", validate("param", ParamsSchema), async (ctx) => {
+  const { cId } = ctx.req.valid("param");
+  const connectionRes = await loadConnection(ctx, cId);
   if (connectionRes.isErr()) {
     return apiError(ctx, {
       status_code: 404,
@@ -31,9 +37,10 @@ app.get("/", async (ctx) => {
   return ctx.json(value);
 });
 
-app.delete("/", async (ctx) => {
+app.delete("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const connectionRes = await loadConnection(ctx);
+  const { cId } = ctx.req.valid("param");
+  const connectionRes = await loadConnection(ctx, cId);
   if (connectionRes.isErr()) {
     return apiError(ctx, {
       status_code: 404,

--- a/front-api/routes/w/[wId]/mcp/connections/[connectionType]/index.ts
+++ b/front-api/routes/w/[wId]/mcp/connections/[connectionType]/index.ts
@@ -38,6 +38,10 @@ const PostConnectionBodySchema = z.union([
   PostConnectionCredentialsBodySchema,
 ]);
 
+const ParamsSchema = z.object({
+  connectionType: z.string(),
+});
+
 export type PostConnectionBodyType = z.infer<typeof PostConnectionBodySchema>;
 
 // Wire shape: ctx.json serializes Date to ISO string, so the response type
@@ -201,30 +205,38 @@ async function validateAuthReferenceForMCPConnection(
 // Mounted under /api/w/:wId/mcp/connections/:connectionType.
 const app = workspaceApp();
 
-app.get("/", async (ctx): HandlerResult<GetConnectionsResponseBody> => {
-  const connectionType = ctx.req.param("connectionType");
-  if (!isMCPServerConnectionConnectionType(connectionType)) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid connection type",
-      },
-    });
-  }
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetConnectionsResponseBody> => {
+    const { connectionType } = ctx.req.valid("param");
+    if (!isMCPServerConnectionConnectionType(connectionType)) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid connection type",
+        },
+      });
+    }
 
-  const auth = ctx.get("auth");
-  const connections = await MCPServerConnectionResource.listByWorkspace(auth, {
-    connectionType,
-  });
-  return ctx.json({ connections: connections.map((c) => c.toJSON()) });
-});
+    const auth = ctx.get("auth");
+    const connections = await MCPServerConnectionResource.listByWorkspace(
+      auth,
+      {
+        connectionType,
+      }
+    );
+    return ctx.json({ connections: connections.map((c) => c.toJSON()) });
+  }
+);
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   validate("json", PostConnectionBodySchema),
   async (ctx): HandlerResult<PostConnectionResponseBody> => {
-    const connectionType = ctx.req.param("connectionType");
+    const { connectionType } = ctx.req.valid("param");
     if (!isMCPServerConnectionConnectionType(connectionType)) {
       return apiError(ctx, {
         status_code: 400,

--- a/front-api/routes/w/[wId]/mcp/views/[viewId]/index.ts
+++ b/front-api/routes/w/[wId]/mcp/views/[viewId]/index.ts
@@ -33,17 +33,22 @@ export type PatchMCPServerViewResponseBody = {
   serverView: MCPServerViewType;
 };
 
+const ParamsSchema = z.object({
+  viewId: z.string(),
+});
+
 // Mounted at /api/w/:wId/mcp/views/:viewId.
 const app = workspaceApp();
 
 app.patch(
   "/",
+  validate("param", ParamsSchema),
   ensureIsUser(),
   validate("json", PatchMCPServerViewBodySchema),
   async (ctx): HandlerResult<PatchMCPServerViewResponseBody> => {
     const auth = ctx.get("auth");
 
-    const viewId = ctx.req.param("viewId") ?? "";
+    const { viewId } = ctx.req.valid("param");
     const body = ctx.req.valid("json");
 
     // Get the system view to validate that viewId refers to a system view.

--- a/front-api/routes/w/[wId]/members/[uId]/index.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/index.ts
@@ -31,16 +31,20 @@ const PostMemberBodySchema = z.object({
   force: z.string().optional(),
 });
 
+const ParamsSchema = z.object({
+  uId: z.string(),
+});
+
 // Mounted at /api/w/:wId/members/:uId.
 const app = workspaceApp();
 
 app.route("/seat-type", seatType);
 app.route("/spend_limit", spendLimit);
 
-app.get("/", async (ctx) => {
+app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
   const owner = auth.getNonNullableWorkspace();
-  const uId = ctx.req.param("uId") ?? "";
+  const { uId } = ctx.req.valid("param");
 
   const user = await getUserForWorkspace(auth, { userId: uId });
   if (!user) {
@@ -88,196 +92,202 @@ app.get("/", async (ctx) => {
   return ctx.json(response);
 });
 
-app.post("/", validate("json", PostMemberBodySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const owner = auth.getNonNullableWorkspace();
-  const uId = ctx.req.param("uId") ?? "";
+app.post(
+  "/",
+  validate("param", ParamsSchema),
+  validate("json", PostMemberBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const owner = auth.getNonNullableWorkspace();
+    const { uId } = ctx.req.valid("param");
 
-  const featureFlags = await getFeatureFlags(auth);
-  const body = ctx.req.valid("json");
-  const isAdmin = auth.isAdmin();
+    const featureFlags = await getFeatureFlags(auth);
+    const body = ctx.req.valid("json");
+    const isAdmin = auth.isAdmin();
 
-  // Allow Dust Super User to force role for testing
-  const allowForSuperUserTesting =
-    showDebugTools(featureFlags) &&
-    auth.isDustSuperUser() &&
-    body.force === "true";
+    // Allow Dust Super User to force role for testing
+    const allowForSuperUserTesting =
+      showDebugTools(featureFlags) &&
+      auth.isDustSuperUser() &&
+      body.force === "true";
 
-  if (!isAdmin && !allowForSuperUserTesting) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "Only users that are `admins` for the current workspace can modify memberships.",
-      },
-    });
-  }
-
-  const user = await getUserForWorkspace(auth, { userId: uId });
-  if (!user) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "workspace_user_not_found",
-        message: "The user requested was not found.",
-      },
-    });
-  }
-
-  // TODO(@fontanierh): use DELETE for revoking membership
-  if (body.role === "revoked") {
-    const revokeResult = await revokeAndTrackMembership(auth, user);
-
-    if (revokeResult.isErr()) {
-      switch (revokeResult.error.type) {
-        case "not_found":
-          logger.error(
-            {
-              panic: true,
-              revokeResult,
-              userId: user.sId,
-              workspaceId: owner.sId,
-            },
-            "Failed to revoke membership and track usage."
-          );
-          return apiError(ctx, {
-            status_code: 404,
-            api_error: {
-              type: "workspace_user_not_found",
-              message: "Could not find the membership.",
-            },
-          });
-        case "last_admin":
-          return apiError(ctx, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: "Cannot revoke the last admin of a workspace.",
-            },
-          });
-        case "already_revoked":
-        case "invalid_end_at":
-          break;
-        default:
-          assertNever(revokeResult.error.type);
-      }
-    }
-  } else {
-    const role = body.role;
-    if (!isMembershipRoleType(role)) {
+    if (!isAdmin && !allowForSuperUserTesting) {
       return apiError(ctx, {
-        status_code: 400,
+        status_code: 403,
         api_error: {
-          type: "invalid_request_error",
+          type: "workspace_auth_error",
           message:
-            "The request body is invalid, expects { role: 'admin' | 'builder' | 'user' }.",
+            "Only users that are `admins` for the current workspace can modify memberships.",
         },
       });
     }
 
-    // Check if this is an admin trying to change their own role and they are the sole admin
-    const currentUser = auth.user();
-    if (currentUser && currentUser.id === user.id && auth.isAdmin()) {
-      // Count active admins to prevent sole admin from changing their own role
-      const adminsCount = await MembershipResource.getMembersCountForWorkspace({
-        workspace: owner,
-        activeOnly: true,
-        rolesFilter: ["admin"],
+    const user = await getUserForWorkspace(auth, { userId: uId });
+    if (!user) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "workspace_user_not_found",
+          message: "The user requested was not found.",
+        },
       });
+    }
 
-      if (adminsCount < 2 && role !== "admin") {
+    // TODO(@fontanierh): use DELETE for revoking membership
+    if (body.role === "revoked") {
+      const revokeResult = await revokeAndTrackMembership(auth, user);
+
+      if (revokeResult.isErr()) {
+        switch (revokeResult.error.type) {
+          case "not_found":
+            logger.error(
+              {
+                panic: true,
+                revokeResult,
+                userId: user.sId,
+                workspaceId: owner.sId,
+              },
+              "Failed to revoke membership and track usage."
+            );
+            return apiError(ctx, {
+              status_code: 404,
+              api_error: {
+                type: "workspace_user_not_found",
+                message: "Could not find the membership.",
+              },
+            });
+          case "last_admin":
+            return apiError(ctx, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: "Cannot revoke the last admin of a workspace.",
+              },
+            });
+          case "already_revoked":
+          case "invalid_end_at":
+            break;
+          default:
+            assertNever(revokeResult.error.type);
+        }
+      }
+    } else {
+      const role = body.role;
+      if (!isMembershipRoleType(role)) {
         return apiError(ctx, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
             message:
-              "Cannot change your role as you are the sole admin of this workspace.",
+              "The request body is invalid, expects { role: 'admin' | 'builder' | 'user' }.",
+          },
+        });
+      }
+
+      // Check if this is an admin trying to change their own role and they are the sole admin
+      const currentUser = auth.user();
+      if (currentUser && currentUser.id === user.id && auth.isAdmin()) {
+        // Count active admins to prevent sole admin from changing their own role
+        const adminsCount =
+          await MembershipResource.getMembersCountForWorkspace({
+            workspace: owner,
+            activeOnly: true,
+            rolesFilter: ["admin"],
+          });
+
+        if (adminsCount < 2 && role !== "admin") {
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "Cannot change your role as you are the sole admin of this workspace.",
+            },
+          });
+        }
+      }
+
+      const allowLastAdminRemoval = showDebugTools(featureFlags);
+
+      const updateRes = await updateMembershipRoleAndTrack({
+        user,
+        workspace: owner,
+        newRole: role,
+        allowTerminated: true,
+        allowLastAdminRemoval,
+        author: auth.user()?.toJSON() ?? "no-author",
+      });
+
+      if (updateRes.isErr()) {
+        switch (updateRes.error.type) {
+          case "not_found":
+            return apiError(ctx, {
+              status_code: 404,
+              api_error: {
+                type: "workspace_user_not_found",
+                message: "Could not find the membership.",
+              },
+            });
+          case "membership_already_terminated":
+            // This cannot happen because we allow updating terminated memberships
+            // by setting `allowTerminated` to true.
+            throw new Error("Unreachable.");
+          case "already_on_role":
+            // Should not happen, but we ignore.
+            break;
+          case "last_admin":
+            return apiError(ctx, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: "Cannot remove the last admin of a workspace.",
+              },
+            });
+          default:
+            assertNever(updateRes.error.type);
+        }
+      }
+
+      if (updateRes.isOk()) {
+        void emitAuditLogEvent({
+          auth,
+          action: "membership.role_updated",
+          targets: [
+            buildAuditLogTarget("workspace", owner),
+            buildAuditLogTarget("user", {
+              sId: user.sId,
+              name: user.fullName() ?? "unknown",
+            }),
+          ],
+          context: getAuditLogContext(auth),
+          metadata: {
+            previous_role: updateRes.value.previousRole,
+            new_role: updateRes.value.newRole,
           },
         });
       }
     }
 
-    const allowLastAdminRemoval = showDebugTools(featureFlags);
+    const w = { ...owner };
+    w.role = "none";
 
-    const updateRes = await updateMembershipRoleAndTrack({
-      user,
-      workspace: owner,
-      newRole: role,
-      allowTerminated: true,
-      allowLastAdminRemoval,
-      author: auth.user()?.toJSON() ?? "no-author",
-    });
-
-    if (updateRes.isErr()) {
-      switch (updateRes.error.type) {
-        case "not_found":
-          return apiError(ctx, {
-            status_code: 404,
-            api_error: {
-              type: "workspace_user_not_found",
-              message: "Could not find the membership.",
-            },
-          });
-        case "membership_already_terminated":
-          // This cannot happen because we allow updating terminated memberships
-          // by setting `allowTerminated` to true.
-          throw new Error("Unreachable.");
-        case "already_on_role":
-          // Should not happen, but we ignore.
-          break;
-        case "last_admin":
-          return apiError(ctx, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: "Cannot remove the last admin of a workspace.",
-            },
-          });
-        default:
-          assertNever(updateRes.error.type);
-      }
+    switch (body.role) {
+      case "admin":
+      case "builder":
+      case "user":
+        w.role = body.role;
+        break;
+      default:
+        w.role = "none";
     }
 
-    if (updateRes.isOk()) {
-      void emitAuditLogEvent({
-        auth,
-        action: "membership.role_updated",
-        targets: [
-          buildAuditLogTarget("workspace", owner),
-          buildAuditLogTarget("user", {
-            sId: user.sId,
-            name: user.fullName() ?? "unknown",
-          }),
-        ],
-        context: getAuditLogContext(auth),
-        metadata: {
-          previous_role: updateRes.value.previousRole,
-          new_role: updateRes.value.newRole,
-        },
-      });
-    }
+    const member = {
+      ...user.toJSON(),
+      workspaces: [w],
+    };
+
+    return ctx.json<PostMemberResponseBody>({ member });
   }
-
-  const w = { ...owner };
-  w.role = "none";
-
-  switch (body.role) {
-    case "admin":
-    case "builder":
-    case "user":
-      w.role = body.role;
-      break;
-    default:
-      w.role = "none";
-  }
-
-  const member = {
-    ...user.toJSON(),
-    workspaces: [w],
-  };
-
-  return ctx.json<PostMemberResponseBody>({ member });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/members/[uId]/seat-type.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/seat-type.ts
@@ -15,6 +15,10 @@ const UpdateMemberSeatTypeBodySchema = z.object({
   seatType: z.enum(MEMBERSHIP_SEAT_TYPES),
 });
 
+const ParamsSchema = z.object({
+  uId: z.string(),
+});
+
 type PatchMemberSeatTypeResponseBody = {
   seatType: MembershipSeatType;
   scheduledSeatChangeAt: string | null;
@@ -25,6 +29,7 @@ const app = workspaceApp();
 
 app.patch(
   "/",
+  validate("param", ParamsSchema),
   ensureIsAdmin(),
   validate("json", UpdateMemberSeatTypeBodySchema),
   async (ctx) => {
@@ -44,7 +49,7 @@ app.patch(
       });
     }
 
-    const uId = ctx.req.param("uId") ?? "";
+    const { uId } = ctx.req.valid("param");
     const user = await getUserForWorkspace(auth, { userId: uId });
 
     if (!user) {

--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.ts
@@ -91,15 +91,6 @@ app.get(
     }
 
     const { uId } = ctx.req.valid("param");
-    if (!uId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid query parameters, `uId` (string) is required.",
-        },
-      });
-    }
 
     const result = await getUserSpendLimit(auth, { userId: uId });
     if (result.isErr()) {
@@ -129,15 +120,6 @@ app.put(
     }
 
     const { uId } = ctx.req.valid("param");
-    if (!uId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid query parameters, `uId` (string) is required.",
-        },
-      });
-    }
 
     const auditContext = getAuditLogContext(auth);
     const result = await setUserSpendLimit(auth, {

--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.ts
@@ -28,6 +28,10 @@ const UpdateUserSpendLimitBodySchema = z.discriminatedUnion("kind", [
   }),
 ]);
 
+const ParamsSchema = z.object({
+  uId: z.string(),
+});
+
 export type GetUserSpendLimitResponseBody = GetUserSpendLimitResponse;
 
 export type PutUserSpendLimitResponseBody = SetUserSpendLimitResponse;
@@ -70,6 +74,7 @@ const app = workspaceApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   ensureIsAdmin(),
   async (ctx): HandlerResult<GetUserSpendLimitResponseBody> => {
     const auth = ctx.get("auth");
@@ -85,7 +90,7 @@ app.get(
       });
     }
 
-    const uId = ctx.req.param("uId") ?? "";
+    const { uId } = ctx.req.valid("param");
     if (!uId) {
       return apiError(ctx, {
         status_code: 400,
@@ -106,6 +111,7 @@ app.get(
 
 app.put(
   "/",
+  validate("param", ParamsSchema),
   ensureIsAdmin(),
   validate("json", UpdateUserSpendLimitBodySchema),
   async (ctx): HandlerResult<PutUserSpendLimitResponseBody> => {
@@ -122,7 +128,7 @@ app.put(
       });
     }
 
-    const uId = ctx.req.param("uId") ?? "";
+    const { uId } = ctx.req.valid("param");
     if (!uId) {
       return apiError(ctx, {
         status_code: 400,

--- a/front-api/routes/w/[wId]/project_tasks/[taskSId]/index.ts
+++ b/front-api/routes/w/[wId]/project_tasks/[taskSId]/index.ts
@@ -10,6 +10,12 @@ import type { PodTaskType } from "@app/types/project_task";
 import type { PodType } from "@app/types/space";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  taskSId: z.string(),
+});
 
 export interface GetWorkspaceProjectTaskResponseBody {
   task: PodTaskType;
@@ -20,9 +26,9 @@ export interface GetWorkspaceProjectTaskResponseBody {
 // Mounted at /api/w/:wId/project_tasks/:taskSId.
 const app = workspaceApp();
 
-app.get("/", async (ctx) => {
+app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const taskSId = ctx.req.param("taskSId") ?? "";
+  const { taskSId } = ctx.req.valid("param");
   if (!taskSId) {
     return apiError(ctx, {
       status_code: 400,

--- a/front-api/routes/w/[wId]/project_tasks/[taskSId]/index.ts
+++ b/front-api/routes/w/[wId]/project_tasks/[taskSId]/index.ts
@@ -29,15 +29,6 @@ const app = workspaceApp();
 app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
   const { taskSId } = ctx.req.valid("param");
-  if (!taskSId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Missing or invalid task id.",
-      },
-    });
-  }
 
   const taskRow = await ProjectTaskResource.fetchBySId(auth, taskSId);
   if (!taskRow) {

--- a/front-api/routes/w/[wId]/providers/[pId]/check.ts
+++ b/front-api/routes/w/[wId]/providers/[pId]/check.ts
@@ -15,15 +15,20 @@ const PostCheckBodySchema = z.object({
   }),
 });
 
+const ParamsSchema = z.object({
+  pId: z.string(),
+});
+
 // Mounted at /api/w/:wId/providers/:pId/check.
 const app = workspaceApp();
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   ensureIsBuilder(),
   validate("json", PostCheckBodySchema),
   async (ctx): HandlerResult<GetProvidersCheckResponseBody> => {
-    const pId = ctx.req.param("pId") ?? "";
+    const { pId } = ctx.req.valid("param");
     const { config } = ctx.req.valid("json");
 
     switch (pId) {

--- a/front-api/routes/w/[wId]/providers/[pId]/index.ts
+++ b/front-api/routes/w/[wId]/providers/[pId]/index.ts
@@ -20,18 +20,23 @@ const PostProviderBodySchema = z.object({
   config: z.string(),
 });
 
+const ParamsSchema = z.object({
+  pId: z.string(),
+});
+
 // Mounted at /api/w/:wId/providers/:pId.
 const app = workspaceApp();
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   ensureIsAdmin(),
   validate("json", PostProviderBodySchema),
   async (ctx): HandlerResult<PostProviderResponseBody> => {
     const auth = ctx.get("auth");
     const owner = auth.getNonNullableWorkspace();
 
-    const pId = ctx.req.param("pId") ?? "";
+    const { pId } = ctx.req.valid("param");
 
     const body = ctx.req.valid("json");
 
@@ -75,12 +80,13 @@ app.post(
 
 app.delete(
   "/",
+  validate("param", ParamsSchema),
   ensureIsAdmin(),
   async (ctx): HandlerResult<DeleteProviderResponseBody> => {
     const auth = ctx.get("auth");
     const owner = auth.getNonNullableWorkspace();
 
-    const pId = ctx.req.param("pId") ?? "";
+    const { pId } = ctx.req.valid("param");
 
     const provider = await ProviderModel.findOne({
       where: {

--- a/front-api/routes/w/[wId]/providers/[pId]/models.ts
+++ b/front-api/routes/w/[wId]/providers/[pId]/models.ts
@@ -11,6 +11,12 @@ import {
 } from "@app/types/assistant/models/togetherai";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  pId: z.string(),
+});
 
 export type GetProviderModelsResponseBody = {
   models: Array<{ id: string }>;
@@ -24,6 +30,7 @@ const app = workspaceApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   async (
     ctx
   ): HandlerResult<
@@ -31,7 +38,7 @@ app.get(
   > => {
     const auth = ctx.get("auth");
     const owner = auth.getNonNullableWorkspace();
-    const pId = ctx.req.param("pId") ?? "";
+    const { pId } = ctx.req.valid("param");
 
     const provider = await ProviderModel.findOne({
       where: {

--- a/front-api/routes/w/[wId]/sandbox/env-vars/[id].ts
+++ b/front-api/routes/w/[wId]/sandbox/env-vars/[id].ts
@@ -19,15 +19,20 @@ const PatchWorkspaceSandboxEnvVarBodySchema = z.object({
   allowedDomains: z.array(z.string()).optional(),
 });
 
+const ParamsSchema = z.object({
+  id: z.string(),
+});
+
 // Mounted at /api/w/:wId/sandbox/env-vars/:id.
 const app = workspaceApp();
 
 app.patch(
   "/",
+  validate("param", ParamsSchema),
   validate("json", PatchWorkspaceSandboxEnvVarBodySchema),
   async (ctx): HandlerResult<PatchWorkspaceSandboxEnvVarResponseBody> => {
     const auth = ctx.get("auth");
-    const id = ctx.req.param("id");
+    const { id } = ctx.req.valid("param");
     if (!id) {
       return apiError(ctx, {
         status_code: 400,
@@ -124,44 +129,48 @@ app.patch(
   }
 );
 
-app.delete("/", async (ctx): HandlerResult<SuccessResponseBody> => {
-  const auth = ctx.get("auth");
-  const id = ctx.req.param("id");
-  if (!id) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid sandbox environment variable id.",
-      },
-    });
-  }
+app.delete(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<SuccessResponseBody> => {
+    const auth = ctx.get("auth");
+    const { id } = ctx.req.valid("param");
+    if (!id) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid sandbox environment variable id.",
+        },
+      });
+    }
 
-  const envVar = await WorkspaceSandboxEnvVarResource.fetchById(auth, id);
-  if (!envVar) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Sandbox environment variable not found.",
-      },
-    });
-  }
+    const envVar = await WorkspaceSandboxEnvVarResource.fetchById(auth, id);
+    if (!envVar) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Sandbox environment variable not found.",
+        },
+      });
+    }
 
-  const deleteResult = await envVar.delete(auth, {
-    context: getAuditLogContext(auth),
-  });
-  if (deleteResult.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: deleteResult.error.message,
-      },
+    const deleteResult = await envVar.delete(auth, {
+      context: getAuditLogContext(auth),
     });
-  }
+    if (deleteResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: deleteResult.error.message,
+        },
+      });
+    }
 
-  return ctx.json({ success: true });
-});
+    return ctx.json({ success: true });
+  }
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/sandbox/env-vars/[id].ts
+++ b/front-api/routes/w/[wId]/sandbox/env-vars/[id].ts
@@ -33,15 +33,6 @@ app.patch(
   async (ctx): HandlerResult<PatchWorkspaceSandboxEnvVarResponseBody> => {
     const auth = ctx.get("auth");
     const { id } = ctx.req.valid("param");
-    if (!id) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid sandbox environment variable id.",
-        },
-      });
-    }
 
     const { allowedDomains, kind } = ctx.req.valid("json");
     if (kind === undefined && allowedDomains === undefined) {
@@ -135,15 +126,6 @@ app.delete(
   async (ctx): HandlerResult<SuccessResponseBody> => {
     const auth = ctx.get("auth");
     const { id } = ctx.req.valid("param");
-    if (!id) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid sandbox environment variable id.",
-        },
-      });
-    }
 
     const envVar = await WorkspaceSandboxEnvVarResource.fetchById(auth, id);
     if (!envVar) {

--- a/front-api/routes/w/[wId]/skills/[sId]/editors.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/editors.ts
@@ -2,13 +2,16 @@ import type { GroupResource } from "@app/lib/resources/group_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import { isString } from "@app/types/shared/utils/general";
 import type { UserType } from "@app/types/user";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { Context } from "hono";
 import { z } from "zod";
+
+const ParamsSchema = z.object({
+  sId: z.string(),
+});
 
 const PatchSkillEditorsRequestBodySchema = z
   .object({
@@ -42,20 +45,10 @@ export interface PatchSkillEditorsResponseBody {
 // resources or a Response describing the failure — keeps the validation
 // prelude in one place per [API10].
 async function loadSkillAndEditorGroup(
-  ctx: Context
+  ctx: Context,
+  sId: string
 ): Promise<{ skill: SkillResource; editorGroup: GroupResource } | Response> {
   const auth = ctx.get("auth");
-  const sId = ctx.req.param("sId");
-
-  if (!isString(sId)) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid skill id.",
-      },
-    });
-  }
 
   const skill = await SkillResource.fetchById(auth, sId);
   if (!skill) {
@@ -85,10 +78,11 @@ async function loadSkillAndEditorGroup(
 // Mounted at /api/w/:wId/skills/:sId/editors.
 const app = workspaceApp();
 
-app.get("/", async (ctx) => {
+app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
+  const { sId } = ctx.req.valid("param");
 
-  const loaded = await loadSkillAndEditorGroup(ctx);
+  const loaded = await loadSkillAndEditorGroup(ctx, sId);
   if (loaded instanceof Response) {
     return loaded;
   }
@@ -102,11 +96,13 @@ app.get("/", async (ctx) => {
 
 app.patch(
   "/",
+  validate("param", ParamsSchema),
   validate("json", PatchSkillEditorsRequestBodySchema),
   async (ctx) => {
     const auth = ctx.get("auth");
+    const { sId } = ctx.req.valid("param");
 
-    const loaded = await loadSkillAndEditorGroup(ctx);
+    const loaded = await loadSkillAndEditorGroup(ctx, sId);
     if (loaded instanceof Response) {
       return loaded;
     }

--- a/front-api/routes/w/[wId]/skills/[sId]/files/[fileId]/content.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/files/[fileId]/content.ts
@@ -1,6 +1,5 @@
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import { isString } from "@app/types/shared/utils/general";
 import { readableToReadableStream } from "@app/types/shared/utils/streams";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
@@ -18,26 +17,6 @@ const app = workspaceApp();
 app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
   const { sId, fileId } = ctx.req.valid("param");
-
-  if (!isString(sId)) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid skill ID.",
-      },
-    });
-  }
-
-  if (!isString(fileId)) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid file ID.",
-      },
-    });
-  }
 
   const skill = await SkillResource.fetchById(auth, sId);
   if (!skill) {

--- a/front-api/routes/w/[wId]/skills/[sId]/files/[fileId]/content.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/files/[fileId]/content.ts
@@ -4,14 +4,20 @@ import { isString } from "@app/types/shared/utils/general";
 import { readableToReadableStream } from "@app/types/shared/utils/streams";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  sId: z.string(),
+  fileId: z.string(),
+});
 
 // Mounted at /api/w/:wId/skills/:sId/files/:fileId/content.
 const app = workspaceApp();
 
-app.get("/", async (ctx) => {
+app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
-  const sId = ctx.req.param("sId");
-  const fileId = ctx.req.param("fileId");
+  const { sId, fileId } = ctx.req.valid("param");
 
   if (!isString(sId)) {
     return apiError(ctx, {

--- a/front-api/routes/w/[wId]/skills/[sId]/history/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/history/index.ts
@@ -6,7 +6,13 @@ import { isString } from "@app/types/shared/utils/general";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 import { fromError } from "zod-validation-error";
+
+const ParamsSchema = z.object({
+  sId: z.string(),
+});
 
 export type GetSkillHistoryResponseBody = {
   history: SkillWithVersionType[];
@@ -15,71 +21,75 @@ export type GetSkillHistoryResponseBody = {
 // Mounted at /api/w/:wId/skills/:sId/history.
 const app = workspaceApp();
 
-app.get("/", async (ctx): HandlerResult<GetSkillHistoryResponseBody> => {
-  const auth = ctx.get("auth");
-  const sId = ctx.req.param("sId");
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetSkillHistoryResponseBody> => {
+    const auth = ctx.get("auth");
+    const { sId } = ctx.req.valid("param");
 
-  if (!isString(sId)) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid skill ID provided.",
-      },
+    if (!isString(sId)) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid skill ID provided.",
+        },
+      });
+    }
+
+    // Check that user has access to this skill.
+    const skill = await SkillResource.fetchById(auth, sId);
+
+    if (!skill || !skill.canWrite(auth)) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "skill_not_found",
+          message: "The skill you're trying to access was not found.",
+        },
+      });
+    }
+
+    const rawLimit = ctx.req.query("limit");
+    const queryValidation = GetSkillHistoryQuerySchema.safeParse({
+      limit: typeof rawLimit === "string" ? parseInt(rawLimit, 10) : undefined,
     });
-  }
+    if (!queryValidation.success) {
+      const pathError = fromError(queryValidation.error).toString();
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `Invalid query parameters: ${pathError}`,
+        },
+      });
+    }
 
-  // Check that user has access to this skill.
-  const skill = await SkillResource.fetchById(auth, sId);
+    const { limit } = queryValidation.data;
 
-  if (!skill || !skill.canWrite(auth)) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "skill_not_found",
-        message: "The skill you're trying to access was not found.",
-      },
+    let skillVersionResources = await skill.listVersions(auth);
+
+    if (limit) {
+      skillVersionResources = skillVersionResources.slice(0, limit);
+    }
+
+    const skillVersions = skillVersionResources.map((resource) => {
+      const serializedSkill = resource.toJSON(auth);
+
+      return {
+        ...serializedSkill,
+        instructionsHtml:
+          serializedSkill.instructionsHtml ??
+          (serializedSkill.instructions
+            ? convertMarkdownToBlockHtml(serializedSkill.instructions)
+            : null),
+        version: resource.version,
+      };
     });
+
+    return ctx.json({ history: skillVersions });
   }
-
-  const rawLimit = ctx.req.query("limit");
-  const queryValidation = GetSkillHistoryQuerySchema.safeParse({
-    limit: typeof rawLimit === "string" ? parseInt(rawLimit, 10) : undefined,
-  });
-  if (!queryValidation.success) {
-    const pathError = fromError(queryValidation.error).toString();
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: `Invalid query parameters: ${pathError}`,
-      },
-    });
-  }
-
-  const { limit } = queryValidation.data;
-
-  let skillVersionResources = await skill.listVersions(auth);
-
-  if (limit) {
-    skillVersionResources = skillVersionResources.slice(0, limit);
-  }
-
-  const skillVersions = skillVersionResources.map((resource) => {
-    const serializedSkill = resource.toJSON(auth);
-
-    return {
-      ...serializedSkill,
-      instructionsHtml:
-        serializedSkill.instructionsHtml ??
-        (serializedSkill.instructions
-          ? convertMarkdownToBlockHtml(serializedSkill.instructions)
-          : null),
-      version: resource.version,
-    };
-  });
-
-  return ctx.json({ history: skillVersions });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/skills/[sId]/history/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/history/index.ts
@@ -2,7 +2,6 @@ import { convertMarkdownToBlockHtml } from "@app/lib/reinforcement/skill_instruc
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { GetSkillHistoryQuerySchema } from "@app/types/api/internal/skill";
 import type { SkillWithVersionType } from "@app/types/assistant/skill_configuration";
-import { isString } from "@app/types/shared/utils/general";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -27,16 +26,6 @@ app.get(
   async (ctx): HandlerResult<GetSkillHistoryResponseBody> => {
     const auth = ctx.get("auth");
     const { sId } = ctx.req.valid("param");
-
-    if (!isString(sId)) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid skill ID provided.",
-        },
-      });
-    }
 
     // Check that user has access to this skill.
     const skill = await SkillResource.fetchById(auth, sId);

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -14,7 +14,6 @@ import type {
 } from "@app/types/assistant/skill_configuration";
 import type { APIErrorResponse } from "@app/types/error";
 import type { ModelId } from "@app/types/shared/model_id";
-import { isString } from "@app/types/shared/utils/general";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -53,6 +52,10 @@ export type DeleteSkillResponseBody = {
   success: boolean;
 };
 
+const ParamsSchema = z.object({
+  sId: z.string(),
+});
+
 // Request body schema for PATCH.
 const PatchSkillRequestBodySchema = z.object({
   name: z.string(),
@@ -76,23 +79,13 @@ const PatchSkillRequestBodySchema = z.object({
 // Shared per-request prelude: resolve :sId to a SkillResource or return a
 // failure Response. See [API10].
 async function loadSkill(
-  ctx: Context
+  ctx: Context,
+  sId: string
 ): Promise<
   | { skill: SkillResource; sId: string }
   | (Response & TypedResponse<APIErrorResponse>)
 > {
   const auth = ctx.get("auth");
-  const sId = ctx.req.param("sId");
-
-  if (!isString(sId)) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid skill ID.",
-      },
-    });
-  }
 
   const skill = await SkillResource.fetchById(auth, sId);
   if (!skill) {
@@ -120,14 +113,16 @@ app.route("/files/:fileId/content", filesRoute);
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   async (
     ctx
   ): HandlerResult<
     GetSkillResponseBody | GetSkillWithRelationsResponseBody
   > => {
     const auth = ctx.get("auth");
+    const { sId } = ctx.req.valid("param");
 
-    const loaded = await loadSkill(ctx);
+    const loaded = await loadSkill(ctx, sId);
     if (loaded instanceof Response) {
       return loaded;
     }
@@ -183,12 +178,14 @@ app.get(
 
 app.patch(
   "/",
+  validate("param", ParamsSchema),
   validate("json", PatchSkillRequestBodySchema),
   async (ctx): HandlerResult<PatchSkillResponseBody> => {
     const auth = ctx.get("auth");
     const owner = auth.getNonNullableWorkspace();
+    const { sId } = ctx.req.valid("param");
 
-    const loaded = await loadSkill(ctx);
+    const loaded = await loadSkill(ctx, sId);
     if (loaded instanceof Response) {
       return loaded;
     }
@@ -437,40 +434,45 @@ app.patch(
   }
 );
 
-app.delete("/", async (ctx): HandlerResult<DeleteSkillResponseBody> => {
-  const auth = ctx.get("auth");
-  const owner = auth.getNonNullableWorkspace();
+app.delete(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<DeleteSkillResponseBody> => {
+    const auth = ctx.get("auth");
+    const owner = auth.getNonNullableWorkspace();
+    const { sId } = ctx.req.valid("param");
 
-  const loaded = await loadSkill(ctx);
-  if (loaded instanceof Response) {
-    return loaded;
+    const loaded = await loadSkill(ctx, sId);
+    if (loaded instanceof Response) {
+      return loaded;
+    }
+    const { skill } = loaded;
+
+    // Check if user can write.
+    if (!skill.canWrite(auth)) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "app_auth_error",
+          message: "Only editors can delete this skill.",
+        },
+      });
+    }
+
+    if (skill.status === "suggested") {
+      logger.info(
+        {
+          skillId: skill.sId,
+          workspaceId: owner.sId,
+        },
+        "Suggested skill rejected"
+      );
+    }
+
+    await skill.archive(auth);
+
+    return ctx.json({ success: true });
   }
-  const { skill } = loaded;
-
-  // Check if user can write.
-  if (!skill.canWrite(auth)) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "Only editors can delete this skill.",
-      },
-    });
-  }
-
-  if (skill.status === "suggested") {
-    logger.info(
-      {
-        skillId: skill.sId,
-        workspaceId: owner.sId,
-      },
-      "Suggested skill rejected"
-    );
-  }
-
-  await skill.archive(auth);
-
-  return ctx.json({ success: true });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/skills/[sId]/reinforcement.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/reinforcement.ts
@@ -36,15 +36,20 @@ export type PatchSkillReinforcementResponseBody = {
   skill: SkillType;
 };
 
+const ParamsSchema = z.object({
+  sId: z.string(),
+});
+
 // Mounted at /api/w/:wId/skills/:sId/reinforcement.
 const app = workspaceApp();
 
 app.patch(
   "/",
+  validate("param", ParamsSchema),
   validate("json", PatchSkillReinforcementBodySchema),
   async (ctx): HandlerResult<PatchSkillReinforcementResponseBody> => {
     const auth = ctx.get("auth");
-    const sId = ctx.req.param("sId");
+    const { sId } = ctx.req.valid("param");
 
     if (!isString(sId)) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/skills/[sId]/reinforcement.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/reinforcement.ts
@@ -6,7 +6,6 @@ import {
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import { SKILL_REINFORCEMENT_MODES } from "@app/types/assistant/skill_configuration";
-import { isString } from "@app/types/shared/utils/general";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -50,16 +49,6 @@ app.patch(
   async (ctx): HandlerResult<PatchSkillReinforcementResponseBody> => {
     const auth = ctx.get("auth");
     const { sId } = ctx.req.valid("param");
-
-    if (!isString(sId)) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid skill ID.",
-        },
-      });
-    }
 
     const skill = await SkillResource.fetchById(auth, sId);
     if (!skill) {

--- a/front-api/routes/w/[wId]/skills/[sId]/restore.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/restore.ts
@@ -1,5 +1,4 @@
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import { isString } from "@app/types/shared/utils/general";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -20,16 +19,6 @@ app.post(
   async (ctx): HandlerResult<SuccessResponseBody> => {
     const auth = ctx.get("auth");
     const { sId } = ctx.req.valid("param");
-
-    if (!isString(sId)) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid skill ID.",
-        },
-      });
-    }
 
     const skillResource = await SkillResource.fetchById(auth, sId);
 

--- a/front-api/routes/w/[wId]/skills/[sId]/restore.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/restore.ts
@@ -3,65 +3,75 @@ import { isString } from "@app/types/shared/utils/general";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import type { SuccessResponseBody } from "@front-api/routes/types";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  sId: z.string(),
+});
 
 // Mounted at /api/w/:wId/skills/:sId/restore.
 const app = workspaceApp();
 
-app.post("/", async (ctx): HandlerResult<SuccessResponseBody> => {
-  const auth = ctx.get("auth");
-  const sId = ctx.req.param("sId");
+app.post(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<SuccessResponseBody> => {
+    const auth = ctx.get("auth");
+    const { sId } = ctx.req.valid("param");
 
-  if (!isString(sId)) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Invalid skill ID.",
-      },
-    });
+    if (!isString(sId)) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Invalid skill ID.",
+        },
+      });
+    }
+
+    const skillResource = await SkillResource.fetchById(auth, sId);
+
+    if (!skillResource) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "skill_not_found",
+          message: "The skill you're trying to access was not found.",
+        },
+      });
+    }
+
+    if (!skillResource.canWrite(auth)) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "app_auth_error",
+          message: "Only editors can restore this skill.",
+        },
+      });
+    }
+
+    // Check for existing active skill with the same name.
+    const existingSkill = await SkillResource.fetchActiveByName(
+      auth,
+      skillResource.name
+    );
+    if (existingSkill) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `A skill with the name "${skillResource.name}" already exists.`,
+        },
+      });
+    }
+
+    await skillResource.restore(auth);
+
+    return ctx.json({ success: true });
   }
-
-  const skillResource = await SkillResource.fetchById(auth, sId);
-
-  if (!skillResource) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "skill_not_found",
-        message: "The skill you're trying to access was not found.",
-      },
-    });
-  }
-
-  if (!skillResource.canWrite(auth)) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "Only editors can restore this skill.",
-      },
-    });
-  }
-
-  // Check for existing active skill with the same name.
-  const existingSkill = await SkillResource.fetchActiveByName(
-    auth,
-    skillResource.name
-  );
-  if (existingSkill) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: `A skill with the name "${skillResource.name}" already exists.`,
-      },
-    });
-  }
-
-  await skillResource.restore(auth);
-
-  return ctx.json({ success: true });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/index.ts
@@ -22,17 +22,22 @@ const PatchAppBodySchema = z.object({
   description: z.string(),
 });
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 // Mounted under /api/w/:wId/spaces/:spaceId/apps/:aId.
 const app = workspaceApp();
 
 // GET / — read app.
 app.get(
   "/",
+  validate("param", ParamsSchema),
   withSpace({ requireCanRead: true }),
   async (ctx): HandlerResult<GetOrPostAppResponseBody> => {
     const auth = ctx.get("auth");
     const space = ctx.get("space");
-    const aId = ctx.req.param("aId") ?? "";
+    const { aId } = ctx.req.valid("param");
 
     const found = await AppResource.fetchById(auth, aId);
     if (!found || found.space.sId !== space.sId || !found.canRead(auth)) {
@@ -51,12 +56,13 @@ app.get(
 // POST / — update app settings.
 app.post(
   "/",
+  validate("param", ParamsSchema),
   withSpace({ requireCanRead: true }),
   validate("json", PatchAppBodySchema),
   async (ctx): HandlerResult<GetOrPostAppResponseBody> => {
     const auth = ctx.get("auth");
     const space = ctx.get("space");
-    const aId = ctx.req.param("aId") ?? "";
+    const { aId } = ctx.req.valid("param");
 
     const found = await AppResource.fetchById(auth, aId);
     if (!found || found.space.sId !== space.sId || !found.canRead(auth)) {
@@ -91,39 +97,44 @@ app.post(
 );
 
 // DELETE / — soft delete app.
-app.delete("/", withSpace({ requireCanRead: true }), async (ctx) => {
-  const auth = ctx.get("auth");
-  const space = ctx.get("space");
-  const aId = ctx.req.param("aId") ?? "";
+app.delete(
+  "/",
+  validate("param", ParamsSchema),
+  withSpace({ requireCanRead: true }),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const space = ctx.get("space");
+    const { aId } = ctx.req.valid("param");
 
-  const found = await AppResource.fetchById(auth, aId);
-  if (!found || found.space.sId !== space.sId || !found.canRead(auth)) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: { type: "app_not_found", message: "The app was not found." },
-    });
+    const found = await AppResource.fetchById(auth, aId);
+    if (!found || found.space.sId !== space.sId || !found.canRead(auth)) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: { type: "app_not_found", message: "The app was not found." },
+      });
+    }
+    if (!found.canWrite(auth)) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "app_auth_error",
+          message: "Deleting an app requires write access to the app's space.",
+        },
+      });
+    }
+    const deleteRes = await softDeleteApp(auth, found);
+    if (deleteRes.isErr()) {
+      return apiError(ctx, {
+        status_code: 409,
+        api_error: {
+          type: "invalid_request_error",
+          message: deleteRes.error.message,
+        },
+      });
+    }
+    return ctx.body(null, 204);
   }
-  if (!found.canWrite(auth)) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "Deleting an app requires write access to the app's space.",
-      },
-    });
-  }
-  const deleteRes = await softDeleteApp(auth, found);
-  if (deleteRes.isErr()) {
-    return apiError(ctx, {
-      status_code: 409,
-      api_error: {
-        type: "invalid_request_error",
-        message: deleteRes.error.message,
-      },
-    });
-  }
-  return ctx.body(null, 204);
-});
+);
 
 app.route("/state", state);
 app.route("/runs", runs);

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
@@ -6,7 +6,16 @@ import type { BlockType, RunType } from "@app/types/run";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import { withSpace } from "@front-api/middlewares/with_space";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  aId: z.string(),
+  runId: z.string(),
+  type: z.string(),
+  name: z.string(),
+});
 
 export type GetRunBlockResponseBody = {
   run: RunType | null;
@@ -18,12 +27,13 @@ const app = workspaceApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   withSpace({ requireCanWrite: true }),
   async (ctx): HandlerResult<GetRunBlockResponseBody> => {
     const auth = ctx.get("auth");
     const space = ctx.get("space");
-    const aId = ctx.req.param("aId") ?? "";
-    let runId: string | null = ctx.req.param("runId") ?? null;
+    const { aId, runId: runIdParam, type, name } = ctx.req.valid("param");
+    let runId: string | null = runIdParam;
 
     const found = await AppResource.fetchById(auth, aId);
     if (!found || found.space.sId !== space.sId) {
@@ -52,8 +62,8 @@ app.get(
     const run = await coreAPI.getRunBlock({
       projectId: found.dustAPIProjectId,
       runId,
-      blockType: ctx.req.param("type") as BlockType,
-      blockName: ctx.req.param("name") ?? "",
+      blockType: type as BlockType,
+      blockName: name,
     });
     if (run.isErr()) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/cancel.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/cancel.ts
@@ -5,7 +5,14 @@ import { CoreAPI } from "@app/types/core/core_api";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import { withSpace } from "@front-api/middlewares/with_space";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  aId: z.string(),
+  runId: z.string(),
+});
 
 export type PostRunCancelResponseBody = {
   success: boolean;
@@ -16,12 +23,12 @@ const app = workspaceApp();
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   withSpace({ requireCanWrite: true }),
   async (ctx): HandlerResult<PostRunCancelResponseBody> => {
     const auth = ctx.get("auth");
     const space = ctx.get("space");
-    const aId = ctx.req.param("aId") ?? "";
-    const runId = ctx.req.param("runId") ?? "";
+    const { aId, runId } = ctx.req.valid("param");
 
     const found = await AppResource.fetchById(auth, aId);
     if (!found || found.space.sId !== space.sId) {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/index.ts
@@ -4,7 +4,14 @@ import type { RunType } from "@app/types/run";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import { withSpace } from "@front-api/middlewares/with_space";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  aId: z.string(),
+  runId: z.string(),
+});
 
 import blocks from "./blocks";
 import cancel from "./cancel";
@@ -21,6 +28,7 @@ const app = workspaceApp();
 // GET / — get a run.
 app.get(
   "/",
+  validate("param", ParamsSchema),
   withSpace({ requireCanRead: true }),
   async (ctx): HandlerResult<GetRunResponseBody> => {
     // Keep the dynamic import: `@app/lib/api/run` is loaded lazily to avoid
@@ -28,8 +36,7 @@ app.get(
     const { getRun } = await import("@app/lib/api/run");
     const auth = ctx.get("auth");
     const space = ctx.get("space");
-    const aId = ctx.req.param("aId") ?? "";
-    const runId = ctx.req.param("runId") ?? "";
+    const { aId, runId } = ctx.req.valid("param");
 
     const found = await AppResource.fetchById(auth, aId);
     if (!found || !found.canRead(auth) || found.space.sId !== space.sId) {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/status.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/status.ts
@@ -6,7 +6,14 @@ import type { RunType } from "@app/types/run";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import { withSpace } from "@front-api/middlewares/with_space";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  aId: z.string(),
+  runId: z.string(),
+});
 
 export type GetRunStatusResponseBody = {
   run: RunType | null;
@@ -17,12 +24,13 @@ const app = workspaceApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   withSpace({ requireCanRead: true }),
   async (ctx): HandlerResult<GetRunStatusResponseBody> => {
     const auth = ctx.get("auth");
     const space = ctx.get("space");
-    const aId = ctx.req.param("aId") ?? "";
-    let runId: string | null = ctx.req.param("runId") ?? null;
+    const { aId, runId: runIdParam } = ctx.req.valid("param");
+    let runId: string | null = runIdParam;
 
     const found = await AppResource.fetchById(auth, aId);
     if (!found || found.space.sId !== space.sId) {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/state.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/state.ts
@@ -17,17 +17,22 @@ const PostStateBodySchema = z.object({
   run: z.string().optional(),
 });
 
+const ParamsSchema = z.object({
+  aId: z.string(),
+});
+
 // Mounted under /api/w/:wId/spaces/:spaceId/apps/:aId/state.
 const app = workspaceApp();
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   withSpace({ requireCanWrite: true }),
   validate("json", PostStateBodySchema),
   async (ctx): HandlerResult<PostStateResponseBody> => {
     const auth = ctx.get("auth");
     const space = ctx.get("space");
-    const aId = ctx.req.param("aId") ?? "";
+    const { aId } = ctx.req.valid("param");
 
     const found = await AppResource.fetchById(auth, aId);
     if (!found || found.space.sId !== space.sId) {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/documents/[documentId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/documents/[documentId]/index.ts
@@ -5,8 +5,14 @@ import type { CoreAPIDocument } from "@app/types/core/data_source";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import { withDataSourceView } from "@front-api/middlewares/with_data_source_view";
 import { withSpace } from "@front-api/middlewares/with_space";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  documentId: z.string(),
+});
 
 export type GetDataSourceViewDocumentResponseBody = {
   document: CoreAPIDocument;
@@ -18,11 +24,12 @@ const app = workspaceApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   withSpace({ requireCanRead: true }),
   withDataSourceView({ requireCanRead: true }),
   async (ctx): HandlerResult<GetDataSourceViewDocumentResponseBody> => {
     const dataSourceView = ctx.get("dataSourceView");
-    const documentId = ctx.req.param("documentId") ?? "";
+    const { documentId } = ctx.req.valid("param");
     const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
     const doc = await coreAPI.getDataSourceDocument({
       dataSourceId: dataSourceView.dataSource.dustAPIDataSourceId,

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/[tableId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/[tableId]/index.ts
@@ -5,8 +5,14 @@ import { CoreAPI } from "@app/types/core/core_api";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import { withDataSourceView } from "@front-api/middlewares/with_data_source_view";
 import { withSpace } from "@front-api/middlewares/with_space";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  tableId: z.string(),
+});
 
 export type GetDataSourceViewTableResponseBody = {
   table: CoreAPITable;
@@ -18,11 +24,12 @@ const app = workspaceApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   withSpace({ requireCanRead: true }),
   withDataSourceView({ requireCanRead: true }),
   async (ctx): HandlerResult<GetDataSourceViewTableResponseBody> => {
     const dataSourceView = ctx.get("dataSourceView");
-    const tableId = ctx.req.param("tableId") ?? "";
+    const { tableId } = ctx.req.valid("param");
     const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
     const tableRes = await coreAPI.getTable({
       projectId: dataSourceView.dataSource.dustAPIProjectId,

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -12,6 +12,11 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { withDataSource } from "@front-api/middlewares/with_data_source";
 import { withSpace } from "@front-api/middlewares/with_space";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  documentId: z.string(),
+});
 
 export type PatchDocumentResponseBody = {
   document: DocumentType | CoreAPILightDocument;
@@ -22,13 +27,14 @@ const app = workspaceApp();
 
 app.patch(
   "/",
+  validate("param", ParamsSchema),
   withSpace({ requireCanRead: true }),
   withDataSource({ requireCanRead: true }),
   validate("json", PostDataSourceDocumentRequestBodySchema),
   async (ctx): HandlerResult<PatchDocumentResponseBody> => {
     const auth = ctx.get("auth");
     const dataSource = ctx.get("dataSource");
-    const documentId = ctx.req.param("documentId") ?? "";
+    const { documentId } = ctx.req.valid("param");
 
     if (!dataSource.canWrite(auth)) {
       return apiError(ctx, {
@@ -116,12 +122,13 @@ app.patch(
 
 app.delete(
   "/",
+  validate("param", ParamsSchema),
   withSpace({ requireCanRead: true }),
   withDataSource({ requireCanRead: true }),
   async (ctx) => {
     const auth = ctx.get("auth");
     const dataSource = ctx.get("dataSource");
-    const documentId = ctx.req.param("documentId") ?? "";
+    const { documentId } = ctx.req.valid("param");
 
     if (!dataSource.canWrite(auth)) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId]/index.ts
@@ -3,20 +3,27 @@ import logger from "@app/logger/logger";
 import { CoreAPI } from "@app/types/core/core_api";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import { withDataSource } from "@front-api/middlewares/with_data_source";
 import { withSpace } from "@front-api/middlewares/with_space";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  fId: z.string(),
+});
 
 // Mounted under /api/w/:wId/spaces/:spaceId/data_sources/:dsId/folders/:fId.
 const app = workspaceApp();
 
 app.delete(
   "/",
+  validate("param", ParamsSchema),
   withSpace({ requireCanReadOrAdministrate: true }),
   withDataSource({ requireCanReadOrAdministrate: true }),
   async (ctx) => {
     const auth = ctx.get("auth");
     const dataSource = ctx.get("dataSource");
-    const fId = ctx.req.param("fId") ?? "";
+    const { fId } = ctx.req.valid("param");
     if (!fId) {
       return apiError(ctx, {
         status_code: 400,

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId]/index.ts
@@ -24,15 +24,6 @@ app.delete(
     const auth = ctx.get("auth");
     const dataSource = ctx.get("dataSource");
     const { fId } = ctx.req.valid("param");
-    if (!fId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Invalid path parameters.",
-        },
-      });
-    }
 
     if (!dataSource.canWrite(auth)) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tableId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tableId]/index.ts
@@ -8,6 +8,11 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { withDataSource } from "@front-api/middlewares/with_data_source";
 import { withSpace } from "@front-api/middlewares/with_space";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  tableId: z.string(),
+});
 
 export type PatchTableResponseBody = {
   table?: { table_id: string };
@@ -18,13 +23,14 @@ const app = workspaceApp();
 
 app.patch(
   "/",
+  validate("param", ParamsSchema),
   withSpace({ requireCanRead: true }),
   withDataSource({ requireCanRead: true }),
   validate("json", PatchDataSourceTableRequestBodySchema),
   async (ctx): HandlerResult<PatchTableResponseBody> => {
     const auth = ctx.get("auth");
     const dataSource = ctx.get("dataSource");
-    const tableId = ctx.req.param("tableId") ?? "";
+    const { tableId } = ctx.req.valid("param");
 
     if (!dataSource.canWrite(auth)) {
       return apiError(ctx, {
@@ -72,12 +78,13 @@ app.patch(
 
 app.delete(
   "/",
+  validate("param", ParamsSchema),
   withSpace({ requireCanRead: true }),
   withDataSource({ requireCanRead: true }),
   async (ctx) => {
     const auth = ctx.get("auth");
     const dataSource = ctx.get("dataSource");
-    const tableId = ctx.req.param("tableId") ?? "";
+    const { tableId } = ctx.req.valid("param");
 
     if (!dataSource.canWrite(auth)) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/files/[...rel].ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/files/[...rel].ts
@@ -22,6 +22,11 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { withSpace } from "@front-api/middlewares/with_space";
 import type { Context, TypedResponse } from "hono";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  rel: z.string(),
+});
 
 export type ProjectFileRelResponseBody = Record<string, never>;
 
@@ -31,7 +36,10 @@ export type ProjectFileRelResponseBody = Record<string, never>;
 // captures everything past `/files/` (matching Next's `[...rel]`).
 const app = workspaceApp();
 
-async function buildContext(ctx: Context): Promise<
+async function buildContext(
+  ctx: Context,
+  rel: string
+): Promise<
   | {
       auth: Authenticator;
       space: SpaceResource;
@@ -55,8 +63,7 @@ async function buildContext(ctx: Context): Promise<
     };
   }
 
-  const rel = ctx.req.param("rel");
-  if (!isString(rel) || rel.length === 0) {
+  if (rel.length === 0) {
     return {
       error: apiError(ctx, {
         status_code: 400,
@@ -105,57 +112,66 @@ async function buildContext(ctx: Context): Promise<
   };
 }
 
-app.get("/:rel{.+}", withSpace({ requireCanRead: true }), async (ctx) => {
-  const built = await buildContext(ctx);
-  if ("error" in built) {
-    return built.error;
-  }
-  const { normalizedGcsPath } = built;
+app.get(
+  "/:rel{.+}",
+  validate("param", ParamsSchema),
+  withSpace({ requireCanRead: true }),
+  async (ctx) => {
+    const { rel } = ctx.req.valid("param");
+    const built = await buildContext(ctx, rel);
+    if ("error" in built) {
+      return built.error;
+    }
+    const { normalizedGcsPath } = built;
 
-  const bucket = getPrivateUploadBucket();
-  const contentTypeResult = await bucket.getFileContentType(normalizedGcsPath);
-  if (contentTypeResult.isErr()) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "file_not_found",
-        message: "File not found.",
+    const bucket = getPrivateUploadBucket();
+    const contentTypeResult =
+      await bucket.getFileContentType(normalizedGcsPath);
+    if (contentTypeResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "file_not_found",
+          message: "File not found.",
+        },
+      });
+    }
+
+    const contentType = contentTypeResult.value ?? "application/octet-stream";
+    const readStream = bucket.file(normalizedGcsPath).createReadStream();
+
+    // Stream the file as the Hono response body.
+    const webStream = new ReadableStream({
+      start(controller) {
+        readStream.on("data", (chunk) => controller.enqueue(chunk));
+        readStream.on("end", () => controller.close());
+        readStream.on("error", (err) => {
+          logger.error(
+            { err, gcsPath: normalizedGcsPath },
+            "Error streaming project file (GCS)"
+          );
+          controller.error(err);
+        });
+      },
+      cancel() {
+        readStream.destroy();
       },
     });
+
+    return new Response(webStream, {
+      status: 200,
+      headers: { "Content-Type": contentType },
+    });
   }
-
-  const contentType = contentTypeResult.value ?? "application/octet-stream";
-  const readStream = bucket.file(normalizedGcsPath).createReadStream();
-
-  // Stream the file as the Hono response body.
-  const webStream = new ReadableStream({
-    start(controller) {
-      readStream.on("data", (chunk) => controller.enqueue(chunk));
-      readStream.on("end", () => controller.close());
-      readStream.on("error", (err) => {
-        logger.error(
-          { err, gcsPath: normalizedGcsPath },
-          "Error streaming project file (GCS)"
-        );
-        controller.error(err);
-      });
-    },
-    cancel() {
-      readStream.destroy();
-    },
-  });
-
-  return new Response(webStream, {
-    status: 200,
-    headers: { "Content-Type": contentType },
-  });
-});
+);
 
 app.patch(
   "/:rel{.+}",
+  validate("param", ParamsSchema),
   withSpace({ requireCanRead: true }),
   async (ctx): HandlerResult<ProjectFileRelResponseBody> => {
-    const built = await buildContext(ctx);
+    const { rel } = ctx.req.valid("param");
+    const built = await buildContext(ctx, rel);
     if ("error" in built) {
       return built.error;
     }
@@ -210,9 +226,11 @@ app.patch(
 
 app.delete(
   "/:rel{.+}",
+  validate("param", ParamsSchema),
   withSpace({ requireCanRead: true }),
   async (ctx): HandlerResult<ProjectFileRelResponseBody> => {
-    const built = await buildContext(ctx);
+    const { rel } = ctx.req.valid("param");
+    const built = await buildContext(ctx, rel);
     if ("error" in built) {
       return built.error;
     }
@@ -248,11 +266,13 @@ app.delete(
 
 app.post(
   "/:rel{.+}",
+  validate("param", ParamsSchema),
   withSpace({ requireCanWrite: true }),
   validate("json", MoveMountFileRequestBodySchema),
   async (c): HandlerResult<ProjectFileRelResponseBody> => {
     const space = c.get("space");
     const auth = c.get("auth");
+    const { rel } = c.req.valid("param");
 
     if (!space.isProject()) {
       return apiError(c, {
@@ -264,7 +284,6 @@ app.post(
       });
     }
 
-    const rel = c.req.param("rel");
     if (!isString(rel) || rel.length === 0) {
       return apiError(c, {
         status_code: 400,

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/files/[...rel].ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/files/[...rel].ts
@@ -63,18 +63,6 @@ async function buildContext(
     };
   }
 
-  if (rel.length === 0) {
-    return {
-      error: apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Missing file path.",
-        },
-      }),
-    };
-  }
-
   const owner = auth.getNonNullableWorkspace();
   const basePath = getPodFilesBasePath({
     workspaceId: owner.sId,
@@ -280,16 +268,6 @@ app.post(
         api_error: {
           type: "invalid_request_error",
           message: "Files are only available for project spaces.",
-        },
-      });
-    }
-
-    if (!isString(rel) || rel.length === 0) {
-      return apiError(c, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Missing file path.",
         },
       });
     }

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/files/rel.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/files/rel.test.ts
@@ -24,7 +24,7 @@ function fileRequest(
 ) {
   // Build the path joined as one fully-encoded string so that ".." segments
   // and slashes survive URL normalization (e.g. for path traversal cases).
-  // The handler decodes the resulting `rel` param via `ctx.req.param("rel")`.
+  // The handler decodes the resulting `rel` param via the validated params.
   const joined = relSegments.join("/");
   const encoded = encodeURIComponent(joined);
   const url = `/api/w/${workspace.sId}/spaces/${spaceId}/files/${encoded}`;

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.ts
@@ -4,7 +4,13 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import { withSpace } from "@front-api/middlewares/with_space";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  svId: z.string(),
+});
 
 export type DeleteMCPServerViewResponseBody = {
   deleted: boolean;
@@ -15,12 +21,13 @@ const app = workspaceApp();
 
 app.delete(
   "/",
+  validate("param", ParamsSchema),
   ensureIsAdmin(),
   withSpace({ requireCanReadOrAdministrate: true }),
   async (ctx): HandlerResult<DeleteMCPServerViewResponseBody> => {
     const auth = ctx.get("auth");
     const space = ctx.get("space");
-    const serverViewId = ctx.req.param("svId") ?? "";
+    const { svId: serverViewId } = ctx.req.valid("param");
 
     const mcpServerView = await MCPServerViewResource.fetchById(
       auth,

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_context/files/[fileId].ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_context/files/[fileId].ts
@@ -2,7 +2,13 @@ import { removeFileFromProject } from "@app/lib/api/projects/context";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import { withSpace } from "@front-api/middlewares/with_space";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  fileId: z.string(),
+});
 
 export type DeleteProjectContextFileResponseBody = Record<string, never>;
 
@@ -14,11 +20,12 @@ const app = workspaceApp();
 
 app.delete(
   "/",
+  validate("param", ParamsSchema),
   withSpace({ requireCanRead: true }),
   async (ctx): HandlerResult<DeleteProjectContextFileResponseBody> => {
     const auth = ctx.get("auth");
     const space = ctx.get("space");
-    const fileId = ctx.req.param("fileId") ?? "";
+    const { fileId } = ctx.req.valid("param");
 
     if (!space.isProject()) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_tasks/[taskId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_tasks/[taskId]/index.ts
@@ -28,6 +28,10 @@ export interface PatchProjectTaskResponseBody {
   };
 }
 
+const ParamsSchema = z.object({
+  taskId: z.string(),
+});
+
 const PatchProjectTaskBodySchema = z
   .object({
     text: z
@@ -54,12 +58,13 @@ const app = workspaceApp();
 
 app.patch(
   "/",
+  validate("param", ParamsSchema),
   withSpace({ requireCanRead: true }),
   validate("json", PatchProjectTaskBodySchema),
   async (ctx): HandlerResult<PatchProjectTaskResponseBody> => {
     const auth = ctx.get("auth");
     const space = ctx.get("space");
-    const taskId = ctx.req.param("taskId") ?? "";
+    const { taskId } = ctx.req.valid("param");
 
     if (!space.isProject()) {
       return apiError(ctx, {
@@ -154,36 +159,41 @@ app.patch(
   }
 );
 
-app.delete("/", withSpace({ requireCanRead: true }), async (ctx) => {
-  const auth = ctx.get("auth");
-  const space = ctx.get("space");
-  const taskId = ctx.req.param("taskId") ?? "";
+app.delete(
+  "/",
+  validate("param", ParamsSchema),
+  withSpace({ requireCanRead: true }),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const space = ctx.get("space");
+    const { taskId } = ctx.req.valid("param");
 
-  if (!space.isProject()) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Tasks are only available for project spaces.",
-      },
-    });
+    if (!space.isProject()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Tasks are only available for project spaces.",
+        },
+      });
+    }
+
+    const task = await ProjectTaskResource.fetchBySId(auth, taskId);
+    if (!task || task.spaceId !== space.id) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "project_task_not_found",
+          message: "Task not found.",
+        },
+      });
+    }
+
+    await task.softDelete(auth);
+
+    return ctx.body(null, 204);
   }
-
-  const task = await ProjectTaskResource.fetchBySId(auth, taskId);
-  if (!task || task.spaceId !== space.id) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "project_task_not_found",
-        message: "Task not found.",
-      },
-    });
-  }
-
-  await task.softDelete(auth);
-
-  return ctx.body(null, 204);
-});
+);
 
 app.route("/start", start);
 

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_tasks/[taskId]/start.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_tasks/[taskId]/start.ts
@@ -11,17 +11,22 @@ const PostStartPodTaskBodySchema = z.object({
   agentConfigurationId: z.string().optional(),
 });
 
+const ParamsSchema = z.object({
+  taskId: z.string(),
+});
+
 // Mounted under /api/w/:wId/spaces/:spaceId/project_tasks/:taskId/start.
 const app = workspaceApp();
 
 app.post(
   "/",
+  validate("param", ParamsSchema),
   withSpace({ requireCanRead: true }),
   validate("json", PostStartPodTaskBodySchema),
   async (ctx) => {
     const auth = ctx.get("auth");
     const space = ctx.get("space");
-    const taskId = ctx.req.param("taskId") ?? "";
+    const { taskId } = ctx.req.valid("param");
 
     if (!space.isProject()) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/webhook_source_views/[webhookSourceViewId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/webhook_source_views/[webhookSourceViewId]/index.ts
@@ -5,7 +5,13 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import { withSpace } from "@front-api/middlewares/with_space";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  webhookSourceViewId: z.string(),
+});
 
 export type DeleteWebhookSourceViewResponseBody = {
   deleted: boolean;
@@ -17,12 +23,13 @@ const app = workspaceApp();
 
 app.delete(
   "/",
+  validate("param", ParamsSchema),
   ensureIsAdmin(),
   withSpace({ requireCanReadOrAdministrate: true }),
   async (ctx): HandlerResult<DeleteWebhookSourceViewResponseBody> => {
     const auth = ctx.get("auth");
     const space = ctx.get("space");
-    const webhookSourceViewId = ctx.req.param("webhookSourceViewId") ?? "";
+    const { webhookSourceViewId } = ctx.req.valid("param");
 
     const view = await WebhookSourcesViewResource.fetchById(
       auth,

--- a/front-api/routes/w/[wId]/tags/[tId]/index.ts
+++ b/front-api/routes/w/[wId]/tags/[tId]/index.ts
@@ -10,80 +10,95 @@ const PutBodySchema = z.object({
   kind: z.enum(["standard", "protected"]),
 });
 
+const ParamsSchema = z.object({
+  tId: z.string(),
+});
+
 // Mounted at /api/w/:wId/tags/:tId.
 const app = workspaceApp();
 
-app.delete("/", ensureIsAdmin(), async (ctx) => {
-  const auth = ctx.get("auth");
-  const tId = ctx.req.param("tId");
+app.delete(
+  "/",
+  validate("param", ParamsSchema),
+  ensureIsAdmin(),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { tId } = ctx.req.valid("param");
 
-  if (!tId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Tag ID is required",
-      },
-    });
+    if (!tId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Tag ID is required",
+        },
+      });
+    }
+
+    const tag = await TagResource.fetchById(auth, tId);
+
+    if (!tag) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Tag not found",
+        },
+      });
+    }
+
+    const result = await tag.delete(auth);
+
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to delete tag",
+        },
+      });
+    }
+
+    return ctx.body(null, 204);
   }
+);
 
-  const tag = await TagResource.fetchById(auth, tId);
+app.put(
+  "/",
+  validate("param", ParamsSchema),
+  ensureIsAdmin(),
+  validate("json", PutBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { tId } = ctx.req.valid("param");
 
-  if (!tag) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Tag not found",
-      },
-    });
+    if (!tId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Tag ID is required",
+        },
+      });
+    }
+
+    const tag = await TagResource.fetchById(auth, tId);
+
+    if (!tag) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Tag not found",
+        },
+      });
+    }
+
+    const { name, kind } = ctx.req.valid("json");
+    await tag.updateTag({ name, kind });
+
+    return ctx.body(null, 200);
   }
-
-  const result = await tag.delete(auth);
-
-  if (result.isErr()) {
-    return apiError(ctx, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Failed to delete tag",
-      },
-    });
-  }
-
-  return ctx.body(null, 204);
-});
-
-app.put("/", ensureIsAdmin(), validate("json", PutBodySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const tId = ctx.req.param("tId");
-
-  if (!tId) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Tag ID is required",
-      },
-    });
-  }
-
-  const tag = await TagResource.fetchById(auth, tId);
-
-  if (!tag) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Tag not found",
-      },
-    });
-  }
-
-  const { name, kind } = ctx.req.valid("json");
-  await tag.updateTag({ name, kind });
-
-  return ctx.body(null, 200);
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/tags/[tId]/index.ts
+++ b/front-api/routes/w/[wId]/tags/[tId]/index.ts
@@ -25,16 +25,6 @@ app.delete(
     const auth = ctx.get("auth");
     const { tId } = ctx.req.valid("param");
 
-    if (!tId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Tag ID is required",
-        },
-      });
-    }
-
     const tag = await TagResource.fetchById(auth, tId);
 
     if (!tag) {
@@ -71,16 +61,6 @@ app.put(
   async (ctx) => {
     const auth = ctx.get("auth");
     const { tId } = ctx.req.valid("param");
-
-    if (!tId) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: "Tag ID is required",
-        },
-      });
-    }
 
     const tag = await TagResource.fetchById(auth, tId);
 

--- a/front-api/routes/w/[wId]/webhook_sources/[webhookSourceId]/index.ts
+++ b/front-api/routes/w/[wId]/webhook_sources/[webhookSourceId]/index.ts
@@ -18,16 +18,21 @@ const PatchWebhookSourceBodySchema = z.object({
   oauthConnectionId: z.unknown().optional(),
 });
 
+const ParamsSchema = z.object({
+  webhookSourceId: z.string(),
+});
+
 // Mounted at /api/w/:wId/webhook_sources/:webhookSourceId.
 const app = workspaceApp();
 
 app.patch(
   "/",
+  validate("param", ParamsSchema),
   ensureIsAdmin(),
   validate("json", PatchWebhookSourceBodySchema),
   async (ctx): HandlerResult<SuccessResponseBody> => {
     const auth = ctx.get("auth");
-    const webhookSourceId = ctx.req.param("webhookSourceId") ?? "";
+    const { webhookSourceId } = ctx.req.valid("param");
 
     const { remoteMetadata, oauthConnectionId } = ctx.req.valid("json");
 
@@ -70,10 +75,11 @@ app.patch(
 
 app.delete(
   "/",
+  validate("param", ParamsSchema),
   ensureIsAdmin(),
   async (ctx): HandlerResult<SuccessResponseBody> => {
     const auth = ctx.get("auth");
-    const webhookSourceId = ctx.req.param("webhookSourceId") ?? "";
+    const { webhookSourceId } = ctx.req.valid("param");
 
     const webhookSourceResource = await WebhookSourceResource.fetchById(
       auth,

--- a/front-api/routes/w/[wId]/webhook_sources/[webhookSourceId]/trigger-estimation.ts
+++ b/front-api/routes/w/[wId]/webhook_sources/[webhookSourceId]/trigger-estimation.ts
@@ -15,15 +15,20 @@ const GetTriggerEstimationQuerySchema = z.object({
   event: z.string().optional(),
 });
 
+const ParamsSchema = z.object({
+  webhookSourceId: z.string(),
+});
+
 // Mounted at /api/w/:wId/webhook_sources/:webhookSourceId/trigger-estimation.
 const app = workspaceApp();
 
 app.get(
   "/",
+  validate("param", ParamsSchema),
   validate("query", GetTriggerEstimationQuerySchema),
   async (ctx): HandlerResult<GetTriggerEstimationResponseBody> => {
     const auth = ctx.get("auth");
-    const webhookSourceId = ctx.req.param("webhookSourceId") ?? "";
+    const { webhookSourceId } = ctx.req.valid("param");
     const { filter, event } = ctx.req.valid("query");
 
     const webhookSourceResource = await WebhookSourceResource.fetchById(

--- a/front-api/routes/w/[wId]/webhook_sources/[webhookSourceId]/views/index.ts
+++ b/front-api/routes/w/[wId]/webhook_sources/[webhookSourceId]/views/index.ts
@@ -3,6 +3,12 @@ import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_v
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  webhookSourceId: z.string(),
+});
 
 export type GetWebhookSourceViewsResponseBody = {
   success: true;
@@ -12,34 +18,38 @@ export type GetWebhookSourceViewsResponseBody = {
 // Mounted at /api/w/:wId/webhook_sources/:webhookSourceId/views.
 const app = workspaceApp();
 
-app.get("/", async (ctx): HandlerResult<GetWebhookSourceViewsResponseBody> => {
-  const auth = ctx.get("auth");
-  const webhookSourceId = ctx.req.param("webhookSourceId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetWebhookSourceViewsResponseBody> => {
+    const auth = ctx.get("auth");
+    const { webhookSourceId } = ctx.req.valid("param");
 
-  const webhookSourceResource = await WebhookSourceResource.fetchById(
-    auth,
-    webhookSourceId
-  );
+    const webhookSourceResource = await WebhookSourceResource.fetchById(
+      auth,
+      webhookSourceId
+    );
 
-  if (!webhookSourceResource) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "webhook_source_not_found",
-        message: "The webhook source was not found.",
-      },
+    if (!webhookSourceResource) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "webhook_source_not_found",
+          message: "The webhook source was not found.",
+        },
+      });
+    }
+
+    const viewResources = await WebhookSourcesViewResource.listByWebhookSource(
+      auth,
+      webhookSourceResource.id
+    );
+
+    return ctx.json({
+      success: true,
+      views: viewResources.map((view) => view.toJSON()),
     });
   }
-
-  const viewResources = await WebhookSourcesViewResource.listByWebhookSource(
-    auth,
-    webhookSourceResource.id
-  );
-
-  return ctx.json({
-    success: true,
-    views: viewResources.map((view) => view.toJSON()),
-  });
-});
+);
 
 export default app;

--- a/front-api/routes/w/[wId]/webhook_sources/views/[viewId]/index.ts
+++ b/front-api/routes/w/[wId]/webhook_sources/views/[viewId]/index.ts
@@ -21,6 +21,10 @@ const PatchWebhookSourceViewBodySchema = z.object({
   icon: z.string().optional(),
 });
 
+const ParamsSchema = z.object({
+  viewId: z.string(),
+});
+
 export type GetWebhookSourceViewResponseBody = {
   webhookSourceView: WebhookSourceViewType;
 };
@@ -32,44 +36,49 @@ export type PatchWebhookSourceViewResponseBody = {
 // Mounted at /api/w/:wId/webhook_sources/views/:viewId.
 const app = workspaceApp();
 
-app.get("/", async (ctx): HandlerResult<GetWebhookSourceViewResponseBody> => {
-  const auth = ctx.get("auth");
-  const viewId = ctx.req.param("viewId") ?? "";
+app.get(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<GetWebhookSourceViewResponseBody> => {
+    const auth = ctx.get("auth");
+    const { viewId } = ctx.req.valid("param");
 
-  const webhookSourceView = await WebhookSourcesViewResource.fetchById(
-    auth,
-    viewId
-  );
+    const webhookSourceView = await WebhookSourcesViewResource.fetchById(
+      auth,
+      viewId
+    );
 
-  if (webhookSourceView === null) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: {
-        type: "webhook_source_view_not_found",
-        message: "Webhook source view not found",
-      },
+    if (webhookSourceView === null) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "webhook_source_view_not_found",
+          message: "Webhook source view not found",
+        },
+      });
+    }
+    if (!webhookSourceView.canRead(auth)) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message: `Cannot read view with id ${viewId}.`,
+        },
+      });
+    }
+    return ctx.json({
+      webhookSourceView: webhookSourceView.toJSON(),
     });
   }
-  if (!webhookSourceView.canRead(auth)) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message: `Cannot read view with id ${viewId}.`,
-      },
-    });
-  }
-  return ctx.json({
-    webhookSourceView: webhookSourceView.toJSON(),
-  });
-});
+);
 
 app.patch(
   "/",
+  validate("param", ParamsSchema),
   validate("json", PatchWebhookSourceViewBodySchema),
   async (ctx): HandlerResult<PatchWebhookSourceViewResponseBody> => {
     const auth = ctx.get("auth");
-    const viewId = ctx.req.param("viewId") ?? "";
+    const { viewId } = ctx.req.valid("param");
 
     const isAdmin = await SpaceResource.canAdministrateSystemSpace(auth);
     if (!isAdmin) {

--- a/front-api/routes/workos/[action].ts
+++ b/front-api/routes/workos/[action].ts
@@ -33,10 +33,16 @@ import { isString } from "@app/types/shared/utils/general";
 import { validateRelativePath } from "@app/types/shared/utils/url_utils";
 import { createHono } from "@front-api/lib/hono";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import { OauthException } from "@workos-inc/node";
 import type { Context } from "hono";
 import { getCookie } from "hono/cookie";
 import { sealData } from "iron-session";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  action: z.string(),
+});
 
 function isValidScreenHint(
   screenHint: string | undefined
@@ -62,8 +68,8 @@ function redirectTo(ctx: Context, sanitizedReturnTo: string) {
 
 const app = createHono();
 
-app.all("/", async (ctx) => {
-  const action = ctx.req.param("action");
+app.all("/", validate("param", ParamsSchema), async (ctx) => {
+  const { action } = ctx.req.valid("param");
   switch (action) {
     case "login":
       return handleLogin(ctx);

--- a/front-api/routes/workos/actions/[actionSecret].ts
+++ b/front-api/routes/workos/actions/[actionSecret].ts
@@ -11,11 +11,13 @@ import { isString } from "@app/types/shared/utils/general";
 import { createHono } from "@front-api/lib/hono";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import type {
   AuthenticationActionResponseData,
   ResponsePayload,
   UserRegistrationActionResponseData,
 } from "@workos-inc/node";
+import { z } from "zod";
 
 type ActionResponseBody = {
   object: string;
@@ -23,119 +25,118 @@ type ActionResponseBody = {
   signature: string;
 };
 
+const ParamsSchema = z.object({
+  actionSecret: z.string(),
+});
+
 const app = createHono();
 
-app.post("/", async (ctx): HandlerResult<ActionResponseBody> => {
-  const actionSecret = ctx.req.param("actionSecret");
-  if (!isString(actionSecret)) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "The actionSecret query parameter is required.",
-      },
+app.post(
+  "/",
+  validate("param", ParamsSchema),
+  async (ctx): HandlerResult<ActionResponseBody> => {
+    const { actionSecret } = ctx.req.valid("param");
+
+    if (actionSecret !== config.getWorkOSActionSecret()) {
+      return apiError(ctx, {
+        status_code: 401,
+        api_error: {
+          type: "not_authenticated",
+          message: "The webhookSecret query parameter is invalid.",
+        },
+      });
+    }
+
+    // Validate the client IP address. Hono does not surface
+    // `req.socket.remoteAddress`, so we rely on forwarded headers (the same
+    // path the Next handler prioritized via `getClientIpFromHeaders`).
+    const headers: Record<string, string | string[] | undefined> = {};
+    ctx.req.raw.headers.forEach((value, key) => {
+      headers[key] = value;
     });
-  }
+    const clientIp = getClientIpFromHeaders(headers);
+    if (!isString(clientIp)) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Could not determine client IP address",
+        },
+      });
+    }
 
-  if (actionSecret !== config.getWorkOSActionSecret()) {
-    return apiError(ctx, {
-      status_code: 401,
-      api_error: {
-        type: "not_authenticated",
-        message: "The webhookSecret query parameter is invalid.",
-      },
+    if (!isWorkOSIpAddress(clientIp)) {
+      logger.error({ clientIp }, "Request not from WorkOS IP range");
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Request not from WorkOS IP range",
+        },
+      });
+    }
+
+    const sigHeader = ctx.req.header("workos-signature");
+    if (!isString(sigHeader)) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "The workos-signature header is required.",
+        },
+      });
+    }
+
+    const payload = await ctx.req.json();
+    const result = await validateWorkOSActionEvent(payload, {
+      signatureHeader: sigHeader,
     });
-  }
+    if (result.isErr()) {
+      logger.error({ error: result.error }, "Invalid WorkOS action");
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: result.error.message,
+        },
+      });
+    }
 
-  // Validate the client IP address. Hono does not surface
-  // `req.socket.remoteAddress`, so we rely on forwarded headers (the same
-  // path the Next handler prioritized via `getClientIpFromHeaders`).
-  const headers: Record<string, string | string[] | undefined> = {};
-  ctx.req.raw.headers.forEach((value, key) => {
-    headers[key] = value;
-  });
-  const clientIp = getClientIpFromHeaders(headers);
-  if (!isString(clientIp)) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Could not determine client IP address",
-      },
-    });
-  }
+    const action = result.value;
+    const workOS = getWorkOS();
 
-  if (!isWorkOSIpAddress(clientIp)) {
-    logger.error({ clientIp }, "Request not from WorkOS IP range");
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Request not from WorkOS IP range",
-      },
-    });
-  }
+    let responsePayload:
+      | UserRegistrationActionResponseData
+      | AuthenticationActionResponseData;
 
-  const sigHeader = ctx.req.header("workos-signature");
-  if (!isString(sigHeader)) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "The workos-signature header is required.",
-      },
-    });
-  }
-
-  const payload = await ctx.req.json();
-  const result = await validateWorkOSActionEvent(payload, {
-    signatureHeader: sigHeader,
-  });
-  if (result.isErr()) {
-    logger.error({ error: result.error }, "Invalid WorkOS action");
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: result.error.message,
-      },
-    });
-  }
-
-  const action = result.value;
-  const workOS = getWorkOS();
-
-  let responsePayload:
-    | UserRegistrationActionResponseData
-    | AuthenticationActionResponseData;
-
-  if (action.object === "user_registration_action_context") {
-    if (isBlacklistedEmailDomain(action.userData.email.split("@")[1])) {
-      responsePayload = {
-        type: "user_registration" as const,
-        verdict: "Deny" as const,
-        errorMessage: "This mail domain is not allowed",
-      };
+    if (action.object === "user_registration_action_context") {
+      if (isBlacklistedEmailDomain(action.userData.email.split("@")[1])) {
+        responsePayload = {
+          type: "user_registration" as const,
+          verdict: "Deny" as const,
+          errorMessage: "This mail domain is not allowed",
+        };
+      } else {
+        responsePayload = {
+          type: "user_registration" as const,
+          verdict: "Allow" as const,
+        };
+      }
     } else {
+      // Always allow authentication actions.
       responsePayload = {
-        type: "user_registration" as const,
+        type: "authentication" as const,
         verdict: "Allow" as const,
       };
     }
-  } else {
-    // Always allow authentication actions.
-    responsePayload = {
-      type: "authentication" as const,
-      verdict: "Allow" as const,
-    };
+
+    const signedResponse = await workOS.actions.signResponse(
+      responsePayload,
+      config.getWorkOSActionSigningSecret()
+    );
+
+    return ctx.json(signedResponse);
   }
-
-  const signedResponse = await workOS.actions.signResponse(
-    responsePayload,
-    config.getWorkOSActionSigningSecret()
-  );
-
-  return ctx.json(signedResponse);
-});
+);
 
 export default app;

--- a/front-api/routes/workos/webhooks/[webhookSecret].ts
+++ b/front-api/routes/workos/webhooks/[webhookSecret].ts
@@ -8,20 +8,17 @@ import logger from "@app/logger/logger";
 import { launchWorkOSEventsWorkflow } from "@app/temporal/workos_events_queue/client";
 import { createHono } from "@front-api/lib/hono";
 import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  webhookSecret: z.string(),
+});
 
 const app = createHono();
 
-app.post("/", async (ctx) => {
-  const webhookSecret = ctx.req.param("webhookSecret");
-  if (typeof webhookSecret !== "string") {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "The webhookSecret query parameter is required.",
-      },
-    });
-  }
+app.post("/", validate("param", ParamsSchema), async (ctx) => {
+  const { webhookSecret } = ctx.req.valid("param");
 
   if (webhookSecret !== config.getWorkOSWebhookSecret()) {
     return apiError(ctx, {


### PR DESCRIPTION
Closes dust-tt/tasks#8193
## Description
Replace ctx.req.param("x") ?? "" with validate("param", ParamsSchema) middleware across all front-api Hono routes (~250 sites). Path params now come back as typed string via ctx.req.valid("param") destructure. Matches the pattern adopted across recent Hono migrations (#26219 and ~56 other files on main).

Five commits split by subtree for easier review:
1. poke/ — 51 files
2. w/ — 141 files
3. misc (workos/, user/, templates/, share/, oauth/, [preStopSecret]/) — 8 files
4. v1/ — 16 files
5. Dead-guard cleanup — 47 files, -504 lines. Removes now-unreachable if (!x) / if (!isString(x)) checks that followed validated params.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Manual smoke test, should be a noop
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
