### PR TITLE
Replace @novu/framework/next with a Hono-native adapter

### DIFF
--- a/front-api/esbuild.shared.ts
+++ b/front-api/esbuild.shared.ts
@@ -69,5 +69,6 @@ export function getBaseBuildOptions(target: BuildTarget): esbuild.BuildOptions {
     metafile: true,
     minifyIdentifiers: false,
     treeShaking: true,
+    jsx: "automatic",
   };
 }

--- a/front-api/routes/novu/index.ts
+++ b/front-api/routes/novu/index.ts
@@ -5,22 +5,27 @@ import { projectAddedAsMemberWorkflow } from "@app/lib/notifications/workflows/p
 import { providerCredentialsHealthUpdatedWorkflow } from "@app/lib/notifications/workflows/provider-credential-updated";
 import { skillSuggestionsReadyWorkflow } from "@app/lib/notifications/workflows/skill-suggestions-ready";
 import { createHono } from "@front-api/lib/hono";
-import { serve } from "@novu/framework/next";
+import type { ServeHandlerOptions } from "@novu/framework";
+import { NovuRequestHandler } from "@novu/framework";
 
 // This endpoint exposes our code-based notification workflows to the Novu
 // platform. The Novu platform calls this endpoint to execute workflow steps.
 // See: https://docs.novu.co/framework/endpoint
 
-// `@novu/framework/next` types its handlers against `NextRequest`, but at
-// runtime they only touch the standard Fetch `Request` surface
-// (url/method/headers/body). We can't import `next/*` in `front-api` per
-// [API9], and there is no type guard that turns a `Request` into a
-// `NextRequest` (the extra fields don't exist at runtime — Novu doesn't read
-// them). We re-type the adapter once, at this boundary, against the actual
-// runtime contract so the call sites below stay clean.
-type FetchHandler = (req: Request, ctx?: unknown) => Promise<Response>;
+// Novu ships per-framework adapters under subpaths (e.g. `@novu/framework/next`),
+// but the Next adapter does `import { NextRequest } from "next/server"` at the
+// top of its module, which forces Node to resolve and load Next at module-load
+// time. That breaks the standalone Hono server whenever Next is not available
+// (e.g. locally) and violates [API9].
+//
+// Instead we build a thin Hono-native adapter directly on `NovuRequestHandler`
+// from the root package, following Novu's documented "custom serve" pattern:
+// https://docs.novu.co/framework/endpoint#writing-a-custom-serve-function
+// At runtime Novu only touches the standard Fetch `Request` surface
+// (method/headers/body/url), which `ctx.req.raw` already provides — so no Next
+// types or runtime are involved.
 
-const novu = serve({
+const options: ServeHandlerOptions = {
   workflows: [
     conversationUnreadWorkflow,
     agentMessageFeedbackWorkflow,
@@ -29,12 +34,29 @@ const novu = serve({
     projectAddedAsMemberWorkflow,
     providerCredentialsHealthUpdatedWorkflow,
   ],
-}) as unknown as Record<"GET" | "POST" | "OPTIONS", FetchHandler>;
+};
+
+// `Input` is the single standard Fetch `Request`; `Output` is a standard Fetch
+// `Response`. The handler maps that `Request` onto the accessor interface Novu
+// expects, and `transformResponse` builds the `Response` Novu hands back.
+const handler = new NovuRequestHandler<[Request], Response>({
+  frameworkName: "hono",
+  ...options,
+  handler: (request) => ({
+    body: () => request.json(),
+    headers: (key) => request.headers.get(key),
+    method: () => request.method,
+    queryString: (key, url) => url.searchParams.get(key),
+    url: () => new URL(request.url),
+    transformResponse: ({ body, status, headers }) =>
+      new Response(body, { status, headers }),
+  }),
+}).createHandler();
 
 const app = createHono();
 
-app.get("/", (ctx) => novu.GET(ctx.req.raw, ctx));
-app.post("/", (ctx) => novu.POST(ctx.req.raw, ctx));
-app.options("/", (ctx) => novu.OPTIONS(ctx.req.raw, ctx));
+app.get("/", (ctx) => handler(ctx.req.raw));
+app.post("/", (ctx) => handler(ctx.req.raw));
+app.options("/", (ctx) => handler(ctx.req.raw));
 
 export default app;

--- a/front-api/routes/novu/index.ts
+++ b/front-api/routes/novu/index.ts
@@ -12,18 +12,12 @@ import { NovuRequestHandler } from "@novu/framework";
 // platform. The Novu platform calls this endpoint to execute workflow steps.
 // See: https://docs.novu.co/framework/endpoint
 
-// Novu ships per-framework adapters under subpaths (e.g. `@novu/framework/next`),
-// but the Next adapter does `import { NextRequest } from "next/server"` at the
-// top of its module, which forces Node to resolve and load Next at module-load
-// time. That breaks the standalone Hono server whenever Next is not available
-// (e.g. locally) and violates [API9].
-//
-// Instead we build a thin Hono-native adapter directly on `NovuRequestHandler`
-// from the root package, following Novu's documented "custom serve" pattern:
+// We build the handler directly on `NovuRequestHandler` (Novu's documented
+// "custom serve" pattern) rather than `@novu/framework/next`: the Next adapter
+// imports `next/server` at module load, which would pull Next into the
+// standalone Hono server and violate [API9]. Novu only touches the standard
+// Fetch `Request` surface at runtime, which `ctx.req.raw` already provides.
 // https://docs.novu.co/framework/endpoint#writing-a-custom-serve-function
-// At runtime Novu only touches the standard Fetch `Request` surface
-// (method/headers/body/url), which `ctx.req.raw` already provides — so no Next
-// types or runtime are involved.
 
 const options: ServeHandlerOptions = {
   workflows: [


### PR DESCRIPTION
## Description
The Next adapter imports next/server at module-load time, which forces Node to load Next.js and breaks the standalone Hono server when Next is not available. Build a thin adapter on NovuRequestHandler from the root @novu/framework package instead, per Novu's documented custom-serve pattern. Resolves the [API9] violation.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Manually verified endpoint
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
