### PR TITLE
ConversationFileExplorer: use 2 separates components to keep state when switching back and forth.

### DIFF
--- a/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
@@ -1,6 +1,7 @@
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { FileExplorer } from "@app/components/file_explorer/FileExplorer";
 import { useFileDownload } from "@app/components/file_explorer/useFileDownload";
+import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useConversationSandboxFiles } from "@app/hooks/conversations/useConversationSandboxFiles";
 import config from "@app/lib/api/config";
 import { downloadFile } from "@app/lib/swr/files";
@@ -10,7 +11,7 @@ import {
   isPodConversation,
 } from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
-import { Button, ButtonGroup } from "@dust-tt/sparkle";
+import { Button, ButtonGroup, cn, XMarkIcon } from "@dust-tt/sparkle";
 import { useCallback, useState } from "react";
 
 type FilesTab = "conversation" | "pod";
@@ -36,7 +37,7 @@ export function ConversationFileExplorer({
   const { files: podFiles, isPodFilesLoading } = usePodFiles({
     owner,
     podId: isPod ? conversation.spaceId : "",
-    disabled: !isPod || activeTab !== "pod",
+    disabled: !isPod,
   });
 
   const getFileUrl = useCallback(
@@ -54,40 +55,84 @@ export function ConversationFileExplorer({
 
   const onFileDownload = useFileDownload({ getFileResponse });
 
-  const isOnPodTab = isPod && activeTab === "pod";
+  const onOpenInteractive = useCallback(
+    (entry: { fileId: string }) =>
+      openPanel({ type: "interactive_content", fileId: entry.fileId }),
+    [openPanel]
+  );
 
   return (
-    <FileExplorer
-      key={activeTab}
-      files={isOnPodTab ? podFiles : sandboxFiles}
-      isLoading={isOnPodTab ? isPodFilesLoading : isSandboxFilesLoading}
-      getFileUrl={getFileUrl}
-      onFileDownload={onFileDownload}
-      onClose={closePanel}
-      rootTitle={
-        isPod ? (
-          <ButtonGroup
-            removeGaps={false}
-            className="rounded-lg bg-muted dark:bg-muted-night p-0.5"
+    <div className="flex h-full min-h-0 flex-col">
+      <AppLayoutTitle>
+        <div className="flex h-full items-center justify-between gap-2">
+          {isPod ? (
+            <ButtonGroup
+              removeGaps={false}
+              className="rounded-lg bg-muted p-0.5 dark:bg-muted-night"
+            >
+              <Button
+                size="xs"
+                variant={activeTab === "conversation" ? "outline" : "ghost"}
+                label="Conversation Files"
+                onClick={() => setActiveTab("conversation")}
+              />
+              <Button
+                size="xs"
+                variant={activeTab === "pod" ? "outline" : "ghost"}
+                label="Pod Files"
+                onClick={() => setActiveTab("pod")}
+              />
+            </ButtonGroup>
+          ) : (
+            <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
+              Conversation Files
+            </span>
+          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            icon={XMarkIcon}
+            onClick={closePanel}
+          />
+        </div>
+      </AppLayoutTitle>
+
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div
+          className={cn(
+            "flex min-h-0 flex-1 flex-col",
+            isPod && activeTab !== "conversation" && "hidden"
+          )}
+        >
+          <FileExplorer
+            files={sandboxFiles}
+            hideBreadcrumbAtRoot
+            isLoading={isSandboxFilesLoading}
+            getFileUrl={getFileUrl}
+            onFileDownload={onFileDownload}
+            onOpenInteractive={onOpenInteractive}
+          />
+        </div>
+
+        {isPod && (
+          <div
+            className={cn(
+              "flex min-h-0 flex-1 flex-col",
+              activeTab !== "pod" && "hidden"
+            )}
           >
-            <Button
-              size="xs"
-              variant={activeTab === "conversation" ? "outline" : "ghost"}
-              label="Conversation Files"
-              onClick={() => setActiveTab("conversation")}
+            <FileExplorer
+              defaultViewMode="list"
+              files={podFiles}
+              hideBreadcrumbAtRoot
+              isLoading={isPodFilesLoading}
+              getFileUrl={getFileUrl}
+              onFileDownload={onFileDownload}
+              onOpenInteractive={onOpenInteractive}
             />
-            <Button
-              size="xs"
-              variant={activeTab === "pod" ? "outline" : "ghost"}
-              label="Pod Files"
-              onClick={() => setActiveTab("pod")}
-            />
-          </ButtonGroup>
-        ) : undefined
-      }
-      onOpenInteractive={(entry) =>
-        openPanel({ type: "interactive_content", fileId: entry.fileId })
-      }
-    />
+          </div>
+        )}
+      </div>
+    </div>
   );
 }

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -22,23 +22,18 @@ import {
   buildFolderTree,
   countFoldersInTree,
   getFolderBreadcrumbSegments,
-  getParentFolderRelativePath,
   getScopedRelativePath,
   isFileExplorerMovableFile,
 } from "@app/components/file_explorer/utils";
-import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import type { FileSystemEntry } from "@app/lib/api/file_system/types";
 import { isInteractiveContentType } from "@app/types/files";
 import { Err, type Result } from "@app/types/shared/result";
 import {
-  Button,
   cn,
   FolderOpenIcon,
   PencilSquareIcon,
   TrashIcon,
-  XMarkIcon,
 } from "@dust-tt/sparkle";
-import { AnimatePresence, motion } from "framer-motion";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -47,14 +42,12 @@ interface FileExplorerProps {
   contentNodes?: ContentNodeEntry[];
   defaultViewMode?: ViewMode;
   emptyState?: React.ReactNode;
-  hideTitleBorder?: boolean;
+  hideBreadcrumbAtRoot?: boolean;
   files: FileSystemEntry[];
   getFileUrl: (path: string) => string;
-  rootTitle?: React.ReactNode;
   toolbarExtraActions?: React.ReactNode;
   isLoading: boolean;
   navigationResetKey?: number;
-  onClose?: () => void;
   onCurrentFolderChange?: (relativePath: string) => void;
   onDelete?: (entry: FileExplorerEntry) => Promise<void>;
   onFileDownload: (entry: FileEntry) => Promise<void>;
@@ -76,12 +69,10 @@ export function FileExplorer({
   emptyState,
   files,
   getFileUrl,
-  rootTitle,
   toolbarExtraActions,
-  hideTitleBorder = false,
+  hideBreadcrumbAtRoot = false,
   isLoading,
   navigationResetKey,
-  onClose,
   onCurrentFolderChange,
   onDelete,
   onFileDownload,
@@ -220,10 +211,6 @@ export function FileExplorer({
     setCurrentFolderPath(node.path);
   };
 
-  const handleGoUp = () => {
-    setCurrentFolderPath(getParentFolderRelativePath(currentFolderPath));
-  };
-
   const fileDragEnabled = Boolean(onMoveFile && totalFolderCount > 0);
 
   const handleMoveFileDrop = useCallback(
@@ -281,80 +268,31 @@ export function FileExplorer({
       ? () => setPreviewFile(fileEntriesAtLevel[previewIndex + 1] ?? null)
       : undefined;
 
-  const inPanel = !!onClose;
+  const showBreadcrumb = !(hideBreadcrumbAtRoot && currentFolderPath === "");
 
   return (
     <>
       <div className="flex h-full w-full min-h-0 flex-1 flex-col">
-        {inPanel && (
-          <AppLayoutTitle
-            className={hideTitleBorder ? "border-b-0" : undefined}
-          >
-            <div
-              className={cn(
-                "flex h-full items-center justify-between gap-2",
-                contentClassName
-              )}
-            >
-              <div className="relative flex h-full flex-1 min-w-0 items-center">
-                <AnimatePresence initial={false}>
-                  {currentFolderPath === "" && rootTitle !== undefined ? (
-                    <motion.div
-                      key="title"
-                      className="absolute inset-0 flex items-center"
-                      initial={{ opacity: 0 }}
-                      animate={{ opacity: 1 }}
-                      exit={{ opacity: 0 }}
-                      transition={{ duration: 0.15 }}
-                    >
-                      {rootTitle}
-                    </motion.div>
-                  ) : (
-                    <motion.div
-                      key="breadcrumb"
-                      className="absolute inset-0 flex items-center"
-                      initial={{ opacity: 0 }}
-                      animate={{ opacity: 1 }}
-                      exit={{ opacity: 0 }}
-                      transition={{ duration: 0.15 }}
-                    >
-                      <FileExplorerBreadcrumb
-                        currentFolderPath={currentFolderPath}
-                        onGoUp={handleGoUp}
-                        onNavigate={handleBreadcrumbNavigate}
-                        onMoveFileDrop={
-                          fileDragEnabled ? handleMoveFileDrop : undefined
-                        }
-                      />
-                    </motion.div>
-                  )}
-                </AnimatePresence>
-              </div>
-              <Button
-                variant="ghost"
-                size="sm"
-                icon={XMarkIcon}
-                onClick={onClose}
+        <div
+          className={cn("flex flex-1 min-h-0 flex-col gap-5", contentClassName)}
+        >
+          {showBreadcrumb && (
+            <div className={cn("px-4", hideBreadcrumbAtRoot && "pt-5")}>
+              <FileExplorerBreadcrumb
+                currentFolderPath={currentFolderPath}
+                onNavigate={handleBreadcrumbNavigate}
+                onMoveFileDrop={
+                  fileDragEnabled ? handleMoveFileDrop : undefined
+                }
               />
             </div>
-          </AppLayoutTitle>
-        )}
-        <div
-          className={cn(
-            "flex flex-1 min-h-0 flex-col gap-5",
-            contentClassName,
-            inPanel ? "pt-5" : undefined
           )}
-        >
-          {!inPanel && (
-            <FileExplorerBreadcrumb
-              currentFolderPath={currentFolderPath}
-              onGoUp={handleGoUp}
-              onNavigate={handleBreadcrumbNavigate}
-              onMoveFileDrop={fileDragEnabled ? handleMoveFileDrop : undefined}
-            />
-          )}
-          <div className="px-4">
+          <div
+            className={cn(
+              "px-4",
+              hideBreadcrumbAtRoot && !showBreadcrumb && "pt-5"
+            )}
+          >
             <FileExplorerToolbar
               searchQuery={searchQuery}
               onSearchQueryChange={setSearchQuery}

--- a/front/components/file_explorer/FileExplorerBreadcrumb.tsx
+++ b/front/components/file_explorer/FileExplorerBreadcrumb.tsx
@@ -8,12 +8,10 @@ import {
   ROOT_FOLDER_LABEL,
 } from "@app/components/file_explorer/utils";
 import {
-  ArrowLeftIcon,
   Breadcrumb,
   BreadcrumbButton,
   BreadcrumbItem,
   BreadcrumbPage,
-  Button,
   cn,
 } from "@dust-tt/sparkle";
 import type React from "react";
@@ -62,14 +60,12 @@ function BreadcrumbDropZone({
 
 export interface FileExplorerBreadcrumbProps {
   currentFolderPath: string;
-  onGoUp: () => void;
   onNavigate: (index: number) => void;
   onMoveFileDrop?: (scopedFilePath: string, parentRelativePath: string) => void;
 }
 
 export function FileExplorerBreadcrumb({
   currentFolderPath,
-  onGoUp,
   onNavigate,
   onMoveFileDrop,
 }: FileExplorerBreadcrumbProps) {
@@ -82,20 +78,11 @@ export function FileExplorerBreadcrumb({
 
   return (
     <div className="flex items-center gap-2">
-      {currentFolderPath !== "" &&
-        (isDragging ? (
-          <span className="animate-in fade-in slide-in-from-left-1 duration-150 text-sm font-medium leading-5 text-foreground dark:text-foreground-night">
-            Move to…
-          </span>
-        ) : (
-          <Button
-            aria-label="Go to parent folder"
-            variant="ghost"
-            size="sm"
-            icon={ArrowLeftIcon}
-            onClick={onGoUp}
-          />
-        ))}
+      {currentFolderPath !== "" && isDragging && (
+        <span className="animate-in fade-in slide-in-from-left-1 duration-150 text-sm font-medium leading-5 text-foreground dark:text-foreground-night">
+          Move to…
+        </span>
+      )}
       <Breadcrumb>
         {allItems.map((item, index) => {
           const isLast = index === allItems.length - 1;
@@ -111,7 +98,7 @@ export function FileExplorerBreadcrumb({
                 ) : (
                   <BreadcrumbButton
                     label={item.label}
-                    variant={isDragging ? "outline" : "ghost"}
+                    variant="outline"
                     onClick={() => onNavigate(index - 1)}
                   />
                 )}

--- a/front/components/pod/files/PodFileExplorer.tsx
+++ b/front/components/pod/files/PodFileExplorer.tsx
@@ -776,7 +776,6 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
         emptyState={hasFiles ? undefined : emptyState}
         files={podGCSFiles}
         getFileUrl={getFileUrl}
-        hideTitleBorder
         navigationResetKey={navigationResetKey}
         onCurrentFolderChange={setCurrentFolderPath}
         onFileDownload={onFileDownload}


### PR DESCRIPTION
## Description

`ConversationFileExplorer` now renders two persistent `FileExplorer` instances (one for conversation files, one for pod files) shown/hidden via CSS `hidden` instead of a single instance remounted via `key={activeTab}`. This preserves each tab's React state — folder navigation, scroll position, search query — when the user switches back and forth.

Side effects of the refactor:
- Pod files are now pre-fetched regardless of active tab (removed the `activeTab !== "pod"` guard on `disabled`), so switching to the Pod Files tab is instant.
- Panel chrome (close button, tab switcher) moved up into `ConversationFileExplorer`'s `AppLayoutTitle`, fully decoupling it from `FileExplorer`.
- `FileExplorer` props removed: `onClose`, `rootTitle`, `hideTitleBorder`; `AnimatePresence`/`motion` title animation dropped. New `hideBreadcrumbAtRoot` prop replaces the old `inPanel` detection.
- `FileExplorerBreadcrumb` drops the `onGoUp` back-arrow button (breadcrumb segments handle all navigation).


https://github.com/user-attachments/assets/cd9a6219-0ff3-446e-8c06-caefe5819b12



## Tests

Tested locally by switching between "Conversation Files" and "Pod Files" tabs and verifying state (folder path, search) is preserved in each tab independently.

## Risk

Low. Pure front-end component refactor with no API or data model changes. The two-instance approach adds one extra data fetch for pod files on mount in pod conversations, but both fetches were already present (just conditionally disabled).

## Deploy Plan

Deploy front.
