### PR TITLE
[front-api] fix: correct SSE redirect double /api prefix (#26472)

### DIFF
--- a/front-api/lib/api/sse/redirect.test.ts
+++ b/front-api/lib/api/sse/redirect.test.ts
@@ -1,7 +1,6 @@
+import { redirectToSse } from "@front-api/lib/api/sse/redirect";
 import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
-
-import { redirectToSse } from "@front-api/lib/api/sse/redirect";
 
 function requestSseRedirect(routePattern: string, path: string) {
   const app = new Hono();
@@ -31,15 +30,16 @@ describe("redirectToSse", () => {
       path: "/api/w/w1/mcp/requests",
       expected: "/api/sse/w/w1/mcp/requests",
     },
-  ])(
-    "rewrites the leading /api/ segment to /api/sse/ for the $name path",
-    async ({ routePattern, path, expected }) => {
-      const res = await requestSseRedirect(routePattern, path);
+  ])("rewrites the leading /api/ segment to /api/sse/ for the $name path", async ({
+    routePattern,
+    path,
+    expected,
+  }) => {
+    const res = await requestSseRedirect(routePattern, path);
 
-      expect(res.status).toBe(307);
-      expect(new URL(res.headers.get("location")!).pathname).toBe(expected);
-    }
-  );
+    expect(res.status).toBe(307);
+    expect(new URL(res.headers.get("location")!).pathname).toBe(expected);
+  });
 
   it("preserves the query string on the redirected location", async () => {
     const res = await requestSseRedirect(

--- a/front-api/lib/api/sse/redirect.test.ts
+++ b/front-api/lib/api/sse/redirect.test.ts
@@ -1,0 +1,57 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+
+import { redirectToSse } from "@front-api/lib/api/sse/redirect";
+
+function requestSseRedirect(routePattern: string, path: string) {
+  const app = new Hono();
+  app.get(routePattern, redirectToSse);
+  return app.request(path, { redirect: "manual" });
+}
+
+describe("redirectToSse", () => {
+  it.each([
+    {
+      name: "message events",
+      routePattern:
+        "/api/v1/w/:wId/assistant/conversations/:cId/messages/:mId/events",
+      path: "/api/v1/w/w1/assistant/conversations/c1/messages/m1/events",
+      expected:
+        "/api/sse/v1/w/w1/assistant/conversations/c1/messages/m1/events",
+    },
+    {
+      name: "conversation events",
+      routePattern: "/api/v1/w/:wId/assistant/conversations/:cId/events",
+      path: "/api/v1/w/w1/assistant/conversations/c1/events",
+      expected: "/api/sse/v1/w/w1/assistant/conversations/c1/events",
+    },
+    {
+      name: "private mcp requests",
+      routePattern: "/api/w/:wId/mcp/requests",
+      path: "/api/w/w1/mcp/requests",
+      expected: "/api/sse/w/w1/mcp/requests",
+    },
+  ])(
+    "rewrites the leading /api/ segment to /api/sse/ for the $name path",
+    async ({ routePattern, path, expected }) => {
+      const res = await requestSseRedirect(routePattern, path);
+
+      expect(res.status).toBe(307);
+      expect(new URL(res.headers.get("location")!).pathname).toBe(expected);
+    }
+  );
+
+  it("preserves the query string on the redirected location", async () => {
+    const res = await requestSseRedirect(
+      "/api/v1/w/:wId/assistant/conversations/:cId/events",
+      "/api/v1/w/w1/assistant/conversations/c1/events?foo=bar"
+    );
+
+    expect(res.status).toBe(307);
+    const location = new URL(res.headers.get("location")!);
+    expect(location.pathname).toBe(
+      "/api/sse/v1/w/w1/assistant/conversations/c1/events"
+    );
+    expect(location.search).toBe("?foo=bar");
+  });
+});

--- a/front-api/lib/api/sse/redirect.ts
+++ b/front-api/lib/api/sse/redirect.ts
@@ -1,12 +1,11 @@
 import type { Context } from "hono";
 
-const SSE_PREFIX = "/api/sse";
-
-// Redirects an original (non-/api/sse) SSE path to its /api/sse counterpart with
-// a 307 so the ingress routes it to dedicated front-sse pods. Mirrors the Next
-// middleware redirect in front/lib/api/sse_redirect.ts.
+// Redirects an SSE path to its /api/sse counterpart with a 307 so the ingress
+// routes it to dedicated front-sse pods. Mirrors the Next middleware redirect in
+// front/lib/api/sse_redirect.ts.
 export function redirectToSse(ctx: Context) {
   const url = new URL(ctx.req.url);
-  const sseUrl = `${url.origin}${SSE_PREFIX}${url.pathname}${url.search}`;
+  const ssePath = url.pathname.replace(/^\/api\//, "/api/sse/");
+  const sseUrl = `${url.origin}${ssePath}${url.search}`;
   return ctx.redirect(sseUrl, 307);
 }


### PR DESCRIPTION
## Problem

Fixes #26472. The Dust CLI fails with `Error: Error requesting event stream: status_code=404` after sending a message. The conversation and message are created server-side (they appear in the web app); only the SSE event-stream request 404s.

## Root cause

`front-api/lib/api/sse/redirect.ts` built the redirect URL by **prepending** `/api/sse` to a pathname that already starts with `/api/`:

```
/api/sse + /api/v1/w/.../events  ->  /api/sse/api/v1/w/.../events   (doubled /api -> 404)
```

Introduced in #26483 ("Migrate SSE 307 routes"), which routed `/api/v1/.../events` through this Hono helper. Flow: the SDK's `fetch` follows the 307 to the malformed `/api/sse/api/v1/...`, the server returns 404, and the SDK throws `Error requesting event stream: status_code=404` (`sdks/js/src/index.ts`). The earlier POST that creates the conversation uses a different, working endpoint, which is why messages still show up.

## Fix

Replace the leading `/api/` prefix with `/api/sse/` instead of prepending, mirroring the correct Next middleware in `front/lib/api/sse_redirect.ts`:

```ts
const ssePath = url.pathname.replace(/^\/api\//, "/api/sse/");
```

## Test

Adds `front-api/lib/api/sse/redirect.test.ts` pinning the redirect rewrite across the message-events, conversation-events and private mcp/requests paths, plus query-string preservation.

Note: only the Hono side was buggy (the Next reference is already correct), so this is intentionally one-sided wrt the migration-sync check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)