### PR TITLE
[connectors] fix: include Slack attachment text in bot threads

### DIFF
--- a/connectors/src/api/webhooks/slack/utils.ts
+++ b/connectors/src/api/webhooks/slack/utils.ts
@@ -1,5 +1,6 @@
 import { botAnswerMessage } from "@connectors/connectors/slack/bot";
 import { getBotUserIdResponse } from "@connectors/connectors/slack/lib/bot_user_helpers";
+import { formatSlackMessageUnfurlAttachments } from "@connectors/connectors/slack/lib/message_attachments";
 import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
 import { throttleWithRedis } from "@connectors/lib/throttle";
 import type { Logger } from "@connectors/logger/logger";
@@ -7,6 +8,8 @@ import { apiError } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
 import type { WithConnectorsAPIErrorReponse } from "@connectors/types";
+import { removeNulls } from "@connectors/types/shared/utils/general";
+import type { MessageElement } from "@slack/web-api/dist/types/response/ConversationsRepliesResponse";
 import tracer from "dd-trace";
 import type { Request, Response } from "express";
 
@@ -69,6 +72,7 @@ export interface SlackWebhookEvent<T = string> {
   type?: string; // event type (eg: message)
   channel_type?: "channel" | "group" | "im" | "mpim";
   text: string; // content of the message
+  attachments?: MessageElement["attachments"];
   old_name?: string; // when renaming channel: old channel name
   name?: string; // when renaming channel: new channel name
   message?: {
@@ -153,7 +157,13 @@ export async function handleChatBot(
 ) {
   const { event } = req.body;
 
-  const slackMessage = event.text;
+  const forwardedMessagesText = formatSlackMessageUnfurlAttachments(
+    event.attachments
+  );
+  const slackMessage = removeNulls([
+    event.text || null,
+    forwardedMessagesText || null,
+  ]).join("\n");
   const slackTeamId = req.body.team_id;
   const slackChannel = event.channel;
   const slackUserId = event.user;

--- a/connectors/src/connectors/slack/lib/message_attachments.ts
+++ b/connectors/src/connectors/slack/lib/message_attachments.ts
@@ -1,0 +1,25 @@
+import { removeNulls } from "@connectors/types/shared/utils/general";
+import type { MessageElement } from "@slack/web-api/dist/types/response/ConversationsRepliesResponse";
+
+export function formatSlackMessageUnfurlAttachments(
+  attachments: MessageElement["attachments"]
+): string {
+  return removeNulls(
+    attachments
+      ?.filter(
+        (a) => a.is_msg_unfurl || a.is_reply_unfurl || a.is_thread_root_unfurl
+      )
+      .map((a) => {
+        const forwardedMessageBody = a.text || a.fallback;
+        if (!forwardedMessageBody?.trim()) {
+          return null;
+        }
+
+        const forwardedMessageHeader = a.author_name
+          ? `Forwarded from @${a.author_name}:`
+          : "Forwarded message:";
+
+        return `${forwardedMessageHeader}\n${forwardedMessageBody}`;
+      }) ?? []
+  ).join("\n---\n");
+}

--- a/connectors/src/connectors/slack/lib/messages.ts
+++ b/connectors/src/connectors/slack/lib/messages.ts
@@ -82,36 +82,34 @@ export async function formatMessagesForUpsert({
             .join("\n")
         : "";
 
-      // Slack stores forwarded/shared messages in `attachments`.
+      // Slack attachments can contain forwarded/shared messages or app content.
       // Link-unfurl attachments (from_url is set) are skipped to avoid noise.
-      const forwardedInfo =
-        message.attachments?.length
-          ? "\n" +
-            message.attachments
-              .filter((a) => !a.from_url)
-              .map((a) => {
-                const parts: string[] = [];
-                if (a.author_name) {
-                  parts.push(`Forwarded from @${a.author_name}:`);
-                }
-                if (a.text) {
-                  parts.push(a.text);
-                } else if (a.fallback) {
-                  parts.push(a.fallback);
-                }
-                return parts.join("\n");
-              })
-              .filter(Boolean)
-              .join("\n---\n")
-          : "";
+      const attachmentText =
+        message.attachments
+          ?.filter((a) => !a.from_url)
+          .map((a) => {
+            const parts: string[] = [];
+            if (a.author_name) {
+              parts.push(`Forwarded from @${a.author_name}:`);
+            }
+            if (a.text) {
+              parts.push(a.text);
+            } else if (a.fallback) {
+              parts.push(a.fallback);
+            }
+            return parts.join("\n");
+          })
+          .filter(Boolean)
+          .join("\n---\n") ?? "";
+      const attachmentsInfo = attachmentText ? `\n${attachmentText}` : "";
 
       return {
         messageDate,
         dateStr: messageDateStr,
         authorName,
         authorEmail,
-        text: text + filesInfo + forwardedInfo,
-        content: text + forwardedInfo + "\n",
+        text: text + filesInfo + attachmentsInfo,
+        content: text + attachmentsInfo + "\n",
         sections: [],
       };
     })

--- a/connectors/src/connectors/slack/lib/messages.ts
+++ b/connectors/src/connectors/slack/lib/messages.ts
@@ -7,6 +7,7 @@ import { renderDocumentTitleAndContent } from "@connectors/lib/data_sources";
 import { formatDateForUpsert } from "@connectors/lib/formatting";
 import type { DataSourceConfig, ModelId } from "@connectors/types";
 import { safeSubstring } from "@connectors/types";
+import { removeNulls } from "@connectors/types/shared/utils/general";
 import type { WebClient } from "@slack/web-api";
 import type { MessageElement } from "@slack/web-api/dist/types/response/ConversationsRepliesResponse";
 
@@ -83,7 +84,7 @@ export async function formatMessagesForUpsert({
         : "";
 
       // Slack renders forwarded/shared messages as message unfurl attachments.
-      const forwardedMessagesText =
+      const forwardedMessagesText = removeNulls(
         message.attachments
           ?.filter(
             (a) =>
@@ -100,9 +101,9 @@ export async function formatMessagesForUpsert({
               : "Forwarded message:";
 
             return `${forwardedMessageHeader}\n${forwardedMessageBody}`;
-          })
-          .filter((text): text is string => text !== null)
-          .join("\n---\n") ?? "";
+          }) ?? []
+      ).join("\n---\n");
+
       const forwardedMessagesInfo = forwardedMessagesText
         ? `\n${forwardedMessagesText}`
         : "";

--- a/connectors/src/connectors/slack/lib/messages.ts
+++ b/connectors/src/connectors/slack/lib/messages.ts
@@ -82,11 +82,13 @@ export async function formatMessagesForUpsert({
             .join("\n")
         : "";
 
-      // Slack attachments can contain forwarded/shared messages or app content.
-      // Link-unfurl attachments (from_url is set) are skipped to avoid noise.
-      const attachmentText =
+      // Slack renders forwarded/shared messages as message unfurl attachments.
+      const forwardedMessagesText =
         message.attachments
-          ?.filter((a) => !a.from_url)
+          ?.filter(
+            (a) =>
+              a.is_msg_unfurl || a.is_reply_unfurl || a.is_thread_root_unfurl
+          )
           .map((a) => {
             const parts: string[] = [];
             if (a.author_name) {
@@ -101,15 +103,17 @@ export async function formatMessagesForUpsert({
           })
           .filter(Boolean)
           .join("\n---\n") ?? "";
-      const attachmentsInfo = attachmentText ? `\n${attachmentText}` : "";
+      const forwardedMessagesInfo = forwardedMessagesText
+        ? `\n${forwardedMessagesText}`
+        : "";
 
       return {
         messageDate,
         dateStr: messageDateStr,
         authorName,
         authorEmail,
-        text: text + filesInfo + attachmentsInfo,
-        content: text + attachmentsInfo + "\n",
+        text: text + filesInfo + forwardedMessagesInfo,
+        content: text + forwardedMessagesInfo + "\n",
         sections: [],
       };
     })

--- a/connectors/src/connectors/slack/lib/messages.ts
+++ b/connectors/src/connectors/slack/lib/messages.ts
@@ -90,18 +90,18 @@ export async function formatMessagesForUpsert({
               a.is_msg_unfurl || a.is_reply_unfurl || a.is_thread_root_unfurl
           )
           .map((a) => {
-            const parts: string[] = [];
-            if (a.author_name) {
-              parts.push(`Forwarded from @${a.author_name}:`);
+            const forwardedMessageBody = a.text || a.fallback;
+            if (!forwardedMessageBody?.trim()) {
+              return null;
             }
-            if (a.text) {
-              parts.push(a.text);
-            } else if (a.fallback) {
-              parts.push(a.fallback);
-            }
-            return parts.join("\n");
+
+            const forwardedMessageHeader = a.author_name
+              ? `Forwarded from @${a.author_name}:`
+              : "Forwarded message:";
+
+            return `${forwardedMessageHeader}\n${forwardedMessageBody}`;
           })
-          .filter(Boolean)
+          .filter((text): text is string => text !== null)
           .join("\n---\n") ?? "";
       const forwardedMessagesInfo = forwardedMessagesText
         ? `\n${forwardedMessagesText}`

--- a/connectors/src/connectors/slack/lib/messages.ts
+++ b/connectors/src/connectors/slack/lib/messages.ts
@@ -82,13 +82,36 @@ export async function formatMessagesForUpsert({
             .join("\n")
         : "";
 
+      // Slack stores forwarded/shared messages in `attachments`.
+      // Link-unfurl attachments (from_url is set) are skipped to avoid noise.
+      const forwardedInfo =
+        message.attachments?.length
+          ? "\n" +
+            message.attachments
+              .filter((a) => !a.from_url)
+              .map((a) => {
+                const parts: string[] = [];
+                if (a.author_name) {
+                  parts.push(`Forwarded from @${a.author_name}:`);
+                }
+                if (a.text) {
+                  parts.push(a.text);
+                } else if (a.fallback) {
+                  parts.push(a.fallback);
+                }
+                return parts.join("\n");
+              })
+              .filter(Boolean)
+              .join("\n---\n")
+          : "";
+
       return {
         messageDate,
         dateStr: messageDateStr,
         authorName,
         authorEmail,
-        text: text + filesInfo,
-        content: text + "\n",
+        text: text + filesInfo + forwardedInfo,
+        content: text + forwardedInfo + "\n",
         sections: [],
       };
     })

--- a/connectors/src/connectors/slack/lib/messages.ts
+++ b/connectors/src/connectors/slack/lib/messages.ts
@@ -7,9 +7,10 @@ import { renderDocumentTitleAndContent } from "@connectors/lib/data_sources";
 import { formatDateForUpsert } from "@connectors/lib/formatting";
 import type { DataSourceConfig, ModelId } from "@connectors/types";
 import { safeSubstring } from "@connectors/types";
-import { removeNulls } from "@connectors/types/shared/utils/general";
 import type { WebClient } from "@slack/web-api";
 import type { MessageElement } from "@slack/web-api/dist/types/response/ConversationsRepliesResponse";
+
+import { formatSlackMessageUnfurlAttachments } from "./message_attachments";
 
 async function processMessageForMentions(
   message: string,
@@ -84,25 +85,9 @@ export async function formatMessagesForUpsert({
         : "";
 
       // Slack renders forwarded/shared messages as message unfurl attachments.
-      const forwardedMessagesText = removeNulls(
+      const forwardedMessagesText = formatSlackMessageUnfurlAttachments(
         message.attachments
-          ?.filter(
-            (a) =>
-              a.is_msg_unfurl || a.is_reply_unfurl || a.is_thread_root_unfurl
-          )
-          .map((a) => {
-            const forwardedMessageBody = a.text || a.fallback;
-            if (!forwardedMessageBody?.trim()) {
-              return null;
-            }
-
-            const forwardedMessageHeader = a.author_name
-              ? `Forwarded from @${a.author_name}:`
-              : "Forwarded message:";
-
-            return `${forwardedMessageHeader}\n${forwardedMessageBody}`;
-          }) ?? []
-      ).join("\n---\n");
+      );
 
       const forwardedMessagesInfo = forwardedMessagesText
         ? `\n${forwardedMessagesText}`


### PR DESCRIPTION
## Description

This PR includes useful Slack attachment text when formatting Slack bot thread messages for upsert, so forwarded/shared messages are indexed with the thread content.

Example of conversation where we don't have the forwarded message [here](https://app.dust.tt/w/0ec9852c2f/conversation/yAy9viJijm).

It skips link-unfurl attachments and only appends attachment content when there is non-empty text or fallback, avoiding formatting changes for messages that only contain unfurls or empty attachments.

## Tests

## Risk

- Low. Purely additive. Safe to rollback.

## Deploy Plan

- Deploy connectors.
