### PR TITLE
[biome] perf: speedup `noCssImportant` check

### DIFF
--- a/.grit/patterns/noCssImportant.grit
+++ b/.grit/patterns/noCssImportant.grit
@@ -7,16 +7,18 @@ language js
 // Narrow exceptions for third-party library overrides and dev tooling are
 // scoped via biome.json overrides.
 //
-// One regex per quote style; each covers all three flagged forms:
+// One regex with an internal 3-way alternation (one branch per quote style).
+// Each branch matches a full string/template literal and excludes only its own
+// delimiter, so inner quotes of a different kind are handled (e.g. an apostrophe
+// inside a double-quoted string). Combining the branches into a single regex
+// rather than a Grit `or { r"...", r"...", r"..." }` roughly halves this rule's
+// runtime: Biome attempts one node match / one compiled automaton per node
+// instead of three. Each branch covers all three flagged forms:
 //   - `!important` keyword (CSS-in-JS, template literals, inline styles)
 //   - Tailwind modifier-prefixed important: `:!<utility>` (e.g. `focus:!ring-0`)
-//   - Tailwind leading important: `"!<utility>"` (e.g. `!mt-0`)
+//   - Tailwind leading important: `!<utility>` right after the opening quote
 pattern css_important_string() {
-    or {
-        r"\"(?:![a-z]|[^\"]*(?:!important|:![a-z]))[^\"]*\"",
-        r"'(?:![a-z]|[^']*(?:!important|:![a-z]))[^']*'",
-        r"`(?:![a-z]|[^`]*(?:!important|:![a-z]))[^`]*`"
-    }
+    r"(?:\"(?:![a-z]|[^\"]*(?:!important|:![a-z]))[^\"]*\"|'(?:![a-z]|[^']*(?:!important|:![a-z]))[^']*'|`(?:![a-z]|[^`]*(?:!important|:![a-z]))[^`]*`)"
 }
 
 css_important_string() as $val where {


### PR DESCRIPTION
## Description

`npm run format` takes ~7 min in CI. `noImportCycles` (~56%) and the grit plugins (~42%) account for most of the time, and within the plugins `noCssImportant` is ~47% of plugin time.

On this PR we went from 7min to 5min14.

The rule was a Grit `or { r"...", r"...", r"..." }` of three quote-specific regexes, so biome attempts three separate node matches per string node.

This PR improves its performances by folding the three branches into one regex with an internal 3-way alternation (one compiled automaton, one node match per node).

- Measured on the full repo in isolation: **294s → 160s CPU (~45%, -134s)** for this rule, with no change to what it flags.
- The three alternation branches are byte-for-byte the original three arms, kept separate on purpose: each excludes only its own delimiter so inner quotes of a different kind (e.g. an apostrophe inside a double-quoted string) are still matched. A naive single quote-class regex was faster but dropped that case.

## Tests

- Checked that the coverage is strictly identical: same diagnostics on a fixture covering all three quote styles, both Tailwind important forms (`focus:!ring-0`, `!mt-0`), inner-quote strings, and negatives, plus an identical full-repo diagnostics diff against the previous pattern.

## Risk

- Low.

## Deploy Plan

- No deploy.
