### PR TITLE
[front] enh: add Skill Builder `Attach capabilities` button

### DIFF
--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
@@ -21,6 +21,8 @@ import { exitSuggestion, Suggestion } from "@tiptap/suggestion";
 import { forwardRef, useImperativeHandle, useMemo, useRef } from "react";
 
 const slashCommandPluginKey = new PluginKey("slashCommand");
+const capabilitiesOnlySlashCommandMetaKey =
+  "skillBuilderCapabilitiesOnlySlashCommand";
 
 const INSERT_KNOWLEDGE_NODE_ACTION = "insert-knowledge-node";
 
@@ -193,7 +195,7 @@ const SkillBuilderSlashCommandDropdown = forwardRef<
   return (
     <SlashCommandDropdown
       ref={ref}
-      items={props.items}
+      items={props.showCapabilitiesOnly ? [] : props.items}
       command={props.command}
       clientRect={props.clientRect}
       onClose={props.onClose}
@@ -259,7 +261,14 @@ export const SlashCommandExtension =
           ({ chain }) => {
             this.storage.showCapabilitiesOnly = true;
 
-            const inserted = chain().focus().insertContent("/").run();
+            const inserted = chain()
+              .focus()
+              .command(({ tr }) => {
+                tr.setMeta(capabilitiesOnlySlashCommandMetaKey, true);
+                return true;
+              })
+              .insertContent("/")
+              .run();
             if (!inserted) {
               this.storage.showCapabilitiesOnly = false;
             }
@@ -281,6 +290,13 @@ export const SlashCommandExtension =
             extensionStorage.showCapabilitiesOnly
               ? []
               : filterSlashCommands(query),
+          shouldShow: ({ transaction }) => {
+            if (transaction.getMeta(capabilitiesOnlySlashCommandMetaKey)) {
+              extensionStorage.showCapabilitiesOnly = true;
+            }
+
+            return true;
+          },
           allow: () => extensionStorage.hasBeenFocused,
           command: ({ editor, range, props }) => {
             if (props.action === INSERT_KNOWLEDGE_NODE_ACTION) {

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
@@ -13,7 +13,7 @@ import { useSkills } from "@app/lib/swr/skill_configurations";
 import type { LightWorkspaceType } from "@app/types/user";
 import { AttachmentIcon } from "@dust-tt/sparkle";
 import { Extension } from "@tiptap/core";
-import { PluginKey } from "@tiptap/pm/state";
+import { type EditorState, Plugin, PluginKey } from "@tiptap/pm/state";
 import type { EditorView } from "@tiptap/pm/view";
 import { ReactRenderer } from "@tiptap/react";
 import type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
@@ -25,6 +25,23 @@ const capabilitiesOnlySlashCommandMetaKey =
   "skillBuilderCapabilitiesOnlySlashCommand";
 
 const INSERT_KNOWLEDGE_NODE_ACTION = "insert-knowledge-node";
+
+function hasSlashCharacterAtPosition(state: EditorState, position: number) {
+  const docSize = state.doc.content.size;
+
+  if (position < 1 || position > docSize) {
+    return false;
+  }
+
+  return (
+    state.doc.textBetween(
+      position,
+      Math.min(position + 1, docSize + 1),
+      undefined,
+      "\ufffc"
+    ) === "/"
+  );
+}
 
 // Define available slash commands.
 const SLASH_COMMANDS: SlashCommand[] = [
@@ -231,7 +248,7 @@ export const SlashCommandExtension =
         // This prevents the slash command dropdown from triggering when content
         // ending with "/" is loaded programmatically via setContent on mount.
         hasBeenFocused: false,
-        showCapabilitiesOnly: false,
+        capabilitiesOnlyTriggerStart: null as number | null,
       };
     },
 
@@ -259,8 +276,6 @@ export const SlashCommandExtension =
         openCapabilitiesSlashCommand:
           () =>
           ({ chain }) => {
-            this.storage.showCapabilitiesOnly = true;
-
             const inserted = chain()
               .focus()
               .command(({ tr }) => {
@@ -269,9 +284,6 @@ export const SlashCommandExtension =
               })
               .insertContent("/")
               .run();
-            if (!inserted) {
-              this.storage.showCapabilitiesOnly = false;
-            }
 
             return inserted;
           },
@@ -286,13 +298,17 @@ export const SlashCommandExtension =
         Suggestion({
           editor: this.editor,
           ...this.options.suggestion,
-          items: ({ query }) =>
-            extensionStorage.showCapabilitiesOnly
+          items: ({ editor, query }) => {
+            const state = slashCommandPluginKey.getState(editor.state);
+
+            return state?.range.from ===
+              extensionStorage.capabilitiesOnlyTriggerStart
               ? []
-              : filterSlashCommands(query),
-          shouldShow: ({ transaction }) => {
+              : filterSlashCommands(query);
+          },
+          shouldShow: ({ range, transaction }) => {
             if (transaction.getMeta(capabilitiesOnlySlashCommandMetaKey)) {
-              extensionStorage.showCapabilitiesOnly = true;
+              extensionStorage.capabilitiesOnlyTriggerStart = range.from;
             }
 
             return true;
@@ -348,7 +364,8 @@ export const SlashCommandExtension =
                       onClose: closeSuggestionDropdown,
                       owner: extensionOptions.owner,
                       showCapabilitiesOnly:
-                        extensionStorage.showCapabilitiesOnly,
+                        props.range.from ===
+                        extensionStorage.capabilitiesOnlyTriggerStart,
                     },
                     editor: props.editor,
                   }
@@ -370,7 +387,9 @@ export const SlashCommandExtension =
                     extensionOptions.includeSkillSuggestions,
                   onClose: closeSuggestionDropdown,
                   owner: extensionOptions.owner,
-                  showCapabilitiesOnly: extensionStorage.showCapabilitiesOnly,
+                  showCapabilitiesOnly:
+                    props.range.from ===
+                    extensionStorage.capabilitiesOnlyTriggerStart,
                 });
 
                 if (!props.clientRect) {
@@ -388,7 +407,6 @@ export const SlashCommandExtension =
               },
 
               onExit() {
-                extensionStorage.showCapabilitiesOnly = false;
                 activeEditorView = null;
                 component?.element?.remove();
                 component?.destroy();
@@ -396,6 +414,22 @@ export const SlashCommandExtension =
               },
             };
           },
+        }),
+        new Plugin({
+          key: new PluginKey("skillBuilderSlashCommandCleanup"),
+          view: () => ({
+            update: (view) => {
+              const triggerStart =
+                extensionStorage.capabilitiesOnlyTriggerStart;
+
+              if (
+                triggerStart !== null &&
+                !hasSlashCharacterAtPosition(view.state, triggerStart)
+              ) {
+                extensionStorage.capabilitiesOnlyTriggerStart = null;
+              }
+            },
+          }),
         }),
       ];
     },

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
@@ -81,6 +81,7 @@ interface SkillBuilderSlashCommandDropdownProps
   includeSkillSuggestions: boolean;
   onClose: () => void;
   owner?: LightWorkspaceType;
+  showCapabilitiesOnly: boolean;
 }
 
 interface SkillBuilderSlashCommandDropdownWithSkillsProps
@@ -93,7 +94,16 @@ const SkillBuilderSlashCommandDropdownWithSkills = forwardRef<
   SkillBuilderSlashCommandDropdownWithSkillsProps
 >(
   (
-    { clientRect, command, currentSkillId, items, onClose, owner, query },
+    {
+      clientRect,
+      command,
+      currentSkillId,
+      items,
+      onClose,
+      owner,
+      query,
+      showCapabilitiesOnly,
+    },
     ref
   ) => {
     const dropdownRef = useRef<SlashCommandDropdownRef>(null);
@@ -107,13 +117,13 @@ const SkillBuilderSlashCommandDropdownWithSkills = forwardRef<
     const slashCommandItems = useMemo(
       () =>
         buildSkillBuilderSlashCommandItems({
-          baseItems: items,
+          baseItems: showCapabilitiesOnly ? [] : items,
           currentSkillId,
           includeSkillSuggestions: true,
           query,
           skills,
         }),
-      [currentSkillId, items, query, skills]
+      [currentSkillId, items, query, showCapabilitiesOnly, skills]
     );
 
     useImperativeHandle(
@@ -189,6 +199,14 @@ export interface SlashCommandExtensionOptions {
   suggestion: Partial<SuggestionOptions>;
 }
 
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    skillBuilderSlashCommand: {
+      openCapabilitiesSlashCommand: () => ReturnType;
+    };
+  }
+}
+
 export const SlashCommandExtension =
   Extension.create<SlashCommandExtensionOptions>({
     name: "slashCommand",
@@ -199,6 +217,7 @@ export const SlashCommandExtension =
         // This prevents the slash command dropdown from triggering when content
         // ending with "/" is loaded programmatically via setContent on mount.
         hasBeenFocused: false,
+        showCapabilitiesOnly: false,
       };
     },
 
@@ -230,6 +249,23 @@ export const SlashCommandExtension =
             );
           },
         },
+      };
+    },
+
+    addCommands() {
+      return {
+        openCapabilitiesSlashCommand:
+          () =>
+          ({ chain }) => {
+            this.storage.showCapabilitiesOnly = true;
+
+            const inserted = chain().focus().insertContent("/").run();
+            if (!inserted) {
+              this.storage.showCapabilitiesOnly = false;
+            }
+
+            return inserted;
+          },
       };
     },
 
@@ -291,6 +327,8 @@ export const SlashCommandExtension =
                         extensionOptions.includeSkillSuggestions,
                       onClose: closeSuggestionDropdown,
                       owner: extensionOptions.owner,
+                      showCapabilitiesOnly:
+                        extensionStorage.showCapabilitiesOnly,
                     },
                     editor: props.editor,
                   }
@@ -312,6 +350,7 @@ export const SlashCommandExtension =
                     extensionOptions.includeSkillSuggestions,
                   onClose: closeSuggestionDropdown,
                   owner: extensionOptions.owner,
+                  showCapabilitiesOnly: extensionStorage.showCapabilitiesOnly,
                 });
 
                 if (!props.clientRect) {
@@ -329,6 +368,7 @@ export const SlashCommandExtension =
               },
 
               onExit() {
+                extensionStorage.showCapabilitiesOnly = false;
                 activeEditorView = null;
                 component?.element?.remove();
                 component?.destroy();

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
@@ -44,6 +44,18 @@ const SLASH_COMMANDS: SlashCommand[] = [
   },
 ];
 
+function filterSlashCommands(query: string): SlashCommand[] {
+  if (!query || query.length === 0) {
+    return SLASH_COMMANDS;
+  }
+
+  return SLASH_COMMANDS.filter(
+    (command) =>
+      command.label.toLowerCase().includes(query.toLowerCase()) ||
+      command.tooltip?.description.toLowerCase().includes(query.toLowerCase())
+  );
+}
+
 export function buildSkillBuilderSlashCommandItems({
   baseItems,
   currentSkillId,
@@ -235,19 +247,7 @@ export const SlashCommandExtension =
           pluginKey: slashCommandPluginKey,
           allowSpaces: false,
           startOfLine: false,
-          items: ({ query }: { query: string }) => {
-            if (!query || query.length === 0) {
-              return SLASH_COMMANDS;
-            }
-
-            return SLASH_COMMANDS.filter(
-              (command) =>
-                command.label.toLowerCase().includes(query.toLowerCase()) ||
-                command.tooltip?.description
-                  .toLowerCase()
-                  .includes(query.toLowerCase())
-            );
-          },
+          items: ({ query }: { query: string }) => filterSlashCommands(query),
         },
       };
     },
@@ -277,6 +277,10 @@ export const SlashCommandExtension =
         Suggestion({
           editor: this.editor,
           ...this.options.suggestion,
+          items: ({ query }) =>
+            extensionStorage.showCapabilitiesOnly
+              ? []
+              : filterSlashCommands(query),
           allow: () => extensionStorage.hasBeenFocused,
           command: ({ editor, range, props }) => {
             if (props.action === INSERT_KNOWLEDGE_NODE_ACTION) {

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -1,5 +1,4 @@
 import { editorVariants } from "@app/components/editor/editorStyles";
-import type { SkillNodeAttributes } from "@app/components/editor/extensions/input_bar/SkillNode";
 import { KNOWLEDGE_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
 import type { KnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
 import {
@@ -87,18 +86,14 @@ function sanitizeSkillInstructionsHtml(
 
 const INSTRUCTIONS_EDITOR_SIZE = "min-h-60 max-h-[1024px]";
 
-export type SkillBuilderCapability = SkillNodeAttributes;
-
 interface SkillBuilderInstructionsEditorProps {
-  onAddCapability?: (
-    addCapability: (capability: SkillBuilderCapability) => void
-  ) => void;
   onAddKnowledge?: (addKnowledge: () => void) => void;
+  onOpenCapabilities?: (openCapabilities: () => void) => void;
 }
 
 export function SkillBuilderInstructionsEditor({
-  onAddCapability,
   onAddKnowledge,
+  onOpenCapabilities,
 }: SkillBuilderInstructionsEditorProps) {
   const { compareVersion, isDiffMode } = useSkillVersionComparisonContext();
   const { resetField } = useFormContext<SkillBuilderFormData>();
@@ -268,22 +263,24 @@ export function SkillBuilderInstructionsEditor({
     }
   }, [editor, handleAddKnowledge, onAddKnowledge]);
 
-  const handleAddCapability = useCallback(
-    (capability: SkillBuilderCapability) => {
-      if (!editor || !enableSkillReferences) {
-        return;
-      }
+  const handleOpenCapabilities = useCallback(() => {
+    if (!editor || !enableSkillReferences) {
+      return;
+    }
 
-      editor.chain().focus().insertSkillNode(capability).run();
-    },
-    [editor, enableSkillReferences]
-  );
+    editor.chain().focus().insertContent("/").run();
+  }, [editor, enableSkillReferences]);
 
   useEffect(() => {
-    if (editor && enableSkillReferences && onAddCapability) {
-      onAddCapability(handleAddCapability);
+    if (editor && enableSkillReferences && onOpenCapabilities) {
+      onOpenCapabilities(handleOpenCapabilities);
     }
-  }, [editor, enableSkillReferences, handleAddCapability, onAddCapability]);
+  }, [
+    editor,
+    enableSkillReferences,
+    handleOpenCapabilities,
+    onOpenCapabilities,
+  ]);
 
   // Register a callback that the suggestions panel can call to accept a
   // suggestion directly via the editor's ProseMirror commands.

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -268,7 +268,7 @@ export function SkillBuilderInstructionsEditor({
       return;
     }
 
-    editor.chain().focus().insertContent("/").run();
+    editor.commands.openCapabilitiesSlashCommand();
   }, [editor, enableSkillReferences]);
 
   useEffect(() => {

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -1,4 +1,5 @@
 import { editorVariants } from "@app/components/editor/editorStyles";
+import type { SkillNodeAttributes } from "@app/components/editor/extensions/input_bar/SkillNode";
 import { KNOWLEDGE_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
 import type { KnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
 import {
@@ -86,11 +87,17 @@ function sanitizeSkillInstructionsHtml(
 
 const INSTRUCTIONS_EDITOR_SIZE = "min-h-60 max-h-[1024px]";
 
+export type SkillBuilderCapability = SkillNodeAttributes;
+
 interface SkillBuilderInstructionsEditorProps {
+  onAddCapability?: (
+    addCapability: (capability: SkillBuilderCapability) => void
+  ) => void;
   onAddKnowledge?: (addKnowledge: () => void) => void;
 }
 
 export function SkillBuilderInstructionsEditor({
+  onAddCapability,
   onAddKnowledge,
 }: SkillBuilderInstructionsEditorProps) {
   const { compareVersion, isDiffMode } = useSkillVersionComparisonContext();
@@ -260,6 +267,23 @@ export function SkillBuilderInstructionsEditor({
       onAddKnowledge(handleAddKnowledge);
     }
   }, [editor, handleAddKnowledge, onAddKnowledge]);
+
+  const handleAddCapability = useCallback(
+    (capability: SkillBuilderCapability) => {
+      if (!editor || !enableSkillReferences) {
+        return;
+      }
+
+      editor.chain().focus().insertSkillNode(capability).run();
+    },
+    [editor, enableSkillReferences]
+  );
+
+  useEffect(() => {
+    if (editor && enableSkillReferences && onAddCapability) {
+      onAddCapability(handleAddCapability);
+    }
+  }, [editor, enableSkillReferences, handleAddCapability, onAddCapability]);
 
   // Register a callback that the suggestions panel can call to accept a
   // suggestion directly via the editor's ProseMirror commands.

--- a/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
@@ -1,14 +1,27 @@
+import type { SlashCommand } from "@app/components/editor/extensions/skill_builder/SlashCommandDropdown";
+import { buildSkillBuilderSlashCommandItems } from "@app/components/editor/extensions/skill_builder/SlashCommandExtension";
+import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
-import { SkillBuilderInstructionsEditor } from "@app/components/skill_builder/SkillBuilderInstructionsEditor";
+import {
+  type SkillBuilderCapability,
+  SkillBuilderInstructionsEditor,
+} from "@app/components/skill_builder/SkillBuilderInstructionsEditor";
 import { useSkillVersionComparisonContext } from "@app/components/skill_builder/SkillBuilderVersionContext";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useSkills } from "@app/lib/swr/skill_configurations";
 import {
   ArrowGoBackIcon,
   BookOpenIcon,
   Button,
   ContentMessage,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   InformationCircleIcon,
+  ToolsIcon,
 } from "@dust-tt/sparkle";
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import { useFormContext } from "react-hook-form";
 
 const LARGE_INSTRUCTIONS_CHARACTER_THRESHOLD = 40_000;
@@ -16,14 +29,123 @@ const LARGE_INSTRUCTIONS_CHARACTER_THRESHOLD = 40_000;
 const INSTRUCTIONS_FIELD_NAME = "instructions";
 const INSTRUCTIONS_HTML_FIELD_NAME = "instructionsHtml";
 
+interface SkillBuilderCapabilitiesDropdownProps {
+  disabled: boolean;
+  emptyMessage: string;
+  isOpen: boolean;
+  items: SlashCommand[];
+  onItemSelect: (item: SlashCommand) => void;
+  onOpenChange: (isOpen: boolean) => void;
+}
+
+function SkillBuilderCapabilitiesDropdown({
+  disabled,
+  emptyMessage,
+  isOpen,
+  items,
+  onItemSelect,
+  onOpenChange,
+}: SkillBuilderCapabilitiesDropdownProps) {
+  return (
+    <DropdownMenu open={isOpen} onOpenChange={onOpenChange}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="primary"
+          label="Attach capabilities"
+          icon={ToolsIcon}
+          disabled={disabled}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-80" align="end">
+        {items.length === 0 ? (
+          <div className="px-2 py-4 text-center text-sm text-muted-foreground dark:text-muted-foreground-night">
+            {emptyMessage}
+          </div>
+        ) : (
+          items.map((item, index) => {
+            const sectionLabel =
+              item.sectionLabel &&
+              items[index - 1]?.sectionLabel !== item.sectionLabel
+                ? item.sectionLabel
+                : undefined;
+            const menuItem = (
+              <DropdownMenuItem
+                icon={item.icon}
+                itemId={item.id}
+                label={item.label}
+                description={item.description}
+                truncateText
+                onClick={() => onItemSelect(item)}
+              />
+            );
+
+            return (
+              <Fragment key={item.id}>
+                {sectionLabel ? (
+                  <div className="px-3 py-2 text-xs font-semibold text-muted-foreground dark:text-muted-foreground-night">
+                    {sectionLabel}
+                  </div>
+                ) : null}
+                {menuItem}
+              </Fragment>
+            );
+          })
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 export function SkillBuilderInstructionsSection() {
   const { setValue, watch } = useFormContext<SkillBuilderFormData>();
+  const { owner, skillId } = useSkillBuilderContext();
   const { compareVersion, exitDiffMode } = useSkillVersionComparisonContext();
+  const { hasFeature } = useFeatureFlags();
   const [addKnowledge, setAddKnowledge] = useState<(() => void) | null>(null);
+  const [addCapability, setAddCapability] = useState<
+    ((capability: SkillBuilderCapability) => void) | null
+  >(null);
+  const [isCapabilitiesDropdownOpen, setIsCapabilitiesDropdownOpen] =
+    useState(false);
+
+  const enableSkillReferences = hasFeature("nested_skills");
+  const { skills, isSkillsError, isSkillsLoading } = useSkills({
+    disabled:
+      !!compareVersion || !isCapabilitiesDropdownOpen || !enableSkillReferences,
+    owner,
+    status: "active",
+  });
 
   const currentInstructions = watch(INSTRUCTIONS_FIELD_NAME);
   const instructionsDiffer =
     compareVersion && compareVersion.instructions !== currentInstructions;
+  const capabilityItems = buildSkillBuilderSlashCommandItems({
+    baseItems: [],
+    currentSkillId: skillId,
+    includeSkillSuggestions: enableSkillReferences,
+    query: "",
+    skills,
+  });
+
+  const handleCapabilitySelect = (item: SlashCommand) => {
+    const skill = item.data?.skill;
+    if (!skill || !addCapability) {
+      return;
+    }
+
+    addCapability({
+      skillIcon: skill.icon,
+      skillId: skill.id,
+      skillName: skill.name,
+    });
+    setIsCapabilitiesDropdownOpen(false);
+  };
+
+  const capabilitiesDropdownEmptyMessage = isSkillsLoading
+    ? "Loading capabilities…"
+    : isSkillsError
+      ? "Unable to load capabilities"
+      : "No capabilities found";
 
   const restoreInstructions = () => {
     if (!compareVersion) {
@@ -60,11 +182,21 @@ export function SkillBuilderInstructionsSection() {
           )}
           {!compareVersion && (
             <Button
-              variant="primary"
+              variant={enableSkillReferences ? "outline" : "primary"}
               label="Attach knowledge"
               icon={BookOpenIcon}
               onClick={addKnowledge ?? undefined}
               disabled={!addKnowledge}
+            />
+          )}
+          {!compareVersion && enableSkillReferences && (
+            <SkillBuilderCapabilitiesDropdown
+              disabled={!addCapability}
+              emptyMessage={capabilitiesDropdownEmptyMessage}
+              isOpen={isCapabilitiesDropdownOpen}
+              items={capabilityItems}
+              onItemSelect={handleCapabilitySelect}
+              onOpenChange={setIsCapabilitiesDropdownOpen}
             />
           )}
         </div>
@@ -82,6 +214,7 @@ export function SkillBuilderInstructionsSection() {
         </ContentMessage>
       )}
       <SkillBuilderInstructionsEditor
+        onAddCapability={(fn) => setAddCapability(() => fn)}
         onAddKnowledge={(fn) => setAddKnowledge(() => fn)}
       />
     </section>

--- a/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
@@ -1,27 +1,16 @@
-import type { SlashCommand } from "@app/components/editor/extensions/skill_builder/SlashCommandDropdown";
-import { buildSkillBuilderSlashCommandItems } from "@app/components/editor/extensions/skill_builder/SlashCommandExtension";
-import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
-import {
-  type SkillBuilderCapability,
-  SkillBuilderInstructionsEditor,
-} from "@app/components/skill_builder/SkillBuilderInstructionsEditor";
+import { SkillBuilderInstructionsEditor } from "@app/components/skill_builder/SkillBuilderInstructionsEditor";
 import { useSkillVersionComparisonContext } from "@app/components/skill_builder/SkillBuilderVersionContext";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
-import { useSkills } from "@app/lib/swr/skill_configurations";
 import {
   ArrowGoBackIcon,
   BookOpenIcon,
   Button,
   ContentMessage,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
   InformationCircleIcon,
   ToolsIcon,
 } from "@dust-tt/sparkle";
-import { Fragment, useState } from "react";
+import { useState } from "react";
 import { useFormContext } from "react-hook-form";
 
 const LARGE_INSTRUCTIONS_CHARACTER_THRESHOLD = 40_000;
@@ -29,123 +18,20 @@ const LARGE_INSTRUCTIONS_CHARACTER_THRESHOLD = 40_000;
 const INSTRUCTIONS_FIELD_NAME = "instructions";
 const INSTRUCTIONS_HTML_FIELD_NAME = "instructionsHtml";
 
-interface SkillBuilderCapabilitiesDropdownProps {
-  disabled: boolean;
-  emptyMessage: string;
-  isOpen: boolean;
-  items: SlashCommand[];
-  onItemSelect: (item: SlashCommand) => void;
-  onOpenChange: (isOpen: boolean) => void;
-}
-
-function SkillBuilderCapabilitiesDropdown({
-  disabled,
-  emptyMessage,
-  isOpen,
-  items,
-  onItemSelect,
-  onOpenChange,
-}: SkillBuilderCapabilitiesDropdownProps) {
-  return (
-    <DropdownMenu open={isOpen} onOpenChange={onOpenChange}>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="primary"
-          label="Attach capabilities"
-          icon={ToolsIcon}
-          disabled={disabled}
-        />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent className="w-80" align="end">
-        {items.length === 0 ? (
-          <div className="px-2 py-4 text-center text-sm text-muted-foreground dark:text-muted-foreground-night">
-            {emptyMessage}
-          </div>
-        ) : (
-          items.map((item, index) => {
-            const sectionLabel =
-              item.sectionLabel &&
-              items[index - 1]?.sectionLabel !== item.sectionLabel
-                ? item.sectionLabel
-                : undefined;
-            const menuItem = (
-              <DropdownMenuItem
-                icon={item.icon}
-                itemId={item.id}
-                label={item.label}
-                description={item.description}
-                truncateText
-                onClick={() => onItemSelect(item)}
-              />
-            );
-
-            return (
-              <Fragment key={item.id}>
-                {sectionLabel ? (
-                  <div className="px-3 py-2 text-xs font-semibold text-muted-foreground dark:text-muted-foreground-night">
-                    {sectionLabel}
-                  </div>
-                ) : null}
-                {menuItem}
-              </Fragment>
-            );
-          })
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
-
 export function SkillBuilderInstructionsSection() {
   const { setValue, watch } = useFormContext<SkillBuilderFormData>();
-  const { owner, skillId } = useSkillBuilderContext();
   const { compareVersion, exitDiffMode } = useSkillVersionComparisonContext();
   const { hasFeature } = useFeatureFlags();
   const [addKnowledge, setAddKnowledge] = useState<(() => void) | null>(null);
-  const [addCapability, setAddCapability] = useState<
-    ((capability: SkillBuilderCapability) => void) | null
-  >(null);
-  const [isCapabilitiesDropdownOpen, setIsCapabilitiesDropdownOpen] =
-    useState(false);
+  const [openCapabilities, setOpenCapabilities] = useState<(() => void) | null>(
+    null
+  );
 
   const enableSkillReferences = hasFeature("nested_skills");
-  const { skills, isSkillsError, isSkillsLoading } = useSkills({
-    disabled:
-      !!compareVersion || !isCapabilitiesDropdownOpen || !enableSkillReferences,
-    owner,
-    status: "active",
-  });
 
   const currentInstructions = watch(INSTRUCTIONS_FIELD_NAME);
   const instructionsDiffer =
     compareVersion && compareVersion.instructions !== currentInstructions;
-  const capabilityItems = buildSkillBuilderSlashCommandItems({
-    baseItems: [],
-    currentSkillId: skillId,
-    includeSkillSuggestions: enableSkillReferences,
-    query: "",
-    skills,
-  });
-
-  const handleCapabilitySelect = (item: SlashCommand) => {
-    const skill = item.data?.skill;
-    if (!skill || !addCapability) {
-      return;
-    }
-
-    addCapability({
-      skillIcon: skill.icon,
-      skillId: skill.id,
-      skillName: skill.name,
-    });
-    setIsCapabilitiesDropdownOpen(false);
-  };
-
-  const capabilitiesDropdownEmptyMessage = isSkillsLoading
-    ? "Loading capabilities…"
-    : isSkillsError
-      ? "Unable to load capabilities"
-      : "No capabilities found";
 
   const restoreInstructions = () => {
     if (!compareVersion) {
@@ -190,13 +76,12 @@ export function SkillBuilderInstructionsSection() {
             />
           )}
           {!compareVersion && enableSkillReferences && (
-            <SkillBuilderCapabilitiesDropdown
-              disabled={!addCapability}
-              emptyMessage={capabilitiesDropdownEmptyMessage}
-              isOpen={isCapabilitiesDropdownOpen}
-              items={capabilityItems}
-              onItemSelect={handleCapabilitySelect}
-              onOpenChange={setIsCapabilitiesDropdownOpen}
+            <Button
+              variant="primary"
+              label="Attach capabilities"
+              icon={ToolsIcon}
+              onClick={openCapabilities ?? undefined}
+              disabled={!openCapabilities}
             />
           )}
         </div>
@@ -214,8 +99,8 @@ export function SkillBuilderInstructionsSection() {
         </ContentMessage>
       )}
       <SkillBuilderInstructionsEditor
-        onAddCapability={(fn) => setAddCapability(() => fn)}
         onAddKnowledge={(fn) => setAddKnowledge(() => fn)}
+        onOpenCapabilities={(fn) => setOpenCapabilities(() => fn)}
       />
     </section>
   );


### PR DESCRIPTION
## Description

This PR adds an `Attach capabilities` button next to `Attach knowledge` in the Skill Builder instructions header when nested skills are enabled.

The button opens a small dropdown of active skills, reusing the existing Skill Builder slash-command item construction. Selecting a capability inserts the same skill node format that the slash command path already uses. The skills list is only loaded while the dropdown is open.

<img width="913" height="473" alt="image" src="https://github.com/user-attachments/assets/9ca90df1-3600-4aba-83b2-c07a58d5ae7f" />

## Tests

- Covered by existing tests.

## Risk

- Low. Behind the nested skills feature flag.

## Deploy Plan

- Deploy front.
