### PR TITLE
[front] feat: add read-only references section in Skill Builder instructions

### DIFF
--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -8,6 +8,7 @@ import {
 import { SKILL_BUILDER_INSTRUCTIONS_BLUR_EVENT } from "@app/components/skill_builder/events";
 import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
+import { SkillBuilderInstructionsReferenceSummary } from "@app/components/skill_builder/SkillBuilderInstructionsReferenceSummary";
 import { useSkillVersionComparisonContext } from "@app/components/skill_builder/SkillBuilderVersionContext";
 import { useSkillSuggestions } from "@app/hooks/useSkillSuggestions";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
@@ -22,7 +23,7 @@ import type { Config } from "dompurify";
 import DOMPurify from "dompurify";
 import debounce from "lodash/debounce";
 import { useCallback, useEffect, useMemo, useRef } from "react";
-import { useController, useFormContext } from "react-hook-form";
+import { useController, useFormContext, useWatch } from "react-hook-form";
 
 const INSTRUCTIONS_FIELD_NAME = "instructions";
 const INSTRUCTIONS_HTML_FIELD_NAME = "instructionsHtml";
@@ -94,7 +95,7 @@ export function SkillBuilderInstructionsEditor({
   onAddKnowledge,
 }: SkillBuilderInstructionsEditorProps) {
   const { compareVersion, isDiffMode } = useSkillVersionComparisonContext();
-  const { resetField } = useFormContext<SkillBuilderFormData>();
+  const { control, resetField } = useFormContext<SkillBuilderFormData>();
   const initializedAttachedKnowledgeEditorRef = useRef<Editor | null>(null);
   const { owner, skillId, selectedSuggestionId, setAcceptInstructionEdits } =
     useSkillBuilderContext();
@@ -123,9 +124,16 @@ export function SkillBuilderInstructionsEditor({
       name: ATTACHED_KNOWLEDGE_FIELD_NAME,
     }
   );
+  const tools = useWatch({ control, name: "tools" }) ?? [];
 
   const displayError =
     !!instructionsFieldState.error || !!attachedKnowledgeFieldState.error;
+  const hasInstructionReferenceSummary =
+    (attachedKnowledgeField.value?.length ?? 0) > 0 ||
+    tools.length > 0 ||
+    (instructionsField.value?.includes("<knowledge ") ?? false) ||
+    (instructionsField.value?.includes("<skill ") ?? false) ||
+    (instructionsField.value?.includes("<tool ") ?? false);
 
   const syncAttachedKnowledgeFromEditor = useCallback(
     (editor: Editor) => {
@@ -383,12 +391,19 @@ export function SkillBuilderInstructionsEditor({
               disabled: isDiffMode,
               readOnly: hasSuggestions,
             }),
-            INSTRUCTIONS_EDITOR_SIZE
+            INSTRUCTIONS_EDITOR_SIZE,
+            hasInstructionReferenceSummary && "pb-36"
           ),
         },
       },
     });
-  }, [editor, displayError, isDiffMode, hasSuggestions]);
+  }, [
+    editor,
+    displayError,
+    isDiffMode,
+    hasSuggestions,
+    hasInstructionReferenceSummary,
+  ]);
 
   // Sync external changes to the editor content
   useEffect(() => {
@@ -488,10 +503,17 @@ export function SkillBuilderInstructionsEditor({
 
   return (
     <div className="space-y-1 p-px">
-      <SkillInstructionsEditorContent
-        editor={editor}
-        isReadOnly={hasSuggestions}
-      />
+      <div className="relative overflow-hidden rounded-xl">
+        <SkillInstructionsEditorContent
+          editor={editor}
+          isReadOnly={hasSuggestions}
+        />
+        <SkillBuilderInstructionsReferenceSummary
+          attachedKnowledge={attachedKnowledgeField.value}
+          instructions={instructionsField.value ?? ""}
+          tools={tools}
+        />
+      </div>
 
       {instructionsFieldState.error && (
         <div className="dark:text-warning-night ml-2 text-xs text-warning">

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -129,11 +129,12 @@ export function SkillBuilderInstructionsEditor({
   const displayError =
     !!instructionsFieldState.error || !!attachedKnowledgeFieldState.error;
   const hasInstructionReferenceSummary =
-    (attachedKnowledgeField.value?.length ?? 0) > 0 ||
-    tools.length > 0 ||
-    (instructionsField.value?.includes("<knowledge ") ?? false) ||
-    (instructionsField.value?.includes("<skill ") ?? false) ||
-    (instructionsField.value?.includes("<tool ") ?? false);
+    enableSkillReferences &&
+    ((attachedKnowledgeField.value?.length ?? 0) > 0 ||
+      tools.length > 0 ||
+      (instructionsField.value?.includes("<knowledge ") ?? false) ||
+      (instructionsField.value?.includes("<skill ") ?? false) ||
+      (instructionsField.value?.includes("<tool ") ?? false));
 
   const syncAttachedKnowledgeFromEditor = useCallback(
     (editor: Editor) => {
@@ -508,11 +509,13 @@ export function SkillBuilderInstructionsEditor({
           editor={editor}
           isReadOnly={hasSuggestions}
         />
-        <SkillBuilderInstructionsReferenceSummary
-          attachedKnowledge={attachedKnowledgeField.value}
-          instructions={instructionsField.value ?? ""}
-          tools={tools}
-        />
+        {enableSkillReferences && (
+          <SkillBuilderInstructionsReferenceSummary
+            attachedKnowledge={attachedKnowledgeField.value}
+            instructions={instructionsField.value ?? ""}
+            tools={tools}
+          />
+        )}
       </div>
 
       {instructionsFieldState.error && (

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -6,6 +6,7 @@ import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { getSkillIcon } from "@app/lib/skill";
 import { extractSkillTags } from "@app/lib/skills/format";
 import { extractToolTags } from "@app/lib/tools/format";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { AttachmentChip, Chip, cn, DocumentIcon } from "@dust-tt/sparkle";
 import { useMemo } from "react";
 
@@ -14,6 +15,25 @@ interface SkillBuilderInstructionsReferenceSummaryProps {
   instructions: string;
   tools: BuilderAction[];
 }
+
+type ReferenceSummaryItem =
+  | {
+      id: string;
+      kind: "knowledge";
+      title: string;
+    }
+  | {
+      icon: string | null;
+      id: string;
+      kind: "skill";
+      title: string;
+    }
+  | {
+      icon: string | null;
+      id: string;
+      kind: "tool";
+      title: string;
+    };
 
 function dedupeById<T extends { id: string }>(items: T[]): T[] {
   const seenIds = new Set<string>();
@@ -26,6 +46,53 @@ function dedupeById<T extends { id: string }>(items: T[]): T[] {
     seenIds.add(item.id);
     return true;
   });
+}
+
+function compareReferenceSummaryItems(
+  a: ReferenceSummaryItem,
+  b: ReferenceSummaryItem
+) {
+  return (
+    a.title.localeCompare(b.title, undefined, { sensitivity: "base" }) ||
+    a.kind.localeCompare(b.kind) ||
+    a.id.localeCompare(b.id)
+  );
+}
+
+function renderReferenceSummaryItem(item: ReferenceSummaryItem) {
+  switch (item.kind) {
+    case "knowledge":
+      return (
+        <AttachmentChip
+          key={`${item.kind}:${item.id}`}
+          label={item.title}
+          icon={{ visual: DocumentIcon }}
+          color="white"
+          size="xs"
+        />
+      );
+    case "skill":
+      return (
+        <Chip
+          key={`${item.kind}:${item.id}`}
+          label={item.title}
+          icon={getSkillIcon(item.icon)}
+          color="white"
+          size="xs"
+        />
+      );
+    case "tool":
+      return (
+        <ToolChip
+          key={`${item.kind}:${item.id}`}
+          title={item.title}
+          toolIcon={item.icon}
+          color="white"
+        />
+      );
+    default:
+      return assertNever(item);
+  }
 }
 
 export function SkillBuilderInstructionsReferenceSummary({
@@ -104,12 +171,32 @@ export function SkillBuilderInstructionsReferenceSummary({
     ...selectedToolReferences,
   ]);
 
-  const hasReferences =
-    knowledgeReferences.length > 0 ||
-    skillReferences.length > 0 ||
-    toolReferences.length > 0;
+  const referenceItems = useMemo(
+    () =>
+      [
+        ...knowledgeReferences.map(
+          (item): ReferenceSummaryItem => ({
+            ...item,
+            kind: "knowledge",
+          })
+        ),
+        ...skillReferences.map(
+          (skill): ReferenceSummaryItem => ({
+            ...skill,
+            kind: "skill",
+          })
+        ),
+        ...toolReferences.map(
+          (tool): ReferenceSummaryItem => ({
+            ...tool,
+            kind: "tool",
+          })
+        ),
+      ].toSorted(compareReferenceSummaryItems),
+    [knowledgeReferences, skillReferences, toolReferences]
+  );
 
-  if (!hasReferences) {
+  if (referenceItems.length === 0) {
     return null;
   }
 
@@ -125,32 +212,7 @@ export function SkillBuilderInstructionsReferenceSummary({
         Capabilities and knowledge
       </div>
       <div className="flex flex-wrap gap-2">
-        {skillReferences.map((skill) => (
-          <Chip
-            key={skill.id}
-            label={skill.title}
-            icon={getSkillIcon(skill.icon)}
-            color="white"
-            size="xs"
-          />
-        ))}
-        {knowledgeReferences.map((item) => (
-          <AttachmentChip
-            key={item.id}
-            label={item.title}
-            icon={{ visual: DocumentIcon }}
-            color="white"
-            size="xs"
-          />
-        ))}
-        {toolReferences.map((tool) => (
-          <ToolChip
-            key={tool.id}
-            title={tool.title}
-            toolIcon={tool.icon}
-            color="white"
-          />
-        ))}
+        {referenceItems.map(renderReferenceSummaryItem)}
       </div>
     </div>
   );

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -208,7 +208,7 @@ export function SkillBuilderInstructionsReferenceSummary({
         "dark:border-border-night/70 dark:bg-background-night/75"
       )}
     >
-      <div className="mb-2 text-sm font-semibold text-foreground dark:text-foreground-night">
+      <div className="mb-2 text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
         Capabilities and knowledge
       </div>
       <div className="flex flex-wrap gap-2">

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -1,0 +1,157 @@
+import { ToolChip } from "@app/components/editor/extensions/skill_builder/ToolChip";
+import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
+import type { BuilderAction } from "@app/components/shared/tools_picker/types";
+import type { AttachedKnowledgeFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
+import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
+import { getSkillIcon } from "@app/lib/skill";
+import { extractSkillTags } from "@app/lib/skills/format";
+import { extractToolTags } from "@app/lib/tools/format";
+import { AttachmentChip, Chip, cn, DocumentIcon } from "@dust-tt/sparkle";
+import { useMemo } from "react";
+
+interface SkillBuilderInstructionsReferenceSummaryProps {
+  attachedKnowledge?: AttachedKnowledgeFormData[];
+  instructions: string;
+  tools: BuilderAction[];
+}
+
+function dedupeById<T extends { id: string }>(items: T[]): T[] {
+  const seenIds = new Set<string>();
+
+  return items.filter((item) => {
+    if (seenIds.has(item.id)) {
+      return false;
+    }
+
+    seenIds.add(item.id);
+    return true;
+  });
+}
+
+export function SkillBuilderInstructionsReferenceSummary({
+  attachedKnowledge,
+  instructions,
+  tools,
+}: SkillBuilderInstructionsReferenceSummaryProps) {
+  const { mcpServerViews, isMCPServerViewsLoading } =
+    useMCPServerViewsContext();
+
+  const knowledgeReferences = useMemo(
+    () =>
+      dedupeById(
+        (attachedKnowledge ?? []).map((item) => ({
+          id: `${item.dataSourceViewId}:${item.nodeId}`,
+          title: item.title,
+        }))
+      ),
+    [attachedKnowledge]
+  );
+
+  const skillReferences = useMemo(
+    () =>
+      dedupeById(
+        extractSkillTags(instructions).map((skill) => ({
+          icon: skill.icon,
+          id: skill.id,
+          title: skill.name,
+        }))
+      ),
+    [instructions]
+  );
+
+  const inlineToolReferences = useMemo(
+    () =>
+      dedupeById(
+        extractToolTags(instructions).map((tool) => {
+          const view = isMCPServerViewsLoading
+            ? null
+            : (mcpServerViews.find((v) => v.sId === tool.id) ?? null);
+
+          return {
+            icon: view?.server.icon ?? tool.icon,
+            id: tool.id,
+            title: view ? getMcpServerViewDisplayName(view) : tool.name,
+          };
+        })
+      ),
+    [instructions, isMCPServerViewsLoading, mcpServerViews]
+  );
+
+  const selectedToolReferences = useMemo(() => {
+    if (isMCPServerViewsLoading) {
+      return tools.map((tool) => ({
+        icon: null,
+        id: tool.configuration.mcpServerViewId,
+        title: tool.name,
+      }));
+    }
+
+    return tools.map((tool) => {
+      const view = mcpServerViews.find(
+        (v) => v.sId === tool.configuration.mcpServerViewId
+      );
+
+      return {
+        icon: view?.server.icon ?? null,
+        id: tool.configuration.mcpServerViewId,
+        title: view ? getMcpServerViewDisplayName(view, tool) : tool.name,
+      };
+    });
+  }, [isMCPServerViewsLoading, mcpServerViews, tools]);
+
+  const toolReferences = dedupeById([
+    ...inlineToolReferences,
+    ...selectedToolReferences,
+  ]);
+
+  const hasReferences =
+    knowledgeReferences.length > 0 ||
+    skillReferences.length > 0 ||
+    toolReferences.length > 0;
+
+  if (!hasReferences) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        "absolute inset-x-px bottom-px z-10 max-h-40 overflow-y-auto rounded-b-xl border-t px-3 pb-3 pt-3",
+        "border-border/70 bg-background/75 shadow-[0_-12px_24px_rgba(0,0,0,0.08)] backdrop-blur-md",
+        "dark:border-border-night/70 dark:bg-background-night/75"
+      )}
+    >
+      <div className="mb-2 text-sm font-semibold text-foreground dark:text-foreground-night">
+        Capabilities and knowledge
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {skillReferences.map((skill) => (
+          <Chip
+            key={skill.id}
+            label={skill.title}
+            icon={getSkillIcon(skill.icon)}
+            color="white"
+            size="xs"
+          />
+        ))}
+        {knowledgeReferences.map((item) => (
+          <AttachmentChip
+            key={item.id}
+            label={item.title}
+            icon={{ visual: DocumentIcon }}
+            color="white"
+            size="xs"
+          />
+        ))}
+        {toolReferences.map((tool) => (
+          <ToolChip
+            key={tool.id}
+            title={tool.title}
+            toolIcon={tool.icon}
+            color="white"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -208,7 +208,7 @@ export function SkillBuilderInstructionsReferenceSummary({
         "dark:border-border-night/70 dark:bg-background-night/75"
       )}
     >
-      <div className="mb-2 text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
+      <div className="mb-2 text-sm font-medium text-foreground dark:text-foreground-night">
         Capabilities and knowledge
       </div>
       <div className="flex flex-wrap gap-2">

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -204,7 +204,7 @@ export function SkillBuilderInstructionsReferenceSummary({
     <div
       className={cn(
         "absolute inset-x-px bottom-px z-10 max-h-40 overflow-y-auto rounded-b-xl border-t px-3 pb-3 pt-3",
-        "border-border/70 bg-background/75 shadow-[0_-12px_24px_rgba(0,0,0,0.08)] backdrop-blur-md",
+        "border-border/70 bg-background/75 shadow-[0_-12px_24px_rgba(0,0,0,0.08)] backdrop-blur-sm",
         "dark:border-border-night/70 dark:bg-background-night/75"
       )}
     >


### PR DESCRIPTION
## Description

This PR adds an anchored read-only footer to the Skill Builder instructions editor, behind `nested_skills`, that repeats the knowledge, skill, and tool references currently attached to the skill. The footer keeps those chips visible while editing long instructions and reserves bottom padding so it does not cover content.

The displayed chips are deduped and sorted alphabetically across reference types. Knowledge comes from the existing attached knowledge form state, selected tools from the existing tools form state, and inline skill/tool references from the serialized instruction content. The tools extraction is intentionally narrow for now since the tools model is expected to change soon.

<img width="892" height="979" alt="image" src="https://github.com/user-attachments/assets/5218306a-4e6f-4ff1-8c89-31aa514b8245" />

## Tests

- Tested locally.

## Risk

- Low. Front-only Skill Builder UI change.

## Deploy Plan

- Deploy front.
