### PR TITLE
[dust-hive] enh: filter completions by environment state

### DIFF
--- a/x/henry/dust-hive/completions/dust-hive.bash
+++ b/x/henry/dust-hive/completions/dust-hive.bash
@@ -70,6 +70,48 @@ _dust_hive_envs() {
   printf '%s\n' "${result[@]}"
 }
 
+_dust_hive_envs_by_state() {
+  local desired_state="${1:?usage: _dust_hive_envs_by_state <state>}"
+  local envs=()
+  local name
+
+  while IFS= read -r name; do
+    [[ -n "$name" ]] && envs+=("$name")
+  done < <(
+    command dust-hive list 2>/dev/null | awk -v desired_state="$desired_state" '
+      /^[[:space:]]*$/ { next }
+      /^NAME[[:space:]]/ { next }
+      /^-+/ { next }
+      $2 == desired_state { print $1 }
+    '
+  )
+
+  local current
+  current="$(_dust_hive_current_env)"
+
+  local result=()
+  if [[ -n "$current" ]]; then
+    for name in "${envs[@]}"; do
+      [[ "$name" == "$current" ]] && result+=("$name")
+    done
+    for name in "${envs[@]}"; do
+      [[ "$name" != "$current" ]] && result+=("$name")
+    done
+  else
+    result=("${envs[@]}")
+  fi
+
+  printf '%s\n' "${result[@]}"
+}
+
+_dust_hive_warmable_envs() {
+  _dust_hive_envs_by_state cold
+}
+
+_dust_hive_coolable_envs() {
+  _dust_hive_envs_by_state warm
+}
+
 _dust_hive_complete() {
   local cur prev words cword
   _init_completion 2>/dev/null || {
@@ -150,11 +192,20 @@ _dust_hive_complete() {
           COMPREPLY=($(compgen -W "-F --no-forward -p --force-ports" -- "$cur"))
           ;;
         *)
-          COMPREPLY=($(compgen -W "$(_dust_hive_envs)" -- "$cur"))
+          COMPREPLY=($(compgen -W "$(_dust_hive_warmable_envs)" -- "$cur"))
           ;;
       esac
       ;;
-    cool|c|start)
+    cool|c)
+      case "$cur" in
+        -*)
+          ;;
+        *)
+          COMPREPLY=($(compgen -W "$(_dust_hive_coolable_envs)" -- "$cur"))
+          ;;
+      esac
+      ;;
+    start)
       case "$cur" in
         -*)
           ;;

--- a/x/henry/dust-hive/completions/dust-hive.bash
+++ b/x/henry/dust-hive/completions/dust-hive.bash
@@ -70,19 +70,26 @@ _dust_hive_envs() {
   printf '%s\n' "${result[@]}"
 }
 
-_dust_hive_envs_by_state() {
-  local desired_state="${1:?usage: _dust_hive_envs_by_state <state>}"
+_dust_hive_envs_by_states() {
+  local desired_states=("$@")
+  [[ ${#desired_states[@]} -gt 0 ]] || return
   local envs=()
   local name
 
   while IFS= read -r name; do
     [[ -n "$name" ]] && envs+=("$name")
   done < <(
-    command dust-hive list 2>/dev/null | awk -v desired_state="$desired_state" '
+    command dust-hive list 2>/dev/null | awk -v desired_states="${desired_states[*]}" '
+      BEGIN {
+        split(desired_states, states, " ")
+        for (i in states) {
+          state_set[states[i]] = 1
+        }
+      }
       /^[[:space:]]*$/ { next }
       /^NAME[[:space:]]/ { next }
       /^-+/ { next }
-      $2 == desired_state { print $1 }
+      state_set[$2] { print $1 }
     '
   )
 
@@ -105,11 +112,23 @@ _dust_hive_envs_by_state() {
 }
 
 _dust_hive_warmable_envs() {
-  _dust_hive_envs_by_state cold
+  _dust_hive_envs_by_states cold
+}
+
+_dust_hive_warm_envs() {
+  _dust_hive_envs_by_states warm
 }
 
 _dust_hive_coolable_envs() {
-  _dust_hive_envs_by_state warm
+  _dust_hive_warm_envs
+}
+
+_dust_hive_startable_envs() {
+  _dust_hive_envs_by_states stopped
+}
+
+_dust_hive_stoppable_envs() {
+  _dust_hive_envs_by_states cold warm
 }
 
 _dust_hive_complete() {
@@ -210,7 +229,7 @@ _dust_hive_complete() {
         -*)
           ;;
         *)
-          COMPREPLY=($(compgen -W "$(_dust_hive_envs)" -- "$cur"))
+          COMPREPLY=($(compgen -W "$(_dust_hive_startable_envs)" -- "$cur"))
           ;;
       esac
       ;;
@@ -221,7 +240,7 @@ _dust_hive_complete() {
         [[ "${COMP_WORDS[$i]}" != -* ]] && (( pos++ ))
       done
       if (( pos == 0 )); then
-        COMPREPLY=($(compgen -W "$(_dust_hive_envs)" -- "$cur"))
+        COMPREPLY=($(compgen -W "$(_dust_hive_stoppable_envs)" -- "$cur"))
       elif (( pos == 1 )); then
         COMPREPLY=($(compgen -W "${_dust_hive_services[*]}" -- "$cur"))
       fi
@@ -307,7 +326,7 @@ _dust_hive_complete() {
         [[ "${COMP_WORDS[$i]}" != -* ]] && (( pos++ ))
       done
       if (( pos == 0 )); then
-        COMPREPLY=($(compgen -W "$(_dust_hive_envs)" -- "$cur"))
+        COMPREPLY=($(compgen -W "$(_dust_hive_warm_envs)" -- "$cur"))
       fi
       ;;
     flag)
@@ -321,7 +340,7 @@ _dust_hive_complete() {
             [[ "${COMP_WORDS[$i]}" != -* ]] && (( pos++ ))
           done
           if (( pos == 0 )); then
-            COMPREPLY=($(compgen -W "$(_dust_hive_envs)" -- "$cur"))
+            COMPREPLY=($(compgen -W "$(_dust_hive_warm_envs)" -- "$cur"))
           fi
           ;;
       esac

--- a/x/henry/dust-hive/completions/dust-hive.bash
+++ b/x/henry/dust-hive/completions/dust-hive.bash
@@ -22,6 +22,8 @@
 #   dhcd  - cd into environment worktree (changes dir in current shell)
 
 _dust_hive_services=(sdk sparkle front core oauth connectors front-workers front-spa-poke front-spa-app viz)
+_dust_hive_warm_state_services=(front front-api core oauth connectors front-workers front-spa-poke front-spa-app viz)
+# Avoid invoking the Bun CLI from completion; derive state from PID files plus one Docker scan.
 
 _dust_hive_current_env() {
   # 1. Detect from cwd (inside a .hives/<name> worktree)
@@ -70,6 +72,73 @@ _dust_hive_envs() {
   printf '%s\n' "${result[@]}"
 }
 
+_dust_hive_pid_is_running() {
+  local pid_file="${1:?usage: _dust_hive_pid_is_running <pid-file>}"
+  local pid
+
+  [[ -r "$pid_file" ]] || return 1
+  IFS= read -r pid < "$pid_file" || [[ -n "$pid" ]] || return 1
+  [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+
+  kill -0 "$pid" 2>/dev/null
+}
+
+_dust_hive_service_is_running() {
+  local env_name="${1:?usage: _dust_hive_service_is_running <env> <service>}"
+  local service="${2:?usage: _dust_hive_service_is_running <env> <service>}"
+
+  _dust_hive_pid_is_running "$HOME/.dust-hive/envs/$env_name/$service.pid"
+}
+
+_dust_hive_docker_warm_envs() {
+  command docker ps --format '{{.Label "com.docker.compose.project"}}' 2>/dev/null |
+    awk '/^dust-hive-/ { sub(/^dust-hive-/, ""); print }' |
+    sort -u
+}
+
+_dust_hive_name_in_lines() {
+  local name="${1:?usage: _dust_hive_name_in_lines <name> <lines>}"
+  local lines="${2-}"
+
+  [[ "
+$lines
+" == *"
+$name
+"* ]]
+}
+
+_dust_hive_fast_state_rows() {
+  local docker_warm_envs env_dir env_name state service
+
+  [[ -d "$HOME/.dust-hive/envs" ]] || return
+
+  docker_warm_envs="$(_dust_hive_docker_warm_envs)"
+
+  while IFS= read -r env_dir; do
+    env_name="${env_dir##*/}"
+    [[ -f "$env_dir/metadata.json" ]] || continue
+
+    state="stopped"
+    if _dust_hive_name_in_lines "$env_name" "$docker_warm_envs"; then
+      state="warm"
+    elif _dust_hive_service_is_running "$env_name" "sdk" &&
+      _dust_hive_service_is_running "$env_name" "sparkle"; then
+      state="cold"
+    fi
+
+    if [[ "$state" != "warm" ]]; then
+      for service in "${_dust_hive_warm_state_services[@]}"; do
+        if _dust_hive_service_is_running "$env_name" "$service"; then
+          state="warm"
+          break
+        fi
+      done
+    fi
+
+    printf '%s %s\n' "$env_name" "$state"
+  done < <(command find "$HOME/.dust-hive/envs" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
+}
+
 _dust_hive_envs_by_states() {
   local desired_states=("$@")
   [[ ${#desired_states[@]} -gt 0 ]] || return
@@ -79,16 +148,13 @@ _dust_hive_envs_by_states() {
   while IFS= read -r name; do
     [[ -n "$name" ]] && envs+=("$name")
   done < <(
-    command dust-hive list 2>/dev/null | awk -v desired_states="${desired_states[*]}" '
+    _dust_hive_fast_state_rows | awk -v desired_states="${desired_states[*]}" '
       BEGIN {
         split(desired_states, states, " ")
         for (i in states) {
           state_set[states[i]] = 1
         }
       }
-      /^[[:space:]]*$/ { next }
-      /^NAME[[:space:]]/ { next }
-      /^-+/ { next }
       state_set[$2] { print $1 }
     '
   )

--- a/x/henry/dust-hive/completions/dust-hive.zsh
+++ b/x/henry/dust-hive/completions/dust-hive.zsh
@@ -56,6 +56,13 @@ _dust_hive_envs() {
   fi
   (( $#envs )) || return
 
+  _dust_hive_describe_envs "${envs[@]}"
+}
+
+_dust_hive_describe_envs() {
+  local -a envs=("$@")
+  (( $#envs )) || return
+
   local current
   current="$(_dust_hive_current_env)"
 
@@ -68,6 +75,30 @@ _dust_hive_envs() {
   else
     _describe -V 'environment' envs
   fi
+}
+
+_dust_hive_envs_by_state() {
+  local desired_state="${1:?usage: _dust_hive_envs_by_state <state>}"
+  local -a envs
+
+  envs=(${(f)"$(
+    command dust-hive list 2>/dev/null | awk -v desired_state="$desired_state" '
+      /^[[:space:]]*$/ { next }
+      /^NAME[[:space:]]/ { next }
+      /^-+/ { next }
+      $2 == desired_state { print $1 }
+    '
+  )"})
+
+  _dust_hive_describe_envs "${envs[@]}"
+}
+
+_dust_hive_warmable_envs() {
+  _dust_hive_envs_by_state cold
+}
+
+_dust_hive_coolable_envs() {
+  _dust_hive_envs_by_state warm
 }
 
 _dust_hive_service() {
@@ -162,14 +193,14 @@ _dust-hive() {
           ;;
         warm|w)
           _arguments \
-            '1::name:_dust_hive_envs' \
+            '1::name:_dust_hive_warmable_envs' \
             '-F[Disable OAuth port forwarding]' \
             '--no-forward[Disable OAuth port forwarding]' \
             '-p[Kill processes blocking service ports]' \
             '--force-ports[Kill processes blocking service ports]'
           ;;
         cool|c)
-          _arguments '1::name:_dust_hive_envs'
+          _arguments '1::name:_dust_hive_coolable_envs'
           ;;
         start)
           _arguments '1::name:_dust_hive_envs'

--- a/x/henry/dust-hive/completions/dust-hive.zsh
+++ b/x/henry/dust-hive/completions/dust-hive.zsh
@@ -77,16 +77,23 @@ _dust_hive_describe_envs() {
   fi
 }
 
-_dust_hive_envs_by_state() {
-  local desired_state="${1:?usage: _dust_hive_envs_by_state <state>}"
+_dust_hive_envs_by_states() {
+  (( $# )) || return
+  local desired_states="$*"
   local -a envs
 
   envs=(${(f)"$(
-    command dust-hive list 2>/dev/null | awk -v desired_state="$desired_state" '
+    command dust-hive list 2>/dev/null | awk -v desired_states="$desired_states" '
+      BEGIN {
+        split(desired_states, states, " ")
+        for (i in states) {
+          state_set[states[i]] = 1
+        }
+      }
       /^[[:space:]]*$/ { next }
       /^NAME[[:space:]]/ { next }
       /^-+/ { next }
-      $2 == desired_state { print $1 }
+      state_set[$2] { print $1 }
     '
   )"})
 
@@ -94,11 +101,23 @@ _dust_hive_envs_by_state() {
 }
 
 _dust_hive_warmable_envs() {
-  _dust_hive_envs_by_state cold
+  _dust_hive_envs_by_states cold
+}
+
+_dust_hive_warm_envs() {
+  _dust_hive_envs_by_states warm
 }
 
 _dust_hive_coolable_envs() {
-  _dust_hive_envs_by_state warm
+  _dust_hive_warm_envs
+}
+
+_dust_hive_startable_envs() {
+  _dust_hive_envs_by_states stopped
+}
+
+_dust_hive_stoppable_envs() {
+  _dust_hive_envs_by_states cold warm
 }
 
 _dust_hive_service() {
@@ -203,11 +222,11 @@ _dust-hive() {
           _arguments '1::name:_dust_hive_coolable_envs'
           ;;
         start)
-          _arguments '1::name:_dust_hive_envs'
+          _arguments '1::name:_dust_hive_startable_envs'
           ;;
         stop|x)
           _arguments \
-            '1::name:_dust_hive_envs' \
+            '1::name:_dust_hive_stoppable_envs' \
             '2::service:_dust_hive_service'
           ;;
         up)
@@ -284,12 +303,12 @@ _dust-hive() {
           ;;
         feed)
           _arguments \
-            '1::name:_dust_hive_envs' \
+            '1::name:_dust_hive_warm_envs' \
             '2::scenario:'
           ;;
         flag)
           _arguments \
-            '1::name:_dust_hive_envs' \
+            '1::name:_dust_hive_warm_envs' \
             '2::flag name:' \
             '-d[Disable the flag]' \
             '--disable[Disable the flag]'

--- a/x/henry/dust-hive/completions/dust-hive.zsh
+++ b/x/henry/dust-hive/completions/dust-hive.zsh
@@ -26,6 +26,10 @@
 _dust_hive_services=(
   sdk sparkle front core oauth connectors front-workers front-spa-poke front-spa-app viz
 )
+_dust_hive_warm_state_services=(
+  front front-api core oauth connectors front-workers front-spa-poke front-spa-app viz
+)
+# Avoid invoking the Bun CLI from completion; derive state from PID files plus one Docker scan.
 
 _dust_hive_current_env() {
   # 1. Detect from cwd (inside a .hives/<name> worktree)
@@ -77,22 +81,86 @@ _dust_hive_describe_envs() {
   fi
 }
 
+_dust_hive_pid_is_running() {
+  local pid_file="${1:?usage: _dust_hive_pid_is_running <pid-file>}"
+  local pid
+
+  [[ -r "$pid_file" ]] || return 1
+  IFS= read -r pid < "$pid_file" || [[ -n "$pid" ]] || return 1
+  [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+
+  kill -0 "$pid" 2>/dev/null
+}
+
+_dust_hive_service_is_running() {
+  local env_name="${1:?usage: _dust_hive_service_is_running <env> <service>}"
+  local service="${2:?usage: _dust_hive_service_is_running <env> <service>}"
+
+  _dust_hive_pid_is_running "$HOME/.dust-hive/envs/$env_name/$service.pid"
+}
+
+_dust_hive_docker_warm_envs() {
+  command docker ps --format '{{.Label "com.docker.compose.project"}}' 2>/dev/null |
+    awk '/^dust-hive-/ { sub(/^dust-hive-/, ""); print }' |
+    sort -u
+}
+
+_dust_hive_name_in_lines() {
+  local name="${1:?usage: _dust_hive_name_in_lines <name> <lines>}"
+  local lines="${2-}"
+
+  [[ "
+$lines
+" == *"
+$name
+"* ]]
+}
+
+_dust_hive_fast_state_rows() {
+  local docker_warm_envs env_dir env_name state service
+
+  [[ -d "$HOME/.dust-hive/envs" ]] || return
+
+  docker_warm_envs="$(_dust_hive_docker_warm_envs)"
+
+  while IFS= read -r env_dir; do
+    env_name="${env_dir##*/}"
+    [[ -f "$env_dir/metadata.json" ]] || continue
+
+    state="stopped"
+    if _dust_hive_name_in_lines "$env_name" "$docker_warm_envs"; then
+      state="warm"
+    elif _dust_hive_service_is_running "$env_name" "sdk" &&
+      _dust_hive_service_is_running "$env_name" "sparkle"; then
+      state="cold"
+    fi
+
+    if [[ "$state" != "warm" ]]; then
+      for service in "${_dust_hive_warm_state_services[@]}"; do
+        if _dust_hive_service_is_running "$env_name" "$service"; then
+          state="warm"
+          break
+        fi
+      done
+    fi
+
+    printf '%s %s\n' "$env_name" "$state"
+  done < <(command find "$HOME/.dust-hive/envs" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
+}
+
 _dust_hive_envs_by_states() {
   (( $# )) || return
   local desired_states="$*"
   local -a envs
 
   envs=(${(f)"$(
-    command dust-hive list 2>/dev/null | awk -v desired_states="$desired_states" '
+    _dust_hive_fast_state_rows | awk -v desired_states="$desired_states" '
       BEGIN {
         split(desired_states, states, " ")
         for (i in states) {
           state_set[states[i]] = 1
         }
       }
-      /^[[:space:]]*$/ { next }
-      /^NAME[[:space:]]/ { next }
-      /^-+/ { next }
       state_set[$2] { print $1 }
     '
   )"})


### PR DESCRIPTION
## Description

This PR makes dust-hive bash and zsh completions suggest only environments that make sense for state-dependent commands:

- `warm` / `dhw`: cold environments
- `cool` / `dhc`: warm environments
- `start`: stopped environments
- `stop`: cold and warm environments
- `feed` / `flag`: warm environments

To keep completions fast, the state-aware path avoids invoking the Bun CLI nor `dust-hive list`. It derives state from dust-hive PID files and a single Docker compose-project scan, including support for no-newline PID files.

Other commands keep the existing all-environment completion behavior.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- No deploy.
