### PR TITLE
fix(sandbox): use native TLS roots for dsbx API client

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "anyhow",
  "base64",
@@ -572,11 +572,11 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1172,6 +1172,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -1186,7 +1187,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1919,15 +1919,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.23"
+version = "0.1.24"
 edition = "2021"
 
 [[bin]]
@@ -20,7 +20,7 @@ lru = "0.16"
 httparse = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots"] }
 rustls = { version = "0.23", features = ["ring"] }
 rustls-native-certs = "0.8"
 rcgen = { version = "0.13", default-features = false, features = ["pem", "ring", "x509-parser"] }

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -94,7 +94,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.32",
+      tag: "0.8.33",
     });
   });
 
@@ -339,7 +339,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.23/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.24/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -19,8 +19,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.32";
-const DSBX_CLI_VERSION = "0.1.23";
+const DUST_BASE_IMAGE_VERSION = "0.8.33";
+const DSBX_CLI_VERSION = "0.1.24";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that
 // list must not silently change this user's UID.


### PR DESCRIPTION
## Description

The dsbx CLI's `DustApiClient` (the client behind `dsbx tools`) was compiled with reqwest's `rustls-tls` feature, which embeds Mozilla's webpki-roots **at compile time and ignores the system trust store entirely**.

Once `dust.tt` entered the egress MITM allowlist, `dsbx tools` traffic to the Dust API started receiving a leaf cert signed by the **Dust Sandbox Egress MITM CA**. webpki-roots has no knowledge of that CA, so the TLS handshake failed — surfacing as a statusless network error from `client.rs` (the `send()` error path with only `GET {url}` context, no HTTP status).

This is why it reproduced **only in production**: local dev calls `teardownInSandboxEgressRedirect`, which removes the in-sandbox nftables redirect so `agent-proxied` traffic flows direct out of the (permissive) E2B network and is never intercepted. With no MITM, webpki-roots is sufficient and the client works.

### Fix

Switch the API client to reqwest's `rustls-tls-native-roots` feature. This loads roots via `rustls-native-certs`, which reads `SSL_CERT_FILE` (`/etc/dust/ca-bundle.pem`) and the OS trust store (`/etc/ssl/certs/ca-certificates.crt`) — both of which contain the MITM CA (installed via `update-ca-certificates` by `dust-install-trust-bundle.sh`).

The change is localized to the reqwest stack. The `dsbx forward` egress forwarder uses a **separate** `tokio-rustls` trust path with its env stripped (`env -u`) and a vendored root, so its loop-prevention behaviour is unaffected.

Also bumps:
- dsbx CLI `0.1.23` -> `0.1.24`
- `dust-base` image `0.8.32` -> `0.8.33` (the dsbx binary is baked into the image at build time, so the image tag must bump for the fix to roll out)

## Tests

- `cargo build` on `dust-sandbox` succeeds with the new feature.
- `front` sandbox image registry tests pass (`registry.test.ts`, 10 tests) — updated the pinned image tag and dsbx download URL assertions.
- End-to-end behaviour (TLS through the MITM proxy) is only observable against a real intercepted egress path, so final verification is prod-side after rollout.

## Risk

Low and well-scoped:
- Only the reqwest-based `DustApiClient` trust config changes; the forwarder's TLS path is untouched.
- `rustls-tls-native-roots` falls back to the OS store, which already contains the MITM CA on the sandbox image, so the fix is robust regardless of `SSL_CERT_FILE`.
- Rollback is a revert of the feature flag + version bumps.

## Deploy Plan

1. **Publish the `dsbx-v0.1.24` GitHub release first** (binary + `checksums-sha256.txt`) via the "Release sandbox tool" workflow. The image build at `registry.ts:351` fetches `releases/download/dsbx-v0.1.24/...` and will fail until that release exists.
2. Build/push the `dust-base:0.8.33` sandbox image.
3. Deploy `front` so new sandboxes pull `0.8.33` with the fixed dsbx.