### PR TITLE
Add workspace_seat_limits table, model and resource (minSeats)

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -134,6 +134,7 @@ import { WakeUpModel } from "@app/lib/resources/storage/models/wakeup";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { WorkspaceHasDomainModel } from "@app/lib/resources/storage/models/workspace_has_domain";
 import { WorkspaceSandboxEnvVarModel } from "@app/lib/resources/storage/models/workspace_sandbox_env_var";
+import { WorkspaceSeatLimitModel } from "@app/lib/resources/storage/models/workspace_seat_limit";
 import { WorkspaceVerificationAttemptModel } from "@app/lib/resources/storage/models/workspace_verification_attempt";
 import logger from "@app/logger/logger";
 import { sendInitDbMessage } from "@app/types/shared/deployment";
@@ -257,6 +258,7 @@ export function loadAllModels() {
     UserProjectPreferencesModel,
     WorkspaceSensitivityLabelConfigModel,
     WorkspaceSandboxEnvVarModel,
+    WorkspaceSeatLimitModel,
   ];
 }
 

--- a/front/lib/resources/storage/models/workspace_seat_limit.ts
+++ b/front/lib/resources/storage/models/workspace_seat_limit.ts
@@ -1,0 +1,56 @@
+import { frontSequelize } from "@app/lib/resources/storage";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { MembershipSeatType } from "@app/types/memberships";
+import type { CreationOptional } from "sequelize";
+import { DataTypes } from "sequelize";
+
+/**
+ * Per-(workspace, seat-type) seat configuration.
+ *
+ * - `minSeats`: billing floor for that seat type — the minimum count billed to
+ *   Metronome even when the actual headcount on the seat type is lower.
+ *
+ * (`maxSeats` — a hard cap on assignments — will be added later.)
+ */
+export class WorkspaceSeatLimitModel extends WorkspaceAwareModel<WorkspaceSeatLimitModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare seatType: MembershipSeatType;
+  declare minSeats: CreationOptional<number>;
+}
+
+WorkspaceSeatLimitModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    seatType: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    minSeats: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 0,
+    },
+  },
+  {
+    modelName: "workspace_seat_limit",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        fields: ["workspaceId", "seatType"],
+        unique: true,
+        name: "workspace_seat_limits_workspace_seat_type_idx",
+      },
+    ],
+  }
+);

--- a/front/lib/resources/workspace_seat_limit_resource.test.ts
+++ b/front/lib/resources/workspace_seat_limit_resource.test.ts
@@ -1,0 +1,112 @@
+import { Authenticator } from "@app/lib/auth";
+import { WorkspaceSeatLimitResource } from "@app/lib/resources/workspace_seat_limit_resource";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { LightWorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("WorkspaceSeatLimitResource", () => {
+  let workspace: LightWorkspaceType;
+
+  beforeEach(async () => {
+    workspace = await WorkspaceFactory.basic();
+  });
+
+  it("upserts and fetches a seat limit", async () => {
+    await WorkspaceSeatLimitResource.upsert({
+      workspace,
+      seatType: "pro",
+      minSeats: 5,
+    });
+
+    const limits = await WorkspaceSeatLimitResource.fetchByWorkspace({
+      workspace,
+    });
+    expect(limits.get("pro")).toEqual({ minSeats: 5 });
+  });
+
+  it("updates minSeats on a second upsert for the same seat type", async () => {
+    await WorkspaceSeatLimitResource.upsert({
+      workspace,
+      seatType: "pro",
+      minSeats: 5,
+    });
+    await WorkspaceSeatLimitResource.upsert({
+      workspace,
+      seatType: "pro",
+      minSeats: 8,
+    });
+
+    const limits = await WorkspaceSeatLimitResource.fetchByWorkspace({
+      workspace,
+    });
+    expect(limits.size).toBe(1);
+    expect(limits.get("pro")).toEqual({ minSeats: 8 });
+  });
+
+  it("keeps limits for distinct seat types independent", async () => {
+    await WorkspaceSeatLimitResource.upsert({
+      workspace,
+      seatType: "pro",
+      minSeats: 3,
+    });
+    await WorkspaceSeatLimitResource.upsert({
+      workspace,
+      seatType: "max",
+      minSeats: 1,
+    });
+
+    const limits = await WorkspaceSeatLimitResource.fetchByWorkspace({
+      workspace,
+    });
+    expect(limits.get("pro")).toEqual({ minSeats: 3 });
+    expect(limits.get("max")).toEqual({ minSeats: 1 });
+  });
+
+  it("removes a configured limit", async () => {
+    await WorkspaceSeatLimitResource.upsert({
+      workspace,
+      seatType: "pro",
+      minSeats: 5,
+    });
+
+    const removed = await WorkspaceSeatLimitResource.remove({
+      workspace,
+      seatType: "pro",
+    });
+    expect(removed).toBe(true);
+
+    const limits = await WorkspaceSeatLimitResource.fetchByWorkspace({
+      workspace,
+    });
+    expect(limits.has("pro")).toBe(false);
+  });
+
+  it("returns false when removing a non-existent limit", async () => {
+    const removed = await WorkspaceSeatLimitResource.remove({
+      workspace,
+      seatType: "pro",
+    });
+    expect(removed).toBe(false);
+  });
+
+  it("deletes all limits for a workspace", async () => {
+    await WorkspaceSeatLimitResource.upsert({
+      workspace,
+      seatType: "pro",
+      minSeats: 3,
+    });
+    await WorkspaceSeatLimitResource.upsert({
+      workspace,
+      seatType: "max",
+      minSeats: 1,
+    });
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await WorkspaceSeatLimitResource.deleteAllForWorkspace(auth);
+
+    const limits = await WorkspaceSeatLimitResource.fetchByWorkspace({
+      workspace,
+    });
+    expect(limits.size).toBe(0);
+  });
+});

--- a/front/lib/resources/workspace_seat_limit_resource.ts
+++ b/front/lib/resources/workspace_seat_limit_resource.ts
@@ -1,0 +1,137 @@
+import type { Authenticator } from "@app/lib/auth";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import { WorkspaceSeatLimitModel } from "@app/lib/resources/storage/models/workspace_seat_limit";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { MembershipSeatType } from "@app/types/memberships";
+import { isMembershipSeatType } from "@app/types/memberships";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { Attributes, ModelStatic, Transaction } from "sequelize";
+
+/**
+ * The seat configuration for a single seat type.
+ *
+ * (`maxSeats` — a hard cap — will be added later.)
+ */
+export type SeatLimit = {
+  minSeats: number;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface WorkspaceSeatLimitResource
+  extends ReadonlyAttributesType<WorkspaceSeatLimitModel> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class WorkspaceSeatLimitResource extends BaseResource<WorkspaceSeatLimitModel> {
+  static model: ModelStaticWorkspaceAware<WorkspaceSeatLimitModel> =
+    WorkspaceSeatLimitModel;
+
+  constructor(
+    model: ModelStatic<WorkspaceSeatLimitModel>,
+    blob: Attributes<WorkspaceSeatLimitModel>
+  ) {
+    super(WorkspaceSeatLimitModel, blob);
+  }
+
+  /**
+   * Returns the configured per-seat-type limits for a workspace, keyed by seat
+   * type. Seat types without a row are simply absent from the map (callers
+   * treat that as "no floor").
+   */
+  static async fetchByWorkspace({
+    workspace,
+  }: {
+    workspace: LightWorkspaceType;
+  }): Promise<Map<MembershipSeatType, SeatLimit>> {
+    const rows = await this.model.findAll({
+      where: { workspaceId: workspace.id },
+    });
+    const result = new Map<MembershipSeatType, SeatLimit>();
+    for (const row of rows) {
+      if (isMembershipSeatType(row.seatType)) {
+        result.set(row.seatType, { minSeats: row.minSeats });
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Create or update the configured limit for a (workspace, seat type).
+   */
+  static async upsert({
+    workspace,
+    seatType,
+    minSeats,
+    transaction,
+  }: {
+    workspace: LightWorkspaceType;
+    seatType: MembershipSeatType;
+    minSeats: number;
+    transaction?: Transaction;
+  }): Promise<void> {
+    const existing = await this.model.findOne({
+      where: { workspaceId: workspace.id, seatType },
+      transaction,
+    });
+    if (existing) {
+      await existing.update({ minSeats }, { transaction });
+      return;
+    }
+    await this.model.create(
+      { workspaceId: workspace.id, seatType, minSeats },
+      { transaction }
+    );
+  }
+
+  /**
+   * Delete all seat-limit rows for a workspace. Called during workspace
+   * deletion/scrubbing to satisfy the `ON DELETE RESTRICT` FK before the
+   * workspace row itself is removed.
+   */
+  static async deleteAllForWorkspace(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<void> {
+    await this.model.destroy({
+      where: { workspaceId: auth.getNonNullableWorkspace().id },
+      transaction,
+    });
+  }
+
+  /**
+   * Remove the configured limit for a (workspace, seat type). Returns whether
+   * a row was actually deleted.
+   */
+  static async remove({
+    workspace,
+    seatType,
+    transaction,
+  }: {
+    workspace: LightWorkspaceType;
+    seatType: MembershipSeatType;
+    transaction?: Transaction;
+  }): Promise<boolean> {
+    const deletedCount = await this.model.destroy({
+      where: { workspaceId: workspace.id, seatType },
+      transaction,
+    });
+    return deletedCount > 0;
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<undefined, Error>> {
+    try {
+      await WorkspaceSeatLimitModel.destroy({
+        where: { id: this.id, workspaceId: auth.getNonNullableWorkspace().id },
+        transaction,
+      });
+      return new Ok(undefined);
+    } catch (err) {
+      return new Err(normalizeError(err));
+    }
+  }
+}

--- a/front/migrations/db/migration_658.sql
+++ b/front/migrations/db/migration_658.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "workspace_seat_limits" (
+    "id" BIGSERIAL PRIMARY KEY,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "seatType" VARCHAR(255) NOT NULL,
+    "minSeats" INTEGER NOT NULL DEFAULT 0,
+    "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX "workspace_seat_limits_workspace_seat_type_idx" ON "workspace_seat_limits" ("workspaceId", "seatType");

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -75,6 +75,7 @@ import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { WorkspaceSeatLimitResource } from "@app/lib/resources/workspace_seat_limit_resource";
 import { WorkspaceVerificationAttemptResource } from "@app/lib/resources/workspace_verification_attempt_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
@@ -775,6 +776,7 @@ export async function deleteWorkspaceActivity({
   await ProgrammaticUsageConfigurationResource.deleteAllForWorkspace(auth);
   await SelfImprovingSkillsUsageResource.deleteAllForWorkspace(auth);
   await WorkspaceVerificationAttemptResource.deleteAllForWorkspace(auth);
+  await WorkspaceSeatLimitResource.deleteAllForWorkspace(auth);
 
   hardDeleteLogger.info({ workspaceId }, "Deleting Workspace");
 


### PR DESCRIPTION
## Description

Introduces the `workspace_seat_limits` table with per-`(workspace, seatType)` configuration, starting with a billing-floor **`minSeats`**. Foundation for per-seat-type seat management; `maxSeats` (a hard cap) will be added in a follow-up.

On Metronome seat-billed workspaces we currently can't express a contracted **minimum** number of seats for a given seat type (a billing floor to bill even when actual headcount is lower). This PR adds the storage + resource layer; later PRs consume it (#26523 clamps the count sent to Metronome; #26524 adds a poke admin plugin).

**Changes**
- **Model** `lib/resources/storage/models/workspace_seat_limit.ts` — `WorkspaceSeatLimitModel` (`WorkspaceAwareModel`): `seatType`, `minSeats` (default 0); unique index on `(workspaceId, seatType)`.
- **Resource** `lib/resources/workspace_seat_limit_resource.ts` — `fetchByWorkspace` → `Map<MembershipSeatType, { minSeats }>`, `upsert`, `remove`, `delete`, and the `SeatLimit` type.
- **Migration** `migrations/db/migration_658.sql` — `CREATE TABLE` + unique index (`BIGSERIAL` id, FK to `workspaces` `ON DELETE RESTRICT ON UPDATE CASCADE`).
- **Registration** `admin/db.ts` — model import + `loadAllModels`.
- **Workspace deletion cleanup** — `WorkspaceSeatLimitResource.deleteAllForWorkspace`, called from the workspace-deletion activity (`poke/temporal/activities.ts`). The `workspaceId` FK is `ON DELETE RESTRICT`, so rows must be removed before the workspace is deleted.

No `maxSeats` and no `none` seat type here — those land in dedicated follow-ups to keep this PR focused.

## Tests

- `WorkspaceSeatLimitResource` functional tests (`lib/resources/workspace_seat_limit_resource.test.ts`): upsert/fetch, update on re-upsert, per-seat-type independence, remove, remove-missing, and `deleteAllForWorkspace`.
- `npx tsgo --noEmit` and `npm run format:changed` clean.
- Cross-checked the migration against the model: applying `migration_658.sql` to a fresh DB yields a schema identical to `admin/db.ts` materialization (same columns, PK, unique index, FK).

## Risk

Low. Purely additive — a brand-new table with no reads/writes from any runtime path in this PR (the resource is only exercised by tests; #26523/#26524 are the first consumers). No existing table or column is touched. Workspace deletion is handled: the new rows are scrubbed before the workspace row is removed, so the `ON DELETE RESTRICT` FK won't block deletion. Safe to roll back by dropping the table.

## Deploy Plan

1. **Pre-deploy migration.** Run `front/migrations/db/migration_658.sql` against the front database (standard numbered-migration apply). It only does `CREATE TABLE "workspace_seat_limits"` + one unique index — fast, non-blocking, no table rewrite, no lock on existing tables.
2. **Deploy code.** Order is not critical (old code ignores the new table; new code in this PR doesn't query it at runtime), but the conventional order is migration first, then code.
3. **Rollback.** `DROP TABLE "workspace_seat_limits";` — safe, since nothing in production reads or writes it yet.

Part of **Pricing Push → Seat management: per-seat-type limits + none seat type**. First of a stack of small PRs (targets `main`; #26523 and #26524 stack on top).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
