### PR TITLE
Dust as remote MCP server (helloworld)

### DIFF
--- a/.github/actions/setup-node-deps/action.yml
+++ b/.github/actions/setup-node-deps/action.yml
@@ -32,6 +32,7 @@ runs:
         path: |
           node_modules
           front/node_modules
+          front-api/node_modules
           front-spa/node_modules
           connectors/node_modules
           sparkle/node_modules

--- a/front-api/app.ts
+++ b/front-api/app.ts
@@ -18,6 +18,8 @@ import { invitationsApp } from "./routes/invitations";
 import { killApp } from "./routes/kill";
 import privateLoginApp from "./routes/login";
 import lookupApp from "./routes/lookup";
+import { mcpApp } from "./routes/mcp/index";
+import { mcpWellKnownApp } from "./routes/mcp/well-known";
 import metronomeApp from "./routes/metronome";
 import novuApp from "./routes/novu";
 import oauthApp from "./routes/oauth";
@@ -83,5 +85,11 @@ apiApp.route("/:preStopSecret", preStopApp);
 export const honoApp = createHono();
 honoApp.use("*", requestLogger);
 honoApp.use("*", cors);
+
+// Dust as MCP Server — inbound from remote clients (Inspector, Cursor, etc.).
+// Mounted at root level so /.well-known/* and /mcp are not under /api/.
+honoApp.route("/mcp", mcpApp);
+honoApp.route("/", mcpWellKnownApp);
+
 honoApp.route("/api", apiApp);
 honoApp.onError(unhandledErrorHandler);

--- a/front-api/middlewares/cors.ts
+++ b/front-api/middlewares/cors.ts
@@ -8,7 +8,7 @@ import { isDevelopment } from "@app/types/shared/env";
 import type { MiddlewareHandler } from "hono";
 
 const ALLOW_METHODS = "GET, POST, PUT, PATCH, DELETE, OPTIONS";
-const EXPOSE_HEADERS = "X-Reload-Required";
+const EXPOSE_HEADERS = "X-Reload-Required, WWW-Authenticate";
 
 /**
  * Mirrors the CORS handling in `front/middleware.ts` (the Next.js Edge

--- a/front-api/package.json
+++ b/front-api/package.json
@@ -10,9 +10,11 @@
     "tsgo": "tsgo"
   },
   "dependencies": {
+    "@hono/mcp": "^0.3.0",
     "@hono/node-server": "^1.19.10",
     "@hono/zod-validator": "^0.7.6",
     "hono": "^4.12.15",
+    "jose": "^6.2.3",
     "next": "^14.2.35",
     "openai": "^6.33.0",
     "zod": "^3.25.76",

--- a/front-api/routes/mcp/index.ts
+++ b/front-api/routes/mcp/index.ts
@@ -1,0 +1,27 @@
+import { mcpServerAuthMiddleware } from "@app/lib/api/mcp_server/auth";
+import { runWithMcpContext } from "@app/lib/api/mcp_server/context";
+import { createDustMcpServer } from "@app/lib/api/mcp_server/server";
+import logger from "@app/logger/logger";
+import { createHono } from "@front-api/lib/hono";
+import { StreamableHTTPTransport } from "@hono/mcp";
+
+const dustMcpServer = createDustMcpServer();
+const transport = new StreamableHTTPTransport();
+
+export const mcpApp = createHono();
+
+// POST, GET, DELETE /mcp — all MCP protocol traffic from remote clients.
+mcpApp.all("/", mcpServerAuthMiddleware, async (c) => {
+  if (!dustMcpServer.isConnected()) {
+    await dustMcpServer.connect(transport);
+  }
+
+  const user = c.get("mcpUser");
+  const auth = c.get("mcpAuth");
+  logger.info(
+    { userId: user.sub, workspaceId: auth.workspace()?.sId },
+    "[dust-mcp-server] Inbound request"
+  );
+
+  return runWithMcpContext({ auth }, () => transport.handleRequest(c));
+});

--- a/front-api/routes/mcp/well-known.ts
+++ b/front-api/routes/mcp/well-known.ts
@@ -1,0 +1,33 @@
+import {
+  getMcpProtectedResourcePath,
+  getMcpResourceServerUrl,
+  getWorkOSAuthKitDomain,
+} from "@app/lib/api/mcp_server/urls";
+import { createHono } from "@front-api/lib/hono";
+
+const WORKOS_AUTHKIT_DOMAIN = getWorkOSAuthKitDomain();
+const DUST_MCP_SERVER_URL = getMcpResourceServerUrl();
+const protectedResourcePath = getMcpProtectedResourcePath(DUST_MCP_SERVER_URL);
+
+const protectedResourceMetadata = {
+  resource: DUST_MCP_SERVER_URL,
+  authorization_servers: [WORKOS_AUTHKIT_DOMAIN],
+  bearer_methods_supported: ["header"],
+} as const;
+
+export const mcpWellKnownApp = createHono();
+
+function serveProtectedResourceMetadata(c: {
+  json: (body: unknown) => Response;
+}) {
+  return c.json(protectedResourceMetadata);
+}
+
+// Path-aware discovery for → /.well-known/oauth-protected-resource/mcp
+mcpWellKnownApp.get(protectedResourcePath, serveProtectedResourceMetadata);
+
+// RFC 9728 root fallback used by some clients and WorkOS docs examples.
+mcpWellKnownApp.get(
+  "/.well-known/oauth-protected-resource",
+  serveProtectedResourceMetadata
+);

--- a/front-api/routes/poke/search.test.ts
+++ b/front-api/routes/poke/search.test.ts
@@ -3,25 +3,7 @@ import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { faker } from "@faker-js/faker";
 import { honoApp } from "@front-api/app";
-import { describe, expect, it, vi } from "vitest";
-
-// The poke search also queries the Connectors API (for connector ID lookups).
-// Mock it to return a dummy URL so it doesn't throw on missing env var.
-vi.mock("@app/lib/api/config", async (importOriginal) => {
-  const mod = await importOriginal<typeof import("@app/lib/api/config")>();
-  return {
-    ...mod,
-    default: {
-      ...mod.default,
-      getConnectorsAPIConfig: vi.fn().mockReturnValue({
-        url: "http://localhost:0",
-        secret: "test",
-        webhookSecret: "test",
-      }),
-      getPokeAppUrl: vi.fn().mockReturnValue("http://localhost:3000/poke"),
-    },
-  };
-});
+import { describe, expect, it } from "vitest";
 
 function searchRequest(query: string) {
   return honoApp.request(

--- a/front-api/routes/poke/workspaces/[wId]/invitations/[iId]/index.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/invitations/[iId]/index.test.ts
@@ -13,24 +13,6 @@ vi.spyOn(sgMail, "send").mockResolvedValue([
   {},
 ] as never);
 
-// Mock config to provide required values for invitation emails.
-vi.mock(import("@app/lib/api/config"), async (importOriginal) => {
-  const mod = await importOriginal();
-  return {
-    ...mod,
-    default: {
-      ...mod.default,
-      getSendgridApiKey: vi.fn().mockReturnValue("SG.test"),
-      getInvitationEmailTemplate: vi.fn().mockReturnValue("d-test"),
-      getSupportEmailAddress: vi.fn().mockReturnValue("test@dust.tt"),
-      getAppUrl: vi.fn().mockReturnValue("http://localhost:3000"),
-      getDustInviteTokenSecret: vi
-        .fn()
-        .mockReturnValue("test-invite-secret-32chars!!!!!"),
-    },
-  };
-});
-
 function patchInvitation(workspace: { sId: string }, invitationSId: string) {
   return honoApp.request(
     `/api/poke/workspaces/${workspace.sId}/invitations/${invitationSId}`,

--- a/front-api/routes/v1/w/[wId]/data_sources/[dsId]/tables/csv.test.ts
+++ b/front-api/routes/v1/w/[wId]/data_sources/[dsId]/tables/csv.test.ts
@@ -58,25 +58,13 @@ const CORE_VALIDATE_CSV_FAKE_RESPONSE = {
   },
 };
 
-vi.mock(import("@app/lib/api/config"), (() => ({
-  default: {
-    getCoreAPIConfig: vi.fn().mockReturnValue({
-      url: "http://localhost:9999",
-      apiKey: "foo",
-    }),
-    getWorkOSClientId: vi.fn(() => "test-workos-client-id"),
-  },
-})) as any);
-
-// Create a mock content setter
 const mockFileContent = {
-  content: "default content", // Default content
+  content: "default content",
   setContent: (newContent: string) => {
     mockFileContent.content = newContent;
   },
 };
 
-// Mock file storage with parameterizable content
 vi.mock("@app/lib/file_storage", async () => {
   const { fileStorageMock } = await import(
     "@app/tests/utils/mocks/file_storage"

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
@@ -58,16 +58,6 @@ const CORE_VALIDATE_CSV_FAKE_RESPONSE = {
   },
 };
 
-vi.mock(import("@app/lib/api/config"), (() => ({
-  default: {
-    getCoreAPIConfig: vi.fn().mockReturnValue({
-      url: "http://localhost:9999",
-      apiKey: "foo",
-    }),
-    getWorkOSClientId: vi.fn(() => "test-workos-client-id"),
-  },
-})) as any);
-
 const mockFileContent = {
   content: "default content",
   setContent: (newContent: string) => {

--- a/front-api/routes/w/[wId]/data_sources/[dsId]/files.test.ts
+++ b/front-api/routes/w/[wId]/data_sources/[dsId]/files.test.ts
@@ -45,17 +45,6 @@ const CORE_VALIDATE_CSV_FAKE_RESPONSE = {
   },
 };
 
-vi.mock(import("@app/lib/api/config"), (() => ({
-  default: {
-    getCoreAPIConfig: vi.fn().mockReturnValue({
-      url: "http://localhost:9999",
-      apiKey: "foo",
-    }),
-    getApiBaseUrl: vi.fn().mockReturnValue("http://localhost:3000"),
-    getWorkOSClientId: vi.fn(() => "test-workos-client-id"),
-  },
-})) as any);
-
 const mockFileContent = {
   content: "default content",
   setContent: (newContent: string) => {

--- a/front-api/routes/w/[wId]/files/[fileId]/export/pdf.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/export/pdf.test.ts
@@ -20,16 +20,6 @@ vi.mock("@app/types/shared/document_renderer", async (importOriginal) => {
   };
 });
 
-vi.mock("@app/lib/api/config", () => ({
-  default: {
-    getDocumentRendererUrl: vi.fn().mockReturnValue("http://localhost:3100"),
-    getVizPublicUrl: vi.fn().mockReturnValue("https://viz.dust.tt"),
-    getAppUrl: vi.fn().mockReturnValue("http://localhost:3000"),
-    getVizJwtSecret: vi.fn().mockReturnValue("test-secret"),
-    getWorkOSClientId: vi.fn(() => "test-workos-client-id"),
-  },
-}));
-
 function url(workspace: { sId: string }, fileId: string) {
   return `/api/w/${workspace.sId}/files/${fileId}/export/pdf`;
 }

--- a/front-api/routes/w/[wId]/google_drive/search_for_authorization.test.ts
+++ b/front-api/routes/w/[wId]/google_drive/search_for_authorization.test.ts
@@ -56,17 +56,6 @@ function createMockMetadataResponse({
   };
 }
 
-// Mock config
-vi.mock("@app/lib/api/config", () => ({
-  default: {
-    getOAuthAPIConfig: vi.fn(() => ({
-      url: "https://oauth-api.example.com",
-      apiKey: "test-api-key",
-    })),
-    getWorkOSClientId: vi.fn(() => "test-workos-client-id"),
-  },
-}));
-
 // Mock rate limiter
 vi.mock("@app/lib/utils/rate_limiter", () => ({
   rateLimiter: vi.fn(),

--- a/front-api/routes/w/[wId]/invitations/index.test.ts
+++ b/front-api/routes/w/[wId]/invitations/index.test.ts
@@ -10,23 +10,6 @@ const sgSendMock = vi
   .spyOn(sgMail, "send")
   .mockResolvedValue([{ statusCode: 202, headers: {}, body: {} }, {}] as never);
 
-vi.mock(import("@app/lib/api/config"), async (importOriginal) => {
-  const mod = await importOriginal();
-  return {
-    ...mod,
-    default: {
-      ...mod.default,
-      getSendgridApiKey: vi.fn().mockReturnValue("SG.test"),
-      getInvitationEmailTemplate: vi.fn().mockReturnValue("d-test"),
-      getSupportEmailAddress: vi.fn().mockReturnValue("test@dust.tt"),
-      getAppUrl: vi.fn().mockReturnValue("http://localhost:3000"),
-      getDustInviteTokenSecret: vi
-        .fn()
-        .mockReturnValue("test-invite-secret-32chars!!!!!"),
-    },
-  };
-});
-
 import { honoApp } from "@front-api/app";
 
 beforeEach(() => {

--- a/front-api/routes/w/[wId]/webhook_sources/service-data.test.ts
+++ b/front-api/routes/w/[wId]/webhook_sources/service-data.test.ts
@@ -6,20 +6,6 @@ import { Err, Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@app/lib/api/config", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@app/lib/api/config")>();
-  return {
-    ...actual,
-    default: {
-      ...actual.default,
-      getOAuthAPIConfig: vi.fn(() => ({
-        url: "https://oauth-api.example.com",
-        apiKey: "test-api-key",
-      })),
-    },
-  };
-});
-
 vi.mock("@app/lib/api/triggers/built-in-webhooks/github/repos", () => ({
   getGithubRepositories: vi.fn(),
 }));

--- a/front-api/vite.config.mjs
+++ b/front-api/vite.config.mjs
@@ -11,7 +11,7 @@ export default defineConfig({
     // jsdom mirrors front's vitest config; some test factories rely on
     // jsdom-provided globals (e.g. globalThis.name).
     environment: "jsdom",
-    setupFiles: "../front/vite.setup.ts",
+    setupFiles: "./vite.setup.ts",
     globalSetup: "../front/vite.globalSetup.ts",
     passWithNoTests: true,
     exclude: ["**/node_modules/**", "**/dist/**"],

--- a/front-api/vite.setup.ts
+++ b/front-api/vite.setup.ts
@@ -1,0 +1,39 @@
+// front-api tests reuse front's vitest setup, then register a shared config mock
+// so honoApp can load MCP routes and tests get stable config values.
+import { vi } from "vitest";
+
+import "../front/vite.setup.ts";
+
+vi.mock("@app/lib/api/config", async (importOriginal) => {
+  const { createAppConfigMock } = await import(
+    "@app/tests/utils/mocks/app_config"
+  );
+  return createAppConfigMock(importOriginal, {
+    getApiBaseUrl: () => "http://localhost:3000",
+    getAppUrl: () => "http://localhost:3000",
+    getCoreAPIConfig: () => ({
+      url: "http://localhost:9999",
+      apiKey: "foo",
+    }),
+    getConnectorsAPIConfig: () => ({
+      url: "http://localhost:0",
+      secret: "test",
+      webhookSecret: "test",
+    }),
+    getDocumentRendererUrl: () => "http://localhost:3100",
+    getDustInviteTokenSecret: () => "test-invite-secret-32chars!!!!!",
+    getInvitationEmailTemplate: () => "d-test",
+    getOAuthAPIConfig: () => ({
+      url: "https://oauth-api.example.com",
+      apiKey: "test-api-key",
+    }),
+    getPokeAppUrl: () => "http://localhost:3000/poke",
+    getSendgridApiKey: () => "SG.test",
+    getSupportEmailAddress: () => ({
+      name: "Dust team",
+      email: "test@dust.tt",
+    }),
+    getVizJwtSecret: () => "test-secret",
+    getVizPublicUrl: () => "https://viz.dust.tt",
+  });
+});

--- a/front/config/cors.ts
+++ b/front/config/cors.ts
@@ -44,6 +44,8 @@ export function isAllowedOrigin(origin: string): boolean {
 export const ALLOWED_HEADERS = [
   "authorization",
   "content-type",
+  "mcp-protocol-version",
+  "mcp-session-id",
   "x-commit-hash",
   "x-dust-extension-version",
   "x-build-date",

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -427,6 +427,9 @@ const config = {
   getWorkOSEnvironmentId: (): string => {
     return EnvironmentConfig.getEnvVariable("WORKOS_ENVIRONMENT_ID");
   },
+  getWorkOSAuthKitDomain: (): string => {
+    return EnvironmentConfig.getEnvVariable("WORKOS_AUTHKIT_DOMAIN");
+  },
   // Profiler.
   getProfilerSecret: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable("DEBUG_PROFILER_SECRET");

--- a/front/lib/api/mcp_server/README.md
+++ b/front/lib/api/mcp_server/README.md
@@ -1,0 +1,44 @@
+# Dust MCP server
+
+Dust exposes itself as an **MCP server** so external clients (Cursor, Claude Desktop, etc.) can call Dust over the Model Context Protocol with OAuth.
+
+## Big picture
+
+- **Dust** is the MCP **resource server** (tools, data).
+- **WorkOS AuthKit** is the **authorization server** (OAuth, org picker, JWTs).
+- Each authenticated session is scoped to a **Dust user + workspace**, derived from the WorkOS org the user picks during OAuth.
+
+HTTP entrypoints live in `front-api/routes/mcp/`. This folder holds the auth and tool logic consumed by those routes.
+
+## Where to start reading
+
+| If you want to understand… | Start here |
+|---|---|
+| HTTP routing and wiring | `front-api/routes/mcp/` |
+| OAuth metadata discovery | `front-api/routes/mcp/well-known.ts` |
+| Tool definitions | `server.ts` |
+| Token verification | `auth.ts` |
+| User + workspace resolution from the token | `authenticator.ts` |
+| How tools access per-request auth | `context.ts` |
+| URLs, env vars, AuthKit domain | `urls.ts` |
+
+## Key concepts (stable)
+
+**Workspace = WorkOS organization.** Dust workspaces map to WorkOS orgs via `workOSOrganizationId`. Not all workspaces have one (especially free/demo). See `front/lib/api/workos/organization.ts` and the org migration in `front/migrations/20250602_migrate_organizations.ts`.
+
+**Tools use a standard `Authenticator`.** Once auth is resolved, tool code should look like any other Dust backend code that receives an `Authenticator` — same permissions, same APIs.
+
+**The MCP server is a singleton.** Per-request state (the `Authenticator`) is threaded separately from tool registration. See `context.ts` and the route handler in `front-api/routes/mcp/index.ts`.
+
+## Adding a tool
+
+Add it in `server.ts`. Use `getAuthenticatorFromMcpContext()` to access the scoped auth inside handlers. MCP clients cache tool lists — reconnect after adding or renaming tools.
+
+## Local dev & config
+
+Run `front-api` locally, register the MCP URL as a WorkOS Connect Resource Indicator, and point your client at `/mcp`. Config env vars are defined in `urls.ts`.
+
+## External references
+
+- [WorkOS AuthKit MCP](https://workos.com/docs/authkit/mcp)
+- [MCP authorization](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization)

--- a/front/lib/api/mcp_server/auth.ts
+++ b/front/lib/api/mcp_server/auth.ts
@@ -1,0 +1,199 @@
+import { getAuthenticatorFromWorkOSClaims } from "@app/lib/api/mcp_server/authenticator";
+import {
+  getMcpResourceMetadataUrl,
+  getMcpResourceServerUrl,
+  getWorkOSAuthKitDomain,
+  normalizeOAuthUrl,
+} from "@app/lib/api/mcp_server/urls";
+import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import type { Context } from "hono";
+import { createMiddleware } from "hono/factory";
+import {
+  createRemoteJWKSet,
+  decodeJwt,
+  type JWTPayload,
+  jwtVerify,
+} from "jose";
+
+export type McpServerAuthUser = JWTPayload & { sub: string };
+
+export type McpServerAuthVariables = {
+  mcpUser: McpServerAuthUser;
+  mcpAuthInfo: AuthInfo;
+  mcpAuth: Authenticator;
+};
+
+function tokenScopes(payload: JWTPayload): string[] {
+  const { scope } = payload;
+  if (typeof scope === "string" && scope.trim()) {
+    return scope.split(" ").filter(Boolean);
+  }
+  return [];
+}
+
+function toMcpAuthInfo(token: string, payload: McpServerAuthUser): AuthInfo {
+  return {
+    token,
+    clientId: payload.sub,
+    scopes: tokenScopes(payload),
+    expiresAt: typeof payload.exp === "number" ? payload.exp : undefined,
+    extra: { user: payload },
+  };
+}
+
+const WORKOS_AUTHKIT_DOMAIN = getWorkOSAuthKitDomain();
+const DUST_MCP_SERVER_URL = getMcpResourceServerUrl();
+const resourceMetadataUrl = getMcpResourceMetadataUrl(DUST_MCP_SERVER_URL);
+
+// WorkOS Connect MCP access tokens — see https://workos.com/docs/authkit/mcp
+const JWKS = createRemoteJWKSet(
+  new URL(`${WORKOS_AUTHKIT_DOMAIN}/oauth2/jwks`)
+);
+
+function extractBearerToken(authHeader: string | undefined): string | null {
+  const match = authHeader?.match(/^Bearer\s+(.+)$/i);
+  const token = match?.[1]?.trim();
+  return token ? token : null;
+}
+
+function isJwtFormat(token: string): boolean {
+  return token.split(".").length === 3;
+}
+
+function tokenAudienceMatchesResource(
+  aud: JWTPayload["aud"],
+  expectedResource: string
+): boolean {
+  const audiences =
+    aud === undefined ? [] : Array.isArray(aud) ? aud : [String(aud)];
+  return audiences.some(
+    (value) => normalizeOAuthUrl(String(value)) === expectedResource
+  );
+}
+
+/** RFC 9728 challenge — must be present on every 401 so MCP clients start OAuth. */
+function unauthorizedResponse(
+  c: Context,
+  {
+    error = "unauthorized",
+    description = "Authorization needed",
+  }: { error?: string; description?: string } = {}
+) {
+  return c.json({ error }, 401, {
+    "WWW-Authenticate": [
+      `Bearer error="${error}"`,
+      `error_description="${description}"`,
+      `resource_metadata="${resourceMetadataUrl}"`,
+    ].join(", "),
+  });
+}
+
+export const mcpServerAuthMiddleware = createMiddleware<{
+  Variables: McpServerAuthVariables;
+}>(async (c, next) => {
+  const token = extractBearerToken(c.req.header("Authorization"));
+
+  if (!token) {
+    return unauthorizedResponse(c);
+  }
+
+  if (!isJwtFormat(token)) {
+    logger.warn(
+      {
+        tokenLength: token.length,
+        looksLikeInspectorProxyToken: /^[0-9a-f]{64}$/i.test(token),
+      },
+      "[dust-mcp-server] Bearer token is not a JWT — returning 401 challenge so the client can start OAuth. If using MCP Inspector: disable any custom Authorization header in the sidebar and clear stored OAuth tokens for this server URL."
+    );
+    return unauthorizedResponse(c, {
+      error: "invalid_token",
+      description: "Access token is not a valid WorkOS JWT",
+    });
+  }
+
+  try {
+    const { payload } = await jwtVerify(token, JWKS, {
+      clockTolerance: 30,
+    });
+
+    if (normalizeOAuthUrl(String(payload.iss)) !== WORKOS_AUTHKIT_DOMAIN) {
+      throw new Error("Token issuer does not match WorkOS AuthKit domain");
+    }
+
+    if (!payload.sub) {
+      throw new Error("Token missing sub claim");
+    }
+
+    if (!tokenAudienceMatchesResource(payload.aud, DUST_MCP_SERVER_URL)) {
+      throw new Error("Token audience does not match MCP resource URL");
+    }
+
+    const mcpUser = payload as McpServerAuthUser;
+    const authResult = await getAuthenticatorFromWorkOSClaims(mcpUser);
+    if (authResult.isErr()) {
+      const descriptions: Record<typeof authResult.error, string> = {
+        organization_missing:
+          "Access token is missing a WorkOS organization (org_id claim)",
+        workspace_not_found:
+          "Access token organization does not match a Dust workspace",
+        user_not_found: "Dust user not found for access token",
+        not_a_member: "User is not a member of the selected workspace",
+        invalid_token_payload: "Access token payload is invalid",
+      };
+
+      logger.warn(
+        {
+          error: authResult.error,
+          tokenClaims: {
+            sub: mcpUser.sub,
+            org_id: mcpUser.org_id,
+          },
+        },
+        "[dust-mcp-server] Failed to build workspace-scoped authenticator"
+      );
+
+      return unauthorizedResponse(c, {
+        error: "invalid_token",
+        description: descriptions[authResult.error],
+      });
+    }
+
+    c.set("mcpUser", mcpUser);
+    c.set("mcpAuthInfo", toMcpAuthInfo(token, mcpUser));
+    c.set("mcpAuth", authResult.value);
+    await next();
+  } catch (err) {
+    let decoded: JWTPayload | undefined;
+    try {
+      decoded = decodeJwt(token);
+    } catch {
+      // Ignore decode errors; log the verification error below.
+    }
+
+    logger.warn(
+      {
+        err,
+        tokenClaims: decoded
+          ? {
+              iss: decoded.iss,
+              aud: decoded.aud,
+              sub: decoded.sub,
+              org_id: decoded.org_id,
+            }
+          : undefined,
+        expected: {
+          issuer: WORKOS_AUTHKIT_DOMAIN,
+          audience: DUST_MCP_SERVER_URL,
+        },
+      },
+      "[dust-mcp-server] Token validation failed"
+    );
+
+    return unauthorizedResponse(c, {
+      error: "invalid_token",
+      description: "Access token validation failed",
+    });
+  }
+});

--- a/front/lib/api/mcp_server/authenticator.ts
+++ b/front/lib/api/mcp_server/authenticator.ts
@@ -1,0 +1,75 @@
+import type { McpServerAuthUser } from "@app/lib/api/mcp_server/auth";
+import {
+  type WorkOSJwtPayload,
+  WorkOSJwtPayloadSchema,
+} from "@app/lib/api/workos";
+import { Authenticator } from "@app/lib/auth";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { isLeft } from "fp-ts/lib/Either";
+
+export type McpAuthenticatorError =
+  | "organization_missing"
+  | "workspace_not_found"
+  | "user_not_found"
+  | "not_a_member"
+  | "invalid_token_payload";
+
+function parseWorkOSJwtPayload(
+  payload: McpServerAuthUser
+): WorkOSJwtPayload | null {
+  const validation = WorkOSJwtPayloadSchema.decode(payload);
+  if (isLeft(validation)) {
+    return null;
+  }
+  return validation.right;
+}
+
+function getOrganizationId(payload: WorkOSJwtPayload): string | null {
+  const orgId = payload.org_id;
+  return typeof orgId === "string" && orgId.trim() ? orgId.trim() : null;
+}
+
+export async function getAuthenticatorFromWorkOSClaims(
+  payload: McpServerAuthUser
+): Promise<Result<Authenticator, McpAuthenticatorError>> {
+  const workOSToken = parseWorkOSJwtPayload(payload);
+  if (!workOSToken) {
+    return new Err("invalid_token_payload");
+  }
+
+  const organizationId = getOrganizationId(workOSToken);
+  if (!organizationId) {
+    return new Err("organization_missing");
+  }
+
+  const workspace =
+    await WorkspaceResource.fetchByWorkOSOrganizationId(organizationId);
+  if (!workspace) {
+    return new Err("workspace_not_found");
+  }
+
+  const authResult = await Authenticator.fromWorkOSToken({
+    token: workOSToken,
+    wId: workspace.sId,
+  });
+
+  if (authResult.isErr()) {
+    switch (authResult.error.code) {
+      case "user_not_found":
+        return new Err("user_not_found");
+      case "workspace_not_found":
+        return new Err("workspace_not_found");
+      default:
+        return new Err("not_a_member");
+    }
+  }
+
+  const auth = authResult.value;
+  if (!auth.user() || auth.role() === "none") {
+    return new Err("not_a_member");
+  }
+
+  return new Ok(auth);
+}

--- a/front/lib/api/mcp_server/context.ts
+++ b/front/lib/api/mcp_server/context.ts
@@ -1,0 +1,21 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+import type { Authenticator } from "@app/lib/auth";
+
+type McpContext = {
+  auth: Authenticator;
+};
+
+const mcpContext = new AsyncLocalStorage<McpContext>();
+
+export function runWithMcpContext<T>(context: McpContext, fn: () => T): T {
+  return mcpContext.run(context, fn);
+}
+
+export function getMcpContext(): McpContext | undefined {
+  return mcpContext.getStore();
+}
+
+export function getAuthenticatorFromMcpContext(): Authenticator | undefined {
+  return getMcpContext()?.auth;
+}

--- a/front/lib/api/mcp_server/server.ts
+++ b/front/lib/api/mcp_server/server.ts
@@ -1,0 +1,38 @@
+import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+export function createDustMcpServer(): McpServer {
+  const server = new McpServer({
+    name: "dust",
+    version: "0.1.0",
+  });
+
+  // hello_world — smoke-test tool
+  // Confirms that a remote client is properly authenticated and talking to Dust.
+  server.tool(
+    "hello_world",
+    "Returns a greeting from Dust. Use this to verify that your MCP client is correctly connected and authenticated.",
+    async () => {
+      const auth = getAuthenticatorFromMcpContext();
+      if (!auth) {
+        return {
+          content: [{ type: "text", text: "Not authenticated." }],
+          isError: true,
+        };
+      }
+
+      const name = auth.user()?.firstName.trim() || "there";
+      const workspaceName = auth.workspace()?.name ?? "unknown workspace";
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Hello, ${name}! You are connected to the Dust MCP server for workspace "${workspaceName}".`,
+          },
+        ],
+      };
+    }
+  );
+
+  return server;
+}

--- a/front/lib/api/mcp_server/urls.ts
+++ b/front/lib/api/mcp_server/urls.ts
@@ -1,0 +1,43 @@
+import config from "@app/lib/api/config";
+
+/**
+ * AuthKit Connect domain for MCP OAuth (e.g. `your-env.authkit.app`).
+ *
+ * This is NOT the same as `WORKOS_ISSUER_URL` / `auth-api.dust.tt`, which is
+ * Dust's WorkOS API hostname used for SDK calls and SSO session JWT issuer.
+ * Connect OAuth metadata and JWKS live on the AuthKit domain — find it in the
+ * WorkOS dashboard under Connect → Configuration.
+ */
+export function getWorkOSAuthKitDomain(): string {
+  return normalizeOAuthUrl(config.getWorkOSAuthKitDomain().trim());
+}
+
+/** Canonical form for comparing OAuth resource/issuer URLs (RFC 8707). */
+export function normalizeOAuthUrl(url: string): string {
+  const withScheme =
+    url.startsWith("http://") || url.startsWith("https://")
+      ? url
+      : `https://${url}`;
+  const parsed = new URL(withScheme);
+  parsed.hash = "";
+  parsed.search = "";
+  const pathname = parsed.pathname.replace(/\/$/, "");
+  return pathname ? `${parsed.origin}${pathname}` : parsed.origin;
+}
+
+export function getMcpResourceServerUrl(): string {
+  return normalizeOAuthUrl(config.getDustAPIConfig().url.trim() + "/mcp");
+}
+
+export function getMcpResourceMetadataUrl(resourceServerUrl: string): URL {
+  const url = new URL(resourceServerUrl);
+  return new URL(
+    `/.well-known/oauth-protected-resource${url.pathname.replace(/\/$/, "")}`,
+    url.origin
+  );
+}
+
+export function getMcpProtectedResourcePath(resourceServerUrl: string): string {
+  const pathname = new URL(resourceServerUrl).pathname.replace(/\/$/, "");
+  return `/.well-known/oauth-protected-resource${pathname}`;
+}

--- a/front/tests/utils/mocks/app_config.ts
+++ b/front/tests/utils/mocks/app_config.ts
@@ -1,0 +1,33 @@
+import { vi } from "vitest";
+
+type ConfigModule = typeof import("@app/lib/api/config");
+export type AppConfig = ConfigModule["default"];
+export type AppConfigMockOverrides = Partial<{
+  [K in keyof AppConfig]: AppConfig[K];
+}>;
+
+/**
+ * Merge config getter overrides onto the real config module.
+ * Use inside vi.mock("@app/lib/api/config", async (importOriginal) => ...).
+ *
+ * Preserves all unmocked getters (required when honoApp loads MCP routes).
+ */
+export async function createAppConfigMock(
+  importOriginal: <T = ConfigModule>() => Promise<T>,
+  overrides: AppConfigMockOverrides = {}
+): Promise<ConfigModule> {
+  const actual = await importOriginal<ConfigModule>();
+  const mocked: Record<string, unknown> = { ...actual.default };
+
+  for (const [key, value] of Object.entries(overrides) as [string, unknown][]) {
+    mocked[key] =
+      typeof value === "function"
+        ? vi.fn(value as (...args: never[]) => unknown)
+        : value;
+  }
+
+  return {
+    ...actual,
+    default: mocked as AppConfig,
+  };
+}

--- a/front/vite.globalSetup.ts
+++ b/front/vite.globalSetup.ts
@@ -45,6 +45,7 @@ export default async function setup() {
     REGION: "us-central1",
     DUST_MCP_SERVER_CREDENTIALS_SECRET: "test-secret",
     WORKOS_CLIENT_ID: "test-workos-client-id",
+    WORKOS_AUTHKIT_DOMAIN: "https://test.authkit.app",
     OAUTH_API: process.env.OAUTH_API ?? "http://fake-oauth-api",
     CORE_API: "http://fake-core-api",
     CONNECTORS_API: "http://fake-connectors-api",

--- a/package-lock.json
+++ b/package-lock.json
@@ -738,9 +738,11 @@
       "name": "@dust-tt/front-api",
       "version": "0.1.0",
       "dependencies": {
+        "@hono/mcp": "^0.3.0",
         "@hono/node-server": "^1.19.10",
         "@hono/zod-validator": "^0.7.6",
         "hono": "^4.12.15",
+        "jose": "^6.2.3",
         "next": "^14.2.35",
         "openai": "^6.33.0",
         "zod": "^3.25.76",
@@ -749,6 +751,37 @@
       "devDependencies": {
         "esbuild": "^0.27.3",
         "tsx": "^4.21.0"
+      }
+    },
+    "front-api/node_modules/@hono/mcp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@hono/mcp/-/mcp-0.3.0.tgz",
+      "integrity": "sha512-UhSWFbZwRxHBdptOn2r1HyB8Vt6gU+BL3AbTis2t8TBW69ZhG4soJQ09yEL/t/ymxszJnWp5Rq6tOXXOjuK1qg==",
+      "license": "MIT",
+      "dependencies": {
+        "pkce-challenge": "^5.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.1",
+        "hono": "*",
+        "hono-rate-limiter": "^0.5.3",
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "front-api/node_modules/hono-rate-limiter": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/hono-rate-limiter/-/hono-rate-limiter-0.5.3.tgz",
+      "integrity": "sha512-M0DxbVMpPELEzLi0AJg1XyBHLGJXz7GySjsPoK+gc5YeeBsdGDGe+2RvVuCAv8ydINiwlbxqYMNxUEyYfRji/A==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "hono": "^4.10.8",
+        "unstorage": "^1.17.3"
+      },
+      "peerDependenciesMeta": {
+        "unstorage": {
+          "optional": true
+        }
       }
     },
     "front-api/node_modules/openai": {
@@ -36933,9 +36966,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"


### PR DESCRIPTION
## Description

⚠️ **This will works only with hono as streamable http support in next is too painful.** ⚠️ 
⚠️ **It requires enabling DCR in workOs (to allow any client to self-register)** ⚠️ 

Exposes Dust as a remote MCP server, accessible from external clients (Cursor, Claude Desktop, MCP Inspector, etc.) over HTTP with WorkOS AuthKit OAuth.

- New `/mcp` Hono route in `front-api` handles all MCP protocol traffic via `StreamableHTTPTransport` from `@hono/mcp`. A singleton `McpServer` + transport pair is wired up with `mcpServerAuthMiddleware` gating every request.
- `mcpServerAuthMiddleware` validates WorkOS JWTs via JWKS (`jose`), checks issuer/audience/sub claims, and maps failures to RFC 9728-compliant 401s with `WWW-Authenticate` headers (also now exposed in CORS).
- `getAuthenticatorFromWorkOSClaims` resolves the token's `org_id` → `WorkspaceResource` → `Authenticator` via `Authenticator.fromWorkOSToken`.
- Per-request auth is threaded into tool handlers via `AsyncLocalStorage<McpContext>` (`runWithMcpContext` / `getAuthenticatorFromMcpContext`).
- `/.well-known/oauth-protected-resource[/mcp]` (RFC 9728) serves OAuth discovery metadata so clients can find WorkOS AuthKit automatically.
- `hello_world` smoke-test tool confirms auth is working and returns the user's name + workspace.
- `mcp-protocol-version` and `mcp-session-id` added to `ALLOWED_HEADERS` in CORS config.

## Tests

Tested manually with cursor.

<img width="704" height="206" alt="image" src="https://github.com/user-attachments/assets/9bf70e96-21e2-4161-96fb-b9cad07c3fe6" />

<img width="579" height="304" alt="image" src="https://github.com/user-attachments/assets/700ddbba-d8c4-41f7-98a0-eca1f92d4152" />


## Risk

Low. The MCP endpoint is entirely new and isolated from existing routes — no existing behaviour is modified beyond the additive CORS header changes. `jose` bumped from 6.1.3 → 6.2.3 (patch). Rollback is safe: removing the two `honoApp.route` registrations restores the previous state.

## Deploy Plan

Add `WORKOS_AUTHKIT_DOMAIN` env var.
Enable DCR on workos.
Deploy front & front-api. No DB migrations.
