### PR TITLE
Clamp Metronome seat count to configured minSeats floor

### DIFF
--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -1106,10 +1106,19 @@ interface SubscriptionSeatsHistoryResponse {
 }
 
 /**
- * Fetch the assigned seat IDs on a SEAT_BASED subscription at `coveringDate`
- * (defaults to now).
+ * The seat state of a SEAT_BASED subscription segment: the explicitly assigned
+ * seat IDs plus the count of unassigned (paid-for but unallocated) seats.
  */
-export async function getMetronomeSubscriptionAssignedSeatIds({
+export type SubscriptionSeatState = {
+  assignedSeatIds: string[];
+  unassignedSeats: number;
+};
+
+/**
+ * Fetch the seat state (assigned seat IDs + unassigned seat count) on a
+ * SEAT_BASED subscription at `coveringDate` (defaults to now).
+ */
+export async function getMetronomeSubscriptionSeatState({
   metronomeCustomerId,
   contractId,
   subscriptionId,
@@ -1121,7 +1130,7 @@ export async function getMetronomeSubscriptionAssignedSeatIds({
   // Defaults to `now`. Pass a future date to read the assignments projected
   // at that point in time.
   coveringDate?: Date;
-}): Promise<Result<string[], Error>> {
+}): Promise<Result<SubscriptionSeatState, Error>> {
   try {
     const response =
       await getMetronomeClient().post<SubscriptionSeatsHistoryResponse>(
@@ -1137,9 +1146,11 @@ export async function getMetronomeSubscriptionAssignedSeatIds({
       );
     // History is returned ascending by starting_at; take the last entry to
     // get the segment active at `coveringDate` (earlier entries are stale).
-    return new Ok(
-      response.data[response.data.length - 1]?.assigned_seat_ids ?? []
-    );
+    const segment = response.data[response.data.length - 1];
+    return new Ok({
+      assignedSeatIds: segment?.assigned_seat_ids ?? [],
+      unassignedSeats: segment?.unassigned_seats ?? 0,
+    });
   } catch (err) {
     const error = normalizeError(err);
     logger.error(
@@ -1148,6 +1159,36 @@ export async function getMetronomeSubscriptionAssignedSeatIds({
     );
     return new Err(error);
   }
+}
+
+/**
+ * Fetch the assigned seat IDs on a SEAT_BASED subscription at `coveringDate`
+ * (defaults to now). Thin wrapper over `getMetronomeSubscriptionSeatState` for
+ * callers that don't need the unassigned-seat count.
+ */
+export async function getMetronomeSubscriptionAssignedSeatIds({
+  metronomeCustomerId,
+  contractId,
+  subscriptionId,
+  coveringDate,
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+  subscriptionId: string;
+  // Defaults to `now`. Pass a future date to read the assignments projected
+  // at that point in time.
+  coveringDate?: Date;
+}): Promise<Result<string[], Error>> {
+  const stateResult = await getMetronomeSubscriptionSeatState({
+    metronomeCustomerId,
+    contractId,
+    subscriptionId,
+    coveringDate,
+  });
+  if (stateResult.isErr()) {
+    return new Err(stateResult.error);
+  }
+  return new Ok(stateResult.value.assignedSeatIds);
 }
 
 /**

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -1,6 +1,7 @@
 import {
   getMetronomeContractById,
   getMetronomeSubscriptionAssignedSeatIds,
+  getMetronomeSubscriptionSeatState,
   updateSubscriptionQuantity,
   updateSubscriptionSeats,
 } from "@app/lib/metronome/client";
@@ -13,6 +14,8 @@ import {
 } from "@app/lib/metronome/seat_types";
 import type { BillingFrequency } from "@app/lib/metronome/types";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import type { SeatLimit } from "@app/lib/resources/workspace_seat_limit_resource";
+import { WorkspaceSeatLimitResource } from "@app/lib/resources/workspace_seat_limit_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import {
   bestEffortInvalidateCacheWithRedis,
@@ -261,10 +264,13 @@ export async function syncSeatCount({
     // transitions: each row has `startAt > now` and represents the seat
     // type the user will be on from `startAt` forward. The companion "current"
     // row (with `endAt = startAt`) still appears in `getActiveMemberships`.
-    const [{ memberships: activeMemberships }, futureMemberships] =
+    const [{ memberships: activeMemberships }, futureMemberships, seatLimits] =
       await Promise.all([
         MembershipResource.getActiveMemberships({ workspace }),
         MembershipResource.getScheduledFutureMemberships({ workspace }),
+        // Per-seat-type min/max configuration (only `minSeats` today). Used to
+        // clamp the count sent to Metronome up to the configured floor.
+        WorkspaceSeatLimitResource.fetchByWorkspace({ workspace }),
       ]);
 
     // userSId → current seat type (the seat they are on right now).
@@ -365,6 +371,7 @@ export async function syncSeatCount({
     for (const { sub, seatType } of seatSubscriptions) {
       const subscriptionId = sub.id!;
       const quantityMode = sub.quantity_management_mode ?? "QUANTITY_ONLY";
+      const seatLimit = seatLimits.get(seatType);
 
       if (quantityMode === "SEAT_BASED") {
         // Now segment.
@@ -374,6 +381,7 @@ export async function syncSeatCount({
           subscriptionId,
           seatType,
           desiredSIds: desiredSIdsAt(seatType, Date.now()),
+          seatLimit,
           startingAt,
           workspaceId: workspace.sId,
         });
@@ -391,6 +399,7 @@ export async function syncSeatCount({
             subscriptionId,
             seatType,
             desiredSIds: desiredSIdsAt(seatType, tMs),
+            seatLimit,
             startingAt: at.toISOString(),
             coveringDate: at,
             workspaceId: workspace.sId,
@@ -404,22 +413,29 @@ export async function syncSeatCount({
         // QUANTITY_ONLY: only sync the "now" total. Scheduled changes within
         // a quantity-only seat tier are not modeled — they're rare in practice
         // (free / unlimited tiers) and Metronome doesn't bill them per-seat.
-        const nowQuantity = desiredSIdsAt(seatType, Date.now()).length;
+        const actualQuantity = desiredSIdsAt(seatType, Date.now()).length;
+        // Clamp up to the configured billing floor: below `minSeats` we still
+        // bill the floor.
+        const quantity = clampSeatCountToMin(actualQuantity, seatLimit);
         logger.info(
           {
             workspaceId: workspace.sId,
             contractId,
             subscriptionId,
             seatType,
-            quantity: nowQuantity,
+            actualQuantity,
+            quantity,
+            minSeats: seatLimit?.minSeats,
           },
-          "[Metronome] Updating seat quantity"
+          quantity !== actualQuantity
+            ? "[Metronome] Updating seat quantity (clamped up to configured min)"
+            : "[Metronome] Updating seat quantity"
         );
         const updateResult = await updateSubscriptionQuantity({
           metronomeCustomerId,
           contractId,
           subscriptionId,
-          quantity: nowQuantity,
+          quantity,
           startingAt,
         });
         if (updateResult.isErr()) {
@@ -441,9 +457,25 @@ export async function syncSeatCount({
 }
 
 /**
+ * Clamp a seat count up to the configured `minSeats` billing floor. Counts at
+ * or above the floor (or with no limit configured) are returned unchanged.
+ */
+function clampSeatCountToMin(
+  count: number,
+  seatLimit: SeatLimit | undefined
+): number {
+  return seatLimit ? Math.max(count, seatLimit.minSeats) : count;
+}
+
+/**
  * Reconcile one SEAT_BASED segment for a single subscription. Reads the
  * current assignment from Metronome at `coveringDate` (defaults to now) and
  * applies only the delta. Idempotent against repeated invocations.
+ *
+ * When a `minSeats` floor is configured and fewer real users are assigned than
+ * the floor, the shortfall is added as *unassigned* seats so the contracted
+ * minimum is still billed. The unassigned count is reconciled to the exact
+ * desired value (added or removed) so repeated runs converge.
  */
 async function reconcileSeatBasedSegment({
   metronomeCustomerId,
@@ -451,6 +483,7 @@ async function reconcileSeatBasedSegment({
   subscriptionId,
   seatType,
   desiredSIds,
+  seatLimit,
   startingAt,
   coveringDate,
   workspaceId,
@@ -460,11 +493,12 @@ async function reconcileSeatBasedSegment({
   subscriptionId: string;
   seatType: MembershipSeatType;
   desiredSIds: string[];
+  seatLimit?: SeatLimit;
   startingAt?: string;
   coveringDate?: Date;
   workspaceId: string;
 }): Promise<Result<boolean, Error>> {
-  const currentResult = await getMetronomeSubscriptionAssignedSeatIds({
+  const currentResult = await getMetronomeSubscriptionSeatState({
     metronomeCustomerId,
     contractId,
     subscriptionId,
@@ -473,13 +507,32 @@ async function reconcileSeatBasedSegment({
   if (currentResult.isErr()) {
     return new Err(currentResult.error);
   }
+  const { assignedSeatIds, unassignedSeats: currentUnassigned } =
+    currentResult.value;
 
   const desired = new Set(desiredSIds);
-  const current = new Set(currentResult.value);
+  const current = new Set(assignedSeatIds);
   const addSeatIds = desiredSIds.filter((id) => !current.has(id));
-  const removeSeatIds = currentResult.value.filter((id) => !desired.has(id));
+  const removeSeatIds = assignedSeatIds.filter((id) => !desired.has(id));
 
-  if (addSeatIds.length === 0 && removeSeatIds.length === 0) {
+  // Top up to the `minSeats` floor with unassigned seats when fewer real users
+  // are assigned than the floor.
+  const desiredUnassigned = Math.max(
+    0,
+    (seatLimit?.minSeats ?? 0) - desiredSIds.length
+  );
+  const addUnassignedSeats = Math.max(0, desiredUnassigned - currentUnassigned);
+  const removeUnassignedSeats = Math.max(
+    0,
+    currentUnassigned - desiredUnassigned
+  );
+
+  if (
+    addSeatIds.length === 0 &&
+    removeSeatIds.length === 0 &&
+    addUnassignedSeats === 0 &&
+    removeUnassignedSeats === 0
+  ) {
     return new Ok(false);
   }
 
@@ -491,6 +544,9 @@ async function reconcileSeatBasedSegment({
       seatType,
       addCount: addSeatIds.length,
       removeCount: removeSeatIds.length,
+      addUnassignedSeats,
+      removeUnassignedSeats,
+      minSeats: seatLimit?.minSeats,
       startingAt,
     },
     "[Metronome] Updating seat-based subscription assignments"
@@ -502,6 +558,8 @@ async function reconcileSeatBasedSegment({
     fromSubscriptionId: subscriptionId,
     addSeatIds,
     removeSeatIds,
+    addUnassignedSeats,
+    removeUnassignedSeats,
     startingAt,
   });
   if (updateResult.isErr()) {

--- a/front/lib/metronome/seats_sync.test.ts
+++ b/front/lib/metronome/seats_sync.test.ts
@@ -1,0 +1,215 @@
+import type { CachedContract } from "@app/lib/metronome/plan_type";
+import { syncSeatCount } from "@app/lib/metronome/seats";
+import type { MembershipSeatType } from "@app/types/memberships";
+import { Ok } from "@app/types/shared/result";
+import type { LightWorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockGetProductSeatTypes,
+  mockUpdateSubscriptionQuantity,
+  mockUpdateSubscriptionSeats,
+  mockGetSeatState,
+  mockGetActiveMemberships,
+  mockGetScheduledFutureMemberships,
+  mockFetchSeatLimits,
+} = vi.hoisted(() => ({
+  mockGetProductSeatTypes: vi.fn(),
+  mockUpdateSubscriptionQuantity: vi.fn(),
+  mockUpdateSubscriptionSeats: vi.fn(),
+  mockGetSeatState: vi.fn(),
+  mockGetActiveMemberships: vi.fn(),
+  mockGetScheduledFutureMemberships: vi.fn(),
+  mockFetchSeatLimits: vi.fn(),
+}));
+
+vi.mock("@app/lib/metronome/client", () => ({
+  getMetronomeContractById: vi.fn(),
+  updateSubscriptionQuantity: mockUpdateSubscriptionQuantity,
+  updateSubscriptionSeats: mockUpdateSubscriptionSeats,
+  getMetronomeSubscriptionSeatState: mockGetSeatState,
+  getMetronomeSubscriptionAssignedSeatIds: vi.fn(),
+}));
+
+vi.mock("@app/lib/metronome/seat_types", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/seat_types")
+  >("@app/lib/metronome/seat_types");
+  return { ...actual, getProductSeatTypes: mockGetProductSeatTypes };
+});
+
+vi.mock("@app/lib/resources/membership_resource", () => ({
+  MembershipResource: {
+    getActiveMemberships: mockGetActiveMemberships,
+    getScheduledFutureMemberships: mockGetScheduledFutureMemberships,
+  },
+}));
+
+vi.mock("@app/lib/resources/workspace_seat_limit_resource", () => ({
+  WorkspaceSeatLimitResource: { fetchByWorkspace: mockFetchSeatLimits },
+}));
+
+// Cache wrappers run at import time and (for invalidate) in `syncSeatCount`'s
+// finally block — stub them so the test never touches Redis.
+vi.mock("@app/lib/utils/cache", () => ({
+  cacheWithRedis: (fn: unknown) => fn,
+  invalidateCacheWithRedis: () => async () => {},
+  bestEffortInvalidateCacheWithRedis: () => async () => {},
+}));
+
+const WORKSPACE = { sId: "ws_1", id: 1 } as unknown as LightWorkspaceType;
+
+function makeContract(
+  subs: Array<{ id: string; productId: string; mode: string }>
+): CachedContract {
+  return {
+    subscriptions: subs.map(({ id, productId, mode }) => ({
+      id,
+      quantity_management_mode: mode,
+      subscription_rate: { product: { id: productId, name: id } },
+    })),
+  } as unknown as CachedContract;
+}
+
+function membership(sId: string, seatType: MembershipSeatType) {
+  return { user: { sId }, seatType };
+}
+
+describe("syncSeatCount min clamping", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetScheduledFutureMemberships.mockResolvedValue([]);
+    mockUpdateSubscriptionQuantity.mockResolvedValue(new Ok(undefined));
+    mockUpdateSubscriptionSeats.mockResolvedValue(new Ok(undefined));
+  });
+
+  it("clamps a QUANTITY_ONLY count up to the configured minSeats", async () => {
+    mockGetProductSeatTypes.mockResolvedValue(
+      new Map([["ws-product", "workspace"]])
+    );
+    mockGetActiveMemberships.mockResolvedValue({
+      memberships: [membership("u1", "workspace")],
+      total: 1,
+    });
+    mockFetchSeatLimits.mockResolvedValue(
+      new Map([["workspace", { minSeats: 5 }]])
+    );
+
+    const result = await syncSeatCount({
+      metronomeCustomerId: "cus_1",
+      contractId: "con_1",
+      workspace: WORKSPACE,
+      contract: makeContract([
+        { id: "sub_ws", productId: "ws-product", mode: "QUANTITY_ONLY" },
+      ]),
+    });
+
+    expect(result.isOk()).toBe(true);
+    // Actual headcount is 1, but the floor of 5 is billed.
+    expect(mockUpdateSubscriptionQuantity).toHaveBeenCalledWith(
+      expect.objectContaining({ subscriptionId: "sub_ws", quantity: 5 })
+    );
+  });
+
+  it("does not clamp a QUANTITY_ONLY count already above minSeats", async () => {
+    mockGetProductSeatTypes.mockResolvedValue(
+      new Map([["ws-product", "workspace"]])
+    );
+    mockGetActiveMemberships.mockResolvedValue({
+      memberships: [
+        membership("u1", "workspace"),
+        membership("u2", "workspace"),
+        membership("u3", "workspace"),
+      ],
+      total: 3,
+    });
+    mockFetchSeatLimits.mockResolvedValue(
+      new Map([["workspace", { minSeats: 2 }]])
+    );
+
+    await syncSeatCount({
+      metronomeCustomerId: "cus_1",
+      contractId: "con_1",
+      workspace: WORKSPACE,
+      contract: makeContract([
+        { id: "sub_ws", productId: "ws-product", mode: "QUANTITY_ONLY" },
+      ]),
+    });
+
+    expect(mockUpdateSubscriptionQuantity).toHaveBeenCalledWith(
+      expect.objectContaining({ subscriptionId: "sub_ws", quantity: 3 })
+    );
+  });
+
+  it("adds unassigned seats to reach minSeats on a SEAT_BASED subscription", async () => {
+    mockGetProductSeatTypes.mockResolvedValue(
+      new Map([["pro-product", "pro"]])
+    );
+    mockGetActiveMemberships.mockResolvedValue({
+      memberships: [membership("u1", "pro")],
+      total: 1,
+    });
+    mockFetchSeatLimits.mockResolvedValue(new Map([["pro", { minSeats: 3 }]]));
+    // No seats currently assigned in Metronome.
+    mockGetSeatState.mockResolvedValue(
+      new Ok({ assignedSeatIds: [], unassignedSeats: 0 })
+    );
+
+    await syncSeatCount({
+      metronomeCustomerId: "cus_1",
+      contractId: "con_1",
+      workspace: WORKSPACE,
+      contract: makeContract([
+        { id: "sub_pro", productId: "pro-product", mode: "SEAT_BASED" },
+      ]),
+    });
+
+    // 1 real user assigned, floor of 3 → 2 unassigned seats added.
+    expect(mockUpdateSubscriptionSeats).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromSubscriptionId: "sub_pro",
+        addSeatIds: ["u1"],
+        addUnassignedSeats: 2,
+        removeUnassignedSeats: 0,
+      })
+    );
+  });
+
+  it("removes excess unassigned seats when headcount rises above minSeats", async () => {
+    mockGetProductSeatTypes.mockResolvedValue(
+      new Map([["pro-product", "pro"]])
+    );
+    mockGetActiveMemberships.mockResolvedValue({
+      memberships: [
+        membership("u1", "pro"),
+        membership("u2", "pro"),
+        membership("u3", "pro"),
+        membership("u4", "pro"),
+      ],
+      total: 4,
+    });
+    mockFetchSeatLimits.mockResolvedValue(new Map([["pro", { minSeats: 3 }]]));
+    // Previously: 1 assigned + 2 unassigned (floor padding). Now 4 real users.
+    mockGetSeatState.mockResolvedValue(
+      new Ok({ assignedSeatIds: ["u1"], unassignedSeats: 2 })
+    );
+
+    await syncSeatCount({
+      metronomeCustomerId: "cus_1",
+      contractId: "con_1",
+      workspace: WORKSPACE,
+      contract: makeContract([
+        { id: "sub_pro", productId: "pro-product", mode: "SEAT_BASED" },
+      ]),
+    });
+
+    expect(mockUpdateSubscriptionSeats).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromSubscriptionId: "sub_pro",
+        addSeatIds: ["u2", "u3", "u4"],
+        addUnassignedSeats: 0,
+        removeUnassignedSeats: 2,
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Description

`syncSeatCount` now reads the per-seat-type `WorkspaceSeatLimitResource` config (#26521) and bills **at least `minSeats`** for each configured seat type, so a workspace is billed its contracted minimum even when fewer members hold the seat.

**Changes**
- **`lib/metronome/seats.ts`** — `syncSeatCount` loads `WorkspaceSeatLimitResource.fetchByWorkspace` once, then per seat subscription:
  - **QUANTITY_ONLY**: synced quantity clamped up to `minSeats` (`clampSeatCountToMin`).
  - **SEAT_BASED**: when fewer real users are assigned than the floor, the shortfall is added as **unassigned seats**; excess unassigned seats are removed once headcount rises. Reconciled idempotently against the current unassigned count.
- **`lib/metronome/client.ts`** — adds `getMetronomeSubscriptionSeatState` (assigned seat IDs **+ unassigned count**); `getMetronomeSubscriptionAssignedSeatIds` delegates to it.

Scope is `minSeats` only — no `maxSeats` cap yet (follow-up).

## Tests

- New `lib/metronome/seats_sync.test.ts`: QUANTITY_ONLY clamps up to floor / leaves a higher count alone; SEAT_BASED adds unassigned seats to reach the floor and removes the excess as headcount grows.
- Full `lib/metronome` suite green; `npx tsgo --noEmit`, `npm run format:changed` clean.

## Risk

Low. The clamp only changes behavior for workspaces that have a `workspace_seat_limits` row configured — there are none until an operator sets one (#26524), so this is effectively a no-op on deploy. Idempotent: re-running once Metronome and DB agree is a no-op. Rollback by reverting the commit; no data migration involved.

## Deploy Plan

Standard deploy. No database migration and no manual steps. Depends on #26521 being deployed first (uses `WorkspaceSeatLimitResource` / the `workspace_seat_limits` table). Rollback: revert.

Stacked on #26521 (`add-workspace-seat-limits-table`). Part of **Pricing Push → Seat management**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
