### PR TITLE
Add poke plugin to configure per-seat-type minimum

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -22,6 +22,7 @@ export * from "./manage_authorized_domains";
 export * from "./manage_conversation_kill_switch";
 export * from "./manage_credit_usage_configuration";
 export * from "./manage_programmatic_usage_configuration";
+export * from "./manage_seat_limits";
 export * from "./manage_workspace_kill_switch";
 export * from "./project_task_details";
 export * from "./reinforcement_workflow";

--- a/front/lib/api/poke/plugins/workspaces/manage_seat_limits.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_seat_limits.ts
@@ -1,0 +1,117 @@
+import { createPlugin } from "@app/lib/api/poke/types";
+import { WorkspaceSeatLimitResource } from "@app/lib/resources/workspace_seat_limit_resource";
+import { launchMetronomeSeatCountSyncWorkflow } from "@app/temporal/usage_queue/client";
+import {
+  isMembershipSeatType,
+  MEMBERSHIP_SEAT_TYPES,
+} from "@app/types/memberships";
+import { isCreditPricedPlan } from "@app/types/plan";
+import { mapToEnumValues } from "@app/types/poke/plugins";
+import { Err, Ok } from "@app/types/shared/result";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+const SeatLimitArgsSchema = z.object({
+  minSeats: z
+    .number()
+    .int("Min seats must be an integer")
+    .min(0, "Min seats must be at least 0"),
+});
+
+export const manageSeatLimitsPlugin = createPlugin({
+  manifest: {
+    id: "manage-seat-limits",
+    name: "Manage Seat Limits",
+    description:
+      "Configure the per-seat-type minimum seat count for this workspace. " +
+      "The minimum is the billing floor sent to Metronome even when fewer " +
+      "members hold that seat (the shortfall is billed as unassigned seats). " +
+      "Disabling removes the floor for the selected seat type.",
+    resourceTypes: ["workspaces"],
+    args: {
+      seatType: {
+        type: "enum",
+        label: "Seat type",
+        description: "The seat type to configure.",
+        values: mapToEnumValues(MEMBERSHIP_SEAT_TYPES, (seatType) => ({
+          label: seatType,
+          value: seatType,
+        })),
+        multiple: false,
+      },
+      enabled: {
+        type: "boolean",
+        variant: "toggle",
+        label: "Enable floor",
+        description:
+          "When off, removes any configured minimum for the selected seat type.",
+      },
+      minSeats: {
+        type: "number",
+        variant: "text",
+        label: "Min seats",
+        description: "Billing floor — minimum seats billed for this type.",
+        dependsOn: { field: "enabled", value: true },
+      },
+    },
+  },
+
+  isApplicableTo: (auth) => {
+    const plan = auth.plan();
+    return plan !== null && isCreditPricedPlan(plan);
+  },
+
+  execute: async (auth, workspace, args) => {
+    if (!workspace) {
+      return new Err(new Error("Cannot find workspace."));
+    }
+
+    const seatType = args.seatType[0];
+    if (!seatType || !isMembershipSeatType(seatType)) {
+      return new Err(new Error("Please select a seat type."));
+    }
+
+    let message: string;
+    if (!args.enabled) {
+      // Disable: drop any configured floor for this seat type.
+      const removed = await WorkspaceSeatLimitResource.remove({
+        workspace,
+        seatType,
+      });
+      message = removed
+        ? `Removed seat floor for '${seatType}'.`
+        : `No seat floor was configured for '${seatType}'.`;
+    } else {
+      const parseResult = SeatLimitArgsSchema.safeParse(args);
+      if (!parseResult.success) {
+        return new Err(new Error(fromError(parseResult.error).toString()));
+      }
+
+      const { minSeats } = parseResult.data;
+      await WorkspaceSeatLimitResource.upsert({
+        workspace,
+        seatType,
+        minSeats,
+      });
+      message = `Seat floor for '${seatType}' saved: min ${minSeats}.`;
+    }
+
+    // Re-sync seats to Metronome so the new floor is reflected immediately.
+    const syncResult = await launchMetronomeSeatCountSyncWorkflow({
+      workspaceId: workspace.sId,
+    });
+    if (syncResult.isErr()) {
+      return new Err(
+        new Error(
+          `${message} However, the Metronome seat sync failed to launch: ` +
+            `${syncResult.error.message}. Re-run once the issue is resolved.`
+        )
+      );
+    }
+
+    return new Ok({
+      display: "text",
+      value: `${message} Metronome seat sync launched.`,
+    });
+  },
+});


### PR DESCRIPTION
## Description

Adds a **"Manage Seat Limits"** workspace poke plugin to configure the per-seat-type minimum seat count (`minSeats`), stored by #26521 and consumed by #26523. Admin-only tooling — no end-user API/UI in this iteration.

**Changes**
- **`lib/api/poke/plugins/workspaces/manage_seat_limits.ts`** — form:
  - **Seat type** — dropdown over `MEMBERSHIP_SEAT_TYPES`.
  - **Enable floor** — toggle; when off, removes any configured minimum for the selected seat type.
  - **Min seats** — number (shown only when enabled) → `WorkspaceSeatLimitResource.upsert`.
  - Gated to credit-priced (Metronome) workspaces (`isApplicableTo`).
  - After writing, launches `launchMetronomeSeatCountSyncWorkflow` so the floor is reflected immediately; surfaces an error if the sync fails to launch (the limit is still saved).
- Registered in the workspace plugin index.

`minSeats` only — no `maxSeats` field (not in the model yet).

## Tests

- `npx tsgo --noEmit`, `npm run format:changed` clean.
- Manual: in poke, set/clear a floor for a seat type on a credit-priced workspace; confirm the row is written/removed and the seat-sync workflow is launched.

## Risk

Low. New, isolated poke plugin (operator-only); changes no existing code path. Gated to credit-priced workspaces. Worst case a bad value writes a wrong `minSeats`, corrected by re-running the plugin.

## Deploy Plan

Standard deploy. No database migration and no manual steps. Depends on #26521 being deployed first (uses `WorkspaceSeatLimitResource`). Rollback: revert.

Stacked on #26521 (`add-workspace-seat-limits-table`); does not depend on #26523. Part of **Pricing Push → Seat management**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
