### PR TITLE
Clean credits configuration

### DIFF
--- a/front/lib/resources/credit_usage_configuration_resource.ts
+++ b/front/lib/resources/credit_usage_configuration_resource.ts
@@ -145,6 +145,21 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
     return new Ok(undefined);
   }
 
+  /**
+   * Delete all credit-usage-configuration rows for a workspace. Called during
+   * workspace deletion/scrubbing to satisfy the `ON DELETE RESTRICT` FK before
+   * the workspace row itself is removed.
+   */
+  static async deleteAllForWorkspace(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<void> {
+    await this.model.destroy({
+      where: { workspaceId: auth.getNonNullableWorkspace().id },
+      transaction,
+    });
+  }
+
   toJSON() {
     return {
       sId: this.sId,

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -30,6 +30,7 @@ import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_res
 import { AppResource } from "@app/lib/resources/app_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { CreditResource } from "@app/lib/resources/credit_resource";
+import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { ExtensionConfigurationResource } from "@app/lib/resources/extension";
@@ -772,6 +773,7 @@ export async function deleteWorkspaceActivity({
     where: { workspaceId: workspace.id },
   });
   await CreditResource.deleteAllForWorkspace(auth);
+  await CreditUsageConfigurationResource.deleteAllForWorkspace(auth);
   await ProgrammaticUsageConfigurationResource.deleteAllForWorkspace(auth);
   await SelfImprovingSkillsUsageResource.deleteAllForWorkspace(auth);
   await WorkspaceVerificationAttemptResource.deleteAllForWorkspace(auth);


### PR DESCRIPTION
## Description

Clean up `credit_usage_configurations` rows when a workspace is deleted.

`CreditUsageConfigurationModel` extends `WorkspaceAwareModel`, so its `workspaceId` FK is `ON DELETE RESTRICT`. Nothing was deleting these rows during workspace deletion, so a workspace that had a credit-usage configuration (created via the `manage_credit_usage_configuration` poke plugin / `syncCreditBasedPayg`) would **fail to delete** on the FK constraint — the final `WorkspaceModel` delete is RESTRICT and nothing cascades.

**Changes**
- **`lib/resources/credit_usage_configuration_resource.ts`** — add `CreditUsageConfigurationResource.deleteAllForWorkspace(auth)` (mirrors the existing instance `delete` and the convention used by the other workspace-scoped resources).
- **`poke/temporal/activities.ts`** — call it in `deleteWorkspaceActivity`, alongside the other `deleteAllForWorkspace` calls (right after `CreditResource`, before `ProgrammaticUsageConfigurationResource`), so the rows are removed before the workspace row is deleted.

## Tests

- `npx tsgo --noEmit` and `npm run format:changed` clean.
- Pre-existing gap on `main` (unrelated to the seat-limits work) found while auditing FK cleanup; the deletion path now scrubs this table with the other workspace-scoped resources.

## Risk

Low. Adds a delete of `credit_usage_configurations` rows for a workspace that is already being hard-deleted — no impact on live workspaces, and the rows are being discarded anyway. No schema change. Without this, hard-deleting an affected workspace fails on the FK; with it, deletion succeeds.

## Deploy Plan

Standard deploy. No database migration and no manual steps. Rollback: revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
