### PR TITLE
Align contracts at beginning of month

### DIFF
--- a/front/lib/metronome/setup_common.ts
+++ b/front/lib/metronome/setup_common.ts
@@ -173,7 +173,9 @@ export interface PackageDef {
   aliases: Array<{ name: string }>;
   rate_card_name: string;
   subscriptions?: PackageSubscription[];
-  // Billing cycle anchored to contract start date (matches Stripe subscription anniversary).
+  // Billing cycle anchor. "contract_start_date" anchors periods to the contract
+  // start day-of-month; "first_billing_period" aligns them to calendar month
+  // boundaries (1st → 1st), leaving a partial first period.
   billing_anchor_date?: "contract_start_date" | "first_billing_period";
   usage_statement_schedule?: {
     frequency: "MONTHLY" | "QUARTERLY" | "ANNUAL" | "WEEKLY";
@@ -242,12 +244,25 @@ const SEAT_TAG = "seat";
 const MONTHLY_TAG = "monthly";
 const YEARLY_TAG = "yearly";
 
-// Billing cycle config shared by all packages — anchored to contract start date.
+// Billing cycle config for legacy packages — anchored to the contract start
+// date (periods recur on the contract start day-of-month).
 export const BILLING_CYCLE_CONFIG = {
   billing_anchor_date: "contract_start_date" as const,
   usage_statement_schedule: {
     frequency: "MONTHLY" as const,
     day: "CONTRACT_START" as const,
+  },
+};
+
+// Billing cycle config for new-pricing packages — anchored to the first of the
+// month. Billing periods (and the usage statement that closes them) align to
+// calendar month boundaries (1st → 1st) regardless of when a contract starts;
+// the first period is a partial stub from contract start to the next 1st.
+export const BILLING_CYCLE_CONFIG_FIRST_OF_MONTH = {
+  billing_anchor_date: "first_billing_period" as const,
+  usage_statement_schedule: {
+    frequency: "MONTHLY" as const,
+    day: "FIRST_OF_MONTH" as const,
   },
 };
 

--- a/front/lib/metronome/setup_new_pricing.ts
+++ b/front/lib/metronome/setup_new_pricing.ts
@@ -13,7 +13,7 @@ import {
 } from "@app/lib/metronome/constants";
 import { TOOL_CATEGORIES } from "@app/lib/metronome/events";
 import {
-  BILLING_CYCLE_CONFIG,
+  BILLING_CYCLE_CONFIG_FIRST_OF_MONTH,
   FREE_SEAT_CREDIT_NAME,
   FREE_SEAT_PRODUCT_NAME,
   getCreditTypeAwuId,
@@ -484,7 +484,7 @@ export function getNewPackages(): PackageDef[] {
           price: 24000,
         },
       ]),
-      ...BILLING_CYCLE_CONFIG,
+      ...BILLING_CYCLE_CONFIG_FIRST_OF_MONTH,
     },
     {
       name: "Enterprise Pooled EUR",
@@ -501,7 +501,7 @@ export function getNewPackages(): PackageDef[] {
           price: 240,
         },
       ]),
-      ...BILLING_CYCLE_CONFIG,
+      ...BILLING_CYCLE_CONFIG_FIRST_OF_MONTH,
     },
     {
       name: "Enterprise Seat-based USD",
@@ -522,7 +522,7 @@ export function getNewPackages(): PackageDef[] {
           price: 168000,
         },
       ]),
-      ...BILLING_CYCLE_CONFIG,
+      ...BILLING_CYCLE_CONFIG_FIRST_OF_MONTH,
     },
     {
       name: "Enterprise Seat-based EUR",
@@ -543,7 +543,7 @@ export function getNewPackages(): PackageDef[] {
           price: 1680,
         },
       ]),
-      ...BILLING_CYCLE_CONFIG,
+      ...BILLING_CYCLE_CONFIG_FIRST_OF_MONTH,
     },
     // Business USD / EUR — Pro and Max seats (plus the free starter seat) priced
     // via overrides; per-seat INDIVIDUAL AWU credit allocations (Pro: 8000 /
@@ -569,7 +569,7 @@ export function getNewPackages(): PackageDef[] {
         },
         { product_name: FREE_SEAT_PRODUCT_NAME, price: 0 },
       ]),
-      ...BILLING_CYCLE_CONFIG,
+      ...BILLING_CYCLE_CONFIG_FIRST_OF_MONTH,
     },
     {
       name: "Business EUR",
@@ -591,7 +591,7 @@ export function getNewPackages(): PackageDef[] {
         },
         { product_name: FREE_SEAT_PRODUCT_NAME, price: 0 },
       ]),
-      ...BILLING_CYCLE_CONFIG,
+      ...BILLING_CYCLE_CONFIG_FIRST_OF_MONTH,
     },
     // Free plan — entitles only the Free Seat.
     {
@@ -604,7 +604,7 @@ export function getNewPackages(): PackageDef[] {
       overrides: buildSeatEntitlementOverrides(CREDIT_TYPE_USD_ID, [
         { product_name: FREE_SEAT_PRODUCT_NAME, price: 0 },
       ]),
-      ...BILLING_CYCLE_CONFIG,
+      ...BILLING_CYCLE_CONFIG_FIRST_OF_MONTH,
     },
   ];
 }

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -799,6 +799,14 @@ interface ExistingPackage {
   aliases?: Array<{ name: string }>;
   rate_card_id?: string;
   scheduled_charges_on_usage_invoices?: "ALL";
+  // Returned by packages.list — the billing-cycle anchor lives here (`day`).
+  // Note: the package-level `billing_anchor_date` we send on create is NOT
+  // echoed back, so we compare `usage_statement_schedule` (the real driver)
+  // rather than that field, which would always mismatch and recreate every run.
+  usage_statement_schedule?: {
+    frequency?: string;
+    day?: string;
+  };
   subscriptions?: Array<{
     collection_schedule: string;
     proration: {
@@ -960,6 +968,30 @@ function packageMatches(ex: ExistingPackage, desired: PackageDef): boolean {
       `    [diff] ${desired.name}: scheduled_charges_on_usage_invoices ${ex.scheduled_charges_on_usage_invoices} → ${desired.scheduled_charges_on_usage_invoices}`
     );
     return false;
+  }
+
+  // Billing cycle: compare the usage statement schedule (frequency + day). The
+  // `day` is what actually anchors billing periods (CONTRACT_START vs
+  // FIRST_OF_MONTH), so a change here must force a package recreation.
+  if (desired.usage_statement_schedule) {
+    if (
+      ex.usage_statement_schedule?.frequency !==
+      desired.usage_statement_schedule.frequency
+    ) {
+      console.log(
+        `    [diff] ${desired.name}: usage_statement_schedule.frequency ${ex.usage_statement_schedule?.frequency} → ${desired.usage_statement_schedule.frequency}`
+      );
+      return false;
+    }
+    if (
+      (ex.usage_statement_schedule?.day ?? undefined) !==
+      (desired.usage_statement_schedule.day ?? undefined)
+    ) {
+      console.log(
+        `    [diff] ${desired.name}: usage_statement_schedule.day ${ex.usage_statement_schedule?.day} → ${desired.usage_statement_schedule.day}`
+      );
+      return false;
+    }
   }
 
   const desiredCredits = desired.recurring_credits ?? [];


### PR DESCRIPTION
## Description

Align **new-pricing** contracts to calendar-month billing boundaries instead of the contract start day.

Previously every package (legacy + new-pricing) shared `BILLING_CYCLE_CONFIG`, which anchored billing periods to the contract start date (`usage_statement_schedule.day: "CONTRACT_START"`) — so a contract starting on the 15th billed on the 15th of each month, and annual subscriptions renewed on the contract anniversary.

This PR:

- Keeps `BILLING_CYCLE_CONFIG` (contract-start anchored) for **legacy** packages — unchanged.
- Adds `BILLING_CYCLE_CONFIG_FIRST_OF_MONTH` (`day: "FIRST_OF_MONTH"`) and uses it for the 7 **new-pricing** packages (Business/Enterprise USD+EUR, Free). Billing periods now align to the 1st of the month; the first period is a partial stub from contract start to the next 1st, and annual subscriptions anchor their renewal to a 1st.
- Fixes the sync gate: `packageMatches` did not compare `usage_statement_schedule`, so flipping the anchor would have matched the existing packages and deployed nothing. It now diffs `frequency` + `day` and forces a package version bump when the anchor changes.

Note on the SDK: the package-level `billing_anchor_date` we send to `packages.create` is **not** echoed back by `packages.list`, so the comparison is on `usage_statement_schedule.day` (the field that actually drives the anchor and round-trips). Comparing `billing_anchor_date` directly would mismatch on every run and recreate the packages endlessly.

## Tests

Manually validated end-to-end against Metronome:

- Ran the setup sync — only the 7 new-pricing packages diffed (`usage_statement_schedule.day CONTRACT_START → FIRST_OF_MONTH`) and were re-versioned; legacy packages stayed up to date.
- Started a new contract and inspected the next invoice:
  - First billing period is the partial stub (contract start → next 1st), invoiced on the following day.
  - The annual Workspace Seat is prorated from contract start to the next **1st-of-month** anniversary (e.g. `May 30 2026 → May 1 2027`), billed in advance, and the prorated amount matches `annual_price × window/year` down to the hour (€220.36 of €240 for ~336 days). ✅

## Risk

- **New contracts only.** The anchor is baked into a contract at creation from its package version, so this affects only contracts created after the new package versions exist. Existing contracts keep their current anchor; migrating them would require per-contract amendments (not in scope).
- Legacy packages are untouched (still `CONTRACT_START`).
- The `packageMatches` change is scoped behind `if (desired.usage_statement_schedule)`, so packages that don't set the field are unaffected (no spurious recreation).
- Rollback: revert the PR and re-run the sync; new contracts go back to contract-start anchoring. Already-created first-of-month contracts are unaffected by the revert.

## Deploy Plan

1. Merge and deploy.
2. Run the Metronome setup sync (`metronome_setup.ts`) — confirm via `--dryrun` first that only the 7 new-pricing packages show the `usage_statement_schedule.day` diff and legacy shows none, then execute.
3. Verify the new package versions exist in Metronome and a fresh contract bills on the 1st.
