### PR TITLE
Fix: prevent Frames edit/creation via the file system tools.

### DIFF
--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -1,6 +1,11 @@
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
+import {
+  CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
+  EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
+  INTERACTIVE_CONTENT_SERVER_NAME,
+} from "@app/lib/api/actions/servers/interactive_content/metadata";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
@@ -230,6 +235,10 @@ const FILES_TOOLS_COMMON_METADATA = {
       "Accepts UTF-8 text content only. Binary files cannot be created via this tool. " +
       `Content is capped at ${CREATE_CONTENT_MAX_BYTES / 1024} KB. ` +
       "If the file already exists it is silently overwritten (shell \`>\` semantics). " +
+      "Does not support Frame files (`application/vnd.dust.frame`, " +
+      "`application/vnd.dust.frame.slideshow`); use " +
+      `\`${getPrefixedToolName(INTERACTIVE_CONTENT_SERVER_NAME, CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME)}\` to create or ` +
+      `\`${getPrefixedToolName(INTERACTIVE_CONTENT_SERVER_NAME, EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME)}\` to edit them. ` +
       "Returns whether the file was created or updated, along with its path and size.",
     schema: {
       path: z

--- a/front/lib/api/actions/servers/files/tools/create.test.ts
+++ b/front/lib/api/actions/servers/files/tools/create.test.ts
@@ -1,0 +1,104 @@
+import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { createHandler } from "@app/lib/api/actions/servers/files/tools/create";
+import { createConversation } from "@app/lib/api/assistant/conversation";
+import { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import assert from "assert";
+import { describe, expect, it, vi } from "vitest";
+
+function makeExtra(
+  auth: Authenticator,
+  conversation: ConversationType
+): ToolHandlerExtra {
+  const agentLoopContext = {
+    runContext: { conversation },
+  } as unknown as AgentLoopContextType;
+  return { auth, agentLoopContext } as unknown as ToolHandlerExtra;
+}
+
+async function setupProjectConversation(): Promise<{
+  auth: Authenticator;
+  conversation: ConversationType;
+}> {
+  const { authenticator: auth, workspace } = await createResourceTest({
+    role: "admin",
+  });
+  const user = auth.getNonNullableUser();
+
+  const space = await SpaceFactory.project(workspace, user.id);
+  const addRes = await space.addMembers(auth, { userIds: [user.sId] });
+  assert(addRes.isOk(), "Failed to add user to project space");
+
+  const projectAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+
+  const conversation = await createConversation(projectAuth, {
+    title: "Test",
+    visibility: "unlisted",
+    spaceId: space.id,
+  });
+
+  return { auth: projectAuth, conversation };
+}
+
+describe("createHandler", () => {
+  it("returns Err when content_type is a frame MIME type", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+
+    const result = await createHandler(
+      {
+        path: `conversation-${conversation.sId}/chart.tsx`,
+        content: "export default function Chart() { return null; }",
+        content_type: "application/vnd.dust.frame",
+      },
+      makeExtra(auth, conversation)
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) {
+      return;
+    }
+    expect(result.error.message).toContain(
+      "interactive_content__create_interactive_content_file"
+    );
+  });
+
+  it("returns Err when overwriting an existing frame file", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+
+    vi.mocked(getPrivateUploadBucket).mockReturnValueOnce({
+      file: vi.fn(() => ({
+        exists: vi.fn().mockResolvedValue([true]),
+        getMetadata: vi
+          .fn()
+          .mockResolvedValue([
+            { contentType: "application/vnd.dust.frame", size: "100" },
+          ]),
+      })),
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+
+    const result = await createHandler(
+      {
+        path: `conversation-${conversation.sId}/interactive.tsx`,
+        content: "export default function App() { return null; }",
+        content_type: "text/plain",
+      },
+      makeExtra(auth, conversation)
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) {
+      return;
+    }
+    expect(result.error.message).toContain(
+      "interactive_content__edit_interactive_content_file"
+    );
+    expect(result.error.message).toContain("files__list");
+  });
+});

--- a/front/lib/api/actions/servers/files/tools/create.ts
+++ b/front/lib/api/actions/servers/files/tools/create.ts
@@ -10,7 +10,15 @@ import {
   requireAgentLoopConversation,
   scopedPathsFromArgs,
 } from "@app/lib/api/actions/servers/files/tools/agent_loop_fs";
-import { isAllSupportedFileContentType } from "@app/types/files";
+import {
+  frameFileCreateRejectedError,
+  frameFileEditRejectedError,
+} from "@app/lib/api/actions/servers/files/tools/utils";
+import {
+  isAllSupportedFileContentType,
+  isInteractiveContentType,
+  stripMimeParameters,
+} from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
@@ -48,9 +56,21 @@ export async function createHandler(
 
   const dustFs = fsResult.value;
 
+  const incomingMimeType = stripMimeParameters(content_type);
+  if (isInteractiveContentType(incomingMimeType)) {
+    return new Err(frameFileCreateRejectedError());
+  }
+
   // Check existence before writing so we can report "Created" vs "Updated".
   const statResult = await dustFs.stat(path);
   const exists = statResult.isOk() && statResult.value !== null;
+
+  if (statResult.isOk() && statResult.value !== null) {
+    const existingMimeType = stripMimeParameters(statResult.value.contentType);
+    if (isInteractiveContentType(existingMimeType)) {
+      return new Err(frameFileEditRejectedError());
+    }
+  }
 
   const writeResult = await dustFs.write(path, contentBuffer, content_type);
   if (writeResult.isErr()) {

--- a/front/lib/api/actions/servers/files/tools/utils.test.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.test.ts
@@ -1,5 +1,27 @@
-import { isReadableAsText } from "@app/lib/api/actions/servers/files/tools/utils";
+import {
+  frameFileCreateRejectedError,
+  frameFileEditRejectedError,
+  isReadableAsText,
+} from "@app/lib/api/actions/servers/files/tools/utils";
 import { describe, expect, it } from "vitest";
+
+describe("frameFileCreateRejectedError", () => {
+  it("names the files create and interactive_content create tools", () => {
+    expect(frameFileCreateRejectedError().message).toContain("files__create");
+    expect(frameFileCreateRejectedError().message).toContain(
+      "interactive_content__create_interactive_content_file"
+    );
+  });
+});
+
+describe("frameFileEditRejectedError", () => {
+  it("names the files list and interactive_content edit tools", () => {
+    expect(frameFileEditRejectedError().message).toContain("files__list");
+    expect(frameFileEditRejectedError().message).toContain(
+      "interactive_content__edit_interactive_content_file"
+    );
+  });
+});
 
 describe("isReadableAsText", () => {
   it("returns true for text/* mime types", () => {

--- a/front/lib/api/actions/servers/files/tools/utils.ts
+++ b/front/lib/api/actions/servers/files/tools/utils.ts
@@ -1,4 +1,15 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
+import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
+import {
+  FILES_CREATE_ACTION_NAME,
+  FILES_LIST_ACTION_NAME,
+  FILES_SERVER_NAME,
+} from "@app/lib/api/actions/servers/files/metadata";
+import {
+  CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
+  EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
+  INTERACTIVE_CONTENT_SERVER_NAME,
+} from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { getGCSPathFromScopedPath } from "@app/lib/api/files/gcs_mount/files";
 import {
   getConversationFilesBasePath,
@@ -132,6 +143,23 @@ export async function resolveFile(
       `File not found: \`${path}\`. Error: ${normalizeError(lastError).message}`,
       { tracked: false }
     )
+  );
+}
+
+export function frameFileCreateRejectedError(): MCPError {
+  return new MCPError(
+    `Frame files cannot be created with \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_CREATE_ACTION_NAME)}\`. ` +
+      `Use \`${getPrefixedToolName(INTERACTIVE_CONTENT_SERVER_NAME, CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME)}\` instead.`,
+    { tracked: false }
+  );
+}
+
+export function frameFileEditRejectedError(): MCPError {
+  return new MCPError(
+    `Frame files cannot be edited with \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_CREATE_ACTION_NAME)}\`. ` +
+      `Use \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\` to get the file id, ` +
+      `then \`${getPrefixedToolName(INTERACTIVE_CONTENT_SERVER_NAME, EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME)}\` to update it.`,
+    { tracked: false }
   );
 }
 


### PR DESCRIPTION
## Description

The `files__create` tool now blocks Frame file creation and overwrite. Two guards added to `createHandler` in `create.ts`:

- **Incoming MIME type**: if `content_type` is `application/vnd.dust.frame` or `application/vnd.dust.frame.slideshow` (detected via `isInteractiveContentType`), returns `frameFileCreateRejectedError` immediately.
- **Existing file MIME type**: if the target path already holds a Frame file (checked via `dustFs.stat`), returns `frameFileEditRejectedError` regardless of the incoming `content_type`.

Both errors are actionable `MCPError`s (untracked) that name the correct tool — `interactive_content__create_interactive_content_file` or `interactive_content__edit_interactive_content_file`. The `files__create` tool description in `metadata.ts` is updated upfront to document the restriction.

## Tests

- New `create.test.ts` with two integration tests: Frame MIME type rejection and existing-frame overwrite rejection (using `vi.mocked(getPrivateUploadBucket)` to simulate existing Frame metadata).
- `utils.test.ts` extended with unit tests for `frameFileCreateRejectedError` and `frameFileEditRejectedError` asserting correct tool names in error messages.

## Risk

Low. Guards return early with descriptive errors before any write occurs. No existing behaviour changed for non-Frame files. Rollback is safe.

## Deploy Plan

Deploy front.
