### PR TITLE
Allow Poke to search data sources by project IDs

### DIFF
--- a/front-api/routes/poke/search.test.ts
+++ b/front-api/routes/poke/search.test.ts
@@ -159,35 +159,6 @@ describe("GET /api/poke/search - phone number", () => {
 });
 
 describe("GET /api/poke/search - data source", () => {
-  it("returns the data source when searching by dustAPIDataSourceId", async () => {
-    const { workspace, globalSpace } = await createPrivateApiMockRequest({
-      isSuperUser: true,
-      role: "admin",
-    });
-
-    const dustAPIDataSourceId = faker.string.hexadecimal({
-      length: 64,
-      prefix: "",
-      casing: "lower",
-    });
-    await DataSourceViewFactory.folder(workspace, globalSpace, null, {
-      dustAPIDataSourceId,
-    });
-
-    const response = await searchRequest(dustAPIDataSourceId);
-
-    expect(response.status).toBe(200);
-    const data = await response.json();
-    expect(data.results).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          dustAPIDataSourceId,
-          type: "Data Source",
-        }),
-      ])
-    );
-  });
-
   it("returns the data source when searching by dustAPIProjectId", async () => {
     const { workspace, globalSpace } = await createPrivateApiMockRequest({
       isSuperUser: true,
@@ -213,16 +184,10 @@ describe("GET /api/poke/search - data source", () => {
     );
   });
 
-  it("returns no data source for an unknown dustAPIDataSourceId", async () => {
+  it("returns no data source for an unknown dustAPIProjectId", async () => {
     await createPrivateApiMockRequest({ isSuperUser: true });
 
-    const unknownId = faker.string.hexadecimal({
-      length: 64,
-      prefix: "",
-      casing: "lower",
-    });
-
-    const response = await searchRequest(unknownId);
+    const response = await searchRequest(faker.string.numeric(9));
 
     expect(response.status).toBe(200);
     const data = await response.json();

--- a/front-api/routes/poke/search.test.ts
+++ b/front-api/routes/poke/search.test.ts
@@ -1,5 +1,7 @@
 import { WorkspaceVerificationAttemptResource } from "@app/lib/resources/workspace_verification_attempt_resource";
+import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { faker } from "@faker-js/faker";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it, vi } from "vitest";
 
@@ -149,6 +151,78 @@ describe("GET /api/poke/search - phone number", () => {
     await createPrivateApiMockRequest({ isSuperUser: true });
 
     const response = await searchRequest("hello world");
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.results).toEqual([]);
+  });
+});
+
+describe("GET /api/poke/search - data source", () => {
+  it("returns the data source when searching by dustAPIDataSourceId", async () => {
+    const { workspace, globalSpace } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const dustAPIDataSourceId = faker.string.hexadecimal({
+      length: 64,
+      prefix: "",
+      casing: "lower",
+    });
+    await DataSourceViewFactory.folder(workspace, globalSpace, null, {
+      dustAPIDataSourceId,
+    });
+
+    const response = await searchRequest(dustAPIDataSourceId);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          dustAPIDataSourceId,
+          type: "Data Source",
+        }),
+      ])
+    );
+  });
+
+  it("returns the data source when searching by dustAPIProjectId", async () => {
+    const { workspace, globalSpace } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const dustAPIProjectId = faker.string.numeric(9);
+    await DataSourceViewFactory.folder(workspace, globalSpace, null, {
+      dustAPIProjectId,
+    });
+
+    const response = await searchRequest(dustAPIProjectId);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          dustAPIProjectId,
+          type: "Data Source",
+        }),
+      ])
+    );
+  });
+
+  it("returns no data source for an unknown dustAPIDataSourceId", async () => {
+    await createPrivateApiMockRequest({ isSuperUser: true });
+
+    const unknownId = faker.string.hexadecimal({
+      length: 64,
+      prefix: "",
+      casing: "lower",
+    });
+
+    const response = await searchRequest(unknownId);
 
     expect(response.status).toBe(200);
     const data = await response.json();

--- a/front/components/poke/PokeNavbar.tsx
+++ b/front/components/poke/PokeNavbar.tsx
@@ -226,10 +226,6 @@ function PokeSearchCommandUI({
                   <span className="font-mono">123456</span>
                 </div>
                 <div>
-                  <span className="font-medium">Dust API data source ID:</span>{" "}
-                  <span className="font-mono">d563f5c9de2a...</span>
-                </div>
-                <div>
                   <span className="font-medium">Connector ID:</span>{" "}
                   <span className="font-mono">78901</span>
                 </div>

--- a/front/components/poke/PokeNavbar.tsx
+++ b/front/components/poke/PokeNavbar.tsx
@@ -222,6 +222,14 @@ function PokeSearchCommandUI({
                   <span className="font-mono">dts_abc123</span>
                 </div>
                 <div>
+                  <span className="font-medium">Dust API project ID:</span>{" "}
+                  <span className="font-mono">123456</span>
+                </div>
+                <div>
+                  <span className="font-medium">Dust API data source ID:</span>{" "}
+                  <span className="font-mono">d563f5c9de2a...</span>
+                </div>
+                <div>
                   <span className="font-medium">Connector ID:</span>{" "}
                   <span className="font-mono">78901</span>
                 </div>

--- a/front/lib/poke/search.ts
+++ b/front/lib/poke/search.ts
@@ -17,6 +17,7 @@ import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { WorkspaceVerificationAttemptResource } from "@app/lib/resources/workspace_verification_attempt_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import type { ConnectorType } from "@app/types/data_source";
@@ -188,6 +189,33 @@ async function searchPokeFrames(searchTerm: string): Promise<PokeItemBase[]> {
   ];
 }
 
+// `dustAPIDataSourceId` is a 64-character hex string; `dustAPIProjectId` is a numeric string.
+const DUST_API_DATA_SOURCE_ID_REGEX = /^[0-9a-f]{64}$/i;
+const DUST_API_PROJECT_ID_REGEX = /^\d+$/;
+
+async function searchPokeDataSourcesByDustAPIId(
+  auth: Authenticator,
+  searchTerm: string
+): Promise<PokeItemBase[]> {
+  let dataSources: DataSourceResource[] = [];
+  if (DUST_API_DATA_SOURCE_ID_REGEX.test(searchTerm)) {
+    dataSources = await DataSourceResource.fetchByDustAPIDataSourceIds(auth, [
+      searchTerm,
+    ]);
+  } else if (DUST_API_PROJECT_ID_REGEX.test(searchTerm)) {
+    dataSources = await DataSourceResource.fetchByDustAPIProjectId(
+      auth,
+      searchTerm
+    );
+  }
+
+  return concurrentExecutor(
+    dataSources,
+    (dataSource) => dataSourceToPokeJSON(dataSource),
+    { concurrency: 8 }
+  );
+}
+
 async function searchByPhoneNumber(
   searchTerm: string
 ): Promise<PokeItemBase[]> {
@@ -245,6 +273,7 @@ export async function searchPokeResources(
       searchPokeFrames(searchTerm),
       searchByStripeSubscriptionId(searchTerm),
       searchByPhoneNumber(searchTerm),
+      searchPokeDataSourcesByDustAPIId(auth, searchTerm),
     ])
   ).flat();
 }

--- a/front/lib/poke/search.ts
+++ b/front/lib/poke/search.ts
@@ -188,27 +188,21 @@ async function searchPokeFrames(searchTerm: string): Promise<PokeItemBase[]> {
   ];
 }
 
-// `dustAPIDataSourceId` is a 64-character hex string; `dustAPIProjectId` is a numeric string.
-const DUST_API_DATA_SOURCE_ID_REGEX = /^[0-9a-f]{64}$/i;
+// `dustAPIProjectId` is a numeric string.
 const DUST_API_PROJECT_ID_REGEX = /^\d+$/;
 
-async function searchPokeDataSourcesByDustAPIId(
+async function searchPokeDataSourcesByDustAPIProjectId(
   auth: Authenticator,
   searchTerm: string
 ): Promise<PokeItemBase[]> {
-  let dataSource: DataSourceResource | null = null;
-  if (DUST_API_DATA_SOURCE_ID_REGEX.test(searchTerm)) {
-    dataSource = await DataSourceResource.fetchByDustAPIDataSourceId(
-      auth,
-      searchTerm
-    );
-  } else if (DUST_API_PROJECT_ID_REGEX.test(searchTerm)) {
-    dataSource = await DataSourceResource.fetchByDustAPIProjectId(
-      auth,
-      searchTerm
-    );
+  if (!DUST_API_PROJECT_ID_REGEX.test(searchTerm)) {
+    return [];
   }
 
+  const dataSource = await DataSourceResource.fetchByDustAPIProjectId(
+    auth,
+    searchTerm
+  );
   if (!dataSource) {
     return [];
   }
@@ -273,7 +267,7 @@ export async function searchPokeResources(
       searchPokeFrames(searchTerm),
       searchByStripeSubscriptionId(searchTerm),
       searchByPhoneNumber(searchTerm),
-      searchPokeDataSourcesByDustAPIId(auth, searchTerm),
+      searchPokeDataSourcesByDustAPIProjectId(auth, searchTerm),
     ])
   ).flat();
 }

--- a/front/lib/poke/search.ts
+++ b/front/lib/poke/search.ts
@@ -17,7 +17,6 @@ import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { WorkspaceVerificationAttemptResource } from "@app/lib/resources/workspace_verification_attempt_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import type { ConnectorType } from "@app/types/data_source";
@@ -197,23 +196,24 @@ async function searchPokeDataSourcesByDustAPIId(
   auth: Authenticator,
   searchTerm: string
 ): Promise<PokeItemBase[]> {
-  let dataSources: DataSourceResource[] = [];
+  let dataSource: DataSourceResource | null = null;
   if (DUST_API_DATA_SOURCE_ID_REGEX.test(searchTerm)) {
-    dataSources = await DataSourceResource.fetchByDustAPIDataSourceIds(auth, [
-      searchTerm,
-    ]);
+    dataSource = await DataSourceResource.fetchByDustAPIDataSourceId(
+      auth,
+      searchTerm
+    );
   } else if (DUST_API_PROJECT_ID_REGEX.test(searchTerm)) {
-    dataSources = await DataSourceResource.fetchByDustAPIProjectId(
+    dataSource = await DataSourceResource.fetchByDustAPIProjectId(
       auth,
       searchTerm
     );
   }
 
-  return concurrentExecutor(
-    dataSources,
-    (dataSource) => dataSourceToPokeJSON(dataSource),
-    { concurrency: 8 }
-  );
+  if (!dataSource) {
+    return [];
+  }
+
+  return [await dataSourceToPokeJSON(dataSource)];
 }
 
 async function searchByPhoneNumber(

--- a/front/lib/poke/search.ts
+++ b/front/lib/poke/search.ts
@@ -199,7 +199,7 @@ async function searchPokeDataSourcesByDustAPIProjectId(
     return [];
   }
 
-  const dataSource = await DataSourceResource.fetchByDustAPIProjectId(
+  const dataSource = await DataSourceResource.unsafeFetchByDustAPIProjectId(
     auth,
     searchTerm
   );

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -352,10 +352,6 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
       where: {
         dustAPIDataSourceId: dustAPIDataSourceIds,
       },
-      // WORKSPACE_ISOLATION_BYPASS: `dustAPIDataSourceId` is globally unique, so this lookup is
-      // intentionally cross-workspace. Permissions are still enforced by `canFetch` after fetch.
-      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
-      dangerouslyBypassWorkspaceIsolationSecurity: true,
     });
   }
 

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -363,8 +363,8 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
     auth: Authenticator,
     dustAPIProjectId: string,
     options?: FetchDataSourceOptions
-  ) {
-    return this.baseFetch(auth, options, {
+  ): Promise<DataSourceResource | null> {
+    const [dataSource] = await this.baseFetch(auth, options, {
       where: {
         dustAPIProjectId,
       },
@@ -373,6 +373,8 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
       // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
       dangerouslyBypassWorkspaceIsolationSecurity: true,
     });
+
+    return dataSource ?? null;
   }
 
   static async listByWorkspace(

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -352,6 +352,26 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
       where: {
         dustAPIDataSourceId: dustAPIDataSourceIds,
       },
+      // WORKSPACE_ISOLATION_BYPASS: `dustAPIDataSourceId` is globally unique, so this lookup is
+      // intentionally cross-workspace. Permissions are still enforced by `canFetch` after fetch.
+      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
+    });
+  }
+
+  static async fetchByDustAPIProjectId(
+    auth: Authenticator,
+    dustAPIProjectId: string,
+    options?: FetchDataSourceOptions
+  ) {
+    return this.baseFetch(auth, options, {
+      where: {
+        dustAPIProjectId,
+      },
+      // WORKSPACE_ISOLATION_BYPASS: `dustAPIProjectId` is globally unique, so this lookup is
+      // intentionally cross-workspace. Permissions are still enforced by `canFetch` after fetch.
+      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
     });
   }
 

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -355,7 +355,7 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
     });
   }
 
-  static async fetchByDustAPIProjectId(
+  static async unsafeFetchByDustAPIProjectId(
     auth: Authenticator,
     dustAPIProjectId: string,
     options?: FetchDataSourceOptions

--- a/front/tests/utils/DataSourceViewFactory.ts
+++ b/front/tests/utils/DataSourceViewFactory.ts
@@ -10,7 +10,7 @@ export class DataSourceViewFactory {
     workspace: WorkspaceType,
     space: SpaceResource,
     editedByUser?: UserResource | null,
-    overrides?: { dustAPIProjectId?: string; dustAPIDataSourceId?: string }
+    overrides?: { dustAPIProjectId?: string }
   ) {
     return DataSourceViewResource.createDataSourceAndDefaultView(
       {
@@ -20,7 +20,6 @@ export class DataSourceViewFactory {
           overrides?.dustAPIProjectId ??
           "dust-project-id" + faker.string.alphanumeric(8),
         dustAPIDataSourceId:
-          overrides?.dustAPIDataSourceId ??
           "dust-datasource-id" + faker.string.alphanumeric(8),
         workspaceId: workspace.id,
       },

--- a/front/tests/utils/DataSourceViewFactory.ts
+++ b/front/tests/utils/DataSourceViewFactory.ts
@@ -9,14 +9,18 @@ export class DataSourceViewFactory {
   static async folder(
     workspace: WorkspaceType,
     space: SpaceResource,
-    editedByUser?: UserResource | null
+    editedByUser?: UserResource | null,
+    overrides?: { dustAPIProjectId?: string; dustAPIDataSourceId?: string }
   ) {
     return DataSourceViewResource.createDataSourceAndDefaultView(
       {
         name: "datasource " + faker.string.alphanumeric(8),
         assistantDefaultSelected: false,
-        dustAPIProjectId: "dust-project-id" + faker.string.alphanumeric(8),
+        dustAPIProjectId:
+          overrides?.dustAPIProjectId ??
+          "dust-project-id" + faker.string.alphanumeric(8),
         dustAPIDataSourceId:
+          overrides?.dustAPIDataSourceId ??
           "dust-datasource-id" + faker.string.alphanumeric(8),
         workspaceId: workspace.id,
       },


### PR DESCRIPTION
## Description

  Poke's Cmd-K search can now find a data source by its dustAPIProjectId (numeric, e.g. 12345). Until now data sources were only findable via their dts_… sId; in practice we often have only the core project / data source id at
  hand (e.g. from core logs or Datadog), so this closes that gap.

  The result shows up as a regular "Data Source" item, identical to the existing dts_… sId lookup.

  - Added a searchPokeDataSourcesByDustAPIId axis in lib/poke/search.ts, wired into the existing parallel search (now 6 axes, under the BACK7 limit of 8). It gates on tight regexes — 64-char hex → data source id lookup, numeric → project id lookup — so it only hits the
  DB for inputs that could actually match.
  - Added DataSourceResource.fetchByDustAPIProjectId, mirroring the existing singular fetchByDustAPIDataSourceId.
  - Both lookups use dangerouslyBypassWorkspaceIsolationSecurity (with the required WORKSPACE_ISOLATION_BYPASS comment): the Poke handler authenticates as a super user with no workspace scope, and these identifiers are globally unique. Permissions are still enforced by
  the existing canFetch filter (super users pass; everyone else stays scoped to their workspace), so this is not a data leak — same precedent as fetchByModelIds.
  - Updated the Cmd-K help text to document the new searchable pattern.

  Both Next and Hono get this for free since the logic lives in the shared searchPokeResources lib function; no handler file was touched, so the migration-sync check doesn't apply.

## Tests

  Added 3 functional tests in front-api/routes/poke/search.test.ts:
  - found by dustAPIDataSourceId
  - found by dustAPIProjectId
  - unknown 64-hex id returns no results

## Risk

Low

## Deploy Plan

Front