### PR TITLE
Enterprise seats are yearly only

### DIFF
--- a/front/lib/metronome/setup_new_pricing.ts
+++ b/front/lib/metronome/setup_new_pricing.ts
@@ -476,8 +476,8 @@ export function getNewPackages(): PackageDef[] {
       subscriptions: ALL_SEAT_SUBSCRIPTIONS,
       scheduled_charges_on_usage_invoices: "ALL",
       recurring_credits: getAllSeatRecurringCredits(),
+      // Enterprise contracts are yearly-only: only the annual seat is entitled.
       overrides: buildSeatEntitlementOverrides(CREDIT_TYPE_USD_ID, [
-        { product_name: WORKSPACE_SEAT_PRODUCT_NAME, price: 2000 },
         {
           product_name:
             WORKSPACE_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
@@ -493,8 +493,8 @@ export function getNewPackages(): PackageDef[] {
       subscriptions: ALL_SEAT_SUBSCRIPTIONS,
       scheduled_charges_on_usage_invoices: "ALL",
       recurring_credits: getAllSeatRecurringCredits(),
+      // Enterprise contracts are yearly-only: only the annual seat is entitled.
       overrides: buildSeatEntitlementOverrides(CREDIT_TYPE_EUR_ID, [
-        { product_name: WORKSPACE_SEAT_PRODUCT_NAME, price: 20 },
         {
           product_name:
             WORKSPACE_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
@@ -510,13 +510,12 @@ export function getNewPackages(): PackageDef[] {
       subscriptions: ALL_SEAT_SUBSCRIPTIONS,
       scheduled_charges_on_usage_invoices: "ALL",
       recurring_credits: getAllSeatRecurringCredits(),
+      // Enterprise contracts are yearly-only: only the annual seats are entitled.
       overrides: buildSeatEntitlementOverrides(CREDIT_TYPE_USD_ID, [
-        { product_name: PRO_SEAT_PRODUCT_NAME, price: 4400 },
         {
           product_name: PRO_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
           price: 52800,
         },
-        { product_name: MAX_SEAT_PRODUCT_NAME, price: 14000 },
         {
           product_name: MAX_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
           price: 168000,
@@ -531,13 +530,12 @@ export function getNewPackages(): PackageDef[] {
       subscriptions: ALL_SEAT_SUBSCRIPTIONS,
       scheduled_charges_on_usage_invoices: "ALL",
       recurring_credits: getAllSeatRecurringCredits(),
+      // Enterprise contracts are yearly-only: only the annual seats are entitled.
       overrides: buildSeatEntitlementOverrides(CREDIT_TYPE_EUR_ID, [
-        { product_name: PRO_SEAT_PRODUCT_NAME, price: 44 },
         {
           product_name: PRO_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
           price: 528,
         },
-        { product_name: MAX_SEAT_PRODUCT_NAME, price: 140 },
         {
           product_name: MAX_SEAT_PRODUCT_NAME + SEAT_PRODUCT_YEARLY_SUFFIX,
           price: 1680,


### PR DESCRIPTION
## Description

Enterprise contracts (new pricing) should only offer yearly subscriptions. This removes the monthly seat entitlement overrides from all four Enterprise packages in `setup_new_pricing.ts`, so only the annual (`*_yearly`) seats are entitled:

- **Enterprise Pooled USD / EUR** — drop the monthly `WORKSPACE_SEAT` override, keep only the annual one.
- **Enterprise Seat-based USD / EUR** — drop the monthly `PRO_SEAT` and `MAX_SEAT` overrides, keep only their annual variants.

Business and Free packages are unchanged and still entitle monthly seats. The monthly seats remain defined on the shared rate card at `entitled: false` / price 0 — they're simply no longer flipped on for Enterprise, so they stay dormant and never bill.

## Tests

`npx tsgo --noEmit` passes. No tests reference these package definitions directly. Change is config-only (Metronome package setup).

## Risk

Low. Only affects which seats are entitled on newly created/updated Enterprise Metronome packages; monthly Enterprise seats are no longer entitled. Existing rate-card definitions are untouched. Safe to roll back by re-adding the monthly override entries.

## Deploy Plan

Standard deploy. Re-run the Metronome package setup so the updated Enterprise packages (yearly-only entitlements) are applied.
