### PR TITLE
Fixed default seatType

### DIFF
--- a/front/lib/metronome/seat_types.test.ts
+++ b/front/lib/metronome/seat_types.test.ts
@@ -1,0 +1,46 @@
+import type { CachedContract } from "@app/lib/metronome/plan_type";
+import { getDefaultSeatTypeForContract } from "@app/lib/metronome/seat_types";
+import type { MembershipSeatType } from "@app/types/memberships";
+import { describe, expect, it } from "vitest";
+
+// Drives new-member seat assignment (`resolveSeatTypeForNewMembership`).
+describe("getDefaultSeatTypeForContract — entitlement", () => {
+  const productSeatTypes = new Map<string, MembershipSeatType>([
+    ["workspace-product", "workspace"],
+    ["workspace-yearly-product", "workspace_yearly"],
+  ]);
+
+  // Contract carries both the monthly and yearly workspace seat subscriptions,
+  // but only `workspace_yearly` is entitled (the monthly one is dormant).
+  const contract = {
+    subscriptions: [
+      {
+        id: "sub_ws",
+        subscription_rate: {
+          product: { id: "workspace-product", name: "workspace" },
+        },
+      },
+      {
+        id: "sub_ws_yearly",
+        subscription_rate: {
+          product: {
+            id: "workspace-yearly-product",
+            name: "Workspace Seat (Yearly)",
+          },
+        },
+      },
+    ],
+    recurring_credits: [],
+    overrides: [
+      { entitled: true, product: { id: "workspace-yearly-product" } },
+    ],
+  } as unknown as CachedContract;
+
+  it("assigns the entitled seat, not a dormant lower-name subscription", () => {
+    // Both seats are 0 AWU; without entitlement filtering the tie-break would
+    // pick "workspace" (< "workspace_yearly"). Entitlement must win.
+    expect(getDefaultSeatTypeForContract(contract, productSeatTypes)).toBe(
+      "workspace_yearly"
+    );
+  });
+});

--- a/front/lib/metronome/seat_types.ts
+++ b/front/lib/metronome/seat_types.ts
@@ -89,9 +89,7 @@ export function getSeatTypeForSubscription(
  * contract creation); seat contracts never have it. Use this gate before any
  * seat-related work on a contract.
  */
-export function isMauContract(
-  contract: Pick<CachedContract, "custom_fields">
-): boolean {
+export function isMauContract(contract: CachedContract): boolean {
   return Boolean(contract.custom_fields?.MAU_THRESHOLD);
 }
 
@@ -151,7 +149,7 @@ export type FreeSeatCounts = {
  * creation).
  */
 export function getDefaultSeatTypeForContract(
-  contract: Pick<CachedContract, "subscriptions" | "recurring_credits">,
+  contract: CachedContract,
   productSeatTypes: Map<string, MembershipSeatType>,
   {
     isReturningMember = false,
@@ -208,19 +206,67 @@ export function getDefaultSeatTypeForContract(
 }
 
 /**
+ * Seat product IDs the contract actually *sells*, i.e. flipped on with an
+ * `entitled: true` override. Non-legacy rate cards carry every seat product at
+ * `entitled: false`; each package/contract entitles only the seats it sells, so
+ * a bare subscription does NOT mean the seat is billable — the entitlement
+ * override does.
+ */
+function getEntitledSeatProductIds(
+  contract: CachedContract,
+  productSeatTypes: Map<string, MembershipSeatType>
+): Set<string> {
+  const ids = new Set<string>();
+  for (const override of contract.overrides ?? []) {
+    if (override.entitled !== true) {
+      continue;
+    }
+    const productIds = [
+      override.product?.id,
+      ...(override.override_specifiers ?? []).map((s) => s.product_id),
+    ];
+    for (const productId of productIds) {
+      if (productId && productSeatTypes.has(productId)) {
+        ids.add(productId);
+      }
+    }
+  }
+  return ids;
+}
+
+/**
  * Walk a contract's subscriptions and build a `seatType → subscription`
  * index using the cached product seat-type map.
+ *
+ * Only seats the contract actually *sells* are included: a seat must be
+ * entitled (`entitled: true` override) — a bare subscription is not enough,
+ * since every package carries all seat subscriptions with the unsold ones at
+ * `entitled: false`. Contracts that don't express seat entitlement at all
+ * (legacy) fall back to including every seat subscription.
  */
 export function getSeatSubscriptionsFromContract(
-  contract: Pick<CachedContract, "subscriptions">,
+  contract: CachedContract,
   productSeatTypes: Map<string, MembershipSeatType>
 ): Map<MembershipSeatType, Subscription> {
+  const entitledSeatProductIds = getEntitledSeatProductIds(
+    contract,
+    productSeatTypes
+  );
   const result = new Map<MembershipSeatType, Subscription>();
   for (const sub of contract.subscriptions ?? []) {
     const seatType = getSeatTypeForSubscription(sub, productSeatTypes);
-    if (seatType) {
-      result.set(seatType, sub);
+    if (!seatType) {
+      continue;
     }
+    // When the contract expresses seat entitlement, keep only entitled seats;
+    // otherwise (no seat entitlement overrides → legacy) keep all.
+    if (
+      entitledSeatProductIds.size > 0 &&
+      !entitledSeatProductIds.has(sub.subscription_rate.product.id)
+    ) {
+      continue;
+    }
+    result.set(seatType, sub);
   }
   return result;
 }
@@ -231,7 +277,7 @@ export function getSeatSubscriptionsFromContract(
  * that exposes only product IDs.
  */
 export function getSeatTypesByProductIdFromContract(
-  contract: Pick<CachedContract, "subscriptions">,
+  contract: CachedContract,
   productSeatTypes: Map<string, MembershipSeatType>
 ): Map<string, MembershipSeatType> {
   const result = new Map<string, MembershipSeatType>();
@@ -286,7 +332,7 @@ function getSeatAwuCreditsPeriod(
  * seats on legacy plans).
  */
 export function getAwuAllocationInfoForSeatType(
-  contract: Pick<CachedContract, "subscriptions" | "recurring_credits">,
+  contract: CachedContract,
   seatType: MembershipSeatType,
   productSeatTypes: Map<string, MembershipSeatType>
 ): SeatAwuAllocationInfo {
@@ -312,7 +358,7 @@ export function getAwuAllocationInfoForSeatType(
 }
 
 export function getAwuAllocationForSeatType(
-  contract: Pick<CachedContract, "subscriptions" | "recurring_credits">,
+  contract: CachedContract,
   seatType: MembershipSeatType,
   productSeatTypes: Map<string, MembershipSeatType>
 ): number {


### PR DESCRIPTION
## Description

Fix the default seat type assigned to memberships so it reflects the seat the contract actually **sells**, not a dormant one.

**Problem.** New members were assigned `workspace` even on contracts that only sell `workspace_yearly`. Non-legacy rate cards carry a subscription for **every** seat product, with the unsold ones flipped off (`entitled: false`); a contract entitles only the seats it sells via `entitled: true` overrides. `getSeatSubscriptionsFromContract` ignored entitlement and returned all seat subscriptions, so `getDefaultSeatTypeForContract` saw both `workspace` and `workspace_yearly` (both 0 AWU) and the name tie-break picked `"workspace"` — the dormant seat.

**Fix.** Make `getSeatSubscriptionsFromContract` entitlement-aware:
- resolve the entitled seat product IDs from the contract's `entitled: true` overrides (`getEntitledSeatProductIds`);
- include only entitled seats;
- fall back to all seat subscriptions when the contract expresses no seat entitlement at all (legacy contracts), preserving existing behavior.

Because `getDefaultSeatTypeForContract` (which drives `resolveSeatTypeForNewMembership`) builds on `getSeatSubscriptionsFromContract`, new-member seat assignment now picks the entitled seat (e.g. `workspace_yearly`). Picks updated to carry `overrides`.

## Tests

- Unit test (`lib/metronome/seat_types.test.ts`): a contract carrying both the dormant `workspace` and an entitled `workspace_yearly` subscription resolves the default to `workspace_yearly` (previously `workspace`).
- Full `lib/metronome` suite green; `npx tsgo --noEmit` and `npm run format:changed` clean.

## Risk

Low. Behavior only changes for contracts that carry dormant (`entitled:false`) seat subscriptions — i.e. new-pricing contracts, where the previous behavior was wrong. Contracts with no seat-entitlement overrides (legacy) fall back to the old "all subscriptions" behavior, so they're unaffected. No schema change; rollback by reverting.

## Deploy Plan

Standard deploy. No database migration and no manual steps. Rollback: revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
