### PR TITLE
Drop upserts that have been in the queue for over an hour

### DIFF
--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -637,6 +637,7 @@ impl LocalTable {
             project_id: self.table.project().project_id(),
             data_source_id: self.table.data_source_id().to_string(),
             table_id: self.table.table_id().to_string(),
+            attempts: 0,
         };
         let _: () = redis_conn
             .hset(

--- a/core/src/databases/table_upserts_background_worker.rs
+++ b/core/src/databases/table_upserts_background_worker.rs
@@ -45,6 +45,12 @@ pub struct TableUpsertActivityData {
     pub project_id: i64,
     pub data_source_id: String,
     pub table_id: String,
+    // Number of times we've tried and failed to process this entry. Bumped on each
+    // failed attempt and used to ensure we never drop an entry that has never been
+    // tried (e.g. after the worker was down longer than MAX_UPSERT_AGE_MS). Existing
+    // entries written before this field existed default to 0.
+    #[serde(default)]
+    pub attempts: u32,
 }
 
 pub struct TableUpsertsBackgroundWorker {
@@ -80,8 +86,8 @@ impl TableUpsertsBackgroundWorker {
     async fn process_table(
         &mut self,
         table: &Table,
-        key: String,
-        table_data: TableUpsertActivityData,
+        key: &str,
+        table_data: &TableUpsertActivityData,
     ) -> Result<(), anyhow::Error> {
         let files =
             GoogleCloudStorageBackgroundProcessingStore::get_gcs_csv_file_names_for_table(&table)
@@ -175,7 +181,7 @@ impl TableUpsertsBackgroundWorker {
         }
 
         let lock_manager = LockManager::new(vec![REDIS_URI.clone()]);
-        for (key, table_data) in active_tables {
+        for (key, mut table_data) in active_tables {
             // They're ordered from oldest to newest, meaning we first see those that are most
             // likely to be past the debounce time. As soon as we find one that is not
             // past the debounce time, we can stop processing.
@@ -185,17 +191,21 @@ impl TableUpsertsBackgroundWorker {
                 break;
             }
 
-            // Drop entries that have been stuck far past the debounce window. These are
-            // poison items (consistently failing) that we'd otherwise retry forever.
+            // Drop entries that have been stuck far past the debounce window AND have already
+            // failed at least once. These are poison items (consistently failing) that we'd
+            // otherwise retry forever. The attempts > 0 guard ensures we never drop an entry
+            // that has never been tried (e.g. if the worker was down for a long time, every
+            // queued entry would be old but untried).
             // Note: this leaves the table's CSV files orphaned in GCS, which is an
             // acceptable (small, separately cleanable) trade-off for not blocking the queue.
-            if time_since_last_upsert > MAX_UPSERT_AGE_MS {
+            if time_since_last_upsert > MAX_UPSERT_AGE_MS && table_data.attempts > 0 {
                 error!(
                     project_id = table_data.project_id,
                     data_source_id = table_data.data_source_id,
                     table_id = table_data.table_id,
                     age_ms = time_since_last_upsert,
-                    "TableUpsertsBackgroundWorker: Entry exceeded max age, dropping"
+                    attempts = table_data.attempts,
+                    "TableUpsertsBackgroundWorker: Entry exceeded max age after failed attempts, dropping"
                 );
                 let _: () = self
                     .redis_conn
@@ -244,11 +254,25 @@ impl TableUpsertsBackgroundWorker {
 
                     // If it fails, log an error but continue processing other tables.
                     // Also, we need to make sure the lock is always released.
-                    if let Err(e) = self.process_table(&table, key, table_data).await {
+                    if let Err(e) = self.process_table(&table, &key, &table_data).await {
                         error!(
                             table_id = table.table_id(),
                             "TableUpsertsBackgroundWorker: Failed to process table: {}", e
                         );
+
+                        // Record the failed attempt so that, once this entry exceeds the max
+                        // age, it gets dropped instead of being retried forever. We keep `time`
+                        // unchanged so the age anchor is preserved. New activity from the
+                        // producer will overwrite this entry and reset attempts to 0.
+                        table_data.attempts += 1;
+                        let _: () = self
+                            .redis_conn
+                            .hset(
+                                REDIS_TABLE_UPSERT_HASH_NAME,
+                                &key,
+                                serde_json::to_string(&table_data)?,
+                            )
+                            .await?;
                     }
 
                     lock_manager.unlock(&lock).await;

--- a/core/src/databases/table_upserts_background_worker.rs
+++ b/core/src/databases/table_upserts_background_worker.rs
@@ -34,6 +34,11 @@ pub const REDIS_LOCK_TTL_SECONDS: u64 = 60;
 
 const UPSERT_DEBOUNCE_TIME_MS: u64 = 10_000;
 
+// Entries that have been stuck in the queue far past the debounce window are
+// poison items (consistently failing), which we'd otherwise retry forever.
+// Drop them once they exceed this age.
+const MAX_UPSERT_AGE_MS: u64 = 60 * 60 * 1_000; // 1 hour
+
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct TableUpsertActivityData {
     pub time: u64,
@@ -178,6 +183,25 @@ impl TableUpsertsBackgroundWorker {
             let time_since_last_upsert = utils::now() - table_data.time; // time is in milliseconds, so we can compare directly
             if time_since_last_upsert < UPSERT_DEBOUNCE_TIME_MS {
                 break;
+            }
+
+            // Drop entries that have been stuck far past the debounce window. These are
+            // poison items (consistently failing) that we'd otherwise retry forever.
+            // Note: this leaves the table's CSV files orphaned in GCS, which is an
+            // acceptable (small, separately cleanable) trade-off for not blocking the queue.
+            if time_since_last_upsert > MAX_UPSERT_AGE_MS {
+                error!(
+                    project_id = table_data.project_id,
+                    data_source_id = table_data.data_source_id,
+                    table_id = table_data.table_id,
+                    age_ms = time_since_last_upsert,
+                    "TableUpsertsBackgroundWorker: Entry exceeded max age, dropping"
+                );
+                let _: () = self
+                    .redis_conn
+                    .hdel(REDIS_TABLE_UPSERT_HASH_NAME, key)
+                    .await?;
+                continue;
             }
 
             let table = self


### PR DESCRIPTION
## Description

## What

  Stop the table upserts background worker from retrying a "poison" queue entry forever, while guaranteeing we never drop an entry that has never actually been tried.

  ## Why

  In `table_upserts_background_worker.rs`, tables are pulled from a Redis queue (`TABLE_UPSERT`) and processed once they're past the debounce window. When `process_table` fails, the error is logged and we move on — but the entry stays in the queue. A consistently-failing table therefore gets re-fetched from GCS and re-attempted on **every** loop iteration (~once per second), indefinitely. Not only this spams the logs with errors, but if it's due to a bad item causing an OOM condition, it can keep crashing the Core worker.

  Previously this was only handled for two specific errors (`"Too many columns in CSV file"`, `"CSV file is too large"`) via string matching. This PR adds a general backstop for any consistent failure.

  ## How

  **1. Age-based drop.** Any queue entry whose last activity is older than `MAX_UPSERT_AGE_MS` (1 hour) is dropped (`HDEL`) with an error log instead of being retried. The check sits right after the existing debounce check, before the table load, so it also covers entries where the load itself is what's failing. The cutoff is far beyond normal processing latency (debounce is 10s), so a healthy table never hits it.

  **2. "Has been attempted" guard.** Age alone can't distinguish "failing for an hour" from "sat in the queue for an hour because the worker was down." So an entry is only dropped when it's aged out **and** has failed at least once:
  - Added `attempts: u32` (with `#[serde(default)]`, so existing in-flight entries deserialize as `0`) to `TableUpsertActivityData`.
  - On each `process_table` failure, `attempts` is incremented and the entry is written back (`HSET`), keeping `time` unchanged so the age anchor is preserved.
  - The drop condition is `age > MAX_UPSERT_AGE_MS && attempts > 0`.

  The producer's unconditional `HSET` on new activity resets `attempts` to `0` — which is desired: fresh data earns a fresh attempt.

  ## Behavior

  - **Live poison table:** fails repeatedly, `attempts` climbs, age eventually crosses 1h → dropped. No longer retried forever.
  - **Worker was down > 1h, then restarts:** entries are old but `attempts = 0` → **not dropped**; each gets a genuine attempt. If still poison, the next iteration drops it.
  - **New activity arrives:** producer overwrites with `attempts = 0` and fresh `time` → fresh start.

  ## Trade-offs

  - Dropping an entry leaves its CSV files orphaned in GCS — an accepted, small, separately-cleanable trade-off that keeps the change simple and robust to load failures.
  - The failure write-back can race a concurrent producer `HSET` (worst case: one slightly-stale entry / off-by-one counter). Producer-clobbering isn't a concern here, so this is acceptable.
  - During a prolonged GCS/DB outage, entries that have already failed once could age out and be dropped en masse. Acceptable given the 1-hour window; revisit with error classification (retry transient errors) or a dead-letter queue if it becomes a concern.


## Tests

Manual

## Risk

Low

## Deploy Plan

Core