### PR TITLE
fix(front-api): use automatic JSX transform in esbuild to fix React not defined in email templates

### DIFF
--- a/front-api/esbuild.shared.ts
+++ b/front-api/esbuild.shared.ts
@@ -69,5 +69,6 @@ export function getBaseBuildOptions(target: BuildTarget): esbuild.BuildOptions {
     metafile: true,
     minifyIdentifiers: false,
     treeShaking: true,
+    jsx: "automatic",
   };
 }


### PR DESCRIPTION
## Description

Fixes a `ReferenceError: React is not defined` that crashed Novu email step execution when using the Hono-based `front-api` server.

**Root cause:** esbuild was using the classic JSX transform by default, which compiles JSX to `React.createElement(...)` and requires `React` to be in scope. `front/lib/notifications/email-templates/_layout.tsx` only has `import type React from "react"` — a type-only import that is erased at runtime — so `React` was undefined when the rendered component tree reached `EmailLayout`.

**Fix:** Add `jsx: "automatic"` to esbuild's shared build options. This switches to the React 17+ automatic transform, which injects `import { jsx as _jsx } from "react/jsx-runtime"` per file at build time instead of relying on a global `React` binding.

## Tests

Manually triggered a Novu `user-awu-cap-reached` workflow (both `isBlocked: true` and `isBlocked: false`) against the local `front-api` server after rebuilding — no `StepExecutionFailedError`, emails rendered correctly.

## Risk

Low. The automatic JSX transform is the standard since React 17 and is already the default in Next.js. No runtime behaviour changes — only how esbuild rewrites JSX syntax.
