### PR TITLE
[front] feat: surface Google Calendar event attachments in tool responses

### DIFF
--- a/front/lib/api/actions/servers/google_calendar/helpers.test.ts
+++ b/front/lib/api/actions/servers/google_calendar/helpers.test.ts
@@ -1,7 +1,6 @@
-import { describe, expect, it } from "vitest";
-
 import type { EnrichedGoogleCalendarEvent } from "@app/lib/api/actions/servers/google_calendar/helpers";
 import { formatEventAsText } from "@app/lib/api/actions/servers/google_calendar/helpers";
+import { describe, expect, it } from "vitest";
 
 describe("formatEventAsText - attachments", () => {
   it("surfaces attachment title, mime type and file URL", () => {

--- a/front/lib/api/actions/servers/google_calendar/helpers.test.ts
+++ b/front/lib/api/actions/servers/google_calendar/helpers.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import type { EnrichedGoogleCalendarEvent } from "@app/lib/api/actions/servers/google_calendar/helpers";
+import { formatEventAsText } from "@app/lib/api/actions/servers/google_calendar/helpers";
+
+describe("formatEventAsText - attachments", () => {
+  it("surfaces attachment title, mime type and file URL", () => {
+    const event: EnrichedGoogleCalendarEvent = {
+      summary: "Weekly 1:1",
+      attachments: [
+        {
+          fileUrl: "https://docs.google.com/document/d/abc123/edit",
+          title: "1:1 Rolling Notes",
+          mimeType: "application/vnd.google-apps.document",
+          fileId: "abc123",
+        },
+      ],
+    };
+
+    const text = formatEventAsText(event);
+
+    expect(text).toContain(
+      "Attachments: 1:1 Rolling Notes [application/vnd.google-apps.document]: https://docs.google.com/document/d/abc123/edit"
+    );
+  });
+
+  it("lists multiple attachments separated by commas", () => {
+    const event: EnrichedGoogleCalendarEvent = {
+      summary: "Comex",
+      attachments: [
+        { fileUrl: "https://drive.google.com/file/1", title: "Agenda" },
+        { fileUrl: "https://drive.google.com/file/2", title: "Notes" },
+      ],
+    };
+
+    const text = formatEventAsText(event);
+
+    expect(text).toContain(
+      "Attachments: Agenda: https://drive.google.com/file/1, Notes: https://drive.google.com/file/2"
+    );
+  });
+
+  it("ignores attachments without a file URL", () => {
+    const event: EnrichedGoogleCalendarEvent = {
+      summary: "No links",
+      attachments: [{ title: "Broken attachment" }],
+    };
+
+    const text = formatEventAsText(event);
+
+    expect(text).not.toContain("Attachments:");
+  });
+
+  it("does not emit an attachments line when there are none", () => {
+    const event: EnrichedGoogleCalendarEvent = {
+      summary: "Plain event",
+    };
+
+    const text = formatEventAsText(event);
+
+    expect(text).not.toContain("Attachments:");
+  });
+});

--- a/front/lib/api/actions/servers/google_calendar/helpers.ts
+++ b/front/lib/api/actions/servers/google_calendar/helpers.ts
@@ -109,6 +109,13 @@ export interface GoogleCalendarEvent {
     signature?: string;
     notes?: string;
   };
+  attachments?: Array<{
+    fileUrl?: string;
+    title?: string;
+    mimeType?: string;
+    iconLink?: string;
+    fileId?: string;
+  }>;
 }
 
 export interface EnrichedGoogleCalendarEvent
@@ -308,6 +315,19 @@ export function formatEventAsText(event: EnrichedGoogleCalendarEvent): string {
 
   if (event.description) {
     lines.push(`Description: ${event.description}`);
+  }
+
+  if (event.attachments && event.attachments.length > 0) {
+    const attachmentList = event.attachments
+      .filter((a) => a.fileUrl)
+      .map((a) => {
+        const title = a.title ?? "Untitled";
+        const mimeType = a.mimeType ? ` [${a.mimeType}]` : "";
+        return `${title}${mimeType}: ${a.fileUrl}`;
+      });
+    if (attachmentList.length > 0) {
+      lines.push(`Attachments: ${attachmentList.join(", ")}`);
+    }
   }
 
   if (event.attendees && event.attendees.length > 0) {


### PR DESCRIPTION
## Description

When asked to "add X to my next 1:1 notes", the Google Calendar MCP would edit the event description or create a brand-new doc — it could not locate and append to the rolling Google Doc attached to a recurring event series. The root cause: the `GoogleCalendarEvent` type never modeled the `attachments[]` field the Calendar API returns, and `formatEventAsText` never rendered it, so the agent simply never saw the attached document.

This surfaces attachment metadata in the tool responses:

- Adds `attachments?` (`fileUrl`, `title`, `mimeType`, `iconLink`, `fileId`) to the `GoogleCalendarEvent` interface.
- Renders attachments in `formatEventAsText` (shared by `get_event`, `list_events`, `create_event`, `update_event`), e.g. `Attachments: 1:1 Rolling Notes [application/vnd.google-apps.document]: https://docs.google.com/document/d/abc123/edit`.

No request-parameter change is needed: attachments are returned by default on read operations, and because `list_events` uses `singleEvents: true`, each expanded instance of a recurring series inherits the series' attachments. With the doc URL now visible, the agent can hand it to the Drive/Docs tools to append, rather than guessing.

## Tests

Added a co-located `helpers.test.ts` covering single attachment, multiple attachments, attachment without a file URL (ignored), and the no-attachments case. All 4 pass. `tsgo --noEmit` is clean for the calendar server.

## Risk

Low. The change is additive — a new optional field plus one extra formatted line that only renders when attachments with a `fileUrl` are present. No change to request parameters or write paths. Safe to roll back.

## Deploy Plan

Standard front deploy. No migrations or config changes.