### PR TITLE
[front] fix(contact): show clear error message when personal email is used on demo form

### DIFF
--- a/front/pages/api/marketing/home/contact/submit.ts
+++ b/front/pages/api/marketing/home/contact/submit.ts
@@ -88,16 +88,23 @@ export default async function handler(
   // Check for personal email domains
   const isPersonalEmail = isPersonalEmailDomain(domain);
 
+  if (isPersonalEmail) {
+    return res.status(400).json({
+      success: false,
+      isQualified: false,
+      error:
+        "Please use a work email address. To try Dust for free, visit dust.tt/sign-up.",
+    });
+  }
+
   // Check MX records for work emails
-  if (!isPersonalEmail) {
-    const hasMx = await hasValidMxRecords(domain);
-    if (!hasMx) {
-      return res.status(400).json({
-        success: false,
-        isQualified: false,
-        error: "Please use a valid work email address",
-      });
-    }
+  const hasMx = await hasValidMxRecords(domain);
+  if (!hasMx) {
+    return res.status(400).json({
+      success: false,
+      isQualified: false,
+      error: "Please use a valid work email address",
+    });
   }
 
   // Determine if lead is qualified based on self-reported headcount (>100 employees)


### PR DESCRIPTION
## Description

Fixes #26537.

When a user submits the demo contact form at `dust.tt/home/contact` with a personal email (Gmail, Outlook, Yahoo, etc.), the error shown was:

> Failed to submit form. Please try again.

This is misleading — the form isn't broken, personal emails are simply not accepted. The user has no indication of what went wrong or what to do next.

**Root cause:** `isPersonalEmailDomain(domain)` was called but the result was never used to gate the submission. Personal emails passed through to HubSpot, which rejected them server-side, triggering only the generic fallback message.

**Fix:** Return a clear, actionable error immediately when a personal email domain is detected, before any HubSpot call is made.

Also took the opportunity to simplify the MX check block — since personal emails are now rejected early, the `if (!isPersonalEmail)` guard around the MX check is no longer needed.

## Before / After

| | Message shown |
|---|---|
| **Before** | `Failed to submit form. Please try again.` |
| **After** | `Please use a work email address. To try Dust for free, visit dust.tt/sign-up.` |

## Tests

Manual: submit the form with a Gmail address and verify the new message appears inline.

## Risk

Low. Change is confined to the error path for personal email domains. The happy path (work email → MX check → HubSpot → success) is untouched. Rollback is a single revert.