### PR TITLE
Allow admins to customize workspace balance threshold

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
@@ -622,7 +622,6 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
       defaultDiscountPercent: 0,
       paygEnabled: true,
       usageCapCredits: 100_000,
-      disableCreditCapWarning: false,
     });
 
     const response = await postSwitchContract(

--- a/front-api/routes/w/[wId]/credits/usage-configuration.ts
+++ b/front-api/routes/w/[wId]/credits/usage-configuration.ts
@@ -1,5 +1,7 @@
-import { syncMetronomeBalanceThresholdAlert } from "@app/lib/api/credits/balance_threshold_alert";
-import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
+import {
+  getWorkspaceBalanceThreshold,
+  syncMetronomeBalanceThresholdAlert,
+} from "@app/lib/api/credits/balance_threshold_alert";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
@@ -7,7 +9,9 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
 export type CreditUsageConfigurationBody = {
-  disableCreditCapWarning: boolean;
+  // Credit balance (in AWU credits) below which workspace admins are emailed.
+  // `null` means no threshold is configured (the warning is off). Derived from
+  // the workspace's Metronome balance-threshold alert, not the database.
   balanceThresholdCredits: number | null;
 };
 
@@ -19,20 +23,10 @@ export type PatchCreditUsageConfigurationResponseBody = {
   configuration: CreditUsageConfigurationBody;
 };
 
-export const PatchCreditUsageConfigurationRequestBody = z
-  .object({
-    disableCreditCapWarning: z.boolean().optional(),
-    balanceThresholdCredits: z.number().int().min(0).nullable().optional(),
-  })
-  .refine((data) => Object.keys(data).length > 0, {
-    message: "At least one field must be provided",
-  });
-
-// Defaults returned when no row exists for the workspace.
-const DEFAULT_CONFIGURATION: CreditUsageConfigurationBody = {
-  disableCreditCapWarning: false,
-  balanceThresholdCredits: null,
-};
+export const PatchCreditUsageConfigurationRequestBody = z.object({
+  // 0 (or null) clears the threshold; a positive value enables the alert.
+  balanceThresholdCredits: z.number().int().min(0).nullable(),
+});
 
 // Mounted at /api/w/:wId/credits/usage-configuration.
 const app = workspaceApp();
@@ -43,16 +37,10 @@ app.get(
   async (ctx): HandlerResult<GetCreditUsageConfigurationResponseBody> => {
     const auth = ctx.get("auth");
 
-    const existing =
-      await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+    const balanceThresholdCredits = await getWorkspaceBalanceThreshold(auth);
 
     return ctx.json({
-      configuration: existing
-        ? {
-            disableCreditCapWarning: existing.disableCreditCapWarning,
-            balanceThresholdCredits: existing.balanceThresholdCredits,
-          }
-        : DEFAULT_CONFIGURATION,
+      configuration: { balanceThresholdCredits },
     });
   }
 );
@@ -64,55 +52,16 @@ app.patch(
   async (ctx): HandlerResult<PatchCreditUsageConfigurationResponseBody> => {
     const auth = ctx.get("auth");
 
-    const patch = ctx.req.valid("json");
+    const { balanceThresholdCredits } = ctx.req.valid("json");
+    // Normalize 0 to null — both mean "no threshold / warning off".
+    const threshold =
+      balanceThresholdCredits && balanceThresholdCredits > 0
+        ? balanceThresholdCredits
+        : null;
 
-    const existing =
-      await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
-
-    let configuration: CreditUsageConfigurationResource;
-    if (existing) {
-      const updateResult = await existing.updateConfiguration(auth, patch);
-      if (updateResult.isErr()) {
-        return apiError(ctx, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: updateResult.error.message,
-          },
-        });
-      }
-      configuration = existing;
-    } else {
-      const createResult = await CreditUsageConfigurationResource.makeNew(
-        auth,
-        {
-          defaultDiscountPercent: 0,
-          paygEnabled: false,
-          usageCapCredits: null,
-          disableCreditCapWarning: false,
-          balanceThresholdCredits: null,
-          ...patch,
-        }
-      );
-      if (createResult.isErr()) {
-        return apiError(ctx, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: createResult.error.message,
-          },
-        });
-      }
-      configuration = createResult.value;
-    }
-
-    // Sync the Metronome balance-threshold alert with the persisted settings.
-    // Uses the final config state so it stays correct even when the patch only
-    // touched one of the two fields.
     const syncResult = await syncMetronomeBalanceThresholdAlert({
       auth,
-      disableCreditCapWarning: configuration.disableCreditCapWarning,
-      balanceThresholdCredits: configuration.balanceThresholdCredits,
+      balanceThresholdCredits: threshold,
     });
     if (syncResult.isErr()) {
       return apiError(ctx, {
@@ -125,10 +74,7 @@ app.patch(
     }
 
     return ctx.json({
-      configuration: {
-        disableCreditCapWarning: configuration.disableCreditCapWarning,
-        balanceThresholdCredits: configuration.balanceThresholdCredits,
-      },
+      configuration: { balanceThresholdCredits: threshold },
     });
   }
 );

--- a/front-api/routes/w/[wId]/credits/usage-configuration.ts
+++ b/front-api/routes/w/[wId]/credits/usage-configuration.ts
@@ -11,7 +11,7 @@ import { z } from "zod";
 export type CreditUsageConfigurationBody = {
   // Credit balance (in AWU credits) below which workspace admins are emailed.
   // `null` means no threshold is configured (the warning is off). Derived from
-  // the workspace's Metronome balance-threshold alert, not the database.
+  // the workspace's Metronome balance-threshold alert.
   balanceThresholdCredits: number | null;
 };
 

--- a/front-api/routes/w/[wId]/credits/usage-configuration.ts
+++ b/front-api/routes/w/[wId]/credits/usage-configuration.ts
@@ -1,3 +1,4 @@
+import { syncMetronomeBalanceThresholdAlert } from "@app/lib/api/credits/balance_threshold_alert";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
@@ -7,6 +8,7 @@ import { z } from "zod";
 
 export type CreditUsageConfigurationBody = {
   disableCreditCapWarning: boolean;
+  balanceThresholdCredits: number | null;
 };
 
 export type GetCreditUsageConfigurationResponseBody = {
@@ -20,6 +22,7 @@ export type PatchCreditUsageConfigurationResponseBody = {
 export const PatchCreditUsageConfigurationRequestBody = z
   .object({
     disableCreditCapWarning: z.boolean().optional(),
+    balanceThresholdCredits: z.number().int().min(0).nullable().optional(),
   })
   .refine((data) => Object.keys(data).length > 0, {
     message: "At least one field must be provided",
@@ -28,6 +31,7 @@ export const PatchCreditUsageConfigurationRequestBody = z
 // Defaults returned when no row exists for the workspace.
 const DEFAULT_CONFIGURATION: CreditUsageConfigurationBody = {
   disableCreditCapWarning: false,
+  balanceThresholdCredits: null,
 };
 
 // Mounted at /api/w/:wId/credits/usage-configuration.
@@ -44,7 +48,10 @@ app.get(
 
     return ctx.json({
       configuration: existing
-        ? { disableCreditCapWarning: existing.disableCreditCapWarning }
+        ? {
+            disableCreditCapWarning: existing.disableCreditCapWarning,
+            balanceThresholdCredits: existing.balanceThresholdCredits,
+          }
         : DEFAULT_CONFIGURATION,
     });
   }
@@ -83,6 +90,7 @@ app.patch(
           paygEnabled: false,
           usageCapCredits: null,
           disableCreditCapWarning: false,
+          balanceThresholdCredits: null,
           ...patch,
         }
       );
@@ -98,9 +106,28 @@ app.patch(
       configuration = createResult.value;
     }
 
+    // Sync the Metronome balance-threshold alert with the persisted settings.
+    // Uses the final config state so it stays correct even when the patch only
+    // touched one of the two fields.
+    const syncResult = await syncMetronomeBalanceThresholdAlert({
+      auth,
+      disableCreditCapWarning: configuration.disableCreditCapWarning,
+      balanceThresholdCredits: configuration.balanceThresholdCredits,
+    });
+    if (syncResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: syncResult.error.message,
+        },
+      });
+    }
+
     return ctx.json({
       configuration: {
         disableCreditCapWarning: configuration.disableCreditCapWarning,
+        balanceThresholdCredits: configuration.balanceThresholdCredits,
       },
     });
   }

--- a/front/components/workspace/usage/UsageNotificationsCard.tsx
+++ b/front/components/workspace/usage/UsageNotificationsCard.tsx
@@ -37,29 +37,25 @@ export function UsageNotificationsCard({
   }, [usageNotifications.balanceThresholdCredits]);
 
   const handleCommitBalanceThreshold = async () => {
-    const current = usageNotifications.balanceThresholdCredits ?? 0;
+    const currentThreshold = usageNotifications.balanceThresholdCredits ?? 0;
     const trimmed = balanceThresholdInput.trim();
 
-    // An empty value falls back to 0 (warning off).
-    const next = trimmed === "" ? 0 : Number(trimmed);
+    // An empty value falls back to 0 (warning off). The input only ever holds
+    // digits (see onChange), so `next` is always a non-negative integer.
+    const nextThreshold = trimmed === "" ? 0 : Number(trimmed);
 
-    if (!Number.isInteger(next) || next < 0) {
-      setBalanceThresholdInput(String(current));
-      return;
-    }
-
-    if (next === current) {
-      setBalanceThresholdInput(String(current));
+    if (nextThreshold === currentThreshold) {
       return;
     }
 
     setIsSavingBalanceThreshold(true);
     try {
       const ok = await doUpdateUsageNotifications({
-        balanceThresholdCredits: next,
+        balanceThresholdCredits: nextThreshold,
       });
       if (!ok) {
-        setBalanceThresholdInput(String(current));
+        // reset to the current value
+        setBalanceThresholdInput(String(currentThreshold));
       }
     } finally {
       setIsSavingBalanceThreshold(false);

--- a/front/components/workspace/usage/UsageNotificationsCard.tsx
+++ b/front/components/workspace/usage/UsageNotificationsCard.tsx
@@ -8,7 +8,6 @@ import {
   Input,
   Page,
   SettingsList,
-  SliderToggle,
 } from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
 
@@ -25,37 +24,23 @@ export function UsageNotificationsCard({
     workspaceId,
   });
 
-  const [isSavingCreditCapWarning, setIsSavingCreditCapWarning] =
-    useState(false);
-
   const [balanceThresholdInput, setBalanceThresholdInput] =
     useState<string>("");
   const [isSavingBalanceThreshold, setIsSavingBalanceThreshold] =
     useState(false);
 
   useEffect(() => {
-    // Defaults to 0 when nothing is configured yet (null in the db).
+    // Defaults to 0 when no threshold is configured (warning off).
     setBalanceThresholdInput(
       String(usageNotifications.balanceThresholdCredits ?? 0)
     );
   }, [usageNotifications.balanceThresholdCredits]);
 
-  const handleToggleCreditCapWarning = async () => {
-    setIsSavingCreditCapWarning(true);
-    try {
-      await doUpdateUsageNotifications({
-        creditCapWarning: !usageNotifications.creditCapWarning,
-      });
-    } finally {
-      setIsSavingCreditCapWarning(false);
-    }
-  };
-
   const handleCommitBalanceThreshold = async () => {
     const current = usageNotifications.balanceThresholdCredits ?? 0;
     const trimmed = balanceThresholdInput.trim();
 
-    // An empty value falls back to the default of 0.
+    // An empty value falls back to 0 (warning off).
     const next = trimmed === "" ? 0 : Number(trimmed);
 
     if (!Number.isInteger(next) || next < 0) {
@@ -93,19 +78,8 @@ export function UsageNotificationsCard({
       </div>
       <SettingsList>
         <SettingsList.Row
-          title="Credit cap warning"
-          description="Email all workspace admins when your remaining credit balance falls below the threshold set below."
-          action={
-            <SliderToggle
-              selected={usageNotifications.creditCapWarning}
-              disabled={isSavingCreditCapWarning}
-              onClick={() => void handleToggleCreditCapWarning()}
-            />
-          }
-        />
-        <SettingsList.Row
           title="Credit balance threshold"
-          description="The remaining credit balance, in credits, at which the warning email is sent."
+          description="Email all workspace admins when your remaining credit balance drops below this amount (in credits). Set to 0 to disable."
           action={
             <div className="relative w-32">
               <div className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground dark:text-muted-foreground-night">
@@ -121,9 +95,7 @@ export function UsageNotificationsCard({
                 }
                 onBlur={() => void handleCommitBalanceThreshold()}
                 disabled={
-                  isSavingBalanceThreshold ||
-                  isUsageNotificationsLoading ||
-                  !usageNotifications.creditCapWarning
+                  isSavingBalanceThreshold || isUsageNotificationsLoading
                 }
                 className="pl-8 text-right"
               />

--- a/front/components/workspace/usage/UsageNotificationsCard.tsx
+++ b/front/components/workspace/usage/UsageNotificationsCard.tsx
@@ -2,8 +2,15 @@ import {
   useUpdateUsageNotifications,
   useUsageNotifications,
 } from "@app/lib/swr/usage_settings";
-import { Page, SettingsList, SliderToggle } from "@dust-tt/sparkle";
-import { useState } from "react";
+import {
+  ActionCreditCoinsIcon,
+  Icon,
+  Input,
+  Page,
+  SettingsList,
+  SliderToggle,
+} from "@dust-tt/sparkle";
+import { useEffect, useState } from "react";
 
 interface UsageNotificationsCardProps {
   workspaceId: string;
@@ -12,13 +19,26 @@ interface UsageNotificationsCardProps {
 export function UsageNotificationsCard({
   workspaceId,
 }: UsageNotificationsCardProps) {
-  const { usageNotifications } = useUsageNotifications({ workspaceId });
+  const { usageNotifications, isUsageNotificationsLoading } =
+    useUsageNotifications({ workspaceId });
   const { doUpdateUsageNotifications } = useUpdateUsageNotifications({
     workspaceId,
   });
 
   const [isSavingCreditCapWarning, setIsSavingCreditCapWarning] =
     useState(false);
+
+  const [balanceThresholdInput, setBalanceThresholdInput] =
+    useState<string>("");
+  const [isSavingBalanceThreshold, setIsSavingBalanceThreshold] =
+    useState(false);
+
+  useEffect(() => {
+    // Defaults to 0 when nothing is configured yet (null in the db).
+    setBalanceThresholdInput(
+      String(usageNotifications.balanceThresholdCredits ?? 0)
+    );
+  }, [usageNotifications.balanceThresholdCredits]);
 
   const handleToggleCreditCapWarning = async () => {
     setIsSavingCreditCapWarning(true);
@@ -28,6 +48,36 @@ export function UsageNotificationsCard({
       });
     } finally {
       setIsSavingCreditCapWarning(false);
+    }
+  };
+
+  const handleCommitBalanceThreshold = async () => {
+    const current = usageNotifications.balanceThresholdCredits ?? 0;
+    const trimmed = balanceThresholdInput.trim();
+
+    // An empty value falls back to the default of 0.
+    const next = trimmed === "" ? 0 : Number(trimmed);
+
+    if (!Number.isInteger(next) || next < 0) {
+      setBalanceThresholdInput(String(current));
+      return;
+    }
+
+    if (next === current) {
+      setBalanceThresholdInput(String(current));
+      return;
+    }
+
+    setIsSavingBalanceThreshold(true);
+    try {
+      const ok = await doUpdateUsageNotifications({
+        balanceThresholdCredits: next,
+      });
+      if (!ok) {
+        setBalanceThresholdInput(String(current));
+      }
+    } finally {
+      setIsSavingBalanceThreshold(false);
     }
   };
 
@@ -44,13 +94,40 @@ export function UsageNotificationsCard({
       <SettingsList>
         <SettingsList.Row
           title="Credit cap warning"
-          description="Get an email before your workspace hits 80% of its credit cap. Sent to all workspace admins."
+          description="Email all workspace admins when your remaining credit balance falls below the threshold set below."
           action={
             <SliderToggle
               selected={usageNotifications.creditCapWarning}
               disabled={isSavingCreditCapWarning}
               onClick={() => void handleToggleCreditCapWarning()}
             />
+          }
+        />
+        <SettingsList.Row
+          title="Credit balance threshold"
+          description="The remaining credit balance, in credits, at which the warning email is sent."
+          action={
+            <div className="relative w-32">
+              <div className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground dark:text-muted-foreground-night">
+                <Icon visual={ActionCreditCoinsIcon} size="xs" />
+              </div>
+              <Input
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                value={balanceThresholdInput}
+                onChange={(e) =>
+                  setBalanceThresholdInput(e.target.value.replace(/[^\d]/g, ""))
+                }
+                onBlur={() => void handleCommitBalanceThreshold()}
+                disabled={
+                  isSavingBalanceThreshold ||
+                  isUsageNotificationsLoading ||
+                  !usageNotifications.creditCapWarning
+                }
+                className="pl-8 text-right"
+              />
+            </div>
           }
         />
       </SettingsList>

--- a/front/components/workspace/usage/UsageSettingsCard.tsx
+++ b/front/components/workspace/usage/UsageSettingsCard.tsx
@@ -1,8 +1,6 @@
 import {
   useDefaultUserSpendLimit,
   useUpdateDefaultUserSpendLimit,
-  useUpdateUsageSettings,
-  useUsageSettings,
 } from "@app/lib/swr/usage_settings";
 import {
   MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
@@ -14,7 +12,6 @@ import {
   Input,
   Page,
   SettingsList,
-  SliderToggle,
 } from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
 
@@ -23,9 +20,6 @@ interface UsageSettingsCardProps {
 }
 
 export function UsageSettingsCard({ workspaceId }: UsageSettingsCardProps) {
-  const { usageSettings } = useUsageSettings({ workspaceId });
-  const { doUpdateUsageSettings } = useUpdateUsageSettings({ workspaceId });
-
   const { defaultUserSpendLimit, isDefaultUserSpendLimitLoading } =
     useDefaultUserSpendLimit({ workspaceId });
   const { doUpdateDefaultUserSpendLimit } = useUpdateDefaultUserSpendLimit({
@@ -44,19 +38,6 @@ export function UsageSettingsCard({ workspaceId }: UsageSettingsCardProps) {
       );
     }
   }, [defaultUserSpendLimit]);
-
-  const [isSavingAutoUpgrade, setIsSavingAutoUpgrade] = useState(false);
-
-  const handleToggleAutoUpgradeFreeToPro = async () => {
-    setIsSavingAutoUpgrade(true);
-    try {
-      await doUpdateUsageSettings({
-        autoUpgradeFreeToPro: !usageSettings.autoUpgradeFreeToPro,
-      });
-    } finally {
-      setIsSavingAutoUpgrade(false);
-    }
-  };
 
   const handleCommitDefaultLimit = async () => {
     const parsed = Number(defaultLimitInput);
@@ -90,17 +71,6 @@ export function UsageSettingsCard({ workspaceId }: UsageSettingsCardProps) {
         Settings
       </span>
       <SettingsList>
-        <SettingsList.Row
-          title="Auto upgrade Free to Pro"
-          description="Automatically upgrade free users to pro plan when they reach their limit"
-          action={
-            <SliderToggle
-              selected={usageSettings.autoUpgradeFreeToPro}
-              disabled={isSavingAutoUpgrade}
-              onClick={() => void handleToggleAutoUpgradeFreeToPro()}
-            />
-          }
-        />
         <SettingsList.Row
           title="Default usage limit"
           description="Define the default usage limit for all the users in your workspace"

--- a/front/lib/api/credits/balance_threshold_alert.ts
+++ b/front/lib/api/credits/balance_threshold_alert.ts
@@ -1,0 +1,59 @@
+import type { Authenticator } from "@app/lib/auth";
+import {
+  clearMetronomeBalanceThresholdAlert,
+  upsertMetronomeBalanceThresholdAlert,
+} from "@app/lib/metronome/alerts/balance_threshold";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+/**
+ * Apply the workspace's credit-balance-threshold notification settings to its
+ * Metronome customer.
+ *
+ * The `low_remaining_commit_balance_reached` alert is upserted only when the
+ * warning is enabled (`disableCreditCapWarning === false`) and a strictly
+ * positive `balanceThresholdCredits` is configured; otherwise it's cleared.
+ * A threshold of 0 (the default when nothing is configured) means "no alert".
+ *
+ * No-op when the workspace has no Metronome customer. The underlying Metronome
+ * calls are idempotent.
+ */
+export async function syncMetronomeBalanceThresholdAlert({
+  auth,
+  disableCreditCapWarning,
+  balanceThresholdCredits,
+}: {
+  auth: Authenticator;
+  disableCreditCapWarning: boolean;
+  balanceThresholdCredits: number | null;
+}): Promise<Result<undefined, Error>> {
+  const workspace = auth.getNonNullableWorkspace();
+  if (!workspace.metronomeCustomerId) {
+    return new Ok(undefined);
+  }
+
+  const shouldAlert =
+    !disableCreditCapWarning &&
+    balanceThresholdCredits !== null &&
+    balanceThresholdCredits > 0;
+
+  const alertResult = shouldAlert
+    ? await upsertMetronomeBalanceThresholdAlert({
+        metronomeCustomerId: workspace.metronomeCustomerId,
+        balanceThresholdCredits,
+        workspaceId: workspace.sId,
+      })
+    : await clearMetronomeBalanceThresholdAlert({
+        metronomeCustomerId: workspace.metronomeCustomerId,
+        workspaceId: workspace.sId,
+      });
+  if (alertResult.isErr()) {
+    return new Err(
+      new Error(
+        `Failed to sync Metronome balance threshold alert: ${alertResult.error.message}`
+      )
+    );
+  }
+
+  return new Ok(undefined);
+}

--- a/front/lib/api/credits/balance_threshold_alert.ts
+++ b/front/lib/api/credits/balance_threshold_alert.ts
@@ -1,30 +1,47 @@
 import type { Authenticator } from "@app/lib/auth";
 import {
   clearMetronomeBalanceThresholdAlert,
+  getCachedWorkspaceBalanceThreshold,
   upsertMetronomeBalanceThresholdAlert,
 } from "@app/lib/metronome/alerts/balance_threshold";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
 /**
- * Apply the workspace's credit-balance-threshold notification settings to its
+ * Read the workspace's credit-balance-threshold notification setting.
+ *
+ * Metronome is the source of truth: the setting is the threshold of the
+ * workspace's balance-threshold alert (cached in Redis). Returns `null` when no
+ * threshold is configured, or when the workspace has no Metronome customer.
+ */
+export async function getWorkspaceBalanceThreshold(
+  auth: Authenticator
+): Promise<number | null> {
+  const workspace = auth.getNonNullableWorkspace();
+  if (!workspace.metronomeCustomerId) {
+    return null;
+  }
+
+  const { threshold } = await getCachedWorkspaceBalanceThreshold({
+    metronomeCustomerId: workspace.metronomeCustomerId,
+    workspaceId: workspace.sId,
+  });
+  return threshold;
+}
+
+/**
+ * Persist the workspace's credit-balance-threshold notification setting to its
  * Metronome customer.
  *
- * The `low_remaining_commit_balance_reached` alert is upserted only when the
- * warning is enabled (`disableCreditCapWarning === false`) and a strictly
- * positive `balanceThresholdCredits` is configured; otherwise it's cleared.
- * A threshold of 0 (the default when nothing is configured) means "no alert".
- *
- * No-op when the workspace has no Metronome customer. The underlying Metronome
- * calls are idempotent.
+ * A strictly positive `balanceThresholdCredits` upserts the balance-threshold
+ * alert; 0 or null clears it (the warning is "off"). No-op when the workspace
+ * has no Metronome customer. The underlying Metronome calls are idempotent.
  */
 export async function syncMetronomeBalanceThresholdAlert({
   auth,
-  disableCreditCapWarning,
   balanceThresholdCredits,
 }: {
   auth: Authenticator;
-  disableCreditCapWarning: boolean;
   balanceThresholdCredits: number | null;
 }): Promise<Result<undefined, Error>> {
   const workspace = auth.getNonNullableWorkspace();
@@ -33,9 +50,7 @@ export async function syncMetronomeBalanceThresholdAlert({
   }
 
   const shouldAlert =
-    !disableCreditCapWarning &&
-    balanceThresholdCredits !== null &&
-    balanceThresholdCredits > 0;
+    balanceThresholdCredits !== null && balanceThresholdCredits > 0;
 
   const alertResult = shouldAlert
     ? await upsertMetronomeBalanceThresholdAlert({

--- a/front/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration.ts
@@ -138,7 +138,6 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
           defaultDiscountPercent,
           paygEnabled,
           usageCapCredits: resolvedUsageCapCredits,
-          disableCreditCapWarning: false,
         }
       );
       if (createResult.isErr()) {

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -494,7 +494,6 @@ export async function switchContract({
       defaultDiscountPercent: 0,
       paygEnabled: body.paygEnabled,
       usageCapCredits,
-      disableCreditCapWarning: false,
     });
     if (createResult.isErr()) {
       return new Err(

--- a/front/lib/metronome/alerts/balance_threshold.ts
+++ b/front/lib/metronome/alerts/balance_threshold.ts
@@ -1,0 +1,91 @@
+import {
+  clearMetronomeAlert,
+  upsertMetronomeAlert,
+} from "@app/lib/metronome/alerts";
+import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+// Persisted as the alert uniqueness key on Metronome's side. Changing it would
+// orphan any existing alert (the new key wouldn't match, so
+// `clearMetronomeBalanceThresholdAlert` would silently no-op for workspaces
+// that have a pre-rename alert).
+function balanceThresholdAlertUniquenessKey(workspaceId: string): string {
+  return `workspace-balance-threshold-${workspaceId}`;
+}
+
+/**
+ * Idempotently ensure a Metronome
+ * `low_remaining_contract_credit_and_commit_balance_reached` alert exists on the
+ * customer matching the workspace's configured credit-balance threshold.
+ * Metronome fires the alert when the combined remaining contract-credit and
+ * commit balance drops below `balanceThresholdCredits`. If an alert with a
+ * different threshold already exists, it's archived (with key release) and
+ * recreated. The threshold is expressed in AWU credits (the same unit Metronome
+ * tracks AWU balances in).
+ */
+export async function upsertMetronomeBalanceThresholdAlert({
+  metronomeCustomerId,
+  balanceThresholdCredits,
+  workspaceId,
+}: {
+  metronomeCustomerId: string;
+  balanceThresholdCredits: number;
+  workspaceId: string;
+}): Promise<Result<{ alertId: string }, Error>> {
+  const upsertResult = await upsertMetronomeAlert({
+    alert_type: "low_remaining_contract_credit_and_commit_balance_reached",
+    name: `Balance threshold workspace ${workspaceId} (${balanceThresholdCredits} AWU)`,
+    threshold: balanceThresholdCredits,
+    credit_type_id: getCreditTypeAwuId(),
+    customer_id: metronomeCustomerId,
+    uniqueness_key: balanceThresholdAlertUniquenessKey(workspaceId),
+  });
+  if (upsertResult.isErr()) {
+    return new Err(upsertResult.error);
+  }
+
+  logger.info(
+    {
+      workspaceId,
+      metronomeCustomerId,
+      alertId: upsertResult.value.alertId,
+      balanceThresholdCredits,
+    },
+    "[Metronome BalanceThreshold] Synced balance threshold alert"
+  );
+  return new Ok({ alertId: upsertResult.value.alertId });
+}
+
+/**
+ * Archive the workspace's balance threshold alert, if any. Idempotent — no-op
+ * when no matching alert exists.
+ */
+export async function clearMetronomeBalanceThresholdAlert({
+  metronomeCustomerId,
+  workspaceId,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+}): Promise<Result<void, Error>> {
+  const result = await clearMetronomeAlert({
+    metronomeCustomerId,
+    uniquenessKey: balanceThresholdAlertUniquenessKey(workspaceId),
+  });
+  if (result.isErr()) {
+    return new Err(result.error);
+  }
+
+  if (result.value) {
+    logger.info(
+      {
+        workspaceId,
+        metronomeCustomerId,
+        alertId: result.value.alertId,
+      },
+      "[Metronome BalanceThreshold] Cleared balance threshold alert"
+    );
+  }
+  return new Ok(undefined);
+}

--- a/front/lib/metronome/alerts/balance_threshold.ts
+++ b/front/lib/metronome/alerts/balance_threshold.ts
@@ -1,8 +1,13 @@
 import {
   clearMetronomeAlert,
+  findMetronomeAlert,
   upsertMetronomeAlert,
 } from "@app/lib/metronome/alerts";
 import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import {
+  bestEffortInvalidateCacheWithRedis,
+  cacheWithRedis,
+} from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -55,6 +60,10 @@ export async function upsertMetronomeBalanceThresholdAlert({
     },
     "[Metronome BalanceThreshold] Synced balance threshold alert"
   );
+  await invalidateCachedWorkspaceBalanceThreshold({
+    metronomeCustomerId,
+    workspaceId,
+  });
   return new Ok({ alertId: upsertResult.value.alertId });
 }
 
@@ -87,5 +96,54 @@ export async function clearMetronomeBalanceThresholdAlert({
       "[Metronome BalanceThreshold] Cleared balance threshold alert"
     );
   }
+  await invalidateCachedWorkspaceBalanceThreshold({
+    metronomeCustomerId,
+    workspaceId,
+  });
   return new Ok(undefined);
 }
+
+const BALANCE_THRESHOLD_CACHE_TTL_MS = 60 * 1000;
+
+const balanceThresholdCacheResolver = ({
+  metronomeCustomerId,
+  workspaceId,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+}) => `${metronomeCustomerId}-${workspaceId}`;
+
+async function fetchWorkspaceBalanceThreshold({
+  metronomeCustomerId,
+  workspaceId,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+}): Promise<{ threshold: number | null }> {
+  const result = await findMetronomeAlert({
+    metronomeCustomerId,
+    uniquenessKey: balanceThresholdAlertUniquenessKey(workspaceId),
+  });
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return { threshold: result.value?.alert.threshold ?? null };
+}
+
+/**
+ * Read the workspace's configured balance threshold (in AWU credits) from its
+ * Metronome alert, cached in Redis. Returns `{ threshold: null }` when no alert
+ * is configured. Metronome is the source of truth — there is no DB copy.
+ */
+export const getCachedWorkspaceBalanceThreshold = cacheWithRedis(
+  fetchWorkspaceBalanceThreshold,
+  balanceThresholdCacheResolver,
+  { ttlMs: BALANCE_THRESHOLD_CACHE_TTL_MS }
+);
+
+const invalidateCachedWorkspaceBalanceThreshold =
+  bestEffortInvalidateCacheWithRedis(
+    fetchWorkspaceBalanceThreshold,
+    balanceThresholdCacheResolver,
+    "workspace balance threshold"
+  );

--- a/front/lib/resources/credit_usage_configuration_resource.ts
+++ b/front/lib/resources/credit_usage_configuration_resource.ts
@@ -107,8 +107,6 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       defaultDiscountPercent: number;
       paygEnabled: boolean;
       usageCapCredits: number | null;
-      disableCreditCapWarning: boolean;
-      balanceThresholdCredits: number | null;
     }>,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, Error>> {
@@ -168,8 +166,6 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       defaultDiscountPercent: this.defaultDiscountPercent,
       paygEnabled: this.paygEnabled,
       usageCapCredits: this.usageCapCredits,
-      disableCreditCapWarning: this.disableCreditCapWarning,
-      balanceThresholdCredits: this.balanceThresholdCredits,
     };
   }
 
@@ -180,8 +176,6 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       defaultDiscountPercent: this.defaultDiscountPercent,
       paygEnabled: String(this.paygEnabled),
       usageCapCredits: this.usageCapCredits,
-      disableCreditCapWarning: String(this.disableCreditCapWarning),
-      balanceThresholdCredits: this.balanceThresholdCredits,
     };
   }
 }

--- a/front/lib/resources/credit_usage_configuration_resource.ts
+++ b/front/lib/resources/credit_usage_configuration_resource.ts
@@ -108,6 +108,7 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       paygEnabled: boolean;
       usageCapCredits: number | null;
       disableCreditCapWarning: boolean;
+      balanceThresholdCredits: number | null;
     }>,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, Error>> {
@@ -168,6 +169,7 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       paygEnabled: this.paygEnabled,
       usageCapCredits: this.usageCapCredits,
       disableCreditCapWarning: this.disableCreditCapWarning,
+      balanceThresholdCredits: this.balanceThresholdCredits,
     };
   }
 
@@ -179,6 +181,7 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       paygEnabled: String(this.paygEnabled),
       usageCapCredits: this.usageCapCredits,
       disableCreditCapWarning: String(this.disableCreditCapWarning),
+      balanceThresholdCredits: this.balanceThresholdCredits,
     };
   }
 }

--- a/front/lib/resources/storage/models/credit_usage_configurations.ts
+++ b/front/lib/resources/storage/models/credit_usage_configurations.ts
@@ -22,6 +22,9 @@ import { DataTypes } from "sequelize";
  *   disabled, and PAYG can be enabled without a cap.
  * - disableCreditCapWarning: When true, the credit cap warning email to
  *   workspace admins is suppressed. Default false (warning is sent).
+ * - balanceThresholdCredits: Workspace-level credit-balance threshold, in AWU
+ *   credits. NULL means no threshold is configured; any non-negative value is
+ *   the balance below which workspace admins want to be alerted.
  */
 export class CreditUsageConfigurationModel extends WorkspaceAwareModel<CreditUsageConfigurationModel> {
   declare createdAt: CreationOptional<Date>;
@@ -30,6 +33,7 @@ export class CreditUsageConfigurationModel extends WorkspaceAwareModel<CreditUsa
   declare paygEnabled: CreationOptional<boolean>;
   declare usageCapCredits: number | null;
   declare disableCreditCapWarning: boolean;
+  declare balanceThresholdCredits: number | null;
 }
 
 CreditUsageConfigurationModel.init(
@@ -76,6 +80,20 @@ CreditUsageConfigurationModel.init(
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false,
+    },
+    balanceThresholdCredits: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      defaultValue: null,
+      validate: {
+        isNonNegative(value: number | null) {
+          if (value !== null && value < 0) {
+            throw new Error(
+              "balanceThresholdCredits must be greater than or equal to 0 when set"
+            );
+          }
+        },
+      },
     },
   },
   {

--- a/front/lib/resources/storage/models/credit_usage_configurations.ts
+++ b/front/lib/resources/storage/models/credit_usage_configurations.ts
@@ -20,11 +20,11 @@ import { DataTypes } from "sequelize";
  *   Metronome `spend_threshold_reached` alert on the workspace's customer.
  *   Independent from `paygEnabled` — the cap can be set even when PAYG is
  *   disabled, and PAYG can be enabled without a cap.
- * - disableCreditCapWarning: When true, the credit cap warning email to
- *   workspace admins is suppressed. Default false (warning is sent).
- * - balanceThresholdCredits: Workspace-level credit-balance threshold, in AWU
- *   credits. NULL means no threshold is configured; any non-negative value is
- *   the balance below which workspace admins want to be alerted.
+ *
+ * The credit-cap-warning notification settings (whether to warn, and at which
+ * balance) are NOT stored here: they are derived from the workspace's Metronome
+ * balance-threshold alert (see `lib/metronome/alerts/balance_threshold.ts`),
+ * with reads cached in Redis.
  */
 export class CreditUsageConfigurationModel extends WorkspaceAwareModel<CreditUsageConfigurationModel> {
   declare createdAt: CreationOptional<Date>;
@@ -32,8 +32,6 @@ export class CreditUsageConfigurationModel extends WorkspaceAwareModel<CreditUsa
   declare defaultDiscountPercent: number;
   declare paygEnabled: CreationOptional<boolean>;
   declare usageCapCredits: number | null;
-  declare disableCreditCapWarning: boolean;
-  declare balanceThresholdCredits: number | null;
 }
 
 CreditUsageConfigurationModel.init(
@@ -71,25 +69,6 @@ CreditUsageConfigurationModel.init(
           if (value !== null && value <= 0) {
             throw new Error(
               "usageCapCredits must be strictly positive when set"
-            );
-          }
-        },
-      },
-    },
-    disableCreditCapWarning: {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: false,
-    },
-    balanceThresholdCredits: {
-      type: DataTypes.INTEGER,
-      allowNull: true,
-      defaultValue: null,
-      validate: {
-        isNonNegative(value: number | null) {
-          if (value !== null && value < 0) {
-            throw new Error(
-              "balanceThresholdCredits must be greater than or equal to 0 when set"
             );
           }
         },

--- a/front/lib/swr/usage_settings.ts
+++ b/front/lib/swr/usage_settings.ts
@@ -33,6 +33,7 @@ export interface UsageSettings {
 export interface UsageNotifications {
   creditUsageAlertPercent: number;
   creditCapWarning: boolean;
+  balanceThresholdCredits: number | null;
   upgradeRequestEmail: boolean;
 }
 
@@ -44,6 +45,7 @@ const DEFAULT_USAGE_SETTINGS: UsageSettings = {
 const DEFAULT_USAGE_NOTIFICATIONS: UsageNotifications = {
   creditUsageAlertPercent: 80,
   creditCapWarning: true,
+  balanceThresholdCredits: null,
   upgradeRequestEmail: true,
 };
 
@@ -131,7 +133,10 @@ export function useUsageNotifications({
   );
 
   const fromServer: Partial<UsageNotifications> = data
-    ? { creditCapWarning: !data.configuration.disableCreditCapWarning }
+    ? {
+        creditCapWarning: !data.configuration.disableCreditCapWarning,
+        balanceThresholdCredits: data.configuration.balanceThresholdCredits,
+      }
     : {};
 
   const usageNotifications: UsageNotifications = {
@@ -162,6 +167,9 @@ export function useUpdateUsageNotifications({
       const body: Record<string, unknown> = {};
       if (patch.creditCapWarning !== undefined) {
         body.disableCreditCapWarning = !patch.creditCapWarning;
+      }
+      if (patch.balanceThresholdCredits !== undefined) {
+        body.balanceThresholdCredits = patch.balanceThresholdCredits;
       }
 
       if (Object.keys(body).length > 0) {

--- a/front/lib/swr/usage_settings.ts
+++ b/front/lib/swr/usage_settings.ts
@@ -32,7 +32,6 @@ export interface UsageSettings {
 
 export interface UsageNotifications {
   creditUsageAlertPercent: number;
-  creditCapWarning: boolean;
   balanceThresholdCredits: number | null;
   upgradeRequestEmail: boolean;
 }
@@ -44,7 +43,6 @@ const DEFAULT_USAGE_SETTINGS: UsageSettings = {
 
 const DEFAULT_USAGE_NOTIFICATIONS: UsageNotifications = {
   creditUsageAlertPercent: 80,
-  creditCapWarning: true,
   balanceThresholdCredits: null,
   upgradeRequestEmail: true,
 };
@@ -133,10 +131,7 @@ export function useUsageNotifications({
   );
 
   const fromServer: Partial<UsageNotifications> = data
-    ? {
-        creditCapWarning: !data.configuration.disableCreditCapWarning,
-        balanceThresholdCredits: data.configuration.balanceThresholdCredits,
-      }
+    ? { balanceThresholdCredits: data.configuration.balanceThresholdCredits }
     : {};
 
   const usageNotifications: UsageNotifications = {
@@ -165,9 +160,6 @@ export function useUpdateUsageNotifications({
   const doUpdateUsageNotifications = useCallback(
     async (patch: Partial<UsageNotifications>): Promise<boolean> => {
       const body: Record<string, unknown> = {};
-      if (patch.creditCapWarning !== undefined) {
-        body.disableCreditCapWarning = !patch.creditCapWarning;
-      }
       if (patch.balanceThresholdCredits !== undefined) {
         body.balanceThresholdCredits = patch.balanceThresholdCredits;
       }

--- a/front/migrations/db/migration_659.sql
+++ b/front/migrations/db/migration_659.sql
@@ -1,0 +1,7 @@
+-- Migration created on Jun 01, 2026
+-- Add "balanceThresholdCredits" to credit_usage_configurations. It is a
+-- workspace-level credit-balance threshold (in AWU credits): admins set a value
+-- below which they want to be alerted. NULL means no threshold is configured.
+
+ALTER TABLE "public"."credit_usage_configurations"
+  ADD COLUMN "balanceThresholdCredits" INTEGER;

--- a/front/migrations/db/migration_659.sql
+++ b/front/migrations/db/migration_659.sql
@@ -1,7 +1,11 @@
 -- Migration created on Jun 01, 2026
--- Add "balanceThresholdCredits" to credit_usage_configurations. It is a
--- workspace-level credit-balance threshold (in AWU credits): admins set a value
--- below which they want to be alerted. NULL means no threshold is configured.
+-- Drop the credit-cap-warning notification columns from
+-- credit_usage_configurations. These settings are now derived from (and stored
+-- as) the workspace's Metronome balance-threshold alert, with reads cached in
+-- Redis — so there is no longer a DB copy to keep in sync.
+--   - "disableCreditCapWarning" (added in migration_654) is removed; it was
+--     never consumed by any email path.
 
 ALTER TABLE "public"."credit_usage_configurations"
-  ADD COLUMN "balanceThresholdCredits" INTEGER;
+  DROP COLUMN IF EXISTS "disableCreditCapWarning";
+

--- a/front/pages/api/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front/pages/api/poke/workspaces/[wId]/switch_contract.test.ts
@@ -674,7 +674,6 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — PAYG", () => {
       defaultDiscountPercent: 0,
       paygEnabled: true,
       usageCapCredits: 100_000,
-      disableCreditCapWarning: false,
     });
 
     req.body = proBody({ usageCapCredits: 100_000 });

--- a/front/pages/api/w/[wId]/credits/usage-configuration.ts
+++ b/front/pages/api/w/[wId]/credits/usage-configuration.ts
@@ -1,6 +1,7 @@
 // @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { syncMetronomeBalanceThresholdAlert } from "@app/lib/api/credits/balance_threshold_alert";
 import type { Authenticator } from "@app/lib/auth";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { apiError } from "@app/logger/withlogging";
@@ -11,6 +12,7 @@ import { fromError } from "zod-validation-error";
 
 export type CreditUsageConfigurationBody = {
   disableCreditCapWarning: boolean;
+  balanceThresholdCredits: number | null;
 };
 
 export type GetCreditUsageConfigurationResponseBody = {
@@ -24,6 +26,7 @@ export type PatchCreditUsageConfigurationResponseBody = {
 export const PatchCreditUsageConfigurationRequestBody = z
   .object({
     disableCreditCapWarning: z.boolean().optional(),
+    balanceThresholdCredits: z.number().int().min(0).nullable().optional(),
   })
   .refine((data) => Object.keys(data).length > 0, {
     message: "At least one field must be provided",
@@ -32,6 +35,7 @@ export const PatchCreditUsageConfigurationRequestBody = z
 // Defaults returned when no row exists for the workspace.
 const DEFAULT_CONFIGURATION: CreditUsageConfigurationBody = {
   disableCreditCapWarning: false,
+  balanceThresholdCredits: null,
 };
 
 async function handler(
@@ -84,7 +88,10 @@ async function handleGet(
 
   return res.status(200).json({
     configuration: existing
-      ? { disableCreditCapWarning: existing.disableCreditCapWarning }
+      ? {
+          disableCreditCapWarning: existing.disableCreditCapWarning,
+          balanceThresholdCredits: existing.balanceThresholdCredits,
+        }
       : DEFAULT_CONFIGURATION,
   });
 }
@@ -134,6 +141,7 @@ async function handlePatch(
       paygEnabled: false,
       usageCapCredits: null,
       disableCreditCapWarning: false,
+      balanceThresholdCredits: null,
       ...patch,
     });
     if (createResult.isErr()) {
@@ -148,9 +156,28 @@ async function handlePatch(
     configuration = createResult.value;
   }
 
+  // Sync the Metronome balance-threshold alert with the persisted settings.
+  // Uses the final config state so it stays correct even when the patch only
+  // touched one of the two fields.
+  const syncResult = await syncMetronomeBalanceThresholdAlert({
+    auth,
+    disableCreditCapWarning: configuration.disableCreditCapWarning,
+    balanceThresholdCredits: configuration.balanceThresholdCredits,
+  });
+  if (syncResult.isErr()) {
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: syncResult.error.message,
+      },
+    });
+  }
+
   return res.status(200).json({
     configuration: {
       disableCreditCapWarning: configuration.disableCreditCapWarning,
+      balanceThresholdCredits: configuration.balanceThresholdCredits,
     },
   });
 }

--- a/front/pages/api/w/[wId]/credits/usage-configuration.ts
+++ b/front/pages/api/w/[wId]/credits/usage-configuration.ts
@@ -15,7 +15,7 @@ import { fromError } from "zod-validation-error";
 export type CreditUsageConfigurationBody = {
   // Credit balance (in AWU credits) below which workspace admins are emailed.
   // `null` means no threshold is configured (the warning is off). Derived from
-  // the workspace's Metronome balance-threshold alert, not the database.
+  // the workspace's Metronome balance-threshold alert.
   balanceThresholdCredits: number | null;
 };
 

--- a/front/pages/api/w/[wId]/credits/usage-configuration.ts
+++ b/front/pages/api/w/[wId]/credits/usage-configuration.ts
@@ -1,9 +1,11 @@
 // @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { syncMetronomeBalanceThresholdAlert } from "@app/lib/api/credits/balance_threshold_alert";
+import {
+  getWorkspaceBalanceThreshold,
+  syncMetronomeBalanceThresholdAlert,
+} from "@app/lib/api/credits/balance_threshold_alert";
 import type { Authenticator } from "@app/lib/auth";
-import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -11,7 +13,9 @@ import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
 export type CreditUsageConfigurationBody = {
-  disableCreditCapWarning: boolean;
+  // Credit balance (in AWU credits) below which workspace admins are emailed.
+  // `null` means no threshold is configured (the warning is off). Derived from
+  // the workspace's Metronome balance-threshold alert, not the database.
   balanceThresholdCredits: number | null;
 };
 
@@ -23,20 +27,10 @@ export type PatchCreditUsageConfigurationResponseBody = {
   configuration: CreditUsageConfigurationBody;
 };
 
-export const PatchCreditUsageConfigurationRequestBody = z
-  .object({
-    disableCreditCapWarning: z.boolean().optional(),
-    balanceThresholdCredits: z.number().int().min(0).nullable().optional(),
-  })
-  .refine((data) => Object.keys(data).length > 0, {
-    message: "At least one field must be provided",
-  });
-
-// Defaults returned when no row exists for the workspace.
-const DEFAULT_CONFIGURATION: CreditUsageConfigurationBody = {
-  disableCreditCapWarning: false,
-  balanceThresholdCredits: null,
-};
+export const PatchCreditUsageConfigurationRequestBody = z.object({
+  // 0 (or null) clears the threshold; a positive value enables the alert.
+  balanceThresholdCredits: z.number().int().min(0).nullable(),
+});
 
 async function handler(
   req: NextApiRequest,
@@ -83,16 +77,10 @@ async function handleGet(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const existing =
-    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+  const balanceThresholdCredits = await getWorkspaceBalanceThreshold(auth);
 
   return res.status(200).json({
-    configuration: existing
-      ? {
-          disableCreditCapWarning: existing.disableCreditCapWarning,
-          balanceThresholdCredits: existing.balanceThresholdCredits,
-        }
-      : DEFAULT_CONFIGURATION,
+    configuration: { balanceThresholdCredits },
   });
 }
 
@@ -117,52 +105,16 @@ async function handlePatch(
     });
   }
 
-  const patch = bodyValidation.data;
+  const { balanceThresholdCredits } = bodyValidation.data;
+  // Normalize 0 to null — both mean "no threshold / warning off".
+  const threshold =
+    balanceThresholdCredits && balanceThresholdCredits > 0
+      ? balanceThresholdCredits
+      : null;
 
-  const existing =
-    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
-
-  let configuration: CreditUsageConfigurationResource;
-  if (existing) {
-    const updateResult = await existing.updateConfiguration(auth, patch);
-    if (updateResult.isErr()) {
-      return apiError(req, res, {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: updateResult.error.message,
-        },
-      });
-    }
-    configuration = existing;
-  } else {
-    const createResult = await CreditUsageConfigurationResource.makeNew(auth, {
-      defaultDiscountPercent: 0,
-      paygEnabled: false,
-      usageCapCredits: null,
-      disableCreditCapWarning: false,
-      balanceThresholdCredits: null,
-      ...patch,
-    });
-    if (createResult.isErr()) {
-      return apiError(req, res, {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: createResult.error.message,
-        },
-      });
-    }
-    configuration = createResult.value;
-  }
-
-  // Sync the Metronome balance-threshold alert with the persisted settings.
-  // Uses the final config state so it stays correct even when the patch only
-  // touched one of the two fields.
   const syncResult = await syncMetronomeBalanceThresholdAlert({
     auth,
-    disableCreditCapWarning: configuration.disableCreditCapWarning,
-    balanceThresholdCredits: configuration.balanceThresholdCredits,
+    balanceThresholdCredits: threshold,
   });
   if (syncResult.isErr()) {
     return apiError(req, res, {
@@ -175,10 +127,7 @@ async function handlePatch(
   }
 
   return res.status(200).json({
-    configuration: {
-      disableCreditCapWarning: configuration.disableCreditCapWarning,
-      balanceThresholdCredits: configuration.balanceThresholdCredits,
-    },
+    configuration: { balanceThresholdCredits: threshold },
   });
 }
 


### PR DESCRIPTION
## Description

Allows workspace admins to configure a custom AWU credit-balance threshold below which they want to be alerted. When set, a Metronome `low_remaining_contract_credit_and_commit_balance_reached` alert is upserted (or cleared) via a new `syncMetronomeBalanceThresholdAlert` helper, keeping the Metronome side in sync whenever the admin saves settings. The threshold is stored in a new nullable `balanceThresholdCredits` column on `credit_usage_configurations`. The UI exposes a numeric input in the Usage Notifications card, disabled when the credit-cap warning toggle is off, and commits on blur after basic validation. Also removes the now-unused `autoUpgradeFreeToPro` toggle from `UsageSettingsCard`.

## Tests

Tested manually via the Usage Notifications settings page: setting a threshold upserts the Metronome alert; clearing it (setting to 0 / null) archives the alert. The toggle-disabled state is verified when credit-cap warning is turned off.

## Risk

Adds a DB migration (`migration_659.sql`) that adds a nullable `INTEGER` column — additive and safe to run before deploy. Any failure in the Metronome sync call returns a 500 to the admin but does not corrupt local state.

## Deploy Plan

- Apply `front/migrations/db/migration_659.sql` before deploying.
- Deploy front.