### PR TITLE
[front] Base64-inline images for direct Anthropic API

### DIFF
--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -153,7 +153,12 @@ export class AnthropicLLM extends LLM<LLMStreamParameters> {
         toMessage(msg, {
           isLast: index === conversation.messages.length - 1,
           omittedThinking: this.omittedThinking,
-          convertToBase64: this.useVertex,
+          // Always base64-inline images rather than handing Anthropic a URL to
+          // fetch. Image URLs are short-lived signed GCS URLs that Anthropic
+          // cannot reliably download (it returns 400 "Unable to download the
+          // file"), so we fetch them ourselves and send the bytes inline. This
+          // matches the Vertex and Google clients.
+          convertToBase64: true,
         }),
       { concurrency: MESSAGE_CONVERSION_CONCURRENCY }
     );

--- a/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
@@ -80,7 +80,7 @@ async function userContentToParam(
       if (!isAcceptedMediaType(mediaType)) {
         return {
           type: "text",
-          text: "Attachement: an unsupported media type was provided.",
+          text: "Attachment: an unsupported media type was provided.",
         };
       }
 


### PR DESCRIPTION
## Description

Fixes the "The request was invalid. Please check your input and try again." errors when agents generate images (e.g. sandbox PDF -> JPEG previews). Tracking: dust-tt/tasks#8460.

Root cause: workspaces not on Vertex (the default, only 9 workspaces have `use_vertex_for_supported_models`) hit the direct Anthropic API. There we passed images as short-lived (5 min) signed GCS URLs via `{type:"url"}` and relied on Anthropic to download them. Anthropic frequently can't, returning `400 invalid_request_error` "Unable to download the file", which we wrap into `multi_actions_error`. Sandbox image generation triggers it constantly since it renders previews on most turns.

Fix: always base64-inline images for Anthropic instead of handing it a URL. `front` fetches the bytes itself (in-region, URL is fresh) and sends them inline. This is what the Vertex and Google clients already do. One line: `convertToBase64: this.useVertex` -> `convertToBase64: true`.

## Tests

Reconstructed the failing conversation from the read replica: the failure lands on the model call right after an image is written to `/files/conversation/`, and every reasoning block shows `inferenceProvider:"anthropic"` (direct API, not Vertex). Confirmed the affected workspace lacks the Vertex flag. The base64 branch already handles fetch failures gracefully (text placeholder, not a hard 400).

## Risk

Low. base64 path is already battle-tested for Vertex/Google. Slightly larger request bodies (mostly one-time per image with prompt caching). No residency change: Anthropic was already fetching these bytes from our EU bucket; now we send them inline to the same endpoint and stop minting public signed URLs. Rollback is a one-line revert.

## Deploy Plan

Standard deploy.