### PR TITLE
[LLM] derive Anthropic reasoning tokens from SDK output_tokens_details

### DIFF
--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -1,8 +1,5 @@
 import Anthropic, { APIError } from "@anthropic-ai/sdk";
-import type {
-  MessageCountTokensParams,
-  MessageCreateParamsNonStreaming,
-} from "@anthropic-ai/sdk/resources";
+import type { MessageCreateParamsNonStreaming } from "@anthropic-ai/sdk/resources";
 import type { BetaMessageStreamParams } from "@anthropic-ai/sdk/resources/beta/messages";
 import type AnthropicVertex from "@anthropic-ai/vertex-sdk";
 
@@ -33,7 +30,6 @@ import {
 import {
   getInferenceClient,
   getModel,
-  getModelForTokenCount,
 } from "@app/lib/api/llm/clients/anthropic/utils/vertex";
 import { LLM } from "@app/lib/api/llm/llm";
 import type { BatchResult, BatchStatus } from "@app/lib/api/llm/types/batch";
@@ -194,27 +190,6 @@ export class AnthropicLLM extends LLM<LLMStreamParameters> {
     return streamParameters;
   }
 
-  private createCountTokensCallback() {
-    const shouldCountReasoningTokens =
-      this.reasoningEffort !== "none" &&
-      (this.reasoningEffort !== "light" ||
-        !!this.modelConfig.useNativeLightReasoning);
-
-    if (!shouldCountReasoningTokens) {
-      return undefined;
-    }
-
-    const model = getModelForTokenCount(this.useVertex, {
-      modelId: this.modelId,
-    });
-
-    return (body: MessageCountTokensParams) =>
-      this.inferenceClient.messages.countTokens({
-        ...body,
-        model,
-      });
-  }
-
   protected async *sendRequest(
     streamParameters: LLMStreamParameters
   ): AsyncGenerator<LLMEvent> {
@@ -237,11 +212,7 @@ export class AnthropicLLM extends LLM<LLMStreamParameters> {
     try {
       const events = this.inferenceClient.beta.messages.stream(payload);
 
-      yield* streamLLMEvents(
-        events,
-        this.metadata,
-        this.createCountTokensCallback()
-      );
+      yield* streamLLMEvents(events, this.metadata);
     } catch (err) {
       if (err instanceof APIError) {
         yield handleError(err, this.metadata);
@@ -288,11 +259,7 @@ export class AnthropicLLM extends LLM<LLMStreamParameters> {
     const batchResult: BatchResult = new Map();
 
     for await (const item of results) {
-      const events = await batchResultToLLMEvents(
-        item.result,
-        this.metadata,
-        this.createCountTokensCallback()
-      );
+      const events = await batchResultToLLMEvents(item.result, this.metadata);
       batchResult.set(item.custom_id, events);
     }
 

--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -1,14 +1,10 @@
 import assert from "node:assert";
-import type { APIPromise } from "@anthropic-ai/sdk";
 import { AnthropicError, APIError } from "@anthropic-ai/sdk";
 import type { BetaRawMessageStreamEvent } from "@anthropic-ai/sdk/resources/beta.mjs";
 import type { MessageBatchResult } from "@anthropic-ai/sdk/resources/messages/batches.mjs";
 import type {
   Message,
-  MessageCountTokensParams,
-  MessageParam,
   MessageStreamEvent,
-  MessageTokensCount,
 } from "@anthropic-ai/sdk/resources/messages/messages.mjs";
 import { validateContentBlockIndex } from "@app/lib/api/llm/clients/anthropic/utils/predicates";
 import type { StreamState } from "@app/lib/api/llm/clients/anthropic/utils/types";
@@ -29,7 +25,6 @@ import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
 import { parseToolArguments } from "@app/lib/api/llm/utils/tool_arguments";
 import logger from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isRecord } from "@app/types/shared/utils/general";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 import cloneDeep from "lodash/cloneDeep";
@@ -40,10 +35,7 @@ const INVALID_TOOL_JSON_NEEDLE = "Unable to parse tool parameter JSON";
 
 export async function* streamLLMEvents(
   messageStreamEvents: AsyncIterable<BetaRawMessageStreamEvent>,
-  metadata: LLMClientMetadata,
-  countTokensCallback?: (
-    body: MessageCountTokensParams
-  ) => APIPromise<MessageTokensCount>
+  metadata: LLMClientMetadata
 ): AsyncGenerator<LLMEvent> {
   const stateContainer: { state: StreamState } = { state: null };
   // Aggregate output items to build a SuccessCompletionEvent at the end of a turn.
@@ -106,14 +98,6 @@ export async function* streamLLMEvents(
       throw err;
     }
   }
-
-  await estimateReasoningTokens(
-    tokenUsageAccumulator,
-    aggregate.textGenerated,
-    aggregate.toolCalls,
-    countTokensCallback,
-    metadata
-  );
 
   yield tokenUsage(tokenUsageAccumulator, metadata);
 
@@ -352,9 +336,12 @@ function* handleMessageDelta(
   const uncachedInputTokens = event.usage.input_tokens ?? 0;
   const inputTokens = uncachedInputTokens + cachedTokens + cacheCreationTokens;
   const outputTokens = event.usage.output_tokens;
+  const reasoningTokens =
+    event.usage.output_tokens_details?.thinking_tokens ?? 0;
 
   tokenUsageAccumulator.inputTokens = inputTokens;
-  tokenUsageAccumulator.outputTokens = outputTokens;
+  tokenUsageAccumulator.outputTokens = outputTokens - reasoningTokens;
+  tokenUsageAccumulator.reasoningTokens = reasoningTokens;
   tokenUsageAccumulator.cachedTokens = cachedTokens;
   tokenUsageAccumulator.cacheCreationTokens = cacheCreationTokens;
   tokenUsageAccumulator.uncachedInputTokens = uncachedInputTokens;
@@ -403,64 +390,6 @@ function* handleStopReason(
         metadata
       );
       break;
-  }
-}
-
-/**
- * Estimates reasoning tokens by comparing total output tokens against a count
- * of non-reasoning output tokens (text + tool calls). Mutates tokenUsageAccumulator
- * in place.
- */
-async function estimateReasoningTokens(
-  tokenUsageAccumulator: Required<TokenUsage>,
-  textGenerated: TextGeneratedEvent | undefined,
-  toolCalls: ToolCallEvent[] | undefined,
-  countTokensCallback:
-    | ((body: MessageCountTokensParams) => APIPromise<MessageTokensCount>)
-    | undefined,
-  metadata: LLMClientMetadata
-): Promise<void> {
-  const outputTokensWithoutReasoning: MessageParam[] = [];
-
-  if (textGenerated) {
-    outputTokensWithoutReasoning.push({
-      content: textGenerated.content.text,
-      role: "user" as const,
-    });
-  }
-  if (toolCalls) {
-    for (const call of toolCalls) {
-      outputTokensWithoutReasoning.push({
-        content: `${call.content.name} ${JSON.stringify(call.content.arguments)}`,
-        role: "user" as const,
-      });
-    }
-  }
-
-  try {
-    // Anthropic does not send the output token count details.
-    // This allows a rough estimation of the reasoning tokens.
-    const tokenCount = (await countTokensCallback?.({
-      model: metadata.modelId,
-      messages: outputTokensWithoutReasoning,
-    })) ?? {
-      input_tokens: tokenUsageAccumulator.outputTokens,
-    };
-    const reasoningTokens = Math.max(
-      0,
-      tokenUsageAccumulator.outputTokens - tokenCount.input_tokens
-    );
-    tokenUsageAccumulator.reasoningTokens = reasoningTokens;
-    tokenUsageAccumulator.outputTokens =
-      tokenUsageAccumulator.outputTokens - reasoningTokens;
-  } catch (err) {
-    logger.error(
-      {
-        errorDetails: normalizeError(err),
-        metadata,
-      },
-      "Failed getting token details from Anthropic"
-    );
   }
 }
 
@@ -645,18 +574,11 @@ function getInvalidToolJsonMessage(err: unknown): string | null {
  */
 export async function batchResultToLLMEvents(
   result: MessageBatchResult,
-  metadata: LLMClientMetadata,
-  countTokensCallback?: (
-    body: MessageCountTokensParams
-  ) => APIPromise<MessageTokensCount>
+  metadata: LLMClientMetadata
 ): Promise<LLMEvent[]> {
   switch (result.type) {
     case "succeeded":
-      return succeededMessageToEvents(
-        result.message,
-        metadata,
-        countTokensCallback
-      );
+      return succeededMessageToEvents(result.message, metadata);
     case "errored":
       return [
         new EventError(
@@ -697,10 +619,7 @@ export async function batchResultToLLMEvents(
 
 async function succeededMessageToEvents(
   message: Message,
-  metadata: LLMClientMetadata,
-  countTokensCallback?: (
-    body: MessageCountTokensParams
-  ) => APIPromise<MessageTokensCount>
+  metadata: LLMClientMetadata
 ): Promise<LLMEvent[]> {
   const events: LLMEvent[] = [];
 
@@ -760,28 +679,21 @@ async function succeededMessageToEvents(
   const cacheCreationTokens = usage.cache_creation_input_tokens ?? 0;
   const uncachedInputTokens = usage.input_tokens;
   const inputTokens = uncachedInputTokens + cachedTokens + cacheCreationTokens;
+  const reasoningTokens = usage.output_tokens_details?.thinking_tokens ?? 0;
   const tokenUsageAccumulator = {
     inputTokens,
-    outputTokens: usage.output_tokens,
+    outputTokens: usage.output_tokens - reasoningTokens,
     cachedTokens,
     cacheCreationTokens,
     uncachedInputTokens,
     totalTokens: inputTokens + usage.output_tokens,
-    reasoningTokens: 0,
+    reasoningTokens,
   };
 
   const textGeneratedEvent: TextGeneratedEvent | undefined =
     textBlocks.length > 0
       ? textGenerated(textBlocks.join(""), metadata)
       : undefined;
-
-  await estimateReasoningTokens(
-    tokenUsageAccumulator,
-    textGeneratedEvent,
-    toolCalls.length > 0 ? toolCalls : undefined,
-    countTokensCallback,
-    metadata
-  );
 
   events.push(tokenUsage(tokenUsageAccumulator, metadata));
 

--- a/front/lib/api/llm/clients/anthropic/utils/test/anthropic_to_events.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/anthropic_to_events.test.ts
@@ -85,6 +85,7 @@ describe("streamLLMEvents", () => {
             cache_creation_input_tokens: 0,
             cache_read_input_tokens: 0,
             output_tokens: 0,
+            output_tokens_details: null,
             service_tier: "standard",
             server_tool_use: null,
             inference_geo: null,
@@ -97,6 +98,7 @@ describe("streamLLMEvents", () => {
           },
           container: null,
           context_management: null,
+          diagnostics: null,
         },
       },
       {

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/reasoning.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/reasoning.ts
@@ -82,9 +82,9 @@ export const reasoningLLMEvents: LLMEvent[] = [
     type: "token_usage",
     content: {
       inputTokens: 2500,
-      outputTokens: 180,
+      outputTokens: 130,
       cachedTokens: 0,
-      reasoningTokens: 0,
+      reasoningTokens: 50,
       cacheCreationTokens: 0,
       totalTokens: 2680,
       uncachedInputTokens: 2500,

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/model_output/empty_tool_call.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/model_output/empty_tool_call.ts
@@ -23,6 +23,7 @@ export const emptyToolCallModelEvents: BetaRawMessageStreamEvent[] = [
           ephemeral_1h_input_tokens: 0,
         },
         output_tokens: 0,
+        output_tokens_details: null,
         service_tier: "standard",
         server_tool_use: null,
         inference_geo: null,
@@ -31,6 +32,7 @@ export const emptyToolCallModelEvents: BetaRawMessageStreamEvent[] = [
       },
       container: null,
       context_management: null,
+      diagnostics: null,
     },
   },
   {
@@ -69,6 +71,7 @@ export const emptyToolCallModelEvents: BetaRawMessageStreamEvent[] = [
       cache_creation_input_tokens: 0,
       cache_read_input_tokens: 0,
       output_tokens: 20,
+      output_tokens_details: null,
       server_tool_use: null,
       iterations: null,
     },

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/model_output/reasoning.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/model_output/reasoning.ts
@@ -23,6 +23,7 @@ export const reasoningModelEvents: BetaRawMessageStreamEvent[] = [
           ephemeral_1h_input_tokens: 0,
         },
         output_tokens: 0,
+        output_tokens_details: null,
         service_tier: "standard",
         server_tool_use: null,
         inference_geo: null,
@@ -31,6 +32,7 @@ export const reasoningModelEvents: BetaRawMessageStreamEvent[] = [
       },
       container: null,
       context_management: null,
+      diagnostics: null,
     },
   },
   {
@@ -48,6 +50,7 @@ export const reasoningModelEvents: BetaRawMessageStreamEvent[] = [
     delta: {
       type: "thinking_delta",
       thinking: "**Solving the Equation**\n\nI need to ",
+      estimated_tokens: null,
     },
   },
   {
@@ -56,6 +59,7 @@ export const reasoningModelEvents: BetaRawMessageStreamEvent[] = [
     delta: {
       type: "thinking_delta",
       thinking: "solve x^2 + 2x + 1 = 0.\n\n",
+      estimated_tokens: null,
     },
   },
   {
@@ -105,6 +109,9 @@ export const reasoningModelEvents: BetaRawMessageStreamEvent[] = [
       cache_creation_input_tokens: 0,
       cache_read_input_tokens: 0,
       output_tokens: 180,
+      output_tokens_details: {
+        thinking_tokens: 50,
+      },
       server_tool_use: null,
       iterations: null,
     },

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/model_output/tool_use.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/model_output/tool_use.ts
@@ -23,6 +23,7 @@ export const toolUseModelEvents: BetaRawMessageStreamEvent[] = [
           ephemeral_1h_input_tokens: 0,
         },
         output_tokens: 0,
+        output_tokens_details: null,
         service_tier: "standard",
         server_tool_use: null,
         inference_geo: null,
@@ -31,6 +32,7 @@ export const toolUseModelEvents: BetaRawMessageStreamEvent[] = [
       },
       container: null,
       context_management: null,
+      diagnostics: null,
     },
   },
   {
@@ -98,6 +100,7 @@ export const toolUseModelEvents: BetaRawMessageStreamEvent[] = [
       cache_creation_input_tokens: 0,
       cache_read_input_tokens: 0,
       output_tokens: 128,
+      output_tokens_details: null,
       server_tool_use: null,
       iterations: null,
     },

--- a/front/lib/api/llm/clients/anthropic/utils/vertex.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/vertex.ts
@@ -29,14 +29,3 @@ export function getModel(
 
   return VERTEX_MODEL_ID_MAP[modelId] ?? modelId;
 }
-
-export function getModelForTokenCount(
-  useVertex: boolean,
-  { modelId }: { modelId: ModelIdType }
-): string {
-  if (!useVertex) {
-    return modelId;
-  }
-
-  return getModel(useVertex, { modelId }).split("@")[0];
-}

--- a/front/package.json
+++ b/front/package.json
@@ -48,7 +48,7 @@
     "generate:hubspot-forms": "tsx scripts/generate-hubspot-forms.ts"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.90.0",
+    "@anthropic-ai/sdk": "^0.100.1",
     "@anthropic-ai/vertex-sdk": "^0.14.4",
     "@contentful/rich-text-react-renderer": "^16.1.6",
     "@contentful/rich-text-types": "^17.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -491,7 +491,7 @@
       "name": "@dust-tt/front",
       "version": "0.1.0",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.90.0",
+        "@anthropic-ai/sdk": "^0.100.1",
         "@anthropic-ai/vertex-sdk": "^0.14.4",
         "@contentful/rich-text-react-renderer": "^16.1.6",
         "@contentful/rich-text-types": "^17.2.5",
@@ -1192,12 +1192,13 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.90.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz",
-      "integrity": "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==",
+      "version": "0.100.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.100.1.tgz",
+      "integrity": "sha512-RANcEe7LpiLczkKGOwoXOTuFdPhuubS0i4xaAKOMpcqc55YO0mukgxppV7eygx3DXNjxWT6RYOLPyOy0aIAmwg==",
       "license": "MIT",
       "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"


### PR DESCRIPTION
## Description

Bumps `@anthropic-ai/sdk` to `^0.100.1` and replaces the `messages.countTokens` round-trip + estimation with the SDK's native `usage.output_tokens_details.thinking_tokens` to split reasoning vs. output tokens.

## Tests

Tested locally;

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`