### PR TITLE
fix(sandbox): return /call response before pausing the sandbox

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/actions/call.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/call.ts
@@ -1,6 +1,7 @@
 import { verifySandboxExecToken } from "@app/lib/api/sandbox/access_tokens";
 import { createSandboxChildAction } from "@app/lib/api/sandbox/create_child_action";
 import { getFeatureFlags } from "@app/lib/auth";
+import logger from "@app/logger/logger";
 import { CallMCPToolRequestBodySchema } from "@dust-tt/client";
 import { publicApiApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
@@ -86,10 +87,25 @@ app.post(
       });
     }
 
-    return ctx.json(
-      { status: "pending", actionId: result.value.actionId },
-      202
-    );
+    const { actionId, pauseSandbox } = result.value;
+
+    // Pause the sandbox only AFTER the response is handed to the runtime.
+    // `betaPause` freezes the in-sandbox `dsbx` client that issued this
+    // request, and `dsbx` must receive `actionId` to start polling for the
+    // result. node-server has no `executionCtx.waitUntil`, so we fire the
+    // pause without awaiting; it sits behind a lock + several DB round-trips
+    // before `provider.sleep`, so in practice the response is on the wire
+    // before the sandbox freezes.
+    if (pauseSandbox) {
+      void pauseSandbox().catch((err) =>
+        logger.error(
+          { err, actionId },
+          "Failed to pause sandbox for blocked sandbox-child"
+        )
+      );
+    }
+
+    return ctx.json({ status: "pending", actionId }, 202);
   }
 );
 

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -33,7 +33,12 @@ import { Err, Ok } from "@app/types/shared/result";
 
 export type CreateSandboxChildActionResult = {
   actionId: string;
-  needsApproval: boolean;
+  // Present only when the child is blocked awaiting approval. Pausing the
+  // sandbox freezes the in-sandbox `dsbx` client that is still awaiting THIS
+  // `/call` request, so the caller MUST run this only after the response
+  // (carrying `actionId`) has been flushed — otherwise `dsbx` never receives
+  // `actionId` and can never poll for the result.
+  pauseSandbox?: () => Promise<void>;
 };
 
 /**
@@ -224,31 +229,43 @@ export async function createSandboxChildAction(
     });
 
     await ConversationResource.markAsActionRequired(auth, { conversation });
-    await pauseSandboxBashForBlockedChild(auth, action, conversation);
-  } else {
-    const userMessageInfo = await getUserMessageIdFromMessageId(auth, {
-      messageId: agentMessage.sId,
-    });
 
-    await launchSandboxChildToolWorkflow(auth, {
-      agentLoopArgs: {
-        agentMessageId: agentMessage.sId,
-        agentMessageVersion: agentMessage.version,
-        conversationId: conversation.sId,
-        conversationTitle: conversation.title,
-        conversationBranchId: agentMessage.branchId,
-        userMessageId: userMessageInfo.userMessageId,
-        userMessageVersion: userMessageInfo.userMessageVersion,
-        userMessageOrigin: userMessageInfo.userMessageOrigin,
-        initialStartTime: Date.now(),
-      },
-      action,
-      step: parentAction.stepContent.step,
+    // Hand the sandbox pause back to the caller instead of pausing here.
+    // `pauseSandboxBashForBlockedChild` freezes the whole sandbox via
+    // `betaPause` — including the `dsbx` client still blocked on this `/call`
+    // request. Pausing before the response is flushed would mean `dsbx` never
+    // receives `actionId`, so it could never poll for the result. The caller
+    // runs this after responding; the surviving `dsbx` process then resumes,
+    // finishes polling, and its output is collected via the bash `tee`/
+    // wait-and-collect wake-up flow.
+    return new Ok({
+      actionId: action.sId,
+      pauseSandbox: () =>
+        pauseSandboxBashForBlockedChild(auth, action, conversation),
     });
   }
 
+  const userMessageInfo = await getUserMessageIdFromMessageId(auth, {
+    messageId: agentMessage.sId,
+  });
+
+  await launchSandboxChildToolWorkflow(auth, {
+    agentLoopArgs: {
+      agentMessageId: agentMessage.sId,
+      agentMessageVersion: agentMessage.version,
+      conversationId: conversation.sId,
+      conversationTitle: conversation.title,
+      conversationBranchId: agentMessage.branchId,
+      userMessageId: userMessageInfo.userMessageId,
+      userMessageVersion: userMessageInfo.userMessageVersion,
+      userMessageOrigin: userMessageInfo.userMessageOrigin,
+      initialStartTime: Date.now(),
+    },
+    action,
+    step: parentAction.stepContent.step,
+  });
+
   return new Ok({
     actionId: action.sId,
-    needsApproval: status === "blocked_validation_required",
   });
 }

--- a/front/pages/api/v1/w/[wId]/sandbox/actions/call.ts
+++ b/front/pages/api/v1/w/[wId]/sandbox/actions/call.ts
@@ -4,6 +4,7 @@ import { verifySandboxExecToken } from "@app/lib/api/sandbox/access_tokens";
 import { createSandboxChildAction } from "@app/lib/api/sandbox/create_child_action";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
+import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { CallMCPToolRequestBodySchema } from "@dust-tt/client";
@@ -99,9 +100,24 @@ async function handler(
     });
   }
 
-  return res
-    .status(202)
-    .json({ status: "pending", actionId: result.value.actionId });
+  const { actionId, pauseSandbox } = result.value;
+
+  res.status(202).json({ status: "pending", actionId });
+
+  // Pause the sandbox only AFTER the response is handed to the runtime.
+  // `betaPause` freezes the in-sandbox `dsbx` client that issued this request,
+  // and `dsbx` must receive `actionId` to start polling for the result. We
+  // fire the pause without awaiting (the response is already sent) and it sits
+  // behind a lock + several DB round-trips before `provider.sleep`, so in
+  // practice the response is on the wire before the sandbox freezes.
+  if (pauseSandbox) {
+    void pauseSandbox().catch((err) =>
+      logger.error(
+        { err, actionId },
+        "Failed to pause sandbox for blocked sandbox-child"
+      )
+    );
+  }
 }
 
 export default withPublicAPIAuthentication(handler);


### PR DESCRIPTION
## Description

A high-stake (approval-required) sandbox child tool call via `POST /api/v1/w/{wId}/sandbox/actions/call` would hang and never return.

**Root cause:** `createSandboxChildAction` paused the sandbox (`betaPause`, via `pauseSandboxBashForBlockedChild`) **inside** the request handler, *before* it flushed `{status:"pending", actionId}`. The `dsbx` client that issued the call runs inside that very sandbox, so the pause froze it mid-request — it never received `actionId`, could never start polling `/{actionId}`, and the call hung indefinitely.

**Fix (ordering only):** `createSandboxChildAction` no longer pauses inline on the blocked branch — it returns a deferred `pauseSandbox` thunk. Both the Next (`front/pages/...`) and Hono (`front-api/routes/...`) `/call` handlers respond **first**, then fire the pause (fire-and-forget, with a logged `.catch`). The client receives `actionId` before the sandbox freezes; the `dsbx` process survives the pause and its output is collected on resume via the existing bash `tee` / wait-and-collect wake-up flow.

Drive-by: dropped the unused `needsApproval` field from `CreateSandboxChildActionResult` (no reader; `pauseSandbox !== undefined` encodes "blocked").

> [!NOTE]
> The post-response ordering relies on `betaPause` sitting behind a lock + several DB round-trips, so the response is on the wire before the freeze — documented in comments rather than enforced by a hard flush barrier. Acceptable for this single high-stake path.

## Tests

Manual reasoning + type-check (`tsgo --noEmit`) on all three files. No automated test added: a functional `/call` test requires a persisted parent action, a high-stake server view wired onto the agent, plus Temporal/E2B mocks, and the pause-after-flush *timing* can't be asserted without provider spies. The Next and Hono handlers are kept in lockstep per the migration rule.

## Risk

Low. Behavioral change is limited to the blocked sandbox-child path: the sandbox is now paused just after the response instead of just before it. The non-blocked path (auto-approved tools launching the child workflow) is unchanged. Safe to rollback.

## Deploy Plan

- [ ] Deploy `front`