### PR TITLE
[LLM] Fix image media type mismatch in Anthropic requests

### DIFF
--- a/front/types/shared/utils/image_utils.ts
+++ b/front/types/shared/utils/image_utils.ts
@@ -5,6 +5,57 @@ export interface Base64EncodedImageContent {
   data: string;
 }
 
+function detectImageMediaType(buffer: Buffer): string | null {
+  // JPEG: FF D8 FF
+  if (
+    buffer.length >= 3 &&
+    buffer[0] === 0xff &&
+    buffer[1] === 0xd8 &&
+    buffer[2] === 0xff
+  ) {
+    return "image/jpeg";
+  }
+  // PNG: 89 50 4E 47 0D 0A 1A 0A
+  if (
+    buffer.length >= 8 &&
+    buffer[0] === 0x89 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x4e &&
+    buffer[3] === 0x47 &&
+    buffer[4] === 0x0d &&
+    buffer[5] === 0x0a &&
+    buffer[6] === 0x1a &&
+    buffer[7] === 0x0a
+  ) {
+    return "image/png";
+  }
+  // GIF: "GIF8" (47 49 46 38)
+  if (
+    buffer.length >= 4 &&
+    buffer[0] === 0x47 &&
+    buffer[1] === 0x49 &&
+    buffer[2] === 0x46 &&
+    buffer[3] === 0x38
+  ) {
+    return "image/gif";
+  }
+  // WebP: "RIFF" (52 49 46 46) .... "WEBP" (57 45 42 50)
+  if (
+    buffer.length >= 12 &&
+    buffer[0] === 0x52 &&
+    buffer[1] === 0x49 &&
+    buffer[2] === 0x46 &&
+    buffer[3] === 0x46 &&
+    buffer[8] === 0x57 &&
+    buffer[9] === 0x45 &&
+    buffer[10] === 0x42 &&
+    buffer[11] === 0x50
+  ) {
+    return "image/webp";
+  }
+  return null;
+}
+
 export async function trustedFetchImageBase64(
   image_url: string
 ): Promise<Base64EncodedImageContent> {
@@ -15,13 +66,17 @@ export async function trustedFetchImageBase64(
       throw new Error(`Invalid image: ${response.statusText}`);
     }
 
-    const mediaType = response.headers.get("content-type");
+    const headerMediaType = response.headers.get("content-type");
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+    const data = buffer.toString("base64");
+
+    // Prefer the media type detected from the actual bytes over the stored
+    // content-type header, which may be stale or mislabeled.
+    const mediaType = detectImageMediaType(buffer) ?? headerMediaType;
     if (!mediaType) {
       throw new Error("Invalid image: missing content-type header");
     }
-
-    const buffer = await response.arrayBuffer();
-    const data = Buffer.from(buffer).toString("base64");
 
     return {
       mediaType,


### PR DESCRIPTION
## Description

Detect an image's real media type from its magic-number bytes (JPEG/PNG/GIF/WebP) when building base64 image blocks for Anthropic, instead of trusting the stored `content-type` header — fixing 400s like `messages.51.content.6.image.source.base64: The image was specified using the image/jpeg media type, but the image appears to be a image/png image`, which occurred when a file's stored content-type disagreed with its actual bytes.

## Tests

Tested locally.

## Risk

Low. Falls back to the content-type header when the byte signature is unrecognized, preserving prior behavior; also retroactively fixes already-stored mislabeled files.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`