### PR TITLE
Enable SEPA for eur enterprise

### DIFF
--- a/front/lib/api/stripe/webhook_handler.ts
+++ b/front/lib/api/stripe/webhook_handler.ts
@@ -427,6 +427,70 @@ async function forceChargeMetronomeFinalizedInvoice(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Enterprise SEPA enablement
+// Metronome-pushed invoices carry no `payment_settings.payment_method_types`,
+// so Stripe falls back to the account-level invoice default (card only here).
+// We don't want SEPA Direct Debit enabled account-wide — only for enterprise
+// contracts — so we add it per-invoice once the invoice is finalized. SEPA is
+// EUR-only and only meaningful for manually-paid (`send_invoice`) invoices.
+// Cheap invoice fields are checked first so we only hit the DB (to resolve the
+// enterprise flag) for candidate invoices.
+// ---------------------------------------------------------------------------
+
+async function enableSepaOnFinalizedEnterpriseInvoice(
+  invoice: Stripe.Invoice,
+  stripe: Stripe
+): Promise<void> {
+  if (
+    invoice.status !== "open" ||
+    invoice.amount_due <= 0 ||
+    invoice.collection_method !== "send_invoice" ||
+    invoice.currency !== "eur" ||
+    !invoice.id
+  ) {
+    return;
+  }
+  // Only Metronome-pushed invoices: those carry `metronome_customer_id` in
+  // metadata (Stripe-subscription / credit-purchase invoices don't and manage
+  // their own payment methods).
+  if (!invoice.metadata?.metronome_customer_id) {
+    return;
+  }
+  // Idempotency: a re-delivered webhook lands here with SEPA already added.
+  if (invoice.payment_settings?.payment_method_types?.includes("sepa_debit")) {
+    return;
+  }
+  // Enterprise only — resolve the workspace + plan from the invoice.
+  const ctx = await resolveInvoiceCtx(invoice);
+  if (!ctx?.isEnterprise) {
+    return;
+  }
+  // Set an explicit list (card + SEPA) rather than appending to the existing
+  // one: the live default is card-only, and pinning the pair keeps card
+  // available alongside SEPA on the hosted invoice page.
+  const paymentMethodTypes: Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodType[] =
+    ["card", "sepa_debit"];
+  try {
+    await stripe.invoices.update(invoice.id, {
+      payment_settings: { payment_method_types: paymentMethodTypes },
+    });
+    logger.info(
+      { invoiceId: invoice.id, customer: invoice.customer },
+      "[Stripe Webhook] Enabled SEPA on enterprise invoice"
+    );
+  } catch (err) {
+    logger.warn(
+      {
+        error: normalizeError(err),
+        invoiceId: invoice.id,
+        customer: invoice.customer,
+      },
+      "[Stripe Webhook] Failed to enable SEPA on enterprise invoice"
+    );
+  }
+}
+
 /**
  * Shared payment-failure handling for a workspace subscription. Skips
  * enterprise plans (paid by wire on 30-day terms), flags the subscription as
@@ -789,6 +853,11 @@ export async function processStripeWebhookEvent({
       ) {
         await forceChargeMetronomeFinalizedInvoice(invoice, stripe);
       }
+
+      // Enterprise EUR invoices paid by send-invoice should offer SEPA Direct
+      // Debit on the hosted invoice page. Self-gated (enterprise + EUR +
+      // send_invoice); no-op otherwise.
+      await enableSepaOnFinalizedEnterpriseInvoice(invoice, stripe);
       break;
     }
 


### PR DESCRIPTION
## Description

Metronome-pushed Stripe invoices carry no `payment_settings.payment_method_types`, so Stripe falls back to the **account-level invoice default** (card only). We don't want SEPA Direct Debit enabled account-wide — only for **enterprise** contracts — so this enables it **per-invoice** on `invoice.finalized`.

New helper `enableSepaOnFinalizedEnterpriseInvoice(invoice, stripe)` in the shared Stripe webhook handler, called from the `invoice.finalized` case. It sets `payment_settings.payment_method_types = ["card", "sepa_debit"]` on the finalized invoice (which re-syncs the PaymentIntent so the hosted invoice page offers SEPA), gated by — in order, cheap checks first so we only hit the DB for real candidates:

- `status === "open"`, `amount_due > 0`, `collection_method === "send_invoice"`, `currency === "eur"` (SEPA is EUR-only and only meaningful for manually-paid invoices).
- `metadata.metronome_customer_id` is set → a Metronome-pushed invoice (Stripe-subscription / credit-purchase invoices manage their own payment methods and are skipped).
- Not already offering `sepa_debit` (idempotent on webhook re-delivery).
- `resolveInvoiceCtx(invoice).isEnterprise` → enterprise plan only.

Stripe errors are caught around the external call and logged; the webhook is never failed by this step (mirrors the existing `forceChargeMetronomeFinalizedInvoice` helper next to it).

Background: SEPA can't be configured through Metronome (its Stripe billing config only exposes `stripe_collection_method`), and the Stripe account default would apply to *all* invoices — hence the per-invoice, enterprise-gated approach.

## Tests

- `npx tsgo --noEmit` clean.
- Manual (test mode): finalize an enterprise EUR `send_invoice` invoice and confirm the hosted invoice page offers SEPA Direct Debit alongside card, and that the underlying PaymentIntent's `payment_method_types` is `["card", "sepa_debit"]`. Verified the same `payment_settings` patch on a live test invoice (`in_…`) flips the PI from `["card","link"]` to include `sepa_debit`.
- No automated test added: the Stripe webhook handler has no existing test harness; building one for a single finalized-invoice branch was out of scope. Happy to add one in a follow-up if wanted.

## Risk

Low. The change only runs on `invoice.finalized`, only for Metronome-pushed enterprise EUR send-invoice invoices, and only adds a payment method (never removes the ability to pay by card). Failures are logged and swallowed — they cannot break webhook processing or invoice finalization. Logic lives in the shared `processStripeWebhookEvent`, so the Next and Hono webhook routes stay in sync automatically.

Known edge: enterprise is determined from the workspace's current plan. If a contract's very first invoice finalizes before the `contract.start` webhook swaps the workspace onto the enterprise plan, SEPA won't be added to that one invoice (recurring invoices, the common case, are well after the swap). Can be hardened later by reading the contract's `PLAN_CODE` custom field instead.

## Deploy Plan

Standard deploy. No migration, no manual steps. SEPA Direct Debit must be enabled on the Stripe account's payment methods for the option to render (already the case). Rollback: revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
