### PR TITLE
Explicitly set some NEXT_PUBLIC_ env in the front-api image

### DIFF
--- a/dockerfiles/front.Dockerfile
+++ b/dockerfiles/front.Dockerfile
@@ -363,6 +363,16 @@ ENV NEXT_PUBLIC_DUST_API_URL=$NEXT_PUBLIC_DUST_API_URL
 ENV NEXT_PUBLIC_DUST_STATIC_WEBSITE_URL=$NEXT_PUBLIC_DUST_STATIC_WEBSITE_URL
 ENV NEXT_PUBLIC_DUST_APP_URL=$NEXT_PUBLIC_DUST_APP_URL
 
+# Unlike the Next.js standalone `front` image, this server is esbuild-bundled, so
+# `NEXT_PUBLIC_*` references are NOT inlined at build time — they remain runtime
+# `process.env` lookups and must be provided as runtime env (same as the workers image).
+ARG NEXT_PUBLIC_NOVU_APPLICATION_IDENTIFIER
+ARG NEXT_PUBLIC_NOVU_API_URL
+ARG NEXT_PUBLIC_NOVU_WEBSOCKET_API_URL
+ENV NEXT_PUBLIC_NOVU_APPLICATION_IDENTIFIER=$NEXT_PUBLIC_NOVU_APPLICATION_IDENTIFIER
+ENV NEXT_PUBLIC_NOVU_API_URL=$NEXT_PUBLIC_NOVU_API_URL
+ENV NEXT_PUBLIC_NOVU_WEBSOCKET_API_URL=$NEXT_PUBLIC_NOVU_WEBSOCKET_API_URL
+
 # Front's transitive runtime deps (e.g. hot-shots) may live in
 # /app/front/node_modules rather than the hoisted /app/node_modules, and node's
 # walk-up from /app/front-api/dist/server.js never visits them. Add it to


### PR DESCRIPTION
## Description

  ### Problem

  front-api crashes with `NEXT_PUBLIC_NOVU_API_URL is not set` (thrown from
  `front/lib/api/config.ts` `getNovuApiUrl()`), while the same code works fine on
  `front` — even though the env var isn't even present on the `front` pod.

  ### Root cause

  `NEXT_PUBLIC_*` vars are inlined **at build time by Next.js/webpack**: during
  `next build`, every `process.env.NEXT_PUBLIC_X` is textually replaced with the
  literal value present at build time, so no runtime lookup remains.

  - **`front`** runs the Next.js standalone output, so `getNovuApiUrl()` already
    has the value baked in as a string literal. That's why it works despite the
    env var being absent at runtime.
  - **`front-api`** runs an **esbuild-bundled** Hono server (`dist/server.js`),
    which imports `front/lib/api/config.ts` via the `@app` alias. esbuild has no
    `NEXT_PUBLIC_*` inlining (no `define` in `esbuild.shared.ts`), so the
    reference stays a genuine runtime `process.env` lookup. The `front-api`
    runtime image never set `NEXT_PUBLIC_NOVU_API_URL` as runtime env → `undefined`
    → throws.

  The `workers` image (also esbuild-bundled) already declares these as runtime
  `ENV` for exactly this reason; the `front-api` runtime stage simply omitted them.

  ### Fix

  Declare the NOVU `NEXT_PUBLIC_*` vars as runtime `ARG`+`ENV` in the `front-api`
  runtime stage of `dockerfiles/front.Dockerfile`, mirroring the `workers` image.

  ### Notes / verification

  - The build args are already supplied to the `front-api` target: the CI
    `build-image` action passes `${build_args[@]}` (sourced from
    `.github/configs/<region>/.env.<env>`) to all three targets, and
    `NEXT_PUBLIC_NOVU_API_URL` is present in those configs.
  - Only the base var is needed server-side — `getNovuApiUrl()` reads
    `NEXT_PUBLIC_NOVU_API_URL` (not the `_EU`/`_US` variants, which are
    client-only via `useNovuClient.ts` and resolved by the `.next` build).
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
