### PR TITLE
cleaning: Introduce constant for usage_type values

### DIFF
--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -50,6 +50,8 @@ import {
   getCreditTypeAwuId,
   getProductExcessCreditsId,
   PLAN_CODE_CUSTOM_FIELD_KEY,
+  USAGE_TYPE_GROUP_KEY,
+  USAGE_TYPE_PROGRAMMATIC,
 } from "@app/lib/metronome/constants";
 import { invalidateContractCache } from "@app/lib/metronome/plan_type";
 import type { ProgrammaticCreditEvent } from "@app/lib/metronome/programmatic_credit_state_machine";
@@ -88,7 +90,8 @@ function isProgrammaticMonthlyCap(
   }
   return (
     event.properties.group_values?.some(
-      (g) => g.key === "usage_type" && g.value === "programmatic"
+      (g) =>
+        g.key === USAGE_TYPE_GROUP_KEY && g.value === USAGE_TYPE_PROGRAMMATIC
     ) ?? false
   );
 }

--- a/front/lib/metronome/alerts/programmatic_cap.ts
+++ b/front/lib/metronome/alerts/programmatic_cap.ts
@@ -3,7 +3,11 @@ import {
   findMetronomeAlert,
   upsertMetronomeAlert,
 } from "@app/lib/metronome/alerts";
-import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import {
+  getCreditTypeAwuId,
+  USAGE_TYPE_GROUP_KEY,
+  USAGE_TYPE_PROGRAMMATIC,
+} from "@app/lib/metronome/constants";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -74,7 +78,7 @@ export async function upsertMetronomeProgrammaticCapAlerts({
   // Scope every alert to programmatic AWU usage only, so contract/pool spend
   // doesn't contribute to the cap thresholds.
   const programmaticGroupValues = [
-    { key: "usage_type", value: "programmatic" },
+    { key: USAGE_TYPE_GROUP_KEY, value: USAGE_TYPE_PROGRAMMATIC },
   ];
 
   // Main cap alert.

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -97,6 +97,14 @@ export const CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY =
 export const CONTRACT_CREDIT_TYPE_EXCESS = "excess";
 export const CONTRACT_CREDIT_TYPE_POOL = "pool";
 
+// Pricing/billable-metric group key that splits AWU usage into "user",
+// "programmatic", and "free" slices. Emitted on every usage event and used
+// by pricing rules, per-user reporting, and spend-threshold alerts.
+export const USAGE_TYPE_GROUP_KEY = "usage_type";
+export const USAGE_TYPE_USER = "user";
+export const USAGE_TYPE_PROGRAMMATIC = "programmatic";
+export const USAGE_TYPE_FREE = "free";
+
 // Suffix appended to the annual variant of each seat product name in
 // Metronome (e.g. "Pro Seat (Yearly)"). Used by the setup script when
 // declaring products and by the UI to strip the suffix from displayed seat

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -6,6 +6,11 @@ import type { RunUsageType } from "@app/lib/resources/run_resource";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import { createHash } from "crypto";
 
+import {
+  USAGE_TYPE_GROUP_KEY,
+  USAGE_TYPE_PROGRAMMATIC,
+  USAGE_TYPE_USER,
+} from "./constants";
 import type { MetronomeEvent } from "./types";
 
 const MAX_TRANSACTION_ID_LENGTH = 128;
@@ -266,7 +271,9 @@ export function buildLlmUsageEvents({
       // TODO: Remove is_programmatic_usage & is_free_usage, this is replaced by single property "usage type"
       is_programmatic_usage: isProgrammaticUsage ? "true" : "false",
       is_free_usage: "false",
-      usage_type: isProgrammaticUsage ? "programmatic" : "user",
+      [USAGE_TYPE_GROUP_KEY]: isProgrammaticUsage
+        ? USAGE_TYPE_PROGRAMMATIC
+        : USAGE_TYPE_USER,
       auth_method: authMethod ?? "unknown",
       api_key_name: apiKeyName ?? "unknown",
       message_status: messageStatus,
@@ -379,7 +386,9 @@ export function buildToolUseEvents({
       total_execution_duration_ms: totalDurationMs,
       // TODO: Remove is_programmatic_usage, this is replaced by single property "usage type"
       is_programmatic_usage: isProgrammaticUsage ? "true" : "false",
-      usage_type: isProgrammaticUsage ? "programmatic" : "user",
+      [USAGE_TYPE_GROUP_KEY]: isProgrammaticUsage
+        ? USAGE_TYPE_PROGRAMMATIC
+        : USAGE_TYPE_USER,
       message_status: messageStatus,
       is_sub_agent_message: isSubAgentMessage ? "true" : "false",
       origin,

--- a/front/lib/metronome/per_user_usage.ts
+++ b/front/lib/metronome/per_user_usage.ts
@@ -6,6 +6,9 @@ import {
 import {
   getMetricLlmProviderCostAwuId,
   getMetricToolInvocationsId,
+  USAGE_TYPE_GROUP_KEY,
+  USAGE_TYPE_PROGRAMMATIC,
+  USAGE_TYPE_USER,
 } from "@app/lib/metronome/constants";
 import { getMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
 import {
@@ -19,7 +22,7 @@ import { Err, Ok } from "@app/types/shared/result";
 // usage_type slices that incur AWU spend. The "free" slice is priced at 0 AWU
 // on every rate card, so it's excluded to mirror the per-user
 // `spend_threshold_reached` alert (AWU credit type) that backs per-user caps.
-const PAID_USAGE_TYPES = ["user", "programmatic"];
+const PAID_USAGE_TYPES = [USAGE_TYPE_USER, USAGE_TYPE_PROGRAMMATIC];
 
 /**
  * Per-user AWU consumption for the current billing period.
@@ -81,8 +84,8 @@ export async function fetchPerUserAwuUsage({
       startingOn,
       endingBefore,
       windowSize: "HOUR",
-      groupKey: ["user_id", "usage_type"],
-      groupFilters: { usage_type: PAID_USAGE_TYPES },
+      groupKey: ["user_id", USAGE_TYPE_GROUP_KEY],
+      groupFilters: { [USAGE_TYPE_GROUP_KEY]: PAID_USAGE_TYPES },
     }),
     listMetronomeUsageWithGroups({
       customerId: metronomeCustomerId,
@@ -90,8 +93,8 @@ export async function fetchPerUserAwuUsage({
       startingOn,
       endingBefore,
       windowSize: "HOUR",
-      groupKey: ["user_id", "usage_type", "tool_category"],
-      groupFilters: { usage_type: PAID_USAGE_TYPES },
+      groupKey: ["user_id", USAGE_TYPE_GROUP_KEY, "tool_category"],
+      groupFilters: { [USAGE_TYPE_GROUP_KEY]: PAID_USAGE_TYPES },
     }),
   ]);
   if (aiResult.isErr()) {

--- a/front/lib/metronome/setup_common.ts
+++ b/front/lib/metronome/setup_common.ts
@@ -23,6 +23,7 @@ import {
   PROD_CREDIT_TYPE_PROG_USD_ID,
   SEAT_PRODUCT_YEARLY_SUFFIX,
   SEAT_TYPE_CUSTOM_FIELD_KEY,
+  USAGE_TYPE_GROUP_KEY,
 } from "@app/lib/metronome/constants";
 import { EXCESS_CREDIT_NAME } from "@app/lib/metronome/types";
 import type { SupportedCurrency } from "@app/types/currency";
@@ -330,7 +331,7 @@ export const PRODUCTS: ProductDef[] = [
     name: "AI Usage",
     type: "USAGE",
     billable_metric_name: "LLM Provider Cost AWU",
-    pricing_group_key: ["usage_type"],
+    pricing_group_key: [USAGE_TYPE_GROUP_KEY],
     presentation_group_key: ["user_id"],
     tags: [USAGE_TAG],
   },
@@ -338,7 +339,7 @@ export const PRODUCTS: ProductDef[] = [
     name: "Tool Usage",
     type: "USAGE",
     billable_metric_name: "Tool Invocations",
-    pricing_group_key: ["usage_type", "tool_category"],
+    pricing_group_key: [USAGE_TYPE_GROUP_KEY, "tool_category"],
     presentation_group_key: ["user_id"],
     tags: [USAGE_TAG],
   },

--- a/front/lib/metronome/setup_new_pricing.ts
+++ b/front/lib/metronome/setup_new_pricing.ts
@@ -10,6 +10,10 @@ import {
   CREDIT_TYPE_EUR_ID,
   CREDIT_TYPE_USD_ID,
   SEAT_PRODUCT_YEARLY_SUFFIX,
+  USAGE_TYPE_FREE,
+  USAGE_TYPE_GROUP_KEY,
+  USAGE_TYPE_PROGRAMMATIC,
+  USAGE_TYPE_USER,
 } from "@app/lib/metronome/constants";
 import { TOOL_CATEGORIES } from "@app/lib/metronome/events";
 import {
@@ -62,7 +66,7 @@ export const NEW_METRICS: MetricDef[] = [
     event_type_filter: { in_values: ["tool_use_v3"] },
     property_filters: [
       { name: "count", exists: true },
-      { name: "usage_type", exists: true },
+      { name: USAGE_TYPE_GROUP_KEY, exists: true },
       { name: "tool_category", exists: true },
       { name: "tool_group", exists: true },
       { name: "user_id", exists: true },
@@ -76,13 +80,13 @@ export const NEW_METRICS: MetricDef[] = [
     // 7 group keys — Metronome's default cap is 5; this metric needs an
     // explicit limit increase (granted by Metronome support).
     group_keys: [
-      ["user_id", "usage_type", "tool_category"],
+      ["user_id", USAGE_TYPE_GROUP_KEY, "tool_category"],
       ["user_id"],
       ["api_key_name"],
       ["tool_category"],
       ["origin"],
       ["agent_id"],
-      ["usage_type"],
+      [USAGE_TYPE_GROUP_KEY],
     ],
   },
   // AWU-based AI cost metric — sums cost_awu directly (no unit conversion).
@@ -94,7 +98,7 @@ export const NEW_METRICS: MetricDef[] = [
     event_type_filter: { in_values: ["llm_usage_v3"] },
     property_filters: [
       { name: "cost_awu", exists: true },
-      { name: "usage_type", exists: true },
+      { name: USAGE_TYPE_GROUP_KEY, exists: true },
       { name: "user_id", exists: true },
       { name: "api_key_name", exists: true },
       { name: "model_id", exists: true },
@@ -105,13 +109,13 @@ export const NEW_METRICS: MetricDef[] = [
     aggregation_key: "cost_awu",
     // 7 group keys — see note on Tool Invocations above.
     group_keys: [
-      ["user_id", "usage_type"],
+      ["user_id", USAGE_TYPE_GROUP_KEY],
       ["user_id"],
       ["api_key_name"],
       ["model_id"],
       ["origin"],
       ["agent_id"],
-      ["usage_type"],
+      [USAGE_TYPE_GROUP_KEY],
     ],
   },
   // Phase 2 token metrics removed — will be added when Pricing Index is ready.
@@ -129,7 +133,7 @@ const TOOL_CATEGORY_PRICES_AWU: Record<
 // usage_type splits each AWU usage rate: "user" and "programmatic" use the
 // nominal price, "free" is priced at 0 (covers free-tagged events, replacing
 // the prior recurring-credit mechanism).
-const PAID_USAGE_TYPES = ["user", "programmatic"] as const;
+const PAID_USAGE_TYPES = [USAGE_TYPE_USER, USAGE_TYPE_PROGRAMMATIC] as const;
 
 function buildAwuToolUsageRates(): RateDef[] {
   return TOOL_CATEGORIES.flatMap((category): RateDef[] => [
@@ -143,7 +147,7 @@ function buildAwuToolUsageRates(): RateDef[] {
         credit_type_id: getCreditTypeAwuId(),
         pricing_group_values: {
           tool_category: category,
-          usage_type: usageType,
+          [USAGE_TYPE_GROUP_KEY]: usageType,
         },
       })
     ),
@@ -154,7 +158,10 @@ function buildAwuToolUsageRates(): RateDef[] {
       rate_type: "FLAT",
       price: 0,
       credit_type_id: getCreditTypeAwuId(),
-      pricing_group_values: { tool_category: category, usage_type: "free" },
+      pricing_group_values: {
+        tool_category: category,
+        [USAGE_TYPE_GROUP_KEY]: USAGE_TYPE_FREE,
+      },
     },
   ]);
 }
@@ -171,7 +178,7 @@ function buildAwuAiUsageRates(): RateDef[] {
         rate_type: "FLAT",
         price: 1,
         credit_type_id: getCreditTypeAwuId(),
-        pricing_group_values: { usage_type: usageType },
+        pricing_group_values: { [USAGE_TYPE_GROUP_KEY]: usageType },
       })
     ),
     {
@@ -181,7 +188,7 @@ function buildAwuAiUsageRates(): RateDef[] {
       rate_type: "FLAT",
       price: 0,
       credit_type_id: getCreditTypeAwuId(),
-      pricing_group_values: { usage_type: "free" },
+      pricing_group_values: { [USAGE_TYPE_GROUP_KEY]: USAGE_TYPE_FREE },
     },
   ];
 }


### PR DESCRIPTION
## Description

I want to use constant to make sure we don't badly write "programatic" somewhere not strictly typed as we start to use the value in more places.

## Tests
no

## Risk

low

## Deploy Plan

deploy front
