### PR TITLE
feat(billing): add sidebar banners for AWU 80% warning and cap reached

### DIFF
--- a/front-api/routes/w/[wId]/me/awu-status.ts
+++ b/front-api/routes/w/[wId]/me/awu-status.ts
@@ -1,0 +1,34 @@
+import { isUserAwuWarned, isUserBlocked } from "@app/lib/metronome/user_block";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+
+export type GetUserAwuStatusResponseBody = {
+  status: "normal" | "warned" | "blocked";
+};
+
+// Mounted at /api/w/:wId/me/awu-status.
+const app = workspaceApp();
+
+app.get("/", async (ctx): HandlerResult<GetUserAwuStatusResponseBody> => {
+  const auth = ctx.get("auth");
+  const workspace = auth.getNonNullableWorkspace();
+  const user = auth.getNonNullableUser();
+
+  if (!workspace.metronomeCustomerId) {
+    return ctx.json({ status: "normal" });
+  }
+
+  const blockedReason = await isUserBlocked(workspace.sId, user.sId);
+  if (blockedReason === "user_cap_reached") {
+    return ctx.json({ status: "blocked" });
+  }
+
+  const warned = await isUserAwuWarned(workspace.sId, user.sId);
+  if (warned) {
+    return ctx.json({ status: "warned" });
+  }
+
+  return ctx.json({ status: "normal" });
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/me/index.ts
+++ b/front-api/routes/w/[wId]/me/index.ts
@@ -1,6 +1,7 @@
 import { workspaceApp } from "@front-api/middlewares/ctx";
 
 import approvals from "./approvals";
+import awuStatus from "./awu-status";
 import pendingInvitations from "./pending-invitations";
 import slackNotifications from "./slack-notifications";
 import triggers from "./triggers";
@@ -9,6 +10,7 @@ import triggers from "./triggers";
 const app = workspaceApp();
 
 app.route("/approvals", approvals);
+app.route("/awu-status", awuStatus);
 app.route("/pending-invitations", pendingInvitations);
 app.route("/slack-notifications", slackNotifications);
 app.route("/triggers", triggers);

--- a/front/components/navigation/AppStatusBanner.tsx
+++ b/front/components/navigation/AppStatusBanner.tsx
@@ -5,11 +5,12 @@ import {
   isEntreprisePlanPrefix,
 } from "@app/lib/plans/plan_codes";
 import { useAppStatus } from "@app/lib/swr/useAppStatus";
+import { useUserAwuStatus } from "@app/lib/swr/user";
 import { DEFAULT_EMBEDDING_PROVIDER_ID } from "@app/types/assistant/models/embedding";
 import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
 import type { SubscriptionType } from "@app/types/plan";
 import { PRETTIFIED_PROVIDER_NAMES } from "@app/types/provider_selection";
-import type { WorkspaceType } from "@app/types/user";
+import type { LightWorkspaceType, WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
 import { cn, LinkWrapper } from "@dust-tt/sparkle";
 import { cva, type VariantProps } from "class-variance-authority";
@@ -198,12 +199,41 @@ function SubscriptionPastDueBanner() {
   );
 }
 
+interface UserAwuCapBannerProps {
+  owner: LightWorkspaceType;
+}
+
+function UserAwuCapBanner({ owner }: UserAwuCapBannerProps) {
+  const { awuStatus } = useUserAwuStatus({ owner });
+
+  if (awuStatus === "normal") {
+    return null;
+  }
+
+  return (
+    <StatusBanner
+      variant={awuStatus === "blocked" ? "danger" : "warning"}
+      title={
+        awuStatus === "blocked"
+          ? "You've reached your usage limit"
+          : "You've used 80% of your usage limit"
+      }
+      description={
+        awuStatus === "blocked"
+          ? "You can no longer run agents. Contact your admin to increase your limit."
+          : "Contact your admin to increase your limit before you are blocked."
+      }
+    />
+  );
+}
+
 export function SidebarBanners() {
   const { workspace: owner, subscription } = useAuth();
   const { appStatus } = useAppStatus();
 
   return (
     <>
+      <UserAwuCapBanner owner={owner} />
       <UnhealthyCredentialsBanner owner={owner} subscription={subscription} />
       {appStatus && <AppStatusBanner appStatus={appStatus} />}
       {subscription.paymentFailingSince &&

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -60,6 +60,10 @@ import {
 import { invalidateContractCache } from "@app/lib/metronome/plan_type";
 import type { ProgrammaticCreditEvent } from "@app/lib/metronome/programmatic_credit_state_machine";
 import { isMetronomeFreeCredit } from "@app/lib/metronome/types";
+import {
+  clearUserAwuWarned,
+  setUserAwuWarned,
+} from "@app/lib/metronome/user_block";
 import type { MetronomeWebhookEvent } from "@app/lib/metronome/webhook_events";
 import { PlanModel } from "@app/lib/models/plan";
 import { notifyUserAwuCapReached } from "@app/lib/notifications/workflows/user-awu-cap-reached";
@@ -670,6 +674,7 @@ async function handlePerUserSpendThresholdEvent({
           )
         );
       }
+      void clearUserAwuWarned(workspace.sId, userId);
       break;
     }
     case "evaluating":
@@ -692,6 +697,7 @@ async function handlePerUserSpendThresholdEvent({
     logger.info(
       "[Metronome Webhook] per-user spend threshold warning: handling..."
     );
+    void setUserAwuWarned(workspace.sId, userId);
     const capAwuCredits = capThreshold ?? 0;
     const user = await UserResource.fetchById(userId);
     if (user) {

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -18,6 +18,7 @@ import {
   upsertMetronomePerUserWarningAlert,
 } from "@app/lib/metronome/alerts/spend_limits";
 import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
+import { clearUserAwuWarned } from "@app/lib/metronome/user_block";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
@@ -240,6 +241,7 @@ export async function setUserSpendLimit(
           "[Metronome PerUserCap] Failed to clear warning alert; continuing"
         );
       }
+      void clearUserAwuWarned(workspace.sId, user.sId);
 
       const defaultResult = await getMetronomeDefaultUserCapAlert({
         metronomeCustomerId: workspace.metronomeCustomerId,

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -1,12 +1,13 @@
 // Redis fast-path cache for credit-state-driven access control.
 //
-// Two orthogonal keys back the credit state machines:
+// Three keys back the credit state machines:
 //   - `metronome:user_cap:<ws>:<user>`: caches the user's per-user cap state.
+//   - `metronome:user_awu_warning:<ws>:<user>`: caches the 80% AWU warning state.
 //   - `metronome:pool_depleted:<ws>`: caches the workspace pool state.
 //
 // Each key stores an explicit boolean flag:
-//   - `"1"`: blocked / depleted
-//   - `"0"`: not blocked / not depleted
+//   - `"1"`: blocked / warned / depleted
+//   - `"0"`: not blocked / not warned / not depleted
 //
 // `isUserBlocked` is the unified read: a user is blocked iff either cached flag
 // is `"1"`, and it returns the reason ("credits_exhausted" for a depleted
@@ -17,6 +18,9 @@
 // of truth. Cache writes are gated on DB transaction commit via
 // `invalidateCacheAfterCommit`, and cache misses fall back to DB and
 // repopulate both flags.
+//
+// The warning flag (`metronome:user_awu_warning`) has no DB column backing it:
+// a cold-cache miss returns `false` (safe default until the next webhook re-sets the flag).
 //
 import { runOnRedis } from "@app/lib/api/redis";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
@@ -41,6 +45,10 @@ const NOT_BLOCKED_FLAG = "0";
 
 function buildUserCapKey(workspaceId: string, userId: string): string {
   return `metronome:user_cap:${workspaceId}:${userId}`;
+}
+
+function buildUserAwuWarningKey(workspaceId: string, userId: string): string {
+  return `metronome:user_awu_warning:${workspaceId}:${userId}`;
 }
 
 function buildWorkspacePoolDepletedKey(workspaceId: string): string {
@@ -148,6 +156,32 @@ export async function clearUserCapBlocked(
   userId: string
 ): Promise<void> {
   await setFlag(buildUserCapKey(workspaceId, userId), NOT_BLOCKED_FLAG);
+}
+
+// Per-user AWU 80% warning (set by webhook; no DB fallback)
+
+export async function setUserAwuWarned(
+  workspaceId: string,
+  userId: string
+): Promise<void> {
+  await setFlag(buildUserAwuWarningKey(workspaceId, userId), BLOCKED_FLAG);
+}
+
+export async function clearUserAwuWarned(
+  workspaceId: string,
+  userId: string
+): Promise<void> {
+  await setFlag(buildUserAwuWarningKey(workspaceId, userId), NOT_BLOCKED_FLAG);
+}
+
+export async function isUserAwuWarned(
+  workspaceId: string,
+  userId: string
+): Promise<boolean> {
+  const val = await runOnRedis({ origin: REDIS_ORIGIN }, async (client) =>
+    client.get(buildUserAwuWarningKey(workspaceId, userId))
+  );
+  return val === BLOCKED_FLAG;
 }
 
 // Workspace pool depleted (workspace credit state machine)

--- a/front/lib/metronome/user_credit_state_machine.test.ts
+++ b/front/lib/metronome/user_credit_state_machine.test.ts
@@ -13,6 +13,7 @@ const {
   mockSetUserCapBlocked,
   mockClearUserCapBlocked,
   mockInvalidateCacheAfterCommit,
+  mockClearUserAwuWarned,
 } = vi.hoisted(() => ({
   mockSetUserCapBlocked: vi.fn(),
   mockClearUserCapBlocked: vi.fn(),
@@ -23,11 +24,13 @@ const {
       void fn();
     }
   ),
+  mockClearUserAwuWarned: vi.fn(),
 }));
 
 vi.mock("@app/lib/metronome/user_block", () => ({
   setUserCapBlocked: mockSetUserCapBlocked,
   clearUserCapBlocked: mockClearUserCapBlocked,
+  clearUserAwuWarned: mockClearUserAwuWarned,
 }));
 
 vi.mock("@app/lib/utils/cache", () => ({

--- a/front/lib/metronome/user_credit_state_machine.ts
+++ b/front/lib/metronome/user_credit_state_machine.ts
@@ -1,4 +1,5 @@
 import {
+  clearUserAwuWarned,
   clearUserCapBlocked,
   setUserCapBlocked,
 } from "@app/lib/metronome/user_block";
@@ -46,6 +47,9 @@ function syncUserCapCacheForState(
     case "normal":
       invalidateCacheAfterCommit(transaction, () =>
         clearUserCapBlocked(ctx.workspaceId, ctx.userId)
+      );
+      invalidateCacheAfterCommit(transaction, () =>
+        clearUserAwuWarned(ctx.workspaceId, ctx.userId)
       );
       return;
 

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -11,6 +11,7 @@ import type { EmailProviderType } from "@app/lib/utils/email_provider_detection"
 import type { GetUserResponseBody } from "@app/pages/api/user";
 import type { GetUserMetadataResponseBody } from "@app/pages/api/user/metadata/[key]";
 import type { GetUserApprovalsResponseBody } from "@app/pages/api/w/[wId]/me/approvals";
+import type { GetUserAwuStatusResponseBody } from "@app/pages/api/w/[wId]/me/awu-status";
 import type { GetPendingInvitationsResponseBody } from "@app/pages/api/w/[wId]/me/pending-invitations";
 import type { GetSlackNotificationResponseBody } from "@app/pages/api/w/[wId]/me/slack-notifications";
 import type { FavoritePlatform } from "@app/types/favorite_platforms";
@@ -249,5 +250,26 @@ export function useSlackNotifications(
   return {
     isSlackSetupLoading,
     canConfigureSlack,
+  };
+}
+
+export function useUserAwuStatus({
+  owner,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const awuStatusFetcher: Fetcher<GetUserAwuStatusResponseBody> = fetcher;
+  const { data, error } = useSWRWithDefaults(
+    `/api/w/${owner.sId}/me/awu-status`,
+    awuStatusFetcher,
+    { disabled }
+  );
+
+  return {
+    awuStatus: data?.status ?? "normal",
+    isAwuStatusLoading: !error && !data && !disabled,
   };
 }

--- a/front/pages/api/w/[wId]/me/awu-status.ts
+++ b/front/pages/api/w/[wId]/me/awu-status.ts
@@ -1,0 +1,50 @@
+// @migration-status: MIGRATED_TO_HONO
+
+/** @ignoreswagger */
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { isUserAwuWarned, isUserBlocked } from "@app/lib/metronome/user_block";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type GetUserAwuStatusResponseBody = {
+  status: "normal" | "warned" | "blocked";
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetUserAwuStatusResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  const user = auth.getNonNullableUser();
+
+  if (!workspace.metronomeCustomerId) {
+    return res.status(200).json({ status: "normal" });
+  }
+
+  const blockedReason = await isUserBlocked(workspace.sId, user.sId);
+  if (blockedReason === "user_cap_reached") {
+    return res.status(200).json({ status: "blocked" });
+  }
+
+  const warned = await isUserAwuWarned(workspace.sId, user.sId);
+  if (warned) {
+    return res.status(200).json({ status: "warned" });
+  }
+
+  return res.status(200).json({ status: "normal" });
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

Adds persistent sidebar banners that appear directly in the app when a user has consumed 80% or 100% of their per-user AWU limit — complementing the email/in-app Novu notifications from the parent PR.

**Redis warning flag:**

A new Redis key `metronome:user_awu_warning:<ws>:<user>` stores the 80% threshold state (mirrors the existing `user_cap` flag used for 100% blocking). It is:
- Set (`"1"`) by the Metronome webhook handler when the 80% warning alert fires.
- Cleared (`"0"`) when the cap resolves (billing cycle reset, webhook `ok` state, billing cycle renewal via the credit state machine, or admin removing the cap via `setUserSpendLimit`).

The flag has no DB column backing it — a cold Redis miss returns `false` (safe default; banner stays hidden until the next webhook).

**Endpoint (`GET /api/w/:wId/me/awu-status`):**

Reads both the `user_cap` and `user_awu_warning` Redis flags — never Metronome — and returns `{ status: "normal" | "warned" | "blocked" }`. Implemented in both Next.js (`@migration-status: MIGRATED_TO_HONO`) and Hono.

**Banner (`UserAwuCapBanner`):**

A new `useUserAwuStatus` SWR hook and `UserAwuCapBanner` component added to `AppStatusBanner.tsx`/`SidebarBanners`. Shows:
- Warning (yellow): "You've used 80% of your usage limit."
- Danger (red): "You've reached your usage limit. You can no longer run agents."

## Test

![Uploading image.png…]()


## Risk
Low. All Redis writes are fire-and-forget (`void`). The new endpoint has no Metronome calls on page load. Existing blocking logic in the parent PR is unchanged.
