### PR TITLE
Add a limit to warn at 80% of programmatic usage

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -64,6 +64,7 @@ import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { extractFromString, serializeMention } from "@app/lib/mentions/format";
 import {
   getWorkspaceCreditPoolStatus,
+  getWorkspaceProgrammaticCreditStatus,
   isApiBlocked,
   isProgrammaticApiBlocked,
   isUserBlocked,
@@ -170,6 +171,18 @@ const PROGRAMMATIC_RATE_LIMIT_DOLLARS_PER_MESSAGE = 3;
 // Prevents close-to-0 attacks where many requests are sent simultaneously
 // before Metronome debits settle.
 const POOL_CREDIT_CONCURRENCY_LIMITS: Record<string, number> = {
+  active: 1000,
+  active_low_balance: 5,
+  active_critical_balance: 1,
+};
+
+// Concurrency limits for programmatic API calls based on the workspace
+// programmatic monthly cap state. Same shape and intent as the pool limits:
+// once the workspace is close to its monthly cap, tighten in-flight
+// programmatic requests so concurrent calls can't overshoot before
+// Metronome debits settle. `depleted` is handled upstream by
+// `isProgrammaticApiBlocked`.
+const PROGRAMMATIC_CREDIT_CONCURRENCY_LIMITS: Record<string, number> = {
   active: 1000,
   active_low_balance: 5,
   active_critical_balance: 1,
@@ -2466,6 +2479,24 @@ async function checkMessagesLimit(
           },
         });
       }
+
+      // Pre-emptive concurrency limit based on the programmatic monthly cap
+      // state. Same close-to-0 defense as the pool concurrency limit above,
+      // but scoped to programmatic API traffic.
+      const programmaticLimit =
+        await checkProgrammaticCreditConcurrencyLimit(auth);
+      if (programmaticLimit.isLimitReached && programmaticLimit.limitType) {
+        return new Err({
+          status_code: 429,
+          api_error: {
+            type: programmaticLimit.limitType,
+            message: getMessageLimitErrorMessage({
+              limitType: programmaticLimit.limitType,
+              message: programmaticLimit.message,
+            }),
+          },
+        });
+      }
     }
   } else if (isProgrammaticUsage(auth, { userMessageOrigin: context.origin })) {
     const limitsResult = await checkProgrammaticUsageLimits(auth);
@@ -2556,6 +2587,54 @@ async function checkPoolCreditConcurrencyLimit(
 
     getStatsDClient().increment(
       "assistant.rate_limiter.pool_credit.concurrency_limit_triggered",
+      1,
+      { workspace_id: owner.sId }
+    );
+
+    return {
+      isLimitReached: true,
+      limitType: "rate_limit_error",
+    };
+  }
+
+  return { isLimitReached: false, limitType: null };
+}
+
+// For programmatic API calls on pool-credit (Metronome) plans, apply
+// concurrency limiting based on the workspace programmatic credit state.
+// Same close-to-0 defense as the pool concurrency limit, but driven by the
+// programmatic monthly cap state machine.
+async function checkProgrammaticCreditConcurrencyLimit(
+  auth: Authenticator
+): Promise<MessageLimit> {
+  const owner = auth.getNonNullableWorkspace();
+  const status = await getWorkspaceProgrammaticCreditStatus(owner.sId);
+
+  const maxConcurrent = PROGRAMMATIC_CREDIT_CONCURRENCY_LIMITS[status];
+  if (maxConcurrent === undefined) {
+    // depleted — handled by isProgrammaticApiBlocked upstream.
+    return { isLimitReached: false, limitType: null };
+  }
+
+  const remaining = await rateLimiter({
+    key: `programmatic_credit_concurrency:${owner.sId}`,
+    maxPerTimeframe: maxConcurrent,
+    timeframeSeconds: 60,
+    logger,
+  });
+
+  if (remaining <= 0) {
+    logger.info(
+      {
+        workspaceId: owner.sId,
+        programmaticCreditStatus: status,
+        maxConcurrent,
+      },
+      "Programmatic credit concurrency limit triggered."
+    );
+
+    getStatsDClient().increment(
+      "assistant.rate_limiter.programmatic_credit.concurrency_limit_triggered",
       1,
       { workspace_id: owner.sId }
     );

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -209,6 +209,25 @@ export async function dispatchProgrammaticCapReset({
 }
 
 /**
+ * Notify admins that programmatic spend has crossed the early-warning
+ * threshold (80% of the monthly cap). Unlike the other programmatic
+ * dispatchers this does not transition the credit state machine — the
+ * workspace stays in its current balance state and no throttling kicks in.
+ * The signal is informational only.
+ */
+export async function dispatchProgrammaticWarning({
+  workspace,
+}: {
+  workspace: WorkspaceResource;
+}): Promise<void> {
+  // TODO: send notification to admin.
+  logger.info(
+    { workspaceId: workspace.sId },
+    "[ProgrammaticCreditDispatcher] Programmatic warning threshold reached"
+  );
+}
+
+/**
  * Reconcile the workspace pool credit state with the current Metronome AWU
  * balance. Used after a new contract is provisioned: the cached pool state
  * may be stale (e.g. `depleted` from the previous contract) and Metronome

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -8,6 +8,7 @@ import {
   dispatchProgrammaticCapReached,
   dispatchProgrammaticCapReset,
   dispatchProgrammaticLowBalance,
+  dispatchProgrammaticWarning,
   syncPoolCreditStateFromBalance,
 } from "@app/lib/api/metronome/credit_state_dispatcher";
 import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
@@ -29,6 +30,7 @@ import {
   PROGRAMMATIC_CAP_ALERT_NAME,
   PROGRAMMATIC_CRITICAL_BALANCE_ALERT_NAME,
   PROGRAMMATIC_LOW_BALANCE_ALERT_NAME,
+  PROGRAMMATIC_WARNING_BALANCE_ALERT_NAME,
 } from "@app/lib/metronome/alerts/programmatic_cap";
 import {
   getMetronomeDefaultUserCapAlert,
@@ -95,8 +97,8 @@ function isProgrammaticMonthlyCap(
 
 // Map a programmatic cap alert name to the state-machine event it should
 // dispatch. Returns null when the alert name doesn't match any of the three
-// programmatic alerts (defensive — Metronome shouldn't fire anything else
-// under the AWU credit type on this code path).
+// FSM-driving programmatic alerts (the warning alert is handled separately
+// since it does not drive the state machine).
 function programmaticEventFromAlertName(
   alertName: string
 ): ProgrammaticCreditEvent | null {
@@ -668,25 +670,33 @@ export async function processMetronomeWebhook({
       } else if (isProgrammaticMonthlyCap(event)) {
         // Programmatic monthly cap alerts. Three alerts exist per workspace
         // with distinct names; route to the matching dispatcher.
+        //
+        // The warning alert (80% of cap) is informational only — it does not
+        // drive the credit state machine, so it's handled separately from the
+        // three FSM-driving alerts (cap reached / low / critical).
         const alertName = event.properties.alert_name ?? "";
-        const programmaticEvent = programmaticEventFromAlertName(alertName);
-        if (programmaticEvent) {
-          switch (programmaticEvent.type) {
-            case "programmatic_cap_reached":
-              await dispatchProgrammaticCapReached({ workspace });
-              break;
-            case "programmatic_low_balance":
-              await dispatchProgrammaticLowBalance({
-                workspace,
-                remainingCredits: programmaticEvent.remainingCredits,
-              });
-              break;
-            case "programmatic_cap_reset":
-              // never happens in spend_threshold_reached
-              // dispatch below by spend_threshold_resolved case
-              break;
-            default:
-              assertNever(programmaticEvent);
+        if (alertName.startsWith(PROGRAMMATIC_WARNING_BALANCE_ALERT_NAME)) {
+          await dispatchProgrammaticWarning({ workspace });
+        } else {
+          const programmaticEvent = programmaticEventFromAlertName(alertName);
+          if (programmaticEvent) {
+            switch (programmaticEvent.type) {
+              case "programmatic_cap_reached":
+                await dispatchProgrammaticCapReached({ workspace });
+                break;
+              case "programmatic_low_balance":
+                await dispatchProgrammaticLowBalance({
+                  workspace,
+                  remainingCredits: programmaticEvent.remainingCredits,
+                });
+                break;
+              case "programmatic_cap_reset":
+                // never happens in spend_threshold_reached
+                // dispatch below by spend_threshold_resolved case
+                break;
+              default:
+                assertNever(programmaticEvent);
+            }
           }
         }
         logger.info(

--- a/front/lib/metronome/alerts/programmatic_cap.ts
+++ b/front/lib/metronome/alerts/programmatic_cap.ts
@@ -12,6 +12,10 @@ function programmaticCapUniquenessKey(workspaceId: string): string {
   return `programmatic-cap-${workspaceId}`;
 }
 
+function programmaticCapWarningUniquenessKey(workspaceId: string): string {
+  return `programmatic-cap-warning-${workspaceId}`;
+}
+
 function programmaticCapLowUniquenessKey(workspaceId: string): string {
   return `programmatic-cap-low-${workspaceId}`;
 }
@@ -20,12 +24,19 @@ function programmaticCapCriticalUniquenessKey(workspaceId: string): string {
   return `programmatic-cap-critical-${workspaceId}`;
 }
 
+// Early-warning threshold (as a fraction of the monthly cap) fires a
+// notification — no state-machine transition, no throttling. Lets admins
+// react before the workspace enters the close-to-cap throttle band.
+export const WARNING_BALANCE_RATIO = 0.8;
+
 // Warning thresholds: fire alerts this many credits before the cap.
 export const LOW_BALANCE_OFFSET = 100;
 export const CRITICAL_BALANCE_OFFSET = 10;
 
 // Alert name prefixes used to identify which alert fired in webhook routing.
 export const PROGRAMMATIC_CAP_ALERT_NAME = "Programmatic cap";
+export const PROGRAMMATIC_WARNING_BALANCE_ALERT_NAME =
+  "Programmatic warning balance";
 export const PROGRAMMATIC_LOW_BALANCE_ALERT_NAME = "Programmatic low balance";
 export const PROGRAMMATIC_CRITICAL_BALANCE_ALERT_NAME =
   "Programmatic critical balance";
@@ -52,13 +63,14 @@ export async function getMetronomeProgrammaticCap({
 }
 
 /**
- * Idempotently create or update the three programmatic cap alerts:
+ * Idempotently create or update the four programmatic cap alerts:
  *   1. Main cap alert (depleted when reached)
- *   2. Low balance alert (cap - 100)
- *   3. Critical balance alert (cap - 10)
+ *   2. Warning balance alert (80% of cap) — notification only, no throttling
+ *   3. Low balance alert (cap - 100)
+ *   4. Critical balance alert (cap - 10)
  *
- * All three use the Programmatic USD credit type so they can be distinguished
- * from AWU pool alerts in webhook routing.
+ * All four use the AWU credit type and are scoped to `usage_type=programmatic`
+ * so contract/pool spend doesn't contribute to the cap thresholds.
  */
 export async function upsertMetronomeProgrammaticCapAlerts({
   metronomeCustomerId,
@@ -89,6 +101,23 @@ export async function upsertMetronomeProgrammaticCapAlerts({
   });
   if (capResult.isErr()) {
     return new Err(capResult.error);
+  }
+
+  // Warning alert (80% of cap).
+  const warningThreshold = Math.floor(
+    monthlyCapCredits * WARNING_BALANCE_RATIO
+  );
+  const warningResult = await upsertMetronomeAlert({
+    alert_type: "spend_threshold_reached",
+    name: `${PROGRAMMATIC_WARNING_BALANCE_ALERT_NAME} ${workspaceId} (${warningThreshold} credits)`,
+    threshold: warningThreshold,
+    credit_type_id: creditTypeId,
+    customer_id: metronomeCustomerId,
+    group_values: programmaticGroupValues,
+    uniqueness_key: programmaticCapWarningUniquenessKey(workspaceId),
+  });
+  if (warningResult.isErr()) {
+    return new Err(warningResult.error);
   }
 
   // Low balance alert (100 credits before cap).
@@ -129,6 +158,7 @@ export async function upsertMetronomeProgrammaticCapAlerts({
       workspaceId,
       metronomeCustomerId,
       monthlyCapCredits,
+      warningThreshold,
       lowThreshold,
       criticalThreshold,
     },
@@ -138,7 +168,7 @@ export async function upsertMetronomeProgrammaticCapAlerts({
 }
 
 /**
- * Archive all three programmatic cap alerts. Idempotent — no-op when no
+ * Archive all four programmatic cap alerts. Idempotent — no-op when no
  * matching alerts exist.
  */
 export async function clearMetronomeProgrammaticCapAlerts({
@@ -150,6 +180,7 @@ export async function clearMetronomeProgrammaticCapAlerts({
 }): Promise<Result<void, Error>> {
   const keys = [
     programmaticCapUniquenessKey(workspaceId),
+    programmaticCapWarningUniquenessKey(workspaceId),
     programmaticCapLowUniquenessKey(workspaceId),
     programmaticCapCriticalUniquenessKey(workspaceId),
   ];


### PR DESCRIPTION
## Description

Register another alert at 80% of programmatic usage
Do not actually notify anybody at the moment, will be done in a follow up PR

## Tests

not tested

## Risk

low

## Deploy Plan

deploy front
