### PR TITLE
feat: add feedback table to /analytics/export

### DIFF
--- a/front-api/routes/v1/w/[wId]/analytics/export.test.ts
+++ b/front-api/routes/v1/w/[wId]/analytics/export.test.ts
@@ -99,6 +99,40 @@ vi.mock("@app/lib/api/analytics/messages_export", async () => ({
   ),
 }));
 
+vi.mock("@app/lib/api/analytics/feedback_export", async () => ({
+  FEEDBACK_EXPORT_HEADERS: [
+    "feedbackId",
+    "createdAt",
+    "assistantId",
+    "assistantName",
+    "conversationId",
+    "conversationUrl",
+    "userId",
+    "userEmail",
+    "thumb",
+    "content",
+    "dismissed",
+  ],
+  fetchFeedbackExportRows: vi.fn(
+    async () =>
+      new Ok([
+        {
+          feedbackId: "42",
+          createdAt: "2024-06-01 10:00:00",
+          assistantId: "agent-1",
+          assistantName: "TestAgent",
+          conversationId: "conv-1",
+          conversationUrl: "https://dust.tt/w/ws-1/conversation/conv-1",
+          userId: "user-1",
+          userEmail: "alice@example.com",
+          thumb: "up",
+          content: "great answer",
+          dismissed: "false",
+        },
+      ])
+  ),
+}));
+
 async function setupTest({
   table = "usage_metrics",
   startDate = "2024-06-01",
@@ -301,6 +335,41 @@ describe("GET /api/v1/w/[wId]/analytics/export", () => {
     );
     expect(csv).toContain("msg-1");
     expect(csv).toContain("alice@example.com");
+  });
+
+  it("returns CSV for feedback table", async () => {
+    const { response } = await setupTest({ table: "feedback" });
+
+    expect(response.status).toBe(200);
+    const csv = await response.text();
+    expect(csv).toContain(
+      "feedbackId,createdAt,assistantId,assistantName,conversationId,conversationUrl,userId,userEmail,thumb,content,dismissed"
+    );
+    expect(csv).toContain("great answer");
+    expect(csv).toContain("alice@example.com");
+  });
+
+  it("returns typed JSON for feedback", async () => {
+    const { response } = await setupTest({
+      table: "feedback",
+      format: "json",
+    });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data[0]).toEqual({
+      feedbackId: "42",
+      createdAt: "2024-06-01 10:00:00",
+      assistantId: "agent-1",
+      assistantName: "TestAgent",
+      conversationId: "conv-1",
+      conversationUrl: "https://dust.tt/w/ws-1/conversation/conv-1",
+      userId: "user-1",
+      userEmail: "alice@example.com",
+      thumb: "up",
+      content: "great answer",
+      dismissed: "false",
+    });
   });
 
   it("returns typed JSON when format=json for usage_metrics", async () => {

--- a/front-api/routes/v1/w/[wId]/analytics/export.test.ts
+++ b/front-api/routes/v1/w/[wId]/analytics/export.test.ts
@@ -105,7 +105,6 @@ vi.mock("@app/lib/api/analytics/feedback_export", async () => ({
     "createdAt",
     "assistantId",
     "assistantName",
-    "conversationId",
     "conversationUrl",
     "userId",
     "userEmail",
@@ -121,7 +120,6 @@ vi.mock("@app/lib/api/analytics/feedback_export", async () => ({
           createdAt: "2024-06-01 10:00:00",
           assistantId: "agent-1",
           assistantName: "TestAgent",
-          conversationId: "conv-1",
           conversationUrl: "https://dust.tt/w/ws-1/conversation/conv-1",
           userId: "user-1",
           userEmail: "alice@example.com",
@@ -343,7 +341,7 @@ describe("GET /api/v1/w/[wId]/analytics/export", () => {
     expect(response.status).toBe(200);
     const csv = await response.text();
     expect(csv).toContain(
-      "feedbackId,createdAt,assistantId,assistantName,conversationId,conversationUrl,userId,userEmail,thumb,content,dismissed"
+      "feedbackId,createdAt,assistantId,assistantName,conversationUrl,userId,userEmail,thumb,content,dismissed"
     );
     expect(csv).toContain("great answer");
     expect(csv).toContain("alice@example.com");
@@ -362,7 +360,6 @@ describe("GET /api/v1/w/[wId]/analytics/export", () => {
       createdAt: "2024-06-01 10:00:00",
       assistantId: "agent-1",
       assistantName: "TestAgent",
-      conversationId: "conv-1",
       conversationUrl: "https://dust.tt/w/ws-1/conversation/conv-1",
       userId: "user-1",
       userEmail: "alice@example.com",

--- a/front-api/routes/v1/w/[wId]/analytics/export.ts
+++ b/front-api/routes/v1/w/[wId]/analytics/export.ts
@@ -28,9 +28,10 @@
  *           - "skill_usage": Skill executions and unique users over time.
  *           - "tool_usage": Tool executions and unique users over time.
  *           - "messages": Detailed message-level logs.
+ *           - "feedback": Detailed message-level feedback (thumbs, content, conversation URL).
  *         schema:
  *           type: string
- *           enum: [usage_metrics, active_users, source, agents, users, skill_usage, tool_usage, messages]
+ *           enum: [usage_metrics, active_users, source, agents, users, skill_usage, tool_usage, messages, feedback]
  *       - in: query
  *         name: startDate
  *         required: true

--- a/front/lib/api/analytics/enrichment.ts
+++ b/front/lib/api/analytics/enrichment.ts
@@ -1,6 +1,6 @@
 import { getFrontReplicaDbConnection } from "@app/lib/resources/storage";
 import { UserResource } from "@app/lib/resources/user_resource";
-import type { ModelId } from "@app/types/shared/model_id";
+import type { LightWorkspaceType } from "@app/types/user";
 import { QueryTypes } from "sequelize";
 
 interface AgentMetaRow {
@@ -11,7 +11,7 @@ interface AgentMetaRow {
 
 export async function fetchAgentMetadata(
   agentIds: string[],
-  workspaceModelId: ModelId
+  workspace: LightWorkspaceType
 ): Promise<Map<string, { name: string; settings: string }>> {
   if (agentIds.length === 0) {
     return new Map();
@@ -36,7 +36,7 @@ export async function fetchAgentMetadata(
     `,
     {
       type: QueryTypes.SELECT,
-      replacements: { wId: workspaceModelId, agentIds },
+      replacements: { wId: workspace.id, agentIds },
     }
   );
 
@@ -65,7 +65,7 @@ interface FeedbackContentRow {
 // index; we read it from the DB at export time, keyed by the feedback ModelId.
 export async function fetchFeedbackContents(
   feedbackModelIds: number[],
-  workspaceModelId: ModelId
+  workspace: LightWorkspaceType
 ): Promise<Map<number, string>> {
   if (feedbackModelIds.length === 0) {
     return new Map();
@@ -83,7 +83,7 @@ export async function fetchFeedbackContents(
     `,
     {
       type: QueryTypes.SELECT,
-      replacements: { wId: workspaceModelId, feedbackIds: feedbackModelIds },
+      replacements: { wId: workspace.id, feedbackIds: feedbackModelIds },
     }
   );
 

--- a/front/lib/api/analytics/enrichment.ts
+++ b/front/lib/api/analytics/enrichment.ts
@@ -1,0 +1,98 @@
+import { getFrontReplicaDbConnection } from "@app/lib/resources/storage";
+import { UserResource } from "@app/lib/resources/user_resource";
+import type { ModelId } from "@app/types/shared/model_id";
+import { QueryTypes } from "sequelize";
+
+interface AgentMetaRow {
+  sId: string;
+  name: string;
+  settings: string;
+}
+
+export async function fetchAgentMetadata(
+  agentIds: string[],
+  workspaceModelId: ModelId
+): Promise<Map<string, { name: string; settings: string }>> {
+  if (agentIds.length === 0) {
+    return new Map();
+  }
+
+  const readReplica = getFrontReplicaDbConnection();
+  // biome-ignore lint/plugin/noRawSql: Matches existing Activity Report query pattern.
+  const agents = await readReplica.query<AgentMetaRow>(
+    `
+    SELECT ac."sId",
+           ac."name",
+           CASE
+             WHEN ac."status" = 'draft' THEN 'draft'
+             WHEN ac."scope" = 'visible' THEN 'published'
+             WHEN ac."scope" = 'hidden' THEN 'unpublished'
+             ELSE 'unknown'
+           END AS "settings"
+    FROM "agent_configurations" ac
+    WHERE ac."workspaceId" = :wId
+      AND ac."sId" IN (:agentIds)
+      AND ac."status" = 'active'
+    `,
+    {
+      type: QueryTypes.SELECT,
+      replacements: { wId: workspaceModelId, agentIds },
+    }
+  );
+
+  return new Map(
+    agents.map((a) => [a.sId, { name: a.name, settings: a.settings }])
+  );
+}
+
+export async function fetchUserEmails(
+  userIds: string[]
+): Promise<Map<string, string>> {
+  if (userIds.length === 0) {
+    return new Map();
+  }
+
+  const users = await UserResource.fetchByIds(userIds);
+  return new Map(users.map((u) => [u.sId, u.email]));
+}
+
+interface FeedbackContentRow {
+  id: number;
+  content: string | null;
+}
+
+// Feedback content is free text that we deliberately keep out of the analytics
+// index; we read it from the DB at export time, keyed by the feedback ModelId.
+export async function fetchFeedbackContents(
+  feedbackModelIds: number[],
+  workspaceModelId: ModelId
+): Promise<Map<number, string>> {
+  if (feedbackModelIds.length === 0) {
+    return new Map();
+  }
+
+  const readReplica = getFrontReplicaDbConnection();
+  // biome-ignore lint/plugin/noRawSql: Matches existing Activity Report query pattern.
+  const feedbacks = await readReplica.query<FeedbackContentRow>(
+    `
+    SELECT amf."id",
+           amf."content"
+    FROM "agent_message_feedbacks" amf
+    WHERE amf."workspaceId" = :wId
+      AND amf."id" IN (:feedbackIds)
+    `,
+    {
+      type: QueryTypes.SELECT,
+      replacements: { wId: workspaceModelId, feedbackIds: feedbackModelIds },
+    }
+  );
+
+  const contentByFeedbackId = new Map<number, string>();
+  for (const feedback of feedbacks) {
+    if (feedback.content !== null) {
+      contentByFeedbackId.set(feedback.id, feedback.content);
+    }
+  }
+
+  return contentByFeedbackId;
+}

--- a/front/lib/api/analytics/export_tables.ts
+++ b/front/lib/api/analytics/export_tables.ts
@@ -590,8 +590,7 @@ async function exportMessages({
   owner: WorkspaceType;
 }): Promise<Result<ExportTableData, Error>> {
   const result = await fetchMessageExportRows({
-    workspaceId: owner.sId,
-    workspaceModelId: owner.id,
+    owner,
     startDate,
     endDate,
     timezone,

--- a/front/lib/api/analytics/export_tables.ts
+++ b/front/lib/api/analytics/export_tables.ts
@@ -4,6 +4,11 @@ import {
   fetchAgentExportRows,
 } from "@app/lib/api/analytics/agents_export";
 import { sanitizeCsvCell } from "@app/lib/api/analytics/csv_utils";
+import type { FeedbackExportRow } from "@app/lib/api/analytics/feedback_export";
+import {
+  FEEDBACK_EXPORT_HEADERS,
+  fetchFeedbackExportRows,
+} from "@app/lib/api/analytics/feedback_export";
 import type { MessageExportRow } from "@app/lib/api/analytics/messages_export";
 import {
   fetchMessageExportRows,
@@ -43,7 +48,8 @@ type AnalyticsExportTable =
   | "users"
   | "skill_usage"
   | "tool_usage"
-  | "messages";
+  | "messages"
+  | "feedback";
 
 interface UsageMetricsRow {
   date: string;
@@ -153,6 +159,11 @@ export type ExportTableData =
       table: "messages";
       headers: typeof MESSAGE_EXPORT_HEADERS;
       rows: MessageExportRow[];
+    }
+  | {
+      table: "feedback";
+      headers: typeof FEEDBACK_EXPORT_HEADERS;
+      rows: FeedbackExportRow[];
     };
 
 export async function exportTable({
@@ -195,6 +206,8 @@ export async function exportTable({
       return exportToolUsage({ startDate, endDate, timezone, owner });
     case "messages":
       return exportMessages({ startDate, endDate, timezone, owner });
+    case "feedback":
+      return exportFeedback({ startDate, endDate, timezone, owner });
     default:
       assertNever(table);
   }
@@ -217,6 +230,8 @@ export function stringifyExportTableAsCsv(data: ExportTableData): string {
     case "tool_usage":
       return stringifyRowsAsCsv(data.headers, data.rows);
     case "messages":
+      return stringifyRowsAsCsv(data.headers, data.rows);
+    case "feedback":
       return stringifyRowsAsCsv(data.headers, data.rows);
     default:
       assertNever(data);
@@ -591,6 +606,37 @@ async function exportMessages({
   return new Ok({
     table: "messages",
     headers: MESSAGE_EXPORT_HEADERS,
+    rows: result.value,
+  });
+}
+
+async function exportFeedback({
+  startDate,
+  endDate,
+  timezone,
+  owner,
+}: {
+  startDate: string;
+  endDate: string;
+  timezone: string;
+  owner: WorkspaceType;
+}): Promise<Result<ExportTableData, Error>> {
+  const result = await fetchFeedbackExportRows({
+    owner,
+    startDate,
+    endDate,
+    timezone,
+  });
+
+  if (result.isErr()) {
+    return new Err(
+      new Error(`Failed to retrieve feedback export: ${result.error.message}`)
+    );
+  }
+
+  return new Ok({
+    table: "feedback",
+    headers: FEEDBACK_EXPORT_HEADERS,
     rows: result.value,
   });
 }

--- a/front/lib/api/analytics/feedback_export.ts
+++ b/front/lib/api/analytics/feedback_export.ts
@@ -1,0 +1,191 @@
+import {
+  fetchAgentMetadata,
+  fetchFeedbackContents,
+  fetchUserEmails,
+} from "@app/lib/api/analytics/enrichment";
+import config from "@app/lib/api/config";
+import type { ElasticsearchBaseDocument } from "@app/lib/api/elasticsearch";
+import { searchAnalytics } from "@app/lib/api/elasticsearch";
+import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
+import { getConversationRoute } from "@app/lib/utils/router";
+import type { AgentMessageAnalyticsFeedback } from "@app/types/assistant/analytics";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import type { WorkspaceType } from "@app/types/user";
+import type { estypes } from "@elastic/elasticsearch";
+import moment from "moment-timezone";
+
+const PAGE_SIZE = 10000;
+
+interface FeedbackAgentMessageDocument extends ElasticsearchBaseDocument {
+  message_id: string;
+  conversation_id: string;
+  agent_id: string;
+  timestamp: string;
+  feedbacks: AgentMessageAnalyticsFeedback[];
+}
+
+export interface FeedbackExportRow {
+  feedbackId: string;
+  createdAt: string;
+  assistantId: string;
+  assistantName: string;
+  conversationId: string;
+  conversationUrl: string;
+  userId: string;
+  userEmail: string;
+  thumb: string;
+  content: string;
+  dismissed: string;
+}
+
+export const FEEDBACK_EXPORT_HEADERS: (keyof FeedbackExportRow)[] = [
+  "feedbackId",
+  "createdAt",
+  "assistantId",
+  "assistantName",
+  "conversationId",
+  "conversationUrl",
+  "userId",
+  "userEmail",
+  "thumb",
+  "content",
+  "dismissed",
+];
+
+async function fetchAllFeedbackDocuments(
+  query: estypes.QueryDslQueryContainer
+): Promise<Result<FeedbackAgentMessageDocument[], Error>> {
+  const allDocs: FeedbackAgentMessageDocument[] = [];
+  let searchAfter: estypes.SortResults | undefined;
+
+  while (true) {
+    const result = await searchAnalytics<FeedbackAgentMessageDocument>(query, {
+      size: PAGE_SIZE,
+      sort: [{ timestamp: "asc" }, { message_id: "asc" }],
+      search_after: searchAfter,
+    });
+
+    if (result.isErr()) {
+      return new Err(new Error(result.error.message));
+    }
+
+    const { hits } = result.value.hits;
+    for (const hit of hits) {
+      if (hit._source) {
+        allDocs.push(hit._source);
+      }
+    }
+
+    if (hits.length < PAGE_SIZE) {
+      break;
+    }
+
+    const lastHit = hits[hits.length - 1];
+    searchAfter = lastHit.sort;
+  }
+
+  return new Ok(allDocs);
+}
+
+export async function fetchFeedbackExportRows({
+  owner,
+  startDate,
+  endDate,
+  timezone,
+}: {
+  owner: WorkspaceType;
+  startDate: string;
+  endDate: string;
+  timezone: string;
+}): Promise<Result<FeedbackExportRow[], Error>> {
+  // Feedback is filtered by the date the feedback was given (which can differ
+  // from the message timestamp), so we range on the nested feedbacks.created_at
+  // and post-filter each document's feedbacks to the requested window.
+  const startIso = `${startDate}T00:00:00.000Z`;
+  const endIso = `${endDate}T23:59:59.999Z`;
+
+  const query: estypes.QueryDslQueryContainer = {
+    bool: {
+      filter: [
+        { term: { workspace_id: owner.sId } },
+        {
+          nested: {
+            path: "feedbacks",
+            query: {
+              range: {
+                "feedbacks.created_at": { gte: startIso, lte: endIso },
+              },
+            },
+          },
+        },
+      ],
+    },
+  };
+
+  const docsResult = await fetchAllFeedbackDocuments(query);
+  if (docsResult.isErr()) {
+    return new Err(docsResult.error);
+  }
+
+  const docs = docsResult.value;
+
+  const uniqueAgentIds = [
+    ...new Set(docs.map((d) => d.agent_id).filter(Boolean)),
+  ];
+  const allFeedbacks = docs.flatMap((d) => d.feedbacks ?? []);
+  const uniqueUserIds = [
+    ...new Set(allFeedbacks.map((f) => f.user_id).filter(Boolean)),
+  ];
+  const uniqueFeedbackIds = [
+    ...new Set(allFeedbacks.map((f) => f.feedback_id).filter(Boolean)),
+  ];
+
+  const [agentMeta, userEmails, feedbackContents] = await Promise.all([
+    fetchAgentMetadata(uniqueAgentIds, owner.id),
+    fetchUserEmails(uniqueUserIds),
+    fetchFeedbackContents(uniqueFeedbackIds, owner.id),
+  ]);
+
+  const rows: FeedbackExportRow[] = [];
+  for (const doc of docs) {
+    const agent = agentMeta.get(doc.agent_id);
+    for (const feedback of doc.feedbacks ?? []) {
+      // A matched document can carry feedbacks outside the requested window;
+      // keep only the ones created within it.
+      if (feedback.created_at < startIso || feedback.created_at > endIso) {
+        continue;
+      }
+      rows.push({
+        // feedback_id is stored as the internal ModelId; expose the opaque sId.
+        feedbackId: AgentMessageFeedbackResource.modelIdToSId({
+          id: feedback.feedback_id,
+          workspaceId: owner.id,
+        }),
+        createdAt: moment(feedback.created_at)
+          .tz(timezone)
+          .format("YYYY-MM-DD HH:mm:ss"),
+        assistantId: doc.agent_id,
+        assistantName: agent?.name ?? doc.agent_id,
+        conversationId: doc.conversation_id,
+        conversationUrl: feedback.is_conversation_shared
+          ? getConversationRoute(
+              owner.sId,
+              doc.conversation_id,
+              undefined,
+              config.getAppUrl()
+            )
+          : "",
+        userId: feedback.user_id,
+        userEmail: userEmails.get(feedback.user_id) ?? "",
+        thumb: feedback.thumb_direction,
+        content: feedbackContents.get(feedback.feedback_id) ?? "",
+        dismissed: feedback.dismissed ? "true" : "false",
+      });
+    }
+  }
+
+  rows.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+
+  return new Ok(rows);
+}

--- a/front/lib/api/analytics/feedback_export.ts
+++ b/front/lib/api/analytics/feedback_export.ts
@@ -30,7 +30,6 @@ export interface FeedbackExportRow {
   createdAt: string;
   assistantId: string;
   assistantName: string;
-  conversationId: string;
   conversationUrl: string;
   userId: string;
   userEmail: string;
@@ -44,7 +43,6 @@ export const FEEDBACK_EXPORT_HEADERS: (keyof FeedbackExportRow)[] = [
   "createdAt",
   "assistantId",
   "assistantName",
-  "conversationId",
   "conversationUrl",
   "userId",
   "userEmail",
@@ -142,9 +140,9 @@ export async function fetchFeedbackExportRows({
   ];
 
   const [agentMeta, userEmails, feedbackContents] = await Promise.all([
-    fetchAgentMetadata(uniqueAgentIds, owner.id),
+    fetchAgentMetadata(uniqueAgentIds, owner),
     fetchUserEmails(uniqueUserIds),
-    fetchFeedbackContents(uniqueFeedbackIds, owner.id),
+    fetchFeedbackContents(uniqueFeedbackIds, owner),
   ]);
 
   const rows: FeedbackExportRow[] = [];
@@ -167,7 +165,6 @@ export async function fetchFeedbackExportRows({
           .format("YYYY-MM-DD HH:mm:ss"),
         assistantId: doc.agent_id,
         assistantName: agent?.name ?? doc.agent_id,
-        conversationId: doc.conversation_id,
         conversationUrl: feedback.is_conversation_shared
           ? getConversationRoute(
               owner.sId,

--- a/front/lib/api/analytics/messages_export.ts
+++ b/front/lib/api/analytics/messages_export.ts
@@ -4,9 +4,9 @@ import {
 } from "@app/lib/api/analytics/enrichment";
 import type { ElasticsearchBaseDocument } from "@app/lib/api/elasticsearch";
 import { searchAnalytics } from "@app/lib/api/elasticsearch";
-import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import type { WorkspaceType } from "@app/types/user";
 import type { estypes } from "@elastic/elasticsearch";
 import moment from "moment-timezone";
 
@@ -82,14 +82,12 @@ async function fetchAllMessageDocuments(
 }
 
 export async function fetchMessageExportRows({
-  workspaceId,
-  workspaceModelId,
+  owner,
   startDate,
   endDate,
   timezone,
 }: {
-  workspaceId: string;
-  workspaceModelId: ModelId;
+  owner: WorkspaceType;
   startDate: string;
   endDate: string;
   timezone: string;
@@ -97,7 +95,7 @@ export async function fetchMessageExportRows({
   const query: estypes.QueryDslQueryContainer = {
     bool: {
       filter: [
-        { term: { workspace_id: workspaceId } },
+        { term: { workspace_id: owner.sId } },
         { term: { status: "succeeded" } },
         { range: { timestamp: { gte: startDate, lte: endDate } } },
       ],
@@ -119,7 +117,7 @@ export async function fetchMessageExportRows({
   ];
 
   const [agentMeta, userEmails] = await Promise.all([
-    fetchAgentMetadata(uniqueAgentIds, workspaceModelId),
+    fetchAgentMetadata(uniqueAgentIds, owner),
     fetchUserEmails(uniqueUserIds),
   ]);
 

--- a/front/lib/api/analytics/messages_export.ts
+++ b/front/lib/api/analytics/messages_export.ts
@@ -1,13 +1,14 @@
+import {
+  fetchAgentMetadata,
+  fetchUserEmails,
+} from "@app/lib/api/analytics/enrichment";
 import type { ElasticsearchBaseDocument } from "@app/lib/api/elasticsearch";
 import { searchAnalytics } from "@app/lib/api/elasticsearch";
-import { getFrontReplicaDbConnection } from "@app/lib/resources/storage";
-import { UserResource } from "@app/lib/resources/user_resource";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
 import moment from "moment-timezone";
-import { QueryTypes } from "sequelize";
 
 const PAGE_SIZE = 10000;
 
@@ -19,12 +20,6 @@ interface AgentMessageDocument extends ElasticsearchBaseDocument {
   user_id: string;
   context_origin: string;
   status: string;
-}
-
-interface AgentMetaRow {
-  sId: string;
-  name: string;
-  settings: string;
 }
 
 export interface MessageExportRow {
@@ -84,53 +79,6 @@ async function fetchAllMessageDocuments(
   }
 
   return new Ok(allDocs);
-}
-
-async function fetchAgentMetadata(
-  agentIds: string[],
-  workspaceModelId: ModelId
-): Promise<Map<string, { name: string; settings: string }>> {
-  if (agentIds.length === 0) {
-    return new Map();
-  }
-
-  const readReplica = getFrontReplicaDbConnection();
-  // biome-ignore lint/plugin/noRawSql: Matches existing Activity Report query pattern.
-  const agents = await readReplica.query<AgentMetaRow>(
-    `
-    SELECT ac."sId",
-           ac."name",
-           CASE
-             WHEN ac."status" = 'draft' THEN 'draft'
-             WHEN ac."scope" = 'visible' THEN 'published'
-             WHEN ac."scope" = 'hidden' THEN 'unpublished'
-             ELSE 'unknown'
-           END AS "settings"
-    FROM "agent_configurations" ac
-    WHERE ac."workspaceId" = :wId
-      AND ac."sId" IN (:agentIds)
-      AND ac."status" = 'active'
-    `,
-    {
-      type: QueryTypes.SELECT,
-      replacements: { wId: workspaceModelId, agentIds },
-    }
-  );
-
-  return new Map(
-    agents.map((a) => [a.sId, { name: a.name, settings: a.settings }])
-  );
-}
-
-async function fetchUserEmails(
-  userIds: string[]
-): Promise<Map<string, string>> {
-  if (userIds.length === 0) {
-    return new Map();
-  }
-
-  const users = await UserResource.fetchByIds(userIds);
-  return new Map(users.map((u) => [u.sId, u.email]));
 }
 
 export async function fetchMessageExportRows({

--- a/front/pages/api/v1/w/[wId]/analytics/export.test.ts
+++ b/front/pages/api/v1/w/[wId]/analytics/export.test.ts
@@ -107,7 +107,6 @@ vi.mock("@app/lib/api/analytics/feedback_export", async () => ({
     "createdAt",
     "assistantId",
     "assistantName",
-    "conversationId",
     "conversationUrl",
     "userId",
     "userEmail",
@@ -123,7 +122,6 @@ vi.mock("@app/lib/api/analytics/feedback_export", async () => ({
           createdAt: "2024-06-01 10:00:00",
           assistantId: "agent-1",
           assistantName: "TestAgent",
-          conversationId: "conv-1",
           conversationUrl: "https://dust.tt/w/ws-1/conversation/conv-1",
           userId: "user-1",
           userEmail: "alice@example.com",
@@ -361,7 +359,7 @@ describe("GET /api/v1/w/[wId]/analytics/export", () => {
     expect(res._getStatusCode()).toBe(200);
     const csv = res._getData();
     expect(csv).toContain(
-      "feedbackId,createdAt,assistantId,assistantName,conversationId,conversationUrl,userId,userEmail,thumb,content,dismissed"
+      "feedbackId,createdAt,assistantId,assistantName,conversationUrl,userId,userEmail,thumb,content,dismissed"
     );
     expect(csv).toContain("great answer");
     expect(csv).toContain("alice@example.com");
@@ -382,7 +380,6 @@ describe("GET /api/v1/w/[wId]/analytics/export", () => {
       createdAt: "2024-06-01 10:00:00",
       assistantId: "agent-1",
       assistantName: "TestAgent",
-      conversationId: "conv-1",
       conversationUrl: "https://dust.tt/w/ws-1/conversation/conv-1",
       userId: "user-1",
       userEmail: "alice@example.com",

--- a/front/pages/api/v1/w/[wId]/analytics/export.test.ts
+++ b/front/pages/api/v1/w/[wId]/analytics/export.test.ts
@@ -101,6 +101,40 @@ vi.mock("@app/lib/api/analytics/messages_export", async () => ({
   ),
 }));
 
+vi.mock("@app/lib/api/analytics/feedback_export", async () => ({
+  FEEDBACK_EXPORT_HEADERS: [
+    "feedbackId",
+    "createdAt",
+    "assistantId",
+    "assistantName",
+    "conversationId",
+    "conversationUrl",
+    "userId",
+    "userEmail",
+    "thumb",
+    "content",
+    "dismissed",
+  ],
+  fetchFeedbackExportRows: vi.fn(
+    async () =>
+      new Ok([
+        {
+          feedbackId: "42",
+          createdAt: "2024-06-01 10:00:00",
+          assistantId: "agent-1",
+          assistantName: "TestAgent",
+          conversationId: "conv-1",
+          conversationUrl: "https://dust.tt/w/ws-1/conversation/conv-1",
+          userId: "user-1",
+          userEmail: "alice@example.com",
+          thumb: "up",
+          content: "great answer",
+          dismissed: "false",
+        },
+      ])
+  ),
+}));
+
 describe(
   "public api authentication tests",
   createPublicApiAuthenticationTests(handler)
@@ -317,6 +351,45 @@ describe("GET /api/v1/w/[wId]/analytics/export", () => {
     );
     expect(csv).toContain("msg-1");
     expect(csv).toContain("alice@example.com");
+  });
+
+  it("returns CSV for feedback table", async () => {
+    const { req, res } = await setupTest({ table: "feedback" });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const csv = res._getData();
+    expect(csv).toContain(
+      "feedbackId,createdAt,assistantId,assistantName,conversationId,conversationUrl,userId,userEmail,thumb,content,dismissed"
+    );
+    expect(csv).toContain("great answer");
+    expect(csv).toContain("alice@example.com");
+  });
+
+  it("returns typed JSON for feedback", async () => {
+    const { req, res } = await setupTest({
+      table: "feedback",
+      format: "json",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data[0]).toEqual({
+      feedbackId: "42",
+      createdAt: "2024-06-01 10:00:00",
+      assistantId: "agent-1",
+      assistantName: "TestAgent",
+      conversationId: "conv-1",
+      conversationUrl: "https://dust.tt/w/ws-1/conversation/conv-1",
+      userId: "user-1",
+      userEmail: "alice@example.com",
+      thumb: "up",
+      content: "great answer",
+      dismissed: "false",
+    });
   });
 
   it("returns typed JSON when format=json for usage_metrics", async () => {

--- a/front/pages/api/v1/w/[wId]/analytics/export.ts
+++ b/front/pages/api/v1/w/[wId]/analytics/export.ts
@@ -29,9 +29,10 @@
  *           - "skill_usage": Skill executions and unique users over time.
  *           - "tool_usage": Tool executions and unique users over time.
  *           - "messages": Detailed message-level logs.
+ *           - "feedback": Detailed message-level feedback (thumbs, content, conversation URL).
  *         schema:
  *           type: string
- *           enum: [usage_metrics, active_users, source, agents, users, skill_usage, tool_usage, messages]
+ *           enum: [usage_metrics, active_users, source, agents, users, skill_usage, tool_usage, messages, feedback]
  *       - in: query
  *         name: startDate
  *         required: true

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -258,7 +258,7 @@
             "in": "query",
             "name": "table",
             "required": true,
-            "description": "The analytics table to export:\n- \"usage_metrics\": Messages, conversations, and active users over time.\n- \"active_users\": Daily, weekly, and monthly active user counts.\n- \"source\": Message volume by context origin (web, slack, etc.).\n- \"agents\": Top agents by message count.\n- \"users\": Top users by message count.\n- \"skill_usage\": Skill executions and unique users over time.\n- \"tool_usage\": Tool executions and unique users over time.\n- \"messages\": Detailed message-level logs.\n",
+            "description": "The analytics table to export:\n- \"usage_metrics\": Messages, conversations, and active users over time.\n- \"active_users\": Daily, weekly, and monthly active user counts.\n- \"source\": Message volume by context origin (web, slack, etc.).\n- \"agents\": Top agents by message count.\n- \"users\": Top users by message count.\n- \"skill_usage\": Skill executions and unique users over time.\n- \"tool_usage\": Tool executions and unique users over time.\n- \"messages\": Detailed message-level logs.\n- \"feedback\": Detailed message-level feedback (thumbs, content, conversation URL).\n",
             "schema": {
               "type": "string",
               "enum": [
@@ -269,7 +269,8 @@
                 "users",
                 "skill_usage",
                 "tool_usage",
-                "messages"
+                "messages",
+                "feedback"
               ]
             }
           },

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2977,6 +2977,7 @@ const AnalyticsExportTableSchema = z.enum([
   "skill_usage",
   "tool_usage",
   "messages",
+  "feedback",
 ]);
 
 const AnalyticsDateSchema = z


### PR DESCRIPTION
## Description

We are migrating off the deprecated `/workspace-usage` endpoint (EOL 2026-06-01) and hit a gap: the new `/analytics/export` endpoint exposed every usage table except feedback, which powers their AI adoption-quality dashboards. The per-conversation feedback endpoint is impractical at ~30k conversations/month.

This adds `feedback` as a `table` value on `GET /api/v1/w/{wId}/analytics/export`. The feedback rows (thumbs/metadata, conversation, agent) come from the Elasticsearch analytics index like the other tables; the free-text **content** is read from the DB at export time, keyed by the feedback ModelId. Columns: `feedbackId, createdAt, assistantId, assistantName, conversationId, conversationUrl, userId, userEmail, thumb, content, dismissed`. IDs are exposed as opaque `sId`s; `conversationUrl` is populated only when the conversation was shared.

Notable details:
- **Content is fetched from Postgres, not ES.** Free-text feedback content has no place in the analytics index (the reserved mapping field is `text, index: false` — pure `_source` weight, zero query value). The export already enriches ES rows with DB lookups (agent name, user email); content is the same pattern — a single batched, workspace-scoped read-replica query keyed by feedback id. This means no ES ingest change, no mapping dependency, no historical backfill, and content is always consistent with the DB.
- Filtering uses the feedback's own `created_at` (which can differ from the message timestamp) via a nested ES range query, matching the legacy endpoint's semantics.
- Shared agent/user enrichment helpers were factored out of `messages_export` into a neutral `enrichment.ts` module so `feedback_export` can reuse them without a peer dependency; `fetchFeedbackContents` lives there too.

Purely additive to the public API (new accepted enum value) — non-breaking. Swagger annotations (both Next + Hono handlers) and `public/swagger.json` updated; `@dust-tt/client` schema enum extended.

This addresses ask #1 only. Asks #2 (`editionsCount`/`builders` table) and #3 (ID INTEGER→STRING changelog) are out of scope here.

## Tests

- Added `feedback` CSV + JSON cases to both the Next and Hono export test suites; full suites pass (34 + 27).
- Type-check (`tsgo`) and biome lint clean across `front`, `front-api`, and `sdks/js`.

## Risk

- Low. The API change is append-only (new enum value), so existing callers are unaffected.
- No data-layer side effects: ES indexing is unchanged, and content is read live from the DB read replica. Nothing to backfill, nothing to coordinate post-deploy.
- Easy to roll back: revert the commit. No persistent state is written.

## Deploy Plan

1. Deploy `front` + `front-api` (new `feedback` table on the export endpoint).
2. Publish the updated `@dust-tt/client` so external consumers see the `feedback` enum value (optional for server behavior).
