### PR TITLE
[front] feat: add tools to create and edit skills

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -571,6 +571,11 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   "skill_management": {
     "enable_skill": "never_ask",
   },
+  "skills": {
+    "create_skill": "medium",
+    "edit_skill": "medium",
+    "upload_skill_files": "medium",
+  },
   "slab": {
     "get_post_contents": "never_ask",
     "get_post_metadata": "never_ask",

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -68,6 +68,7 @@ import { SANDBOX_SERVER } from "@app/lib/api/actions/servers/sandbox/metadata";
 import { SCHEDULES_MANAGEMENT_SERVER } from "@app/lib/api/actions/servers/schedules_management/metadata";
 import { SEARCH_SERVER } from "@app/lib/api/actions/servers/search/metadata";
 import { SKILL_MANAGEMENT_SERVER } from "@app/lib/api/actions/servers/skill_management/metadata";
+import { SKILLS_SERVER } from "@app/lib/api/actions/servers/skills/metadata";
 import { SLAB_SERVER } from "@app/lib/api/actions/servers/slab/metadata";
 import { SLACK_BOT_SERVER } from "@app/lib/api/actions/servers/slack_bot/metadata";
 import { SLACK_PERSONAL_SERVER } from "@app/lib/api/actions/servers/slack_personal/metadata";
@@ -206,6 +207,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "zendesk",
   SEARCH_SERVER_NAME,
   TABLE_QUERY_V2_SERVER_NAME,
+  "skills",
   "skill_management",
   "schedules_management",
   "pod_manager",
@@ -1135,6 +1137,18 @@ export const INTERNAL_MCP_SERVERS = {
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     metadata: FILES_SERVER,
+  },
+  skills: {
+    id: 1034,
+    availability: "auto_hidden_builder",
+    allowMultipleInstances: false,
+    isRestricted: ({ featureFlags }) =>
+      !featureFlags.includes("skill_edition_tools"),
+    isPreview: false,
+    tools_arguments_requiring_approval: undefined,
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    metadata: SKILLS_SERVER,
   },
   // Using satisfies here instead of: type to avoid TypeScript widening the type and breaking the type inference for AutoInternalMCPServerNameType.
 } satisfies {

--- a/front/lib/actions/mcp_internal_actions/internal_mcp_server_availability.snapshot.json
+++ b/front/lib/actions/mcp_internal_actions/internal_mcp_server_availability.snapshot.json
@@ -32,7 +32,8 @@
     { "name": "pod_tasks", "id": 1029 },
     { "name": "wakeups", "id": 1031 },
     { "name": "plan_mode", "id": 1032 },
-    { "name": "files", "id": 1033 }
+    { "name": "files", "id": 1033 },
+    { "name": "skills", "id": 1034 }
   ],
   "manual": [
     { "name": "github", "id": 1 },

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -63,6 +63,7 @@ import { default as sandboxServer } from "@app/lib/api/actions/servers/sandbox";
 import { default as schedulesManagementServer } from "@app/lib/api/actions/servers/schedules_management";
 import { default as searchServer } from "@app/lib/api/actions/servers/search";
 import { default as skillManagementServer } from "@app/lib/api/actions/servers/skill_management";
+import { default as skillsServer } from "@app/lib/api/actions/servers/skills";
 import { default as slabServer } from "@app/lib/api/actions/servers/slab";
 import { default as slackBotServer } from "@app/lib/api/actions/servers/slack_bot";
 import { default as slackServer } from "@app/lib/api/actions/servers/slack_personal";
@@ -246,6 +247,8 @@ export async function getInternalMCPServer(
       return zendeskServer(auth, agentLoopContext);
     case "skill_management":
       return skillManagementServer(auth, agentLoopContext);
+    case "skills":
+      return skillsServer(auth, agentLoopContext);
     case "schedules_management":
       return schedulesManagementServer(auth, agentLoopContext);
     case "productboard":

--- a/front/lib/api/actions/servers/skills/index.ts
+++ b/front/lib/api/actions/servers/skills/index.ts
@@ -1,0 +1,23 @@
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { TOOLS } from "@app/lib/api/actions/servers/skills/tools";
+import type { Authenticator } from "@app/lib/auth";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
+  const server = makeInternalMCPServer("skills");
+
+  for (const tool of TOOLS) {
+    registerTool(auth, agentLoopContext, server, tool, {
+      monitoringName: "skills",
+    });
+  }
+
+  return server;
+}
+
+export default createServer;

--- a/front/lib/api/actions/servers/skills/metadata.ts
+++ b/front/lib/api/actions/servers/skills/metadata.ts
@@ -1,0 +1,118 @@
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+const SkillAttachmentSchema = z.object({
+  path: z
+    .string()
+    .min(1)
+    .describe(
+      "Source file path to attach. Use a scoped path returned by files__list, such as conversation-<id>/script.py, or the matching sandbox path under /files/."
+    ),
+  fileName: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      "Optional destination file name/path inside the skill, such as scripts/process.py. Defaults to the source file name."
+    ),
+});
+
+export const SKILLS_TOOLS_METADATA = createToolsRecord({
+  create_skill: {
+    description:
+      "Create a new workspace skill from a description and concise instructions.",
+    schema: {
+      name: z.string().describe("The new skill name."),
+      description: z
+        .string()
+        .describe(
+          "Short description of what the skill does and when an agent should use it."
+        ),
+      instructions: z
+        .string()
+        .describe("Markdown instructions that define the skill behavior."),
+    },
+    stake: "medium",
+    displayLabels: {
+      running: "Creating skill",
+      done: "Create skill",
+    },
+  },
+  edit_skill: {
+    description:
+      "Edit an existing workspace skill's instructions by replacing exact text. This avoids full-instruction rewrites.",
+    schema: {
+      skillName: z.string().min(1).describe("The exact skill name."),
+      oldString: z
+        .string()
+        .min(1)
+        .describe(
+          "The exact instruction text to replace. Must match the current instructions exactly, including whitespace."
+        ),
+      newString: z
+        .string()
+        .describe(
+          "The exact replacement text to put in the skill instructions."
+        ),
+      expectedReplacements: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe(
+          "Optional number of expected replacements. Defaults to 1. Use when replacing multiple identical instances."
+        ),
+    },
+    stake: "medium",
+    displayLabels: {
+      running: "Editing skill",
+      done: "Edit skill",
+    },
+  },
+  upload_skill_files: {
+    description:
+      "Upload files from source paths and attach them to an existing workspace skill. Use for scripts, references, templates, or assets.",
+    schema: {
+      skillName: z.string().min(1).describe("The exact skill name."),
+      files: z
+        .array(SkillAttachmentSchema)
+        .min(1)
+        .describe("Source files to upload and attach to the skill."),
+      replaceExistingFiles: z
+        .boolean()
+        .optional()
+        .describe(
+          "When files are supplied, replace existing file attachments instead of appending. Defaults to false."
+        ),
+    },
+    stake: "medium",
+    displayLabels: {
+      running: "Uploading skill files",
+      done: "Upload skill files",
+    },
+  },
+});
+
+export const SKILLS_SERVER = {
+  serverInfo: {
+    name: "skills",
+    version: "1.0.0",
+    description: "Tools for creating and editing workspace skills.",
+    authorization: null,
+    icon: "PuzzleIcon",
+    documentationUrl: null,
+    instructions: null,
+  },
+  tools: Object.values(SKILLS_TOOLS_METADATA).map((t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
+  })),
+  tools_stakes: Object.fromEntries(
+    Object.values(SKILLS_TOOLS_METADATA).map((t) => [t.name, t.stake])
+  ),
+} as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/skills/tools/index.ts
+++ b/front/lib/api/actions/servers/skills/tools/index.ts
@@ -1,0 +1,498 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { SKILLS_TOOLS_METADATA } from "@app/lib/api/actions/servers/skills/metadata";
+import { DustFileSystem } from "@app/lib/api/file_system";
+import { uploadBase64DataToFileStorage } from "@app/lib/api/files/upload";
+import { getUpdatedContentAndOccurrences } from "@app/lib/api/files/utils";
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import { convertMarkdownToBlockHtml } from "@app/lib/reinforcement/skill_instructions_html";
+import { pruneOutdatedSkillEditSuggestions } from "@app/lib/reinforcement/skill_suggestion_pruning";
+import type { FileResource } from "@app/lib/resources/file_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { streamToBuffer } from "@app/lib/utils/streams";
+import {
+  contentTypeFromFileName,
+  DEFAULT_FILE_CONTENT_TYPE,
+  isSupportedFileContentType,
+  type SupportedFileContentType,
+  stripMimeParameters,
+} from "@app/types/files";
+import type { ModelId } from "@app/types/shared/model_id";
+import { Err, Ok, type Result } from "@app/types/shared/result";
+import * as path from "path";
+
+const DEFAULT_SKILL_ICON = "ActionListIcon";
+
+type SkillFileInput = {
+  path: string;
+  fileName?: string;
+};
+
+function resolveContentType({
+  sourcePath,
+  targetFileName,
+  statContentType,
+}: {
+  sourcePath: string;
+  targetFileName: string;
+  statContentType: string;
+}): SupportedFileContentType {
+  const strippedStatContentType = stripMimeParameters(statContentType);
+
+  return (
+    contentTypeFromFileName(targetFileName) ??
+    contentTypeFromFileName(sourcePath) ??
+    (isSupportedFileContentType(strippedStatContentType)
+      ? strippedStatContentType
+      : DEFAULT_FILE_CONTENT_TYPE)
+  );
+}
+
+function sourcePathFromSandboxPath({
+  dustFs,
+  sourcePath,
+}: {
+  dustFs: DustFileSystem;
+  sourcePath: string;
+}): string | null {
+  for (const mount of dustFs.getMounts()) {
+    const sandboxMountPoints = [
+      mount.sandboxMountPoint,
+      mount.legacySandboxMountPoint,
+    ];
+
+    for (const sandboxMountPoint of sandboxMountPoints) {
+      if (!sandboxMountPoint) {
+        continue;
+      }
+
+      if (sourcePath === sandboxMountPoint) {
+        return mount.scopedPrefix;
+      }
+
+      const prefix = `${sandboxMountPoint}/`;
+      if (sourcePath.startsWith(prefix)) {
+        return `${mount.scopedPrefix}/${sourcePath.slice(prefix.length)}`;
+      }
+    }
+  }
+
+  return null;
+}
+
+function resolveSourcePath(
+  dustFs: DustFileSystem,
+  sourcePath: string
+): Result<string, MCPError> {
+  const trimmedSourcePath = sourcePath.trim();
+  if (!trimmedSourcePath) {
+    return new Err(
+      new MCPError("Source file path cannot be empty.", { tracked: false })
+    );
+  }
+
+  const scopedPath =
+    sourcePathFromSandboxPath({ dustFs, sourcePath: trimmedSourcePath }) ??
+    trimmedSourcePath;
+
+  const normalized = DustFileSystem.normalizeScopedPath(scopedPath);
+  if (!normalized) {
+    return new Err(
+      new MCPError(
+        `Invalid file path: ${sourcePath}. Use a scoped file path from files__list or a sandbox path under /files/.`,
+        { tracked: false }
+      )
+    );
+  }
+
+  return new Ok(normalized);
+}
+
+function resolveTargetFileName({
+  sourcePath,
+  targetFileName,
+}: {
+  sourcePath: string;
+  targetFileName?: string;
+}): Result<string, MCPError> {
+  const fileName = (targetFileName ?? path.posix.basename(sourcePath)).trim();
+  const segments = fileName.split("/");
+
+  if (
+    !fileName ||
+    fileName.startsWith("/") ||
+    fileName.includes("\\") ||
+    fileName.includes("\0") ||
+    fileName.includes("\n") ||
+    fileName.includes("\r") ||
+    segments.some((segment) => !segment || segment === "." || segment === "..")
+  ) {
+    return new Err(
+      new MCPError(
+        `Invalid skill attachment file name: ${targetFileName ?? fileName}. Use a relative file path such as scripts/process.py.`,
+        { tracked: false }
+      )
+    );
+  }
+
+  return new Ok(fileName);
+}
+
+async function uploadSkillFiles(
+  auth: Authenticator,
+  { dustFs, files }: { dustFs: DustFileSystem; files: SkillFileInput[] }
+): Promise<Result<FileResource[], MCPError>> {
+  const uploadedFiles: FileResource[] = [];
+
+  for (const file of files) {
+    const sourcePathRes = resolveSourcePath(dustFs, file.path);
+    if (sourcePathRes.isErr()) {
+      return sourcePathRes;
+    }
+    const sourcePath = sourcePathRes.value;
+
+    const targetFileNameRes = resolveTargetFileName({
+      sourcePath,
+      targetFileName: file.fileName,
+    });
+    if (targetFileNameRes.isErr()) {
+      return targetFileNameRes;
+    }
+    const targetFileName = targetFileNameRes.value;
+
+    const statResult = await dustFs.stat(sourcePath);
+    if (statResult.isErr()) {
+      return new Err(
+        new MCPError(
+          `Failed to read ${sourcePath}: ${statResult.error.message}`
+        )
+      );
+    }
+    if (!statResult.value) {
+      return new Err(
+        new MCPError(`File not found: ${sourcePath}.`, { tracked: false })
+      );
+    }
+
+    const contentType = resolveContentType({
+      sourcePath,
+      targetFileName,
+      statContentType: statResult.value.contentType,
+    });
+
+    const readResult = await dustFs.read(sourcePath);
+    if (readResult.isErr()) {
+      return new Err(
+        new MCPError(
+          `Failed to read ${sourcePath}: ${readResult.error.message}`
+        )
+      );
+    }
+    if (!readResult.value) {
+      return new Err(
+        new MCPError(`File not found: ${sourcePath}.`, { tracked: false })
+      );
+    }
+
+    const bufferResult = await streamToBuffer(readResult.value);
+    if (bufferResult.isErr()) {
+      return new Err(new MCPError(bufferResult.error));
+    }
+
+    const uploadResult = await uploadBase64DataToFileStorage(auth, {
+      base64: bufferResult.value.toString("base64"),
+      contentType,
+      fileName: targetFileName,
+      useCase: "skill_attachment",
+    });
+
+    if (uploadResult.isErr()) {
+      return new Err(
+        new MCPError(
+          `Failed to upload ${targetFileName}: ${uploadResult.error.message}`
+        )
+      );
+    }
+
+    uploadedFiles.push(uploadResult.value);
+  }
+
+  return new Ok(uploadedFiles);
+}
+
+function validateSkillReferences(
+  auth: Authenticator,
+  {
+    enabled,
+    instructions,
+    parentSkillModelId,
+  }: {
+    enabled: boolean;
+    instructions: string;
+    parentSkillModelId?: ModelId;
+  }
+): Result<undefined, MCPError> {
+  if (!enabled) {
+    return new Ok(undefined);
+  }
+
+  const validation = SkillResource.getValidatedSkillReferenceModelIds(auth, {
+    instructions,
+    parentSkillId: parentSkillModelId,
+  });
+  if (validation.isErr()) {
+    return new Err(new MCPError(validation.error.message, { tracked: false }));
+  }
+
+  return new Ok(undefined);
+}
+
+const handlers: ToolHandlers<typeof SKILLS_TOOLS_METADATA> = {
+  create_skill: async ({ name, description, instructions }, { auth }) => {
+    if (!auth.isBuilder()) {
+      return new Err(
+        new MCPError("Only builders can create skills.", { tracked: false })
+      );
+    }
+    const user = auth.user();
+    if (!user) {
+      return new Err(
+        new MCPError("User must be authenticated.", { tracked: false })
+      );
+    }
+
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      return new Err(
+        new MCPError("Skill name cannot be empty.", { tracked: false })
+      );
+    }
+    if (!instructions.trim()) {
+      return new Err(
+        new MCPError("Skill instructions cannot be empty.", {
+          tracked: false,
+        })
+      );
+    }
+
+    const existingSkill = await SkillResource.fetchActiveByName(
+      auth,
+      trimmedName
+    );
+    if (existingSkill) {
+      return new Err(
+        new MCPError(`A skill with the name "${trimmedName}" already exists.`, {
+          tracked: false,
+        })
+      );
+    }
+
+    const featureFlags = await getFeatureFlags(auth);
+    const enableSkillReferences = featureFlags.includes("nested_skills");
+    const skillReferenceValidation = validateSkillReferences(auth, {
+      enabled: enableSkillReferences,
+      instructions,
+    });
+    if (skillReferenceValidation.isErr()) {
+      return skillReferenceValidation;
+    }
+
+    const skillResource = await SkillResource.makeNew(
+      auth,
+      {
+        status: "active",
+        name: trimmedName,
+        agentFacingDescription: description,
+        userFacingDescription: description,
+        instructions,
+        instructionsHtml: convertMarkdownToBlockHtml(instructions),
+        editedBy: user.id,
+        requestedSpaceIds: [],
+        extendedSkillId: null,
+        icon: DEFAULT_SKILL_ICON,
+        source: "api",
+        sourceMetadata: null,
+        isDefault: false,
+        reinforcement: "on",
+      },
+      {
+        mcpServerViews: [],
+        fileAttachments: [],
+        enableSkillReferences,
+      }
+    );
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: `Created skill "${skillResource.name}".`,
+      },
+    ]);
+  },
+
+  edit_skill: async (
+    { skillName, oldString, newString, expectedReplacements = 1 },
+    { auth }
+  ) => {
+    const skillResource = await SkillResource.fetchActiveByName(
+      auth,
+      skillName.trim()
+    );
+    if (!skillResource) {
+      return new Err(
+        new MCPError(`Skill "${skillName}" not found.`, { tracked: false })
+      );
+    }
+    if (!skillResource.canWrite(auth)) {
+      return new Err(
+        new MCPError("Only editors can modify this skill.", {
+          tracked: false,
+        })
+      );
+    }
+
+    const { updatedContent: instructions, occurrences } =
+      getUpdatedContentAndOccurrences({
+        oldString,
+        newString,
+        currentContent: skillResource.instructions,
+      });
+
+    if (occurrences === 0) {
+      return new Err(
+        new MCPError(`String not found in skill "${skillResource.name}".`, {
+          tracked: false,
+        })
+      );
+    }
+
+    if (occurrences !== expectedReplacements) {
+      return new Err(
+        new MCPError(
+          `Expected ${expectedReplacements} replacements, but found ${occurrences}.`,
+          { tracked: false }
+        )
+      );
+    }
+
+    if (!instructions.trim()) {
+      return new Err(
+        new MCPError("Skill instructions cannot be empty.", {
+          tracked: false,
+        })
+      );
+    }
+
+    const featureFlags = await getFeatureFlags(auth);
+    const enableSkillReferences = featureFlags.includes("nested_skills");
+    const skillReferenceValidation = validateSkillReferences(auth, {
+      enabled: enableSkillReferences,
+      instructions,
+      parentSkillModelId: skillResource.id,
+    });
+    if (skillReferenceValidation.isErr()) {
+      return skillReferenceValidation;
+    }
+
+    const attachedKnowledge = await skillResource.getAttachedKnowledge(auth);
+    await skillResource.updateSkill(auth, {
+      name: skillResource.name,
+      agentFacingDescription: skillResource.agentFacingDescription,
+      userFacingDescription: skillResource.userFacingDescription,
+      instructions,
+      instructionsHtml: convertMarkdownToBlockHtml(instructions),
+      icon: skillResource.icon,
+      mcpServerViews: skillResource.mcpServerViews,
+      attachedKnowledge,
+      requestedSpaceIds: skillResource.requestedSpaceIds,
+      enableSkillReferences,
+    });
+
+    await pruneOutdatedSkillEditSuggestions(auth, skillResource);
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: `Updated instructions for skill "${skillResource.name}" with ${occurrences} replacement${
+          occurrences === 1 ? "" : "s"
+        }.`,
+      },
+    ]);
+  },
+
+  upload_skill_files: async (
+    { skillName, files, replaceExistingFiles },
+    { auth, agentLoopContext }
+  ) => {
+    const skillResource = await SkillResource.fetchActiveByName(
+      auth,
+      skillName.trim()
+    );
+    if (!skillResource) {
+      return new Err(
+        new MCPError(`Skill "${skillName}" not found.`, { tracked: false })
+      );
+    }
+    if (!skillResource.canWrite(auth)) {
+      return new Err(
+        new MCPError("Only editors can modify this skill.", {
+          tracked: false,
+        })
+      );
+    }
+
+    const featureFlags = await getFeatureFlags(auth);
+    if (!featureFlags.includes("sandbox_tools")) {
+      return new Err(
+        new MCPError("File attachments are not supported.", { tracked: false })
+      );
+    }
+
+    const conversation = agentLoopContext?.runContext?.conversation;
+    if (!conversation) {
+      return new Err(
+        new MCPError("No conversation context available.", { tracked: false })
+      );
+    }
+
+    const dustFsResult = await DustFileSystem.forConversation(
+      auth,
+      conversation
+    );
+    if (dustFsResult.isErr()) {
+      return new Err(
+        new MCPError(dustFsResult.error.message, { tracked: false })
+      );
+    }
+
+    const uploadedFilesRes = await uploadSkillFiles(auth, {
+      dustFs: dustFsResult.value,
+      files,
+    });
+    if (uploadedFilesRes.isErr()) {
+      return uploadedFilesRes;
+    }
+
+    await skillResource.updateFileAttachments(
+      auth,
+      replaceExistingFiles
+        ? uploadedFilesRes.value
+        : [...skillResource.getFileAttachments(), ...uploadedFilesRes.value]
+    );
+
+    await pruneOutdatedSkillEditSuggestions(auth, skillResource);
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: `Uploaded ${uploadedFilesRes.value.length} file${
+          uploadedFilesRes.value.length === 1 ? "" : "s"
+        } to skill "${skillResource.name}".`,
+      },
+    ]);
+  },
+};
+
+export const TOOLS = buildTools(SKILLS_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/skills/tools/index.ts
+++ b/front/lib/api/actions/servers/skills/tools/index.ts
@@ -21,6 +21,7 @@ import {
 } from "@app/types/files";
 import type { ModelId } from "@app/types/shared/model_id";
 import { Err, Ok, type Result } from "@app/types/shared/result";
+import { pluralize } from "@app/types/shared/utils/string_utils";
 import * as path from "path";
 
 const DEFAULT_SKILL_ICON = "ActionListIcon";
@@ -487,9 +488,9 @@ const handlers: ToolHandlers<typeof SKILLS_TOOLS_METADATA> = {
     return new Ok([
       {
         type: "text" as const,
-        text: `Uploaded ${uploadedFilesRes.value.length} file${
-          uploadedFilesRes.value.length === 1 ? "" : "s"
-        } to skill "${skillResource.name}".`,
+        text: `Uploaded ${uploadedFilesRes.value.length} file${pluralize(
+          uploadedFilesRes.value.length
+        )} to skill "${skillResource.name}".`,
       },
     ]);
   },

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -79,6 +79,7 @@ const TOOL_CATEGORY_MAP: Record<InternalMCPServerNameType, ToolCategory> = {
   missing_action_catcher: "basic",
   primitive_types_debugger: "basic",
   jit_testing: "basic",
+  skills: "basic",
   skill_management: "basic",
   schedules_management: "basic",
   pod_manager: "basic",

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -10,6 +10,7 @@ import { serializeSkillTag } from "@app/lib/skills/format";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
@@ -696,6 +697,60 @@ describe("SkillResource", () => {
       ).rejects.toThrow(
         `Skill reference ID does not belong to this workspace: ${outOfWorkspaceSkillId}`
       );
+    });
+  });
+
+  describe("updateFileAttachments", () => {
+    it("saves a version and replaces file attachments", async () => {
+      const skill = await SkillFactory.create(testContext.authenticator, {
+        name: "Skill With File Attachments",
+      });
+      const firstFile = await FileFactory.create(
+        testContext.authenticator,
+        testContext.user,
+        {
+          contentType: "text/plain",
+          fileName: "first.txt",
+          fileSize: 100,
+          status: "ready",
+          useCase: "skill_attachment",
+        }
+      );
+      const secondFile = await FileFactory.create(
+        testContext.authenticator,
+        testContext.user,
+        {
+          contentType: "text/plain",
+          fileName: "second.txt",
+          fileSize: 100,
+          status: "ready",
+          useCase: "skill_attachment",
+        }
+      );
+
+      await skill.updateFileAttachments(testContext.authenticator, [firstFile]);
+      await skill.updateFileAttachments(testContext.authenticator, [
+        secondFile,
+      ]);
+
+      expect(skill.getFileAttachments().map((file) => file.id)).toEqual([
+        secondFile.id,
+      ]);
+
+      const freshSkill = await SkillResource.fetchByModelIdWithAuth(
+        testContext.authenticator,
+        skill.id
+      );
+      expect(freshSkill?.getFileAttachments().map((file) => file.id)).toEqual([
+        secondFile.id,
+      ]);
+
+      const versions = await skill.listVersions(testContext.authenticator);
+      expect(
+        versions.map((version) =>
+          version.getFileAttachments().map((file) => file.id)
+        )
+      ).toEqual([[firstFile.id], []]);
     });
   });
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2252,6 +2252,33 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     await this.update({ reinforcement });
   }
 
+  async updateFileAttachments(
+    auth: Authenticator,
+    fileAttachments: FileResource[]
+  ): Promise<void> {
+    assert(
+      this.canWrite(auth),
+      "User is not authorized to update this skill's file attachments"
+    );
+
+    await withTransaction(async (transaction) => {
+      await this.saveVersion(auth, { transaction });
+
+      const editedBy = auth.user()?.id;
+      if (editedBy) {
+        await this.update({ editedBy }, transaction);
+      }
+
+      await this.setFileAttachments(auth, fileAttachments, { transaction });
+    });
+
+    await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
+      skillId: this.sId,
+    });
+
+    await this.upsertCurrentUserAsEditor(auth);
+  }
+
   async updateSelfImprovementLock(selfImprovementLock: boolean): Promise<void> {
     await this.update({ selfImprovementLock });
   }
@@ -2591,7 +2618,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   private async setFileAttachments(
     auth: Authenticator,
-    fileAttachments: FileResource[]
+    fileAttachments: FileResource[],
+    { transaction }: { transaction?: Transaction } = {}
   ): Promise<void> {
     const workspace = auth.getNonNullableWorkspace();
 
@@ -2600,6 +2628,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         skillConfigurationId: this.id,
         workspaceId: workspace.id,
       },
+      transaction,
     });
 
     const desiredFileModelIds = new Set(fileAttachments.map((f) => f.id));
@@ -2617,6 +2646,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           id: { [Op.in]: toRemove.map((a) => a.id) },
           workspaceId: workspace.id,
         },
+        transaction,
       });
     }
 
@@ -2631,7 +2661,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           skillConfigurationId: this.id,
           fileId: file.id,
           fileName: file.fileName,
-        }))
+        })),
+        { transaction }
       );
     }
 

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -169,6 +169,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Enable nested skills",
     stage: "dust_only",
   },
+  skill_edition_tools: {
+    description: "Enable tools for creating and editing workspace skills",
+    stage: "dust_only",
+  },
   power_bi_mcp: {
     description: "Power BI MCP tool for querying semantic models and DAX",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -745,6 +745,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "slack_enhanced_default_agent"
   | "slack_message_splitting"
   | "slideshow"
+  | "skill_edition_tools"
   | "skills_as_user_messages"
   | "run_tools_from_prompt"
   | "usage_data_api"


### PR DESCRIPTION
## Description

This PR adds a `skills` internal MCP server behind the `skill_edition_tools` feature flag. It exposes focused tools for creating workspace skills, editing instructions with exact text replacement, and attaching skill files from source file paths instead of asking the model to inline file contents.

It also adds `SkillResource.updateFileAttachments` so file attachment updates save a skill version and stamp file metadata through a resource-level path.

The `Manage Skills` global skill is intentionally split into follow-up PR #26625.

## Tests

- Added tests for skill file attachment updates.
- Updated MCP server metadata and availability tests.

## Risk

- Low. Behind feature flag.

## Deploy Plan

- Deploy front.
