### PR TITLE
feat(feature-flags): add user_settings_v2 flag

### DIFF
--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -293,6 +293,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Unified GCS-backed file explorer with folder hierarchy, replacing the two-tab files panel.",
     stage: "dust_only",
   },
+  user_settings_v2: {
+    description: "Enable the new user settings v2 experience",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -760,6 +760,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "new_file_explorer"
   | "use_vertex_for_supported_models"
   | "metronome_billing_usage_page"
+  | "user_settings_v2"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

Adds a new `user_settings_v2` feature flag (`dust_only` stage) to gate the upcoming user settings v2 experience. Both the `front` feature flags config and the JS SDK's `WhitelistableFeaturesSchema` are updated so the flag is recognized across the stack.

## Tests

No automated tests needed — adding a flag entry requires no logic changes.

## Risk

Low. Adding a new entry to an additive enum/config; no existing behavior is affected.
