### PR TITLE
[front] feat: add method to serialize tag for global skills

### DIFF
--- a/front/lib/resources/skill/code_defined/global_registry.ts
+++ b/front/lib/resources/skill/code_defined/global_registry.ts
@@ -11,6 +11,7 @@ import {
 } from "@app/lib/resources/skill/code_defined/shared";
 import { xlsxSkill } from "@app/lib/resources/skill/code_defined/xlsx";
 import type { AllSkillConfigurationFindOptions } from "@app/lib/resources/skill/types";
+import { serializeSkillTag } from "@app/lib/skills/format";
 
 // Registry is a simple array.
 const GLOBAL_SKILLS_ARRAY = ensureUniqueSIds([
@@ -54,6 +55,19 @@ export class GlobalSkillsRegistry {
   ): Promise<GlobalSkillDefinition[]> {
     return filterSkillDefinitions(auth, GLOBAL_SKILLS_ARRAY, where, {
       isDefault: true,
+    });
+  }
+
+  static serializeSkillTag(sId: GlobalSkillId): string {
+    const skill = this.getByIdInternal(sId);
+    if (!skill) {
+      throw new Error(`Unknown global skill: ${sId}`);
+    }
+
+    return serializeSkillTag({
+      id: skill.sId,
+      icon: skill.icon,
+      name: skill.name,
     });
   }
 


### PR DESCRIPTION
## Description

- Adds a `GlobalSkillsRegistry.serializeSkillTag(...)` helper to generate inline `<skill ... />` tags for code-defined global skills.
- Reuses the existing skill-tag serializer so global skill references use the same `id`, `name`, and `icon` format as other inline skill references.
- Goal is to be able to nest global skills with `${GlobalSkillRegistry.serializeSkillTag("frames")}`.
- Does not cover `SkillInfoPage` and Manage Skills.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
