### PR TITLE
[front] fix: preserve dollar signs when renaming skill references

### DIFF
--- a/front/lib/skills/format.test.ts
+++ b/front/lib/skills/format.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { renameSkillReferencesInContent } from "./format";
+
+describe("renameSkillReferencesInContent", () => {
+  it("preserves dollar replacement tokens in renamed skill names", () => {
+    const content =
+      'before <skill id="ski_target" name="Old name" /> middle <skill id="ski_other" name="Other" /> after';
+    const newName = "Cost $1 $& $$ $` $'";
+
+    expect(
+      renameSkillReferencesInContent(content, {
+        skillId: "ski_target",
+        newName,
+      })
+    ).toEqual(
+      `before <skill id="ski_target" name="${newName}" /> middle <skill id="ski_other" name="Other" /> after`
+    );
+  });
+});

--- a/front/lib/skills/format.ts
+++ b/front/lib/skills/format.ts
@@ -101,7 +101,11 @@ export function renameSkillReferencesInContent(
     const id = tag.match(/\bid="([^"]+)"/)?.[1];
 
     if (id === skillId) {
-      return tag.replace(SKILL_NAME_ATTRIBUTE_REGEX, `$1${newName}$2`);
+      return tag.replace(
+        SKILL_NAME_ATTRIBUTE_REGEX,
+        (_match, prefix: string, suffix: string) =>
+          `${prefix}${newName}${suffix}`
+      );
     }
 
     return tag;


### PR DESCRIPTION
## Description

- This PR fixes skill reference renaming when the new skill name contains `$` replacement tokens. The rename path now inserts the new name literally instead of letting `String.replace` interpret values like `$1`, `$&`, or `$$`.
- Addresses a comment in a previous PR.

## Tests

- Added a regression test.

## Risk

- Low.

## Deploy Plan

- Deploy front.
