### PR TITLE
fix(dsbx): parse JSON object/array file contents for __file__: args

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.24"
+version = "0.1.25"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/src/commands/tools/exec.rs
+++ b/cli/dust-sandbox/src/commands/tools/exec.rs
@@ -81,11 +81,9 @@ pub async fn cmd_exec(
 /// Parse `--key value` pairs into a JSON object.
 /// Auto-detects numbers, booleans, JSON objects/arrays, and falls back to string.
 ///
-/// A value prefixed with `__file__:` is interpreted as a path reference:
-/// the file at that path is read (UTF-8, capped at 100 MB) and its contents
-/// are used as a string value for the key. This bypasses type coercion
-/// and lets agents pass values larger than the OS argv limit (ARG_MAX)
-/// by writing them to disk first.
+/// A value prefixed with `__file__:` reads the file at that path (UTF-8, capped
+/// at 100 MB), letting agents pass values larger than the OS argv limit
+/// (ARG_MAX). JSON object/array contents are parsed; other content is a string.
 fn parse_args(raw: &[String]) -> anyhow::Result<Option<serde_json::Value>> {
     if raw.is_empty() {
         return Ok(Some(serde_json::Value::Object(serde_json::Map::new())));
@@ -127,7 +125,16 @@ fn parse_args(raw: &[String]) -> anyhow::Result<Option<serde_json::Value>> {
 
 fn coerce_value_or_read_file(s: &str) -> anyhow::Result<serde_json::Value> {
     if let Some(path) = s.strip_prefix("__file__:") {
-        return Ok(serde_json::Value::String(read_file_arg(path)?));
+        let contents = read_file_arg(path)?;
+        // JSON object/array contents are parsed (like inline values); anything
+        // else is a string. Malformed JSON-shaped content errors rather than
+        // silently degrading, since the file isn't visible on the command line.
+        let trimmed = contents.trim();
+        if looks_like_json_object_or_array(trimmed) {
+            return serde_json::from_str::<serde_json::Value>(trimmed)
+                .with_context(|| format!("__file__:{path} looks like JSON but failed to parse"));
+        }
+        return Ok(serde_json::Value::String(contents));
     }
     Ok(coerce_value(s))
 }
@@ -165,14 +172,22 @@ fn coerce_value(s: &str) -> serde_json::Value {
             return serde_json::Value::Number(num);
         }
     }
-    // JSON object or array
-    if (s.starts_with('{') && s.ends_with('}')) || (s.starts_with('[') && s.ends_with(']')) {
-        if let Ok(v) = serde_json::from_str::<serde_json::Value>(s) {
+    // JSON object or array; shaped-but-invalid falls back to a string.
+    let trimmed = s.trim();
+    if looks_like_json_object_or_array(trimmed) {
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(trimmed) {
             return v;
         }
     }
     // Fallback: string
     serde_json::Value::String(s.to_string())
+}
+
+/// Shape check only (delimited by `{}`/`[]`); the content may still be invalid
+/// JSON. Expects an already-trimmed string.
+fn looks_like_json_object_or_array(trimmed: &str) -> bool {
+    (trimmed.starts_with('{') && trimmed.ends_with('}'))
+        || (trimmed.starts_with('[') && trimmed.ends_with(']'))
 }
 
 #[cfg(test)]
@@ -239,6 +254,16 @@ mod tests {
     }
 
     #[test]
+    fn parse_inline_malformed_json_falls_back_to_string() {
+        let args = vec!["--filter".to_string(), "[not valid json]".to_string()];
+        let result = parse_args(&args)
+            .expect("should parse")
+            .expect("should have value");
+        assert_eq!(result["filter"], "[not valid json]");
+        assert!(result["filter"].is_string());
+    }
+
+    #[test]
     fn parse_float_args() {
         let args = vec!["--ratio".to_string(), "3.125".to_string()];
         let result = parse_args(&args)
@@ -302,6 +327,72 @@ mod tests {
             .expect("should have value");
         assert_eq!(result["count"], "42");
         assert!(result["count"].is_string());
+    }
+
+    #[test]
+    fn parse_file_prefix_parses_json_array() {
+        let file = write_tempfile(br#"[{"path":"README.md","content":"hello"}]"#);
+        let args = vec![
+            "--files".to_string(),
+            format!("__file__:{}", file.path().to_string_lossy()),
+        ];
+        let result = parse_args(&args)
+            .expect("should parse")
+            .expect("should have value");
+        assert!(result["files"].is_array());
+        assert_eq!(result["files"][0]["path"], "README.md");
+        assert_eq!(result["files"][0]["content"], "hello");
+    }
+
+    #[test]
+    fn parse_file_prefix_parses_json_object() {
+        let file = write_tempfile(br#"{"status":"active"}"#);
+        let args = vec![
+            "--filter".to_string(),
+            format!("__file__:{}", file.path().to_string_lossy()),
+        ];
+        let result = parse_args(&args)
+            .expect("should parse")
+            .expect("should have value");
+        assert_eq!(result["filter"]["status"], "active");
+    }
+
+    #[test]
+    fn parse_file_prefix_parses_json_array_with_trailing_newline() {
+        let file = write_tempfile(b"[1, 2, 3]\n");
+        let args = vec![
+            "--values".to_string(),
+            format!("__file__:{}", file.path().to_string_lossy()),
+        ];
+        let result = parse_args(&args)
+            .expect("should parse")
+            .expect("should have value");
+        assert!(result["values"].is_array());
+        assert_eq!(result["values"][2], 3);
+    }
+
+    #[test]
+    fn parse_file_prefix_malformed_json_array_errors() {
+        let file = write_tempfile(b"[not valid json]");
+        let args = vec![
+            "--files".to_string(),
+            format!("__file__:{}", file.path().to_string_lossy()),
+        ];
+        assert!(parse_args(&args).is_err());
+    }
+
+    #[test]
+    fn parse_file_prefix_non_json_shaped_content_is_string() {
+        let file = write_tempfile(b"just some free-form text");
+        let args = vec![
+            "--query".to_string(),
+            format!("__file__:{}", file.path().to_string_lossy()),
+        ];
+        let result = parse_args(&args)
+            .expect("should parse")
+            .expect("should have value");
+        assert_eq!(result["query"], "just some free-form text");
+        assert!(result["query"].is_string());
     }
 
     #[test]

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -94,7 +94,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.33",
+      tag: "0.8.34",
     });
   });
 
@@ -339,7 +339,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.24/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.25/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -19,8 +19,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.33";
-const DSBX_CLI_VERSION = "0.1.24";
+const DUST_BASE_IMAGE_VERSION = "0.8.34";
+const DSBX_CLI_VERSION = "0.1.25";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that
 // list must not silently change this user's UID.

--- a/front/lib/resources/skill/code_defined/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.ts
@@ -31,7 +31,8 @@ function buildSandboxInstructionProse({
     instructions.push(
       "You can use the `dsbx` command line tool to list and run tools programmatically in the sandbox.",
       "Use it with `dsbx tools [SERVER_NAME] [TOOL_NAME] [ARGS]...`. Run `dsbx tools --help` for more information.",
-      "For very large argument values, write the value to a file in the sandbox and pass the path with a `__file__:` prefix (e.g. `--query __file__:/tmp/q.txt`) instead of inlining the value on the command line. Any value starting with `__file__:` is read as a UTF-8 string (max 100 MB) and used as the value for that key. The file must already exist in the sandbox filesystem."
+      "For very large argument values, write the value to a file in the sandbox and pass the path with a `__file__:` prefix (e.g. `--query __file__:/tmp/q.txt`) instead of inlining the value on the command line. Any value starting with `__file__:` is read from the file (UTF-8, max 100 MB) and used as the value for that key. File contents that are a JSON object or array are parsed into structured data (e.g. `--files __file__:/tmp/files.json` for a tool expecting an array), exactly as if the same JSON had been passed inline; any other content is used as a string. The file must already exist in the sandbox filesystem.",
+      "Pass `--json` (before the server and tool names, e.g. `dsbx tools --json [SERVER_NAME] [TOOL_NAME] [ARGS]...`) to get the tool result as structured JSON (`{ content, isError }`) instead of plain text, which is easier to parse programmatically. Placed after the positional arguments it is treated as a tool argument instead."
     );
   }
 


### PR DESCRIPTION
## Description

`__file__:` always read file contents as a raw string, so passing an array/object param via a file failed:

```
dsbx tools github-mcp-server push_files --files __file__:/tmp/files.json
# → "files parameter must be an array of objects with path and content"
```

while the same JSON inline worked fine. `push_files` is the only tool that commits multiple files atomically, and `__file__:` is the intended escape hatch for large arrays — so this was the primary use case it was designed for.

Now, file contents shaped like a JSON object/array are parsed into structured data, identical to passing the same JSON inline. Other content stays a string.

Malformed JSON-shaped file content is a hard error rather than a silent string fallback — the content isn't visible on the command line, so degrading would only resurface as a confusing tool-level error. The inline path keeps its string fallback.

Drive-by 🚗: documented the `--json` flag (and its before-the-positionals placement) in the sandbox instructions.

## Tests

Unit tests in `exec.rs`: array/object parsing, trailing newline, malformed-shaped file content errors, non-JSON file content stays a string, and inline malformed stays a string. `cargo test`, `cargo fmt`, `cargo clippy` clean. Front `registry.test.ts` and `sandbox.test.ts` pass.

## Risk

Worst case, a JSON-shaped-but-malformed file now errors instead of silently becoming a string. Safe to rollback.

## Deploy Plan

- [ ] Release dsbx CLI v0.1.25 (Release dsbx CLI workflow)
- [ ] Build/publish the dust-base sandbox image 0.8.34
- [ ] Deploy front