### PR TITLE
Treat missing table CSV as empty when GCS returns a 404

### DIFF
--- a/core/src/databases_store/gcs.rs
+++ b/core/src/databases_store/gcs.rs
@@ -85,15 +85,27 @@ impl GoogleCloudStorageDatabasesStore {
         match csv.parse().await {
             Ok(rows) => Ok(rows),
             Err(e) => match e.downcast_ref::<cloud_storage::Error>() {
-                // Treat a non-existing file as an empty table
-                // Checking for this is trickier than it should be, due to how the cloud_storage crate handles errors.
-                // In particular, when it can't download a file because it doesn't exist, it returns an 'Other' error,
-                // instead of the more meaningful Google(GoogleErrorResponse) with a 404 (which it correctly uses
-                // when trying to *delete* a non-existing file).
+                // Treat a non-existing file as an empty table.
+                // Checking for this is trickier than it should be, due to how the cloud_storage crate handles errors,
+                // and depends on which underlying GCS call hits the missing object first:
+                //  - Object::download (the actual file download) returns an 'Other' error containing "No such object".
+                //  - Object::read (the metadata probe parse() does for its file-size check) returns the more
+                //    meaningful Google(GoogleErrorResponse) with a 404, same as Object::delete on a missing object.
+                // We treat both as an empty table.
                 Some(cloud_storage::Error::Other(s)) if s.contains("No such object") => {
                     info!(
                         table_id = table.table_id(),
                         "DSSTRUCTSTAT [get_rows_from_csv] no GCS file, treating as empty table"
+                    );
+                    Ok(Vec::new())
+                }
+                Some(cloud_storage::Error::Google(GoogleErrorResponse {
+                    error: ErrorList { code: 404, .. },
+                    ..
+                })) => {
+                    info!(
+                        table_id = table.table_id(),
+                        "DSSTRUCTSTAT [get_rows_from_csv] no GCS file (404), treating as empty table"
                     );
                     Ok(Vec::new())
                 }


### PR DESCRIPTION
## Description

  ## What

  Fix a recurring `TableUpsertsBackgroundWorker: Failed to process table` error caused by a 404 when reading a table's CSV during a non-truncate upsert.

  ## Symptom

```
  TableUpsertsBackgroundWorker: Failed to process table: Google(GoogleErrorResponse {
    error: ErrorList { errors: [GoogleError { reason: NotFound,
      message: "No such object: bkt-...-tables/project-...//.csv" }],
      code: 404, ... } })
```

  The entry then stays in the queue and is retried every loop iteration.

  ## Root cause

  `GoogleCloudStorageDatabasesStore::get_rows_from_csv` already intends to treat a missing CSV as an empty table — but it only catches one of the two ways the `cloud_storage` crate reports "object not found":

  - `Object::download` (the file download) → `Error::Other("No such object")` ✅ handled
  - `Object::read` (metadata fetch) → `Error::Google(GoogleErrorResponse { code: 404 })` ❌ not handled

  `csv.parse()` was later changed to call `Object::read` **first** (a metadata probe for its file-size guard) before downloading. So when the CSV is missing, the *metadata* call now 404s before the download is ever attempted — surfacing the `Google` variant that the handler doesn't match. It falls through to `_ => Err(e)` and propagates.

  This fires for **any** non-truncate upsert whose `{table_id}.csv` doesn't exist yet:
  - the table's CSV was deleted (e.g. table deleted/recreated) while a queued upsert was pending,
  - the table was truncated away,
  - or it's simply a brand-new table's first upsert.

  All of these used to be handled as "empty table" before the metadata probe was added.

  ## Fix

  Extend the not-found handler in `get_rows_from_csv` to also treat the `Error::Google(... code: 404 ...)` variant as an empty table, mirroring the pattern already used in `delete_table_data`. The stale comment is updated to document both code paths.

  With this, the upsert merges into an empty row set and re-writes the file, and the queue entry clears normally.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Core