### PR TITLE
Add reminderSentAt to membership invitations

### DIFF
--- a/front/lib/models/membership_invitation.ts
+++ b/front/lib/models/membership_invitation.ts
@@ -15,6 +15,8 @@ export class MembershipInvitationModel extends WorkspaceAwareModel<MembershipInv
   declare initialRole: Exclude<RoleType, "none">;
 
   declare invitedUserId: ForeignKey<UserModel["id"]> | null;
+
+  declare reminderSentAt: Date | null;
 }
 MembershipInvitationModel.init(
   {
@@ -46,6 +48,11 @@ MembershipInvitationModel.init(
       allowNull: false,
       defaultValue: "user",
     },
+    reminderSentAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      defaultValue: null,
+    },
   },
   {
     modelName: "membership_invitation",
@@ -54,6 +61,11 @@ MembershipInvitationModel.init(
       { fields: ["workspaceId", "status"] },
       { unique: true, fields: ["sId"] },
       { fields: ["inviteEmail", "status"] },
+      {
+        fields: ["createdAt", "id"],
+        where: { status: "pending", reminderSentAt: null },
+        concurrently: true,
+      },
     ],
   }
 );

--- a/front/lib/resources/membership_invitation_resource.ts
+++ b/front/lib/resources/membership_invitation_resource.ts
@@ -483,6 +483,7 @@ export class MembershipInvitationResource extends BaseResource<MembershipInvitat
   toJSON(): MembershipInvitationType {
     return {
       createdAt: this.createdAt.getTime(),
+      reminderSentAt: this.reminderSentAt?.getTime() ?? null,
       id: this.id,
       initialRole: this.initialRole,
       inviteEmail: this.inviteEmail,

--- a/front/migrations/db/migration_662.sql
+++ b/front/migrations/db/migration_662.sql
@@ -1,0 +1,3 @@
+-- Migration created on Jun 01, 2026
+ALTER TABLE "public"."membership_invitations" ADD COLUMN "reminderSentAt" TIMESTAMP WITH TIME ZONE DEFAULT NULL;
+CREATE INDEX CONCURRENTLY "membership_invitations_created_at_id" ON "membership_invitations" ("createdAt", "id") WHERE "status" = 'pending' AND "reminderSentAt" IS NULL;

--- a/front/types/membership_invitation.ts
+++ b/front/types/membership_invitation.ts
@@ -12,6 +12,7 @@ export type MembershipInvitationType = {
   inviteEmail: string;
   initialRole: ActiveRoleType;
   createdAt: number;
+  reminderSentAt: number | null;
   isExpired: boolean;
 };
 


### PR DESCRIPTION
## Description

This PR is the first of three stacked PRs implementing automated invitation reminders. When a workspace invitation expires without being accepted, the system will send a one-time reminder email to the invitee with a refreshed invitation link.

The three PRs are: 
(1) this one, which adds the database column and migration; 
(2) reinvite_workflow_scaffolding, which wires up the Temporal worker, queue, and cron workflow shell; 
(3) reinvite_workflow_logic, which adds the resource methods, activity implementation, token logic, and tests.

The core design choice is to track reminder state directly on the existing `membership_invitations` row rather than creating a new invitation. A nullable `reminderSentAt` timestamp column serves three purposes at once. 

First, it is the idempotency guard: the reminder job issues a conditional `UPDATE WHERE reminderSentAt IS NULL`, which atomically claims the slot and prevents two workers from sending duplicate emails even if the activity is retried. 

Second, it is the token validity anchor: after a reminder is sent, the invitation token is re-anchored on `reminderSentAt` rather than `createdAt`, giving the recipient a fresh 7-day window from the moment the reminder lands. 

Third, it is the eligibility filter: the partial index on `(createdAt, id) WHERE status = 'pending' AND reminderSentAt IS NULL` lets the reminder job scan only un-reminded pending invitations efficiently without touching rows that have already been handled or consumed.

One reminder is sent per invitation, ever. There is no re-sending within the eligibility window because `reminderSentAt IS NULL` is a one-way gate.

## Tests

This one untested but new column unused yet. 

## Risk

/ 

## Deploy Plan

Run migration. 
Deploy front. 