### PR TITLE
Use light version for pod conversations sync

### DIFF
--- a/connectors/src/connectors/dust_project/lib/conversation_formatting.test.ts
+++ b/connectors/src/connectors/dust_project/lib/conversation_formatting.test.ts
@@ -1,4 +1,4 @@
-import type { ConversationPublicType } from "@dust-tt/client";
+import type { ConversationForDataSourceSyncType } from "@dust-tt/client";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -8,14 +8,10 @@ import {
 } from "./conversation_formatting";
 
 function minimalConversation(
-  overrides: Partial<ConversationPublicType>
-): ConversationPublicType {
+  overrides: Partial<ConversationForDataSourceSyncType>
+): ConversationForDataSourceSyncType {
   return {
-    id: 1,
     created: 0,
-    unread: false,
-    actionRequired: false,
-    owner: {} as ConversationPublicType["owner"],
     sId: "conv-1",
     title: "T",
     visibility: "workspace",

--- a/connectors/src/connectors/dust_project/lib/conversation_formatting.ts
+++ b/connectors/src/connectors/dust_project/lib/conversation_formatting.ts
@@ -3,26 +3,20 @@ import { renderDocumentTitleAndContent } from "@connectors/lib/data_sources";
 import { formatDateForUpsert } from "@connectors/lib/formatting";
 import logger from "@connectors/logger/logger";
 import type { DataSourceConfig } from "@connectors/types";
-import type { ConversationPublicType } from "@dust-tt/client";
+import type { ConversationForDataSourceSyncType } from "@dust-tt/client";
 
 /** Max messages (user / agent / content_fragment) per Core document to avoid upsert size limits. */
 export const CONVERSATION_MESSAGES_PER_DOCUMENT = 256;
 
 /**
- * Builds one document section per message (last version per rank) for indexing.
+ * Builds one document section per message for indexing.
  */
 export function buildConversationMessageSections(
-  conversation: ConversationPublicType
+  conversation: ConversationForDataSourceSyncType
 ): CoreAPIDataSourceDocumentSection[] {
   const messageSections: CoreAPIDataSourceDocumentSection[] = [];
 
-  for (const versions of conversation.content) {
-    const msg = versions[versions.length - 1];
-
-    if (!msg) {
-      continue;
-    }
-
+  for (const msg of conversation.content) {
     let prefix: string | null = null;
     let content: string | null = null;
     const dateStr: string = formatDateForUpsert(new Date(msg.created));
@@ -33,6 +27,15 @@ export function buildConversationMessageSections(
       const userId = msg.user?.sId || "Unknown";
       prefix = `>> User (name: ${userName}, email: ${userEmail}, id: ${userId}) [${dateStr}]:\n`;
       content = msg.content ? msg.content + "\n" : "\n";
+
+      for (const cf of msg.contentFragments) {
+        content += `>> Content Fragment from the user message [${dateStr}]:\n`;
+        content += "ID: " + cf.contentFragmentId + "\n";
+        content += "Content-Type: " + cf.contentType + "\n";
+        content += "Title: " + cf.title + "\n";
+        content += "Version: " + cf.version + "\n";
+        content += "Source URL: " + cf.sourceUrl + "\n";
+      }
     } else if (msg.type === "agent_message") {
       const agentName = msg.configuration?.name || "Assistant";
       prefix = `>> Assistant (${agentName}) [${dateStr}]:\n`;
@@ -43,13 +46,8 @@ export function buildConversationMessageSections(
         logger.warn({ msg }, "Agent message has no content");
         content = "\n";
       }
-    } else if (msg.type === "content_fragment") {
-      prefix = `>> Content Fragment [${dateStr}]:\n`;
-      content = "ID: " + msg.contentFragmentId + "\n";
-      content += "Content-Type: " + msg.contentType + "\n";
-      content += "Title: " + msg.title + "\n";
-      content += "Version: " + msg.version + "\n";
-      content += "Source URL: " + msg.sourceUrl + "\n";
+    } else {
+      assertNever(msg.type);
     }
 
     if (prefix !== null && content !== null) {
@@ -87,7 +85,7 @@ export function chunkMessageSectionsForDocuments(
  * Title for a Core document: base conversation title, with ` (part i of n)` when split across multiple documents.
  */
 export function getConversationDocumentUpsertTitle(
-  conversation: ConversationPublicType,
+  conversation: ConversationForDataSourceSyncType,
   partIndex: number,
   totalParts: number
 ): string {
@@ -109,7 +107,7 @@ export async function formatConversationSectionsForUpsert({
   totalParts,
 }: {
   dataSourceConfig: DataSourceConfig;
-  conversation: ConversationPublicType;
+  conversation: ConversationForDataSourceSyncType;
   sections: CoreAPIDataSourceDocumentSection[];
   partIndex: number;
   totalParts: number;
@@ -144,7 +142,7 @@ export async function formatConversationForUpsert({
   conversation,
 }: {
   dataSourceConfig: DataSourceConfig;
-  conversation: ConversationPublicType;
+  conversation: ConversationForDataSourceSyncType;
 }): Promise<CoreAPIDataSourceDocumentSection> {
   const sections = buildConversationMessageSections(conversation);
   return formatConversationSectionsForUpsert({

--- a/connectors/src/connectors/dust_project/lib/sync_conversation.ts
+++ b/connectors/src/connectors/dust_project/lib/sync_conversation.ts
@@ -7,7 +7,10 @@ import logger from "@connectors/logger/logger";
 import { DustProjectConversationResource } from "@connectors/resources/dust_project_conversation_resource";
 import type { DataSourceConfig, ModelId } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types/shared/internal_mime_types";
-import { type ConversationPublicType, removeNulls } from "@dust-tt/client";
+import {
+  type ConversationForDataSourceSyncType,
+  removeNulls,
+} from "@dust-tt/client";
 
 import {
   buildConversationMessageSections,
@@ -126,7 +129,7 @@ export async function syncConversation({
   connectorId: ModelId;
   dataSourceConfig: DataSourceConfig;
   projectId: string;
-  conversation: ConversationPublicType;
+  conversation: ConversationForDataSourceSyncType;
   syncType: "batch" | "incremental";
 }): Promise<void> {
   const localLogger = logger.child({
@@ -153,11 +156,9 @@ export async function syncConversation({
   const isGroupConversation =
     new Set(
       removeNulls(
-        conversation.content
-          .map((versions) => versions[-1])
-          .map((m) =>
-            m?.type === "user_message" && m.user ? m.user.sId : null
-          )
+        conversation.content.map((m) =>
+          m.type === "user_message" && m.user ? m.user.sId : null
+        )
       )
     ).size > 1;
 

--- a/connectors/src/connectors/dust_project/temporal/activities.ts
+++ b/connectors/src/connectors/dust_project/temporal/activities.ts
@@ -117,7 +117,7 @@ export async function dustProjectConversationsFullSyncActivity({
     }
 
     // Sync each conversation (including deleted ones - syncConversation handles deletion)
-    // conversations is an array of ConversationSchema objects (full ConversationType)
+    // conversations is an array of ConversationForDataSourceSyncSchema objects
     await concurrentExecutor(
       conversations,
       async (conversation) => {
@@ -227,7 +227,7 @@ export async function dustProjectConversationsIncrementalSyncActivity({
     );
 
     // Sync each conversation (including deleted ones - syncConversation handles deletion)
-    // conversations is an array of ConversationSchema objects (full ConversationType)
+    // conversations is an array of ConversationForDataSourceSyncSchema objects
     await concurrentExecutor(
       conversations,
       async (conversation) => {

--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -1,7 +1,6 @@
 import { groupMessagesIntoInteractions } from "@app/lib/api/assistant/conversation/interactions";
 import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import config from "@app/lib/api/config";
-import { addBackwardCompatibleConversationFields } from "@app/lib/api/v1/backward_compatibility";
 import type { Authenticator } from "@app/lib/auth";
 import {
   AgentMessageModel,
@@ -38,7 +37,13 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { isArrayOf } from "@app/types/shared/typescipt_utils";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
+import {
+  ConversationForDataSourceSyncSchema,
+  type ConversationForDataSourceSyncType,
+  // biome-ignore lint/plugin/enforceClientTypesInPublicApi: useful to convert for sync
+} from "@dust-tt/client";
 import { Op, type WhereOptions } from "sequelize";
 
 // Helper type to map viewType to the correct message type
@@ -433,6 +438,77 @@ async function _getConversation<V extends "light" | "full">(
   }
 }
 
+export function toConversationForDataSourceSync(
+  conversation: LightConversationType
+): ConversationForDataSourceSyncType {
+  const content = removeNulls(
+    conversation.content.map((msg) => {
+      const type = msg.type;
+      switch (type) {
+        case "user_message": {
+          return {
+            type: "user_message" as const,
+            created: msg.created,
+            visibility: msg.visibility,
+            content: msg.content,
+            user: msg.user
+              ? {
+                  sId: msg.user.sId,
+                  fullName: msg.user.fullName,
+                  username: msg.user.username,
+                  email: msg.user.email,
+                }
+              : null,
+            contentFragments: msg.contentFragments.map((cf) => ({
+              type: "content_fragment" as const,
+              created: cf.created,
+              visibility: cf.visibility,
+              contentFragmentId: cf.contentFragmentId,
+              contentType: cf.contentType,
+              title: cf.title,
+              version: cf.version,
+              sourceUrl: cf.sourceUrl,
+            })),
+          };
+        }
+        case "agent_message": {
+          return {
+            type: "agent_message" as const,
+            created: msg.created,
+            visibility: msg.visibility,
+            configuration: { name: msg.configuration.name },
+            content: msg.content,
+          };
+        }
+
+        case "compaction_message": {
+          // Ignore compaction messages for sync, we want the full signal.
+          return null;
+        }
+
+        default: {
+          assertNever(type);
+        }
+      }
+      return null;
+    })
+  );
+  return ConversationForDataSourceSyncSchema.parse({
+    sId: conversation.sId,
+    created: conversation.created,
+    updated: conversation.updated,
+    title: conversation.title,
+    visibility: conversation.visibility,
+    url: getConversationRoute(
+      conversation.owner.sId,
+      conversation.sId,
+      undefined,
+      config.getAppUrl()
+    ),
+    content,
+  });
+}
+
 // Lists conversations in a space along with their full content, formatted for
 // the connectors-driven sync flow (each conversation is enriched with a public
 // URL and backward-compatible fields). Includes deleted conversations so sync
@@ -461,7 +537,7 @@ export async function listSpaceConversationsForSync(
 
   const conversationsFull = await concurrentExecutor(
     spaceConversations,
-    async (c) => getConversation(auth, c.sId, true),
+    async (c) => getLightConversation(auth, c.sId, true),
     { concurrency: 4 }
   );
 
@@ -479,5 +555,5 @@ export async function listSpaceConversationsForSync(
         config.getAppUrl()
       ),
     }))
-    .map(addBackwardCompatibleConversationFields);
+    .map(toConversationForDataSourceSync);
 }

--- a/front/scripts/dev/print_public_api_conversation.ts
+++ b/front/scripts/dev/print_public_api_conversation.ts
@@ -9,12 +9,11 @@
  * Do not use top-level await — tsx often emits CJS, which does not support it.
  */
 
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
-import config from "@app/lib/api/config";
-import { addBackwardCompatibleConversationFields } from "@app/lib/api/v1/backward_compatibility";
+import {
+  getLightConversation,
+  toConversationForDataSourceSync,
+} from "@app/lib/api/assistant/conversation/fetch";
 import { Authenticator } from "@app/lib/auth";
-import { getConversationRoute } from "@app/lib/utils/router";
-import type { ConversationType } from "@app/types/assistant/conversation";
 import parseArgs from "minimist";
 
 async function main() {
@@ -34,21 +33,15 @@ async function main() {
     dangerouslyRequestAllGroups: true,
   });
 
-  const conversationRes = await getConversation(auth, cId, includeDeleted);
+  const conversationRes = await getLightConversation(auth, cId, includeDeleted);
   if (conversationRes.isErr()) {
     throw new Error(conversationRes.error.message);
   }
 
   const c = conversationRes.value;
 
-  // Same pipeline as spaces/[spaceId]/conversations/index.ts (list map + backward compat).
-  const responseConversation = {
-    ...c,
-    url: getConversationRoute(wId, c.sId, undefined, config.getAppUrl()),
-  };
-  const publicConversation = addBackwardCompatibleConversationFields(
-    responseConversation as ConversationType
-  );
+  // Same pipeline as spaces/[spaceId]/conversations/index.ts
+  const publicConversation = toConversationForDataSourceSync(c);
 
   console.log(JSON.stringify(publicConversation, null, 2));
 }

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1199,6 +1199,71 @@ export type ConversationWithoutContentPublicType = z.infer<
 >;
 export type ConversationPublicType = z.infer<typeof ConversationSchema>;
 
+/**
+ * Subset of {@link ConversationSchema} used by connectors when syncing conversations
+ * to a data source (dust_project). `content` is the latest version of each message
+ * (no per-message version arrays). Matches fields read in sync_conversation and
+ * conversation_formatting.
+ */
+const ConversationForDataSourceSyncUserSchema = UserSchema.pick({
+  sId: true,
+  fullName: true,
+  username: true,
+  email: true,
+});
+
+const ConversationForDataSourceSyncContentFragmentSchema = z.object({
+  type: z.literal("content_fragment"),
+  created: z.number(),
+  visibility: VisibilitySchema,
+  contentFragmentId: z.string(),
+  contentType: SupportedContentFragmentTypeSchema,
+  title: z.string(),
+  version: z.number(),
+  sourceUrl: z.string().nullable(),
+});
+
+const ConversationForDataSourceSyncUserMessageSchema = z.object({
+  type: z.literal("user_message"),
+  created: z.number(),
+  visibility: VisibilitySchema,
+  user: ConversationForDataSourceSyncUserSchema.nullable(),
+  content: z.string(),
+  contentFragments: z.array(ConversationForDataSourceSyncContentFragmentSchema),
+});
+
+const ConversationForDataSourceSyncAgentMessageSchema = z.object({
+  type: z.literal("agent_message"),
+  created: z.number(),
+  visibility: VisibilitySchema,
+  configuration: z.object({
+    name: z.string(),
+  }),
+  content: z.string().nullable(),
+});
+
+const ConversationForDataSourceSyncMessageSchema = z.discriminatedUnion(
+  "type",
+  [
+    ConversationForDataSourceSyncUserMessageSchema,
+    ConversationForDataSourceSyncAgentMessageSchema,
+  ]
+);
+
+export const ConversationForDataSourceSyncSchema = z.object({
+  sId: z.string(),
+  created: z.number(),
+  updated: z.number().optional(),
+  title: z.string().nullable(),
+  visibility: ConversationVisibilitySchema,
+  url: z.string(),
+  content: z.array(ConversationForDataSourceSyncMessageSchema),
+});
+
+export type ConversationForDataSourceSyncType = z.infer<
+  typeof ConversationForDataSourceSyncSchema
+>;
+
 const ConversationMessageReactionsSchema = z.array(
   z.object({
     messageId: z.string(),
@@ -2627,7 +2692,7 @@ export type CheckUpsertQueueResponseType = z.infer<
 >;
 
 export const GetSpaceConversationsForDataSourceResponseSchema = z.object({
-  conversations: z.array(ConversationSchema),
+  conversations: z.array(ConversationForDataSourceSyncSchema),
 });
 export type GetSpaceConversationsForDataSourceResponseType = z.infer<
   typeof GetSpaceConversationsForDataSourceResponseSchema


### PR DESCRIPTION
This is to fix a stuck connector because the conversation is 900Mb (due to large mcp output payloads that we don't care about) and it's good in general.

## Description

Introduces `ConversationForDataSourceSyncType` — a slim Zod schema in `sdks/js/src/types.ts` purpose-built for the `dust_project` connector sync path. Replaces the full `ConversationPublicType` (which carries per-message version arrays and public API fields unused during sync).

Key changes:
- `listSpaceConversationsForSync` now calls `getLightConversation` instead of `getConversation`, reducing the DB/render footprint per conversation.
- `toConversationForDataSourceSync()` maps `LightConversationType` to the new flat structure, replacing `addBackwardCompatibleConversationFields`.
- Content fragments are now nested inside `user_message.contentFragments` rather than emitted as separate top-level messages, matching how they're logically attached.
- Fixes a latent bug in `syncConversation`: `versions[-1]` was always `undefined` in JS (no Python-style negative indexing); the new flat model iterates messages directly.
- `compaction_message` entries are explicitly filtered out during mapping.
- `GetSpaceConversationsForDataSourceResponseSchema` updated to use the new slim schema.

## Tests

- Updated existing Vitest unit tests in `conversation_formatting.test.ts` to use `ConversationForDataSourceSyncType`.
- Tested locally via `print_public_api_conversation.ts` dev script (now uses `getLightConversation` + `toConversationForDataSourceSync`).

## Risk

Medium. The `content` structure in the API response changes from `MessageVersions[][]` (arrays of arrays) to a flat `Message[]`. This is a breaking change between front and connectors — if deployed out of order, the Zod parse on the connectors side will fail for that sync window.

Rollback: safe independently per service once both are deployed.

## Deploy Plan

1. Deploy **front** (changes `listSpaceConversationsForSync` response shape).
2. Deploy **connectors** (reads the new `ConversationForDataSourceSyncSchema`).
