### PR TITLE
Wire up the invitations Temporal worker

### DIFF
--- a/front/scripts/temporal-build/build-temporal-bundles.ts
+++ b/front/scripts/temporal-build/build-temporal-bundles.ts
@@ -50,6 +50,8 @@ function getWorkerDirectory(workerName: WorkerName): string | null {
       return path.join(baseDir, "temporal/data_retention");
     case "hard_delete":
       return path.join(baseDir, "temporal/hard_delete");
+    case "invitations":
+      return path.join(baseDir, "temporal/invitations");
     case "labs":
       return path.join(baseDir, "temporal/labs/transcripts");
     case "mentions_count":

--- a/front/temporal/invitations/activities.ts
+++ b/front/temporal/invitations/activities.ts
@@ -1,0 +1,4 @@
+// Stub — replaced in reinvite_workflow_logic.
+export async function sendInvitationReminderBatchActivity(): Promise<boolean> {
+  return false;
+}

--- a/front/temporal/invitations/admin/cli.sh
+++ b/front/temporal/invitations/admin/cli.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+npx tsx temporal/invitations/admin/cli.ts "$@"

--- a/front/temporal/invitations/admin/cli.ts
+++ b/front/temporal/invitations/admin/cli.ts
@@ -1,4 +1,6 @@
+import logger from "@app/logger/logger";
 import { launchInvitationRemindersWorkflow } from "@app/temporal/invitations/client";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import parseArgs from "minimist";
 
 const main = async () => {
@@ -6,22 +8,28 @@ const main = async () => {
   const [command] = argv._;
 
   switch (command) {
-    case "start":
-      await launchInvitationRemindersWorkflow();
+    case "start": {
+      const result = await launchInvitationRemindersWorkflow();
+      if (result.isErr()) {
+        throw result.error;
+      }
       return;
+    }
     default:
-      console.error("\x1b[31m%s\x1b[0m", `Error: Unknown command`);
+      logger.error({ command }, "[Invitation Reminders] Unknown command.");
       return;
   }
 };
 
 main()
   .then(() => {
-    console.error("\x1b[32m%s\x1b[0m", `Done`);
+    logger.info("[Invitation Reminders] Done.");
     process.exit(0);
   })
   .catch((err) => {
-    console.error("\x1b[31m%s\x1b[0m", `Error: ${err.message}`);
-    console.log(err);
+    logger.error(
+      { err: normalizeError(err) },
+      "[Invitation Reminders] CLI error."
+    );
     process.exit(1);
   });

--- a/front/temporal/invitations/admin/cli.ts
+++ b/front/temporal/invitations/admin/cli.ts
@@ -1,0 +1,27 @@
+import { launchInvitationRemindersWorkflow } from "@app/temporal/invitations/client";
+import parseArgs from "minimist";
+
+const main = async () => {
+  const argv = parseArgs(process.argv.slice(2));
+  const [command] = argv._;
+
+  switch (command) {
+    case "start":
+      await launchInvitationRemindersWorkflow();
+      return;
+    default:
+      console.error("\x1b[31m%s\x1b[0m", `Error: Unknown command`);
+      return;
+  }
+};
+
+main()
+  .then(() => {
+    console.error("\x1b[32m%s\x1b[0m", `Done`);
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error("\x1b[31m%s\x1b[0m", `Error: ${err.message}`);
+    console.log(err);
+    process.exit(1);
+  });

--- a/front/temporal/invitations/client.ts
+++ b/front/temporal/invitations/client.ts
@@ -1,14 +1,19 @@
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
-import { Ok } from "@app/types/shared/result";
-import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import {
+  ScheduleAlreadyRunning,
+  ScheduleOverlapPolicy,
+} from "@temporalio/client";
 
 import { QUEUE_NAME } from "./config";
 import { invitationRemindersWorkflow } from "./workflows";
 
-// 17:00 UTC = 09:00–10:00 San Francisco, 12:00–13:00 US East Coast, 18:00–19:00 Central Europe.
-const CRON_SCHEDULE = "0 17 * * 1-5";
+// 17:00 UTC = 09:00 San Francisco, 13:00 US East Coast, 19:00 Central Europe.
+const SCHEDULE_ID = "invitation-reminders-schedule";
+const CRON_EXPRESSION = "0 17 * * 1-5";
 
 export async function launchInvitationRemindersWorkflow(): Promise<
   Result<undefined, Error>
@@ -16,20 +21,26 @@ export async function launchInvitationRemindersWorkflow(): Promise<
   const client = await getTemporalClientForFrontNamespace();
 
   try {
-    await client.workflow.start(invitationRemindersWorkflow, {
-      args: [],
-      taskQueue: QUEUE_NAME,
-      workflowId: "invitation-reminders-workflow",
-      cronSchedule: CRON_SCHEDULE,
+    await client.schedule.create({
+      scheduleId: SCHEDULE_ID,
+      action: {
+        type: "startWorkflow",
+        workflowType: invitationRemindersWorkflow,
+        args: [],
+        taskQueue: QUEUE_NAME,
+      },
+      policies: {
+        overlap: ScheduleOverlapPolicy.SKIP,
+      },
+      spec: {
+        cronExpressions: [CRON_EXPRESSION],
+      },
     });
-    logger.info("[Invitation Reminders] Launched workflow.");
-  } catch (e) {
-    if (e instanceof WorkflowExecutionAlreadyStartedError) {
-      logger.info(
-        "[Invitation Reminders] Workflow already running (idempotency check passed)."
-      );
-    } else {
-      throw e;
+    logger.info("[Invitation Reminders] Schedule created.");
+  } catch (err) {
+    if (!(err instanceof ScheduleAlreadyRunning)) {
+      logger.error({}, "[Invitation Reminders] Failed to create schedule.");
+      return new Err(normalizeError(err));
     }
   }
 

--- a/front/temporal/invitations/client.ts
+++ b/front/temporal/invitations/client.ts
@@ -1,0 +1,37 @@
+import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
+
+import { QUEUE_NAME } from "./config";
+import { invitationRemindersWorkflow } from "./workflows";
+
+// 17:00 UTC = 09:00–10:00 San Francisco, 12:00–13:00 US East Coast, 18:00–19:00 Central Europe.
+const CRON_SCHEDULE = "0 17 * * 1-5";
+
+export async function launchInvitationRemindersWorkflow(): Promise<
+  Result<undefined, Error>
+> {
+  const client = await getTemporalClientForFrontNamespace();
+
+  try {
+    await client.workflow.start(invitationRemindersWorkflow, {
+      args: [],
+      taskQueue: QUEUE_NAME,
+      workflowId: "invitation-reminders-workflow",
+      cronSchedule: CRON_SCHEDULE,
+    });
+    logger.info("[Invitation Reminders] Launched workflow.");
+  } catch (e) {
+    if (e instanceof WorkflowExecutionAlreadyStartedError) {
+      logger.info(
+        "[Invitation Reminders] Workflow already running (idempotency check passed)."
+      );
+    } else {
+      throw e;
+    }
+  }
+
+  return new Ok(undefined);
+}

--- a/front/temporal/invitations/client.ts
+++ b/front/temporal/invitations/client.ts
@@ -34,12 +34,16 @@ export async function launchInvitationRemindersWorkflow(): Promise<
       },
       spec: {
         cronExpressions: [CRON_EXPRESSION],
+        timezone: "UTC",
       },
     });
     logger.info("[Invitation Reminders] Schedule created.");
   } catch (err) {
     if (!(err instanceof ScheduleAlreadyRunning)) {
-      logger.error({}, "[Invitation Reminders] Failed to create schedule.");
+      logger.error(
+        { err },
+        "[Invitation Reminders] Failed to create schedule."
+      );
       return new Err(normalizeError(err));
     }
   }

--- a/front/temporal/invitations/config.ts
+++ b/front/temporal/invitations/config.ts
@@ -1,0 +1,3 @@
+const QUEUE_VERSION = 1;
+
+export const QUEUE_NAME = `invitations-queue-v${QUEUE_VERSION}`;

--- a/front/temporal/invitations/worker.ts
+++ b/front/temporal/invitations/worker.ts
@@ -1,0 +1,38 @@
+import {
+  getTemporalWorkerConnection,
+  TEMPORAL_MAXED_CACHED_WORKFLOWS,
+} from "@app/lib/temporal";
+import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import logger from "@app/logger/logger";
+import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import * as activities from "@app/temporal/invitations/activities";
+import type { Context } from "@temporalio/activity";
+import { Worker } from "@temporalio/worker";
+
+import { QUEUE_NAME } from "./config";
+
+export async function runInvitationsWorker() {
+  const { connection, namespace } = await getTemporalWorkerConnection();
+
+  const worker = await Worker.create({
+    ...getWorkflowConfig({
+      workerName: "invitations",
+      getWorkflowsPath: () => require.resolve("./workflows"),
+    }),
+    activities,
+    taskQueue: QUEUE_NAME,
+    maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
+    maxConcurrentActivityTaskExecutions: 4,
+    connection,
+    namespace,
+    interceptors: {
+      activity: [
+        (ctx: Context) => ({
+          inbound: new ActivityInboundLogInterceptor(ctx, logger),
+        }),
+      ],
+    },
+  });
+
+  await worker.run();
+}

--- a/front/temporal/invitations/workflows.ts
+++ b/front/temporal/invitations/workflows.ts
@@ -1,0 +1,16 @@
+import type * as activities from "@app/temporal/invitations/activities";
+import { proxyActivities } from "@temporalio/workflow";
+
+const { sendInvitationReminderBatchActivity } = proxyActivities<
+  typeof activities
+>({
+  startToCloseTimeout: "5 minutes",
+  heartbeatTimeout: "1 minute",
+});
+
+export async function invitationRemindersWorkflow(): Promise<void> {
+  // Each activity call fetches and processes one batch. Loop until no more eligible invitations.
+  while (await sendInvitationReminderBatchActivity()) {
+    // continue
+  }
+}

--- a/front/temporal/worker_registry.ts
+++ b/front/temporal/worker_registry.ts
@@ -6,6 +6,7 @@ import { runCreditAlertsWorker } from "@app/temporal/credit_alerts/worker";
 import { runDataRetentionWorker } from "@app/temporal/data_retention/worker";
 import { runESIndexationQueueWorker } from "@app/temporal/es_indexation/worker";
 import { runHardDeleteWorker } from "@app/temporal/hard_delete/worker";
+import { runInvitationsWorker } from "@app/temporal/invitations/worker";
 import { runLabsTranscriptsWorker } from "@app/temporal/labs/transcripts/worker";
 import { runMentionsCountWorker } from "@app/temporal/mentions_count_queue/worker";
 import { runMentionsQueueWorker } from "@app/temporal/mentions_queue/worker";
@@ -37,6 +38,7 @@ export type WorkerName =
   | "es_indexation_queue"
   | "hard_delete"
   | "labs"
+  | "invitations"
   | "mentions_count"
   | "mentions_queue"
   | "metronome_events_queue"
@@ -63,6 +65,7 @@ export const workerFunctions: Record<WorkerName, () => Promise<void>> = {
   data_retention: runDataRetentionWorker,
   hard_delete: runHardDeleteWorker,
   labs: runLabsTranscriptsWorker,
+  invitations: runInvitationsWorker,
   mentions_count: runMentionsCountWorker,
   mentions_queue: runMentionsQueueWorker,
   metronome_events_queue: runMetronomeEventsWorker,


### PR DESCRIPTION
## Description

This PR is the second of three stacked PRs implementing automated invitation reminders. It registers the new worker, queue, and cron workflow shell without any business logic. The activity implementation lands in the third PR.

The three PRs are: 
(1) reinvite_migration, which adds the reminderSentAt column and partial index; 
(2) this one, which wires up the Temporal infrastructure; 
(3) reinvite_workflow_logic, which adds the resource methods, activity implementation, token logic, and tests.

The worker is named invitations rather than invitation_reminders because the queue is designed as a domain-level home for all invitation-related async work. Batch invitations are currently sent synchronously in the API handler with no retry on email failure. If that ever moves to a Temporal workflow, it belongs here. 

## Tests

/ 

## Risk

/ 

## Deploy Plan

Merge. 
Then I think I have to first do a PR in dust-infra to run the new worker. 
Then I'll merge the 3rd PR to have the workflow logic, before running it on prod with the cli. 