### PR TITLE
Gmail attachments

### DIFF
--- a/front/lib/api/actions/servers/gmail/helpers.ts
+++ b/front/lib/api/actions/servers/gmail/helpers.ts
@@ -60,7 +60,7 @@ export interface MessageDetail {
 
 export const MESSAGES_MAX_RESULTS = 50;
 export const MESSAGES_WITH_ATTACHMENTS_MAX_RESULTS = 10;
-export const  MAX_ATTACHMENT_SIZE_BYTES = 5 * 1024 * 1024; // 5MB
+export const MAX_ATTACHMENT_SIZE_BYTES = 5 * 1024 * 1024; // 5MB
 
 /**
  * Typeguard for GmailMessage

--- a/front/lib/api/actions/servers/gmail/helpers.ts
+++ b/front/lib/api/actions/servers/gmail/helpers.ts
@@ -60,6 +60,7 @@ export interface MessageDetail {
 
 export const MESSAGES_MAX_RESULTS = 50;
 export const MESSAGES_WITH_ATTACHMENTS_MAX_RESULTS = 10;
+export const  MAX_ATTACHMENT_SIZE_BYTES = 5 * 1024 * 1024; // 5MB
 
 /**
  * Typeguard for GmailMessage

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -76,10 +76,12 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .describe(
           "Optional. The ID of the message to reply to. If provided, the draft will be created as a reply in the existing thread, with proper threading headers and the original message quoted."
         ),
-        attachmentFileId: z
+      attachmentFileId: z
         .string()
         .optional()
-        .describe("Optional. The file ID of a conversation attachment to include in the email. The file must be present in the current conversation.")
+        .describe(
+          "Optional. The file ID of a conversation attachment to include in the email. The file must be present in the current conversation."
+        ),
     },
     stake: "medium",
     displayLabels: {
@@ -246,10 +248,12 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .describe(
           "Optional. The ID of the message to reply to. If provided, the email will be sent as a reply in the existing thread, with proper threading headers and the original message quoted."
         ),
-        attachmentFileId: z
+      attachmentFileId: z
         .string()
         .optional()
-        .describe("Optional. The file ID of a conversation attachment to include in the email. The file must be present in the current conversation.")
+        .describe(
+          "Optional. The file ID of a conversation attachment to include in the email. The file must be present in the current conversation."
+        ),
     },
     stake: "high",
     displayLabels: {

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -76,6 +76,10 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .describe(
           "Optional. The ID of the message to reply to. If provided, the draft will be created as a reply in the existing thread, with proper threading headers and the original message quoted."
         ),
+        attachmentFileId: z
+        .string()
+        .optional()
+        .describe("Optional. The file ID of a conversation attachment to include in the email. The file must be present in the current conversation.")
     },
     stake: "medium",
     displayLabels: {
@@ -242,6 +246,10 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .describe(
           "Optional. The ID of the message to reply to. If provided, the email will be sent as a reply in the existing thread, with proper threading headers and the original message quoted."
         ),
+        attachmentFileId: z
+        .string()
+        .optional()
+        .describe("Optional. The file ID of a conversation attachment to include in the email. The file must be present in the current conversation.")
     },
     stake: "high",
     displayLabels: {

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -76,11 +76,11 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .describe(
           "Optional. The ID of the message to reply to. If provided, the draft will be created as a reply in the existing thread, with proper threading headers and the original message quoted."
         ),
-      attachmentFileId: z
+      attachmentFilePath: z
         .string()
         .optional()
         .describe(
-          "Optional. The file ID of a conversation attachment to include in the email. The file must be present in the current conversation."
+          "Optional. Scoped path of the file to attach to the email (e.g. `conversation-<id>/report.pdf` or `pod-<id>/data.csv`)."
         ),
     },
     stake: "medium",
@@ -248,11 +248,11 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .describe(
           "Optional. The ID of the message to reply to. If provided, the email will be sent as a reply in the existing thread, with proper threading headers and the original message quoted."
         ),
-      attachmentFileId: z
+      attachmentFilePath: z
         .string()
         .optional()
         .describe(
-          "Optional. The file ID of a conversation attachment to include in the email. The file must be present in the current conversation."
+          "Optional. Scoped path of the file to attach to the email (e.g. `conversation-<id>/report.pdf` or `pod-<id>/data.csv`)."
         ),
     },
     stake: "high",

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -255,13 +255,13 @@ async function buildReplyContext(params: {
 
 async function fetchAttachment(
   auth: ToolHandlerExtra["auth"],
-  attachmentFileId: string | undefined,
+  attachmentFilePath: string | undefined,
   agentLoopContext: ToolHandlerExtra["agentLoopContext"]
 ): Promise<
   | Ok<{ buffer: Buffer; filename: string; contentType: string } | null>
   | Err<MCPError>
 > {
-  if (!attachmentFileId) {
+  if (!attachmentFilePath) {
     return new Ok(null);
   }
 
@@ -271,13 +271,13 @@ async function fetchAttachment(
 
   const fileResult = await getFileFromConversationAttachment(
     auth,
-    attachmentFileId,
+    attachmentFilePath,
     agentLoopContext
   );
 
   if (fileResult.isErr()) {
     return new Err(
-      new MCPError(`File not found: ${attachmentFileId}`, { tracked: false })
+      new MCPError(`File not found: ${attachmentFilePath}`, { tracked: false })
     );
   }
 
@@ -364,7 +364,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       contentType,
       body,
       replyToMessageId,
-      attachmentFileId,
+      attachmentFilePath,
     },
     { authInfo, auth, agentLoopContext }
   ) => {
@@ -399,7 +399,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     }
     const attachmentResult = await fetchAttachment(
       auth,
-      attachmentFileId,
+      attachmentFilePath,
       agentLoopContext
     );
     if (attachmentResult.isErr()) {
@@ -944,7 +944,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       contentType,
       body,
       replyToMessageId,
-      attachmentFileId,
+      attachmentFilePath,
     },
     { authInfo, auth, agentLoopContext }
   ) => {
@@ -978,7 +978,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     }
     const attachmentResult = await fetchAttachment(
       auth,
-      attachmentFileId,
+      attachmentFilePath,
       agentLoopContext
     );
     if (attachmentResult.isErr()) {

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -1,5 +1,8 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  ToolHandlerExtra,
+  ToolHandlers,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { jsonToMarkdown } from "@app/lib/actions/mcp_internal_actions/utils";
 import {
@@ -85,7 +88,15 @@ function buildAndEncodeEmail(params: {
     return validationError;
   }
 
-  let messageLines: string[] = [];
+  let messageLines: string[];
+
+  const commonLines = [
+    `To: ${params.to.join(", ")}`,
+    params.from ? `From: ${params.from}` : null,
+    params.cc?.length ? `Cc: ${params.cc.join(", ")}` : null,
+    params.bcc?.length ? `Bcc: ${params.bcc.join(", ")}` : null,
+    `Subject: ${encodedSubject}`,
+  ].filter((line): line is string => line !== null);
 
   if (params.attachment) {
     const boundary = crypto.randomUUID().replace(/-/g, "");
@@ -94,11 +105,7 @@ function buildAndEncodeEmail(params: {
       "application/octet-stream";
     // Create the email message with proper headers, content and attachment file
     messageLines = [
-      `To: ${params.to.join(", ")}`,
-      params.from ? `From: ${params.from}` : null,
-      params.cc?.length ? `Cc: ${params.cc.join(", ")}` : null,
-      params.bcc?.length ? `Bcc: ${params.bcc.join(", ")}` : null,
-      `Subject: ${encodedSubject}`,
+      ...commonLines,
       `Content-Type: multipart/mixed; boundary="${boundary}"`,
       "MIME-Version: 1.0",
       ...(params.threadingHeaders ?? []),
@@ -115,21 +122,17 @@ function buildAndEncodeEmail(params: {
       "",
       params.attachment.buffer.toString("base64"),
       `--${boundary}--`,
-    ].filter((line): line is string => line !== null);
+    ];
   } else {
     // Create the email message with proper headers and content.
     messageLines = [
-      `To: ${params.to.join(", ")}`,
-      params.from ? `From: ${params.from}` : null,
-      params.cc?.length ? `Cc: ${params.cc.join(", ")}` : null,
-      params.bcc?.length ? `Bcc: ${params.bcc.join(", ")}` : null,
-      `Subject: ${encodedSubject}`,
+      ...commonLines,
       `Content-Type: ${params.contentType}; charset=UTF-8`,
       "MIME-Version: 1.0",
       ...(params.threadingHeaders ?? []),
       "",
       params.body,
-    ].filter((line): line is string => line !== null);
+    ];
   }
 
   const message = messageLines.join("\r\n");
@@ -250,6 +253,46 @@ async function buildReplyContext(params: {
   });
 }
 
+async function fetchAttachment(
+  auth: ToolHandlerExtra["auth"],
+  attachmentFileId: string | undefined,
+  agentLoopContext: ToolHandlerExtra["agentLoopContext"]
+): Promise<
+  | Ok<{ buffer: Buffer; filename: string; contentType: string } | undefined>
+  | Err<MCPError>
+> {
+  if (!attachmentFileId) {
+    return new Ok(undefined);
+  }
+
+  if (!agentLoopContext) {
+    return new Err(new MCPError("No agent context available"));
+  }
+
+  const fileResult = await getFileFromConversationAttachment(
+    auth,
+    attachmentFileId,
+    agentLoopContext
+  );
+
+  if (fileResult.isErr()) {
+    return new Err(
+      new MCPError(`File not found: ${attachmentFileId}`, { tracked: false })
+    );
+  }
+
+  const { buffer, filename, contentType } = fileResult.value;
+
+  if (buffer.length > MAX_ATTACHMENT_SIZE_BYTES) {
+    return new Err(
+      new MCPError(
+        `Attachment file size exceeds the ${MAX_ATTACHMENT_SIZE_BYTES / (1024 * 1024)}MB limit.`
+      )
+    );
+  }
+  return new Ok({ buffer, filename, contentType });
+}
+
 const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
   get_drafts: async ({ q, pageToken }, { authInfo }) => {
     const accessToken = authInfo?.token;
@@ -354,43 +397,15 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         }
       }
     }
-
-    let fileBuffer: Buffer | undefined = undefined;
-    let filename: string | undefined = undefined;
-    let filetype: string | undefined = undefined;
-
-    if (attachmentFileId) {
-      if (!agentLoopContext) {
-        return new Err(new MCPError("No agent context available"));
-      }
-
-      const fileResult = await getFileFromConversationAttachment(
-        auth,
-        attachmentFileId,
-        agentLoopContext
-      );
-
-      if (fileResult.isErr()) {
-        return new Err(
-          new MCPError(`File not found: ${attachmentFileId}`, {
-            tracked: false,
-          })
-        );
-      }
-      ({
-        buffer: fileBuffer,
-        filename,
-        contentType: filetype,
-      } = fileResult.value);
-
-      if (fileBuffer.length > MAX_ATTACHMENT_SIZE_BYTES) {
-        return new Err(
-          new MCPError(
-            `Attachment file size exceeds the ${MAX_ATTACHMENT_SIZE_BYTES / (1024 * 1024)}MB limit.`
-          )
-        );
-      }
+    const attachmentResult = await fetchAttachment(
+      auth,
+      attachmentFileId,
+      agentLoopContext
+    );
+    if (attachmentResult.isErr()) {
+      return attachmentResult;
     }
+    const attachment = attachmentResult.value;
 
     let encodedMessage: string | undefined = undefined;
     let threadId: string | undefined = undefined;
@@ -437,13 +452,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         contentType: "text/html",
         body: fullBody,
         threadingHeaders,
-        attachment: fileBuffer
-          ? {
-              buffer: fileBuffer,
-              filename: filename ?? "",
-              contentType: filetype ?? "",
-            }
-          : undefined,
+        attachment,
       });
       if (encodedMessageResult.isErr()) {
         return encodedMessageResult;
@@ -480,13 +489,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         subject,
         contentType,
         body,
-        attachment: fileBuffer
-          ? {
-              buffer: fileBuffer,
-              filename: filename ?? "",
-              contentType: filetype ?? "",
-            }
-          : undefined,
+        attachment: attachment,
       });
 
       if (encodedMessageResult.isErr()) {
@@ -973,40 +976,15 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         }
       }
     }
-    let fileBuffer: Buffer | undefined = undefined;
-    let filename: string | undefined = undefined;
-    let filetype: string | undefined = undefined;
-
-    if (attachmentFileId) {
-      if (!agentLoopContext) {
-        return new Err(new MCPError("No agent context available"));
-      }
-
-      const fileResult = await getFileFromConversationAttachment(
-        auth,
-        attachmentFileId,
-        agentLoopContext
-      );
-      if (fileResult.isErr()) {
-        return new Err(
-          new MCPError(`File not found: ${attachmentFileId}`, {
-            tracked: false,
-          })
-        );
-      }
-      ({
-        buffer: fileBuffer,
-        filename,
-        contentType: filetype,
-      } = fileResult.value);
-      if (fileBuffer.length > MAX_ATTACHMENT_SIZE_BYTES) {
-        return new Err(
-          new MCPError(
-            `Attachment file size exceeds the ${MAX_ATTACHMENT_SIZE_BYTES / (1024 * 1024)}MB limit.`
-          )
-        );
-      }
+    const attachmentResult = await fetchAttachment(
+      auth,
+      attachmentFileId,
+      agentLoopContext
+    );
+    if (attachmentResult.isErr()) {
+      return attachmentResult;
     }
+    const attachment = attachmentResult.value;
 
     let encodedMessage: string | undefined = undefined;
     let threadId: string | undefined = undefined;
@@ -1054,13 +1032,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         contentType: "text/html",
         body: fullBody,
         threadingHeaders,
-        attachment: fileBuffer
-          ? {
-              buffer: fileBuffer,
-              filename: filename ?? "",
-              contentType: filetype ?? "",
-            }
-          : undefined,
+        attachment: attachment,
       });
 
       if (encodedMessageResult.isErr()) {
@@ -1098,13 +1070,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         subject,
         contentType,
         body,
-        attachment: fileBuffer
-          ? {
-              buffer: fileBuffer,
-              filename: filename ?? "",
-              contentType: filetype ?? "",
-            }
-          : undefined,
+        attachment: attachment,
       });
 
       if (encodedMessageResult.isErr()) {

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -69,11 +69,11 @@ function buildAndEncodeEmail(params: {
   contentType: string;
   body: string;
   threadingHeaders?: string[];
-  attachment?: {
+  attachment: {
     buffer: Buffer;
     filename: string;
     contentType: string;
-  };
+  } | null;
 }): Err<MCPError> | Ok<string> {
   const encodedSubject = encodeSubject(params.subject);
 
@@ -258,11 +258,11 @@ async function fetchAttachment(
   attachmentFileId: string | undefined,
   agentLoopContext: ToolHandlerExtra["agentLoopContext"]
 ): Promise<
-  | Ok<{ buffer: Buffer; filename: string; contentType: string } | undefined>
+  | Ok<{ buffer: Buffer; filename: string; contentType: string } | null>
   | Err<MCPError>
 > {
   if (!attachmentFileId) {
-    return new Ok(undefined);
+    return new Ok(null);
   }
 
   if (!agentLoopContext) {
@@ -452,7 +452,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         contentType: "text/html",
         body: fullBody,
         threadingHeaders,
-        attachment,
+        attachment, 
       });
       if (encodedMessageResult.isErr()) {
         return encodedMessageResult;
@@ -489,7 +489,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         subject,
         contentType,
         body,
-        attachment: attachment,
+        attachment,
       });
 
       if (encodedMessageResult.isErr()) {
@@ -1032,7 +1032,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         contentType: "text/html",
         body: fullBody,
         threadingHeaders,
-        attachment: attachment,
+        attachment,
       });
 
       if (encodedMessageResult.isErr()) {
@@ -1070,7 +1070,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         subject,
         contentType,
         body,
-        attachment: attachment,
+        attachment,
       });
 
       if (encodedMessageResult.isErr()) {

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -89,9 +89,9 @@ function buildAndEncodeEmail(params: {
 
   if (params.attachment) {
     const boundary = crypto.randomUUID().replace(/-/g, "");
-    const safeContentType = params.attachment.contentType
-      .replace(/[\r\n]/g, "")
-      .trim() || "application/octet-stream";
+    const safeContentType =
+      params.attachment.contentType.replace(/[\r\n]/g, "").trim() ||
+      "application/octet-stream";
     // Create the email message with proper headers, content and attachment file
     messageLines = [
       `To: ${params.to.join(", ")}`,

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -452,7 +452,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         contentType: "text/html",
         body: fullBody,
         threadingHeaders,
-        attachment, 
+        attachment,
       });
       if (encodedMessageResult.isErr()) {
         return encodedMessageResult;

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -88,6 +88,10 @@ function buildAndEncodeEmail(params: {
   let messageLines: string[] = [];
 
   if (params.attachment) {
+    const boundary = crypto.randomUUID().replace(/-/g, "");
+    const safeContentType = params.attachment.contentType
+      .replace(/[\r\n]/g, "")
+      .trim() || "application/octet-stream";
     // Create the email message with proper headers, content and attachment file
     messageLines = [
       `To: ${params.to.join(", ")}`,
@@ -95,22 +99,22 @@ function buildAndEncodeEmail(params: {
       params.cc?.length ? `Cc: ${params.cc.join(", ")}` : null,
       params.bcc?.length ? `Bcc: ${params.bcc.join(", ")}` : null,
       `Subject: ${encodedSubject}`,
-      `Content-Type: multipart/mixed; boundary="boundary123"`,
+      `Content-Type: multipart/mixed; boundary="${boundary}"`,
       "MIME-Version: 1.0",
       ...(params.threadingHeaders ?? []),
       "",
-      "--boundary123",
+      `--${boundary}`,
       `Content-Type: ${params.contentType}; charset=UTF-8`,
       "",
       params.body,
       "",
-      "--boundary123",
-      `Content-Type: ${params.attachment.contentType}; name="${params.attachment.filename}"`,
+      `--${boundary}`,
+      `Content-Type: ${safeContentType}; name="${params.attachment.filename}"`,
       `Content-Disposition: attachment; filename="${params.attachment.filename}"`,
       "Content-Transfer-Encoding: base64",
       "",
       params.attachment.buffer.toString("base64"),
-      "--boundary123--",
+      `--${boundary}--`,
     ].filter((line): line is string => line !== null);
   } else {
     // Create the email message with proper headers and content.
@@ -344,7 +348,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         if (!aliasConfigured) {
           return new Err(
             new MCPError(
-              `"${from}" is not configured as a send-as alias in Gmail settings. The email was not sent.`
+              `"${from}" is not configured as a send-as alias in Gmail settings. The draft was not created.`
             )
           );
         }
@@ -472,10 +476,10 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         to,
         cc: cc ?? null,
         bcc: bcc ?? null,
+        from,
         subject,
         contentType,
         body,
-        threadingHeaders: [],
         attachment: fileBuffer
           ? {
               buffer: fileBuffer,
@@ -1094,7 +1098,6 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         subject,
         contentType,
         body,
-        threadingHeaders: [],
         attachment: fileBuffer
           ? {
               buffer: fileBuffer,

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -6,7 +6,7 @@ import {
   extractTextFromBuffer,
   processAttachment,
 } from "@app/lib/actions/mcp_internal_actions/utils/attachment_processing";
-import { sanitizeFilename } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
+import { sanitizeFilename, getFileFromConversationAttachment } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import type {
   GmailMessage,
   MessageDetail,
@@ -25,6 +25,7 @@ import {
   isGmailMessage,
   MESSAGES_MAX_RESULTS,
   MESSAGES_WITH_ATTACHMENTS_MAX_RESULTS,
+  MAX_ATTACHMENT_SIZE_BYTES
 } from "@app/lib/api/actions/servers/gmail/helpers";
 import { GMAIL_TOOLS_METADATA } from "@app/lib/api/actions/servers/gmail/metadata";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -62,7 +63,13 @@ function buildAndEncodeEmail(params: {
   contentType: string;
   body: string;
   threadingHeaders?: string[];
-}): Err<MCPError> | Ok<string> {
+  attachment? : {
+    buffer: Buffer
+    filename : string
+    contentType: string
+  };
+}
+): Err<MCPError> | Ok<string> {
   const encodedSubject = encodeSubject(params.subject);
 
   // Validate email addresses to prevent header injection
@@ -76,19 +83,51 @@ function buildAndEncodeEmail(params: {
     return validationError;
   }
 
-  // Create the email message with proper headers and content.
-  const messageLines = [
-    `To: ${params.to.join(", ")}`,
-    params.from ? `From: ${params.from}` : null,
-    params.cc?.length ? `Cc: ${params.cc.join(", ")}` : null,
-    params.bcc?.length ? `Bcc: ${params.bcc.join(", ")}` : null,
-    `Subject: ${encodedSubject}`,
-    `Content-Type: ${params.contentType}; charset=UTF-8`,
-    "MIME-Version: 1.0",
-    ...(params.threadingHeaders ?? []),
-    "",
-    params.body,
-  ].filter((line): line is string => line !== null);
+  let messageLines:  string[] = []
+
+  if (params.attachment) {
+    // Create the email message with proper headers, content and attachment file
+    messageLines = [
+
+      `To: ${params.to.join(", ")}`,
+      params.from ? `From: ${params.from}` : null,
+      params.cc?.length ? `Cc: ${params.cc.join(", ")}` : null,
+      params.bcc?.length ? `Bcc: ${params.bcc.join(", ")}` : null,
+      `Subject: ${encodedSubject}`,
+      `Content-Type: multipart/mixed; boundary="boundary123"`,
+      "MIME-Version: 1.0",
+      ...(params.threadingHeaders ?? []),
+      "",
+      "--boundary123",
+      `Content-Type: ${params.contentType}; charset=UTF-8`,
+      "",
+      params.body,
+      "",
+      "--boundary123",
+      `Content-Type: ${params.attachment.contentType}; name="${params.attachment.filename}"`,
+      `Content-Disposition: attachment; filename="${params.attachment.filename}"`,
+      "Content-Transfer-Encoding: base64",
+      "",
+      params.attachment.buffer.toString("base64"),
+      "--boundary123--",
+    ].filter((line): line is string => line !== null);
+  }
+
+  else {
+    // Create the email message with proper headers and content.
+    messageLines = [
+      `To: ${params.to.join(", ")}`,
+      params.from ? `From: ${params.from}` : null,
+      params.cc?.length ? `Cc: ${params.cc.join(", ")}` : null,
+      params.bcc?.length ? `Bcc: ${params.bcc.join(", ")}` : null,
+      `Subject: ${encodedSubject}`,
+      `Content-Type: ${params.contentType}; charset=UTF-8`,
+      "MIME-Version: 1.0",
+      ...(params.threadingHeaders ?? []),
+      "",
+      params.body,
+    ].filter((line): line is string => line !== null);
+    }
 
   const message = messageLines.join("\r\n");
   const encodedMessage = encodeMessageForGmail(message);
@@ -270,8 +309,8 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
   },
 
   create_draft: async (
-    { to, cc, bcc, from, subject, contentType, body, replyToMessageId },
-    { authInfo }
+    { to, cc, bcc, from, subject, contentType, body, replyToMessageId, attachmentFileId },
+    { authInfo, auth, agentLoopContext}
   ) => {
     const accessToken = authInfo?.token;
     if (!accessToken) {
@@ -303,6 +342,32 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       }
     }
 
+    let fileBuffer: Buffer | undefined = undefined;
+    let filename: string | undefined = undefined;
+    let filetype: string | undefined = undefined;
+  
+    if (attachmentFileId) {
+
+      if (!agentLoopContext) {
+        return new Err(new MCPError("No agent context available"));
+      }
+
+      const fileResult = await getFileFromConversationAttachment(
+        auth,
+        attachmentFileId,
+        agentLoopContext
+      );
+  
+      if (fileResult.isErr()) {
+        return new Err(new MCPError(`File not found: ${attachmentFileId}`, { tracked: false }));
+      }
+      ({ buffer: fileBuffer, filename, contentType: filetype } = fileResult.value);
+      
+      if (fileBuffer.length > MAX_ATTACHMENT_SIZE_BYTES) {
+        return new Err(new MCPError(`Attachment file size exceeds the ${MAX_ATTACHMENT_SIZE_BYTES / (1024 * 1024)}MB limit.`))
+      }   
+    }
+
     let encodedMessage: string | undefined = undefined;
     let threadId: string | undefined = undefined;
 
@@ -314,7 +379,6 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
           )
         );
       }
-
       const replyContext = await buildReplyContext({
         replyToMessageId,
         accessToken,
@@ -349,12 +413,14 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         contentType: "text/html",
         body: fullBody,
         threadingHeaders,
+        attachment: fileBuffer ? { buffer: fileBuffer, filename: filename ?? "", contentType: filetype ?? "" } : undefined,
       });
       if (encodedMessageResult.isErr()) {
         return encodedMessageResult;
       }
       encodedMessage = encodedMessageResult.value;
     } else {
+
       if (!contentType) {
         return new Err(
           new MCPError(
@@ -362,6 +428,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
           )
         );
       }
+
       if (!subject?.trim()) {
         return new Err(
           new MCPError("Subject is required when not replying to a message.")
@@ -383,6 +450,9 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         subject,
         contentType,
         body,
+        threadingHeaders: [],
+        attachment: fileBuffer ? { buffer: fileBuffer, filename: filename ?? "", contentType: filetype ?? "" } : undefined,
+
       });
 
       if (encodedMessageResult.isErr()) {
@@ -828,8 +898,8 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
   },
 
   send_mail: async (
-    { to, cc, bcc, from, subject, contentType, body, replyToMessageId },
-    { authInfo }
+    { to, cc, bcc, from, subject, contentType, body, replyToMessageId, attachmentFileId },
+    { authInfo, auth, agentLoopContext }
   ) => {
     const accessToken = authInfo?.token;
     if (!accessToken) {
@@ -853,25 +923,48 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         if (!aliasConfigured) {
           return new Err(
             new MCPError(
-              `"${from}" is not configured as a send-as alias in Gmail settings. The email was not sent.`
+              `"${from}" is not configured as a send-as alias in Gmail settings. 
+              The email was not sent.`
             )
           );
         }
       }
+    }
+    let fileBuffer: Buffer | undefined = undefined;
+    let filename: string | undefined = undefined;
+    let filetype: string | undefined = undefined;
+
+    if (attachmentFileId) {
+
+    if (!agentLoopContext) {
+      return new Err(new MCPError("No agent context available"));
+    }
+
+    const fileResult = await getFileFromConversationAttachment(
+      auth,
+      attachmentFileId,
+      agentLoopContext
+    );
+    if (fileResult.isErr()) {
+      return new Err(new MCPError(`File not found: ${attachmentFileId}`, { tracked: false }));
+    }
+    ({ buffer: fileBuffer, filename, contentType: filetype } = fileResult.value);
+    if (fileBuffer.length > MAX_ATTACHMENT_SIZE_BYTES) {
+      return new Err(new MCPError(`Attachment file size exceeds the ${MAX_ATTACHMENT_SIZE_BYTES / (1024 * 1024)}MB limit.`));
+    }
     }
 
     let encodedMessage: string | undefined = undefined;
     let threadId: string | undefined = undefined;
 
     if (replyToMessageId) {
+
       if (contentType) {
         return new Err(
           new MCPError(
-            "contentType must be omitted when replying to a message."
-          )
+            "contentType must be omitted when replying to a message.")
         );
       }
-
       const replyContext = await buildReplyContext({
         replyToMessageId,
         accessToken,
@@ -880,6 +973,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         bcc: bcc ?? null,
         body,
         subject,
+        
       });
       if (replyContext.isErr()) {
         return replyContext;
@@ -907,6 +1001,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         contentType: "text/html",
         body: fullBody,
         threadingHeaders,
+        attachment: fileBuffer ? { buffer: fileBuffer, filename: filename ?? "", contentType: filetype ?? "" } : undefined,
       });
 
       if (encodedMessageResult.isErr()) {
@@ -921,11 +1016,13 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
           )
         );
       }
+
       if (!subject?.trim()) {
         return new Err(
           new MCPError("Subject is required when not replying to a message.")
         );
       }
+
       if (!to?.length) {
         return new Err(
           new MCPError(
@@ -942,6 +1039,8 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         subject,
         contentType,
         body,
+        threadingHeaders: [],
+        attachment: fileBuffer ? { buffer: fileBuffer, filename: filename ?? "", contentType: filetype ?? "" } : undefined,
       });
 
       if (encodedMessageResult.isErr()) {

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -6,7 +6,10 @@ import {
   extractTextFromBuffer,
   processAttachment,
 } from "@app/lib/actions/mcp_internal_actions/utils/attachment_processing";
-import { sanitizeFilename, getFileFromConversationAttachment } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
+import {
+  getFileFromConversationAttachment,
+  sanitizeFilename,
+} from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import type {
   GmailMessage,
   MessageDetail,
@@ -23,9 +26,9 @@ import {
   getErrorText,
   getHeaderValue,
   isGmailMessage,
+  MAX_ATTACHMENT_SIZE_BYTES,
   MESSAGES_MAX_RESULTS,
   MESSAGES_WITH_ATTACHMENTS_MAX_RESULTS,
-  MAX_ATTACHMENT_SIZE_BYTES
 } from "@app/lib/api/actions/servers/gmail/helpers";
 import { GMAIL_TOOLS_METADATA } from "@app/lib/api/actions/servers/gmail/metadata";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -63,13 +66,12 @@ function buildAndEncodeEmail(params: {
   contentType: string;
   body: string;
   threadingHeaders?: string[];
-  attachment? : {
-    buffer: Buffer
-    filename : string
-    contentType: string
+  attachment?: {
+    buffer: Buffer;
+    filename: string;
+    contentType: string;
   };
-}
-): Err<MCPError> | Ok<string> {
+}): Err<MCPError> | Ok<string> {
   const encodedSubject = encodeSubject(params.subject);
 
   // Validate email addresses to prevent header injection
@@ -83,12 +85,11 @@ function buildAndEncodeEmail(params: {
     return validationError;
   }
 
-  let messageLines:  string[] = []
+  let messageLines: string[] = [];
 
   if (params.attachment) {
     // Create the email message with proper headers, content and attachment file
     messageLines = [
-
       `To: ${params.to.join(", ")}`,
       params.from ? `From: ${params.from}` : null,
       params.cc?.length ? `Cc: ${params.cc.join(", ")}` : null,
@@ -111,9 +112,7 @@ function buildAndEncodeEmail(params: {
       params.attachment.buffer.toString("base64"),
       "--boundary123--",
     ].filter((line): line is string => line !== null);
-  }
-
-  else {
+  } else {
     // Create the email message with proper headers and content.
     messageLines = [
       `To: ${params.to.join(", ")}`,
@@ -127,7 +126,7 @@ function buildAndEncodeEmail(params: {
       "",
       params.body,
     ].filter((line): line is string => line !== null);
-    }
+  }
 
   const message = messageLines.join("\r\n");
   const encodedMessage = encodeMessageForGmail(message);
@@ -309,8 +308,18 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
   },
 
   create_draft: async (
-    { to, cc, bcc, from, subject, contentType, body, replyToMessageId, attachmentFileId },
-    { authInfo, auth, agentLoopContext}
+    {
+      to,
+      cc,
+      bcc,
+      from,
+      subject,
+      contentType,
+      body,
+      replyToMessageId,
+      attachmentFileId,
+    },
+    { authInfo, auth, agentLoopContext }
   ) => {
     const accessToken = authInfo?.token;
     if (!accessToken) {
@@ -345,9 +354,8 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     let fileBuffer: Buffer | undefined = undefined;
     let filename: string | undefined = undefined;
     let filetype: string | undefined = undefined;
-  
-    if (attachmentFileId) {
 
+    if (attachmentFileId) {
       if (!agentLoopContext) {
         return new Err(new MCPError("No agent context available"));
       }
@@ -357,15 +365,27 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         attachmentFileId,
         agentLoopContext
       );
-  
+
       if (fileResult.isErr()) {
-        return new Err(new MCPError(`File not found: ${attachmentFileId}`, { tracked: false }));
+        return new Err(
+          new MCPError(`File not found: ${attachmentFileId}`, {
+            tracked: false,
+          })
+        );
       }
-      ({ buffer: fileBuffer, filename, contentType: filetype } = fileResult.value);
-      
+      ({
+        buffer: fileBuffer,
+        filename,
+        contentType: filetype,
+      } = fileResult.value);
+
       if (fileBuffer.length > MAX_ATTACHMENT_SIZE_BYTES) {
-        return new Err(new MCPError(`Attachment file size exceeds the ${MAX_ATTACHMENT_SIZE_BYTES / (1024 * 1024)}MB limit.`))
-      }   
+        return new Err(
+          new MCPError(
+            `Attachment file size exceeds the ${MAX_ATTACHMENT_SIZE_BYTES / (1024 * 1024)}MB limit.`
+          )
+        );
+      }
     }
 
     let encodedMessage: string | undefined = undefined;
@@ -413,14 +433,19 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         contentType: "text/html",
         body: fullBody,
         threadingHeaders,
-        attachment: fileBuffer ? { buffer: fileBuffer, filename: filename ?? "", contentType: filetype ?? "" } : undefined,
+        attachment: fileBuffer
+          ? {
+              buffer: fileBuffer,
+              filename: filename ?? "",
+              contentType: filetype ?? "",
+            }
+          : undefined,
       });
       if (encodedMessageResult.isErr()) {
         return encodedMessageResult;
       }
       encodedMessage = encodedMessageResult.value;
     } else {
-
       if (!contentType) {
         return new Err(
           new MCPError(
@@ -451,8 +476,13 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         contentType,
         body,
         threadingHeaders: [],
-        attachment: fileBuffer ? { buffer: fileBuffer, filename: filename ?? "", contentType: filetype ?? "" } : undefined,
-
+        attachment: fileBuffer
+          ? {
+              buffer: fileBuffer,
+              filename: filename ?? "",
+              contentType: filetype ?? "",
+            }
+          : undefined,
       });
 
       if (encodedMessageResult.isErr()) {
@@ -898,7 +928,17 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
   },
 
   send_mail: async (
-    { to, cc, bcc, from, subject, contentType, body, replyToMessageId, attachmentFileId },
+    {
+      to,
+      cc,
+      bcc,
+      from,
+      subject,
+      contentType,
+      body,
+      replyToMessageId,
+      attachmentFileId,
+    },
     { authInfo, auth, agentLoopContext }
   ) => {
     const accessToken = authInfo?.token;
@@ -923,8 +963,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         if (!aliasConfigured) {
           return new Err(
             new MCPError(
-              `"${from}" is not configured as a send-as alias in Gmail settings. 
-              The email was not sent.`
+              `"${from}" is not configured as a send-as alias in Gmail settings. The email was not sent.`
             )
           );
         }
@@ -935,34 +974,45 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     let filetype: string | undefined = undefined;
 
     if (attachmentFileId) {
+      if (!agentLoopContext) {
+        return new Err(new MCPError("No agent context available"));
+      }
 
-    if (!agentLoopContext) {
-      return new Err(new MCPError("No agent context available"));
-    }
-
-    const fileResult = await getFileFromConversationAttachment(
-      auth,
-      attachmentFileId,
-      agentLoopContext
-    );
-    if (fileResult.isErr()) {
-      return new Err(new MCPError(`File not found: ${attachmentFileId}`, { tracked: false }));
-    }
-    ({ buffer: fileBuffer, filename, contentType: filetype } = fileResult.value);
-    if (fileBuffer.length > MAX_ATTACHMENT_SIZE_BYTES) {
-      return new Err(new MCPError(`Attachment file size exceeds the ${MAX_ATTACHMENT_SIZE_BYTES / (1024 * 1024)}MB limit.`));
-    }
+      const fileResult = await getFileFromConversationAttachment(
+        auth,
+        attachmentFileId,
+        agentLoopContext
+      );
+      if (fileResult.isErr()) {
+        return new Err(
+          new MCPError(`File not found: ${attachmentFileId}`, {
+            tracked: false,
+          })
+        );
+      }
+      ({
+        buffer: fileBuffer,
+        filename,
+        contentType: filetype,
+      } = fileResult.value);
+      if (fileBuffer.length > MAX_ATTACHMENT_SIZE_BYTES) {
+        return new Err(
+          new MCPError(
+            `Attachment file size exceeds the ${MAX_ATTACHMENT_SIZE_BYTES / (1024 * 1024)}MB limit.`
+          )
+        );
+      }
     }
 
     let encodedMessage: string | undefined = undefined;
     let threadId: string | undefined = undefined;
 
     if (replyToMessageId) {
-
       if (contentType) {
         return new Err(
           new MCPError(
-            "contentType must be omitted when replying to a message.")
+            "contentType must be omitted when replying to a message."
+          )
         );
       }
       const replyContext = await buildReplyContext({
@@ -973,7 +1023,6 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         bcc: bcc ?? null,
         body,
         subject,
-        
       });
       if (replyContext.isErr()) {
         return replyContext;
@@ -1001,7 +1050,13 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         contentType: "text/html",
         body: fullBody,
         threadingHeaders,
-        attachment: fileBuffer ? { buffer: fileBuffer, filename: filename ?? "", contentType: filetype ?? "" } : undefined,
+        attachment: fileBuffer
+          ? {
+              buffer: fileBuffer,
+              filename: filename ?? "",
+              contentType: filetype ?? "",
+            }
+          : undefined,
       });
 
       if (encodedMessageResult.isErr()) {
@@ -1040,7 +1095,13 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         contentType,
         body,
         threadingHeaders: [],
-        attachment: fileBuffer ? { buffer: fileBuffer, filename: filename ?? "", contentType: filetype ?? "" } : undefined,
+        attachment: fileBuffer
+          ? {
+              buffer: fileBuffer,
+              filename: filename ?? "",
+              contentType: filetype ?? "",
+            }
+          : undefined,
       });
 
       if (encodedMessageResult.isErr()) {


### PR DESCRIPTION
## Description
Add support for attaching conversation files to send_mail and create_draft in the Gmail MCP server.

Both tools now accept an optional attachmentFileId parameter. When provided, the file is fetched from the current conversation, validated against a 5 MB size limit, and included as a MIME multipart attachment in the outgoing email or draft. Emails without an attachment continue to use the existing single-part encoding path.

## Tests
Tested manually: sent an email with an attachment and created a draft with an attachment from a Dust conversation. Verified the attachment appears correctly in Gmail. Also verified that the existing send/draft flows (without attachment, with reply) are unaffected.

## Risk
Low. The attachmentFileId parameter is optional and existing behavior is preserved when it's omitted. The only new code path is the file fetch + size validation + MIME multipart encoding, which is already used by other MCP servers (Jira, Slack, Outlook).

## Deploy Plan
Standard deploy, no specific ordering required.
