### PR TITLE
fix(assistant): use correct prop name for useTranscribingProgress

### DIFF
--- a/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
@@ -81,7 +81,7 @@ export function AttachmentCitation({
       : undefined;
 
   const transcriptionProgress = useTranscribingProgress({
-    isActive: isTranscribingAudio,
+    isTranscriptingInProgress: isTranscribingAudio,
     sizeBytes: audioSizeBytes ?? 0,
   });
   const loadingLabel =


### PR DESCRIPTION
## Description

Fixes a TypeScript error (TS2353) in `AttachmentCitation`. The `useTranscribingProgress` hook expects an `isTranscriptingInProgress` prop, but the call site was passing `isActive`, which is not part of the hook's input type. Renamed the property at the call site to match the hook signature.

## Tests

Type-check passes for the touched file (the remaining `tsgo` errors are pre-existing Anthropic SDK type mismatches unrelated to this change).

## Risk

None — single-line type fix with no behavioral change.

## Deploy Plan

Standard deploy, no special steps.
