### PR TITLE
[front] Hide legacy Skill Builder tools section

### DIFF
--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -82,6 +82,7 @@ export default function SkillBuilder({
 
   const hasSelfImprovingSkills =
     hasFeature("reinforced_agents") && hasFeature("reinforcement_ui");
+  const enableSkillReferences = hasFeature("nested_skills");
 
   const { suggestions } = useSkillSuggestions({
     skillId: skill?.sId ?? null,
@@ -213,7 +214,7 @@ export default function SkillBuilder({
               size="lg"
             >
               A customized version of {extendedSkill.name} with your own
-              guidelines and tools.
+              guidelines and {enableSkillReferences ? "capabilities" : "tools"}.
             </ContentMessage>
           )}
           {skill?.status === "suggested" && (
@@ -234,7 +235,9 @@ export default function SkillBuilder({
           <SkillBuilderAgentFacingDescriptionSection />
           <SkillBuilderInstructionsSection />
           {hasFeature("sandbox_tools") && <SkillBuilderFilesSection />}
-          <SkillBuilderToolsSection extendedSkill={extendedSkill} />
+          {!enableSkillReferences && (
+            <SkillBuilderToolsSection extendedSkill={extendedSkill} />
+          )}
           <SkillBuilderSettingsOrComparisonFooter
             skill={skill}
             hasSelfImprovingSkills={hasSelfImprovingSkills}


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/26488.

Hides the legacy Skill Builder Tools section when the nested skill references flow is enabled. Capabilities are now attached through the instructions dropdown / Attach capabilities entrypoint, while the old section remains available for non-flagged workspaces.

Capability removal is handled separately in https://github.com/dust-tt/dust/pull/26586 and should merge before this PR.

## Risks
Blast radius: Skill Builder layout for workspaces with nested skill references enabled.
Risk: low

## Deploy Plan
- pmrr
- deploy front