### PR TITLE
Allow enabling custom seats

### DIFF
--- a/front/components/poke/shadcn/ui/form/fields.tsx
+++ b/front/components/poke/shadcn/ui/form/fields.tsx
@@ -106,17 +106,7 @@ export function SelectField<T extends FieldValues>({
   );
 }
 
-export function InputField<T extends FieldValues>({
-  control,
-  name,
-  title,
-  type,
-  placeholder,
-  min,
-  step,
-  readOnly,
-  transformValue,
-}: {
+interface InputFieldProps<T extends FieldValues> {
   control: Control<T>;
   name: Path<T>;
   title?: string;
@@ -127,9 +117,23 @@ export function InputField<T extends FieldValues>({
   /** Native `step` attribute, useful for `number` and `datetime-local`. */
   step?: number | string;
   readOnly?: boolean;
+  disabled?: boolean;
   /** Optional transform applied to the raw string value before updating the form. */
   transformValue?: (value: string) => string | number;
-}) {
+}
+
+export function InputField<T extends FieldValues>({
+  control,
+  name,
+  title,
+  type,
+  placeholder,
+  min,
+  step,
+  readOnly,
+  disabled,
+  transformValue,
+}: InputFieldProps<T>) {
   return (
     <PokeFormField
       control={control}
@@ -162,6 +166,7 @@ export function InputField<T extends FieldValues>({
                 field.onChange(e.target.value);
               }}
               readOnly={readOnly}
+              disabled={disabled}
             />
           </PokeFormControl>
           <PokeFormMessage />

--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -25,6 +25,7 @@ import { isCreditPricedPlan } from "@app/types/plan";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Button,
+  Checkbox,
   Dialog,
   DialogContainer,
   DialogContent,
@@ -86,15 +87,18 @@ const SwitchContractFormSchema = z.object({
     .number()
     .min(0, "Invoice amount must be zero or more")
     .optional(),
-  // Per-seat-type settings, keyed by seat type. Only the seats of the selected
-  // package are shown/submitted. `minSeats` is the billing floor (0 = none);
-  // `rate` is the per-seat rate, prefilled from the package override default;
-  // `commitmentPrice` (optional) creates a prepaid commit of `minSeats * rate`
-  // invoiced at that price.
+  // Per-seat-type settings, keyed by seat type. Every seat type the selected
+  // package knows about is shown; only `selected` ones are submitted. `selected`
+  // is pre-checked for the seats the package entitles by default, and can be
+  // toggled to opt into entitling additional seats. `minSeats` is the billing
+  // floor (0 = none); `rate` is the per-seat rate, prefilled from the package
+  // override default; `commitmentPrice` (optional) creates a prepaid commit of
+  // `minSeats * rate` invoiced at that price.
   seats: z
     .record(
       z.string(),
       z.object({
+        selected: z.boolean().default(false),
         minSeats: z.number().int().min(0),
         rate: z.number().min(0),
         commitmentPrice: z.number().min(0).optional(),
@@ -241,19 +245,24 @@ export default function SwitchContractDialog({
     [selectedPackage]
   );
 
-  // Reset the seat settings to the seats of the newly selected package: min
-  // seats defaults to 0, the rate is prefilled from the package override
-  // default. The default is in Metronome's fiat unit (cents for USD, whole
-  // units for EUR); the dialog works in major units (dollars/euros), so convert
-  // for display. Avoids stale values leaking across package selections.
+  // Reset the seat settings to the seats of the newly selected package: seats
+  // the package entitles are pre-selected, the rest are shown unchecked for the
+  // operator to opt into. Min seats defaults to 0, the rate is prefilled from
+  // the package override default. The default is in Metronome's fiat unit (cents
+  // for USD, whole units for EUR); the dialog works in major units
+  // (dollars/euros), so convert for display. Avoids stale values leaking across
+  // package selections.
   useEffect(() => {
-    const next: Record<string, { minSeats: number; rate: number }> = {};
+    const next: Record<
+      string,
+      { selected: boolean; minSeats: number; rate: number }
+    > = {};
     for (const seat of selectedSeats) {
       const rate =
         seat.defaultRate != null && resolvedCurrency
           ? amountCents(seat.defaultRate, resolvedCurrency) / 100
           : (seat.defaultRate ?? 0);
-      next[seat.seatType] = { minSeats: 0, rate };
+      next[seat.seatType] = { selected: seat.entitled, minSeats: 0, rate };
     }
     form.setValue("seats", next);
   }, [selectedSeats, form, resolvedCurrency]);
@@ -356,6 +365,7 @@ export default function SwitchContractDialog({
 
   const showInitialCredits = form.watch("showInitialCredits");
   const stripeCollectionMethod = form.watch("stripeCollectionMethod");
+  const watchedSeats = form.watch("seats");
 
   const onSubmit = useCallback(
     (values: SwitchContractFormValues) => {
@@ -411,11 +421,15 @@ export default function SwitchContractDialog({
           cleaned.startingAt = new Date(values.startingAt).toISOString();
         }
       }
-      // Seats: only the selected package's seat types. Include a seat when it
-      // has a positive floor and/or a positive commitment price.
+      // Seats: every seat the package knows about, each carrying its `selected`
+      // state, so the server can entitle checked seats and disable unchecked
+      // ones the package would otherwise sell. Entitled-by-default seats are
+      // pre-checked. A checked seat the package does not entitle requires a
+      // positive rate (except the free seat, which may be entitled at rate 0).
       const seats: SwitchContractBodyInput["seats"] = [];
-      for (const { seatType, defaultRate } of selectedSeats) {
+      for (const { seatType, entitled } of selectedSeats) {
         const entry = values.seats?.[seatType];
+        const selected = entry?.selected ?? false;
         const minSeats = Number.isFinite(entry?.minSeats)
           ? (entry?.minSeats ?? 0)
           : 0;
@@ -426,17 +440,14 @@ export default function SwitchContractDialog({
           entry.commitmentPrice > 0
             ? entry.commitmentPrice
             : undefined;
-        // Include a seat when it has a floor, a commitment, or a changed rate
-        // (the rate override only fires when it differs from the default). The
-        // form rate is in major units; convert the native default to compare.
-        const defaultRateMajor =
-          defaultRate != null && resolvedCurrency
-            ? amountCents(defaultRate, resolvedCurrency) / 100
-            : (defaultRate ?? 0);
-        const rateChanged = rate > 0 && rate !== defaultRateMajor;
-        if (minSeats > 0 || commitmentPrice !== undefined || rateChanged) {
-          seats.push({ seatType, minSeats, rate, commitmentPrice });
+        if (selected && !entitled && seatType !== "free" && !(rate > 0)) {
+          setError(
+            `Seat "${seatType}" is not entitled by the selected package and ` +
+              "requires a rate greater than 0 to entitle it."
+          );
+          return;
         }
+        seats.push({ seatType, selected, minSeats, rate, commitmentPrice });
       }
       if (seats.length > 0) {
         cleaned.seats = seats;
@@ -478,7 +489,6 @@ export default function SwitchContractDialog({
       selectedTier,
       selectedSeats,
       retroactiveFirstOfMonthISO,
-      resolvedCurrency,
     ]
   );
 
@@ -650,48 +660,77 @@ export default function SwitchContractDialog({
                         ? `(rate & price in ${resolvedCurrency.toUpperCase()})`
                         : ""}
                     </Label>
-                    {selectedSeats.map(({ seatType }) => (
-                      <div key={seatType} className="flex items-end gap-3">
-                        <div className="w-24 shrink-0 pb-2 font-mono text-sm">
-                          {seatType}
+                    <div className="text-xs text-muted-foreground">
+                      Checked seats are entitled on the new contract. Seats the
+                      package does not entitle by default are unchecked — check
+                      one to entitle it (a non-zero rate is required, except for
+                      the free seat).
+                    </div>
+                    {selectedSeats.map(({ seatType, entitled }) => {
+                      const isSelected =
+                        watchedSeats?.[seatType]?.selected ?? false;
+                      return (
+                        <div key={seatType} className="flex items-end gap-3">
+                          <div className="flex w-32 shrink-0 items-center gap-2 pb-2">
+                            <Checkbox
+                              checked={isSelected}
+                              onCheckedChange={(checked) =>
+                                form.setValue(
+                                  `seats.${seatType}.selected`,
+                                  checked === true
+                                )
+                              }
+                            />
+                            <span className="font-mono text-sm">
+                              {seatType}
+                              {!entitled && (
+                                <span className="ml-1 text-muted-foreground">
+                                  *
+                                </span>
+                              )}
+                            </span>
+                          </div>
+                          <div className="flex-1">
+                            <InputField
+                              control={form.control}
+                              name={`seats.${seatType}.minSeats`}
+                              title="Min seats"
+                              type="number"
+                              placeholder="0"
+                              disabled={!isSelected}
+                            />
+                          </div>
+                          <div className="flex-1">
+                            <InputField
+                              control={form.control}
+                              name={`seats.${seatType}.rate`}
+                              title={
+                                resolvedCurrency
+                                  ? `Seat rate (${resolvedCurrency.toUpperCase()})`
+                                  : "Seat rate"
+                              }
+                              type="number"
+                              placeholder="0"
+                              disabled={!isSelected}
+                            />
+                          </div>
+                          <div className="flex-1">
+                            <InputField
+                              control={form.control}
+                              name={`seats.${seatType}.commitmentPrice`}
+                              title={
+                                resolvedCurrency
+                                  ? `Commitment price (${resolvedCurrency.toUpperCase()})`
+                                  : "Commitment price"
+                              }
+                              type="number"
+                              placeholder="optional"
+                              disabled={!isSelected}
+                            />
+                          </div>
                         </div>
-                        <div className="flex-1">
-                          <InputField
-                            control={form.control}
-                            name={`seats.${seatType}.minSeats`}
-                            title="Min seats"
-                            type="number"
-                            placeholder="0"
-                          />
-                        </div>
-                        <div className="flex-1">
-                          <InputField
-                            control={form.control}
-                            name={`seats.${seatType}.rate`}
-                            title={
-                              resolvedCurrency
-                                ? `Seat rate (${resolvedCurrency.toUpperCase()})`
-                                : "Seat rate"
-                            }
-                            type="number"
-                            placeholder="0"
-                          />
-                        </div>
-                        <div className="flex-1">
-                          <InputField
-                            control={form.control}
-                            name={`seats.${seatType}.commitmentPrice`}
-                            title={
-                              resolvedCurrency
-                                ? `Commitment price (${resolvedCurrency.toUpperCase()})`
-                                : "Commitment price"
-                            }
-                            type="number"
-                            placeholder="optional"
-                          />
-                        </div>
-                      </div>
-                    ))}
+                      );
+                    })}
                   </div>
                 )}
                 {trimmedStripeCustomerId && resolvedCurrency && (

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -25,7 +25,9 @@ import {
   ensureMetronomeCustomerForWorkspace,
   provisionMetronomeContract,
   type SeatRateOverride,
+  syncContractQuantities,
 } from "@app/lib/metronome/contracts";
+import { remapMembershipSeatTypesForContract } from "@app/lib/metronome/seats";
 import {
   isPaygEligibleTier,
   type MetronomePackageTier,
@@ -110,6 +112,11 @@ export const SwitchContractBodySchema = z.object({
     .array(
       z.object({
         seatType: z.string(),
+        // Whether the seat is entitled on the new contract. `true` (the default,
+        // for backward compatibility) entitles and configures the seat; `false`
+        // disables a seat the package would otherwise sell. The dialog submits
+        // every known seat so deselections can be turned into disable overrides.
+        selected: z.boolean().default(true),
         minSeats: z.number().int().min(0, "Min seats must be ≥ 0"),
         rate: z.number().min(0, "Rate must be ≥ 0"),
         commitmentPrice: z
@@ -369,6 +376,32 @@ export async function switchContract({
     );
   }
 
+  // A seat the package does not entitle by default can be entitled here, but
+  // only at an explicit non-zero rate — except the free seat, which is allowed
+  // at rate 0. This guards against accidentally entitling a paid seat for free.
+  const pkgSeatByType = new Map(pkg.seats.map((s) => [s.seatType, s]));
+  for (const seat of body.seats ?? []) {
+    if (!isMembershipSeatType(seat.seatType)) {
+      continue;
+    }
+    const pkgSeat = pkgSeatByType.get(seat.seatType);
+    if (
+      seat.selected &&
+      pkgSeat &&
+      !pkgSeat.entitled &&
+      seat.seatType !== "free" &&
+      seat.rate <= 0
+    ) {
+      return new Err(
+        new SwitchContractError(
+          "invalid_request",
+          `Seat "${seat.seatType}" is not entitled by the selected package and ` +
+            "requires a rate greater than 0 to entitle it."
+        )
+      );
+    }
+  }
+
   // Resolve when the swap happens.
   //  - startingAt provided: schedule at the requested moment, ceiled to the
   //    next hour boundary. Any moment is accepted, including the past — the
@@ -417,7 +450,8 @@ export async function switchContract({
     if (!isMembershipSeatType(seat.seatType)) {
       continue;
     }
-    if (seat.minSeats > 0) {
+    // A deselected seat carries no billing floor — clear any existing one.
+    if (seat.selected && seat.minSeats > 0) {
       await WorkspaceSeatLimitResource.upsert({
         workspace: owner,
         seatType: seat.seatType,
@@ -597,9 +631,9 @@ export async function switchContract({
   // floor (`minSeats`) was already persisted before provisioning (above) so the
   // provisioning sync could clamp to it.
   if (body.seats && body.seats.length > 0) {
-    // Seat product + default rate by seat type, from the package's entitlement
-    // overrides — used to target rate overrides and detect rate changes.
-    const pkgSeatByType = new Map(pkg.seats.map((s) => [s.seatType, s]));
+    // `pkgSeatByType` (built above) maps every seat type the package knows about
+    // to its config — used to target rate overrides, detect rate changes, and
+    // tell entitled seats apart from ones the operator is opting into.
     const seatRateOverrides: SeatRateOverride[] = [];
 
     for (const seat of body.seats) {
@@ -629,6 +663,7 @@ export async function switchContract({
       // 1st-of-month boundary. `rateNative`/`commitmentPriceNative` are already
       // in the contract's fiat unit (matching the fiat credit type).
       if (
+        seat.selected &&
         seat.commitmentPrice &&
         seat.commitmentPrice > 0 &&
         seat.minSeats > 0 &&
@@ -685,19 +720,39 @@ export async function switchContract({
         }
       }
 
-      // Seat rate override: when the operator changed the seat rate from the
-      // package default, overwrite the seat product's rate on the contract.
-      if (
-        resolvedCurrency &&
-        pkgSeat &&
+      // Seat override, applied as an OVERWRITE on the contract:
+      //  - selected + not entitled by the package → entitle it (the operator
+      //    opted in), or
+      //  - selected + entitled but the operator changed its rate from the
+      //    package default → set the new rate, or
+      //  - deselected but entitled by the package → disable it (`entitled:
+      //    false`, price 0) so the package's default seat is turned off.
+      // The free seat is allowed in at rate 0; paid seats are validated to a
+      // positive rate above before reaching this point.
+      const needsEntitle = seat.selected && pkgSeat ? !pkgSeat.entitled : false;
+      const rateChanged =
+        seat.selected &&
+        pkgSeat != null &&
+        pkgSeat.entitled &&
         seat.rate > 0 &&
-        rateNative !== pkgSeat.defaultRate
-      ) {
+        rateNative !== pkgSeat.defaultRate;
+      const needsDisable =
+        !seat.selected && pkgSeat != null && pkgSeat.entitled;
+      if (resolvedCurrency && pkgSeat && (needsEntitle || rateChanged)) {
         seatRateOverrides.push({
           productId: pkgSeat.productId,
           billingFrequency,
           priceNative: rateNative,
           creditTypeId: CURRENCY_TO_CREDIT_TYPE_ID[resolvedCurrency],
+          entitled: true,
+        });
+      } else if (resolvedCurrency && pkgSeat && needsDisable) {
+        seatRateOverrides.push({
+          productId: pkgSeat.productId,
+          billingFrequency,
+          priceNative: 0,
+          creditTypeId: CURRENCY_TO_CREDIT_TYPE_ID[resolvedCurrency],
+          entitled: false,
         });
       }
     }
@@ -717,6 +772,59 @@ export async function switchContract({
             "Manual cleanup may be required."
         )
       );
+    }
+
+    // Re-remap memberships and re-sync seat quantities now that entitlements
+    // have changed. Both ran inside `provisionMetronomeContract` BEFORE these
+    // overrides were applied, so they only saw the package's default-entitled
+    // seats. Without re-running:
+    //  - a membership on a seat the operator just DISABLED (e.g. pro_yearly,
+    //    swapped for pro) would stay on that now-unbilled seat type, and
+    //  - a seat the operator just ENTITLED would stay at quantity 0 (unbilled).
+    // The remap moves members off disabled seats onto an entitled one; the sync
+    // then reconciles quantities. Both re-fetch the contract fresh (no cache),
+    // so the new effective entitlements are visible. Skipped when no override
+    // changed entitlement.
+    if (seatRateOverrides.length > 0) {
+      const ownerLight = renderLightWorkspaceType({ workspace: owner });
+      const remapResult = await remapMembershipSeatTypesForContract({
+        metronomeCustomerId,
+        contractId: metronomeContractId,
+        workspace: ownerLight,
+        swapAt,
+        startingAt: alignedStart,
+      });
+      if (remapResult.isErr()) {
+        return new Err(
+          new SwitchContractError(
+            "provision_inconsistent",
+            `Provisioned Metronome contract ${metronomeContractId} and applied ` +
+              `seat entitlement overrides, but failed to re-map membership seat ` +
+              `types: ${remapResult.error.message}. Members may remain on a seat ` +
+              "type the new contract no longer bills. Manual reconciliation may " +
+              "be required."
+          )
+        );
+      }
+
+      const resyncResult = await syncContractQuantities(
+        metronomeCustomerId,
+        metronomeContractId,
+        ownerLight,
+        alignedStart.toISOString()
+      );
+      if (resyncResult.isErr()) {
+        return new Err(
+          new SwitchContractError(
+            "provision_inconsistent",
+            `Provisioned Metronome contract ${metronomeContractId} and applied ` +
+              `seat entitlement overrides, but failed to re-sync seat ` +
+              `quantities: ${resyncResult.error.message}. The newly entitled ` +
+              "seats may bill at quantity 0 until the next sync. Manual " +
+              "reconciliation may be required."
+          )
+        );
+      }
     }
   }
 

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -466,17 +466,22 @@ export interface MetronomePackageSummary {
 }
 
 /**
- * A seat type sold by a package, plus the default per-seat flat rate stamped by
- * the package's entitlement override (in the rate card's fiat unit, e.g. cents
- * for USD). `defaultRate` is null when the override only flips entitlement
+ * A seat type that can be sold on a package. `entitled` reflects whether the
+ * package flips this seat on by default (via an `entitled: true` override);
+ * non-entitled seats are still surfaced so an operator can opt into entitling
+ * them when switching the contract. `defaultRate` is the per-seat flat rate
+ * stamped by the package's entitlement override (in the rate card's fiat unit,
+ * e.g. cents for USD); it is null when the seat is not entitled, or entitled
  * without an explicit rate. `productId` is the Metronome seat product the
- * override targets — used to apply a rate override on the provisioned contract.
+ * override targets — used to apply a rate/entitlement override on the
+ * provisioned contract.
  */
 export interface PackageSeatConfig {
   seatType: MembershipSeatType;
   productId: string;
   productName: string;
   defaultRate: number | null;
+  entitled: boolean;
 }
 
 // Structural shape of the package list-response overrides we read — only the
@@ -489,10 +494,12 @@ type PackageEntitlementOverride = {
 };
 
 /**
- * Resolve the seats a package sells from its entitlement overrides. A package
- * flips `entitled: true` on the seat products it sells (and stamps their flat
- * rate via `overwrite_rate`); we map those product IDs to seat types via the
- * `productId → seatType` map and surface the override's default rate.
+ * Resolve every seat a package can sell, flagging which ones it entitles by
+ * default. A package flips `entitled: true` on the seat products it sells (and
+ * stamps their flat rate via `overwrite_rate`); those become `entitled` seats
+ * with their default rate. Every other known seat product is surfaced as a
+ * non-entitled seat (no default rate) so an operator can opt into entitling it
+ * when switching the contract.
  */
 // `productId → { seatType, name }` for all seat products.
 type SeatProductInfo = { seatType: MembershipSeatType; name: string };
@@ -502,6 +509,8 @@ function seatConfigsFromPackageOverrides(
   seatProducts: Map<string, SeatProductInfo>
 ): PackageSeatConfig[] {
   const bySeatType = new Map<MembershipSeatType, PackageSeatConfig>();
+
+  // First pass: the seats the package entitles, with their default rate.
   for (const override of overrides ?? []) {
     if (override.entitled !== true) {
       continue;
@@ -518,10 +527,26 @@ function seatConfigsFromPackageOverrides(
           productId,
           productName: info.name,
           defaultRate: override.overwrite_rate?.price ?? null,
+          entitled: true,
         });
       }
     }
   }
+
+  // Second pass: every remaining seat product, surfaced as not entitled so the
+  // operator can opt into it.
+  for (const [productId, info] of seatProducts) {
+    if (!bySeatType.has(info.seatType)) {
+      bySeatType.set(info.seatType, {
+        seatType: info.seatType,
+        productId,
+        productName: info.name,
+        defaultRate: null,
+        entitled: false,
+      });
+    }
+  }
+
   return [...bySeatType.values()].sort((a, b) =>
     a.seatType.localeCompare(b.seatType)
   );

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -1026,24 +1026,29 @@ export async function applyEnterpriseOverrides({
 }
 
 /**
- * A per-seat FLAT rate override to apply on a contract: set `productId`'s rate
- * to `priceNative` from `startingAt`. `priceNative` is in Metronome's fiat unit
- * (cents for USD, whole units for EUR) — the same unit the rate card uses, so
- * it is not labelled `Cents` (that would be wrong for EUR). `billingFrequency`
- * disambiguates the seat product's subscription rate (monthly vs annual seats).
+ * A per-seat FLAT override to apply on a contract. When `entitled` is true (the
+ * default) it sets `productId`'s rate to `priceNative` from `startingAt`; when
+ * `entitled` is false it disables the seat product (de-entitles it) — used when
+ * an operator unchecks a seat the package would otherwise sell. `priceNative` is
+ * in Metronome's fiat unit (cents for USD, whole units for EUR) — the same unit
+ * the rate card uses, so it is not labelled `Cents` (that would be wrong for
+ * EUR); pass 0 when disabling. `billingFrequency` disambiguates the seat
+ * product's subscription rate (monthly vs annual seats).
  */
 export interface SeatRateOverride {
   productId: string;
   billingFrequency: "MONTHLY" | "ANNUAL";
   priceNative: number;
   creditTypeId: string;
+  entitled: boolean;
 }
 
 /**
- * Apply FLAT per-seat rate overrides on a provisioned contract. Seats are
- * provisioned from the package at its default override rate; this overwrites
- * those rates with operator-specified values (e.g. a negotiated seat price)
- * effective at `startingAt`. No-op when `overrides` is empty.
+ * Apply FLAT per-seat overrides on a provisioned contract. Seats are provisioned
+ * from the package at its default override rate; this overwrites those rates
+ * with operator-specified values (e.g. a negotiated seat price), entitles seats
+ * the package does not sell by default, or disables seats the operator opted
+ * out of — all effective at `startingAt`. No-op when `overrides` is empty.
  */
 export async function applySeatRateOverrides({
   metronomeCustomerId,
@@ -1065,7 +1070,7 @@ export async function applySeatRateOverrides({
     add_overrides: overrides.map((o) => ({
       starting_at: startingAt,
       type: "OVERWRITE" as const,
-      entitled: true,
+      entitled: o.entitled,
       override_specifiers: [
         { product_id: o.productId, billing_frequency: o.billingFrequency },
       ],

--- a/front/lib/metronome/seat_types.test.ts
+++ b/front/lib/metronome/seat_types.test.ts
@@ -1,5 +1,8 @@
 import type { CachedContract } from "@app/lib/metronome/plan_type";
-import { getDefaultSeatTypeForContract } from "@app/lib/metronome/seat_types";
+import {
+  getDefaultSeatTypeForContract,
+  getSeatSubscriptionsFromContract,
+} from "@app/lib/metronome/seat_types";
 import type { MembershipSeatType } from "@app/types/memberships";
 import { describe, expect, it } from "vitest";
 
@@ -42,5 +45,88 @@ describe("getDefaultSeatTypeForContract — entitlement", () => {
     expect(getDefaultSeatTypeForContract(contract, productSeatTypes)).toBe(
       "workspace_yearly"
     );
+  });
+});
+
+// A contract switch can entitle a seat the package doesn't sell and disable one
+// it does, layering `entitled: true`/`false` overrides on the same product. The
+// effective entitlement is the latest override per product (ties → disable).
+describe("getSeatSubscriptionsFromContract — effective entitlement", () => {
+  const productSeatTypes = new Map<string, MembershipSeatType>([
+    ["pro-product", "pro"],
+    ["pro-yearly-product", "pro_yearly"],
+  ]);
+
+  const baseSubscriptions = [
+    {
+      id: "sub_pro",
+      subscription_rate: { product: { id: "pro-product", name: "Pro" } },
+    },
+    {
+      id: "sub_pro_yearly",
+      subscription_rate: {
+        product: { id: "pro-yearly-product", name: "Pro (Yearly)" },
+      },
+    },
+  ];
+
+  it("drops a seat disabled by a later override and keeps a newly entitled one", () => {
+    const contract = {
+      subscriptions: baseSubscriptions,
+      recurring_credits: [],
+      overrides: [
+        // Package baseline: pro_yearly entitled (no starting_at → earliest).
+        { entitled: true, product: { id: "pro-yearly-product" } },
+        // Operator switch: disable pro_yearly, entitle pro — both timestamped.
+        {
+          entitled: false,
+          starting_at: "2026-06-01T00:00:00.000Z",
+          product: { id: "pro-yearly-product" },
+        },
+        {
+          entitled: true,
+          starting_at: "2026-06-01T00:00:00.000Z",
+          product: { id: "pro-product" },
+        },
+      ],
+    } as unknown as CachedContract;
+
+    const seatTypes = [
+      ...getSeatSubscriptionsFromContract(contract, productSeatTypes).keys(),
+    ];
+    expect(seatTypes).toEqual(["pro"]);
+  });
+
+  it("lets a same-timestamp disable win over an entitle", () => {
+    // `pro` is entitled so the contract isn't treated as legacy (which would
+    // keep all seats); `pro_yearly` has a true+false pair at the same instant.
+    const contract = {
+      subscriptions: baseSubscriptions,
+      recurring_credits: [],
+      overrides: [
+        {
+          entitled: true,
+          starting_at: "2026-06-01T00:00:00.000Z",
+          product: { id: "pro-product" },
+        },
+        {
+          entitled: true,
+          starting_at: "2026-06-01T00:00:00.000Z",
+          product: { id: "pro-yearly-product" },
+        },
+        {
+          entitled: false,
+          starting_at: "2026-06-01T00:00:00.000Z",
+          product: { id: "pro-yearly-product" },
+        },
+      ],
+    } as unknown as CachedContract;
+
+    const onContract = getSeatSubscriptionsFromContract(
+      contract,
+      productSeatTypes
+    );
+    expect(onContract.has("pro")).toBe(true);
+    expect(onContract.has("pro_yearly")).toBe(false);
   });
 });

--- a/front/lib/metronome/seat_types.ts
+++ b/front/lib/metronome/seat_types.ts
@@ -206,29 +206,58 @@ export function getDefaultSeatTypeForContract(
 }
 
 /**
- * Seat product IDs the contract actually *sells*, i.e. flipped on with an
- * `entitled: true` override. Non-legacy rate cards carry every seat product at
+ * Seat product IDs the contract actually *sells*, i.e. whose effective
+ * entitlement is `true`. Non-legacy rate cards carry every seat product at
  * `entitled: false`; each package/contract entitles only the seats it sells, so
  * a bare subscription does NOT mean the seat is billable — the entitlement
  * override does.
+ *
+ * A product can carry several overrides (e.g. the package entitles a seat, then
+ * an operator switching the contract disables it). We resolve the EFFECTIVE
+ * entitlement per product as the value of the override with the latest
+ * `starting_at`; on a tie, a disabling (`entitled: false`) override wins, so an
+ * operator's explicit opt-out beats a same-moment package entitlement.
+ * Overrides without a `starting_at` (e.g. baseline package entitlements) sort
+ * earliest, so any timestamped override supersedes them.
  */
 function getEntitledSeatProductIds(
   contract: CachedContract,
   productSeatTypes: Map<string, MembershipSeatType>
 ): Set<string> {
-  const ids = new Set<string>();
+  // productId → { startMs, entitled } of the currently-winning override.
+  const effective = new Map<string, { startMs: number; entitled: boolean }>();
   for (const override of contract.overrides ?? []) {
-    if (override.entitled !== true) {
+    if (typeof override.entitled !== "boolean") {
       continue;
     }
+    const entitled = override.entitled;
+    const startMs = override.starting_at
+      ? Date.parse(override.starting_at)
+      : Number.NEGATIVE_INFINITY;
     const productIds = [
       override.product?.id,
       ...(override.override_specifiers ?? []).map((s) => s.product_id),
     ];
     for (const productId of productIds) {
-      if (productId && productSeatTypes.has(productId)) {
-        ids.add(productId);
+      if (!productId || !productSeatTypes.has(productId)) {
+        continue;
       }
+      const current = effective.get(productId);
+      // Later override wins; on an equal timestamp a disable beats an entitle.
+      if (
+        !current ||
+        startMs > current.startMs ||
+        (startMs === current.startMs && current.entitled && !entitled)
+      ) {
+        effective.set(productId, { startMs, entitled });
+      }
+    }
+  }
+
+  const ids = new Set<string>();
+  for (const [productId, { entitled }] of effective) {
+    if (entitled) {
+      ids.add(productId);
     }
   }
   return ids;

--- a/front/pages/api/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front/pages/api/poke/workspaces/[wId]/switch_contract.test.ts
@@ -8,9 +8,12 @@ import {
   getProductPrepaidCommitId,
 } from "@app/lib/metronome/constants";
 import {
+  applySeatRateOverrides,
   ensureMetronomeCustomerForWorkspace,
   provisionMetronomeContract,
+  syncContractQuantities,
 } from "@app/lib/metronome/contracts";
+import { remapMembershipSeatTypesForContract } from "@app/lib/metronome/seats";
 import { PlanModel } from "@app/lib/models/plan";
 import {
   CREDIT_PRICED_BUSINESS_PLAN_CODE,
@@ -53,6 +56,18 @@ vi.mock("@app/lib/metronome/contracts", async () => {
     ...actual,
     ensureMetronomeCustomerForWorkspace: vi.fn(),
     provisionMetronomeContract: vi.fn(),
+    applySeatRateOverrides: vi.fn(),
+    syncContractQuantities: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/metronome/seats", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/seats")
+  >("@app/lib/metronome/seats");
+  return {
+    ...actual,
+    remapMembershipSeatTypesForContract: vi.fn(),
   };
 });
 
@@ -214,7 +229,29 @@ beforeEach(() => {
         aliases: ["business"],
         tier: "business",
         currency: "usd",
-        seats: [],
+        seats: [
+          {
+            seatType: "workspace",
+            productId: "prod_workspace",
+            productName: "Workspace seat",
+            defaultRate: 4000,
+            entitled: true,
+          },
+          {
+            seatType: "max",
+            productId: "prod_max",
+            productName: "Max seat",
+            defaultRate: null,
+            entitled: false,
+          },
+          {
+            seatType: "free",
+            productId: "prod_free",
+            productName: "Free seat",
+            defaultRate: null,
+            entitled: false,
+          },
+        ],
       },
     ])
   );
@@ -224,6 +261,11 @@ beforeEach(() => {
   vi.mocked(scheduleSubscriptionCancellation).mockResolvedValue(true);
   vi.mocked(addPrepaidCommitToContract).mockResolvedValue(
     new Ok({ editId: "edit_xxx" })
+  );
+  vi.mocked(applySeatRateOverrides).mockResolvedValue(new Ok(undefined));
+  vi.mocked(syncContractQuantities).mockResolvedValue(new Ok(undefined));
+  vi.mocked(remapMembershipSeatTypesForContract).mockResolvedValue(
+    new Ok(undefined)
   );
 });
 
@@ -501,6 +543,116 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — Pro / Business", (
     expect(secondPending!.metronomeContractId).toBe(SECOND_CONTRACT_ID);
     expect(secondPending!.getPlan().code).toBe(
       CREDIT_PRICED_BUSINESS_PLAN_CODE
+    );
+  });
+});
+
+describe("POST /api/poke/workspaces/[wId]/switch_contract — seats entitlement", () => {
+  it("entitles a seat the package does not entitle by default via a rate override", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
+
+    req.body = businessBody({
+      seats: [{ seatType: "max", minSeats: 0, rate: 50 }],
+    });
+    req.query.wId = workspace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(applySeatRateOverrides).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contractId: NEW_CONTRACT_ID,
+        overrides: [
+          expect.objectContaining({ productId: "prod_max", entitled: true }),
+        ],
+      })
+    );
+    // Memberships are re-mapped and seat quantities re-synced after entitlement
+    // changes, so members land on a billed seat and the new seat is billed.
+    expect(remapMembershipSeatTypesForContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contractId: NEW_CONTRACT_ID,
+        workspace: expect.objectContaining({ sId: workspace.sId }),
+      })
+    );
+    expect(syncContractQuantities).toHaveBeenCalledWith(
+      METRONOME_CUSTOMER_ID,
+      NEW_CONTRACT_ID,
+      expect.objectContaining({ sId: workspace.sId }),
+      expect.any(String)
+    );
+  });
+
+  it("disables a package-entitled seat the operator unchecks", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
+
+    req.body = businessBody({
+      seats: [{ seatType: "workspace", selected: false, minSeats: 0, rate: 0 }],
+    });
+    req.query.wId = workspace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(applySeatRateOverrides).toHaveBeenCalledWith(
+      expect.objectContaining({
+        overrides: [
+          expect.objectContaining({
+            productId: "prod_workspace",
+            entitled: false,
+          }),
+        ],
+      })
+    );
+  });
+
+  it("rejects entitling a non-free seat at rate 0", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
+
+    req.body = businessBody({
+      seats: [{ seatType: "max", minSeats: 0, rate: 0 }],
+    });
+    req.query.wId = workspace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.message).toContain(
+      "requires a rate greater than 0"
+    );
+  });
+
+  it("allows entitling the free seat at rate 0", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
+
+    req.body = businessBody({
+      seats: [{ seatType: "free", minSeats: 0, rate: 0 }],
+    });
+    req.query.wId = workspace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(applySeatRateOverrides).toHaveBeenCalledWith(
+      expect.objectContaining({
+        overrides: [expect.objectContaining({ productId: "prod_free" })],
+      })
     );
   });
 });


### PR DESCRIPTION
## Description

<img width="830" height="1346" alt="Screenshot 2026-06-02 at 09 09 49" src="https://github.com/user-attachments/assets/688d7417-69af-4706-b734-f2a998fdc096" />

Lets a Poke operator entitle/disable **any** seat type when switching a contract, instead of being limited to the seats the selected Metronome package entitles by default. Allow to enable monthly seats on an enterprise plan, disable max on business, or mix any kind of seats.

**Dialog (`SwitchContractDialog`)**
- The seats section now lists **every** seat type the package knows about, each with a checkbox. Seats the package entitles by default are pre-checked; the rest are shown unchecked (marked with `*`) for the operator to opt into.
- Min seats / rate / commitment inputs are disabled until a seat is checked.
- A checked seat the package does not entitle requires a rate > 0 — except the `free` seat, which may be entitled at rate 0.
- Every known seat is submitted with its `selected` state, so deselecting a default-entitled seat is captured explicitly (rather than inferred from absence).

**Backend (`switch_contract`)**
- `listMetronomePackages` now surfaces all seat products with an `entitled` flag (entitled-by-default vs. opt-in), not just the entitled ones.
- Selected non-entitled seats get an `entitled: true` rate override; deselected default-entitled seats get an `entitled: false` (disable) override; entitled seats with a changed rate keep the existing rate-override behavior.
- After applying the entitlement overrides, the membership **seat-type remap** and the **seat-quantity sync** are re-run. Both originally ran inside `provisionMetronomeContract`, i.e. *before* the overrides existed — so without this a member on a seat the operator just disabled (e.g. `pro_yearly` → `pro`) would stay on the now-unbilled seat, and a newly entitled seat would bill at quantity 0.
- `getEntitledSeatProductIds` now resolves **effective** entitlement per product (latest `starting_at` wins; a same-moment disable beats an entitle), so a layered `entitled: false` override actually de-entitles a seat the package entitled. Normal single-override contracts are unaffected.

## Tests

- `switch_contract.test.ts`: entitling a non-default seat applies the override and re-runs the remap + quantity sync; disabling a default-entitled seat emits an `entitled: false` override; non-free seat at rate 0 is rejected; `free` seat at rate 0 is allowed.
- `seat_types.test.ts`: effective-entitlement resolution — a later disable drops a seat while a new entitle is kept; a same-timestamp disable wins.
- Full `lib/metronome` suite (219 tests) green; touched files type-check and lint clean.

## Risk

- Poke-only, super-user-gated flow; no public/customer API surface.
- The `seats` request field is backward compatible — `selected` defaults to `true`, so omitting it preserves the prior "configure/entitle this seat" semantics.
- `getEntitledSeatProductIds` behavior only changes when a product carries both `entitled: true` and `entitled: false` overrides (the new disable path); single-`true` contracts are unchanged.
- Known limitation: for a **future-dated** switch, the entitlement overrides and the remap are scheduled at the contract start rather than applied immediately (consistent with how future switches already defer).
- Rollback-safe: pure code change, no migrations.

## Deploy Plan

Standard deploy. No migrations, no env changes, no ordering constraints.
