### PR TITLE
Add UI to set and clear the monthly cap for programmatic usage

### DIFF
--- a/front-api/routes/w/[wId]/usage_settings/index.ts
+++ b/front-api/routes/w/[wId]/usage_settings/index.ts
@@ -1,10 +1,12 @@
 import { workspaceApp } from "@front-api/middlewares/ctx";
 
 import defaultUserSpendLimit from "./default_user_spend_limit";
+import programmaticUsageLimit from "./programmatic_usage_limit";
 
 // Mounted at /api/w/:wId/usage_settings.
 const app = workspaceApp();
 
 app.route("/default_user_spend_limit", defaultUserSpendLimit);
+app.route("/programmatic_usage_limit", programmaticUsageLimit);
 
 export default app;

--- a/front-api/routes/w/[wId]/usage_settings/programmatic_usage_limit.test.ts
+++ b/front-api/routes/w/[wId]/usage_settings/programmatic_usage_limit.test.ts
@@ -1,0 +1,268 @@
+import * as businessLayer from "@app/lib/api/credits/programmatic_usage_limit";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Err, Ok } from "@app/types/shared/result";
+import type { WorkspaceType } from "@app/types/user";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/credits/programmatic_usage_limit", async () => {
+  const actual = await vi.importActual<typeof businessLayer>(
+    "@app/lib/api/credits/programmatic_usage_limit"
+  );
+  return {
+    ...actual,
+    getProgrammaticUsageLimit: vi.fn(),
+    syncProgrammaticUsageLimit: vi.fn(),
+  };
+});
+
+const TEST_METRONOME_CUSTOMER_ID = "cust_test_xxx";
+
+async function makeMetronomeWorkspace(): Promise<WorkspaceType> {
+  return WorkspaceFactory.metronome({
+    metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
+  });
+}
+
+function getRequest(wId: string) {
+  return honoApp.request(
+    `/api/w/${wId}/usage_settings/programmatic_usage_limit`
+  );
+}
+
+function putRequest(wId: string, body: Record<string, unknown>) {
+  return honoApp.request(
+    `/api/w/${wId}/usage_settings/programmatic_usage_limit`,
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(businessLayer.getProgrammaticUsageLimit).mockResolvedValue(
+    new Ok(500)
+  );
+  vi.mocked(businessLayer.syncProgrammaticUsageLimit).mockResolvedValue(
+    new Ok(undefined)
+  );
+});
+
+describe("/api/w/[wId]/usage_settings/programmatic_usage_limit", () => {
+  describe("auth", () => {
+    it("returns 403 when caller is not an admin", async () => {
+      const { workspace } = await createPrivateApiMockRequest({
+        role: "user",
+      });
+
+      const response = await getRequest(workspace.sId);
+
+      expect(response.status).toBe(403);
+      const data = (await response.json()) as { error: { type: string } };
+      expect(data.error.type).toBe("workspace_auth_error");
+    });
+  });
+
+  describe("method validation", () => {
+    it("returns 404 for unsupported methods", async () => {
+      const workspace = await makeMetronomeWorkspace();
+      await createPrivateApiMockRequest({
+        role: "admin",
+        workspace,
+      });
+
+      const response = await honoApp.request(
+        `/api/w/${workspace.sId}/usage_settings/programmatic_usage_limit`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        }
+      );
+
+      // Hono returns 404 for unregistered methods (no route matched).
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("GET", () => {
+    it("returns the configured cap", async () => {
+      vi.mocked(businessLayer.getProgrammaticUsageLimit).mockResolvedValueOnce(
+        new Ok(1000)
+      );
+
+      const workspace = await makeMetronomeWorkspace();
+      await createPrivateApiMockRequest({
+        role: "admin",
+        workspace,
+      });
+
+      const response = await getRequest(workspace.sId);
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ monthlyCapCredits: 1000 });
+    });
+
+    it("returns null when no cap is configured", async () => {
+      vi.mocked(businessLayer.getProgrammaticUsageLimit).mockResolvedValueOnce(
+        new Ok(null)
+      );
+
+      const workspace = await makeMetronomeWorkspace();
+      await createPrivateApiMockRequest({
+        role: "admin",
+        workspace,
+      });
+
+      const response = await getRequest(workspace.sId);
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ monthlyCapCredits: null });
+    });
+
+    it("returns 500 on business layer error", async () => {
+      vi.mocked(businessLayer.getProgrammaticUsageLimit).mockResolvedValueOnce(
+        new Err(new Error("boom"))
+      );
+
+      const workspace = await makeMetronomeWorkspace();
+      await createPrivateApiMockRequest({
+        role: "admin",
+        workspace,
+      });
+
+      const response = await getRequest(workspace.sId);
+
+      expect(response.status).toBe(500);
+    });
+  });
+
+  describe("PUT", () => {
+    it("sets the cap and returns the new value", async () => {
+      vi.mocked(businessLayer.syncProgrammaticUsageLimit).mockResolvedValueOnce(
+        new Ok(undefined)
+      );
+
+      const workspace = await makeMetronomeWorkspace();
+      await createPrivateApiMockRequest({
+        role: "admin",
+        workspace,
+      });
+
+      const response = await putRequest(workspace.sId, {
+        monthlyCapCredits: 500,
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ monthlyCapCredits: 500 });
+      expect(businessLayer.syncProgrammaticUsageLimit).toHaveBeenCalledWith(
+        expect.objectContaining({ monthlyCapCredits: 500 })
+      );
+    });
+
+    it("clears the cap when null is passed", async () => {
+      vi.mocked(businessLayer.syncProgrammaticUsageLimit).mockResolvedValueOnce(
+        new Ok(undefined)
+      );
+
+      const workspace = await makeMetronomeWorkspace();
+      await createPrivateApiMockRequest({
+        role: "admin",
+        workspace,
+      });
+
+      const response = await putRequest(workspace.sId, {
+        monthlyCapCredits: null,
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ monthlyCapCredits: null });
+      expect(businessLayer.syncProgrammaticUsageLimit).toHaveBeenCalledWith(
+        expect.objectContaining({ monthlyCapCredits: null })
+      );
+    });
+
+    it("returns 400 when monthlyCapCredits is missing", async () => {
+      const workspace = await makeMetronomeWorkspace();
+      await createPrivateApiMockRequest({
+        role: "admin",
+        workspace,
+      });
+
+      const response = await putRequest(workspace.sId, {});
+
+      expect(response.status).toBe(400);
+      const data = (await response.json()) as { error: { type: string } };
+      expect(data.error.type).toBe("invalid_request_error");
+      expect(businessLayer.syncProgrammaticUsageLimit).not.toHaveBeenCalled();
+    });
+
+    it("accepts monthlyCapCredits of zero", async () => {
+      vi.mocked(businessLayer.syncProgrammaticUsageLimit).mockResolvedValueOnce(
+        new Ok(undefined)
+      );
+
+      const workspace = await makeMetronomeWorkspace();
+      await createPrivateApiMockRequest({
+        role: "admin",
+        workspace,
+      });
+
+      const response = await putRequest(workspace.sId, {
+        monthlyCapCredits: 0,
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ monthlyCapCredits: 0 });
+    });
+
+    it("returns 400 when monthlyCapCredits is negative", async () => {
+      const workspace = await makeMetronomeWorkspace();
+      await createPrivateApiMockRequest({
+        role: "admin",
+        workspace,
+      });
+
+      const response = await putRequest(workspace.sId, {
+        monthlyCapCredits: -10,
+      });
+
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 400 when monthlyCapCredits is non-integer", async () => {
+      const workspace = await makeMetronomeWorkspace();
+      await createPrivateApiMockRequest({
+        role: "admin",
+        workspace,
+      });
+
+      const response = await putRequest(workspace.sId, {
+        monthlyCapCredits: 1.5,
+      });
+
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 500 when the business layer fails", async () => {
+      vi.mocked(businessLayer.syncProgrammaticUsageLimit).mockResolvedValueOnce(
+        new Err(new Error("metronome down"))
+      );
+
+      const workspace = await makeMetronomeWorkspace();
+      await createPrivateApiMockRequest({
+        role: "admin",
+        workspace,
+      });
+
+      const response = await putRequest(workspace.sId, {
+        monthlyCapCredits: 500,
+      });
+
+      expect(response.status).toBe(500);
+    });
+  });
+});

--- a/front-api/routes/w/[wId]/usage_settings/programmatic_usage_limit.ts
+++ b/front-api/routes/w/[wId]/usage_settings/programmatic_usage_limit.ts
@@ -11,7 +11,7 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
 const UpdateProgrammaticUsageLimitBodySchema = z.object({
-  monthlyCapCredits: z.number().int().positive().nullable(),
+  monthlyCapCredits: z.number().int().nonnegative().nullable(),
 });
 
 export type GetProgrammaticUsageLimitResponseBody = {

--- a/front-api/routes/w/[wId]/usage_settings/programmatic_usage_limit.ts
+++ b/front-api/routes/w/[wId]/usage_settings/programmatic_usage_limit.ts
@@ -1,0 +1,72 @@
+/** @ignoreswagger */
+
+import {
+  getProgrammaticUsageLimit,
+  syncProgrammaticUsageLimit,
+} from "@app/lib/api/credits/programmatic_usage_limit";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const UpdateProgrammaticUsageLimitBodySchema = z.object({
+  monthlyCapCredits: z.number().int().positive().nullable(),
+});
+
+export type GetProgrammaticUsageLimitResponseBody = {
+  monthlyCapCredits: number | null;
+};
+
+export type PutProgrammaticUsageLimitResponseBody = {
+  monthlyCapCredits: number | null;
+};
+
+// Mounted at /api/w/:wId/usage_settings/programmatic_usage_limit.
+const app = workspaceApp();
+
+app.get(
+  "/",
+  ensureIsAdmin(),
+  async (ctx): HandlerResult<GetProgrammaticUsageLimitResponseBody> => {
+    const auth = ctx.get("auth");
+    const result = await getProgrammaticUsageLimit(auth);
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: result.error.message,
+        },
+      });
+    }
+    return ctx.json({ monthlyCapCredits: result.value });
+  }
+);
+
+app.put(
+  "/",
+  ensureIsAdmin(),
+  validate("json", UpdateProgrammaticUsageLimitBodySchema),
+  async (ctx): HandlerResult<PutProgrammaticUsageLimitResponseBody> => {
+    const auth = ctx.get("auth");
+    const { monthlyCapCredits } = ctx.req.valid("json");
+
+    const result = await syncProgrammaticUsageLimit({
+      auth,
+      monthlyCapCredits,
+    });
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: result.error.message,
+        },
+      });
+    }
+    return ctx.json({ monthlyCapCredits });
+  }
+);
+
+export default app;

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -6,6 +6,7 @@ import { ChangeSeatModal } from "@app/components/workspace/ChangeSeatModal";
 import { EditSpendLimitModal } from "@app/components/workspace/EditSpendLimitModal";
 import { MembersUsageTable } from "@app/components/workspace/MembersUsageTable";
 import { UsageNotificationsCard } from "@app/components/workspace/usage/UsageNotificationsCard";
+import { UsageProgrammaticLimitCard } from "@app/components/workspace/usage/UsageProgrammaticLimitCard";
 import { UsageSettingsCard } from "@app/components/workspace/usage/UsageSettingsCard";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
@@ -325,6 +326,8 @@ export function UsagePage() {
         </Page.Vertical>
 
         <UsageSettingsCard workspaceId={owner.sId} />
+
+        <UsageProgrammaticLimitCard workspaceId={owner.sId} />
 
         <UsageNotificationsCard workspaceId={owner.sId} />
 

--- a/front/components/workspace/usage/UsageProgrammaticLimitCard.tsx
+++ b/front/components/workspace/usage/UsageProgrammaticLimitCard.tsx
@@ -4,7 +4,6 @@ import {
 } from "@app/lib/swr/usage_settings";
 import {
   ActionCreditCoinsIcon,
-  Button,
   Icon,
   Input,
   Page,
@@ -58,7 +57,7 @@ export function UsageProgrammaticLimitCard({
     }
 
     const parsed = Number(limitInput);
-    if (!Number.isInteger(parsed) || parsed <= 0 || parsed === current) {
+    if (!Number.isInteger(parsed) || parsed < 0 || parsed === current) {
       setLimitInput(current !== null ? String(current) : "");
       return;
     }
@@ -76,18 +75,6 @@ export function UsageProgrammaticLimitCard({
 
   const isInputDisabled = isSaving || isProgrammaticUsageLimitLoading;
 
-  const handleClear = async () => {
-    setIsSaving(true);
-    try {
-      const result = await doUpdateProgrammaticUsageLimit(null);
-      if (result) {
-        setLimitInput("");
-      }
-    } finally {
-      setIsSaving(false);
-    }
-  };
-
   return (
     <Page.Vertical gap="sm" align="stretch">
       <div className="flex flex-col gap-0.5">
@@ -100,34 +87,23 @@ export function UsageProgrammaticLimitCard({
           title="Programmatic monthly limit"
           description="Maximum credits allowed for programmatic usage per month"
           action={
-            <div className="flex items-center gap-2">
-              <div className="relative w-32">
-                <div className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground dark:text-muted-foreground-night">
-                  <Icon visual={ActionCreditCoinsIcon} size="xs" />
-                </div>
-                <Input
-                  type="text"
-                  inputMode="numeric"
-                  pattern="[0-9]*"
-                  placeholder="No limit"
-                  value={limitInput}
-                  onChange={(e) =>
-                    setLimitInput(e.target.value.replace(/[^\d]/g, ""))
-                  }
-                  onBlur={() => void handleCommitLimit()}
-                  disabled={isInputDisabled}
-                  className="pl-8 text-right"
-                />
+            <div className="relative w-32">
+              <div className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground dark:text-muted-foreground-night">
+                <Icon visual={ActionCreditCoinsIcon} size="xs" />
               </div>
-              {programmaticUsageLimit?.monthlyCapCredits !== null && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  label="Clear"
-                  onClick={() => void handleClear()}
-                  disabled={isInputDisabled}
-                />
-              )}
+              <Input
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                placeholder="No limit"
+                value={limitInput}
+                onChange={(e) =>
+                  setLimitInput(e.target.value.replace(/[^\d]/g, ""))
+                }
+                onBlur={() => void handleCommitLimit()}
+                disabled={isInputDisabled}
+                className="pl-8 text-right"
+              />
             </div>
           }
         />

--- a/front/components/workspace/usage/UsageProgrammaticLimitCard.tsx
+++ b/front/components/workspace/usage/UsageProgrammaticLimitCard.tsx
@@ -1,0 +1,137 @@
+import {
+  useProgrammaticUsageLimit,
+  useUpdateProgrammaticUsageLimit,
+} from "@app/lib/swr/usage_settings";
+import {
+  ActionCreditCoinsIcon,
+  Button,
+  Icon,
+  Input,
+  Page,
+  SettingsList,
+} from "@dust-tt/sparkle";
+import { useEffect, useState } from "react";
+
+interface UsageProgrammaticLimitCardProps {
+  workspaceId: string;
+}
+
+export function UsageProgrammaticLimitCard({
+  workspaceId,
+}: UsageProgrammaticLimitCardProps) {
+  const { programmaticUsageLimit, isProgrammaticUsageLimitLoading } =
+    useProgrammaticUsageLimit({ workspaceId });
+  const { doUpdateProgrammaticUsageLimit } = useUpdateProgrammaticUsageLimit({
+    workspaceId,
+  });
+
+  const [limitInput, setLimitInput] = useState<string>("");
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    if (programmaticUsageLimit?.monthlyCapCredits !== undefined) {
+      setLimitInput(
+        programmaticUsageLimit.monthlyCapCredits !== null
+          ? String(programmaticUsageLimit.monthlyCapCredits)
+          : ""
+      );
+    }
+  }, [programmaticUsageLimit]);
+
+  const handleCommitLimit = async () => {
+    const current = programmaticUsageLimit?.monthlyCapCredits ?? null;
+
+    if (limitInput.trim() === "") {
+      if (current === null) {
+        return;
+      }
+      setIsSaving(true);
+      try {
+        const result = await doUpdateProgrammaticUsageLimit(null);
+        if (!result) {
+          setLimitInput(current !== null ? String(current) : "");
+        }
+      } finally {
+        setIsSaving(false);
+      }
+      return;
+    }
+
+    const parsed = Number(limitInput);
+    if (!Number.isInteger(parsed) || parsed <= 0 || parsed === current) {
+      setLimitInput(current !== null ? String(current) : "");
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const result = await doUpdateProgrammaticUsageLimit(parsed);
+      if (!result) {
+        setLimitInput(current !== null ? String(current) : "");
+      }
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const isInputDisabled = isSaving || isProgrammaticUsageLimitLoading;
+
+  const handleClear = async () => {
+    setIsSaving(true);
+    try {
+      const result = await doUpdateProgrammaticUsageLimit(null);
+      if (result) {
+        setLimitInput("");
+      }
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Page.Vertical gap="sm" align="stretch">
+      <div className="flex flex-col gap-0.5">
+        <span className="heading-base text-foreground dark:text-foreground-night">
+          Programmatic usage
+        </span>
+      </div>
+      <SettingsList>
+        <SettingsList.Row
+          title="Programmatic monthly limit"
+          description="Maximum credits allowed for programmatic usage per month"
+          action={
+            <div className="flex items-center gap-2">
+              <div className="relative w-32">
+                <div className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground dark:text-muted-foreground-night">
+                  <Icon visual={ActionCreditCoinsIcon} size="xs" />
+                </div>
+                <Input
+                  type="text"
+                  inputMode="numeric"
+                  pattern="[0-9]*"
+                  placeholder="No limit"
+                  value={limitInput}
+                  onChange={(e) =>
+                    setLimitInput(e.target.value.replace(/[^\d]/g, ""))
+                  }
+                  onBlur={() => void handleCommitLimit()}
+                  disabled={isInputDisabled}
+                  className="pl-8 text-right"
+                />
+              </div>
+              {programmaticUsageLimit?.monthlyCapCredits !== null && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  label="Clear"
+                  onClick={() => void handleClear()}
+                  disabled={isInputDisabled}
+                />
+              )}
+            </div>
+          }
+        />
+      </SettingsList>
+    </Page.Vertical>
+  );
+}

--- a/front/lib/api/credits/programmatic_usage_limit.ts
+++ b/front/lib/api/credits/programmatic_usage_limit.ts
@@ -1,0 +1,82 @@
+import type { Authenticator } from "@app/lib/auth";
+import {
+  clearMetronomeProgrammaticCapAlerts,
+  getMetronomeProgrammaticCap,
+  upsertMetronomeProgrammaticCapAlerts,
+} from "@app/lib/metronome/alerts/programmatic_cap";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+/**
+ * Read the workspace's programmatic usage monthly cap.
+ *
+ * Metronome is the source of truth: the cap is the threshold of the
+ * workspace's programmatic cap alert. Returns `null` when no cap is
+ * configured, or when the workspace has no Metronome customer.
+ */
+export async function getProgrammaticUsageLimit(
+  auth: Authenticator
+): Promise<Result<number | null, Error>> {
+  const workspace = auth.getNonNullableWorkspace();
+  if (!workspace.metronomeCustomerId) {
+    return new Err(
+      new Error(`Workspace ${workspace.sId} has no Metronome customer ID.`)
+    );
+  }
+
+  const result = await getMetronomeProgrammaticCap({
+    metronomeCustomerId: workspace.metronomeCustomerId,
+    workspaceId: workspace.sId,
+  });
+  if (result.isErr()) {
+    return new Err(
+      new Error(
+        `Failed to read programmatic cap from Metronome: ${result.error.message}`
+      )
+    );
+  }
+  return new Ok(result.value);
+}
+
+/**
+ * Set or clear the workspace's programmatic usage monthly cap.
+ *
+ * A strictly positive `monthlyCapCredits` upserts the three programmatic cap
+ * alerts (cap, low balance, critical balance); `null` clears them.
+ * No-op when the workspace has no Metronome customer.
+ */
+export async function syncProgrammaticUsageLimit({
+  auth,
+  monthlyCapCredits,
+}: {
+  auth: Authenticator;
+  monthlyCapCredits: number | null;
+}): Promise<Result<undefined, Error>> {
+  const workspace = auth.getNonNullableWorkspace();
+  if (!workspace.metronomeCustomerId) {
+    return new Err(
+      new Error(`Workspace ${workspace.sId} has no Metronome customer ID.`)
+    );
+  }
+
+  const alertResult =
+    monthlyCapCredits !== null && monthlyCapCredits >= 0
+      ? await upsertMetronomeProgrammaticCapAlerts({
+          metronomeCustomerId: workspace.metronomeCustomerId,
+          workspaceId: workspace.sId,
+          monthlyCapCredits,
+        })
+      : await clearMetronomeProgrammaticCapAlerts({
+          metronomeCustomerId: workspace.metronomeCustomerId,
+          workspaceId: workspace.sId,
+        });
+  if (alertResult.isErr()) {
+    return new Err(
+      new Error(
+        `Failed to sync Metronome programmatic cap alerts: ${alertResult.error.message}`
+      )
+    );
+  }
+
+  return new Ok(undefined);
+}

--- a/front/lib/swr/usage_settings.ts
+++ b/front/lib/swr/usage_settings.ts
@@ -370,7 +370,7 @@ export function useUpdateProgrammaticUsageLimit({
       if (monthlyCapCredits === null) {
         sendNotification({
           type: "success",
-          title: "Programmatic usage limit cleared",
+          title: "Programmatic usage limit has been removed",
         });
       } else {
         sendNotification({

--- a/front/lib/swr/usage_settings.ts
+++ b/front/lib/swr/usage_settings.ts
@@ -11,6 +11,10 @@ import type {
   GetDefaultUserSpendLimitResponseBody,
   PutDefaultUserSpendLimitResponseBody,
 } from "@app/pages/api/w/[wId]/usage_settings/default_user_spend_limit";
+import type {
+  GetProgrammaticUsageLimitResponseBody,
+  PutProgrammaticUsageLimitResponseBody,
+} from "@app/pages/api/w/[wId]/usage_settings/programmatic_usage_limit";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { useCallback, useSyncExternalStore } from "react";
 import type { Fetcher } from "swr";
@@ -296,4 +300,91 @@ export function useUpdateDefaultUserSpendLimit({
   );
 
   return { doUpdateDefaultUserSpendLimit };
+}
+
+// Programmatic usage limit
+
+const GetProgrammaticUsageLimitResponseSchema = z.object({
+  monthlyCapCredits: z.number().int().nullable(),
+});
+
+function programmaticUsageLimitUrl(workspaceId: string): string {
+  return `/api/w/${workspaceId}/usage_settings/programmatic_usage_limit`;
+}
+
+export function useProgrammaticUsageLimit({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const { fetcher } = useFetcher();
+  const limitFetcher: Fetcher<GetProgrammaticUsageLimitResponseBody> = async (
+    url: string
+  ) => {
+    const result = await fetcher(url);
+    return GetProgrammaticUsageLimitResponseSchema.parse(result);
+  };
+  const { data, error } = useSWRWithDefaults(
+    programmaticUsageLimitUrl(workspaceId),
+    limitFetcher
+  );
+
+  return {
+    programmaticUsageLimit: data,
+    isProgrammaticUsageLimitLoading: !error && !data,
+    isProgrammaticUsageLimitError: !!error,
+  };
+}
+
+export function useUpdateProgrammaticUsageLimit({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const sendNotification = useSendNotification();
+
+  const doUpdateProgrammaticUsageLimit = useCallback(
+    async (
+      monthlyCapCredits: number | null
+    ): Promise<PutProgrammaticUsageLimitResponseBody | null> => {
+      const res = await clientFetch(programmaticUsageLimitUrl(workspaceId), {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ monthlyCapCredits }),
+      });
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: "Failed to update programmatic usage limit",
+          description: errorData.message,
+        });
+        return null;
+      }
+
+      const body = GetProgrammaticUsageLimitResponseSchema.parse(
+        await res.json()
+      );
+
+      if (monthlyCapCredits === null) {
+        sendNotification({
+          type: "success",
+          title: "Programmatic usage limit cleared",
+        });
+      } else {
+        sendNotification({
+          type: "success",
+          title: "Programmatic usage limit updated",
+          description: `The monthly programmatic usage limit has been set to ${monthlyCapCredits.toLocaleString("en-US")} credits.`,
+        });
+      }
+
+      await mutate(programmaticUsageLimitUrl(workspaceId));
+      return body;
+    },
+    [workspaceId, sendNotification]
+  );
+
+  return { doUpdateProgrammaticUsageLimit };
 }

--- a/front/pages/api/w/[wId]/usage_settings/programmatic_usage_limit.ts
+++ b/front/pages/api/w/[wId]/usage_settings/programmatic_usage_limit.ts
@@ -1,0 +1,108 @@
+// @migration-status: MIGRATED_TO_HONO
+/** @ignoreswagger */
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import {
+  getProgrammaticUsageLimit,
+  syncProgrammaticUsageLimit,
+} from "@app/lib/api/credits/programmatic_usage_limit";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+const UpdateProgrammaticUsageLimitBodySchema = z.object({
+  monthlyCapCredits: z.number().int().positive().nullable(),
+});
+
+export type GetProgrammaticUsageLimitResponseBody = {
+  monthlyCapCredits: number | null;
+};
+
+export type PutProgrammaticUsageLimitResponseBody = {
+  monthlyCapCredits: number | null;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<
+      | GetProgrammaticUsageLimitResponseBody
+      | PutProgrammaticUsageLimitResponseBody
+    >
+  >,
+  auth: Authenticator
+): Promise<void> {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can manage the programmatic usage limit.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const result = await getProgrammaticUsageLimit(auth);
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: result.error.message,
+          },
+        });
+      }
+      return res.status(200).json({ monthlyCapCredits: result.value });
+    }
+
+    case "PUT": {
+      const bodyValidation = UpdateProgrammaticUsageLimitBodySchema.safeParse(
+        req.body
+      );
+      if (!bodyValidation.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${fromError(bodyValidation.error).toString()}`,
+          },
+        });
+      }
+
+      const { monthlyCapCredits } = bodyValidation.data;
+
+      const result = await syncProgrammaticUsageLimit({
+        auth,
+        monthlyCapCredits,
+      });
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: result.error.message,
+          },
+        });
+      }
+      return res.status(200).json({ monthlyCapCredits });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, GET or PUT is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/usage_settings/programmatic_usage_limit.ts
+++ b/front/pages/api/w/[wId]/usage_settings/programmatic_usage_limit.ts
@@ -14,7 +14,7 @@ import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
 const UpdateProgrammaticUsageLimitBodySchema = z.object({
-  monthlyCapCredits: z.number().int().positive().nullable(),
+  monthlyCapCredits: z.number().int().nonnegative().nullable(),
 });
 
 export type GetProgrammaticUsageLimitResponseBody = {


### PR DESCRIPTION
## Description

Allow admin to set a monthly cap for programmatic usage.

## Tests

tested locally 

<img width="2182" height="926" alt="image" src="https://github.com/user-attachments/assets/095fa781-c3da-4d96-a619-fa3ebff441fe" />

Unit tested
```
 ✓ routes/w/[wId]/usage_settings/programmatic_usage_limit.test.ts (12 tests) 423ms
   ✓ /api/w/[wId]/usage_settings/programmatic_usage_limit (12)
     ✓ auth (1)
       ✓ returns 403 when caller is not an admin 124ms
     ✓ method validation (1)
       ✓ returns 404 for unsupported methods 31ms
     ✓ GET (3)
       ✓ returns the configured cap 37ms
       ✓ returns null when no cap is configured 26ms
       ✓ returns 500 on business layer error 26ms
     ✓ PUT (7)
       ✓ sets the cap and returns the new value 30ms
       ✓ clears the cap when null is passed 24ms
       ✓ returns 400 when monthlyCapCredits is missing 23ms
       ✓ accepts monthlyCapCredits of zero 22ms
       ✓ returns 400 when monthlyCapCredits is negative 24ms
       ✓ returns 400 when monthlyCapCredits is non-integer 23ms
       ✓ returns 500 when the business layer fails 31ms

 Test Files  1 passed (1)
      Tests  12 passed (12)
   Start at  10:02:22
   Duration  24.22s (transform 10.18s, setup 302ms, import 19.32s, tests 423ms, environment 286ms)
```


## Risk

low, can be reverted if needed

## Deploy Plan

deploy front
