### PR TITLE
[front] enh: inline reinforced skill tool suggestions

### DIFF
--- a/front/lib/reinforcement/aggregate_suggestions.test.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.test.ts
@@ -217,7 +217,7 @@ describe("buildSkillAggregationPrompt", () => {
     expect(userMessage).not.toContain("Previously rejected suggestions");
   });
 
-  it("system prompt mentions the suggestion tool", () => {
+  it("system prompt mentions the suggestion tool and inline tool references", () => {
     const { systemPrompt } = buildSkillAggregationPrompt(
       makeSkill(),
       [makeInstructionSuggestion()],
@@ -225,6 +225,8 @@ describe("buildSkillAggregationPrompt", () => {
     );
 
     expect(systemPrompt).toContain("edit_skill");
+    expect(systemPrompt).toContain("inline <tool>");
+    expect(systemPrompt).toContain('Do NOT include "toolEdits"');
   });
 
   it("formats agent-facing description edits with the new content", () => {
@@ -286,7 +288,7 @@ describe("buildSkillAggregationPrompt", () => {
     expect(userMessage).not.toContain("<title>");
   });
 
-  it("includes skill configured tools in user message", () => {
+  it("does not include skill tools as a separate user message block", () => {
     const skill = makeSkill({
       tools: [
         {
@@ -301,8 +303,8 @@ describe("buildSkillAggregationPrompt", () => {
       { pending: [], rejected: [] }
     );
 
-    expect(userMessage).toContain("<tools>");
-    expect(userMessage).toContain('name="web_search"');
-    expect(userMessage).toContain('sId="tool-ws"');
+    expect(userMessage).not.toContain("<tools>");
+    expect(userMessage).not.toContain('name="web_search"');
+    expect(userMessage).not.toContain('sId="tool-ws"');
   });
 });

--- a/front/lib/reinforcement/aggregate_suggestions.test.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.test.ts
@@ -217,11 +217,24 @@ describe("buildSkillAggregationPrompt", () => {
     expect(userMessage).not.toContain("Previously rejected suggestions");
   });
 
-  it("system prompt mentions the suggestion tool and inline tool references", () => {
+  it("system prompt mentions the suggestion tool", () => {
     const { systemPrompt } = buildSkillAggregationPrompt(
       makeSkill(),
       [makeInstructionSuggestion()],
       { pending: [], rejected: [] }
+    );
+
+    expect(systemPrompt).toContain("edit_skill");
+    expect(systemPrompt).not.toContain("inline <tool>");
+    expect(systemPrompt).not.toContain('Do NOT include "toolEdits"');
+  });
+
+  it("system prompt mentions inline tool references when inline tools are enabled", () => {
+    const { systemPrompt } = buildSkillAggregationPrompt(
+      makeSkill(),
+      [makeInstructionSuggestion()],
+      { pending: [], rejected: [] },
+      { useInlineTools: true }
     );
 
     expect(systemPrompt).toContain("edit_skill");
@@ -288,7 +301,7 @@ describe("buildSkillAggregationPrompt", () => {
     expect(userMessage).not.toContain("<title>");
   });
 
-  it("does not include skill tools as a separate user message block", () => {
+  it("includes skill tools as a separate user message block by default", () => {
     const skill = makeSkill({
       tools: [
         {
@@ -301,6 +314,27 @@ describe("buildSkillAggregationPrompt", () => {
       skill,
       [makeInstructionSuggestion()],
       { pending: [], rejected: [] }
+    );
+
+    expect(userMessage).toContain("<tools>");
+    expect(userMessage).toContain('name="web_search"');
+    expect(userMessage).toContain('sId="tool-ws"');
+  });
+
+  it("does not include skill tools as a separate user message block when inline tools are enabled", () => {
+    const skill = makeSkill({
+      tools: [
+        {
+          sId: "tool-ws",
+          name: "web_search",
+        } as SkillType["tools"][number],
+      ],
+    });
+    const { userMessage } = buildSkillAggregationPrompt(
+      skill,
+      [makeInstructionSuggestion()],
+      { pending: [], rejected: [] },
+      { useInlineTools: true }
     );
 
     expect(userMessage).not.toContain("<tools>");

--- a/front/lib/reinforcement/aggregate_suggestions.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.ts
@@ -6,7 +6,7 @@ import {
 import { toFileContentFragment } from "@app/lib/api/assistant/conversation/content_fragment";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
-import type { Authenticator } from "@app/lib/auth";
+import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { formatSkillContext } from "@app/lib/reinforcement/format_skill_context";
 import { buildReinforcedSkillsLLMParams } from "@app/lib/reinforcement/run_reinforced_analysis";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -29,15 +29,21 @@ const AGGREGATION_ASSEMBLY_ORDER = [
 
 type AggregationSectionKey = (typeof AGGREGATION_ASSEMBLY_ORDER)[number];
 
-const REINFORCED_SKILL_AGGREGATION_SECTIONS: Record<
-  AggregationSectionKey,
-  string
-> = {
-  primary: `You improve a skill's configuration by consolidating many draft suggestions. Each draft was produced from a single conversation that used the skill.
+function getReinforcedSkillAggregationSections({
+  useInlineTools,
+}: {
+  useInlineTools: boolean;
+}): Record<AggregationSectionKey, string> {
+  return {
+    primary: `You improve a skill's configuration by consolidating many draft suggestions. Each draft was produced from a single conversation that used the skill.
 Your job is to produce a subset of the highest quality suggestions for the skill builder to review.
 
 You have access to the following tools:
-- edit_skill: For suggesting instruction edits, inline tool reference changes, and/or agent-facing description changes for one skill.
+- edit_skill: ${
+      useInlineTools
+        ? "For suggesting instruction edits, inline tool reference changes, and/or agent-facing description changes for one skill."
+        : "For suggesting instruction edits, tool add/remove, and/or agent-facing description changes for one skill."
+    }
 - reject_suggestion: For discarding source suggestions that are invalid, not actionable, or too similar to already declined suggestions. Do NOT reject minor but valid suggestions, simply ignore them.
 
 Your goal is to keep the most impactful suggestions. NEVER create more than 5 suggestions.
@@ -49,10 +55,14 @@ IMPORTANT: Both edit_skill and reject_suggestion are terminal calls — you will
 It is ok to simply call no tool if all suggestions are minor.
 `,
 
-  aggregation_rules: `
+    aggregation_rules: `
 Start by grouping suggestions by skill, then within each skill group by topic:
 - For instruction edits, group by coherent theme within the skill (e.g. tone, tool usage, formatting). Suggestions that address different topics MUST be kept as separate suggestions — do NOT merge unrelated topics into one suggestion.
-- For inline tool reference changes, group by the target <tool> reference within each skill. Tool references are instruction edits, so NEVER output separate tool edits.
+- ${
+      useInlineTools
+        ? "For inline tool reference changes, group by the target <tool> reference within each skill. Tool references are instruction edits, so NEVER output separate tool edits."
+        : "For tool changes, group by the target tool within each skill. NEVER create more than one suggestion per tool."
+    }
 - For agent-facing description edits, create AT MOST ONE description-edit suggestion per skill. When multiple drafts target the description, merge them into a single coherent replacement.
 NEVER create more than one suggestion per (skill, topic) pair.
 
@@ -71,13 +81,17 @@ Classify the groups in these 3 categories:
 
 You SHOULD ignore suggestions that only have minor impact and are only supported by a single conversation (don't reject them, do NOT call reject_suggestion, just take no action for these suggestions).
 
-There may be situations where suggestions are co-dependent. For example, there may be an instruction suggestion that requires adding an inline <tool> tag to be effective. In this case, NEVER create one suggestion without the other.`,
+There may be situations where suggestions are co-dependent. For example, there may be an instruction suggestion that requires ${
+      useInlineTools ? "adding an inline <tool> tag" : "a tool suggestion"
+    } to be effective. In this case, NEVER create one suggestion without the other.`,
 
-  suggestion_tool_calls: `
+    suggestion_tool_calls: `
 You are provided all of the attributes associated with a conversation suggestion. You MUST use these EXACT attributes to create the final suggestion.
-The exceptions are:
-- The "analysis", "title", and "sourceSuggestionIds" attributes; these MUST be newly authored for each final suggestion.
-- Legacy "toolEdits"; convert these into instruction edits that add or remove the corresponding inline <tool> tag. Do NOT include "toolEdits" in the final edit_skill call.
+The ${
+      useInlineTools
+        ? 'exceptions are:\n- The "analysis", "title", and "sourceSuggestionIds" attributes; these MUST be newly authored for each final suggestion.\n- Legacy "toolEdits"; convert these into instruction edits that add or remove the corresponding inline <tool> tag. Do NOT include "toolEdits" in the final edit_skill call.'
+        : 'only exceptions are the "analysis", "title", and "sourceSuggestionIds" attributes; these MUST be newly authored for each final suggestion.'
+    }
 
 For "analysis": Provide a user-facing explanation of why the suggestion is impactful and how many conversations support it. The end user does NOT care about the technical considerations behind your thought process.
 
@@ -85,11 +99,17 @@ For "title": You MUST provide a short, action-oriented, user-facing title that s
 
 For "sourceSuggestionIds": You MUST include the sIds of ALL the source suggestions that were consolidated into this final suggestion. Each suggestion has an sId attribute. Every final suggestion MUST reference at least one source suggestion.
 `,
-};
+  };
+}
 
-export function buildSkillAggregationSystemPrompt(): string {
+export function buildSkillAggregationSystemPrompt({
+  useInlineTools = false,
+}: {
+  useInlineTools?: boolean;
+} = {}): string {
+  const sections = getReinforcedSkillAggregationSections({ useInlineTools });
   return AGGREGATION_ASSEMBLY_ORDER.map((key) => {
-    const body = REINFORCED_SKILL_AGGREGATION_SECTIONS[key].trim();
+    const body = sections[key].trim();
     return `<${key}>\n${body}\n</${key}>`;
   }).join("\n\n");
 }
@@ -133,11 +153,12 @@ export function buildSkillAggregationPrompt(
   existingSuggestions: {
     pending: SkillSuggestionType[];
     rejected: SkillSuggestionType[];
-  }
+  },
+  { useInlineTools = false }: { useInlineTools?: boolean } = {}
 ): { systemPrompt: string; userMessage: string } {
-  const systemPrompt = buildSkillAggregationSystemPrompt();
+  const systemPrompt = buildSkillAggregationSystemPrompt({ useInlineTools });
 
-  let userMessage = `${formatSkillContext(skill)}
+  let userMessage = `${formatSkillContext(skill, { useInlineTools })}
 
 ## Synthetic suggestions from conversation analyses
 
@@ -166,11 +187,13 @@ interface SkillAggregationContext {
   skill: SkillResource;
   syntheticSuggestions: SkillSuggestionResource[];
   prompt: { systemPrompt: string; userMessage: string };
+  useInlineTools: boolean;
 }
 
 export async function loadSkillAggregationContext(
   auth: Authenticator,
-  skillId: string
+  skillId: string,
+  { useInlineTools }: { useInlineTools?: boolean } = {}
 ): Promise<SkillAggregationContext | null> {
   const syntheticSuggestions =
     await SkillSuggestionResource.listBySkillConfigurationId(auth, skillId, {
@@ -215,6 +238,8 @@ export async function loadSkillAggregationContext(
   );
 
   const skillType = skill.toJSON(auth);
+  const resolvedUseInlineTools =
+    useInlineTools ?? (await getFeatureFlags(auth)).includes("nested_skills");
 
   const prompt = buildSkillAggregationPrompt(
     skillType,
@@ -222,10 +247,16 @@ export async function loadSkillAggregationContext(
     {
       pending: pendingSuggestions.map((s) => s.toJSON()),
       rejected: recentRejectedSuggestions.map((s) => s.toJSON()),
-    }
+    },
+    { useInlineTools: resolvedUseInlineTools }
   );
 
-  return { skill, syntheticSuggestions, prompt };
+  return {
+    skill,
+    syntheticSuggestions,
+    prompt,
+    useInlineTools: resolvedUseInlineTools,
+  };
 }
 
 /**
@@ -246,7 +277,8 @@ export async function buildSkillAggregationBatchMap(
       "aggregation",
       buildReinforcedSkillsLLMParams(
         ctx.prompt,
-        "reinforcement_aggregate_suggestions"
+        "reinforcement_aggregate_suggestions",
+        { useInlineTools: ctx.useInlineTools }
       ),
     ],
   ]);

--- a/front/lib/reinforcement/aggregate_suggestions.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.ts
@@ -37,7 +37,7 @@ const REINFORCED_SKILL_AGGREGATION_SECTIONS: Record<
 Your job is to produce a subset of the highest quality suggestions for the skill builder to review.
 
 You have access to the following tools:
-- edit_skill: For suggesting instruction edits, tool add/remove, and/or agent-facing description changes for one skill.
+- edit_skill: For suggesting instruction edits, inline tool reference changes, and/or agent-facing description changes for one skill.
 - reject_suggestion: For discarding source suggestions that are invalid, not actionable, or too similar to already declined suggestions. Do NOT reject minor but valid suggestions, simply ignore them.
 
 Your goal is to keep the most impactful suggestions. NEVER create more than 5 suggestions.
@@ -52,7 +52,7 @@ It is ok to simply call no tool if all suggestions are minor.
   aggregation_rules: `
 Start by grouping suggestions by skill, then within each skill group by topic:
 - For instruction edits, group by coherent theme within the skill (e.g. tone, tool usage, formatting). Suggestions that address different topics MUST be kept as separate suggestions — do NOT merge unrelated topics into one suggestion.
-- For tool changes, group by the target tool within each skill. NEVER create more than one suggestion per tool.
+- For inline tool reference changes, group by the target <tool> reference within each skill. Tool references are instruction edits, so NEVER output separate tool edits.
 - For agent-facing description edits, create AT MOST ONE description-edit suggestion per skill. When multiple drafts target the description, merge them into a single coherent replacement.
 NEVER create more than one suggestion per (skill, topic) pair.
 
@@ -71,11 +71,13 @@ Classify the groups in these 3 categories:
 
 You SHOULD ignore suggestions that only have minor impact and are only supported by a single conversation (don't reject them, do NOT call reject_suggestion, just take no action for these suggestions).
 
-There may be situations where suggestions are co-dependent. For example, there may be an instruction suggestion that requires a tool suggestion to be effective. In this case, NEVER create one suggestion without the other.`,
+There may be situations where suggestions are co-dependent. For example, there may be an instruction suggestion that requires adding an inline <tool> tag to be effective. In this case, NEVER create one suggestion without the other.`,
 
   suggestion_tool_calls: `
 You are provided all of the attributes associated with a conversation suggestion. You MUST use these EXACT attributes to create the final suggestion.
-The only exceptions are the "analysis", "title", and "sourceSuggestionIds" attributes; these MUST be newly authored for each final suggestion.
+The exceptions are:
+- The "analysis", "title", and "sourceSuggestionIds" attributes; these MUST be newly authored for each final suggestion.
+- Legacy "toolEdits"; convert these into instruction edits that add or remove the corresponding inline <tool> tag. Do NOT include "toolEdits" in the final edit_skill call.
 
 For "analysis": Provide a user-facing explanation of why the suggestion is impactful and how many conversations support it. The end user does NOT care about the technical considerations behind your thought process.
 

--- a/front/lib/reinforcement/analyze_conversation.test.ts
+++ b/front/lib/reinforcement/analyze_conversation.test.ts
@@ -130,6 +130,7 @@ describe("buildSkillAnalysisPrompt", () => {
 
     expect(systemPrompt).toContain("edit_skill");
     expect(systemPrompt).toContain("get_available_tools");
+    expect(systemPrompt).toContain("inline <tool>");
   });
 
   it("system prompt has guidance for agent-facing description edits", () => {
@@ -142,7 +143,7 @@ describe("buildSkillAnalysisPrompt", () => {
     expect(systemPrompt).toMatch(/routing|when to enable/i);
   });
 
-  it("includes skill configured tools in user message", () => {
+  it("does not include skill tools as a separate user message block", () => {
     const skill = makeSkill({
       tools: [
         {
@@ -153,9 +154,9 @@ describe("buildSkillAnalysisPrompt", () => {
     });
     const { userMessage } = buildSkillAnalysisPrompt("User: hello", [skill]);
 
-    expect(userMessage).toContain("<tools>");
-    expect(userMessage).toContain('sId="tool-ws"');
-    expect(userMessage).toContain('name="web_search"');
+    expect(userMessage).not.toContain("<tools>");
+    expect(userMessage).not.toContain('sId="tool-ws"');
+    expect(userMessage).not.toContain('name="web_search"');
   });
 
   it("includes multiple skills in user message", () => {

--- a/front/lib/reinforcement/analyze_conversation.test.ts
+++ b/front/lib/reinforcement/analyze_conversation.test.ts
@@ -130,6 +130,18 @@ describe("buildSkillAnalysisPrompt", () => {
 
     expect(systemPrompt).toContain("edit_skill");
     expect(systemPrompt).toContain("get_available_tools");
+    expect(systemPrompt).not.toContain("inline <tool>");
+  });
+
+  it("system prompt mentions inline tool references when inline tools are enabled", () => {
+    const { systemPrompt } = buildSkillAnalysisPrompt(
+      "User: hello",
+      [makeSkill()],
+      { useInlineTools: true }
+    );
+
+    expect(systemPrompt).toContain("edit_skill");
+    expect(systemPrompt).toContain("get_available_tools");
     expect(systemPrompt).toContain("inline <tool>");
   });
 
@@ -143,7 +155,7 @@ describe("buildSkillAnalysisPrompt", () => {
     expect(systemPrompt).toMatch(/routing|when to enable/i);
   });
 
-  it("does not include skill tools as a separate user message block", () => {
+  it("includes skill tools as a separate user message block by default", () => {
     const skill = makeSkill({
       tools: [
         {
@@ -153,6 +165,24 @@ describe("buildSkillAnalysisPrompt", () => {
       ],
     });
     const { userMessage } = buildSkillAnalysisPrompt("User: hello", [skill]);
+
+    expect(userMessage).toContain("<tools>");
+    expect(userMessage).toContain('sId="tool-ws"');
+    expect(userMessage).toContain('name="web_search"');
+  });
+
+  it("does not include skill tools as a separate user message block when inline tools are enabled", () => {
+    const skill = makeSkill({
+      tools: [
+        {
+          sId: "tool-ws",
+          name: "web_search",
+        } as SkillType["tools"][number],
+      ],
+    });
+    const { userMessage } = buildSkillAnalysisPrompt("User: hello", [skill], {
+      useInlineTools: true,
+    });
 
     expect(userMessage).not.toContain("<tools>");
     expect(userMessage).not.toContain('sId="tool-ws"');

--- a/front/lib/reinforcement/analyze_conversation.ts
+++ b/front/lib/reinforcement/analyze_conversation.ts
@@ -1,9 +1,9 @@
 import { renderConversationAsTextWithFeedback } from "@app/lib/api/assistant/conversation/render_conversation_with_feedback";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
-import type { Authenticator } from "@app/lib/auth";
+import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { formatSkillContext } from "@app/lib/reinforcement/format_skill_context";
 import { buildReinforcedSkillsLLMParams } from "@app/lib/reinforcement/run_reinforced_analysis";
-import { SKILL_INSTRUCTION_HTML_EDIT_PROMPT } from "@app/lib/reinforcement/skill_instruction_edit_prompt";
+import { buildSkillInstructionHtmlEditPrompt } from "@app/lib/reinforcement/skill_instruction_edit_prompt";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import logger from "@app/logger/logger";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
@@ -21,8 +21,13 @@ const ASSEMBLY_ORDER = [
 
 type SectionKey = (typeof ASSEMBLY_ORDER)[number];
 
-const REINFORCED_SKILL_ANALYSIS_SECTIONS: Record<SectionKey, string> = {
-  primary_goal: `You are a Dust skill improvement analyst. Your job is to analyze a conversation that used one or more skills and suggest concrete improvements to those skills.
+function getReinforcedSkillAnalysisSections({
+  useInlineTools,
+}: {
+  useInlineTools: boolean;
+}): Record<SectionKey, string> {
+  return {
+    primary_goal: `You are a Dust skill improvement analyst. Your job is to analyze a conversation that used one or more skills and suggest concrete improvements to those skills.
 A skill bundles tools and instructions that are used by a Dust agent to perform a specific task.
 
 See <skill_usage_analysis> for guidance on how to analyze the relevance of a skill in the conversation.
@@ -35,22 +40,34 @@ In most conversations, the correct outcome is no configuration change. This mean
 Propose configuration changes only when <analysis_workflow> yields concrete evidence. If you are unsure, do not call edit_skill.
 
 ## Exploration tools (optional — use these if you need more context)
-- get_available_tools: ALWAYS call this before embedding any <tool> tag in an instruction edit — the tag requires an MCP server view ID and name that must come from this tool. See <tool_references> for more details.
+- get_available_tools: ${
+      useInlineTools
+        ? "ALWAYS call this before embedding any <tool> tag in an instruction edit — the tag requires an MCP server view ID and name that must come from this tool. See <tool_references> for more details."
+        : "Use this to discover tools you could suggest adding or to verify that suggested tools exist."
+    }
 - describe_mcp: ALWAYS call this before suggesting instruction changes that reference specific tool names or workflows for a given MCP — you need to know the exact tool names and their inputs to write accurate instructions.
 - search_knowledge: ALWAYS call this before embedding any <knowledge> tag in an instruction edit — the tag requires node attributes (id, space, dsv, hasChildren) that must come from this tool. Use this whenever the conversation shows the agent navigating or retrieving specific data nodes that the skill instructions should directly reference. See <knowledge_nodes> for more details.
 `,
 
-  skill_usage_analysis: `In <skill_context>, you have received all custom skills that were enabled in the conversation.
+    skill_usage_analysis: `In <skill_context>, you have received all custom skills that were enabled in the conversation.
 When enabled, skill instructions are rendered in the conversation as dedicated <dust_system> user messages.
 This means that every subsequent agent action can be influenced by each enabled skill in addition to the agent's system prompt.
-The only strong signal of skill influence on the agent behavior is when the agent calls a tool that the skill references in its instructions.
+The only strong signal of skill influence on the agent behavior is when the agent calls a tool that ${
+      useInlineTools
+        ? "the skill references in its instructions"
+        : "the skill provides"
+    }.
 You will need to infer the impact of the skill on the agent behavior by checking tool calls and agent messages.`,
 
-  analysis_workflow: `Follow this process for every conversation you analyze:
+    analysis_workflow: `Follow this process for every conversation you analyze:
 
 Step 1: Determine which skills were relevant to the conversation.
 For each skill in <skill_context>, ask yourself these questions:
-- Were any tools referenced by the skill's instructions called in <conversation>? Match inline <tool> tags and their described MCP tools against the functionCallName in actions.
+- ${
+      useInlineTools
+        ? "Were any tools referenced by the skill's instructions called in <conversation>? Match inline <tool> tags and their described MCP tools against the functionCallName in actions."
+        : "Were any of the skill's configured tools called in <conversation>? Match the skill's tool names/IDs against the functionCallName in actions."
+    }
 - Does the conversation topic match the skill's purpose and instructions? Use <agentFacingDescription> and <instructions> inside each <skill> in <skill_context>.
 - Was there an enable_skill tool call for the skill? If so, note when. This means the agent made an explicit decision to enable the skill for the rest of the conversation.
 
@@ -66,8 +83,14 @@ A key consideration is that conversations can be user-specific, but skills share
 Step 4: For each skill improvement identified in Step 3, formulate a suggestion.
 ALWAYS ensure that the suggestion is inline with the skill's purpose and instructions. Skills SHOULD be single purpose and not be overloaded with multiple responsibilities.
 Consider the following improvements to a skill:
-- Review instructions to determine if the skill is meeting the user intent and properly utilizing its inline tool references: <instructions_guidance>.
-- If the skill references or requires external actions or knowledge, inline <tool> or <knowledge> references may need to be added or removed from its instructions. See <tools_guidance>.
+- Review instructions to determine if the skill is meeting the user intent and properly utilizing ${
+      useInlineTools ? "its inline tool references" : "the configured tools"
+    }: <instructions_guidance>.
+- ${
+      useInlineTools
+        ? "If the skill references or requires external actions or knowledge, inline <tool> or <knowledge> references may need to be added or removed from its instructions. See <tools_guidance>."
+        : "If the skill references or requires external actions or knowledge, then tools may need to be added or removed. See <tools_guidance>."
+    }
 - If the conversation reveals that the agent enabled the skill in the wrong situation, or failed to enable it when it should have, the agent-facing description may need to be improved. See <agent_facing_description_guidance>.
 All improvements that should be treated as a single atomic unit should be grouped together in a single suggestion.
 NEVER group things that are not related to each other.
@@ -84,35 +107,49 @@ Step 7: Make suggestions.
 ONLY make suggestions that will affect the skill behavior. NEVER suggest cosmetic-only fixes.
 `,
 
-  conversation_analysis: `ALWAYS inspect the full conversation, which is a chronological timeline of messages. Agent messages may include an Actions section listing tool calls with their inputs and outputs, and a User feedback section with sentiment and comments. Here are key signals of areas where the agent behavior could be improved:
+    conversation_analysis: `ALWAYS inspect the full conversation, which is a chronological timeline of messages. Agent messages may include an Actions section listing tool calls with their inputs and outputs, and a User feedback section with sentiment and comments. Here are key signals of areas where the agent behavior could be improved:
 1. Feedback - If the user provided feedback, it will be included after the agent message in a "User feedback:" section with thumbs up/down ratings and optional comments. This is the MOST important signal as it is directly provided by the user and an explicit signal.
 2. User reaction - Any user indication of confusion, disagreement, or correction is a signal of dissatisfaction. A user follow-up question or request could mean the skill response was useful, but a skill could be improved in terms of proactively providing that information or performing the action without user intervention.
 3. Tool calls - If the tool calls needed to be retried, could a skill's instructions be more clear on how to use that tool?
 4. Sequence - Did the agent call the tools in the correct order?
 `,
 
-  instructions_guidance: `When suggesting instruction improvements for skills, follow these principles:
+    instructions_guidance: `When suggesting instruction improvements for skills, follow these principles:
 
 - Focus on actionable information that changes what the skill does.
 - Preserve the skill's existing goals — NEVER change what the goal is, only improve HOW it achieves it.
-- Instructions SHOULD reference how to use tools that are inlined in the skill instructions.
+- Instructions SHOULD reference how to use tools that are ${
+      useInlineTools
+        ? "inlined in the skill instructions"
+        : "configured in the skill"
+    }.
 - Suggestions ALWAYS need to be using the same language as the existing instructions OR, for new skills, the language of the user conversation.
 - Prefer small, focused changes over large rewrites.
 - Extract the INTENT from examples, not the literal pattern.
 - Filter out information only relevant for humans, not the LLM.`,
 
-  instruction_editing: SKILL_INSTRUCTION_HTML_EDIT_PROMPT,
+    instruction_editing: buildSkillInstructionHtmlEditPrompt({
+      useInlineTools,
+    }),
 
-  tools_guidance: `Tools provide capabilities to the skill through inline <tool> tags in the instructions. When evaluating tool changes:
+    tools_guidance: useInlineTools
+      ? `Tools provide capabilities to the skill through inline <tool> tags in the instructions. When evaluating tool changes:
 
 - Discover available tools by calling get_available_tools.
 - Only suggest adding a tool if there is clear evidence from the conversation that the skill needed a capability it did not have.
 - Only suggest removing a tool if there is clear evidence the tool is causing confusion or is unused and cluttering the skill configuration.
 - When suggesting a tool addition, ensure the tool exists in the workspace by checking available tools first.
 - Suggest tool additions by creating an instruction edit that embeds a self-closing <tool> tag in the relevant instruction block. Suggest tool removals by creating an instruction edit that removes the obsolete <tool> tag and related usage instructions. NEVER use separate tool edits.
+- When the conversation involves a tool call that failed or produced unexpected results, call describe_mcp for the relevant MCP to understand the full list of available tools and their correct usage before suggesting instruction changes.`
+      : `Tools provide capabilities to the skill. When evaluating tool changes:
+
+- Discover available tools by calling get_available_tools.
+- Only suggest adding a tool if there is clear evidence from the conversation that the skill needed a capability it did not have.
+- Only suggest removing a tool if there is clear evidence the tool is causing confusion or is unused and cluttering the skill configuration.
+- When suggesting a tool addition, ensure the tool exists in the workspace by checking available tools first.
 - When the conversation involves a tool call that failed or produced unexpected results, call describe_mcp for the relevant MCP to understand the full list of available tools and their correct usage before suggesting instruction changes.`,
 
-  agent_facing_description_guidance: `The agent-facing description (\`<agentFacingDescription>\` in the skill context) is what the agent reads to decide WHEN to enable the skill. It is NOT the skill's behavior — that lives in \`<instructions>\`.
+    agent_facing_description_guidance: `The agent-facing description (\`<agentFacingDescription>\` in the skill context) is what the agent reads to decide WHEN to enable the skill. It is NOT the skill's behavior — that lives in \`<instructions>\`.
 
 Suggest editing it only when the conversation surfaces clear evidence of a routing problem:
 - The agent enabled the skill in a situation it does not actually cover.
@@ -124,23 +161,30 @@ When suggesting a description edit:
 - Preserve the skill's actual purpose. Sharpen the trigger conditions; do not redefine the skill.
 - Keep it focused on routing signals (when to use, what scenarios). Do not duplicate the instructions.
 - Use the same language as the existing description.`,
-};
+  };
+}
 
-export function buildSkillAnalysisSystemPrompt(): string {
+export function buildSkillAnalysisSystemPrompt({
+  useInlineTools = false,
+}: {
+  useInlineTools?: boolean;
+} = {}): string {
+  const sections = getReinforcedSkillAnalysisSections({ useInlineTools });
   return ASSEMBLY_ORDER.map((key) => {
-    const body = REINFORCED_SKILL_ANALYSIS_SECTIONS[key].trim();
+    const body = sections[key].trim();
     return `<${key}>\n${body}\n</${key}>`;
   }).join("\n\n");
 }
 
 export function buildSkillAnalysisPrompt(
   conversationText: string,
-  skills: SkillType[]
+  skills: SkillType[],
+  { useInlineTools = false }: { useInlineTools?: boolean } = {}
 ): { systemPrompt: string; userMessage: string } {
-  const systemPrompt = buildSkillAnalysisSystemPrompt();
+  const systemPrompt = buildSkillAnalysisSystemPrompt({ useInlineTools });
 
   const skillContexts = skills
-    .map((s) => formatSkillContext(s))
+    .map((s) => formatSkillContext(s, { useInlineTools }))
     .join("\n\n---\n\n");
 
   const userMessage = `<skill_context>
@@ -161,9 +205,12 @@ ${conversationText}
  */
 export async function buildSkillConversationAnalysisBatchMap(
   auth: Authenticator,
-  conversationsWithSkills: { conversationId: string; skillIds: string[] }[]
+  conversationsWithSkills: { conversationId: string; skillIds: string[] }[],
+  { useInlineTools }: { useInlineTools?: boolean } = {}
 ): Promise<Map<string, LLMStreamParameters> | null> {
   const batchMap = new Map<string, LLMStreamParameters>();
+  const resolvedUseInlineTools =
+    useInlineTools ?? (await getFeatureFlags(auth)).includes("nested_skills");
 
   // Collect all unique skill sIds across all conversations.
   const allSkillIds = [
@@ -203,13 +250,15 @@ export async function buildSkillConversationAnalysisBatchMap(
 
     const prompt = buildSkillAnalysisPrompt(
       conversationRes.value.text,
-      skillTypes
+      skillTypes,
+      { useInlineTools: resolvedUseInlineTools }
     );
     batchMap.set(
       conversationId,
       buildReinforcedSkillsLLMParams(
         prompt,
-        "reinforcement_analyze_conversation"
+        "reinforcement_analyze_conversation",
+        { useInlineTools: resolvedUseInlineTools }
       )
     );
   }

--- a/front/lib/reinforcement/analyze_conversation.ts
+++ b/front/lib/reinforcement/analyze_conversation.ts
@@ -35,7 +35,7 @@ In most conversations, the correct outcome is no configuration change. This mean
 Propose configuration changes only when <analysis_workflow> yields concrete evidence. If you are unsure, do not call edit_skill.
 
 ## Exploration tools (optional — use these if you need more context)
-- get_available_tools: Use this to discover tools you could suggest adding or to verify that suggested tools exist.
+- get_available_tools: ALWAYS call this before embedding any <tool> tag in an instruction edit — the tag requires an MCP server view ID and name that must come from this tool. See <tool_references> for more details.
 - describe_mcp: ALWAYS call this before suggesting instruction changes that reference specific tool names or workflows for a given MCP — you need to know the exact tool names and their inputs to write accurate instructions.
 - search_knowledge: ALWAYS call this before embedding any <knowledge> tag in an instruction edit — the tag requires node attributes (id, space, dsv, hasChildren) that must come from this tool. Use this whenever the conversation shows the agent navigating or retrieving specific data nodes that the skill instructions should directly reference. See <knowledge_nodes> for more details.
 `,
@@ -43,14 +43,14 @@ Propose configuration changes only when <analysis_workflow> yields concrete evid
   skill_usage_analysis: `In <skill_context>, you have received all custom skills that were enabled in the conversation.
 When enabled, skill instructions are rendered in the conversation as dedicated <dust_system> user messages.
 This means that every subsequent agent action can be influenced by each enabled skill in addition to the agent's system prompt.
-The only strong signal of skill influence on the agent behavior is when the agent calls a tool that the skill provides.
+The only strong signal of skill influence on the agent behavior is when the agent calls a tool that the skill references in its instructions.
 You will need to infer the impact of the skill on the agent behavior by checking tool calls and agent messages.`,
 
   analysis_workflow: `Follow this process for every conversation you analyze:
 
 Step 1: Determine which skills were relevant to the conversation.
 For each skill in <skill_context>, ask yourself these questions:
-- Were any of the skill's configured tools called in <conversation>? Match the skill's tool names/IDs against the functionCallName in actions.
+- Were any tools referenced by the skill's instructions called in <conversation>? Match inline <tool> tags and their described MCP tools against the functionCallName in actions.
 - Does the conversation topic match the skill's purpose and instructions? Use <agentFacingDescription> and <instructions> inside each <skill> in <skill_context>.
 - Was there an enable_skill tool call for the skill? If so, note when. This means the agent made an explicit decision to enable the skill for the rest of the conversation.
 
@@ -66,8 +66,8 @@ A key consideration is that conversations can be user-specific, but skills share
 Step 4: For each skill improvement identified in Step 3, formulate a suggestion.
 ALWAYS ensure that the suggestion is inline with the skill's purpose and instructions. Skills SHOULD be single purpose and not be overloaded with multiple responsibilities.
 Consider the following improvements to a skill:
-- Review instructions to determine if the skill is meeting the user intent and properly utilizing the configured tools: <instructions_guidance>.
-- If the skill references or requires external actions or knowledge, then tools may need to be added or removed. See <tools_guidance>.
+- Review instructions to determine if the skill is meeting the user intent and properly utilizing its inline tool references: <instructions_guidance>.
+- If the skill references or requires external actions or knowledge, inline <tool> or <knowledge> references may need to be added or removed from its instructions. See <tools_guidance>.
 - If the conversation reveals that the agent enabled the skill in the wrong situation, or failed to enable it when it should have, the agent-facing description may need to be improved. See <agent_facing_description_guidance>.
 All improvements that should be treated as a single atomic unit should be grouped together in a single suggestion.
 NEVER group things that are not related to each other.
@@ -95,7 +95,7 @@ ONLY make suggestions that will affect the skill behavior. NEVER suggest cosmeti
 
 - Focus on actionable information that changes what the skill does.
 - Preserve the skill's existing goals — NEVER change what the goal is, only improve HOW it achieves it.
-- Instructions SHOULD reference how to use tools that are configured in the skill.
+- Instructions SHOULD reference how to use tools that are inlined in the skill instructions.
 - Suggestions ALWAYS need to be using the same language as the existing instructions OR, for new skills, the language of the user conversation.
 - Prefer small, focused changes over large rewrites.
 - Extract the INTENT from examples, not the literal pattern.
@@ -103,12 +103,13 @@ ONLY make suggestions that will affect the skill behavior. NEVER suggest cosmeti
 
   instruction_editing: SKILL_INSTRUCTION_HTML_EDIT_PROMPT,
 
-  tools_guidance: `Tools provide capabilities to the skill. When evaluating tool changes:
+  tools_guidance: `Tools provide capabilities to the skill through inline <tool> tags in the instructions. When evaluating tool changes:
 
 - Discover available tools by calling get_available_tools.
 - Only suggest adding a tool if there is clear evidence from the conversation that the skill needed a capability it did not have.
 - Only suggest removing a tool if there is clear evidence the tool is causing confusion or is unused and cluttering the skill configuration.
 - When suggesting a tool addition, ensure the tool exists in the workspace by checking available tools first.
+- Suggest tool additions by creating an instruction edit that embeds a self-closing <tool> tag in the relevant instruction block. Suggest tool removals by creating an instruction edit that removes the obsolete <tool> tag and related usage instructions. NEVER use separate tool edits.
 - When the conversation involves a tool call that failed or produced unexpected results, call describe_mcp for the relevant MCP to understand the full list of available tools and their correct usage before suggesting instruction changes.`,
 
   agent_facing_description_guidance: `The agent-facing description (\`<agentFacingDescription>\` in the skill context) is what the agent reads to decide WHEN to enable the skill. It is NOT the skill's behavior — that lives in \`<instructions>\`.

--- a/front/lib/reinforcement/format_skill_context.ts
+++ b/front/lib/reinforcement/format_skill_context.ts
@@ -4,16 +4,6 @@ import type { SkillType } from "@app/types/assistant/skill_configuration";
 import { escapeXml } from "@app/types/shared/utils/string_utils";
 
 export function formatSkillContext(skill: SkillType): string {
-  const toolsBlock =
-    skill.tools.length > 0
-      ? `<tools>${skill.tools
-          .map(
-            (t) =>
-              `<tool sId="${escapeXml(t.sId)}" name="${escapeXml(t.name ?? "")}"/>`
-          )
-          .join("")}</tools>`
-      : "";
-
   const descBlock = skill.agentFacingDescription
     ? `<agentFacingDescription>${escapeXml(skill.agentFacingDescription)}</agentFacingDescription>`
     : "";
@@ -24,5 +14,5 @@ export function formatSkillContext(skill: SkillType): string {
       )}</instructions>`
     : "";
 
-  return `<skill ID="${escapeXml(skill.sId)}" name="${escapeXml(skill.name)}">${toolsBlock}${descBlock}${instructionsBlock}</skill>`;
+  return `<skill ID="${escapeXml(skill.sId)}" name="${escapeXml(skill.name)}">${descBlock}${instructionsBlock}</skill>`;
 }

--- a/front/lib/reinforcement/format_skill_context.ts
+++ b/front/lib/reinforcement/format_skill_context.ts
@@ -3,7 +3,20 @@ import { stripToolTagPresentationAttributes } from "@app/lib/tools/format";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import { escapeXml } from "@app/types/shared/utils/string_utils";
 
-export function formatSkillContext(skill: SkillType): string {
+export function formatSkillContext(
+  skill: SkillType,
+  { useInlineTools = false }: { useInlineTools?: boolean } = {}
+): string {
+  const toolsBlock =
+    !useInlineTools && skill.tools.length > 0
+      ? `<tools>${skill.tools
+          .map(
+            (t) =>
+              `<tool sId="${escapeXml(t.sId)}" name="${escapeXml(t.name ?? "")}"/>`
+          )
+          .join("")}</tools>`
+      : "";
+
   const descBlock = skill.agentFacingDescription
     ? `<agentFacingDescription>${escapeXml(skill.agentFacingDescription)}</agentFacingDescription>`
     : "";
@@ -14,5 +27,5 @@ export function formatSkillContext(skill: SkillType): string {
       )}</instructions>`
     : "";
 
-  return `<skill ID="${escapeXml(skill.sId)}" name="${escapeXml(skill.name)}">${descBlock}${instructionsBlock}</skill>`;
+  return `<skill ID="${escapeXml(skill.sId)}" name="${escapeXml(skill.name)}">${toolsBlock}${descBlock}${instructionsBlock}</skill>`;
 }

--- a/front/lib/reinforcement/run_reinforced_analysis.test.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.test.ts
@@ -54,7 +54,13 @@ describe("buildReinforcedSkillsLLMParams", () => {
 describe("TOOL_SCHEMAS.edit_skill title validation", () => {
   const baseArgs = {
     skillId: "skl_abc",
-    toolEdits: [{ action: "add" as const, toolId: "tool_x" }],
+    instructionEdits: [
+      {
+        targetBlockId: "abc12345",
+        content: "<p>Updated.</p>",
+        type: "replace" as const,
+      },
+    ],
   };
 
   it("accepts a title of exactly 25 characters", () => {
@@ -76,7 +82,7 @@ describe("TOOL_SCHEMAS.edit_skill title validation", () => {
 });
 
 describe("TOOL_SCHEMAS.edit_skill agentFacingDescriptionEdit", () => {
-  it("accepts a description-only edit (no instruction or tool edits)", () => {
+  it("accepts a description-only edit (no instruction edits)", () => {
     const parsed = TOOL_SCHEMAS.edit_skill.safeParse({
       skillId: "skl_abc",
       agentFacingDescriptionEdit: {
@@ -86,7 +92,7 @@ describe("TOOL_SCHEMAS.edit_skill agentFacingDescriptionEdit", () => {
     expect(parsed.success).toBe(true);
   });
 
-  it("accepts a description edit alongside instruction/tool edits", () => {
+  it("accepts a description edit alongside instruction edits", () => {
     const parsed = TOOL_SCHEMAS.edit_skill.safeParse({
       skillId: "skl_abc",
       instructionEdits: [
@@ -96,7 +102,6 @@ describe("TOOL_SCHEMAS.edit_skill agentFacingDescriptionEdit", () => {
           type: "replace",
         },
       ],
-      toolEdits: [{ action: "add" as const, toolId: "tool_x" }],
       agentFacingDescriptionEdit: { content: "New description." },
     });
     expect(parsed.success).toBe(true);
@@ -139,6 +144,21 @@ describe("buildReinforcedSkillsLLMParams edit_skill spec", () => {
     expect(editSkillSpec).toBeDefined();
     expect(JSON.stringify(editSkillSpec?.inputSchema)).toContain(
       "agentFacingDescriptionEdit"
+    );
+  });
+
+  it("does not expose toolEdits on the edit_skill input schema", () => {
+    const params = buildReinforcedSkillsLLMParams(
+      { systemPrompt: "System.", userMessage: "User." },
+      "reinforcement_analyze_conversation"
+    );
+    const editSkillSpec = params.specifications?.find(
+      (s) => s.name === "edit_skill"
+    );
+
+    expect(editSkillSpec).toBeDefined();
+    expect(JSON.stringify(editSkillSpec?.inputSchema)).not.toContain(
+      "toolEdits"
     );
   });
 });

--- a/front/lib/reinforcement/run_reinforced_analysis.test.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.test.ts
@@ -1,5 +1,8 @@
 import { buildReinforcedSkillsLLMParams } from "@app/lib/reinforcement/run_reinforced_analysis";
-import { TOOL_SCHEMAS } from "@app/lib/reinforcement/types";
+import {
+  getEditSkillToolSchema,
+  TOOL_SCHEMAS,
+} from "@app/lib/reinforcement/types";
 import { describe, expect, it } from "vitest";
 
 describe("buildReinforcedSkillsLLMParams", () => {
@@ -116,6 +119,19 @@ describe("TOOL_SCHEMAS.edit_skill agentFacingDescriptionEdit", () => {
   });
 });
 
+describe("getEditSkillToolSchema", () => {
+  it("accepts legacy tool edits when inline tools are disabled", () => {
+    const parsed = getEditSkillToolSchema({
+      useInlineTools: false,
+    }).safeParse({
+      skillId: "skl_abc",
+      toolEdits: [{ action: "add", toolId: "tool_x" }],
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+});
+
 describe("buildReinforcedSkillsLLMParams edit_skill spec", () => {
   it("exposes agentFacingDescriptionEdit on the analyze edit_skill input schema", () => {
     const params = buildReinforcedSkillsLLMParams(
@@ -147,10 +163,24 @@ describe("buildReinforcedSkillsLLMParams edit_skill spec", () => {
     );
   });
 
-  it("does not expose toolEdits on the edit_skill input schema", () => {
+  it("exposes toolEdits by default when inline tools are disabled", () => {
     const params = buildReinforcedSkillsLLMParams(
       { systemPrompt: "System.", userMessage: "User." },
       "reinforcement_analyze_conversation"
+    );
+    const editSkillSpec = params.specifications?.find(
+      (s) => s.name === "edit_skill"
+    );
+
+    expect(editSkillSpec).toBeDefined();
+    expect(JSON.stringify(editSkillSpec?.inputSchema)).toContain("toolEdits");
+  });
+
+  it("does not expose toolEdits when inline tools are enabled", () => {
+    const params = buildReinforcedSkillsLLMParams(
+      { systemPrompt: "System.", userMessage: "User." },
+      "reinforcement_analyze_conversation",
+      { useInlineTools: true }
     );
     const editSkillSpec = params.specifications?.find(
       (s) => s.name === "edit_skill"

--- a/front/lib/reinforcement/run_reinforced_analysis.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.ts
@@ -48,7 +48,7 @@ const REINFORCED_SKILLS_TOOL_DEFINITIONS: Record<
 > = {
   get_available_tools: {
     description:
-      "Get the list of available tools (MCP servers) that can be added to skills.",
+      "Get the list of available tools (MCP servers) that can be referenced in skill instructions with inline <tool> tags.",
     schema: {},
   },
   [DESCRIBE_MCP_TOOL_NAME]: {
@@ -78,7 +78,7 @@ const REINFORCED_SKILLS_TOOL_DEFINITIONS: Record<
   },
   edit_skill: {
     description:
-      "Suggest edits to a skill's instructions and/or configured tools.",
+      "Suggest edits to a skill's instructions and/or agent-facing description.",
     schema: {
       skillId: z.string().describe("The sId of the skill to modify"),
       instructionEdits: z
@@ -99,21 +99,8 @@ const REINFORCED_SKILLS_TOOL_DEFINITIONS: Record<
         )
         .optional()
         .describe(
-          "Block-targeted edits to the skill instructions. Each item targets one block by its data-block-id."
+          "Block-targeted edits to the skill instructions. Each item targets one block by its data-block-id. Tool changes must be represented by adding or removing inline <tool> tags in these instruction edits."
         ),
-      toolEdits: z
-        .array(
-          z.object({
-            action: z
-              .enum(["add", "remove"])
-              .describe("Whether to add or remove the tool"),
-            toolId: z
-              .string()
-              .describe("The identifier of the tool to add or remove"),
-          })
-        )
-        .optional()
-        .describe("Tools to add or remove from the skill."),
       agentFacingDescriptionEdit: z
         .object({
           content: z
@@ -125,7 +112,7 @@ const REINFORCED_SKILLS_TOOL_DEFINITIONS: Record<
         })
         .optional()
         .describe(
-          "Replacement for the skill's agent-facing description. Should typically be its own suggestion, not bundled with instruction or tool edits."
+          "Replacement for the skill's agent-facing description. Should typically be its own suggestion, not bundled with instruction edits."
         ),
       analysis: z
         .string()
@@ -524,18 +511,13 @@ async function createSkillSuggestionsFromToolCall({
 
       const hasInstructionEdits =
         (parsed.data.instructionEdits?.length ?? 0) > 0;
-      const hasToolEdits = (parsed.data.toolEdits?.length ?? 0) > 0;
       const hasAgentFacingDescriptionEdit =
         parsed.data.agentFacingDescriptionEdit !== undefined;
-      if (
-        !hasInstructionEdits &&
-        !hasToolEdits &&
-        !hasAgentFacingDescriptionEdit
-      ) {
+      if (!hasInstructionEdits && !hasAgentFacingDescriptionEdit) {
         return {
           type: "error",
           errorMessage:
-            "edit_skill requires at least one instruction edit, tool edit, or description edit.",
+            "edit_skill requires at least one instruction edit or description edit.",
         };
       }
 
@@ -551,7 +533,6 @@ async function createSkillSuggestionsFromToolCall({
         hasSuggestionSelfConflict(
           {
             instructionEdits: parsed.data.instructionEdits,
-            toolEdits: parsed.data.toolEdits,
             agentFacingDescriptionEdit: parsed.data.agentFacingDescriptionEdit,
           },
           skill.instructionsHtml
@@ -560,7 +541,7 @@ async function createSkillSuggestionsFromToolCall({
         return {
           type: "error",
           errorMessage:
-            "Suggestion has conflicting edits (overlapping block targets or duplicate tool IDs).",
+            "Suggestion has conflicting edits (overlapping block targets).",
         };
       }
 
@@ -590,7 +571,6 @@ async function createSkillSuggestionsFromToolCall({
           kind: "edit",
           suggestion: {
             instructionEdits: parsed.data.instructionEdits,
-            toolEdits: parsed.data.toolEdits,
             agentFacingDescriptionEdit: parsed.data.agentFacingDescriptionEdit,
           },
           analysis: parsed.data.analysis ?? null,

--- a/front/lib/reinforcement/run_reinforced_analysis.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.ts
@@ -6,7 +6,7 @@ import type { LLM } from "@app/lib/api/llm/llm";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
-import type { Authenticator } from "@app/lib/auth";
+import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { getLargeWhitelistedModelWithBatchMode } from "@app/lib/reinforcement/models";
 import {
   hasSuggestionSelfConflict,
@@ -16,6 +16,7 @@ import {
   ALL_TOOLS,
   DESCRIBE_MCP_TOOL_NAME,
   type ExploratoryToolCallInfo,
+  getEditSkillToolSchema,
   getReinforcedSkillsMetadata,
   isExploratoryToolName,
   isTerminalToolName,
@@ -42,107 +43,95 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 export const REINFORCEMENT_SKILLS_AGENT_ID = "reinforcement";
 
 // Tool schemas for reinforced skills (exploration + terminal).
-const REINFORCED_SKILLS_TOOL_DEFINITIONS: Record<
+function buildReinforcedSkillsToolDefinitions({
+  useInlineTools,
+}: {
+  useInlineTools: boolean;
+}): Record<
   string,
-  { description: string; schema: z.ZodRawShape }
-> = {
-  get_available_tools: {
-    description:
-      "Get the list of available tools (MCP servers) that can be referenced in skill instructions with inline <tool> tags.",
-    schema: {},
-  },
-  [DESCRIBE_MCP_TOOL_NAME]: {
-    description:
-      "Get detailed information about a specific MCP server: its description, and each tool's name, description, and input parameters. Use this to understand what a tool can do before suggesting instruction changes that reference it.",
-    schema: {
-      mcpId: z.string().describe("The sId of the MCP server to describe"),
+  { description: string; schema: z.ZodObject<z.ZodRawShape> }
+> {
+  return {
+    get_available_tools: {
+      description: useInlineTools
+        ? "Get the list of available tools (MCP servers) that can be referenced in skill instructions with inline <tool> tags."
+        : "Get the list of available tools (MCP servers) that can be added to skills.",
+      schema: z.object({}),
     },
-  },
-  search_knowledge: {
-    description:
-      "Search workspace knowledge sources to discover relevant data nodes.",
-    schema: {
-      query: z
-        .string()
-        .describe("Natural language query describing the knowledge needed."),
-      topK: z
-        .number()
-        .int()
-        .positive()
-        .max(10)
-        .optional()
-        .describe(
-          "Maximum number of document hits to retrieve per data source (default: 5, only applies when query is provided)"
-        ),
+    [DESCRIBE_MCP_TOOL_NAME]: {
+      description:
+        "Get detailed information about a specific MCP server: its description, and each tool's name, description, and input parameters. Use this to understand what a tool can do before suggesting instruction changes that reference it.",
+      schema: z.object({
+        mcpId: z.string().describe("The sId of the MCP server to describe"),
+      }),
     },
-  },
-  edit_skill: {
-    description:
-      "Suggest edits to a skill's instructions and/or agent-facing description.",
-    schema: {
-      skillId: z.string().describe("The sId of the skill to modify"),
-      instructionEdits: z
-        .array(
-          z.object({
-            targetBlockId: z
-              .string()
-              .describe(
-                'The data-block-id of the block to replace. Use "instructions-root" to replace all instructions.'
-              ),
-            content: z
-              .string()
-              .describe(
-                "Full HTML replacement content for the block, including its wrapping tag. Must be a single-line string with no literal newlines."
-              ),
-            type: z.literal("replace"),
-          })
-        )
-        .optional()
-        .describe(
-          "Block-targeted edits to the skill instructions. Each item targets one block by its data-block-id. Tool changes must be represented by adding or removing inline <tool> tags in these instruction edits."
-        ),
-      agentFacingDescriptionEdit: z
-        .object({
-          content: z
-            .string()
-            .min(1)
-            .describe(
-              "The full new agent-facing description (replaces the current one)."
-            ),
-        })
-        .optional()
-        .describe(
-          "Replacement for the skill's agent-facing description. Should typically be its own suggestion, not bundled with instruction edits."
-        ),
-      analysis: z
-        .string()
-        .optional()
-        .describe("Why this change improves the skill"),
-      title: z
-        .string()
-        .max(25)
-        .optional()
-        .describe(
-          "A short, action-oriented user-facing title for this suggestion (MUST be at most 25 characters). " +
-            "Only set this when producing final aggregated suggestions; leave unset for synthetic suggestions."
-        ),
+    search_knowledge: {
+      description:
+        "Search workspace knowledge sources to discover relevant data nodes.",
+      schema: z.object({
+        query: z
+          .string()
+          .describe("Natural language query describing the knowledge needed."),
+        topK: z
+          .number()
+          .int()
+          .positive()
+          .max(10)
+          .optional()
+          .describe(
+            "Maximum number of document hits to retrieve per data source (default: 5, only applies when query is provided)"
+          ),
+      }),
     },
-  },
-  reject_suggestion: {
-    description:
-      "Reject source suggestions that are very bad quality, not actionable, or too similar to already declined suggestions. " +
-      "Use this tool in parallel with edit_skill calls — both are terminal and no further calls will be made after." +
-      "Do not use to ingore minor suggestions.",
-    schema: {
-      sourceSuggestionIds: z
-        .array(z.string())
-        .min(1)
-        .describe(
-          "The sIds of the source suggestions to reject. Must include at least one suggestion sId."
-        ),
+    edit_skill: {
+      description: useInlineTools
+        ? "Suggest edits to a skill's instructions and/or agent-facing description."
+        : "Suggest edits to a skill's instructions and/or configured tools.",
+      schema: getEditSkillToolSchema({ useInlineTools }),
     },
-  },
-};
+    reject_suggestion: {
+      description:
+        "Reject source suggestions that are very bad quality, not actionable, or too similar to already declined suggestions. " +
+        "Use this tool in parallel with edit_skill calls — both are terminal and no further calls will be made after." +
+        "Do not use to ingore minor suggestions.",
+      schema: z.object({
+        sourceSuggestionIds: z
+          .array(z.string())
+          .min(1)
+          .describe(
+            "The sIds of the source suggestions to reject. Must include at least one suggestion sId."
+          ),
+      }),
+    },
+  };
+}
+
+async function shouldUseInlineTools(auth: Authenticator): Promise<boolean> {
+  const featureFlags = await getFeatureFlags(auth);
+  return featureFlags.includes("nested_skills");
+}
+
+function getToolEdits(data: Record<string, unknown>) {
+  const toolEdits = data.toolEdits;
+  if (!Array.isArray(toolEdits)) {
+    return undefined;
+  }
+
+  return toolEdits.filter(
+    (
+      edit
+    ): edit is {
+      action: "add" | "remove";
+      toolId: string;
+    } =>
+      edit !== null &&
+      typeof edit === "object" &&
+      "action" in edit &&
+      (edit.action === "add" || edit.action === "remove") &&
+      "toolId" in edit &&
+      typeof edit.toolId === "string"
+  );
+}
 
 const AGGREGATION_EXTRA_FIELDS: z.ZodRawShape = {
   sourceSuggestionIds: z
@@ -155,9 +144,13 @@ const AGGREGATION_EXTRA_FIELDS: z.ZodRawShape = {
 };
 
 export function buildReinforcedSkillsSpecifications(
-  operationType: ReinforcedSkillsOperationType
+  operationType: ReinforcedSkillsOperationType,
+  { useInlineTools = false }: { useInlineTools?: boolean } = {}
 ): AgentActionSpecification[] {
   const isAggregation = operationType === "reinforcement_aggregate_suggestions";
+  const toolDefinitions = buildReinforcedSkillsToolDefinitions({
+    useInlineTools,
+  });
 
   return ALL_TOOLS.filter((toolName) => {
     // reject_suggestion is only available during aggregation.
@@ -166,11 +159,11 @@ export function buildReinforcedSkillsSpecifications(
     }
     return true;
   }).map((toolName) => {
-    const meta = REINFORCED_SKILLS_TOOL_DEFINITIONS[toolName];
+    const meta = toolDefinitions[toolName];
     const schema =
       toolName === "edit_skill" && isAggregation
-        ? z.object({ ...meta.schema, ...AGGREGATION_EXTRA_FIELDS })
-        : z.object(meta.schema);
+        ? meta.schema.extend(AGGREGATION_EXTRA_FIELDS)
+        : meta.schema;
     return {
       name: toolName,
       description: meta.description,
@@ -252,7 +245,8 @@ export function buildReinforcedSkillsLLMParams(
     systemPrompt: string;
     userMessage: string;
   },
-  operationType: ReinforcedSkillsOperationType
+  operationType: ReinforcedSkillsOperationType,
+  { useInlineTools = false }: { useInlineTools?: boolean } = {}
 ): LLMStreamParameters {
   return {
     conversation: {
@@ -265,7 +259,9 @@ export function buildReinforcedSkillsLLMParams(
       ],
     },
     prompt: systemPrompt,
-    specifications: buildReinforcedSkillsSpecifications(operationType),
+    specifications: buildReinforcedSkillsSpecifications(operationType, {
+      useInlineTools,
+    }),
   };
 }
 
@@ -279,14 +275,20 @@ export async function createReinforcedSkillsConversation(
     operationType,
     contextId,
     skillIds,
+    useInlineTools,
   }: {
     prompt: { systemPrompt: string; userMessage: string };
     operationType: ReinforcedSkillsOperationType;
     contextId: string;
     skillIds: string[];
+    useInlineTools?: boolean;
   }
 ): Promise<string> {
-  const llmParams = buildReinforcedSkillsLLMParams(prompt, operationType);
+  const resolvedUseInlineTools =
+    useInlineTools ?? (await shouldUseInlineTools(auth));
+  const llmParams = buildReinforcedSkillsLLMParams(prompt, operationType, {
+    useInlineTools: resolvedUseInlineTools,
+  });
   const { conversation: llmConversation, ...llmParamsWithoutConversation } =
     llmParams;
   const writeResult = await writeBatchUserMessages(auth, {
@@ -345,6 +347,7 @@ export async function processSkillReinforcedEvents({
   contextId,
   conversation,
   eligibleSkillIds,
+  useInlineTools,
 }: {
   auth: Authenticator;
   events: LLMEvent[];
@@ -353,6 +356,7 @@ export async function processSkillReinforcedEvents({
   contextId: string;
   conversation?: ConversationResource;
   eligibleSkillIds: string[];
+  useInlineTools?: boolean;
 }): Promise<ProcessReinforcedSkillsEventsResult> {
   const errorEvents = events.filter((e) => e.type === "error");
   if (errorEvents.length > 0) {
@@ -396,6 +400,8 @@ export async function processSkillReinforcedEvents({
   const approvedSourceSuggestionIds: string[] = [];
   const successfulToolCalls: TerminalToolCallSuccess[] = [];
   const failedToolCalls: TerminalToolCallFailure[] = [];
+  const resolvedUseInlineTools =
+    useInlineTools ?? (await shouldUseInlineTools(auth));
 
   for (const event of toolCallEvents) {
     const { id, name, arguments: args } = event.content;
@@ -409,6 +415,7 @@ export async function processSkillReinforcedEvents({
       contextId,
       conversation,
       eligibleSkillIds,
+      useInlineTools: resolvedUseInlineTools,
     });
     switch (result.type) {
       case "created": {
@@ -465,6 +472,7 @@ async function createSkillSuggestionsFromToolCall({
   contextId,
   conversation,
   eligibleSkillIds,
+  useInlineTools,
 }: {
   auth: Authenticator;
   toolName: string;
@@ -474,10 +482,13 @@ async function createSkillSuggestionsFromToolCall({
   contextId: string;
   conversation?: ConversationResource;
   eligibleSkillIds: string[];
+  useInlineTools: boolean;
 }): Promise<ToolCallResult> {
   switch (toolName) {
     case "edit_skill": {
-      const parsed = TOOL_SCHEMAS.edit_skill.safeParse(actionArguments);
+      const parsed = getEditSkillToolSchema({ useInlineTools }).safeParse(
+        actionArguments
+      );
       if (!parsed.success) {
         logger.warn(
           { contextId, toolName, error: parsed.error },
@@ -511,13 +522,20 @@ async function createSkillSuggestionsFromToolCall({
 
       const hasInstructionEdits =
         (parsed.data.instructionEdits?.length ?? 0) > 0;
+      const toolEdits = useInlineTools ? undefined : getToolEdits(parsed.data);
+      const hasToolEdits = (toolEdits?.length ?? 0) > 0;
       const hasAgentFacingDescriptionEdit =
         parsed.data.agentFacingDescriptionEdit !== undefined;
-      if (!hasInstructionEdits && !hasAgentFacingDescriptionEdit) {
+      if (
+        !hasInstructionEdits &&
+        !hasToolEdits &&
+        !hasAgentFacingDescriptionEdit
+      ) {
         return {
           type: "error",
-          errorMessage:
-            "edit_skill requires at least one instruction edit or description edit.",
+          errorMessage: useInlineTools
+            ? "edit_skill requires at least one instruction edit or description edit."
+            : "edit_skill requires at least one instruction edit, tool edit, or description edit.",
         };
       }
 
@@ -533,6 +551,7 @@ async function createSkillSuggestionsFromToolCall({
         hasSuggestionSelfConflict(
           {
             instructionEdits: parsed.data.instructionEdits,
+            toolEdits,
             agentFacingDescriptionEdit: parsed.data.agentFacingDescriptionEdit,
           },
           skill.instructionsHtml
@@ -540,8 +559,9 @@ async function createSkillSuggestionsFromToolCall({
       ) {
         return {
           type: "error",
-          errorMessage:
-            "Suggestion has conflicting edits (overlapping block targets).",
+          errorMessage: useInlineTools
+            ? "Suggestion has conflicting edits (overlapping block targets)."
+            : "Suggestion has conflicting edits (overlapping block targets or duplicate tool IDs).",
         };
       }
 
@@ -571,6 +591,7 @@ async function createSkillSuggestionsFromToolCall({
           kind: "edit",
           suggestion: {
             instructionEdits: parsed.data.instructionEdits,
+            ...(toolEdits !== undefined ? { toolEdits } : {}),
             agentFacingDescriptionEdit: parsed.data.agentFacingDescriptionEdit,
           },
           analysis: parsed.data.analysis ?? null,

--- a/front/lib/reinforcement/skill_instruction_edit_prompt.ts
+++ b/front/lib/reinforcement/skill_instruction_edit_prompt.ts
@@ -1,6 +1,6 @@
 import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
 
-export const SKILL_INSTRUCTION_HTML_EDIT_PROMPT = `
+const BASE_SKILL_INSTRUCTION_HTML_EDIT_PROMPT = `
 Skill instructions are organized as a hierarchy of blocks. You design this hierarchy
 so that future edits are precise. Group related instructions under parent blocks.
 Keep each leaf block to a single concern. A well-structured hierarchy means most
@@ -75,9 +75,9 @@ Example:
 \`\`\`
 <p data-block-id="a1b2c3d4">When answering questions about onboarding, refer to <knowledge id="doc_abc123" title="Onboarding Guide" space="space_xyz" dsv="dsv_456" hasChildren="false"/>.</p>
 \`\`\`
-</knowledge_nodes>
+</knowledge_nodes>`;
 
-<tool_references>
+const SKILL_TOOL_REFERENCES_INSTRUCTION_PROMPT = `<tool_references>
 Instructions can reference MCP tools using inline \`<tool>\` tags.
 During runtime, tools referenced this way are attached to the skill and available to the agent using it.
 
@@ -101,3 +101,20 @@ Example:
 <p data-block-id="a1b2c3d4">When researching pull requests, use <tool id="mcp_server_view_123" name="GitHub"/> and summarize the files changed before commenting.</p>
 \`\`\`
 </tool_references>`;
+
+export function buildSkillInstructionHtmlEditPrompt({
+  useInlineTools,
+}: {
+  useInlineTools: boolean;
+}): string {
+  if (!useInlineTools) {
+    return BASE_SKILL_INSTRUCTION_HTML_EDIT_PROMPT;
+  }
+
+  return `${BASE_SKILL_INSTRUCTION_HTML_EDIT_PROMPT}
+
+${SKILL_TOOL_REFERENCES_INSTRUCTION_PROMPT}`;
+}
+
+export const SKILL_INSTRUCTION_HTML_EDIT_PROMPT =
+  buildSkillInstructionHtmlEditPrompt({ useInlineTools: true });

--- a/front/lib/reinforcement/skill_instruction_edit_prompt.ts
+++ b/front/lib/reinforcement/skill_instruction_edit_prompt.ts
@@ -75,4 +75,29 @@ Example:
 \`\`\`
 <p data-block-id="a1b2c3d4">When answering questions about onboarding, refer to <knowledge id="doc_abc123" title="Onboarding Guide" space="space_xyz" dsv="dsv_456" hasChildren="false"/>.</p>
 \`\`\`
-</knowledge_nodes>`;
+</knowledge_nodes>
+
+<tool_references>
+Instructions can reference MCP tools using inline \`<tool>\` tags.
+During runtime, tools referenced this way are attached to the skill and available to the agent using it.
+
+\`\`\`
+<tool id="MCP_SERVER_VIEW_ID" name="MCP_SERVER_DISPLAY_NAME"/>
+\`\`\`
+
+Attribute mapping from get_available_tools results:
+- tag \`id\` <= \`ID\`
+- tag \`name\` <= \`name\`
+
+To embed a tool reference:
+1. Call \`get_available_tools\` to find the candidate MCP server view.
+2. Call \`describe_mcp\` for that MCP server view before writing instructions about exact tool names, inputs, or workflows.
+3. Embed the self-closing tag inline inside the relevant instruction block.
+
+To remove a tool reference, remove the \`<tool>\` tag and any instructions that only make sense with that tool.
+
+Example:
+\`\`\`
+<p data-block-id="a1b2c3d4">When researching pull requests, use <tool id="mcp_server_view_123" name="GitHub"/> and summarize the files changed before commenting.</p>
+\`\`\`
+</tool_references>`;

--- a/front/lib/reinforcement/types.ts
+++ b/front/lib/reinforcement/types.ts
@@ -60,21 +60,8 @@ export const TOOL_SCHEMAS: Record<
       .array(SkillInstructionEditArgSchema)
       .optional()
       .describe(
-        "Block-targeted edits to the skill instructions. Each item targets one block by its data-block-id."
+        "Block-targeted edits to the skill instructions. Each item targets one block by its data-block-id. Tool changes must be represented by adding or removing inline <tool> tags in these instruction edits."
       ),
-    toolEdits: z
-      .array(
-        z.object({
-          action: z
-            .enum(["add", "remove"])
-            .describe("Whether to add or remove the tool"),
-          toolId: z
-            .string()
-            .describe("The identifier of the tool to add or remove"),
-        })
-      )
-      .optional()
-      .describe("Tools to add or remove from the skill."),
     agentFacingDescriptionEdit: z
       .object({
         content: z
@@ -86,7 +73,7 @@ export const TOOL_SCHEMAS: Record<
       })
       .optional()
       .describe(
-        "Replacement for the skill's agent-facing description. Should typically be its own suggestion, not bundled with instruction or tool edits."
+        "Replacement for the skill's agent-facing description. Should typically be its own suggestion, not bundled with instruction edits."
       ),
     analysis: z
       .string()

--- a/front/lib/reinforcement/types.ts
+++ b/front/lib/reinforcement/types.ts
@@ -50,18 +50,36 @@ const SkillInstructionEditArgSchema = z.object({
   type: z.literal("replace"),
 });
 
-export const TOOL_SCHEMAS: Record<
-  TerminalToolName,
-  z.ZodObject<z.ZodRawShape>
-> = {
-  edit_skill: z.object({
+const SkillToolEditArgSchema = z.object({
+  action: z
+    .enum(["add", "remove"])
+    .describe("Whether to add or remove the tool"),
+  toolId: z.string().describe("The identifier of the tool to add or remove"),
+});
+
+export function getEditSkillToolSchema({
+  useInlineTools,
+}: {
+  useInlineTools: boolean;
+}): z.ZodObject<z.ZodRawShape> {
+  return z.object({
     skillId: z.string().describe("The sId of the skill to modify"),
     instructionEdits: z
       .array(SkillInstructionEditArgSchema)
       .optional()
       .describe(
-        "Block-targeted edits to the skill instructions. Each item targets one block by its data-block-id. Tool changes must be represented by adding or removing inline <tool> tags in these instruction edits."
+        useInlineTools
+          ? "Block-targeted edits to the skill instructions. Each item targets one block by its data-block-id. Tool changes must be represented by adding or removing inline <tool> tags in these instruction edits."
+          : "Block-targeted edits to the skill instructions. Each item targets one block by its data-block-id."
       ),
+    ...(useInlineTools
+      ? {}
+      : {
+          toolEdits: z
+            .array(SkillToolEditArgSchema)
+            .optional()
+            .describe("Tools to add or remove from the skill."),
+        }),
     agentFacingDescriptionEdit: z
       .object({
         content: z
@@ -73,7 +91,9 @@ export const TOOL_SCHEMAS: Record<
       })
       .optional()
       .describe(
-        "Replacement for the skill's agent-facing description. Should typically be its own suggestion, not bundled with instruction edits."
+        useInlineTools
+          ? "Replacement for the skill's agent-facing description. Should typically be its own suggestion, not bundled with instruction edits."
+          : "Replacement for the skill's agent-facing description. Should typically be its own suggestion, not bundled with instruction or tool edits."
       ),
     analysis: z
       .string()
@@ -94,7 +114,14 @@ export const TOOL_SCHEMAS: Record<
       .describe(
         "The sIds of the source suggestions consolidated into this suggestion."
       ),
-  }),
+  });
+}
+
+export const TOOL_SCHEMAS: Record<
+  TerminalToolName,
+  z.ZodObject<z.ZodRawShape>
+> = {
+  edit_skill: getEditSkillToolSchema({ useInlineTools: true }),
   reject_suggestion: z.object({
     sourceSuggestionIds: z
       .array(z.string())

--- a/front/scripts/seed/reinforcement/assets/skill_suggestions.json
+++ b/front/scripts/seed/reinforcement/assets/skill_suggestions.json
@@ -11,14 +11,8 @@
       "instructionEdits": [
         {
           "targetBlockId": "ci02intr",
-          "content": "<p>When searching for contact information, follow these steps. When internal directories are insufficient, also leverage the web search tool to find publicly available professional contact information:</p>",
+          "content": "<p>When searching for contact information, follow these steps. When internal directories are insufficient, use <tool id=\"__WEB_SEARCH_TOOL_ID__\" name=\"Web Search\" /> to find publicly available professional contact information:</p>",
           "type": "replace"
-        }
-      ],
-      "toolEdits": [
-        {
-          "action": "add",
-          "toolId": "web_search_&_browse"
         }
       ]
     }

--- a/front/scripts/seed/reinforcement/seed.test.ts
+++ b/front/scripts/seed/reinforcement/seed.test.ts
@@ -144,12 +144,17 @@ describe("reinforcement seed script integration test", () => {
     );
     expect(allReinforcement).toBe(true);
 
-    // First suggestion has both instruction edits and tool edits
-    const withToolEdits = skillSuggestions.find((s) => {
+    // First suggestion includes an inline tool reference in its instruction edit
+    // so the nested_skills path can be exercised manually from seed data.
+    const withInlineToolReference = skillSuggestions.find((s) => {
       const json = s.toJSON();
-      return json.suggestion.toolEdits && json.suggestion.toolEdits.length > 0;
+      return json.suggestion.instructionEdits?.some(
+        (edit) =>
+          edit.content.includes("<tool") &&
+          edit.content.includes('name="Web Search"')
+      );
     });
-    expect(withToolEdits).toBeDefined();
+    expect(withInlineToolReference).toBeDefined();
 
     // Second suggestion has 2 instruction edits and no tool edits
     const withOnlyInstructionEdits = skillSuggestions.find((s) => {

--- a/front/scripts/seed/reinforcement/seed.ts
+++ b/front/scripts/seed/reinforcement/seed.ts
@@ -12,6 +12,7 @@ makeScript({}, async ({ execute }, logger) => {
     await FeatureFlagResource.enableMany(ctx.workspace, [
       "reinforced_agents",
       "reinforcement_ui",
+      "nested_skills",
     ]);
     logger.info("Feature flag enabled");
   }

--- a/front/scripts/seed/reinforcement/seedReinforcement.ts
+++ b/front/scripts/seed/reinforcement/seedReinforcement.ts
@@ -1,7 +1,9 @@
+import { WEB_SEARCH_BROWSE_SERVER_NAME } from "@app/lib/api/actions/servers/web_search_browse/metadata";
 import { MessageModel } from "@app/lib/models/agent/conversation";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type {
   AgentAsset,
@@ -149,6 +151,27 @@ export async function seedReinforcement(
     ctx.logger.warn(
       { error: e },
       "Failed to seed data sources (CoreAPI unavailable?), skills will have unresolved placeholders"
+    );
+  }
+
+  ctx.logger.info("Resolving MCP tool placeholders...");
+  try {
+    if (ctx.execute) {
+      await MCPServerViewResource.ensureAllAutoToolsAreCreated(ctx.auth);
+      const [webSearchView] =
+        await MCPServerViewResource.getMCPServerViewsForAutoInternalTools(
+          ctx.auth,
+          [WEB_SEARCH_BROWSE_SERVER_NAME]
+        );
+      const webSearchViewJson = webSearchView?.toJSON();
+      if (webSearchViewJson) {
+        placeholders.__WEB_SEARCH_TOOL_ID__ = webSearchViewJson.sId;
+      }
+    }
+  } catch (e) {
+    ctx.logger.warn(
+      { error: e },
+      "Failed to resolve MCP tool placeholders, inline tool seed suggestions will have unresolved placeholders"
     );
   }
 

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -167,6 +167,7 @@ async function runReinforcedSkillsStep({
   source,
   conversation,
   eligibleSkillIds,
+  useInlineTools,
 }: {
   auth: Authenticator;
   reinforcementConversationId: string;
@@ -176,6 +177,7 @@ async function runReinforcedSkillsStep({
   source: "synthetic" | "reinforcement";
   conversation?: ConversationResource;
   eligibleSkillIds: string[];
+  useInlineTools: boolean;
 }): Promise<{
   isTerminal: boolean;
   suggestionsCreated: number;
@@ -205,7 +207,9 @@ async function runReinforcedSkillsStep({
     throw conversationRes.error;
   }
 
-  const specifications = buildReinforcedSkillsSpecifications(operationType);
+  const specifications = buildReinforcedSkillsSpecifications(operationType, {
+    useInlineTools,
+  });
   const modelConfig = llm.getModelConfig();
   const toolsJson = JSON.stringify(
     specifications.map((s) => ({
@@ -289,6 +293,7 @@ async function runReinforcedSkillsStep({
       contextId,
       conversation,
       eligibleSkillIds,
+      useInlineTools,
     });
 
     // Store results for all terminal tool calls so the conversation is complete.
@@ -693,6 +698,7 @@ export async function analyzeConversationStepActivity({
   toolActionInfo?: ReinforcedToolActionInfo;
 }> {
   const auth = await getAuthForWorkspace(workspaceId);
+  const useInlineTools = await hasFeatureFlag(auth, "nested_skills");
 
   // On first step, build the analysis prompt and create a reinforcement conversation.
   if (!reinforcementConversationId) {
@@ -731,7 +737,8 @@ export async function analyzeConversationStepActivity({
 
     const prompt = buildSkillAnalysisPrompt(
       conversationRes.value.text,
-      skillTypes
+      skillTypes,
+      { useInlineTools }
     );
     reinforcementConversationId = await createReinforcedSkillsConversation(
       auth,
@@ -740,6 +747,7 @@ export async function analyzeConversationStepActivity({
         operationType: "reinforcement_analyze_conversation",
         contextId: conversationId,
         skillIds: skillIds,
+        useInlineTools,
       }
     );
   }
@@ -752,11 +760,12 @@ export async function analyzeConversationStepActivity({
     auth,
     reinforcementConversationId,
     operationType: "reinforcement_analyze_conversation",
-    systemPrompt: buildSkillAnalysisSystemPrompt(),
+    systemPrompt: buildSkillAnalysisSystemPrompt({ useInlineTools }),
     contextId: conversationId,
     source: "synthetic",
     conversation,
     eligibleSkillIds: skillIds,
+    useInlineTools,
   });
   return { ...result, reinforcementConversationId };
 }
@@ -826,10 +835,13 @@ export async function aggregateSuggestionsForSkillStepActivity({
   toolActionInfo?: ReinforcedToolActionInfo;
 }> {
   const auth = await getAuthForWorkspace(workspaceId);
+  const useInlineTools = await hasFeatureFlag(auth, "nested_skills");
 
   // On first step, load aggregation context and create a reinforcement conversation.
   if (!reinforcementConversationId) {
-    const ctx = await loadSkillAggregationContext(auth, skillId);
+    const ctx = await loadSkillAggregationContext(auth, skillId, {
+      useInlineTools,
+    });
     if (!ctx) {
       return {
         isTerminal: true,
@@ -845,6 +857,7 @@ export async function aggregateSuggestionsForSkillStepActivity({
         operationType: "reinforcement_aggregate_suggestions",
         contextId: skillId,
         skillIds: [skillId],
+        useInlineTools,
       }
     );
   }
@@ -853,10 +866,11 @@ export async function aggregateSuggestionsForSkillStepActivity({
     auth,
     reinforcementConversationId,
     operationType: "reinforcement_aggregate_suggestions",
-    systemPrompt: buildSkillAggregationSystemPrompt(),
+    systemPrompt: buildSkillAggregationSystemPrompt({ useInlineTools }),
     contextId: skillId,
     source: "reinforcement",
     eligibleSkillIds: [skillId],
+    useInlineTools,
   });
   return { ...result, reinforcementConversationId };
 }
@@ -978,6 +992,7 @@ export async function startSkillConversationAnalysisBatchActivity({
   reinforcementConversationMap: Record<string, string>;
 } | null> {
   const auth = await getAuthForWorkspace(workspaceId);
+  const useInlineTools = await hasFeatureFlag(auth, "nested_skills");
 
   const llm = await getReinforcedSkillsLLM(
     auth,
@@ -1001,13 +1016,15 @@ export async function startSkillConversationAnalysisBatchActivity({
   if (firstTimeConversations.length > 0) {
     batchMap = await buildSkillConversationAnalysisBatchMap(
       auth,
-      firstTimeConversations
+      firstTimeConversations,
+      { useInlineTools }
     );
   }
 
-  const systemPrompt = buildSkillAnalysisSystemPrompt();
+  const systemPrompt = buildSkillAnalysisSystemPrompt({ useInlineTools });
   const specifications = buildReinforcedSkillsSpecifications(
-    "reinforcement_analyze_conversation"
+    "reinforcement_analyze_conversation",
+    { useInlineTools }
   );
 
   const batchConversations: LlmConversationOptions[] = [];
@@ -1111,6 +1128,7 @@ export async function processSkillConversationAnalysisBatchResultActivity({
   conversationSkillMap: Record<string, string[]>;
 }): Promise<ConversationContinuationInfo[]> {
   const auth = await getAuthForWorkspace(workspaceId);
+  const useInlineTools = await hasFeatureFlag(auth, "nested_skills");
 
   const llm = await getReinforcedSkillsLLM(
     auth,
@@ -1202,6 +1220,7 @@ export async function processSkillConversationAnalysisBatchResultActivity({
         contextId: analysedConvId,
         conversation: conversationById.get(analysedConvId),
         eligibleSkillIds: conversationSkillMap[analysedConvId] ?? [],
+        useInlineTools,
       });
       totalCreated += result.suggestionsCreated;
 
@@ -1275,6 +1294,7 @@ export async function startSkillAggregationBatchActivity({
   reinforcementConversationIds: string[];
 } | null> {
   const auth = await getAuthForWorkspace(workspaceId);
+  const useInlineTools = await hasFeatureFlag(auth, "nested_skills");
 
   const llm = await getReinforcedSkillsLLM(
     auth,
@@ -1289,9 +1309,10 @@ export async function startSkillAggregationBatchActivity({
     return null;
   }
 
-  const systemPrompt = buildSkillAggregationSystemPrompt();
+  const systemPrompt = buildSkillAggregationSystemPrompt({ useInlineTools });
   const specifications = buildReinforcedSkillsSpecifications(
-    "reinforcement_aggregate_suggestions"
+    "reinforcement_aggregate_suggestions",
+    { useInlineTools }
   );
 
   let batchConversations: LlmConversationOptions[];
@@ -1386,6 +1407,7 @@ export async function processSkillAggregationBatchResultActivity({
   toolActionInfo?: ReinforcedToolActionInfo;
 }> {
   const auth = await getAuthForWorkspace(workspaceId);
+  const useInlineTools = await hasFeatureFlag(auth, "nested_skills");
 
   const llm = await getReinforcedSkillsLLM(
     auth,
@@ -1458,6 +1480,7 @@ export async function processSkillAggregationBatchResultActivity({
       operationType: "reinforcement_aggregate_suggestions",
       contextId: skillId,
       eligibleSkillIds: [skillId],
+      useInlineTools,
     });
 
     // Store results for all terminal tool calls.

--- a/front/tests/reinforcement-evals/lib/assertions.ts
+++ b/front/tests/reinforcement-evals/lib/assertions.ts
@@ -87,6 +87,18 @@ function getToolEdits(args: Record<string, unknown>): ToolEditItem[] {
   return edits.filter(isToolEditItem);
 }
 
+function instructionEditsContainToolReference(
+  instructionEdits: InstructionEditItem[],
+  toolId: string
+): boolean {
+  const escapedToolId = toolId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const toolReferenceRegex = new RegExp(
+    `<tool\\b[^>]*\\bid=["']${escapedToolId}["']`,
+    "i"
+  );
+  return instructionEdits.some((e) => toolReferenceRegex.test(e.content));
+}
+
 function getAgentFacingDescriptionEditContent(
   args: Record<string, unknown>
 ): string | undefined {
@@ -152,6 +164,66 @@ export function validateToolCallAssertion(
         return {
           success: false,
           error: `Expected an edit_skill call with toolEdit toolId "${assertion.toolId}" for skillId "${assertion.skillId}", but no such call was made`,
+        };
+      }
+      if (assertion.sourceSuggestionIds) {
+        const sourceResult = validateSourceSuggestionIds(
+          call,
+          assertion.sourceSuggestionIds
+        );
+        if (sourceResult) {
+          return sourceResult;
+        }
+      }
+      return { success: true };
+    }
+    case "editSkillWithInlineToolReference": {
+      const call = findEditSkillCall(toolCalls, (c) => {
+        const instructionEdits = getInstructionEdits(c.arguments);
+        return (
+          getSkillId(c.arguments) === assertion.skillId &&
+          instructionEdits.length > 0 &&
+          getToolEdits(c.arguments).length === 0 &&
+          instructionEditsContainToolReference(
+            instructionEdits,
+            assertion.toolId
+          )
+        );
+      });
+      if (!call) {
+        return {
+          success: false,
+          error: `Expected an edit_skill call with instructionEdits referencing inline tool "${assertion.toolId}" for skillId "${assertion.skillId}", and no toolEdits, but no such call was made`,
+        };
+      }
+      if (assertion.sourceSuggestionIds) {
+        const sourceResult = validateSourceSuggestionIds(
+          call,
+          assertion.sourceSuggestionIds
+        );
+        if (sourceResult) {
+          return sourceResult;
+        }
+      }
+      return { success: true };
+    }
+    case "editSkillWithoutInlineToolReference": {
+      const call = findEditSkillCall(toolCalls, (c) => {
+        const instructionEdits = getInstructionEdits(c.arguments);
+        return (
+          getSkillId(c.arguments) === assertion.skillId &&
+          instructionEdits.length > 0 &&
+          getToolEdits(c.arguments).length === 0 &&
+          !instructionEditsContainToolReference(
+            instructionEdits,
+            assertion.toolId
+          )
+        );
+      });
+      if (!call) {
+        return {
+          success: false,
+          error: `Expected an edit_skill call with instructionEdits removing inline tool "${assertion.toolId}" for skillId "${assertion.skillId}", and no toolEdits, but no such call was made`,
         };
       }
       if (assertion.sourceSuggestionIds) {

--- a/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
+++ b/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
@@ -101,13 +101,16 @@ function buildPromptForTestCase(testCase: TestCase): {
   if (isAnalysisTestCase(testCase)) {
     const skillTypes = testCase.skillConfigs.map(makeSkillType);
     const conversationText = buildConversationText(testCase.conversation);
-    return buildSkillAnalysisPrompt(conversationText, skillTypes);
+    return buildSkillAnalysisPrompt(conversationText, skillTypes, {
+      useInlineTools: testCase.useInlineTools,
+    });
   }
   const skillType = makeSkillType(testCase.skillConfig);
   return buildSkillAggregationPrompt(
     skillType,
     testCase.syntheticSuggestions,
-    testCase.existingSuggestions ?? { pending: [], rejected: [] }
+    testCase.existingSuggestions ?? { pending: [], rejected: [] },
+    { useInlineTools: testCase.useInlineTools }
   );
 }
 
@@ -327,7 +330,9 @@ export async function executeReinforced(
   const operationType = isAggregationTestCase(testCase)
     ? "reinforcement_aggregate_suggestions"
     : "reinforcement_analyze_conversation";
-  const params = buildReinforcedSkillsLLMParams(prompt, operationType);
+  const params = buildReinforcedSkillsLLMParams(prompt, operationType, {
+    useInlineTools: testCase.useInlineTools,
+  });
 
   return executeMultiStep(
     llm,
@@ -380,7 +385,9 @@ export async function executeBatch(
       : "reinforcement_analyze_conversation";
     pendingParams.set(
       tc.scenarioId,
-      buildReinforcedSkillsLLMParams(prompt, operationType)
+      buildReinforcedSkillsLLMParams(prompt, operationType, {
+        useInlineTools: tc.useInlineTools,
+      })
     );
   }
 

--- a/front/tests/reinforcement-evals/lib/types.ts
+++ b/front/tests/reinforcement-evals/lib/types.ts
@@ -127,6 +127,7 @@ export interface MockSkillConfig {
 
 interface BaseTestCase {
   scenarioId: string;
+  useInlineTools?: boolean;
   expectedToolCalls?: ToolCallAssertion[];
   judgeCriteria: string;
   workspaceContext: WorkspaceContext;
@@ -205,6 +206,18 @@ export type ToolCallAssertion =
       sourceSuggestionIds?: string[];
     }
   | {
+      type: "editSkillWithInlineToolReference";
+      skillId: string;
+      toolId: string;
+      sourceSuggestionIds?: string[];
+    }
+  | {
+      type: "editSkillWithoutInlineToolReference";
+      skillId: string;
+      toolId: string;
+      sourceSuggestionIds?: string[];
+    }
+  | {
       type: "editSkillWithAgentFacingDescription";
       skillId: string;
       sourceSuggestionIds?: string[];
@@ -234,6 +247,34 @@ export function editSkillWithTool(
   sourceSuggestionIds?: string[]
 ): ToolCallAssertion {
   return { type: "editSkillWithTool", skillId, toolId, sourceSuggestionIds };
+}
+
+/** Expects an edit_skill call that adds/references a tool via instructionEdits. */
+export function editSkillWithInlineToolReference(
+  skillId: string,
+  toolId: string,
+  sourceSuggestionIds?: string[]
+): ToolCallAssertion {
+  return {
+    type: "editSkillWithInlineToolReference",
+    skillId,
+    toolId,
+    sourceSuggestionIds,
+  };
+}
+
+/** Expects an edit_skill instruction edit that removes a tool reference. */
+export function editSkillWithoutInlineToolReference(
+  skillId: string,
+  toolId: string,
+  sourceSuggestionIds?: string[]
+): ToolCallAssertion {
+  return {
+    type: "editSkillWithoutInlineToolReference",
+    skillId,
+    toolId,
+    sourceSuggestionIds,
+  };
 }
 
 /** Expects an edit_skill call with an agentFacingDescriptionEdit for the given skill. */

--- a/front/tests/reinforcement-evals/test-suites/aggregate-suggestions.ts
+++ b/front/tests/reinforcement-evals/test-suites/aggregate-suggestions.ts
@@ -2,8 +2,8 @@ import {
   editSkillCallCount,
   editSkillCallsWithSources,
   editSkillWithAgentFacingDescription,
+  editSkillWithInlineToolReference,
   editSkillWithInstructions,
-  editSkillWithTool,
   mockTool,
   noSuggestion,
   rejectSuggestion,
@@ -188,6 +188,7 @@ Score 3 if well-merged with all themes, clear structure, and analysis referencin
     {
       scenarioId: "merge-duplicate-tools",
       type: "aggregation",
+      useInlineTools: true,
       skillConfig: {
         name: "Engineering Helper",
         sId: "skill_engineering",
@@ -223,20 +224,21 @@ Score 3 if well-merged with all themes, clear structure, and analysis referencin
       ],
       workspaceContext: WORKSPACE_CONTEXT,
       expectedToolCalls: [
-        editSkillWithTool("skill_engineering", "mcp_jira", [
+        editSkillWithInlineToolReference("skill_engineering", "mcp_jira", [
           "sug-1",
           "sug-2",
           "sug-3",
         ]),
       ],
-      judgeCriteria: `The analyst MUST call edit_skill with toolEdits to suggest adding JIRA (mcp_jira)
-to skill "skill_engineering". The aggregated suggestion should:
+      judgeCriteria: `The analyst MUST call edit_skill with instructionEdits to suggest adding JIRA (mcp_jira)
+as an inline <tool id="mcp_jira" name="JIRA" /> reference to skill "skill_engineering". The aggregated suggestion should:
 - Merge the 3 individual suggestions into a single recommendation
 - Mention that 3 conversations support this suggestion
 - Include a comprehensive analysis covering the different use cases (ticket creation, sprint status, assignment)
-- Use action "add" with toolId "mcp_jira"
+- Convert the legacy source toolEdits into an instruction edit with an inline <tool> tag; it MUST NOT include toolEdits
 
 Score 0 if no edit_skill call or if it creates 3 separate calls.
+Score 0 if the final edit_skill call uses toolEdits instead of an inline <tool> instruction edit.
 Score 1 if merged but analysis doesn't reference multiple conversations/use cases.
 Score 2 if properly merged with multi-conversation reference but analysis could be better.
 Score 3 if well-merged with clear analysis covering all use cases and conversation count.`,
@@ -460,6 +462,7 @@ Score 3 if no edit_skill suggestion is created AND reject_suggestion is not call
     {
       scenarioId: "merge-description-edits-keep-tool-separate",
       type: "aggregation",
+      useInlineTools: true,
       skillConfig: {
         name: "Payment Issue Resolver",
         sId: "skill_payment_resolver",
@@ -500,19 +503,22 @@ Score 3 if no edit_skill suggestion is created AND reject_suggestion is not call
           "sug-desc-1",
           "sug-desc-2",
         ]),
-        editSkillWithTool("skill_payment_resolver", "mcp_jira", ["sug-tool-1"]),
+        editSkillWithInlineToolReference("skill_payment_resolver", "mcp_jira", [
+          "sug-tool-1",
+        ]),
       ],
       judgeCriteria: `Two of the three drafts target the agent-facing description (both about narrowing routing), and one is unrelated tooling work (adding JIRA). Aggregation rules require:
 - ONE description-edit suggestion per skill, merging both description drafts (sug-desc-1 + sug-desc-2). The merged description must explicitly limit the skill to payment failures + chargebacks AND steer the agent away from generic billing/invoice/account-management requests.
 - The description edit MUST be its own standalone edit_skill call. Do NOT bundle it with the tool addition (different topic, different fix).
-- A separate edit_skill call for the JIRA tool addition (sug-tool-1).
+- A separate edit_skill call that converts the legacy JIRA tool addition (sug-tool-1) into an instruction edit with an inline <tool id="mcp_jira" name="JIRA" /> reference. It MUST NOT include toolEdits.
 
 Score 0 if no edit_skill call carries an agentFacingDescriptionEdit for skill_payment_resolver.
 Score 0 if the description edit and the tool addition are bundled into a single edit_skill call.
+Score 0 if the JIRA addition is output as toolEdits instead of an inline <tool> instruction edit.
 Score 0 if more than 2 edit_skill calls are produced (failure to merge sug-desc-1 + sug-desc-2).
 Score 1 if 2 separate edit_skill calls are made but the merged description doesn't explicitly carve out billing/invoice routing (i.e. it stays vague).
 Score 2 if 2 separate edit_skill calls are made and the merged description narrows scope but does not reference both supporting drafts (sug-desc-1 + sug-desc-2 in sourceSuggestionIds).
-Score 3 if exactly 2 edit_skill calls are made: one with agentFacingDescriptionEdit consolidating sug-desc-1 + sug-desc-2 into a description that limits the skill to failures/chargebacks AND explicitly excludes generic billing/invoice/account-management requests; one with toolEdits adding mcp_jira referencing sug-tool-1.`,
+Score 3 if exactly 2 edit_skill calls are made: one with agentFacingDescriptionEdit consolidating sug-desc-1 + sug-desc-2 into a description that limits the skill to failures/chargebacks AND explicitly excludes generic billing/invoice/account-management requests; one with instructionEdits adding an inline mcp_jira tool reference and referencing sug-tool-1.`,
     },
   ],
 };

--- a/front/tests/reinforcement-evals/test-suites/analyze-conversation.ts
+++ b/front/tests/reinforcement-evals/test-suites/analyze-conversation.ts
@@ -1,8 +1,9 @@
 import {
   calledDescribeMcp,
   editSkillWithAgentFacingDescription,
+  editSkillWithInlineToolReference,
   editSkillWithInstructions,
-  editSkillWithTool,
+  editSkillWithoutInlineToolReference,
   type MockMcpDescription,
   mockTool,
   noSuggestion,
@@ -167,6 +168,7 @@ Score 3 if the suggestion provides clear, actionable instructions that would pre
     {
       scenarioId: "missing-tool",
       type: "analysis",
+      useInlineTools: true,
       skillConfigs: [
         {
           name: "Research Assistant",
@@ -201,33 +203,36 @@ Score 3 if the suggestion provides clear, actionable instructions that would pre
       ],
       workspaceContext: WORKSPACE_CONTEXT,
       expectedToolCalls: [
-        editSkillWithTool("skill_research", "mcp_web_search"),
+        editSkillWithInlineToolReference("skill_research", "mcp_web_search"),
       ],
-      judgeCriteria: `The analyst MUST call edit_skill with toolEdits to suggest adding the Web Search tool
-(mcp_web_search) to skill "skill_research". The suggestion should:
-- Recommend adding Web Search (toolId: mcp_web_search) with action "add"
+      judgeCriteria: `The analyst MUST call edit_skill with instructionEdits to suggest adding the Web Search tool
+as an inline <tool id="mcp_web_search" name="Web Search" /> reference in skill "skill_research". The suggestion should:
+- Discover available tools before authoring the inline <tool> reference
+- Add Web Search through an instruction edit; it MUST NOT include toolEdits
 - Include an analysis explaining that the skill's purpose requires web search for current information
 - Reference that the agent couldn't fulfill the user's core request without this capability
 
-Score 0 if no edit_skill with toolEdits call is made.
-Score 0-1 if edit_skill with toolEdits is called but with the wrong tool ID or wrong skill ID.
-Score 2 if the correct tool is suggested but the analysis is weak.
-Score 3 if the correct tool is suggested with a clear, well-reasoned analysis.`,
+Score 0 if no edit_skill with instructionEdits call is made.
+Score 0 if the suggestion uses toolEdits instead of an inline <tool> tag.
+Score 0-1 if edit_skill is called but with the wrong tool ID or wrong skill ID.
+Score 2 if the correct inline tool reference is suggested but the analysis is weak.
+Score 3 if the correct inline tool reference is suggested with a clear, well-reasoned analysis.`,
     },
     {
       scenarioId: "unused-tool",
       type: "analysis",
+      useInlineTools: true,
       skillConfigs: [
         {
           name: "Code Review Helper",
           sId: "skill_code_review",
           description: "Helps review code and suggest improvements",
-          instructions:
+          instructions: [
             "Review code provided by the user. Focus on code quality, potential bugs, and best practices. Suggest improvements.",
-          tools: [
-            { name: "GitHub", sId: "mcp_github" },
-            { name: "Calendar", sId: "mcp_calendar" },
-          ],
+            "",
+            '<tool id="mcp_github" name="GitHub" />',
+            '<tool id="mcp_calendar" name="Calendar" />',
+          ].join("\n"),
         },
       ],
       conversation: [
@@ -262,22 +267,27 @@ Score 3 if the correct tool is suggested with a clear, well-reasoned analysis.`,
       ],
       workspaceContext: WORKSPACE_CONTEXT,
       expectedToolCalls: [
-        editSkillWithTool("skill_code_review", "mcp_calendar"),
+        editSkillWithoutInlineToolReference(
+          "skill_code_review",
+          "mcp_calendar"
+        ),
       ],
-      judgeCriteria: `The analyst MUST call edit_skill with toolEdits to suggest removing the Calendar tool
-(mcp_calendar) from skill "skill_code_review". The suggestion should:
-- Recommend removing Calendar (toolId: mcp_calendar) with action "remove"
+      judgeCriteria: `The analyst MUST call edit_skill with instructionEdits to remove the inline Calendar tool
+reference (<tool id="mcp_calendar" name="Calendar" />) from skill "skill_code_review". The suggestion should:
+- Remove Calendar through an instruction edit; it MUST NOT include toolEdits
 - Include an analysis explaining that Calendar is irrelevant to code review and caused confusion
 - Reference the failed tool call and user complaint
 
-Score 0 if no edit_skill with toolEdits call is made.
-Score 0-1 if edit_skill with toolEdits is called but with the wrong action (add instead of remove).
-Score 2 if the correct tool removal is suggested but the analysis is weak.
+Score 0 if no edit_skill with instructionEdits call is made.
+Score 0 if the suggestion uses toolEdits instead of removing the inline <tool> tag.
+Score 0-1 if edit_skill is called but it removes the wrong inline tool reference.
+Score 2 if the correct inline tool removal is suggested but the analysis is weak.
 Score 3 if the correct removal is suggested with a clear analysis referencing the confusion it caused.`,
     },
     {
       scenarioId: "instruction-and-tool-gap",
       type: "analysis",
+      useInlineTools: true,
       skillConfigs: [
         {
           name: "Bug Reporter",
@@ -311,20 +321,19 @@ Score 3 if the correct removal is suggested with a clear analysis referencing th
       ],
       workspaceContext: WORKSPACE_CONTEXT,
       expectedToolCalls: [
-        editSkillWithInstructions("skill_bug_reporter"),
-        editSkillWithTool("skill_bug_reporter", "mcp_jira"),
+        editSkillWithInlineToolReference("skill_bug_reporter", "mcp_jira"),
       ],
-      judgeCriteria: `The analyst MUST make BOTH types of suggestions for skill "skill_bug_reporter":
-1. edit_skill with instructionEdits to update instructions to reference the JIRA tool for filing
-2. edit_skill with toolEdits to add JIRA (mcp_jira) so the skill can actually file bugs
+      judgeCriteria: `The analyst MUST call edit_skill with instructionEdits for skill "skill_bug_reporter".
+The instruction edit must add the JIRA capability as an inline <tool id="mcp_jira" name="JIRA" /> reference and update the surrounding instructions to use JIRA for filing bugs.
+The suggestion MUST NOT include toolEdits.
 
-The suggestions should be co-dependent — the instructions should reference using JIRA,
-and the tool addition provides the capability.
+The inline tool reference and instruction change are co-dependent and should be expressed together in the instruction edit.
 
-Score 0 if only one type of suggestion is made.
-Score 1 if both are made but the instructions don't reference the tool, or the analysis is weak.
-Score 2 if both are made with decent analysis but the instruction/tool connection isn't explicit.
-Score 3 if both are made with clear co-dependency: instructions reference JIRA, tool provides the capability, and analysis explains the mismatch.`,
+Score 0 if no edit_skill with instructionEdits call is made.
+Score 0 if the suggestion uses toolEdits instead of an inline <tool> tag.
+Score 1 if the inline JIRA tag is added but the instructions don't explain how to use it, or the analysis is weak.
+Score 2 if the JIRA tag and instructions are both present but the instruction/tool connection isn't explicit.
+Score 3 if the instruction edit clearly adds JIRA as an inline tool reference, tells the skill to file bugs through it, and explains the mismatch.`,
     },
     {
       scenarioId: "successful-conversation",
@@ -424,6 +433,7 @@ Score 3 if the suggestion addresses both brand voice and remedy guidance with a 
     {
       scenarioId: "wrong-tool-order-linkedin-enrich",
       type: "analysis",
+      useInlineTools: true,
       skillConfigs: [
         {
           name: "Enrich user info with LinkedIn",
@@ -431,8 +441,7 @@ Score 3 if the suggestion addresses both brand voice and remedy guidance with a 
           description:
             "Enriches company and people profiles using LinkedIn data",
           instructions:
-            "Use the LinkedIn tool to enrich user and company information when requested. Call enrich_user to get detailed profile data for a person, or enrich_company_data for company information.",
-          tools: [{ name: "LinkedIn", sId: "mcp_linkedin" }],
+            'Use the LinkedIn tool to enrich user and company information when requested.\n\n<tool id="mcp_linkedin" name="LinkedIn" />\n\nCall enrich_user to get detailed profile data for a person, or enrich_company_data for company information.',
         },
       ],
       conversation: [


### PR DESCRIPTION
## Description

This PR updates reinforced skill suggestions for the nested skills model. Behind `nested_skills`, tools are attached through inline instruction references instead of a separate tool field.

The flagged path hides `toolEdits` from the reinforced `edit_skill` schema, asks the model to suggest tool additions/removals as instruction edits with inline `<tool>` tags, and omits the separate tool block from skill context. When the flag is off, the workflow keeps the legacy configured-tool prompt, schema, and skill context shape.

The reinforcement eval suites now include inline-tool scenarios, and the reinforcement seed includes an inline tool suggestion for manual testing with `nested_skills` enabled.

## Tests

- Updated existing reinforcement prompt/schema tests.
- Updated reinforcement eval suites.
- Tested reinforcement seed locally.

## Risk

- Low. Behind feature flag.

## Deploy Plan

- Deploy front.