### PR TITLE
[connectors] fix: skip Confluence pages under databases

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -49,6 +49,7 @@ const ConfluencePageCodec = t.intersection([
     parentType: t.union([
       t.literal("page"),
       t.literal("folder"),
+      t.literal("database"),
       t.null,
       t.undefined,
     ]),

--- a/connectors/src/connectors/confluence/lib/content/pages.ts
+++ b/connectors/src/connectors/confluence/lib/content/pages.ts
@@ -162,6 +162,14 @@ export async function upsertConfluencePageInDb(
   page: ConfluencePageWithBodyType,
   visitedAtMs: number
 ) {
+  if (page.parentType === "database") {
+    logger.info(
+      { connectorId, pageId: page.id, parentId: page.parentId },
+      "Skipping Confluence page database upsert with database parent."
+    );
+    return;
+  }
+
   await ConfluencePageModel.upsert({
     connectorId,
     externalUrl: page._links.tinyui,
@@ -266,6 +274,14 @@ export async function confluenceCheckAndUpsertSinglePage({
   if (!page) {
     localLogger.info("Confluence page not found.");
     // Return false to skip the child pages.
+    return false;
+  }
+
+  if (page.parentType === "database") {
+    localLogger.info(
+      { parentId: page.parentId },
+      "Skipping Confluence page with database parent."
+    );
     return false;
   }
 

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -695,6 +695,14 @@ export async function confluenceUpsertPageWithFullParentsActivity({
     return false;
   }
 
+  if (page.parentType === "database") {
+    localLogger.info(
+      { parentId: page.parentId },
+      "Skipping Confluence page with database parent."
+    );
+    return false;
+  }
+
   let spaceName = cachedSpaceNames[page.spaceId];
   if (!spaceName) {
     const space = await client.getSpaceById(page.spaceId);


### PR DESCRIPTION
## Description

- Confluence can return pages with `parentType: "database"`, which the connector does not support yet.
- This PR accepts that API value so response decoding does not fail, then skips those pages in normal sync and full-parent upserts instead of trying to build an unsupported parent chain.
- This is intentionally narrow: the follow-up long-term fix is to model Confluence databases as folders and place child pages under them.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.