### PR TITLE
Send email to admins when balance threshold reached

### DIFF
--- a/front-api/routes/novu/index.ts
+++ b/front-api/routes/novu/index.ts
@@ -1,5 +1,6 @@
 import { agentMessageFeedbackWorkflow } from "@app/lib/notifications/workflows/agent-message-feedback";
 import { agentSuggestionsReadyWorkflow } from "@app/lib/notifications/workflows/agent-suggestions-ready";
+import { balanceThresholdReachedWorkflow } from "@app/lib/notifications/workflows/balance-threshold-reached";
 import { conversationUnreadWorkflow } from "@app/lib/notifications/workflows/conversation-unread";
 import { projectAddedAsMemberWorkflow } from "@app/lib/notifications/workflows/project-added-as-member";
 import { providerCredentialsHealthUpdatedWorkflow } from "@app/lib/notifications/workflows/provider-credential-updated";
@@ -29,6 +30,7 @@ const options: ServeHandlerOptions = {
     projectAddedAsMemberWorkflow,
     providerCredentialsHealthUpdatedWorkflow,
     userAwuCapReachedWorkflow,
+    balanceThresholdReachedWorkflow,
   ],
 };
 

--- a/front/lib/api/credits/balance_threshold_alert.ts
+++ b/front/lib/api/credits/balance_threshold_alert.ts
@@ -107,7 +107,7 @@ export async function maybeNotifyAdminsBalanceThresholdReached({
       return;
     }
 
-    const { threshold, alertId: configuredAlertId } =
+    const { threshold: thresholdCredits, alertId: configuredAlertId } =
       await getCachedWorkspaceBalanceThreshold({
         metronomeCustomerId,
         workspaceId,
@@ -115,7 +115,7 @@ export async function maybeNotifyAdminsBalanceThresholdReached({
 
     // Only notify for the workspace's own configured balance-threshold alert.
     if (
-      threshold === null ||
+      thresholdCredits === null ||
       configuredAlertId === null ||
       configuredAlertId !== alertId
     ) {
@@ -153,7 +153,7 @@ export async function maybeNotifyAdminsBalanceThresholdReached({
       })),
       workspaceId,
       workspaceName: workspace.name,
-      balanceThresholdCredits: threshold,
+      balanceThresholdCredits: thresholdCredits,
       remainingBalanceCredits,
       isEnterprise: isEntreprisePlanPrefix(auth.getNonNullablePlan().code),
       eventId,

--- a/front/lib/api/credits/balance_threshold_alert.ts
+++ b/front/lib/api/credits/balance_threshold_alert.ts
@@ -1,11 +1,16 @@
-import type { Authenticator } from "@app/lib/auth";
+import { getMembers } from "@app/lib/api/workspace";
+import { Authenticator } from "@app/lib/auth";
 import {
   clearMetronomeBalanceThresholdAlert,
   getCachedWorkspaceBalanceThreshold,
   upsertMetronomeBalanceThresholdAlert,
 } from "@app/lib/metronome/alerts/balance_threshold";
+import { notifyAdminsBalanceThresholdReached } from "@app/lib/notifications/workflows/balance-threshold-reached";
+import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
+import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 /**
  * Read the workspace's credit-balance-threshold notification setting.
@@ -71,4 +76,92 @@ export async function syncMetronomeBalanceThresholdAlert({
   }
 
   return new Ok(undefined);
+}
+
+/**
+ * Notify workspace admins that their configured credit-balance threshold has
+ * been reached, but only when the firing Metronome alert (`alertId`) is the
+ * workspace's own balance-threshold alert — the same `low_remaining_*` event
+ * type also fires for unrelated pool alerts, which must not trigger this email.
+ *
+ * The notification is delivered via Novu (email only for now), triggered once
+ * per admin and deduped via a `transactionId` keyed on the Metronome event so
+ * redeliveries don't re-send. Best-effort: any failure here is logged and
+ * swallowed so it never disrupts the webhook's credit-state processing.
+ */
+export async function maybeNotifyAdminsBalanceThresholdReached({
+  metronomeCustomerId,
+  workspaceId,
+  eventId,
+  alertId,
+  remainingBalanceCredits,
+}: {
+  metronomeCustomerId: string | null;
+  workspaceId: string;
+  eventId: string;
+  alertId: string | null;
+  remainingBalanceCredits: number | null;
+}): Promise<void> {
+  try {
+    if (!metronomeCustomerId || !alertId) {
+      return;
+    }
+
+    const { threshold, alertId: configuredAlertId } =
+      await getCachedWorkspaceBalanceThreshold({
+        metronomeCustomerId,
+        workspaceId,
+      });
+
+    // Only notify for the workspace's own configured balance-threshold alert.
+    if (
+      threshold === null ||
+      configuredAlertId === null ||
+      configuredAlertId !== alertId
+    ) {
+      return;
+    }
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+    const workspace = auth.workspace();
+    if (!workspace) {
+      logger.error(
+        { workspaceId },
+        "[Balance Threshold] Workspace not found for threshold alert email"
+      );
+      return;
+    }
+
+    const { members: admins } = await getMembers(auth, {
+      roles: ["admin"],
+      activeOnly: true,
+    });
+    if (admins.length === 0) {
+      logger.warn(
+        { workspaceId },
+        "[Balance Threshold] No active admins for threshold alert email"
+      );
+      return;
+    }
+
+    notifyAdminsBalanceThresholdReached({
+      admins: admins.map((admin) => ({
+        sId: admin.sId,
+        email: admin.email,
+        firstName: admin.firstName,
+        lastName: admin.lastName,
+      })),
+      workspaceId,
+      workspaceName: workspace.name,
+      balanceThresholdCredits: threshold,
+      remainingBalanceCredits,
+      isEnterprise: isEntreprisePlanPrefix(auth.getNonNullablePlan().code),
+      eventId,
+    });
+  } catch (err) {
+    logger.error(
+      { workspaceId, error: normalizeError(err).message },
+      "[Balance Threshold] Failed to notify admins of balance threshold"
+    );
+  }
 }

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -1,3 +1,4 @@
+import { maybeNotifyAdminsBalanceThresholdReached } from "@app/lib/api/credits/balance_threshold_alert";
 import {
   dispatchCreditsAdded,
   dispatchLowBalance,
@@ -889,6 +890,16 @@ export async function processMetronomeWebhook({
           "[Metronome Webhook] low_remaining_contract_credit_and_commit_balance_reached: low balance dispatched"
         );
       }
+
+      // If this is the workspace's own configured balance-threshold alert,
+      // email its admins.
+      await maybeNotifyAdminsBalanceThresholdReached({
+        metronomeCustomerId: workspace.metronomeCustomerId,
+        workspaceId: workspace.sId,
+        eventId: event.id,
+        alertId: event.properties.alert_id ?? null,
+        remainingBalanceCredits: remaining ?? null,
+      });
       break;
     }
     case "alerts.low_remaining_contract_credit_and_commit_balance_resolved": {

--- a/front/lib/metronome/alerts/balance_threshold.ts
+++ b/front/lib/metronome/alerts/balance_threshold.ts
@@ -119,7 +119,7 @@ async function fetchWorkspaceBalanceThreshold({
 }: {
   metronomeCustomerId: string;
   workspaceId: string;
-}): Promise<{ threshold: number | null }> {
+}): Promise<{ threshold: number | null; alertId: string | null }> {
   const result = await findMetronomeAlert({
     metronomeCustomerId,
     uniquenessKey: balanceThresholdAlertUniquenessKey(workspaceId),
@@ -127,13 +127,18 @@ async function fetchWorkspaceBalanceThreshold({
   if (result.isErr()) {
     throw result.error;
   }
-  return { threshold: result.value?.alert.threshold ?? null };
+  return {
+    threshold: result.value?.alert.threshold ?? null,
+    alertId: result.value?.alert.id ?? null,
+  };
 }
 
 /**
- * Read the workspace's configured balance threshold (in AWU credits) from its
- * Metronome alert, cached in Redis. Returns `{ threshold: null }` when no alert
- * is configured. Metronome is the source of truth — there is no DB copy.
+ * Read the workspace's configured balance threshold (in AWU credits) and the id
+ * of its Metronome alert, cached in Redis. Returns `null` fields when no alert
+ * is configured. Metronome is the source of truth — there is no DB copy. The
+ * `alertId` lets webhook handling confirm that an incoming alert event
+ * corresponds to this workspace-configured alert.
  */
 export const getCachedWorkspaceBalanceThreshold = cacheWithRedis(
   fetchWorkspaceBalanceThreshold,

--- a/front/lib/notifications/workflows/balance-threshold-reached.ts
+++ b/front/lib/notifications/workflows/balance-threshold-reached.ts
@@ -1,0 +1,145 @@
+import config from "@app/lib/api/config";
+import { renderEmail } from "@app/lib/notifications/email-templates/default";
+import { getNovuClient } from "@app/lib/notifications/novu-client";
+import logger from "@app/logger/logger";
+import {
+  BALANCE_THRESHOLD_REACHED_TAG,
+  BALANCE_THRESHOLD_REACHED_TRIGGER_ID,
+} from "@app/types/notification_preferences";
+import { workflow } from "@novu/framework";
+import z from "zod";
+
+const BalanceThresholdReachedPayloadSchema = z.object({
+  workspaceId: z.string(),
+  workspaceName: z.string(),
+  // The credit-balance threshold (in AWU credits) the admin configured.
+  balanceThresholdCredits: z.number(),
+  // The remaining balance reported by Metronome when the alert fired, if known.
+  remainingBalanceCredits: z.number().nullable(),
+  // Enterprise workspaces can't self-serve credits, so we point them to their
+  // Dust representative instead of the usage page.
+  isEnterprise: z.boolean(),
+});
+
+type BalanceThresholdReachedPayloadType = z.infer<
+  typeof BalanceThresholdReachedPayloadSchema
+>;
+
+function formatCredits(credits: number): string {
+  return credits.toLocaleString("en-US");
+}
+
+// Email-only for now (no in-app step).
+export const balanceThresholdReachedWorkflow = workflow(
+  BALANCE_THRESHOLD_REACHED_TRIGGER_ID,
+  async ({ step, payload, subscriber }) => {
+    await step.email("balance-threshold-reached-email", async () => {
+      const subject = `[Dust] Credit balance alert - your workspace balance dropped below ${formatCredits(
+        payload.balanceThresholdCredits
+      )} credits`;
+
+      const remainingLine =
+        payload.remainingBalanceCredits !== null
+          ? `\nRemaining balance: ${formatCredits(payload.remainingBalanceCredits)} credits`
+          : "";
+      const purchaseLine = payload.isEnterprise
+        ? `To avoid running out of credits, please reach out to your Dust representative.`
+        : `To avoid running out of credits, you can purchase more from your workspace usage page.`;
+      const content =
+        `Your workspace's remaining credit balance has dropped below the threshold you configured.\n` +
+        `Alert threshold: ${formatCredits(payload.balanceThresholdCredits)} credits${remainingLine}\n` +
+        purchaseLine;
+
+      const body = await renderEmail({
+        name: subscriber.firstName ?? "there",
+        workspace: {
+          id: payload.workspaceId,
+          name: payload.workspaceName,
+        },
+        content,
+        action: {
+          label: payload.isEnterprise ? "Manage credits" : "See usage details",
+          url: `${config.getAppUrl()}/w/${payload.workspaceId}/usage`,
+        },
+      });
+      return { subject, body };
+    });
+  },
+  {
+    payloadSchema: BalanceThresholdReachedPayloadSchema,
+    tags: [BALANCE_THRESHOLD_REACHED_TAG],
+  }
+);
+
+/**
+ * Email a workspace's admins that their configured credit-balance threshold has
+ * been reached. One Novu event is triggered per admin (subscribed by their Dust
+ * user sId), deduped via a `transactionId` keyed on the Metronome event so
+ * redeliveries don't re-send. Fire-and-forget — errors are logged but don't
+ * block the caller.
+ */
+export function notifyAdminsBalanceThresholdReached({
+  admins,
+  workspaceId,
+  workspaceName,
+  balanceThresholdCredits,
+  remainingBalanceCredits,
+  isEnterprise,
+  eventId,
+}: {
+  admins: Array<{
+    sId: string;
+    email: string;
+    firstName: string | null;
+    lastName: string | null;
+  }>;
+  workspaceId: string;
+  workspaceName: string;
+  balanceThresholdCredits: number;
+  remainingBalanceCredits: number | null;
+  isEnterprise: boolean;
+  eventId: string;
+}): void {
+  if (admins.length === 0) {
+    return;
+  }
+
+  const payload: BalanceThresholdReachedPayloadType = {
+    workspaceId,
+    workspaceName,
+    balanceThresholdCredits,
+    remainingBalanceCredits,
+    isEnterprise,
+  };
+
+  void getNovuClient()
+    .then((novuClient) =>
+      novuClient.triggerBulk({
+        events: admins.map((admin) => ({
+          workflowId: BALANCE_THRESHOLD_REACHED_TRIGGER_ID,
+          to: {
+            subscriberId: admin.sId,
+            email: admin.email,
+            firstName: admin.firstName ?? undefined,
+            lastName: admin.lastName ?? undefined,
+          },
+          payload,
+          transactionId: `${BALANCE_THRESHOLD_REACHED_TRIGGER_ID}-${eventId}-${admin.sId}`,
+        })),
+      })
+    )
+    .then((r) => {
+      if (r.result.some((res) => !!res.error?.length)) {
+        logger.error(
+          { workspaceId, balanceThresholdCredits },
+          "Failed to trigger balance threshold reached notification"
+        );
+      }
+    })
+    .catch((err) => {
+      logger.error(
+        { err, workspaceId, balanceThresholdCredits },
+        "Failed to trigger balance threshold reached notification"
+      );
+    });
+}

--- a/front/pages/api/novu/index.ts
+++ b/front/pages/api/novu/index.ts
@@ -3,6 +3,7 @@
 /** @ignoreswagger */
 import { agentMessageFeedbackWorkflow } from "@app/lib/notifications/workflows/agent-message-feedback";
 import { agentSuggestionsReadyWorkflow } from "@app/lib/notifications/workflows/agent-suggestions-ready";
+import { balanceThresholdReachedWorkflow } from "@app/lib/notifications/workflows/balance-threshold-reached";
 import { conversationUnreadWorkflow } from "@app/lib/notifications/workflows/conversation-unread";
 import { projectAddedAsMemberWorkflow } from "@app/lib/notifications/workflows/project-added-as-member";
 import { providerCredentialsHealthUpdatedWorkflow } from "@app/lib/notifications/workflows/provider-credential-updated";
@@ -24,5 +25,6 @@ export default serve({
     projectAddedAsMemberWorkflow,
     providerCredentialsHealthUpdatedWorkflow,
     userAwuCapReachedWorkflow,
+    balanceThresholdReachedWorkflow,
   ],
 });

--- a/front/types/notification_preferences.ts
+++ b/front/types/notification_preferences.ts
@@ -109,10 +109,16 @@ export const PROVIDER_CREDENTIALS_HEALTH_UPDATED_TAG =
 export const USER_AWU_CAP_REACHED_TRIGGER_ID = "user-awu-cap-reached" as const;
 export const USER_AWU_CAP_REACHED_TAG = "user-awu-cap-reached" as const;
 
+export const BALANCE_THRESHOLD_REACHED_TRIGGER_ID =
+  "balance-threshold-reached" as const;
+export const BALANCE_THRESHOLD_REACHED_TAG =
+  "balance-threshold-reached" as const;
+
 export type WorkflowTriggerId =
   | typeof CONVERSATION_UNREAD_TRIGGER_ID
   | typeof PROJECT_ADDED_AS_MEMBER_TRIGGER_ID
   | typeof AGENT_SUGGESTIONS_READY_TRIGGER_ID
   | typeof SKILL_SUGGESTIONS_READY_TRIGGER_ID
   | typeof PROVIDER_CREDENTIALS_HEALTH_UPDATED_TRIGGER_ID
-  | typeof USER_AWU_CAP_REACHED_TRIGGER_ID;
+  | typeof USER_AWU_CAP_REACHED_TRIGGER_ID
+  | typeof BALANCE_THRESHOLD_REACHED_TRIGGER_ID;


### PR DESCRIPTION
## Description

Follows #26540 (which let admins configure a custom AWU credit-balance threshold backed by a Metronome alert). This PR closes the loop by actually emailing workspace admins when that threshold is crossed.

When Metronome fires a `low_remaining_contract_credit_and_commit_balance_reached` webhook event, a new `maybeNotifyAdminsBalanceThresholdReached` helper is called. It fetches the workspace's configured alert from cache (now also returning the `alertId`) and only proceeds when the firing alert ID matches the workspace's own configured one — this is necessary because the same event type fires for unrelated pool alerts. All active admins are then notified via a new Novu `balance-threshold-reached` email workflow, deduped via a `transactionId` keyed on `{workflowId}-{eventId}-{adminSId}` to avoid re-sending on Metronome retries. Enterprise workspaces get a "contact your Dust representative" CTA; non-enterprise workspaces get a link to the usage page.

## Tests

Tested manually end-to-end: balance threshold alert fires → admins receive email with correct threshold, remaining balance, and CTA. Guard logic (mismatched `alertId`, missing admins) verified via logs.

## Risk

Low — all notification calls are fire-and-forget (errors logged and swallowed, never disrupting webhook credit-state processing). The `getCachedWorkspaceBalanceThreshold` return type is extended with `alertId` but the cache key/TTL is unchanged.

## Deploy Plan

Deploy front.