### PR TITLE
[front] Keep Skill Builder capability removals in sync

### DIFF
--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -2,6 +2,7 @@ import { getDefaultMCPAction } from "@app/components/agent_builder/types";
 import { editorVariants } from "@app/components/editor/editorStyles";
 import { KNOWLEDGE_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
 import type { KnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
+import { TOOL_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/ToolNode";
 import {
   SkillInstructionsEditorContent,
   useSkillInstructionsEditor,
@@ -18,6 +19,7 @@ import {
   postProcessMarkdown,
   preprocessMarkdownForEditor,
 } from "@app/lib/editor/skill_instructions_preprocessing";
+import { isString } from "@app/types/shared/utils/general";
 import { cn } from "@dust-tt/sparkle";
 import type { Transaction } from "@tiptap/pm/state";
 import type { Editor } from "@tiptap/react";
@@ -62,6 +64,21 @@ function collectKnowledgeItems(editor: Editor): KnowledgeItem[] {
   return items;
 }
 
+function collectToolReferenceIds(editor: Editor): Set<string> {
+  const toolIds = new Set<string>();
+
+  editor.state.doc.descendants((node) => {
+    if (
+      node.type.name === TOOL_NODE_TYPE &&
+      isString(node.attrs?.mcpServerViewId)
+    ) {
+      toolIds.add(node.attrs.mcpServerViewId);
+    }
+  });
+
+  return toolIds;
+}
+
 function toAttachedKnowledge(
   items: readonly KnowledgeItem[]
 ): SkillBuilderFormData["attachedKnowledge"] {
@@ -101,6 +118,7 @@ export function SkillBuilderInstructionsEditor({
   const { compareVersion, isDiffMode } = useSkillVersionComparisonContext();
   const { resetField } = useFormContext<SkillBuilderFormData>();
   const initializedAttachedKnowledgeEditorRef = useRef<Editor | null>(null);
+  const previousInlineToolIdsRef = useRef<Set<string>>(new Set());
   const { owner, skillId, selectedSuggestionId, setAcceptInstructionEdits } =
     useSkillBuilderContext();
   const { hasFeature } = useFeatureFlags();
@@ -154,6 +172,27 @@ export function SkillBuilderInstructionsEditor({
     [attachedKnowledgeField.onChange]
   );
 
+  const syncToolReferencesFromEditor = useCallback(
+    (editor: Editor) => {
+      const currentInlineToolIds = collectToolReferenceIds(editor);
+      const removedToolIds = [...previousInlineToolIdsRef.current].filter(
+        (toolId) => !currentInlineToolIds.has(toolId)
+      );
+
+      if (removedToolIds.length > 0) {
+        const removedToolIdsSet = new Set(removedToolIds);
+        onToolsChange(
+          tools.filter(
+            (tool) => !removedToolIdsSet.has(tool.configuration.mcpServerViewId)
+          )
+        );
+      }
+
+      previousInlineToolIdsRef.current = currentInlineToolIds;
+    },
+    [onToolsChange, tools]
+  );
+
   const syncInstructionsFromEditor = useCallback(
     (editor: Editor) => {
       instructionsField.onChange(
@@ -165,12 +204,14 @@ export function SkillBuilderInstructionsEditor({
         })
       );
       syncAttachedKnowledgeFromEditor(editor);
+      syncToolReferencesFromEditor(editor);
     },
     [
       enableSkillReferences,
       instructionsField.onChange,
       instructionsHtmlField.onChange,
       syncAttachedKnowledgeFromEditor,
+      syncToolReferencesFromEditor,
     ]
   );
 
@@ -187,10 +228,11 @@ export function SkillBuilderInstructionsEditor({
   const handleUpdate = useCallback(
     ({ editor, transaction }: { editor: Editor; transaction: Transaction }) => {
       if (transaction.docChanged) {
+        syncToolReferencesFromEditor(editor);
         debouncedUpdate(editor);
       }
     },
-    [debouncedUpdate]
+    [debouncedUpdate, syncToolReferencesFromEditor]
   );
 
   const handleBlur = useCallback(() => {
@@ -202,8 +244,9 @@ export function SkillBuilderInstructionsEditor({
   const handleDelete = useCallback(
     (editorInstance: Editor) => {
       syncAttachedKnowledgeFromEditor(editorInstance);
+      syncToolReferencesFromEditor(editorInstance);
     },
-    [syncAttachedKnowledgeFromEditor]
+    [syncAttachedKnowledgeFromEditor, syncToolReferencesFromEditor]
   );
 
   const handleSelectToolReference = useCallback(
@@ -244,6 +287,41 @@ export function SkillBuilderInstructionsEditor({
     onBlur: handleBlur,
     onDelete: handleDelete,
   });
+
+  const handleRemoveToolReference = useCallback(
+    (toolId: string) => {
+      onToolsChange(
+        tools.filter((tool) => tool.configuration.mcpServerViewId !== toolId)
+      );
+
+      if (!editor || editor.isDestroyed) {
+        return;
+      }
+
+      const ranges: { from: number; to: number }[] = [];
+      editor.state.doc.descendants((node, position) => {
+        if (
+          node.type.name === TOOL_NODE_TYPE &&
+          node.attrs?.mcpServerViewId === toolId
+        ) {
+          ranges.push({ from: position, to: position + node.nodeSize });
+        }
+      });
+
+      if (ranges.length === 0) {
+        return;
+      }
+
+      const transaction = editor.state.tr;
+      for (const range of ranges.toReversed()) {
+        transaction.delete(range.from, range.to);
+      }
+
+      editor.view.dispatch(transaction);
+      syncInstructionsFromEditor(editor);
+    },
+    [editor, onToolsChange, syncInstructionsFromEditor, tools]
+  );
 
   useEffect(() => {
     if (!editor || editor.isDestroyed) {
@@ -359,6 +437,7 @@ export function SkillBuilderInstructionsEditor({
       keepError: true,
       keepTouched: true,
     });
+    previousInlineToolIdsRef.current = collectToolReferenceIds(editor);
   }, [editor, isContentReady, isDiffMode, resetField]);
 
   // Apply pending instruction suggestions as inline diff decorations.
@@ -557,6 +636,7 @@ export function SkillBuilderInstructionsEditor({
           <SkillBuilderInstructionsReferenceSummary
             attachedKnowledge={attachedKnowledgeField.value}
             instructions={instructionsField.value ?? ""}
+            onRemoveTool={isDiffMode ? undefined : handleRemoveToolReference}
             tools={tools}
           />
         )}

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -119,6 +119,7 @@ export function SkillBuilderInstructionsEditor({
   const { resetField } = useFormContext<SkillBuilderFormData>();
   const initializedAttachedKnowledgeEditorRef = useRef<Editor | null>(null);
   const previousInlineToolIdsRef = useRef<Set<string>>(new Set());
+  const toolsRef = useRef<SkillBuilderFormData["tools"]>([]);
   const { owner, skillId, selectedSuggestionId, setAcceptInstructionEdits } =
     useSkillBuilderContext();
   const { hasFeature } = useFeatureFlags();
@@ -153,6 +154,10 @@ export function SkillBuilderInstructionsEditor({
     name: "tools",
   });
 
+  useEffect(() => {
+    toolsRef.current = tools;
+  }, [tools]);
+
   const displayError =
     !!instructionsFieldState.error || !!attachedKnowledgeFieldState.error;
   const hasInstructionReferenceSummary =
@@ -181,16 +186,16 @@ export function SkillBuilderInstructionsEditor({
 
       if (removedToolIds.length > 0) {
         const removedToolIdsSet = new Set(removedToolIds);
-        onToolsChange(
-          tools.filter(
-            (tool) => !removedToolIdsSet.has(tool.configuration.mcpServerViewId)
-          )
+        const nextTools = toolsRef.current.filter(
+          (tool) => !removedToolIdsSet.has(tool.configuration.mcpServerViewId)
         );
+        toolsRef.current = nextTools;
+        onToolsChange(nextTools);
       }
 
       previousInlineToolIdsRef.current = currentInlineToolIds;
     },
-    [onToolsChange, tools]
+    [onToolsChange]
   );
 
   const syncInstructionsFromEditor = useCallback(
@@ -251,7 +256,7 @@ export function SkillBuilderInstructionsEditor({
 
   const handleSelectToolReference = useCallback(
     (view: MCPServerViewType) => {
-      const alreadyAdded = tools.some(
+      const alreadyAdded = toolsRef.current.some(
         (tool) => tool.configuration.mcpServerViewId === view.sId
       );
 
@@ -259,9 +264,11 @@ export function SkillBuilderInstructionsEditor({
         return;
       }
 
-      onToolsChange([...tools, getDefaultMCPAction(view)]);
+      const nextTools = [...toolsRef.current, getDefaultMCPAction(view)];
+      toolsRef.current = nextTools;
+      onToolsChange(nextTools);
     },
-    [onToolsChange, tools]
+    [onToolsChange]
   );
 
   const { suggestions, isSuggestionsLoading } = useSkillSuggestions({
@@ -290,9 +297,11 @@ export function SkillBuilderInstructionsEditor({
 
   const handleRemoveToolReference = useCallback(
     (toolId: string) => {
-      onToolsChange(
-        tools.filter((tool) => tool.configuration.mcpServerViewId !== toolId)
+      const nextTools = toolsRef.current.filter(
+        (tool) => tool.configuration.mcpServerViewId !== toolId
       );
+      toolsRef.current = nextTools;
+      onToolsChange(nextTools);
 
       if (!editor || editor.isDestroyed) {
         return;
@@ -320,7 +329,7 @@ export function SkillBuilderInstructionsEditor({
       editor.view.dispatch(transaction);
       syncInstructionsFromEditor(editor);
     },
-    [editor, onToolsChange, syncInstructionsFromEditor, tools]
+    [editor, onToolsChange, syncInstructionsFromEditor]
   );
 
   useEffect(() => {

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -6,13 +6,14 @@ import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { getSkillIcon } from "@app/lib/skill";
 import { extractSkillTags } from "@app/lib/skills/format";
 import { extractToolTags } from "@app/lib/tools/format";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { AttachmentChip, Chip, cn, DocumentIcon } from "@dust-tt/sparkle";
 import { useMemo } from "react";
 
 interface SkillBuilderInstructionsReferenceSummaryProps {
   attachedKnowledge?: AttachedKnowledgeFormData[];
   instructions: string;
+  onRemoveTool?: (toolId: string) => void;
   tools: BuilderAction[];
 }
 
@@ -59,7 +60,13 @@ function compareReferenceSummaryItems(
   );
 }
 
-function renderReferenceSummaryItem(item: ReferenceSummaryItem) {
+function renderReferenceSummaryItem({
+  item,
+  onRemoveTool,
+}: {
+  item: ReferenceSummaryItem;
+  onRemoveTool?: (toolId: string) => void;
+}) {
   switch (item.kind) {
     case "knowledge":
       return (
@@ -87,17 +94,20 @@ function renderReferenceSummaryItem(item: ReferenceSummaryItem) {
           key={`${item.kind}:${item.id}`}
           title={item.title}
           toolIcon={item.icon}
+          onRemove={onRemoveTool ? () => onRemoveTool(item.id) : undefined}
           color="white"
         />
       );
     default:
-      return assertNever(item);
+      assertNeverAndIgnore(item);
+      return null;
   }
 }
 
 export function SkillBuilderInstructionsReferenceSummary({
   attachedKnowledge,
   instructions,
+  onRemoveTool,
   tools,
 }: SkillBuilderInstructionsReferenceSummaryProps) {
   const { mcpServerViews, isMCPServerViewsLoading } =
@@ -212,7 +222,9 @@ export function SkillBuilderInstructionsReferenceSummary({
         Capabilities and knowledge
       </div>
       <div className="flex flex-wrap gap-2">
-        {referenceItems.map(renderReferenceSummaryItem)}
+        {referenceItems.map((item) =>
+          renderReferenceSummaryItem({ item, onRemoveTool })
+        )}
       </div>
     </div>
   );

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -6,7 +6,7 @@ import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { getSkillIcon } from "@app/lib/skill";
 import { extractSkillTags } from "@app/lib/skills/format";
 import { extractToolTags } from "@app/lib/tools/format";
-import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { AttachmentChip, Chip, cn, DocumentIcon } from "@dust-tt/sparkle";
 import { useMemo } from "react";
 
@@ -99,8 +99,7 @@ function renderReferenceSummaryItem({
         />
       );
     default:
-      assertNeverAndIgnore(item);
-      return null;
+      return assertNever(item);
   }
 }
 


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/26488 and unblocks https://github.com/dust-tt/dust/pull/26575.

Adds the missing removal path for Skill Builder tool capabilities in the inline-reference flow. Removing a capability from the summary removes it from the `tools` form field and deletes matching inline tool chips; deleting an inline chip also removes the matching selected tool while preserving legacy selected tools that do not yet have inline tags.

## Risks
Blast radius: Skill Builder capability selection and removal when nested skill references are enabled.
Risk: standard

## Deploy Plan
- pmrr
- deploy front

## Tests
- [x] `NODE_ENV=test npm run test -- ./components/editor/extensions/skill_builder/ToolNode.test.ts ./components/editor/extensions/skill_builder/SlashCommandExtension.test.ts ./lib/editor/skill_instructions_preprocessing.test.ts`