### PR TITLE
Reject table upserts when too many files are already pending (429)

### DIFF
--- a/core/src/api/tables.rs
+++ b/core/src/api/tables.rs
@@ -10,7 +10,7 @@ use crate::api::api_state::APIState;
 use crate::api::data_sources::DataSourcesDocumentsUpdateParentsPayload;
 use crate::{
     data_sources::node::ProviderVisibility,
-    databases::table::{LocalTable, Row},
+    databases::table::{LocalTable, Row, TableUpsertError},
     project,
     search_filter::{Filterable, SearchFilter},
     search_stores::search_store::NodeItem,
@@ -542,12 +542,20 @@ pub async fn tables_csv_upsert(
                     )
                     .await
                 {
-                    Err(e) => error_response(
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        "internal_server_error",
-                        "Failed to upsert rows",
-                        Some(e),
-                    ),
+                    Err(e) => match e.downcast_ref::<TableUpsertError>() {
+                        Some(TableUpsertError::TooManyPendingUpserts { .. }) => error_response(
+                            StatusCode::TOO_MANY_REQUESTS,
+                            "too_many_pending_upserts",
+                            "Too many pending upserts for this table, retry later",
+                            Some(e),
+                        ),
+                        None => error_response(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "internal_server_error",
+                            "Failed to upsert rows",
+                            Some(e),
+                        ),
+                    },
                     Ok(_) => (
                         StatusCode::OK,
                         Json(APIResponse {
@@ -610,12 +618,20 @@ pub async fn tables_rows_upsert(
                     )
                     .await
                 {
-                    Err(e) => error_response(
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        "internal_server_error",
-                        "Failed to upsert rows",
-                        Some(e),
-                    ),
+                    Err(e) => match e.downcast_ref::<TableUpsertError>() {
+                        Some(TableUpsertError::TooManyPendingUpserts { .. }) => error_response(
+                            StatusCode::TOO_MANY_REQUESTS,
+                            "too_many_pending_upserts",
+                            "Too many pending upserts for this table, retry later",
+                            Some(e),
+                        ),
+                        None => error_response(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "internal_server_error",
+                            "Failed to upsert rows",
+                            Some(e),
+                        ),
+                    },
                     Ok(_) => (
                         StatusCode::OK,
                         Json(APIResponse {

--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -42,7 +42,7 @@ pub enum TableType {
 // Maximum number of pending (not-yet-processed) CSV files allowed for a single table.
 // Beyond this, the producer (API) rejects new upserts/deletes so files don't accumulate
 // into a merge the background worker cannot handle (which would OOM-crash the worker).
-const MAX_PENDING_UPSERT_FILES: usize = 50;
+const MAX_PENDING_UPSERT_FILES: usize = 100;
 
 // Errors from table upserts that callers (e.g. the HTTP API) may want to handle specially
 // rather than treating as a generic internal error.

--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -42,7 +42,7 @@ pub enum TableType {
 // Maximum number of pending (not-yet-processed) CSV files allowed for a single table.
 // Beyond this, the producer (API) rejects new upserts/deletes so files don't accumulate
 // into a merge the background worker cannot handle (which would OOM-crash the worker).
-const MAX_PENDING_UPSERT_FILES: usize = 100;
+const MAX_PENDING_UPSERT_FILES: usize = 200;
 
 // Errors from table upserts that callers (e.g. the HTTP API) may want to handle specially
 // rather than treating as a generic internal error.

--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -39,6 +39,19 @@ pub enum TableType {
     Remote(String),
 }
 
+// Maximum number of pending (not-yet-processed) CSV files allowed for a single table.
+// Beyond this, the producer (API) rejects new upserts/deletes so files don't accumulate
+// into a merge the background worker cannot handle (which would OOM-crash the worker).
+const MAX_PENDING_UPSERT_FILES: usize = 50;
+
+// Errors from table upserts that callers (e.g. the HTTP API) may want to handle specially
+// rather than treating as a generic internal error.
+#[derive(Debug, thiserror::Error)]
+pub enum TableUpsertError {
+    #[error("Too many pending upserts queued for this table (limit {max}); retry later")]
+    TooManyPendingUpserts { max: usize },
+}
+
 pub fn get_table_unique_id(project: &Project, data_source_id: &str, table_id: &str) -> String {
     format!("{}__{}__{}", project.project_id(), data_source_id, table_id)
 }
@@ -617,6 +630,23 @@ impl LocalTable {
     }
 
     async fn schedule_background_upsert_or_delete(&self, rows: Vec<Row>) -> Result<()> {
+        // Backpressure: if too many files are already pending for this table, the background
+        // worker has fallen behind (or is stuck). Reject the call rather than letting files
+        // accumulate into a merge large enough to OOM-crash the worker. Truncate upserts are
+        // not affected (they don't go through this path) and reset the pending files, so they
+        // remain a way to recover a wedged table.
+        let pending_files =
+            GoogleCloudStorageBackgroundProcessingStore::get_gcs_csv_file_names_for_table(
+                &self.table,
+            )
+            .await?;
+        if pending_files.len() >= MAX_PENDING_UPSERT_FILES {
+            return Err(TableUpsertError::TooManyPendingUpserts {
+                max: MAX_PENDING_UPSERT_FILES,
+            }
+            .into());
+        }
+
         let mut redis_conn = REDIS_CLIENT.get_async_connection().await?;
 
         let now = utils::now();

--- a/core/src/databases/table_upserts_background_worker.rs
+++ b/core/src/databases/table_upserts_background_worker.rs
@@ -191,29 +191,6 @@ impl TableUpsertsBackgroundWorker {
                 break;
             }
 
-            // Drop entries that have been stuck far past the debounce window AND have already
-            // failed at least once. These are poison items (consistently failing) that we'd
-            // otherwise retry forever. The attempts > 0 guard ensures we never drop an entry
-            // that has never been tried (e.g. if the worker was down for a long time, every
-            // queued entry would be old but untried).
-            // Note: this leaves the table's CSV files orphaned in GCS, which is an
-            // acceptable (small, separately cleanable) trade-off for not blocking the queue.
-            if time_since_last_upsert > MAX_UPSERT_AGE_MS && table_data.attempts > 0 {
-                error!(
-                    project_id = table_data.project_id,
-                    data_source_id = table_data.data_source_id,
-                    table_id = table_data.table_id,
-                    age_ms = time_since_last_upsert,
-                    attempts = table_data.attempts,
-                    "TableUpsertsBackgroundWorker: Entry exceeded max age after failed attempts, dropping"
-                );
-                let _: () = self
-                    .redis_conn
-                    .hdel(REDIS_TABLE_UPSERT_HASH_NAME, key)
-                    .await?;
-                continue;
-            }
-
             let table = self
                 .store
                 .load_data_source_table(
@@ -225,6 +202,40 @@ impl TableUpsertsBackgroundWorker {
 
             match table {
                 Some(table) => {
+                    // Drop entries that have been stuck far past the debounce window AND have
+                    // already failed at least once. These are poison items (consistently failing)
+                    // that we'd otherwise retry forever. The attempts > 0 guard ensures we never
+                    // drop an entry that has never been tried (e.g. if the worker was down for a
+                    // long time, every queued entry would be old but untried).
+                    // We also delete the table's CSV files; otherwise they stay orphaned in GCS
+                    // and keep the pending-file count high, which would make the producer-side
+                    // backpressure reject all future upserts for this table forever.
+                    if time_since_last_upsert > MAX_UPSERT_AGE_MS && table_data.attempts > 0 {
+                        error!(
+                            table_id = table.table_id(),
+                            age_ms = time_since_last_upsert,
+                            attempts = table_data.attempts,
+                            "TableUpsertsBackgroundWorker: Entry exceeded max age after failed attempts, dropping"
+                        );
+                        if let Err(e) =
+                            GoogleCloudStorageBackgroundProcessingStore::delete_all_files_for_table(
+                                &table,
+                            )
+                            .await
+                        {
+                            error!(
+                                table_id = table.table_id(),
+                                "TableUpsertsBackgroundWorker: Failed to delete files for dropped entry: {}",
+                                e
+                            );
+                        }
+                        let _: () = self
+                            .redis_conn
+                            .hdel(REDIS_TABLE_UPSERT_HASH_NAME, key)
+                            .await?;
+                        continue;
+                    }
+
                     let mut now = utils::now();
 
                     let lock = match lock_manager


### PR DESCRIPTION
## Description

  ## What

  Add producer-side backpressure so a single table can't accumulate an unbounded number of pending update files. Once a table has too many unprocessed files queued, the API rejects further upserts/deletes with **429 Too Many Requests** instead of letting them pile up.

  ## Why

  The background worker (`TableUpsertsBackgroundWorker`) reads **all** pending update files for a table and merges them — into memory — in one shot (`get_deduped_rows_from_all_files` + the non-truncate merge in `batch_upsert_table_rows`). Each individual file is size-bounded, but nothing bounds the *count* or *aggregate* size. If the worker falls behind or a table is hammered, files accumulate until the merge is large enough to **OOM-crash the worker**.

  Per-file limits exist at the API level, but the background path had no protection against accumulation. The cleanest fix is to fail fast at the source rather than build heroics into the worker.

  ## How

  **Backpressure at the producer** (`databases/table.rs`):
  - `schedule_background_upsert_or_delete` (the non-truncate path, used by both row and CSV upserts *and* deletes) now counts the table's pending files and, if `>= MAX_PENDING_UPSERT_FILES` (100), returns a new typed error `TableUpsertError::TooManyPendingUpserts` instead of writing another file.
  - Truncate upserts bypass this path and reset the pending files, so they remain the recovery escape hatch for a wedged table.

  **429 mapping** (`api/tables.rs`):
  - `tables_rows_upsert` and `tables_csv_upsert` downcast the error and return `429 too_many_pending_upserts`; everything else stays `500`.

  **Reclaim orphaned files on drop** (`databases/table_upserts_background_worker.rs`):
  - The existing max-age drop (for poison entries) previously left the table's CSV files orphaned in GCS. With backpressure in place, orphaned files would keep the pending count high and 429 that table **forever**. The drop now also deletes the table's CSV files (`delete_all_files_for_table`), so the count can return to zero. The check moved into the `Some(table)` branch to reuse the existing delete helper — behavior-preserving, since the `attempts > 0` guard could only ever fire on the `process_table` path anyway.

  ## Trade-offs / notes

  - The pending-file count uses a full prefix list rather than a capped probe. In steady state the count is capped at ~100, so the list is small; a larger list only happens for a pre-existing backlog, which the worker drains.
  - **Front (separate repo) still needs to handle the 429** — pass it through and back off/retry rather than treating it as a hard failure.
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Core