### PR TITLE
[front] fix: allow white spaces in skill slash search

### DIFF
--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
@@ -264,7 +264,7 @@ export const SlashCommandExtension =
         suggestion: {
           char: "/",
           pluginKey: slashCommandPluginKey,
-          allowSpaces: false,
+          allowSpaces: true,
           startOfLine: false,
           items: ({ query }: { query: string }) => filterSlashCommands(query),
         },


### PR DESCRIPTION
## Description

This PR lets users keep typing multi-word queries in the Skill Builder `/` dropdown.

The dropdown previously closed once the query contained a space because the TipTap slash suggestion config did not allow spaces. We now allow spaces for the Skill Builder slash command suggestion, so actions and capabilities can be searched with natural multi-word input.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
