### PR TITLE
Add audit log when updating the prog usage cap

### DIFF
--- a/front-api/routes/w/[wId]/usage_settings/programmatic_usage_limit.ts
+++ b/front-api/routes/w/[wId]/usage_settings/programmatic_usage_limit.ts
@@ -1,5 +1,6 @@
 /** @ignoreswagger */
 
+import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
 import {
   getProgrammaticUsageLimit,
   syncProgrammaticUsageLimit,
@@ -52,9 +53,11 @@ app.put(
     const auth = ctx.get("auth");
     const { monthlyCapCredits } = ctx.req.valid("json");
 
+    const auditContext = getAuditLogContext(auth);
     const result = await syncProgrammaticUsageLimit({
       auth,
       monthlyCapCredits,
+      auditContext,
     });
     if (result.isErr()) {
       return apiError(ctx, {

--- a/front/admin/audit_log_schemas/workspace.programmatic_usage_limit_updated.json
+++ b/front/admin/audit_log_schemas/workspace.programmatic_usage_limit_updated.json
@@ -1,0 +1,8 @@
+{
+  "action": "workspace.programmatic_usage_limit_updated",
+  "targets": [{ "type": "workspace" }],
+  "metadata": {
+    "previous_monthly_cap_credits": "string",
+    "new_monthly_cap_credits": "string"
+  }
+}

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -73,6 +73,7 @@ export const AUDIT_ACTIONS = [
   // Workspace settings.
   "workspace.audit_logs_updated",
   "workspace.default_user_spend_limit_updated",
+  "workspace.programmatic_usage_limit_updated",
   // SCIM / Directory Sync.
   "scim.user_provisioned",
   "scim.user_updated",

--- a/front/lib/api/credits/programmatic_usage_limit.test.ts
+++ b/front/lib/api/credits/programmatic_usage_limit.test.ts
@@ -1,0 +1,139 @@
+import * as workosAudit from "@app/lib/api/audit/workos_audit";
+import { syncProgrammaticUsageLimit } from "@app/lib/api/credits/programmatic_usage_limit";
+import { Authenticator } from "@app/lib/auth";
+import * as programmaticCap from "@app/lib/metronome/alerts/programmatic_cap";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/alerts/programmatic_cap", async () => {
+  const actual = await vi.importActual<typeof programmaticCap>(
+    "@app/lib/metronome/alerts/programmatic_cap"
+  );
+  return {
+    ...actual,
+    getMetronomeProgrammaticCap: vi.fn(),
+    upsertMetronomeProgrammaticCapAlerts: vi.fn(),
+    clearMetronomeProgrammaticCapAlerts: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/api/audit/workos_audit", async () => {
+  const actual = await vi.importActual<typeof workosAudit>(
+    "@app/lib/api/audit/workos_audit"
+  );
+  return {
+    ...actual,
+    emitAuditLogEvent: vi.fn(),
+  };
+});
+
+const METRONOME_CUSTOMER_ID = "cust_test_xxx";
+const AUDIT_CONTEXT = { location: "127.0.0.1" };
+
+beforeEach(() => {
+  vi.mocked(programmaticCap.getMetronomeProgrammaticCap).mockResolvedValue(
+    new Ok(null)
+  );
+  vi.mocked(
+    programmaticCap.upsertMetronomeProgrammaticCapAlerts
+  ).mockResolvedValue(new Ok(undefined));
+  vi.mocked(
+    programmaticCap.clearMetronomeProgrammaticCapAlerts
+  ).mockResolvedValue(new Ok(undefined));
+  vi.mocked(workosAudit.emitAuditLogEvent).mockResolvedValue(undefined);
+});
+
+describe("syncProgrammaticUsageLimit audit", () => {
+  it("emits an audit event with previous and new cap", async () => {
+    const workspace = await WorkspaceFactory.metronome({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    vi.mocked(programmaticCap.getMetronomeProgrammaticCap).mockResolvedValue(
+      new Ok(200)
+    );
+
+    await syncProgrammaticUsageLimit({
+      auth,
+      monthlyCapCredits: 500,
+      auditContext: AUDIT_CONTEXT,
+    });
+
+    expect(workosAudit.emitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "workspace.programmatic_usage_limit_updated",
+        metadata: {
+          previous_monthly_cap_credits: "200",
+          new_monthly_cap_credits: "500",
+        },
+      })
+    );
+  });
+
+  it("records previous as 'unset' when no cap existed", async () => {
+    const workspace = await WorkspaceFactory.metronome({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    await syncProgrammaticUsageLimit({
+      auth,
+      monthlyCapCredits: 1000,
+      auditContext: AUDIT_CONTEXT,
+    });
+
+    expect(workosAudit.emitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: {
+          previous_monthly_cap_credits: "unset",
+          new_monthly_cap_credits: "1000",
+        },
+      })
+    );
+  });
+
+  it("records new as 'unset' when clearing the cap", async () => {
+    const workspace = await WorkspaceFactory.metronome({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    vi.mocked(programmaticCap.getMetronomeProgrammaticCap).mockResolvedValue(
+      new Ok(500)
+    );
+
+    await syncProgrammaticUsageLimit({
+      auth,
+      monthlyCapCredits: null,
+      auditContext: AUDIT_CONTEXT,
+    });
+
+    expect(workosAudit.emitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: {
+          previous_monthly_cap_credits: "500",
+          new_monthly_cap_credits: "unset",
+        },
+      })
+    );
+  });
+
+  it("skips audit when upsert fails", async () => {
+    const workspace = await WorkspaceFactory.metronome({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    vi.mocked(
+      programmaticCap.upsertMetronomeProgrammaticCapAlerts
+    ).mockResolvedValue(new Err(new Error("metronome down")));
+
+    const result = await syncProgrammaticUsageLimit({
+      auth,
+      monthlyCapCredits: 500,
+      auditContext: AUDIT_CONTEXT,
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(workosAudit.emitAuditLogEvent).not.toHaveBeenCalled();
+  });
+});

--- a/front/lib/api/credits/programmatic_usage_limit.ts
+++ b/front/lib/api/credits/programmatic_usage_limit.ts
@@ -1,3 +1,8 @@
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+} from "@app/lib/api/audit/workos_audit";
+import type { AuditLogContext } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
 import {
   clearMetronomeProgrammaticCapAlerts,
@@ -12,7 +17,7 @@ import { Err, Ok } from "@app/types/shared/result";
  *
  * Metronome is the source of truth: the cap is the threshold of the
  * workspace's programmatic cap alert. Returns `null` when no cap is
- * configured, or when the workspace has no Metronome customer.
+ * configured.
  */
 export async function getProgrammaticUsageLimit(
   auth: Authenticator
@@ -43,14 +48,15 @@ export async function getProgrammaticUsageLimit(
  *
  * A strictly positive `monthlyCapCredits` upserts the three programmatic cap
  * alerts (cap, low balance, critical balance); `null` clears them.
- * No-op when the workspace has no Metronome customer.
  */
 export async function syncProgrammaticUsageLimit({
   auth,
   monthlyCapCredits,
+  auditContext,
 }: {
   auth: Authenticator;
   monthlyCapCredits: number | null;
+  auditContext?: AuditLogContext;
 }): Promise<Result<undefined, Error>> {
   const workspace = auth.getNonNullableWorkspace();
   if (!workspace.metronomeCustomerId) {
@@ -58,6 +64,15 @@ export async function syncProgrammaticUsageLimit({
       new Error(`Workspace ${workspace.sId} has no Metronome customer ID.`)
     );
   }
+
+  // Read previous cap for audit metadata (best-effort).
+  const previousResult = await getMetronomeProgrammaticCap({
+    metronomeCustomerId: workspace.metronomeCustomerId,
+    workspaceId: workspace.sId,
+  });
+  const previousCapCredits = previousResult.isOk()
+    ? previousResult.value
+    : null;
 
   const alertResult =
     monthlyCapCredits !== null && monthlyCapCredits >= 0
@@ -77,6 +92,19 @@ export async function syncProgrammaticUsageLimit({
       )
     );
   }
+
+  void emitAuditLogEvent({
+    auth,
+    action: "workspace.programmatic_usage_limit_updated",
+    targets: [buildAuditLogTarget("workspace", workspace)],
+    context: auditContext,
+    metadata: {
+      previous_monthly_cap_credits:
+        previousCapCredits !== null ? String(previousCapCredits) : "unset",
+      new_monthly_cap_credits:
+        monthlyCapCredits !== null ? String(monthlyCapCredits) : "unset",
+    },
+  });
 
   return new Ok(undefined);
 }

--- a/front/lib/api/poke/plugins/workspaces/manage_programmatic_monthly_cap.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_programmatic_monthly_cap.ts
@@ -1,3 +1,7 @@
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+} from "@app/lib/api/audit/workos_audit";
 import { dispatchProgrammaticCapReset } from "@app/lib/api/metronome/credit_state_dispatcher";
 import { createPlugin } from "@app/lib/api/poke/types";
 import {
@@ -89,7 +93,7 @@ export const manageProgrammaticMonthlyCapPlugin = createPlugin({
     });
   },
 
-  execute: async (_auth, workspace, rawArgs) => {
+  execute: async (auth, workspace, rawArgs) => {
     if (!workspace) {
       return new Err(new Error("Cannot find workspace."));
     }
@@ -114,6 +118,15 @@ export const manageProgrammaticMonthlyCapPlugin = createPlugin({
     }
     const { enabled, monthlyCapAwu } = parsed.data;
 
+    // Read previous cap for audit metadata (best-effort).
+    const previousResult = await getMetronomeProgrammaticCap({
+      metronomeCustomerId,
+      workspaceId: workspace.sId,
+    });
+    const previousCapCredits = previousResult.isOk()
+      ? previousResult.value
+      : null;
+
     if (enabled && monthlyCapAwu) {
       const result = await upsertMetronomeProgrammaticCapAlerts({
         metronomeCustomerId,
@@ -126,6 +139,17 @@ export const manageProgrammaticMonthlyCapPlugin = createPlugin({
 
       // Reset the state machine — thresholds may have changed.
       await dispatchProgrammaticCapReset({ workspace: workspaceResource });
+
+      void emitAuditLogEvent({
+        auth,
+        action: "workspace.programmatic_usage_limit_updated",
+        targets: [buildAuditLogTarget("workspace", workspace)],
+        metadata: {
+          previous_monthly_cap_credits:
+            previousCapCredits !== null ? String(previousCapCredits) : "unset",
+          new_monthly_cap_credits: String(monthlyCapAwu),
+        },
+      });
 
       return new Ok({
         display: "text",
@@ -142,6 +166,17 @@ export const manageProgrammaticMonthlyCapPlugin = createPlugin({
       return new Err(clearResult.error);
     }
     await dispatchProgrammaticCapReset({ workspace: workspaceResource });
+
+    void emitAuditLogEvent({
+      auth,
+      action: "workspace.programmatic_usage_limit_updated",
+      targets: [buildAuditLogTarget("workspace", workspace)],
+      metadata: {
+        previous_monthly_cap_credits:
+          previousCapCredits !== null ? String(previousCapCredits) : "unset",
+        new_monthly_cap_credits: "unset",
+      },
+    });
 
     return new Ok({
       display: "text",

--- a/front/pages/api/w/[wId]/usage_settings/programmatic_usage_limit.ts
+++ b/front/pages/api/w/[wId]/usage_settings/programmatic_usage_limit.ts
@@ -1,6 +1,7 @@
 // @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
 
+import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import {
   getProgrammaticUsageLimit,
@@ -77,9 +78,11 @@ async function handler(
 
       const { monthlyCapCredits } = bodyValidation.data;
 
+      const auditContext = getAuditLogContext(auth, req);
       const result = await syncProgrammaticUsageLimit({
         auth,
         monthlyCapCredits,
+        auditContext,
       });
       if (result.isErr()) {
         return apiError(req, res, {


### PR DESCRIPTION
## Description

Follow up of https://github.com/dust-tt/dust/pull/26580
Closes https://github.com/dust-tt/tasks/issues/8478

Add audit log when we changed the value from UI or from poke

## Tests

unit tested 

```
 ✓ lib/api/credits/programmatic_usage_limit.test.ts (4 tests) 105ms
   ✓ syncProgrammaticUsageLimit audit (4)
     ✓ emits an audit event with previous and new cap 67ms
     ✓ records previous as 'unset' when no cap existed 14ms
     ✓ records new as 'unset' when clearing the cap 13ms
     ✓ skips audit when upsert fails 11ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  10:30:24
   Duration  6.82s (transform 601ms, setup 336ms, import 1.80s, tests 105ms, environment 313ms)
```


## Risk
low

## Deploy Plan

merge
```
 npx tsx front/admin/register_audit_log_schemas.ts --execute --changed
```
deploy