### PR TITLE
[front] enh: scroll to skill instruction references

### DIFF
--- a/front/components/editor/extensions/skill_builder/ToolChip.tsx
+++ b/front/components/editor/extensions/skill_builder/ToolChip.tsx
@@ -24,6 +24,7 @@ function getToolIcon(toolIcon: string | null) {
 
 interface ToolChipProps {
   color?: React.ComponentProps<typeof AttachmentChip>["color"];
+  onClick?: () => void;
   onRemove?: () => void;
   title: string;
   toolIcon: string | null;
@@ -31,6 +32,7 @@ interface ToolChipProps {
 
 export function ToolChip({
   color = "white",
+  onClick,
   onRemove,
   title,
   toolIcon,
@@ -40,6 +42,7 @@ export function ToolChip({
       label={title}
       icon={getToolIcon(toolIcon)}
       color={color}
+      onClick={onClick}
       onRemove={onRemove}
       size="xs"
     />

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -1,5 +1,6 @@
 import { getDefaultMCPAction } from "@app/components/agent_builder/types";
 import { editorVariants } from "@app/components/editor/editorStyles";
+import { SKILL_NODE_TYPE } from "@app/components/editor/extensions/input_bar/SkillNode";
 import { KNOWLEDGE_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
 import type { KnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
 import { TOOL_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/ToolNode";
@@ -10,7 +11,10 @@ import {
 import { SKILL_BUILDER_INSTRUCTIONS_BLUR_EVENT } from "@app/components/skill_builder/events";
 import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
-import { SkillBuilderInstructionsReferenceSummary } from "@app/components/skill_builder/SkillBuilderInstructionsReferenceSummary";
+import {
+  type ReferenceSummaryTarget,
+  SkillBuilderInstructionsReferenceSummary,
+} from "@app/components/skill_builder/SkillBuilderInstructionsReferenceSummary";
 import { useSkillVersionComparisonContext } from "@app/components/skill_builder/SkillBuilderVersionContext";
 import { useSkillSuggestions } from "@app/hooks/useSkillSuggestions";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
@@ -26,6 +30,7 @@ import {
 import { TOOL_TAG_NAME } from "@app/lib/tools/format";
 import { isString } from "@app/types/shared/utils/general";
 import { cn } from "@dust-tt/sparkle";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import type { Transaction } from "@tiptap/pm/state";
 import type { Editor } from "@tiptap/react";
 import type { Config } from "dompurify";
@@ -88,6 +93,87 @@ function collectToolReferenceIds(editor: Editor): Set<string> {
   return toolIds;
 }
 
+function getKnowledgeReferenceId(node: ProseMirrorNode): string | null {
+  const selectedItems = node.attrs.selectedItems;
+  if (!Array.isArray(selectedItems)) {
+    return null;
+  }
+
+  const item = selectedItems[0];
+  if (!item) {
+    return null;
+  }
+
+  return `${item.dataSourceViewId}:${item.nodeId}`;
+}
+
+function matchesReferenceTarget(
+  node: ProseMirrorNode,
+  target: ReferenceSummaryTarget
+): boolean {
+  switch (target.kind) {
+    case "knowledge":
+      return (
+        node.type.name === KNOWLEDGE_NODE_TYPE &&
+        getKnowledgeReferenceId(node) === target.id
+      );
+    case "skill":
+      return (
+        node.type.name === SKILL_NODE_TYPE && node.attrs.skillId === target.id
+      );
+    case "tool":
+      return (
+        node.type.name === TOOL_NODE_TYPE &&
+        node.attrs.mcpServerViewId === target.id
+      );
+  }
+}
+
+function getFirstReferencePosition(
+  editor: Editor,
+  target: ReferenceSummaryTarget
+): number | null {
+  let referencePosition: number | null = null;
+
+  editor.state.doc.descendants((node, position) => {
+    if (matchesReferenceTarget(node, target)) {
+      referencePosition = position;
+      return false;
+    }
+
+    return true;
+  });
+
+  return referencePosition;
+}
+
+function scrollReferenceIntoView({
+  overlayHeight,
+  referenceElement,
+  scrollContainer,
+}: {
+  overlayHeight: number;
+  referenceElement: HTMLElement;
+  scrollContainer: HTMLElement;
+}) {
+  const containerRect = scrollContainer.getBoundingClientRect();
+  const referenceRect = referenceElement.getBoundingClientRect();
+  const visibleHeight = Math.max(
+    0,
+    scrollContainer.clientHeight - overlayHeight
+  );
+  const referenceTop =
+    referenceRect.top - containerRect.top + scrollContainer.scrollTop;
+
+  scrollContainer.scrollTo({
+    behavior: "smooth",
+    top: Math.max(
+      0,
+      referenceTop + referenceRect.height / 2 - visibleHeight / 2
+    ),
+  });
+}
+
 function toAttachedKnowledge(
   items: readonly KnowledgeItem[]
 ): SkillBuilderFormData["attachedKnowledge"] {
@@ -115,7 +201,7 @@ function sanitizeSkillInstructionsHtml(
 
 const INSTRUCTIONS_EDITOR_SIZE = "min-h-60 max-h-[1024px]";
 const INSTRUCTIONS_EDITOR_REFERENCE_SUMMARY_SIZE =
-  "min-h-80 rounded-b-none border-b-0 pb-28";
+  "min-h-80 rounded-b-none border-b-0 pb-44";
 
 interface SkillBuilderInstructionsEditorProps {
   onAddKnowledge?: (addKnowledge: () => void) => void;
@@ -129,6 +215,7 @@ export function SkillBuilderInstructionsEditor({
   const { compareVersion, isDiffMode } = useSkillVersionComparisonContext();
   const { resetField } = useFormContext<SkillBuilderFormData>();
   const initializedAttachedKnowledgeEditorRef = useRef<Editor | null>(null);
+  const instructionReferenceSummaryRef = useRef<HTMLDivElement | null>(null);
   const previousInlineToolIdsRef = useRef<Set<string>>(new Set());
   const toolsRef = useRef<SkillBuilderFormData["tools"]>([]);
   const { owner, skillId, selectedSuggestionId, setAcceptInstructionEdits } =
@@ -174,7 +261,6 @@ export function SkillBuilderInstructionsEditor({
   const hasInstructionReferenceSummary =
     enableSkillReferences &&
     ((attachedKnowledgeField.value?.length ?? 0) > 0 ||
-      tools.length > 0 ||
       (instructionsField.value?.includes("<knowledge ") ?? false) ||
       (instructionsField.value?.includes("<skill ") ?? false) ||
       (instructionsField.value?.includes("<tool ") ?? false));
@@ -363,6 +449,45 @@ export function SkillBuilderInstructionsEditor({
 
     editor.commands.openCapabilitiesSlashCommand();
   }, [editor, enableSkillReferences]);
+
+  const handleReferenceClick = useCallback(
+    (target: ReferenceSummaryTarget) => {
+      if (!editor || editor.isDestroyed) {
+        return;
+      }
+
+      const referencePosition = getFirstReferencePosition(editor, target);
+      if (referencePosition === null) {
+        return;
+      }
+
+      const referenceNode = editor.view.nodeDOM(referencePosition);
+      editor.commands.focus(referencePosition);
+
+      const referenceElement =
+        referenceNode instanceof HTMLElement
+          ? referenceNode
+          : referenceNode?.parentElement;
+      if (!referenceElement) {
+        return;
+      }
+
+      requestAnimationFrame(() => {
+        if (editor.isDestroyed) {
+          return;
+        }
+
+        scrollReferenceIntoView({
+          overlayHeight:
+            instructionReferenceSummaryRef.current?.getBoundingClientRect()
+              .height ?? 0,
+          referenceElement,
+          scrollContainer: editor.view.dom,
+        });
+      });
+    },
+    [editor]
+  );
 
   useEffect(() => {
     if (editor && enableSkillReferences && onOpenCapabilities) {
@@ -619,9 +744,10 @@ export function SkillBuilderInstructionsEditor({
         {enableSkillReferences && (
           <SkillBuilderInstructionsReferenceSummary
             attachedKnowledge={attachedKnowledgeField.value}
+            containerRef={instructionReferenceSummaryRef}
             hasError={displayError}
             instructions={instructionsField.value ?? ""}
-            tools={tools}
+            onReferenceClick={handleReferenceClick}
           />
         )}
       </div>

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -23,10 +23,10 @@ export type ReferenceSummaryTarget =
   | { id: string; kind: "skill" }
   | { id: string; kind: "tool" };
 
-type ReferenceSummaryItem = ReferenceSummaryTarget & {
-  icon?: string | null;
-  title: string;
-};
+type ReferenceSummaryItem =
+  | { id: string; kind: "knowledge"; title: string }
+  | { icon: string | null; id: string; kind: "skill"; title: string }
+  | { icon: string | null; id: string; kind: "tool"; title: string };
 
 function dedupeById<T extends { id: string }>(items: T[]): T[] {
   const seenIds = new Set<string>();
@@ -78,7 +78,7 @@ function renderReferenceSummaryItem({
         <Chip
           key={`${item.kind}:${item.id}`}
           label={item.title}
-          icon={getSkillIcon(item.icon ?? null)}
+          icon={getSkillIcon(item.icon)}
           color="white"
           size="xs"
           onClick={handleClick}
@@ -89,7 +89,7 @@ function renderReferenceSummaryItem({
         <ToolChip
           key={`${item.kind}:${item.id}`}
           title={item.title}
-          toolIcon={item.icon ?? null}
+          toolIcon={item.icon}
           color="white"
           onClick={handleClick}
         />

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -23,10 +23,10 @@ export type ReferenceSummaryTarget =
   | { id: string; kind: "skill" }
   | { id: string; kind: "tool" };
 
-type ReferenceSummaryItem =
-  | { id: string; kind: "knowledge"; title: string }
-  | { icon: string | null; id: string; kind: "skill"; title: string }
-  | { icon: string | null; id: string; kind: "tool"; title: string };
+type ReferenceSummaryItem = ReferenceSummaryTarget & {
+  icon?: string | null;
+  title: string;
+};
 
 function dedupeById<T extends { id: string }>(items: T[]): T[] {
   const seenIds = new Set<string>();
@@ -78,7 +78,7 @@ function renderReferenceSummaryItem({
         <Chip
           key={`${item.kind}:${item.id}`}
           label={item.title}
-          icon={getSkillIcon(item.icon)}
+          icon={getSkillIcon(item.icon ?? null)}
           color="white"
           size="xs"
           onClick={handleClick}
@@ -89,7 +89,7 @@ function renderReferenceSummaryItem({
         <ToolChip
           key={`${item.kind}:${item.id}`}
           title={item.title}
-          toolIcon={item.icon}
+          toolIcon={item.icon ?? null}
           color="white"
           onClick={handleClick}
         />

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -1,6 +1,5 @@
 import { ToolChip } from "@app/components/editor/extensions/skill_builder/ToolChip";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
-import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import type { AttachedKnowledgeFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { getSkillIcon } from "@app/lib/skill";
@@ -8,33 +7,26 @@ import { extractSkillTags } from "@app/lib/skills/format";
 import { extractToolTags } from "@app/lib/tools/format";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { AttachmentChip, Chip, cn, DocumentIcon } from "@dust-tt/sparkle";
+import type { Ref } from "react";
 import { useMemo } from "react";
 
 interface SkillBuilderInstructionsReferenceSummaryProps {
   attachedKnowledge?: AttachedKnowledgeFormData[];
+  containerRef?: Ref<HTMLDivElement>;
   hasError: boolean;
   instructions: string;
-  tools: BuilderAction[];
+  onReferenceClick: (target: ReferenceSummaryTarget) => void;
 }
 
-type ReferenceSummaryItem =
-  | {
-      id: string;
-      kind: "knowledge";
-      title: string;
-    }
-  | {
-      icon: string | null;
-      id: string;
-      kind: "skill";
-      title: string;
-    }
-  | {
-      icon: string | null;
-      id: string;
-      kind: "tool";
-      title: string;
-    };
+export type ReferenceSummaryTarget =
+  | { id: string; kind: "knowledge" }
+  | { id: string; kind: "skill" }
+  | { id: string; kind: "tool" };
+
+type ReferenceSummaryItem = ReferenceSummaryTarget & {
+  icon?: string | null;
+  title: string;
+};
 
 function dedupeById<T extends { id: string }>(items: T[]): T[] {
   const seenIds = new Set<string>();
@@ -60,7 +52,15 @@ function compareReferenceSummaryItems(
   );
 }
 
-function renderReferenceSummaryItem(item: ReferenceSummaryItem) {
+function renderReferenceSummaryItem({
+  item,
+  onReferenceClick,
+}: {
+  item: ReferenceSummaryItem;
+  onReferenceClick: (target: ReferenceSummaryTarget) => void;
+}) {
+  const handleClick = () => onReferenceClick({ id: item.id, kind: item.kind });
+
   switch (item.kind) {
     case "knowledge":
       return (
@@ -70,6 +70,7 @@ function renderReferenceSummaryItem(item: ReferenceSummaryItem) {
           icon={{ visual: DocumentIcon }}
           color="white"
           size="xs"
+          onClick={handleClick}
         />
       );
     case "skill":
@@ -77,9 +78,10 @@ function renderReferenceSummaryItem(item: ReferenceSummaryItem) {
         <Chip
           key={`${item.kind}:${item.id}`}
           label={item.title}
-          icon={getSkillIcon(item.icon)}
+          icon={getSkillIcon(item.icon ?? null)}
           color="white"
           size="xs"
+          onClick={handleClick}
         />
       );
     case "tool":
@@ -87,8 +89,9 @@ function renderReferenceSummaryItem(item: ReferenceSummaryItem) {
         <ToolChip
           key={`${item.kind}:${item.id}`}
           title={item.title}
-          toolIcon={item.icon}
+          toolIcon={item.icon ?? null}
           color="white"
+          onClick={handleClick}
         />
       );
     default:
@@ -98,9 +101,10 @@ function renderReferenceSummaryItem(item: ReferenceSummaryItem) {
 
 export function SkillBuilderInstructionsReferenceSummary({
   attachedKnowledge,
+  containerRef,
   hasError,
   instructions,
-  tools,
+  onReferenceClick,
 }: SkillBuilderInstructionsReferenceSummaryProps) {
   const { mcpServerViews, isMCPServerViewsLoading } =
     useMCPServerViewsContext();
@@ -146,33 +150,6 @@ export function SkillBuilderInstructionsReferenceSummary({
     [instructions, isMCPServerViewsLoading, mcpServerViews]
   );
 
-  const selectedToolReferences = useMemo(() => {
-    if (isMCPServerViewsLoading) {
-      return tools.map((tool) => ({
-        icon: null,
-        id: tool.configuration.mcpServerViewId,
-        title: tool.name,
-      }));
-    }
-
-    return tools.map((tool) => {
-      const view = mcpServerViews.find(
-        (v) => v.sId === tool.configuration.mcpServerViewId
-      );
-
-      return {
-        icon: view?.server.icon ?? null,
-        id: tool.configuration.mcpServerViewId,
-        title: view ? getMcpServerViewDisplayName(view, tool) : tool.name,
-      };
-    });
-  }, [isMCPServerViewsLoading, mcpServerViews, tools]);
-
-  const toolReferences = dedupeById([
-    ...inlineToolReferences,
-    ...selectedToolReferences,
-  ]);
-
   const referenceItems = useMemo(
     () =>
       [
@@ -188,14 +165,14 @@ export function SkillBuilderInstructionsReferenceSummary({
             kind: "skill",
           })
         ),
-        ...toolReferences.map(
+        ...inlineToolReferences.map(
           (tool): ReferenceSummaryItem => ({
             ...tool,
             kind: "tool",
           })
         ),
       ].toSorted(compareReferenceSummaryItems),
-    [knowledgeReferences, skillReferences, toolReferences]
+    [knowledgeReferences, skillReferences, inlineToolReferences]
   );
 
   if (referenceItems.length === 0) {
@@ -204,6 +181,7 @@ export function SkillBuilderInstructionsReferenceSummary({
 
   return (
     <div
+      ref={containerRef}
       className={cn(
         "absolute inset-x-0 bottom-0 z-10 max-h-40 overflow-y-auto rounded-b-xl border-x border-b bg-background px-3 pb-3 pt-3",
         "dark:bg-background-night",
@@ -222,7 +200,9 @@ export function SkillBuilderInstructionsReferenceSummary({
         Capabilities and knowledge
       </div>
       <div className="flex flex-wrap gap-2">
-        {referenceItems.map(renderReferenceSummaryItem)}
+        {referenceItems.map((item) =>
+          renderReferenceSummaryItem({ item, onReferenceClick })
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Description

This PR makes the read-only “Capabilities and knowledge” chips in the Skill Builder instructions editor actionable. Clicking an inline knowledge, skill, or tool chip now finds the first matching reference in the instructions, focuses that editor position, and scrolls it into view.

We actually scroll to put it in the middle instead of scrolling at little as possible. It's better for highlighting the chip and avoids having the chip end up behind the read-only section.

<img width="1136" height="1048" alt="Jun-01-2026 10-37-31 PM" src="https://github.com/user-attachments/assets/40b21319-3d2a-401f-819e-454dba587b13" />

## Tests

- Tested locally.

## Risk

- Low. Skill Builder UI only. Behind feature flag. Safe to rollback.

## Deploy Plan

- Deploy front.
