### PR TITLE
Implement invitation reminder logic and harden re-invite flow

### DIFF
--- a/front-api/routes/invitations.ts
+++ b/front-api/routes/invitations.ts
@@ -1,7 +1,7 @@
-import { getMembershipInvitationToken } from "@app/lib/api/invitation";
 import { fetchInvitationsFromOtherRegion } from "@app/lib/api/regions/lookup";
 import { getUserFromSession } from "@app/lib/iam/session";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
+import { getMembershipInvitationToken } from "@app/lib/utils/invitation_token";
 import logger from "@app/logger/logger";
 import type { PendingInvitationOption } from "@app/types/membership_invitation";
 import { sessionApp } from "@front-api/middlewares/ctx";

--- a/front-api/routes/poke/workspaces/[wId]/memberships.ts
+++ b/front-api/routes/poke/workspaces/[wId]/memberships.ts
@@ -1,6 +1,6 @@
-import { getMembershipInvitationUrl } from "@app/lib/api/invitation";
 import { getMembers } from "@app/lib/api/workspace";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
+import { getMembershipInvitationUrl } from "@app/lib/utils/invitation_token";
 import type { MembershipInvitationTypeWithLink } from "@app/types/membership_invitation";
 import type { UserTypeWithWorkspaces } from "@app/types/user";
 import { pokeApp } from "@front-api/middlewares/ctx";

--- a/front-api/routes/w/[wId]/join.test.ts
+++ b/front-api/routes/w/[wId]/join.test.ts
@@ -1,4 +1,4 @@
-import { getMembershipInvitationToken } from "@app/lib/api/invitation";
+import { getMembershipInvitationToken } from "@app/lib/utils/invitation_token";
 import { MembershipInvitationFactory } from "@app/tests/utils/MembershipInvitationFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { honoApp } from "@front-api/app";

--- a/front-api/routes/w/[wId]/me/pending-invitations.ts
+++ b/front-api/routes/w/[wId]/me/pending-invitations.ts
@@ -1,5 +1,5 @@
-import { getMembershipInvitationToken } from "@app/lib/api/invitation";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
+import { getMembershipInvitationToken } from "@app/lib/utils/invitation_token";
 import type { PendingInvitationOption } from "@app/types/membership_invitation";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";

--- a/front/components/poke/invitations/columns.tsx
+++ b/front/components/poke/invitations/columns.tsx
@@ -1,5 +1,4 @@
 import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
-import { INVITATION_EXPIRATION_TIME_SEC } from "@app/lib/constants/invitation";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { MembershipInvitationTypeWithLink } from "@app/types/membership_invitation";
 import {
@@ -11,15 +10,11 @@ import {
 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 
-const INVITATION_EXPIRATION_TIME_MS = INVITATION_EXPIRATION_TIME_SEC * 1000;
-
-function formatExpiresIn(createdAt: number): {
+function formatExpiresIn(expiresAtMs: number): {
   label: string;
   isExpired: boolean;
   exactDate: string;
 } {
-  const expiresAtMs =
-    new Date(createdAt).getTime() + INVITATION_EXPIRATION_TIME_MS;
   const nowMs = Date.now();
   const diffMs = expiresAtMs - nowMs;
   const exactDate = new Date(expiresAtMs).toLocaleString();
@@ -65,8 +60,8 @@ export function makeColumnsForInvitations(
       id: "expires",
       header: "Expires",
       cell: ({ row }) => {
-        const createdAt: number = row.original.createdAt;
-        const { label, isExpired, exactDate } = formatExpiresIn(createdAt);
+        const expiresAt: number = row.original.expiresAt;
+        const { label, isExpired, exactDate } = formatExpiresIn(expiresAt);
         return (
           <Tooltip
             label={exactDate}

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -113,6 +113,11 @@ const config = {
       "SENDGRID_INVITATION_EMAIL_TEMPLATE_ID"
     );
   },
+  getInvitationReminderEmailTemplate: (): string => {
+    return EnvironmentConfig.getEnvVariable(
+      "SENDGRID_INVITATION_REMINDER_EMAIL_TEMPLATE_ID"
+    );
+  },
   getGenericEmailTemplate: (): string => {
     return EnvironmentConfig.getEnvVariable(
       "SENDGRID_GENERIC_EMAIL_TEMPLATE_ID"

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -189,9 +189,9 @@ export async function handleMembershipInvitations(
     ): Promise<
       Result<InvitationTransactionPayload, APIErrorWithContentfulStatusCode>
     > => {
-      if (maxUsers !== -1) {
-        await getWorkspaceAdministrationVersionLock(owner, t);
+      await getWorkspaceAdministrationVersionLock(owner, t);
 
+      if (maxUsers !== -1) {
         const membersCount =
           await MembershipResource.getMembersCountForWorkspace({
             workspace: owner,

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -9,12 +9,12 @@ import {
   getWorkspaceAdministrationVersionLock,
 } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
-import { INVITATION_EXPIRATION_TIME_SEC } from "@app/lib/constants/invitation";
 import { MAX_UNCONSUMED_INVITATIONS_PER_WORKSPACE_PER_DAY } from "@app/lib/invitations";
 import { MembershipInvitationModel } from "@app/lib/models/membership_invitation";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { isEmailValid } from "@app/lib/utils";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { getMembershipInvitationUrl } from "@app/lib/utils/invitation_token";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
@@ -33,7 +33,6 @@ import type {
 } from "@app/types/user";
 import sgMail from "@sendgrid/mail";
 import { escape } from "html-escaper";
-import { sign } from "jsonwebtoken";
 import type { Transaction } from "sequelize";
 import { Op } from "sequelize";
 
@@ -66,37 +65,6 @@ export async function getInvitation(
   return invitation.toJSON();
 }
 
-export function getMembershipInvitationToken(
-  invitation: MembershipInvitationType
-) {
-  const iat = Math.floor(invitation.createdAt / 1000);
-  const exp = iat + INVITATION_EXPIRATION_TIME_SEC;
-
-  return sign(
-    {
-      membershipInvitationId: invitation.id,
-      iat,
-      exp,
-    },
-    config.getDustInviteTokenSecret()
-  );
-}
-
-function getMembershipInvitationUrlForToken(
-  owner: LightWorkspaceType,
-  invitationToken: string
-) {
-  return `${config.getAppUrl()}/w/${owner.sId}/join/?t=${invitationToken}`;
-}
-
-export function getMembershipInvitationUrl(
-  owner: LightWorkspaceType,
-  invitation: MembershipInvitationType
-) {
-  const invitationToken = getMembershipInvitationToken(invitation);
-  return getMembershipInvitationUrlForToken(owner, invitationToken);
-}
-
 export async function sendWorkspaceInvitationEmail(
   owner: WorkspaceType,
   user: UserType,
@@ -111,6 +79,24 @@ export async function sendWorkspaceInvitationEmail(
       inviteLink: getMembershipInvitationUrl(owner, invitation),
       // Escape the name to prevent XSS attacks via injected script elements.
       inviterName: escape(user.fullName),
+      workspaceName: owner.name,
+    },
+  };
+
+  sgMail.setApiKey(config.getSendgridApiKey());
+  await sgMail.send(message);
+}
+
+export async function sendWorkspaceInvitationReminderEmail(
+  owner: LightWorkspaceType,
+  invitation: MembershipInvitationType
+) {
+  const message = {
+    to: invitation.inviteEmail,
+    from: config.getSupportEmailAddress(),
+    templateId: config.getInvitationReminderEmailTemplate(),
+    dynamic_template_data: {
+      inviteLink: getMembershipInvitationUrl(owner, invitation),
       workspaceName: owner.name,
     },
   };
@@ -362,9 +348,6 @@ export async function handleMembershipInvitations(
         inviteEmail: string;
         initialRole: ActiveRoleType;
       }[] = [];
-      // Group role updates by target role so we issue one UPDATE per distinct
-      // role (bounded by the number of active roles) instead of per invitation.
-      const toUpdateRoleByRole = new Map<ActiveRoleType, ModelId[]>();
       const invitationBySanitizedEmail = new Map<
         string,
         MembershipInvitationType
@@ -375,38 +358,16 @@ export async function handleMembershipInvitations(
         role,
       } of uniqueCandidateBySanitizedEmail.values()) {
         const existing = existingByEmail.get(sanitizedEmail);
-        if (!existing || existing.isExpired()) {
-          if (existing) {
-            toRevokeModelIds.push(existing.id);
-          }
-          toCreate.push({
-            inviteEmail: sanitizedEmail,
-            initialRole: role,
-          });
-        } else {
-          if (existing.initialRole !== role) {
-            const group = toUpdateRoleByRole.get(role) ?? [];
-            group.push(existing.id);
-            toUpdateRoleByRole.set(role, group);
-          }
-          invitationBySanitizedEmail.set(sanitizedEmail, {
-            ...existing.toJSON(),
-            initialRole: role,
-          });
+        if (existing) {
+          toRevokeModelIds.push(existing.id);
         }
+        toCreate.push({ inviteEmail: sanitizedEmail, initialRole: role });
       }
 
       await MembershipInvitationResource.bulkRevokeByModelIds(auth, {
         modelIds: toRevokeModelIds,
         transaction: t,
       });
-
-      for (const [role, modelIds] of toUpdateRoleByRole) {
-        await MembershipInvitationResource.bulkUpdateInitialRoleByModelIds(
-          auth,
-          { modelIds, role, transaction: t }
-        );
-      }
 
       const created = await MembershipInvitationResource.bulkMakeNewPending(
         auth,

--- a/front/lib/api/regions/lookup.ts
+++ b/front/lib/api/regions/lookup.ts
@@ -1,10 +1,10 @@
-import { getMembershipInvitationToken } from "@app/lib/api/invitation";
 import { config } from "@app/lib/api/regions/config";
 import { isWorkspaceRelocationDone } from "@app/lib/api/workspace";
 import { findWorkspaceWithVerifiedDomain } from "@app/lib/iam/workspaces";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { cacheWithRedis, invalidateCacheWithRedis } from "@app/lib/utils/cache";
+import { getMembershipInvitationToken } from "@app/lib/utils/invitation_token";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import type {
   InvitationsLookupRequestBodyType,

--- a/front/lib/constants/invitation.ts
+++ b/front/lib/constants/invitation.ts
@@ -1,2 +1,7 @@
 // Make token expires after 7 days
 export const INVITATION_EXPIRATION_TIME_SEC = 60 * 60 * 24 * 7;
+export const INVITATION_EXPIRATION_TIME_MS =
+  INVITATION_EXPIRATION_TIME_SEC * 1000;
+
+// Send reminder for invitations created between 7 and 10 days ago.
+export const INVITATION_REMINDER_WINDOW_MS = 10 * 24 * 60 * 60 * 1000;

--- a/front/lib/resources/membership_invitation_resource.ts
+++ b/front/lib/resources/membership_invitation_resource.ts
@@ -1,6 +1,9 @@
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
-import { INVITATION_EXPIRATION_TIME_SEC } from "@app/lib/constants/invitation";
+import {
+  INVITATION_EXPIRATION_TIME_MS,
+  INVITATION_REMINDER_WINDOW_MS,
+} from "@app/lib/constants/invitation";
 import { AuthFlowError } from "@app/lib/iam/errors";
 import { MembershipInvitationModel } from "@app/lib/models/membership_invitation";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -8,6 +11,7 @@ import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import { getInvitationTokenStartMs } from "@app/lib/utils/invitation_token";
 import logger from "@app/logger/logger";
 import type { MembershipInvitationType } from "@app/types/membership_invitation";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -81,12 +85,6 @@ export class MembershipInvitationResource extends BaseResource<MembershipInvitat
           workspace: invitation.workspace,
         })
       : null;
-  }
-
-  private static invitationExpired(createdAt: Date) {
-    return (
-      createdAt.getTime() + INVITATION_EXPIRATION_TIME_SEC * 1000 < Date.now()
-    );
   }
 
   static async listRecentPendingAndRevokedInvitations(
@@ -163,16 +161,13 @@ export class MembershipInvitationResource extends BaseResource<MembershipInvitat
     });
 
     return invitations
-      .filter(
-        (invitation) =>
-          includeExpired || !this.invitationExpired(invitation.createdAt)
-      )
       .map(
         (invitation) =>
           new MembershipInvitationResource(this.model, invitation.get(), {
             workspace: invitation.workspace,
           })
-      );
+      )
+      .filter((r) => includeExpired || !r.isExpired());
   }
 
   static async listPendingForEmailsAndWorkspace({
@@ -201,16 +196,13 @@ export class MembershipInvitationResource extends BaseResource<MembershipInvitat
     });
 
     return invitations
-      .filter(
-        (invitation) =>
-          includeExpired || !this.invitationExpired(invitation.createdAt)
-      )
       .map(
         (invitation) =>
           new MembershipInvitationResource(this.model, invitation.get(), {
             workspace: invitation.workspace,
           })
-      );
+      )
+      .filter((r) => includeExpired || !r.isExpired());
   }
 
   static async getPendingForEmailAndWorkspace({
@@ -306,25 +298,6 @@ export class MembershipInvitationResource extends BaseResource<MembershipInvitat
     });
   }
 
-  static async bulkUpdateInitialRoleByModelIds(
-    auth: Authenticator,
-    {
-      modelIds,
-      role,
-      transaction,
-    }: {
-      modelIds: ModelId[];
-      role: ActiveRoleType;
-      transaction?: Transaction;
-    }
-  ): Promise<void> {
-    await this.bulkUpdateByModelIds(auth, {
-      modelIds,
-      values: { initialRole: role },
-      transaction,
-    });
-  }
-
   static async getPendingInvitations(
     auth: Authenticator,
     { includeExpired = false }: { includeExpired?: boolean } = {}
@@ -347,16 +320,13 @@ export class MembershipInvitationResource extends BaseResource<MembershipInvitat
     });
 
     return invitations
-      .filter(
-        (invitation) =>
-          includeExpired || !this.invitationExpired(invitation.createdAt)
-      )
       .map(
         (i) =>
           new MembershipInvitationResource(this.model, i.get(), {
             workspace: i.workspace,
           })
-      );
+      )
+      .filter((r) => includeExpired || !r.isExpired());
   }
 
   static async getPendingForToken(
@@ -408,7 +378,13 @@ export class MembershipInvitationResource extends BaseResource<MembershipInvitat
         );
       }
 
-      if (this.invitationExpired(membershipInvite.createdAt)) {
+      const resource = new MembershipInvitationResource(
+        this.model,
+        membershipInvite.get(),
+        { workspace: membershipInvite.workspace }
+      );
+
+      if (resource.isExpired()) {
         return new Err(
           new AuthFlowError(
             "expired_invitation",
@@ -417,20 +393,67 @@ export class MembershipInvitationResource extends BaseResource<MembershipInvitat
         );
       }
 
-      return new Ok(
-        new MembershipInvitationResource(this.model, membershipInvite.get(), {
-          workspace: membershipInvite.workspace,
-        })
-      );
+      return new Ok(resource);
     }
 
     return new Ok(null);
   }
 
-  isExpired() {
-    return (
-      this.createdAt.getTime() + INVITATION_EXPIRATION_TIME_SEC * 1000 <
-      Date.now()
+  getTokenExpirationDate(): Date {
+    const startDateMs = getInvitationTokenStartMs({
+      createdAt: this.createdAt,
+      reminderSentAt: this.reminderSentAt,
+    });
+    return new Date(startDateMs + INVITATION_EXPIRATION_TIME_MS);
+  }
+
+  isExpired(): boolean {
+    return this.getTokenExpirationDate().getTime() < Date.now();
+  }
+
+  // Atomically claims the reminder slot. Returns true if claimed, false if another worker already did.
+  // Updates this resource in-memory on success so toJSON() and token generation use the new reminderSentAt.
+  async claimReminderSlot(): Promise<boolean> {
+    const reminderSentAt = new Date();
+    const [affectedCount] = await MembershipInvitationModel.update(
+      { reminderSentAt },
+      { where: { id: this.id, reminderSentAt: null } }
+    );
+    if (affectedCount > 0) {
+      Object.assign(this, { reminderSentAt });
+    }
+    return affectedCount > 0;
+  }
+
+  static async listEligibleForReminder({
+    limit,
+  }: {
+    limit: number;
+  }): Promise<MembershipInvitationResource[]> {
+    const expirationCutoff = new Date(
+      Date.now() - INVITATION_EXPIRATION_TIME_MS
+    );
+    const reminderCutoff = new Date(Date.now() - INVITATION_REMINDER_WINDOW_MS);
+
+    const invitations = await this.model.findAll({
+      where: {
+        status: "pending",
+        createdAt: { [Op.lt]: expirationCutoff, [Op.gt]: reminderCutoff },
+        reminderSentAt: { [Op.is]: null },
+      },
+      order: [
+        ["createdAt", "ASC"],
+        ["id", "ASC"],
+      ],
+      limit,
+      include: [WorkspaceModel],
+      // WORKSPACE_ISOLATION_BYPASS: Reminder job scans across all workspaces.
+      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
+    });
+
+    return invitations.map(
+      (inv) => new this(this.model, inv.get(), { workspace: inv.workspace })
     );
   }
 
@@ -484,6 +507,7 @@ export class MembershipInvitationResource extends BaseResource<MembershipInvitat
     return {
       createdAt: this.createdAt.getTime(),
       reminderSentAt: this.reminderSentAt?.getTime() ?? null,
+      expiresAt: this.getTokenExpirationDate().getTime(),
       id: this.id,
       initialRole: this.initialRole,
       inviteEmail: this.inviteEmail,

--- a/front/lib/utils/invitation_token.ts
+++ b/front/lib/utils/invitation_token.ts
@@ -1,0 +1,45 @@
+import config from "@app/lib/api/config";
+import { INVITATION_EXPIRATION_TIME_MS } from "@app/lib/constants/invitation";
+import type { MembershipInvitationType } from "@app/types/membership_invitation";
+import type { LightWorkspaceType } from "@app/types/user";
+import { sign } from "jsonwebtoken";
+
+// After a reminder is sent, the token is re-anchored on reminderSentAt so the recipient gets a fresh 7-day window.
+export function getInvitationTokenStartMs({
+  createdAt,
+  reminderSentAt,
+}: {
+  createdAt: Date | number;
+  reminderSentAt: Date | number | null;
+}): number {
+  const createdAtMs =
+    createdAt instanceof Date ? createdAt.getTime() : createdAt;
+  const reminderSentAtMs =
+    reminderSentAt instanceof Date ? reminderSentAt.getTime() : reminderSentAt;
+  return reminderSentAtMs ?? createdAtMs;
+}
+
+export function getMembershipInvitationToken(
+  invitation: MembershipInvitationType
+) {
+  const tokenStartMs = getInvitationTokenStartMs(invitation);
+  const iat = Math.floor(tokenStartMs / 1000);
+  const exp = Math.floor((tokenStartMs + INVITATION_EXPIRATION_TIME_MS) / 1000);
+
+  return sign(
+    {
+      membershipInvitationId: invitation.id,
+      iat,
+      exp,
+    },
+    config.getDustInviteTokenSecret()
+  );
+}
+
+export function getMembershipInvitationUrl(
+  owner: LightWorkspaceType,
+  invitation: MembershipInvitationType
+) {
+  const token = getMembershipInvitationToken(invitation);
+  return `${config.getAppUrl()}/w/${owner.sId}/join/?t=${token}`;
+}

--- a/front/pages/api/invitations.ts
+++ b/front/pages/api/invitations.ts
@@ -2,11 +2,11 @@
 
 /** @ignoreswagger */
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
-import { getMembershipInvitationToken } from "@app/lib/api/invitation";
 import { fetchInvitationsFromOtherRegion } from "@app/lib/api/regions/lookup";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { getUserFromSession } from "@app/lib/iam/session";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
+import { getMembershipInvitationToken } from "@app/lib/utils/invitation_token";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";

--- a/front/pages/api/poke/workspaces/[wId]/memberships.ts
+++ b/front/pages/api/poke/workspaces/[wId]/memberships.ts
@@ -1,11 +1,11 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
-import { getMembershipInvitationUrl } from "@app/lib/api/invitation";
 import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
+import { getMembershipInvitationUrl } from "@app/lib/utils/invitation_token";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { MembershipInvitationTypeWithLink } from "@app/types/membership_invitation";

--- a/front/pages/api/w/[wId]/invitations/index.test.ts
+++ b/front/pages/api/w/[wId]/invitations/index.test.ts
@@ -69,15 +69,12 @@ describe("POST /api/w/[wId]/invitations", () => {
     expect(sgSendMock).toHaveBeenCalledTimes(3);
   });
 
-  it("updates the role on an existing pending invitation without creating a new row", async () => {
+  it("revokes an existing non-expired invitation and creates a fresh one with the new role", async () => {
     const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "POST",
       role: "admin",
     });
 
-    // Invitations created in the last 24h hit the "already sent recently"
-    // rate limit, so age the existing invitation past that window but stay
-    // under the 7-day expiration so the role-update path fires.
     const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
     const existing = await MembershipInvitationFactory.create(workspace, {
       inviteEmail: "role-change@example.com",
@@ -97,10 +94,17 @@ describe("POST /api/w/[wId]/invitations", () => {
     const adminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
+
+    const oldInvitation = await MembershipInvitationResource.fetchById(
+      adminAuth,
+      existing.sId
+    );
+    expect(oldInvitation?.status).toBe("revoked");
+
     const invitations =
       await MembershipInvitationResource.getPendingInvitations(adminAuth);
     expect(invitations).toHaveLength(1);
-    expect(invitations[0].sId).toBe(existing.sId);
+    expect(invitations[0].sId).not.toBe(existing.sId);
     expect(invitations[0].initialRole).toBe("admin");
   });
 

--- a/front/pages/api/w/[wId]/join.test.ts
+++ b/front/pages/api/w/[wId]/join.test.ts
@@ -1,4 +1,4 @@
-import { getMembershipInvitationToken } from "@app/lib/api/invitation";
+import { getMembershipInvitationToken } from "@app/lib/utils/invitation_token";
 import { MembershipInvitationFactory } from "@app/tests/utils/MembershipInvitationFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { NextApiRequest, NextApiResponse } from "next";

--- a/front/pages/api/w/[wId]/me/pending-invitations.ts
+++ b/front/pages/api/w/[wId]/me/pending-invitations.ts
@@ -2,9 +2,9 @@
 
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { getMembershipInvitationToken } from "@app/lib/api/invitation";
 import type { Authenticator } from "@app/lib/auth";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
+import { getMembershipInvitationToken } from "@app/lib/utils/invitation_token";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { PendingInvitationOption } from "@app/types/membership_invitation";

--- a/front/temporal/invitations/activities.ts
+++ b/front/temporal/invitations/activities.ts
@@ -1,4 +1,89 @@
-// Stub — replaced in reinvite_workflow_logic.
+import config from "@app/lib/api/config";
+import { sendWorkspaceInvitationReminderEmail } from "@app/lib/api/invitation";
+import { Authenticator } from "@app/lib/auth";
+import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { Context } from "@temporalio/activity";
+
+const EMAIL_CONCURRENCY = 8;
+const BATCH_SIZE = 50;
+
+// Returns true if a full batch was processed, meaning there may be more to process.
 export async function sendInvitationReminderBatchActivity(): Promise<boolean> {
-  return false;
+  // Preflight: fail fast before mutating any rows if config is missing.
+  config.getInvitationReminderEmailTemplate();
+  config.getSendgridApiKey();
+
+  const invitations =
+    await MembershipInvitationResource.listEligibleForReminder({
+      limit: BATCH_SIZE,
+    });
+
+  if (invitations.length === 0) {
+    return false;
+  }
+
+  Context.current().heartbeat();
+
+  // Group by workspaceId to create the Authenticator once per workspace.
+  const byWorkspaceId = new Map<string, typeof invitations>();
+  for (const invitation of invitations) {
+    byWorkspaceId.set(invitation.workspace.sId, [
+      ...(byWorkspaceId.get(invitation.workspace.sId) ?? []),
+      invitation,
+    ]);
+  }
+
+  let emailsFailed = 0;
+
+  for (const [workspaceId, batch] of byWorkspaceId) {
+    const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+
+    await concurrentExecutor(
+      batch,
+      async (invitation) => {
+        // DB failure propagates → concurrentExecutor aborts → activity fails → Temporal retries.
+        // Safe to retry: claimReminderSlot uses a conditional UPDATE (WHERE reminderSentAt IS NULL)
+        // so already-claimed invitations are skipped on the next attempt.
+        const claimed = await invitation.claimReminderSlot();
+
+        if (!claimed) {
+          return;
+        }
+
+        try {
+          await sendWorkspaceInvitationReminderEmail(
+            auth.getNonNullableWorkspace(),
+            invitation.toJSON()
+          );
+        } catch (err) {
+          // Email failure is per-item and non-retryable at activity level.
+          // reminderSentAt is already set, so this invitation won't be retried automatically.
+          logger.error(
+            {
+              err: normalizeError(err),
+              inviteEmail: invitation.inviteEmail,
+              workspaceId,
+            },
+            "[Invitation Reminders] Failed to send reminder email."
+          );
+          emailsFailed++;
+        }
+      },
+      { concurrency: EMAIL_CONCURRENCY }
+    );
+
+    Context.current().heartbeat();
+  }
+
+  if (emailsFailed > 0) {
+    logger.warn(
+      { emailsFailed },
+      "[Invitation Reminders] Some reminder emails failed to send."
+    );
+  }
+
+  return invitations.length === BATCH_SIZE;
 }

--- a/front/temporal/invitations/activities.ts
+++ b/front/temporal/invitations/activities.ts
@@ -30,10 +30,9 @@ export async function sendInvitationReminderBatchActivity(): Promise<boolean> {
   // Group by workspaceId to create the Authenticator once per workspace.
   const byWorkspaceId = new Map<string, typeof invitations>();
   for (const invitation of invitations) {
-    byWorkspaceId.set(invitation.workspace.sId, [
-      ...(byWorkspaceId.get(invitation.workspace.sId) ?? []),
-      invitation,
-    ]);
+    const group = byWorkspaceId.get(invitation.workspace.sId) ?? [];
+    group.push(invitation);
+    byWorkspaceId.set(invitation.workspace.sId, group);
   }
 
   let emailsFailed = 0;

--- a/front/temporal/invitations/invitation_reminders.test.ts
+++ b/front/temporal/invitations/invitation_reminders.test.ts
@@ -13,6 +13,17 @@ import { beforeAll, describe, expect, it, vi } from "vitest";
 
 const TEST_SECRET = "test-invite-secret";
 
+function decodeToken(
+  token: string,
+  secret: string
+): { iat: number; exp: number } {
+  const decoded = verify(token, secret);
+  if (typeof decoded === "string" || !decoded) {
+    throw new Error("unexpected token shape");
+  }
+  return decoded as { iat: number; exp: number };
+}
+
 beforeAll(() => {
   vi.stubEnv("DUST_INVITE_TOKEN_SECRET", TEST_SECRET);
 });
@@ -66,7 +77,7 @@ describe("getMembershipInvitationToken", () => {
     const createdAt = Date.now() - 1000;
     const invitation = makeInvitation(createdAt);
     const token = getMembershipInvitationToken(invitation);
-    const decoded = verify(token, secret) as { iat: number; exp: number };
+    const decoded = decodeToken(token, secret);
 
     expect(decoded.iat).toBe(Math.floor(createdAt / 1000));
     expect(decoded.exp).toBe(
@@ -79,7 +90,7 @@ describe("getMembershipInvitationToken", () => {
     const reminderSentAt = Date.now() - 1000;
     const invitation = makeInvitation(createdAt, reminderSentAt);
     const token = getMembershipInvitationToken(invitation);
-    const decoded = verify(token, secret) as { iat: number; exp: number };
+    const decoded = decodeToken(token, secret);
 
     expect(decoded.iat).toBe(Math.floor(reminderSentAt / 1000));
     expect(decoded.exp).toBe(
@@ -105,7 +116,7 @@ describe("getMembershipInvitationToken", () => {
     const reminderSentAt = Date.now() - 1000;
     const invitation = makeInvitation(createdAt, reminderSentAt);
     const token = getMembershipInvitationToken(invitation);
-    const decoded = verify(token, secret) as { exp: number };
+    const decoded = decodeToken(token, secret);
 
     expect(decoded.exp).toBe(
       Math.floor(reminderSentAt / 1000) + INVITATION_EXPIRATION_TIME_SEC
@@ -149,7 +160,7 @@ describe("claimReminderSlot", () => {
     expect(resource.reminderSentAt).toEqual(new Date(now));
     expect(resource.toJSON().reminderSentAt).toBe(now);
     const token = getMembershipInvitationToken(resource.toJSON());
-    const decoded = verify(token, TEST_SECRET) as { iat: number };
+    const decoded = decodeToken(token, TEST_SECRET);
     expect(decoded.iat).toBe(Math.floor(now / 1000));
 
     vi.useRealTimers();

--- a/front/temporal/invitations/invitation_reminders.test.ts
+++ b/front/temporal/invitations/invitation_reminders.test.ts
@@ -1,0 +1,208 @@
+import {
+  INVITATION_EXPIRATION_TIME_MS,
+  INVITATION_EXPIRATION_TIME_SEC,
+} from "@app/lib/constants/invitation";
+import { MembershipInvitationModel } from "@app/lib/models/membership_invitation";
+import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
+import {
+  getInvitationTokenStartMs,
+  getMembershipInvitationToken,
+} from "@app/lib/utils/invitation_token";
+import { verify } from "jsonwebtoken";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+const TEST_SECRET = "test-invite-secret";
+
+beforeAll(() => {
+  vi.stubEnv("DUST_INVITE_TOKEN_SECRET", TEST_SECRET);
+});
+
+// Minimal MembershipInvitationType shape needed for token tests.
+function makeInvitation(
+  createdAt: number,
+  reminderSentAt: number | null = null
+) {
+  return {
+    id: 1,
+    sId: "test-sid",
+    status: "pending" as const,
+    inviteEmail: "user@example.com",
+    initialRole: "user" as const,
+    createdAt,
+    reminderSentAt,
+    expiresAt:
+      getInvitationTokenStartMs({
+        createdAt,
+        reminderSentAt,
+      }) + INVITATION_EXPIRATION_TIME_MS,
+    isExpired: false,
+  };
+}
+
+describe("getInvitationTokenStartMs", () => {
+  it("returns createdAt when reminderSentAt is null", () => {
+    const createdAt = Date.now() - 1000;
+    expect(
+      getInvitationTokenStartMs({
+        createdAt,
+        reminderSentAt: null,
+      })
+    ).toBe(createdAt);
+  });
+
+  it("returns reminderSentAt when set", () => {
+    const createdAt = Date.now() - 8 * 24 * 60 * 60 * 1000;
+    const reminderSentAt = Date.now() - 1000;
+    expect(getInvitationTokenStartMs({ createdAt, reminderSentAt })).toBe(
+      reminderSentAt
+    );
+  });
+});
+
+describe("getMembershipInvitationToken", () => {
+  const secret = TEST_SECRET;
+
+  it("anchors token on createdAt when no reminder has been sent", () => {
+    const createdAt = Date.now() - 1000;
+    const invitation = makeInvitation(createdAt);
+    const token = getMembershipInvitationToken(invitation);
+    const decoded = verify(token, secret) as { iat: number; exp: number };
+
+    expect(decoded.iat).toBe(Math.floor(createdAt / 1000));
+    expect(decoded.exp).toBe(
+      Math.floor(createdAt / 1000) + INVITATION_EXPIRATION_TIME_SEC
+    );
+  });
+
+  it("anchors token on reminderSentAt after reminder is sent", () => {
+    const createdAt = Date.now() - 8 * 24 * 60 * 60 * 1000;
+    const reminderSentAt = Date.now() - 1000;
+    const invitation = makeInvitation(createdAt, reminderSentAt);
+    const token = getMembershipInvitationToken(invitation);
+    const decoded = verify(token, secret) as { iat: number; exp: number };
+
+    expect(decoded.iat).toBe(Math.floor(reminderSentAt / 1000));
+    expect(decoded.exp).toBe(
+      Math.floor(reminderSentAt / 1000) + INVITATION_EXPIRATION_TIME_SEC
+    );
+  });
+
+  it("old token generated before reminder remains expired after reminderSentAt is set", () => {
+    const createdAt = Date.now() - 8 * 24 * 60 * 60 * 1000;
+    const invitationBeforeReminder = makeInvitation(createdAt, null);
+    const oldToken = getMembershipInvitationToken(invitationBeforeReminder);
+
+    const reminderSentAt = Date.now() - 1000;
+    const invitationAfterReminder = makeInvitation(createdAt, reminderSentAt);
+    const newToken = getMembershipInvitationToken(invitationAfterReminder);
+
+    expect(() => verify(oldToken, secret)).toThrow();
+    expect(() => verify(newToken, secret)).not.toThrow();
+  });
+
+  it("new token expires 7 days after reminderSentAt", () => {
+    const createdAt = Date.now() - 8 * 24 * 60 * 60 * 1000;
+    const reminderSentAt = Date.now() - 1000;
+    const invitation = makeInvitation(createdAt, reminderSentAt);
+    const token = getMembershipInvitationToken(invitation);
+    const decoded = verify(token, secret) as { exp: number };
+
+    expect(decoded.exp).toBe(
+      Math.floor(reminderSentAt / 1000) + INVITATION_EXPIRATION_TIME_SEC
+    );
+  });
+});
+
+describe("claimReminderSlot", () => {
+  it("updates the in-memory resource so toJSON() and token generation use the new reminderSentAt", async () => {
+    const now = Date.now();
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    const createdAt = now - 8 * 24 * 60 * 60 * 1000;
+
+    const resource = new MembershipInvitationResource(
+      MembershipInvitationModel,
+      {
+        id: 1,
+        sId: "test-sid",
+        workspaceId: 1,
+        inviteEmail: "user@example.com",
+        status: "pending",
+        initialRole: "user",
+        createdAt: new Date(createdAt),
+        updatedAt: new Date(createdAt),
+        reminderSentAt: null,
+        invitedUserId: null,
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { workspace: {} as any }
+    );
+
+    vi.spyOn(MembershipInvitationModel, "update").mockResolvedValueOnce([
+      1,
+    ] as unknown as [number]);
+
+    const claimed = await resource.claimReminderSlot();
+
+    expect(claimed).toBe(true);
+    expect(resource.reminderSentAt).toEqual(new Date(now));
+    expect(resource.toJSON().reminderSentAt).toBe(now);
+    const token = getMembershipInvitationToken(resource.toJSON());
+    const decoded = verify(token, TEST_SECRET) as { iat: number };
+    expect(decoded.iat).toBe(Math.floor(now / 1000));
+
+    vi.useRealTimers();
+  });
+
+  it("returns false and leaves the resource unchanged when already claimed", async () => {
+    const createdAt = Date.now() - 8 * 24 * 60 * 60 * 1000;
+
+    const resource = new MembershipInvitationResource(
+      MembershipInvitationModel,
+      {
+        id: 1,
+        sId: "test-sid",
+        workspaceId: 1,
+        inviteEmail: "user@example.com",
+        status: "pending",
+        initialRole: "user",
+        createdAt: new Date(createdAt),
+        updatedAt: new Date(createdAt),
+        reminderSentAt: null,
+        invitedUserId: null,
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { workspace: {} as any }
+    );
+
+    vi.spyOn(MembershipInvitationModel, "update").mockResolvedValueOnce([
+      0,
+      [],
+    ] as unknown as [number]);
+
+    const claimed = await resource.claimReminderSlot();
+
+    expect(claimed).toBe(false);
+    expect(resource.reminderSentAt).toBeNull();
+  });
+});
+
+describe("expiresAt on serialized invitation", () => {
+  it("equals createdAt + 7 days when no reminder", () => {
+    const createdAt = Date.now() - 1000;
+    const invitation = makeInvitation(createdAt, null);
+    expect(invitation.expiresAt).toBe(
+      createdAt + INVITATION_EXPIRATION_TIME_MS
+    );
+  });
+
+  it("equals reminderSentAt + 7 days after reminder", () => {
+    const createdAt = Date.now() - 8 * 24 * 60 * 60 * 1000;
+    const reminderSentAt = Date.now() - 1000;
+    const invitation = makeInvitation(createdAt, reminderSentAt);
+    expect(invitation.expiresAt).toBe(
+      reminderSentAt + INVITATION_EXPIRATION_TIME_MS
+    );
+  });
+});

--- a/front/types/membership_invitation.ts
+++ b/front/types/membership_invitation.ts
@@ -13,6 +13,7 @@ export type MembershipInvitationType = {
   initialRole: ActiveRoleType;
   createdAt: number;
   reminderSentAt: number | null;
+  expiresAt: number;
   isExpired: boolean;
 };
 


### PR DESCRIPTION
## Description

Adds automated reminder emails for workspace invitations that are 7-10 days old and have not yet been accepted. After a reminder is sent, the invitation token is re-anchored on `reminderSentAt` so the recipient gets a fresh 7-day window to accept.

This is the third and final PR of the reinvite series, building on the `reminderSentAt` column (migration PR) and the `invitations` Temporal worker (scaffolding PR).

The reminder job runs on a Temporal Schedule (weekdays at 17:00 UTC, SKIP overlap policy). Each firing processes invitations in batches of 50. Claiming a reminder slot is atomic via `UPDATE WHERE reminderSentAt IS NULL`, so concurrent workers cannot double-send. Email failures after a successful claim are logged and accepted as best-effort: the invitation will not be re-reminded automatically, but the fresh token remains valid for 7 days from `reminderSentAt`.

Re-invite flows (admin resend, Poke) now always revoke the existing invitation and create a new one. This was necessary to prevent handing recipients a stale token anchored on the original `createdAt` when a reminder had already extended the window.

Requires a new env var: `SENDGRID_INVITATION_REMINDER_EMAIL_TEMPLATE_ID`.

## Tests

Added unit tests covering token anchoring, `claimReminderSlot` in-memory update (with fake timers), race condition (double-claim returns false), and `expiresAt` serialization.

Updated the re-invite test to reflect the new revoke-and-create behavior.

## Risk

The claim is atomic, so double-sending is not possible. 
Rollback is safe: disabling the schedule stops reminder sending immediately, and the `reminderSentAt` column has no effect on existing flows if the worker is not running.

## Deploy Plan

1. Ensure `SENDGRID_INVITATION_REMINDER_EMAIL_TEMPLATE_ID` is set in prod secrets before deploying.
2. Deploy front.
3. Register the new worker with a PR on infra. 
4. Register the Temporal schedule: `npx tsx front/temporal/invitations/admin/cli.ts start`.