### PR TITLE
[front] enh: allow `.skill` file imports when uploading skills

### DIFF
--- a/front/components/skills/import/ImportFromFilesTab.tsx
+++ b/front/components/skills/import/ImportFromFilesTab.tsx
@@ -16,7 +16,8 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useFormContext } from "react-hook-form";
 
-const ACCEPTED_EXTENSIONS = [".zip"];
+const ACCEPTED_EXTENSIONS = [".zip", ".skill"];
+const ACCEPTED_EXTENSIONS_LABEL = ".zip or .skill";
 
 interface ImportFromFilesTabProps {
   owner: LightWorkspaceType;
@@ -70,10 +71,13 @@ export function ImportFromFilesTab({
         return;
       }
       const rejected = files.filter(
-        (f) => !ACCEPTED_EXTENSIONS.some((ext) => f.name.endsWith(ext))
+        (f) =>
+          !ACCEPTED_EXTENSIONS.some((ext) => f.name.toLowerCase().endsWith(ext))
       );
       if (rejected.length > 0) {
-        setFileTypeError("Only .zip files are accepted.");
+        setFileTypeError(
+          `Only ${ACCEPTED_EXTENSIONS_LABEL} files are accepted.`
+        );
         if (fileInputRef.current) {
           fileInputRef.current.value = "";
         }
@@ -157,7 +161,7 @@ function SkillFileDropzone({
       <DropzoneOverlay
         isDragActive={isDragOver}
         title="Drop files here"
-        description="Upload .zip files"
+        description={`Upload ${ACCEPTED_EXTENSIONS_LABEL} files`}
       />
       {isLoading ? (
         <>
@@ -202,7 +206,10 @@ function FileRequirements() {
       size="lg"
     >
       <ul className="list-disc pl-4 text-sm">
-        <li>The imported .zip must include a SKILL.md file</li>
+        <li>
+          The imported {ACCEPTED_EXTENSIONS_LABEL} archive must include a
+          SKILL.md file
+        </li>
         <li>
           This file must contain the skill name and description formatted in
           YAML

--- a/front/components/skills/import/ImportSkillsDialog.tsx
+++ b/front/components/skills/import/ImportSkillsDialog.tsx
@@ -35,7 +35,7 @@ interface ImportSkillsDialogProps {
 
 const TAB_DESCRIPTION: Record<ImportType, string> = {
   repository: "Enter a GitHub repository URL to detect skills.",
-  files: "Upload a .zip file with your skills.",
+  files: "Upload a .zip or .skill file with your skills.",
 };
 
 export function ImportSkillsDialog({


### PR DESCRIPTION
## Description

This PR lets users import skills from `.skill` archives when uploading skill files from their computer. The files import tab now accepts both `.zip` and `.skill`, updates the upload copy/error text accordingly, and keeps the server-side archive detection path shared for both extensions.

## Tests

- Added a test for `.skill` archive detection.

## Risk

- Low.

## Deploy Plan

- Deploy front.

