### PR TITLE
[front-api] fix: use relative SSE redirect to preserve Authorization

### DIFF
--- a/front-api/lib/api/sse/redirect.test.ts
+++ b/front-api/lib/api/sse/redirect.test.ts
@@ -38,7 +38,20 @@ describe("redirectToSse", () => {
     const res = await requestSseRedirect(routePattern, path);
 
     expect(res.status).toBe(307);
-    expect(new URL(res.headers.get("location")!).pathname).toBe(expected);
+    expect(res.headers.get("location")).toBe(expected);
+  });
+
+  // The Location must stay relative so the client resolves it against the
+  // original https request, preserving the Authorization header (an absolute
+  // http:// Location would downgrade the scheme and strip the header -> 401).
+  it("emits a relative location (no scheme/origin)", async () => {
+    const res = await requestSseRedirect(
+      "/api/v1/w/:wId/assistant/conversations/:cId/events",
+      "/api/v1/w/w1/assistant/conversations/c1/events"
+    );
+
+    const location = res.headers.get("location")!;
+    expect(location.startsWith("/")).toBe(true);
   });
 
   it("preserves the query string on the redirected location", async () => {
@@ -48,10 +61,8 @@ describe("redirectToSse", () => {
     );
 
     expect(res.status).toBe(307);
-    const location = new URL(res.headers.get("location")!);
-    expect(location.pathname).toBe(
-      "/api/sse/v1/w/w1/assistant/conversations/c1/events"
+    expect(res.headers.get("location")).toBe(
+      "/api/sse/v1/w/w1/assistant/conversations/c1/events?foo=bar"
     );
-    expect(location.search).toBe("?foo=bar");
   });
 });

--- a/front-api/lib/api/sse/redirect.ts
+++ b/front-api/lib/api/sse/redirect.ts
@@ -3,9 +3,16 @@ import type { Context } from "hono";
 // Redirects an SSE path to its /api/sse counterpart with a 307 so the ingress
 // routes it to dedicated front-sse pods. Mirrors the Next middleware redirect in
 // front/lib/api/sse_redirect.ts.
+//
+// The Location is relative (path + query only) on purpose. front-api runs as a
+// plain-HTTP server behind a TLS-terminating ingress, so ctx.req.url's scheme is
+// "http". An absolute Location would therefore downgrade https -> http, and HTTP
+// clients (e.g. the CLI's reqwest) strip the Authorization header on a protocol
+// downgrade, producing a 401 on the redirected request. A relative Location is
+// resolved by the client against the original https request URI, preserving the
+// scheme, origin, and Authorization header.
 export function redirectToSse(ctx: Context) {
   const url = new URL(ctx.req.url);
   const ssePath = url.pathname.replace(/^\/api\//, "/api/sse/");
-  const sseUrl = `${url.origin}${ssePath}${url.search}`;
-  return ctx.redirect(sseUrl, 307);
+  return ctx.redirect(`${ssePath}${url.search}`, 307);
 }


### PR DESCRIPTION
## Description

This is a follow-up on https://github.com/dust-tt/dust/pull/26513

redirectToSse built an absolute Location from ctx.req.url's origin. front-api runs as a plain-HTTP server behind a TLS-terminating ingress, so that origin is http://, producing an https -> http downgrade on the 307. HTTP clients (the CLI's reqwest) strip the Authorization header on a protocol downgrade, so the redirected SSE request hit front-sse unauthenticated -> 401.

Emit a relative Location (path + query) instead. The client resolves it against the original https request URI, preserving scheme, origin, and the Authorization header. This mirrors the effective behavior of the Next middleware redirect, which keeps the public https origin via x-forwarded-proto.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Front