### PR TITLE
 [front] chore: clean up nested skill tests

### DIFF
--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -3,7 +3,6 @@ import {
   SkillFileAttachmentModel,
   SkillVersionModel,
 } from "@app/lib/models/skill";
-import { SkillReferenceModel } from "@app/lib/models/skill/skill_reference";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { serializeSkillTag } from "@app/lib/skills/format";
@@ -154,10 +153,9 @@ describe("GET /api/w/:wId/skills/:sId", () => {
     const childSkill = await SkillFactory.create(skillOwnerAuth, {
       name: "Child Skill",
     });
-    await SkillReferenceModel.create({
-      workspaceId: workspace.id,
-      parentSkillId: skill.id,
-      childSkillId: childSkill.id,
+    await SkillFactory.updateNestedSkillReferences(skillOwnerAuth, {
+      parentSkill: skill,
+      childSkills: [childSkill],
     });
 
     const response = await getSkillWithRelations(workspace, skill.sId);
@@ -184,10 +182,9 @@ describe("GET /api/w/:wId/skills/:sId", () => {
     const childSkill = await SkillFactory.create(skillOwnerAuth, {
       name: "Hidden Child Skill",
     });
-    await SkillReferenceModel.create({
-      workspaceId: workspace.id,
-      parentSkillId: skill.id,
-      childSkillId: childSkill.id,
+    await SkillFactory.updateNestedSkillReferences(skillOwnerAuth, {
+      parentSkill: skill,
+      childSkills: [childSkill],
     });
 
     const response = await getSkillWithRelations(workspace, skill.sId);
@@ -361,11 +358,8 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
     const childSkill = await SkillFactory.create(requestUserAuth, {
       name: "Referenced Skill",
     });
-    const skillReferenceTag = serializeSkillTag({
-      id: childSkill.sId,
-      icon: null,
-      name: childSkill.name,
-    });
+    const skillReferenceTag =
+      SkillFactory.serializeSkillReferenceTag(childSkill);
     const instructionsWithReference = `Use ${skillReferenceTag} for deeper analysis.`;
     const buildBody = (instructions: string) => ({
       name: skill.name,
@@ -384,14 +378,14 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
       buildBody(instructionsWithReference)
     );
     expect(disabledResponse.status).toBe(200);
+    const skillWithoutFeatureFlag = await SkillResource.fetchById(
+      requestUserAuth,
+      skill.sId
+    );
+    expect(skillWithoutFeatureFlag).not.toBeNull();
     await expect(
-      SkillReferenceModel.count({
-        where: {
-          workspaceId: workspace.id,
-          parentSkillId: skill.id,
-        },
-      })
-    ).resolves.toBe(0);
+      skillWithoutFeatureFlag!.fetchChildSkills(requestUserAuth)
+    ).resolves.toHaveLength(0);
 
     await FeatureFlagFactory.basic(requestUserAuth, "nested_skills");
 
@@ -401,15 +395,18 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
       buildBody(instructionsWithReference)
     );
     expect(enabledResponse.status).toBe(200);
+    const skillWithReference = await SkillResource.fetchById(
+      requestUserAuth,
+      skill.sId
+    );
+    expect(skillWithReference).not.toBeNull();
     await expect(
-      SkillReferenceModel.count({
-        where: {
-          workspaceId: workspace.id,
-          parentSkillId: skill.id,
-          childSkillId: childSkill.id,
-        },
-      })
-    ).resolves.toBe(1);
+      skillWithReference!.fetchChildSkills(requestUserAuth)
+    ).resolves.toEqual([
+      expect.objectContaining({
+        sId: childSkill.sId,
+      }),
+    ]);
 
     const removeResponse = await patchSkill(
       workspace,
@@ -417,14 +414,14 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
       buildBody("No nested skill references here.")
     );
     expect(removeResponse.status).toBe(200);
+    const skillWithoutReference = await SkillResource.fetchById(
+      requestUserAuth,
+      skill.sId
+    );
+    expect(skillWithoutReference).not.toBeNull();
     await expect(
-      SkillReferenceModel.count({
-        where: {
-          workspaceId: workspace.id,
-          parentSkillId: skill.id,
-        },
-      })
-    ).resolves.toBe(0);
+      skillWithoutReference!.fetchChildSkills(requestUserAuth)
+    ).resolves.toHaveLength(0);
   });
 
   it("returns 400 for out-of-workspace nested skill references", async () => {

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -1,6 +1,5 @@
 import { Authenticator } from "@app/lib/auth";
 import { SkillMCPServerConfigurationModel } from "@app/lib/models/skill";
-import { SkillReferenceModel } from "@app/lib/models/skill/skill_reference";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { discoverToolsSkill } from "@app/lib/resources/skill/code_defined/discover_tools";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -422,16 +421,13 @@ describe("GET /api/w/:wId/skills?withRelations=true", () => {
       workspace.sId
     );
 
-    const childSkill = await SkillFactory.create(auth, {
-      name: "Referenced Skill",
-    });
-    const parentSkill = await SkillFactory.create(auth, {
-      name: "Parent Skill",
-    });
-
-    await SkillFactory.linkSkillToSkill(auth, {
-      parentSkillId: parentSkill.id,
-      childSkillId: childSkill.id,
+    const { childSkill } = await SkillFactory.createWithNestedSkill(auth, {
+      childOverrides: {
+        name: "Referenced Skill",
+      },
+      parentOverrides: {
+        name: "Parent Skill",
+      },
     });
 
     const response = await getSkills(workspace, { withRelations: "true" });
@@ -455,17 +451,15 @@ describe("GET /api/w/:wId/skills?withRelations=true", () => {
     );
     await FeatureFlagFactory.basic(auth, "nested_skills");
 
-    const parentSkill = await SkillFactory.create(auth, {
-      name: "Parent Skill",
-    });
-    const childSkill = await SkillFactory.create(auth, {
-      name: "Child Skill",
-    });
-
-    await SkillFactory.linkSkillToSkill(auth, {
-      parentSkillId: parentSkill.id,
-      childSkillId: childSkill.id,
-    });
+    const { parentSkill, childSkill } =
+      await SkillFactory.createWithNestedSkill(auth, {
+        childOverrides: {
+          name: "Child Skill",
+        },
+        parentOverrides: {
+          name: "Parent Skill",
+        },
+      });
 
     const response = await getSkills(workspace, { withRelations: "true" });
 
@@ -500,17 +494,15 @@ describe("GET /api/w/:wId/skills?withRelations=true", () => {
     );
     await FeatureFlagFactory.basic(auth, "nested_skills");
 
-    const childSkill = await SkillFactory.create(auth, {
-      name: "Referenced Skill",
-    });
-    const parentSkill = await SkillFactory.create(auth, {
-      name: "Parent Skill",
-    });
-
-    await SkillFactory.linkSkillToSkill(auth, {
-      parentSkillId: parentSkill.id,
-      childSkillId: childSkill.id,
-    });
+    const { childSkill, parentSkill } =
+      await SkillFactory.createWithNestedSkill(auth, {
+        childOverrides: {
+          name: "Referenced Skill",
+        },
+        parentOverrides: {
+          name: "Parent Skill",
+        },
+      });
 
     const response = await getSkills(workspace, { withRelations: "true" });
 
@@ -658,11 +650,8 @@ describe("POST /api/w/:wId/skills", () => {
     const childSkill = await SkillFactory.create(auth, {
       name: "Referenced Skill",
     });
-    const skillReferenceTag = serializeSkillTag({
-      id: childSkill.sId,
-      icon: null,
-      name: childSkill.name,
-    });
+    const skillReferenceTag =
+      SkillFactory.serializeSkillReferenceTag(childSkill);
 
     const response = await postSkill(workspace, {
       name: "Parent Skill",
@@ -684,15 +673,11 @@ describe("POST /api/w/:wId/skills", () => {
     );
     expect(createdSkill).not.toBeNull();
 
-    await expect(
-      SkillReferenceModel.count({
-        where: {
-          workspaceId: workspace.id,
-          parentSkillId: createdSkill!.id,
-          childSkillId: childSkill.id,
-        },
-      })
-    ).resolves.toBe(1);
+    await expect(createdSkill!.fetchChildSkills(auth)).resolves.toEqual([
+      expect.objectContaining({
+        sId: childSkill.sId,
+      }),
+    ]);
   });
 
   it("returns 400 for invalid nested skill references", async () => {

--- a/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
@@ -3,7 +3,6 @@ import {
   SkillFileAttachmentModel,
   SkillVersionModel,
 } from "@app/lib/models/skill";
-import { SkillReferenceModel } from "@app/lib/models/skill/skill_reference";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { serializeSkillTag } from "@app/lib/skills/format";
@@ -182,7 +181,7 @@ describe("GET /api/w/[wId]/skills/[sId]", () => {
   });
 
   it("should return child skills when nested_skills is enabled", async () => {
-    const { req, res, skill, skillOwnerAuth, workspace } = await setupTest({
+    const { req, res, skill, skillOwnerAuth } = await setupTest({
       requestUserRole: "admin",
     });
 
@@ -191,10 +190,9 @@ describe("GET /api/w/[wId]/skills/[sId]", () => {
     const childSkill = await SkillFactory.create(skillOwnerAuth, {
       name: "Child Skill",
     });
-    await SkillReferenceModel.create({
-      workspaceId: workspace.id,
-      parentSkillId: skill.id,
-      childSkillId: childSkill.id,
+    await SkillFactory.updateNestedSkillReferences(skillOwnerAuth, {
+      parentSkill: skill,
+      childSkills: [childSkill],
     });
 
     req.query = { ...req.query, withRelations: "true" };
@@ -216,17 +214,16 @@ describe("GET /api/w/[wId]/skills/[sId]", () => {
   });
 
   it("should not return child skills when nested_skills is disabled", async () => {
-    const { req, res, skill, skillOwnerAuth, workspace } = await setupTest({
+    const { req, res, skill, skillOwnerAuth } = await setupTest({
       requestUserRole: "admin",
     });
 
     const childSkill = await SkillFactory.create(skillOwnerAuth, {
       name: "Hidden Child Skill",
     });
-    await SkillReferenceModel.create({
-      workspaceId: workspace.id,
-      parentSkillId: skill.id,
-      childSkillId: childSkill.id,
+    await SkillFactory.updateNestedSkillReferences(skillOwnerAuth, {
+      parentSkill: skill,
+      childSkills: [childSkill],
     });
 
     req.query = { ...req.query, withRelations: "true" };
@@ -425,11 +422,8 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
     const childSkill = await SkillFactory.create(requestUserAuth, {
       name: "Referenced Skill",
     });
-    const skillReferenceTag = serializeSkillTag({
-      id: childSkill.sId,
-      icon: null,
-      name: childSkill.name,
-    });
+    const skillReferenceTag =
+      SkillFactory.serializeSkillReferenceTag(childSkill);
     const instructionsWithReference = `Use ${skillReferenceTag} for deeper analysis.`;
 
     req.body = makePatchSkillBody(skill, {
@@ -437,14 +431,14 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
     });
     await handler(req, res);
     expect(res._getStatusCode()).toBe(200);
+    const skillWithoutFeatureFlag = await SkillResource.fetchById(
+      requestUserAuth,
+      skill.sId
+    );
+    expect(skillWithoutFeatureFlag).not.toBeNull();
     await expect(
-      SkillReferenceModel.count({
-        where: {
-          workspaceId: workspace.id,
-          parentSkillId: skill.id,
-        },
-      })
-    ).resolves.toBe(0);
+      skillWithoutFeatureFlag!.fetchChildSkills(requestUserAuth)
+    ).resolves.toHaveLength(0);
 
     await FeatureFlagFactory.basic(requestUserAuth, "nested_skills");
 
@@ -458,15 +452,18 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
 
     await handler(enabledReq, enabledRes);
     expect(enabledRes._getStatusCode()).toBe(200);
+    const skillWithReference = await SkillResource.fetchById(
+      requestUserAuth,
+      skill.sId
+    );
+    expect(skillWithReference).not.toBeNull();
     await expect(
-      SkillReferenceModel.count({
-        where: {
-          workspaceId: workspace.id,
-          parentSkillId: skill.id,
-          childSkillId: childSkill.id,
-        },
-      })
-    ).resolves.toBe(1);
+      skillWithReference!.fetchChildSkills(requestUserAuth)
+    ).resolves.toEqual([
+      expect.objectContaining({
+        sId: childSkill.sId,
+      }),
+    ]);
 
     const { req: removeReq, res: removeRes } = createPatchSkillRequest({
       workspaceId: workspace.sId,
@@ -478,14 +475,14 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
 
     await handler(removeReq, removeRes);
     expect(removeRes._getStatusCode()).toBe(200);
+    const skillWithoutReference = await SkillResource.fetchById(
+      requestUserAuth,
+      skill.sId
+    );
+    expect(skillWithoutReference).not.toBeNull();
     await expect(
-      SkillReferenceModel.count({
-        where: {
-          workspaceId: workspace.id,
-          parentSkillId: skill.id,
-        },
-      })
-    ).resolves.toBe(0);
+      skillWithoutReference!.fetchChildSkills(requestUserAuth)
+    ).resolves.toHaveLength(0);
   });
 
   it("returns 400 for out-of-workspace nested skill references", async () => {

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -1,6 +1,5 @@
 import { Authenticator } from "@app/lib/auth";
 import { SkillMCPServerConfigurationModel } from "@app/lib/models/skill";
-import { SkillReferenceModel } from "@app/lib/models/skill/skill_reference";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { discoverToolsSkill } from "@app/lib/resources/skill/code_defined/discover_tools";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -476,16 +475,13 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
       workspace.sId
     );
 
-    const childSkill = await SkillFactory.create(auth, {
-      name: "Referenced Skill",
-    });
-    const parentSkill = await SkillFactory.create(auth, {
-      name: "Parent Skill",
-    });
-
-    await SkillFactory.linkSkillToSkill(auth, {
-      parentSkillId: parentSkill.id,
-      childSkillId: childSkill.id,
+    const { childSkill } = await SkillFactory.createWithNestedSkill(auth, {
+      childOverrides: {
+        name: "Referenced Skill",
+      },
+      parentOverrides: {
+        name: "Parent Skill",
+      },
     });
 
     req.query = { ...req.query, wId: workspace.sId, withRelations: "true" };
@@ -513,17 +509,15 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
     );
     await FeatureFlagFactory.basic(auth, "nested_skills");
 
-    const parentSkill = await SkillFactory.create(auth, {
-      name: "Parent Skill",
-    });
-    const childSkill = await SkillFactory.create(auth, {
-      name: "Child Skill",
-    });
-
-    await SkillFactory.linkSkillToSkill(auth, {
-      parentSkillId: parentSkill.id,
-      childSkillId: childSkill.id,
-    });
+    const { parentSkill, childSkill } =
+      await SkillFactory.createWithNestedSkill(auth, {
+        childOverrides: {
+          name: "Child Skill",
+        },
+        parentOverrides: {
+          name: "Parent Skill",
+        },
+      });
 
     req.query = { ...req.query, wId: workspace.sId, withRelations: "true" };
 
@@ -562,17 +556,15 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
     );
     await FeatureFlagFactory.basic(auth, "nested_skills");
 
-    const childSkill = await SkillFactory.create(auth, {
-      name: "Referenced Skill",
-    });
-    const parentSkill = await SkillFactory.create(auth, {
-      name: "Parent Skill",
-    });
-
-    await SkillFactory.linkSkillToSkill(auth, {
-      parentSkillId: parentSkill.id,
-      childSkillId: childSkill.id,
-    });
+    const { childSkill, parentSkill } =
+      await SkillFactory.createWithNestedSkill(auth, {
+        childOverrides: {
+          name: "Referenced Skill",
+        },
+        parentOverrides: {
+          name: "Parent Skill",
+        },
+      });
 
     req.query = { ...req.query, wId: workspace.sId, withRelations: "true" };
 
@@ -729,17 +721,14 @@ describe("POST /api/w/[wId]/skills", () => {
   });
 
   it("creates skill references when nested skills is enabled", async () => {
-    const { auth, req, res, workspace } = await setupTest("POST", "admin");
+    const { auth, req, res } = await setupTest("POST", "admin");
 
     await FeatureFlagFactory.basic(auth, "nested_skills");
     const childSkill = await SkillFactory.create(auth, {
       name: "Referenced Skill",
     });
-    const skillReferenceTag = serializeSkillTag({
-      id: childSkill.sId,
-      icon: null,
-      name: childSkill.name,
-    });
+    const skillReferenceTag =
+      SkillFactory.serializeSkillReferenceTag(childSkill);
 
     req.body = {
       name: "Parent Skill",
@@ -762,15 +751,11 @@ describe("POST /api/w/[wId]/skills", () => {
     );
     expect(createdSkill).not.toBeNull();
 
-    await expect(
-      SkillReferenceModel.count({
-        where: {
-          workspaceId: workspace.id,
-          parentSkillId: createdSkill!.id,
-          childSkillId: childSkill.id,
-        },
-      })
-    ).resolves.toBe(1);
+    await expect(createdSkill!.fetchChildSkills(auth)).resolves.toEqual([
+      expect.objectContaining({
+        sId: childSkill.sId,
+      }),
+    ]);
   });
 
   it("returns 400 for invalid nested skill references", async () => {

--- a/front/tests/utils/SkillFactory.ts
+++ b/front/tests/utils/SkillFactory.ts
@@ -1,15 +1,30 @@
 import type { Authenticator } from "@app/lib/auth";
 import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
-import { SkillReferenceModel } from "@app/lib/models/skill/skill_reference";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { GlobalSkillId } from "@app/lib/resources/skill/code_defined/global_registry";
 import type { SystemSkillId } from "@app/lib/resources/skill/code_defined/system_registry";
 import type { SkillAttachedKnowledge } from "@app/lib/resources/skill/skill_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SKILL_ICON } from "@app/lib/skill";
+import { serializeSkillTag } from "@app/lib/skills/format";
 import type { SkillStatus } from "@app/types/assistant/skill_configuration";
 import type { ModelId } from "@app/types/shared/model_id";
 import assert from "assert";
+
+type CreateSkillOverrides = Partial<{
+  name: string;
+  agentFacingDescription: string;
+  userFacingDescription: string;
+  instructions: string;
+  instructionsHtml: string | null;
+  status: SkillStatus;
+  version: number;
+  requestedSpaceIds: ModelId[];
+  addCurrentUserAsEditor: boolean;
+  attachedKnowledge: SkillAttachedKnowledge[];
+  mcpServerViews: MCPServerViewResource[];
+  enableSkillReferences: boolean;
+}>;
 
 export class SkillFactory {
   static withExtendedSkill(
@@ -21,19 +36,7 @@ export class SkillFactory {
 
   static async create(
     auth: Authenticator,
-    overrides: Partial<{
-      name: string;
-      agentFacingDescription: string;
-      userFacingDescription: string;
-      instructions: string;
-      instructionsHtml: string | null;
-      status: SkillStatus;
-      version: number;
-      requestedSpaceIds: ModelId[];
-      addCurrentUserAsEditor: boolean;
-      attachedKnowledge: SkillAttachedKnowledge[];
-      mcpServerViews: MCPServerViewResource[];
-    }> = {}
+    overrides: CreateSkillOverrides = {}
   ): Promise<SkillResource> {
     const user = auth.user();
     assert(user, "User is required");
@@ -68,8 +71,86 @@ export class SkillFactory {
         mcpServerViews,
         addCurrentUserAsEditor: overrides.addCurrentUserAsEditor,
         attachedKnowledge,
+        enableSkillReferences: overrides.enableSkillReferences,
       }
     );
+  }
+
+  static serializeSkillReferenceTag(
+    skill: Pick<SkillResource, "sId" | "icon" | "name">
+  ): string {
+    return serializeSkillTag({
+      id: skill.sId,
+      icon: skill.icon,
+      name: skill.name,
+    });
+  }
+
+  static async createWithNestedSkill(
+    auth: Authenticator,
+    {
+      parentOverrides = {},
+      childOverrides = {},
+    }: {
+      parentOverrides?: CreateSkillOverrides;
+      childOverrides?: CreateSkillOverrides;
+    } = {}
+  ): Promise<{
+    parentSkill: SkillResource;
+    childSkill: SkillResource;
+    skillReferenceTag: string;
+  }> {
+    const childSkill = await this.create(auth, childOverrides);
+    const skillReferenceTag = this.serializeSkillReferenceTag(childSkill);
+    const parentSkill = await this.create(auth, {
+      ...parentOverrides,
+      instructions: parentOverrides.instructions ?? `Use ${skillReferenceTag}.`,
+      enableSkillReferences: true,
+    });
+
+    return { parentSkill, childSkill, skillReferenceTag };
+  }
+
+  static async updateNestedSkillReferences(
+    auth: Authenticator,
+    {
+      childSkills,
+      instructions,
+      parentSkill,
+    }: {
+      childSkills: SkillResource[];
+      instructions?: string;
+      parentSkill: SkillResource;
+    }
+  ): Promise<SkillResource> {
+    const nestedSkillInstructions =
+      instructions ??
+      (childSkills.length > 0
+        ? `Use ${childSkills
+            .map((childSkill) => this.serializeSkillReferenceTag(childSkill))
+            .join(", ")}.`
+        : "No nested skill references.");
+
+    await parentSkill.updateSkill(auth, {
+      name: parentSkill.name,
+      agentFacingDescription: parentSkill.agentFacingDescription,
+      userFacingDescription: parentSkill.userFacingDescription,
+      instructions: nestedSkillInstructions,
+      instructionsHtml: parentSkill.instructionsHtml,
+      icon: parentSkill.icon,
+      mcpServerViews: parentSkill.mcpServerViews,
+      attachedKnowledge: await parentSkill.getAttachedKnowledge(auth),
+      requestedSpaceIds: parentSkill.requestedSpaceIds,
+      enableSkillReferences: true,
+    });
+
+    const updatedParentSkill = await SkillResource.fetchById(
+      auth,
+      parentSkill.sId
+    );
+    assert(updatedParentSkill, "Updated parent skill is required");
+
+    return updatedParentSkill;
   }
 
   static async linkToAgent(
@@ -114,25 +195,5 @@ export class SkillFactory {
     });
 
     return agentSkill;
-  }
-
-  // TODO(2026-05-29 aubin): replace with resource methods.
-  static async linkSkillToSkill(
-    auth: Authenticator,
-    {
-      parentSkillId,
-      childSkillId,
-    }: {
-      parentSkillId: ModelId;
-      childSkillId: ModelId;
-    }
-  ): Promise<SkillReferenceModel> {
-    const workspace = auth.getNonNullableWorkspace();
-
-    return SkillReferenceModel.create({
-      workspaceId: workspace.id,
-      parentSkillId,
-      childSkillId,
-    });
   }
 }

--- a/front/tests/utils/SkillFactory.ts
+++ b/front/tests/utils/SkillFactory.ts
@@ -196,4 +196,32 @@ export class SkillFactory {
 
     return agentSkill;
   }
+
+  static async linkSkillToSkill(
+    auth: Authenticator,
+    {
+      parentSkillId,
+      childSkillId,
+    }: {
+      parentSkillId: ModelId;
+      childSkillId: ModelId;
+    }
+  ): Promise<SkillResource> {
+    const parentSkill = await SkillResource.fetchByModelIdWithAuth(
+      auth,
+      parentSkillId
+    );
+    assert(parentSkill, "Parent skill is required");
+
+    const childSkill = await SkillResource.fetchByModelIdWithAuth(
+      auth,
+      childSkillId
+    );
+    assert(childSkill, "Child skill is required");
+
+    return this.updateNestedSkillReferences(auth, {
+      parentSkill,
+      childSkills: [childSkill],
+    });
+  }
 }


### PR DESCRIPTION
## Description

- Cleans up nested-skill tests so they no longer create or assert references through Sequelize models directly.
- Adds `SkillFactory` helpers to create nested-skill setups and serialize inline skill reference tags through the same resource-backed path used by the feature.
- Keeps the scope to test setup/assertions; no runtime behavior changes.

## Tests

- Updated existing tests.
- Tested locally.

## Risk

- Low. Test-only cleanup.

## Deploy Plan

- No deploy.

