### PR TITLE
[front] chore: add script to export skill editors

### DIFF
--- a/front/migrations/20260601_extract_skill_editors.ts
+++ b/front/migrations/20260601_extract_skill_editors.ts
@@ -33,6 +33,11 @@ interface EditorWithSkills {
   skills: SkillInfo[];
 }
 
+interface WorkspaceSkillEditorExport {
+  activeSkillCount: number;
+  editors: EditorWithSkills[];
+}
+
 type SkillEditorCsvRecord = Record<string, string | number>;
 
 const DUST_APP_URL = "https://app.dust.tt";
@@ -52,7 +57,7 @@ async function fetchSkillEditorsForWorkspace({
   workspace,
 }: {
   workspace: LightWorkspaceType;
-}): Promise<EditorWithSkills[]> {
+}): Promise<WorkspaceSkillEditorExport> {
   // The export must include skills in restricted spaces.
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId, {
     dangerouslyRequestAllGroups: true,
@@ -65,7 +70,7 @@ async function fetchSkillEditorsForWorkspace({
   });
 
   if (skills.length === 0) {
-    return [];
+    return { activeSkillCount: 0, editors: [] };
   }
 
   const editorsBySkillId = await SkillResource.batchListEditors(auth, skills);
@@ -106,29 +111,32 @@ async function fetchSkillEditorsForWorkspace({
     }
   }
 
-  return [...editorsByUserModelId.values()]
-    .map((editor) => ({
-      workspaceId: editor.workspaceId,
-      workspaceName: editor.workspaceName,
-      editorUserId: editor.editorUserId,
-      editorEmail: editor.editorEmail,
-      editorName: editor.editorName,
-      skills: [...editor.skillsById.values()].sort((left, right) => {
-        const nameComparison = compareStrings(left.name, right.name);
-        return nameComparison === 0
-          ? compareStrings(left.id, right.id)
-          : nameComparison;
+  return {
+    activeSkillCount: skills.length,
+    editors: [...editorsByUserModelId.values()]
+      .map((editor) => ({
+        workspaceId: editor.workspaceId,
+        workspaceName: editor.workspaceName,
+        editorUserId: editor.editorUserId,
+        editorEmail: editor.editorEmail,
+        editorName: editor.editorName,
+        skills: [...editor.skillsById.values()].sort((left, right) => {
+          const nameComparison = compareStrings(left.name, right.name);
+          return nameComparison === 0
+            ? compareStrings(left.id, right.id)
+            : nameComparison;
+        }),
+      }))
+      .sort((left, right) => {
+        const emailComparison = compareStrings(
+          left.editorEmail,
+          right.editorEmail
+        );
+        return emailComparison === 0
+          ? compareStrings(left.editorUserId, right.editorUserId)
+          : emailComparison;
       }),
-    }))
-    .sort((left, right) => {
-      const emailComparison = compareStrings(
-        left.editorEmail,
-        right.editorEmail
-      );
-      return emailComparison === 0
-        ? compareStrings(left.editorUserId, right.editorUserId)
-        : emailComparison;
-    });
+  };
 }
 
 function buildCsvRecords(editors: EditorWithSkills[]): SkillEditorCsvRecord[] {
@@ -167,21 +175,19 @@ makeScript(
 
     await runOnAllWorkspaces(
       async (workspace) => {
-        const workspaceEditors = await fetchSkillEditorsForWorkspace({
-          workspace,
-        });
+        const { activeSkillCount, editors: workspaceEditors } =
+          await fetchSkillEditorsForWorkspace({
+            workspace,
+          });
         editors.push(...workspaceEditors);
         processedWorkspaces += 1;
 
         if (outputFile) {
           logger.info(
             {
-              exportedEditorRows: workspaceEditors.length,
+              activeSkillCount,
               processedWorkspaces,
-              totalExportedEditorRows: editors.length,
               workspaceId: workspace.sId,
-              workspaceModelId: workspace.id,
-              workspaceName: workspace.name,
             },
             "Processed workspace for skill editor export"
           );

--- a/front/migrations/20260601_extract_skill_editors.ts
+++ b/front/migrations/20260601_extract_skill_editors.ts
@@ -1,19 +1,13 @@
 import { writeFile } from "node:fs/promises";
 
 import { sanitizeCsvCell } from "@app/lib/api/analytics/csv_utils";
-import { SkillConfigurationModel } from "@app/lib/models/skill";
-import { GroupSkillModel } from "@app/lib/models/skill/group_skill";
-import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
-import { GroupModel } from "@app/lib/resources/storage/models/groups";
-import { MembershipModel } from "@app/lib/resources/storage/models/membership";
-import { UserModel } from "@app/lib/resources/storage/models/user";
-import { makeSId } from "@app/lib/resources/string_ids";
+import { Authenticator } from "@app/lib/auth";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 import type { LightWorkspaceType } from "@app/types/user";
 import { stringify } from "csv-stringify/sync";
-import { Op } from "sequelize";
 
 interface SkillInfo {
   id: string;
@@ -43,10 +37,6 @@ type SkillEditorCsvRecord = Record<string, string | number>;
 
 const DUST_APP_URL = "https://app.dust.tt";
 
-function uniqueNumbers(values: number[]): number[] {
-  return [...new Set(values)];
-}
-
 function compareStrings(left: string, right: string): number {
   return left.localeCompare(right, undefined, { sensitivity: "base" });
 }
@@ -59,152 +49,60 @@ function getSkillBuilderUrl(workspaceId: string, skillId: string): string {
 }
 
 async function fetchSkillEditorsForWorkspace({
-  now,
   workspace,
 }: {
-  now: Date;
   workspace: LightWorkspaceType;
 }): Promise<EditorWithSkills[]> {
-  const skills = await SkillConfigurationModel.findAll({
-    where: { workspaceId: workspace.id, status: "active" },
-    attributes: ["id", "name", "workspaceId"],
-    order: [
-      ["name", "ASC"],
-      ["id", "ASC"],
-    ],
+  // The export must include skills in restricted spaces.
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId, {
+    dangerouslyRequestAllGroups: true,
+  });
+  const skills = await SkillResource.listByWorkspace(auth, {
+    onlyCustom: true,
+    status: "active",
+    withInstructions: false,
+    withTools: false,
   });
 
   if (skills.length === 0) {
     return [];
   }
 
-  const skillByModelId = new Map<number, SkillInfo>(
-    skills.map((skill): [number, SkillInfo] => {
-      const skillId = makeSId("skill", {
-        id: skill.id,
-        workspaceId: workspace.id,
-      });
-
-      return [
-        skill.id,
-        {
-          id: skillId,
-          name: skill.name,
-          url: getSkillBuilderUrl(workspace.sId, skillId),
-        },
-      ];
-    })
-  );
-
-  const groupSkillLinks = await GroupSkillModel.findAll({
-    where: {
-      workspaceId: workspace.id,
-      skillConfigurationId: [...skillByModelId.keys()],
-    },
-    attributes: ["groupId", "skillConfigurationId"],
-  });
-
-  if (groupSkillLinks.length === 0) {
-    return [];
-  }
-
-  const groups = await GroupModel.findAll({
-    where: {
-      workspaceId: workspace.id,
-      id: uniqueNumbers(groupSkillLinks.map((link) => link.groupId)),
-      kind: "skill_editors",
-    },
-    attributes: ["id"],
-  });
-
-  const editorGroupIds = new Set(groups.map((group) => group.id));
-  if (editorGroupIds.size === 0) {
-    return [];
-  }
-
-  const skillModelIdsByGroupId = new Map<number, Set<number>>();
-  for (const link of groupSkillLinks) {
-    if (!editorGroupIds.has(link.groupId)) {
-      continue;
-    }
-
-    const skillModelIds = skillModelIdsByGroupId.get(link.groupId) ?? new Set();
-    skillModelIds.add(link.skillConfigurationId);
-    skillModelIdsByGroupId.set(link.groupId, skillModelIds);
-  }
-
-  const groupMemberships = await GroupMembershipModel.findAll({
-    where: {
-      workspaceId: workspace.id,
-      groupId: [...editorGroupIds],
-      status: "active",
-      startAt: { [Op.lte]: now },
-      [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: now } }],
-    },
-    attributes: ["groupId", "userId"],
-  });
-
-  if (groupMemberships.length === 0) {
-    return [];
-  }
-
-  const groupMemberUserIds = uniqueNumbers(
-    groupMemberships.map((membership) => membership.userId)
-  );
-
-  const activeWorkspaceMemberships = await MembershipModel.findAll({
-    where: {
-      workspaceId: workspace.id,
-      userId: groupMemberUserIds,
-      startAt: { [Op.lte]: now },
-      [Op.or]: [{ endAt: null }, { endAt: { [Op.gte]: now } }],
-    },
-    attributes: ["userId"],
-  });
-
-  const activeUserIds = new Set(
-    activeWorkspaceMemberships.map((membership) => membership.userId)
-  );
-  if (activeUserIds.size === 0) {
-    return [];
-  }
-
-  const users = await UserModel.findAll({
-    where: { id: [...activeUserIds] },
-    attributes: ["id", "sId", "email", "name"],
-  });
-  const userByModelId = new Map(users.map((user) => [user.id, user]));
+  const editorsBySkillId = await SkillResource.batchListEditors(auth, skills);
   const editorsByUserModelId = new Map<number, EditorAccumulator>();
 
-  for (const membership of groupMemberships) {
-    if (!activeUserIds.has(membership.userId)) {
+  for (const skill of [...skills].sort((left, right) => {
+    const nameComparison = compareStrings(left.name, right.name);
+    return nameComparison === 0
+      ? compareStrings(left.sId, right.sId)
+      : nameComparison;
+  })) {
+    const skillEditors = editorsBySkillId.get(skill.sId) ?? [];
+    if (skillEditors.length === 0) {
       continue;
     }
 
-    const user = userByModelId.get(membership.userId);
-    const skillModelIds = skillModelIdsByGroupId.get(membership.groupId);
-    if (!user || !skillModelIds) {
-      continue;
-    }
-
-    const editor = editorsByUserModelId.get(user.id) ?? {
-      workspaceId: workspace.sId,
-      workspaceName: workspace.name,
-      editorUserId: user.sId,
-      editorEmail: user.email,
-      editorName: user.name,
-      skillsById: new Map<string, SkillInfo>(),
+    const skillInfo = {
+      id: skill.sId,
+      name: skill.name,
+      url: getSkillBuilderUrl(workspace.sId, skill.sId),
     };
 
-    for (const skillModelId of skillModelIds) {
-      const skill = skillByModelId.get(skillModelId);
-      if (skill) {
-        editor.skillsById.set(skill.id, skill);
-      }
-    }
+    for (const user of skillEditors) {
+      const editor = editorsByUserModelId.get(user.id) ?? {
+        workspaceId: workspace.sId,
+        workspaceName: workspace.name,
+        editorUserId: user.sId,
+        editorEmail: user.email,
+        editorName: user.name,
+        skillsById: new Map<string, SkillInfo>(),
+      };
 
-    if (!editorsByUserModelId.has(user.id)) {
-      editorsByUserModelId.set(user.id, editor);
+      editor.skillsById.set(skillInfo.id, skillInfo);
+
+      if (!editorsByUserModelId.has(user.id)) {
+        editorsByUserModelId.set(user.id, editor);
+      }
     }
   }
 
@@ -264,13 +162,11 @@ makeScript(
     },
   },
   async ({ outputFile, workspaceId }) => {
-    const now = new Date();
     const editors: EditorWithSkills[] = [];
 
     await runOnAllWorkspaces(
       async (workspace) => {
         const workspaceEditors = await fetchSkillEditorsForWorkspace({
-          now,
           workspace,
         });
         editors.push(...workspaceEditors);

--- a/front/migrations/20260601_extract_skill_editors.ts
+++ b/front/migrations/20260601_extract_skill_editors.ts
@@ -161,8 +161,9 @@ makeScript(
       demandOption: false,
     },
   },
-  async ({ outputFile, workspaceId }) => {
+  async ({ outputFile, workspaceId }, logger) => {
     const editors: EditorWithSkills[] = [];
+    let processedWorkspaces = 0;
 
     await runOnAllWorkspaces(
       async (workspace) => {
@@ -170,6 +171,21 @@ makeScript(
           workspace,
         });
         editors.push(...workspaceEditors);
+        processedWorkspaces += 1;
+
+        if (outputFile) {
+          logger.info(
+            {
+              exportedEditorRows: workspaceEditors.length,
+              processedWorkspaces,
+              totalExportedEditorRows: editors.length,
+              workspaceId: workspace.sId,
+              workspaceModelId: workspace.id,
+              workspaceName: workspace.name,
+            },
+            "Processed workspace for skill editor export"
+          );
+        }
       },
       { concurrency: 1, wId: workspaceId }
     );

--- a/front/migrations/20260601_extract_skill_editors.ts
+++ b/front/migrations/20260601_extract_skill_editors.ts
@@ -41,6 +41,7 @@ interface WorkspaceSkillEditorExport {
 type SkillEditorCsvRecord = Record<string, string | number>;
 
 const DUST_APP_URL = "https://app.dust.tt";
+const SKILL_LIST_DELIMITER = "\n";
 
 function compareStrings(left: string, right: string): number {
   return left.localeCompare(right, undefined, { sensitivity: "base" });
@@ -148,10 +149,10 @@ function buildCsvRecords(editors: EditorWithSkills[]): SkillEditorCsvRecord[] {
     editor_name: sanitizeCsvCell(editor.editorName),
     skill_count: editor.skills.length,
     skill_urls: sanitizeCsvCell(
-      editor.skills.map((skill) => skill.url).join("|")
+      editor.skills.map((skill) => skill.url).join(SKILL_LIST_DELIMITER)
     ),
     skill_names: sanitizeCsvCell(
-      editor.skills.map((skill) => skill.name).join("|")
+      editor.skills.map((skill) => skill.name).join(SKILL_LIST_DELIMITER)
     ),
   }));
 }

--- a/front/migrations/20260601_extract_skill_editors.ts
+++ b/front/migrations/20260601_extract_skill_editors.ts
@@ -7,18 +7,13 @@ import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_me
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import { UserModel } from "@app/lib/resources/storage/models/user";
-import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { makeSId } from "@app/lib/resources/string_ids";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import type { LightWorkspaceType } from "@app/types/user";
 import { stringify } from "csv-stringify/sync";
 import { Op } from "sequelize";
-
-interface WorkspaceInfo {
-  id: number;
-  sId: string;
-  name: string;
-}
 
 interface SkillInfo {
   id: string;
@@ -48,29 +43,6 @@ type SkillEditorCsvRecord = Record<string, string | number>;
 
 const DUST_APP_URL = "https://app.dust.tt";
 
-async function fetchWorkspaces(
-  workspaceId: string | null
-): Promise<WorkspaceInfo[]> {
-  const workspaces = await WorkspaceModel.findAll({
-    where: workspaceId ? { sId: workspaceId } : undefined,
-    attributes: ["id", "sId", "name"],
-    order: [
-      ["name", "ASC"],
-      ["sId", "ASC"],
-    ],
-  });
-
-  if (workspaceId && workspaces.length === 0) {
-    throw new Error(`Workspace not found: ${workspaceId}.`);
-  }
-
-  return workspaces.map((workspace) => ({
-    id: workspace.id,
-    sId: workspace.sId,
-    name: workspace.name,
-  }));
-}
-
 function uniqueNumbers(values: number[]): number[] {
   return [...new Set(values)];
 }
@@ -91,7 +63,7 @@ async function fetchSkillEditorsForWorkspace({
   workspace,
 }: {
   now: Date;
-  workspace: WorkspaceInfo;
+  workspace: LightWorkspaceType;
 }): Promise<EditorWithSkills[]> {
   const skills = await SkillConfigurationModel.findAll({
     where: { workspaceId: workspace.id, status: "active" },
@@ -292,19 +264,19 @@ makeScript(
     },
   },
   async ({ outputFile, workspaceId }) => {
-    const workspaces = await fetchWorkspaces(workspaceId ?? null);
     const now = new Date();
     const editors: EditorWithSkills[] = [];
 
-    for (const workspace of workspaces) {
-      const workspaceEditors = await fetchSkillEditorsForWorkspace({
-        now,
-        workspace,
-      });
-      editors.push(
-        ...workspaceEditors
-      );
-    }
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        const workspaceEditors = await fetchSkillEditorsForWorkspace({
+          now,
+          workspace,
+        });
+        editors.push(...workspaceEditors);
+      },
+      { concurrency: 1, wId: workspaceId }
+    );
 
     const records = buildCsvRecords(editors);
     const csv = stringify(records, {

--- a/front/migrations/20260601_extract_skill_editors.ts
+++ b/front/migrations/20260601_extract_skill_editors.ts
@@ -182,7 +182,7 @@ makeScript(
         editors.push(...workspaceEditors);
         processedWorkspaces += 1;
 
-        if (outputFile) {
+        if (outputFile && activeSkillCount > 0) {
           logger.info(
             {
               activeSkillCount,

--- a/front/migrations/20260601_extract_skill_editors.ts
+++ b/front/migrations/20260601_extract_skill_editors.ts
@@ -294,49 +294,38 @@ makeScript(
     },
   },
   async ({ outputFile, workspaceId }, logger) => {
-    try {
-      const workspaces = await fetchWorkspaces(workspaceId ?? null);
-      const now = new Date();
-      const editors: EditorWithSkills[] = [];
+    const workspaces = await fetchWorkspaces(workspaceId ?? null);
+    const now = new Date();
+    const editors: EditorWithSkills[] = [];
 
-      for (const workspace of workspaces) {
-        editors.push(
-          ...(await fetchSkillEditorsForWorkspace({
-            now,
-            workspace,
-          }))
-        );
-      }
-
-      const records = buildCsvRecords(editors);
-      const csv = stringify(records, {
-        columns: [
-          { key: "workspace_id", header: "workspace_id" },
-          { key: "workspace_name", header: "workspace_name" },
-          { key: "editor_user_id", header: "editor_user_id" },
-          { key: "editor_email", header: "editor_email" },
-          { key: "editor_name", header: "editor_name" },
-          { key: "skill_count", header: "skill_count" },
-          { key: "skill_urls", header: "skill_urls" },
-          { key: "skill_names", header: "skill_names" },
-        ],
-        header: true,
-      });
-
-      if (outputFile) {
-        await writeFile(outputFile, csv, "utf-8");
-      } else {
-        process.stdout.write(csv);
-      }
-    } catch (error) {
-      const normalizedError = normalizeError(error);
-      logger.error(
-        { err: normalizedError, workspaceId },
-        "Failed to extract skill editors"
+    for (const workspace of workspaces) {
+      editors.push(
+        ...(await fetchSkillEditorsForWorkspace({
+          now,
+          workspace,
+        }))
       );
-      throw normalizedError;
-    } finally {
-      await frontSequelize.close();
+    }
+
+    const records = buildCsvRecords(editors);
+    const csv = stringify(records, {
+      columns: [
+        { key: "workspace_id", header: "workspace_id" },
+        { key: "workspace_name", header: "workspace_name" },
+        { key: "editor_user_id", header: "editor_user_id" },
+        { key: "editor_email", header: "editor_email" },
+        { key: "editor_name", header: "editor_name" },
+        { key: "skill_count", header: "skill_count" },
+        { key: "skill_urls", header: "skill_urls" },
+        { key: "skill_names", header: "skill_names" },
+      ],
+      header: true,
+    });
+
+    if (outputFile) {
+      await writeFile(outputFile, csv, "utf-8");
+    } else {
+      process.stdout.write(csv);
     }
   }
 );

--- a/front/migrations/20260601_extract_skill_editors.ts
+++ b/front/migrations/20260601_extract_skill_editors.ts
@@ -48,6 +48,8 @@ interface EditorWithSkills {
 
 type SkillEditorCsvRecord = Record<string, string | number>;
 
+const DUST_APP_URL = "https://app.dust.tt";
+
 async function fetchWorkspaces(
   workspaceId: string | null
 ): Promise<WorkspaceInfo[]> {
@@ -77,6 +79,13 @@ function uniqueNumbers(values: number[]): number[] {
 
 function compareStrings(left: string, right: string): number {
   return left.localeCompare(right, undefined, { sensitivity: "base" });
+}
+
+function getSkillBuilderUrl(workspaceId: string, skillId: string): string {
+  return new URL(
+    getSkillBuilderRoute(workspaceId, skillId),
+    DUST_APP_URL
+  ).toString();
 }
 
 async function fetchSkillEditorsForWorkspace({
@@ -111,7 +120,7 @@ async function fetchSkillEditorsForWorkspace({
         {
           id: skillId,
           name: skill.name,
-          url: getSkillBuilderRoute(workspace.sId, skillId),
+          url: getSkillBuilderUrl(workspace.sId, skillId),
         },
       ];
     })

--- a/front/migrations/20260601_extract_skill_editors.ts
+++ b/front/migrations/20260601_extract_skill_editors.ts
@@ -1,0 +1,333 @@
+import { writeFile } from "node:fs/promises";
+
+import { sanitizeCsvCell } from "@app/lib/api/analytics/csv_utils";
+import { SkillConfigurationModel } from "@app/lib/models/skill";
+import { GroupSkillModel } from "@app/lib/models/skill/group_skill";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
+import { GroupModel } from "@app/lib/resources/storage/models/groups";
+import { MembershipModel } from "@app/lib/resources/storage/models/membership";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+import { makeSId } from "@app/lib/resources/string_ids";
+import { getSkillBuilderRoute } from "@app/lib/utils/router";
+import { makeScript } from "@app/scripts/helpers";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { stringify } from "csv-stringify/sync";
+import { Op } from "sequelize";
+
+interface WorkspaceInfo {
+  id: number;
+  sId: string;
+  name: string;
+}
+
+interface SkillInfo {
+  id: string;
+  name: string;
+  url: string;
+}
+
+interface EditorAccumulator {
+  workspaceId: string;
+  workspaceName: string;
+  editorUserId: string;
+  editorEmail: string;
+  editorName: string;
+  skillsById: Map<string, SkillInfo>;
+}
+
+interface EditorWithSkills {
+  workspaceId: string;
+  workspaceName: string;
+  editorUserId: string;
+  editorEmail: string;
+  editorName: string;
+  skills: SkillInfo[];
+}
+
+type SkillEditorCsvRecord = Record<string, string | number>;
+
+async function fetchWorkspaces(
+  workspaceId: string | null
+): Promise<WorkspaceInfo[]> {
+  const workspaces = await WorkspaceModel.findAll({
+    where: workspaceId ? { sId: workspaceId } : undefined,
+    attributes: ["id", "sId", "name"],
+    order: [
+      ["name", "ASC"],
+      ["sId", "ASC"],
+    ],
+  });
+
+  if (workspaceId && workspaces.length === 0) {
+    throw new Error(`Workspace not found: ${workspaceId}.`);
+  }
+
+  return workspaces.map((workspace) => ({
+    id: workspace.id,
+    sId: workspace.sId,
+    name: workspace.name,
+  }));
+}
+
+function uniqueNumbers(values: number[]): number[] {
+  return [...new Set(values)];
+}
+
+function compareStrings(left: string, right: string): number {
+  return left.localeCompare(right, undefined, { sensitivity: "base" });
+}
+
+async function fetchSkillEditorsForWorkspace({
+  now,
+  workspace,
+}: {
+  now: Date;
+  workspace: WorkspaceInfo;
+}): Promise<EditorWithSkills[]> {
+  const skills = await SkillConfigurationModel.findAll({
+    where: { workspaceId: workspace.id, status: "active" },
+    attributes: ["id", "name", "workspaceId"],
+    order: [
+      ["name", "ASC"],
+      ["id", "ASC"],
+    ],
+  });
+
+  if (skills.length === 0) {
+    return [];
+  }
+
+  const skillByModelId = new Map<number, SkillInfo>(
+    skills.map((skill): [number, SkillInfo] => {
+      const skillId = makeSId("skill", {
+        id: skill.id,
+        workspaceId: workspace.id,
+      });
+
+      return [
+        skill.id,
+        {
+          id: skillId,
+          name: skill.name,
+          url: getSkillBuilderRoute(workspace.sId, skillId),
+        },
+      ];
+    })
+  );
+
+  const groupSkillLinks = await GroupSkillModel.findAll({
+    where: {
+      workspaceId: workspace.id,
+      skillConfigurationId: [...skillByModelId.keys()],
+    },
+    attributes: ["groupId", "skillConfigurationId"],
+  });
+
+  if (groupSkillLinks.length === 0) {
+    return [];
+  }
+
+  const groups = await GroupModel.findAll({
+    where: {
+      workspaceId: workspace.id,
+      id: uniqueNumbers(groupSkillLinks.map((link) => link.groupId)),
+      kind: "skill_editors",
+    },
+    attributes: ["id"],
+  });
+
+  const editorGroupIds = new Set(groups.map((group) => group.id));
+  if (editorGroupIds.size === 0) {
+    return [];
+  }
+
+  const skillModelIdsByGroupId = new Map<number, Set<number>>();
+  for (const link of groupSkillLinks) {
+    if (!editorGroupIds.has(link.groupId)) {
+      continue;
+    }
+
+    const skillModelIds = skillModelIdsByGroupId.get(link.groupId) ?? new Set();
+    skillModelIds.add(link.skillConfigurationId);
+    skillModelIdsByGroupId.set(link.groupId, skillModelIds);
+  }
+
+  const groupMemberships = await GroupMembershipModel.findAll({
+    where: {
+      workspaceId: workspace.id,
+      groupId: [...editorGroupIds],
+      status: "active",
+      startAt: { [Op.lte]: now },
+      [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: now } }],
+    },
+    attributes: ["groupId", "userId"],
+  });
+
+  if (groupMemberships.length === 0) {
+    return [];
+  }
+
+  const groupMemberUserIds = uniqueNumbers(
+    groupMemberships.map((membership) => membership.userId)
+  );
+
+  const activeWorkspaceMemberships = await MembershipModel.findAll({
+    where: {
+      workspaceId: workspace.id,
+      userId: groupMemberUserIds,
+      startAt: { [Op.lte]: now },
+      [Op.or]: [{ endAt: null }, { endAt: { [Op.gte]: now } }],
+    },
+    attributes: ["userId"],
+  });
+
+  const activeUserIds = new Set(
+    activeWorkspaceMemberships.map((membership) => membership.userId)
+  );
+  if (activeUserIds.size === 0) {
+    return [];
+  }
+
+  const users = await UserModel.findAll({
+    where: { id: [...activeUserIds] },
+    attributes: ["id", "sId", "email", "name"],
+  });
+  const userByModelId = new Map(users.map((user) => [user.id, user]));
+  const editorsByUserModelId = new Map<number, EditorAccumulator>();
+
+  for (const membership of groupMemberships) {
+    if (!activeUserIds.has(membership.userId)) {
+      continue;
+    }
+
+    const user = userByModelId.get(membership.userId);
+    const skillModelIds = skillModelIdsByGroupId.get(membership.groupId);
+    if (!user || !skillModelIds) {
+      continue;
+    }
+
+    const editor = editorsByUserModelId.get(user.id) ?? {
+      workspaceId: workspace.sId,
+      workspaceName: workspace.name,
+      editorUserId: user.sId,
+      editorEmail: user.email,
+      editorName: user.name,
+      skillsById: new Map<string, SkillInfo>(),
+    };
+
+    for (const skillModelId of skillModelIds) {
+      const skill = skillByModelId.get(skillModelId);
+      if (skill) {
+        editor.skillsById.set(skill.id, skill);
+      }
+    }
+
+    if (!editorsByUserModelId.has(user.id)) {
+      editorsByUserModelId.set(user.id, editor);
+    }
+  }
+
+  return [...editorsByUserModelId.values()]
+    .map((editor) => ({
+      workspaceId: editor.workspaceId,
+      workspaceName: editor.workspaceName,
+      editorUserId: editor.editorUserId,
+      editorEmail: editor.editorEmail,
+      editorName: editor.editorName,
+      skills: [...editor.skillsById.values()].sort((left, right) => {
+        const nameComparison = compareStrings(left.name, right.name);
+        return nameComparison === 0
+          ? compareStrings(left.id, right.id)
+          : nameComparison;
+      }),
+    }))
+    .sort((left, right) => {
+      const emailComparison = compareStrings(
+        left.editorEmail,
+        right.editorEmail
+      );
+      return emailComparison === 0
+        ? compareStrings(left.editorUserId, right.editorUserId)
+        : emailComparison;
+    });
+}
+
+function buildCsvRecords(editors: EditorWithSkills[]): SkillEditorCsvRecord[] {
+  return editors.map((editor) => ({
+    workspace_id: sanitizeCsvCell(editor.workspaceId),
+    workspace_name: sanitizeCsvCell(editor.workspaceName),
+    editor_user_id: sanitizeCsvCell(editor.editorUserId),
+    editor_email: sanitizeCsvCell(editor.editorEmail),
+    editor_name: sanitizeCsvCell(editor.editorName),
+    skill_count: editor.skills.length,
+    skill_urls: sanitizeCsvCell(
+      editor.skills.map((skill) => skill.url).join("|")
+    ),
+    skill_names: sanitizeCsvCell(
+      editor.skills.map((skill) => skill.name).join("|")
+    ),
+  }));
+}
+
+makeScript(
+  {
+    outputFile: {
+      type: "string",
+      description: "Write CSV to a file instead of stdout.",
+      demandOption: false,
+    },
+    workspaceId: {
+      type: "string",
+      description: "Restrict export to one workspace sId.",
+      demandOption: false,
+    },
+  },
+  async ({ outputFile, workspaceId }, logger) => {
+    try {
+      const workspaces = await fetchWorkspaces(workspaceId ?? null);
+      const now = new Date();
+      const editors: EditorWithSkills[] = [];
+
+      for (const workspace of workspaces) {
+        editors.push(
+          ...(await fetchSkillEditorsForWorkspace({
+            now,
+            workspace,
+          }))
+        );
+      }
+
+      const records = buildCsvRecords(editors);
+      const csv = stringify(records, {
+        columns: [
+          { key: "workspace_id", header: "workspace_id" },
+          { key: "workspace_name", header: "workspace_name" },
+          { key: "editor_user_id", header: "editor_user_id" },
+          { key: "editor_email", header: "editor_email" },
+          { key: "editor_name", header: "editor_name" },
+          { key: "skill_count", header: "skill_count" },
+          { key: "skill_urls", header: "skill_urls" },
+          { key: "skill_names", header: "skill_names" },
+        ],
+        header: true,
+      });
+
+      if (outputFile) {
+        await writeFile(outputFile, csv, "utf-8");
+      } else {
+        process.stdout.write(csv);
+      }
+    } catch (error) {
+      const normalizedError = normalizeError(error);
+      logger.error(
+        { err: normalizedError, workspaceId },
+        "Failed to extract skill editors"
+      );
+      throw normalizedError;
+    } finally {
+      await frontSequelize.close();
+    }
+  }
+);

--- a/front/migrations/20260601_extract_skill_editors.ts
+++ b/front/migrations/20260601_extract_skill_editors.ts
@@ -3,7 +3,6 @@ import { writeFile } from "node:fs/promises";
 import { sanitizeCsvCell } from "@app/lib/api/analytics/csv_utils";
 import { SkillConfigurationModel } from "@app/lib/models/skill";
 import { GroupSkillModel } from "@app/lib/models/skill/group_skill";
-import { frontSequelize } from "@app/lib/resources/storage";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
@@ -12,7 +11,6 @@ import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { makeSId } from "@app/lib/resources/string_ids";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import { makeScript } from "@app/scripts/helpers";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { stringify } from "csv-stringify/sync";
 import { Op } from "sequelize";
 
@@ -293,17 +291,18 @@ makeScript(
       demandOption: false,
     },
   },
-  async ({ outputFile, workspaceId }, logger) => {
+  async ({ outputFile, workspaceId }) => {
     const workspaces = await fetchWorkspaces(workspaceId ?? null);
     const now = new Date();
     const editors: EditorWithSkills[] = [];
 
     for (const workspace of workspaces) {
+      const workspaceEditors = await fetchSkillEditorsForWorkspace({
+        now,
+        workspace,
+      });
       editors.push(
-        ...(await fetchSkillEditorsForWorkspace({
-          now,
-          workspace,
-        }))
+        ...workspaceEditors
       );
     }
 


### PR DESCRIPTION
## Description

- Adds a script to export active skill editors to CSV.
- The export groups rows by workspace/editor and includes the active skill count, skill builder URLs, and skill names.
- Will be used in the context of preparing external communications.

## Tests

- Tested locally for script invocation.

## Risk

- Low.

## Deploy Plan

- No deploy. Run the migration helper manually.
