### PR TITLE
[front] Keep Skill Builder reference summary read-only

### DIFF
--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -295,43 +295,6 @@ export function SkillBuilderInstructionsEditor({
     onDelete: handleDelete,
   });
 
-  const handleRemoveToolReference = useCallback(
-    (toolId: string) => {
-      const nextTools = toolsRef.current.filter(
-        (tool) => tool.configuration.mcpServerViewId !== toolId
-      );
-      toolsRef.current = nextTools;
-      onToolsChange(nextTools);
-
-      if (!editor || editor.isDestroyed) {
-        return;
-      }
-
-      const ranges: { from: number; to: number }[] = [];
-      editor.state.doc.descendants((node, position) => {
-        if (
-          node.type.name === TOOL_NODE_TYPE &&
-          node.attrs?.mcpServerViewId === toolId
-        ) {
-          ranges.push({ from: position, to: position + node.nodeSize });
-        }
-      });
-
-      if (ranges.length === 0) {
-        return;
-      }
-
-      const transaction = editor.state.tr;
-      for (const range of ranges.toReversed()) {
-        transaction.delete(range.from, range.to);
-      }
-
-      editor.view.dispatch(transaction);
-      syncInstructionsFromEditor(editor);
-    },
-    [editor, onToolsChange, syncInstructionsFromEditor]
-  );
-
   useEffect(() => {
     if (!editor || editor.isDestroyed) {
       return;
@@ -645,7 +608,6 @@ export function SkillBuilderInstructionsEditor({
           <SkillBuilderInstructionsReferenceSummary
             attachedKnowledge={attachedKnowledgeField.value}
             instructions={instructionsField.value ?? ""}
-            onRemoveTool={isDiffMode ? undefined : handleRemoveToolReference}
             tools={tools}
           />
         )}

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -13,7 +13,6 @@ import { useMemo } from "react";
 interface SkillBuilderInstructionsReferenceSummaryProps {
   attachedKnowledge?: AttachedKnowledgeFormData[];
   instructions: string;
-  onRemoveTool?: (toolId: string) => void;
   tools: BuilderAction[];
 }
 
@@ -60,13 +59,7 @@ function compareReferenceSummaryItems(
   );
 }
 
-function renderReferenceSummaryItem({
-  item,
-  onRemoveTool,
-}: {
-  item: ReferenceSummaryItem;
-  onRemoveTool?: (toolId: string) => void;
-}) {
+function renderReferenceSummaryItem(item: ReferenceSummaryItem) {
   switch (item.kind) {
     case "knowledge":
       return (
@@ -94,7 +87,6 @@ function renderReferenceSummaryItem({
           key={`${item.kind}:${item.id}`}
           title={item.title}
           toolIcon={item.icon}
-          onRemove={onRemoveTool ? () => onRemoveTool(item.id) : undefined}
           color="white"
         />
       );
@@ -106,7 +98,6 @@ function renderReferenceSummaryItem({
 export function SkillBuilderInstructionsReferenceSummary({
   attachedKnowledge,
   instructions,
-  onRemoveTool,
   tools,
 }: SkillBuilderInstructionsReferenceSummaryProps) {
   const { mcpServerViews, isMCPServerViewsLoading } =
@@ -221,9 +212,7 @@ export function SkillBuilderInstructionsReferenceSummary({
         Capabilities and knowledge
       </div>
       <div className="flex flex-wrap gap-2">
-        {referenceItems.map((item) =>
-          renderReferenceSummaryItem({ item, onRemoveTool })
-        )}
+        {referenceItems.map(renderReferenceSummaryItem)}
       </div>
     </div>
   );


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/26586 and https://github.com/dust-tt/dust/pull/26575.

Removes the remove action from Skill Builder reference summary tool chips. Tool capability removal still syncs when the user deletes the inline tool chip from the instructions editor itself.

## Risks
Blast radius: Skill Builder instructions reference summary for nested skill references.
Risk: low

## Deploy Plan
- deploy front