### PR TITLE
fix(streaming): fix GCS write stream leaks and SSE double-unsubscribe

### DIFF
--- a/front/lib/api/assistant/mcp_events.ts
+++ b/front/lib/api/assistant/mcp_events.ts
@@ -82,6 +82,7 @@ export async function* getMCPEventsForServer(
   } catch (e) {
     logger.error({ error: e }, "Error getting conversation MCP events");
   } finally {
+    signal.removeEventListener("abort", unsubscribe);
     unsubscribe();
   }
 }

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -101,6 +101,7 @@ export async function* getConversationEvents({
   } catch (e) {
     logger.error({ error: e }, "Error getting conversation events");
   } finally {
+    signal.removeEventListener("abort", unsubscribe);
     unsubscribe();
   }
 }
@@ -265,6 +266,7 @@ export async function* getMessagesEvents(
   } catch (e) {
     logger.error({ error: e }, "Error getting messages events");
   } finally {
+    signal.removeEventListener("abort", unsubscribe);
     unsubscribe();
   }
 }

--- a/front/lib/api/files/processing.ts
+++ b/front/lib/api/files/processing.ts
@@ -200,13 +200,13 @@ const resizeAndWriteToProcessed = async (
     );
   }
 
-  const writeStream = file.getWriteStream({
-    auth,
-    version: "processed",
-  });
-
   try {
     const stream = await createReadableFromUrl(result.file.url);
+
+    const writeStream = file.getWriteStream({
+      auth,
+      version: "processed",
+    });
 
     await pipeline(stream, writeStream);
     return new Ok(undefined);
@@ -669,11 +669,7 @@ export async function processAndStoreFile(
         file.getWriteStream({ auth, version: "original" })
       );
     } else {
-      const r = await parseUploadRequest(
-        file,
-        content.value,
-        file.getWriteStream({ auth, version: "original" })
-      );
+      const r = await parseUploadRequest(auth, file, content.value);
       if (r.isErr()) {
         await file.markAsFailed();
         return r;

--- a/front/lib/api/files/utils.ts
+++ b/front/lib/api/files/utils.ts
@@ -14,9 +14,9 @@ import type { IncomingMessage } from "http";
 import type { Writable } from "stream";
 
 export const parseUploadRequest = async (
+  auth: Authenticator,
   file: FileResource,
-  req: IncomingMessage,
-  writableStream: Writable
+  req: IncomingMessage
 ): Promise<
   Result<
     File,
@@ -29,10 +29,18 @@ export const parseUploadRequest = async (
     }
   >
 > => {
+  // Created by formidable only after the filter accepts a file part, so it is
+  // never allocated for rejected uploads. Captured here so the catch block can
+  // destroy it if formidable throws mid-upload after opening the stream.
+  let writeStream: Writable | undefined;
+
   try {
     const form = new IncomingForm({
       // Stream the uploaded document to the cloud storage.
-      fileWriteStreamHandler: () => writableStream,
+      fileWriteStreamHandler: () => {
+        writeStream = file.getWriteStream({ auth, version: "original" });
+        return writeStream;
+      },
 
       // Support only one file upload.
       maxFiles: 1,
@@ -66,6 +74,7 @@ export const parseUploadRequest = async (
 
     return new Ok(maybeFiles[0]);
   } catch (error) {
+    writeStream?.destroy();
     if (error instanceof Error) {
       if (error.message.startsWith("options.maxTotalFileSize")) {
         return new Err({


### PR DESCRIPTION
## Summary

- Noticed a few write stream memory leaks. These should be minor (not what is causing occasional OOM crashes, but still worth fixing
- Fixed bug that could cause SSE to unsubscribe twice, causing inconsistent metrics

## Testing
Localhost

## Risk
* Low (no behavior change)

## Deploy Plan
1. Deploy Front