### PR TITLE
[front] fix: polish skill instructions reference summary

### DIFF
--- a/front/components/editor/extensions/skill_builder/ToolChip.tsx
+++ b/front/components/editor/extensions/skill_builder/ToolChip.tsx
@@ -5,6 +5,7 @@ import {
 } from "@app/components/resources/resources_icons";
 import {
   AttachmentChip,
+  Chip,
   ExclamationCircleIcon,
   ToolsIcon,
 } from "@dust-tt/sparkle";
@@ -35,9 +36,9 @@ export function ToolChip({
   toolIcon,
 }: ToolChipProps) {
   return (
-    <AttachmentChip
+    <Chip
       label={title}
-      icon={{ visual: getToolIcon(toolIcon) }}
+      icon={getToolIcon(toolIcon)}
       color={color}
       onRemove={onRemove}
       size="xs"

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -1,5 +1,4 @@
 import { getDefaultMCPAction } from "@app/components/agent_builder/types";
-import { editorVariants } from "@app/components/editor/editorStyles";
 import { KNOWLEDGE_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
 import type { KnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
 import { TOOL_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/ToolNode";
@@ -106,6 +105,11 @@ function sanitizeSkillInstructionsHtml(
 
 const INSTRUCTIONS_EDITOR_SIZE = "min-h-60 max-h-[1024px]";
 const INSTRUCTIONS_EDITOR_REFERENCE_SUMMARY_SIZE = "min-h-80 pb-28";
+const INSTRUCTIONS_EDITOR_CONTENT_STYLES = cn(
+  "overflow-auto rounded-none border-0 px-3 pt-2 pb-8 resize-y",
+  "bg-transparent transition-all duration-200",
+  "focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0"
+);
 
 interface SkillBuilderInstructionsEditorProps {
   onAddKnowledge?: (addKnowledge: () => void) => void;
@@ -473,7 +477,9 @@ export function SkillBuilderInstructionsEditor({
     };
   }, [debouncedUpdate]);
 
-  // Set editor class based on error state (applies to ProseMirror element)
+  // Set editor class based on state (applies to ProseMirror element).
+  // The wrapper owns the border/focus styles so the reference summary can sit
+  // inside the same rounded frame without drawing over the focused edge.
   useEffect(() => {
     if (!editor) {
       return;
@@ -483,11 +489,9 @@ export function SkillBuilderInstructionsEditor({
       editorProps: {
         attributes: {
           class: cn(
-            editorVariants({
-              error: displayError,
-              disabled: isDiffMode,
-              readOnly: hasSuggestions,
-            }),
+            INSTRUCTIONS_EDITOR_CONTENT_STYLES,
+            isDiffMode && "cursor-not-allowed resize-none opacity-60",
+            hasSuggestions && "cursor-not-allowed",
             INSTRUCTIONS_EDITOR_SIZE,
             hasInstructionReferenceSummary &&
               INSTRUCTIONS_EDITOR_REFERENCE_SUMMARY_SIZE
@@ -495,13 +499,7 @@ export function SkillBuilderInstructionsEditor({
         },
       },
     });
-  }, [
-    editor,
-    displayError,
-    isDiffMode,
-    hasSuggestions,
-    hasInstructionReferenceSummary,
-  ]);
+  }, [editor, isDiffMode, hasSuggestions, hasInstructionReferenceSummary]);
 
   // Sync external changes to the editor content
   useEffect(() => {
@@ -601,7 +599,26 @@ export function SkillBuilderInstructionsEditor({
 
   return (
     <div className="space-y-1 p-px">
-      <div className="relative overflow-hidden rounded-xl">
+      <div
+        className={cn(
+          "relative overflow-hidden rounded-xl border transition-all duration-200",
+          "bg-muted-background dark:bg-muted-background-night",
+          displayError
+            ? [
+                "border-border-warning/30 dark:border-border-warning-night/60",
+                "focus-within:border-border-warning dark:focus-within:border-border-warning-night",
+                "focus-within:outline-none focus-within:ring-2",
+                "focus-within:ring-warning/10 dark:focus-within:ring-warning-night/30",
+              ]
+            : [
+                "border-border dark:border-border-night",
+                "focus-within:border-highlight-300 dark:focus-within:border-highlight-300-night",
+              ],
+          isDiffMode &&
+            "bg-muted-background/50 dark:bg-muted-background-night/50",
+          hasSuggestions && "cursor-not-allowed"
+        )}
+      >
         <SkillInstructionsEditorContent
           editor={editor}
           isReadOnly={hasSuggestions}

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -1,4 +1,5 @@
 import { getDefaultMCPAction } from "@app/components/agent_builder/types";
+import { editorVariants } from "@app/components/editor/editorStyles";
 import { KNOWLEDGE_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
 import type { KnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
 import { TOOL_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/ToolNode";
@@ -105,11 +106,6 @@ function sanitizeSkillInstructionsHtml(
 
 const INSTRUCTIONS_EDITOR_SIZE = "min-h-60 max-h-[1024px]";
 const INSTRUCTIONS_EDITOR_REFERENCE_SUMMARY_SIZE = "min-h-80 pb-28";
-const INSTRUCTIONS_EDITOR_CONTENT_STYLES = cn(
-  "overflow-auto rounded-none border-0 px-3 pt-2 pb-8 resize-y",
-  "bg-transparent transition-all duration-200",
-  "focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0"
-);
 
 interface SkillBuilderInstructionsEditorProps {
   onAddKnowledge?: (addKnowledge: () => void) => void;
@@ -477,9 +473,7 @@ export function SkillBuilderInstructionsEditor({
     };
   }, [debouncedUpdate]);
 
-  // Set editor class based on state (applies to ProseMirror element).
-  // The wrapper owns the border/focus styles so the reference summary can sit
-  // inside the same rounded frame without drawing over the focused edge.
+  // Set editor class based on error state (applies to ProseMirror element)
   useEffect(() => {
     if (!editor) {
       return;
@@ -489,9 +483,11 @@ export function SkillBuilderInstructionsEditor({
       editorProps: {
         attributes: {
           class: cn(
-            INSTRUCTIONS_EDITOR_CONTENT_STYLES,
-            isDiffMode && "cursor-not-allowed resize-none opacity-60",
-            hasSuggestions && "cursor-not-allowed",
+            editorVariants({
+              error: displayError,
+              disabled: isDiffMode,
+              readOnly: hasSuggestions,
+            }),
             INSTRUCTIONS_EDITOR_SIZE,
             hasInstructionReferenceSummary &&
               INSTRUCTIONS_EDITOR_REFERENCE_SUMMARY_SIZE
@@ -499,7 +495,13 @@ export function SkillBuilderInstructionsEditor({
         },
       },
     });
-  }, [editor, isDiffMode, hasSuggestions, hasInstructionReferenceSummary]);
+  }, [
+    editor,
+    displayError,
+    isDiffMode,
+    hasSuggestions,
+    hasInstructionReferenceSummary,
+  ]);
 
   // Sync external changes to the editor content
   useEffect(() => {
@@ -599,26 +601,7 @@ export function SkillBuilderInstructionsEditor({
 
   return (
     <div className="space-y-1 p-px">
-      <div
-        className={cn(
-          "relative overflow-hidden rounded-xl border transition-all duration-200",
-          "bg-muted-background dark:bg-muted-background-night",
-          displayError
-            ? [
-                "border-border-warning/30 dark:border-border-warning-night/60",
-                "focus-within:border-border-warning dark:focus-within:border-border-warning-night",
-                "focus-within:outline-none focus-within:ring-2",
-                "focus-within:ring-warning/10 dark:focus-within:ring-warning-night/30",
-              ]
-            : [
-                "border-border dark:border-border-night",
-                "focus-within:border-highlight-300 dark:focus-within:border-highlight-300-night",
-              ],
-          isDiffMode &&
-            "bg-muted-background/50 dark:bg-muted-background-night/50",
-          hasSuggestions && "cursor-not-allowed"
-        )}
-      >
+      <div className="relative overflow-hidden rounded-xl">
         <SkillInstructionsEditorContent
           editor={editor}
           isReadOnly={hasSuggestions}

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -105,7 +105,8 @@ function sanitizeSkillInstructionsHtml(
 }
 
 const INSTRUCTIONS_EDITOR_SIZE = "min-h-60 max-h-[1024px]";
-const INSTRUCTIONS_EDITOR_REFERENCE_SUMMARY_SIZE = "min-h-80 pb-28";
+const INSTRUCTIONS_EDITOR_REFERENCE_SUMMARY_SIZE =
+  "min-h-80 rounded-b-none border-b-0 pb-28";
 
 interface SkillBuilderInstructionsEditorProps {
   onAddKnowledge?: (addKnowledge: () => void) => void;
@@ -601,7 +602,7 @@ export function SkillBuilderInstructionsEditor({
 
   return (
     <div className="space-y-1 p-px">
-      <div className="relative overflow-hidden rounded-xl">
+      <div className="group relative overflow-hidden rounded-xl">
         <SkillInstructionsEditorContent
           editor={editor}
           isReadOnly={hasSuggestions}
@@ -609,6 +610,7 @@ export function SkillBuilderInstructionsEditor({
         {enableSkillReferences && (
           <SkillBuilderInstructionsReferenceSummary
             attachedKnowledge={attachedKnowledgeField.value}
+            hasError={displayError}
             instructions={instructionsField.value ?? ""}
             tools={tools}
           />

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -105,6 +105,7 @@ function sanitizeSkillInstructionsHtml(
 }
 
 const INSTRUCTIONS_EDITOR_SIZE = "min-h-60 max-h-[1024px]";
+const INSTRUCTIONS_EDITOR_REFERENCE_SUMMARY_SIZE = "min-h-96 pb-40";
 
 interface SkillBuilderInstructionsEditorProps {
   onAddKnowledge?: (addKnowledge: () => void) => void;
@@ -488,7 +489,8 @@ export function SkillBuilderInstructionsEditor({
               readOnly: hasSuggestions,
             }),
             INSTRUCTIONS_EDITOR_SIZE,
-            hasInstructionReferenceSummary && "pb-36"
+            hasInstructionReferenceSummary &&
+              INSTRUCTIONS_EDITOR_REFERENCE_SUMMARY_SIZE
           ),
         },
       },

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -105,7 +105,7 @@ function sanitizeSkillInstructionsHtml(
 }
 
 const INSTRUCTIONS_EDITOR_SIZE = "min-h-60 max-h-[1024px]";
-const INSTRUCTIONS_EDITOR_REFERENCE_SUMMARY_SIZE = "min-h-96 pb-40";
+const INSTRUCTIONS_EDITOR_REFERENCE_SUMMARY_SIZE = "min-h-80 pb-28";
 
 interface SkillBuilderInstructionsEditorProps {
   onAddKnowledge?: (addKnowledge: () => void) => void;

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -203,9 +203,9 @@ export function SkillBuilderInstructionsReferenceSummary({
   return (
     <div
       className={cn(
-        "absolute inset-x-px bottom-px z-10 max-h-40 overflow-y-auto rounded-b-xl border-t px-3 pb-3 pt-3",
-        "border-border/70 bg-background/75 shadow-[0_-12px_24px_rgba(0,0,0,0.08)] backdrop-blur-sm",
-        "dark:border-border-night/70 dark:bg-background-night/75"
+        "absolute inset-x-px bottom-px z-10 max-h-40 overflow-y-auto rounded-b-[11px] border-t px-3 pb-3 pt-3",
+        "border-border/70 bg-background/90 shadow-[0_-4px_12px_rgba(0,0,0,0.04)] backdrop-blur-sm",
+        "dark:border-border-night/70 dark:bg-background-night/90"
       )}
     >
       <div className="mb-2 text-sm font-medium text-foreground dark:text-foreground-night">

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -12,6 +12,7 @@ import { useMemo } from "react";
 
 interface SkillBuilderInstructionsReferenceSummaryProps {
   attachedKnowledge?: AttachedKnowledgeFormData[];
+  hasError: boolean;
   instructions: string;
   tools: BuilderAction[];
 }
@@ -97,6 +98,7 @@ function renderReferenceSummaryItem(item: ReferenceSummaryItem) {
 
 export function SkillBuilderInstructionsReferenceSummary({
   attachedKnowledge,
+  hasError,
   instructions,
   tools,
 }: SkillBuilderInstructionsReferenceSummaryProps) {
@@ -203,17 +205,24 @@ export function SkillBuilderInstructionsReferenceSummary({
   return (
     <div
       className={cn(
-        "absolute inset-x-px bottom-px z-10 max-h-40 overflow-y-auto bg-background px-3 pb-3",
-        "dark:bg-background-night"
+        "absolute inset-x-0 bottom-0 z-10 max-h-40 overflow-y-auto rounded-b-xl border-x border-b bg-background px-3 pb-3 pt-3",
+        "dark:bg-background-night",
+        hasError
+          ? [
+              "border-border-warning/30 group-focus-within:border-border-warning",
+              "dark:border-border-warning-night/60 dark:group-focus-within:border-border-warning-night",
+            ]
+          : [
+              "border-border group-focus-within:border-highlight-300",
+              "dark:border-border-night dark:group-focus-within:border-highlight-300-night",
+            ]
       )}
     >
-      <div className="border-t border-border/70 pt-3 dark:border-border-night/70">
-        <div className="mb-2 text-sm font-medium text-foreground dark:text-foreground-night">
-          Capabilities and knowledge
-        </div>
-        <div className="flex flex-wrap gap-2">
-          {referenceItems.map(renderReferenceSummaryItem)}
-        </div>
+      <div className="mb-2 text-sm font-medium text-foreground dark:text-foreground-night">
+        Capabilities and knowledge
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {referenceItems.map(renderReferenceSummaryItem)}
       </div>
     </div>
   );

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -203,16 +203,17 @@ export function SkillBuilderInstructionsReferenceSummary({
   return (
     <div
       className={cn(
-        "absolute inset-x-0 bottom-0 z-10 max-h-40 overflow-y-auto border-t px-3 pb-3 pt-3",
-        "border-border/70 bg-background",
-        "dark:border-border-night/70 dark:bg-background-night"
+        "absolute inset-x-px bottom-px z-10 max-h-40 overflow-y-auto bg-background px-3 pb-3",
+        "dark:bg-background-night"
       )}
     >
-      <div className="mb-2 text-sm font-medium text-foreground dark:text-foreground-night">
-        Capabilities and knowledge
-      </div>
-      <div className="flex flex-wrap gap-2">
-        {referenceItems.map(renderReferenceSummaryItem)}
+      <div className="border-t border-border/70 pt-3 dark:border-border-night/70">
+        <div className="mb-2 text-sm font-medium text-foreground dark:text-foreground-night">
+          Capabilities and knowledge
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {referenceItems.map(renderReferenceSummaryItem)}
+        </div>
       </div>
     </div>
   );

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -203,9 +203,9 @@ export function SkillBuilderInstructionsReferenceSummary({
   return (
     <div
       className={cn(
-        "absolute inset-x-px bottom-px z-10 max-h-40 overflow-y-auto rounded-b-[11px] border-t px-3 pb-3 pt-3",
-        "border-border/70 bg-background/90 shadow-[0_-4px_12px_rgba(0,0,0,0.04)] backdrop-blur-sm",
-        "dark:border-border-night/70 dark:bg-background-night/90"
+        "absolute inset-x-px bottom-px z-10 max-h-40 overflow-y-auto border-t px-3 pb-3 pt-3",
+        "border-border/70 bg-background",
+        "dark:border-border-night/70 dark:bg-background-night"
       )}
     >
       <div className="mb-2 text-sm font-medium text-foreground dark:text-foreground-night">

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -203,7 +203,7 @@ export function SkillBuilderInstructionsReferenceSummary({
   return (
     <div
       className={cn(
-        "absolute inset-x-px bottom-px z-10 max-h-40 overflow-y-auto border-t px-3 pb-3 pt-3",
+        "absolute inset-x-0 bottom-0 z-10 max-h-40 overflow-y-auto border-t px-3 pb-3 pt-3",
         "border-border/70 bg-background",
         "dark:border-border-night/70 dark:bg-background-night"
       )}


### PR DESCRIPTION
## Description

This PR polishes the Skill Builder instructions reference summary so it feels less heavy when attached to the bottom of the editor.

The summary now uses a softer top shadow, a more opaque background, and an inner bottom radius that matches the editor border inset.
It also reserves more editor height when the reference summary is visible, so the base instructions block still leaves enough usable writing space above the attached capabilities and knowledge strip.
Also fixes a font size in chips.

After
<img width="910" height="376" alt="image" src="https://github.com/user-attachments/assets/f51abb1b-6bce-4972-82f1-345a3f7b572c" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
