### PR TITLE
[front] enh: explain unavailable skill references in prompt

### DIFF
--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -490,6 +490,37 @@ describe("constructPromptMultiActions - system prompt stability", () => {
     expect(text).not.toContain("## AVAILABLE SKILLS");
   });
 
+  it("should explain unavailable skill references only when nested skills are enabled", () => {
+    const params = {
+      userMessage: userMessage1,
+      agentConfiguration: agentConfig1,
+      model: modelConfig,
+      hasAvailableActions: true,
+      agentsList: null,
+      systemSkills: [],
+      enabledSkills: [],
+      equippedSkills: [],
+    };
+
+    const defaultSections = constructPromptMultiActions(authenticator1, params);
+    const nestedSections = constructPromptMultiActions(authenticator1, {
+      ...params,
+      hasNestedSkills: true,
+    });
+
+    const defaultText = systemPromptToText(defaultSections);
+    const nestedText = systemPromptToText(nestedSections);
+
+    expect(defaultText).not.toContain("<unavailable_skill");
+    expect(nestedText).toContain(
+      'Enabled skill instructions can also contain `<unavailable_skill id="..." />` tags.'
+    );
+    expect(nestedText).toContain(
+      "the referenced skill is no longer available in the current scope"
+    );
+    expect(nestedText).toContain("do not try to enable them from the tag");
+  });
+
   it("should keep system skill instructions in the system prompt", async () => {
     const discoverSkills = await SkillResource.fetchById(
       authenticator1,

--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -490,37 +490,6 @@ describe("constructPromptMultiActions - system prompt stability", () => {
     expect(text).not.toContain("## AVAILABLE SKILLS");
   });
 
-  it("should explain unavailable skill references only when nested skills are enabled", () => {
-    const params = {
-      userMessage: userMessage1,
-      agentConfiguration: agentConfig1,
-      model: modelConfig,
-      hasAvailableActions: true,
-      agentsList: null,
-      systemSkills: [],
-      enabledSkills: [],
-      equippedSkills: [],
-    };
-
-    const defaultSections = constructPromptMultiActions(authenticator1, params);
-    const nestedSections = constructPromptMultiActions(authenticator1, {
-      ...params,
-      hasNestedSkills: true,
-    });
-
-    const defaultText = systemPromptToText(defaultSections);
-    const nestedText = systemPromptToText(nestedSections);
-
-    expect(defaultText).not.toContain("<unavailable_skill");
-    expect(nestedText).toContain(
-      'Enabled skill instructions can also contain `<unavailable_skill id="..." />` tags.'
-    );
-    expect(nestedText).toContain(
-      "the referenced skill is no longer available in the current scope"
-    );
-    expect(nestedText).toContain("do not try to enable them from the tag");
-  });
-
   it("should keep system skill instructions in the system prompt", async () => {
     const discoverSkills = await SkillResource.fetchById(
       authenticator1,

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -227,7 +227,10 @@ function constructSkillsSection({
         "These tags are strong hints that the referenced skill is relevant, including when a skill author nested one skill inside another. " +
         `If the referenced skill would help and is not already enabled, call \`${toolDisplayName}\` with \`skillName\` set to the tag's \`name\` value.\n` +
         "Referenced skills may not appear in the available-skills list; a tag is enough to enable the skill by name. " +
-        "Only enable skills you actually need, because enabling a skill loads its full instructions into context.\n"
+        "Only enable skills you actually need, because enabling a skill loads its full instructions into context.\n" +
+        `Enabled skill instructions can also contain \`<unavailable_skill id=\"...\" />\` tags. ` +
+        "These are former nested skill references that cannot currently be resolved because the referenced skill is no longer available in the current scope, for example because skill scope or permissions changed. " +
+        "Treat them as context explaining that an unavailable skill used to be referenced; do not try to enable them from the tag.\n"
       : `If a user message contains a \`<skill id=\"...\" name=\"...\" />\` tag, treat it as a strong hint that the ` +
         "referenced skill is relevant: it means the user specifically mentioned this skill. If the skill is not already " +
         `enabled, and it would help, enable it with \`${toolDisplayName}\`.\n` +

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -229,8 +229,8 @@ function constructSkillsSection({
         "Referenced skills may not appear in the available-skills list; a tag is enough to enable the skill by name. " +
         "Only enable skills you actually need, because enabling a skill loads its full instructions into context.\n" +
         `Enabled skill instructions can also contain \`<unavailable_skill id=\"...\" />\` tags. ` +
-        "These are former nested skill references that cannot currently be resolved because the referenced skill is no longer available in the current scope, for example because skill scope or permissions changed. " +
-        "Treat them as context explaining that an unavailable skill used to be referenced; do not try to enable them from the tag.\n"
+        "These mean the instructions used to reference another skill, but that skill is no longer available to this conversation, for example because skill scope or permissions changed. " +
+        "Do not try to enable unavailable skill tags.\n"
       : `If a user message contains a \`<skill id=\"...\" name=\"...\" />\` tag, treat it as a strong hint that the ` +
         "referenced skill is relevant: it means the user specifically mentioned this skill. If the skill is not already " +
         `enabled, and it would help, enable it with \`${toolDisplayName}\`.\n` +


### PR DESCRIPTION
## Description

This PR extends the nested-skills system prompt guidance to explain `<unavailable_skill id="..." />` tags that can appear in enabled skill instructions.

These tags represent former nested skill references that can no longer be resolved because the referenced skill is not available in the current scope, for example after a permission changes. The guidance stays behind the `nested_skills` path and tells the model to treat those tags as context, not as skill references to enable.

## Tests

- Checked locally.

## Risk

- Low. Behind the nested-skills prompt path.

## Deploy Plan

- Deploy front.
