### PR TITLE
[front] fix: show nested skill space blockers in Skill Builder

### DIFF
--- a/front/components/shared/RemoveSpaceDialog.tsx
+++ b/front/components/shared/RemoveSpaceDialog.tsx
@@ -4,7 +4,7 @@ import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { getSkillAvatarIcon } from "@app/lib/skill";
+import { getSkillAvatarIcon, getSkillIcon } from "@app/lib/skill";
 import { getSpaceName } from "@app/lib/spaces";
 import type { SpaceType } from "@app/types/space";
 import { Chip, DocumentIcon, Icon, ToolsIcon } from "@dust-tt/sparkle";
@@ -50,7 +50,7 @@ function getActionChipIcon(
   return getIcon(mcpServerView.server.icon);
 }
 
-function getSkillIcon(skill: SkillToRemove): React.ReactNode {
+function getSkillInlineIcon(skill: SkillToRemove): React.ReactNode {
   return React.createElement(getSkillAvatarIcon(skill.icon));
 }
 
@@ -87,6 +87,7 @@ interface ConfirmBlockedSkillSpaceRemovalParams {
   space: SpaceType;
   actions: BuilderAction[];
   knowledge: KnowledgeToRemove[];
+  skills?: SkillToRemove[];
 }
 
 export function useRemoveSpaceConfirm({
@@ -110,7 +111,7 @@ export function useRemoveSpaceConfirm({
       ...skills.map((skill) => ({
         id: skill.sId,
         name: skill.name,
-        icon: getSkillIcon(skill),
+        icon: getSkillInlineIcon(skill),
       })),
       ...actions.map((action) => ({
         id: action.id,
@@ -171,6 +172,7 @@ export function useBlockedSkillSpaceRemovalConfirm({
     space,
     actions,
     knowledge,
+    skills = [],
   }: ConfirmBlockedSkillSpaceRemovalParams): Promise<boolean> => {
     return confirm({
       title: `${getSpaceName(space)} can't be removed`,
@@ -178,7 +180,7 @@ export function useBlockedSkillSpaceRemovalConfirm({
         <div className="space-y-3">
           <p className="text-sm">
             This space can't be removed from the skill because the skill uses
-            knowledge or tools that belong to it.
+            knowledge or capabilities that belong to it.
           </p>
           <div className="flex flex-wrap gap-2">
             {knowledge.map((knowledgeItem) => (
@@ -188,6 +190,15 @@ export function useBlockedSkillSpaceRemovalConfirm({
                 color="primary"
                 icon={DocumentIcon}
                 label={knowledgeItem.title}
+              />
+            ))}
+            {skills.map((skill) => (
+              <Chip
+                key={`skill-${skill.sId}`}
+                size="xs"
+                color="primary"
+                icon={getSkillIcon(skill.icon)}
+                label={skill.name}
               />
             ))}
             {actions.map((action) => (

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -6,6 +6,7 @@ import { SpaceChips } from "@app/components/shared/SpaceChips";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type {
   AttachedKnowledgeFormData,
+  ReferencedSkillFormData,
   SkillBuilderFormData,
 } from "@app/components/skill_builder/SkillBuilderFormContext";
 import { useSpaceProjectsLookup } from "@app/lib/swr/spaces";
@@ -30,6 +31,9 @@ export function SkillBuilderRequestedSpacesSection({
       name: "attachedKnowledge",
     }
   );
+  const referencedSkills = useWatch<SkillBuilderFormData, "referencedSkills">({
+    name: "referencedSkills",
+  });
 
   const {
     field: additionalSpacesField,
@@ -77,17 +81,28 @@ export function SkillBuilderRequestedSpacesSection({
     return new Set(attachedKnowledge?.map((k) => k.spaceId) ?? []);
   }, [attachedKnowledge]);
 
+  const spaceIdsFromNestedSkills = useMemo(() => {
+    return new Set(
+      (referencedSkills ?? []).flatMap((skill) => skill.requestedSpaceIds)
+    );
+  }, [referencedSkills]);
+
   const spaceIdsUsedBySkill = useMemo(() => {
     const actionRequestedSpaceIds = Object.keys(actionsBySpaceId).filter(
       (spaceId) => actionsBySpaceId[spaceId]?.length > 0
     );
 
-    return new Set([...actionRequestedSpaceIds, ...spaceIdsFromKnowledge]);
-  }, [actionsBySpaceId, spaceIdsFromKnowledge]);
+    return new Set([
+      ...actionRequestedSpaceIds,
+      ...spaceIdsFromKnowledge,
+      ...spaceIdsFromNestedSkills,
+    ]);
+  }, [actionsBySpaceId, spaceIdsFromKnowledge, spaceIdsFromNestedSkills]);
 
   const areSpaceRequirementsReady =
     !isMCPServerViewsLoading &&
-    (!initialRequestedSpaceIds || attachedKnowledge !== undefined);
+    (!initialRequestedSpaceIds ||
+      (attachedKnowledge !== undefined && referencedSkills !== undefined));
 
   const knowledgeBySpaceId = useMemo(() => {
     const knowledgeBySpace: Record<string, AttachedKnowledgeFormData[]> = {};
@@ -100,6 +115,18 @@ export function SkillBuilderRequestedSpacesSection({
 
     return knowledgeBySpace;
   }, [attachedKnowledge]);
+
+  const skillsBySpaceId = useMemo(() => {
+    const skillsBySpace: Record<string, ReferencedSkillFormData[]> = {};
+
+    for (const skill of referencedSkills ?? []) {
+      for (const spaceId of skill.requestedSpaceIds) {
+        skillsBySpace[spaceId] = (skillsBySpace[spaceId] ?? []).concat(skill);
+      }
+    }
+
+    return skillsBySpace;
+  }, [referencedSkills]);
 
   const initialAdditionalSpaces = useMemo(() => {
     if (!areSpaceRequirementsReady || !initialRequestedSpaceIds?.length) {
@@ -158,6 +185,11 @@ export function SkillBuilderRequestedSpacesSection({
         space,
         actions: actionsBySpaceId[space.sId] ?? [],
         knowledge: knowledgeBySpaceId[space.sId] ?? [],
+        skills: (skillsBySpaceId[space.sId] ?? []).map((skill) => ({
+          sId: skill.id,
+          name: skill.name,
+          icon: skill.icon,
+        })),
       });
       return;
     }


### PR DESCRIPTION
## Description

Stacked on #26619.

This PR uses the nested skill references stored in Skill Builder form state to render the space-restricted flow. Spaces required by child skills are shown as non-removable in the Skill Builder space list, and the blocked removal dialog now includes skill chips alongside knowledge and tools.

This is frontend-only: child-skill spaces are not persisted onto the parent skill requested spaces.

## Tests

- Tested locally.

## Risk

- Low. Frontend-only Skill Builder space restriction UI.

## Deploy Plan

- Deploy front.