### PR TITLE
Fix subscription mismatch

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
@@ -1,5 +1,8 @@
 import { Authenticator } from "@app/lib/auth";
-import { listMetronomePackages } from "@app/lib/metronome/client";
+import {
+  getMetronomeContractById,
+  listMetronomePackages,
+} from "@app/lib/metronome/client";
 import {
   ensureMetronomeCustomerForWorkspace,
   provisionMetronomeContract,
@@ -31,6 +34,7 @@ vi.mock("@app/lib/metronome/client", async () => {
   return {
     ...actual,
     listMetronomePackages: vi.fn(),
+    getMetronomeContractById: vi.fn(),
   };
 });
 
@@ -221,6 +225,18 @@ beforeEach(() => {
   vi.mocked(provisionMetronomeContract).mockResolvedValue(
     new Ok({ metronomeContractId: NEW_CONTRACT_ID })
   );
+  // The active contract the backdating guard reads. Started 90 days ago, so
+  // future and recently-backdated switches are accepted; only a switch dated
+  // before this start is rejected.
+  vi.mocked(getMetronomeContractById).mockResolvedValue(
+    new Ok({
+      id: EXISTING_CONTRACT_ID,
+      customer_id: METRONOME_CUSTOMER_ID,
+      starting_at: new Date(
+        Date.now() - 90 * 24 * 60 * 60 * 1000
+      ).toISOString(),
+    } as never)
+  );
 });
 
 describe("POST /api/poke/workspaces/[wId]/switch_contract — Enterprise", () => {
@@ -294,6 +310,36 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — Enterprise", () =>
         swapAt: "next-hour",
       })
     );
+  });
+
+  it("rejects a startingAt earlier than the current active contract's start", async () => {
+    await ensureEnterprisePlan();
+    const { workspace } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
+
+    // Active contract started 1 hour ago; backdating 48h before it would
+    // create overlapping contracts the sunset pass can't resolve.
+    vi.mocked(getMetronomeContractById).mockResolvedValue(
+      new Ok({
+        id: EXISTING_CONTRACT_ID,
+        customer_id: METRONOME_CUSTOMER_ID,
+        starting_at: futureIso(-1),
+      } as never)
+    );
+
+    const response = await postSwitchContract(
+      workspace.sId,
+      enterpriseBody({ startingAt: futureIso(-48) })
+    );
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error.message).toContain(
+      "before the current active contract's start"
+    );
+    expect(provisionMetronomeContract).not.toHaveBeenCalled();
   });
 
   it("rejects when the package currency does not match the Stripe customer currency", async () => {

--- a/front/lib/api/metronome/process_webhook.test.ts
+++ b/front/lib/api/metronome/process_webhook.test.ts
@@ -373,6 +373,64 @@ describe("processMetronomeWebhook — contract.start", () => {
 
     expect(restoreWorkspaceAfterSubscription).toHaveBeenCalledTimes(1);
   });
+
+  it("leaves the subscription alone for a superseded contract's stale start (its sub row is ended)", async () => {
+    // Two switch_contract calls in a row: the first staged a pending sub on
+    // OLD_CONTRACT_ID, the second superseded it — ending that pending row and
+    // staging NEW_CONTRACT_ID, which then activated. A late, stale
+    // contract.start for OLD_CONTRACT_ID must NOT swap the active sub back onto
+    // the superseded (and Metronome-sunset) contract.
+    const supersededPlan = await PlanFactory.enterprise(ENT_PLAN_CODE);
+    const workspace = await setupMetronomeWorkspace(NEW_CONTRACT_ID);
+    const workspaceModelId = (await WorkspaceResource.fetchById(workspace.sId))!
+      .id;
+    // The superseded contract's subscription row, ended by the second switch.
+    await SubscriptionResource.makeNew(
+      {
+        sId: generateRandomModelSId(),
+        workspaceId: workspaceModelId,
+        planId: supersededPlan.id,
+        status: "ended",
+        startDate: new Date(),
+        endDate: new Date(),
+        stripeSubscriptionId: null,
+        metronomeContractId: OLD_CONTRACT_ID,
+      },
+      renderPlanFromModel({ plan: supersededPlan })
+    );
+
+    vi.mocked(getMetronomeContractById).mockResolvedValue(
+      new Ok({
+        id: OLD_CONTRACT_ID,
+        customer_id: METRONOME_CUSTOMER_ID,
+        starting_at: new Date().toISOString(),
+        custom_fields: { [PLAN_CODE_CUSTOM_FIELD_KEY]: ENT_PLAN_CODE },
+      } as never)
+    );
+
+    const result = await processMetronomeWebhook({
+      event: contractEvent("contract.start", OLD_CONTRACT_ID) as never,
+      workspace,
+    });
+    expect(result.isOk()).toBe(true);
+
+    // Active sub still points at the winning contract — no swap onto the
+    // superseded one.
+    const refreshed = await WorkspaceResource.fetchById(workspace.sId);
+    const activeSub = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+      refreshed!.id
+    );
+    expect(activeSub!.metronomeContractId).toBe(NEW_CONTRACT_ID);
+    expect(activeSub!.status).toBe("active");
+
+    // The superseded row stays ended; nothing reactivated it.
+    const supersededSub = await SubscriptionResource.fetchByMetronomeContractId(
+      refreshed!,
+      OLD_CONTRACT_ID
+    );
+    expect(supersededSub!.status).toBe("ended");
+    expect(restoreWorkspaceAfterSubscription).not.toHaveBeenCalled();
+  });
 });
 
 describe("processMetronomeWebhook — contract.end", () => {

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -1190,48 +1190,66 @@ export async function processMetronomeWebhook({
         break;
       }
 
-      // Preferred path: a pending (created_backend_only) subscription was
-      // staged when the contract was provisioned. Flip it to active and
-      // end whatever active sub the workspace currently holds.
-      const pendingSubscription =
+      // A subscription row was staged for this contract when it was
+      // provisioned. Its status tells us whether this contract.start is still
+      // relevant.
+      const subscriptionForContract =
         await SubscriptionResource.fetchByMetronomeContractId(
           workspace,
           contractId
         );
-      if (
-        pendingSubscription &&
-        pendingSubscription.status === "created_backend_only"
-      ) {
-        const previousPlanCode = activeSubscription.getPlan().code;
-        await pendingSubscription.activatePending();
-        await invalidateContractCache(workspace.sId);
-        const auth = await Authenticator.internalAdminForWorkspace(
-          workspace.sId
-        );
-        await restoreWorkspaceAfterSubscription(auth);
-        await ensureWorkOSOrganizationForPaidPlan({
-          workspace,
-          planCode: targetPlan.code,
-          contractId,
-        });
-        emitSubscriptionChangedAuditEvent({
-          auth,
-          planCode: targetPlanCode,
-          previousPlanCode,
-          metronomeContractId: contractId,
-        });
+      if (subscriptionForContract) {
+        // Preferred path: the pending (created_backend_only) subscription is
+        // still the workspace's target. Flip it to active and end whatever
+        // active sub the workspace currently holds.
+        if (subscriptionForContract.status === "created_backend_only") {
+          const previousPlanCode = activeSubscription.getPlan().code;
+          await subscriptionForContract.activatePending();
+          await invalidateContractCache(workspace.sId);
+          const auth = await Authenticator.internalAdminForWorkspace(
+            workspace.sId
+          );
+          await restoreWorkspaceAfterSubscription(auth);
+          await ensureWorkOSOrganizationForPaidPlan({
+            workspace,
+            planCode: targetPlan.code,
+            contractId,
+          });
+          emitSubscriptionChangedAuditEvent({
+            auth,
+            planCode: targetPlanCode,
+            previousPlanCode,
+            metronomeContractId: contractId,
+          });
+          logger.info(
+            {
+              contractId,
+              planCode: targetPlan.code,
+              workspaceId: workspace.sId,
+            },
+            "[Metronome Webhook] contract.start: pending subscription activated"
+          );
+          break;
+        }
+
+        // A row exists for this contract but it is no longer pending — a later
+        // switch_contract superseded this contract (its pending sub was ended
+        // and the Metronome contract sunset by the overlap-sunset pass). Its
+        // contract.start is stale: swapping onto it would point the workspace
+        // at an ended contract. Leave the subscription alone.
         logger.info(
           {
             contractId,
-            planCode: targetPlan.code,
+            status: subscriptionForContract.status,
             workspaceId: workspace.sId,
           },
-          "[Metronome Webhook] contract.start: pending subscription activated"
+          "[Metronome Webhook] contract.start: subscription for contract is no longer pending (superseded), leaving subscription alone"
         );
         break;
       }
 
-      // Legacy fallback: no pending row was staged. Only swap when the
+      // Legacy fallback: no row was ever staged for this contract. Only swap
+      // when the
       // workspace is Metronome-only billed, or not billed at all. Shadow
       // billed subscriptions (Stripe + Metronome) follow Stripe's signal,
       // and pure Stripe subs have no Metronome contract at all.

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -11,6 +11,7 @@ import {
   ceilToHourISO,
   editMetronomeContract,
   floorToHourISO,
+  getMetronomeContractById,
   listMetronomePackages,
 } from "@app/lib/metronome/client";
 import {
@@ -390,6 +391,44 @@ export async function switchContract({
     }
     startingAtDate = new Date(requestedStartMs);
     swapAt = "next-hour";
+
+    // Reject backdating before the current active contract's start. A new
+    // contract starting before the active one fully shadows it, but the
+    // overlap-sunset pass in `provisionMetronomeContract` only ends contracts
+    // that start at or before the new one — so the active contract would stay
+    // live and overlap the new one (Metronome also can't end a contract before
+    // it begins). Rather than archive an already-billed contract here, refuse
+    // the switch and let the operator archive the active contract manually.
+    const activeContractId = currentSubscription?.metronomeContractId ?? null;
+    if (activeContractId) {
+      const activeContractResult = await getMetronomeContractById({
+        metronomeCustomerId,
+        metronomeContractId: activeContractId,
+      });
+      if (activeContractResult.isErr()) {
+        return new Err(
+          new SwitchContractError(
+            "metronome_api_error",
+            `Failed to fetch the active Metronome contract ${activeContractId}: ` +
+              `${activeContractResult.error.message}`
+          )
+        );
+      }
+      const activeStartMs = Date.parse(activeContractResult.value.starting_at);
+      const alignedStartMs = new Date(ceilToHourISO(startingAtDate)).getTime();
+      if (alignedStartMs < activeStartMs) {
+        return new Err(
+          new SwitchContractError(
+            "invalid_request",
+            `startingAt (${startingAtDate.toISOString()}) is before the current ` +
+              `active contract's start (${activeContractResult.value.starting_at}). ` +
+              "Backdating a switch before the active contract would create " +
+              "overlapping contracts. Archive the active contract manually " +
+              "before backdating."
+          )
+        );
+      }
+    }
   } else {
     startingAtDate = new Date();
     swapAt = "current-hour";

--- a/front/pages/api/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front/pages/api/poke/workspaces/[wId]/switch_contract.test.ts
@@ -1,6 +1,7 @@
 import { Authenticator } from "@app/lib/auth";
 import {
   addPrepaidCommitToContract,
+  getMetronomeContractById,
   listMetronomePackages,
 } from "@app/lib/metronome/client";
 import {
@@ -42,6 +43,7 @@ vi.mock("@app/lib/metronome/client", async () => {
     ...actual,
     listMetronomePackages: vi.fn(),
     addPrepaidCommitToContract: vi.fn(),
+    getMetronomeContractById: vi.fn(),
   };
 });
 
@@ -221,6 +223,18 @@ beforeEach(() => {
   vi.mocked(provisionMetronomeContract).mockResolvedValue(
     new Ok({ metronomeContractId: NEW_CONTRACT_ID })
   );
+  // The active contract the backdating guard reads. Started 90 days ago, so
+  // future and recently-backdated switches are accepted; only a switch dated
+  // before this start is rejected.
+  vi.mocked(getMetronomeContractById).mockResolvedValue(
+    new Ok({
+      id: EXISTING_CONTRACT_ID,
+      customer_id: METRONOME_CUSTOMER_ID,
+      starting_at: new Date(
+        Date.now() - 90 * 24 * 60 * 60 * 1000
+      ).toISOString(),
+    } as never)
+  );
   vi.mocked(scheduleSubscriptionCancellation).mockResolvedValue(true);
   vi.mocked(addPrepaidCommitToContract).mockResolvedValue(
     new Ok({ editId: "edit_xxx" })
@@ -304,6 +318,36 @@ describe("POST /api/poke/workspaces/[wId]/switch_contract — Enterprise", () =>
         swapAt: "next-hour",
       })
     );
+  });
+
+  it("rejects a startingAt earlier than the current active contract's start", async () => {
+    await ensureEnterprisePlan();
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+    });
+    await makeSubscriptionMetronomeBilled(workspace, EXISTING_CONTRACT_ID);
+
+    // Active contract started 1 hour ago; backdating 48h before it would
+    // create overlapping contracts the sunset pass can't resolve.
+    vi.mocked(getMetronomeContractById).mockResolvedValue(
+      new Ok({
+        id: EXISTING_CONTRACT_ID,
+        customer_id: METRONOME_CUSTOMER_ID,
+        starting_at: futureIso(-1),
+      } as never)
+    );
+
+    req.body = enterpriseBody({ startingAt: futureIso(-48) });
+    req.query.wId = workspace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.message).toContain(
+      "before the current active contract's start"
+    );
+    expect(provisionMetronomeContract).not.toHaveBeenCalled();
   });
 
   it("rejects when the package currency does not match the Stripe customer currency", async () => {


### PR DESCRIPTION
## Fix subscription/contract mismatch from racing & backdated contract switches

### Problem

A workspace ended up with its **active subscription pointing at an ended Metronome contract**, while the **live contract had no subscription linked**. As a result `getMetronomeCurrentBillingPeriod` threw `"No current billing period found on Metronome contract"`, breaking the members-usage endpoint (logged as a `[MembersUsage] Failed to fetch per-user usage` warning).

Two distinct bugs, both exposed by `switch_contract`, could produce this state.

### Bug 1 — stale `contract.start` swaps onto a superseded contract

When two `switch_contract` calls happen before their webhooks land, the first switch's pending subscription is ended (status `ended`) by the second. The `contract.start` handler only treated a row as "pending" when it was `created_backend_only`; any other status fell through to the **legacy fallback**, which swapped the active subscription onto that contract. So a late `contract.start` for the superseded (and Metronome-sunset) contract would point the workspace's active sub back at a dead contract.

**Fix:** if a subscription row exists for the contract but is no longer `created_backend_only`, the handler logs and leaves the subscription alone. The legacy fallback now only runs when **no** row was ever staged for the contract.

### Bug 2 — backdating before the active contract creates overlapping contracts

`provisionMetronomeContract`'s overlap-sunset pass only ends existing contracts that start **at or before** the new contract. Now that `startingAt` accepts past timestamps, a contract backdated *before* the current active one is never sunset (and Metronome can't end a contract before it begins), leaving two overlapping live contracts.

**Fix:** `switch_contract` now rejects a `startingAt` earlier than the current active contract's start with a `400`, instructing the operator to archive the active contract manually before backdating.

### Changes

- `lib/api/metronome/process_webhook.ts` — restructure the `contract.start` swap logic to short-circuit on superseded (non-pending) subscription rows.
- `lib/api/poke/switch_contract.ts` — add a guard rejecting backdating before the active contract's start (reads the active contract via `getMetronomeContractById`).

### Tests

- `process_webhook.test.ts` — stale `contract.start` for a superseded (`ended`) contract leaves the active subscription untouched.
- `switch_contract.test.ts` — backdating before the active contract's start returns `400`; existing `startingAt` tests updated to mock `getMetronomeContractById`.

### Note

This prevents recurrence but does not repair already-corrupted workspaces — those still need the active subscription re-pointed at the live contract (e.g. a fresh switch or a manual DB fixup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
