### PR TITLE
Simplify per user usage call

### DIFF
--- a/front/lib/metronome/per_user_usage.ts
+++ b/front/lib/metronome/per_user_usage.ts
@@ -1,6 +1,5 @@
 import {
   ceilToMidnightUTC,
-  floorToMidnightUTC,
   listMetronomeUsageWithGroups,
 } from "@app/lib/metronome/client";
 import {
@@ -30,18 +29,18 @@ const PAID_USAGE_TYPES = [USAGE_TYPE_USER, USAGE_TYPE_PROGRAMMATIC];
  * Usage is now folded on the invoice (no per-user line item), so we read it
  * straight from the grouped usage API instead of walking draft invoices.
  *
- * The billing period is hour-precise (contracts are anchored on hour
- * boundaries, e.g. a period running 14:00→14:00), but the usage endpoint has
- * two constraints we can't both satisfy directly:
+ * Billing periods always start on the 1st of the month at UTC midnight, so
+ * `cycleStart`/`cycleEnd` already satisfy the usage endpoint's two constraints:
  *   - `current_period: true` is rejected ("must have an active plan") — that
  *     flag keys off Metronome's legacy v1 Plan entity, and we provision
- *     customers exclusively via Contracts, so no Plan exists.
- *   - explicit `starting_on`/`ending_before` must be UTC midnight.
- * So we query midnight-aligned bounds that *enclose* the period with
- * `window_size: "HOUR"`, then keep only the hourly buckets that fall inside
- * the exact `[cycleStart, cycleEnd)` window — hour-precise, matching the
- * period the per-user spend cap alert evaluates. The request end is capped at
- * the next midnight after `now` so we don't fetch the period's future days.
+ *     customers exclusively via Contracts, so no Plan exists. We pass explicit
+ *     `starting_on`/`ending_before` instead.
+ *   - explicit `starting_on`/`ending_before` must be UTC midnight — which the
+ *     period bounds already are.
+ * So we query `[cycleStart, cycleEnd)` directly with `window_size: "DAY"`; every
+ * returned bucket falls inside the period, no trimming needed. The request end
+ * is capped at the next midnight after `now` so we don't fetch the period's
+ * future days.
  *
  * AWU spend has two sources, both priced in the AWU credit type:
  *   - AI Usage: the `cost_awu` metric, priced 1 AWU per unit, so the metric
@@ -68,12 +67,12 @@ export async function fetchPerUserAwuUsage({
     return new Ok(new Map());
   }
   const { cycleStart, cycleEnd } = periodResult.value;
-  const cycleStartMs = cycleStart.getTime();
   const cycleEndMs = cycleEnd.getTime();
 
-  // Midnight-aligned request bounds enclosing the period (API requirement).
-  // The hourly buckets outside [cycleStart, cycleEnd) are trimmed below.
-  const startingOn = floorToMidnightUTC(cycleStart).toISOString();
+  // Period bounds are already UTC midnight (1st of month), so we query them
+  // directly. The request end is capped at the next midnight after `now` so we
+  // don't fetch the period's future days.
+  const startingOn = cycleStart.toISOString();
   const requestEnd = new Date(Math.min(cycleEndMs, Date.now()));
   const endingBefore = ceilToMidnightUTC(requestEnd).toISOString();
 
@@ -83,7 +82,7 @@ export async function fetchPerUserAwuUsage({
       billableMetricId: getMetricLlmProviderCostAwuId(),
       startingOn,
       endingBefore,
-      windowSize: "HOUR",
+      windowSize: "DAY",
       groupKey: ["user_id", USAGE_TYPE_GROUP_KEY],
       groupFilters: { [USAGE_TYPE_GROUP_KEY]: PAID_USAGE_TYPES },
     }),
@@ -92,7 +91,7 @@ export async function fetchPerUserAwuUsage({
       billableMetricId: getMetricToolInvocationsId(),
       startingOn,
       endingBefore,
-      windowSize: "HOUR",
+      windowSize: "DAY",
       groupKey: ["user_id", USAGE_TYPE_GROUP_KEY, "tool_category"],
       groupFilters: { [USAGE_TYPE_GROUP_KEY]: PAID_USAGE_TYPES },
     }),
@@ -104,18 +103,12 @@ export async function fetchPerUserAwuUsage({
     return new Err(toolResult.error);
   }
 
-  // Keep only hourly buckets that fall within the exact billing period.
-  const isInPeriod = (startingOnIso: string): boolean => {
-    const ts = new Date(startingOnIso).getTime();
-    return ts >= cycleStartMs && ts < cycleEndMs;
-  };
-
   const perUser = new Map<string, number>();
 
   // AI usage: the value is already AWU spend (cost_awu, priced 1:1).
   for (const entry of aiResult.value) {
     const userId = entry.group?.["user_id"];
-    if (!userId || entry.value === null || !isInPeriod(entry.startingOn)) {
+    if (!userId || entry.value === null) {
       continue;
     }
     perUser.set(userId, (perUser.get(userId) ?? 0) + entry.value);
@@ -130,8 +123,7 @@ export async function fetchPerUserAwuUsage({
       !userId ||
       entry.value === null ||
       !category ||
-      !isToolCategory(category) ||
-      !isInPeriod(entry.startingOn)
+      !isToolCategory(category)
     ) {
       continue;
     }


### PR DESCRIPTION
## Description

Simplifies `fetchPerUserAwuUsage` now that billing periods always start on the 1st of the month at UTC midnight.

The hourly aggregation was a workaround for **hour-precise** billing periods (contracts could be anchored mid-day, e.g. a period running 14:00→14:00). The Metronome usage endpoint requires UTC-midnight `starting_on`/`ending_before` bounds, so the code queried midnight-aligned bounds that *enclosed* the period with `window_size: "HOUR"`, then trimmed the hourly buckets falling outside the exact `[cycleStart, cycleEnd)` window.

Since periods are now always midnight-aligned, `cycleStart`/`cycleEnd` already satisfy the endpoint's constraints directly. So:

- Query `[cycleStart, cycleEnd)` directly with `window_size: "DAY"` (was `"HOUR"`).
- Drop the `isInPeriod` bucket-trimming logic and its call sites — every returned daily bucket falls inside the period by construction.
- Use `cycleStart` directly instead of `floorToMidnightUTC(cycleStart)` (now a no-op), and remove the unused `floorToMidnightUTC` import.

The request end is still capped at the next midnight after `now` so we don't fetch the period's future days.

## Tests

No behavioral change for midnight-aligned periods (the only kind that now exist), so no new tests. Type-checks clean (`tsgo --noEmit`).

## Risk

Low. Fewer, coarser buckets returned by Metronome and no client-side filtering. The result is identical for midnight-aligned periods. If a non-midnight-aligned period somehow existed, daily buckets at the edges could include out-of-period usage — but that's no longer a supported state. Safe to roll back (revert).

## Deploy Plan

Standard deploy, no migration or coordination required.
