### PR TITLE
[viz] prefetch canonical scoped file refs in shared frames

### DIFF
--- a/viz/app/content/ServerVisualizationWrapper.tsx
+++ b/viz/app/content/ServerVisualizationWrapper.tsx
@@ -25,11 +25,12 @@ async function fetchFileRefsRecursively(
       }
       visited.add(key);
 
-      // The files endpoint only accepts the "conversation/" and "pod/" prefixes.
-      // Older frame code may still reference the legacy "project/" prefix, which
-      // maps to the same Pod files. Rewrite only the request path; the prefetched
-      // file stays keyed by the original scopedPath (`key`) so the frame's
-      // useFile("project/...") lookup still resolves.
+      // The files endpoint accepts the "conversation/" and "pod/" prefixes (and
+      // their canonical "conversation-{id}/" / "pod-{id}/" forms), but not the
+      // legacy "project/" prefix, which older frame code may still reference and
+      // which maps to the same Pod files. Rewrite only the request path; the
+      // prefetched file stays keyed by the original scopedPath (`key`) so the
+      // frame's useFile("project/...") lookup still resolves.
       let requestPath: string;
       if (ref.type === "fileId") {
         requestPath = ref.fileId;

--- a/viz/app/lib/parseFileRefs.test.ts
+++ b/viz/app/lib/parseFileRefs.test.ts
@@ -53,6 +53,38 @@ describe("extractFileRefs", () => {
     ]);
   });
 
+  // Canonical, portable scopes are the form frame code is INSTRUCTED to use
+  // (bare `conversation/` and `pod/` are explicitly discouraged). These must be
+  // extracted so the public-share prefetch can fetch them.
+  it("extracts canonical conversation scope from useFile (conversation-{id}/)", () => {
+    const code = `const f = useFile("conversation-conv_123/report.csv");`;
+    expect(extractFileRefs(code)).toEqual([
+      { type: "path", scopedPath: "conversation-conv_123/report.csv" },
+    ]);
+  });
+
+  it("extracts canonical pod scope from string literals (pod-{id}/)", () => {
+    const code = `const path = "pod-pod_456/notes.md";`;
+    expect(extractFileRefs(code)).toEqual([
+      { type: "path", scopedPath: "pod-pod_456/notes.md" },
+    ]);
+  });
+
+  it("extracts canonical conversation scope from import specifiers", () => {
+    const code = `import MyFrame from "conversation-conv_123/MyFrame.tsx";`;
+    expect(extractFileRefs(code)).toEqual([
+      { type: "path", scopedPath: "conversation-conv_123/MyFrame.tsx" },
+    ]);
+  });
+
+  it("ignores canonical prefixes with an empty id", () => {
+    const code = `
+      const a = "conversation-/file.csv";
+      const b = "pod-/file.csv";
+    `;
+    expect(extractFileRefs(code)).toEqual([]);
+  });
+
   it("deduplicates refs across visitors", () => {
     const code = `
       function Comp() {

--- a/viz/app/lib/parseFileRefs.ts
+++ b/viz/app/lib/parseFileRefs.ts
@@ -6,12 +6,21 @@ export type FileRef =
   | { type: "path"; scopedPath: string };
 
 function isScopedPath(value: string): boolean {
-  return (
-    value.startsWith("conversation/") ||
-    value.startsWith("pod/") ||
-    // Legacy prefix, still used by older frame code.
-    value.startsWith("project/")
-  );
+  const slashIdx = value.indexOf("/");
+  if (slashIdx <= 0) {
+    return false;
+  }
+  const prefix = value.slice(0, slashIdx);
+
+  // Canonical, portable scopes are what frame code is instructed to use, e.g.
+  // `conversation-{conversationId}/report.csv` or `pod-{podId}/notes.md`. This mirrors the
+  // server contract in front's `parseRawVizScope`: the id after the prefix must be non-empty.
+  if (prefix.startsWith("conversation-") || prefix.startsWith("pod-")) {
+    return !prefix.endsWith("-");
+  }
+
+  // Legacy bare prefixes, still used by older frame code.
+  return prefix === "conversation" || prefix === "pod" || prefix === "project";
 }
 
 export function extractFileRefs(code: string): FileRef[] {

--- a/viz/app/lib/parseFileRefs.ts
+++ b/viz/app/lib/parseFileRefs.ts
@@ -5,6 +5,12 @@ export type FileRef =
   | { type: "fileId"; fileId: string }
   | { type: "path"; scopedPath: string };
 
+// Mirrors front's `parseRawVizScope` contract. Canonical scopes are `${PREFIX}-{id}/...`;
+// the bare prefixes are legacy forms still emitted by older frame code.
+const SCOPED_PREFIX_CONVERSATION = "conversation";
+const SCOPED_PREFIX_POD = "pod";
+const SCOPED_PREFIX_PROJECT = "project";
+
 function isScopedPath(value: string): boolean {
   const slashIdx = value.indexOf("/");
   if (slashIdx <= 0) {
@@ -15,12 +21,19 @@ function isScopedPath(value: string): boolean {
   // Canonical, portable scopes are what frame code is instructed to use, e.g.
   // `conversation-{conversationId}/report.csv` or `pod-{podId}/notes.md`. This mirrors the
   // server contract in front's `parseRawVizScope`: the id after the prefix must be non-empty.
-  if (prefix.startsWith("conversation-") || prefix.startsWith("pod-")) {
+  if (
+    prefix.startsWith(`${SCOPED_PREFIX_CONVERSATION}-`) ||
+    prefix.startsWith(`${SCOPED_PREFIX_POD}-`)
+  ) {
     return !prefix.endsWith("-");
   }
 
   // Legacy bare prefixes, still used by older frame code.
-  return prefix === "conversation" || prefix === "pod" || prefix === "project";
+  return (
+    prefix === SCOPED_PREFIX_CONVERSATION ||
+    prefix === SCOPED_PREFIX_POD ||
+    prefix === SCOPED_PREFIX_PROJECT
+  );
 }
 
 export function extractFileRefs(code: string): FileRef[] {


### PR DESCRIPTION
## Description

Data files referenced by a Frame failed to load when the Frame was opened via a public share link (`useFile` got nothing), while the same Frame worked in-conversation.

Shared frames render server-side and prefetch every file the frame references, since the sandbox can't call back to the host the way it does in-conversation. `extractFileRefs` / `isScopedPath` only recognized the legacy bare prefixes (`conversation/`, `pod/`, `project/`), but frame code is instructed to use the canonical `conversation-{id}/` and `pod-{id}/` form. Those refs were skipped during prefetch, so the cache was empty and `useFile` had nothing to return under a share link.

Fix recognizes the canonical hyphenated scopes (id must be non-empty), mirroring front's `parseRawVizScope` contract, and keeps the legacy bare prefixes working. Affects any publicly shared frame that references a file by the instructed scoped path; only bare `fil_` refs survived before.

## Tests

Added 4 unit tests in `parseFileRefs.test.ts` for the canonical `conversation-{id}/` and `pod-{id}/` forms (from `useFile` and import specifiers) plus empty-id rejection. Traced the full share path end to end against the frame that surfaced the bug (`useFile("conversation-zVLcQYIHQf/alan_weekly_messages.csv")`): server `parseRawVizScope` already resolves the hyphenated scope and the file carries the right `conversationId`, so the gap was only this client-side prefetch parser.

## Risk

Low. Widens which string literals get treated as scoped file refs (canonical hyphenated prefixes), no behavior removed. Easy rollback.

## Deploy Plan

Standard viz deploy. Existing shared frames start loading their data files once deployed, no regeneration needed.