### PR TITLE
[dust-hive] fix: hide selected envs from completions

### DIFF
--- a/x/henry/dust-hive/completions/dust-hive.bash
+++ b/x/henry/dust-hive/completions/dust-hive.bash
@@ -69,7 +69,34 @@ _dust_hive_envs() {
     result=("${envs[@]}")
   fi
 
-  printf '%s\n' "${result[@]}"
+  _dust_hive_filter_selected_envs "${result[@]}"
+}
+
+_dust_hive_env_already_selected() {
+  local candidate="${1:?usage: _dust_hive_env_already_selected <name>}"
+  local start=1
+  local comp_cword="${COMP_CWORD:-0}"
+  local i word
+
+  if [[ -n "${cmd_index:-}" ]] && (( cmd_index > 0 )); then
+    start=$(( cmd_index + 1 ))
+  fi
+
+  for (( i=start; i<comp_cword; i++ )); do
+    word="${COMP_WORDS[$i]}"
+    [[ "$word" == -* ]] && continue
+    [[ "$word" == "$candidate" ]] && return 0
+  done
+
+  return 1
+}
+
+_dust_hive_filter_selected_envs() {
+  local env
+
+  for env in "$@"; do
+    _dust_hive_env_already_selected "$env" || printf '%s\n' "$env"
+  done
 }
 
 _dust_hive_pid_is_running() {
@@ -174,7 +201,7 @@ _dust_hive_envs_by_states() {
     result=("${envs[@]}")
   fi
 
-  printf '%s\n' "${result[@]}"
+  _dust_hive_filter_selected_envs "${result[@]}"
 }
 
 _dust_hive_warmable_envs() {

--- a/x/henry/dust-hive/completions/dust-hive.zsh
+++ b/x/henry/dust-hive/completions/dust-hive.zsh
@@ -63,8 +63,29 @@ _dust_hive_envs() {
   _dust_hive_describe_envs "${envs[@]}"
 }
 
+_dust_hive_env_already_selected() {
+  local candidate="${1:?usage: _dust_hive_env_already_selected <name>}"
+  local i word
+
+  for (( i = 1; i < CURRENT; i++ )); do
+    word="${words[i]}"
+    [[ "$word" == -* ]] && continue
+    [[ "$word" == "$candidate" ]] && return 0
+  done
+
+  return 1
+}
+
 _dust_hive_describe_envs() {
   local -a envs=("$@")
+  (( $#envs )) || return
+
+  local env
+  local -a filtered_envs=()
+  for env in "${envs[@]}"; do
+    _dust_hive_env_already_selected "$env" || filtered_envs+=("$env")
+  done
+  envs=("${filtered_envs[@]}")
   (( $#envs )) || return
 
   local current


### PR DESCRIPTION
## Description

This PR prevents dust-hive shell completions from suggesting an environment that is already present in the current command line. Bash and zsh now filter completion candidates against previously selected positional args before returning env names, while keeping existing current-env ordering and state-aware filters.

Allows doing things like `dhc TAB TAB TAB`.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- No deploy.