### PR TITLE
[front] Add GitHub link for Matthieu Haguenauer on about page

### DIFF
--- a/front/components/home/content/shared/team.ts
+++ b/front/components/home/content/shared/team.ts
@@ -607,7 +607,7 @@ export const PEOPLE: Record<string, TeamMember> = {
     title: "Solution Engineer",
     image: "https://ca.slack-edge.com/T050RH73H9P-U0B5PBQBJG7-dec9667095f7-512",
     linkedIn: "https://www.linkedin.com/in/matthieu-haguenauer/",
-    github: "",
+    github: "https://github.com/matthieuhaguen",
   },
 };
 


### PR DESCRIPTION
## Description

- Adds GitHub profile link for Matthieu Haguenauer (`matthieuhaguen`) in the team data file

## Tests

- Visited dust.tt/home/about and verify the GitHub icon appears on Matthieu Haguenauer's card