### PR TITLE
[Poké] Rename credits section to API Usage

### DIFF
--- a/front/components/poke/credits/table.tsx
+++ b/front/components/poke/credits/table.tsx
@@ -92,7 +92,7 @@ export function CreditsDataTable({
   return (
     <>
       <PokeDataTableConditionalFetch<PokeCreditsData, PokeCreditsData>
-        header="Credits"
+        header="API Usage"
         owner={owner}
         loadOnInit={loadOnInit}
         useSWRHook={usePokeCredits}

--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -271,7 +271,7 @@ export function WorkspacePage() {
 
               <TabsTrigger value="triggers" label="Triggers" />
               <TabsTrigger value="webhooksources" label="Webhook Sources" />
-              <TabsTrigger value="credits" label="Credits" />
+              <TabsTrigger value="credits" label="API Usage" />
               <TabsTrigger value="analytics" label="Analytics" />
             </TabsList>
 


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/8237

Rename the Poke workspace "Credits" tab and matching section header to "API Usage" so the view is not confused with the workspace credits system.

## Risks
Blast radius: Poke workspace navigation and API usage section header only.
Risk: low

## Deploy Plan
- pmrr
- deploy front