### PR TITLE
[front] fix: scroll to first instruction reference

### DIFF
--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -136,6 +136,10 @@ function getFirstReferencePosition(
   let referencePosition: number | null = null;
 
   editor.state.doc.descendants((node, position) => {
+    if (referencePosition !== null) {
+      return false;
+    }
+
     if (matchesReferenceTarget(node, target)) {
       referencePosition = position;
       return false;


### PR DESCRIPTION
## Description

Follow up on https://github.com/dust-tt/dust/pull/26590.

This PR fixes reference summary chip clicks when the same knowledge, skill, or tool reference appears multiple times in the instructions. ProseMirror `descendants` keeps visiting sibling nodes after a callback returns `false`, so the previous implementation could overwrite the first match with a later one. The traversal now stops updating once the first matching position has been found.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
