### PR TITLE
Remove positive check for price

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/grant_awu_credits.ts
+++ b/front/lib/api/poke/plugins/workspaces/grant_awu_credits.ts
@@ -34,11 +34,7 @@ const GrantAwuCreditsArgsSchema = z
       .finite("Amount must be a valid number"),
     isFreeCredit: z.boolean(),
     setPrice: z.boolean(),
-    price: z
-      .number()
-      .positive("Price must be greater than 0")
-      .finite("Price must be a valid number")
-      .optional(),
+    price: z.number().finite("Price must be a valid number").optional(),
     overrideDiscount: z.boolean(),
     discountPercent: z
       .number()


### PR DESCRIPTION
## Description

Removes the field-level `.positive()` constraint on the `price` field in the `GrantAwuCreditsArgsSchema` within the Grant AWU Credits poke plugin. The cross-field `.refine()` already validates that `price > 0` when `setPrice` is enabled (with a more contextual error message), making the redundant field-level positive check unnecessary and potentially causing conflicting validation errors.

## Tests

Manual testing via the Poke UI: verify the "Set Price" path still rejects a zero or missing price when the toggle is enabled, and that valid prices are accepted as before.

## Risk

Low. The effective validation behaviour is unchanged — the cross-field `refine` still enforces `price > 0` when `setPrice` is true. Only the redundant field-level constraint is removed.

## Deploy Plan

Deploy `front`.