### PR TITLE
Hide dollar monthly cap on API keys

### DIFF
--- a/front/components/pages/workspace/developers/APIKeysPage.tsx
+++ b/front/components/pages/workspace/developers/APIKeysPage.tsx
@@ -4,13 +4,14 @@ import { EditKeyCapDialog } from "@app/components/workspace/api-keys/EditKeyCapD
 import { NewAPIKeyDialog } from "@app/components/workspace/api-keys/NewAPIKeyDialog";
 import type { KeyRole } from "@app/components/workspace/api-keys/utils";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { useWorkspace } from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
 import { useKeys } from "@app/lib/swr/apps";
 import { useGroups } from "@app/lib/swr/groups";
 import type { GroupType } from "@app/types/groups";
 import type { KeyType } from "@app/types/key";
+import { isCreditPricedPlan } from "@app/types/plan";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { WorkspaceType } from "@app/types/user";
 import {
@@ -30,6 +31,8 @@ interface APIKeysProps {
 
 export function APIKeys({ owner }: APIKeysProps) {
   const { mutate } = useSWRConfig();
+  const { subscription } = useAuth();
+  const showLegacyUsdMonthlyCap = !isCreditPricedPlan(subscription.plan);
   const [isNewApiKeyCreatedOpen, setIsNewApiKeyCreatedOpen] = useState(false);
   const [editCapKey, setEditCapKey] = useState<KeyType | null>(null);
 
@@ -167,6 +170,7 @@ export function APIKeys({ owner }: APIKeysProps) {
           isGenerating={isGenerating}
           isRevoking={isRevoking}
           onCreate={handleGenerate}
+          showLegacyUsdMonthlyCap={showLegacyUsdMonthlyCap}
         />
       </Page.Horizontal>
       <APIKeysList
@@ -176,8 +180,9 @@ export function APIKeys({ owner }: APIKeysProps) {
         isGenerating={isGenerating}
         onRevoke={handleRevoke}
         onEditCap={setEditCapKey}
+        showLegacyUsdMonthlyCap={showLegacyUsdMonthlyCap}
       />
-      {editCapKey && (
+      {showLegacyUsdMonthlyCap && editCapKey && (
         <EditKeyCapDialog
           keyData={editCapKey}
           isOpen={!!editCapKey}

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -18,6 +18,7 @@ type APIKeysListProps = {
   isGenerating: boolean;
   onRevoke: (key: KeyType) => Promise<void>;
   onEditCap: (key: KeyType) => void;
+  showLegacyUsdMonthlyCap: boolean;
 };
 
 const getKeySpaces = (
@@ -53,6 +54,7 @@ export const APIKeysList = ({
   isGenerating,
   onRevoke,
   onEditCap,
+  showLegacyUsdMonthlyCap,
 }: APIKeysListProps) => {
   return (
     <div className="space-y-4 divide-y divide-gray-200 dark:divide-gray-200-night">
@@ -111,19 +113,21 @@ export const APIKeysList = ({
                       >
                         Scope: <strong>{formatKeyScope(key.role)}</strong>
                       </p>
-                      <p
-                        className={cn(
-                          "truncate font-mono text-sm",
-                          "text-muted-foreground dark:text-muted-foreground-night"
-                        )}
-                      >
-                        Monthly cap:{" "}
-                        <strong>
-                          {key.monthlyCapMicroUsd !== null
-                            ? `$${(key.monthlyCapMicroUsd / 1_000_000).toFixed(2)}`
-                            : "Unlimited"}
-                        </strong>
-                      </p>
+                      {showLegacyUsdMonthlyCap && (
+                        <p
+                          className={cn(
+                            "truncate font-mono text-sm",
+                            "text-muted-foreground dark:text-muted-foreground-night"
+                          )}
+                        >
+                          Monthly cap:{" "}
+                          <strong>
+                            {key.monthlyCapMicroUsd !== null
+                              ? `$${(key.monthlyCapMicroUsd / 1_000_000).toFixed(2)}`
+                              : "Unlimited"}
+                          </strong>
+                        </p>
+                      )}
                       <pre className="text-sm">{key.secret}</pre>
                       <p
                         className={cn(
@@ -161,12 +165,14 @@ export const APIKeysList = ({
               </div>
               {key.status === "active" ? (
                 <div className="flex gap-2">
-                  <Button
-                    variant="outline"
-                    disabled={isRevoking || isGenerating}
-                    onClick={() => onEditCap(key)}
-                    label="Edit cap"
-                  />
+                  {showLegacyUsdMonthlyCap && (
+                    <Button
+                      variant="outline"
+                      disabled={isRevoking || isGenerating}
+                      onClick={() => onEditCap(key)}
+                      label="Edit cap"
+                    />
+                  )}
                   <Button
                     variant="warning"
                     disabled={isRevoking || isGenerating}

--- a/front/components/workspace/api-keys/NewAPIKeyDialog.tsx
+++ b/front/components/workspace/api-keys/NewAPIKeyDialog.tsx
@@ -56,6 +56,7 @@ interface NewAPIKeyDialogProps {
     monthlyCapMicroUsd: number | null;
     role: KeyRole;
   }) => Promise<void>;
+  showLegacyUsdMonthlyCap: boolean;
 }
 
 export const NewAPIKeyDialog = ({
@@ -63,6 +64,7 @@ export const NewAPIKeyDialog = ({
   isGenerating,
   isRevoking,
   onCreate,
+  showLegacyUsdMonthlyCap,
 }: NewAPIKeyDialogProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [spaceSearch, setSpaceSearch] = useState("");
@@ -285,22 +287,24 @@ export const NewAPIKeyDialog = ({
                 </RadioGroup>
               </div>
 
-              <BaseFormFieldSection
-                title="Monthly cap (USD)"
-                fieldName="monthlyCapDollars"
-              >
-                {({ registerRef, registerProps, onChange, errorMessage }) => (
-                  <Input
-                    ref={registerRef}
-                    {...registerProps}
-                    onChange={onChange}
-                    placeholder="Leave empty for unlimited"
-                    isError={!!errorMessage}
-                    message={errorMessage}
-                    messageStatus="error"
-                  />
-                )}
-              </BaseFormFieldSection>
+              {showLegacyUsdMonthlyCap && (
+                <BaseFormFieldSection
+                  title="Monthly cap (USD)"
+                  fieldName="monthlyCapDollars"
+                >
+                  {({ registerRef, registerProps, onChange, errorMessage }) => (
+                    <Input
+                      ref={registerRef}
+                      {...registerProps}
+                      onChange={onChange}
+                      placeholder="Leave empty for unlimited"
+                      isError={!!errorMessage}
+                      message={errorMessage}
+                      messageStatus="error"
+                    />
+                  )}
+                </BaseFormFieldSection>
+              )}
             </div>
           </FormProvider>
         </SheetContainer>

--- a/front/lib/api/programmatic_usage/tracking.ts
+++ b/front/lib/api/programmatic_usage/tracking.ts
@@ -86,17 +86,20 @@ export async function checkProgrammaticUsageLimits(
     );
   }
 
-  // Then check per-key cap.
-  const keyCapReached = await hasKeyReachedUsageCap(auth);
-  if (keyCapReached) {
-    const message = isAdmin
-      ? "This API key has reached its monthly usage cap. " +
-        "Please increase the cap in the Developers > API Keys section of the Dust dashboard."
-      : "This API key has reached its monthly usage cap. " +
-        "Please ask a Dust workspace admin to increase the cap.";
-    return new Err(
-      new ProgrammaticUsageLimitError("rate_limit_error", message)
-    );
+  // Then check per-key cap (not applicable to credit-priced/Metronome plans).
+  const plan = auth.subscription()?.plan;
+  if (!plan || !isCreditPricedPlan(plan)) {
+    const keyCapReached = await hasKeyReachedUsageCap(auth);
+    if (keyCapReached) {
+      const message = isAdmin
+        ? "This API key has reached its monthly usage cap. " +
+          "Please increase the cap in the Developers > API Keys section of the Dust dashboard."
+        : "This API key has reached its monthly usage cap. " +
+          "Please ask a Dust workspace admin to increase the cap.";
+      return new Err(
+        new ProgrammaticUsageLimitError("rate_limit_error", message)
+      );
+    }
   }
 
   // Finally check daily cap.


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/8466

When using metronome pricing we cannot currently set a limit to the API key.
Actual implementation will be done later.

## Tests

### Before

<img width="2412" height="798" alt="image" src="https://github.com/user-attachments/assets/39e88e25-2869-4bf8-b189-79226d2220de" />

<img width="550" height="550" alt="image" src="https://github.com/user-attachments/assets/2d798af9-93be-48dd-ab35-1ad787e3c6aa" />


### After

<img width="2182" height="676" alt="image" src="https://github.com/user-attachments/assets/13b4cb76-4649-4dbb-ac82-8374dbc0cdcf" />

<img width="500" height="450" alt="image" src="https://github.com/user-attachments/assets/2a425207-61a4-4d42-b1dc-2fd6f30d1706" />


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
