### PR TITLE
[front] fix: track nested skill references in builder form

### DIFF
--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -5,7 +5,6 @@ import {
 } from "@app/lib/models/skill";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
-import { serializeSkillTag } from "@app/lib/skills/format";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
@@ -358,10 +357,12 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
     const childSkill = await SkillFactory.create(requestUserAuth, {
       name: "Referenced Skill",
     });
-    const skillReferenceTag =
-      SkillFactory.serializeSkillReferenceTag(childSkill);
-    const instructionsWithReference = `Use ${skillReferenceTag} for deeper analysis.`;
-    const buildBody = (instructions: string) => ({
+    const instructionsWithReference =
+      "Use the referenced skill for deeper analysis.";
+    const buildBody = (
+      instructions: string,
+      referencedSkillIds?: string[]
+    ) => ({
       name: skill.name,
       agentFacingDescription: skill.agentFacingDescription,
       userFacingDescription: skill.userFacingDescription,
@@ -370,12 +371,13 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
       tools: [],
       attachedKnowledge: [],
       instructionsHtml: null,
+      ...(referencedSkillIds !== undefined ? { referencedSkillIds } : {}),
     });
 
     const disabledResponse = await patchSkill(
       workspace,
       skill.sId,
-      buildBody(instructionsWithReference)
+      buildBody(instructionsWithReference, [childSkill.sId])
     );
     expect(disabledResponse.status).toBe(200);
     const skillWithoutFeatureFlag = await SkillResource.fetchById(
@@ -392,7 +394,7 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
     const enabledResponse = await patchSkill(
       workspace,
       skill.sId,
-      buildBody(instructionsWithReference)
+      buildBody(instructionsWithReference, [childSkill.sId])
     );
     expect(enabledResponse.status).toBe(200);
     const skillWithReference = await SkillResource.fetchById(
@@ -411,7 +413,7 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
     const removeResponse = await patchSkill(
       workspace,
       skill.sId,
-      buildBody("No nested skill references here.")
+      buildBody("No nested skill references here.", [])
     );
     expect(removeResponse.status).toBe(200);
     const skillWithoutReference = await SkillResource.fetchById(
@@ -424,7 +426,7 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
     ).resolves.toHaveLength(0);
   });
 
-  it("returns 400 for out-of-workspace nested skill references", async () => {
+  it("drops missing nested skill references", async () => {
     const { workspace, skill, requestUserAuth } = await setupTest({
       requestUserRole: "admin",
     });
@@ -434,30 +436,70 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
       id: skill.id + 1,
       workspaceId: workspace.id + 1,
     });
-    const outOfWorkspaceSkillReferenceTag = serializeSkillTag({
-      id: outOfWorkspaceSkillId,
-      icon: null,
-      name: "Other Workspace Skill",
-    });
 
     const response = await patchSkill(workspace, skill.sId, {
       name: skill.name,
       agentFacingDescription: skill.agentFacingDescription,
       userFacingDescription: skill.userFacingDescription,
-      instructions: `Use ${outOfWorkspaceSkillReferenceTag}.`,
+      instructions: "Use the other workspace skill.",
       icon: null,
       tools: [],
       attachedKnowledge: [],
+      referencedSkillIds: [outOfWorkspaceSkillId],
       instructionsHtml: null,
     });
 
-    expect(response.status).toBe(400);
-    expect(await response.json()).toEqual({
-      error: {
-        type: "invalid_request_error",
-        message: `Skill reference ID does not belong to this workspace: ${outOfWorkspaceSkillId}`,
-      },
+    expect(response.status).toBe(200);
+
+    const updatedSkill = await SkillResource.fetchById(
+      requestUserAuth,
+      skill.sId
+    );
+    expect(updatedSkill).not.toBeNull();
+
+    await expect(
+      updatedSkill!.fetchChildSkills(requestUserAuth)
+    ).resolves.toHaveLength(0);
+  });
+
+  it("keeps unavailable nested skill references when child spaces are not readable", async () => {
+    const { workspace, skill, requestUserAuth } = await setupTest({
+      requestUserRole: "admin",
     });
+
+    await FeatureFlagFactory.basic(requestUserAuth, "nested_skills");
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    const childSkill = await SkillFactory.create(requestUserAuth, {
+      name: "Restricted Child Skill",
+      requestedSpaceIds: [restrictedSpace.id],
+    });
+
+    await expect(
+      SkillResource.fetchById(requestUserAuth, childSkill.sId)
+    ).resolves.toBeNull();
+
+    const response = await patchSkill(workspace, skill.sId, {
+      name: skill.name,
+      agentFacingDescription: skill.agentFacingDescription,
+      userFacingDescription: skill.userFacingDescription,
+      instructions: `Use ${SkillFactory.serializeSkillReferenceTag(childSkill)}.`,
+      icon: null,
+      tools: [],
+      attachedKnowledge: [],
+      referencedSkillIds: [childSkill.sId],
+      instructionsHtml: null,
+    });
+
+    expect(response.status).toBe(200);
+
+    const updatedSkill = await SkillResource.fetchById(
+      requestUserAuth,
+      skill.sId
+    );
+    expect(updatedSkill).not.toBeNull();
+    expect(updatedSkill!.instructions).toContain(
+      `<unavailable_skill id="${childSkill.sId}" />`
+    );
   });
 
   it("should update requestedSpaceIds when adding a tool from a new space", async () => {

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -68,6 +68,7 @@ const PatchSkillRequestBodySchema = z.object({
   attachedKnowledge: z.array(AttachedKnowledgeSchema),
   instructionsHtml: z.string().nullable(),
   additionalRequestedSpaceIds: z.array(z.string()).optional(),
+  referencedSkillIds: z.array(z.string()).optional(),
   fileAttachments: z.array(z.object({ fileId: z.string() })).optional(),
   isDefault: z.boolean().optional(),
   reinforcement: z.enum(["auto", "on", "off"]).optional(),
@@ -342,23 +343,11 @@ app.patch(
 
     const featureFlags = await getFeatureFlags(auth);
     const enableSkillReferences = featureFlags.includes("nested_skills");
-    if (enableSkillReferences) {
-      const skillReferenceValidation =
-        SkillResource.getValidatedSkillReferenceModelIds(auth, {
-          instructions: body.instructions,
-          parentSkillId: skill.id,
-        });
-
-      if (skillReferenceValidation.isErr()) {
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: skillReferenceValidation.error.message,
-          },
-        });
-      }
-    }
+    const referencedSkillIds = uniq(
+      (body.referencedSkillIds ?? []).filter(
+        (referencedSkillId) => referencedSkillId !== skill.sId
+      )
+    );
 
     // Validate file attachments if provided (gated behind sandbox_tools).
     let files: FileResource[] | undefined;
@@ -427,6 +416,7 @@ app.patch(
       reinforcement: body.reinforcement,
       requestedSpaceIds,
       enableSkillReferences,
+      referencedSkillIds,
       userFacingDescription: body.userFacingDescription,
       ...(shouldActivate ? { status: "active" as const } : {}),
     });

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -3,7 +3,6 @@ import { SkillMCPServerConfigurationModel } from "@app/lib/models/skill";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { discoverToolsSkill } from "@app/lib/resources/skill/code_defined/discover_tools";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import { serializeSkillTag } from "@app/lib/skills/format";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
@@ -650,18 +649,17 @@ describe("POST /api/w/:wId/skills", () => {
     const childSkill = await SkillFactory.create(auth, {
       name: "Referenced Skill",
     });
-    const skillReferenceTag =
-      SkillFactory.serializeSkillReferenceTag(childSkill);
 
     const response = await postSkill(workspace, {
       name: "Parent Skill",
       agentFacingDescription: "To use with another skill",
       userFacingDescription: "A skill with a nested reference",
-      instructions: `Start with ${skillReferenceTag}.`,
+      instructions: "Start with the referenced skill.",
       icon: "PuzzleIcon",
       tools: [],
       extendedSkillId: null,
       attachedKnowledge: [],
+      referencedSkillIds: [childSkill.sId],
       instructionsHtml: null,
     });
 
@@ -680,35 +678,31 @@ describe("POST /api/w/:wId/skills", () => {
     ]);
   });
 
-  it("returns 400 for invalid nested skill references", async () => {
+  it("drops missing nested skill references", async () => {
     const { auth, workspace } = await setupTest("admin");
 
     await FeatureFlagFactory.basic(auth, "nested_skills");
-    const invalidSkillReferenceTag = serializeSkillTag({
-      id: "not-a-skill-reference",
-      icon: null,
-      name: "Invalid Skill Reference",
-    });
 
     const response = await postSkill(workspace, {
       name: "Parent Skill",
       agentFacingDescription: "To use with another skill",
       userFacingDescription: "A skill with an invalid nested reference",
-      instructions: `Start with ${invalidSkillReferenceTag}.`,
+      instructions: "Start with an invalid nested reference.",
       icon: "PuzzleIcon",
       tools: [],
       extendedSkillId: null,
       attachedKnowledge: [],
+      referencedSkillIds: ["not-a-skill-reference"],
       instructionsHtml: null,
     });
 
-    expect(response.status).toBe(400);
-    expect(await response.json()).toEqual({
-      error: {
-        type: "invalid_request_error",
-        message: "Invalid skill reference ID: not-a-skill-reference",
-      },
-    });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    const createdSkill = await SkillResource.fetchById(auth, data.skill.sId);
+    expect(createdSkill).not.toBeNull();
+
+    await expect(createdSkill!.fetchChildSkills(auth)).resolves.toHaveLength(0);
   });
 
   it("creates a skill configuration with additional requested spaces", async () => {

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -69,6 +69,7 @@ const PostSkillRequestBodySchema = z.intersection(
     attachedKnowledge: z.array(AttachedKnowledgeSchema),
     instructionsHtml: z.string().nullable(),
     additionalRequestedSpaceIds: z.array(z.string()).optional(),
+    referencedSkillIds: z.array(z.string()).optional(),
     fileAttachments: z.array(z.object({ fileId: z.string() })).optional(),
     isDefault: z.boolean().optional(),
     reinforcement: z.enum(SKILL_REINFORCEMENT_MODES).optional(),
@@ -371,22 +372,7 @@ app.post(
 
     const featureFlags = await getFeatureFlags(auth);
     const enableSkillReferences = featureFlags.includes("nested_skills");
-    if (enableSkillReferences) {
-      const skillReferenceValidation =
-        SkillResource.getValidatedSkillReferenceModelIds(auth, {
-          instructions: body.instructions,
-        });
-
-      if (skillReferenceValidation.isErr()) {
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: skillReferenceValidation.error.message,
-          },
-        });
-      }
-    }
+    const referencedSkillIds = uniq(body.referencedSkillIds ?? []);
 
     // Validate file attachments if provided (gated behind sandbox_tools).
     let files: FileResource[] | undefined;
@@ -471,6 +457,7 @@ app.post(
         attachedKnowledge: attachedKnowledgeWithDataSourceViews,
         fileAttachments: files,
         enableSkillReferences,
+        referencedSkillIds,
       }
     );
 

--- a/front/components/editor/SkillInstructionsEditor.tsx
+++ b/front/components/editor/SkillInstructionsEditor.tsx
@@ -1,4 +1,5 @@
 import { AgentInstructionDiffExtension } from "@app/components/editor/extensions/agent_builder/AgentInstructionDiffExtension";
+import type { SlashCommandSkillSuggestion } from "@app/components/editor/extensions/shared/SlashCommandSkillItems";
 import { KNOWLEDGE_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
 import type { KnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
 import { SlashCommandExtension } from "@app/components/editor/extensions/skill_builder/SlashCommandExtension";
@@ -98,6 +99,7 @@ function useEditorService(
 interface SkillInstructionsSkillReferencesOptions {
   currentSkillId?: string | null;
   enableSkillReferences: boolean;
+  onSelectSkill?: (skill: SlashCommandSkillSuggestion) => void;
   onSelectTool?: (tool: MCPServerViewType) => void;
   owner?: LightWorkspaceType;
 }
@@ -115,11 +117,13 @@ interface UseSkillInstructionsEditorProps {
 function buildSkillInstructionsEditableExtensions({
   currentSkillId,
   includeSkillSuggestions,
+  onSelectSkill,
   onSelectTool,
   owner,
 }: {
   currentSkillId?: string | null;
   includeSkillSuggestions: boolean;
+  onSelectSkill?: (skill: SlashCommandSkillSuggestion) => void;
   onSelectTool?: (tool: MCPServerViewType) => void;
   owner?: LightWorkspaceType;
 }) {
@@ -127,6 +131,7 @@ function buildSkillInstructionsEditableExtensions({
     SlashCommandExtension.configure({
       currentSkillId: currentSkillId ?? null,
       includeSkillSuggestions,
+      onSelectSkill,
       onSelectTool,
       owner,
     }),
@@ -153,6 +158,7 @@ export function useSkillInstructionsEditor({
 }: UseSkillInstructionsEditorProps) {
   const enableSkillReferences = skillReferences?.enableSkillReferences === true;
   const currentSkillId = skillReferences?.currentSkillId ?? null;
+  const onSelectSkill = skillReferences?.onSelectSkill;
   const onSelectTool = skillReferences?.onSelectTool;
   const owner = skillReferences?.owner;
   const includeSkillSuggestions = enableSkillReferences && !!owner;
@@ -161,10 +167,17 @@ export function useSkillInstructionsEditor({
       buildSkillInstructionsEditableExtensions({
         currentSkillId,
         includeSkillSuggestions,
+        onSelectSkill,
         onSelectTool,
         owner,
       }),
-    [currentSkillId, includeSkillSuggestions, onSelectTool, owner]
+    [
+      currentSkillId,
+      includeSkillSuggestions,
+      onSelectSkill,
+      onSelectTool,
+      owner,
+    ]
   );
 
   const extensions = useMemo(

--- a/front/components/editor/extensions/shared/SlashCommandSkillItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandSkillItems.ts
@@ -7,7 +7,7 @@ export const SELECT_SKILL_SLASH_COMMAND_ACTION = "select-skill";
 
 export type SlashCommandSkillSuggestion = Pick<
   SkillWithoutInstructionsAndToolsType,
-  "icon" | "name" | "sId" | "userFacingDescription"
+  "icon" | "name" | "requestedSpaceIds" | "sId" | "userFacingDescription"
 >;
 
 export function matchesSlashCommandQuery({
@@ -75,11 +75,7 @@ export function getSkillSlashCommandItem(
   return {
     action: SELECT_SKILL_SLASH_COMMAND_ACTION,
     data: {
-      skill: {
-        icon: skill.icon,
-        id: skill.sId,
-        name: skill.name,
-      },
+      skill,
     },
     description: skill.userFacingDescription,
     icon: getSkillAvatarIcon(skill.icon),

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -1,3 +1,4 @@
+import type { SlashCommandSkillSuggestion } from "@app/components/editor/extensions/shared/SlashCommandSkillItems";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import {
   cn,
@@ -41,11 +42,7 @@ const EMPTY_SCROLL_FADE_STATE: ScrollFadeState = {
 export interface SlashCommand {
   action: string;
   data?: {
-    skill?: {
-      icon?: string | null;
-      id: string;
-      name: string;
-    };
+    skill?: SlashCommandSkillSuggestion;
     tool?: {
       icon: string | null;
       id: string;

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.test.ts
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.test.ts
@@ -15,11 +15,13 @@ const attachKnowledgeItem: SlashCommand = {
 
 const skillSuggestion = ({
   icon = null,
+  requestedSpaceIds = [],
   userFacingDescription = "",
   ...skill
 }: Pick<SlashCommandSkillSuggestion, "name" | "sId"> &
   Partial<SlashCommandSkillSuggestion>): SlashCommandSkillSuggestion => ({
   icon,
+  requestedSpaceIds,
   userFacingDescription,
   ...skill,
 });
@@ -113,8 +115,9 @@ describe("buildSkillBuilderSlashCommandItems", () => {
       data: {
         skill: {
           icon: null,
-          id: "skill_create_memo",
           name: "Create memo",
+          requestedSpaceIds: [],
+          sId: "skill_create_memo",
         },
       },
       description: "Draft structured memos.",

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
@@ -313,6 +313,7 @@ SkillBuilderSlashCommandDropdown.displayName =
 export interface SlashCommandExtensionOptions {
   currentSkillId?: string | null;
   includeSkillSuggestions: boolean;
+  onSelectSkill?: (skill: SlashCommandSkillSuggestion) => void;
   onSelectTool?: (tool: MCPServerViewType) => void;
   owner?: LightWorkspaceType;
   suggestion: Partial<SuggestionOptions>;
@@ -348,6 +349,7 @@ export const SlashCommandExtension =
       return {
         currentSkillId: null,
         includeSkillSuggestions: false,
+        onSelectSkill: undefined,
         onSelectTool: undefined,
         owner: undefined,
         suggestion: {
@@ -419,11 +421,12 @@ export const SlashCommandExtension =
                   .focus()
                   .deleteRange(range)
                   .insertSkillNode({
-                    skillId: skill.id,
+                    skillId: skill.sId,
                     skillIcon: skill.icon,
                     skillName: skill.name,
                   })
                   .run();
+                extensionOptions.onSelectSkill?.(skill);
               }
             } else if (props.action === SELECT_TOOL_SLASH_COMMAND_ACTION) {
               const tool = props.data?.tool;

--- a/front/components/skill_builder/SkillBuilderFormContext.tsx
+++ b/front/components/skill_builder/SkillBuilderFormContext.tsx
@@ -1,5 +1,8 @@
 import { actionSchema } from "@app/components/shared/tools_picker/types";
-import { SKILL_REINFORCEMENT_MODES } from "@app/types/assistant/skill_configuration";
+import {
+  SKILL_REINFORCEMENT_MODES,
+  SkillWithoutInstructionsAndToolsSchema,
+} from "@app/types/assistant/skill_configuration";
 import { editorUserSchema } from "@app/types/editors";
 import { createContext } from "react";
 import type { UseFormReturn } from "react-hook-form";
@@ -14,6 +17,21 @@ export const attachedKnowledgeSchema = z.object({
   title: z.string(),
 });
 export type AttachedKnowledgeFormData = z.infer<typeof attachedKnowledgeSchema>;
+
+const {
+  sId: skillIdSchema,
+  name: skillNameSchema,
+  icon: skillIconSchema,
+  requestedSpaceIds: skillRequestedSpaceIdsSchema,
+} = SkillWithoutInstructionsAndToolsSchema.shape;
+
+export const referencedSkillSchema = z.object({
+  id: skillIdSchema,
+  name: skillNameSchema,
+  icon: skillIconSchema,
+  requestedSpaceIds: skillRequestedSpaceIdsSchema,
+});
+export type ReferencedSkillFormData = z.infer<typeof referencedSkillSchema>;
 
 const fileAttachmentSchema = z.object({
   fileId: z.string(),
@@ -43,6 +61,8 @@ export const skillBuilderFormSchema = z.object({
   reinforcement: z.enum(SKILL_REINFORCEMENT_MODES),
   fileAttachments: z.array(fileAttachmentSchema),
   attachedKnowledge: z.array(attachedKnowledgeSchema).optional(),
+  referencedSkills: z.array(referencedSkillSchema),
+  referencedSkillIds: z.array(z.string()),
   additionalSpaces: z.array(z.string()),
 });
 

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -1,6 +1,7 @@
 import { getDefaultMCPAction } from "@app/components/agent_builder/types";
 import { editorVariants } from "@app/components/editor/editorStyles";
 import { SKILL_NODE_TYPE } from "@app/components/editor/extensions/input_bar/SkillNode";
+import type { SlashCommandSkillSuggestion } from "@app/components/editor/extensions/shared/SlashCommandSkillItems";
 import { KNOWLEDGE_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
 import type { KnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
 import { TOOL_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/ToolNode";
@@ -10,7 +11,10 @@ import {
 } from "@app/components/editor/SkillInstructionsEditor";
 import { SKILL_BUILDER_INSTRUCTIONS_BLUR_EVENT } from "@app/components/skill_builder/events";
 import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
-import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
+import type {
+  ReferencedSkillFormData,
+  SkillBuilderFormData,
+} from "@app/components/skill_builder/SkillBuilderFormContext";
 import {
   type ReferenceSummaryTarget,
   SkillBuilderInstructionsReferenceSummary,
@@ -42,6 +46,8 @@ import { useController, useFormContext } from "react-hook-form";
 const INSTRUCTIONS_FIELD_NAME = "instructions";
 const INSTRUCTIONS_HTML_FIELD_NAME = "instructionsHtml";
 const ATTACHED_KNOWLEDGE_FIELD_NAME = "attachedKnowledge";
+const REFERENCED_SKILLS_FIELD_NAME = "referencedSkills";
+const REFERENCED_SKILL_IDS_FIELD_NAME = "referencedSkillIds";
 const BASE_ALLOWED_INSTRUCTIONS_TAGS = ["knowledge"];
 const BASE_ALLOWED_INSTRUCTIONS_ATTRS = ["space", "dsv", "hasChildren"];
 const SKILL_REFERENCE_ALLOWED_TAGS = [
@@ -174,6 +180,28 @@ function scrollReferenceIntoView({
   });
 }
 
+function collectSkillReferenceIds(editor: Editor): Set<string> {
+  const skillIds = new Set<string>();
+
+  editor.state.doc.descendants((node) => {
+    if (node.type.name === SKILL_NODE_TYPE && isString(node.attrs?.skillId)) {
+      skillIds.add(node.attrs.skillId);
+    }
+  });
+
+  return skillIds;
+}
+
+function haveSameSkillReferenceIds(
+  currentIds: readonly string[],
+  nextIds: ReadonlySet<string>
+): boolean {
+  return (
+    currentIds.length === nextIds.size &&
+    currentIds.every((skillId) => nextIds.has(skillId))
+  );
+}
+
 function toAttachedKnowledge(
   items: readonly KnowledgeItem[]
 ): SkillBuilderFormData["attachedKnowledge"] {
@@ -183,6 +211,17 @@ function toAttachedKnowledge(
     spaceId: item.spaceId,
     title: item.label,
   }));
+}
+
+function toReferencedSkill(
+  skill: SlashCommandSkillSuggestion
+): ReferencedSkillFormData {
+  return {
+    id: skill.sId,
+    name: skill.name,
+    icon: skill.icon,
+    requestedSpaceIds: skill.requestedSpaceIds,
+  };
 }
 
 function sanitizeSkillInstructionsHtml(
@@ -217,7 +256,14 @@ export function SkillBuilderInstructionsEditor({
   const initializedAttachedKnowledgeEditorRef = useRef<Editor | null>(null);
   const instructionReferenceSummaryRef = useRef<HTMLDivElement | null>(null);
   const previousInlineToolIdsRef = useRef<Set<string>>(new Set());
+  const previousInlineSkillIdsRef = useRef<Set<string>>(new Set());
   const toolsRef = useRef<SkillBuilderFormData["tools"]>([]);
+  const referencedSkillsRef = useRef<SkillBuilderFormData["referencedSkills"]>(
+    []
+  );
+  const referencedSkillIdsRef = useRef<
+    SkillBuilderFormData["referencedSkillIds"]
+  >([]);
   const { owner, skillId, selectedSuggestionId, setAcceptInstructionEdits } =
     useSkillBuilderContext();
   const { hasFeature } = useFeatureFlags();
@@ -252,17 +298,41 @@ export function SkillBuilderInstructionsEditor({
     name: "tools",
   });
 
+  const {
+    field: { onChange: onReferencedSkillsChange, value: referencedSkills },
+  } = useController<SkillBuilderFormData, typeof REFERENCED_SKILLS_FIELD_NAME>({
+    name: REFERENCED_SKILLS_FIELD_NAME,
+  });
+
+  const {
+    field: { onChange: onReferencedSkillIdsChange, value: referencedSkillIds },
+  } = useController<
+    SkillBuilderFormData,
+    typeof REFERENCED_SKILL_IDS_FIELD_NAME
+  >({
+    name: REFERENCED_SKILL_IDS_FIELD_NAME,
+  });
+
   useEffect(() => {
     toolsRef.current = tools;
   }, [tools]);
+
+  useEffect(() => {
+    referencedSkillsRef.current = referencedSkills;
+  }, [referencedSkills]);
+
+  useEffect(() => {
+    referencedSkillIdsRef.current = referencedSkillIds;
+  }, [referencedSkillIds]);
 
   const displayError =
     !!instructionsFieldState.error || !!attachedKnowledgeFieldState.error;
   const hasInstructionReferenceSummary =
     enableSkillReferences &&
     ((attachedKnowledgeField.value?.length ?? 0) > 0 ||
+      referencedSkills.length > 0 ||
+      tools.length > 0 ||
       (instructionsField.value?.includes("<knowledge ") ?? false) ||
-      (instructionsField.value?.includes("<skill ") ?? false) ||
       (instructionsField.value?.includes("<tool ") ?? false));
 
   const syncAttachedKnowledgeFromEditor = useCallback(
@@ -274,7 +344,7 @@ export function SkillBuilderInstructionsEditor({
     [attachedKnowledgeField.onChange]
   );
 
-  const syncToolReferencesFromEditor = useCallback(
+  const syncInlineReferencesFromEditor = useCallback(
     (editor: Editor) => {
       const currentInlineToolIds = collectToolReferenceIds(editor);
       const removedToolIds = [...previousInlineToolIdsRef.current].filter(
@@ -291,8 +361,35 @@ export function SkillBuilderInstructionsEditor({
       }
 
       previousInlineToolIdsRef.current = currentInlineToolIds;
+
+      const currentInlineSkillIds = collectSkillReferenceIds(editor);
+      if (
+        !haveSameSkillReferenceIds(
+          referencedSkillIdsRef.current,
+          currentInlineSkillIds
+        )
+      ) {
+        const nextReferencedSkillIds = [...currentInlineSkillIds];
+        referencedSkillIdsRef.current = nextReferencedSkillIds;
+        onReferencedSkillIdsChange(nextReferencedSkillIds);
+      }
+
+      const removedSkillIds = [...previousInlineSkillIdsRef.current].filter(
+        (skillId) => !currentInlineSkillIds.has(skillId)
+      );
+
+      if (removedSkillIds.length > 0) {
+        const removedSkillIdsSet = new Set(removedSkillIds);
+        const nextReferencedSkills = referencedSkillsRef.current.filter(
+          (skill) => !removedSkillIdsSet.has(skill.id)
+        );
+        referencedSkillsRef.current = nextReferencedSkills;
+        onReferencedSkillsChange(nextReferencedSkills);
+      }
+
+      previousInlineSkillIdsRef.current = currentInlineSkillIds;
     },
-    [onToolsChange]
+    [onReferencedSkillIdsChange, onReferencedSkillsChange, onToolsChange]
   );
 
   const syncInstructionsFromEditor = useCallback(
@@ -306,14 +403,14 @@ export function SkillBuilderInstructionsEditor({
         })
       );
       syncAttachedKnowledgeFromEditor(editor);
-      syncToolReferencesFromEditor(editor);
+      syncInlineReferencesFromEditor(editor);
     },
     [
       enableSkillReferences,
       instructionsField.onChange,
       instructionsHtmlField.onChange,
       syncAttachedKnowledgeFromEditor,
-      syncToolReferencesFromEditor,
+      syncInlineReferencesFromEditor,
     ]
   );
 
@@ -330,11 +427,11 @@ export function SkillBuilderInstructionsEditor({
   const handleUpdate = useCallback(
     ({ editor, transaction }: { editor: Editor; transaction: Transaction }) => {
       if (transaction.docChanged) {
-        syncToolReferencesFromEditor(editor);
+        syncInlineReferencesFromEditor(editor);
         debouncedUpdate(editor);
       }
     },
-    [debouncedUpdate, syncToolReferencesFromEditor]
+    [debouncedUpdate, syncInlineReferencesFromEditor]
   );
 
   const handleBlur = useCallback(() => {
@@ -346,9 +443,9 @@ export function SkillBuilderInstructionsEditor({
   const handleDelete = useCallback(
     (editorInstance: Editor) => {
       syncAttachedKnowledgeFromEditor(editorInstance);
-      syncToolReferencesFromEditor(editorInstance);
+      syncInlineReferencesFromEditor(editorInstance);
     },
-    [syncAttachedKnowledgeFromEditor, syncToolReferencesFromEditor]
+    [syncAttachedKnowledgeFromEditor, syncInlineReferencesFromEditor]
   );
 
   const handleSelectToolReference = useCallback(
@@ -368,6 +465,33 @@ export function SkillBuilderInstructionsEditor({
     [onToolsChange]
   );
 
+  const handleSelectSkillReference = useCallback(
+    (skill: SlashCommandSkillSuggestion) => {
+      const alreadyAdded = referencedSkillsRef.current.some(
+        (referencedSkill) => referencedSkill.id === skill.sId
+      );
+
+      if (!alreadyAdded) {
+        const nextReferencedSkills = [
+          ...referencedSkillsRef.current,
+          toReferencedSkill(skill),
+        ];
+        referencedSkillsRef.current = nextReferencedSkills;
+        onReferencedSkillsChange(nextReferencedSkills);
+      }
+
+      if (!referencedSkillIdsRef.current.includes(skill.sId)) {
+        const nextReferencedSkillIds = [
+          ...referencedSkillIdsRef.current,
+          skill.sId,
+        ];
+        referencedSkillIdsRef.current = nextReferencedSkillIds;
+        onReferencedSkillIdsChange(nextReferencedSkillIds);
+      }
+    },
+    [onReferencedSkillIdsChange, onReferencedSkillsChange]
+  );
+
   const { suggestions, isSuggestionsLoading } = useSkillSuggestions({
     skillId,
     states: ["pending"],
@@ -384,6 +508,7 @@ export function SkillBuilderInstructionsEditor({
     skillReferences: {
       currentSkillId: skillId,
       enableSkillReferences,
+      onSelectSkill: handleSelectSkillReference,
       onSelectTool: handleSelectToolReference,
       owner,
     },
@@ -546,6 +671,15 @@ export function SkillBuilderInstructionsEditor({
       keepTouched: true,
     });
     previousInlineToolIdsRef.current = collectToolReferenceIds(editor);
+    const inlineSkillIds = collectSkillReferenceIds(editor);
+    const inlineSkillIdList = [...inlineSkillIds];
+    previousInlineSkillIdsRef.current = inlineSkillIds;
+    referencedSkillIdsRef.current = inlineSkillIdList;
+    resetField(REFERENCED_SKILL_IDS_FIELD_NAME, {
+      defaultValue: inlineSkillIdList,
+      keepError: true,
+      keepTouched: true,
+    });
   }, [editor, isContentReady, isDiffMode, resetField]);
 
   // Apply pending instruction suggestions as inline diff decorations.
@@ -748,6 +882,8 @@ export function SkillBuilderInstructionsEditor({
             hasError={displayError}
             instructions={instructionsField.value ?? ""}
             onReferenceClick={handleReferenceClick}
+            referencedSkills={referencedSkills}
+            tools={tools}
           />
         )}
       </div>

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -1,9 +1,12 @@
 import { ToolChip } from "@app/components/editor/extensions/skill_builder/ToolChip";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
-import type { AttachedKnowledgeFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
+import type { BuilderAction } from "@app/components/shared/tools_picker/types";
+import type {
+  AttachedKnowledgeFormData,
+  ReferencedSkillFormData,
+} from "@app/components/skill_builder/SkillBuilderFormContext";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { getSkillIcon } from "@app/lib/skill";
-import { extractSkillTags } from "@app/lib/skills/format";
 import { extractToolTags } from "@app/lib/tools/format";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { AttachmentChip, Chip, cn, DocumentIcon } from "@dust-tt/sparkle";
@@ -16,6 +19,8 @@ interface SkillBuilderInstructionsReferenceSummaryProps {
   hasError: boolean;
   instructions: string;
   onReferenceClick: (target: ReferenceSummaryTarget) => void;
+  referencedSkills: ReferencedSkillFormData[];
+  tools: BuilderAction[];
 }
 
 export type ReferenceSummaryTarget =
@@ -105,6 +110,8 @@ export function SkillBuilderInstructionsReferenceSummary({
   hasError,
   instructions,
   onReferenceClick,
+  referencedSkills,
+  tools,
 }: SkillBuilderInstructionsReferenceSummaryProps) {
   const { mcpServerViews, isMCPServerViewsLoading } =
     useMCPServerViewsContext();
@@ -123,13 +130,13 @@ export function SkillBuilderInstructionsReferenceSummary({
   const skillReferences = useMemo(
     () =>
       dedupeById(
-        extractSkillTags(instructions).map((skill) => ({
+        referencedSkills.map((skill) => ({
           icon: skill.icon,
           id: skill.id,
           title: skill.name,
         }))
       ),
-    [instructions]
+    [referencedSkills]
   );
 
   const inlineToolReferences = useMemo(
@@ -150,6 +157,19 @@ export function SkillBuilderInstructionsReferenceSummary({
     [instructions, isMCPServerViewsLoading, mcpServerViews]
   );
 
+  const selectedToolReferences = useMemo(() => {
+    return tools.map((tool) => ({
+      icon: null,
+      id: tool.configuration.mcpServerViewId,
+      title: tool.name,
+    }));
+  }, [tools]);
+
+  const toolReferences = useMemo(
+    () => dedupeById([...selectedToolReferences, ...inlineToolReferences]),
+    [inlineToolReferences, selectedToolReferences]
+  );
+
   const referenceItems = useMemo(
     () =>
       [
@@ -165,14 +185,14 @@ export function SkillBuilderInstructionsReferenceSummary({
             kind: "skill",
           })
         ),
-        ...inlineToolReferences.map(
+        ...toolReferences.map(
           (tool): ReferenceSummaryItem => ({
             ...tool,
             kind: "tool",
           })
         ),
       ].toSorted(compareReferenceSummaryItems),
-    [knowledgeReferences, skillReferences, inlineToolReferences]
+    [knowledgeReferences, skillReferences, toolReferences]
   );
 
   if (referenceItems.length === 0) {

--- a/front/components/skill_builder/skillFormData.ts
+++ b/front/components/skill_builder/skillFormData.ts
@@ -1,6 +1,10 @@
 import { getDefaultMCPAction } from "@app/components/agent_builder/types";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
+import { extractUniqueSkillReferenceIds } from "@app/lib/skills/format";
+import type {
+  SkillRelations,
+  SkillType,
+} from "@app/types/assistant/skill_configuration";
 import type { UserType } from "@app/types/user";
 
 /**
@@ -8,7 +12,7 @@ import type { UserType } from "@app/types/user";
  * Editors are intentionally set to empty defaults as they will be populated reactively.
  */
 export function transformSkillTypeToFormData(
-  skill: SkillType
+  skill: SkillType & { relations?: Pick<SkillRelations, "childSkills"> }
 ): SkillBuilderFormData {
   return {
     name: skill.name,
@@ -24,6 +28,20 @@ export function transformSkillTypeToFormData(
     isDefault: skill.isDefault,
     reinforcement: skill.reinforcement,
     additionalSpaces: [],
+    referencedSkills:
+      skill.relations?.childSkills?.map((childSkill) => ({
+        id: childSkill.sId,
+        name: childSkill.name,
+        icon: childSkill.icon,
+        requestedSpaceIds: childSkill.requestedSpaceIds,
+      })) ?? [],
+    referencedSkillIds: [
+      ...new Set([
+        ...(skill.relations?.childSkills?.map((childSkill) => childSkill.sId) ??
+          []),
+        ...extractUniqueSkillReferenceIds(skill.instructions ?? ""),
+      ]),
+    ],
   };
 }
 
@@ -51,5 +69,7 @@ export function getDefaultSkillFormData({
     isDefault: false,
     reinforcement: "on",
     additionalSpaces: [],
+    referencedSkills: [],
+    referencedSkillIds: [],
   };
 }

--- a/front/components/skill_builder/submitSkillBuilderForm.ts
+++ b/front/components/skill_builder/submitSkillBuilderForm.ts
@@ -14,7 +14,7 @@ export async function submitSkillBuilderForm({
   currentEditors = [],
 }: {
   formData: SkillBuilderFormData;
-  owner: WorkspaceType;
+  owner: Pick<WorkspaceType, "sId">;
   skillId?: string;
   currentEditors?: UserType[];
 }): Promise<
@@ -56,6 +56,7 @@ export async function submitSkillBuilderForm({
         })),
         attachedKnowledge: formData.attachedKnowledge ?? [],
         additionalRequestedSpaceIds: formData.additionalSpaces,
+        referencedSkillIds: formData.referencedSkillIds,
       }),
     });
 

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -674,6 +674,7 @@ describe("SkillResource", () => {
         instructions: `Use ${skillReferenceTag}.`,
         instructionsHtml: `<p>Use ${skillReferenceHtmlTag}.</p>`,
         enableSkillReferences: true,
+        referencedSkillIds: [childSkill.sId],
       });
 
       expect(parentSkill.instructions).toContain(
@@ -701,6 +702,7 @@ describe("SkillResource", () => {
         attachedKnowledge: [],
         requestedSpaceIds: parentSkill.requestedSpaceIds,
         enableSkillReferences: true,
+        referencedSkillIds: [childSkill.sId],
       });
 
       const updatedParentSkill = await SkillResource.fetchById(
@@ -739,6 +741,7 @@ describe("SkillResource", () => {
         name: "Parent Skill",
         instructions: `Use ${SkillFactory.serializeSkillReferenceTag(childSkill)}.`,
         enableSkillReferences: true,
+        referencedSkillIds: [childSkill.sId],
       });
 
       expect(parentSkill.instructions).toContain(
@@ -756,6 +759,7 @@ describe("SkillResource", () => {
         attachedKnowledge: [],
         requestedSpaceIds: [restrictedSpace.id],
         enableSkillReferences: true,
+        referencedSkillIds: [childSkill.sId],
       });
 
       const updatedParentSkill = await SkillResource.fetchById(
@@ -777,6 +781,7 @@ describe("SkillResource", () => {
         name: "Parent Skill",
         instructions: `Use ${SkillFactory.serializeSkillReferenceTag(childSkill)}.`,
         enableSkillReferences: true,
+        referencedSkillIds: [childSkill.sId],
       });
 
       expect(parentSkill.instructions).toContain(
@@ -794,6 +799,7 @@ describe("SkillResource", () => {
         attachedKnowledge: [],
         requestedSpaceIds: [restrictedSpace.id],
         enableSkillReferences: true,
+        referencedSkillIds: [],
       });
 
       const unavailableParentSkill = await SkillResource.fetchById(
@@ -816,6 +822,7 @@ describe("SkillResource", () => {
         attachedKnowledge: [],
         requestedSpaceIds: [],
         enableSkillReferences: true,
+        referencedSkillIds: [],
       });
 
       const availableParentSkill = await SkillResource.fetchById(
@@ -825,62 +832,6 @@ describe("SkillResource", () => {
 
       expect(availableParentSkill?.instructions).toContain(
         SkillFactory.serializeSkillReferenceTag(childSkill)
-      );
-    });
-
-    it("throws when syncing an invalid nested skill reference", async () => {
-      const skill = await SkillFactory.create(testContext.authenticator, {
-        name: "Skill With Invalid Reference",
-      });
-      const invalidSkillReferenceTag = serializeSkillTag({
-        id: "not-a-skill-reference",
-        icon: null,
-        name: "Invalid Skill Reference",
-      });
-
-      await expect(
-        skill.updateSkill(testContext.authenticator, {
-          name: skill.name,
-          agentFacingDescription: skill.agentFacingDescription,
-          userFacingDescription: skill.userFacingDescription,
-          instructions: `Use ${invalidSkillReferenceTag}.`,
-          icon: skill.icon,
-          mcpServerViews: [],
-          attachedKnowledge: [],
-          requestedSpaceIds: [],
-          enableSkillReferences: true,
-        })
-      ).rejects.toThrow("Invalid skill reference ID: not-a-skill-reference");
-    });
-
-    it("throws when syncing an out-of-workspace nested skill reference", async () => {
-      const skill = await SkillFactory.create(testContext.authenticator, {
-        name: "Skill With Out Of Workspace Reference",
-      });
-      const outOfWorkspaceSkillId = SkillResource.modelIdToSId({
-        id: skill.id + 1,
-        workspaceId: testContext.workspace.id + 1,
-      });
-      const outOfWorkspaceSkillReferenceTag = serializeSkillTag({
-        id: outOfWorkspaceSkillId,
-        icon: null,
-        name: "Out Of Workspace Skill Reference",
-      });
-
-      await expect(
-        skill.updateSkill(testContext.authenticator, {
-          name: skill.name,
-          agentFacingDescription: skill.agentFacingDescription,
-          userFacingDescription: skill.userFacingDescription,
-          instructions: `Use ${outOfWorkspaceSkillReferenceTag}.`,
-          icon: skill.icon,
-          mcpServerViews: [],
-          attachedKnowledge: [],
-          requestedSpaceIds: [],
-          enableSkillReferences: true,
-        })
-      ).rejects.toThrow(
-        `Skill reference ID does not belong to this workspace: ${outOfWorkspaceSkillId}`
       );
     });
   });

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -379,12 +379,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       attachedKnowledge = [],
       fileAttachments = [],
       enableSkillReferences = false,
+      referencedSkillIds = [],
     }: {
       mcpServerViews: MCPServerViewResource[];
       addCurrentUserAsEditor?: boolean;
       attachedKnowledge?: SkillAttachedKnowledge[];
       fileAttachments?: FileResource[];
       enableSkillReferences?: boolean;
+      referencedSkillIds?: string[];
     }
   ): Promise<SkillResource> {
     const owner = auth.getNonNullableWorkspace();
@@ -453,7 +455,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         await skillResource.normalizeSkillReferenceTags(auth, { transaction });
         await skillResource.syncSkillReferences(
           auth,
-          { instructions: skillResource.instructions },
+          { referencedSkillIds },
           { transaction }
         );
       }
@@ -2315,6 +2317,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       sourceMetadata,
       status,
       enableSkillReferences = false,
+      referencedSkillIds = [],
       userFacingDescription,
     }: {
       agentFacingDescription: string;
@@ -2332,6 +2335,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       sourceMetadata?: SkillSourceMetadata;
       status?: SkillStatus;
       enableSkillReferences?: boolean;
+      referencedSkillIds?: string[];
       userFacingDescription: string;
     }
   ): Promise<void> {
@@ -2386,7 +2390,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         await this.normalizeSkillReferenceTags(auth, { transaction });
         await this.syncSkillReferences(
           auth,
-          { instructions: this.instructions },
+          { referencedSkillIds },
           { transaction }
         );
 
@@ -2547,69 +2551,34 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     await this.update({ lastReinforcementAnalysisAt: new Date() });
   }
 
-  static getValidatedSkillReferenceModelIds(
-    auth: Authenticator,
-    {
-      instructions,
-      parentSkillId,
-    }: {
-      instructions: string;
-      parentSkillId?: ModelId;
-    }
-  ): Result<ModelId[], Error> {
-    const workspace = auth.getNonNullableWorkspace();
-    const childSkillModelIds = new Set<ModelId>();
-
-    for (const skillId of extractUniqueSkillReferenceIds(instructions)) {
-      const parsed = getResourceNameAndIdFromSId(skillId);
-
-      if (!parsed || parsed.resourceName !== "skill") {
-        return new Err(new Error(`Invalid skill reference ID: ${skillId}`));
-      }
-
-      if (parsed.workspaceModelId !== workspace.id) {
-        return new Err(
-          new Error(
-            `Skill reference ID does not belong to this workspace: ${skillId}`
-          )
-        );
-      }
-
-      if (parsed.resourceModelId === parentSkillId) {
-        continue;
-      }
-
-      childSkillModelIds.add(parsed.resourceModelId);
-    }
-
-    return new Ok([...childSkillModelIds]);
-  }
-
   /**
-   * Persist the custom skills referenced by the skill instructions.
+   * Persist the custom skills referenced by the skill form.
    */
   private async syncSkillReferences(
     auth: Authenticator,
     {
-      instructions,
+      referencedSkillIds,
     }: {
-      instructions: string;
+      referencedSkillIds: string[];
     },
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<void> {
     const workspace = auth.getNonNullableWorkspace();
     const parentSkillId = this.id;
-    const childSkillModelIdsRes =
-      SkillResource.getValidatedSkillReferenceModelIds(auth, {
-        instructions,
-        parentSkillId,
-      });
 
-    if (childSkillModelIdsRes.isErr()) {
-      throw childSkillModelIdsRes.error;
-    }
+    const referencedCustomSkillIds = uniq(
+      removeNulls(
+        referencedSkillIds.map((sId) => {
+          const parsed = getResourceNameAndIdFromSId(sId);
 
-    const childSkillModelIds = childSkillModelIdsRes.value;
+          return parsed?.resourceName === "skill" &&
+            parsed.workspaceModelId === workspace.id &&
+            parsed.resourceModelId !== parentSkillId
+            ? parsed.resourceModelId
+            : null;
+        })
+      )
+    );
 
     const existingReferences = await SkillReferenceModel.findAll({
       where: {
@@ -2619,7 +2588,20 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       transaction,
     });
 
-    if (childSkillModelIds.length === 0) {
+    const childSkills =
+      referencedCustomSkillIds.length > 0
+        ? await this.model.findAll({
+            attributes: ["id"],
+            where: {
+              id: { [Op.in]: referencedCustomSkillIds },
+              workspaceId: workspace.id,
+            },
+            transaction,
+          })
+        : [];
+    const childSkillIds = new Set(childSkills.map((skill) => skill.id));
+
+    if (childSkillIds.size === 0) {
       if (existingReferences.length > 0) {
         await SkillReferenceModel.destroy({
           where: {
@@ -2633,18 +2615,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       return;
     }
 
-    const referencedSkills = await this.model.findAll({
-      where: {
-        id: { [Op.in]: childSkillModelIds },
-        workspaceId: workspace.id,
-      },
-      attributes: ["id"],
-      transaction,
-    });
-
-    const desiredChildSkillIds = new Set(
-      referencedSkills.map((skill) => skill.id)
-    );
+    const desiredChildSkillIds = childSkillIds;
     const existingChildSkillIds = new Set(
       existingReferences.map((ref) => ref.childSkillId)
     );

--- a/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
@@ -5,7 +5,6 @@ import {
 } from "@app/lib/models/skill";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
-import { serializeSkillTag } from "@app/lib/skills/format";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
@@ -135,6 +134,7 @@ function makePatchSkillBody(
   overrides: Partial<{
     instructions: string;
     instructionsHtml: string | null;
+    referencedSkillIds: string[];
   }> = {}
 ) {
   return {
@@ -422,12 +422,12 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
     const childSkill = await SkillFactory.create(requestUserAuth, {
       name: "Referenced Skill",
     });
-    const skillReferenceTag =
-      SkillFactory.serializeSkillReferenceTag(childSkill);
-    const instructionsWithReference = `Use ${skillReferenceTag} for deeper analysis.`;
+    const instructionsWithReference =
+      "Use the referenced skill for deeper analysis.";
 
     req.body = makePatchSkillBody(skill, {
       instructions: instructionsWithReference,
+      referencedSkillIds: [childSkill.sId],
     });
     await handler(req, res);
     expect(res._getStatusCode()).toBe(200);
@@ -447,6 +447,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
       skillId: skill.sId,
       body: makePatchSkillBody(skill, {
         instructions: instructionsWithReference,
+        referencedSkillIds: [childSkill.sId],
       }),
     });
 
@@ -470,6 +471,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
       skillId: skill.sId,
       body: makePatchSkillBody(skill, {
         instructions: "No nested skill references here.",
+        referencedSkillIds: [],
       }),
     });
 
@@ -485,7 +487,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
     ).resolves.toHaveLength(0);
   });
 
-  it("returns 400 for out-of-workspace nested skill references", async () => {
+  it("drops missing nested skill references", async () => {
     const { req, res, skill, requestUserAuth, workspace } = await setupTest({
       requestUserRole: "admin",
       method: "PATCH",
@@ -496,24 +498,59 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
       id: skill.id + 1,
       workspaceId: workspace.id + 1,
     });
-    const outOfWorkspaceSkillReferenceTag = serializeSkillTag({
-      id: outOfWorkspaceSkillId,
-      icon: null,
-      name: "Other Workspace Skill",
-    });
 
     req.body = makePatchSkillBody(skill, {
-      instructions: `Use ${outOfWorkspaceSkillReferenceTag}.`,
+      instructions: "Use the other workspace skill.",
+      referencedSkillIds: [outOfWorkspaceSkillId],
     });
 
     await handler(req, res);
-    expect(res._getStatusCode()).toBe(400);
-    expect(res._getJSONData()).toEqual({
-      error: {
-        type: "invalid_request_error",
-        message: `Skill reference ID does not belong to this workspace: ${outOfWorkspaceSkillId}`,
-      },
+    expect(res._getStatusCode()).toBe(200);
+
+    const updatedSkill = await SkillResource.fetchById(
+      requestUserAuth,
+      skill.sId
+    );
+    expect(updatedSkill).not.toBeNull();
+
+    await expect(
+      updatedSkill!.fetchChildSkills(requestUserAuth)
+    ).resolves.toHaveLength(0);
+  });
+
+  it("keeps unavailable nested skill references when child spaces are not readable", async () => {
+    const { req, res, skill, requestUserAuth, workspace } = await setupTest({
+      requestUserRole: "admin",
+      method: "PATCH",
     });
+
+    await FeatureFlagFactory.basic(requestUserAuth, "nested_skills");
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    const childSkill = await SkillFactory.create(requestUserAuth, {
+      name: "Restricted Child Skill",
+      requestedSpaceIds: [restrictedSpace.id],
+    });
+
+    await expect(
+      SkillResource.fetchById(requestUserAuth, childSkill.sId)
+    ).resolves.toBeNull();
+
+    req.body = makePatchSkillBody(skill, {
+      instructions: `Use ${SkillFactory.serializeSkillReferenceTag(childSkill)}.`,
+      referencedSkillIds: [childSkill.sId],
+    });
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+
+    const updatedSkill = await SkillResource.fetchById(
+      requestUserAuth,
+      skill.sId
+    );
+    expect(updatedSkill).not.toBeNull();
+    expect(updatedSkill!.instructions).toContain(
+      `<unavailable_skill id="${childSkill.sId}" />`
+    );
   });
 
   it("should update requestedSpaceIds when adding a tool from a new space", async () => {

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -63,6 +63,7 @@ const PatchSkillRequestBodySchema = z.object({
   attachedKnowledge: z.array(AttachedKnowledgeSchema),
   instructionsHtml: z.string().nullable(),
   additionalRequestedSpaceIds: z.array(z.string()).optional(),
+  referencedSkillIds: z.array(z.string()).optional(),
   fileAttachments: z.array(z.object({ fileId: z.string() })).optional(),
   isDefault: z.boolean().optional(),
   reinforcement: z.enum(["auto", "on", "off"]).optional(),
@@ -320,23 +321,11 @@ async function handler(
 
       const featureFlags = await getFeatureFlags(auth);
       const enableSkillReferences = featureFlags.includes("nested_skills");
-      if (enableSkillReferences) {
-        const skillReferenceValidation =
-          SkillResource.getValidatedSkillReferenceModelIds(auth, {
-            instructions: body.instructions,
-            parentSkillId: skill.id,
-          });
-
-        if (skillReferenceValidation.isErr()) {
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: skillReferenceValidation.error.message,
-            },
-          });
-        }
-      }
+      const referencedSkillIds = uniq(
+        (body.referencedSkillIds ?? []).filter(
+          (referencedSkillId) => referencedSkillId !== skill.sId
+        )
+      );
 
       // Validate file attachments if provided (gated behind sandbox_tools).
       let files: FileResource[] | undefined;
@@ -405,6 +394,7 @@ async function handler(
         reinforcement: body.reinforcement,
         requestedSpaceIds,
         enableSkillReferences,
+        referencedSkillIds,
         userFacingDescription: body.userFacingDescription,
         ...(shouldActivate ? { status: "active" as const } : {}),
       });

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -3,7 +3,6 @@ import { SkillMCPServerConfigurationModel } from "@app/lib/models/skill";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { discoverToolsSkill } from "@app/lib/resources/skill/code_defined/discover_tools";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import { serializeSkillTag } from "@app/lib/skills/format";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
@@ -727,18 +726,17 @@ describe("POST /api/w/[wId]/skills", () => {
     const childSkill = await SkillFactory.create(auth, {
       name: "Referenced Skill",
     });
-    const skillReferenceTag =
-      SkillFactory.serializeSkillReferenceTag(childSkill);
 
     req.body = {
       name: "Parent Skill",
       agentFacingDescription: "To use with another skill",
       userFacingDescription: "A skill with a nested reference",
-      instructions: `Start with ${skillReferenceTag}.`,
+      instructions: "Start with the referenced skill.",
       icon: "PuzzleIcon",
       tools: [],
       extendedSkillId: null,
       attachedKnowledge: [],
+      referencedSkillIds: [childSkill.sId],
       instructionsHtml: null,
     };
 
@@ -758,36 +756,34 @@ describe("POST /api/w/[wId]/skills", () => {
     ]);
   });
 
-  it("returns 400 for invalid nested skill references", async () => {
+  it("drops missing nested skill references", async () => {
     const { auth, req, res } = await setupTest("POST", "admin");
 
     await FeatureFlagFactory.basic(auth, "nested_skills");
-    const invalidSkillReferenceTag = serializeSkillTag({
-      id: "not-a-skill-reference",
-      icon: null,
-      name: "Invalid Skill Reference",
-    });
 
     req.body = {
       name: "Parent Skill",
       agentFacingDescription: "To use with another skill",
       userFacingDescription: "A skill with an invalid nested reference",
-      instructions: `Start with ${invalidSkillReferenceTag}.`,
+      instructions: "Start with an invalid nested reference.",
       icon: "PuzzleIcon",
       tools: [],
       extendedSkillId: null,
       attachedKnowledge: [],
+      referencedSkillIds: ["not-a-skill-reference"],
       instructionsHtml: null,
     };
 
     await handler(req, res);
-    expect(res._getStatusCode()).toBe(400);
-    expect(res._getJSONData()).toEqual({
-      error: {
-        type: "invalid_request_error",
-        message: "Invalid skill reference ID: not-a-skill-reference",
-      },
-    });
+    expect(res._getStatusCode()).toBe(200);
+
+    const createdSkill = await SkillResource.fetchById(
+      auth,
+      res._getJSONData().skill.sId
+    );
+    expect(createdSkill).not.toBeNull();
+
+    await expect(createdSkill!.fetchChildSkills(auth)).resolves.toHaveLength(0);
   });
 
   it("creates a skill configuration with additional requested spaces", async () => {

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -66,6 +66,7 @@ const PostSkillRequestBodySchema = z.intersection(
     attachedKnowledge: z.array(AttachedKnowledgeSchema),
     instructionsHtml: z.string().nullable(),
     additionalRequestedSpaceIds: z.array(z.string()).optional(),
+    referencedSkillIds: z.array(z.string()).optional(),
     fileAttachments: z.array(z.object({ fileId: z.string() })).optional(),
     isDefault: z.boolean().optional(),
     reinforcement: z.enum(SKILL_REINFORCEMENT_MODES).optional(),
@@ -372,22 +373,7 @@ async function handler(
 
       const featureFlags = await getFeatureFlags(auth);
       const enableSkillReferences = featureFlags.includes("nested_skills");
-      if (enableSkillReferences) {
-        const skillReferenceValidation =
-          SkillResource.getValidatedSkillReferenceModelIds(auth, {
-            instructions: body.instructions,
-          });
-
-        if (skillReferenceValidation.isErr()) {
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: skillReferenceValidation.error.message,
-            },
-          });
-        }
-      }
+      const referencedSkillIds = uniq(body.referencedSkillIds ?? []);
 
       // Validate file attachments if provided (gated behind sandbox_tools).
       let files: FileResource[] | undefined;
@@ -472,6 +458,7 @@ async function handler(
           attachedKnowledge: attachedKnowledgeWithDataSourceViews,
           fileAttachments: files,
           enableSkillReferences,
+          referencedSkillIds,
         }
       );
 

--- a/front/tests/utils/SkillFactory.ts
+++ b/front/tests/utils/SkillFactory.ts
@@ -24,6 +24,7 @@ type CreateSkillOverrides = Partial<{
   attachedKnowledge: SkillAttachedKnowledge[];
   mcpServerViews: MCPServerViewResource[];
   enableSkillReferences: boolean;
+  referencedSkillIds: string[];
 }>;
 
 export class SkillFactory {
@@ -72,6 +73,7 @@ export class SkillFactory {
         addCurrentUserAsEditor: overrides.addCurrentUserAsEditor,
         attachedKnowledge,
         enableSkillReferences: overrides.enableSkillReferences,
+        referencedSkillIds: overrides.referencedSkillIds ?? [],
       }
     );
   }
@@ -106,6 +108,7 @@ export class SkillFactory {
       ...parentOverrides,
       instructions: parentOverrides.instructions ?? `Use ${skillReferenceTag}.`,
       enableSkillReferences: true,
+      referencedSkillIds: [childSkill.sId],
     });
 
     return { parentSkill, childSkill, skillReferenceTag };
@@ -142,6 +145,7 @@ export class SkillFactory {
       attachedKnowledge: await parentSkill.getAttachedKnowledge(auth),
       requestedSpaceIds: parentSkill.requestedSpaceIds,
       enableSkillReferences: true,
+      referencedSkillIds: childSkills.map((childSkill) => childSkill.sId),
     });
 
     const updatedParentSkill = await SkillResource.fetchById(


### PR DESCRIPTION
## Description

This PR adds nested skill references to the Skill Builder react-hook-form state. The builder keeps full `referencedSkills` metadata for chips/requested-space UI and an ID-only `referencedSkillIds` field for saving, so unavailable skill nodes rendered as `<unavailable_skill id="..." />` are preserved when the skill is saved.

The create/update skill routes pass the submitted IDs to `SkillResource.makeNew` and `updateSkill`. The resource layer resolves same-workspace custom skills from the form data and persists `skill_references` rows when `nested_skills` is enabled, while dropping unresolved, cross-workspace, global, and self references.

The space-restriction UI flow is left for the follow-up PR.

## Tests

- Updated existing resource and route tests.
- Tested locally.

## Risk

- Low. Limited to nested skill references in Skill Builder.

## Deploy Plan

- Deploy front.
