### PR TITLE
[LLM] Consolidate Google tool declarations into a single Tool

### DIFF
--- a/front/lib/api/llm/clients/google/index.ts
+++ b/front/lib/api/llm/clients/google/index.ts
@@ -6,7 +6,7 @@ import {
 } from "@app/lib/api/llm/clients/google/types";
 import {
   toContents,
-  toTool,
+  toFunctionDeclaration,
 } from "@app/lib/api/llm/clients/google/utils/conversation_to_google";
 import {
   responseToLLMEvents,
@@ -88,7 +88,14 @@ export class GoogleLLM extends LLM<GoogleGenerateContentRequestParams> {
   ) {
     return {
       temperature: this.temperature ?? undefined,
-      tools: specifications.map(toTool),
+      tools:
+        specifications.length > 0
+          ? [
+              {
+                functionDeclarations: specifications.map(toFunctionDeclaration),
+              },
+            ]
+          : [],
       systemInstruction: { text: systemPromptToText(prompt) },
       // We only need one
       candidateCount: 1,

--- a/front/lib/api/llm/clients/google/utils/conversation_to_google.ts
+++ b/front/lib/api/llm/clients/google/utils/conversation_to_google.ts
@@ -19,7 +19,12 @@ import type {
 import type { ModelIdType } from "@app/types/assistant/models/types";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { trustedFetchImageBase64 } from "@app/types/shared/utils/image_utils";
-import type { Content, FunctionResponse, Part, Tool } from "@google/genai";
+import type {
+  Content,
+  FunctionDeclaration,
+  FunctionResponse,
+  Part,
+} from "@google/genai";
 import assert from "assert";
 
 const MESSAGE_CONVERSION_CONCURRENCY = 10;
@@ -183,15 +188,13 @@ async function assistantMessageToParts(
   };
 }
 
-export function toTool(specification: AgentActionSpecification): Tool {
+export function toFunctionDeclaration(
+  specification: AgentActionSpecification
+): FunctionDeclaration {
   return {
-    functionDeclarations: [
-      {
-        name: specification.name,
-        description: specification.description,
-        parametersJsonSchema: specification.inputSchema,
-      },
-    ],
+    name: specification.name,
+    description: specification.description,
+    parametersJsonSchema: specification.inputSchema,
   };
 }
 


### PR DESCRIPTION
## Description

Group all Google function declarations into a single `Tool` object instead of one `Tool` per declaration, which made Gemini fail to match function calls against their declarations (UNEXPECTED_TOOL_CALL).

## Tests

Tested locally.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`