### PR TITLE
fix: extension logout when closing and reopening

### DIFF
--- a/extension/.env.development
+++ b/extension/.env.development
@@ -3,3 +3,5 @@ WORKOS_CLIENT_ID=client_01JGCT55EJ328PJ8MSCVSKVDKE
 DUST_US_URL="http://localhost:3000"
 DUST_EU_URL="http://localhost:3000"
 FRONT_EXTENSION_URL="http://localhost:3012"
+DUST_API_URL_US="http://localhost:3000"
+DUST_API_URL_EU="http://localhost:3000"

--- a/extension/.env.production
+++ b/extension/.env.production
@@ -3,3 +3,5 @@ WORKOS_CLIENT_ID=client_01JGCT55T7FVDG9XF74925R1KT
 DUST_US_URL="https://dust.tt"
 DUST_EU_URL="https://eu.dust.tt"
 FRONT_EXTENSION_URL="https://front-ext.dust.tt"
+DUST_API_URL_US="https://dust.tt"
+DUST_API_URL_EU="https://eu.dust.tt"

--- a/extension/config/webpack_env.ts
+++ b/extension/config/webpack_env.ts
@@ -1,0 +1,33 @@
+import dotenv from "dotenv";
+import fs from "fs";
+
+// The shared `front` `RegionContext` resolves the API base URL from
+// `import.meta.env.VITE_DUST_API_URL*`. Vite injects those in the SPA build, but
+// the extension is built with webpack, which only exposes `process.env.*`. As a
+// result `import.meta.env` is undefined in the extension bundle, the resolved
+// base URL is "", and `/api/*` calls fall back to the extension origin
+// (`chrome-extension://<id>/api/...` → ERR_FILE_NOT_FOUND), logging the user out
+// on every reopen.
+//
+// We mirror the VITE_* values webpack needs here, mapping them from the
+// extension's DUST_API_URL_US / DUST_API_URL_EU config (loaded from
+// .env.{development,production}), so `import.meta.env` resolves the same way it
+// does in the SPA.
+export function getImportMetaEnv(envPath: string): Record<string, string> {
+  const fileVars = fs.existsSync(envPath)
+    ? dotenv.parse(fs.readFileSync(envPath, "utf8"))
+    : {};
+
+  const resolve = (key: string): string =>
+    fileVars[key] ?? process.env[key] ?? "";
+
+  const usUrl = resolve("DUST_API_URL_US");
+  const euUrl = resolve("DUST_API_URL_EU");
+
+  return {
+    VITE_DUST_API_URL: usUrl,
+    VITE_DUST_API_URL_US: usUrl,
+    VITE_DUST_API_URL_EU: euUrl,
+    VITE_DUST_REGION: "us-central1",
+  };
+}

--- a/extension/platforms/chrome/webpack.config.ts
+++ b/extension/platforms/chrome/webpack.config.ts
@@ -14,6 +14,7 @@ import WebpackBar from "webpackbar";
 import ZipPlugin from "zip-webpack-plugin";
 
 import type { Environment } from "../../config/env";
+import { getImportMetaEnv } from "../../config/webpack_env";
 
 const rootDir = path.resolve(__dirname);
 
@@ -171,6 +172,16 @@ export const getConfig = async ({
     plugins: [
       new webpack.DefinePlugin({
         global: "globalThis",
+        // Expose VITE_* vars on `import.meta.env` so the shared `front`
+        // RegionContext can resolve the regional API base URL in the webpack
+        // build (Vite only injects these in the SPA).
+        "import.meta.env": JSON.stringify(
+          getImportMetaEnv(
+            resolvePath(
+              isDevelopment ? "../../.env.development" : "../../.env.production"
+            )
+          )
+        ),
       }),
       new WebpackBar({
         name: `DustExt [${env}]`,

--- a/extension/platforms/firefox/webpack.config.ts
+++ b/extension/platforms/firefox/webpack.config.ts
@@ -14,6 +14,7 @@ import WebpackBar from "webpackbar";
 import ZipPlugin from "zip-webpack-plugin";
 
 import type { Environment } from "../../config/env";
+import { getImportMetaEnv } from "../../config/webpack_env";
 
 const rootDir = path.resolve(__dirname);
 
@@ -183,6 +184,16 @@ export const getConfig = async ({
     plugins: [
       new webpack.DefinePlugin({
         global: "globalThis",
+        // Expose VITE_* vars on `import.meta.env` so the shared `front`
+        // RegionContext can resolve the regional API base URL in the webpack
+        // build (Vite only injects these in the SPA).
+        "import.meta.env": JSON.stringify(
+          getImportMetaEnv(
+            resolvePath(
+              isDevelopment ? "../../.env.development" : "../../.env.production"
+            )
+          )
+        ),
       }),
       new WebpackBar({
         name: `DustExt Firefox [${env}]`,

--- a/extension/platforms/front/webpack.config.ts
+++ b/extension/platforms/front/webpack.config.ts
@@ -1,4 +1,5 @@
 import type { Environment } from "@extension/config/env";
+import { getImportMetaEnv } from "@extension/config/webpack_env";
 import { execSync } from "child_process";
 import Dotenv from "dotenv-webpack";
 import fs from "fs";
@@ -120,6 +121,19 @@ export const getConfig = ({ env }: { env: Environment }) => {
       }),
       new webpack.ProvidePlugin({
         Buffer: ["buffer", "Buffer"],
+      }),
+      new webpack.DefinePlugin({
+        // Expose VITE_* vars on `import.meta.env` so the shared `front`
+        // RegionContext can resolve the regional API base URL in the webpack
+        // build (Vite only injects these in the SPA).
+        "import.meta.env": JSON.stringify(
+          getImportMetaEnv(
+            path.resolve(
+              __dirname,
+              isDevelopment ? "../../.env.development" : "../../.env.production"
+            )
+          )
+        ),
       }),
 
       new webpack.EnvironmentPlugin({


### PR DESCRIPTION
## Description

This PR fixes a logout bug in the browser extension that occurred every time the extension was closed and reopened.

- The shared `front` `RegionContext` resolves the API base URL from `import.meta.env.VITE_DUST_API_URL*`, which Vite injects in the SPA build — but since the extension is built with webpack, `import.meta.env` was `undefined`, causing API calls to resolve to `chrome-extension://<id>/api/...` (ERR_FILE_NOT_FOUND) and logging the user out on every reopen.
- Adds a `webpack_env.ts` helper that maps `DUST_API_URL_US` / `DUST_API_URL_EU` (from the extension's `.env` files) to the expected `VITE_DUST_API_URL*` variables.
- Uses webpack's `DefinePlugin` to statically inject `import.meta.env` with those values in the Chrome, Firefox, and Front webpack configs.
- Adds `DUST_API_URL_US` and `DUST_API_URL_EU` to `.env.development` and `.env.production`.

## Tests

Manually.

## Risks

Low risk — build configuration change only, no runtime logic modified.

## Deploy Plan

Standard deployment.

