### PR TITLE
Make app.dust.tt and poke.dust.tt point to Hono

### DIFF
--- a/.github/configs/us-central1/.env.prod
+++ b/.github/configs/us-central1/.env.prod
@@ -1,7 +1,7 @@
 NEXT_PUBLIC_DUST_APP_URL=https://app.dust.tt
-NEXT_PUBLIC_DUST_API_URL="https://dust.tt"
-NEXT_PUBLIC_DUST_API_URL_US="https://dust.tt"
-NEXT_PUBLIC_DUST_API_URL_EU="https://eu.dust.tt"
+NEXT_PUBLIC_DUST_API_URL="https://us-api.dust.tt"
+NEXT_PUBLIC_DUST_API_URL_US="https://us-api.dust.tt"
+NEXT_PUBLIC_DUST_API_URL_EU="https://eu-api.dust.tt"
 NEXT_PUBLIC_DUST_STATIC_WEBSITE_URL="https://dust.tt"
 NEXT_PUBLIC_ENABLE_BOT_CRAWLING="true"
 NEXT_PUBLIC_GTM_TRACKING_ID="GTM-MDWPND4G"


### PR DESCRIPTION
## Description

Right now, https://poke.dust.tt/ hits dust.tt and eu.dust.tt. Change it to hit https://us-api.dust.tt/ and https://eu-api.dust.tt/, just like https://poke.bleeding-edge.dust.tt/.

Fixes https://github.com/dust-tt/tasks/issues/8508.

IMPORTANT: we should only do this when we're confident all the routes work!

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
