### PR TITLE
[front] add dust-pistache and dust-chalom custom model agents

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -960,6 +960,9 @@ type CustomModelDustGlobalAgentConfig = {
   preferredReasoningEffort: ReasoningEffort;
 };
 
+// `customModelIndex` is a position into `CUSTOM_MODEL_CONFIGS`, which is generated
+// at build time from the infra custom-models config (GCS). It must stay in sync with
+// the ordering of models in that config: shifting the array silently rebinds agents.
 export const CUSTOM_MODEL_DUST_GLOBAL_AGENT_CONFIGS = new Map<
   GLOBAL_AGENTS_SID,
   CustomModelDustGlobalAgentConfig

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -1060,6 +1060,54 @@ export const CUSTOM_MODEL_DUST_GLOBAL_AGENT_CONFIGS = new Map<
       preferredReasoningEffort: "high",
     },
   ],
+  [
+    GLOBAL_AGENTS_SID.DUST_PISTACHE,
+    {
+      name: "dust-pistache",
+      customModelIndex: 3,
+      preferredReasoningEffort: "light",
+    },
+  ],
+  [
+    GLOBAL_AGENTS_SID.DUST_PISTACHE_MEDIUM,
+    {
+      name: "dust-pistache-medium",
+      customModelIndex: 3,
+      preferredReasoningEffort: "medium",
+    },
+  ],
+  [
+    GLOBAL_AGENTS_SID.DUST_PISTACHE_HIGH,
+    {
+      name: "dust-pistache-high",
+      customModelIndex: 3,
+      preferredReasoningEffort: "high",
+    },
+  ],
+  [
+    GLOBAL_AGENTS_SID.DUST_CHALOM,
+    {
+      name: "dust-chalom",
+      customModelIndex: 4,
+      preferredReasoningEffort: "light",
+    },
+  ],
+  [
+    GLOBAL_AGENTS_SID.DUST_CHALOM_MEDIUM,
+    {
+      name: "dust-chalom-medium",
+      customModelIndex: 4,
+      preferredReasoningEffort: "medium",
+    },
+  ],
+  [
+    GLOBAL_AGENTS_SID.DUST_CHALOM_HIGH,
+    {
+      name: "dust-chalom-high",
+      customModelIndex: 4,
+      preferredReasoningEffort: "high",
+    },
+  ],
 ]);
 
 export function getCustomModelDustGlobalAgentIndex(

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -386,6 +386,50 @@ export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
         description: "Same as dust-sundae but with high reasoning effort.",
         pictureUrl: DUST_AVATAR_URL,
       };
+    case GLOBAL_AGENTS_SID.DUST_PISTACHE:
+      return {
+        sId: GLOBAL_AGENTS_SID.DUST_PISTACHE,
+        name: "dust-pistache",
+        description:
+          "Same as dust but running a custom model for internal testing.",
+        pictureUrl: DUST_AVATAR_URL,
+      };
+    case GLOBAL_AGENTS_SID.DUST_PISTACHE_MEDIUM:
+      return {
+        sId: GLOBAL_AGENTS_SID.DUST_PISTACHE_MEDIUM,
+        name: "dust-pistache-medium",
+        description: "Same as dust-pistache but with medium reasoning effort.",
+        pictureUrl: DUST_AVATAR_URL,
+      };
+    case GLOBAL_AGENTS_SID.DUST_PISTACHE_HIGH:
+      return {
+        sId: GLOBAL_AGENTS_SID.DUST_PISTACHE_HIGH,
+        name: "dust-pistache-high",
+        description: "Same as dust-pistache but with high reasoning effort.",
+        pictureUrl: DUST_AVATAR_URL,
+      };
+    case GLOBAL_AGENTS_SID.DUST_CHALOM:
+      return {
+        sId: GLOBAL_AGENTS_SID.DUST_CHALOM,
+        name: "dust-chalom",
+        description:
+          "Same as dust but running a custom model for internal testing.",
+        pictureUrl: DUST_AVATAR_URL,
+      };
+    case GLOBAL_AGENTS_SID.DUST_CHALOM_MEDIUM:
+      return {
+        sId: GLOBAL_AGENTS_SID.DUST_CHALOM_MEDIUM,
+        name: "dust-chalom-medium",
+        description: "Same as dust-chalom but with medium reasoning effort.",
+        pictureUrl: DUST_AVATAR_URL,
+      };
+    case GLOBAL_AGENTS_SID.DUST_CHALOM_HIGH:
+      return {
+        sId: GLOBAL_AGENTS_SID.DUST_CHALOM_HIGH,
+        name: "dust-chalom-high",
+        description: "Same as dust-chalom but with high reasoning effort.",
+        pictureUrl: DUST_AVATAR_URL,
+      };
     case GLOBAL_AGENTS_SID.DUST_GOOG:
       return {
         sId: GLOBAL_AGENTS_SID.DUST_GOOG,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -400,6 +400,42 @@ const GLOBAL_AGENT_FLAGS: Record<
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
+  [GLOBAL_AGENTS_SID.DUST_PISTACHE]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
+  [GLOBAL_AGENTS_SID.DUST_PISTACHE_MEDIUM]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
+  [GLOBAL_AGENTS_SID.DUST_PISTACHE_HIGH]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
+  [GLOBAL_AGENTS_SID.DUST_CHALOM]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
+  [GLOBAL_AGENTS_SID.DUST_CHALOM_MEDIUM]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
+  [GLOBAL_AGENTS_SID.DUST_CHALOM_HIGH]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
   [GLOBAL_AGENTS_SID.HELPER]: {
     injectsMemory: false,
     injectsToolsets: false,
@@ -1166,6 +1202,12 @@ function getGlobalAgent({
     case GLOBAL_AGENTS_SID.DUST_SUNDAE:
     case GLOBAL_AGENTS_SID.DUST_SUNDAE_MEDIUM:
     case GLOBAL_AGENTS_SID.DUST_SUNDAE_HIGH:
+    case GLOBAL_AGENTS_SID.DUST_PISTACHE:
+    case GLOBAL_AGENTS_SID.DUST_PISTACHE_MEDIUM:
+    case GLOBAL_AGENTS_SID.DUST_PISTACHE_HIGH:
+    case GLOBAL_AGENTS_SID.DUST_CHALOM:
+    case GLOBAL_AGENTS_SID.DUST_CHALOM_MEDIUM:
+    case GLOBAL_AGENTS_SID.DUST_CHALOM_HIGH:
       agentConfiguration = _getCustomModelDustLikeGlobalAgent(
         auth,
         {
@@ -1394,6 +1436,12 @@ export async function getGlobalAgents(
     GLOBAL_AGENTS_SID.DUST_SUNDAE,
     GLOBAL_AGENTS_SID.DUST_SUNDAE_MEDIUM,
     GLOBAL_AGENTS_SID.DUST_SUNDAE_HIGH,
+    GLOBAL_AGENTS_SID.DUST_PISTACHE,
+    GLOBAL_AGENTS_SID.DUST_PISTACHE_MEDIUM,
+    GLOBAL_AGENTS_SID.DUST_PISTACHE_HIGH,
+    GLOBAL_AGENTS_SID.DUST_CHALOM,
+    GLOBAL_AGENTS_SID.DUST_CHALOM_MEDIUM,
+    GLOBAL_AGENTS_SID.DUST_CHALOM_HIGH,
   ];
   if (!flags.includes("dust_internal_global_agents")) {
     agentsIdsToFetch = agentsIdsToFetch.filter(

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -79,6 +79,12 @@ export enum GLOBAL_AGENTS_SID {
   DUST_SUNDAE = "dust-sundae",
   DUST_SUNDAE_MEDIUM = "dust-sundae-medium",
   DUST_SUNDAE_HIGH = "dust-sundae-high",
+  DUST_PISTACHE = "dust-pistache",
+  DUST_PISTACHE_MEDIUM = "dust-pistache-medium",
+  DUST_PISTACHE_HIGH = "dust-pistache-high",
+  DUST_CHALOM = "dust-chalom",
+  DUST_CHALOM_MEDIUM = "dust-chalom-medium",
+  DUST_CHALOM_HIGH = "dust-chalom-high",
   DUST_ANT = "dust-ant",
   DUST_ANT_MEDIUM = "dust-ant-medium",
   DUST_ANT_HIGH = "dust-ant-high",
@@ -215,6 +221,12 @@ const GLOBAL_AGENTS_SORT_ORDER: string[] = [
   GLOBAL_AGENTS_SID.DUST_SUNDAE,
   GLOBAL_AGENTS_SID.DUST_SUNDAE_MEDIUM,
   GLOBAL_AGENTS_SID.DUST_SUNDAE_HIGH,
+  GLOBAL_AGENTS_SID.DUST_PISTACHE,
+  GLOBAL_AGENTS_SID.DUST_PISTACHE_MEDIUM,
+  GLOBAL_AGENTS_SID.DUST_PISTACHE_HIGH,
+  GLOBAL_AGENTS_SID.DUST_CHALOM,
+  GLOBAL_AGENTS_SID.DUST_CHALOM_MEDIUM,
+  GLOBAL_AGENTS_SID.DUST_CHALOM_HIGH,
 ];
 const globalAgentIndexMap = new Map(
   GLOBAL_AGENTS_SORT_ORDER.map((id, index) => [id, index])


### PR DESCRIPTION
## Description

Adds two internal custom-model agents, dust-pistache and dust-chalom, each with light/medium/high reasoning variants. Wired up exactly like dust-sundae: enum entries, sort order, metadata, injects config, dispatch switch, and the internal-agents fetch list. They map to custom model indices 3 and 4. The actual model definitions live in the infra custom-models config (GCS), not in the repo.

Gated behind the `dust_internal_global_agents` flag (agents) and `custom_model_feature` flag (models), US region only, same as the existing chawi/soupinou/sundae agents.

Follow up of #26248.

## Tests

Typecheck passes locally. Custom model configs resolve to null in local dev (the generated config is empty until built from infra), same behavior as the existing custom agents.

## Risk

Low. Additive only, no existing agents touched. Behind feature flags. Revert is a plain code revert.

## Deploy Plan

Standard deploy.