### PR TITLE
[front] fix: scope agent_messages join to workspace in assistants usage query

### DIFF
--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -688,6 +688,7 @@ async function getAssistantsUsageData(
              LEFT JOIN "users" aut ON ac."authorId" = aut."id"
              LEFT JOIN "agent_messages" a
                       ON a."agentConfigurationId" = ac."sId"
+                      AND a."workspaceId" = :wId
                       AND a."status" = 'succeeded'
                       AND a."createdAt" BETWEEN :startDate AND :endDate
              LEFT JOIN "messages" m ON a."id" = m."agentMessageId"


### PR DESCRIPTION
## Description

The LEFT JOIN on agent_messages in getAssistantsUsageData had no workspaceId constraint, making the (workspaceId, agentConfigurationId) index unusable and forcing a scan of the whole multi-tenant table on every workspace-usage call.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Now, no change in the results

## Deploy Plan

front