### PR TITLE
feat: extension save page to pod

### DIFF
--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -56,6 +56,11 @@ chrome.runtime.onInstalled.addListener(() => {
     title: "Add selection to conversation",
     contexts: ["selection"],
   });
+  chrome.contextMenus.create({
+    id: "save_page_to_pod",
+    title: "Save page to Pod",
+    contexts: ["all"],
+  });
 });
 
 registerContextMenuTabListeners(platform);

--- a/extension/platforms/firefox/background.ts
+++ b/extension/platforms/firefox/background.ts
@@ -34,6 +34,11 @@ chrome.runtime.onInstalled.addListener(() => {
     title: "Add selection to conversation",
     contexts: ["selection"],
   });
+  chrome.contextMenus.create({
+    id: "save_page_to_pod",
+    title: "Save page to Pod",
+    contexts: ["all"],
+  });
 });
 
 registerContextMenuTabListeners(platform);

--- a/extension/shared/background.ts
+++ b/extension/shared/background.ts
@@ -143,11 +143,14 @@ const shouldDisableContextMenuForDomain = async (
 };
 
 const toggleContextMenus = (isDisabled: boolean) => {
-  ["add_tab_content", "add_tab_screenshot", "add_selection"].forEach(
-    (menuId) => {
-      chrome.contextMenus.update(menuId, { enabled: !isDisabled });
-    }
-  );
+  [
+    "add_tab_content",
+    "add_tab_screenshot",
+    "add_selection",
+    "save_page_to_pod",
+  ].forEach((menuId) => {
+    chrome.contextMenus.update(menuId, { enabled: !isDisabled });
+  });
 };
 
 /**
@@ -229,6 +232,12 @@ export const getActionHandler = (menuItemId: string | number) => {
           includeContent: true,
           includeCapture: false,
           includeSelectionOnly: true,
+        });
+      };
+    case "save_page_to_pod":
+      return () => {
+        void chrome.runtime.sendMessage({
+          type: "EXT_SAVE_TO_POD",
         });
       };
   }

--- a/extension/shared/hooks/useCaptureActions.ts
+++ b/extension/shared/hooks/useCaptureActions.ts
@@ -1,7 +1,12 @@
+import { useActivePodId } from "@app/hooks/useActivePodId";
 import { useExtensionConfig } from "@app/lib/swr/extension";
+import { usePodFiles } from "@app/lib/swr/pods";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCurrentUrlAndDomain } from "@extension/shared/hooks/useCurrentDomain";
-import type { CaptureActions } from "@extension/shared/services/platform";
+import type {
+  CaptureActions,
+  SavePageToPodActions,
+} from "@extension/shared/services/platform";
 import { useCallback, useMemo } from "react";
 
 export function useCaptureActions(
@@ -10,10 +15,18 @@ export function useCaptureActions(
     includeContent: boolean;
     includeCapture: boolean;
   }) => Promise<unknown>,
-  isCapturing: boolean
+  isCapturing: boolean,
+  savePageToPodActions?: SavePageToPodActions | null
 ): CaptureActions | undefined {
+  const activePodId = useActivePodId();
   const { currentDomain, currentUrl } = useCurrentUrlAndDomain();
   const { blacklistedDomains } = useExtensionConfig(workspace);
+
+  const { refreshPodFiles } = usePodFiles({
+    owner: workspace,
+    podId: activePodId ?? "",
+    disabled: true,
+  });
 
   const handleCapture = useCallback(
     (type: "text" | "screenshot") => {
@@ -33,6 +46,22 @@ export function useCaptureActions(
     [uploadContentTab]
   );
 
+  const handleSavePageToPod = useCallback(async () => {
+    if (!savePageToPodActions) {
+      return;
+    }
+
+    if (!activePodId) {
+      savePageToPodActions.openSavePageToPodDialog();
+      return;
+    }
+
+    const saved = await savePageToPodActions.savePageToPod(activePodId);
+    if (saved) {
+      await refreshPodFiles();
+    }
+  }, [activePodId, refreshPodFiles, savePageToPodActions]);
+
   const isEnabled = useMemo(() => {
     if (currentDomain === "chrome" || currentDomain === "firefox-internal") {
       return false;
@@ -45,8 +74,26 @@ export function useCaptureActions(
     );
   }, [currentDomain, currentUrl, blacklistedDomains]);
 
-  return useMemo(
-    () => (isEnabled ? { onCapture: handleCapture, isCapturing } : undefined),
-    [handleCapture, isCapturing, isEnabled]
-  );
+  return useMemo(() => {
+    if (!isEnabled) {
+      return undefined;
+    }
+
+    return {
+      onCapture: handleCapture,
+      isCapturing,
+      ...(savePageToPodActions
+        ? {
+            onSavePageToPod: handleSavePageToPod,
+            isSavingPageToPod: savePageToPodActions.isSavingPageToPod,
+          }
+        : {}),
+    };
+  }, [
+    handleCapture,
+    handleSavePageToPod,
+    isCapturing,
+    isEnabled,
+    savePageToPodActions,
+  ]);
 }

--- a/extension/shared/messages.ts
+++ b/extension/shared/messages.ts
@@ -75,11 +75,20 @@ export type AttachSelectionMessage = {
   type: "EXT_ATTACH_TAB";
 } & CaptureOptions;
 
+export type SaveToPodMessage = {
+  type: "EXT_SAVE_TO_POD";
+};
+
 export type RouteChangeMesssage = {
   type: "EXT_ROUTE_CHANGE";
   pathname: string;
   search: string;
 };
+
+export type ExtensionAppMessage =
+  | AttachSelectionMessage
+  | RouteChangeMesssage
+  | SaveToPodMessage;
 
 export type CaptureFullPageMessage = {
   type: "PAGE_CAPTURE_FULL_PAGE";

--- a/extension/shared/services/browser_messaging.ts
+++ b/extension/shared/services/browser_messaging.ts
@@ -1,18 +1,18 @@
-import type { AttachSelectionMessage } from "@extension/shared/messages";
+import type { ExtensionAppMessage } from "@extension/shared/messages";
 import type { BrowserMessagingService } from "@extension/shared/services/platform";
 
 export class ChromeFirefoxBrowserMessagingService
   implements BrowserMessagingService
 {
   addMessageListener(
-    listener: (message: AttachSelectionMessage) => void | Promise<void>
+    listener: (message: ExtensionAppMessage) => void | Promise<void>
   ) {
     chrome.runtime.onMessage.addListener(listener);
     return () => this.removeMessageListener(listener);
   }
 
   removeMessageListener(
-    listener: (message: AttachSelectionMessage) => void | Promise<void>
+    listener: (message: ExtensionAppMessage) => void | Promise<void>
   ) {
     chrome.runtime.onMessage.removeListener(listener);
   }

--- a/extension/shared/services/platform.ts
+++ b/extension/shared/services/platform.ts
@@ -7,6 +7,14 @@ import type { StorageService } from "@extension/shared/services/storage";
 export interface CaptureActions {
   onCapture: (type: "text" | "screenshot") => void;
   isCapturing: boolean;
+  onSavePageToPod?: () => Promise<void>;
+  isSavingPageToPod?: boolean;
+}
+
+export interface SavePageToPodActions {
+  isSavingPageToPod: boolean;
+  openSavePageToPodDialog: () => void;
+  savePageToPod: (podId: string) => Promise<boolean>;
 }
 
 export type UseCaptureActionsHook = (
@@ -15,7 +23,8 @@ export type UseCaptureActionsHook = (
     includeContent: boolean;
     includeCapture: boolean;
   }) => Promise<unknown>,
-  isCapturing: boolean
+  isCapturing: boolean,
+  savePageToPodActions?: SavePageToPodActions | null
 ) => CaptureActions | undefined;
 
 const PLATFORM_TYPES = ["chrome", "front", "firefox"] as const;

--- a/extension/ui/components/auth/ProtectedRoute.tsx
+++ b/extension/ui/components/auth/ProtectedRoute.tsx
@@ -2,6 +2,7 @@ import { cn, Spinner } from "@dust-tt/sparkle";
 import { usePlatform } from "@extension/shared/context/PlatformContext";
 import type { RouteChangeMesssage } from "@extension/shared/messages";
 import { useExtensionAuth } from "@extension/ui/components/auth/AuthProvider";
+import { ExtensionQuickActionsProvider } from "@extension/ui/components/quick_actions/ExtensionQuickActionsProvider";
 import { useEffect } from "react";
 import { Outlet, useNavigate } from "react-router-dom";
 
@@ -59,7 +60,9 @@ export const ProtectedRoute = () => {
         "dark:bg-background-night dark:text-foreground-night"
       )}
     >
-      <Outlet />
+      <ExtensionQuickActionsProvider owner={workspace}>
+        <Outlet />
+      </ExtensionQuickActionsProvider>
     </div>
   );
 };

--- a/extension/ui/components/conversation/ExtensionInputBarProvider.tsx
+++ b/extension/ui/components/conversation/ExtensionInputBarProvider.tsx
@@ -8,6 +8,7 @@ import type { LightWorkspaceType } from "@app/types/user";
 import { usePlatform } from "@extension/shared/context/PlatformContext";
 import type { AttachSelectionMessage } from "@extension/shared/messages";
 import { useSearchParam } from "@extension/shared/platform";
+import { useExtensionQuickActions } from "@extension/ui/components/quick_actions/ExtensionQuickActionsProvider";
 import { useFileUploaderService } from "@extension/ui/hooks/useFileUploaderService";
 import type { ReactNode } from "react";
 import { useContext, useEffect, useState } from "react";
@@ -24,6 +25,7 @@ export function ExtensionInputBarProvider({
   children,
 }: ExtensionInputBarProviderProps) {
   const platform = usePlatform();
+  const quickActions = useExtensionQuickActions();
   const fileUploaderService = useFileUploaderService(
     platform.capture,
     conversationId
@@ -32,7 +34,8 @@ export function ExtensionInputBarProvider({
   const captureActions = platform.useCaptureActions(
     workspace,
     fileUploaderService.uploadContentTab,
-    fileUploaderService.isCapturing
+    fileUploaderService.isCapturing,
+    quickActions
   );
 
   // Reset fileBlobs when conversationId changes.

--- a/extension/ui/components/quick_actions/ExtensionQuickActionsProvider.tsx
+++ b/extension/ui/components/quick_actions/ExtensionQuickActionsProvider.tsx
@@ -1,0 +1,82 @@
+import type { LightWorkspaceType } from "@app/types/user";
+import { usePlatform } from "@extension/shared/context/PlatformContext";
+import type { ExtensionAppMessage } from "@extension/shared/messages";
+import { SavePageToPodDialog } from "@extension/ui/components/quick_actions/SavePageToPodDialog";
+import { useSavePageToPod } from "@extension/ui/hooks/useSavePageToPod";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+interface ExtensionQuickActionsContextValue {
+  isSavingPageToPod: boolean;
+  openSavePageToPodDialog: () => void;
+  savePageToPod: (podId: string) => Promise<boolean>;
+}
+
+const ExtensionQuickActionsContext =
+  createContext<ExtensionQuickActionsContextValue | null>(null);
+
+export function useExtensionQuickActions() {
+  return useContext(ExtensionQuickActionsContext);
+}
+
+interface ExtensionQuickActionsProviderProps {
+  owner: LightWorkspaceType;
+  children: ReactNode;
+}
+
+export function ExtensionQuickActionsProvider({
+  owner,
+  children,
+}: ExtensionQuickActionsProviderProps) {
+  const platform = usePlatform();
+  const { isSaving, savePageToPod } = useSavePageToPod({ owner });
+  const [showSaveToPodDialog, setShowSaveToPodDialog] = useState(false);
+
+  const openSavePageToPodDialog = useCallback(() => {
+    setShowSaveToPodDialog(true);
+  }, []);
+
+  useEffect(() => {
+    const cleanup = platform.messaging?.addMessageListener(
+      (message: ExtensionAppMessage) => {
+        if (message.type !== "EXT_SAVE_TO_POD") {
+          return;
+        }
+        openSavePageToPodDialog();
+      }
+    );
+
+    return () => {
+      cleanup?.();
+    };
+  }, [openSavePageToPodDialog, platform.messaging]);
+
+  const contextValue = useMemo(
+    () => ({
+      isSavingPageToPod: isSaving,
+      openSavePageToPodDialog,
+      savePageToPod,
+    }),
+    [isSaving, openSavePageToPodDialog, savePageToPod]
+  );
+
+  return (
+    <ExtensionQuickActionsContext.Provider value={contextValue}>
+      <SavePageToPodDialog
+        owner={owner}
+        isOpen={showSaveToPodDialog}
+        onClose={() => setShowSaveToPodDialog(false)}
+        onSelect={savePageToPod}
+        isSaving={isSaving}
+      />
+      {children}
+    </ExtensionQuickActionsContext.Provider>
+  );
+}

--- a/extension/ui/components/quick_actions/SavePageToPodDialog.tsx
+++ b/extension/ui/components/quick_actions/SavePageToPodDialog.tsx
@@ -1,0 +1,206 @@
+import { useActivePodId } from "@app/hooks/useActivePodId";
+import { getSpaceIcon } from "@app/lib/spaces";
+import { usePodFiles } from "@app/lib/swr/pods";
+import { useSpaces } from "@app/lib/swr/spaces";
+import { isManualPodFilesManagementAllowed } from "@app/lib/workspace_policies";
+import { isProjectType, type PodType } from "@app/types/space";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Button,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Icon,
+  ListGroup,
+  ListItem,
+  SearchInput,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+type RefreshPodFiles = () => Promise<void>;
+
+interface SavePageToPodDialogProps {
+  owner: LightWorkspaceType;
+  isOpen: boolean;
+  onClose: () => void;
+  onSelect: (podId: string) => Promise<boolean>;
+  isSaving: boolean;
+}
+
+export function SavePageToPodDialog({
+  owner,
+  isOpen,
+  onClose,
+  onSelect,
+  isSaving,
+}: SavePageToPodDialogProps) {
+  const activePodId = useActivePodId();
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedPodId, setSelectedPodId] = useState<string | null>(null);
+
+  const {
+    spaces: pods,
+    isSpacesLoading: isPodsLoading,
+    isSpacesError: isPodsError,
+  } = useSpaces({
+    kinds: ["project"],
+    workspaceId: owner.sId,
+    disabled: !isOpen,
+  });
+  const canManuallyManagePodFiles = isManualPodFilesManagementAllowed(owner);
+  const isBusy = isSaving || selectedPodId !== null;
+
+  useEffect(() => {
+    if (!isOpen) {
+      setSearchQuery("");
+      setSelectedPodId(null);
+    }
+  }, [isOpen]);
+
+  const filteredPods: PodType[] = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+
+    return pods.filter(
+      (pod): pod is PodType =>
+        isProjectType(pod) &&
+        !pod.archivedAt &&
+        pod.name.toLowerCase().includes(query)
+    );
+  }, [searchQuery, pods]);
+
+  const activePod =
+    activePodId !== null && searchQuery.trim() === ""
+      ? filteredPods.find((pod) => pod.sId === activePodId)
+      : null;
+  const orderedPods = activePod
+    ? [activePod, ...filteredPods.filter((pod) => pod.sId !== activePod.sId)]
+    : filteredPods;
+
+  const handleSelect = useCallback(
+    async (pod: PodType, refreshPodFiles: RefreshPodFiles) => {
+      setSelectedPodId(pod.sId);
+      try {
+        const saved = await onSelect(pod.sId);
+        if (saved) {
+          await refreshPodFiles();
+          onClose();
+        }
+      } finally {
+        setSelectedPodId(null);
+      }
+    },
+    [onClose, onSelect]
+  );
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open && !isBusy) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent size="md">
+        <DialogHeader>
+          <DialogTitle>Save page to Pod</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>
+          <div className="flex flex-col gap-3">
+            <SearchInput
+              name="save-page-to-pod-search"
+              placeholder="Search Pods"
+              value={searchQuery}
+              onChange={setSearchQuery}
+              disabled={isBusy}
+            />
+
+            <div className="max-h-80 overflow-y-auto rounded-lg border-x border-border dark:border-border-night">
+              <ListGroup>
+                {isPodsLoading ? (
+                  <div className="flex items-center justify-center py-8">
+                    <Spinner size="sm" />
+                  </div>
+                ) : isPodsError ? (
+                  <div className="px-3 py-4 text-sm text-muted-foreground dark:text-muted-foreground-night">
+                    Failed to load Pods.
+                  </div>
+                ) : !canManuallyManagePodFiles ? (
+                  <div className="px-3 py-4 text-sm text-muted-foreground dark:text-muted-foreground-night">
+                    Adding files to Pods is disabled by your workspace admin.
+                  </div>
+                ) : filteredPods.length === 0 ? (
+                  <div className="px-3 py-4 text-sm text-muted-foreground dark:text-muted-foreground-night">
+                    No Pods found.
+                  </div>
+                ) : (
+                  orderedPods.map((pod) => (
+                    <PodPickerListItem
+                      key={pod.sId}
+                      owner={owner}
+                      pod={pod}
+                      isSelected={selectedPodId === pod.sId}
+                      isDisabled={isBusy || !canManuallyManagePodFiles}
+                      onSelect={handleSelect}
+                    />
+                  ))
+                )}
+              </ListGroup>
+            </div>
+          </div>
+        </DialogContainer>
+        <DialogFooter>
+          <Button
+            label="Cancel"
+            variant="outline"
+            onClick={onClose}
+            disabled={isBusy}
+          />
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function PodPickerListItem({
+  owner,
+  pod,
+  isSelected,
+  isDisabled,
+  onSelect,
+}: {
+  owner: LightWorkspaceType;
+  pod: PodType;
+  isSelected: boolean;
+  isDisabled: boolean;
+  onSelect: (pod: PodType, refreshPodFiles: RefreshPodFiles) => Promise<void>;
+}) {
+  const { refreshPodFiles } = usePodFiles({
+    owner,
+    podId: pod.sId,
+    disabled: true,
+  });
+
+  return (
+    <ListItem
+      itemsAlignment="center"
+      onClick={
+        isDisabled
+          ? undefined
+          : () => {
+              void onSelect(pod, refreshPodFiles);
+            }
+      }
+    >
+      <Icon visual={getSpaceIcon(pod)} size="xs" />
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        <span className="min-w-0 truncate font-medium">{pod.name}</span>
+      </div>
+      {isSelected && <Spinner size="xs" />}
+    </ListItem>
+  );
+}

--- a/extension/ui/hooks/useSavePageToPod.ts
+++ b/extension/ui/hooks/useSavePageToPod.ts
@@ -1,0 +1,120 @@
+import { useFileUploaderService as useFrontFileUploaderService } from "@app/hooks/useFileUploaderService";
+import type { LightWorkspaceType } from "@app/types/user";
+// biome-ignore lint/plugin/noDirectSparkleNotification: extension notification provider setup follows this pattern.
+import { useSendNotification } from "@dust-tt/sparkle";
+import { usePlatform } from "@extension/shared/context/PlatformContext";
+import { useCallback, useMemo, useState } from "react";
+
+function sanitizeFileName(fileName: string) {
+  return fileName.replace(/[\\/:*?"<>|]/g, "-").trim() || "page";
+}
+
+export function useSavePageToPod({ owner }: { owner: LightWorkspaceType }) {
+  const platform = usePlatform();
+  const sendNotification = useSendNotification();
+  const [isCapturing, setIsCapturing] = useState(false);
+
+  const { handleFilesUpload, isProcessingFiles, resetUpload } =
+    useFrontFileUploaderService({
+      hasSandboxTools: false,
+      owner,
+      useCase: "project_context",
+    });
+
+  const savePageToPod = useCallback(
+    async (podId: string) => {
+      if (!platform.capture) {
+        return false;
+      }
+
+      setIsCapturing(true);
+
+      try {
+        const contentRes = await platform.capture.handleOperation(
+          "capture-page-content",
+          {
+            includeContent: true,
+            includeCapture: false,
+          }
+        );
+        setIsCapturing(false);
+
+        if (contentRes && contentRes.isErr()) {
+          sendNotification({
+            title: "Cannot get page content",
+            description: contentRes.error.message,
+            type: "error",
+          });
+          return false;
+        }
+
+        const tabContent =
+          contentRes && contentRes.isOk() ? contentRes.value : null;
+
+        if (!tabContent?.content) {
+          sendNotification({
+            title: "Cannot get page content",
+            description: "No content found.",
+            type: "error",
+          });
+          return false;
+        }
+
+        const parts = [];
+        if (tabContent.title) {
+          parts.push(`Title: ${tabContent.title}`);
+        }
+        if (tabContent.url) {
+          parts.push(`URL: ${tabContent.url}`);
+        }
+        if (parts.length > 0) {
+          parts.push("");
+        }
+        parts.push(tabContent.content);
+
+        const file = new File(
+          [parts.join("\n")],
+          `${sanitizeFileName(tabContent.title || "page")}.md`,
+          {
+            type: "text/markdown",
+          }
+        );
+
+        const uploadedFiles = await handleFilesUpload([file], {
+          useCaseMetadata: { spaceId: podId },
+        });
+
+        resetUpload();
+
+        if (!uploadedFiles || uploadedFiles.length === 0) {
+          return false;
+        }
+
+        sendNotification({
+          title: "Page saved",
+          description: `Saved "${tabContent.title || "page"}" to the selected Pod.`,
+          type: "success",
+        });
+
+        return true;
+      } catch {
+        sendNotification({
+          title: "Cannot save page",
+          description: "Something wrong happened.",
+          type: "error",
+        });
+        setIsCapturing(false);
+        return false;
+      }
+    },
+    [handleFilesUpload, platform.capture, resetUpload, sendNotification]
+  );
+
+  return useMemo(
+    () => ({
+      isSaving: isCapturing || isProcessingFiles,
+      savePageToPod,
+    }),
+    [isCapturing, isProcessingFiles, savePageToPod]
+  );
+}

--- a/extension/ui/pages/PodMainPage.tsx
+++ b/extension/ui/pages/PodMainPage.tsx
@@ -12,6 +12,7 @@ import { useSpaceInfo } from "@app/lib/swr/spaces";
 import {
   ChatBubbleLeftRightIcon,
   CheckCircleIcon,
+  FolderIcon,
   Spinner,
   Tabs,
   TabsList,
@@ -87,10 +88,26 @@ export const PodMainPage = () => {
             <TabsList border={false}>
               <TabsTrigger
                 value="conversations"
-                label="Conversations"
+                label={
+                  currentTab === "conversations" ? "Conversations" : undefined
+                }
+                tooltip={
+                  currentTab !== "conversations" ? "Conversations" : undefined
+                }
                 icon={ChatBubbleLeftRightIcon}
               />
-              <TabsTrigger value="tasks" label="Tasks" icon={CheckCircleIcon} />
+              <TabsTrigger
+                value="tasks"
+                label={currentTab === "tasks" ? "Tasks" : undefined}
+                tooltip={currentTab !== "tasks" ? "Tasks" : undefined}
+                icon={CheckCircleIcon}
+              />
+              <TabsTrigger
+                value="files"
+                label={currentTab === "files" ? "Files" : undefined}
+                tooltip={currentTab !== "files" ? "Files" : undefined}
+                icon={FolderIcon}
+              />
             </TabsList>
           </div>
         }

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -57,6 +57,7 @@ import {
   CameraIcon,
   Chip,
   cn,
+  DocumentPlusIcon,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -1346,6 +1347,21 @@ const InputBarContainer = ({
                               />
                             }
                           />
+                          {captureActions.onSavePageToPod && (
+                            <DropdownMenuItem
+                              icon={DocumentPlusIcon}
+                              label="Save page to Pod"
+                              disabled={
+                                disableInput ||
+                                captureActions.isCapturing ||
+                                captureActions.isSavingPageToPod ||
+                                fileUploaderService.isProcessingFiles
+                              }
+                              onClick={() => {
+                                void captureActions.onSavePageToPod?.();
+                              }}
+                            />
+                          )}
                         </>
                       )}
                     </DropdownMenuContent>

--- a/front/components/assistant/conversation/input_bar/InputBarContext.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContext.tsx
@@ -24,6 +24,13 @@ export type PendingConversationMessage = {
   contentFragments: ContentFragmentsType;
 };
 
+type CaptureActions = {
+  onCapture: (type: "text" | "screenshot") => void;
+  isCapturing: boolean;
+  onSavePageToPod?: () => Promise<void>;
+  isSavingPageToPod?: boolean;
+};
+
 export const InputBarContext = createContext<{
   animate: boolean;
   getAndClearSelectedAgent: () => RichAgentMention | null;
@@ -42,10 +49,7 @@ export const InputBarContext = createContext<{
   ) => void;
   clearPendingFirstMessage: (conversationId: string) => void;
   fileUploaderService: FileUploaderService;
-  captureActions?: {
-    onCapture: (type: "text" | "screenshot") => void;
-    isCapturing: boolean;
-  };
+  captureActions?: CaptureActions;
 }>({
   animate: false,
   getAndClearSelectedAgent: () => null,
@@ -74,10 +78,7 @@ export const InputBarContext = createContext<{
 interface InputBarContextProviderProps {
   children: ReactNode;
   fileUploaderService: FileUploaderService;
-  captureActions?: {
-    onCapture: (type: "text" | "screenshot") => void;
-    isCapturing: boolean;
-  };
+  captureActions?: CaptureActions;
 }
 
 export function InputBarContextProvider({

--- a/front/lib/swr/pods.ts
+++ b/front/lib/swr/pods.ts
@@ -117,9 +117,9 @@ export function usePodFiles({
 
   const { data, error, mutate, mutateRegardlessOfQueryParams } =
     useSWRWithDefaults(
-      disabled || !podId ? null : `/api/w/${owner.sId}/spaces/${podId}/files`,
+      !podId ? null : `/api/w/${owner.sId}/spaces/${podId}/files`,
       podFilesFetcher,
-      { keepPreviousData: true }
+      { disabled, keepPreviousData: true }
     );
 
   const refreshPodFiles = useCallback(async () => {


### PR DESCRIPTION
## Description

This PR adds a "Save page to Pod" feature to the browser extension, allowing users to save the current web page's content directly to a Pod via a context menu item or the input bar.

- Adds a new `save_page_to_pod` context menu entry in Chrome and Firefox background scripts, dispatching an `EXT_SAVE_TO_POD` message
- Introduces `ExtensionQuickActionsProvider` to listen for the message and manage the save-to-pod dialog state globally
- Creates `SavePageToPodDialog` for picking a target Pod, and `useSavePageToPod` hook to capture page content and upload it as a Markdown file
- Exposes `onSavePageToPod` / `isSavingPageToPod` through `CaptureActions` and wires them into the input bar dropdown


https://github.com/user-attachments/assets/bfe0ac11-b974-4ca8-a90d-5e4eaa550793



## Tests

Manually.

## Risks
Low.
<!-- Discuss potential risks and how they will be mitigated. -->

## Deploy Plan
Standard deployment.
<!-- Outline the deployment steps if needed. -->

