### PR TITLE
[front] enh: fetch usage tables sequentially for table=all exports

### DIFF
--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -810,14 +810,21 @@ export async function fetchUsageData({
         feedback: await getFeedbackUsageData(start, end, workspace),
       };
     case "all":
-      const [users, assistant_messages, builders, assistants, feedback] =
-        await Promise.all([
-          getUserUsageData(start, end, workspace, { includeInactive }),
-          getMessageUsageData(start, end, workspace),
-          getBuildersUsageData(start, end, workspace),
-          getAssistantsUsageData(start, end, workspace, { includeInactive }),
-          getFeedbackUsageData(start, end, workspace),
-        ]);
+      // Sequential on purpose: each query is heavy, running them in parallel
+      // spikes load on the read replica.
+      const users = await getUserUsageData(start, end, workspace, {
+        includeInactive,
+      });
+      const assistant_messages = await getMessageUsageData(
+        start,
+        end,
+        workspace
+      );
+      const builders = await getBuildersUsageData(start, end, workspace);
+      const assistants = await getAssistantsUsageData(start, end, workspace, {
+        includeInactive,
+      });
+      const feedback = await getFeedbackUsageData(start, end, workspace);
       return { users, assistant_messages, builders, assistants, feedback };
     default:
       assertNever(table);


### PR DESCRIPTION
## Description

Promise.all ran the five heavy export queries concurrently, spiking load on the read replica for every table=all workspace-usage request.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low, endpoint will be slower but load on replica will be lighter

## Deploy Plan

front