### PR TITLE
[front] Only surface egress allowlist denials to sandbox agents

### DIFF
--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -352,6 +352,106 @@ describe("runSandboxBashTool", () => {
     expect(first.text).not.toContain(secretValue);
   });
 
+  it("surfaces only allowlist denials and drops harness deny reasons", async () => {
+    mockLoadEnv.mockResolvedValue(new Ok({}));
+    mockReadNewDenyLogEntries.mockResolvedValue(
+      new Ok([
+        JSON.stringify({
+          ts: "t",
+          reason: "proxy_denied",
+          domain: "example.com",
+          port: 443,
+          secret_name: "unknown",
+          sni: null,
+          host: null,
+        }),
+        JSON.stringify({
+          ts: "t",
+          reason: "placeholder_on_non_allowed",
+          domain: "api.openai.com",
+          port: 443,
+          secret_name: "OPENAI_API_KEY",
+          sni: "api.openai.com",
+          host: "api.openai.com",
+        }),
+      ])
+    );
+    const sandbox = {
+      providerId: "provider-id",
+      sId: "sandbox-id",
+      exec: vi
+        .fn()
+        .mockResolvedValue(new Ok({ exitCode: 0, stdout: "ok", stderr: "" })),
+    };
+
+    mockEnsureSandboxReady.mockResolvedValue(
+      new Ok({ sandbox, freshlyCreated: false })
+    );
+
+    const result = await runSandboxBashTool(
+      { command: "echo ok", description: "Run command" },
+      makeExtra()
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    const first = result.value[0];
+    if (first.type !== "text") {
+      throw new Error(`expected text item, got ${first.type}`);
+    }
+    expect(first.text).toContain(
+      "<network_proxy_logs>\ndenied example.com:443 (blocked by egress allowlist)\n</network_proxy_logs>"
+    );
+    // Harness request-policy denials must not masquerade as domain blocks.
+    expect(first.text).not.toContain("placeholder_on_non_allowed");
+    expect(first.text).not.toContain("api.openai.com");
+  });
+
+  it("omits the network proxy logs block when only harness denials are present", async () => {
+    mockLoadEnv.mockResolvedValue(new Ok({}));
+    mockReadNewDenyLogEntries.mockResolvedValue(
+      new Ok([
+        JSON.stringify({
+          ts: "t",
+          reason: "host_sni_mismatch",
+          domain: "api.openai.com",
+          port: 443,
+          secret_name: "unknown",
+          sni: "api.openai.com",
+          host: "evil.example",
+        }),
+      ])
+    );
+    const sandbox = {
+      providerId: "provider-id",
+      sId: "sandbox-id",
+      exec: vi
+        .fn()
+        .mockResolvedValue(new Ok({ exitCode: 0, stdout: "ok", stderr: "" })),
+    };
+
+    mockEnsureSandboxReady.mockResolvedValue(
+      new Ok({ sandbox, freshlyCreated: false })
+    );
+
+    const result = await runSandboxBashTool(
+      { command: "echo ok", description: "Run command" },
+      makeExtra()
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    const first = result.value[0];
+    if (first.type !== "text") {
+      throw new Error(`expected text item, got ${first.type}`);
+    }
+    expect(first.text).not.toContain("<network_proxy_logs>");
+  });
+
   it("does not redact short or low-entropy values", async () => {
     mockLoadEnv.mockResolvedValue(
       new Ok({

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -47,6 +47,7 @@ import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import { isDevelopment } from "@app/types/shared/env";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import { z } from "zod";
 
 const DEFAULT_WORKING_DIRECTORY = "/home/agent";
 const DEFAULT_EXEC_TIMEOUT_MS = 24 * 60 * 60 * 1000; // 24h
@@ -85,6 +86,53 @@ function formatExecOutput(
   }
 
   return sections.join("\n") || "(no output)";
+}
+
+// The egress proxy's domain-allowlist gate writes this reason. It is the only
+// deny reason that means "this domain was blocked" and is actionable by the
+// agent (ask an admin / add_egress_domain).
+const PROXY_ALLOWLIST_DENY_REASON = "proxy_denied";
+
+const DenyLogLineSchema = z.object({
+  reason: z.string(),
+  domain: z.string().nullish(),
+  port: z.number().nullish(),
+});
+
+function safeJsonParse(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+// The sandbox deny log is written by two distinct layers into one file: the
+// egress proxy's domain-allowlist gate (`proxy_denied`) and the in-sandbox
+// request-rewrite harness (malformed headers, secret-to-host scoping, SNI
+// checks, ...). Only the allowlist denials mean "this domain was blocked".
+// Surfacing the harness reasons under the same `<network_proxy_logs>` block
+// makes agents misread auth/4xx failures on *allowed* domains as proxy blocks,
+// so we keep only allowlist denials for the agent and present them as a clean,
+// unambiguous line. Unrecognized lines are kept verbatim (fail open) so we
+// never silently swallow a real denial we don't understand.
+function filterAgentFacingDenyLogEntries(rawLines: string[]): string[] {
+  return rawLines.flatMap((line) => {
+    const parsed = DenyLogLineSchema.safeParse(safeJsonParse(line));
+    if (!parsed.success) {
+      return [line];
+    }
+    if (parsed.data.reason !== PROXY_ALLOWLIST_DENY_REASON) {
+      return [];
+    }
+    const { domain, port } = parsed.data;
+    if (!domain) {
+      return [line];
+    }
+    return [
+      `denied ${domain}${port ? `:${port}` : ""} (blocked by egress allowlist)`,
+    ];
+  });
 }
 
 // Shannon entropy in bits/char. Uniform random characters approach
@@ -399,7 +447,10 @@ export async function runSandboxBashTool(
       "Failed to read egress deny log"
     );
   } else if (denyResult.value.length > 0) {
-    denyLogEntries = denyResult.value;
+    const filtered = filterAgentFacingDenyLogEntries(denyResult.value);
+    if (filtered.length > 0) {
+      denyLogEntries = filtered;
+    }
   }
 
   const output = formatExecOutput(execResult.value, { denyLogEntries });

--- a/front/lib/resources/skill/code_defined/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.ts
@@ -156,10 +156,18 @@ Workspace allowlist:
 
 ${formatWorkspaceAllowlist(workspaceDomains)}
 
-If a request is blocked, the bash tool output will include a
-\`<network_proxy_logs>\` block listing the denied domain(s). Surface that
+If a domain is blocked by the allowlist, the bash tool output will include a
+\`<network_proxy_logs>\` block naming the denied domain(s). Surface that
 information to the user so they can decide whether to ask their admin to
-allowlist it; do not retry without changes.`;
+allowlist it; do not retry without changes.
+
+The block lists **only** domains rejected by the allowlist. A request that
+reaches an allowed domain and comes back with an HTTP \`401\`/\`403\` (or any
+other \`4xx\`) in \`<stdout>\` is an upstream authentication/authorization
+error, not a proxy block — do not treat it as a domain that needs
+allowlisting. If the block names a host you did not call directly, the request
+most likely followed a redirect to that host (for example an auth/login
+domain).`;
   }
 
   return `#### Sandbox Network Access
@@ -188,13 +196,21 @@ do NOT call \`add_egress_domain\`; just use the domain. Only call
 accepted) and a one-sentence reason the user will see in the approval prompt.
 This is preferable to running the command first and reacting to a denial.
 
-If a request does get blocked — for example because you missed a domain or
-a redirect chain hits an unexpected host — the bash tool output will
-include a \`<network_proxy_logs>\` block listing the denied domain(s).
+If a request is blocked by the allowlist — for example because you missed a
+domain or a redirect chain hits an unexpected host — the bash tool output
+will include a \`<network_proxy_logs>\` block naming the denied domain(s).
 Use that block to identify the missing domain and call
-\`add_egress_domain\` to unblock the next attempt. If a request mysteriously
-hangs or fails with TLS/DNS errors, check the \`<network_proxy_logs>\`
-block first; a denied egress is a possible cause.`;
+\`add_egress_domain\` to unblock the next attempt.
+
+The block lists **only** domains rejected by the allowlist. A request that
+reaches an allowed domain and returns an HTTP \`401\`/\`403\` (or any other
+\`4xx\`) in \`<stdout>\` is an upstream authentication/authorization error, not
+a proxy block — do **not** call \`add_egress_domain\` for it. If the block
+names a host you did not call directly, the request most likely followed a
+redirect to that host (such as an auth/login domain); allowlist that host only
+if you intend to follow the redirect. If a request mysteriously hangs or fails
+with TLS/DNS errors, check the \`<network_proxy_logs>\` block first; a denied
+egress is a possible cause.`;
 }
 
 function buildEnvironmentVariablesSection(): string {


### PR DESCRIPTION
## Description

Sandbox agents kept reading "unauthorized" / 4xx failures on whitelisted domains as egress proxy denials. Root cause: the sandbox deny log (`/tmp/dust-egress-denied.log`) is written by two different layers into one file, and both were dumped raw into the `<network_proxy_logs>` block shown to the agent:

- the egress proxy's domain-allowlist gate, reason `proxy_denied` (the only "this domain was blocked" signal, actionable via `add_egress_domain` / admin), and
- the in-sandbox request-rewrite harness, which logs ~12 other reasons (`malformed_headers`, `placeholder_on_non_allowed`, `host_sni_mismatch`, ...) that all fire on domains that are already allowed and reachable.

A plain unauthenticated request to an allowed domain returns its 401/403 in stdout and is not a proxy deny at all, but the framing and the mixed log made the agent conclude the domain was blocked.

Changes:
- `tools/index.ts`: classify deny-log lines and surface only `proxy_denied` to the agent, as a clean `denied <domain>:<port> (blocked by egress allowlist)` line. Other reasons are dropped; unparseable lines are kept verbatim so we never swallow a real denial.
- `sandbox.ts` skill text (both the restricted and `add_egress_domain` variants): the block lists allowlist denials only; a 401/403/4xx in stdout with no deny entry is an upstream auth error, not a proxy block; a denied host you did not call directly is usually a redirect (auth/login).

## Tests

Added two unit tests: one asserting a `proxy_denied` line is surfaced while a `placeholder_on_non_allowed` harness entry is dropped, one asserting the block is omitted entirely when only harness denials are present. Existing redaction test (non-JSON line) still passes via the fail-open path. `npm test lib/api/actions/servers/sandbox/tools/index.test.ts` green (24 tests).

## Risk

Low. Surfacing-only change in `front`, no proxy/sandbox binary changes. Worst case is a harness deny reason no longer shown to the agent, which was misleading anyway; real allowlist blocks and unknown lines are still surfaced.

## Deploy Plan

Standard deploy.