### PR TITLE
[front] add sandbox cold-start phase instrumentation

### DIFF
--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -496,8 +496,9 @@ export async function setupEgressForwarder(
   }
 
   if (restartExisting) {
-    const killResult = await traceSandboxStartupPhase("egress.kill_existing", () =>
-      killEgressForwarder(auth, sandbox)
+    const killResult = await traceSandboxStartupPhase(
+      "egress.kill_existing",
+      () => killEgressForwarder(auth, sandbox)
     );
     if (killResult.isErr()) {
       return killResult;
@@ -571,7 +572,9 @@ export async function setupEgressForwarder(
         await sleep(EGRESS_SETUP_WAIT_MS);
       }
 
-      return new Err(new Error("Sandbox egress did not become healthy in time"));
+      return new Err(
+        new Error("Sandbox egress did not become healthy in time")
+      );
     }
   );
   if (waitResult.isErr()) {

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -7,6 +7,7 @@ import {
 } from "@app/lib/api/sandbox/egress_secrets";
 import { writeSandboxEnvManifestFile } from "@app/lib/api/sandbox/env_manifest";
 import { SANDBOX_AGENT_PROXIED_UID } from "@app/lib/api/sandbox/image/types";
+import { traceSandboxStartupPhase } from "@app/lib/api/sandbox/instrumentation";
 import {
   type RootCommand,
   renderRootCommand,
@@ -245,22 +246,24 @@ export async function checkEgressForwarderHealth(
 
   // Root is required: `nft list table` needs CAP_NET_ADMIN, and the probe also
   // reads /proc/net/{tcp,udp} which is fine non-root but pointless to split.
-  const result = await sandbox.execRoot(
-    auth,
-    rootCommand.exec("/opt/bin/dsbx", [
-      "healthcheck",
-      "--forwarder-listen",
-      EGRESS_FORWARDER_LISTEN_ADDR,
-      "--resolver-listen",
-      EGRESS_RESOLVER_LISTEN_ADDR,
-      "--proxied-uid",
-      EGRESS_PROXIED_UID,
-      "--ca-bundle",
-      MITM_CA_BUNDLE_PATH,
-      "--ca-bundle-marker",
-      MITM_CA_BUNDLE_MARKER_PATH,
-    ]),
-    { timeoutMs: 1_000 }
+  const result = await traceSandboxStartupPhase("egress.healthcheck", () =>
+    sandbox.execRoot(
+      auth,
+      rootCommand.exec("/opt/bin/dsbx", [
+        "healthcheck",
+        "--forwarder-listen",
+        EGRESS_FORWARDER_LISTEN_ADDR,
+        "--resolver-listen",
+        EGRESS_RESOLVER_LISTEN_ADDR,
+        "--proxied-uid",
+        EGRESS_PROXIED_UID,
+        "--ca-bundle",
+        MITM_CA_BUNDLE_PATH,
+        "--ca-bundle-marker",
+        MITM_CA_BUNDLE_MARKER_PATH,
+      ]),
+      { timeoutMs: 1_000 }
+    )
   );
 
   if (result.isErr()) {
@@ -432,9 +435,13 @@ export async function setupEgressForwarder(
     sandboxId: sandbox.sId,
   };
 
+  // resolve_proxy is a Node-side DNS lookup that never becomes a sandbox
+  // command, so it has no provider span — a genuine timing blindspot until now.
   let proxyAddr: string;
   try {
-    proxyAddr = await resolveProxyAddr();
+    proxyAddr = await traceSandboxStartupPhase("egress.resolve_proxy", () =>
+      resolveProxyAddr()
+    );
   } catch (error) {
     return new Err(normalizeError(error));
   }
@@ -443,19 +450,27 @@ export async function setupEgressForwarder(
     sandbox.providerId,
     auth.getNonNullableWorkspace().sId
   );
-  const tokenWriteResult = await sandbox.writeFile(
-    auth,
-    EGRESS_TOKEN_PATH,
-    new TextEncoder().encode(token).buffer
+  const tokenWriteResult = await traceSandboxStartupPhase(
+    "egress.write_token",
+    () =>
+      sandbox.writeFile(
+        auth,
+        EGRESS_TOKEN_PATH,
+        new TextEncoder().encode(token).buffer
+      )
   );
   if (tokenWriteResult.isErr()) {
     return tokenWriteResult;
   }
 
-  const prepareTokenResult = await runSuccessfulRootCommand(
-    auth,
-    sandbox,
-    rootCommand.exec("/usr/bin/chmod", ["600", EGRESS_TOKEN_PATH])
+  const prepareTokenResult = await traceSandboxStartupPhase(
+    "egress.chmod_token",
+    () =>
+      runSuccessfulRootCommand(
+        auth,
+        sandbox,
+        rootCommand.exec("/usr/bin/chmod", ["600", EGRESS_TOKEN_PATH])
+      )
   );
   if (prepareTokenResult.isErr()) {
     return prepareTokenResult;
@@ -464,18 +479,26 @@ export async function setupEgressForwarder(
   // Write the secrets file before killing the old dsbx so a write failure
   // leaves the existing forwarder running instead of taking it down with
   // nothing to replace it.
-  const secretsWriteResult = await writeEgressSecretsFile(auth, sandbox);
+  const secretsWriteResult = await traceSandboxStartupPhase(
+    "egress.write_secrets",
+    () => writeEgressSecretsFile(auth, sandbox)
+  );
   if (secretsWriteResult.isErr()) {
     return secretsWriteResult;
   }
 
-  const manifestWriteResult = await writeSandboxEnvManifestFile(auth, sandbox);
+  const manifestWriteResult = await traceSandboxStartupPhase(
+    "egress.write_manifest",
+    () => writeSandboxEnvManifestFile(auth, sandbox)
+  );
   if (manifestWriteResult.isErr()) {
     return manifestWriteResult;
   }
 
   if (restartExisting) {
-    const killResult = await killEgressForwarder(auth, sandbox);
+    const killResult = await traceSandboxStartupPhase("egress.kill_existing", () =>
+      killEgressForwarder(auth, sandbox)
+    );
     if (killResult.isErr()) {
       return killResult;
     }
@@ -514,35 +537,50 @@ export async function setupEgressForwarder(
     )
   );
 
-  const startResult = await runSuccessfulRootCommand(
-    auth,
-    sandbox,
-    startForwarderCommand
+  const startResult = await traceSandboxStartupPhase(
+    "egress.start_forwarder",
+    () => runSuccessfulRootCommand(auth, sandbox, startForwarderCommand)
   );
   if (startResult.isErr()) {
     return startResult;
   }
 
-  for (let i = 0; i < EGRESS_SETUP_WAIT_RETRIES; i++) {
-    const healthResult = await checkEgressForwarderHealth(auth, sandbox);
-    if (healthResult.isErr()) {
-      return healthResult;
-    }
-    // Setup waits on the forwarder and DNS enforcement. The bundle gets
-    // installed below and is checked on subsequent execs.
-    if (
-      healthResult.value.portOk &&
-      healthResult.value.resolverOk &&
-      healthResult.value.nftablesOk
-    ) {
-      logger.info(logContext, "Sandbox egress is healthy");
-      return installMitmTrustBundle(auth, sandbox);
-    }
+  // wait_healthy brackets the poll loop (≤ EGRESS_SETUP_WAIT_RETRIES iterations
+  // with EGRESS_SETUP_WAIT_MS sleeps + per-iteration healthchecks) so the time
+  // spent waiting for the forwarder + DNS enforcement to come up is measured
+  // separately from installing the trust bundle.
+  const waitResult = await traceSandboxStartupPhase(
+    "egress.wait_healthy",
+    async () => {
+      for (let i = 0; i < EGRESS_SETUP_WAIT_RETRIES; i++) {
+        const healthResult = await checkEgressForwarderHealth(auth, sandbox);
+        if (healthResult.isErr()) {
+          return healthResult;
+        }
+        // Setup waits on the forwarder and DNS enforcement. The bundle gets
+        // installed below and is checked on subsequent execs.
+        if (
+          healthResult.value.portOk &&
+          healthResult.value.resolverOk &&
+          healthResult.value.nftablesOk
+        ) {
+          logger.info(logContext, "Sandbox egress is healthy");
+          return new Ok(undefined);
+        }
 
-    await sleep(EGRESS_SETUP_WAIT_MS);
+        await sleep(EGRESS_SETUP_WAIT_MS);
+      }
+
+      return new Err(new Error("Sandbox egress did not become healthy in time"));
+    }
+  );
+  if (waitResult.isErr()) {
+    return waitResult;
   }
 
-  return new Err(new Error("Sandbox egress did not become healthy in time"));
+  return traceSandboxStartupPhase("egress.install_trust_bundle", () =>
+    installMitmTrustBundle(auth, sandbox)
+  );
 }
 
 async function killEgressForwarder(

--- a/front/lib/api/sandbox/gcs/mount.ts
+++ b/front/lib/api/sandbox/gcs/mount.ts
@@ -4,6 +4,7 @@ import {
 } from "@app/lib/api/files/mount_path";
 import { mintDownscopedGcsToken } from "@app/lib/api/sandbox/gcs/token";
 import type { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
+import { traceSandboxStartupPhase } from "@app/lib/api/sandbox/instrumentation";
 import {
   type RootCommand,
   rootCommand,
@@ -105,11 +106,14 @@ export async function mountConversationFiles(
     prefixes: targets.map((t) => t.prefix),
   });
 
-  // 1. Mint downscoped token covering every prefix.
-  const tokenResult = await mintDownscopedGcsToken({
-    bucket,
-    prefixes: targets.map((t) => t.prefix),
-  });
+  // 1. Mint downscoped token covering every prefix. This is a Node-side GCP
+  // call (no sandbox command, so no provider span) — a real timing blindspot.
+  const tokenResult = await traceSandboxStartupPhase("gcs.mint_token", () =>
+    mintDownscopedGcsToken({
+      bucket,
+      prefixes: targets.map((t) => t.prefix),
+    })
+  );
   if (tokenResult.isErr()) {
     childLogger.error(
       { err: tokenResult.error },
@@ -127,9 +131,11 @@ export async function mountConversationFiles(
   });
 
   // 2. Write token file into the sandbox.
-  const writeResult = await sandbox.exec(
-    auth,
-    `printf '%s' '${escapeSingleQuotes(tokenJson)}' > /tmp/token.json`
+  const writeResult = await traceSandboxStartupPhase("gcs.write_token", () =>
+    sandbox.exec(
+      auth,
+      `printf '%s' '${escapeSingleQuotes(tokenJson)}' > /tmp/token.json`
+    )
   );
   if (writeResult.isErr()) {
     childLogger.error(
@@ -142,9 +148,13 @@ export async function mountConversationFiles(
   // 3. Start token server and wait until it's listening.
   // The server script is a netcat loop baked into the template.
   // Start in background, then verify with a separate exec (matching PoC).
-  const startResult = await sandbox.exec(
-    auth,
-    "bash /home/agent/.bin/token-server.sh > /tmp/server.log 2>&1 &"
+  const startResult = await traceSandboxStartupPhase(
+    "gcs.start_token_server",
+    () =>
+      sandbox.exec(
+        auth,
+        "bash /home/agent/.bin/token-server.sh > /tmp/server.log 2>&1 &"
+      )
   );
   if (startResult.isErr()) {
     childLogger.error(
@@ -154,9 +164,15 @@ export async function mountConversationFiles(
     return startResult;
   }
 
-  const checkResult = await sandbox.exec(
-    auth,
-    "sleep 1 && curl -sf http://127.0.0.1:9876 > /dev/null 2>&1"
+  // wait_token_server brackets the hardcoded `sleep 1` + readiness probe, so
+  // that fixed cost is visible on its own.
+  const checkResult = await traceSandboxStartupPhase(
+    "gcs.wait_token_server",
+    () =>
+      sandbox.exec(
+        auth,
+        "sleep 1 && curl -sf http://127.0.0.1:9876 > /dev/null 2>&1"
+      )
   );
   if (checkResult.isErr() || checkResult.value.exitCode !== 0) {
     const msg = "Token server not ready after 1s";
@@ -169,9 +185,14 @@ export async function mountConversationFiles(
     targets,
     async (target) => {
       const mountCmd = buildMountCommand({ bucket, ...target });
-      const mountResult = await sandbox.execRoot(auth, mountCmd, {
-        timeoutMs: MOUNT_TIMEOUT_MS,
-      });
+      const mountResult = await traceSandboxStartupPhase(
+        "gcs.gcsfuse_mount",
+        () =>
+          sandbox.execRoot(auth, mountCmd, {
+            timeoutMs: MOUNT_TIMEOUT_MS,
+          }),
+        { target: target.label }
+      );
 
       if (mountResult.isErr()) {
         childLogger.error(

--- a/front/lib/api/sandbox/instrumentation.ts
+++ b/front/lib/api/sandbox/instrumentation.ts
@@ -79,14 +79,19 @@ export function traceSandboxStartupPhase<T>(
 // time for one ensureSandboxReady, split cold (fresh create path) vs warm
 // (wake/reuse). This is NOT covered by sandbox.tools.duration, whose timer
 // starts only once setup is already done and times the user command alone.
+//
+// Intentionally NOT tagged by workspace_id: the cold/warm split per region is
+// what matters for latency, and workspace_id would multiply cardinality on a
+// per-ensureSandboxReady distribution. Per-workspace drill-down stays available
+// via APM traces.
 export function recordSandboxStartupTotal(
   durationMs: number,
-  ctx: MetricContext & { cold: boolean },
+  { region, cold }: { region?: string; cold: boolean },
   status: "success" | "error"
 ): void {
   getStatsDClient().distribution("sandbox.startup.total.duration", durationMs, [
-    ...buildTags(ctx),
-    `cold:${ctx.cold}`,
+    `region:${region ?? regionConfig.getCurrentRegion()}`,
+    `cold:${cold}`,
     `status:${status}`,
   ]);
 }

--- a/front/lib/api/sandbox/instrumentation.ts
+++ b/front/lib/api/sandbox/instrumentation.ts
@@ -20,14 +20,16 @@ function buildTags(ctx: MetricContext): string[] {
 // and GROUP the per-command spans that traceSandboxOperation already emits
 // (trace.sandbox.provider.exec / .writeFile / .create / .wake): without a
 // parent span every setup command is an undifferentiated `provider.exec`.
-// The few entries that never become a sandbox command — resolve_proxy (DNS),
-// gcs.mint_token (GCP token mint) — are the real timing blindspots a parent
-// span alone would not cover.
+// The few entries that never become a sandbox command (resolve_proxy DNS,
+// gcs.mint_token GCP token mint) are the real timing blindspots a parent span
+// alone would not cover.
+//
+// Naming: coarse phases are snake_case (`provider_ensure`, `gcs_mount`);
+// sub-steps are `<area>.step` (`gcs.gcsfuse_mount`) so they group by prefix.
 export type SandboxStartupPhase =
   // Coarse phases (one per ensureSandboxReady step).
   | "total"
   | "provider_ensure"
-  | "image_fetch"
   | "egress_prep"
   | "gcs_mount"
   | "gcs_refresh"

--- a/front/lib/api/sandbox/instrumentation.ts
+++ b/front/lib/api/sandbox/instrumentation.ts
@@ -1,6 +1,7 @@
 import { config as regionConfig } from "@app/lib/api/regions/config";
 import type { SandboxStatus } from "@app/lib/resources/storage/models/sandbox";
 import { getStatsDClient } from "@app/lib/utils/statsd";
+import tracer from "@app/logger/tracer";
 
 interface MetricContext {
   workspaceId: string;
@@ -12,6 +13,80 @@ function buildTags(ctx: MetricContext): string[] {
     `workspace_id:${ctx.workspaceId}`,
     `region:${ctx.region ?? regionConfig.getCurrentRegion()}`,
   ];
+}
+
+// Semantic phases of the "zero to first executed command" startup path, in
+// roughly the order they run on a fresh sandbox. These exist purely to LABEL
+// and GROUP the per-command spans that traceSandboxOperation already emits
+// (trace.sandbox.provider.exec / .writeFile / .create / .wake): without a
+// parent span every setup command is an undifferentiated `provider.exec`.
+// The few entries that never become a sandbox command — resolve_proxy (DNS),
+// gcs.mint_token (GCP token mint) — are the real timing blindspots a parent
+// span alone would not cover.
+export type SandboxStartupPhase =
+  // Coarse phases (one per ensureSandboxReady step).
+  | "total"
+  | "provider_ensure"
+  | "image_fetch"
+  | "egress_prep"
+  | "gcs_mount"
+  | "gcs_refresh"
+  | "egress_on_exec"
+  | "telemetry_start"
+  // provider.create split.
+  | "provider.create_vm"
+  | "provider.hardening"
+  // Egress forwarder bring-up sub-steps.
+  | "egress.resolve_proxy"
+  | "egress.write_token"
+  | "egress.chmod_token"
+  | "egress.write_secrets"
+  | "egress.write_manifest"
+  | "egress.kill_existing"
+  | "egress.start_forwarder"
+  | "egress.wait_healthy"
+  | "egress.healthcheck"
+  | "egress.install_trust_bundle"
+  // GCS FUSE mount sub-steps.
+  | "gcs.mint_token"
+  | "gcs.write_token"
+  | "gcs.start_token_server"
+  | "gcs.wait_token_server"
+  | "gcs.gcsfuse_mount";
+
+// Opens a parent APM span for a startup phase. The provider.* child spans nest
+// underneath automatically, so this adds semantic grouping (and a per-phase
+// trace.sandbox.startup.<phase> metric with p50/p95/p99) WITHOUT duplicating
+// the per-command timing that already exists. No statsd here on purpose: phase
+// percentiles come for free from the trace metric.
+export function traceSandboxStartupPhase<T>(
+  phase: SandboxStartupPhase,
+  fn: () => Promise<T>,
+  tags?: Record<string, string>
+): Promise<T> {
+  return tracer.trace("sandbox.startup", { resource: phase }, async (span) => {
+    span?.setTag("phase", phase);
+    if (tags) {
+      Object.entries(tags).forEach(([key, value]) => span?.setTag(key, value));
+    }
+    return fn();
+  });
+}
+
+// The single net-new aggregate metric: the headline "0 -> first command" wall
+// time for one ensureSandboxReady, split cold (fresh create path) vs warm
+// (wake/reuse). This is NOT covered by sandbox.tools.duration, whose timer
+// starts only once setup is already done and times the user command alone.
+export function recordSandboxStartupTotal(
+  durationMs: number,
+  ctx: MetricContext & { cold: boolean },
+  status: "success" | "error"
+): void {
+  getStatsDClient().distribution("sandbox.startup.total.duration", durationMs, [
+    ...buildTags(ctx),
+    `cold:${ctx.cold}`,
+    `status:${status}`,
+  ]);
 }
 
 export function recordLifecycleOperation(

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -32,9 +32,8 @@ export async function ensureSandboxReady(
 ): Promise<Result<EnsureSandboxReadyResult, Error>> {
   const workspaceId = auth.getNonNullableWorkspace().sId;
   const startMs = performance.now();
-  // cold is only known once ensureActive returns; default to a cold-leaning
-  // false only matters if ensureActive itself errors (rare), where the total
-  // is recorded as a failed warm attempt.
+  // cold is unknown until ensureActive returns; if it errors first (rare) we
+  // record the failure as a warm attempt.
   let cold = false;
   let status: "success" | "error" = "success";
 
@@ -44,8 +43,7 @@ export async function ensureSandboxReady(
       async () => {
         const ensureResult = await traceSandboxStartupPhase(
           "provider_ensure",
-          () => SandboxResource.ensureActive(auth, conversation),
-          { workspace_id: workspaceId }
+          () => SandboxResource.ensureActive(auth, conversation)
         );
         if (ensureResult.isErr()) {
           status = "error";
@@ -71,9 +69,8 @@ export async function ensureSandboxReady(
           }
         }
 
-        const imageResult = await traceSandboxStartupPhase("image_fetch", () =>
-          Promise.resolve(getSandboxImage(auth))
-        );
+        // Synchronous and cheap: not worth a span (it would always read ~0ms).
+        const imageResult = getSandboxImage(auth);
         if (imageResult.isErr()) {
           logger.error(
             { err: imageResult.error },
@@ -121,8 +118,7 @@ export async function ensureSandboxReady(
         }
 
         return new Ok({ sandbox, freshlyCreated });
-      },
-      { workspace_id: workspaceId }
+      }
     );
   } finally {
     recordSandboxStartupTotal(

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -38,88 +38,85 @@ export async function ensureSandboxReady(
   let status: "success" | "error" = "success";
 
   try {
-    return await traceSandboxStartupPhase(
-      "total",
-      async () => {
-        const ensureResult = await traceSandboxStartupPhase(
-          "provider_ensure",
-          () => SandboxResource.ensureActive(auth, conversation)
-        );
-        if (ensureResult.isErr()) {
-          status = "error";
-          return ensureResult;
-        }
-
-        const { sandbox, freshlyCreated, wokeFromSleep } = ensureResult.value;
-        cold = freshlyCreated;
-
-        // Egress prep must run BEFORE GCS mounts.
-        // sandbox_resource.buildSandboxEnvVars exports replace-style trust env
-        // vars pointing at /etc/dust/ca-bundle.pem. The image seeds that path
-        // with system roots; forwarder setup later merges in the dsbx CA.
-        // Mounting (gcsfuse and friends) can make HTTPS calls that read the
-        // trust bundle, so the path has to be valid first.
-        if (freshlyCreated) {
-          const prepResult = await traceSandboxStartupPhase("egress_prep", () =>
-            prepareSandboxEgressBeforeMount(auth, sandbox)
-          );
-          if (prepResult.isErr()) {
-            status = "error";
-            return prepResult;
-          }
-        }
-
-        // Synchronous and cheap: not worth a span (it would always read ~0ms).
-        const imageResult = getSandboxImage(auth);
-        if (imageResult.isErr()) {
-          logger.error(
-            { err: imageResult.error },
-            "Failed to get sandbox image for GCS mount"
-          );
-          status = "error";
-          return imageResult;
-        }
-        const image = imageResult.value;
-
-        void startTelemetry(auth, sandbox, conversation).catch((err) =>
-          logger.error({ err }, "Telemetry start failed (fire-and-forget)")
-        );
-
-        // Only mount on first creation. e2b preserves the FUSE mount and the
-        // token server across betaPause + connect (verified empirically), so on
-        // wake we just need a fresh GCS access token in /tmp/token.json (the
-        // running token server will hand it to gcsfuse on the next request).
-        if (freshlyCreated) {
-          const mountResult = await traceSandboxStartupPhase("gcs_mount", () =>
-            mountConversationFiles(auth, sandbox, conversation, image)
-          );
-          if (mountResult.isErr()) {
-            status = "error";
-            return mountResult;
-          }
-        } else {
-          const refreshResult = await traceSandboxStartupPhase(
-            "gcs_refresh",
-            () => refreshGcsToken(auth, sandbox, conversation, image)
-          );
-          if (refreshResult.isErr()) {
-            status = "error";
-            return refreshResult;
-          }
-        }
-
-        const ensureEgressResult = await traceSandboxStartupPhase(
-          "egress_on_exec",
-          () => ensureSandboxEgressOnExec(auth, sandbox, { wokeFromSleep })
-        );
-        if (ensureEgressResult.isErr()) {
-          status = "error";
-          return ensureEgressResult;
-        }
-
-        return new Ok({ sandbox, freshlyCreated });
+    return await traceSandboxStartupPhase("total", async () => {
+      const ensureResult = await traceSandboxStartupPhase(
+        "provider_ensure",
+        () => SandboxResource.ensureActive(auth, conversation)
+      );
+      if (ensureResult.isErr()) {
+        status = "error";
+        return ensureResult;
       }
-    );
+
+      const { sandbox, freshlyCreated, wokeFromSleep } = ensureResult.value;
+      cold = freshlyCreated;
+
+      // Egress prep must run BEFORE GCS mounts.
+      // sandbox_resource.buildSandboxEnvVars exports replace-style trust env
+      // vars pointing at /etc/dust/ca-bundle.pem. The image seeds that path
+      // with system roots; forwarder setup later merges in the dsbx CA.
+      // Mounting (gcsfuse and friends) can make HTTPS calls that read the
+      // trust bundle, so the path has to be valid first.
+      if (freshlyCreated) {
+        const prepResult = await traceSandboxStartupPhase("egress_prep", () =>
+          prepareSandboxEgressBeforeMount(auth, sandbox)
+        );
+        if (prepResult.isErr()) {
+          status = "error";
+          return prepResult;
+        }
+      }
+
+      // Synchronous and cheap: not worth a span (it would always read ~0ms).
+      const imageResult = getSandboxImage(auth);
+      if (imageResult.isErr()) {
+        logger.error(
+          { err: imageResult.error },
+          "Failed to get sandbox image for GCS mount"
+        );
+        status = "error";
+        return imageResult;
+      }
+      const image = imageResult.value;
+
+      void startTelemetry(auth, sandbox, conversation).catch((err) =>
+        logger.error({ err }, "Telemetry start failed (fire-and-forget)")
+      );
+
+      // Only mount on first creation. e2b preserves the FUSE mount and the
+      // token server across betaPause + connect (verified empirically), so on
+      // wake we just need a fresh GCS access token in /tmp/token.json (the
+      // running token server will hand it to gcsfuse on the next request).
+      if (freshlyCreated) {
+        const mountResult = await traceSandboxStartupPhase("gcs_mount", () =>
+          mountConversationFiles(auth, sandbox, conversation, image)
+        );
+        if (mountResult.isErr()) {
+          status = "error";
+          return mountResult;
+        }
+      } else {
+        const refreshResult = await traceSandboxStartupPhase(
+          "gcs_refresh",
+          () => refreshGcsToken(auth, sandbox, conversation, image)
+        );
+        if (refreshResult.isErr()) {
+          status = "error";
+          return refreshResult;
+        }
+      }
+
+      const ensureEgressResult = await traceSandboxStartupPhase(
+        "egress_on_exec",
+        () => ensureSandboxEgressOnExec(auth, sandbox, { wokeFromSleep })
+      );
+      if (ensureEgressResult.isErr()) {
+        status = "error";
+        return ensureEgressResult;
+      }
+
+      return new Ok({ sandbox, freshlyCreated });
+    });
   } finally {
     recordSandboxStartupTotal(
       performance.now() - startMs,

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -7,6 +7,10 @@ import {
   refreshGcsToken,
 } from "@app/lib/api/sandbox/gcs/mount";
 import { getSandboxImage } from "@app/lib/api/sandbox/image";
+import {
+  recordSandboxStartupTotal,
+  traceSandboxStartupPhase,
+} from "@app/lib/api/sandbox/instrumentation";
 import { startTelemetry } from "@app/lib/api/sandbox/telemetry";
 import type { Authenticator } from "@app/lib/auth";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
@@ -26,71 +30,105 @@ export async function ensureSandboxReady(
   auth: Authenticator,
   conversation: ConversationType
 ): Promise<Result<EnsureSandboxReadyResult, Error>> {
-  const ensureResult = await SandboxResource.ensureActive(auth, conversation);
-  if (ensureResult.isErr()) {
-    return ensureResult;
-  }
+  const workspaceId = auth.getNonNullableWorkspace().sId;
+  const startMs = performance.now();
+  // cold is only known once ensureActive returns; default to a cold-leaning
+  // false only matters if ensureActive itself errors (rare), where the total
+  // is recorded as a failed warm attempt.
+  let cold = false;
+  let status: "success" | "error" = "success";
 
-  const { sandbox, freshlyCreated, wokeFromSleep } = ensureResult.value;
+  try {
+    return await traceSandboxStartupPhase(
+      "total",
+      async () => {
+        const ensureResult = await traceSandboxStartupPhase(
+          "provider_ensure",
+          () => SandboxResource.ensureActive(auth, conversation),
+          { workspace_id: workspaceId }
+        );
+        if (ensureResult.isErr()) {
+          status = "error";
+          return ensureResult;
+        }
 
-  // Egress prep must run BEFORE GCS mounts. sandbox_resource.buildSandboxEnvVars
-  // exports replace-style trust env vars pointing at /etc/dust/ca-bundle.pem.
-  // The image seeds that path with system roots; forwarder setup later merges
-  // in the dsbx CA. Mounting (gcsfuse and friends) can make HTTPS calls that
-  // read the trust bundle, so the path has to be valid first.
-  if (freshlyCreated) {
-    const prepResult = await prepareSandboxEgressBeforeMount(auth, sandbox);
-    if (prepResult.isErr()) {
-      return prepResult;
-    }
-  }
+        const { sandbox, freshlyCreated, wokeFromSleep } = ensureResult.value;
+        cold = freshlyCreated;
 
-  const imageResult = getSandboxImage(auth);
-  if (imageResult.isErr()) {
-    logger.error(
-      { err: imageResult.error },
-      "Failed to get sandbox image for GCS mount"
+        // Egress prep must run BEFORE GCS mounts.
+        // sandbox_resource.buildSandboxEnvVars exports replace-style trust env
+        // vars pointing at /etc/dust/ca-bundle.pem. The image seeds that path
+        // with system roots; forwarder setup later merges in the dsbx CA.
+        // Mounting (gcsfuse and friends) can make HTTPS calls that read the
+        // trust bundle, so the path has to be valid first.
+        if (freshlyCreated) {
+          const prepResult = await traceSandboxStartupPhase("egress_prep", () =>
+            prepareSandboxEgressBeforeMount(auth, sandbox)
+          );
+          if (prepResult.isErr()) {
+            status = "error";
+            return prepResult;
+          }
+        }
+
+        const imageResult = await traceSandboxStartupPhase("image_fetch", () =>
+          Promise.resolve(getSandboxImage(auth))
+        );
+        if (imageResult.isErr()) {
+          logger.error(
+            { err: imageResult.error },
+            "Failed to get sandbox image for GCS mount"
+          );
+          status = "error";
+          return imageResult;
+        }
+        const image = imageResult.value;
+
+        void startTelemetry(auth, sandbox, conversation).catch((err) =>
+          logger.error({ err }, "Telemetry start failed (fire-and-forget)")
+        );
+
+        // Only mount on first creation. e2b preserves the FUSE mount and the
+        // token server across betaPause + connect (verified empirically), so on
+        // wake we just need a fresh GCS access token in /tmp/token.json (the
+        // running token server will hand it to gcsfuse on the next request).
+        if (freshlyCreated) {
+          const mountResult = await traceSandboxStartupPhase("gcs_mount", () =>
+            mountConversationFiles(auth, sandbox, conversation, image)
+          );
+          if (mountResult.isErr()) {
+            status = "error";
+            return mountResult;
+          }
+        } else {
+          const refreshResult = await traceSandboxStartupPhase(
+            "gcs_refresh",
+            () => refreshGcsToken(auth, sandbox, conversation, image)
+          );
+          if (refreshResult.isErr()) {
+            status = "error";
+            return refreshResult;
+          }
+        }
+
+        const ensureEgressResult = await traceSandboxStartupPhase(
+          "egress_on_exec",
+          () => ensureSandboxEgressOnExec(auth, sandbox, { wokeFromSleep })
+        );
+        if (ensureEgressResult.isErr()) {
+          status = "error";
+          return ensureEgressResult;
+        }
+
+        return new Ok({ sandbox, freshlyCreated });
+      },
+      { workspace_id: workspaceId }
     );
-    return imageResult;
-  }
-  const image = imageResult.value;
-
-  void startTelemetry(auth, sandbox, conversation).catch((err) =>
-    logger.error({ err }, "Telemetry start failed (fire-and-forget)")
-  );
-
-  // Only mount on first creation. e2b preserves the FUSE mount and the
-  // token server across betaPause + connect (verified empirically), so on
-  // wake we just need a fresh GCS access token in /tmp/token.json (the
-  // running token server will hand it to gcsfuse on the next request).
-  if (freshlyCreated) {
-    const mountResult = await mountConversationFiles(
-      auth,
-      sandbox,
-      conversation,
-      image
+  } finally {
+    recordSandboxStartupTotal(
+      performance.now() - startMs,
+      { workspaceId, cold },
+      status
     );
-    if (mountResult.isErr()) {
-      return mountResult;
-    }
-  } else {
-    const refreshResult = await refreshGcsToken(
-      auth,
-      sandbox,
-      conversation,
-      image
-    );
-    if (refreshResult.isErr()) {
-      return refreshResult;
-    }
   }
-
-  const ensureEgressResult = await ensureSandboxEgressOnExec(auth, sandbox, {
-    wokeFromSleep,
-  });
-  if (ensureEgressResult.isErr()) {
-    return ensureEgressResult;
-  }
-
-  return new Ok({ sandbox, freshlyCreated });
 }

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -30,7 +30,6 @@ export async function ensureSandboxReady(
   auth: Authenticator,
   conversation: ConversationType
 ): Promise<Result<EnsureSandboxReadyResult, Error>> {
-  const workspaceId = auth.getNonNullableWorkspace().sId;
   const startMs = performance.now();
   // cold is unknown until ensureActive returns; if it errors first (rare) we
   // record the failure as a warm attempt.
@@ -118,10 +117,6 @@ export async function ensureSandboxReady(
       return new Ok({ sandbox, freshlyCreated });
     });
   } finally {
-    recordSandboxStartupTotal(
-      performance.now() - startMs,
-      { workspaceId, cold },
-      status
-    );
+    recordSandboxStartupTotal(performance.now() - startMs, { cold }, status);
   }
 }

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -276,19 +276,16 @@ export class E2BSandboxProvider implements SandboxProvider {
           // Split out from create so the raw E2B VM-create latency is visible
           // separately from the hardening command that follows it (the two
           // share the parent sandbox.provider.create span otherwise).
-          sandbox = await traceSandboxStartupPhase(
-            "provider.create_vm",
-            () =>
-              Sandbox.create(templateId, {
-                ...this.connectionOpts(),
-                envs: hasEnvVars ? envVars : undefined,
-                timeoutMs: SANDBOX_LIFETIME_MS,
-                requestTimeoutMs: REQUEST_TIMEOUT_MS,
-                network: config.network
-                  ? toE2BNetworkOpts(config.network)
-                  : { allowPublicTraffic: false },
-              }),
-            { workspace_id: tracingOpts.workspaceId }
+          sandbox = await traceSandboxStartupPhase("provider.create_vm", () =>
+            Sandbox.create(templateId, {
+              ...this.connectionOpts(),
+              envs: hasEnvVars ? envVars : undefined,
+              timeoutMs: SANDBOX_LIFETIME_MS,
+              requestTimeoutMs: REQUEST_TIMEOUT_MS,
+              network: config.network
+                ? toE2BNetworkOpts(config.network)
+                : { allowPublicTraffic: false },
+            })
           );
         } catch (err) {
           return new Err(normalizeError(err));
@@ -310,8 +307,7 @@ export class E2BSandboxProvider implements SandboxProvider {
                   timeoutMs: LOCAL_ACCOUNT_HARDENING_TIMEOUT_MS,
                   user: "root",
                 }
-              ),
-            { workspace_id: tracingOpts.workspaceId }
+              )
           );
           hardeningResult = {
             exitCode: result.exitCode,

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -6,6 +6,7 @@ import {
   formatSandboxImageId,
   type NetworkPolicy,
 } from "@app/lib/api/sandbox/image/types";
+import { traceSandboxStartupPhase } from "@app/lib/api/sandbox/instrumentation";
 import type {
   ExecOptions,
   ExecResult,
@@ -272,32 +273,45 @@ export class E2BSandboxProvider implements SandboxProvider {
         try {
           const envVars = config.envVars ?? {};
           const hasEnvVars = Object.keys(envVars).length > 0;
-          sandbox = await Sandbox.create(templateId, {
-            ...this.connectionOpts(),
-            envs: hasEnvVars ? envVars : undefined,
-            timeoutMs: SANDBOX_LIFETIME_MS,
-            requestTimeoutMs: REQUEST_TIMEOUT_MS,
-            network: config.network
-              ? toE2BNetworkOpts(config.network)
-              : { allowPublicTraffic: false },
-          });
+          // Split out from create so the raw E2B VM-create latency is visible
+          // separately from the hardening command that follows it (the two
+          // share the parent sandbox.provider.create span otherwise).
+          sandbox = await traceSandboxStartupPhase(
+            "provider.create_vm",
+            () =>
+              Sandbox.create(templateId, {
+                ...this.connectionOpts(),
+                envs: hasEnvVars ? envVars : undefined,
+                timeoutMs: SANDBOX_LIFETIME_MS,
+                requestTimeoutMs: REQUEST_TIMEOUT_MS,
+                network: config.network
+                  ? toE2BNetworkOpts(config.network)
+                  : { allowPublicTraffic: false },
+              }),
+            { workspace_id: tracingOpts.workspaceId }
+          );
         } catch (err) {
           return new Err(normalizeError(err));
         }
 
         let hardeningResult: ExecResult;
         try {
-          const result = await sandbox.commands.run(
-            getRootSafeSandboxCommand(
-              rootCommand.unsafeShell(
-                getLocalAccountPrivilegeHardeningCommand(),
-                "create-time sandbox local account hardening"
-              )
-            ),
-            {
-              timeoutMs: LOCAL_ACCOUNT_HARDENING_TIMEOUT_MS,
-              user: "root",
-            }
+          const result = await traceSandboxStartupPhase(
+            "provider.hardening",
+            () =>
+              sandbox.commands.run(
+                getRootSafeSandboxCommand(
+                  rootCommand.unsafeShell(
+                    getLocalAccountPrivilegeHardeningCommand(),
+                    "create-time sandbox local account hardening"
+                  )
+                ),
+                {
+                  timeoutMs: LOCAL_ACCOUNT_HARDENING_TIMEOUT_MS,
+                  user: "root",
+                }
+              ),
+            { workspace_id: tracingOpts.workspaceId }
           );
           hardeningResult = {
             exitCode: result.exitCode,

--- a/front/lib/api/sandbox/telemetry/index.ts
+++ b/front/lib/api/sandbox/telemetry/index.ts
@@ -1,4 +1,5 @@
 import config from "@app/lib/api/config";
+import { traceSandboxStartupPhase } from "@app/lib/api/sandbox/instrumentation";
 import { rootCommand } from "@app/lib/api/sandbox/root_command";
 import type { Authenticator } from "@app/lib/auth";
 import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
@@ -31,21 +32,26 @@ export async function startTelemetry(
 
   // /!\ DD_API_KEY must never appear literally in the command string;
   // journalctl logs argv. Always interpolate from the envVars below.
-  const result = await sandbox.execRoot(
-    auth,
-    rootCommand.unsafeShell(
-      `/usr/bin/systemctl set-environment DD_HOST="$DD_HOST" DD_API_KEY="$DD_API_KEY" E2B_SANDBOX_ID="$E2B_SANDBOX_ID" CONVERSATION_ID="$CONVERSATION_ID" WORKSPACE_ID="$WORKSPACE_ID" && /usr/bin/systemctl start fluent-bit`,
-      "systemctl environment command expands sandbox env vars without embedding secrets in the TypeScript command string"
-    ),
-    {
-      envVars: {
-        DD_HOST: "http-intake.logs.datadoghq.eu",
-        DD_API_KEY: config.getDatadogApiKey() ?? "",
-        E2B_SANDBOX_ID: sandbox.providerId,
-        CONVERSATION_ID: conversation.sId,
-        WORKSPACE_ID: workspaceId,
-      },
-    }
+  const result = await traceSandboxStartupPhase(
+    "telemetry_start",
+    () =>
+      sandbox.execRoot(
+        auth,
+        rootCommand.unsafeShell(
+          `/usr/bin/systemctl set-environment DD_HOST="$DD_HOST" DD_API_KEY="$DD_API_KEY" E2B_SANDBOX_ID="$E2B_SANDBOX_ID" CONVERSATION_ID="$CONVERSATION_ID" WORKSPACE_ID="$WORKSPACE_ID" && /usr/bin/systemctl start fluent-bit`,
+          "systemctl environment command expands sandbox env vars without embedding secrets in the TypeScript command string"
+        ),
+        {
+          envVars: {
+            DD_HOST: "http-intake.logs.datadoghq.eu",
+            DD_API_KEY: config.getDatadogApiKey() ?? "",
+            E2B_SANDBOX_ID: sandbox.providerId,
+            CONVERSATION_ID: conversation.sId,
+            WORKSPACE_ID: workspaceId,
+          },
+        }
+      ),
+    { workspace_id: workspaceId }
   );
 
   if (result.isErr()) {

--- a/front/lib/api/sandbox/telemetry/index.ts
+++ b/front/lib/api/sandbox/telemetry/index.ts
@@ -32,25 +32,23 @@ export async function startTelemetry(
 
   // /!\ DD_API_KEY must never appear literally in the command string;
   // journalctl logs argv. Always interpolate from the envVars below.
-  const result = await traceSandboxStartupPhase(
-    "telemetry_start",
-    () =>
-      sandbox.execRoot(
-        auth,
-        rootCommand.unsafeShell(
-          `/usr/bin/systemctl set-environment DD_HOST="$DD_HOST" DD_API_KEY="$DD_API_KEY" E2B_SANDBOX_ID="$E2B_SANDBOX_ID" CONVERSATION_ID="$CONVERSATION_ID" WORKSPACE_ID="$WORKSPACE_ID" && /usr/bin/systemctl start fluent-bit`,
-          "systemctl environment command expands sandbox env vars without embedding secrets in the TypeScript command string"
-        ),
-        {
-          envVars: {
-            DD_HOST: "http-intake.logs.datadoghq.eu",
-            DD_API_KEY: config.getDatadogApiKey() ?? "",
-            E2B_SANDBOX_ID: sandbox.providerId,
-            CONVERSATION_ID: conversation.sId,
-            WORKSPACE_ID: workspaceId,
-          },
-        }
-      )
+  const result = await traceSandboxStartupPhase("telemetry_start", () =>
+    sandbox.execRoot(
+      auth,
+      rootCommand.unsafeShell(
+        `/usr/bin/systemctl set-environment DD_HOST="$DD_HOST" DD_API_KEY="$DD_API_KEY" E2B_SANDBOX_ID="$E2B_SANDBOX_ID" CONVERSATION_ID="$CONVERSATION_ID" WORKSPACE_ID="$WORKSPACE_ID" && /usr/bin/systemctl start fluent-bit`,
+        "systemctl environment command expands sandbox env vars without embedding secrets in the TypeScript command string"
+      ),
+      {
+        envVars: {
+          DD_HOST: "http-intake.logs.datadoghq.eu",
+          DD_API_KEY: config.getDatadogApiKey() ?? "",
+          E2B_SANDBOX_ID: sandbox.providerId,
+          CONVERSATION_ID: conversation.sId,
+          WORKSPACE_ID: workspaceId,
+        },
+      }
+    )
   );
 
   if (result.isErr()) {

--- a/front/lib/api/sandbox/telemetry/index.ts
+++ b/front/lib/api/sandbox/telemetry/index.ts
@@ -50,8 +50,7 @@ export async function startTelemetry(
             WORKSPACE_ID: workspaceId,
           },
         }
-      ),
-    { workspace_id: workspaceId }
+      )
   );
 
   if (result.isErr()) {

--- a/front/lib/lock.ts
+++ b/front/lib/lock.ts
@@ -63,9 +63,9 @@ export const executeWithLock = async <T>(
   const client = await getRedisStreamClient({ origin: "lock" });
 
   const acquire = async (): Promise<string | undefined> => {
-    const start = Date.now();
+    const startMs = Date.now();
     let acquired: string | undefined;
-    while (Date.now() - start < timeoutMs) {
+    while (Date.now() - startMs < timeoutMs) {
       // Try to acquire the lock
       acquired = await distributedLock(client, lockName);
       if (acquired) {

--- a/front/lib/lock.ts
+++ b/front/lib/lock.ts
@@ -1,3 +1,5 @@
+import tracer from "@app/logger/tracer";
+
 import { getRedisStreamClient, type RedisClientType } from "./api/redis";
 
 // Distributed lock implementation using Redis
@@ -52,21 +54,37 @@ const WAIT_BETWEEN_RETRIES = 100;
 export const executeWithLock = async <T>(
   lockName: string,
   callback: () => Promise<T>,
-  timeoutMs: number = 30_000
+  timeoutMs: number = 30_000,
+  // Opt-in: when set, the acquisition wait (only) is wrapped in a
+  // `lock.acquire` APM span with this resource, so contention/wait time is
+  // visible separately from the time spent holding the lock. Off by default so
+  // existing callers are unchanged and we don't span every lock app-wide.
+  { traceAcquireResource }: { traceAcquireResource?: string } = {}
 ): Promise<T> => {
   const client = await getRedisStreamClient({ origin: "lock" });
 
-  const start = Date.now();
-  let lockValue: string | undefined;
-  while (Date.now() - start < timeoutMs) {
-    // Try to acquire the lock
-    lockValue = await distributedLock(client, lockName);
-    if (lockValue) {
-      break;
+  const acquire = async (): Promise<string | undefined> => {
+    const start = Date.now();
+    let acquired: string | undefined;
+    while (Date.now() - start < timeoutMs) {
+      // Try to acquire the lock
+      acquired = await distributedLock(client, lockName);
+      if (acquired) {
+        break;
+      }
+      // Wait a bit before retrying
+      await new Promise((resolve) => setTimeout(resolve, WAIT_BETWEEN_RETRIES));
     }
-    // Wait a bit before retrying
-    await new Promise((resolve) => setTimeout(resolve, WAIT_BETWEEN_RETRIES));
-  }
+    return acquired;
+  };
+
+  const lockValue = traceAcquireResource
+    ? await tracer.trace(
+        "lock.acquire",
+        { resource: traceAcquireResource },
+        acquire
+      )
+    : await acquire();
 
   if (!lockValue) {
     throw new Error(`Lock acquisition timed out for ${lockName}`);

--- a/front/lib/lock.ts
+++ b/front/lib/lock.ts
@@ -1,6 +1,5 @@
+import { getRedisStreamClient, type RedisClientType } from "@app/lib/api/redis";
 import tracer from "@app/logger/tracer";
-
-import { getRedisStreamClient, type RedisClientType } from "./api/redis";
 
 // Distributed lock implementation using Redis
 // Returns the lock value if the lock is acquired, that can be used to unlock, otherwise undefined.

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -336,8 +336,11 @@ export class SandboxResource extends BaseResource<SandboxModel> {
       return new Err(new Error("Sandbox provider not configured."));
     }
 
-    return executeWithLock(`sandbox:lifecycle:${conversationId}`, () =>
-      fn(provider)
+    return executeWithLock(
+      `sandbox:lifecycle:${conversationId}`,
+      () => fn(provider),
+      undefined,
+      { traceAcquireResource: "sandbox:lifecycle" }
     );
   }
 


### PR DESCRIPTION
## Description

We want to cut sandbox startup latency but had no clean view of where the time goes from zero (no sandbox) to the first executed command.

What already existed: every setup command is timed in APM (trace.sandbox.provider.exec/writeFile), but they all share resource:exec, so egress bring-up, GCS mount and the user command are indistinguishable in aggregate. And sandbox.tools.duration times only the user command, its timer starts after setup is done.

This wraps each ensureSandboxReady phase in a parent sandbox.startup span. The existing provider spans nest underneath, so we get semantic labels and per-phase p50/p95/p99 for free, no re-timing. Details:

- Split provider.create into create_vm vs hardening.
- Add spans for the three Node-side steps that never become sandbox commands and had no coverage: lock acquire, egress DNS resolve, GCS token mint.
- One new aggregate metric, sandbox.startup.total.duration, tagged cold/warm: the headline 0-to-first-command number.
- lock.acquire tracing is opt-in on executeWithLock, off for every other caller.

## Tests

Typechecks and lints locally. Span/metric emission verifies on deploy (APM trace.sandbox.startup.* and the new distribution). No behavior change to the startup path itself.

## Risk

Low. Pure instrumentation: spans wrap existing calls and preserve control flow. The egress wait-healthy loop was lightly restructured (returns Ok on healthy, then installs the trust bundle) but is behaviorally identical. The executeWithLock change is additive (new optional arg, default off).

## Deploy Plan

Standard deploy. After it lands, enable percentile aggregation on sandbox.startup.total.duration in the DD metric summary to query tails (APM phase spans already expose percentiles).