### PR TITLE
feat(metronome): add programmatic cap notifications and banners

### DIFF
--- a/front-api/routes/novu/index.ts
+++ b/front-api/routes/novu/index.ts
@@ -6,6 +6,7 @@ import { projectAddedAsMemberWorkflow } from "@app/lib/notifications/workflows/p
 import { providerCredentialsHealthUpdatedWorkflow } from "@app/lib/notifications/workflows/provider-credential-updated";
 import { skillSuggestionsReadyWorkflow } from "@app/lib/notifications/workflows/skill-suggestions-ready";
 import { userAwuCapReachedWorkflow } from "@app/lib/notifications/workflows/user-awu-cap-reached";
+import { workspaceProgrammaticCapWarningWorkflow } from "@app/lib/notifications/workflows/workspace-programmatic-cap-warning";
 import { createHono } from "@front-api/lib/hono";
 import type { ServeHandlerOptions } from "@novu/framework";
 import { NovuRequestHandler } from "@novu/framework";
@@ -31,6 +32,7 @@ const options: ServeHandlerOptions = {
     providerCredentialsHealthUpdatedWorkflow,
     userAwuCapReachedWorkflow,
     balanceThresholdReachedWorkflow,
+    workspaceProgrammaticCapWarningWorkflow,
   ],
 };
 

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
@@ -18,10 +18,8 @@ import {
   addBackwardCompatibleConversationWithoutContentFields,
   normalizeConversationVisibility,
 } from "@app/lib/api/v1/backward_compatibility";
-import {
-  isApiBlocked,
-  isProgrammaticApiBlocked,
-} from "@app/lib/metronome/user_block";
+import { isProgrammaticApiBlocked } from "@app/lib/metronome/alerts/programmatic_cap";
+import { isApiBlocked } from "@app/lib/metronome/user_block";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";

--- a/front-api/routes/w/[wId]/usage-status.ts
+++ b/front-api/routes/w/[wId]/usage-status.ts
@@ -1,15 +1,24 @@
 import {
+  getWorkspaceProgrammaticCreditStatus,
+  isWorkspaceProgrammaticWarned,
+} from "@app/lib/metronome/alerts/programmatic_cap";
+import {
   getWorkspaceCreditPoolStatus,
   isUserAwuWarned,
   isUserBlocked,
 } from "@app/lib/metronome/user_block";
-import type { WorkspacePoolCreditState } from "@app/types/credits";
+import type {
+  WorkspacePoolCreditState,
+  WorkspaceProgrammaticCreditState,
+} from "@app/types/credits";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
 export type GetWorkspaceUsageStatusResponseBody = {
   awuStatus: "normal" | "warned" | "blocked";
   poolCreditState: WorkspacePoolCreditState;
+  programmaticCreditState: WorkspaceProgrammaticCreditState;
+  programmaticWarned: boolean;
 };
 
 // Mounted at /api/w/:wId/usage-status.
@@ -24,12 +33,24 @@ app.get(
 
     // Workspaces not on Metronome billing have no usage status to report.
     if (!workspace.metronomeCustomerId) {
-      return ctx.json({ awuStatus: "normal", poolCreditState: "active" });
+      return ctx.json({
+        awuStatus: "normal",
+        poolCreditState: "active",
+        programmaticCreditState: "active",
+        programmaticWarned: false,
+      });
     }
 
-    const [poolCreditState, blockedReason] = await Promise.all([
+    const [
+      poolCreditState,
+      programmaticCreditState,
+      blockedReason,
+      programmaticWarned,
+    ] = await Promise.all([
       getWorkspaceCreditPoolStatus(workspace.sId),
+      getWorkspaceProgrammaticCreditStatus(workspace.sId),
       isUserBlocked(workspace.sId, user.sId),
+      isWorkspaceProgrammaticWarned(workspace.sId),
     ]);
 
     let awuStatus: GetWorkspaceUsageStatusResponseBody["awuStatus"] = "normal";
@@ -39,7 +60,12 @@ app.get(
       awuStatus = "warned";
     }
 
-    return ctx.json({ awuStatus, poolCreditState });
+    return ctx.json({
+      awuStatus,
+      poolCreditState,
+      programmaticCreditState,
+      programmaticWarned,
+    });
   }
 );
 

--- a/front/components/navigation/AppStatusBanner.tsx
+++ b/front/components/navigation/AppStatusBanner.tsx
@@ -204,22 +204,36 @@ interface UsageStatusBannerProps {
 }
 
 function UsageStatusBanner({ owner }: UsageStatusBannerProps) {
-  const { awuStatus, poolCreditState } = useWorkspaceUsageStatus({ owner });
+  const {
+    awuStatus,
+    poolCreditState,
+    programmaticCreditState,
+    programmaticWarned,
+  } = useWorkspaceUsageStatus({ owner });
 
-  // The pool balance banner is only shown to admins, who manage workspace
-  // credits. The AWU cap banner is shown to any user subject to a usage cap.
-  // Both can be displayed at the same time.
+  // The pool balance and programmatic cap banners are only shown to admins, who
+  // manage workspace credits. The AWU cap banner is shown to any user subject to
+  // a usage cap. All can be displayed at the same time.
   const showPoolBanner =
     isAdmin(owner) &&
     (poolCreditState === "active_low_balance" ||
       poolCreditState === "active_critical_balance");
   const showAwuBanner = awuStatus !== "normal";
+  const showProgrammaticBanner =
+    isAdmin(owner) &&
+    (programmaticCreditState !== "active" || programmaticWarned);
 
-  if (!showPoolBanner && !showAwuBanner) {
+  if (!showPoolBanner && !showAwuBanner && !showProgrammaticBanner) {
     return null;
   }
 
   const isPoolCritical = poolCreditState === "active_critical_balance";
+  const isProgrammaticDepleted = programmaticCreditState === "depleted";
+  const isProgrammaticCritical =
+    programmaticCreditState === "active_critical_balance";
+  // 80% warning: FSM still "active" but warning flag fired from webhook.
+  const isProgrammaticAtWarning =
+    programmaticWarned && programmaticCreditState === "active";
 
   return (
     <>
@@ -235,6 +249,38 @@ function UsageStatusBanner({ owner }: UsageStatusBannerProps) {
             isPoolCritical
               ? "Your workspace credits are almost depleted. Top up now to avoid interruptions to your agents."
               : "Your workspace credits are running low. Consider topping up to avoid interruptions to your agents."
+          }
+          footer={
+            <LinkWrapper href={`/w/${owner.sId}/usage`} className="underline">
+              Manage credits
+            </LinkWrapper>
+          }
+        />
+      )}
+      {showProgrammaticBanner && (
+        <StatusBanner
+          variant={
+            isProgrammaticDepleted || isProgrammaticCritical
+              ? "danger"
+              : "warning"
+          }
+          title={
+            isProgrammaticDepleted
+              ? "Your workspace's programmatic API has reached its monthly cap"
+              : isProgrammaticCritical
+                ? "Your workspace's programmatic API is critically close to its monthly cap"
+                : isProgrammaticAtWarning
+                  ? "Your workspace's programmatic API has reached 80% of its monthly cap"
+                  : "Your workspace's programmatic API is approaching its monthly cap"
+          }
+          description={
+            isProgrammaticDepleted
+              ? "Programmatic API calls are now blocked until the next billing cycle or the cap is increased."
+              : isProgrammaticCritical
+                ? "Programmatic API calls will be blocked very soon. Increase the cap to avoid interruptions."
+                : isProgrammaticAtWarning
+                  ? "Programmatic API calls will be blocked when the cap is reached. Consider increasing the cap."
+                  : "Programmatic API calls will be blocked when the cap is reached. Consider increasing the cap."
           }
           footer={
             <LinkWrapper href={`/w/${owner.sId}/usage`} className="underline">

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -63,10 +63,12 @@ import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { extractFromString, serializeMention } from "@app/lib/mentions/format";
 import {
-  getWorkspaceCreditPoolStatus,
   getWorkspaceProgrammaticCreditStatus,
-  isApiBlocked,
   isProgrammaticApiBlocked,
+} from "@app/lib/metronome/alerts/programmatic_cap";
+import {
+  getWorkspaceCreditPoolStatus,
+  isApiBlocked,
   isUserBlocked,
 } from "@app/lib/metronome/user_block";
 import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -1,3 +1,4 @@
+import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import { isPAYGEnabled } from "@app/lib/credits/credit_payg";
 import { listMetronomeBalances } from "@app/lib/metronome/client";
@@ -8,6 +9,8 @@ import { clearUserCapBlocked } from "@app/lib/metronome/user_block";
 import { transitionUserCreditState } from "@app/lib/metronome/user_credit_state_machine";
 import type { WorkspaceCreditEvent } from "@app/lib/metronome/workspace_credit_state_machine";
 import { transitionWorkspaceCreditState } from "@app/lib/metronome/workspace_credit_state_machine";
+import { notifyAdminsProgrammaticCapWarning } from "@app/lib/notifications/workflows/workspace-programmatic-cap-warning";
+import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -15,6 +18,7 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 export async function dispatchPerUserCapReached({
   workspace,
@@ -213,18 +217,65 @@ export async function dispatchProgrammaticCapReset({
  * threshold (80% of the monthly cap). Unlike the other programmatic
  * dispatchers this does not transition the credit state machine — the
  * workspace stays in its current balance state and no throttling kicks in.
- * The signal is informational only.
+ * The signal is informational only. Best-effort: failures are logged and
+ * swallowed so the webhook's credit-state processing is never disrupted.
  */
 export async function dispatchProgrammaticWarning({
   workspace,
+  monthlyCapCredits,
+  eventId,
 }: {
   workspace: WorkspaceResource;
+  monthlyCapCredits: number;
+  eventId: string;
 }): Promise<void> {
-  // TODO: send notification to admin.
   logger.info(
     { workspaceId: workspace.sId },
     "[ProgrammaticCreditDispatcher] Programmatic warning threshold reached"
   );
+
+  try {
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const workspaceType = auth.workspace();
+    if (!workspaceType) {
+      logger.error(
+        { workspaceId: workspace.sId },
+        "[ProgrammaticCreditDispatcher] Workspace not found for programmatic warning notification"
+      );
+      return;
+    }
+
+    const { members: admins } = await getMembers(auth, {
+      roles: ["admin"],
+      activeOnly: true,
+    });
+    if (admins.length === 0) {
+      logger.warn(
+        { workspaceId: workspace.sId },
+        "[ProgrammaticCreditDispatcher] No active admins for programmatic warning notification"
+      );
+      return;
+    }
+
+    notifyAdminsProgrammaticCapWarning({
+      admins: admins.map((admin) => ({
+        sId: admin.sId,
+        email: admin.email,
+        firstName: admin.firstName,
+        lastName: admin.lastName,
+      })),
+      workspaceId: workspace.sId,
+      workspaceName: workspaceType.name,
+      monthlyCapCredits,
+      isEnterprise: isEntreprisePlanPrefix(auth.getNonNullablePlan().code),
+      eventId,
+    });
+  } catch (err) {
+    logger.error(
+      { workspaceId: workspace.sId, error: normalizeError(err).message },
+      "[ProgrammaticCreditDispatcher] Failed to notify admins of programmatic cap warning"
+    );
+  }
 }
 
 /**

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -27,11 +27,14 @@ import {
 } from "@app/lib/credits/free";
 import {
   CRITICAL_BALANCE_OFFSET,
+  clearWorkspaceProgrammaticWarned,
   LOW_BALANCE_OFFSET,
   PROGRAMMATIC_CAP_ALERT_NAME,
   PROGRAMMATIC_CRITICAL_BALANCE_ALERT_NAME,
   PROGRAMMATIC_LOW_BALANCE_ALERT_NAME,
   PROGRAMMATIC_WARNING_BALANCE_ALERT_NAME,
+  setWorkspaceProgrammaticWarned,
+  WARNING_BALANCE_RATIO,
 } from "@app/lib/metronome/alerts/programmatic_cap";
 import {
   getMetronomeDefaultUserCapAlert,
@@ -779,7 +782,23 @@ export async function processMetronomeWebhook({
         // three FSM-driving alerts (cap reached / low / critical).
         const alertName = event.properties.alert_name ?? "";
         if (alertName.startsWith(PROGRAMMATIC_WARNING_BALANCE_ALERT_NAME)) {
-          await dispatchProgrammaticWarning({ workspace });
+          const warningThreshold = event.properties.threshold;
+          if (warningThreshold == null) {
+            logger.warn(
+              { eventId: event.id, workspaceId: workspace.sId },
+              "[Metronome Webhook] spend_threshold_reached: programmatic warning alert missing threshold, skipping notification"
+            );
+            break;
+          }
+          const monthlyCapCredits = Math.round(
+            warningThreshold / WARNING_BALANCE_RATIO
+          );
+          void setWorkspaceProgrammaticWarned(workspace.sId);
+          await dispatchProgrammaticWarning({
+            workspace,
+            monthlyCapCredits,
+            eventId: event.id,
+          });
         } else {
           const programmaticEvent = programmaticEventFromAlertName(alertName);
           if (programmaticEvent) {
@@ -856,6 +875,7 @@ export async function processMetronomeWebhook({
           return handleResult;
         }
       } else if (isProgrammaticMonthlyCap(event)) {
+        void clearWorkspaceProgrammaticWarned(workspace.sId);
         await dispatchProgrammaticCapReset({ workspace });
         logger.info(
           { eventId: event.id, workspaceId: workspace.sId },

--- a/front/lib/metronome/alerts/programmatic_cap.ts
+++ b/front/lib/metronome/alerts/programmatic_cap.ts
@@ -1,3 +1,4 @@
+import { runOnRedis } from "@app/lib/api/redis";
 import {
   clearMetronomeAlert,
   findMetronomeAlert,
@@ -8,7 +9,10 @@ import {
   USAGE_TYPE_GROUP_KEY,
   USAGE_TYPE_PROGRAMMATIC,
 } from "@app/lib/metronome/constants";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
+import type { WorkspaceProgrammaticCreditState } from "@app/types/credits";
+import { isWorkspaceProgrammaticCreditState } from "@app/types/credits";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -47,7 +51,7 @@ export const PROGRAMMATIC_CRITICAL_BALANCE_ALERT_NAME =
 
 /**
  * Read the current programmatic monthly cap from Metronome. Returns the cap
- * alert threshold (in Programmatic USD credits), or null if no cap is set.
+ * alert threshold (in AWU credits), or null if no cap is set.
  */
 export async function getMetronomeProgrammaticCap({
   metronomeCustomerId,
@@ -204,4 +208,157 @@ export async function clearMetronomeProgrammaticCapAlerts({
     "[Metronome ProgrammaticCap] Cleared programmatic cap alerts"
   );
   return new Ok(undefined);
+}
+
+// =============================================================================
+// Redis fast-path cache for programmatic credit state.
+//
+// Keys:
+//   metronome:programmatic_depleted:<ws>  — "1"/"0" block flag (fast path for
+//     API enforcement; backed by workspace.programmaticCreditState in DB).
+//   metronome:programmatic_credit_status:<ws> — fine-grained state string for
+//     UI/notifications; backed by workspace.programmaticCreditState in DB.
+//   metronome:programmatic_warning:<ws>  — "1"/"0" flag set by the 80%
+//     webhook; no DB backing (safe default: false on cold miss).
+// =============================================================================
+
+const REDIS_ORIGIN = "metronome_limit" as const;
+const BLOCKED_FLAG = "1";
+const NOT_BLOCKED_FLAG = "0";
+
+function buildWorkspaceProgrammaticDepletedKey(workspaceId: string): string {
+  return `metronome:programmatic_depleted:${workspaceId}`;
+}
+
+function buildWorkspaceProgrammaticCreditStatusKey(
+  workspaceId: string
+): string {
+  return `metronome:programmatic_credit_status:${workspaceId}`;
+}
+
+function buildWorkspaceProgrammaticWarningKey(workspaceId: string): string {
+  return `metronome:programmatic_warning:${workspaceId}`;
+}
+
+async function setFlag(key: string, value: string): Promise<void> {
+  await runOnRedis({ origin: REDIS_ORIGIN }, async (client) => {
+    await client.set(key, value);
+  });
+}
+
+export async function setWorkspaceProgrammaticDepleted(
+  workspaceId: string
+): Promise<void> {
+  await setFlag(
+    buildWorkspaceProgrammaticDepletedKey(workspaceId),
+    BLOCKED_FLAG
+  );
+}
+
+export async function clearWorkspaceProgrammaticDepleted(
+  workspaceId: string
+): Promise<void> {
+  await setFlag(
+    buildWorkspaceProgrammaticDepletedKey(workspaceId),
+    NOT_BLOCKED_FLAG
+  );
+}
+
+export async function setWorkspaceProgrammaticCreditStatus(
+  workspaceId: string,
+  status: WorkspaceProgrammaticCreditState
+): Promise<void> {
+  await setFlag(buildWorkspaceProgrammaticCreditStatusKey(workspaceId), status);
+}
+
+export async function getWorkspaceProgrammaticCreditStatus(
+  workspaceId: string
+): Promise<WorkspaceProgrammaticCreditState> {
+  const cached = await runOnRedis({ origin: REDIS_ORIGIN }, async (client) =>
+    client.get(buildWorkspaceProgrammaticCreditStatusKey(workspaceId))
+  );
+
+  if (cached && isWorkspaceProgrammaticCreditState(cached)) {
+    return cached;
+  }
+
+  logger.info(
+    { workspaceId },
+    "[ProgrammaticCap] Cache miss during programmatic credit status check, falling back to DB"
+  );
+
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  if (!workspace) {
+    logger.warn(
+      { workspaceId },
+      "[ProgrammaticCap] Workspace not found during programmatic credit status cache read-through fallback"
+    );
+    return "active";
+  }
+
+  const status = workspace.programmaticCreditState;
+  await setFlag(buildWorkspaceProgrammaticCreditStatusKey(workspaceId), status);
+  return status;
+}
+
+export async function isProgrammaticApiBlocked(
+  workspaceId: string
+): Promise<boolean> {
+  const depleted = await runOnRedis({ origin: REDIS_ORIGIN }, async (client) =>
+    client.get(buildWorkspaceProgrammaticDepletedKey(workspaceId))
+  );
+
+  if (depleted === BLOCKED_FLAG || depleted === NOT_BLOCKED_FLAG) {
+    return depleted === BLOCKED_FLAG;
+  }
+
+  logger.info(
+    { workspaceId },
+    "[ProgrammaticCap] Cache miss during programmatic API blocked check, falling back to DB"
+  );
+
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  if (!workspace) {
+    logger.warn(
+      { workspaceId },
+      "[ProgrammaticCap] Workspace not found during programmatic API blocked cache read-through fallback"
+    );
+    return false;
+  }
+
+  const programmaticDepleted = workspace.programmaticCreditState === "depleted";
+  await setFlag(
+    buildWorkspaceProgrammaticDepletedKey(workspaceId),
+    programmaticDepleted ? BLOCKED_FLAG : NOT_BLOCKED_FLAG
+  );
+  return programmaticDepleted;
+}
+
+// 80% warning flag — set by webhook, no DB backing.
+
+export async function setWorkspaceProgrammaticWarned(
+  workspaceId: string
+): Promise<void> {
+  await setFlag(
+    buildWorkspaceProgrammaticWarningKey(workspaceId),
+    BLOCKED_FLAG
+  );
+}
+
+export async function clearWorkspaceProgrammaticWarned(
+  workspaceId: string
+): Promise<void> {
+  await setFlag(
+    buildWorkspaceProgrammaticWarningKey(workspaceId),
+    NOT_BLOCKED_FLAG
+  );
+}
+
+export async function isWorkspaceProgrammaticWarned(
+  workspaceId: string
+): Promise<boolean> {
+  const val = await runOnRedis({ origin: REDIS_ORIGIN }, async (client) =>
+    client.get(buildWorkspaceProgrammaticWarningKey(workspaceId))
+  );
+  return val === BLOCKED_FLAG;
 }

--- a/front/lib/metronome/programmatic_credit_state_machine.ts
+++ b/front/lib/metronome/programmatic_credit_state_machine.ts
@@ -1,9 +1,9 @@
-import { CRITICAL_BALANCE_OFFSET } from "@app/lib/metronome/alerts/programmatic_cap";
 import {
+  CRITICAL_BALANCE_OFFSET,
   clearWorkspaceProgrammaticDepleted,
   setWorkspaceProgrammaticCreditStatus,
   setWorkspaceProgrammaticDepleted,
-} from "@app/lib/metronome/user_block";
+} from "@app/lib/metronome/alerts/programmatic_cap";
 import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { invalidateCacheAfterCommit } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -1,13 +1,11 @@
 // Redis fast-path cache for credit-state-driven access control.
 //
-// Three keys back the credit state machines:
+// Keys:
 //   - `metronome:user_cap:<ws>:<user>`: caches the user's per-user cap state.
 //   - `metronome:user_awu_warning:<ws>:<user>`: caches the 80% AWU warning state.
 //   - `metronome:pool_depleted:<ws>`: caches the workspace pool state.
 //
-// Each key stores an explicit boolean flag:
-//   - `"1"`: blocked / warned / depleted
-//   - `"0"`: not blocked / not warned / not depleted
+// Each key stores an explicit boolean flag: "1" (blocked/warned) or "0" (ok).
 //
 // `isUserBlocked` is the unified read: a user is blocked iff either cached flag
 // is `"1"`, and it returns the reason ("credits_exhausted" for a depleted
@@ -19,8 +17,11 @@
 // `invalidateCacheAfterCommit`, and cache misses fall back to DB and
 // repopulate both flags.
 //
-// The warning flag (`metronome:user_awu_warning`) has no DB column backing it:
-// a cold-cache miss returns `false` (safe default until the next webhook re-sets the flag).
+// The AWU warning flag has no DB column backing it: a cold-cache miss returns
+// `false` (safe default until the next webhook re-sets the flag).
+//
+// Programmatic cap state (depleted, credit status, warning flag) lives in
+// front/lib/metronome/alerts/programmatic_cap.ts.
 //
 import { runOnRedis } from "@app/lib/api/redis";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
@@ -28,14 +29,8 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
-import type {
-  WorkspacePoolCreditState,
-  WorkspaceProgrammaticCreditState,
-} from "@app/types/credits";
-import {
-  isWorkspacePoolCreditState,
-  isWorkspaceProgrammaticCreditState,
-} from "@app/types/credits";
+import type { WorkspacePoolCreditState } from "@app/types/credits";
+import { isWorkspacePoolCreditState } from "@app/types/credits";
 
 export type UserBlockedReason = "credits_exhausted" | "user_cap_reached";
 
@@ -57,16 +52,6 @@ function buildWorkspacePoolDepletedKey(workspaceId: string): string {
 
 function buildWorkspaceCreditPoolStatusKey(workspaceId: string): string {
   return `metronome:pool_credit_status:${workspaceId}`;
-}
-
-function buildWorkspaceProgrammaticDepletedKey(workspaceId: string): string {
-  return `metronome:programmatic_depleted:${workspaceId}`;
-}
-
-function buildWorkspaceProgrammaticCreditStatusKey(
-  workspaceId: string
-): string {
-  return `metronome:programmatic_credit_status:${workspaceId}`;
 }
 
 function isBlockFlag(value: string | null): value is "0" | "1" {
@@ -297,102 +282,6 @@ export async function getWorkspaceCreditPoolStatus(
   const status = workspace.poolCreditState;
   await setFlag(buildWorkspaceCreditPoolStatusKey(workspaceId), status);
   return status;
-}
-
-// Workspace programmatic credit state (monthly cap).
-
-export async function setWorkspaceProgrammaticDepleted(
-  workspaceId: string
-): Promise<void> {
-  await setFlag(
-    buildWorkspaceProgrammaticDepletedKey(workspaceId),
-    BLOCKED_FLAG
-  );
-}
-
-export async function clearWorkspaceProgrammaticDepleted(
-  workspaceId: string
-): Promise<void> {
-  await setFlag(
-    buildWorkspaceProgrammaticDepletedKey(workspaceId),
-    NOT_BLOCKED_FLAG
-  );
-}
-
-export async function setWorkspaceProgrammaticCreditStatus(
-  workspaceId: string,
-  status: WorkspaceProgrammaticCreditState
-): Promise<void> {
-  await setFlag(buildWorkspaceProgrammaticCreditStatusKey(workspaceId), status);
-}
-
-export async function getWorkspaceProgrammaticCreditStatus(
-  workspaceId: string
-): Promise<WorkspaceProgrammaticCreditState> {
-  const cached = await runOnRedis({ origin: REDIS_ORIGIN }, async (client) =>
-    client.get(buildWorkspaceProgrammaticCreditStatusKey(workspaceId))
-  );
-
-  if (cached && isWorkspaceProgrammaticCreditState(cached)) {
-    return cached;
-  }
-
-  logger.info(
-    {
-      workspaceId,
-      workspaceProgrammaticCreditStatusCacheHit: false,
-    },
-    "[MetronomeUserBlock] Cache miss during programmatic credit status check, falling back to DB"
-  );
-
-  const workspace = await WorkspaceResource.fetchById(workspaceId);
-  if (!workspace) {
-    logger.warn(
-      { workspaceId },
-      "[MetronomeUserBlock] Workspace not found during programmatic credit status cache read-through fallback"
-    );
-    return "active";
-  }
-
-  const status = workspace.programmaticCreditState;
-  await setFlag(buildWorkspaceProgrammaticCreditStatusKey(workspaceId), status);
-  return status;
-}
-
-export async function isProgrammaticApiBlocked(
-  workspaceId: string
-): Promise<boolean> {
-  const depleted = await runOnRedis({ origin: REDIS_ORIGIN }, async (client) =>
-    client.get(buildWorkspaceProgrammaticDepletedKey(workspaceId))
-  );
-
-  if (isBlockFlag(depleted)) {
-    return depleted === BLOCKED_FLAG;
-  }
-
-  logger.info(
-    {
-      workspaceId,
-      workspaceProgrammaticCacheHit: false,
-    },
-    "[MetronomeUserBlock] Cache miss during programmatic API blocked check, falling back to DB"
-  );
-
-  const workspace = await WorkspaceResource.fetchById(workspaceId);
-  if (!workspace) {
-    logger.warn(
-      { workspaceId },
-      "[MetronomeUserBlock] Workspace not found during programmatic API blocked cache read-through fallback"
-    );
-    return false;
-  }
-
-  const programmaticDepleted = workspace.programmaticCreditState === "depleted";
-  await setFlag(
-    buildWorkspaceProgrammaticDepletedKey(workspaceId),
-    programmaticDepleted ? BLOCKED_FLAG : NOT_BLOCKED_FLAG
-  );
-  return programmaticDepleted;
 }
 
 // Workspace-pool-only read for API calls (no per-user cap).

--- a/front/lib/notifications/workflows/workspace-programmatic-cap-warning.ts
+++ b/front/lib/notifications/workflows/workspace-programmatic-cap-warning.ts
@@ -1,0 +1,147 @@
+import config from "@app/lib/api/config";
+import { renderEmail } from "@app/lib/notifications/email-templates/default";
+import { getNovuClient } from "@app/lib/notifications/novu-client";
+import logger from "@app/logger/logger";
+import {
+  WORKSPACE_PROGRAMMATIC_CAP_WARNING_TAG,
+  WORKSPACE_PROGRAMMATIC_CAP_WARNING_TRIGGER_ID,
+} from "@app/types/notification_preferences";
+import { workflow } from "@novu/framework";
+import z from "zod";
+
+const WorkspaceProgrammaticCapWarningPayloadSchema = z.object({
+  workspaceId: z.string(),
+  workspaceName: z.string(),
+  monthlyCapCredits: z.number(),
+  // Enterprise workspaces can't self-serve credits, so we point them to their
+  // Dust representative instead of the usage page.
+  isEnterprise: z.boolean(),
+});
+
+type WorkspaceProgrammaticCapWarningPayloadType = z.infer<
+  typeof WorkspaceProgrammaticCapWarningPayloadSchema
+>;
+
+function formatCredits(credits: number): string {
+  return credits.toLocaleString("en-US");
+}
+
+export const workspaceProgrammaticCapWarningWorkflow = workflow(
+  WORKSPACE_PROGRAMMATIC_CAP_WARNING_TRIGGER_ID,
+  async ({ step, payload, subscriber }) => {
+    await step.inApp("workspace-programmatic-cap-warning-in-app", async () => {
+      const subject = `Your workspace's programmatic API usage has reached 80% of its monthly cap`;
+      const body =
+        `The workspace "${payload.workspaceName}" has used 80% of its ${formatCredits(payload.monthlyCapCredits)}-credit programmatic API monthly cap. ` +
+        (payload.isEnterprise
+          ? `Please reach out to your Dust representative to increase the cap.`
+          : `Visit the usage page to increase the cap before API calls are blocked.`);
+      return {
+        subject,
+        body,
+        data: {
+          workspaceId: payload.workspaceId,
+          monthlyCapCredits: payload.monthlyCapCredits,
+        },
+      };
+    });
+
+    await step.email("workspace-programmatic-cap-warning-email", async () => {
+      const subject = `[Dust] Your programmatic API usage has reached 80% in ${payload.workspaceName}`;
+      const purchaseLine = payload.isEnterprise
+        ? `To avoid having programmatic API calls blocked, please reach out to your Dust representative.`
+        : `To avoid having programmatic API calls blocked, you can increase the cap from your workspace usage page.`;
+      const content =
+        `Your workspace "${payload.workspaceName}" has used 80% of its programmatic API monthly cap.\n` +
+        `Monthly cap: ${formatCredits(payload.monthlyCapCredits)} credits\n` +
+        purchaseLine;
+
+      const body = await renderEmail({
+        name: subscriber.firstName ?? "there",
+        workspace: {
+          id: payload.workspaceId,
+          name: payload.workspaceName,
+        },
+        content,
+        action: {
+          label: payload.isEnterprise ? "Manage credits" : "See usage details",
+          url: `${config.getAppUrl()}/w/${payload.workspaceId}/usage`,
+        },
+      });
+      return { subject, body };
+    });
+  },
+  {
+    payloadSchema: WorkspaceProgrammaticCapWarningPayloadSchema,
+    tags: [WORKSPACE_PROGRAMMATIC_CAP_WARNING_TAG],
+  }
+);
+
+/**
+ * Notify workspace admins that the programmatic API monthly cap has crossed
+ * the 80% early-warning threshold. One Novu event per admin, deduped via a
+ * `transactionId` keyed on the Metronome event so redeliveries don't re-send.
+ * Fire-and-forget — errors are logged but don't block the caller.
+ */
+export function notifyAdminsProgrammaticCapWarning({
+  admins,
+  workspaceId,
+  workspaceName,
+  monthlyCapCredits,
+  isEnterprise,
+  eventId,
+}: {
+  admins: Array<{
+    sId: string;
+    email: string;
+    firstName: string | null;
+    lastName: string | null;
+  }>;
+  workspaceId: string;
+  workspaceName: string;
+  monthlyCapCredits: number;
+  isEnterprise: boolean;
+  eventId: string;
+}): void {
+  if (admins.length === 0) {
+    return;
+  }
+
+  const payload: WorkspaceProgrammaticCapWarningPayloadType = {
+    workspaceId,
+    workspaceName,
+    monthlyCapCredits,
+    isEnterprise,
+  };
+
+  void getNovuClient()
+    .then((novuClient) =>
+      novuClient.triggerBulk({
+        events: admins.map((admin) => ({
+          workflowId: WORKSPACE_PROGRAMMATIC_CAP_WARNING_TRIGGER_ID,
+          to: {
+            subscriberId: admin.sId,
+            email: admin.email,
+            firstName: admin.firstName ?? undefined,
+            lastName: admin.lastName ?? undefined,
+          },
+          payload,
+          transactionId: `${WORKSPACE_PROGRAMMATIC_CAP_WARNING_TRIGGER_ID}-${eventId}-${admin.sId}`,
+        })),
+      })
+    )
+    .then((r) => {
+      if (r.result.some((res) => !!res.error?.length)) {
+        logger.error(
+          { workspaceId, monthlyCapCredits },
+          "Failed to trigger programmatic cap warning notification"
+        );
+      }
+    })
+    .catch((err) => {
+      logger.error(
+        { err, workspaceId, monthlyCapCredits },
+        "Failed to trigger programmatic cap warning notification"
+      );
+    });
+}

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -272,6 +272,8 @@ export function useWorkspaceUsageStatus({
   return {
     awuStatus: data?.awuStatus ?? "normal",
     poolCreditState: data?.poolCreditState ?? "active",
+    programmaticCreditState: data?.programmaticCreditState ?? "active",
+    programmaticWarned: data?.programmaticWarned ?? false,
     isUsageStatusLoading: !error && !data && !disabled,
   };
 }

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -5,10 +5,8 @@ import type { DustError } from "@app/lib/error";
 import { getWebhookRequestsBucket } from "@app/lib/file_storage";
 import { isGCSPreconditionFailedError } from "@app/lib/file_storage/types";
 import { matchPayload, parseMatcherExpression } from "@app/lib/matcher";
-import {
-  isApiBlocked,
-  isProgrammaticApiBlocked,
-} from "@app/lib/metronome/user_block";
+import { isProgrammaticApiBlocked } from "@app/lib/metronome/alerts/programmatic_cap";
+import { isApiBlocked } from "@app/lib/metronome/user_block";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
 import type { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";

--- a/front/pages/api/novu/index.ts
+++ b/front/pages/api/novu/index.ts
@@ -9,6 +9,7 @@ import { projectAddedAsMemberWorkflow } from "@app/lib/notifications/workflows/p
 import { providerCredentialsHealthUpdatedWorkflow } from "@app/lib/notifications/workflows/provider-credential-updated";
 import { skillSuggestionsReadyWorkflow } from "@app/lib/notifications/workflows/skill-suggestions-ready";
 import { userAwuCapReachedWorkflow } from "@app/lib/notifications/workflows/user-awu-cap-reached";
+import { workspaceProgrammaticCapWarningWorkflow } from "@app/lib/notifications/workflows/workspace-programmatic-cap-warning";
 import { serve } from "@novu/framework/next";
 
 // This endpoint exposes our code-based notifications workflows to the Novu platform.
@@ -26,5 +27,6 @@ export default serve({
     providerCredentialsHealthUpdatedWorkflow,
     userAwuCapReachedWorkflow,
     balanceThresholdReachedWorkflow,
+    workspaceProgrammaticCapWarningWorkflow,
   ],
 });

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -25,10 +25,8 @@ import {
   normalizeConversationVisibility,
 } from "@app/lib/api/v1/backward_compatibility";
 import type { Authenticator } from "@app/lib/auth";
-import {
-  isApiBlocked,
-  isProgrammaticApiBlocked,
-} from "@app/lib/metronome/user_block";
+import { isProgrammaticApiBlocked } from "@app/lib/metronome/alerts/programmatic_cap";
+import { isApiBlocked } from "@app/lib/metronome/user_block";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";

--- a/front/pages/api/w/[wId]/usage-status.ts
+++ b/front/pages/api/w/[wId]/usage-status.ts
@@ -4,18 +4,27 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import {
+  getWorkspaceProgrammaticCreditStatus,
+  isWorkspaceProgrammaticWarned,
+} from "@app/lib/metronome/alerts/programmatic_cap";
+import {
   getWorkspaceCreditPoolStatus,
   isUserAwuWarned,
   isUserBlocked,
 } from "@app/lib/metronome/user_block";
 import { apiError } from "@app/logger/withlogging";
-import type { WorkspacePoolCreditState } from "@app/types/credits";
+import type {
+  WorkspacePoolCreditState,
+  WorkspaceProgrammaticCreditState,
+} from "@app/types/credits";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export type GetWorkspaceUsageStatusResponseBody = {
   awuStatus: "normal" | "warned" | "blocked";
   poolCreditState: WorkspacePoolCreditState;
+  programmaticCreditState: WorkspaceProgrammaticCreditState;
+  programmaticWarned: boolean;
 };
 
 async function handler(
@@ -40,14 +49,24 @@ async function handler(
 
   // Workspaces not on Metronome billing have no usage status to report.
   if (!workspace.metronomeCustomerId) {
-    return res
-      .status(200)
-      .json({ awuStatus: "normal", poolCreditState: "active" });
+    return res.status(200).json({
+      awuStatus: "normal",
+      poolCreditState: "active",
+      programmaticCreditState: "active",
+      programmaticWarned: false,
+    });
   }
 
-  const [poolCreditState, blockedReason] = await Promise.all([
+  const [
+    poolCreditState,
+    programmaticCreditState,
+    blockedReason,
+    programmaticWarned,
+  ] = await Promise.all([
     getWorkspaceCreditPoolStatus(workspace.sId),
+    getWorkspaceProgrammaticCreditStatus(workspace.sId),
     isUserBlocked(workspace.sId, user.sId),
+    isWorkspaceProgrammaticWarned(workspace.sId),
   ]);
 
   let awuStatus: GetWorkspaceUsageStatusResponseBody["awuStatus"] = "normal";
@@ -57,7 +76,12 @@ async function handler(
     awuStatus = "warned";
   }
 
-  return res.status(200).json({ awuStatus, poolCreditState });
+  return res.status(200).json({
+    awuStatus,
+    poolCreditState,
+    programmaticCreditState,
+    programmaticWarned,
+  });
 }
 
 export default withSessionAuthenticationForWorkspace(handler, {

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -13,10 +13,8 @@ import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import { getRemainingDailyCapMicroUsd } from "@app/lib/api/programmatic_usage/daily_cap";
 import { checkProgrammaticUsageLimits } from "@app/lib/api/programmatic_usage/tracking";
 import { type Authenticator, hasFeatureFlag } from "@app/lib/auth";
-import {
-  isApiBlocked,
-  isProgrammaticApiBlocked,
-} from "@app/lib/metronome/user_block";
+import { isProgrammaticApiBlocked } from "@app/lib/metronome/alerts/programmatic_cap";
+import { isApiBlocked } from "@app/lib/metronome/user_block";
 import {
   AgentMessageModel,
   MessageModel,

--- a/front/types/notification_preferences.ts
+++ b/front/types/notification_preferences.ts
@@ -114,6 +114,11 @@ export const BALANCE_THRESHOLD_REACHED_TRIGGER_ID =
 export const BALANCE_THRESHOLD_REACHED_TAG =
   "balance-threshold-reached" as const;
 
+export const WORKSPACE_PROGRAMMATIC_CAP_WARNING_TRIGGER_ID =
+  "workspace-programmatic-cap-warning" as const;
+export const WORKSPACE_PROGRAMMATIC_CAP_WARNING_TAG =
+  "workspace-programmatic-cap-warning" as const;
+
 export type WorkflowTriggerId =
   | typeof CONVERSATION_UNREAD_TRIGGER_ID
   | typeof PROJECT_ADDED_AS_MEMBER_TRIGGER_ID
@@ -121,4 +126,5 @@ export type WorkflowTriggerId =
   | typeof SKILL_SUGGESTIONS_READY_TRIGGER_ID
   | typeof PROVIDER_CREDENTIALS_HEALTH_UPDATED_TRIGGER_ID
   | typeof USER_AWU_CAP_REACHED_TRIGGER_ID
-  | typeof BALANCE_THRESHOLD_REACHED_TRIGGER_ID;
+  | typeof BALANCE_THRESHOLD_REACHED_TRIGGER_ID
+  | typeof WORKSPACE_PROGRAMMATIC_CAP_WARNING_TRIGGER_ID;


### PR DESCRIPTION
## Description

Follow-up to #26555 which added the 80% warning alert for the programmatic monthly cap but left `dispatchProgrammaticWarning` as a TODO.

**Notifications (email + in-app):** When the Metronome webhook fires for the 80% programmatic cap warning, workspace admins now receive an email and in-app Novu notification. Uses transactionId-based dedup so redeliveries don't re-send. Best-effort — failures are logged and swallowed so webhook processing is never disrupted.

**Sidebar banners:** The `usage-status` endpoint now exposes `programmaticCreditState`. Admins see a new sidebar banner at `active_low_balance` (warning), `active_critical_balance` (danger), and `depleted` (danger, API blocked), matching the existing pool-credit banner.

**Redis caching:** `upsertMetronomeProgrammaticCapAlerts` now warms the Redis cache with the exact monthly cap via `warmCacheWithRedis`. The webhook handler reads from Redis — no Metronome round-trip on the hot path. Cache is invalidated on `clearMetronomeProgrammaticCapAlerts`.

## Tests

Manual only.

## Risk

low

## Deploy Plan

deploy front
