### PR TITLE
chore: bump extension version

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/extension",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Dust Chrome Extension",
   "scripts": {
     "clean": "rm -rf build/*",

--- a/extension/platforms/chrome/manifests/manifest.base.json
+++ b/extension/platforms/chrome/manifests/manifest.base.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dust",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Get more done, faster, with the power of your agents at your fingertips.",
   "icons": {
     "16": "images/dust16.png",

--- a/extension/platforms/firefox/manifests/manifest.base.json
+++ b/extension/platforms/firefox/manifests/manifest.base.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dust",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Get more done, faster, with the power of your agents at your fingertips.",
   "icons": {
     "16": "images/dust16.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -408,7 +408,7 @@
     },
     "extension": {
       "name": "@dust-tt/extension",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "ISC",
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",


### PR DESCRIPTION
## Description

This PR bumps the Dust browser extension version from `0.1.8` to `0.1.9` in `extension/package.json` and the Chrome and Firefox manifest files.

## Tests

Manually.

## Risks

## Deploy Plan
