### PR TITLE
Require double ESC to stop the agent loop

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -375,8 +375,8 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
       e.preventDefault();
       lastEscTimeRef.current = now;
       setTimeout(() => {
-        if (lastEscTimeRef.current === now) {
-          doAction(hasPending ? "interrupt" : "cancel");
+        if (lastEscTimeRef.current === now && hasPending) {
+          doAction("interrupt");
         }
       }, DOUBLE_ESC_WINDOW_MS);
     }


### PR DESCRIPTION
## Description

Behavior before:
- Single ESC: skips the next queued message if there are messages pending, or stops the loop if the queue is empty
- Double ESC: always stops the loop

New behavior:
- Single ESC: skips the next queued message if there are messages pending, or does nothing if the queue is empty
- Double ESC: always stops the loop

Why

Single ESC with an empty queue would silently stop the loop, making it too easy to accidentally cancel. The new behavior requires an intentional double ESC to stop.

## Tests

Will test on a preview app.

## Risk

/ 

## Deploy Plan

Deploy front. 