### PR TITLE
fix: prevent pods drag and drop

### DIFF
--- a/front/components/assistant/conversation/sidebar/PodList.tsx
+++ b/front/components/assistant/conversation/sidebar/PodList.tsx
@@ -79,6 +79,10 @@ const PodListItem = memo(
     const [isDragOver, setIsDragOver] = useState(false);
     const dragCounterRef = useRef(0);
 
+    const handleDragStart = (e: React.DragEvent) => {
+      e.preventDefault();
+    };
+
     const handleDragEnter = (e: React.DragEvent) => {
       e.preventDefault();
       dragCounterRef.current++;
@@ -135,6 +139,7 @@ const PodListItem = memo(
     return (
       <NavigationListItem
         ref={dropZoneRef}
+        onDragStart={handleDragStart}
         onDragEnter={handleDragEnter}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}


### PR DESCRIPTION
## Description

This PR prevents pods from being dragged in the conversation sidebar by handling the `dragstart` event and calling `e.preventDefault()`.

## Tests

Manually.

## Risks
Low.

## Deploy Plan
Standard deployment.
