### PR TITLE
feat(agents): add editable-stake tool calls with "Edit & send" flow

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit-and-send-action.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit-and-send-action.ts
@@ -1,0 +1,100 @@
+import { editAndResumeAction } from "@app/lib/api/assistant/conversation/edit_and_resume_action";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const EditAndSendActionSchema = z.object({
+  actionId: z.string(),
+  editedInputs: z.record(z.unknown()),
+});
+
+// Mounted at /api/w/:wId/assistant/conversations/:cId/messages/:mId/edit-and-send-action.
+const app = workspaceApp();
+
+app.post("/", validate("json", EditAndSendActionSchema), async (ctx) => {
+  const auth = ctx.get("auth");
+  const cId = ctx.req.param("cId") ?? "";
+  const mId = ctx.req.param("mId") ?? "";
+
+  const conversation = await ConversationResource.fetchById(auth, cId);
+  if (!conversation) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "Conversation not found.",
+      },
+    });
+  }
+
+  const { actionId, editedInputs } = ctx.req.valid("json");
+
+  const result = await editAndResumeAction(auth, conversation, {
+    actionId,
+    messageId: mId,
+    editedInputs,
+  });
+
+  if (result.isErr()) {
+    switch (result.error.code) {
+      case "action_not_blocked":
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "action_not_blocked",
+            message: result.error.message,
+          },
+        });
+      case "action_not_found":
+        return apiError(ctx, {
+          status_code: 404,
+          api_error: {
+            type: "action_not_found",
+            message: result.error.message,
+          },
+        });
+      case "tool_not_editable":
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: result.error.message,
+          },
+        });
+      case "invalid_edited_inputs":
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: result.error.message,
+          },
+        });
+      case "unauthorized":
+        return apiError(ctx, {
+          status_code: 403,
+          api_error: {
+            type: "invalid_request_error",
+            message: result.error.message,
+          },
+        });
+      default:
+        return apiError(
+          ctx,
+          {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: "Failed to edit and send action",
+            },
+          },
+          result.error
+        );
+    }
+  }
+
+  return ctx.json({ success: true });
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
@@ -20,6 +20,7 @@ import { apiError } from "@front-api/middlewares/utils";
 import actions from "./actions";
 import answerQuestion from "./answer-question";
 import edit from "./edit";
+import editAndSendAction from "./edit-and-send-action";
 import events from "./events";
 import feedbacks from "./feedbacks";
 import mentions from "./mentions";
@@ -213,6 +214,7 @@ app.delete("/", async (ctx) => {
 app.route("/actions", actions);
 app.route("/answer-question", answerQuestion);
 app.route("/edit", edit);
+app.route("/edit-and-send-action", editAndSendAction);
 app.route("/events", events);
 app.route("/feedbacks", feedbacks);
 app.route("/mentions", mentions);

--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -74,6 +74,7 @@ function ToolItem({
     medium: "Medium (allows per-agent confirmation save)",
     low: "Low (allows user-global confirmation save)",
     never_ask: "Never ask (automatic execution)",
+    editable: "Editable (user can modify inputs before sending)",
   };
 
   return (

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -330,6 +330,7 @@ export function AgentMessage({
                 argumentsRequiringApproval:
                   eventPayload.data.argumentsRequiringApproval,
                 approvalArgsLabel: eventPayload.data.approvalArgsLabel,
+                editableArguments: eventPayload.data.editableArguments,
               },
             });
             break;

--- a/front/components/assistant/conversation/GmailComposeEditor.tsx
+++ b/front/components/assistant/conversation/GmailComposeEditor.tsx
@@ -1,5 +1,5 @@
 import { Input, TextArea } from "@dust-tt/sparkle";
-import { useState } from "react";
+import { useLayoutEffect, useState } from "react";
 
 interface GmailComposeEditorProps {
   editedFields: Record<string, string>;
@@ -13,8 +13,10 @@ function parseEmailArray(raw: string): string {
     if (Array.isArray(parsed)) {
       return parsed.join(", ");
     }
+    // JSON but not an array (e.g. '""' when the input was undefined) — treat as empty
+    return "";
   } catch {
-    // not JSON
+    // not JSON — treat as plain comma-separated text
   }
   return raw;
 }
@@ -38,6 +40,24 @@ export function GmailComposeEditor({
   const [showBcc, setShowBcc] = useState(
     () => !!parseEmailArray(editedFields["bcc"] ?? "[]")
   );
+
+  // Normalize email array fields on mount so they always hold valid JSON arrays.
+  // When blockedAction.inputs["cc"] is undefined, the parent initializes editedFields["cc"]
+  // as '""' (JSON-encoded empty string). Submitting that would send cc="" (string) instead
+  // of cc=[] (array), failing the MCP schema validation.
+  useLayoutEffect(() => {
+    setEditedFields((prev) => {
+      const updates: Record<string, string> = {};
+      for (const key of ["to", "cc", "bcc"]) {
+        const display = parseEmailArray(prev[key] ?? "");
+        const normalized = serializeEmailArray(display);
+        if (normalized !== prev[key]) {
+          updates[key] = normalized;
+        }
+      }
+      return Object.keys(updates).length > 0 ? { ...prev, ...updates } : prev;
+    });
+  }, [setEditedFields]);
 
   function handleEmailField(key: string, value: string) {
     setEditedFields((prev) => ({

--- a/front/components/assistant/conversation/GmailComposeEditor.tsx
+++ b/front/components/assistant/conversation/GmailComposeEditor.tsx
@@ -1,0 +1,158 @@
+import { Input, TextArea } from "@dust-tt/sparkle";
+import { useState } from "react";
+
+interface GmailComposeEditorProps {
+  editedFields: Record<string, string>;
+  setEditedFields: React.Dispatch<React.SetStateAction<Record<string, string>>>;
+  disabled: boolean;
+}
+
+function parseEmailArray(raw: string): string {
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed.join(", ");
+    }
+  } catch {
+    // not JSON
+  }
+  return raw;
+}
+
+function serializeEmailArray(value: string): string {
+  const emails = value
+    .split(",")
+    .map((e) => e.trim())
+    .filter(Boolean);
+  return JSON.stringify(emails);
+}
+
+export function GmailComposeEditor({
+  editedFields,
+  setEditedFields,
+  disabled,
+}: GmailComposeEditorProps) {
+  const [showCc, setShowCc] = useState(
+    () => !!parseEmailArray(editedFields["cc"] ?? "[]")
+  );
+  const [showBcc, setShowBcc] = useState(
+    () => !!parseEmailArray(editedFields["bcc"] ?? "[]")
+  );
+
+  function handleEmailField(key: string, value: string) {
+    setEditedFields((prev) => ({
+      ...prev,
+      [key]: serializeEmailArray(value),
+    }));
+  }
+
+  function handleTextField(key: string, value: string) {
+    setEditedFields((prev) => ({ ...prev, [key]: value }));
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-border shadow-lg dark:border-border-night">
+      {/* Compose header */}
+      <div className="flex items-center bg-muted-background px-3 py-2 dark:bg-muted-background-night">
+        <span className="text-xs font-semibold text-foreground dark:text-foreground-night">
+          New message
+        </span>
+        <div className="ml-auto flex gap-2">
+          {!showCc && (
+            <button
+              type="button"
+              className="text-xs text-muted-foreground hover:text-foreground dark:text-muted-foreground-night dark:hover:text-foreground-night"
+              onClick={() => setShowCc(true)}
+            >
+              Cc
+            </button>
+          )}
+          {!showBcc && (
+            <button
+              type="button"
+              className="text-xs text-muted-foreground hover:text-foreground dark:text-muted-foreground-night dark:hover:text-foreground-night"
+              onClick={() => setShowBcc(true)}
+            >
+              Bcc
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Field rows */}
+      <div className="flex flex-col bg-background dark:bg-background-night">
+        <FieldRow label="To">
+          <Input
+            value={parseEmailArray(editedFields["to"] ?? "[]")}
+            onChange={(e) => handleEmailField("to", e.target.value)}
+            disabled={disabled}
+            placeholder="Recipients"
+            className="rounded-none border-0 shadow-none focus-visible:ring-0"
+          />
+        </FieldRow>
+
+        {showCc && (
+          <FieldRow label="Cc">
+            <Input
+              value={parseEmailArray(editedFields["cc"] ?? "[]")}
+              onChange={(e) => handleEmailField("cc", e.target.value)}
+              disabled={disabled}
+              placeholder="CC recipients"
+              className="rounded-none border-0 shadow-none focus-visible:ring-0"
+            />
+          </FieldRow>
+        )}
+
+        {showBcc && (
+          <FieldRow label="Bcc">
+            <Input
+              value={parseEmailArray(editedFields["bcc"] ?? "[]")}
+              onChange={(e) => handleEmailField("bcc", e.target.value)}
+              disabled={disabled}
+              placeholder="BCC recipients"
+              className="rounded-none border-0 shadow-none focus-visible:ring-0"
+            />
+          </FieldRow>
+        )}
+
+        <FieldRow label="Subject">
+          <Input
+            value={editedFields["subject"] ?? ""}
+            onChange={(e) => handleTextField("subject", e.target.value)}
+            disabled={disabled}
+            placeholder="Subject"
+            className="rounded-none border-0 shadow-none focus-visible:ring-0"
+          />
+        </FieldRow>
+
+        {/* Body */}
+        <div className="border-t border-border p-2 dark:border-border-night">
+          <TextArea
+            value={editedFields["body"] ?? ""}
+            onChange={(e) => handleTextField("body", e.target.value)}
+            disabled={disabled}
+            minRows={6}
+            placeholder="Write your email..."
+            className="resize-none border-0 p-1 shadow-none focus-visible:ring-0"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface FieldRowProps {
+  label: string;
+  children: React.ReactNode;
+}
+
+function FieldRow({ label, children }: FieldRowProps) {
+  return (
+    <div className="flex items-center border-b border-border dark:border-border-night">
+      <span className="w-14 shrink-0 pl-3 text-xs text-muted-foreground dark:text-muted-foreground-night">
+        {label}
+      </span>
+      <div className="min-w-0 flex-1">{children}</div>
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -1,6 +1,7 @@
 import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import { ToolValidationDetails } from "@app/components/assistant/conversation/ToolValidationDetails";
 import { getIcon } from "@app/components/resources/resources_icons";
+import { useEditAndSendAction } from "@app/hooks/useEditAndSendAction";
 import { useValidateAction } from "@app/hooks/useValidateAction";
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
@@ -29,6 +30,7 @@ import {
   CheckIcon,
   ContentMessage,
   Label,
+  TextArea,
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import { useMemo, useState } from "react";
@@ -153,6 +155,24 @@ export function MCPToolValidationRequired({
   const [neverAskAgain, setNeverAskAgain] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
+  // For editable-stake tools: track per-field edits
+  const editableArguments =
+    blockedAction.stake === "editable"
+      ? (blockedAction.editableArguments ??
+        Object.keys(blockedAction.inputs))
+      : [];
+  const [editedFields, setEditedFields] = useState<Record<string, string>>(
+    () =>
+      Object.fromEntries(
+        editableArguments.map((key) => [
+          key,
+          typeof blockedAction.inputs[key] === "string"
+            ? (blockedAction.inputs[key] as string)
+            : JSON.stringify(blockedAction.inputs[key] ?? ""),
+        ])
+      )
+  );
+
   const {
     getBlockedActions,
     removeCompletedAction,
@@ -160,6 +180,10 @@ export function MCPToolValidationRequired({
     stopPulsingAction,
   } = useBlockedActionsContext();
   const { validateAction, isValidating } = useValidateAction({
+    owner,
+    onError: setErrorMessage,
+  });
+  const { editAndSendAction, isEditing } = useEditAndSendAction({
     owner,
     onError: setErrorMessage,
   });
@@ -219,6 +243,32 @@ export function MCPToolValidationRequired({
         }
       }
     }
+  };
+
+  const handleEditAndSend = async () => {
+    stopPulsingAction(blockedAction.actionId);
+    setErrorMessage(null);
+
+    const editedInputs: Record<string, unknown> = {};
+    for (const key of editableArguments) {
+      const rawValue = editedFields[key] ?? "";
+      try {
+        editedInputs[key] = JSON.parse(rawValue);
+      } catch {
+        editedInputs[key] = rawValue;
+      }
+    }
+
+    const result = await editAndSendAction({
+      validationRequest: blockedAction,
+      editedInputs,
+    });
+
+    if (!result.success) {
+      setErrorMessage("Failed to edit and send action. Please try again.");
+      return;
+    }
+    removeCompletedAction(blockedAction.actionId);
   };
 
   const toolOverride =
@@ -293,6 +343,27 @@ export function MCPToolValidationRequired({
             conversationId={conversationId}
             defaultExpanded={toolOverride?.detailsExpanded}
           />
+          {/* Provisional editable fields for editable-stake tools */}
+          {blockedAction.stake === "editable" && editableArguments.length > 0 && (
+            <div className="flex flex-col gap-2">
+              {editableArguments.map((key) => (
+                <div key={key} className="flex flex-col gap-1">
+                  <Label className="text-xs font-medium">{key}</Label>
+                  <TextArea
+                    value={editedFields[key] ?? ""}
+                    onChange={(e) =>
+                      setEditedFields((prev) => ({
+                        ...prev,
+                        [key]: e.target.value,
+                      }))
+                    }
+                    disabled={isEditing || isValidating}
+                    minRows={3}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
           {errorMessage && (
             <div className="mt-2 text-sm font-medium text-warning-800 dark:text-warning-800-night">
               {errorMessage}
@@ -324,19 +395,42 @@ export function MCPToolValidationRequired({
                 variant="outline"
                 size="xs"
                 icon={XMarkIcon}
-                disabled={isValidating}
+                disabled={isValidating || isEditing}
                 isPulsing={isPulsing}
                 onClick={() => void handleValidation("rejected")}
               />
-              <Button
-                label="Allow"
-                variant="highlight"
-                size="xs"
-                icon={CheckIcon}
-                disabled={isValidating}
-                isPulsing={isPulsing}
-                onClick={() => void handleValidation("approved")}
-              />
+              {blockedAction.stake === "editable" ? (
+                <>
+                  <Button
+                    label="Send as-is"
+                    variant="outline"
+                    size="xs"
+                    icon={CheckIcon}
+                    disabled={isValidating || isEditing}
+                    isPulsing={isPulsing}
+                    onClick={() => void handleValidation("approved")}
+                  />
+                  <Button
+                    label="Edit & send"
+                    variant="highlight"
+                    size="xs"
+                    icon={CheckIcon}
+                    disabled={isEditing || isValidating}
+                    isPulsing={isPulsing}
+                    onClick={() => void handleEditAndSend()}
+                  />
+                </>
+              ) : (
+                <Button
+                  label="Allow"
+                  variant="highlight"
+                  size="xs"
+                  icon={CheckIcon}
+                  disabled={isValidating}
+                  isPulsing={isPulsing}
+                  onClick={() => void handleValidation("approved")}
+                />
+              )}
             </div>
           </div>
         </>

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -1,10 +1,15 @@
 import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
+import { GmailComposeEditor } from "@app/components/assistant/conversation/GmailComposeEditor";
 import { ToolValidationDetails } from "@app/components/assistant/conversation/ToolValidationDetails";
 import { getIcon } from "@app/components/resources/resources_icons";
 import { useEditAndSendAction } from "@app/hooks/useEditAndSendAction";
 import { useValidateAction } from "@app/hooks/useValidateAction";
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
+import {
+  GMAIL_TOOL_NAME,
+  SEND_MAIL_TOOL_NAME,
+} from "@app/lib/api/actions/servers/gmail/metadata";
 import {
   POD_MANAGER_SERVER_NAME,
   UPDATE_MEMBERS_TOOL_NAME,
@@ -158,19 +163,17 @@ export function MCPToolValidationRequired({
   // For editable-stake tools: track per-field edits
   const editableArguments =
     blockedAction.stake === "editable"
-      ? (blockedAction.editableArguments ??
-        Object.keys(blockedAction.inputs))
+      ? (blockedAction.editableArguments ?? Object.keys(blockedAction.inputs))
       : [];
-  const [editedFields, setEditedFields] = useState<Record<string, string>>(
-    () =>
-      Object.fromEntries(
-        editableArguments.map((key) => [
-          key,
-          typeof blockedAction.inputs[key] === "string"
-            ? (blockedAction.inputs[key] as string)
-            : JSON.stringify(blockedAction.inputs[key] ?? ""),
-        ])
-      )
+  const [editedFields, setEditedFields] = useState<Record<string, string>>(() =>
+    Object.fromEntries(
+      editableArguments.map((key) => [
+        key,
+        typeof blockedAction.inputs[key] === "string"
+          ? (blockedAction.inputs[key] as string)
+          : JSON.stringify(blockedAction.inputs[key] ?? ""),
+      ])
+    )
   );
 
   const {
@@ -344,26 +347,38 @@ export function MCPToolValidationRequired({
             defaultExpanded={toolOverride?.detailsExpanded}
           />
           {/* Provisional editable fields for editable-stake tools */}
-          {blockedAction.stake === "editable" && editableArguments.length > 0 && (
-            <div className="flex flex-col gap-2">
-              {editableArguments.map((key) => (
-                <div key={key} className="flex flex-col gap-1">
-                  <Label className="text-xs font-medium">{key}</Label>
-                  <TextArea
-                    value={editedFields[key] ?? ""}
-                    onChange={(e) =>
-                      setEditedFields((prev) => ({
-                        ...prev,
-                        [key]: e.target.value,
-                      }))
-                    }
+          {blockedAction.stake === "editable" &&
+            editableArguments.length > 0 && (
+              <>
+                {blockedAction.metadata.mcpServerName === GMAIL_TOOL_NAME &&
+                blockedAction.metadata.toolName === SEND_MAIL_TOOL_NAME ? (
+                  <GmailComposeEditor
+                    editedFields={editedFields}
+                    setEditedFields={setEditedFields}
                     disabled={isEditing || isValidating}
-                    minRows={3}
                   />
-                </div>
-              ))}
-            </div>
-          )}
+                ) : (
+                  <div className="flex flex-col gap-2">
+                    {editableArguments.map((key) => (
+                      <div key={key} className="flex flex-col gap-1">
+                        <Label className="text-xs font-medium">{key}</Label>
+                        <TextArea
+                          value={editedFields[key] ?? ""}
+                          onChange={(e) =>
+                            setEditedFields((prev) => ({
+                              ...prev,
+                              [key]: e.target.value,
+                            }))
+                          }
+                          disabled={isEditing || isValidating}
+                          minRows={3}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </>
+            )}
           {errorMessage && (
             <div className="mt-2 text-sm font-medium text-warning-800 dark:text-warning-800-night">
               {errorMessage}

--- a/front/hooks/useEditAndSendAction.ts
+++ b/front/hooks/useEditAndSendAction.ts
@@ -1,0 +1,59 @@
+import { useFetcher } from "@app/lib/swr/swr";
+import type { MCPActionValidationRequest } from "@app/types/assistant/conversation";
+import { isAPIErrorResponse } from "@app/types/error";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useCallback, useState } from "react";
+
+interface UseEditAndSendActionParams {
+  owner: LightWorkspaceType;
+  onError: (errorMessage: string) => void;
+}
+
+export function useEditAndSendAction({
+  owner,
+  onError,
+}: UseEditAndSendActionParams) {
+  const { fetcher } = useFetcher();
+  const [isEditing, setIsEditing] = useState(false);
+
+  const editAndSendAction = useCallback(
+    async ({
+      validationRequest,
+      editedInputs,
+    }: {
+      validationRequest: MCPActionValidationRequest;
+      editedInputs: Record<string, unknown>;
+    }) => {
+      setIsEditing(true);
+
+      try {
+        await fetcher(
+          `/api/w/${owner.sId}/assistant/conversations/${validationRequest.conversationId}/messages/${validationRequest.messageId}/edit-and-send-action`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              actionId: validationRequest.actionId,
+              editedInputs,
+            }),
+          }
+        );
+
+        return { success: true };
+      } catch (e) {
+        if (isAPIErrorResponse(e) && e.error.type === "action_not_blocked") {
+          return { success: true };
+        }
+        onError("Failed to edit and send action. Please try again.");
+        return { success: false };
+      } finally {
+        setIsEditing(false);
+      }
+    },
+    [owner.sId, onError, fetcher]
+  );
+
+  return { editAndSendAction, isEditing };
+}

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -41,6 +41,7 @@ export const MCP_TOOL_STAKE_LEVELS = [
   "medium",
   "low",
   "never_ask",
+  "editable",
 ] as const;
 export type MCPToolStakeLevelType = (typeof MCP_TOOL_STAKE_LEVELS)[number];
 

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -65,6 +65,8 @@ export type ServerSideMCPToolType = Omit<
   // For "medium" stake tools: defines which arguments require per-agent approval.
   // When present, the user must approve the specific (agent, tool, argument values) combination.
   argumentsRequiringApproval?: string[];
+  // For "editable" stake tools: which input fields the user may edit before sending.
+  editableArguments?: string[];
   displayLabels?: ToolDisplayLabels;
 };
 
@@ -80,6 +82,8 @@ export type ClientSideMCPToolType = Omit<
   // For "medium" stake tools: defines which arguments require per-agent approval.
   // When present, the user must approve the specific (agent, tool, argument values) combination.
   argumentsRequiringApproval?: string[];
+  // For "editable" stake tools: which input fields the user may edit before sending.
+  editableArguments?: string[];
   displayLabels?: ToolDisplayLabels;
 };
 

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -159,6 +159,7 @@ export function getToolExtraFields(
   let serverTimeoutMs: number | undefined;
   let toolsRetryPolicies: Record<string, MCPToolRetryPolicyType> | undefined;
   let toolsArgumentsRequiringApproval: Record<string, string[]> | undefined;
+  let toolsEditableArguments: Record<string, string[]> | undefined;
 
   const { serverType } = getServerTypeAndIdFromSId(mcpServerId);
   if (serverType === "internal") {
@@ -173,6 +174,8 @@ export function getToolExtraFields(
     serverTimeoutMs = INTERNAL_MCP_SERVERS[serverName]?.timeoutMs;
     toolsArgumentsRequiringApproval =
       INTERNAL_MCP_SERVERS[serverName].tools_arguments_requiring_approval;
+    toolsEditableArguments =
+      INTERNAL_MCP_SERVERS[serverName].tools_editable_arguments;
 
     metadata.forEach(
       ({ toolName, permission }) => (toolsStakes[toolName] = permission)
@@ -198,13 +201,15 @@ export function getToolExtraFields(
     toolsRetryPolicies,
     serverTimeoutMs,
     toolsArgumentsRequiringApproval,
+    toolsEditableArguments,
   });
 }
 
 export function makeServerSideMCPToolConfigurations(
   config: ServerSideMCPServerConfigurationType,
   tools: ServerSideMCPToolTypeWithStakeAndRetryPolicy[],
-  toolsArgumentsRequiringApproval?: Record<string, string[]>
+  toolsArgumentsRequiringApproval?: Record<string, string[]>,
+  toolsEditableArguments?: Record<string, string[]>
 ): ServerSideMCPToolConfigurationType[] {
   return tools.map((tool) => ({
     sId: generateRandomModelSId(),
@@ -238,6 +243,7 @@ export function makeServerSideMCPToolConfigurations(
     ...(tool.timeoutMs && { timeoutMs: tool.timeoutMs }),
     ...(tool.displayLabels && { displayLabels: tool.displayLabels }),
     argumentsRequiringApproval: toolsArgumentsRequiringApproval?.[tool.name],
+    editableArguments: toolsEditableArguments?.[tool.name],
   }));
 }
 
@@ -267,6 +273,7 @@ function makeClientSideMCPToolConfigurations(
     toolServerId,
     icon: config.icon,
     argumentsRequiringApproval: tool.argumentsRequiringApproval,
+    editableArguments: tool.editableArguments,
     displayLabels: tool.displayLabels,
     ...(tool.timeoutMs && { timeoutMs: tool.timeoutMs }),
   }));
@@ -1257,6 +1264,7 @@ async function buildToolConfigurationsFromRawTools(
     serverTimeoutMs,
     toolsRetryPolicies,
     toolsArgumentsRequiringApproval,
+    toolsEditableArguments,
   } = r.value;
 
   const availability = getAvailabilityOfInternalMCPServerById(mcpServerId);
@@ -1284,7 +1292,8 @@ async function buildToolConfigurationsFromRawTools(
   const serverSideToolConfigs = makeServerSideMCPToolConfigurations(
     config,
     toolsWithStakesRetryPoliciesAndTimeout,
-    toolsArgumentsRequiringApproval
+    toolsArgumentsRequiringApproval,
+    toolsEditableArguments
   );
   return new Ok(serverSideToolConfigs);
 }

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -33,6 +33,7 @@ import {
 } from "@app/lib/actions/mcp_helper";
 import {
   getAvailabilityOfInternalMCPServerById,
+  getInternalMCPServerEditableArguments,
   getInternalMCPServerNameAndWorkspaceId,
   getInternalMCPServerToolStakes,
   INTERNAL_MCP_SERVERS,
@@ -174,8 +175,7 @@ export function getToolExtraFields(
     serverTimeoutMs = INTERNAL_MCP_SERVERS[serverName]?.timeoutMs;
     toolsArgumentsRequiringApproval =
       INTERNAL_MCP_SERVERS[serverName].tools_arguments_requiring_approval;
-    toolsEditableArguments =
-      INTERNAL_MCP_SERVERS[serverName].tools_editable_arguments;
+    toolsEditableArguments = getInternalMCPServerEditableArguments(serverName);
 
     metadata.forEach(
       ({ toolName, permission }) => (toolsStakes[toolName] = permission)

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1376,6 +1376,13 @@ export function getInternalMCPServerToolStakes(
   return server.metadata.tools_stakes;
 }
 
+export function getInternalMCPServerEditableArguments(
+  name: InternalMCPServerNameType
+): Record<string, string[]> | undefined {
+  const server: InternalMCPServerEntry = INTERNAL_MCP_SERVERS[name];
+  return server.tools_editable_arguments;
+}
+
 export function getInternalMCPServerToolDisplayLabels<
   N extends InternalMCPServerNameType,
 >(name: N): Record<string, ToolDisplayLabels> | null {

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -388,6 +388,9 @@ export const INTERNAL_MCP_SERVERS = {
       create_draft: ["to"],
       send_mail: ["to", "from"],
     },
+    tools_editable_arguments: {
+      send_mail: ["to", "cc", "bcc", "subject", "body"],
+    },
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     metadata: GMAIL_SERVER,
@@ -1157,6 +1160,8 @@ type InternalMCPServerEntryCommon = {
   // When a tool has "medium" stake, the user must approve the specific combination
   // of (agent, tool, argument values) before the tool can execute.
   tools_arguments_requiring_approval: Record<string, string[]> | undefined;
+  // Defines which input fields may be edited by the user for "editable" stake tools.
+  tools_editable_arguments?: Record<string, string[]>;
   tools_retry_policies: Record<string, MCPToolRetryPolicyType> | undefined;
   timeoutMs: number | undefined;
   requiresBearerToken?: boolean;

--- a/front/lib/actions/mcp_internal_actions/events.ts
+++ b/front/lib/actions/mcp_internal_actions/events.ts
@@ -26,6 +26,8 @@ export interface ToolExecution<
   argumentsRequiringApproval?: string[];
   // Human-readable label for the "always allow" approval checkbox.
   approvalArgsLabel?: string;
+  // For editable-stake tools: which input fields the user may edit before sending.
+  editableArguments?: string[];
 }
 
 type ToolPersonalAuthError = {

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -51,6 +51,9 @@ export interface ToolDefinition<
   schema: TSchema;
   stake: MCPToolStakeLevelType;
   displayLabels: ToolDisplayLabels;
+  editableArguments?: Array<
+    Extract<keyof z.infer<z.ZodObject<TSchema>>, string>
+  >;
   handler: (
     params: z.infer<z.ZodObject<TSchema>>,
     extra: ToolHandlerExtra
@@ -68,6 +71,9 @@ interface ClientToolDefinition<
   stake: MCPToolStakeLevelType;
   displayLabels: ToolDisplayLabels;
   argumentsRequiringApproval?: Array<
+    Extract<keyof z.infer<z.ZodObject<TSchema>>, string>
+  >;
+  editableArguments?: Array<
     Extract<keyof z.infer<z.ZodObject<TSchema>>, string>
   >;
   handler: (

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -791,6 +791,7 @@ export type DustToolMeta = {
   stake?: MCPToolStakeLevelType;
   displayLabels?: ToolDisplayLabels;
   argumentsRequiringApproval?: string[];
+  editableArguments?: string[];
   timeoutMs?: number;
 };
 
@@ -838,6 +839,9 @@ export function getDustToolMeta(
   }
   if (isStringArray(dust.argumentsRequiringApproval)) {
     result.argumentsRequiringApproval = dust.argumentsRequiringApproval;
+  }
+  if (isStringArray(dust.editableArguments)) {
+    result.editableArguments = dust.editableArguments;
   }
   if (isValidTimeout(dust.timeoutMs)) {
     result.timeoutMs = dust.timeoutMs;

--- a/front/lib/actions/tool_status.ts
+++ b/front/lib/actions/tool_status.ts
@@ -91,6 +91,8 @@ export async function getExecutionStatusFromConfig(
     }
     case "high":
       return { status: "blocked_validation_required" };
+    case "editable":
+      return { status: "blocked_validation_required" };
     default:
       assertNever(actionConfiguration.permission);
   }

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -243,7 +243,8 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
           "Optional. The ID of the message to reply to. If provided, the email will be sent as a reply in the existing thread, with proper threading headers and the original message quoted."
         ),
     },
-    stake: "high",
+    stake: "editable",
+    editableArguments: ["to", "cc", "bcc", "subject", "body"],
     displayLabels: {
       running: "Sending Gmail email",
       done: "Send Gmail email",

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const GMAIL_TOOL_NAME = "gmail" as const;
+export const SEND_MAIL_TOOL_NAME = "send_mail" as const;
 
 export const GMAIL_TOOLS_METADATA = createToolsRecord({
   get_drafts: {

--- a/front/lib/api/assistant/conversation/edit_and_resume_action.test.ts
+++ b/front/lib/api/assistant/conversation/edit_and_resume_action.test.ts
@@ -1,0 +1,356 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/temporal/agent_loop/client", () => ({
+  launchAgentLoopWorkflow: vi.fn().mockResolvedValue({ isOk: () => true }),
+}));
+
+vi.mock("@app/lib/api/redis-hybrid-manager", () => ({
+  getRedisHybridManager: vi.fn().mockReturnValue({
+    removeEvent: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
+import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
+import { editAndResumeAction } from "@app/lib/api/assistant/conversation/edit_and_resume_action";
+import { Authenticator } from "@app/lib/auth";
+import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
+import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
+import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
+import {
+  AgentMessageModel,
+  MessageModel,
+} from "@app/lib/models/agent/conversation";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import type { WorkspaceType } from "@app/types/user";
+
+describe("editAndResumeAction", () => {
+  let workspace: WorkspaceType;
+  let auth: Authenticator;
+  let conversation: ConversationType;
+  let conversationResource: ConversationResource;
+  let agentMessageId: number;
+  let messageRowSId: string;
+  let stepContentIndex = 0;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    stepContentIndex = 0;
+
+    const setup = await createResourceTest({});
+    workspace = setup.workspace;
+    auth = setup.authenticator;
+
+    const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+    });
+
+    conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+
+    conversationResource = (await ConversationResource.fetchById(
+      auth,
+      conversation.sId
+    ))!;
+
+    const { messageRow: userMessageRow } =
+      await ConversationFactory.createUserMessage({
+        auth,
+        workspace,
+        conversation,
+        content: "Test message",
+      });
+
+    const agentMessageRow = await AgentMessageModel.create({
+      workspaceId: workspace.id,
+      status: "created",
+      agentConfigurationId: agent.sId,
+      agentConfigurationVersion: 0,
+      skipToolsValidation: false,
+    });
+    agentMessageId = agentMessageRow.id;
+
+    const agentMsgRow = await MessageModel.create({
+      workspaceId: workspace.id,
+      sId: generateRandomModelSId(),
+      conversationId: conversation.id,
+      rank: 1,
+      parentId: userMessageRow.id,
+      agentMessageId: agentMessageRow.id,
+    });
+    messageRowSId = agentMsgRow.sId;
+  });
+
+  async function createEditableAction({
+    status = "blocked_validation_required" as ToolExecutionStatus,
+    editableArguments = ["body", "subject"] as string[],
+    augmentedInputs = {
+      body: "original body",
+      subject: "original subject",
+    } as Record<string, unknown>,
+    permission = "editable" as LightMCPToolConfigurationType["permission"],
+  } = {}) {
+    const index = stepContentIndex++;
+
+    const stepContent = await AgentStepContentModel.create({
+      workspaceId: workspace.id,
+      agentMessageId,
+      step: 0,
+      index,
+      version: 0,
+      type: "function_call",
+      value: {
+        type: "function_call",
+        value: {
+          id: generateRandomModelSId(),
+          name: "send_email",
+          arguments: JSON.stringify(augmentedInputs),
+        },
+      },
+    });
+
+    const toolConfiguration: LightMCPToolConfigurationType = {
+      id: 1,
+      sId: generateRandomModelSId(),
+      type: "mcp_configuration",
+      name: "send_email",
+      dataSources: null,
+      tables: null,
+      childAgentId: null,
+      timeFrame: null,
+      jsonSchema: null,
+      additionalConfiguration: {},
+      mcpServerViewId: "test-server-view",
+      dustAppConfiguration: null,
+      secretName: null,
+      dustProject: null,
+      internalMCPServerId: null,
+      availability: "auto",
+      permission,
+      toolServerId: "test-server",
+      retryPolicy: "no_retry",
+      originalName: "send_email",
+      mcpServerName: "test_email_server",
+      ...(permission === "editable" ? { editableArguments } : {}),
+    };
+
+    const action = await AgentMCPActionModel.create({
+      workspaceId: workspace.id,
+      agentMessageId,
+      mcpServerConfigurationId: generateRandomModelSId(),
+      status,
+      citationsAllocated: 0,
+      augmentedInputs,
+      toolConfiguration,
+      stepContentId: stepContent.id,
+      stepContext: {
+        citationsCount: 0,
+        citationsOffset: 0,
+        resumeState: null,
+        retrievalTopK: 10,
+        websearchResultCount: 5,
+      },
+    });
+
+    await AgentStepContentToolExecutionModel.create({
+      workspaceId: workspace.id,
+      conversationId: conversation.id,
+      agentMessageId,
+      agentMCPActionId: action.id,
+      stepContentId: stepContent.id,
+    });
+
+    const actionId = AgentMCPActionResource.modelIdToSId({
+      id: action.id,
+      workspaceId: workspace.id,
+    });
+
+    return { action, actionId, stepContent };
+  }
+
+  it("creates a new agent message version with edited inputs and ready status", async () => {
+    const { actionId } = await createEditableAction();
+
+    const result = await editAndResumeAction(auth, conversationResource, {
+      actionId,
+      messageId: messageRowSId,
+      editedInputs: { body: "edited body", subject: "edited subject" },
+    });
+
+    expect(result.isOk()).toBe(true);
+
+    // Verify a new MessageModel version was created at the same rank
+    const messages = await MessageModel.findAll({
+      where: {
+        workspaceId: workspace.id,
+        conversationId: conversation.id,
+        rank: 1,
+      },
+      order: [["version", "ASC"]],
+    });
+    expect(messages.length).toBe(2);
+    expect(messages[1].version).toBe(1);
+
+    // Verify new step content has the edited arguments
+    const newAgentMessageModelId = messages[1].agentMessageId!;
+    const newStepContents = await AgentStepContentModel.findAll({
+      where: {
+        workspaceId: workspace.id,
+        agentMessageId: newAgentMessageModelId,
+      },
+    });
+    expect(newStepContents.length).toBeGreaterThan(0);
+    const functionCallContent = newStepContents.find(
+      (sc) => sc.type === "function_call"
+    );
+    expect(functionCallContent).toBeDefined();
+
+    const args = JSON.parse(
+      (functionCallContent!.value as { type: string; value: { arguments: string } })
+        .value.arguments
+    );
+    expect(args.body).toBe("edited body");
+    expect(args.subject).toBe("edited subject");
+
+    // Verify the new action has ready_allowed_explicitly status and edited inputs
+    const newAction = await AgentMCPActionModel.findOne({
+      where: {
+        workspaceId: workspace.id,
+        agentMessageId: newAgentMessageModelId,
+      },
+    });
+    expect(newAction).toBeDefined();
+    expect(newAction!.status).toBe("ready_allowed_explicitly");
+    expect((newAction!.augmentedInputs as Record<string, unknown>).body).toBe(
+      "edited body"
+    );
+    expect(
+      (newAction!.augmentedInputs as Record<string, unknown>).subject
+    ).toBe("edited subject");
+
+    // Verify launchAgentLoopWorkflow was called at step 0
+    expect(launchAgentLoopWorkflow).toHaveBeenCalledOnce();
+    const callArgs = vi.mocked(launchAgentLoopWorkflow).mock.calls[0][0];
+    expect(callArgs.startStep).toBe(0);
+    expect(callArgs.agentLoopArgs.agentMessageVersion).toBe(1);
+  });
+
+  it("marks the original blocked action as denied", async () => {
+    const { action, actionId } = await createEditableAction();
+
+    await editAndResumeAction(auth, conversationResource, {
+      actionId,
+      messageId: messageRowSId,
+      editedInputs: { body: "edited body" },
+    });
+
+    const updatedAction = await AgentMCPActionModel.findByPk(action.id);
+    expect(updatedAction!.status).toBe("denied");
+  });
+
+  it("rejects when tool is not editable (high stake)", async () => {
+    const { actionId } = await createEditableAction({ permission: "high" });
+
+    const result = await editAndResumeAction(auth, conversationResource, {
+      actionId,
+      messageId: messageRowSId,
+      editedInputs: {},
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("tool_not_editable");
+    }
+  });
+
+  it("rejects when action is not blocked (succeeded status)", async () => {
+    const { actionId } = await createEditableAction({ status: "succeeded" });
+
+    const result = await editAndResumeAction(auth, conversationResource, {
+      actionId,
+      messageId: messageRowSId,
+      editedInputs: { body: "new body" },
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("action_not_blocked");
+    }
+  });
+
+  it("rejects when editing an out-of-scope key", async () => {
+    const { actionId } = await createEditableAction({
+      editableArguments: ["body"],
+    });
+
+    const result = await editAndResumeAction(auth, conversationResource, {
+      actionId,
+      messageId: messageRowSId,
+      editedInputs: { body: "new body", forbidden_field: "hacked" },
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("invalid_edited_inputs");
+    }
+  });
+
+  it("returns action_not_found for a non-existent action", async () => {
+    const result = await editAndResumeAction(auth, conversationResource, {
+      actionId: "non-existent-action-id",
+      messageId: messageRowSId,
+      editedInputs: {},
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("action_not_found");
+    }
+  });
+
+  it("preserves original inputs for fields not in editedInputs", async () => {
+    const { actionId } = await createEditableAction({
+      augmentedInputs: {
+        body: "original body",
+        subject: "original subject",
+        to: "user@example.com",
+      },
+    });
+
+    const result = await editAndResumeAction(auth, conversationResource, {
+      actionId,
+      messageId: messageRowSId,
+      editedInputs: { body: "edited body" },
+    });
+
+    expect(result.isOk()).toBe(true);
+
+    const messages = await MessageModel.findAll({
+      where: {
+        workspaceId: workspace.id,
+        conversationId: conversation.id,
+        rank: 1,
+      },
+      order: [["version", "ASC"]],
+    });
+    const newAgentMessageModelId = messages[1].agentMessageId!;
+
+    const newAction = await AgentMCPActionModel.findOne({
+      where: { workspaceId: workspace.id, agentMessageId: newAgentMessageModelId },
+    });
+    expect(newAction).toBeDefined();
+    const inputs = newAction!.augmentedInputs as Record<string, unknown>;
+    expect(inputs.body).toBe("edited body");
+    expect(inputs.subject).toBe("original subject");
+    expect(inputs.to).toBe("user@example.com");
+  });
+});

--- a/front/lib/api/assistant/conversation/edit_and_resume_action.test.ts
+++ b/front/lib/api/assistant/conversation/edit_and_resume_action.test.ts
@@ -13,7 +13,7 @@ vi.mock("@app/lib/api/redis-hybrid-manager", () => ({
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { editAndResumeAction } from "@app/lib/api/assistant/conversation/edit_and_resume_action";
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
 import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
@@ -215,8 +215,12 @@ describe("editAndResumeAction", () => {
     expect(functionCallContent).toBeDefined();
 
     const args = JSON.parse(
-      (functionCallContent!.value as { type: string; value: { arguments: string } })
-        .value.arguments
+      (
+        functionCallContent!.value as {
+          type: string;
+          value: { arguments: string };
+        }
+      ).value.arguments
     );
     expect(args.body).toBe("edited body");
     expect(args.subject).toBe("edited subject");
@@ -345,7 +349,10 @@ describe("editAndResumeAction", () => {
     const newAgentMessageModelId = messages[1].agentMessageId!;
 
     const newAction = await AgentMCPActionModel.findOne({
-      where: { workspaceId: workspace.id, agentMessageId: newAgentMessageModelId },
+      where: {
+        workspaceId: workspace.id,
+        agentMessageId: newAgentMessageModelId,
+      },
     });
     expect(newAction).toBeDefined();
     const inputs = newAction!.augmentedInputs as Record<string, unknown>;

--- a/front/lib/api/assistant/conversation/edit_and_resume_action.ts
+++ b/front/lib/api/assistant/conversation/edit_and_resume_action.ts
@@ -35,15 +35,9 @@ export async function editAndResumeAction(
 ): Promise<Result<void, DustError>> {
   const user = auth.user();
   const owner = auth.getNonNullableWorkspace();
-  const {
-    sId: conversationId,
-    title: conversationTitle,
-    branchId: conversationBranchId,
-  } = conversation;
+  const { sId: conversationId, title: conversationTitle } = conversation;
 
   const {
-    agentMessageId: messageSId,
-    agentMessageVersion,
     userMessageId,
     userMessageVersion,
     userMessageUserId,
@@ -139,10 +133,11 @@ export async function editAndResumeAction(
   }
 
   // Fetch step-k function_call step contents and the actions linked to them
-  const allStepContentsForMessage = await AgentStepContentResource.fetchByAgentMessages(
-    auth,
-    { agentMessageIds: [agentMessageModelId], latestVersionsOnly: true }
-  );
+  const allStepContentsForMessage =
+    await AgentStepContentResource.fetchByAgentMessages(auth, {
+      agentMessageIds: [agentMessageModelId],
+      latestVersionsOnly: true,
+    });
   const stepKContents = allStepContentsForMessage.filter(
     (c) => c.step === blockedStep && c.type === "function_call"
   );
@@ -221,9 +216,8 @@ export async function editAndResumeAction(
 
       // Copy step contents 0..blockedStep onto the new agent message,
       // overriding the edited action's function_call arguments
-      const newStepContents = await AgentStepContentResource.copyForAgentMessage(
-        auth,
-        {
+      const newStepContents =
+        await AgentStepContentResource.copyForAgentMessage(auth, {
           fromAgentMessageId: agentMessageModelId,
           toAgentMessageId: newAgentMessageRow.id,
           throughStep: blockedStep,
@@ -235,8 +229,7 @@ export async function editAndResumeAction(
             },
           ],
           transaction: t,
-        }
-      );
+        });
 
       // Map new step contents by (step, index) for quick lookup
       const newStepContentMap = new Map(
@@ -300,7 +293,10 @@ export async function editAndResumeAction(
 
   if (!newMessageSId || newMessageVersion === null) {
     return new Err(
-      new DustError("internal_error", "Failed to create new agent message version")
+      new DustError(
+        "internal_error",
+        "Failed to create new agent message version"
+      )
     );
   }
 

--- a/front/lib/api/assistant/conversation/edit_and_resume_action.ts
+++ b/front/lib/api/assistant/conversation/edit_and_resume_action.ts
@@ -251,9 +251,9 @@ export async function editAndResumeAction(
         const newAugmentedInputs = isEditedAction
           ? { ...originalAction.augmentedInputs, ...restrictedInputs }
           : originalAction.augmentedInputs;
-        const newStatus = isEditedAction
-          ? ("ready_allowed_explicitly" as const)
-          : originalAction.status;
+        // Siblings (other actions at the same step) are auto-approved as-is:
+        // the user's "Edit & send" implicitly confirms the whole step.
+        const newStatus = "ready_allowed_explicitly" as const;
 
         await AgentMCPActionResource.makeNew(
           auth,

--- a/front/lib/api/assistant/conversation/edit_and_resume_action.ts
+++ b/front/lib/api/assistant/conversation/edit_and_resume_action.ts
@@ -1,0 +1,324 @@
+import { isMCPApproveExecutionEvent } from "@app/lib/actions/mcp";
+import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
+import { getConversationRankVersionLock } from "@app/lib/api/assistant/conversation/lock";
+import { getUserMessageIdFromMessageId } from "@app/lib/api/assistant/conversation/messages";
+import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
+import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
+import type { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
+import {
+  AgentMessageModel,
+  MessageModel,
+} from "@app/lib/models/agent/conversation";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { withTransaction } from "@app/lib/utils/sql_utils";
+import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export async function editAndResumeAction(
+  auth: Authenticator,
+  conversation: ConversationResource,
+  {
+    actionId,
+    messageId,
+    editedInputs,
+  }: {
+    actionId: string;
+    messageId: string;
+    editedInputs: Record<string, unknown>;
+  }
+): Promise<Result<void, DustError>> {
+  const user = auth.user();
+  const owner = auth.getNonNullableWorkspace();
+  const {
+    sId: conversationId,
+    title: conversationTitle,
+    branchId: conversationBranchId,
+  } = conversation;
+
+  const {
+    agentMessageId: messageSId,
+    agentMessageVersion,
+    userMessageId,
+    userMessageVersion,
+    userMessageUserId,
+    userMessageOrigin,
+    branchId,
+  } = await getUserMessageIdFromMessageId(auth, { messageId });
+
+  if (
+    !canCurrentUserRespondToParentUserMessage({
+      parentUserId: userMessageUserId,
+      currentUserId: user?.id,
+    })
+  ) {
+    return new Err(
+      new DustError(
+        "unauthorized",
+        "User is not authorized to edit this action"
+      )
+    );
+  }
+
+  const action = await AgentMCPActionResource.fetchById(auth, actionId);
+  if (!action) {
+    return new Err(
+      new DustError("action_not_found", `Action not found: ${actionId}`)
+    );
+  }
+
+  if (action.status !== "blocked_validation_required") {
+    return new Err(
+      new DustError(
+        "action_not_blocked",
+        `Action is not blocked: ${action.status}`
+      )
+    );
+  }
+
+  if (action.toolConfiguration.permission !== "editable") {
+    return new Err(
+      new DustError(
+        "tool_not_editable",
+        `Tool does not have editable stake: ${action.toolConfiguration.permission}`
+      )
+    );
+  }
+
+  // Restrict edited inputs to declared editableArguments
+  const editableArguments = action.toolConfiguration.editableArguments;
+  const restrictedInputs: Record<string, unknown> = {};
+  if (editableArguments) {
+    for (const key of Object.keys(editedInputs)) {
+      if (!editableArguments.includes(key)) {
+        return new Err(
+          new DustError(
+            "invalid_edited_inputs",
+            `Key "${key}" is not in editableArguments for this tool`
+          )
+        );
+      }
+      restrictedInputs[key] = editedInputs[key];
+    }
+  } else {
+    Object.assign(restrictedInputs, editedInputs);
+  }
+
+  const blockedStep = action.stepContent.step;
+  const blockedIndex = action.stepContent.index;
+
+  // Fetch the MessageModel for the current agent message to get rank/version/parentId
+  const agentMessageModelId = action.agentMessageId;
+  const messageRow = await MessageModel.findOne({
+    where: {
+      workspaceId: owner.id,
+      conversationId: conversation.id,
+      agentMessageId: agentMessageModelId,
+    },
+    include: [
+      {
+        model: AgentMessageModel,
+        as: "agentMessage",
+        required: true,
+      },
+    ],
+  });
+
+  if (!messageRow?.agentMessage || !messageRow.parentId) {
+    return new Err(
+      new DustError(
+        "action_not_found",
+        "Could not find the agent message for this action"
+      )
+    );
+  }
+
+  // Fetch step-k function_call step contents and the actions linked to them
+  const allStepContentsForMessage = await AgentStepContentResource.fetchByAgentMessages(
+    auth,
+    { agentMessageIds: [agentMessageModelId], latestVersionsOnly: true }
+  );
+  const stepKContents = allStepContentsForMessage.filter(
+    (c) => c.step === blockedStep && c.type === "function_call"
+  );
+  const stepKActions = await AgentMCPActionResource.fetchByStepContents(auth, {
+    stepContents: stepKContents,
+  });
+
+  // Build the new arguments string by merging edited inputs on top of the original raw inputs
+  const originalArguments = action.stepContent.isFunctionCallContent()
+    ? (JSON.parse(action.stepContent.value.value.arguments) as Record<
+        string,
+        unknown
+      >)
+    : {};
+  const newArgumentsString = JSON.stringify({
+    ...originalArguments,
+    ...restrictedInputs,
+  });
+
+  let newMessageSId: string | null = null;
+  let newMessageVersion: number | null = null;
+
+  try {
+    await withTransaction(async (t) => {
+      await getConversationRankVersionLock(
+        auth,
+        conversation as unknown as ConversationWithoutContentType,
+        t
+      );
+
+      // Guard against a concurrent fork
+      const existingNewer = await MessageModel.findOne({
+        where: {
+          workspaceId: owner.id,
+          rank: messageRow.rank,
+          conversationId: conversation.id,
+          version: messageRow.version + 1,
+        },
+        transaction: t,
+      });
+      if (existingNewer) {
+        throw new Error(
+          "A newer version of this message already exists; concurrent edit detected"
+        );
+      }
+
+      // Create new AgentMessageModel + MessageModel for version N+1
+      const agentMsg = messageRow.agentMessage!;
+      const newAgentMessageRow = await AgentMessageModel.create(
+        {
+          status: "created",
+          agentConfigurationId: agentMsg.agentConfigurationId,
+          agentConfigurationVersion: agentMsg.agentConfigurationVersion,
+          workspaceId: owner.id,
+          skipToolsValidation: agentMsg.skipToolsValidation,
+        },
+        { transaction: t }
+      );
+
+      const newMessageRow = await MessageModel.create(
+        {
+          sId: generateRandomModelSId(),
+          rank: messageRow.rank,
+          conversationId: conversation.id,
+          branchId: messageRow.branchId,
+          parentId: messageRow.parentId,
+          version: messageRow.version + 1,
+          agentMessageId: newAgentMessageRow.id,
+          workspaceId: owner.id,
+        },
+        { transaction: t }
+      );
+
+      newMessageSId = newMessageRow.sId;
+      newMessageVersion = newMessageRow.version;
+
+      // Copy step contents 0..blockedStep onto the new agent message,
+      // overriding the edited action's function_call arguments
+      const newStepContents = await AgentStepContentResource.copyForAgentMessage(
+        auth,
+        {
+          fromAgentMessageId: agentMessageModelId,
+          toAgentMessageId: newAgentMessageRow.id,
+          throughStep: blockedStep,
+          argumentOverrides: [
+            {
+              step: blockedStep,
+              index: blockedIndex,
+              arguments: newArgumentsString,
+            },
+          ],
+          transaction: t,
+        }
+      );
+
+      // Map new step contents by (step, index) for quick lookup
+      const newStepContentMap = new Map(
+        newStepContents.map((sc) => [`${sc.step}:${sc.index}`, sc])
+      );
+
+      const conversationForMakeNew =
+        conversation as unknown as ConversationWithoutContentType;
+
+      // Recreate each step-k action on the new agent message
+      for (const originalAction of stepKActions) {
+        const key = `${originalAction.stepContent.step}:${originalAction.stepContent.index}`;
+        const newStepContent = newStepContentMap.get(key);
+        if (!newStepContent) {
+          continue;
+        }
+
+        const isEditedAction = originalAction.sId === actionId;
+        const newAugmentedInputs = isEditedAction
+          ? { ...originalAction.augmentedInputs, ...restrictedInputs }
+          : originalAction.augmentedInputs;
+        const newStatus = isEditedAction
+          ? ("ready_allowed_explicitly" as const)
+          : originalAction.status;
+
+        await AgentMCPActionResource.makeNew(
+          auth,
+          { conversation: conversationForMakeNew, stepContent: newStepContent },
+          {
+            agentMessageId: newAgentMessageRow.id,
+            augmentedInputs: newAugmentedInputs,
+            citationsAllocated: originalAction.citationsAllocated,
+            mcpServerConfigurationId: originalAction.mcpServerConfigurationId,
+            status: newStatus,
+            stepContext: originalAction.stepContext,
+            toolConfiguration: originalAction.toolConfiguration,
+          },
+          { transaction: t }
+        );
+      }
+    });
+  } catch (e) {
+    return new Err(
+      new DustError(
+        "internal_error",
+        e instanceof Error ? e.message : "Failed to fork agent message"
+      )
+    );
+  }
+
+  // Defensively mark the original action as denied so it no longer appears blocked
+  await action.updateStatus("denied");
+
+  // Remove the tool approval request event from the message channel
+  await getRedisHybridManager().removeEvent((event) => {
+    const payload = JSON.parse(event.message["payload"]);
+    return isMCPApproveExecutionEvent(payload)
+      ? payload.actionId === actionId
+      : false;
+  }, getMessageChannelId(messageId));
+
+  if (!newMessageSId || newMessageVersion === null) {
+    return new Err(
+      new DustError("internal_error", "Failed to create new agent message version")
+    );
+  }
+
+  // Launch the agent loop on version N+1 starting at the blocked step
+  await launchAgentLoopWorkflow({
+    auth,
+    agentLoopArgs: {
+      agentMessageId: newMessageSId,
+      agentMessageVersion: newMessageVersion,
+      conversationId,
+      conversationTitle,
+      conversationBranchId: branchId,
+      userMessageId,
+      userMessageVersion,
+      userMessageOrigin,
+    },
+    startStep: blockedStep,
+  });
+
+  return new Ok(undefined);
+}

--- a/front/lib/api/assistant/conversation/edit_and_resume_action.ts
+++ b/front/lib/api/assistant/conversation/edit_and_resume_action.ts
@@ -1,7 +1,9 @@
 import { isMCPApproveExecutionEvent } from "@app/lib/actions/mcp";
 import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { getConversationRankVersionLock } from "@app/lib/api/assistant/conversation/lock";
 import { getUserMessageIdFromMessageId } from "@app/lib/api/assistant/conversation/messages";
+import { publishAgentMessagesEvents } from "@app/lib/api/assistant/streaming/events";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";
@@ -16,7 +18,10 @@ import type { ConversationResource } from "@app/lib/resources/conversation_resou
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
-import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import {
+  type ConversationWithoutContentType,
+  isAgentMessageType,
+} from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -315,6 +320,24 @@ export async function editAndResumeAction(
     },
     startStep: blockedStep,
   });
+
+  // Notify the conversation stream about N+1 so the frontend subscribes to its SSE channel.
+  // Without this, the ConversationViewer never learns about the new message version and the
+  // agent's response never appears in the UI.
+  const freshConversation = await getConversation(auth, conversationId);
+  if (freshConversation.isOk()) {
+    const allMessages = freshConversation.value.content.flat();
+    const newAgentMessage = allMessages.find(
+      (m): m is (typeof allMessages)[number] & { sId: string } =>
+        isAgentMessageType(m) && m.sId === newMessageSId
+    );
+    if (newAgentMessage && isAgentMessageType(newAgentMessage)) {
+      await publishAgentMessagesEvents(
+        freshConversation.value as unknown as ConversationWithoutContentType,
+        [newAgentMessage]
+      );
+    }
+  }
 
   return new Ok(undefined);
 }

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -109,6 +109,8 @@ export async function validateAction(
           functionCallName: action.functionCallName,
         });
         break;
+      case "editable":
+        break;
       case "medium":
         const agentMessage = await AgentMessageModel.findOne({
           where: {

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -121,6 +121,7 @@ export type ServerSideMCPToolTypeWithStakeAndRetryPolicy =
 export type ClientSideMCPToolTypeWithStakeLevel =
   WithStakeLevelType<MCPToolWithAvailabilityType> & {
     argumentsRequiringApproval?: string[];
+    editableArguments?: string[];
     timeoutMs?: number;
   };
 

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -50,6 +50,8 @@ export type DustErrorCode =
   | "name_conflict"
   | "action_not_found"
   | "action_not_blocked"
+  | "tool_not_editable"
+  | "invalid_edited_inputs"
   | "mcp_access_token_error"
   // Triggers errors
   | "webhook_source_not_found"

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -464,6 +464,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
         },
         argumentsRequiringApproval:
           action.toolConfiguration.argumentsRequiringApproval,
+        editableArguments: action.toolConfiguration.editableArguments,
         approvalArgsLabel: await getApprovalArgsLabel({
           auth,
           internalMCPServerName: action.toolConfiguration.toolServerId

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -426,6 +426,94 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     };
   }
 
+  /**
+   * Copies step contents from one agent message to another through a given step,
+   * optionally overriding the arguments of specific function_call rows.
+   * Used by the edit-and-resume flow to fork a paused agent message.
+   */
+  static async copyForAgentMessage(
+    auth: Authenticator,
+    {
+      fromAgentMessageId,
+      toAgentMessageId,
+      throughStep,
+      argumentOverrides,
+      transaction,
+    }: {
+      fromAgentMessageId: ModelId;
+      toAgentMessageId: ModelId;
+      throughStep: number;
+      argumentOverrides: Array<{
+        step: number;
+        index: number;
+        arguments: string;
+      }>;
+      transaction: Transaction;
+    }
+  ): Promise<AgentStepContentResource[]> {
+    const owner = auth.getNonNullableWorkspace();
+
+    const sourceContents = await this.model.findAll({
+      where: {
+        workspaceId: owner.id,
+        agentMessageId: fromAgentMessageId,
+        step: { [Op.lte]: throughStep },
+      },
+      order: [
+        ["step", "ASC"],
+        ["index", "ASC"],
+        ["version", "DESC"],
+      ],
+      transaction,
+    });
+
+    const latestContents = this.filterLatestVersions(sourceContents, [
+      "step",
+      "index",
+    ]);
+
+    const overrideMap = new Map(
+      argumentOverrides.map((o) => [`${o.step}:${o.index}`, o.arguments])
+    );
+
+    const created: AgentStepContentResource[] = [];
+    for (const source of latestContents) {
+      let value = source.value;
+
+      const overrideKey = `${source.step}:${source.index}`;
+      if (
+        source.type === "function_call" &&
+        overrideMap.has(overrideKey) &&
+        isAgentFunctionCallContent(value)
+      ) {
+        value = {
+          ...value,
+          value: {
+            ...value.value,
+            arguments: overrideMap.get(overrideKey)!,
+          },
+        };
+      }
+
+      const newContent = await this.model.create(
+        {
+          workspaceId: owner.id,
+          agentMessageId: toAgentMessageId,
+          step: source.step,
+          index: source.index,
+          version: 0,
+          type: source.type,
+          value,
+        },
+        { transaction }
+      );
+
+      created.push(new AgentStepContentResource(this.model, newContent.get()));
+    }
+
+    return created;
+  }
+
   static async createNewVersion({
     agentMessageId,
     workspaceId,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit-and-send-action.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit-and-send-action.ts
@@ -1,0 +1,138 @@
+// @migration-status: MIGRATED_TO_HONO
+/** @ignoreswagger */
+import { editAndResumeAction } from "@app/lib/api/assistant/conversation/edit_and_resume_action";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+const EditAndSendActionSchema = z.object({
+  actionId: z.string(),
+  editedInputs: z.record(z.unknown()),
+});
+
+export type EditAndSendActionResponse = {
+  success: boolean;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<EditAndSendActionResponse>>,
+  auth: Authenticator
+): Promise<void> {
+  const { cId, mId } = req.query;
+  if (typeof cId !== "string" || typeof mId !== "string") {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "Conversation, message, or workspace not found.",
+      },
+    });
+  }
+
+  if (req.method !== "POST") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, POST is expected.",
+      },
+    });
+  }
+
+  const parseResult = EditAndSendActionSchema.safeParse(req.body);
+  if (!parseResult.success) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid request body: ${parseResult.error.message}`,
+      },
+    });
+  }
+
+  const conversation = await ConversationResource.fetchById(auth, cId);
+  if (!conversation) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "Conversation not found.",
+      },
+    });
+  }
+
+  const { actionId, editedInputs } = parseResult.data;
+
+  const result = await editAndResumeAction(auth, conversation, {
+    actionId,
+    messageId: mId,
+    editedInputs,
+  });
+
+  if (result.isErr()) {
+    switch (result.error.code) {
+      case "action_not_blocked":
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "action_not_blocked",
+            message: result.error.message,
+          },
+        });
+      case "action_not_found":
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "action_not_found",
+            message: result.error.message,
+          },
+        });
+      case "tool_not_editable":
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: result.error.message,
+          },
+        });
+      case "invalid_edited_inputs":
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: result.error.message,
+          },
+        });
+      case "unauthorized":
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "invalid_request_error",
+            message: result.error.message,
+          },
+        });
+      default:
+        return apiError(
+          req,
+          res,
+          {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: "Failed to edit and send action",
+            },
+          },
+          result.error
+        );
+    }
+  }
+
+  res.status(200).json({ success: true });
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -275,6 +275,7 @@ async function createActionForTool(
               inputs: rawInputs,
               argumentsRequiringApproval,
             }),
+            editableArguments: actionConfiguration.editableArguments,
           }
         : undefined,
   };

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1288,7 +1288,7 @@ export type ConversationMessageReactionsType = z.infer<
 >;
 
 const MCPStakeLevelSchema = z
-  .enum(["low", "medium", "high", "never_ask"])
+  .enum(["low", "medium", "high", "never_ask", "editable"])
   .optional();
 
 const MCPValidationMetadataSchema = z.object({

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1444,6 +1444,7 @@ const ToolExecutionMetadataSchema = z.object({
   }),
   argumentsRequiringApproval: z.array(z.string()).optional(),
   approvalArgsLabel: z.string().optional(),
+  editableArguments: z.array(z.string()).optional(),
 });
 
 const BlockedActionExecutionSchema = ToolExecutionMetadataSchema.extend({


### PR DESCRIPTION
## Description

Introduces a new `"editable"` MCP tool stake level that pauses execution like `"high"` but also lets the user modify input fields before the tool runs ("Edit & send"), forking the agent message into a new version that runs with the edited inputs.

### Phase 1 — New stake + payload propagation
- Adds `"editable"` to `MCP_TOOL_STAKE_LEVELS` and all downstream types (`ServerSideMCPToolType`, `ClientSideMCPToolType`, `ToolExecution`, `BlockedToolExecution`)
- Adds `editableArguments?: string[]` field to tool definition types and configurations, mirroring `argumentsRequiringApproval`
- Handles `"editable"` in `tool_status.ts` (blocks like `"high"`) and `validate_actions.ts` (excluded from always-approve flow)
- Propagates `editableArguments` through `mcp_actions.ts`, `create_tool_actions.ts`, and `agent_mcp_action_resource.ts` into streaming events and blocked-action payloads

### Phase 2 — Fork-and-edit backend
- `AgentStepContentResource.copyForAgentMessage`: copies step contents 0..k onto a new agent message, optionally overriding `function_call` arguments
- `editAndResumeAction` in `lib/api/assistant/conversation/edit_and_resume_action.ts`: validates the action, creates version N+1 via a rank-version-locked transaction, copies step contents with edited arguments, recreates the step-k actions (edited → `ready_allowed_explicitly`; siblings preserve status), marks the original action `denied`, then launches the agent loop at `startStep=k`
- `POST .../messages/:mId/edit-and-send-action` (Next.js + Hono mirror per BACK17 convention)

### Phase 3 — Frontend
- `useEditAndSendAction` hook (mirrors `useValidateAction`)
- `MCPToolValidationRequired`: when `stake === "editable"`, renders provisional editable text areas for each `editableArgument` and shows "Edit & send" / "Send as-is" / "Decline" buttons
- **Gmail compose UI**: when the blocked tool is Gmail's `send_mail`, renders a Gmail compose-style card (header, labeled To/Cc/Bcc/Subject/Body field rows, collapsible Cc and Bcc) instead of the generic textarea list

### Phase 4 — Pilot tool + fixes
- `schedule_wakeup` (wakeups server) is the pilot: `stake: "editable"`, `editableArguments: ["when", "reason", "timezone"]`
- `send_mail` (Gmail) uses `stake: "editable"`, `editableArguments: ["to", "cc", "bcc", "subject", "body"]` with a bespoke compose UI
- SDK type fix: adds `"editable"` to `MCPStakeLevelSchema` in `sdks/js/src/types.ts`
- Functional tests covering: successful fork with edited inputs, original action denied, non-editable tool rejection, non-blocked action rejection, out-of-scope key rejection, non-existent action

## Tests

Functional tests in `front/lib/api/assistant/conversation/edit_and_resume_action.test.ts`. Run with:

```bash
npm run test -- edit_and_resume_action
```

Manual end-to-end: ask an agent to send an email → observe the Gmail compose card with editable To/Cc/Bcc/Subject/Body → edit fields → click "Edit & send" → confirm a new agent message version appears and the email is sent with the edited inputs.

## Risk

**Low** — The `"editable"` stake behaves exactly like `"high"` from the agent loop's perspective. The fork path mirrors the existing `retryAgentMessage` fork. No DB migrations. The Gmail compose UI is purely presentational — it serializes to the same JSON payload as the generic textarea list.
