### PR TITLE
Add poke tab for usage

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/analytics/awu-usage.ts
+++ b/front-api/routes/poke/workspaces/[wId]/analytics/awu-usage.ts
@@ -1,0 +1,57 @@
+import {
+  AwuUsageQuerySchema,
+  type GetAwuUsageResponse,
+  getAwuUsage,
+} from "@app/lib/api/analytics/awu_usage";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { pokeApp } from "@front-api/middlewares/ctx";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+
+export type { GetAwuUsageResponse };
+
+// Mounted at /api/poke/workspaces/:wId/analytics/awu-usage.
+const app = pokeApp();
+
+app.get("/", validate("query", AwuUsageQuerySchema), async (ctx) => {
+  const auth = ctx.get("auth");
+
+  const result = await getAwuUsage(auth, ctx.req.valid("query"));
+  if (result.isErr()) {
+    const err = result.error;
+    switch (err.type) {
+      case "metronome_not_configured":
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Workspace is not configured for Metronome billing.",
+          },
+        });
+      case "invalid_group_key":
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              `Grouping by "${err.groupBy}" is not available. The billable metric ` +
+              `must have "${err.eventProperty}" configured as a group key in Metronome.`,
+          },
+        });
+      case "internal_error":
+        return apiError(ctx, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: err.message,
+          },
+        });
+      default:
+        assertNever(err);
+    }
+  }
+
+  return ctx.json(result.value);
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/analytics/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/analytics/index.ts
@@ -1,6 +1,7 @@
 import { pokeApp } from "@front-api/middlewares/ctx";
 
 import activeUsers from "./active-users";
+import awuUsage from "./awu-usage";
 import metronomeUsage from "./metronome-usage";
 import programmaticCost from "./programmatic-cost";
 import usageMetrics from "./usage-metrics";
@@ -8,6 +9,7 @@ import usageMetrics from "./usage-metrics";
 const app = pokeApp();
 
 app.route("/active-users", activeUsers);
+app.route("/awu-usage", awuUsage);
 app.route("/metronome-usage", metronomeUsage);
 app.route("/programmatic-cost", programmaticCost);
 app.route("/usage-metrics", usageMetrics);

--- a/front-api/routes/poke/workspaces/[wId]/credits/awu-pool-summary.ts
+++ b/front-api/routes/poke/workspaces/[wId]/credits/awu-pool-summary.ts
@@ -1,0 +1,51 @@
+import type { AwuPoolSummaryResponseBody } from "@app/lib/api/credits/awu_pool_summary";
+import { getAwuPoolSummary } from "@app/lib/api/credits/awu_pool_summary";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { pokeApp } from "@front-api/middlewares/ctx";
+import { apiError } from "@front-api/middlewares/utils";
+
+export type { AwuPoolSummaryResponseBody };
+
+// Mounted at /api/poke/workspaces/:wId/credits/awu-pool-summary.
+const app = pokeApp();
+
+app.get("/", async (ctx) => {
+  const auth = ctx.get("auth");
+
+  const result = await getAwuPoolSummary(auth);
+  if (result.isErr()) {
+    const err = result.error;
+    switch (err.type) {
+      case "not_configured":
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Workspace is not configured for Metronome billing.",
+          },
+        });
+      case "balances_fetch_failed":
+        return apiError(ctx, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve Metronome balances: ${err.cause?.message ?? ""}`,
+          },
+        });
+      case "invoices_fetch_failed":
+        return apiError(ctx, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve Metronome invoices: ${err.cause?.message ?? ""}`,
+          },
+        });
+      default:
+        assertNever(err.type);
+    }
+  }
+
+  return ctx.json(result.value);
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/credits/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/credits/index.ts
@@ -8,6 +8,8 @@ import type { CreditDisplayData, CreditType } from "@app/types/credits";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
+import awuPoolSummary from "./awu-pool-summary";
+
 export type PokeCreditType = {
   id: number;
   createdAt: string;
@@ -138,5 +140,7 @@ app.get("/", async (ctx): HandlerResult<PokeListCreditsResponseBody> => {
     hasMetronome,
   });
 });
+
+app.route("/awu-pool-summary", awuPoolSummary);
 
 export default app;

--- a/front/components/poke/credits/PokeAwuUsageChart.tsx
+++ b/front/components/poke/credits/PokeAwuUsageChart.tsx
@@ -1,0 +1,66 @@
+import { BaseAwuUsageChart } from "@app/components/workspace/AwuUsageChart";
+import { formatPeriod } from "@app/components/workspace/ProgrammaticCostChart";
+import type { AwuUsageGroupByType } from "@app/lib/api/analytics/awu_usage";
+import { getBillingCycleFromDay } from "@app/lib/client/subscription";
+import { usePokeAwuUsage } from "@app/poke/swr/credits";
+import type { WorkspaceType } from "@app/types/user";
+import { useState } from "react";
+
+interface PokeAwuUsageChartProps {
+  owner: WorkspaceType;
+  billingCycleStartDay: number;
+}
+
+export function PokeAwuUsageChart({
+  owner,
+  billingCycleStartDay,
+}: PokeAwuUsageChartProps) {
+  // Default view is split by usage type (programmatic / user / free).
+  const [groupBy, setGroupBy] = useState<AwuUsageGroupByType | undefined>(
+    "usage_type"
+  );
+  const [groupByCount, setGroupByCount] = useState<number>(5);
+  const [displayMode, setDisplayMode] = useState<"cumulative" | "daily">(
+    "cumulative"
+  );
+  const [filter, setFilter] = useState<
+    Partial<Record<AwuUsageGroupByType, string[]>>
+  >({});
+
+  const [selectedPeriod, setSelectedPeriod] = useState<string>(() => {
+    const currentBillingCycle = getBillingCycleFromDay(
+      billingCycleStartDay,
+      new Date(),
+      true
+    );
+    return formatPeriod(currentBillingCycle.cycleStart);
+  });
+
+  const { awuUsageData, isAwuUsageLoading, isAwuUsageError } = usePokeAwuUsage({
+    owner,
+    selectedPeriod,
+    billingCycleStartDay,
+    groupBy,
+    groupByCount,
+    windowSize: displayMode === "cumulative" ? "HOUR" : "DAY",
+  });
+
+  return (
+    <BaseAwuUsageChart
+      awuUsageData={awuUsageData}
+      isLoading={isAwuUsageLoading}
+      isError={!!isAwuUsageError}
+      groupBy={groupBy}
+      setGroupBy={setGroupBy}
+      groupByCount={groupByCount}
+      setGroupByCount={setGroupByCount}
+      filter={filter}
+      setFilter={setFilter}
+      selectedPeriod={selectedPeriod}
+      setSelectedPeriod={setSelectedPeriod}
+      billingCycleStartDay={billingCycleStartDay}
+      displayMode={displayMode}
+      setDisplayMode={setDisplayMode}
+    />
+  );
+}

--- a/front/components/poke/credits/PokeUsageTab.tsx
+++ b/front/components/poke/credits/PokeUsageTab.tsx
@@ -1,0 +1,129 @@
+import { PokeAwuUsageChart } from "@app/components/poke/credits/PokeAwuUsageChart";
+import type { PokeStripeSubscriptionWire } from "@app/lib/api/poke/workspace_info";
+import { usePokeAwuPoolSummary } from "@app/poke/swr/credits";
+import type { SubscriptionType } from "@app/types/plan";
+import type { WorkspaceType } from "@app/types/user";
+import {
+  ContentMessage,
+  ExclamationCircleIcon,
+  Spinner,
+} from "@dust-tt/sparkle";
+
+interface PokeUsageTabProps {
+  owner: WorkspaceType;
+  subscription: SubscriptionType;
+  stripeSubscription: PokeStripeSubscriptionWire | null;
+}
+
+function formatCredits(credits: number): string {
+  return Math.round(credits).toLocaleString("en-US");
+}
+
+interface PokeCreditPoolCardProps {
+  owner: WorkspaceType;
+}
+
+function PokeCreditPoolCard({ owner }: PokeCreditPoolCardProps) {
+  const { awuPoolSummary, isAwuPoolSummaryLoading, isAwuPoolSummaryError } =
+    usePokeAwuPoolSummary({ owner });
+
+  if (isAwuPoolSummaryLoading) {
+    return (
+      <div className="flex justify-center py-8">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (isAwuPoolSummaryError || !awuPoolSummary) {
+    return (
+      <ContentMessage
+        title="Failed to load Workspace Credits Pool"
+        icon={ExclamationCircleIcon}
+        variant="warning"
+      >
+        Could not load the credit pool summary for this workspace.
+      </ContentMessage>
+    );
+  }
+
+  const {
+    totalActiveCredits,
+    totalRemainingCredits,
+    resetDate,
+    overageCredits,
+  } = awuPoolSummary;
+  const consumed = Math.max(0, totalActiveCredits - totalRemainingCredits);
+  const consumedPct =
+    totalActiveCredits > 0
+      ? Math.min((consumed / totalActiveCredits) * 100, 100)
+      : 0;
+
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border border-border p-4 dark:border-border-night">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-foreground dark:text-foreground-night">
+          Workspace Credits Pool
+        </span>
+        <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
+          {formatCredits(consumed)} / {formatCredits(totalActiveCredits)}{" "}
+          credits
+        </span>
+      </div>
+      <div className="flex h-2 w-full overflow-hidden rounded-full bg-muted-foreground/10 dark:bg-muted-foreground-night/10">
+        <div
+          className="h-full shrink-0 bg-highlight transition-all dark:bg-highlight-night"
+          style={{ width: `${consumedPct}%` }}
+        />
+      </div>
+      <div className="flex flex-wrap gap-x-6 gap-y-1 text-xs text-muted-foreground dark:text-muted-foreground-night">
+        <span>{formatCredits(totalRemainingCredits)} credits remaining</span>
+        {overageCredits !== null && overageCredits > 0 && (
+          <span>{formatCredits(overageCredits)} overage credits</span>
+        )}
+        {resetDate && (
+          <span>
+            Resets{" "}
+            {new Date(resetDate).toLocaleDateString("en-US", {
+              month: "short",
+              day: "numeric",
+              year: "numeric",
+              timeZone: "UTC",
+            })}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function PokeUsageTab({
+  owner,
+  subscription,
+  stripeSubscription,
+}: PokeUsageTabProps) {
+  // Billing cycle start day from Stripe subscription, fallback to Dust
+  // subscription (mirrors CreditsDataTable).
+  const getBillingCycleStartDay = (): number | null => {
+    if (stripeSubscription?.current_period_start) {
+      return new Date(stripeSubscription.current_period_start * 1000).getDate();
+    }
+    if (subscription.startDate) {
+      return new Date(subscription.startDate).getDate();
+    }
+    return null;
+  };
+  const billingCycleStartDay = getBillingCycleStartDay();
+
+  return (
+    <div className="flex flex-col gap-4">
+      <PokeCreditPoolCard owner={owner} />
+      {billingCycleStartDay && (
+        <PokeAwuUsageChart
+          owner={owner}
+          billingCycleStartDay={billingCycleStartDay}
+        />
+      )}
+    </div>
+  );
+}

--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -1,6 +1,7 @@
 import { PokeWorkspaceUsageChart } from "@app/components/poke/analytics/PokeWorkspaceUsageChart";
 import { AppDataTable } from "@app/components/poke/apps/table";
 import { AssistantsDataTable } from "@app/components/poke/assistants/table";
+import { PokeUsageTab } from "@app/components/poke/credits/PokeUsageTab";
 import { CreditsDataTable } from "@app/components/poke/credits/table";
 import { DataSourceViewsDataTable } from "@app/components/poke/data_source_views/table";
 import { DataSourceDataTable } from "@app/components/poke/data_sources/table";
@@ -33,6 +34,7 @@ import { usePokeRegion } from "@app/lib/swr/poke";
 import { usePokePageMetadata } from "@app/poke/swr/currentPage";
 import { usePokeDataRetention } from "@app/poke/swr/data_retention";
 import { usePokeWorkspaceInfo } from "@app/poke/swr/workspace_info";
+import { isCreditPricedPlan } from "@app/types/plan";
 import { isString } from "@app/types/shared/utils/general";
 import type { WorkspaceSegmentationType } from "@app/types/user";
 import {
@@ -144,6 +146,10 @@ export function WorkspacePage() {
     workosEnvironmentId,
     temporalFrontNamespace,
   } = workspaceInfo;
+
+  // The Usage tab (AWU usage chart + credit pool) only applies to credit-based
+  // (CP_) pricing workspaces.
+  const isCreditPriced = isCreditPricedPlan(activeSubscription.plan);
 
   return (
     <div className="ml-8 p-6">
@@ -272,6 +278,7 @@ export function WorkspacePage() {
               <TabsTrigger value="triggers" label="Triggers" />
               <TabsTrigger value="webhooksources" label="Webhook Sources" />
               <TabsTrigger value="credits" label="API Usage" />
+              {isCreditPriced && <TabsTrigger value="usage" label="Usage" />}
               <TabsTrigger value="analytics" label="Analytics" />
             </TabsList>
 
@@ -328,6 +335,15 @@ export function WorkspacePage() {
                 loadOnInit
               />
             </TabsContent>
+            {isCreditPriced && (
+              <TabsContent value="usage">
+                <PokeUsageTab
+                  owner={owner}
+                  subscription={activeSubscription}
+                  stripeSubscription={stripeSubscription}
+                />
+              </TabsContent>
+            )}
             <TabsContent value="analytics">
               <div className="flex flex-col gap-6">
                 <PokeWorkspaceUsageChart workspaceId={owner.sId} period={30} />

--- a/front/components/workspace/AwuUsageChart.tsx
+++ b/front/components/workspace/AwuUsageChart.tsx
@@ -238,7 +238,7 @@ interface BaseAwuUsageChartProps {
   setDisplayMode: (v: DisplayMode) => void;
 }
 
-function BaseAwuUsageChart({
+export function BaseAwuUsageChart({
   awuUsageData,
   isLoading,
   isError,

--- a/front/pages/api/poke/workspaces/[wId]/analytics/awu-usage.ts
+++ b/front/pages/api/poke/workspaces/[wId]/analytics/awu-usage.ts
@@ -1,0 +1,106 @@
+/** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
+import type { GetAwuUsageResponse } from "@app/lib/api/analytics/awu_usage";
+import {
+  AwuUsageQuerySchema,
+  getAwuUsage,
+} from "@app/lib/api/analytics/awu_usage";
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetAwuUsageResponse>>,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId } = req.query;
+  if (!isString(wId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace you're trying to access was not found.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+
+  const owner = auth.workspace();
+
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Could not find the workspace.",
+      },
+    });
+  }
+
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  const q = AwuUsageQuerySchema.safeParse(req.query);
+  if (!q.success) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid query parameters: ${q.error.message}`,
+      },
+    });
+  }
+
+  const result = await getAwuUsage(auth, q.data);
+  if (result.isErr()) {
+    const err = result.error;
+    switch (err.type) {
+      case "metronome_not_configured":
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Workspace is not configured for Metronome billing.",
+          },
+        });
+      case "invalid_group_key":
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              `Grouping by "${err.groupBy}" is not available. The billable metric ` +
+              `must have "${err.eventProperty}" configured as a group key in Metronome.`,
+          },
+        });
+      case "internal_error":
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: err.message,
+          },
+        });
+      default:
+        assertNever(err);
+    }
+  }
+
+  res.status(200).json(result.value);
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/api/poke/workspaces/[wId]/credits/awu-pool-summary.ts
+++ b/front/pages/api/poke/workspaces/[wId]/credits/awu-pool-summary.ts
@@ -1,0 +1,100 @@
+/** @ignoreswagger */
+// @migration-status: MIGRATED_TO_HONO
+
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type {
+  AwuPoolSummaryError,
+  AwuPoolSummaryResponseBody,
+} from "@app/lib/api/credits/awu_pool_summary";
+import { getAwuPoolSummary } from "@app/lib/api/credits/awu_pool_summary";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+function summaryErrorToApi(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  err: AwuPoolSummaryError
+) {
+  switch (err.type) {
+    case "not_configured":
+      return apiError(req, res, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Workspace is not configured for Metronome billing.",
+        },
+      });
+    case "balances_fetch_failed":
+      return apiError(req, res, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome balances: ${err.cause?.message ?? ""}`,
+        },
+      });
+    case "invoices_fetch_failed":
+      return apiError(req, res, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve Metronome invoices: ${err.cause?.message ?? ""}`,
+        },
+      });
+    default:
+      assertNever(err.type);
+  }
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<AwuPoolSummaryResponseBody>>,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId } = req.query;
+  if (!isString(wId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace you're trying to access was not found.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+
+  const owner = auth.workspace();
+
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Could not find the workspace.",
+      },
+    });
+  }
+
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  const result = await getAwuPoolSummary(auth);
+  if (result.isErr()) {
+    return summaryErrorToApi(req, res, result.error);
+  }
+  return res.status(200).json(result.value);
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -1,4 +1,8 @@
 import type {
+  AwuUsageGroupByType,
+  GetAwuUsageResponse,
+} from "@app/lib/api/analytics/awu_usage";
+import type {
   GetMetronomeUsageResponse,
   MetronomeUsageGroupByType,
 } from "@app/lib/api/analytics/metronome_usage";
@@ -7,6 +11,7 @@ import type {
   GroupByType,
 } from "@app/lib/api/analytics/programmatic_cost";
 import type { WindowSize } from "@app/lib/api/analytics/time_utils";
+import type { AwuPoolSummaryResponseBody } from "@app/lib/api/credits/awu_pool_summary";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeListCreditsResponseBody } from "@app/pages/api/poke/workspaces/[wId]/credits";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
@@ -135,5 +140,76 @@ export function usePokeMetronomeUsage({
     isMetronomeUsageLoading: !error && !data && !disabled,
     isMetronomeUsageError: error,
     isMetronomeUsageValidating: isValidating,
+  };
+}
+
+export function usePokeAwuUsage({
+  owner,
+  groupBy,
+  groupByCount,
+  selectedPeriod,
+  billingCycleStartDay,
+  windowSize,
+  disabled,
+}: PokeConditionalFetchProps & {
+  groupBy?: AwuUsageGroupByType;
+  groupByCount?: number;
+  selectedPeriod?: string;
+  billingCycleStartDay: number;
+  windowSize?: WindowSize;
+}) {
+  const { fetcher } = useFetcher();
+  const fetcherFn: Fetcher<GetAwuUsageResponse> = fetcher;
+
+  const queryParams = new URLSearchParams();
+  queryParams.set("billingCycleStartDay", billingCycleStartDay.toString());
+  if (selectedPeriod) {
+    queryParams.set("selectedPeriod", selectedPeriod);
+  }
+  if (groupBy) {
+    queryParams.set("groupBy", groupBy);
+  }
+  if (groupByCount !== undefined) {
+    queryParams.set("groupByCount", groupByCount.toString());
+  }
+  if (windowSize) {
+    queryParams.set("windowSize", windowSize);
+  }
+  const queryString = queryParams.toString();
+  const key = `/api/poke/workspaces/${owner.sId}/analytics/awu-usage?${queryString}`;
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    disabled ? null : key,
+    fetcherFn
+  );
+
+  return {
+    awuUsageData: data,
+    isAwuUsageLoading: !error && !data && !disabled,
+    isAwuUsageError: error,
+    isAwuUsageValidating: isValidating,
+  };
+}
+
+export function usePokeAwuPoolSummary({
+  owner,
+  disabled,
+}: PokeConditionalFetchProps) {
+  const { fetcher } = useFetcher();
+  const fetcherFn: Fetcher<AwuPoolSummaryResponseBody> = fetcher;
+
+  const { data, error, isValidating, mutate } = useSWRWithDefaults(
+    disabled
+      ? null
+      : `/api/poke/workspaces/${owner.sId}/credits/awu-pool-summary`,
+    fetcherFn
+  );
+
+  return {
+    awuPoolSummary: data ?? null,
+    isAwuPoolSummaryLoading: !error && !data && !disabled,
+    isAwuPoolSummaryError: error,
+    isAwuPoolSummaryValidating: isValidating,
+    mutateAwuPoolSummary: mutate,
   };
 }


### PR DESCRIPTION
## Description

Adds a new **"Usage"** tab to the Poke workspace page, showing the AWU usage
chart and the Workspace Credits Pool — the same view customers see, for admin
inspection. The tab is **only shown for credit-priced (`CP_`) workspaces**
(`isCreditPricedPlan(activeSubscription.plan)` gates both the trigger and
content in `WorkspacePage.tsx`).

**Backend** (superuser-auth Poke endpoints; Next + Hono mirror per BACK17):
- `analytics/awu-usage` — calls the shared `getAwuUsage` (same business logic as
  the customer `/api/w/[wId]/analytics/awu-usage`).
- `credits/awu-pool-summary` — calls the shared `getAwuPoolSummary`. On the
  Hono side it's mounted as a sub-route on the existing Poke credits app
  (which itself serves the credits list at `/`).
- Both registered in their front-api routers.

**Frontend:**
- `BaseAwuUsageChart` is now exported from `AwuUsageChart.tsx` so Poke can reuse
  the presentation layer (mirrors the existing `BaseMetronomeUsageChart`
  pattern).
- `PokeAwuUsageChart` — wrapper using a new `usePokeAwuUsage` hook; same default
  grouping (by usage type) and all groupings including the LLM / Basic / Advanced
  category breakdown.
- `PokeUsageTab` — compact "Workspace Credits Pool" card (consumed / total,
  remaining, overage, reset date) + the chart. Computes `billingCycleStartDay`
  from the Stripe/Dust subscription, same as `CreditsDataTable`.
- `usePokeAwuUsage` + `usePokeAwuPoolSummary` added to `poke/swr/credits.ts`.

No business logic is duplicated — the Poke endpoints just add superuser auth and
delegate to the existing `getAwuUsage` / `getAwuPoolSummary`.

## Tests

- `tsgo` and biome pass for both `front` and `front-api`.
- Verified in Poke on a credit-priced workspace: the Usage tab appears, the pool
  card and chart render, and the tab is hidden for non-credit-priced workspaces.

## Risk

- Low. Read-only Poke admin views; no billing/credit mutations.
- Superuser-only endpoints (`withSessionAuthenticationForPoke` +
  `Authenticator.fromSuperUserSession`).
- Tab is gated to `CP_` workspaces; reuses the same metric data as the customer
  chart, so the recreated-metric backfill caveat applies to the tool slices.
- Rollback: revert the files.

## Deploy Plan

- Standard `front` (+ `front-api`) deploy. No DB migration, no Metronome setup
  change.
