### PR TITLE
[front] feature flag to default @dust agent to GPT 5.5

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -75,6 +75,9 @@ interface DustLikeGlobalAgentArgs {
   hasDeepDive: boolean;
   globalAgentContext?: GlobalAgentContext;
   excludeProviders?: ReadonlySet<ModelProviderIdType>;
+  // When set, the @dust agent defaults to GPT 5.5 (medium reasoning) instead of
+  // Claude Sonnet 4.6. Gated by the `dust_agent_gpt_5_5_default` feature flag.
+  preferGpt55DefaultModel?: boolean;
 }
 
 const INSTRUCTION_SECTIONS = {
@@ -506,7 +509,9 @@ export function _getDustGlobalAgent(
   return _getDustLikeGlobalAgent(auth, args, {
     agentId: GLOBAL_AGENTS_SID.DUST,
     name: "dust",
-    preferredModelConfiguration: CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+    preferredModelConfiguration: args.preferGpt55DefaultModel
+      ? GPT_5_5_MODEL_CONFIG
+      : CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
     preferredReasoningEffort: "medium",
   });
 }

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -691,6 +691,7 @@ function getGlobalAgent({
   hasSandbox,
   globalAgentContext,
   excludeProviders,
+  preferGpt55DefaultModel,
 }: {
   auth: Authenticator;
   sId: string | number;
@@ -702,6 +703,7 @@ function getGlobalAgent({
   hasSandbox: boolean;
   globalAgentContext?: GlobalAgentContext;
   excludeProviders: ReadonlySet<ModelProviderIdType>;
+  preferGpt55DefaultModel: boolean;
 }): AgentConfigurationType | null {
   const settings =
     globalAgentSettings.find((settings) => settings.agentId === sId) ?? null;
@@ -908,6 +910,7 @@ function getGlobalAgent({
         hasDeepDive,
         globalAgentContext,
         excludeProviders,
+        preferGpt55DefaultModel,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_HIGH:
@@ -1490,6 +1493,7 @@ export async function getGlobalAgents(
       hasSandbox: flags.includes("sandbox_tools"),
       globalAgentContext: options?.globalAgentContext,
       excludeProviders,
+      preferGpt55DefaultModel: flags.includes("dust_agent_gpt_5_5_default"),
     })
   );
 

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -26,6 +26,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Access to internal global agents (dust-edge, dust-quick, dust-oai, dust-goog, custom model agents and their variants)",
     stage: "dust_only",
   },
+  dust_agent_gpt_5_5_default: {
+    description:
+      "Use GPT 5.5 (medium reasoning) as the default model for the @dust agent",
+    stage: "dust_only",
+  },
   notion_private_integration: {
     description: "Setup Notion private integration tokens",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -703,6 +703,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "discord_bot"
   | "dummy_feature_for_flag_testing"
   | "dust_academy"
+  | "dust_agent_gpt_5_5_default"
   | "dust_internal_global_agents"
   | "dust_no_spa"
   | "dust_spa"


### PR DESCRIPTION
## Description

Adds the `dust_agent_gpt_5_5_default` feature flag. When enabled for a workspace, the `@dust` global agent defaults to GPT 5.5 (medium reasoning) instead of Claude Sonnet 4.6.

Only affects the user-facing `@dust` agent. The dust-high / dust-omitted / internal variants are untouched. Existing model-selection rules still apply: the preferred model is only used when its provider is whitelisted and the workspace is upgraded.

> [!NOTE]
> The flag only takes effect on workspaces where the `openai` provider is whitelisted and the workspace is upgraded. Otherwise `@dust` falls back to the large whitelisted model as today, so enabling the flag is a no-op. Enable the OpenAI whitelist first.

## Tests

Tested locally by toggling the flag and checking the `@dust` agent resolves to GPT 5.5 medium vs Claude Sonnet 4.6.

## Risk

Low. Flag-gated and off by default (`dust_only` stage), so no behavior change without explicit opt-in.

## Deploy Plan

Standard deploy.