### PR TITLE
[front] cut sandbox cold-start round-trips in egress + GCS setup

### DIFF
--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -200,19 +200,19 @@ describe("sandbox egress helpers", () => {
     expect(mockLookup).toHaveBeenCalledWith("eu.sandbox-egress.dust.tt", {
       family: 4,
     });
-    expect(sandbox.writeFile).toHaveBeenCalledWith(
-      auth,
-      "/etc/dust/egress-token",
-      expect.anything()
-    );
+    // Token now lands via a single root `install -m600 /dev/stdin` (was a
+    // writeFile + chmod), with the JWT passed through stdin, never argv.
     expect(sandbox.execRoot).toHaveBeenNthCalledWith(
       1,
       auth,
-      expect.any(Object)
+      expect.any(Object),
+      { stdin: expect.any(String) }
     );
-    expect(getRootCommandCall(sandbox.execRoot, 0)).toContain(
-      "chmod 600 /etc/dust/egress-token"
+    const tokenCall = getRootCommandCall(sandbox.execRoot, 0);
+    expect(tokenCall).toContain(
+      "/usr/bin/install -o root -g root -m 600 /dev/stdin"
     );
+    expect(tokenCall).toContain("/etc/dust/egress-token");
     expect(mockWriteEgressSecretsFile).toHaveBeenCalledWith(auth, sandbox);
     expect(mockWriteSandboxEnvManifestFile).toHaveBeenCalledWith(auth, sandbox);
     const spawnCall = getRootCommandCall(sandbox.execRoot, 1);

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -169,7 +169,6 @@ describe("sandbox egress helpers", () => {
     const sandbox = {
       providerId: "provider-sandbox-id",
       sId: "sandbox-id",
-      writeFile: vi.fn().mockResolvedValue(new Ok(undefined)),
       execRoot: vi
         .fn()
         .mockResolvedValueOnce(new Ok({ exitCode: 0, stdout: "", stderr: "" }))
@@ -294,7 +293,6 @@ describe("sandbox egress helpers", () => {
     const sandbox = {
       providerId: "provider-sandbox-id",
       sId: "sandbox-id",
-      writeFile: vi.fn().mockResolvedValue(new Ok(undefined)),
       execRoot: vi
         .fn()
         // First call: health probe with empty stdout.
@@ -390,7 +388,6 @@ describe("sandbox egress helpers", () => {
     const sandbox = {
       providerId: "provider-sandbox-id",
       sId: "sandbox-id",
-      writeFile: vi.fn().mockResolvedValue(new Ok(undefined)),
       execRoot: vi
         .fn()
         .mockResolvedValue(new Err(new Error("sandbox command failed"))),
@@ -412,7 +409,6 @@ describe("sandbox egress helpers", () => {
     const sandbox = {
       providerId: "provider-sandbox-id",
       sId: "sandbox-id",
-      writeFile: vi.fn().mockResolvedValue(new Ok(undefined)),
       execRoot: vi
         .fn()
         .mockResolvedValue(new Ok({ exitCode: 0, stdout: "", stderr: "" })),
@@ -435,7 +431,6 @@ describe("sandbox egress helpers", () => {
     const sandbox = {
       providerId: "provider-sandbox-id",
       sId: "sandbox-id",
-      writeFile: vi.fn().mockResolvedValue(new Ok(undefined)),
       execRoot: vi
         .fn()
         .mockResolvedValue(new Ok({ exitCode: 0, stdout: "", stderr: "" })),
@@ -454,7 +449,6 @@ describe("sandbox egress helpers", () => {
     const sandbox = {
       providerId: "provider-sandbox-id",
       sId: "sandbox-id",
-      writeFile: vi.fn().mockResolvedValue(new Ok(undefined)),
       execRoot: vi
         .fn()
         .mockResolvedValueOnce(new Ok({ exitCode: 0, stdout: "", stderr: "" }))
@@ -483,7 +477,6 @@ describe("sandbox egress helpers", () => {
     const sandbox = {
       providerId: "provider-sandbox-id",
       sId: "sandbox-id",
-      writeFile: vi.fn().mockResolvedValue(new Ok(undefined)),
       execRoot: vi
         .fn()
         .mockResolvedValueOnce(new Ok({ exitCode: 0, stdout: "", stderr: "" }))
@@ -631,7 +624,6 @@ describe("sandbox egress helpers", () => {
     const sandbox = {
       providerId: "provider-sandbox-id",
       sId: "sandbox-id",
-      writeFile: vi.fn().mockResolvedValue(new Ok(undefined)),
       execRoot: vi
         .fn()
         .mockResolvedValueOnce(

--- a/front/lib/api/sandbox/egress.test.ts
+++ b/front/lib/api/sandbox/egress.test.ts
@@ -421,6 +421,10 @@ describe("sandbox egress helpers", () => {
       expect(result.error.message).toContain("secrets write failed");
     }
     expect(sandbox.execRoot).toHaveBeenCalledTimes(1);
+    // The writes are sequentially gated: a secrets failure must short-circuit
+    // before the manifest is touched, so the sandbox-visible manifest never
+    // diverges from what the forwarder loaded on the restart path.
+    expect(mockWriteSandboxEnvManifestFile).not.toHaveBeenCalled();
   });
 
   it("surfaces failures from writing the environment manifest file", async () => {

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -496,31 +496,32 @@ export async function setupEgressForwarder(
     auth.getNonNullableWorkspace().sId
   );
 
-  // The token, secrets, and manifest each land in a distinct file with no
-  // dependency on one another, so write them concurrently to collapse three
-  // sandbox round-trips into roughly one. The forwarder start below reads the
-  // token and secrets files, so it waits for all three writes to finish.
-  //
-  // Secrets are written here, before the kill on the restart path, so a write
-  // failure leaves any existing forwarder running rather than taking it down
-  // with nothing to replace it.
-  const [tokenWriteResult, secretsWriteResult, manifestWriteResult] =
-    await Promise.all([
-      traceSandboxStartupPhase("egress.write_token", () =>
-        writeEgressTokenFile(auth, sandbox, token)
-      ),
-      traceSandboxStartupPhase("egress.write_secrets", () =>
-        writeEgressSecretsFile(auth, sandbox)
-      ),
-      traceSandboxStartupPhase("egress.write_manifest", () =>
-        writeSandboxEnvManifestFile(auth, sandbox)
-      ),
-    ]);
-  for (const writeResult of [
-    tokenWriteResult,
-    secretsWriteResult,
-    manifestWriteResult,
-  ]) {
+  // The token write gates the rest: in the original sequential flow a token
+  // failure returned before any secrets/manifest hit disk, so we keep that
+  // contract by awaiting it first. This matters on the restart path, where a
+  // token failure must leave the existing forwarder's secrets/manifest files
+  // untouched rather than rewriting them under a still-running forwarder while
+  // setup returns Err.
+  const tokenWriteResult = await traceSandboxStartupPhase(
+    "egress.write_token",
+    () => writeEgressTokenFile(auth, sandbox, token)
+  );
+  if (tokenWriteResult.isErr()) {
+    return tokenWriteResult;
+  }
+
+  // Secrets and manifest are independent files with no ordering between them,
+  // so write them concurrently once the token is in place. The forwarder start
+  // below reads both, so it waits for these writes to finish.
+  const [secretsWriteResult, manifestWriteResult] = await Promise.all([
+    traceSandboxStartupPhase("egress.write_secrets", () =>
+      writeEgressSecretsFile(auth, sandbox)
+    ),
+    traceSandboxStartupPhase("egress.write_manifest", () =>
+      writeSandboxEnvManifestFile(auth, sandbox)
+    ),
+  ]);
+  for (const writeResult of [secretsWriteResult, manifestWriteResult]) {
     if (writeResult.isErr()) {
       return writeResult;
     }

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -496,12 +496,18 @@ export async function setupEgressForwarder(
     auth.getNonNullableWorkspace().sId
   );
 
-  // The token write gates the rest: in the original sequential flow a token
-  // failure returned before any secrets/manifest hit disk, so we keep that
-  // contract by awaiting it first. This matters on the restart path, where a
-  // token failure must leave the existing forwarder's secrets/manifest files
-  // untouched rather than rewriting them under a still-running forwarder while
-  // setup returns Err.
+  // Token, secrets, and manifest are written in order, each gated on the
+  // previous succeeding, mirroring the original sequential flow exactly: any
+  // write failure returns before the next file is touched. This keeps the
+  // restart path safe — a failed write leaves the remaining files (and the
+  // still-running forwarder reading them) untouched rather than rewriting some
+  // of them under a forwarder that setup then declines to replace.
+  //
+  // These stay sequential on purpose: parallelizing them would let a later
+  // file (e.g. the manifest) land even when an earlier write fails, diverging
+  // the sandbox-visible state from what the forwarder actually loaded. The big
+  // round-trip wins in this path come from the merged token install and the
+  // GCS changes, not from overlapping these three.
   const tokenWriteResult = await traceSandboxStartupPhase(
     "egress.write_token",
     () => writeEgressTokenFile(auth, sandbox, token)
@@ -510,21 +516,20 @@ export async function setupEgressForwarder(
     return tokenWriteResult;
   }
 
-  // Secrets and manifest are independent files with no ordering between them,
-  // so write them concurrently once the token is in place. The forwarder start
-  // below reads both, so it waits for these writes to finish.
-  const [secretsWriteResult, manifestWriteResult] = await Promise.all([
-    traceSandboxStartupPhase("egress.write_secrets", () =>
-      writeEgressSecretsFile(auth, sandbox)
-    ),
-    traceSandboxStartupPhase("egress.write_manifest", () =>
-      writeSandboxEnvManifestFile(auth, sandbox)
-    ),
-  ]);
-  for (const writeResult of [secretsWriteResult, manifestWriteResult]) {
-    if (writeResult.isErr()) {
-      return writeResult;
-    }
+  const secretsWriteResult = await traceSandboxStartupPhase(
+    "egress.write_secrets",
+    () => writeEgressSecretsFile(auth, sandbox)
+  );
+  if (secretsWriteResult.isErr()) {
+    return secretsWriteResult;
+  }
+
+  const manifestWriteResult = await traceSandboxStartupPhase(
+    "egress.write_manifest",
+    () => writeSandboxEnvManifestFile(auth, sandbox)
+  );
+  if (manifestWriteResult.isErr()) {
+    return manifestWriteResult;
   }
 
   if (restartExisting) {

--- a/front/lib/api/sandbox/egress.ts
+++ b/front/lib/api/sandbox/egress.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import { lookup } from "node:dns/promises";
 import config from "@app/lib/api/config";
 import { config as regionConfig } from "@app/lib/api/regions/config";
@@ -28,6 +29,7 @@ import { fromError } from "zod-validation-error";
 const EGRESS_FORWARDER_LISTEN_ADDR = "127.0.0.1:9990";
 const EGRESS_RESOLVER_LISTEN_ADDR = "127.0.0.1:1053";
 const EGRESS_PROXIED_UID = SANDBOX_AGENT_PROXIED_UID;
+const EGRESS_TOKEN_DIR = "/etc/dust";
 const EGRESS_TOKEN_PATH = "/etc/dust/egress-token";
 const EGRESS_DENY_LOG_PATH = "/tmp/dust-egress-denied.log";
 const EGRESS_DENY_LOG_OFFSET_PATH = "/tmp/.dust-egress-deny-offset";
@@ -424,6 +426,49 @@ export async function teardownInSandboxEgressRedirect(
   return runSuccessfulRootCommand(auth, sandbox, command);
 }
 
+// Writes the egress JWT to /etc/dust/egress-token as root, mode 600, in a
+// single round-trip (was a writeFile followed by a separate chmod). The token
+// is fed through stdin so it never lands in argv/journald, and goes via a tmp
+// file + mv so a reader (an old forwarder mid-restart) never sees a partial
+// write.
+async function writeEgressTokenFile(
+  auth: Authenticator,
+  sandbox: SandboxResource,
+  token: string
+): Promise<Result<void, Error>> {
+  const tmpPath = `${EGRESS_TOKEN_DIR}/.egress-token.${randomBytes(8).toString("hex")}.tmp`;
+  const command = rootCommand.and([
+    rootCommand.exec("/usr/bin/mkdir", ["-p", EGRESS_TOKEN_DIR]),
+    rootCommand.exec("/usr/bin/install", [
+      "-o",
+      "root",
+      "-g",
+      "root",
+      "-m",
+      "600",
+      "/dev/stdin",
+      tmpPath,
+    ]),
+    rootCommand.exec("/usr/bin/mv", [tmpPath, EGRESS_TOKEN_PATH]),
+  ]);
+
+  const result = await sandbox.execRoot(auth, command, { stdin: token });
+  if (result.isErr()) {
+    return result;
+  }
+  if (result.value.exitCode !== 0) {
+    return new Err(
+      new Error(
+        `Failed to write sandbox egress token file: ${
+          result.value.stderr || result.value.stdout || "unknown error"
+        }`
+      )
+    );
+  }
+
+  return new Ok(undefined);
+}
+
 export async function setupEgressForwarder(
   auth: Authenticator,
   sandbox: SandboxResource,
@@ -450,49 +495,35 @@ export async function setupEgressForwarder(
     sandbox.providerId,
     auth.getNonNullableWorkspace().sId
   );
-  const tokenWriteResult = await traceSandboxStartupPhase(
-    "egress.write_token",
-    () =>
-      sandbox.writeFile(
-        auth,
-        EGRESS_TOKEN_PATH,
-        new TextEncoder().encode(token).buffer
-      )
-  );
-  if (tokenWriteResult.isErr()) {
-    return tokenWriteResult;
-  }
 
-  const prepareTokenResult = await traceSandboxStartupPhase(
-    "egress.chmod_token",
-    () =>
-      runSuccessfulRootCommand(
-        auth,
-        sandbox,
-        rootCommand.exec("/usr/bin/chmod", ["600", EGRESS_TOKEN_PATH])
-      )
-  );
-  if (prepareTokenResult.isErr()) {
-    return prepareTokenResult;
-  }
-
-  // Write the secrets file before killing the old dsbx so a write failure
-  // leaves the existing forwarder running instead of taking it down with
-  // nothing to replace it.
-  const secretsWriteResult = await traceSandboxStartupPhase(
-    "egress.write_secrets",
-    () => writeEgressSecretsFile(auth, sandbox)
-  );
-  if (secretsWriteResult.isErr()) {
-    return secretsWriteResult;
-  }
-
-  const manifestWriteResult = await traceSandboxStartupPhase(
-    "egress.write_manifest",
-    () => writeSandboxEnvManifestFile(auth, sandbox)
-  );
-  if (manifestWriteResult.isErr()) {
-    return manifestWriteResult;
+  // The token, secrets, and manifest each land in a distinct file with no
+  // dependency on one another, so write them concurrently to collapse three
+  // sandbox round-trips into roughly one. The forwarder start below reads the
+  // token and secrets files, so it waits for all three writes to finish.
+  //
+  // Secrets are written here, before the kill on the restart path, so a write
+  // failure leaves any existing forwarder running rather than taking it down
+  // with nothing to replace it.
+  const [tokenWriteResult, secretsWriteResult, manifestWriteResult] =
+    await Promise.all([
+      traceSandboxStartupPhase("egress.write_token", () =>
+        writeEgressTokenFile(auth, sandbox, token)
+      ),
+      traceSandboxStartupPhase("egress.write_secrets", () =>
+        writeEgressSecretsFile(auth, sandbox)
+      ),
+      traceSandboxStartupPhase("egress.write_manifest", () =>
+        writeSandboxEnvManifestFile(auth, sandbox)
+      ),
+    ]);
+  for (const writeResult of [
+    tokenWriteResult,
+    secretsWriteResult,
+    manifestWriteResult,
+  ]) {
+    if (writeResult.isErr()) {
+      return writeResult;
+    }
   }
 
   if (restartExisting) {

--- a/front/lib/api/sandbox/gcs/mount.ts
+++ b/front/lib/api/sandbox/gcs/mount.ts
@@ -130,53 +130,31 @@ export async function mountConversationFiles(
     expires_in: expiresInSeconds,
   });
 
-  // 2. Write token file into the sandbox.
-  const writeResult = await traceSandboxStartupPhase("gcs.write_token", () =>
-    sandbox.exec(
-      auth,
-      `printf '%s' '${escapeSingleQuotes(tokenJson)}' > /tmp/token.json`
-    )
-  );
-  if (writeResult.isErr()) {
-    childLogger.error(
-      { err: writeResult.error },
-      "GCS mount: failed to write token file"
-    );
-    return writeResult;
-  }
-
-  // 3. Start token server and wait until it's listening.
-  // The server script is a netcat loop baked into the template.
-  // Start in background, then verify with a separate exec (matching PoC).
-  const startResult = await traceSandboxStartupPhase(
-    "gcs.start_token_server",
+  // 2-3. Write the token file, start the token server (netcat loop baked into
+  // the template), and poll it ready, all in ONE exec. Polling every 50ms
+  // returns the instant the server is listening (typically <100ms) instead of
+  // a flat `sleep 1`, and folds what used to be three sandbox round-trips into
+  // one. The server is nohup'd so it survives this shell exiting.
+  const tokenServerResult = await traceSandboxStartupPhase(
+    "gcs.token_server",
     () =>
       sandbox.exec(
         auth,
-        "bash /home/agent/.bin/token-server.sh > /tmp/server.log 2>&1 &"
+        `printf '%s' '${escapeSingleQuotes(tokenJson)}' > /tmp/token.json; ` +
+          "nohup bash /home/agent/.bin/token-server.sh > /tmp/server.log 2>&1 & " +
+          "i=0; while [ $i -lt 100 ]; do " +
+          "curl -sf http://127.0.0.1:9876 > /dev/null 2>&1 && exit 0; " +
+          "sleep 0.05; i=$((i+1)); " +
+          "done; exit 1",
+        { timeoutMs: 10_000 }
       )
   );
-  if (startResult.isErr()) {
+  if (tokenServerResult.isErr() || tokenServerResult.value.exitCode !== 0) {
+    const msg = "Token server not ready in time";
     childLogger.error(
-      { err: startResult.error },
-      "GCS mount: failed to start token server"
+      tokenServerResult.isErr() ? { err: tokenServerResult.error } : {},
+      msg
     );
-    return startResult;
-  }
-
-  // wait_token_server brackets the hardcoded `sleep 1` + readiness probe, so
-  // that fixed cost is visible on its own.
-  const checkResult = await traceSandboxStartupPhase(
-    "gcs.wait_token_server",
-    () =>
-      sandbox.exec(
-        auth,
-        "sleep 1 && curl -sf http://127.0.0.1:9876 > /dev/null 2>&1"
-      )
-  );
-  if (checkResult.isErr() || checkResult.value.exitCode !== 0) {
-    const msg = "Token server not ready after 1s";
-    childLogger.error({}, msg);
     return new Err(new Error(msg));
   }
 

--- a/front/lib/api/sandbox/gcs/mount.ts
+++ b/front/lib/api/sandbox/gcs/mount.ts
@@ -24,6 +24,18 @@ const MOUNT_TIMEOUT_MS = 30_000;
 const MOUNT_POINT_CONVERSATION = "/files/conversation";
 const MOUNT_POINT_POD = "/files/pod";
 
+// The token HTTP server (netcat loop baked into the image) that hands gcsfuse a
+// fresh GCS access token. gcsfuse fetches from it on every request.
+const TOKEN_SERVER_URL = "http://127.0.0.1:9876";
+
+// Readiness poll after starting the token server: up to
+// POLL_ATTEMPTS * POLL_INTERVAL_SECONDS = 5s of polling, well under the 10s
+// exec hard timeout. The loop exits the instant curl succeeds (typically
+// <100ms), so the 5s ceiling only bites on a genuinely stuck server.
+const TOKEN_SERVER_POLL_ATTEMPTS = 100;
+const TOKEN_SERVER_POLL_INTERVAL_SECONDS = 0.05;
+const TOKEN_SERVER_EXEC_TIMEOUT_MS = 10_000;
+
 interface MountTarget {
   label: "conversation" | "pod";
   mountPoint: string;
@@ -142,17 +154,26 @@ export async function mountConversationFiles(
         auth,
         `printf '%s' '${escapeSingleQuotes(tokenJson)}' > /tmp/token.json; ` +
           "nohup bash /home/agent/.bin/token-server.sh > /tmp/server.log 2>&1 & " +
-          "i=0; while [ $i -lt 100 ]; do " +
-          "curl -sf http://127.0.0.1:9876 > /dev/null 2>&1 && exit 0; " +
-          "sleep 0.05; i=$((i+1)); " +
+          `i=0; while [ $i -lt ${TOKEN_SERVER_POLL_ATTEMPTS} ]; do ` +
+          `curl -sf ${TOKEN_SERVER_URL} > /dev/null 2>&1 && exit 0; ` +
+          `sleep ${TOKEN_SERVER_POLL_INTERVAL_SECONDS}; i=$((i+1)); ` +
           "done; exit 1",
-        { timeoutMs: 10_000 }
+        { timeoutMs: TOKEN_SERVER_EXEC_TIMEOUT_MS }
       )
   );
   if (tokenServerResult.isErr() || tokenServerResult.value.exitCode !== 0) {
     const msg = "Token server not ready in time";
+    // Surface the poll-loop's own output (the nohup'd server logs to
+    // /tmp/server.log inside the sandbox, but the exec's stdout/stderr is the
+    // only signal we get back here) so a broken token-server.sh isn't an opaque
+    // timeout.
     childLogger.error(
-      tokenServerResult.isErr() ? { err: tokenServerResult.error } : {},
+      tokenServerResult.isErr()
+        ? { err: tokenServerResult.error }
+        : {
+            stdout: tokenServerResult.value.stdout,
+            stderr: tokenServerResult.value.stderr,
+          },
       msg
     );
     return new Err(new Error(msg));
@@ -287,7 +308,7 @@ export function buildMountCommand({
     rootCommand.timeout(
       rootCommand.exec("/usr/bin/gcsfuse", [
         "--token-url",
-        "http://127.0.0.1:9876",
+        TOKEN_SERVER_URL,
         "--reuse-token-from-url=false",
         "--only-dir",
         prefix,

--- a/front/lib/api/sandbox/gcs/mount.ts
+++ b/front/lib/api/sandbox/gcs/mount.ts
@@ -161,19 +161,28 @@ export async function mountConversationFiles(
         { timeoutMs: TOKEN_SERVER_EXEC_TIMEOUT_MS }
       )
   );
-  if (tokenServerResult.isErr() || tokenServerResult.value.exitCode !== 0) {
+  // A provider-level Err (sandbox-not-found, command transport failure,
+  // timeout) is a different failure class than "server didn't come up", so
+  // return it as-is to keep the concrete cause at the caller boundary rather
+  // than flattening it into the generic readiness error.
+  if (tokenServerResult.isErr()) {
+    childLogger.error(
+      { err: tokenServerResult.error },
+      "GCS mount: token server exec failed"
+    );
+    return tokenServerResult;
+  }
+  if (tokenServerResult.value.exitCode !== 0) {
     const msg = "Token server not ready in time";
     // Surface the poll-loop's own output (the nohup'd server logs to
     // /tmp/server.log inside the sandbox, but the exec's stdout/stderr is the
     // only signal we get back here) so a broken token-server.sh isn't an opaque
     // timeout.
     childLogger.error(
-      tokenServerResult.isErr()
-        ? { err: tokenServerResult.error }
-        : {
-            stdout: tokenServerResult.value.stdout,
-            stderr: tokenServerResult.value.stderr,
-          },
+      {
+        stdout: tokenServerResult.value.stdout,
+        stderr: tokenServerResult.value.stderr,
+      },
       msg
     );
     return new Err(new Error(msg));

--- a/front/lib/api/sandbox/instrumentation.ts
+++ b/front/lib/api/sandbox/instrumentation.ts
@@ -38,10 +38,10 @@ export type SandboxStartupPhase =
   // provider.create split.
   | "provider.create_vm"
   | "provider.hardening"
-  // Egress forwarder bring-up sub-steps.
+  // Egress forwarder bring-up sub-steps. The token/secrets/manifest writes run
+  // concurrently (independent files), so their spans overlap under egress_prep.
   | "egress.resolve_proxy"
   | "egress.write_token"
-  | "egress.chmod_token"
   | "egress.write_secrets"
   | "egress.write_manifest"
   | "egress.kill_existing"
@@ -49,11 +49,10 @@ export type SandboxStartupPhase =
   | "egress.wait_healthy"
   | "egress.healthcheck"
   | "egress.install_trust_bundle"
-  // GCS FUSE mount sub-steps.
+  // GCS FUSE mount sub-steps. token_server brackets the single exec that writes
+  // the token, starts the token server, and polls it ready (was three execs).
   | "gcs.mint_token"
-  | "gcs.write_token"
-  | "gcs.start_token_server"
-  | "gcs.wait_token_server"
+  | "gcs.token_server"
   | "gcs.gcsfuse_mount";
 
 // Opens a parent APM span for a startup phase. The provider.* child spans nest

--- a/front/lib/api/sandbox/instrumentation.ts
+++ b/front/lib/api/sandbox/instrumentation.ts
@@ -39,7 +39,8 @@ export type SandboxStartupPhase =
   | "provider.create_vm"
   | "provider.hardening"
   // Egress forwarder bring-up sub-steps. The token/secrets/manifest writes run
-  // concurrently (independent files), so their spans overlap under egress_prep.
+  // sequentially, each gated on the previous, so their spans are back-to-back
+  // under egress_prep.
   | "egress.resolve_proxy"
   | "egress.write_token"
   | "egress.write_secrets"


### PR DESCRIPTION
## Description

Follow-up to the sandbox startup instrumentation. The Datadog cold-start waterfall showed per-step VM round-trip latency (plus a hardcoded `sleep 1`) as the dominant cost. This bundles the independent setup steps.

**GCS mount:** the token write, token-server start, and readiness probe were three separate execs ending in a flat `sleep 1`. Folded into one exec that `nohup`s the server and polls `curl` every 50ms, returning the instant it's listening (typically <100ms). Removes ~1s and 2 round-trips.

Note: the readiness ceiling changes from a fixed 1s wait to up to ~5s of polling (100 attempts at 50ms). The happy path is faster (returns on first success), but a token server that becomes ready between 1-5s now succeeds where the old fixed wait failed, and a genuinely stuck server takes up to ~5s to fail instead of ~1s. This is an intentional robustness tradeoff, not a pure no-op.

**Egress prep:**
- Token write + chmod merged into a single root `install -m600 /dev/stdin` (JWT passed via stdin, never argv). This is the round-trip the egress path saves.
- The token, secrets, and manifest writes stay sequentially gated (token -> secrets -> manifest), each short-circuiting the rest on failure, exactly as before. They are deliberately not parallelized: doing so let a later file (e.g. the manifest) land even when an earlier write failed, diverging the sandbox-visible state from what the forwarder loaded on the restart path.

Net: ~1 fewer round-trip on egress (the token+chmod merge) and ~1s + 2 round-trips on GCS per cold start. Failure-path semantics on egress are unchanged.

## Tests

`npm run test lib/api/sandbox/` green. Existing egress test indices are preserved because `install` replaces `chmod` at the same `execRoot` position and the mocked secrets/manifest helpers add no `execRoot` calls; updated the happy-path assertion to check the token now lands via `install -m600 /dev/stdin` with stdin set, and added an assertion that the manifest write is skipped when the secrets write fails.

## Risk

Touches the egress security setup path. Token/secrets stay out of argv (stdin only); the three writes remain sequentially gated so a failure leaves later files untouched; forwarder still starts only after all writes land. The GCS poll loop is pure-POSIX (no `seq`), capped at a 10s exec timeout.

## Deploy Plan

Standard deploy. Watch `trace.sandbox.startup.gcs.token_server` and the `egress.write_*` spans for the expected drop, and `sandbox.startup.total.duration{cold:true}`.