### PR TITLE
Don't cancel/terminate workflow on retryable errors

### DIFF
--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -122,9 +122,21 @@ export async function retrieveNewTranscriptsActivity(
         localLogger
       );
       if (googleTranscriptsRes.isErr()) {
+        const { error } = googleTranscriptsRes;
+        if (error.retryable) {
+          // Transient error (rate limit, 5xx, network blip): let Temporal retry
+          // the activity with backoff. Do NOT stop the schedule, otherwise a
+          // transient failure (e.g. "User rate limit exceeded.") would disable
+          // the user's sync permanently.
+          throw new Error(
+            `Error retrieving Google transcripts: ${error.message}`
+          );
+        }
+        // Permanent error (revoked token, lost access, ...): stop the schedule
+        // so we don't keep failing every 5 minutes, and don't retry this run.
         await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);
         throw new TranscriptNonRetryableError(
-          `Error retrieving Google transcripts: ${googleTranscriptsRes.error.message}`
+          `Error retrieving Google transcripts: ${error.message}`
         );
       }
       return {

--- a/front/temporal/labs/transcripts/utils/google.ts
+++ b/front/temporal/labs/transcripts/utils/google.ts
@@ -8,6 +8,104 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { drive_v3 } from "googleapis";
 import { google } from "googleapis";
+import { GaxiosError } from "googleapis-common";
+
+// Google API "reason" codes that indicate a transient rate limit, even when the
+// HTTP status is 403 rather than 429.
+const RATE_LIMIT_REASONS = new Set([
+  "rateLimitExceeded",
+  "userRateLimitExceeded",
+]);
+
+// HTTP statuses that are safe to retry: explicit rate limiting and transient
+// upstream errors.
+const RETRYABLE_HTTP_STATUSES = new Set([429, 500, 502, 503, 504]);
+
+// Node network errnos surfaced by Gaxios when the request never completed.
+const RETRYABLE_NETWORK_CODES = new Set([
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EAI_AGAIN",
+  "ENOTFOUND",
+  "EPIPE",
+  "ETIMEDOUT",
+]);
+
+function isObjectWithError(
+  data: unknown
+): data is { error: { errors: unknown } } {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "error" in data &&
+    typeof data.error === "object" &&
+    data.error !== null &&
+    "errors" in data.error
+  );
+}
+
+function isErrorWithReason(err: unknown): err is { reason: string } {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "reason" in err &&
+    typeof err.reason === "string"
+  );
+}
+
+function hasRateLimitReason(err: GaxiosError): boolean {
+  const data: unknown = err.response?.data;
+  if (!isObjectWithError(data)) {
+    return false;
+  }
+  const { errors } = data.error;
+  if (!Array.isArray(errors)) {
+    return false;
+  }
+  return errors.some(
+    (e) => isErrorWithReason(e) && RATE_LIMIT_REASONS.has(e.reason)
+  );
+}
+
+// Decides whether an error from the Google Drive API is transient and should be
+// retried (true), or permanent and should stop the transcripts schedule
+// (false). Transient: rate limits (429 or 403 with a rate-limit reason),
+// transient 5xx, and network blips. Everything else (revoked token, lost
+// access, unexpected errors) is treated as permanent so we don't retry forever.
+export function isRetryableGoogleError(error: unknown): boolean {
+  if (!(error instanceof GaxiosError)) {
+    return false;
+  }
+
+  if (
+    typeof error.code === "string" &&
+    RETRYABLE_NETWORK_CODES.has(error.code)
+  ) {
+    return true;
+  }
+
+  const status = error.response?.status;
+  if (status === undefined) {
+    return false;
+  }
+  if (RETRYABLE_HTTP_STATUSES.has(status)) {
+    return true;
+  }
+  return status === 403 && hasRateLimitReason(error);
+}
+
+// Error returned by `retrieveGoogleTranscripts`. `retryable` tells the caller
+// whether the failure is transient (retry) or permanent (stop the schedule).
+export class RetrieveGoogleTranscriptsError extends Error {
+  readonly retryable: boolean;
+
+  constructor(cause: Error, retryable: boolean) {
+    super(cause.message);
+    this.name = "RetrieveGoogleTranscriptsError";
+    this.retryable = retryable;
+  }
+}
 
 export async function retrieveRecentGoogleTranscripts(
   {
@@ -63,7 +161,7 @@ export async function retrieveGoogleTranscripts(
   auth: Authenticator,
   transcriptsConfiguration: LabsTranscriptsConfigurationResource,
   localLogger: Logger
-): Promise<Result<string[], Error>> {
+): Promise<Result<string[], RetrieveGoogleTranscriptsError>> {
   const fileIdsToProcess: string[] = [];
 
   let recentTranscriptFiles: drive_v3.Schema$File[] | null = null;
@@ -77,11 +175,14 @@ export async function retrieveGoogleTranscripts(
       localLogger
     );
   } catch (error) {
+    const retryable = isRetryableGoogleError(error);
     localLogger.error(
-      { error, transcriptsConfiguration },
+      { error, retryable, transcriptsConfiguration },
       "[retrieveGoogleTranscripts] Error retrieving recent Google transcripts."
     );
-    return new Err(normalizeError(error));
+    return new Err(
+      new RetrieveGoogleTranscriptsError(normalizeError(error), retryable)
+    );
   }
 
   for (const recentTranscriptFile of recentTranscriptFiles) {


### PR DESCRIPTION
## Description

The `labs-transcripts-retrieve` workflow was permanently disabling a user's
transcript sync on **any** error returned by `retrieveGoogleTranscripts` —
including transient ones. A transient `"User rate limit exceeded."` from the
Google Drive API would hit the `google_drive` branch of
`retrieveNewTranscriptsActivity`, which called `stopRetrieveTranscriptsWorkflow`
(deleting the Temporal schedule and setting the config to `disabled`) and threw
a `TranscriptNonRetryableError`. The user's sync was then dead until manually
revived, even though the underlying error was momentary.

This PR teaches the Google retrieval path to tell transient errors from
permanent ones, and reacts accordingly:

- **`utils/google.ts`**: the raw `GaxiosError` (status + reason) used to be
  flattened to a bare message by `normalizeError`, so the caller couldn't
  classify it. Added `isRetryableGoogleError(...)` (mirroring the connectors'
  `google_drive` error classification) and a `RetrieveGoogleTranscriptsError`
  that carries a `retryable` flag. Transient = `429`, `5xx`, `403` with a
  rate-limit reason (`userRateLimitExceeded` / `rateLimitExceeded`), and network
  errnos (`ECONNRESET`, `ETIMEDOUT`, …). Everything else (revoked token, lost
  access, unexpected errors) is treated as permanent.
- **`activities.ts`**: the `google_drive` branch now branches on that flag:
  - **transient** → throw a plain `Error` so Temporal retries the activity with
    backoff and recovers on its own; the schedule is left untouched.
  - **permanent** → keep the previous behavior: `stopRetrieveTranscriptsWorkflow`
    + `TranscriptNonRetryableError`, so we stop scheduling instead of failing
    every 5 minutes forever.

Note: unknown / non-Gaxios errors are intentionally treated as permanent
(stop scheduling) rather than retried indefinitely.

## Tests

Manual reasoning against the Temporal retry config (`workflows.ts` has no
`maximumAttempts`; the schedule uses `ScheduleOverlapPolicy.SKIP` on a `*/5 * * * *`
cron): a transient error now retries with backoff and recovers, a permanent
error unschedules cleanly. Type-checks and lints clean. No automated tests added
yet — `isRetryableGoogleError` is a good unit-test candidate if we want one.

## Risk

Low and easy to roll back (revert the 2 files). Behavioral change is scoped to
the `google_drive` transcripts retrieval error path:
- Transient Google errors no longer disable a user's sync (the bug being fixed).
- A genuinely permanent failure still unschedules, as before.
- Edge case: an unrecognized transient error pattern would be classified as
  permanent and stop the schedule (same as today's behavior, just no longer the
  default for known-transient errors).

## Deploy Plan

Standard deploy. No migration. After deploy, transcript configs disabled by the
previous behavior won't auto-revive — revive them as usual (e.g. via
`restart_failed_transcript_workflows.ts` or by re-enabling the config) if needed.
