### PR TITLE
Usage graph: Remove others when filtering

### DIFF
--- a/front/components/workspace/AwuUsageChart.tsx
+++ b/front/components/workspace/AwuUsageChart.tsx
@@ -399,15 +399,19 @@ export function BaseAwuUsageChart({
     [filter, setFilter]
   );
 
+  // Filtering is scoped to the active grouping (it only hides/keeps series of
+  // the current groupBy), so only surface chips for that grouping — otherwise a
+  // filter set on another dimension would show as active while doing nothing.
   const activeFilterChips = useMemo(() => {
-    return GROUP_BY_OPTIONS.flatMap(({ value: type }) =>
-      (filter[type] ?? []).map((key) => ({
-        groupByType: type,
-        filterKey: key,
-        label: getFilterLabel(type, key),
-      }))
-    );
-  }, [filter, getFilterLabel]);
+    if (!groupBy) {
+      return [];
+    }
+    return (filter[groupBy] ?? []).map((key) => ({
+      groupByType: groupBy,
+      filterKey: key,
+      label: getFilterLabel(groupBy, key),
+    }));
+  }, [filter, groupBy, getFilterLabel]);
 
   const legendItems: LegendItem[] = useMemo(() => {
     const items: LegendItem[] = availableGroupsArray.map((group) => {
@@ -670,12 +674,10 @@ export function BaseAwuUsageChart({
           }}
         />
         {allGroupKeys
-          .filter(
-            (key) =>
-              ["total", "others"].includes(key) ||
-              !enabledGroupKeys ||
-              enabledGroupKeys.includes(key)
-          )
+          // With no filter, render every series (including "others"). Once a
+          // filter is active, render only the selected keys — "others"/"total"
+          // are never selectable, so they drop out.
+          .filter((key) => !enabledGroupKeys || enabledGroupKeys.includes(key))
           .map((groupKey) => {
             const colorClassName = getColorClassName(
               groupBy,


### PR DESCRIPTION
## Description

Two fixes to filtering in the AWU usage chart (`AwuUsageChart` / `BaseAwuUsageChart`,
used on the customer Usage page and the Poke Usage tab).

**1. "Others" stayed visible while filtering.** The series filter
unconditionally kept the `total`/`others` keys:
```ts
["total", "others"].includes(key) || !enabledGroupKeys || enabledGroupKeys.includes(key)
```
so `others` rendered even when a filter was applied. Now:
```ts
!enabledGroupKeys || enabledGroupKeys.includes(key)
```
- No filter → all series render (including `others`), unchanged.
- Filter active → only the selected keys render; `total`/`others` drop out
  (they're never selectable, so never in `enabledGroupKeys`).

**2. Stale filter chip across groupings.** Filtering is client-side and scoped
to the active grouping (`enabledGroupKeys = filter[groupBy]`), but the chips were
rendered for every dimension. So filtering "by model → claude" then switching to
"by user" left a `model: claude` chip showing as active while doing nothing.
`activeFilterChips` now only surfaces chips for the current grouping, so the
displayed state matches what's actually applied.

Note: this does **not** add cross-dimensional filtering (e.g. model=claude while
grouped by user). That would require server-side filtering, which the
Metronome-backed chart can't do without registering `[dimension×dimension]`
group keys (combinatorial, and the metric is already at Metronome's 7-key cap).
Filtering remains scoped to the active grouping by design.

## Tests

- `tsgo` and biome pass.
- Verified: with a filter applied, only selected series show (no `others`);
  switching groupings no longer shows stale, inert filter chips.

## Risk

- Low. Client-side chart rendering only; no API/data changes.
- Affects both the customer Usage page and the Poke Usage tab (shared component).
- Rollback: revert the file.

## Deploy Plan

- Standard `front` deploy. No migration.
