### PR TITLE
Change spend limit to be on top of seat usage

### DIFF
--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
@@ -1,6 +1,8 @@
 import * as creditStateDispatcher from "@app/lib/api/metronome/credit_state_dispatcher";
 import * as spendLimits from "@app/lib/metronome/alerts/spend_limits";
 import * as perUserUsage from "@app/lib/metronome/per_user_usage";
+import * as planType from "@app/lib/metronome/plan_type";
+import * as seatTypes from "@app/lib/metronome/seat_types";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
@@ -19,7 +21,25 @@ vi.mock("@app/lib/metronome/alerts/spend_limits", async () => {
     upsertMetronomePerUserCapAlert: vi.fn(),
     clearMetronomePerUserCapAlert: vi.fn(),
     getMetronomePerUserCap: vi.fn(),
-    getMetronomeDefaultUserCapAlert: vi.fn(),
+    getMetronomeDefaultUserCapAlertForSeatType: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/metronome/plan_type", async () => {
+  const actual = await vi.importActual<typeof planType>(
+    "@app/lib/metronome/plan_type"
+  );
+  return { ...actual, getActiveContract: vi.fn() };
+});
+
+vi.mock("@app/lib/metronome/seat_types", async () => {
+  const actual = await vi.importActual<typeof seatTypes>(
+    "@app/lib/metronome/seat_types"
+  );
+  return {
+    ...actual,
+    getProductSeatTypes: vi.fn(),
+    getAwuAllocationForSeatType: vi.fn(),
   };
 });
 
@@ -65,11 +85,11 @@ beforeEach(() => {
     new Ok(undefined)
   );
   vi.mocked(spendLimits.getMetronomePerUserCap).mockResolvedValue(new Ok(null));
+  vi.mocked(
+    spendLimits.getMetronomeDefaultUserCapAlertForSeatType
+  ).mockResolvedValue(new Ok(null));
   vi.mocked(perUserUsage.fetchPerUserAwuUsage).mockResolvedValue(
     new Ok(new Map())
-  );
-  vi.mocked(spendLimits.getMetronomeDefaultUserCapAlert).mockResolvedValue(
-    new Ok(null)
   );
   vi.mocked(creditStateDispatcher.dispatchPerUserCapReached).mockResolvedValue(
     new Ok(undefined)
@@ -77,6 +97,11 @@ beforeEach(() => {
   vi.mocked(creditStateDispatcher.dispatchPerUserCapResolved).mockResolvedValue(
     new Ok(undefined)
   );
+
+  // Seat allowance resolution mocks (resolveUserSeatAllowance).
+  vi.mocked(planType.getActiveContract).mockResolvedValue(null);
+  vi.mocked(seatTypes.getProductSeatTypes).mockResolvedValue(new Map());
+  vi.mocked(seatTypes.getAwuAllocationForSeatType).mockReturnValue(0);
 });
 
 describe("/api/w/[wId]/members/[uId]/spend_limit", () => {

--- a/front-api/routes/w/[wId]/usage_settings/default_user_spend_limit.ts
+++ b/front-api/routes/w/[wId]/usage_settings/default_user_spend_limit.ts
@@ -61,6 +61,14 @@ function mapErrorToApiError(
           message: error.message,
         },
       };
+    case "contract_not_found":
+      return {
+        status_code: 404,
+        api_error: {
+          type: "workspace_not_found",
+          message: error.message,
+        },
+      };
     case "metronome_error":
       return {
         status_code: 502,

--- a/front/components/workspace/EditSpendLimitModal.tsx
+++ b/front/components/workspace/EditSpendLimitModal.tsx
@@ -200,7 +200,9 @@ export function EditSpendLimitModal({
                 Edit spend limit for {displayedMember?.name}
               </DialogTitle>
               <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                Maximum credits this member can consume during a billing cycle.
+                Maximum pool credits this member can consume during a billing
+                cycle. This limit is added on top of the seat&apos;s built-in
+                allowance.
               </p>
             </div>
           </div>

--- a/front/components/workspace/usage/UsageSettingsCard.tsx
+++ b/front/components/workspace/usage/UsageSettingsCard.tsx
@@ -72,8 +72,8 @@ export function UsageSettingsCard({ workspaceId }: UsageSettingsCardProps) {
       </span>
       <SettingsList>
         <SettingsList.Row
-          title="Default usage limit"
-          description="Define the default usage limit for all the users in your workspace"
+          title="Default pool credit limit"
+          description="Define the pool credit limit for users in your workspace. This limit is added on top of each seat's built-in allowance."
           action={
             <div className="relative w-32">
               <div className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground dark:text-muted-foreground-night">

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1,8 +1,8 @@
 import type { Authenticator } from "@app/lib/auth";
 import {
-  getCachedDefaultCapThreshold,
+  getCachedDefaultCapThresholdsBySeatType,
   getCachedPerUserCapThresholds,
-  getMetronomeDefaultUserCapAlert,
+  getMetronomeDefaultUserCapAlertForSeatType,
   listMetronomePerUserCapsForWorkspace,
 } from "@app/lib/metronome/alerts/spend_limits";
 import {
@@ -19,7 +19,14 @@ import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { resolveEffectiveSpendLimitAwuCredits } from "@app/lib/spend_limits/effective";
 import logger from "@app/logger/logger";
-import type { MembershipSeatType } from "@app/types/memberships";
+import type {
+  MembershipSeatType,
+  NormalizedPoolLimitSeatType,
+} from "@app/types/memberships";
+import {
+  NORMALIZED_POOL_LIMIT_SEAT_TYPES,
+  normalizeToPoolLimitSeatType,
+} from "@app/types/memberships";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { z } from "zod";
 
@@ -209,37 +216,41 @@ async function fetchPerUserCapOverridesUncached({
   return thresholds;
 }
 
-async function fetchDefaultCapUncached({
+async function fetchDefaultCapsBySeatTypeUncached({
   metronomeCustomerId,
   workspaceId,
 }: {
   metronomeCustomerId: string;
   workspaceId: string;
-}): Promise<number | null> {
-  const result = await getMetronomeDefaultUserCapAlert({
-    metronomeCustomerId,
-    workspaceId,
-  });
-  if (result.isErr()) {
-    logger.warn(
-      { err: result.error, workspaceId },
-      "[MembersUsage] Failed to fetch default spend cap"
-    );
-    return null;
+}): Promise<Partial<Record<NormalizedPoolLimitSeatType, number>>> {
+  const thresholds: Partial<Record<NormalizedPoolLimitSeatType, number>> = {};
+  for (const seatType of NORMALIZED_POOL_LIMIT_SEAT_TYPES) {
+    const result = await getMetronomeDefaultUserCapAlertForSeatType({
+      metronomeCustomerId,
+      workspaceId,
+      seatType,
+    });
+    if (result.isErr()) {
+      logger.warn(
+        { err: result.error, workspaceId, seatType },
+        "[MembersUsage] Failed to fetch default spend cap for seat type"
+      );
+      continue;
+    }
+    if (result.value) {
+      thresholds[seatType] = result.value.alert.threshold;
+    }
   }
-
-  return result.value?.alert.threshold ?? null;
+  return thresholds;
 }
 
 /**
  * Resolve the effective per-user spend limit for the members table:
  *   - if the user has a per-user override, the override threshold wins
- *   - otherwise, the workspace default (if any) applies
+ *   - otherwise, the workspace default for the user's seat type applies
  *   - otherwise, the user is uncapped (`null`)
  *
- * Returns a `{ perUser, default }` pair so the caller can compute the
- * effective value with `perUser.get(userId) ?? default` for each member —
- * including members that don't appear in the overrides map.
+ * Returns per-user overrides and per-seat-type default thresholds.
  */
 async function fetchEffectivePerUserSpendLimits({
   metronomeCustomerId,
@@ -249,18 +260,20 @@ async function fetchEffectivePerUserSpendLimits({
   workspaceId: string;
 }): Promise<{
   perUserOverrides: Map<string, number>;
-  defaultAwuCredits: number | null;
+  defaultAwuCreditsBySeatType: Partial<
+    Record<NormalizedPoolLimitSeatType, number>
+  >;
 }> {
   if (!metronomeCustomerId) {
-    return { perUserOverrides: new Map(), defaultAwuCredits: null };
+    return { perUserOverrides: new Map(), defaultAwuCreditsBySeatType: {} };
   }
 
-  const [perUserOverrides, defaultAwuCredits] = await Promise.all([
+  const [perUserOverrides, defaultAwuCreditsBySeatType] = await Promise.all([
     fetchPerUserCapOverrides({ metronomeCustomerId, workspaceId }),
-    fetchDefaultCap({ metronomeCustomerId, workspaceId }),
+    fetchDefaultCapsBySeatType({ metronomeCustomerId, workspaceId }),
   ]);
 
-  return { perUserOverrides, defaultAwuCredits };
+  return { perUserOverrides, defaultAwuCreditsBySeatType };
 }
 
 async function fetchPerUserCapOverrides({
@@ -291,25 +304,24 @@ async function fetchPerUserCapOverrides({
   }
 }
 
-async function fetchDefaultCap({
+async function fetchDefaultCapsBySeatType({
   metronomeCustomerId,
   workspaceId,
 }: {
   metronomeCustomerId: string;
   workspaceId: string;
-}): Promise<number | null> {
+}): Promise<Partial<Record<NormalizedPoolLimitSeatType, number>>> {
   try {
-    const { threshold } = await getCachedDefaultCapThreshold({
+    return await getCachedDefaultCapThresholdsBySeatType({
       metronomeCustomerId,
       workspaceId,
     });
-    return threshold;
   } catch (err) {
     logger.warn(
       { err: normalizeError(err), workspaceId },
-      "[MembersUsage] Failed to read cached default spend cap, falling back to uncached fetch"
+      "[MembersUsage] Failed to read cached default spend caps by seat type, falling back to uncached fetch"
     );
-    return fetchDefaultCapUncached({
+    return fetchDefaultCapsBySeatTypeUncached({
       metronomeCustomerId,
       workspaceId,
     });
@@ -366,7 +378,7 @@ export async function getMembersUsage({
       workspaceId: workspace.sId,
     }),
   ]);
-  const { perUserOverrides, defaultAwuCredits } = perUserSpendLimits;
+  const { perUserOverrides, defaultAwuCreditsBySeatType } = perUserSpendLimits;
 
   const { memberships } = membershipsResult;
 
@@ -398,6 +410,14 @@ export async function getMembersUsage({
     const consumedFromPoolAwuCredits =
       totalConsumedCredits - consumedFromAllowanceAwuCredits;
 
+    // Resolve the default cap for this member's seat type.
+    const normalizedSeatType = normalizeToPoolLimitSeatType(
+      membership.seatType
+    );
+    const defaultAwuCreditsForSeatType = normalizedSeatType
+      ? (defaultAwuCreditsBySeatType[normalizedSeatType] ?? null)
+      : null;
+
     return [
       {
         sId: userId,
@@ -414,7 +434,7 @@ export async function getMembersUsage({
         scheduledSeatChangeAt: scheduled?.startAt.toISOString() ?? null,
         spendLimitAwuCredits: resolveEffectiveSpendLimitAwuCredits({
           overrideAwuCredits: perUserOverrides.get(userId) ?? null,
-          defaultAwuCredits,
+          defaultAwuCredits: defaultAwuCreditsForSeatType,
         }),
       },
     ];

--- a/front/lib/api/metronome/process_webhook.test.ts
+++ b/front/lib/api/metronome/process_webhook.test.ts
@@ -66,7 +66,39 @@ vi.mock("@app/lib/metronome/alerts/spend_limits", async () => {
   return {
     ...actual,
     getMetronomePerUserCap: vi.fn(),
-    getMetronomeDefaultUserCapAlert: vi.fn(),
+    getMetronomePerUserWarningAlert: vi.fn(),
+    getMetronomeDefaultUserCapAlertForSeatType: vi.fn(),
+    getMetronomeDefaultUserWarningAlertForSeatType: vi.fn(),
+  };
+});
+
+// Mock UserResource.fetchById and MembershipResource for resolveUserSpendAlerts.
+// The default mock returns a user with a "pro" seat so the default alert path works.
+vi.mock("@app/lib/resources/user_resource", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/resources/user_resource")
+  >("@app/lib/resources/user_resource");
+  return {
+    ...actual,
+    UserResource: {
+      ...actual.UserResource,
+      fetchById: vi.fn().mockResolvedValue({ sId: "user_test_xxx" }),
+    },
+  };
+});
+
+vi.mock("@app/lib/resources/membership_resource", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/resources/membership_resource")
+  >("@app/lib/resources/membership_resource");
+  return {
+    ...actual,
+    MembershipResource: {
+      ...actual.MembershipResource,
+      getActiveMembershipOfUserInWorkspace: vi
+        .fn()
+        .mockResolvedValue({ seatType: "pro" }),
+    },
   };
 });
 
@@ -93,13 +125,15 @@ function contractEvent(
 
 function spendThresholdEvent(
   type: "alerts.spend_threshold_reached" | "alerts.spend_threshold_resolved",
-  groupValues?: Array<{ key: string; value?: string }>
+  groupValues?: Array<{ key: string; value?: string }>,
+  alertId?: string
 ): MetronomeWebhookEvent {
   return {
     id: `evt_${type}_xxx`,
     type,
     properties: {
       customer_id: METRONOME_CUSTOMER_ID,
+      alert_id: alertId,
       current_spend: 1234,
       group_values: groupValues,
     },
@@ -158,7 +192,13 @@ beforeEach(() => {
     new Ok(null)
   );
   vi.mocked(
-    defaultUserCapAlert.getMetronomeDefaultUserCapAlert
+    defaultUserCapAlert.getMetronomeDefaultUserCapAlertForSeatType
+  ).mockResolvedValue(new Ok(null));
+  vi.mocked(perUserAlerts.getMetronomePerUserWarningAlert).mockResolvedValue(
+    new Ok(null)
+  );
+  vi.mocked(
+    defaultUserCapAlert.getMetronomeDefaultUserWarningAlertForSeatType
   ).mockResolvedValue(new Ok(null));
 });
 
@@ -643,7 +683,7 @@ describe("processMetronomeWebhook — swap webhook ordering", () => {
 });
 
 describe("processMetronomeWebhook — per-user spend threshold (no default alert)", () => {
-  it("dispatches reached when override is IN_ALARM (on reached event)", async () => {
+  it("dispatches reached when override cap alert fires (reached event)", async () => {
     const workspace = await setupMetronomeWorkspaceResource();
     vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValue(
       new Ok(
@@ -656,9 +696,11 @@ describe("processMetronomeWebhook — per-user spend threshold (no default alert
     );
 
     const result = await processMetronomeWebhook({
-      event: spendThresholdEvent("alerts.spend_threshold_reached", [
-        { key: "user_id", value: USER_ID },
-      ]),
+      event: spendThresholdEvent(
+        "alerts.spend_threshold_reached",
+        [{ key: "user_id", value: USER_ID }],
+        "alert_override_xxx"
+      ),
       workspace,
     });
 
@@ -669,7 +711,7 @@ describe("processMetronomeWebhook — per-user spend threshold (no default alert
     expect(dispatchPerUserCapResolved).not.toHaveBeenCalled();
   });
 
-  it("dispatches resolved when override is OK (on resolved event)", async () => {
+  it("dispatches resolved when override cap alert fires (resolved event)", async () => {
     const workspace = await setupMetronomeWorkspaceResource();
     vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValue(
       new Ok(
@@ -682,9 +724,11 @@ describe("processMetronomeWebhook — per-user spend threshold (no default alert
     );
 
     const result = await processMetronomeWebhook({
-      event: spendThresholdEvent("alerts.spend_threshold_resolved", [
-        { key: "user_id", value: USER_ID },
-      ]),
+      event: spendThresholdEvent(
+        "alerts.spend_threshold_resolved",
+        [{ key: "user_id", value: USER_ID }],
+        "alert_override_xxx"
+      ),
       workspace,
     });
 
@@ -695,9 +739,9 @@ describe("processMetronomeWebhook — per-user spend threshold (no default alert
     expect(dispatchPerUserCapReached).not.toHaveBeenCalled();
   });
 
-  it("no-ops when neither override nor default is configured (defensive)", async () => {
+  it("ignores event when neither override nor default is configured", async () => {
     const workspace = await setupMetronomeWorkspaceResource();
-    // getMetronomePerUserCap and getMetronomeDefaultUserCapAlert default to Ok(null).
+    // getMetronomePerUserCap and getMetronomeDefaultUserCapAlertForSeatType default to Ok(null).
 
     const result = await processMetronomeWebhook({
       event: spendThresholdEvent("alerts.spend_threshold_reached", [
@@ -707,11 +751,9 @@ describe("processMetronomeWebhook — per-user spend threshold (no default alert
     });
 
     expect(result.isOk()).toBe(true);
+    // No matching alert → event ignored, no dispatch.
     expect(dispatchPerUserCapReached).not.toHaveBeenCalled();
-    // With no alert in place, effective state is "ok" → dispatch resolved.
-    expect(dispatchPerUserCapResolved).toHaveBeenCalledWith(
-      expect.objectContaining({ userId: USER_ID })
-    );
+    expect(dispatchPerUserCapResolved).not.toHaveBeenCalled();
   });
 
   it("skips per-user events with no user_id value", async () => {
@@ -733,10 +775,10 @@ describe("processMetronomeWebhook — per-user spend threshold (no default alert
 });
 
 describe("processMetronomeWebhook — per-user spend threshold (default alert configured)", () => {
-  it("uses default alert state when no override exists (IN_ALARM → reached)", async () => {
+  it("dispatches reached when default cap alert fires (reached event)", async () => {
     const workspace = await setupMetronomeWorkspaceResource();
     vi.mocked(
-      defaultUserCapAlert.getMetronomeDefaultUserCapAlert
+      defaultUserCapAlert.getMetronomeDefaultUserCapAlertForSeatType
     ).mockResolvedValue(
       new Ok(
         mockCustomerAlert({
@@ -748,9 +790,11 @@ describe("processMetronomeWebhook — per-user spend threshold (default alert co
     );
 
     const result = await processMetronomeWebhook({
-      event: spendThresholdEvent("alerts.spend_threshold_reached", [
-        { key: "user_id", value: USER_ID },
-      ]),
+      event: spendThresholdEvent(
+        "alerts.spend_threshold_reached",
+        [{ key: "user_id", value: USER_ID }],
+        "alert_default_xxx"
+      ),
       workspace,
     });
 
@@ -761,7 +805,7 @@ describe("processMetronomeWebhook — per-user spend threshold (default alert co
     expect(dispatchPerUserCapResolved).not.toHaveBeenCalled();
   });
 
-  it("override (OK) wins over default (IN_ALARM) — dispatches resolved", async () => {
+  it("override alert ID takes precedence — event matching override dispatches resolved", async () => {
     const workspace = await setupMetronomeWorkspaceResource();
     vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValue(
       new Ok(
@@ -773,7 +817,7 @@ describe("processMetronomeWebhook — per-user spend threshold (default alert co
       )
     );
     vi.mocked(
-      defaultUserCapAlert.getMetronomeDefaultUserCapAlert
+      defaultUserCapAlert.getMetronomeDefaultUserCapAlertForSeatType
     ).mockResolvedValue(
       new Ok(
         mockCustomerAlert({
@@ -784,10 +828,13 @@ describe("processMetronomeWebhook — per-user spend threshold (default alert co
       )
     );
 
+    // Event comes from the override alert (resolved).
     const result = await processMetronomeWebhook({
-      event: spendThresholdEvent("alerts.spend_threshold_reached", [
-        { key: "user_id", value: USER_ID },
-      ]),
+      event: spendThresholdEvent(
+        "alerts.spend_threshold_resolved",
+        [{ key: "user_id", value: USER_ID }],
+        "alert_override_xxx"
+      ),
       workspace,
     });
 
@@ -798,11 +845,11 @@ describe("processMetronomeWebhook — per-user spend threshold (default alert co
     expect(dispatchPerUserCapReached).not.toHaveBeenCalled();
     // Override existed → default lookup was skipped.
     expect(
-      defaultUserCapAlert.getMetronomeDefaultUserCapAlert
+      defaultUserCapAlert.getMetronomeDefaultUserCapAlertForSeatType
     ).not.toHaveBeenCalled();
   });
 
-  it("override (IN_ALARM) wins over default (OK) — dispatches reached", async () => {
+  it("override alert ID takes precedence — event matching override dispatches reached", async () => {
     const workspace = await setupMetronomeWorkspaceResource();
     vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValue(
       new Ok(
@@ -813,22 +860,14 @@ describe("processMetronomeWebhook — per-user spend threshold (default alert co
         })
       )
     );
-    vi.mocked(
-      defaultUserCapAlert.getMetronomeDefaultUserCapAlert
-    ).mockResolvedValue(
-      new Ok(
-        mockCustomerAlert({
-          id: "alert_default_xxx",
-          threshold: 1_000_000,
-          customer_status: "ok",
-        })
-      )
-    );
 
+    // Event comes from the override alert (reached).
     const result = await processMetronomeWebhook({
-      event: spendThresholdEvent("alerts.spend_threshold_resolved", [
-        { key: "user_id", value: USER_ID },
-      ]),
+      event: spendThresholdEvent(
+        "alerts.spend_threshold_reached",
+        [{ key: "user_id", value: USER_ID }],
+        "alert_override_xxx"
+      ),
       workspace,
     });
 
@@ -839,24 +878,25 @@ describe("processMetronomeWebhook — per-user spend threshold (default alert co
     expect(dispatchPerUserCapResolved).not.toHaveBeenCalled();
   });
 
-  it("no-ops when effective state is EVALUATING", async () => {
+  it("ignores event from unrelated alert when override exists", async () => {
     const workspace = await setupMetronomeWorkspaceResource();
-    vi.mocked(
-      defaultUserCapAlert.getMetronomeDefaultUserCapAlert
-    ).mockResolvedValue(
+    vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValue(
       new Ok(
         mockCustomerAlert({
-          id: "alert_default_xxx",
-          threshold: 50_000,
-          customer_status: "evaluating",
+          id: "alert_override_xxx",
+          threshold: 100,
+          customer_status: "in_alarm",
         })
       )
     );
 
+    // Event comes from a different alert (e.g. default for another seat type).
     const result = await processMetronomeWebhook({
-      event: spendThresholdEvent("alerts.spend_threshold_reached", [
-        { key: "user_id", value: USER_ID },
-      ]),
+      event: spendThresholdEvent(
+        "alerts.spend_threshold_reached",
+        [{ key: "user_id", value: USER_ID }],
+        "alert_unrelated_zzz"
+      ),
       workspace,
     });
 

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -34,8 +34,8 @@ import {
   PROGRAMMATIC_WARNING_BALANCE_ALERT_NAME,
 } from "@app/lib/metronome/alerts/programmatic_cap";
 import {
-  getMetronomeDefaultUserCapAlert,
-  getMetronomeDefaultUserWarningAlert,
+  getMetronomeDefaultUserCapAlertForSeatType,
+  getMetronomeDefaultUserWarningAlertForSeatType,
   getMetronomePerUserCap,
   getMetronomePerUserWarningAlert,
 } from "@app/lib/metronome/alerts/spend_limits";
@@ -69,6 +69,7 @@ import type { MetronomeWebhookEvent } from "@app/lib/metronome/webhook_events";
 import { PlanModel } from "@app/lib/models/plan";
 import { notifyUserAwuCapReached } from "@app/lib/notifications/workflows/user-awu-cap-reached";
 import { isFreePlan } from "@app/lib/plans/plan_codes";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -76,13 +77,11 @@ import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { launchScheduleWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
+import { normalizeToPoolLimitSeatType } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { Commit, Credit } from "@metronome/sdk/resources";
-import type { CustomerAlert } from "@metronome/sdk/resources/v1/customers";
-
-type MetronomeAlertState = CustomerAlert["customer_status"];
 
 // Programmatic cap alerts share the AWU credit type with PAYG cap alerts;
 // the `usage_type=programmatic` group filter is what distinguishes them.
@@ -504,27 +503,33 @@ async function ensureWorkOSOrganizationForPaidPlan({
  * webhook arriving later either re-confirms the state or skips (when
  * Metronome is still in `evaluating`).
  */
-async function handlePerUserSpendThresholdEvent({
+type UserSpendAlerts = {
+  capAlertId: string | null;
+  warningAlertId: string | null;
+  capThreshold: number;
+  source: "override" | "default" | "none";
+};
+
+/**
+ * Resolve the Metronome alert IDs that govern this user's spend cap.
+ *
+ * Priority: per-user override > per-seat-type default > none.
+ */
+async function resolveUserSpendAlerts({
+  metronomeCustomerId,
+  workspaceId,
   workspace,
   userId,
-  event,
 }: {
+  metronomeCustomerId: string;
+  workspaceId: string;
   workspace: WorkspaceResource;
   userId: string;
-  event: MetronomeWebhookEvent;
-}): Promise<Result<undefined, ProcessMetronomeWebhookError>> {
-  const metronomeCustomerId = workspace.metronomeCustomerId;
-  if (!metronomeCustomerId) {
-    logger.warn(
-      { eventId: event.id, eventType: event.type, workspaceId: workspace.sId },
-      "[Metronome Webhook] per-user spend threshold event for workspace without metronomeCustomerId, skipping"
-    );
-    return new Ok(undefined);
-  }
-
+}): Promise<Result<UserSpendAlerts, ProcessMetronomeWebhookError>> {
+  // Check for a per-user override first.
   const userCapResult = await getMetronomePerUserCap({
     metronomeCustomerId,
-    workspaceId: workspace.sId,
+    workspaceId,
     userId,
   });
   if (userCapResult.isErr()) {
@@ -536,80 +541,125 @@ async function handlePerUserSpendThresholdEvent({
     );
   }
 
-  let effectiveCapState: MetronomeAlertState;
-  let effectiveWarningState: MetronomeAlertState;
-  let source: "override" | "default" | "none";
-  let capThreshold: number | null | undefined;
-
   if (userCapResult.value) {
-    effectiveCapState = userCapResult.value.customer_status;
-    capThreshold = userCapResult.value.alert.threshold;
-    source = "override";
-
     const userWarningResult = await getMetronomePerUserWarningAlert({
       metronomeCustomerId,
-      workspaceId: workspace.sId,
+      workspaceId,
       userId,
     });
-    if (userWarningResult.isErr()) {
-      logger.warn(
-        {
-          eventId: event.id,
-          workspaceId: workspace.sId,
-          userId,
-          err: userWarningResult.error,
-        },
-        "[Metronome Webhook] per-user spend threshold: failed to read warning alert, skipping notification"
-      );
-      effectiveWarningState = "ok";
-    } else {
-      effectiveWarningState = userWarningResult.value?.customer_status ?? "ok";
-    }
-  } else {
-    const defaultResult = await getMetronomeDefaultUserCapAlert({
-      metronomeCustomerId,
-      workspaceId: workspace.sId,
+    return new Ok({
+      capAlertId: userCapResult.value.alert.id,
+      capThreshold: userCapResult.value.alert.threshold,
+      warningAlertId: userWarningResult.isOk()
+        ? (userWarningResult.value?.alert.id ?? null)
+        : null,
+      source: "override",
     });
-    if (defaultResult.isErr()) {
-      return new Err(
-        new ProcessMetronomeWebhookError(
-          "processing_failed",
-          `Error reading default user cap: ${defaultResult.error.message}`
-        )
-      );
-    }
-    if (defaultResult.value) {
-      effectiveCapState = defaultResult.value.customer_status;
-      capThreshold = defaultResult.value.alert.threshold;
-      source = "default";
-
-      const warningResult = await getMetronomeDefaultUserWarningAlert({
-        metronomeCustomerId,
-        workspaceId: workspace.sId,
-      });
-      if (warningResult.isErr()) {
-        logger.warn(
-          {
-            eventId: event.id,
-            workspaceId: workspace.sId,
-            userId,
-            err: warningResult.error,
-          },
-          "[Metronome Webhook] per-user spend threshold: failed to read default warning alert, skipping notification"
-        );
-        effectiveWarningState = "ok";
-      } else {
-        effectiveWarningState = warningResult.value?.customer_status ?? "ok";
-      }
-    } else {
-      effectiveCapState = "ok";
-      effectiveWarningState = "ok";
-      source = "none";
-    }
   }
 
-  switch (effectiveCapState) {
-    case "in_alarm": {
+  // No override — resolve user's seat type and find the matching default.
+  const user = await UserResource.fetchById(userId);
+  const lightWorkspace = renderLightWorkspaceType({ workspace });
+  const membership = user
+    ? await MembershipResource.getActiveMembershipOfUserInWorkspace({
+        user,
+        workspace: lightWorkspace,
+      })
+    : null;
+  const normalizedSeatType = normalizeToPoolLimitSeatType(membership?.seatType);
+
+  if (!normalizedSeatType) {
+    return new Ok({
+      capAlertId: null,
+      warningAlertId: null,
+      capThreshold: 0,
+      source: "none",
+    });
+  }
+
+  const [defaultCapResult, defaultWarningResult] = await Promise.all([
+    getMetronomeDefaultUserCapAlertForSeatType({
+      metronomeCustomerId,
+      workspaceId,
+      seatType: normalizedSeatType,
+    }),
+    getMetronomeDefaultUserWarningAlertForSeatType({
+      metronomeCustomerId,
+      workspaceId,
+      seatType: normalizedSeatType,
+    }),
+  ]);
+  if (defaultCapResult.isErr()) {
+    return new Err(
+      new ProcessMetronomeWebhookError(
+        "processing_failed",
+        `Error reading default user cap for seat type ${normalizedSeatType}: ${defaultCapResult.error.message}`
+      )
+    );
+  }
+
+  if (!defaultCapResult.value) {
+    return new Ok({
+      capAlertId: null,
+      warningAlertId: null,
+      capThreshold: 0,
+      source: "none",
+    });
+  }
+
+  return new Ok({
+    capAlertId: defaultCapResult.value.alert.id,
+    capThreshold: defaultCapResult.value.alert.threshold,
+    warningAlertId: defaultWarningResult.isOk()
+      ? (defaultWarningResult.value?.alert.id ?? null)
+      : null,
+    source: "default",
+  });
+}
+
+type SpendThresholdEvent = Extract<
+  MetronomeWebhookEvent,
+  {
+    type: "alerts.spend_threshold_reached" | "alerts.spend_threshold_resolved";
+  }
+>;
+
+async function handlePerUserSpendThresholdEvent({
+  workspace,
+  userId,
+  event,
+}: {
+  workspace: WorkspaceResource;
+  userId: string;
+  event: SpendThresholdEvent;
+}): Promise<Result<undefined, ProcessMetronomeWebhookError>> {
+  const metronomeCustomerId = workspace.metronomeCustomerId;
+  if (!metronomeCustomerId) {
+    logger.warn(
+      { eventId: event.id, eventType: event.type, workspaceId: workspace.sId },
+      "[Metronome Webhook] per-user spend threshold event for workspace without metronomeCustomerId, skipping"
+    );
+    return new Ok(undefined);
+  }
+
+  const alertsResult = await resolveUserSpendAlerts({
+    metronomeCustomerId,
+    workspaceId: workspace.sId,
+    workspace,
+    userId,
+  });
+  if (alertsResult.isErr()) {
+    return alertsResult;
+  }
+
+  const { capAlertId, warningAlertId, capThreshold, source } =
+    alertsResult.value;
+  const eventAlertId = event.properties.alert_id;
+  const isReached = event.type === "alerts.spend_threshold_reached";
+
+  if (eventAlertId === capAlertId) {
+    // Cap alert fired for this user.
+    if (isReached) {
       const dispatchResult = await dispatchPerUserCapReached({
         workspace,
         userId,
@@ -618,7 +668,6 @@ async function handlePerUserSpendThresholdEvent({
         logger.error(
           {
             eventId: event.id,
-            eventType: event.type,
             workspaceId: workspace.sId,
             userId,
             source,
@@ -634,24 +683,21 @@ async function handlePerUserSpendThresholdEvent({
         );
       }
       // Notify the user (email + in-app) that they are now hard-blocked.
-      const capAwuCreditsBlocked = capThreshold ?? 0;
-      const blockedUser = await UserResource.fetchById(userId);
-      if (blockedUser) {
+      const user = await UserResource.fetchById(userId);
+      if (user) {
         const lightWorkspace = renderLightWorkspaceType({ workspace });
         notifyUserAwuCapReached({
-          userSId: blockedUser.sId,
-          userEmail: blockedUser.email,
-          userFirstName: blockedUser.firstName,
-          userLastName: blockedUser.lastName,
+          userSId: user.sId,
+          userEmail: user.email,
+          userFirstName: user.firstName,
+          userLastName: user.lastName,
           workspaceId: workspace.sId,
           workspaceName: lightWorkspace.name,
-          capAwuCredits: capAwuCreditsBlocked,
+          capAwuCredits: capThreshold,
           isBlocked: true,
         });
       }
-      break;
-    }
-    case "ok": {
+    } else {
       const dispatchResult = await dispatchPerUserCapResolved({
         workspace,
         userId,
@@ -660,7 +706,6 @@ async function handlePerUserSpendThresholdEvent({
         logger.error(
           {
             eventId: event.id,
-            eventType: event.type,
             workspaceId: workspace.sId,
             userId,
             source,
@@ -676,30 +721,10 @@ async function handlePerUserSpendThresholdEvent({
         );
       }
       void clearUserAwuWarned(workspace.sId, userId);
-      break;
     }
-    case "evaluating":
-    case null:
-      // No-op: Metronome hasn't settled yet (or the alert is archived). The
-      // eager dispatch from `setUserSpendLimit` / `setDefaultUserSpendLimit`
-      // already set the right state; a follow-up event will reconcile.
-      break;
-    default:
-      assertNever(effectiveCapState);
-  }
-
-  // Notify the user (email + in-app) when they've crossed 80% of their AWU cap
-  // but have not yet been hard-blocked. The cap alert fires at 100% and is
-  // handled above; the warning alert fires at 80% and triggers notifications only.
-  if (
-    effectiveWarningState === "in_alarm" &&
-    effectiveCapState !== "in_alarm"
-  ) {
-    logger.info(
-      "[Metronome Webhook] per-user spend threshold warning: handling..."
-    );
+  } else if (eventAlertId === warningAlertId && isReached) {
+    // Warning alert (80%) fired — notify but don't block.
     void setUserAwuWarned(workspace.sId, userId);
-    const capAwuCredits = capThreshold ?? 0;
     const user = await UserResource.fetchById(userId);
     if (user) {
       const lightWorkspace = renderLightWorkspaceType({ workspace });
@@ -710,24 +735,25 @@ async function handlePerUserSpendThresholdEvent({
         userLastName: user.lastName,
         workspaceId: workspace.sId,
         workspaceName: lightWorkspace.name,
-        capAwuCredits,
+        capAwuCredits: capThreshold,
         isBlocked: false,
       });
     }
+  } else {
+    // Event is from an unrelated alert (e.g. a different seat type) — ignore.
+    logger.info(
+      {
+        eventId: event.id,
+        eventType: event.type,
+        workspaceId: workspace.sId,
+        userId,
+        eventAlertId,
+        source,
+      },
+      "[Metronome Webhook] per-user spend threshold: event does not match user's alerts, ignoring"
+    );
   }
 
-  logger.info(
-    {
-      eventId: event.id,
-      eventType: event.type,
-      workspaceId: workspace.sId,
-      userId,
-      effectiveCapState,
-      effectiveWarningState,
-      source,
-    },
-    "[Metronome Webhook] per-user spend threshold: handled"
-  );
   return new Ok(undefined);
 }
 

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -12,15 +12,23 @@ import type { Authenticator } from "@app/lib/auth";
 import {
   clearMetronomePerUserCapAlert,
   clearMetronomePerUserWarningAlert,
-  getMetronomeDefaultUserCapAlert,
+  getMetronomeDefaultUserCapAlertForSeatType,
   getMetronomePerUserCap,
   upsertMetronomePerUserCapAlert,
   upsertMetronomePerUserWarningAlert,
 } from "@app/lib/metronome/alerts/spend_limits";
 import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
+import { getActiveContract } from "@app/lib/metronome/plan_type";
+import {
+  getAwuAllocationForSeatType,
+  getProductSeatTypes,
+} from "@app/lib/metronome/seat_types";
 import { clearUserAwuWarned } from "@app/lib/metronome/user_block";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
+import { normalizeToPoolLimitSeatType } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -55,6 +63,37 @@ export class UserSpendLimitError extends Error {
   ) {
     super(message);
   }
+}
+
+/**
+ * Resolve the seat AWU allowance for a user based on their membership seat
+ * type and the active contract. Returns 0 when the contract or seat type
+ * can't be resolved (e.g. free seats, no contract).
+ */
+async function resolveUserSeatAllowance(
+  auth: Authenticator,
+  user: UserResource
+): Promise<number> {
+  const workspace = auth.getNonNullableWorkspace();
+  const membership =
+    await MembershipResource.getActiveMembershipOfUserInWorkspace({
+      user,
+      workspace,
+    });
+  const normalizedSeatType = normalizeToPoolLimitSeatType(membership?.seatType);
+  if (!normalizedSeatType) {
+    return 0;
+  }
+  const contract = await getActiveContract(workspace.sId);
+  if (!contract) {
+    return 0;
+  }
+  const productSeatTypes = await getProductSeatTypes();
+  return getAwuAllocationForSeatType(
+    contract,
+    normalizedSeatType,
+    productSeatTypes
+  );
 }
 
 export async function getUserSpendLimit(
@@ -95,7 +134,12 @@ export async function getUserSpendLimit(
   if (!result.value) {
     return new Ok({ kind: "unlimited" });
   }
-  return new Ok({ kind: "limited", awuCredits: result.value.alert.threshold });
+
+  // The Metronome threshold includes the seat allowance. Subtract it to
+  // return the pool-only portion (what the admin entered).
+  const seatAllowance = await resolveUserSeatAllowance(auth, user);
+  const poolAwuCredits = result.value.alert.threshold - seatAllowance;
+  return new Ok({ kind: "limited", awuCredits: poolAwuCredits });
 }
 
 /**
@@ -243,19 +287,33 @@ export async function setUserSpendLimit(
       }
       void clearUserAwuWarned(workspace.sId, user.sId);
 
-      const defaultResult = await getMetronomeDefaultUserCapAlert({
-        metronomeCustomerId: workspace.metronomeCustomerId,
-        workspaceId: workspace.sId,
-      });
-      if (defaultResult.isErr()) {
-        return new Err(
-          new UserSpendLimitError(
-            "metronome_error",
-            defaultResult.error.message
-          )
-        );
+      // Look up the user's seat type to find the matching default cap.
+      const membership =
+        await MembershipResource.getActiveMembershipOfUserInWorkspace({
+          user,
+          workspace,
+        });
+      const normalizedSeatType = normalizeToPoolLimitSeatType(
+        membership?.seatType
+      );
+
+      let defaultAlert = null;
+      if (normalizedSeatType) {
+        const defaultResult = await getMetronomeDefaultUserCapAlertForSeatType({
+          metronomeCustomerId: workspace.metronomeCustomerId,
+          workspaceId: workspace.sId,
+          seatType: normalizedSeatType,
+        });
+        if (defaultResult.isErr()) {
+          return new Err(
+            new UserSpendLimitError(
+              "metronome_error",
+              defaultResult.error.message
+            )
+          );
+        }
+        defaultAlert = defaultResult.value;
       }
-      const defaultAlert = defaultResult.value;
 
       if (defaultAlert) {
         transitionedTo = await resolveLocalCapState({
@@ -279,11 +337,16 @@ export async function setUserSpendLimit(
       break;
     }
     case "limited": {
+      // The admin enters pool credits. Add the seat allowance to get the
+      // total Metronome threshold.
+      const seatAllowance = await resolveUserSeatAllowance(auth, user);
+      const totalAwuCredits = limit.awuCredits + seatAllowance;
+
       const upsertResult = await upsertMetronomePerUserCapAlert({
         metronomeCustomerId: workspace.metronomeCustomerId,
         workspaceId: workspace.sId,
         userId: user.sId,
-        awuCredits: limit.awuCredits,
+        awuCredits: totalAwuCredits,
       });
       if (upsertResult.isErr()) {
         return new Err(
@@ -296,14 +359,14 @@ export async function setUserSpendLimit(
         metronomeCustomerId: workspace.metronomeCustomerId,
         workspaceId: workspace.sId,
         userId: user.sId,
-        capAwuCredits: limit.awuCredits,
+        capAwuCredits: totalAwuCredits,
       });
       if (upsertWarningResult.isErr()) {
         logger.warn(
           {
             workspaceId: workspace.sId,
             userId: user.sId,
-            awuCredits: limit.awuCredits,
+            awuCredits: totalAwuCredits,
             err: upsertWarningResult.error,
           },
           "[Metronome PerUserCap] Failed to upsert warning alert; continuing"
@@ -314,7 +377,7 @@ export async function setUserSpendLimit(
         metronomeCustomerId: workspace.metronomeCustomerId,
         metronomeContractId: auth.subscription()?.metronomeContractId ?? null,
         userId: user.sId,
-        awuCapCredits: limit.awuCredits,
+        awuCapCredits: totalAwuCredits,
       });
       if (transitionedTo !== null) {
         await dispatchTransition({

--- a/front/lib/api/workspace/default_user_spend_limit.test.ts
+++ b/front/lib/api/workspace/default_user_spend_limit.test.ts
@@ -5,9 +5,13 @@ import {
 } from "@app/lib/api/workspace/default_user_spend_limit";
 import { Authenticator } from "@app/lib/auth";
 import * as defaultUserCapAlert from "@app/lib/metronome/alerts/spend_limits";
+import * as planType from "@app/lib/metronome/plan_type";
+import * as seatTypes from "@app/lib/metronome/seat_types";
 import { buildCustomerAlertMock } from "@app/tests/utils/metronome_alerts";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { MembershipSeatType } from "@app/types/memberships";
 import { Err, Ok } from "@app/types/shared/result";
+import type { Subscription } from "@metronome/sdk/resources";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/metronome/alerts/spend_limits", async () => {
@@ -16,8 +20,9 @@ vi.mock("@app/lib/metronome/alerts/spend_limits", async () => {
   );
   return {
     ...actual,
-    getMetronomeDefaultUserCapAlert: vi.fn(),
-    upsertMetronomeDefaultUserCapAlert: vi.fn(),
+    getMetronomeDefaultUserCapAlertForSeatType: vi.fn(),
+    upsertMetronomeDefaultUserCapAlertForSeatType: vi.fn(),
+    upsertMetronomeDefaultUserWarningAlertForSeatType: vi.fn(),
   };
 });
 
@@ -31,27 +36,78 @@ vi.mock("@app/lib/api/audit/workos_audit", async () => {
   };
 });
 
+vi.mock("@app/lib/metronome/plan_type", async () => {
+  const actual = await vi.importActual<typeof planType>(
+    "@app/lib/metronome/plan_type"
+  );
+  return {
+    ...actual,
+    getActiveContract: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/metronome/seat_types", async () => {
+  const actual = await vi.importActual<typeof seatTypes>(
+    "@app/lib/metronome/seat_types"
+  );
+  return {
+    ...actual,
+    getProductSeatTypes: vi.fn(),
+    getSeatSubscriptionsFromContract: vi.fn(),
+    getAwuAllocationForSeatType: vi.fn(),
+  };
+});
+
 const METRONOME_CUSTOMER_ID = "cust_test_xxx";
 const AUDIT_CONTEXT = { location: "127.0.0.1" };
 
+// Minimal fake contract and seat type setup.
+const FAKE_CONTRACT = {
+  id: "contract_xxx",
+  customer_id: METRONOME_CUSTOMER_ID,
+  rate_card_id: "rc_xxx",
+  subscriptions: [],
+} as unknown as planType.CachedContract;
+
+const FAKE_PRODUCT_SEAT_TYPES = new Map([["prod_pro", "pro" as const]]);
+const FAKE_SEAT_SUBSCRIPTIONS = new Map<MembershipSeatType, Subscription>([
+  [
+    "pro",
+    { subscription_rate: { product: { id: "prod_pro" } } } as Subscription,
+  ],
+]);
+
 beforeEach(() => {
   vi.mocked(
-    defaultUserCapAlert.getMetronomeDefaultUserCapAlert
+    defaultUserCapAlert.getMetronomeDefaultUserCapAlertForSeatType
   ).mockResolvedValue(new Ok(null));
   vi.mocked(
-    defaultUserCapAlert.upsertMetronomeDefaultUserCapAlert
+    defaultUserCapAlert.upsertMetronomeDefaultUserCapAlertForSeatType
   ).mockResolvedValue(new Ok({ alertId: "alert_default_xxx" }));
+  vi.mocked(
+    defaultUserCapAlert.upsertMetronomeDefaultUserWarningAlertForSeatType
+  ).mockResolvedValue(new Ok({ alertId: "alert_warning_xxx" }));
   vi.mocked(workosAudit.emitAuditLogEvent).mockResolvedValue(undefined);
+
+  // Contract + seat type mocks for setDefaultUserSpendLimit.
+  vi.mocked(planType.getActiveContract).mockResolvedValue(FAKE_CONTRACT);
+  vi.mocked(seatTypes.getProductSeatTypes).mockResolvedValue(
+    FAKE_PRODUCT_SEAT_TYPES
+  );
+  vi.mocked(seatTypes.getSeatSubscriptionsFromContract).mockReturnValue(
+    FAKE_SEAT_SUBSCRIPTIONS
+  );
+  vi.mocked(seatTypes.getAwuAllocationForSeatType).mockReturnValue(8000);
 });
 
 describe("getDefaultUserSpendLimit", () => {
-  it("returns the configured threshold", async () => {
+  it("returns the configured threshold minus seat allowance", async () => {
     const workspace = await WorkspaceFactory.metronome({
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
     });
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
     vi.mocked(
-      defaultUserCapAlert.getMetronomeDefaultUserCapAlert
+      defaultUserCapAlert.getMetronomeDefaultUserCapAlertForSeatType
     ).mockResolvedValue(
       new Ok(
         buildCustomerAlertMock({
@@ -66,7 +122,8 @@ describe("getDefaultUserSpendLimit", () => {
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value).toEqual({ awuCredits: 50_000 });
+      // 50_000 (Metronome threshold) - 8_000 (seat allowance) = 42_000
+      expect(result.value).toEqual({ awuCredits: 42_000 });
     }
   });
 
@@ -94,9 +151,8 @@ describe("getDefaultUserSpendLimit", () => {
     if (result.isErr()) {
       expect(result.error.type).toBe("workspace_not_metronome_billed");
     }
-    // Should not even talk to Metronome when the workspace isn't billed there.
     expect(
-      defaultUserCapAlert.getMetronomeDefaultUserCapAlert
+      defaultUserCapAlert.getMetronomeDefaultUserCapAlertForSeatType
     ).not.toHaveBeenCalled();
   });
 
@@ -106,7 +162,7 @@ describe("getDefaultUserSpendLimit", () => {
     });
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
     vi.mocked(
-      defaultUserCapAlert.getMetronomeDefaultUserCapAlert
+      defaultUserCapAlert.getMetronomeDefaultUserCapAlertForSeatType
     ).mockResolvedValue(new Err(new Error("metronome down")));
 
     const result = await getDefaultUserSpendLimit(auth);
@@ -119,7 +175,7 @@ describe("getDefaultUserSpendLimit", () => {
 });
 
 describe("setDefaultUserSpendLimit", () => {
-  it("upserts the alert with the new threshold and returns the updated value", async () => {
+  it("upserts per-seat-type alert with seat allowance added to pool limit", async () => {
     const workspace = await WorkspaceFactory.metronome({
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
     });
@@ -134,27 +190,29 @@ describe("setDefaultUserSpendLimit", () => {
     if (result.isOk()) {
       expect(result.value).toEqual({ awuCredits: 25_000 });
     }
+    // Metronome threshold = 8_000 (seat) + 25_000 (pool) = 33_000
     expect(
-      defaultUserCapAlert.upsertMetronomeDefaultUserCapAlert
+      defaultUserCapAlert.upsertMetronomeDefaultUserCapAlertForSeatType
     ).toHaveBeenCalledWith({
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
       workspaceId: workspace.sId,
-      awuCredits: 25_000,
+      seatType: "pro",
+      awuCredits: 33_000,
     });
   });
 
-  it("emits an audit event with previous and new thresholds", async () => {
+  it("emits an audit event with previous and new pool limits", async () => {
     const workspace = await WorkspaceFactory.metronome({
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
     });
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
     vi.mocked(
-      defaultUserCapAlert.getMetronomeDefaultUserCapAlert
+      defaultUserCapAlert.getMetronomeDefaultUserCapAlertForSeatType
     ).mockResolvedValue(
       new Ok(
         buildCustomerAlertMock({
           id: "alert_default_xxx",
-          threshold: 10_000,
+          threshold: 18_000, // 8_000 seat + 10_000 pool
           customerStatus: "ok",
         })
       )
@@ -213,9 +271,8 @@ describe("setDefaultUserSpendLimit", () => {
         expect(result.error.type).toBe("invalid_threshold");
       }
     }
-    // No Metronome side effects on validation failures.
     expect(
-      defaultUserCapAlert.upsertMetronomeDefaultUserCapAlert
+      defaultUserCapAlert.upsertMetronomeDefaultUserCapAlertForSeatType
     ).not.toHaveBeenCalled();
     expect(workosAudit.emitAuditLogEvent).not.toHaveBeenCalled();
   });
@@ -234,8 +291,27 @@ describe("setDefaultUserSpendLimit", () => {
       expect(result.error.type).toBe("workspace_not_metronome_billed");
     }
     expect(
-      defaultUserCapAlert.upsertMetronomeDefaultUserCapAlert
+      defaultUserCapAlert.upsertMetronomeDefaultUserCapAlertForSeatType
     ).not.toHaveBeenCalled();
+  });
+
+  it("returns contract_not_found when no active contract exists", async () => {
+    const workspace = await WorkspaceFactory.metronome({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    vi.mocked(planType.getActiveContract).mockResolvedValue(null);
+
+    const result = await setDefaultUserSpendLimit(auth, {
+      awuCredits: 1000,
+      auditContext: AUDIT_CONTEXT,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.type).toBe("contract_not_found");
+    }
+    expect(workosAudit.emitAuditLogEvent).not.toHaveBeenCalled();
   });
 
   it("surfaces upsert failures as metronome_error and skips audit", async () => {
@@ -244,7 +320,7 @@ describe("setDefaultUserSpendLimit", () => {
     });
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
     vi.mocked(
-      defaultUserCapAlert.upsertMetronomeDefaultUserCapAlert
+      defaultUserCapAlert.upsertMetronomeDefaultUserCapAlertForSeatType
     ).mockResolvedValue(new Err(new Error("metronome down")));
 
     const result = await setDefaultUserSpendLimit(auth, {

--- a/front/lib/api/workspace/default_user_spend_limit.ts
+++ b/front/lib/api/workspace/default_user_spend_limit.ts
@@ -5,15 +5,26 @@ import {
 import type { AuditLogContext } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
 import {
-  getMetronomeDefaultUserCapAlert,
-  upsertMetronomeDefaultUserCapAlert,
-  upsertMetronomeDefaultUserWarningAlert,
+  getMetronomeDefaultUserCapAlertForSeatType,
+  upsertMetronomeDefaultUserCapAlertForSeatType,
+  upsertMetronomeDefaultUserWarningAlertForSeatType,
 } from "@app/lib/metronome/alerts/spend_limits";
+import { getActiveContract } from "@app/lib/metronome/plan_type";
+import {
+  getAwuAllocationForSeatType,
+  getProductSeatTypes,
+  getSeatSubscriptionsFromContract,
+} from "@app/lib/metronome/seat_types";
 import logger from "@app/logger/logger";
 import {
   MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
   MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
 } from "@app/types/credits";
+import {
+  NORMALIZED_POOL_LIMIT_SEAT_TYPES,
+  type NormalizedPoolLimitSeatType,
+  normalizeToPoolLimitSeatType,
+} from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -25,7 +36,8 @@ export type DefaultUserSpendLimitErrorType =
   | "workspace_not_metronome_billed"
   | "metronome_error"
   | "not_found"
-  | "invalid_threshold";
+  | "invalid_threshold"
+  | "contract_not_found";
 
 export class DefaultUserSpendLimitError extends Error {
   constructor(
@@ -36,6 +48,13 @@ export class DefaultUserSpendLimitError extends Error {
   }
 }
 
+/**
+ * Read the default pool credit limit for the workspace. Reads per-seat-type
+ * alerts and recovers the pool limit by subtracting the seat allowance.
+ *
+ * Since all seat types share the same pool limit, we read the first
+ * per-seat-type alert we find and subtract its seat type's AWU allocation.
+ */
 export async function getDefaultUserSpendLimit(
   auth: Authenticator
 ): Promise<Result<DefaultUserSpendLimit, DefaultUserSpendLimitError>> {
@@ -49,40 +68,51 @@ export async function getDefaultUserSpendLimit(
     );
   }
 
-  const result = await getMetronomeDefaultUserCapAlert({
-    metronomeCustomerId: workspace.metronomeCustomerId,
-    workspaceId: workspace.sId,
-  });
-  if (result.isErr()) {
-    return new Err(
-      new DefaultUserSpendLimitError("metronome_error", result.error.message)
-    );
+  const contract = await getActiveContract(workspace.sId);
+  const productSeatTypes = contract ? await getProductSeatTypes() : null;
+
+  // Try each normalized seat type until we find one with an alert configured.
+  for (const seatType of NORMALIZED_POOL_LIMIT_SEAT_TYPES) {
+    const result = await getMetronomeDefaultUserCapAlertForSeatType({
+      metronomeCustomerId: workspace.metronomeCustomerId,
+      workspaceId: workspace.sId,
+      seatType,
+    });
+    if (result.isErr()) {
+      return new Err(
+        new DefaultUserSpendLimitError("metronome_error", result.error.message)
+      );
+    }
+    if (result.value) {
+      const totalThreshold = result.value.alert.threshold;
+      const seatAllowance =
+        contract && productSeatTypes
+          ? getAwuAllocationForSeatType(contract, seatType, productSeatTypes)
+          : 0;
+      return new Ok({ awuCredits: totalThreshold - seatAllowance });
+    }
   }
-  if (!result.value) {
-    return new Err(
-      new DefaultUserSpendLimitError(
-        "not_found",
-        "No default per-user spend limit configured for this workspace."
-      )
-    );
-  }
-  return new Ok({ awuCredits: result.value.alert.threshold });
+
+  return new Err(
+    new DefaultUserSpendLimitError(
+      "not_found",
+      "No default per-user spend limit configured for this workspace."
+    )
+  );
 }
 
 /**
- * Update the workspace-wide default per-user spend limit.
+ * Update the workspace-wide default pool credit limit.
  *
- * Per-user state transitions are NOT dispatched eagerly here: that would be
- * O(members) work and adds little value for a policy change. The Metronome
- * webhook handler fans out `reached` / `resolved` events as users cross
- * the new threshold, and `process_webhook.ts` re-derives effective state
- * (override > default > uncapped) on every per-user event — so the right
- * state lands per user once Metronome has finished evaluating.
+ * Creates one Metronome alert per seat type on the contract. Each alert's
+ * threshold = seatAllowance + poolAwuCredits so that the limit only
+ * concerns pool credits, not the seat allowance.
+ *
  */
 export async function setDefaultUserSpendLimit(
   auth: Authenticator,
   {
-    awuCredits,
+    awuCredits: poolAwuCredits,
     auditContext,
   }: {
     awuCredits: number;
@@ -90,9 +120,10 @@ export async function setDefaultUserSpendLimit(
   }
 ): Promise<Result<DefaultUserSpendLimit, DefaultUserSpendLimitError>> {
   if (
-    !Number.isInteger(awuCredits) ||
-    awuCredits < MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS ||
-    awuCredits > MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS
+    // TODO: allow O, not reason not to.
+    !Number.isInteger(poolAwuCredits) ||
+    poolAwuCredits < MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS ||
+    poolAwuCredits > MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS
   ) {
     return new Err(
       new DefaultUserSpendLimitError(
@@ -113,47 +144,82 @@ export async function setDefaultUserSpendLimit(
   }
   const { metronomeCustomerId } = workspace;
 
-  // Read previous threshold for audit metadata. Best-effort: if the lookup
-  // fails or no alert exists yet, we still proceed with the upsert.
-  const previousResult = await getMetronomeDefaultUserCapAlert({
-    metronomeCustomerId,
-    workspaceId: workspace.sId,
-  });
-  const previousAwuCredits = previousResult.isOk()
-    ? (previousResult.value?.alert.threshold ?? null)
-    : null;
-
-  const upsertResult = await upsertMetronomeDefaultUserCapAlert({
-    metronomeCustomerId,
-    workspaceId: workspace.sId,
-    awuCredits,
-  });
-  if (upsertResult.isErr()) {
+  const contract = await getActiveContract(workspace.sId);
+  if (!contract) {
     return new Err(
       new DefaultUserSpendLimitError(
-        "metronome_error",
-        upsertResult.error.message
+        "contract_not_found",
+        "No active contract found for this workspace."
       )
     );
   }
+  const productSeatTypes = await getProductSeatTypes();
 
-  // Upsert a companion 80% warning alert so users get advance notice before
-  // the hard block fires. Errors are logged but don't fail the whole operation.
-  const warningResult = await upsertMetronomeDefaultUserWarningAlert({
-    metronomeCustomerId,
-    workspaceId: workspace.sId,
-    capAwuCredits: awuCredits,
-  });
-  if (warningResult.isErr()) {
-    logger.warn(
-      {
-        workspaceId: workspace.sId,
-        metronomeCustomerId,
-        awuCredits,
-        err: warningResult.error,
-      },
-      "[DefaultUserSpendLimit] Failed to upsert warning alert; continuing"
+  // Determine which seat types the contract actually sells.
+  const seatSubscriptions = getSeatSubscriptionsFromContract(
+    contract,
+    productSeatTypes
+  );
+
+  // Normalize to pool-limit seat types (dedup monthly/yearly).
+  const normalizedSeatTypes = new Set<NormalizedPoolLimitSeatType>();
+  for (const seatType of seatSubscriptions.keys()) {
+    const normalized = normalizeToPoolLimitSeatType(seatType);
+    if (normalized) {
+      normalizedSeatTypes.add(normalized);
+    }
+  }
+
+  // Read previous pool limit for audit metadata (best-effort).
+  const previousResult = await getDefaultUserSpendLimit(auth);
+  const previousAwuCredits = previousResult.isOk()
+    ? previousResult.value.awuCredits
+    : null;
+
+  // Create per-seat-type alerts.
+  for (const seatType of normalizedSeatTypes) {
+    const seatAllowance = getAwuAllocationForSeatType(
+      contract,
+      seatType,
+      productSeatTypes
     );
+    const totalThreshold = seatAllowance + poolAwuCredits;
+
+    const upsertResult = await upsertMetronomeDefaultUserCapAlertForSeatType({
+      metronomeCustomerId,
+      workspaceId: workspace.sId,
+      seatType,
+      awuCredits: totalThreshold,
+    });
+    if (upsertResult.isErr()) {
+      return new Err(
+        new DefaultUserSpendLimitError(
+          "metronome_error",
+          upsertResult.error.message
+        )
+      );
+    }
+
+    // 80% warning alert. Errors are logged but don't fail the operation.
+    const warningResult =
+      await upsertMetronomeDefaultUserWarningAlertForSeatType({
+        metronomeCustomerId,
+        workspaceId: workspace.sId,
+        seatType,
+        capAwuCredits: totalThreshold,
+      });
+    if (warningResult.isErr()) {
+      logger.warn(
+        {
+          workspaceId: workspace.sId,
+          seatType,
+          metronomeCustomerId,
+          poolAwuCredits,
+          err: warningResult.error,
+        },
+        "[DefaultUserSpendLimit] Failed to upsert warning alert for seat type; continuing"
+      );
+    }
   }
 
   void emitAuditLogEvent({
@@ -164,9 +230,9 @@ export async function setDefaultUserSpendLimit(
     metadata: {
       previous_awu_credits:
         previousAwuCredits !== null ? String(previousAwuCredits) : "unset",
-      new_awu_credits: String(awuCredits),
+      new_awu_credits: String(poolAwuCredits),
     },
   });
 
-  return new Ok({ awuCredits });
+  return new Ok({ awuCredits: poolAwuCredits });
 }

--- a/front/lib/metronome/alerts/spend_limits.test.ts
+++ b/front/lib/metronome/alerts/spend_limits.test.ts
@@ -1,7 +1,7 @@
 import * as alerts from "@app/lib/metronome/alerts";
 import {
-  getMetronomeDefaultUserCapAlert,
-  upsertMetronomeDefaultUserCapAlert,
+  getMetronomeDefaultUserCapAlertForSeatType,
+  upsertMetronomeDefaultUserCapAlertForSeatType,
 } from "@app/lib/metronome/alerts/spend_limits";
 import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
 import { mockCustomerAlert } from "@app/tests/utils/mocks/metronome";
@@ -27,27 +27,29 @@ beforeEach(() => {
   vi.mocked(alerts.upsertMetronomeAlert).mockReset();
 });
 
-describe("getMetronomeDefaultUserCapAlert", () => {
+describe("getMetronomeDefaultUserCapAlertForSeatType", () => {
   it("queries by the workspace-scoped uniqueness key", async () => {
     vi.mocked(alerts.findMetronomeAlert).mockResolvedValue(new Ok(null));
 
-    await getMetronomeDefaultUserCapAlert({
+    await getMetronomeDefaultUserCapAlertForSeatType({
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
       workspaceId: WORKSPACE_ID,
+      seatType: "pro",
     });
 
     expect(alerts.findMetronomeAlert).toHaveBeenCalledWith({
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
-      uniquenessKey: `default-user-cap-${WORKSPACE_ID}`,
+      uniquenessKey: `default-user-cap-pro-${WORKSPACE_ID}`,
     });
   });
 
   it("returns null when no alert is configured", async () => {
     vi.mocked(alerts.findMetronomeAlert).mockResolvedValue(new Ok(null));
 
-    const result = await getMetronomeDefaultUserCapAlert({
+    const result = await getMetronomeDefaultUserCapAlertForSeatType({
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
       workspaceId: WORKSPACE_ID,
+      seatType: "pro",
     });
 
     expect(result.isOk()).toBe(true);
@@ -61,13 +63,14 @@ describe("getMetronomeDefaultUserCapAlert", () => {
       id: "alert_default_xxx",
       threshold: 50_000,
       customer_status: "ok",
-      uniqueness_key: `default-user-cap-${WORKSPACE_ID}`,
+      uniqueness_key: `default-user-cap-pro-${WORKSPACE_ID}`,
     });
     vi.mocked(alerts.findMetronomeAlert).mockResolvedValue(new Ok(alert));
 
-    const result = await getMetronomeDefaultUserCapAlert({
+    const result = await getMetronomeDefaultUserCapAlertForSeatType({
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
       workspaceId: WORKSPACE_ID,
+      seatType: "pro",
     });
 
     expect(result.isOk()).toBe(true);
@@ -81,9 +84,10 @@ describe("getMetronomeDefaultUserCapAlert", () => {
       new Err(new Error("metronome down"))
     );
 
-    const result = await getMetronomeDefaultUserCapAlert({
+    const result = await getMetronomeDefaultUserCapAlertForSeatType({
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
       workspaceId: WORKSPACE_ID,
+      seatType: "pro",
     });
 
     expect(result.isErr()).toBe(true);
@@ -93,29 +97,30 @@ describe("getMetronomeDefaultUserCapAlert", () => {
   });
 });
 
-describe("upsertMetronomeDefaultUserCapAlert", () => {
+describe("upsertMetronomeDefaultUserCapAlertForSeatType", () => {
   it("upserts a spend_threshold_reached alert with a no-value user_id group fan-out", async () => {
     vi.mocked(alerts.upsertMetronomeAlert).mockResolvedValue(
       new Ok({ alertId: "alert_default_xxx" })
     );
 
-    const result = await upsertMetronomeDefaultUserCapAlert({
+    const result = await upsertMetronomeDefaultUserCapAlertForSeatType({
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
       workspaceId: WORKSPACE_ID,
+      seatType: "pro",
       awuCredits: 50_000,
     });
 
     expect(result.isOk()).toBe(true);
     expect(alerts.upsertMetronomeAlert).toHaveBeenCalledWith({
       alert_type: "spend_threshold_reached",
-      name: `Default per-user cap ${WORKSPACE_ID} (50000 AWU)`,
+      name: `Default per-user cap pro ${WORKSPACE_ID} (50000 AWU)`,
       threshold: 50_000,
       credit_type_id: getCreditTypeAwuId(),
       customer_id: METRONOME_CUSTOMER_ID,
       // Fan-out marker: `user_id` key with no `value` tells Metronome to
       // emit one event per user that crosses the threshold.
       group_values: [{ key: "user_id" }],
-      uniqueness_key: `default-user-cap-${WORKSPACE_ID}`,
+      uniqueness_key: `default-user-cap-pro-${WORKSPACE_ID}`,
     });
   });
 
@@ -124,9 +129,10 @@ describe("upsertMetronomeDefaultUserCapAlert", () => {
       new Ok({ alertId: "alert_default_xxx" })
     );
 
-    const result = await upsertMetronomeDefaultUserCapAlert({
+    const result = await upsertMetronomeDefaultUserCapAlertForSeatType({
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
       workspaceId: WORKSPACE_ID,
+      seatType: "pro",
       awuCredits: 50_000,
     });
 
@@ -141,9 +147,10 @@ describe("upsertMetronomeDefaultUserCapAlert", () => {
       new Err(new Error("metronome down"))
     );
 
-    const result = await upsertMetronomeDefaultUserCapAlert({
+    const result = await upsertMetronomeDefaultUserCapAlertForSeatType({
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
       workspaceId: WORKSPACE_ID,
+      seatType: "pro",
       awuCredits: 50_000,
     });
 

--- a/front/lib/metronome/alerts/spend_limits.ts
+++ b/front/lib/metronome/alerts/spend_limits.ts
@@ -10,6 +10,8 @@ import {
   cacheWithRedis,
 } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
+import type { NormalizedPoolLimitSeatType } from "@app/types/memberships";
+import { NORMALIZED_POOL_LIMIT_SEAT_TYPES } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -25,8 +27,19 @@ function warningAwuCredits(capAwuCredits: number): number {
   return Math.floor(capAwuCredits * USER_AWU_WARNING_PERCENTAGE);
 }
 
-function defaultUserCapAlertUniquenessKey(workspaceId: string): string {
-  return `default-user-cap-${workspaceId}`;
+// Per-seat-type default alert uniqueness keys.
+function defaultUserCapAlertUniquenessKeyForSeatType(
+  seatType: NormalizedPoolLimitSeatType,
+  workspaceId: string
+): string {
+  return `default-user-cap-${seatType}-${workspaceId}`;
+}
+
+function defaultUserWarningAlertUniquenessKeyForSeatType(
+  seatType: NormalizedPoolLimitSeatType,
+  workspaceId: string
+): string {
+  return `default-user-warning-${seatType}-${workspaceId}`;
 }
 
 function perUserAlertUniquenessKeyPrefix(workspaceId: string): string {
@@ -38,10 +51,6 @@ function perUserAlertUniquenessKey(
   userId: string
 ): string {
   return `${perUserAlertUniquenessKeyPrefix(workspaceId)}${userId}`;
-}
-
-function defaultUserWarningAlertUniquenessKey(workspaceId: string): string {
-  return `default-user-warning-${workspaceId}`;
 }
 
 function perUserWarningAlertUniquenessKeyPrefix(workspaceId: string): string {
@@ -56,53 +65,60 @@ function perUserWarningAlertUniquenessKey(
 }
 
 /**
- * Look up the workspace-wide default per-user cap alert. Returns the alert
+ * Look up the per-seat-type default per-user cap alert. Returns the alert
  * id, threshold and current Metronome evaluation state, or `null` if no
- * default cap has been configured yet.
+ * cap has been configured for this seat type.
  *
- * The default alert is fanned out per `user_id` by Metronome: it uses
- * `group_values: [{ key: "user_id" }]` with no value, so a single alert
- * configuration produces per-user `reached` / `resolved` events.
+ * Each seat type has its own alert with threshold = seatAllowance + poolLimit.
+ * Fan-out: `group_values: [{ key: "user_id" }]` with no value — Metronome
+ * fires per-user `reached` / `resolved` events.
  */
-export async function getMetronomeDefaultUserCapAlert({
+export async function getMetronomeDefaultUserCapAlertForSeatType({
   metronomeCustomerId,
   workspaceId,
+  seatType,
 }: {
   metronomeCustomerId: string;
   workspaceId: string;
+  seatType: NormalizedPoolLimitSeatType;
 }): Promise<Result<CustomerAlert | null, Error>> {
   return findMetronomeAlert({
     metronomeCustomerId,
-    uniquenessKey: defaultUserCapAlertUniquenessKey(workspaceId),
+    uniquenessKey: defaultUserCapAlertUniquenessKeyForSeatType(
+      seatType,
+      workspaceId
+    ),
   });
 }
 
 /**
- * Idempotently ensure a workspace-wide default per-user cap alert exists on
- * the customer, with the given AWU threshold. If an alert with a different
- * threshold already exists, it's archived (with key release) and recreated.
- *
- * Fan-out: `group_values: [{ key: "user_id" }]` with no value — Metronome
- * fires one `reached` / `resolved` event per user that crosses the threshold,
- * with that user's id populated in `group_values[].value`.
+ * Idempotently ensure a per-seat-type default per-user cap alert exists on
+ * the customer, with the given AWU threshold (seatAllowance + poolLimit,
+ * computed by the caller). If an alert with a different threshold already
+ * exists, it's archived (with key release) and recreated.
  */
-export async function upsertMetronomeDefaultUserCapAlert({
+export async function upsertMetronomeDefaultUserCapAlertForSeatType({
   metronomeCustomerId,
   workspaceId,
+  seatType,
   awuCredits,
 }: {
   metronomeCustomerId: string;
   workspaceId: string;
+  seatType: NormalizedPoolLimitSeatType;
   awuCredits: number;
 }): Promise<Result<{ alertId: string }, Error>> {
   const upsertResult = await upsertMetronomeAlert({
     alert_type: "spend_threshold_reached",
-    name: `Default per-user cap ${workspaceId} (${awuCredits} AWU)`,
+    name: `Default per-user cap ${seatType} ${workspaceId} (${awuCredits} AWU)`,
     threshold: awuCredits,
     credit_type_id: getCreditTypeAwuId(),
     customer_id: metronomeCustomerId,
     group_values: [{ key: USER_ID_GROUP_KEY }],
-    uniqueness_key: defaultUserCapAlertUniquenessKey(workspaceId),
+    uniqueness_key: defaultUserCapAlertUniquenessKeyForSeatType(
+      seatType,
+      workspaceId
+    ),
   });
   if (upsertResult.isErr()) {
     return new Err(upsertResult.error);
@@ -111,13 +127,14 @@ export async function upsertMetronomeDefaultUserCapAlert({
   logger.info(
     {
       workspaceId,
+      seatType,
       metronomeCustomerId,
       alertId: upsertResult.value.alertId,
       awuCredits,
     },
-    "[Metronome DefaultUserCap] Synced default per-user cap alert"
+    "[Metronome DefaultUserCap] Synced per-seat-type default per-user cap alert"
   );
-  await invalidateCachedDefaultCapThreshold({
+  await invalidateCachedDefaultCapThresholdsBySeatType({
     metronomeCustomerId,
     workspaceId,
   });
@@ -216,28 +233,48 @@ const invalidateCachedPerUserCapThresholds = bestEffortInvalidateCacheWithRedis(
   "members-usage per-user spend caps"
 );
 
-async function fetchDefaultCapThreshold(args: {
+/**
+ * Fetch the default cap thresholds for all seat types configured on this
+ * workspace. Returns a map of `NormalizedPoolLimitSeatType → totalThreshold`
+ * (seatAllowance + poolLimit). Empty record when no per-seat-type alerts exist.
+ */
+async function fetchDefaultCapThresholdsBySeatType(args: {
   metronomeCustomerId: string;
   workspaceId: string;
-}): Promise<{ threshold: number | null }> {
-  const result = await getMetronomeDefaultUserCapAlert(args);
-  if (result.isErr()) {
-    throw result.error;
+}): Promise<Record<NormalizedPoolLimitSeatType, number>> {
+  const results = await Promise.all(
+    NORMALIZED_POOL_LIMIT_SEAT_TYPES.map(async (seatType) => {
+      const result = await getMetronomeDefaultUserCapAlertForSeatType({
+        ...args,
+        seatType,
+      });
+      if (result.isErr()) {
+        throw result.error;
+      }
+      return [seatType, result.value?.alert.threshold ?? null] as const;
+    })
+  );
+  const thresholds = {} as Record<NormalizedPoolLimitSeatType, number>;
+  for (const [seatType, threshold] of results) {
+    if (threshold !== null) {
+      thresholds[seatType] = threshold;
+    }
   }
-  return { threshold: result.value?.alert.threshold ?? null };
+  return thresholds;
 }
 
-export const getCachedDefaultCapThreshold = cacheWithRedis(
-  fetchDefaultCapThreshold,
+export const getCachedDefaultCapThresholdsBySeatType = cacheWithRedis(
+  fetchDefaultCapThresholdsBySeatType,
   spendLimitCacheResolver,
   { ttlMs: SPEND_LIMIT_CACHE_TTL_MS }
 );
 
-const invalidateCachedDefaultCapThreshold = bestEffortInvalidateCacheWithRedis(
-  fetchDefaultCapThreshold,
-  spendLimitCacheResolver,
-  "members-usage default spend cap"
-);
+const invalidateCachedDefaultCapThresholdsBySeatType =
+  bestEffortInvalidateCacheWithRedis(
+    fetchDefaultCapThresholdsBySeatType,
+    spendLimitCacheResolver,
+    "members-usage default spend caps by seat type"
+  );
 
 /**
  * Idempotently ensure a Metronome `spend_threshold_reached` alert exists on
@@ -331,33 +368,40 @@ export async function clearMetronomePerUserCapAlert({
 // ============================================================================
 
 /**
- * Look up the workspace-wide default per-user 80% warning alert.
+ * Look up the per-seat-type default per-user 80% warning alert.
  */
-export async function getMetronomeDefaultUserWarningAlert({
+export async function getMetronomeDefaultUserWarningAlertForSeatType({
   metronomeCustomerId,
   workspaceId,
+  seatType,
 }: {
   metronomeCustomerId: string;
   workspaceId: string;
+  seatType: NormalizedPoolLimitSeatType;
 }): Promise<Result<CustomerAlert | null, Error>> {
   return findMetronomeAlert({
     metronomeCustomerId,
-    uniquenessKey: defaultUserWarningAlertUniquenessKey(workspaceId),
+    uniquenessKey: defaultUserWarningAlertUniquenessKeyForSeatType(
+      seatType,
+      workspaceId
+    ),
   });
 }
 
 /**
- * Idempotently ensure a workspace-wide default per-user 80% warning alert
- * exists. The threshold is floor(capAwuCredits * 0.8). Skipped if the result
- * would be zero.
+ * Idempotently ensure a per-seat-type default per-user 80% warning alert
+ * exists. The threshold is floor(capAwuCredits * 0.8). Skipped if the
+ * result would be zero.
  */
-export async function upsertMetronomeDefaultUserWarningAlert({
+export async function upsertMetronomeDefaultUserWarningAlertForSeatType({
   metronomeCustomerId,
   workspaceId,
+  seatType,
   capAwuCredits,
 }: {
   metronomeCustomerId: string;
   workspaceId: string;
+  seatType: NormalizedPoolLimitSeatType;
   capAwuCredits: number;
 }): Promise<Result<{ alertId: string } | null, Error>> {
   const threshold = warningAwuCredits(capAwuCredits);
@@ -366,12 +410,15 @@ export async function upsertMetronomeDefaultUserWarningAlert({
   }
   const upsertResult = await upsertMetronomeAlert({
     alert_type: "spend_threshold_reached",
-    name: `Default per-user warning ${workspaceId} (${threshold} AWU / ${Math.round(USER_AWU_WARNING_PERCENTAGE * 100)}% of ${capAwuCredits})`,
+    name: `Default per-user warning ${seatType} ${workspaceId} (${threshold} AWU / ${Math.round(USER_AWU_WARNING_PERCENTAGE * 100)}% of ${capAwuCredits})`,
     threshold,
     credit_type_id: getCreditTypeAwuId(),
     customer_id: metronomeCustomerId,
     group_values: [{ key: USER_ID_GROUP_KEY }],
-    uniqueness_key: defaultUserWarningAlertUniquenessKey(workspaceId),
+    uniqueness_key: defaultUserWarningAlertUniquenessKeyForSeatType(
+      seatType,
+      workspaceId
+    ),
   });
   if (upsertResult.isErr()) {
     return new Err(upsertResult.error);
@@ -379,12 +426,13 @@ export async function upsertMetronomeDefaultUserWarningAlert({
   logger.info(
     {
       workspaceId,
+      seatType,
       metronomeCustomerId,
       alertId: upsertResult.value.alertId,
       threshold,
       capAwuCredits,
     },
-    "[Metronome DefaultUserWarning] Synced default per-user warning alert"
+    "[Metronome DefaultUserWarning] Synced per-seat-type default per-user warning alert"
   );
   return new Ok({ alertId: upsertResult.value.alertId });
 }

--- a/front/pages/api/w/[wId]/members/[uId]/spend_limit.test.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/spend_limit.test.ts
@@ -22,7 +22,7 @@ vi.mock("@app/lib/metronome/alerts/spend_limits", async () => {
     upsertMetronomePerUserCapAlert: vi.fn(),
     clearMetronomePerUserCapAlert: vi.fn(),
     getMetronomePerUserCap: vi.fn(),
-    getMetronomeDefaultUserCapAlert: vi.fn(),
+    getMetronomeDefaultUserCapAlertForSeatType: vi.fn(),
   };
 });
 
@@ -70,7 +70,7 @@ beforeEach(() => {
     new Ok(new Map())
   );
   vi.mocked(
-    defaultUserCapAlert.getMetronomeDefaultUserCapAlert
+    defaultUserCapAlert.getMetronomeDefaultUserCapAlertForSeatType
   ).mockResolvedValue(new Ok(null));
   vi.mocked(creditStateDispatcher.dispatchPerUserCapReached).mockResolvedValue(
     new Ok(undefined)
@@ -298,7 +298,7 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
       });
 
       vi.mocked(
-        defaultUserCapAlert.getMetronomeDefaultUserCapAlert
+        defaultUserCapAlert.getMetronomeDefaultUserCapAlertForSeatType
       ).mockResolvedValueOnce(
         new Ok(
           mockCustomerAlert({
@@ -345,7 +345,7 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
       });
 
       vi.mocked(
-        defaultUserCapAlert.getMetronomeDefaultUserCapAlert
+        defaultUserCapAlert.getMetronomeDefaultUserCapAlertForSeatType
       ).mockResolvedValueOnce(
         new Ok(
           mockCustomerAlert({

--- a/front/pages/api/w/[wId]/usage_settings/default_user_spend_limit.ts
+++ b/front/pages/api/w/[wId]/usage_settings/default_user_spend_limit.ts
@@ -65,6 +65,14 @@ function mapErrorToHttp(
           message: error.message,
         },
       });
+    case "contract_not_found":
+      return apiError(req, res, {
+        status_code: 404,
+        api_error: {
+          type: "workspace_not_found",
+          message: error.message,
+        },
+      });
     case "metronome_error":
       return apiError(req, res, {
         status_code: 502,

--- a/front/scripts/migrate_legacy_spend_limits.ts
+++ b/front/scripts/migrate_legacy_spend_limits.ts
@@ -1,0 +1,213 @@
+/**
+ * One-off migration: convert legacy single default user spend-limit alerts
+ * to per-seat-type alerts.
+ *
+ * For each workspace with a legacy `default-user-cap-{workspaceId}` alert:
+ *   1. Read the old threshold (total AWU cap, same for all users).
+ *   2. Look up the contract's seat types and their AWU allocations.
+ *   3. For each seat type: create a per-seat-type cap + warning alert with
+ *      threshold = seatAllowance + poolLimit (old threshold treated as pool limit).
+ *   4. Archive the legacy cap + warning alerts.
+ *
+ * Usage:
+ *   npx tsx scripts/migrate_legacy_spend_limits.ts           # dry run
+ *   npx tsx scripts/migrate_legacy_spend_limits.ts --execute  # apply
+ *   npx tsx scripts/migrate_legacy_spend_limits.ts --execute --workspaceId <sId>
+ */
+import {
+  clearMetronomeAlert,
+  findMetronomeAlert,
+} from "@app/lib/metronome/alerts";
+import {
+  upsertMetronomeDefaultUserCapAlertForSeatType,
+  upsertMetronomeDefaultUserWarningAlertForSeatType,
+} from "@app/lib/metronome/alerts/spend_limits";
+import { getActiveContract } from "@app/lib/metronome/plan_type";
+import {
+  getAwuAllocationForSeatType,
+  getProductSeatTypes,
+  getSeatSubscriptionsFromContract,
+} from "@app/lib/metronome/seat_types";
+import type { NormalizedPoolLimitSeatType } from "@app/types/memberships";
+import { normalizeToPoolLimitSeatType } from "@app/types/memberships";
+import type { LightWorkspaceType } from "@app/types/user";
+
+import { makeScript } from "./helpers";
+import { runOnAllWorkspaces } from "./workspace_helpers";
+
+// Legacy uniqueness keys (pre-seat-type).
+function legacyCapKey(workspaceId: string): string {
+  return `default-user-cap-${workspaceId}`;
+}
+
+function legacyWarningKey(workspaceId: string): string {
+  return `default-user-warning-${workspaceId}`;
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  let migrated = 0;
+  let skipped = 0;
+  let failed = 0;
+  const productSeatTypes = await getProductSeatTypes();
+
+  async function migrateWorkspace(
+    workspace: LightWorkspaceType
+  ): Promise<void> {
+    const { metronomeCustomerId } = workspace;
+    if (!metronomeCustomerId) {
+      skipped++;
+      return;
+    }
+
+    // Check if a legacy cap alert exists.
+    const legacyResult = await findMetronomeAlert({
+      metronomeCustomerId,
+      uniquenessKey: legacyCapKey(workspace.sId),
+    });
+    if (legacyResult.isErr()) {
+      logger.warn(
+        { workspaceId: workspace.sId, err: legacyResult.error },
+        "Failed to read legacy alert, skipping"
+      );
+      failed++;
+      return;
+    }
+    if (!legacyResult.value) {
+      skipped++;
+      return;
+    }
+
+    const legacyThreshold = legacyResult.value.alert.threshold;
+    logger.info(
+      { workspaceId: workspace.sId, legacyThreshold },
+      "Found legacy default user cap alert"
+    );
+
+    // Look up the contract's seat types.
+    const contract = await getActiveContract(workspace.sId);
+    if (!contract) {
+      logger.warn(
+        { workspaceId: workspace.sId },
+        "No active contract found, skipping"
+      );
+      skipped++;
+      return;
+    }
+
+    const seatSubscriptions = getSeatSubscriptionsFromContract(
+      contract,
+      productSeatTypes
+    );
+
+    const normalizedSeatTypes = new Set<NormalizedPoolLimitSeatType>();
+    for (const seatType of seatSubscriptions.keys()) {
+      const normalized = normalizeToPoolLimitSeatType(seatType);
+      if (normalized) {
+        normalizedSeatTypes.add(normalized);
+      }
+    }
+
+    // The legacy threshold was a total cap applied uniformly. Treat it as
+    // the pool credit limit. For each seat type, the new threshold =
+    // seatAllowance + poolLimit.
+    const poolAwuCredits = legacyThreshold;
+
+    for (const seatType of normalizedSeatTypes) {
+      const seatAllowance = getAwuAllocationForSeatType(
+        contract,
+        seatType,
+        productSeatTypes
+      );
+      const totalThreshold = seatAllowance + poolAwuCredits;
+
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          seatType,
+          seatAllowance,
+          poolAwuCredits,
+          totalThreshold,
+        },
+        "Creating per-seat-type alert"
+      );
+
+      if (execute) {
+        const capResult = await upsertMetronomeDefaultUserCapAlertForSeatType({
+          metronomeCustomerId,
+          workspaceId: workspace.sId,
+          seatType,
+          awuCredits: totalThreshold,
+        });
+        if (capResult.isErr()) {
+          logger.error(
+            { workspaceId: workspace.sId, seatType, err: capResult.error },
+            "Failed to create per-seat-type cap alert"
+          );
+          failed++;
+          return;
+        }
+
+        const warningResult =
+          await upsertMetronomeDefaultUserWarningAlertForSeatType({
+            metronomeCustomerId,
+            workspaceId: workspace.sId,
+            seatType,
+            capAwuCredits: totalThreshold,
+          });
+        if (warningResult.isErr()) {
+          logger.warn(
+            {
+              workspaceId: workspace.sId,
+              seatType,
+              err: warningResult.error,
+            },
+            "Failed to create per-seat-type warning alert, continuing"
+          );
+        }
+      }
+    }
+
+    // Archive the legacy alerts.
+    if (execute) {
+      const [capArchive, warningArchive] = await Promise.all([
+        clearMetronomeAlert({
+          metronomeCustomerId,
+          uniquenessKey: legacyCapKey(workspace.sId),
+        }),
+        clearMetronomeAlert({
+          metronomeCustomerId,
+          uniquenessKey: legacyWarningKey(workspace.sId),
+        }),
+      ]);
+      if (capArchive.isOk() && capArchive.value) {
+        logger.info(
+          { workspaceId: workspace.sId, alertId: capArchive.value.alertId },
+          "Archived legacy cap alert"
+        );
+      }
+      if (warningArchive.isOk() && warningArchive.value) {
+        logger.info(
+          {
+            workspaceId: workspace.sId,
+            alertId: warningArchive.value.alertId,
+          },
+          "Archived legacy warning alert"
+        );
+      }
+    }
+
+    migrated++;
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        seatTypes: [...normalizedSeatTypes],
+        poolAwuCredits,
+      },
+      "Migrated legacy alert to per-seat-type alerts"
+    );
+  }
+
+  await runOnAllWorkspaces(migrateWorkspace);
+
+  logger.info({ migrated, skipped, failed }, "Migration complete");
+});

--- a/front/scripts/migrate_legacy_spend_limits.ts
+++ b/front/scripts/migrate_legacy_spend_limits.ts
@@ -44,170 +44,181 @@ function legacyWarningKey(workspaceId: string): string {
   return `default-user-warning-${workspaceId}`;
 }
 
-makeScript({}, async ({ execute }, logger) => {
-  let migrated = 0;
-  let skipped = 0;
-  let failed = 0;
-  const productSeatTypes = await getProductSeatTypes();
+makeScript(
+  {
+    workspaceId: {
+      alias: "w",
+      describe: "Run on a single workspace (sId)",
+      type: "string" as const,
+    },
+  },
+  async ({ execute, workspaceId }, logger) => {
+    let migrated = 0;
+    let skipped = 0;
+    let failed = 0;
+    const productSeatTypes = await getProductSeatTypes();
 
-  async function migrateWorkspace(
-    workspace: LightWorkspaceType
-  ): Promise<void> {
-    const { metronomeCustomerId } = workspace;
-    if (!metronomeCustomerId) {
-      skipped++;
-      return;
-    }
-
-    // Check if a legacy cap alert exists.
-    const legacyResult = await findMetronomeAlert({
-      metronomeCustomerId,
-      uniquenessKey: legacyCapKey(workspace.sId),
-    });
-    if (legacyResult.isErr()) {
-      logger.warn(
-        { workspaceId: workspace.sId, err: legacyResult.error },
-        "Failed to read legacy alert, skipping"
-      );
-      failed++;
-      return;
-    }
-    if (!legacyResult.value) {
-      skipped++;
-      return;
-    }
-
-    const legacyThreshold = legacyResult.value.alert.threshold;
-    logger.info(
-      { workspaceId: workspace.sId, legacyThreshold },
-      "Found legacy default user cap alert"
-    );
-
-    // Look up the contract's seat types.
-    const contract = await getActiveContract(workspace.sId);
-    if (!contract) {
-      logger.warn(
-        { workspaceId: workspace.sId },
-        "No active contract found, skipping"
-      );
-      skipped++;
-      return;
-    }
-
-    const seatSubscriptions = getSeatSubscriptionsFromContract(
-      contract,
-      productSeatTypes
-    );
-
-    const normalizedSeatTypes = new Set<NormalizedPoolLimitSeatType>();
-    for (const seatType of seatSubscriptions.keys()) {
-      const normalized = normalizeToPoolLimitSeatType(seatType);
-      if (normalized) {
-        normalizedSeatTypes.add(normalized);
+    async function migrateWorkspace(
+      workspace: LightWorkspaceType
+    ): Promise<void> {
+      const { metronomeCustomerId } = workspace;
+      if (!metronomeCustomerId) {
+        skipped++;
+        return;
       }
-    }
 
-    // The legacy threshold was a total cap applied uniformly. Treat it as
-    // the pool credit limit. For each seat type, the new threshold =
-    // seatAllowance + poolLimit.
-    const poolAwuCredits = legacyThreshold;
+      // Check if a legacy cap alert exists.
+      const legacyResult = await findMetronomeAlert({
+        metronomeCustomerId,
+        uniquenessKey: legacyCapKey(workspace.sId),
+      });
+      if (legacyResult.isErr()) {
+        logger.warn(
+          { workspaceId: workspace.sId, err: legacyResult.error },
+          "Failed to read legacy alert, skipping"
+        );
+        failed++;
+        return;
+      }
+      if (!legacyResult.value) {
+        skipped++;
+        return;
+      }
 
-    for (const seatType of normalizedSeatTypes) {
-      const seatAllowance = getAwuAllocationForSeatType(
+      const legacyThreshold = legacyResult.value.alert.threshold;
+      logger.info(
+        { workspaceId: workspace.sId, legacyThreshold },
+        "Found legacy default user cap alert"
+      );
+
+      // Look up the contract's seat types.
+      const contract = await getActiveContract(workspace.sId);
+      if (!contract) {
+        logger.warn(
+          { workspaceId: workspace.sId },
+          "No active contract found, skipping"
+        );
+        skipped++;
+        return;
+      }
+
+      const seatSubscriptions = getSeatSubscriptionsFromContract(
         contract,
-        seatType,
         productSeatTypes
       );
-      const totalThreshold = seatAllowance + poolAwuCredits;
 
-      logger.info(
-        {
-          workspaceId: workspace.sId,
-          seatType,
-          seatAllowance,
-          poolAwuCredits,
-          totalThreshold,
-        },
-        "Creating per-seat-type alert"
-      );
-
-      if (execute) {
-        const capResult = await upsertMetronomeDefaultUserCapAlertForSeatType({
-          metronomeCustomerId,
-          workspaceId: workspace.sId,
-          seatType,
-          awuCredits: totalThreshold,
-        });
-        if (capResult.isErr()) {
-          logger.error(
-            { workspaceId: workspace.sId, seatType, err: capResult.error },
-            "Failed to create per-seat-type cap alert"
-          );
-          failed++;
-          return;
-        }
-
-        const warningResult =
-          await upsertMetronomeDefaultUserWarningAlertForSeatType({
-            metronomeCustomerId,
-            workspaceId: workspace.sId,
-            seatType,
-            capAwuCredits: totalThreshold,
-          });
-        if (warningResult.isErr()) {
-          logger.warn(
-            {
-              workspaceId: workspace.sId,
-              seatType,
-              err: warningResult.error,
-            },
-            "Failed to create per-seat-type warning alert, continuing"
-          );
+      const normalizedSeatTypes = new Set<NormalizedPoolLimitSeatType>();
+      for (const seatType of seatSubscriptions.keys()) {
+        const normalized = normalizeToPoolLimitSeatType(seatType);
+        if (normalized) {
+          normalizedSeatTypes.add(normalized);
         }
       }
-    }
 
-    // Archive the legacy alerts.
-    if (execute) {
-      const [capArchive, warningArchive] = await Promise.all([
-        clearMetronomeAlert({
-          metronomeCustomerId,
-          uniquenessKey: legacyCapKey(workspace.sId),
-        }),
-        clearMetronomeAlert({
-          metronomeCustomerId,
-          uniquenessKey: legacyWarningKey(workspace.sId),
-        }),
-      ]);
-      if (capArchive.isOk() && capArchive.value) {
-        logger.info(
-          { workspaceId: workspace.sId, alertId: capArchive.value.alertId },
-          "Archived legacy cap alert"
+      // The legacy threshold was a total cap applied uniformly. Treat it as
+      // the pool credit limit. For each seat type, the new threshold =
+      // seatAllowance + poolLimit.
+      const poolAwuCredits = legacyThreshold;
+
+      for (const seatType of normalizedSeatTypes) {
+        const seatAllowance = getAwuAllocationForSeatType(
+          contract,
+          seatType,
+          productSeatTypes
         );
-      }
-      if (warningArchive.isOk() && warningArchive.value) {
+        const totalThreshold = seatAllowance + poolAwuCredits;
+
         logger.info(
           {
             workspaceId: workspace.sId,
-            alertId: warningArchive.value.alertId,
+            seatType,
+            seatAllowance,
+            poolAwuCredits,
+            totalThreshold,
           },
-          "Archived legacy warning alert"
+          "Creating per-seat-type alert"
         );
+
+        if (execute) {
+          const capResult = await upsertMetronomeDefaultUserCapAlertForSeatType(
+            {
+              metronomeCustomerId,
+              workspaceId: workspace.sId,
+              seatType,
+              awuCredits: totalThreshold,
+            }
+          );
+          if (capResult.isErr()) {
+            logger.error(
+              { workspaceId: workspace.sId, seatType, err: capResult.error },
+              "Failed to create per-seat-type cap alert"
+            );
+            failed++;
+            return;
+          }
+
+          const warningResult =
+            await upsertMetronomeDefaultUserWarningAlertForSeatType({
+              metronomeCustomerId,
+              workspaceId: workspace.sId,
+              seatType,
+              capAwuCredits: totalThreshold,
+            });
+          if (warningResult.isErr()) {
+            logger.warn(
+              {
+                workspaceId: workspace.sId,
+                seatType,
+                err: warningResult.error,
+              },
+              "Failed to create per-seat-type warning alert, continuing"
+            );
+          }
+        }
       }
+
+      // Archive the legacy alerts.
+      if (execute) {
+        const [capArchive, warningArchive] = await Promise.all([
+          clearMetronomeAlert({
+            metronomeCustomerId,
+            uniquenessKey: legacyCapKey(workspace.sId),
+          }),
+          clearMetronomeAlert({
+            metronomeCustomerId,
+            uniquenessKey: legacyWarningKey(workspace.sId),
+          }),
+        ]);
+        if (capArchive.isOk() && capArchive.value) {
+          logger.info(
+            { workspaceId: workspace.sId, alertId: capArchive.value.alertId },
+            "Archived legacy cap alert"
+          );
+        }
+        if (warningArchive.isOk() && warningArchive.value) {
+          logger.info(
+            {
+              workspaceId: workspace.sId,
+              alertId: warningArchive.value.alertId,
+            },
+            "Archived legacy warning alert"
+          );
+        }
+      }
+
+      migrated++;
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          seatTypes: [...normalizedSeatTypes],
+          poolAwuCredits,
+        },
+        "Migrated legacy alert to per-seat-type alerts"
+      );
     }
 
-    migrated++;
-    logger.info(
-      {
-        workspaceId: workspace.sId,
-        seatTypes: [...normalizedSeatTypes],
-        poolAwuCredits,
-      },
-      "Migrated legacy alert to per-seat-type alerts"
-    );
+    await runOnAllWorkspaces(migrateWorkspace, { wId: workspaceId });
+
+    logger.info({ migrated, skipped, failed }, "Migration complete");
   }
-
-  await runOnAllWorkspaces(migrateWorkspace);
-
-  logger.info({ migrated, skipped, failed }, "Migration complete");
-});
+);

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -1,3 +1,5 @@
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
 export const MEMBERSHIP_ROLE_TYPES = ["admin", "builder", "user"] as const;
 
 export type MembershipRoleType = (typeof MEMBERSHIP_ROLE_TYPES)[number];
@@ -41,6 +43,55 @@ export function isMembershipSeatType(
     typeof value === "string" &&
     MEMBERSHIP_SEAT_TYPES.includes(value as MembershipSeatType)
   );
+}
+
+// Normalized seat types for pool credit limits. Monthly and yearly variants
+// share a single pool limit. Free seats are excluded (lifetime allocation,
+// no pool access).
+export const NORMALIZED_POOL_LIMIT_SEAT_TYPES = [
+  "pro",
+  "max",
+  "workspace",
+] as const;
+
+export type NormalizedPoolLimitSeatType =
+  (typeof NORMALIZED_POOL_LIMIT_SEAT_TYPES)[number];
+
+export function isNormalizedPoolLimitSeatType(
+  value: unknown
+): value is NormalizedPoolLimitSeatType {
+  return (
+    typeof value === "string" &&
+    (NORMALIZED_POOL_LIMIT_SEAT_TYPES as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Map a membership seat type to its normalized pool-limit seat type.
+ * Returns null for `free` seats (they have a fixed lifetime allocation with
+ * no pool access).
+ */
+export function normalizeToPoolLimitSeatType(
+  seatType: MembershipSeatType | null | undefined
+): NormalizedPoolLimitSeatType | null {
+  if (!seatType) {
+    return null;
+  }
+  switch (seatType) {
+    case "pro":
+    case "pro_yearly":
+      return "pro";
+    case "max":
+    case "max_yearly":
+      return "max";
+    case "workspace":
+    case "workspace_yearly":
+      return "workspace";
+    case "free":
+      return null;
+    default:
+      assertNever(seatType);
+  }
 }
 
 // Per-user credit state on a membership. Models where a user sits in the


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/8501

 - The cap set in UI it now additive to the seat limit. For a workspace we now register one limit per seat type.
 - CHanges how the webhook processing is done: first determine if the event received impact the user (depending on user's seat and personal limit) then apply the event if there is a match
 - Added a script to migrate old limits to new ones. 

## Tests

Tested locally

<img width="2180" height="1548" alt="image" src="https://github.com/user-attachments/assets/d6a3ae59-4382-4856-8feb-ad3df8ee51d0" />

<img width="802" height="528" alt="image" src="https://github.com/user-attachments/assets/62f9c0c2-e190-4a6e-bd75-e396a9fcbe2b" />


## Risk

low

## Deploy Plan

deploy front
run migration script
