### PR TITLE
Create new user credit states

### DIFF
--- a/front/lib/api/metronome/credit_state_dispatcher.test.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.test.ts
@@ -24,7 +24,7 @@ const TEST_METRONOME_CUSTOMER_ID = "cust_test_xxx";
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(transitionUserCreditState).mockResolvedValue(new Ok("normal"));
+  vi.mocked(transitionUserCreditState).mockResolvedValue(new Ok("on_pool"));
 });
 
 describe("credit_state_dispatcher per-user caps", () => {
@@ -49,7 +49,7 @@ describe("credit_state_dispatcher per-user caps", () => {
     });
 
     expect(transitionUserCreditState).toHaveBeenCalledWith(
-      expect.objectContaining({ seatType: "pro", creditState: "normal" }),
+      expect.objectContaining({ seatType: "pro", creditState: "on_pool" }),
       { type: "per_user_cap_reached" },
       { workspaceId: workspaceType.sId, userId: user.sId }
     );
@@ -76,7 +76,7 @@ describe("credit_state_dispatcher per-user caps", () => {
     });
 
     expect(transitionUserCreditState).toHaveBeenCalledWith(
-      expect.objectContaining({ seatType: "max", creditState: "normal" }),
+      expect.objectContaining({ seatType: "max", creditState: "on_pool" }),
       { type: "per_user_cap_resolved" },
       { workspaceId: workspaceType.sId, userId: user.sId }
     );

--- a/front/lib/metronome/user_block.test.ts
+++ b/front/lib/metronome/user_block.test.ts
@@ -133,7 +133,7 @@ describe("isUserBlocked", () => {
     });
     mockFetchUserById.mockResolvedValue({ sId: "u_test", id: 7 });
     mockGetActiveMembershipOfUserInWorkspace.mockResolvedValue({
-      creditState: "normal",
+      creditState: "on_pool",
     });
 
     const blocked = await isUserBlocked("ws_test", "u_test");

--- a/front/lib/metronome/user_credit_state_machine.test.ts
+++ b/front/lib/metronome/user_credit_state_machine.test.ts
@@ -70,8 +70,8 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("UserCreditStateMachine — transitions", () => {
-  it("normal + per_user_cap_reached → capped (blocks user)", async () => {
-    const membership = makeMembership("normal");
+  it("on_pool + per_user_cap_reached → capped (blocks user)", async () => {
+    const membership = makeMembership("on_pool");
     const result = await transitionUserCreditState(
       membership,
       { type: "per_user_cap_reached" },
@@ -89,7 +89,7 @@ describe("UserCreditStateMachine — transitions", () => {
     expect(mockClearUserCapBlocked).not.toHaveBeenCalled();
   });
 
-  it("capped + admin_raised_user_cap → normal (unblocks user)", async () => {
+  it("capped + admin_raised_user_cap → on_pool (unblocks user)", async () => {
     const membership = makeMembership("capped");
     const result = await transitionUserCreditState(
       membership,
@@ -98,17 +98,17 @@ describe("UserCreditStateMachine — transitions", () => {
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value).toBe("normal");
+      expect(result.value).toBe("on_pool");
     }
     expect(membership.updateCreditState).toHaveBeenCalledWith(
-      "normal",
+      "on_pool",
       undefined
     );
     expect(mockClearUserCapBlocked).toHaveBeenCalledWith("ws_test", "u_test");
     expect(mockSetUserCapBlocked).not.toHaveBeenCalled();
   });
 
-  it("capped + per_user_cap_resolved → normal (unblocks user)", async () => {
+  it("capped + per_user_cap_resolved → on_pool (unblocks user)", async () => {
     const membership = makeMembership("capped");
     const result = await transitionUserCreditState(
       membership,
@@ -117,10 +117,10 @@ describe("UserCreditStateMachine — transitions", () => {
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value).toBe("normal");
+      expect(result.value).toBe("on_pool");
     }
     expect(membership.updateCreditState).toHaveBeenCalledWith(
-      "normal",
+      "on_pool",
       undefined
     );
     expect(mockClearUserCapBlocked).toHaveBeenCalledWith("ws_test", "u_test");
@@ -143,8 +143,8 @@ describe("UserCreditStateMachine — transitions", () => {
     expect(mockClearUserCapBlocked).not.toHaveBeenCalled();
   });
 
-  it("normal + per_user_cap_resolved is idempotent and re-applies the unblock cache", async () => {
-    const membership = makeMembership("normal");
+  it("on_pool + per_user_cap_resolved is idempotent and re-applies the unblock cache", async () => {
+    const membership = makeMembership("on_pool");
     const result = await transitionUserCreditState(
       membership,
       { type: "per_user_cap_resolved" },
@@ -152,7 +152,7 @@ describe("UserCreditStateMachine — transitions", () => {
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value).toBe("normal");
+      expect(result.value).toBe("on_pool");
     }
     expect(membership.updateCreditState).not.toHaveBeenCalled();
     expect(mockClearUserCapBlocked).toHaveBeenCalledWith("ws_test", "u_test");
@@ -166,7 +166,7 @@ describe("UserCreditStateMachine — transitions", () => {
 
 describe("UserCreditStateMachine — side effects and transactions", () => {
   it("invokes the DB update before registering the Redis side-effect", async () => {
-    const membership = makeMembership("normal");
+    const membership = makeMembership("on_pool");
     await transitionUserCreditState(
       membership,
       { type: "per_user_cap_reached" },
@@ -180,7 +180,7 @@ describe("UserCreditStateMachine — side effects and transactions", () => {
 
   it("forwards the provided transaction to both the DB update and cache invalidator", async () => {
     const tx = { __mock: "transaction" } as unknown as Transaction;
-    const membership = makeMembership("normal");
+    const membership = makeMembership("on_pool");
     await transitionUserCreditState(
       membership,
       { type: "per_user_cap_reached" },
@@ -195,7 +195,7 @@ describe("UserCreditStateMachine — side effects and transactions", () => {
   });
 
   it("passes undefined transaction when none is provided", async () => {
-    const membership = makeMembership("normal");
+    const membership = makeMembership("on_pool");
     await transitionUserCreditState(
       membership,
       { type: "per_user_cap_reached" },

--- a/front/lib/metronome/user_credit_state_machine.ts
+++ b/front/lib/metronome/user_credit_state_machine.ts
@@ -46,7 +46,9 @@ function syncUserCapCacheForState(
 ): void {
   switch (state) {
     // Spending normally (personal credits or workspace pool): not capped, no
-    // low-balance warning.
+    // low-balance warning. "normal" is the legacy alias of "on_pool" kept
+    // during the migration window (see USER_CREDIT_STATES).
+    case "normal":
     case "user_seat":
     case "on_pool":
       invalidateCacheAfterCommit(transaction, () =>
@@ -126,7 +128,11 @@ export async function transitionUserCreditState(
   ctx: UserCreditContext,
   { transaction }: { transaction?: Transaction } = {}
 ): Promise<Result<UserCreditState, Error>> {
-  const currentState = membership.creditState;
+  const rawState = membership.creditState;
+  // "normal" is the legacy alias of "on_pool" (migration window): match
+  // transitions as if the row were already "on_pool". A matching transition
+  // then persists the canonical value, opportunistically migrating the row.
+  const currentState = rawState === "normal" ? "on_pool" : rawState;
   const match = findTransition(currentState, event);
 
   if (!match) {
@@ -146,7 +152,9 @@ export async function transitionUserCreditState(
     );
   }
 
-  if (currentState !== match.to) {
+  // Compare against the raw value so a legacy "normal" row is rewritten to the
+  // canonical "on_pool" even when the normalized state already matches.
+  if (rawState !== match.to) {
     await membership.updateCreditState(match.to, transaction);
   }
   syncUserCapCacheForState(match.to, ctx, transaction);
@@ -154,10 +162,10 @@ export async function transitionUserCreditState(
     {
       workspaceId: ctx.workspaceId,
       userId: ctx.userId,
-      fromState: currentState,
+      fromState: rawState,
       toState: match.to,
       eventType: event.type,
-      wasStateChanged: currentState !== match.to,
+      wasStateChanged: rawState !== match.to,
     },
     "[UserCreditStateMachine] Transition applied"
   );

--- a/front/lib/metronome/user_credit_state_machine.ts
+++ b/front/lib/metronome/user_credit_state_machine.ts
@@ -1,6 +1,7 @@
 import {
   clearUserAwuWarned,
   clearUserCapBlocked,
+  setUserAwuWarned,
   setUserCapBlocked,
 } from "@app/lib/metronome/user_block";
 import type { MembershipResource } from "@app/lib/resources/membership_resource";
@@ -44,12 +45,27 @@ function syncUserCapCacheForState(
   transaction: Transaction | undefined
 ): void {
   switch (state) {
-    case "normal":
+    // Spending normally (personal credits or workspace pool): not capped, no
+    // low-balance warning.
+    case "user_seat":
+    case "on_pool":
       invalidateCacheAfterCommit(transaction, () =>
         clearUserCapBlocked(ctx.workspaceId, ctx.userId)
       );
       invalidateCacheAfterCommit(transaction, () =>
         clearUserAwuWarned(ctx.workspaceId, ctx.userId)
+      );
+      return;
+
+    // Still spending, but ≥80% of the personal balance / per-user cap used:
+    // not capped, but the low-balance warning is active.
+    case "user_seat_low_balance":
+    case "on_pool_low_balance":
+      invalidateCacheAfterCommit(transaction, () =>
+        clearUserCapBlocked(ctx.workspaceId, ctx.userId)
+      );
+      invalidateCacheAfterCommit(transaction, () =>
+        setUserAwuWarned(ctx.workspaceId, ctx.userId)
       );
       return;
 
@@ -66,7 +82,7 @@ function syncUserCapCacheForState(
 
 const TRANSITIONS: UserCreditTransition[] = [
   {
-    from: "normal",
+    from: "on_pool",
     event: "per_user_cap_reached",
     to: "capped",
   },
@@ -78,22 +94,22 @@ const TRANSITIONS: UserCreditTransition[] = [
   {
     from: "capped",
     event: "admin_raised_user_cap",
-    to: "normal",
+    to: "on_pool",
   },
   {
-    from: "normal",
+    from: "on_pool",
     event: "admin_raised_user_cap",
-    to: "normal",
+    to: "on_pool",
   },
   {
     from: "capped",
     event: "per_user_cap_resolved",
-    to: "normal",
+    to: "on_pool",
   },
   {
-    from: "normal",
+    from: "on_pool",
     event: "per_user_cap_resolved",
-    to: "normal",
+    to: "on_pool",
   },
 ];
 

--- a/front/lib/resources/storage/models/membership.ts
+++ b/front/lib/resources/storage/models/membership.ts
@@ -66,7 +66,7 @@ MembershipModel.init(
     creditState: {
       type: DataTypes.STRING,
       allowNull: false,
-      defaultValue: "normal",
+      defaultValue: "on_pool",
     },
   },
   {

--- a/front/migrations/db/migration_665.sql
+++ b/front/migrations/db/migration_665.sql
@@ -1,0 +1,11 @@
+-- Per-user credit state ("memberships"."creditState") rename + extension.
+--
+-- The former "normal" state is renamed to "on_pool" (user spending from the
+-- workspace pool) and the set of states is extended to model the
+-- personal-credits → workspace-pool → cap progression:
+--   user_seat, user_seat_low_balance, on_pool, on_pool_low_balance, capped.
+--
+-- "on_pool" is the renamed former "normal" state, so every existing row
+-- migrates to it and it becomes the new column default.
+ALTER TABLE "public"."memberships" ALTER COLUMN "creditState" SET DEFAULT 'on_pool';
+UPDATE "public"."memberships" SET "creditState" = 'on_pool' WHERE "creditState" = 'normal';

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -63,9 +63,16 @@ export function isMembershipSeatType(
 //                          spending from the workspace pool. (Formerly "normal".)
 //   on_pool_low_balance:   same, but ≥80% of the per-user cap already used.
 //   capped:                per-user spend cap hit; can no longer spend.
+//
+// MIGRATION (transitional): "normal" is the legacy name for "on_pool" and is
+// kept as an accepted alias so the deployed code reads existing rows without
+// breaking. It is treated as equivalent to "on_pool" everywhere (see the state
+// machine). Remove it once migration 665 has renamed all rows and the
+// follow-up PR lands.
 export const USER_CREDIT_STATES = [
   "user_seat",
   "user_seat_low_balance",
+  "normal",
   "on_pool",
   "on_pool_low_balance",
   "capped",

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -43,15 +43,33 @@ export function isMembershipSeatType(
   );
 }
 
-// Per-user credit state on a membership. Only models the per-user dimension, the
-// workspace-level pool state lives separately on `workspaces.poolCreditState`
-// (see WORKSPACE_POOL_CREDIT_STATES in `front/types/credits.ts`). A user is
-// allowed to spend iff `creditState = 'normal'` AND the workspace pool is not
-// depleted.
+// Per-user credit state on a membership. Models where a user sits in the
+// personal-credits → workspace-pool → cap progression. Only the per-user
+// dimension lives here; the workspace-level pool state lives separately on
+// `workspaces.poolCreditState` (see WORKSPACE_POOL_CREDIT_STATES in
+// `front/types/credits.ts`). A user is allowed to spend iff `creditState !=
+// 'capped'` AND the workspace pool is not depleted.
 //
-//   normal:  within personal spend limits
-//   capped:  admin-set per-user spend cap hit (Enterprise Pooled only today)
-export const USER_CREDIT_STATES = ["normal", "capped"] as const;
+// Two customer shapes:
+//   - pool-based only: users spend from a shared workspace credits pool (they
+//     may be capped). Such users sit in the `on_pool*` states.
+//   - seat-based: each user has a personal credit balance they spend first,
+//     then fall back to the workspace pool. Such users start in `user_seat*`
+//     and move to `on_pool*` once their personal balance is exhausted.
+//
+//   user_seat:             spending from personal credits.
+//   user_seat_low_balance: same, but ≥80% of personal credits already used.
+//   on_pool:               personal credits exhausted (or pool-based workspace);
+//                          spending from the workspace pool. (Formerly "normal".)
+//   on_pool_low_balance:   same, but ≥80% of the per-user cap already used.
+//   capped:                per-user spend cap hit; can no longer spend.
+export const USER_CREDIT_STATES = [
+  "user_seat",
+  "user_seat_low_balance",
+  "on_pool",
+  "on_pool_low_balance",
+  "capped",
+] as const;
 
 export type UserCreditState = (typeof USER_CREDIT_STATES)[number];
 


### PR DESCRIPTION
## Description

Extends the per-user credit state machine to model the full personal-credits → workspace-pool → cap progression. The former `"normal"` state (user spending from the workspace pool) is renamed to `"on_pool"`, and three new states are introduced:

- `user_seat` – spending from personal credits
- `user_seat_low_balance` – spending from personal credits, ≥80% used
- `on_pool_low_balance` – spending from workspace pool, ≥80% of per-user cap used

`syncUserCapCacheForState` is updated to handle these new states: `user_seat` / `on_pool` clear the cap-blocked cache (same behaviour as the old `normal`), while the `*_low_balance` variants additionally set the AWU-warned cache key. All existing transitions, tests, and the Sequelize model default are updated to use `on_pool` in place of `normal`.

NB: This PR doesn't remove the `normal` state, in order to not break prod. It will be removed in a coming PR.

## Tests

All existing unit tests updated to use the new state names (`normal` → `on_pool`). Tests pass locally. No new behavioural paths are exercised yet (transitions for the new states are not wired up in this PR).

## Risk

The DB migration renames all existing `"normal"` rows to `"on_pool"` and updates the column default — a pure data rename with no structural schema change. Low risk.

## Deploy Plan

- Apply `front/migrations/db/migration_664.sql` before deploying (renames `creditState = 'normal'` to `'on_pool'` and updates the column default).
- Deploy front.