### PR TITLE
Fix: copy

### DIFF
--- a/front/components/pages/workspace/model_providers/EmbeddingModelSelect.tsx
+++ b/front/components/pages/workspace/model_providers/EmbeddingModelSelect.tsx
@@ -35,7 +35,7 @@ export function EmbeddingModelSelect({ workspace }: EmbeddingModelSelectProps) {
           <DropdownMenuTrigger asChild disabled>
             <Button
               disabled
-              tooltip="Please contact us if you are willing to change this setting."
+              tooltip="Please contact us if you want to change this setting."
               isSelect
               label={PRETTIFIED_PROVIDER_NAMES[embeddingProvider]}
               variant="outline"


### PR DESCRIPTION
## Description

Fixes the tooltip wording on the disabled embedding model selector button in `EmbeddingModelSelect`: "are willing to change" → "want to change".

## Tests

No automated tests needed for a single-word tooltip fix. Verified visually in the workspace model providers settings page.

## Risk

Low — one-character change in a static tooltip string, no logic affected.

## Deploy Plan

Deploy front.
