### PR TITLE
feat(mobile): adapt to API drift and improve send/streaming UX

### DIFF
--- a/x/adrsimon/mobile/Dust/Config/AppConfig.swift
+++ b/x/adrsimon/mobile/Dust/Config/AppConfig.swift
@@ -87,10 +87,6 @@ enum AppConfig {
             "/api/w/\(workspaceId)/assistant/conversations/\(conversationId)/tools"
         }
 
-        static func conversationSkills(workspaceId: String, conversationId: String) -> String {
-            "/api/w/\(workspaceId)/assistant/conversations/\(conversationId)/skills"
-        }
-
         static func search(workspaceId: String) -> String {
             "/api/w/\(workspaceId)/search"
         }

--- a/x/adrsimon/mobile/Dust/Models/Conversation.swift
+++ b/x/adrsimon/mobile/Dust/Models/Conversation.swift
@@ -8,13 +8,14 @@ extension Double {
 }
 
 struct Conversation: Codable, Identifiable, Hashable {
-    let id: Int
     let sId: String
     let created: Double
     let updated: Double
     let title: String?
     var unread: Bool
     var actionRequired: Bool
+
+    var id: String { sId }
 
     var updatedDate: Date {
         updated.dateFromEpochMs

--- a/x/adrsimon/mobile/Dust/Models/CreateConversation.swift
+++ b/x/adrsimon/mobile/Dust/Models/CreateConversation.swift
@@ -36,7 +36,6 @@ struct MessageContext: Encodable {
     let timezone: String
     let profilePictureUrl: String?
     var selectedMCPServerViewIds: [String]?
-    var selectedSkillIds: [String]?
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
@@ -44,11 +43,10 @@ struct MessageContext: Encodable {
         // Explicitly encode nil as JSON null
         try container.encode(profilePictureUrl, forKey: .profilePictureUrl)
         try container.encodeIfPresent(selectedMCPServerViewIds, forKey: .selectedMCPServerViewIds)
-        try container.encodeIfPresent(selectedSkillIds, forKey: .selectedSkillIds)
     }
 
     private enum CodingKeys: String, CodingKey {
-        case timezone, profilePictureUrl, selectedMCPServerViewIds, selectedSkillIds
+        case timezone, profilePictureUrl, selectedMCPServerViewIds
     }
 }
 

--- a/x/adrsimon/mobile/Dust/Models/Message.swift
+++ b/x/adrsimon/mobile/Dust/Models/Message.swift
@@ -10,6 +10,7 @@ enum AgentMessageStatus: String, Codable {
     case succeeded
     case failed
     case cancelled
+    case interrupted
     case gracefullyStopped = "gracefully_stopped"
 }
 

--- a/x/adrsimon/mobile/Dust/Models/StreamingEvent.swift
+++ b/x/adrsimon/mobile/Dust/Models/StreamingEvent.swift
@@ -206,6 +206,7 @@ struct AgentGenerationCancelledEvent: Decodable {
     let created: Double
     let configurationId: String
     let messageId: String
+    let status: String?
 }
 
 struct AgentMessageGracefullyStoppedEvent: Decodable {

--- a/x/adrsimon/mobile/Dust/Services/CapabilityService.swift
+++ b/x/adrsimon/mobile/Dust/Services/CapabilityService.swift
@@ -70,20 +70,6 @@ enum CapabilityService {
         let body = ConversationToolActionRequest(action: action, mcpServerViewId: mcpServerViewId)
         try await APIClient.authenticatedSend(endpoint, method: "POST", body: body, tokenProvider: tokenProvider, snakeCase: true)
     }
-
-    static func updateSkill(
-        action: ConversationAction,
-        workspaceId: String,
-        conversationId: String,
-        skillId: String,
-        tokenProvider: TokenProvider
-    ) async throws {
-        let endpoint = AppConfig.Endpoints.conversationSkills(
-            workspaceId: workspaceId, conversationId: conversationId
-        )
-        let body = ConversationSkillActionRequest(action: action, skillId: skillId)
-        try await APIClient.authenticatedSend(endpoint, method: "POST", body: body, tokenProvider: tokenProvider)
-    }
 }
 
 // MARK: - Request Bodies
@@ -91,9 +77,4 @@ enum CapabilityService {
 private struct ConversationToolActionRequest: Encodable {
     let action: ConversationAction
     let mcpServerViewId: String
-}
-
-private struct ConversationSkillActionRequest: Encodable {
-    let action: ConversationAction
-    let skillId: String
 }

--- a/x/adrsimon/mobile/Dust/Services/StreamingService.swift
+++ b/x/adrsimon/mobile/Dust/Services/StreamingService.swift
@@ -27,6 +27,12 @@ final private class AuthPreservingDelegate: NSObject, URLSessionTaskDelegate {
     }
 }
 
+private enum SSEConfig {
+    // High because the server sends no heartbeat; idle streams must not time out.
+    static let requestTimeoutSeconds: TimeInterval = 3600
+    static let resourceTimeoutSeconds: TimeInterval = 86400
+}
+
 /// Lightweight SSE client using URLSession async bytes.
 enum StreamingService {
     /// Connects to a Server-Sent Events endpoint and yields parsed `data:` payloads.
@@ -96,7 +102,10 @@ enum StreamingService {
             lastEventId: lastEventId
         )
         let delegate = AuthPreservingDelegate(accessToken: accessToken)
-        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = SSEConfig.requestTimeoutSeconds
+        configuration.timeoutIntervalForResource = SSEConfig.resourceTimeoutSeconds
+        let session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
 
         logger.info("SSE connecting: \(endpoint)")
         let (bytes, response) = try await session.bytes(for: request)

--- a/x/adrsimon/mobile/Dust/ViewModels/ConversationDetailViewModel.swift
+++ b/x/adrsimon/mobile/Dust/ViewModels/ConversationDetailViewModel.swift
@@ -175,6 +175,7 @@ final class ConversationDetailViewModel: ObservableObject {
             startMessageStream(for: newEvent.message.sId)
 
         case let .userMessageNew(newEvent):
+            removeOptimisticUserMessage()
             insertMessageIfNew(.user(newEvent.message))
 
         case let .userMessagePromoted(event):
@@ -191,6 +192,37 @@ final class ConversationDetailViewModel: ObservableObject {
         guard !messages.contains(where: { $0.id == msg.id }) else { return }
         messages.append(msg)
         messages.sort(by: ConversationMessage.byRank)
+    }
+
+    // MARK: - Optimistic User Message
+
+    private var optimisticUserMessageId: String?
+
+    func addOptimisticUserMessage(content: String, userEmail: String) {
+        removeOptimisticUserMessage()
+        let sId = "pending-\(UUID().uuidString)"
+        let nextRank = (messages.map(\.rank).max() ?? 0) + 1
+        let message = UserMessage(
+            id: 0,
+            sId: sId,
+            type: .userMessage,
+            created: Date().timeIntervalSince1970 * 1000,
+            visibility: "visible",
+            version: 0,
+            rank: nextRank,
+            content: content,
+            context: UserMessageContext(username: nil, fullName: nil, email: userEmail, profilePictureUrl: nil),
+            contentFragments: nil
+        )
+        optimisticUserMessageId = sId
+        messages.append(.user(message))
+        messages.sort(by: ConversationMessage.byRank)
+    }
+
+    func removeOptimisticUserMessage() {
+        guard let id = optimisticUserMessageId else { return }
+        messages.removeAll { $0.id == id }
+        optimisticUserMessageId = nil
     }
 
     // MARK: - Message Streaming (tokens, thinking, actions)
@@ -314,8 +346,8 @@ final class ConversationDetailViewModel: ObservableObject {
             lastError = ErrorInfo(from: event.error, messageId: messageId)
             finalizeMessage(messageId: messageId, status: .failed)
 
-        case .agentGenerationCancelled:
-            finalizeMessage(messageId: messageId, status: .cancelled)
+        case let .agentGenerationCancelled(event):
+            finalizeMessage(messageId: messageId, status: event.status == "interrupted" ? .interrupted : .cancelled)
 
         case let .toolPersonalAuthRequired(event):
             streamingPhase = .personalAuthRequired(

--- a/x/adrsimon/mobile/Dust/ViewModels/InputBarViewModel.swift
+++ b/x/adrsimon/mobile/Dust/ViewModels/InputBarViewModel.swift
@@ -95,22 +95,27 @@ final class InputBarViewModel: ObservableObject {
         guard !selectedCapabilities.contains(where: { $0.id == capability.id }) else { return }
         selectedCapabilities.append(capability)
         showCapabilitiesPicker = false
-
-        if let conversationId {
-            Task {
-                do { try await syncCapability(capability, action: .add, conversationId: conversationId) }
-                catch { logger.error("Failed to sync capability: \(error)") }
-            }
-        }
+        syncTool(capability, action: .add, conversationId: conversationId)
     }
 
     func deselectCapability(_ capability: Capability, conversationId: String? = nil) {
         selectedCapabilities.removeAll { $0.id == capability.id }
+        syncTool(capability, action: .delete, conversationId: conversationId)
+    }
 
-        if let conversationId {
-            Task {
-                do { try await syncCapability(capability, action: .delete, conversationId: conversationId) }
-                catch { logger.error("Failed to sync capability: \(error)") }
+    private func syncTool(_ capability: Capability, action: ConversationAction, conversationId: String?) {
+        guard let conversationId, case let .tool(serverView) = capability else { return }
+        Task {
+            do {
+                try await CapabilityService.updateTool(
+                    action: action,
+                    workspaceId: workspaceId,
+                    conversationId: conversationId,
+                    mcpServerViewId: serverView.sId,
+                    tokenProvider: tokenProvider
+                )
+            } catch {
+                logger.error("Failed to sync tool: \(error)")
             }
         }
     }
@@ -319,25 +324,30 @@ final class InputBarViewModel: ObservableObject {
     // MARK: - Private
 
     private var messageContext: MessageContext {
-        var toolIds: [String] = []
-        var skillIds: [String] = []
-        for capability in selectedCapabilities {
-            switch capability {
-            case let .tool(serverView): toolIds.append(serverView.sId)
-            case let .skill(skill): skillIds.append(skill.sId)
-            }
+        let toolIds = selectedCapabilities.compactMap { capability -> String? in
+            if case let .tool(serverView) = capability { return serverView.sId }
+            return nil
         }
         return MessageContext(
             timezone: TimeZone.current.identifier,
             profilePictureUrl: user.profilePictureUrl,
-            selectedMCPServerViewIds: toolIds.isEmpty ? nil : toolIds,
-            selectedSkillIds: skillIds.isEmpty ? nil : skillIds
+            selectedMCPServerViewIds: toolIds.isEmpty ? nil : toolIds
         )
+    }
+
+    private func contentWithSkillTags(_ content: String) -> String {
+        let tags = selectedCapabilities.compactMap { capability -> String? in
+            guard case let .skill(skill) = capability else { return nil }
+            let iconAttribute = skill.icon.map { " icon=\"\($0)\"" } ?? ""
+            return "<skill id=\"\(skill.sId)\" name=\"\(skill.name)\"\(iconAttribute) />"
+        }
+        guard !tags.isEmpty else { return content }
+        return ([content] + tags).joined(separator: "\n")
     }
 
     private func prepareSend() -> (text: String, context: MessageContext) {
         let text = messageText.trimmingCharacters(in: .whitespacesAndNewlines)
-        return (text, messageContext)
+        return (contentWithSkillTags(text), messageContext)
     }
 
     private func resolveMentions() -> [MentionPayload] {
@@ -363,29 +373,6 @@ final class InputBarViewModel: ObservableObject {
             self.error = error.localizedDescription
             isSending = false
             return nil
-        }
-    }
-
-    // MARK: - Capabilities
-
-    private func syncCapability(_ capability: Capability, action: ConversationAction, conversationId: String) async throws {
-        switch capability {
-        case let .tool(serverView):
-            try await CapabilityService.updateTool(
-                action: action,
-                workspaceId: workspaceId,
-                conversationId: conversationId,
-                mcpServerViewId: serverView.sId,
-                tokenProvider: tokenProvider
-            )
-        case let .skill(skill):
-            try await CapabilityService.updateSkill(
-                action: action,
-                workspaceId: workspaceId,
-                conversationId: conversationId,
-                skillId: skill.sId,
-                tokenProvider: tokenProvider
-            )
         }
     }
 

--- a/x/adrsimon/mobile/Dust/Views/Components/InputBarView.swift
+++ b/x/adrsimon/mobile/Dust/Views/Components/InputBarView.swift
@@ -6,6 +6,8 @@ struct InputBarView: View {
     var conversationId: String?
     var onConversationCreated: ((Conversation) -> Void)?
     var onMessageSent: (() -> Void)?
+    var onWillSendReply: ((String) -> Void)?
+    var onReplySendFailed: (() -> Void)?
 
     @FocusState private var isTextFieldFocused: Bool
 
@@ -275,8 +277,14 @@ struct InputBarView: View {
             Task {
                 isTextFieldFocused = false
                 if let conversationId {
+                    let pendingText = viewModel.messageText.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !pendingText.isEmpty {
+                        onWillSendReply?(pendingText)
+                    }
                     if await viewModel.sendReply(conversationId: conversationId) {
                         onMessageSent?()
+                    } else {
+                        onReplySendFailed?()
                     }
                 } else if let conversation = await viewModel.sendMessage() {
                     onConversationCreated?(conversation)

--- a/x/adrsimon/mobile/Dust/Views/ConversationDetailView.swift
+++ b/x/adrsimon/mobile/Dust/Views/ConversationDetailView.swift
@@ -47,7 +47,11 @@ struct ConversationDetailView: View {
             messageList
             InputBarView(
                 viewModel: inputBarViewModel,
-                conversationId: conversation.sId
+                conversationId: conversation.sId,
+                onWillSendReply: { text in
+                    viewModel.addOptimisticUserMessage(content: text, userEmail: currentUserEmail)
+                },
+                onReplySendFailed: { viewModel.removeOptimisticUserMessage() }
             )
         }
         .background(Color.dustBackground)
@@ -113,13 +117,11 @@ struct ConversationDetailView: View {
 
     // MARK: - Steering Detection
 
-    /// Returns true if the agent message at the given index is a steered follow-up
-    /// (i.e., the previous agent message with the same configuration was gracefully stopped).
     private func isSteeredAgentMessage(at index: Int) -> Bool {
         guard case let .agent(agentMsg) = viewModel.messages[index] else { return false }
         for i in stride(from: index - 1, through: 0, by: -1) {
             if case let .agent(prevAgent) = viewModel.messages[i] {
-                return prevAgent.status == .gracefullyStopped
+                return (prevAgent.status == .gracefullyStopped || prevAgent.status == .interrupted)
                     && prevAgent.configuration.sId == agentMsg.configuration.sId
             }
         }


### PR DESCRIPTION
## Description

The native iOS app (`x/adrsimon/mobile`) had drifted far behind the API and stopped working at runtime. This adapts the client to the current API and fixes the send/streaming UX along the way.

- **Conversation list** — the server dropped the numeric `id` from list items (SEC2); removing it from the model fixes the decode failure that broke the whole list.
- **Interrupted status** — handle the `interrupted` agent message status (produced by steering) on both decode and render.
- **Inlined skills** — skills are no longer a per-conversation action; the app now inlines `<skill id="…" name="…" />` tags into the message content at send time and drops the removed skills endpoint + sync code.
- **SSE keepalive** — the server sends no heartbeat, so URLSession's default 60s request timeout was killing idle conversation streams and forcing slow reconnects. Raised the per-request timeout for SSE.
- **Optimistic send** — the user message is inserted locally on send so it appears instantly, then reconciled with the server event.
- **Steered rendering** — a steered follow-up agent message renders as a continuation of the previous one rather than a fresh bubble.

## Tests

Manual, on the iOS simulator (iPhone 17 Pro) against prod: conversation list loads, sending shows the message instantly, streaming stays connected, and steered conversations render correctly. Built clean.

## Risk

Low, and scoped to the mobile app only — no server or shared code touched. Pure client decode/render changes; rollback is reverting the branch.

## Deploy Plan

No deploy. Native app, not part of the web release.