### PR TITLE
[front] fix: improve typing of summary items

### DIFF
--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -16,7 +16,7 @@ import type {
   SkillBuilderFormData,
 } from "@app/components/skill_builder/SkillBuilderFormContext";
 import {
-  type ReferenceSummaryTarget,
+  type ReferenceSummaryItem,
   SkillBuilderInstructionsReferenceSummary,
 } from "@app/components/skill_builder/SkillBuilderInstructionsReferenceSummary";
 import { useSkillVersionComparisonContext } from "@app/components/skill_builder/SkillBuilderVersionContext";
@@ -115,7 +115,7 @@ function getKnowledgeReferenceId(node: ProseMirrorNode): string | null {
 
 function matchesReferenceTarget(
   node: ProseMirrorNode,
-  target: ReferenceSummaryTarget
+  target: ReferenceSummaryItem
 ): boolean {
   switch (target.kind) {
     case "knowledge":
@@ -137,7 +137,7 @@ function matchesReferenceTarget(
 
 function getFirstReferencePosition(
   editor: Editor,
-  target: ReferenceSummaryTarget
+  target: ReferenceSummaryItem
 ): number | null {
   let referencePosition: number | null = null;
 
@@ -580,7 +580,7 @@ export function SkillBuilderInstructionsEditor({
   }, [editor, enableSkillReferences]);
 
   const handleReferenceClick = useCallback(
-    (target: ReferenceSummaryTarget) => {
+    (target: ReferenceSummaryItem) => {
       if (!editor || editor.isDestroyed) {
         return;
       }

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -18,18 +18,27 @@ interface SkillBuilderInstructionsReferenceSummaryProps {
   containerRef?: Ref<HTMLDivElement>;
   hasError: boolean;
   instructions: string;
-  onReferenceClick: (target: ReferenceSummaryTarget) => void;
+  onReferenceClick: (target: ReferenceSummaryItem) => void;
   referencedSkills: ReferencedSkillFormData[];
   tools: BuilderAction[];
 }
 
-export type ReferenceSummaryTarget =
-  | { id: string; kind: "knowledge" }
-  | { id: string; kind: "skill" }
-  | { id: string; kind: "tool" };
-
-type ReferenceSummaryItem = ReferenceSummaryTarget & {
-  icon?: string | null;
+type ReferenceSummaryItem =
+  | {
+  id: string;
+  kind: "knowledge";
+  title: string;
+}
+  | {
+  icon: string | null;
+  id: string;
+  kind: "skill";
+  title: string;
+}
+  | {
+  icon: string | null;
+  id: string;
+  kind: "tool";
   title: string;
 };
 
@@ -62,10 +71,8 @@ function renderReferenceSummaryItem({
   onReferenceClick,
 }: {
   item: ReferenceSummaryItem;
-  onReferenceClick: (target: ReferenceSummaryTarget) => void;
+  onReferenceClick: (target: ReferenceSummaryItem) => void;
 }) {
-  const handleClick = () => onReferenceClick({ id: item.id, kind: item.kind });
-
   switch (item.kind) {
     case "knowledge":
       return (
@@ -76,7 +83,7 @@ function renderReferenceSummaryItem({
           color="white"
           size="xs"
           className="text-xs"
-          onClick={handleClick}
+          onClick={() => onReferenceClick(item)}
         />
       );
     case "skill":
@@ -84,10 +91,10 @@ function renderReferenceSummaryItem({
         <Chip
           key={`${item.kind}:${item.id}`}
           label={item.title}
-          icon={getSkillIcon(item.icon ?? null)}
+          icon={getSkillIcon(item.icon)}
           color="white"
           size="xs"
-          onClick={handleClick}
+          onClick={() => onReferenceClick(item)}
         />
       );
     case "tool":
@@ -95,9 +102,9 @@ function renderReferenceSummaryItem({
         <ToolChip
           key={`${item.kind}:${item.id}`}
           title={item.title}
-          toolIcon={item.icon ?? null}
+          toolIcon={item.icon}
           color="white"
-          onClick={handleClick}
+          onClick={() => onReferenceClick(item)}
         />
       );
     default:

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -25,22 +25,22 @@ interface SkillBuilderInstructionsReferenceSummaryProps {
 
 export type ReferenceSummaryItem =
   | {
-  id: string;
-  kind: "knowledge";
-  title: string;
-}
+      id: string;
+      kind: "knowledge";
+      title: string;
+    }
   | {
-  icon: string | null;
-  id: string;
-  kind: "skill";
-  title: string;
-}
+      icon: string | null;
+      id: string;
+      kind: "skill";
+      title: string;
+    }
   | {
-  icon: string | null;
-  id: string;
-  kind: "tool";
-  title: string;
-};
+      icon: string | null;
+      id: string;
+      kind: "tool";
+      title: string;
+    };
 
 function dedupeById<T extends { id: string }>(items: T[]): T[] {
   const seenIds = new Set<string>();

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -23,7 +23,7 @@ interface SkillBuilderInstructionsReferenceSummaryProps {
   tools: BuilderAction[];
 }
 
-type ReferenceSummaryItem =
+export type ReferenceSummaryItem =
   | {
   id: string;
   kind: "knowledge";


### PR DESCRIPTION
## Description

- This PR fixes the typing of summary items to properly type icons and simplify the type dispatch between tools/skills/knowledge.
- Consequently allows fixing an issue with tool icons not rendering properly.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
