### PR TITLE
[front] fix: align vertically tool chips in Skill Builder

### DIFF
--- a/front/components/editor/extensions/skill_builder/ToolNodeWithView.tsx
+++ b/front/components/editor/extensions/skill_builder/ToolNodeWithView.tsx
@@ -57,7 +57,7 @@ function ToolNodeView({ node }: NodeViewProps) {
   const display = useToolNodeDisplay(attrs);
 
   return (
-    <NodeViewWrapper as="span" className="inline">
+    <NodeViewWrapper className="inline-flex align-middle">
       {display.kind === "error" ? (
         <ToolErrorChip title={display.title} />
       ) : (


### PR DESCRIPTION
## Description

- This PR fixes the vertical alignment of tool chips in the Skill Builder.

<img width="1859" height="735" alt="image" src="https://github.com/user-attachments/assets/a2cfef00-41f6-4d8e-b8d3-f7f59dc3a750" />

## Tests

- Checked on app preview.

## Risk

- Low.

## Deploy Plan

- Deploy front.
