### PR TITLE
[front] Ungate nested skills

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -209,7 +209,6 @@ app.post(
     });
 
     const isNewFileExplorer = conversation.metadata?.useFileSystem === true;
-    const hasNestedSkills = await hasFeatureFlag(auth, "nested_skills");
     const useFramesV2 = await hasFeatureFlag(auth, "frames_skill_v2");
 
     const promptSections = constructPromptMultiActions(auth, {
@@ -227,7 +226,6 @@ app.post(
       equippedSkills,
       projectContext,
       isNewFileExplorer,
-      hasNestedSkills,
       useFramesV2,
     });
     const prompt = systemPromptToText(promptSections);

--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -169,6 +169,7 @@ describe("GET /api/w/:wId/skills/:sId", () => {
     expect(data.skill.relations.childSkills[0]).not.toHaveProperty(
       "instructions"
     );
+    expect(data.skill.relations.usage.skills).toEqual([]);
   });
 
   it("should return 404 for non-existent skill", async () => {

--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -142,12 +142,10 @@ describe("GET /api/w/:wId/skills/:sId", () => {
     expect(data.skill.name).toBe("Test Skill");
   });
 
-  it("should return child skills when nested_skills is enabled", async () => {
+  it("should return child skills", async () => {
     const { workspace, skill, skillOwnerAuth } = await setupTest({
       requestUserRole: "admin",
     });
-
-    await FeatureFlagFactory.basic(skillOwnerAuth, "nested_skills");
 
     const childSkill = await SkillFactory.create(skillOwnerAuth, {
       name: "Child Skill",
@@ -171,27 +169,6 @@ describe("GET /api/w/:wId/skills/:sId", () => {
     expect(data.skill.relations.childSkills[0]).not.toHaveProperty(
       "instructions"
     );
-  });
-
-  it("should not return child skills when nested_skills is disabled", async () => {
-    const { workspace, skill, skillOwnerAuth } = await setupTest({
-      requestUserRole: "admin",
-    });
-
-    const childSkill = await SkillFactory.create(skillOwnerAuth, {
-      name: "Hidden Child Skill",
-    });
-    await SkillFactory.updateNestedSkillReferences(skillOwnerAuth, {
-      parentSkill: skill,
-      childSkills: [childSkill],
-    });
-
-    const response = await getSkillWithRelations(workspace, skill.sId);
-
-    expect(response.status).toBe(200);
-    const data = await response.json();
-
-    expect(data.skill.relations).not.toHaveProperty("childSkills");
   });
 
   it("should return 404 for non-existent skill", async () => {
@@ -349,7 +326,7 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
     expect(updatedSkill?.agentFacingDescription).toBe(newDescription);
   });
 
-  it("syncs nested skill references when the feature is enabled", async () => {
+  it("syncs nested skill references", async () => {
     const { workspace, skill, requestUserAuth } = await setupTest({
       requestUserRole: "admin",
     });
@@ -374,29 +351,12 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
       ...(referencedSkillIds !== undefined ? { referencedSkillIds } : {}),
     });
 
-    const disabledResponse = await patchSkill(
+    const addResponse = await patchSkill(
       workspace,
       skill.sId,
       buildBody(instructionsWithReference, [childSkill.sId])
     );
-    expect(disabledResponse.status).toBe(200);
-    const skillWithoutFeatureFlag = await SkillResource.fetchById(
-      requestUserAuth,
-      skill.sId
-    );
-    expect(skillWithoutFeatureFlag).not.toBeNull();
-    await expect(
-      skillWithoutFeatureFlag!.fetchChildSkills(requestUserAuth)
-    ).resolves.toHaveLength(0);
-
-    await FeatureFlagFactory.basic(requestUserAuth, "nested_skills");
-
-    const enabledResponse = await patchSkill(
-      workspace,
-      skill.sId,
-      buildBody(instructionsWithReference, [childSkill.sId])
-    );
-    expect(enabledResponse.status).toBe(200);
+    expect(addResponse.status).toBe(200);
     const skillWithReference = await SkillResource.fetchById(
       requestUserAuth,
       skill.sId
@@ -450,7 +410,6 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
       requestUserRole: "admin",
     });
 
-    await FeatureFlagFactory.basic(requestUserAuth, "nested_skills");
     const outOfWorkspaceSkillId = SkillResource.modelIdToSId({
       id: skill.id + 1,
       workspaceId: workspace.id + 1,
@@ -486,7 +445,6 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
       requestUserRole: "admin",
     });
 
-    await FeatureFlagFactory.basic(requestUserAuth, "nested_skills");
     const restrictedSpace = await SpaceFactory.regular(workspace);
     const childSkill = await SkillFactory.create(requestUserAuth, {
       name: "Restricted Child Skill",

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -114,18 +114,13 @@ app.get(
     const serializedSkill = skill.toJSON(auth);
 
     if (withRelations === "true") {
-      const featureFlags = await getFeatureFlags(auth);
-      const includeChildSkills = featureFlags.includes("nested_skills");
-
       const usage = await skill.fetchUsage(auth);
       const editors = await skill.listEditors(auth);
       const editedByUser = await skill.fetchEditedByUser(auth);
       const extendedSkill = serializedSkill.extendedSkillId
         ? await SkillResource.fetchById(auth, serializedSkill.extendedSkillId)
         : null;
-      const childSkills = includeChildSkills
-        ? await skill.fetchChildSkills(auth)
-        : [];
+      const childSkills = await skill.fetchChildSkills(auth);
 
       const skillWithRelations: SkillWithRelationsType = {
         ...serializedSkill,
@@ -134,20 +129,16 @@ app.get(
           editors: editors ? editors.map((e) => e.toJSON()) : null,
           editedByUser: editedByUser ? editedByUser.toJSON() : null,
           extendedSkill: extendedSkill ? extendedSkill.toJSON(auth) : null,
-          ...(includeChildSkills
-            ? {
-                childSkills: childSkills.map((childSkill) => {
-                  const {
-                    instructions,
-                    instructionsHtml,
-                    tools,
-                    ...childSkillWithoutInstructionsAndTools
-                  } = childSkill.toJSON(auth);
+          childSkills: childSkills.map((childSkill) => {
+            const {
+              instructions,
+              instructionsHtml,
+              tools,
+              ...childSkillWithoutInstructionsAndTools
+            } = childSkill.toJSON(auth);
 
-                  return childSkillWithoutInstructionsAndTools;
-                }),
-              }
-            : {}),
+            return childSkillWithoutInstructionsAndTools;
+          }),
         },
       };
 
@@ -318,8 +309,15 @@ app.patch(
       ...additionalRequestedSpaceIds,
     ]);
 
+    const referencedSkillIds =
+      body.referencedSkillIds !== undefined
+        ? uniq(
+            body.referencedSkillIds.filter(
+              (referencedSkillId) => referencedSkillId !== skill.sId
+            )
+          )
+        : undefined;
     const featureFlags = await getFeatureFlags(auth);
-    const enableSkillReferences = featureFlags.includes("nested_skills");
 
     // Validate file attachments if provided (gated behind sandbox_tools).
     let files: FileResource[] | undefined;
@@ -387,8 +385,7 @@ app.patch(
       name,
       reinforcement: body.reinforcement,
       requestedSpaceIds,
-      enableSkillReferences,
-      referencedSkillIds: body.referencedSkillIds,
+      referencedSkillIds,
       userFacingDescription: body.userFacingDescription,
       ...(shouldActivate ? { status: "active" as const } : {}),
     });

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -121,11 +121,19 @@ app.get(
         ? await SkillResource.fetchById(auth, serializedSkill.extendedSkillId)
         : null;
       const childSkills = await skill.fetchChildSkills(auth);
+      const usedBySkills =
+        (await SkillResource.batchFetchUsedBySkills(auth, [skill])).get(
+          skill.sId
+        ) ?? [];
 
       const skillWithRelations: SkillWithRelationsType = {
         ...serializedSkill,
         relations: {
-          usage,
+          usage: {
+            ...usage,
+            count: usage.count + usedBySkills.length,
+            skills: usedBySkills,
+          },
           editors: editors ? editors.map((e) => e.toJSON()) : null,
           editedByUser: editedByUser ? editedByUser.toJSON() : null,
           extendedSkill: extendedSkill ? extendedSkill.toJSON(auth) : null,

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -407,7 +407,7 @@ describe("GET /api/w/:wId/skills?withRelations=true", () => {
 
     expect(skillResult).toMatchObject({
       relations: {
-        usage: { count: 0, agents: [] },
+        usage: { count: 0, agents: [], skills: [] },
       },
     });
   });
@@ -449,7 +449,7 @@ describe("GET /api/w/:wId/skills?withRelations=true", () => {
         ],
       },
     });
-    expect(skillResult.relations.childSkills?.[0]).not.toHaveProperty(
+    expect(skillResult.relations.childSkills[0]).not.toHaveProperty(
       "instructions"
     );
   });

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -412,43 +412,13 @@ describe("GET /api/w/:wId/skills?withRelations=true", () => {
     });
   });
 
-  it("should not return used-by skills without the nested_skills feature flag", async () => {
+  it("should return child skills", async () => {
     const { workspace, user } = await setupTest();
 
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
       workspace.sId
     );
-
-    const { childSkill } = await SkillFactory.createWithNestedSkill(auth, {
-      childOverrides: {
-        name: "Referenced Skill",
-      },
-      parentOverrides: {
-        name: "Parent Skill",
-      },
-    });
-
-    const response = await getSkills(workspace, { withRelations: "true" });
-
-    expect(response.status).toBe(200);
-
-    const skillResult = (await response.json()).skills.find(
-      (s: SkillWithoutInstructionsAndToolsWithRelationsType) =>
-        s.sId === childSkill.sId
-    );
-
-    expect(skillResult.relations.usage).not.toHaveProperty("skills");
-  });
-
-  it("should return child skills when nested_skills is enabled", async () => {
-    const { workspace, user } = await setupTest();
-
-    const auth = await Authenticator.fromUserIdAndWorkspaceId(
-      user.sId,
-      workspace.sId
-    );
-    await FeatureFlagFactory.basic(auth, "nested_skills");
 
     const { parentSkill, childSkill } =
       await SkillFactory.createWithNestedSkill(auth, {
@@ -484,14 +454,13 @@ describe("GET /api/w/:wId/skills?withRelations=true", () => {
     );
   });
 
-  it("should return skills that reference a skill when nested_skills is enabled", async () => {
+  it("should return skills that reference a skill", async () => {
     const { workspace, user } = await setupTest();
 
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
       workspace.sId
     );
-    await FeatureFlagFactory.basic(auth, "nested_skills");
 
     const { childSkill, parentSkill } =
       await SkillFactory.createWithNestedSkill(auth, {
@@ -642,10 +611,9 @@ describe("POST /api/w/:wId/skills", () => {
     expect(createdSkill).not.toBeNull();
   });
 
-  it("creates skill references when nested skills is enabled", async () => {
+  it("creates skill references", async () => {
     const { auth, workspace } = await setupTest("admin");
 
-    await FeatureFlagFactory.basic(auth, "nested_skills");
     const childSkill = await SkillFactory.create(auth, {
       name: "Referenced Skill",
     });
@@ -680,8 +648,6 @@ describe("POST /api/w/:wId/skills", () => {
 
   it("drops missing nested skill references", async () => {
     const { auth, workspace } = await setupTest("admin");
-
-    await FeatureFlagFactory.basic(auth, "nested_skills");
 
     const response = await postSkill(workspace, {
       name: "Parent Skill",

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -15,7 +15,6 @@ import logger from "@app/logger/logger";
 import {
   SKILL_REINFORCEMENT_MODES,
   type SkillWithoutInstructionsAndToolsWithRelationsType,
-  type UsedBySkillType,
 } from "@app/types/assistant/skill_configuration";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { isBuilder } from "@app/types/user";
@@ -127,9 +126,6 @@ app.get(
     });
 
     if (withRelations === "true") {
-      const featureFlags = await getFeatureFlags(auth);
-      const includeNestedSkills = featureFlags.includes("nested_skills");
-
       const extendedSkills = await SkillResource.fetchByIds(
         auth,
         removeNulls(uniq(skills.map((s) => s.extendedSkillId)))
@@ -140,16 +136,14 @@ app.get(
         auth,
         skills
       );
-      let childSkillsMap = new Map<string, SkillResource[]>();
-      if (includeNestedSkills) {
-        childSkillsMap = await SkillResource.batchFetchChildSkills(
-          auth,
-          skills
-        );
-      }
-      const usedBySkillsMap = includeNestedSkills
-        ? await SkillResource.batchFetchUsedBySkills(auth, skills)
-        : new Map<string, UsedBySkillType[]>();
+      const childSkillsMap = await SkillResource.batchFetchChildSkills(
+        auth,
+        skills
+      );
+      const usedBySkillsMap = await SkillResource.batchFetchUsedBySkills(
+        auth,
+        skills
+      );
 
       const extendedSkillsMap = new Map(extendedSkills.map((s) => [s.sId, s]));
 
@@ -165,13 +159,11 @@ app.get(
         const editors = editorsMap.get(sc.sId) ?? null;
         const editedByUser = editedByUsersMap.get(sc.sId) ?? null;
         const usedBySkills = usedBySkillsMap.get(sc.sId) ?? [];
-        const usageWithSkills = includeNestedSkills
-          ? {
-              ...usage,
-              count: usage.count + usedBySkills.length,
-              skills: usedBySkills,
-            }
-          : usage;
+        const usageWithSkills = {
+          ...usage,
+          count: usage.count + usedBySkills.length,
+          skills: usedBySkills,
+        };
 
         return {
           ...skillWithoutInstructionsAndTools,
@@ -183,22 +175,18 @@ app.get(
               ? (extendedSkillsMap.get(sc.extendedSkillId)?.toJSON(auth) ??
                 null)
               : null,
-            ...(includeNestedSkills
-              ? {
-                  childSkills: (childSkillsMap.get(sc.sId) ?? []).map(
-                    (childSkill) => {
-                      const {
-                        instructions,
-                        instructionsHtml,
-                        tools,
-                        ...childSkillWithoutInstructionsAndTools
-                      } = childSkill.toJSON(auth);
+            childSkills: (childSkillsMap.get(sc.sId) ?? []).map(
+              (childSkill) => {
+                const {
+                  instructions,
+                  instructionsHtml,
+                  tools,
+                  ...childSkillWithoutInstructionsAndTools
+                } = childSkill.toJSON(auth);
 
-                      return childSkillWithoutInstructionsAndTools;
-                    }
-                  ),
-                }
-              : {}),
+                return childSkillWithoutInstructionsAndTools;
+              }
+            ),
           },
         } satisfies SkillWithoutInstructionsAndToolsWithRelationsType;
       });
@@ -355,9 +343,8 @@ app.post(
       });
     }
 
-    const featureFlags = await getFeatureFlags(auth);
-    const enableSkillReferences = featureFlags.includes("nested_skills");
     const referencedSkillIds = uniq(body.referencedSkillIds ?? []);
+    const featureFlags = await getFeatureFlags(auth);
 
     // Validate file attachments if provided (gated behind sandbox_tools).
     let files: FileResource[] | undefined;
@@ -441,7 +428,6 @@ app.post(
         mcpServerViews,
         attachedKnowledge: attachedKnowledgeWithDataSourceViews,
         fileAttachments: files,
-        enableSkillReferences,
         referencedSkillIds,
       }
     );

--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -10,7 +10,6 @@ import { SkillBuilderInstructionsSection } from "@app/components/skill_builder/S
 import { SkillBuilderRequestedSpacesSection } from "@app/components/skill_builder/SkillBuilderRequestedSpacesSection";
 import { SkillBuilderSettingsSection } from "@app/components/skill_builder/SkillBuilderSettingsSection";
 import { SkillBuilderSuggestionsPanel } from "@app/components/skill_builder/SkillBuilderSuggestionsPanel";
-import { SkillBuilderToolsSection } from "@app/components/skill_builder/SkillBuilderToolsSection";
 import { SkillVersionHistoryPicker } from "@app/components/skill_builder/SkillBuilderVersionComparisonBanner";
 import { SkillBuilderVersionComparisonFooter } from "@app/components/skill_builder/SkillBuilderVersionComparisonFooter";
 import {
@@ -82,7 +81,6 @@ export default function SkillBuilder({
 
   const hasSelfImprovingSkills =
     hasFeature("reinforced_agents") && hasFeature("reinforcement_ui");
-  const enableSkillReferences = hasFeature("nested_skills");
 
   const { suggestions } = useSkillSuggestions({
     skillId: skill?.sId ?? null,
@@ -214,7 +212,7 @@ export default function SkillBuilder({
               size="lg"
             >
               A customized version of {extendedSkill.name} with your own
-              guidelines and {enableSkillReferences ? "capabilities" : "tools"}.
+              guidelines and capabilities.
             </ContentMessage>
           )}
           {skill?.status === "suggested" && (
@@ -235,9 +233,6 @@ export default function SkillBuilder({
             initialRequestedSpaceIds={skill?.requestedSpaceIds}
           />
           {hasFeature("sandbox_tools") && <SkillBuilderFilesSection />}
-          {!enableSkillReferences && (
-            <SkillBuilderToolsSection extendedSkill={extendedSkill} />
-          )}
           <SkillBuilderSettingsOrComparisonFooter
             skill={skill}
             hasSelfImprovingSkills={hasSelfImprovingSkills}

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -284,7 +284,6 @@ export function SkillBuilderInstructionsEditor({
   const { hasFeature } = useFeatureFlags();
   const hasReinforcementFeature =
     hasFeature("reinforced_agents") && hasFeature("reinforcement_ui");
-  const enableSkillReferences = hasFeature("nested_skills");
 
   const { field: instructionsField, fieldState: instructionsFieldState } =
     useController<SkillBuilderFormData, typeof INSTRUCTIONS_FIELD_NAME>({
@@ -343,12 +342,11 @@ export function SkillBuilderInstructionsEditor({
   const displayError =
     !!instructionsFieldState.error || !!attachedKnowledgeFieldState.error;
   const hasInstructionReferenceSummary =
-    enableSkillReferences &&
-    ((attachedKnowledgeField.value?.length ?? 0) > 0 ||
-      referencedSkills.length > 0 ||
-      tools.length > 0 ||
-      (instructionsField.value?.includes("<knowledge ") ?? false) ||
-      (instructionsField.value?.includes("<tool ") ?? false));
+    (attachedKnowledgeField.value?.length ?? 0) > 0 ||
+    referencedSkills.length > 0 ||
+    tools.length > 0 ||
+    (instructionsField.value?.includes("<knowledge ") ?? false) ||
+    (instructionsField.value?.includes("<tool ") ?? false);
 
   const syncAttachedKnowledgeFromEditor = useCallback(
     (editor: Editor) => {
@@ -414,14 +412,13 @@ export function SkillBuilderInstructionsEditor({
       );
       instructionsHtmlField.onChange(
         sanitizeSkillInstructionsHtml(editor.getHTML(), {
-          enableSkillReferences,
+          enableSkillReferences: true,
         })
       );
       syncAttachedKnowledgeFromEditor(editor);
       syncInlineReferencesFromEditor(editor);
     },
     [
-      enableSkillReferences,
       instructionsField.onChange,
       instructionsHtmlField.onChange,
       syncAttachedKnowledgeFromEditor,
@@ -533,7 +530,7 @@ export function SkillBuilderInstructionsEditor({
     isReadOnly: hasSuggestions,
     skillReferences: {
       currentSkillId: skillId,
-      enableSkillReferences,
+      enableSkillReferences: true,
       onSkillDetails: handleSkillDetails,
       onSkillNodeDetails: setSelectedSkillIdForDetails,
       onSelectSkill: handleSelectSkillReference,
@@ -597,12 +594,12 @@ export function SkillBuilderInstructionsEditor({
   }, [editor, handleAddKnowledge, onAddKnowledge]);
 
   const handleOpenCapabilities = useCallback(() => {
-    if (!editor || !enableSkillReferences) {
+    if (!editor) {
       return;
     }
 
     editor.commands.openCapabilitiesSlashCommand();
-  }, [editor, enableSkillReferences]);
+  }, [editor]);
 
   const handleReferenceClick = useCallback(
     (target: ReferenceSummaryItem) => {
@@ -649,15 +646,10 @@ export function SkillBuilderInstructionsEditor({
   );
 
   useEffect(() => {
-    if (editor && enableSkillReferences && onOpenCapabilities) {
+    if (editor && onOpenCapabilities) {
       onOpenCapabilities(handleOpenCapabilities);
     }
-  }, [
-    editor,
-    enableSkillReferences,
-    handleOpenCapabilities,
-    onOpenCapabilities,
-  ]);
+  }, [editor, handleOpenCapabilities, onOpenCapabilities]);
 
   // Register a callback that the suggestions panel can call to accept a
   // suggestion directly via the editor's ProseMirror commands.
@@ -824,12 +816,12 @@ export function SkillBuilderInstructionsEditor({
 
     const incomingHtml = instructionsHtmlField.value;
     const currentHtml = sanitizeSkillInstructionsHtml(editor.getHTML(), {
-      enableSkillReferences,
+      enableSkillReferences: true,
     });
     if (currentHtml !== incomingHtml) {
       editor.commands.setContent(incomingHtml, { emitUpdate: false });
     }
-  }, [editor, enableSkillReferences, isDiffMode, instructionsHtmlField.value]);
+  }, [editor, isDiffMode, instructionsHtmlField.value]);
 
   useEffect(() => {
     if (!editor || editor.isDestroyed) {
@@ -851,7 +843,7 @@ export function SkillBuilderInstructionsEditor({
 
         editor.commands.setContent(
           preprocessMarkdownForEditor(currentText, {
-            enableSkillReferences,
+            enableSkillReferences: true,
           }),
           {
             emitUpdate: false,
@@ -860,10 +852,10 @@ export function SkillBuilderInstructionsEditor({
         );
         editor.commands.applyDiff(
           preprocessMarkdownForEditor(compareText, {
-            enableSkillReferences,
+            enableSkillReferences: true,
           }),
           preprocessMarkdownForEditor(currentText, {
-            enableSkillReferences,
+            enableSkillReferences: true,
           })
         );
         editor.setEditable(false);
@@ -878,7 +870,7 @@ export function SkillBuilderInstructionsEditor({
         } else {
           editor.commands.setContent(
             preprocessMarkdownForEditor(instructionsField.value ?? "", {
-              enableSkillReferences,
+              enableSkillReferences: true,
             }),
             {
               emitUpdate: false,
@@ -897,7 +889,6 @@ export function SkillBuilderInstructionsEditor({
   }, [
     compareVersion,
     editor,
-    enableSkillReferences,
     instructionsField.value,
     instructionsHtmlField.value,
   ]);
@@ -910,17 +901,15 @@ export function SkillBuilderInstructionsEditor({
             editor={editor}
             isReadOnly={hasSuggestions}
           />
-          {enableSkillReferences && (
-            <SkillBuilderInstructionsReferenceSummary
-              attachedKnowledge={attachedKnowledgeField.value}
-              containerRef={instructionReferenceSummaryRef}
-              hasError={displayError}
-              instructions={instructionsField.value ?? ""}
-              onReferenceClick={handleReferenceClick}
-              referencedSkills={referencedSkills}
-              tools={tools}
-            />
-          )}
+          <SkillBuilderInstructionsReferenceSummary
+            attachedKnowledge={attachedKnowledgeField.value}
+            containerRef={instructionReferenceSummaryRef}
+            hasError={displayError}
+            instructions={instructionsField.value ?? ""}
+            onReferenceClick={handleReferenceClick}
+            referencedSkills={referencedSkills}
+            tools={tools}
+          />
         </div>
 
         {instructionsFieldState.error && (

--- a/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
@@ -1,7 +1,6 @@
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import { SkillBuilderInstructionsEditor } from "@app/components/skill_builder/SkillBuilderInstructionsEditor";
 import { useSkillVersionComparisonContext } from "@app/components/skill_builder/SkillBuilderVersionContext";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { SKILL_INSTRUCTIONS_LABEL } from "@app/lib/skills/labels";
 import {
   BookOpen01,
@@ -22,13 +21,10 @@ const INSTRUCTIONS_HTML_FIELD_NAME = "instructionsHtml";
 export function SkillBuilderInstructionsSection() {
   const { setValue, watch } = useFormContext<SkillBuilderFormData>();
   const { compareVersion, exitDiffMode } = useSkillVersionComparisonContext();
-  const { hasFeature } = useFeatureFlags();
   const [addKnowledge, setAddKnowledge] = useState<(() => void) | null>(null);
   const [openCapabilities, setOpenCapabilities] = useState<(() => void) | null>(
     null
   );
-
-  const enableSkillReferences = hasFeature("nested_skills");
 
   const currentInstructions = watch(INSTRUCTIONS_FIELD_NAME);
   const instructionsDiffer =
@@ -75,14 +71,14 @@ export function SkillBuilderInstructionsSection() {
           )}
           {!compareVersion && (
             <Button
-              variant={enableSkillReferences ? "outline" : "primary"}
+              variant="outline"
               label="Attach knowledge"
               icon={BookOpen01}
               onClick={addKnowledge ?? undefined}
               disabled={!addKnowledge}
             />
           )}
-          {!compareVersion && enableSkillReferences && (
+          {!compareVersion && (
             <Button
               variant="primary"
               label="Attach capabilities"

--- a/front/components/skill_builder/SkillSuggestionCard.tsx
+++ b/front/components/skill_builder/SkillSuggestionCard.tsx
@@ -1,7 +1,6 @@
 import { useMaybeMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import { getBlockOuterHtml } from "@app/components/shared/utils";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { buildSkillInstructionsExtensions } from "@app/lib/editor/build_skill_instructions_extensions";
 import type {
   SkillAgentFacingDescriptionEditType,
@@ -123,8 +122,6 @@ function InstructionEditDiffBlock({
   getSkillInstructionsHtml,
 }: InstructionEditDiffBlockProps) {
   const { targetBlockId, content } = edit;
-  const { hasFeature } = useFeatureFlags();
-  const enableSkillReferences = hasFeature("nested_skills");
 
   const blockHtml = useMemo(() => {
     const instructionsHtml = getSkillInstructionsHtml();
@@ -138,7 +135,7 @@ function InstructionEditDiffBlock({
     {
       extensions: [
         ...buildSkillInstructionsExtensions(true, [], {
-          enableSkillReferences,
+          enableSkillReferences: true,
         }),
       ],
       editable: false,
@@ -156,7 +153,7 @@ function InstructionEditDiffBlock({
         e.commands.setHighlightedSuggestion(targetBlockId);
       },
     },
-    [blockHtml, enableSkillReferences]
+    [blockHtml]
   );
 
   return <DiffBlock>{editor && <EditorContent editor={editor} />}</DiffBlock>;

--- a/front/components/skill_builder/skillFormData.ts
+++ b/front/components/skill_builder/skillFormData.ts
@@ -29,7 +29,7 @@ export function transformSkillTypeToFormData(
     reinforcement: skill.reinforcement,
     additionalSpaces: [],
     referencedSkills:
-      skill.relations?.childSkills?.map((childSkill) => ({
+      skill.relations?.childSkills.map((childSkill) => ({
         id: childSkill.sId,
         name: childSkill.name,
         icon: childSkill.icon,
@@ -37,7 +37,7 @@ export function transformSkillTypeToFormData(
       })) ?? [],
     referencedSkillIds: [
       ...new Set([
-        ...(skill.relations?.childSkills?.map((childSkill) => childSkill.sId) ??
+        ...(skill.relations?.childSkills.map((childSkill) => childSkill.sId) ??
           []),
         ...extractUniqueSkillReferenceIds(skill.instructions ?? ""),
       ]),

--- a/front/components/skills/ArchiveSkillDialog.tsx
+++ b/front/components/skills/ArchiveSkillDialog.tsx
@@ -30,7 +30,7 @@ export function ArchiveSkillDialog({
   const [isArchiving, setIsArchiving] = useState(false);
   const doArchive = useArchiveSkill({ owner, skill: skill });
   const agentsUsageCount = skill.relations.usage.agents.length;
-  const skillsUsageCount = skill.relations.usage.skills?.length ?? 0;
+  const skillsUsageCount = skill.relations.usage.skills.length;
   const usageLabels = removeNulls([
     agentsUsageCount > 0
       ? `${agentsUsageCount} agent${pluralize(agentsUsageCount)}`

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -92,7 +92,7 @@ export function SkillInfoTab({
     [skill.relations?.childSkills]
   );
 
-  const showChildSkills = hasFeature("nested_skills") && childSkills.length > 0;
+  const showChildSkills = childSkills.length > 0;
 
   const handleKnowledgeItemsChange = useCallback((items: KnowledgeItem[]) => {
     setKnowledgeItems(items);
@@ -125,7 +125,7 @@ export function SkillInfoTab({
           <SkillInstructionsReadOnlyEditor
             content={skill.instructions}
             htmlContent={skill.instructionsHtml ?? ""}
-            enableSkillReferences={hasFeature("nested_skills")}
+            enableSkillReferences
             owner={owner}
             onKnowledgeItemsChange={handleKnowledgeItemsChange}
             className="max-h-150 overflow-y-auto"

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -3,6 +3,7 @@ import type {
   SkillUsageType,
   UsedBySkillType,
 } from "@app/types/assistant/skill_configuration";
+import type { AgentsUsageType } from "@app/types/data_source";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { pluralize } from "@app/types/shared/utils/string_utils";
@@ -103,7 +104,7 @@ function UsedByButtonIcon({
 }
 
 interface UsedByButtonProps {
-  usage: SkillUsageType | null;
+  usage: AgentsUsageType | SkillUsageType | null;
   onItemClick: (assistantSid: string) => void;
   onSkillClick?: (skillId: string) => void;
 }
@@ -117,7 +118,7 @@ export function UsedByButton({
   const [isOpen, setIsOpen] = useState(false);
 
   const agents = usage?.agents ?? [];
-  const skills = usage?.skills ?? [];
+  const skills = usage && "skills" in usage ? usage.skills : [];
   const agentCount = agents.length;
   const skillCount = skills.length;
   const totalCount = agentCount + skillCount;

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.test.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.test.ts
@@ -9,7 +9,6 @@ import {
 import { isSkillAuthoringResultOutput } from "@app/lib/api/actions/servers/skill_authoring/rendering";
 import { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
@@ -541,7 +540,6 @@ describe("skill_authoring tools", () => {
 
   it("rejects a targeted edit that drops a nested skill tag", async () => {
     const { authenticator } = await createResourceTest({ role: "builder" });
-    await FeatureFlagFactory.basic(authenticator, "nested_skills");
 
     const childSkill = await SkillFactory.create(authenticator, {
       name: "Child Skill",
@@ -552,7 +550,6 @@ describe("skill_authoring tools", () => {
     const parentSkill = await seedSkill(authenticator, {
       name: "Parent Skill",
       instructions: originalInstructions,
-      enableSkillReferences: true,
       referencedSkillIds: [childSkill.sId],
     });
 
@@ -668,7 +665,6 @@ describe("skill_authoring tools", () => {
 
   it("keeps nested skill references in sync when editing instructions", async () => {
     const { authenticator } = await createResourceTest({ role: "builder" });
-    await FeatureFlagFactory.basic(authenticator, "nested_skills");
 
     const childSkill = await SkillFactory.create(authenticator, {
       name: "Child Skill",
@@ -680,7 +676,6 @@ describe("skill_authoring tools", () => {
     const parentSkill = await seedSkill(authenticator, {
       name: "Parent Skill",
       instructions: `Use ${skillReferenceTag} when needed.`,
-      enableSkillReferences: false,
       referencedSkillIds: [],
     });
 
@@ -756,7 +751,6 @@ describe("skill_authoring tools", () => {
 
   it("rejects creating a skill that embeds a nested skill reference", async () => {
     const { authenticator } = await createResourceTest({ role: "builder" });
-    await FeatureFlagFactory.basic(authenticator, "nested_skills");
 
     const childSkill = await SkillFactory.create(authenticator, {
       name: "Child Skill",

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.ts
@@ -16,7 +16,7 @@ import {
 import { makeSkillAuthoringResultOutput } from "@app/lib/api/actions/servers/skill_authoring/rendering";
 import { getUpdatedContentAndOccurrences } from "@app/lib/api/files/utils";
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
-import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { convertMarkdownToBlockHtml } from "@app/lib/reinforcement/skill_instructions_html";
 import { pruneOutdatedSkillEditSuggestions } from "@app/lib/reinforcement/skill_suggestion_pruning";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -297,7 +297,6 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
       {
         mcpServerViews: [],
         attachedKnowledge: [],
-        enableSkillReferences: false,
         referencedSkillIds: [],
       }
     );
@@ -468,9 +467,6 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
       );
     }
 
-    const enableSkillReferences = (await getFeatureFlags(auth)).includes(
-      "nested_skills"
-    );
     const attachedKnowledge = await skill.getAttachedKnowledge(auth);
 
     // When the instructions change, re-derive the referenced skills from the new
@@ -494,7 +490,6 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
       mcpServerViews: skill.mcpServerViews,
       name: trimmedName,
       requestedSpaceIds: skill.requestedSpaceIds,
-      enableSkillReferences,
       referencedSkillIds,
       userFacingDescription:
         userFacingDescription ?? skill.userFacingDescription,

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -206,11 +206,9 @@ function constructToolsSection({
 
 function constructSkillsSection({
   systemSkills,
-  hasNestedSkills = false,
   useFramesV2,
 }: {
   systemSkills: SkillResource[];
-  hasNestedSkills?: boolean;
   useFramesV2: boolean;
 }): string {
   const toolDisplayName = `${SKILL_MANAGEMENT_SERVER_NAME}${TOOL_NAME_SEPARATOR}${ENABLE_SKILL_TOOL_NAME}`;
@@ -224,21 +222,14 @@ function constructSkillsSection({
     `You can enable them using the \`${toolDisplayName}\` tool when they become relevant to the conversation.\n` +
     "- **Enabled**: Fully active with instructions loaded.\n\n" +
     "Enable skills proactively when a user's request matches a skill's purpose.\n" +
-    (hasNestedSkills
-      ? `Skill references can also appear as \`<skill id=\"...\" name=\"...\" />\` tags in user messages or enabled skill instructions. ` +
-        "These tags are strong hints that the referenced skill is relevant, including when a skill author nested one skill inside another. " +
-        `If the referenced skill would help and is not already enabled, call \`${toolDisplayName}\` with \`skillName\` set to the tag's \`name\` value.\n` +
-        "Referenced skills may not appear in the available-skills list; a tag is enough to enable the skill by name. " +
-        "Only enable skills you actually need, because enabling a skill loads its full instructions into context.\n" +
-        `Enabled skill instructions can also contain \`<unavailable_skill id=\"...\" />\` tags. ` +
-        "These mean the instructions used to reference another skill, but that skill is no longer available to this conversation, for example because skill scope or permissions changed. " +
-        "Do not try to enable unavailable skill tags.\n"
-      : `If a user message contains a \`<skill id=\"...\" name=\"...\" />\` tag, treat it as a strong hint that the ` +
-        "referenced skill is relevant: it means the user specifically mentioned this skill. If the skill is not already " +
-        `enabled, and it would help, enable it with \`${toolDisplayName}\`.\n` +
-        "It is expected that these skills do not appear in the list of available skills, they are specifically requested " +
-        "by the user and can be enabled safely." +
-        "Only enable skills you actually need, enabling a skill loads its full instructions into context.\n") +
+    `Skill references can also appear as \`<skill id=\"...\" name=\"...\" />\` tags in user messages or enabled skill instructions. ` +
+    "These tags are strong hints that the referenced skill is relevant, including when a skill author nested one skill inside another. " +
+    `If the referenced skill would help and is not already enabled, call \`${toolDisplayName}\` with \`skillName\` set to the tag's \`name\` value.\n` +
+    "Referenced skills may not appear in the available-skills list; a tag is enough to enable the skill by name. " +
+    "Only enable skills you actually need, because enabling a skill loads its full instructions into context.\n" +
+    `Enabled skill instructions can also contain \`<unavailable_skill id=\"...\" />\` tags. ` +
+    "These mean the instructions used to reference another skill, but that skill is no longer available to this conversation, for example because skill scope or permissions changed. " +
+    "Do not try to enable unavailable skill tags.\n" +
     "If you need to enable multiple skills, enable them in parallel.\n\n" +
     "When in doubt about enabling a skill, prefer enabling it as it may give you a new " +
     "perspective on the currently available context.\n";
@@ -416,7 +407,6 @@ export function constructPromptMultiActions(
     projectContext,
     isNewFileExplorer = false,
     hasSandboxTools = false,
-    hasNestedSkills = false,
     useFramesV2 = false,
     disableFormattingPrompt = false,
   }: {
@@ -439,7 +429,6 @@ export function constructPromptMultiActions(
     projectContext?: string;
     isNewFileExplorer?: boolean;
     hasSandboxTools?: boolean;
-    hasNestedSkills?: boolean;
     useFramesV2?: boolean;
     disableFormattingPrompt?: boolean;
   }
@@ -480,7 +469,6 @@ export function constructPromptMultiActions(
   });
   const skillsSection = constructSkillsSection({
     systemSkills,
-    hasNestedSkills,
     useFramesV2,
   });
   const attachmentsSection = isNewFileExplorer

--- a/front/lib/reinforcement/aggregate_suggestions.test.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.test.ts
@@ -217,11 +217,12 @@ describe("buildSkillAggregationPrompt", () => {
     expect(userMessage).not.toContain("Previously rejected suggestions");
   });
 
-  it("system prompt mentions the suggestion tool", () => {
+  it("system prompt mentions the suggestion tool when inline tools are disabled", () => {
     const { systemPrompt } = buildSkillAggregationPrompt(
       makeSkill(),
       [makeInstructionSuggestion()],
-      { pending: [], rejected: [] }
+      { pending: [], rejected: [] },
+      { useInlineTools: false }
     );
 
     expect(systemPrompt).toContain("edit_skill");
@@ -301,7 +302,7 @@ describe("buildSkillAggregationPrompt", () => {
     expect(userMessage).not.toContain("<title>");
   });
 
-  it("includes skill tools as a separate user message block by default", () => {
+  it("includes skill tools as a separate user message block when inline tools are disabled", () => {
     const skill = makeSkill({
       tools: [
         {
@@ -313,7 +314,8 @@ describe("buildSkillAggregationPrompt", () => {
     const { userMessage } = buildSkillAggregationPrompt(
       skill,
       [makeInstructionSuggestion()],
-      { pending: [], rejected: [] }
+      { pending: [], rejected: [] },
+      { useInlineTools: false }
     );
 
     expect(userMessage).toContain("<tools>");

--- a/front/lib/reinforcement/aggregate_suggestions.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.ts
@@ -6,7 +6,7 @@ import {
 import { toFileContentFragment } from "@app/lib/api/assistant/conversation/content_fragment";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
-import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { formatSkillContext } from "@app/lib/reinforcement/format_skill_context";
 import { buildReinforcedSkillsLLMParams } from "@app/lib/reinforcement/run_reinforced_analysis";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -103,7 +103,7 @@ For "sourceSuggestionIds": You MUST include the sIds of ALL the source suggestio
 }
 
 export function buildSkillAggregationSystemPrompt({
-  useInlineTools = false,
+  useInlineTools = true,
 }: {
   useInlineTools?: boolean;
 } = {}): string {
@@ -154,7 +154,7 @@ export function buildSkillAggregationPrompt(
     pending: SkillSuggestionType[];
     rejected: SkillSuggestionType[];
   },
-  { useInlineTools = false }: { useInlineTools?: boolean } = {}
+  { useInlineTools = true }: { useInlineTools?: boolean } = {}
 ): { systemPrompt: string; userMessage: string } {
   const systemPrompt = buildSkillAggregationSystemPrompt({ useInlineTools });
 
@@ -238,8 +238,7 @@ export async function loadSkillAggregationContext(
   );
 
   const skillType = skill.toJSON(auth);
-  const resolvedUseInlineTools =
-    useInlineTools ?? (await getFeatureFlags(auth)).includes("nested_skills");
+  const resolvedUseInlineTools = useInlineTools ?? true;
 
   const prompt = buildSkillAggregationPrompt(
     skillType,

--- a/front/lib/reinforcement/analyze_conversation.test.ts
+++ b/front/lib/reinforcement/analyze_conversation.test.ts
@@ -123,10 +123,12 @@ describe("buildSkillAnalysisPrompt", () => {
     expect(userMessage).toContain("</skill_context>");
   });
 
-  it("system prompt mentions suggestion and exploration tools", () => {
-    const { systemPrompt } = buildSkillAnalysisPrompt("User: hello", [
-      makeSkill(),
-    ]);
+  it("system prompt mentions suggestion and exploration tools when inline tools are disabled", () => {
+    const { systemPrompt } = buildSkillAnalysisPrompt(
+      "User: hello",
+      [makeSkill()],
+      { useInlineTools: false }
+    );
 
     expect(systemPrompt).toContain("edit_skill");
     expect(systemPrompt).toContain("get_available_tools");
@@ -155,7 +157,7 @@ describe("buildSkillAnalysisPrompt", () => {
     expect(systemPrompt).toMatch(/routing|when to enable/i);
   });
 
-  it("includes skill tools as a separate user message block by default", () => {
+  it("includes skill tools as a separate user message block when inline tools are disabled", () => {
     const skill = makeSkill({
       tools: [
         {
@@ -164,7 +166,9 @@ describe("buildSkillAnalysisPrompt", () => {
         } as SkillType["tools"][number],
       ],
     });
-    const { userMessage } = buildSkillAnalysisPrompt("User: hello", [skill]);
+    const { userMessage } = buildSkillAnalysisPrompt("User: hello", [skill], {
+      useInlineTools: false,
+    });
 
     expect(userMessage).toContain("<tools>");
     expect(userMessage).toContain('sId="tool-ws"');

--- a/front/lib/reinforcement/analyze_conversation.ts
+++ b/front/lib/reinforcement/analyze_conversation.ts
@@ -1,6 +1,6 @@
 import { renderConversationAsTextWithFeedback } from "@app/lib/api/assistant/conversation/render_conversation_with_feedback";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
-import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { formatSkillContext } from "@app/lib/reinforcement/format_skill_context";
 import { buildReinforcedSkillsLLMParams } from "@app/lib/reinforcement/run_reinforced_analysis";
 import { buildSkillInstructionHtmlEditPrompt } from "@app/lib/reinforcement/skill_instruction_edit_prompt";
@@ -165,7 +165,7 @@ When suggesting a description edit:
 }
 
 export function buildSkillAnalysisSystemPrompt({
-  useInlineTools = false,
+  useInlineTools = true,
 }: {
   useInlineTools?: boolean;
 } = {}): string {
@@ -179,7 +179,7 @@ export function buildSkillAnalysisSystemPrompt({
 export function buildSkillAnalysisPrompt(
   conversationText: string,
   skills: SkillType[],
-  { useInlineTools = false }: { useInlineTools?: boolean } = {}
+  { useInlineTools = true }: { useInlineTools?: boolean } = {}
 ): { systemPrompt: string; userMessage: string } {
   const systemPrompt = buildSkillAnalysisSystemPrompt({ useInlineTools });
 
@@ -209,8 +209,7 @@ export async function buildSkillConversationAnalysisBatchMap(
   { useInlineTools }: { useInlineTools?: boolean } = {}
 ): Promise<Map<string, LLMStreamParameters> | null> {
   const batchMap = new Map<string, LLMStreamParameters>();
-  const resolvedUseInlineTools =
-    useInlineTools ?? (await getFeatureFlags(auth)).includes("nested_skills");
+  const resolvedUseInlineTools = useInlineTools ?? true;
 
   // Collect all unique skill sIds across all conversations.
   const allSkillIds = [

--- a/front/lib/reinforcement/run_reinforced_analysis.test.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.test.ts
@@ -163,10 +163,11 @@ describe("buildReinforcedSkillsLLMParams edit_skill spec", () => {
     );
   });
 
-  it("exposes toolEdits by default when inline tools are disabled", () => {
+  it("exposes toolEdits when inline tools are disabled", () => {
     const params = buildReinforcedSkillsLLMParams(
       { systemPrompt: "System.", userMessage: "User." },
-      "reinforcement_analyze_conversation"
+      "reinforcement_analyze_conversation",
+      { useInlineTools: false }
     );
     const editSkillSpec = params.specifications?.find(
       (s) => s.name === "edit_skill"

--- a/front/lib/reinforcement/run_reinforced_analysis.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.ts
@@ -6,7 +6,7 @@ import type { LLM } from "@app/lib/api/llm/llm";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
-import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { getLargeWhitelistedModelWithBatchMode } from "@app/lib/reinforcement/models";
 import {
   hasSuggestionSelfConflict,
@@ -106,11 +106,6 @@ function buildReinforcedSkillsToolDefinitions({
   };
 }
 
-async function shouldUseInlineTools(auth: Authenticator): Promise<boolean> {
-  const featureFlags = await getFeatureFlags(auth);
-  return featureFlags.includes("nested_skills");
-}
-
 function getToolEdits(data: Record<string, unknown>) {
   const toolEdits = data.toolEdits;
   if (!Array.isArray(toolEdits)) {
@@ -145,7 +140,7 @@ const AGGREGATION_EXTRA_FIELDS: z.ZodRawShape = {
 
 export function buildReinforcedSkillsSpecifications(
   operationType: ReinforcedSkillsOperationType,
-  { useInlineTools = false }: { useInlineTools?: boolean } = {}
+  { useInlineTools = true }: { useInlineTools?: boolean } = {}
 ): AgentActionSpecification[] {
   const isAggregation = operationType === "reinforcement_aggregate_suggestions";
   const toolDefinitions = buildReinforcedSkillsToolDefinitions({
@@ -246,7 +241,7 @@ export function buildReinforcedSkillsLLMParams(
     userMessage: string;
   },
   operationType: ReinforcedSkillsOperationType,
-  { useInlineTools = false }: { useInlineTools?: boolean } = {}
+  { useInlineTools = true }: { useInlineTools?: boolean } = {}
 ): LLMStreamParameters {
   return {
     conversation: {
@@ -284,8 +279,7 @@ export async function createReinforcedSkillsConversation(
     useInlineTools?: boolean;
   }
 ): Promise<string> {
-  const resolvedUseInlineTools =
-    useInlineTools ?? (await shouldUseInlineTools(auth));
+  const resolvedUseInlineTools = useInlineTools ?? true;
   const llmParams = buildReinforcedSkillsLLMParams(prompt, operationType, {
     useInlineTools: resolvedUseInlineTools,
   });
@@ -400,8 +394,7 @@ export async function processSkillReinforcedEvents({
   const approvedSourceSuggestionIds: string[] = [];
   const successfulToolCalls: TerminalToolCallSuccess[] = [];
   const failedToolCalls: TerminalToolCallFailure[] = [];
-  const resolvedUseInlineTools =
-    useInlineTools ?? (await shouldUseInlineTools(auth));
+  const resolvedUseInlineTools = useInlineTools ?? true;
 
   for (const event of toolCallEvents) {
     const { id, name, arguments: args } = event.content;

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -674,7 +674,6 @@ describe("SkillResource", () => {
         name: "Parent Skill",
         instructions: `Use ${skillReferenceTag}.`,
         instructionsHtml: `<p>Use ${skillReferenceHtmlTag}.</p>`,
-        enableSkillReferences: true,
         referencedSkillIds: [childSkill.sId],
       });
 
@@ -702,7 +701,6 @@ describe("SkillResource", () => {
         mcpServerViews: [],
         attachedKnowledge: [],
         requestedSpaceIds: parentSkill.requestedSpaceIds,
-        enableSkillReferences: true,
         referencedSkillIds: [childSkill.sId],
       });
 
@@ -741,7 +739,6 @@ describe("SkillResource", () => {
       const parentSkill = await SkillFactory.create(testContext.authenticator, {
         name: "Parent Skill",
         instructions: `Use ${SkillFactory.serializeSkillReferenceTag(childSkill)}.`,
-        enableSkillReferences: true,
         referencedSkillIds: [childSkill.sId],
       });
 
@@ -759,7 +756,6 @@ describe("SkillResource", () => {
         mcpServerViews: [],
         attachedKnowledge: [],
         requestedSpaceIds: [restrictedSpace.id],
-        enableSkillReferences: true,
         referencedSkillIds: [childSkill.sId],
       });
 
@@ -790,7 +786,6 @@ describe("SkillResource", () => {
         mcpServerViews: [],
         attachedKnowledge: [],
         requestedSpaceIds: parentSkill.requestedSpaceIds,
-        enableSkillReferences: true,
       });
 
       const updatedParentSkill = await SkillResource.fetchById(
@@ -816,7 +811,6 @@ describe("SkillResource", () => {
         mcpServerViews: [],
         attachedKnowledge: [],
         requestedSpaceIds: updatedParentSkill!.requestedSpaceIds,
-        enableSkillReferences: true,
         referencedSkillIds: [],
       });
 
@@ -838,7 +832,6 @@ describe("SkillResource", () => {
       const parentSkill = await SkillFactory.create(testContext.authenticator, {
         name: "Parent Skill",
         instructions: `Use ${SkillFactory.serializeSkillReferenceTag(childSkill)}.`,
-        enableSkillReferences: true,
         referencedSkillIds: [childSkill.sId],
       });
 
@@ -856,7 +849,6 @@ describe("SkillResource", () => {
         mcpServerViews: [],
         attachedKnowledge: [],
         requestedSpaceIds: [restrictedSpace.id],
-        enableSkillReferences: true,
         referencedSkillIds: [],
       });
 
@@ -879,7 +871,6 @@ describe("SkillResource", () => {
         mcpServerViews: [],
         attachedKnowledge: [],
         requestedSpaceIds: [],
-        enableSkillReferences: true,
         referencedSkillIds: [],
       });
 
@@ -899,7 +890,6 @@ describe("SkillResource", () => {
       const parentSkill = await SkillFactory.create(testContext.authenticator, {
         name: "Parent With Global Skill Reference",
         instructions: `Use ${globalSkillReferenceTag}.`,
-        enableSkillReferences: true,
         referencedSkillIds: ["frames"],
       });
 

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -945,7 +945,6 @@ describe("SkillResource", () => {
         mcpServerViews: [],
         attachedKnowledge: [],
         requestedSpaceIds: parentSkill.requestedSpaceIds,
-        enableSkillReferences: true,
         referencedSkillIds: [missingSkillId],
       });
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -378,14 +378,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       addCurrentUserAsEditor = true,
       attachedKnowledge = [],
       fileAttachments = [],
-      enableSkillReferences = false,
       referencedSkillIds = [],
     }: {
       mcpServerViews: MCPServerViewResource[];
       addCurrentUserAsEditor?: boolean;
       attachedKnowledge?: SkillAttachedKnowledge[];
       fileAttachments?: FileResource[];
-      enableSkillReferences?: boolean;
       referencedSkillIds?: string[];
     }
   ): Promise<SkillResource> {
@@ -451,14 +449,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         })),
       });
 
-      if (enableSkillReferences) {
-        await skillResource.normalizeSkillReferenceTags(auth, { transaction });
-        await skillResource.syncSkillReferences(
-          auth,
-          { referencedSkillIds },
-          { transaction }
-        );
-      }
+      await skillResource.normalizeSkillReferenceTags(auth, { transaction });
+      await skillResource.syncSkillReferences(
+        auth,
+        { referencedSkillIds },
+        { transaction }
+      );
 
       return skillResource;
     });
@@ -2355,7 +2351,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       source,
       sourceMetadata,
       status,
-      enableSkillReferences = false,
       referencedSkillIds,
       userFacingDescription,
     }: {
@@ -2373,7 +2368,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       source?: SkillSourceType;
       sourceMetadata?: SkillSourceMetadata;
       status?: SkillStatus;
-      enableSkillReferences?: boolean;
       referencedSkillIds?: string[];
       userFacingDescription: string;
     }
@@ -2397,15 +2391,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         );
 
       const editedBy = auth.user()?.id;
-      const shouldUpdateInstructionsHtml =
-        instructionsHtml !== undefined || enableSkillReferences;
       await this.update(
         {
           name,
           agentFacingDescription,
           userFacingDescription,
           instructions,
-          ...(shouldUpdateInstructionsHtml
+          ...(instructionsHtml !== undefined
             ? {
                 instructionsHtml:
                   instructionsHtml !== undefined
@@ -2425,27 +2417,25 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         transaction
       );
 
-      if (enableSkillReferences) {
-        await this.normalizeSkillReferenceTags(auth, { transaction });
-        if (referencedSkillIds) {
-          await this.syncSkillReferences(
-            auth,
-            { referencedSkillIds },
-            { transaction }
-          );
-        }
+      await this.normalizeSkillReferenceTags(auth, { transaction });
+      if (referencedSkillIds !== undefined) {
+        await this.syncSkillReferences(
+          auth,
+          { referencedSkillIds },
+          { transaction }
+        );
+      }
 
-        if (name !== previousName || requestedSpaceIdsChanged) {
-          await this.propagateReferenceUpdatesToParentSkills(
-            auth,
-            {
-              icon,
-              name,
-              requestedSpaceIds,
-            },
-            { transaction }
-          );
-        }
+      if (name !== previousName || requestedSpaceIdsChanged) {
+        await this.propagateReferenceUpdatesToParentSkills(
+          auth,
+          {
+            icon,
+            name,
+            requestedSpaceIds,
+          },
+          { transaction }
+        );
       }
 
       await this.updateMCPServerViews(auth, mcpServerViews, { transaction });

--- a/front/migrations/20260602_backfill_skill_tool_references.ts
+++ b/front/migrations/20260602_backfill_skill_tool_references.ts
@@ -1,5 +1,5 @@
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
-import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import { generateShortBlockId } from "@app/lib/generate_short_block_id";
 import { SkillConfigurationModel } from "@app/lib/models/skill";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -26,7 +26,6 @@ type WorkspaceStats = {
   changed: number;
   errors: number;
   processed: number;
-  skippedWithoutFlag: number;
   skippedWithoutTools: number;
 };
 
@@ -34,24 +33,12 @@ async function processWorkspace(
   workspace: LightWorkspaceType,
   {
     execute,
-    includeUnflagged,
   }: {
     execute: boolean;
-    includeUnflagged: boolean;
   },
   logger: Logger
 ): Promise<WorkspaceStats> {
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-  const hasNestedSkills = await hasFeatureFlag(auth, "nested_skills");
-  if (!hasNestedSkills && !includeUnflagged) {
-    return {
-      changed: 0,
-      errors: 0,
-      processed: 0,
-      skippedWithoutFlag: 1,
-      skippedWithoutTools: 0,
-    };
-  }
 
   const skills = await SkillResource.listByWorkspace(auth, {
     onlyCustom: true,
@@ -62,7 +49,6 @@ async function processWorkspace(
     changed: 0,
     errors: 0,
     processed: skills.length,
-    skippedWithoutFlag: 0,
     skippedWithoutTools: 0,
   };
 
@@ -204,28 +190,18 @@ makeScript(
       describe: "Resume from this numeric workspace id.",
       type: "number",
     },
-    includeUnflagged: {
-      default: false,
-      describe:
-        "Also process workspaces without the nested_skills feature flag.",
-      type: "boolean",
-    },
     wId: {
       describe:
         "Process skills for a single workspace (sId). Omit to run on all workspaces.",
       type: "string",
     },
   },
-  async (
-    { concurrency, execute, fromWorkspaceId, includeUnflagged, wId },
-    logger
-  ) => {
+  async ({ concurrency, execute, fromWorkspaceId, wId }, logger) => {
     logger.info(
       {
         concurrency,
         execute,
         fromWorkspaceId,
-        includeUnflagged,
         workspaceId: wId ?? "all",
       },
       execute
@@ -237,21 +213,15 @@ makeScript(
       changed: 0,
       errors: 0,
       processed: 0,
-      skippedWithoutFlag: 0,
       skippedWithoutTools: 0,
     };
 
     await runOnAllWorkspaces(
       async (workspace) => {
-        const stats = await processWorkspace(
-          workspace,
-          { execute, includeUnflagged },
-          logger
-        );
+        const stats = await processWorkspace(workspace, { execute }, logger);
         totals.changed += stats.changed;
         totals.errors += stats.errors;
         totals.processed += stats.processed;
-        totals.skippedWithoutFlag += stats.skippedWithoutFlag;
         totals.skippedWithoutTools += stats.skippedWithoutTools;
       },
       {

--- a/front/scripts/migrate_skill_instructions_html.ts
+++ b/front/scripts/migrate_skill_instructions_html.ts
@@ -22,7 +22,9 @@ import { MarkdownManager } from "@tiptap/markdown";
 import { unescape } from "html-escaper";
 import { Op } from "sequelize";
 
-const SKILL_EDITOR_EXTENSIONS = buildSkillInstructionsExtensions(true, []);
+const SKILL_EDITOR_EXTENSIONS = buildSkillInstructionsExtensions(true, [], {
+  enableSkillReferences: true,
+});
 const MARKDOWN_MANAGER = new MarkdownManager({
   extensions: SKILL_EDITOR_EXTENSIONS,
 });

--- a/front/scripts/seed/reinforcement/seed.test.ts
+++ b/front/scripts/seed/reinforcement/seed.test.ts
@@ -144,8 +144,7 @@ describe("reinforcement seed script integration test", () => {
     );
     expect(allReinforcement).toBe(true);
 
-    // First suggestion includes an inline tool reference in its instruction edit
-    // so the nested_skills path can be exercised manually from seed data.
+    // First suggestion includes an inline tool reference in its instruction edit.
     const withInlineToolReference = skillSuggestions.find((s) => {
       const json = s.toJSON();
       return json.suggestion.instructionEdits?.some(

--- a/front/scripts/seed/reinforcement/seed.ts
+++ b/front/scripts/seed/reinforcement/seed.ts
@@ -12,7 +12,6 @@ makeScript({}, async ({ execute }, logger) => {
     await FeatureFlagResource.enableMany(ctx.workspace, [
       "reinforced_agents",
       "reinforcement_ui",
-      "nested_skills",
     ]);
     logger.info("Feature flag enabled");
   }

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -378,7 +378,6 @@ export async function runModel(
   const isNewFileExplorer = conversation.metadata?.useFileSystem === true;
   const featureFlags = await getFeatureFlags(auth);
   const hasSandboxTools = featureFlags.includes("sandbox_tools");
-  const hasNestedSkills = featureFlags.includes("nested_skills");
   const useFramesV2 = featureFlags.includes("frames_skill_v2");
   const disableFormattingPrompt = featureFlags.includes(
     "disable_formatting_prompt"
@@ -404,7 +403,6 @@ export async function runModel(
     projectContext,
     isNewFileExplorer,
     hasSandboxTools,
-    hasNestedSkills,
     useFramesV2,
     disableFormattingPrompt,
   });

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -698,7 +698,7 @@ export async function analyzeConversationStepActivity({
   toolActionInfo?: ReinforcedToolActionInfo;
 }> {
   const auth = await getAuthForWorkspace(workspaceId);
-  const useInlineTools = await hasFeatureFlag(auth, "nested_skills");
+  const useInlineTools = true;
 
   // On first step, build the analysis prompt and create a reinforcement conversation.
   if (!reinforcementConversationId) {
@@ -835,7 +835,7 @@ export async function aggregateSuggestionsForSkillStepActivity({
   toolActionInfo?: ReinforcedToolActionInfo;
 }> {
   const auth = await getAuthForWorkspace(workspaceId);
-  const useInlineTools = await hasFeatureFlag(auth, "nested_skills");
+  const useInlineTools = true;
 
   // On first step, load aggregation context and create a reinforcement conversation.
   if (!reinforcementConversationId) {
@@ -992,7 +992,7 @@ export async function startSkillConversationAnalysisBatchActivity({
   reinforcementConversationMap: Record<string, string>;
 } | null> {
   const auth = await getAuthForWorkspace(workspaceId);
-  const useInlineTools = await hasFeatureFlag(auth, "nested_skills");
+  const useInlineTools = true;
 
   const llm = await getReinforcedSkillsLLM(
     auth,
@@ -1128,7 +1128,7 @@ export async function processSkillConversationAnalysisBatchResultActivity({
   conversationSkillMap: Record<string, string[]>;
 }): Promise<ConversationContinuationInfo[]> {
   const auth = await getAuthForWorkspace(workspaceId);
-  const useInlineTools = await hasFeatureFlag(auth, "nested_skills");
+  const useInlineTools = true;
 
   const llm = await getReinforcedSkillsLLM(
     auth,
@@ -1294,7 +1294,7 @@ export async function startSkillAggregationBatchActivity({
   reinforcementConversationIds: string[];
 } | null> {
   const auth = await getAuthForWorkspace(workspaceId);
-  const useInlineTools = await hasFeatureFlag(auth, "nested_skills");
+  const useInlineTools = true;
 
   const llm = await getReinforcedSkillsLLM(
     auth,
@@ -1407,7 +1407,7 @@ export async function processSkillAggregationBatchResultActivity({
   toolActionInfo?: ReinforcedToolActionInfo;
 }> {
   const auth = await getAuthForWorkspace(workspaceId);
-  const useInlineTools = await hasFeatureFlag(auth, "nested_skills");
+  const useInlineTools = true;
 
   const llm = await getReinforcedSkillsLLM(
     auth,

--- a/front/tests/utils/SkillFactory.ts
+++ b/front/tests/utils/SkillFactory.ts
@@ -23,7 +23,6 @@ type CreateSkillOverrides = Partial<{
   addCurrentUserAsEditor: boolean;
   attachedKnowledge: SkillAttachedKnowledge[];
   mcpServerViews: MCPServerViewResource[];
-  enableSkillReferences: boolean;
   referencedSkillIds: string[];
 }>;
 
@@ -72,7 +71,6 @@ export class SkillFactory {
         mcpServerViews,
         addCurrentUserAsEditor: overrides.addCurrentUserAsEditor,
         attachedKnowledge,
-        enableSkillReferences: overrides.enableSkillReferences,
         referencedSkillIds: overrides.referencedSkillIds ?? [],
       }
     );
@@ -107,7 +105,6 @@ export class SkillFactory {
     const parentSkill = await this.create(auth, {
       ...parentOverrides,
       instructions: parentOverrides.instructions ?? `Use ${skillReferenceTag}.`,
-      enableSkillReferences: true,
       referencedSkillIds: [childSkill.sId],
     });
 
@@ -144,7 +141,6 @@ export class SkillFactory {
       mcpServerViews: parentSkill.mcpServerViews,
       attachedKnowledge: await parentSkill.getAttachedKnowledge(auth),
       requestedSpaceIds: parentSkill.requestedSpaceIds,
-      enableSkillReferences: true,
       referencedSkillIds: childSkills.map((childSkill) => childSkill.sId),
     });
 

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -78,7 +78,7 @@ export type UsedBySkillType = {
 };
 
 export type SkillUsageType = AgentsUsageType & {
-  skills?: UsedBySkillType[];
+  skills: UsedBySkillType[];
 };
 
 export type SkillRelations = {
@@ -86,7 +86,7 @@ export type SkillRelations = {
   editors: UserType[] | null;
   editedByUser: UserType | null;
   extendedSkill: SkillType | null;
-  childSkills?: SkillWithoutInstructionsAndToolsType[];
+  childSkills: SkillWithoutInstructionsAndToolsType[];
 };
 
 export type SkillWithRelationsType = SkillType & {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -167,10 +167,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Access to legacy Dust Apps (editor and associated tools)",
     stage: "on_demand",
   },
-  nested_skills: {
-    description: "Enable nested skills",
-    stage: "dust_only",
-  },
   power_bi_mcp: {
     description: "Power BI MCP tool for querying semantic models and DAX",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -717,7 +717,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "labs_transcripts"
   | "legacy_dust_apps"
   | "netsuite_mcp"
-  | "nested_skills"
   | "noop_model_feature"
   | "notion_private_integration"
   | "allow_old_notion_mcp"


### PR DESCRIPTION
## Description

- This PR removes the `nested_skills` feature flag now that nested skill references are the default behavior.
- The former enabled path is now unconditional across skill APIs, Skill Builder, skill info rendering, assistant prompts, and reinforcement inline-tool handling.
- It also removes stale flag setup from seed/backfill scripts and the JS SDK feature flag type.

## Tests

- Updated existing tests.

## Risk

- Medium.

## Deploy Plan

- Deploy front.
