### PR TITLE
[front] fix: categorize Praiz and Fathom as transcripts integrations

### DIFF
--- a/front/components/home/content/Integration/utils/integrationRegistry.ts
+++ b/front/components/home/content/Integration/utils/integrationRegistry.ts
@@ -109,6 +109,8 @@ const MCP_CATEGORY_MAP: Record<string, IntegrationCategory> = {
   vanta: "security",
   // AI
   openai_usage: "ai",
+  // Transcripts
+  fathom: "transcripts",
 };
 
 // Category mapping for remote MCP servers (by name, lowercased)
@@ -119,6 +121,7 @@ const REMOTE_MCP_CATEGORY_MAP: Record<string, IntegrationCategory> = {
   supabase: "development",
   guru: "productivity",
   granola: "transcripts",
+  praiz: "transcripts",
   intercom: "support",
   attio: "crm",
   gitlab: "development",


### PR DESCRIPTION
## Description

On `/integrations`, **Praiz** and **Fathom** show under the "Productivity" filter even though they're meeting-transcript tools. They were defaulting to `"productivity"` because neither slug was listed in `MCP_CATEGORY_MAP` (Fathom — internal MCP server) or `REMOTE_MCP_CATEGORY_MAP` (Praiz — remote MCP server) in `front/components/home/content/Integration/utils/integrationRegistry.ts`. This puts them in the `"transcripts"` category alongside Gong, Granola, Google Meet, and Modjo.

## Tests

Verified locally against `next dev`:

- `/integrations/praiz` and `/integrations/fathom` now use the transcripts SEO-title pattern (`"AI Meeting Assistant for Praiz" / "...for Fathom"`) instead of `"AI-Powered X Automation"`.
- They appear under the "Transcripts" filter chip on `/integrations`, no longer under "Productivity".
- `/integrations/notion` (control, still productivity) still renders `"AI-Powered Notion Automation"`.
- `npx tsgo --noEmit` and `npx biome check` pass on the changed file; lefthook (biome + front-typecheck + ggshield) passed on commit.

## Risk

Low. Two-entry data change to two category maps. `"transcripts"` is an existing value in `IntegrationCategory` already used by 4 other integrations. No control-flow changes. Trivially reversible.

## Deploy Plan

Standard `front` deploy.