### PR TITLE
[front] fix: confirm missing connector workflows via describe() to avoid visibility lag false positives

### DIFF
--- a/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
+++ b/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
@@ -20,6 +20,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { Client, ScheduleHandle } from "@temporalio/client";
+import { WorkflowNotFoundError } from "@temporalio/client";
 import chunk from "lodash/chunk";
 import { QueryTypes } from "sequelize";
 
@@ -155,13 +156,13 @@ async function listRunningWorkflowIds(
 // ones that truly are not running. This runs only for the (normally tiny) set
 // of candidate-missing workflows, so the number of `describe()` calls stays
 // bounded and the batched visibility query remains the fast path.
-async function confirmRunningWorkflowIds(
+async function confirmMissingWorkflowIds(
   client: Client,
   workflowIds: string[],
   logger: Logger,
   heartbeat: () => void
 ) {
-  const runningWorkflowIds = new Set<string>();
+  const missingWorkflowIds = new Set<string>();
 
   // External Temporal calls (not DB queries), so concurrentExecutor is the
   // right fit here.
@@ -174,21 +175,32 @@ async function confirmRunningWorkflowIds(
         const description = await client.workflow
           .getHandle(workflowId)
           .describe();
-        if (description.status.name === "RUNNING") {
-          runningWorkflowIds.add(workflowId);
+        if (description.status.name !== "RUNNING") {
+          missingWorkflowIds.add(workflowId);
         }
       } catch (err) {
-        // `describe()` throws when the workflow does not exist; treat as missing.
-        logger.info(
+        // `describe()` throws `WorkflowNotFoundError` when the workflow does
+        // not exist — that is a genuine missing workflow. Any other error
+        // (transient RPC failure, auth/namespace issue, timeout) is a Temporal
+        // API problem: treating it as missing would reintroduce the very false
+        // positive this confirmation step is meant to avoid, so rethrow and let
+        // the check fail loudly instead.
+        if (err instanceof WorkflowNotFoundError) {
+          missingWorkflowIds.add(workflowId);
+          return;
+        }
+
+        logger.error(
           { workflowId, err: normalizeError(err) },
-          "Workflow not found while confirming missing Temporal workflow."
+          "Failed to confirm Temporal workflow status via describe()."
         );
+        throw err;
       }
     },
     { concurrency: 8 }
   );
 
-  return runningWorkflowIds;
+  return missingWorkflowIds;
 }
 
 async function getMissingTemporalSchedulesActive(
@@ -262,7 +274,7 @@ export const checkActiveWorkflows: CheckFunction = async (
         const candidateMissingWorkflowIds = workflowIds.filter(
           (workflowId) => !runningWorkflowIds.has(workflowId)
         );
-        const confirmedRunningWorkflowIds = await confirmRunningWorkflowIds(
+        const confirmedMissingWorkflowIds = await confirmMissingWorkflowIds(
           client,
           candidateMissingWorkflowIds,
           logger,
@@ -271,10 +283,8 @@ export const checkActiveWorkflows: CheckFunction = async (
 
         missingActiveWorkflows = removeNulls(
           workflowIdsByConnector.map(({ connector, workflowIds }) => {
-            const missingEntities = workflowIds.filter(
-              (workflowId) =>
-                !runningWorkflowIds.has(workflowId) &&
-                !confirmedRunningWorkflowIds.has(workflowId)
+            const missingEntities = workflowIds.filter((workflowId) =>
+              confirmedMissingWorkflowIds.has(workflowId)
             );
 
             return missingEntities.length > 0

--- a/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
+++ b/front/lib/production_checks/checks/check_active_workflows_for_connectors.ts
@@ -1,6 +1,7 @@
 import config from "@app/lib/api/config";
 import { getConnectorsPrimaryDbConnection } from "@app/lib/production_checks/utils";
 import { getTemporalClientForConnectorsNamespace } from "@app/lib/temporal";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { Logger } from "@app/logger/logger";
 import {
   getZendeskGarbageCollectionWorkflowId,
@@ -16,6 +17,7 @@ import {
 import type { ConnectorProvider } from "@app/types/data_source";
 import type { ActionLink, CheckFunction } from "@app/types/production_checks";
 import type { ModelId } from "@app/types/shared/model_id";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { Client, ScheduleHandle } from "@temporalio/client";
 import chunk from "lodash/chunk";
@@ -144,6 +146,51 @@ async function listRunningWorkflowIds(
   return runningWorkflowIds;
 }
 
+// `client.workflow.list` reads from Temporal's visibility store, which is
+// eventually consistent and can lag behind the actual workflow state — notably
+// for incremental sync workflows that `continueAsNew` on every cycle, where a
+// genuinely running workflow can transiently be absent from the visibility
+// query. To avoid false positives, re-check any workflow flagged as missing
+// against the authoritative mutable state via `describe()`, and only keep the
+// ones that truly are not running. This runs only for the (normally tiny) set
+// of candidate-missing workflows, so the number of `describe()` calls stays
+// bounded and the batched visibility query remains the fast path.
+async function confirmRunningWorkflowIds(
+  client: Client,
+  workflowIds: string[],
+  logger: Logger,
+  heartbeat: () => void
+) {
+  const runningWorkflowIds = new Set<string>();
+
+  // External Temporal calls (not DB queries), so concurrentExecutor is the
+  // right fit here.
+  await concurrentExecutor(
+    workflowIds,
+    async (workflowId) => {
+      heartbeat();
+
+      try {
+        const description = await client.workflow
+          .getHandle(workflowId)
+          .describe();
+        if (description.status.name === "RUNNING") {
+          runningWorkflowIds.add(workflowId);
+        }
+      } catch (err) {
+        // `describe()` throws when the workflow does not exist; treat as missing.
+        logger.info(
+          { workflowId, err: normalizeError(err) },
+          "Workflow not found while confirming missing Temporal workflow."
+        );
+      }
+    },
+    { concurrency: 8 }
+  );
+
+  return runningWorkflowIds;
+}
+
 async function getMissingTemporalSchedulesActive(
   client: Client,
   connector: ConnectorBlob,
@@ -209,10 +256,25 @@ export const checkActiveWorkflows: CheckFunction = async (
           heartbeat
         );
 
+        // Workflows the visibility query did not return are only *candidates*
+        // for being missing — confirm them against the authoritative mutable
+        // state before reporting, to avoid false positives from visibility lag.
+        const candidateMissingWorkflowIds = workflowIds.filter(
+          (workflowId) => !runningWorkflowIds.has(workflowId)
+        );
+        const confirmedRunningWorkflowIds = await confirmRunningWorkflowIds(
+          client,
+          candidateMissingWorkflowIds,
+          logger,
+          heartbeat
+        );
+
         missingActiveWorkflows = removeNulls(
           workflowIdsByConnector.map(({ connector, workflowIds }) => {
             const missingEntities = workflowIds.filter(
-              (workflowId) => !runningWorkflowIds.has(workflowId)
+              (workflowId) =>
+                !runningWorkflowIds.has(workflowId) &&
+                !confirmedRunningWorkflowIds.has(workflowId)
             );
 
             return missingEntities.length > 0


### PR DESCRIPTION
## Problem

The `check_active_workflows_for_connectors` production check fires false-positive `Missing <provider> temporal workflows.` alerts even when all workflows are running. Observed in prod for ~15 Google Drive connectors at once.

## Root cause

The check determined "running" status solely via:

```ts
client.workflow.list({ query: `WorkflowId IN (...) AND ExecutionStatus = "Running"` })
```

`workflow.list` reads from Temporal's **visibility store**, which is eventually consistent and lags behind actual workflow state. Incremental sync workflows (e.g. `googleDriveIncrementalSyncV2`) call `continueAsNew` on **every** cycle, so a genuinely running workflow can transiently be absent from the visibility query — reported as missing even though it's healthy. This explains why only a sporadic subset of connectors showed up.

The *schedule* path in the same file, and `check_active_workflows_for_front`, already avoid this by using the authoritative `describe()`.

## Fix

- The batched visibility `list` query still runs first (unchanged fast path).
- Workflows it does **not** return are now *candidates*, not confirmed missing.
- Each candidate is re-checked against authoritative mutable state via `getHandle(id).describe()` (status `=== "RUNNING"`), using `concurrentExecutor` (concurrency 8).
- Only workflows failing this authoritative check are reported as missing.

The candidate set is normally near-zero, so the batched-list optimization (#26314) stays intact while the lag-induced false positives are eliminated.

## Test plan

- `npx tsgo --noEmit` clean
- `biome check` clean
- Behavior: when Temporal visibility lags during `continueAsNew`, the workflow is now confirmed via `describe()` and not falsely reported as missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)