### PR TITLE
Fix: do not auto translate agent names, dust reserved words (fix a crash on new convo)

### DIFF
--- a/front/components/assistant/AgentPicker.tsx
+++ b/front/components/assistant/AgentPicker.tsx
@@ -117,7 +117,7 @@ export function AgentPicker({
               icon={() => <Avatar size="xs" visual={c.pictureUrl} />}
               label={c.name}
               truncateText
-              className="group py-1"
+              className="group py-1 notranslate"
               endComponent={
                 onAgentDetailsClick && clientType !== "extension" ? (
                   <Button

--- a/front/components/assistant/conversation/AgentHandle.tsx
+++ b/front/components/assistant/conversation/AgentHandle.tsx
@@ -34,7 +34,7 @@ export function AgentHandle({
       href={href}
       shallow
       className={cn(
-        "max-w-[14rem] cursor-pointer truncate transition duration-200 hover:text-highlight active:text-highlight-600 sm:max-w-fit",
+        "max-w-[14rem] cursor-pointer truncate transition duration-200 hover:text-highlight active:text-highlight-600 sm:max-w-fit notranslate",
         isDisabled && "text-gray-600 text-opacity-75"
       )}
     >

--- a/front/components/assistant/conversation/agent_browser/MobileOrExtensionAgentBrowser.tsx
+++ b/front/components/assistant/conversation/agent_browser/MobileOrExtensionAgentBrowser.tsx
@@ -61,6 +61,7 @@ export function MobileOrExtensionAgentBrowser({
                 key={tab.id}
                 disabled={agentsByTab[tab.id].length === 0}
                 onClick={() => setSelectedTab(tab.id)}
+                className="notranslate"
                 label={tab.label}
               />
             ))}

--- a/front/components/assistant/conversation/agent_browser/shared.tsx
+++ b/front/components/assistant/conversation/agent_browser/shared.tsx
@@ -240,6 +240,7 @@ export function SearchDropdownContent({
       {filteredAgents.length > 0 && <DropdownMenuLabel label="Agents" />}
       {filteredAgents.map((agent) => (
         <DropdownMenuItem
+          className="notranslate"
           key={agent.sId}
           onClick={() => onAgentClick(agent)}
           truncateText

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -121,7 +121,9 @@ export const InputBarButtons = React.memo(function InputBarButtons({
             )}
           >
             <Avatar size="xxs" visual={selectedAgent.pictureUrl} />
-            <span className="grow truncate">{selectedAgent.label}</span>
+            <span className="grow truncate notranslate">
+              {selectedAgent.label}
+            </span>
             <button
               type="button"
               aria-label="Remove agent"

--- a/front/components/assistant/details/AgentDetailsSheet.tsx
+++ b/front/components/assistant/details/AgentDetailsSheet.tsx
@@ -244,7 +244,7 @@ export function AgentDetailsSheet({
 
         {/* Title and edit info */}
         <div className="flex flex-col items-center gap-1">
-          <h2 className="text-xl font-semibold text-foreground dark:text-foreground-night">
+          <h2 className="text-xl font-semibold text-foreground dark:text-foreground-night notranslate">
             {agentConfiguration?.name ?? ""}
           </h2>
           {editedDate && (

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -87,6 +87,7 @@ export const NavigationSidebar = React.forwardRef<
                 {navs.map((tab) => (
                   <div key={tab.id} ref={tab.ref ?? undefined}>
                     <TabsTrigger
+                      className="notranslate"
                       key={tab.id}
                       value={tab.id}
                       label={tab.hideLabel ? undefined : tab.label}

--- a/sparkle/src/components/AssistantCard.tsx
+++ b/sparkle/src/components/AssistantCard.tsx
@@ -72,7 +72,7 @@ export const AssistantCard = React.forwardRef<
             <h3>
               <TruncatedText
                 lineClamp={1}
-                className="s-heading-base s-overflow-hidden s-text-ellipsis s-break-all"
+                className="s-heading-base s-overflow-hidden s-text-ellipsis s-break-all notranslate"
               >
                 {title}
               </TruncatedText>

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -447,7 +447,12 @@ const NavigationListCollapsibleSection = React.forwardRef<
 
     const isCollapsible = type !== "static";
     const labelElement = (
-      <div className={collapseableStyles({ variant, isCollapsible })}>
+      <div
+        className={cn(
+          "notranslate",
+          collapseableStyles({ variant, isCollapsible })
+        )}
+      >
         {icon ? (
           <span className="s-flex s-items-center s-gap-1.5">
             <Icon visual={icon} size="xs" />

--- a/sparkle/src/components/TypingAnimation.tsx
+++ b/sparkle/src/components/TypingAnimation.tsx
@@ -36,5 +36,5 @@ export function TypingAnimation({
     };
   }, [duration, i, text]);
 
-  return <>{displayedText}</>;
+  return <span className="notranslate">{displayedText}</span>;
 }


### PR DESCRIPTION
## Description

Browser auto-translation (e.g. Google Translate) mutates the DOM in ways React doesn't expect, causing a crash on new conversation init. Agent names and Dust reserved words (nav labels, `TypingAnimation`, collapsible section headers) should never be translated.

Adds `notranslate` CSS class to all surfaces that render agent names or Dust-specific UI labels:
- `AgentPicker`, `AgentHandle`, `InputBarButtons`, `AgentDetailsSheet`, `SearchDropdownContent`, `MobileOrExtensionAgentBrowser` (front)
- `AssistantCard`, `NavigationList`, `TypingAnimation` (sparkle)
- `NavigationSidebar` tab triggers (front)

## Tests

Tested locally: opened a new conversation with browser translation active — no crash, agent names render untranslated.

## Risk

Low. Pure CSS class additions (`notranslate`), no logic changes. Safe to rollback.

## Deploy Plan

Deploy front.
