### PR TITLE
Allow editor plug-ins on archived agents

### DIFF
--- a/front/lib/api/poke/plugins/agents/agent_editors.ts
+++ b/front/lib/api/poke/plugins/agents/agent_editors.ts
@@ -142,10 +142,10 @@ export const updateEditorsPlugin = createPlugin({
       value: message,
     });
   },
-  isApplicableTo: (auth, resource) => {
+  isApplicableTo: (_auth, resource) => {
     if (!resource) {
       return false;
     }
-    return resource.status === "active";
+    return resource.status === "active" || resource.status === "archived";
   },
 });

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1467,7 +1467,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     }
 
     // Check if the user is already a member of the group.
-    const activeMembers = await this.getActiveMembers(auth);
+    const activeMembers = await this.getActiveMembers(auth, { transaction });
     const activeMembersIds = activeMembers.map((m) => m.sId);
     const alreadyActiveUserIds = userIds.filter((userId) =>
       activeMembersIds.includes(userId)


### PR DESCRIPTION
## Description

`updateEditorsPlugin.isApplicableTo` was restricted to `status === "active"`, blocking the plug-in from running on archived agents.
This allow restoring archived agents with no editors (add editor then restore).

## Tests

Tested manually via Poke on an archived agent to confirm the editor plug-in is now accessible.

## Risk

Low.

## Deploy Plan

Deploy front.
