### PR TITLE
[front] Show payment method in credit pool top-up dialog

### DIFF
--- a/front/components/workspace/BuyAwuCreditsDialog.tsx
+++ b/front/components/workspace/BuyAwuCreditsDialog.tsx
@@ -49,6 +49,22 @@ function formatCredits(credits: number): string {
   return Math.round(credits).toLocaleString("en-US");
 }
 
+function formatPaymentMethodLabel(
+  pm:
+    | { type: "card"; brand: string; last4: string }
+    | { type: "sepa_debit"; last4: string }
+): string {
+  switch (pm.type) {
+    case "card":
+      return `${formatBrandName(pm.brand)} ${pm.last4}`;
+    case "sepa_debit":
+      return `IBAN •••• ${pm.last4}`;
+    default:
+      assertNeverAndIgnore(pm);
+      return "";
+  }
+}
+
 function formatCost(amount: number): string {
   if (Number.isInteger(amount)) {
     return amount.toLocaleString("en-US");
@@ -429,9 +445,9 @@ export function BuyAwuCreditsDialog({
                               />
                             ) : null}
                             <span className="text-sm font-medium">
-                              {awuPurchaseInfo.paymentMethod.type === "card"
-                                ? `${formatBrandName(awuPurchaseInfo.paymentMethod.brand)} ${awuPurchaseInfo.paymentMethod.last4}`
-                                : `IBAN •••• ${awuPurchaseInfo.paymentMethod.last4}`}
+                              {formatPaymentMethodLabel(
+                                awuPurchaseInfo.paymentMethod
+                              )}
                             </span>
                           </div>
                           <Button

--- a/front/components/workspace/BuyAwuCreditsDialog.tsx
+++ b/front/components/workspace/BuyAwuCreditsDialog.tsx
@@ -1,3 +1,7 @@
+import {
+  CardBrandIcon,
+  formatBrandName,
+} from "@app/components/checkout/PaymentMethodRow";
 import { useAwuPurchase } from "@app/hooks/useAwuPurchase";
 import config from "@app/lib/api/config";
 import type { AwuPurchaseInfo } from "@app/lib/credits/awu_purchase";
@@ -408,6 +412,37 @@ export function BuyAwuCreditsDialog({
                       if you need more.
                     </p>
                   )}
+
+                  {awuPurchaseInfo?.canPurchase &&
+                    awuPurchaseInfo.paymentMethod && (
+                      <div className="flex flex-col gap-2">
+                        <p className="text-sm font-medium text-foreground dark:text-foreground-night">
+                          Payment method
+                        </p>
+                        <div className="flex w-full items-center justify-between rounded-lg border border-separator bg-muted px-4 py-3">
+                          <div className="flex items-center gap-3">
+                            {awuPurchaseInfo.paymentMethod.type === "card" ? (
+                              <CardBrandIcon
+                                brand={awuPurchaseInfo.paymentMethod.brand}
+                                width={38}
+                                height={24}
+                              />
+                            ) : null}
+                            <span className="text-sm font-medium">
+                              {awuPurchaseInfo.paymentMethod.type === "card"
+                                ? `${formatBrandName(awuPurchaseInfo.paymentMethod.brand)} ${awuPurchaseInfo.paymentMethod.last4}`
+                                : `IBAN •••• ${awuPurchaseInfo.paymentMethod.last4}`}
+                            </span>
+                          </div>
+                          <Button
+                            label="Change"
+                            variant="ghost"
+                            size="sm"
+                            href={`/w/${workspaceId}/subscription/manage`}
+                          />
+                        </div>
+                      </div>
+                    )}
                 </div>
               </TabsContent>
 

--- a/front/lib/credits/awu_purchase.test.ts
+++ b/front/lib/credits/awu_purchase.test.ts
@@ -143,6 +143,7 @@ describe("getAwuPurchaseInfo", () => {
       remainingCycleCredits: 0,
       currency: "eur",
       discountPercent: 0,
+      paymentMethod: null,
     });
   });
 });

--- a/front/lib/credits/awu_purchase.ts
+++ b/front/lib/credits/awu_purchase.ts
@@ -178,8 +178,9 @@ export async function getAwuPurchaseInfo(
       expand: ["invoice_settings.default_payment_method"],
     });
     if (!("deleted" in customer)) {
-      const pm = customer.invoice_settings
-        ?.default_payment_method as Stripe.PaymentMethod | null;
+      const pmRaw = customer.invoice_settings?.default_payment_method;
+      const pm: Stripe.PaymentMethod | null =
+        pmRaw && typeof pmRaw !== "string" ? pmRaw : null;
       if (pm?.type === "card" && pm.card) {
         paymentMethod = {
           type: "card",
@@ -187,7 +188,10 @@ export async function getAwuPurchaseInfo(
           last4: pm.card.last4 ?? "",
         };
       } else if (pm?.type === "sepa_debit" && pm.sepa_debit) {
-        paymentMethod = { type: "sepa_debit", last4: pm.sepa_debit.last4 ?? "" };
+        paymentMethod = {
+          type: "sepa_debit",
+          last4: pm.sepa_debit.last4 ?? "",
+        };
       }
     }
   } catch {

--- a/front/lib/credits/awu_purchase.ts
+++ b/front/lib/credits/awu_purchase.ts
@@ -50,6 +50,10 @@ export type AwuPurchaseInfo =
       remainingCycleCredits: number;
       currency: SupportedCurrency;
       discountPercent: number;
+      paymentMethod:
+        | { type: "card"; brand: string; last4: string }
+        | { type: "sepa_debit"; last4: string }
+        | null;
     };
 
 export type AwuPurchaseResult = {
@@ -164,6 +168,32 @@ export async function getAwuPurchaseInfo(
 
   const discountPercent = await resolveAwuPurchaseDiscountPercent(auth);
 
+  // Fetch default payment method for display.
+  let paymentMethod:
+    | { type: "card"; brand: string; last4: string }
+    | { type: "sepa_debit"; last4: string }
+    | null = null;
+  try {
+    const customer = await stripe.customers.retrieve(stripeCustomerId, {
+      expand: ["invoice_settings.default_payment_method"],
+    });
+    if (!("deleted" in customer)) {
+      const pm = customer.invoice_settings
+        ?.default_payment_method as Stripe.PaymentMethod | null;
+      if (pm?.type === "card" && pm.card) {
+        paymentMethod = {
+          type: "card",
+          brand: pm.card.brand ?? "unknown",
+          last4: pm.card.last4 ?? "",
+        };
+      } else if (pm?.type === "sepa_debit" && pm.sepa_debit) {
+        paymentMethod = { type: "sepa_debit", last4: pm.sepa_debit.last4 ?? "" };
+      }
+    }
+  } catch {
+    // Non-fatal — display without payment method info.
+  }
+
   const billingCycle = getBillingCycle(subscription.startDate);
   if (!billingCycle) {
     return {
@@ -171,6 +201,7 @@ export async function getAwuPurchaseInfo(
       remainingCycleCredits: MAX_AWU_PURCHASE_CREDITS_PER_CYCLE,
       currency,
       discountPercent,
+      paymentMethod,
     };
   }
 
@@ -195,6 +226,7 @@ export async function getAwuPurchaseInfo(
     ),
     currency,
     discountPercent,
+    paymentMethod,
   };
 }
 


### PR DESCRIPTION
## Description

* Completing design in Figma to show the payment method metadata (same as we do on billing page): https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=6951-21030&t=ua0sWrakAwWW8QXP-0

## Tests
<img width="371" height="367" alt="Screenshot 2026-06-02 at 10 32 24 PM" src="https://github.com/user-attachments/assets/afb9bf8d-b739-4e3e-839c-b6ca26d2e848" />

## Risk

* Low (already expose this information)

## Deploy Plan

* Deploy front