### PR TITLE
[front] fix: preserve omitted nested skill references

### DIFF
--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -410,6 +410,25 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
       }),
     ]);
 
+    const omittedResponse = await patchSkill(
+      workspace,
+      skill.sId,
+      buildBody(instructionsWithReference)
+    );
+    expect(omittedResponse.status).toBe(200);
+    const skillAfterOmittedReferences = await SkillResource.fetchById(
+      requestUserAuth,
+      skill.sId
+    );
+    expect(skillAfterOmittedReferences).not.toBeNull();
+    await expect(
+      skillAfterOmittedReferences!.fetchChildSkills(requestUserAuth)
+    ).resolves.toEqual([
+      expect.objectContaining({
+        sId: childSkill.sId,
+      }),
+    ]);
+
     const removeResponse = await patchSkill(
       workspace,
       skill.sId,

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -340,11 +340,14 @@ app.patch(
 
     const featureFlags = await getFeatureFlags(auth);
     const enableSkillReferences = featureFlags.includes("nested_skills");
-    const referencedSkillIds = uniq(
-      (body.referencedSkillIds ?? []).filter(
-        (referencedSkillId) => referencedSkillId !== skill.sId
-      )
-    );
+    const referencedSkillIds =
+      body.referencedSkillIds
+        ? uniq(
+            body.referencedSkillIds.filter(
+              (referencedSkillId) => referencedSkillId !== skill.sId
+            )
+          )
+        : undefined;
 
     // Validate file attachments if provided (gated behind sandbox_tools).
     let files: FileResource[] | undefined;

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -773,6 +773,63 @@ describe("SkillResource", () => {
       );
     });
 
+    it("preserves nested skill references when referencedSkillIds is omitted", async () => {
+      const { childSkill, parentSkill, skillReferenceTag } =
+        await SkillFactory.createWithNestedSkill(testContext.authenticator, {
+          childOverrides: { name: "Omitted References Child Skill" },
+          parentOverrides: { name: "Omitted References Parent Skill" },
+        });
+
+      await parentSkill.updateSkill(testContext.authenticator, {
+        name: parentSkill.name,
+        agentFacingDescription: "Updated agent description",
+        userFacingDescription: parentSkill.userFacingDescription,
+        instructions: `Use ${skillReferenceTag}.`,
+        instructionsHtml: parentSkill.instructionsHtml,
+        icon: parentSkill.icon,
+        mcpServerViews: [],
+        attachedKnowledge: [],
+        requestedSpaceIds: parentSkill.requestedSpaceIds,
+        enableSkillReferences: true,
+      });
+
+      const updatedParentSkill = await SkillResource.fetchById(
+        testContext.authenticator,
+        parentSkill.sId
+      );
+      expect(updatedParentSkill).not.toBeNull();
+      await expect(
+        updatedParentSkill!.fetchChildSkills(testContext.authenticator)
+      ).resolves.toEqual([
+        expect.objectContaining({
+          sId: childSkill.sId,
+        }),
+      ]);
+
+      await updatedParentSkill!.updateSkill(testContext.authenticator, {
+        name: updatedParentSkill!.name,
+        agentFacingDescription: updatedParentSkill!.agentFacingDescription,
+        userFacingDescription: updatedParentSkill!.userFacingDescription,
+        instructions: "No nested skill references.",
+        instructionsHtml: updatedParentSkill!.instructionsHtml,
+        icon: updatedParentSkill!.icon,
+        mcpServerViews: [],
+        attachedKnowledge: [],
+        requestedSpaceIds: updatedParentSkill!.requestedSpaceIds,
+        enableSkillReferences: true,
+        referencedSkillIds: [],
+      });
+
+      const clearedParentSkill = await SkillResource.fetchById(
+        testContext.authenticator,
+        parentSkill.sId
+      );
+      expect(clearedParentSkill).not.toBeNull();
+      await expect(
+        clearedParentSkill!.fetchChildSkills(testContext.authenticator)
+      ).resolves.toHaveLength(0);
+    });
+
     it("updates parent skill references when child requested spaces change", async () => {
       const restrictedSpace = await SpaceFactory.regular(testContext.workspace);
       const childSkill = await SkillFactory.create(testContext.authenticator, {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2356,7 +2356,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       sourceMetadata,
       status,
       enableSkillReferences = false,
-      referencedSkillIds = [],
+      referencedSkillIds,
       userFacingDescription,
     }: {
       agentFacingDescription: string;
@@ -2427,11 +2427,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
       if (enableSkillReferences) {
         await this.normalizeSkillReferenceTags(auth, { transaction });
-        await this.syncSkillReferences(
-          auth,
-          { referencedSkillIds },
-          { transaction }
-        );
+        if (referencedSkillIds) {
+          await this.syncSkillReferences(
+            auth,
+            { referencedSkillIds },
+            { transaction }
+          );
+        }
 
         if (name !== previousName || requestedSpaceIdsChanged) {
           await this.propagateReferenceUpdatesToParentSkills(

--- a/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
@@ -466,6 +466,29 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
       }),
     ]);
 
+    const { req: omittedReq, res: omittedRes } = createPatchSkillRequest({
+      workspaceId: workspace.sId,
+      skillId: skill.sId,
+      body: makePatchSkillBody(skill, {
+        instructions: instructionsWithReference,
+      }),
+    });
+
+    await handler(omittedReq, omittedRes);
+    expect(omittedRes._getStatusCode()).toBe(200);
+    const skillAfterOmittedReferences = await SkillResource.fetchById(
+      requestUserAuth,
+      skill.sId
+    );
+    expect(skillAfterOmittedReferences).not.toBeNull();
+    await expect(
+      skillAfterOmittedReferences!.fetchChildSkills(requestUserAuth)
+    ).resolves.toEqual([
+      expect.objectContaining({
+        sId: childSkill.sId,
+      }),
+    ]);
+
     const { req: removeReq, res: removeRes } = createPatchSkillRequest({
       workspaceId: workspace.sId,
       skillId: skill.sId,

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -321,11 +321,14 @@ async function handler(
 
       const featureFlags = await getFeatureFlags(auth);
       const enableSkillReferences = featureFlags.includes("nested_skills");
-      const referencedSkillIds = uniq(
-        (body.referencedSkillIds ?? []).filter(
-          (referencedSkillId) => referencedSkillId !== skill.sId
-        )
-      );
+      const referencedSkillIds =
+        body.referencedSkillIds
+          ? uniq(
+              body.referencedSkillIds.filter(
+                (referencedSkillId) => referencedSkillId !== skill.sId
+              )
+            )
+          : undefined;
 
       // Validate file attachments if provided (gated behind sandbox_tools).
       let files: FileResource[] | undefined;


### PR DESCRIPTION
## Description

This PR fixes skill updates so callers that omit `referencedSkillIds` no longer clear all nested skill references.

The resource layer now only syncs skill references when the field is explicitly provided. The Next and Hono PATCH routes preserve the same distinction: omitted means “leave references unchanged”, while `referencedSkillIds: []` still means “clear all references”.

## Tests

- Updated existing tests to cover omitted vs explicit empty nested skill references.

## Risk

- Low. Affects nested skill reference persistence behind `nested_skills`.

## Deploy Plan

- Deploy front.
