### PR TITLE
[front] fix: allow nested skill self-references

### DIFF
--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -340,14 +340,6 @@ app.patch(
 
     const featureFlags = await getFeatureFlags(auth);
     const enableSkillReferences = featureFlags.includes("nested_skills");
-    const referencedSkillIds =
-      body.referencedSkillIds
-        ? uniq(
-            body.referencedSkillIds.filter(
-              (referencedSkillId) => referencedSkillId !== skill.sId
-            )
-          )
-        : undefined;
 
     // Validate file attachments if provided (gated behind sandbox_tools).
     let files: FileResource[] | undefined;
@@ -416,7 +408,7 @@ app.patch(
       reinforcement: body.reinforcement,
       requestedSpaceIds,
       enableSkillReferences,
-      referencedSkillIds,
+      referencedSkillIds: body.referencedSkillIds,
       userFacingDescription: body.userFacingDescription,
       ...(shouldActivate ? { status: "active" as const } : {}),
     });

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2500,9 +2500,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     });
 
     const referencingSkillIds = uniq(
-      references
-        .map((reference) => reference.parentSkillId)
-        .filter((parentSkillId) => parentSkillId !== this.id)
+      references.map((reference) => reference.parentSkillId)
     );
 
     if (referencingSkillIds.length === 0) {
@@ -2613,8 +2611,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           const parsed = getResourceNameAndIdFromSId(sId);
 
           return parsed?.resourceName === "skill" &&
-            parsed.workspaceModelId === workspace.id &&
-            parsed.resourceModelId !== parentSkillId
+            parsed.workspaceModelId === workspace.id
             ? parsed.resourceModelId
             : null;
         })

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -321,14 +321,6 @@ async function handler(
 
       const featureFlags = await getFeatureFlags(auth);
       const enableSkillReferences = featureFlags.includes("nested_skills");
-      const referencedSkillIds =
-        body.referencedSkillIds
-          ? uniq(
-              body.referencedSkillIds.filter(
-                (referencedSkillId) => referencedSkillId !== skill.sId
-              )
-            )
-          : undefined;
 
       // Validate file attachments if provided (gated behind sandbox_tools).
       let files: FileResource[] | undefined;
@@ -397,7 +389,7 @@ async function handler(
         reinforcement: body.reinforcement,
         requestedSpaceIds,
         enableSkillReferences,
-        referencedSkillIds,
+        referencedSkillIds: body.referencedSkillIds,
         userFacingDescription: body.userFacingDescription,
         ...(shouldActivate ? { status: "active" as const } : {}),
       });


### PR DESCRIPTION
## Description

This PR removes the special handling that prevented a skill from referencing itself as a nested skill.

Self-references are now preserved through the skill update routes and `SkillResource.syncSkillReferences`. Reference propagation also includes self-referencing skills, so renames keep the inline self-reference tag up to date. The existing omitted vs explicit empty `referencedSkillIds` behavior is preserved.

Also remove the uniqueness handling in the handler, it's handled downstream in `syncSkillRefs` (Skill resource).

## Tests

- Updated existing tests.

## Risk

- Low. Behind `nested_skills` FF.

## Deploy Plan

- Deploy front.