### PR TITLE
[front] fix stale nested skill refs on archive

### DIFF
--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -885,6 +885,111 @@ describe("SkillResource", () => {
       );
     });
 
+    it("updates parent skill references when child status changes", async () => {
+      const { parentSkill, childSkill, skillReferenceTag } =
+        await SkillFactory.createWithNestedSkill(testContext.authenticator, {
+          childOverrides: {
+            name: "Child Status Skill",
+          },
+          parentOverrides: {
+            name: "Parent Status Skill",
+          },
+        });
+
+      await childSkill.updateSkill(testContext.authenticator, {
+        name: childSkill.name,
+        agentFacingDescription: childSkill.agentFacingDescription,
+        userFacingDescription: childSkill.userFacingDescription,
+        instructions: childSkill.instructions,
+        instructionsHtml: childSkill.instructionsHtml,
+        icon: childSkill.icon,
+        mcpServerViews: [],
+        attachedKnowledge: [],
+        requestedSpaceIds: childSkill.requestedSpaceIds,
+        referencedSkillIds: [],
+        status: "archived",
+      });
+
+      const unavailableParentSkill = await SkillResource.fetchById(
+        testContext.authenticator,
+        parentSkill.sId
+      );
+      expect(unavailableParentSkill?.instructions).toContain(
+        `<unavailable_skill id="${childSkill.sId}" />`
+      );
+
+      await childSkill.updateSkill(testContext.authenticator, {
+        name: childSkill.name,
+        agentFacingDescription: childSkill.agentFacingDescription,
+        userFacingDescription: childSkill.userFacingDescription,
+        instructions: childSkill.instructions,
+        instructionsHtml: childSkill.instructionsHtml,
+        icon: childSkill.icon,
+        mcpServerViews: [],
+        attachedKnowledge: [],
+        requestedSpaceIds: childSkill.requestedSpaceIds,
+        referencedSkillIds: [],
+        status: "active",
+      });
+
+      const availableParentSkill = await SkillResource.fetchById(
+        testContext.authenticator,
+        parentSkill.sId
+      );
+      expect(availableParentSkill?.instructions).toContain(skillReferenceTag);
+    });
+
+    it("normalizes missing nested skill references as unavailable", async () => {
+      const MISSING_SKILL_MODEL_ID = 999_999;
+      const missingSkillId = SkillResource.modelIdToSId({
+        id: MISSING_SKILL_MODEL_ID,
+        workspaceId: testContext.workspace.id,
+      });
+      const missingSkillReferenceTag = serializeSkillTag({
+        id: missingSkillId,
+        icon: null,
+        name: "Deleted Skill",
+      });
+
+      const parentSkill = await SkillFactory.create(testContext.authenticator, {
+        name: "Parent With Missing Skill Reference",
+        instructions: `Use ${missingSkillReferenceTag}.`,
+        referencedSkillIds: [missingSkillId],
+      });
+
+      expect(parentSkill.instructions).toContain(
+        `<unavailable_skill id="${missingSkillId}" />`
+      );
+      await expect(
+        parentSkill.fetchChildSkills(testContext.authenticator)
+      ).resolves.toHaveLength(0);
+    });
+
+    it("normalizes archived nested skill references as unavailable", async () => {
+      const archivedChildSkill = await SkillFactory.create(
+        testContext.authenticator,
+        {
+          name: "Archived Child Skill",
+          status: "archived",
+        }
+      );
+      const skillReferenceTag =
+        SkillFactory.serializeSkillReferenceTag(archivedChildSkill);
+
+      const parentSkill = await SkillFactory.create(testContext.authenticator, {
+        name: "Parent With Archived Skill Reference",
+        instructions: `Use ${skillReferenceTag}.`,
+        referencedSkillIds: [archivedChildSkill.sId],
+      });
+
+      expect(parentSkill.instructions).toContain(
+        `<unavailable_skill id="${archivedChildSkill.sId}" />`
+      );
+      await expect(
+        parentSkill.fetchChildSkills(testContext.authenticator)
+      ).resolves.toHaveLength(0);
+    });
+
     it("syncs global skill references", async () => {
       const globalSkillReferenceTag =
         GlobalSkillsRegistry.serializeSkillTag("frames");
@@ -1095,6 +1200,86 @@ describe("SkillResource", () => {
       );
       expect(agentAfter?.requestedSpaceIds).toContain(sharedSpace.sId);
     });
+
+    it("marks parent skill references unavailable while a child skill is archived", async () => {
+      const childSkill = await SkillFactory.create(testContext.authenticator, {
+        name: "Archived Child Skill",
+      });
+      const skillReferenceTag =
+        SkillFactory.serializeSkillReferenceTag(childSkill);
+      const skillReferenceHtmlTag = serializeSkillTag(
+        {
+          icon: childSkill.icon,
+          id: childSkill.sId,
+          name: childSkill.name,
+        },
+        { html: true }
+      );
+      const parentSkill = await SkillFactory.create(testContext.authenticator, {
+        name: "Parent Skill",
+        instructions: `Use ${skillReferenceTag}.`,
+        instructionsHtml: `<p>Use ${skillReferenceHtmlTag}.</p>`,
+        referencedSkillIds: [childSkill.sId],
+      });
+
+      const { affectedCount: archiveCount } = await childSkill.archive(
+        testContext.authenticator
+      );
+      expect(archiveCount).toBe(1);
+
+      const archivedParentSkill = await SkillResource.fetchById(
+        testContext.authenticator,
+        parentSkill.sId
+      );
+      expect(archivedParentSkill?.instructions).toContain(
+        `<unavailable_skill id="${childSkill.sId}" />`
+      );
+      expect(archivedParentSkill?.instructionsHtml).toContain(
+        `<unavailable_skill id="${childSkill.sId}"></unavailable_skill>`
+      );
+      await expect(
+        archivedParentSkill!.fetchChildSkills(testContext.authenticator)
+      ).resolves.toHaveLength(0);
+
+      await archivedParentSkill!.updateSkill(testContext.authenticator, {
+        name: archivedParentSkill!.name,
+        agentFacingDescription: archivedParentSkill!.agentFacingDescription,
+        userFacingDescription: archivedParentSkill!.userFacingDescription,
+        instructions: archivedParentSkill!.instructions,
+        instructionsHtml: archivedParentSkill!.instructionsHtml,
+        icon: archivedParentSkill!.icon,
+        mcpServerViews: [],
+        attachedKnowledge: [],
+        requestedSpaceIds: archivedParentSkill!.requestedSpaceIds,
+        referencedSkillIds: [childSkill.sId],
+      });
+
+      const updatedArchivedParentSkill = await SkillResource.fetchById(
+        testContext.authenticator,
+        parentSkill.sId
+      );
+      expect(updatedArchivedParentSkill?.instructions).toContain(
+        `<unavailable_skill id="${childSkill.sId}" />`
+      );
+
+      const { affectedCount: restoreCount } = await childSkill.restore(
+        testContext.authenticator
+      );
+      expect(restoreCount).toBe(1);
+
+      const restoredParentSkill = await SkillResource.fetchById(
+        testContext.authenticator,
+        parentSkill.sId
+      );
+      expect(restoredParentSkill?.instructions).toContain(skillReferenceTag);
+      await expect(
+        restoredParentSkill!.fetchChildSkills(testContext.authenticator)
+      ).resolves.toEqual([
+        expect.objectContaining({
+          sId: childSkill.sId,
+        }),
+      ]);
+    });
   });
 
   describe("delete", () => {
@@ -1186,6 +1371,32 @@ describe("SkillResource", () => {
       expect(skillsForAgentAfter.some((s) => s.id === skillResource.id)).toBe(
         false
       );
+    });
+
+    it("marks parent skill references unavailable before deleting a child skill", async () => {
+      const { parentSkill, childSkill } =
+        await SkillFactory.createWithNestedSkill(testContext.authenticator, {
+          childOverrides: {
+            name: "Deleted Child Skill",
+          },
+          parentOverrides: {
+            name: "Parent Skill",
+          },
+        });
+
+      const result = await childSkill.delete(testContext.authenticator);
+      expect(result.isOk()).toBe(true);
+
+      const parentSkillAfterDelete = await SkillResource.fetchById(
+        testContext.authenticator,
+        parentSkill.sId
+      );
+      expect(parentSkillAfterDelete?.instructions).toContain(
+        `<unavailable_skill id="${childSkill.sId}" />`
+      );
+      await expect(
+        parentSkillAfterDelete!.fetchChildSkills(testContext.authenticator)
+      ).resolves.toHaveLength(0);
     });
   });
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -111,6 +111,11 @@ type SkillReferenceTarget = {
   id: string;
   name: string;
   requestedSpaceIds: readonly ModelId[];
+  status: SkillStatus;
+};
+
+type ReplaceSkillReferenceTagsOptions = {
+  html?: boolean;
 };
 
 type SkillResourceConstructorOptions =
@@ -2316,8 +2321,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         );
       }
 
-      // We preserve AgentSkillModel and ConversationSkillModel relationships
-      // so they can be restored when the skill is unarchived.
+      // We preserve AgentSkillModel, ConversationSkillModel, and
+      // SkillReferenceModel relationships so they can be restored when the skill
+      // is unarchived.
       const [count] = await this.update({ status: "archived" }, transaction);
 
       if (count > 0) {
@@ -2329,6 +2335,17 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           {
             previousRequestedSpaceIds: this.requestedSpaceIds,
             newRequestedSpaceIds: [],
+          },
+          { transaction }
+        );
+
+        await this.propagateReferenceUpdatesToParentSkills(
+          auth,
+          {
+            icon: this.icon,
+            name: this.name,
+            requestedSpaceIds: this.requestedSpaceIds,
+            status: "archived",
           },
           { transaction }
         );
@@ -2359,6 +2376,17 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           {
             previousRequestedSpaceIds: [],
             newRequestedSpaceIds: this.requestedSpaceIds,
+          },
+          { transaction }
+        );
+
+        await this.propagateReferenceUpdatesToParentSkills(
+          auth,
+          {
+            icon: this.icon,
+            name: this.name,
+            requestedSpaceIds: this.requestedSpaceIds,
+            status: "active",
           },
           { transaction }
         );
@@ -2417,6 +2445,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     // Snapshot the previous name before updating to detect a rename below.
     const previousName = this.name;
+    const previousStatus = this.status;
 
     await withTransaction(async (transaction) => {
       // Save the current version before updating.
@@ -2430,6 +2459,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         requestedSpaceIds.some(
           (spaceId) => !previousRequestedSpaceIdsSet.has(spaceId)
         );
+      const statusChanged = status !== undefined && previousStatus !== status;
 
       const editedBy = auth.user()?.id;
       await this.update(
@@ -2467,13 +2497,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         );
       }
 
-      if (name !== previousName || requestedSpaceIdsChanged) {
+      if (name !== previousName || requestedSpaceIdsChanged || statusChanged) {
         await this.propagateReferenceUpdatesToParentSkills(
           auth,
           {
             icon,
             name,
             requestedSpaceIds,
+            status: status ?? this.status,
           },
           { transaction }
         );
@@ -2505,7 +2536,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   /**
    * Rewrites inline references to this skill in every parent skill so their tag
-   * availability reflects this skill's current requested spaces.
+   * availability reflects this skill's current status and requested spaces.
    */
   private async propagateReferenceUpdatesToParentSkills(
     auth: Authenticator,
@@ -2513,10 +2544,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       icon,
       name,
       requestedSpaceIds,
+      status,
     }: {
       icon: string | null;
       name: string;
       requestedSpaceIds: readonly ModelId[];
+      status: SkillStatus;
     },
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<void> {
@@ -2550,6 +2583,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           id: this.sId,
           name,
           requestedSpaceIds,
+          status,
         },
       ],
     ]);
@@ -3012,6 +3046,17 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       );
 
       const affectedCount = await withTransaction(async (transaction) => {
+        await this.propagateReferenceUpdatesToParentSkills(
+          auth,
+          {
+            icon: this.icon,
+            name: this.name,
+            requestedSpaceIds: this.requestedSpaceIds,
+            status: "archived",
+          },
+          { transaction }
+        );
+
         // Delete agent-skill associations.
         await AgentSkillModel.destroy({
           where: {
@@ -3376,7 +3421,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     content: string,
     targets: ReadonlyMap<string, SkillReferenceTarget>,
     parentRequestedSpaceIds: readonly ModelId[],
-    { html = false }: { html?: boolean } = {}
+    { html = false }: ReplaceSkillReferenceTagsOptions = {}
   ): string {
     if (targets.size === 0) {
       return content;
@@ -3392,9 +3437,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         return tag;
       }
 
-      const isAvailable = target.requestedSpaceIds.every((spaceId) =>
-        parentRequestedSpaceIdsSet.has(spaceId)
-      );
+      const isAvailable =
+        target.status === "active" &&
+        target.requestedSpaceIds.every((spaceId) =>
+          parentRequestedSpaceIdsSet.has(spaceId)
+        );
 
       if (!isAvailable) {
         return serializeUnavailableSkillTag({ id: target.id }, { html });
@@ -3437,7 +3484,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         id: [...customSkillIdByModelId.keys()],
         workspaceId: workspace.id,
       },
-      attributes: ["id", "icon", "name", "requestedSpaceIds"],
+      attributes: ["id", "icon", "name", "requestedSpaceIds", "status"],
       transaction,
     });
     const targets = new Map<string, SkillReferenceTarget>(
@@ -3453,12 +3500,24 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
                   id: sId,
                   name: skill.name,
                   requestedSpaceIds: skill.requestedSpaceIds,
+                  status: skill.status,
                 },
               ]
             : null;
         })
       )
     );
+    for (const skillId of customSkillIdByModelId.values()) {
+      if (!targets.has(skillId)) {
+        targets.set(skillId, {
+          icon: null,
+          id: skillId,
+          name: "",
+          requestedSpaceIds: [],
+          status: "archived",
+        });
+      }
+    }
 
     const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(
       auth,


### PR DESCRIPTION
## Description

This PR fixes nested skill lifecycle paths where parent instructions could keep live-looking `<skill ...>` tags after a child skill was archived or deleted.

Archive/delete now rewrite parent references to `<unavailable_skill ...>` before archived children disappear from relation payloads or delete drops relation rows. Restore rewrites preserved parent references back to `<skill ...>`. The save-time normalizer also treats missing or non-active custom targets as unavailable.

## Tests

- Updated resource tests for missing, archived/restored, and deleted nested skill references.

## Risk

- Low. Affects custom skill nested-reference lifecycle handling.

## Deploy Plan

- Deploy front.
