### PR TITLE
[front] fix: ignore global-space in nested skills availability check

### DIFF
--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2507,6 +2507,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       return;
     }
 
+    const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(
+      auth,
+      transaction
+    );
     const target = new Map<string, SkillReferenceTarget>([
       [
         this.sId,
@@ -2530,6 +2534,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     // Each update carries distinct instructions content so it cannot be
     // batched. Bounded by the number of skills referencing this one.
     for (const referencingSkill of referencingSkills) {
+      const parentRequestedSpaceIds = uniq([
+        ...referencingSkill.requestedSpaceIds,
+        globalSpace.id,
+      ]);
       const renamedInstructions = renameSkillReferencesInContent(
         referencingSkill.instructions,
         { skillId: this.sId, newName: name }
@@ -2544,14 +2552,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       const instructions = SkillResource.replaceSkillReferenceTags(
         renamedInstructions,
         target,
-        referencingSkill.requestedSpaceIds
+        parentRequestedSpaceIds
       );
       const instructionsHtml =
         renamedInstructionsHtml !== null
           ? SkillResource.replaceSkillReferenceTags(
               renamedInstructionsHtml,
               target,
-              referencingSkill.requestedSpaceIds,
+              parentRequestedSpaceIds,
               { html: true }
             )
           : null;
@@ -3435,17 +3443,26 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       )
     );
 
+    const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(
+      auth,
+      transaction
+    );
+    const parentRequestedSpaceIds = uniq([
+      ...this.requestedSpaceIds,
+      globalSpace.id,
+    ]);
+
     const instructions = SkillResource.replaceSkillReferenceTags(
       this.instructions,
       targets,
-      this.requestedSpaceIds
+      parentRequestedSpaceIds
     );
     const instructionsHtml =
       this.instructionsHtml !== null
         ? SkillResource.replaceSkillReferenceTags(
             this.instructionsHtml,
             targets,
-            this.requestedSpaceIds,
+            parentRequestedSpaceIds,
             { html: true }
           )
         : null;


### PR DESCRIPTION

## Description

This PR fixes nested skill normalization for child skills that only require the workspace global space.

Global space is now treated as implicitly available when checking whether a parent skill can use a nested skill. This prevents global-space child skills from being rewritten as `<unavailable_skill />` when the parent does not have the global space explicitly requested. The same logic is applied during child skill rename/scope propagation so tags stay available over time.

Our db state is actually inconsistent wrt storing the global space.
```sql
SELECT * FROM skill_configurations WHERE id = id_from_sid('skl_z2c3w2KRmt25')
SELECT * FROM skill_configurations WHERE id = id_from_sid('skl_07TSt0hRa7h8');
```

Some nested skills are incorrectly marked as unavailable on our workspace due to this.

## Tests

- Checked locally.

## Risk

- Low. Behind `nested_skills` FF.

## Deploy Plan

- Deploy front.