### PR TITLE
[front] chore: cleanup nested skill reference normalization

### DIFF
--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -935,6 +935,63 @@ describe("SkillResource", () => {
         },
       ]);
     });
+
+    it("drops missing same-workspace nested skill references", async () => {
+      const parentSkill = await SkillFactory.create(testContext.authenticator, {
+        name: "Parent With Missing Skill Reference",
+      });
+      const missingSkillId = SkillResource.modelIdToSId({
+        id: parentSkill.id + 1_000_000,
+        workspaceId: testContext.workspace.id,
+      });
+
+      await parentSkill.updateSkill(testContext.authenticator, {
+        name: parentSkill.name,
+        agentFacingDescription: parentSkill.agentFacingDescription,
+        userFacingDescription: parentSkill.userFacingDescription,
+        instructions: parentSkill.instructions,
+        instructionsHtml: parentSkill.instructionsHtml,
+        icon: parentSkill.icon,
+        mcpServerViews: [],
+        attachedKnowledge: [],
+        requestedSpaceIds: parentSkill.requestedSpaceIds,
+        enableSkillReferences: true,
+        referencedSkillIds: [missingSkillId],
+      });
+
+      await expect(
+        parentSkill.fetchChildSkills(testContext.authenticator)
+      ).resolves.toHaveLength(0);
+    });
+
+    it("normalizes nested skill references present only in instructionsHtml", async () => {
+      const restrictedSpace = await SpaceFactory.regular(testContext.workspace);
+      const childSkill = await SkillFactory.create(testContext.authenticator, {
+        name: "HTML Only Child Skill",
+        requestedSpaceIds: [restrictedSpace.id],
+      });
+      const skillReferenceHtmlTag = serializeSkillTag(
+        {
+          icon: childSkill.icon,
+          id: childSkill.sId,
+          name: childSkill.name,
+        },
+        { html: true }
+      );
+
+      const parentSkill = await SkillFactory.create(testContext.authenticator, {
+        name: "Parent With HTML Only Reference",
+        instructions: "Use the HTML-only child skill.",
+        instructionsHtml: `<p>Use ${skillReferenceHtmlTag}.</p>`,
+        enableSkillReferences: true,
+        referencedSkillIds: [childSkill.sId],
+      });
+
+      expect(parentSkill.instructions).not.toContain("<unavailable_skill");
+      expect(parentSkill.instructionsHtml).toContain(
+        `<unavailable_skill id="${childSkill.sId}"></unavailable_skill>`
+      );
+    });
   });
 
   describe("archive and restore", () => {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2611,8 +2611,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<void> {
     const workspace = auth.getNonNullableWorkspace();
-    const parentSkillId = this.id;
 
+    // Retrieve what we want the end state to be.
     const referencedCustomSkillIds = uniq(
       removeNulls(
         referencedSkillIds.map((sId) => {
@@ -2629,49 +2629,29 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       referencedSkillIds.filter((sId) => !getResourceNameAndIdFromSId(sId))
     );
 
+    const desiredCustomSkillIds = new Set(referencedCustomSkillIds);
+    const desiredGlobalSkillIds = new Set(referencedGlobalSkillIds);
+
+    // Retrieve the current state.
     const existingReferences = await SkillReferenceModel.findAll({
       where: {
         workspaceId: workspace.id,
-        parentSkillId,
+        parentSkillId: this.id,
       },
       transaction,
     });
 
-    const childSkills = await this.model.findAll({
-      attributes: ["id"],
-      where: {
-        id: { [Op.in]: referencedCustomSkillIds },
-        workspaceId: workspace.id,
-      },
-      transaction,
-    });
-    const desiredChildSkillIds = new Set(childSkills.map((skill) => skill.id));
-    const desiredGlobalSkillIds = new Set(referencedGlobalSkillIds);
-
-    if (desiredChildSkillIds.size === 0 && desiredGlobalSkillIds.size === 0) {
-      if (existingReferences.length > 0) {
-        await SkillReferenceModel.destroy({
-          where: {
-            id: { [Op.in]: existingReferences.map((ref) => ref.id) },
-            workspaceId: workspace.id,
-          },
-          transaction,
-        });
-      }
-
-      return;
-    }
-
-    const existingChildSkillIds = new Set(
+    const existingCustomSkillIds = new Set(
       removeNulls(existingReferences.map((ref) => ref.childCustomSkillId))
     );
     const existingGlobalSkillIds = new Set(
       removeNulls(existingReferences.map((ref) => ref.childGlobalSkillId))
     );
 
+    // Delete references that are in the current state but not the end state.
     const referencesToDelete = existingReferences.filter((ref) => {
       if (ref.childCustomSkillId !== null) {
-        return !desiredChildSkillIds.has(ref.childCustomSkillId);
+        return !desiredCustomSkillIds.has(ref.childCustomSkillId);
       }
 
       if (ref.childGlobalSkillId !== null) {
@@ -2680,6 +2660,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
       return true;
     });
+
     if (referencesToDelete.length > 0) {
       await SkillReferenceModel.destroy({
         where: {
@@ -2690,12 +2671,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       });
     }
 
+    // Add references that are in the end state but not the current state.
     const referencesToCreate = [
-      ...[...desiredChildSkillIds]
-        .filter((childSkillId) => !existingChildSkillIds.has(childSkillId))
+      ...[...desiredCustomSkillIds]
+        .filter((childSkillId) => !existingCustomSkillIds.has(childSkillId))
         .map((childSkillId) => ({
           workspaceId: workspace.id,
-          parentSkillId,
+          parentSkillId: this.id,
           childCustomSkillId: childSkillId,
           childGlobalSkillId: null,
         })),
@@ -2703,11 +2685,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         .filter((globalSkillId) => !existingGlobalSkillIds.has(globalSkillId))
         .map((globalSkillId) => ({
           workspaceId: workspace.id,
-          parentSkillId,
+          parentSkillId: this.id,
           childCustomSkillId: null,
           childGlobalSkillId: globalSkillId,
         })),
     ];
+
     if (referencesToCreate.length > 0) {
       await SkillReferenceModel.bulkCreate(referencesToCreate, { transaction });
     }

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -3377,21 +3377,15 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   ): Promise<void> {
     const workspace = auth.getNonNullableWorkspace();
     const customSkillIdByModelId = new Map<ModelId, string>(
-      [
-        ...new Set(
-          [this.instructions, this.instructionsHtml].flatMap((content) =>
-            extractUniqueSkillReferenceIds(content ?? "")
-          )
-        ),
-      ].flatMap((skillId) => {
-        const modelId = isResourceSId("skill", skillId)
-          ? getResourceIdFromSId(skillId)
-          : null;
+      removeNulls(
+        extractUniqueSkillReferenceIds(this.instructions).map((skillId) => {
+          const modelId = isResourceSId("skill", skillId)
+            ? getResourceIdFromSId(skillId)
+            : null;
 
-        return modelId !== null && modelId !== this.id
-          ? ([[modelId, skillId]] satisfies [ModelId, string][])
-          : [];
-      })
+          return modelId ? [modelId, skillId] : null;
+        })
+      )
     );
 
     if (customSkillIdByModelId.size === 0) {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2629,7 +2629,16 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       referencedSkillIds.filter((sId) => !getResourceNameAndIdFromSId(sId))
     );
 
-    const desiredCustomSkillIds = new Set(referencedCustomSkillIds);
+    const childSkills = await this.model.findAll({
+      attributes: ["id"],
+      where: {
+        id: { [Op.in]: referencedCustomSkillIds },
+        workspaceId: workspace.id,
+      },
+      transaction,
+    });
+
+    const desiredCustomSkillIds = new Set(childSkills.map((skill) => skill.id));
     const desiredGlobalSkillIds = new Set(referencedGlobalSkillIds);
 
     // Retrieve the current state.


### PR DESCRIPTION
## Description

This PR cleans up nested skill reference syncing and tag normalization.

The sync path now computes desired and existing custom/global references directly before deleting removed references and creating missing ones. The normalization path also narrows target extraction before rewriting nested skill tags.

## Tests

- Covered by existing tests.

## Risk

- Low, behind `nested_skills` FF.

## Deploy Plan

- Deploy front.