### PR TITLE
Opt: improve snappiness of conversation creation by doing in 2 steps.

### DIFF
--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -103,7 +103,11 @@ export function ConversationContainerVirtuoso({
           contentFragments,
           clientSideMCPServerIds,
           selectedMCPServerViewIds,
+          richMentions: mentions,
         },
+        // Navigate as soon as the conversation exists; the first message is posted
+        // from ConversationViewer on mount.
+        deferMessage: true,
       });
 
       setIsSubmitting(false);

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -9,6 +9,10 @@ import {
 } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { useGenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
 import {
+  InputBarContext,
+  type PendingConversationMessage,
+} from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import {
   createPlaceholderAgentMessage,
   createPlaceholderUserMessage,
 } from "@app/components/assistant/conversation/lib";
@@ -83,7 +87,14 @@ import {
 } from "@virtuoso.dev/message-list";
 import debounce from "lodash/debounce";
 import type { MutableRefObject } from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
 import { mutate } from "swr";
@@ -259,6 +270,51 @@ function addConversationForkNotices(
 
   return mergedMessages;
 }
+
+interface FirstMessagePlaceholders {
+  userMessage: VirtuosoMessage;
+  agentMessages: VirtuosoMessage[];
+}
+
+// Builds the optimistic placeholders for the very first message of a
+// freshly-created conversation, so the list can mount non-empty.
+function buildFirstMessagePlaceholders(
+  pending: PendingConversationMessage,
+  user: UserType
+): FirstMessagePlaceholders {
+  const { input, mentions, contentFragments } = pending;
+
+  // Empty conversation: ranks start at 0 (no existing messages).
+  let rank =
+    contentFragments.contentNodes.length + contentFragments.uploaded.length;
+
+  const userMessage = createPlaceholderUserMessage({
+    input,
+    mentions,
+    user,
+    branchId: null,
+    rank,
+    contentFragments,
+  });
+
+  const agentMessages: VirtuosoMessage[] = [];
+  for (const mention of mentions) {
+    if (isRichAgentMention(mention)) {
+      rank += 1;
+      agentMessages.push(
+        createPlaceholderAgentMessage({
+          userMessage,
+          mention,
+          rank,
+          branchId: null,
+        })
+      );
+    }
+  }
+
+  return { userMessage, agentMessages };
+}
+
 export const ConversationViewer = ({
   owner,
   user,
@@ -280,6 +336,7 @@ export const ConversationViewer = ({
   });
   const sendNotification = useSendNotification();
   const { incrementPendingSteeringCount } = useGenerationContext();
+  const { peekPendingFirstMessage } = useContext(InputBarContext);
 
   const { mutateConversationAttachments } = useConversationAttachments({
     conversationId,
@@ -372,9 +429,39 @@ export const ConversationViewer = ({
   });
   const submitInFlightRef = useRef(false);
 
+  // Pending first message for a freshly-created conversation (deferred-send flow).
+  // Read from InputBarContext (survives Strict Mode remounts) and seeded as the
+  // initial (non-empty) list data so the message shows instantly. The actual send
+  // is handled by useCreateConversationWithMessage; this is display-only.
+  const pendingFirstMessageRef = useRef<
+    PendingConversationMessage | null | undefined
+  >(undefined);
+  if (pendingFirstMessageRef.current === undefined) {
+    pendingFirstMessageRef.current = peekPendingFirstMessage(conversationId);
+  }
+  const firstMessagePlaceholdersRef = useRef<FirstMessagePlaceholders | null>(
+    null
+  );
+  if (
+    pendingFirstMessageRef.current &&
+    firstMessagePlaceholdersRef.current === null
+  ) {
+    firstMessagePlaceholdersRef.current = buildFirstMessagePlaceholders(
+      pendingFirstMessageRef.current,
+      user
+    );
+  }
+
   const [initialListData, setInitialListData] = useState<
     VirtuosoMessage[] | undefined
-  >(undefined);
+  >(() =>
+    firstMessagePlaceholdersRef.current
+      ? [
+          firstMessagePlaceholdersRef.current.userMessage,
+          ...firstMessagePlaceholdersRef.current.agentMessages,
+        ]
+      : undefined
+  );
 
   const [messageIdToScrollTo, setMessageIdToScrollTo] = useState<number | null>(
     null

--- a/front/components/assistant/conversation/input_bar/InputBarContext.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContext.tsx
@@ -4,7 +4,11 @@ import {
   useFileUploaderService,
 } from "@app/hooks/useFileUploaderService";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
-import type { RichAgentMention } from "@app/types/assistant/mentions";
+import type {
+  RichAgentMention,
+  RichMention,
+} from "@app/types/assistant/mentions";
+import type { ContentFragmentsType } from "@app/types/content_fragment";
 import {
   createContext,
   type ReactNode,
@@ -12,6 +16,13 @@ import {
   useMemo,
   useState,
 } from "react";
+
+/** Payload for the first message when creation is deferred until after navigation. */
+export type PendingConversationMessage = {
+  input: string;
+  mentions: RichMention[];
+  contentFragments: ContentFragmentsType;
+};
 
 export const InputBarContext = createContext<{
   animate: boolean;
@@ -22,6 +33,14 @@ export const InputBarContext = createContext<{
   setSelectedSingleAgent: (agentMention: RichAgentMention | null) => void;
   getAndClearPendingInputText: () => string | null;
   setPendingInputText: (text: string | null) => void;
+  peekPendingFirstMessage: (
+    conversationId: string
+  ) => PendingConversationMessage | null;
+  setPendingFirstMessage: (
+    conversationId: string,
+    message: PendingConversationMessage
+  ) => void;
+  clearPendingFirstMessage: (conversationId: string) => void;
   fileUploaderService: FileUploaderService;
   captureActions?: {
     onCapture: (type: "text" | "screenshot") => void;
@@ -36,6 +55,9 @@ export const InputBarContext = createContext<{
   setSelectedSingleAgent: () => {},
   getAndClearPendingInputText: () => null,
   setPendingInputText: () => {},
+  peekPendingFirstMessage: () => null,
+  setPendingFirstMessage: () => {},
+  clearPendingFirstMessage: () => {},
   fileUploaderService: {
     fileBlobs: [],
     handleFileChange: async () => undefined,
@@ -79,6 +101,35 @@ export function InputBarContextProvider({
     null
   );
 
+  // First message stashed while navigating to a newly-created conversation (deferred-send flow).
+  const [
+    pendingFirstMessagesByConversation,
+    setPendingFirstMessagesByConversation,
+  ] = useState<Record<string, PendingConversationMessage>>({});
+
+  const setPendingFirstMessage = useCallback(
+    (conversationId: string, message: PendingConversationMessage) => {
+      setPendingFirstMessagesByConversation((prev) => ({
+        ...prev,
+        [conversationId]: message,
+      }));
+    },
+    []
+  );
+
+  const peekPendingFirstMessage = useCallback(
+    (conversationId: string) =>
+      pendingFirstMessagesByConversation[conversationId] ?? null,
+    [pendingFirstMessagesByConversation]
+  );
+
+  const clearPendingFirstMessage = useCallback((conversationId: string) => {
+    setPendingFirstMessagesByConversation((prev) => {
+      const { [conversationId]: _, ...rest } = prev;
+      return rest;
+    });
+  }, []);
+
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   const setSelectedAgentOuter = useCallback(
     (agentMention: RichAgentMention | null) => {
@@ -120,6 +171,9 @@ export function InputBarContextProvider({
       setSelectedSingleAgent,
       getAndClearPendingInputText,
       setPendingInputText,
+      peekPendingFirstMessage,
+      setPendingFirstMessage,
+      clearPendingFirstMessage,
       captureActions,
       fileUploaderService,
     }),
@@ -130,6 +184,9 @@ export function InputBarContextProvider({
       selectedSingleAgent,
       getAndClearPendingInputText,
       setPendingInputText,
+      peekPendingFirstMessage,
+      setPendingFirstMessage,
+      clearPendingFirstMessage,
       captureActions,
       fileUploaderService,
     ]

--- a/front/components/pod/PodPageContent.tsx
+++ b/front/components/pod/PodPageContent.tsx
@@ -121,8 +121,12 @@ export function PodPageContent({
           mentions: mentions.map(toMentionType),
           contentFragments,
           selectedMCPServerViewIds,
+          richMentions: mentions,
         },
         spaceId: podInfo.sId,
+        // Navigate as soon as the conversation exists; the first message is posted
+        // from ConversationViewer on mount.
+        deferMessage: true,
       });
 
       setIsSubmitting(false);

--- a/front/hooks/useCreateConversationWithMessage.ts
+++ b/front/hooks/useCreateConversationWithMessage.ts
@@ -1,11 +1,18 @@
+import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { useClientType } from "@app/lib/context/clientType";
+import { clientFetch } from "@app/lib/egress/client";
 import { useFetcher } from "@app/lib/swr/swr";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
 import type { PostConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations";
 import type {
   InternalPostConversationsRequestBodySchema,
   SupportedContentNodeContentType,
 } from "@app/types/api/internal/assistant";
-import { isSupportedContentNodeFragmentContentType } from "@app/types/api/internal/assistant";
+import {
+  isSupportedContentNodeFragmentContentType,
+  PostConversationsResponseBodySchema,
+} from "@app/types/api/internal/assistant";
 import type {
   ClientMessageOrigin,
   ConversationMetadata,
@@ -13,13 +20,13 @@ import type {
   ConversationVisibility,
   SubmitMessageError,
 } from "@app/types/assistant/conversation";
-import type { MentionType } from "@app/types/assistant/mentions";
+import type { MentionType, RichMention } from "@app/types/assistant/mentions";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
 import { isAPIErrorResponse } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { UserType, WorkspaceType } from "@app/types/user";
-import { useCallback } from "react";
+import { useCallback, useContext } from "react";
 import type { z } from "zod";
 
 export function useCreateConversationWithMessage({
@@ -31,6 +38,8 @@ export function useCreateConversationWithMessage({
 }) {
   const { fetcher } = useFetcher();
   const contextOrigin = useClientType();
+  const { setPendingFirstMessage, clearPendingFirstMessage } =
+    useContext(InputBarContext);
 
   return useCallback(
     async ({
@@ -40,6 +49,7 @@ export function useCreateConversationWithMessage({
       spaceId,
       title,
       visibility = "unlisted",
+      deferMessage = false,
     }: {
       messageData: {
         input: string;
@@ -48,12 +58,20 @@ export function useCreateConversationWithMessage({
         clientSideMCPServerIds?: string[];
         selectedMCPServerViewIds?: string[];
         origin?: ClientMessageOrigin;
+        // Rich mentions used to render optimistic placeholder messages when the
+        // first message is deferred and posted from `ConversationViewer`.
+        richMentions?: RichMention[];
       };
       visibility?: ConversationVisibility;
       title?: string;
       spaceId?: string | null;
       metadata?: ConversationMetadata;
       skipToolsValidation?: boolean;
+      // When true (and no conversation-level tools are selected), create the
+      // conversation without the initial message and stash the message so that
+      // `ConversationViewer` posts it on mount. This lets the caller navigate to
+      // the conversation page as soon as the `sId` is known.
+      deferMessage?: boolean;
     }): Promise<Result<ConversationType, SubmitMessageError>> => {
       if (!user) {
         return new Err({
@@ -70,8 +88,72 @@ export function useCreateConversationWithMessage({
         clientSideMCPServerIds,
         selectedMCPServerViewIds,
         origin: messageOrigin,
+        richMentions,
       } = messageData;
       const origin = messageOrigin ?? contextOrigin;
+
+      // `selectedMCPServerViewIds` (conversation-level tools) are only wired up by
+      // the conversations endpoint when an initial message is posted (it calls
+      // `upsertMCPServerViews` inside `if (message)`), and the messages endpoint drops
+      // them. Until that's wired through, deferring with tools would silently lose
+      // them, so we keep the combined call in that case.
+      const canDefer =
+        deferMessage && (selectedMCPServerViewIds?.length ?? 0) === 0;
+
+      if (canDefer) {
+        const createBody: z.infer<
+          typeof InternalPostConversationsRequestBodySchema
+        > = {
+          title: title ?? null,
+          visibility,
+          spaceId: spaceId ?? null,
+          metadata,
+          skipToolsValidation,
+          message: null,
+          contentFragments: [],
+        };
+
+        try {
+          const conversationData = parsePostConversationsResponse(
+            await fetcher(`/api/w/${owner.sId}/assistant/conversations`, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify(createBody),
+            })
+          );
+
+          // Stash the message so `ConversationViewer` can render optimistic
+          // placeholders immediately (display only).
+          const conversationId = conversationData.conversation.sId;
+
+          setPendingFirstMessage(conversationId, {
+            input,
+            mentions: richMentions ?? [],
+            contentFragments,
+          });
+
+          // Post the message in the background so navigation isn't blocked on it.
+          void postFirstMessageInBackground({
+            workspaceId: owner.sId,
+            conversationId,
+            input,
+            mentions,
+            contentFragments,
+            clientSideMCPServerIds,
+            origin,
+            skipToolsValidation,
+            profilePictureUrl: user.image,
+          }).finally(() => {
+            clearPendingFirstMessage(conversationId);
+          });
+
+          return new Ok(conversationData.conversation);
+        } catch (e) {
+          return toConversationCreationError(e);
+        }
+      }
 
       const body: z.infer<typeof InternalPostConversationsRequestBodySchema> = {
         title: title ?? null,
@@ -125,37 +207,162 @@ export function useCreateConversationWithMessage({
 
       // Create new conversation and post the initial message at the same time.
       try {
-        const conversationData = (await fetcher(
-          `/api/w/${owner.sId}/assistant/conversations`,
-          {
+        const conversationData = parsePostConversationsResponse(
+          await fetcher(`/api/w/${owner.sId}/assistant/conversations`, {
             method: "POST",
             headers: {
               "Content-Type": "application/json",
             },
             body: JSON.stringify(body),
-          }
-        )) as PostConversationsResponseBody;
+          })
+        );
 
         return new Ok(conversationData.conversation);
       } catch (e) {
-        const isApiError = isAPIErrorResponse(e);
-        return new Err({
-          type:
-            isApiError && e.error.type === "plan_message_limit_exceeded"
-              ? "plan_limit_reached_error"
-              : isApiError && e.error.type === "credits_exhausted"
-                ? "credits_exhausted_error"
-                : isApiError && e.error.type === "user_cap_reached"
-                  ? "user_cap_reached_error"
-                  : "message_send_error",
-          title: "Your message could not be sent.",
-          message: isApiError
-            ? // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-              e.error.message || "Please try again or contact us."
-            : "Please try again or contact us.",
-        });
+        return toConversationCreationError(e);
       }
     },
-    [owner, user, fetcher, contextOrigin]
+    [
+      owner,
+      user,
+      fetcher,
+      contextOrigin,
+      setPendingFirstMessage,
+      clearPendingFirstMessage,
+    ]
   );
+}
+
+// Posts the first message of a deferred conversation in the background. Mirrors
+// useSubmitMessage (content fragments first, then the message). Errors are
+// swallowed/logged: the conversation already exists and the user is on its page.
+async function postFirstMessageInBackground({
+  workspaceId,
+  conversationId,
+  input,
+  mentions,
+  contentFragments,
+  clientSideMCPServerIds,
+  origin,
+  skipToolsValidation,
+  profilePictureUrl,
+}: {
+  workspaceId: string;
+  conversationId: string;
+  input: string;
+  mentions: MentionType[];
+  contentFragments: ContentFragmentsType;
+  clientSideMCPServerIds?: string[];
+  origin: ClientMessageOrigin;
+  skipToolsValidation: boolean;
+  profilePictureUrl: string | null;
+}): Promise<void> {
+  const timezone =
+    Intl.DateTimeFormat().resolvedOptions().timeZone || "Etc/UTC";
+
+  try {
+    const contentFragmentUploads = [
+      ...contentFragments.uploaded.map((cf) => ({
+        kind: "uploaded" as const,
+        cf,
+      })),
+      ...contentFragments.contentNodes.map((cf) => ({
+        kind: "contentNode" as const,
+        cf,
+      })),
+    ];
+
+    if (contentFragmentUploads.length > 0) {
+      await concurrentExecutor(
+        contentFragmentUploads,
+        async (item) => {
+          if (item.kind === "uploaded") {
+            const { cf } = item;
+            await clientFetch(
+              `/api/w/${workspaceId}/assistant/conversations/${conversationId}/content_fragment`,
+              {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  title: cf.title,
+                  fileId: cf.fileId,
+                  url: cf.url,
+                  context: { timezone, profilePictureUrl },
+                }),
+              }
+            );
+            return;
+          }
+
+          const { cf } = item;
+          await clientFetch(
+            `/api/w/${workspaceId}/assistant/conversations/${conversationId}/content_fragment`,
+            {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                title: cf.title,
+                nodeId: cf.internalId,
+                nodeDataSourceViewId: cf.dataSourceView.sId,
+                context: { timezone, profilePictureUrl },
+              }),
+            }
+          );
+        },
+        { concurrency: 8 }
+      );
+    }
+
+    await clientFetch(
+      `/api/w/${workspaceId}/assistant/conversations/${conversationId}/messages`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          content: input,
+          context: {
+            timezone,
+            profilePictureUrl,
+            clientSideMCPServerIds,
+            origin,
+          },
+          mentions,
+          skipToolsValidation,
+        }),
+      }
+    );
+  } catch (e) {
+    logger.error({ err: e }, "Failed to post first message in background");
+  }
+}
+
+function parsePostConversationsResponse(
+  data: unknown
+): PostConversationsResponseBody {
+  const parsed = PostConversationsResponseBodySchema.safeParse(data);
+  if (!parsed.success) {
+    throw new Error("Invalid create conversation response");
+  }
+  return parsed.data as PostConversationsResponseBody;
+}
+
+function toConversationCreationError(
+  e: unknown
+): Result<never, SubmitMessageError> {
+  const isApiError = isAPIErrorResponse(e);
+  return new Err({
+    type:
+      isApiError && e.error.type === "plan_message_limit_exceeded"
+        ? "plan_limit_reached_error"
+        : isApiError && e.error.type === "credits_exhausted"
+          ? "credits_exhausted_error"
+          : isApiError && e.error.type === "user_cap_reached"
+            ? "user_cap_reached_error"
+            : "message_send_error",
+    title: "Your message could not be sent.",
+    message: isApiError
+      ? // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        e.error.message || "Please try again or contact us."
+      : "Please try again or contact us.",
+  });
 }

--- a/front/hooks/useCreateConversationWithMessage.ts
+++ b/front/hooks/useCreateConversationWithMessage.ts
@@ -1,4 +1,5 @@
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useClientType } from "@app/lib/context/clientType";
 import { clientFetch } from "@app/lib/egress/client";
 import { useFetcher } from "@app/lib/swr/swr";
@@ -38,6 +39,7 @@ export function useCreateConversationWithMessage({
 }) {
   const { fetcher } = useFetcher();
   const contextOrigin = useClientType();
+  const { hasFeature } = useFeatureFlags();
   const { setPendingFirstMessage, clearPendingFirstMessage } =
     useContext(InputBarContext);
 
@@ -98,7 +100,9 @@ export function useCreateConversationWithMessage({
       // them. Until that's wired through, deferring with tools would silently lose
       // them, so we keep the combined call in that case.
       const canDefer =
-        deferMessage && (selectedMCPServerViewIds?.length ?? 0) === 0;
+        deferMessage &&
+        hasFeature("deferred_conversation_creation") &&
+        (selectedMCPServerViewIds?.length ?? 0) === 0;
 
       if (canDefer) {
         const createBody: z.infer<
@@ -227,6 +231,7 @@ export function useCreateConversationWithMessage({
       user,
       fetcher,
       contextOrigin,
+      hasFeature,
       setPendingFirstMessage,
       clearPendingFirstMessage,
     ]

--- a/front/types/api/internal/assistant.ts
+++ b/front/types/api/internal/assistant.ts
@@ -195,6 +195,17 @@ export const InternalPostConversationsRequestBodySchema = z.object({
   skipToolsValidation: z.boolean().optional(),
 });
 
+/** Response shape for POST /api/w/[wId]/assistant/conversations (deferred or combined). */
+export const PostConversationsResponseBodySchema = z.object({
+  conversation: z
+    .object({
+      sId: z.string(),
+    })
+    .passthrough(),
+  contentFragments: z.array(z.unknown()),
+  message: z.unknown().optional(),
+});
+
 export const InternalPostBuilderSuggestionsRequestBodySchema = z.union([
   z.object({
     type: z.literal("name"),

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -289,6 +289,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Enable Microsoft sensitivity labels for data classification on connectors and MCP servers",
     stage: "on_demand",
   },
+  deferred_conversation_creation: {
+    description:
+      "Create conversations in two steps (conversation first, first message in background) for faster navigation to the conversation page",
+    stage: "dust_only",
+  },
   conversation_search_indexing: {
     description: "Enable ES indexing of conversations on mutation (write path)",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -759,6 +759,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "sensitivity_labels"
   | "conversation_search_indexing"
   | "conversation_search_read"
+  | "deferred_conversation_creation"
   | "new_file_explorer"
   | "use_vertex_for_supported_models"
   | "metronome_billing_usage_page"


### PR DESCRIPTION
## Description

Conversation creation now navigates to the new conversation as soon as the `sId` is returned, without waiting for the first message to be posted. The message is sent in the background via `postFirstMessageInBackground` while `ConversationViewer` mounts with optimistic placeholder messages built from a `PendingConversationMessage` stashed in `InputBarContext`.

- `useCreateConversationWithMessage`: new `deferMessage` flag — when set (and no `selectedMCPServerViewIds`), creates the conversation with `message: null` then fires the message POST as a background void.
- `InputBarContext`: `setPendingFirstMessage`/`peekPendingFirstMessage`/`clearPendingFirstMessage` store the pending payload keyed by `conversationId`; survives React Strict Mode remounts via a ref.
- `ConversationViewer`: `buildFirstMessagePlaceholders` seeds `initialListData` on first render so the list is never empty on navigation; clears the stash after the background POST settles.
- `ConversationContainer` and `PodPageContent`: pass `deferMessage: true` and `richMentions`.

The `canDefer` guard disables the optimisation when `selectedMCPServerViewIds` are present (conversation-level tools are only wired through the combined endpoint today).

## Tests

Tested locally — conversation page loads and shows the optimistic message immediately on navigation; agent response streams normally.

## Risk

Low-medium. If the background message POST fails, the conversation exists but is empty (error is logged, not surfaced). No retry logic. Rollback-safe: removing `deferMessage: true` at the call sites restores the previous behaviour instantly.

## Deploy Plan

Deploy front.
