### PR TITLE
Add: support passing a list of tools / skills on first message (and allow defer path in that case)

### DIFF
--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/index.test.ts
@@ -1,0 +1,95 @@
+import { Authenticator } from "@app/lib/auth";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/programmatic_usage/tracking", () => ({
+  isProgrammaticUsage: () => false,
+  checkProgrammaticUsageLimits: vi.fn(),
+}));
+
+function postMessage(
+  workspace: { sId: string },
+  conversationId: string,
+  key: { secret: string },
+  body: unknown
+) {
+  return honoApp.request(
+    `/api/v1/w/${workspace.sId}/assistant/conversations/${conversationId}/messages`,
+    {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${key.secret}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+describe("POST /api/v1/w/[wId]/assistant/conversations/[cId]/messages", () => {
+  it("returns 401 when an API key (no user) sends selectedMCPServerViewIds", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      method: "POST",
+    });
+
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const conversation = await ConversationFactory.create(userAuth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const response = await postMessage(workspace, conversation.sId, key, {
+      content: "Hello",
+      mentions: [],
+      context: {
+        username: "tester",
+        timezone: "Europe/Paris",
+        origin: "api",
+        selectedMCPServerViewIds: ["msv_abcdef123456"],
+      },
+    });
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message:
+          "Selecting MCP server views is only available to authenticated users.",
+      },
+    });
+  });
+
+  it("returns 400 when the request body fails schema validation", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      method: "POST",
+    });
+
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const conversation = await ConversationFactory.create(userAuth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const response = await postMessage(workspace, conversation.sId, key, {
+      content: "missing mentions and context",
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+});

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -7,6 +7,8 @@ import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { isUserMessageContextOverflowing } from "@app/lib/api/assistant/conversation/helper";
 import { postUserMessageAndWaitForCompletion } from "@app/lib/api/assistant/streaming/blocking";
 import { addBackwardCompatibleAgentMessageFields } from "@app/lib/api/v1/backward_compatibility";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { UserMessageContext } from "@app/types/assistant/conversation";
 import { isEmptyString } from "@app/types/shared/utils/general";
@@ -158,6 +160,41 @@ app.post(
             "Messages from run_agent or agent_handover must come from a system key.",
         },
       });
+    }
+
+    if (context.selectedMCPServerViewIds?.length) {
+      if (!auth.user()) {
+        return apiError(ctx, {
+          status_code: 401,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "Selecting MCP server views is only available to authenticated users.",
+          },
+        });
+      }
+
+      const mcpServerViews = await MCPServerViewResource.fetchByIds(
+        auth,
+        context.selectedMCPServerViewIds
+      );
+
+      const upsertRes = await ConversationResource.upsertMCPServerViews(auth, {
+        conversation,
+        mcpServerViews,
+        enabled: true,
+        source: "conversation",
+        agentConfigurationId: null,
+      });
+      if (upsertRes.isErr()) {
+        return apiError(ctx, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to add MCP server views to conversation",
+          },
+        });
+      }
     }
 
     const messageContext: UserMessageContext = {

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.test.ts
@@ -1,0 +1,112 @@
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import type { MembershipRoleType } from "@app/types/memberships";
+import { honoApp } from "@front-api/app";
+import { assert, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/programmatic_usage/tracking", () => ({
+  isProgrammaticUsage: () => false,
+  checkProgrammaticUsageLimits: vi.fn(),
+}));
+
+async function setupTest(role: MembershipRoleType = "admin") {
+  const { workspace, auth, globalSpace, user } =
+    await createPrivateApiMockRequest({ role, method: "POST" });
+
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+    messagesCreatedAt: [new Date()],
+  });
+
+  return { auth, conversation, globalSpace, user, workspace };
+}
+
+function postMessage(
+  workspace: { sId: string },
+  conversationId: string,
+  body: unknown
+) {
+  return honoApp.request(
+    `/api/w/${workspace.sId}/assistant/conversations/${conversationId}/messages`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+function getTools(workspace: { sId: string }, conversationId: string) {
+  return honoApp.request(
+    `/api/w/${workspace.sId}/assistant/conversations/${conversationId}/tools`
+  );
+}
+
+describe("POST /api/w/:wId/assistant/conversations/:cId/messages", () => {
+  it("enables MCP server views when selectedMCPServerViewIds are provided", async () => {
+    const { workspace, conversation, auth, globalSpace, user } =
+      await setupTest("admin");
+
+    const remoteMCPServer = await RemoteMCPServerFactory.create(workspace);
+    const systemView =
+      await MCPServerViewResource.getMCPServerViewForSystemSpace(
+        auth,
+        remoteMCPServer.sId
+      );
+    assert(systemView, "MCP server view not found");
+    const { view: mcpServerView } = await MCPServerViewResource.create(auth, {
+      systemView,
+      space: globalSpace,
+    });
+
+    const toolsBefore = await getTools(workspace, conversation.sId);
+    expect((await toolsBefore.json()).tools).toEqual([]);
+
+    const response = await postMessage(workspace, conversation.sId, {
+      content: "Message with conversation tools",
+      mentions: [{ configurationId: GLOBAL_AGENTS_SID.DUST }],
+      context: {
+        timezone: "Europe/Paris",
+        profilePictureUrl: user.imageUrl ?? null,
+        selectedMCPServerViewIds: [mcpServerView.sId],
+      },
+      skipToolsValidation: true,
+    });
+
+    expect(response.status).toBe(200);
+
+    const toolsAfter = await getTools(workspace, conversation.sId);
+    expect(toolsAfter.status).toBe(200);
+    const toolsData = await toolsAfter.json();
+    expect(toolsData.tools).toHaveLength(1);
+    expect(toolsData.tools[0].sId).toBe(mcpServerView.sId);
+
+    const relationships = await ConversationResource.fetchMCPServerViews(
+      auth,
+      conversation
+    );
+    expect(relationships).toHaveLength(1);
+    expect(relationships[0].enabled).toBe(true);
+    expect(relationships[0].mcpServerViewId).toBe(mcpServerView.id);
+  });
+
+  it("returns 404 when conversation doesn't exist", async () => {
+    const { workspace } = await setupTest("admin");
+
+    const response = await postMessage(workspace, "non-existent-conversation", {
+      content: "Hello",
+      mentions: [{ configurationId: GLOBAL_AGENTS_SID.DUST }],
+      context: {
+        timezone: "Europe/Paris",
+        profilePictureUrl: null,
+      },
+      skipToolsValidation: true,
+    });
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -4,6 +4,8 @@ import { postUserMessage } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { fetchConversationMessages } from "@app/lib/api/assistant/messages";
 import { getPaginationParams } from "@app/lib/api/pagination";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { extractUniqueSkillIds } from "@app/lib/skills/format";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -173,6 +175,30 @@ app.post(
     }
 
     const conversation = conversationRes.value;
+
+    if (context.selectedMCPServerViewIds?.length) {
+      const mcpServerViews = await MCPServerViewResource.fetchByIds(
+        auth,
+        context.selectedMCPServerViewIds
+      );
+
+      const upsertRes = await ConversationResource.upsertMCPServerViews(auth, {
+        conversation,
+        mcpServerViews,
+        enabled: true,
+        source: "conversation",
+        agentConfigurationId: null,
+      });
+      if (upsertRes.isErr()) {
+        return apiError(ctx, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to add MCP server views to conversation",
+          },
+        });
+      }
+    }
 
     const selectedSkillIds = extractUniqueSkillIds(content);
     if (selectedSkillIds.length > 0) {

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -106,7 +106,7 @@ export function ConversationContainerVirtuoso({
           richMentions: mentions,
         },
         // Navigate as soon as the conversation exists; the first message is posted
-        // from ConversationViewer on mount.
+        // in the background by useCreateConversationWithMessage.
         deferMessage: true,
       });
 

--- a/front/components/pod/PodPageContent.tsx
+++ b/front/components/pod/PodPageContent.tsx
@@ -125,7 +125,7 @@ export function PodPageContent({
         },
         spaceId: podInfo.sId,
         // Navigate as soon as the conversation exists; the first message is posted
-        // from ConversationViewer on mount.
+        // in the background by useCreateConversationWithMessage.
         deferMessage: true,
       });
 

--- a/front/hooks/useCreateConversationWithMessage.ts
+++ b/front/hooks/useCreateConversationWithMessage.ts
@@ -69,10 +69,10 @@ export function useCreateConversationWithMessage({
       spaceId?: string | null;
       metadata?: ConversationMetadata;
       skipToolsValidation?: boolean;
-      // When true (and no conversation-level tools are selected), create the
-      // conversation without the initial message and stash the message so that
-      // `ConversationViewer` posts it on mount. This lets the caller navigate to
-      // the conversation page as soon as the `sId` is known.
+      // When true, create the conversation without the initial message and stash
+      // the message so placeholders render immediately. The message (and tools) are
+      // posted in the background so the caller can navigate as soon as the `sId`
+      // is known.
       deferMessage?: boolean;
     }): Promise<Result<ConversationType, SubmitMessageError>> => {
       if (!user) {
@@ -100,9 +100,7 @@ export function useCreateConversationWithMessage({
       // them. Until that's wired through, deferring with tools would silently lose
       // them, so we keep the combined call in that case.
       const canDefer =
-        deferMessage &&
-        hasFeature("deferred_conversation_creation") &&
-        (selectedMCPServerViewIds?.length ?? 0) === 0;
+        deferMessage && hasFeature("deferred_conversation_creation");
 
       if (canDefer) {
         const createBody: z.infer<
@@ -146,6 +144,7 @@ export function useCreateConversationWithMessage({
             mentions,
             contentFragments,
             clientSideMCPServerIds,
+            selectedMCPServerViewIds,
             origin,
             skipToolsValidation,
             profilePictureUrl: user.image,
@@ -248,6 +247,7 @@ async function postFirstMessageInBackground({
   mentions,
   contentFragments,
   clientSideMCPServerIds,
+  selectedMCPServerViewIds,
   origin,
   skipToolsValidation,
   profilePictureUrl,
@@ -258,6 +258,7 @@ async function postFirstMessageInBackground({
   mentions: MentionType[];
   contentFragments: ContentFragmentsType;
   clientSideMCPServerIds?: string[];
+  selectedMCPServerViewIds?: string[];
   origin: ClientMessageOrigin;
   skipToolsValidation: boolean;
   profilePictureUrl: string | null;
@@ -329,6 +330,7 @@ async function postFirstMessageInBackground({
             timezone,
             profilePictureUrl,
             clientSideMCPServerIds,
+            selectedMCPServerViewIds,
             origin,
           },
           mentions,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.test.ts
@@ -1,0 +1,84 @@
+import { Authenticator } from "@app/lib/auth";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/programmatic_usage/tracking", () => ({
+  isProgrammaticUsage: () => false,
+  checkProgrammaticUsageLimits: vi.fn(),
+}));
+
+import handler from "./index";
+
+describe("POST /api/v1/w/[wId]/assistant/conversations/[cId]/messages", () => {
+  it("returns 401 when an API key (no user) sends selectedMCPServerViewIds", async () => {
+    const { req, res, workspace, key } = await createPublicApiMockRequest({
+      method: "POST",
+    });
+
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const conversation = await ConversationFactory.create(userAuth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    req.url = `/api/v1/w/${workspace.sId}/assistant/conversations/${conversation.sId}/messages`;
+    req.query = { wId: workspace.sId, cId: conversation.sId };
+    req.headers.authorization = `Bearer ${key.secret}`;
+    req.body = {
+      content: "Hello",
+      mentions: [],
+      context: {
+        username: "tester",
+        timezone: "Europe/Paris",
+        origin: "api",
+        selectedMCPServerViewIds: ["msv_abcdef123456"],
+      },
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(401);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message:
+          "Selecting MCP server views is only available to authenticated users.",
+      },
+    });
+  });
+
+  it("returns 400 when the request body fails schema validation", async () => {
+    const { req, res, workspace } = await createPublicApiMockRequest({
+      method: "POST",
+    });
+
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const conversation = await ConversationFactory.create(userAuth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    req.url = `/api/v1/w/${workspace.sId}/assistant/conversations/${conversation.sId}/messages`;
+    req.query = { wId: workspace.sId, cId: conversation.sId };
+    req.body = { content: "missing mentions and context" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+});

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -14,6 +14,8 @@ import { postUserMessageAndWaitForCompletion } from "@app/lib/api/assistant/stre
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import { addBackwardCompatibleAgentMessageFields } from "@app/lib/api/v1/backward_compatibility";
 import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -192,6 +194,44 @@ async function handler(
               "Messages from run_agent or agent_handover must come from a system key.",
           },
         });
+      }
+
+      if (context.selectedMCPServerViewIds?.length) {
+        if (!auth.user()) {
+          return apiError(req, res, {
+            status_code: 401,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "Selecting MCP server views is only available to authenticated users.",
+            },
+          });
+        }
+
+        const mcpServerViews = await MCPServerViewResource.fetchByIds(
+          auth,
+          context.selectedMCPServerViewIds
+        );
+
+        const upsertRes = await ConversationResource.upsertMCPServerViews(
+          auth,
+          {
+            conversation,
+            mcpServerViews,
+            enabled: true,
+            source: "conversation",
+            agentConfigurationId: null,
+          }
+        );
+        if (upsertRes.isErr()) {
+          return apiError(req, res, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: "Failed to add MCP server views to conversation",
+            },
+          });
+        }
       }
 
       const ctx: UserMessageContext = {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -96,6 +96,10 @@
  *                     type: array
  *                     items:
  *                       type: string
+ *                   selectedMCPServerViewIds:
+ *                     type: array
+ *                     items:
+ *                       type: string
  *               skipToolsValidation:
  *                 type: boolean
  *     responses:
@@ -128,6 +132,8 @@ import { fetchConversationMessages } from "@app/lib/api/assistant/messages";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getPaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { extractUniqueSkillIds } from "@app/lib/skills/format";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -309,6 +315,33 @@ async function handler(
       }
 
       const conversation = conversationRes.value;
+
+      if (context.selectedMCPServerViewIds?.length) {
+        const mcpServerViews = await MCPServerViewResource.fetchByIds(
+          auth,
+          context.selectedMCPServerViewIds
+        );
+
+        const upsertRes = await ConversationResource.upsertMCPServerViews(
+          auth,
+          {
+            conversation,
+            mcpServerViews,
+            enabled: true,
+            source: "conversation",
+            agentConfigurationId: null,
+          }
+        );
+        if (upsertRes.isErr()) {
+          return apiError(req, res, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: "Failed to add MCP server views to conversation",
+            },
+          });
+        }
+      }
 
       const selectedSkillIds = extractUniqueSkillIds(content);
       if (selectedSkillIds.length > 0) {

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -7722,6 +7722,12 @@
                         "items": {
                           "type": "string"
                         }
+                      },
+                      "selectedMCPServerViewIds": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
                       }
                     }
                   },


### PR DESCRIPTION
## Description

The messages endpoint (`POST /w/:wId/assistant/conversations/:cId/messages` and its public API counterpart) previously ignored `selectedMCPServerViewIds`, causing `useCreateConversationWithMessage` to skip the `deferMessage` path whenever conversation-level tools were selected — falling back to a slower combined call.

- Wire `selectedMCPServerViewIds` through `postFirstMessageInBackground` to the messages endpoint.
- Both message handlers now call `MCPServerViewResource.fetchByIds` + `ConversationResource.upsertMCPServerViews` when tool IDs are present, mirroring what the conversations endpoint already does.
- Public API endpoint guards this behind `auth.user()` — API-key callers get a 401.
- `deferMessage` now always defers regardless of selected tools, and comment docs updated accordingly.

## Tests

- Added unit tests for `POST /api/v1/.../messages`: 401 when an API key passes `selectedMCPServerViewIds`, 400 on schema validation failure.
- Tested locally end-to-end: new conversation with tools selected navigates immediately and tools are correctly attached.

## Risk

Low. The `upsertMCPServerViews` call is idempotent and already battle-tested via the conversations endpoint. The only new branch is the tool-upsert block in the messages handler; requests without `selectedMCPServerViewIds` are unaffected.

## Deploy Plan

Deploy front.
