### PR TITLE
feat(billing): programmatic cap warning redis, email notifications, and in-app banner

### DIFF
--- a/front-api/routes/novu/index.ts
+++ b/front-api/routes/novu/index.ts
@@ -2,6 +2,7 @@ import { agentMessageFeedbackWorkflow } from "@app/lib/notifications/workflows/a
 import { agentSuggestionsReadyWorkflow } from "@app/lib/notifications/workflows/agent-suggestions-ready";
 import { balanceThresholdReachedWorkflow } from "@app/lib/notifications/workflows/balance-threshold-reached";
 import { conversationUnreadWorkflow } from "@app/lib/notifications/workflows/conversation-unread";
+import { programmaticCapReachedWorkflow } from "@app/lib/notifications/workflows/programmatic-cap-reached";
 import { projectAddedAsMemberWorkflow } from "@app/lib/notifications/workflows/project-added-as-member";
 import { providerCredentialsHealthUpdatedWorkflow } from "@app/lib/notifications/workflows/provider-credential-updated";
 import { skillSuggestionsReadyWorkflow } from "@app/lib/notifications/workflows/skill-suggestions-ready";
@@ -31,6 +32,7 @@ const options: ServeHandlerOptions = {
     providerCredentialsHealthUpdatedWorkflow,
     userAwuCapReachedWorkflow,
     balanceThresholdReachedWorkflow,
+    programmaticCapReachedWorkflow,
   ],
 };
 

--- a/front-api/routes/w/[wId]/usage-status.ts
+++ b/front-api/routes/w/[wId]/usage-status.ts
@@ -1,15 +1,20 @@
 import {
   getWorkspaceCreditPoolStatus,
+  getWorkspaceProgrammaticCreditStatus,
   isUserAwuWarned,
   isUserBlocked,
+  isWorkspaceProgrammaticWarned,
 } from "@app/lib/metronome/user_block";
 import type { WorkspacePoolCreditState } from "@app/types/credits";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
+export type ProgrammaticCreditStatus = "active" | "warned" | "depleted";
+
 export type GetWorkspaceUsageStatusResponseBody = {
   awuStatus: "normal" | "warned" | "blocked";
   poolCreditState: WorkspacePoolCreditState;
+  programmaticCreditStatus: ProgrammaticCreditStatus;
 };
 
 // Mounted at /api/w/:wId/usage-status.
@@ -24,13 +29,19 @@ app.get(
 
     // Workspaces not on Metronome billing have no usage status to report.
     if (!workspace.metronomeCustomerId) {
-      return ctx.json({ awuStatus: "normal", poolCreditState: "active" });
+      return ctx.json({
+        awuStatus: "normal",
+        poolCreditState: "active",
+        programmaticCreditStatus: "active",
+      });
     }
 
-    const [poolCreditState, blockedReason] = await Promise.all([
-      getWorkspaceCreditPoolStatus(workspace.sId),
-      isUserBlocked(workspace.sId, user.sId),
-    ]);
+    const [poolCreditState, blockedReason, programmaticState] =
+      await Promise.all([
+        getWorkspaceCreditPoolStatus(workspace.sId),
+        isUserBlocked(workspace.sId, user.sId),
+        getWorkspaceProgrammaticCreditStatus(workspace.sId),
+      ]);
 
     let awuStatus: GetWorkspaceUsageStatusResponseBody["awuStatus"] = "normal";
     if (blockedReason === "user_cap_reached") {
@@ -39,7 +50,14 @@ app.get(
       awuStatus = "warned";
     }
 
-    return ctx.json({ awuStatus, poolCreditState });
+    let programmaticCreditStatus: ProgrammaticCreditStatus = "active";
+    if (programmaticState === "depleted") {
+      programmaticCreditStatus = "depleted";
+    } else if (await isWorkspaceProgrammaticWarned(workspace.sId)) {
+      programmaticCreditStatus = "warned";
+    }
+
+    return ctx.json({ awuStatus, poolCreditState, programmaticCreditStatus });
   }
 );
 

--- a/front/components/navigation/AppStatusBanner.tsx
+++ b/front/components/navigation/AppStatusBanner.tsx
@@ -205,18 +205,21 @@ interface UsageStatusBannerProps {
 }
 
 function UsageStatusBanner({ owner }: UsageStatusBannerProps) {
-  const { awuStatus, poolCreditState } = useWorkspaceUsageStatus({ owner });
+  const { awuStatus, poolCreditState, programmaticCreditStatus } =
+    useWorkspaceUsageStatus({ owner });
 
-  // The pool balance banner is only shown to admins, who manage workspace
-  // credits. The AWU cap banner is shown to any user subject to a usage cap.
-  // Both can be displayed at the same time.
+  // Pool balance and programmatic cap banners are only shown to admins who
+  // manage workspace credits. The AWU cap banner is shown to any user subject
+  // to a per-user usage cap. All can be displayed at the same time.
   const showPoolBanner =
     isAdmin(owner) &&
     (poolCreditState === "active_low_balance" ||
       poolCreditState === "active_critical_balance");
   const showAwuBanner = awuStatus !== "normal";
+  const showProgrammaticBanner =
+    isAdmin(owner) && programmaticCreditStatus !== "active";
 
-  if (!showPoolBanner && !showAwuBanner) {
+  if (!showPoolBanner && !showAwuBanner && !showProgrammaticBanner) {
     return null;
   }
 
@@ -256,6 +259,28 @@ function UsageStatusBanner({ owner }: UsageStatusBannerProps) {
             awuStatus === "blocked"
               ? "You can no longer run agents. Contact your admin to increase your limit."
               : "Contact your admin to increase your limit before you are blocked."
+          }
+        />
+      )}
+      {showProgrammaticBanner && (
+        <StatusBanner
+          variant={
+            programmaticCreditStatus === "depleted" ? "danger" : "warning"
+          }
+          title={
+            programmaticCreditStatus === "depleted"
+              ? "Programmatic API cap reached"
+              : "Programmatic API cap at 80%"
+          }
+          description={
+            programmaticCreditStatus === "depleted"
+              ? "Your workspace has exhausted its monthly programmatic API credit cap. Programmatic API calls are blocked until the billing cycle resets or the cap is raised."
+              : "Your workspace has used 80% of its monthly programmatic API credit cap. Consider raising the cap to avoid interruptions."
+          }
+          footer={
+            <LinkWrapper href={`/w/${owner.sId}/usage`} className="underline">
+              Manage usage
+            </LinkWrapper>
           }
         />
       )}

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -1,13 +1,20 @@
+import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import { isPAYGEnabled } from "@app/lib/credits/credit_payg";
+import { getMetronomeProgrammaticCap } from "@app/lib/metronome/alerts/programmatic_cap";
 import { listMetronomeBalances } from "@app/lib/metronome/client";
 import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
 import { invalidateWorkspacePoolCredits } from "@app/lib/metronome/credit_balance";
 import { transitionProgrammaticCreditState } from "@app/lib/metronome/programmatic_credit_state_machine";
-import { clearUserCapBlocked } from "@app/lib/metronome/user_block";
+import {
+  clearUserCapBlocked,
+  clearWorkspaceProgrammaticWarned,
+  setWorkspaceProgrammaticWarned,
+} from "@app/lib/metronome/user_block";
 import { transitionUserCreditState } from "@app/lib/metronome/user_credit_state_machine";
 import type { WorkspaceCreditEvent } from "@app/lib/metronome/workspace_credit_state_machine";
 import { transitionWorkspaceCreditState } from "@app/lib/metronome/workspace_credit_state_machine";
+import { notifyAdminsProgrammaticCapReached } from "@app/lib/notifications/workflows/programmatic-cap-reached";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -190,11 +197,18 @@ export async function dispatchProgrammaticLowBalance({
 
 export async function dispatchProgrammaticCapReached({
   workspace,
+  eventId,
 }: {
   workspace: WorkspaceResource;
+  eventId: string;
 }): Promise<void> {
   await transitionProgrammaticCreditState(workspace, {
     type: "programmatic_cap_reached",
+  });
+  void notifyAdminsProgrammaticCapAboutStatus({
+    workspace,
+    isBlocked: true,
+    eventId,
   });
 }
 
@@ -206,6 +220,7 @@ export async function dispatchProgrammaticCapReset({
   await transitionProgrammaticCreditState(workspace, {
     type: "programmatic_cap_reset",
   });
+  void clearWorkspaceProgrammaticWarned(workspace.sId);
 }
 
 /**
@@ -213,18 +228,82 @@ export async function dispatchProgrammaticCapReset({
  * threshold (80% of the monthly cap). Unlike the other programmatic
  * dispatchers this does not transition the credit state machine — the
  * workspace stays in its current balance state and no throttling kicks in.
- * The signal is informational only.
+ * Sets the warning flag in Redis and emails workspace admins.
  */
 export async function dispatchProgrammaticWarning({
   workspace,
+  eventId,
 }: {
   workspace: WorkspaceResource;
+  eventId: string;
 }): Promise<void> {
-  // TODO: send notification to admin.
+  void setWorkspaceProgrammaticWarned(workspace.sId);
+  void notifyAdminsProgrammaticCapAboutStatus({
+    workspace,
+    isBlocked: false,
+    eventId,
+  });
   logger.info(
     { workspaceId: workspace.sId },
     "[ProgrammaticCreditDispatcher] Programmatic warning threshold reached"
   );
+}
+
+async function notifyAdminsProgrammaticCapAboutStatus({
+  workspace,
+  isBlocked,
+  eventId,
+}: {
+  workspace: WorkspaceResource;
+  isBlocked: boolean;
+  eventId: string;
+}): Promise<void> {
+  const metronomeCustomerId = workspace.metronomeCustomerId;
+  if (!metronomeCustomerId) {
+    return;
+  }
+
+  try {
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const lightWorkspace = renderLightWorkspaceType({ workspace });
+
+    const capResult = await getMetronomeProgrammaticCap({
+      metronomeCustomerId,
+      workspaceId: workspace.sId,
+    });
+    const monthlyCapCredits = capResult.isOk() ? capResult.value : null;
+
+    const { members: admins } = await getMembers(auth, {
+      roles: ["admin"],
+      activeOnly: true,
+    });
+    if (admins.length === 0) {
+      logger.warn(
+        { workspaceId: workspace.sId },
+        "[ProgrammaticCreditDispatcher] No active admins found for cap notification"
+      );
+      return;
+    }
+
+    notifyAdminsProgrammaticCapReached({
+      admins: admins.map((admin) => ({
+        sId: admin.sId,
+        email: admin.email,
+        firstName: admin.firstName,
+        lastName: admin.lastName,
+      })),
+      workspaceId: workspace.sId,
+      workspaceName: lightWorkspace.name,
+      monthlyCapCredits,
+      isBlocked,
+      eventId,
+    });
+  } catch (err) {
+    logger.error(
+      { workspaceId: workspace.sId, isBlocked, err },
+      "[ProgrammaticCreditDispatcher] Failed to notify admins of programmatic cap status"
+    );
+  }
 }
 
 /**

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -779,13 +779,16 @@ export async function processMetronomeWebhook({
         // three FSM-driving alerts (cap reached / low / critical).
         const alertName = event.properties.alert_name ?? "";
         if (alertName.startsWith(PROGRAMMATIC_WARNING_BALANCE_ALERT_NAME)) {
-          await dispatchProgrammaticWarning({ workspace });
+          await dispatchProgrammaticWarning({ workspace, eventId: event.id });
         } else {
           const programmaticEvent = programmaticEventFromAlertName(alertName);
           if (programmaticEvent) {
             switch (programmaticEvent.type) {
               case "programmatic_cap_reached":
-                await dispatchProgrammaticCapReached({ workspace });
+                await dispatchProgrammaticCapReached({
+                  workspace,
+                  eventId: event.id,
+                });
                 break;
               case "programmatic_low_balance":
                 await dispatchProgrammaticLowBalance({

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -59,6 +59,10 @@ function buildWorkspaceCreditPoolStatusKey(workspaceId: string): string {
   return `metronome:pool_credit_status:${workspaceId}`;
 }
 
+function buildWorkspaceProgrammaticWarningKey(workspaceId: string): string {
+  return `metronome:programmatic_warning:${workspaceId}`;
+}
+
 function buildWorkspaceProgrammaticDepletedKey(workspaceId: string): string {
   return `metronome:programmatic_depleted:${workspaceId}`;
 }
@@ -180,6 +184,35 @@ export async function isUserAwuWarned(
 ): Promise<boolean> {
   const val = await runOnRedis({ origin: REDIS_ORIGIN }, async (client) =>
     client.get(buildUserAwuWarningKey(workspaceId, userId))
+  );
+  return val === BLOCKED_FLAG;
+}
+
+// Workspace programmatic cap 80% warning (set by webhook; no DB fallback)
+
+export async function setWorkspaceProgrammaticWarned(
+  workspaceId: string
+): Promise<void> {
+  await setFlag(
+    buildWorkspaceProgrammaticWarningKey(workspaceId),
+    BLOCKED_FLAG
+  );
+}
+
+export async function clearWorkspaceProgrammaticWarned(
+  workspaceId: string
+): Promise<void> {
+  await setFlag(
+    buildWorkspaceProgrammaticWarningKey(workspaceId),
+    NOT_BLOCKED_FLAG
+  );
+}
+
+export async function isWorkspaceProgrammaticWarned(
+  workspaceId: string
+): Promise<boolean> {
+  const val = await runOnRedis({ origin: REDIS_ORIGIN }, async (client) =>
+    client.get(buildWorkspaceProgrammaticWarningKey(workspaceId))
   );
   return val === BLOCKED_FLAG;
 }

--- a/front/lib/notifications/workflows/programmatic-cap-reached.ts
+++ b/front/lib/notifications/workflows/programmatic-cap-reached.ts
@@ -1,0 +1,136 @@
+import config from "@app/lib/api/config";
+import { renderEmail } from "@app/lib/notifications/email-templates/default";
+import { getNovuClient } from "@app/lib/notifications/novu-client";
+import logger from "@app/logger/logger";
+import {
+  PROGRAMMATIC_CAP_REACHED_TAG,
+  PROGRAMMATIC_CAP_REACHED_TRIGGER_ID,
+} from "@app/types/notification_preferences";
+import { workflow } from "@novu/framework";
+import z from "zod";
+
+const ProgrammaticCapReachedPayloadSchema = z.object({
+  workspaceId: z.string(),
+  workspaceName: z.string(),
+  // The monthly programmatic credit cap in AWU credits, if known.
+  monthlyCapCredits: z.number().nullable(),
+  // true → cap fully depleted and API calls are blocked; false → 80% warning.
+  isBlocked: z.boolean(),
+});
+
+type ProgrammaticCapReachedPayloadType = z.infer<
+  typeof ProgrammaticCapReachedPayloadSchema
+>;
+
+function formatCredits(credits: number): string {
+  return credits.toLocaleString("en-US");
+}
+
+// Email-only (no in-app): these notifications target workspace admins who
+// manage programmatic API usage, not individual end-users.
+export const programmaticCapReachedWorkflow = workflow(
+  PROGRAMMATIC_CAP_REACHED_TRIGGER_ID,
+  async ({ step, payload, subscriber }) => {
+    await step.email("programmatic-cap-reached-email", async () => {
+      const capLine =
+        payload.monthlyCapCredits !== null
+          ? ` of ${formatCredits(payload.monthlyCapCredits)} credits`
+          : "";
+
+      const subject = payload.isBlocked
+        ? `[Dust] Your workspace has reached its programmatic API credit cap in ${payload.workspaceName}`
+        : `[Dust] Your workspace has used 80% of its programmatic API credit cap in ${payload.workspaceName}`;
+
+      const content = payload.isBlocked
+        ? `Your workspace "${payload.workspaceName}" has exhausted its monthly programmatic API credit cap${capLine}.\nProgrammatic API calls are now blocked until the billing cycle resets or the cap is raised.`
+        : `Your workspace "${payload.workspaceName}" has used 80% of its monthly programmatic API credit cap${capLine}.\nOnce the cap is fully reached, programmatic API calls will be blocked. Consider raising the cap before that happens.`;
+
+      const body = await renderEmail({
+        name: subscriber.firstName ?? "there",
+        workspace: {
+          id: payload.workspaceId,
+          name: payload.workspaceName,
+        },
+        content,
+        action: {
+          label: "Manage workspace usage",
+          url: `${config.getAppUrl()}/w/${payload.workspaceId}/usage`,
+        },
+      });
+      return { subject, body };
+    });
+  },
+  {
+    payloadSchema: ProgrammaticCapReachedPayloadSchema,
+    tags: [PROGRAMMATIC_CAP_REACHED_TAG],
+  }
+);
+
+/**
+ * Email workspace admins about programmatic API credit cap status.
+ * isBlocked=true → cap depleted, API calls blocked.
+ * isBlocked=false → 80% warning.
+ * Fire-and-forget — errors are logged but don't block the caller.
+ */
+export function notifyAdminsProgrammaticCapReached({
+  admins,
+  workspaceId,
+  workspaceName,
+  monthlyCapCredits,
+  isBlocked,
+  eventId,
+}: {
+  admins: Array<{
+    sId: string;
+    email: string;
+    firstName: string | null;
+    lastName: string | null;
+  }>;
+  workspaceId: string;
+  workspaceName: string;
+  monthlyCapCredits: number | null;
+  isBlocked: boolean;
+  eventId: string;
+}): void {
+  if (admins.length === 0) {
+    return;
+  }
+
+  const payload: ProgrammaticCapReachedPayloadType = {
+    workspaceId,
+    workspaceName,
+    monthlyCapCredits,
+    isBlocked,
+  };
+
+  void getNovuClient()
+    .then((novuClient) =>
+      novuClient.triggerBulk({
+        events: admins.map((admin) => ({
+          workflowId: PROGRAMMATIC_CAP_REACHED_TRIGGER_ID,
+          to: {
+            subscriberId: admin.sId,
+            email: admin.email,
+            firstName: admin.firstName ?? undefined,
+            lastName: admin.lastName ?? undefined,
+          },
+          payload,
+          transactionId: `${PROGRAMMATIC_CAP_REACHED_TRIGGER_ID}-${eventId}-${admin.sId}-${isBlocked ? "blocked" : "warned"}`,
+        })),
+      })
+    )
+    .then((r) => {
+      if (r.result.some((res) => !!res.error?.length)) {
+        logger.error(
+          { workspaceId, isBlocked },
+          "Failed to trigger programmatic cap reached notification"
+        );
+      }
+    })
+    .catch((err) => {
+      logger.error(
+        { err, workspaceId, isBlocked },
+        "Failed to trigger programmatic cap reached notification"
+      );
+    });
+}

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -272,6 +272,7 @@ export function useWorkspaceUsageStatus({
   return {
     awuStatus: data?.awuStatus ?? "normal",
     poolCreditState: data?.poolCreditState ?? "active",
+    programmaticCreditStatus: data?.programmaticCreditStatus ?? "active",
     isUsageStatusLoading: !error && !data && !disabled,
   };
 }

--- a/front/pages/api/novu/index.ts
+++ b/front/pages/api/novu/index.ts
@@ -5,6 +5,7 @@ import { agentMessageFeedbackWorkflow } from "@app/lib/notifications/workflows/a
 import { agentSuggestionsReadyWorkflow } from "@app/lib/notifications/workflows/agent-suggestions-ready";
 import { balanceThresholdReachedWorkflow } from "@app/lib/notifications/workflows/balance-threshold-reached";
 import { conversationUnreadWorkflow } from "@app/lib/notifications/workflows/conversation-unread";
+import { programmaticCapReachedWorkflow } from "@app/lib/notifications/workflows/programmatic-cap-reached";
 import { projectAddedAsMemberWorkflow } from "@app/lib/notifications/workflows/project-added-as-member";
 import { providerCredentialsHealthUpdatedWorkflow } from "@app/lib/notifications/workflows/provider-credential-updated";
 import { skillSuggestionsReadyWorkflow } from "@app/lib/notifications/workflows/skill-suggestions-ready";
@@ -26,5 +27,6 @@ export default serve({
     providerCredentialsHealthUpdatedWorkflow,
     userAwuCapReachedWorkflow,
     balanceThresholdReachedWorkflow,
+    programmaticCapReachedWorkflow,
   ],
 });

--- a/front/pages/api/w/[wId]/usage-status.ts
+++ b/front/pages/api/w/[wId]/usage-status.ts
@@ -5,17 +5,22 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import {
   getWorkspaceCreditPoolStatus,
+  getWorkspaceProgrammaticCreditStatus,
   isUserAwuWarned,
   isUserBlocked,
+  isWorkspaceProgrammaticWarned,
 } from "@app/lib/metronome/user_block";
 import { apiError } from "@app/logger/withlogging";
 import type { WorkspacePoolCreditState } from "@app/types/credits";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+export type ProgrammaticCreditStatus = "active" | "warned" | "depleted";
+
 export type GetWorkspaceUsageStatusResponseBody = {
   awuStatus: "normal" | "warned" | "blocked";
   poolCreditState: WorkspacePoolCreditState;
+  programmaticCreditStatus: ProgrammaticCreditStatus;
 };
 
 async function handler(
@@ -40,15 +45,20 @@ async function handler(
 
   // Workspaces not on Metronome billing have no usage status to report.
   if (!workspace.metronomeCustomerId) {
-    return res
-      .status(200)
-      .json({ awuStatus: "normal", poolCreditState: "active" });
+    return res.status(200).json({
+      awuStatus: "normal",
+      poolCreditState: "active",
+      programmaticCreditStatus: "active",
+    });
   }
 
-  const [poolCreditState, blockedReason] = await Promise.all([
-    getWorkspaceCreditPoolStatus(workspace.sId),
-    isUserBlocked(workspace.sId, user.sId),
-  ]);
+  const [poolCreditState, blockedReason, programmaticState] = await Promise.all(
+    [
+      getWorkspaceCreditPoolStatus(workspace.sId),
+      isUserBlocked(workspace.sId, user.sId),
+      getWorkspaceProgrammaticCreditStatus(workspace.sId),
+    ]
+  );
 
   let awuStatus: GetWorkspaceUsageStatusResponseBody["awuStatus"] = "normal";
   if (blockedReason === "user_cap_reached") {
@@ -57,7 +67,16 @@ async function handler(
     awuStatus = "warned";
   }
 
-  return res.status(200).json({ awuStatus, poolCreditState });
+  let programmaticCreditStatus: ProgrammaticCreditStatus = "active";
+  if (programmaticState === "depleted") {
+    programmaticCreditStatus = "depleted";
+  } else if (await isWorkspaceProgrammaticWarned(workspace.sId)) {
+    programmaticCreditStatus = "warned";
+  }
+
+  return res
+    .status(200)
+    .json({ awuStatus, poolCreditState, programmaticCreditStatus });
 }
 
 export default withSessionAuthenticationForWorkspace(handler, {

--- a/front/types/notification_preferences.ts
+++ b/front/types/notification_preferences.ts
@@ -114,6 +114,10 @@ export const BALANCE_THRESHOLD_REACHED_TRIGGER_ID =
 export const BALANCE_THRESHOLD_REACHED_TAG =
   "balance-threshold-reached" as const;
 
+export const PROGRAMMATIC_CAP_REACHED_TRIGGER_ID =
+  "programmatic-cap-reached" as const;
+export const PROGRAMMATIC_CAP_REACHED_TAG = "programmatic-cap-reached" as const;
+
 export type WorkflowTriggerId =
   | typeof CONVERSATION_UNREAD_TRIGGER_ID
   | typeof PROJECT_ADDED_AS_MEMBER_TRIGGER_ID
@@ -121,4 +125,5 @@ export type WorkflowTriggerId =
   | typeof SKILL_SUGGESTIONS_READY_TRIGGER_ID
   | typeof PROVIDER_CREDENTIALS_HEALTH_UPDATED_TRIGGER_ID
   | typeof USER_AWU_CAP_REACHED_TRIGGER_ID
-  | typeof BALANCE_THRESHOLD_REACHED_TRIGGER_ID;
+  | typeof BALANCE_THRESHOLD_REACHED_TRIGGER_ID
+  | typeof PROGRAMMATIC_CAP_REACHED_TRIGGER_ID;


### PR DESCRIPTION
## Description

Follow-up to #26555. Wires up the three missing pieces for the programmatic API credit cap notification system:

**Redis warning flag** (`metronome:programmatic_warning:<ws>`):
- Set when the Metronome 80% warning webhook fires (`dispatchProgrammaticWarning`)
- Cleared when the cap resets (`dispatchProgrammaticCapReset`)
- No DB column — a cold Redis miss returns `false` (safe default; banner stays hidden until the next webhook)

**Admin email notifications** (Novu, email-only):
- 80% warning: "Your workspace has used 80% of its monthly programmatic API credit cap"
- 100% depleted: "Your workspace has exhausted its monthly programmatic API credit cap"
- Deduped via `transactionId` keyed on Metronome event ID + admin sId + blocked state
- Both `dispatchProgrammaticWarning` and `dispatchProgrammaticCapReached` now accept `eventId` for dedup

**In-app sidebar banner** (admin-only):
- `GET /api/w/:wId/usage-status` now returns `programmaticCreditStatus: "active" | "warned" | "depleted"`
- `useWorkspaceUsageStatus` exposes `programmaticCreditStatus`
- `UsageStatusBanner` shows a yellow warning banner at 80% and a red danger banner when depleted

## Tests

Manual: webhook paths tested via existing Metronome flow. All notification calls are fire-and-forget (`void`).

## Risk

Low — Redis writes are fire-and-forget. The new endpoint field is additive. The warning flag has no DB backing (cold miss = hidden banner).

## Deploy Plan

Deploy `front`. After deploy, sync Novu workflows: `npx tsx front/admin/sync_novu_workflows.ts`.
