### PR TITLE
Reduce debounce time, warn user

### DIFF
--- a/front/components/workspace/ChangeSeatModal.tsx
+++ b/front/components/workspace/ChangeSeatModal.tsx
@@ -346,6 +346,9 @@ export function ChangeSeatModal({
         memberName: displayedMember.name,
         seatType: selectedSeat,
         isCancellingScheduledChange,
+        // The target seat is backed by a pool only when it carries an AWU
+        // allocation in the seat plan.
+        hasSeatPool: (seatPlans[selectedSeat]?.awuCredits ?? 0) > 0,
       });
       if (ok) {
         onClose();

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -287,11 +287,13 @@ export function useUpdateMemberSeatType({
       memberName,
       seatType,
       isCancellingScheduledChange,
+      hasSeatPool,
     }: {
       memberId: string;
       memberName: string;
       seatType: MembershipSeatType;
       isCancellingScheduledChange: boolean;
+      hasSeatPool: boolean;
     }): Promise<boolean> => {
       const res = await clientFetch(
         `/api/w/${workspaceId}/members/${memberId}/seat-type`,
@@ -321,7 +323,9 @@ export function useUpdateMemberSeatType({
           ? `${memberName}'s seat will change to ${seatType} at the next credit refresh.`
           : isCancellingScheduledChange
             ? `${memberName}'s scheduled seat change has been cancelled.`
-            : `${memberName}'s seat has been updated to ${seatType}.`,
+            : hasSeatPool
+              ? `${memberName}'s seat has been updated to ${seatType}. The seat pool will be provisioned shortly.`
+              : `${memberName}'s seat has been updated to ${seatType}.`,
       });
 
       await invalidateMembersUsage(workspaceId);

--- a/front/temporal/usage_queue/workflows.ts
+++ b/front/temporal/usage_queue/workflows.ts
@@ -4,7 +4,7 @@ import { syncMetronomeSeatCountSignal } from "@app/temporal/usage_queue/signals"
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import { proxyActivities, setHandler, sleep } from "@temporalio/workflow";
 
-const METRONOME_SEAT_COUNT_DEBOUNCE_MS = 15 * 60 * 1000;
+const METRONOME_SEAT_COUNT_DEBOUNCE_MS = 15 * 1000;
 
 const { recordUsageActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",


### PR DESCRIPTION
## Description

Reduce debounce window from 15min to 15s - enough to handle batch updates from scim or others, but give the user a more reactive experience. Metronome seats must be updated for the user to see their assigned pool.



## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low

## Deploy Plan

deploy front
