### PR TITLE
feat: allow posting a message with no user in open pod

### DIFF
--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -2441,7 +2441,7 @@ describe("postUserMessage", () => {
         expect(result.error.status_code).toBe(403);
         expect(result.error.api_error.type).toBe("workspace_auth_error");
         expect(result.error.api_error.message).toBe(
-          "You are not a member of the project."
+          "You are not a member of the Pod."
         );
       }
     });

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -90,6 +90,7 @@ import { ConversationForkResource } from "@app/lib/resources/conversation_fork_r
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { GroupSpaceViewerResource } from "@app/lib/resources/group_space_viewer_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { makeSId } from "@app/lib/resources/string_ids";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -2447,7 +2448,50 @@ describe("postUserMessage", () => {
       }
     });
 
-    it("should allow posting a message without an auth user to an open pod when user association is disabled", async () => {
+    it("should reject posting a message without an auth user to a restricted Pod even when user association is disabled", async () => {
+      expect(projectSpace.isOpen()).toBe(false);
+
+      const apiKey = await KeyFactory.regular(globalGroup);
+      const { workspaceAuth: apiKeyAuth } = await Authenticator.fromKey(
+        apiKey,
+        workspace.sId
+      );
+
+      expect(apiKeyAuth.user()).toBeNull();
+      const restrictedPod = await SpaceResource.fetchById(
+        apiKeyAuth,
+        projectSpace.sId
+      );
+      expect(restrictedPod).not.toBeNull();
+      expect(restrictedPod?.isOpen()).toBe(false);
+
+      const result = await postUserMessage(apiKeyAuth, {
+        conversation: projectConversation,
+        content: "Hello from an integration",
+        mentions: [],
+        context: {
+          username: "slack-bot",
+          timezone: "UTC",
+          fullName: null,
+          email: null,
+          profilePictureUrl: null,
+          origin: "slack",
+        },
+        doNotAssociateUser: true,
+        skipToolsValidation: false,
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.status_code).toBe(403);
+        expect(result.error.api_error.type).toBe("workspace_auth_error");
+        expect(result.error.api_error.message).toBe(
+          "You are not a member of the Pod."
+        );
+      }
+    });
+
+    it("should allow posting a message without an auth user to an open Pod when user association is disabled", async () => {
       const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
         workspace.sId
       );
@@ -2463,6 +2507,12 @@ describe("postUserMessage", () => {
       );
 
       expect(apiKeyAuth.user()).toBeNull();
+      const openPod = await SpaceResource.fetchById(
+        apiKeyAuth,
+        projectSpace.sId
+      );
+      expect(openPod).not.toBeNull();
+      expect(openPod?.isOpen()).toBe(true);
 
       const result = await postUserMessage(apiKeyAuth, {
         conversation: projectConversation,
@@ -2489,7 +2539,7 @@ describe("postUserMessage", () => {
       }
     });
 
-    it("should reject posting a message without an auth user to an open pod when user association is enabled", async () => {
+    it("should reject posting a message without an auth user to an open Pod when user association is enabled", async () => {
       const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
         workspace.sId
       );
@@ -2505,6 +2555,12 @@ describe("postUserMessage", () => {
       );
 
       expect(apiKeyAuth.user()).toBeNull();
+      const openPod = await SpaceResource.fetchById(
+        apiKeyAuth,
+        projectSpace.sId
+      );
+      expect(openPod).not.toBeNull();
+      expect(openPod?.isOpen()).toBe(true);
 
       const result = await postUserMessage(apiKeyAuth, {
         conversation: projectConversation,

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -89,6 +89,7 @@ import { ConversationBranchResource } from "@app/lib/resources/conversation_bran
 import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { CreditResource } from "@app/lib/resources/credit_resource";
+import { GroupSpaceViewerResource } from "@app/lib/resources/group_space_viewer_resource";
 import { makeSId } from "@app/lib/resources/string_ids";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -2446,6 +2447,90 @@ describe("postUserMessage", () => {
       }
     });
 
+    it("should allow posting a message without an auth user to an open pod when user association is disabled", async () => {
+      const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      await GroupSpaceViewerResource.makeNew(internalAdminAuth, {
+        group: globalGroup,
+        space: projectSpace,
+      });
+
+      const apiKey = await KeyFactory.regular(globalGroup);
+      const { workspaceAuth: apiKeyAuth } = await Authenticator.fromKey(
+        apiKey,
+        workspace.sId
+      );
+
+      expect(apiKeyAuth.user()).toBeNull();
+
+      const result = await postUserMessage(apiKeyAuth, {
+        conversation: projectConversation,
+        content: "Hello from an integration",
+        mentions: [],
+        context: {
+          username: "slack-bot",
+          timezone: "UTC",
+          fullName: null,
+          email: null,
+          profilePictureUrl: null,
+          origin: "slack",
+        },
+        doNotAssociateUser: true,
+        skipToolsValidation: false,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.userMessage.content).toBe(
+          "Hello from an integration"
+        );
+        expect(result.value.userMessage.user).toBeNull();
+      }
+    });
+
+    it("should reject posting a message without an auth user to an open pod when user association is enabled", async () => {
+      const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      await GroupSpaceViewerResource.makeNew(internalAdminAuth, {
+        group: globalGroup,
+        space: projectSpace,
+      });
+
+      const apiKey = await KeyFactory.regular(globalGroup);
+      const { workspaceAuth: apiKeyAuth } = await Authenticator.fromKey(
+        apiKey,
+        workspace.sId
+      );
+
+      expect(apiKeyAuth.user()).toBeNull();
+
+      const result = await postUserMessage(apiKeyAuth, {
+        conversation: projectConversation,
+        content: "Hello from an integration",
+        mentions: [],
+        context: {
+          username: "slack-bot",
+          timezone: "UTC",
+          fullName: null,
+          email: null,
+          profilePictureUrl: null,
+          origin: "slack",
+        },
+        skipToolsValidation: false,
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.status_code).toBe(403);
+        expect(result.error.api_error.type).toBe("workspace_auth_error");
+        expect(result.error.api_error.message).toBe(
+          "You are not a member of the Pod."
+        );
+      }
+    });
+
     it("should return 404 when project space does not exist", async () => {
       const user = memberAuth.getNonNullableUser();
       const userJson = user.toJSON();
@@ -2475,7 +2560,7 @@ describe("postUserMessage", () => {
       if (result.isErr()) {
         expect(result.error.status_code).toBe(404);
         expect(result.error.api_error.type).toBe("space_not_found");
-        expect(result.error.api_error.message).toBe("Space not found");
+        expect(result.error.api_error.message).toBe("Pod not found");
       }
     });
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -577,26 +577,30 @@ export async function postUserMessage(
   }
 
   const featureFlags = await getFeatureFlags(auth);
-  const isPartOfProject = isPodConversation(conversation);
+  const isPartOfPod = isPodConversation(conversation);
 
-  if (isPartOfProject) {
+  if (isPartOfPod) {
     // Check if the user is a member of the space.
-    const space = await SpaceResource.fetchById(auth, conversation.spaceId);
-    if (!space) {
+    const pod = await SpaceResource.fetchById(auth, conversation.spaceId);
+    if (!pod) {
       return new Err({
         status_code: 404,
         api_error: {
           type: "space_not_found",
-          message: "Space not found",
+          message: "Pod not found",
         },
       });
     }
-    if (!space.isMember(auth)) {
+    // If the Pod is open and there is no user in the context (eg: slack bot message),
+    // we allow the message to be posted.
+    const skipMembershipCheck =
+      pod.isOpen() && !auth.user() && doNotAssociateUser === true;
+    if (!skipMembershipCheck && !pod.isMember(auth)) {
       return new Err({
         status_code: 403,
         api_error: {
           type: "workspace_auth_error",
-          message: "You are not a member of the project.",
+          message: "You are not a member of the Pod.",
         },
       });
     }
@@ -798,7 +802,7 @@ export async function postUserMessage(
     }
 
     // When the agent is not usable, we will create a branch.
-    if (isPartOfProject) {
+    if (isPartOfPod) {
       const canAgentBeUsed = await canAgentBeUsedInProjectConversation(auth, {
         configuration: agentConfig,
         conversation,

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -584,7 +584,7 @@ export async function createConversationFork(
   const parentSpace = parentConversation.space;
   if (parentSpace?.isProject() && !parentSpace.isMember(auth)) {
     return new Err(
-      new DustError("unauthorized", "You are not a member of the project.")
+      new DustError("unauthorized", "You are not a member of the Pod.")
     );
   }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8270

This PR allows posting a message in an open Pod conversation without a user in context (e.g., Slack bot messages) by skipping the membership check when the Pod is open.

- Adds a `skipMembershipCheck` bypass in `postUserMessage` when the Pod is open, no auth user is present, and `doNotAssociateUser === true`.

## Tests

Manually.

## Risks

Low.

## Deploy Plan

Standard deployment.
