### PR TITLE
Fixed seat sync with assigned/unassigned counts. Add poke plugin

### DIFF
--- a/front/lib/api/metronome/seat_sync.ts
+++ b/front/lib/api/metronome/seat_sync.ts
@@ -1,0 +1,84 @@
+import { getActiveContract } from "@app/lib/metronome/plan_type";
+import {
+  hasContractSeatSubscription,
+  syncSeatCount,
+} from "@app/lib/metronome/seats";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import type { LightWorkspaceType } from "@app/types/user";
+
+/**
+ * Outcome of `syncMetronomeSeatCountForWorkspace`. `synced` means the
+ * reconciliation ran; `skipped` means there was nothing to sync (not on
+ * Metronome, no active contract, or no seat subscription) — with a
+ * human-readable `reason`.
+ */
+export type SeatSyncOutcome =
+  | { status: "synced" }
+  | { status: "skipped"; reason: string };
+
+/**
+ * Resolve a workspace's active Metronome contract and reconcile its seat
+ * subscriptions to the DB membership state — the same work the debounced
+ * `syncMetronomeSeatCountActivity` performs, but callable directly (e.g. from
+ * a poke plugin) to run the sync immediately, without the debounce.
+ *
+ * Lives in `lib/api/metronome` rather than `lib/metronome/seats` on purpose:
+ * it depends on `SubscriptionResource`, and `subscription_resource` →
+ * `metronome/contracts` → `metronome/seats` already forms a chain, so importing
+ * the resource from `seats.ts` would close an import cycle. `lib/api/*` sits
+ * above the resource layer, breaking it.
+ *
+ * Returns a domain `Result`: a Metronome failure from `syncSeatCount` is
+ * propagated as `Err` rather than swallowed, so the caller can surface it.
+ */
+export async function syncMetronomeSeatCountForWorkspace({
+  workspace,
+}: {
+  workspace: LightWorkspaceType;
+}): Promise<Result<SeatSyncOutcome, Error>> {
+  if (!workspace.metronomeCustomerId) {
+    return new Ok({
+      status: "skipped",
+      reason: "workspace is not provisioned on Metronome",
+    });
+  }
+
+  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+    workspace.id
+  );
+  if (!subscription?.metronomeContractId) {
+    return new Ok({
+      status: "skipped",
+      reason: "workspace has no Metronome contract on its active subscription",
+    });
+  }
+
+  const contract = await getActiveContract(workspace.sId);
+  if (!contract) {
+    return new Ok({
+      status: "skipped",
+      reason: "no active contract found for workspace",
+    });
+  }
+
+  if (!(await hasContractSeatSubscription(contract))) {
+    return new Ok({
+      status: "skipped",
+      reason: "active contract has no seat subscription",
+    });
+  }
+
+  const result = await syncSeatCount({
+    metronomeCustomerId: workspace.metronomeCustomerId,
+    contractId: subscription.metronomeContractId,
+    workspace,
+    contract,
+  });
+  if (result.isErr()) {
+    return new Err(result.error);
+  }
+
+  return new Ok({ status: "synced" });
+}

--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -37,6 +37,7 @@ export * from "./run_reinforcement_workflow";
 export * from "./send_onboarding_conversation";
 export * from "./soft_delete_conversation";
 export * from "./switch_to_metronome_billing";
+export * from "./sync_metronome_seats";
 export * from "./sync_missing_transcripts_date_range";
 export * from "./sync_pool_credit_state";
 export * from "./toggle_auto_create_space";

--- a/front/lib/api/poke/plugins/workspaces/sync_metronome_seats.ts
+++ b/front/lib/api/poke/plugins/workspaces/sync_metronome_seats.ts
@@ -1,0 +1,51 @@
+import { syncMetronomeSeatCountForWorkspace } from "@app/lib/api/metronome/seat_sync";
+import { createPlugin } from "@app/lib/api/poke/types";
+import { isCreditPricedPlan } from "@app/types/plan";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+export const syncMetronomeSeatsPlugin = createPlugin({
+  manifest: {
+    id: "sync-metronome-seats",
+    name: "Sync Metronome Seat Count",
+    description:
+      "Reconcile this workspace's Metronome seat subscriptions to the current " +
+      "membership state right now, bypassing the debounce. Use to apply a seat " +
+      "change immediately or to repair a drifted seat/unassigned count.",
+    resourceTypes: ["workspaces"],
+    args: {},
+  },
+
+  isApplicableTo: (auth) => {
+    const plan = auth.plan();
+    return plan !== null && isCreditPricedPlan(plan);
+  },
+
+  execute: async (auth) => {
+    const workspace = auth.getNonNullableWorkspace();
+
+    // `syncMetronomeSeatCountForWorkspace` returns a domain `Result`: a
+    // Metronome failure is returned as `Err`, not thrown, so we propagate it
+    // straight to the operator instead of swallowing it.
+    const result = await syncMetronomeSeatCountForWorkspace({ workspace });
+    if (result.isErr()) {
+      return new Err(result.error);
+    }
+
+    const outcome = result.value;
+    switch (outcome.status) {
+      case "synced":
+        return new Ok({
+          display: "text",
+          value: "Metronome seat count synced.",
+        });
+      case "skipped":
+        return new Ok({
+          display: "text",
+          value: `Nothing to sync: ${outcome.reason}.`,
+        });
+      default:
+        return assertNever(outcome);
+    }
+  },
+});

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -1219,15 +1219,19 @@ export async function updateSubscriptionQuantity({
 
 // Response shape for POST /v1/contracts/getSubscriptionSeatsHistory. The
 // Metronome Node SDK (3.5.0, latest) has no typed binding for this endpoint —
-// `retrieveSubscriptionQuantityHistory` is the closest and returns quantity
+// `retrieveSubscriptionQuantityHistory` is the closest but returns quantity
 // totals, not seat IDs. So we route through the SDK client's generic post(),
 // which still gives us auth + retries + error handling.
+//
+// NOTE: this endpoint reliably returns the assigned seat IDs but does NOT
+// return the unassigned-seat count — the field below is never populated in
+// practice. The unassigned count is derived separately from the absolute
+// billed quantity (see `getMetronomeSubscriptionSeatState`).
 interface SubscriptionSeatsHistoryResponse {
   data: Array<{
     starting_at: string;
     ending_before?: string | null;
     assigned_seat_ids: string[];
-    unassigned_seats?: number;
   }>;
 }
 
@@ -1241,10 +1245,10 @@ export type SubscriptionSeatState = {
 };
 
 /**
- * Fetch the seat state (assigned seat IDs + unassigned seat count) on a
- * SEAT_BASED subscription at `coveringDate` (defaults to now).
+ * Fetch the assigned seat IDs on a SEAT_BASED subscription at `coveringDate`
+ * (defaults to now), via the (untyped) getSubscriptionSeatsHistory endpoint.
  */
-export async function getMetronomeSubscriptionSeatState({
+async function fetchAssignedSeatIdsFromHistory({
   metronomeCustomerId,
   contractId,
   subscriptionId,
@@ -1253,10 +1257,8 @@ export async function getMetronomeSubscriptionSeatState({
   metronomeCustomerId: string;
   contractId: string;
   subscriptionId: string;
-  // Defaults to `now`. Pass a future date to read the assignments projected
-  // at that point in time.
   coveringDate?: Date;
-}): Promise<Result<SubscriptionSeatState, Error>> {
+}): Promise<Result<string[], Error>> {
   try {
     const response =
       await getMetronomeClient().post<SubscriptionSeatsHistoryResponse>(
@@ -1273,10 +1275,7 @@ export async function getMetronomeSubscriptionSeatState({
     // History is returned ascending by starting_at; take the last entry to
     // get the segment active at `coveringDate` (earlier entries are stale).
     const segment = response.data[response.data.length - 1];
-    return new Ok({
-      assignedSeatIds: segment?.assigned_seat_ids ?? [],
-      unassignedSeats: segment?.unassigned_seats ?? 0,
-    });
+    return new Ok(segment?.assigned_seat_ids ?? []);
   } catch (err) {
     const error = normalizeError(err);
     logger.error(
@@ -1288,8 +1287,113 @@ export async function getMetronomeSubscriptionSeatState({
 }
 
 /**
+ * Fetch the absolute billed seat quantity (assigned + unassigned) on a
+ * SEAT_BASED subscription at `coveringDate` (defaults to now).
+ *
+ * This is the only reliable source for the unassigned-seat count:
+ * `getSubscriptionSeatsHistory` returns assigned seat IDs but not the
+ * unassigned total, so we read the absolute quantity here and derive
+ * `unassigned = quantity - assignedCount` in `getMetronomeSubscriptionSeatState`.
+ *
+ * Future scheduled changes are NOT included by this endpoint, so a future
+ * `coveringDate` resolves to the latest quantity at/under `now`.
+ */
+export async function getMetronomeSubscriptionTotalQuantity({
+  metronomeCustomerId,
+  contractId,
+  subscriptionId,
+  coveringDate,
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+  subscriptionId: string;
+  coveringDate?: Date;
+}): Promise<Result<number, Error>> {
+  try {
+    const response =
+      await getMetronomeClient().v1.contracts.retrieveSubscriptionQuantityHistory(
+        {
+          customer_id: metronomeCustomerId,
+          contract_id: contractId,
+          subscription_id: subscriptionId,
+        }
+      );
+    const coveringMs = (coveringDate ?? new Date()).getTime();
+    // `history` is ascending by `starting_at`. Pick the latest segment that
+    // has started at/under `coveringDate`; its quantity is the absolute total.
+    let quantity = 0;
+    let bestStartMs = Number.NEGATIVE_INFINITY;
+    for (const segment of response.data?.history ?? []) {
+      const startMs = Date.parse(segment.starting_at);
+      if (startMs <= coveringMs && startMs >= bestStartMs) {
+        bestStartMs = startMs;
+        // A seat subscription carries a single quantity datapoint per segment;
+        // take the last to be safe against multiple rate rows.
+        const points = segment.data ?? [];
+        quantity = points.length > 0 ? points[points.length - 1].quantity : 0;
+      }
+    }
+    return new Ok(quantity);
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      { error, metronomeCustomerId, contractId, subscriptionId },
+      "[Metronome] Failed to fetch subscription quantity history"
+    );
+    return new Err(error);
+  }
+}
+
+/**
+ * Fetch the seat state (assigned seat IDs + unassigned seat count) on a
+ * SEAT_BASED subscription at `coveringDate` (defaults to now).
+ *
+ * `unassignedSeats` is derived as `totalQuantity - assignedCount` because the
+ * seats-history endpoint does not return the unassigned count directly.
+ */
+export async function getMetronomeSubscriptionSeatState({
+  metronomeCustomerId,
+  contractId,
+  subscriptionId,
+  coveringDate,
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+  subscriptionId: string;
+  // Defaults to `now`. Pass a future date to read the assignments projected
+  // at that point in time.
+  coveringDate?: Date;
+}): Promise<Result<SubscriptionSeatState, Error>> {
+  const assignedResult = await fetchAssignedSeatIdsFromHistory({
+    metronomeCustomerId,
+    contractId,
+    subscriptionId,
+    coveringDate,
+  });
+  if (assignedResult.isErr()) {
+    return new Err(assignedResult.error);
+  }
+  const assignedSeatIds = assignedResult.value;
+
+  const quantityResult = await getMetronomeSubscriptionTotalQuantity({
+    metronomeCustomerId,
+    contractId,
+    subscriptionId,
+    coveringDate,
+  });
+  if (quantityResult.isErr()) {
+    return new Err(quantityResult.error);
+  }
+
+  return new Ok({
+    assignedSeatIds,
+    unassignedSeats: Math.max(0, quantityResult.value - assignedSeatIds.length),
+  });
+}
+
+/**
  * Fetch the assigned seat IDs on a SEAT_BASED subscription at `coveringDate`
- * (defaults to now). Thin wrapper over `getMetronomeSubscriptionSeatState` for
+ * (defaults to now). Reads only the seats history (no quantity lookup) for
  * callers that don't need the unassigned-seat count.
  */
 export async function getMetronomeSubscriptionAssignedSeatIds({
@@ -1305,16 +1409,12 @@ export async function getMetronomeSubscriptionAssignedSeatIds({
   // at that point in time.
   coveringDate?: Date;
 }): Promise<Result<string[], Error>> {
-  const stateResult = await getMetronomeSubscriptionSeatState({
+  return fetchAssignedSeatIdsFromHistory({
     metronomeCustomerId,
     contractId,
     subscriptionId,
     coveringDate,
   });
-  if (stateResult.isErr()) {
-    return new Err(stateResult.error);
-  }
-  return new Ok(stateResult.value.assignedSeatIds);
 }
 
 /**

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -733,11 +733,49 @@ async function reconcileSeatBasedSegment({
     0,
     (seatLimit?.minSeats ?? 0) - desiredSIds.length
   );
-  const addUnassignedSeats = Math.max(0, desiredUnassigned - currentUnassigned);
+
+  // Metronome auto-fills unassigned seats when seat IDs are added: each added
+  // seat consumes one unassigned seat (total quantity unchanged) before
+  // increasing the total. So by the time our explicit unassigned delta is
+  // applied, the unassigned pool is already reduced by the number of seats we
+  // assign in this same edit (floored at 0). Reconcile against that post-fill
+  // baseline, NOT the raw current count — otherwise we'd double-count by both
+  // letting Metronome auto-fill AND explicitly removing/adding a seat, which is
+  // what caused the unassigned pool to balloon on every sync.
+  // (`removeSeatIds` decrease the total quantity rather than returning seats to
+  // the unassigned pool, so they don't affect this baseline.)
+  const unassignedAfterAutoFill = Math.max(
+    0,
+    currentUnassigned - addSeatIds.length
+  );
+  const addUnassignedSeats = Math.max(
+    0,
+    desiredUnassigned - unassignedAfterAutoFill
+  );
   const removeUnassignedSeats = Math.max(
     0,
-    currentUnassigned - desiredUnassigned
+    unassignedAfterAutoFill - desiredUnassigned
   );
+
+  // Snapshot of the current vs. desired seat state, logged on every reconcile
+  // (including no-ops) so the assigned/unassigned/total counts are always
+  // visible when debugging billing discrepancies.
+  const currentAssigned = assignedSeatIds.length;
+  const desiredAssigned = desiredSIds.length;
+  const seatStateLog = {
+    workspaceId,
+    contractId,
+    subscriptionId,
+    seatType,
+    minSeats: seatLimit?.minSeats,
+    currentAssigned,
+    currentUnassigned,
+    currentTotal: currentAssigned + currentUnassigned,
+    desiredAssigned,
+    desiredUnassigned,
+    desiredTotal: desiredAssigned + desiredUnassigned,
+    startingAt,
+  };
 
   if (
     addSeatIds.length === 0 &&
@@ -745,21 +783,21 @@ async function reconcileSeatBasedSegment({
     addUnassignedSeats === 0 &&
     removeUnassignedSeats === 0
   ) {
+    logger.info(
+      seatStateLog,
+      "[Metronome] Seat-based subscription already in sync — no changes"
+    );
     return new Ok(false);
   }
 
   logger.info(
     {
-      workspaceId,
-      contractId,
-      subscriptionId,
-      seatType,
+      ...seatStateLog,
       addCount: addSeatIds.length,
       removeCount: removeSeatIds.length,
+      unassignedAfterAutoFill,
       addUnassignedSeats,
       removeUnassignedSeats,
-      minSeats: seatLimit?.minSeats,
-      startingAt,
     },
     "[Metronome] Updating seat-based subscription assignments"
   );

--- a/front/lib/metronome/seats_sync.test.ts
+++ b/front/lib/metronome/seats_sync.test.ts
@@ -203,12 +203,92 @@ describe("syncSeatCount min clamping", () => {
       ]),
     });
 
+    // Assigning u2/u3/u4 auto-fills the 2 unassigned seats (Metronome consumes
+    // them) and adds 1 net seat → no explicit unassigned removal needed.
     expect(mockUpdateSubscriptionSeats).toHaveBeenCalledWith(
       expect.objectContaining({
         fromSubscriptionId: "sub_pro",
         addSeatIds: ["u2", "u3", "u4"],
         addUnassignedSeats: 0,
-        removeUnassignedSeats: 2,
+        removeUnassignedSeats: 0,
+      })
+    );
+  });
+
+  it("does not re-add the floor when assigning a seat fills an existing unassigned seat", async () => {
+    // Regression for the incident where every sync re-added the whole floor:
+    // floor 200, 1 real user just assigned, Metronome already holds the 200
+    // floor as unassigned seats. Assigning the user auto-fills one of them, so
+    // the reconcile must touch nothing (no add, no remove).
+    mockGetProductSeatTypes.mockResolvedValue(
+      new Map([["pro-product", "pro"]])
+    );
+    mockGetActiveMemberships.mockResolvedValue({
+      memberships: [membership("u1", "pro")],
+      total: 1,
+    });
+    mockFetchSeatLimits.mockResolvedValue(
+      new Map([["pro", { minSeats: 200 }]])
+    );
+    // 200 floor already provisioned as unassigned; user not yet assigned.
+    mockGetSeatState.mockResolvedValue(
+      new Ok({ assignedSeatIds: [], unassignedSeats: 200 })
+    );
+
+    await syncSeatCount({
+      metronomeCustomerId: "cus_1",
+      contractId: "con_1",
+      workspace: WORKSPACE,
+      contract: makeContract([
+        { id: "sub_pro", productId: "pro-product", mode: "SEAT_BASED" },
+      ]),
+    });
+
+    expect(mockUpdateSubscriptionSeats).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromSubscriptionId: "sub_pro",
+        addSeatIds: ["u1"],
+        addUnassignedSeats: 0,
+        removeUnassignedSeats: 0,
+      })
+    );
+  });
+
+  it("self-heals a ballooned unassigned pool back down to the floor", async () => {
+    // The incident left the contract at 1 assigned + 598 unassigned (total
+    // 599) with a floor of 200. The next sync must remove the excess so the
+    // total converges back to the floor.
+    mockGetProductSeatTypes.mockResolvedValue(
+      new Map([["pro-product", "pro"]])
+    );
+    mockGetActiveMemberships.mockResolvedValue({
+      memberships: [membership("u1", "pro")],
+      total: 1,
+    });
+    mockFetchSeatLimits.mockResolvedValue(
+      new Map([["pro", { minSeats: 200 }]])
+    );
+    mockGetSeatState.mockResolvedValue(
+      new Ok({ assignedSeatIds: ["u1"], unassignedSeats: 598 })
+    );
+
+    await syncSeatCount({
+      metronomeCustomerId: "cus_1",
+      contractId: "con_1",
+      workspace: WORKSPACE,
+      contract: makeContract([
+        { id: "sub_pro", productId: "pro-product", mode: "SEAT_BASED" },
+      ]),
+    });
+
+    // Desired unassigned = 200 - 1 = 199; current 598, no seats added → remove 399.
+    expect(mockUpdateSubscriptionSeats).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromSubscriptionId: "sub_pro",
+        addSeatIds: [],
+        removeSeatIds: [],
+        addUnassignedSeats: 0,
+        removeUnassignedSeats: 399,
       })
     );
   });

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -1,4 +1,5 @@
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
+import { syncMetronomeSeatCountForWorkspace } from "@app/lib/api/metronome/seat_sync";
 import {
   isProgrammaticUsage,
   trackProgrammaticCost,
@@ -15,10 +16,6 @@ import {
   syncMauCount,
 } from "@app/lib/metronome/mau_sync";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
-import {
-  hasContractSeatSubscription,
-  syncSeatCount,
-} from "@app/lib/metronome/seats";
 import {
   AgentMessageModel,
   MessageModel,
@@ -456,62 +453,13 @@ export async function syncMetronomeSeatCountActivity(
     return;
   }
 
-  if (!workspace.metronomeCustomerId) {
-    logger.info(
-      {
-        workspaceId: workspace.sId,
-      },
-      "[Metronome] Skipping seat count sync: workspace missing metronomeCustomerId"
-    );
-    return;
-  }
-
-  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
-    workspace.id
-  );
-  if (!subscription?.metronomeContractId) {
-    logger.info(
-      {
-        workspaceId: workspace.sId,
-        metronomeCustomerId: workspace.metronomeCustomerId,
-      },
-      "[Metronome] Skipping seat count sync: workspace missing metronomeContractId"
-    );
-    return;
-  }
-
-  const contract = await getActiveContract(workspace.sId);
-  if (!contract) {
-    logger.info(
-      {
-        workspaceId: workspace.sId,
-        metronomeCustomerId: workspace.metronomeCustomerId,
-        metronomeContractId: subscription.metronomeContractId,
-      },
-      "[Metronome] Skipping seat count sync: no active contract found for workspace"
-    );
-    return;
-  }
-
   logger.info(
-    {
-      workspaceId: workspace.sId,
-      metronomeCustomerId: workspace.metronomeCustomerId,
-      metronomeContractId: subscription.metronomeContractId,
-    },
+    { workspaceId: workspace.sId },
     "[Metronome] Executing debounced seat count sync"
   );
 
-  const hasSeatSubscription = await hasContractSeatSubscription(contract);
-  if (!hasSeatSubscription) {
-    return;
-  }
-
-  const result = await syncSeatCount({
-    metronomeCustomerId: workspace.metronomeCustomerId,
-    contractId: subscription.metronomeContractId,
+  const result = await syncMetronomeSeatCountForWorkspace({
     workspace: renderLightWorkspaceType({ workspace }),
-    contract,
   });
   if (result.isErr()) {
     logger.error(


### PR DESCRIPTION
## Description

Fixes a bug where the Metronome seat-count sync **kept inflating the unassigned-seat pool on every run**. A workspace with a `minSeats=200` floor and 1 real member drifted to **599 billed seats** (1 assigned + 598 unassigned) after two syncs, because every sync re-added the entire floor.

Two compounding root causes:

1. **Broken unassigned read.** `getMetronomeSubscriptionSeatState` derived `unassignedSeats` from `getSubscriptionSeatsHistory`'s `unassigned_seats` field, which that endpoint never returns — so `currentUnassigned` was always `0`. Each sync then thought it had to re-add the whole floor (`addUnassignedSeats = 200`, then `199`, …).
   - Fix: read the **absolute billed quantity** via the SDK's `retrieveSubscriptionQuantityHistory` and derive `unassignedSeats = max(0, totalQuantity − assignedCount)`. Split out a `fetchAssignedSeatIdsFromHistory` helper so the assigned-only path doesn't pay for the extra quantity call.

2. **Auto-fill double-count.** Metronome auto-fills unassigned seats when seat IDs are added (`add_seat_ids` consumes an unassigned seat before increasing the total). The reconcile didn't account for this, so it adjusted unassigned *on top of* the auto-fill.
   - Fix: in `reconcileSeatBasedSegment`, baseline the unassigned delta against `max(0, currentUnassigned − addSeatIds.length)`.

With both fixes the reconcile converges to `total = max(assignedCount, minSeats)` and is **self-healing**: the next sync on the affected workspace computes `removeUnassignedSeats = 399` and returns it to 200.

Also in this PR:

- **New poke plugin "Sync Metronome Seat Count"** (`workspaces` scope) to reconcile a workspace's seats **immediately, bypassing the 15-min debounce** — useful to apply a seat change now or repair a drifted count. Metronome errors are propagated to the operator (returned as `Err`, not swallowed).
- **Refactor:** extracted the activity's resolve-contract-then-`syncSeatCount` logic into a shared `syncMetronomeSeatCountForWorkspace` in `lib/api/metronome/seat_sync.ts`, called by both the debounced activity and the new plugin. It lives in `lib/api/*` (above the resource layer) on purpose — putting it in `lib/metronome/seats.ts` closes an import cycle (`seats → SubscriptionResource → contracts → seats`).
- **Logging:** `reconcileSeatBasedSegment` now logs the current vs. desired assigned/unassigned/total counts on every reconcile, including no-ops ("already in sync"), so billing discrepancies are debuggable from the logs.

## Tests

- Updated `seats_sync.test.ts`:
  - Corrected the auto-fill expectation (assigning seats that fill existing unassigned seats no longer issues a redundant `removeUnassignedSeats`).
  - Added a regression test: assigning a seat that fills an existing unassigned seat is a no-op on the unassigned pool.
  - Added a regression test: a ballooned pool (1 assigned + 598 unassigned, floor 200) self-heals back to the floor (`removeUnassignedSeats = 399`).
- `lib/metronome/{seats,client}.test.ts` still green.
- Manually verified against the affected workspace's Metronome contract and worker logs (`addUnassignedSeats` was 200 then 199 where it should have been 0 / remove 1).

## Risk

- Low. The change makes the reconcile read the true seat quantity and stop double-counting; it is idempotent and self-healing, so a re-run converges any drifted workspace back to the floor.
- The new read calls one extra Metronome endpoint (`retrieveSubscriptionQuantityHistory`) per seat subscription during a sync; the assigned-only path is unchanged.
- The poke plugin is operator-only and gated to credit-priced plans.
- Safe to roll back: reverting restores the prior (buggy) behavior without data migration.

## Deploy Plan

- Standard deploy. After deploy, the next seat sync per workspace (debounced or triggered via the new poke plugin) reconciles automatically.
- For already-drifted workspaces, run the **Sync Metronome Seat Count** poke plugin (or wait for the next debounced sync) to converge the billed quantity back to the floor.
