### PR TITLE
[front] Fix data source GCS over-deletion via bare project-id prefix

### DIFF
--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -269,13 +269,22 @@ export async function hardDeleteDataSource(
   assert(auth.isBuilder(), "Only builders can delete data sources.");
 
   // Delete all files in the data source's bucket.
+  //
+  // The GCS object key for a data source document is
+  // `{dustAPIProjectId}/{dataSourceInternalId}/{documentIdHash}/{version}.json`. The trailing
+  // slash on the prefix is REQUIRED: GCS matches `prefix` as a raw byte string, not by path
+  // segment, so a bare `dustAPIProjectId` (e.g. "1134") also matches every sibling project whose
+  // id merely starts with the same digits (e.g. "11340", "1134276"), deleting unrelated data
+  // sources' files across other workspaces. Projects map 1-1 to data sources, so scoping the
+  // prefix to `{dustAPIProjectId}/` deletes exactly this data source's files and nothing else.
   const { dustAPIProjectId } = dataSource;
+  const prefix = `${dustAPIProjectId}/`;
 
   let files;
 
   do {
     files = await getDustDataSourcesBucket().getFiles({
-      prefix: dustAPIProjectId,
+      prefix,
       maxResults: FILE_BATCH_SIZE,
     });
 


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/8527


## Problem

`hardDeleteDataSource` deletes a data source's documents from the data sources GCS bucket by listing objects with `prefix: dustAPIProjectId` — a bare project id with **no trailing slash**.

The object key is `{dustAPIProjectId}/{internalId}/{documentIdHash}/{version}.json`. GCS matches `prefix` as a **raw byte string** (we pass no `delimiter`), so deleting a data source in project `"1134"` also matches every *sibling project whose id merely starts with those digits* — `"11340"`, `"113427"`, `"1134276"`, etc. Because project ids are sequential integers, deleting an older (shorter-id) data source silently wipes a whole range of newer, unrelated projects in other workspaces.

The affected workspaces keep their core/Postgres metadata (documents still listed), but the GCS blobs are gone, surfacing as `No such object` / `Failed to download document blob` on read.

This matches the recurring incident in [tasks#8527](https://github.com/dust-tt/tasks/issues/8527): all of a folder's files disappearing at a single instant, with no user-initiated deletion of that data source, across multiple workspaces.

### Confirmed against a real case
For project `1134276`, every document blob was soft-deleted at the same instant (`2026-05-29 06:01:42Z`) while the documents remained `latest` in core — consistent with a `hardDeleteDataSource` on a different data source whose project id is a string-prefix of `1134276` (e.g. `113427`).

## Fix

Scope the listing prefix to `` `${dustAPIProjectId}/` ``. The trailing `/` terminates the match at the project namespace boundary, so it matches exactly this data source's objects and never collides with `11342760/…` or `113427/…`. Projects map 1-1 to data sources, so this deletes the data source's files and nothing else.

## Notes
- One-line behavioral change + explanatory comment.
- Recovery for already-affected customers is separate: blobs are restorable from GCS soft-delete until their hard-delete (soft-delete + 14d retention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)