### PR TITLE
Free usage for sidekick and some platform tools

### DIFF
--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -7,6 +7,7 @@ import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import { createHash } from "crypto";
 
 import {
+  USAGE_TYPE_FREE,
   USAGE_TYPE_GROUP_KEY,
   USAGE_TYPE_PROGRAMMATIC,
   USAGE_TYPE_USER,
@@ -163,6 +164,48 @@ export function getToolCategory(
 }
 
 // ---------------------------------------------------------------------------
+// Usage type helpers
+// ---------------------------------------------------------------------------
+
+export type UsageType =
+  | typeof USAGE_TYPE_USER
+  | typeof USAGE_TYPE_PROGRAMMATIC
+  | typeof USAGE_TYPE_FREE;
+
+// Origins whose entire conversation is free (platform-assistive, not
+// user-requested output).
+const FREE_ORIGINS: ReadonlySet<string> = new Set<string>(["agent_sidekick"]);
+
+// Internal MCP servers whose tool invocations are always free regardless of
+// the message-level usage type (platform plumbing, not user output).
+const FREE_TOOL_SERVERS: ReadonlySet<string> = new Set<string>([
+  "agent_router",
+  "common_utilities",
+  "toolsets",
+  "agent_memory",
+]);
+
+export function getUsageType(
+  isProgrammaticUsage: boolean,
+  origin: string
+): UsageType {
+  if (FREE_ORIGINS.has(origin)) {
+    return USAGE_TYPE_FREE;
+  }
+  return isProgrammaticUsage ? USAGE_TYPE_PROGRAMMATIC : USAGE_TYPE_USER;
+}
+
+function getToolUsageType(
+  baseUsageType: UsageType,
+  internalMCPServerName: string | null
+): UsageType {
+  if (internalMCPServerName && FREE_TOOL_SERVERS.has(internalMCPServerName)) {
+    return USAGE_TYPE_FREE;
+  }
+  return baseUsageType;
+}
+
+// ---------------------------------------------------------------------------
 // LLM usage events
 // ---------------------------------------------------------------------------
 
@@ -184,7 +227,7 @@ export function buildLlmUsageEvents({
   runKey,
   runUsages,
   origin,
-  isProgrammaticUsage,
+  usageType,
   authMethod,
   apiKeyName,
   messageStatus,
@@ -201,7 +244,7 @@ export function buildLlmUsageEvents({
   runKey: string;
   runUsages: RunUsageType[];
   origin: UserMessageOrigin;
-  isProgrammaticUsage: boolean;
+  usageType: UsageType;
   authMethod: string | null;
   apiKeyName: string | null;
   messageStatus: string;
@@ -269,11 +312,10 @@ export function buildLlmUsageEvents({
       // 1 AWU credit = $0.0085
       cost_awu: Math.ceil(group.costMicroUsd / 0.85 / 10_000),
       // TODO: Remove is_programmatic_usage & is_free_usage, this is replaced by single property "usage type"
-      is_programmatic_usage: isProgrammaticUsage ? "true" : "false",
-      is_free_usage: "false",
-      [USAGE_TYPE_GROUP_KEY]: isProgrammaticUsage
-        ? USAGE_TYPE_PROGRAMMATIC
-        : USAGE_TYPE_USER,
+      is_programmatic_usage:
+        usageType === USAGE_TYPE_PROGRAMMATIC ? "true" : "false",
+      is_free_usage: usageType === USAGE_TYPE_FREE ? "true" : "false",
+      [USAGE_TYPE_GROUP_KEY]: usageType,
       auth_method: authMethod ?? "unknown",
       api_key_name: apiKeyName ?? "unknown",
       message_status: messageStatus,
@@ -313,7 +355,7 @@ export function buildToolUseEvents({
   runKey,
   actions,
   origin,
-  isProgrammaticUsage,
+  usageType,
   authMethod,
   apiKeyName,
   messageStatus,
@@ -329,7 +371,7 @@ export function buildToolUseEvents({
   runKey: string;
   actions: ToolAction[];
   origin: UserMessageOrigin;
-  isProgrammaticUsage: boolean;
+  usageType: UsageType;
   authMethod: string | null;
   apiKeyName: string | null;
   messageStatus: string;
@@ -356,44 +398,49 @@ export function buildToolUseEvents({
     }
   }
 
-  return [...groups.values()].map(({ action, count, totalDurationMs }) => ({
-    transaction_id: truncateTransactionId(
-      `tool3-${workspaceId}-${conversationId}-${agentMessageId}-${runKey}-${action.toolName}-${action.mcpServerId ?? ""}-${action.status}`
-    ),
-    customer_id: workspaceId,
-    event_type: "tool_use_v3",
-    timestamp,
-    properties: {
-      workspace_id: workspaceId,
-      user_id: userId ?? "unknown",
-      agent_message_id: agentMessageId,
-      conversation_id: conversationId,
-      agent_id: agentId ?? "unknown",
-      parent_agent_message_id: parentAgentMessageId ?? "none",
-      auth_method: authMethod ?? "unknown",
-      api_key_name: apiKeyName ?? "unknown",
-      tool_name: truncatePropertyValue(action.toolName),
-      mcp_server_id: truncatePropertyValue(action.mcpServerId ?? ""),
-      internal_mcp_server_name: truncatePropertyValue(
-        action.internalMCPServerName ?? ""
+  return [...groups.values()].map(({ action, count, totalDurationMs }) => {
+    const effectiveUsageType = getToolUsageType(
+      usageType,
+      action.internalMCPServerName
+    );
+    return {
+      transaction_id: truncateTransactionId(
+        `tool3-${workspaceId}-${conversationId}-${agentMessageId}-${runKey}-${action.toolName}-${action.mcpServerId ?? ""}-${action.status}`
       ),
-      tool_category: getToolCategory(action.internalMCPServerName),
-      // Constant grouping key — used as presentation_group_key in Metronome to
-      // aggregate all tool categories into a single "Tool Usage" invoice line.
-      tool_group: "tools",
-      status: action.status,
-      count,
-      total_execution_duration_ms: totalDurationMs,
-      // TODO: Remove is_programmatic_usage, this is replaced by single property "usage type"
-      is_programmatic_usage: isProgrammaticUsage ? "true" : "false",
-      [USAGE_TYPE_GROUP_KEY]: isProgrammaticUsage
-        ? USAGE_TYPE_PROGRAMMATIC
-        : USAGE_TYPE_USER,
-      message_status: messageStatus,
-      is_sub_agent_message: isSubAgentMessage ? "true" : "false",
-      origin,
-    },
-  }));
+      customer_id: workspaceId,
+      event_type: "tool_use_v3",
+      timestamp,
+      properties: {
+        workspace_id: workspaceId,
+        user_id: userId ?? "unknown",
+        agent_message_id: agentMessageId,
+        conversation_id: conversationId,
+        agent_id: agentId ?? "unknown",
+        parent_agent_message_id: parentAgentMessageId ?? "none",
+        auth_method: authMethod ?? "unknown",
+        api_key_name: apiKeyName ?? "unknown",
+        tool_name: truncatePropertyValue(action.toolName),
+        mcp_server_id: truncatePropertyValue(action.mcpServerId ?? ""),
+        internal_mcp_server_name: truncatePropertyValue(
+          action.internalMCPServerName ?? ""
+        ),
+        tool_category: getToolCategory(action.internalMCPServerName),
+        // Constant grouping key — used as presentation_group_key in Metronome to
+        // aggregate all tool categories into a single "Tool Usage" invoice line.
+        tool_group: "tools",
+        status: action.status,
+        count,
+        total_execution_duration_ms: totalDurationMs,
+        // TODO: Remove is_programmatic_usage, this is replaced by single property "usage type"
+        is_programmatic_usage:
+          effectiveUsageType === USAGE_TYPE_PROGRAMMATIC ? "true" : "false",
+        [USAGE_TYPE_GROUP_KEY]: effectiveUsageType,
+        message_status: messageStatus,
+        is_sub_agent_message: isSubAgentMessage ? "true" : "false",
+        origin,
+      },
+    };
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -12,7 +12,7 @@ import {
   USAGE_TYPE_PROGRAMMATIC,
   USAGE_TYPE_USER,
 } from "./constants";
-import type { MetronomeEvent } from "./types";
+import type { MetronomeEvent, UsageType } from "./types";
 
 const MAX_TRANSACTION_ID_LENGTH = 128;
 const MAX_PROPERTY_VALUE_BYTES = 128;
@@ -166,11 +166,6 @@ export function getToolCategory(
 // ---------------------------------------------------------------------------
 // Usage type helpers
 // ---------------------------------------------------------------------------
-
-export type UsageType =
-  | typeof USAGE_TYPE_USER
-  | typeof USAGE_TYPE_PROGRAMMATIC
-  | typeof USAGE_TYPE_FREE;
 
 // Origins whose entire conversation is free (platform-assistive, not
 // user-requested output).

--- a/front/lib/metronome/types.ts
+++ b/front/lib/metronome/types.ts
@@ -10,6 +10,9 @@ import {
   getCreditTypeProgrammaticUsdId,
   getProductExcessCreditsId,
   getProductFreeCreditId,
+  type USAGE_TYPE_FREE,
+  type USAGE_TYPE_PROGRAMMATIC,
+  type USAGE_TYPE_USER,
 } from "@app/lib/metronome/constants";
 import type { SupportedCurrency } from "@app/types/currency";
 import type { Commit, Credit } from "@metronome/sdk/resources/shared";
@@ -94,6 +97,11 @@ export function classifyMetronomePackageCurrencyByName(
   }
   return "usd";
 }
+
+export type UsageType =
+  | typeof USAGE_TYPE_USER
+  | typeof USAGE_TYPE_PROGRAMMATIC
+  | typeof USAGE_TYPE_FREE;
 
 export interface MetronomeEvent {
   transaction_id: string;

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -9,6 +9,7 @@ import { ingestMetronomeEvents } from "@app/lib/metronome/client";
 import {
   buildLlmUsageEvents,
   buildToolUseEvents,
+  getUsageType,
 } from "@app/lib/metronome/events";
 import {
   hasMauSubscriptionInContract,
@@ -270,6 +271,7 @@ export async function emitMetronomeUsageEventsActivity(
   const isSubAgentMessage = userMessage?.agenticMessageType !== null;
 
   const programmatic = isProgrammaticUsage(auth, { userMessageOrigin });
+  const usageType = getUsageType(programmatic, userMessageOrigin);
   // Use updatedAt — this is when the agent message finished (not when it was created).
   const timestamp = agentMessage.updatedAt.toISOString();
   const authMethod = userMessage?.userContextAuthMethod ?? null;
@@ -343,7 +345,7 @@ export async function emitMetronomeUsageEventsActivity(
     runKey,
     runUsages,
     origin: userMessageOrigin,
-    isProgrammaticUsage: programmatic,
+    usageType,
     authMethod,
     apiKeyName,
     messageStatus,
@@ -361,7 +363,7 @@ export async function emitMetronomeUsageEventsActivity(
     runKey,
     actions: toolActions,
     origin: userMessageOrigin,
-    isProgrammaticUsage: programmatic,
+    usageType,
     authMethod,
     apiKeyName,
     messageStatus,


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/8298

Implement free usage as per https://github.com/dust-tt/tasks/issues/7799

Add some free usage for the following:
 - Agent Sidekick (origin "agent_sidekick") → getUsageType returns "free" → all LLM and tool events
  are free
 - Agent Router / common_utilities / toolsets / agent_memory tools in a normal conversation →
  getToolUsageType overrides to "free" per-tool, while LLM events remain "user" or "programmatic"

Other free usage are not being reported to metronome (like title suggestions) they are done with direct LLM calls.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
