### PR TITLE
chore(mobile): fix swiftlint/swiftformat scope and add pre-commit hooks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -127,6 +127,21 @@ pre-commit:
       run: cargo fmt -- {staged_files}
       stage_fixed: true
 
+    # Mobile (Swift) format — auto-formats staged files and re-stages them
+    mobile-swiftformat:
+      tags: mobile
+      glob: "*.swift"
+      root: x/adrsimon/mobile/
+      run: swiftformat {staged_files}
+      stage_fixed: true
+
+    # Mobile (Swift) lint — fails on lint errors (warnings do not block)
+    mobile-swiftlint:
+      tags: mobile
+      glob: "*.swift"
+      root: x/adrsimon/mobile/
+      run: swiftlint lint --quiet {staged_files}
+
     # Guard against adding files to frozen migrations/db/ directories
     no-legacy-db-migration-connectors:
       glob: "connectors/migrations/db/*.sql"

--- a/x/adrsimon/mobile/.swiftformat
+++ b/x/adrsimon/mobile/.swiftformat
@@ -14,4 +14,4 @@
 --header strip
 --ifdef no-indent
 --modifierorder nonisolated,private,static
---exclude Dust.xcodeproj,SparkleTokens/Sources/SparkleTokens/Generated
+--exclude Dust.xcodeproj,build,SparkleTokens/build,SparkleTokens/Sources/SparkleTokens/Generated

--- a/x/adrsimon/mobile/.swiftlint.yml
+++ b/x/adrsimon/mobile/.swiftlint.yml
@@ -1,5 +1,6 @@
 included:
   - Dust
+  - SparkleTokens/Sources/SparkleTokens/Helpers
 
 excluded:
   - Dust.xcodeproj
@@ -8,6 +9,13 @@ excluded:
 disabled_rules:
   - trailing_comma
   - todo
+  # Length thresholds are arbitrary and noisy — disabled.
+  - file_length
+  - type_body_length
+  - function_body_length
+  # Owned by SwiftFormat to avoid lint-fix/format ping-pong.
+  - opening_brace
+  - modifier_order
 
 opt_in_rules:
   - empty_count
@@ -19,7 +27,6 @@ opt_in_rules:
   - fatal_error_message
   - first_where
   - last_where
-  - modifier_order
   - overridden_super_call
   - private_action
   - private_outlet
@@ -31,15 +38,3 @@ opt_in_rules:
 line_length:
   warning: 120
   error: 200
-
-type_body_length:
-  warning: 300
-  error: 500
-
-file_length:
-  warning: 500
-  error: 1000
-
-function_body_length:
-  warning: 50
-  error: 100

--- a/x/adrsimon/mobile/Dust/Models/Attachment.swift
+++ b/x/adrsimon/mobile/Dust/Models/Attachment.swift
@@ -43,8 +43,7 @@ struct Attachment: Identifiable {
         if contentType.hasPrefix("image/") { return "photo" }
         if contentType.contains("pdf") { return "doc.richtext" }
         if contentType.contains("text") || contentType.contains("json")
-            || contentType.contains("xml") || contentType.contains("html")
-        { return "doc.text" }
+            || contentType.contains("xml") || contentType.contains("html") { return "doc.text" }
         if contentType.contains("spreadsheet") || contentType.contains("csv") { return "tablecells" }
         return "doc"
     }

--- a/x/adrsimon/mobile/Dust/Models/Capability.swift
+++ b/x/adrsimon/mobile/Dust/Models/Capability.swift
@@ -8,36 +8,36 @@ enum Capability: Identifiable {
     var id: String {
         switch self {
         case let .tool(serverView):
-            return "tool:\(serverView.sId)"
+            "tool:\(serverView.sId)"
         case let .skill(skill):
-            return "skill:\(skill.sId)"
+            "skill:\(skill.sId)"
         }
     }
 
     var displayName: String {
         switch self {
         case let .tool(serverView):
-            return serverView.displayName
+            serverView.displayName
         case let .skill(skill):
-            return skill.name
+            skill.name
         }
     }
 
     var displayDescription: String {
         switch self {
         case let .tool(serverView):
-            return serverView.displayDescription
+            serverView.displayDescription
         case let .skill(skill):
-            return skill.displayDescription
+            skill.displayDescription
         }
     }
 
     var icon: SparkleIcon {
         switch self {
         case let .tool(serverView):
-            return MCPServerIcon.icon(for: serverView.server.name) ?? .bolt
+            MCPServerIcon.icon(for: serverView.server.name) ?? .bolt
         case .skill:
-            return .puzzle
+            .puzzle
         }
     }
 
@@ -46,5 +46,7 @@ enum Capability: Identifiable {
         return false
     }
 
-    var sortKey: String { displayName.lowercased() }
+    var sortKey: String {
+        displayName.lowercased()
+    }
 }

--- a/x/adrsimon/mobile/Dust/Models/Conversation.swift
+++ b/x/adrsimon/mobile/Dust/Models/Conversation.swift
@@ -15,7 +15,9 @@ struct Conversation: Codable, Identifiable, Hashable {
     var unread: Bool
     var actionRequired: Bool
 
-    var id: String { sId }
+    var id: String {
+        sId
+    }
 
     var updatedDate: Date {
         updated.dateFromEpochMs

--- a/x/adrsimon/mobile/Dust/Models/CreateConversation.swift
+++ b/x/adrsimon/mobile/Dust/Models/CreateConversation.swift
@@ -80,8 +80,19 @@ struct ContentFragmentPayload: Encodable {
     }
 
     /// Creates a knowledge node content fragment.
-    static func node(title: String, nodeId: String, nodeDataSourceViewId: String, context: ContentFragmentContext) -> ContentFragmentPayload {
-        ContentFragmentPayload(title: title, fileId: nil, nodeId: nodeId, nodeDataSourceViewId: nodeDataSourceViewId, context: context)
+    static func node(
+        title: String,
+        nodeId: String,
+        nodeDataSourceViewId: String,
+        context: ContentFragmentContext
+    ) -> ContentFragmentPayload {
+        ContentFragmentPayload(
+            title: title,
+            fileId: nil,
+            nodeId: nodeId,
+            nodeDataSourceViewId: nodeDataSourceViewId,
+            context: context
+        )
     }
 
     func encode(to encoder: Encoder) throws {

--- a/x/adrsimon/mobile/Dust/Models/KnowledgeItem.swift
+++ b/x/adrsimon/mobile/Dust/Models/KnowledgeItem.swift
@@ -9,7 +9,9 @@ struct KnowledgeItem: Identifiable {
     let connectorProvider: String?
     let nodeType: String?
 
-    var id: String { "\(dataSourceViewId):\(internalId)" }
+    var id: String {
+        "\(dataSourceViewId):\(internalId)"
+    }
 
     var icon: SparkleIcon {
         if let provider = connectorProvider, let icon = MCPServerIcon.icon(for: provider) {

--- a/x/adrsimon/mobile/Dust/Models/MCPServerView.swift
+++ b/x/adrsimon/mobile/Dust/Models/MCPServerView.swift
@@ -14,9 +14,17 @@ struct MCPServerView: Decodable, Identifiable {
     let spaceId: String
     let server: MCPServer
 
-    var id: String { sId }
-    var displayName: String { name ?? server.name }
-    var displayDescription: String { description ?? server.description }
+    var id: String {
+        sId
+    }
+
+    var displayName: String {
+        name ?? server.name
+    }
+
+    var displayDescription: String {
+        description ?? server.description
+    }
 }
 
 struct MCPServerViewsResponse: Decodable {

--- a/x/adrsimon/mobile/Dust/Models/Message.swift
+++ b/x/adrsimon/mobile/Dust/Models/Message.swift
@@ -67,11 +67,15 @@ struct GeneratedFile: Codable, Identifiable, Hashable {
     let contentType: String
     let createdAt: Double?
     let updatedAt: Double?
-    let isInProjectContext: Bool?
     let hidden: Bool?
 
-    var id: String { fileId }
-    var isVisible: Bool { hidden != true }
+    var id: String {
+        fileId
+    }
+
+    var isVisible: Bool {
+        hidden != true
+    }
 }
 
 // MARK: - Citation (attached to AgentMessage)

--- a/x/adrsimon/mobile/Dust/Models/SearchResponse.swift
+++ b/x/adrsimon/mobile/Dust/Models/SearchResponse.swift
@@ -10,7 +10,9 @@ struct SearchNode: Decodable, Identifiable {
     let dataSource: SearchDataSource?
     let dataSourceViews: [SearchDataSourceView]?
 
-    var id: String { internalId }
+    var id: String {
+        internalId
+    }
 
     func toKnowledgeItem() -> KnowledgeItem? {
         guard let dsvId = dataSourceViews?.first?.sId else { return nil }

--- a/x/adrsimon/mobile/Dust/Models/Skill.swift
+++ b/x/adrsimon/mobile/Dust/Models/Skill.swift
@@ -6,8 +6,13 @@ struct Skill: Decodable, Identifiable {
     let userFacingDescription: String?
     let icon: String?
 
-    var id: String { sId }
-    var displayDescription: String { userFacingDescription ?? "" }
+    var id: String {
+        sId
+    }
+
+    var displayDescription: String {
+        userFacingDescription ?? ""
+    }
 }
 
 struct SkillsResponse: Decodable {

--- a/x/adrsimon/mobile/Dust/Models/Space.swift
+++ b/x/adrsimon/mobile/Dust/Models/Space.swift
@@ -5,9 +5,10 @@ struct Space: Codable, Identifiable, Hashable {
     let name: String
     let kind: String
     let description: String?
-    let isMember: Bool?
 
-    var id: String { sId }
+    var id: String {
+        sId
+    }
 }
 
 struct SpaceSummaryEntry: Codable {

--- a/x/adrsimon/mobile/Dust/Services/CapabilityService.swift
+++ b/x/adrsimon/mobile/Dust/Services/CapabilityService.swift
@@ -68,7 +68,13 @@ enum CapabilityService {
             workspaceId: workspaceId, conversationId: conversationId
         )
         let body = ConversationToolActionRequest(action: action, mcpServerViewId: mcpServerViewId)
-        try await APIClient.authenticatedSend(endpoint, method: "POST", body: body, tokenProvider: tokenProvider, snakeCase: true)
+        try await APIClient.authenticatedSend(
+            endpoint,
+            method: "POST",
+            body: body,
+            tokenProvider: tokenProvider,
+            snakeCase: true
+        )
     }
 }
 

--- a/x/adrsimon/mobile/Dust/ViewModels/SnakeGameViewModel.swift
+++ b/x/adrsimon/mobile/Dust/ViewModels/SnakeGameViewModel.swift
@@ -4,7 +4,6 @@ import SwiftUI
 class SnakeGameViewModel: ObservableObject {
     let gridSize = 10
 
-    // swiftlint:disable:next identifier_name
     struct GridPosition: Equatable, Hashable {
         var col: Int
         var row: Int

--- a/x/adrsimon/mobile/Dust/Views/Components/CapabilitiesPickerSheet.swift
+++ b/x/adrsimon/mobile/Dust/Views/Components/CapabilitiesPickerSheet.swift
@@ -76,7 +76,6 @@ struct CapabilitiesPickerSheet: View {
         }
     }
 
-    @ViewBuilder
     private func capabilityIcon(_ capability: Capability) -> some View {
         capability.icon.image
             .resizable()

--- a/x/adrsimon/mobile/Dust/Views/Components/DustMarkdown.swift
+++ b/x/adrsimon/mobile/Dust/Views/Components/DustMarkdown.swift
@@ -40,7 +40,7 @@ func processCiteDirectives(_ markdown: String) -> (text: String, mapping: [CiteE
               let refsRange = Range(match.range(at: 1), in: markdown)
         else { continue }
 
-        result += markdown[lastEnd..<matchRange.lowerBound]
+        result += markdown[lastEnd ..< matchRange.lowerBound]
 
         let markers = markdown[refsRange].split(separator: ",").compactMap { part -> String? in
             let ref = part.trimmingCharacters(in: .whitespaces)
@@ -61,8 +61,8 @@ func processCiteDirectives(_ markdown: String) -> (text: String, mapping: [CiteE
 
 private let superscriptDigits: [Character] = ["⁰", "¹", "²", "³", "⁴", "⁵", "⁶", "⁷", "⁸", "⁹"]
 
-private func superscript(_ n: Int) -> String {
-    String(String(n).map { superscriptDigits[Int(String($0))!] })
+private func superscript(_ number: Int) -> String {
+    String(String(number).map { superscriptDigits[Int(String($0))!] })
 }
 
 struct CiteEntry {

--- a/x/adrsimon/mobile/Dust/Views/Components/KnowledgePickerSheet.swift
+++ b/x/adrsimon/mobile/Dust/Views/Components/KnowledgePickerSheet.swift
@@ -16,7 +16,7 @@ struct KnowledgePickerSheet: View {
             Group {
                 if searchVM.searchText.count < 2 {
                     promptView
-                } else if searchVM.isLoading && searchVM.results.isEmpty {
+                } else if searchVM.isLoading, searchVM.results.isEmpty {
                     loadingView
                 } else if searchVM.results.isEmpty {
                     noResultsView
@@ -174,7 +174,7 @@ struct KnowledgePickerSheet: View {
 private let logger = Logger(subsystem: AppConfig.bundleId, category: "KnowledgeSearch")
 
 @MainActor
-private final class KnowledgeSearchViewModel: ObservableObject {
+final private class KnowledgeSearchViewModel: ObservableObject {
     @Published var searchText = ""
     @Published var results: [SearchNode] = []
     @Published var isLoading = false

--- a/x/adrsimon/mobile/Dust/Views/Components/MessageBubbleView.swift
+++ b/x/adrsimon/mobile/Dust/Views/Components/MessageBubbleView.swift
@@ -312,7 +312,9 @@ struct CitationCard: View {
     struct Entry: Identifiable {
         let ref: String
         let citation: CitationReference
-        var id: String { ref }
+        var id: String {
+            ref
+        }
     }
 
     let entry: Entry
@@ -453,7 +455,9 @@ struct ActivityTimelineView: View {
         }
     }
 
-    private var isDone: Bool { !isStreaming }
+    private var isDone: Bool {
+        !isStreaming
+    }
 
     private var hasContent: Bool {
         !completedSteps.isEmpty

--- a/x/adrsimon/mobile/Dust/Views/ConversationDetailView.swift
+++ b/x/adrsimon/mobile/Dust/Views/ConversationDetailView.swift
@@ -119,8 +119,8 @@ struct ConversationDetailView: View {
 
     private func isSteeredAgentMessage(at index: Int) -> Bool {
         guard case let .agent(agentMsg) = viewModel.messages[index] else { return false }
-        for i in stride(from: index - 1, through: 0, by: -1) {
-            if case let .agent(prevAgent) = viewModel.messages[i] {
+        for priorIndex in stride(from: index - 1, through: 0, by: -1) {
+            if case let .agent(prevAgent) = viewModel.messages[priorIndex] {
                 return (prevAgent.status == .gracefullyStopped || prevAgent.status == .interrupted)
                     && prevAgent.configuration.sId == agentMsg.configuration.sId
             }

--- a/x/adrsimon/mobile/Dust/Views/MainContainerView.swift
+++ b/x/adrsimon/mobile/Dust/Views/MainContainerView.swift
@@ -89,6 +89,7 @@ struct MainContainerView: View {
                             currentUserEmail: user.email
                         )
                     }
+
                 case .newConversation:
                     if let workspaceId = viewModel.workspace?.sId {
                         NewConversationView(

--- a/x/adrsimon/mobile/Dust/Views/NewConversationView.swift
+++ b/x/adrsimon/mobile/Dust/Views/NewConversationView.swift
@@ -12,7 +12,7 @@ struct NewConversationView: View {
     let user: User
     let workspaceId: String
     let tokenProvider: TokenProvider
-    var spaceId: String? = nil
+    var spaceId: String?
     let onConversationCreated: (Conversation) -> Void
 
     @StateObject private var inputBarViewModel: InputBarViewModel

--- a/x/adrsimon/mobile/Makefile
+++ b/x/adrsimon/mobile/Makefile
@@ -112,12 +112,12 @@ lint-fix:
 ## format: format sources with SwiftFormat
 .PHONY: format
 format:
-	swiftformat .
+	swiftformat Dust SparkleTokens/Sources
 
 ## format-check: check formatting without writing changes
 .PHONY: format-check
 format-check:
-	swiftformat . --lint
+	swiftformat Dust SparkleTokens/Sources --lint
 
 ## clean: remove build artifacts
 .PHONY: clean


### PR DESCRIPTION
## Description

Tidies up the mobile app's lint/format setup.

- SwiftFormat was running against `.`, so it walked `build/` and the vendored SPM checkouts (~190 dependency files). Scoped it to the app sources; SwiftLint now also covers the SparkleTokens helpers.
- Deconflicted the two tools — SwiftFormat owns brace and modifier ordering, so `opening_brace`/`modifier_order` are off in SwiftLint to stop the lint-fix/format ping-pong.
- Dropped the arbitrary body/file-length rules (noise); kept `line_length`.
- Added `swiftformat` + `swiftlint` to the lefthook pre-commit hooks.
- Includes the resulting formatting pass over the app sources, and removal of two decoded-but-unused optional fields (`GeneratedFile.isInProjectContext`, `Space.isMember`).

## Tests

`make lint` and `make format-check` are clean. Verified the lefthook hooks run on staged Swift files and skip otherwise (they ran on this PR's own commit).

## Risk

Low — tooling/config and formatting only. No behavioral changes; the two removed fields were never read.

## Deploy Plan

None — dev tooling.