### PR TITLE
Handle case for unverifiable numbers

### DIFF
--- a/front/lib/api/workspace_verification/persona/lookup.ts
+++ b/front/lib/api/workspace_verification/persona/lookup.ts
@@ -33,13 +33,13 @@ const PersonaReportResponseSchema = z.object({
     id: z.string(),
     attributes: z.object({
       status: z.string(),
-      "phone-number": z.string().optional(),
-      "phone-type": z.string().optional(),
-      "phone-carrier": z.string().nullable().optional(),
-      "phone-risk-level": z.string().optional(),
-      "phone-risk-score": z.number().optional(),
-      "phone-risk-recommendation": z.string().optional(),
-      "phone-risk-sim-swap": z.string().nullable().optional(),
+      "phone-number": z.string().nullish(),
+      "phone-type": z.string().nullish(),
+      "phone-carrier": z.string().nullish(),
+      "phone-risk-level": z.string().nullish(),
+      "phone-risk-score": z.number().nullish(),
+      "phone-risk-recommendation": z.string().nullish(),
+      "phone-risk-sim-swap": z.string().nullish(),
     }),
   }),
 });
@@ -257,6 +257,19 @@ export async function lookupPhoneNumber(
 
     const report = fetchResult.value;
     const attrs = report.data.attributes;
+
+    // "ready" is a terminal status. If the risk fields are still null at that
+    // point, Persona has finished and has no data on this number (typically a
+    // fake/invalid number). Reject now rather than polling out and returning a
+    // misleading "try again".
+    if (attrs.status === "ready" && !isCompletedReport(attrs)) {
+      return new Err(
+        new PhoneLookupError(
+          "invalid_phone_number",
+          "This phone number could not be verified."
+        )
+      );
+    }
 
     if (!isCompletedReport(attrs)) {
       continue;


### PR DESCRIPTION
## Description

Hardens the Persona phone-lookup path against `null` risk fields, which surface mainly for clearly fake/unverifiable numbers.

Two changes in `front/lib/api/workspace_verification/persona/lookup.ts`:

- **Tolerate `null` in the report schema.** Persona returns the `phone-*` attributes with explicit `null` values (not omitted) when it has no data on a number. The schema used `.optional()`, which accepts a missing key but rejects `null`, so parsing threw a `ZodError` and `fetchReport` returned the generic `lookup_failed`. The fields are now `.nullish()` (`= .nullable().optional()`), consistent with the already-nullable `phone-carrier` / `phone-risk-sim-swap`. Downstream consumption already handles `null` (`?? 0`, `?? ""`, `?? null`).
- **Reject unverifiable numbers fast.** `status === "ready"` is terminal — if the risk fields are still `null` at that point, Persona has finished and has nothing on the number (typically a fake/invalid number). We now return `invalid_phone_number` ("This phone number could not be verified.") immediately instead of polling out all attempts (~10s) and returning a misleading "Please try again."

Before: a fake number threw a spurious `[Persona] Invalid report format` error on each poll, burned all 5 attempts, then told the user to retry.
After: it parses cleanly and is rejected in a single poll with an accurate message.

## Tests

Manual. Verified type-checking passes (`npx tsgo --noEmit`). The change is localized to schema nullability and one early-return branch in the existing polling loop; the surrounding `isCompletedReport` gating and downstream null-coalescing are unchanged.

## Risk

Low. Scoped to the Persona lookup module.
- Schema change only loosens validation (`null` now accepted), so it cannot reject previously-valid responses.
- The new branch only triggers on a terminal `ready` report missing risk data — a state that previously ended in `lookup_failed` anyway, so the only behavioral change is a faster, clearer rejection.
- Safe to roll back (single commit, no data/migration impact).

## Deploy Plan

Standard `front` deploy. No migrations, env vars, or coordination required.
