### PR TITLE
Listen to Metronome seat-balance credit alerts

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -65,9 +65,9 @@ import { extractFromString, serializeMention } from "@app/lib/mentions/format";
 import {
   getWorkspaceCreditPoolStatus,
   getWorkspaceProgrammaticCreditStatus,
-  isApiBlocked,
   isProgrammaticApiBlocked,
   isUserBlocked,
+  isWorkspacePoolDepleted,
 } from "@app/lib/metronome/user_block";
 import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
 import {
@@ -2416,7 +2416,7 @@ async function checkMessagesLimit(
 
   // Credit-state + programmatic rate-limit gate. Two systems coexist:
   // - Credit-priced (Metronome) plans: workspace pool + per-user cap, cached in Redis.
-  //   For API calls (no user), only the workspace pool applies via `isApiBlocked`.
+  //   For API calls (no user), only the workspace pool applies via `isWorkspacePoolDepleted`.
   //   Pool-balance concurrency limiting (`checkPoolCreditConcurrencyLimit`) prevents
   //   close-to-0 attacks where many requests overshoot the pool before debits settle.
   // - Legacy plans: programmatic credits checked via `checkProgrammaticUsageLimits`,
@@ -2427,7 +2427,7 @@ async function checkMessagesLimit(
   if (owner.metronomeCustomerId && plan && isCreditPricedPlan(plan)) {
     const blockedReason = user
       ? await isUserBlocked(owner.sId, user.sId)
-      : (await isApiBlocked(owner.sId))
+      : (await isWorkspacePoolDepleted(owner.sId))
         ? ("credits_exhausted" as const)
         : null;
     if (blockedReason === "user_cap_reached") {
@@ -2564,7 +2564,7 @@ async function checkPoolCreditConcurrencyLimit(
 
   const maxConcurrent = POOL_CREDIT_CONCURRENCY_LIMITS[status];
   if (maxConcurrent === undefined) {
-    // depleted / overage — handled by isUserBlocked / isApiBlocked upstream.
+    // depleted / overage — handled by isUserBlocked / isWorkspacePoolDepleted upstream.
     return { isLimitReached: false, limitType: null };
   }
 

--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -8,6 +8,7 @@ import type { AuditLogActor } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import {
+  getAwuAllocationForSeatType,
   getDefaultSeatTypeForContract,
   getProductSeatTypes,
 } from "@app/lib/metronome/seat_types";
@@ -32,6 +33,7 @@ import type {
   MembershipOriginType,
   MembershipRoleType,
   MembershipSeatType,
+  UserCreditState,
 } from "@app/types/memberships";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -61,27 +63,35 @@ import type { Transaction } from "sequelize";
  * `evaluateWorkspaceSeatAvailability` (signup) and `invitation.ts` (invite
  * creation).
  *
- * Returns `undefined` for workspaces not on Metronome billing. The caller
- * passes `undefined` to `createMembership`, which applies its built-in
- * default.
+ * Also resolves the new member's initial per-user credit state: `user_seat`
+ * when the resolved seat tier carries personal (seat) AWU credits, so a
+ * seat-based member starts spending their own credits immediately rather than
+ * waiting for the next billing-cycle reset; `on_pool` otherwise.
+ *
+ * Returns `seatType: undefined` for workspaces not on Metronome billing (the
+ * caller passes it to `createMembership`, which applies its built-in default)
+ * and `creditState: "on_pool"` — the pooled baseline.
  */
 async function resolveSeatTypeForNewMembership(
   user: UserResource,
   workspace: LightWorkspaceType,
   { useFreeSeat = true }: { useFreeSeat?: boolean } = {}
-): Promise<MembershipSeatType | undefined> {
+): Promise<{
+  seatType: MembershipSeatType | undefined;
+  creditState: UserCreditState;
+}> {
   if (!workspace.metronomeCustomerId) {
-    return undefined;
+    return { seatType: undefined, creditState: "on_pool" };
   }
   const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
     workspace.id
   );
   if (!subscription?.metronomeContractId) {
-    return undefined;
+    return { seatType: undefined, creditState: "on_pool" };
   }
   const contract = await getActiveContract(workspace.sId);
   if (!contract) {
-    return undefined;
+    return { seatType: undefined, creditState: "on_pool" };
   }
   const planLimits = subscription.toJSON().plan.limits.users;
   // `isReturningMember` is always queried — the one-shot rule (`free`
@@ -117,7 +127,17 @@ async function resolveSeatTypeForNewMembership(
       `Cannot resolve a seat type for user ${user.sId} in workspace ${workspace.sId}: contract has seat subscriptions but no tier is assignable${isReturningMember ? " (returning user; `free` is one-shot)" : ""}.`
     );
   }
-  return defaultSeatType;
+  // A seat tier with a personal AWU allocation starts the member on
+  // `user_seat`; tiers without one (and pooled workspaces) start on `on_pool`.
+  const seatAwuAllocation = getAwuAllocationForSeatType(
+    contract,
+    defaultSeatType,
+    productSeatTypes
+  );
+  return {
+    seatType: defaultSeatType,
+    creditState: seatAwuAllocation > 0 ? "user_seat" : "on_pool",
+  };
 }
 
 /**
@@ -158,9 +178,11 @@ export async function createAndTrackMembership({
       ? renderLightWorkspaceType({ workspace })
       : workspace;
 
-  const seatType = await resolveSeatTypeForNewMembership(user, w, {
-    useFreeSeat,
-  });
+  const { seatType, creditState } = await resolveSeatTypeForNewMembership(
+    user,
+    w,
+    { useFreeSeat }
+  );
 
   const m = await MembershipResource.createMembership({
     role,
@@ -168,6 +190,7 @@ export async function createAndTrackMembership({
     workspace: w,
     origin,
     seatType,
+    creditState,
   });
 
   void ServerSideTracking.trackCreateMembership({

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -4,17 +4,78 @@ import { listMetronomeBalances } from "@app/lib/metronome/client";
 import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
 import { invalidateWorkspacePoolCredits } from "@app/lib/metronome/credit_balance";
 import { transitionProgrammaticCreditState } from "@app/lib/metronome/programmatic_credit_state_machine";
-import { clearUserCapBlocked } from "@app/lib/metronome/user_block";
-import { transitionUserCreditState } from "@app/lib/metronome/user_credit_state_machine";
+import { buildSeatDataByUserId } from "@app/lib/metronome/seats";
+import { clearUserCreditStatus } from "@app/lib/metronome/user_block";
+import type { UserCreditEvent } from "@app/lib/metronome/user_credit_state_machine";
+import {
+  resetUserCreditState,
+  transitionUserCreditState,
+} from "@app/lib/metronome/user_credit_state_machine";
 import type { WorkspaceCreditEvent } from "@app/lib/metronome/workspace_credit_state_machine";
 import { transitionWorkspaceCreditState } from "@app/lib/metronome/workspace_credit_state_machine";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
+import type { UserCreditState } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
+
+/**
+ * Resolve the user's active membership and feed `event` to the user credit
+ * state machine. Shared by the per-user-cap and seat-balance dispatchers.
+ *
+ * A no-op (returns `Ok`) when the user or their active membership can't be
+ * resolved; `onMissing` lets callers run a side effect in that case (e.g.
+ * clearing the legacy Redis block on cap resolution).
+ */
+async function transitionUserCredit({
+  workspace,
+  userId,
+  event,
+  onMissing,
+}: {
+  workspace: WorkspaceResource;
+  userId: string;
+  event: UserCreditEvent;
+  onMissing?: () => Promise<void>;
+}): Promise<Result<void, Error>> {
+  const user = await UserResource.fetchById(userId);
+  if (!user) {
+    logger.warn(
+      { workspaceId: workspace.sId, userId, event: event.type },
+      "[CreditStateDispatcher] user not found, skipping transition"
+    );
+    await onMissing?.();
+    return new Ok(undefined);
+  }
+
+  const membership =
+    await MembershipResource.getActiveMembershipOfUserInWorkspace({
+      user,
+      workspace: renderLightWorkspaceType({ workspace }),
+    });
+  if (!membership) {
+    logger.warn(
+      { workspaceId: workspace.sId, userId, event: event.type },
+      "[CreditStateDispatcher] no active membership, skipping transition"
+    );
+    await onMissing?.();
+    return new Ok(undefined);
+  }
+
+  const result = await transitionUserCreditState(membership, event, {
+    workspaceId: workspace.sId,
+    userId,
+  });
+  if (result.isErr()) {
+    return result;
+  }
+  return new Ok(undefined);
+}
 
 export async function dispatchPerUserCapReached({
   workspace,
@@ -23,38 +84,11 @@ export async function dispatchPerUserCapReached({
   workspace: WorkspaceResource;
   userId: string;
 }): Promise<Result<void, Error>> {
-  const user = await UserResource.fetchById(userId);
-  if (!user) {
-    logger.warn(
-      { workspaceId: workspace.sId, userId },
-      "[CreditStateDispatcher] per_user_cap_reached: user not found, skipping"
-    );
-    return new Ok(undefined);
-  }
-
-  const lightWorkspace = renderLightWorkspaceType({ workspace });
-  const membership =
-    await MembershipResource.getActiveMembershipOfUserInWorkspace({
-      user,
-      workspace: lightWorkspace,
-    });
-  if (!membership) {
-    logger.warn(
-      { workspaceId: workspace.sId, userId },
-      "[CreditStateDispatcher] per_user_cap_reached: no active membership, skipping"
-    );
-    return new Ok(undefined);
-  }
-
-  const result = await transitionUserCreditState(
-    membership,
-    { type: "per_user_cap_reached" },
-    { workspaceId: workspace.sId, userId }
-  );
-  if (result.isErr()) {
-    return result;
-  }
-  return new Ok(undefined);
+  return transitionUserCredit({
+    workspace,
+    userId,
+    event: { type: "per_user_cap_reached" },
+  });
 }
 
 export async function dispatchPerUserCapResolved({
@@ -64,41 +98,116 @@ export async function dispatchPerUserCapResolved({
   workspace: WorkspaceResource;
   userId: string;
 }): Promise<Result<void, Error>> {
-  const user = await UserResource.fetchById(userId);
-  if (!user) {
-    logger.warn(
-      { workspaceId: workspace.sId, userId },
-      "[CreditStateDispatcher] per_user_cap_resolved: user not found, clearing legacy block"
-    );
-    await clearUserCapBlocked(workspace.sId, userId);
-    return new Ok(undefined);
-  }
+  return transitionUserCredit({
+    workspace,
+    userId,
+    event: { type: "per_user_cap_resolved" },
+    // Drop the cached credit status when the user / membership is gone, so a
+    // departed user doesn't stay blocked in the cache.
+    onMissing: () => clearUserCreditStatus(workspace.sId, userId),
+  });
+}
 
+/**
+ * A user's personal (seat) credit balance reached 0. Move them from the
+ * `user_seat*` states to `on_pool` so they spend from the workspace pool.
+ */
+export async function dispatchSeatBalanceExhausted({
+  workspace,
+  userId,
+}: {
+  workspace: WorkspaceResource;
+  userId: string;
+}): Promise<Result<void, Error>> {
+  return transitionUserCredit({
+    workspace,
+    userId,
+    event: { type: "seat_balance_exhausted" },
+  });
+}
+
+/**
+ * A user's personal (seat) credit balance is running low (still > 0). Surface
+ * the low-balance warning by moving `user_seat` → `user_seat_low_balance`.
+ */
+export async function dispatchSeatBalanceLow({
+  workspace,
+  userId,
+}: {
+  workspace: WorkspaceResource;
+  userId: string;
+}): Promise<Result<void, Error>> {
+  return transitionUserCredit({
+    workspace,
+    userId,
+    event: { type: "seat_balance_low" },
+  });
+}
+
+const CREDIT_STATE_RESET_CONCURRENCY = 8;
+
+/**
+ * Reset every active member's per-user credit state to their billing-cycle
+ * baseline: `user_seat` for users holding a seat with an allocation, `on_pool`
+ * for everyone else (including all members of pool-only workspaces). Called
+ * when AWU credits refill at a new billing period — seat and pool credits both
+ * reset, so users return to spending personal credits first (seat-based) or the
+ * pool (pooled), regardless of where they ended the prior period.
+ *
+ * Idempotent and derived from live Metronome seat data, so it also corrects any
+ * drift from missed or duplicated webhooks. On a seat-data fetch error the map
+ * is empty, degrading safely to "everyone on_pool".
+ */
+export async function resetWorkspaceUserCreditStates({
+  workspace,
+  metronomeCustomerId,
+}: {
+  workspace: WorkspaceResource;
+  metronomeCustomerId: string;
+}): Promise<void> {
   const lightWorkspace = renderLightWorkspaceType({ workspace });
-  const membership =
-    await MembershipResource.getActiveMembershipOfUserInWorkspace({
-      user,
-      workspace: lightWorkspace,
-    });
 
-  if (!membership) {
-    logger.warn(
-      { workspaceId: workspace.sId, userId },
-      "[CreditStateDispatcher] per_user_cap_resolved: no active membership, clearing legacy block"
-    );
-    await clearUserCapBlocked(workspace.sId, userId);
-    return new Ok(undefined);
-  }
-
-  const result = await transitionUserCreditState(
-    membership,
-    { type: "per_user_cap_resolved" },
-    { workspaceId: workspace.sId, userId }
+  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+    workspace.id
   );
-  if (result.isErr()) {
-    return result;
-  }
-  return new Ok(undefined);
+  const contractId = subscription?.metronomeContractId;
+
+  // Per-user seat allocations; empty for pool-only workspaces.
+  const seatDataByUserId = contractId
+    ? await buildSeatDataByUserId({ metronomeCustomerId, contractId })
+    : new Map<string, unknown>();
+
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    workspace: lightWorkspace,
+  });
+
+  await concurrentExecutor(
+    memberships,
+    async (membership) => {
+      const userId = membership.user?.sId;
+      if (!userId) {
+        return;
+      }
+      const target: UserCreditState = seatDataByUserId.has(userId)
+        ? "user_seat"
+        : "on_pool";
+      await resetUserCreditState(membership, target, {
+        workspaceId: workspace.sId,
+        userId,
+      });
+    },
+    { concurrency: CREDIT_STATE_RESET_CONCURRENCY }
+  );
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      metronomeCustomerId,
+      memberCount: memberships.length,
+      seatUserCount: seatDataByUserId.size,
+    },
+    "[CreditStateDispatcher] Reset user credit states for new billing cycle"
+  );
 }
 
 export async function dispatchPoolExhausted({

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -10,6 +10,9 @@ import {
   dispatchProgrammaticCapReset,
   dispatchProgrammaticLowBalance,
   dispatchProgrammaticWarning,
+  dispatchSeatBalanceExhausted,
+  dispatchSeatBalanceLow,
+  resetWorkspaceUserCreditStates,
   syncPoolCreditStateFromBalance,
 } from "@app/lib/api/metronome/credit_state_dispatcher";
 import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
@@ -130,6 +133,22 @@ function programmaticEventFromAlertName(
     };
   }
   return null;
+}
+
+// Resolve the user sId a seat-balance alert is scoped to. Metronome fans the
+// alert out per seat via `seat_filter` (seat_group_key "user_id"); the fired
+// event echoes the resolved seat group key/value. We read it from either the
+// seat-specific `seat_group_values` or the generic `group_values`, whichever
+// Metronome populates. Returns null when no `user_id` value is present.
+function seatBalanceEventUserId(
+  event: Extract<
+    MetronomeWebhookEvent,
+    { type: "alerts.low_remaining_seat_balance_reached" }
+  >
+): string | null {
+  const groups =
+    event.properties.seat_group_values ?? event.properties.group_values;
+  return groups?.find((g) => g.key === "user_id")?.value ?? null;
 }
 
 export class ProcessMetronomeWebhookError extends Error {
@@ -923,9 +942,71 @@ export async function processMetronomeWebhook({
       );
       break;
     }
-    // Handled by custom alerts above
-    case "alerts.low_remaining_seat_balance_reached":
+    case "alerts.low_remaining_seat_balance_reached": {
+      // Per-seat fan-out: the alert is scoped per user via `seat_filter`
+      // (seat_group_key "user_id"), so Metronome fires one event per user whose
+      // personal (seat) credit balance crosses a threshold. Two alerts feed
+      // this event type; route by `remaining_balance` (same pattern as the
+      // pool's combined balance alert):
+      //   - ≤ 0  → balance exhausted: `user_seat*` → `on_pool`.
+      //   - > 0  → balance low: `user_seat` → `user_seat_low_balance`.
+      const userId = seatBalanceEventUserId(event);
+      if (!userId) {
+        logger.warn(
+          {
+            eventId: event.id,
+            workspaceId: workspace.sId,
+            properties: event.properties,
+          },
+          "[Metronome Webhook] low_remaining_seat_balance_reached: could not resolve user_id from event, skipping"
+        );
+        break;
+      }
+      const remaining = event.properties.remaining_balance;
+      const exhausted = remaining == null || remaining <= 0;
+      const dispatchResult = exhausted
+        ? await dispatchSeatBalanceExhausted({ workspace, userId })
+        : await dispatchSeatBalanceLow({ workspace, userId });
+      if (dispatchResult.isErr()) {
+        logger.error(
+          {
+            eventId: event.id,
+            workspaceId: workspace.sId,
+            userId,
+            exhausted,
+            err: dispatchResult.error,
+          },
+          "[Metronome Webhook] low_remaining_seat_balance_reached: dispatch failed"
+        );
+        return new Err(
+          new ProcessMetronomeWebhookError(
+            "processing_failed",
+            `Error dispatching seat balance ${exhausted ? "exhausted" : "low"}: ${dispatchResult.error.message}`
+          )
+        );
+      }
+      logger.info(
+        {
+          eventId: event.id,
+          workspaceId: workspace.sId,
+          userId,
+          remaining,
+          exhausted,
+        },
+        exhausted
+          ? "[Metronome Webhook] low_remaining_seat_balance_reached: user moved to pool"
+          : "[Metronome Webhook] low_remaining_seat_balance_reached: user seat balance low"
+      );
+      break;
+    }
     case "alerts.low_remaining_seat_balance_resolved":
+      // Seat (personal) credits replenished — e.g. at a new billing period.
+      // Moving the user back to `user_seat` is a future enhancement; today we
+      // leave the state untouched (the workspace pool already covers them).
+      logger.info(
+        { eventId: event.id, workspaceId: workspace.sId },
+        "[Metronome Webhook] low_remaining_seat_balance_resolved: no transition"
+      );
       break;
 
     case "alerts.invoice_total_reached":
@@ -1103,6 +1184,19 @@ export async function processMetronomeWebhook({
       }
 
       if (event.type === "credit.segment.start") {
+        // A new AWU credit segment marks a new billing period: seat and pool
+        // credits have refilled, so reset every member to their starting state
+        // (`user_seat` / `on_pool`).
+        if (
+          creditResult.value?.access_schedule?.credit_type?.id ===
+          getCreditTypeAwuId()
+        ) {
+          await resetWorkspaceUserCreditStates({
+            workspace,
+            metronomeCustomerId,
+          });
+        }
+
         // Special case: only a contract-bound managed free credit drives the
         // free monthly/yearly credit grant. Customer-level credits with no
         // parent contract can't be the managed free credit, so stop here.

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -1,26 +1,19 @@
 // Redis fast-path cache for credit-state-driven access control.
 //
-// Three keys back the credit state machines:
-//   - `metronome:user_cap:<ws>:<user>`: caches the user's per-user cap state.
-//   - `metronome:user_awu_warning:<ws>:<user>`: caches the 80% AWU warning state.
-//   - `metronome:pool_depleted:<ws>`: caches the workspace pool state.
+// Per-user credit state is cached as the raw `UserCreditState` string under
+// `metronome:user_credit_status:<ws>:<user>`, mirroring the
+// `memberships.creditState` column. The workspace pool state is a separate
+// boolean flag under `metronome:pool_depleted:<ws>`.
 //
-// Each key stores an explicit boolean flag:
-//   - `"1"`: blocked / warned / depleted
-//   - `"0"`: not blocked / not warned / not depleted
+//   - `isUserBlocked` derives the block reason: "credits_exhausted" when the
+//     workspace pool is depleted (this shadows the per-user state), else
+//     "user_cap_reached" when the user's state is `capped`.
+//   - `isUserAwuWarned` derives the 80% warning from the `*_low_balance` states.
 //
-// `isUserBlocked` is the unified read: a user is blocked iff either cached flag
-// is `"1"`, and it returns the reason ("credits_exhausted" for a depleted
-// workspace pool, or "user_cap_reached" for a per-user cap) so callers can
-// surface a tailored message. When both flags are set, `credits_exhausted`
-// wins since the pool shadows the per-user state. The DB columns
-// (`memberships.creditState`, `workspaces.poolCreditState`) remain the source
-// of truth. Cache writes are gated on DB transaction commit via
-// `invalidateCacheAfterCommit`, and cache misses fall back to DB and
-// repopulate both flags.
-//
-// The warning flag (`metronome:user_awu_warning`) has no DB column backing it:
-// a cold-cache miss returns `false` (safe default until the next webhook re-sets the flag).
+// The DB columns (`memberships.creditState`, `workspaces.poolCreditState`)
+// remain the source of truth; cache misses fall back to them and repopulate.
+// State-machine writes are gated on DB transaction commit via
+// `invalidateCacheAfterCommit`.
 //
 import { runOnRedis } from "@app/lib/api/redis";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
@@ -36,6 +29,8 @@ import {
   isWorkspacePoolCreditState,
   isWorkspaceProgrammaticCreditState,
 } from "@app/types/credits";
+import type { UserCreditState } from "@app/types/memberships";
+import { isUserCreditState } from "@app/types/memberships";
 
 export type UserBlockedReason = "credits_exhausted" | "user_cap_reached";
 
@@ -43,16 +38,12 @@ const REDIS_ORIGIN = "metronome_limit" as const;
 const BLOCKED_FLAG = "1";
 const NOT_BLOCKED_FLAG = "0";
 
-function buildUserCapKey(workspaceId: string, userId: string): string {
-  return `metronome:user_cap:${workspaceId}:${userId}`;
-}
-
-function buildUserAwuWarningKey(workspaceId: string, userId: string): string {
-  return `metronome:user_awu_warning:${workspaceId}:${userId}`;
-}
-
 function buildWorkspacePoolDepletedKey(workspaceId: string): string {
   return `metronome:pool_depleted:${workspaceId}`;
+}
+
+function buildUserCreditStatusKey(workspaceId: string, userId: string): string {
+  return `metronome:user_credit_status:${workspaceId}:${userId}`;
 }
 
 function buildWorkspaceCreditPoolStatusKey(workspaceId: string): string {
@@ -79,35 +70,31 @@ async function setFlag(key: string, value: string): Promise<void> {
   });
 }
 
-async function getUserBlockedStateFromDb({
+// Source-of-truth read: the user's `creditState` column (default `on_pool`
+// when the workspace, user, or active membership can't be resolved).
+async function fetchUserCreditStateFromDb({
   workspaceId,
   userId,
 }: {
   workspaceId: string;
   userId: string;
-}): Promise<{ userCapBlocked: boolean; workspacePoolDepleted: boolean }> {
+}): Promise<UserCreditState> {
   const workspace = await WorkspaceResource.fetchById(workspaceId);
   if (!workspace) {
     logger.warn(
       { workspaceId, userId },
-      "[MetronomeUserBlock] Workspace not found during cache read-through fallback"
+      "[MetronomeUserBlock] Workspace not found during credit-status read-through fallback"
     );
-    return {
-      userCapBlocked: false,
-      workspacePoolDepleted: false,
-    };
+    return "on_pool";
   }
 
   const user = await UserResource.fetchById(userId);
   if (!user) {
     logger.warn(
       { workspaceId, userId },
-      "[MetronomeUserBlock] User not found during cache read-through fallback"
+      "[MetronomeUserBlock] User not found during credit-status read-through fallback"
     );
-    return {
-      userCapBlocked: false,
-      workspacePoolDepleted: workspace.poolCreditState === "depleted",
-    };
+    return "on_pool";
   }
 
   const membership =
@@ -116,72 +103,98 @@ async function getUserBlockedStateFromDb({
       workspace: renderLightWorkspaceType({ workspace }),
     });
 
-  return {
-    userCapBlocked: membership?.creditState === "capped",
-    workspacePoolDepleted: workspace.poolCreditState === "depleted",
-  };
+  return membership?.creditState ?? "on_pool";
 }
 
-async function syncCachedBlockedState({
-  workspaceId,
-  userId,
-  userCapBlocked,
-  workspacePoolDepleted,
-}: {
-  workspaceId: string;
-  userId: string;
-  userCapBlocked: boolean;
-  workspacePoolDepleted: boolean;
-}): Promise<void> {
-  await Promise.all([
-    setFlag(buildUserCapKey(workspaceId, userId), userCapBlocked ? "1" : "0"),
-    setFlag(
-      buildWorkspacePoolDepletedKey(workspaceId),
-      workspacePoolDepleted ? "1" : "0"
-    ),
-  ]);
+// Per-user credit state (mirrors `memberships.creditState`).
+
+function isLowBalanceState(state: UserCreditState): boolean {
+  return state === "user_seat_low_balance" || state === "on_pool_low_balance";
 }
 
-// Per-user cap (user credit state machine)
+export async function setUserCreditStatus(
+  workspaceId: string,
+  userId: string,
+  state: UserCreditState
+): Promise<void> {
+  await setFlag(buildUserCreditStatusKey(workspaceId, userId), state);
+}
 
-export async function setUserCapBlocked(
+// Drop the cached entry so the next read re-derives from the DB. Used when the
+// membership is gone (e.g. a departed user) and there's no state to cache.
+export async function clearUserCreditStatus(
   workspaceId: string,
   userId: string
 ): Promise<void> {
-  await setFlag(buildUserCapKey(workspaceId, userId), BLOCKED_FLAG);
+  await runOnRedis({ origin: REDIS_ORIGIN }, async (client) => {
+    await client.del(buildUserCreditStatusKey(workspaceId, userId));
+  });
 }
 
-export async function clearUserCapBlocked(
+export async function getUserCreditStatus(
   workspaceId: string,
   userId: string
-): Promise<void> {
-  await setFlag(buildUserCapKey(workspaceId, userId), NOT_BLOCKED_FLAG);
+): Promise<UserCreditState> {
+  const cached = await runOnRedis({ origin: REDIS_ORIGIN }, async (client) =>
+    client.get(buildUserCreditStatusKey(workspaceId, userId))
+  );
+
+  if (cached && isUserCreditState(cached)) {
+    return cached;
+  }
+
+  logger.info(
+    { workspaceId, userId, userCreditStatusCacheHit: false },
+    "[MetronomeUserBlock] Cache miss during user credit status check, falling back to DB"
+  );
+
+  const state = await fetchUserCreditStateFromDb({ workspaceId, userId });
+  await setUserCreditStatus(workspaceId, userId, state);
+  return state;
 }
 
-// Per-user AWU 80% warning (set by webhook; no DB fallback)
+// Per-user AWU 80% warning. Backed by the `*_low_balance` credit states; these
+// helpers flip a user between the base state and its low-balance variant. The
+// authoritative writer is the credit state machine — these are best-effort
+// webhook-driven nudges and degrade to the DB value on a cache miss.
 
 export async function setUserAwuWarned(
   workspaceId: string,
   userId: string
 ): Promise<void> {
-  await setFlag(buildUserAwuWarningKey(workspaceId, userId), BLOCKED_FLAG);
+  const current = await getUserCreditStatus(workspaceId, userId);
+  const next: UserCreditState =
+    current === "user_seat"
+      ? "user_seat_low_balance"
+      : current === "on_pool" || current === "normal"
+        ? "on_pool_low_balance"
+        : current;
+  if (next !== current) {
+    await setUserCreditStatus(workspaceId, userId, next);
+  }
 }
 
 export async function clearUserAwuWarned(
   workspaceId: string,
   userId: string
 ): Promise<void> {
-  await setFlag(buildUserAwuWarningKey(workspaceId, userId), NOT_BLOCKED_FLAG);
+  const current = await getUserCreditStatus(workspaceId, userId);
+  const next: UserCreditState =
+    current === "user_seat_low_balance"
+      ? "user_seat"
+      : current === "on_pool_low_balance"
+        ? "on_pool"
+        : current;
+  if (next !== current) {
+    await setUserCreditStatus(workspaceId, userId, next);
+  }
 }
 
 export async function isUserAwuWarned(
   workspaceId: string,
   userId: string
 ): Promise<boolean> {
-  const val = await runOnRedis({ origin: REDIS_ORIGIN }, async (client) =>
-    client.get(buildUserAwuWarningKey(workspaceId, userId))
-  );
-  return val === BLOCKED_FLAG;
+  return isLowBalanceState(await getUserCreditStatus(workspaceId, userId));
 }
 
 // Workspace pool depleted (workspace credit state machine)
@@ -220,41 +233,18 @@ export async function isUserBlocked(
   workspaceId: string,
   userId: string
 ): Promise<UserBlockedReason | null> {
-  const [userCap, poolDepleted] = await runOnRedis(
-    { origin: REDIS_ORIGIN },
-    async (client) =>
-      Promise.all([
-        client.get(buildUserCapKey(workspaceId, userId)),
-        client.get(buildWorkspacePoolDepletedKey(workspaceId)),
-      ])
-  );
+  // Each dimension reads its own cache with a DB read-through fallback:
+  // `getUserCreditStatus` for the per-user state, `isWorkspacePoolDepleted`
+  // for the pool.
+  const [creditStatus, workspacePoolDepleted] = await Promise.all([
+    getUserCreditStatus(workspaceId, userId),
+    isWorkspacePoolDepleted(workspaceId),
+  ]);
 
-  if (isBlockFlag(userCap) && isBlockFlag(poolDepleted)) {
-    return deriveBlockedReason({
-      userCapBlocked: userCap === BLOCKED_FLAG,
-      workspacePoolDepleted: poolDepleted === BLOCKED_FLAG,
-    });
-  }
-
-  logger.info(
-    {
-      workspaceId,
-      userId,
-      userCapCacheHit: isBlockFlag(userCap),
-      workspacePoolCacheHit: isBlockFlag(poolDepleted),
-    },
-    "[MetronomeUserBlock] Cache miss during user blocked check, falling back to DB"
-  );
-
-  const state = await getUserBlockedStateFromDb({ workspaceId, userId });
-  await syncCachedBlockedState({
-    workspaceId,
-    userId,
-    userCapBlocked: state.userCapBlocked,
-    workspacePoolDepleted: state.workspacePoolDepleted,
+  return deriveBlockedReason({
+    userCapBlocked: creditStatus === "capped",
+    workspacePoolDepleted,
   });
-
-  return deriveBlockedReason(state);
 }
 
 // Workspace credit pool status (fine-grained state for UI/notifications).
@@ -395,8 +385,12 @@ export async function isProgrammaticApiBlocked(
   return programmaticDepleted;
 }
 
-// Workspace-pool-only read for API calls (no per-user cap).
-export async function isApiBlocked(workspaceId: string): Promise<boolean> {
+// Whether the workspace pool is depleted (the pool-only dimension of access
+// control — no per-user cap). Used directly for API calls, and as one input to
+// `isUserBlocked`.
+export async function isWorkspacePoolDepleted(
+  workspaceId: string
+): Promise<boolean> {
   const poolDepleted = await runOnRedis(
     { origin: REDIS_ORIGIN },
     async (client) => client.get(buildWorkspacePoolDepletedKey(workspaceId))

--- a/front/lib/metronome/user_credit_state_machine.test.ts
+++ b/front/lib/metronome/user_credit_state_machine.test.ts
@@ -158,6 +158,56 @@ describe("UserCreditStateMachine — transitions", () => {
     expect(mockClearUserCapBlocked).toHaveBeenCalledWith("ws_test", "u_test");
     expect(mockSetUserCapBlocked).not.toHaveBeenCalled();
   });
+
+  it("user_seat + seat_balance_exhausted → on_pool (falls back to the pool)", async () => {
+    const membership = makeMembership("user_seat");
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "seat_balance_exhausted" },
+      baseCtx
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("on_pool");
+    }
+    expect(membership.updateCreditState).toHaveBeenCalledWith(
+      "on_pool",
+      undefined
+    );
+    expect(mockClearUserCapBlocked).toHaveBeenCalledWith("ws_test", "u_test");
+    expect(mockSetUserCapBlocked).not.toHaveBeenCalled();
+  });
+
+  it("user_seat_low_balance + seat_balance_exhausted → on_pool", async () => {
+    const membership = makeMembership("user_seat_low_balance");
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "seat_balance_exhausted" },
+      baseCtx
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("on_pool");
+    }
+    expect(membership.updateCreditState).toHaveBeenCalledWith(
+      "on_pool",
+      undefined
+    );
+  });
+
+  it("on_pool + seat_balance_exhausted is idempotent (already on the pool)", async () => {
+    const membership = makeMembership("on_pool");
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "seat_balance_exhausted" },
+      baseCtx
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("on_pool");
+    }
+    expect(membership.updateCreditState).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/front/lib/metronome/user_credit_state_machine.ts
+++ b/front/lib/metronome/user_credit_state_machine.ts
@@ -1,16 +1,10 @@
-import {
-  clearUserAwuWarned,
-  clearUserCapBlocked,
-  setUserAwuWarned,
-  setUserCapBlocked,
-} from "@app/lib/metronome/user_block";
+import { setUserCreditStatus } from "@app/lib/metronome/user_block";
 import type { MembershipResource } from "@app/lib/resources/membership_resource";
 import { invalidateCacheAfterCommit } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import type { UserCreditState } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { Transaction } from "sequelize";
 
 export type UserCreditContext = {
@@ -31,7 +25,24 @@ export type UserCreditEvent =
    * TODO(remy): fire this transition when a user alert is removed and a
    * new one is created.
    */
-  | { type: "admin_raised_user_cap" };
+  | { type: "admin_raised_user_cap" }
+  /**
+   * This user crossed the 80% spend-warning threshold while spending from the
+   * workspace pool. Surfaces the low-balance warning without hard-blocking.
+   */
+  | { type: "spend_threshold_reached" }
+  /**
+   * This user's personal (seat) credit balance reached 0. Triggered by the
+   * per-seat `alerts.low_remaining_seat_balance_reached` Metronome alert. The
+   * user falls back to spending from the workspace pool.
+   */
+  | { type: "seat_balance_exhausted" }
+  /**
+   * This user's personal (seat) credit balance is running low (still > 0).
+   * Triggered by the low-threshold per-seat `low_remaining_seat_balance_reached`
+   * alert. Surfaces the low-balance warning while still on personal credits.
+   */
+  | { type: "seat_balance_low" };
 
 type UserCreditTransition = {
   from: UserCreditState;
@@ -39,47 +50,17 @@ type UserCreditTransition = {
   to: UserCreditState;
 };
 
+// Mirror the new credit state into the Redis fast-path cache (gated on DB
+// commit). The cache holds the raw state; `isUserBlocked` / `isUserAwuWarned`
+// derive blocked/warned from it.
 function syncUserCapCacheForState(
   state: UserCreditState,
   ctx: UserCreditContext,
   transaction: Transaction | undefined
 ): void {
-  switch (state) {
-    // Spending normally (personal credits or workspace pool): not capped, no
-    // low-balance warning. "normal" is the legacy alias of "on_pool" kept
-    // during the migration window (see USER_CREDIT_STATES).
-    case "normal":
-    case "user_seat":
-    case "on_pool":
-      invalidateCacheAfterCommit(transaction, () =>
-        clearUserCapBlocked(ctx.workspaceId, ctx.userId)
-      );
-      invalidateCacheAfterCommit(transaction, () =>
-        clearUserAwuWarned(ctx.workspaceId, ctx.userId)
-      );
-      return;
-
-    // Still spending, but ≥80% of the personal balance / per-user cap used:
-    // not capped, but the low-balance warning is active.
-    case "user_seat_low_balance":
-    case "on_pool_low_balance":
-      invalidateCacheAfterCommit(transaction, () =>
-        clearUserCapBlocked(ctx.workspaceId, ctx.userId)
-      );
-      invalidateCacheAfterCommit(transaction, () =>
-        setUserAwuWarned(ctx.workspaceId, ctx.userId)
-      );
-      return;
-
-    case "capped":
-      invalidateCacheAfterCommit(transaction, () =>
-        setUserCapBlocked(ctx.workspaceId, ctx.userId)
-      );
-      return;
-
-    default:
-      assertNever(state);
-  }
+  invalidateCacheAfterCommit(transaction, () =>
+    setUserCreditStatus(ctx.workspaceId, ctx.userId, state)
+  );
 }
 
 const TRANSITIONS: UserCreditTransition[] = [
@@ -112,6 +93,72 @@ const TRANSITIONS: UserCreditTransition[] = [
     from: "on_pool",
     event: "per_user_cap_resolved",
     to: "on_pool",
+  },
+  {
+    from: "on_pool",
+    event: "spend_threshold_reached",
+    to: "on_pool_low_balance",
+  },
+  {
+    from: "on_pool_low_balance",
+    event: "spend_threshold_reached",
+    to: "on_pool_low_balance",
+  },
+  // Personal (seat) credits exhausted: fall back to the workspace pool. Users
+  // already on the pool (or capped) stay where they are — the seat-credit
+  // phase is behind them.
+  {
+    from: "user_seat",
+    event: "seat_balance_exhausted",
+    to: "on_pool",
+  },
+  {
+    from: "user_seat_low_balance",
+    event: "seat_balance_exhausted",
+    to: "on_pool",
+  },
+  {
+    from: "on_pool",
+    event: "seat_balance_exhausted",
+    to: "on_pool",
+  },
+  {
+    from: "on_pool_low_balance",
+    event: "seat_balance_exhausted",
+    to: "on_pool_low_balance",
+  },
+  {
+    from: "capped",
+    event: "seat_balance_exhausted",
+    to: "capped",
+  },
+  // Personal (seat) credits running low (still > 0): surface the warning while
+  // still on personal credits. Users already past the seat phase (on the pool
+  // or capped) stay where they are.
+  {
+    from: "user_seat",
+    event: "seat_balance_low",
+    to: "user_seat_low_balance",
+  },
+  {
+    from: "user_seat_low_balance",
+    event: "seat_balance_low",
+    to: "user_seat_low_balance",
+  },
+  {
+    from: "on_pool",
+    event: "seat_balance_low",
+    to: "on_pool",
+  },
+  {
+    from: "on_pool_low_balance",
+    event: "seat_balance_low",
+    to: "on_pool_low_balance",
+  },
+  {
+    from: "capped",
+    event: "seat_balance_low",
+    to: "capped",
   },
 ];
 
@@ -171,4 +218,23 @@ export async function transitionUserCreditState(
   );
 
   return new Ok(match.to);
+}
+
+/**
+ * Force-reset a user's credit state to `state`, bypassing the transition table.
+ * Used at billing-cycle boundaries: when seat and pool credits refill, every
+ * user returns to their starting state (`user_seat` for seat-based users,
+ * `on_pool` otherwise) regardless of where they ended the prior period. Syncs
+ * the Redis cap/warning flags to match the target state.
+ */
+export async function resetUserCreditState(
+  membership: MembershipResource,
+  state: UserCreditState,
+  ctx: UserCreditContext,
+  { transaction }: { transaction?: Transaction } = {}
+): Promise<void> {
+  if (membership.creditState !== state) {
+    await membership.updateCreditState(state, transaction);
+  }
+  syncUserCapCacheForState(state, ctx, transaction);
 }

--- a/front/lib/metronome/webhook_events.ts
+++ b/front/lib/metronome/webhook_events.ts
@@ -176,9 +176,22 @@ const InvoiceTotalResolvedSchema = z.object({
 });
 
 // alerts.low_remaining_seat_balance_*
-// Undocumented in the public webhook docs but emitted today.
+// Undocumented in the public webhook docs but emitted today. The alert is
+// scoped per seat via `seat_filter` (seat_group_key "user_id"), so the fired
+// event must carry the seat group key/value identifying whose balance crossed.
+// Metronome's exact field name for this on the webhook payload isn't
+// documented, so we accept both the seat-specific shape (`seat_group_values`)
+// and the generic `group_values` shape used by spend alerts, and read
+// whichever is populated. The handler logs the raw payload when it can't
+// resolve a user so the field can be confirmed from production.
+const seatGroupValuesSchema = z
+  .array(z.object({ key: z.string(), value: z.string().nullish() }))
+  .nullish();
 const lowRemainingSeatBalanceProps = baseAlertPropertiesSchema.extend({
   remaining_balance: z.number().nullish(),
+  credit_type_id: z.string().nullish(),
+  seat_group_values: seatGroupValuesSchema,
+  group_values: seatGroupValuesSchema,
 });
 const LowRemainingSeatBalanceReachedSchema = z.object({
   id: z.string(),

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -992,6 +992,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     role,
     origin = "invited",
     seatType = "workspace",
+    creditState,
     startAt = new Date(),
     transaction,
   }: {
@@ -1000,6 +1001,8 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     role: MembershipRoleType;
     origin?: MembershipOriginType;
     seatType?: MembershipSeatType;
+    // Initial per-user credit state. When omitted, the model default applies.
+    creditState?: UserCreditState;
     startAt?: Date;
     transaction?: Transaction;
   }): Promise<MembershipResource> {
@@ -1030,6 +1033,8 @@ export class MembershipResource extends BaseResource<MembershipModel> {
         role,
         origin,
         seatType,
+        // Omit when undefined so the model default ("on_pool") applies.
+        ...(creditState ? { creditState } : {}),
         firstUsedAt: origin === "provisioned" ? null : new Date(),
       },
       { transaction }

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -6,8 +6,8 @@ import { getWebhookRequestsBucket } from "@app/lib/file_storage";
 import { isGCSPreconditionFailedError } from "@app/lib/file_storage/types";
 import { matchPayload, parseMatcherExpression } from "@app/lib/matcher";
 import {
-  isApiBlocked,
   isProgrammaticApiBlocked,
+  isWorkspacePoolDepleted,
 } from "@app/lib/metronome/user_block";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
@@ -269,7 +269,10 @@ async function checkWorkspaceRateLimit({
   // depleted, no downstream message can be posted, so reject early instead of
   // spinning up the trigger workflow only to fail in `checkMessagesLimit`.
   if (plan && isCreditPricedPlan(plan)) {
-    if (owner.metronomeCustomerId && (await isApiBlocked(owner.sId))) {
+    if (
+      owner.metronomeCustomerId &&
+      (await isWorkspacePoolDepleted(owner.sId))
+    ) {
       errorMessage =
         "Your workspace has run out of credits. Please purchase more credits to continue.";
     }

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -26,8 +26,8 @@ import {
 } from "@app/lib/api/v1/backward_compatibility";
 import type { Authenticator } from "@app/lib/auth";
 import {
-  isApiBlocked,
   isProgrammaticApiBlocked,
+  isWorkspacePoolDepleted,
 } from "@app/lib/metronome/user_block";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -191,7 +191,7 @@ async function handler(
           if (plan && isCreditPricedPlan(plan)) {
             if (
               workspace.metronomeCustomerId &&
-              (await isApiBlocked(workspace.sId))
+              (await isWorkspacePoolDepleted(workspace.sId))
             ) {
               return apiError(req, res, {
                 status_code: 429,

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -14,8 +14,8 @@ import { getRemainingDailyCapMicroUsd } from "@app/lib/api/programmatic_usage/da
 import { checkProgrammaticUsageLimits } from "@app/lib/api/programmatic_usage/tracking";
 import { type Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import {
-  isApiBlocked,
   isProgrammaticApiBlocked,
+  isWorkspacePoolDepleted,
 } from "@app/lib/metronome/user_block";
 import {
   AgentMessageModel,
@@ -596,7 +596,7 @@ export async function getReinforcementSettingsActivity({
   let programmaticUsageLimitReached: boolean;
   if (plan && isCreditPricedPlan(plan) && workspace.metronomeCustomerId) {
     programmaticUsageLimitReached =
-      (await isApiBlocked(workspace.sId)) ||
+      (await isWorkspacePoolDepleted(workspace.sId)) ||
       (await isProgrammaticApiBlocked(workspace.sId));
   } else {
     // Legacy check for not metronome workspaces


### PR DESCRIPTION
Metronome integration that drives the per-user credit state machine (stacked on the credit-state-core PR):

- Creation: per-seat low_remaining_seat_balance_reached alerts (exhausted at 0, fanned out; low-balance per user at 20% of allocation), provisioned at Metronome customer creation + on the seat-sync path, plus a backfill script.
- Listening: webhook handling for low_remaining_seat_balance_reached/resolved (routes exhausted vs low by remaining_balance) and the billing-cycle reset trigger on credit.segment.start; seat-balance webhook event schema.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
