### PR TITLE
Create seat balance alerts in Metronome

### DIFF
--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -137,10 +137,18 @@ async function fetchSeatDataForMembersTableUncached({
   metronomeCustomerId: string;
   metronomeContractId: string;
 }): Promise<Map<string, SeatData>> {
-  return buildSeatDataByUserId({
+  const seatDataResult = await buildSeatDataByUserId({
     metronomeCustomerId,
     contractId: metronomeContractId,
   });
+  if (seatDataResult.isErr()) {
+    logger.warn(
+      { err: seatDataResult.error, metronomeCustomerId },
+      "[MembersUsage] Failed to build seat data, degrading to empty map"
+    );
+    return new Map();
+  }
+  return seatDataResult.value;
 }
 
 async function fetchSeatDataForMembersTable({

--- a/front/lib/metronome/alerts/seat_balance.ts
+++ b/front/lib/metronome/alerts/seat_balance.ts
@@ -134,25 +134,25 @@ export async function syncMetronomeSeatLowBalanceAlerts({
   }
   const staleUserIds = new Set(existingResult.value);
 
-  const upserts: Array<{ userId: string; threshold: number }> = [];
+  const upserts: Array<{ userId: string; thresholdAwu: number }> = [];
   for (const [userId, { awuAllocation }] of seatDataByUserId) {
     staleUserIds.delete(userId);
-    const threshold = Math.ceil(
+    const thresholdAwu = Math.ceil(
       awuAllocation * SEAT_LOW_BALANCE_REMAINING_RATIO
     );
-    if (threshold <= 0) {
+    if (thresholdAwu <= 0) {
       continue;
     }
-    upserts.push({ userId, threshold });
+    upserts.push({ userId, thresholdAwu });
   }
 
   const results = await concurrentExecutor(
     upserts,
-    ({ userId, threshold }) =>
+    ({ userId, thresholdAwu }) =>
       upsertMetronomeAlert({
         alert_type: "low_remaining_seat_balance_reached",
-        name: `Seat low balance ${workspaceId}-${userId} (${threshold} AWU)`,
-        threshold,
+        name: `Seat low balance ${workspaceId}-${userId} (${thresholdAwu} AWU)`,
+        threshold: thresholdAwu,
         credit_type_id: getCreditTypeAwuId(),
         customer_id: metronomeCustomerId,
         seat_filter: {

--- a/front/lib/metronome/alerts/seat_balance.ts
+++ b/front/lib/metronome/alerts/seat_balance.ts
@@ -25,7 +25,7 @@ const SEAT_LOW_BALANCE_REMAINING_RATIO = 0.2;
 const SEAT_ALERT_CONCURRENCY = 5;
 
 function seatExhaustedAlertUniquenessKey(workspaceId: string): string {
-  return `seat-balance-${workspaceId}`;
+  return `seat-exhausted-balance-${workspaceId}`;
 }
 
 function seatLowBalanceAlertUniquenessKeyPrefix(workspaceId: string): string {
@@ -114,16 +114,14 @@ export async function syncMetronomeSeatLowBalanceAlerts({
   contractId: string;
   workspaceId: string;
 }): Promise<Result<void, Error>> {
-  let seatDataByUserId: Map<string, { awuAllocation: number }>;
-  try {
-    seatDataByUserId = await buildSeatDataByUserId({
-      metronomeCustomerId,
-      contractId,
-      throwOnError: true,
-    });
-  } catch (err) {
-    return new Err(normalizeError(err));
+  const seatDataResult = await buildSeatDataByUserId({
+    metronomeCustomerId,
+    contractId,
+  });
+  if (seatDataResult.isErr()) {
+    return new Err(seatDataResult.error);
   }
+  const seatDataByUserId = seatDataResult.value;
 
   const existingResult = await listSeatLowBalanceAlertUserIds({
     metronomeCustomerId,

--- a/front/lib/metronome/alerts/seat_balance.ts
+++ b/front/lib/metronome/alerts/seat_balance.ts
@@ -1,0 +1,264 @@
+import {
+  clearMetronomeAlert,
+  upsertMetronomeAlert,
+} from "@app/lib/metronome/alerts";
+import { listMetronomeAlerts } from "@app/lib/metronome/client";
+import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import { buildSeatDataByUserId } from "@app/lib/metronome/seats";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+// Seat-balance alerts fan out per seat via `seat_filter`. Seat ids in Metronome
+// are user sIds, so the seat group key is "user_id".
+const SEAT_BALANCE_SEAT_GROUP_KEY = "user_id";
+
+// Exhaustion fires at 0 remaining (allocation-independent → a single alert
+// fanned out across all seats). The low-balance warning fires when the
+// remaining balance drops to this fraction of the seat's allocation, i.e. when
+// the user has spent 80% of their personal credits. Because each seat tier has
+// a different allocation, the low threshold is an absolute AWU value computed
+// per user, so it must be created per user (one alert each, scoped via
+// `seat_group_value`) rather than as a single fanned-out alert.
+const SEAT_EXHAUSTED_THRESHOLD_AWU = 0;
+const SEAT_LOW_BALANCE_REMAINING_RATIO = 0.2;
+
+const SEAT_ALERT_CONCURRENCY = 5;
+
+function seatExhaustedAlertUniquenessKey(workspaceId: string): string {
+  return `seat-balance-${workspaceId}`;
+}
+
+function seatLowBalanceAlertUniquenessKeyPrefix(workspaceId: string): string {
+  return `seat-low-balance-${workspaceId}-`;
+}
+
+function seatLowBalanceAlertUniquenessKey(
+  workspaceId: string,
+  userId: string
+): string {
+  return `${seatLowBalanceAlertUniquenessKeyPrefix(workspaceId)}${userId}`;
+}
+
+/**
+ * Idempotently ensure the workspace's seat-exhaustion alert exists: a single
+ * `low_remaining_seat_balance_reached` alert at threshold 0, fanned out per
+ * user via `seat_filter`. Fires when any user's personal (seat) AWU balance
+ * reaches 0 → the credit state machine moves them to `on_pool`.
+ *
+ * Allocation-independent, so it can be provisioned eagerly (e.g. at Metronome
+ * customer creation) before any seats exist.
+ */
+export async function upsertMetronomeSeatExhaustedAlert({
+  metronomeCustomerId,
+  workspaceId,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+}): Promise<Result<{ alertId: string }, Error>> {
+  const upsertResult = await upsertMetronomeAlert({
+    alert_type: "low_remaining_seat_balance_reached",
+    name: `Seat balance ${workspaceId} (${SEAT_EXHAUSTED_THRESHOLD_AWU} AWU)`,
+    threshold: SEAT_EXHAUSTED_THRESHOLD_AWU,
+    credit_type_id: getCreditTypeAwuId(),
+    customer_id: metronomeCustomerId,
+    seat_filter: { seat_group_key: SEAT_BALANCE_SEAT_GROUP_KEY },
+    uniqueness_key: seatExhaustedAlertUniquenessKey(workspaceId),
+  });
+  if (upsertResult.isErr()) {
+    return new Err(upsertResult.error);
+  }
+
+  logger.info(
+    {
+      workspaceId,
+      metronomeCustomerId,
+      alertId: upsertResult.value.alertId,
+    },
+    "[Metronome SeatBalance] Synced seat-exhaustion alert"
+  );
+  return new Ok({ alertId: upsertResult.value.alertId });
+}
+
+// userId → uniqueness_key for every existing per-user low-balance alert on the
+// customer for this workspace (matched by uniqueness_key prefix).
+async function listSeatLowBalanceAlertUserIds({
+  metronomeCustomerId,
+  workspaceId,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+}): Promise<Result<Set<string>, Error>> {
+  const prefix = seatLowBalanceAlertUniquenessKeyPrefix(workspaceId);
+  const userIds = new Set<string>();
+  try {
+    for await (const entry of listMetronomeAlerts({
+      customer_id: metronomeCustomerId,
+      alert_statuses: ["ENABLED"],
+    })) {
+      const key = entry.alert.uniqueness_key;
+      if (key && key.startsWith(prefix)) {
+        const userId = key.slice(prefix.length);
+        if (userId) {
+          userIds.add(userId);
+        }
+      }
+    }
+    return new Ok(userIds);
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}
+
+/**
+ * Sync the per-user seat low-balance alerts for a workspace. For each user with
+ * a seat allocation, upserts a `low_remaining_seat_balance_reached` alert at
+ * `ceil(20% × allocation)` (fires at 80% spent → `user_seat_low_balance`),
+ * scoped to that user via `seat_filter.seat_group_value`. Alerts for users who
+ * no longer hold a seat are archived.
+ *
+ * Depends on per-user allocations, so it must run on the seat-sync path (where
+ * seats/allocations are known and change), not at customer creation.
+ */
+export async function syncMetronomeSeatLowBalanceAlerts({
+  metronomeCustomerId,
+  contractId,
+  workspaceId,
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+  workspaceId: string;
+}): Promise<Result<void, Error>> {
+  let seatDataByUserId: Map<string, { awuAllocation: number }>;
+  try {
+    seatDataByUserId = await buildSeatDataByUserId({
+      metronomeCustomerId,
+      contractId,
+      throwOnError: true,
+    });
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+
+  const existingResult = await listSeatLowBalanceAlertUserIds({
+    metronomeCustomerId,
+    workspaceId,
+  });
+  if (existingResult.isErr()) {
+    return new Err(existingResult.error);
+  }
+  const staleUserIds = new Set(existingResult.value);
+
+  const upserts: Array<{ userId: string; threshold: number }> = [];
+  for (const [userId, { awuAllocation }] of seatDataByUserId) {
+    staleUserIds.delete(userId);
+    const threshold = Math.ceil(
+      awuAllocation * SEAT_LOW_BALANCE_REMAINING_RATIO
+    );
+    if (threshold <= 0) {
+      continue;
+    }
+    upserts.push({ userId, threshold });
+  }
+
+  const results = await concurrentExecutor(
+    upserts,
+    ({ userId, threshold }) =>
+      upsertMetronomeAlert({
+        alert_type: "low_remaining_seat_balance_reached",
+        name: `Seat low balance ${workspaceId}-${userId} (${threshold} AWU)`,
+        threshold,
+        credit_type_id: getCreditTypeAwuId(),
+        customer_id: metronomeCustomerId,
+        seat_filter: {
+          seat_group_key: SEAT_BALANCE_SEAT_GROUP_KEY,
+          seat_group_value: userId,
+        },
+        uniqueness_key: seatLowBalanceAlertUniquenessKey(workspaceId, userId),
+      }),
+    { concurrency: SEAT_ALERT_CONCURRENCY }
+  );
+  for (const result of results) {
+    if (result.isErr()) {
+      return new Err(result.error);
+    }
+  }
+
+  // Archive alerts for users who no longer hold a seat.
+  const clears = await concurrentExecutor(
+    [...staleUserIds],
+    (userId) =>
+      clearMetronomeAlert({
+        metronomeCustomerId,
+        uniquenessKey: seatLowBalanceAlertUniquenessKey(workspaceId, userId),
+      }),
+    { concurrency: SEAT_ALERT_CONCURRENCY }
+  );
+  for (const result of clears) {
+    if (result.isErr()) {
+      return new Err(result.error);
+    }
+  }
+
+  logger.info(
+    {
+      workspaceId,
+      metronomeCustomerId,
+      upserted: upserts.length,
+      cleared: staleUserIds.size,
+    },
+    "[Metronome SeatBalance] Synced per-user seat low-balance alerts"
+  );
+  return new Ok(undefined);
+}
+
+/**
+ * Archive the workspace's seat-balance alerts (the exhaustion alert and every
+ * per-user low-balance alert). Idempotent — no-op for alerts that don't exist.
+ */
+export async function clearMetronomeSeatBalanceAlerts({
+  metronomeCustomerId,
+  workspaceId,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+}): Promise<Result<void, Error>> {
+  const exhaustedResult = await clearMetronomeAlert({
+    metronomeCustomerId,
+    uniquenessKey: seatExhaustedAlertUniquenessKey(workspaceId),
+  });
+  if (exhaustedResult.isErr()) {
+    return new Err(exhaustedResult.error);
+  }
+
+  const existingResult = await listSeatLowBalanceAlertUserIds({
+    metronomeCustomerId,
+    workspaceId,
+  });
+  if (existingResult.isErr()) {
+    return new Err(existingResult.error);
+  }
+
+  const clears = await concurrentExecutor(
+    [...existingResult.value],
+    (userId) =>
+      clearMetronomeAlert({
+        metronomeCustomerId,
+        uniquenessKey: seatLowBalanceAlertUniquenessKey(workspaceId, userId),
+      }),
+    { concurrency: SEAT_ALERT_CONCURRENCY }
+  );
+  for (const result of clears) {
+    if (result.isErr()) {
+      return new Err(result.error);
+    }
+  }
+
+  logger.info(
+    { workspaceId, metronomeCustomerId },
+    "[Metronome SeatBalance] Cleared seat-balance alerts"
+  );
+  return new Ok(undefined);
+}

--- a/front/lib/metronome/alerts/seat_balance.ts
+++ b/front/lib/metronome/alerts/seat_balance.ts
@@ -134,7 +134,11 @@ export async function syncMetronomeSeatLowBalanceAlerts({
   }
   const staleUserIds = new Set(existingResult.value);
 
-  const upserts: Array<{ userId: string; thresholdAwu: number }> = [];
+  const upserts: Array<{
+    userId: string;
+    thresholdAwu: number;
+    awuAllocation: number;
+  }> = [];
   for (const [userId, { awuAllocation }] of seatDataByUserId) {
     staleUserIds.delete(userId);
     const thresholdAwu = Math.ceil(
@@ -143,15 +147,15 @@ export async function syncMetronomeSeatLowBalanceAlerts({
     if (thresholdAwu <= 0) {
       continue;
     }
-    upserts.push({ userId, thresholdAwu });
+    upserts.push({ userId, thresholdAwu, awuAllocation });
   }
 
   const results = await concurrentExecutor(
     upserts,
-    ({ userId, thresholdAwu }) =>
+    ({ userId, thresholdAwu, awuAllocation }) =>
       upsertMetronomeAlert({
         alert_type: "low_remaining_seat_balance_reached",
-        name: `Seat low balance ${workspaceId}-${userId} (${thresholdAwu} AWU)`,
+        name: `Seat low balance ${workspaceId}-${userId} (${thresholdAwu} AWU  / ${Math.round(SEAT_LOW_BALANCE_REMAINING_RATIO * 100)}% of ${awuAllocation} )`,
         threshold: thresholdAwu,
         credit_type_id: getCreditTypeAwuId(),
         customer_id: metronomeCustomerId,

--- a/front/lib/metronome/alerts/seat_balance.ts
+++ b/front/lib/metronome/alerts/seat_balance.ts
@@ -18,10 +18,7 @@ const SEAT_BALANCE_SEAT_GROUP_KEY = "user_id";
 // Exhaustion fires at 0 remaining (allocation-independent → a single alert
 // fanned out across all seats). The low-balance warning fires when the
 // remaining balance drops to this fraction of the seat's allocation, i.e. when
-// the user has spent 80% of their personal credits. Because each seat tier has
-// a different allocation, the low threshold is an absolute AWU value computed
-// per user, so it must be created per user (one alert each, scoped via
-// `seat_group_value`) rather than as a single fanned-out alert.
+// the user has spent 80% of their personal credits.
 const SEAT_EXHAUSTED_THRESHOLD_AWU = 0;
 const SEAT_LOW_BALANCE_REMAINING_RATIO = 0.2;
 
@@ -42,15 +39,6 @@ function seatLowBalanceAlertUniquenessKey(
   return `${seatLowBalanceAlertUniquenessKeyPrefix(workspaceId)}${userId}`;
 }
 
-/**
- * Idempotently ensure the workspace's seat-exhaustion alert exists: a single
- * `low_remaining_seat_balance_reached` alert at threshold 0, fanned out per
- * user via `seat_filter`. Fires when any user's personal (seat) AWU balance
- * reaches 0 → the credit state machine moves them to `on_pool`.
- *
- * Allocation-independent, so it can be provisioned eagerly (e.g. at Metronome
- * customer creation) before any seats exist.
- */
 export async function upsertMetronomeSeatExhaustedAlert({
   metronomeCustomerId,
   workspaceId,
@@ -82,8 +70,6 @@ export async function upsertMetronomeSeatExhaustedAlert({
   return new Ok({ alertId: upsertResult.value.alertId });
 }
 
-// userId → uniqueness_key for every existing per-user low-balance alert on the
-// customer for this workspace (matched by uniqueness_key prefix).
 async function listSeatLowBalanceAlertUserIds({
   metronomeCustomerId,
   workspaceId,
@@ -118,9 +104,6 @@ async function listSeatLowBalanceAlertUserIds({
  * `ceil(20% × allocation)` (fires at 80% spent → `user_seat_low_balance`),
  * scoped to that user via `seat_filter.seat_group_value`. Alerts for users who
  * no longer hold a seat are archived.
- *
- * Depends on per-user allocations, so it must run on the seat-sync path (where
- * seats/allocations are known and change), not at customer creation.
  */
 export async function syncMetronomeSeatLowBalanceAlerts({
   metronomeCustomerId,
@@ -210,55 +193,6 @@ export async function syncMetronomeSeatLowBalanceAlerts({
       cleared: staleUserIds.size,
     },
     "[Metronome SeatBalance] Synced per-user seat low-balance alerts"
-  );
-  return new Ok(undefined);
-}
-
-/**
- * Archive the workspace's seat-balance alerts (the exhaustion alert and every
- * per-user low-balance alert). Idempotent — no-op for alerts that don't exist.
- */
-export async function clearMetronomeSeatBalanceAlerts({
-  metronomeCustomerId,
-  workspaceId,
-}: {
-  metronomeCustomerId: string;
-  workspaceId: string;
-}): Promise<Result<void, Error>> {
-  const exhaustedResult = await clearMetronomeAlert({
-    metronomeCustomerId,
-    uniquenessKey: seatExhaustedAlertUniquenessKey(workspaceId),
-  });
-  if (exhaustedResult.isErr()) {
-    return new Err(exhaustedResult.error);
-  }
-
-  const existingResult = await listSeatLowBalanceAlertUserIds({
-    metronomeCustomerId,
-    workspaceId,
-  });
-  if (existingResult.isErr()) {
-    return new Err(existingResult.error);
-  }
-
-  const clears = await concurrentExecutor(
-    [...existingResult.value],
-    (userId) =>
-      clearMetronomeAlert({
-        metronomeCustomerId,
-        uniquenessKey: seatLowBalanceAlertUniquenessKey(workspaceId, userId),
-      }),
-    { concurrency: SEAT_ALERT_CONCURRENCY }
-  );
-  for (const result of clears) {
-    if (result.isErr()) {
-      return new Err(result.error);
-    }
-  }
-
-  logger.info(
-    { workspaceId, metronomeCustomerId },
-    "[Metronome SeatBalance] Cleared seat-balance alerts"
   );
   return new Ok(undefined);
 }

--- a/front/lib/metronome/contracts.test.ts
+++ b/front/lib/metronome/contracts.test.ts
@@ -26,6 +26,7 @@ const {
   mockSyncMauCount,
   mockSyncSeatCount,
   mockRemapMembershipSeatTypesForContract,
+  mockBuildSeatDataByUserId,
 } = vi.hoisted(() => {
   const mockPrices = { retrieve: vi.fn() };
 
@@ -45,6 +46,7 @@ const {
     mockSyncMauCount: vi.fn(),
     mockSyncSeatCount: vi.fn(),
     mockRemapMembershipSeatTypesForContract: vi.fn(),
+    mockBuildSeatDataByUserId: vi.fn(),
   };
 });
 
@@ -79,6 +81,7 @@ vi.mock("@app/lib/metronome/seats", () => ({
   hasContractSeatSubscription: mockHasContractSeatSubscription,
   syncSeatCount: mockSyncSeatCount,
   remapMembershipSeatTypesForContract: mockRemapMembershipSeatTypesForContract,
+  buildSeatDataByUserId: mockBuildSeatDataByUserId,
 }));
 
 vi.mock("@app/lib/api/metronome/credit_state_dispatcher", () => ({
@@ -174,6 +177,9 @@ beforeEach(() => {
 
   mockRemapMembershipSeatTypesForContract.mockReset();
   mockRemapMembershipSeatTypesForContract.mockResolvedValue(new Ok(undefined));
+
+  mockBuildSeatDataByUserId.mockReset();
+  mockBuildSeatDataByUserId.mockResolvedValue(new Ok(new Map()));
 });
 
 function makeSubscription(

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -1,5 +1,9 @@
 import type { BillingCycle } from "@app/lib/client/subscription";
 import {
+  syncMetronomeSeatLowBalanceAlerts,
+  upsertMetronomeSeatExhaustedAlert,
+} from "@app/lib/metronome/alerts/seat_balance";
+import {
   ceilToHourISO,
   createMetronomeContract,
   createMetronomeCustomer,
@@ -103,6 +107,21 @@ export async function ensureMetronomeCustomerForWorkspace({
       return new Err(createResult.error);
     }
     metronomeCustomerId = createResult.value.metronomeCustomerId;
+
+    // Provision the seat-exhaustion alert up front, when the Metronome customer
+    // is first created. It fans out per seat (seat_filter "user_id"), driving
+    // the credit state machine to move each user to `on_pool` when their
+    // personal balance hits 0.
+    const seatAlertResult = await upsertMetronomeSeatExhaustedAlert({
+      metronomeCustomerId,
+      workspaceId: workspace.sId,
+    });
+    if (seatAlertResult.isErr()) {
+      logger.warn(
+        { workspaceId: workspace.sId, error: seatAlertResult.error.message },
+        "[Metronome] Failed to upsert seat-exhaustion alert at customer creation (non-fatal)"
+      );
+    }
   }
 
   if (workspace.metronomeCustomerId !== metronomeCustomerId) {
@@ -427,6 +446,27 @@ export async function syncContractQuantities(
   for (const result of results) {
     if (result.isErr()) {
       return new Err(result.error);
+    }
+  }
+
+  // Sync the per-user seat low-balance alerts (fire at 80% of each seat's
+  // allocation spent) now that seats are reconciled and per-user allocations
+  // are known.
+  if (shouldSyncSeats) {
+    const lowBalanceAlertResult = await syncMetronomeSeatLowBalanceAlerts({
+      metronomeCustomerId,
+      contractId: metronomeContractId,
+      workspaceId: workspace.sId,
+    });
+    if (lowBalanceAlertResult.isErr()) {
+      logger.warn(
+        {
+          workspaceId: workspace.sId,
+          metronomeContractId,
+          error: lowBalanceAlertResult.error.message,
+        },
+        "[Metronome] Failed to sync seat low-balance alerts (non-fatal)"
+      );
     }
   }
 

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -828,17 +828,15 @@ export type SeatData = {
  * a map of userId → { awuAllocation, billingFrequency }. Makes a single
  * contract fetch and one seat-ID fetch per subscription.
  *
- * Returns an empty map on any error so callers degrade gracefully.
+ * Returns an Err on any contract or seat-ID fetch failure.
  */
 export async function buildSeatDataByUserId({
   metronomeCustomerId,
   contractId,
-  throwOnError = false,
 }: {
   metronomeCustomerId: string;
   contractId: string;
-  throwOnError?: boolean;
-}): Promise<Map<string, SeatData>> {
+}): Promise<Result<Map<string, SeatData>, Error>> {
   const contractResult = await getMetronomeContractById({
     metronomeCustomerId,
     metronomeContractId: contractId,
@@ -848,10 +846,7 @@ export async function buildSeatDataByUserId({
       { error: contractResult.error, metronomeCustomerId, contractId },
       "[Metronome] Failed to fetch contract"
     );
-    if (throwOnError) {
-      throw contractResult.error;
-    }
-    return new Map();
+    return new Err(contractResult.error);
   }
 
   const contract = contractResult.value;
@@ -862,11 +857,11 @@ export async function buildSeatDataByUserId({
     subscriptions,
     async (sub) => {
       if (sub.quantity_management_mode !== "SEAT_BASED" || !sub.id) {
-        return null;
+        return new Ok(null);
       }
       const seatType = getSeatTypeForSubscription(sub, productSeatTypes);
       if (!seatType) {
-        return null;
+        return new Ok(null);
       }
       const awuAllocation = getAwuAllocationForSeatType(
         contract,
@@ -874,7 +869,7 @@ export async function buildSeatDataByUserId({
         productSeatTypes
       );
       if (awuAllocation === 0) {
-        return null;
+        return new Ok(null);
       }
 
       const seatIdsResult = await getMetronomeSubscriptionAssignedSeatIds({
@@ -893,35 +888,36 @@ export async function buildSeatDataByUserId({
           },
           "[Metronome] Failed to fetch seat IDs"
         );
-        if (throwOnError) {
-          throw seatIdsResult.error;
-        }
-        return null;
+        return new Err(seatIdsResult.error);
       }
 
       const freq = sub.subscription_rate.billing_frequency;
-      return {
+      return new Ok({
         seatIds: seatIdsResult.value,
         awuAllocation,
         billingFrequency: freq === "MONTHLY" || freq === "ANNUAL" ? freq : null,
-      };
+      });
     },
     { concurrency: 10 }
   );
 
   const seatDataByUserId = new Map<string, SeatData>();
   for (const result of results) {
-    if (result) {
-      for (const seatId of result.seatIds) {
+    if (result.isErr()) {
+      return new Err(result.error);
+    }
+    const subSeatData = result.value;
+    if (subSeatData) {
+      for (const seatId of subSeatData.seatIds) {
         seatDataByUserId.set(seatId, {
-          awuAllocation: result.awuAllocation,
-          billingFrequency: result.billingFrequency,
+          awuAllocation: subSeatData.awuAllocation,
+          billingFrequency: subSeatData.billingFrequency,
         });
       }
     }
   }
 
-  return seatDataByUserId;
+  return new Ok(seatDataByUserId);
 }
 
 const SEAT_DATA_CACHE_TTL_MS = 60 * 1000;
@@ -938,12 +934,12 @@ async function fetchSeatDataRecord(args: {
   metronomeCustomerId: string;
   contractId: string;
 }): Promise<Record<string, SeatData>> {
-  return Object.fromEntries(
-    await buildSeatDataByUserId({
-      ...args,
-      throwOnError: true,
-    })
-  );
+  const seatDataResult = await buildSeatDataByUserId(args);
+  // Throw at the cache boundary so a transient fetch failure is not cached.
+  if (seatDataResult.isErr()) {
+    throw seatDataResult.error;
+  }
+  return Object.fromEntries(seatDataResult.value);
 }
 
 export const getCachedSeatDataByUserId = cacheWithRedis(

--- a/front/scripts/backfill_metronome_seat_balance_alerts.ts
+++ b/front/scripts/backfill_metronome_seat_balance_alerts.ts
@@ -1,0 +1,139 @@
+/**
+ * Backfill the per-seat `low_remaining_seat_balance_reached` Metronome alerts
+ * for every seat-based ("personal credits") workspace.
+ *
+ * For each workspace with an active Metronome contract that has at least one
+ * seat subscription, idempotently upserts the seat-balance alerts (the
+ * exhausted/0 and the low-balance thresholds, fanned out per user via
+ * seat_filter). Pool-only workspaces are skipped.
+ *
+ * The alerts are also provisioned going forward at Metronome customer creation
+ * (see `ensureMetronomeCustomerForWorkspace`); this script reconciles existing
+ * customers created before that hook.
+ *
+ * Run with:
+ *   npx tsx scripts/backfill_metronome_seat_balance_alerts.ts [--execute] [--workspaceId <sId>]
+ */
+
+import {
+  syncMetronomeSeatLowBalanceAlerts,
+  upsertMetronomeSeatExhaustedAlert,
+} from "@app/lib/metronome/alerts/seat_balance";
+import { getMetronomeContractById } from "@app/lib/metronome/client";
+import { hasContractSeatSubscription } from "@app/lib/metronome/seats";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import type { Logger } from "@app/logger/logger";
+import type { LightWorkspaceType } from "@app/types/user";
+
+import { makeScript } from "./helpers";
+import { runOnAllWorkspaces } from "./workspace_helpers";
+
+async function backfillSeatBalanceAlertForWorkspace(
+  workspace: LightWorkspaceType,
+  execute: boolean,
+  logger: Logger
+): Promise<void> {
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId) {
+    return;
+  }
+
+  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+    workspace.id
+  );
+  const metronomeContractId = subscription?.metronomeContractId;
+  if (!metronomeContractId) {
+    return;
+  }
+
+  const contractResult = await getMetronomeContractById({
+    metronomeCustomerId,
+    metronomeContractId,
+  });
+  if (contractResult.isErr()) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        metronomeContractId,
+        error: contractResult.error.message,
+      },
+      "[SeatBalanceAlertBackfill] Failed to fetch contract"
+    );
+    return;
+  }
+
+  // Only seat-based ("personal credits") workspaces need the alert. Pool-only
+  // workspaces have no seat balances for it to track.
+  const isSeatBased = await hasContractSeatSubscription(contractResult.value);
+  if (!isSeatBased) {
+    return;
+  }
+
+  if (!execute) {
+    logger.info(
+      { workspaceId: workspace.sId, metronomeCustomerId },
+      "[SeatBalanceAlertBackfill] [DRY RUN] Would upsert seat-balance alerts"
+    );
+    return;
+  }
+
+  const exhaustedResult = await upsertMetronomeSeatExhaustedAlert({
+    metronomeCustomerId,
+    workspaceId: workspace.sId,
+  });
+  if (exhaustedResult.isErr()) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        metronomeCustomerId,
+        error: exhaustedResult.error.message,
+      },
+      "[SeatBalanceAlertBackfill] Failed to upsert seat-exhaustion alert"
+    );
+    return;
+  }
+
+  const lowBalanceResult = await syncMetronomeSeatLowBalanceAlerts({
+    metronomeCustomerId,
+    contractId: metronomeContractId,
+    workspaceId: workspace.sId,
+  });
+  if (lowBalanceResult.isErr()) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        metronomeCustomerId,
+        error: lowBalanceResult.error.message,
+      },
+      "[SeatBalanceAlertBackfill] Failed to sync seat low-balance alerts"
+    );
+    return;
+  }
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      metronomeCustomerId,
+    },
+    "[SeatBalanceAlertBackfill] Synced seat-balance alerts"
+  );
+}
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string" as const,
+      description:
+        "Optional workspace sId to process (processes all if omitted)",
+      required: false,
+    },
+  },
+  async ({ workspaceId, execute }, logger) => {
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        await backfillSeatBalanceAlertForWorkspace(workspace, execute, logger);
+      },
+      { concurrency: 4, wId: workspaceId }
+    );
+  }
+);


### PR DESCRIPTION
## Description

Adds two types of Metronome seat-balance alerts to support the per-user credit state machine for seat-based ("personal credits") workspaces:

- **Seat-exhausted alert** (`low_remaining_seat_balance_reached` at 0 AWU): a single alert fanned out across all seats via `seat_filter { seat_group_key: "user_id" }`, provisioned upfront when a Metronome customer is first created. Fires when a user's personal balance hits 0, triggering the transition to `on_pool`.
- **Per-user low-balance alerts** (`low_remaining_seat_balance_reached` at `ceil(20% × allocation)`): one alert per user, scoped to that user via `seat_group_value`. Synced after each seat reconciliation in `syncContractQuantities`; alerts for users who no longer hold a seat are archived.

Both alerts use uniqueness keys (`seat-balance-<workspaceId>` and `seat-low-balance-<workspaceId>-<userId>`) to make upserts idempotent. A backfill script (`backfill_metronome_seat_balance_alerts.ts`) retroactively provisions both alerts on all existing seat-based workspaces (supports `--execute` and `--workspaceId` flags for dry-run and scoped runs).

## Tests

Manual testing: creating a new workspace locally created the two alerts in Metronome

## Risk

Low. Alert failures are non-fatal (logged as warnings)

## Deploy Plan

- Deploy `front`.
- Run the backfill script to provision alerts on existing customers:
  ```
  npx tsx scripts/backfill_metronome_seat_balance_alerts.ts --execute
  ```