### PR TITLE
adding speech to text tool

### DIFF
--- a/front/lib/api/actions/servers/speech_generator/metadata.ts
+++ b/front/lib/api/actions/servers/speech_generator/metadata.ts
@@ -62,11 +62,26 @@ const ALLOWED_AUDIO_URL_DOMAINS = [
   "wistia.com",
   "wistia.net",
   "vidyard.com",
-  // Meeting recordings
+  // Meeting recordings & AI notetakers
   "zoom.us",
   "webex.com",
   "grain.com",
   "riverside.fm",
+  "fathom.video",
+  "granola.so",
+  "fireflies.ai",
+  "otter.ai",
+  "tldv.io",
+  "meetgeek.ai",
+  "avoma.com",
+  "gong.io",
+  "chorus.ai",
+  "read.ai",
+  "bluedot.ai",
+  "notta.ai",
+  "sembly.ai",
+  "tactiq.io",
+  "meetjamie.ai",
   // Cloud storage
   "drive.google.com",
   "googleusercontent.com",
@@ -82,7 +97,7 @@ const ALLOWED_AUDIO_URL_DOMAINS = [
   "soundcloud.com",
 ] as const;
 
-function isAllowedAudioUrl(url: string): boolean {
+export function isAllowedAudioUrl(url: string): boolean {
   try {
     const { hostname } = new URL(url);
     return ALLOWED_AUDIO_URL_DOMAINS.some(

--- a/front/lib/api/actions/servers/speech_generator/metadata.ts
+++ b/front/lib/api/actions/servers/speech_generator/metadata.ts
@@ -49,6 +49,42 @@ export type VoiceUseCase = (typeof VOICE_USE_CASES)[number];
 export const SPEECH_GENERATOR_SERVER_NAME = "speech_generator" as const;
 
 export const SPEECH_GENERATOR_TOOLS_METADATA = createToolsRecord({
+  speech_to_text: {
+    description:
+      "Transcribe speech from an audio or video file into text. " +
+      "Supported formats: MP3, WAV, OGG, FLAC, AAC, MP4, MOV, WEBM, MKV, and most " +
+      "common audio/video formats.",
+    schema: {
+      audio_url: z
+        .string()
+        .url()
+        .optional()
+        .describe(
+          "HTTPS URL of the audio or video file to transcribe (up to 2GB). " +
+            "Any valid HTTPS URL is accepted, including pre-signed URLs from cloud storage providers. " +
+            "Mutually exclusive with audio_blob."
+        ),
+      audio_blob: z
+        .string()
+        .optional()
+        .describe(
+          "Base64-encoded content of an audio or video file. " +
+            "Mutually exclusive with audio_url."
+        ),
+      language_code: z
+        .string()
+        .optional()
+        .describe(
+          "ISO-639-1 or ISO-639-3 language code of the audio (e.g. 'en', 'fr'). " +
+            "Auto-detected if omitted."
+        ),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Transcribing audio",
+      done: "Transcribe audio",
+    },
+  },
   text_to_speech: {
     description: "Generate speech audio from a text prompt with desired voice.",
     schema: {

--- a/front/lib/api/actions/servers/speech_generator/metadata.ts
+++ b/front/lib/api/actions/servers/speech_generator/metadata.ts
@@ -60,7 +60,7 @@ export const SPEECH_GENERATOR_TOOLS_METADATA = createToolsRecord({
         .url()
         .optional()
         .describe(
-          "HTTPS URL of the audio or video file to transcribe (up to 2GB). " +
+          "HTTPS URL of the audio or video file to transcribe. " +
             "Any valid HTTPS URL is accepted, including pre-signed URLs from cloud storage providers. " +
             "Mutually exclusive with audio_blob."
         ),

--- a/front/lib/api/actions/servers/speech_generator/metadata.ts
+++ b/front/lib/api/actions/servers/speech_generator/metadata.ts
@@ -48,6 +48,51 @@ export type VoiceUseCase = (typeof VOICE_USE_CASES)[number];
 
 export const SPEECH_GENERATOR_SERVER_NAME = "speech_generator" as const;
 
+const ALLOWED_AUDIO_URL_DOMAINS = [
+  // Video platforms
+  "youtube.com",
+  "youtu.be",
+  "googlevideo.com",
+  "vimeo.com",
+  "vimeocdn.com",
+  "dailymotion.com",
+  // Async video / screen recording
+  "loom.com",
+  "tella.tv",
+  "wistia.com",
+  "wistia.net",
+  "vidyard.com",
+  // Meeting recordings
+  "zoom.us",
+  "webex.com",
+  "grain.com",
+  "riverside.fm",
+  // Cloud storage
+  "drive.google.com",
+  "googleusercontent.com",
+  "sharepoint.com",
+  "onedrive.live.com",
+  "onedrive.com",
+  "1drv.ms",
+  "dropbox.com",
+  "dropboxusercontent.com",
+  // Collaboration / comms
+  "slack.com",
+  // Audio
+  "soundcloud.com",
+] as const;
+
+function isAllowedAudioUrl(url: string): boolean {
+  try {
+    const { hostname } = new URL(url);
+    return ALLOWED_AUDIO_URL_DOMAINS.some(
+      (domain) => hostname === domain || hostname.endsWith(`.${domain}`)
+    );
+  } catch {
+    return false;
+  }
+}
+
 export const SPEECH_GENERATOR_TOOLS_METADATA = createToolsRecord({
   speech_to_text: {
     description:
@@ -58,10 +103,13 @@ export const SPEECH_GENERATOR_TOOLS_METADATA = createToolsRecord({
       audio_url: z
         .string()
         .url()
+        .refine(isAllowedAudioUrl, {
+          message: `URL must be from an allowed domain: ${ALLOWED_AUDIO_URL_DOMAINS.join(", ")}.`,
+        })
         .optional()
         .describe(
           "HTTPS URL of the audio or video file to transcribe. " +
-            "Any valid HTTPS URL is accepted, including pre-signed URLs from cloud storage providers. " +
+            "Only URLs from the allowlist of known video/audio platforms are accepted. " +
             "Mutually exclusive with audio_blob."
         ),
       audio_blob: z

--- a/front/lib/api/actions/servers/speech_generator/tools/index.ts
+++ b/front/lib/api/actions/servers/speech_generator/tools/index.ts
@@ -11,6 +11,37 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 const handlers: ToolHandlers<typeof SPEECH_GENERATOR_TOOLS_METADATA> = {
+  speech_to_text: async ({ audio_url, audio_blob, language_code }) => {
+    if (!audio_url && !audio_blob) {
+      return new Err(
+        new MCPError("Either audio_url or audio_blob must be provided.")
+      );
+    }
+
+    try {
+      const client = getElevenLabsClient();
+
+      const result = await client.speechToText.convert({
+        ...(audio_url
+          ? { cloudStorageUrl: audio_url }
+          : { file: Buffer.from(audio_blob!, "base64") }),
+        modelId: "scribe_v2",
+        enableLogging: false,
+        ...(language_code ? { languageCode: language_code } : {}),
+      });
+
+      return new Ok([{ type: "text" as const, text: result.text }]);
+    } catch (e) {
+      const cause = normalizeError(e);
+      return new Err(
+        new MCPError(
+          `Error transcribing audio with ElevenLabs: ${cause.message}`,
+          { cause }
+        )
+      );
+    }
+  },
+
   text_to_speech: async ({
     text,
     gender = "female",

--- a/front/lib/api/actions/servers/speech_generator/tools/index.ts
+++ b/front/lib/api/actions/servers/speech_generator/tools/index.ts
@@ -23,7 +23,7 @@ const handlers: ToolHandlers<typeof SPEECH_GENERATOR_TOOLS_METADATA> = {
 
       const result = await client.speechToText.convert({
         ...(audio_url
-          ? { cloudStorageUrl: audio_url }
+          ? { sourceUrl: audio_url }
           : { file: Buffer.from(audio_blob!, "base64") }),
         modelId: "scribe_v2",
         enableLogging: false,

--- a/front/lib/api/actions/servers/speech_generator/tools/index.ts
+++ b/front/lib/api/actions/servers/speech_generator/tools/index.ts
@@ -6,7 +6,10 @@ import {
   resolveDefaultVoiceId,
   streamToBase64,
 } from "@app/lib/api/actions/servers/elevenlabs/utils";
-import { SPEECH_GENERATOR_TOOLS_METADATA } from "@app/lib/api/actions/servers/speech_generator/metadata";
+import {
+  isAllowedAudioUrl,
+  SPEECH_GENERATOR_TOOLS_METADATA,
+} from "@app/lib/api/actions/servers/speech_generator/metadata";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
@@ -15,6 +18,14 @@ const handlers: ToolHandlers<typeof SPEECH_GENERATOR_TOOLS_METADATA> = {
     if (!audio_url && !audio_blob) {
       return new Err(
         new MCPError("Either audio_url or audio_blob must be provided.")
+      );
+    }
+
+    if (audio_url && !isAllowedAudioUrl(audio_url)) {
+      return new Err(
+        new MCPError(
+          "audio_url must be from an allowed domain. Check the tool schema for the list of accepted platforms."
+        )
       );
     }
 


### PR DESCRIPTION
## Description

Adds a `speech_to_text` tool to the existing `speech_generator` MCP server (ElevenLabs), powered by the `scribe_v2` model. The tool accepts either an `audio_url` (HTTPS URL, up to 2 GB, preferred path) or an `audio_blob` (base64-encoded file content), plus an optional ISO language code for language hinting. It's added to the existing server rather than a new one given thematic proximity to the TTS tools. 
Note: `audio_blob` via inline base64 tends to fail in practice, agents attempt conversion that gets truncated but via `dsbx` it's working well, it's a prompting concern.

## Tests

Tested manually via `dsbx` using both `audio_url` and `audio_blob` (file reference path). The `audio_url` path is the most reliable; `audio_blob` works when the base64 is passed via a file reference.

## Risk

Low. Additive change only — no existing tools or behavior modified.

## Deploy Plan

Deploy front.