### PR TITLE
fix(ci): upgrade npm to 11.10.0 to support min-release-age config

### DIFF
--- a/.github/actions/setup-node-deps/action.yml
+++ b/.github/actions/setup-node-deps/action.yml
@@ -25,6 +25,10 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
 
+    - name: Upgrade npm
+      shell: bash
+      run: npm install -g npm@11.10.0
+
     - name: Cache node_modules
       id: cache-node-modules
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5


### PR DESCRIPTION
## Description

Node 24.14.0 ships with npm 11.9.0. The `.npmrc` sets `min-release-age=7`, a config key that was introduced in npm 11.10.0 — so any older npm emits `npm warn Unknown project config "min-release-age"` and the setting is silently ignored.

This adds an explicit upgrade step to the shared `setup-node-deps` action to pin npm to 11.10.0, silencing the warning and ensuring the min-release-age security policy is actually enforced.

## Tests

No functional change — the warning disappears on the next CI run.

## Risk

Low. Bumping npm within the same major version (11.x) is backward-compatible. The only risk is a npm regression in 11.10.0, which can be rolled back by removing the upgrade step.
