### PR TITLE
Add test flag to use new API backend URL

### DIFF
--- a/front-api/routes/w/[wId]/auth-context.ts
+++ b/front-api/routes/w/[wId]/auth-context.ts
@@ -1,5 +1,8 @@
 import config from "@app/lib/api/config";
-import { getWorkspaceRegionRedirect } from "@app/lib/api/regions/lookup";
+import {
+  getForcedApiUrlRedirect,
+  getWorkspaceRegionRedirect,
+} from "@app/lib/api/regions/lookup";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { isWorkspaceEligibleForTrial } from "@app/lib/plans/trial";
 import type { SubscriptionType } from "@app/types/plan";
@@ -82,6 +85,25 @@ app.get(
       : false;
 
     const featureFlags = await getFeatureFlags(auth);
+
+    // When the workspace is flagged, force the SPA onto the regional API
+    // subdomain as its backend by reusing the region-redirect mechanism.
+    const forcedApiUrlRedirect = getForcedApiUrlRedirect({
+      enabled: featureFlags.includes("force_us_api_url"),
+      requestHost: ctx.req.header("host"),
+    });
+    if (forcedApiUrlRedirect) {
+      return ctx.json(
+        {
+          error: {
+            type: "workspace_in_different_region",
+            message: "Workspace is located in a different region",
+            redirect: forcedApiUrlRedirect,
+          },
+        },
+        400
+      );
+    }
 
     return ctx.json({
       user: user.toJSON(),

--- a/front/lib/api/regions/lookup.ts
+++ b/front/lib/api/regions/lookup.ts
@@ -304,6 +304,45 @@ export async function lookupShareToken(
   }
 }
 
+// Regional API subdomains the SPA can be forced onto via the `force_us_api_url`
+// feature flag. Hardcoded on purpose: these are stable public hostnames that
+// are independent of the per-environment app URLs in `config`.
+const REGION_API_URLS: Record<RegionType, string> = {
+  "europe-west1": "https://eu-api.dust.tt",
+  "us-central1": "https://us-api.dust.tt",
+};
+
+/**
+ * When the `force_us_api_url` flag is enabled on a workspace, returns a redirect
+ * that points the SPA at the current region's API subdomain (us-api/eu-api.dust.tt)
+ * so it uses that as its backend. Returns null when the flag is disabled or when
+ * the request already arrived on the target host (avoids a redirect loop once the
+ * SPA has switched).
+ */
+export function getForcedApiUrlRedirect({
+  enabled,
+  requestHost,
+}: {
+  enabled: boolean;
+  requestHost: string | undefined;
+}): RegionRedirectError | null {
+  if (!enabled) {
+    return null;
+  }
+
+  const currentRegion = config.getCurrentRegion();
+  const targetUrl = REGION_API_URLS[currentRegion];
+
+  if (requestHost === new URL(targetUrl).host) {
+    return null;
+  }
+
+  return {
+    region: currentRegion,
+    url: targetUrl,
+  };
+}
+
 /**
  * Checks if a workspace exists in another region and returns a redirect response if so.
  * Returns null if the workspace should be handled locally or doesn't exist.

--- a/front/pages/api/w/[wId]/auth-context.ts
+++ b/front/pages/api/w/[wId]/auth-context.ts
@@ -2,7 +2,10 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
-import { getWorkspaceRegionRedirect } from "@app/lib/api/regions/lookup";
+import {
+  getForcedApiUrlRedirect,
+  getWorkspaceRegionRedirect,
+} from "@app/lib/api/regions/lookup";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { isWorkspaceEligibleForTrial } from "@app/lib/plans/trial";
@@ -89,6 +92,22 @@ async function handler(
     : false;
 
   const featureFlags = await getFeatureFlags(auth);
+
+  // When the workspace is flagged, force the SPA onto the regional API subdomain
+  // as its backend by reusing the region-redirect mechanism.
+  const forcedApiUrlRedirect = getForcedApiUrlRedirect({
+    enabled: featureFlags.includes("force_us_api_url"),
+    requestHost: req.headers.host,
+  });
+  if (forcedApiUrlRedirect) {
+    return res.status(400).json({
+      error: {
+        type: "workspace_in_different_region",
+        message: "Workspace is located in a different region",
+        redirect: forcedApiUrlRedirect,
+      },
+    });
+  }
 
   return res.status(200).json({
     user: user.toJSON(),

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -312,6 +312,12 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Enable the new user settings v2 experience",
     stage: "dust_only",
   },
+  force_us_api_url: {
+    description:
+      "Force the SPA to use the regional API subdomain (us-api/eu-api.dust.tt) " +
+      "as its backend for this workspace",
+    stage: "on_demand",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -708,6 +708,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "dust_no_spa"
   | "dust_spa"
   | "fireworks_new_model_feature"
+  | "force_us_api_url"
   | "frames_skill_v2"
   | "gemini_3_1_pro_feature"
   | "clari_copilot_mcp"


### PR DESCRIPTION
## Description

  Adds a `force_us_api_url` feature flag that, when enabled on a workspace, makes
  the SPA use the **regional API subdomain** as its backend for that workspace:
  `https://us-api.dust.tt` (or `https://eu-api.dust.tt` in `europe-west1`) instead
  of the default app domain (`https://dust.tt` / `https://eu.dust.tt`).

  ### How it works

  The SPA only switches its backend URL in response to the
  `workspace_in_different_region` 400 redirect from `auth-context` — `useAuthContext`
  calls `setRegionInfo(redirect)`, persists it to localStorage, and refetches against
  the new URL. So when a workspace is local **and** flagged, we emit that same redirect
  shape pointing at the api subdomain, reusing the existing client plumbing (no SPA
  changes needed).

  A host-header check prevents an infinite redirect loop: once the SPA has switched
  onto the target host, the subsequent `auth-context` request arrives on
  `us-api.dust.tt` and no further redirect is emitted.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low, under flag

## Deploy Plan

Front