### PR TITLE
[sdks/js] Fix v1 PATCH agent_configurations silently dropping config …

### DIFF
--- a/front-api/routes/v1/w/[wId]/assistant/agent_configurations/[sId]/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/agent_configurations/[sId]/index.test.ts
@@ -1,0 +1,74 @@
+import { Authenticator } from "@app/lib/auth";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+async function setupTest() {
+  const { workspace, key } = await createPublicApiMockRequest();
+
+  await SpaceFactory.defaults(
+    await Authenticator.internalAdminForWorkspace(workspace.sId)
+  );
+
+  const user = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, user, { role: "builder" });
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+
+  const agentConfig = await AgentConfigurationFactory.createTestAgent(auth);
+
+  return { workspace, key, agentConfig };
+}
+
+function patchAgentConfiguration(
+  workspace: { sId: string },
+  key: { secret: string },
+  agentId: string,
+  body: unknown
+) {
+  return honoApp.request(
+    `/api/v1/w/${workspace.sId}/assistant/agent_configurations/${agentId}`,
+    {
+      method: "PATCH",
+      headers: {
+        authorization: `Bearer ${key.secret}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+describe("PATCH /api/v1/w/[wId]/assistant/agent_configurations/[sId]", () => {
+  it("applies configuration patch fields beyond userFavorite (regression dust-tt/dust#26698)", async () => {
+    const { workspace, key, agentConfig } = await setupTest();
+
+    const response = await patchAgentConfiguration(
+      workspace,
+      key,
+      agentConfig.sId,
+      { instructions: "Updated instructions" }
+    );
+
+    const data = await response.json();
+    expect(response.status, JSON.stringify(data)).toBe(200);
+    expect(data.agentConfiguration.instructions).toBe("Updated instructions");
+    expect(data.agentConfiguration.version).toBe(agentConfig.version + 1);
+  });
+
+  it("returns 404 when the agent configuration does not exist", async () => {
+    const { workspace, key } = await setupTest();
+
+    const response = await patchAgentConfiguration(workspace, key, "unknown", {
+      instructions: "Updated instructions",
+    });
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2132,9 +2132,15 @@ export type GetOrPatchAgentConfigurationResponseType = z.infer<
   typeof GetOrPatchAgentConfigurationResponseSchema
 >;
 
-export const PatchAgentConfigurationRequestSchema = z.object({
-  userFavorite: z.boolean().optional(),
-});
+// Passthrough is required: beyond `userFavorite`, the endpoint accepts agent configuration
+// patch fields (`instructions`, `agent`, `generation_settings`, `tags`, `editors`, `skills`,
+// `toolset`, ...) which are validated server-side by `agentYAMLConfigPatchSchema`. Stripping
+// unknown keys here would silently drop them (see dust-tt/dust#26698).
+export const PatchAgentConfigurationRequestSchema = z
+  .object({
+    userFavorite: z.boolean().optional(),
+  })
+  .passthrough();
 
 export type PatchAgentConfigurationRequestType = z.infer<
   typeof PatchAgentConfigurationRequestSchema


### PR DESCRIPTION
## Description

The Hono handler validates the PATCH body with PatchAgentConfigurationRequestSchema via ctx.req.valid("json"). Since the schema only declares userFavorite and zod strips unknown keys by default, all configuration patch fields (instructions, agent, generation_settings, tags, editors, skills, toolset) were silently dropped and the endpoint returned 200 with the unchanged config. The legacy Next handler read configPatch from the raw req.body, so it was unaffected.

Make the schema passthrough so unknown keys reach patchAgentConfigurationFromJSON, which validates them against agentYAMLConfigPatchSchema server-side. Add a route-level regression test (fails without the fix: instructions stay unchanged).

Fixes #26698

## Tests

Added

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
