### PR TITLE
Shorten sandbox running label to "Executing command"

### DIFF
--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -39,7 +39,7 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Executing command in the Computer",
+      running: "Executing command",
       done: "Execute command in the Computer",
     },
   },


### PR DESCRIPTION
## Description

The sandbox tool running label read "Executing command in the Computer". Shortened it to "Executing command".

## Tests

Copy-only change.

## Risk

Low.

## Deploy Plan

Standard deploy.