### PR TITLE
[front] cut sandbox cold-start: drop update-ca-certificates, overlap GCS mount

### DIFF
--- a/front/lib/api/sandbox/image/egress/dust-install-trust-bundle.sh
+++ b/front/lib/api/sandbox/image/egress/dust-install-trust-bundle.sh
@@ -35,6 +35,11 @@ if ! /usr/bin/openssl x509 -in "$CA_PATH" -out "$normalized_ca_tmp" -outform PEM
   exit 1
 fi
 
+# Snapshot the untouched system bundle once, before we ever fold in the dsbx
+# CA, so repeated installs (the health-probe repair path re-runs this) rebuild
+# deterministically from pristine roots instead of compounding. This lives on
+# the per-image rootfs, so it can't outlive the image version it was taken
+# from: a base-image bump ships a fresh rootfs with no stale .orig to reuse.
 if [ ! -s "$PRISTINE_SYSTEM_BUNDLE" ]; then
   /usr/bin/install -o root -g root -m 644 "$SYSTEM_CA_BUNDLE" "$PRISTINE_SYSTEM_BUNDLE"
 fi
@@ -64,6 +69,10 @@ system_tmp="$(/usr/bin/mktemp "${SYSTEM_CA_CERTS_DIR}/.ca-certificates.crt.XXXXX
 /usr/bin/chmod 644 "$system_tmp"
 /usr/bin/mv "$system_tmp" "$SYSTEM_CA_BUNDLE"
 
+# Replicate what c_rehash does for our one cert: openssl resolves trusted CAs
+# in SYSTEM_CA_CERTS_DIR via <subject_hash>.N symlinks. Find the first free
+# slot so we never clobber a system cert that happens to share the hash, and
+# no-op if a prior run already linked our cert (keeps re-runs idempotent).
 ca_hash="$(/usr/bin/openssl x509 -hash -noout -in "$normalized_ca_tmp")"
 slot=0
 while [ -e "${SYSTEM_CA_CERTS_DIR}/${ca_hash}.${slot}" ]; do

--- a/front/lib/api/sandbox/image/egress/dust-install-trust-bundle.sh
+++ b/front/lib/api/sandbox/image/egress/dust-install-trust-bundle.sh
@@ -4,32 +4,39 @@ set -euo pipefail
 CA_PATH="/run/dust/egress-ca.pem"
 SYSTEM_CA_DIR="/usr/local/share/ca-certificates"
 SYSTEM_CA_DEST="${SYSTEM_CA_DIR}/dust-egress.crt"
-SYSTEM_CA_BUNDLE="/etc/ssl/certs/ca-certificates.crt"
+SYSTEM_CA_CERTS_DIR="/etc/ssl/certs"
+SYSTEM_CA_BUNDLE="${SYSTEM_CA_CERTS_DIR}/ca-certificates.crt"
 MERGED_BUNDLE="/etc/dust/ca-bundle.pem"
+PRISTINE_SYSTEM_BUNDLE="/etc/dust/system-ca-certificates.crt.orig"
 
 if [ ! -s "$CA_PATH" ]; then
-  echo "dsbx CA file $CA_PATH missing or empty" >&2
+  /usr/bin/printf '%s\n' "dsbx CA file $CA_PATH missing or empty" >&2
   exit 1
 fi
 
-/usr/bin/mkdir -p /etc/dust /etc/ssl/certs/java
+/usr/bin/mkdir -p /etc/dust "${SYSTEM_CA_CERTS_DIR}/java"
 
 normalized_ca_tmp="$(/usr/bin/mktemp /etc/dust/.egress-ca.pem.XXXXXX)"
+system_tmp=""
 bundle_tmp=""
 keytool_output=""
 cleanup() {
-  /bin/rm -f "$normalized_ca_tmp" "$bundle_tmp" "$keytool_output"
+  /bin/rm -f "$normalized_ca_tmp" "$system_tmp" "$bundle_tmp" "$keytool_output"
 }
 trap cleanup EXIT
 
 if [ ! -x /usr/bin/openssl ]; then
-  echo "openssl is required to validate $CA_PATH" >&2
+  /usr/bin/printf '%s\n' "openssl is required to validate $CA_PATH" >&2
   exit 1
 fi
 
 if ! /usr/bin/openssl x509 -in "$CA_PATH" -out "$normalized_ca_tmp" -outform PEM >/dev/null 2>&1; then
-  echo "dsbx CA file $CA_PATH is not a valid X.509 PEM certificate" >&2
+  /usr/bin/printf '%s\n' "dsbx CA file $CA_PATH is not a valid X.509 PEM certificate" >&2
   exit 1
+fi
+
+if [ ! -s "$PRISTINE_SYSTEM_BUNDLE" ]; then
+  /usr/bin/install -o root -g root -m 644 "$SYSTEM_CA_BUNDLE" "$PRISTINE_SYSTEM_BUNDLE"
 fi
 
 if [ -L "$SYSTEM_CA_DIR" ] || { [ -e "$SYSTEM_CA_DIR" ] && [ ! -d "$SYSTEM_CA_DIR" ]; }; then
@@ -40,30 +47,40 @@ fi
 /usr/bin/chown root:root "$SYSTEM_CA_DIR"
 /usr/bin/chmod 755 "$SYSTEM_CA_DIR"
 
-# update-ca-certificates follows symlinks under this directory. Treat it as
-# Dust-owned staging and keep only the CA we install below before root asks it
-# to rebuild the world-readable system bundle.
+# Treat this directory as Dust-owned staging and keep only the CA we install
+# below, so the incremental system-store update cannot ingest workload-staged
+# symlinks or garbage certs.
 /usr/bin/find "$SYSTEM_CA_DIR" -mindepth 1 -maxdepth 1 -exec /bin/rm -rf -- {} +
 /bin/rm -f "$SYSTEM_CA_DEST"
 
-if [ -x /usr/sbin/update-ca-certificates ]; then
-  /usr/bin/install -o root -g root -m 644 "$normalized_ca_tmp" "$SYSTEM_CA_DEST"
-  if ! /usr/sbin/update-ca-certificates >/dev/null 2>&1; then
-    echo "update-ca-certificates failed; continuing with explicit bundle" >&2
+# update-ca-certificates forks openssl once per system root and spends most of
+# cold-start on the constrained microVM. The image already has the public roots,
+# so install only the runtime dsbx CA and reproduce the same bundle/hash-symlink
+# outcome incrementally.
+/usr/bin/install -o root -g root -m 644 "$normalized_ca_tmp" "$SYSTEM_CA_DEST"
+
+system_tmp="$(/usr/bin/mktemp "${SYSTEM_CA_CERTS_DIR}/.ca-certificates.crt.XXXXXX")"
+{ /bin/cat "$PRISTINE_SYSTEM_BUNDLE"; /usr/bin/printf '\n'; /bin/cat "$normalized_ca_tmp"; } > "$system_tmp"
+/usr/bin/chmod 644 "$system_tmp"
+/usr/bin/mv "$system_tmp" "$SYSTEM_CA_BUNDLE"
+
+ca_hash="$(/usr/bin/openssl x509 -hash -noout -in "$normalized_ca_tmp")"
+slot=0
+while [ -e "${SYSTEM_CA_CERTS_DIR}/${ca_hash}.${slot}" ]; do
+  if [ "$(/usr/bin/readlink -f "${SYSTEM_CA_CERTS_DIR}/${ca_hash}.${slot}")" = "$SYSTEM_CA_DEST" ]; then
+    slot=""
+    break
   fi
-else
-  echo "update-ca-certificates not found; continuing with explicit bundle" >&2
-fi
+  slot=$((slot+1))
+done
+[ -n "$slot" ] && /bin/ln -sf "$SYSTEM_CA_DEST" "${SYSTEM_CA_CERTS_DIR}/${ca_hash}.${slot}"
 
 bundle_tmp="$(/usr/bin/mktemp /etc/dust/.ca-bundle.pem.XXXXXX)"
 
 # Concatenate with an explicit newline so the join point can never glue the
-# last cert footer to the next BEGIN line if ca-certificates.crt drops its
-# trailing newline. If update-ca-certificates ran successfully the dsbx CA is
-# already in $SYSTEM_CA_BUNDLE; the explicit second copy is harmless (OpenSSL
-# dedupes by subject) and keeps the merged bundle correct even when update-ca-
-# certificates is missing or fails.
-{ /bin/cat "$SYSTEM_CA_BUNDLE"; printf '\n'; /bin/cat "$normalized_ca_tmp"; } > "$bundle_tmp"
+# last cert footer to the next BEGIN line if the pristine bundle drops its
+# trailing newline.
+{ /bin/cat "$PRISTINE_SYSTEM_BUNDLE"; /usr/bin/printf '\n'; /bin/cat "$normalized_ca_tmp"; } > "$bundle_tmp"
 /usr/bin/chmod 644 "$bundle_tmp"
 /usr/bin/mv "$bundle_tmp" "$MERGED_BUNDLE"
 

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -5,6 +5,8 @@ import {
   mkdtempSync,
   readdirSync,
   readFileSync,
+  readlinkSync,
+  realpathSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -94,7 +96,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.34",
+      tag: "0.8.35",
     });
   });
 
@@ -426,9 +428,24 @@ describe("sandbox image registry", () => {
     expect(installer).toContain(
       '/usr/bin/install -o root -g root -m 644 "$normalized_ca_tmp" "$SYSTEM_CA_DEST"'
     );
-    expect(installer).toContain("/usr/sbin/update-ca-certificates");
-    expect(installer).toContain('/bin/cat "$SYSTEM_CA_BUNDLE"');
+    expect(installer).not.toContain("/usr/sbin/update-ca-certificates");
+    expect(installer).toContain(
+      'PRISTINE_SYSTEM_BUNDLE="/etc/dust/system-ca-certificates.crt.orig"'
+    );
+    expect(installer).toContain(
+      'system_tmp="$(/usr/bin/mktemp "${SYSTEM_CA_CERTS_DIR}/.ca-certificates.crt.XXXXXX")"'
+    );
+    expect(installer).toContain('/bin/cat "$PRISTINE_SYSTEM_BUNDLE"');
     expect(installer).toContain('/bin/cat "$normalized_ca_tmp"');
+    expect(installer).toContain(
+      '/usr/bin/openssl x509 -hash -noout -in "$normalized_ca_tmp"'
+    );
+    expect(installer).toContain(
+      '/usr/bin/readlink -f "${SYSTEM_CA_CERTS_DIR}/${ca_hash}.${slot}"'
+    );
+    expect(installer).toContain(
+      '/bin/ln -sf "$SYSTEM_CA_DEST" "${SYSTEM_CA_CERTS_DIR}/${ca_hash}.${slot}"'
+    );
     expect(installer).toContain("/etc/ssl/certs/java/cacerts");
     expect(installer).toContain("if [ -x /usr/bin/keytool ]; then");
     expect(installer).toContain(
@@ -446,7 +463,8 @@ describe("sandbox image registry", () => {
     const sandboxRoot = mkdtempSync(join(tmpdir(), "dust-trust-helper-"));
     const runDustDir = join(sandboxRoot, "run", "dust");
     const etcDustDir = join(sandboxRoot, "etc", "dust");
-    const javaCertsDir = join(sandboxRoot, "etc", "ssl", "certs", "java");
+    const systemSslCertsDir = join(sandboxRoot, "etc", "ssl", "certs");
+    const javaCertsDir = join(systemSslCertsDir, "java");
     const stubBinDir = join(sandboxRoot, "bin");
     const systemCaDir = join(
       sandboxRoot,
@@ -455,12 +473,10 @@ describe("sandbox image registry", () => {
       "share",
       "ca-certificates"
     );
-    const systemCaBundle = join(
-      sandboxRoot,
-      "etc",
-      "ssl",
-      "certs",
-      "ca-certificates.crt"
+    const systemCaBundle = join(systemSslCertsDir, "ca-certificates.crt");
+    const pristineSystemCaBundle = join(
+      etcDustDir,
+      "system-ca-certificates.crt.orig"
     );
     const mergedBundle = join(etcDustDir, "ca-bundle.pem");
     const caPath = join(runDustDir, "egress-ca.pem");
@@ -472,10 +488,12 @@ describe("sandbox image registry", () => {
       chown: getCommandPath("chown"),
       find: getCommandPath("find"),
       install: getCommandPath("install"),
+      ln: getCommandPath("ln"),
       mkdir: getCommandPath("mkdir"),
       mktemp: getCommandPath("mktemp"),
       mv: getCommandPath("mv"),
       openssl: getCommandPath("openssl"),
+      readlink: join(stubBinDir, "readlink"),
       rm: getCommandPath("rm"),
     };
 
@@ -483,17 +501,18 @@ describe("sandbox image registry", () => {
       mkdirSync(runDustDir, { recursive: true });
       mkdirSync(stubBinDir, { recursive: true });
       mkdirSync(systemCaDir, { recursive: true });
-      mkdirSync(join(sandboxRoot, "etc", "ssl", "certs"), {
-        recursive: true,
-      });
+      mkdirSync(systemSslCertsDir, { recursive: true });
       chmodSync(systemCaDir, 0o777);
       writeFileSync(systemCaBundle, "system-root\n");
-      const updateCaCertificatesStub = join(
-        stubBinDir,
-        "update-ca-certificates"
+      writeFileSync(
+        commandPaths.readlink,
+        "#!/bin/sh\n" +
+          'if [ "$1" = "-f" ]; then\n' +
+          "  shift\n" +
+          "fi\n" +
+          '/usr/bin/readlink "$1"\n'
       );
-      writeFileSync(updateCaCertificatesStub, "#!/bin/sh\nexit 0\n");
-      chmodSync(updateCaCertificatesStub, 0o755);
+      chmodSync(commandPaths.readlink, 0o755);
       writeFileSync(leakedSecretPath, "DSEC_SECRET=should-not-leak\n");
       symlinkSync(leakedSecretPath, join(systemCaDir, "secrets.crt"));
       writeFileSync(
@@ -532,15 +551,11 @@ describe("sandbox image registry", () => {
           `SYSTEM_CA_DIR="${systemCaDir}"`
         )
         .replace(
-          'SYSTEM_CA_BUNDLE="/etc/ssl/certs/ca-certificates.crt"',
-          `SYSTEM_CA_BUNDLE="${systemCaBundle}"`
+          'SYSTEM_CA_CERTS_DIR="/etc/ssl/certs"',
+          `SYSTEM_CA_CERTS_DIR="${systemSslCertsDir}"`
         )
         .replaceAll("/etc/dust", etcDustDir)
         .replaceAll("/etc/ssl/certs/java", javaCertsDir)
-        .replaceAll(
-          "/usr/sbin/update-ca-certificates",
-          updateCaCertificatesStub
-        )
         .replaceAll(
           "/usr/bin/install -d -o root -g root -m 755",
           "/usr/bin/install -d -m 755"
@@ -556,40 +571,90 @@ describe("sandbox image registry", () => {
         .replaceAll("/usr/bin/chown", commandPaths.chown)
         .replaceAll("/usr/bin/find", commandPaths.find)
         .replaceAll("/usr/bin/install", commandPaths.install)
+        .replaceAll("/bin/ln", commandPaths.ln)
         .replaceAll("/usr/bin/mkdir", commandPaths.mkdir)
         .replaceAll("/usr/bin/mktemp", commandPaths.mktemp)
         .replaceAll("/usr/bin/mv", commandPaths.mv)
         .replaceAll("/usr/bin/openssl", commandPaths.openssl)
+        .replaceAll("/usr/bin/readlink", commandPaths.readlink)
         .replaceAll("/bin/rm", commandPaths.rm);
       const scriptPath = join(sandboxRoot, "install-trust-bundle.sh");
       writeFileSync(scriptPath, rewrittenInstaller);
 
-      const runResult = spawnSync("bash", [scriptPath], {
-        encoding: "utf8",
-        env: {
-          ...process.env,
-          PATH: `${stubBinDir}:${process.env.PATH ?? ""}`,
-        },
-      });
+      const runInstaller = () =>
+        spawnSync("bash", [scriptPath], {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            PATH: `${stubBinDir}:${process.env.PATH ?? ""}`,
+          },
+        });
+
+      const runResult = runInstaller();
 
       if (runResult.status !== 0) {
         throw new Error(
           `trust helper failed:\nstdout:\n${runResult.stdout}\nstderr:\n${runResult.stderr}`
         );
       }
+
+      const hashResult = spawnSync(
+        commandPaths.openssl,
+        [
+          "x509",
+          "-hash",
+          "-noout",
+          "-in",
+          join(systemCaDir, "dust-egress.crt"),
+        ],
+        { encoding: "utf8" }
+      );
+      expect(hashResult.status).toBe(0);
+      const hashSymlink = join(
+        systemSslCertsDir,
+        `${hashResult.stdout.trim()}.0`
+      );
       const mergedBundleContent = readFileSync(mergedBundle, "utf8");
+      const systemCaBundleContent = readFileSync(systemCaBundle, "utf8");
       const installedCaContent = readFileSync(
         join(systemCaDir, "dust-egress.crt"),
         "utf8"
       );
+      const hashSymlinkTarget = readlinkSync(hashSymlink);
 
       expect(readdirSync(systemCaDir)).toEqual(["dust-egress.crt"]);
-      expect(mergedBundleContent).toContain("system-root");
-      expect(mergedBundleContent).toContain("BEGIN CERTIFICATE");
+      expect(readFileSync(pristineSystemCaBundle, "utf8")).toBe(
+        "system-root\n"
+      );
+      expect(systemCaBundleContent).toBe(mergedBundleContent);
+      expect(systemCaBundleContent).toContain("system-root");
+      expect(systemCaBundleContent).toContain("BEGIN CERTIFICATE");
+      expect(systemCaBundleContent).not.toContain("DSEC_SECRET");
+      expect(systemCaBundleContent).not.toContain("DSEC_GARBAGE");
+      expect(systemCaBundleContent).not.toContain("DSEC_APPENDED");
       expect(mergedBundleContent).not.toContain("DSEC_SECRET");
       expect(mergedBundleContent).not.toContain("DSEC_GARBAGE");
       expect(mergedBundleContent).not.toContain("DSEC_APPENDED");
       expect(installedCaContent).not.toContain("DSEC_APPENDED");
+      expect(realpathSync(hashSymlink)).toBe(
+        realpathSync(join(systemCaDir, "dust-egress.crt"))
+      );
+
+      const secondRunResult = runInstaller();
+
+      if (secondRunResult.status !== 0) {
+        throw new Error(
+          `trust helper failed on second run:\nstdout:\n${secondRunResult.stdout}\nstderr:\n${secondRunResult.stderr}`
+        );
+      }
+
+      expect(readFileSync(systemCaBundle, "utf8")).toBe(systemCaBundleContent);
+      expect(readFileSync(mergedBundle, "utf8")).toBe(mergedBundleContent);
+      expect(readFileSync(join(systemCaDir, "dust-egress.crt"), "utf8")).toBe(
+        installedCaContent
+      );
+      expect(readlinkSync(hashSymlink)).toBe(hashSymlinkTarget);
+      expect(readdirSync(systemCaDir)).toEqual(["dust-egress.crt"]);
     } finally {
       rmSync(sandboxRoot, { recursive: true, force: true });
     }

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -19,7 +19,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.34";
+const DUST_BASE_IMAGE_VERSION = "0.8.35";
 const DSBX_CLI_VERSION = "0.1.25";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that

--- a/front/lib/api/sandbox/lifecycle.test.ts
+++ b/front/lib/api/sandbox/lifecycle.test.ts
@@ -65,6 +65,9 @@ function createDeferred<T>() {
     resolvePromise = resolve;
   });
 
+  // The Promise executor runs synchronously, so resolvePromise is always
+  // assigned by here. This guard is a type-narrowing crutch (avoids a `!`), not
+  // a reachable error path.
   if (!resolvePromise) {
     throw new Error("Deferred promise resolver was not initialized.");
   }

--- a/front/lib/api/sandbox/lifecycle.test.ts
+++ b/front/lib/api/sandbox/lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { Err, Ok } from "@app/types/shared/result";
+import { Err, Ok, type Result } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
@@ -59,6 +59,19 @@ vi.mock("@app/logger/logger", () => ({
 
 import { ensureSandboxReady } from "./lifecycle";
 
+function createDeferred<T>() {
+  let resolvePromise: ((value: T | PromiseLike<T>) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  if (!resolvePromise) {
+    throw new Error("Deferred promise resolver was not initialized.");
+  }
+
+  return { promise, resolve: resolvePromise };
+}
+
 describe("ensureSandboxReady", () => {
   const auth = { getNonNullableWorkspace: () => ({ sId: "workspace-id" }) };
   const conversation = { sId: "conversation-id" };
@@ -117,12 +130,42 @@ describe("ensureSandboxReady", () => {
       wokeFromSleep: false,
     });
 
-    expect(
-      mockPrepareSandboxEgressBeforeMount.mock.invocationCallOrder[0]
-    ).toBeLessThan(mockMountConversationFiles.mock.invocationCallOrder[0]);
     expect(mockMountConversationFiles.mock.invocationCallOrder[0]).toBeLessThan(
       mockEnsureSandboxEgressOnExec.mock.invocationCallOrder[0]
     );
+  });
+
+  it("starts GCS mount before initial egress prep resolves", async () => {
+    const prepStarted = createDeferred<void>();
+    const prepResult = createDeferred<Result<void, Error>>();
+    mockEnsureActive.mockResolvedValue(
+      new Ok({
+        freshlyCreated: true,
+        sandbox,
+        wokeFromSleep: false,
+      })
+    );
+    mockPrepareSandboxEgressBeforeMount.mockImplementation(() => {
+      prepStarted.resolve(undefined);
+      return prepResult.promise;
+    });
+
+    const resultPromise = ensureSandboxReady(
+      auth as never,
+      conversation as never
+    );
+
+    await prepStarted.promise;
+    await Promise.resolve();
+
+    expect(mockMountConversationFiles).toHaveBeenCalledTimes(1);
+    expect(mockEnsureSandboxEgressOnExec).not.toHaveBeenCalled();
+
+    prepResult.resolve(new Ok(undefined));
+    const result = await resultPromise;
+
+    expect(result.isOk()).toBe(true);
+    expect(mockEnsureSandboxEgressOnExec).toHaveBeenCalledTimes(1);
   });
 
   it("only refreshes the token (no remount) when the sandbox woke from sleep", async () => {
@@ -208,7 +251,8 @@ describe("ensureSandboxReady", () => {
     expect(mockGetSandboxImage).not.toHaveBeenCalled();
   });
 
-  it("short-circuits when initial egress prep fails", async () => {
+  it("returns the initial egress prep error after also running the GCS mount", async () => {
+    const setupError = new Error("setup failed");
     mockEnsureActive.mockResolvedValue(
       new Ok({
         freshlyCreated: true,
@@ -216,8 +260,33 @@ describe("ensureSandboxReady", () => {
         wokeFromSleep: false,
       })
     );
-    mockPrepareSandboxEgressBeforeMount.mockResolvedValue(
-      new Err(new Error("setup failed"))
+    mockPrepareSandboxEgressBeforeMount.mockResolvedValue(new Err(setupError));
+
+    const result = await ensureSandboxReady(
+      auth as never,
+      conversation as never
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBe(setupError);
+    }
+    expect(mockMountConversationFiles).toHaveBeenCalledTimes(1);
+    expect(mockEnsureSandboxEgressOnExec).not.toHaveBeenCalled();
+  });
+
+  it("returns the initial egress prep error when both initial phases fail", async () => {
+    const setupError = new Error("setup failed");
+    mockEnsureActive.mockResolvedValue(
+      new Ok({
+        freshlyCreated: true,
+        sandbox,
+        wokeFromSleep: false,
+      })
+    );
+    mockPrepareSandboxEgressBeforeMount.mockResolvedValue(new Err(setupError));
+    mockMountConversationFiles.mockResolvedValue(
+      new Err(new Error("mount failed"))
     );
 
     const result = await ensureSandboxReady(
@@ -226,8 +295,11 @@ describe("ensureSandboxReady", () => {
     );
 
     expect(result.isErr()).toBe(true);
-    expect(mockGetSandboxImage).not.toHaveBeenCalled();
-    expect(mockMountConversationFiles).not.toHaveBeenCalled();
+    if (result.isErr()) {
+      expect(result.error).toBe(setupError);
+    }
+    expect(mockMountConversationFiles).toHaveBeenCalledTimes(1);
+    expect(mockEnsureSandboxEgressOnExec).not.toHaveBeenCalled();
   });
 
   it("short-circuits when mounting conversation files fails", async () => {

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -50,22 +50,6 @@ export async function ensureSandboxReady(
       const { sandbox, freshlyCreated, wokeFromSleep } = ensureResult.value;
       cold = freshlyCreated;
 
-      // Egress prep must run BEFORE GCS mounts.
-      // sandbox_resource.buildSandboxEnvVars exports replace-style trust env
-      // vars pointing at /etc/dust/ca-bundle.pem. The image seeds that path
-      // with system roots; forwarder setup later merges in the dsbx CA.
-      // Mounting (gcsfuse and friends) can make HTTPS calls that read the
-      // trust bundle, so the path has to be valid first.
-      if (freshlyCreated) {
-        const prepResult = await traceSandboxStartupPhase("egress_prep", () =>
-          prepareSandboxEgressBeforeMount(auth, sandbox)
-        );
-        if (prepResult.isErr()) {
-          status = "error";
-          return prepResult;
-        }
-      }
-
       // Synchronous and cheap: not worth a span (it would always read ~0ms).
       const imageResult = getSandboxImage(auth);
       if (imageResult.isErr()) {
@@ -87,9 +71,22 @@ export async function ensureSandboxReady(
       // wake we just need a fresh GCS access token in /tmp/token.json (the
       // running token server will hand it to gcsfuse on the next request).
       if (freshlyCreated) {
-        const mountResult = await traceSandboxStartupPhase("gcs_mount", () =>
-          mountConversationFiles(auth, sandbox, conversation, image)
-        );
+        // The image seeds /etc/dust/ca-bundle.pem with system roots, and
+        // gcsfuse runs as root to storage.googleapis.com, which bypasses the
+        // uid-1003 nftables proxy rules. Egress prep can therefore overlap with
+        // the GCS mount while still keeping egress errors first.
+        const [prepResult, mountResult] = await Promise.all([
+          traceSandboxStartupPhase("egress_prep", () =>
+            prepareSandboxEgressBeforeMount(auth, sandbox)
+          ),
+          traceSandboxStartupPhase("gcs_mount", () =>
+            mountConversationFiles(auth, sandbox, conversation, image)
+          ),
+        ]);
+        if (prepResult.isErr()) {
+          status = "error";
+          return prepResult;
+        }
         if (mountResult.isErr()) {
           status = "error";
           return mountResult;

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -72,9 +72,13 @@ export async function ensureSandboxReady(
       // running token server will hand it to gcsfuse on the next request).
       if (freshlyCreated) {
         // The image seeds /etc/dust/ca-bundle.pem with system roots, and
-        // gcsfuse runs as root to storage.googleapis.com, which bypasses the
-        // uid-1003 nftables proxy rules. Egress prep can therefore overlap with
-        // the GCS mount while still keeping egress errors first.
+        // gcsfuse runs as root to storage.googleapis.com, which the in-sandbox
+        // nftables ruleset never touches: every rule is scoped to the agent uid
+        // (1003) and the chains default to accept, so root egress is never
+        // dropped, even mid-setup. The dev-unrestricted branch only tears the
+        // table down (loosening egress further), so it's safe to overlap too.
+        // Egress prep can therefore run alongside the GCS mount, with egress
+        // errors still taking precedence.
         const [prepResult, mountResult] = await Promise.all([
           traceSandboxStartupPhase("egress_prep", () =>
             prepareSandboxEgressBeforeMount(auth, sandbox)


### PR DESCRIPTION
## Description

Follow-up to #26654. Datadog showed the egress trust-bundle install as the single largest remaining cold-start cost: ~1.65s, almost entirely `update-ca-certificates`, which forks openssl once per system root to rebuild the whole CA store on the microVM.

Two changes:

- **Trust bundle (image):** stop calling `update-ca-certificates`. The image already ships the public roots; the per-sandbox dsbx MITM CA is the only runtime addition. The helper now snapshots the pristine system bundle once, rebuilds `/etc/ssl/certs/ca-certificates.crt` as pristine + dsbx CA, and drops in the single `SSL_CERT_DIR` hash symlink. Byte-identical trust outcome, ~tens of ms instead of ~1.65s. Idempotent across the health-probe repair path. Base image bumped to 0.8.35.
- **GCS/egress overlap (front):** run egress prep concurrently with the GCS mount on cold start. The mount only reaches `storage.googleapis.com` as root, which the in-sandbox nftables rules never touch (every rule is scoped to the agent uid 1003; chains default to accept), so it has no dependency on egress finishing. Egress errors still take precedence.

🚗 While in the trust helper, swapped `echo` for `/usr/bin/printf '%s\n'` (absolute path per SEC3, and immune to format-string surprises if the CA path ever contained `%`).

Expected: cold start ~2.2s (US) / ~3.1s (EU) down toward ~0.7s / ~1.6s, landing gradually as sandboxes cycle onto the new image.

## Tests

Extended the registry trust-helper execution test (it actually runs the script against a stubbed sandbox root) to assert the rebuilt system bundle contains the dsbx CA, the hash symlink resolves to it, and a second run is idempotent. Verified the nftables ruleset only scopes rules to the agent uid, so the parallel GCS mount as root is never transiently blocked.

## Risk

Trust path is security-sensitive. The new install keeps the system store byte-identical to what `update-ca-certificates` produced for our one CA, so no env-var-bypassing tool loses trust. A broken trust install fails closed (TLS errors), not open. The GCS/egress overlap is gated on cold create only and preserves egress-error-first semantics.

## Deploy Plan

Standard front deploy through the `deploy.yml` workflow (component `front`). No extra manual steps before merge beyond the image acknowledgment below.

What runs, in order:

1. **CI on the PR:** `build-and-test-front.yml` and the Danger checks (`danger-front`). The top-level `Danger` check gates on the `sandbox-image-ack` label because the PR touches `front/lib/api/sandbox/image/`. Label is added, so it passes.
2. **At deploy time**, `deploy.yml` runs the `ensure-sandbox-images` job first, which calls the `sandbox-img-registry.yml` workflow. Per region (eu, us) it runs `scripts/sandbox_image_check.ts`, sees `dust-base:0.8.35` is missing, and builds it via `scripts/sandbox_image_build.ts` into the E2B template registry. The front rollout only proceeds once that job succeeds.
3. **Front rolls out.** The `lifecycle.ts` GCS/egress overlap is front runtime code, so it takes effect immediately for all new cold starts, independent of image version.
4. **Post-deploy (manual):** open `/poke/kill` (Kill Switches) and kill older `dust-base` versions so existing conversations get fresh `0.8.35` sandboxes. This is the second half of the `sandbox-image-ack` commitment.

Watch `trace.sandbox.startup.egress.install_trust_bundle`, `egress_prep`, `gcs_mount`, and `sandbox.startup.total.duration{cold:true}` for the drop.

> [!NOTE]
> The trust-bundle change is baked into `dust-base:0.8.35`, so it only helps sandboxes created on the new image. Running sandboxes stay on `0.8.34` until cycled, so without the `/poke/kill` step the win lands only gradually as conversations naturally turn over.