### PR TITLE
fix(tests): await transaction.rollback() in vite setup to prevent pg concurrent query warning

### DIFF
--- a/connectors/vite.setup.ts
+++ b/connectors/vite.setup.ts
@@ -57,7 +57,7 @@ beforeEach(async (c) => {
 
 afterEach(async (c2) => {
   // @ts-expect-error - storing context in the test context
-  c2["transaction"].rollback();
+  await c2["transaction"].rollback();
   // @ts-expect-error - storing context in the test context
   c2["namespace"].exit(c2["context"]);
 });

--- a/front/vite.setup.ts
+++ b/front/vite.setup.ts
@@ -155,8 +155,8 @@ vi.mock("@app/lib/utils/cache", () => ({
   invalidateCacheAfterCommit: vi
     .fn()
     .mockImplementation(
-      (_transaction: unknown, invalidateFn: () => Promise<void>) => {
-        invalidateFn();
+      async (_transaction: unknown, invalidateFn: () => Promise<void>) => {
+        await invalidateFn();
       }
     ),
 }));
@@ -249,7 +249,7 @@ beforeEach(async (c) => {
 afterEach(async (c2) => {
   if ("transaction" in c2) {
     // @ts-expect-error - storing context in the test context
-    c2["transaction"].rollback();
+    await c2["transaction"].rollback();
   }
   if ("namespace" in c2) {
     // @ts-expect-error - storing context in the test context


### PR DESCRIPTION
## Description

Fix a race condition in test setup that caused the `pg` deprecation warning:
> Calling client.query() when the client is already executing a query is deprecated and will be removed in pg@9.0.

In both `front/vite.setup.ts` and `connectors/vite.setup.ts`, `afterEach` called `transaction.rollback()` without `await`. The `ROLLBACK` query was dispatched to the pg client but the hook returned immediately, so the next test's `beforeEach` could send `BEGIN` on the same connection before `ROLLBACK` completed — exactly the race pg warns about.

Also fixed a secondary issue in `front/vite.setup.ts`: the `invalidateCacheAfterCommit` mock was calling `invalidateFn()` without `await`, which could cause unawaited async work to race against the active transaction.

## Tests

Already covered by the existing test suites — the warning should no longer appear in CI output.
