### PR TITLE
Add tool for self-improving skill agent to discover skills

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -59,6 +59,10 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
+    "describe_skill": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
     "get_agent_feedback": {
       "freeUsage": true,
       "toolCostCategory": "basic",

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -2525,6 +2525,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   },
   "agent_sidekick_context": {
     "describe_mcp": "never_ask",
+    "describe_skill": "never_ask",
     "get_agent_feedback": "never_ask",
     "get_agent_insights": "never_ask",
     "get_agent_template": "never_ask",

--- a/front/lib/api/actions/servers/agent_sidekick_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/metadata.ts
@@ -7,7 +7,10 @@ import {
   MAX_PENDING_SUB_AGENT_SUGGESTIONS,
   MAX_PENDING_TOOLS_SUGGESTIONS,
 } from "@app/lib/api/actions/servers/agent_sidekick_context/constants";
-import { DESCRIBE_MCP_TOOL_NAME } from "@app/lib/reinforcement/types";
+import {
+  DESCRIBE_MCP_TOOL_NAME,
+  DESCRIBE_SKILL_TOOL_NAME,
+} from "@app/lib/reinforcement/types";
 import { MODEL_IDS } from "@app/types/assistant/models/models";
 import { ORDERED_REASONING_EFFORTS } from "@app/types/assistant/models/reasoning";
 import {
@@ -158,6 +161,18 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
     },
     toolCostCategory: "basic",
     freeUsage: true,
+  },
+  [DESCRIBE_SKILL_TOOL_NAME]: {
+    description:
+      "Get detailed information about a skill: its name, description, instructions, and configured tools.",
+    schema: {
+      skillId: z.string().describe("The sId of the skill to describe"),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Describing skill",
+      done: "Describe skill",
+    },
   },
   get_available_agents: {
     description:

--- a/front/lib/api/actions/servers/agent_sidekick_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/metadata.ts
@@ -173,6 +173,8 @@ export const AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA = createToolsRecord({
       running: "Describing skill",
       done: "Describe skill",
     },
+    toolCostCategory: "basic",
+    freeUsage: true,
   },
   get_available_agents: {
     description:

--- a/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/tools/index.ts
@@ -24,16 +24,33 @@ import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { renderConversationAsTextWithFeedback } from "@app/lib/api/assistant/conversation/render_conversation_with_feedback";
 import type { AgentMessageFeedbackWithMetadataType } from "@app/lib/api/assistant/feedback";
 import { getAgentFeedbacks } from "@app/lib/api/assistant/feedback";
+import {
+  formatAvailableModels,
+  formatAvailableSkills,
+  formatAvailableTools,
+  formatMcpDescription,
+} from "@app/lib/api/assistant/global_agents/sidekick_context";
 import { fetchAgentOverview } from "@app/lib/api/assistant/observability/overview";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import {
   formatTemplatesAsText,
   getTemplatesForSidekick,
 } from "@app/lib/api/assistant/sidekick_templates";
+import {
+  describeMcpServer,
+  getAvailableModelsForWorkspace,
+  listAvailableSkills,
+  listAvailableTools,
+} from "@app/lib/api/assistant/workspace_capabilities";
 import config from "@app/lib/api/config";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import type { Authenticator } from "@app/lib/auth";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
+import { formatSkillContext } from "@app/lib/reinforcement/format_skill_context";
+import {
+  DESCRIBE_MCP_TOOL_NAME,
+  DESCRIBE_SKILL_TOOL_NAME,
+} from "@app/lib/reinforcement/types";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -77,6 +94,7 @@ import {
   isToolsSuggestion,
 } from "@app/types/suggestions/agent_suggestion";
 import { JSDOM } from "jsdom";
+import type { z } from "zod";
 
 const SIDEKICK_KNOWLEDGE_CATEGORIES: DataSourceViewCategory[] = [
   "managed",
@@ -510,21 +528,6 @@ export async function createSkillsSuggestions({
   return new Ok(createdSuggestions);
 }
 
-import {
-  formatAvailableModels,
-  formatAvailableSkills,
-  formatAvailableTools,
-  formatMcpDescription,
-} from "@app/lib/api/assistant/global_agents/sidekick_context";
-import {
-  describeMcpServer,
-  getAvailableModelsForWorkspace,
-  listAvailableSkills,
-  listAvailableTools,
-} from "@app/lib/api/assistant/workspace_capabilities";
-import { DESCRIBE_MCP_TOOL_NAME } from "@app/lib/reinforcement/types";
-import type { z } from "zod";
-
 /**
  * Lists all knowledge data source views across all spaces the user has access to.
  * Filters to knowledge categories (managed, folder, website), with optional category narrowing.
@@ -602,6 +605,21 @@ const handlers: ToolHandlers<typeof AGENT_SIDEKICK_CONTEXT_TOOLS_METADATA> = {
     }
     return new Ok([
       { type: "text" as const, text: formatMcpDescription(mcpId, server) },
+    ]);
+  },
+
+  [DESCRIBE_SKILL_TOOL_NAME]: async ({ skillId }, { auth }) => {
+    const skill = await SkillResource.fetchById(auth, skillId);
+    if (!skill) {
+      return new Ok([
+        { type: "text" as const, text: `Skill not found: ${skillId}` },
+      ]);
+    }
+    return new Ok([
+      {
+        type: "text" as const,
+        text: formatSkillContext(skill.toJSON(auth)),
+      },
     ]);
   },
 

--- a/front/lib/reinforcement/analyze_conversation.ts
+++ b/front/lib/reinforcement/analyze_conversation.ts
@@ -40,6 +40,7 @@ Propose configuration changes only when <analysis_workflow> yields concrete evid
 ## Exploration tools (optional — use these if you need more context)
 - get_available_tools: ALWAYS call this before embedding any <tool> tag in an instruction edit — the tag requires an MCP server view ID and name that must come from this tool. See <tool_references> for more details.
 - describe_mcp: ALWAYS call this before suggesting instruction changes that reference specific tool names or workflows for a given MCP — you need to know the exact tool names and their inputs to write accurate instructions.
+- describe_skill: Use this to get the full details (instructions, tools, description) of a skill referenced in the conversation or inlined in another skill's instructions. Call this when you see a <skill> tag with an ID attribute and need to understand what the skill does before suggesting changes.
 - search_knowledge: ALWAYS call this before embedding any <knowledge> tag in an instruction edit — the tag requires node attributes (id, space, dsv, hasChildren) that must come from this tool. Use this whenever the conversation shows the agent navigating or retrieving specific data nodes that the skill instructions should directly reference. See <knowledge_nodes> for more details.
 `,
 

--- a/front/lib/reinforcement/run_reinforced_analysis.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.ts
@@ -14,6 +14,7 @@ import {
 import {
   ALL_TOOLS,
   DESCRIBE_MCP_TOOL_NAME,
+  DESCRIBE_SKILL_TOOL_NAME,
   type ExploratoryToolCallInfo,
   getEditSkillToolSchema,
   getReinforcedSkillsMetadata,
@@ -58,6 +59,13 @@ function buildReinforcedSkillsToolDefinitions(): Record<
         "Get detailed information about a specific MCP server: its description, and each tool's name, description, and input parameters. Use this to understand what a tool can do before suggesting instruction changes that reference it.",
       schema: z.object({
         mcpId: z.string().describe("The sId of the MCP server to describe"),
+      }),
+    },
+    [DESCRIBE_SKILL_TOOL_NAME]: {
+      description:
+        "Get detailed information about a skill referenced in the conversation or in another skill's instructions. Returns the skill's name, description, instructions, and configured tools.",
+      schema: z.object({
+        skillId: z.string().describe("The sId of the skill to describe"),
       }),
     },
     search_knowledge: {

--- a/front/lib/reinforcement/types.ts
+++ b/front/lib/reinforcement/types.ts
@@ -2,11 +2,13 @@ import type { ToolCallEvent } from "@app/lib/api/llm/types/events";
 import { z } from "zod";
 
 export const DESCRIBE_MCP_TOOL_NAME = "describe_mcp" as const;
+export const DESCRIBE_SKILL_TOOL_NAME = "describe_skill" as const;
 
 export type ExploratoryToolName =
   | "get_available_tools"
   | "search_knowledge"
-  | typeof DESCRIBE_MCP_TOOL_NAME;
+  | typeof DESCRIBE_MCP_TOOL_NAME
+  | typeof DESCRIBE_SKILL_TOOL_NAME;
 
 export type TerminalToolName = "edit_skill" | "reject_suggestion";
 
@@ -19,6 +21,7 @@ export const EXPLORATORY_TOOLS: ExploratoryToolName[] = [
   "get_available_tools",
   "search_knowledge",
   DESCRIBE_MCP_TOOL_NAME,
+  DESCRIBE_SKILL_TOOL_NAME,
 ];
 
 export const ALL_TOOLS = [...TERMINAL_TOOLS, ...EXPLORATORY_TOOLS];

--- a/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
+++ b/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
@@ -12,12 +12,17 @@ import type { Authenticator } from "@app/lib/auth";
 import { buildSkillAggregationPrompt } from "@app/lib/reinforcement/aggregate_suggestions";
 import { buildSkillAnalysisPrompt } from "@app/lib/reinforcement/analyze_conversation";
 import { MAX_REINFORCED_ANALYSIS_STEPS } from "@app/lib/reinforcement/constants";
+import { formatSkillContext } from "@app/lib/reinforcement/format_skill_context";
 import {
   buildReinforcedSkillsLLMParams,
   classifySkillToolCalls,
 } from "@app/lib/reinforcement/run_reinforced_analysis";
 import { convertMarkdownToBlockHtml } from "@app/lib/reinforcement/skill_instructions_html";
-import { DESCRIBE_MCP_TOOL_NAME } from "@app/lib/reinforcement/types";
+import {
+  DESCRIBE_MCP_TOOL_NAME,
+  DESCRIBE_SKILL_TOOL_NAME,
+  isExploratoryToolName,
+} from "@app/lib/reinforcement/types";
 import { buildContinuationMessages } from "@app/lib/reinforcement/utils";
 import {
   BATCH_POLL_INTERVAL_MS,
@@ -38,6 +43,7 @@ import {
   type WorkspaceContext,
 } from "@app/tests/reinforcement-evals/lib/types";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
 
 function makeSkillType(config: MockSkillConfig): SkillType {
@@ -90,6 +96,35 @@ function makeSkillType(config: MockSkillConfig): SkillType {
     fileAttachments: [],
     canWrite: false,
     isDefault: false,
+  };
+}
+
+/**
+ * Build the effective workspace context by merging the test case's skill configs
+ * into workspaceContext.skillConfigs, so describe_skill can resolve them.
+ */
+function buildEffectiveWorkspaceContext(testCase: TestCase): WorkspaceContext {
+  const testSkillConfigs = isAnalysisTestCase(testCase)
+    ? testCase.skillConfigs
+    : [testCase.skillConfig];
+
+  const existingSkillIds = new Set(
+    (testCase.workspaceContext.skillConfigs ?? []).map((s) => s.sId)
+  );
+  const newSkillConfigs = testSkillConfigs.filter(
+    (s) => !existingSkillIds.has(s.sId)
+  );
+
+  if (newSkillConfigs.length === 0) {
+    return testCase.workspaceContext;
+  }
+
+  return {
+    ...testCase.workspaceContext,
+    skillConfigs: [
+      ...(testCase.workspaceContext.skillConfigs ?? []),
+      ...newSkillConfigs,
+    ],
   };
 }
 
@@ -180,6 +215,10 @@ function simulateExploratoryTool(
   args: Record<string, unknown>,
   workspaceContext: WorkspaceContext
 ): string {
+  if (!isExploratoryToolName(toolName)) {
+    throw new Error(`Unknown exploratory tool: ${toolName}`);
+  }
+
   switch (toolName) {
     case "get_available_tools":
       return formatAvailableTools(workspaceContext.tools);
@@ -200,6 +239,19 @@ function simulateExploratoryTool(
         mcpId,
         mockDescriptionToFormatInput(mcpName, desc)
       );
+    }
+    case DESCRIBE_SKILL_TOOL_NAME: {
+      const skillId = args["skillId"];
+      if (!isString(skillId)) {
+        return "Error: skillId parameter is required";
+      }
+      const skillConfig = workspaceContext.skillConfigs?.find(
+        (s) => s.sId === skillId
+      );
+      if (!skillConfig) {
+        return `Skill not found: ${skillId}`;
+      }
+      return formatSkillContext(makeSkillType(skillConfig));
     }
     case "search_knowledge": {
       const nodes = workspaceContext.searchKnowledgeNodes ?? [];
@@ -222,7 +274,7 @@ function simulateExploratoryTool(
       return JSON.stringify({ dataSourceViews, nodes }, null, 2);
     }
     default:
-      return `Unknown exploratory tool: ${toolName}`;
+      assertNever(toolName);
   }
 }
 
@@ -338,7 +390,7 @@ export async function executeReinforced(
   return executeMultiStep(
     llm,
     params,
-    testCase.workspaceContext,
+    buildEffectiveWorkspaceContext(testCase),
     testCase.scenarioId
   );
 }
@@ -372,9 +424,9 @@ export async function executeBatch(
 ): Promise<Map<string, ExecutionResult>> {
   const llm = await getLLMInstance(auth, "batch");
 
-  const testCaseById = new Map<string, CategorizedTestCase>();
+  const effectiveContextById = new Map<string, WorkspaceContext>();
   for (const tc of testCases) {
-    testCaseById.set(tc.scenarioId, tc);
+    effectiveContextById.set(tc.scenarioId, buildEffectiveWorkspaceContext(tc));
   }
 
   // Build initial params for all test cases.
@@ -422,13 +474,13 @@ export async function executeBatch(
           );
         }
         // Simulate tool responses and prepare continuation params.
-        const tc = testCaseById.get(scenarioId)!;
+        const effectiveContext = effectiveContextById.get(scenarioId)!;
         const toolResultsMap: Record<string, string> = {};
         for (const toolCall of exploratoryToolCalls) {
           toolResultsMap[toolCall.id] = simulateExploratoryTool(
             toolCall.name,
             toolCall.arguments,
-            tc.workspaceContext
+            effectiveContext
           );
         }
         if (VERBOSE) {

--- a/front/tests/reinforcement-evals/lib/types.ts
+++ b/front/tests/reinforcement-evals/lib/types.ts
@@ -44,6 +44,8 @@ export interface WorkspaceContext {
   mcpDescriptions?: MockMcpDescription[];
   /** Optional knowledge nodes returned when search_knowledge is called during eval. */
   searchKnowledgeNodes?: MockSearchKnowledgeNode[];
+  /** Optional skill configs returned when describe_skill is called during eval. */
+  skillConfigs?: MockSkillConfig[];
 }
 
 function slugify(name: string): string {


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/8515
 
skills can be inlined either in a conversation message or in another skill's description.
We need a way for the self-improving agent to get the content of these skills.
The PR add a new MCP function for that.
Note that it also add the function to sidekick, but I think it is legit.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low

## Deploy Plan

deploy front
