### PR TITLE
feat(mobile): rename Projects to Pods, add conversation previews

### DIFF
--- a/x/adrsimon/mobile/Dust/Models/Conversation.swift
+++ b/x/adrsimon/mobile/Dust/Models/Conversation.swift
@@ -7,13 +7,22 @@ extension Double {
     }
 }
 
-struct Conversation: Codable, Identifiable, Hashable {
+/// `nil` for endpoints that omit `content` (e.g. the inbox list).
+struct ConversationPreview: Codable, Hashable {
+    let authorName: String?
+    let authorAvatarUrl: String?
+    let snippet: String?
+    let replyCount: Int
+}
+
+struct Conversation: Decodable, Identifiable, Hashable {
     let sId: String
     let created: Double
     let updated: Double
     let title: String?
     var unread: Bool
     var actionRequired: Bool
+    let preview: ConversationPreview?
 
     var id: String {
         sId
@@ -30,9 +39,95 @@ struct Conversation: Codable, Identifiable, Hashable {
     var effectiveDate: Date {
         updated > 0 ? updatedDate : createdDate
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case sId, created, updated, title, unread, actionRequired, content
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.sId = try container.decode(String.self, forKey: .sId)
+        self.created = try container.decode(Double.self, forKey: .created)
+        self.updated = try container.decode(Double.self, forKey: .updated)
+        self.title = try container.decodeIfPresent(String.self, forKey: .title)
+        self.unread = try container.decode(Bool.self, forKey: .unread)
+        self.actionRequired = try container.decode(Bool.self, forKey: .actionRequired)
+
+        let content = try container.decodeIfPresent([PreviewMessage].self, forKey: .content)
+        self.preview = content.flatMap(ConversationPreview.init(content:))
+    }
 }
 
-struct ConversationsResponse: Codable {
+// MARK: - Preview derivation from the conversation `content` array
+
+/// Fields beyond `type` are optional so this absorbs user, agent and compaction messages alike.
+private struct PreviewMessage: Decodable {
+    struct User: Decodable {
+        let fullName: String?
+        let image: String?
+    }
+
+    struct Context: Decodable {
+        let fullName: String?
+        let profilePictureUrl: String?
+    }
+
+    struct Configuration: Decodable {
+        let name: String?
+        let pictureUrl: String?
+    }
+
+    static let visibleUserVisibility = "visible"
+
+    let type: String
+    let content: String?
+    let visibility: String?
+    let status: String?
+    let user: User?
+    let context: Context?
+    let configuration: Configuration?
+
+    /// Mirrors the `validMessages` filter in the web front-end.
+    var isValid: Bool {
+        switch type {
+        case MessageType.userMessage.rawValue:
+            visibility == Self.visibleUserVisibility
+        case MessageType.agentMessage.rawValue:
+            status == AgentMessageStatus.succeeded.rawValue
+        default:
+            false
+        }
+    }
+}
+
+private extension ConversationPreview {
+    init?(content: [PreviewMessage]) {
+        let valid = content.filter(\.isValid)
+        guard let first = valid.first else { return nil }
+
+        switch first.type {
+        case MessageType.agentMessage.rawValue:
+            self.authorName = first.configuration?.name.map { "@\($0)" }
+            self.authorAvatarUrl = first.configuration?.pictureUrl
+        default:
+            self.authorName = first.user?.fullName ?? first.context?.fullName
+            self.authorAvatarUrl = first.user?.image ?? first.context?.profilePictureUrl
+        }
+        self.snippet = first.content?.strippedSnippet
+        self.replyCount = max(0, valid.count - 1)
+    }
+}
+
+private extension String {
+    static let leadingMarkdownMarkers = "#>-*` "
+
+    var strippedSnippet: String {
+        let collapsed = split(whereSeparator: \.isWhitespace).joined(separator: " ")
+        return String(collapsed.drop(while: { Self.leadingMarkdownMarkers.contains($0) }))
+    }
+}
+
+struct ConversationsResponse: Decodable {
     let conversations: [Conversation]
     let hasMore: Bool
     let lastValue: String?

--- a/x/adrsimon/mobile/Dust/Models/Message.swift
+++ b/x/adrsimon/mobile/Dust/Models/Message.swift
@@ -23,6 +23,7 @@ struct UserMessage: Codable, Identifiable {
     let version: Int
     let rank: Int
     let content: String
+    let user: MessageUser?
     let context: UserMessageContext?
     let contentFragments: [ContentFragment]?
 
@@ -33,6 +34,20 @@ struct UserMessage: Codable, Identifiable {
     var createdDate: Date {
         created.dateFromEpochMs
     }
+
+    /// `context` picture is often absent for other people's messages, so prefer `user`.
+    var authorAvatarUrl: String? {
+        user?.image ?? context?.profilePictureUrl
+    }
+
+    var authorName: String? {
+        user?.fullName ?? context?.fullName ?? context?.username
+    }
+}
+
+struct MessageUser: Codable {
+    let fullName: String?
+    let image: String?
 }
 
 struct UserMessageContext: Codable {
@@ -343,4 +358,35 @@ struct ConversationMessagesResponse: Decodable {
     let messages: [ConversationMessage]
     let hasMore: Bool
     let lastValue: Int?
+
+    private enum CodingKeys: String, CodingKey {
+        case messages, hasMore, lastValue
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.hasMore = try container.decode(Bool.self, forKey: .hasMore)
+        self.lastValue = try container.decodeIfPresent(Int.self, forKey: .lastValue)
+        self.messages = try container.decode([RenderableMessage].self, forKey: .messages).compactMap(\.message)
+    }
+}
+
+/// Skips unrenderable types (e.g. `compaction_message`) but lets a renderable message that
+/// fails to decode throw, so schema drift surfaces instead of dropping messages silently.
+private struct RenderableMessage: Decodable {
+    let message: ConversationMessage?
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+    }
+
+    init(from decoder: Decoder) throws {
+        let type = try decoder.container(keyedBy: CodingKeys.self).decode(String.self, forKey: .type)
+        switch type {
+        case MessageType.userMessage.rawValue, MessageType.agentMessage.rawValue:
+            self.message = try ConversationMessage(from: decoder)
+        default:
+            self.message = nil
+        }
+    }
 }

--- a/x/adrsimon/mobile/Dust/Models/Space.swift
+++ b/x/adrsimon/mobile/Dust/Models/Space.swift
@@ -5,9 +5,23 @@ struct Space: Codable, Identifiable, Hashable {
     let name: String
     let kind: String
     let description: String?
+    let isRestricted: Bool
 
     var id: String {
         sId
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case sId, name, kind, description, isRestricted
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.sId = try container.decode(String.self, forKey: .sId)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.kind = try container.decode(String.self, forKey: .kind)
+        self.description = try container.decodeIfPresent(String.self, forKey: .description)
+        self.isRestricted = try container.decodeIfPresent(Bool.self, forKey: .isRestricted) ?? false
     }
 }
 

--- a/x/adrsimon/mobile/Dust/Services/SpaceService.swift
+++ b/x/adrsimon/mobile/Dust/Services/SpaceService.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum SpaceService {
-    static func fetchProjects(
+    static func fetchPods(
         workspaceId: String,
         tokenProvider: TokenProvider
     ) async throws -> [Space] {

--- a/x/adrsimon/mobile/Dust/ViewModels/ConversationDetailViewModel.swift
+++ b/x/adrsimon/mobile/Dust/ViewModels/ConversationDetailViewModel.swift
@@ -211,6 +211,7 @@ final class ConversationDetailViewModel: ObservableObject {
             version: 0,
             rank: nextRank,
             content: content,
+            user: nil,
             context: UserMessageContext(username: nil, fullName: nil, email: userEmail, profilePictureUrl: nil),
             contentFragments: nil
         )

--- a/x/adrsimon/mobile/Dust/ViewModels/ConversationListViewModel.swift
+++ b/x/adrsimon/mobile/Dust/ViewModels/ConversationListViewModel.swift
@@ -79,8 +79,8 @@ final class ConversationListViewModel: ObservableObject {
     @Published var searchText: String = ""
     @Published var workspace: Workspace?
     @Published var workspaces: [Workspace] = []
-    @Published var projects: [Space] = []
-    @Published var isProjectsExpanded: Bool = true
+    @Published var pods: [Space] = []
+    @Published var isPodsExpanded: Bool = true
 
     private let tokenProvider: TokenProvider
 
@@ -102,9 +102,9 @@ final class ConversationListViewModel: ObservableObject {
 
             workspace = dustUser.workspaces.first { $0.sId == workspaceId }
             async let convosTask: Void = loadConversations()
-            async let projectsTask: Void = loadProjects()
+            async let podsTask: Void = loadPods()
             try await convosTask
-            await projectsTask
+            await podsTask
         } catch {
             logger.error("Failed to load conversations: \(error)")
             state = .error(error.localizedDescription)
@@ -114,13 +114,13 @@ final class ConversationListViewModel: ObservableObject {
     func switchWorkspace(_ newWorkspace: Workspace) async {
         workspace = newWorkspace
         conversations = []
-        projects = []
+        pods = []
         state = .loading
         do {
             async let convosTask: Void = loadConversations()
-            async let projectsTask: Void = loadProjects()
+            async let podsTask: Void = loadPods()
             try await convosTask
-            await projectsTask
+            await podsTask
         } catch {
             logger.error("Failed to load conversations: \(error)")
             state = .error(error.localizedDescription)
@@ -130,9 +130,9 @@ final class ConversationListViewModel: ObservableObject {
     func refresh() async {
         do {
             async let convosTask: Void = loadConversations()
-            async let projectsTask: Void = loadProjects()
+            async let podsTask: Void = loadPods()
             try await convosTask
-            await projectsTask
+            await podsTask
         } catch {
             logger.error("Failed to refresh conversations: \(error)")
         }
@@ -148,15 +148,15 @@ final class ConversationListViewModel: ObservableObject {
         state = .loaded
     }
 
-    private func loadProjects() async {
+    private func loadPods() async {
         guard let workspaceId = workspace?.sId else { return }
         do {
-            projects = try await SpaceService.fetchProjects(
+            pods = try await SpaceService.fetchPods(
                 workspaceId: workspaceId,
                 tokenProvider: tokenProvider
             )
         } catch {
-            logger.error("Failed to load projects: \(error)")
+            logger.error("Failed to load pods: \(error)")
         }
     }
 

--- a/x/adrsimon/mobile/Dust/ViewModels/PodConversationsViewModel.swift
+++ b/x/adrsimon/mobile/Dust/ViewModels/PodConversationsViewModel.swift
@@ -1,10 +1,10 @@
 import Foundation
 import os
 
-private let logger = Logger(subsystem: AppConfig.bundleId, category: "ProjectConversations")
+private let logger = Logger(subsystem: AppConfig.bundleId, category: "PodConversations")
 
 @MainActor
-final class ProjectConversationsViewModel: ObservableObject {
+final class PodConversationsViewModel: ObservableObject {
     enum State {
         case loading
         case loaded
@@ -30,7 +30,7 @@ final class ProjectConversationsViewModel: ObservableObject {
         do {
             try await loadConversations()
         } catch {
-            logger.error("Failed to load project conversations: \(error)")
+            logger.error("Failed to load pod conversations: \(error)")
             state = .error(error.localizedDescription)
         }
     }
@@ -39,7 +39,7 @@ final class ProjectConversationsViewModel: ObservableObject {
         do {
             try await loadConversations()
         } catch {
-            logger.error("Failed to refresh project conversations: \(error)")
+            logger.error("Failed to refresh pod conversations: \(error)")
         }
     }
 
@@ -49,7 +49,8 @@ final class ProjectConversationsViewModel: ObservableObject {
             spaceId: space.sId,
             tokenProvider: tokenProvider
         )
-        conversations = response.conversations
+        // Hide conversations without a visible first message (e.g. compaction-only), as front does.
+        conversations = response.conversations.filter { $0.preview != nil }
         state = .loaded
     }
 

--- a/x/adrsimon/mobile/Dust/Views/Components/Avatar.swift
+++ b/x/adrsimon/mobile/Dust/Views/Components/Avatar.swift
@@ -6,21 +6,31 @@ struct Avatar: View {
     var size: CGFloat = 24
 
     var body: some View {
-        AsyncImage(url: url.flatMap { URL(string: $0) }) { image in
-            image
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-        } placeholder: {
+        if let emojiAvatar = url.flatMap({ EmojiAvatar(urlString: $0) }) {
             Circle()
-                .fill(Color.dustFaint.opacity(0.3))
+                .fill(emojiAvatar.backgroundColor)
+                .frame(width: size, height: size)
                 .overlay {
-                    SparkleIcon.user.image
-                        .resizable()
-                        .frame(width: size * 0.5, height: size * 0.5)
-                        .foregroundStyle(Color.dustFaint)
+                    Text(emojiAvatar.emoji)
+                        .font(.system(size: size * 0.55))
                 }
+        } else {
+            AsyncImage(url: url.flatMap { URL(string: $0) }) { image in
+                image
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            } placeholder: {
+                Circle()
+                    .fill(Color.dustFaint.opacity(0.3))
+                    .overlay {
+                        SparkleIcon.user.image
+                            .resizable()
+                            .frame(width: size * 0.5, height: size * 0.5)
+                            .foregroundStyle(Color.dustFaint)
+                    }
+            }
+            .frame(width: size, height: size)
+            .clipShape(Circle())
         }
-        .frame(width: size, height: size)
-        .clipShape(Circle())
     }
 }

--- a/x/adrsimon/mobile/Dust/Views/Components/ConversationRowView.swift
+++ b/x/adrsimon/mobile/Dust/Views/Components/ConversationRowView.swift
@@ -5,16 +5,29 @@ struct ConversationRowView: View {
     let conversation: Conversation
 
     var body: some View {
+        if let preview = conversation.preview {
+            previewRow(preview)
+        } else {
+            titleRow
+        }
+    }
+
+    @ViewBuilder
+    private var statusDot: some View {
+        if conversation.actionRequired {
+            Circle()
+                .fill(Color.golden400)
+                .frame(width: 8, height: 8)
+        } else if conversation.unread {
+            Circle()
+                .fill(Color.highlight500)
+                .frame(width: 8, height: 8)
+        }
+    }
+
+    private var titleRow: some View {
         HStack(spacing: 6) {
-            if conversation.actionRequired {
-                Circle()
-                    .fill(Color.golden400)
-                    .frame(width: 8, height: 8)
-            } else if conversation.unread {
-                Circle()
-                    .fill(Color.highlight500)
-                    .frame(width: 8, height: 8)
-            }
+            statusDot
 
             Text(conversation.title ?? "New conversation")
                 .sparkleCopySm()
@@ -22,6 +35,42 @@ struct ConversationRowView: View {
                 .lineLimit(1)
                 .truncationMode(.tail)
                 .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    private func previewRow(_ preview: ConversationPreview) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Avatar(url: preview.authorAvatarUrl, size: 32)
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    statusDot
+
+                    Text(conversation.title ?? "New conversation")
+                        .sparkleCopySm()
+                        .foregroundStyle(Color.dustForeground)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
+                if let snippet = preview.snippet, !snippet.isEmpty {
+                    Text(snippet)
+                        .sparkleCopySm()
+                        .foregroundStyle(Color.dustFaint)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
+                if preview.replyCount > 0 {
+                    Text("\(preview.replyCount) \(preview.replyCount == 1 ? "reply" : "replies")")
+                        .sparkleLabelXs()
+                        .foregroundStyle(Color.dustFaint)
+                }
+            }
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)

--- a/x/adrsimon/mobile/Dust/Views/Components/EmojiAvatar.swift
+++ b/x/adrsimon/mobile/Dust/Views/Components/EmojiAvatar.swift
@@ -1,0 +1,102 @@
+import SparkleTokens
+import SwiftUI
+
+/// Dust encodes emoji-based avatars as URLs of the form
+/// `.../emojis/bg-{color}-{shade}/{id}/{unified}` rather than real image files.
+/// The web client parses these and renders the native emoji on a Tailwind
+/// background; there is no image to fetch (the URL 404s). This mirrors that
+/// parsing so the mobile `Avatar` can render the emoji instead of a placeholder.
+struct EmojiAvatar {
+    let emoji: String
+    let backgroundColor: Color
+
+    init?(urlString: String) {
+        guard let range = urlString.range(of: "/emojis/bg-") else {
+            return nil
+        }
+        let parts = urlString[range.upperBound...].split(separator: "/")
+        guard parts.count >= 3 else {
+            return nil
+        }
+
+        let unified = parts[2].prefix { $0 != "." && $0 != "?" }
+        guard let emoji = Self.emoji(fromUnified: String(unified)) else {
+            return nil
+        }
+
+        // The emoji is the content: render it even when the background color is
+        // an unknown Tailwind family, falling back to a neutral background.
+        self.emoji = emoji
+        self.backgroundColor = Self.backgroundColor(for: String(parts[0])) ?? .gray100
+    }
+
+    /// `unified` is a hyphen-separated list of hex Unicode code points
+    /// (e.g. `1f468-200d-1f4bb`); concatenating the scalars rebuilds the emoji.
+    private static func emoji(fromUnified unified: String) -> String? {
+        var scalars = String.UnicodeScalarView()
+        for segment in unified.split(separator: "-") {
+            guard let code = UInt32(segment, radix: 16),
+                  let scalar = Unicode.Scalar(code)
+            else {
+                return nil
+            }
+            scalars.append(scalar)
+        }
+        return scalars.isEmpty ? nil : String(scalars)
+    }
+
+    /// Maps a `{color}-{shade}` token (e.g. `pink-300`) to the matching Sparkle
+    /// palette color (shades 100…800). Stock/legacy Tailwind family names are
+    /// aliased to the nearest Sparkle family, mirroring how the web's Tailwind
+    /// config aliases e.g. `amber`→`golden` and `sky`→`blue`.
+    private static func backgroundColor(for token: String) -> Color? {
+        let components = token.split(separator: "-")
+        guard components.count == 2, let shade = Int(components[1]) else {
+            return nil
+        }
+        let family = familyAliases[String(components[0])] ?? String(components[0])
+        let index = shade / 100 - 1
+        guard let palette = palettes[family], palette.indices.contains(index) else {
+            return nil
+        }
+        return palette[index]
+    }
+
+    private static let familyAliases: [String: String] = [
+        "yellow": "golden",
+        "amber": "golden",
+        "sky": "blue",
+        "cyan": "blue",
+        "teal": "emerald",
+        "indigo": "violet",
+        "purple": "violet",
+        "fuchsia": "pink",
+        "slate": "gray",
+        "zinc": "gray",
+        "neutral": "gray",
+        "stone": "gray",
+    ]
+
+    private static let palettes: [String: [Color]] = [
+        "gray": [.gray100, .gray200, .gray300, .gray400, .gray500, .gray600, .gray700, .gray800],
+        "blue": [.blue100, .blue200, .blue300, .blue400, .blue500, .blue600, .blue700, .blue800],
+        "violet": [.violet100, .violet200, .violet300, .violet400, .violet500, .violet600, .violet700, .violet800],
+        "pink": [.pink100, .pink200, .pink300, .pink400, .pink500, .pink600, .pink700, .pink800],
+        "rose": [.rose100, .rose200, .rose300, .rose400, .rose500, .rose600, .rose700, .rose800],
+        "red": [.red100, .red200, .red300, .red400, .red500, .red600, .red700, .red800],
+        "orange": [.orange100, .orange200, .orange300, .orange400, .orange500, .orange600, .orange700, .orange800],
+        "golden": [.golden100, .golden200, .golden300, .golden400, .golden500, .golden600, .golden700, .golden800],
+        "lime": [.lime100, .lime200, .lime300, .lime400, .lime500, .lime600, .lime700, .lime800],
+        "green": [.green100, .green200, .green300, .green400, .green500, .green600, .green700, .green800],
+        "emerald": [
+            .emerald100,
+            .emerald200,
+            .emerald300,
+            .emerald400,
+            .emerald500,
+            .emerald600,
+            .emerald700,
+            .emerald800,
+        ],
+    ]
+}

--- a/x/adrsimon/mobile/Dust/Views/Components/MessageBubbleView.swift
+++ b/x/adrsimon/mobile/Dust/Views/Components/MessageBubbleView.swift
@@ -79,9 +79,9 @@ struct OtherUserMessageBubble: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 8) {
-                Avatar(url: message.context?.profilePictureUrl)
+                Avatar(url: message.authorAvatarUrl)
 
-                Text(message.context?.fullName ?? message.context?.username ?? "User")
+                Text(message.authorName ?? "User")
                     .sparkleLabelXs()
                     .foregroundStyle(Color.dustForeground)
             }

--- a/x/adrsimon/mobile/Dust/Views/ConversationListView.swift
+++ b/x/adrsimon/mobile/Dust/Views/ConversationListView.swift
@@ -4,15 +4,15 @@ import SwiftUI
 struct ConversationListView: View {
     @Binding var searchText: String
     let groupedConversations: [(String, [Conversation])]
-    let projects: [Space]
-    @Binding var isProjectsExpanded: Bool
+    let pods: [Space]
+    @Binding var isPodsExpanded: Bool
     let user: User
     let currentWorkspace: Workspace?
     let workspaces: [Workspace]
     let isLoading: Bool
     let onNewConversation: () -> Void
     let onSelectConversation: (Conversation) -> Void
-    let onSelectProject: (Space) -> Void
+    let onSelectPod: (Space) -> Void
     let onSwitchWorkspace: (Workspace) -> Void
     let onToggleReadStatus: (Conversation) -> Void
     let onDelete: (Conversation) -> Void
@@ -112,41 +112,47 @@ struct ConversationListView: View {
         .liquidGlassCapsule()
     }
 
-    // MARK: - Projects
+    // MARK: - Pods
 
-    private var projectsSection: some View {
+    private var podsSection: some View {
         Section {
-            if isProjectsExpanded {
-                ForEach(projects) { project in
+            if isPodsExpanded {
+                ForEach(pods) { pod in
                     Button {
-                        onSelectProject(project)
+                        onSelectPod(pod)
                     } label: {
-                        Text(project.name)
-                            .sparkleCopySm()
-                            .foregroundStyle(Color.dustForeground)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 8)
+                        HStack(spacing: 8) {
+                            (pod.isRestricted ? SparkleIcon.spaceClosed : SparkleIcon.spaceOpen).image
+                                .resizable()
+                                .frame(width: 14, height: 14)
+                                .foregroundStyle(Color.dustFaint)
+                            Text(pod.name)
+                                .sparkleCopySm()
+                                .foregroundStyle(Color.dustForeground)
+                                .lineLimit(1)
+                                .truncationMode(.tail)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
                     }
                 }
             }
         } header: {
             Button {
                 withAnimation(.easeInOut(duration: 0.2)) {
-                    isProjectsExpanded.toggle()
+                    isPodsExpanded.toggle()
                 }
             } label: {
                 HStack(spacing: 4) {
-                    Text("Projects")
+                    Text("Pods")
                         .sparkleLabelXs()
                         .textCase(.uppercase)
 
                     SparkleIcon.chevronDown.image
                         .resizable()
                         .frame(width: 8, height: 8)
-                        .rotationEffect(.degrees(isProjectsExpanded ? 0 : -90))
+                        .rotationEffect(.degrees(isPodsExpanded ? 0 : -90))
 
                     Spacer()
                 }
@@ -203,8 +209,8 @@ struct ConversationListView: View {
 
     private var conversationList: some View {
         List {
-            if !projects.isEmpty {
-                projectsSection
+            if !pods.isEmpty {
+                podsSection
                     .listRowInsets(EdgeInsets())
                     .listRowBackground(Color.clear)
                     .listRowSeparator(.hidden)

--- a/x/adrsimon/mobile/Dust/Views/MainContainerView.swift
+++ b/x/adrsimon/mobile/Dust/Views/MainContainerView.swift
@@ -4,8 +4,8 @@ import SwiftUI
 enum ConversationDestination: Hashable {
     case conversation(Conversation)
     case newConversation
-    case project(Space)
-    case newProjectConversation(Space)
+    case pod(Space)
+    case newPodConversation(Space)
 }
 
 struct MainContainerView: View {
@@ -43,8 +43,8 @@ struct MainContainerView: View {
             ConversationListView(
                 searchText: $viewModel.searchText,
                 groupedConversations: viewModel.groupedConversations,
-                projects: viewModel.projects,
-                isProjectsExpanded: $viewModel.isProjectsExpanded,
+                pods: viewModel.pods,
+                isPodsExpanded: $viewModel.isPodsExpanded,
                 user: user,
                 currentWorkspace: viewModel.workspace,
                 workspaces: viewModel.workspaces,
@@ -55,8 +55,8 @@ struct MainContainerView: View {
                 onSelectConversation: { conversation in
                     navigationPath.append(ConversationDestination.conversation(conversation))
                 },
-                onSelectProject: { project in
-                    navigationPath.append(ConversationDestination.project(project))
+                onSelectPod: { pod in
+                    navigationPath.append(ConversationDestination.pod(pod))
                 },
                 onSwitchWorkspace: { workspace in
                     navigationPath = NavigationPath()
@@ -103,9 +103,9 @@ struct MainContainerView: View {
                         )
                     }
 
-                case let .project(space):
+                case let .pod(space):
                     if let workspaceId = viewModel.workspace?.sId {
-                        ProjectConversationsView(
+                        PodConversationsView(
                             space: space,
                             workspaceId: workspaceId,
                             tokenProvider: tokenProvider,
@@ -113,12 +113,12 @@ struct MainContainerView: View {
                                 navigationPath.append(ConversationDestination.conversation(conversation))
                             },
                             onNewConversation: {
-                                navigationPath.append(ConversationDestination.newProjectConversation(space))
+                                navigationPath.append(ConversationDestination.newPodConversation(space))
                             }
                         )
                     }
 
-                case let .newProjectConversation(space):
+                case let .newPodConversation(space):
                     if let workspaceId = viewModel.workspace?.sId {
                         NewConversationView(
                             firstName: user.firstName,
@@ -128,7 +128,7 @@ struct MainContainerView: View {
                             spaceId: space.sId,
                             onConversationCreated: { conversation in
                                 navigationPath = NavigationPath([
-                                    ConversationDestination.project(space),
+                                    ConversationDestination.pod(space),
                                     ConversationDestination.conversation(conversation),
                                 ])
                             }

--- a/x/adrsimon/mobile/Dust/Views/PodConversationsView.swift
+++ b/x/adrsimon/mobile/Dust/Views/PodConversationsView.swift
@@ -1,12 +1,12 @@
 import SparkleTokens
 import SwiftUI
 
-struct ProjectConversationsView: View {
+struct PodConversationsView: View {
     let space: Space
     let onSelectConversation: (Conversation) -> Void
     let onNewConversation: () -> Void
 
-    @StateObject private var viewModel: ProjectConversationsViewModel
+    @StateObject private var viewModel: PodConversationsViewModel
 
     init(
         space: Space,
@@ -19,7 +19,7 @@ struct ProjectConversationsView: View {
         self.onSelectConversation = onSelectConversation
         self.onNewConversation = onNewConversation
         _viewModel = StateObject(
-            wrappedValue: ProjectConversationsViewModel(
+            wrappedValue: PodConversationsViewModel(
                 space: space,
                 workspaceId: workspaceId,
                 tokenProvider: tokenProvider


### PR DESCRIPTION
## Description

Renames the **Projects** concept to **Pods** in the mobile app and brings the Pod conversation list closer to the web front-end. The backend wire value is still `kind: "project"` — only the app-side concept/UI is renamed.

- Rename Projects → Pods across views, view models, services and types.
- Show a space icon next to each Pod in the sidebar (`spaceOpen`/`spaceClosed` by `isRestricted`).
- Pod conversation rows show the first message's author avatar, a one-line snippet and a reply count, mirroring `PodConversationListItem`. Conversations with no visible first message (e.g. compaction-only) are hidden, as front does.
- Render Dust emoji-URL avatars instead of the generic placeholder.
- Fix: skip `compaction_message` when decoding a conversation (was crashing the detail view); a renderable message that fails to decode still throws so schema drift surfaces.
- Fix: show other participants' real avatar in the conversation view (prefer `user.image` over the often-empty `context` picture).

## Tests

- `make build` (XcodeGen + compile) green; swiftformat + swiftlint clean (pre-commit hooks pass).
- Manually exercised in the simulator: Pod list, Pod conversation previews, conversation detail with multiple participants, and a compaction-containing conversation (no longer crashes).
- No automated tests — the project has no test target yet.

## Risk

Mobile-only; no backend or wire-format change (`kind` stays `"project"`). Worst case is a UI regression in the conversation list/detail. Safe to rollback — revert the PR.

## Deploy Plan

N/A — mobile not shipped