### PR TITLE
Correctly classify sidekick message as origin agent_sidekick

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -245,13 +245,12 @@ app.post(
       }
     }
 
-    // Derive origin: use explicitly provided origin, fall back to conversation
-    // metadata, then default to "web".
-    const origin =
-      context.origin ??
-      (isSidekickConversation(conversation.metadata)
-        ? "agent_sidekick"
-        : "web");
+    // Sidekick conversations always use "agent_sidekick" origin regardless of
+    // what the client sends (follow-up messages default to "web" because
+    // useClientType() doesn't know about sidekick context).
+    const origin = isSidekickConversation(conversation.metadata)
+      ? "agent_sidekick"
+      : (context.origin ?? "web");
 
     const messageRes = await postUserMessage(auth, {
       conversation,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -386,13 +386,12 @@ async function handler(
         }
       }
 
-      // Derive origin: use explicitly provided origin, fall back to conversation metadata,
-      // then default to "web".
-      const origin =
-        context.origin ??
-        (isSidekickConversation(conversation.metadata)
-          ? "agent_sidekick"
-          : "web");
+      // Sidekick conversations always use "agent_sidekick" origin regardless of
+      // what the client sends (follow-up messages default to "web" because
+      // useClientType() doesn't know about sidekick context).
+      const origin = isSidekickConversation(conversation.metadata)
+        ? "agent_sidekick"
+        : (context.origin ?? "web");
 
       const messageRes = await postUserMessage(auth, {
         conversation,


### PR DESCRIPTION
## Description
 
 - correctly mark the messages with sidekick as origin agent_sidekick, they were marked as web 

## Tests

tested locally, they are now marked as agent_sidekick 

## Risk

low

## Deploy Plan

deploy front
