### PR TITLE
Wake-up rendering to avoid null virtuoso element

### DIFF
--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -20,6 +20,7 @@ import {
   isUserMessage,
 } from "@app/components/assistant/conversation/types";
 import { UserMessage } from "@app/components/assistant/conversation/UserMessage";
+import { WakeUpMessage } from "@app/components/assistant/conversation/WakeUpMessage";
 import { useMessageFeedback } from "@app/hooks/useMessageFeedback";
 import { useReaction } from "@app/hooks/useReaction";
 import { useSubmitFunction } from "@app/lib/client/utils";
@@ -248,12 +249,6 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
       return null;
     }
 
-    if (isHiddenMessage(data)) {
-      // This is hacky but in case of handover we generate a user message from the agent and we want
-      // to hide it in the conversation because it has no value to display.
-      return null;
-    }
-
     const topMargin = getMessageTopMargin({
       data,
       prevData,
@@ -261,6 +256,27 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
       isSteeredAgentMessage,
       isPreviousAgentMessageSteered,
     });
+
+    if (isUserMessage(data) && data.context.origin === "wakeup") {
+      return (
+        <div
+          ref={ref}
+          className={cn(
+            "mx-auto max-w-conversation",
+            topMargin,
+            !nextData && "mb-10"
+          )}
+        >
+          <WakeUpMessage message={data} />
+        </div>
+      );
+    }
+
+    if (isHiddenMessage(data)) {
+      // This is hacky but in case of handover we generate a user message from the agent and we want
+      // to hide it in the conversation because it has no value to display.
+      return null;
+    }
 
     // No message without a conversation
     if (!context.conversation) {

--- a/front/components/assistant/conversation/WakeUpMessage.tsx
+++ b/front/components/assistant/conversation/WakeUpMessage.tsx
@@ -1,0 +1,19 @@
+import { formatTimestring } from "@app/lib/utils/timestamps";
+import type { UserMessageTypeWithContentFragments } from "@app/types/assistant/conversation";
+
+interface WakeUpMessageProps {
+  message: UserMessageTypeWithContentFragments;
+}
+
+export function WakeUpMessage({ message }: WakeUpMessageProps) {
+  const label =
+    message.visibility === "pending" ? "Wake-up pending" : "Wake-up executed";
+
+  return (
+    <div className="flex items-center justify-center gap-1.5">
+      <span className="text-sm text-muted-foreground">
+        {label} · {formatTimestring(message.created)}
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/8546

Virtuoso does not support scrolling to a `null` component. When we have a wake-up pending on a message, the last message is the hidden wake-up which leads to Virtuoso not loading the list at all.

We introduce a rendering for the wake-ups which is discrete and aligned with compaction. Actually useful and solves the problem.

The behavior described in the issue is definitely good. Wake-up messages are queued and will all be inserted in the conversation once the tool approval is confirmed giving a full consistent state to the agent.

## Tests

Tested locally

## Risk

Low

## Deploy Plan

- deploy `front`