### PR TITLE
fix: prevent file overwrite when moving files

### DIFF
--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].test.ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].test.ts
@@ -17,7 +17,7 @@ function makeReadStream() {
 
 function makeBucket(
   overrides: Partial<{
-    exists: ReturnType<typeof vi.fn>;
+    existingFilePathSuffixes: string[];
     getMetadata: ReturnType<typeof vi.fn>;
     createReadStream: ReturnType<typeof vi.fn>;
     copyFile: ReturnType<typeof vi.fn>;
@@ -25,17 +25,23 @@ function makeBucket(
     getAllFilesByPrefix: ReturnType<typeof vi.fn>;
   }> = {}
 ) {
-  const fileObj = {
-    exists: overrides.exists ?? vi.fn().mockResolvedValue([true]),
-    getMetadata:
-      overrides.getMetadata ??
-      vi.fn().mockResolvedValue([{ contentType: "text/plain", size: "42" }]),
-    createReadStream:
-      overrides.createReadStream ?? vi.fn().mockReturnValue(makeReadStream()),
-  };
+  const existingFilePathSuffixes = overrides.existingFilePathSuffixes ?? [];
+  const getMetadata =
+    overrides.getMetadata ??
+    vi.fn().mockResolvedValue([{ contentType: "text/plain", size: "42" }]);
+  const createReadStream =
+    overrides.createReadStream ?? vi.fn().mockReturnValue(makeReadStream());
 
   return {
-    file: vi.fn().mockReturnValue(fileObj),
+    file: vi.fn((filePath: string) => ({
+      exists: vi
+        .fn()
+        .mockResolvedValue([
+          existingFilePathSuffixes.some((suffix) => filePath.endsWith(suffix)),
+        ]),
+      getMetadata,
+      createReadStream,
+    })),
     copyFile: overrides.copyFile ?? vi.fn().mockResolvedValue(undefined),
     delete: overrides.delete ?? vi.fn().mockResolvedValue(undefined),
     getAllFilesByPrefix:
@@ -100,9 +106,7 @@ describe("GET /api/w/:wId/files/path/:canonicalPath", () => {
   it("returns 404 when file does not exist in GCS", async () => {
     const { workspace, conversation } = await setup();
 
-    const bucket = makeBucket({
-      exists: vi.fn().mockResolvedValue([false]),
-    });
+    const bucket = makeBucket();
     vi.mocked(getPrivateUploadBucket).mockReturnValue(bucket as any);
 
     const response = await request(
@@ -118,6 +122,7 @@ describe("GET /api/w/:wId/files/path/:canonicalPath", () => {
     const { workspace, conversation } = await setup();
 
     const bucket = makeBucket({
+      existingFilePathSuffixes: ["/files/report.pdf"],
       getMetadata: vi
         .fn()
         .mockResolvedValue([{ contentType: "application/pdf", size: "1024" }]),
@@ -137,7 +142,9 @@ describe("GET /api/w/:wId/files/path/:canonicalPath", () => {
   it("sets Content-Disposition when ?download=1", async () => {
     const { workspace, conversation } = await setup();
 
-    const bucket = makeBucket();
+    const bucket = makeBucket({
+      existingFilePathSuffixes: ["/files/report.txt"],
+    });
     vi.mocked(getPrivateUploadBucket).mockReturnValue(bucket as any);
 
     const segments = `conversation-${conversation.sId}/report.txt`
@@ -164,6 +171,7 @@ describe("GET /api/w/:wId/files/path/:canonicalPath?thumbnail=1", () => {
     const { workspace, auth, conversation } = await setup();
 
     const bucket = makeBucket({
+      existingFilePathSuffixes: ["/files/photo.png"],
       getMetadata: vi
         .fn()
         .mockResolvedValue([{ contentType: "image/png", size: "2048" }]),
@@ -201,6 +209,7 @@ describe("GET /api/w/:wId/files/path/:canonicalPath?thumbnail=1", () => {
     const { workspace, conversation } = await setup();
 
     const bucket = makeBucket({
+      existingFilePathSuffixes: ["/files/data.csv"],
       getMetadata: vi
         .fn()
         .mockResolvedValue([{ contentType: "text/plain", size: "100" }]),
@@ -229,6 +238,7 @@ describe("HEAD /api/w/:wId/files/path/:canonicalPath", () => {
     const { workspace, conversation } = await setup();
 
     const bucket = makeBucket({
+      existingFilePathSuffixes: ["/files/data.csv"],
       getMetadata: vi
         .fn()
         .mockResolvedValue([{ contentType: "text/csv", size: "512" }]),
@@ -251,9 +261,7 @@ describe("HEAD /api/w/:wId/files/path/:canonicalPath", () => {
   it("returns 404 when file does not exist", async () => {
     const { workspace, conversation } = await setup();
 
-    const bucket = makeBucket({
-      exists: vi.fn().mockResolvedValue([false]),
-    });
+    const bucket = makeBucket();
     vi.mocked(getPrivateUploadBucket).mockReturnValue(bucket as any);
 
     const segments = `conversation-${conversation.sId}/missing.txt`
@@ -294,7 +302,9 @@ describe("PATCH /api/w/:wId/files/path/:canonicalPath", () => {
   it("renames a file", async () => {
     const { workspace, conversation } = await setup();
 
-    const bucket = makeBucket();
+    const bucket = makeBucket({
+      existingFilePathSuffixes: ["/files/old.txt"],
+    });
     vi.mocked(getPrivateUploadBucket).mockReturnValue(bucket as any);
 
     const response = await request(
@@ -314,7 +324,9 @@ describe("PATCH /api/w/:wId/files/path/:canonicalPath", () => {
   it("moves a file to another path", async () => {
     const { workspace, conversation } = await setup();
 
-    const bucket = makeBucket();
+    const bucket = makeBucket({
+      existingFilePathSuffixes: ["/files/old.txt"],
+    });
     vi.mocked(getPrivateUploadBucket).mockReturnValue(bucket as any);
 
     const dest = `conversation-${conversation.sId}/archive/old.txt`;
@@ -356,7 +368,9 @@ describe("DELETE /api/w/:wId/files/path/:canonicalPath", () => {
   it("deletes a file and returns 204", async () => {
     const { workspace, conversation } = await setup();
 
-    const bucket = makeBucket();
+    const bucket = makeBucket({
+      existingFilePathSuffixes: ["/files/file.txt"],
+    });
     vi.mocked(getPrivateUploadBucket).mockReturnValue(bucket as any);
 
     const response = await request(
@@ -373,7 +387,6 @@ describe("DELETE /api/w/:wId/files/path/:canonicalPath", () => {
     const { workspace, conversation } = await setup();
 
     const bucket = makeBucket({
-      exists: vi.fn().mockResolvedValue([false]),
       getAllFilesByPrefix: vi
         .fn()
         .mockResolvedValue({ files: [], pageFetchCount: 1 }),

--- a/front/lib/api/actions/servers/files/tools/move.test.ts
+++ b/front/lib/api/actions/servers/files/tools/move.test.ts
@@ -3,12 +3,12 @@ import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { moveHandler } from "@app/lib/api/actions/servers/files/tools/move";
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { Authenticator } from "@app/lib/auth";
-import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import assert from "assert";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 function makeExtra(
   auth: Authenticator,
@@ -56,6 +56,11 @@ describe("moveHandler", () => {
   it("moves a file from conversation to pod mount", async () => {
     const { auth, conversation, spaceId } = await setupProjectConversation();
 
+    // Source (conversation) exists, destination (pod) does not.
+    fileStorageMock.setFileExists((filePath) =>
+      filePath.includes("/conversations/")
+    );
+
     const result = await moveHandler(
       {
         source: `conversation-${conversation.sId}/report.pdf`,
@@ -77,6 +82,9 @@ describe("moveHandler", () => {
   it("moves a file from pod to conversation mount", async () => {
     const { auth, conversation, spaceId } = await setupProjectConversation();
 
+    // Source (pod) exists, destination (conversation) does not.
+    fileStorageMock.setFileExists((filePath) => filePath.includes("/pods/"));
+
     const result = await moveHandler(
       {
         source: `pod-${spaceId}/spec.md`,
@@ -91,13 +99,7 @@ describe("moveHandler", () => {
   it("returns Err when the source file does not exist", async () => {
     const { auth, conversation, spaceId } = await setupProjectConversation();
 
-    vi.mocked(getPrivateUploadBucket).mockReturnValueOnce({
-      file: vi.fn(() => ({
-        exists: vi.fn().mockResolvedValue([false]),
-        getMetadata: vi.fn().mockRejectedValue(new Error("Not Found")),
-        delete: vi.fn().mockResolvedValue(undefined),
-      })),
-    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
+    fileStorageMock.setFileExists(() => false);
 
     const result = await moveHandler(
       {

--- a/front/lib/api/file_system/backends/file_system_backend.ts
+++ b/front/lib/api/file_system/backends/file_system_backend.ts
@@ -52,6 +52,13 @@ export interface FileSystemBackend {
     >
   >;
 
+  /**
+   * Returns `Ok(true)` when a file exists at `scopedPath`, `Ok(false)` otherwise.
+   * Unlike `stat`, this never fetches metadata, so it is cheaper for pure existence checks.
+   * Returns `Err` on path or permission errors (including `invalid_path`).
+   */
+  exists(scopedPath: string): Promise<Result<boolean, DustFileSystemError>>;
+
   write(
     scopedPath: string,
     content: Buffer | string,

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.ts
@@ -318,6 +318,29 @@ export class GCSFileSystemBackend implements FileSystemBackend {
     }
   }
 
+  async exists(
+    scopedPath: string
+  ): Promise<Result<boolean, DustFileSystemError>> {
+    const gcsPath = this.toGCSPath(scopedPath);
+    if (!gcsPath) {
+      return new Err(
+        new DustFileSystemError(
+          "invalid_path",
+          `GCSFileSystemBackend.exists: unrecognised scoped path: ${scopedPath}`
+        )
+      );
+    }
+
+    try {
+      const [exists] = await getPrivateUploadBucket().file(gcsPath).exists();
+      return new Ok(exists);
+    } catch (err) {
+      return new Err(
+        new DustFileSystemError("internal", normalizeError(err).message)
+      );
+    }
+  }
+
   async write(
     scopedPath: string,
     content: Buffer | string,

--- a/front/lib/api/file_system/dust_file_system.test.ts
+++ b/front/lib/api/file_system/dust_file_system.test.ts
@@ -1240,16 +1240,18 @@ describe("DustFileSystem.move", () => {
   let auth: Authenticator;
   let conversationId: string;
   let copyFileMock: ReturnType<typeof vi.fn>;
-  let existsMock: ReturnType<typeof vi.fn>;
+  let fileExists: (filePath: string) => boolean;
   let deleteMock: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
     copyFileMock = vi.fn().mockResolvedValue(undefined);
-    existsMock = vi.fn().mockResolvedValue([true]);
+    fileExists = (filePath: string) => filePath.endsWith("/src.txt");
     deleteMock = vi.fn().mockResolvedValue(undefined);
     vi.mocked(getPrivateUploadBucket).mockReturnValue({
       copyFile: copyFileMock,
-      file: vi.fn(() => ({ exists: existsMock })),
+      file: vi.fn((filePath: string) => ({
+        exists: () => Promise.resolve([fileExists(filePath)]),
+      })),
       delete: deleteMock,
     } as unknown as ReturnType<typeof getPrivateUploadBucket>);
 
@@ -1283,6 +1285,28 @@ describe("DustFileSystem.move", () => {
     expect(result.value.sourceDeletionFailed).toBe(false);
     expect(copyFileMock).toHaveBeenCalledOnce();
     expect(deleteMock).toHaveBeenCalledOnce();
+  });
+
+  it("returns Err(already_exists) when the destination file already exists", async () => {
+    fileExists = (filePath: string) =>
+      filePath.endsWith("/src.txt") || filePath.endsWith("/dest.txt");
+
+    const convRes = await ConversationResource.fetchById(auth, conversationId);
+    assert(convRes !== null);
+    const fs = await DustFileSystem.forConversation(auth, convRes.toJSON());
+    assert(fs.isOk());
+
+    const result = await fs.value.move({
+      src: `conversation-${conversationId}/src.txt`,
+      dest: `conversation-${conversationId}/dest.txt`,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("already_exists");
+    }
+    expect(copyFileMock).not.toHaveBeenCalled();
+    expect(deleteMock).not.toHaveBeenCalled();
   });
 
   it("returns Ok with sourceDeletionFailed true when delete fails after a successful copy", async () => {
@@ -1353,7 +1377,9 @@ describe("DustFileSystem.rename", () => {
     deleteMock = vi.fn().mockResolvedValue(undefined);
     vi.mocked(getPrivateUploadBucket).mockReturnValue({
       copyFile: copyFileMock,
-      file: vi.fn(() => ({ exists: vi.fn().mockResolvedValue([true]) })),
+      file: vi.fn((filePath: string) => ({
+        exists: vi.fn().mockResolvedValue([filePath.endsWith("/report.pdf")]),
+      })),
       delete: deleteMock,
     } as unknown as ReturnType<typeof getPrivateUploadBucket>);
 

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -815,6 +815,17 @@ export class DustFileSystem {
     return new Ok({ dest, ...moveResult.value });
   }
 
+  private async destinationFileExists(
+    scopedPath: string
+  ): Promise<Result<boolean, DustFileSystemError>> {
+    const fileStat = await this.backend.stat(scopedPath);
+    if (fileStat.isErr()) {
+      return fileStat;
+    }
+
+    return new Ok(fileStat.value !== null);
+  }
+
   /**
    * Move `src` to `dest` (copy then delete source).
    *
@@ -836,6 +847,21 @@ export class DustFileSystem {
     const resolvedDest = this.requireWriteMount(dest);
     if (resolvedDest.isErr()) {
       return resolvedDest;
+    }
+
+    const destExists = await this.destinationFileExists(
+      resolvedDest.value.path
+    );
+    if (destExists.isErr()) {
+      return destExists;
+    }
+    if (destExists.value) {
+      return new Err(
+        new DustFileSystemError(
+          "already_exists",
+          `Destination path already exists: ${dest}`
+        )
+      );
     }
 
     const copyResult = await this.backend.copy({

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -818,12 +818,7 @@ export class DustFileSystem {
   private async fileExists(
     scopedPath: string
   ): Promise<Result<boolean, DustFileSystemError>> {
-    const fileStat = await this.backend.stat(scopedPath);
-    if (fileStat.isErr()) {
-      return fileStat;
-    }
-
-    return new Ok(fileStat.value !== null);
+    return this.backend.exists(scopedPath);
   }
 
   /**

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -815,7 +815,7 @@ export class DustFileSystem {
     return new Ok({ dest, ...moveResult.value });
   }
 
-  private async destinationFileExists(
+  private async fileExists(
     scopedPath: string
   ): Promise<Result<boolean, DustFileSystemError>> {
     const fileStat = await this.backend.stat(scopedPath);
@@ -849,9 +849,7 @@ export class DustFileSystem {
       return resolvedDest;
     }
 
-    const destExists = await this.destinationFileExists(
-      resolvedDest.value.path
-    );
+    const destExists = await this.fileExists(resolvedDest.value.path);
     if (destExists.isErr()) {
       return destExists;
     }

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -857,10 +857,7 @@ export class DustFileSystem {
     }
     if (destExists.value) {
       return new Err(
-        new DustFileSystemError(
-          "already_exists",
-          `Destination path already exists: ${dest}`
-        )
+        new DustFileSystemError("already_exists", `File name already exists`)
       );
     }
 

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -19,13 +19,23 @@ export interface WriteStreamCall {
  */
 class FileStorageMock {
   private _writeStreamCalls: WriteStreamCall[] = [];
+  private _existsPredicate: (filePath: string) => boolean = () => true;
 
   get writeStreamCalls(): readonly WriteStreamCall[] {
     return this._writeStreamCalls;
   }
 
+  /**
+   * Controls what `file(path).exists()` resolves to, keyed by the GCS path.
+   * Defaults to always-exists. Reset between tests via `reset()`.
+   */
+  setFileExists(predicate: (filePath: string) => boolean): void {
+    this._existsPredicate = predicate;
+  }
+
   reset(): void {
     this._writeStreamCalls.length = 0;
+    this._existsPredicate = () => true;
   }
 
   /**
@@ -60,7 +70,9 @@ class FileStorageMock {
         }),
       delete: vi.fn().mockResolvedValue(undefined),
       download: vi.fn().mockResolvedValue([Buffer.from("", "utf-8")]),
-      exists: vi.fn().mockResolvedValue([true]),
+      exists: vi.fn(() =>
+        Promise.resolve([this._existsPredicate(filePath ?? "")])
+      ),
       getMetadata: vi
         .fn()
         .mockResolvedValue([{ contentType: "text/plain", size: "0" }]),


### PR DESCRIPTION
## Description

This PR prevents file overwrite when moving files in `DustFileSystem` by checking if the destination path already exists before executing the move.

- Adds a `destinationFileExists` private method that uses `backend.stat` to check the destination.
- Returns an `Err` with code `already_exists` if the destination file is present, aborting the copy+delete operation.

## Tests

Unit tests updated to cover the new `already_exists` error case and to make the `file()` mock path-aware.

## Risks

Low.

## Deploy Plan
Standard deployment.
