### PR TITLE
fix: delete file resource on file delete

### DIFF
--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].test.ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].test.ts
@@ -22,6 +22,7 @@ function makeBucket(
     createReadStream: ReturnType<typeof vi.fn>;
     copyFile: ReturnType<typeof vi.fn>;
     delete: ReturnType<typeof vi.fn>;
+    fileDelete: ReturnType<typeof vi.fn>;
     getAllFilesByPrefix: ReturnType<typeof vi.fn>;
   }> = {}
 ) {
@@ -31,6 +32,8 @@ function makeBucket(
     vi.fn().mockResolvedValue([{ contentType: "text/plain", size: "42" }]);
   const createReadStream =
     overrides.createReadStream ?? vi.fn().mockReturnValue(makeReadStream());
+  const fileDelete =
+    overrides.fileDelete ?? vi.fn().mockResolvedValue(undefined);
 
   return {
     file: vi.fn((filePath: string) => ({
@@ -41,6 +44,7 @@ function makeBucket(
         ]),
       getMetadata,
       createReadStream,
+      delete: fileDelete,
     })),
     copyFile: overrides.copyFile ?? vi.fn().mockResolvedValue(undefined),
     delete: overrides.delete ?? vi.fn().mockResolvedValue(undefined),
@@ -381,6 +385,31 @@ describe("DELETE /api/w/:wId/files/path/:canonicalPath", () => {
 
     expect(response.status).toBe(204);
     expect(bucket.delete).toHaveBeenCalledOnce();
+  });
+
+  it("deletes the linked FileResource when one exists", async () => {
+    const { workspace, auth, conversation } = await setup();
+
+    const bucket = makeBucket();
+    vi.mocked(getPrivateUploadBucket).mockReturnValue(bucket as any);
+
+    const file = await FileFactory.create(auth, auth.getNonNullableUser(), {
+      contentType: "text/plain",
+      fileName: "linked.txt",
+      fileSize: 42,
+      status: "ready",
+      useCase: "tool_output",
+    });
+    await file.setUseCaseMetadata(auth, { conversationId: conversation.sId });
+
+    const response = await request(
+      workspace,
+      `conversation-${conversation.sId}/linked.txt`,
+      { method: "DELETE" }
+    );
+
+    expect(response.status).toBe(204);
+    await expect(FileResource.fetchById(auth, file.sId)).resolves.toBeNull();
   });
 
   it("returns 404 when file does not exist", async () => {

--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
@@ -1,6 +1,7 @@
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import type { DustFileSystemError } from "@app/lib/api/file_system/types";
 import {
+  deleteCanonicalFile,
   moveCanonicalFile,
   renameCanonicalFile,
   streamThumbnail,
@@ -291,13 +292,14 @@ app.delete(
   "/:canonicalPath{.+}",
   validate("param", ParamsSchema),
   async (ctx) => {
+    const auth = ctx.get("auth");
     const { canonicalPath } = ctx.req.valid("param");
     const { fs: dustFs, err } = await resolveFs(ctx, canonicalPath);
     if (err) {
       return err;
     }
 
-    const deleteResult = await dustFs.delete(canonicalPath);
+    const deleteResult = await deleteCanonicalFile(auth, dustFs, canonicalPath);
     if (deleteResult.isErr()) {
       return apiError(ctx, mapDustFsError(deleteResult.error));
     }

--- a/front/lib/api/files/file_system_ops.ts
+++ b/front/lib/api/files/file_system_ops.ts
@@ -5,11 +5,9 @@
  */
 
 import type { DustFileSystem } from "@app/lib/api/file_system";
-import type {
-  DustFileSystemError,
-  FileSystemEntry,
-} from "@app/lib/api/file_system/types";
 import {
+  DustFileSystemError,
+  type FileSystemEntry,
   SCOPED_PREFIX_CONVERSATION,
   SCOPED_PREFIX_POD,
 } from "@app/lib/api/file_system/types";
@@ -192,6 +190,27 @@ export async function enrichListWithFileResourceIds(
 }
 
 // ---------------------------------------------------------------------------
+// FileResource lookup helpers
+// ---------------------------------------------------------------------------
+
+async function fetchLinkedFile(
+  auth: Authenticator,
+  dustFs: DustFileSystem,
+  scopedPath: string
+): Promise<FileResource | undefined> {
+  const gcsPath = dustFs.toMountFilePath(scopedPath);
+  if (!gcsPath) {
+    return undefined;
+  }
+
+  const [linkedFile] = await FileResource.fetchByMountFilePaths(auth, [
+    gcsPath,
+  ]);
+
+  return linkedFile;
+}
+
+// ---------------------------------------------------------------------------
 // Move with FileResource sync
 // ---------------------------------------------------------------------------
 
@@ -248,17 +267,7 @@ export async function renameCanonicalFile(
 ): Promise<
   Result<{ dest: string; sourceDeletionFailed: boolean }, DustFileSystemError>
 > {
-  const srcGcsPath = dustFs.toMountFilePath(scopedPath);
-  let linkedFile: FileResource | undefined;
-
-  if (srcGcsPath) {
-    const candidates = [srcGcsPath];
-    const legacyPath = srcGcsPath.replace(/\/pods\//, "/projects/");
-    if (legacyPath !== srcGcsPath) {
-      candidates.push(legacyPath);
-    }
-    [linkedFile] = await FileResource.fetchByMountFilePaths(auth, candidates);
-  }
+  const linkedFile = await fetchLinkedFile(auth, dustFs, scopedPath);
 
   const renameResult = await dustFs.rename(scopedPath, newFileName);
   if (renameResult.isErr()) {
@@ -296,17 +305,7 @@ export async function moveCanonicalFile(
   dest: string
 ): Promise<Result<{ sourceDeletionFailed: boolean }, DustFileSystemError>> {
   // Look up the linked FileResource before the bytes move.
-  const srcGcsPath = dustFs.toMountFilePath(src);
-  let linkedFile: FileResource | undefined;
-
-  if (srcGcsPath) {
-    const candidates = [srcGcsPath];
-    const legacyPath = srcGcsPath.replace(/\/pods\//, "/projects/");
-    if (legacyPath !== srcGcsPath) {
-      candidates.push(legacyPath);
-    }
-    [linkedFile] = await FileResource.fetchByMountFilePaths(auth, candidates);
-  }
+  const linkedFile = await fetchLinkedFile(auth, dustFs, src);
 
   const moveResult = await dustFs.move({ src, dest });
   if (moveResult.isErr()) {
@@ -330,4 +329,29 @@ export async function moveCanonicalFile(
   }
 
   return moveResult;
+}
+
+/**
+ * Delete a file at `scopedPath` and delete the linked FileResource record when
+ * the path corresponds to one. If no FileResource exists (for example a file
+ * created directly in the sandbox), falls back to deleting the raw GCS object.
+ */
+export async function deleteCanonicalFile(
+  auth: Authenticator,
+  dustFs: DustFileSystem,
+  scopedPath: string
+): Promise<Result<void, DustFileSystemError>> {
+  const linkedFile = await fetchLinkedFile(auth, dustFs, scopedPath);
+  if (!linkedFile) {
+    return dustFs.delete(scopedPath);
+  }
+
+  const deleteResult = await linkedFile.delete(auth);
+  if (deleteResult.isErr()) {
+    return new Err(
+      new DustFileSystemError("internal", deleteResult.error.message)
+    );
+  }
+
+  return new Ok(undefined);
 }

--- a/front/lib/api/files/file_system_ops.ts
+++ b/front/lib/api/files/file_system_ops.ts
@@ -193,7 +193,7 @@ export async function enrichListWithFileResourceIds(
 // FileResource lookup helpers
 // ---------------------------------------------------------------------------
 
-async function fetchLinkedFile(
+async function fetchLinkedFileResource(
   auth: Authenticator,
   dustFs: DustFileSystem,
   scopedPath: string
@@ -267,20 +267,24 @@ export async function renameCanonicalFile(
 ): Promise<
   Result<{ dest: string; sourceDeletionFailed: boolean }, DustFileSystemError>
 > {
-  const linkedFile = await fetchLinkedFile(auth, dustFs, scopedPath);
+  const linkedFileResource = await fetchLinkedFileResource(
+    auth,
+    dustFs,
+    scopedPath
+  );
 
   const renameResult = await dustFs.rename(scopedPath, newFileName);
   if (renameResult.isErr()) {
     return renameResult;
   }
 
-  if (linkedFile) {
+  if (linkedFileResource) {
     const { dest } = renameResult.value;
     const destGcsPath = dustFs.toMountFilePath(dest);
     const destInfo = inferDestMountInfo(dest);
 
     if (destGcsPath && destInfo) {
-      await linkedFile.updateMount({
+      await linkedFileResource.updateMount({
         destFileName: newFileName,
         destMountFilePath: destGcsPath,
         destUseCase: destInfo.useCase,
@@ -305,7 +309,7 @@ export async function moveCanonicalFile(
   dest: string
 ): Promise<Result<{ sourceDeletionFailed: boolean }, DustFileSystemError>> {
   // Look up the linked FileResource before the bytes move.
-  const linkedFile = await fetchLinkedFile(auth, dustFs, src);
+  const linkedFileResource = await fetchLinkedFileResource(auth, dustFs, src);
 
   const moveResult = await dustFs.move({ src, dest });
   if (moveResult.isErr()) {
@@ -313,13 +317,13 @@ export async function moveCanonicalFile(
   }
 
   // Update the FileResource to point to the new location.
-  if (linkedFile) {
+  if (linkedFileResource) {
     const destGcsPath = dustFs.toMountFilePath(dest);
     const destInfo = inferDestMountInfo(dest);
 
     if (destGcsPath && destInfo) {
       const destFileName = dest.split("/").pop() ?? dest;
-      await linkedFile.updateMount({
+      await linkedFileResource.updateMount({
         destFileName,
         destMountFilePath: destGcsPath,
         destUseCase: destInfo.useCase,
@@ -341,12 +345,16 @@ export async function deleteCanonicalFile(
   dustFs: DustFileSystem,
   scopedPath: string
 ): Promise<Result<void, DustFileSystemError>> {
-  const linkedFile = await fetchLinkedFile(auth, dustFs, scopedPath);
-  if (!linkedFile) {
+  const linkedFileResource = await fetchLinkedFileResource(
+    auth,
+    dustFs,
+    scopedPath
+  );
+  if (!linkedFileResource) {
     return dustFs.delete(scopedPath);
   }
 
-  const deleteResult = await linkedFile.delete(auth);
+  const deleteResult = await linkedFileResource.delete(auth);
   if (deleteResult.isErr()) {
     return new Err(
       new DustFileSystemError("internal", deleteResult.error.message)

--- a/front/pages/api/w/[wId]/files/path/[...canonicalPath].ts
+++ b/front/pages/api/w/[wId]/files/path/[...canonicalPath].ts
@@ -5,6 +5,7 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import type { DustFileSystemError } from "@app/lib/api/file_system/types";
 import {
+  deleteCanonicalFile,
   moveCanonicalFile,
   renameCanonicalFile,
   streamThumbnail,
@@ -246,7 +247,11 @@ async function handler(
     }
 
     case "DELETE": {
-      const deleteResult = await dustFs.delete(canonicalPath);
+      const deleteResult = await deleteCanonicalFile(
+        auth,
+        dustFs,
+        canonicalPath
+      );
       if (deleteResult.isErr()) {
         return apiError(req, res, mapDustFsError(deleteResult.error));
       }

--- a/front/pages/api/w/[wId]/files/path/canonicalPath.test.ts
+++ b/front/pages/api/w/[wId]/files/path/canonicalPath.test.ts
@@ -18,6 +18,7 @@ vi.mock("@app/lib/api/files/file_system_ops", async (importOriginal) => {
     streamThumbnail: vi.fn(),
     renameCanonicalFile: vi.fn(),
     moveCanonicalFile: vi.fn(),
+    deleteCanonicalFile: vi.fn(),
   };
 });
 
@@ -624,7 +625,10 @@ describe("DELETE /api/w/[wId]/files/path/[...canonicalPath]", () => {
     });
 
     vi.spyOn(DustFileSystem, "fromScopedPath").mockResolvedValue(
-      new Ok(makeMockFs({ found: true }))
+      new Ok(makeMockFs())
+    );
+    vi.mocked(fileSystemOps.deleteCanonicalFile).mockResolvedValue(
+      new Ok(undefined)
     );
 
     req.query = {
@@ -635,6 +639,7 @@ describe("DELETE /api/w/[wId]/files/path/[...canonicalPath]", () => {
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(204);
+    expect(fileSystemOps.deleteCanonicalFile).toHaveBeenCalledOnce();
   });
 
   it("returns 404 when the file does not exist", async () => {
@@ -642,16 +647,11 @@ describe("DELETE /api/w/[wId]/files/path/[...canonicalPath]", () => {
       method: "DELETE",
     });
 
-    const mockFs = {
-      delete: vi
-        .fn()
-        .mockResolvedValue(
-          new Err(new DustFileSystemError("not_found", "File not found."))
-        ),
-    } as unknown as DustFileSystem;
-
     vi.spyOn(DustFileSystem, "fromScopedPath").mockResolvedValue(
-      new Ok(mockFs)
+      new Ok(makeMockFs())
+    );
+    vi.mocked(fileSystemOps.deleteCanonicalFile).mockResolvedValue(
+      new Err(new DustFileSystemError("not_found", "File not found."))
     );
 
     req.query = {


### PR DESCRIPTION
## Description

This PR fixes a bug where deleting a file via the file system API only removed the GCS object but left the linked `FileResource` database record orphaned.

This caused a bug when uploading a file => deleting it => uploading it again (on gcs if would be uploaded with the fileId as suffix) => renaming it to the original name

- Adds a `deleteCanonicalFile` function in `file_system_ops.ts` that looks up the linked `FileResource` for the given path and deletes it (which handles GCS cleanup); falls back to a direct GCS delete if no `FileResource` exists.
- Extracts a shared `fetchLinkedFile` helper, removing duplicated lookup logic from `moveCanonicalFile` and `renameCanonicalFile`.
- Updates both the Pages API and front-api DELETE handlers to call `deleteCanonicalFile` instead of `dustFs.delete()` directly.

## Tests

Unit test added for the new behavior.

## Risk

<!-- Discuss potential risks and how they will be mitigated. -->

## Deploy Plan

<!-- Outline the deployment steps. -->
