### PR TITLE
fix(mobile): stop conversation SSE streams leaking after navigating away

### DIFF
--- a/x/adrsimon/mobile/Dust/Services/StreamingService.swift
+++ b/x/adrsimon/mobile/Dust/Services/StreamingService.swift
@@ -52,6 +52,7 @@ enum StreamingService {
                     )
                     defer { session.invalidateAndCancel() }
                     try await readLines(from: bytes, into: continuation)
+                    logger.info("SSE disconnected: \(endpoint)")
                     continuation.finish()
                 } catch {
                     if !Task.isCancelled {
@@ -62,6 +63,7 @@ enum StreamingService {
             }
 
             continuation.onTermination = { _ in
+                logger.info("SSE cancelled: \(endpoint)")
                 task.cancel()
             }
         }

--- a/x/adrsimon/mobile/Dust/ViewModels/ConversationDetailViewModel.swift
+++ b/x/adrsimon/mobile/Dust/ViewModels/ConversationDetailViewModel.swift
@@ -124,15 +124,14 @@ final class ConversationDetailViewModel: ObservableObject {
 
     private func startConversationEvents() {
         conversationEventsTask?.cancel()
-        conversationEventsTask = Task { [weak self] in
-            guard let self else { return }
+        conversationEventsTask = Task { [weak self, workspaceId, conversationId = conversation.sId, tokenProvider] in
             var retryDelay: UInt64 = 1_000_000_000 // 1s
             let maxDelay: UInt64 = 30_000_000_000 // 30s
 
             while !Task.isCancelled {
                 let endpoint = AppConfig.Endpoints.conversationEvents(
                     workspaceId: workspaceId,
-                    conversationId: conversation.sId
+                    conversationId: conversationId
                 )
 
                 let stream = StreamingService.eventStream(
@@ -150,7 +149,7 @@ final class ConversationDetailViewModel: ObservableObject {
 
                         do {
                             let envelope = try decoder.decode(ConversationEventEnvelope.self, from: data)
-                            await handleConversationEvent(envelope.data)
+                            await self?.handleConversationEvent(envelope.data)
                         } catch {
                             logger.debug("Skipping unhandled conversation event: \(error)")
                         }
@@ -252,11 +251,10 @@ final class ConversationDetailViewModel: ObservableObject {
         currentThinkingBuffer = ""
         stepCounter = 0
 
-        messageStreamTask = Task { [weak self] in
-            guard let self else { return }
+        messageStreamTask = Task { [weak self, workspaceId, conversationId = conversation.sId, tokenProvider] in
             let endpoint = AppConfig.Endpoints.messageEvents(
                 workspaceId: workspaceId,
-                conversationId: conversation.sId,
+                conversationId: conversationId,
                 messageId: messageId
             )
 
@@ -274,7 +272,7 @@ final class ConversationDetailViewModel: ObservableObject {
 
                     do {
                         let envelope = try decoder.decode(SSEEnvelope.self, from: data)
-                        await handleMessageEvent(envelope.data, messageId: messageId)
+                        await self?.handleMessageEvent(envelope.data, messageId: messageId)
                     } catch {
                         logger.debug("Skipping unhandled message event: \(error)")
                     }
@@ -287,6 +285,7 @@ final class ConversationDetailViewModel: ObservableObject {
 
             // Stream ended — only clean up if we're still the active generation
             // and not in a blocking state (approval/auth persist until resolved)
+            guard let self else { return }
             if streamGeneration == currentGeneration {
                 switch streamingPhase {
                 case .approvalRequired, .personalAuthRequired, .fileAuthRequired:


### PR DESCRIPTION
## Description

Each conversation detail screen opens a long-lived SSE connection to `/conversations/{id}/events` (and a per-message stream while an agent replies). Both stream tasks captured `self` strongly via `guard let self` at the top of their loop, which pinned the view model for the lifetime of the task. Since the events loop runs `while !Task.isCancelled` and is only cancelled in `deinit`, `deinit` could never fire — so leaving a conversation left its SSE loop reconnecting forever. Visiting several conversations left an equal number of streams reconnecting indefinitely on the main menu, each triggering a token refresh on every reconnect.

Fix: capture the immutable inputs (`workspaceId`, `conversationId`, `tokenProvider`) by value and reference `self` weakly inside the loops. The task no longer retains the view model, so `deinit` fires when the screen is popped and cancels the stream. Also added `SSE disconnected` / `SSE cancelled` logs so teardown is observable.

## Tests

Manual: opened several conversations, navigated back, and confirmed via logs that streams now emit `SSE cancelled` on dismissal and stop reconnecting (previously they kept reconnecting from the conversation list). No SSE activity remains while idle on the main menu.

## Risk

Low. Behavior-only change to stream lifecycle in the mobile app; no API or schema changes. The weak-self handlers no-op if the view model is gone, which is the desired teardown behavior. Safe to roll back by reverting.

## Deploy Plan

Ships with the next mobile build. No backend coordination required.