### PR TITLE
Pause salesforce on app_not_found

### DIFF
--- a/connectors/src/connectors/salesforce/lib/oauth.ts
+++ b/connectors/src/connectors/salesforce/lib/oauth.ts
@@ -45,6 +45,7 @@ function isSalesforceSignInError(err: unknown): err is Error {
       "Error retrieving access token from salesforce: code=provider_access_token_refresh_error"
     ) &&
     (err.message.includes("invalid_grant") ||
-      err.message.includes("oauth_flow_disabled"))
+      err.message.includes("oauth_flow_disabled") ||
+      err.message.includes("app_not_found"))
   );
 }


### PR DESCRIPTION
## Description

Salesforce token refresh can fail with `app_not_found` ("External client app is not installed in this org") when the Connected App is removed from the customer's org. This is unrecoverable until they re-install/re-authorize, but it was not classified as an auth error, so the connector kept retrying instead of pausing.

This adds `app_not_found` to `isSalesforceSignInError`, so it throws `ExternalOAuthTokenError` → `ActivityInboundLogInterceptor` pauses and stops the connector (`oauth_token_revoked`).

## Risk

Low. Only widens existing auth-error matching; safe to roll back.