### PR TITLE
Fix blank agent generation

### DIFF
--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -566,6 +566,90 @@ describe("useAgentMessageStream", () => {
     expect(currentMessage.content).toBe("");
   });
 
+  it("keeps the success payload content when only activity tokens streamed", () => {
+    let currentMessage = makeInitialMessageStreamState(
+      makeLightAgentMessage({ content: null, chainOfThought: null })
+    );
+    let onEventCallback: ((event: string) => void) | null = null;
+
+    mockUseVirtuosoMethods.mockReturnValue(
+      makeVirtuosoMethodsMock(
+        (
+          updater: (message: typeof currentMessage) => typeof currentMessage
+        ) => {
+          currentMessage = updater(currentMessage);
+          return [currentMessage];
+        }
+      )
+    );
+
+    mockUseEventSource.mockImplementation(
+      (
+        _buildURL: unknown,
+        callback: (event: string) => void
+      ): { isError: null } => {
+        onEventCallback = callback;
+        return { isError: null };
+      }
+    );
+
+    renderHook(() =>
+      useAgentMessageStream({
+        agentMessage: currentMessage,
+        conversationId: "conv_123",
+        isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
+        owner: mockOwner,
+        streamId: "stream_123",
+      })
+    );
+
+    act(() => {
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "1-0",
+          data: {
+            type: "generation_tokens",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            text: "I should inspect the tool results first.",
+            classification: "chain_of_thought",
+          },
+        })
+      );
+      onEventCallback!(
+        JSON.stringify({
+          eventId: "2-0",
+          data: {
+            type: "agent_message_success",
+            created: Date.now(),
+            configurationId: "agent_123",
+            messageId: currentMessage.sId,
+            message: {
+              ...makeLightAgentMessage({
+                content: "Here is the final answer from the model.",
+                chainOfThought: "I should inspect the tool results first.",
+              }),
+              actions: [],
+            },
+          },
+        })
+      );
+    });
+
+    expect(currentMessage.content).toBe(
+      "Here is the final answer from the model."
+    );
+    expect(currentMessage.streaming.agentState).toBe("done");
+    expect(currentMessage.streaming.inlineActivitySteps).toEqual([
+      {
+        type: "thinking",
+        content: "I should inspect the tool results first.",
+        id: expect.stringContaining("thinking-final-"),
+      },
+    ]);
+  });
+
   it("discards stale tokens from prior Temporal retries at tool_params", () => {
     let currentMessage = makeInitialMessageStreamState(
       makeLightAgentMessage({ content: null, chainOfThought: null })

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -810,12 +810,12 @@ export function useAgentMessageStream({
           // content.current tracks only the final text segment (intermediate
           // segments were flushed to content steps). The server's full message
           // includes ALL text, so we override with the tracked final segment.
-          // Only override when tokens were actually streamed (lastClassification
-          // is non-null); otherwise the content was set server-side without
-          // streaming (e.g. prompt commands like /list) and the server's value
-          // should be used as-is.
+          // Only override when final answer tokens were actually streamed.
+          // Reasoning/activity-only streams still receive the canonical answer
+          // in the success payload; overriding those with the empty token
+          // buffer would hide the final generation until reload.
           const finalSegment = content.current;
-          const hadStreamedTokens = lastClassification.current !== null;
+          const hadStreamedTokens = lastClassification.current === "tokens";
           lastClassification.current = null;
           mapMessagesWithAutoScroll((m) => {
             if (!isAgentMessageWithStreaming(m) || m.sId !== sId) {


### PR DESCRIPTION
## Description

## Summary

Fixes a UI bug where an agent message could stream inline activity/thinking steps, finish successfully, but show no final answer until the page was reloaded.

This mostly showed up in tool-heavy conversations and with GPT models because those runs can emit activity/reasoning stream events before the final `agent_message_success` payload.

## Root Cause

In `useAgentMessageStream`, the terminal success handler used:

```ts
const hadStreamedTokens = lastClassification.current !== null;
```

That treated both answer tokens and chain_of_thought/activity tokens as streamed final content.
So when the stream had activity/reasoning events but no final answer token segment, the success handler would apply the canonical backend message and then overwrite its content with finalSegment || null.
Because finalSegment was empty in activity-only streams, the visible message content became null. Reloading fixed the display because the backend message content was correct.

## Fix

Only override the server-provided message content when actual final answer tokens were streamed:
```ts
const hadStreamedTokens = lastClassification.current === "tokens";
```
For activity/reasoning-only streams, we now keep the canonical message.content from the agent_message_success payload.



## Tests

Added some tests, will also test manually before shipping. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy fonrt. 