### PR TITLE
[front-api] Port /subtle1 PostHog reverse proxy from Next rewrites

### DIFF
--- a/front-api/app.ts
+++ b/front-api/app.ts
@@ -25,6 +25,7 @@ import pokeApp from "./routes/poke";
 import shareApp from "./routes/share";
 import sseApp from "./routes/sse";
 import stripeApp from "./routes/stripe";
+import subtle1App from "./routes/subtle1";
 import tApp from "./routes/t";
 import templatesApp from "./routes/templates";
 import userApp from "./routes/user";
@@ -84,4 +85,7 @@ export const honoApp = createHono();
 honoApp.use("*", requestLogger);
 honoApp.use("*", cors);
 honoApp.route("/api", apiApp);
+// PostHog reverse proxy lives at the domain root (not under /api), matching
+// the `/subtle1` rewrites in front/next.config.js.
+honoApp.route("/subtle1", subtle1App);
 honoApp.onError(unhandledErrorHandler);

--- a/front-api/routes/subtle1.test.ts
+++ b/front-api/routes/subtle1.test.ts
@@ -1,0 +1,67 @@
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+function getUpstreamRequest(): Request {
+  const [input] = fetchSpy.mock.calls[0];
+  if (!(input instanceof Request)) {
+    throw new Error("Expected fetch to be called with a Request");
+  }
+  return input;
+}
+
+describe("/subtle1 PostHog proxy", () => {
+  beforeEach(() => {
+    fetchSpy.mockReset();
+    fetchSpy.mockResolvedValue(new Response("ok", { status: 200 }));
+  });
+
+  it("proxies ingestion requests to eu.i.posthog.com, preserving path and query", async () => {
+    const response = await honoApp.request("/subtle1/decide/?v=3&ip=1");
+
+    expect(response.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(getUpstreamRequest().url).toBe(
+      "https://eu.i.posthog.com/decide/?v=3&ip=1"
+    );
+  });
+
+  it("proxies static asset requests to eu-assets.i.posthog.com", async () => {
+    const response = await honoApp.request("/subtle1/static/array.js");
+
+    expect(response.status).toBe(200);
+    expect(getUpstreamRequest().url).toBe(
+      "https://eu-assets.i.posthog.com/static/array.js"
+    );
+  });
+
+  it("forwards method and body, and drops the client Host header", async () => {
+    const response = await honoApp.request("/subtle1/e/", {
+      method: "POST",
+      body: '{"batch":[]}',
+      headers: {
+        "content-type": "application/json",
+        host: "us-api.dust.tt",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const upstreamRequest = getUpstreamRequest();
+    expect(upstreamRequest.url).toBe("https://eu.i.posthog.com/e/");
+    expect(upstreamRequest.method).toBe("POST");
+    expect(await upstreamRequest.text()).toBe('{"batch":[]}');
+    expect(upstreamRequest.headers.get("content-type")).toBe(
+      "application/json"
+    );
+    expect(upstreamRequest.headers.get("host")).toBeNull();
+  });
+
+  it("relays upstream error statuses", async () => {
+    fetchSpy.mockResolvedValue(new Response("nope", { status: 502 }));
+
+    const response = await honoApp.request("/subtle1/e/", { method: "POST" });
+
+    expect(response.status).toBe(502);
+  });
+});

--- a/front-api/routes/subtle1.ts
+++ b/front-api/routes/subtle1.ts
@@ -1,0 +1,34 @@
+import { createHono } from "@front-api/lib/hono";
+import type { Context } from "hono";
+import { proxy } from "hono/proxy";
+
+// PostHog ingestion reverse proxy, mirroring the `/subtle1` rewrites in
+// front/next.config.js. The obfuscated path name keeps analytics requests
+// from being flagged by ad blockers (see PostHogTracker.tsx which points
+// the PostHog client's api_host at `<api base url>/subtle1`).
+const POSTHOG_INGESTION_URL = "https://eu.i.posthog.com";
+const POSTHOG_ASSETS_URL = "https://eu-assets.i.posthog.com";
+
+// Mounted at /subtle1 (root level, not under /api).
+const app = createHono();
+
+const proxyToPostHog = (upstreamBaseUrl: string) => (c: Context) => {
+  const url = new URL(c.req.url);
+  const upstreamPath = url.pathname.replace(/^\/subtle1/, "");
+
+  // Drop the client's Host header so fetch derives it from the upstream URL;
+  // forwarding our own host would break PostHog's routing. Hop-by-hop headers
+  // (connection, keep-alive, ...) are stripped by the proxy helper itself.
+  const headers = new Headers(c.req.raw.headers);
+  headers.delete("host");
+
+  return proxy(
+    `${upstreamBaseUrl}${upstreamPath}${url.search}`,
+    new Request(c.req.raw, { headers })
+  );
+};
+
+app.all("/static/*", proxyToPostHog(POSTHOG_ASSETS_URL));
+app.all("/*", proxyToPostHog(POSTHOG_INGESTION_URL));
+
+export default app;


### PR DESCRIPTION

## Description

The Next app proxies /subtle1/* to PostHog EU (rewrites in next.config.js) as an ad-blocker-evading ingestion endpoint; PostHogTracker points the client's api_host at <api base url>/subtle1. Mirror the rewrites in Hono using the hono/proxy helper, mounted at the domain root.

## Tests

Added

## Risk

Low

## Deploy Plan

Front