### PR TITLE
Fix missing user in metronome event when posting message on behalf

### DIFF
--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -259,7 +259,12 @@ export async function emitMetronomeUsageEventsActivity(
     ],
   });
 
-  const userId = userMessageRow?.userMessage?.user?.sId ?? null;
+  // Prefer the user associated with the UserMessage row; fall back to the
+  // user on the authenticator (covers doNotAssociateUser messages like
+  // pod_manager sub-conversations where the DB row has no user but the auth
+  // still carries the original session user).
+  const userId =
+    userMessageRow?.userMessage?.user?.sId ?? auth.user()?.sId ?? null;
 
   // Sub-agent messages have agenticMessageType set (e.g. "run_agent", "agent_handover").
   // agenticOriginMessageId is the sId of the parent agent message that spawned this one.


### PR DESCRIPTION
## Description

Issue: we have a `user: unknown` in the metronome events when posting in a pod on behalf of a user (only when pinging an agent)

<img width="876" height="650" alt="image" src="https://github.com/user-attachments/assets/22937971-2435-44b1-9bd5-e097ae8cde02" />


## Tests

Tested locally, before the fix I had empty user
```
[workers] [17:33:50.116] INFO (82492): [Metronome] LLM usage event {"workspaceId":"DevWkSpace","agentId":"dust","origin":"web","usageType":"user","userId":null,"modelId":"claude-sonnet-4-6","costAwu":2,"isSubAgentMessage":false}
```
With the fix I have the user:
```
[workers] [17:38:46.846] INFO (93474): [Metronome] LLM usage event {"workspaceId":"DevWkSpace","agentId":"dust","origin":"web","usageType":"user","userId":"ETDa5wLhO3","modelId":"claude-sonnet-4-6","costAwu":2,"isSubAgentMessage":false}
```


## Risk

low

## Deploy Plan

deploy front