### PR TITLE
Adds pods shortcut to Command Palette

### DIFF
--- a/front/components/command_palette/CommandPalette.tsx
+++ b/front/components/command_palette/CommandPalette.tsx
@@ -1,5 +1,8 @@
 import { AgentDetailsSheet } from "@app/components/assistant/details/AgentDetailsSheet";
-import type { CommandPaletteAction } from "@app/components/command_palette/CommandPaletteActionPhase";
+import type {
+  ActionPhaseItem,
+  CommandPaletteAction,
+} from "@app/components/command_palette/CommandPaletteActionPhase";
 import { CommandPaletteActionPhase } from "@app/components/command_palette/CommandPaletteActionPhase";
 import { useCommandPalette } from "@app/components/command_palette/CommandPaletteContext";
 import type { CommandPaletteItem } from "@app/components/command_palette/CommandPaletteSearchPhase";
@@ -8,13 +11,16 @@ import { SkillDetailsSheetById } from "@app/components/command_palette/SkillDeta
 import { useAppRouter } from "@app/lib/platform";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import { useSkills } from "@app/lib/swr/skill_configurations";
+import { useSpaces } from "@app/lib/swr/spaces";
 import { filterAndSortAgents, subFilter } from "@app/lib/utils";
 import {
   getAgentBuilderRoute,
   getConversationRoute,
+  getPodRoute,
   getSkillBuilderRoute,
 } from "@app/lib/utils/router";
 import { compareAgentsForSort } from "@app/types/assistant/assistant";
+import { isProjectType } from "@app/types/space";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import { Dialog, DialogContent } from "@dust-tt/sparkle";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -32,7 +38,7 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [phase, setPhase] = useState<"search" | "action">("search");
   const [selectedIndex, setSelectedIndex] = useState(0);
-  const [selectedItem, setSelectedItem] = useState<CommandPaletteItem | null>(
+  const [selectedItem, setSelectedItem] = useState<ActionPhaseItem | null>(
     null
   );
 
@@ -53,6 +59,16 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
     disabled: !isOpen,
     status: "active",
   });
+
+  const { spaces, isSpacesLoading } = useSpaces({
+    workspaceId: owner.sId,
+    kinds: ["project"],
+    disabled: !isOpen,
+  });
+  const memberPods = useMemo(
+    () => spaces.filter(isProjectType).filter((p) => p.archivedAt === null),
+    [spaces]
+  );
 
   // Debounce the search query to avoid expensive fuzzy filtering on every keystroke.
   const [debouncedQuery, setDebouncedQuery] = useState("");
@@ -78,8 +94,9 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
   // Cap the number of rendered items to avoid slow DOM rendering on large workspaces.
   // This is a temporary measure until the command palette moves to Sparkle with
   // proper list virtualization (@tanstack/react-virtual).
-  const MAX_DISPLAYED_AGENTS = 25;
-  const MAX_DISPLAYED_SKILLS = 15;
+  const MAX_DISPLAYED_AGENTS = 5;
+  const MAX_DISPLAYED_PODS = 5;
+  const MAX_DISPLAYED_SKILLS = 5;
 
   const allFilteredAgents = useMemo(
     () =>
@@ -89,6 +106,16 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
     [agentConfigurations, debouncedQuery]
   );
 
+  const allFilteredPods = useMemo(() => {
+    if (!debouncedQuery) {
+      return memberPods;
+    }
+    const lowerQuery = debouncedQuery.toLowerCase();
+    return memberPods.filter((p) =>
+      subFilter(lowerQuery, p.name.toLowerCase())
+    );
+  }, [memberPods, debouncedQuery]);
+
   const allFilteredSkills = useMemo(() => {
     if (!debouncedQuery) {
       return skills;
@@ -97,13 +124,30 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
     return skills.filter((s) => subFilter(lowerQuery, s.name.toLowerCase()));
   }, [skills, debouncedQuery]);
 
-  const filteredAgents = allFilteredAgents.slice(0, MAX_DISPLAYED_AGENTS);
-  const filteredSkills = allFilteredSkills.slice(0, MAX_DISPLAYED_SKILLS);
-  const hasMoreAgents = allFilteredAgents.length > MAX_DISPLAYED_AGENTS;
-  const hasMoreSkills = allFilteredSkills.length > MAX_DISPLAYED_SKILLS;
+  const {
+    filteredAgents,
+    filteredPods,
+    filteredSkills,
+    hasMoreAgents,
+    hasMorePods,
+    hasMoreSkills,
+  } = useMemo(
+    () => ({
+      filteredAgents: allFilteredAgents.slice(0, MAX_DISPLAYED_AGENTS),
+      filteredPods: allFilteredPods.slice(0, MAX_DISPLAYED_PODS),
+      filteredSkills: allFilteredSkills.slice(0, MAX_DISPLAYED_SKILLS),
+      hasMoreAgents: allFilteredAgents.length > MAX_DISPLAYED_AGENTS,
+      hasMorePods: allFilteredPods.length > MAX_DISPLAYED_PODS,
+      hasMoreSkills: allFilteredSkills.length > MAX_DISPLAYED_SKILLS,
+    }),
+    [allFilteredAgents, allFilteredPods, allFilteredSkills]
+  );
 
   const isLoading =
-    isAgentConfigurationsLoading || isSkillsLoading || isDebouncing;
+    isAgentConfigurationsLoading ||
+    isSkillsLoading ||
+    isSpacesLoading ||
+    isDebouncing;
 
   // Reset state when dialog opens/closes.
   useEffect(() => {
@@ -131,14 +175,14 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
         case "view_details":
           if (item.kind === "agent") {
             setAgentDetailsId(item.agent.sId);
-          } else {
+          } else if (item.kind === "skill") {
             setSkillDetailsId(item.skill.sId);
           }
           break;
         case "edit":
           if (item.kind === "agent") {
             void router.push(getAgentBuilderRoute(owner.sId, item.agent.sId));
-          } else {
+          } else if (item.kind === "skill") {
             void router.push(getSkillBuilderRoute(owner.sId, item.skill.sId));
           }
           break;
@@ -149,6 +193,11 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
 
   const handleItemSelect = useCallback(
     (item: CommandPaletteItem) => {
+      if (item.kind === "pod") {
+        close();
+        void router.push(getPodRoute(owner.sId, item.pod.sId));
+        return;
+      }
       // Skills without write access have only one action (view details).
       if (item.kind === "skill" && !item.skill.canWrite) {
         executeAction(item, "view_details");
@@ -157,7 +206,7 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
         setPhase("action");
       }
     },
-    [executeAction]
+    [close, executeAction, owner.sId, router]
   );
 
   const handleBack = useCallback(() => {
@@ -192,8 +241,10 @@ export function CommandPalette({ owner, user }: CommandPaletteProps) {
               searchQuery={searchQuery}
               onSearchQueryChange={setSearchQuery}
               agents={filteredAgents}
+              pods={filteredPods}
               skills={filteredSkills}
               hasMoreAgents={hasMoreAgents}
+              hasMorePods={hasMorePods}
               hasMoreSkills={hasMoreSkills}
               isLoading={isLoading}
               selectedIndex={selectedIndex}

--- a/front/components/command_palette/CommandPaletteActionPhase.tsx
+++ b/front/components/command_palette/CommandPaletteActionPhase.tsx
@@ -14,8 +14,14 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 
 export type CommandPaletteAction = "view_details" | "edit" | "chat_with";
 
+// Pods navigate directly and never enter the action phase.
+export type ActionPhaseItem = Extract<
+  CommandPaletteItem,
+  { kind: "agent" | "skill" }
+>;
+
 interface CommandPaletteActionPhaseProps {
-  item: CommandPaletteItem;
+  item: ActionPhaseItem;
   onAction: (action: CommandPaletteAction) => void;
   onBack: () => void;
   onClose: () => void;
@@ -28,7 +34,7 @@ interface ActionDefinition {
   icon: typeof EyeIcon;
 }
 
-function canEdit(item: CommandPaletteItem): boolean {
+function canEdit(item: ActionPhaseItem): boolean {
   switch (item.kind) {
     case "agent":
       return item.agent.canEdit;

--- a/front/components/command_palette/CommandPaletteSearchPhase.tsx
+++ b/front/components/command_palette/CommandPaletteSearchPhase.tsx
@@ -5,21 +5,26 @@ import {
   KeyboardHints,
 } from "@app/components/command_palette/CommandPaletteItems";
 import { getSkillAvatarIcon } from "@app/lib/skill";
+import { getSpaceIcon } from "@app/lib/spaces";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
-import { Avatar, SearchInput } from "@dust-tt/sparkle";
+import type { PodType } from "@app/types/space";
+import { Avatar, Icon, SearchInput } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useRef } from "react";
 
 export type CommandPaletteItem =
   | { kind: "agent"; agent: LightAgentConfigurationType }
+  | { kind: "pod"; pod: PodType }
   | { kind: "skill"; skill: SkillWithoutInstructionsAndToolsType };
 
 interface CommandPaletteSearchPhaseProps {
   searchQuery: string;
   onSearchQueryChange: (query: string) => void;
   agents: LightAgentConfigurationType[];
+  pods: PodType[];
   skills: SkillWithoutInstructionsAndToolsType[];
   hasMoreAgents: boolean;
+  hasMorePods: boolean;
   hasMoreSkills: boolean;
   isLoading: boolean;
   selectedIndex: number;
@@ -30,10 +35,12 @@ interface CommandPaletteSearchPhaseProps {
 
 function getFlatItems(
   agents: LightAgentConfigurationType[],
+  pods: PodType[],
   skills: SkillWithoutInstructionsAndToolsType[]
 ): CommandPaletteItem[] {
   return [
     ...agents.map((agent): CommandPaletteItem => ({ kind: "agent", agent })),
+    ...pods.map((pod): CommandPaletteItem => ({ kind: "pod", pod })),
     ...skills.map((skill): CommandPaletteItem => ({ kind: "skill", skill })),
   ];
 }
@@ -42,8 +49,10 @@ export function CommandPaletteSearchPhase({
   searchQuery,
   onSearchQueryChange,
   agents,
+  pods,
   skills,
   hasMoreAgents,
+  hasMorePods,
   hasMoreSkills,
   isLoading,
   selectedIndex,
@@ -52,8 +61,8 @@ export function CommandPaletteSearchPhase({
   onClose,
 }: CommandPaletteSearchPhaseProps) {
   const flatItems = useMemo(
-    () => getFlatItems(agents, skills),
-    [agents, skills]
+    () => getFlatItems(agents, pods, skills),
+    [agents, pods, skills]
   );
   const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -73,10 +82,10 @@ export function CommandPaletteSearchPhase({
   }, [selectedIndex]);
 
   // Reset selection when the number of results changes (e.g., after typing).
-  // biome-ignore lint/correctness/useExhaustiveDependencies: agents.length and skills.length are intentional triggers
+  // biome-ignore lint/correctness/useExhaustiveDependencies: agents.length, pods.length and skills.length are intentional triggers
   useEffect(() => {
     onSelectedIndexChange(0);
-  }, [agents.length, skills.length, onSelectedIndexChange]);
+  }, [agents.length, pods.length, skills.length, onSelectedIndexChange]);
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     const totalItems = flatItems.length;
@@ -113,7 +122,7 @@ export function CommandPaletteSearchPhase({
         <SearchInput
           ref={searchInputRef}
           name="command-palette-search"
-          placeholder="Search agents and skills…"
+          placeholder="Search agents, pods and skills…"
           value={searchQuery}
           onChange={onSearchQueryChange}
           onKeyDown={handleKeyDown}
@@ -138,7 +147,9 @@ export function CommandPaletteSearchPhase({
           <ItemEmptyState>No results found.</ItemEmptyState>
         )}
         {!isLoading && flatItems.length === 0 && searchQuery.length === 0 && (
-          <ItemEmptyState>Type to search agents and skills.</ItemEmptyState>
+          <ItemEmptyState>
+            Type to search agents, pods and skills.
+          </ItemEmptyState>
         )}
 
         {agents.length > 0 && (
@@ -174,11 +185,51 @@ export function CommandPaletteSearchPhase({
           </div>
         )}
 
+        {pods.length > 0 && (
+          <div>
+            <ItemTitle>Pods</ItemTitle>
+            {pods.map((pod, i) => {
+              const globalIndex = agents.length + i;
+              return (
+                <ItemRow
+                  key={pod.sId}
+                  ref={(el) => {
+                    itemRefs.current[globalIndex] = el;
+                  }}
+                  isSelected={selectedIndex === globalIndex}
+                  onClick={() => onItemSelect({ kind: "pod", pod })}
+                  onMouseEnter={() => onSelectedIndexChange(globalIndex)}
+                >
+                  <Icon visual={getSpaceIcon(pod)} size="xs" />
+                  <div className="flex min-w-0 items-center gap-1.5">
+                    <span className="shrink-0 font-medium">{pod.name}</span>
+                    {pod.description && (
+                      <>
+                        <span className="shrink-0 text-muted-foreground dark:text-muted-foreground-night">
+                          -
+                        </span>
+                        <span className="min-w-0 truncate text-muted-foreground dark:text-muted-foreground-night">
+                          {pod.description}
+                        </span>
+                      </>
+                    )}
+                  </div>
+                </ItemRow>
+              );
+            })}
+            {hasMorePods && (
+              <div className="px-3 py-2 text-xs text-muted-foreground dark:text-muted-foreground-night">
+                More pods available. Type to filter.
+              </div>
+            )}
+          </div>
+        )}
+
         {skills.length > 0 && (
           <div>
             <ItemTitle>Skills</ItemTitle>
             {skills.map((skill, i) => {
-              const globalIndex = agents.length + i;
+              const globalIndex = agents.length + pods.length + i;
               const SkillAvatar = getSkillAvatarIcon(skill.icon);
               return (
                 <ItemRow


### PR DESCRIPTION
## Description

Add Pods to the command palette. 
Order is 5 agents > 5 Pods > 5 skills. 


(Next PR I'll improve the agent listed using https://github.com/dust-tt/dust/blob/main/front/lib/api/assistant/conversation/mention_suggestions.ts#L144. Then I'll fix the scroll behavior when using arrow keys, it's broken, but was not introduced in this PR)

## Tests

Locally.
On the review app.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 