### PR TITLE
fix: rename projects to pods in notifications

### DIFF
--- a/front/lib/notifications/email-templates/conversations-unread.tsx
+++ b/front/lib/notifications/email-templates/conversations-unread.tsx
@@ -149,7 +149,7 @@ const ConversationsUnreadEmailTemplate = ({
               ? newProjectConversations.length === 1
                 ? `There's a new conversation in ${uniqueProjectNames[0]}:`
                 : `There are ${newProjectConversations.length} new conversations in ${uniqueProjectNames[0]}:`
-              : `There are ${newProjectConversations.length} new conversations in your projects:`}
+              : `There are ${newProjectConversations.length} new conversations in your Pods:`}
           </p>
           <div>
             {newProjectConversations.map((conversation) => (

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -737,7 +737,7 @@ const getEmailSubject = (
     if (uniqueProjectNames.length === 1) {
       return `[Dust] New conversation${pluralize(conversations.length)} in '${uniqueProjectNames[0]}'`;
     }
-    return `[Dust] New conversations in your projects`;
+    return `[Dust] New conversations in your Pods`;
   }
   if (conversations.length === 1) {
     return `[Dust] ${conversations[0]?.title ?? "New unread message(s) in conversation"}`;

--- a/front/lib/notifications/workflows/project-added-as-member.ts
+++ b/front/lib/notifications/workflows/project-added-as-member.ts
@@ -44,7 +44,7 @@ const getProjectDetails = async ({
   subscriberId?: string | null;
   payload: ProjectAddedAsMemberPayloadType;
 }): Promise<ProjectDetailsType> => {
-  let projectName: string = "A project";
+  let projectName: string = "A Pod";
   let userThatAddedYouFullname: string = "Someone";
   let workspaceName: string = "A workspace";
 
@@ -120,7 +120,7 @@ export const projectAddedAsMemberWorkflow = workflow(
       async () => {
         return {
           subject: details.projectName,
-          body: `${details.userThatAddedYouFullname} added you to project "${details.projectName}".`,
+          body: `${details.userThatAddedYouFullname} added you to Pod "${details.projectName}".`,
           primaryAction: {
             label: "View",
             redirect: {
@@ -145,9 +145,9 @@ export const projectAddedAsMemberWorkflow = workflow(
           config.getAppUrl() +
           getPodRoute(payload.workspaceId, payload.projectId);
 
-        const baseMessage = `${details.userThatAddedYouFullname} added you to project "${details.projectName}"`;
+        const baseMessage = `${details.userThatAddedYouFullname} added you to Pod "${details.projectName}"`;
 
-        const message = `${baseMessage}\n<${projectUrl}|View project>`;
+        const message = `${baseMessage}\n<${projectUrl}|View Pod>`;
 
         return {
           body: message,
@@ -180,16 +180,16 @@ export const projectAddedAsMemberWorkflow = workflow(
             id: payload.workspaceId,
             name: details.workspaceName,
           },
-          content: `${details.userThatAddedYouFullname} added you to project "${details.projectName}".`,
+          content: `${details.userThatAddedYouFullname} added you to Pod "${details.projectName}".`,
           action: {
-            label: "View project",
+            label: "View Pod",
             url:
               config.getAppUrl() +
               getPodRoute(payload.workspaceId, payload.projectId),
           },
         });
         return {
-          subject: `[Dust] You were added to project '${details.projectName}'`,
+          subject: `[Dust] You were added to Pod '${details.projectName}'`,
           body,
         };
       },


### PR DESCRIPTION




## Description

This PR renames references from "project" to "Pod" in notification messages to align with the updated product terminology.

## Tests

Manually.

## Risks

## Deploy Plan

