### PR TITLE
Add available seats count

### DIFF
--- a/front/components/workspace/billing/BillingSeatsOverview.tsx
+++ b/front/components/workspace/billing/BillingSeatsOverview.tsx
@@ -92,9 +92,10 @@ export function BillingSeatsOverview({ owner }: BillingSeatsOverviewProps) {
   const { seatPlans, isSeatPlanLoading } = useSeatPlan({
     workspaceId: owner.sId,
   });
-  const { membersSeats, isMembersSeatsLoading } = useMembersSeats({
-    workspaceId: owner.sId,
-  });
+  const { membersSeats, metronomeSeats, isMembersSeatsLoading } =
+    useMembersSeats({
+      workspaceId: owner.sId,
+    });
 
   if (isSeatPlanLoading || isMembersSeatsLoading) {
     return (
@@ -134,21 +135,46 @@ export function BillingSeatsOverview({ owner }: BillingSeatsOverviewProps) {
     );
   });
 
+  // Total seats billed in Metronome per seat type (assigned + unassigned),
+  // grouped the same way as the member counts. `undefined` for a group means
+  // Metronome had nothing to report for it (so we hide the unassigned line).
+  const metronomeBilledBySeatType = new Map<MembershipSeatType, number>();
+
+  Object.entries(metronomeSeats).forEach(([seatType, billed]) => {
+    if (!isMembershipSeatType(seatType) || billed === undefined) {
+      return;
+    }
+
+    const groupSeatType = seatTypeGroup(seatType);
+    metronomeBilledBySeatType.set(
+      groupSeatType,
+      (metronomeBilledBySeatType.get(groupSeatType) ?? 0) + billed
+    );
+  });
+
   const plansWithMembers: Array<{
     seatType: MembershipSeatType;
     primaryPlan: SeatTypeInfo;
     membersCount: number;
+    unassignedCount: number | null;
   }> = Array.from(plansBySeatType.entries()).flatMap(([seatType, plans]) => {
     const primaryPlan = plans.monthly ?? plans.annual;
     if (!primaryPlan) {
       return [];
     }
 
+    const membersCount = membersCountBySeatType.get(seatType) ?? 0;
+    const billed = metronomeBilledBySeatType.get(seatType);
+
     return [
       {
         seatType,
         primaryPlan,
-        membersCount: membersCountBySeatType.get(seatType) ?? 0,
+        membersCount,
+        // Unassigned = billed seats not backed by a real member. Null when
+        // Metronome had no figure for this seat type.
+        unassignedCount:
+          billed === undefined ? null : Math.max(0, billed - membersCount),
       },
     ];
   });
@@ -167,7 +193,7 @@ export function BillingSeatsOverview({ owner }: BillingSeatsOverviewProps) {
   return (
     <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
       {orderedPlansWithMembers.map(
-        ({ seatType, primaryPlan, membersCount }) => {
+        ({ seatType, primaryPlan, membersCount, unassignedCount }) => {
           const avatarColors = seatTypeAvatarColors(seatType);
 
           return (
@@ -193,6 +219,9 @@ export function BillingSeatsOverview({ owner }: BillingSeatsOverviewProps) {
                   <span>
                     {membersCount.toLocaleString()}{" "}
                     {membersCount === 1 ? "seat assigned" : "seats assigned"}
+                    {unassignedCount !== null && unassignedCount > 0
+                      ? ` - ${unassignedCount.toLocaleString()} available`
+                      : ""}
                   </span>
                 </div>
                 <div className="flex items-center gap-2">

--- a/front/lib/api/credits/members_seats.ts
+++ b/front/lib/api/credits/members_seats.ts
@@ -1,11 +1,126 @@
 import type { Authenticator } from "@app/lib/auth";
+import { getMetronomeSubscriptionSeatState } from "@app/lib/metronome/client";
+import { getActiveContract } from "@app/lib/metronome/plan_type";
+import {
+  getProductSeatTypes,
+  getSeatSubscriptionsFromContract,
+} from "@app/lib/metronome/seat_types";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
 import type { MembershipSeatType } from "@app/types/memberships";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { Subscription } from "@metronome/sdk/resources";
 
 export type GetMembersSeatsResponseBody = {
+  // Active members per seat type, from the DB ("assigned" seats).
   seatTypes: Partial<Record<MembershipSeatType, number>>;
+  // Total seat quantity billed in Metronome per seat type (assigned +
+  // unassigned). Absent when the workspace isn't on a Metronome seat contract,
+  // or omitted for a seat type if Metronome couldn't be read. The UI derives
+  // the unassigned count as `metronomeSeats - seatTypes` per type.
+  metronomeSeats: Partial<Record<MembershipSeatType, number>>;
   total: number;
 };
+
+/**
+ * Read the current quantity from a subscription's `quantity_schedule` (used for
+ * QUANTITY_ONLY seats — `workspace`/`free`). The schedule lists the current
+ * quantity and future changes, each with a `starting_at`; pick the latest entry
+ * that has started and not yet ended.
+ *
+ * NOTE: this is only valid for QUANTITY_ONLY subs. For SEAT_BASED subs the
+ * schedule reports the base/proration quantity, not the seat-driven total —
+ * those go through `getMetronomeSubscriptionSeatState` instead.
+ */
+function currentQuantityFromSchedule(sub: Subscription): number {
+  const now = Date.now();
+  let quantity = 0;
+  let bestStartMs = Number.NEGATIVE_INFINITY;
+  for (const entry of sub.quantity_schedule ?? []) {
+    const startMs = Date.parse(entry.starting_at);
+    const endsOk =
+      !entry.ending_before || Date.parse(entry.ending_before) > now;
+    if (startMs <= now && endsOk && startMs >= bestStartMs) {
+      bestStartMs = startMs;
+      quantity = entry.quantity;
+    }
+  }
+  return quantity;
+}
+
+/**
+ * Best-effort: the seat quantity billed in Metronome per seat type (assigned +
+ * unassigned). Returns `{}` when the workspace has no Metronome seat contract,
+ * and silently omits any seat type whose live state can't be read so the DB
+ * counts are always returned.
+ */
+async function getMetronomeBilledSeatsByType(
+  workspace: LightWorkspaceType
+): Promise<Partial<Record<MembershipSeatType, number>>> {
+  if (!workspace.metronomeCustomerId) {
+    return {};
+  }
+
+  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+    workspace.id
+  );
+  if (!subscription?.metronomeContractId) {
+    return {};
+  }
+
+  const contract = await getActiveContract(workspace.sId);
+  if (!contract) {
+    return {};
+  }
+
+  const productSeatTypes = await getProductSeatTypes();
+  const seatSubscriptions: Array<[MembershipSeatType, Subscription]> = [
+    ...getSeatSubscriptionsFromContract(contract, productSeatTypes),
+  ];
+
+  const metronomeCustomerId = workspace.metronomeCustomerId;
+  const contractId = subscription.metronomeContractId;
+
+  const results = await concurrentExecutor(
+    seatSubscriptions,
+    async ([seatType, sub]): Promise<[MembershipSeatType, number] | null> => {
+      if (!sub.id) {
+        return null;
+      }
+      if (sub.quantity_management_mode === "SEAT_BASED") {
+        const state = await getMetronomeSubscriptionSeatState({
+          metronomeCustomerId,
+          contractId,
+          subscriptionId: sub.id,
+        });
+        if (state.isErr()) {
+          logger.warn(
+            { workspaceId: workspace.sId, seatType, err: state.error },
+            "[Metronome] Failed to read seat state for billed-seats overview"
+          );
+          return null;
+        }
+        return [
+          seatType,
+          state.value.assignedSeatIds.length + state.value.unassignedSeats,
+        ];
+      }
+      // QUANTITY_ONLY: the billed quantity lives on the quantity schedule.
+      return [seatType, currentQuantityFromSchedule(sub)];
+    },
+    { concurrency: 4 }
+  );
+
+  const metronomeSeats: Partial<Record<MembershipSeatType, number>> = {};
+  for (const result of results) {
+    if (result) {
+      metronomeSeats[result[0]] = result[1];
+    }
+  }
+  return metronomeSeats;
+}
 
 export async function getMembersSeats({
   auth,
@@ -18,8 +133,11 @@ export async function getMembersSeats({
       workspace,
     });
 
+  const metronomeSeats = await getMetronomeBilledSeatsByType(workspace);
+
   return {
     seatTypes,
+    metronomeSeats,
     total: Object.values(seatTypes).reduce((sum, count) => sum + count, 0),
   };
 }

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -348,6 +348,7 @@ export function useMembersSeats({
 
   return {
     membersSeats: data?.seatTypes ?? {},
+    metronomeSeats: data?.metronomeSeats ?? {},
     totalMembersSeats: data?.total ?? 0,
     isMembersSeatsLoading: !error && !data && !disabled,
     isMembersSeatsError: error,


### PR DESCRIPTION
## Description

Surfaces the **available (unassigned) seat count** alongside the assigned count on the billing page, for both SEAT_BASED and QUANTITY_ONLY seat types.

The billing page already showed "N seats assigned" per seat type (the DB count of members holding that seat). It now also shows how many seats Metronome is billing that aren't backed by a real member:

- `12 seats assigned - 1 available` when there are unassigned seats, and
- `32 seats assigned` when none are available (line stays clean).

This makes the minimum-seat billing floor (and any drift) visible to admins directly on the billing page, instead of only in Metronome.

Changes (3 files):

- **`lib/api/credits/members_seats.ts`** — the (admin-only) `members-seats` endpoint now also returns `metronomeSeats`: the total seat quantity billed in Metronome per seat type (assigned + unassigned). It's computed **best-effort**:
  - SEAT_BASED (pro/max/free): live total via `getMetronomeSubscriptionSeatState` (`assigned + unassigned`).
  - QUANTITY_ONLY (workspace): current quantity read from the subscription's `quantity_schedule` (the correct source for QTY_ONLY — the seat-state endpoint rejects those subs).
  - Returns `{}` when the workspace has no Metronome seat contract, and silently omits any seat type it can't read, so the DB counts are always returned even if Metronome is unavailable. Reads run via `concurrentExecutor` (concurrency 4).
- **`lib/swr/credits.ts`** — `useMembersSeats` now also exposes `metronomeSeats`.
- **`components/workspace/billing/BillingSeatsOverview.tsx`** — groups the billed totals the same way as the assigned counts (`pro_yearly` → `pro`, etc.) and renders `available = max(0, billed − assigned)`, appended only when `> 0`.

The `members-seats` endpoint is shared between the Next and Hono handlers, which both return the lib result directly with the shared `GetMembersSeatsResponseBody` type — so the new field flows to both automatically.

## Tests

- Type-check + biome clean.
- Manually verified on the billing page: seat cards show `assigned - available` (e.g. a workspace with a 200-seat floor and a few members shows `N seats assigned - (200-N) available`), and the line collapses to just `N seats assigned` when nothing is available or when Metronome has no figure for that seat type.

## Risk

- Low. Additive response field; the UI degrades gracefully (no "available" suffix) when `metronomeSeats` is absent.
- The endpoint now makes a few Metronome reads per request, but it's admin-only and low-traffic; failures are best-effort and never block the DB counts.
- Safe to roll back (the field simply stops being returned/displayed).

## Deploy Plan

- Standard deploy. No migration or config changes.
