### PR TITLE
Add origin column in poke

### DIFF
--- a/front/components/poke/members/columns.tsx
+++ b/front/components/poke/members/columns.tsx
@@ -78,6 +78,19 @@ export function makeColumnsForMembers({
       },
     },
     {
+      accessorKey: "origin",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Origin" />
+      ),
+      filterFn: (row, id, value) => {
+        return value.includes(row.getValue(id));
+      },
+      cell: ({ row }) => {
+        const { origin } = row.original;
+        return <span>{origin ?? "-"}</span>;
+      },
+    },
+    {
       accessorKey: "role",
       header: ({ column }) => (
         <PokeColumnSortableHeader column={column} label="Role" />

--- a/front/components/poke/members/table.tsx
+++ b/front/components/poke/members/table.tsx
@@ -3,7 +3,10 @@ import { makeColumnsForMembers } from "@app/components/poke/members/columns";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
 import { clientFetch } from "@app/lib/egress/client";
 import { useAppRouter } from "@app/lib/platform";
-import { MEMBERSHIP_ROLE_TYPES } from "@app/types/memberships";
+import {
+  MEMBERSHIP_ORIGIN_TYPES,
+  MEMBERSHIP_ROLE_TYPES,
+} from "@app/types/memberships";
 import type {
   RoleType,
   UserTypeWithWorkspaces,
@@ -112,6 +115,14 @@ export function MembersDataTable({
           })}
           data={prepareMembersForDisplay(members)}
           facets={[
+            {
+              columnId: "origin",
+              title: "Origin",
+              options: MEMBERSHIP_ORIGIN_TYPES.map((o) => ({
+                label: o,
+                value: o,
+              })),
+            },
             {
               columnId: "role",
               title: "Role",


### PR DESCRIPTION
## Description

Adds an **Origin** column to the members table in Poke, showing each membership's origin (falling back to `-` when unset). The column is sortable and comes with a facet filter populated from `MEMBERSHIP_ORIGIN_TYPES`.

## Tests

Tested manually in Poke: the Origin column renders, sorts, and filters correctly.

## Risk

Low. Read-only UI change scoped to the internal Poke members table.

## Deploy Plan

Standard deploy, no special steps.
