### PR TITLE
Set a global "low balance" Metronome alert

### DIFF
--- a/front/lib/metronome/alerts/seat_balance.ts
+++ b/front/lib/metronome/alerts/seat_balance.ts
@@ -19,14 +19,9 @@ const SEAT_BALANCE_SEAT_GROUP_KEY = "user_id";
 // fanned out across all seats). The low-balance warning fires when the
 // remaining balance drops to this fraction of the seat's allocation, i.e. when
 // the user has spent 80% of their personal credits.
-const SEAT_EXHAUSTED_THRESHOLD_AWU = 0;
 const SEAT_LOW_BALANCE_REMAINING_RATIO = 0.2;
 
 const SEAT_ALERT_CONCURRENCY = 5;
-
-function seatExhaustedAlertUniquenessKey(workspaceId: string): string {
-  return `seat-exhausted-balance-${workspaceId}`;
-}
 
 function seatLowBalanceAlertUniquenessKeyPrefix(workspaceId: string): string {
   return `seat-low-balance-${workspaceId}-`;
@@ -37,37 +32,6 @@ function seatLowBalanceAlertUniquenessKey(
   userId: string
 ): string {
   return `${seatLowBalanceAlertUniquenessKeyPrefix(workspaceId)}${userId}`;
-}
-
-export async function upsertMetronomeSeatExhaustedAlert({
-  metronomeCustomerId,
-  workspaceId,
-}: {
-  metronomeCustomerId: string;
-  workspaceId: string;
-}): Promise<Result<{ alertId: string }, Error>> {
-  const upsertResult = await upsertMetronomeAlert({
-    alert_type: "low_remaining_seat_balance_reached",
-    name: `Seat balance ${workspaceId} (${SEAT_EXHAUSTED_THRESHOLD_AWU} AWU)`,
-    threshold: SEAT_EXHAUSTED_THRESHOLD_AWU,
-    credit_type_id: getCreditTypeAwuId(),
-    customer_id: metronomeCustomerId,
-    seat_filter: { seat_group_key: SEAT_BALANCE_SEAT_GROUP_KEY },
-    uniqueness_key: seatExhaustedAlertUniquenessKey(workspaceId),
-  });
-  if (upsertResult.isErr()) {
-    return new Err(upsertResult.error);
-  }
-
-  logger.info(
-    {
-      workspaceId,
-      metronomeCustomerId,
-      alertId: upsertResult.value.alertId,
-    },
-    "[Metronome SeatBalance] Synced seat-exhaustion alert"
-  );
-  return new Ok({ alertId: upsertResult.value.alertId });
 }
 
 async function listSeatLowBalanceAlertUserIds({

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -1,8 +1,5 @@
 import type { BillingCycle } from "@app/lib/client/subscription";
-import {
-  syncMetronomeSeatLowBalanceAlerts,
-  upsertMetronomeSeatExhaustedAlert,
-} from "@app/lib/metronome/alerts/seat_balance";
+import { syncMetronomeSeatLowBalanceAlerts } from "@app/lib/metronome/alerts/seat_balance";
 import {
   ceilToHourISO,
   createMetronomeContract,
@@ -107,21 +104,6 @@ export async function ensureMetronomeCustomerForWorkspace({
       return new Err(createResult.error);
     }
     metronomeCustomerId = createResult.value.metronomeCustomerId;
-
-    // Provision the seat-exhaustion alert up front, when the Metronome customer
-    // is first created. It fans out per seat (seat_filter "user_id"), driving
-    // the credit state machine to move each user to `on_pool` when their
-    // personal balance hits 0.
-    const seatAlertResult = await upsertMetronomeSeatExhaustedAlert({
-      metronomeCustomerId,
-      workspaceId: workspace.sId,
-    });
-    if (seatAlertResult.isErr()) {
-      logger.warn(
-        { workspaceId: workspace.sId, error: seatAlertResult.error.message },
-        "[Metronome] Failed to upsert seat-exhaustion alert at customer creation (non-fatal)"
-      );
-    }
   }
 
   if (workspace.metronomeCustomerId !== metronomeCustomerId) {

--- a/front/scripts/backfill_metronome_seat_balance_alerts.ts
+++ b/front/scripts/backfill_metronome_seat_balance_alerts.ts
@@ -15,10 +15,7 @@
  *   npx tsx scripts/backfill_metronome_seat_balance_alerts.ts [--execute] [--workspaceId <sId>]
  */
 
-import {
-  syncMetronomeSeatLowBalanceAlerts,
-  upsertMetronomeSeatExhaustedAlert,
-} from "@app/lib/metronome/alerts/seat_balance";
+import { syncMetronomeSeatLowBalanceAlerts } from "@app/lib/metronome/alerts/seat_balance";
 import { getMetronomeContractById } from "@app/lib/metronome/client";
 import { hasContractSeatSubscription } from "@app/lib/metronome/seats";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
@@ -73,22 +70,6 @@ async function backfillSeatBalanceAlertForWorkspace(
     logger.info(
       { workspaceId: workspace.sId, metronomeCustomerId },
       "[SeatBalanceAlertBackfill] [DRY RUN] Would upsert seat-balance alerts"
-    );
-    return;
-  }
-
-  const exhaustedResult = await upsertMetronomeSeatExhaustedAlert({
-    metronomeCustomerId,
-    workspaceId: workspace.sId,
-  });
-  if (exhaustedResult.isErr()) {
-    logger.error(
-      {
-        workspaceId: workspace.sId,
-        metronomeCustomerId,
-        error: exhaustedResult.error.message,
-      },
-      "[SeatBalanceAlertBackfill] Failed to upsert seat-exhaustion alert"
     );
     return;
   }

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -1468,13 +1468,21 @@ interface AlertDef {
   alert_type:
     | "low_remaining_contract_credit_balance_reached"
     | "low_remaining_commit_balance_reached"
-    | "low_remaining_contract_credit_and_commit_balance_reached";
+    | "low_remaining_contract_credit_and_commit_balance_reached"
+    | "low_remaining_seat_balance_reached";
   threshold: number;
   // Idempotency key — Metronome rejects duplicate creates with the same key.
   uniqueness_key: string;
   // Tag identifying which credit type the threshold tracks. Resolved at sync
   // time (AWU ID differs per environment).
   credit_type: "AWU";
+  // Required for `low_remaining_seat_balance_reached` alerts. Scopes the alert
+  // to a seat group key; omitting `seat_group_value` fans the alert out across
+  // all seats (allocation-independent — e.g. a 0-balance exhaustion alert).
+  seat_filter?: {
+    seat_group_key: string;
+    seat_group_value?: string;
+  };
   // Custom field filters scoped to ContractCredit / Commit / Contract. Used
   // here to exclude excess recurring credits from contract-credit-balance
   // alerts (those credits exist solely to absorb over-consumption and would
@@ -1528,6 +1536,18 @@ const ALERTS: AlertDef[] = [
     credit_type: "AWU",
     custom_field_filters: [POOL_CONTRACT_CREDIT_FILTER],
   },
+  {
+    // Seat exhaustion: fires at 0 remaining seat balance. Allocation-independent
+    // (no `seat_group_value`) so the single default alert fans out across every
+    // seat of every customer. Seat ids in Metronome are user sIds, hence the
+    // "user_id" group key.
+    name: "Default: Empty seat balance (AWU)",
+    alert_type: "low_remaining_seat_balance_reached",
+    threshold: 0,
+    uniqueness_key: "default-low-seat-balance-zero-awu",
+    credit_type: "AWU",
+    seat_filter: { seat_group_key: "user_id" },
+  },
 ];
 
 async function syncAlerts(): Promise<void> {
@@ -1554,6 +1574,7 @@ async function syncAlerts(): Promise<void> {
         ...(desired.custom_field_filters
           ? { custom_field_filters: desired.custom_field_filters }
           : {}),
+        ...(desired.seat_filter ? { seat_filter: desired.seat_filter } : {}),
       });
       const id = (created as { data: { id: string } }).data.id;
       console.log(`  + Created: ${desired.name} → ${id}`);


### PR DESCRIPTION
## Description

Follow-up to #26700. Rather than provisioning a per-workspace seat-exhaustion alert at Metronome customer creation time, this PR moves it to a single **global default alert** declared in `metronome_setup.ts`. Metronome fans the global alert out across every seat of every customer automatically (no `seat_group_value` means allocation-independent), so a single `"Default: Empty seat balance (AWU)"` alert at threshold 0 replaces all the per-workspace variants.

The `upsertMetronomeSeatExhaustedAlert` function and its call site in `ensureMetronomeCustomerForWorkspace` (contracts.ts) are removed entirely, as is its usage in the backfill script.

## Tests

Manual: run `syncAlerts()` in `metronome_setup.ts` to confirm the global alert is created/synced in Metronome; verify the per-workspace provisioning path is gone.

## Risk

Low. Existing per-workspace exhaustion alerts already in Metronome remain active; the global one adds coverage for all customers going forward. Removing `upsertMetronomeSeatExhaustedAlert` from the customer-creation path is non-fatal by design (it was already logged as a warning on failure).

## Deploy Plan

- Deploy `front`.
- Run `metronome_setup.ts` to sync the new global seat-exhaustion alert to Metronome.