### PR TITLE
Fix: use correct env variables for API urls

### DIFF
--- a/front-spa/package.json
+++ b/front-spa/package.json
@@ -6,8 +6,8 @@
   },
   "type": "module",
   "scripts": {
-    "dev:poke": "VITE_APP_NAME=poke VITE_DUST_API_URL=$DUST_CLIENT_FACING_URL vite",
-    "dev:app": "VITE_APP_NAME=app VITE_DUST_API_URL=$DUST_CLIENT_FACING_URL vite",
+    "dev:poke": "VITE_APP_NAME=poke VITE_DUST_API_URL=$DUST_INTERNAL_API_URL vite",
+    "dev:app": "VITE_APP_NAME=app VITE_DUST_API_URL=$DUST_INTERNAL_API_URL vite",
     "build:poke": "VITE_APP_NAME=poke vite build && cp _headers dist/poke/_headers",
     "build:app": "VITE_APP_NAME=app vite build && cp _headers dist/app/_headers",
     "build": "npm run build:poke && npm run build:app",

--- a/front/lib/api/mcp_server/urls.ts
+++ b/front/lib/api/mcp_server/urls.ts
@@ -1,4 +1,5 @@
 import config from "@app/lib/api/config";
+import { EnvironmentConfig } from "@app/types/shared/utils/config";
 
 /**
  * AuthKit Connect domain for MCP OAuth (e.g. `your-env.authkit.app`).
@@ -26,7 +27,13 @@ export function normalizeOAuthUrl(url: string): string {
 }
 
 export function getMcpResourceServerUrl(): string {
-  return normalizeOAuthUrl(config.getDustAPIConfig().url.trim() + "/mcp");
+  return normalizeOAuthUrl(
+    (
+      EnvironmentConfig.getOptionalEnvVariable("DUST_API_URL") ??
+      EnvironmentConfig.getOptionalEnvVariable("DUST_INTERNAL_API_URL") ??
+      "https://us-api.dust.tt"
+    ).trim() + "/mcp"
+  );
 }
 
 export function getMcpResourceMetadataUrl(resourceServerUrl: string): URL {


### PR DESCRIPTION
## Description

Two env variable fixes for API URL resolution:

- `front-spa/package.json`: `dev:poke` and `dev:app` scripts were passing `$DUST_CLIENT_FACING_URL` as `VITE_DUST_API_URL`; corrected to `$DUST_INTERNAL_API_URL` so local dev hits the internal API, not the client-facing URL.
- `front/lib/api/mcp_server/urls.ts`: `getMcpResourceServerUrl()` was deriving the MCP resource server URL from `config.getDustAPIConfig().url`, which resolves to the wrong endpoint in some environments. Now reads `DUST_API_URL` → `DUST_INTERNAL_API_URL` → `https://us-api.dust.tt` (fallback).

## Tests

Tested locally — dev scripts and MCP OAuth resource server URL resolve to the correct endpoint.

## Risk

Low. Config-only changes; no logic changes. Rollback is trivial (revert env var references).

## Deploy Plan

Deploy front.
