### PR TITLE
fix(front): use app URL instead of API URL for conversation copy link [#8572]

### DIFF
--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -194,7 +194,7 @@ export function ConversationMenu({
         owner.sId,
         activeConversationId,
         `agentDetails=${agentId}`,
-        config.getApiBaseUrl()
+        config.getAppUrl()
       );
       window.open(agentDetailsUrl, "_blank");
       return;
@@ -209,7 +209,7 @@ export function ConversationMenu({
         owner.sId,
         activeConversationId,
         `userDetails=${userId}`,
-        config.getApiBaseUrl()
+        config.getAppUrl()
       );
       window.open(userDetailsUrl, "_blank");
       return;
@@ -295,7 +295,7 @@ export function ConversationMenu({
     owner.sId,
     activeConversationId,
     undefined,
-    config.getApiBaseUrl()
+    config.getAppUrl()
   );
 
   const doDelete = useDeleteConversation(owner);


### PR DESCRIPTION
## Description

Fixes #8572 — The "Copy link" action in the conversation menu was generating a URL using `config.getApiBaseUrl()`, which can resolve to an internal service URL (e.g. `http://front-internal-service`) instead of the public-facing app URL.

Changed all three `getConversationRoute` calls in `ConversationMenu.tsx` that build user-facing URLs (copy link, open in browser tab, open agent/user details in new tab) to use `config.getAppUrl()` instead.

## Tests

Verified locally: "Copy link" now produces a `https://dust.tt/w/.../conversation/...` URL.

## Risk

Low — one-line change per call site, no logic change.
