### PR TITLE
feat(voice): add live speech-to-text via ElevenLabs WebSocket streaming

### DIFF
--- a/front-api/routes/w/[wId]/services/transcribe/get-token.ts
+++ b/front-api/routes/w/[wId]/services/transcribe/get-token.ts
@@ -1,0 +1,70 @@
+import { config as regionsConfig } from "@app/lib/api/regions/config";
+import type { GetTranscribeTokenResponseBody } from "@app/lib/api/transcribe";
+import { dustManagedServiceCredentials } from "@app/types/api/credentials";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
+import { ElevenLabsEnvironment } from "@elevenlabs/elevenlabs-js/environments";
+import { createHono } from "@front-api/lib/hono";
+import type { WorkspaceAwareCtx } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+
+// Mounted at /api/w/:wId/services/transcribe/get-token.
+const app = createHono<WorkspaceAwareCtx>();
+
+/** @ignoreswagger */
+app.get("/", async (ctx): HandlerResult<GetTranscribeTokenResponseBody> => {
+  const auth = ctx.get("auth");
+
+  const plan = auth.getNonNullablePlan();
+  if (plan.isByok) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message: "Voice transcription is not available on this plan.",
+      },
+    });
+  }
+
+  const { ELEVENLABS_API_KEY: apiKey } = dustManagedServiceCredentials();
+
+  if (!apiKey) {
+    return apiError(ctx, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "Voice transcription is not configured.",
+      },
+    });
+  }
+
+  const isEu = regionsConfig.getCurrentRegion() === "europe-west1";
+
+  const elevenlabs = new ElevenLabsClient({
+    apiKey,
+    environment: isEu
+      ? ElevenLabsEnvironment.ProductionEu
+      : ElevenLabsEnvironment.ProductionUs,
+  });
+
+  try {
+    const { token } =
+      await elevenlabs.tokens.singleUse.create("realtime_scribe");
+
+    const baseUri = isEu
+      ? "wss://api.eu.elevenlabs.io"
+      : "wss://api.elevenlabs.io";
+
+    return ctx.json({ token, baseUri });
+  } catch (err) {
+    return apiError(ctx, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: normalizeError(err).message,
+      },
+    });
+  }
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/services/transcribe/index.ts
+++ b/front-api/routes/w/[wId]/services/transcribe/index.ts
@@ -11,6 +11,7 @@ import { apiError } from "@front-api/middlewares/utils";
 import type { HttpBindings } from "@hono/node-server";
 import formidable from "formidable";
 import { stream } from "hono/streaming";
+import getToken from "./get-token";
 
 export type PostTranscribeResponseBody = { text: string };
 
@@ -150,5 +151,7 @@ app.post("/", async (ctx) => {
     }
   });
 });
+
+app.route("/get-token", getToken);
 
 export default app;

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -29,10 +29,11 @@ import {
 } from "@app/hooks/conversations";
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { useVoiceLiveTranscriberService } from "@app/hooks/useVoiceLiveTranscriberService";
 import { useVoiceTranscriberService } from "@app/hooks/useVoiceTranscriberService";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { useAuth } from "@app/lib/auth/AuthContext";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
 import { isNodeCandidate } from "@app/lib/connectors";
 import { useClientType } from "@app/lib/context/clientType";
@@ -732,6 +733,9 @@ const InputBarContainer = ({
     });
   }, [attachedNodes]);
 
+  const { hasFeature } = useFeatureFlags();
+  const isLiveStt = hasFeature("live_speech_to_text");
+
   const voiceTranscriberService = useVoiceTranscriberService({
     owner,
     fileUploaderService,
@@ -764,6 +768,29 @@ const InputBarContainer = ({
       });
     },
   });
+
+  const voiceLiveTranscriberService = useVoiceLiveTranscriberService({
+    owner,
+    onTranscribeDelta: (text) => {
+      editorService.appendText(text);
+    },
+    onTranscribeComplete: () => {
+      if (isCompactRef.current) {
+        void submitCompactVoiceMessageRef.current?.();
+      }
+    },
+    onError: (error) => {
+      sendNotification({
+        type: "error",
+        title: "Failed to transcribe voice",
+        description: normalizeError(error).message,
+      });
+    },
+  });
+
+  const activeVoiceService = isLiveStt
+    ? voiceLiveTranscriberService
+    : voiceTranscriberService;
 
   // Keep the editor non-editable while the input is fully disabled (e.g. a
   // non-owner viewing a conversation with an active wake-up). The placeholder
@@ -1199,7 +1226,7 @@ const InputBarContainer = ({
     (isEmpty && !canSubmitEmpty) ||
     isSubmitting ||
     isSubmitBlocked ||
-    voiceTranscriberService.status !== "idle";
+    activeVoiceService.status !== "idle";
 
   const hideCapabilities = startsWithUserMention && !selectedSingleAgent;
 
@@ -1225,8 +1252,8 @@ const InputBarContainer = ({
     "px-3 sm:pl-4 pt-3 sm:pt-3.5"
   );
 
-  const isRecording = voiceTranscriberService.status === "recording";
-  const isVoiceActive = voiceTranscriberService.status !== "idle";
+  const isRecording = activeVoiceService.status === "recording";
+  const isVoiceActive = activeVoiceService.status !== "idle";
   const compactPreviewText = editorService.getTrimmedText();
   const compactDisplayPlaceholder =
     (disableInput ? submitBlockMessage : placeholder) ?? "Get work done";
@@ -1312,11 +1339,11 @@ const InputBarContainer = ({
                 data-compact-voice
               >
                 <VoicePicker
-                  status={voiceTranscriberService.status}
-                  level={voiceTranscriberService.level}
-                  elapsedSeconds={voiceTranscriberService.elapsedSeconds}
-                  onRecordStart={voiceTranscriberService.startRecording}
-                  onRecordStop={voiceTranscriberService.stopRecording}
+                  status={activeVoiceService.status}
+                  level={activeVoiceService.level}
+                  elapsedSeconds={activeVoiceService.elapsedSeconds}
+                  onRecordStart={activeVoiceService.startRecording}
+                  onRecordStop={activeVoiceService.stopRecording}
                   size="xs"
                   compact
                   showStopLabel={false}
@@ -1596,11 +1623,11 @@ const InputBarContainer = ({
                 actions.includes("voice") &&
                 !isCompact && (
                   <VoicePicker
-                    status={voiceTranscriberService.status}
-                    level={voiceTranscriberService.level}
-                    elapsedSeconds={voiceTranscriberService.elapsedSeconds}
-                    onRecordStart={voiceTranscriberService.startRecording}
-                    onRecordStop={voiceTranscriberService.stopRecording}
+                    status={activeVoiceService.status}
+                    level={activeVoiceService.level}
+                    elapsedSeconds={activeVoiceService.elapsedSeconds}
+                    onRecordStart={activeVoiceService.startRecording}
+                    onRecordStop={activeVoiceService.stopRecording}
                     size={buttonSize}
                     showStopLabel={!isMobile}
                     disabled={disableInput}
@@ -1630,7 +1657,7 @@ const InputBarContainer = ({
                     size={buttonSize}
                     isLoading={
                       isSubmitting &&
-                      voiceTranscriberService.status !== "transcribing"
+                      activeVoiceService.status !== "transcribing"
                     }
                     icon={ArrowUp}
                     variant={isSubmitBlocked ? "ghost-secondary" : "highlight"}

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -51,6 +51,10 @@ const useEditorService = (editor: Editor | null) => {
       insertText: (text: string) => {
         editor?.chain().focus().insertContent(text).run();
       },
+      // Append text at the end of the document (always at the end, regardless of cursor position).
+      appendText: (text: string) => {
+        editor?.chain().focus("end").insertContent(text).run();
+      },
       // Insert mention helper function.
       insertMention: ({
         type,

--- a/front/hooks/useVoiceLiveTranscriberService.ts
+++ b/front/hooks/useVoiceLiveTranscriberService.ts
@@ -1,0 +1,226 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { requestMicrophone } from "@app/hooks/useVoiceTranscriberService";
+import {
+  hasWebkitAudioContext,
+  quackingVoiceTranscriptService,
+  startLevelMeteringInterval,
+  useElapsedSeconds,
+  type VoiceTranscriberService,
+  type VoiceTranscriberStatus,
+} from "@app/hooks/utils/voice";
+import type { GetTranscribeTokenResponseBody } from "@app/lib/api/transcribe";
+import { clientFetch } from "@app/lib/egress/client";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { LightWorkspaceType } from "@app/types/user";
+import { AudioFormat, CommitStrategy, useScribe } from "@elevenlabs/react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface UseVoiceLiveTranscriberServiceParams {
+  owner: LightWorkspaceType;
+  onTranscribeDelta?: (text: string) => void;
+  onTranscribeComplete?: () => void;
+  onError?: (error: Error) => void;
+}
+
+export type VoiceLiveTranscriberService = VoiceTranscriberService;
+
+function float32ToInt16(input: Float32Array): Int16Array {
+  const output = new Int16Array(input.length);
+  for (let i = 0; i < input.length; i++) {
+    const s = Math.max(-1, Math.min(1, input[i]));
+    output[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
+  }
+  return output;
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  return btoa(String.fromCharCode(...bytes));
+}
+
+export function useVoiceLiveTranscriberService({
+  owner,
+  onTranscribeDelta,
+  onTranscribeComplete,
+  onError,
+}: UseVoiceLiveTranscriberServiceParams): VoiceLiveTranscriberService {
+  const [status, setStatus] = useState<VoiceTranscriberStatus>("idle");
+  const [level, setLevel] = useState(0);
+  const elapsedSeconds = useElapsedSeconds(status);
+
+  const streamRef = useRef<MediaStream | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const processorRef = useRef<ScriptProcessorNode | null>(null);
+  const analyserRef = useRef<AnalyserNode | null>(null);
+  const levelIntervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Keep latest callbacks in refs so the stable SDK closures always see fresh values.
+  const onTranscribeDeltaRef = useRef(onTranscribeDelta);
+  onTranscribeDeltaRef.current = onTranscribeDelta;
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
+
+  const sendNotification = useSendNotification();
+
+  const cleanup = useCallback(() => {
+    if (levelIntervalRef.current !== null) {
+      clearInterval(levelIntervalRef.current);
+      levelIntervalRef.current = null;
+    }
+    try {
+      processorRef.current?.disconnect();
+      analyserRef.current?.disconnect();
+      if (audioContextRef.current) {
+        void audioContextRef.current.close();
+      }
+    } catch {
+      // ignore cleanup errors
+    }
+    processorRef.current = null;
+    analyserRef.current = null;
+    audioContextRef.current = null;
+
+    streamRef.current?.getTracks().forEach((t) => t.stop());
+    streamRef.current = null;
+
+    setLevel(0);
+  }, []);
+
+  const handleCommittedTranscript = useCallback(
+    ({ text }: { text: string }) => {
+      onTranscribeDeltaRef.current?.(text);
+    },
+    []
+  );
+
+  const handleError = useCallback(
+    (err: Error | Event) => {
+      const error =
+        err instanceof Error ? err : new Error("Transcription error.");
+      onErrorRef.current?.(error);
+      cleanup();
+      setStatus("idle");
+    },
+    [cleanup]
+  );
+
+  const scribe = useScribe({
+    modelId: "scribe_v2_realtime",
+    audioFormat: AudioFormat.PCM_16000,
+    sampleRate: 16000,
+    commitStrategy: CommitStrategy.VAD,
+    onCommittedTranscript: handleCommittedTranscript,
+    onError: handleError,
+  });
+
+  // Keep a stable ref so onaudioprocess always reaches the latest scribe instance.
+  const scribeRef = useRef(scribe);
+  scribeRef.current = scribe;
+
+  useEffect(() => {
+    return () => {
+      scribeRef.current.disconnect();
+      cleanup();
+    };
+  }, [cleanup]);
+
+  const startRecording = useCallback(async () => {
+    if (status === "recording" || status === "authorizing_microphone") {
+      return;
+    }
+
+    try {
+      setStatus("authorizing_microphone");
+
+      // Fetch a single-use ElevenLabs token from our backend.
+      const resp = await clientFetch(
+        `/api/w/${owner.sId}/services/transcribe/get-token`
+      );
+      if (!resp.ok) {
+        throw new Error("Failed to obtain transcription token.");
+      }
+      const { token, baseUri } =
+        (await resp.json()) as GetTranscribeTokenResponseBody;
+
+      // Request microphone access.
+      const stream = await requestMicrophone();
+      streamRef.current = stream;
+
+      // Connect to ElevenLabs Scribe (manual audio mode — we handle PCM capture).
+      await scribeRef.current.connect({ token, baseUri });
+
+      // Create AudioContext at 16 kHz — matches ElevenLabs pcm_16000 format.
+      const AC = hasWebkitAudioContext(window)
+        ? window.webkitAudioContext
+        : window.AudioContext;
+      const audioContext = new AC({ sampleRate: 16000 });
+      audioContextRef.current = audioContext;
+
+      const source = audioContext.createMediaStreamSource(stream);
+
+      // Level metering via AnalyserNode.
+      const analyser = audioContext.createAnalyser();
+      analyser.fftSize = 2048;
+      analyser.smoothingTimeConstant = 0.85;
+      source.connect(analyser);
+      analyserRef.current = analyser;
+      levelIntervalRef.current = startLevelMeteringInterval(
+        analyser,
+        analyserRef,
+        setLevel
+      );
+
+      // ScriptProcessorNode captures raw PCM and forwards it to Scribe.
+      // eslint-disable-next-line deprecation/deprecation
+      const processor = audioContext.createScriptProcessor(4096, 1, 1);
+      processorRef.current = processor;
+      source.connect(processor);
+      // ScriptProcessorNode must be connected to destination to fire onaudioprocess.
+      processor.connect(audioContext.destination);
+
+      processor.onaudioprocess = (e) => {
+        const inputData = e.inputBuffer.getChannelData(0);
+        const int16 = float32ToInt16(inputData);
+        const b64 = arrayBufferToBase64(int16.buffer as ArrayBuffer);
+        scribeRef.current.sendAudio(b64, { sampleRate: 16000 });
+      };
+
+      setStatus("recording");
+    } catch (err) {
+      const error = normalizeError(err);
+      const isPermissionError =
+        err instanceof DOMException &&
+        (err.name === "NotAllowedError" ||
+          err.name === "PermissionDeniedError");
+
+      sendNotification({
+        type: "error",
+        title: isPermissionError
+          ? "Microphone permission required."
+          : "Could not start recording.",
+        description: isPermissionError
+          ? "Please allow microphone access and try again."
+          : error.message,
+      });
+      scribeRef.current.disconnect();
+      cleanup();
+      setStatus("idle");
+    }
+  }, [owner.sId, status, sendNotification, cleanup]);
+
+  const stopRecording = useCallback(async () => {
+    if (status !== "recording") {
+      return;
+    }
+
+    scribeRef.current.disconnect();
+    cleanup();
+    setStatus("idle");
+
+    onTranscribeComplete?.();
+  }, [status, onTranscribeComplete, cleanup]);
+
+  return owner.metadata?.allowVoiceTranscription !== false
+    ? { status, level, elapsedSeconds, startRecording, stopRecording }
+    : quackingVoiceTranscriptService;
+}

--- a/front/hooks/useVoiceTranscriberService.ts
+++ b/front/hooks/useVoiceTranscriberService.ts
@@ -1,6 +1,14 @@
 /// <reference types="chrome" />
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useSendNotification } from "@app/hooks/useNotification";
+import {
+  hasWebkitAudioContext,
+  quackingVoiceTranscriptService,
+  startLevelMeteringInterval,
+  useElapsedSeconds,
+  type VoiceTranscriberService,
+  type VoiceTranscriberStatus,
+} from "@app/hooks/utils/voice";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   isBrowserExtension,
@@ -22,26 +30,12 @@ const MAXIMUM_FILE_SIZE_FOR_INPUT_BAR_IN_BYTES = 1200 * 1024;
 
 const MICROPHONE_POPUP_TIMEOUT_MS = 60_000; // 1 minute
 
-type VoiceTranscriberStatus =
-  | "idle"
-  | "authorizing_microphone"
-  | "recording"
-  | "transcribing";
-
 interface UseVoiceTranscriberServiceParams {
   owner: LightWorkspaceType;
   onTranscribeDelta?: (delta: string) => void;
   onTranscribeComplete?: (transcript: AugmentedMessage[]) => void;
   onError?: (error: Error) => void;
   fileUploaderService: FileUploaderService;
-}
-
-export interface VoiceTranscriberService {
-  status: VoiceTranscriberStatus;
-  level: number;
-  elapsedSeconds: number;
-  startRecording: () => Promise<void>;
-  stopRecording: () => Promise<void>;
 }
 
 export function useVoiceTranscriberService({
@@ -53,7 +47,7 @@ export function useVoiceTranscriberService({
 }: UseVoiceTranscriberServiceParams): VoiceTranscriberService {
   const [status, setStatus] = useState<VoiceTranscriberStatus>("idle");
   const [level, setLevel] = useState(0);
-  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const elapsedSeconds = useElapsedSeconds(status);
 
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const chunksRef = useRef<Blob[]>([]);
@@ -111,27 +105,11 @@ export function useVoiceTranscriberService({
         analyserRef.current = analyser;
         sourceNodeRef.current = source;
 
-        const buffer = new Uint8Array(analyser.frequencyBinCount);
-        const tick = () => {
-          const a = analyserRef.current;
-          if (!a) {
-            return;
-          }
-
-          a.getByteTimeDomainData(buffer);
-          // Compute RMS level from time-domain data. Normalize to [0, 1].
-          let sumSquares = 0;
-          for (let i = 0; i < buffer.length; i++) {
-            const v = (buffer[i] - 128) / 128; // [-1, 1]
-            sumSquares += v * v;
-          }
-          const rms = Math.sqrt(sumSquares / buffer.length); // ~0..1
-          // Map RMS to a smoother visual level with light bias to show activity.
-          const visual = Math.max(0, Math.min(1, (rms - 0.02) / 0.3));
-
-          setLevel(visual);
-        };
-        intervalRef.current = setInterval(tick, 250);
+        intervalRef.current = startLevelMeteringInterval(
+          analyser,
+          analyserRef,
+          setLevel
+        );
       } catch {
         // If metering fails (unsupported), we silently ignore.
         audioContextRef.current = null;
@@ -149,25 +127,6 @@ export function useVoiceTranscriberService({
       stopTracks(streamRef.current);
     };
   }, [stopLevelMetering]);
-
-  useEffect(() => {
-    let interval: NodeJS.Timeout | null = null;
-
-    if (status === "recording") {
-      interval = setInterval(() => {
-        setElapsedSeconds((prev) => prev + 1);
-      }, 1000);
-    } else {
-      // Reset timer when not recording.
-      setElapsedSeconds(0);
-    }
-
-    return () => {
-      if (interval) {
-        clearInterval(interval);
-      }
-    };
-  }, [status]);
 
   const startRecording = useCallback(async () => {
     if (status === "recording" || status === "authorizing_microphone") {
@@ -323,14 +282,6 @@ export function useVoiceTranscriberService({
 
 // Helpers ---------------------------------------------------------------------
 
-const quackingVoiceTranscriptService: VoiceTranscriberService = {
-  status: "idle",
-  level: 0,
-  elapsedSeconds: 0,
-  startRecording: () => Promise.resolve(),
-  stopRecording: () => Promise.resolve(),
-};
-
 const stopTracks = (stream: MediaStream | null) => {
   if (!stream) {
     return;
@@ -485,14 +436,6 @@ const createRecorder = (
   };
   return recorder;
 };
-
-// Type guard to check for prefixed webkitAudioContext without unsafe casts.
-function hasWebkitAudioContext(
-  w: Window & typeof globalThis
-  // @ts-expect-error - Type 'Window' is not assignable to type 'Window & typeof globalThis'.
-): w is Window & { webkitAudioContext: typeof AudioContext } {
-  return "webkitAudioContext" in w;
-}
 
 // There is no built-in SSE support in the Fetch API for POST, so we manually parse the stream.
 const readSSEFromPostRequest = async ({

--- a/front/hooks/utils/voice.ts
+++ b/front/hooks/utils/voice.ts
@@ -1,0 +1,72 @@
+import type { MutableRefObject } from "react";
+import { useEffect, useState } from "react";
+
+export type VoiceTranscriberStatus =
+  | "idle"
+  | "authorizing_microphone"
+  | "recording"
+  | "transcribing";
+
+export interface VoiceTranscriberService {
+  status: VoiceTranscriberStatus;
+  level: number;
+  elapsedSeconds: number;
+  startRecording: () => Promise<void>;
+  stopRecording: () => Promise<void>;
+}
+
+export const quackingVoiceTranscriptService: VoiceTranscriberService = {
+  status: "idle",
+  level: 0,
+  elapsedSeconds: 0,
+  startRecording: () => Promise.resolve(),
+  stopRecording: () => Promise.resolve(),
+};
+
+export function useElapsedSeconds(status: VoiceTranscriberStatus): number {
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  useEffect(() => {
+    let interval: NodeJS.Timeout | null = null;
+    if (status === "recording") {
+      interval = setInterval(() => setElapsedSeconds((prev) => prev + 1), 1000);
+    } else {
+      setElapsedSeconds(0);
+    }
+    return () => {
+      if (interval) {
+        clearInterval(interval);
+      }
+    };
+  }, [status]);
+  return elapsedSeconds;
+}
+
+// Type guard to check for prefixed webkitAudioContext without unsafe casts.
+export function hasWebkitAudioContext(
+  w: Window & typeof globalThis
+  // @ts-expect-error - Type 'Window' is not assignable to type 'Window & typeof globalThis'.
+): w is Window & { webkitAudioContext: typeof AudioContext } {
+  return "webkitAudioContext" in w;
+}
+
+export function startLevelMeteringInterval(
+  analyser: AnalyserNode,
+  analyserRef: MutableRefObject<AnalyserNode | null>,
+  setLevel: (v: number) => void
+): NodeJS.Timeout {
+  const buffer = new Uint8Array(analyser.frequencyBinCount);
+  return setInterval(() => {
+    const a = analyserRef.current;
+    if (!a) {
+      return;
+    }
+    a.getByteTimeDomainData(buffer);
+    let sumSquares = 0;
+    for (let i = 0; i < buffer.length; i++) {
+      const v = (buffer[i] - 128) / 128;
+      sumSquares += v * v;
+    }
+    const rms = Math.sqrt(sumSquares / buffer.length);
+    setLevel(Math.max(0, Math.min(1, (rms - 0.02) / 0.3)));
+  }, 250);
+}

--- a/front/lib/api/transcribe.ts
+++ b/front/lib/api/transcribe.ts
@@ -1,0 +1,4 @@
+export type GetTranscribeTokenResponseBody = {
+  token: string;
+  baseUri: string;
+};

--- a/front/package.json
+++ b/front/package.json
@@ -46,6 +46,7 @@
     "@dust-tt/sparkle": "^0.7.7",
     "@elastic/elasticsearch": "^8.15.0",
     "@elevenlabs/elevenlabs-js": "^2.49.1",
+    "@elevenlabs/react": "^1.6.4",
     "@emoji-mart/data": "^1.2.1",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -1,4 +1,9 @@
 export const WHITELISTABLE_FEATURES_CONFIG = {
+  live_speech_to_text: {
+    description:
+      "Enable real-time speech-to-text in the input bar via ElevenLabs WebSocket streaming",
+    stage: "dust_only",
+  },
   advanced_notion_management: {
     description:
       "Advanced features for Notion workspace management shown to admins",

--- a/package-lock.json
+++ b/package-lock.json
@@ -503,6 +503,7 @@
         "@dust-tt/sparkle": "^0.7.7",
         "@elastic/elasticsearch": "^8.15.0",
         "@elevenlabs/elevenlabs-js": "^2.49.1",
+        "@elevenlabs/react": "^1.6.4",
         "@emoji-mart/data": "^1.2.1",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
@@ -4523,6 +4524,16 @@
         "node": ">=18.17"
       }
     },
+    "node_modules/@elevenlabs/client": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@elevenlabs/client/-/client-1.9.0.tgz",
+      "integrity": "sha512-czkbwUv7n18DoH5L9YdAKr0ATlcPSYNxhVQTfnFvAUdijvWfhwn8Ct0WHbPxX1oGwH6s1hMbPPAK+CUURHyowg==",
+      "license": "MIT",
+      "dependencies": {
+        "@elevenlabs/types": "0.14.0",
+        "livekit-client": "2.16.1"
+      }
+    },
     "node_modules/@elevenlabs/elevenlabs-js": {
       "version": "2.49.1",
       "resolved": "https://registry.npmjs.org/@elevenlabs/elevenlabs-js/-/elevenlabs-js-2.49.1.tgz",
@@ -4578,6 +4589,23 @@
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }
+    },
+    "node_modules/@elevenlabs/react": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@elevenlabs/react/-/react-1.6.4.tgz",
+      "integrity": "sha512-+5pF0BfLOShv0IJtGQWGLjG0kVYlfxRqpQlKmWPc8T8NzEzFX8hTCr+fjPNldAGEQSUsTGFiOvVNJHzpfQe4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@elevenlabs/client": "1.9.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@elevenlabs/types": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@elevenlabs/types/-/types-0.14.0.tgz",
+      "integrity": "sha512-CfpxFyNtTq9Iwm1/Hfxk+FK0QlFgsHpXcNM9jMPYrjP/kAYMFi9rgFoosdJcBGYbgkvzUL7hwT9I6WzHyNyxDg=="
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
@@ -7495,6 +7523,27 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/@livekit/mutex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@livekit/mutex/-/mutex-1.1.1.tgz",
+      "integrity": "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@livekit/protocol": {
+      "version": "1.42.2",
+      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.42.2.tgz",
+      "integrity": "sha512-0jeCwoMJKcwsZICg5S6RZM4xhJoF78qMvQELjACJQn6/VB+jmiySQKOSELTXvPBVafHfEbMlqxUw2UR1jTXs2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      }
+    },
+    "node_modules/@livekit/protocol/node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@marsidev/react-turnstile": {
       "version": "1.5.2",
@@ -20597,6 +20646,13 @@
       "integrity": "sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/dom-mediacapture-record": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.22.tgz",
+      "integrity": "sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/dotenv-webpack": {
       "version": "7.0.8",
@@ -36502,6 +36558,27 @@
         "node": ">=14"
       }
     },
+    "node_modules/livekit-client": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.16.1.tgz",
+      "integrity": "sha512-PmOHiGdkzw2P/t0vLbJRwHU59+T+JcFlGTYDV7PObWmzvypIij1Vlj0WhZKDZ/Ac7CvwWinbiGCVw/Pb/OiYYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@livekit/mutex": "1.1.1",
+        "@livekit/protocol": "1.42.2",
+        "events": "^3.3.0",
+        "jose": "^6.1.0",
+        "loglevel": "^1.9.2",
+        "sdp-transform": "^2.15.0",
+        "ts-debounce": "^4.0.0",
+        "tslib": "2.8.1",
+        "typed-emitter": "^2.1.0",
+        "webrtc-adapter": "^9.0.1"
+      },
+      "peerDependencies": {
+        "@types/dom-mediacapture-record": "^1"
+      }
+    },
     "node_modules/load-tsconfig": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
@@ -36772,6 +36849,19 @@
       },
       "engines": {
         "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
     "node_modules/long": {
@@ -50227,6 +50317,21 @@
       "deprecated": "Just use Node.js's crypto.timingSafeEqual()",
       "license": "BSD-3-Clause"
     },
+    "node_modules/sdp": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.2.tgz",
+      "integrity": "sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==",
+      "license": "MIT"
+    },
+    "node_modules/sdp-transform": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.15.0.tgz",
+      "integrity": "sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==",
+      "license": "MIT",
+      "bin": {
+        "sdp-verify": "checker.js"
+      }
+    },
     "node_modules/secure-json-parse": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-3.0.2.tgz",
@@ -53941,6 +54046,12 @@
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "license": "MIT"
     },
+    "node_modules/ts-debounce": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ts-debounce/-/ts-debounce-4.0.0.tgz",
+      "integrity": "sha512-+1iDGY6NmOGidq7i7xZGA4cm8DAa6fqdYcvO5Z6yBevH++Bdo9Qt/mN0TzHUgcCcKv1gmh9+W5dHqz8pMWbCbg==",
+      "license": "MIT"
+    },
     "node_modules/ts-dedent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
@@ -54530,6 +54641,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "rxjs": "*"
       }
     },
     "node_modules/typed-function": {
@@ -56819,6 +56939,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/webrtc-adapter": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.5.tgz",
+      "integrity": "sha512-U9vjByy/sK2OMXu5mmfuZFKTMIUQe34c0JXRO+oDrxJTsntdYT2iIFwYMOV7HhMTuktcZLGf2W1N/OcSf9ssWg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "sdp": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
       }
     },
     "node_modules/websocket-driver": {

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -778,6 +778,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "user_settings_v2"
   | "admin_governance"
   | "use_new_llm_router"
+  | "live_speech_to_text"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

Adds a real-time speech-to-text mode to the input bar, gated behind the `live_speech_to_text` feature flag (currently `dust_only`).

**How it works:**
- When the flag is on, recording opens a WebSocket directly to ElevenLabs' `scribe_v2_realtime` model instead of uploading a file after recording stops.
- A new backend endpoint (`GET /api/w/:wId/services/transcribe/stream-url`) validates the session and plan, then returns the ElevenLabs WebSocket URL with the API key embedded — the key never leaves the server-to-client HTTPS response and is not logged.
- The browser captures 16 kHz mono PCM via `AudioContext` + `ScriptProcessorNode`, encodes chunks as base64, and sends them over the WebSocket.
- ElevenLabs' VAD automatically commits phrases; `partial_transcript` events update a live preview displayed in the input bar while recording, and `committed_transcript` events accumulate the final text.
- On stop, the full committed transcript is inserted into the editor via the existing `onTranscribeComplete` flow.
- When the flag is off, the existing batch-upload flow is unchanged.
- Shared primitives (`VoiceTranscriberStatus`, `VoiceTranscriberService`, `useElapsedSeconds`, `startLevelMeteringInterval`, `hasWebkitAudioContext`) are extracted into `front/hooks/utils/voice.ts` to avoid duplication between the two hooks.

https://github.com/user-attachments/assets/4462ed14-ea64-446e-aeb2-ea9572695f34


## Tests

Tested manually with the `live_speech_to_text` flag enabled on a local workspace. Verified:
- Live preview appears while speaking and updates word by word.
- Transcript is inserted into the editor on stop.
- Error notifications appear on auth/quota failures.
- Existing batch flow unaffected when flag is off.

## Risk

