### PR TITLE
feat(mobile): AgentMessageStream reducer + ask_user_question tool support

### DIFF
--- a/x/adrsimon/mobile/CONTEXT.md
+++ b/x/adrsimon/mobile/CONTEXT.md
@@ -1,0 +1,51 @@
+# Dust iOS
+
+The native Swift/SwiftUI client for Dust. This file fixes the vocabulary the codebase
+uses so reviews and refactors stay consistent with the web frontend (`front/`) where the
+two share a behaviour model.
+
+## Language
+
+### Conversation & messages
+
+**Conversation**:
+A thread of messages between a user and one or more agents.
+
+**ConversationMessage**:
+One entry in a conversation — either a user message or an agent message. Modelled as the
+`.user` / `.agent` enum the message list holds.
+
+**AgentMessage**:
+A message produced by an agent. While it is being produced its content arrives over a
+stream; once finished it is a persisted record.
+
+### Streaming
+
+**AgentMessageStream**:
+The pure value type that reduces a sequence of streaming events into the live state of the
+one agent message currently being produced — accumulating content and chain-of-thought,
+the activity lifecycle, running actions, completed steps, and any error. Holds no
+SwiftUI, network, or concurrency; events in, snapshot out.
+_Avoid_: AgentTurn, StreamingTurn, reducer, message reducer
+
+**Activity**:
+The lifecycle of a streaming agent message: `thinking` then `generating`. Absence of a
+stream is the idle state (no `AgentMessageStream`). Distinct from a BlockedAction, which
+outlives the stream.
+_Avoid_: phase, agentState, status (status is the persisted terminal state of the message)
+
+**ActivityStep**:
+A completed entry in the agent's timeline — a finished thinking segment or a finished
+action.
+_Avoid_: inline activity step, timeline item
+
+**ActiveAction**:
+A tool currently executing within the streaming message.
+_Avoid_: pending tool call, running tool
+
+**BlockedAction**:
+A point where the agent is waiting on the user before it can continue — approval of a tool
+call, personal authentication, or file authorization. A concern separate from
+AgentMessageStream: it is seeded by a REST reconciliation on load as well as by stream
+events, and it persists past the end of the stream until resolved.
+_Avoid_: blocking phase, approval state, gate

--- a/x/adrsimon/mobile/Dust/Config/AppConfig.swift
+++ b/x/adrsimon/mobile/Dust/Config/AppConfig.swift
@@ -84,6 +84,10 @@ enum AppConfig {
             "/api/v1/w/\(workspaceId)/assistant/conversations/\(conversationId)/messages/\(messageId)/retry"
         }
 
+        static func answerQuestion(workspaceId: String, conversationId: String, messageId: String) -> String {
+            "/api/v1/w/\(workspaceId)/assistant/conversations/\(conversationId)/messages/\(messageId)/answer-question"
+        }
+
         static func mcpServerViews(workspaceId: String) -> String {
             "/api/w/\(workspaceId)/mcp/views"
         }

--- a/x/adrsimon/mobile/Dust/Models/AgentMessageStream.swift
+++ b/x/adrsimon/mobile/Dust/Models/AgentMessageStream.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+/// Reduces the streaming events of a single in-flight agent message into its live state.
+///
+/// Pure value type — feed events through `apply`, read `snapshot`. It holds no SwiftUI,
+/// networking, or concurrency, so the reduction (token accumulation, thinking-buffer flush
+/// ordering, action lifecycle, terminal status) is exercised by feeding events and asserting
+/// the snapshot. Blocked/approval/auth is a separate concern owned by the ViewModel and is
+/// intentionally ignored here.
+struct AgentMessageStream {
+    enum Activity: Equatable {
+        case thinking
+        case generating
+    }
+
+    struct Snapshot: Equatable {
+        let messageId: String
+        var content: String = ""
+        var chainOfThought: String?
+        var activity: Activity = .thinking
+        var activeActions: [ActiveAction] = []
+        var completedSteps: [ActivityStep] = []
+        var error: ErrorInfo?
+        /// nil while in flight; set once a terminal event arrives.
+        var status: AgentMessageStatus?
+        /// Final files/citations, populated only on a successful/stopped finish.
+        var generatedFiles: [GeneratedFile]?
+        var citations: [String: CitationReference]?
+
+        var isFinished: Bool {
+            status != nil
+        }
+    }
+
+    private(set) var snapshot: Snapshot
+    /// Current thinking segment, flushed to a completed step on the next action or on finish.
+    private var thinkingBuffer = ""
+    private var stepCounter = 0
+
+    init(messageId: String) {
+        self.snapshot = Snapshot(messageId: messageId)
+    }
+
+    mutating func apply(_ event: StreamingEventData) {
+        switch event {
+        case let .generationTokens(tokens):
+            applyTokens(tokens)
+
+        case let .toolParams(params):
+            flushThinkingBuffer()
+            // The live thinking was flushed to a step; clear it off the message.
+            snapshot.chainOfThought = nil
+            let action = ActiveAction(
+                id: params.action.id,
+                label: params.action.displayLabels?.running ?? params.action.toolName ?? "Working…",
+                serverName: params.action.internalMCPServerName
+            )
+            if !snapshot.activeActions.contains(where: { $0.id == action.id }) {
+                snapshot.activeActions.append(action)
+            }
+
+        case let .agentActionSuccess(event):
+            let doneLabel = event.action.displayLabels?.done ?? event.action.toolName ?? "Tool"
+            stepCounter += 1
+            snapshot.completedSteps.append(.action(
+                id: "action-\(stepCounter)",
+                label: doneLabel,
+                serverName: event.action.internalMCPServerName
+            ))
+            snapshot.activeActions.removeAll { $0.id == event.action.id }
+
+        case let .agentMessageSuccess(success):
+            finalize(status: .succeeded, from: success.message)
+
+        case let .agentMessageGracefullyStopped(event):
+            finalize(status: .gracefullyStopped, from: event.message)
+
+        case let .agentError(event):
+            snapshot.error = ErrorInfo(from: event.error, messageId: snapshot.messageId)
+            finalize(status: .failed, from: nil)
+
+        case let .toolError(event):
+            snapshot.error = ErrorInfo(from: event.error, messageId: snapshot.messageId)
+            finalize(status: .failed, from: nil)
+
+        case let .agentGenerationCancelled(event):
+            finalize(status: event.status == "interrupted" ? .interrupted : .cancelled, from: nil)
+
+        // Owned by the ViewModel (blocked-state) or carry no activity meaning.
+        case .toolPersonalAuthRequired, .toolFileAuthRequired, .toolApproveExecution,
+             .toolAskUserQuestion, .toolNotification, .agentContextPruned, .endOfStream, .unknown:
+            break
+        }
+    }
+
+    private mutating func applyTokens(_ tokens: GenerationTokensEvent) {
+        switch tokens.classification {
+        case .tokens:
+            snapshot.content += tokens.text
+            snapshot.activity = .generating
+        case .chainOfThought:
+            snapshot.chainOfThought = (snapshot.chainOfThought ?? "") + tokens.text
+            thinkingBuffer += tokens.text
+            snapshot.activity = .thinking
+        case .openingDelimiter, .closingDelimiter:
+            break
+        }
+    }
+
+    private mutating func finalize(status: AgentMessageStatus, from final: AgentMessage?) {
+        flushThinkingBuffer()
+        if let final {
+            snapshot.content = final.content ?? snapshot.content
+            snapshot.chainOfThought = final.chainOfThought
+            snapshot.generatedFiles = final.generatedFiles
+            snapshot.citations = final.citations
+        }
+        snapshot.status = status
+        snapshot.activeActions = []
+    }
+
+    private mutating func flushThinkingBuffer() {
+        let text = thinkingBuffer.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+        stepCounter += 1
+        snapshot.completedSteps.append(.thinking(id: "thinking-\(stepCounter)", content: text))
+        thinkingBuffer = ""
+    }
+}

--- a/x/adrsimon/mobile/Dust/Models/Message.swift
+++ b/x/adrsimon/mobile/Dust/Models/Message.swift
@@ -292,6 +292,40 @@ struct ErrorInfo: Equatable {
     }
 }
 
+/// A point where the agent is waiting on the user before it can continue. Owned by the
+/// ViewModel and seeded both by the blocked-actions REST reconciliation and by stream events;
+/// outlives the stream until resolved. Distinct from the streaming `Activity`.
+enum BlockedState: Equatable {
+    case approval(ToolApprovalInfo)
+    case personalAuth(provider: String, toolName: String)
+    case fileAuth(fileName: String, toolName: String)
+    case userQuestion(UserQuestionInfo)
+}
+
+/// Everything needed to render a tool's question to the user and submit their answer back.
+struct UserQuestionInfo: Equatable {
+    let actionId: String
+    let messageId: String
+    let conversationId: String
+    let question: UserQuestion
+
+    init(from event: ToolAskUserQuestionEvent, fallbackMessageId: String, fallbackConversationId: String) {
+        self.actionId = event.actionId ?? ""
+        self.messageId = event.messageId ?? fallbackMessageId
+        self.conversationId = event.conversationId ?? fallbackConversationId
+        self.question = event.question
+    }
+
+    init(from action: BlockedAction, question: UserQuestion, fallbackConversationId: String) {
+        self.actionId = action.actionId ?? ""
+        self.messageId = action.messageId ?? ""
+        self.conversationId = action.conversationId ?? fallbackConversationId
+        self.question = question
+    }
+}
+
+/// View-facing projection of the agent's streaming state: the streaming `Activity` overlaid
+/// with any `BlockedState`. Not stored — derived by the ViewModel from its split state.
 enum AgentStreamingPhase: Equatable {
     case idle
     case thinking
@@ -299,6 +333,18 @@ enum AgentStreamingPhase: Equatable {
     case personalAuthRequired(provider: String, toolName: String)
     case fileAuthRequired(fileName: String, toolName: String)
     case approvalRequired(approval: ToolApprovalInfo)
+    case userQuestionRequired(question: UserQuestionInfo)
+}
+
+extension BlockedState {
+    var asPhase: AgentStreamingPhase {
+        switch self {
+        case let .approval(info): .approvalRequired(approval: info)
+        case let .personalAuth(provider, toolName): .personalAuthRequired(provider: provider, toolName: toolName)
+        case let .fileAuth(fileName, toolName): .fileAuthRequired(fileName: fileName, toolName: toolName)
+        case let .userQuestion(info): .userQuestionRequired(question: info)
+        }
+    }
 }
 
 enum ConversationMessage: Identifiable {

--- a/x/adrsimon/mobile/Dust/Models/StreamingEvent.swift
+++ b/x/adrsimon/mobile/Dust/Models/StreamingEvent.swift
@@ -93,6 +93,7 @@ enum StreamingEventData: Decodable {
     case toolPersonalAuthRequired(ToolPersonalAuthRequiredEvent)
     case toolFileAuthRequired(ToolFileAuthRequiredEvent)
     case toolApproveExecution(ToolApproveExecutionEvent)
+    case toolAskUserQuestion(ToolAskUserQuestionEvent)
     case agentContextPruned
     case endOfStream
     case unknown(String)
@@ -131,6 +132,8 @@ enum StreamingEventData: Decodable {
             self = try .toolFileAuthRequired(ToolFileAuthRequiredEvent(from: decoder))
         case "tool_approve_execution":
             self = try .toolApproveExecution(ToolApproveExecutionEvent(from: decoder))
+        case "tool_ask_user_question":
+            self = try .toolAskUserQuestion(ToolAskUserQuestionEvent(from: decoder))
         case "agent_context_pruned":
             self = .agentContextPruned
         case "end-of-stream":
@@ -260,6 +263,31 @@ struct ToolApprovalMetadata: Decodable {
     let agentName: String?
 }
 
+struct ToolAskUserQuestionEvent: Decodable {
+    let conversationId: String?
+    let messageId: String?
+    let actionId: String?
+    let question: UserQuestion
+}
+
+struct UserQuestion: Decodable, Equatable {
+    let question: String
+    let options: [UserQuestionOption]
+    let multiSelect: Bool
+}
+
+struct UserQuestionOption: Decodable, Equatable {
+    let label: String
+    let description: String?
+}
+
+/// The user's reply to a `UserQuestion`: the indices of the chosen options plus an optional
+/// free-text response. Matches the server's `answer-question` body.
+struct UserQuestionAnswer: Encodable, Equatable {
+    let selectedOptions: [Int]
+    let customResponse: String?
+}
+
 /// Lightweight wrapper for heterogeneous JSON values in tool inputs.
 enum ToolInputValue: Decodable, Equatable {
     case string(String)
@@ -329,6 +357,7 @@ struct BlockedAction: Decodable {
     let argumentsRequiringApproval: [String]?
     let authError: ToolPersonalAuthError?
     let fileAuthorizationInfo: BlockedFileAuthInfo?
+    let question: UserQuestion?
 }
 
 struct BlockedFileAuthInfo: Decodable {

--- a/x/adrsimon/mobile/Dust/Services/ConversationService.swift
+++ b/x/adrsimon/mobile/Dust/Services/ConversationService.swift
@@ -188,6 +188,28 @@ enum ConversationService {
         )
     }
 
+    // swiftlint:disable:next function_parameter_count
+    static func answerQuestion(
+        workspaceId: String,
+        conversationId: String,
+        messageId: String,
+        actionId: String,
+        answer: UserQuestionAnswer,
+        tokenProvider: TokenProvider
+    ) async throws {
+        let endpoint = AppConfig.Endpoints.answerQuestion(
+            workspaceId: workspaceId,
+            conversationId: conversationId,
+            messageId: messageId
+        )
+        try await APIClient.authenticatedSend(
+            endpoint,
+            method: "POST",
+            body: AnswerQuestionRequest(actionId: actionId, answer: answer),
+            tokenProvider: tokenProvider
+        )
+    }
+
     static func retryMessage(
         workspaceId: String,
         conversationId: String,
@@ -212,6 +234,11 @@ enum ConversationService {
     private struct ValidateActionRequest: Encodable {
         let actionId: String
         let approved: String
+    }
+
+    private struct AnswerQuestionRequest: Encodable {
+        let actionId: String
+        let answer: UserQuestionAnswer
     }
 
     private struct RetryMessageRequest: Encodable {}

--- a/x/adrsimon/mobile/Dust/ViewModels/ConversationDetailViewModel.swift
+++ b/x/adrsimon/mobile/Dust/ViewModels/ConversationDetailViewModel.swift
@@ -16,12 +16,10 @@ final class ConversationDetailViewModel: ObservableObject {
     @Published var messages: [ConversationMessage] = []
     @Published var hasMore = false
 
-    /// Streaming phase for the currently streaming agent message (if any).
-    @Published var streamingPhase: AgentStreamingPhase = .idle
-    /// Currently running actions (tools executing in parallel).
-    @Published var activeActions: [ActiveAction] = []
-    /// Completed activity timeline steps (thinking segments + finished actions).
-    @Published var completedSteps: [ActivityStep] = []
+    /// Live reduction of the currently streaming agent message (nil when not streaming).
+    @Published var turn: AgentMessageStream?
+    /// What the agent is blocked on, if anything. Outlives `turn` until resolved.
+    @Published var blockedState: BlockedState?
     /// sId of the message currently being streamed.
     @Published var streamingMessageId: String?
     /// Error info for the last failed agent message (if any).
@@ -29,16 +27,42 @@ final class ConversationDetailViewModel: ObservableObject {
     /// Whether a validate-action request is in-flight.
     @Published var isValidatingAction = false
 
+    /// View-facing projection: the streaming activity overlaid with any blocked state.
+    var streamingPhase: AgentStreamingPhase {
+        if let blockedState { return blockedState.asPhase }
+        switch turn?.snapshot.activity {
+        case .thinking: return .thinking
+        case .generating: return .generating
+        case nil: return .idle
+        }
+    }
+
+    var activeActions: [ActiveAction] {
+        turn?.snapshot.activeActions ?? []
+    }
+
+    var completedSteps: [ActivityStep] {
+        turn?.snapshot.completedSteps ?? []
+    }
+
+    /// The message as it should currently render: the streaming message overlaid with its
+    /// live snapshot, since content/thinking accumulate in `turn` until finalize commits them.
+    func renderMessage(_ message: ConversationMessage) -> ConversationMessage {
+        guard case let .agent(agent) = message,
+              let snapshot = turn?.snapshot, snapshot.messageId == agent.sId
+        else { return message }
+        var merged = agent
+        merged.content = snapshot.content.isEmpty ? agent.content : snapshot.content
+        merged.chainOfThought = snapshot.chainOfThought
+        return .agent(merged)
+    }
+
     private let conversation: Conversation
     private let workspaceId: String
     private let tokenProvider: TokenProvider
     private var lastValue: Int?
     /// Monotonic counter to identify the active message stream generation.
     private var streamGeneration: UInt64 = 0
-    /// Buffer for the current thinking segment, flushed as a completed step on transition.
-    private var currentThinkingBuffer: String = ""
-    /// Counter for generating unique step IDs.
-    private var stepCounter: Int = 0
 
     // Streaming tasks
     private var conversationEventsTask: Task<Void, Never>?
@@ -237,7 +261,6 @@ final class ConversationDetailViewModel: ObservableObject {
         }
     }
 
-    // swiftlint:disable:next cyclomatic_complexity
     private func startMessageStream(for messageId: String) {
         if streamingMessageId == messageId { return }
 
@@ -245,11 +268,9 @@ final class ConversationDetailViewModel: ObservableObject {
         streamGeneration += 1
         let currentGeneration = streamGeneration
         streamingMessageId = messageId
-        streamingPhase = .thinking
+        turn = AgentMessageStream(messageId: messageId)
+        blockedState = nil
         lastError = nil
-        completedSteps = []
-        currentThinkingBuffer = ""
-        stepCounter = 0
 
         messageStreamTask = Task { [weak self, workspaceId, conversationId = conversation.sId, tokenProvider] in
             let endpoint = AppConfig.Endpoints.messageEvents(
@@ -272,7 +293,7 @@ final class ConversationDetailViewModel: ObservableObject {
 
                     do {
                         let envelope = try decoder.decode(SSEEnvelope.self, from: data)
-                        await self?.handleMessageEvent(envelope.data, messageId: messageId)
+                        await self?.reduce(envelope.data, messageId: messageId)
                     } catch {
                         logger.debug("Skipping unhandled message event: \(error)")
                     }
@@ -283,144 +304,66 @@ final class ConversationDetailViewModel: ObservableObject {
                 }
             }
 
-            // Stream ended — only clean up if we're still the active generation
-            // and not in a blocking state (approval/auth persist until resolved)
+            // Stream ended — only clean up if we're still the active generation and not
+            // blocked (approval/auth keep their turn alive until the user resolves them).
             guard let self else { return }
-            if streamGeneration == currentGeneration {
-                switch streamingPhase {
-                case .approvalRequired, .personalAuthRequired, .fileAuthRequired:
-                    break
-                case .idle, .thinking, .generating:
-                    streamingPhase = .idle
-                    streamingMessageId = nil
-                }
+            if streamGeneration == currentGeneration, blockedState == nil {
+                turn = nil
+                streamingMessageId = nil
             }
         }
     }
 
-    // swiftlint:disable:next cyclomatic_complexity
-    private func handleMessageEvent(_ event: StreamingEventData, messageId: String) async {
+    /// Routes a decoded message event: blocking events seed the separate `blockedState`;
+    /// everything else drives the `AgentMessageStream` reducer. When the reducer reaches a
+    /// terminal status, its snapshot is committed onto the persisted message.
+    private func reduce(_ event: StreamingEventData, messageId: String) {
         switch event {
-        case let .generationTokens(tokens):
-            handleGenerationTokens(tokens, messageId: messageId)
-
-        case let .toolParams(params):
-            flushThinkingBuffer()
-            // Clear the live chainOfThought on the message since it was flushed to a step.
-            updateAgentMessage(id: messageId) { msg in
-                msg.chainOfThought = nil
-            }
-            let action = ActiveAction(
-                id: params.action.id,
-                label: params.action.displayLabels?.running ?? params.action.toolName ?? "Working…",
-                serverName: params.action.internalMCPServerName
-            )
-            if !activeActions.contains(where: { $0.id == action.id }) {
-                activeActions.append(action)
-            }
-
-        case let .agentActionSuccess(event):
-            let doneLabel = event.action.displayLabels?.done ?? event.action.toolName ?? "Tool"
-            stepCounter += 1
-            completedSteps.append(.action(
-                id: "action-\(stepCounter)",
-                label: doneLabel,
-                serverName: event.action.internalMCPServerName
+        case let .toolApproveExecution(event):
+            blockedState = .approval(ToolApprovalInfo(
+                from: event,
+                fallbackMessageId: messageId,
+                fallbackConversationId: conversation.sId
             ))
-            activeActions.removeAll { $0.id == event.action.id }
-            if activeActions.isEmpty, streamingPhase != .generating, streamingPhase != .thinking {
-                streamingPhase = .thinking
-            }
-
-        case let .agentMessageSuccess(success):
-            finalizeMessage(messageId: messageId, status: .succeeded, from: success.message)
-
-        case let .agentMessageGracefullyStopped(event):
-            finalizeMessage(messageId: messageId, status: .gracefullyStopped, from: event.message)
-
-        case let .agentError(event):
-            lastError = ErrorInfo(from: event.error, messageId: messageId)
-            finalizeMessage(messageId: messageId, status: .failed)
-
-        case let .toolError(event):
-            lastError = ErrorInfo(from: event.error, messageId: messageId)
-            finalizeMessage(messageId: messageId, status: .failed)
-
-        case let .agentGenerationCancelled(event):
-            finalizeMessage(messageId: messageId, status: event.status == "interrupted" ? .interrupted : .cancelled)
 
         case let .toolPersonalAuthRequired(event):
-            streamingPhase = .personalAuthRequired(
+            blockedState = .personalAuth(
                 provider: event.authError.provider,
                 toolName: event.authError.toolName
             )
 
         case let .toolFileAuthRequired(event):
-            streamingPhase = .fileAuthRequired(
+            blockedState = .fileAuth(
                 fileName: event.fileAuthError.fileName,
                 toolName: event.fileAuthError.toolName
             )
 
-        case let .toolApproveExecution(event):
-            let approval = ToolApprovalInfo(
+        case let .toolAskUserQuestion(event):
+            blockedState = .userQuestion(UserQuestionInfo(
                 from: event,
                 fallbackMessageId: messageId,
                 fallbackConversationId: conversation.sId
-            )
-            streamingPhase = .approvalRequired(approval: approval)
+            ))
 
-        case .toolNotification, .agentContextPruned, .endOfStream, .unknown:
-            break
+        default:
+            turn?.apply(event)
+            if let snapshot = turn?.snapshot, snapshot.isFinished {
+                commitFinishedTurn(snapshot)
+            }
         }
     }
 
-    private func handleGenerationTokens(_ tokens: GenerationTokensEvent, messageId: String) {
-        updateAgentMessage(id: messageId) { msg in
-            switch tokens.classification {
-            case .tokens:
-                msg.content = (msg.content ?? "") + tokens.text
-            case .chainOfThought:
-                msg.chainOfThought = (msg.chainOfThought ?? "") + tokens.text
-            case .openingDelimiter, .closingDelimiter:
-                break
-            }
+    private func commitFinishedTurn(_ snapshot: AgentMessageStream.Snapshot) {
+        updateAgentMessage(id: snapshot.messageId) { msg in
+            msg.content = snapshot.content.isEmpty ? msg.content : snapshot.content
+            msg.chainOfThought = snapshot.chainOfThought
+            if let files = snapshot.generatedFiles { msg.generatedFiles = files }
+            if let citations = snapshot.citations { msg.citations = citations }
+            if let status = snapshot.status { msg.status = status }
         }
-        if tokens.classification == .chainOfThought {
-            currentThinkingBuffer += tokens.text
-        }
-        let newPhase: AgentStreamingPhase? = switch tokens.classification {
-        case .chainOfThought: .thinking
-        case .tokens: .generating
-        case .openingDelimiter, .closingDelimiter: nil
-        }
-        if let newPhase, streamingPhase != newPhase {
-            streamingPhase = newPhase
-        }
-    }
-
-    private func finalizeMessage(messageId: String, status: AgentMessageStatus, from final: AgentMessage? = nil) {
-        flushThinkingBuffer()
-        updateAgentMessage(id: messageId) { msg in
-            if let final {
-                msg.content = final.content
-                msg.chainOfThought = final.chainOfThought
-                msg.generatedFiles = final.generatedFiles
-                msg.citations = final.citations
-            }
-            msg.status = status
-        }
-        streamingPhase = .idle
-        activeActions = []
+        lastError = snapshot.error
+        turn = nil
         streamingMessageId = nil
-    }
-
-    /// Flush the current thinking buffer as a completed thinking step if non-empty.
-    private func flushThinkingBuffer() {
-        let text = currentThinkingBuffer.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !text.isEmpty else { return }
-        stepCounter += 1
-        completedSteps.append(.thinking(id: "thinking-\(stepCounter)", content: text))
-        currentThinkingBuffer = ""
     }
 
     private func updateUserMessage(id: String, mutate: (inout UserMessage) -> Void) {
@@ -444,7 +387,7 @@ final class ConversationDetailViewModel: ObservableObject {
     // MARK: - Tool Approval
 
     func validateAction(approved: ActionApproval) async {
-        guard case let .approvalRequired(info) = streamingPhase else { return }
+        guard case let .approval(info) = blockedState else { return }
         isValidatingAction = true
         defer { isValidatingAction = false }
 
@@ -457,16 +400,38 @@ final class ConversationDetailViewModel: ObservableObject {
                 approved: approved,
                 tokenProvider: tokenProvider
             )
-            streamingPhase = .thinking
+            blockedState = nil
         } catch {
             logger.error("Failed to validate action: \(error)")
         }
     }
 
+    func answerQuestion(_ answer: UserQuestionAnswer) async {
+        guard case let .userQuestion(info) = blockedState else { return }
+        isValidatingAction = true
+        defer { isValidatingAction = false }
+
+        do {
+            try await ConversationService.answerQuestion(
+                workspaceId: workspaceId,
+                conversationId: info.conversationId,
+                messageId: info.messageId,
+                actionId: info.actionId,
+                answer: answer,
+                tokenProvider: tokenProvider
+            )
+            blockedState = nil
+        } catch {
+            logger.error("Failed to answer question: \(error)")
+        }
+    }
+
     // MARK: - Blocked Actions Reconciliation
 
-    /// Fetches any blocked actions from the server and sets the streaming phase accordingly.
-    /// This handles the case where we attach to a conversation that's already blocked.
+    /// Re-syncs `blockedState` against the server. Authoritative in both directions: it sets a
+    /// block when the server reports one, and clears it when the server reports none — the latter
+    /// is how a block resolved out-of-app (e.g. web authentication) gets unstuck, since the
+    /// message-events stream is dead while the agent is parked.
     private func reconcileBlockedActions() async {
         do {
             let blocked = try await ConversationService.fetchBlockedActions(
@@ -474,35 +439,70 @@ final class ConversationDetailViewModel: ObservableObject {
                 conversationId: conversation.sId,
                 tokenProvider: tokenProvider
             )
-            guard let action = blocked.first else { return }
-
-            // Find the message this action belongs to and ensure we're tracking it
-            if let messageId = action.messageId {
-                if streamingMessageId == nil {
-                    streamingMessageId = messageId
+            guard let action = blocked.first else {
+                // Resolved elsewhere — drop the block and release the stream id so
+                // startMessageStream can re-attach to the resumed message.
+                if blockedState != nil {
+                    blockedState = nil
+                    streamingMessageId = nil
+                    turn = nil
                 }
+                return
             }
 
-            switch action.status {
-            case .blockedValidationRequired:
-                let approval = ToolApprovalInfo(from: action, fallbackConversationId: conversation.sId)
-                streamingPhase = .approvalRequired(approval: approval)
+            // Find the message this action belongs to and ensure we're tracking it
+            if let messageId = action.messageId, streamingMessageId == nil {
+                streamingMessageId = messageId
+            }
 
-            case .blockedAuthenticationRequired:
-                let provider = action.metadata?.mcpServerName ?? "Unknown"
-                let toolName = action.metadata?.toolName ?? ""
-                streamingPhase = .personalAuthRequired(provider: provider, toolName: toolName)
-
-            case .blockedFileAuthorizationRequired:
-                let fileName = action.fileAuthorizationInfo?.fileName ?? "Unknown"
-                let toolName = action.fileAuthorizationInfo?.toolName ?? action.metadata?.toolName ?? ""
-                streamingPhase = .fileAuthRequired(fileName: fileName, toolName: toolName)
-
-            case .blockedChildActionInputRequired, .blockedUserAnswerRequired:
-                break
+            if let mapped = mapBlockedState(from: action) {
+                blockedState = mapped
             }
         } catch {
             logger.error("Failed to fetch blocked actions: \(error)")
+        }
+    }
+
+    /// Maps a server blocked action to the local `BlockedState`. Returns nil for statuses the app
+    /// doesn't surface (e.g. child-action input).
+    private func mapBlockedState(from action: BlockedAction) -> BlockedState? {
+        switch action.status {
+        case .blockedValidationRequired:
+            return .approval(ToolApprovalInfo(from: action, fallbackConversationId: conversation.sId))
+
+        case .blockedAuthenticationRequired:
+            return .personalAuth(
+                provider: action.metadata?.mcpServerName ?? "Unknown",
+                toolName: action.metadata?.toolName ?? ""
+            )
+
+        case .blockedFileAuthorizationRequired:
+            return .fileAuth(
+                fileName: action.fileAuthorizationInfo?.fileName ?? "Unknown",
+                toolName: action.fileAuthorizationInfo?.toolName ?? action.metadata?.toolName ?? ""
+            )
+
+        case .blockedUserAnswerRequired:
+            guard let question = action.question else { return nil }
+            return .userQuestion(UserQuestionInfo(
+                from: action,
+                question: question,
+                fallbackConversationId: conversation.sId
+            ))
+
+        case .blockedChildActionInputRequired:
+            return nil
+        }
+    }
+
+    /// Re-sync when the app returns to the foreground: the only signal we have that a block was
+    /// resolved out-of-app (web auth). Reconciles, and if the block cleared, reloads so the
+    /// stream re-attaches to the resumed message.
+    func resyncOnForeground() async {
+        guard blockedState != nil else { return }
+        await reconcileBlockedActions()
+        if blockedState == nil {
+            await loadMessages()
         }
     }
 

--- a/x/adrsimon/mobile/Dust/Views/Components/MessageBubbleView.swift
+++ b/x/adrsimon/mobile/Dust/Views/Components/MessageBubbleView.swift
@@ -16,6 +16,7 @@ struct MessageBubbleView: View {
     var onGeneratedFileTap: ((GeneratedFile) -> Void)?
     var onCitationTap: ((CitationReference) -> Void)?
     var onValidateAction: ((ActionApproval) -> Void)?
+    var onAnswerQuestion: ((UserQuestionAnswer) -> Void)?
     var onRetry: ((String) -> Void)?
     var onOpenInBrowser: (() -> Void)?
 
@@ -39,6 +40,7 @@ struct MessageBubbleView: View {
                 onGeneratedFileTap: onGeneratedFileTap,
                 onCitationTap: onCitationTap,
                 onValidateAction: onValidateAction,
+                onAnswerQuestion: onAnswerQuestion,
                 onRetry: onRetry,
                 onOpenInBrowser: onOpenInBrowser
             )
@@ -114,6 +116,7 @@ struct AgentMessageBubble: View {
     var onGeneratedFileTap: ((GeneratedFile) -> Void)?
     var onCitationTap: ((CitationReference) -> Void)?
     var onValidateAction: ((ActionApproval) -> Void)?
+    var onAnswerQuestion: ((UserQuestionAnswer) -> Void)?
     var onRetry: ((String) -> Void)?
     var onOpenInBrowser: (() -> Void)?
 
@@ -177,6 +180,12 @@ struct AgentMessageBubble: View {
                     AuthRequiredView(
                         label: "File access required for \(fileName)",
                         onOpenInBrowser: onOpenInBrowser
+                    )
+                case let .userQuestionRequired(info):
+                    UserQuestionInlineView(
+                        question: info.question,
+                        isLoading: isValidatingAction,
+                        onAnswer: onAnswerQuestion
                     )
                 case .idle, .thinking, .generating:
                     EmptyView()
@@ -867,6 +876,133 @@ struct AuthRequiredView: View {
         }
         .padding(12)
         .liquidGlassRoundedRect()
+    }
+}
+
+// MARK: - User Question
+
+struct UserQuestionInlineView: View {
+    let question: UserQuestion
+    var isLoading: Bool = false
+    var onAnswer: ((UserQuestionAnswer) -> Void)?
+
+    @State private var selectedOptions: Set<Int> = []
+    @State private var customResponse = ""
+
+    private var trimmedResponse: String {
+        customResponse.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var canSend: Bool {
+        !selectedOptions.isEmpty || !trimmedResponse.isEmpty
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(question.question)
+                .sparkleLabelSm()
+                .foregroundStyle(Color.dustForeground)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            VStack(spacing: 6) {
+                ForEach(Array(question.options.enumerated()), id: \.offset) { index, option in
+                    optionRow(index: index, option: option)
+                }
+            }
+
+            TextField("Type something else", text: $customResponse, axis: .vertical)
+                .sparkleCopyXs()
+                .lineLimit(1 ... 4)
+                .padding(10)
+                .background(Color.dustMutedBackground)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+
+            Divider()
+                .foregroundStyle(Color.dustBorder)
+
+            VStack(spacing: 8) {
+                Button { onAnswer?(buildAnswer()) } label: {
+                    Text("Send")
+                        .sparkleLabelXs()
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .background(Color.highlight)
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                }
+                .disabled(!canSend)
+                .opacity(canSend ? 1.0 : 0.5)
+
+                Button { onAnswer?(UserQuestionAnswer(selectedOptions: [], customResponse: nil)) } label: {
+                    Text("Skip")
+                        .sparkleLabelXs()
+                        .foregroundStyle(Color.dustForeground)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                }
+            }
+            .disabled(isLoading)
+            .opacity(isLoading ? 0.5 : 1.0)
+        }
+        .padding(12)
+        .liquidGlassRoundedRect()
+    }
+
+    private func optionRow(index: Int, option: UserQuestionOption) -> some View {
+        let isSelected = selectedOptions.contains(index)
+        return Button {
+            toggle(index)
+        } label: {
+            HStack(alignment: .top, spacing: 8) {
+                (isSelected ? SparkleIcon.checkCircle : SparkleIcon.circle).image
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 16, height: 16)
+                    .foregroundStyle(isSelected ? Color.highlight : Color.dustFaint)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(option.label)
+                        .sparkleLabelXs()
+                        .foregroundStyle(Color.dustForeground)
+                    if let description = option.description, !description.isEmpty {
+                        Text(description)
+                            .sparkleCopyXs()
+                            .foregroundStyle(Color.dustFaint)
+                    }
+                }
+
+                Spacer(minLength: 0)
+            }
+            .padding(10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.dustMutedBackground)
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(isSelected ? Color.highlight : Color.clear, lineWidth: 1)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func toggle(_ index: Int) {
+        if question.multiSelect {
+            if selectedOptions.contains(index) {
+                selectedOptions.remove(index)
+            } else {
+                selectedOptions.insert(index)
+            }
+        } else {
+            selectedOptions = [index]
+        }
+    }
+
+    private func buildAnswer() -> UserQuestionAnswer {
+        UserQuestionAnswer(
+            selectedOptions: selectedOptions.sorted(),
+            customResponse: trimmedResponse.isEmpty ? nil : trimmedResponse
+        )
     }
 }
 

--- a/x/adrsimon/mobile/Dust/Views/ConversationDetailView.swift
+++ b/x/adrsimon/mobile/Dust/Views/ConversationDetailView.swift
@@ -14,6 +14,7 @@ struct ConversationDetailView: View {
     @State private var showFilesSheet = false
     @State private var selectedFragment: ContentFragment?
     @State private var selectedGeneratedFile: GeneratedFile?
+    @Environment(\.scenePhase) private var scenePhase
 
     init(
         conversation: Conversation,
@@ -79,6 +80,11 @@ struct ConversationDetailView: View {
             async let agents: () = inputBarViewModel.loadAgents()
             async let caps: () = inputBarViewModel.loadCapabilities()
             _ = await (agents, caps)
+        }
+        .onChange(of: scenePhase) { _, phase in
+            if phase == .active {
+                Task { await viewModel.resyncOnForeground() }
+            }
         }
         .onDisappear {
             inputBarViewModel.cancelUploads()
@@ -174,7 +180,7 @@ struct ConversationDetailView: View {
                                 let isStreaming = message.id == viewModel.streamingMessageId
                                 let hideAgentHeader = isSteeredAgentMessage(at: index)
                                 MessageBubbleView(
-                                    message: message,
+                                    message: viewModel.renderMessage(message),
                                     currentUserEmail: currentUserEmail,
                                     streamingPhase: isStreaming ? viewModel.streamingPhase : .idle,
                                     activeActions: isStreaming ? viewModel.activeActions : [],
@@ -197,6 +203,9 @@ struct ConversationDetailView: View {
                                     },
                                     onValidateAction: { approval in
                                         Task { await viewModel.validateAction(approved: approval) }
+                                    },
+                                    onAnswerQuestion: { answer in
+                                        Task { await viewModel.answerQuestion(answer) }
                                     },
                                     onRetry: { messageId in
                                         Task { await viewModel.retryMessage(messageId: messageId) }


### PR DESCRIPTION
## Description

Two related changes to the mobile conversation view.

**1. Extract an `AgentMessageStream` reducer.** The streaming-event reduction was smeared across `ConversationDetailViewModel` — `handleMessageEvent`/`handleGenerationTokens`/`finalizeMessage`/`flushThinkingBuffer` mutating six separate `@Published` fields plus two private buffers, in a specific order, only reachable through a live `@MainActor` SSE subscription. That's the most intricate logic in the app and it had no home and no test surface.

It now lives in a pure value type — `apply(event) -> snapshot`, no SwiftUI / networking / concurrency — that owns token & chain-of-thought accumulation, the thinking-buffer flush ordering, the action lifecycle, and terminal status. The ViewModel keeps the network subscription and a 4-line router, and commits the finished snapshot onto the persisted message.

Blocking (approval / personal auth / file auth) is split out of the activity lifecycle into a separate `BlockedState`. `AgentStreamingPhase` survives only as a *derived view projection*, so `MessageBubbleView` / `ActivityTimelineView` are unchanged.

While splitting, fixed a latent stuck-banner bug: `reconcileBlockedActions` was set-only. It's now authoritative in both directions — an empty server result clears the local block and releases the stream id so the stream can re-attach — and a foreground resync (`scenePhase`) picks up blocks resolved out-of-app (e.g. web authentication). The message-events stream is dead while the agent is parked on a block, so app foreground is the only resume signal we have.

**2. Support the `ask_user_question` tool.** A new blocking event the app didn't handle. Decodes the `tool_ask_user_question` stream event and the `blocked_user_answer_required` reconcile status, renders the question with single/multi-select options + an optional free-text answer, and submits via `POST .../messages/{mId}/answer-question` with `{ actionId, answer: { selectedOptions, customResponse? } }` — matching the web frontend's contract.

## Tests

Manual build + lint clean (`make build`, `make format-check`, `make lint`). No new tests in this PR — the reducer was built to be unit-tested in isolation (feed events, assert snapshot) and that's the natural follow-up; flagging it explicitly rather than claiming coverage I didn't add.

## Risk

Mobile-only, behind no server change. The refactor is behavior-preserving — `AgentStreamingPhase` is reprojected from the split state, so the views render the same. Worst case, a streaming-state regression in the conversation detail view (timeline/blocking UI); safe to roll back, it's a single self-contained commit. The `ask_user_question` UI degrades gracefully if the question payload is absent (block simply isn't surfaced).

## Deploy Plan

Standard mobile build — no migration, no server ordering. The `answer-question` endpoint already exists in `front`.