### PR TITLE
fix: start task with restricted agent

### DIFF
--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -1453,6 +1453,9 @@ describe("postUserMessage", () => {
   let globalGroup: Awaited<
     ReturnType<typeof createResourceTest>
   >["globalGroup"];
+  let globalSpace: Awaited<
+    ReturnType<typeof createResourceTest>
+  >["globalSpace"];
   let conversation: ConversationType;
   let agentConfig1: LightAgentConfigurationType;
 
@@ -1461,6 +1464,7 @@ describe("postUserMessage", () => {
     auth = setup.authenticator;
     workspace = setup.workspace;
     globalGroup = setup.globalGroup;
+    globalSpace = setup.globalSpace;
 
     agentConfig1 = await AgentConfigurationFactory.createTestAgent(auth, {
       name: "Test Agent 1",
@@ -3072,6 +3076,119 @@ describe("postUserMessage", () => {
         });
         expect(mentionRow).not.toBeNull();
         expect(mentionRow!.status).toBe("approved");
+
+        rateLimiterSpy.mockRestore();
+      });
+
+      it("should create a branch anchor when the conversation only contains content fragments", async () => {
+        const user = auth.getNonNullableUser();
+        const userJson = user.toJSON();
+        const dsViewInGlobalSpace = await DataSourceViewFactory.folder(
+          workspace,
+          globalSpace,
+          user
+        );
+
+        const blob = new Ok({
+          contentType: "text/plain" as const,
+          fileId: null,
+          nodeId: "task-instructions-node-id",
+          nodeDataSourceViewId: dsViewInGlobalSpace.id,
+          nodeType: "document" as const,
+          sourceUrl: null,
+          textBytes: null,
+          title: "How to complete the task",
+        });
+        vi.mocked(getContentFragmentBlob).mockResolvedValueOnce(blob);
+
+        expect(projectConversation.content.length).toBe(0);
+
+        const contentFragmentRes = await postNewContentFragment(
+          auth,
+          projectConversation,
+          {
+            title: "How to complete the task",
+            nodeId: "task-instructions-node-id",
+            nodeDataSourceViewId: dsViewInGlobalSpace.sId,
+          },
+          null
+        );
+        expect(contentFragmentRes.isOk()).toBe(true);
+
+        const conversationWithContentFragmentRes = await getConversation(
+          auth,
+          projectConversation.sId
+        );
+        expect(conversationWithContentFragmentRes.isOk()).toBe(true);
+        if (conversationWithContentFragmentRes.isErr()) {
+          return;
+        }
+        projectConversation = conversationWithContentFragmentRes.value;
+        expect(projectConversation.content.length).toBe(1);
+
+        const rateLimiterSpy = vi
+          .spyOn(rateLimiterModule, "rateLimiter")
+          .mockResolvedValue(100);
+
+        const result = await postUserMessage(auth, {
+          conversation: projectConversation,
+          content: `Hello @${agentWithDifferentSpace.name}`,
+          mentions: [{ configurationId: agentWithDifferentSpace.sId }],
+          context: {
+            username: userJson.username,
+            timezone: "UTC",
+            fullName: userJson.fullName,
+            email: userJson.email,
+            profilePictureUrl: userJson.image,
+            origin: "web",
+          },
+          skipToolsValidation: false,
+        });
+
+        expect(result.isOk()).toBe(true);
+        if (!result.isOk()) {
+          return;
+        }
+
+        const branchesAfter =
+          await ConversationBranchResource.listForConversation(
+            auth,
+            projectConversation.id
+          );
+        expect(branchesAfter.length).toBe(1);
+        const branch = branchesAfter[0];
+        expect(projectConversation.branchId).toBe(branch.sId);
+
+        const anchorMessageRow = await MessageModel.findOne({
+          where: {
+            conversationId: projectConversation.id,
+            workspaceId: workspace.id,
+            rank: 1,
+            branchId: null,
+          },
+          include: [
+            {
+              model: UserMessageModel,
+              as: "userMessage",
+              required: true,
+            },
+          ],
+        });
+        expect(anchorMessageRow).not.toBeNull();
+        expect(anchorMessageRow!.userMessage!.content).toBe("");
+        expect(anchorMessageRow!.userMessage!.userContextOrigin).toBe(
+          "branch_anchor"
+        );
+
+        const newUserMessageRow = await MessageModel.findOne({
+          where: {
+            id: result.value.userMessage.id,
+            workspaceId: workspace.id,
+          },
+        });
+        expect(newUserMessageRow).not.toBeNull();
+        expect(newUserMessageRow!.branchId).toBe(branch.id);
+        expect(newUserMessageRow!.rank).toBe(2);
 
         rateLimiterSpy.mockRestore();
       });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -151,6 +151,7 @@ import type {
   ContentFragmentContextType,
   ContentFragmentType,
 } from "@app/types/content_fragment";
+import { isContentFragmentType } from "@app/types/content_fragment";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -834,62 +835,75 @@ export async function postUserMessage(
         logger.info(
           "Message has user mentions, for now we do not support branching with user mentions."
         );
-      } else if (conversation.content.length === 0) {
-        // Create an invisible anchor message so the branch has a previousMessageId
-        // to reference.
-        const anchorMessage = await createUserMessage(auth, {
-          conversation,
-          content: "",
-          metadata: {
-            type: "create",
-            user: user.toJSON(),
-            rank: 0,
-            context: {
-              ...context,
-              origin: "branch_anchor",
-            },
-          },
-          transaction: t,
-        });
-
-        const branch = await ConversationBranchResource.makeNew(
-          auth,
-          {
-            conversationId: conversation.id,
-            previousMessageId: anchorMessage.id,
-            state: "open",
-            userId: user.id,
-          },
-          t
-        );
-
-        conversation.branchId = branch.sId;
-        nextMessageRank = 1;
       } else {
-        // Get the last message in the conversation.
-        const previousMessage =
-          conversation.content[conversation.content.length - 1].at(-1);
-        if (!previousMessage) {
-          logger.error(
-            "Last message in conversation has no content, cannot create branch."
-          );
-        } else {
-          // Create a new branch for the conversation.
+        const latestMessages = removeNulls(
+          conversation.content.map((versions) => versions.at(-1))
+        );
+        const shouldCreateAnchorMessage =
+          latestMessages.length === 0 ||
+          latestMessages.every(isContentFragmentType);
+
+        if (shouldCreateAnchorMessage) {
+          // Create an invisible anchor message so the branch has a previousMessageId
+          // to reference. If the conversation only contains content fragments, keep
+          // them before the anchor so they remain attached to the branch context.
+          const anchorMessageRank =
+            latestMessages.length > 0
+              ? Math.max(...latestMessages.map((m) => m.rank)) + 1
+              : 0;
+          const anchorMessage = await createUserMessage(auth, {
+            conversation,
+            content: "",
+            metadata: {
+              type: "create",
+              user: user.toJSON(),
+              rank: anchorMessageRank,
+              context: {
+                ...context,
+                origin: "branch_anchor",
+              },
+            },
+            transaction: t,
+          });
+
           const branch = await ConversationBranchResource.makeNew(
             auth,
             {
               conversationId: conversation.id,
-              previousMessageId: previousMessage.id,
+              previousMessageId: anchorMessage.id,
               state: "open",
               userId: user.id,
             },
             t
           );
 
-          // Update the conversation with the new branch id so the rest of the functions will operate on the branch.
           conversation.branchId = branch.sId;
-          // Set the next message rank to the rank of the previous message plus one.
-          nextMessageRank = previousMessage.rank + 1;
+          nextMessageRank = anchorMessageRank + 1;
+        } else {
+          // Get the last message in the conversation.
+          const previousMessage = latestMessages.at(-1);
+          if (!previousMessage) {
+            logger.error(
+              "Last message in conversation has no content, cannot create branch."
+            );
+          } else {
+            // Create a new branch for the conversation.
+            const branch = await ConversationBranchResource.makeNew(
+              auth,
+              {
+                conversationId: conversation.id,
+                previousMessageId: previousMessage.id,
+                state: "open",
+                userId: user.id,
+              },
+              t
+            );
+
+            // Update the conversation with the new branch id so the rest of the functions will operate on the branch.
+            conversation.branchId = branch.sId;
+            // Set the next message rank to the rank of the previous message plus one.
+            nextMessageRank = previousMessage.rank + 1;
+          }
         }
       }
     }

--- a/front/lib/api/assistant/conversation/branches.test.ts
+++ b/front/lib/api/assistant/conversation/branches.test.ts
@@ -14,6 +14,7 @@ import {
 import { ConversationBranchModel } from "@app/lib/models/agent/conversation_branch";
 import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
@@ -414,6 +415,95 @@ describe("mergeConversationBranch", () => {
       where: { id: branch.id, workspaceId: workspace.id },
     });
     expect(updatedBranch?.state).toBe("merged");
+  });
+
+  it("should unlink deleted task conversations from their task", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const projectSpace = await SpaceFactory.project(workspace);
+
+    const task = await ProjectTaskResource.makeNew(auth, {
+      spaceId: projectSpace.id,
+      userId: user.id,
+      createdByType: "user",
+      createdByUserId: user.id,
+      createdByAgentConfigurationId: null,
+      markedAsDoneByType: null,
+      markedAsDoneByUserId: null,
+      markedAsDoneByAgentConfigurationId: null,
+      text: "Task with rejected branch conversation",
+      status: "todo",
+      doneAt: null,
+      actorRationale: null,
+      agentInstructions: null,
+      agentSuggestionStatus: null,
+      agentSuggestionReviewedAt: null,
+      agentSuggestionReviewedByUserId: null,
+    });
+
+    const conversation = await ConversationModel.create({
+      workspaceId: workspace.id,
+      sId: generateRandomModelSId(),
+      title: "Task branch rejection test conversation",
+      requestedSpaceIds: [],
+      spaceId: projectSpace.id,
+      metadata: {
+        projectTaskId: task.sId,
+      },
+    });
+
+    await task.addConversation(auth, { conversationModelId: conversation.id });
+    await expect(task.getLatestConversationId(auth)).resolves.toBe(
+      conversation.sId
+    );
+
+    const anchorUserMessage = await UserMessageModel.create({
+      userId: user.id,
+      workspaceId: workspace.id,
+      content: "",
+      userContextUsername: "testuser",
+      userContextTimezone: "UTC",
+      userContextFullName: "Test User",
+      userContextEmail: "test@example.com",
+      userContextProfilePictureUrl: null,
+      userContextOrigin: "branch_anchor",
+      clientSideMCPServerIds: [],
+    });
+
+    const anchorMessage = await MessageModel.create({
+      workspaceId: workspace.id,
+      sId: generateRandomModelSId(),
+      rank: 0,
+      conversationId: conversation.id,
+      parentId: null,
+      userMessageId: anchorUserMessage.id,
+      agentMessageId: null,
+      contentFragmentId: null,
+    });
+
+    const branch = await ConversationBranchResource.makeNew(auth, {
+      state: "open",
+      previousMessageId: anchorMessage.id,
+      conversationId: conversation.id,
+      userId: user.id,
+    });
+
+    const res = await closeConversationBranch(auth, {
+      branchId: branch.sId,
+      conversationId: conversation.sId,
+    });
+    if (res.isErr()) {
+      throw res.error;
+    }
+
+    expect(res.value.conversationDeleted).toBe(true);
+    await expect(task.getLatestConversationId(auth)).resolves.toBeNull();
   });
 
   it("should return branch_not_found when branch does not exist", async () => {

--- a/front/lib/api/assistant/conversation/branches.ts
+++ b/front/lib/api/assistant/conversation/branches.ts
@@ -17,6 +17,7 @@ import { MessageModel } from "@app/lib/models/agent/conversation";
 import { ConversationBranchModel } from "@app/lib/models/agent/conversation_branch";
 import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import {
@@ -463,6 +464,14 @@ export async function closeConversationBranch(
     );
   }
   await conversation.updateVisibilityToDeleted(auth);
+
+  const taskId = conversation.metadata?.projectTaskId;
+  if (taskId) {
+    await ProjectTaskResource.unlinkConversation(auth, {
+      taskId,
+      conversationModelId: conversation.id,
+    });
+  }
 
   return new Ok({
     closedBranchId: closeRes.value.branch.id,

--- a/front/lib/resources/project_task_resource.ts
+++ b/front/lib/resources/project_task_resource.ts
@@ -684,6 +684,27 @@ export class ProjectTaskResource extends BaseResource<ProjectTaskModel> {
     });
   }
 
+  static async unlinkConversation(
+    auth: Authenticator,
+    {
+      taskId,
+      conversationModelId,
+    }: { taskId: string; conversationModelId: ModelId }
+  ): Promise<number> {
+    const taskModelId = getResourceIdFromSId(taskId);
+    if (taskModelId === null) {
+      return 0;
+    }
+
+    return ProjectTaskConversationModel.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        projectTodoId: taskModelId,
+        conversationId: conversationModelId,
+      },
+    });
+  }
+
   // ── Source links (* => todo) ─────────────────────────────────────────────
 
   // Links the given takeaway item + source document to this todo. Idempotent


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8504

This PR fixes branching when starting a task with a restricted agent by extending the anchor message creation logic to also handle conversations that contain only content fragments (not just empty conversations).

- When `postUserMessage` is called on a conversation that only has content fragments (e.g., task instructions injected before any user message), it now creates a branch anchor so the branch has a valid `previousMessageId` to reference.
- Adds `ProjectTaskResource.unlinkConversation` to clean up the task-conversation link when a branch rejection causes the conversation to be deleted.
- Updates `closeConversationBranch` to call `unlinkConversation` when the conversation is deleted and carries a `projectTaskId` in its metadata.

## Tests

Manually + unit tests added for both the anchor message creation on content-fragment-only conversations and the task conversation unlinking on branch deletion.

## Risks
Low.

## Deploy Plan

Standard deployment.

