### PR TITLE
[front] Fix HubSpot create_meeting/create_communication using removed ENGAGEMENT object type

### DIFF
--- a/front/lib/api/actions/servers/hubspot/client.ts
+++ b/front/lib/api/actions/servers/hubspot/client.ts
@@ -977,13 +977,7 @@ export const createCommunication = async ({
 }): Promise<SimplePublicObject> => {
   const hubspotClient = new Client({ accessToken });
 
-  const finalProperties = { ...properties };
-
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  if (!finalProperties.hs_engagement_type) {
-    finalProperties.hs_engagement_type = "COMMUNICATION";
-  }
-  if (!finalProperties.hs_communication_channel_type) {
+  if (!properties.hs_communication_channel_type) {
     throw normalizeError(
       new Error(
         "hs_communication_channel_type is required in properties for createCommunication."
@@ -1003,7 +997,7 @@ export const createCommunication = async ({
       if (mapping.ids && mapping.ids.length > 0) {
         const associationTypeId = await getAssociationTypeId(
           accessToken,
-          "engagements",
+          "communications",
           mapping.toObjectType
         );
         for (const id of mapping.ids) {
@@ -1023,20 +1017,20 @@ export const createCommunication = async ({
   }
 
   const communicationData: SimplePublicObjectInputForCreate = {
-    properties: finalProperties,
+    properties,
     associations: builtAssociations,
   };
 
   try {
     const communication = await hubspotClient.crm.objects.basicApi.create(
-      "engagements",
+      "communications",
       communicationData
     );
     return communication;
   } catch (error) {
     localLogger.error(
       { error, communicationData, function: "createCommunication" },
-      `Error creating communication (engagement type: ${finalProperties.hs_engagement_type}, channel: ${finalProperties.hs_communication_channel_type}).`
+      `Error creating communication (channel: ${properties.hs_communication_channel_type}).`
     );
     throw normalizeError(error);
   }
@@ -1057,13 +1051,6 @@ export const createMeeting = async ({
 }): Promise<SimplePublicObject> => {
   const hubspotClient = new Client({ accessToken });
 
-  const finalProperties = { ...properties };
-
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  if (!finalProperties.hs_engagement_type) {
-    finalProperties.hs_engagement_type = "MEETING";
-  }
-
   const builtAssociations: SimplePublicObjectInputForCreate["associations"] =
     [];
   if (associations) {
@@ -1076,7 +1063,7 @@ export const createMeeting = async ({
       if (mapping.ids && mapping.ids.length > 0) {
         const associationTypeId = await getAssociationTypeId(
           accessToken,
-          "engagements",
+          "meetings",
           mapping.toObjectType
         );
         for (const id of mapping.ids) {
@@ -1096,20 +1083,20 @@ export const createMeeting = async ({
   }
 
   const meetingInput: SimplePublicObjectInputForCreate = {
-    properties: finalProperties,
+    properties,
     associations: builtAssociations,
   };
 
   try {
     const meeting = await hubspotClient.crm.objects.basicApi.create(
-      "engagements",
+      "meetings",
       meetingInput
     );
     return meeting;
   } catch (error) {
     localLogger.error(
       { error, meetingInput, function: "createMeeting" },
-      `Error creating meeting engagement (type: ${finalProperties.hs_engagement_type}).`
+      `Error creating meeting.`
     );
     throw normalizeError(error);
   }
@@ -1221,7 +1208,6 @@ export const getMeeting = async (
       "hs_meeting_external_url",
       "hubspot_owner_id",
     ];
-    // HubSpot CRM v3: meetings are created via "engagements" but retrieved via "meetings".
     const meeting = await hubspotClient.crm.objects.basicApi.getById(
       "meetings",
       meetingId,

--- a/front/lib/api/actions/servers/hubspot/metadata.ts
+++ b/front/lib/api/actions/servers/hubspot/metadata.ts
@@ -645,12 +645,12 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
   create_communication: {
     description:
-      "Creates a new communication (WhatsApp, LinkedIn, SMS) in Hubspot as an engagement. Requires hs_communication_channel_type in properties.",
+      "Creates a new communication (WhatsApp, LinkedIn, SMS) in Hubspot. Requires hs_communication_channel_type in properties.",
     schema: {
       properties: z
         .record(z.any())
         .describe(
-          "Properties, including hs_engagement_type (e.g., 'COMMUNICATION'), hs_communication_channel_type, and message content (e.g., hs_communication_body)."
+          "Properties, including hs_communication_channel_type (e.g., 'SMS', 'WHATS_APP', 'LINKEDIN'), message content (e.g., hs_communication_body), and hs_timestamp."
         ),
       associations: engagementAssociationsSchema
         .optional()
@@ -664,12 +664,12 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
   },
   create_meeting: {
     description:
-      "Creates a new meeting in Hubspot as an engagement. Ensure hs_engagement_type='MEETING' and meeting details are in properties.",
+      "Creates a new meeting in Hubspot. Meeting details are in properties.",
     schema: {
       properties: z
         .record(z.any())
         .describe(
-          "Properties, including hs_engagement_type='MEETING', hs_meeting_title, hs_meeting_start_time, etc."
+          "Properties, including hs_meeting_title, hs_meeting_start_time, hs_meeting_end_time, hs_timestamp, etc."
         ),
       associations: engagementAssociationsSchema
         .optional()


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8582

HubSpot dropped support for the legacy "engagements" object type on the CRM v3 Objects create endpoint, breaking the create_meeting tool with "Object type ENGAGEMENT is not supported by this endpoint" (HTTP 400).

- createMeeting now creates via "meetings" and resolves association type IDs from "meetings".
- createCommunication now creates via "communications" and resolves association type IDs from "communications" (same latent failure).
- Stop defaulting hs_engagement_type into properties: the typed endpoints manage it server-side.
- Update tool metadata so the model is no longer instructed to send hs_engagement_type.

## Tests

Local

## Risk

Low, fix a currently broken behaviour

## Deploy Plan

Front
