### PR TITLE
refactor(mobile): extract AgentMessageStream reducer

### DIFF
--- a/x/adrsimon/mobile/Dust/Models/AgentMessageStream.swift
+++ b/x/adrsimon/mobile/Dust/Models/AgentMessageStream.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+/// Reduces an agent message's streaming events into its live state. Pure value type:
+/// `apply` events, read `snapshot`. Blocked/approval/auth is owned by the ViewModel.
+struct AgentMessageStream {
+    enum Activity: Equatable {
+        case thinking
+        case generating
+    }
+
+    struct Snapshot: Equatable {
+        let messageId: String
+        var content: String = ""
+        var chainOfThought: String?
+        var activity: Activity = .thinking
+        var activeActions: [ActiveAction] = []
+        var completedSteps: [ActivityStep] = []
+        var error: ErrorInfo?
+        /// nil until a terminal event arrives.
+        var status: AgentMessageStatus?
+        var generatedFiles: [GeneratedFile]?
+        var citations: [String: CitationReference]?
+
+        var isFinished: Bool {
+            status != nil
+        }
+    }
+
+    private(set) var snapshot: Snapshot
+    private var thinkingBuffer = ""
+    private var stepCounter = 0
+
+    init(messageId: String) {
+        self.snapshot = Snapshot(messageId: messageId)
+    }
+
+    mutating func apply(_ event: StreamingEventData) {
+        switch event {
+        case let .generationTokens(tokens):
+            applyTokens(tokens)
+
+        case let .toolParams(params):
+            flushThinkingBuffer()
+            snapshot.chainOfThought = nil
+            let action = ActiveAction(
+                id: params.action.id,
+                label: params.action.displayLabels?.running ?? params.action.toolName ?? "Working…",
+                serverName: params.action.internalMCPServerName
+            )
+            if !snapshot.activeActions.contains(where: { $0.id == action.id }) {
+                snapshot.activeActions.append(action)
+            }
+
+        case let .agentActionSuccess(event):
+            let doneLabel = event.action.displayLabels?.done ?? event.action.toolName ?? "Tool"
+            stepCounter += 1
+            snapshot.completedSteps.append(.action(
+                id: "action-\(stepCounter)",
+                label: doneLabel,
+                serverName: event.action.internalMCPServerName
+            ))
+            snapshot.activeActions.removeAll { $0.id == event.action.id }
+
+        case let .agentMessageSuccess(success):
+            finalize(status: .succeeded, from: success.message)
+
+        case let .agentMessageGracefullyStopped(event):
+            finalize(status: .gracefullyStopped, from: event.message)
+
+        case let .agentError(event):
+            snapshot.error = ErrorInfo(from: event.error, messageId: snapshot.messageId)
+            finalize(status: .failed, from: nil)
+
+        case let .toolError(event):
+            snapshot.error = ErrorInfo(from: event.error, messageId: snapshot.messageId)
+            finalize(status: .failed, from: nil)
+
+        case let .agentGenerationCancelled(event):
+            finalize(status: event.status == "interrupted" ? .interrupted : .cancelled, from: nil)
+
+        // Handled by the ViewModel, or no activity meaning.
+        case .toolPersonalAuthRequired, .toolFileAuthRequired, .toolApproveExecution,
+             .toolNotification, .agentContextPruned, .endOfStream, .unknown:
+            break
+        }
+    }
+
+    private mutating func applyTokens(_ tokens: GenerationTokensEvent) {
+        switch tokens.classification {
+        case .tokens:
+            snapshot.content += tokens.text
+            snapshot.activity = .generating
+        case .chainOfThought:
+            snapshot.chainOfThought = (snapshot.chainOfThought ?? "") + tokens.text
+            thinkingBuffer += tokens.text
+            snapshot.activity = .thinking
+        case .openingDelimiter, .closingDelimiter:
+            break
+        }
+    }
+
+    private mutating func finalize(status: AgentMessageStatus, from final: AgentMessage?) {
+        flushThinkingBuffer()
+        if let final {
+            snapshot.content = final.content ?? snapshot.content
+            snapshot.chainOfThought = final.chainOfThought
+            snapshot.generatedFiles = final.generatedFiles
+            snapshot.citations = final.citations
+        }
+        snapshot.status = status
+        snapshot.activeActions = []
+    }
+
+    private mutating func flushThinkingBuffer() {
+        let text = thinkingBuffer.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+        stepCounter += 1
+        snapshot.completedSteps.append(.thinking(id: "thinking-\(stepCounter)", content: text))
+        thinkingBuffer = ""
+    }
+}

--- a/x/adrsimon/mobile/Dust/Models/Message.swift
+++ b/x/adrsimon/mobile/Dust/Models/Message.swift
@@ -292,6 +292,14 @@ struct ErrorInfo: Equatable {
     }
 }
 
+/// What the agent is waiting on the user for. Outlives the stream until resolved.
+enum BlockedState: Equatable {
+    case approval(ToolApprovalInfo)
+    case personalAuth(provider: String, toolName: String)
+    case fileAuth(fileName: String, toolName: String)
+}
+
+/// Derived view projection of `Activity` overlaid with any `BlockedState`. Not stored.
 enum AgentStreamingPhase: Equatable {
     case idle
     case thinking
@@ -299,6 +307,16 @@ enum AgentStreamingPhase: Equatable {
     case personalAuthRequired(provider: String, toolName: String)
     case fileAuthRequired(fileName: String, toolName: String)
     case approvalRequired(approval: ToolApprovalInfo)
+}
+
+extension BlockedState {
+    var asPhase: AgentStreamingPhase {
+        switch self {
+        case let .approval(info): .approvalRequired(approval: info)
+        case let .personalAuth(provider, toolName): .personalAuthRequired(provider: provider, toolName: toolName)
+        case let .fileAuth(fileName, toolName): .fileAuthRequired(fileName: fileName, toolName: toolName)
+        }
+    }
 }
 
 enum ConversationMessage: Identifiable {

--- a/x/adrsimon/mobile/Dust/ViewModels/ConversationDetailViewModel.swift
+++ b/x/adrsimon/mobile/Dust/ViewModels/ConversationDetailViewModel.swift
@@ -16,12 +16,10 @@ final class ConversationDetailViewModel: ObservableObject {
     @Published var messages: [ConversationMessage] = []
     @Published var hasMore = false
 
-    /// Streaming phase for the currently streaming agent message (if any).
-    @Published var streamingPhase: AgentStreamingPhase = .idle
-    /// Currently running actions (tools executing in parallel).
-    @Published var activeActions: [ActiveAction] = []
-    /// Completed activity timeline steps (thinking segments + finished actions).
-    @Published var completedSteps: [ActivityStep] = []
+    /// Live reduction of the currently streaming agent message (nil when not streaming).
+    @Published var turn: AgentMessageStream?
+    /// What the agent is blocked on, if anything. Outlives `turn` until resolved.
+    @Published var blockedState: BlockedState?
     /// sId of the message currently being streamed.
     @Published var streamingMessageId: String?
     /// Error info for the last failed agent message (if any).
@@ -29,16 +27,40 @@ final class ConversationDetailViewModel: ObservableObject {
     /// Whether a validate-action request is in-flight.
     @Published var isValidatingAction = false
 
+    var streamingPhase: AgentStreamingPhase {
+        if let blockedState { return blockedState.asPhase }
+        switch turn?.snapshot.activity {
+        case .thinking: return .thinking
+        case .generating: return .generating
+        case nil: return .idle
+        }
+    }
+
+    var activeActions: [ActiveAction] {
+        turn?.snapshot.activeActions ?? []
+    }
+
+    var completedSteps: [ActivityStep] {
+        turn?.snapshot.completedSteps ?? []
+    }
+
+    /// Overlays the streaming message with its live snapshot until finalize commits it.
+    func renderMessage(_ message: ConversationMessage) -> ConversationMessage {
+        guard case let .agent(agent) = message,
+              let snapshot = turn?.snapshot, snapshot.messageId == agent.sId
+        else { return message }
+        var merged = agent
+        merged.content = snapshot.content.isEmpty ? agent.content : snapshot.content
+        merged.chainOfThought = snapshot.chainOfThought
+        return .agent(merged)
+    }
+
     private let conversation: Conversation
     private let workspaceId: String
     private let tokenProvider: TokenProvider
     private var lastValue: Int?
     /// Monotonic counter to identify the active message stream generation.
     private var streamGeneration: UInt64 = 0
-    /// Buffer for the current thinking segment, flushed as a completed step on transition.
-    private var currentThinkingBuffer: String = ""
-    /// Counter for generating unique step IDs.
-    private var stepCounter: Int = 0
 
     // Streaming tasks
     private var conversationEventsTask: Task<Void, Never>?
@@ -237,7 +259,6 @@ final class ConversationDetailViewModel: ObservableObject {
         }
     }
 
-    // swiftlint:disable:next cyclomatic_complexity
     private func startMessageStream(for messageId: String) {
         if streamingMessageId == messageId { return }
 
@@ -245,11 +266,9 @@ final class ConversationDetailViewModel: ObservableObject {
         streamGeneration += 1
         let currentGeneration = streamGeneration
         streamingMessageId = messageId
-        streamingPhase = .thinking
+        turn = AgentMessageStream(messageId: messageId)
+        blockedState = nil
         lastError = nil
-        completedSteps = []
-        currentThinkingBuffer = ""
-        stepCounter = 0
 
         messageStreamTask = Task { [weak self, workspaceId, conversationId = conversation.sId, tokenProvider] in
             let endpoint = AppConfig.Endpoints.messageEvents(
@@ -272,7 +291,7 @@ final class ConversationDetailViewModel: ObservableObject {
 
                     do {
                         let envelope = try decoder.decode(SSEEnvelope.self, from: data)
-                        await self?.handleMessageEvent(envelope.data, messageId: messageId)
+                        await self?.reduce(envelope.data, messageId: messageId)
                     } catch {
                         logger.debug("Skipping unhandled message event: \(error)")
                     }
@@ -283,144 +302,57 @@ final class ConversationDetailViewModel: ObservableObject {
                 }
             }
 
-            // Stream ended — only clean up if we're still the active generation
-            // and not in a blocking state (approval/auth persist until resolved)
+            // Stream ended — only clean up if we're still the active generation and not
+            // blocked (approval/auth keep their turn alive until the user resolves them).
             guard let self else { return }
-            if streamGeneration == currentGeneration {
-                switch streamingPhase {
-                case .approvalRequired, .personalAuthRequired, .fileAuthRequired:
-                    break
-                case .idle, .thinking, .generating:
-                    streamingPhase = .idle
-                    streamingMessageId = nil
-                }
+            if streamGeneration == currentGeneration, blockedState == nil {
+                turn = nil
+                streamingMessageId = nil
             }
         }
     }
 
-    // swiftlint:disable:next cyclomatic_complexity
-    private func handleMessageEvent(_ event: StreamingEventData, messageId: String) async {
+    /// Blocking events seed `blockedState`; everything else drives the reducer.
+    private func reduce(_ event: StreamingEventData, messageId: String) {
         switch event {
-        case let .generationTokens(tokens):
-            handleGenerationTokens(tokens, messageId: messageId)
-
-        case let .toolParams(params):
-            flushThinkingBuffer()
-            // Clear the live chainOfThought on the message since it was flushed to a step.
-            updateAgentMessage(id: messageId) { msg in
-                msg.chainOfThought = nil
-            }
-            let action = ActiveAction(
-                id: params.action.id,
-                label: params.action.displayLabels?.running ?? params.action.toolName ?? "Working…",
-                serverName: params.action.internalMCPServerName
-            )
-            if !activeActions.contains(where: { $0.id == action.id }) {
-                activeActions.append(action)
-            }
-
-        case let .agentActionSuccess(event):
-            let doneLabel = event.action.displayLabels?.done ?? event.action.toolName ?? "Tool"
-            stepCounter += 1
-            completedSteps.append(.action(
-                id: "action-\(stepCounter)",
-                label: doneLabel,
-                serverName: event.action.internalMCPServerName
+        case let .toolApproveExecution(event):
+            blockedState = .approval(ToolApprovalInfo(
+                from: event,
+                fallbackMessageId: messageId,
+                fallbackConversationId: conversation.sId
             ))
-            activeActions.removeAll { $0.id == event.action.id }
-            if activeActions.isEmpty, streamingPhase != .generating, streamingPhase != .thinking {
-                streamingPhase = .thinking
-            }
-
-        case let .agentMessageSuccess(success):
-            finalizeMessage(messageId: messageId, status: .succeeded, from: success.message)
-
-        case let .agentMessageGracefullyStopped(event):
-            finalizeMessage(messageId: messageId, status: .gracefullyStopped, from: event.message)
-
-        case let .agentError(event):
-            lastError = ErrorInfo(from: event.error, messageId: messageId)
-            finalizeMessage(messageId: messageId, status: .failed)
-
-        case let .toolError(event):
-            lastError = ErrorInfo(from: event.error, messageId: messageId)
-            finalizeMessage(messageId: messageId, status: .failed)
-
-        case let .agentGenerationCancelled(event):
-            finalizeMessage(messageId: messageId, status: event.status == "interrupted" ? .interrupted : .cancelled)
 
         case let .toolPersonalAuthRequired(event):
-            streamingPhase = .personalAuthRequired(
+            blockedState = .personalAuth(
                 provider: event.authError.provider,
                 toolName: event.authError.toolName
             )
 
         case let .toolFileAuthRequired(event):
-            streamingPhase = .fileAuthRequired(
+            blockedState = .fileAuth(
                 fileName: event.fileAuthError.fileName,
                 toolName: event.fileAuthError.toolName
             )
 
-        case let .toolApproveExecution(event):
-            let approval = ToolApprovalInfo(
-                from: event,
-                fallbackMessageId: messageId,
-                fallbackConversationId: conversation.sId
-            )
-            streamingPhase = .approvalRequired(approval: approval)
-
-        case .toolNotification, .agentContextPruned, .endOfStream, .unknown:
-            break
+        default:
+            turn?.apply(event)
+            if let snapshot = turn?.snapshot, snapshot.isFinished {
+                commitFinishedTurn(snapshot)
+            }
         }
     }
 
-    private func handleGenerationTokens(_ tokens: GenerationTokensEvent, messageId: String) {
-        updateAgentMessage(id: messageId) { msg in
-            switch tokens.classification {
-            case .tokens:
-                msg.content = (msg.content ?? "") + tokens.text
-            case .chainOfThought:
-                msg.chainOfThought = (msg.chainOfThought ?? "") + tokens.text
-            case .openingDelimiter, .closingDelimiter:
-                break
-            }
+    private func commitFinishedTurn(_ snapshot: AgentMessageStream.Snapshot) {
+        updateAgentMessage(id: snapshot.messageId) { msg in
+            msg.content = snapshot.content.isEmpty ? msg.content : snapshot.content
+            msg.chainOfThought = snapshot.chainOfThought
+            if let files = snapshot.generatedFiles { msg.generatedFiles = files }
+            if let citations = snapshot.citations { msg.citations = citations }
+            if let status = snapshot.status { msg.status = status }
         }
-        if tokens.classification == .chainOfThought {
-            currentThinkingBuffer += tokens.text
-        }
-        let newPhase: AgentStreamingPhase? = switch tokens.classification {
-        case .chainOfThought: .thinking
-        case .tokens: .generating
-        case .openingDelimiter, .closingDelimiter: nil
-        }
-        if let newPhase, streamingPhase != newPhase {
-            streamingPhase = newPhase
-        }
-    }
-
-    private func finalizeMessage(messageId: String, status: AgentMessageStatus, from final: AgentMessage? = nil) {
-        flushThinkingBuffer()
-        updateAgentMessage(id: messageId) { msg in
-            if let final {
-                msg.content = final.content
-                msg.chainOfThought = final.chainOfThought
-                msg.generatedFiles = final.generatedFiles
-                msg.citations = final.citations
-            }
-            msg.status = status
-        }
-        streamingPhase = .idle
-        activeActions = []
+        lastError = snapshot.error
+        turn = nil
         streamingMessageId = nil
-    }
-
-    /// Flush the current thinking buffer as a completed thinking step if non-empty.
-    private func flushThinkingBuffer() {
-        let text = currentThinkingBuffer.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !text.isEmpty else { return }
-        stepCounter += 1
-        completedSteps.append(.thinking(id: "thinking-\(stepCounter)", content: text))
-        currentThinkingBuffer = ""
     }
 
     private func updateUserMessage(id: String, mutate: (inout UserMessage) -> Void) {
@@ -444,7 +376,7 @@ final class ConversationDetailViewModel: ObservableObject {
     // MARK: - Tool Approval
 
     func validateAction(approved: ActionApproval) async {
-        guard case let .approvalRequired(info) = streamingPhase else { return }
+        guard case let .approval(info) = blockedState else { return }
         isValidatingAction = true
         defer { isValidatingAction = false }
 
@@ -457,7 +389,7 @@ final class ConversationDetailViewModel: ObservableObject {
                 approved: approved,
                 tokenProvider: tokenProvider
             )
-            streamingPhase = .thinking
+            blockedState = nil
         } catch {
             logger.error("Failed to validate action: \(error)")
         }
@@ -465,8 +397,7 @@ final class ConversationDetailViewModel: ObservableObject {
 
     // MARK: - Blocked Actions Reconciliation
 
-    /// Fetches any blocked actions from the server and sets the streaming phase accordingly.
-    /// This handles the case where we attach to a conversation that's already blocked.
+    /// Sets `blockedState` from the server, for a conversation that's already blocked on load.
     private func reconcileBlockedActions() async {
         do {
             let blocked = try await ConversationService.fetchBlockedActions(
@@ -477,26 +408,23 @@ final class ConversationDetailViewModel: ObservableObject {
             guard let action = blocked.first else { return }
 
             // Find the message this action belongs to and ensure we're tracking it
-            if let messageId = action.messageId {
-                if streamingMessageId == nil {
-                    streamingMessageId = messageId
-                }
+            if let messageId = action.messageId, streamingMessageId == nil {
+                streamingMessageId = messageId
             }
 
             switch action.status {
             case .blockedValidationRequired:
-                let approval = ToolApprovalInfo(from: action, fallbackConversationId: conversation.sId)
-                streamingPhase = .approvalRequired(approval: approval)
+                blockedState = .approval(ToolApprovalInfo(from: action, fallbackConversationId: conversation.sId))
 
             case .blockedAuthenticationRequired:
                 let provider = action.metadata?.mcpServerName ?? "Unknown"
                 let toolName = action.metadata?.toolName ?? ""
-                streamingPhase = .personalAuthRequired(provider: provider, toolName: toolName)
+                blockedState = .personalAuth(provider: provider, toolName: toolName)
 
             case .blockedFileAuthorizationRequired:
                 let fileName = action.fileAuthorizationInfo?.fileName ?? "Unknown"
                 let toolName = action.fileAuthorizationInfo?.toolName ?? action.metadata?.toolName ?? ""
-                streamingPhase = .fileAuthRequired(fileName: fileName, toolName: toolName)
+                blockedState = .fileAuth(fileName: fileName, toolName: toolName)
 
             case .blockedChildActionInputRequired, .blockedUserAnswerRequired:
                 break

--- a/x/adrsimon/mobile/Dust/Views/ConversationDetailView.swift
+++ b/x/adrsimon/mobile/Dust/Views/ConversationDetailView.swift
@@ -174,7 +174,7 @@ struct ConversationDetailView: View {
                                 let isStreaming = message.id == viewModel.streamingMessageId
                                 let hideAgentHeader = isSteeredAgentMessage(at: index)
                                 MessageBubbleView(
-                                    message: message,
+                                    message: viewModel.renderMessage(message),
                                     currentUserEmail: currentUserEmail,
                                     streamingPhase: isStreaming ? viewModel.streamingPhase : .idle,
                                     activeActions: isStreaming ? viewModel.activeActions : [],


### PR DESCRIPTION
## Description

The streaming-event reduction was smeared across `ConversationDetailViewModel` — `handleMessageEvent` / `handleGenerationTokens` / `finalizeMessage` / `flushThinkingBuffer` mutating six `@Published` fields plus two private buffers in a specific order, reachable only through a live `@MainActor` SSE subscription. That's the most intricate logic in the conversation view and it had no home and no test surface.

This moves it into a pure `AgentMessageStream` value type — `apply(event) -> snapshot`, no SwiftUI / networking / concurrency — that owns token & chain-of-thought accumulation, the thinking-buffer flush ordering, the action lifecycle, and terminal status. The ViewModel keeps the subscription and a thin router, and commits the finished snapshot onto the persisted message.

Blocking (approval / personal auth / file auth) is split out of the activity lifecycle into a separate `BlockedState`. `AgentStreamingPhase` survives only as a derived view projection, so the message views are unchanged.

Behavior-preserving refactor — no functional change intended.

## Tests

Build + lint clean. No new tests in this PR; `AgentMessageStream` was built to be unit-tested in isolation (feed events, assert snapshot) — that's the natural follow-up.

## Risk

Worst case, a streaming-state regression in the conversation detail view (timeline / blocking UI). Mobile-only, no server change. Safe to roll back.

## Deploy Plan

Standard mobile build. No migration, no ordering.