### PR TITLE
fix(mobile): unstick the blocked-action banner after out-of-app resolution

### DIFF
--- a/x/adrsimon/mobile/Dust/ViewModels/ConversationDetailViewModel.swift
+++ b/x/adrsimon/mobile/Dust/ViewModels/ConversationDetailViewModel.swift
@@ -397,7 +397,8 @@ final class ConversationDetailViewModel: ObservableObject {
 
     // MARK: - Blocked Actions Reconciliation
 
-    /// Sets `blockedState` from the server, for a conversation that's already blocked on load.
+    /// Authoritative both ways: sets the block when the server reports one, clears it when not —
+    /// the latter unsticks a block resolved out-of-app (web auth), since the stream is then dead.
     private func reconcileBlockedActions() async {
         do {
             let blocked = try await ConversationService.fetchBlockedActions(
@@ -405,7 +406,15 @@ final class ConversationDetailViewModel: ObservableObject {
                 conversationId: conversation.sId,
                 tokenProvider: tokenProvider
             )
-            guard let action = blocked.first else { return }
+            guard let action = blocked.first else {
+                // Resolved elsewhere — release the stream id so the stream can re-attach.
+                if blockedState != nil {
+                    blockedState = nil
+                    streamingMessageId = nil
+                    turn = nil
+                }
+                return
+            }
 
             // Find the message this action belongs to and ensure we're tracking it
             if let messageId = action.messageId, streamingMessageId == nil {
@@ -431,6 +440,15 @@ final class ConversationDetailViewModel: ObservableObject {
             }
         } catch {
             logger.error("Failed to fetch blocked actions: \(error)")
+        }
+    }
+
+    /// Foreground is the only signal that a block was resolved out-of-app; reload if it cleared.
+    func resyncOnForeground() async {
+        guard blockedState != nil else { return }
+        await reconcileBlockedActions()
+        if blockedState == nil {
+            await loadMessages()
         }
     }
 

--- a/x/adrsimon/mobile/Dust/Views/ConversationDetailView.swift
+++ b/x/adrsimon/mobile/Dust/Views/ConversationDetailView.swift
@@ -14,6 +14,7 @@ struct ConversationDetailView: View {
     @State private var showFilesSheet = false
     @State private var selectedFragment: ContentFragment?
     @State private var selectedGeneratedFile: GeneratedFile?
+    @Environment(\.scenePhase) private var scenePhase
 
     init(
         conversation: Conversation,
@@ -79,6 +80,11 @@ struct ConversationDetailView: View {
             async let agents: () = inputBarViewModel.loadAgents()
             async let caps: () = inputBarViewModel.loadCapabilities()
             _ = await (agents, caps)
+        }
+        .onChange(of: scenePhase) { _, phase in
+            if phase == .active {
+                Task { await viewModel.resyncOnForeground() }
+            }
         }
         .onDisappear {
             inputBarViewModel.cancelUploads()


### PR DESCRIPTION
## Description

When a tool needs authentication, the server parks the agent loop and closes the message-events SSE. The stream is then dead — so when the user authenticates in the web app and comes back, nothing in the app clears the blocked banner, and it stays up over a conversation that has actually resumed.

`reconcileBlockedActions` was set-only: it set a block when the server reported one but never cleared it. This makes it authoritative in both directions — an empty server result now drops the block and releases the stream id so `startMessageStream` can re-attach to the resumed message. Driven from a `scenePhase` foreground hook, which is the only resume signal the app has while the stream is parked.

## Tests

Build + lint clean. Verified the foreground path manually is the follow-up (needs a real auth-required tool run).

## Risk

Worst case, an over-eager clear of the banner on foreground (gated behind `blockedState != nil` + a single `fetchBlockedActions`). Mobile-only. Safe to roll back.

## Deploy Plan

Standard mobile build. No migration.