### PR TITLE
feat(mobile): support the ask_user_question tool

### DIFF
--- a/x/adrsimon/mobile/Dust/Config/AppConfig.swift
+++ b/x/adrsimon/mobile/Dust/Config/AppConfig.swift
@@ -84,6 +84,10 @@ enum AppConfig {
             "/api/v1/w/\(workspaceId)/assistant/conversations/\(conversationId)/messages/\(messageId)/retry"
         }
 
+        static func answerQuestion(workspaceId: String, conversationId: String, messageId: String) -> String {
+            "/api/v1/w/\(workspaceId)/assistant/conversations/\(conversationId)/messages/\(messageId)/answer-question"
+        }
+
         static func mcpServerViews(workspaceId: String) -> String {
             "/api/w/\(workspaceId)/mcp/views"
         }

--- a/x/adrsimon/mobile/Dust/Models/AgentMessageStream.swift
+++ b/x/adrsimon/mobile/Dust/Models/AgentMessageStream.swift
@@ -80,7 +80,7 @@ struct AgentMessageStream {
 
         // Handled by the ViewModel, or no activity meaning.
         case .toolPersonalAuthRequired, .toolFileAuthRequired, .toolApproveExecution,
-             .toolNotification, .agentContextPruned, .endOfStream, .unknown:
+             .toolAskUserQuestion, .toolNotification, .agentContextPruned, .endOfStream, .unknown:
             break
         }
     }

--- a/x/adrsimon/mobile/Dust/Models/Message.swift
+++ b/x/adrsimon/mobile/Dust/Models/Message.swift
@@ -297,6 +297,28 @@ enum BlockedState: Equatable {
     case approval(ToolApprovalInfo)
     case personalAuth(provider: String, toolName: String)
     case fileAuth(fileName: String, toolName: String)
+    case userQuestion(UserQuestionInfo)
+}
+
+struct UserQuestionInfo: Equatable {
+    let actionId: String
+    let messageId: String
+    let conversationId: String
+    let question: UserQuestion
+
+    init(from event: ToolAskUserQuestionEvent, fallbackMessageId: String, fallbackConversationId: String) {
+        self.actionId = event.actionId ?? ""
+        self.messageId = event.messageId ?? fallbackMessageId
+        self.conversationId = event.conversationId ?? fallbackConversationId
+        self.question = event.question
+    }
+
+    init(from action: BlockedAction, question: UserQuestion, fallbackConversationId: String) {
+        self.actionId = action.actionId ?? ""
+        self.messageId = action.messageId ?? ""
+        self.conversationId = action.conversationId ?? fallbackConversationId
+        self.question = question
+    }
 }
 
 /// Derived view projection of `Activity` overlaid with any `BlockedState`. Not stored.
@@ -307,6 +329,7 @@ enum AgentStreamingPhase: Equatable {
     case personalAuthRequired(provider: String, toolName: String)
     case fileAuthRequired(fileName: String, toolName: String)
     case approvalRequired(approval: ToolApprovalInfo)
+    case userQuestionRequired(question: UserQuestionInfo)
 }
 
 extension BlockedState {
@@ -315,6 +338,7 @@ extension BlockedState {
         case let .approval(info): .approvalRequired(approval: info)
         case let .personalAuth(provider, toolName): .personalAuthRequired(provider: provider, toolName: toolName)
         case let .fileAuth(fileName, toolName): .fileAuthRequired(fileName: fileName, toolName: toolName)
+        case let .userQuestion(info): .userQuestionRequired(question: info)
         }
     }
 }

--- a/x/adrsimon/mobile/Dust/Models/StreamingEvent.swift
+++ b/x/adrsimon/mobile/Dust/Models/StreamingEvent.swift
@@ -93,6 +93,7 @@ enum StreamingEventData: Decodable {
     case toolPersonalAuthRequired(ToolPersonalAuthRequiredEvent)
     case toolFileAuthRequired(ToolFileAuthRequiredEvent)
     case toolApproveExecution(ToolApproveExecutionEvent)
+    case toolAskUserQuestion(ToolAskUserQuestionEvent)
     case agentContextPruned
     case endOfStream
     case unknown(String)
@@ -131,6 +132,8 @@ enum StreamingEventData: Decodable {
             self = try .toolFileAuthRequired(ToolFileAuthRequiredEvent(from: decoder))
         case "tool_approve_execution":
             self = try .toolApproveExecution(ToolApproveExecutionEvent(from: decoder))
+        case "tool_ask_user_question":
+            self = try .toolAskUserQuestion(ToolAskUserQuestionEvent(from: decoder))
         case "agent_context_pruned":
             self = .agentContextPruned
         case "end-of-stream":
@@ -260,6 +263,30 @@ struct ToolApprovalMetadata: Decodable {
     let agentName: String?
 }
 
+struct ToolAskUserQuestionEvent: Decodable {
+    let conversationId: String?
+    let messageId: String?
+    let actionId: String?
+    let question: UserQuestion
+}
+
+struct UserQuestion: Decodable, Equatable {
+    let question: String
+    let options: [UserQuestionOption]
+    let multiSelect: Bool
+}
+
+struct UserQuestionOption: Decodable, Equatable {
+    let label: String
+    let description: String?
+}
+
+/// Indices of the chosen options plus an optional free-text response.
+struct UserQuestionAnswer: Encodable, Equatable {
+    let selectedOptions: [Int]
+    let customResponse: String?
+}
+
 /// Lightweight wrapper for heterogeneous JSON values in tool inputs.
 enum ToolInputValue: Decodable, Equatable {
     case string(String)
@@ -329,6 +356,7 @@ struct BlockedAction: Decodable {
     let argumentsRequiringApproval: [String]?
     let authError: ToolPersonalAuthError?
     let fileAuthorizationInfo: BlockedFileAuthInfo?
+    let question: UserQuestion?
 }
 
 struct BlockedFileAuthInfo: Decodable {

--- a/x/adrsimon/mobile/Dust/Services/ConversationService.swift
+++ b/x/adrsimon/mobile/Dust/Services/ConversationService.swift
@@ -188,6 +188,28 @@ enum ConversationService {
         )
     }
 
+    // swiftlint:disable:next function_parameter_count
+    static func answerQuestion(
+        workspaceId: String,
+        conversationId: String,
+        messageId: String,
+        actionId: String,
+        answer: UserQuestionAnswer,
+        tokenProvider: TokenProvider
+    ) async throws {
+        let endpoint = AppConfig.Endpoints.answerQuestion(
+            workspaceId: workspaceId,
+            conversationId: conversationId,
+            messageId: messageId
+        )
+        try await APIClient.authenticatedSend(
+            endpoint,
+            method: "POST",
+            body: AnswerQuestionRequest(actionId: actionId, answer: answer),
+            tokenProvider: tokenProvider
+        )
+    }
+
     static func retryMessage(
         workspaceId: String,
         conversationId: String,
@@ -212,6 +234,11 @@ enum ConversationService {
     private struct ValidateActionRequest: Encodable {
         let actionId: String
         let approved: String
+    }
+
+    private struct AnswerQuestionRequest: Encodable {
+        let actionId: String
+        let answer: UserQuestionAnswer
     }
 
     private struct RetryMessageRequest: Encodable {}

--- a/x/adrsimon/mobile/Dust/ViewModels/ConversationDetailViewModel.swift
+++ b/x/adrsimon/mobile/Dust/ViewModels/ConversationDetailViewModel.swift
@@ -334,6 +334,13 @@ final class ConversationDetailViewModel: ObservableObject {
                 toolName: event.fileAuthError.toolName
             )
 
+        case let .toolAskUserQuestion(event):
+            blockedState = .userQuestion(UserQuestionInfo(
+                from: event,
+                fallbackMessageId: messageId,
+                fallbackConversationId: conversation.sId
+            ))
+
         default:
             turn?.apply(event)
             if let snapshot = turn?.snapshot, snapshot.isFinished {
@@ -395,6 +402,26 @@ final class ConversationDetailViewModel: ObservableObject {
         }
     }
 
+    func answerQuestion(_ answer: UserQuestionAnswer) async {
+        guard case let .userQuestion(info) = blockedState else { return }
+        isValidatingAction = true
+        defer { isValidatingAction = false }
+
+        do {
+            try await ConversationService.answerQuestion(
+                workspaceId: workspaceId,
+                conversationId: info.conversationId,
+                messageId: info.messageId,
+                actionId: info.actionId,
+                answer: answer,
+                tokenProvider: tokenProvider
+            )
+            blockedState = nil
+        } catch {
+            logger.error("Failed to answer question: \(error)")
+        }
+    }
+
     // MARK: - Blocked Actions Reconciliation
 
     /// Authoritative both ways: sets the block when the server reports one, clears it when not —
@@ -421,25 +448,41 @@ final class ConversationDetailViewModel: ObservableObject {
                 streamingMessageId = messageId
             }
 
-            switch action.status {
-            case .blockedValidationRequired:
-                blockedState = .approval(ToolApprovalInfo(from: action, fallbackConversationId: conversation.sId))
-
-            case .blockedAuthenticationRequired:
-                let provider = action.metadata?.mcpServerName ?? "Unknown"
-                let toolName = action.metadata?.toolName ?? ""
-                blockedState = .personalAuth(provider: provider, toolName: toolName)
-
-            case .blockedFileAuthorizationRequired:
-                let fileName = action.fileAuthorizationInfo?.fileName ?? "Unknown"
-                let toolName = action.fileAuthorizationInfo?.toolName ?? action.metadata?.toolName ?? ""
-                blockedState = .fileAuth(fileName: fileName, toolName: toolName)
-
-            case .blockedChildActionInputRequired, .blockedUserAnswerRequired:
-                break
+            if let mapped = mapBlockedState(from: action) {
+                blockedState = mapped
             }
         } catch {
             logger.error("Failed to fetch blocked actions: \(error)")
+        }
+    }
+
+    private func mapBlockedState(from action: BlockedAction) -> BlockedState? {
+        switch action.status {
+        case .blockedValidationRequired:
+            return .approval(ToolApprovalInfo(from: action, fallbackConversationId: conversation.sId))
+
+        case .blockedAuthenticationRequired:
+            return .personalAuth(
+                provider: action.metadata?.mcpServerName ?? "Unknown",
+                toolName: action.metadata?.toolName ?? ""
+            )
+
+        case .blockedFileAuthorizationRequired:
+            return .fileAuth(
+                fileName: action.fileAuthorizationInfo?.fileName ?? "Unknown",
+                toolName: action.fileAuthorizationInfo?.toolName ?? action.metadata?.toolName ?? ""
+            )
+
+        case .blockedUserAnswerRequired:
+            guard let question = action.question else { return nil }
+            return .userQuestion(UserQuestionInfo(
+                from: action,
+                question: question,
+                fallbackConversationId: conversation.sId
+            ))
+
+        case .blockedChildActionInputRequired:
+            return nil
         }
     }
 

--- a/x/adrsimon/mobile/Dust/Views/Components/MessageBubbleView.swift
+++ b/x/adrsimon/mobile/Dust/Views/Components/MessageBubbleView.swift
@@ -16,6 +16,7 @@ struct MessageBubbleView: View {
     var onGeneratedFileTap: ((GeneratedFile) -> Void)?
     var onCitationTap: ((CitationReference) -> Void)?
     var onValidateAction: ((ActionApproval) -> Void)?
+    var onAnswerQuestion: ((UserQuestionAnswer) -> Void)?
     var onRetry: ((String) -> Void)?
     var onOpenInBrowser: (() -> Void)?
 
@@ -39,6 +40,7 @@ struct MessageBubbleView: View {
                 onGeneratedFileTap: onGeneratedFileTap,
                 onCitationTap: onCitationTap,
                 onValidateAction: onValidateAction,
+                onAnswerQuestion: onAnswerQuestion,
                 onRetry: onRetry,
                 onOpenInBrowser: onOpenInBrowser
             )
@@ -114,6 +116,7 @@ struct AgentMessageBubble: View {
     var onGeneratedFileTap: ((GeneratedFile) -> Void)?
     var onCitationTap: ((CitationReference) -> Void)?
     var onValidateAction: ((ActionApproval) -> Void)?
+    var onAnswerQuestion: ((UserQuestionAnswer) -> Void)?
     var onRetry: ((String) -> Void)?
     var onOpenInBrowser: (() -> Void)?
 
@@ -177,6 +180,12 @@ struct AgentMessageBubble: View {
                     AuthRequiredView(
                         label: "File access required for \(fileName)",
                         onOpenInBrowser: onOpenInBrowser
+                    )
+                case let .userQuestionRequired(info):
+                    UserQuestionInlineView(
+                        question: info.question,
+                        isLoading: isValidatingAction,
+                        onAnswer: onAnswerQuestion
                     )
                 case .idle, .thinking, .generating:
                     EmptyView()
@@ -867,6 +876,133 @@ struct AuthRequiredView: View {
         }
         .padding(12)
         .liquidGlassRoundedRect()
+    }
+}
+
+// MARK: - User Question
+
+struct UserQuestionInlineView: View {
+    let question: UserQuestion
+    var isLoading: Bool = false
+    var onAnswer: ((UserQuestionAnswer) -> Void)?
+
+    @State private var selectedOptions: Set<Int> = []
+    @State private var customResponse = ""
+
+    private var trimmedResponse: String {
+        customResponse.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var canSend: Bool {
+        !selectedOptions.isEmpty || !trimmedResponse.isEmpty
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(question.question)
+                .sparkleLabelSm()
+                .foregroundStyle(Color.dustForeground)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            VStack(spacing: 6) {
+                ForEach(Array(question.options.enumerated()), id: \.offset) { index, option in
+                    optionRow(index: index, option: option)
+                }
+            }
+
+            TextField("Type something else", text: $customResponse, axis: .vertical)
+                .sparkleCopyXs()
+                .lineLimit(1 ... 4)
+                .padding(10)
+                .background(Color.dustMutedBackground)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+
+            Divider()
+                .foregroundStyle(Color.dustBorder)
+
+            VStack(spacing: 8) {
+                Button { onAnswer?(buildAnswer()) } label: {
+                    Text("Send")
+                        .sparkleLabelXs()
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .background(Color.highlight)
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                }
+                .disabled(!canSend)
+                .opacity(canSend ? 1.0 : 0.5)
+
+                Button { onAnswer?(UserQuestionAnswer(selectedOptions: [], customResponse: nil)) } label: {
+                    Text("Skip")
+                        .sparkleLabelXs()
+                        .foregroundStyle(Color.dustForeground)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                }
+            }
+            .disabled(isLoading)
+            .opacity(isLoading ? 0.5 : 1.0)
+        }
+        .padding(12)
+        .liquidGlassRoundedRect()
+    }
+
+    private func optionRow(index: Int, option: UserQuestionOption) -> some View {
+        let isSelected = selectedOptions.contains(index)
+        return Button {
+            toggle(index)
+        } label: {
+            HStack(alignment: .top, spacing: 8) {
+                (isSelected ? SparkleIcon.checkCircle : SparkleIcon.circle).image
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 16, height: 16)
+                    .foregroundStyle(isSelected ? Color.highlight : Color.dustFaint)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(option.label)
+                        .sparkleLabelXs()
+                        .foregroundStyle(Color.dustForeground)
+                    if let description = option.description, !description.isEmpty {
+                        Text(description)
+                            .sparkleCopyXs()
+                            .foregroundStyle(Color.dustFaint)
+                    }
+                }
+
+                Spacer(minLength: 0)
+            }
+            .padding(10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.dustMutedBackground)
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(isSelected ? Color.highlight : Color.clear, lineWidth: 1)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func toggle(_ index: Int) {
+        if question.multiSelect {
+            if selectedOptions.contains(index) {
+                selectedOptions.remove(index)
+            } else {
+                selectedOptions.insert(index)
+            }
+        } else {
+            selectedOptions = [index]
+        }
+    }
+
+    private func buildAnswer() -> UserQuestionAnswer {
+        UserQuestionAnswer(
+            selectedOptions: selectedOptions.sorted(),
+            customResponse: trimmedResponse.isEmpty ? nil : trimmedResponse
+        )
     }
 }
 

--- a/x/adrsimon/mobile/Dust/Views/ConversationDetailView.swift
+++ b/x/adrsimon/mobile/Dust/Views/ConversationDetailView.swift
@@ -204,6 +204,9 @@ struct ConversationDetailView: View {
                                     onValidateAction: { approval in
                                         Task { await viewModel.validateAction(approved: approval) }
                                     },
+                                    onAnswerQuestion: { answer in
+                                        Task { await viewModel.answerQuestion(answer) }
+                                    },
                                     onRetry: { messageId in
                                         Task { await viewModel.retryMessage(messageId: messageId) }
                                     },


### PR DESCRIPTION
**PR 3/3** — stacked on #26758.

## Description

The agent's `ask_user_question` tool emits a blocking event the app didn't handle, leaving the agent parked with no way to answer from mobile.

This decodes the `tool_ask_user_question` stream event and the `blocked_user_answer_required` reconcile status, renders the question with single/multi-select options and an optional free-text answer, and submits via `POST .../messages/{mId}/answer-question` with `{ actionId, answer: { selectedOptions, customResponse? } }` — matching the web frontend's contract. Reuses the existing `BlockedState` machinery, so the question flows through the same block/resolve path as approval and auth.

## Tests

Build + lint clean. Contract mirrored from `front` (`answer-question` route + `UserQuestion` / `UserQuestionAnswer` schemas).

## Risk

Worst case, the question UI doesn't render (degrades gracefully — if the `question` payload is absent the block simply isn't surfaced). Mobile-only, the `answer-question` endpoint already exists in `front`. Safe to roll back.

## Deploy Plan

Standard mobile build. No migration.