### PR TITLE
Reset user credit state on balance resolved

### DIFF
--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -79,6 +79,54 @@ export async function dispatchSeatBalanceExhausted({
   }
 }
 
+export async function dispatchSeatBalanceResolved({
+  workspace,
+  userId,
+}: {
+  workspace: WorkspaceResource;
+  userId: string;
+}): Promise<void> {
+  const user = await UserResource.fetchById(userId);
+  if (!user) {
+    logger.warn(
+      { workspaceId: workspace.sId, userId },
+      "[CreditStateDispatcher] dispatchSeatBalanceResolved: user not found, skipping"
+    );
+    return;
+  }
+
+  const lightWorkspace = renderLightWorkspaceType({ workspace });
+  const membership =
+    await MembershipResource.getActiveMembershipOfUserInWorkspace({
+      user,
+      workspace: lightWorkspace,
+    });
+  if (!membership) {
+    logger.warn(
+      { workspaceId: workspace.sId, userId },
+      "[CreditStateDispatcher] dispatchSeatBalanceResolved: no active membership, skipping"
+    );
+    return;
+  }
+
+  const result = await transitionUserCreditState(
+    membership,
+    { type: "seat_balance_resolved" },
+    { workspaceId: workspace.sId, userId, seatType: membership.seatType }
+  );
+  if (result.isErr()) {
+    logger.warn(
+      {
+        workspaceId: workspace.sId,
+        userId,
+        seatType: membership.seatType,
+        creditState: membership.creditState,
+      },
+      "[CreditStateDispatcher] dispatchSeatBalanceResolved: transition skipped"
+    );
+  }
+}
+
 export async function dispatchSeatLowBalance({
   workspace,
   userId,

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -11,6 +11,7 @@ import {
   dispatchProgrammaticLowBalance,
   dispatchProgrammaticWarning,
   dispatchSeatBalanceExhausted,
+  dispatchSeatBalanceResolved,
   dispatchSeatLowBalance,
   syncPoolCreditStateFromBalance,
 } from "@app/lib/api/metronome/credit_state_dispatcher";
@@ -992,8 +993,22 @@ export async function processMetronomeWebhook({
       }
       break;
     }
-    case "alerts.low_remaining_seat_balance_resolved":
+    case "alerts.low_remaining_seat_balance_resolved": {
+      const userId = event.properties.seat_filter?.seat_group_value;
+      if (!userId) {
+        logger.warn(
+          { eventId: event.id, workspaceId: workspace.sId },
+          "[Metronome Webhook] low_remaining_seat_balance_resolved: no seat_group_value in payload, skipping"
+        );
+        break;
+      }
+      await dispatchSeatBalanceResolved({ workspace, userId });
+      logger.info(
+        { eventId: event.id, workspaceId: workspace.sId, userId },
+        "[Metronome Webhook] low_remaining_seat_balance_resolved: seat balance resolved dispatched"
+      );
       break;
+    }
 
     case "alerts.invoice_total_reached":
     case "alerts.invoice_total_resolved":

--- a/front/lib/metronome/user_credit_state_machine.ts
+++ b/front/lib/metronome/user_credit_state_machine.ts
@@ -193,7 +193,6 @@ const TRANSITIONS: UserCreditTransition[] = [
       "user_seat_low_balance",
       "on_pool",
       "on_pool_low_balance",
-      "capped",
     ],
     event: "seat_balance_resolved",
     guard: (ctx) =>

--- a/front/lib/metronome/user_credit_state_machine.ts
+++ b/front/lib/metronome/user_credit_state_machine.ts
@@ -183,10 +183,6 @@ const TRANSITIONS: UserCreditTransition[] = [
       (ctx.seatType === "pro" || ctx.seatType === "pro_yearly"),
     to: "user_seat_low_balance",
   },
-
-  // Seat low-balance warning (balance > 0).
-  { from: "user_seat", event: "seat_low_balance", to: "user_seat_low_balance" },
-  { from: "on_pool", event: "seat_low_balance", to: "on_pool_low_balance" },
 ];
 
 function findTransition(

--- a/front/lib/metronome/user_credit_state_machine.ts
+++ b/front/lib/metronome/user_credit_state_machine.ts
@@ -183,6 +183,26 @@ const TRANSITIONS: UserCreditTransition[] = [
       (ctx.seatType === "pro" || ctx.seatType === "pro_yearly"),
     to: "user_seat_low_balance",
   },
+
+  // Billing-period renewal for pro/max seats: reset to user_seat regardless
+  // of current state. Workspace seats are reset by per_user_cap_resolved;
+  // free seats are not reset.
+  {
+    from: [
+      "user_seat",
+      "user_seat_low_balance",
+      "on_pool",
+      "on_pool_low_balance",
+      "capped",
+    ],
+    event: "seat_balance_resolved",
+    guard: (ctx) =>
+      ctx.seatType === "pro" ||
+      ctx.seatType === "pro_yearly" ||
+      ctx.seatType === "max" ||
+      ctx.seatType === "max_yearly",
+    to: "user_seat",
+  },
 ];
 
 function findTransition(

--- a/front/lib/metronome/user_credit_state_machine.ts
+++ b/front/lib/metronome/user_credit_state_machine.ts
@@ -183,6 +183,10 @@ const TRANSITIONS: UserCreditTransition[] = [
       (ctx.seatType === "pro" || ctx.seatType === "pro_yearly"),
     to: "user_seat_low_balance",
   },
+
+  // Seat low-balance warning (balance > 0).
+  { from: "user_seat", event: "seat_low_balance", to: "user_seat_low_balance" },
+  { from: "on_pool", event: "seat_low_balance", to: "on_pool_low_balance" },
 ];
 
 function findTransition(


### PR DESCRIPTION
## Description

Follow-up to #26755. Wires up the `alerts.low_remaining_seat_balance_resolved` Metronome webhook event, which was previously a no-op `break`. When this event fires (typically at billing-period renewal when a seat balance is replenished), the handler extracts the `userId` from `seat_filter.value` and dispatches `dispatchSeatBalanceResolved`.

A new `seat_balance_resolved` event is added to the user credit state machine with a guard restricting it to paid seats (`pro`, `pro_yearly`, `max`, `max_yearly`) — these are the only seat types whose personal balance is replenished by Metronome. The transition resets any state (`user_seat`, `user_seat_low_balance`, `on_pool`, `on_pool_low_balance`, `capped`) back to `user_seat`. Free seats remain `capped` (no personal balance), and workspace seats are reset via the existing `per_user_cap_resolved` path.

## Tests

Tested manually by verifying the webhook handler routes the resolved event correctly and that the state machine resets the expected seat types back to `user_seat`.

## Risk

Low. The previous code path was already a no-op for this event; free and workspace seat types are explicitly excluded by the guard, so only the intended seat types are affected.

## Deploy Plan

Deploy `front`.