### PR TITLE
Fix arrow scroll nav on Command Palette

### DIFF
--- a/front/components/command_palette/CommandPaletteItems.tsx
+++ b/front/components/command_palette/CommandPaletteItems.tsx
@@ -4,12 +4,12 @@ import React from "react";
 interface ItemRowProps {
   isSelected: boolean;
   onClick: () => void;
-  onMouseEnter: () => void;
+  onMouseMove: () => void;
   children: React.ReactNode;
 }
 
 export const ItemRow = React.forwardRef<HTMLDivElement, ItemRowProps>(
-  function ItemRow({ isSelected, onClick, onMouseEnter, children }, ref) {
+  function ItemRow({ isSelected, onClick, onMouseMove, children }, ref) {
     return (
       <div
         ref={ref}
@@ -21,7 +21,7 @@ export const ItemRow = React.forwardRef<HTMLDivElement, ItemRowProps>(
             : "hover:bg-muted-background dark:hover:bg-muted-background-night"
         )}
         onClick={onClick}
-        onMouseEnter={onMouseEnter}
+        onMouseMove={onMouseMove}
       >
         {children}
       </div>

--- a/front/components/command_palette/CommandPaletteSearchPhase.tsx
+++ b/front/components/command_palette/CommandPaletteSearchPhase.tsx
@@ -76,14 +76,18 @@ export function CommandPaletteSearchPhase({
     return () => cancelAnimationFrame(frameId);
   }, []);
 
-  // Scroll selected item into view.
+  // Scroll selected item into view. Guard against selectedIndex being
+  // transiently out-of-bounds on the render cycle before the reset effect fires.
   useEffect(() => {
-    itemRefs.current[selectedIndex]?.scrollIntoView({ block: "nearest" });
-  }, [selectedIndex]);
+    if (selectedIndex < flatItems.length) {
+      itemRefs.current[selectedIndex]?.scrollIntoView({ block: "nearest" });
+    }
+  }, [selectedIndex, flatItems.length]);
 
-  // Reset selection when the number of results changes (e.g., after typing).
+  // Reset selection and trim stale refs when the number of results changes.
   // biome-ignore lint/correctness/useExhaustiveDependencies: agents.length, pods.length and skills.length are intentional triggers
   useEffect(() => {
+    itemRefs.current.length = flatItems.length;
     onSelectedIndexChange(0);
   }, [agents.length, pods.length, skills.length, onSelectedIndexChange]);
 
@@ -163,7 +167,7 @@ export function CommandPaletteSearchPhase({
                 }}
                 isSelected={selectedIndex === i}
                 onClick={() => onItemSelect({ kind: "agent", agent })}
-                onMouseEnter={() => onSelectedIndexChange(i)}
+                onMouseMove={() => onSelectedIndexChange(i)}
               >
                 <Avatar visual={agent.pictureUrl} size="xs" />
                 <div className="flex min-w-0 items-center gap-1.5">
@@ -198,7 +202,7 @@ export function CommandPaletteSearchPhase({
                   }}
                   isSelected={selectedIndex === globalIndex}
                   onClick={() => onItemSelect({ kind: "pod", pod })}
-                  onMouseEnter={() => onSelectedIndexChange(globalIndex)}
+                  onMouseMove={() => onSelectedIndexChange(globalIndex)}
                 >
                   <Icon visual={getSpaceIcon(pod)} size="xs" />
                   <div className="flex min-w-0 items-center gap-1.5">
@@ -239,7 +243,7 @@ export function CommandPaletteSearchPhase({
                   }}
                   isSelected={selectedIndex === globalIndex}
                   onClick={() => onItemSelect({ kind: "skill", skill })}
-                  onMouseEnter={() => onSelectedIndexChange(globalIndex)}
+                  onMouseMove={() => onSelectedIndexChange(globalIndex)}
                 >
                   <SkillAvatar size="xs" />
                   <div className="flex min-w-0 items-center gap-1.5">


### PR DESCRIPTION
## Description

When keyboard navigation scrolled the list, rows could pass under the mouse cursor and trigger `mouseEnter`, which reset the selected item unexpectedly. We now update hover selection on `mouseMove` instead.

Also guards against stale item refs when results change.

## Tests

Locally / Review app.

-> On prod you will see the bug if you open the Palette and scroll down using the bottom arrow key. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 