### PR TITLE
Keep @dust-tt/sparkle out of the worker bundle for skill instructions HTML

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -632,6 +632,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "generate_sound_effects": "low",
   },
   "speech_generator": {
+    "speech_to_text": "low",
     "text_to_dialogue": "low",
     "text_to_speech": "low",
   },

--- a/front/lib/editor/build_skill_instructions_extensions_server.ts
+++ b/front/lib/editor/build_skill_instructions_extensions_server.ts
@@ -1,10 +1,10 @@
 // Server-side variant of buildSkillInstructionsExtensions. Mirrors the editor
-// builder but uses schema-only TipTap extensions and skips React/sparkle
-// imports, so it can be loaded by server code (e.g. skill_instructions_html)
-// without dragging the editor's React NodeView chain into the import graph.
+// builder but uses schema-only TipTap extensions and avoids React/sparkle
+// imports, so it can be loaded by server and worker code (e.g.
+// skill_instructions_html) without dragging the editor's React NodeView chain
+// or @dust-tt/sparkle into the import graph (the worker bundle forbids sparkle).
 import { InstructionSuggestionExtension } from "@app/components/editor/extensions/agent_builder/InstructionSuggestionExtension";
 import { CodeExtension } from "@app/components/editor/extensions/CodeExtension";
-import { HeadingExtension } from "@app/components/editor/extensions/HeadingExtension";
 import { BlockIdExtension } from "@app/components/editor/extensions/instructions/BlockIdExtension";
 import { InstructionsDocumentExtension } from "@app/components/editor/extensions/instructions/InstructionsDocumentExtension";
 import { InstructionsRootExtension } from "@app/components/editor/extensions/instructions/InstructionsRootExtension";
@@ -17,6 +17,7 @@ import {
 import { ToolNode } from "@app/components/editor/extensions/skill_builder/ToolNode";
 import { LinkExtension } from "@app/components/editor/input_bar/LinkExtension";
 import type { Extensions } from "@tiptap/core";
+import { Heading } from "@tiptap/extension-heading";
 import { Markdown } from "@tiptap/markdown";
 import { StarterKit } from "@tiptap/starter-kit";
 
@@ -47,7 +48,12 @@ export function buildSkillInstructionsExtensionsForServer(): Extensions {
       autolink: false,
       openOnClick: false,
     }),
-    HeadingExtension.configure({
+    // Use the plain TipTap Heading (not HeadingExtension) here: HeadingExtension
+    // imports markdownHeaderClasses from @dust-tt/sparkle, which is forbidden in
+    // the worker bundle. Server-side rendering strips presentation attributes
+    // anyway (see stripPresentationAttributes in skill_instructions_html.ts), so
+    // the sparkle-derived classes would be removed regardless.
+    Heading.configure({
       levels: [1, 2, 3, 4, 5, 6],
     }),
     BlockIdExtension,

--- a/front/lib/resources/webhook_request_resource.ts
+++ b/front/lib/resources/webhook_request_resource.ts
@@ -258,9 +258,13 @@ export class WebhookRequestResource extends BaseResource<WebhookRequestModel> {
       }
     );
 
-    return WorkspaceResource.fetchByModelIds(
+    // fetchByModelIds does not preserve input order, so re-sort by id ascending
+    // to honor the query's ORDER BY "workspaceId" ASC.
+    const workspaces = await WorkspaceResource.fetchByModelIds(
       rows.map((row) => row.workspaceId)
     );
+
+    return workspaces.sort((a, b) => a.id - b.id);
   }
 
   static async cleanUpWorkspace(


### PR DESCRIPTION
## Description

Three breakages currently on main, all blocking the prod deploy, none related to each other:

1. **Worker bundle (prod build failure).** `npm run build:workers` rejected the bundle: `HeadingExtension.ts imports @dust-tt/sparkle`. The server-side skill instructions extensions builder was meant to be sparkle-free but imported `HeadingExtension`, which imports `markdownHeaderClasses` from `@dust-tt/sparkle`. Latent until the skill authoring MCP server (#26740) pulled `skill_instructions_html` into the worker import graph. Swap `HeadingExtension` for the plain `Heading` from `@tiptap/extension-heading` (same pattern the file already uses for schema-only `KnowledgeNode`/`ToolNode`). Server-side rendering strips presentation attributes anyway, so the sparkle classes were discarded regardless. No behavior change.

2. **MCP metadata snapshot (test failure).** `speech_to_text` was added to the `speech_generator` server in #26701 without regenerating the tool stakes snapshot. Regenerated.

3. **Flaky webhook ordering test.** `getWorkspacesWithTooManyRequests` orders its raw SQL by `workspaceId ASC`, then passes the ids to `fetchByModelIds`, which does `WHERE id IN (...)` with no `ORDER BY` and returns rows in arbitrary scan order. The "verify sorted order" test passed or failed depending on Postgres. Re-sort the resources by id after fetching.

## Tests

`build:workers` passes (forbidden-import check clean). `mcp_servers_metadata` and `webhook_request_resource` tests pass locally. `tsgo --noEmit` clean.

## Risk

Low. HTML output unchanged; snapshot records an already-shipped tool; ordering fix only makes an already-intended order deterministic.

## Deploy Plan

Standard deploy.