### PR TITLE
Fix how we get the client IP in Hono

### DIFF
--- a/front-api/lib/request.ts
+++ b/front-api/lib/request.ts
@@ -1,0 +1,18 @@
+import { getClientIp } from "@app/lib/utils/request";
+import { getConnInfo } from "@hono/node-server/conninfo";
+import type { Context } from "hono";
+
+// Resolves the client IP for a Hono request. Prefers Cloudflare/forwarded
+// headers, falling back to the underlying socket's remote address (exposed by
+// the Node server adapter) so internal pod-to-pod requests still log a real IP
+// instead of "internal".
+export function getClientIpFromContext(c: Context): string {
+  const headers: Record<string, string | string[] | undefined> = {};
+  c.req.raw.headers.forEach((value, key) => {
+    headers[key] = value;
+  });
+
+  const remoteAddress = getConnInfo(c).remote.address;
+
+  return getClientIp({ headers, socket: { remoteAddress } });
+}

--- a/front-api/lib/request.ts
+++ b/front-api/lib/request.ts
@@ -12,7 +12,20 @@ export function getClientIpFromContext(c: Context): string {
     headers[key] = value;
   });
 
-  const remoteAddress = getConnInfo(c).remote.address;
+  return getClientIp({
+    headers,
+    socket: { remoteAddress: getRemoteAddress(c) },
+  });
+}
 
-  return getClientIp({ headers, socket: { remoteAddress } });
+// `getConnInfo` reads the Node server bindings off `c.env`, which only exist
+// when the app runs through the `@hono/node-server` adapter. Under
+// `honoApp.request(...)` (tests, plain fetch) those bindings are absent and it
+// throws, so we guard the external call and fall back to no socket address.
+function getRemoteAddress(c: Context): string | undefined {
+  try {
+    return getConnInfo(c).remote.address;
+  } catch {
+    return undefined;
+  }
 }

--- a/front-api/middlewares/request_logger.ts
+++ b/front-api/middlewares/request_logger.ts
@@ -1,9 +1,9 @@
 import type { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import { getClientIp } from "@app/lib/utils/request";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
+import { getClientIpFromContext } from "@front-api/lib/request";
 import { createMiddleware } from "hono/factory";
 
 type RequestLoggerEnv = {
@@ -50,11 +50,7 @@ export const requestLogger = createMiddleware<RequestLoggerEnv>(
     const statusCode = c.res.status;
     const route = c.req.routePath ?? c.req.path;
 
-    const headers: Record<string, string | string[] | undefined> = {};
-    c.req.raw.headers.forEach((value, key) => {
-      headers[key] = value;
-    });
-    const clientIp = getClientIp({ headers });
+    const clientIp = getClientIpFromContext(c);
 
     const auth = c.get("auth");
     const session = c.get("session");

--- a/front-api/middlewares/utils.ts
+++ b/front-api/middlewares/utils.ts
@@ -1,4 +1,3 @@
-import { getClientIp } from "@app/lib/utils/request";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
@@ -9,6 +8,7 @@ import type {
   APIErrorWithContentfulStatusCode,
 } from "@app/types/error";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { getClientIpFromContext } from "@front-api/lib/request";
 import type { Context, ErrorHandler, TypedResponse } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { routePath } from "hono/route";
@@ -114,14 +114,9 @@ export const unhandledErrorHandler: ErrorHandler = (err, ctx) => {
   const error = normalizeError(err);
   const sequelizeDetails = getSequelizeErrorDetails(error);
 
-  const headers: Record<string, string | string[] | undefined> = {};
-  ctx.req.raw.headers.forEach((value, key) => {
-    headers[key] = value;
-  });
-
   logger.error(
     {
-      clientIp: getClientIp({ headers }),
+      clientIp: getClientIpFromContext(ctx),
       method: ctx.req.method,
       route: routePath(ctx) ?? ctx.req.path,
       url: ctx.req.path,


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/8587

## Problem

  Internal requests to `front-api` (Hono) log `clientIp=internal`, while the equivalent Next.js service logs the real pod IP (e.g. `clientIp=10.96.133.108`). External requests are fine in both.

  Internal pod-to-pod requests carry no `cf-connecting-ip` / `x-forwarded-for` header, so the shared `getClientIp` helper falls through to its socket fallback (`req.socket?.remoteAddress ?? "internal"`). The Hono call sites only passed `{ headers }` and never a socket, so internal requests always resolved to the `"internal"` literal. Next.js passes `req.socket.remoteAddress`, so it logs the pod IP instead.

  ## Fix

  Add `getClientIpFromContext(c)` in `front-api/lib/request.ts` that, in addition to the request headers, grabs the connection's remote address via `getConnInfo(c)` (from `@hono/node-server/conninfo` — the Node adapter's equivalent of `req.socket.remoteAddress`) and feeds it into the existing shared `getClientIp` through its already-supported `socket: { remoteAddress }` shape.

  Both Hono clientIp call sites now use this helper:
  - `front-api/middlewares/request_logger.ts`
  - `front-api/middlewares/utils.ts` (unhandled error logger)

  The shared `getClientIp` in `front/lib/utils/request.ts` is unchanged, so Next.js behavior is untouched. External requests keep resolving from headers as before.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Front