### PR TITLE
Fix wake-up: `nextWakeupAt` hydration for conversation listing

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -58,7 +58,7 @@ import { FILE_ID_PATTERN } from "@app/lib/files";
 import { useConversationWakeUps } from "@app/lib/swr/wakeups";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { formatTimestring } from "@app/lib/utils/timestamps";
-import { getNextWakeUpFireAt } from "@app/lib/utils/wakeup_description";
+import { getNextWakeUpFireAtFromScheduleConfig } from "@app/lib/utils/wakeup_description";
 import datadogLogger from "@app/logger/datadogLogger";
 import type { FetchConversationMessageResponseLight } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]";
 import {
@@ -434,7 +434,9 @@ export function AgentMessage({
                 const activeWakeUp =
                   updated?.wakeUps.find(isActiveWakeUp) ?? null;
                 const nextWakeupAt = activeWakeUp
-                  ? getNextWakeUpFireAt(activeWakeUp)
+                  ? getNextWakeUpFireAtFromScheduleConfig(
+                      activeWakeUp.scheduleConfig
+                    )
                   : null;
                 void mutateConversations(
                   (currentData: ConversationListItemType[] | undefined) =>

--- a/front/lib/api/actions/servers/wakeups/tools/index.ts
+++ b/front/lib/api/actions/servers/wakeups/tools/index.ts
@@ -226,7 +226,7 @@ export function createWakeupsTools(
       const result = await WakeUpResource.makeNew(
         auth,
         blob,
-        conversation,
+        conversation.toJSON(),
         agentConfiguration
       );
       if (result.isErr()) {

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -22,6 +22,7 @@ import {
 } from "@app/lib/resources/permission_utils";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { WakeUpModel } from "@app/lib/resources/storage/models/wakeup";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -2500,6 +2501,59 @@ describe("listPrivateConversationsForUser", () => {
     expect(userConversations).toHaveLength(1);
     expect(userConversations[0].sId).toBe(conversationIds[0]);
     expect(userConversations[0]).toBeInstanceOf(ConversationResource);
+  });
+
+  it("hydrates nextWakeupAt in the DB paginated list", async () => {
+    const conversation = await ConversationFactory.create(adminAuth, {
+      agentConfigurationId: agents[0].sId,
+      messagesCreatedAt: [new Date()],
+    });
+    await ConversationResource.upsertParticipation(userAuth, {
+      conversation,
+      action: "posted",
+      user: userAuth.getNonNullableUser().toJSON(),
+    });
+
+    const scheduledFireAt = new Date("2030-01-01T12:00:00.000Z");
+    const cancelledFireAt = new Date("2029-01-01T12:00:00.000Z");
+
+    await WakeUpModel.bulkCreate([
+      {
+        workspaceId: workspace.id,
+        conversationId: conversation.id,
+        userId: adminAuth.getNonNullableUser().id,
+        agentConfigurationId: agents[0].sId,
+        scheduleType: "one_shot",
+        fireAt: cancelledFireAt,
+        cronExpression: null,
+        cronTimezone: null,
+        reason: "Cancelled wake-up",
+        status: "cancelled",
+        fireCount: 0,
+      },
+      {
+        workspaceId: workspace.id,
+        conversationId: conversation.id,
+        userId: adminAuth.getNonNullableUser().id,
+        agentConfigurationId: agents[0].sId,
+        scheduleType: "one_shot",
+        fireAt: scheduledFireAt,
+        cronExpression: null,
+        cronTimezone: null,
+        reason: "Scheduled wake-up",
+        status: "scheduled",
+        fireCount: 0,
+      },
+    ]);
+
+    const result =
+      await ConversationResource.listPrivateConversationsForUserPaginatedFromDB(
+        userAuth,
+        { limit: 100 }
+      );
+    const item = result.conversations.find((c) => c.sId === conversation.sId);
+
+    expect(item?.nextWakeupAt).toBe(scheduledFireAt.getTime());
   });
 
   it("should return conversations with populated participation data", async () => {

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -22,11 +22,12 @@ import {
 } from "@app/lib/resources/permission_utils";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
-import { WakeUpModel } from "@app/lib/resources/storage/models/wakeup";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { launchIndexConversationEsWorkflow } from "@app/temporal/es_indexation/client";
+import * as wakeUpTemporalClient from "@app/temporal/triggers/wakeup_client";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
@@ -40,6 +41,7 @@ import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import { Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
 import { assert, beforeEach, describe, expect, it, vi } from "vitest";
 import { destroyConversation } from "../api/assistant/conversation/destroy";
@@ -2504,8 +2506,15 @@ describe("listPrivateConversationsForUser", () => {
   });
 
   it("hydrates nextWakeupAt in the DB paginated list", async () => {
+    vi.spyOn(
+      wakeUpTemporalClient,
+      "launchOrScheduleWakeUpTemporalWorkflow"
+    ).mockResolvedValue(new Ok(undefined));
+
+    const agentConfiguration =
+      await AgentConfigurationFactory.createTestAgent(adminAuth);
     const conversation = await ConversationFactory.create(adminAuth, {
-      agentConfigurationId: agents[0].sId,
+      agentConfigurationId: agentConfiguration.sId,
       messagesCreatedAt: [new Date()],
     });
     await ConversationResource.upsertParticipation(userAuth, {
@@ -2517,34 +2526,34 @@ describe("listPrivateConversationsForUser", () => {
     const scheduledFireAt = new Date("2030-01-01T12:00:00.000Z");
     const cancelledFireAt = new Date("2029-01-01T12:00:00.000Z");
 
-    await WakeUpModel.bulkCreate([
+    const cancelledWakeUpResult = await WakeUpResource.makeNew(
+      adminAuth,
       {
-        workspaceId: workspace.id,
-        conversationId: conversation.id,
-        userId: adminAuth.getNonNullableUser().id,
-        agentConfigurationId: agents[0].sId,
         scheduleType: "one_shot",
         fireAt: cancelledFireAt,
         cronExpression: null,
         cronTimezone: null,
         reason: "Cancelled wake-up",
-        status: "cancelled",
-        fireCount: 0,
       },
+      conversation,
+      agentConfiguration
+    );
+    assert(cancelledWakeUpResult.isOk(), "Failed to create cancelled wake-up.");
+    await cancelledWakeUpResult.value.markCancelled(adminAuth);
+
+    const scheduledWakeUpResult = await WakeUpResource.makeNew(
+      adminAuth,
       {
-        workspaceId: workspace.id,
-        conversationId: conversation.id,
-        userId: adminAuth.getNonNullableUser().id,
-        agentConfigurationId: agents[0].sId,
         scheduleType: "one_shot",
         fireAt: scheduledFireAt,
         cronExpression: null,
         cronTimezone: null,
         reason: "Scheduled wake-up",
-        status: "scheduled",
-        fireCount: 0,
       },
-    ]);
+      conversation,
+      agentConfiguration
+    );
+    assert(scheduledWakeUpResult.isOk(), "Failed to create scheduled wake-up.");
 
     const result =
       await ConversationResource.listPrivateConversationsForUserPaginatedFromDB(

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -27,14 +27,15 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import { UserModel } from "@app/lib/resources/storage/models/user";
+import { WakeUpModel } from "@app/lib/resources/storage/models/wakeup";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { UserResource } from "@app/lib/resources/user_resource";
-import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
+import { getNextWakeUpFireAtFromScheduleConfig } from "@app/lib/utils/wakeup_description";
 import logger from "@app/logger/logger";
 import { launchIndexConversationEsWorkflow } from "@app/temporal/es_indexation/client";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
@@ -55,6 +56,10 @@ import {
   getConversationDisplayTitle,
   getConversationUrlAccessMode,
 } from "@app/types/assistant/conversation";
+import {
+  ACTIVE_WAKE_UP_STATUSES,
+  type WakeUpScheduleConfig,
+} from "@app/types/assistant/wakeups";
 import type { ContentFragmentVersion } from "@app/types/content_fragment";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -1828,7 +1833,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       pagination
     );
     const nextWakeupAtByConversationId =
-      await WakeUpResource.fetchNextWakeupAtByConversationId(
+      await this.fetchNextWakeupAtByConversationId(
         auth,
         result.conversations.map((c) => c.id)
       );
@@ -1841,6 +1846,68 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       hasMore: result.hasMore,
       lastValue: result.lastValue,
     };
+  }
+
+  /**
+   * This wake-up hydration lives here instead of `WakeUpResource` because `WakeUpResource` already
+   * depends on `ConversationResource` to reuse the established conversation ES reindexing path.
+   * This is all to avoid import cycles.
+   */
+  private static async fetchNextWakeupAtByConversationId(
+    auth: Authenticator,
+    conversationIds: ModelId[]
+  ): Promise<Map<ModelId, number>> {
+    if (conversationIds.length === 0) {
+      return new Map();
+    }
+
+    const wakeUps = await WakeUpModel.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        conversationId: { [Op.in]: conversationIds },
+        status: ACTIVE_WAKE_UP_STATUSES,
+      },
+      order: [
+        ["createdAt", "ASC"],
+        ["id", "ASC"],
+      ],
+    });
+
+    const nextWakeupAtByConversationId = new Map<ModelId, number>();
+    for (const wakeUp of wakeUps) {
+      const scheduleConfig: WakeUpScheduleConfig | null = (() => {
+        switch (wakeUp.scheduleType) {
+          case "one_shot":
+            return wakeUp.fireAt
+              ? { type: "one_shot", fireAt: wakeUp.fireAt.getTime() }
+              : null;
+          case "cron":
+            return wakeUp.cronExpression && wakeUp.cronTimezone
+              ? {
+                  type: "cron",
+                  cron: wakeUp.cronExpression,
+                  timezone: wakeUp.cronTimezone,
+                }
+              : null;
+          default:
+            return assertNever(wakeUp.scheduleType);
+        }
+      })();
+
+      const nextWakeupAt = scheduleConfig
+        ? getNextWakeUpFireAtFromScheduleConfig(scheduleConfig)
+        : null;
+      if (nextWakeupAt === null) {
+        continue;
+      }
+
+      const previous = nextWakeupAtByConversationId.get(wakeUp.conversationId);
+      if (previous === undefined || nextWakeupAt < previous) {
+        nextWakeupAtByConversationId.set(wakeUp.conversationId, nextWakeupAt);
+      }
+    }
+
+    return nextWakeupAtByConversationId;
   }
 
   static async listSpaceUnreadConversationsAndActivityForUser(

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -27,6 +27,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import { UserModel } from "@app/lib/resources/storage/models/user";
+import { WakeUpModel } from "@app/lib/resources/storage/models/wakeup";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
@@ -34,6 +35,7 @@ import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
+import { getNextWakeUpFireAtFromScheduleConfig } from "@app/lib/utils/wakeup_description";
 import logger from "@app/logger/logger";
 import { launchIndexConversationEsWorkflow } from "@app/temporal/es_indexation/client";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
@@ -54,6 +56,10 @@ import {
   getConversationDisplayTitle,
   getConversationUrlAccessMode,
 } from "@app/types/assistant/conversation";
+import {
+  ACTIVE_WAKE_UP_STATUSES,
+  type WakeUpScheduleConfig,
+} from "@app/types/assistant/wakeups";
 import type { ContentFragmentVersion } from "@app/types/content_fragment";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -1826,11 +1832,77 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       auth,
       pagination
     );
+    const nextWakeupAtByConversationId =
+      await this.fetchNextWakeupAtByConversationId(
+        auth,
+        result.conversations.map((c) => c.id)
+      );
+
     return {
-      conversations: result.conversations.map((c) => c.toListItem()),
+      conversations: result.conversations.map((c) => ({
+        ...c.toListItem(),
+        nextWakeupAt: nextWakeupAtByConversationId.get(c.id) ?? null,
+      })),
       hasMore: result.hasMore,
       lastValue: result.lastValue,
     };
+  }
+
+  private static async fetchNextWakeupAtByConversationId(
+    auth: Authenticator,
+    conversationIds: ModelId[]
+  ): Promise<Map<ModelId, number>> {
+    if (conversationIds.length === 0) {
+      return new Map();
+    }
+
+    const wakeUps = await WakeUpModel.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        conversationId: { [Op.in]: conversationIds },
+        status: ACTIVE_WAKE_UP_STATUSES,
+      },
+      order: [
+        ["createdAt", "ASC"],
+        ["id", "ASC"],
+      ],
+    });
+
+    const nextWakeupAtByConversationId = new Map<ModelId, number>();
+    for (const wakeUp of wakeUps) {
+      const scheduleConfig: WakeUpScheduleConfig | null = (() => {
+        switch (wakeUp.scheduleType) {
+          case "one_shot":
+            return wakeUp.fireAt
+              ? { type: "one_shot", fireAt: wakeUp.fireAt.getTime() }
+              : null;
+          case "cron":
+            return wakeUp.cronExpression && wakeUp.cronTimezone
+              ? {
+                  type: "cron",
+                  cron: wakeUp.cronExpression,
+                  timezone: wakeUp.cronTimezone,
+                }
+              : null;
+          default:
+            return assertNever(wakeUp.scheduleType);
+        }
+      })();
+
+      const nextWakeupAt = scheduleConfig
+        ? getNextWakeUpFireAtFromScheduleConfig(scheduleConfig)
+        : null;
+      if (nextWakeupAt === null) {
+        continue;
+      }
+
+      const previous = nextWakeupAtByConversationId.get(wakeUp.conversationId);
+      if (previous === undefined || nextWakeupAt < previous) {
+        nextWakeupAtByConversationId.set(wakeUp.conversationId, nextWakeupAt);
+      }
+    }
+
+    return nextWakeupAtByConversationId;
   }
 
   static async listSpaceUnreadConversationsAndActivityForUser(

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -27,7 +27,6 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import { UserModel } from "@app/lib/resources/storage/models/user";
-import { WakeUpModel } from "@app/lib/resources/storage/models/wakeup";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
@@ -35,7 +34,6 @@ import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
-import { getNextWakeUpFireAtFromScheduleConfig } from "@app/lib/utils/wakeup_description";
 import logger from "@app/logger/logger";
 import { launchIndexConversationEsWorkflow } from "@app/temporal/es_indexation/client";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
@@ -56,10 +54,6 @@ import {
   getConversationDisplayTitle,
   getConversationUrlAccessMode,
 } from "@app/types/assistant/conversation";
-import {
-  ACTIVE_WAKE_UP_STATUSES,
-  type WakeUpScheduleConfig,
-} from "@app/types/assistant/wakeups";
 import type { ContentFragmentVersion } from "@app/types/content_fragment";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1826,8 +1826,11 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       auth,
       pagination
     );
+    const { WakeUpResource } = await import(
+      "@app/lib/resources/wakeup_resource"
+    );
     const nextWakeupAtByConversationId =
-      await this.fetchNextWakeupAtByConversationId(
+      await WakeUpResource.fetchNextWakeupAtByConversationId(
         auth,
         result.conversations.map((c) => c.id)
       );
@@ -1840,63 +1843,6 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       hasMore: result.hasMore,
       lastValue: result.lastValue,
     };
-  }
-
-  private static async fetchNextWakeupAtByConversationId(
-    auth: Authenticator,
-    conversationIds: ModelId[]
-  ): Promise<Map<ModelId, number>> {
-    if (conversationIds.length === 0) {
-      return new Map();
-    }
-
-    const wakeUps = await WakeUpModel.findAll({
-      where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        conversationId: { [Op.in]: conversationIds },
-        status: ACTIVE_WAKE_UP_STATUSES,
-      },
-      order: [
-        ["createdAt", "ASC"],
-        ["id", "ASC"],
-      ],
-    });
-
-    const nextWakeupAtByConversationId = new Map<ModelId, number>();
-    for (const wakeUp of wakeUps) {
-      const scheduleConfig: WakeUpScheduleConfig | null = (() => {
-        switch (wakeUp.scheduleType) {
-          case "one_shot":
-            return wakeUp.fireAt
-              ? { type: "one_shot", fireAt: wakeUp.fireAt.getTime() }
-              : null;
-          case "cron":
-            return wakeUp.cronExpression && wakeUp.cronTimezone
-              ? {
-                  type: "cron",
-                  cron: wakeUp.cronExpression,
-                  timezone: wakeUp.cronTimezone,
-                }
-              : null;
-          default:
-            return assertNever(wakeUp.scheduleType);
-        }
-      })();
-
-      const nextWakeupAt = scheduleConfig
-        ? getNextWakeUpFireAtFromScheduleConfig(scheduleConfig)
-        : null;
-      if (nextWakeupAt === null) {
-        continue;
-      }
-
-      const previous = nextWakeupAtByConversationId.get(wakeUp.conversationId);
-      if (previous === undefined || nextWakeupAt < previous) {
-        nextWakeupAtByConversationId.set(wakeUp.conversationId, nextWakeupAt);
-      }
-    }
-
-    return nextWakeupAtByConversationId;
   }
 
   static async listSpaceUnreadConversationsAndActivityForUser(

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -32,6 +32,7 @@ import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrapp
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
@@ -1825,9 +1826,6 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     const result = await this.listPrivateConversationsForUserPaginated(
       auth,
       pagination
-    );
-    const { WakeUpResource } = await import(
-      "@app/lib/resources/wakeup_resource"
     );
     const nextWakeupAtByConversationId =
       await WakeUpResource.fetchNextWakeupAtByConversationId(

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -3,9 +3,9 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
-import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
-import { ConversationModel } from "@app/lib/models/agent/conversation";
+import { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { WakeUpModel } from "@app/lib/resources/storage/models/wakeup";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -14,7 +14,6 @@ import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { getNextWakeUpFireAtFromScheduleConfig } from "@app/lib/utils/wakeup_description";
-import { launchIndexConversationEsWorkflow } from "@app/temporal/es_indexation/client";
 import {
   cancelWakeUpTemporalWorkflow,
   launchOrScheduleWakeUpTemporalWorkflow,
@@ -790,27 +789,12 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
   private async triggerConversationESIndexing(
     auth: Authenticator
   ): Promise<void> {
-    if (!(await hasFeatureFlag(auth, "conversation_search_indexing"))) {
-      return;
-    }
-
-    const conversation = await ConversationModel.findOne({
-      where: {
-        id: this.conversationId,
-        workspaceId: auth.getNonNullableWorkspace().id,
-      },
-      attributes: ["sId"],
-    });
-    if (!conversation) {
-      return;
-    }
-
-    const result = await launchIndexConversationEsWorkflow({
-      conversationId: conversation.sId,
-      workspaceId: auth.getNonNullableWorkspace().sId,
-    });
-    if (result.isErr()) {
-      throw result.error;
+    const conversation =
+      (
+        await ConversationResource.fetchByModelIds(auth, [this.conversationId])
+      )[0] ?? null;
+    if (conversation) {
+      await ConversationResource.triggerEsIndexing(auth, conversation.sId);
     }
   }
 

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -36,7 +36,12 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { UserType } from "@app/types/user";
 import { CronExpressionParser } from "cron-parser";
-import type { Attributes, Transaction, WhereOptions } from "sequelize";
+import {
+  type Attributes,
+  Op,
+  type Transaction,
+  type WhereOptions,
+} from "sequelize";
 
 // Maximum fire counts for each wake-up to prevent run-away situations. The limit is exposed to
 // agents to let them reschedule their wake-ups if they want to keep being triggered after reaching

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -334,6 +334,63 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
     });
   }
 
+  static async fetchNextWakeupAtByConversationId(
+    auth: Authenticator,
+    conversationIds: ModelId[]
+  ): Promise<Map<ModelId, number>> {
+    if (conversationIds.length === 0) {
+      return new Map();
+    }
+
+    const wakeUps = await this.model.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        conversationId: { [Op.in]: conversationIds },
+        status: ACTIVE_WAKE_UP_STATUSES,
+      },
+      order: [
+        ["createdAt", "ASC"],
+        ["id", "ASC"],
+      ],
+    });
+
+    const nextWakeupAtByConversationId = new Map<ModelId, number>();
+    for (const wakeUp of wakeUps) {
+      const scheduleConfig: WakeUpScheduleConfig | null = (() => {
+        switch (wakeUp.scheduleType) {
+          case "one_shot":
+            return wakeUp.fireAt
+              ? { type: "one_shot", fireAt: wakeUp.fireAt.getTime() }
+              : null;
+          case "cron":
+            return wakeUp.cronExpression && wakeUp.cronTimezone
+              ? {
+                  type: "cron",
+                  cron: wakeUp.cronExpression,
+                  timezone: wakeUp.cronTimezone,
+                }
+              : null;
+          default:
+            return assertNever(wakeUp.scheduleType);
+        }
+      })();
+
+      const nextWakeupAt = scheduleConfig
+        ? getNextWakeUpFireAtFromScheduleConfig(scheduleConfig)
+        : null;
+      if (nextWakeupAt === null) {
+        continue;
+      }
+
+      const previous = nextWakeupAtByConversationId.get(wakeUp.conversationId);
+      if (previous === undefined || nextWakeupAt < previous) {
+        nextWakeupAtByConversationId.set(wakeUp.conversationId, nextWakeupAt);
+      }
+    }
+
+    return nextWakeupAtByConversationId;
+  }
+
   /**
    * Checks whether the caller can post or edit user messages in a conversation that has active
    * wake-ups. Rejects when any active (scheduled) wake-up is owned by a user other than the current

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -3,9 +3,9 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
-import { Authenticator } from "@app/lib/auth";
+import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
+import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { WakeUpModel } from "@app/lib/resources/storage/models/wakeup";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -18,6 +18,7 @@ import {
   cancelWakeUpTemporalWorkflow,
   launchOrScheduleWakeUpTemporalWorkflow,
 } from "@app/temporal/triggers/wakeup_client";
+import { launchIndexConversationEsWorkflow } from "@app/temporal/es_indexation/client";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import {
@@ -200,7 +201,7 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
           cronTimezone: string;
           reason: string;
         },
-    conversation: ConversationResource,
+    conversation: ConversationWithoutContentType,
     agentConfiguration: AgentConfigurationType,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<WakeUpResource, Error>> {

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -35,12 +35,7 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { UserType } from "@app/types/user";
 import { CronExpressionParser } from "cron-parser";
-import {
-  type Attributes,
-  Op,
-  type Transaction,
-  type WhereOptions,
-} from "sequelize";
+import type { Attributes, Transaction, WhereOptions } from "sequelize";
 
 // Maximum fire counts for each wake-up to prevent run-away situations. The limit is exposed to
 // agents to let them reschedule their wake-ups if they want to keep being triggered after reaching
@@ -337,63 +332,6 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
         ["id", "ASC"],
       ],
     });
-  }
-
-  static async fetchNextWakeupAtByConversationId(
-    auth: Authenticator,
-    conversationIds: ModelId[]
-  ): Promise<Map<ModelId, number>> {
-    if (conversationIds.length === 0) {
-      return new Map();
-    }
-
-    const wakeUps = await this.model.findAll({
-      where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        conversationId: { [Op.in]: conversationIds },
-        status: ACTIVE_WAKE_UP_STATUSES,
-      },
-      order: [
-        ["createdAt", "ASC"],
-        ["id", "ASC"],
-      ],
-    });
-
-    const nextWakeupAtByConversationId = new Map<ModelId, number>();
-    for (const wakeUp of wakeUps) {
-      const scheduleConfig: WakeUpScheduleConfig | null = (() => {
-        switch (wakeUp.scheduleType) {
-          case "one_shot":
-            return wakeUp.fireAt
-              ? { type: "one_shot", fireAt: wakeUp.fireAt.getTime() }
-              : null;
-          case "cron":
-            return wakeUp.cronExpression && wakeUp.cronTimezone
-              ? {
-                  type: "cron",
-                  cron: wakeUp.cronExpression,
-                  timezone: wakeUp.cronTimezone,
-                }
-              : null;
-          default:
-            return assertNever(wakeUp.scheduleType);
-        }
-      })();
-
-      const nextWakeupAt = scheduleConfig
-        ? getNextWakeUpFireAtFromScheduleConfig(scheduleConfig)
-        : null;
-      if (nextWakeupAt === null) {
-        continue;
-      }
-
-      const previous = nextWakeupAtByConversationId.get(wakeUp.conversationId);
-      if (previous === undefined || nextWakeupAt < previous) {
-        nextWakeupAtByConversationId.set(wakeUp.conversationId, nextWakeupAt);
-      }
-    }
-
-    return nextWakeupAtByConversationId;
   }
 
   /**

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -13,6 +13,7 @@ import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { getNextWakeUpFireAtFromScheduleConfig } from "@app/lib/utils/wakeup_description";
 import {
   cancelWakeUpTemporalWorkflow,
   launchOrScheduleWakeUpTemporalWorkflow,
@@ -579,26 +580,32 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
     if (this.status !== "scheduled") {
       return null;
     }
-    switch (this.scheduleType) {
-      case "one_shot":
-        return this.fireAt ?? null;
-      case "cron": {
-        if (!this.cronExpression || !this.cronTimezone) {
-          return null;
-        }
-        try {
-          return CronExpressionParser.parse(this.cronExpression, {
-            tz: this.cronTimezone,
-          })
-            .next()
-            .toDate();
-        } catch {
-          return null;
-        }
+
+    const scheduleConfig: WakeUpScheduleConfig | null = (() => {
+      switch (this.scheduleType) {
+        case "one_shot":
+          return this.fireAt
+            ? { type: "one_shot", fireAt: this.fireAt.getTime() }
+            : null;
+        case "cron":
+          return this.cronExpression && this.cronTimezone
+            ? {
+                type: "cron",
+                cron: this.cronExpression,
+                timezone: this.cronTimezone,
+              }
+            : null;
+        default:
+          return assertNever(this.scheduleType);
       }
-      default:
-        return assertNever(this.scheduleType);
+    })();
+
+    if (!scheduleConfig) {
+      return null;
     }
+
+    const nextFireAt = getNextWakeUpFireAtFromScheduleConfig(scheduleConfig);
+    return nextFireAt === null ? null : new Date(nextFireAt);
   }
 
   async markFired(

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -14,11 +14,11 @@ import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { getNextWakeUpFireAtFromScheduleConfig } from "@app/lib/utils/wakeup_description";
+import { launchIndexConversationEsWorkflow } from "@app/temporal/es_indexation/client";
 import {
   cancelWakeUpTemporalWorkflow,
   launchOrScheduleWakeUpTemporalWorkflow,
 } from "@app/temporal/triggers/wakeup_client";
-import { launchIndexConversationEsWorkflow } from "@app/temporal/es_indexation/client";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import {
@@ -785,12 +785,27 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
   private async triggerConversationESIndexing(
     auth: Authenticator
   ): Promise<void> {
-    const conversation =
-      (
-        await ConversationResource.fetchByModelIds(auth, [this.conversationId])
-      )[0] ?? null;
-    if (conversation) {
-      await ConversationResource.triggerEsIndexing(auth, conversation.sId);
+    if (!(await hasFeatureFlag(auth, "conversation_search_indexing"))) {
+      return;
+    }
+
+    const conversation = await ConversationModel.findOne({
+      where: {
+        id: this.conversationId,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      attributes: ["sId"],
+    });
+    if (!conversation) {
+      return;
+    }
+
+    const result = await launchIndexConversationEsWorkflow({
+      conversationId: conversation.sId,
+      workspaceId: auth.getNonNullableWorkspace().sId,
+    });
+    if (result.isErr()) {
+      throw result.error;
     }
   }
 

--- a/front/lib/utils/wakeup_description.test.ts
+++ b/front/lib/utils/wakeup_description.test.ts
@@ -1,7 +1,7 @@
 import {
   describeWakeUpSchedule,
   formatWakeUpSidebarLabel,
-  getNextWakeUpFireAt,
+  getNextWakeUpFireAtFromScheduleConfig,
 } from "@app/lib/utils/wakeup_description";
 import type { WakeUpType } from "@app/types/assistant/wakeups";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -161,11 +161,12 @@ describe("formatWakeUpSidebarLabel", () => {
   });
 });
 
-describe("getNextWakeUpFireAt", () => {
+describe("getNextWakeUpFireAtFromScheduleConfig", () => {
   it("returns fireAt as-is for one-shot schedules", () => {
     const fireAt = new Date(2026, 3, 27, 9, 0).getTime();
-    const wakeUp = makeWakeUp({ type: "one_shot", fireAt });
-    expect(getNextWakeUpFireAt(wakeUp)).toBe(fireAt);
+    expect(
+      getNextWakeUpFireAtFromScheduleConfig({ type: "one_shot", fireAt })
+    ).toBe(fireAt);
   });
 
   it("resolves the next cron firing in the schedule's stored timezone", () => {
@@ -173,12 +174,11 @@ describe("getNextWakeUpFireAt", () => {
     // is a Monday.
     vi.useFakeTimers();
     vi.setSystemTime(new Date(2026, 3, 27, 12, 0));
-    const wakeUp = makeWakeUp({
+    const nextFire = getNextWakeUpFireAtFromScheduleConfig({
       type: "cron",
       cron: "0 9 * * *",
       timezone: "America/New_York",
     });
-    const nextFire = getNextWakeUpFireAt(wakeUp);
     expect(nextFire).toBeGreaterThan(Date.now());
     vi.useRealTimers();
   });

--- a/front/lib/utils/wakeup_description.ts
+++ b/front/lib/utils/wakeup_description.ts
@@ -1,4 +1,7 @@
-import type { WakeUpType } from "@app/types/assistant/wakeups";
+import type {
+  WakeUpScheduleConfig,
+  WakeUpType,
+} from "@app/types/assistant/wakeups";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { CronExpressionParser } from "cron-parser";
 import cronstrue from "cronstrue";
@@ -27,22 +30,33 @@ function prefers24HourTime(): boolean {
 // Compute the millisecond timestamp of the next time a wake-up fires. For
 // one-shot schedules this is the stored `fireAt`; for cron schedules we
 // resolve the next firing in the schedule's stored timezone.
-export function getNextWakeUpFireAt(wakeUp: WakeUpType): number {
-  const config = wakeUp.scheduleConfig;
-  switch (config.type) {
+export function getNextWakeUpFireAtFromScheduleConfig(
+  scheduleConfig: WakeUpScheduleConfig
+): number | null {
+  switch (scheduleConfig.type) {
     case "one_shot":
-      return config.fireAt;
+      return scheduleConfig.fireAt;
     case "cron":
-      return CronExpressionParser.parse(config.cron, { tz: config.timezone })
-        .next()
-        .toDate()
-        .getTime();
+      try {
+        return CronExpressionParser.parse(scheduleConfig.cron, {
+          tz: scheduleConfig.timezone,
+        })
+          .next()
+          .toDate()
+          .getTime();
+      } catch {
+        return null;
+      }
     default:
-      assertNeverAndIgnore(config);
-      // Unknown schedule type from a newer server: treat as "fires now" so
-      // the optimistic-clear timer clears the indicator on the next tick.
-      return Date.now();
+      assertNeverAndIgnore(scheduleConfig);
+      return null;
   }
+}
+
+export function getNextWakeUpFireAt(wakeUp: WakeUpType): number {
+  return (
+    getNextWakeUpFireAtFromScheduleConfig(wakeUp.scheduleConfig) ?? Date.now()
+  );
 }
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;

--- a/front/lib/utils/wakeup_description.ts
+++ b/front/lib/utils/wakeup_description.ts
@@ -53,12 +53,6 @@ export function getNextWakeUpFireAtFromScheduleConfig(
   }
 }
 
-export function getNextWakeUpFireAt(wakeUp: WakeUpType): number {
-  return (
-    getNextWakeUpFireAtFromScheduleConfig(wakeUp.scheduleConfig) ?? Date.now()
-  );
-}
-
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
 // Compact label for the sidebar conversation-list wake-up indicator. When


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8557

Hydrates `nextWakeupAt` when listing conversation. We didn't do it initially as the plan was to move to ES but that did not happen (cc @flvndvd)

Asking review from @Fraggle (conversation listing) and @id13 (DB calls).

The query should be well indexed by `wake_ups_conversation_id`

## Tests

Added test, tested locally

## Risk

Adds an hydration step in conversation loading which is added latency. Probably better than an additional join. Wake-ups should be sparse so likely OK. 

Latency to monitor: [logs](https://app.datadoghq.eu/logs?agg_m_a=%40durationMs&agg_m_b=%40durationMs&agg_m_c=%40durationMs&agg_m_source_a=base&agg_m_source_b=base&agg_m_source_c=base&agg_t_a=pc90&agg_t_b=pc95&agg_t_c=pc99&analyticsOptions=%5B%22line%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&clustering_pattern_field_path_a=message&clustering_pattern_field_path_b=message&clustering_pattern_field_path_c=message&cols=host%2Cservice&ff_display=a%2Cb%2Cc&fromUser=true&messageDisplay=inline&query_a=%40route%3A%22%2Fapi%2Fw%2F%3AwId%2Fassistant%2Fconversations%22&query_b=%40route%3A%22%2Fapi%2Fw%2F%3AwId%2Fassistant%2Fconversations%22&query_c=%40route%3A%22%2Fapi%2Fw%2F%3AwId%2Fassistant%2Fconversations%22&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=timeseries&from_ts=1748852391672&to_ts=1748853291672&live=true)

## Deploy Plan

- deploy `front`