### PR TITLE
feat(assistant): add costCredits column to agent_message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ mprocs.log
 AGENTS.local.md
 CLAUDE.local.md
 node_modules
+thoughts/*
 
 # dust-hive worktrees
 .hives/

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -451,6 +451,7 @@ export class AgentMessageModel extends WorkspaceAwareModel<AgentMessageModel> {
   declare modelInteractionDurationMs: number | null;
   declare completedAt: Date | null;
   declare prunedContext: boolean | null;
+  declare costCredits: number | null;
 }
 
 AgentMessageModel.init(
@@ -535,6 +536,11 @@ AgentMessageModel.init(
       type: DataTypes.BOOLEAN,
       allowNull: true,
       defaultValue: false,
+    },
+    costCredits: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      defaultValue: null,
     },
   },
   {

--- a/front/migrations/db/migration_666.sql
+++ b/front/migrations/db/migration_666.sql
@@ -1,0 +1,7 @@
+-- Migration created on Jun 4, 2026
+-- Add "costCredits" to agent_messages: per-message credit usage (in AWU
+-- credits) consumed to produce the message. Nullable so existing rows and
+-- messages produced before tracking remain unset.
+SET statement_timeout = '2s';
+SET lock_timeout = '2s';
+ALTER TABLE "public"."agent_messages" ADD COLUMN "costCredits" INTEGER;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Adds the nullable INTEGER agent_message.costCredits column (migration_666) and
the corresponding Sequelize model field. No reader/writer yet; foundation for
per-message credit cost.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
Migrate the db before deploying the PR.

you need to not use the default $FRONT_DATABASE_URI when running your psql ... in prodbox
instead replace 6432 by 5432 for the port
(bypassing pgbouncer)