### PR TITLE
feat(assistant): thread costCredits through message and api

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -169,6 +169,7 @@ app.post(
       completionDurationMs: null,
       richMentions: [],
       reactions: [],
+      costCredits: null,
     };
 
     const { serverToolsAndInstructions, error: mcpToolsListingError } =

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.test.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.test.tsx
@@ -58,6 +58,7 @@ const mockAgentMessage: LightAgentMessageType = {
   richMentions: [],
   completionDurationMs: null,
   reactions: [],
+  costCredits: null,
   configuration: {
     sId: "agent_123",
     name: "dust",

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -179,6 +179,7 @@ export function createPlaceholderAgentMessage({
     richMentions: [],
     completionDurationMs: null,
     reactions: [],
+    costCredits: null,
 
     streaming: {
       agentState: "placeholder",

--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -108,6 +108,7 @@ function makeLightAgentMessage(
     richMentions: [],
     completionDurationMs: null,
     reactions: [],
+    costCredits: null,
     configuration: {
       sId: "agent_123",
       name: "dust",

--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -570,6 +570,7 @@ describe("tryCallMCPTool", () => {
       rank: messageRow.rank,
       branchId: messageRow.getBranchId(),
       richMentions: [],
+      costCredits: null,
     };
 
     // Create tool configuration

--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -197,6 +197,7 @@ export function getLightAgentMessageFromAgentMessage(
     completionDurationMs: agentMessage.completionDurationMs,
     reactions: agentMessage.reactions,
     prunedContext: agentMessage.prunedContext,
+    costCredits: agentMessage.costCredits,
     activitySteps: [],
   };
 }

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -4417,6 +4417,7 @@ describe("isConversationEventAllowedForAuth", () => {
       configurationId: "config-1",
       messageId: "msg-1",
       status: "success" as const,
+      costCredits: null,
     };
     const result = await isConversationEventAllowedForAuth(auth, { event });
     expect(result).toBe(true);

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -552,6 +552,7 @@ export const createAgentMessages = async (
             ),
             richMentions: [],
             reactions: [],
+            costCredits: null,
           };
         }
       }

--- a/front/lib/api/assistant/conversation_rendering/helpers.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.test.ts
@@ -308,6 +308,7 @@ The following skills are available for use with the skill_management__enable_ski
       richMentions: [],
       completionDurationMs: null,
       reactions: [],
+      costCredits: null,
     } satisfies AgentMessageType;
 
     const steps = await getSteps(authenticator, {
@@ -437,6 +438,7 @@ describe("vision image rendering in getSteps", () => {
       richMentions: [],
       completionDurationMs: null,
       reactions: [],
+      costCredits: null,
     };
 
     return { auth: authenticator, message, model, workspaceId, conversationId };

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
@@ -137,6 +137,7 @@ describe("renderAllMessages", () => {
             richMentions: [],
             completionDurationMs: null,
             reactions: [],
+            costCredits: null,
           } satisfies AgentMessageType,
         ];
       }

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -632,7 +632,6 @@ export async function batchRenderAgentMessages<V extends RenderMessageVariant>(
       );
     }
   }
-
   const renderedMessages: Array<
     Result<RenderedAgentMessage, ConversationError>
   > = [];
@@ -845,6 +844,9 @@ async function renderSingleAgentMessage(
 
   const created = message.createdAt.getTime();
   const completedTs = agentMessage.completedAt?.getTime() ?? null;
+  // costCredits is computed once at the end of the agentic loop and persisted on the agent message
+  // (see computeAndStoreAgentMessageCredits). Older messages predating this have a null value.
+  const costCredits = agentMessage.costCredits ?? null;
   const renderedMessage = {
     id: message.id,
     agentMessageId: agentMessage.id,
@@ -871,6 +873,7 @@ async function renderSingleAgentMessage(
     completionDurationMs: getCompletionDuration(created, completedTs, actions),
     reactions: reactionsByMessageId[message.id] ?? [],
     prunedContext: agentMessage.prunedContext ?? false,
+    costCredits,
   } satisfies AgentMessageType;
 
   if (viewType === "full") {

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -217,6 +217,7 @@ async function handler(
         completionDurationMs: null,
         richMentions: [],
         reactions: [],
+        costCredits: null,
       };
 
       const { serverToolsAndInstructions, error: mcpToolsListingError } =

--- a/front/pages/api/swagger_private_schemas.ts
+++ b/front/pages/api/swagger_private_schemas.ts
@@ -400,6 +400,10 @@
  *           type: array
  *           items:
  *             $ref: '#/components/schemas/PrivateReaction'
+ *         costCredits:
+ *           type: integer
+ *           nullable: true
+ *           description: Cost of producing this agent message, in AWU credits (intelligence + tool credits). Null when no billable usage is attributed to the message.
  *     PrivateLightAgentMessage:
  *       type: object
  *       description: A lighter agent message used in paginated message list responses.
@@ -492,6 +496,10 @@
  *         completionDurationMs:
  *           type: integer
  *           nullable: true
+ *         costCredits:
+ *           type: integer
+ *           nullable: true
+ *           description: Cost of producing this agent message, in AWU credits (intelligence + tool credits). Null when no billable usage is attributed to the message.
  *         activitySteps:
  *           type: array
  *           items:

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -10466,6 +10466,11 @@
             "items": {
               "$ref": "#/components/schemas/PrivateReaction"
             }
+          },
+          "costCredits": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Cost of producing this agent message, in AWU credits (intelligence + tool credits). Null when no billable usage is attributed to the message."
           }
         }
       },
@@ -10607,6 +10612,11 @@
           "completionDurationMs": {
             "type": "integer",
             "nullable": true
+          },
+          "costCredits": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Cost of producing this agent message, in AWU credits (intelligence + tool credits). Null when no billable usage is attributed to the message."
           },
           "activitySteps": {
             "type": "array",

--- a/front/scripts/investigate_render_conversation.ts
+++ b/front/scripts/investigate_render_conversation.ts
@@ -144,6 +144,7 @@ makeScript(
       completionDurationMs: null,
       richMentions: [],
       reactions: [],
+      costCredits: null,
     };
 
     const { serverToolsAndInstructions, error: mcpToolsListingError } =

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -351,9 +351,11 @@ async function processEventForUnreadState(
   {
     event,
     conversation,
+    costCredits,
   }: {
     event: AgentMessageEvents;
     conversation: ConversationWithoutContentType;
+    costCredits: number | null;
   }
 ) {
   // If the event is a done event, we want to mark the conversation as unread for all participants.
@@ -371,6 +373,7 @@ async function processEventForUnreadState(
           event.type === "agent_error" || event.type === "tool_error"
             ? "error"
             : "success",
+        costCredits,
       },
     });
   }
@@ -392,7 +395,9 @@ export async function updateResourceAndPublishEvent(
     modelInteractionDurationMs?: number;
   }
 ): Promise<void> {
-  // Process DB updates and unread state for all events.
+  // Process DB updates and unread state for all events. costCredits is threaded through
+  // to the agent_message_done event for the live client, but the value is computed in a
+  // later change; it is null here until the credit-cost computation lands.
   await Promise.all([
     processEventForDatabase(auth, {
       event,
@@ -401,7 +406,11 @@ export async function updateResourceAndPublishEvent(
       conversation,
       modelInteractionDurationMs,
     }),
-    processEventForUnreadState(auth, { event, conversation }),
+    processEventForUnreadState(auth, {
+      event,
+      conversation,
+      costCredits: null,
+    }),
   ]);
 
   // All events go through the coalescer, which handles batching logic internally.
@@ -521,6 +530,7 @@ export async function notifyWorkflowError(
     ),
     richMentions: [],
     reactions: [],
+    costCredits: null,
 
     // HACKY: These last 3 fields are not used in the workflow error case but required in the type.
     configuration: null as unknown as LightAgentConfigurationType,

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -351,11 +351,9 @@ async function processEventForUnreadState(
   {
     event,
     conversation,
-    costCredits,
   }: {
     event: AgentMessageEvents;
     conversation: ConversationWithoutContentType;
-    costCredits: number | null;
   }
 ) {
   // If the event is a done event, we want to mark the conversation as unread for all participants.
@@ -373,7 +371,7 @@ async function processEventForUnreadState(
           event.type === "agent_error" || event.type === "tool_error"
             ? "error"
             : "success",
-        costCredits,
+        costCredits: null,
       },
     });
   }
@@ -409,7 +407,6 @@ export async function updateResourceAndPublishEvent(
     processEventForUnreadState(auth, {
       event,
       conversation,
-      costCredits: null,
     }),
   ]);
 

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -385,6 +385,7 @@ export class ConversationFactory {
       rank: messageRow.rank,
       branchId: messageRow.getBranchId(),
       richMentions: [],
+      costCredits: null,
     };
 
     if (!mcpAction) {

--- a/front/tests/utils/conversation_test_factories.ts
+++ b/front/tests/utils/conversation_test_factories.ts
@@ -114,6 +114,7 @@ export function mockAgentMessage(
     richMentions: [],
     completionDurationMs: null,
     reactions: [],
+    costCredits: null,
     configuration: {
       sId: "",
       name: params.agentName ?? "Agent",

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -299,7 +299,12 @@ export type AgentMessageDoneEvent = {
   configurationId: string;
   messageId: string;
   status: "success" | "error";
-  costCredits: number | null;
+  // Optional during rollout: this event is published to pub/sub and replayed to
+  // browsers that may run a different deploy than the worker emitting it, so an
+  // old worker (or a replayed pre-deploy event) can omit the field entirely
+  // (`undefined`, not `null`). Tighten to `number | null` once the whole credit-cost
+  // stack is deployed and the replay buffer TTL has cycled. See [BACK12].
+  costCredits?: number | null;
 };
 
 // Event sent when an error occurred during the tool call.

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -299,6 +299,7 @@ export type AgentMessageDoneEvent = {
   configurationId: string;
   messageId: string;
   status: "success" | "error";
+  costCredits: number | null;
 };
 
 // Event sent when an error occurred during the tool call.

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -302,7 +302,11 @@ export type BaseAgentMessageType = {
   completionDurationMs: number | null;
   reactions: MessageReactionType[];
   prunedContext?: boolean;
-  costCredits: number | null;
+  // Optional during rollout: serialized from the API, so an old API server can
+  // return agent messages without this field (`undefined`) to a newer client
+  // during the credit-cost stack rollout. Tighten to `number | null` once the API
+  // change is fully deployed. See [BACK12].
+  costCredits?: number | null;
 };
 
 export type InlineActivityStep =

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -302,6 +302,7 @@ export type BaseAgentMessageType = {
   completionDurationMs: number | null;
   reactions: MessageReactionType[];
   prunedContext?: boolean;
+  costCredits: number | null;
 };
 
 export type InlineActivityStep =


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Adds costCredits to BaseAgentMessageType, plus the
null-fills at every construction site (renderers, poke render handlers,
placeholder/light message builders, test factories) and the swagger schema.
common.ts threads costCredits through the agent_message_done event as null; the
actual computation lands in a later change.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
