### PR TITLE
feat(assistant): compute and persist per-message credit cost

### DIFF
--- a/front/lib/api/assistant/credit_cost.test.ts
+++ b/front/lib/api/assistant/credit_cost.test.ts
@@ -1,0 +1,128 @@
+import { computeAgentMessageCredits } from "@app/lib/api/assistant/credit_cost";
+import {
+  awuFromMicroUsd,
+  intelligenceAwuFromRunUsages,
+  toolAwuFromActions,
+} from "@app/lib/metronome/events";
+import type { RunUsageType } from "@app/lib/resources/run_resource";
+import { describe, expect, it } from "vitest";
+
+function usage(overrides: Partial<RunUsageType>): RunUsageType {
+  return {
+    completionTokens: 0,
+    promptTokens: 0,
+    cachedTokens: 0,
+    cacheCreationTokens: 0,
+    costMicroUsd: 0,
+    modelId: "gpt-4o",
+    providerId: "openai",
+    isBatch: false,
+    ...overrides,
+  };
+}
+
+describe("awuFromMicroUsd", () => {
+  it("converts at 1 credit = $0.0085 (8500 microUSD), rounding up", () => {
+    // 8500 microUSD = exactly 1 credit.
+    expect(awuFromMicroUsd(8500)).toBe(1);
+    // Any non-zero cost rounds up to at least 1 credit.
+    expect(awuFromMicroUsd(1)).toBe(1);
+    // 17000 microUSD = 2 credits.
+    expect(awuFromMicroUsd(17000)).toBe(2);
+    // 0 cost = 0 credits.
+    expect(awuFromMicroUsd(0)).toBe(0);
+  });
+});
+
+describe("intelligenceAwuFromRunUsages", () => {
+  it("groups by model and ceils per group before summing", () => {
+    const sameModel = intelligenceAwuFromRunUsages([
+      usage({ costMicroUsd: 5000, modelId: "gpt-4o", providerId: "openai" }),
+      usage({ costMicroUsd: 5000, modelId: "gpt-4o", providerId: "openai" }),
+    ]);
+    expect(sameModel).toBe(2);
+
+    const twoModels = intelligenceAwuFromRunUsages([
+      usage({ costMicroUsd: 5000, modelId: "gpt-4o", providerId: "openai" }),
+      usage({
+        costMicroUsd: 5000,
+        modelId: "claude-opus-4-8",
+        providerId: "anthropic",
+      }),
+    ]);
+    // ceil(5000/8500)=1 per model -> 2.
+    expect(twoModels).toBe(2);
+  });
+
+  it("returns 0 for no usages", () => {
+    expect(intelligenceAwuFromRunUsages([])).toBe(0);
+  });
+});
+
+describe("toolAwuFromActions", () => {
+  it("charges 1 credit for basic and 3 for advanced tools", () => {
+    expect(
+      toolAwuFromActions([
+        { internalMCPServerName: "web_search_&_browse" }, // basic = 1
+        { internalMCPServerName: "search" }, // advanced = 3
+      ])
+    ).toBe(4);
+  });
+
+  it("treats unknown / external servers as advanced (3)", () => {
+    expect(toolAwuFromActions([{ internalMCPServerName: null }])).toBe(3);
+  });
+
+  it("does not charge for free tools (priced at 0 in the rate card)", () => {
+    // agent_memory is in FREE_TOOL_SERVERS — billed free, so contributes 0.
+    expect(
+      toolAwuFromActions([{ internalMCPServerName: "agent_memory" }])
+    ).toBe(0);
+    expect(
+      toolAwuFromActions([{ internalMCPServerName: "agent_memory" }])
+    ).toBe(0);
+  });
+});
+
+describe("computeAgentMessageCredits", () => {
+  it("sums intelligence and tool credits", () => {
+    const credits = computeAgentMessageCredits({
+      runUsages: [usage({ costMicroUsd: 8500 })], // 1 intelligence credit
+      actions: [{ internalMCPServerName: "search", status: "succeeded" }], // 3 tool credits
+    });
+    expect(credits).toBe(4);
+  });
+
+  it("ignores non-final actions", () => {
+    const credits = computeAgentMessageCredits({
+      runUsages: [],
+      actions: [{ internalMCPServerName: "search", status: "running" }],
+    });
+    expect(credits).toBeNull();
+  });
+
+  it("returns null when there is no billable usage", () => {
+    expect(
+      computeAgentMessageCredits({ runUsages: [], actions: [] })
+    ).toBeNull();
+  });
+
+  it("costs 0 for free-origin usage (e.g. agent_sidekick), LLM and tools alike", () => {
+    const credits = computeAgentMessageCredits({
+      runUsages: [usage({ costMicroUsd: 8500 })], // would be 1 intelligence credit
+      actions: [{ internalMCPServerName: "search", status: "succeeded" }], // would be 3 tool credits
+      isFreeUsage: true,
+    });
+    expect(credits).toBe(0);
+  });
+
+  it("still returns null for free-origin usage when there is nothing to track", () => {
+    expect(
+      computeAgentMessageCredits({
+        runUsages: [],
+        actions: [],
+        isFreeUsage: true,
+      })
+    ).toBeNull();
+  });
+});

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -27,16 +27,16 @@ export function computeAgentMessageCredits({
   actions: CreditActionMinimalInput[];
   isFreeUsage?: boolean;
 }): number | null {
+  if (isFreeUsage) {
+    return 0;
+  }
+
   const finalActions = actions.filter((a) =>
     isToolExecutionStatusFinal(a.status)
   );
 
   if (runUsages.length === 0 && finalActions.length === 0) {
     return null;
-  }
-
-  if (isFreeUsage) {
-    return 0;
   }
 
   return (

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -1,0 +1,118 @@
+import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
+import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  intelligenceAwuFromRunUsages,
+  isFreeOrigin,
+  toolAwuFromActions,
+} from "@app/lib/metronome/events";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { RunUsageType } from "@app/lib/resources/run_resource";
+import { RunResource } from "@app/lib/resources/run_resource";
+import logger from "@app/logger/logger";
+import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
+
+interface CreditActionMinimalInput {
+  internalMCPServerName: string | null;
+  status: ToolExecutionStatus;
+}
+
+export function computeAgentMessageCredits({
+  runUsages,
+  actions,
+  isFreeUsage = false,
+}: {
+  runUsages: RunUsageType[];
+  actions: CreditActionMinimalInput[];
+  isFreeUsage?: boolean;
+}): number | null {
+  const finalActions = actions.filter((a) =>
+    isToolExecutionStatusFinal(a.status)
+  );
+
+  if (runUsages.length === 0 && finalActions.length === 0) {
+    return null;
+  }
+
+  if (isFreeUsage) {
+    return 0;
+  }
+
+  return (
+    intelligenceAwuFromRunUsages(runUsages) + toolAwuFromActions(finalActions)
+  );
+}
+
+/**
+ * Compute the agent message credit cost once at the end of the agentic loop and persist it on the
+ * agent message. Returns the computed value (or null when there is nothing to track) so callers
+ * can attach it to the terminal `agent_message_done` event and update the live client without a
+ * reload.
+ *
+ * Computes from the message's full accumulated runIds + all final-status actions (the message-level
+ * total), so re-runs (interrupt/resume) overwrite the stored value with the complete cost. Only
+ * persists for statuses we track for billing, matching the Metronome gate.
+ */
+export async function computeAndStoreAgentMessageCredits(
+  auth: Authenticator,
+  { agentMessageId }: { agentMessageId: string }
+): Promise<number | null> {
+  const creditContext =
+    await ConversationResource.fetchAgentMessageCreditContext(auth, {
+      agentMessageId,
+    });
+
+  if (!creditContext) {
+    logger.warn(
+      { workspaceId: auth.getNonNullableWorkspace().sId, agentMessageId },
+      "[Credits] Agent message not found while computing costCredits."
+    );
+    return null;
+  }
+
+  const { agentMessageModelId, status, runIds, triggeringUserMessageOrigin } =
+    creditContext;
+
+  if (!AGENT_MESSAGE_STATUSES_TO_TRACK.includes(status)) {
+    return null;
+  }
+
+  const [runUsages, actions] = await Promise.all([
+    fetchRunUsagesForAgentMessage(auth, runIds),
+    AgentMCPActionResource.listByAgentMessageIds(auth, [agentMessageModelId]),
+  ]);
+
+  const costCredits = computeAgentMessageCredits({
+    runUsages,
+    actions: actions.map((action) => ({
+      internalMCPServerName: action.metadata.internalMCPServerName,
+      status: action.status,
+    })),
+    isFreeUsage:
+      triggeringUserMessageOrigin !== null &&
+      isFreeOrigin(triggeringUserMessageOrigin),
+  });
+
+  await ConversationResource.updateAgentMessageCostCredits(auth, {
+    agentMessageModelId,
+    costCredits,
+  });
+
+  return costCredits;
+}
+
+async function fetchRunUsagesForAgentMessage(
+  auth: Authenticator,
+  runIds: string[] | null
+): Promise<RunUsageType[]> {
+  const dustRunIds = [...new Set(runIds ?? [])];
+  if (dustRunIds.length === 0) {
+    return [];
+  }
+
+  // All runs are fetched from this message's own runIds, so every usage they
+  // produce belongs to this message.
+  const runs = await RunResource.listByDustRunIds(auth, { dustRunIds });
+  return RunResource.listRunUsagesForRuns(auth, { runs });
+}

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -27,16 +27,16 @@ export function computeAgentMessageCredits({
   actions: CreditActionMinimalInput[];
   isFreeUsage?: boolean;
 }): number | null {
-  if (isFreeUsage) {
-    return 0;
-  }
-
   const finalActions = actions.filter((a) =>
     isToolExecutionStatusFinal(a.status)
   );
 
   if (runUsages.length === 0 && finalActions.length === 0) {
     return null;
+  }
+
+  if (isFreeUsage) {
+    return 0;
   }
 
   return (

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -46,9 +46,12 @@ export function computeAgentMessageCredits({
 
 /**
  * Compute the agent message credit cost once at the end of the agentic loop and persist it on the
- * agent message. Returns the computed value (or null when there is nothing to track) so callers
- * can attach it to the terminal `agent_message_done` event and update the live client without a
- * reload.
+ * agent message. Returns the computed value (or null when there is nothing to track).
+ *
+ * Called from the finalize activities (alongside the Metronome usage events it is derived from),
+ * not from the hot terminal-event path, so publishing the terminal events stays lightweight. The
+ * value is not pushed on any event — clients read it from the messages / conversation API on their
+ * next revalidation.
  *
  * Computes from the message's full accumulated runIds + all final-status actions (the message-level
  * total), so re-runs (interrupt/resume) overwrite the stored value with the complete cost. Only

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -844,9 +844,6 @@ async function renderSingleAgentMessage(
 
   const created = message.createdAt.getTime();
   const completedTs = agentMessage.completedAt?.getTime() ?? null;
-  // costCredits is computed once at the end of the agentic loop and persisted on the agent message
-  // (see computeAndStoreAgentMessageCredits). Older messages predating this have a null value.
-  const costCredits = agentMessage.costCredits ?? null;
   const renderedMessage = {
     id: message.id,
     agentMessageId: agentMessage.id,
@@ -873,7 +870,7 @@ async function renderSingleAgentMessage(
     completionDurationMs: getCompletionDuration(created, completedTs, actions),
     reactions: reactionsByMessageId[message.id] ?? [],
     prunedContext: agentMessage.prunedContext ?? false,
-    costCredits,
+    costCredits: agentMessage.costCredits ?? null,
   } satisfies AgentMessageType;
 
   if (viewType === "full") {

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -180,24 +180,94 @@ const FREE_TOOL_SERVERS: ReadonlySet<string> = new Set<string>([
   "agent_memory",
 ]);
 
+export function isFreeOrigin(origin: string): boolean {
+  return FREE_ORIGINS.has(origin);
+}
+
 export function getUsageType(
   isProgrammaticUsage: boolean,
   origin: string
 ): UsageType {
-  if (FREE_ORIGINS.has(origin)) {
+  if (isFreeOrigin(origin)) {
     return USAGE_TYPE_FREE;
   }
   return isProgrammaticUsage ? USAGE_TYPE_PROGRAMMATIC : USAGE_TYPE_USER;
+}
+
+// A tool invocation is always free (priced at 0 in the rate card) when its
+// internal MCP server is platform plumbing — see FREE_TOOL_SERVERS.
+export function isFreeToolServer(
+  internalMCPServerName: string | null
+): boolean {
+  return (
+    internalMCPServerName !== null &&
+    FREE_TOOL_SERVERS.has(internalMCPServerName)
+  );
 }
 
 function getToolUsageType(
   baseUsageType: UsageType,
   internalMCPServerName: string | null
 ): UsageType {
-  if (internalMCPServerName && FREE_TOOL_SERVERS.has(internalMCPServerName)) {
+  if (isFreeToolServer(internalMCPServerName)) {
     return USAGE_TYPE_FREE;
   }
   return baseUsageType;
+}
+
+// ---------------------------------------------------------------------------
+// AWU credit conversion helpers
+// ---------------------------------------------------------------------------
+// These are the single source of truth for converting raw usage into AWU
+// credits. They are used both when emitting Metronome billing events (below)
+// and when surfacing the cost of a message/conversation to the frontend, so
+// the displayed credits always match what is billed.
+
+// Convert a raw model-compute cost in microUSD into AWU credits.
+// 1 AWU credit = $0.0085 of compute (margin baked in), so 1 credit = 8500
+// microUSD. Rounded up, matching the Metronome event conversion.
+export function awuFromMicroUsd(microUsd: number): number {
+  return Math.ceil(microUsd / 0.85 / 10_000);
+}
+
+// Intelligence (AI compute) credits for a set of run usages. Usages are
+// grouped by (providerId, modelId) and converted per group before summing —
+// this mirrors `buildLlmUsageEvents` so the total equals the billed amount.
+export function intelligenceAwuFromRunUsages(
+  runUsages: RunUsageType[]
+): number {
+  const costByModel = new Map<string, number>();
+  for (const usage of runUsages) {
+    // Need this grouping to rightfully apply the Math.ceil in awuFromMicroUsd
+    const key = `${usage.providerId}|${usage.modelId}`;
+    costByModel.set(key, (costByModel.get(key) ?? 0) + usage.costMicroUsd);
+  }
+
+  let total = 0;
+  for (const costMicroUsd of costByModel.values()) {
+    total += awuFromMicroUsd(costMicroUsd);
+  }
+  return total;
+}
+
+// Tool (platform action) credits for a set of executed actions. Each action
+// costs a fixed number of credits depending on its category (basic = 1,
+// advanced = 3), except free tools (FREE_TOOL_SERVERS, e.g. agent_memory) which
+// are priced at 0 in the rate card and therefore contribute nothing. Callers
+// should pass only final-status actions (matching the usage_queue extraction)
+// so this equals the billed amount.
+export function toolAwuFromActions(
+  actions: { internalMCPServerName: string | null }[]
+): number {
+  return actions.reduce((total, action) => {
+    if (isFreeToolServer(action.internalMCPServerName)) {
+      return total;
+    }
+    return (
+      total +
+      TOOL_CATEGORY_AWU_WEIGHTS[getToolCategory(action.internalMCPServerName)]
+    );
+  }, 0);
 }
 
 // ---------------------------------------------------------------------------
@@ -305,7 +375,7 @@ export function buildLlmUsageEvents({
       // Provider cost without markup — markup is applied in Metronome rate card. Only used for legacy rates.
       cost_micro_usd: group.costMicroUsd,
       // 1 AWU credit = $0.0085
-      cost_awu: Math.ceil(group.costMicroUsd / 0.85 / 10_000),
+      cost_awu: awuFromMicroUsd(group.costMicroUsd),
       // TODO: Remove is_programmatic_usage & is_free_usage, this is replaced by single property "usage type"
       is_programmatic_usage:
         usageType === USAGE_TYPE_PROGRAMMATIC ? "true" : "false",

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -40,6 +40,7 @@ import logger from "@app/logger/logger";
 import { launchIndexConversationEsWorkflow } from "@app/temporal/es_indexation/client";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type {
+  AgentMessageStatus,
   ConversationForkedChildType,
   ConversationForkedFromType,
   ConversationForkingDataType,
@@ -50,6 +51,7 @@ import type {
   ConversationVisibility,
   ConversationWithoutContentType,
   ParticipantActionType,
+  UserMessageOrigin,
 } from "@app/types/assistant/conversation";
 import {
   ConversationError,
@@ -663,6 +665,74 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       result.set(row.conversationId, parseInt(row.get("count") as string, 10));
     }
     return result;
+  }
+
+  /**
+   * Fetches everything needed to compute an agent message's credit cost: the
+   * agent message model id (used to look up its runs and actions), its tracking
+   * status, its runIds, and the origin of the user message that triggered it
+   * (used to detect free-origin usage). Returns null when the agent message
+   * cannot be found.
+   */
+  static async fetchAgentMessageCreditContext(
+    auth: Authenticator,
+    { agentMessageId }: { agentMessageId: string }
+  ): Promise<{
+    agentMessageModelId: ModelId;
+    status: AgentMessageStatus;
+    runIds: string[] | null;
+    triggeringUserMessageOrigin: UserMessageOrigin | null;
+  } | null> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    const messageRow = await MessageModel.findOne({
+      where: { sId: agentMessageId, workspaceId },
+      include: [
+        { model: AgentMessageModel, as: "agentMessage", required: true },
+      ],
+    });
+
+    const agentMessage = messageRow?.agentMessage;
+    if (!agentMessage) {
+      return null;
+    }
+
+    let triggeringUserMessageOrigin: UserMessageOrigin | null = null;
+    if (messageRow.parentId !== null) {
+      const parentRow = await MessageModel.findOne({
+        where: { id: messageRow.parentId, workspaceId },
+        include: [
+          { model: UserMessageModel, as: "userMessage", required: false },
+        ],
+      });
+      triggeringUserMessageOrigin =
+        parentRow?.userMessage?.userContextOrigin ?? null;
+    }
+
+    return {
+      agentMessageModelId: agentMessage.id,
+      status: agentMessage.status,
+      runIds: agentMessage.runIds,
+      triggeringUserMessageOrigin,
+    };
+  }
+
+  static async updateAgentMessageCostCredits(
+    auth: Authenticator,
+    {
+      agentMessageModelId,
+      costCredits,
+    }: { agentMessageModelId: ModelId; costCredits: number | null }
+  ): Promise<void> {
+    await AgentMessageModel.update(
+      { costCredits },
+      {
+        where: {
+          id: agentMessageModelId,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+      }
+    );
   }
 
   private static getOptions(

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -351,11 +351,9 @@ async function processEventForUnreadState(
   {
     event,
     conversation,
-    costCredits,
   }: {
     event: AgentMessageEvents;
     conversation: ConversationWithoutContentType;
-    costCredits: number | null;
   }
 ) {
   // If the event is a done event, we want to mark the conversation as unread for all participants.

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -1,5 +1,4 @@
 import { updateAgentMessageWithFinalStatus } from "@app/lib/api/assistant/conversation";
-import { computeAndStoreAgentMessageCredits } from "@app/lib/api/assistant/credit_cost";
 import { getCompletionDuration } from "@app/lib/api/assistant/messages";
 import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streaming/events";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
@@ -338,12 +337,14 @@ export async function processEventForDatabase(
       break;
   }
 
-  if (TERMINAL_AGENT_MESSAGE_EVENT_TYPES.includes(event.type)) {
-    await ConversationResource.setIsRunningAgentLoop(auth, {
-      conversation,
-      isRunningAgentLoop: false,
-    });
+  if (!TERMINAL_AGENT_MESSAGE_EVENT_TYPES.includes(event.type)) {
+    return;
   }
+
+  await ConversationResource.setIsRunningAgentLoop(auth, {
+    conversation,
+    isRunningAgentLoop: false,
+  });
 }
 
 // Process unread state for agent events before publishing to Redis.
@@ -352,11 +353,9 @@ async function processEventForUnreadState(
   {
     event,
     conversation,
-    costCredits,
   }: {
     event: AgentMessageEvents;
     conversation: ConversationWithoutContentType;
-    costCredits: number | null;
   }
 ) {
   // If the event is a done event, we want to mark the conversation as unread for all participants.
@@ -374,7 +373,6 @@ async function processEventForUnreadState(
           event.type === "agent_error" || event.type === "tool_error"
             ? "error"
             : "success",
-        costCredits,
       },
     });
   }
@@ -396,16 +394,10 @@ export async function updateResourceAndPublishEvent(
     modelInteractionDurationMs?: number;
   }
 ): Promise<void> {
-  // Persist the DB updates, then (for terminal events) compute the credit cost, then
-  // process the unread state. The order matters: the cost computation is gated on the
-  // committed terminal status, so the DB write must land first; the resulting cost then
-  // rides on the agent_message_done event published by processEventForUnreadState,
-  // updating the live client without a reload. processEventForUnreadState is a no-op for
-  // non-terminal events, so this single sequential flow covers both cases.
-  //
-  // computeAndStoreAgentMessageCredits is the computation site for the paths that flow
-  // through here (success, gracefully_stopped, cancelled); the interrupted path computes
-  // it in finalize.
+  // Persist the DB updates first, then publish the terminal done event. The credit cost is
+  // computed and persisted later, in the finalize activities (see finalize.ts), so it is
+  // intentionally not carried on the terminal events here — clients read it from the messages /
+  // conversation API on their next revalidation.
   await processEventForDatabase(auth, {
     event,
     agentMessage,
@@ -414,16 +406,9 @@ export async function updateResourceAndPublishEvent(
     modelInteractionDurationMs,
   });
 
-  const costCredits = TERMINAL_AGENT_MESSAGE_EVENT_TYPES.includes(event.type)
-    ? await computeAndStoreAgentMessageCredits(auth, {
-        agentMessageId: event.messageId,
-      })
-    : null;
-
   await processEventForUnreadState(auth, {
     event,
     conversation,
-    costCredits,
   });
 
   // All events go through the coalescer, which handles batching logic internally.

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -1,4 +1,5 @@
 import { updateAgentMessageWithFinalStatus } from "@app/lib/api/assistant/conversation";
+import { computeAndStoreAgentMessageCredits } from "@app/lib/api/assistant/credit_cost";
 import { getCompletionDuration } from "@app/lib/api/assistant/messages";
 import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streaming/events";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
@@ -351,9 +352,11 @@ async function processEventForUnreadState(
   {
     event,
     conversation,
+    costCredits,
   }: {
     event: AgentMessageEvents;
     conversation: ConversationWithoutContentType;
+    costCredits: number | null;
   }
 ) {
   // If the event is a done event, we want to mark the conversation as unread for all participants.
@@ -371,7 +374,7 @@ async function processEventForUnreadState(
           event.type === "agent_error" || event.type === "tool_error"
             ? "error"
             : "success",
-        costCredits: null,
+        costCredits,
       },
     });
   }
@@ -393,22 +396,35 @@ export async function updateResourceAndPublishEvent(
     modelInteractionDurationMs?: number;
   }
 ): Promise<void> {
-  // Process DB updates and unread state for all events. costCredits is threaded through
-  // to the agent_message_done event for the live client, but the value is computed in a
-  // later change; it is null here until the credit-cost computation lands.
-  await Promise.all([
-    processEventForDatabase(auth, {
-      event,
-      agentMessage,
-      step,
-      conversation,
-      modelInteractionDurationMs,
-    }),
-    processEventForUnreadState(auth, {
-      event,
-      conversation,
-    }),
-  ]);
+  // Persist the DB updates, then (for terminal events) compute the credit cost, then
+  // process the unread state. The order matters: the cost computation is gated on the
+  // committed terminal status, so the DB write must land first; the resulting cost then
+  // rides on the agent_message_done event published by processEventForUnreadState,
+  // updating the live client without a reload. processEventForUnreadState is a no-op for
+  // non-terminal events, so this single sequential flow covers both cases.
+  //
+  // computeAndStoreAgentMessageCredits is the computation site for the paths that flow
+  // through here (success, gracefully_stopped, cancelled); the interrupted path computes
+  // it in finalize.
+  await processEventForDatabase(auth, {
+    event,
+    agentMessage,
+    step,
+    conversation,
+    modelInteractionDurationMs,
+  });
+
+  const costCredits = TERMINAL_AGENT_MESSAGE_EVENT_TYPES.includes(event.type)
+    ? await computeAndStoreAgentMessageCredits(auth, {
+        agentMessageId: event.messageId,
+      })
+    : null;
+
+  await processEventForUnreadState(auth, {
+    event,
+    conversation,
+    costCredits,
+  });
 
   // All events go through the coalescer, which handles batching logic internally.
   const key = `${conversation.sId}-${event.messageId}-${step}`;

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -351,9 +351,11 @@ async function processEventForUnreadState(
   {
     event,
     conversation,
+    costCredits,
   }: {
     event: AgentMessageEvents;
     conversation: ConversationWithoutContentType;
+    costCredits: number | null;
   }
 ) {
   // If the event is a done event, we want to mark the conversation as unread for all participants.

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -31,6 +31,9 @@ export async function finalizeSuccessfulAgentLoopActivity(
     launchAgentMessageAnalytics(auth, agentLoopArgs),
     launchTrackProgrammaticUsage(auth, agentLoopArgs),
     launchEmitMetronomeUsageEvents(auth, agentLoopArgs),
+    computeAndStoreAgentMessageCredits(auth, {
+      agentMessageId: agentLoopArgs.agentMessageId,
+    }),
     conversationUnreadNotification(auth, agentLoopArgs),
     handleMentions(auth, agentLoopArgs),
     sendEmailReplyOnCompletion(auth, agentLoopArgs),
@@ -56,6 +59,9 @@ export async function finalizeGracefullyStoppedAgentLoopActivity(
     launchAgentMessageAnalytics(auth, agentLoopArgs),
     launchTrackProgrammaticUsage(auth, agentLoopArgs),
     launchEmitMetronomeUsageEvents(auth, agentLoopArgs),
+    computeAndStoreAgentMessageCredits(auth, {
+      agentMessageId: agentLoopArgs.agentMessageId,
+    }),
     conversationUnreadNotification(auth, agentLoopArgs),
     handleMentions(auth, agentLoopArgs),
   ]);
@@ -103,6 +109,9 @@ export async function finalizeCancelledAgentLoopActivity(
     launchAgentMessageAnalytics(auth, agentLoopArgs),
     launchTrackProgrammaticUsage(auth, agentLoopArgs),
     launchEmitMetronomeUsageEvents(auth, agentLoopArgs),
+    computeAndStoreAgentMessageCredits(auth, {
+      agentMessageId: agentLoopArgs.agentMessageId,
+    }),
     sendEmailReplyOnError(
       auth,
       agentLoopArgs,
@@ -125,6 +134,9 @@ export async function finalizeErroredAgentLoopActivity(
     launchAgentMessageAnalytics(auth, agentLoopArgs),
     launchTrackProgrammaticUsage(auth, agentLoopArgs),
     launchEmitMetronomeUsageEvents(auth, agentLoopArgs),
+    computeAndStoreAgentMessageCredits(auth, {
+      agentMessageId: agentLoopArgs.agentMessageId,
+    }),
     sendEmailReplyOnError(
       auth,
       agentLoopArgs,

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -1,3 +1,4 @@
+import { computeAndStoreAgentMessageCredits } from "@app/lib/api/assistant/credit_cost";
 import {
   sendEmailReplyOnCompletion,
   sendEmailReplyOnError,
@@ -55,7 +56,6 @@ export async function finalizeGracefullyStoppedAgentLoopActivity(
     launchAgentMessageAnalytics(auth, agentLoopArgs),
     launchTrackProgrammaticUsage(auth, agentLoopArgs),
     launchEmitMetronomeUsageEvents(auth, agentLoopArgs),
-
     conversationUnreadNotification(auth, agentLoopArgs),
     handleMentions(auth, agentLoopArgs),
   ]);
@@ -82,6 +82,9 @@ export async function finalizeInterruptedAgentLoopActivity(
     launchAgentMessageAnalytics(auth, agentLoopArgs),
     launchTrackProgrammaticUsage(auth, agentLoopArgs),
     launchEmitMetronomeUsageEvents(auth, agentLoopArgs),
+    computeAndStoreAgentMessageCredits(auth, {
+      agentMessageId: agentLoopArgs.agentMessageId,
+    }),
     conversationUnreadNotification(auth, agentLoopArgs),
     handleMentions(auth, agentLoopArgs),
   ]);

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -299,12 +299,6 @@ export type AgentMessageDoneEvent = {
   configurationId: string;
   messageId: string;
   status: "success" | "error";
-  // Optional during rollout: this event is published to pub/sub and replayed to
-  // browsers that may run a different deploy than the worker emitting it, so an
-  // old worker (or a replayed pre-deploy event) can omit the field entirely
-  // (`undefined`, not `null`). Tighten to `number | null` once the whole credit-cost
-  // stack is deployed and the replay buffer TTL has cycled. See [BACK12].
-  costCredits?: number | null;
 };
 
 // Event sent when an error occurred during the tool call.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Adds credit_cost.ts (computeAgentMessageCredits + computeAndStoreAgentMessageCredits),
the metronome AWU conversion helpers (single source of truth shared with billing),
the ConversationResource write methods (fetchAgentMessageCreditContext,
updateAgentMessageCostCredits), and wires the computation into the agent loop:
common.ts computes on terminal events and rides the value on agent_message_done,
finalize.ts covers the interrupted path.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
