### PR TITLE
[connectors] Give up on persistently-failing Notion upstream errors (502/504/530)

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -115,23 +115,32 @@ const wrapWithErrorCheck = async <T>(
   try {
     return await callback();
   } catch (e) {
-    if (APIResponseError.isAPIResponseError(e)) {
-      if (
-        (e.code === "internal_server_error" && e.status === 500) ||
-        (e.code === "service_unavailable" && e.status === 503)
-      ) {
-        if (Context.current().info.attempt > 20) {
-          logger.error(
-            {
-              ...loggerArgs,
-              error: e,
-              attempt: Context.current().info.attempt,
-            },
-            "Failed to get make notion call. Giving up and moving on"
-          );
-          return null;
-        }
-      }
+    const isRetriableApiError =
+      APIResponseError.isAPIResponseError(e) &&
+      ((e.code === "internal_server_error" && e.status === 500) ||
+        (e.code === "service_unavailable" && e.status === 503));
+    // Transient upstream 5xx (502/504/530) surface as UnknownHTTPResponseError rather than
+    // APIResponseError (see the Notion `cast_known_errors` interceptor). When a cursor or
+    // resource consistently fails with one of these, it never recovers on its own and would
+    // otherwise be retried forever. We give up after enough attempts and move on — Notion
+    // workspaces are resynced daily so nothing is lost forever.
+    const isTransientUpstreamError =
+      UnknownHTTPResponseError.isUnknownHTTPResponseError(e) &&
+      [502, 504, 530].includes(e.status);
+
+    if (
+      (isRetriableApiError || isTransientUpstreamError) &&
+      Context.current().info.attempt > 20
+    ) {
+      logger.error(
+        {
+          ...loggerArgs,
+          error: e,
+          attempt: Context.current().info.attempt,
+        },
+        "Failed to make notion call. Giving up and moving on"
+      );
+      return null;
     }
 
     throw e;


### PR DESCRIPTION
## Description

Notion gateway/upstream errors (\`502/504/530\`) surface as \`UnknownHTTPResponseError\` and get cast to \`ProviderTransientError\` by the \`cast_known_errors\` interceptor. The Notion worker sets no \`maximumAttempts\`, so an activity hitting a cursor/resource that *consistently* returns one of these retries **forever** (with a 2h backoff after attempt 19).

This was hit in production: a \`fetchDatabaseChildPages\` activity (workflow \`workflow-notion-18689-process-database-upsert-queue\`) looped for 24h+ on a persistent \`504\` on a single database cursor.

\`wrapWithErrorCheck\` already gave up — returns \`null\`, so the sync skips that cursor and moves on — after attempt 20 for \`APIResponseError\` \`500/503\`. The \`502/504/530\` statuses slipped through only because they are \`UnknownHTTPResponseError\`, not \`APIResponseError\`. This PR extends the existing give-up to cover them. The status list matches \`cast_known_errors.ts\`.

Both call sites (\`fetchDatabaseChildPages\`, \`notionUpsertDatabaseActivity\`) already handle a \`null\` return gracefully. Non-transient errors (auth, \`400\`/\`404\`, bugs) continue to throw as before, so they stay visible and alert via \`temporal_monitoring\`.

## Tests

Reasoning + typecheck only. No unit test added: \`wrapWithErrorCheck\` is module-private, the \`connectors\` vitest harness requires a test DB just to import the activities module, and there is no precedent for unit-testing Temporal activities in this workspace. The change broadens an already-trusted give-up branch and the status list is copied verbatim from \`cast_known_errors.ts\`. \`tsgo --noEmit\` passes.

## Risk

Low. Only behavior change: after 20 failed attempts on a \`502/504/530\`, the activity returns empty instead of retrying indefinitely. Notion workspaces resync daily, so the skipped cursor/database recovers on the next run. Single-function change, easy to roll back.

## Deploy Plan

Standard connectors deploy. No migration. Workflows already stuck pick up the new behavior on their next attempt after deploy (or can be unblocked manually, e.g. \`notion skip-database\`).