### PR TITLE
Update Adrien Simon website title

### DIFF
--- a/front/components/home/content/shared/team.ts
+++ b/front/components/home/content/shared/team.ts
@@ -156,7 +156,7 @@ export const PEOPLE: Record<string, TeamMember> = {
   },
   adrsimon: {
     name: "Adrien Simon",
-    title: "Software Engineer",
+    title: "Head of Mobile App",
     image: "https://avatars.githubusercontent.com/u/99071153",
     github: "https://github.com/adrsimon",
     linkedIn: "https://www.linkedin.com/in/adrsimon/",


### PR DESCRIPTION
## Description

Updates Adrien Simon's title on the website team data from `Software Engineer` to `Head of Mobile App`.

## Tests

Not run locally in the Computer. This is a content-only change and validation is delegated to PR CI checks.

## Risk

Low. The change only updates a displayed team member title in static website content. Rollback is straightforward by reverting this commit.

## Deploy Plan

Merge after review and CI validation. No special deploy steps required.
