### PR TITLE
feat: client side mcp server in wake up message

### DIFF
--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -21,7 +21,10 @@ import { getWebhookRequestPayloadFromGCS } from "@app/lib/triggers/webhook";
 import logger from "@app/logger/logger";
 import { makeTriggerScheduleId } from "@app/temporal/triggers/schedule_client";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
-import type { ConversationType } from "@app/types/assistant/conversation";
+import {
+  type ConversationType,
+  isUserMessageType,
+} from "@app/types/assistant/conversation";
 import type { TriggerType } from "@app/types/assistant/triggers";
 import type { WakeUpType } from "@app/types/assistant/wakeups";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
@@ -349,6 +352,27 @@ function buildWakeUpMessageContent(wakeUp: WakeUpType): string {
   return content;
 }
 
+function getWakeUpClientSideMCPServerIds(
+  conversation: ConversationType
+): string[] {
+  const previousUserMessageVersions = conversation.content.findLast(
+    (versions) => {
+      const message = versions.at(-1);
+      return (
+        !!message &&
+        isUserMessageType(message) &&
+        message.context.origin !== "wakeup"
+      );
+    }
+  );
+
+  const previousUserMessage = previousUserMessageVersions?.at(-1);
+
+  return previousUserMessage && isUserMessageType(previousUserMessage)
+    ? (previousUserMessage.context.clientSideMCPServerIds ?? [])
+    : [];
+}
+
 export async function runWakeUpActivity({
   workspaceId,
   wakeUpId,
@@ -408,6 +432,7 @@ export async function runWakeUpActivity({
   }
 
   const conversation = conversationRes.value;
+  const clientSideMCPServerIds = getWakeUpClientSideMCPServerIds(conversation);
 
   const postMessageResult = await postUserMessage(auth, {
     conversation,
@@ -420,6 +445,7 @@ export async function runWakeUpActivity({
       email: null,
       profilePictureUrl: null,
       origin: "wakeup",
+      clientSideMCPServerIds,
     },
     skipToolsValidation: false,
   });


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8150

This PR ensures client-side MCP servers (used by the Chrome extension) are preserved in wake-up messages.

When a wake-up is triggered, the system posts an automated follow-up message on behalf of the conversation. Previously, this message did not include the `clientSideMCPServerIds` from the original user message, causing the agent to run without access to the Chrome extension's local MCP tools.

- Adds `getWakeUpClientSideMCPServerIds` helper that finds the last non-wakeup user message in the conversation and extracts its `clientSideMCPServerIds`.
- Passes those IDs into `postUserMessage` when running the wake-up activity.

## Tests

Manually.

## Risks
Low.
<!-- Discuss potential risks and how they will be mitigated. -->

## Deploy Plan
Standard deployment.
<!-- Outline the deployment steps. -->

