### PR TITLE
fix(mobile): repair voice transcription by consolidating transport

### DIFF
--- a/x/adrsimon/mobile/Dust/Services/APIClient.swift
+++ b/x/adrsimon/mobile/Dust/Services/APIClient.swift
@@ -163,14 +163,14 @@ enum APIClient {
 
             var request = URLRequest(url: fullURL)
             request.httpMethod = "POST"
-            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+            request.setBearer(token)
             request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
             request.httpBody = body
             return try await execute(request, endpoint: urlString, decoder: decoder)
         }
     }
 
-    private static func buildMultipartBody(
+    static func buildMultipartBody(
         fileData: Data,
         fileName: String,
         mimeType: String,
@@ -198,7 +198,7 @@ enum APIClient {
     }
 
     /// Executes a closure with a valid access token, retrying once on 401 after refreshing.
-    private static func withAuthRetry<T>(
+    static func withAuthRetry<T>(
         tokenProvider: TokenProvider,
         _ operation: (String) async throws -> T
     ) async throws -> T {
@@ -218,7 +218,7 @@ enum APIClient {
         var request = URLRequest(url: url)
         request.timeoutInterval = 30
         if let accessToken {
-            request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+            request.setBearer(accessToken)
         }
         return request
     }
@@ -260,5 +260,11 @@ enum APIClient {
             logger.error("Decode error: \(error)")
             throw APIError.decodingError(error)
         }
+    }
+}
+
+extension URLRequest {
+    mutating func setBearer(_ token: String) {
+        setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
     }
 }

--- a/x/adrsimon/mobile/Dust/Services/SpeechService.swift
+++ b/x/adrsimon/mobile/Dust/Services/SpeechService.swift
@@ -99,6 +99,7 @@ final class SpeechService {
             transcribedText = try await TranscriptionService.transcribe(
                 fileURL: recordingURL,
                 workspaceId: workspaceId,
+                mimeType: "audio/wav",
                 tokenProvider: tokenProvider
             )
         } catch {

--- a/x/adrsimon/mobile/Dust/Services/StreamingService.swift
+++ b/x/adrsimon/mobile/Dust/Services/StreamingService.swift
@@ -22,7 +22,7 @@ final private class AuthPreservingDelegate: NSObject, URLSessionTaskDelegate {
         completionHandler: @escaping (URLRequest?) -> Void
     ) {
         var redirected = request
-        redirected.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        redirected.setBearer(accessToken)
         completionHandler(redirected)
     }
 }
@@ -69,26 +69,13 @@ enum StreamingService {
         }
     }
 
-    /// Connects with token refresh on 401, invalidating the failed session before retry.
     private static func connectWithRetry(
         endpoint: String,
         tokenProvider: TokenProvider,
         lastEventId: String?
     ) async throws -> (URLSession.AsyncBytes, URLSession) {
-        let token = try await tokenProvider.validAccessToken()
-        do {
-            return try await connect(
-                endpoint: endpoint,
-                accessToken: token,
-                lastEventId: lastEventId
-            )
-        } catch APIError.httpError(statusCode: 401, _) {
-            let freshToken = try await tokenProvider.refreshedAccessToken()
-            return try await connect(
-                endpoint: endpoint,
-                accessToken: freshToken,
-                lastEventId: lastEventId
-            )
+        try await APIClient.withAuthRetry(tokenProvider: tokenProvider) { token in
+            try await connect(endpoint: endpoint, accessToken: token, lastEventId: lastEventId)
         }
     }
 
@@ -147,7 +134,7 @@ enum StreamingService {
         }
 
         var request = URLRequest(url: url)
-        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setBearer(accessToken)
         request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
         return request
     }

--- a/x/adrsimon/mobile/Dust/Services/TranscriptionService.swift
+++ b/x/adrsimon/mobile/Dust/Services/TranscriptionService.swift
@@ -25,66 +25,38 @@ enum TranscriptionService {
     static func transcribe(
         fileURL: URL,
         workspaceId: String,
+        mimeType: String,
         tokenProvider: TokenProvider
-    ) async throws -> String {
-        let token = try await tokenProvider.validAccessToken()
-        do {
-            return try await performTranscription(fileURL: fileURL, workspaceId: workspaceId, accessToken: token)
-        } catch let error as APIError where error.is401 {
-            let freshToken = try await tokenProvider.refreshedAccessToken()
-            return try await performTranscription(fileURL: fileURL, workspaceId: workspaceId, accessToken: freshToken)
-        }
-    }
-
-    private static func performTranscription(
-        fileURL: URL,
-        workspaceId: String,
-        accessToken: String
     ) async throws -> String {
         let endpoint = AppConfig.Endpoints.transcribe(workspaceId: workspaceId)
         guard let url = URL(string: "\(AppConfig.apiBaseURL)\(endpoint)") else {
             throw APIError.invalidURL
         }
-
         let fileData = try Data(contentsOf: fileURL)
-        let boundary = UUID().uuidString
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
-        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
-        request.httpBody = buildMultipartBody(
+        let boundary = "Boundary-\(UUID().uuidString)"
+        let body = APIClient.buildMultipartBody(
             fileData: fileData,
             fileName: fileURL.lastPathComponent,
+            mimeType: mimeType,
             boundary: boundary
         )
 
-        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+        return try await APIClient.withAuthRetry(tokenProvider: tokenProvider) { token in
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.setBearer(token)
+            request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+            request.httpBody = body
 
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw APIError.invalidResponse
+            let (bytes, response) = try await URLSession.shared.bytes(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw APIError.invalidResponse
+            }
+            guard (200 ... 299).contains(httpResponse.statusCode) else {
+                throw APIError.httpError(statusCode: httpResponse.statusCode, body: "Transcription request failed")
+            }
+            return try await parseSSEStream(bytes)
         }
-        if httpResponse.statusCode == 401 {
-            throw APIError.httpError(statusCode: 401, body: "Unauthorized")
-        }
-        guard (200 ... 299).contains(httpResponse.statusCode) else {
-            throw APIError.httpError(statusCode: httpResponse.statusCode, body: "Transcription request failed")
-        }
-
-        return try await parseSSEStream(bytes)
-    }
-
-    private static func buildMultipartBody(fileData: Data, fileName: String, boundary: String) -> Data {
-        var body = Data()
-        let crlf = "\r\n"
-        body.append("--\(boundary)\(crlf)")
-        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(fileName)\"\(crlf)")
-        body.append("Content-Type: audio/wav\(crlf)")
-        body.append(crlf)
-        body.append(fileData)
-        body.append(crlf)
-        body.append("--\(boundary)--\(crlf)")
-        return body
     }
 
     private static func parseSSEStream(_ bytes: URLSession.AsyncBytes) async throws -> String {
@@ -139,24 +111,5 @@ enum TranscriptionService {
                 return ""
             }
         }.joined()
-    }
-}
-
-// MARK: - Helpers
-
-private extension Data {
-    mutating func append(_ string: String) {
-        if let data = string.data(using: .utf8) {
-            append(data)
-        }
-    }
-}
-
-private extension APIError {
-    var is401: Bool {
-        if case let .httpError(statusCode, _) = self, statusCode == 401 {
-            return true
-        }
-        return false
     }
 }


### PR DESCRIPTION
## Description

Voice transcription was failing: `TranscriptionService` built its multipart body with a bare-UUID boundary, which the server's `formidable` parser rejected. The failure surfaced on the client as `URLSession -1017` ("cannot parse response"). Routing transcription through `APIClient`'s multipart builder — which prefixes the boundary with `Boundary-` — fixes it.

The fix rides on a small transport consolidation. `StreamingService` and `TranscriptionService` each re-implemented 401 refresh-retry and the `Bearer` header, and transcription carried its own divergent multipart builder (with the bad boundary and a hardcoded `audio/wav`). Both now go through `APIClient.withAuthRetry` and `APIClient.buildMultipartBody`, a `URLRequest.setBearer` helper replaces the repeated header, and the audio mime type is passed down from `SpeechService` rather than hardcoded in transport. Each service keeps only what's genuinely its own (SSE session/delegate/line-framing for streaming, SSE parsing for transcription).

Net `-86/+33`.

## Tests

Manual, on the iPhone simulator:
- Voice recording → transcript now returns (previously `-1017`).
- Conversation list loads, conversation opens, message streams token-by-token and finalizes (exercises the shared `Bearer` header + SSE 401-retry path, including the auth-preserving redirect).

## Risk

Low. No behavior change to the streaming/JSON paths — they already used `APIClient.withAuthRetry`; this only routes the two stragglers through the same primitives. The transcription 401 path is preserved (the `2xx` guard throws `httpError(401)`, which `withAuthRetry` retries). Trivial to roll back.

## Deploy Plan

Mobile-only; ships with the next app build. No server changes.