### PR TITLE
[front] checkout: move prepare/payment logic to lib/api/checkout

### DIFF
--- a/front-api/routes/w/[wId]/subscriptions/checkout/payment.ts
+++ b/front-api/routes/w/[wId]/subscriptions/checkout/payment.ts
@@ -1,6 +1,6 @@
 import {
-  BodySchema,
   type CheckoutPaymentError,
+  PostCheckoutPaymentBodySchema,
   type PostCheckoutPaymentResponseBody,
   processCheckoutPayment,
 } from "@app/lib/api/checkout/payment";
@@ -10,14 +10,12 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 
-export type { PostCheckoutPaymentResponseBody };
-
 // Mounted at /api/w/:wId/subscriptions/checkout/payment.
 const app = workspaceApp();
 
 app.post(
   "/",
-  validate("json", BodySchema),
+  validate("json", PostCheckoutPaymentBodySchema),
   async (ctx): HandlerResult<PostCheckoutPaymentResponseBody> => {
     return wakeLock(
       async () => {
@@ -38,16 +36,10 @@ app.post(
         const { setupSessionId } = ctx.req.valid("json");
         const result = await processCheckoutPayment(auth, setupSessionId);
         if (result.isErr()) {
-          if (result.error.type === "metronome_provisioning_failed") {
-            return ctx.json<PostCheckoutPaymentResponseBody>(
-              { error: "metronome_error" },
-              500
-            );
-          }
           return mapCheckoutPaymentError(ctx, result.error);
         }
 
-        return ctx.json<PostCheckoutPaymentResponseBody>(result.value);
+        return ctx.json<PostCheckoutPaymentResponseBody>({ success: true });
       },
       { endpoint: ctx.req.url ?? null }
     );
@@ -56,11 +48,8 @@ app.post(
 
 function mapCheckoutPaymentError(
   ctx: Parameters<typeof apiError>[0],
-  error: Exclude<
-    CheckoutPaymentError,
-    { type: "metronome_provisioning_failed" }
-  >
-): ReturnType<typeof apiError> {
+  error: CheckoutPaymentError
+) {
   switch (error.type) {
     case "metronome_not_enabled":
       return apiError(ctx, {
@@ -111,6 +100,26 @@ function mapCheckoutPaymentError(
           message: "Stripe customer has been deleted.",
         },
       });
+    case "setup_failed":
+      return ctx.json<PostCheckoutPaymentResponseBody>(
+        { error: "setup_failed" },
+        500
+      );
+    case "invalid_coupon":
+      return ctx.json<PostCheckoutPaymentResponseBody>(
+        { error: "invalid_coupon" },
+        500
+      );
+    case "payment_failed":
+      return ctx.json<PostCheckoutPaymentResponseBody>(
+        { error: "payment_failed" },
+        500
+      );
+    case "metronome_provisioning_failed":
+      return ctx.json<PostCheckoutPaymentResponseBody>(
+        { error: "metronome_error" },
+        500
+      );
     default:
       assertNever(error);
   }

--- a/front-api/routes/w/[wId]/subscriptions/checkout/payment.ts
+++ b/front-api/routes/w/[wId]/subscriptions/checkout/payment.ts
@@ -1,38 +1,16 @@
-import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
-import { provisionMetronomeFirstPeriodSubscription } from "@app/lib/metronome/checkout";
-import { getBillingCurrencyForCountry } from "@app/lib/plans/billing_currency";
 import {
-  chargeFirstPeriodInvoice,
-  getStripeClient,
-  setStripeCustomerDefaultPaymentMethod,
-} from "@app/lib/plans/stripe";
-import { CouponRedemptionResource } from "@app/lib/resources/coupon_redemption_resource";
-import { CouponResource } from "@app/lib/resources/coupon_resource";
-import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
-import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+  BodySchema,
+  type CheckoutPaymentError,
+  type PostCheckoutPaymentResponseBody,
+  processCheckoutPayment,
+} from "@app/lib/api/checkout/payment";
 import { wakeLock } from "@app/lib/wake_lock";
-import logger from "@app/logger/logger";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { isString } from "@app/types/shared/utils/general";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import { z } from "zod";
 
-const BodySchema = z.object({
-  setupSessionId: z.string(),
-});
-
-export type PostCheckoutPaymentResponseBody =
-  | { success: true }
-  | {
-      error:
-        | "setup_failed"
-        | "payment_failed"
-        | "metronome_error"
-        | "internal_error"
-        | "invalid_coupon";
-    };
+export type { PostCheckoutPaymentResponseBody };
 
 // Mounted at /api/w/:wId/subscriptions/checkout/payment.
 const app = workspaceApp();
@@ -57,295 +35,85 @@ app.post(
           });
         }
 
-        const useMetronomeBilling = await isMetronomeBillingEnabled(auth);
-        if (!useMetronomeBilling) {
-          return apiError(ctx, {
-            status_code: 403,
-            api_error: {
-              type: "workspace_auth_error",
-              message: "Metronome billing is not enabled for this workspace.",
-            },
-          });
-        }
-
         const { setupSessionId } = ctx.req.valid("json");
-        const owner = auth.getNonNullableWorkspace();
-
-        // Idempotency guard: provisioning already completed.
-        const workspace = await WorkspaceResource.fetchById(owner.sId);
-        if (workspace) {
-          const activeSubscription =
-            await SubscriptionResource.fetchActiveByWorkspaceModelId(
-              workspace.id
+        const result = await processCheckoutPayment(auth, setupSessionId);
+        if (result.isErr()) {
+          if (result.error.type === "metronome_provisioning_failed") {
+            return ctx.json<PostCheckoutPaymentResponseBody>(
+              { error: "metronome_error" },
+              500
             );
-          if (activeSubscription?.metronomeContractId) {
-            return ctx.json<PostCheckoutPaymentResponseBody>({ success: true });
           }
+          return mapCheckoutPaymentError(ctx, result.error);
         }
 
-        const stripe = getStripeClient();
-        const setupSession = await stripe.checkout.sessions.retrieve(
-          setupSessionId,
-          {
-            expand: ["setup_intent", "setup_intent.payment_method"],
-          }
-        );
-
-        const setupIntent = setupSession.setup_intent;
-        if (
-          !setupIntent ||
-          isString(setupIntent) ||
-          setupIntent.status !== "succeeded"
-        ) {
-          return ctx.json<PostCheckoutPaymentResponseBody>({
-            error: "setup_failed",
-          });
-        }
-        if (setupSession.client_reference_id !== owner.sId) {
-          return apiError(ctx, {
-            status_code: 403,
-            api_error: {
-              type: "workspace_auth_error",
-              message:
-                "Setup intent does not correspond to the current workspace.",
-            },
-          });
-        }
-
-        const {
-          billingPeriod,
-          seatCount: seatCountStr,
-          pricePerSeatCents: pricePerSeatCentsStr,
-        } = setupSession.metadata ?? {};
-
-        if (
-          !billingPeriod ||
-          !isString(seatCountStr) ||
-          !isString(pricePerSeatCentsStr)
-        ) {
-          return apiError(ctx, {
-            status_code: 500,
-            api_error: {
-              type: "internal_server_error",
-              message:
-                "Setup session metadata is missing billingPeriod, seatCount or pricePerSeatCents.",
-            },
-          });
-        }
-
-        const seatCount = Number(seatCountStr);
-        const pricePerSeatCents = Number(pricePerSeatCentsStr);
-        const subtotalCents = seatCount * pricePerSeatCents;
-        const stripeCustomerId = setupSession.customer;
-
-        if (!isString(stripeCustomerId)) {
-          return apiError(ctx, {
-            status_code: 500,
-            api_error: {
-              type: "internal_server_error",
-              message: "Setup session is missing a customer ID.",
-            },
-          });
-        }
-
-        const rawPaymentMethod = setupIntent.payment_method;
-        const paymentMethodId =
-          rawPaymentMethod === null
-            ? null
-            : isString(rawPaymentMethod)
-              ? rawPaymentMethod
-              : rawPaymentMethod.id;
-
-        if (!paymentMethodId) {
-          return apiError(ctx, {
-            status_code: 500,
-            api_error: {
-              type: "internal_server_error",
-              message: "Setup intent is missing a payment method.",
-            },
-          });
-        }
-
-        const shouldEnforceFirstPeriodPayment =
-          rawPaymentMethod !== null &&
-          !isString(rawPaymentMethod) &&
-          rawPaymentMethod.type === "card";
-
-        const customer = await stripe.customers.retrieve(stripeCustomerId);
-        if (customer.deleted) {
-          return apiError(ctx, {
-            status_code: 500,
-            api_error: {
-              type: "internal_server_error",
-              message: "Stripe customer has been deleted.",
-            },
-          });
-        }
-        const country = customer.address?.country ?? "US";
-        const currency = getBillingCurrencyForCountry(country, true);
-
-        // Coupon: validate + create pending redemption before charging.
-        const couponCode = setupSession.metadata?.couponCode;
-        let coupon: CouponResource | undefined;
-        let pendingRedemption: CouponRedemptionResource | undefined;
-
-        if (couponCode) {
-          const found = await CouponResource.findByCode(couponCode);
-          if (!found) {
-            return ctx.json<PostCheckoutPaymentResponseBody>({
-              error: "invalid_coupon",
-            });
-          }
-          const validation = found.validateRedemption();
-          if (validation.isErr()) {
-            return ctx.json<PostCheckoutPaymentResponseBody>({
-              error: "invalid_coupon",
-            });
-          }
-          const existing =
-            await CouponRedemptionResource.findActiveOrPendingByCouponAndWorkspace(
-              auth,
-              { coupon: found }
-            );
-          if (existing) {
-            return ctx.json<PostCheckoutPaymentResponseBody>({
-              error: "invalid_coupon",
-            });
-          }
-          const pendingResult = await CouponRedemptionResource.createPending(
-            auth,
-            { coupon: found }
-          );
-          if (pendingResult.isErr()) {
-            logger.error(
-              {
-                workspaceId: owner.sId,
-                couponCode,
-                error: pendingResult.error.message,
-              },
-              "[Checkout] Failed to create pending coupon redemption"
-            );
-            return ctx.json<PostCheckoutPaymentResponseBody>({
-              error: "invalid_coupon",
-            });
-          }
-          pendingRedemption = pendingResult.value;
-          coupon = found;
-        }
-
-        const couponAmountCents = coupon ? coupon.amount * 100 : 0;
-        const effectiveSubtotalCents = Math.max(
-          0,
-          subtotalCents - couponAmountCents
-        );
-
-        const user = auth.getNonNullableUser();
-        const planCode = setupSession.metadata?.planCode ?? "";
-        const metronomePackageAlias =
-          setupSession.metadata?.metronomePackageAlias ?? "";
-
-        // Set the payment method as the customer's Stripe default
-        // for future Metronome-generated invoices (month 2+).
-        const setDefaultPaymentMethodResult =
-          await setStripeCustomerDefaultPaymentMethod({
-            stripeCustomerId,
-            paymentMethodId,
-            workspaceId: owner.sId,
-          });
-        if (setDefaultPaymentMethodResult.isErr()) {
-          if (pendingRedemption && coupon) {
-            const rollbackResult = await pendingRedemption.rollback(coupon);
-            if (rollbackResult.isErr()) {
-              logger.error(
-                {
-                  err: rollbackResult.error,
-                  workspaceId: owner.sId,
-                },
-                "[Checkout] Failed to rollback coupon redemption after setDefaultPaymentMethod failure"
-              );
-            }
-          }
-          return ctx.json<PostCheckoutPaymentResponseBody>({
-            error: "payment_failed",
-          });
-        }
-
-        if (shouldEnforceFirstPeriodPayment && effectiveSubtotalCents > 0) {
-          const chargeResult = await chargeFirstPeriodInvoice({
-            stripeCustomerId,
-            paymentMethodId,
-            billingPeriod,
-            pricePerSeatCents,
-            couponAmountCents,
-            seatCount,
-            setupSessionId,
-            workspaceId: owner.sId,
-            currency,
-            couponCode,
-          });
-          if (chargeResult.isErr()) {
-            if (pendingRedemption && coupon) {
-              const rollbackResult = await pendingRedemption.rollback(coupon);
-              if (rollbackResult.isErr()) {
-                logger.error(
-                  { err: rollbackResult.error, workspaceId: owner.sId },
-                  "[Checkout] Failed to rollback coupon redemption after chargeFirstPeriodInvoice failure"
-                );
-              }
-            }
-            return ctx.json<PostCheckoutPaymentResponseBody>({
-              error: "payment_failed",
-            });
-          }
-        }
-
-        const provisionResult = await provisionMetronomeFirstPeriodSubscription(
-          {
-            stripeCustomerId,
-            currency,
-            workspaceId: owner.sId,
-            userId: user.sId,
-            planCode,
-            metronomePackageAlias,
-            coupon,
-            pendingRedemption,
-            firstPeriodPaymentEnforced: shouldEnforceFirstPeriodPayment,
-            firstPeriodPaymentCents: effectiveSubtotalCents,
-            uniquenessKey: setupSessionId,
-            now: new Date(),
-          }
-        );
-
-        if (provisionResult.isErr()) {
-          logger.error(
-            {
-              panic: true,
-              error: normalizeError(provisionResult.error).message,
-              stripeCustomerId,
-              currency,
-              workspaceId: owner.sId,
-              userId: user.sId,
-              planCode,
-              metronomePackageAlias,
-              couponId: coupon?.sId,
-              pendingRedemptionId: pendingRedemption?.sId,
-              firstPeriodPaymentEnforced: shouldEnforceFirstPeriodPayment,
-              firstPeriodPaymentCents: effectiveSubtotalCents,
-              uniquenessKey: setupSessionId,
-            },
-            "[Checkout] Payment succeeded but Metronome provisioning failed"
-          );
-          return ctx.json<PostCheckoutPaymentResponseBody>(
-            { error: "metronome_error" },
-            500
-          );
-        }
-
-        return ctx.json<PostCheckoutPaymentResponseBody>({ success: true });
+        return ctx.json<PostCheckoutPaymentResponseBody>(result.value);
       },
       { endpoint: ctx.req.url ?? null }
     );
   }
 );
+
+function mapCheckoutPaymentError(
+  ctx: Parameters<typeof apiError>[0],
+  error: Exclude<
+    CheckoutPaymentError,
+    { type: "metronome_provisioning_failed" }
+  >
+): ReturnType<typeof apiError> {
+  switch (error.type) {
+    case "metronome_not_enabled":
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message: "Metronome billing is not enabled for this workspace.",
+        },
+      });
+    case "workspace_mismatch":
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message: "Setup intent does not correspond to the current workspace.",
+        },
+      });
+    case "missing_metadata":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message:
+            "Setup session metadata is missing billingPeriod, seatCount or pricePerSeatCents.",
+        },
+      });
+    case "missing_customer_id":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Setup session is missing a customer ID.",
+        },
+      });
+    case "missing_payment_method":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Setup intent is missing a payment method.",
+        },
+      });
+    case "customer_deleted":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Stripe customer has been deleted.",
+        },
+      });
+    default:
+      assertNever(error);
+  }
+}
 
 export default app;

--- a/front-api/routes/w/[wId]/subscriptions/checkout/prepare-payment.ts
+++ b/front-api/routes/w/[wId]/subscriptions/checkout/prepare-payment.ts
@@ -1,30 +1,15 @@
-import { getStripeCheckoutSessionStatus } from "@app/lib/api/stripe/checkout_status";
-import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
-import { getBillingCurrencyForCountry } from "@app/lib/plans/billing_currency";
-import { calculateTax, getStripeClient } from "@app/lib/plans/stripe";
-import { CouponResource } from "@app/lib/resources/coupon_resource";
-import type { SupportedCurrency } from "@app/types/currency";
+import {
+  type GetPreparePaymentResponseBody,
+  getPreparePaymentData,
+  type PreparePaymentError,
+} from "@app/lib/api/checkout/prepare_payment";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 
-export type GetPreparePaymentResponseBody =
-  | { status: "pending" }
-  | {
-      status: "success";
-      subtotalCents: number;
-      taxCents: number;
-      totalCents: number;
-      seatCount: number;
-      pricePerSeatCents: number;
-      planCode: string;
-      metronomePackageAlias: string;
-      currency: SupportedCurrency;
-      cardBrand?: string;
-      cardLast4?: string;
-      sepaLast4?: string;
-    };
+export type { GetPreparePaymentResponseBody };
 
 // Mounted at /api/w/:wId/subscriptions/checkout/prepare-payment.
 const app = workspaceApp();
@@ -33,23 +18,6 @@ app.get(
   "/",
   ensureIsAdmin(),
   async (ctx): HandlerResult<GetPreparePaymentResponseBody> => {
-    const auth = ctx.get("auth");
-    const owner = auth.getNonNullableWorkspace();
-
-    const useMetronomeBilling = await isMetronomeBillingEnabled(auth);
-    if (!useMetronomeBilling) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "workspace_auth_error",
-          message: "Metronome billing is not enabled for this workspace.",
-        },
-      });
-    }
-
-    // Prevent HTTP caching as session status can change on every call.
-    ctx.header("Cache-Control", "no-store");
-
     const setup_session_id = ctx.req.query("setup_session_id");
     if (!isString(setup_session_id)) {
       return apiError(ctx, {
@@ -61,26 +29,33 @@ app.get(
       });
     }
 
-    // onComplete fires on the client before Stripe marks the session complete server-side.
-    // We return "pending" so the client can retry instead of blocking here.
-    const sessionStatus =
-      await getStripeCheckoutSessionStatus(setup_session_id);
-    if (sessionStatus?.status !== "complete") {
-      return ctx.json<GetPreparePaymentResponseBody>({ status: "pending" });
+    // Prevent HTTP caching as session status can change on every call.
+    ctx.header("Cache-Control", "no-store");
+
+    const auth = ctx.get("auth");
+    const result = await getPreparePaymentData(auth, setup_session_id);
+    if (result.isErr()) {
+      return mapPreparePaymentError(ctx, result.error);
     }
 
-    const stripe = getStripeClient();
-    const setupSession = await stripe.checkout.sessions.retrieve(
-      setup_session_id,
-      { expand: ["setup_intent", "setup_intent.payment_method"] }
-    );
+    return ctx.json<GetPreparePaymentResponseBody>(result.value);
+  }
+);
 
-    const setupIntent = setupSession.setup_intent;
-    if (
-      !setupIntent ||
-      isString(setupIntent) ||
-      setupIntent.status !== "succeeded"
-    ) {
+function mapPreparePaymentError(
+  ctx: Parameters<typeof apiError>[0],
+  error: PreparePaymentError
+): ReturnType<typeof apiError> {
+  switch (error.type) {
+    case "metronome_not_enabled":
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message: "Metronome billing is not enabled for this workspace.",
+        },
+      });
+    case "setup_not_succeeded":
       return apiError(ctx, {
         status_code: 400,
         api_error: {
@@ -88,8 +63,7 @@ app.get(
           message: "Setup session has not completed successfully.",
         },
       });
-    }
-    if (setupSession.client_reference_id !== owner.sId) {
+    case "workspace_mismatch":
       return apiError(ctx, {
         status_code: 403,
         api_error: {
@@ -97,12 +71,7 @@ app.get(
           message: "Setup intent does not correspond to the current workspace.",
         },
       });
-    }
-
-    const { seatCount: seatCountStr, pricePerSeatCents: pricePerSeatCentsStr } =
-      setupSession.metadata ?? {};
-
-    if (!isString(seatCountStr) || !isString(pricePerSeatCentsStr)) {
+    case "missing_metadata":
       return apiError(ctx, {
         status_code: 500,
         api_error: {
@@ -111,14 +80,7 @@ app.get(
             "Setup session metadata is missing seatCount or pricePerSeatCents.",
         },
       });
-    }
-
-    const seatCount = Number(seatCountStr);
-    const pricePerSeatCents = Number(pricePerSeatCentsStr);
-    const subtotalCents = seatCount * pricePerSeatCents;
-    const stripeCustomerId = setupSession.customer;
-
-    if (!isString(stripeCustomerId)) {
+    case "missing_customer_id":
       return apiError(ctx, {
         status_code: 500,
         api_error: {
@@ -126,27 +88,7 @@ app.get(
           message: "Setup session is missing a customer ID.",
         },
       });
-    }
-
-    const planCode = setupSession.metadata?.planCode ?? "";
-    const metronomePackageAlias =
-      setupSession.metadata?.metronomePackageAlias ?? "";
-
-    const rawPaymentMethod = setupIntent.payment_method;
-    let cardBrand: string | undefined;
-    let cardLast4: string | undefined;
-    let sepaLast4: string | undefined;
-    if (rawPaymentMethod && !isString(rawPaymentMethod)) {
-      if (rawPaymentMethod.card) {
-        cardBrand = rawPaymentMethod.card.brand;
-        cardLast4 = rawPaymentMethod.card.last4;
-      } else if (rawPaymentMethod.sepa_debit) {
-        sepaLast4 = rawPaymentMethod.sepa_debit.last4 ?? undefined;
-      }
-    }
-
-    const customer = await stripe.customers.retrieve(stripeCustomerId);
-    if (customer.deleted) {
+    case "customer_deleted":
       return apiError(ctx, {
         status_code: 500,
         api_error: {
@@ -154,54 +96,17 @@ app.get(
           message: "Stripe customer has been deleted.",
         },
       });
-    }
-    const country = customer.address?.country ?? "US";
-    const currency = getBillingCurrencyForCountry(country, true);
-
-    // Apply coupon discount to the tax base if a coupon was stored in session metadata.
-    // No validation here — enforcement happens in POST /payment.
-    const couponCode = setupSession.metadata?.couponCode;
-    let discountedSubtotalCents = subtotalCents;
-    if (couponCode) {
-      const coupon = await CouponResource.findByCode(couponCode);
-      if (coupon) {
-        discountedSubtotalCents = Math.max(
-          0,
-          subtotalCents - coupon.amount * 100
-        );
-      }
-    }
-
-    const taxResult = await calculateTax({
-      stripeCustomerId,
-      amountCents: discountedSubtotalCents,
-      currency,
-    });
-    if (taxResult.isErr()) {
+    case "tax_calculation_failed":
       return apiError(ctx, {
         status_code: 500,
         api_error: {
           type: "internal_server_error",
-          message: taxResult.error.error_message,
+          message: error.message,
         },
       });
-    }
-
-    return ctx.json<GetPreparePaymentResponseBody>({
-      status: "success",
-      subtotalCents,
-      taxCents: taxResult.value.taxCents,
-      totalCents: taxResult.value.totalCents,
-      seatCount,
-      pricePerSeatCents,
-      planCode,
-      metronomePackageAlias,
-      currency,
-      cardBrand,
-      cardLast4,
-      sepaLast4,
-    });
+    default:
+      assertNever(error);
   }
-);
+}
 
 export default app;

--- a/front-api/routes/w/[wId]/subscriptions/checkout/prepare-payment.ts
+++ b/front-api/routes/w/[wId]/subscriptions/checkout/prepare-payment.ts
@@ -9,8 +9,6 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 
-export type { GetPreparePaymentResponseBody };
-
 // Mounted at /api/w/:wId/subscriptions/checkout/prepare-payment.
 const app = workspaceApp();
 

--- a/front/lib/api/checkout/payment.ts
+++ b/front/lib/api/checkout/payment.ts
@@ -1,0 +1,265 @@
+import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
+import type { Authenticator } from "@app/lib/auth";
+import { provisionMetronomeFirstPeriodSubscription } from "@app/lib/metronome/checkout";
+import { getBillingCurrencyForCountry } from "@app/lib/plans/billing_currency";
+import {
+  chargeFirstPeriodInvoice,
+  getStripeClient,
+  setStripeCustomerDefaultPaymentMethod,
+} from "@app/lib/plans/stripe";
+import { CouponRedemptionResource } from "@app/lib/resources/coupon_redemption_resource";
+import { CouponResource } from "@app/lib/resources/coupon_resource";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import logger from "@app/logger/logger";
+import { Err, Ok, type Result } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isString } from "@app/types/shared/utils/general";
+import { z } from "zod";
+
+export const BodySchema = z.object({
+  setupSessionId: z.string(),
+});
+
+export type PostCheckoutPaymentResponseBody =
+  | { success: true }
+  | {
+      error:
+        | "setup_failed"
+        | "payment_failed"
+        | "metronome_error"
+        | "internal_error"
+        | "invalid_coupon";
+    };
+
+export type CheckoutPaymentError =
+  | { type: "metronome_not_enabled" }
+  | { type: "workspace_mismatch" }
+  | { type: "missing_metadata" }
+  | { type: "missing_customer_id" }
+  | { type: "missing_payment_method" }
+  | { type: "customer_deleted" }
+  | { type: "metronome_provisioning_failed" };
+
+export async function processCheckoutPayment(
+  auth: Authenticator,
+  setupSessionId: string
+): Promise<Result<PostCheckoutPaymentResponseBody, CheckoutPaymentError>> {
+  const useMetronomeBilling = await isMetronomeBillingEnabled(auth);
+  if (!useMetronomeBilling) {
+    return new Err({ type: "metronome_not_enabled" });
+  }
+
+  const owner = auth.getNonNullableWorkspace();
+
+  // Idempotency guard: provisioning already completed.
+  const workspace = await WorkspaceResource.fetchById(owner.sId);
+  if (workspace) {
+    const activeSubscription =
+      await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
+    if (activeSubscription?.metronomeContractId) {
+      return new Ok({ success: true });
+    }
+  }
+
+  const stripe = getStripeClient();
+  const setupSession = await stripe.checkout.sessions.retrieve(setupSessionId, {
+    expand: ["setup_intent", "setup_intent.payment_method"],
+  });
+
+  const setupIntent = setupSession.setup_intent;
+  if (
+    !setupIntent ||
+    isString(setupIntent) ||
+    setupIntent.status !== "succeeded"
+  ) {
+    return new Ok({ error: "setup_failed" });
+  }
+
+  if (setupSession.client_reference_id !== owner.sId) {
+    return new Err({ type: "workspace_mismatch" });
+  }
+
+  const {
+    billingPeriod,
+    seatCount: seatCountStr,
+    pricePerSeatCents: pricePerSeatCentsStr,
+  } = setupSession.metadata ?? {};
+
+  if (
+    !billingPeriod ||
+    !isString(seatCountStr) ||
+    !isString(pricePerSeatCentsStr)
+  ) {
+    return new Err({ type: "missing_metadata" });
+  }
+
+  const seatCount = Number(seatCountStr);
+  const pricePerSeatCents = Number(pricePerSeatCentsStr);
+  const subtotalCents = seatCount * pricePerSeatCents;
+  const stripeCustomerId = setupSession.customer;
+
+  if (!isString(stripeCustomerId)) {
+    return new Err({ type: "missing_customer_id" });
+  }
+
+  const rawPaymentMethod = setupIntent.payment_method;
+  const paymentMethodId =
+    rawPaymentMethod === null
+      ? null
+      : isString(rawPaymentMethod)
+        ? rawPaymentMethod
+        : rawPaymentMethod.id;
+
+  if (!paymentMethodId) {
+    return new Err({ type: "missing_payment_method" });
+  }
+
+  const shouldEnforceFirstPeriodPayment =
+    rawPaymentMethod !== null &&
+    !isString(rawPaymentMethod) &&
+    rawPaymentMethod.type === "card";
+
+  const customer = await stripe.customers.retrieve(stripeCustomerId);
+  if (customer.deleted) {
+    return new Err({ type: "customer_deleted" });
+  }
+
+  const country = customer.address?.country ?? "US";
+  const currency = getBillingCurrencyForCountry(country, true);
+
+  // Coupon: validate + create pending redemption before charging.
+  const couponCode = setupSession.metadata?.couponCode;
+  let coupon: CouponResource | undefined;
+  let pendingRedemption: CouponRedemptionResource | undefined;
+
+  if (couponCode) {
+    const found = await CouponResource.findByCode(couponCode);
+    if (!found) {
+      return new Ok({ error: "invalid_coupon" });
+    }
+    const validation = found.validateRedemption();
+    if (validation.isErr()) {
+      return new Ok({ error: "invalid_coupon" });
+    }
+    const existing =
+      await CouponRedemptionResource.findActiveOrPendingByCouponAndWorkspace(
+        auth,
+        { coupon: found }
+      );
+    if (existing) {
+      return new Ok({ error: "invalid_coupon" });
+    }
+    const pendingResult = await CouponRedemptionResource.createPending(auth, {
+      coupon: found,
+    });
+    if (pendingResult.isErr()) {
+      logger.error(
+        {
+          workspaceId: owner.sId,
+          couponCode,
+          error: pendingResult.error.message,
+        },
+        "[Checkout] Failed to create pending coupon redemption"
+      );
+      return new Ok({ error: "invalid_coupon" });
+    }
+    pendingRedemption = pendingResult.value;
+    coupon = found;
+  }
+
+  const couponAmountCents = coupon ? coupon.amount * 100 : 0;
+  const effectiveSubtotalCents = Math.max(0, subtotalCents - couponAmountCents);
+
+  const user = auth.getNonNullableUser();
+  const planCode = setupSession.metadata?.planCode ?? "";
+  const metronomePackageAlias =
+    setupSession.metadata?.metronomePackageAlias ?? "";
+
+  // Set the payment method as the customer's Stripe default
+  // for future Metronome-generated invoices (month 2+).
+  const setDefaultPaymentMethodResult =
+    await setStripeCustomerDefaultPaymentMethod({
+      stripeCustomerId,
+      paymentMethodId,
+      workspaceId: owner.sId,
+    });
+  if (setDefaultPaymentMethodResult.isErr()) {
+    if (pendingRedemption && coupon) {
+      const rollbackResult = await pendingRedemption.rollback(coupon);
+      if (rollbackResult.isErr()) {
+        logger.error(
+          { err: rollbackResult.error, workspaceId: owner.sId },
+          "[Checkout] Failed to rollback coupon redemption after setDefaultPaymentMethod failure"
+        );
+      }
+    }
+    return new Ok({ error: "payment_failed" });
+  }
+
+  if (shouldEnforceFirstPeriodPayment && effectiveSubtotalCents > 0) {
+    const chargeResult = await chargeFirstPeriodInvoice({
+      stripeCustomerId,
+      paymentMethodId,
+      billingPeriod,
+      pricePerSeatCents,
+      couponAmountCents,
+      seatCount,
+      setupSessionId,
+      workspaceId: owner.sId,
+      currency,
+      couponCode,
+    });
+    if (chargeResult.isErr()) {
+      if (pendingRedemption && coupon) {
+        const rollbackResult = await pendingRedemption.rollback(coupon);
+        if (rollbackResult.isErr()) {
+          logger.error(
+            { err: rollbackResult.error, workspaceId: owner.sId },
+            "[Checkout] Failed to rollback coupon redemption after chargeFirstPeriodInvoice failure"
+          );
+        }
+      }
+      return new Ok({ error: "payment_failed" });
+    }
+  }
+
+  const provisionResult = await provisionMetronomeFirstPeriodSubscription({
+    stripeCustomerId,
+    currency,
+    workspaceId: owner.sId,
+    userId: user.sId,
+    planCode,
+    metronomePackageAlias,
+    coupon,
+    pendingRedemption,
+    firstPeriodPaymentEnforced: shouldEnforceFirstPeriodPayment,
+    firstPeriodPaymentCents: effectiveSubtotalCents,
+    uniquenessKey: setupSessionId,
+    now: new Date(),
+  });
+
+  if (provisionResult.isErr()) {
+    logger.error(
+      {
+        panic: true,
+        error: normalizeError(provisionResult.error).message,
+        stripeCustomerId,
+        currency,
+        workspaceId: owner.sId,
+        userId: user.sId,
+        planCode,
+        metronomePackageAlias,
+        couponId: coupon?.sId,
+        pendingRedemptionId: pendingRedemption?.sId,
+        firstPeriodPaymentEnforced: shouldEnforceFirstPeriodPayment,
+        firstPeriodPaymentCents: effectiveSubtotalCents,
+        uniquenessKey: setupSessionId,
+      },
+      "[Checkout] Payment succeeded but Metronome provisioning failed"
+    );
+    return new Err({ type: "metronome_provisioning_failed" });
+  }
+
+  return new Ok({ success: true });
+}

--- a/front/lib/api/checkout/payment.ts
+++ b/front/lib/api/checkout/payment.ts
@@ -17,7 +17,7 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
 import { z } from "zod";
 
-export const BodySchema = z.object({
+export const PostCheckoutPaymentBodySchema = z.object({
   setupSessionId: z.string(),
 });
 
@@ -34,17 +34,20 @@ export type PostCheckoutPaymentResponseBody =
 
 export type CheckoutPaymentError =
   | { type: "metronome_not_enabled" }
+  | { type: "setup_failed" }
   | { type: "workspace_mismatch" }
   | { type: "missing_metadata" }
   | { type: "missing_customer_id" }
   | { type: "missing_payment_method" }
   | { type: "customer_deleted" }
+  | { type: "invalid_coupon" }
+  | { type: "payment_failed" }
   | { type: "metronome_provisioning_failed" };
 
 export async function processCheckoutPayment(
   auth: Authenticator,
   setupSessionId: string
-): Promise<Result<PostCheckoutPaymentResponseBody, CheckoutPaymentError>> {
+): Promise<Result<{ success: true }, CheckoutPaymentError>> {
   const useMetronomeBilling = await isMetronomeBillingEnabled(auth);
   if (!useMetronomeBilling) {
     return new Err({ type: "metronome_not_enabled" });
@@ -73,7 +76,7 @@ export async function processCheckoutPayment(
     isString(setupIntent) ||
     setupIntent.status !== "succeeded"
   ) {
-    return new Ok({ error: "setup_failed" });
+    return new Err({ type: "setup_failed" });
   }
 
   if (setupSession.client_reference_id !== owner.sId) {
@@ -136,11 +139,11 @@ export async function processCheckoutPayment(
   if (couponCode) {
     const found = await CouponResource.findByCode(couponCode);
     if (!found) {
-      return new Ok({ error: "invalid_coupon" });
+      return new Err({ type: "invalid_coupon" });
     }
     const validation = found.validateRedemption();
     if (validation.isErr()) {
-      return new Ok({ error: "invalid_coupon" });
+      return new Err({ type: "invalid_coupon" });
     }
     const existing =
       await CouponRedemptionResource.findActiveOrPendingByCouponAndWorkspace(
@@ -148,7 +151,7 @@ export async function processCheckoutPayment(
         { coupon: found }
       );
     if (existing) {
-      return new Ok({ error: "invalid_coupon" });
+      return new Err({ type: "invalid_coupon" });
     }
     const pendingResult = await CouponRedemptionResource.createPending(auth, {
       coupon: found,
@@ -162,7 +165,7 @@ export async function processCheckoutPayment(
         },
         "[Checkout] Failed to create pending coupon redemption"
       );
-      return new Ok({ error: "invalid_coupon" });
+      return new Err({ type: "invalid_coupon" });
     }
     pendingRedemption = pendingResult.value;
     coupon = found;
@@ -194,7 +197,7 @@ export async function processCheckoutPayment(
         );
       }
     }
-    return new Ok({ error: "payment_failed" });
+    return new Err({ type: "payment_failed" });
   }
 
   if (shouldEnforceFirstPeriodPayment && effectiveSubtotalCents > 0) {
@@ -220,7 +223,7 @@ export async function processCheckoutPayment(
           );
         }
       }
-      return new Ok({ error: "payment_failed" });
+      return new Err({ type: "payment_failed" });
     }
   }
 

--- a/front/lib/api/checkout/prepare_payment.ts
+++ b/front/lib/api/checkout/prepare_payment.ts
@@ -1,0 +1,153 @@
+import { getStripeCheckoutSessionStatus } from "@app/lib/api/stripe/checkout_status";
+import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
+import type { Authenticator } from "@app/lib/auth";
+import { getBillingCurrencyForCountry } from "@app/lib/plans/billing_currency";
+import { calculateTax, getStripeClient } from "@app/lib/plans/stripe";
+import { CouponResource } from "@app/lib/resources/coupon_resource";
+import type { SupportedCurrency } from "@app/types/currency";
+import { Err, Ok, type Result } from "@app/types/shared/result";
+import { isString } from "@app/types/shared/utils/general";
+
+export type GetPreparePaymentResponseBody =
+  | { status: "pending" }
+  | {
+      status: "success";
+      subtotalCents: number;
+      taxCents: number;
+      totalCents: number;
+      seatCount: number;
+      pricePerSeatCents: number;
+      planCode: string;
+      metronomePackageAlias: string;
+      currency: SupportedCurrency;
+      cardBrand?: string;
+      cardLast4?: string;
+      sepaLast4?: string;
+    };
+
+export type PreparePaymentError =
+  | { type: "metronome_not_enabled" }
+  | { type: "setup_not_succeeded" }
+  | { type: "workspace_mismatch" }
+  | { type: "missing_metadata" }
+  | { type: "missing_customer_id" }
+  | { type: "customer_deleted" }
+  | { type: "tax_calculation_failed"; message: string };
+
+export async function getPreparePaymentData(
+  auth: Authenticator,
+  setupSessionId: string
+): Promise<Result<GetPreparePaymentResponseBody, PreparePaymentError>> {
+  const useMetronomeBilling = await isMetronomeBillingEnabled(auth);
+  if (!useMetronomeBilling) {
+    return new Err({ type: "metronome_not_enabled" });
+  }
+
+  const owner = auth.getNonNullableWorkspace();
+
+  // onComplete fires on the client before Stripe marks the session complete server-side.
+  // We return "pending" so the client can retry instead of blocking here.
+  const sessionStatus = await getStripeCheckoutSessionStatus(setupSessionId);
+  if (sessionStatus?.status !== "complete") {
+    return new Ok({ status: "pending" });
+  }
+
+  const stripe = getStripeClient();
+  const setupSession = await stripe.checkout.sessions.retrieve(setupSessionId, {
+    expand: ["setup_intent", "setup_intent.payment_method"],
+  });
+
+  const setupIntent = setupSession.setup_intent;
+  if (
+    !setupIntent ||
+    isString(setupIntent) ||
+    setupIntent.status !== "succeeded"
+  ) {
+    return new Err({ type: "setup_not_succeeded" });
+  }
+
+  if (setupSession.client_reference_id !== owner.sId) {
+    return new Err({ type: "workspace_mismatch" });
+  }
+
+  const { seatCount: seatCountStr, pricePerSeatCents: pricePerSeatCentsStr } =
+    setupSession.metadata ?? {};
+  if (!isString(seatCountStr) || !isString(pricePerSeatCentsStr)) {
+    return new Err({ type: "missing_metadata" });
+  }
+
+  const seatCount = Number(seatCountStr);
+  const pricePerSeatCents = Number(pricePerSeatCentsStr);
+  const subtotalCents = seatCount * pricePerSeatCents;
+  const stripeCustomerId = setupSession.customer;
+
+  if (!isString(stripeCustomerId)) {
+    return new Err({ type: "missing_customer_id" });
+  }
+
+  const planCode = setupSession.metadata?.planCode ?? "";
+  const metronomePackageAlias =
+    setupSession.metadata?.metronomePackageAlias ?? "";
+
+  const rawPaymentMethod = setupIntent.payment_method;
+  let cardBrand: string | undefined;
+  let cardLast4: string | undefined;
+  let sepaLast4: string | undefined;
+  if (rawPaymentMethod && !isString(rawPaymentMethod)) {
+    if (rawPaymentMethod.card) {
+      cardBrand = rawPaymentMethod.card.brand;
+      cardLast4 = rawPaymentMethod.card.last4;
+    } else if (rawPaymentMethod.sepa_debit) {
+      sepaLast4 = rawPaymentMethod.sepa_debit.last4 ?? undefined;
+    }
+  }
+
+  const customer = await stripe.customers.retrieve(stripeCustomerId);
+  if (customer.deleted) {
+    return new Err({ type: "customer_deleted" });
+  }
+
+  const country = customer.address?.country ?? "US";
+  const currency = getBillingCurrencyForCountry(country, true);
+
+  // Apply coupon discount to the tax base if a coupon was stored in session metadata.
+  // No validation here — enforcement happens in POST /payment.
+  const couponCode = setupSession.metadata?.couponCode;
+  let discountedSubtotalCents = subtotalCents;
+  if (couponCode) {
+    const coupon = await CouponResource.findByCode(couponCode);
+    if (coupon) {
+      discountedSubtotalCents = Math.max(
+        0,
+        subtotalCents - coupon.amount * 100
+      );
+    }
+  }
+
+  const taxResult = await calculateTax({
+    stripeCustomerId,
+    amountCents: discountedSubtotalCents,
+    currency,
+  });
+  if (taxResult.isErr()) {
+    return new Err({
+      type: "tax_calculation_failed",
+      message: taxResult.error.error_message,
+    });
+  }
+
+  return new Ok({
+    status: "success",
+    subtotalCents,
+    taxCents: taxResult.value.taxCents,
+    totalCents: taxResult.value.totalCents,
+    seatCount,
+    pricePerSeatCents,
+    planCode,
+    metronomePackageAlias,
+    currency,
+    cardBrand,
+    cardLast4,
+    sepaLast4,
+  });
+}

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -14,6 +14,7 @@ import type {
 } from "@app/lib/api/analytics/programmatic_cost";
 import type { GetBillingInfoResponseBody } from "@app/lib/api/billing/info";
 import type { GetBillingInvoicesResponseBody } from "@app/lib/api/billing/invoices";
+import type { PostCheckoutPaymentResponseBody } from "@app/lib/api/checkout/payment";
 import type { GetPreparePaymentResponseBody } from "@app/lib/api/checkout/prepare_payment";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import { clientFetch } from "@app/lib/egress/client";
@@ -42,7 +43,6 @@ import type {
   GetSubscriptionsResponseBody,
   PostSubscriptionResponseBody,
 } from "@app/pages/api/w/[wId]/subscriptions";
-import type { PostCheckoutPaymentResponseBody } from "@app/pages/api/w/[wId]/subscriptions/checkout/payment";
 import type { GetCheckoutStatusResponseBody } from "@app/pages/api/w/[wId]/subscriptions/checkout-status";
 import type { GetSubscriptionPricingResponseBody } from "@app/pages/api/w/[wId]/subscriptions/pricing";
 import type { GetSubscriptionStatusResponseBody } from "@app/pages/api/w/[wId]/subscriptions/status";

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -1301,7 +1301,7 @@ export function useConfirmPayment({ workspaceId }: { workspaceId: string }) {
             return null;
           }
         }
-        return res.json();
+        return await res.json();
       } finally {
         setIsConfirming(false);
       }

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -14,6 +14,7 @@ import type {
 } from "@app/lib/api/analytics/programmatic_cost";
 import type { GetBillingInfoResponseBody } from "@app/lib/api/billing/info";
 import type { GetBillingInvoicesResponseBody } from "@app/lib/api/billing/invoices";
+import type { GetPreparePaymentResponseBody } from "@app/lib/api/checkout/prepare_payment";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
@@ -42,7 +43,6 @@ import type {
   PostSubscriptionResponseBody,
 } from "@app/pages/api/w/[wId]/subscriptions";
 import type { PostCheckoutPaymentResponseBody } from "@app/pages/api/w/[wId]/subscriptions/checkout/payment";
-import type { GetPreparePaymentResponseBody } from "@app/pages/api/w/[wId]/subscriptions/checkout/prepare-payment";
 import type { GetCheckoutStatusResponseBody } from "@app/pages/api/w/[wId]/subscriptions/checkout-status";
 import type { GetSubscriptionPricingResponseBody } from "@app/pages/api/w/[wId]/subscriptions/pricing";
 import type { GetSubscriptionStatusResponseBody } from "@app/pages/api/w/[wId]/subscriptions/status";

--- a/front/pages/api/w/[wId]/subscriptions/checkout/payment.ts
+++ b/front/pages/api/w/[wId]/subscriptions/checkout/payment.ts
@@ -3,8 +3,8 @@
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import {
-  BodySchema,
   type CheckoutPaymentError,
+  PostCheckoutPaymentBodySchema,
   type PostCheckoutPaymentResponseBody,
   processCheckoutPayment,
 } from "@app/lib/api/checkout/payment";
@@ -15,8 +15,6 @@ import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { fromError } from "zod-validation-error";
-
-export type { PostCheckoutPaymentResponseBody };
 
 async function handler(
   req: NextApiRequest,
@@ -46,7 +44,7 @@ async function handler(
         });
       }
 
-      const bodyValidation = BodySchema.safeParse(req.body);
+      const bodyValidation = PostCheckoutPaymentBodySchema.safeParse(req.body);
       if (!bodyValidation.success) {
         return apiError(req, res, {
           status_code: 400,
@@ -63,7 +61,7 @@ async function handler(
         return mapCheckoutPaymentError(req, res, result.error);
       }
 
-      return res.status(200).json(result.value);
+      return res.status(200).json({ success: true });
     },
     { endpoint: req.url ?? null }
   );
@@ -83,6 +81,9 @@ function mapCheckoutPaymentError(
           message: "Metronome billing is not enabled for this workspace.",
         },
       });
+    case "setup_failed":
+      res.status(500).json({ error: "setup_failed" });
+      return;
     case "workspace_mismatch":
       return apiError(req, res, {
         status_code: 403,
@@ -124,6 +125,12 @@ function mapCheckoutPaymentError(
           message: "Stripe customer has been deleted.",
         },
       });
+    case "invalid_coupon":
+      res.status(500).json({ error: "invalid_coupon" });
+      return;
+    case "payment_failed":
+      res.status(500).json({ error: "payment_failed" });
+      return;
     case "metronome_provisioning_failed":
       res.status(500).json({ error: "metronome_error" });
       return;

--- a/front/pages/api/w/[wId]/subscriptions/checkout/payment.ts
+++ b/front/pages/api/w/[wId]/subscriptions/checkout/payment.ts
@@ -1,43 +1,22 @@
 // @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
+
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
-import type { Authenticator } from "@app/lib/auth";
-import { provisionMetronomeFirstPeriodSubscription } from "@app/lib/metronome/checkout";
-import { getBillingCurrencyForCountry } from "@app/lib/plans/billing_currency";
 import {
-  chargeFirstPeriodInvoice,
-  getStripeClient,
-  setStripeCustomerDefaultPaymentMethod,
-} from "@app/lib/plans/stripe";
-import { CouponRedemptionResource } from "@app/lib/resources/coupon_redemption_resource";
-import { CouponResource } from "@app/lib/resources/coupon_resource";
-import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
-import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+  BodySchema,
+  type CheckoutPaymentError,
+  type PostCheckoutPaymentResponseBody,
+  processCheckoutPayment,
+} from "@app/lib/api/checkout/payment";
+import type { Authenticator } from "@app/lib/auth";
 import { wakeLock } from "@app/lib/wake_lock";
-import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { isString } from "@app/types/shared/utils/general";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
-const BodySchema = z.object({
-  setupSessionId: z.string(),
-});
-
-export type PostCheckoutPaymentResponseBody =
-  | { success: true }
-  | {
-      error:
-        | "setup_failed"
-        | "payment_failed"
-        | "metronome_error"
-        | "internal_error"
-        | "invalid_coupon";
-    };
+export type { PostCheckoutPaymentResponseBody };
 
 async function handler(
   req: NextApiRequest,
@@ -67,17 +46,6 @@ async function handler(
         });
       }
 
-      const useMetronomeBilling = await isMetronomeBillingEnabled(auth);
-      if (!useMetronomeBilling) {
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "workspace_auth_error",
-            message: "Metronome billing is not enabled for this workspace.",
-          },
-        });
-      }
-
       const bodyValidation = BodySchema.safeParse(req.body);
       if (!bodyValidation.success) {
         return apiError(req, res, {
@@ -90,263 +58,78 @@ async function handler(
       }
 
       const { setupSessionId } = bodyValidation.data;
-      const owner = auth.getNonNullableWorkspace();
-
-      // Idempotency guard: provisioning already completed.
-      const workspace = await WorkspaceResource.fetchById(owner.sId);
-      if (workspace) {
-        const activeSubscription =
-          await SubscriptionResource.fetchActiveByWorkspaceModelId(
-            workspace.id
-          );
-        if (activeSubscription?.metronomeContractId) {
-          return res.status(200).json({ success: true });
-        }
+      const result = await processCheckoutPayment(auth, setupSessionId);
+      if (result.isErr()) {
+        return mapCheckoutPaymentError(req, res, result.error);
       }
 
-      const stripe = getStripeClient();
-      const setupSession = await stripe.checkout.sessions.retrieve(
-        setupSessionId,
-        {
-          expand: ["setup_intent", "setup_intent.payment_method"],
-        }
-      );
-
-      const setupIntent = setupSession.setup_intent;
-      if (
-        !setupIntent ||
-        isString(setupIntent) ||
-        setupIntent.status !== "succeeded"
-      ) {
-        return res.status(200).json({ error: "setup_failed" });
-      }
-      if (setupSession.client_reference_id !== owner.sId) {
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "workspace_auth_error",
-            message:
-              "Setup intent does not correspond to the current workspace.",
-          },
-        });
-      }
-
-      const {
-        billingPeriod,
-        seatCount: seatCountStr,
-        pricePerSeatCents: pricePerSeatCentsStr,
-      } = setupSession.metadata ?? {};
-
-      if (
-        !billingPeriod ||
-        !isString(seatCountStr) ||
-        !isString(pricePerSeatCentsStr)
-      ) {
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message:
-              "Setup session metadata is missing billingPeriod, seatCount or pricePerSeatCents.",
-          },
-        });
-      }
-
-      const seatCount = Number(seatCountStr);
-      const pricePerSeatCents = Number(pricePerSeatCentsStr);
-      const subtotalCents = seatCount * pricePerSeatCents;
-      const stripeCustomerId = setupSession.customer;
-
-      if (!isString(stripeCustomerId)) {
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: "Setup session is missing a customer ID.",
-          },
-        });
-      }
-
-      const rawPaymentMethod = setupIntent.payment_method;
-      const paymentMethodId =
-        rawPaymentMethod === null
-          ? null
-          : isString(rawPaymentMethod)
-            ? rawPaymentMethod
-            : rawPaymentMethod.id;
-
-      if (!paymentMethodId) {
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: "Setup intent is missing a payment method.",
-          },
-        });
-      }
-
-      const shouldEnforceFirstPeriodPayment =
-        rawPaymentMethod !== null &&
-        !isString(rawPaymentMethod) &&
-        rawPaymentMethod.type === "card";
-
-      const customer = await stripe.customers.retrieve(stripeCustomerId);
-      if (customer.deleted) {
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: "Stripe customer has been deleted.",
-          },
-        });
-      }
-      const country = customer.address?.country ?? "US";
-      const currency = getBillingCurrencyForCountry(country, true);
-
-      // Coupon: validate + create pending redemption before charging.
-      const couponCode = setupSession.metadata?.couponCode;
-      let coupon: CouponResource | undefined;
-      let pendingRedemption: CouponRedemptionResource | undefined;
-
-      if (couponCode) {
-        const found = await CouponResource.findByCode(couponCode);
-        if (!found) {
-          return res.status(200).json({ error: "invalid_coupon" });
-        }
-        const validation = found.validateRedemption();
-        if (validation.isErr()) {
-          return res.status(200).json({ error: "invalid_coupon" });
-        }
-        const existing =
-          await CouponRedemptionResource.findActiveOrPendingByCouponAndWorkspace(
-            auth,
-            { coupon: found }
-          );
-        if (existing) {
-          return res.status(200).json({ error: "invalid_coupon" });
-        }
-        const pendingResult = await CouponRedemptionResource.createPending(
-          auth,
-          { coupon: found }
-        );
-        if (pendingResult.isErr()) {
-          logger.error(
-            {
-              workspaceId: owner.sId,
-              couponCode,
-              error: pendingResult.error.message,
-            },
-            "[Checkout] Failed to create pending coupon redemption"
-          );
-          return res.status(200).json({ error: "invalid_coupon" });
-        }
-        pendingRedemption = pendingResult.value;
-        coupon = found;
-      }
-
-      const couponAmountCents = coupon ? coupon.amount * 100 : 0;
-      const effectiveSubtotalCents = Math.max(
-        0,
-        subtotalCents - couponAmountCents
-      );
-
-      const user = auth.getNonNullableUser();
-      const planCode = setupSession.metadata?.planCode ?? "";
-      const metronomePackageAlias =
-        setupSession.metadata?.metronomePackageAlias ?? "";
-
-      // Set the payment method as the customer's Stripe default
-      // for future Metronome-generated invoices (month 2+).
-      const setDefaultPaymentMethodResult =
-        await setStripeCustomerDefaultPaymentMethod({
-          stripeCustomerId,
-          paymentMethodId,
-          workspaceId: owner.sId,
-        });
-      if (setDefaultPaymentMethodResult.isErr()) {
-        if (pendingRedemption && coupon) {
-          const rollbackResult = await pendingRedemption.rollback(coupon);
-          if (rollbackResult.isErr()) {
-            logger.error(
-              {
-                err: rollbackResult.error,
-                workspaceId: owner.sId,
-              },
-              "[Checkout] Failed to rollback coupon redemption after setDefaultPaymentMethod failure"
-            );
-          }
-        }
-        return res.status(200).json({ error: "payment_failed" });
-      }
-
-      if (shouldEnforceFirstPeriodPayment && effectiveSubtotalCents > 0) {
-        const chargeResult = await chargeFirstPeriodInvoice({
-          stripeCustomerId,
-          paymentMethodId,
-          billingPeriod,
-          pricePerSeatCents,
-          couponAmountCents,
-          seatCount,
-          setupSessionId,
-          workspaceId: owner.sId,
-          currency,
-          couponCode,
-        });
-        if (chargeResult.isErr()) {
-          if (pendingRedemption && coupon) {
-            const rollbackResult = await pendingRedemption.rollback(coupon);
-            if (rollbackResult.isErr()) {
-              logger.error(
-                { err: rollbackResult.error, workspaceId: owner.sId },
-                "[Checkout] Failed to rollback coupon redemption after chargeFirstPeriodInvoice failure"
-              );
-            }
-          }
-          return res.status(200).json({ error: "payment_failed" });
-        }
-      }
-
-      const provisionResult = await provisionMetronomeFirstPeriodSubscription({
-        stripeCustomerId,
-        currency,
-        workspaceId: owner.sId,
-        userId: user.sId,
-        planCode,
-        metronomePackageAlias,
-        coupon,
-        pendingRedemption,
-        firstPeriodPaymentEnforced: shouldEnforceFirstPeriodPayment,
-        firstPeriodPaymentCents: effectiveSubtotalCents,
-        uniquenessKey: setupSessionId,
-        now: new Date(),
-      });
-
-      if (provisionResult.isErr()) {
-        logger.error(
-          {
-            panic: true,
-            error: normalizeError(provisionResult.error).message,
-            stripeCustomerId,
-            currency,
-            workspaceId: owner.sId,
-            userId: user.sId,
-            planCode,
-            metronomePackageAlias,
-            couponId: coupon?.sId,
-            pendingRedemptionId: pendingRedemption?.sId,
-            firstPeriodPaymentEnforced: shouldEnforceFirstPeriodPayment,
-            firstPeriodPaymentCents: effectiveSubtotalCents,
-            uniquenessKey: setupSessionId,
-          },
-          "[Checkout] Payment succeeded but Metronome provisioning failed"
-        );
-        return res.status(500).json({ error: "metronome_error" });
-      }
-
-      return res.status(200).json({ success: true });
+      return res.status(200).json(result.value);
     },
     { endpoint: req.url ?? null }
   );
+}
+
+function mapCheckoutPaymentError(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PostCheckoutPaymentResponseBody>>,
+  error: CheckoutPaymentError
+): void {
+  switch (error.type) {
+    case "metronome_not_enabled":
+      return apiError(req, res, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message: "Metronome billing is not enabled for this workspace.",
+        },
+      });
+    case "workspace_mismatch":
+      return apiError(req, res, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message: "Setup intent does not correspond to the current workspace.",
+        },
+      });
+    case "missing_metadata":
+      return apiError(req, res, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message:
+            "Setup session metadata is missing billingPeriod, seatCount or pricePerSeatCents.",
+        },
+      });
+    case "missing_customer_id":
+      return apiError(req, res, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Setup session is missing a customer ID.",
+        },
+      });
+    case "missing_payment_method":
+      return apiError(req, res, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Setup intent is missing a payment method.",
+        },
+      });
+    case "customer_deleted":
+      return apiError(req, res, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Stripe customer has been deleted.",
+        },
+      });
+    case "metronome_provisioning_failed":
+      res.status(500).json({ error: "metronome_error" });
+      return;
+    default:
+      assertNever(error);
+  }
 }
 
 export default withSessionAuthenticationForWorkspace(handler, {

--- a/front/pages/api/w/[wId]/subscriptions/checkout/prepare-payment.ts
+++ b/front/pages/api/w/[wId]/subscriptions/checkout/prepare-payment.ts
@@ -14,8 +14,6 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export type { GetPreparePaymentResponseBody };
-
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<GetPreparePaymentResponseBody>>,

--- a/front/pages/api/w/[wId]/subscriptions/checkout/prepare-payment.ts
+++ b/front/pages/api/w/[wId]/subscriptions/checkout/prepare-payment.ts
@@ -1,34 +1,20 @@
 // @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
+
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { getStripeCheckoutSessionStatus } from "@app/lib/api/stripe/checkout_status";
-import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
+import {
+  type GetPreparePaymentResponseBody,
+  getPreparePaymentData,
+  type PreparePaymentError,
+} from "@app/lib/api/checkout/prepare_payment";
 import type { Authenticator } from "@app/lib/auth";
-import { getBillingCurrencyForCountry } from "@app/lib/plans/billing_currency";
-import { calculateTax, getStripeClient } from "@app/lib/plans/stripe";
-import { CouponResource } from "@app/lib/resources/coupon_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { SupportedCurrency } from "@app/types/currency";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export type GetPreparePaymentResponseBody =
-  | { status: "pending" }
-  | {
-      status: "success";
-      subtotalCents: number;
-      taxCents: number;
-      totalCents: number;
-      seatCount: number;
-      pricePerSeatCents: number;
-      planCode: string;
-      metronomePackageAlias: string;
-      currency: SupportedCurrency;
-      cardBrand?: string;
-      cardLast4?: string;
-      sepaLast4?: string;
-    };
+export type { GetPreparePaymentResponseBody };
 
 async function handler(
   req: NextApiRequest,
@@ -55,21 +41,6 @@ async function handler(
       },
     });
   }
-  const owner = auth.getNonNullableWorkspace();
-
-  const useMetronomeBilling = await isMetronomeBillingEnabled(auth);
-  if (!useMetronomeBilling) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message: "Metronome billing is not enabled for this workspace.",
-      },
-    });
-  }
-
-  // Prevent HTTP caching as session status can change on every call.
-  res.setHeader("Cache-Control", "no-store");
 
   const { setup_session_id } = req.query;
   if (!isString(setup_session_id)) {
@@ -82,145 +53,83 @@ async function handler(
     });
   }
 
-  // onComplete fires on the client before Stripe marks the session complete server-side.
-  // We return "pending" so the client can retry instead of blocking here.
-  const sessionStatus = await getStripeCheckoutSessionStatus(setup_session_id);
-  if (sessionStatus?.status !== "complete") {
-    return res.status(200).json({ status: "pending" });
+  // Prevent HTTP caching as session status can change on every call.
+  res.setHeader("Cache-Control", "no-store");
+
+  const result = await getPreparePaymentData(auth, setup_session_id);
+  if (result.isErr()) {
+    return mapPreparePaymentError(req, res, result.error);
   }
 
-  const stripe = getStripeClient();
-  const setupSession = await stripe.checkout.sessions.retrieve(
-    setup_session_id,
-    { expand: ["setup_intent", "setup_intent.payment_method"] }
-  );
+  return res.status(200).json(result.value);
+}
 
-  const setupIntent = setupSession.setup_intent;
-  if (
-    !setupIntent ||
-    isString(setupIntent) ||
-    setupIntent.status !== "succeeded"
-  ) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Setup session has not completed successfully.",
-      },
-    });
+function mapPreparePaymentError(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetPreparePaymentResponseBody>>,
+  error: PreparePaymentError
+): void {
+  switch (error.type) {
+    case "metronome_not_enabled":
+      return apiError(req, res, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message: "Metronome billing is not enabled for this workspace.",
+        },
+      });
+    case "setup_not_succeeded":
+      return apiError(req, res, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Setup session has not completed successfully.",
+        },
+      });
+    case "workspace_mismatch":
+      return apiError(req, res, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message: "Setup intent does not correspond to the current workspace.",
+        },
+      });
+    case "missing_metadata":
+      return apiError(req, res, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message:
+            "Setup session metadata is missing seatCount or pricePerSeatCents.",
+        },
+      });
+    case "missing_customer_id":
+      return apiError(req, res, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Setup session is missing a customer ID.",
+        },
+      });
+    case "customer_deleted":
+      return apiError(req, res, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Stripe customer has been deleted.",
+        },
+      });
+    case "tax_calculation_failed":
+      return apiError(req, res, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: error.message,
+        },
+      });
+    default:
+      assertNever(error);
   }
-  if (setupSession.client_reference_id !== owner.sId) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message: "Setup intent does not correspond to the current workspace.",
-      },
-    });
-  }
-
-  const { seatCount: seatCountStr, pricePerSeatCents: pricePerSeatCentsStr } =
-    setupSession.metadata ?? {};
-
-  if (!isString(seatCountStr) || !isString(pricePerSeatCentsStr)) {
-    return apiError(req, res, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message:
-          "Setup session metadata is missing seatCount or pricePerSeatCents.",
-      },
-    });
-  }
-
-  const seatCount = Number(seatCountStr);
-  const pricePerSeatCents = Number(pricePerSeatCentsStr);
-  const subtotalCents = seatCount * pricePerSeatCents;
-  const stripeCustomerId = setupSession.customer;
-
-  if (!isString(stripeCustomerId)) {
-    return apiError(req, res, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Setup session is missing a customer ID.",
-      },
-    });
-  }
-
-  const planCode = setupSession.metadata?.planCode ?? "";
-  const metronomePackageAlias =
-    setupSession.metadata?.metronomePackageAlias ?? "";
-
-  const rawPaymentMethod = setupIntent.payment_method;
-  let cardBrand: string | undefined;
-  let cardLast4: string | undefined;
-  let sepaLast4: string | undefined;
-  if (rawPaymentMethod && !isString(rawPaymentMethod)) {
-    if (rawPaymentMethod.card) {
-      cardBrand = rawPaymentMethod.card.brand;
-      cardLast4 = rawPaymentMethod.card.last4;
-    } else if (rawPaymentMethod.sepa_debit) {
-      sepaLast4 = rawPaymentMethod.sepa_debit.last4 ?? undefined;
-    }
-  }
-
-  const customer = await stripe.customers.retrieve(stripeCustomerId);
-  if (customer.deleted) {
-    return apiError(req, res, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Stripe customer has been deleted.",
-      },
-    });
-  }
-  const country = customer.address?.country ?? "US";
-  const currency = getBillingCurrencyForCountry(country, true);
-
-  // Apply coupon discount to the tax base if a coupon was stored in session metadata.
-  // No validation here — enforcement happens in POST /payment.
-  const couponCode = setupSession.metadata?.couponCode;
-  let discountedSubtotalCents = subtotalCents;
-  if (couponCode) {
-    const coupon = await CouponResource.findByCode(couponCode);
-    if (coupon) {
-      discountedSubtotalCents = Math.max(
-        0,
-        subtotalCents - coupon.amount * 100
-      );
-    }
-  }
-
-  const taxResult = await calculateTax({
-    stripeCustomerId,
-    amountCents: discountedSubtotalCents,
-    currency,
-  });
-  if (taxResult.isErr()) {
-    return apiError(req, res, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: taxResult.error.error_message,
-      },
-    });
-  }
-
-  return res.status(200).json({
-    status: "success",
-    subtotalCents,
-    taxCents: taxResult.value.taxCents,
-    totalCents: taxResult.value.totalCents,
-    seatCount,
-    pricePerSeatCents,
-    planCode,
-    metronomePackageAlias,
-    currency,
-    cardBrand,
-    cardLast4,
-    sepaLast4,
-  });
 }
 
 export default withSessionAuthenticationForWorkspace(handler, {


### PR DESCRIPTION
## Description

Move logic for prepare-payment and payment to lib/api/checkout to avoid duplicated coded for front-api
* Both Next.js and Hono handlers now share a single implementation — auth checks, request validation, and HTTP mapping stay in each handler; everything else lives in the lib
* Moves the shared response types (GetPreparePaymentResponseBody, PostCheckoutPaymentResponseBody) to the lib; SWR hooks import from there directly

## Tests

Tested locally

## Risk

Low, those endpoints are still not used (behind metronome billing feature flag)

## Deploy Plan

Deploy front