### PR TITLE
feat: add usage page in user settings

### DIFF
--- a/front-api/routes/w/[wId]/credits/index.ts
+++ b/front-api/routes/w/[wId]/credits/index.ts
@@ -13,6 +13,7 @@ import awuPoolSummary from "./awu-pool-summary";
 import membersSeats from "./members-seats";
 import membersUsage from "./members-usage";
 import metronomeBalances from "./metronome-balances";
+import myUsage from "./my-usage";
 import purchase from "./purchase";
 import usageConfiguration from "./usage-configuration";
 
@@ -23,6 +24,7 @@ app.route("/awu-pool-summary", awuPoolSummary);
 app.route("/members-seats", membersSeats);
 app.route("/members-usage", membersUsage);
 app.route("/metronome-balances", metronomeBalances);
+app.route("/my-usage", myUsage);
 app.route("/purchase", purchase);
 app.route("/usage-configuration", usageConfiguration);
 

--- a/front-api/routes/w/[wId]/credits/my-usage.ts
+++ b/front-api/routes/w/[wId]/credits/my-usage.ts
@@ -1,0 +1,16 @@
+import type { GetMemberUsageResponseBody } from "@app/lib/api/credits/members_usage";
+import { getMemberUsage } from "@app/lib/api/credits/members_usage";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+
+// Mounted at /api/w/:wId/credits/my-usage.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get("/", async (ctx): HandlerResult<GetMemberUsageResponseBody> => {
+  const auth = ctx.get("auth");
+  const body = await getMemberUsage({ auth });
+  return ctx.json(body);
+});
+
+export default app;

--- a/front/components/UserSettingsPopover.tsx
+++ b/front/components/UserSettingsPopover.tsx
@@ -5,7 +5,14 @@ import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useIsMac } from "@app/hooks/useKeyboardShortcutLabel";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { isSubmitMessageKey } from "@app/lib/keymaps";
+import {
+  useAwuPoolSummary,
+  useCreditPurchaseInfo,
+  useMyUsage,
+  useSeatPlan,
+} from "@app/lib/swr/credits";
 import { usePatchUser, useUser } from "@app/lib/swr/user";
 import type { WorkspaceType } from "@app/types/user";
 import { ANONYMOUS_USER_IMAGE_URL } from "@app/types/user";
@@ -27,7 +34,6 @@ import {
   Edit04,
   Input,
   Label,
-  LinkExternal01,
   Moon01,
   NavigationList,
   NavigationListItem,
@@ -46,6 +52,8 @@ import {
   Zap,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { ExternalLinkIcon } from "lucide-react";
+import type React from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useController, useForm } from "react-hook-form";
 import { z } from "zod";
@@ -104,33 +112,56 @@ function SectionContent({
 
 // ─── Usage ────────────────────────────────────────────────────────────────────
 
-function CreditRow({
-  label,
-  description,
-}: {
-  label: string;
-  description: string;
-}) {
-  return (
-    <div className="flex items-center justify-between">
-      <div className="flex flex-col gap-0.5">
-        <span className="flex items-center gap-1">
-          <span className="text-sm font-medium text-foreground dark:text-foreground-night">
-            {label}
-          </span>
-        </span>
-        <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-          {description}
-        </span>
-      </div>
-      <span className="flex items-center gap-1 text-xs text-muted-foreground opacity-90 dark:text-muted-foreground-night">
-        10000/<span className="font-medium">10000</span>
-      </span>
-    </div>
-  );
+function formatCredits(credits: number): string {
+  return Math.round(credits).toLocaleString("en-US");
 }
 
-function UsageSection() {
+function ordinalDay(day: number): string {
+  const suffix =
+    day >= 11 && day <= 13
+      ? "th"
+      : day % 10 === 1
+        ? "st"
+        : day % 10 === 2
+          ? "nd"
+          : day % 10 === 3
+            ? "rd"
+            : "th";
+  return `${day}${suffix}`;
+}
+
+function UsageSection({ owner }: { owner: WorkspaceType }) {
+  const { isAdmin, subscription } = useAuth();
+  const { isCreditPurchaseInfoLoading, billingCycleStartDay } =
+    useCreditPurchaseInfo({
+      workspaceId: owner.sId,
+    });
+  const {
+    totalRemainingCredits,
+    totalActiveCredits,
+    overageCredits,
+    resetDate,
+    isAwuPoolSummaryLoading,
+    isAwuPoolSummaryError,
+  } = useAwuPoolSummary({ workspaceId: owner.sId });
+  const { myUsage, isMyUsageLoading } = useMyUsage({ workspaceId: owner.sId });
+  const { seatPlans } = useSeatPlan({ workspaceId: owner.sId });
+
+  const seatName =
+    (myUsage?.seatType ? seatPlans[myUsage.seatType]?.name : null) ??
+    subscription.plan.name;
+
+  const isLoading =
+    isAwuPoolSummaryLoading || isCreditPurchaseInfoLoading || isMyUsageLoading;
+  const totalConsumedCredits = Math.max(
+    0,
+    totalActiveCredits - totalRemainingCredits
+  );
+  const consumedPercentage =
+    totalActiveCredits > 0
+      ? Math.min((totalConsumedCredits / totalActiveCredits) * 100, 100)
+      : 0;
+
   return (
     <SectionContent
       title="Usage"
@@ -143,44 +174,108 @@ function UsageSection() {
               <Stars02 className="h-3 w-3 text-highlight-500" />
             </span>
             <span className="text-base font-semibold text-foreground dark:text-foreground-night">
-              Pro plan
+              {seatName}
             </span>
           </span>
-          <Button variant="primary" size="xs" label="Request for upgrade" />
+          {isAdmin && (
+            <Button
+              variant="primary"
+              size="xs"
+              label="Request for upgrade"
+              href={`/w/${owner.sId}/usage`}
+            />
+          )}
         </div>
         <Separator />
-        <div className="flex flex-col gap-4">
-          <CreditRow
-            label="Personal Credit"
-            description="Every 14th of the months"
-          />
-          <CreditRow
-            label="Workspace Credit"
-            description="Your access to your Workspace credit pools"
-          />
-        </div>
-        <Separator />
-        <p className="cursor-pointer text-center text-xs text-muted-foreground underline dark:text-muted-foreground-night">
-          Request more credit
-        </p>
+        {isLoading ? (
+          <div className="flex justify-center py-2">
+            <Spinner size="sm" />
+          </div>
+        ) : isAwuPoolSummaryError ? (
+          <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            Failed to load credits data.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium text-foreground dark:text-foreground-night">
+                Workspace Credits Pool
+              </span>
+              <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
+                {formatCredits(totalConsumedCredits)} /{" "}
+                {formatCredits(totalActiveCredits)}
+              </span>
+            </div>
+            <div className="h-2 w-full overflow-hidden rounded-full bg-muted-foreground/10 dark:bg-muted-foreground-night/10">
+              <div
+                className="h-full bg-highlight transition-all dark:bg-highlight-night"
+                style={{ width: `${consumedPercentage}%` }}
+              />
+            </div>
+            <div className="flex items-center justify-between text-xs text-muted-foreground dark:text-muted-foreground-night">
+              {overageCredits !== null && overageCredits > 0 ? (
+                <span>{formatCredits(overageCredits)} overage credits</span>
+              ) : (
+                <span />
+              )}
+              {resetDate && (
+                <span>
+                  Resets{" "}
+                  {new Date(resetDate).toLocaleDateString(undefined, {
+                    month: "short",
+                    day: "numeric",
+                  })}
+                </span>
+              )}
+            </div>
+            {myUsage && myUsage.memberUsageLimit !== null && (
+              <>
+                <Separator />
+                <div className="flex items-center justify-between">
+                  <div className="flex flex-col gap-0.5">
+                    <span className="flex items-center gap-1.5 text-sm font-medium text-foreground dark:text-foreground-night">
+                      <User01 className="h-3.5 w-3.5" />
+                      Personal Credit
+                    </span>
+                    {billingCycleStartDay !== null && (
+                      <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                        Every {ordinalDay(billingCycleStartDay)} of the month
+                      </span>
+                    )}
+                  </div>
+                  <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                    {formatCredits(myUsage.consumedFromAllowanceAwuCredits)}
+                    <span className="font-medium">
+                      /{formatCredits(myUsage.memberUsageLimit)}
+                    </span>
+                  </span>
+                </div>
+              </>
+            )}
+          </div>
+        )}
       </section>
 
-      <section className="flex items-center justify-between border-b border-border pb-4 dark:border-border-night">
-        <div className="flex flex-col gap-0.5">
-          <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
-            Invoices
-          </span>
-          <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-            Access and download your invoices
-          </span>
-        </div>
-        <Button
-          variant="outline"
-          size="xs"
-          label="Billing"
-          icon={LinkExternal01}
-        />
-      </section>
+      {isAdmin && (
+        <section className="flex items-center justify-between border-b border-border pb-4 dark:border-border-night">
+          <div className="flex flex-col gap-0.5">
+            <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
+              Invoices
+            </span>
+            <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              Access and download your invoices
+            </span>
+          </div>
+          <Button
+            variant="outline"
+            size="xs"
+            label="Billing"
+            icon={ExternalLinkIcon}
+            href={`/w/${owner.sId}/billing`}
+            target="_blank"
+          />
+        </section>
+      )}
     </SectionContent>
   );
 }
@@ -647,7 +742,7 @@ export function UserSettingsPopover({
             {activeSection === "personal" && (
               <PersonalInfoSection owner={owner} />
             )}
-            {activeSection === "usage" && <UsageSection />}
+            {activeSection === "usage" && <UsageSection owner={owner} />}
             {activeSection === "customization" && <CustomizationSection />}
             {activeSection === "notifications" && (
               <NotificationsSection owner={owner} />

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -545,6 +545,119 @@ export async function fetchRemainingCapCreditsPercentageForUser({
   return Math.max(0, (spendLimitAwuCredits - consumed) / spendLimitAwuCredits);
 }
 
+export type GetMemberUsageResponseBody = {
+  member: MemberUsageType | null;
+};
+
+export async function getMemberUsage({
+  auth,
+}: {
+  auth: Authenticator;
+}): Promise<GetMemberUsageResponseBody> {
+  const workspace = auth.getNonNullableWorkspace();
+  const subscription = auth.subscription();
+  const userResource = auth.user();
+
+  if (!userResource) {
+    return { member: null };
+  }
+
+  const { metronomeCustomerId } = workspace;
+  const metronomeContractId = subscription?.metronomeContractId ?? null;
+  const userId = userResource.sId;
+
+  const [
+    membershipsResult,
+    perUserTotalConsumedCredits,
+    seatDataByUserId,
+    perUserSpendLimits,
+  ] = await Promise.all([
+    MembershipResource.getActiveMemberships({
+      workspace,
+      users: [userResource],
+    }),
+    fetchPerUserUsageCreditsForMembersTable({
+      metronomeCustomerId: metronomeCustomerId ?? null,
+      metronomeContractId,
+      userIds: [userId],
+    }),
+    fetchSeatDataForMembersTable({
+      metronomeCustomerId: metronomeCustomerId ?? null,
+      metronomeContractId,
+    }),
+    fetchEffectivePerUserSpendLimits({
+      metronomeCustomerId: metronomeCustomerId ?? null,
+      workspaceId: workspace.sId,
+      includeAlertLinks: false,
+    }),
+  ]);
+
+  const { defaultAwuCreditsBySeatType, seatAllowanceBySeatType } =
+    perUserSpendLimits;
+  const { memberships } = membershipsResult;
+  const membership = memberships.find((m) => m.userId === userResource.id);
+
+  if (!membership) {
+    return { member: null };
+  }
+
+  const totalConsumedCredits = perUserTotalConsumedCredits.get(userId) ?? 0;
+  const seatData = seatDataByUserId.get(userId);
+  const awuAllocation = seatData?.awuAllocation ?? 0;
+
+  const consumedFromAllowanceAwuCredits = Math.min(
+    totalConsumedCredits,
+    awuAllocation
+  );
+  const consumedFromPoolAwuCredits =
+    totalConsumedCredits - consumedFromAllowanceAwuCredits;
+
+  const normalizedSeatType = normalizeToPoolLimitSeatType(membership.seatType);
+  const defaultCap = normalizedSeatType
+    ? (defaultAwuCreditsBySeatType[normalizedSeatType] ?? null)
+    : null;
+  const overrideAwuCredits =
+    membership.poolCapOverrideAwuCredits !== null
+      ? membership.poolCapOverrideAwuCredits +
+        (normalizedSeatType
+          ? (seatAllowanceBySeatType[normalizedSeatType] ?? 0)
+          : 0)
+      : null;
+
+  const spendLimitSource = resolveEffectiveSpendLimitSource({
+    overrideAwuCredits,
+    defaultAwuCredits: defaultCap?.threshold ?? null,
+  });
+
+  return {
+    member: {
+      sId: userId,
+      name: userResource.fullName() || userResource.name,
+      email: userResource.email ?? null,
+      image: userResource.imageUrl ?? null,
+      seatType: membership.seatType ?? null,
+      memberUsageLimit: awuAllocation > 0 ? awuAllocation : null,
+      seatBalanceAwu: null,
+      consumedAwuCredits: totalConsumedCredits,
+      consumedFromAllowanceAwuCredits,
+      consumedFromPoolAwuCredits,
+      billingFrequency:
+        seatData?.billingFrequency ??
+        deriveWorkspaceSeatBillingFrequency(membership.seatType ?? null),
+      scheduledSeatType: null,
+      scheduledSeatChangeAt: null,
+      spendLimitAwuCredits: resolveEffectiveSpendLimitAwuCredits({
+        overrideAwuCredits,
+        defaultAwuCredits: defaultCap?.threshold ?? null,
+      }),
+      spendLimitSource,
+      spendLimitAlertId: null,
+      spendLimitWarningAlertId: null,
+      creditState: membership.creditState,
+    },
+  };
+}
+
 export async function getMembersUsage({
   auth,
   paginationParams,

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -1,5 +1,6 @@
 import type { AwuPoolSummaryResponseBody } from "@app/lib/api/credits/awu_pool_summary";
 import type { GetMembersSeatsResponseBody } from "@app/lib/api/credits/members_seats";
+import type { GetMemberUsageResponseBody } from "@app/lib/api/credits/members_usage";
 import type { GetCreditPurchaseInfoResponseBody } from "@app/lib/api/credits/purchase";
 import type { SeatPlanResponseBody } from "@app/lib/api/credits/seat_plan";
 import type { GetAwuPurchaseInfoResponseBody } from "@app/lib/credits/awu_purchase";
@@ -325,6 +326,29 @@ export function useAwuPurchaseInfo({
     isAwuPurchaseInfoValidating: isValidating,
     isAwuPurchaseInfoError: error,
     mutateAwuPurchaseInfo: mutate,
+  };
+}
+
+export function useMyUsage({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const myUsageFetcher: Fetcher<GetMemberUsageResponseBody> = fetcher;
+
+  const { data, error } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/credits/my-usage`,
+    myUsageFetcher,
+    { disabled }
+  );
+
+  return {
+    myUsage: data?.member ?? null,
+    isMyUsageLoading: !error && !data && !disabled,
+    isMyUsageError: error,
   };
 }
 


### PR DESCRIPTION
## Description

Adds a **Usage** tab to the user settings popover with two sections:

### Workspace Credits Pool
- Fetches AWU pool data via \`useAwuPoolSummary\` (total active, remaining, overage, reset date)
- Progress bar showing consumed vs. total credits
- Overage credits and next reset date displayed below the bar
- **Enterprise gate**: hides the \"Request for upgrade\" button for enterprise plans (via \`useCreditPurchaseInfo\`)
- **Admin gate**: Invoices / Billing link only shown to admins

### Personal Credit (new)
- New \`getMemberUsage\` function in \`lib/api/credits/members_usage.ts\` — single-user variant of \`getMembersUsage\` that fetches the authenticated user's per-seat AWU consumption, seat allocation, and spend limits
- New \`GET /api/w/:wId/credits/my-usage\` endpoint (no admin check — available to all workspace members)
- New \`useMyUsage\` SWR hook in \`lib/swr/credits.ts\`
- Renders a \"Personal Credit\" row inside the section when the user has a personal seat allocation (\`memberUsageLimit !== null\`); hidden for pool-based seats
- Shows consumed-from-allowance / total-allowance with reset day label (\"Every Nth of the month\" using \`billingCycleStartDay\`)

## Tests

Manually verified: workspace credits pool renders with real data, personal credit row appears for seat-based users and is hidden for pool-based users.

## Risk

Low — read-only UI and API changes. The new endpoint returns data already computed server-side by \`getMembersUsage\`; it reuses the same caches.

## Deploy Plan

No special deployment steps required.