### PR TITLE
Handle per_user_cap_warning event to transition states

### DIFF
--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -218,6 +218,53 @@ export async function dispatchPerUserCapReached({
   return new Ok(undefined);
 }
 
+export async function dispatchPerUserCapWarning({
+  workspace,
+  userId,
+}: {
+  workspace: WorkspaceResource;
+  userId: string;
+}): Promise<void> {
+  const user = await UserResource.fetchById(userId);
+  if (!user) {
+    logger.warn(
+      { workspaceId: workspace.sId, userId },
+      "[CreditStateDispatcher] per_user_cap_warning: user not found, skipping"
+    );
+    return;
+  }
+
+  const lightWorkspace = renderLightWorkspaceType({ workspace });
+  const membership =
+    await MembershipResource.getActiveMembershipOfUserInWorkspace({
+      user,
+      workspace: lightWorkspace,
+    });
+  if (!membership) {
+    logger.warn(
+      { workspaceId: workspace.sId, userId },
+      "[CreditStateDispatcher] per_user_cap_warning: no active membership, skipping"
+    );
+    return;
+  }
+
+  const result = await transitionUserCreditState(
+    membership,
+    { type: "per_user_cap_warning" },
+    { workspaceId: workspace.sId, userId }
+  );
+  if (result.isErr()) {
+    logger.warn(
+      {
+        workspaceId: workspace.sId,
+        userId,
+        creditState: membership.creditState,
+      },
+      "[CreditStateDispatcher] per_user_cap_warning: transition skipped"
+    );
+  }
+}
+
 export async function dispatchPerUserCapResolved({
   workspace,
   userId,

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -5,6 +5,7 @@ import {
   dispatchPaygCapReached,
   dispatchPerUserCapReached,
   dispatchPerUserCapResolved,
+  dispatchPerUserCapWarning,
   dispatchPoolExhausted,
   dispatchProgrammaticCapReached,
   dispatchProgrammaticCapReset,
@@ -728,6 +729,7 @@ async function handlePerUserSpendThresholdEvent({
   } else if (eventAlertId === warningAlertId && isReached) {
     // Warning alert (80%) fired — notify but don't block.
     void setUserAwuWarned(workspace.sId, userId);
+    void dispatchPerUserCapWarning({ workspace, userId });
     const user = await UserResource.fetchById(userId);
     if (user) {
       const lightWorkspace = renderLightWorkspaceType({ workspace });

--- a/front/lib/metronome/user_credit_state_machine.ts
+++ b/front/lib/metronome/user_credit_state_machine.ts
@@ -59,7 +59,13 @@ export type UserCreditEvent =
    * Only applies to pro/max seats (workspace seats have no individual seat
    * balance; free seats stay `capped`). Resets any state back to `user_seat`.
    */
-  | { type: "seat_balance_resolved" };
+  | { type: "seat_balance_resolved" }
+  /**
+   * User hit the 80% warning threshold of their admin-configured per-user
+   * spend cap. Moves `on_pool` → `on_pool_low_balance` to surface the
+   * low-balance warning without blocking the user.
+   */
+  | { type: "per_user_cap_warning" };
 
 type UserCreditGuard = (
   ctx: UserCreditContext,
@@ -182,6 +188,13 @@ const TRANSITIONS: UserCreditTransition[] = [
       event.threshold === 0.2 * PRO_SEAT_MONTHLY_AWU_CREDITS &&
       (ctx.seatType === "pro" || ctx.seatType === "pro_yearly"),
     to: "user_seat_low_balance",
+  },
+
+  // Per-user cap 80% warning: move on_pool → on_pool_low_balance.
+  {
+    from: ["on_pool", "on_pool_low_balance"],
+    event: "per_user_cap_warning",
+    to: "on_pool_low_balance",
   },
 
   // Billing-period renewal for pro/max seats: reset to user_seat regardless


### PR DESCRIPTION
## Description

When the 80% per-user spend cap warning alert fires from Metronome, the webhook handler was already setting the Redis warning flag via `setUserAwuWarned`, but the DB membership `creditState` was never updated to reflect `on_pool_low_balance`. This PR plugs that gap by calling the new `dispatchPerUserCapWarning` dispatcher (fire-and-forget) alongside the existing Redis call.

A new `per_user_cap_warning` event is added to the user credit state machine with a single transition: `on_pool` / `on_pool_low_balance` → `on_pool_low_balance`. This keeps the DB credit state in sync with the Redis warning flag without blocking the user.


## Risk

Low. The dispatcher is fire-and-forget (`void`) — a failure only produces a warning log and does not affect the existing Redis-based warning path. The `on_pool_low_balance` → `on_pool_low_balance` self-transition is idempotent.

## Deploy Plan

Deploy `front`.