### PR TITLE
Support targeted instruction edits in update_skill

### DIFF
--- a/front/lib/api/actions/servers/skill_authoring/metadata.ts
+++ b/front/lib/api/actions/servers/skill_authoring/metadata.ts
@@ -63,8 +63,10 @@ export const SKILL_AUTHORING_TOOLS_METADATA = createToolsRecord({
   [UPDATE_SKILL_TOOL_NAME]: {
     description:
       "Update an existing custom Skill by id. Provide only the fields that should change. " +
-      "To change the instructions you can either replace them wholesale with `instructions`, " +
+      "To change the instructions you can either replace them entirely with `instructions`, " +
       "or make a targeted edit with `old_string`/`new_string` (preferred for small changes). " +
+      "A targeted edit is an exact string replacement (not a regular expression) and replaces " +
+      "every occurrence of `old_string`; by default `old_string` must match exactly once. " +
       "These two modes are mutually exclusive.",
     schema: {
       sId: z.string().describe("The custom skill id to update."),
@@ -89,11 +91,11 @@ export const SKILL_AUTHORING_TOOLS_METADATA = createToolsRecord({
         .string()
         .optional()
         .describe(
-          "For a targeted edit of the instructions: the exact existing text to replace. " +
-            "Must match the current instructions exactly, including whitespace and line " +
-            "breaks. Include enough surrounding context to identify the text uniquely. " +
-            "Call `get_skill` first to read the current instructions. Cannot be combined " +
-            "with `instructions`."
+          "For a targeted edit of the instructions: the exact existing text to replace " +
+            "(literal text, not a regular expression). Must match the current instructions " +
+            "exactly, including whitespace and line breaks. Include enough surrounding context " +
+            "to identify the text uniquely. Call `get_skill` first to read the current " +
+            "instructions. Cannot be combined with `instructions`."
         ),
       new_string: z
         .string()

--- a/front/lib/api/actions/servers/skill_authoring/metadata.ts
+++ b/front/lib/api/actions/servers/skill_authoring/metadata.ts
@@ -62,7 +62,10 @@ export const SKILL_AUTHORING_TOOLS_METADATA = createToolsRecord({
   },
   [UPDATE_SKILL_TOOL_NAME]: {
     description:
-      "Update an existing custom Skill by id. Provide only the fields that should change.",
+      "Update an existing custom Skill by id. Provide only the fields that should change. " +
+      "To change the instructions you can either replace them wholesale with `instructions`, " +
+      "or make a targeted edit with `old_string`/`new_string` (preferred for small changes). " +
+      "These two modes are mutually exclusive.",
     schema: {
       sId: z.string().describe("The custom skill id to update."),
       name: z.string().optional().describe("New skill name."),
@@ -77,7 +80,37 @@ export const SKILL_AUTHORING_TOOLS_METADATA = createToolsRecord({
       instructions: z
         .string()
         .optional()
-        .describe("New skill instructions/playbook in markdown."),
+        .describe(
+          "New skill instructions/playbook in markdown. Replaces the instructions " +
+            "entirely. For small, targeted changes prefer `old_string`/`new_string`. " +
+            "Cannot be combined with `old_string`/`new_string`."
+        ),
+      old_string: z
+        .string()
+        .optional()
+        .describe(
+          "For a targeted edit of the instructions: the exact existing text to replace. " +
+            "Must match the current instructions exactly, including whitespace and line " +
+            "breaks. Include enough surrounding context to identify the text uniquely. " +
+            "Call `get_skill` first to read the current instructions. Cannot be combined " +
+            "with `instructions`."
+        ),
+      new_string: z
+        .string()
+        .optional()
+        .describe(
+          "The replacement text for `old_string`. Use an empty string to delete the " +
+            "matched text. Required when `old_string` is provided."
+        ),
+      expected_replacements: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe(
+          "Number of occurrences of `old_string` expected to be replaced. Defaults to 1. " +
+            "The edit fails if the actual count differs."
+        ),
       icon: z.string().optional().describe("New icon name."),
     },
     stake: "high",

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.test.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.test.ts
@@ -314,4 +314,193 @@ describe("skill_authoring tools", () => {
     );
     expect(skill?.icon).toBe("ActionListIcon");
   });
+
+  it("applies a targeted instructions edit with old_string/new_string", async () => {
+    const { authenticator } = await createResourceTest({ role: "builder" });
+
+    const createResult = await getTool(CREATE_SKILL_TOOL_NAME).handler(
+      {
+        name: "Targeted Edit Skill",
+        userFacingDescription: "Skill to edit.",
+        agentFacingDescription: "Use to verify targeted edits.",
+        instructions: "Collect impact, timeline, root cause, and follow-ups.",
+        icon: "ActionListIcon",
+      },
+      makeExtra(authenticator)
+    );
+    expect(createResult.isOk()).toBe(true);
+    if (createResult.isErr()) {
+      throw createResult.error;
+    }
+    const output = createResult.value[0];
+    if (!isSkillAuthoringResultOutput(output)) {
+      throw new Error("Expected structured skill authoring output.");
+    }
+
+    const updateResult = await getTool(UPDATE_SKILL_TOOL_NAME).handler(
+      {
+        sId: output.resource.skillId,
+        old_string: "follow-ups",
+        new_string: "owners",
+      },
+      makeExtra(authenticator)
+    );
+    expect(updateResult.isOk()).toBe(true);
+
+    const skill = await SkillResource.fetchById(
+      authenticator,
+      output.resource.skillId
+    );
+    expect(skill?.instructions).toBe(
+      "Collect impact, timeline, root cause, and owners."
+    );
+    expect(skill?.instructionsHtml).toContain("owners");
+  });
+
+  it("rejects an edit when old_string is not found", async () => {
+    const { authenticator } = await createResourceTest({ role: "builder" });
+
+    const createResult = await getTool(CREATE_SKILL_TOOL_NAME).handler(
+      {
+        name: "Missing Match Skill",
+        userFacingDescription: "Skill to edit.",
+        agentFacingDescription: "Use to verify missing matches.",
+        instructions: "Do the thing.",
+        icon: "ActionListIcon",
+      },
+      makeExtra(authenticator)
+    );
+    expect(createResult.isOk()).toBe(true);
+    if (createResult.isErr()) {
+      throw createResult.error;
+    }
+    const output = createResult.value[0];
+    if (!isSkillAuthoringResultOutput(output)) {
+      throw new Error("Expected structured skill authoring output.");
+    }
+
+    const updateResult = await getTool(UPDATE_SKILL_TOOL_NAME).handler(
+      {
+        sId: output.resource.skillId,
+        old_string: "not in the instructions",
+        new_string: "whatever",
+      },
+      makeExtra(authenticator)
+    );
+
+    expect(updateResult.isErr()).toBe(true);
+    if (updateResult.isOk()) {
+      throw new Error("Expected a missing old_string to be rejected.");
+    }
+    expect(updateResult.error.message).toContain("was not found");
+
+    // The instructions are left untouched.
+    const skill = await SkillResource.fetchById(
+      authenticator,
+      output.resource.skillId
+    );
+    expect(skill?.instructions).toBe("Do the thing.");
+  });
+
+  it("rejects an edit when the replacement count does not match", async () => {
+    const { authenticator } = await createResourceTest({ role: "builder" });
+
+    const createResult = await getTool(CREATE_SKILL_TOOL_NAME).handler(
+      {
+        name: "Multiple Match Skill",
+        userFacingDescription: "Skill to edit.",
+        agentFacingDescription: "Use to verify count mismatches.",
+        instructions: "step. step. step.",
+        icon: "ActionListIcon",
+      },
+      makeExtra(authenticator)
+    );
+    expect(createResult.isOk()).toBe(true);
+    if (createResult.isErr()) {
+      throw createResult.error;
+    }
+    const output = createResult.value[0];
+    if (!isSkillAuthoringResultOutput(output)) {
+      throw new Error("Expected structured skill authoring output.");
+    }
+
+    const updateResult = await getTool(UPDATE_SKILL_TOOL_NAME).handler(
+      {
+        sId: output.resource.skillId,
+        old_string: "step",
+        new_string: "phase",
+      },
+      makeExtra(authenticator)
+    );
+
+    expect(updateResult.isErr()).toBe(true);
+    if (updateResult.isOk()) {
+      throw new Error("Expected a count mismatch to be rejected.");
+    }
+    expect(updateResult.error.message).toContain("matched 3 times");
+
+    // Passing the right expected_replacements lets the edit through.
+    const retryResult = await getTool(UPDATE_SKILL_TOOL_NAME).handler(
+      {
+        sId: output.resource.skillId,
+        old_string: "step",
+        new_string: "phase",
+        expected_replacements: 3,
+      },
+      makeExtra(authenticator)
+    );
+    expect(retryResult.isOk()).toBe(true);
+
+    const skill = await SkillResource.fetchById(
+      authenticator,
+      output.resource.skillId
+    );
+    expect(skill?.instructions).toBe("phase. phase. phase.");
+  });
+
+  it("rejects combining a full instructions replace with a targeted edit", async () => {
+    const { authenticator } = await createResourceTest({ role: "builder" });
+
+    const createResult = await getTool(CREATE_SKILL_TOOL_NAME).handler(
+      {
+        name: "Conflicting Modes Skill",
+        userFacingDescription: "Skill to edit.",
+        agentFacingDescription: "Use to verify mutually exclusive modes.",
+        instructions: "Original instructions.",
+        icon: "ActionListIcon",
+      },
+      makeExtra(authenticator)
+    );
+    expect(createResult.isOk()).toBe(true);
+    if (createResult.isErr()) {
+      throw createResult.error;
+    }
+    const output = createResult.value[0];
+    if (!isSkillAuthoringResultOutput(output)) {
+      throw new Error("Expected structured skill authoring output.");
+    }
+
+    const updateResult = await getTool(UPDATE_SKILL_TOOL_NAME).handler(
+      {
+        sId: output.resource.skillId,
+        instructions: "Brand new instructions.",
+        old_string: "Original",
+        new_string: "Updated",
+      },
+      makeExtra(authenticator)
+    );
+
+    expect(updateResult.isErr()).toBe(true);
+    if (updateResult.isOk()) {
+      throw new Error("Expected conflicting modes to be rejected.");
+    }
+    expect(updateResult.error.message).toContain("not both");
+
+    // Nothing changed.
+    const skill = await SkillResource.fetchById(
+      authenticator,
+      output.resource.skillId
+    );
+    expect(skill?.instructions).toBe("Original instructions.");
+  });
 });

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.ts
@@ -306,9 +306,7 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
 
     // Resolve the new instructions: undefined keeps the existing ones, a full
     // string replaces them, and a targeted edit applies a str-replace on the
-    // current instructions (mirroring the Files MCP edit pattern). Unlike
-    // editClientExecutableFile, we don't take an edit lock: a skill is a single
-    // builder-driven row, so the read-modify-write contention isn't a concern.
+    // current instructions (mirroring the Files MCP edit pattern).
     let resolvedInstructions: string | undefined = instructions;
     // The `old_string !== undefined` check only narrows the type; both halves
     // are already guaranteed non-undefined by the validation above.

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.ts
@@ -306,8 +306,12 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
 
     // Resolve the new instructions: undefined keeps the existing ones, a full
     // string replaces them, and a targeted edit applies a str-replace on the
-    // current instructions (mirroring the Files MCP edit pattern).
+    // current instructions (mirroring the Files MCP edit pattern). Unlike
+    // editClientExecutableFile, we don't take an edit lock: a skill is a single
+    // builder-driven row, so the read-modify-write contention isn't a concern.
     let resolvedInstructions: string | undefined = instructions;
+    // The `old_string !== undefined` check only narrows the type; both halves
+    // are already guaranteed non-undefined by the validation above.
     if (isTargetedInstructionsEdit && old_string !== undefined) {
       const { updatedContent, occurrences } = getUpdatedContentAndOccurrences({
         oldString: old_string,

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.ts
@@ -13,6 +13,7 @@ import {
   UPDATE_SKILL_TOOL_NAME,
 } from "@app/lib/api/actions/servers/skill_authoring/metadata";
 import { makeSkillAuthoringResultOutput } from "@app/lib/api/actions/servers/skill_authoring/rendering";
+import { getUpdatedContentAndOccurrences } from "@app/lib/api/files/utils";
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { convertMarkdownToBlockHtml } from "@app/lib/reinforcement/skill_instructions_html";
@@ -232,6 +233,9 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
       agentFacingDescription,
       icon,
       instructions,
+      old_string,
+      new_string,
+      expected_replacements,
       userFacingDescription,
       name,
       sId,
@@ -248,14 +252,39 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
       return new Err(customSkillId.error);
     }
 
+    const isTargetedInstructionsEdit =
+      old_string !== undefined || new_string !== undefined;
+
     if (
       agentFacingDescription === undefined &&
       icon === undefined &&
       instructions === undefined &&
+      !isTargetedInstructionsEdit &&
       name === undefined &&
       userFacingDescription === undefined
     ) {
       return new Err(new MCPError("No skill updates were provided."));
+    }
+
+    if (isTargetedInstructionsEdit && instructions !== undefined) {
+      return new Err(
+        new MCPError(
+          "Provide either `instructions` (full replace) or `old_string`/" +
+            "`new_string` (targeted edit), not both."
+        )
+      );
+    }
+
+    if (
+      isTargetedInstructionsEdit &&
+      (old_string === undefined || new_string === undefined)
+    ) {
+      return new Err(
+        new MCPError(
+          "A targeted instructions edit requires both `old_string` and " +
+            "`new_string`."
+        )
+      );
     }
 
     if (icon !== undefined && !isValidSkillIcon(icon)) {
@@ -273,6 +302,40 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
 
     if (!skill.canWrite(auth)) {
       return new Err(new MCPError("Skill not found."));
+    }
+
+    // Resolve the new instructions: undefined keeps the existing ones, a full
+    // string replaces them, and a targeted edit applies a str-replace on the
+    // current instructions (mirroring the Files MCP edit pattern).
+    let resolvedInstructions: string | undefined = instructions;
+    if (isTargetedInstructionsEdit && old_string !== undefined) {
+      const { updatedContent, occurrences } = getUpdatedContentAndOccurrences({
+        oldString: old_string,
+        newString: new_string ?? "",
+        currentContent: skill.instructions,
+      });
+
+      if (occurrences === 0) {
+        return new Err(
+          new MCPError(
+            `\`old_string\` was not found in the skill instructions: "${old_string}".`
+          )
+        );
+      }
+
+      const expected = expected_replacements ?? 1;
+      if (occurrences !== expected) {
+        return new Err(
+          new MCPError(
+            `Expected ${expected} replacement${expected === 1 ? "" : "s"}, but ` +
+              `\`old_string\` matched ${occurrences} time${occurrences === 1 ? "" : "s"}. ` +
+              "Add more surrounding context to target a single occurrence, or set " +
+              "`expected_replacements`."
+          )
+        );
+      }
+
+      resolvedInstructions = updatedContent;
     }
 
     const trimmedName = name !== undefined ? name.trim() : skill.name;
@@ -300,10 +363,10 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
         agentFacingDescription ?? skill.agentFacingDescription,
       attachedKnowledge,
       icon: icon !== undefined ? icon : skill.icon,
-      instructions: instructions ?? skill.instructions,
+      instructions: resolvedInstructions ?? skill.instructions,
       instructionsHtml:
-        instructions !== undefined
-          ? convertMarkdownToBlockHtml(instructions)
+        resolvedInstructions !== undefined
+          ? convertMarkdownToBlockHtml(resolvedInstructions)
           : skill.instructionsHtml,
       mcpServerViews: skill.mcpServerViews,
       name: trimmedName,


### PR DESCRIPTION
## Description

`update_skill` required passing the entire instructions string to change anything, which is awkward when an agent just wants to tweak a line. Add a targeted-edit mode (`old_string` / `new_string` / `expected_replacements`) alongside the existing full-replace `instructions` field. The two modes are mutually exclusive.

Reuses `getUpdatedContentAndOccurrences` from the Files MCP server (`lib/api/files/utils.ts`), the same str-replace helper behind `edit_interactive_content_file`, so behavior matches the file edit pattern: error on no match, error on count mismatch.

## Tests

Added unit tests for the new mode: successful edit, no-match rejection, count mismatch (plus retry with `expected_replacements`), and the mutually-exclusive guard.

## Risk

Low. Additive params on an existing tool; the full-replace path is unchanged.

## Deploy Plan

Standard deploy.