### PR TITLE
Use parent agent name

### DIFF
--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -218,6 +218,7 @@ export function buildLlmUsageEvents({
   userId,
   agentMessageId,
   agentId,
+  subAgentId,
   parentAgentMessageId,
   runKey,
   runUsages,
@@ -235,6 +236,7 @@ export function buildLlmUsageEvents({
   userId: string | null;
   agentMessageId: string;
   agentId: string | null;
+  subAgentId: string | null;
   parentAgentMessageId: string | null;
   runKey: string;
   runUsages: RunUsageType[];
@@ -295,6 +297,7 @@ export function buildLlmUsageEvents({
       agent_message_id: agentMessageId,
       conversation_id: conversationId,
       agent_id: agentId ?? "unknown",
+      sub_agent_id: subAgentId ?? "none",
       parent_agent_message_id: parentAgentMessageId ?? "none",
       provider_id: group.providerId,
       model_id: group.modelId,
@@ -346,6 +349,7 @@ export function buildToolUseEvents({
   userId,
   agentMessageId,
   agentId,
+  subAgentId,
   parentAgentMessageId,
   runKey,
   actions,
@@ -362,6 +366,7 @@ export function buildToolUseEvents({
   userId: string | null;
   agentMessageId: string;
   agentId: string | null;
+  subAgentId: string | null;
   parentAgentMessageId: string | null;
   runKey: string;
   actions: ToolAction[];
@@ -411,6 +416,7 @@ export function buildToolUseEvents({
         agent_message_id: agentMessageId,
         conversation_id: conversationId,
         agent_id: agentId ?? "unknown",
+        sub_agent_id: subAgentId ?? "none",
         parent_agent_message_id: parentAgentMessageId ?? "none",
         auth_method: authMethod ?? "unknown",
         api_key_name: apiKeyName ?? "unknown",

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -37,6 +37,7 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import mainLogger from "@app/logger/logger";
 import logger from "@app/logger/logger";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+import { isHiddenHelperSubAgentId } from "@app/types/assistant/assistant";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
 import { createHash } from "crypto";
@@ -277,8 +278,38 @@ export async function emitMetronomeUsageEventsActivity(
   // Use updatedAt — this is when the agent message finished (not when it was created).
   const timestamp = agentMessage.updatedAt.toISOString();
   const authMethod = userMessage?.userContextAuthMethod ?? null;
-  const agentId = agentMessage.agentConfigurationId ?? null;
   const messageStatus = agentMessage.status ?? "unknown";
+
+  // Attribute usage to the parent (triggering) agent only for *hidden helper*
+  // sub-agents (e.g. the dust-task / dust-planning runs spawned by "go deep").
+  // These run in their own child conversation under the workspace system key and
+  // are not meaningful to users on their own, so surfacing them by their own name
+  // (e.g. "dust-task") is confusing — we attribute their usage to the user-facing
+  // parent agent that spawned them instead. Other sub-agents (real user agents
+  // invoked via run_agent / agent_handover) keep their own attribution.
+  let agentId = agentMessage.agentConfigurationId ?? null;
+  // When we override agentId to the parent, keep the original (child) agent id
+  // around as sub_agent_id so it can still be recovered from the event if needed.
+  let subAgentId: string | null = null;
+  if (
+    isSubAgentMessage &&
+    parentAgentMessageId &&
+    agentId &&
+    isHiddenHelperSubAgentId(agentId)
+  ) {
+    const parentAgentMessageRow = await MessageModel.findOne({
+      where: { sId: parentAgentMessageId, workspaceId: workspace.id },
+      include: [
+        { model: AgentMessageModel, as: "agentMessage", required: true },
+      ],
+    });
+    const parentAgentId =
+      parentAgentMessageRow?.agentMessage?.agentConfigurationId ?? null;
+    if (parentAgentId) {
+      subAgentId = agentId;
+      agentId = parentAgentId;
+    }
+  }
 
   // Resolve API key name from the stored numeric FK.
   let apiKeyName: string | null = null;
@@ -343,6 +374,7 @@ export async function emitMetronomeUsageEventsActivity(
     userId,
     agentMessageId,
     agentId,
+    subAgentId,
     parentAgentMessageId,
     runKey,
     runUsages,
@@ -361,6 +393,7 @@ export async function emitMetronomeUsageEventsActivity(
     userId,
     agentMessageId,
     agentId,
+    subAgentId,
     parentAgentMessageId,
     runKey,
     actions: toolActions,

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -151,6 +151,22 @@ export function isGlobalAgentId(sId: string): sId is GLOBAL_AGENTS_SID {
   return (Object.values(GLOBAL_AGENTS_SID) as string[]).includes(sId);
 }
 
+// Hidden helper sub-agents that are only ever invoked internally (e.g. via
+// run_agent by the Deep Dive agent). On their own they are not meaningful to
+// users, so usage they generate should be attributed to the parent agent that
+// spawned them rather than to the helper itself. Other sub-agents (real user
+// agents invoked via run_agent / agent_handover) keep their own attribution.
+export const HIDDEN_HELPER_SUB_AGENT_SIDS: ReadonlySet<string> =
+  new Set<string>([
+    GLOBAL_AGENTS_SID.DUST_TASK,
+    GLOBAL_AGENTS_SID.DUST_PLANNING,
+    GLOBAL_AGENTS_SID.DUST_BROWSER_SUMMARY,
+  ]);
+
+export function isHiddenHelperSubAgentId(sId: string): boolean {
+  return HIDDEN_HELPER_SUB_AGENT_SIDS.has(sId);
+}
+
 // If you want to show feedback buttons for global agents, add sId here.
 const GLOBAL_AGENTS_WITH_FEEDBACK = new Set<GLOBAL_AGENTS_SID>([
   GLOBAL_AGENTS_SID.DUST,


### PR DESCRIPTION
https://github.com/dust-tt/tasks/issues/8571

## Description

Hidden helper sub-agents (`dust-task`, `dust-planning`, `dust-browser-summary`) are only ever invoked internally via `run_agent` — e.g. by the **Go Deep** agent — and are not meaningful to users on their own. Their token/tool usage was surfacing in Metronome under their own `agent_id` (e.g. `"dust-task"`) instead of the user-facing parent agent that spawned them.

This attributes their usage to the **parent (triggering) agent's** configuration in the Metronome usage events. All other sub-agents (real user agents invoked via `run_agent` / `agent_handover`) keep their own `agent_id`.

**Changes:**
- `types/assistant/assistant.ts`: new shared `HIDDEN_HELPER_SUB_AGENT_SIDS` set + `isHiddenHelperSubAgentId()` helper (the three hidden helper sub-agents).
- `temporal/usage_queue/activities.ts`: for sub-agent messages whose child agent is a hidden helper, resolve the parent agent message and report its `agent_id` instead of the helper's.

> Note: a follow-up PR (#26888, stacked on this one) handles the related **API key** attribution for these sub-agent runs.

## Tests

- `tsgo --noEmit` clean; `biome check` clean.
- `lib/api/assistant/conversation.test.ts` — 82/82 pass.

## Risk

Low. Analytics attribution only — no authorization or schema change. Behavior change: hidden-helper sub-agent usage now reports under the parent agent's `agent_id` rather than the helper's own. Forward-only: past events are not rewritten. Rollback-safe.

## Deploy Plan

Deploy front. No migration.
