### PR TITLE
feat(sparkle): deploy storybook and playground to production

### DIFF
--- a/.github/workflows/build-sparkle.yml
+++ b/.github/workflows/build-sparkle.yml
@@ -22,3 +22,5 @@ jobs:
           node-version: '24.14.0'
       - name: Build
         run: npm -w sparkle run build
+      - name: Build Storybook
+        run: npm -w sparkle run build-storybook

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,7 @@ on:
           - viz
           - dante
           - egress-proxy
+          - sparkle-storybook
       check_deployment_blocked:
         description: "Check #deployment locks or force deploy"
         required: true

--- a/dockerfiles/sparkle-storybook.Dockerfile
+++ b/dockerfiles/sparkle-storybook.Dockerfile
@@ -1,0 +1,32 @@
+FROM node:24.14.0 AS builder
+
+RUN npm install -g npm@11.11.0
+
+WORKDIR /app
+
+# Install root workspace deps (covers sparkle devDeps: storybook, vite, etc.)
+COPY package.json package-lock.json ./
+COPY sparkle/package.json ./sparkle/
+RUN --mount=type=cache,id=npm-cache,target=/root/.npm npm ci
+
+# Copy sparkle source (includes .storybook/ and playground/)
+COPY sparkle/ ./sparkle/
+# staticDirs in .storybook/main.ts references this path
+COPY front/public/static/ ./front/public/static/
+
+# Build storybook static site → sparkle/storybook-static/
+RUN npm -w sparkle run build-storybook
+
+# Install playground deps (standalone package, not a root workspace)
+WORKDIR /app/sparkle/playground
+RUN --mount=type=cache,id=npm-cache,target=/root/.npm npm ci
+# Build playground at /playground/ base path so assets resolve correctly under that prefix
+RUN npm run build -- --base /playground/
+
+FROM nginx:1.27-alpine
+
+COPY --from=builder /app/sparkle/storybook-static/ /usr/share/nginx/html/storybook/
+COPY --from=builder /app/sparkle/playground/dist/ /usr/share/nginx/html/playground/
+COPY dockerfiles/sparkle/sparkle-storybook-nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80

--- a/dockerfiles/sparkle/sparkle-storybook-nginx.conf
+++ b/dockerfiles/sparkle/sparkle-storybook-nginx.conf
@@ -1,0 +1,20 @@
+server {
+    listen 80;
+    server_name _;
+
+    gzip on;
+    gzip_types text/plain text/css application/javascript application/json image/svg+xml;
+    gzip_min_length 1024;
+
+    # Playground SPA — assets are built with base=/playground/
+    location /playground/ {
+        root /usr/share/nginx/html;
+        try_files $uri $uri/ /playground/index.html;
+    }
+
+    # Storybook static site
+    location / {
+        root /usr/share/nginx/html/storybook;
+        try_files $uri $uri/ =404;
+    }
+}


### PR DESCRIPTION
## Description

Adds the build and deployment infrastructure to serve Sparkle Storybook and Playground as a production service at `sparkle.dust.tt`.

- **`dockerfiles/sparkle-storybook.Dockerfile`** — Multi-stage build: Node 24 installs workspace deps, builds the Storybook static site and the Playground (with `--base /playground/` so asset paths resolve under that prefix), then copies both outputs into an nginx:alpine image.
- **`dockerfiles/sparkle-storybook-nginx.conf`** — nginx config serving Storybook at `/` and the Playground SPA at `/playground/` with a `try_files` SPA fallback.
- **`deploy.yml`** — Adds `sparkle-storybook` to the deployable component list.
- **`build-sparkle.yml`** — Adds a `build-storybook` CI step so storybook breakage is caught on every PR touching `sparkle/`.

Companion infra PR: dust-tt/dust-infra#837

## Deploy Plan

1. Merge dust-tt/dust-infra#837 first (Helm chart + ingress).
2. Publish the `sparkle-storybook` Helm chart via `publish-chart.yaml` → `sparkle-storybook`.
3. Apply the updated `k8s/ingress.yaml` to the us-central1 cluster.
4. Trigger `deploy.yml` → component: `sparkle-storybook`, region: `us-central1`.
5. Add `sparkle.dust.tt` DNS A record pointing to `130.211.30.24` (existing ingress IP).
