### PR TITLE
fix: allow leaving conversations with inaccessible agents

### DIFF
--- a/front/lib/api/assistant/participants.ts
+++ b/front/lib/api/assistant/participants.ts
@@ -140,10 +140,17 @@ export async function fetchConversationParticipants(
     fetchAllAgentsById(auth, [...agentConfigurationIds]),
   ]);
 
-  // if less agents than agentConfigurationIds, it means some agents are forbidden
-  // to the user
+  // `agents` may contain fewer entries than `agentConfigurationIds` when an agent used in the
+  // conversation later moved to a space the user can no longer read. In that case we still return
+  // the participants list to actual participants (so they can leave/delete the conversation), but
+  // keep treating it as an access restriction for everyone else.
   if (agents.length < agentConfigurationIds.size) {
-    return new Err(new ConversationError("conversation_access_restricted"));
+    const currentUser = auth.user();
+    const isParticipant =
+      currentUser !== null && userIds.includes(currentUser.id);
+    if (!isParticipant) {
+      return new Err(new ConversationError("conversation_access_restricted"));
+    }
   }
 
   const userIdToAction = new Map<ModelId, ParticipantActionType>(


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8540

Users can end up with older conversations that still appear in their sidebar, but where the participants endpoint fails because one of the agents used in the conversation is no longer accessible to them. In the reported case, the agent used in the conversation was modified after the conversation was created to access a private space. The conversation still shows up because it is listed through the conversation’s `requestedSpaceIds`, but fetching participants fails, which also prevents the UI from enabling the Delete/Leave action. As a result, the user is stuck with conversations they can see in the list but cannot leave or delete.

This PR changes `fetchConversationParticipants` so that, when the user is a participant of the conversation, inaccessible agents are omitted from the returned participant list instead of causing the whole participants fetch to fail with `conversation_access_restricted`.

## Tests
Manually

## Risks

The main behavior change is that the participants endpoint can now return a partial list of agents when some agents are inaccessible to the current user and the user is a participant of the conversation.

This is safe because this function is not the source of truth for conversation access. Conversation-level authorization is already enforced upstream when fetching the conversation through the regular access checks. This PR does not grant access to the conversation, to hidden agents, or to any restricted space data. It only avoids failing the participants fetch after the user has already been authorized to access the conversation-level action.

This also preserves the permission boundary for agents: inaccessible agents are not returned to the caller, so we do not leak agent metadata that the user is not allowed to see.

## Deploy Plan

Standard deployment.
