### PR TITLE
[front] feat: add source/agent/user filters to analytics base query

### DIFF
--- a/front-api/routes/v1/w/[wId]/analytics/export.test.ts
+++ b/front-api/routes/v1/w/[wId]/analytics/export.test.ts
@@ -37,12 +37,18 @@ vi.mock(
   })
 );
 
-vi.mock("@app/lib/api/assistant/observability/context_origin", async () => ({
-  fetchContextOriginDailyBreakdown: vi.fn(
-    async () =>
-      new Ok([{ date: "2024-06-01", origin: "web", messageCount: 10 }])
-  ),
-}));
+vi.mock(
+  "@app/lib/api/assistant/observability/context_origin",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("@app/lib/api/assistant/observability/context_origin")
+    >()),
+    fetchContextOriginDailyBreakdown: vi.fn(
+      async () =>
+        new Ok([{ date: "2024-06-01", origin: "web", messageCount: 10 }])
+    ),
+  })
+);
 
 vi.mock("@app/lib/api/analytics/agents_export", async () => ({
   AGENT_EXPORT_HEADERS: ["agentId", "name", "messages"],

--- a/front/lib/api/assistant/observability/context_origin.test.ts
+++ b/front/lib/api/assistant/observability/context_origin.test.ts
@@ -1,0 +1,56 @@
+import { contextOriginFilter } from "@app/lib/api/assistant/observability/context_origin";
+import { describe, expect, it } from "vitest";
+
+describe("contextOriginFilter", () => {
+  it("returns no clause for undefined / empty array / empty string", () => {
+    expect(contextOriginFilter(undefined)).toEqual([]);
+    expect(contextOriginFilter([])).toEqual([]);
+    expect(contextOriginFilter("")).toEqual([]);
+  });
+
+  it("emits a term query for a single known origin", () => {
+    expect(contextOriginFilter("slack")).toEqual([
+      { term: { context_origin: "slack" } },
+    ]);
+  });
+
+  it("emits a terms query for multiple known origins", () => {
+    expect(contextOriginFilter(["slack", "web"])).toEqual([
+      { terms: { context_origin: ["slack", "web"] } },
+    ]);
+  });
+
+  it("matches the literal value OR a missing field for the unknown sentinel", () => {
+    expect(contextOriginFilter("unknown")).toEqual([
+      {
+        bool: {
+          should: [
+            { term: { context_origin: "unknown" } },
+            { bool: { must_not: { exists: { field: "context_origin" } } } },
+          ],
+          minimum_should_match: 1,
+        },
+      },
+    ]);
+  });
+
+  it("matches all values literally and ORs the missing-field clause when unknown is included", () => {
+    expect(contextOriginFilter(["slack", "unknown"])).toEqual([
+      {
+        bool: {
+          should: [
+            { terms: { context_origin: ["slack", "unknown"] } },
+            { bool: { must_not: { exists: { field: "context_origin" } } } },
+          ],
+          minimum_should_match: 1,
+        },
+      },
+    ]);
+  });
+
+  it("drops empty values before building clauses", () => {
+    expect(contextOriginFilter(["slack", ""])).toEqual([
+      { term: { context_origin: "slack" } },
+    ]);
+  });
+});

--- a/front/lib/api/assistant/observability/context_origin.ts
+++ b/front/lib/api/assistant/observability/context_origin.ts
@@ -7,6 +7,49 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
 
+// Missing context_origin values are bucketed under this sentinel by the
+// aggregations, and the backfill (20251116_backfill_context_origin_analytics)
+// writes it as a literal value too. Filtering by it must therefore match both
+// the literal string and the absent-field case.
+export const UNKNOWN_CONTEXT_ORIGIN = "unknown";
+
+export function contextOriginFilter(
+  value: string | string[] | undefined
+): estypes.QueryDslQueryContainer[] {
+  if (value === undefined) {
+    return [];
+  }
+  const values = (Array.isArray(value) ? value : [value]).filter(
+    (v) => v.length > 0
+  );
+  if (values.length === 0) {
+    return [];
+  }
+
+  const valueClause: estypes.QueryDslQueryContainer =
+    values.length === 1
+      ? { term: { context_origin: values[0] } }
+      : { terms: { context_origin: values } };
+
+  if (!values.includes(UNKNOWN_CONTEXT_ORIGIN)) {
+    return [valueClause];
+  }
+
+  // "unknown" also covers rows with no context_origin, so OR the literal match
+  // with a missing-field clause.
+  return [
+    {
+      bool: {
+        should: [
+          valueClause,
+          { bool: { must_not: { exists: { field: "context_origin" } } } },
+        ],
+        minimum_should_match: 1,
+      },
+    },
+  ];
+}
+
 export type ContextOriginBucket = {
   origin: string;
   count: number;
@@ -27,7 +70,7 @@ export async function fetchContextOriginBreakdown(
       terms: {
         field: "context_origin",
         size: 20,
-        missing: "unknown",
+        missing: UNKNOWN_CONTEXT_ORIGIN,
       },
     },
   };
@@ -92,7 +135,7 @@ export async function fetchContextOriginDailyBreakdown(
           terms: {
             field: "context_origin",
             size: 20,
-            missing: "unknown",
+            missing: UNKNOWN_CONTEXT_ORIGIN,
           },
         },
       },

--- a/front/lib/api/assistant/observability/utils.test.ts
+++ b/front/lib/api/assistant/observability/utils.test.ts
@@ -1,0 +1,64 @@
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { describe, expect, it } from "vitest";
+
+describe("buildAgentAnalyticsBaseQuery", () => {
+  it("keeps the single-agent path unchanged (sidekick shape)", () => {
+    expect(
+      buildAgentAnalyticsBaseQuery({
+        workspaceId: "w1",
+        agentId: "a1",
+        days: 30,
+      })
+    ).toEqual({
+      bool: {
+        filter: [
+          { term: { workspace_id: "w1" } },
+          { term: { agent_id: "a1" } },
+          { range: { timestamp: { gte: "now-30d/d" } } },
+        ],
+      },
+    });
+  });
+
+  it("adds agentIds / userIds / contextOrigin filters when provided", () => {
+    expect(
+      buildAgentAnalyticsBaseQuery({
+        workspaceId: "w1",
+        agentIds: ["a1", "a2"],
+        userIds: ["u1"],
+        contextOrigin: "slack",
+        startDate: "2026-01-01",
+        endDate: "2026-01-31",
+      })
+    ).toEqual({
+      bool: {
+        filter: [
+          { term: { workspace_id: "w1" } },
+          { terms: { agent_id: ["a1", "a2"] } },
+          { term: { user_id: "u1" } },
+          { term: { context_origin: "slack" } },
+          { range: { timestamp: { gte: "2026-01-01", lte: "2026-01-31" } } },
+        ],
+      },
+    });
+  });
+
+  it("omits empty array filters", () => {
+    expect(
+      buildAgentAnalyticsBaseQuery({
+        workspaceId: "w1",
+        agentIds: [],
+        userIds: [],
+      })
+    ).toEqual({ bool: { filter: [{ term: { workspace_id: "w1" } }] } });
+  });
+
+  it("rejects passing both agentId and agentIds at compile time", () => {
+    // @ts-expect-error agentId and agentIds are mutually exclusive
+    buildAgentAnalyticsBaseQuery({
+      workspaceId: "w1",
+      agentId: "a1",
+      agentIds: ["a2"],
+    });
+  });
+});

--- a/front/lib/api/assistant/observability/utils.ts
+++ b/front/lib/api/assistant/observability/utils.ts
@@ -1,3 +1,4 @@
+import { contextOriginFilter } from "@app/lib/api/assistant/observability/context_origin";
 import type { estypes } from "@elastic/elasticsearch";
 import moment from "moment-timezone";
 import { z } from "zod";
@@ -24,9 +25,32 @@ export function daysToDateRange(
   return { startDate: start, endDate: end };
 }
 
+function termFilter(
+  field: string,
+  value: string | string[] | undefined
+): estypes.QueryDslQueryContainer[] {
+  if (value === undefined) {
+    return [];
+  }
+  const values = (Array.isArray(value) ? value : [value]).filter(
+    (v) => v.length > 0
+  );
+  if (values.length === 0) {
+    return [];
+  }
+  return [
+    values.length === 1
+      ? { term: { [field]: values[0] } }
+      : { terms: { [field]: values } },
+  ];
+}
+
 export function buildAgentAnalyticsBaseQuery({
   workspaceId,
   agentId,
+  agentIds,
+  userIds,
+  contextOrigin,
   days,
   startDate,
   endDate,
@@ -34,16 +58,23 @@ export function buildAgentAnalyticsBaseQuery({
   feedbackNestedQuery,
 }: {
   workspaceId: string;
-  agentId?: string;
+  userIds?: string[];
+  contextOrigin?: string | string[];
   days?: number;
   startDate?: string;
   endDate?: string;
   version?: string;
   feedbackNestedQuery?: estypes.QueryDslQueryContainer;
-}): estypes.QueryDslQueryContainer {
+} & (
+  | { agentId?: string; agentIds?: never }
+  | { agentId?: never; agentIds?: string[] }
+)): estypes.QueryDslQueryContainer {
   const filters: estypes.QueryDslQueryContainer[] = [
     { term: { workspace_id: workspaceId } },
     ...(agentId ? [{ term: { agent_id: agentId } }] : []),
+    ...termFilter("agent_id", agentIds),
+    ...termFilter("user_id", userIds),
+    ...contextOriginFilter(contextOrigin),
   ];
 
   if (startDate && endDate) {

--- a/front/pages/api/v1/w/[wId]/analytics/export.test.ts
+++ b/front/pages/api/v1/w/[wId]/analytics/export.test.ts
@@ -39,12 +39,18 @@ vi.mock(
   })
 );
 
-vi.mock("@app/lib/api/assistant/observability/context_origin", async () => ({
-  fetchContextOriginDailyBreakdown: vi.fn(
-    async () =>
-      new Ok([{ date: "2024-06-01", origin: "web", messageCount: 10 }])
-  ),
-}));
+vi.mock(
+  "@app/lib/api/assistant/observability/context_origin",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("@app/lib/api/assistant/observability/context_origin")
+    >()),
+    fetchContextOriginDailyBreakdown: vi.fn(
+      async () =>
+        new Ok([{ date: "2024-06-01", origin: "web", messageCount: 10 }])
+    ),
+  })
+);
 
 vi.mock("@app/lib/api/analytics/agents_export", async () => ({
   AGENT_EXPORT_HEADERS: ["agentId", "name", "messages"],


### PR DESCRIPTION
## Description

Extend buildAgentAnalyticsBaseQuery with optional agentIds, userIds, and contextOrigin filters so workspace-analytics tools can scope queries by message origin, agent, or user. 

Additive: existing single-agent callers are unchanged. A small termFilter helper normalizes string | string[], drops empty values, and emits term for a single value / terms for multiple.

agentId and agentIds target the same field, so they are made mutually exclusive via an XOR parameter type (compile-time, no runtime check): callers pass one or the other, never both.

context_origin is nullable and aggregations bucket missing values under an "unknown" sentinel, so a term match on "unknown" would return nothing. Add a dedicated contextOriginFilter (in context_origin.ts, alongside the sentinel constant now shared with the aggregations) that maps "unknown" to a missing-field clause and combines it with real origins via should/minimum_should_match.

Add unit tests for contextOriginFilter and buildAgentAnalyticsBaseQuery (including the unchanged single-agent path and the mutual-exclusivity guard).

## Tests

Unit + local

## Risk

This should not have any impact. The `unknown` logic in context_origin is a bit hairy so if I miss something it's possible we now return only partial results. But current tests should cover for that.

## Deploy Plan

Front