### PR TITLE
Add Ellen Woodcock GitHub profile URL

### DIFF
--- a/front/components/home/content/shared/team.ts
+++ b/front/components/home/content/shared/team.ts
@@ -579,7 +579,7 @@ export const PEOPLE: Record<string, TeamMember> = {
     title: "Marketing",
     image: "https://ca.slack-edge.com/T050RH73H9P-U0ATZB2QZNW-7de3b65a6066-512",
     linkedIn: "https://www.linkedin.com/in/ellen-woodcock/",
-    github: "",
+    github: "https://github.com/ecw42990",
   },
   tvicaire: {
     name: "Thomas Vicaire",


### PR DESCRIPTION
## Description

Add Ellen Woodcock's missing GitHub profile URL to the team page data.

## Tests

Ran `git diff --check` locally in the Computer. No UI or runtime tests were run for this data-only change.

## Risk

Low risk. This only fills an empty GitHub URL field for one team member and is safe to rollback.

## Deploy Plan

Deploy through the standard web app deployment pipeline after PR CI passes.
