### PR TITLE
[front] checkout: add seat subscription commit product

### DIFF
--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -32,6 +32,8 @@ const DEV_PRODUCT_EXCESS_CREDITS = "7e74d48b-44be-4e9c-9543-7136e6da8d96";
 const DEV_PRODUCT_PREPAID_COMMIT = "5f4331b7-4bf6-488b-9a0c-51bd139ac91c";
 const DEV_PRODUCT_SEAT_SUBSCRIPTION_CREDITS =
   "92f3466b-2423-4f2a-a8d1-0f6e9f7f0140";
+const DEV_PRODUCT_SEAT_SUBSCRIPTION_COMMIT =
+  "475eb7dd-5043-49bc-96eb-1b08f94fda51";
 
 // --- PROD (production) — TODO: update after running setup script in production ---
 
@@ -63,6 +65,8 @@ const PROD_PRODUCT_EXCESS_CREDITS = "26f0023b-e123-4154-a82d-104451fba068";
 const PROD_PRODUCT_PREPAID_COMMIT = "1408c9fc-dea1-4269-bd6d-1bc0aa1f1218";
 const PROD_PRODUCT_SEAT_SUBSCRIPTION_CREDITS =
   "03faa744-c1ab-4b94-aaf1-5fdaec89e11a";
+const PROD_PRODUCT_SEAT_SUBSCRIPTION_COMMIT =
+  "TODO_PROD_PRODUCT_SEAT_SUBSCRIPTION_COMMIT";
 
 // --- Credit type IDs (stable across envs unless noted) ---
 
@@ -182,6 +186,11 @@ export const getProductSeatSubscriptionCreditsId = () =>
   devOrProd(
     DEV_PRODUCT_SEAT_SUBSCRIPTION_CREDITS,
     PROD_PRODUCT_SEAT_SUBSCRIPTION_CREDITS
+  );
+export const getProductSeatSubscriptionCommitId = () =>
+  devOrProd(
+    DEV_PRODUCT_SEAT_SUBSCRIPTION_COMMIT,
+    PROD_PRODUCT_SEAT_SUBSCRIPTION_COMMIT
   );
 
 // AWU commit priorities — lower number is consumed first.

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -66,7 +66,7 @@ const PROD_PRODUCT_PREPAID_COMMIT = "1408c9fc-dea1-4269-bd6d-1bc0aa1f1218";
 const PROD_PRODUCT_SEAT_SUBSCRIPTION_CREDITS =
   "03faa744-c1ab-4b94-aaf1-5fdaec89e11a";
 const PROD_PRODUCT_SEAT_SUBSCRIPTION_COMMIT =
-  "TODO_PROD_PRODUCT_SEAT_SUBSCRIPTION_COMMIT";
+  "5cdb49e6-0a92-4a55-9c92-c8913b2df0d5";
 
 // --- Credit type IDs (stable across envs unless noted) ---
 

--- a/front/lib/metronome/setup_common.ts
+++ b/front/lib/metronome/setup_common.ts
@@ -427,6 +427,10 @@ export const PRODUCTS: ProductDef[] = [
     name: "Seat Subscription Credits",
     type: "FIXED",
   },
+  {
+    name: "Seat Subscription Commit",
+    type: "FIXED",
+  },
 ];
 
 // Factory for a single seat subscription. All share the same ADVANCE collection


### PR DESCRIPTION
## Description

Adding a new product for seat subscription commit (for checkout => payment gated commit)

## Tests

N/A

## Risk

None

## Deploy Plan

Run `npx tsx scripts/metronome_setup.ts --execute` on prodbox and update the ID
