### PR TITLE
fix: check file existence before moving to pod

### DIFF
--- a/front-api/routes/w/[wId]/files/[fileId]/save-in-project.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/save-in-project.test.ts
@@ -1,6 +1,7 @@
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { frameContentType } from "@app/types/files";
@@ -255,6 +256,8 @@ describe("POST /api/w/:wId/files/:fileId/save-in-project", () => {
       useCaseMetadata: { conversationId: conversation.sId },
     });
 
+    fileStorageMock.setFileExists(() => false);
+
     const response = await postSave(workspace, file.sId, {
       projectId: project.sId,
     });
@@ -270,5 +273,43 @@ describe("POST /api/w/:wId/files/:fileId/save-in-project", () => {
     // updateUseCase clears conversationId to avoid confusion when accessing the
     // file in project context.
     expect(data.file.useCaseMetadata.conversationId).toBeUndefined();
+  });
+
+  it("should return 400 when a file with the same name already exists in the project", async () => {
+    const { auth, user, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "user",
+    });
+
+    const project = await SpaceFactory.project(workspace, user.id);
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const file = await FileFactory.create(auth, user, {
+      contentType: frameContentType,
+      fileName: "test.frame",
+      fileSize: 1024,
+      status: "ready",
+      useCase: "tool_output",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
+
+    // A file with the same name already exists at the destination in the Pod.
+    fileStorageMock.setFileExists(() => true);
+
+    const response = await postSave(workspace, file.sId, {
+      projectId: project.sId,
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "A file with this name already exists in the Pod.",
+      },
+    });
   });
 });

--- a/front-api/routes/w/[wId]/files/[fileId]/save-in-project.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/save-in-project.ts
@@ -116,9 +116,9 @@ app.post(
     });
     if (result.isErr()) {
       return apiError(ctx, {
-        status_code: 500,
+        status_code: 400,
         api_error: {
-          type: "internal_server_error",
+          type: "invalid_request_error",
           message: result.error.message,
         },
       });

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -723,6 +723,17 @@ export class DustFileSystem {
     return this.backend.stat(resolved.value.path);
   }
 
+  async exists(
+    scopedPath: string
+  ): Promise<Result<boolean, DustFileSystemError>> {
+    const resolved = this.requireReadMount(scopedPath);
+    if (resolved.isErr()) {
+      return resolved;
+    }
+
+    return this.backend.exists(resolved.value.path);
+  }
+
   async write(
     scopedPath: string,
     content: Buffer | string,
@@ -815,12 +826,6 @@ export class DustFileSystem {
     return new Ok({ dest, ...moveResult.value });
   }
 
-  private async fileExists(
-    scopedPath: string
-  ): Promise<Result<boolean, DustFileSystemError>> {
-    return this.backend.exists(scopedPath);
-  }
-
   /**
    * Move `src` to `dest` (copy then delete source).
    *
@@ -844,7 +849,7 @@ export class DustFileSystem {
       return resolvedDest;
     }
 
-    const destExists = await this.fileExists(resolvedDest.value.path);
+    const destExists = await this.backend.exists(resolvedDest.value.path);
     if (destExists.isErr()) {
       return destExists;
     }

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -5,6 +5,8 @@ import {
 } from "@app/lib/api/assistant/conversation/attachments";
 import { getContentFragmentBlob } from "@app/lib/api/assistant/conversation/content_fragment";
 import { getContentNodesForDataSourceView } from "@app/lib/api/data_source_view";
+import { DustFileSystem } from "@app/lib/api/file_system";
+import { SCOPED_PREFIX_POD } from "@app/lib/api/file_system/types";
 import {
   createGCSMountDirectory,
   deleteGCSMountFile,
@@ -366,6 +368,36 @@ export async function addFileToProject(
     }
 
     const destFileName = file.fileName;
+    const destScopedPath = `${SCOPED_PREFIX_POD}${space.sId}/${destFileName}`;
+
+    // Reject the move when a file with the same name already exists in the Pod, rather
+    // than silently overwriting it. moveFile (raw GCS) does not check, so we check the
+    // destination through a Pod-scoped file system first.
+    const fsRes = await DustFileSystem.forPod(auth, space);
+    if (fsRes.isErr()) {
+      return new Err({
+        name: "dust_error",
+        code: "internal_error",
+        message: fsRes.error.message,
+      });
+    }
+
+    const destExistsRes = await fsRes.value.exists(destScopedPath);
+    if (destExistsRes.isErr()) {
+      return new Err({
+        name: "dust_error",
+        code: "internal_error",
+        message: destExistsRes.error.message,
+      });
+    }
+    if (destExistsRes.value) {
+      return new Err({
+        name: "dust_error",
+        code: "invalid_request_error",
+        message: "A file with this name already exists in the Pod.",
+      });
+    }
+
     const moveRes = await moveFile(auth, {
       file,
       sourceGcsPath: file.mountFilePath,

--- a/front/pages/api/w/[wId]/files/[fileId]/save-in-project.test.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/save-in-project.test.ts
@@ -1,6 +1,7 @@
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { frameContentType } from "@app/types/files";
@@ -289,6 +290,8 @@ describe("POST /api/w/[wId]/files/[fileId]/save-in-project", () => {
       useCaseMetadata: { conversationId: conversation.sId },
     });
 
+    fileStorageMock.setFileExists(() => false);
+
     req.query = {
       ...req.query,
       fileId: file.sId,
@@ -307,6 +310,49 @@ describe("POST /api/w/[wId]/files/[fileId]/save-in-project", () => {
     );
     // updateUseCase clears conversationId to avoid confusion when accessing the file in project context.
     expect(data.file.useCaseMetadata.conversationId).toBeUndefined();
+  });
+
+  it("should return 400 when a file with the same name already exists in the project", async () => {
+    const { req, res, workspace, user, auth } =
+      await createPrivateApiMockRequest({
+        method: "POST",
+        role: "user",
+      });
+
+    const project = await SpaceFactory.project(workspace, user.id);
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const file = await FileFactory.create(auth, user, {
+      contentType: frameContentType,
+      fileName: "test.frame",
+      fileSize: 1024,
+      status: "ready",
+      useCase: "tool_output",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
+
+    // A file with the same name already exists at the destination in the Pod.
+    fileStorageMock.setFileExists(() => true);
+
+    req.query = {
+      ...req.query,
+      fileId: file.sId,
+    };
+    req.body = { projectId: project.sId };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "A file with this name already exists in the Pod.",
+      },
+    });
   });
 
   it("should return 405 for unsupported methods", async () => {

--- a/front/pages/api/w/[wId]/files/[fileId]/save-in-project.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/save-in-project.ts
@@ -142,9 +142,9 @@ async function handler(
       });
       if (result.isErr()) {
         return apiError(req, res, {
-          status_code: 500,
+          status_code: 400,
           api_error: {
-            type: "internal_server_error",
+            type: "invalid_request_error",
             message: result.error.message,
           },
         });


### PR DESCRIPTION
## Description

This PR prevents silently overwriting existing Pod files when moving a file to a Pod by checking for a name conflict before performing the move. This also caused an unhandled api error caused by trying to update the mountfilepath of the file after moving it.

## Tests

Manually.

## Risks

<!-- Discuss potential risks and how they will be mitigated. -->

## Deploy Plan

<!-- Outline the deployment steps. -->

