### PR TITLE
[front] feat: none seat type + message-send gate

### DIFF
--- a/front/components/app/ReachedLimitPopup.tsx
+++ b/front/components/app/ReachedLimitPopup.tsx
@@ -25,7 +25,8 @@ export type WorkspaceLimit =
   | "message_limit"
   | "credits_exhausted"
   | "pool_credits_exhausted"
-  | "user_credits_exhausted";
+  | "user_credits_exhausted"
+  | "no_seat";
 
 function getLimitPromptForCode(
   router: AppRouter,
@@ -194,6 +195,21 @@ function getLimitPromptForCode(
               {isAdmin
                 ? "Your workspace has run out of credits. Please purchase more credits to continue using Dust."
                 : "Your workspace has run out of credits. Please contact your administrator to purchase more credits."}
+            </Page.P>
+          </>
+        ),
+      };
+    }
+
+    case "no_seat": {
+      return {
+        title: "No seat assigned",
+        validateLabel: "Ok",
+        children: (
+          <>
+            <Page.P>
+              You don&apos;t have a seat assigned in this workspace. Please
+              contact your administrator to assign you one.
             </Page.P>
           </>
         ),

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -36,6 +36,8 @@ import {
 } from "@app/types/assistant/mentions";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import {
+  AlertCircleV2,
+  ContentMessage,
   ContentMessageAction,
   ContentMessageInline,
   EmptyCTA,
@@ -494,6 +496,17 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
           />
         )}
       </div>
+      {context.isNoSeat && (
+        <ContentMessage
+          icon={AlertCircleV2}
+          variant="warning"
+          className="mb-3 flex w-full"
+          title="No seat assigned"
+        >
+          You don&apos;t have a seat in this workspace. Contact your admin to
+          send messages.
+        </ContentMessage>
+      )}
       {blockedActions.length > 0 && (
         <ContentMessageInline
           icon={InfoCircle}

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -36,8 +36,6 @@ import {
 } from "@app/types/assistant/mentions";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import {
-  AlertCircleV2,
-  ContentMessage,
   ContentMessageAction,
   ContentMessageInline,
   EmptyCTA,
@@ -496,17 +494,6 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
           />
         )}
       </div>
-      {context.isNoSeat && (
-        <ContentMessage
-          icon={AlertCircleV2}
-          variant="warning"
-          className="mb-3 flex w-full"
-          title="No seat assigned"
-        >
-          You don&apos;t have a seat in this workspace. Contact your admin to
-          send messages.
-        </ContentMessage>
-      )}
       {blockedActions.length > 0 && (
         <ContentMessageInline
           icon={InfoCircle}

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -13,6 +13,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { getRandomGreetingForName } from "@app/lib/client/greetings";
 import type { DustError } from "@app/lib/error";
 import { useAppRouter } from "@app/lib/platform";
+import { useMembersUsage } from "@app/lib/swr/memberships";
 import { classNames } from "@app/lib/utils";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { ConversationListItemType } from "@app/types/assistant/conversation";
@@ -28,7 +29,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import type { UserType, WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
 import { Button, Card, Lightbulb04, Page, XClose } from "@dust-tt/sparkle";
-import { useCallback, useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
 
 interface ConversationContainerProps {
   owner: WorkspaceType;
@@ -61,6 +62,29 @@ export function ConversationContainerVirtuoso({
 
   const [limitReachedCode, setLimitReachedCode] =
     useState<WorkspaceLimit | null>(null);
+
+  // Proactively fetch the current user's seat type so the no-seat banner
+  // shows immediately without requiring a failed send first.
+  const { membersUsage: selfUsage } = useMembersUsage({
+    workspaceId: owner.sId,
+    searchTerm: user.email ?? "",
+    pageIndex: 0,
+    pageSize: 1,
+    disabled: !user.email,
+  });
+  const isNoSeat =
+    selfUsage.length > 0 &&
+    selfUsage[0].sId === user.sId &&
+    selfUsage[0].seatType === "none";
+
+  const effectiveLimitCode: WorkspaceLimit | null = isNoSeat
+    ? "no_seat"
+    : limitReachedCode;
+
+  const lastLimitReachedCode = useRef<WorkspaceLimit>("message_limit");
+  if (effectiveLimitCode !== null) {
+    lastLimitReachedCode.current = effectiveLimitCode;
+  }
   const { setSelectedSingleAgent } = useContext(InputBarContext);
 
   const router = useAppRouter();
@@ -185,6 +209,7 @@ export function ConversationContainerVirtuoso({
           user={user}
           conversationId={activeConversationId}
           setLimitReachedCode={setLimitReachedCode}
+          limitReachedCode={effectiveLimitCode}
           key={conversationViewerKey}
           clientSideMCPServerIds={clientSideMCPServerIds}
         />
@@ -210,6 +235,9 @@ export function ConversationContainerVirtuoso({
               onSubmit={handleConversationCreation}
               draftKey="home-new-conversation"
               disableAutoFocus={false}
+              submitBlockMessage={
+                isNoSeat ? "You don't have a seat in this workspace." : null
+              }
             />
           </div>
 
@@ -253,11 +281,11 @@ export function ConversationContainerVirtuoso({
       )}
       <ReachedLimitPopup
         isAdmin={isAdmin(owner)}
-        isOpened={!!limitReachedCode}
+        isOpened={!!effectiveLimitCode && effectiveLimitCode !== "no_seat"}
         onClose={() => setLimitReachedCode(null)}
         subscription={subscription}
         owner={owner}
-        code={limitReachedCode ?? "message_limit"}
+        code={lastLimitReachedCode.current}
       />
     </DropzoneContainer>
   );

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -13,7 +13,6 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { getRandomGreetingForName } from "@app/lib/client/greetings";
 import type { DustError } from "@app/lib/error";
 import { useAppRouter } from "@app/lib/platform";
-import { useMembersUsage } from "@app/lib/swr/memberships";
 import { classNames } from "@app/lib/utils";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { ConversationListItemType } from "@app/types/assistant/conversation";
@@ -29,7 +28,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import type { UserType, WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
 import { Button, Card, Lightbulb04, Page, XClose } from "@dust-tt/sparkle";
-import { useCallback, useContext, useEffect, useRef, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 
 interface ConversationContainerProps {
   owner: WorkspaceType;
@@ -62,29 +61,6 @@ export function ConversationContainerVirtuoso({
 
   const [limitReachedCode, setLimitReachedCode] =
     useState<WorkspaceLimit | null>(null);
-
-  // Proactively fetch the current user's seat type so the no-seat banner
-  // shows immediately without requiring a failed send first.
-  const { membersUsage: selfUsage } = useMembersUsage({
-    workspaceId: owner.sId,
-    searchTerm: user.email ?? "",
-    pageIndex: 0,
-    pageSize: 1,
-    disabled: !user.email,
-  });
-  const isNoSeat =
-    selfUsage.length > 0 &&
-    selfUsage[0].sId === user.sId &&
-    selfUsage[0].seatType === "none";
-
-  const effectiveLimitCode: WorkspaceLimit | null = isNoSeat
-    ? "no_seat"
-    : limitReachedCode;
-
-  const lastLimitReachedCode = useRef<WorkspaceLimit>("message_limit");
-  if (effectiveLimitCode !== null) {
-    lastLimitReachedCode.current = effectiveLimitCode;
-  }
   const { setSelectedSingleAgent } = useContext(InputBarContext);
 
   const router = useAppRouter();
@@ -143,6 +119,8 @@ export function ConversationContainerVirtuoso({
           setLimitReachedCode("pool_credits_exhausted");
         } else if (conversationRes.error.type === "user_cap_reached_error") {
           setLimitReachedCode("user_credits_exhausted");
+        } else if (conversationRes.error.type === "no_seat_error") {
+          setLimitReachedCode("no_seat");
         } else {
           sendNotification({
             title: conversationRes.error.title,
@@ -209,7 +187,7 @@ export function ConversationContainerVirtuoso({
           user={user}
           conversationId={activeConversationId}
           setLimitReachedCode={setLimitReachedCode}
-          limitReachedCode={effectiveLimitCode}
+          limitReachedCode={limitReachedCode}
           key={conversationViewerKey}
           clientSideMCPServerIds={clientSideMCPServerIds}
         />
@@ -222,6 +200,17 @@ export function ConversationContainerVirtuoso({
           >
             <Page.Header title={greeting} />
           </div>
+          {limitReachedCode === "no_seat" && (
+            <ContentMessage
+              icon={AlertCircleV2}
+              variant="warning"
+              className="w-full max-w-conversation"
+              title="No seat assigned"
+            >
+              You don&apos;t have a seat in this workspace. Contact your admin
+              to send messages.
+            </ContentMessage>
+          )}
           <div
             className={classNames(
               "sticky bottom-0 z-20 flex max-h-dvh w-full",
@@ -236,7 +225,9 @@ export function ConversationContainerVirtuoso({
               draftKey="home-new-conversation"
               disableAutoFocus={false}
               submitBlockMessage={
-                isNoSeat ? "You don't have a seat in this workspace." : null
+                limitReachedCode === "no_seat"
+                  ? "You don't have a seat in this workspace."
+                  : null
               }
             />
           </div>
@@ -281,11 +272,11 @@ export function ConversationContainerVirtuoso({
       )}
       <ReachedLimitPopup
         isAdmin={isAdmin(owner)}
-        isOpened={!!effectiveLimitCode && effectiveLimitCode !== "no_seat"}
+        isOpened={!!limitReachedCode && limitReachedCode !== "no_seat"}
         onClose={() => setLimitReachedCode(null)}
         subscription={subscription}
         owner={owner}
-        code={lastLimitReachedCode.current}
+        code={limitReachedCode ?? "message_limit"}
       />
     </DropzoneContainer>
   );

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -119,8 +119,6 @@ export function ConversationContainerVirtuoso({
           setLimitReachedCode("pool_credits_exhausted");
         } else if (conversationRes.error.type === "user_cap_reached_error") {
           setLimitReachedCode("user_credits_exhausted");
-        } else if (conversationRes.error.type === "no_seat_error") {
-          setLimitReachedCode("no_seat");
         } else {
           sendNotification({
             title: conversationRes.error.title,
@@ -200,17 +198,6 @@ export function ConversationContainerVirtuoso({
           >
             <Page.Header title={greeting} />
           </div>
-          {limitReachedCode === "no_seat" && (
-            <ContentMessage
-              icon={AlertCircleV2}
-              variant="warning"
-              className="w-full max-w-conversation"
-              title="No seat assigned"
-            >
-              You don&apos;t have a seat in this workspace. Contact your admin
-              to send messages.
-            </ContentMessage>
-          )}
           <div
             className={classNames(
               "sticky bottom-0 z-20 flex max-h-dvh w-full",
@@ -224,11 +211,6 @@ export function ConversationContainerVirtuoso({
               onSubmit={handleConversationCreation}
               draftKey="home-new-conversation"
               disableAutoFocus={false}
-              submitBlockMessage={
-                limitReachedCode === "no_seat"
-                  ? "You don't have a seat in this workspace."
-                  : null
-              }
             />
           </div>
 
@@ -272,7 +254,7 @@ export function ConversationContainerVirtuoso({
       )}
       <ReachedLimitPopup
         isAdmin={isAdmin(owner)}
-        isOpened={!!limitReachedCode && limitReachedCode !== "no_seat"}
+        isOpened={!!limitReachedCode}
         onClose={() => setLimitReachedCode(null)}
         subscription={subscription}
         owner={owner}

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -1227,6 +1227,8 @@ export const ConversationViewer = ({
             setLimitReachedCode?.("pool_credits_exhausted");
           } else if (result.error.type === "user_cap_reached_error") {
             setLimitReachedCode?.("user_credits_exhausted");
+          } else if (result.error.type === "no_seat_error") {
+            setLimitReachedCode?.("no_seat");
           } else {
             sendNotification({
               title: result.error.title,

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -111,6 +111,7 @@ interface ConversationViewerProps {
   additionalMarkdownComponents?: Components;
   additionalMarkdownPlugins?: PluggableList;
   setLimitReachedCode?: (code: WorkspaceLimit) => void;
+  limitReachedCode?: WorkspaceLimit | null;
   owner: WorkspaceType;
   user: UserType;
   clientSideMCPServerIds?: string[];
@@ -323,6 +324,7 @@ export const ConversationViewer = ({
   additionalMarkdownComponents,
   additionalMarkdownPlugins,
   setLimitReachedCode,
+  limitReachedCode,
   clientSideMCPServerIds,
 }: ConversationViewerProps) => {
   const virtuosoMessageListRef =
@@ -1409,6 +1411,7 @@ export const ConversationViewer = ({
       branchIdToApprove: branchIdToApprove ?? undefined,
       setBranchIdToApprove,
       isAutoScrollEnabledRef,
+      isNoSeat: limitReachedCode === "no_seat",
     };
   }, [
     user,
@@ -1426,6 +1429,7 @@ export const ConversationViewer = ({
     spaceInfo?.archivedAt,
     spaceInfo?.name,
     branchIdToApprove,
+    limitReachedCode,
   ]);
 
   return (

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -1227,8 +1227,6 @@ export const ConversationViewer = ({
             setLimitReachedCode?.("pool_credits_exhausted");
           } else if (result.error.type === "user_cap_reached_error") {
             setLimitReachedCode?.("user_credits_exhausted");
-          } else if (result.error.type === "no_seat_error") {
-            setLimitReachedCode?.("no_seat");
           } else {
             sendNotification({
               title: result.error.title,
@@ -1237,7 +1235,15 @@ export const ConversationViewer = ({
             });
           }
 
-          // If the API errors, the original data will be rolled back by SWR automatically.
+          // Remove optimistic placeholders — SWR rolls back the server cache but
+          // Virtuoso's in-memory list must be cleaned up manually.
+          const failedPlaceholderSids = [
+            placeholderUserMsg.sId,
+            ...placeholderAgentMessages.map((m) => m.sId),
+          ];
+          virtuosoMessageListRef.current.data.findAndDelete((m) =>
+            failedPlaceholderSids.includes(m.sId)
+          );
           logger.error({ err: result.error }, "Failed to post message");
           return new Err({
             code: "internal_error",

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -141,6 +141,7 @@ export type VirtuosoMessageListContext = {
   branchIdToApprove?: string;
   setBranchIdToApprove?: (branchId: string | null) => void;
   isAutoScrollEnabledRef: MutableRefObject<boolean>;
+  isNoSeat?: boolean;
 };
 
 export const areSameRankAndBranch = (

--- a/front/components/workspace/ChangeSeatModal.tsx
+++ b/front/components/workspace/ChangeSeatModal.tsx
@@ -26,6 +26,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  AlertCircle,
   Hexagon01,
   SeatMax,
 } from "@dust-tt/sparkle";
@@ -35,6 +36,7 @@ import { useEffect, useRef, useState } from "react";
 // (`SeatTypeInfo.name`) so adding a new seat tier only requires tagging the
 // product in Metronome — no code change here.
 const SEAT_TYPE_ICONS: Record<MembershipSeatType, React.ComponentType> = {
+  none: AlertCircle,
   free: Hexagon01,
   pro: Cube01,
   pro_yearly: Cube01,

--- a/front/components/workspace/ChangeSeatModal.tsx
+++ b/front/components/workspace/ChangeSeatModal.tsx
@@ -14,6 +14,7 @@ import {
 } from "@app/types/memberships";
 import type { WorkspaceType } from "@app/types/user";
 import {
+  AlertCircle,
   Avatar,
   Button,
   ButtonGroup,
@@ -26,7 +27,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  AlertCircle,
   Hexagon01,
   SeatMax,
 } from "@dust-tt/sparkle";

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -8,11 +8,10 @@ import {
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { ANONYMOUS_USER_IMAGE_URL } from "@app/types/user";
 import {
+  AlertCircle,
   Cube01,
   DataTable,
-  AlertCircle,
   Hexagon01,
-  Icon,
   LoadingBlock,
   type MenuItem,
   SeatMax,

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -10,7 +10,9 @@ import { ANONYMOUS_USER_IMAGE_URL } from "@app/types/user";
 import {
   Cube01,
   DataTable,
+  AlertCircle,
   Hexagon01,
+  Icon,
   LoadingBlock,
   type MenuItem,
   SeatMax,
@@ -47,6 +49,7 @@ type Info = CellContext<RowData, string>;
 const SEAT_TYPE_ICONS: Partial<
   Record<MembershipSeatType, React.ComponentType>
 > = {
+  none: AlertCircle,
   max: SeatMax,
   pro: Cube01,
   free: Hexagon01,

--- a/front/components/workspace/billing/BillingSeatsOverview.tsx
+++ b/front/components/workspace/billing/BillingSeatsOverview.tsx
@@ -62,6 +62,8 @@ function seatTypeGroup(seatType: MembershipSeatType): MembershipSeatType {
       return "pro";
     case "max_yearly":
       return "max";
+    case "none":
+      return "none";
     default:
       assertNeverAndIgnore(seatType);
       return seatType;

--- a/front/hooks/useCreateConversationWithMessage.ts
+++ b/front/hooks/useCreateConversationWithMessage.ts
@@ -1,4 +1,5 @@
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import { useSendNotification } from "@app/hooks/useNotification";
 import type { PostConversationsResponseBody } from "@app/lib/api/assistant/conversation/types";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useClientType } from "@app/lib/context/clientType";
@@ -40,6 +41,7 @@ export function useCreateConversationWithMessage({
   const { fetcher } = useFetcher();
   const contextOrigin = useClientType();
   const { hasFeature } = useFeatureFlags();
+  const sendNotification = useSendNotification();
   const { setPendingFirstMessage, clearPendingFirstMessage } =
     useContext(InputBarContext);
 
@@ -148,6 +150,13 @@ export function useCreateConversationWithMessage({
             origin,
             skipToolsValidation,
             profilePictureUrl: user.image,
+            onError: (err) => {
+              sendNotification({
+                title: err.title,
+                description: err.message,
+                type: "error",
+              });
+            },
           }).finally(() => {
             clearPendingFirstMessage(conversationId);
           });
@@ -231,6 +240,7 @@ export function useCreateConversationWithMessage({
       fetcher,
       contextOrigin,
       hasFeature,
+      sendNotification,
       setPendingFirstMessage,
       clearPendingFirstMessage,
     ]
@@ -251,6 +261,7 @@ async function postFirstMessageInBackground({
   origin,
   skipToolsValidation,
   profilePictureUrl,
+  onError,
 }: {
   workspaceId: string;
   conversationId: string;
@@ -262,6 +273,7 @@ async function postFirstMessageInBackground({
   origin: ClientMessageOrigin;
   skipToolsValidation: boolean;
   profilePictureUrl: string | null;
+  onError?: (err: SubmitMessageError) => void;
 }): Promise<void> {
   const timezone =
     Intl.DateTimeFormat().resolvedOptions().timeZone || "Etc/UTC";
@@ -319,7 +331,7 @@ async function postFirstMessageInBackground({
       );
     }
 
-    await clientFetch(
+    const msgRes = await clientFetch(
       `/api/w/${workspaceId}/assistant/conversations/${conversationId}/messages`,
       {
         method: "POST",
@@ -338,8 +350,25 @@ async function postFirstMessageInBackground({
         }),
       }
     );
+    if (!msgRes.ok) {
+      const body = await msgRes.json().catch(() => null);
+      if (onError) {
+        const errResult = toConversationCreationError(
+          isAPIErrorResponse(body) ? body : new Error("Failed to post message")
+        );
+        if (errResult.isErr()) {
+          onError(errResult.error);
+        }
+      }
+    }
   } catch (e) {
     logger.error({ err: e }, "Failed to post first message in background");
+    if (onError) {
+      const err = toConversationCreationError(e);
+      if (err.isErr()) {
+        onError(err.error);
+      }
+    }
   }
 }
 

--- a/front/hooks/useCreateConversationWithMessage.ts
+++ b/front/hooks/useCreateConversationWithMessage.ts
@@ -394,7 +394,9 @@ function toConversationCreationError(
           ? "credits_exhausted_error"
           : isApiError && e.error.type === "user_cap_reached"
             ? "user_cap_reached_error"
-            : "message_send_error",
+            : isApiError && e.error.type === "no_seat"
+              ? "no_seat_error"
+              : "message_send_error",
     title: "Your message could not be sent.",
     message: isApiError
       ? // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing

--- a/front/hooks/useSubmitMessage.ts
+++ b/front/hooks/useSubmitMessage.ts
@@ -156,7 +156,9 @@ export function useSubmitMessage({
                 ? "credits_exhausted_error"
                 : data.error.type === "user_cap_reached"
                   ? "user_cap_reached_error"
-                  : "message_send_error",
+                  : data.error.type === "no_seat"
+                    ? "no_seat_error"
+                    : "message_send_error",
           title: "Your message could not be sent.",
           // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           message: data.error.message || "Please try again or contact us.",

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -39,6 +39,7 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { ProjectFileFactory } from "@app/tests/utils/ProjectFileFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type {
   ContentFragmentInputWithContentNode,
   ContentFragmentInputWithFileIdType,
@@ -4748,6 +4749,61 @@ describe("conversation fetch forkingData", () => {
       expect(conversationResult.value.forkingData).toEqual({
         forkedChildren: expectedForkedChildren,
       });
+    }
+  });
+});
+
+describe("postUserMessage no-seat gate", () => {
+  it("rejects messages from a member with the `none` seat type", async () => {
+    // Credit-priced (Metronome) workspace — the seat gate only applies there.
+    const workspace = await WorkspaceFactory.creditPriced();
+    await SpaceFactory.defaults(
+      await Authenticator.internalAdminForWorkspace(workspace.sId)
+    );
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, {
+      role: "user",
+      seatType: "none",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Seatless Test Agent",
+      description: "Agent for the no-seat gate test",
+    });
+    const created = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+      visibility: "unlisted",
+    });
+    const fetched = await getConversation(auth, created.sId);
+    if (fetched.isErr()) {
+      throw new Error("Failed to fetch conversation");
+    }
+
+    const userJson = user.toJSON();
+    const result = await postUserMessage(auth, {
+      conversation: fetched.value,
+      content: `Hello @${agent.name}`,
+      mentions: [{ configurationId: agent.sId } satisfies AgentMention],
+      context: {
+        username: userJson.username,
+        timezone: "UTC",
+        fullName: userJson.fullName,
+        email: userJson.email,
+        profilePictureUrl: userJson.image,
+        origin: "web",
+      },
+      skipToolsValidation: false,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.status_code).toBe(403);
+      expect(result.error.api_error.type).toBe("no_seat");
     }
   });
 });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1203,6 +1203,14 @@ export async function editUserMessage(
     return canInteractRes;
   }
 
+  const editLimitResult = await checkMessagesLimit(auth, {
+    mentions,
+    context: message.context,
+  });
+  if (editLimitResult.isErr()) {
+    return editLimitResult;
+  }
+
   let userMessage: UserMessageType | null = null;
   let agentMessages: AgentMessageType[] = [];
 
@@ -2445,6 +2453,26 @@ async function checkMessagesLimit(
   const owner = auth.getNonNullableWorkspace();
   const plan = auth.subscription()?.plan;
   const user = auth.user();
+
+  if (user) {
+    const membership =
+      await MembershipResource.getActiveMembershipOfUserInWorkspace({
+        user,
+        workspace: owner,
+      });
+    if (membership?.seatType === "none") {
+      return new Err({
+        status_code: 403,
+        api_error: {
+          type: "no_seat",
+          message:
+            "You don't have a seat in this workspace. Ask a workspace admin " +
+            "to assign you one to start sending messages.",
+        },
+      });
+    }
+  }
+
   if (owner.metronomeCustomerId && plan && isCreditPricedPlan(plan)) {
     const blockedReason = user
       ? await isUserBlocked(owner.sId, user.sId)

--- a/front/tests/utils/WorkspaceFactory.ts
+++ b/front/tests/utils/WorkspaceFactory.ts
@@ -1,6 +1,7 @@
 import { PlanModel } from "@app/lib/models/plan";
 import { upsertFreePlans } from "@app/lib/plans/free_plans";
 import {
+  CREDIT_PRICED_BUSINESS_PLAN_CODE,
   FREE_BYOK_PLAN_CODE,
   FREE_TEST_PLAN_CODE,
   PRO_PLAN_SEAT_29_CODE,
@@ -43,6 +44,19 @@ export class WorkspaceFactory {
     return this.create(PRO_PLAN_SEAT_29_CODE, overrides, {
       metronomeContractId: "test-metronome-contract-id",
     });
+  }
+
+  // A Metronome credit-priced workspace (plan code prefixed `CP_`), used to
+  // exercise credit-priced gating such as the per-user credit cap or the
+  // `none`-seat message block.
+  static async creditPriced(
+    overrides?: WorkspaceOverrides
+  ): Promise<WorkspaceType> {
+    return this.create(
+      CREDIT_PRICED_BUSINESS_PLAN_CODE,
+      { metronomeCustomerId: "cus_test_credit_priced", ...overrides },
+      { metronomeContractId: "test-metronome-contract-id" }
+    );
   }
 
   // Plans are seeded by the DB init script (admin/db.ts) to avoid deadlocks

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -677,6 +677,7 @@ export type SubmitMessageError = {
     | "plan_limit_reached_error"
     | "credits_exhausted_error"
     | "user_cap_reached_error"
+    | "no_seat_error"
     | "content_too_large";
   title: string;
   message: string;

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -74,6 +74,7 @@ const API_ERROR_TYPES = [
   "plan_message_limit_exceeded",
   "credits_exhausted",
   "user_cap_reached",
+  "no_seat",
   "model_disabled",
   "global_agent_error",
   "stripe_invalid_product_id_error",

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -24,7 +24,8 @@ export function isMembershipOriginType(
   return MEMBERSHIP_ORIGIN_TYPES.includes(value as MembershipOriginType);
 }
 
-export const MEMBERSHIP_SEAT_TYPES = [
+// Billable seat types — each maps to a Metronome product.
+export const BILLABLE_SEAT_TYPES = [
   "free",
   "workspace",
   "workspace_yearly",
@@ -32,6 +33,12 @@ export const MEMBERSHIP_SEAT_TYPES = [
   "pro_yearly",
   "max",
   "max_yearly",
+] as const;
+
+export const MEMBERSHIP_SEAT_TYPES = [
+  // `none` = no billable seat assigned; member cannot send messages.
+  "none",
+  ...BILLABLE_SEAT_TYPES,
 ] as const;
 
 export type MembershipSeatType = (typeof MEMBERSHIP_SEAT_TYPES)[number];
@@ -88,6 +95,7 @@ export function normalizeToPoolLimitSeatType(
     case "workspace_yearly":
       return "workspace";
     case "free":
+    case "none":
       return null;
     default:
       assertNever(seatType);

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -123,6 +123,7 @@ export function isSeatBased(
     case "max":
     case "max_yearly":
       return true;
+    case "none":
     case "workspace":
     case "workspace_yearly":
       return false;


### PR DESCRIPTION
## Summary

* Creating "none" seat type
* Blocking users with none seat type from sending messages
* Clear error messages to help users resolve situation

## Testing

<img width="933" height="490" alt="Screenshot 2026-06-04 at 2 16 07 PM" src="https://github.com/user-attachments/assets/43b6ec8d-3842-4da1-bfa2-fb2fbb87bb2a" />
<img width="971" height="94" alt="Screenshot 2026-06-04 at 2 16 38 PM" src="https://github.com/user-attachments/assets/34dc6236-06fd-42ff-afc6-d5ed8198a7e8" />

## Risk

* Only risk is unintended consequences for other seat types

## Deployment
1. deploy main