### PR TITLE
Pricing: default to 0 pool credits per user for business plans

### DIFF
--- a/front-api/routes/w/[wId]/usage_settings/default_user_spend_limit.test.ts
+++ b/front-api/routes/w/[wId]/usage_settings/default_user_spend_limit.test.ts
@@ -119,7 +119,7 @@ describe("/api/w/[wId]/usage_settings/default_user_spend_limit", () => {
       expect(await response.json()).toEqual({ awuCredits: 25_000 });
     });
 
-    it("returns 200 with awuCredits=null when no default is configured", async () => {
+    it("returns 200 with plan default when no default is configured (pro plan → 0)", async () => {
       vi.mocked(businessLayer.getDefaultUserSpendLimit).mockResolvedValueOnce(
         new Err(new DefaultUserSpendLimitError("not_found", "no default"))
       );
@@ -133,7 +133,7 @@ describe("/api/w/[wId]/usage_settings/default_user_spend_limit", () => {
       const response = await getRequest(workspace.sId);
 
       expect(response.status).toBe(200);
-      expect(await response.json()).toEqual({ awuCredits: null });
+      expect(await response.json()).toEqual({ awuCredits: 0 });
     });
 
     it("returns 502 on Metronome errors", async () => {

--- a/front-api/routes/w/[wId]/usage_settings/default_user_spend_limit.ts
+++ b/front-api/routes/w/[wId]/usage_settings/default_user_spend_limit.ts
@@ -7,6 +7,7 @@ import {
   getDefaultUserSpendLimit,
   setDefaultUserSpendLimit,
 } from "@app/lib/api/workspace/default_user_spend_limit";
+import { getPlanDefaultPoolLimitAwuCredits } from "@app/lib/plans/plan_codes";
 import {
   MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
   MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
@@ -106,7 +107,12 @@ app.get(
     const result = await getDefaultUserSpendLimit(auth);
     if (result.isErr()) {
       if (result.error.type === "not_found") {
-        return ctx.json({ awuCredits: null });
+        const planCode = auth
+          .getNonNullableSubscriptionResource()
+          .getPlan().code;
+        return ctx.json({
+          awuCredits: getPlanDefaultPoolLimitAwuCredits(planCode),
+        });
       }
       return apiError(ctx, mapErrorToApiError(result.error));
     }

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -67,9 +67,9 @@ async function resolvePoolLimitForUser({
   });
   if (userCapResult.isOk() && userCapResult.value) {
     // The threshold includes the seat allowance; subtract it to get the pool limit.
-    const totalThreshold = userCapResult.value.alert.threshold;
-    const seatAllowance = await getSeatAllowance(workspace, seatType);
-    return Math.max(0, totalThreshold - seatAllowance);
+    const totalThresholdAwuCredits = userCapResult.value.alert.threshold;
+    const seatAllowanceAwuCredits = await getSeatAllowance(workspace, seatType);
+    return Math.max(0, totalThresholdAwuCredits - seatAllowanceAwuCredits);
   }
 
   // 2. Per-seat-type workspace default.
@@ -81,9 +81,12 @@ async function resolvePoolLimitForUser({
       seatType: normalizedSeatType,
     });
     if (defaultCapResult.isOk() && defaultCapResult.value) {
-      const totalThreshold = defaultCapResult.value.alert.threshold;
-      const seatAllowance = await getSeatAllowance(workspace, seatType);
-      return Math.max(0, totalThreshold - seatAllowance);
+      const totalThresholdAwuCredits = defaultCapResult.value.alert.threshold;
+      const seatAllowanceAwuCredits = await getSeatAllowance(
+        workspace,
+        seatType
+      );
+      return Math.max(0, totalThresholdAwuCredits - seatAllowanceAwuCredits);
     }
   }
 

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -2,10 +2,19 @@ import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import { isPAYGEnabled } from "@app/lib/credits/credit_payg";
 import { getMetronomeProgrammaticCap } from "@app/lib/metronome/alerts/programmatic_cap";
+import {
+  getMetronomeDefaultUserCapAlertForSeatType,
+  getMetronomePerUserCap,
+} from "@app/lib/metronome/alerts/spend_limits";
 import { listMetronomeBalances } from "@app/lib/metronome/client";
 import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
 import { invalidateWorkspacePoolCredits } from "@app/lib/metronome/credit_balance";
+import { getActiveContract } from "@app/lib/metronome/plan_type";
 import { transitionProgrammaticCreditState } from "@app/lib/metronome/programmatic_credit_state_machine";
+import {
+  getAwuAllocationForSeatType,
+  getProductSeatTypes,
+} from "@app/lib/metronome/seat_types";
 import {
   clearUserCapBlocked,
   clearWorkspaceProgrammaticWarned,
@@ -15,21 +24,108 @@ import { transitionUserCreditState } from "@app/lib/metronome/user_credit_state_
 import type { WorkspaceCreditEvent } from "@app/lib/metronome/workspace_credit_state_machine";
 import { transitionWorkspaceCreditState } from "@app/lib/metronome/workspace_credit_state_machine";
 import { notifyAdminsProgrammaticCapReached } from "@app/lib/notifications/workflows/programmatic-cap-reached";
+import { getPlanDefaultPoolLimitAwuCredits } from "@app/lib/plans/plan_codes";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
+import type { MembershipSeatType } from "@app/types/memberships";
+import { normalizeToPoolLimitSeatType } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+
+/**
+ * Resolve the effective pool credit limit for a user.
+ *
+ * Priority: per-user Metronome override > per-seat-type workspace default > plan-tier fallback.
+ *
+ * Returns `number | null`:
+ *   - a number (including 0) when a limit is configured or implied by the plan
+ *   - `null` when the user has unlimited pool access (enterprise with no limit)
+ */
+async function resolvePoolLimitForUser({
+  workspace,
+  userId,
+  seatType,
+}: {
+  workspace: WorkspaceResource;
+  userId: string;
+  seatType: MembershipSeatType | null | undefined;
+}): Promise<number | null> {
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId) {
+    return null;
+  }
+
+  // 1. Per-user override.
+  const userCapResult = await getMetronomePerUserCap({
+    metronomeCustomerId,
+    workspaceId: workspace.sId,
+    userId,
+  });
+  if (userCapResult.isOk() && userCapResult.value) {
+    // The threshold includes the seat allowance; subtract it to get the pool limit.
+    const totalThreshold = userCapResult.value.alert.threshold;
+    const seatAllowance = await getSeatAllowance(workspace, seatType);
+    return Math.max(0, totalThreshold - seatAllowance);
+  }
+
+  // 2. Per-seat-type workspace default.
+  const normalizedSeatType = normalizeToPoolLimitSeatType(seatType);
+  if (normalizedSeatType) {
+    const defaultCapResult = await getMetronomeDefaultUserCapAlertForSeatType({
+      metronomeCustomerId,
+      workspaceId: workspace.sId,
+      seatType: normalizedSeatType,
+    });
+    if (defaultCapResult.isOk() && defaultCapResult.value) {
+      const totalThreshold = defaultCapResult.value.alert.threshold;
+      const seatAllowance = await getSeatAllowance(workspace, seatType);
+      return Math.max(0, totalThreshold - seatAllowance);
+    }
+  }
+
+  // 3. Plan-tier fallback: enterprise → unlimited, everything else → 0.
+  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+    workspace.id
+  );
+  const planCode = subscription?.getPlan().code;
+  if (!planCode) {
+    return 0;
+  }
+  return getPlanDefaultPoolLimitAwuCredits(planCode);
+}
+
+async function getSeatAllowance(
+  workspace: WorkspaceResource,
+  seatType: MembershipSeatType | null | undefined
+): Promise<number> {
+  const normalizedSeatType = normalizeToPoolLimitSeatType(seatType);
+  if (!normalizedSeatType) {
+    return 0;
+  }
+  const contract = await getActiveContract(workspace.sId);
+  if (!contract) {
+    return 0;
+  }
+  const productSeatTypes = await getProductSeatTypes();
+  return getAwuAllocationForSeatType(
+    contract,
+    normalizedSeatType,
+    productSeatTypes
+  );
+}
 
 /**
  * Transition a single user from `user_seat` / `user_seat_low_balance` when
  * Metronome fires `alerts.low_remaining_seat_balance_reached` for that user.
  *
- * Paid seats fall back to the workspace pool (`on_pool`). Free seats have no
- * pool access and are capped (`capped`). The guard in the state machine decides
- * which branch applies based on `seatType`.
+ * Resolves the user's effective pool credit limit from Metronome alerts, then
+ * falls back by plan tier (enterprise → unlimited, business → 0). The state
+ * machine uses this limit to decide whether the user goes to `on_pool` or
+ * `capped`.
  */
 export async function dispatchSeatBalanceExhausted({
   workspace,
@@ -61,9 +157,15 @@ export async function dispatchSeatBalanceExhausted({
     return;
   }
 
+  const poolLimitAwuCredits = await resolvePoolLimitForUser({
+    workspace,
+    userId,
+    seatType: membership.seatType,
+  });
+
   const result = await transitionUserCreditState(
     membership,
-    { type: "seat_balance_exhausted" },
+    { type: "seat_balance_exhausted", poolLimitAwuCredits },
     { workspaceId: workspace.sId, userId, seatType: membership.seatType }
   );
   if (result.isErr()) {
@@ -73,6 +175,7 @@ export async function dispatchSeatBalanceExhausted({
         userId,
         seatType: membership.seatType,
         creditState: membership.creditState,
+        poolLimitAwuCredits,
       },
       "[CreditStateDispatcher] dispatchSeatBalanceExhausted: transition skipped"
     );

--- a/front/lib/api/workspace/default_user_spend_limit.test.ts
+++ b/front/lib/api/workspace/default_user_spend_limit.test.ts
@@ -261,7 +261,7 @@ describe("setDefaultUserSpendLimit", () => {
     });
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-    for (const awuCredits of [0, -1, 1_000_001, 1.5]) {
+    for (const awuCredits of [-1, 1_000_001, 1.5]) {
       const result = await setDefaultUserSpendLimit(auth, {
         awuCredits,
         auditContext: AUDIT_CONTEXT,

--- a/front/lib/api/workspace/default_user_spend_limit.ts
+++ b/front/lib/api/workspace/default_user_spend_limit.ts
@@ -120,7 +120,6 @@ export async function setDefaultUserSpendLimit(
   }
 ): Promise<Result<DefaultUserSpendLimit, DefaultUserSpendLimitError>> {
   if (
-    // TODO: allow O, not reason not to.
     !Number.isInteger(poolAwuCredits) ||
     poolAwuCredits < MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS ||
     poolAwuCredits > MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS

--- a/front/lib/metronome/user_credit_state_machine.test.ts
+++ b/front/lib/metronome/user_credit_state_machine.test.ts
@@ -214,7 +214,7 @@ describe("UserCreditStateMachine — seat_balance_exhausted", () => {
     const membership = makeMembership("user_seat", "free");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted" },
+      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
       { ...baseCtx, seatType: "free" }
     );
     expect(result.isOk()).toBe(true);
@@ -238,7 +238,7 @@ describe("UserCreditStateMachine — seat_balance_exhausted", () => {
     const membership = makeMembership("user_seat_low_balance", "free");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted" },
+      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
       { ...baseCtx, seatType: "free" }
     );
     expect(result.isOk()).toBe(true);
@@ -257,11 +257,11 @@ describe("UserCreditStateMachine — seat_balance_exhausted", () => {
     );
   });
 
-  it("user_seat + pro seat → on_pool", async () => {
+  it("user_seat + pro seat + pool limit > 0 → on_pool", async () => {
     const membership = makeMembership("user_seat", "pro");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted" },
+      { type: "seat_balance_exhausted", poolLimitAwuCredits: 5000 },
       { ...baseCtx, seatType: "pro" }
     );
     expect(result.isOk()).toBe(true);
@@ -281,11 +281,56 @@ describe("UserCreditStateMachine — seat_balance_exhausted", () => {
     );
   });
 
-  it("user_seat_low_balance + max seat → on_pool", async () => {
+  it("user_seat + pro seat + pool limit null (unlimited) → on_pool", async () => {
+    const membership = makeMembership("user_seat", "pro");
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
+      { ...baseCtx, seatType: "pro" }
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("on_pool");
+    }
+    expect(membership.updateCreditState).toHaveBeenCalledWith(
+      "on_pool",
+      undefined
+    );
+    expect(mockSetUserCreditState).toHaveBeenCalledWith(
+      "ws_test",
+      "u_test",
+      "on_pool"
+    );
+  });
+
+  it("user_seat + pro seat + pool limit = 0 → capped", async () => {
+    const membership = makeMembership("user_seat", "pro");
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "seat_balance_exhausted", poolLimitAwuCredits: 0 },
+      { ...baseCtx, seatType: "pro" }
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("capped");
+    }
+    expect(membership.updateCreditState).toHaveBeenCalledWith(
+      "capped",
+      undefined
+    );
+    expect(mockSetUserCapBlocked).toHaveBeenCalledWith("ws_test", "u_test");
+    expect(mockSetUserCreditState).toHaveBeenCalledWith(
+      "ws_test",
+      "u_test",
+      "capped"
+    );
+  });
+
+  it("user_seat_low_balance + max seat + pool limit null → on_pool", async () => {
     const membership = makeMembership("user_seat_low_balance", "max");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted" },
+      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
       { ...baseCtx, seatType: "max" }
     );
     expect(result.isOk()).toBe(true);

--- a/front/lib/metronome/user_credit_state_machine.ts
+++ b/front/lib/metronome/user_credit_state_machine.ts
@@ -43,12 +43,13 @@ export type UserCreditEvent =
    */
   | { type: "admin_raised_user_cap" }
   /**
-   * This user's personal seat balance is exhausted. Paid seats fall back to
-   * the workspace pool (`on_pool`); free seats cannot use the pool and are
-   * transitioned to `capped`. The guard on each transition decides which
-   * branch applies based on `ctx.seatType`.
+   * This user's personal seat balance is exhausted. The user's effective pool
+   * limit determines the next state:
+   *   - free seats → always `capped` (no pool access)
+   *   - paid seats with `poolLimitAwuCredits === 0` → `capped`
+   *   - paid seats with `poolLimitAwuCredits > 0` or `null` (unlimited) → `on_pool`
    */
-  | { type: "seat_balance_exhausted" }
+  | { type: "seat_balance_exhausted"; poolLimitAwuCredits: number | null }
   /**
    * This user's personal seat balance crossed a low-balance warning threshold
    * (balance > 0). Moves `user_seat` → `user_seat_low_balance`.
@@ -154,8 +155,10 @@ const TRANSITIONS: UserCreditTransition[] = [
     to: "on_pool",
   },
 
-  // Seat balance exhausted. Order matters: free check first (guard wins on
-  // first match), paid fallback second.
+  // Seat balance exhausted. Order matters: most specific guard first.
+  //  1. Free seats → always capped (no pool access).
+  //  2. Paid seats with pool limit = 0 → capped (no pool budget).
+  //  3. Paid seats with pool limit > 0 or null (unlimited) → on_pool.
   {
     from: ["user_seat", "user_seat_low_balance", "capped"],
     event: "seat_balance_exhausted",
@@ -163,9 +166,21 @@ const TRANSITIONS: UserCreditTransition[] = [
     to: "capped",
   },
   {
+    from: ["user_seat", "user_seat_low_balance", "capped"],
+    event: "seat_balance_exhausted",
+    guard: (ctx, event) =>
+      ctx.seatType !== "free" &&
+      event.type === "seat_balance_exhausted" &&
+      event.poolLimitAwuCredits === 0,
+    to: "capped",
+  },
+  {
     from: ["user_seat", "user_seat_low_balance", "on_pool"],
     event: "seat_balance_exhausted",
-    guard: (ctx) => ctx.seatType !== "free",
+    guard: (ctx, event) =>
+      ctx.seatType !== "free" &&
+      event.type === "seat_balance_exhausted" &&
+      event.poolLimitAwuCredits !== 0,
     to: "on_pool",
   },
 

--- a/front/lib/plans/plan_codes.ts
+++ b/front/lib/plans/plan_codes.ts
@@ -116,6 +116,22 @@ export function isProOrBusinessPlanCode(plan?: PlanType) {
 }
 
 /**
+ * Returns the implicit default pool credit limit for a plan when no explicit
+ * limit has been configured in Metronome.
+ *
+ *   - Enterprise plans → `null` (unlimited pool access)
+ *   - Everything else (business, pro, free) → `0` (no pool access)
+ */
+export function getPlanDefaultPoolLimitAwuCredits(
+  planCode: string
+): number | null {
+  if (isEnterprisePlanPrefix(planCode)) {
+    return null;
+  }
+  return 0;
+}
+
+/**
  * `isUpgraded` returns true if the plan has access to all features of Dust, including large
  * language models (meaning it's either a paid plan or free plan with (eg friends and family, or
  * free trial plan)).

--- a/front/pages/api/w/[wId]/usage_settings/default_user_spend_limit.test.ts
+++ b/front/pages/api/w/[wId]/usage_settings/default_user_spend_limit.test.ts
@@ -97,7 +97,7 @@ describe("/api/w/[wId]/usage_settings/default_user_spend_limit", () => {
       expect(res._getJSONData()).toEqual({ awuCredits: 25_000 });
     });
 
-    it("returns 200 with awuCredits=null when no default is configured", async () => {
+    it("returns 200 with plan default when no default is configured (pro plan → 0)", async () => {
       vi.mocked(businessLayer.getDefaultUserSpendLimit).mockResolvedValueOnce(
         new Err(new DefaultUserSpendLimitError("not_found", "no default"))
       );
@@ -112,7 +112,7 @@ describe("/api/w/[wId]/usage_settings/default_user_spend_limit", () => {
       await handler(req, res);
 
       expect(res._getStatusCode()).toBe(200);
-      expect(res._getJSONData()).toEqual({ awuCredits: null });
+      expect(res._getJSONData()).toEqual({ awuCredits: 0 });
     });
 
     it("returns 502 on Metronome errors", async () => {

--- a/front/pages/api/w/[wId]/usage_settings/default_user_spend_limit.ts
+++ b/front/pages/api/w/[wId]/usage_settings/default_user_spend_limit.ts
@@ -10,6 +10,7 @@ import {
   setDefaultUserSpendLimit,
 } from "@app/lib/api/workspace/default_user_spend_limit";
 import type { Authenticator } from "@app/lib/auth";
+import { getPlanDefaultPoolLimitAwuCredits } from "@app/lib/plans/plan_codes";
 import { apiError } from "@app/logger/withlogging";
 import {
   MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
@@ -124,7 +125,12 @@ async function handler(
       const result = await getDefaultUserSpendLimit(auth);
       if (result.isErr()) {
         if (result.error.type === "not_found") {
-          return res.status(200).json({ awuCredits: null });
+          const planCode = auth
+            .getNonNullableSubscriptionResource()
+            .getPlan().code;
+          return res.status(200).json({
+            awuCredits: getPlanDefaultPoolLimitAwuCredits(planCode),
+          });
         }
         return mapErrorToHttp(req, res, result.error);
       }

--- a/front/types/credits.ts
+++ b/front/types/credits.ts
@@ -80,7 +80,7 @@ export function isCreditType(value: unknown): value is CreditType {
 // Credit expiration duration in days (default: 1 year)
 export const CREDIT_EXPIRATION_DAYS = 365;
 
-export const MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS = 1000;
+export const MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS = 0;
 export const MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS = 1_000_000;
 
 export type CreditDisplayData = {


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/8620

Business plan default credit pool limit is now 0. 
We don't set the 0 limit explicitly in metronome, but when reaching the end of the seat we do check the value:
 - if the user or their seat has a limit, use this
 - if no limit has been set and user is in business, then it's 0 and the user is capped.


## Tests


## Risk

low

## Deploy Plan

deploy front 
