### PR TITLE
update(eleven labs package) for sourceUrl

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -56,7 +56,7 @@
     "@dust-tt/client": "file:../sdks/js",
     "@dust-tt/sparkle": "^0.7.7",
     "@elastic/elasticsearch": "^8.15.0",
-    "@elevenlabs/elevenlabs-js": "^2.39.0",
+    "@elevenlabs/elevenlabs-js": "^2.49.1",
     "@emoji-mart/data": "^1.2.1",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -499,7 +499,7 @@
         "@dust-tt/client": "file:../sdks/js",
         "@dust-tt/sparkle": "^0.7.7",
         "@elastic/elasticsearch": "^8.15.0",
-        "@elevenlabs/elevenlabs-js": "^2.39.0",
+        "@elevenlabs/elevenlabs-js": "^2.49.1",
         "@emoji-mart/data": "^1.2.1",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
@@ -4415,9 +4415,9 @@
       }
     },
     "node_modules/@elevenlabs/elevenlabs-js": {
-      "version": "2.39.0",
-      "resolved": "https://registry.npmjs.org/@elevenlabs/elevenlabs-js/-/elevenlabs-js-2.39.0.tgz",
-      "integrity": "sha512-Yfh2wa5Y7wwoEHi2Na1YWrkc3z21oeHMo8qhGc5kcbQoWfgQfIxWuGfXHZSmUXOJz0mNL5bAfp3hHaJEX68DIA==",
+      "version": "2.49.1",
+      "resolved": "https://registry.npmjs.org/@elevenlabs/elevenlabs-js/-/elevenlabs-js-2.49.1.tgz",
+      "integrity": "sha512-ctwKJaF+ZU3auuuVQK/UBYz5Qev1pqDrnV+BktM+vRvtyt9s1vJvHydCODuj9/uObp8BST2+a5/zu1uShd+ryQ==",
       "license": "MIT",
       "dependencies": {
         "command-exists": "^1.2.9",


### PR DESCRIPTION
## Description

Upgrades the `@elevenlabs/elevenlabs-js` dependency from `^2.39.0` to `^2.49.1`. Version 2.49.1 adds the full response object to Speech Engine API calls, which exposes the `sourceUrl` field needed for downstream use in the speech generation tooling.

## Tests

Manual testing of the speech generation and transcription features using the updated SDK.

## Risk

Minor risk from the library upgrade (10 minor versions). The change is limited to the ElevenLabs SDK and does not affect any database schema or infrastructure configuration.

## Deploy Plan

Deploy front.