### PR TITLE
fix: add retry for GCS stream uploads and retryOptions to connectors Storage [#8608]

### DIFF
--- a/connectors/src/connectors/github/lib/code/gcs_repository.ts
+++ b/connectors/src/connectors/github/lib/code/gcs_repository.ts
@@ -7,8 +7,8 @@ import {
 import type { Logger } from "@connectors/logger/logger";
 import logger from "@connectors/logger/logger";
 import { isDevelopment } from "@connectors/types";
-import type { Bucket, File } from "@google-cloud/storage";
-import { Storage } from "@google-cloud/storage";
+import type { ApiError, Bucket, File } from "@google-cloud/storage";
+import { RETRYABLE_ERR_FN_DEFAULT, Storage } from "@google-cloud/storage";
 import chunk from "lodash/chunk";
 import type { Readable } from "stream";
 import { pipeline } from "stream/promises";
@@ -25,6 +25,14 @@ const STREAM_THRESHOLD_BYTES = 2 * 1024 * 1024; // 2MB - files smaller than this
 const SMALL_FILE_UPLOAD_MAX_RETRIES = 3;
 const SMALL_FILE_UPLOAD_BASE_DELAY_MS = 500;
 const GCS_RESUMABLE_UPLOAD_THRESHOLD_BYTES = 10 * 1024 * 1024; // 10MB
+const GCS_EXTRA_RETRYABLE_ERROR_MESSAGE_REGEX = /socket hang up/i;
+
+function isRetryableGCSError(err: ApiError): boolean {
+  return (
+    RETRYABLE_ERR_FN_DEFAULT(err) ||
+    GCS_EXTRA_RETRYABLE_ERROR_MESSAGE_REGEX.test(err.message)
+  );
+}
 
 // Files are faster to upsert than directories, so we can afford to have more files per index file.
 const FILES_PER_INDEX = 4000; // Files per index file.
@@ -70,6 +78,10 @@ export class GCSRepositoryManager {
       keyFilename: isDevelopment()
         ? connectorsConfig.getServiceAccount()
         : undefined,
+      retryOptions: {
+        maxRetries: SMALL_FILE_UPLOAD_MAX_RETRIES,
+        retryableErrorFn: isRetryableGCSError,
+      },
     });
     this.bucket = this.storage.bucket(
       connectorsConfig.getDustTmpSyncBucketName()

--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -79,17 +79,48 @@ export class FileStorage {
    */
 
   async uploadFileToBucket(file: formidable.File, destPath: string) {
-    const gcsFile = this.file(destPath);
-    const fileStream = fs.createReadStream(file.filepath);
+    // Stream-based uploads via pipeline() + createWriteStream() bypass the
+    // SDK's built-in retryOptions, so we need application-level retry.
+    // Since the source is a local file we can safely re-create the read stream.
+    for (let attempt = 1; attempt <= GCS_COPY_MAX_RETRIES; attempt++) {
+      try {
+        const gcsFile = this.file(destPath);
+        const fileStream = fs.createReadStream(file.filepath);
 
-    await pipeline(
-      fileStream,
-      gcsFile.createWriteStream({
-        metadata: {
-          contentType: file.mimetype ?? undefined,
-        },
-      })
-    );
+        await pipeline(
+          fileStream,
+          gcsFile.createWriteStream({
+            metadata: {
+              contentType: file.mimetype ?? undefined,
+            },
+          })
+        );
+
+        return;
+      } catch (err) {
+        if (
+          attempt === GCS_COPY_MAX_RETRIES ||
+          !isRetryableGCSError(err as ApiError)
+        ) {
+          throw err;
+        }
+
+        const delayMs = GCS_COPY_BASE_DELAY_MS * attempt ** 2;
+
+        logger.warn(
+          {
+            error: normalizeError(err),
+            destPath,
+            attempt,
+            maxRetries: GCS_COPY_MAX_RETRIES,
+            delayMs,
+          },
+          "GCS file upload failed (stream), retrying."
+        );
+
+        await setTimeoutAsync(delayMs);
+      }
+    }
   }
 
   async uploadRawContentToBucket({


### PR DESCRIPTION
## Description

Fixes two gaps that left GCS stream uploads and the connectors GitHub code sync Storage instance without retry logic on `socket hang up` / `ECONNRESET` errors (6,000+/day across EU and US buckets). Closes dust-tt/tasks#8608.

**Gap 1 — `uploadFileToBucket()` bypasses SDK retries.**
`pipeline() + createWriteStream()` is a streaming operation; the GCS SDK's `retryOptions` only apply to non-streaming methods. Added an application-level retry loop (up to `GCS_COPY_MAX_RETRIES = 3` attempts, exponential backoff starting at 500 ms) reusing the existing `isRetryableGCSError` / `GCS_COPY_BASE_DELAY_MS` / `GCS_COPY_MAX_RETRIES` constants. The read stream is re-created on each attempt since the source is a local file.

**Gap 2 — `GCSRepositoryManager` Storage has no `retryableErrorFn`.**
Added `isRetryableGCSError` (same pattern as `front`) and wired `retryOptions` into the connectors `Storage` constructor so SDK methods (`.save()`, `.download()`) also retry on `socket hang up`.

## Tests

Manually verified type-check passes on both `front` and `connectors` workspaces. The retry path mirrors the existing `copyFile()` retry pattern which is already in production.

## Risk

Low. Non-retryable errors are re-thrown immediately on the first failure. Retryable errors get up to 3 attempts (500 ms, 2 s, 4.5 s backoff). The `isRetryableGCSError` function is already battle-tested in `front`.
