### PR TITLE
feat(mobile): land on the new conversation screen as homepage

### DIFF
--- a/x/adrsimon/mobile/Dust/Views/Components/InputBarView.swift
+++ b/x/adrsimon/mobile/Dust/Views/Components/InputBarView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct InputBarView: View {
     @ObservedObject var viewModel: InputBarViewModel
     var conversationId: String?
+    var autoFocus: Bool = false
     var onConversationCreated: ((Conversation) -> Void)?
     var onMessageSent: (() -> Void)?
     var onWillSendReply: ((String) -> Void)?
@@ -86,6 +87,12 @@ struct InputBarView: View {
                 }
             )
             .presentationDetents([.medium, .large])
+        }
+        .task {
+            // A task hop is needed; setting @FocusState in onAppear doesn't take.
+            if autoFocus {
+                isTextFieldFocused = true
+            }
         }
     }
 
@@ -274,7 +281,8 @@ struct InputBarView: View {
 
     private var sendButton: some View {
         Button {
-            Task {
+            // @MainActor so callbacks after the await (e.g. navigation) run on the main actor.
+            Task { @MainActor in
                 isTextFieldFocused = false
                 if let conversationId {
                     let pendingText = viewModel.messageText.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/x/adrsimon/mobile/Dust/Views/MainContainerView.swift
+++ b/x/adrsimon/mobile/Dust/Views/MainContainerView.swift
@@ -2,8 +2,8 @@ import SparkleTokens
 import SwiftUI
 
 enum ConversationDestination: Hashable {
+    case compose
     case conversation(Conversation)
-    case newConversation
     case pod(Space)
     case newPodConversation(Space)
 }
@@ -15,7 +15,8 @@ struct MainContainerView: View {
     @EnvironmentObject private var authViewModel: AuthViewModel
     @StateObject private var viewModel: ConversationListViewModel
     @Environment(\.scenePhase) private var scenePhase
-    @State private var navigationPath = NavigationPath()
+    // List is the nav root; compose is pushed so we land on compose and swipe-back reveals the list.
+    @State private var navigationPath = NavigationPath([ConversationDestination.compose])
     @State private var showCatchUp = false
 
     private let tokenProvider: TokenProvider
@@ -40,102 +41,11 @@ struct MainContainerView: View {
 
     private var mainContent: some View {
         NavigationStack(path: $navigationPath) {
-            ConversationListView(
-                searchText: $viewModel.searchText,
-                groupedConversations: viewModel.groupedConversations,
-                pods: viewModel.pods,
-                isPodsExpanded: $viewModel.isPodsExpanded,
-                user: user,
-                currentWorkspace: viewModel.workspace,
-                workspaces: viewModel.workspaces,
-                isLoading: isLoading,
-                onNewConversation: {
-                    navigationPath.append(ConversationDestination.newConversation)
-                },
-                onSelectConversation: { conversation in
-                    navigationPath.append(ConversationDestination.conversation(conversation))
-                },
-                onSelectPod: { pod in
-                    navigationPath.append(ConversationDestination.pod(pod))
-                },
-                onSwitchWorkspace: { workspace in
-                    navigationPath = NavigationPath()
-                    Task { await viewModel.switchWorkspace(workspace) }
-                },
-                onToggleReadStatus: { conversation in
-                    Task { await viewModel.toggleReadStatus(for: conversation) }
-                },
-                onDelete: { conversation in
-                    Task { await viewModel.deleteConversation(conversation) }
-                },
-                onLogout: onLogout,
-                onCatchUp: viewModel.unreadConversations.isEmpty ? nil : {
-                    showCatchUp = true
-                },
-                onRefresh: {
-                    await viewModel.refresh()
+            conversationList
+                .navigationBarHidden(true)
+                .navigationDestination(for: ConversationDestination.self) { destination in
+                    destinationView(for: destination)
                 }
-            )
-            .navigationBarHidden(true)
-            .navigationDestination(for: ConversationDestination.self) { destination in
-                switch destination {
-                case let .conversation(conversation):
-                    if let workspaceId = viewModel.workspace?.sId {
-                        ConversationDetailView(
-                            conversation: conversation,
-                            workspaceId: workspaceId,
-                            tokenProvider: tokenProvider,
-                            user: user,
-                            currentUserEmail: user.email
-                        )
-                    }
-
-                case .newConversation:
-                    if let workspaceId = viewModel.workspace?.sId {
-                        NewConversationView(
-                            firstName: user.firstName,
-                            user: user,
-                            workspaceId: workspaceId,
-                            tokenProvider: tokenProvider,
-                            onConversationCreated: { conversation in
-                                navigationPath = NavigationPath([ConversationDestination.conversation(conversation)])
-                            }
-                        )
-                    }
-
-                case let .pod(space):
-                    if let workspaceId = viewModel.workspace?.sId {
-                        PodConversationsView(
-                            space: space,
-                            workspaceId: workspaceId,
-                            tokenProvider: tokenProvider,
-                            onSelectConversation: { conversation in
-                                navigationPath.append(ConversationDestination.conversation(conversation))
-                            },
-                            onNewConversation: {
-                                navigationPath.append(ConversationDestination.newPodConversation(space))
-                            }
-                        )
-                    }
-
-                case let .newPodConversation(space):
-                    if let workspaceId = viewModel.workspace?.sId {
-                        NewConversationView(
-                            firstName: user.firstName,
-                            user: user,
-                            workspaceId: workspaceId,
-                            tokenProvider: tokenProvider,
-                            spaceId: space.sId,
-                            onConversationCreated: { conversation in
-                                navigationPath = NavigationPath([
-                                    ConversationDestination.pod(space),
-                                    ConversationDestination.conversation(conversation),
-                                ])
-                            }
-                        )
-                    }
-                }
-            }
         }
         .fullScreenCover(isPresented: $showCatchUp) {
             if let workspaceId = viewModel.workspace?.sId {
@@ -150,8 +60,7 @@ struct MainContainerView: View {
                     },
                     onOpenConversation: { conversation in
                         showCatchUp = false
-                        navigationPath = NavigationPath()
-                        navigationPath.append(ConversationDestination.conversation(conversation))
+                        navigationPath = NavigationPath([ConversationDestination.conversation(conversation)])
                     }
                 )
             }
@@ -167,6 +76,113 @@ struct MainContainerView: View {
         .onChange(of: scenePhase) {
             if scenePhase == .active {
                 Task { await viewModel.refresh() }
+            }
+        }
+    }
+
+    // MARK: - Root: conversation list
+
+    private var conversationList: some View {
+        ConversationListView(
+            searchText: $viewModel.searchText,
+            groupedConversations: viewModel.groupedConversations,
+            pods: viewModel.pods,
+            isPodsExpanded: $viewModel.isPodsExpanded,
+            user: user,
+            currentWorkspace: viewModel.workspace,
+            workspaces: viewModel.workspaces,
+            isLoading: isLoading,
+            onNewConversation: {
+                navigationPath.append(ConversationDestination.compose)
+            },
+            onSelectConversation: { conversation in
+                navigationPath.append(ConversationDestination.conversation(conversation))
+            },
+            onSelectPod: { pod in
+                navigationPath.append(ConversationDestination.pod(pod))
+            },
+            onSwitchWorkspace: { workspace in
+                navigationPath = NavigationPath()
+                Task { await viewModel.switchWorkspace(workspace) }
+            },
+            onToggleReadStatus: { conversation in
+                Task { await viewModel.toggleReadStatus(for: conversation) }
+            },
+            onDelete: { conversation in
+                Task { await viewModel.deleteConversation(conversation) }
+            },
+            onLogout: onLogout,
+            onCatchUp: viewModel.unreadConversations.isEmpty ? nil : {
+                showCatchUp = true
+            },
+            onRefresh: {
+                await viewModel.refresh()
+            }
+        )
+    }
+
+    // MARK: - Pushed destinations
+
+    @ViewBuilder
+    private func destinationView(for destination: ConversationDestination) -> some View {
+        switch destination {
+        case .compose:
+            if let workspaceId = viewModel.workspace?.sId {
+                NewConversationView(
+                    firstName: user.firstName,
+                    user: user,
+                    workspaceId: workspaceId,
+                    tokenProvider: tokenProvider,
+                    autoFocus: true,
+                    onConversationCreated: { conversation in
+                        // Replace compose so back returns to the list.
+                        navigationPath = NavigationPath([ConversationDestination.conversation(conversation)])
+                    }
+                )
+                .id(workspaceId)
+            }
+
+        case let .conversation(conversation):
+            if let workspaceId = viewModel.workspace?.sId {
+                ConversationDetailView(
+                    conversation: conversation,
+                    workspaceId: workspaceId,
+                    tokenProvider: tokenProvider,
+                    user: user,
+                    currentUserEmail: user.email
+                )
+            }
+
+        case let .pod(space):
+            if let workspaceId = viewModel.workspace?.sId {
+                PodConversationsView(
+                    space: space,
+                    workspaceId: workspaceId,
+                    tokenProvider: tokenProvider,
+                    onSelectConversation: { conversation in
+                        navigationPath.append(ConversationDestination.conversation(conversation))
+                    },
+                    onNewConversation: {
+                        navigationPath.append(ConversationDestination.newPodConversation(space))
+                    }
+                )
+            }
+
+        case let .newPodConversation(space):
+            if let workspaceId = viewModel.workspace?.sId {
+                NewConversationView(
+                    firstName: user.firstName,
+                    user: user,
+                    workspaceId: workspaceId,
+                    tokenProvider: tokenProvider,
+                    spaceId: space.sId,
+                    onConversationCreated: { conversation in
+                        navigationPath = NavigationPath([
+                            ConversationDestination.pod(space),
+                            ConversationDestination.conversation(conversation),
+                        ])
+                    }
+                )
             }
         }
     }

--- a/x/adrsimon/mobile/Dust/Views/NewConversationView.swift
+++ b/x/adrsimon/mobile/Dust/Views/NewConversationView.swift
@@ -13,6 +13,7 @@ struct NewConversationView: View {
     let workspaceId: String
     let tokenProvider: TokenProvider
     var spaceId: String?
+    var autoFocus: Bool = false
     let onConversationCreated: (Conversation) -> Void
 
     @StateObject private var inputBarViewModel: InputBarViewModel
@@ -34,6 +35,7 @@ struct NewConversationView: View {
         workspaceId: String,
         tokenProvider: TokenProvider,
         spaceId: String? = nil,
+        autoFocus: Bool = false,
         onConversationCreated: @escaping (Conversation) -> Void
     ) {
         self.firstName = firstName
@@ -41,6 +43,7 @@ struct NewConversationView: View {
         self.workspaceId = workspaceId
         self.tokenProvider = tokenProvider
         self.spaceId = spaceId
+        self.autoFocus = autoFocus
         self.onConversationCreated = onConversationCreated
         _inputBarViewModel = StateObject(
             wrappedValue: InputBarViewModel(
@@ -87,6 +90,7 @@ struct NewConversationView: View {
 
                 InputBarView(
                     viewModel: inputBarViewModel,
+                    autoFocus: autoFocus,
                     onConversationCreated: onConversationCreated
                 )
                 .opacity(uiOpacity)


### PR DESCRIPTION
## Description

Makes the mobile app open directly on the compose ("new conversation") screen instead of the conversation list.

The conversation list is now the navigation root, with compose pushed on top at launch. This is plain `NavigationStack` (no overlay, no custom gestures) and gives the natural hierarchy:

- Launch → land on compose, with the message field auto-focused.
- Swipe left→right from compose → the list slides in from the left (native back gesture).
- Tap a conversation in the list → push it; swipe back returns to the **list**.
- Send from compose → opens the created conversation; back → list.
- "New conversation" from the list → pushes a fresh compose.

Also fixes a latent concurrency bug in the send path — the post-`await` callback ran on a non-isolated `Task`, so the navigation that opens the created conversation could run off the main actor and be dropped; it now runs on `@MainActor`.

## Tests

Manual, on a device build:
- Cold launch lands on compose with keyboard up.
- Swipe-back from compose reveals the list; swipe-back from a conversation returns to the list.
- Pod new-conversation flow unaffected.

## Risk

Low, mobile-only. Worst case the navigation hierarchy feels off; safe to rollback (single revert, no migrations or API changes).

## Deploy Plan

Standard mobile build/release; no backend or migration steps. Merge #26808 first.