### PR TITLE
fix(mobile): decode nested conversation content

### DIFF
--- a/x/adrsimon/mobile/Dust/Models/Conversation.swift
+++ b/x/adrsimon/mobile/Dust/Models/Conversation.swift
@@ -53,8 +53,8 @@ struct Conversation: Decodable, Identifiable, Hashable {
         self.unread = try container.decode(Bool.self, forKey: .unread)
         self.actionRequired = try container.decode(Bool.self, forKey: .actionRequired)
 
-        let content = try container.decodeIfPresent([PreviewMessage].self, forKey: .content)
-        self.preview = content.flatMap(ConversationPreview.init(content:))
+        let content = try container.decodeIfPresent([[PreviewMessage]].self, forKey: .content)
+        self.preview = content.map { $0.compactMap(\.last) }.flatMap(ConversationPreview.init(content:))
     }
 }
 


### PR DESCRIPTION
## Description

Sending a message in the mobile app appeared to fail silently: the conversation was created server-side, but the client never navigated to it.

Root cause: the conversation create/detail API returns `content` as a nested array (messages-by-rank — each rank is an array of message versions), but `Conversation` decoded it as a flat array and threw a `typeMismatch` at `conversation.content[0]`. The decode error bubbled up, `sendMessage()` returned nil, and the UI stayed put. The conversation **list** endpoint omits `content`, which is why this stayed hidden.

Fix: decode the nested `[[PreviewMessage]]` shape and take the current (last) version of each rank when deriving the preview.

## Tests

Manual, on a device build: confirmed via device logs that the create response was throwing a decode `typeMismatch`; after the fix the response decodes and message sending navigates into the created conversation.

## Risk

Low, mobile-only. The change is strictly more permissive — it matches the actual API shape. Safe to rollback (single revert, no backend/migration impact).

## Deploy Plan

Standard mobile build/release; no backend or migration steps.