### PR TITLE
[front] support per-model EAP Anthropic API key

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -102,6 +102,13 @@ const config = {
   getSendgridApiKey: (): string => {
     return EnvironmentConfig.getEnvVariable("SENDGRID_API_KEY");
   },
+  // Dedicated Anthropic API key scoped to our EAP workspace. Optional: only set
+  // in deployments that serve EAP models (those with `useEapKey` in their config).
+  getAnthropicEapApiKey: (): string | null => {
+    return (
+      EnvironmentConfig.getOptionalEnvVariable("ANTHROPIC_EAP_API_KEY") ?? null
+    );
+  },
   getSupportEmailAddress: (): { name: string; email: string } => {
     return {
       name: "Dust team",

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -158,10 +158,17 @@ export async function getLLM(
   }
 
   if (isAnthropicWhitelistedModelId(modelId)) {
-    const useVertex =
-      useVertexPrerequisite && isAnthropicVertexWhitelistedModelId(modelId);
+    const useEapKey = modelConfig.useEapKey ?? false;
 
-    const anthropicCredentials = modelConfig.useEapKey
+    // EAP models must hit the Anthropic API directly with the EAP key. Vertex
+    // authenticates via GCP project creds and ignores ANTHROPIC_API_KEY, so
+    // routing an EAP model through Vertex would silently drop the EAP key.
+    const useVertex =
+      !useEapKey &&
+      useVertexPrerequisite &&
+      isAnthropicVertexWhitelistedModelId(modelId);
+
+    const anthropicCredentials = useEapKey
       ? withEapAnthropicKey(modelId, credentials)
       : credentials;
 

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -1,3 +1,4 @@
+import config from "@app/lib/api/config";
 import { AnthropicLLM } from "@app/lib/api/llm/clients/anthropic";
 import {
   isAnthropicVertexWhitelistedModelId,
@@ -23,6 +24,23 @@ import type { LLMParameters } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
+import type { LLMCredentialsType } from "@app/types/provider_credential";
+
+// EAP models are served through a dedicated Anthropic workspace key
+// (ANTHROPIC_EAP_API_KEY) rather than the workspace's Dust-managed / BYOK
+// credentials. Fail loudly if the key is missing so the model is unavailable
+// instead of silently falling back to the standard key.
+function withEapAnthropicKey(
+  credentials: LLMCredentialsType
+): LLMCredentialsType {
+  const eapApiKey = config.getAnthropicEapApiKey();
+  if (!eapApiKey) {
+    throw new Error(
+      "ANTHROPIC_EAP_API_KEY is not configured but this model requires the EAP Anthropic key."
+    );
+  }
+  return { ...credentials, ANTHROPIC_API_KEY: eapApiKey };
+}
 
 export async function getLLM(
   auth: Authenticator,
@@ -140,7 +158,9 @@ export async function getLLM(
 
     return new AnthropicLLM(auth, {
       useVertex,
-      credentials,
+      credentials: modelConfig.useEapKey
+        ? withEapAnthropicKey(credentials)
+        : credentials,
       getTraceInput,
       getTraceOutput,
       modelId,

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -24,19 +24,24 @@ import type { LLMParameters } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
+import type { ModelIdType } from "@app/types/assistant/models/types";
 import type { LLMCredentialsType } from "@app/types/provider_credential";
 
-// EAP models are served through a dedicated Anthropic workspace key
-// (ANTHROPIC_EAP_API_KEY) rather than the workspace's Dust-managed / BYOK
-// credentials. Fail loudly if the key is missing so the model is unavailable
-// instead of silently falling back to the standard key.
+// EAP (Early Access Program) models are served through a dedicated Anthropic
+// workspace key (ANTHROPIC_EAP_API_KEY) rather than the workspace's
+// Dust-managed / BYOK credentials.
+//
+// Invariant: the env key must be set before any model opts into `useEapKey`
+// (see deploy plan). We throw rather than degrade to "unsupported" so the
+// misconfiguration is loud instead of silently falling back to the standard key.
 function withEapAnthropicKey(
+  modelId: ModelIdType,
   credentials: LLMCredentialsType
 ): LLMCredentialsType {
   const eapApiKey = config.getAnthropicEapApiKey();
   if (!eapApiKey) {
     throw new Error(
-      "ANTHROPIC_EAP_API_KEY is not configured but this model requires the EAP Anthropic key."
+      `ANTHROPIC_EAP_API_KEY is not configured but model ${modelId} requires the EAP Anthropic key.`
     );
   }
   return { ...credentials, ANTHROPIC_API_KEY: eapApiKey };
@@ -156,11 +161,13 @@ export async function getLLM(
     const useVertex =
       useVertexPrerequisite && isAnthropicVertexWhitelistedModelId(modelId);
 
+    const anthropicCredentials = modelConfig.useEapKey
+      ? withEapAnthropicKey(modelId, credentials)
+      : credentials;
+
     return new AnthropicLLM(auth, {
       useVertex,
-      credentials: modelConfig.useEapKey
-        ? withEapAnthropicKey(credentials)
-        : credentials,
+      credentials: anthropicCredentials,
       getTraceInput,
       getTraceOutput,
       modelId,

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -75,9 +75,11 @@ export const ModelConfigurationSchema = z.object({
   }),
   customThinkingType: z.enum(CUSTOM_THINKING_TYPES).optional(),
   customBetas: z.array(z.string()).optional(),
-  // If true, the model is served through the dedicated EAP Anthropic API key
-  // (ANTHROPIC_EAP_API_KEY) instead of the workspace's Dust-managed / BYOK
-  // credentials. Used for models hosted in a separate Anthropic workspace.
+  // If true, the model is served through the dedicated EAP (Early Access
+  // Program) Anthropic API key (ANTHROPIC_EAP_API_KEY) instead of the
+  // workspace's Dust-managed / BYOK credentials, for models hosted in a
+  // separate Anthropic workspace. Only consulted for Anthropic models;
+  // ignored for other providers.
   useEapKey: z.boolean().optional(),
   disablePrefill: z.boolean().optional(),
   supportsBatchProcessing: z.boolean().optional(),

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -75,6 +75,10 @@ export const ModelConfigurationSchema = z.object({
   }),
   customThinkingType: z.enum(CUSTOM_THINKING_TYPES).optional(),
   customBetas: z.array(z.string()).optional(),
+  // If true, the model is served through the dedicated EAP Anthropic API key
+  // (ANTHROPIC_EAP_API_KEY) instead of the workspace's Dust-managed / BYOK
+  // credentials. Used for models hosted in a separate Anthropic workspace.
+  useEapKey: z.boolean().optional(),
   disablePrefill: z.boolean().optional(),
   supportsBatchProcessing: z.boolean().optional(),
   // Specify if the model is available in specific regions.


### PR DESCRIPTION
## Description

Some Anthropic models are served from a separate Anthropic workspace and need a different API key than our standard Dust-managed / BYOK credentials.

- Add an optional `useEapKey` flag to the model config schema (so it can be set from the GCS custom-models config). Only consulted for Anthropic models.
- When a model has `useEapKey` set, the Anthropic client is built with `ANTHROPIC_EAP_API_KEY` instead of the workspace credentials, overriding both Dust-managed and BYOK for that model.
- Fail loudly (with the model id in the error) if `ANTHROPIC_EAP_API_KEY` is missing rather than silently falling back to the standard key.

No model sets the flag yet, so this is a dormant capability.

## Tests

Typecheck only. No model exercises the path yet; behavior is unchanged for every existing model (flag unset). `new AnthropicLLM(...)` has a single construction site (getLLM), so the override covers all Anthropic inference paths.

## Risk

Low. Pure addition gated on an opt-in flag that nothing sets. Safe to roll back.

## Deploy Plan

Standard deploy.

> [!WARNING]
> Set `ANTHROPIC_EAP_API_KEY` in the relevant env/secrets BEFORE any model opts into `useEapKey`. Opting in without the key set will throw and make that model unavailable.