### PR TITLE
fix: don't page eng-oncall on Persona phone lookup timeout

### DIFF
--- a/front/lib/api/workspace_verification/persona/lookup.ts
+++ b/front/lib/api/workspace_verification/persona/lookup.ts
@@ -334,7 +334,7 @@ export async function lookupPhoneNumber(
 
   return new Err(
     new PhoneLookupError(
-      "lookup_failed",
+      "lookup_timeout",
       "Phone lookup failed. Please try again.",
       `poll_timeout after ${MAX_POLL_ATTEMPTS} attempts ` +
         `(lastStatus: ${lastStatus ?? "none"}` +

--- a/front/lib/api/workspace_verification/start_verification.ts
+++ b/front/lib/api/workspace_verification/start_verification.ts
@@ -137,6 +137,11 @@ export async function startVerification(
         message = error.message;
         panic = true;
         break;
+      case "lookup_timeout":
+        // Persona was still processing when our poll window elapsed. This is
+        // transient latency on their side, not actionable by eng-oncall.
+        message = error.message;
+        break;
       default:
         assertNever(error.code);
     }

--- a/front/types/workspace_verification.ts
+++ b/front/types/workspace_verification.ts
@@ -72,6 +72,9 @@ export type PhoneLookupResult = {
 export type PhoneLookupErrorCode =
   | "invalid_phone_number"
   | "lookup_failed"
+  // Persona accepted the report but did not finish risk analysis within our
+  // poll window. Transient (Persona latency), not an error on our side.
+  | "lookup_timeout"
   | "not_mobile"
   | "prepaid_not_accepted"
   | "high_risk_blocked"


### PR DESCRIPTION
## What

Persona phone lookups in workspace verification frequently log a panic with `errorCode: lookup_failed`. With the diagnostic `detail` added in #26789, prod logs confirm the dominant path is:

```
poll_timeout after 5 attempts (lastStatus: pending)
```

i.e. `createReport` succeeds, but Persona has not finished the risk analysis within our ~10s poll window (5 × 2s) — the report is still `pending` when we give up. This is **transient latency on Persona's side**, not an error on ours and not actionable by eng-oncall, yet it was lumped into `lookup_failed` and triggered a panic page.

## Change

- Add a distinct `lookup_timeout` code to `PhoneLookupErrorCode`.
- The poll-exhausted return in `persona/lookup.ts` now uses `lookup_timeout` (same user-facing message and diagnostic `detail`).
- `startVerification` handles `lookup_timeout` with `panic = false` — it's still logged (with `detail`), just no longer paged.
- Genuine failures (`createReport` threw / non-OK status / bad schema) stay `lookup_failed` and keep panicking.

## Note (not addressed here)

This silences the alert but users hitting the timeout are still blocked (no OTP; a retry creates a fresh report that may also time out). If `pending` timeouts are frequent, the real fix is to extend the poll window or make verification async — happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)