### PR TITLE
[front] redirect logged-in users from marketing root to the app

### DIFF
--- a/front/pages/index.tsx
+++ b/front/pages/index.tsx
@@ -1,5 +1,6 @@
 import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
 import LandingLayout from "@app/components/home/LandingLayout";
+import { getSession } from "@app/lib/auth";
 import type { NewsItem } from "@app/lib/homepage_news";
 import { fetchHomepageNews } from "@app/lib/homepage_news";
 import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
@@ -14,6 +15,25 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
   news: NewsItem[];
 }>(async (context) => {
   const { inviteToken } = context.query;
+
+  // The root marketing page is the one place where an authenticated user's intent when typing
+  // "dust.tt" is overwhelmingly to open the product, not to browse the homepage. If they have a
+  // valid session, send them straight into the app via /api/login (which resolves the target
+  // workspace). Marketing sub-pages (/pricing, /security, /resources/..., etc.) are separate routes
+  // and are intentionally left untouched so they stay accessible to logged-in users.
+  const session = await getSession(context.req, context.res);
+  if (session) {
+    const queryIndex = context.resolvedUrl.indexOf("?");
+    const queryString =
+      queryIndex >= 0 ? context.resolvedUrl.slice(queryIndex) : "";
+
+    return {
+      redirect: {
+        permanent: false,
+        destination: `/api/login${queryString}`,
+      },
+    };
+  }
 
   let postLoginCallbackUrl = "/api/login";
   if (inviteToken) {

--- a/front/pages/index.tsx
+++ b/front/pages/index.tsx
@@ -4,6 +4,7 @@ import { getSession } from "@app/lib/auth";
 import type { NewsItem } from "@app/lib/homepage_news";
 import { fetchHomepageNews } from "@app/lib/homepage_news";
 import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
+import logger from "@app/logger/logger";
 import { Landing } from "@app/pages/home";
 import type { ReactElement } from "react";
 
@@ -16,21 +17,24 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
 }>(async (context) => {
   const { inviteToken } = context.query;
 
-  // The root marketing page is the one place where an authenticated user's intent when typing
-  // "dust.tt" is overwhelmingly to open the product, not to browse the homepage. If they have a
-  // valid session, send them straight into the app via /api/login (which resolves the target
-  // workspace). Marketing sub-pages (/pricing, /security, /resources/..., etc.) are separate routes
-  // and are intentionally left untouched so they stay accessible to logged-in users.
+  // On the marketing root, an authenticated user's intent is to open the product, not browse the
+  // homepage. Send them into the app via /api/login (which resolves the target workspace). Marketing
+  // sub-pages (/pricing, /security, /resources/...) are separate routes, left untouched.
+  //
+  // We don't forward the query string: the only params /api/login reads here is inviteToken, and an
+  // expired/invalid token makes it return a 400, which would turn the bare root into an error wall.
+  // The "open the product" intent doesn't depend on any param, so a plain redirect is safer.
   const session = await getSession(context.req, context.res);
   if (session) {
-    const queryIndex = context.resolvedUrl.indexOf("?");
-    const queryString =
-      queryIndex >= 0 ? context.resolvedUrl.slice(queryIndex) : "";
+    logger.info(
+      { path: context.resolvedUrl },
+      "Redirecting authenticated user from marketing root to the app"
+    );
 
     return {
       redirect: {
         permanent: false,
-        destination: `/api/login${queryString}`,
+        destination: "/api/login",
       },
     };
   }

--- a/front/pages/index.tsx
+++ b/front/pages/index.tsx
@@ -4,6 +4,7 @@ import { getSession } from "@app/lib/auth";
 import type { NewsItem } from "@app/lib/homepage_news";
 import { fetchHomepageNews } from "@app/lib/homepage_news";
 import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
+import { extractUTMParams } from "@app/lib/utils/utm";
 import logger from "@app/logger/logger";
 import { Landing } from "@app/pages/home";
 import type { ReactElement } from "react";
@@ -21,20 +22,35 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
   // homepage. Send them into the app via /api/login (which resolves the target workspace). Marketing
   // sub-pages (/pricing, /security, /resources/...) are separate routes, left untouched.
   //
-  // We don't forward the query string: the only params /api/login reads here is inviteToken, and an
-  // expired/invalid token makes it return a 400, which would turn the bare root into an error wall.
-  // The "open the product" intent doesn't depend on any param, so a plain redirect is safer.
+  // We forward only marketing/attribution params (UTM + click IDs) so /api/login keeps signup
+  // attribution, which the client-rendered landing would otherwise have carried over. We do NOT
+  // forward inviteToken: an expired/invalid one makes /api/login return a 400, which would turn the
+  // bare root into an error wall, and the redirect intent doesn't depend on it.
   const session = await getSession(context.req, context.res);
   if (session) {
+    const utmSearchParams = new URLSearchParams();
+    for (const [key, value] of Object.entries(
+      extractUTMParams(context.query)
+    )) {
+      if (value) {
+        utmSearchParams.set(key, value);
+      }
+    }
+    const utmQueryString = utmSearchParams.toString();
+
+    // Log a static path: context.resolvedUrl carries the query string, which can include sensitive
+    // params like inviteToken.
     logger.info(
-      { path: context.resolvedUrl },
+      { path: "/" },
       "Redirecting authenticated user from marketing root to the app"
     );
 
     return {
       redirect: {
         permanent: false,
-        destination: "/api/login",
+        destination: utmQueryString
+          ? `/api/login?${utmQueryString}`
+          : "/api/login",
       },
     };
   }


### PR DESCRIPTION
## Description

Logged-in users who type dust.tt landed on the marketing homepage and had to click "Open Dust" to get into the product. Now the root page redirects them straight into the app.

The root page's `getServerSideProps` (front/pages/index.tsx) checks for a valid session and, if present, redirects to `/api/login`, which resolves the target workspace and sends the user to app.dust.tt.

Scoped to `/` only:
- Marketing sub-pages (/pricing, /security, /resources/..., /customers/...) are separate routes and stay accessible to logged-in users.
- Logged-out users still get the marketing homepage everywhere.

Uses the authoritative session check rather than the `dust-has-session` indicator cookie, so a stale cookie (expired session) can't bounce a user onto the `/api/login` 401 page. The redirect goes to a plain `/api/login` with no query forwarding: `/api/login` 400s on an expired/invalid inviteToken, so forwarding a bad token from the root would turn it into an error wall.

> [!NOTE]
> Side effect: logged-in users no longer render the marketing root, so the homepage GTM pageview won't fire for them anymore. If anyone tracks root pageviews, expect a dent. GTM still loads on all other marketing pages.

## Tests

Not yet exercised on a deploy preview. Worth a manual check of the four cases before merge: authenticated root redirects to the app, authenticated /pricing renders, logged-out root renders the homepage, logged-out /pricing renders.

## Risk

Low. Single page change, scoped to the root path. Rollback is reverting the commit. Marketing sub-pages and app routing are untouched.

## Deploy Plan

Standard deploy.