### PR TITLE
[front] add dust-lionel custom-model global agents

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -1117,6 +1117,30 @@ export const CUSTOM_MODEL_DUST_GLOBAL_AGENT_CONFIGS = new Map<
       preferredReasoningEffort: "high",
     },
   ],
+  [
+    GLOBAL_AGENTS_SID.DUST_LIONEL,
+    {
+      name: "dust-lionel",
+      customModelIndex: 5,
+      preferredReasoningEffort: "light",
+    },
+  ],
+  [
+    GLOBAL_AGENTS_SID.DUST_LIONEL_MEDIUM,
+    {
+      name: "dust-lionel-medium",
+      customModelIndex: 5,
+      preferredReasoningEffort: "medium",
+    },
+  ],
+  [
+    GLOBAL_AGENTS_SID.DUST_LIONEL_HIGH,
+    {
+      name: "dust-lionel-high",
+      customModelIndex: 5,
+      preferredReasoningEffort: "high",
+    },
+  ],
 ]);
 
 export function getCustomModelDustGlobalAgentIndex(

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -430,6 +430,28 @@ export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
         description: "Same as dust-chalom but with high reasoning effort.",
         pictureUrl: DUST_AVATAR_URL,
       };
+    case GLOBAL_AGENTS_SID.DUST_LIONEL:
+      return {
+        sId: GLOBAL_AGENTS_SID.DUST_LIONEL,
+        name: "dust-lionel",
+        description:
+          "Same as dust but running a custom model for internal testing.",
+        pictureUrl: DUST_AVATAR_URL,
+      };
+    case GLOBAL_AGENTS_SID.DUST_LIONEL_MEDIUM:
+      return {
+        sId: GLOBAL_AGENTS_SID.DUST_LIONEL_MEDIUM,
+        name: "dust-lionel-medium",
+        description: "Same as dust-lionel but with medium reasoning effort.",
+        pictureUrl: DUST_AVATAR_URL,
+      };
+    case GLOBAL_AGENTS_SID.DUST_LIONEL_HIGH:
+      return {
+        sId: GLOBAL_AGENTS_SID.DUST_LIONEL_HIGH,
+        name: "dust-lionel-high",
+        description: "Same as dust-lionel but with high reasoning effort.",
+        pictureUrl: DUST_AVATAR_URL,
+      };
     case GLOBAL_AGENTS_SID.DUST_GOOG:
       return {
         sId: GLOBAL_AGENTS_SID.DUST_GOOG,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -436,6 +436,24 @@ const GLOBAL_AGENT_FLAGS: Record<
     injectsUserContext: false,
     injectsWorkspaceContext: false,
   },
+  [GLOBAL_AGENTS_SID.DUST_LIONEL]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
+  [GLOBAL_AGENTS_SID.DUST_LIONEL_MEDIUM]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
+  [GLOBAL_AGENTS_SID.DUST_LIONEL_HIGH]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
   [GLOBAL_AGENTS_SID.HELPER]: {
     injectsMemory: false,
     injectsToolsets: false,
@@ -1211,6 +1229,9 @@ function getGlobalAgent({
     case GLOBAL_AGENTS_SID.DUST_CHALOM:
     case GLOBAL_AGENTS_SID.DUST_CHALOM_MEDIUM:
     case GLOBAL_AGENTS_SID.DUST_CHALOM_HIGH:
+    case GLOBAL_AGENTS_SID.DUST_LIONEL:
+    case GLOBAL_AGENTS_SID.DUST_LIONEL_MEDIUM:
+    case GLOBAL_AGENTS_SID.DUST_LIONEL_HIGH:
       agentConfiguration = _getCustomModelDustLikeGlobalAgent(
         auth,
         {
@@ -1445,6 +1466,9 @@ export async function getGlobalAgents(
     GLOBAL_AGENTS_SID.DUST_CHALOM,
     GLOBAL_AGENTS_SID.DUST_CHALOM_MEDIUM,
     GLOBAL_AGENTS_SID.DUST_CHALOM_HIGH,
+    GLOBAL_AGENTS_SID.DUST_LIONEL,
+    GLOBAL_AGENTS_SID.DUST_LIONEL_MEDIUM,
+    GLOBAL_AGENTS_SID.DUST_LIONEL_HIGH,
   ];
   if (!flags.includes("dust_internal_global_agents")) {
     agentsIdsToFetch = agentsIdsToFetch.filter(

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -85,6 +85,9 @@ export enum GLOBAL_AGENTS_SID {
   DUST_CHALOM = "dust-chalom",
   DUST_CHALOM_MEDIUM = "dust-chalom-medium",
   DUST_CHALOM_HIGH = "dust-chalom-high",
+  DUST_LIONEL = "dust-lionel",
+  DUST_LIONEL_MEDIUM = "dust-lionel-medium",
+  DUST_LIONEL_HIGH = "dust-lionel-high",
   DUST_ANT = "dust-ant",
   DUST_ANT_MEDIUM = "dust-ant-medium",
   DUST_ANT_HIGH = "dust-ant-high",
@@ -227,6 +230,9 @@ const GLOBAL_AGENTS_SORT_ORDER: string[] = [
   GLOBAL_AGENTS_SID.DUST_CHALOM,
   GLOBAL_AGENTS_SID.DUST_CHALOM_MEDIUM,
   GLOBAL_AGENTS_SID.DUST_CHALOM_HIGH,
+  GLOBAL_AGENTS_SID.DUST_LIONEL,
+  GLOBAL_AGENTS_SID.DUST_LIONEL_MEDIUM,
+  GLOBAL_AGENTS_SID.DUST_LIONEL_HIGH,
 ];
 const globalAgentIndexMap = new Map(
   GLOBAL_AGENTS_SORT_ORDER.map((id, index) => [id, index])


### PR DESCRIPTION
## Description

Adds three internal global agents: `dust-lionel`, `dust-lionel-medium`, `dust-lionel-high`. They mirror the existing `dust-pistache` / `dust-chalom` setup and differ only by reasoning effort (light / medium / high). All three bind to custom model index 5.

The model config lives in the infra custom-models config (pulled from GCS at build time), not in the repo. It is an Anthropic model that routes through the dedicated EAP Anthropic key via the `useEapKey` flag added in #26809. Agents are gated behind `custom_model_feature` and `dust_internal_global_agents`, so they only show up for internal workspaces with those flags.

## Tests

Ran the build-time custom-models fetch/codegen against the updated infra config locally and typechecked the result (`tsc --noEmit`, clean). Verified the three agents resolve to the new model index and that the existing indices (pistache=3, chalom=4) are unchanged. The append-only ordering is preserved so no existing agent is rebound.

## Risk

Low. New agents are additive and gated behind two feature flags, so default workspaces are unaffected. The model entry is dormant until a flagged workspace selects it. The EAP key it depends on is already set in both prod regions. Rollback is a straight revert; the GCS config entry can also be removed independently.

## Deploy Plan

The EAP key and the GCS custom-model entry are already in place. Standard deploy: the front build pulls the updated custom-models config from GCS and regenerates the model list, after which the agents become available to flagged workspaces.