### PR TITLE
Config-driven server-side fallback for Anthropic models

### DIFF
--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -50,6 +50,14 @@ import assert from "assert";
 const MESSAGE_CONVERSION_CONCURRENCY = 10;
 const BATCH_PAYLOAD_BUILD_CONCURRENCY = 10;
 
+// Server-side fallback is a beta param not yet typed by the SDK. We forward it
+// as an extra body param alongside the typed request fields. The list of
+// fallback model ids is driven by modelConfig.fallbackModels (set in the GCS
+// custom-model entry), so no fallback target is hardcoded here.
+type AnthropicRequestPayload = MessageCreateParamsNonStreaming & {
+  fallback?: { model: string }[];
+};
+
 /**
  * Maps prompt tiers to Anthropic system blocks with cache breakpoints.
  *
@@ -156,7 +164,7 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
     prompt,
     specifications,
     forceToolCall,
-  }: LLMStreamParameters): Promise<MessageCreateParamsNonStreaming> {
+  }: LLMStreamParameters): Promise<AnthropicRequestPayload> {
     const messages = await concurrentExecutor(
       conversation.messages,
       (msg, index) =>
@@ -198,6 +206,12 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
       hasConditionalJITTools,
     });
 
+    const fallbackModels = this.modelConfig.fallbackModels;
+    const fallback =
+      fallbackModels && fallbackModels.length > 0
+        ? fallbackModels.map((model) => ({ model }))
+        : undefined;
+
     return {
       model: this.modelId,
       ...thinkingConfig,
@@ -207,6 +221,7 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
       tools: specifications.map(toTool),
       max_tokens: this.modelConfig.generationTokensCount,
       tool_choice: toToolChoiceParam(specifications, forceToolCall),
+      ...(fallback ? { fallback } : {}),
     };
   }
 

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -50,12 +50,18 @@ import assert from "assert";
 const MESSAGE_CONVERSION_CONCURRENCY = 10;
 const BATCH_PAYLOAD_BUILD_CONCURRENCY = 10;
 
-// Server-side fallback is a beta param not yet typed by the SDK. We forward it
-// as an extra body param alongside the typed request fields. The list of
-// fallback model ids is driven by modelConfig.fallbackModels (set in the GCS
-// custom-model entry), so no fallback target is hardcoded here.
-type AnthropicRequestPayload = MessageCreateParamsNonStreaming & {
-  fallback?: { model: string }[];
+// Required (with exactly this date) for the `fallbacks` request param; any
+// other server-side-fallback-* value gets the request rejected with a 400.
+// https://platform.claude.com/docs/en/build-with-claude/refusals-and-fallback#server-side-fallback
+const SERVER_SIDE_FALLBACK_BETA_HEADER = "server-side-fallback-2026-06-01";
+
+// Server-side fallback is a beta param not yet typed by the SDK (0.100.1). We
+// forward it as an extra body param on the streaming request. The list of
+// fallback model ids is driven by modelConfig.fallbackModels, so no fallback
+// target is hardcoded here. Scoped to the streaming path only: the Message
+// Batches API rejects the fallbacks param.
+type AnthropicStreamPayload = BetaMessageStreamParams & {
+  fallbacks?: { model: string }[];
 };
 
 /**
@@ -164,7 +170,7 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
     prompt,
     specifications,
     forceToolCall,
-  }: LLMStreamParameters): Promise<AnthropicRequestPayload> {
+  }: LLMStreamParameters): Promise<MessageCreateParamsNonStreaming> {
     const messages = await concurrentExecutor(
       conversation.messages,
       (msg, index) =>
@@ -206,12 +212,6 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
       hasConditionalJITTools,
     });
 
-    const fallbackModels = this.modelConfig.fallbackModels;
-    const fallback =
-      fallbackModels && fallbackModels.length > 0
-        ? fallbackModels.map((model) => ({ model }))
-        : undefined;
-
     return {
       model: this.modelId,
       ...thinkingConfig,
@@ -221,19 +221,39 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
       tools: specifications.map(toTool),
       max_tokens: this.modelConfig.generationTokensCount,
       tool_choice: toToolChoiceParam(specifications, forceToolCall),
-      ...(fallback ? { fallback } : {}),
     };
+  }
+
+  // Builds the server-side fallback param from modelConfig.fallbackModels, or
+  // undefined when none are configured (so the param is omitted entirely).
+  // Server-side fallback is not available on Vertex AI, so it is never attached
+  // to Vertex requests.
+  private buildFallbacksParam(): { model: string }[] | undefined {
+    const fallbackModels = this.modelConfig.fallbackModels;
+    if (this.useVertex || !fallbackModels || fallbackModels.length === 0) {
+      return undefined;
+    }
+    return fallbackModels.map((model) => ({ model }));
   }
 
   protected async buildStreamRequestPayload(
     streamParameters: LLMStreamParameters
   ): Promise<BetaMessageStreamParams> {
-    const betas = this.modelConfig.customBetas;
-
     const basePayload = await this.buildBaseRequestPayload(streamParameters);
     const outputFormat = toOutputFormatParam(this.responseFormat);
+    const fallbacks = this.buildFallbacksParam();
 
-    return {
+    // The fallbacks param is rejected unless the request carries the
+    // server-side fallback beta header, so the header is attached here rather
+    // than left to customBetas (which could drift out of sync).
+    const betas = fallbacks
+      ? [
+          ...(this.modelConfig.customBetas ?? []),
+          SERVER_SIDE_FALLBACK_BETA_HEADER,
+        ]
+      : this.modelConfig.customBetas;
+
+    const payload: AnthropicStreamPayload = {
       ...basePayload,
       stream: true,
       betas,
@@ -244,7 +264,9 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
       // buildBaseRequestPayload (isFirst and isLast) cover Vertex instead.
       ...(!this.useVertex ? { cache_control: { type: "ephemeral" } } : {}),
       model: getModel(this.useVertex, { modelId: this.modelId }),
+      ...(fallbacks ? { fallbacks } : {}),
     };
+    return payload;
   }
 
   protected async *sendRequest(

--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -120,6 +120,9 @@ function* handleMessageStreamEvent(
   metadata: LLMClientMetadata,
   tokenUsageAccumulator: Required<TokenUsage>
 ): Generator<LLMEvent> {
+  // Captured for logging in the default branch, where messageStreamEvent is
+  // narrowed to `never` and its properties can no longer be accessed.
+  const eventType = messageStreamEvent.type;
   switch (messageStreamEvent.type) {
     case "message_start":
       yield {
@@ -171,8 +174,9 @@ function* handleMessageStreamEvent(
       // Anthropic may emit new top-level stream event types (e.g. the
       // server-side fallback event) before the SDK types and this client are
       // updated. Log and ignore rather than crashing the stream with a throw.
+      // Only log the event type to avoid dumping prompt/response content.
       logger.warn(
-        { event: messageStreamEvent },
+        { eventType },
         "Unhandled Anthropic message stream event type, ignoring."
       );
       assertNeverAndIgnore(messageStreamEvent);
@@ -237,7 +241,14 @@ function* handleContentBlockStart(
       // We don't use these Anthropic tools
       return;
     default:
-      assertNever(blockType);
+      // New content block types may appear (e.g. via a new beta) before the
+      // SDK types and this client are updated. Ignore rather than crash.
+      logger.warn(
+        { blockType },
+        "Unhandled Anthropic content block type, ignoring."
+      );
+      assertNeverAndIgnore(blockType);
+      return;
   }
 }
 
@@ -247,6 +258,9 @@ function* handleContentBlockDelta(
   metadata: LLMClientMetadata
 ): Generator<LLMEvent> {
   validateContentBlockIndex(stateContainer.state, event);
+  // Captured for logging in the default branch, where event.delta is narrowed
+  // to `never` and its properties can no longer be accessed.
+  const deltaType = event.delta.type;
   switch (event.delta.type) {
     case "text_delta":
       stateContainer.state.accumulator += event.delta.text;
@@ -272,7 +286,14 @@ function* handleContentBlockDelta(
       // We don't use Anthropic citations, as we have our own citations implementation
       break;
     default:
-      assertNever(event.delta);
+      // New delta types may appear (e.g. via a new beta) before the SDK types
+      // and this client are updated. Ignore rather than crash.
+      logger.warn(
+        { deltaType },
+        "Unhandled Anthropic content block delta type, ignoring."
+      );
+      assertNeverAndIgnore(event.delta);
+      break;
   }
 }
 

--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -24,7 +24,10 @@ import { EventError } from "@app/lib/api/llm/types/events";
 import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
 import { parseToolArguments } from "@app/lib/api/llm/utils/tool_arguments";
 import logger from "@app/logger/logger";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import {
+  assertNever,
+  assertNeverAndIgnore,
+} from "@app/types/shared/utils/assert_never";
 import { isRecord } from "@app/types/shared/utils/general";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 import cloneDeep from "lodash/cloneDeep";
@@ -165,7 +168,14 @@ function* handleMessageStreamEvent(
       );
       break;
     default:
-      assertNever(messageStreamEvent);
+      // Anthropic may emit new top-level stream event types (e.g. the
+      // server-side fallback event) before the SDK types and this client are
+      // updated. Log and ignore rather than crashing the stream with a throw.
+      logger.warn(
+        { event: messageStreamEvent },
+        "Unhandled Anthropic message stream event type, ignoring."
+      );
+      assertNeverAndIgnore(messageStreamEvent);
   }
 }
 

--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -176,7 +176,7 @@ function* handleMessageStreamEvent(
       // updated. Log and ignore rather than crashing the stream with a throw.
       // Only log the event type to avoid dumping prompt/response content.
       logger.warn(
-        { eventType },
+        { eventType, ...metadata },
         "Unhandled Anthropic message stream event type, ignoring."
       );
       assertNeverAndIgnore(messageStreamEvent);
@@ -244,7 +244,7 @@ function* handleContentBlockStart(
       // New content block types may appear (e.g. via a new beta) before the
       // SDK types and this client are updated. Ignore rather than crash.
       logger.warn(
-        { blockType },
+        { blockType, ...metadata },
         "Unhandled Anthropic content block type, ignoring."
       );
       assertNeverAndIgnore(blockType);
@@ -289,7 +289,7 @@ function* handleContentBlockDelta(
       // New delta types may appear (e.g. via a new beta) before the SDK types
       // and this client are updated. Ignore rather than crash.
       logger.warn(
-        { deltaType },
+        { deltaType, ...metadata },
         "Unhandled Anthropic content block delta type, ignoring."
       );
       assertNeverAndIgnore(event.delta);

--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -302,6 +302,12 @@ function* handleContentBlockStop(
   stateContainer: { state: StreamState },
   metadata: LLMClientMetadata
 ): Generator<LLMEvent> {
+  // A null state here means the block's content_block_start was ignored (e.g.
+  // the server-side fallback boundary block, or a server tool block we don't
+  // use). Ignore the matching stop instead of failing the index validation.
+  if (stateContainer.state === null) {
+    return;
+  }
   validateContentBlockIndex(stateContainer.state, event);
   switch (stateContainer.state.accumulatorType) {
     case "text":

--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -409,6 +409,9 @@ export const CLAUDE_FABLE_5_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
     featureFlag: "claude_fable_5_feature",
   },
   customBetas: ["auto-thinking-2026-01-12", "max-effort-2026-01-24"],
+  // Fable 5's safety classifiers can decline a request; retry server-side on
+  // Opus 4.8 so the user still gets an answer in one round trip.
+  fallbackModels: [CLAUDE_OPUS_4_8_MODEL_ID],
   // Served from a separate Anthropic workspace (EAP), like the EAP custom
   // models. Forces non-Vertex routing.
   useEapKey: true,

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -75,6 +75,12 @@ export const ModelConfigurationSchema = z.object({
   }),
   customThinkingType: z.enum(CUSTOM_THINKING_TYPES).optional(),
   customBetas: z.array(z.string()).optional(),
+  // Ordered list of fallback model ids. When set, the request is sent with a
+  // server-side fallback param so the provider retries against these models, in
+  // order, if the primary model refuses or is unavailable. Requires the relevant
+  // beta header (carried in customBetas) and provider-side enablement. Only
+  // consulted for Anthropic models; ignored for other providers.
+  fallbackModels: z.array(z.string()).optional(),
   // If true, the model is served through the dedicated EAP (Early Access
   // Program) Anthropic API key (ANTHROPIC_EAP_API_KEY) instead of the
   // workspace's Dust-managed / BYOK credentials, for models hosted in a

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -75,15 +75,9 @@ export const ModelConfigurationSchema = z.object({
   }),
   customThinkingType: z.enum(CUSTOM_THINKING_TYPES).optional(),
   customBetas: z.array(z.string()).optional(),
-  // Ordered list of fallback model ids (3 max). When set, the streaming request
-  // carries the `fallbacks` param so the provider retries against these models,
-  // in order, when the primary model's safety classifiers decline the request
-  // (rate limits, overload and server errors are returned as-is). The client
-  // attaches the required server-side fallback beta header automatically. Each
-  // target must be an allowed fallback for the primary model and invokable with
-  // the same API key. Only consulted for Anthropic models; ignored for other
-  // providers and on Vertex AI, and never sent on batch requests (the Batches
-  // API rejects the param).
+  // Ordered list of fallback model ids (3 max), sent as the `fallbacks` param on
+  // Anthropic streaming requests so the API retries on these models when the
+  // primary model's safety classifiers decline the request.
   // https://platform.claude.com/docs/en/build-with-claude/refusals-and-fallback#server-side-fallback
   fallbackModels: z.array(z.string()).optional(),
   // If true, the model is served through the dedicated EAP (Early Access

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -75,11 +75,16 @@ export const ModelConfigurationSchema = z.object({
   }),
   customThinkingType: z.enum(CUSTOM_THINKING_TYPES).optional(),
   customBetas: z.array(z.string()).optional(),
-  // Ordered list of fallback model ids. When set, the request is sent with a
-  // server-side fallback param so the provider retries against these models, in
-  // order, if the primary model refuses or is unavailable. Requires the relevant
-  // beta header (carried in customBetas) and provider-side enablement. Only
-  // consulted for Anthropic models; ignored for other providers.
+  // Ordered list of fallback model ids (3 max). When set, the streaming request
+  // carries the `fallbacks` param so the provider retries against these models,
+  // in order, when the primary model's safety classifiers decline the request
+  // (rate limits, overload and server errors are returned as-is). The client
+  // attaches the required server-side fallback beta header automatically. Each
+  // target must be an allowed fallback for the primary model and invokable with
+  // the same API key. Only consulted for Anthropic models; ignored for other
+  // providers and on Vertex AI, and never sent on batch requests (the Batches
+  // API rejects the param).
+  // https://platform.claude.com/docs/en/build-with-claude/refusals-and-fallback#server-side-fallback
   fallbackModels: z.array(z.string()).optional(),
   // If true, the model is served through the dedicated EAP (Early Access
   // Program) Anthropic API key (ANTHROPIC_EAP_API_KEY) instead of the


### PR DESCRIPTION
## Description

Adds support for Anthropic server-side fallback, driven by model config, and enables it on Claude Fable 5 with Opus 4.8 as the fallback target.

- New optional `fallbackModels?: string[]` on the model config schema. When set, the streaming request includes the `fallbacks: [{ model }]` beta param, so the API retries against those models, in order, when the primary model's safety classifiers decline the request. Rate limits, overload and server errors are returned as-is (per the API docs, only classifier declines trigger fallback).
- The client attaches the required `server-side-fallback-2026-06-01` beta header itself whenever fallbacks are configured, instead of relying on customBetas (the param is rejected without the header carrying exactly that date, so leaving it to config could drift).
- `CLAUDE_FABLE_5_DEFAULT_MODEL_CONFIG` sets `fallbackModels: ["claude-opus-4-8"]`, the only permitted target per the Models API (`allowed_fallback_models`).
- Scoped to the streaming path: the Batches API rejects the `fallbacks` param. Never attached on Vertex AI (server-side fallback is not available there).
- Stream handling copes with the new response shape. The fallback boundary arrives as a `fallback` content block (a start/stop pair with no deltas): the start was already ignored by the hardened switch, and `content_block_stop` now skips blocks whose start was ignored instead of failing the index assertion. Unknown stream event, content block and delta types are logged and ignored via `assertNeverAndIgnore` rather than crashing the stream.

No behavior change for any model without `fallbackModels` set.

## Tests

Verified end to end against the live API with the EAP key:
- `GET /v1/models/claude-fable-5` reports `allowed_fallback_models: ["claude-opus-4-8"]`.
- A prompt that trips the reasoning_extraction classifier gets declined by Fable 5 and served by Opus 4.8 in the same request, both non-streaming (response carries the `fallback` content block and `usage.iterations`) and streaming (fallback block arrives as a bare content_block_start/stop pair, matching what the parser now handles).
- Full LLM integration suite on claude-fable-5 with fallbacks attached: 33/34 passing, the one failure being the known forced tool_choice model limitation, unrelated to fallback.

## Known gaps (operational, not addressed here)

- Token usage and pricing are attributed to the primary model id even when the fallback model serves the response. We do not read `usage.iterations` per attempt. Since Fable 5 is priced higher than Opus 4.8, we will over-estimate cost when the fallback serves the response. Acceptable tradeoff in the near term since Fable is gated behind a dust-only flag; revisit before wider rollout.
- Fallback model ids from config are not validated against the whitelist or `allowed_fallback_models`. A bad id surfaces as a 400 up front (the API validates the chain at request time).
- The request body is computed for the primary model and reused for the fallback attempt. Restrict targets to capability-compatible models (Opus 4.8 accepts everything we send to Fable 5).

## Risk

Low. The new request param is only attached when a model config opts in; today that is only claude-fable-5, which is behind a dust-only feature flag. The stream-switch changes are strictly more lenient (log and skip instead of throw).

## Deploy Plan

Standard deploy.
