### PR TITLE
[Skill Builder] Disable legacy skill customization entry points

### DIFF
--- a/front/components/pages/builder/skills/CreateSkillPage.tsx
+++ b/front/components/pages/builder/skills/CreateSkillPage.tsx
@@ -2,45 +2,16 @@ import SkillBuilder from "@app/components/skill_builder/SkillBuilder";
 import { SkillBuilderProvider } from "@app/components/skill_builder/SkillBuilderContext";
 import { useDocumentTitle } from "@app/hooks/useDocumentTitle";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
-import { useSearchParam } from "@app/lib/platform";
-import { useSkill } from "@app/lib/swr/skill_configurations";
-import { Spinner } from "@dust-tt/sparkle";
 
 export function CreateSkillPage() {
   const owner = useWorkspace();
   const { user } = useAuth();
-  const extendsParam = useSearchParam("extends");
-
-  const {
-    skill: extendedSkillData,
-    isSkillLoading: isExtendedSkillLoading,
-    mutateSkill,
-  } = useSkill({
-    workspaceId: owner.sId,
-    skillId: extendsParam,
-    disabled: !extendsParam,
-  });
 
   useDocumentTitle("Dust - New Skill");
 
-  if (extendsParam && isExtendedSkillLoading) {
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <Spinner size="xl" />
-      </div>
-    );
-  }
-
-  const extendedSkill = extendedSkillData?.isExtendable
-    ? extendedSkillData
-    : null;
-
   return (
     <SkillBuilderProvider owner={owner} user={user} skillId={null}>
-      <SkillBuilder
-        extendedSkill={extendedSkill ?? undefined}
-        onSaved={mutateSkill}
-      />
+      <SkillBuilder onSaved={() => undefined} />
     </SkillBuilderProvider>
   );
 }

--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -1,11 +1,9 @@
 import { ArchiveSkillDialog } from "@app/components/skills/ArchiveSkillDialog";
-import { useAppRouter } from "@app/lib/platform";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import type { SkillWithoutInstructionsAndToolsWithRelationsType } from "@app/types/assistant/skill_configuration";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Button,
-  Clipboard,
   DotsHorizontal,
   DropdownMenu,
   DropdownMenuContent,
@@ -27,10 +25,9 @@ export function SkillDetailsButtonBar({
   owner,
   onClose,
 }: SkillDetailsButtonBarProps) {
-  const router = useAppRouter();
   const [showArchiveDialog, setShowArchiveDialog] = useState(false);
 
-  if (!skill.canWrite && !skill.isExtendable) {
+  if (!skill.canWrite) {
     return null;
   }
 
@@ -60,22 +57,6 @@ export function SkillDetailsButtonBar({
             <Button icon={DotsHorizontal} size="sm" variant="ghost" />
           </DropdownMenuTrigger>
           <DropdownMenuContent>
-            {skill.isExtendable && (
-              <DropdownMenuItem
-                label="Customize (New)"
-                icon={Clipboard}
-                onClick={async (e) => {
-                  e.stopPropagation();
-                  await router.push(
-                    getSkillBuilderRoute(
-                      owner.sId,
-                      "new",
-                      `extends=${skill.sId}`
-                    )
-                  );
-                }}
-              />
-            )}
             {skill.canWrite && (
               <DropdownMenuItem
                 label="Archive"

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -12,7 +12,7 @@ import type {
 } from "@app/types/assistant/skill_configuration";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import type { MenuItem } from "@dust-tt/sparkle";
-import { Clipboard, DataTable, Edit04, Eye, Trash01 } from "@dust-tt/sparkle";
+import { DataTable, Edit04, Eye, Trash01 } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 
@@ -209,22 +209,6 @@ export function SkillsTable({
                   onClick: (e: React.MouseEvent) => {
                     e.stopPropagation();
                     onSkillClick(skill);
-                  },
-                  kind: "item" as const,
-                },
-                {
-                  label: "Customize (New)",
-                  icon: Clipboard,
-                  disabled: !skill.isExtendable,
-                  onClick: (e: React.MouseEvent) => {
-                    e.stopPropagation();
-                    void router.push(
-                      getSkillBuilderRoute(
-                        owner.sId,
-                        "new",
-                        `extends=${skill.sId}`
-                      )
-                    );
                   },
                   kind: "item" as const,
                 },


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/8611

Removes the legacy Customize (New) entry points from Manage Skills and Skill Details. The new-skill route also ignores the old extends query path, while editing existing customized skills still loads their extended skill relation.

## Risks
Blast radius: Skill Builder create page and Manage Skills actions.
Risk: low

## Deploy Plan
- deploy front