### PR TITLE
[Skill Builder] Fix capabilities dropdown opening

### DIFF
--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.test.ts
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.test.ts
@@ -8,8 +8,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { SlashCommand } from "./SlashCommandDropdown";
 import {
   buildSkillBuilderSlashCommandItems,
-  slashCommandPluginKey,
   SlashCommandExtension,
+  slashCommandPluginKey,
 } from "./SlashCommandExtension";
 
 const attachKnowledgeItem: SlashCommand = {

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.test.ts
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.test.ts
@@ -1,10 +1,16 @@
 import type { SlashCommandSkillSuggestion } from "@app/components/editor/extensions/shared/SlashCommandSkillItems";
 import type { SlashCommandToolSuggestion } from "@app/components/editor/extensions/shared/SlashCommandToolItems";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { describe, expect, it } from "vitest";
+import { Editor } from "@tiptap/react";
+import { StarterKit } from "@tiptap/starter-kit";
+import { afterEach, describe, expect, it } from "vitest";
 
 import type { SlashCommand } from "./SlashCommandDropdown";
-import { buildSkillBuilderSlashCommandItems } from "./SlashCommandExtension";
+import {
+  buildSkillBuilderSlashCommandItems,
+  slashCommandPluginKey,
+  SlashCommandExtension,
+} from "./SlashCommandExtension";
 
 const attachKnowledgeItem: SlashCommand = {
   action: "insert-knowledge-node",
@@ -183,5 +189,48 @@ describe("buildSkillBuilderSlashCommandItems", () => {
       id: "mcp_server_view_search",
       sectionLabel: "Capabilities",
     });
+  });
+});
+
+describe("SlashCommandExtension", () => {
+  let editor: Editor | null = null;
+
+  afterEach(() => {
+    editor?.destroy();
+    editor = null;
+  });
+
+  function createEditor() {
+    editor = new Editor({
+      extensions: [
+        StarterKit,
+        SlashCommandExtension.configure({
+          includeSkillSuggestions: false,
+        }),
+      ],
+    });
+
+    return editor;
+  }
+
+  it("opens capabilities after marked text", () => {
+    const editor = createEditor();
+    editor.commands.setContent("<p><em>Italic text</em></p>");
+    editor.commands.focus("end");
+
+    editor.commands.openCapabilitiesSlashCommand();
+
+    expect(editor.getText()).toBe("Italic text/");
+    expect(slashCommandPluginKey.getState(editor.state)?.active).toBe(true);
+  });
+
+  it("keeps typed slash closed after regular text", () => {
+    const editor = createEditor();
+    editor.commands.setContent("<p>regular text</p>");
+    editor.commands.focus("end");
+
+    editor.commands.insertContent("/");
+
+    expect(slashCommandPluginKey.getState(editor.state)?.active).toBe(false);
   });
 });

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.test.ts
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.test.ts
@@ -220,7 +220,18 @@ describe("SlashCommandExtension", () => {
 
     editor.commands.openCapabilitiesSlashCommand();
 
-    expect(editor.getText()).toBe("Italic text/");
+    expect(editor.getText()).toBe("Italic text /");
+    expect(slashCommandPluginKey.getState(editor.state)?.active).toBe(true);
+  });
+
+  it("opens capabilities after regular text", () => {
+    const editor = createEditor();
+    editor.commands.setContent("<p>regular text</p>");
+    editor.commands.focus("end");
+
+    editor.commands.openCapabilitiesSlashCommand();
+
+    expect(editor.getText()).toBe("regular text /");
     expect(slashCommandPluginKey.getState(editor.state)?.active).toBe(true);
   });
 

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
@@ -347,7 +347,7 @@ export const SlashCommandExtension =
         // ending with "/" is loaded programmatically via setContent on mount.
         hasBeenFocused: false,
         capabilitiesOnlyTriggerStart: null as number | null,
-        isOpeningCapsOnly: false,
+        isOpeningCapabilitiesOnly: false,
       };
     },
 
@@ -379,7 +379,7 @@ export const SlashCommandExtension =
           () =>
           ({ chain }) => {
             this.storage.hasBeenFocused = true;
-            this.storage.isOpeningCapsOnly = true;
+            this.storage.isOpeningCapabilitiesOnly = true;
 
             const inserted = chain()
               .focus()
@@ -420,7 +420,7 @@ export const SlashCommandExtension =
           },
           allow: ({ state, range }) =>
             extensionStorage.hasBeenFocused &&
-            (extensionStorage.isOpeningCapsOnly ||
+            (extensionStorage.isOpeningCapabilitiesOnly ||
               hasAllowedSlashPrefix(state, range.from)),
           command: ({ editor, range, props }) => {
             if (props.action === INSERT_KNOWLEDGE_NODE_ACTION) {
@@ -543,7 +543,7 @@ export const SlashCommandExtension =
           key: new PluginKey("skillBuilderSlashCommandCleanup"),
           view: () => ({
             update: (view) => {
-              extensionStorage.isOpeningCapsOnly = false;
+              extensionStorage.isOpeningCapabilitiesOnly = false;
               const triggerStart =
                 extensionStorage.capabilitiesOnlyTriggerStart;
 

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
@@ -53,13 +53,12 @@ function hasSlashCharacterAtPosition(state: EditorState, position: number) {
   );
 }
 
-function hasAllowedSlashPrefix(state: EditorState, position: number) {
-  const $position = state.doc.resolve(position);
-  const textBefore = $position.nodeBefore?.isText
-    ? $position.nodeBefore.text
+function shouldInsertSlashBoundarySpace(state: EditorState) {
+  const textBefore = state.selection.$from.nodeBefore?.isText
+    ? state.selection.$from.nodeBefore.text
     : null;
 
-  return !textBefore || textBefore.endsWith(" ");
+  return !!textBefore && !textBefore.endsWith(" ");
 }
 
 // Define available slash commands.
@@ -347,7 +346,6 @@ export const SlashCommandExtension =
         // ending with "/" is loaded programmatically via setContent on mount.
         hasBeenFocused: false,
         capabilitiesOnlyTriggerStart: null as number | null,
-        isOpeningCapabilitiesOnly: false,
       };
     },
 
@@ -366,7 +364,6 @@ export const SlashCommandExtension =
           char: "/",
           pluginKey: slashCommandPluginKey,
           allowSpaces: true,
-          allowedPrefixes: null,
           startOfLine: false,
           items: ({ query }: { query: string }) => filterSlashCommands(query),
         },
@@ -379,7 +376,11 @@ export const SlashCommandExtension =
           () =>
           ({ chain }) => {
             this.storage.hasBeenFocused = true;
-            this.storage.isOpeningCapabilitiesOnly = true;
+            const triggerText = shouldInsertSlashBoundarySpace(
+              this.editor.state
+            )
+              ? " /"
+              : "/";
 
             const inserted = chain()
               .focus()
@@ -387,7 +388,7 @@ export const SlashCommandExtension =
                 tr.setMeta(capabilitiesOnlySlashCommandMetaKey, true);
                 return true;
               })
-              .insertContent("/")
+              .insertContent(triggerText)
               .run();
 
             return inserted;
@@ -418,10 +419,7 @@ export const SlashCommandExtension =
 
             return true;
           },
-          allow: ({ state, range }) =>
-            extensionStorage.hasBeenFocused &&
-            (extensionStorage.isOpeningCapabilitiesOnly ||
-              hasAllowedSlashPrefix(state, range.from)),
+          allow: () => extensionStorage.hasBeenFocused,
           command: ({ editor, range, props }) => {
             if (props.action === INSERT_KNOWLEDGE_NODE_ACTION) {
               editor
@@ -543,7 +541,6 @@ export const SlashCommandExtension =
           key: new PluginKey("skillBuilderSlashCommandCleanup"),
           view: () => ({
             update: (view) => {
-              extensionStorage.isOpeningCapabilitiesOnly = false;
               const triggerStart =
                 extensionStorage.capabilitiesOnlyTriggerStart;
 

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
@@ -30,7 +30,7 @@ import type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
 import { exitSuggestion, Suggestion } from "@tiptap/suggestion";
 import { forwardRef, useImperativeHandle, useMemo, useRef } from "react";
 
-const slashCommandPluginKey = new PluginKey("slashCommand");
+export const slashCommandPluginKey = new PluginKey("slashCommand");
 const capabilitiesOnlySlashCommandMetaKey =
   "skillBuilderCapabilitiesOnlySlashCommand";
 
@@ -51,6 +51,15 @@ function hasSlashCharacterAtPosition(state: EditorState, position: number) {
       "\ufffc"
     ) === "/"
   );
+}
+
+function hasAllowedSlashPrefix(state: EditorState, position: number) {
+  const $position = state.doc.resolve(position);
+  const textBefore = $position.nodeBefore?.isText
+    ? $position.nodeBefore.text
+    : null;
+
+  return !textBefore || textBefore.endsWith(" ");
 }
 
 // Define available slash commands.
@@ -338,6 +347,7 @@ export const SlashCommandExtension =
         // ending with "/" is loaded programmatically via setContent on mount.
         hasBeenFocused: false,
         capabilitiesOnlyTriggerStart: null as number | null,
+        isOpeningCapsOnly: false,
       };
     },
 
@@ -356,6 +366,7 @@ export const SlashCommandExtension =
           char: "/",
           pluginKey: slashCommandPluginKey,
           allowSpaces: true,
+          allowedPrefixes: null,
           startOfLine: false,
           items: ({ query }: { query: string }) => filterSlashCommands(query),
         },
@@ -367,6 +378,9 @@ export const SlashCommandExtension =
         openCapabilitiesSlashCommand:
           () =>
           ({ chain }) => {
+            this.storage.hasBeenFocused = true;
+            this.storage.isOpeningCapsOnly = true;
+
             const inserted = chain()
               .focus()
               .command(({ tr }) => {
@@ -404,7 +418,10 @@ export const SlashCommandExtension =
 
             return true;
           },
-          allow: () => extensionStorage.hasBeenFocused,
+          allow: ({ state, range }) =>
+            extensionStorage.hasBeenFocused &&
+            (extensionStorage.isOpeningCapsOnly ||
+              hasAllowedSlashPrefix(state, range.from)),
           command: ({ editor, range, props }) => {
             if (props.action === INSERT_KNOWLEDGE_NODE_ACTION) {
               editor
@@ -526,6 +543,7 @@ export const SlashCommandExtension =
           key: new PluginKey("skillBuilderSlashCommandCleanup"),
           view: () => ({
             update: (view) => {
+              extensionStorage.isOpeningCapsOnly = false;
               const triggerStart =
                 extensionStorage.capabilitiesOnlyTriggerStart;
 

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -127,7 +127,8 @@ export function useUpdateWorkspaceRegionalModelsOnly({
           sendNotification({
             type: "error",
             title: "Update failed",
-            description: "Some active agents may not be eligible for regional models.",
+            description:
+              "Some active agents may not be eligible for regional models.",
           });
           return false;
         }


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/8612

The Attach capabilities button opens the same menu as typing `/`, by focusing the editor and inserting a slash at the cursor.

Root cause: the slash-command plugin only opens for a slash at the start of a paragraph or after a space. When the cursor was directly after text, for example `hell` or italic text, the button inserted `hell/`; the plugin treated that like a normal slash inside a word and ignored it.

The fix keeps the normal typed-slash behavior unchanged. The button now inserts ` /` when the cursor is immediately after text, and just `/` when the cursor is already at a valid boundary. So typing `hell/` still does not open the menu, while clicking Attach capabilities after `hell` opens it as `hell /`.

## Risks
Blast radius: Skill Builder instructions editor Attach capabilities button behavior.
Risk: low

## Deploy Plan
- deploy front

## Test
- [x] `NODE_ENV=test npm test components/editor/extensions/skill_builder/SlashCommandExtension.test.ts`