### PR TITLE
[Skill Builder] Rename skill authoring fields

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/skills/suggestions.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/suggestions.ts
@@ -1,5 +1,9 @@
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import {
+  SKILL_INSTRUCTIONS_LABEL,
+  SKILL_INVOCATION_LABEL,
+} from "@app/lib/skills/labels";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
@@ -11,8 +15,8 @@ export const PostSkillSuggestionBodySchema = z.object({
   userFacingDescription: z.string().min(1, "Description is required."),
   agentFacingDescription: z
     .string()
-    .min(1, "What will this skill be used for is required."),
-  instructions: z.string().min(1, "Instructions are required."),
+    .min(1, `${SKILL_INVOCATION_LABEL} is required.`),
+  instructions: z.string().min(1, `${SKILL_INSTRUCTIONS_LABEL} are required.`),
   icon: z.string().nullable(),
   mcpServerViewIds: z.array(z.string()),
 });

--- a/front/components/poke/skills/CreateSkillSuggestionSheet.tsx
+++ b/front/components/poke/skills/CreateSkillSuggestionSheet.tsx
@@ -1,6 +1,10 @@
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import {
+  SKILL_INSTRUCTIONS_LABEL,
+  SKILL_INVOCATION_LABEL,
+} from "@app/lib/skills/labels";
 import { usePokeMCPServerViews } from "@app/poke/swr/mcp_server_views";
 import { useCreatePokeSkillSuggestion } from "@app/poke/swr/skills";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -187,7 +191,7 @@ export function CreateSkillSuggestionSheet({
 
             <div className="flex flex-col gap-2">
               <Label htmlFor="agentFacingDescription">
-                What will this skill be used for?
+                {SKILL_INVOCATION_LABEL}
               </Label>
               <TextArea
                 id="agentFacingDescription"
@@ -199,9 +203,7 @@ export function CreateSkillSuggestionSheet({
             </div>
 
             <div className="flex flex-col gap-2">
-              <Label htmlFor="instructions">
-                What guidelines should it provide?
-              </Label>
+              <Label htmlFor="instructions">{SKILL_INSTRUCTIONS_LABEL}</Label>
               <TextArea
                 id="instructions"
                 value={instructions}

--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -9,6 +9,7 @@ import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuild
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import { useSkillVersionComparisonContext } from "@app/components/skill_builder/SkillBuilderVersionContext";
 import { useDebounceWithAbort } from "@app/hooks/useDebounce";
+import { SKILL_INVOCATION_LABEL } from "@app/lib/skills/labels";
 import { useSimilarSkills, useSkills } from "@app/lib/swr/skill_configurations";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import { Button, cn, ReverseLeftV2 } from "@dust-tt/sparkle";
@@ -189,7 +190,7 @@ export function SkillBuilderAgentFacingDescriptionSection() {
     <section className="space-y-4">
       <div className="flex items-center justify-between">
         <h3 className="heading-lg font-semibold text-foreground dark:text-foreground-night">
-          When to use this skill
+          {SKILL_INVOCATION_LABEL}
         </h3>
         {descriptionDiffers && (
           <Button

--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -189,7 +189,7 @@ export function SkillBuilderAgentFacingDescriptionSection() {
     <section className="space-y-4">
       <div className="flex items-center justify-between">
         <h3 className="heading-lg font-semibold text-foreground dark:text-foreground-night">
-          What will this skill be used for?
+          When to use this skill
         </h3>
         {descriptionDiffers && (
           <Button

--- a/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
@@ -54,7 +54,7 @@ export function SkillBuilderInstructionsSection() {
     <section className="flex flex-col gap-3">
       <div className="flex flex-col items-end justify-between gap-2 sm:flex-row">
         <h3 className="heading-lg font-semibold text-foreground dark:text-foreground-night">
-          What guidelines should it provide?
+          Instructions
         </h3>
         <div className="flex items-center gap-2">
           {instructionsDiffer && (

--- a/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
@@ -2,6 +2,7 @@ import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBu
 import { SkillBuilderInstructionsEditor } from "@app/components/skill_builder/SkillBuilderInstructionsEditor";
 import { useSkillVersionComparisonContext } from "@app/components/skill_builder/SkillBuilderVersionContext";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { SKILL_INSTRUCTIONS_LABEL } from "@app/lib/skills/labels";
 import {
   BookOpen01V2,
   Button,
@@ -54,7 +55,7 @@ export function SkillBuilderInstructionsSection() {
     <section className="flex flex-col gap-3">
       <div className="flex flex-col items-end justify-between gap-2 sm:flex-row">
         <h3 className="heading-lg font-semibold text-foreground dark:text-foreground-night">
-          Instructions
+          {SKILL_INSTRUCTIONS_LABEL}
         </h3>
         <div className="flex items-center gap-2">
           {instructionsDiffer && (

--- a/front/components/skill_builder/SkillBuilderIsDefaultSection.tsx
+++ b/front/components/skill_builder/SkillBuilderIsDefaultSection.tsx
@@ -87,9 +87,7 @@ export function SkillBuilderIsDefaultSection() {
                   className="w-full"
                 >
                   The content in&nbsp;
-                  <span className="font-semibold">
-                    What will this skill be used for
-                  </span>
+                  <span className="font-semibold">When to use this skill</span>
                   &nbsp;may be too short for agents to clearly understand when
                   to use this skill. Consider making it more descriptive before
                   allowing discovery.

--- a/front/components/skill_builder/SkillBuilderIsDefaultSection.tsx
+++ b/front/components/skill_builder/SkillBuilderIsDefaultSection.tsx
@@ -1,4 +1,5 @@
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
+import { SKILL_INVOCATION_LABEL } from "@app/lib/skills/labels";
 import {
   ContentMessage,
   Dialog,
@@ -87,7 +88,9 @@ export function SkillBuilderIsDefaultSection() {
                   className="w-full"
                 >
                   The content in&nbsp;
-                  <span className="font-semibold">When to use this skill</span>
+                  <span className="font-semibold">
+                    {SKILL_INVOCATION_LABEL}
+                  </span>
                   &nbsp;may be too short for agents to clearly understand when
                   to use this skill. Consider making it more descriptive before
                   allowing discovery.

--- a/front/lib/skills/labels.ts
+++ b/front/lib/skills/labels.ts
@@ -1,0 +1,2 @@
+export const SKILL_INVOCATION_LABEL = "When to use this skill";
+export const SKILL_INSTRUCTIONS_LABEL = "Instructions";

--- a/front/pages/api/poke/workspaces/[wId]/skills/suggestions.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skills/suggestions.ts
@@ -5,6 +5,10 @@ import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import {
+  SKILL_INSTRUCTIONS_LABEL,
+  SKILL_INVOCATION_LABEL,
+} from "@app/lib/skills/labels";
 import { apiError } from "@app/logger/withlogging";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -17,8 +21,8 @@ const PostSkillSuggestionBodySchema = z.object({
   userFacingDescription: z.string().min(1, "Description is required."),
   agentFacingDescription: z
     .string()
-    .min(1, "What will this skill be used for is required."),
-  instructions: z.string().min(1, "Instructions are required."),
+    .min(1, `${SKILL_INVOCATION_LABEL} is required.`),
+  instructions: z.string().min(1, `${SKILL_INSTRUCTIONS_LABEL} are required.`),
   icon: z.string().nullable(),
   mcpServerViewIds: z.array(z.string()),
 });


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8609

Renames the skill authoring field titles to "When to use this skill" and "Instructions" across Skill Builder and Poke skill suggestions, including validation copy and the warning copy that references the renamed field. The shared labels live in `front/lib/skills/labels.ts` to keep the UI and validation paths aligned.

## Risks

Blast radius: Skill authoring field labels and related validation/warning copy.
Risk: low

## Deploy Plan
- pmrr
- deploy front