### PR TITLE
[Skill Builder] Add skill authoring hints

### DIFF
--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -188,10 +188,15 @@ export function SkillBuilderAgentFacingDescriptionSection() {
 
   return (
     <section className="space-y-4">
-      <div className="flex items-center justify-between">
-        <h3 className="heading-lg font-semibold text-foreground dark:text-foreground-night">
-          {SKILL_INVOCATION_LABEL}
-        </h3>
+      <div className="flex items-start justify-between gap-2">
+        <div className="space-y-1">
+          <h3 className="heading-lg font-semibold text-foreground dark:text-foreground-night">
+            {SKILL_INVOCATION_LABEL}
+          </h3>
+          <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            Tell the agent when it should use this skill.
+          </p>
+        </div>
         {descriptionDiffers && (
           <Button
             variant="outline"

--- a/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
@@ -53,10 +53,16 @@ export function SkillBuilderInstructionsSection() {
 
   return (
     <section className="flex flex-col gap-3">
-      <div className="flex flex-col items-end justify-between gap-2 sm:flex-row">
-        <h3 className="heading-lg font-semibold text-foreground dark:text-foreground-night">
-          {SKILL_INSTRUCTIONS_LABEL}
-        </h3>
+      <div className="flex flex-col items-start justify-between gap-2 sm:flex-row">
+        <div className="space-y-1">
+          <h3 className="heading-lg font-semibold text-foreground dark:text-foreground-night">
+            {SKILL_INSTRUCTIONS_LABEL}
+          </h3>
+          <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            Provide the guidelines the skill should follow when it runs. Type
+            "/" to attach knowledge, tools, or another skill.
+          </p>
+        </div>
         <div className="flex items-center gap-2">
           {instructionsDiffer && (
             <Button


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8619

Follows https://github.com/dust-tt/dust/pull/26819

Adds short helper copy under "When to use this skill" and "Instructions", including the slash-command hint for attaching knowledge, tools, or another skill.

## Risks

Blast radius: Skill Builder helper copy.
Risk: low

## Deploy Plan
- pmrr
- deploy front