### PR TITLE
[Skill Builder] Keep instruction attachments visible

### DIFF
--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -242,7 +242,7 @@ function sanitizeSkillInstructionsHtml(
   }
 }
 
-const INSTRUCTIONS_EDITOR_SIZE = "min-h-60 max-h-[1024px]";
+const INSTRUCTIONS_EDITOR_SIZE = "min-h-60 max-h-[50vh]";
 const INSTRUCTIONS_EDITOR_REFERENCE_SUMMARY_SIZE =
   "min-h-80 rounded-b-none border-b-0 pb-44";
 


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8618

Follows https://github.com/dust-tt/dust/pull/26820

Caps the Skill Builder instructions editor at half the viewport height while keeping its existing minimum height. Long instructions now scroll inside the editor so the attach buttons above it remain reachable.

## Risks

Blast radius: Skill Builder instructions editor height.
Risk: low

## Deploy Plan
- pmrr
- deploy front