### PR TITLE
Release the skill authoring tool globally and remove its feature flag

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -979,9 +979,7 @@ export const INTERNAL_MCP_SERVERS = {
     availability: "auto_hidden_builder",
     allowMultipleInstances: false,
     isPreview: false,
-    isRestricted: ({ featureFlags }) => {
-      return !featureFlags.includes("skill_authoring_tool");
-    },
+    isRestricted: undefined,
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,

--- a/front/lib/resources/skill/code_defined/skill_authoring.test.ts
+++ b/front/lib/resources/skill/code_defined/skill_authoring.test.ts
@@ -3,19 +3,12 @@ import {
   SKILL_AUTHORING_SERVER_NAME,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { GlobalSkillsRegistry } from "@app/lib/resources/skill/code_defined/global_registry";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { describe, expect, it } from "vitest";
 
 describe("skill authoring code-defined skill", () => {
-  it("is restricted with the same feature flag as the internal server", async () => {
+  it("is available to every workspace without a feature flag", async () => {
     const { authenticator } = await createResourceTest({ role: "builder" });
-
-    await expect(
-      GlobalSkillsRegistry.getById(authenticator, "skill-authoring")
-    ).resolves.toBeNull();
-
-    await FeatureFlagFactory.basic(authenticator, "skill_authoring_tool");
 
     const skill = await GlobalSkillsRegistry.getById(
       authenticator,
@@ -26,22 +19,8 @@ describe("skill authoring code-defined skill", () => {
       mcpServers: [{ name: SKILL_AUTHORING_SERVER_NAME }],
     });
 
-    const isRestricted =
-      INTERNAL_MCP_SERVERS[SKILL_AUTHORING_SERVER_NAME].isRestricted;
-    expect(isRestricted).toBeDefined();
     expect(
-      isRestricted?.({
-        featureFlags: [],
-        isDeepDiveDisabled: false,
-        plan: authenticator.getNonNullablePlan(),
-      })
-    ).toBe(true);
-    expect(
-      isRestricted?.({
-        featureFlags: ["skill_authoring_tool"],
-        isDeepDiveDisabled: false,
-        plan: authenticator.getNonNullablePlan(),
-      })
-    ).toBe(false);
+      INTERNAL_MCP_SERVERS[SKILL_AUTHORING_SERVER_NAME].isRestricted
+    ).toBeUndefined();
   });
 });

--- a/front/lib/resources/skill/code_defined/skill_authoring.ts
+++ b/front/lib/resources/skill/code_defined/skill_authoring.ts
@@ -1,4 +1,3 @@
-import { getFeatureFlags } from "@app/lib/auth";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
 
 const SKILL_AUTHORING_INSTRUCTIONS = `
@@ -35,6 +34,4 @@ export const skillAuthoringSkill = {
   mcpServers: [{ name: "skill_authoring" }],
   version: 1,
   icon: "ActionListIcon",
-  isRestricted: async (auth) =>
-    !(await getFeatureFlags(auth)).includes("skill_authoring_tool"),
 } as const satisfies GlobalSkillDefinition;

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -144,10 +144,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Access to Gemini 3.1 Pro model in the agent builder",
     stage: "on_demand",
   },
-  skill_authoring_tool: {
-    description: "MCP tool for agents to create and update workspace Skills",
-    stage: "dust_only",
-  },
   hootl_subscriptions: {
     description: "Subscription feature for Schedule & Triggers.",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -687,7 +687,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "agent_builder_copilot"
   | "agent_builder_copilot_builders"
   | "agent_builder_shrink_wrap"
-  | "skill_authoring_tool"
   | "custom_model_feature"
   | "anthropic_vertex_fallback"
   | "audit_logs"


### PR DESCRIPTION
## Description

The skill authoring MCP server and its code-defined "Author Skills" global skill were gated behind the `skill_authoring_tool` feature flag. This releases the feature to every workspace and removes the flag.

- Removes `skill_authoring_tool` from `feature_flags.ts` and the SDK `WhitelistableFeature` union.
- Drops `isRestricted` from the `skill-authoring` global skill so it is always available.
- Sets the `skill_authoring` internal server `isRestricted` to `undefined`, matching the other unrestricted skill servers (`skill_management`).
- Rewrites the gating test to assert the skill and server are available without any flag.

## Tests

Ran `skill_authoring.test.ts` and the `skill_authoring` tool tests locally against the test DB (10 passing). Typecheck clean.

## Risk

Low. The feature has been running behind the flag for dust-only workspaces; this makes it the default everywhere. No schema changes. Rollback is a straight revert.

## Deploy Plan

Standard deploy. The `skill_authoring_tool` flag rows become inert and can be cleaned up separately.