### PR TITLE
[front] feat: none seat type, message-send gate + seat removal

### DIFF
--- a/front/components/app/ReachedLimitPopup.tsx
+++ b/front/components/app/ReachedLimitPopup.tsx
@@ -25,7 +25,8 @@ export type WorkspaceLimit =
   | "message_limit"
   | "credits_exhausted"
   | "pool_credits_exhausted"
-  | "user_credits_exhausted";
+  | "user_credits_exhausted"
+  | "no_seat";
 
 function getLimitPromptForCode(
   router: AppRouter,
@@ -194,6 +195,21 @@ function getLimitPromptForCode(
               {isAdmin
                 ? "Your workspace has run out of credits. Please purchase more credits to continue using Dust."
                 : "Your workspace has run out of credits. Please contact your administrator to purchase more credits."}
+            </Page.P>
+          </>
+        ),
+      };
+    }
+
+    case "no_seat": {
+      return {
+        title: "No seat assigned",
+        validateLabel: "Ok",
+        children: (
+          <>
+            <Page.P>
+              You don&apos;t have a seat assigned in this workspace. Please
+              contact your administrator to assign you one.
             </Page.P>
           </>
         ),

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -36,6 +36,8 @@ import {
 } from "@app/types/assistant/mentions";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import {
+  AlertCircleV2,
+  ContentMessage,
   ContentMessageAction,
   ContentMessageInline,
   EmptyCTA,
@@ -494,6 +496,17 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
           />
         )}
       </div>
+      {context.isNoSeat && (
+        <ContentMessage
+          icon={AlertCircleV2}
+          variant="warning"
+          className="mb-3 flex w-full"
+          title="No seat assigned"
+        >
+          You don&apos;t have a seat in this workspace. Contact your admin to
+          send messages.
+        </ContentMessage>
+      )}
       {blockedActions.length > 0 && (
         <ContentMessageInline
           icon={InfoCircleV2}

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -13,6 +13,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { getRandomGreetingForName } from "@app/lib/client/greetings";
 import type { DustError } from "@app/lib/error";
 import { useAppRouter } from "@app/lib/platform";
+import { useMembersUsage } from "@app/lib/swr/memberships";
 import { classNames } from "@app/lib/utils";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { ConversationListItemType } from "@app/types/assistant/conversation";
@@ -28,7 +29,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import type { UserType, WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
 import { Button, Card, Lightbulb04V2, Page, XCloseV2 } from "@dust-tt/sparkle";
-import { useCallback, useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
 
 interface ConversationContainerProps {
   owner: WorkspaceType;
@@ -61,6 +62,29 @@ export function ConversationContainerVirtuoso({
 
   const [limitReachedCode, setLimitReachedCode] =
     useState<WorkspaceLimit | null>(null);
+
+  // Proactively fetch the current user's seat type so the no-seat banner
+  // shows immediately without requiring a failed send first.
+  const { membersUsage: selfUsage } = useMembersUsage({
+    workspaceId: owner.sId,
+    searchTerm: user.email ?? "",
+    pageIndex: 0,
+    pageSize: 1,
+    disabled: !user.email,
+  });
+  const isNoSeat =
+    selfUsage.length > 0 &&
+    selfUsage[0].sId === user.sId &&
+    selfUsage[0].seatType === "none";
+
+  const effectiveLimitCode: WorkspaceLimit | null = isNoSeat
+    ? "no_seat"
+    : limitReachedCode;
+
+  const lastLimitReachedCode = useRef<WorkspaceLimit>("message_limit");
+  if (effectiveLimitCode !== null) {
+    lastLimitReachedCode.current = effectiveLimitCode;
+  }
   const { setSelectedSingleAgent } = useContext(InputBarContext);
 
   const router = useAppRouter();
@@ -185,6 +209,7 @@ export function ConversationContainerVirtuoso({
           user={user}
           conversationId={activeConversationId}
           setLimitReachedCode={setLimitReachedCode}
+          limitReachedCode={effectiveLimitCode}
           key={conversationViewerKey}
           clientSideMCPServerIds={clientSideMCPServerIds}
         />
@@ -210,6 +235,9 @@ export function ConversationContainerVirtuoso({
               onSubmit={handleConversationCreation}
               draftKey="home-new-conversation"
               disableAutoFocus={false}
+              submitBlockMessage={
+                isNoSeat ? "You don't have a seat in this workspace." : null
+              }
             />
           </div>
 
@@ -253,11 +281,11 @@ export function ConversationContainerVirtuoso({
       )}
       <ReachedLimitPopup
         isAdmin={isAdmin(owner)}
-        isOpened={!!limitReachedCode}
+        isOpened={!!effectiveLimitCode && effectiveLimitCode !== "no_seat"}
         onClose={() => setLimitReachedCode(null)}
         subscription={subscription}
         owner={owner}
-        code={limitReachedCode ?? "message_limit"}
+        code={lastLimitReachedCode.current}
       />
     </DropzoneContainer>
   );

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -111,6 +111,7 @@ interface ConversationViewerProps {
   additionalMarkdownComponents?: Components;
   additionalMarkdownPlugins?: PluggableList;
   setLimitReachedCode?: (code: WorkspaceLimit) => void;
+  limitReachedCode?: WorkspaceLimit | null;
   owner: WorkspaceType;
   user: UserType;
   clientSideMCPServerIds?: string[];
@@ -323,6 +324,7 @@ export const ConversationViewer = ({
   additionalMarkdownComponents,
   additionalMarkdownPlugins,
   setLimitReachedCode,
+  limitReachedCode,
   clientSideMCPServerIds,
 }: ConversationViewerProps) => {
   const virtuosoMessageListRef =
@@ -1409,6 +1411,7 @@ export const ConversationViewer = ({
       branchIdToApprove: branchIdToApprove ?? undefined,
       setBranchIdToApprove,
       isAutoScrollEnabledRef,
+      isNoSeat: limitReachedCode === "no_seat",
     };
   }, [
     user,
@@ -1426,6 +1429,7 @@ export const ConversationViewer = ({
     spaceInfo?.archivedAt,
     spaceInfo?.name,
     branchIdToApprove,
+    limitReachedCode,
   ]);
 
   return (

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -141,6 +141,7 @@ export type VirtuosoMessageListContext = {
   branchIdToApprove?: string;
   setBranchIdToApprove?: (branchId: string | null) => void;
   isAutoScrollEnabledRef: MutableRefObject<boolean>;
+  isNoSeat?: boolean;
 };
 
 export const areSameRankAndBranch = (

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -19,7 +19,10 @@ import {
   useCreditPurchaseInfo,
   useSeatPlan,
 } from "@app/lib/swr/credits";
-import { useMembersUsage } from "@app/lib/swr/memberships";
+import {
+  useMembersUsage,
+  useUpdateMemberSeatType,
+} from "@app/lib/swr/memberships";
 import {
   usePerSeatPricing,
   useWorkspaceSeatAvailability,
@@ -45,7 +48,8 @@ import {
   Tooltip,
 } from "@dust-tt/sparkle";
 import type { PaginationState } from "@tanstack/react-table";
-import { useCallback, useEffect, useState } from "react";
+import { ConfirmContext } from "@app/components/Confirm";
+import { useCallback, useContext, useEffect, useState } from "react";
 
 function formatCredits(credits: number): string {
   return Math.round(credits).toLocaleString("en-US");
@@ -109,6 +113,32 @@ export function UsagePage() {
   const [showBuyCreditDialog, setShowBuyCreditDialog] = useState(false);
   const [changeSeatMember, setChangeSeatMember] =
     useState<MemberUsageType | null>(null);
+
+  const confirm = useContext(ConfirmContext);
+  const { doUpdateSeatType } = useUpdateMemberSeatType({
+    workspaceId: owner.sId,
+  });
+  const onRemoveSeat = useCallback(
+    async (member: MemberUsageType) => {
+      const confirmed = await confirm({
+        title: "Remove seat",
+        message: `Are you sure you want to remove ${member.name}'s seat? They will keep access until the end of the current billing period, then lose the ability to send messages.`,
+        validateLabel: "Remove seat",
+        validateVariant: "warning",
+      });
+      if (!confirmed) {
+        return;
+      }
+      void doUpdateSeatType({
+        memberId: member.sId,
+        memberName: member.name,
+        seatType: "none",
+        isCancellingScheduledChange: false,
+        hasSeatPool: false,
+      });
+    },
+    [confirm, doUpdateSeatType]
+  );
   const [editSpendLimitMember, setEditSpendLimitMember] =
     useState<MemberUsageType | null>(null);
   const [inviteBlockedPopupReason, setInviteBlockedPopupReason] =
@@ -378,6 +408,7 @@ export function UsagePage() {
             seatTypeFilter={seatTypeFilter}
             isSeatBased={isSeatBased}
             onChangeSeat={setChangeSeatMember}
+            onRemoveSeat={onRemoveSeat}
             onEditSpendLimit={setEditSpendLimitMember}
             pagination={pagination}
             setPagination={setPagination}

--- a/front/components/workspace/ChangeSeatModal.tsx
+++ b/front/components/workspace/ChangeSeatModal.tsx
@@ -27,6 +27,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  ExclamationCircleIcon,
   Hexagon01V2,
   SeatMaxV2,
 } from "@dust-tt/sparkle";
@@ -36,6 +37,7 @@ import { useEffect, useRef, useState } from "react";
 // (`SeatTypeInfo.name`) so adding a new seat tier only requires tagging the
 // product in Metronome — no code change here.
 const SEAT_TYPE_ICONS: Record<MembershipSeatType, React.ComponentType> = {
+  none: ExclamationCircleIcon,
   free: Hexagon01V2,
   pro: Cube01V2,
   pro_yearly: Cube01V2,

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -10,6 +10,7 @@ import {
   CoinsStacked03V2,
   Cube01V2,
   DataTable,
+  ExclamationCircleIcon,
   Hexagon01V2,
   Icon,
   LoadingBlock,
@@ -47,6 +48,7 @@ type Info = CellContext<RowData, string>;
 const SEAT_TYPE_ICONS: Partial<
   Record<MembershipSeatType, React.ComponentType>
 > = {
+  none: ExclamationCircleIcon,
   max: SeatMaxV2,
   pro: Cube01V2,
   free: Hexagon01V2,
@@ -377,6 +379,7 @@ interface MembersUsageTableProps {
   seatTypeFilter: MembershipSeatType | "none" | null;
   isSeatBased: boolean;
   onChangeSeat: (member: MemberUsageType) => void;
+  onRemoveSeat: (member: MemberUsageType) => void;
   onEditSpendLimit: (member: MemberUsageType) => void;
   pagination: PaginationState;
   setPagination: (pagination: PaginationState) => void;
@@ -389,6 +392,7 @@ export function MembersUsageTable({
   seatTypeFilter,
   isSeatBased,
   onChangeSeat,
+  onRemoveSeat,
   onEditSpendLimit,
   pagination,
   setPagination,
@@ -435,9 +439,20 @@ export function MembersUsageTable({
             ? [
                 {
                   kind: "item" as const,
-                  label: "Change seat type",
+                  label: m.seatType ? "Change seat type" : "Assign seat",
                   onClick: () => onChangeSeat(m),
                 },
+                // Only members who currently hold a billable seat can have it removed.
+                ...(m.seatType && m.seatType !== "none"
+                  ? [
+                      {
+                        kind: "item" as const,
+                        label: "Remove seat",
+                        variant: "warning" as const,
+                        onClick: () => onRemoveSeat(m),
+                      },
+                    ]
+                  : []),
               ]
             : []),
           {
@@ -447,7 +462,7 @@ export function MembersUsageTable({
           },
         ],
       })),
-    [filtered, isSeatBased, onChangeSeat, onEditSpendLimit]
+    [filtered, isSeatBased, onChangeSeat, onRemoveSeat, onEditSpendLimit]
   );
 
   const displayPeriodColumn = useMemo(

--- a/front/components/workspace/billing/BillingSeatsOverview.tsx
+++ b/front/components/workspace/billing/BillingSeatsOverview.tsx
@@ -63,6 +63,8 @@ function seatTypeGroup(seatType: MembershipSeatType): MembershipSeatType {
       return "pro";
     case "max_yearly":
       return "max";
+    case "none":
+      return "none";
     default:
       assertNeverAndIgnore(seatType);
       return seatType;

--- a/front/hooks/useCreateConversationWithMessage.ts
+++ b/front/hooks/useCreateConversationWithMessage.ts
@@ -1,4 +1,5 @@
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import { useSendNotification } from "@app/hooks/useNotification";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useClientType } from "@app/lib/context/clientType";
 import { clientFetch } from "@app/lib/egress/client";
@@ -40,6 +41,7 @@ export function useCreateConversationWithMessage({
   const { fetcher } = useFetcher();
   const contextOrigin = useClientType();
   const { hasFeature } = useFeatureFlags();
+  const sendNotification = useSendNotification();
   const { setPendingFirstMessage, clearPendingFirstMessage } =
     useContext(InputBarContext);
 
@@ -148,6 +150,13 @@ export function useCreateConversationWithMessage({
             origin,
             skipToolsValidation,
             profilePictureUrl: user.image,
+            onError: (err) => {
+              sendNotification({
+                title: err.title,
+                description: err.message,
+                type: "error",
+              });
+            },
           }).finally(() => {
             clearPendingFirstMessage(conversationId);
           });
@@ -231,6 +240,7 @@ export function useCreateConversationWithMessage({
       fetcher,
       contextOrigin,
       hasFeature,
+      sendNotification,
       setPendingFirstMessage,
       clearPendingFirstMessage,
     ]
@@ -251,6 +261,7 @@ async function postFirstMessageInBackground({
   origin,
   skipToolsValidation,
   profilePictureUrl,
+  onError,
 }: {
   workspaceId: string;
   conversationId: string;
@@ -262,6 +273,7 @@ async function postFirstMessageInBackground({
   origin: ClientMessageOrigin;
   skipToolsValidation: boolean;
   profilePictureUrl: string | null;
+  onError?: (err: SubmitMessageError) => void;
 }): Promise<void> {
   const timezone =
     Intl.DateTimeFormat().resolvedOptions().timeZone || "Etc/UTC";
@@ -319,7 +331,7 @@ async function postFirstMessageInBackground({
       );
     }
 
-    await clientFetch(
+    const msgRes = await clientFetch(
       `/api/w/${workspaceId}/assistant/conversations/${conversationId}/messages`,
       {
         method: "POST",
@@ -338,8 +350,25 @@ async function postFirstMessageInBackground({
         }),
       }
     );
+    if (!msgRes.ok) {
+      const body = await msgRes.json().catch(() => null);
+      if (onError) {
+        const errResult = toConversationCreationError(
+          isAPIErrorResponse(body) ? body : new Error("Failed to post message")
+        );
+        if (errResult.isErr()) {
+          onError(errResult.error);
+        }
+      }
+    }
   } catch (e) {
     logger.error({ err: e }, "Failed to post first message in background");
+    if (onError) {
+      const err = toConversationCreationError(e);
+      if (err.isErr()) {
+        onError(err.error);
+      }
+    }
   }
 }
 

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -39,6 +39,7 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { ProjectFileFactory } from "@app/tests/utils/ProjectFileFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type {
   ContentFragmentInputWithContentNode,
   ContentFragmentInputWithFileIdType,
@@ -4747,6 +4748,61 @@ describe("conversation fetch forkingData", () => {
       expect(conversationResult.value.forkingData).toEqual({
         forkedChildren: expectedForkedChildren,
       });
+    }
+  });
+});
+
+describe("postUserMessage no-seat gate", () => {
+  it("rejects messages from a member with the `none` seat type", async () => {
+    // Credit-priced (Metronome) workspace — the seat gate only applies there.
+    const workspace = await WorkspaceFactory.creditPriced();
+    await SpaceFactory.defaults(
+      await Authenticator.internalAdminForWorkspace(workspace.sId)
+    );
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, {
+      role: "user",
+      seatType: "none",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Seatless Test Agent",
+      description: "Agent for the no-seat gate test",
+    });
+    const created = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+      visibility: "unlisted",
+    });
+    const fetched = await getConversation(auth, created.sId);
+    if (fetched.isErr()) {
+      throw new Error("Failed to fetch conversation");
+    }
+
+    const userJson = user.toJSON();
+    const result = await postUserMessage(auth, {
+      conversation: fetched.value,
+      content: `Hello @${agent.name}`,
+      mentions: [{ configurationId: agent.sId } satisfies AgentMention],
+      context: {
+        username: userJson.username,
+        timezone: "UTC",
+        fullName: userJson.fullName,
+        email: userJson.email,
+        profilePictureUrl: userJson.image,
+        origin: "web",
+      },
+      skipToolsValidation: false,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.status_code).toBe(403);
+      expect(result.error.api_error.type).toBe("no_seat");
     }
   });
 });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1200,6 +1200,14 @@ export async function editUserMessage(
     return canInteractRes;
   }
 
+  const editLimitResult = await checkMessagesLimit(auth, {
+    mentions,
+    context: message.context,
+  });
+  if (editLimitResult.isErr()) {
+    return editLimitResult;
+  }
+
   let userMessage: UserMessageType | null = null;
   let agentMessages: AgentMessageType[] = [];
 
@@ -2442,6 +2450,26 @@ async function checkMessagesLimit(
   const owner = auth.getNonNullableWorkspace();
   const plan = auth.subscription()?.plan;
   const user = auth.user();
+
+  if (user) {
+    const membership =
+      await MembershipResource.getActiveMembershipOfUserInWorkspace({
+        user,
+        workspace: owner,
+      });
+    if (membership?.seatType === "none") {
+      return new Err({
+        status_code: 403,
+        api_error: {
+          type: "no_seat",
+          message:
+            "You don't have a seat in this workspace. Ask a workspace admin " +
+            "to assign you one to start sending messages.",
+        },
+      });
+    }
+  }
+
   if (owner.metronomeCustomerId && plan && isCreditPricedPlan(plan)) {
     const blockedReason = user
       ? await isUserBlocked(owner.sId, user.sId)

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -163,12 +163,16 @@ export function classifySeatChange({
     newSeatType,
     productSeatTypes
   );
-  if (newAllocation >= previousAllocation) {
+  // Removing a seat (`none`) always defers, even when the previous tier had
+  // zero AWU allocation (e.g. workspace seats): 0 >= 0 would otherwise
+  // classify as immediate. Any genuine upgrade takes effect right away.
+  if (newSeatType !== "none" && newAllocation >= previousAllocation) {
     return { kind: "immediate" };
   }
 
-  // Downgrade — defer to the start of the next billing period so the user
-  // keeps the richer access they've already paid for. Billing-period
+  // Downgrade (or seat removal) — defer to the start of the next billing
+  // period so the user keeps the richer access they've already paid for.
+  // Billing-period
   // boundaries aren't anchored to midnight on the contract, so ceil to
   // midnight UTC to match how the invoice timestamp is displayed.
   const nextStartingAt = (contract.subscriptions ?? [])
@@ -519,6 +523,10 @@ export async function syncSeatCount({
     );
     const uncoveredUsersBySeatType = new Map<MembershipSeatType, string[]>();
     for (const [userSId, seatType] of currentSeatByUserSId) {
+      // `none` is intentionally unbilled — skip silently.
+      if (seatType === "none") {
+        continue;
+      }
       if (!coveredSeatTypes.has(seatType)) {
         const bucket = uncoveredUsersBySeatType.get(seatType) ?? [];
         bucket.push(userSId);

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -316,16 +316,27 @@ export function useUpdateMemberSeatType({
 
       const body = await res.json();
       const isDeferred = !!body?.scheduledSeatChangeAt;
+      const isRemoval = seatType === "none";
       sendNotification({
         type: "success",
-        title: isDeferred ? "Seat change scheduled" : "Seat updated",
-        description: isDeferred
-          ? `${memberName}'s seat will change to ${seatType} at the next credit refresh.`
-          : isCancellingScheduledChange
-            ? `${memberName}'s scheduled seat change has been cancelled.`
-            : hasSeatPool
-              ? `${memberName}'s seat has been updated to ${seatType}. The seat pool will be provisioned shortly.`
-              : `${memberName}'s seat has been updated to ${seatType}.`,
+        title: isRemoval
+          ? isDeferred
+            ? "Seat removal scheduled"
+            : "Seat removed"
+          : isDeferred
+            ? "Seat change scheduled"
+            : "Seat updated",
+        description: isRemoval
+          ? isDeferred
+            ? `${memberName}'s seat will be removed at the next billing period. They keep full access until then.`
+            : `${memberName}'s seat has been removed.`
+          : isDeferred
+            ? `${memberName}'s seat will change to ${seatType} at the next credit refresh.`
+            : isCancellingScheduledChange
+              ? `${memberName}'s scheduled seat change has been cancelled.`
+              : hasSeatPool
+                ? `${memberName}'s seat has been updated to ${seatType}. The seat pool will be provisioned shortly.`
+                : `${memberName}'s seat has been updated to ${seatType}.`,
       });
 
       await invalidateMembersUsage(workspaceId);

--- a/front/tests/utils/WorkspaceFactory.ts
+++ b/front/tests/utils/WorkspaceFactory.ts
@@ -1,6 +1,7 @@
 import { PlanModel } from "@app/lib/models/plan";
 import { upsertFreePlans } from "@app/lib/plans/free_plans";
 import {
+  CREDIT_PRICED_BUSINESS_PLAN_CODE,
   FREE_BYOK_PLAN_CODE,
   FREE_TEST_PLAN_CODE,
   PRO_PLAN_SEAT_29_CODE,
@@ -43,6 +44,19 @@ export class WorkspaceFactory {
     return this.create(PRO_PLAN_SEAT_29_CODE, overrides, {
       metronomeContractId: "test-metronome-contract-id",
     });
+  }
+
+  // A Metronome credit-priced workspace (plan code prefixed `CP_`), used to
+  // exercise credit-priced gating such as the per-user credit cap or the
+  // `none`-seat message block.
+  static async creditPriced(
+    overrides?: WorkspaceOverrides
+  ): Promise<WorkspaceType> {
+    return this.create(
+      CREDIT_PRICED_BUSINESS_PLAN_CODE,
+      { metronomeCustomerId: "cus_test_credit_priced", ...overrides },
+      { metronomeContractId: "test-metronome-contract-id" }
+    );
   }
 
   // Plans are seeded by the DB init script (admin/db.ts) to avoid deadlocks

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -74,6 +74,7 @@ const API_ERROR_TYPES = [
   "plan_message_limit_exceeded",
   "credits_exhausted",
   "user_cap_reached",
+  "no_seat",
   "model_disabled",
   "global_agent_error",
   "stripe_invalid_product_id_error",

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -24,7 +24,8 @@ export function isMembershipOriginType(
   return MEMBERSHIP_ORIGIN_TYPES.includes(value as MembershipOriginType);
 }
 
-export const MEMBERSHIP_SEAT_TYPES = [
+// Billable seat types — each maps to a Metronome product.
+export const BILLABLE_SEAT_TYPES = [
   "free",
   "workspace",
   "workspace_yearly",
@@ -32,6 +33,12 @@ export const MEMBERSHIP_SEAT_TYPES = [
   "pro_yearly",
   "max",
   "max_yearly",
+] as const;
+
+export const MEMBERSHIP_SEAT_TYPES = [
+  // `none` = no billable seat assigned; member cannot send messages.
+  "none",
+  ...BILLABLE_SEAT_TYPES,
 ] as const;
 
 export type MembershipSeatType = (typeof MEMBERSHIP_SEAT_TYPES)[number];
@@ -88,6 +95,7 @@ export function normalizeToPoolLimitSeatType(
     case "workspace_yearly":
       return "workspace";
     case "free":
+    case "none":
       return null;
     default:
       assertNever(seatType);


### PR DESCRIPTION
## Summary

**None seat type**
- Adds `none` to `MEMBERSHIP_SEAT_TYPES` for members who hold no billable seat

**Message-send gate**
- `checkMessagesLimit` (shared by `postUserMessage`, `editUserMessage`, `retryAgentMessage`) blocks `none`-seat members with 403 `no_seat` before any message is created — billing-system agnostic
- Deferred new-conversation path: check `msgRes.ok` so 403s surface as notifications
- Proactive seat type fetch in `ConversationContainer` drives a persistent warning banner above the input bar
- Error on send shows as a regular `sendNotification` toast

**Seat removal**
- "Remove seat" button in the usage page member table (only for members with a billable seat, not `none`-seat members)
- Defers to the next billing period — member keeps full access until then
- Confirmation dialog before removing
- Fixes `classifySeatChange` to always defer when `newSeatType === "none"`: `workspace → none` compares `0 >= 0` without the guard and incorrectly classifies as `immediate`
- Skips `none`-seat users in `syncSeatCount`'s uncovered-subscription warning

**UI**
- `ExclamationCircleIcon` for `none` in `ChangeSeatModal` and `MembersUsageTable`; `none` case in `BillingSeatsOverview`

## Test
- `postUserMessage` no-seat gate test
- `WorkspaceFactory.creditPriced()` factory for credit-priced workspace setup

## Risk
Low — `none` is a new seat type value. Existing members don't hold it; no existing code paths are affected unless explicitly assigned `none`. The `classifySeatChange` fix is correctness-only for a path not yet reachable in production.