### PR TITLE
[front] feat: none seat type + seat removal from usage page

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -1,5 +1,6 @@
 import type { WorkspaceLimit } from "@app/components/app/ReachedLimitPopup";
 import { ReachedLimitPopup } from "@app/components/app/ReachedLimitPopup";
+import { ConfirmContext } from "@app/components/Confirm";
 import { InviteEmailButtonWithModal } from "@app/components/members/InviteEmailButtonWithModal";
 import { AwuUsageChart } from "@app/components/workspace/AwuUsageChart";
 import { BuyAwuCreditsDialog } from "@app/components/workspace/BuyAwuCreditsDialog";

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -19,7 +19,10 @@ import {
   useCreditPurchaseInfo,
   useSeatPlan,
 } from "@app/lib/swr/credits";
-import { useMembersUsage } from "@app/lib/swr/memberships";
+import {
+  useMembersUsage,
+  useUpdateMemberSeatType,
+} from "@app/lib/swr/memberships";
 import {
   usePerSeatPricing,
   useWorkspaceSeatAvailability,
@@ -42,8 +45,9 @@ import {
   SearchInput,
   Spinner,
 } from "@dust-tt/sparkle";
+import { ConfirmContext } from "@app/components/Confirm";
 import type { PaginationState, SortingState } from "@tanstack/react-table";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 
 function formatCredits(credits: number): string {
   return Math.round(credits).toLocaleString("en-US");
@@ -82,6 +86,32 @@ export function UsagePage() {
   const [showBuyCreditDialog, setShowBuyCreditDialog] = useState(false);
   const [changeSeatMember, setChangeSeatMember] =
     useState<MemberUsageType | null>(null);
+
+  const confirm = useContext(ConfirmContext);
+  const { doUpdateSeatType } = useUpdateMemberSeatType({
+    workspaceId: owner.sId,
+  });
+  const onRemoveSeat = useCallback(
+    async (member: MemberUsageType) => {
+      const confirmed = await confirm({
+        title: "Remove seat",
+        message: `Are you sure you want to remove ${member.name}'s seat? They will keep access until the end of the current billing period, then lose the ability to send messages.`,
+        validateLabel: "Remove seat",
+        validateVariant: "warning",
+      });
+      if (!confirmed) {
+        return;
+      }
+      void doUpdateSeatType({
+        memberId: member.sId,
+        memberName: member.name,
+        seatType: "none",
+        isCancellingScheduledChange: false,
+        hasSeatPool: false,
+      });
+    },
+    [confirm, doUpdateSeatType]
+  );
   const [editSpendLimitMember, setEditSpendLimitMember] =
     useState<MemberUsageType | null>(null);
   const [inviteBlockedPopupReason, setInviteBlockedPopupReason] =
@@ -330,6 +360,7 @@ export function UsagePage() {
             seatTypeFilter={seatTypeFilter}
             isSeatBased={isSeatBased}
             onChangeSeat={setChangeSeatMember}
+            onRemoveSeat={onRemoveSeat}
             onEditSpendLimit={setEditSpendLimitMember}
             pagination={pagination}
             setPagination={setPagination}

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -46,7 +46,6 @@ import {
   SearchInput,
   Spinner,
 } from "@dust-tt/sparkle";
-import { ConfirmContext } from "@app/components/Confirm";
 import type { PaginationState, SortingState } from "@tanstack/react-table";
 import { useCallback, useContext, useEffect, useState } from "react";
 

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -375,6 +375,7 @@ interface MembersUsageTableProps {
   seatTypeFilter: MembershipSeatType | "none" | null;
   isSeatBased: boolean;
   onChangeSeat: (member: MemberUsageType) => void;
+  onRemoveSeat: (member: MemberUsageType) => void;
   onEditSpendLimit: (member: MemberUsageType) => void;
   pagination: PaginationState;
   setPagination: (pagination: PaginationState) => void;
@@ -389,6 +390,7 @@ export function MembersUsageTable({
   seatTypeFilter,
   isSeatBased,
   onChangeSeat,
+  onRemoveSeat,
   onEditSpendLimit,
   pagination,
   setPagination,
@@ -437,9 +439,20 @@ export function MembersUsageTable({
             ? [
                 {
                   kind: "item" as const,
-                  label: "Change seat type",
+                  label: m.seatType ? "Change seat type" : "Assign seat",
                   onClick: () => onChangeSeat(m),
                 },
+                // Only members who currently hold a billable seat can have it removed.
+                ...(m.seatType && m.seatType !== "none"
+                  ? [
+                      {
+                        kind: "item" as const,
+                        label: "Remove seat",
+                        variant: "warning" as const,
+                        onClick: () => onRemoveSeat(m),
+                      },
+                    ]
+                  : []),
               ]
             : []),
           {
@@ -449,7 +462,7 @@ export function MembersUsageTable({
           },
         ],
       })),
-    [filtered, isSeatBased, onChangeSeat, onEditSpendLimit]
+    [filtered, isSeatBased, onChangeSeat, onRemoveSeat, onEditSpendLimit]
   );
 
   const displayPeriodColumn = useMemo(

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -163,12 +163,16 @@ export function classifySeatChange({
     newSeatType,
     productSeatTypes
   );
-  if (newAllocation >= previousAllocation) {
+  // Removing a seat (`none`) always defers, even when the previous tier had
+  // zero AWU allocation (e.g. workspace seats): 0 >= 0 would otherwise
+  // classify as immediate. Any genuine upgrade takes effect right away.
+  if (newSeatType !== "none" && newAllocation >= previousAllocation) {
     return { kind: "immediate" };
   }
 
-  // Downgrade — defer to the start of the next billing period so the user
-  // keeps the richer access they've already paid for. Billing-period
+  // Downgrade (or seat removal) — defer to the start of the next billing
+  // period so the user keeps the richer access they've already paid for.
+  // Billing-period
   // boundaries aren't anchored to midnight on the contract, so ceil to
   // midnight UTC to match how the invoice timestamp is displayed.
   const nextStartingAt = (contract.subscriptions ?? [])
@@ -519,6 +523,10 @@ export async function syncSeatCount({
     );
     const uncoveredUsersBySeatType = new Map<MembershipSeatType, string[]>();
     for (const [userSId, seatType] of currentSeatByUserSId) {
+      // `none` is intentionally unbilled — skip silently.
+      if (seatType === "none") {
+        continue;
+      }
       if (!coveredSeatTypes.has(seatType)) {
         const bucket = uncoveredUsersBySeatType.get(seatType) ?? [];
         bucket.push(userSId);

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -333,16 +333,27 @@ export function useUpdateMemberSeatType({
 
       const body = await res.json();
       const isDeferred = !!body?.scheduledSeatChangeAt;
+      const isRemoval = seatType === "none";
       sendNotification({
         type: "success",
-        title: isDeferred ? "Seat change scheduled" : "Seat updated",
-        description: isDeferred
-          ? `${memberName}'s seat will change to ${seatType} at the next credit refresh.`
-          : isCancellingScheduledChange
-            ? `${memberName}'s scheduled seat change has been cancelled.`
-            : hasSeatPool
-              ? `${memberName}'s seat has been updated to ${seatType}. The seat pool will be provisioned shortly.`
-              : `${memberName}'s seat has been updated to ${seatType}.`,
+        title: isRemoval
+          ? isDeferred
+            ? "Seat removal scheduled"
+            : "Seat removed"
+          : isDeferred
+            ? "Seat change scheduled"
+            : "Seat updated",
+        description: isRemoval
+          ? isDeferred
+            ? `${memberName}'s seat will be removed at the next billing period. They keep full access until then.`
+            : `${memberName}'s seat has been removed.`
+          : isDeferred
+            ? `${memberName}'s seat will change to ${seatType} at the next credit refresh.`
+            : isCancellingScheduledChange
+              ? `${memberName}'s scheduled seat change has been cancelled.`
+              : hasSeatPool
+                ? `${memberName}'s seat has been updated to ${seatType}. The seat pool will be provisioned shortly.`
+                : `${memberName}'s seat has been updated to ${seatType}.`,
       });
 
       await invalidateMembersUsage(workspaceId);

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -333,28 +333,14 @@ export function useUpdateMemberSeatType({
 
       const body = await res.json();
       const isDeferred = !!body?.scheduledSeatChangeAt;
-      const isRemoval = seatType === "none";
-      sendNotification({
-        type: "success",
-        title: isRemoval
-          ? isDeferred
-            ? "Seat removal scheduled"
-            : "Seat removed"
-          : isDeferred
-            ? "Seat change scheduled"
-            : "Seat updated",
-        description: isRemoval
-          ? isDeferred
-            ? `${memberName}'s seat will be removed at the next billing period. They keep full access until then.`
-            : `${memberName}'s seat has been removed.`
-          : isDeferred
-            ? `${memberName}'s seat will change to ${seatType} at the next credit refresh.`
-            : isCancellingScheduledChange
-              ? `${memberName}'s scheduled seat change has been cancelled.`
-              : hasSeatPool
-                ? `${memberName}'s seat has been updated to ${seatType}. The seat pool will be provisioned shortly.`
-                : `${memberName}'s seat has been updated to ${seatType}.`,
+      const notification = getSeatUpdateNotification({
+        seatType,
+        isDeferred,
+        isCancellingScheduledChange,
+        hasSeatPool,
+        memberName,
       });
+      sendNotification({ type: "success", ...notification });
 
       await invalidateMembersUsage(workspaceId);
       return true;
@@ -363,6 +349,39 @@ export function useUpdateMemberSeatType({
   );
 
   return { doUpdateSeatType };
+}
+
+function getSeatUpdateNotification({
+  seatType,
+  isDeferred,
+  isCancellingScheduledChange,
+  hasSeatPool,
+  memberName,
+}: {
+  seatType: MembershipSeatType;
+  isDeferred: boolean;
+  isCancellingScheduledChange: boolean;
+  hasSeatPool: boolean;
+  memberName: string;
+}): { title: string; description: string } {
+  if (seatType === "none") {
+    return {
+      title: isDeferred ? "Seat removal scheduled" : "Seat removed",
+      description: isDeferred
+        ? `${memberName}'s seat will be removed at the next billing period. They keep full access until then.`
+        : `${memberName}'s seat has been removed.`,
+    };
+  }
+  return {
+    title: isDeferred ? "Seat change scheduled" : "Seat updated",
+    description: isDeferred
+      ? `${memberName}'s seat will change to ${seatType} at the next credit refresh.`
+      : isCancellingScheduledChange
+        ? `${memberName}'s scheduled seat change has been cancelled.`
+        : hasSeatPool
+          ? `${memberName}'s seat has been updated to ${seatType}. The seat pool will be provisioned shortly.`
+          : `${memberName}'s seat has been updated to ${seatType}.`,
+  };
 }
 
 function spendLimitUrl(workspaceId: string, memberId: string): string {


### PR DESCRIPTION
## Summary
- Some overlap with https://github.com/dust-tt/dust/pull/26798
- "Remove seat" button in the usage page member table (only for members with a billable seat, not `none`-seat members)
- Confirmation dialog: member keeps full access until end of the current billing period, then loses the ability to send messages
- Defers via `updateMembershipSeatAndTrack` → `classifySeatChange` → scheduled row at next billing period start

**Two Metronome fixes for `none`:**
- `classifySeatChange`: add `newSeatType !== "none"` guard — `workspace → none` compares `0 >= 0` and incorrectly classifies as `immediate` without it
- `syncSeatCount`: skip `none`-seat members from the uncovered-subscription warning — `none` is intentionally unbilled

## Risk

Low — `none` is a new value not held by any existing member. The `classifySeatChange` fix is correctness-only for a path not yet reachable in production without the removal UI.