### PR TITLE
[Pods] Fix optimistic branch sidebar update

### DIFF
--- a/front/hooks/conversations/useBranchConversation.ts
+++ b/front/hooks/conversations/useBranchConversation.ts
@@ -87,44 +87,44 @@ export function useBranchConversation({
           return false;
         }
 
-        // Write directly into the SWR cache instead of dispatching ConversationsUpdatedEvent.
-        // ConversationsUpdatedEvent triggers an immediate refetch, but ES indexes conversations
-        // asynchronously via Temporal so the new conversation is not in ES yet at that point —
-        // the item would disappear from the sidebar. { revalidate: false } keeps the optimistic
-        // item until the next natural SWR revalidation, by which time ES has caught up.
-        const displayTitle = responseBody.parentConversationTitle
-          ? `Branched from '${responseBody.parentConversationTitle}'`
-          : "Branched conversation";
+        if (responseBody.spaceId === null) {
+          // Write directly into the SWR cache instead of dispatching ConversationsUpdatedEvent.
+          // ConversationsUpdatedEvent triggers an immediate refetch, but ES indexes conversations
+          // asynchronously via Temporal so the new conversation is not in ES yet at that point —
+          // the item would disappear from the sidebar. { revalidate: false } keeps the optimistic
+          // item until the next natural SWR revalidation, by which time ES has caught up.
+          const displayTitle = responseBody.parentConversationTitle
+            ? `Branched from '${responseBody.parentConversationTitle}'`
+            : "Branched conversation";
 
-        const nowMs = Date.now();
-        const optimisticConversationItem: ConversationListItemType = {
-          actionRequired: false,
-          created: nowMs,
-          hasError: false,
-          lastReadMs: nowMs,
-          metadata: {},
-          nextWakeupAt: null,
-          requestedSpaceIds: [],
-          sId: responseBody.conversationId,
-          // Inherited from the parent conversation — safe to return via the fork API
-          // because the caller already has access to the parent (they just branched it).
-          spaceId: responseBody.spaceId,
-          title: displayTitle,
-          triggerId: null,
-          unread: false,
-          updated: nowMs,
-          isRunningAgentLoop: false,
-        };
+          const nowMs = Date.now();
+          const optimisticConversationItem: ConversationListItemType = {
+            actionRequired: false,
+            created: nowMs,
+            hasError: false,
+            lastReadMs: nowMs,
+            metadata: {},
+            nextWakeupAt: null,
+            requestedSpaceIds: [],
+            sId: responseBody.conversationId,
+            spaceId: null,
+            title: displayTitle,
+            triggerId: null,
+            unread: false,
+            updated: nowMs,
+            isRunningAgentLoop: false,
+          };
 
-        void mutateConversations(
-          (prevConversations) => {
-            if (!prevConversations) {
-              return prevConversations;
-            }
-            return [optimisticConversationItem, ...prevConversations];
-          },
-          { revalidate: false }
-        );
+          void mutateConversations(
+            (prevConversations) => {
+              if (!prevConversations) {
+                return prevConversations;
+              }
+              return [optimisticConversationItem, ...prevConversations];
+            },
+            { revalidate: false }
+          );
+        }
 
         void onConversationBranched?.();
         await router.push(


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/8328

When a conversation is branched from inside a Pod, the fork response carries the inherited `spaceId`. The personal sidebar endpoint filters out conversations with a `space_id`, but the optimistic cache write still inserted the new branch there, so it appeared both in the sidebar and in the Pod panel until refresh.

This keeps the optimistic personal-sidebar insertion only for private branches. Pod branches still navigate to the new conversation normally and are handled by the Pod-scoped conversation lists.

## Risks
Blast radius: conversation branching in the web app sidebar and Pod conversation views.
Risk: low

## Deploy Plan
- pmrr
- deploy front