### PR TITLE
Remove invalid credits line

### DIFF
--- a/front/components/workspace/AwuUsageChart.tsx
+++ b/front/components/workspace/AwuUsageChart.tsx
@@ -53,7 +53,6 @@ type DisplayMode = "cumulative" | "daily";
 
 type ChartDataPoint = {
   timestamp: number;
-  totalCredits?: number;
   [key: string]: string | number | undefined;
 };
 
@@ -106,8 +105,7 @@ function UsageTooltip(
   props: TooltipContentProps<number, string>,
   groupBy: AwuUsageGroupByType | undefined,
   availableGroups: { groupKey: string; groupLabel: string }[],
-  displayMode: DisplayMode,
-  shouldShowTotalCredits: boolean
+  displayMode: DisplayMode
 ): JSX.Element | null {
   const { active, payload } = props;
   if (!active || !payload || payload.length === 0) {
@@ -121,11 +119,7 @@ function UsageTooltip(
 
   const rows = payload
     .filter(
-      (p) =>
-        p.dataKey !== "totalCredits" &&
-        p.value != null &&
-        typeof p.value === "number" &&
-        p.value > 0
+      (p) => p.value != null && typeof p.value === "number" && p.value > 0
     )
     .map((p) => {
       const groupKey = p.name;
@@ -148,14 +142,6 @@ function UsageTooltip(
         ),
       };
     });
-
-  if (shouldShowTotalCredits) {
-    rows.push({
-      label: "Total credits",
-      value: `${formatCredits(data.totalCredits)} credits`,
-      colorClassName: COST_PALETTE.totalCredits,
-    });
-  }
 
   if (rows.length === 0) {
     return null;
@@ -311,28 +297,6 @@ export function BaseAwuUsageChart({
     return keys;
   }, [points]);
 
-  const maxCumulatedValue = useMemo(() => {
-    return points.reduce((max, point) => {
-      return Math.max(
-        max,
-        point.groups.reduce(
-          (sum, group) => sum + (group.cumulatedValueCredits ?? 0),
-          0
-        )
-      );
-    }, 0);
-  }, [points]);
-
-  const shouldShowTotalCredits = useMemo(() => {
-    if (displayMode !== "cumulative") {
-      return false;
-    }
-    const futurePoints = points.filter((p) => p.timestamp > nowMs);
-    return !futurePoints.every(
-      (p) => p.totalInitialCredits > 4 * maxCumulatedValue
-    );
-  }, [points, maxCumulatedValue, nowMs, displayMode]);
-
   const enabledGroupKeys = groupBy ? filter[groupBy] : undefined;
 
   useEffect(() => {
@@ -442,22 +406,12 @@ export function BaseAwuUsageChart({
       };
     });
 
-    if (shouldShowTotalCredits) {
-      items.push({
-        key: "totalCredits",
-        label: "Total credits",
-        colorClassName: COST_PALETTE.totalCredits,
-        isActive: true,
-      });
-    }
-
     return items;
   }, [
     availableGroupsArray,
     allGroupKeys,
     groupBy,
     visibleGroupKeys,
-    shouldShowTotalCredits,
     enabledGroupKeys,
     handleFilterChange,
   ]);
@@ -466,7 +420,6 @@ export function BaseAwuUsageChart({
     if (displayMode === "cumulative") {
       return points.map((point) => {
         const dataPoint: ChartDataPoint = { timestamp: point.timestamp };
-        dataPoint.totalCredits = point.totalInitialCredits;
         for (const g of point.groups) {
           dataPoint[g.groupKey] = g.cumulatedValueCredits;
         }
@@ -656,13 +609,7 @@ export function BaseAwuUsageChart({
         />
         <Tooltip
           content={(props: TooltipContentProps<number, string>) =>
-            UsageTooltip(
-              props,
-              groupBy,
-              availableGroupsArray,
-              displayMode,
-              shouldShowTotalCredits
-            )
+            UsageTooltip(props, groupBy, availableGroupsArray, displayMode)
           }
           cursor={false}
           wrapperStyle={{ outline: "none" }}
@@ -721,19 +668,6 @@ export function BaseAwuUsageChart({
               />
             );
           })}
-        {shouldShowTotalCredits && (
-          <Line
-            type="monotone"
-            dataKey="totalCredits"
-            name="Total credits"
-            stroke="currentColor"
-            strokeWidth={2}
-            className={COST_PALETTE.totalCredits}
-            strokeDasharray="5 5"
-            dot={false}
-            activeDot={{ r: 5 }}
-          />
-        )}
       </ChartComponent>
     </ChartContainer>
   );

--- a/front/lib/api/analytics/awu_usage.ts
+++ b/front/lib/api/analytics/awu_usage.ts
@@ -12,12 +12,10 @@ import { getBillingCycleFromDay } from "@app/lib/client/subscription";
 import {
   ceilToMidnightUTC,
   floorToMidnightUTC,
-  listMetronomeBalances,
   listMetronomeUsage,
   listMetronomeUsageWithGroups,
 } from "@app/lib/metronome/client";
 import {
-  getCreditTypeAwuId,
   getMetricLlmProviderCostAwuId,
   getMetricToolInvocationsId,
   USAGE_TYPE_FREE,
@@ -28,8 +26,6 @@ import {
   isToolCategory,
   TOOL_CATEGORY_AWU_WEIGHTS,
 } from "@app/lib/metronome/events";
-import type { MetronomeBalance } from "@app/lib/metronome/types";
-import { isMetronomeExcessCredit } from "@app/lib/metronome/types";
 import { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
@@ -110,9 +106,6 @@ export interface AwuUsagePointGroup {
 export interface AwuUsagePoint {
   timestamp: number;
   groups: AwuUsagePointGroup[];
-  totalInitialCredits: number;
-  totalConsumedCredits: number;
-  totalRemainingCredits: number;
 }
 
 export interface AwuUsageAvailableGroup {
@@ -133,77 +126,6 @@ export type AwuUsageError =
       eventProperty: string;
     }
   | { type: "internal_error"; message: string };
-
-interface ParsedBalance {
-  initialAmountCredits: number;
-  balanceCredits: number;
-  intervals: { start: number; end: number }[];
-}
-
-// Credit totals per timestamp, expressed in whole AWU credits (no USD scaling).
-export function calculateAwuCreditTotalsFromBalances(
-  balances: MetronomeBalance[],
-  timestamps: number[]
-): Map<
-  number,
-  {
-    totalInitialCredits: number;
-    totalConsumedCredits: number;
-    totalRemainingCredits: number;
-  }
-> {
-  const parsed: ParsedBalance[] = balances.map((entry) => {
-    const items = entry.access_schedule?.schedule_items ?? [];
-    let initialAmountCredits = 0;
-    const intervals: { start: number; end: number }[] = [];
-
-    for (const item of items) {
-      initialAmountCredits += item.amount;
-      intervals.push({
-        start: new Date(item.starting_at).getTime(),
-        end: new Date(item.ending_before).getTime(),
-      });
-    }
-
-    return {
-      initialAmountCredits,
-      balanceCredits: entry.balance ?? 0,
-      intervals,
-    };
-  });
-
-  const result = new Map<
-    number,
-    {
-      totalInitialCredits: number;
-      totalConsumedCredits: number;
-      totalRemainingCredits: number;
-    }
-  >();
-
-  for (const timestamp of timestamps) {
-    let totalInitialCredits = 0;
-    let totalRemainingCredits = 0;
-
-    for (const b of parsed) {
-      const isActive = b.intervals.some(
-        (iv) => timestamp >= iv.start && timestamp < iv.end
-      );
-      if (isActive) {
-        totalInitialCredits += b.initialAmountCredits;
-        totalRemainingCredits += b.balanceCredits;
-      }
-    }
-
-    result.set(timestamp, {
-      totalInitialCredits,
-      totalConsumedCredits: totalInitialCredits - totalRemainingCredits,
-      totalRemainingCredits,
-    });
-  }
-
-  return result;
-}
 
 // LLM (cost_awu) query config per grouping. cost_awu is already AWU credits.
 function getLlmQueryConfig(groupBy: AwuUsageGroupByType): {
@@ -457,8 +379,6 @@ export async function getAwuUsage(
 
   const timestamps = getTimestampsForWindow(rangeStart, rangeEnd, windowSize);
 
-  const balancesPromise = listMetronomeBalances(metronomeCustomerId);
-
   const groupValues: Record<string, Map<number, number>> = {};
   const availableGroups: AwuUsageAvailableGroup[] = [];
 
@@ -605,26 +525,6 @@ export async function getAwuUsage(
     }
   }
 
-  const balancesResult = await balancesPromise;
-  if (balancesResult.isErr()) {
-    logger.error(
-      { error: balancesResult.error, metronomeCustomerId },
-      "[Metronome] Failed to fetch AWU balances for credit overlay"
-    );
-  }
-  const awuCreditTypeId = getCreditTypeAwuId();
-  const balances = balancesResult.isOk()
-    ? balancesResult.value.filter(
-        (entry) =>
-          entry.access_schedule?.credit_type?.id === awuCreditTypeId &&
-          !isMetronomeExcessCredit(entry)
-      )
-    : [];
-  const creditTotalsMap = calculateAwuCreditTotalsFromBalances(
-    balances,
-    timestamps
-  );
-
   const cumulatedValues: Record<string, number> = {};
   for (const key of Object.keys(groupValues)) {
     cumulatedValues[key] = 0;
@@ -663,13 +563,9 @@ export async function getAwuUsage(
       });
     }
 
-    const credit = creditTotalsMap.get(timestamp);
     return {
       timestamp,
       groups,
-      totalInitialCredits: credit?.totalInitialCredits ?? 0,
-      totalConsumedCredits: credit?.totalConsumedCredits ?? 0,
-      totalRemainingCredits: credit?.totalRemainingCredits ?? 0,
     };
   });
 


### PR DESCRIPTION
## Description

Removes the dashed "Total credits" line from the AWU usage graph (`AwuUsageChart`). The line plotted the total initial AWU credit allotment over the billing period, but it cannot be displayed properly (the credit allotment dwarfs actual usage, flattening the usage series), so it adds no value.

The removal is end-to-end — both the chart rendering and the data that fed it:

**`front/components/workspace/AwuUsageChart.tsx`**
- Drop `totalCredits` from `ChartDataPoint`.
- Remove the `shouldShowTotalCredits` parameter from `UsageTooltip`, the `dataKey !== "totalCredits"` filter, and the "Total credits" tooltip row.
- Remove the `maxCumulatedValue` and `shouldShowTotalCredits` memos.
- Remove the "Total credits" legend item and the dashed `<Line dataKey="totalCredits" />`.

**`front/lib/api/analytics/awu_usage.ts`**
- Drop `totalInitialCredits` / `totalConsumedCredits` / `totalRemainingCredits` from `AwuUsagePoint`.
- Remove the `ParsedBalance` interface and `calculateAwuCreditTotalsFromBalances`.
- Remove the balances fetch, AWU credit-type filtering, and per-timestamp credit map in `getAwuUsage`, plus the now-unused imports (`listMetronomeBalances`, `getCreditTypeAwuId`, `MetronomeBalance`, `isMetronomeExcessCredit`).

The equivalent credit line in `ProgrammaticCostChart` is intentionally left in place.

## Tests

No automated tests cover this chart. Verified via type-check (`tsgo --noEmit`, no new errors in the touched files) and Biome lint/format (clean).

## Risk

Low. This only removes a display series and the read-only data that backed it; no write paths, schemas, or other charts are affected. The endpoint response shape loses three fields on `AwuUsagePoint`, but they have no other consumers. Safe to roll back by reverting the commit.

## Deploy Plan

Standard deploy. No migrations or coordinated client/server changes required.
