### PR TITLE
[dsbx] Skip secret substitution in reflection-prone headers

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.25"
+version = "0.1.26"
 edition = "2021"
 
 [[bin]]

--- a/cli/dust-sandbox/src/commands/forward/http_rewriter.rs
+++ b/cli/dust-sandbox/src/commands/forward/http_rewriter.rs
@@ -1312,6 +1312,146 @@ mod tests {
         Ok(())
     }
 
+    // Regression for the reflection exfil: a recognized placeholder in an
+    // unsafe (non-credential, reflection-prone) header must be left intact, so
+    // the real secret never reaches a reflecting endpoint like
+    // `/cdn-cgi/trace` (which echoes `User-Agent`).
+    async fn assert_skips_unsafe_header(header_line: &str, header_echo: &str) -> Result<()> {
+        let placeholder = "__DSEC_0123456789abcdef0123456789abcdef__";
+        let table = secret_table_with_secret(
+            "OPENAI_API_KEY",
+            placeholder,
+            "sk-real",
+            &["api.openai.com"],
+        )?;
+        let input = format!("GET / HTTP/1.1\r\nHost: api.openai.com\r\n{header_line}\r\n\r\n");
+
+        let output = rewrite_once(
+            input.as_bytes(),
+            &table,
+            HttpRewriteMode::Tls {
+                sni: "api.openai.com",
+            },
+        )
+        .await?;
+        let text = String::from_utf8(output)?;
+
+        assert!(
+            text.contains(&format!("{header_echo}\r\n")),
+            "placeholder must be left intact in unsafe header, got: {text}"
+        );
+        assert!(
+            !text.contains("sk-real"),
+            "real secret must not be substituted into unsafe header, got: {text}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn skips_substitution_in_user_agent_header() -> Result<()> {
+        let placeholder = "__DSEC_0123456789abcdef0123456789abcdef__";
+        assert_skips_unsafe_header(
+            &format!("User-Agent: {placeholder}"),
+            &format!("User-Agent: {placeholder}"),
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn skips_substitution_in_origin_header() -> Result<()> {
+        let placeholder = "__DSEC_0123456789abcdef0123456789abcdef__";
+        assert_skips_unsafe_header(
+            &format!("Origin: {placeholder}"),
+            &format!("Origin: {placeholder}"),
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn skips_substitution_in_request_id_header() -> Result<()> {
+        let placeholder = "__DSEC_0123456789abcdef0123456789abcdef__";
+        assert_skips_unsafe_header(
+            &format!("X-Request-Id: {placeholder}"),
+            &format!("X-Request-Id: {placeholder}"),
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn skips_substitution_in_extended_accept_header() -> Result<()> {
+        let placeholder = "__DSEC_0123456789abcdef0123456789abcdef__";
+        assert_skips_unsafe_header(
+            &format!("Accept: {placeholder}"),
+            &format!("Accept: {placeholder}"),
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn skips_substitution_in_sec_ch_ua_prefix_header() -> Result<()> {
+        let placeholder = "__DSEC_0123456789abcdef0123456789abcdef__";
+        assert_skips_unsafe_header(
+            &format!("Sec-CH-UA-Platform: {placeholder}"),
+            &format!("Sec-CH-UA-Platform: {placeholder}"),
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn substitutes_in_non_blocklisted_cookie_header() -> Result<()> {
+        // Cookie carries session credentials and is deliberately NOT
+        // blocklisted: substitution must still fire.
+        let placeholder = "__DSEC_0123456789abcdef0123456789abcdef__";
+        let table =
+            secret_table_with_secret("SESSION", placeholder, "sk-real", &["api.openai.com"])?;
+        let input = format!(
+            "GET / HTTP/1.1\r\nHost: api.openai.com\r\nCookie: session={placeholder}\r\n\r\n"
+        );
+
+        let output = rewrite_once(
+            input.as_bytes(),
+            &table,
+            HttpRewriteMode::Tls {
+                sni: "api.openai.com",
+            },
+        )
+        .await?;
+        let text = String::from_utf8(output)?;
+
+        assert!(text.contains("Cookie: session=sk-real\r\n"));
+        assert!(!text.contains(placeholder));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn substitutes_in_non_blocklisted_custom_header() -> Result<()> {
+        // No default-deny: a bespoke auth header still substitutes.
+        let placeholder = "__DSEC_0123456789abcdef0123456789abcdef__";
+        let table = secret_table_with_secret(
+            "OPENAI_API_KEY",
+            placeholder,
+            "sk-real",
+            &["api.openai.com"],
+        )?;
+        let input = format!(
+            "GET / HTTP/1.1\r\nHost: api.openai.com\r\nX-Acme-Token: {placeholder}\r\n\r\n"
+        );
+
+        let output = rewrite_once(
+            input.as_bytes(),
+            &table,
+            HttpRewriteMode::Tls {
+                sni: "api.openai.com",
+            },
+        )
+        .await?;
+        let text = String::from_utf8(output)?;
+
+        assert!(text.contains("X-Acme-Token: sk-real\r\n"));
+        assert!(!text.contains(placeholder));
+        Ok(())
+    }
+
     #[tokio::test]
     async fn denies_unknown_placeholder_in_header_value() -> Result<()> {
         let table = secret_table_with_secret(

--- a/cli/dust-sandbox/src/commands/forward/http_rewriter.rs
+++ b/cli/dust-sandbox/src/commands/forward/http_rewriter.rs
@@ -903,6 +903,8 @@ mod tests {
     use super::super::test_support::{empty_table, secret_table_with_secret};
     use super::*;
 
+    const TEST_PLACEHOLDER: &str = "__DSEC_0123456789abcdef0123456789abcdef__";
+
     #[tokio::test]
     async fn forwards_get_request_unchanged() -> Result<()> {
         let table = empty_table()?;
@@ -1231,7 +1233,7 @@ mod tests {
 
     #[tokio::test]
     async fn substitutes_placeholder_in_header_value() -> Result<()> {
-        let placeholder = "__DSEC_0123456789abcdef0123456789abcdef__";
+        let placeholder = TEST_PLACEHOLDER;
         let table = secret_table_with_secret(
             "OPENAI_API_KEY",
             placeholder,
@@ -1315,12 +1317,13 @@ mod tests {
     // Regression for the reflection exfil: a recognized placeholder in an
     // unsafe (non-credential, reflection-prone) header must be left intact, so
     // the real secret never reaches a reflecting endpoint like
-    // `/cdn-cgi/trace` (which echoes `User-Agent`).
-    async fn assert_skips_unsafe_header(header_line: &str, header_echo: &str) -> Result<()> {
-        let placeholder = "__DSEC_0123456789abcdef0123456789abcdef__";
+    // `/cdn-cgi/trace` (which echoes `User-Agent`). The header line is echoed
+    // back verbatim with the placeholder unsubstituted, and the real value
+    // never appears on the wire.
+    async fn assert_skips_unsafe_header(header_line: &str) -> Result<()> {
         let table = secret_table_with_secret(
             "OPENAI_API_KEY",
-            placeholder,
+            TEST_PLACEHOLDER,
             "sk-real",
             &["api.openai.com"],
         )?;
@@ -1337,7 +1340,7 @@ mod tests {
         let text = String::from_utf8(output)?;
 
         assert!(
-            text.contains(&format!("{header_echo}\r\n")),
+            text.contains(&format!("{header_line}\r\n")),
             "placeholder must be left intact in unsafe header, got: {text}"
         );
         assert!(
@@ -1349,59 +1352,34 @@ mod tests {
 
     #[tokio::test]
     async fn skips_substitution_in_user_agent_header() -> Result<()> {
-        let placeholder = "__DSEC_0123456789abcdef0123456789abcdef__";
-        assert_skips_unsafe_header(
-            &format!("User-Agent: {placeholder}"),
-            &format!("User-Agent: {placeholder}"),
-        )
-        .await
+        assert_skips_unsafe_header(&format!("User-Agent: {TEST_PLACEHOLDER}")).await
     }
 
     #[tokio::test]
     async fn skips_substitution_in_origin_header() -> Result<()> {
-        let placeholder = "__DSEC_0123456789abcdef0123456789abcdef__";
-        assert_skips_unsafe_header(
-            &format!("Origin: {placeholder}"),
-            &format!("Origin: {placeholder}"),
-        )
-        .await
+        assert_skips_unsafe_header(&format!("Origin: {TEST_PLACEHOLDER}")).await
     }
 
     #[tokio::test]
     async fn skips_substitution_in_request_id_header() -> Result<()> {
-        let placeholder = "__DSEC_0123456789abcdef0123456789abcdef__";
-        assert_skips_unsafe_header(
-            &format!("X-Request-Id: {placeholder}"),
-            &format!("X-Request-Id: {placeholder}"),
-        )
-        .await
+        assert_skips_unsafe_header(&format!("X-Request-Id: {TEST_PLACEHOLDER}")).await
     }
 
     #[tokio::test]
-    async fn skips_substitution_in_extended_accept_header() -> Result<()> {
-        let placeholder = "__DSEC_0123456789abcdef0123456789abcdef__";
-        assert_skips_unsafe_header(
-            &format!("Accept: {placeholder}"),
-            &format!("Accept: {placeholder}"),
-        )
-        .await
+    async fn skips_substitution_in_accept_header() -> Result<()> {
+        assert_skips_unsafe_header(&format!("Accept: {TEST_PLACEHOLDER}")).await
     }
 
     #[tokio::test]
     async fn skips_substitution_in_sec_ch_ua_prefix_header() -> Result<()> {
-        let placeholder = "__DSEC_0123456789abcdef0123456789abcdef__";
-        assert_skips_unsafe_header(
-            &format!("Sec-CH-UA-Platform: {placeholder}"),
-            &format!("Sec-CH-UA-Platform: {placeholder}"),
-        )
-        .await
+        assert_skips_unsafe_header(&format!("Sec-CH-UA-Platform: {TEST_PLACEHOLDER}")).await
     }
 
     #[tokio::test]
     async fn substitutes_in_non_blocklisted_cookie_header() -> Result<()> {
         // Cookie carries session credentials and is deliberately NOT
         // blocklisted: substitution must still fire.
-        let placeholder = "__DSEC_0123456789abcdef0123456789abcdef__";
+        let placeholder = TEST_PLACEHOLDER;
         let table =
             secret_table_with_secret("SESSION", placeholder, "sk-real", &["api.openai.com"])?;
         let input = format!(
@@ -1426,7 +1404,7 @@ mod tests {
     #[tokio::test]
     async fn substitutes_in_non_blocklisted_custom_header() -> Result<()> {
         // No default-deny: a bespoke auth header still substitutes.
-        let placeholder = "__DSEC_0123456789abcdef0123456789abcdef__";
+        let placeholder = TEST_PLACEHOLDER;
         let table = secret_table_with_secret(
             "OPENAI_API_KEY",
             placeholder,

--- a/cli/dust-sandbox/src/commands/forward/rewrite_policy.rs
+++ b/cli/dust-sandbox/src/commands/forward/rewrite_policy.rs
@@ -235,6 +235,13 @@ fn rewrite_header_value(
     // (it reveals nothing) rather than substituting or dropping the
     // connection. Checked after the port-80 guard so plaintext HTTP keeps its
     // stricter drop-on-placeholder behavior.
+    //
+    // Note this short-circuits before the substitution path, so it also
+    // suppresses that path's unknown-placeholder and non-allowed-host denies
+    // for these headers: a forged or cross-host placeholder in a blocklisted
+    // header now travels upstream as the opaque placeholder instead of
+    // dropping the connection. Acceptable because the placeholder reveals
+    // nothing and any real credential check fails loudly upstream.
     if is_unsafe_substitution_header(&header.name) {
         if contains_placeholder(&header.value) {
             debug!(
@@ -272,11 +279,13 @@ fn is_unsafe_substitution_header(name: &str) -> bool {
     let lower = name.to_ascii_lowercase();
 
     // Prefix families: UA client hints (`Sec-CH-UA`, `Sec-CH-UA-Platform`,
-    // ...), fetch metadata (`Sec-Fetch-Site`, ...), and B3 trace headers
-    // (`X-B3-TraceId`, `X-B3-SpanId`, ...).
+    // ...), fetch metadata (`Sec-Fetch-Site`, ...), B3 trace headers
+    // (`X-B3-TraceId`, `X-B3-SpanId`, ...), and Datadog trace headers
+    // (`X-Datadog-Trace-Id`, `X-Datadog-Parent-Id`, ...).
     if lower.starts_with("sec-ch-ua")
         || lower.starts_with("sec-fetch-")
         || lower.starts_with("x-b3-")
+        || lower.starts_with("x-datadog-")
     {
         return true;
     }
@@ -303,6 +312,7 @@ fn is_unsafe_substitution_header(name: &str) -> bool {
             | "traceparent"
             | "tracestate"
             | "x-amzn-trace-id"
+            | "x-cloud-trace-context"
             | "uber-trace-id"
             | "b3"
             // Privacy / preference signals — never credentials, UA-like reflection.
@@ -530,4 +540,101 @@ fn validate_host_headers_match(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_unsafe_substitution_header;
+
+    // Locks down the full blocklist membership: this set is the security
+    // surface of the reflection-skip, so a fat-fingered edit that drops a
+    // header should fail here rather than silently start leaking it.
+    #[test]
+    fn unsafe_header_blocklist_membership() {
+        let unsafe_headers = [
+            // Identity / referrer.
+            "user-agent",
+            "referer",
+            "origin",
+            "from",
+            // Forwarding / proxy metadata.
+            "x-forwarded-for",
+            "x-forwarded-host",
+            "x-forwarded-proto",
+            "x-forwarded-port",
+            "forwarded",
+            "x-real-ip",
+            "via",
+            // Request-id / trace context.
+            "x-request-id",
+            "x-correlation-id",
+            "request-id",
+            "traceparent",
+            "tracestate",
+            "x-amzn-trace-id",
+            "x-cloud-trace-context",
+            "uber-trace-id",
+            "b3",
+            // Privacy / preference signals.
+            "dnt",
+            "sec-gpc",
+            // Content negotiation (extended).
+            "accept",
+            "accept-encoding",
+            "accept-language",
+            "accept-charset",
+            // Caching / conditional (extended).
+            "cache-control",
+            "pragma",
+            "if-match",
+            "if-none-match",
+            "if-modified-since",
+            "if-unmodified-since",
+            "if-range",
+            "range",
+            // Prefix families.
+            "sec-ch-ua",
+            "sec-ch-ua-platform",
+            "sec-fetch-site",
+            "sec-fetch-mode",
+            "x-b3-traceid",
+            "x-b3-spanid",
+            "x-datadog-trace-id",
+            "x-datadog-parent-id",
+        ];
+
+        for header in unsafe_headers {
+            assert!(
+                is_unsafe_substitution_header(header),
+                "expected {header} to be blocklisted"
+            );
+        }
+    }
+
+    #[test]
+    fn credential_and_custom_headers_are_not_blocklisted() {
+        for header in [
+            "authorization",
+            "cookie",
+            "proxy-authorization",
+            "x-api-key",
+            "x-auth-token",
+            "x-acme-token",
+            "content-type",
+        ] {
+            assert!(
+                !is_unsafe_substitution_header(header),
+                "expected {header} to still substitute"
+            );
+        }
+    }
+
+    #[test]
+    fn blocklist_match_is_case_insensitive() {
+        assert!(is_unsafe_substitution_header("User-Agent"));
+        assert!(is_unsafe_substitution_header("USER-AGENT"));
+        assert!(is_unsafe_substitution_header("Sec-CH-UA"));
+        assert!(is_unsafe_substitution_header("X-Datadog-Trace-Id"));
+        assert!(!is_unsafe_substitution_header("Authorization"));
+    }
 }

--- a/cli/dust-sandbox/src/commands/forward/rewrite_policy.rs
+++ b/cli/dust-sandbox/src/commands/forward/rewrite_policy.rs
@@ -1,4 +1,5 @@
 use base64::{engine::general_purpose, Engine as _};
+use tracing::debug;
 
 use crate::egress_secrets::{
     Secret, SecretTable, PLACEHOLDER_HEX_LEN, PLACEHOLDER_PREFIX as PLACEHOLDER_PREFIX_STR,
@@ -226,6 +227,25 @@ fn rewrite_header_value(
         ));
     }
 
+    // Never release a real secret into a non-credential header that tends to
+    // be reflected back in responses (CORS `Origin`, request-id/trace echo,
+    // `/cdn-cgi/trace`'s `uag=`) or written to logs and forwarded downstream.
+    // Substituting here would let the agent read the secret back or leak it,
+    // defeating the placeholder model. Leave the opaque placeholder in place
+    // (it reveals nothing) rather than substituting or dropping the
+    // connection. Checked after the port-80 guard so plaintext HTTP keeps its
+    // stricter drop-on-placeholder behavior.
+    if is_unsafe_substitution_header(&header.name) {
+        if contains_placeholder(&header.value) {
+            debug!(
+                header = %header.name,
+                host = %host,
+                "skipping secret substitution in unsafe header; placeholder left in place"
+            );
+        }
+        return Ok(header.value.clone());
+    }
+
     if header.name.eq_ignore_ascii_case("authorization") {
         if let Some(value) = rewrite_basic_auth(&header.value, host, secret_table, mode)? {
             return Ok(value);
@@ -236,6 +256,73 @@ fn rewrite_header_value(
         Some(rewritten) => Ok(rewritten),
         None => Ok(header.value.clone()),
     }
+}
+
+// Request headers we never substitute secrets into. These are not credential
+// carriers and are routinely reflected back to the client (CORS `Origin`,
+// request-id/trace echo, `/cdn-cgi/trace`'s `uag=`) or written to logs and
+// forwarded downstream, so a real secret placed here would round-trip back to
+// the agent or leak out of band.
+//
+// This is a blocklist by design, not a credential allowlist: standard auth
+// headers (`Authorization`, `Cookie`, `Proxy-Authorization`) and any bespoke
+// custom header (`X-Api-Key`, `X-Acme-Token`, ...) still substitute, so
+// callers using non-standard auth header names are unaffected.
+fn is_unsafe_substitution_header(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+
+    // Prefix families: UA client hints (`Sec-CH-UA`, `Sec-CH-UA-Platform`,
+    // ...), fetch metadata (`Sec-Fetch-Site`, ...), and B3 trace headers
+    // (`X-B3-TraceId`, `X-B3-SpanId`, ...).
+    if lower.starts_with("sec-ch-ua")
+        || lower.starts_with("sec-fetch-")
+        || lower.starts_with("x-b3-")
+    {
+        return true;
+    }
+
+    matches!(
+        lower.as_str(),
+        // Identity / referrer — reflected by echo endpoints and analytics, logged.
+        "user-agent"
+            | "referer"
+            | "origin"
+            | "from"
+            // Forwarding / proxy metadata — logged and echoed by debug endpoints.
+            | "x-forwarded-for"
+            | "x-forwarded-host"
+            | "x-forwarded-proto"
+            | "x-forwarded-port"
+            | "forwarded"
+            | "x-real-ip"
+            | "via"
+            // Request-id / trace context — echoed into response headers by convention.
+            | "x-request-id"
+            | "x-correlation-id"
+            | "request-id"
+            | "traceparent"
+            | "tracestate"
+            | "x-amzn-trace-id"
+            | "uber-trace-id"
+            | "b3"
+            // Privacy / preference signals — never credentials, UA-like reflection.
+            | "dnt"
+            | "sec-gpc"
+            // Content negotiation (extended) — never credentials.
+            | "accept"
+            | "accept-encoding"
+            | "accept-language"
+            | "accept-charset"
+            // Caching / conditional (extended) — never credentials.
+            | "cache-control"
+            | "pragma"
+            | "if-match"
+            | "if-none-match"
+            | "if-modified-since"
+            | "if-unmodified-since"
+            | "if-range"
+            | "range"
+    )
 }
 
 fn rewrite_basic_auth(

--- a/cli/dust-sandbox/src/commands/forward/rewrite_policy.rs
+++ b/cli/dust-sandbox/src/commands/forward/rewrite_policy.rs
@@ -302,8 +302,11 @@ fn is_unsafe_substitution_header(name: &str) -> bool {
             | "x-forwarded-host"
             | "x-forwarded-proto"
             | "x-forwarded-port"
+            | "x-forwarded-server"
             | "forwarded"
             | "x-real-ip"
+            | "true-client-ip"
+            | "cf-connecting-ip"
             | "via"
             // Request-id / trace context — echoed into response headers by convention.
             | "x-request-id"
@@ -311,9 +314,11 @@ fn is_unsafe_substitution_header(name: &str) -> bool {
             | "request-id"
             | "traceparent"
             | "tracestate"
+            | "baggage"
             | "x-amzn-trace-id"
             | "x-cloud-trace-context"
             | "uber-trace-id"
+            | "grpc-trace-bin"
             | "b3"
             // Privacy / preference signals — never credentials, UA-like reflection.
             | "dnt"
@@ -562,8 +567,11 @@ mod tests {
             "x-forwarded-host",
             "x-forwarded-proto",
             "x-forwarded-port",
+            "x-forwarded-server",
             "forwarded",
             "x-real-ip",
+            "true-client-ip",
+            "cf-connecting-ip",
             "via",
             // Request-id / trace context.
             "x-request-id",
@@ -571,9 +579,11 @@ mod tests {
             "request-id",
             "traceparent",
             "tracestate",
+            "baggage",
             "x-amzn-trace-id",
             "x-cloud-trace-context",
             "uber-trace-id",
+            "grpc-trace-bin",
             "b3",
             // Privacy / preference signals.
             "dnt",

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -96,7 +96,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base image tag", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.35",
+      tag: "0.8.36",
     });
   });
 
@@ -341,7 +341,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.25/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.26/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -19,8 +19,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.35";
-const DSBX_CLI_VERSION = "0.1.25";
+const DUST_BASE_IMAGE_VERSION = "0.8.36";
+const DSBX_CLI_VERSION = "0.1.26";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_UNTRUSTED_UIDS as a set; reordering that
 // list must not silently change this user's UID.


### PR DESCRIPTION
## Description

HTTPS-secret substitution swapped a DSEC placeholder for the real secret wherever it appeared in a request header, including non-credential headers like `User-Agent`. Endpoints that echo those headers back in the response (Cloudflare's `/cdn-cgi/trace` reflects `User-Agent` as `uag=`; CORS reflects `Origin`; proxies echo `X-Request-Id` / trace headers) let an agent read the plaintext secret back out, defeating the point of the placeholder.

dsbx now skips substitution for a curated blocklist of headers that are never credentials and are routinely reflected or logged (User-Agent, Referer, Origin, From, forwarding/client-IP headers, request-id/trace headers incl. GCP/Datadog/OTel, client hints, plus content-negotiation and caching/conditional headers). The opaque placeholder is left in place instead of dropping the connection. `Authorization`, `Cookie`, and any custom header still substitute, so bespoke auth header names keep working (blocklist, not default-deny).

Single choke point in `rewrite_header_value`, so it covers both HTTP/1.1 and HTTP/2.

Found via internal audit, no external report.

## Tests

Added rewriter tests: placeholder left intact for `User-Agent`, `Origin`, `X-Request-Id`, `Accept`, and the `Sec-CH-UA-*` prefix family; still substituted for `Cookie` and a custom `X-Acme-Token` header. Added membership unit tests pinning the full blocklist (and its credential/custom negatives) so a dropped header fails CI instead of silently leaking.

## Risk

Low. Behavior change is scoped to placeholder-bearing requests on the MITM path. No secret is configured to inject into a blocklisted header (those are not credential slots); such a call would now send the placeholder and fail upstream loudly rather than leaking.

> [!NOTE]
> The blocklist short-circuits before the substitution path, so it also suppresses that path's unknown-placeholder / non-allowed-host **deny** for these headers: a forged or cross-host placeholder in a blocklisted header now travels upstream as the opaque placeholder instead of dropping the connection. Acceptable, the placeholder reveals nothing and any real credential check fails loudly upstream.

This is request-side hardening. It does not redact secrets from responses, so an all-header echo service (httpbin-style) on an allowlisted domain could still reflect a credential header. That is handled at the domain-allowlist level; full response-side redaction is the eventual complete fix and is out of scope here.

## Deploy Plan

The fix ships in the dsbx binary, which is baked into the sandbox base image, so it needs a dsbx release plus an image rebuild. Versions are already bumped in this PR (dsbx `0.1.25` -> `0.1.26`, base image `0.8.35` -> `0.8.36`, `DSBX_CLI_VERSION` pin updated).

Ordering matters. The image build (`sandbox-img-registry.yml`) runs `curl -f .../dsbx-v0.1.26/dsbx-linux-x86_64`, and it runs automatically during a `front` deploy. If the `dsbx-v0.1.26` release does not exist yet, that curl 404s and the image build (and the deploy) fails. `release-dsbx-cli.yml` is manual dispatch only and is not triggered by merge.

So, after merge and before deploying `front`:
1. Run `Release dsbx CLI` (`release-dsbx-cli.yml`, manual dispatch). Publishes the `dsbx-v0.1.26` release (linux binary + `checksums-sha256.txt`). Confirm the release exists.
2. Run `Sandbox Image Registry` (`sandbox-img-registry.yml`, manual dispatch) for eu + us, or let the `front` deploy trigger it. Rebuilds the base image, which pulls `dsbx-v0.1.26` and tags `dust-base:0.8.36`.
3. Deploy `front` as usual; it picks up the new `DSBX_CLI_VERSION` / base image tag.

Rollback: revert the version bumps. dsbx falls back to `0.1.25` and `dust-base:0.8.35`, both already published.