### PR TITLE
Fix user credit state

### DIFF
--- a/front/lib/api/metronome/credit_state_dispatcher.test.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.test.ts
@@ -49,7 +49,8 @@ describe("credit_state_dispatcher per-user caps", () => {
     });
 
     expect(transitionUserCreditState).toHaveBeenCalledWith(
-      expect.objectContaining({ seatType: "pro", creditState: "on_pool" }),
+      // createMembership seeds pro/max seats at user_seat (their initial state).
+      expect.objectContaining({ seatType: "pro", creditState: "user_seat" }),
       { type: "per_user_cap_reached" },
       { workspaceId: workspaceType.sId, userId: user.sId }
     );
@@ -76,7 +77,8 @@ describe("credit_state_dispatcher per-user caps", () => {
     });
 
     expect(transitionUserCreditState).toHaveBeenCalledWith(
-      expect.objectContaining({ seatType: "max", creditState: "on_pool" }),
+      // createMembership seeds pro/max seats at user_seat (their initial state).
+      expect.objectContaining({ seatType: "max", creditState: "user_seat" }),
       { type: "per_user_cap_resolved" },
       { workspaceId: workspaceType.sId, userId: user.sId }
     );

--- a/front/lib/api/metronome/reconcile_credit_state.test.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.test.ts
@@ -1,0 +1,166 @@
+import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { reconcileWorkspaceUserCreditStates } from "./reconcile_credit_state";
+
+const {
+  mockListMetronomeSeatBalances,
+  mockFetchPerUserAwuUsage,
+  mockGetCachedPerUserCapThresholds,
+  mockGetCachedDefaultCapThresholdsBySeatType,
+} = vi.hoisted(() => ({
+  mockListMetronomeSeatBalances: vi.fn(),
+  mockFetchPerUserAwuUsage: vi.fn(),
+  mockGetCachedPerUserCapThresholds: vi.fn(),
+  mockGetCachedDefaultCapThresholdsBySeatType: vi.fn(),
+}));
+
+vi.mock("@app/lib/metronome/client", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/client")
+  >("@app/lib/metronome/client");
+  return {
+    ...actual,
+    listMetronomeSeatBalances: mockListMetronomeSeatBalances,
+  };
+});
+
+vi.mock("@app/lib/metronome/per_user_usage", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/per_user_usage")
+  >("@app/lib/metronome/per_user_usage");
+  return { ...actual, fetchPerUserAwuUsage: mockFetchPerUserAwuUsage };
+});
+
+vi.mock("@app/lib/metronome/alerts/spend_limits", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/alerts/spend_limits")
+  >("@app/lib/metronome/alerts/spend_limits");
+  return {
+    ...actual,
+    getCachedPerUserCapThresholds: mockGetCachedPerUserCapThresholds,
+    getCachedDefaultCapThresholdsBySeatType:
+      mockGetCachedDefaultCapThresholdsBySeatType,
+  };
+});
+
+const METRONOME_CUSTOMER_ID = "cust_test_reconcile";
+const METRONOME_CONTRACT_ID = "ct_test_reconcile";
+
+function seatBalance(userId: string, balance: number, starting: number) {
+  return {
+    seat_id: userId,
+    balances: [
+      {
+        credit_type_id: getCreditTypeAwuId(),
+        balance,
+        starting_balance: starting,
+      },
+    ],
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFetchPerUserAwuUsage.mockResolvedValue(new Ok(new Map<string, number>()));
+  mockGetCachedPerUserCapThresholds.mockResolvedValue({});
+  mockGetCachedDefaultCapThresholdsBySeatType.mockResolvedValue({});
+});
+
+describe("reconcileWorkspaceUserCreditStates", () => {
+  it("moves a stale on_pool pro user with personal balance back to user_seat", async () => {
+    const workspace = await WorkspaceFactory.metronome({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+    });
+    const user = await UserFactory.basic();
+    const membership = await MembershipFactory.associate(workspace, user, {
+      role: "user",
+      seatType: "pro",
+    });
+    // Simulate the stale state the bug leaves users in.
+    await membership.updateCreditState("on_pool");
+
+    mockListMetronomeSeatBalances.mockResolvedValue(
+      new Ok([seatBalance(user.sId, 8000, 8000)])
+    );
+
+    await reconcileWorkspaceUserCreditStates({
+      workspace: renderLightWorkspaceType({ workspace }),
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+      metronomeContractId: METRONOME_CONTRACT_ID,
+    });
+
+    const refreshed =
+      await MembershipResource.getActiveMembershipOfUserInWorkspace({
+        user,
+        workspace: renderLightWorkspaceType({ workspace }),
+      });
+    expect(refreshed?.creditState).toBe("user_seat");
+  });
+
+  it("moves a pro user whose personal balance is exhausted to on_pool", async () => {
+    const workspace = await WorkspaceFactory.metronome({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+    });
+    const user = await UserFactory.basic();
+    const membership = await MembershipFactory.associate(workspace, user, {
+      role: "user",
+      seatType: "pro",
+    });
+    // Factory seeds pro at user_seat; the exhausted balance should flip it.
+    expect(membership.creditState).toBe("user_seat");
+
+    mockListMetronomeSeatBalances.mockResolvedValue(
+      new Ok([seatBalance(user.sId, 0, 8000)])
+    );
+
+    await reconcileWorkspaceUserCreditStates({
+      workspace: renderLightWorkspaceType({ workspace }),
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+      metronomeContractId: METRONOME_CONTRACT_ID,
+    });
+
+    const refreshed =
+      await MembershipResource.getActiveMembershipOfUserInWorkspace({
+        user,
+        workspace: renderLightWorkspaceType({ workspace }),
+      });
+    expect(refreshed?.creditState).toBe("on_pool");
+  });
+
+  it("leaves a workspace (pool-based) user on_pool and reads balances/usage only once", async () => {
+    const workspace = await WorkspaceFactory.metronome({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+    });
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, {
+      role: "user",
+      seatType: "workspace",
+    });
+
+    // Workspace seats have no individual seat allocation.
+    mockListMetronomeSeatBalances.mockResolvedValue(new Ok([]));
+
+    await reconcileWorkspaceUserCreditStates({
+      workspace: renderLightWorkspaceType({ workspace }),
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+      metronomeContractId: METRONOME_CONTRACT_ID,
+    });
+
+    const refreshed =
+      await MembershipResource.getActiveMembershipOfUserInWorkspace({
+        user,
+        workspace: renderLightWorkspaceType({ workspace }),
+      });
+    expect(refreshed?.creditState).toBe("on_pool");
+    // Shared inputs fetched once for the whole workspace, not per user.
+    expect(mockListMetronomeSeatBalances).toHaveBeenCalledTimes(1);
+    expect(mockFetchPerUserAwuUsage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/front/lib/api/metronome/reconcile_credit_state.test.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.test.ts
@@ -53,14 +53,14 @@ vi.mock("@app/lib/metronome/alerts/spend_limits", async () => {
 const METRONOME_CUSTOMER_ID = "cust_test_reconcile";
 const METRONOME_CONTRACT_ID = "ct_test_reconcile";
 
-function seatBalance(userId: string, balance: number, starting: number) {
+function seatBalance(userId: string, balanceAwu: number, startingAwu: number) {
   return {
     seat_id: userId,
     balances: [
       {
         credit_type_id: getCreditTypeAwuId(),
-        balance,
-        starting_balance: starting,
+        balance: balanceAwu,
+        starting_balance: startingAwu,
       },
     ],
   };

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -1,39 +1,50 @@
-import {
-  dispatchPerUserCapReached,
-  dispatchPerUserCapResolved,
-  getWorkspacePoolAwuBalance,
-  syncPoolCreditStateFromBalance,
-} from "@app/lib/api/metronome/credit_state_dispatcher";
+import { getWorkspacePoolAwuBalance } from "@app/lib/api/metronome/credit_state_dispatcher";
 import type { Authenticator } from "@app/lib/auth";
 import { isPAYGEnabled } from "@app/lib/credits/credit_payg";
+import { getMetronomeProgrammaticCapAlertStates } from "@app/lib/metronome/alerts/programmatic_cap";
+import type { MetronomeCapAlertInfo } from "@app/lib/metronome/alerts/spend_limits";
 import {
-  CRITICAL_BALANCE_OFFSET,
-  getMetronomeProgrammaticCapAlertStates,
-  LOW_BALANCE_OFFSET,
-} from "@app/lib/metronome/alerts/programmatic_cap";
-import {
+  getCachedDefaultCapThresholdsBySeatType,
+  getCachedPerUserCapThresholds,
   getMetronomeDefaultUserCapAlertForSeatType,
   getMetronomePerUserCap,
 } from "@app/lib/metronome/alerts/spend_limits";
+import { listMetronomeSeatBalances } from "@app/lib/metronome/client";
+import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
 import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
 import {
   expectedProgrammaticCreditStateFromAlerts,
-  transitionProgrammaticCreditState,
+  setProgrammaticCreditStateReconciled,
 } from "@app/lib/metronome/programmatic_credit_state_machine";
-import { expectedPoolCreditStateFromBalance } from "@app/lib/metronome/workspace_credit_state_machine";
+import type { MetronomeSeatBalance } from "@app/lib/metronome/types";
+import { setUserCreditStateReconciled } from "@app/lib/metronome/user_credit_state_machine";
+import {
+  expectedPoolCreditStateFromBalance,
+  setWorkspacePoolCreditStateReconciled,
+} from "@app/lib/metronome/workspace_credit_state_machine";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
+import logger from "@app/logger/logger";
 import type {
   WorkspacePoolCreditState,
   WorkspaceProgrammaticCreditState,
 } from "@app/types/credits";
-import type { UserCreditState } from "@app/types/memberships";
-import { normalizeToPoolLimitSeatType } from "@app/types/memberships";
+import type {
+  MembershipSeatType,
+  NormalizedPoolLimitSeatType,
+  UserCreditState,
+} from "@app/types/memberships";
+import {
+  expectedUserCreditState,
+  normalizeToPoolLimitSeatType,
+} from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { LightWorkspaceType } from "@app/types/user";
 
 export const RECONCILE_CREDIT_STATE_TARGETS = [
   "pool",
@@ -43,8 +54,6 @@ export const RECONCILE_CREDIT_STATE_TARGETS = [
 
 export type ReconcileCreditStateTarget =
   (typeof RECONCILE_CREDIT_STATE_TARGETS)[number];
-
-type ExpectedUserCapState = "capped" | "uncapped" | "unknown";
 
 type PoolReconcileReport = {
   target: "pool";
@@ -72,12 +81,15 @@ type ProgrammaticReconcileReport = {
 type UserReconcileReport = {
   target: "user";
   userId: string;
+  seatType: MembershipSeatType | null;
   previousState: UserCreditState;
+  expectedState: UserCreditState;
   newState: UserCreditState;
-  expectedCapState: ExpectedUserCapState;
   wasInvalid: boolean;
   corrected: boolean;
   executed: boolean;
+  seatBalanceAwu: number | null;
+  seatStartingBalanceAwu: number | null;
   effectiveCapAwuCredits: number | null;
   capSource: "override" | "default" | "none";
   consumedAwuCredits: number | null;
@@ -88,18 +100,37 @@ export type ReconcileCreditStateReport =
   | ProgrammaticReconcileReport
   | UserReconcileReport;
 
+// Treat the legacy "normal" alias as its canonical "on_pool" value when
+// comparing the persisted state with the expected one (see USER_CREDIT_STATES).
+function normalizeUserCreditState(state: UserCreditState): UserCreditState {
+  return state === "normal" ? "on_pool" : state;
+}
+
+// The remaining + full AWU seat balance for a user, read from the live
+// per-seat balances. Returns null when the user has no individual AWU seat
+// allocation (pool-based seat), so callers treat them as spending from the pool.
+function awuSeatBalanceForUser(
+  seatBalances: MetronomeSeatBalance[],
+  userId: string
+): { balanceAwu: number; startingBalanceAwu: number } | null {
+  const awuCreditTypeId = getCreditTypeAwuId();
+  const seat = seatBalances.find((b) => b.seat_id === userId);
+  const awu = seat?.balances.find((b) => b.credit_type_id === awuCreditTypeId);
+  if (!awu) {
+    return null;
+  }
+  return { balanceAwu: awu.balance, startingBalanceAwu: awu.starting_balance };
+}
+
 /**
  * Debug/reconcile entry point behind the poke "Check & Reconcile Credit State"
  * plugin. For the requested credit state machine — pool, programmatic, or a
  * single user — it recomputes the state the workspace *should* be in from the
  * live source of truth (Metronome balance + PAYG for pool, the programmatic cap
- * alert evaluation states for programmatic, the effective per-user cap vs.
- * usage for user), compares it with the persisted state, and — when
- * `execute` is true — reconciles through the same machinery the webhooks use.
- *
- * For `user`, only the capped ↔ uncapped dimension is recomputed (the only
- * events the user machine exposes); the seat/pool/low-balance nuances are left
- * to the webhooks, exactly as in production.
+ * alert evaluation states for programmatic, the live per-user seat balance +
+ * effective per-user cap vs. usage for user), compares it with the persisted
+ * state, and — when `execute` is true — writes the expected state through the
+ * matching authoritative reconcile setter.
  */
 export async function reconcileCreditState({
   auth,
@@ -170,7 +201,10 @@ async function reconcilePool({
 
   let newState = previousState;
   if (execute) {
-    await syncPoolCreditStateFromBalance({ workspace, metronomeCustomerId });
+    await setWorkspacePoolCreditStateReconciled(workspace, expectedState, {
+      workspaceId: workspace.sId,
+      paygEnabled,
+    });
     newState = workspace.poolCreditState;
   }
 
@@ -224,7 +258,7 @@ async function reconcileProgrammatic({
 
   let newState = previousState;
   if (execute) {
-    await applyProgrammaticState(workspace, expectedState);
+    await setProgrammaticCreditStateReconciled(workspace, expectedState);
     newState = workspace.programmaticCreditState;
   }
 
@@ -238,48 +272,6 @@ async function reconcileProgrammatic({
     executed: execute,
     alarms,
   });
-}
-
-// Drive the programmatic machine to `expected` by dispatching the matching
-// event(s). For the low-balance bands we first reset to `active` (a no-op when
-// already active) so the `programmatic_low_balance` transition — which is only
-// legal from an active state — always lands, then route by `remainingCredits`.
-async function applyProgrammaticState(
-  workspace: WorkspaceResource,
-  expected: WorkspaceProgrammaticCreditState
-): Promise<void> {
-  switch (expected) {
-    case "active":
-      await transitionProgrammaticCreditState(workspace, {
-        type: "programmatic_cap_reset",
-      });
-      return;
-    case "depleted":
-      await transitionProgrammaticCreditState(workspace, {
-        type: "programmatic_cap_reached",
-      });
-      return;
-    case "active_low_balance":
-      await transitionProgrammaticCreditState(workspace, {
-        type: "programmatic_cap_reset",
-      });
-      await transitionProgrammaticCreditState(workspace, {
-        type: "programmatic_low_balance",
-        remainingCredits: LOW_BALANCE_OFFSET,
-      });
-      return;
-    case "active_critical_balance":
-      await transitionProgrammaticCreditState(workspace, {
-        type: "programmatic_cap_reset",
-      });
-      await transitionProgrammaticCreditState(workspace, {
-        type: "programmatic_low_balance",
-        remainingCredits: CRITICAL_BALANCE_OFFSET,
-      });
-      return;
-    default:
-      assertNever(expected);
-  }
 }
 
 async function reconcileUser({
@@ -312,6 +304,30 @@ async function reconcileUser({
     );
   }
   const previousState = membership.creditState;
+  const seatType = membership.seatType;
+  const metronomeContractId = auth.subscription()?.metronomeContractId ?? null;
+
+  // Live per-user seat balance (the seat↔pool dimension's source of truth).
+  let seatBalanceAwu: number | null = null;
+  let seatStartingBalanceAwu: number | null = null;
+  if (metronomeContractId) {
+    const seatBalancesResult = await listMetronomeSeatBalances({
+      metronomeCustomerId,
+      metronomeContractId,
+    });
+    if (seatBalancesResult.isErr()) {
+      return new Err(
+        new Error(
+          `Failed to read seat balances: ${seatBalancesResult.error.message}`
+        )
+      );
+    }
+    const seat = awuSeatBalanceForUser(seatBalancesResult.value, userId);
+    if (seat) {
+      seatBalanceAwu = seat.balanceAwu;
+      seatStartingBalanceAwu = seat.startingBalanceAwu;
+    }
+  }
 
   // Resolve the effective per-user cap threshold (in AWU credits, seat
   // allowance included): the user-specific override if present, otherwise the
@@ -333,9 +349,7 @@ async function reconcileUser({
     effectiveCapAwuCredits = overrideResult.value.alert.threshold;
     capSource = "override";
   } else {
-    const normalizedSeatType = normalizeToPoolLimitSeatType(
-      membership.seatType
-    );
+    const normalizedSeatType = normalizeToPoolLimitSeatType(seatType);
     if (normalizedSeatType) {
       const defaultResult = await getMetronomeDefaultUserCapAlertForSeatType({
         metronomeCustomerId,
@@ -356,72 +370,161 @@ async function reconcileUser({
     }
   }
 
-  // Compare the user's current consumption against the cap. Mirrors the
-  // production "local cap state" check used when a spend limit is updated.
+  // Consumption is only needed for the cap bands (capped / on_pool_low_balance),
+  // which require a configured cap; skip the fetch otherwise.
   let consumedAwuCredits: number | null = null;
-  let expectedCapState: ExpectedUserCapState;
-  if (effectiveCapAwuCredits === null) {
-    // No cap configured: the user can never be in the capped state.
-    expectedCapState = "uncapped";
-  } else {
-    const metronomeContractId =
-      auth.subscription()?.metronomeContractId ?? null;
-    if (!metronomeContractId) {
-      expectedCapState = "unknown";
-    } else {
-      const usageResult = await fetchPerUserAwuUsage({
-        metronomeCustomerId,
-        metronomeContractId,
-      });
-      if (usageResult.isErr()) {
-        return new Err(
-          new Error(
-            `Failed to read per-user usage: ${usageResult.error.message}`
-          )
-        );
-      }
-      consumedAwuCredits = usageResult.value.get(userId) ?? 0;
-      expectedCapState =
-        consumedAwuCredits >= effectiveCapAwuCredits ? "capped" : "uncapped";
+  if (effectiveCapAwuCredits !== null && metronomeContractId) {
+    const usageResult = await fetchPerUserAwuUsage({
+      metronomeCustomerId,
+      metronomeContractId,
+    });
+    if (usageResult.isErr()) {
+      return new Err(
+        new Error(`Failed to read per-user usage: ${usageResult.error.message}`)
+      );
     }
+    consumedAwuCredits = usageResult.value.get(userId) ?? 0;
   }
 
-  const wasCapped = previousState === "capped";
-  const wasInvalid =
-    expectedCapState === "unknown"
-      ? false
-      : (expectedCapState === "capped") !== wasCapped;
+  const expectedState = expectedUserCreditState({
+    seatType,
+    seatBalanceAwu,
+    seatStartingBalanceAwu,
+    perUserCapAwuCredits: effectiveCapAwuCredits,
+    consumedAwuCredits,
+  });
+  const wasInvalid = normalizeUserCreditState(previousState) !== expectedState;
 
   let newState = previousState;
-  if (execute && expectedCapState !== "unknown") {
-    const dispatchResult =
-      expectedCapState === "capped"
-        ? await dispatchPerUserCapReached({ workspace, userId })
-        : await dispatchPerUserCapResolved({ workspace, userId });
-    if (dispatchResult.isErr()) {
-      return new Err(dispatchResult.error);
-    }
-    // The dispatch mutates a freshly fetched membership, so re-read to report
-    // the persisted state.
-    const refreshed =
-      await MembershipResource.getActiveMembershipOfUserInWorkspace({
-        user,
-        workspace: lightWorkspace,
-      });
-    newState = refreshed?.creditState ?? previousState;
+  if (execute) {
+    newState = await setUserCreditStateReconciled(membership, expectedState, {
+      workspaceId: workspace.sId,
+      userId,
+      seatType,
+    });
   }
 
   return new Ok({
     target: "user",
     userId,
+    seatType,
     previousState,
+    expectedState,
     newState,
-    expectedCapState,
     wasInvalid,
-    corrected: previousState !== newState,
+    corrected: normalizeUserCreditState(previousState) !== newState,
     executed: execute,
+    seatBalanceAwu,
+    seatStartingBalanceAwu,
     effectiveCapAwuCredits,
     capSource,
     consumedAwuCredits,
   });
+}
+
+/**
+ * Reconcile every active seated user's credit state for a workspace from the
+ * live Metronome source of truth. Called right after the seat-count sync
+ * assigns per-user credits, so freshly-created and just-upgraded users land in
+ * the correct seat↔pool state (e.g. a new pro user → `user_seat`) instead of
+ * being left at the `on_pool` default until a billing-cycle webhook fires.
+ *
+ * Fetches the shared inputs once (seat balances, per-user usage, the per-user
+ * cap overrides and per-seat-type defaults) to avoid an N+1, then computes and
+ * applies the expected state per membership. Never throws — a failure here must
+ * not fail the seat sync; it logs and returns.
+ */
+export async function reconcileWorkspaceUserCreditStates({
+  workspace,
+  metronomeCustomerId,
+  metronomeContractId,
+}: {
+  workspace: LightWorkspaceType;
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+}): Promise<void> {
+  const workspaceId = workspace.sId;
+
+  let seatBalances: MetronomeSeatBalance[];
+  let usageByUser: Map<string, number>;
+  let capOverrides: Record<string, MetronomeCapAlertInfo>;
+  let defaultCaps: Record<NormalizedPoolLimitSeatType, MetronomeCapAlertInfo>;
+  let memberships: MembershipResource[];
+  try {
+    const seatBalancesResult = await listMetronomeSeatBalances({
+      metronomeCustomerId,
+      metronomeContractId,
+    });
+    if (seatBalancesResult.isErr()) {
+      throw seatBalancesResult.error;
+    }
+    const usageResult = await fetchPerUserAwuUsage({
+      metronomeCustomerId,
+      metronomeContractId,
+    });
+    if (usageResult.isErr()) {
+      throw usageResult.error;
+    }
+    seatBalances = seatBalancesResult.value;
+    usageByUser = usageResult.value;
+    capOverrides = await getCachedPerUserCapThresholds({
+      metronomeCustomerId,
+      workspaceId,
+    });
+    defaultCaps = await getCachedDefaultCapThresholdsBySeatType({
+      metronomeCustomerId,
+      workspaceId,
+    });
+    ({ memberships } = await MembershipResource.getActiveMemberships({
+      workspace,
+    }));
+  } catch (err) {
+    logger.error(
+      { workspaceId, err: normalizeError(err) },
+      "[ReconcileCreditState] Failed to load inputs for workspace user reconcile"
+    );
+    return;
+  }
+
+  for (const membership of memberships) {
+    const userId = membership.user?.sId;
+    if (!userId) {
+      continue;
+    }
+    const seatType = membership.seatType;
+
+    const normalizedSeatType = normalizeToPoolLimitSeatType(seatType);
+    const effectiveCapAwuCredits =
+      capOverrides[userId]?.threshold ??
+      (normalizedSeatType
+        ? (defaultCaps[normalizedSeatType]?.threshold ?? null)
+        : null);
+
+    const seat = awuSeatBalanceForUser(seatBalances, userId);
+    const expectedState = expectedUserCreditState({
+      seatType,
+      seatBalanceAwu: seat?.balanceAwu ?? null,
+      seatStartingBalanceAwu: seat?.startingBalanceAwu ?? null,
+      perUserCapAwuCredits: effectiveCapAwuCredits,
+      consumedAwuCredits:
+        effectiveCapAwuCredits !== null ? (usageByUser.get(userId) ?? 0) : null,
+    });
+
+    if (normalizeUserCreditState(membership.creditState) === expectedState) {
+      continue;
+    }
+
+    try {
+      await setUserCreditStateReconciled(membership, expectedState, {
+        workspaceId,
+        userId,
+        seatType,
+      });
+    } catch (err) {
+      logger.error(
+        { workspaceId, userId, err: normalizeError(err) },
+        "[ReconcileCreditState] Failed to reconcile a user's credit state"
+      );
+    }
+  }
 }

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -88,6 +88,11 @@ type UserReconcileReport = {
   wasInvalid: boolean;
   corrected: boolean;
   executed: boolean;
+  // Live Metronome per-seat AWU balance for this user: `seatBalanceAwu` is the
+  // amount remaining, `seatStartingBalanceAwu` the full allocation granted for
+  // the period (e.g. 8000 for a pro seat). Both null for pool-based seats with
+  // no individual allocation. The remaining/starting ratio drives the
+  // user_seat ↔ user_seat_low_balance band.
   seatBalanceAwu: number | null;
   seatStartingBalanceAwu: number | null;
   effectiveCapAwuCredits: number | null;
@@ -445,28 +450,39 @@ export async function reconcileWorkspaceUserCreditStates({
 }): Promise<void> {
   const workspaceId = workspace.sId;
 
-  let seatBalances: MetronomeSeatBalance[];
-  let usageByUser: Map<string, number>;
+  // These return our `Result` type: handle their errors with early returns
+  // rather than throw + catch (ERR1).
+  const seatBalancesResult = await listMetronomeSeatBalances({
+    metronomeCustomerId,
+    metronomeContractId,
+  });
+  if (seatBalancesResult.isErr()) {
+    logger.error(
+      { workspaceId, err: seatBalancesResult.error },
+      "[ReconcileCreditState] Failed to load seat balances"
+    );
+    return;
+  }
+  const usageResult = await fetchPerUserAwuUsage({
+    metronomeCustomerId,
+    metronomeContractId,
+  });
+  if (usageResult.isErr()) {
+    logger.error(
+      { workspaceId, err: usageResult.error },
+      "[ReconcileCreditState] Failed to load per-user usage"
+    );
+    return;
+  }
+  const seatBalances = seatBalancesResult.value;
+  const usageByUser = usageResult.value;
+
+  // The cap-threshold caches (Metronome alert list) and the membership query
+  // (DB) can genuinely throw, so they stay wrapped — the ERR1-authorised case.
   let capOverrides: Record<string, MetronomeCapAlertInfo>;
   let defaultCaps: Record<NormalizedPoolLimitSeatType, MetronomeCapAlertInfo>;
   let memberships: MembershipResource[];
   try {
-    const seatBalancesResult = await listMetronomeSeatBalances({
-      metronomeCustomerId,
-      metronomeContractId,
-    });
-    if (seatBalancesResult.isErr()) {
-      throw seatBalancesResult.error;
-    }
-    const usageResult = await fetchPerUserAwuUsage({
-      metronomeCustomerId,
-      metronomeContractId,
-    });
-    if (usageResult.isErr()) {
-      throw usageResult.error;
-    }
-    seatBalances = seatBalancesResult.value;
-    usageByUser = usageResult.value;
     capOverrides = await getCachedPerUserCapThresholds({
       metronomeCustomerId,
       workspaceId,
@@ -481,11 +497,16 @@ export async function reconcileWorkspaceUserCreditStates({
   } catch (err) {
     logger.error(
       { workspaceId, err: normalizeError(err) },
-      "[ReconcileCreditState] Failed to load inputs for workspace user reconcile"
+      "[ReconcileCreditState] Failed to load cap thresholds or memberships"
     );
     return;
   }
 
+  // One UPDATE per drifting membership. Bounded by the workspace's seat count
+  // and gated on the `continue` above, so steady-state writes are ~zero; even
+  // the worst case (every seat drifting) is a small, infrequent loop on a
+  // rarely-used path. A bulk UPDATE-per-target-state isn't worth the
+  // complexity here (the cache sync would still have to run per-membership).
   for (const membership of memberships) {
     const userId = membership.user?.sId;
     if (!userId) {

--- a/front/lib/api/metronome/seat_sync.ts
+++ b/front/lib/api/metronome/seat_sync.ts
@@ -1,3 +1,4 @@
+import { reconcileWorkspaceUserCreditStates } from "@app/lib/api/metronome/reconcile_credit_state";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import {
   hasContractSeatSubscription,
@@ -79,6 +80,16 @@ export async function syncMetronomeSeatCountForWorkspace({
   if (result.isErr()) {
     return new Err(result.error);
   }
+
+  // Now that per-user seat credits are assigned, reconcile each seated user's
+  // credit state from the live balances — this is what moves a freshly-created
+  // or just-upgraded seat user into the correct seat↔pool state. Never throws;
+  // a downstream reconcile issue must not fail (and retry) the seat sync.
+  await reconcileWorkspaceUserCreditStates({
+    workspace,
+    metronomeCustomerId: workspace.metronomeCustomerId,
+    metronomeContractId: subscription.metronomeContractId,
+  });
 
   return new Ok({ status: "synced" });
 }

--- a/front/lib/metronome/programmatic_credit_state_machine.ts
+++ b/front/lib/metronome/programmatic_credit_state_machine.ts
@@ -213,3 +213,34 @@ export async function transitionProgrammaticCreditState(
 
   return new Ok(match.to);
 }
+
+/**
+ * Authoritatively set the workspace programmatic credit state to `targetState`,
+ * bypassing the event/transition graph. Used by reconciliation, which computes
+ * the expected state directly from the cap alert evaluation via
+ * `expectedProgrammaticCreditStateFromAlerts` — simpler and less fragile than
+ * re-deriving it by replaying reset + low-balance events. Persists the new
+ * state and syncs the same caches the transitions do.
+ */
+export async function setProgrammaticCreditStateReconciled(
+  workspace: WorkspaceResource,
+  targetState: WorkspaceProgrammaticCreditState,
+  { transaction }: { transaction?: Transaction } = {}
+): Promise<WorkspaceProgrammaticCreditState> {
+  const workspaceId = workspace.sId;
+  const currentState = workspace.programmaticCreditState;
+  if (currentState !== targetState) {
+    await workspace.updateProgrammaticCreditState(targetState, transaction);
+  }
+  syncProgrammaticCacheForState(targetState, workspaceId, transaction);
+  logger.info(
+    {
+      workspaceId,
+      fromState: currentState,
+      toState: targetState,
+      wasStateChanged: currentState !== targetState,
+    },
+    "[ProgrammaticCreditStateMachine] State reconciled"
+  );
+  return targetState;
+}

--- a/front/lib/metronome/user_credit_state_machine.test.ts
+++ b/front/lib/metronome/user_credit_state_machine.test.ts
@@ -3,7 +3,10 @@ import {
   PRO_SEAT_MONTHLY_AWU_CREDITS,
 } from "@app/lib/metronome/setup_new_pricing";
 import type { UserCreditContext } from "@app/lib/metronome/user_credit_state_machine";
-import { transitionUserCreditState } from "@app/lib/metronome/user_credit_state_machine";
+import {
+  setUserCreditStateReconciled,
+  transitionUserCreditState,
+} from "@app/lib/metronome/user_credit_state_machine";
 import type { MembershipResource } from "@app/lib/resources/membership_resource";
 import type {
   MembershipSeatType,
@@ -389,6 +392,77 @@ describe("UserCreditStateMachine — seat_low_balance", () => {
       "ws_test",
       "u_test",
       "user_seat_low_balance"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Authoritative reconcile setter
+// ---------------------------------------------------------------------------
+
+describe("UserCreditStateMachine — setUserCreditStateReconciled", () => {
+  it("on_pool → user_seat persists and syncs the cache (no transition needed)", async () => {
+    const membership = makeMembership("on_pool", "pro");
+    const result = await setUserCreditStateReconciled(membership, "user_seat", {
+      ...baseCtx,
+      seatType: "pro",
+    });
+    expect(result).toBe("user_seat");
+    expect(membership.updateCreditState).toHaveBeenCalledWith(
+      "user_seat",
+      undefined
+    );
+    // user_seat clears both the cap block and the AWU warning.
+    expect(mockClearUserCapBlocked).toHaveBeenCalledWith("ws_test", "u_test");
+    expect(mockClearUserAwuWarned).toHaveBeenCalledWith("ws_test", "u_test");
+    expect(mockSetUserCreditState).toHaveBeenCalledWith(
+      "ws_test",
+      "u_test",
+      "user_seat"
+    );
+  });
+
+  it("is idempotent when already in the target state but re-syncs the cache", async () => {
+    const membership = makeMembership("user_seat", "pro");
+    const result = await setUserCreditStateReconciled(membership, "user_seat", {
+      ...baseCtx,
+      seatType: "pro",
+    });
+    expect(result).toBe("user_seat");
+    expect(membership.updateCreditState).not.toHaveBeenCalled();
+    expect(mockSetUserCreditState).toHaveBeenCalledWith(
+      "ws_test",
+      "u_test",
+      "user_seat"
+    );
+  });
+
+  it("migrates a legacy 'normal' row to 'on_pool'", async () => {
+    const membership = makeMembership("normal", "workspace");
+    const result = await setUserCreditStateReconciled(membership, "on_pool", {
+      ...baseCtx,
+      seatType: "workspace",
+    });
+    expect(result).toBe("on_pool");
+    expect(membership.updateCreditState).toHaveBeenCalledWith(
+      "on_pool",
+      undefined
+    );
+  });
+
+  it("forwards the provided transaction to the DB update and cache invalidator", async () => {
+    const tx = { __mock: "transaction" } as unknown as Transaction;
+    const membership = makeMembership("on_pool", "pro");
+    await setUserCreditStateReconciled(
+      membership,
+      "user_seat",
+      { ...baseCtx, seatType: "pro" },
+      { transaction: tx }
+    );
+    expect(membership.updateCreditState).toHaveBeenCalledWith("user_seat", tx);
+    expect(mockInvalidateCacheAfterCommit).toHaveBeenCalledWith(
+      tx,
+      expect.any(Function)
     );
   });
 });

--- a/front/lib/metronome/user_credit_state_machine.ts
+++ b/front/lib/metronome/user_credit_state_machine.ts
@@ -282,3 +282,37 @@ export async function transitionUserCreditState(
 
   return new Ok(match.to);
 }
+
+/**
+ * Authoritatively set a user's credit state to `targetState`, bypassing the
+ * event/transition graph. Used by reconciliation, which computes the expected
+ * state directly from the live source of truth (Metronome seat balance + cap +
+ * usage) — the seat↔pool dimension is not reachable from the event-driven
+ * transitions alone (e.g. nothing dispatches a user back to `user_seat` outside
+ * a billing-cycle webhook). Persists the new state (treating the legacy
+ * "normal" alias as "on_pool" so such rows migrate) and syncs the same caches
+ * the transitions do.
+ */
+export async function setUserCreditStateReconciled(
+  membership: MembershipResource,
+  targetState: UserCreditState,
+  ctx: UserCreditContext,
+  { transaction }: { transaction?: Transaction } = {}
+): Promise<UserCreditState> {
+  const rawState = membership.creditState;
+  if (rawState !== targetState) {
+    await membership.updateCreditState(targetState, transaction);
+  }
+  syncUserCapCacheForState(targetState, ctx, transaction);
+  logger.info(
+    {
+      workspaceId: ctx.workspaceId,
+      userId: ctx.userId,
+      fromState: rawState,
+      toState: targetState,
+      wasStateChanged: rawState !== targetState,
+    },
+    "[UserCreditStateMachine] State reconciled"
+  );
+  return targetState;
+}

--- a/front/lib/metronome/workspace_credit_state_machine.ts
+++ b/front/lib/metronome/workspace_credit_state_machine.ts
@@ -371,3 +371,33 @@ export async function transitionWorkspaceCreditState(
 
   return new Ok(match.to);
 }
+
+/**
+ * Authoritatively set the workspace pool credit state to `targetState`,
+ * bypassing the event/transition graph. Used by reconciliation, which computes
+ * the expected state directly from the live AWU balance + PAYG via
+ * `expectedPoolCreditStateFromBalance`. Persists the new state and syncs the
+ * same caches the transitions do.
+ */
+export async function setWorkspacePoolCreditStateReconciled(
+  workspace: WorkspaceResource,
+  targetState: WorkspacePoolCreditState,
+  ctx: WorkspaceCreditContext,
+  { transaction }: { transaction?: Transaction } = {}
+): Promise<WorkspacePoolCreditState> {
+  const currentState = workspace.poolCreditState;
+  if (currentState !== targetState) {
+    await workspace.updatePoolCreditState(targetState, transaction);
+  }
+  syncWorkspacePoolCacheForState(targetState, ctx, transaction);
+  logger.info(
+    {
+      workspaceId: ctx.workspaceId,
+      fromState: currentState,
+      toState: targetState,
+      wasStateChanged: currentState !== targetState,
+    },
+    "[WorkspaceCreditStateMachine] State reconciled"
+  );
+  return targetState;
+}

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -19,6 +19,7 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger, { auditLog } from "@app/logger/logger";
 import { launchIndexUserSearchWorkflow } from "@app/temporal/es_indexation/client";
 import {
+  initialCreditStateForSeatType,
   isMembershipSeatType,
   type MembershipOriginType,
   type MembershipRoleType,
@@ -1030,6 +1031,11 @@ export class MembershipResource extends BaseResource<MembershipModel> {
         role,
         origin,
         seatType,
+        // Optimistic initial state from the seat type (pro/max → user_seat) so a
+        // new seat user isn't stuck at the "on_pool" DB default during the seat
+        // sync's debounce window; the post-sync reconcile refines it from the
+        // live Metronome balance.
+        creditState: initialCreditStateForSeatType(seatType),
         firstUsedAt: origin === "provisioned" ? null : new Date(),
       },
       { transaction }

--- a/front/types/memberships.test.ts
+++ b/front/types/memberships.test.ts
@@ -1,0 +1,157 @@
+import {
+  expectedUserCreditState,
+  initialCreditStateForSeatType,
+  isSeatBased,
+} from "@app/types/memberships";
+import { describe, expect, it } from "vitest";
+
+// A pro seat allocates 8000 AWU/month; max allocates 40000. These tests use
+// round numbers and don't depend on the real constants.
+const PRO_ALLOWANCE = 8000;
+const CAP = 10000; // seat allowance + pool limit
+
+describe("isSeatBased", () => {
+  it("pro/max/free seats are seat-based", () => {
+    expect(isSeatBased("pro")).toBe(true);
+    expect(isSeatBased("pro_yearly")).toBe(true);
+    expect(isSeatBased("max")).toBe(true);
+    expect(isSeatBased("max_yearly")).toBe(true);
+    expect(isSeatBased("free")).toBe(true);
+  });
+
+  it("workspace seats and unset seats are not seat-based", () => {
+    expect(isSeatBased("workspace")).toBe(false);
+    expect(isSeatBased("workspace_yearly")).toBe(false);
+    expect(isSeatBased(null)).toBe(false);
+    expect(isSeatBased(undefined)).toBe(false);
+  });
+});
+
+describe("initialCreditStateForSeatType", () => {
+  it("seat-based seats (pro/max/free) start in user_seat", () => {
+    expect(initialCreditStateForSeatType("pro")).toBe("user_seat");
+    expect(initialCreditStateForSeatType("pro_yearly")).toBe("user_seat");
+    expect(initialCreditStateForSeatType("max")).toBe("user_seat");
+    expect(initialCreditStateForSeatType("max_yearly")).toBe("user_seat");
+    expect(initialCreditStateForSeatType("free")).toBe("user_seat");
+  });
+
+  it("pool-based and unset seats start on_pool", () => {
+    expect(initialCreditStateForSeatType("workspace")).toBe("on_pool");
+    expect(initialCreditStateForSeatType("workspace_yearly")).toBe("on_pool");
+    expect(initialCreditStateForSeatType(null)).toBe("on_pool");
+    expect(initialCreditStateForSeatType(undefined)).toBe("on_pool");
+  });
+});
+
+describe("expectedUserCreditState", () => {
+  it("pro seat with full personal balance → user_seat", () => {
+    expect(
+      expectedUserCreditState({
+        seatType: "pro",
+        seatBalanceAwu: PRO_ALLOWANCE,
+        seatStartingBalanceAwu: PRO_ALLOWANCE,
+        perUserCapAwuCredits: CAP,
+        consumedAwuCredits: 0,
+      })
+    ).toBe("user_seat");
+  });
+
+  it("pro seat with ≤20% personal balance remaining → user_seat_low_balance", () => {
+    expect(
+      expectedUserCreditState({
+        seatType: "pro",
+        seatBalanceAwu: 0.2 * PRO_ALLOWANCE,
+        seatStartingBalanceAwu: PRO_ALLOWANCE,
+        perUserCapAwuCredits: CAP,
+        consumedAwuCredits: 0.8 * PRO_ALLOWANCE,
+      })
+    ).toBe("user_seat_low_balance");
+  });
+
+  it("pro seat with exhausted personal balance, below the cap warning → on_pool", () => {
+    expect(
+      expectedUserCreditState({
+        seatType: "pro",
+        seatBalanceAwu: 0,
+        seatStartingBalanceAwu: PRO_ALLOWANCE,
+        // Cap well above consumption so we land on plain on_pool, not the 80% band.
+        perUserCapAwuCredits: 20000,
+        consumedAwuCredits: PRO_ALLOWANCE,
+      })
+    ).toBe("on_pool");
+  });
+
+  it("free seat with personal balance → user_seat", () => {
+    expect(
+      expectedUserCreditState({
+        seatType: "free",
+        seatBalanceAwu: 300,
+        seatStartingBalanceAwu: 300,
+        perUserCapAwuCredits: null,
+        consumedAwuCredits: null,
+      })
+    ).toBe("user_seat");
+  });
+
+  it("free seat with exhausted balance → capped (no pool fallback)", () => {
+    expect(
+      expectedUserCreditState({
+        seatType: "free",
+        seatBalanceAwu: 0,
+        seatStartingBalanceAwu: 300,
+        perUserCapAwuCredits: null,
+        consumedAwuCredits: null,
+      })
+    ).toBe("capped");
+  });
+
+  it("pool-based (workspace) seat → on_pool (no personal seat balance)", () => {
+    expect(
+      expectedUserCreditState({
+        seatType: "workspace",
+        seatBalanceAwu: null,
+        seatStartingBalanceAwu: null,
+        perUserCapAwuCredits: CAP,
+        consumedAwuCredits: 0,
+      })
+    ).toBe("on_pool");
+  });
+
+  it("consumption ≥ cap → capped (hard block wins over seat balance)", () => {
+    expect(
+      expectedUserCreditState({
+        seatType: "pro",
+        // Even with a (stale) positive seat balance, hitting the cap blocks.
+        seatBalanceAwu: 10,
+        seatStartingBalanceAwu: PRO_ALLOWANCE,
+        perUserCapAwuCredits: CAP,
+        consumedAwuCredits: CAP,
+      })
+    ).toBe("capped");
+  });
+
+  it("on pool at ≥80% of cap → on_pool_low_balance", () => {
+    expect(
+      expectedUserCreditState({
+        seatType: "workspace",
+        seatBalanceAwu: null,
+        seatStartingBalanceAwu: null,
+        perUserCapAwuCredits: CAP,
+        consumedAwuCredits: 0.8 * CAP,
+      })
+    ).toBe("on_pool_low_balance");
+  });
+
+  it("no cap configured → never capped (uncapped pool user)", () => {
+    expect(
+      expectedUserCreditState({
+        seatType: "workspace",
+        seatBalanceAwu: null,
+        seatStartingBalanceAwu: null,
+        perUserCapAwuCredits: null,
+        consumedAwuCredits: null,
+      })
+    ).toBe("on_pool");
+  });
+});

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -94,6 +94,35 @@ export function normalizeToPoolLimitSeatType(
   }
 }
 
+/**
+ * Whether a seat type carries an individual (per-user) credit allocation the
+ * user spends from before falling back to the workspace pool. Pro and max seats
+ * do; free seats also have a personal allocation (a fixed lifetime grant) — the
+ * only difference is free seats have no pool fallback, so once exhausted they are
+ * `capped` rather than `on_pool`. Workspace seats have no individual allocation
+ * (they spend straight from the shared pool).
+ */
+export function isSeatBased(
+  seatType: MembershipSeatType | null | undefined
+): boolean {
+  if (!seatType) {
+    return false;
+  }
+  switch (seatType) {
+    case "free":
+    case "pro":
+    case "pro_yearly":
+    case "max":
+    case "max_yearly":
+      return true;
+    case "workspace":
+    case "workspace_yearly":
+      return false;
+    default:
+      return assertNever(seatType);
+  }
+}
+
 // Per-user credit state on a membership. Models where a user sits in the
 // personal-credits → workspace-pool → cap progression. Only the per-user
 // dimension lives here; the workspace-level pool state lives separately on
@@ -136,4 +165,100 @@ export function isUserCreditState(value: unknown): value is UserCreditState {
     typeof value === "string" &&
     USER_CREDIT_STATES.includes(value as UserCreditState)
   );
+}
+
+// Fraction of the personal seat balance / per-user cap at which the
+// low-balance warning bands kick in. Mirrors the seat-low-balance guards in
+// `lib/metronome/user_credit_state_machine.ts` (threshold === 0.2 * allowance)
+// and `USER_AWU_WARNING_PERCENTAGE` (0.8) backing the per-user warning alerts.
+const SEAT_LOW_BALANCE_FRACTION = 0.2;
+const CAP_WARNING_FRACTION = 0.8;
+
+/**
+ * The credit state a freshly-allocated seat should start in, derived purely
+ * from the seat type (assumes a full, unspent balance):
+ *   - seat-based (pro/max/free): `user_seat` — they spend personal credits first.
+ *   - workspace (pool-based): `on_pool` — no personal allocation, straight to
+ *     the shared pool.
+ *
+ * Used to initialize the state at membership creation; the authoritative
+ * reconcile from live Metronome balances refines it afterwards.
+ */
+export function initialCreditStateForSeatType(
+  seatType: MembershipSeatType | null | undefined
+): UserCreditState {
+  return isSeatBased(seatType) ? "user_seat" : "on_pool";
+}
+
+/**
+ * Compute the credit state a user *should* be in from the live source of
+ * truth, across both dimensions of `UserCreditState`:
+ *   - the cap dimension (`capped`): consumption reached the effective per-user
+ *     cap (seat allowance + pool limit). This is the hard block, evaluated
+ *     first — if consumption reached the cap, the personal seat is necessarily
+ *     exhausted too.
+ *   - the seat↔pool dimension: a seat-based user with personal balance left is
+ *     `user_seat` (or `user_seat_low_balance` at ≤20% remaining); once the
+ *     personal balance is exhausted — or for pool-based seats that never had
+ *     one — they spend from the workspace pool (`on_pool`, or
+ *     `on_pool_low_balance` at ≥80% of the cap). Free seats are the exception:
+ *     they are seat-based but have no pool fallback, so an exhausted free seat
+ *     is `capped`.
+ *
+ * `seatBalanceAwu` / `seatStartingBalanceAwu` come from the live Metronome
+ * per-seat balance (`listMetronomeSeatBalances`); `null` means the user has no
+ * individual seat allocation (pool-based seat), so they are treated as
+ * spending from the pool. `perUserCapAwuCredits` / `consumedAwuCredits` are
+ * `null` when no cap is configured or usage is unknown, in which case the cap
+ * bands are skipped.
+ */
+export function expectedUserCreditState({
+  seatType,
+  seatBalanceAwu,
+  seatStartingBalanceAwu,
+  perUserCapAwuCredits,
+  consumedAwuCredits,
+}: {
+  seatType: MembershipSeatType | null | undefined;
+  seatBalanceAwu: number | null;
+  seatStartingBalanceAwu: number | null;
+  perUserCapAwuCredits: number | null;
+  consumedAwuCredits: number | null;
+}): UserCreditState {
+  const capKnown = perUserCapAwuCredits !== null && consumedAwuCredits !== null;
+
+  // Hard block first: consumption reached the per-user cap.
+  if (capKnown && consumedAwuCredits >= perUserCapAwuCredits) {
+    return "capped";
+  }
+
+  // Seat-based user (pro/max/free) with a known personal balance.
+  if (isSeatBased(seatType) && seatBalanceAwu !== null) {
+    if (seatBalanceAwu > 0) {
+      // Still spending personal credits.
+      if (
+        seatStartingBalanceAwu !== null &&
+        seatBalanceAwu <= SEAT_LOW_BALANCE_FRACTION * seatStartingBalanceAwu
+      ) {
+        return "user_seat_low_balance";
+      }
+      return "user_seat";
+    }
+    // Personal balance exhausted. Free seats have no pool fallback, so they are
+    // capped; pro/max fall through to the workspace-pool bands below.
+    if (normalizeToPoolLimitSeatType(seatType) === null) {
+      return "capped";
+    }
+  }
+
+  // Otherwise spending from the workspace pool (pool-based seat, or pro/max
+  // whose personal balance is exhausted). Surface the 80% cap warning when
+  // applicable.
+  if (
+    capKnown &&
+    consumedAwuCredits >= CAP_WARNING_FRACTION * perUserCapAwuCredits
+  ) {
+    return "on_pool_low_balance";
+  }
+  return "on_pool";
 }


### PR DESCRIPTION
## Description

Fixes the per-user credit-state reconciliation so seat-based users land in the correct state instead of being stuck at `on_pool`.

**Problem.** The per-user credit state has two dimensions — the seat↔pool dimension (`user_seat*` ↔ `on_pool*`) and the cap dimension (`capped`) — but only the cap dimension was ever reconciled:

- `reconcileUser` (the poke "Check & Reconcile Credit State" plugin) only recomputed capped ↔ uncapped by dispatching `per_user_cap_reached`/`per_user_cap_resolved`, and the resolved path always lands on `on_pool`. There was **no path to `user_seat`**, so reconciling a pro/max user left them on `on_pool`.
- New memberships defaulted `creditState` to `on_pool`, and seat-type changes fired no credit-state event.

So `user_seat` was only ever reachable via the billing-cycle `seat_balance_resolved` webhook — which a freshly-created or just-upgraded user won't see for weeks.

**Fix.**

- **Pure helpers** (`types/memberships.ts`):
  - `isSeatBased(seatType)` — `pro`/`max`/`free` carry an individual allocation; `workspace` is pool-only.
  - `expectedUserCreditState(...)` — computes the full state from the live source of truth (seat balance + effective per-user cap + usage). Free seats are seat-based but have no pool fallback, so an exhausted free seat → `capped`.
  - `initialCreditStateForSeatType(...)` — at-creation default (seat-based → `user_seat`, else `on_pool`).
- **Live source of truth:** reconciliation now reads `listMetronomeSeatBalances()` (authoritative per-user remaining/starting AWU), which the old code never consulted.
- **Authoritative reconcile setters on all three machines** — `setUserCreditStateReconciled`, `setWorkspacePoolCreditStateReconciled`, `setProgrammaticCreditStateReconciled`. Reconcilers now compute the expected state and set it directly (+ sync the same caches) instead of replaying fragile event sequences; the brittle `applyProgrammaticState` helper is gone. The pool and programmatic reconcilers are wired through their setters too.
- **Reconcile after credits are assigned:** `reconcileWorkspaceUserCreditStates(...)` runs at the end of `syncMetronomeSeatCountForWorkspace`, right after the seat-count sync assigns per-user seat credits. Both membership creation and seat-type change already launch that workflow, so this single hook covers both, with accurate live balances. It fetches shared inputs once (no N+1), only writes on drift, and never throws (won't fail the seat sync).
- **Optimistic init** in `createMembership` so a new seat-based user shows `user_seat` immediately rather than during the seat-sync debounce window.

## Tests

- `front/types/memberships.test.ts` — `isSeatBased`, `initialCreditStateForSeatType`, and the band logic of `expectedUserCreditState` (pro full balance → `user_seat`; ≤20% → `user_seat_low_balance`; exhausted → `on_pool`; free with balance → `user_seat`; exhausted free → `capped`; workspace → `on_pool`; consumed ≥ cap → `capped`; ≥80% of cap → `on_pool_low_balance`).
- `front/lib/metronome/user_credit_state_machine.test.ts` — `setUserCreditStateReconciled` (persist + cache sync, idempotency, legacy `normal` → `on_pool`, transaction forwarding).
- `front/lib/api/metronome/reconcile_credit_state.test.ts` — DB-backed functional test for the batch reconcile (stale `on_pool` pro → `user_seat`; exhausted pro → `on_pool`; workspace stays `on_pool`; shared inputs fetched once).
- Updated `credit_state_dispatcher.test.ts` assertions for the new `user_seat` initial state.
- Neighboring suites (`seats`, `seats_sync`, `spend_limit`, pool/programmatic machines, `programmatic_usage/tracking`, `switch_contract`) all pass. Typecheck clean; biome-formatted.

## Risk

- Scoped to the new-pricing Metronome credit-state machinery, which has no real contracts yet, so blast radius is low.
- The reconcile hook never throws and only writes on drift, so it cannot fail the seat-count sync or thrash unchanged rows.
- The pool/programmatic reconcilers now apply the computed expected state directly; the resulting states are identical to the previous event-replay (covered by the existing machine tests), just without the fragile sequencing.
- Behavioral change to note: free seats now initialize at `user_seat` (was `on_pool`); the post-sync reconcile flips exhausted free seats to `capped` from the live balance.
- `listMetronomeSeatBalances` hits an unpublished Metronome endpoint; on failure the batch reconcile logs and returns (the plugin surfaces the error so drift stays visible).
- Safe to roll back — no schema/migration changes.

## Deploy Plan

Standard deploy. No migration. After deploy, run the poke "Check & Reconcile Credit State" plugin (target `user`, mode `execute`) on affected users, or trigger a seat-count sync, to converge existing memberships.
