### PR TITLE
Add: Dust as remote MCP server first set of tools.

### DIFF
--- a/front-api/routes/mcp/index.ts
+++ b/front-api/routes/mcp/index.ts
@@ -19,7 +19,7 @@ mcpApp.all("/", mcpServerAuthMiddleware, async (c) => {
   const user = c.get("mcpUser");
   const auth = c.get("mcpAuth");
   logger.info(
-    { userId: user.sub, workspaceId: auth.workspace()?.sId },
+    { userId: user.sub, workspaceId: auth.workspace().sId },
     "[dust-mcp-server] Inbound request"
   );
 

--- a/front-api/routes/mcp/well-known.ts
+++ b/front-api/routes/mcp/well-known.ts
@@ -8,6 +8,10 @@ import { createHono } from "@front-api/lib/hono";
 const WORKOS_AUTHKIT_DOMAIN = getWorkOSAuthKitDomain();
 const DUST_MCP_SERVER_URL = getMcpResourceServerUrl();
 const protectedResourcePath = getMcpProtectedResourcePath(DUST_MCP_SERVER_URL);
+const authorizationServerMetadataUrl = new URL(
+  "/.well-known/oauth-authorization-server",
+  WORKOS_AUTHKIT_DOMAIN
+);
 
 const protectedResourceMetadata = {
   resource: DUST_MCP_SERVER_URL,
@@ -23,6 +27,19 @@ function serveProtectedResourceMetadata(c: {
   return c.json(protectedResourceMetadata);
 }
 
+async function serveAuthorizationServerMetadata(c: {
+  json: (body: unknown, status?: number) => Response;
+}) {
+  const response = await fetch(authorizationServerMetadataUrl);
+  const metadata = await response.json();
+
+  if (!response.ok) {
+    return c.json(metadata, response.status);
+  }
+
+  return c.json(metadata);
+}
+
 // Path-aware discovery for → /.well-known/oauth-protected-resource/mcp
 mcpWellKnownApp.get(protectedResourcePath, serveProtectedResourceMetadata);
 
@@ -30,4 +47,11 @@ mcpWellKnownApp.get(protectedResourcePath, serveProtectedResourceMetadata);
 mcpWellKnownApp.get(
   "/.well-known/oauth-protected-resource",
   serveProtectedResourceMetadata
+);
+
+// Compatibility fallback for clients that look for Authorization Server
+// Metadata on the MCP host instead of following the protected resource metadata.
+mcpWellKnownApp.get(
+  "/.well-known/oauth-authorization-server",
+  serveAuthorizationServerMetadata
 );

--- a/front/lib/api/actions/servers/search/tools/index.ts
+++ b/front/lib/api/actions/servers/search/tools/index.ts
@@ -8,7 +8,7 @@ import {
   applyNodeIdsFilterToCoreSearchArgs,
   getCoreSearchArgs,
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { AgentLoopContextType, StepContext } from "@app/lib/actions/types";
 import {
   SEARCH_TOOL_METADATA_WITH_TAGS,
   SEARCH_TOOL_NAME,
@@ -44,6 +44,7 @@ export async function searchFunction(
     tagsIn,
     tagsNot,
     agentLoopContext,
+    stepContext,
   }: {
     query: string;
     relativeTimeFrame: string;
@@ -53,6 +54,7 @@ export async function searchFunction(
     tagsIn?: string[];
     tagsNot?: string[];
     agentLoopContext?: AgentLoopContextType;
+    stepContext?: StepContext;
   }
 ): Promise<Result<CallToolResult["content"], MCPError>> {
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
@@ -60,14 +62,14 @@ export async function searchFunction(
   const credentials = await getLlmCredentials(auth);
   const timeFrame = parseTimeFrame(relativeTimeFrame);
 
-  if (!agentLoopContext?.runContext) {
+  if (!agentLoopContext?.runContext?.stepContext && !stepContext) {
     throw new Error(
-      "agentLoopRunContext is required where the tool is called."
+      "agentLoopRunContext.stepContext or stepContext is required where the tool is called."
     );
   }
 
   const { retrievalTopK, citationsOffset } =
-    agentLoopContext.runContext.stepContext;
+    agentLoopContext?.runContext?.stepContext ?? stepContext!;
 
   // Get the core search args for each data source, fail if any of them are invalid.
   const coreSearchArgsResults = await getCoreSearchArgs(auth, dataSources);

--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -75,8 +75,19 @@ export const getLightConversation = async (
   auth: Authenticator,
   conversationId: string,
   includeDeleted: boolean = false,
-  branchId: string | null = null
-) => _getConversation(auth, conversationId, includeDeleted, branchId, "light");
+  branchId: string | null = null,
+  lastInteractionsToFetchToolOutputContentFor: number | null = null,
+  messagePagination?: { limit: number; lastRank: number | null }
+) =>
+  _getConversation(
+    auth,
+    conversationId,
+    includeDeleted,
+    branchId,
+    "light",
+    lastInteractionsToFetchToolOutputContentFor,
+    messagePagination
+  );
 
 async function _getConversation<V extends "light" | "full">(
   auth: Authenticator,

--- a/front/lib/api/mcp_server/README.md
+++ b/front/lib/api/mcp_server/README.md
@@ -16,7 +16,7 @@ HTTP entrypoints live in `front-api/routes/mcp/`. This folder holds the auth and
 |---|---|
 | HTTP routing and wiring | `front-api/routes/mcp/` |
 | OAuth metadata discovery | `front-api/routes/mcp/well-known.ts` |
-| Tool definitions | `server.ts` |
+| Tool definitions | `tools/` (registered from `server.ts`; grouped under `tools/agents/`, `tools/conversations/`, `tools/pods/`, `tools/search/`, `tools/files/`) |
 | Token verification | `auth.ts` |
 | User + workspace resolution from the token | `authenticator.ts` |
 | How tools access per-request auth | `context.ts` |
@@ -32,7 +32,7 @@ HTTP entrypoints live in `front-api/routes/mcp/`. This folder holds the auth and
 
 ## Adding a tool
 
-Add it in `server.ts`. Use `getAuthenticatorFromMcpContext()` to access the scoped auth inside handlers. MCP clients cache tool lists — reconnect after adding or renaming tools.
+Add a file under `tools/` and register it in `tools/index.ts`. Use `getAuthenticatorFromMcpContext()` to access the scoped auth inside handlers. MCP clients cache tool lists — reconnect after adding or renaming tools.
 
 ## Local dev & config
 

--- a/front/lib/api/mcp_server/auth.ts
+++ b/front/lib/api/mcp_server/auth.ts
@@ -1,11 +1,13 @@
-import { getAuthenticatorFromWorkOSClaims } from "@app/lib/api/mcp_server/authenticator";
+import {
+  getAuthenticatorFromWorkOSClaims,
+  type McpAuthenticator,
+} from "@app/lib/api/mcp_server/authenticator";
 import {
   getMcpResourceMetadataUrl,
   getMcpResourceServerUrl,
   getWorkOSAuthKitDomain,
   normalizeOAuthUrl,
 } from "@app/lib/api/mcp_server/urls";
-import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { Context } from "hono";
@@ -22,7 +24,7 @@ export type McpServerAuthUser = JWTPayload & { sub: string };
 export type McpServerAuthVariables = {
   mcpUser: McpServerAuthUser;
   mcpAuthInfo: AuthInfo;
-  mcpAuth: Authenticator;
+  mcpAuth: McpAuthenticator;
 };
 
 function tokenScopes(payload: JWTPayload): string[] {

--- a/front/lib/api/mcp_server/authenticator.ts
+++ b/front/lib/api/mcp_server/authenticator.ts
@@ -4,10 +4,17 @@ import {
   WorkOSJwtPayloadSchema,
 } from "@app/lib/api/workos";
 import { Authenticator } from "@app/lib/auth";
+import type { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import type { WorkspaceType } from "@app/types/user";
 import { isLeft } from "fp-ts/lib/Either";
+
+export interface McpAuthenticator extends Authenticator {
+  workspace(): WorkspaceType;
+  user(): UserResource;
+}
 
 export type McpAuthenticatorError =
   | "organization_missing"
@@ -33,7 +40,7 @@ function getOrganizationId(payload: WorkOSJwtPayload): string | null {
 
 export async function getAuthenticatorFromWorkOSClaims(
   payload: McpServerAuthUser
-): Promise<Result<Authenticator, McpAuthenticatorError>> {
+): Promise<Result<McpAuthenticator, McpAuthenticatorError>> {
   const workOSToken = parseWorkOSJwtPayload(payload);
   if (!workOSToken) {
     return new Err("invalid_token_payload");
@@ -67,9 +74,9 @@ export async function getAuthenticatorFromWorkOSClaims(
   }
 
   const auth = authResult.value;
-  if (!auth.user() || auth.role() === "none") {
+  if (!auth.workspace() || !auth.user() || auth.role() === "none") {
     return new Err("not_a_member");
   }
 
-  return new Ok(auth);
+  return new Ok(auth as McpAuthenticator);
 }

--- a/front/lib/api/mcp_server/context.ts
+++ b/front/lib/api/mcp_server/context.ts
@@ -1,14 +1,19 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 
-import type { Authenticator } from "@app/lib/auth";
+import type { McpAuthenticator } from "@app/lib/api/mcp_server/authenticator";
+
+export type { McpAuthenticator } from "@app/lib/api/mcp_server/authenticator";
 
 type McpContext = {
-  auth: Authenticator;
+  auth: McpAuthenticator;
 };
 
 const mcpContext = new AsyncLocalStorage<McpContext>();
 
-export function runWithMcpContext<T>(context: McpContext, fn: () => T): T {
+export function runWithMcpContext<T>(
+  context: { auth: McpAuthenticator },
+  fn: () => T
+): T {
   return mcpContext.run(context, fn);
 }
 
@@ -16,6 +21,12 @@ export function getMcpContext(): McpContext | undefined {
   return mcpContext.getStore();
 }
 
-export function getAuthenticatorFromMcpContext(): Authenticator | undefined {
-  return getMcpContext()?.auth;
+export function getAuthenticatorFromMcpContext(): McpAuthenticator {
+  const auth = getMcpContext()?.auth;
+  if (!auth) {
+    throw new Error(
+      "getAuthenticatorFromMcpContext called outside MCP context."
+    );
+  }
+  return auth;
 }

--- a/front/lib/api/mcp_server/server.ts
+++ b/front/lib/api/mcp_server/server.ts
@@ -1,38 +1,55 @@
-import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import config from "@app/lib/api/config";
+import { registerDustMcpTools } from "@app/lib/api/mcp_server/tools";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Icon } from "@modelcontextprotocol/sdk/types.js";
+
+const DUST_LOGO_SQUARE_SVG_PATH =
+  "/static/landing/logos/dust/Dust_LogoSquare.svg";
+const DUST_LOGO_SQUARE_PNG_PATH =
+  "/static/landing/logos/dust/Dust_LogoSquare.png";
+
+function getDustMcpServerIcons(): Icon[] {
+  const appUrl = config.getAppUrl();
+  return [
+    {
+      src: `${appUrl}${DUST_LOGO_SQUARE_SVG_PATH}`,
+      mimeType: "image/svg+xml",
+      sizes: ["any"],
+    },
+    {
+      src: `${appUrl}${DUST_LOGO_SQUARE_PNG_PATH}`,
+      mimeType: "image/png",
+      sizes: ["48x48"],
+    },
+  ];
+}
+
+const DUST_MCP_SERVER_INSTRUCTIONS = `Dust MCP server — programmatic access to a Dust workspace for external clients (Cursor, Claude Desktop, etc.).
+
+Every call is scoped to the authenticated Dust user and workspace.
+
+## Key concepts
+
+- **Workspace**: the Dust organization you signed into. All tools operate within it.
+- **Conversation**: a chat thread with Dust agents. Conversations can live at workspace level or inside a Pod. Each has its own file system for attachments and generated files.
+- **Pod**: a Dust project space — shared context with a description, tasks, linked company-data nodes, conversations, and files.
+- **File system**: scoped paths such as \`conversation-<id>/...\` or \`pod-<id>/...\`.
+- **Search**: semantic search across all globally accessible Spaces in the workspace.`;
 
 export function createDustMcpServer(): McpServer {
-  const server = new McpServer({
-    name: "dust",
-    version: "0.1.0",
-  });
-
-  // hello_world — smoke-test tool
-  // Confirms that a remote client is properly authenticated and talking to Dust.
-  server.tool(
-    "hello_world",
-    "Returns a greeting from Dust. Use this to verify that your MCP client is correctly connected and authenticated.",
-    async () => {
-      const auth = getAuthenticatorFromMcpContext();
-      if (!auth) {
-        return {
-          content: [{ type: "text", text: "Not authenticated." }],
-          isError: true,
-        };
-      }
-
-      const name = auth.user()?.firstName.trim() || "there";
-      const workspaceName = auth.workspace()?.name ?? "unknown workspace";
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Hello, ${name}! You are connected to the Dust MCP server for workspace "${workspaceName}".`,
-          },
-        ],
-      };
-    }
+  const server = new McpServer(
+    {
+      name: "Dust",
+      version: "1.0",
+      description:
+        "Dust is where people and agents collaborate as co-contributors, so that work doesn't just get done – it gets rewired.",
+      websiteUrl: config.getStaticWebsiteUrl(),
+      icons: getDustMcpServerIcons(),
+    },
+    { instructions: DUST_MCP_SERVER_INSTRUCTIONS }
   );
+
+  registerDustMcpTools(server);
 
   return server;
 }

--- a/front/lib/api/mcp_server/tools/agents/index.ts
+++ b/front/lib/api/mcp_server/tools/agents/index.ts
@@ -1,0 +1,6 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerAgentsListTool } from "./list";
+
+export function registerAgentsTools(server: McpServer) {
+  registerAgentsListTool(server);
+}

--- a/front/lib/api/mcp_server/tools/agents/list.ts
+++ b/front/lib/api/mcp_server/tools/agents/list.ts
@@ -1,0 +1,79 @@
+import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
+import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import { filterAndSortAgents } from "@app/lib/utils";
+import { compareAgentsForSort } from "@app/types/assistant/assistant";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { mcpJsonResponse } from "../response";
+
+const LIST_AGENTS_PAGE_SIZE = 25;
+
+const inputSchema = {
+  name: z
+    .string()
+    .optional()
+    .describe("Optional filter on agent name (fuzzy match)."),
+  lastValue: z
+    .string()
+    .optional()
+    .describe(
+      "Cursor from a previous response's lastValue field (agent id) for the next page."
+    ),
+};
+
+export function registerAgentsListTool(server: McpServer) {
+  server.registerTool(
+    "list_agents",
+    {
+      description:
+        "List agents accessible to the authenticated user in the current workspace (25 per page). Supports cursor pagination via lastValue. Optionally filter by agent name.",
+      inputSchema,
+    },
+    async ({ name, lastValue }) => {
+      const auth = getAuthenticatorFromMcpContext();
+
+      const agents = await getAgentConfigurationsForView({
+        auth,
+        agentsGetView: "list",
+        variant: "extra_light",
+        omitInstructions: true,
+      });
+
+      const accessibleAgents = agents.filter((agent) => agent.canRead);
+
+      const sortedAgents = name
+        ? filterAndSortAgents(accessibleAgents, name)
+        : [...accessibleAgents].sort(compareAgentsForSort);
+
+      let startIndex = 0;
+      if (lastValue) {
+        const cursorIndex = sortedAgents.findIndex(
+          (agent) => agent.sId === lastValue
+        );
+        startIndex = cursorIndex === -1 ? sortedAgents.length : cursorIndex + 1;
+      }
+
+      const pageAgents = sortedAgents.slice(
+        startIndex,
+        startIndex + LIST_AGENTS_PAGE_SIZE
+      );
+      const hasMore = startIndex + LIST_AGENTS_PAGE_SIZE < sortedAgents.length;
+      const nextLastValue =
+        hasMore && pageAgents.length > 0
+          ? pageAgents[pageAgents.length - 1].sId
+          : null;
+
+      return mcpJsonResponse({
+        agents: pageAgents.map((agent) => ({
+          id: agent.sId,
+          name: agent.name,
+          description: agent.description,
+          pictureUrl: agent.pictureUrl,
+          scope: agent.scope,
+        })),
+        hasMore,
+        lastValue: nextLastValue,
+      });
+    }
+  );
+}

--- a/front/lib/api/mcp_server/tools/conversations/create.ts
+++ b/front/lib/api/mcp_server/tools/conversations/create.ts
@@ -1,0 +1,148 @@
+import { resolveAgentConfigurationIdByName } from "@app/lib/api/assistant/configuration/agent";
+import {
+  createConversation,
+  postUserMessage,
+} from "@app/lib/api/assistant/conversation";
+import config from "@app/lib/api/config";
+import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { getConversationRoute } from "@app/lib/utils/router";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { mcpError, mcpJsonResponse } from "../response";
+
+const DEFAULT_AGENT_NAME = "Dust";
+
+const inputSchema = {
+  title: z.string().describe("Title for the new conversation."),
+  podId: z
+    .string()
+    .optional()
+    .describe(
+      "Optional Pod id. When provided, the conversation is created in that Pod."
+    ),
+  message: z
+    .string()
+    .optional()
+    .describe(
+      "Optional first user message to post after creating the conversation."
+    ),
+  agentName: z
+    .string()
+    .nullable()
+    .default(DEFAULT_AGENT_NAME)
+    .describe(
+      `Agent name to mention and trigger when posting the first message. Defaults to "${DEFAULT_AGENT_NAME}". Pass null explicitly to post without triggering any agent. Only used when message is provided.`
+    ),
+};
+
+export function registerConversationsCreateTool(server: McpServer) {
+  server.registerTool(
+    "create_conversation",
+    {
+      description: `Create a new conversation in the current workspace. Optionally pass podId to create it in a Pod, and message to post the first user message in the same call (triggers the "${DEFAULT_AGENT_NAME}" agent by default; pass agentName: null to post without triggering any agent).`,
+      inputSchema,
+    },
+    async ({ title, podId, message, agentName }) => {
+      const auth = getAuthenticatorFromMcpContext();
+
+      let resolvedSpaceModelId: number | null = null;
+      let podName: string | null = null;
+
+      if (podId) {
+        const pod = await SpaceResource.fetchById(auth, podId);
+        if (!pod || !pod.isProject() || !pod.isMember(auth)) {
+          return mcpError("Pod not found or you do not have access.");
+        }
+        resolvedSpaceModelId = pod.id;
+        podName = pod.name;
+      }
+
+      let conversation;
+      try {
+        conversation = await createConversation(auth, {
+          title,
+          visibility: "unlisted",
+          spaceId: resolvedSpaceModelId,
+        });
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Failed to create conversation.";
+        return mcpError(message);
+      }
+
+      if (conversation.depth === 0) {
+        await ConversationResource.upsertParticipation(auth, {
+          conversation,
+          action: "subscribed",
+          user: auth.user().toJSON(),
+        });
+      }
+
+      const owner = auth.workspace();
+      const conversationUrl = `${config.getAppUrl()}${getConversationRoute(
+        owner.sId,
+        conversation.sId
+      )}`;
+
+      let userMessageId: string | null = null;
+      let agentMessageIds: string[] = [];
+
+      if (message) {
+        const user = auth.user();
+
+        let mentions: { configurationId: string }[] = [];
+        if (agentName !== null) {
+          const matchedAgentId = await resolveAgentConfigurationIdByName(
+            auth,
+            agentName
+          );
+          if (!matchedAgentId) {
+            return mcpError(`No agent found matching name: "${agentName}"`);
+          }
+          mentions = [{ configurationId: matchedAgentId }];
+        }
+
+        const messageRes = await postUserMessage(auth, {
+          conversation,
+          content: message,
+          mentions,
+          context: {
+            timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+            username: user.username,
+            fullName: user.fullName(),
+            email: user.email,
+            profilePictureUrl: user.imageUrl,
+            origin: "api",
+            clientSideMCPServerIds: [],
+            selectedMCPServerViewIds: [],
+            lastTriggerRunAt: null,
+          },
+          skipToolsValidation: false,
+        });
+
+        if (messageRes.isErr()) {
+          return mcpError(messageRes.error.api_error.message);
+        }
+
+        userMessageId = messageRes.value.userMessage.sId;
+        agentMessageIds = messageRes.value.agentMessages.map(
+          (agentMessage) => agentMessage.sId
+        );
+      }
+
+      return mcpJsonResponse({
+        conversationId: conversation.sId,
+        title: conversation.title,
+        podId: conversation.spaceId,
+        podName,
+        conversationUrl,
+        userMessageId,
+        agentMessageIds,
+      });
+    }
+  );
+}

--- a/front/lib/api/mcp_server/tools/conversations/create_message.ts
+++ b/front/lib/api/mcp_server/tools/conversations/create_message.ts
@@ -1,0 +1,97 @@
+import { resolveAgentConfigurationIdByName } from "@app/lib/api/assistant/configuration/agent";
+import { postUserMessage } from "@app/lib/api/assistant/conversation";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { getConversationApiError } from "@app/lib/api/assistant/conversation/helper";
+import config from "@app/lib/api/config";
+import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import { getConversationRoute } from "@app/lib/utils/router";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { mcpError, mcpJsonResponse } from "../response";
+
+const DEFAULT_AGENT_NAME = "Dust";
+
+const inputSchema = {
+  conversationId: z
+    .string()
+    .describe("ID of the conversation to post a message to."),
+  message: z.string().describe("Message content to post."),
+  agentName: z
+    .string()
+    .nullable()
+    .default(DEFAULT_AGENT_NAME)
+    .describe(
+      `Agent name to mention and trigger. Defaults to "${DEFAULT_AGENT_NAME}". Pass null explicitly to post a message without triggering any agent.`
+    ),
+};
+
+export function registerConversationsCreateMessageTool(server: McpServer) {
+  server.registerTool(
+    "create_conversation_message",
+    {
+      description: `Post a user message to an existing conversation. By default triggers the "${DEFAULT_AGENT_NAME}" agent. Pass agentName: null to post without triggering any agent.`,
+      inputSchema,
+    },
+    async ({ conversationId, message, agentName }) => {
+      const auth = getAuthenticatorFromMcpContext();
+      const user = auth.user();
+
+      const conversationRes = await getConversation(auth, conversationId);
+      if (conversationRes.isErr()) {
+        const apiError = getConversationApiError(conversationRes.error);
+        return mcpError(apiError.api_error.message);
+      }
+
+      const conversation = conversationRes.value;
+
+      let mentions: { configurationId: string }[] = [];
+      if (agentName !== null) {
+        const matchedAgentId = await resolveAgentConfigurationIdByName(
+          auth,
+          agentName
+        );
+        if (!matchedAgentId) {
+          return mcpError(`No agent found matching name: "${agentName}"`);
+        }
+        mentions = [{ configurationId: matchedAgentId }];
+      }
+
+      const messageRes = await postUserMessage(auth, {
+        conversation,
+        content: message,
+        mentions,
+        context: {
+          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+          username: user.username,
+          fullName: user.fullName(),
+          email: user.email,
+          profilePictureUrl: user.imageUrl,
+          origin: "api",
+          clientSideMCPServerIds: [],
+          selectedMCPServerViewIds: [],
+          lastTriggerRunAt: null,
+        },
+        skipToolsValidation: false,
+      });
+
+      if (messageRes.isErr()) {
+        return mcpError(messageRes.error.api_error.message);
+      }
+
+      const owner = auth.workspace();
+      const conversationUrl = `${config.getAppUrl()}${getConversationRoute(
+        owner.sId,
+        conversation.sId
+      )}`;
+
+      return mcpJsonResponse({
+        conversationId: conversation.sId,
+        conversationUrl,
+        userMessageId: messageRes.value.userMessage.sId,
+        agentMessageIds: messageRes.value.agentMessages.map(
+          (agentMessage) => agentMessage.sId
+        ),
+      });
+    }
+  );
+}

--- a/front/lib/api/mcp_server/tools/conversations/get_messages.ts
+++ b/front/lib/api/mcp_server/tools/conversations/get_messages.ts
@@ -1,0 +1,75 @@
+import { getLightConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { getConversationApiError } from "@app/lib/api/assistant/conversation/helper";
+import { renderConversationAsText } from "@app/lib/api/assistant/conversation/render_as_text";
+import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { mcpJsonResponse } from "../response";
+
+const GET_CONVERSATION_MESSAGES_PAGE_SIZE = 25;
+
+const inputSchema = {
+  conversationId: z
+    .string()
+    .describe("ID of the conversation to fetch messages from."),
+  lastValue: z
+    .number()
+    .int()
+    .optional()
+    .describe(
+      "Cursor from a previous response's lastValue field (message rank) for the next page."
+    ),
+};
+
+export function registerConversationsGetMessagesTool(server: McpServer) {
+  server.registerTool(
+    "get_conversation_messages",
+    {
+      description:
+        "Fetch a paginated page of messages from a conversation (25 per page, most recent first). Returns human-readable message text. Use lastValue to load older messages.",
+      inputSchema,
+    },
+    async ({ conversationId, lastValue }) => {
+      const auth = getAuthenticatorFromMcpContext();
+
+      const conversationRes = await getLightConversation(
+        auth,
+        conversationId,
+        false,
+        null,
+        null,
+        {
+          limit: GET_CONVERSATION_MESSAGES_PAGE_SIZE,
+          lastRank: lastValue ?? null,
+        }
+      );
+
+      if (conversationRes.isErr()) {
+        const apiError = getConversationApiError(conversationRes.error);
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: apiError.api_error.message,
+            },
+          ],
+          isError: true as const,
+        };
+      }
+
+      const conversation = conversationRes.value;
+
+      return mcpJsonResponse({
+        conversationId: conversation.sId,
+        title: conversation.title,
+        messages: renderConversationAsText(conversation, {
+          includeTimestamps: true,
+          includeEmail: true,
+          includeUnread: true,
+        }),
+        hasMore: conversation.hasMore ?? false,
+        lastValue: conversation.lastValue ?? null,
+      });
+    }
+  );
+}

--- a/front/lib/api/mcp_server/tools/conversations/index.ts
+++ b/front/lib/api/mcp_server/tools/conversations/index.ts
@@ -1,0 +1,12 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerConversationsCreateTool } from "./create";
+import { registerConversationsCreateMessageTool } from "./create_message";
+import { registerConversationsGetMessagesTool } from "./get_messages";
+import { registerConversationsListTool } from "./list";
+
+export function registerConversationsTools(server: McpServer) {
+  registerConversationsListTool(server);
+  registerConversationsCreateTool(server);
+  registerConversationsCreateMessageTool(server);
+  registerConversationsGetMessagesTool(server);
+}

--- a/front/lib/api/mcp_server/tools/conversations/list.ts
+++ b/front/lib/api/mcp_server/tools/conversations/list.ts
@@ -1,0 +1,120 @@
+import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { mcpError, mcpJsonResponse } from "../response";
+
+const LIST_CONVERSATIONS_PAGE_SIZE = 25;
+const LIST_CONVERSATIONS_ORDER_DIRECTION = "desc" as const;
+
+const inputSchema = {
+  podId: z
+    .string()
+    .optional()
+    .describe(
+      "Optional Pod id. When provided, lists conversations in that Pod instead of all user conversations."
+    ),
+  lastValue: z
+    .string()
+    .optional()
+    .describe(
+      "Cursor from a previous response's lastValue field for the next page."
+    ),
+  orderDirection: z
+    .enum(["asc", "desc"])
+    .optional()
+    .describe(
+      "Sort direction by updatedAt (default desc, most recently updated first)."
+    ),
+};
+
+export function registerConversationsListTool(server: McpServer) {
+  server.registerTool(
+    "list_conversations",
+    {
+      description:
+        "List conversations for the authenticated user in the current workspace (25 per page), sorted by most recently updated. Supports cursor pagination via lastValue. When podId is provided, lists conversations in that Pod instead.",
+      inputSchema,
+    },
+    async ({ podId, lastValue, orderDirection }) => {
+      const auth = getAuthenticatorFromMcpContext();
+
+      const resolvedOrderDirection =
+        orderDirection ?? LIST_CONVERSATIONS_ORDER_DIRECTION;
+
+      if (podId) {
+        const pod = await SpaceResource.fetchById(auth, podId);
+        if (!pod || !pod.isProject() || !pod.canReadOrAdministrate(auth)) {
+          return mcpError("Pod not found or you do not have access.");
+        }
+
+        const spaceConversations =
+          await ConversationResource.listConversationsInSpace(auth, {
+            spaceId: podId,
+            options: { excludeTest: true },
+          });
+
+        const sortedConversations =
+          resolvedOrderDirection === "asc"
+            ? [...spaceConversations].reverse()
+            : spaceConversations;
+
+        let startIndex = 0;
+        if (lastValue) {
+          const cursorMs = Number.parseInt(lastValue, 10);
+          if (!Number.isNaN(cursorMs)) {
+            const cursorIndex = sortedConversations.findIndex(
+              (conversation) => {
+                const updated = conversation.toJSON().updated;
+                return resolvedOrderDirection === "desc"
+                  ? updated < cursorMs
+                  : updated > cursorMs;
+              }
+            );
+            startIndex =
+              cursorIndex === -1 ? sortedConversations.length : cursorIndex;
+          }
+        }
+
+        const pageConversations = sortedConversations.slice(
+          startIndex,
+          startIndex + LIST_CONVERSATIONS_PAGE_SIZE
+        );
+        const hasMore =
+          startIndex + LIST_CONVERSATIONS_PAGE_SIZE <
+          sortedConversations.length;
+        const lastPageUpdated =
+          pageConversations.length > 0
+            ? pageConversations[pageConversations.length - 1].toJSON().updated
+            : null;
+        const nextLastValue =
+          hasMore && lastPageUpdated !== null ? String(lastPageUpdated) : null;
+
+        return mcpJsonResponse({
+          conversations: pageConversations.map((conversation) =>
+            conversation.toListItem()
+          ),
+          hasMore,
+          lastValue: nextLastValue,
+        });
+      }
+
+      const result =
+        await ConversationResource.listPrivateConversationsForUserPaginatedFromDB(
+          auth,
+          {
+            limit: LIST_CONVERSATIONS_PAGE_SIZE,
+            lastValue,
+            orderDirection: resolvedOrderDirection,
+          }
+        );
+
+      return mcpJsonResponse({
+        conversations: result.conversations,
+        hasMore: result.hasMore,
+        lastValue: result.lastValue,
+      });
+    }
+  );
+}

--- a/front/lib/api/mcp_server/tools/files/cat.ts
+++ b/front/lib/api/mcp_server/tools/files/cat.ts
@@ -1,0 +1,200 @@
+import { FILE_OFFLOAD_TEXT_SIZE_BYTES } from "@app/lib/actions/action_output_limits";
+import {
+  CAT_LINES_DEFAULT,
+  CAT_LINES_MAX,
+} from "@app/lib/api/actions/servers/files/metadata";
+import { isReadableAsText } from "@app/lib/api/actions/servers/files/tools/utils";
+import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import { isLLMVisionSupportedImageContentType } from "@app/types/files";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import * as readline from "readline";
+import type { Readable } from "stream";
+import { z } from "zod";
+import { mcpError, mcpJsonResponse } from "../response";
+import { getDustFileSystemForScope, validatePathMatchesScope } from "./context";
+import { FILES_SCOPE_SCHEMA } from "./schemas";
+
+const CAT_IMAGE_MAX_BYTES = 2 * 1024 * 1024;
+
+const inputSchema = {
+  scope: FILES_SCOPE_SCHEMA.describe(
+    "File system scope matching the path's conversation or Pod."
+  ),
+  path: z
+    .string()
+    .describe(
+      "Scoped file path as returned by `files_list` (e.g. `conversation-<id>/data.csv` or `pod-<id>/notes.md`)."
+    ),
+  offset: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe("Line number to start reading from (1-indexed, default 1)."),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(CAT_LINES_MAX)
+    .optional()
+    .describe(
+      `Maximum number of lines to return (default ${CAT_LINES_DEFAULT}, max ${CAT_LINES_MAX}).`
+    ),
+};
+
+async function readTextFilePage(
+  stream: Readable,
+  path: string,
+  startLine: number,
+  maxLines: number,
+  fileSizeBytes: number
+): Promise<string> {
+  const lines: string[] = [];
+  let lineNumber = 0;
+  let byteCount = 0;
+  let byteCapped = false;
+  let totalLines = 0;
+
+  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+
+  try {
+    for await (const line of rl) {
+      lineNumber++;
+
+      if (lineNumber < startLine) {
+        continue;
+      }
+
+      totalLines++;
+
+      const lineWithNumber = `${lineNumber}: ${line}`;
+      const lineBytes = Buffer.byteLength(lineWithNumber + "\n", "utf8");
+
+      if (byteCount + lineBytes > FILE_OFFLOAD_TEXT_SIZE_BYTES) {
+        if (lines.length === 0) {
+          const truncated = Buffer.from(lineWithNumber, "utf8")
+            .slice(0, FILE_OFFLOAD_TEXT_SIZE_BYTES)
+            .toString("utf8");
+          lines.push(truncated);
+        }
+        byteCapped = true;
+        break;
+      }
+
+      lines.push(lineWithNumber);
+      byteCount += lineBytes;
+
+      if (totalLines >= maxLines) {
+        break;
+      }
+    }
+  } finally {
+    rl.close();
+  }
+
+  if (lines.length === 0) {
+    if (startLine > 1) {
+      return `No lines found at offset ${startLine} in \`${path}\`.`;
+    }
+    return `\`${path}\` is empty.`;
+  }
+
+  const endLine = startLine + lines.length - 1;
+  let text = lines.join("\n");
+
+  const kb = FILE_OFFLOAD_TEXT_SIZE_BYTES / 1024;
+  const fileSizeKb = Math.ceil(fileSizeBytes / 1024);
+
+  if (byteCapped) {
+    text +=
+      `\n\n[Truncated at ${kb}KB. File is ${fileSizeKb}KB.` +
+      ` Showing lines ${startLine}-${endLine}.` +
+      ` Use offset=${endLine + 1} to read more.]`;
+  } else if (totalLines >= maxLines) {
+    text += `\n\n[Showing lines ${startLine}-${endLine}. Use offset=${endLine + 1} to read more.]`;
+  }
+
+  return text;
+}
+
+export function registerFilesCatTool(server: McpServer) {
+  server.registerTool(
+    "files_cat",
+    {
+      description:
+        "Read the content of a file. For text files, returns numbered lines. Use `offset` and `limit` to paginate. " +
+        "For binary sources, prefer the `*.processed.<ext>` sibling from `files_list`. " +
+        "Requires an explicit scope with conversation_id or pod_id.",
+      inputSchema,
+    },
+    async ({ scope, path, offset, limit }) => {
+      const auth = getAuthenticatorFromMcpContext();
+
+      const pathError = validatePathMatchesScope(path, scope);
+      if (pathError) {
+        return mcpError(pathError);
+      }
+
+      const fsResult = await getDustFileSystemForScope(auth, scope);
+      if (fsResult.isErr()) {
+        return mcpError(fsResult.error);
+      }
+      const dustFs = fsResult.value;
+
+      const statResult = await dustFs.stat(path);
+      if (statResult.isErr()) {
+        return mcpError(statResult.error.message);
+      }
+      if (statResult.value === null) {
+        return mcpError(`File not found: \`${path}\`.`);
+      }
+
+      const { contentType: mimeType, sizeBytes } = statResult.value;
+
+      if (isLLMVisionSupportedImageContentType(mimeType)) {
+        if (sizeBytes > CAT_IMAGE_MAX_BYTES) {
+          return mcpJsonResponse({
+            text:
+              `\`${path}\` is an image (${Math.ceil(sizeBytes / 1024)} KB) ` +
+              `that exceeds the ${CAT_IMAGE_MAX_BYTES / 1024} KB limit and cannot be displayed via MCP.`,
+          });
+        }
+        return mcpJsonResponse({
+          text: `\`${path}\` is an image (${mimeType}, ${Math.ceil(sizeBytes / 1024)} KB). Image binary content is not returned via MCP.`,
+          path,
+          mimeType,
+        });
+      }
+
+      if (!isReadableAsText(mimeType)) {
+        return mcpJsonResponse({
+          text: `\`${path}\` is a binary file (${mimeType}) and cannot be read as text.`,
+        });
+      }
+
+      const readResult = await dustFs.read(path);
+      if (readResult.isErr()) {
+        return mcpError(readResult.error.message);
+      }
+      if (readResult.value === null) {
+        return mcpError(`File not found: \`${path}\`.`);
+      }
+
+      try {
+        const text = await readTextFilePage(
+          readResult.value,
+          path,
+          offset ?? 1,
+          limit ?? CAT_LINES_DEFAULT,
+          sizeBytes
+        );
+        return mcpJsonResponse({ text });
+      } catch (err) {
+        return mcpError(
+          `Failed to read file \`${path}\`: ${normalizeError(err).message}`
+        );
+      }
+    }
+  );
+}

--- a/front/lib/api/mcp_server/tools/files/context.ts
+++ b/front/lib/api/mcp_server/tools/files/context.ts
@@ -1,0 +1,67 @@
+import {
+  DustFileSystem,
+  SCOPED_PREFIX_CONVERSATION,
+  SCOPED_PREFIX_POD,
+} from "@app/lib/api/file_system";
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import type { FilesScope } from "./schemas";
+
+export function scopedPrefixForScope(scope: FilesScope): string {
+  if (scope.type === "conversation") {
+    return `${SCOPED_PREFIX_CONVERSATION}${scope.conversation_id}/`;
+  }
+  return `${SCOPED_PREFIX_POD}${scope.pod_id}/`;
+}
+
+export function validatePathMatchesScope(
+  path: string,
+  scope: FilesScope
+): string | null {
+  const expectedPrefix = scopedPrefixForScope(scope);
+  if (!path.startsWith(expectedPrefix)) {
+    return `Path must start with \`${expectedPrefix}\` for the given scope.`;
+  }
+  return null;
+}
+
+export async function getDustFileSystemForScope(
+  auth: Authenticator,
+  scope: FilesScope
+): Promise<Result<DustFileSystem, string>> {
+  if (scope.type === "conversation") {
+    const conversationRes =
+      await ConversationResource.fetchConversationWithoutContent(
+        auth,
+        scope.conversation_id
+      );
+    if (conversationRes.isErr()) {
+      return new Err(
+        `Conversation not found or not accessible: ${scope.conversation_id}`
+      );
+    }
+
+    const fsResult = await DustFileSystem.forConversation(
+      auth,
+      conversationRes.value
+    );
+    if (fsResult.isErr()) {
+      return new Err(fsResult.error.message);
+    }
+    return new Ok(fsResult.value);
+  }
+
+  const pod = await SpaceResource.fetchById(auth, scope.pod_id);
+  if (!pod || !pod.isProject() || !pod.canRead(auth)) {
+    return new Err(`Pod not found or you do not have access: ${scope.pod_id}`);
+  }
+
+  const fsResult = await DustFileSystem.forPod(auth, pod);
+  if (fsResult.isErr()) {
+    return new Err(fsResult.error.message);
+  }
+  return new Ok(fsResult.value);
+}

--- a/front/lib/api/mcp_server/tools/files/create.ts
+++ b/front/lib/api/mcp_server/tools/files/create.ts
@@ -1,0 +1,106 @@
+import { CREATE_CONTENT_MAX_BYTES } from "@app/lib/api/actions/servers/files/metadata";
+import {
+  frameFileCreateRejectedError,
+  frameFileEditRejectedError,
+} from "@app/lib/api/actions/servers/files/tools/utils";
+import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import {
+  isInteractiveContentType,
+  stripMimeParameters,
+} from "@app/types/files";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { mcpError, mcpJsonResponse } from "../response";
+import { getDustFileSystemForScope, validatePathMatchesScope } from "./context";
+import { FILES_SCOPE_SCHEMA } from "./schemas";
+
+const inputSchema = {
+  scope: FILES_SCOPE_SCHEMA.describe(
+    "File system scope matching the path's conversation or Pod."
+  ),
+  path: z
+    .string()
+    .describe(
+      "Scoped file path for the new file (e.g. `conversation-<id>/output.json` or `pod-<id>/reports/summary.txt`)."
+    ),
+  content: z.string().describe("UTF-8 text content to write."),
+  content_type: z
+    .string()
+    .describe(
+      "MIME content type (e.g. `text/plain`, `application/json`, `text/csv`, `text/markdown`)."
+    ),
+};
+
+export function registerFilesCreateTool(server: McpServer) {
+  server.registerTool(
+    "files_create",
+    {
+      description:
+        "Create or overwrite a UTF-8 text file in a conversation or Pod file system. " +
+        `Content is capped at ${CREATE_CONTENT_MAX_BYTES / 1024} KB. Overwrites existing files. ` +
+        "Requires an explicit scope with conversation_id or pod_id.",
+      inputSchema,
+    },
+    async ({ scope, path, content, content_type }) => {
+      const auth = getAuthenticatorFromMcpContext();
+
+      const pathError = validatePathMatchesScope(path, scope);
+      if (pathError) {
+        return mcpError(pathError);
+      }
+
+      const contentBuffer = Buffer.from(content, "utf8");
+      if (contentBuffer.byteLength > CREATE_CONTENT_MAX_BYTES) {
+        return mcpError(
+          `Content exceeds the ${CREATE_CONTENT_MAX_BYTES / 1024} KB limit.`
+        );
+      }
+
+      const fsResult = await getDustFileSystemForScope(auth, scope);
+      if (fsResult.isErr()) {
+        return mcpError(fsResult.error);
+      }
+      const dustFs = fsResult.value;
+
+      const incomingMimeType = stripMimeParameters(content_type);
+      if (isInteractiveContentType(incomingMimeType)) {
+        return mcpError(frameFileCreateRejectedError().message);
+      }
+
+      const statResult = await dustFs.stat(path);
+      const exists = statResult.isOk() && statResult.value !== null;
+
+      if (statResult.isOk() && statResult.value !== null) {
+        const existingMimeType = stripMimeParameters(
+          statResult.value.contentType
+        );
+        if (isInteractiveContentType(existingMimeType)) {
+          return mcpError(frameFileEditRejectedError().message);
+        }
+      }
+
+      const writeResult = await dustFs.write(path, contentBuffer, content_type);
+      if (writeResult.isErr()) {
+        const err = writeResult.error;
+        switch (err.code) {
+          case "legacy_path":
+          case "unauthorized":
+            return mcpError(err.message);
+          case "invalid_path":
+            return mcpError(`Invalid path: \`${path}\`.`);
+          default:
+            return mcpError(`Failed to write file \`${path}\`: ${err.message}`);
+        }
+      }
+
+      const sizeKb = Math.ceil(contentBuffer.byteLength / 1024);
+      const verb = exists ? "Updated" : "Created";
+
+      return mcpJsonResponse({
+        message: `${verb} \`${path}\` (${content_type}, ${sizeKb} KB)`,
+        path,
+        contentType: content_type,
+      });
+    }
+  );
+}

--- a/front/lib/api/mcp_server/tools/files/grep.ts
+++ b/front/lib/api/mcp_server/tools/files/grep.ts
@@ -1,0 +1,132 @@
+import { GREP_MATCHES_MAX } from "@app/lib/api/actions/servers/files/metadata";
+import { isReadableAsText } from "@app/lib/api/actions/servers/files/tools/utils";
+import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import * as readline from "readline";
+import { z } from "zod";
+import { mcpError, mcpJsonResponse } from "../response";
+import { getDustFileSystemForScope, validatePathMatchesScope } from "./context";
+import { FILES_SCOPE_SCHEMA } from "./schemas";
+
+const inputSchema = {
+  scope: FILES_SCOPE_SCHEMA.describe(
+    "File system scope matching the path's conversation or Pod."
+  ),
+  path: z
+    .string()
+    .describe(
+      "Scoped file path as returned by `files_list` (e.g. `conversation-<id>/data.csv`)."
+    ),
+  pattern: z
+    .string()
+    .describe(
+      "Regular expression to search for (case-sensitive; use `(?i)` prefix for case-insensitive)."
+    ),
+};
+
+export function registerFilesGrepTool(server: McpServer) {
+  server.registerTool(
+    "files_grep",
+    {
+      description:
+        "Search a text file for lines matching a regular expression. " +
+        `Results are capped at ${GREP_MATCHES_MAX} matches. Use \`files_cat\` with a line offset to read surrounding context. ` +
+        "Requires an explicit scope with conversation_id or pod_id.",
+      inputSchema,
+    },
+    async ({ scope, path, pattern }) => {
+      const auth = getAuthenticatorFromMcpContext();
+
+      const pathError = validatePathMatchesScope(path, scope);
+      if (pathError) {
+        return mcpError(pathError);
+      }
+
+      const fsResult = await getDustFileSystemForScope(auth, scope);
+      if (fsResult.isErr()) {
+        return mcpError(fsResult.error);
+      }
+      const dustFs = fsResult.value;
+
+      const statResult = await dustFs.stat(path);
+      if (statResult.isErr()) {
+        return mcpError(statResult.error.message);
+      }
+      if (statResult.value === null) {
+        return mcpError(`File not found: \`${path}\`.`);
+      }
+
+      const { contentType: mimeType } = statResult.value;
+
+      if (!isReadableAsText(mimeType)) {
+        return mcpJsonResponse({
+          text:
+            `\`${path}\` is not a text file (${mimeType}) ` +
+            `and cannot be searched with grep.`,
+        });
+      }
+
+      let regex: RegExp;
+      try {
+        regex = new RegExp(pattern, "m");
+      } catch (err) {
+        return mcpError(
+          `Invalid regular expression: \`${pattern}\`. Error: ${normalizeError(err).message}`
+        );
+      }
+
+      const readResult = await dustFs.read(path);
+      if (readResult.isErr()) {
+        return mcpError(readResult.error.message);
+      }
+      if (readResult.value === null) {
+        return mcpError(`File not found: \`${path}\`.`);
+      }
+
+      const matches: string[] = [];
+      let lineNumber = 0;
+      let capped = false;
+
+      const rl = readline.createInterface({
+        input: readResult.value,
+        crlfDelay: Infinity,
+      });
+
+      try {
+        for await (const line of rl) {
+          lineNumber++;
+
+          if (regex.test(line)) {
+            matches.push(`${lineNumber}: ${line}`);
+
+            if (matches.length >= GREP_MATCHES_MAX) {
+              capped = true;
+              rl.close();
+              break;
+            }
+          }
+        }
+      } catch (err) {
+        return mcpError(
+          `Failed to read file \`${path}\`: ${normalizeError(err).message}`
+        );
+      }
+
+      if (matches.length === 0) {
+        return mcpJsonResponse({
+          text: `No lines matched \`${pattern}\` in \`${path}\`.`,
+        });
+      }
+
+      let text = matches.join("\n");
+      if (capped) {
+        text += `\n\n[Showing first ${GREP_MATCHES_MAX} matches. Refine your pattern or use \`files_cat\` with a line offset to read a specific section.]`;
+      } else {
+        text += `\n\n[${matches.length} match${matches.length === 1 ? "" : "es"} found]`;
+      }
+
+      return mcpJsonResponse({ text });
+    }
+  );
+}

--- a/front/lib/api/mcp_server/tools/files/index.ts
+++ b/front/lib/api/mcp_server/tools/files/index.ts
@@ -1,0 +1,14 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerFilesCatTool } from "./cat";
+import { registerFilesCreateTool } from "./create";
+import { registerFilesGrepTool } from "./grep";
+import { registerFilesListTool } from "./list";
+import { registerFilesResolveTool } from "./resolve";
+
+export function registerFilesTools(server: McpServer) {
+  registerFilesListTool(server);
+  registerFilesCatTool(server);
+  registerFilesCreateTool(server);
+  registerFilesGrepTool(server);
+  registerFilesResolveTool(server);
+}

--- a/front/lib/api/mcp_server/tools/files/list.ts
+++ b/front/lib/api/mcp_server/tools/files/list.ts
@@ -1,0 +1,41 @@
+import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { mcpError, mcpJsonResponse } from "../response";
+import { getDustFileSystemForScope, scopedPrefixForScope } from "./context";
+import { formatFileListOutput } from "./list_output";
+import { FILES_SCOPE_SCHEMA } from "./schemas";
+
+const inputSchema = {
+  scope: FILES_SCOPE_SCHEMA.describe(
+    'File system scope: `{ type: "conversation", conversation_id: "..." }` or `{ type: "pod", pod_id: "..." }`.'
+  ),
+};
+
+export function registerFilesListTool(server: McpServer) {
+  server.registerTool(
+    "files_list",
+    {
+      description:
+        "List files in the Dust file system. Returns scoped paths (e.g. `conversation-<id>/chart.png`, `pod-<id>/spec.md`), content types, and sizes. " +
+        "Some files have a `*.processed.<ext>` sibling with extracted text or transcripts for binary sources. " +
+        "Requires an explicit conversation_id or pod_id.",
+      inputSchema,
+    },
+    async ({ scope }) => {
+      const auth = getAuthenticatorFromMcpContext();
+
+      const fsResult = await getDustFileSystemForScope(auth, scope);
+      if (fsResult.isErr()) {
+        return mcpError(fsResult.error);
+      }
+
+      const text = await formatFileListOutput(
+        auth,
+        fsResult.value,
+        scopedPrefixForScope(scope)
+      );
+
+      return mcpJsonResponse({ text });
+    }
+  );
+}

--- a/front/lib/api/mcp_server/tools/files/list_output.ts
+++ b/front/lib/api/mcp_server/tools/files/list_output.ts
@@ -1,0 +1,119 @@
+import type { DustFileSystem } from "@app/lib/api/file_system";
+import type {
+  FileSystemEntry,
+  FileSystemFileEntry,
+} from "@app/lib/api/file_system/types";
+import { enrichListWithFileResourceIds } from "@app/lib/api/files/file_system_ops";
+import { parseProcessedFilename } from "@app/lib/api/files/mount_path";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  isInteractiveContentType,
+  stripMimeParameters,
+} from "@app/types/files";
+import partition from "lodash/partition";
+
+function getDirAndFileName(path: string): { dir: string; fileName: string } {
+  const lastSlash = path.lastIndexOf("/");
+  if (lastSlash < 0) {
+    return { dir: "", fileName: path };
+  }
+
+  return {
+    dir: path.substring(0, lastSlash),
+    fileName: path.substring(lastSlash + 1),
+  };
+}
+
+export async function formatFileListOutput(
+  auth: Authenticator,
+  dustFs: DustFileSystem,
+  scopedPrefix: string
+): Promise<string> {
+  const entries = await enrichListWithFileResourceIds(
+    auth,
+    dustFs,
+    await dustFs.list(scopedPrefix, { includeProcessed: true })
+  );
+
+  const [dirs, rawFiles] = partition(entries, (e) => e.isDirectory);
+  const files = rawFiles.filter(
+    (e): e is FileSystemFileEntry => !e.isDirectory
+  );
+
+  if (dirs.length === 0 && files.length === 0) {
+    return "No files available.";
+  }
+
+  return formatFileEntries(dirs, files);
+}
+
+function formatFileEntries(
+  dirs: FileSystemEntry[],
+  files: FileSystemFileEntry[]
+): string {
+  const nonEmptyDirPaths = new Set<string>();
+  for (const file of files) {
+    const parts = file.path.split("/");
+    for (let i = 1; i < parts.length - 1; i++) {
+      nonEmptyDirPaths.add(parts.slice(0, i + 1).join("/"));
+    }
+  }
+
+  const sourcePathByKey = new Map<string, string>();
+  for (const file of files) {
+    const { dir, fileName } = getDirAndFileName(file.path);
+    if (parseProcessedFilename(fileName).isProcessed) {
+      continue;
+    }
+    const lastDot = fileName.lastIndexOf(".");
+    const base = lastDot > 0 ? fileName.substring(0, lastDot) : fileName;
+    sourcePathByKey.set(`${dir}/${base}`, file.path);
+  }
+
+  const annotated = files.map((file) => {
+    const { dir, fileName } = getDirAndFileName(file.path);
+    const parsed = parseProcessedFilename(fileName);
+    if (!parsed.isProcessed) {
+      return { file, sortKey: file.path, tieBreak: 0, sourcePath: null };
+    }
+
+    const sourcePath =
+      sourcePathByKey.get(`${dir}/${parsed.sourceBaseName}`) ?? null;
+
+    return {
+      file,
+      sortKey: sourcePath ?? file.path,
+      tieBreak: sourcePath ? 1 : 0,
+      sourcePath,
+    };
+  });
+
+  annotated.sort(
+    (a, b) => a.sortKey.localeCompare(b.sortKey) || a.tieBreak - b.tieBreak
+  );
+
+  const lines: string[] = [];
+
+  for (const dir of dirs) {
+    if (!nonEmptyDirPaths.has(dir.path)) {
+      lines.push(`${dir.path}/ [empty directory]`);
+    }
+  }
+
+  for (const { file, sourcePath } of annotated) {
+    const mimeType = stripMimeParameters(file.contentType);
+    const kb = Math.ceil(file.sizeBytes / 1024);
+    const annotation = sourcePath
+      ? ` (processed version of ${sourcePath})`
+      : "";
+    const fileIdSuffix =
+      isInteractiveContentType(mimeType) && file.fileId
+        ? ` [id: ${file.fileId}]`
+        : "";
+    lines.push(
+      `${file.path} (${mimeType}, ${kb} KB)${fileIdSuffix}${annotation}`
+    );
+  }
+
+  return lines.join("\n");
+}

--- a/front/lib/api/mcp_server/tools/files/resolve.ts
+++ b/front/lib/api/mcp_server/tools/files/resolve.ts
@@ -1,0 +1,120 @@
+import {
+  SCOPED_PREFIX_CONVERSATION,
+  SCOPED_PREFIX_POD,
+} from "@app/lib/api/file_system";
+import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import { FileResource } from "@app/lib/resources/file_resource";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { mcpError, mcpJsonResponse } from "../response";
+import { getDustFileSystemForScope } from "./context";
+import type { FilesScope } from "./schemas";
+import { FILES_SCOPE_SCHEMA } from "./schemas";
+
+function gcsPathToCanonical(
+  workspace: LightWorkspaceType,
+  mountFilePath: string
+): string | null {
+  const base = `w/${workspace.sId}/`;
+  if (!mountFilePath.startsWith(base)) {
+    return null;
+  }
+
+  const rest = mountFilePath.slice(base.length);
+
+  const conv = rest.match(/^conversations\/([^/]+)\/files\/(.+)$/);
+  if (conv) {
+    return `${SCOPED_PREFIX_CONVERSATION}${conv[1]}/${conv[2]}`;
+  }
+
+  const pod =
+    rest.match(/^pods\/([^/]+)\/files\/(.+)$/) ??
+    rest.match(/^projects\/([^/]+)\/files\/(.+)$/);
+  if (pod) {
+    return `${SCOPED_PREFIX_POD}${pod[1]}/${pod[2]}`;
+  }
+
+  return null;
+}
+
+function scopeMatchesCanonicalPath(
+  scope: FilesScope,
+  canonicalPath: string
+): boolean {
+  if (scope.type === "conversation") {
+    return canonicalPath.startsWith(
+      `${SCOPED_PREFIX_CONVERSATION}${scope.conversation_id}/`
+    );
+  }
+  return canonicalPath.startsWith(`${SCOPED_PREFIX_POD}${scope.pod_id}/`);
+}
+
+const inputSchema = {
+  scope: FILES_SCOPE_SCHEMA.describe(
+    "File system scope for the conversation or Pod that owns the file."
+  ),
+  file_id: z
+    .string()
+    .describe(
+      "File identifier starting with `fil_` (e.g. `fil_abc123def456`)."
+    ),
+};
+
+export function registerFilesResolveTool(server: McpServer) {
+  server.registerTool(
+    "files_resolve",
+    {
+      description:
+        "Resolve a file ID (e.g. `fil_abc123`) to its scoped file system path " +
+        "(e.g. `conversation-<id>/report.pdf` or `pod-<id>/data.csv`) for use with `files_cat` or `files_grep`. " +
+        "Requires an explicit scope with conversation_id or pod_id.",
+      inputSchema,
+    },
+    async ({ scope, file_id }) => {
+      const auth = getAuthenticatorFromMcpContext();
+
+      const file = await FileResource.fetchById(auth, file_id);
+      if (!file) {
+        return mcpError(`File not found: \`${file_id}\`.`);
+      }
+
+      if (!file.mountFilePath) {
+        return mcpError(
+          `File \`${file_id}\` is not accessible through the file system.`
+        );
+      }
+
+      const workspace = auth.workspace();
+      const canonicalPath = gcsPathToCanonical(workspace, file.mountFilePath);
+      if (!canonicalPath) {
+        return mcpError(
+          `File \`${file_id}\` is not accessible through the file system (use case: ${file.useCase}).`
+        );
+      }
+
+      if (!scopeMatchesCanonicalPath(scope, canonicalPath)) {
+        return mcpError(
+          `File \`${file_id}\` does not belong to the given scope. Resolved path: \`${canonicalPath}\`.`
+        );
+      }
+
+      const fsResult = await getDustFileSystemForScope(auth, scope);
+      if (fsResult.isErr()) {
+        return mcpError(fsResult.error);
+      }
+
+      const statResult = await fsResult.value.stat(canonicalPath);
+      if (statResult.isErr()) {
+        return mcpError(statResult.error.message);
+      }
+      if (!statResult.value) {
+        return mcpError(
+          `File \`${file_id}\` is not accessible through the file system.`
+        );
+      }
+
+      return mcpJsonResponse({ path: canonicalPath });
+    }
+  );
+}

--- a/front/lib/api/mcp_server/tools/files/schemas.ts
+++ b/front/lib/api/mcp_server/tools/files/schemas.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const FILES_SCOPE_SCHEMA = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("conversation"),
+    conversation_id: z
+      .string()
+      .describe("Conversation id whose file system to use."),
+  }),
+  z.object({
+    type: z.literal("pod"),
+    pod_id: z.string().describe("Pod id whose file system to use."),
+  }),
+]);
+
+export type FilesScope = z.infer<typeof FILES_SCOPE_SCHEMA>;

--- a/front/lib/api/mcp_server/tools/identity.ts
+++ b/front/lib/api/mcp_server/tools/identity.ts
@@ -1,0 +1,27 @@
+import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { mcpJsonResponse } from "./response";
+
+export function registerIdentityTool(server: McpServer) {
+  server.registerTool(
+    "identity",
+    {
+      description:
+        "Returns information about the authenticated user and workspace.",
+    },
+    async () => {
+      const auth = getAuthenticatorFromMcpContext();
+      const user = auth.user();
+      const workspace = auth.workspace();
+
+      const name = user.firstName.trim() || "there";
+      const workspaceName = workspace.name ?? "unknown workspace";
+      return mcpJsonResponse({
+        id: user.sId,
+        name,
+        workspaceId: workspace.sId,
+        workspaceName,
+      });
+    }
+  );
+}

--- a/front/lib/api/mcp_server/tools/index.ts
+++ b/front/lib/api/mcp_server/tools/index.ts
@@ -1,0 +1,16 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerAgentsTools } from "./agents";
+import { registerConversationsTools } from "./conversations";
+import { registerFilesTools } from "./files";
+import { registerIdentityTool } from "./identity";
+import { registerPodsTools } from "./pods";
+import { registerSearchTools } from "./search";
+
+export function registerDustMcpTools(server: McpServer) {
+  registerIdentityTool(server);
+  registerAgentsTools(server);
+  registerConversationsTools(server);
+  registerPodsTools(server);
+  registerSearchTools(server);
+  registerFilesTools(server);
+}

--- a/front/lib/api/mcp_server/tools/pods/get.ts
+++ b/front/lib/api/mcp_server/tools/pods/get.ts
@@ -1,0 +1,70 @@
+import { isContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
+import config from "@app/lib/api/config";
+import { DustFileSystem, SCOPED_PREFIX_POD } from "@app/lib/api/file_system";
+import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import { listProjectContextAttachments } from "@app/lib/api/projects/context";
+import { listNonArchivedMemberSpacesWithMetadata } from "@app/lib/api/projects/list";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { getPodRoute } from "@app/lib/utils/router";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { mcpError, mcpJsonResponse } from "../response";
+
+const inputSchema = {
+  podId: z.string().describe("Pod id to fetch information for."),
+};
+
+export function registerPodsGetTool(server: McpServer) {
+  server.registerTool(
+    "get_pod",
+    {
+      description:
+        "Get information about a Pod: title, description, URL, pinned frame, linked content nodes, and file count.",
+      inputSchema,
+    },
+    async ({ podId }) => {
+      const auth = getAuthenticatorFromMcpContext();
+      const owner = auth.workspace();
+      const { nonArchivedSpaces } =
+        await listNonArchivedMemberSpacesWithMetadata(auth);
+      const pod = nonArchivedSpaces.find(
+        (space) => space.isProject() && space.sId === podId
+      );
+
+      if (!pod) {
+        return mcpError("Pod not found or you do not have access.");
+      }
+
+      const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
+      const attachments = await listProjectContextAttachments(auth, pod);
+      const contentNodes = attachments
+        .filter(isContentNodeAttachmentType)
+        .map((node) => ({
+          name: node.title,
+          nodeId: node.nodeId,
+          dataSourceViewId: node.nodeDataSourceViewId,
+        }));
+
+      const fsResult = await DustFileSystem.forPod(auth, pod);
+      if (fsResult.isErr()) {
+        return mcpError("Failed to initialise file system for this Pod.");
+      }
+      const podFiles = await fsResult.value.list(
+        `${SCOPED_PREFIX_POD}${pod.sId}`
+      );
+      const fileCount = podFiles.filter((entry) => !entry.isDirectory).length;
+
+      return mcpJsonResponse({
+        pod: {
+          id: pod.sId,
+          name: pod.name,
+          url: `${config.getAppUrl()}${getPodRoute(owner.sId, pod.sId)}`,
+          description: metadata?.description ?? null,
+          pinnedFramePath: metadata?.pinnedFramePath ?? null,
+          contentNodes,
+          fileCount,
+        },
+      });
+    }
+  );
+}

--- a/front/lib/api/mcp_server/tools/pods/get_tasks.ts
+++ b/front/lib/api/mcp_server/tools/pods/get_tasks.ts
@@ -1,0 +1,109 @@
+import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import { listNonArchivedMemberSpacesWithMetadata } from "@app/lib/api/projects/list";
+import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { mcpError, mcpJsonResponse } from "../response";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+const inputSchema = {
+  podId: z.string().describe("Pod id to list tasks for."),
+  assigneeFilter: z
+    .enum(["mine", "all"])
+    .optional()
+    .describe(
+      "Which tasks to return. 'mine' = only the current user's tasks; 'all' = all tasks (default)."
+    ),
+  statusFilter: z
+    .enum(["open", "done", "all"])
+    .optional()
+    .describe(
+      "Which tasks to return. 'open' = not done + in_progress (default); 'done' = completed; 'all' = everything."
+    ),
+  daysAgo: z
+    .number()
+    .min(1)
+    .max(90)
+    .optional()
+    .describe(
+      "When statusFilter is 'done' or 'all', limit completed tasks to this many days back. Defaults to 7."
+    ),
+};
+
+export function registerPodsGetTasksTool(server: McpServer) {
+  server.registerTool(
+    "get_pod_tasks",
+    {
+      description:
+        "List tasks in a Pod. Defaults to all assignees and open tasks. Use statusFilter='done' or 'all' with daysAgo to include recently completed tasks.",
+      inputSchema,
+    },
+    async ({
+      podId,
+      assigneeFilter = "all",
+      statusFilter = "open",
+      daysAgo = 7,
+    }) => {
+      const auth = getAuthenticatorFromMcpContext();
+
+      const { nonArchivedSpaces } =
+        await listNonArchivedMemberSpacesWithMetadata(auth);
+      const pod = nonArchivedSpaces.find(
+        (space) => space.isProject() && space.sId === podId
+      );
+
+      if (!pod) {
+        return mcpError("Pod not found or you do not have access.");
+      }
+
+      let rows: ProjectTaskResource[] = [];
+
+      if (assigneeFilter === "mine") {
+        rows = await ProjectTaskResource.fetchLatestBySpace(auth, {
+          spaceId: pod.id,
+        });
+      } else {
+        rows = await ProjectTaskResource.fetchBySpace(auth, {
+          spaceId: pod.id,
+          timeScope: "all",
+        });
+      }
+
+      const cutoff = new Date(Date.now() - daysAgo * MS_PER_DAY);
+
+      if (statusFilter === "open") {
+        rows = rows.filter((task) => task.status !== "done");
+      } else if (statusFilter === "done") {
+        rows = rows.filter(
+          (task) =>
+            task.status === "done" &&
+            task.doneAt !== null &&
+            task.doneAt >= cutoff
+        );
+      } else {
+        rows = rows.filter(
+          (task) =>
+            task.status !== "done" ||
+            (task.doneAt !== null && task.doneAt >= cutoff)
+        );
+      }
+
+      if (statusFilter === "done") {
+        rows.sort(
+          (a, b) => (b.doneAt?.getTime() ?? 0) - (a.doneAt?.getTime() ?? 0)
+        );
+      }
+
+      return mcpJsonResponse({
+        count: rows.length,
+        podId: pod.sId,
+        podName: pod.name,
+        assigneeFilter,
+        statusFilter,
+        daysAgo,
+        tasks: rows.map((task) => task.toJSON()),
+      });
+    }
+  );
+}

--- a/front/lib/api/mcp_server/tools/pods/index.ts
+++ b/front/lib/api/mcp_server/tools/pods/index.ts
@@ -1,0 +1,10 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerPodsGetTool } from "./get";
+import { registerPodsGetTasksTool } from "./get_tasks";
+import { registerPodsListTool } from "./list";
+
+export function registerPodsTools(server: McpServer) {
+  registerPodsListTool(server);
+  registerPodsGetTool(server);
+  registerPodsGetTasksTool(server);
+}

--- a/front/lib/api/mcp_server/tools/pods/list.ts
+++ b/front/lib/api/mcp_server/tools/pods/list.ts
@@ -1,0 +1,38 @@
+import config from "@app/lib/api/config";
+import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import { listNonArchivedMemberSpacesWithMetadata } from "@app/lib/api/projects/list";
+import { getPodRoute } from "@app/lib/utils/router";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { mcpJsonResponse } from "../response";
+
+export function registerPodsListTool(server: McpServer) {
+  server.registerTool(
+    "list_pods",
+    {
+      description:
+        "List non-archived Pods that you are a member of in the current workspace.",
+    },
+    async () => {
+      const auth = getAuthenticatorFromMcpContext();
+      const owner = auth.workspace();
+      const { nonArchivedSpaces } =
+        await listNonArchivedMemberSpacesWithMetadata(auth);
+      const memberPods = nonArchivedSpaces
+        .filter((space) => space.isProject())
+        .sort((a, b) =>
+          a.name.localeCompare(b.name, undefined, { sensitivity: "base" })
+        );
+
+      const pods = memberPods.map((pod) => ({
+        id: pod.sId,
+        name: pod.name,
+        url: `${config.getAppUrl()}${getPodRoute(owner.sId, pod.sId)}`,
+      }));
+
+      return mcpJsonResponse({
+        count: pods.length,
+        pods,
+      });
+    }
+  );
+}

--- a/front/lib/api/mcp_server/tools/response.ts
+++ b/front/lib/api/mcp_server/tools/response.ts
@@ -1,0 +1,24 @@
+export function mcpAuthError() {
+  return {
+    content: [{ type: "text" as const, text: "Not authenticated." }],
+    isError: true as const,
+  };
+}
+
+export function mcpError(text: string) {
+  return {
+    content: [{ type: "text" as const, text }],
+    isError: true as const,
+  };
+}
+
+export function mcpJsonResponse(data: unknown) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(data),
+      },
+    ],
+  };
+}

--- a/front/lib/api/mcp_server/tools/search/index.ts
+++ b/front/lib/api/mcp_server/tools/search/index.ts
@@ -1,0 +1,6 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerSearchTool } from "./search";
+
+export function registerSearchTools(server: McpServer) {
+  registerSearchTool(server);
+}

--- a/front/lib/api/mcp_server/tools/search/search.ts
+++ b/front/lib/api/mcp_server/tools/search/search.ts
@@ -1,0 +1,128 @@
+import { getDataSourceURI } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import { isSearchResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { searchFunction } from "@app/lib/api/actions/servers/search/tools";
+import { getDataSourcesAndWorkspaceIdForGlobalAgents } from "@app/lib/api/assistant/global_agents/tools";
+import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import { isIncludedInDefaultCompanyData } from "@app/lib/data_sources";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { mcpError, mcpJsonResponse } from "../response";
+
+const inputSchema = {
+  query: z
+    .string()
+    .describe(
+      "Semantic search query. Include relevant context and keywords for best results."
+    ),
+  relativeTimeFrame: z
+    .string()
+    .regex(/^(all|\d+[hdwmy])$/)
+    .optional()
+    .describe(
+      "Optional time frame to restrict results relative to now. Values: `all`, `{k}h`, `{k}d`, `{k}w`, `{k}m`, `{k}y` (e.g. `7d`, `30d`). Defaults to `all`."
+    ),
+  tagsIn: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Optional labels (tags) to include. Documents matching at least one tag are returned."
+    ),
+  tagsNot: z
+    .array(z.string())
+    .optional()
+    .describe("Optional labels (tags) to exclude from results."),
+  nodeIds: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Optional content node IDs to scope the search to specific folders or documents."
+    ),
+  topK: z
+    .number()
+    .int()
+    .min(1)
+    .max(64)
+    .default(10)
+    .describe(
+      "Maximum number of document chunks to return (default 10, max 64)."
+    ),
+};
+
+export function registerSearchTool(server: McpServer) {
+  server.registerTool(
+    "search",
+    {
+      description:
+        "Semantic search across all globally accessible spaces in Dust. Returns matching document chunks ranked by relevance.",
+      inputSchema,
+    },
+    async ({ query, relativeTimeFrame, tagsIn, tagsNot, nodeIds, topK }) => {
+      const auth = getAuthenticatorFromMcpContext();
+
+      const { dataSourceViews, workspaceId } =
+        await getDataSourcesAndWorkspaceIdForGlobalAgents(auth);
+
+      const dataSources = dataSourceViews
+        .filter((dsView) => isIncludedInDefaultCompanyData(dsView.dataSource))
+        .map((dsView) => ({
+          uri: getDataSourceURI({
+            dataSourceViewId: dsView.sId,
+            workspaceId,
+            filter: {
+              parents: {
+                in: dsView.parentsIn ?? [],
+                not: [],
+              },
+              tags: null,
+            },
+          }),
+          mimeType: "application/vnd.dust.tool-input.data-source" as const,
+        }));
+
+      if (dataSources.length === 0) {
+        return mcpError(
+          "No searchable data sources are available in globally accessible spaces."
+        );
+      }
+
+      const searchResult = await searchFunction(auth, {
+        query,
+        relativeTimeFrame: relativeTimeFrame ?? "all",
+        dataSources,
+        nodeIds,
+        tagsIn,
+        tagsNot,
+        stepContext: {
+          citationsCount: topK,
+          citationsOffset: 0,
+          retrievalTopK: topK,
+          resumeState: null,
+          websearchResultCount: 0,
+        },
+      });
+
+      if (searchResult.isErr()) {
+        return mcpError(searchResult.error.message);
+      }
+
+      const results = searchResult.value
+        .filter(isSearchResultResourceType)
+        .map(({ resource }) => ({
+          ref: resource.ref,
+          title: resource.text,
+          uri: resource.uri,
+          id: resource.id,
+          provider: resource.source.provider ?? null,
+          dataSourceId: resource.source.data_source_id ?? null,
+          dataSourceViewId: resource.source.data_source_view_id ?? null,
+          tags: resource.tags,
+          chunks: resource.chunks,
+        }));
+
+      return mcpJsonResponse({
+        count: results.length,
+        results,
+      });
+    }
+  );
+}


### PR DESCRIPTION
## Description

Replaces the `hello_world` smoke-test with a full first-party tool set on the Dust remote MCP server. Adds server metadata (description, website URL, Dust icons, system instructions) and refactors tool registration from a single `server.ts` into namespaced subdirectories under `tools/`.

New tools registered via `registerDustMcpTools`:
- **`identity`** — user + workspace info
- **`list_agents`** — paginated agent list with optional fuzzy name filter
- **`list_conversations`**, **`create_conversation`**, **`create_conversation_message`**, **`get_conversation_messages`** — full conversation CRUD; `getLightConversation` extended with `messagePagination` to support message-level paging
- **`get_pod`**, **`get_pod_tasks`** — pod metadata and task listing (with assignee/status/date filters)
- **`files_list`**, **`files_cat`**, **`files_create`**, **`files_grep`**, **`files_resolve`** — explicit-scope file system operations on conversations and pods
- **`search`** — semantic search across workspace Spaces

Also adds a `/.well-known/oauth-authorization-server` proxy in `well-known.ts` that forwards to WorkOS AuthKit — compatibility fallback for clients that look for auth server metadata on the MCP host instead of following the protected resource metadata link.

Note: I'll refactor the "files" tools to unify the code with our own internal "files" tools, i wanted to avoid mixing this PR with a refactor.

## Tests

Tested manually against a local Dust MCP server with Cursor and Claude Desktop as remote MCP clients.

## Risk

Low. All tools are additive and read/write paths guard with `getAuthenticatorFromMcpContext()` — unauthenticated calls return structured errors, not crashes. The `/.well-known/oauth-authorization-server` endpoint proxies WorkOS and fails gracefully if WorkOS is down. `getLightConversation` signature change is backward-compatible (new params are optional with defaults).

## Deploy Plan

Deploy front-api (part of the front service). No DB migrations.
