### PR TITLE
Fix user table pagination+sorting

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -44,7 +44,7 @@ import {
   Spinner,
   Tooltip,
 } from "@dust-tt/sparkle";
-import type { PaginationState } from "@tanstack/react-table";
+import type { PaginationState, SortingState } from "@tanstack/react-table";
 import { useCallback, useEffect, useState } from "react";
 
 function formatCredits(credits: number): string {
@@ -105,6 +105,20 @@ export function UsagePage() {
     pageIndex: 0,
     pageSize: DEFAULT_PAGE_SIZE,
   });
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: "name", desc: false },
+  ]);
+
+  // Members are sorted server-side; reset to the first page when the sort
+  // changes so the user lands on the start of the new ordering.
+  const handleSetSorting = useCallback((next: SortingState) => {
+    setSorting(next);
+    setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+  }, []);
+
+  const sort = sorting[0];
+  const membersOrderColumn = sort?.id === "email" ? "email" : "name";
+  const membersOrderDirection = sort?.desc ? "desc" : "asc";
 
   const [showBuyCreditDialog, setShowBuyCreditDialog] = useState(false);
   const [changeSeatMember, setChangeSeatMember] =
@@ -146,6 +160,8 @@ export function UsagePage() {
       searchTerm,
       pageIndex: pagination.pageIndex,
       pageSize: pagination.pageSize,
+      orderColumn: membersOrderColumn,
+      orderDirection: membersOrderDirection,
     });
 
   const { hasAvailableSeats } = useWorkspaceSeatAvailability({
@@ -382,6 +398,8 @@ export function UsagePage() {
             pagination={pagination}
             setPagination={setPagination}
             totalRowCount={totalMembersUsage}
+            sorting={sorting}
+            setSorting={handleSetSorting}
           />
         </Page.Vertical>
 

--- a/front/components/poke/credits/PokeMembersUsageTable.tsx
+++ b/front/components/poke/credits/PokeMembersUsageTable.tsx
@@ -1,6 +1,5 @@
 import { CreditStateLogsLink } from "@app/components/poke/credits/CreditStateLogsLink";
 import { ReconcileCreditStateButton } from "@app/components/poke/credits/ReconcileCreditStateButton";
-import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import { getMetronomeAlertUrl } from "@app/lib/metronome/urls";
@@ -9,13 +8,41 @@ import type { UserCreditState } from "@app/types/memberships";
 import type { WorkspaceType } from "@app/types/user";
 import {
   AlertCircle,
+  ArrowDown,
+  ArrowUp,
   Chip,
   ContentMessage,
+  Icon,
   LinkWrapper,
-  Spinner,
 } from "@dust-tt/sparkle";
-import type { ColumnDef } from "@tanstack/react-table";
-import { useMemo } from "react";
+import type { ColumnDef, PaginationState } from "@tanstack/react-table";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+type SortDirection = "asc" | "desc";
+
+// Explicit, server-driven sort header for the Member (name) column. Toggling
+// updates the parent sort state directly (no reliance on react-table's
+// manual-sorting toggle), which re-queries the server.
+function MemberSortHeader({
+  direction,
+  onToggle,
+}: {
+  direction: SortDirection;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className="flex items-center gap-1 hover:text-foreground dark:hover:text-foreground-night"
+    >
+      Member
+      <Icon visual={direction === "desc" ? ArrowDown : ArrowUp} size="xs" />
+    </button>
+  );
+}
+
+const DEFAULT_PAGE_SIZE = 25;
 
 function formatCredits(credits: number): string {
   return Math.round(credits).toLocaleString("en-US");
@@ -40,15 +67,23 @@ interface PokeMembersUsageTableProps {
 function makeColumns({
   owner,
   onReconciled,
+  nameSortDirection,
+  onToggleNameSort,
 }: {
   owner: WorkspaceType;
   onReconciled: () => void;
+  nameSortDirection: SortDirection;
+  onToggleNameSort: () => void;
 }): ColumnDef<MemberUsageType>[] {
   return [
     {
       accessorKey: "name",
-      header: ({ column }) => (
-        <PokeColumnSortableHeader column={column} label="Member" />
+      enableSorting: false,
+      header: () => (
+        <MemberSortHeader
+          direction={nameSortDirection}
+          onToggle={onToggleNameSort}
+        />
       ),
       cell: ({ row }) => {
         const { name, email } = row.original;
@@ -66,29 +101,22 @@ function makeColumns({
     },
     {
       accessorKey: "seatType",
-      header: ({ column }) => (
-        <PokeColumnSortableHeader column={column} label="Seat type" />
-      ),
-      cell: ({ row }) => {
-        const { seatType } = row.original;
-        return <span>{seatType ?? "-"}</span>;
-      },
+      header: "Seat type",
+      enableSorting: false,
+      cell: ({ row }) => <span>{row.original.seatType ?? "-"}</span>,
     },
     {
       accessorKey: "consumedAwuCredits",
-      header: ({ column }) => (
-        <PokeColumnSortableHeader column={column} label="Consumed" />
+      header: "Consumed",
+      enableSorting: false,
+      cell: ({ row }) => (
+        <span>{formatCredits(row.original.consumedAwuCredits)}</span>
       ),
-      cell: ({ row }) => {
-        const { consumedAwuCredits } = row.original;
-        return <span>{formatCredits(consumedAwuCredits)}</span>;
-      },
     },
     {
       accessorKey: "spendLimitAwuCredits",
-      header: ({ column }) => (
-        <PokeColumnSortableHeader column={column} label="User cap" />
-      ),
+      header: "User cap",
+      enableSorting: false,
       cell: ({ row }) => {
         const {
           spendLimitAwuCredits,
@@ -131,9 +159,8 @@ function makeColumns({
     },
     {
       accessorKey: "memberUsageLimit",
-      header: ({ column }) => (
-        <PokeColumnSortableHeader column={column} label="Seat allowance" />
-      ),
+      header: "Seat allowance",
+      enableSorting: false,
       cell: ({ row }) => {
         const { memberUsageLimit } = row.original;
         return (
@@ -145,12 +172,8 @@ function makeColumns({
     },
     {
       accessorKey: "creditState",
-      header: ({ column }) => (
-        <PokeColumnSortableHeader column={column} label="Credit state" />
-      ),
-      filterFn: (row, id, value) => {
-        return value.includes(row.getValue(id));
-      },
+      header: "Credit state",
+      enableSorting: false,
       cell: ({ row }) => {
         const { creditState, sId } = row.original;
         return (
@@ -186,25 +209,56 @@ function makeColumns({
 }
 
 export function PokeMembersUsageTable({ owner }: PokeMembersUsageTableProps) {
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: DEFAULT_PAGE_SIZE,
+  });
+  // Only name sorting is supported (server-side). Default: name ascending.
+  const [orderDirection, setOrderDirection] = useState<SortDirection>("asc");
+  const [searchInput, setSearchInput] = useState("");
+  const [search, setSearch] = useState("");
+
+  // Debounce the search input, and reset to the first page on a new query.
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setSearch(searchInput);
+      setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+    }, 300);
+    return () => clearTimeout(id);
+  }, [searchInput]);
+
   const {
     members,
+    totalMembers,
     isMembersUsageLoading,
     isMembersUsageError,
     mutateMembersUsage,
-  } = usePokeMembersUsage({ owner });
+  } = usePokeMembersUsage({
+    owner,
+    pageIndex: pagination.pageIndex,
+    pageSize: pagination.pageSize,
+    search,
+    orderColumn: "name",
+    orderDirection,
+  });
+
+  // Toggle name sort direction and jump back to the first page. Stable across
+  // renders (only uses functional setters), so it's safe in the columns memo.
+  const toggleNameSort = useCallback(() => {
+    setOrderDirection((prev) => (prev === "asc" ? "desc" : "asc"));
+    setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+  }, []);
 
   const columns = useMemo(
-    () => makeColumns({ owner, onReconciled: () => void mutateMembersUsage() }),
-    [owner, mutateMembersUsage]
+    () =>
+      makeColumns({
+        owner,
+        onReconciled: () => void mutateMembersUsage(),
+        nameSortDirection: orderDirection,
+        onToggleNameSort: toggleNameSort,
+      }),
+    [owner, mutateMembersUsage, orderDirection, toggleNameSort]
   );
-
-  if (isMembersUsageLoading) {
-    return (
-      <div className="flex justify-center py-8">
-        <Spinner />
-      </div>
-    );
-  }
 
   if (isMembersUsageError) {
     return (
@@ -224,7 +278,16 @@ export function PokeMembersUsageTable({ owner }: PokeMembersUsageTableProps) {
       <span className="text-sm font-medium text-foreground dark:text-foreground-night">
         Members credit states
       </span>
-      <PokeDataTable columns={columns} data={members} />
+      <PokeDataTable
+        columns={columns}
+        data={members}
+        isLoading={isMembersUsageLoading}
+        serverSideRowCount={totalMembers}
+        pagination={pagination}
+        onPaginationChange={setPagination}
+        search={searchInput}
+        onSearchChange={setSearchInput}
+      />
     </div>
   );
 }

--- a/front/components/poke/shadcn/ui/data_table.tsx
+++ b/front/components/poke/shadcn/ui/data_table.tsx
@@ -12,7 +12,9 @@ import { Input } from "@dust-tt/sparkle";
 import type {
   ColumnDef,
   ColumnFiltersState,
+  PaginationState,
   SortingState,
+  Updater,
 } from "@tanstack/react-table";
 import {
   flexRender,
@@ -43,6 +45,19 @@ interface DataTableProps<TData, TValue> {
   isLoading?: boolean;
   facets?: Facet[];
   pageSize?: number;
+  // Server-side (manual) mode. When `serverSideRowCount` is provided,
+  // pagination and sorting are controlled by the caller and applied
+  // server-side (the `data` prop is the current page only). Otherwise the
+  // table paginates/sorts/filters the full `data` set client-side as before.
+  serverSideRowCount?: number;
+  pagination?: PaginationState;
+  onPaginationChange?: (pagination: PaginationState) => void;
+  sorting?: SortingState;
+  onSortingChange?: (sorting: SortingState) => void;
+  // When provided, the filter box drives server-side search (controlled by the
+  // caller) instead of the built-in client-side global filter.
+  search?: string;
+  onSearchChange?: (search: string) => void;
 }
 
 export function PokeDataTable<TData, TValue>({
@@ -52,9 +67,21 @@ export function PokeDataTable<TData, TValue>({
   facets,
   isLoading,
   pageSize = 10,
+  serverSideRowCount,
+  pagination,
+  onPaginationChange,
+  sorting,
+  onSortingChange,
+  search,
+  onSearchChange,
 }: DataTableProps<TData, TValue>) {
-  const [sorting, setSorting] = useState<SortingState>([]);
+  const isServerSide = serverSideRowCount !== undefined;
+  const isServerSearch = onSearchChange !== undefined;
+
+  const [internalSorting, setInternalSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+
+  const resolvedSorting = isServerSide ? (sorting ?? []) : internalSorting;
 
   // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
@@ -65,19 +92,38 @@ export function PokeDataTable<TData, TValue>({
     getFacetedUniqueValues: getFacetedUniqueValues(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
-    getSortedRowModel: getSortedRowModel(),
     onColumnFiltersChange: setColumnFilters,
-    onSortingChange: setSorting,
     globalFilterFn: "includesString", // built-in filter function
+    manualPagination: isServerSide,
+    manualSorting: isServerSide,
+    ...(isServerSide
+      ? { rowCount: serverSideRowCount }
+      : { getSortedRowModel: getSortedRowModel() }),
+    onSortingChange: isServerSide
+      ? (updater: Updater<SortingState>) => {
+          const next =
+            typeof updater === "function" ? updater(resolvedSorting) : updater;
+          onSortingChange?.(next);
+        }
+      : setInternalSorting,
+    ...(isServerSide
+      ? {
+          onPaginationChange: (updater: Updater<PaginationState>) => {
+            const current = pagination ?? { pageIndex: 0, pageSize };
+            const next =
+              typeof updater === "function" ? updater(current) : updater;
+            onPaginationChange?.(next);
+          },
+        }
+      : {}),
     state: {
       columnFilters,
-      sorting,
+      sorting: resolvedSorting,
+      ...(isServerSide && pagination ? { pagination } : {}),
     },
     initialState: {
       globalFilter: "",
-      pagination: {
-        pageSize,
-      },
+      ...(isServerSide ? {} : { pagination: { pageSize } }),
     },
   });
 
@@ -88,25 +134,35 @@ export function PokeDataTable<TData, TValue>({
   return (
     <div className="w-full space-y-2">
       <div className="flex items-center gap-4">
-        <Input
-          name="filter"
-          placeholder="Filter ..."
-          value={
-            defaultFilterColumn
-              ? (table
-                  .getColumn(defaultFilterColumn)
-                  ?.getFilterValue() as string)
-              : table.getState().globalFilter
-          }
-          onChange={(e) =>
-            defaultFilterColumn
-              ? table
-                  .getColumn(defaultFilterColumn)
-                  ?.setFilterValue(e.target.value)
-              : table.setGlobalFilter(e.target.value)
-          }
-          className="max-w-sm"
-        />
+        {isServerSearch ? (
+          <Input
+            name="search"
+            placeholder="Search ..."
+            value={search ?? ""}
+            onChange={(e) => onSearchChange?.(e.target.value)}
+            className="max-w-sm"
+          />
+        ) : (
+          <Input
+            name="filter"
+            placeholder="Filter ..."
+            value={
+              defaultFilterColumn
+                ? (table
+                    .getColumn(defaultFilterColumn)
+                    ?.getFilterValue() as string)
+                : table.getState().globalFilter
+            }
+            onChange={(e) =>
+              defaultFilterColumn
+                ? table
+                    .getColumn(defaultFilterColumn)
+                    ?.setFilterValue(e.target.value)
+                : table.setGlobalFilter(e.target.value)
+            }
+            className="max-w-sm"
+          />
+        )}
         {facets &&
           facets.map((facet) => (
             <PokeDataTableFacetedFilter

--- a/front/components/poke/shadcn/ui/pagination.tsx
+++ b/front/components/poke/shadcn/ui/pagination.tsx
@@ -11,7 +11,11 @@ export function PokeDataTablePagination<TData>({
   return (
     <div className="flex items-center justify-between px-2">
       <div className="flex-1 text-sm text-muted-foreground">
-        Total of {table.getFilteredRowModel().rows.length} row(s).
+        Total of{" "}
+        {table.options.manualPagination
+          ? table.getRowCount()
+          : table.getFilteredRowModel().rows.length}{" "}
+        row(s).
       </div>
       <div className="flex items-center space-x-6 lg:space-x-8">
         <div className="font-sm flex w-[100px] items-center justify-center text-sm">

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -21,6 +21,7 @@ import type {
   CellContext,
   ColumnDef,
   PaginationState,
+  SortingState,
 } from "@tanstack/react-table";
 import type React from "react";
 import { useMemo } from "react";
@@ -218,6 +219,7 @@ function AwuUsageBar({
 const nameColumn: ColumnDef<RowData, string> = {
   id: "name" as const,
   header: "Name",
+  enableSorting: true,
   accessorFn: (row) => row.name,
   cell: (info: Info) => (
     <DataTable.CellContent
@@ -239,6 +241,7 @@ const nameColumn: ColumnDef<RowData, string> = {
 const seatTypeColumn: ColumnDef<RowData, string> = {
   id: "seatType" as const,
   header: "Seat",
+  enableSorting: false,
   accessorFn: (row) => row.seatType ?? "",
   cell: (info: Info) => {
     const seatType = info.row.original.seatType;
@@ -275,6 +278,7 @@ const seatTypeColumn: ColumnDef<RowData, string> = {
 const billingFrequencyColumn: ColumnDef<RowData, string> = {
   id: "billingFrequency" as const,
   header: "Period",
+  enableSorting: false,
   accessorFn: (row) => row.billingFrequency ?? "",
   cell: (info: Info) => {
     const freq = info.row.original.billingFrequency;
@@ -332,14 +336,15 @@ const consumedAwuCreditsColumn: ColumnDef<RowData, string> = {
   meta: {
     className: "w-64",
   },
-  enableSorting: true,
-  sortingFn: (a, b) =>
-    a.original.consumedAwuCredits - b.original.consumedAwuCredits,
+  // Consumed is computed per-page from Metronome usage, not a server-sortable
+  // field, so it can't participate in server-side sorting.
+  enableSorting: false,
 };
 
 const actionsColumn: ColumnDef<RowData, string> = {
   id: "actions" as const,
   header: "",
+  enableSorting: false,
   accessorKey: "actions",
   cell: (info: Info) => (
     <DataTable.MoreButton menuItems={info.row.original.menuItems} />
@@ -381,6 +386,8 @@ interface MembersUsageTableProps {
   pagination: PaginationState;
   setPagination: (pagination: PaginationState) => void;
   totalRowCount: number;
+  sorting: SortingState;
+  setSorting: (sorting: SortingState) => void;
 }
 
 export function MembersUsageTable({
@@ -393,6 +400,8 @@ export function MembersUsageTable({
   pagination,
   setPagination,
   totalRowCount,
+  sorting,
+  setSorting,
 }: MembersUsageTableProps) {
   // Name/email search is handled server-side; only filter by seat type here.
   const filtered = useMemo(
@@ -477,6 +486,9 @@ export function MembersUsageTable({
       pagination={pagination}
       setPagination={setPagination}
       totalRowCount={totalRowCount}
+      sorting={sorting}
+      setSorting={setSorting}
+      isServerSideSorting
     />
   );
 }

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -99,6 +99,10 @@ export const MembersUsagePaginationSchema = z.object({
     .catch(DEFAULT_MEMBERS_USAGE_PAGE_LIMIT),
   offset: z.coerce.number().int().min(0).catch(0),
   search: z.string().optional().catch(undefined),
+  // Members are ordered by name (ascending) by default, giving a stable order
+  // for pagination instead of relevance ranking.
+  orderColumn: z.enum(["name", "email"]).catch("name"),
+  orderDirection: z.enum(["asc", "desc"]).catch("asc"),
 });
 
 export type MembersUsagePaginationInput = z.infer<
@@ -393,6 +397,10 @@ export async function getMembersUsage({
     searchTerm: paginationParams.search ?? "",
     offset: paginationParams.offset,
     limit: paginationParams.limit,
+    orderBy: {
+      field: paginationParams.orderColumn,
+      direction: paginationParams.orderDirection,
+    },
   });
 
   if (usersResult.isErr()) {

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -8,6 +8,7 @@ import {
   UserToolApprovalModel,
 } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { SearchUsersOrderBy } from "@app/lib/user_search/search";
 import { searchUsers } from "@app/lib/user_search/search";
 import {
   cacheWithRedis,
@@ -354,10 +355,12 @@ export class UserResource extends BaseResource<UserModel> {
       searchTerm,
       offset,
       limit,
+      orderBy,
     }: {
       searchTerm: string;
       offset: number;
       limit: number;
+      orderBy?: SearchUsersOrderBy;
     }
   ): Promise<Result<{ users: UserResource[]; total: number }, Error>> {
     const owner = auth.getNonNullableWorkspace();
@@ -368,6 +371,7 @@ export class UserResource extends BaseResource<UserModel> {
       searchTerm,
       offset,
       limit,
+      orderBy,
     });
     if (searchResult.isErr()) {
       return searchResult;

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -231,12 +231,16 @@ export function useMembersUsage({
   searchTerm = "",
   pageIndex,
   pageSize,
+  orderColumn,
+  orderDirection,
   disabled,
 }: {
   workspaceId: string;
   searchTerm?: string;
   pageIndex: number;
   pageSize: number;
+  orderColumn?: "name" | "email";
+  orderDirection?: "asc" | "desc";
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
@@ -254,6 +258,12 @@ export function useMembersUsage({
   });
   if (debouncedSearchTerm.trim().length > 0) {
     searchParams.set("search", debouncedSearchTerm.trim());
+  }
+  if (orderColumn) {
+    searchParams.set("orderColumn", orderColumn);
+  }
+  if (orderDirection) {
+    searchParams.set("orderDirection", orderDirection);
   }
 
   const { data, error } = useSWRWithDefaults(

--- a/front/lib/user_search/search.ts
+++ b/front/lib/user_search/search.ts
@@ -10,6 +10,13 @@ export interface SearchUsersResult {
   total: number;
 }
 
+// Optional ordering for browsing/listing use cases. When omitted, results are
+// ranked by relevance (`_score`), which is what free-text search wants.
+export type SearchUsersOrderBy = {
+  field: "name" | "email";
+  direction: "asc" | "desc";
+};
+
 /**
  * Search users by email and full name.
  * - full_name: Uses prefix matching on any word (edge n-grams)
@@ -20,11 +27,13 @@ export async function searchUsers({
   searchTerm,
   offset,
   limit,
+  orderBy,
 }: {
   owner: LightWorkspaceType;
   searchTerm: string;
   offset: number;
   limit: number;
+  orderBy?: SearchUsersOrderBy;
 }): Promise<Result<SearchUsersResult, ElasticsearchError>> {
   return withEs(async (client) => {
     // If searchTerm is empty or only whitespace, return all users from the workspace.
@@ -57,12 +66,26 @@ export async function searchUsers({
       },
     };
 
+    // When an explicit order is requested, sort on the keyword sub-field (with
+    // `user_id` as a stable tiebreaker for consistent pagination); otherwise
+    // rank by relevance. `full_name.keyword` / `email.keyword` exist in the
+    // index mapping.
+    const sort: estypes.Sort = orderBy
+      ? [
+          {
+            [orderBy.field === "name" ? "full_name.keyword" : "email.keyword"]:
+              { order: orderBy.direction },
+          },
+          { user_id: { order: "asc" } },
+        ]
+      : [{ _score: { order: "desc" } }];
+
     const response = await client.search<UserSearchDocument>({
       index: USER_SEARCH_ALIAS_NAME,
       query,
       size: limit,
       from: offset,
-      sort: [{ _score: { order: "desc" } }],
+      sort,
     });
 
     const users = response.hits.hits.map((hit) => hit._source!);

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -223,13 +223,41 @@ export function usePokeAwuPoolSummary({
 export function usePokeMembersUsage({
   owner,
   disabled,
-}: PokeConditionalFetchProps) {
+  pageIndex,
+  pageSize,
+  search,
+  orderColumn,
+  orderDirection,
+}: PokeConditionalFetchProps & {
+  pageIndex: number;
+  pageSize: number;
+  search?: string;
+  orderColumn?: "name" | "email";
+  orderDirection?: "asc" | "desc";
+}) {
   const { fetcher } = useFetcher();
   const fetcherFn: Fetcher<GetMembersUsageResponseBody> = fetcher;
 
+  const params = new URLSearchParams({
+    offset: String(pageIndex * pageSize),
+    limit: String(pageSize),
+  });
+  if (search && search.trim().length > 0) {
+    params.set("search", search.trim());
+  }
+  if (orderColumn) {
+    params.set("orderColumn", orderColumn);
+  }
+  if (orderDirection) {
+    params.set("orderDirection", orderDirection);
+  }
+
   const { data, error, isValidating, mutate } = useSWRWithDefaults(
-    disabled ? null : `/api/poke/workspaces/${owner.sId}/credits/members-usage`,
-    fetcherFn
+    disabled
+      ? null
+      : `/api/poke/workspaces/${owner.sId}/credits/members-usage?${params.toString()}`,
+    fetcherFn,
+    { revalidateOnFocus: false, keepPreviousData: true }
   );
 
   return {


### PR DESCRIPTION
## Description

Adds proper **server-side pagination and sorting** to the members usage tables, on both the Poke admin view and the customer-facing Usage page.

Previously the Poke "Members credit states" table fetched only the first page (default 50) and paginated/sorted that subset client-side — so on workspaces with many members you couldn't page past the first chunk, and sorting only reordered the loaded rows. This makes both tables page through the full member set and sort it on the server.

**Backend**
- `searchUsers` (ES) takes an optional `orderBy` (`name` | `email`, `asc` | `desc`), sorting on the `full_name.keyword` / `email.keyword` sub-fields with `user_id` as a stable tiebreaker. When omitted it keeps ranking by relevance (`_score`), so free-text user search elsewhere is unchanged.
- Threaded through `UserResource.searchUsers` (ES result order is preserved by the existing reconstruction step).
- `MembersUsagePaginationSchema` gains `orderColumn` (default `name`) and `orderDirection` (default `asc`); `getMembersUsage` passes them as `orderBy`. This also gives a stable, name-ordered default instead of arbitrary relevance order.

**Poke table (`PokeMembersUsageTable`)**
- Extended the shared `PokeDataTable` with optional server-side props (`serverSideRowCount`, controlled `pagination`/`onPaginationChange`, `sorting`/`onSortingChange`, and `search`/`onSearchChange`). These are fully backward-compatible — without them the table behaves exactly as before (client-side paginate/sort/filter), so other Poke pages are unaffected. The pagination footer shows the server total in manual mode.
- The table now uses server-side pagination + a debounced server search, with a single combined **Member** (name + email) column that's server-sortable by name (asc/desc) via an explicit header toggle.

**Usage page (`MembersUsageTable`)**
- Server-side sorting on the **Name** column (combined name+email cell), wired through `useMembersUsage` (`orderColumn`/`orderDirection`) and `UsagePage`'s sort state. The previous client-side "Credits usage" sort is removed (consumed is computed per-page from Metronome, not a server-sortable field, and it only worked on single-page workspaces).

## Tests

Manual testing in Poke and on the Usage page (credit-priced workspaces): paging through all members, toggling name sort (asc/desc) and confirming the order reverses across pages, and searching by name/email. Type-check (`tsgo`) and lint/format (`biome`) pass.

## Risk

Low, UI/read-path only.
- The `PokeDataTable` change is additive; the new server-side props default off, preserving existing behavior for all other Poke tables.
- The members-usage default order changes from relevance to name-ascending (a stable, expected improvement for paginated browsing).
- `searchUsers`'s `orderBy` is opt-in, so non-members-usage callers are unchanged. No schema/data migration; safe to roll back.

## Deploy Plan

Standard deploy, no migration or ordering constraints.
