### PR TITLE
feat: update chrome tools prompt

### DIFF
--- a/extension/platforms/chrome/services/mcp.ts
+++ b/extension/platforms/chrome/services/mcp.ts
@@ -4,7 +4,10 @@ import type { WorkspaceType } from "@app/types/user";
 import type { CaptureService } from "@extension/shared/services/capture";
 import { McpService } from "@extension/shared/services/mcp";
 import { registerAllTools } from "@extension/shared/tools";
+import { getBrowserMCPServerInstructions } from "@extension/shared/tools/metadata";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+const CHROME_MCP_SERVER_NAME = "chrome-mcp-server";
 
 /**
  * Chrome-specific implementation of the MCP service.
@@ -28,17 +31,14 @@ export class ChromeMcpService extends McpService {
     try {
       const server = new McpServer(
         {
-          name: "chrome-mcp-server",
+          name: CHROME_MCP_SERVER_NAME,
           version: "1.0.0",
         },
         {
-          instructions:
-            "You are running inside a Dust Chrome extension. " +
-            "The user is actively browsing the web, so their questions often relate to content on their current browser tab. " +
-            "When the user's message implicitly or explicitly refers to a page, article, document, or 'this' / 'it' / 'the page' without further specification, " +
-            "proactively call `get-current-browser-page` to fetch the page title, URL, and text content before answering. " +
-            "For pages that are visual or non-text (images, PDFs, dashboards), call `get-current-browser-page-view` instead — it will attach the file directly when possible. " +
-            "Do not ask the user to paste the content themselves — retrieve it directly with the available tools.",
+          instructions: getBrowserMCPServerInstructions({
+            platformName: "Chrome",
+            serverName: CHROME_MCP_SERVER_NAME,
+          }),
         }
       );
 

--- a/extension/platforms/firefox/services/mcp.ts
+++ b/extension/platforms/firefox/services/mcp.ts
@@ -3,7 +3,10 @@ import type { WorkspaceType } from "@app/types/user";
 import type { CaptureService } from "@extension/shared/services/capture";
 import { McpService } from "@extension/shared/services/mcp";
 import { registerAllTools } from "@extension/shared/tools";
+import { getBrowserMCPServerInstructions } from "@extension/shared/tools/metadata";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+const FIREFOX_MCP_SERVER_NAME = "firefox-mcp-server";
 
 export class FirefoxMcpService extends McpService {
   private captureService: CaptureService | null = null;
@@ -23,17 +26,14 @@ export class FirefoxMcpService extends McpService {
     try {
       const server = new McpServer(
         {
-          name: "firefox-mcp-server",
+          name: FIREFOX_MCP_SERVER_NAME,
           version: "1.0.0",
         },
         {
-          instructions:
-            "You are running inside a Dust Firefox extension. " +
-            "The user is actively browsing the web, so their questions often relate to content on their current browser tab. " +
-            "When the user's message implicitly or explicitly refers to a page, article, document, or 'this' / 'it' / 'the page' without further specification, " +
-            "proactively call `get-current-browser-page` to fetch the page title, URL, and text content before answering. " +
-            "For pages that are visual or non-text (images, PDFs, dashboards), call `get-current-browser-page-view` instead — it will attach the file directly when possible. " +
-            "Do not ask the user to paste the content themselves — retrieve it directly with the available tools.",
+          instructions: getBrowserMCPServerInstructions({
+            platformName: "Firefox",
+            serverName: FIREFOX_MCP_SERVER_NAME,
+          }),
         }
       );
 

--- a/extension/shared/tools/index.ts
+++ b/extension/shared/tools/index.ts
@@ -7,7 +7,18 @@ import type { CaptureService } from "@extension/shared/services/capture";
 import { attachTabsTextTool } from "@extension/shared/tools/attachPageTextTool";
 import { interactWithPageTool } from "@extension/shared/tools/interactWithPageTool";
 import { listBrowserTabsTool } from "@extension/shared/tools/listTabsTool";
-import { CHROME_TOOLS_METADATA } from "@extension/shared/tools/metadata";
+import {
+  ATTACH_TABS_TEXT_TOOL_NAME,
+  CHROME_TOOLS_METADATA,
+  CLOSE_BROWSER_TAB_TOOL_NAME,
+  INTERACT_WITH_PAGE_TOOL_NAME,
+  LIST_BROWSER_TABS_TOOL_NAME,
+  MOVE_BROWSER_TAB_TOOL_NAME,
+  OPEN_BROWSER_TAB_TOOL_NAME,
+  RELOAD_BROWSER_TAB_TOOL_NAME,
+  SWITCH_TO_BROWSER_TAB_TOOL_NAME,
+  TAKE_SCREENSHOT_OR_ATTACH_FILE_TOOL_NAME,
+} from "@extension/shared/tools/metadata";
 import {
   closeBrowserTabTool,
   moveBrowserTabTool,
@@ -29,21 +40,21 @@ export function registerAllTools(
   workspaceId: string
 ): void {
   const handlers: ClientToolHandlers<typeof CHROME_TOOLS_METADATA> = {
-    attach_tabs_text: (params) =>
+    [ATTACH_TABS_TEXT_TOOL_NAME]: (params) =>
       attachTabsTextTool({ ...params, captureService }),
-    take_screenshot_or_attach_file: (params) =>
+    [TAKE_SCREENSHOT_OR_ATTACH_FILE_TOOL_NAME]: (params) =>
       takeScreenshotOrAttachFileTool({
         ...params,
         captureService,
         workspaceId,
       }),
-    list_browser_tabs: () => listBrowserTabsTool(),
-    switch_to_browser_tab: (params) => switchBrowserTabTool(params),
-    close_browser_tab: (params) => closeBrowserTabTool(params),
-    move_browser_tab: (params) => moveBrowserTabTool(params),
-    open_browser_tab: (params) => openBrowserTab(params),
-    reload_browser_tab: (params) => reloadBrowserTabTool(params),
-    interact_with_page: (params) => interactWithPageTool(params),
+    [LIST_BROWSER_TABS_TOOL_NAME]: () => listBrowserTabsTool(),
+    [SWITCH_TO_BROWSER_TAB_TOOL_NAME]: (params) => switchBrowserTabTool(params),
+    [CLOSE_BROWSER_TAB_TOOL_NAME]: (params) => closeBrowserTabTool(params),
+    [MOVE_BROWSER_TAB_TOOL_NAME]: (params) => moveBrowserTabTool(params),
+    [OPEN_BROWSER_TAB_TOOL_NAME]: (params) => openBrowserTab(params),
+    [RELOAD_BROWSER_TAB_TOOL_NAME]: (params) => reloadBrowserTabTool(params),
+    [INTERACT_WITH_PAGE_TOOL_NAME]: (params) => interactWithPageTool(params),
   };
 
   const tools = buildClientTools(CHROME_TOOLS_METADATA, handlers);

--- a/extension/shared/tools/metadata.ts
+++ b/extension/shared/tools/metadata.ts
@@ -1,13 +1,54 @@
 import { createClientToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import { z } from "zod";
 
+export const ATTACH_TABS_TEXT_TOOL_NAME = "attach_tabs_text";
+export const TAKE_SCREENSHOT_OR_ATTACH_FILE_TOOL_NAME =
+  "take_screenshot_or_attach_file";
+export const LIST_BROWSER_TABS_TOOL_NAME = "list_browser_tabs";
+export const SWITCH_TO_BROWSER_TAB_TOOL_NAME = "switch_to_browser_tab";
+export const CLOSE_BROWSER_TAB_TOOL_NAME = "close_browser_tab";
+export const OPEN_BROWSER_TAB_TOOL_NAME = "open_browser_tab";
+export const MOVE_BROWSER_TAB_TOOL_NAME = "move_browser_tab";
+export const RELOAD_BROWSER_TAB_TOOL_NAME = "reload_browser_tab";
+export const INTERACT_WITH_PAGE_TOOL_NAME = "interact_with_page";
+
+export function getBrowserMCPServerInstructions({
+  platformName,
+  serverName,
+}: {
+  platformName: string;
+  serverName: string;
+}) {
+  return (
+    `You are running inside a Dust ${platformName} extension. ` +
+    "The user is actively browsing the web, so their questions often relate to content on their current browser tab. " +
+    "When the user's message implicitly or explicitly refers to a page, article, document, email, thread, or 'this' / 'it' / 'the page' without further specification, retrieve the relevant context with the least intrusive tool that can answer accurately. " +
+    `Use \`${getPrefixedToolName(
+      serverName,
+      ATTACH_TABS_TEXT_TOOL_NAME
+    )}\` when the user asks about the specific content currently visible in the browser, including ordinary HTML pages, rendered emails or threads, search results, filtered lists, and transient UI state. ` +
+    "Use dedicated MCP tools when the task needs structured access, search, creation, editing, or other canonical actions in a supported service. Do not treat a service domain as a hard rule: visible browser content may still be the best signal. " +
+    `Use \`${getPrefixedToolName(
+      serverName,
+      INTERACT_WITH_PAGE_TOOL_NAME
+    )}\` only when the task requires manipulating the visible UI. ` +
+    `Use \`${getPrefixedToolName(
+      serverName,
+      TAKE_SCREENSHOT_OR_ATTACH_FILE_TOOL_NAME
+    )}\` only when visual or file content is necessary, such as PDFs, images, layout, charts, visible errors, canvas content, or when page text or dedicated tools are insufficient. ` +
+    "Do not ask the user to paste the content themselves — retrieve it directly with the available tools."
+  );
+}
+
 export const CHROME_TOOLS_METADATA = createClientToolsRecord({
-  attach_tabs_text: {
+  [ATTACH_TABS_TEXT_TOOL_NAME]: {
     description:
       "Extracts the title, URL, and text content of a browser tab. " +
-      "Use this to read and understand what the user is viewing. " +
-      "For non-text pages (PDFs, images, etc.), use take_screenshot_or_attach_file instead — it will attach the file directly to the conversation." +
-      "Use list_browser_tabs to discover tab IDs. Group by domains to fetch the content of all tabs from the same domain.",
+      "Use this to read and understand the specific content the user is viewing, including ordinary HTML pages, rendered emails or threads, search results, filtered lists, and other visible browser state. " +
+      "For structured access or canonical actions in supported services, prefer dedicated MCP tools when available. " +
+      `For visual or file content that text extraction cannot capture (PDFs, images, charts, layout, visible errors, canvas content), use ${TAKE_SCREENSHOT_OR_ATTACH_FILE_TOOL_NAME} instead. ` +
+      `Use ${LIST_BROWSER_TABS_TOOL_NAME} to discover tab IDs. Group by domains to fetch the content of all tabs from the same domain.`,
     schema: {
       tabsToFetch: z
         .string()
@@ -24,13 +65,14 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
       done: "Page content retrieved",
     },
   },
-  take_screenshot_or_attach_file: {
+  [TAKE_SCREENSHOT_OR_ATTACH_FILE_TOOL_NAME]: {
     description:
-      "Captures or attaches the content of a browser tab. " +
+      "Captures or attaches visual or file content from a browser tab. " +
       "For PDF pages, uploads the file and returns the full extracted text so you can read it. " +
       "For image pages, returns the image directly so you can visually analyze it. " +
-      "For HTML pages, takes a screenshot for visual inspection (Drive canvas, dashboards, etc.)." +
-      "Use list_browser_tabs to discover tab IDs. Group by domains to fetch the content of all tabs from the same domain.",
+      "For HTML pages, use this only when visual inspection is required or text extraction and dedicated MCP tools are insufficient, for example charts, layout-specific questions, visible errors, dashboards, or unsupported canvas-like surfaces. " +
+      "Do not use this as the default way to read ordinary page content. " +
+      `Use ${LIST_BROWSER_TABS_TOOL_NAME} to discover tab IDs. Group by domains to fetch the content of all tabs from the same domain.`,
     schema: {
       tabsToFetch: z
         .string()
@@ -47,12 +89,12 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
       done: "Tab content attached",
     },
   },
-  list_browser_tabs: {
+  [LIST_BROWSER_TABS_TOOL_NAME]: {
     description:
       "Lists all open tabs in the current browser window with their tab ID, title, URL, and whether they are active. " +
       "The active tab (what the user is currently looking at) is marked with an asterisk (*). " +
       "Use this to discover which tabs the user has open and to identify the currently active tab. " +
-      "Tab IDs can be passed to attach_page_text or take_screenshot_or_attach_file to read a specific tab.",
+      `Tab IDs can be passed to ${ATTACH_TABS_TEXT_TOOL_NAME} or ${TAKE_SCREENSHOT_OR_ATTACH_FILE_TOOL_NAME} to read a specific tab.`,
     schema: {},
     stake: "low",
     displayLabels: {
@@ -60,10 +102,10 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
       done: "Browser tabs listed",
     },
   },
-  switch_to_browser_tab: {
+  [SWITCH_TO_BROWSER_TAB_TOOL_NAME]: {
     description:
       "Switches to the specified browser tab, making it the active tab. " +
-      "Use list_browser_tabs to discover tab IDs.",
+      `Use ${LIST_BROWSER_TABS_TOOL_NAME} to discover tab IDs.`,
     schema: {
       tabId: z.number().describe("The tab ID to activate."),
     },
@@ -73,9 +115,8 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
       done: "Browser tab activated",
     },
   },
-  close_browser_tab: {
-    description:
-      "Closes the specified browser tab. Use list_browser_tabs to discover tab IDs.",
+  [CLOSE_BROWSER_TAB_TOOL_NAME]: {
+    description: `Closes the specified browser tab. Use ${LIST_BROWSER_TABS_TOOL_NAME} to discover tab IDs.`,
     schema: {
       tabId: z.number().describe("The tab ID to close."),
     },
@@ -85,7 +126,7 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
       done: "Browser tab closed",
     },
   },
-  open_browser_tab: {
+  [OPEN_BROWSER_TAB_TOOL_NAME]: {
     description: "Opens a new browser tab with the specified URL.",
     schema: {
       url: z.string().url().describe("The URL to open in a new tab."),
@@ -96,10 +137,10 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
       done: "Browser tab opened",
     },
   },
-  move_browser_tab: {
+  [MOVE_BROWSER_TAB_TOOL_NAME]: {
     description:
       "Moves a browser tab to a new position (index) in the tab bar. " +
-      "Use list_browser_tabs to discover tab IDs and current order.",
+      `Use ${LIST_BROWSER_TABS_TOOL_NAME} to discover tab IDs and current order.`,
     schema: {
       tabId: z.number().describe("The tab ID to move."),
       index: z
@@ -114,10 +155,10 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
       done: "Browser tab moved",
     },
   },
-  reload_browser_tab: {
+  [RELOAD_BROWSER_TAB_TOOL_NAME]: {
     description:
       "Reloads the specified browser tab. Useful after server-side actions that modify page content. " +
-      "Use list_browser_tabs to discover tab IDs.",
+      `Use ${LIST_BROWSER_TABS_TOOL_NAME} to discover tab IDs.`,
     schema: {
       tabId: z.number().describe("The tab ID to reload."),
     },
@@ -127,7 +168,7 @@ export const CHROME_TOOLS_METADATA = createClientToolsRecord({
       done: "Browser tab reloaded",
     },
   },
-  interact_with_page: {
+  [INTERACT_WITH_PAGE_TOOL_NAME]: {
     description: `Interact with a browser tab of the user's browser window.
 
 Available actions:
@@ -140,7 +181,9 @@ Important rules:
 - Use get_elements when you need to see what elements are available.
 - Use click_element for controls like buttons or links.
 - Use type_text for entering text into inputs. Or removing text with the replace option.
-- Do NOT use this tool on pages from services like Notion, Gmail, Google Docs, or Google Calendar without first checking for a dedicated MCP tool via toolsets__list. If one exists, use it instead.
+- Before interacting with pages from services that commonly have dedicated MCP tools, such as Notion, Gmail, Google Docs, or Google Calendar, check for a dedicated tool via toolsets__list when available.
+- Prefer dedicated MCP tools for structured access, search, creation, editing, or other canonical actions in supported services.
+- Use this tool when the task requires manipulating the visible UI, when the dedicated tool cannot access the relevant browser state, or when no suitable dedicated tool is available.
 
 type_text automatically focuses the element before typing.
 delete_text automatically focuses the element before deleting the text.


### PR DESCRIPTION
## Description

This PR updates the browser extension MCP server instructions and tool descriptions to reduce screenshot tool usage in favor of more targeted alternatives, preferring text extraction for ordinary page content and dedicated MCP tools for supported services, with screenshots reserved only when visual or file content is strictly necessary.

## Tests

Manually.

## Risks

## Deploy Plan
