### PR TITLE
[front] checkout: PR1 - feature flag, types, checkout payment status

### DIFF
--- a/front-api/routes/w/[wId]/subscriptions/checkout/checkout-payment-status.ts
+++ b/front-api/routes/w/[wId]/subscriptions/checkout/checkout-payment-status.ts
@@ -1,0 +1,41 @@
+import type { CheckoutPayment } from "@app/lib/credits/checkout_payment_status";
+import { getCheckoutPaymentStatus } from "@app/lib/credits/checkout_payment_status";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+
+export type GetCheckoutPaymentStatusResponseBody = {
+  checkoutPayment: CheckoutPayment | null;
+};
+
+// Mounted at /api/w/:wId/subscriptions/checkout/checkout-payment-status.
+const app = workspaceApp();
+
+app.get(
+  "/",
+  ensureIsAdmin(),
+  async (ctx): HandlerResult<GetCheckoutPaymentStatusResponseBody> => {
+    const auth = ctx.get("auth");
+
+    const setupSessionId = ctx.req.query("setup_session_id");
+    if (!setupSessionId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Missing required query parameter: setup_session_id.",
+        },
+      });
+    }
+
+    const checkoutPayment = await getCheckoutPaymentStatus({
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      setupSessionId,
+    });
+
+    return ctx.json({ checkoutPayment });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/subscriptions/checkout/checkout-payment-status.ts
+++ b/front-api/routes/w/[wId]/subscriptions/checkout/checkout-payment-status.ts
@@ -18,20 +18,20 @@ app.get(
   async (ctx): HandlerResult<GetCheckoutPaymentStatusResponseBody> => {
     const auth = ctx.get("auth");
 
-    const setupSessionId = ctx.req.query("setup_session_id");
-    if (!setupSessionId) {
+    const contractId = ctx.req.query("contract_id");
+    if (!contractId) {
       return apiError(ctx, {
         status_code: 400,
         api_error: {
           type: "invalid_request_error",
-          message: "Missing required query parameter: setup_session_id.",
+          message: "Missing required query parameter: contract_id.",
         },
       });
     }
 
     const checkoutPayment = await getCheckoutPaymentStatus({
       workspaceId: auth.getNonNullableWorkspace().sId,
-      setupSessionId,
+      contractId,
     });
 
     return ctx.json({ checkoutPayment });

--- a/front-api/routes/w/[wId]/subscriptions/checkout/index.ts
+++ b/front-api/routes/w/[wId]/subscriptions/checkout/index.ts
@@ -1,11 +1,13 @@
 import { workspaceApp } from "@front-api/middlewares/ctx";
 
+import checkoutPaymentStatus from "./checkout-payment-status";
 import payment from "./payment";
 import preparePayment from "./prepare-payment";
 
 // Mounted at /api/w/:wId/subscriptions/checkout.
 const app = workspaceApp();
 
+app.route("/checkout-payment-status", checkoutPaymentStatus);
 app.route("/payment", payment);
 app.route("/prepare-payment", preparePayment);
 

--- a/front/lib/api/checkout/types.ts
+++ b/front/lib/api/checkout/types.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+// Base paid seat types for the self-serve checkout flow.
+// "pro" and "max" only — the yearly variant is expressed by billingPeriod,
+// not by the seat type (unlike MembershipSeatType which has "pro_yearly" etc.).
+export const CHECKOUT_SEAT_TYPES = ["pro", "max"] as const;
+export type CheckoutSeatType = (typeof CHECKOUT_SEAT_TYPES)[number];
+export const CheckoutSeatTypeSchema = z.enum(CHECKOUT_SEAT_TYPES);
+
+export const CHECKOUT_BILLING_PERIODS = ["monthly", "yearly"] as const;
+export type CheckoutBillingPeriod = (typeof CHECKOUT_BILLING_PERIODS)[number];
+export const CheckoutBillingPeriodSchema = z.enum(CHECKOUT_BILLING_PERIODS);

--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -71,6 +71,7 @@ export type RedisUsageTagsType =
   | "metronome_limit"
   | "metronome_webhook_dedup"
   | "awu_purchase_status"
+  | "checkout_payment_status"
   | "message_events"
   | "notion_url_sync"
   | "poke_cache_invalidation"

--- a/front/lib/api/subscription.ts
+++ b/front/lib/api/subscription.ts
@@ -32,6 +32,16 @@ export async function isMetronomeBillingEnabled(
   return hasFlag || !killed;
 }
 
+export async function isMetronomeCheckoutEnabled(
+  auth: Authenticator
+): Promise<boolean> {
+  const [metronomeBilling, hasCheckoutFlag] = await Promise.all([
+    isMetronomeBillingEnabled(auth),
+    hasFeatureFlag(auth, "metronome_cp_checkout"),
+  ]);
+  return metronomeBilling && hasCheckoutFlag;
+}
+
 /**
  * Restores a workspace to full functionality after subscription activation/reactivation.
  * This function is called when:

--- a/front/lib/credits/checkout_payment_status.test.ts
+++ b/front/lib/credits/checkout_payment_status.test.ts
@@ -1,0 +1,280 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// In-memory Redis store shared across all mock calls within a test.
+const store: Map<string, string> = new Map();
+
+vi.mock("@app/lib/api/redis", () => ({
+  runOnRedisCache: vi.fn(
+    async (_opts: unknown, fn: (cli: unknown) => Promise<unknown>) => {
+      const cli = {
+        get: async (key: string) => store.get(key) ?? null,
+        set: async (key: string, value: string) => {
+          store.set(key, value);
+        },
+      };
+      return fn(cli);
+    }
+  ),
+}));
+
+import {
+  getCheckoutPaymentStatus,
+  markCheckoutPaymentFailed,
+  markCheckoutPaymentSucceeded,
+  recordCheckoutPaymentSyncFailure,
+  setCheckoutPaymentPending,
+} from "@app/lib/credits/checkout_payment_status";
+
+const BASE_INPUT = {
+  workspaceId: "ws_test",
+  setupSessionId: "cs_test_123",
+  contractId: "contract_abc",
+  userId: "user_1",
+  targetUserId: "user_2",
+  seatType: "pro" as const,
+  billingPeriod: "monthly" as const,
+  currency: "usd" as const,
+  initialAmountCents: 3000,
+  uniquenessKey: "checkout-payment-ws_test-cs_test_123",
+};
+
+describe("checkout_payment_status Redis helpers", () => {
+  beforeEach(() => {
+    store.clear();
+  });
+
+  describe("setCheckoutPaymentPending", () => {
+    it("stores a pending entry with correct fields", async () => {
+      await setCheckoutPaymentPending(BASE_INPUT);
+
+      const result = await getCheckoutPaymentStatus({
+        workspaceId: BASE_INPUT.workspaceId,
+        setupSessionId: BASE_INPUT.setupSessionId,
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe("pending");
+      expect(result!.workspaceId).toBe(BASE_INPUT.workspaceId);
+      expect(result!.setupSessionId).toBe(BASE_INPUT.setupSessionId);
+      expect(result!.contractId).toBe(BASE_INPUT.contractId);
+      expect(result!.seatType).toBe("pro");
+      expect(result!.billingPeriod).toBe("monthly");
+      expect(result!.currency).toBe("usd");
+      expect(result!.initialAmountCents).toBe(3000);
+      expect(typeof result!.createdAtMs).toBe("number");
+    });
+
+    it("keys entries by workspaceId + setupSessionId", async () => {
+      await setCheckoutPaymentPending(BASE_INPUT);
+      await setCheckoutPaymentPending({
+        ...BASE_INPUT,
+        setupSessionId: "cs_other",
+        contractId: "contract_other",
+      });
+
+      const first = await getCheckoutPaymentStatus({
+        workspaceId: BASE_INPUT.workspaceId,
+        setupSessionId: BASE_INPUT.setupSessionId,
+      });
+      const second = await getCheckoutPaymentStatus({
+        workspaceId: BASE_INPUT.workspaceId,
+        setupSessionId: "cs_other",
+      });
+
+      expect(first!.contractId).toBe("contract_abc");
+      expect(second!.contractId).toBe("contract_other");
+    });
+  });
+
+  describe("getCheckoutPaymentStatus", () => {
+    it("returns null when no entry exists", async () => {
+      const result = await getCheckoutPaymentStatus({
+        workspaceId: "ws_test",
+        setupSessionId: "cs_nonexistent",
+      });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("markCheckoutPaymentSucceeded", () => {
+    it("updates status to succeeded and stores invoiceId", async () => {
+      await setCheckoutPaymentPending(BASE_INPUT);
+
+      const result = await markCheckoutPaymentSucceeded({
+        workspaceId: BASE_INPUT.workspaceId,
+        setupSessionId: BASE_INPUT.setupSessionId,
+        contractId: BASE_INPUT.contractId,
+        invoiceId: "in_invoice_1",
+      });
+
+      expect(result!.status).toBe("succeeded");
+      expect(result!.invoiceId).toBe("in_invoice_1");
+
+      const stored = await getCheckoutPaymentStatus({
+        workspaceId: BASE_INPUT.workspaceId,
+        setupSessionId: BASE_INPUT.setupSessionId,
+      });
+      expect(stored!.status).toBe("succeeded");
+    });
+
+    it("returns null when no entry exists", async () => {
+      const result = await markCheckoutPaymentSucceeded({
+        workspaceId: "ws_test",
+        setupSessionId: "cs_nonexistent",
+        contractId: "contract_abc",
+        invoiceId: "in_1",
+      });
+      expect(result).toBeNull();
+    });
+
+    it("ignores update when contractId does not match (stale webhook)", async () => {
+      await setCheckoutPaymentPending(BASE_INPUT);
+
+      const result = await markCheckoutPaymentSucceeded({
+        workspaceId: BASE_INPUT.workspaceId,
+        setupSessionId: BASE_INPUT.setupSessionId,
+        contractId: "contract_stale",
+        invoiceId: "in_stale",
+      });
+
+      expect(result).toBeNull();
+
+      const stored = await getCheckoutPaymentStatus({
+        workspaceId: BASE_INPUT.workspaceId,
+        setupSessionId: BASE_INPUT.setupSessionId,
+      });
+      expect(stored!.status).toBe("pending");
+    });
+
+    it("is idempotent: second success does not overwrite the first", async () => {
+      await setCheckoutPaymentPending(BASE_INPUT);
+
+      await markCheckoutPaymentSucceeded({
+        workspaceId: BASE_INPUT.workspaceId,
+        setupSessionId: BASE_INPUT.setupSessionId,
+        contractId: BASE_INPUT.contractId,
+        invoiceId: "in_first",
+      });
+
+      const second = await markCheckoutPaymentSucceeded({
+        workspaceId: BASE_INPUT.workspaceId,
+        setupSessionId: BASE_INPUT.setupSessionId,
+        contractId: BASE_INPUT.contractId,
+        invoiceId: "in_second",
+      });
+
+      // Returns the existing succeeded entry unchanged.
+      expect(second!.invoiceId).toBe("in_first");
+
+      const stored = await getCheckoutPaymentStatus({
+        workspaceId: BASE_INPUT.workspaceId,
+        setupSessionId: BASE_INPUT.setupSessionId,
+      });
+      expect(stored!.invoiceId).toBe("in_first");
+    });
+  });
+
+  describe("markCheckoutPaymentFailed", () => {
+    it("updates status to failed with errorMessage", async () => {
+      await setCheckoutPaymentPending(BASE_INPUT);
+
+      const result = await markCheckoutPaymentFailed({
+        workspaceId: BASE_INPUT.workspaceId,
+        setupSessionId: BASE_INPUT.setupSessionId,
+        contractId: BASE_INPUT.contractId,
+        errorMessage: "Card declined",
+      });
+
+      expect(result!.status).toBe("failed");
+      expect(result!.errorMessage).toBe("Card declined");
+    });
+
+    it("stores invoiceId when provided", async () => {
+      await setCheckoutPaymentPending(BASE_INPUT);
+
+      const result = await markCheckoutPaymentFailed({
+        workspaceId: BASE_INPUT.workspaceId,
+        setupSessionId: BASE_INPUT.setupSessionId,
+        contractId: BASE_INPUT.contractId,
+        errorMessage: "Insufficient funds",
+        invoiceId: "in_failed",
+      });
+
+      expect(result!.invoiceId).toBe("in_failed");
+    });
+
+    it("ignores update when contractId does not match", async () => {
+      await setCheckoutPaymentPending(BASE_INPUT);
+
+      const result = await markCheckoutPaymentFailed({
+        workspaceId: BASE_INPUT.workspaceId,
+        setupSessionId: BASE_INPUT.setupSessionId,
+        contractId: "contract_stale",
+        errorMessage: "stale",
+      });
+
+      expect(result).toBeNull();
+
+      const stored = await getCheckoutPaymentStatus({
+        workspaceId: BASE_INPUT.workspaceId,
+        setupSessionId: BASE_INPUT.setupSessionId,
+      });
+      expect(stored!.status).toBe("pending");
+    });
+
+    it("does not overwrite a succeeded entry", async () => {
+      await setCheckoutPaymentPending(BASE_INPUT);
+      await markCheckoutPaymentSucceeded({
+        workspaceId: BASE_INPUT.workspaceId,
+        setupSessionId: BASE_INPUT.setupSessionId,
+        contractId: BASE_INPUT.contractId,
+        invoiceId: "in_1",
+      });
+
+      const result = await markCheckoutPaymentFailed({
+        workspaceId: BASE_INPUT.workspaceId,
+        setupSessionId: BASE_INPUT.setupSessionId,
+        contractId: BASE_INPUT.contractId,
+        errorMessage: "late failure",
+      });
+
+      // updatePaymentIfContractMatches guards on status === "succeeded".
+      expect(result!.status).toBe("succeeded");
+
+      const stored = await getCheckoutPaymentStatus({
+        workspaceId: BASE_INPUT.workspaceId,
+        setupSessionId: BASE_INPUT.setupSessionId,
+      });
+      expect(stored!.status).toBe("succeeded");
+    });
+  });
+
+  describe("recordCheckoutPaymentSyncFailure", () => {
+    it("marks a pending entry as failed unconditionally", async () => {
+      await setCheckoutPaymentPending(BASE_INPUT);
+
+      await recordCheckoutPaymentSyncFailure({
+        workspaceId: BASE_INPUT.workspaceId,
+        setupSessionId: BASE_INPUT.setupSessionId,
+        errorMessage: "Metronome call failed",
+      });
+
+      const stored = await getCheckoutPaymentStatus({
+        workspaceId: BASE_INPUT.workspaceId,
+        setupSessionId: BASE_INPUT.setupSessionId,
+      });
+      expect(stored!.status).toBe("failed");
+      expect(stored!.errorMessage).toBe("Metronome call failed");
+    });
+
+    it("is a no-op when no entry exists", async () => {
+      await expect(
+        recordCheckoutPaymentSyncFailure({
+          workspaceId: "ws_test",
+          setupSessionId: "cs_nonexistent",
+          errorMessage: "error",
+        })
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/front/lib/credits/checkout_payment_status.test.ts
+++ b/front/lib/credits/checkout_payment_status.test.ts
@@ -27,7 +27,6 @@ import {
 
 const BASE_INPUT = {
   workspaceId: "ws_test",
-  setupSessionId: "cs_test_123",
   contractId: "contract_abc",
   userId: "user_1",
   targetUserId: "user_2",
@@ -35,7 +34,7 @@ const BASE_INPUT = {
   billingPeriod: "monthly" as const,
   currency: "usd" as const,
   initialAmountCents: 3000,
-  uniquenessKey: "checkout-payment-ws_test-cs_test_123",
+  uniquenessKey: "checkout-payment-ws_test-contract_abc",
 };
 
 describe("checkout_payment_status Redis helpers", () => {
@@ -49,13 +48,12 @@ describe("checkout_payment_status Redis helpers", () => {
 
       const result = await getCheckoutPaymentStatus({
         workspaceId: BASE_INPUT.workspaceId,
-        setupSessionId: BASE_INPUT.setupSessionId,
+        contractId: BASE_INPUT.contractId,
       });
 
       expect(result).not.toBeNull();
       expect(result!.status).toBe("pending");
       expect(result!.workspaceId).toBe(BASE_INPUT.workspaceId);
-      expect(result!.setupSessionId).toBe(BASE_INPUT.setupSessionId);
       expect(result!.contractId).toBe(BASE_INPUT.contractId);
       expect(result!.seatType).toBe("pro");
       expect(result!.billingPeriod).toBe("monthly");
@@ -64,21 +62,20 @@ describe("checkout_payment_status Redis helpers", () => {
       expect(typeof result!.createdAtMs).toBe("number");
     });
 
-    it("keys entries by workspaceId + setupSessionId", async () => {
+    it("keys entries by workspaceId + contractId", async () => {
       await setCheckoutPaymentPending(BASE_INPUT);
       await setCheckoutPaymentPending({
         ...BASE_INPUT,
-        setupSessionId: "cs_other",
         contractId: "contract_other",
       });
 
       const first = await getCheckoutPaymentStatus({
         workspaceId: BASE_INPUT.workspaceId,
-        setupSessionId: BASE_INPUT.setupSessionId,
+        contractId: BASE_INPUT.contractId,
       });
       const second = await getCheckoutPaymentStatus({
         workspaceId: BASE_INPUT.workspaceId,
-        setupSessionId: "cs_other",
+        contractId: "contract_other",
       });
 
       expect(first!.contractId).toBe("contract_abc");
@@ -90,7 +87,7 @@ describe("checkout_payment_status Redis helpers", () => {
     it("returns null when no entry exists", async () => {
       const result = await getCheckoutPaymentStatus({
         workspaceId: "ws_test",
-        setupSessionId: "cs_nonexistent",
+        contractId: "contract_nonexistent",
       });
       expect(result).toBeNull();
     });
@@ -102,7 +99,6 @@ describe("checkout_payment_status Redis helpers", () => {
 
       const result = await markCheckoutPaymentSucceeded({
         workspaceId: BASE_INPUT.workspaceId,
-        setupSessionId: BASE_INPUT.setupSessionId,
         contractId: BASE_INPUT.contractId,
         invoiceId: "in_invoice_1",
       });
@@ -112,7 +108,7 @@ describe("checkout_payment_status Redis helpers", () => {
 
       const stored = await getCheckoutPaymentStatus({
         workspaceId: BASE_INPUT.workspaceId,
-        setupSessionId: BASE_INPUT.setupSessionId,
+        contractId: BASE_INPUT.contractId,
       });
       expect(stored!.status).toBe("succeeded");
     });
@@ -120,30 +116,10 @@ describe("checkout_payment_status Redis helpers", () => {
     it("returns null when no entry exists", async () => {
       const result = await markCheckoutPaymentSucceeded({
         workspaceId: "ws_test",
-        setupSessionId: "cs_nonexistent",
-        contractId: "contract_abc",
+        contractId: "contract_nonexistent",
         invoiceId: "in_1",
       });
       expect(result).toBeNull();
-    });
-
-    it("ignores update when contractId does not match (stale webhook)", async () => {
-      await setCheckoutPaymentPending(BASE_INPUT);
-
-      const result = await markCheckoutPaymentSucceeded({
-        workspaceId: BASE_INPUT.workspaceId,
-        setupSessionId: BASE_INPUT.setupSessionId,
-        contractId: "contract_stale",
-        invoiceId: "in_stale",
-      });
-
-      expect(result).toBeNull();
-
-      const stored = await getCheckoutPaymentStatus({
-        workspaceId: BASE_INPUT.workspaceId,
-        setupSessionId: BASE_INPUT.setupSessionId,
-      });
-      expect(stored!.status).toBe("pending");
     });
 
     it("is idempotent: second success does not overwrite the first", async () => {
@@ -151,14 +127,12 @@ describe("checkout_payment_status Redis helpers", () => {
 
       await markCheckoutPaymentSucceeded({
         workspaceId: BASE_INPUT.workspaceId,
-        setupSessionId: BASE_INPUT.setupSessionId,
         contractId: BASE_INPUT.contractId,
         invoiceId: "in_first",
       });
 
       const second = await markCheckoutPaymentSucceeded({
         workspaceId: BASE_INPUT.workspaceId,
-        setupSessionId: BASE_INPUT.setupSessionId,
         contractId: BASE_INPUT.contractId,
         invoiceId: "in_second",
       });
@@ -168,7 +142,7 @@ describe("checkout_payment_status Redis helpers", () => {
 
       const stored = await getCheckoutPaymentStatus({
         workspaceId: BASE_INPUT.workspaceId,
-        setupSessionId: BASE_INPUT.setupSessionId,
+        contractId: BASE_INPUT.contractId,
       });
       expect(stored!.invoiceId).toBe("in_first");
     });
@@ -180,7 +154,6 @@ describe("checkout_payment_status Redis helpers", () => {
 
       const result = await markCheckoutPaymentFailed({
         workspaceId: BASE_INPUT.workspaceId,
-        setupSessionId: BASE_INPUT.setupSessionId,
         contractId: BASE_INPUT.contractId,
         errorMessage: "Card declined",
       });
@@ -194,7 +167,6 @@ describe("checkout_payment_status Redis helpers", () => {
 
       const result = await markCheckoutPaymentFailed({
         workspaceId: BASE_INPUT.workspaceId,
-        setupSessionId: BASE_INPUT.setupSessionId,
         contractId: BASE_INPUT.contractId,
         errorMessage: "Insufficient funds",
         invoiceId: "in_failed",
@@ -203,47 +175,26 @@ describe("checkout_payment_status Redis helpers", () => {
       expect(result!.invoiceId).toBe("in_failed");
     });
 
-    it("ignores update when contractId does not match", async () => {
-      await setCheckoutPaymentPending(BASE_INPUT);
-
-      const result = await markCheckoutPaymentFailed({
-        workspaceId: BASE_INPUT.workspaceId,
-        setupSessionId: BASE_INPUT.setupSessionId,
-        contractId: "contract_stale",
-        errorMessage: "stale",
-      });
-
-      expect(result).toBeNull();
-
-      const stored = await getCheckoutPaymentStatus({
-        workspaceId: BASE_INPUT.workspaceId,
-        setupSessionId: BASE_INPUT.setupSessionId,
-      });
-      expect(stored!.status).toBe("pending");
-    });
-
     it("does not overwrite a succeeded entry", async () => {
       await setCheckoutPaymentPending(BASE_INPUT);
       await markCheckoutPaymentSucceeded({
         workspaceId: BASE_INPUT.workspaceId,
-        setupSessionId: BASE_INPUT.setupSessionId,
         contractId: BASE_INPUT.contractId,
         invoiceId: "in_1",
       });
 
       const result = await markCheckoutPaymentFailed({
         workspaceId: BASE_INPUT.workspaceId,
-        setupSessionId: BASE_INPUT.setupSessionId,
         contractId: BASE_INPUT.contractId,
         errorMessage: "late failure",
       });
 
-      // updatePaymentIfContractMatches guards on status === "succeeded".
+      // updatePayment guards on status === "succeeded".
       expect(result!.status).toBe("succeeded");
 
       const stored = await getCheckoutPaymentStatus({
         workspaceId: BASE_INPUT.workspaceId,
-        setupSessionId: BASE_INPUT.setupSessionId,
+        contractId: BASE_INPUT.contractId,
       });
       expect(stored!.status).toBe("succeeded");
     });
@@ -255,13 +206,13 @@ describe("checkout_payment_status Redis helpers", () => {
 
       await recordCheckoutPaymentSyncFailure({
         workspaceId: BASE_INPUT.workspaceId,
-        setupSessionId: BASE_INPUT.setupSessionId,
+        contractId: BASE_INPUT.contractId,
         errorMessage: "Metronome call failed",
       });
 
       const stored = await getCheckoutPaymentStatus({
         workspaceId: BASE_INPUT.workspaceId,
-        setupSessionId: BASE_INPUT.setupSessionId,
+        contractId: BASE_INPUT.contractId,
       });
       expect(stored!.status).toBe("failed");
       expect(stored!.errorMessage).toBe("Metronome call failed");
@@ -271,7 +222,7 @@ describe("checkout_payment_status Redis helpers", () => {
       await expect(
         recordCheckoutPaymentSyncFailure({
           workspaceId: "ws_test",
-          setupSessionId: "cs_nonexistent",
+          contractId: "contract_nonexistent",
           errorMessage: "error",
         })
       ).resolves.toBeUndefined();

--- a/front/lib/credits/checkout_payment_status.ts
+++ b/front/lib/credits/checkout_payment_status.ts
@@ -12,7 +12,6 @@ export type CheckoutPaymentStatus = "pending" | "succeeded" | "failed";
 export type CheckoutPayment = {
   status: CheckoutPaymentStatus;
   workspaceId: string;
-  setupSessionId: string;
   contractId: string;
   userId: string;
   targetUserId: string;
@@ -31,8 +30,8 @@ export type CheckoutPayment = {
 // 1 hour: matches a generous bound on the webhook delivery / UI polling
 const TTL_SECONDS = 60 * 60;
 
-function redisKey(workspaceId: string, setupSessionId: string): string {
-  return `checkout_payment:${workspaceId}:${setupSessionId}`;
+function redisKey(workspaceId: string, contractId: string): string {
+  return `checkout_payment:${workspaceId}:${contractId}`;
 }
 
 export async function setCheckoutPaymentPending(
@@ -45,7 +44,7 @@ export async function setCheckoutPaymentPending(
   };
   await runOnRedisCache({ origin: REDIS_ORIGIN }, async (cli) => {
     await cli.set(
-      redisKey(input.workspaceId, input.setupSessionId),
+      redisKey(input.workspaceId, input.contractId),
       JSON.stringify(payment),
       { EX: TTL_SECONDS }
     );
@@ -54,13 +53,13 @@ export async function setCheckoutPaymentPending(
 
 export async function getCheckoutPaymentStatus({
   workspaceId,
-  setupSessionId,
+  contractId,
 }: {
   workspaceId: string;
-  setupSessionId: string;
+  contractId: string;
 }): Promise<CheckoutPayment | null> {
   return runOnRedisCache({ origin: REDIS_ORIGIN }, async (cli) => {
-    const raw = await cli.get(redisKey(workspaceId, setupSessionId));
+    const raw = await cli.get(redisKey(workspaceId, contractId));
     if (!raw) {
       return null;
     }
@@ -68,7 +67,7 @@ export async function getCheckoutPaymentStatus({
       return JSON.parse(raw) as CheckoutPayment;
     } catch (err) {
       logger.warn(
-        { workspaceId, setupSessionId, err },
+        { workspaceId, contractId, err },
         "[Checkout Payment Status] Failed to parse stored payment"
       );
       return null;
@@ -76,17 +75,13 @@ export async function getCheckoutPaymentStatus({
   });
 }
 
-// Update the stored payment if (and only if) the contractId matches what was
-// written at payment time. Mismatched contracts indicate stale webhook
-// deliveries and must be ignored.
-async function updatePaymentIfContractMatches(
+async function updatePayment(
   workspaceId: string,
-  setupSessionId: string,
   contractId: string,
   apply: (current: CheckoutPayment) => CheckoutPayment
 ): Promise<CheckoutPayment | null> {
   return runOnRedisCache({ origin: REDIS_ORIGIN }, async (cli) => {
-    const raw = await cli.get(redisKey(workspaceId, setupSessionId));
+    const raw = await cli.get(redisKey(workspaceId, contractId));
     if (!raw) {
       return null;
     }
@@ -96,81 +91,66 @@ async function updatePaymentIfContractMatches(
     } catch {
       return null;
     }
-    if (current.contractId !== contractId) {
-      return null;
-    }
     // Idempotency: if already succeeded, do not overwrite.
     if (current.status === "succeeded") {
       return current;
     }
     const updated = apply(current);
-    await cli.set(
-      redisKey(workspaceId, setupSessionId),
-      JSON.stringify(updated),
-      { EX: TTL_SECONDS }
-    );
+    await cli.set(redisKey(workspaceId, contractId), JSON.stringify(updated), {
+      EX: TTL_SECONDS,
+    });
     return updated;
   });
 }
 
 export async function markCheckoutPaymentSucceeded({
   workspaceId,
-  setupSessionId,
   contractId,
   invoiceId,
 }: {
   workspaceId: string;
-  setupSessionId: string;
   contractId: string;
   invoiceId: string;
 }): Promise<CheckoutPayment | null> {
-  return updatePaymentIfContractMatches(
-    workspaceId,
-    setupSessionId,
-    contractId,
-    (current) => ({ ...current, status: "succeeded", invoiceId })
-  );
+  return updatePayment(workspaceId, contractId, (current) => ({
+    ...current,
+    status: "succeeded",
+    invoiceId,
+  }));
 }
 
 export async function markCheckoutPaymentFailed({
   workspaceId,
-  setupSessionId,
   contractId,
   errorMessage,
   invoiceId,
 }: {
   workspaceId: string;
-  setupSessionId: string;
   contractId: string;
   errorMessage: string;
   invoiceId?: string;
 }): Promise<CheckoutPayment | null> {
-  return updatePaymentIfContractMatches(
-    workspaceId,
-    setupSessionId,
-    contractId,
-    (current) => ({
-      ...current,
-      status: "failed",
-      errorMessage,
-      invoiceId: invoiceId ?? current.invoiceId,
-    })
-  );
+  return updatePayment(workspaceId, contractId, (current) => ({
+    ...current,
+    status: "failed",
+    errorMessage,
+    invoiceId: invoiceId ?? current.invoiceId,
+  }));
 }
 
 // Used when the Metronome call fails synchronously (no webhook will fire).
 // Unconditional overwrite of the entry we just wrote.
 export async function recordCheckoutPaymentSyncFailure({
   workspaceId,
-  setupSessionId,
+  contractId,
   errorMessage,
 }: {
   workspaceId: string;
-  setupSessionId: string;
+  contractId: string;
   errorMessage: string;
 }): Promise<void> {
   await runOnRedisCache({ origin: REDIS_ORIGIN }, async (cli) => {
-    const raw = await cli.get(redisKey(workspaceId, setupSessionId));
+    const raw = await cli.get(redisKey(workspaceId, contractId));
     if (!raw) {
       return;
     }
@@ -185,10 +165,8 @@ export async function recordCheckoutPaymentSyncFailure({
       status: "failed",
       errorMessage,
     };
-    await cli.set(
-      redisKey(workspaceId, setupSessionId),
-      JSON.stringify(updated),
-      { EX: TTL_SECONDS }
-    );
+    await cli.set(redisKey(workspaceId, contractId), JSON.stringify(updated), {
+      EX: TTL_SECONDS,
+    });
   });
 }

--- a/front/lib/credits/checkout_payment_status.ts
+++ b/front/lib/credits/checkout_payment_status.ts
@@ -1,31 +1,34 @@
-import type {
-  CheckoutBillingPeriod,
-  CheckoutSeatType,
+import {
+  CheckoutBillingPeriodSchema,
+  CheckoutSeatTypeSchema,
 } from "@app/lib/api/checkout/types";
 import { runOnRedisCache } from "@app/lib/api/redis";
 import logger from "@app/logger/logger";
+import { z } from "zod";
 
 const REDIS_ORIGIN = "checkout_payment_status";
 
 export type CheckoutPaymentStatus = "pending" | "succeeded" | "failed";
 
-export type CheckoutPayment = {
-  status: CheckoutPaymentStatus;
-  workspaceId: string;
-  contractId: string;
-  userId: string;
-  targetUserId: string;
-  seatType: CheckoutSeatType;
-  billingPeriod: CheckoutBillingPeriod;
-  currency: "usd" | "eur";
-  initialAmountCents: number;
-  couponCode?: string;
-  couponRedemptionId?: string;
-  uniquenessKey: string;
-  createdAtMs: number;
-  invoiceId?: string;
-  errorMessage?: string;
-};
+export const CheckoutPaymentSchema = z.object({
+  status: z.enum(["pending", "succeeded", "failed"]),
+  workspaceId: z.string(),
+  contractId: z.string(),
+  userId: z.string(),
+  targetUserId: z.string(),
+  seatType: CheckoutSeatTypeSchema,
+  billingPeriod: CheckoutBillingPeriodSchema,
+  currency: z.enum(["usd", "eur"]),
+  initialAmountCents: z.number(),
+  couponCode: z.string().optional(),
+  couponRedemptionId: z.string().optional(),
+  uniquenessKey: z.string(),
+  createdAtMs: z.number(),
+  invoiceId: z.string().optional(),
+  errorMessage: z.string().optional(),
+});
+
+export type CheckoutPayment = z.infer<typeof CheckoutPaymentSchema>;
 
 // 1 hour: matches a generous bound on the webhook delivery / UI polling
 const TTL_SECONDS = 60 * 60;
@@ -63,15 +66,15 @@ export async function getCheckoutPaymentStatus({
     if (!raw) {
       return null;
     }
-    try {
-      return JSON.parse(raw) as CheckoutPayment;
-    } catch (err) {
+    const parsed = CheckoutPaymentSchema.safeParse(JSON.parse(raw));
+    if (!parsed.success) {
       logger.warn(
-        { workspaceId, contractId, err },
-        "[Checkout Payment Status] Failed to parse stored payment"
+        { workspaceId, contractId },
+        "[Checkout Payment Status] Stored payment failed schema validation"
       );
       return null;
     }
+    return parsed.data;
   });
 }
 
@@ -85,12 +88,11 @@ async function updatePayment(
     if (!raw) {
       return null;
     }
-    let current: CheckoutPayment;
-    try {
-      current = JSON.parse(raw) as CheckoutPayment;
-    } catch {
+    const parsedCurrent = CheckoutPaymentSchema.safeParse(JSON.parse(raw));
+    if (!parsedCurrent.success) {
       return null;
     }
+    const current = parsedCurrent.data;
     // Idempotency: if already succeeded, do not overwrite.
     if (current.status === "succeeded") {
       return current;
@@ -154,12 +156,11 @@ export async function recordCheckoutPaymentSyncFailure({
     if (!raw) {
       return;
     }
-    let current: CheckoutPayment;
-    try {
-      current = JSON.parse(raw) as CheckoutPayment;
-    } catch {
+    const parsedCurrent = CheckoutPaymentSchema.safeParse(JSON.parse(raw));
+    if (!parsedCurrent.success) {
       return;
     }
+    const current = parsedCurrent.data;
     const updated: CheckoutPayment = {
       ...current,
       status: "failed",

--- a/front/lib/credits/checkout_payment_status.ts
+++ b/front/lib/credits/checkout_payment_status.ts
@@ -1,0 +1,194 @@
+import type {
+  CheckoutBillingPeriod,
+  CheckoutSeatType,
+} from "@app/lib/api/checkout/types";
+import { runOnRedisCache } from "@app/lib/api/redis";
+import logger from "@app/logger/logger";
+
+const REDIS_ORIGIN = "checkout_payment_status";
+
+export type CheckoutPaymentStatus = "pending" | "succeeded" | "failed";
+
+export type CheckoutPayment = {
+  status: CheckoutPaymentStatus;
+  workspaceId: string;
+  setupSessionId: string;
+  contractId: string;
+  userId: string;
+  targetUserId: string;
+  seatType: CheckoutSeatType;
+  billingPeriod: CheckoutBillingPeriod;
+  currency: "usd" | "eur";
+  initialAmountCents: number;
+  couponCode?: string;
+  couponRedemptionId?: string;
+  uniquenessKey: string;
+  createdAtMs: number;
+  invoiceId?: string;
+  errorMessage?: string;
+};
+
+// 1 hour: matches a generous bound on the webhook delivery / UI polling
+const TTL_SECONDS = 60 * 60;
+
+function redisKey(workspaceId: string, setupSessionId: string): string {
+  return `checkout_payment:${workspaceId}:${setupSessionId}`;
+}
+
+export async function setCheckoutPaymentPending(
+  input: Omit<CheckoutPayment, "status" | "createdAtMs">
+): Promise<void> {
+  const payment: CheckoutPayment = {
+    ...input,
+    status: "pending",
+    createdAtMs: Date.now(),
+  };
+  await runOnRedisCache({ origin: REDIS_ORIGIN }, async (cli) => {
+    await cli.set(
+      redisKey(input.workspaceId, input.setupSessionId),
+      JSON.stringify(payment),
+      { EX: TTL_SECONDS }
+    );
+  });
+}
+
+export async function getCheckoutPaymentStatus({
+  workspaceId,
+  setupSessionId,
+}: {
+  workspaceId: string;
+  setupSessionId: string;
+}): Promise<CheckoutPayment | null> {
+  return runOnRedisCache({ origin: REDIS_ORIGIN }, async (cli) => {
+    const raw = await cli.get(redisKey(workspaceId, setupSessionId));
+    if (!raw) {
+      return null;
+    }
+    try {
+      return JSON.parse(raw) as CheckoutPayment;
+    } catch (err) {
+      logger.warn(
+        { workspaceId, setupSessionId, err },
+        "[Checkout Payment Status] Failed to parse stored payment"
+      );
+      return null;
+    }
+  });
+}
+
+// Update the stored payment if (and only if) the contractId matches what was
+// written at payment time. Mismatched contracts indicate stale webhook
+// deliveries and must be ignored.
+async function updatePaymentIfContractMatches(
+  workspaceId: string,
+  setupSessionId: string,
+  contractId: string,
+  apply: (current: CheckoutPayment) => CheckoutPayment
+): Promise<CheckoutPayment | null> {
+  return runOnRedisCache({ origin: REDIS_ORIGIN }, async (cli) => {
+    const raw = await cli.get(redisKey(workspaceId, setupSessionId));
+    if (!raw) {
+      return null;
+    }
+    let current: CheckoutPayment;
+    try {
+      current = JSON.parse(raw) as CheckoutPayment;
+    } catch {
+      return null;
+    }
+    if (current.contractId !== contractId) {
+      return null;
+    }
+    // Idempotency: if already succeeded, do not overwrite.
+    if (current.status === "succeeded") {
+      return current;
+    }
+    const updated = apply(current);
+    await cli.set(
+      redisKey(workspaceId, setupSessionId),
+      JSON.stringify(updated),
+      { EX: TTL_SECONDS }
+    );
+    return updated;
+  });
+}
+
+export async function markCheckoutPaymentSucceeded({
+  workspaceId,
+  setupSessionId,
+  contractId,
+  invoiceId,
+}: {
+  workspaceId: string;
+  setupSessionId: string;
+  contractId: string;
+  invoiceId: string;
+}): Promise<CheckoutPayment | null> {
+  return updatePaymentIfContractMatches(
+    workspaceId,
+    setupSessionId,
+    contractId,
+    (current) => ({ ...current, status: "succeeded", invoiceId })
+  );
+}
+
+export async function markCheckoutPaymentFailed({
+  workspaceId,
+  setupSessionId,
+  contractId,
+  errorMessage,
+  invoiceId,
+}: {
+  workspaceId: string;
+  setupSessionId: string;
+  contractId: string;
+  errorMessage: string;
+  invoiceId?: string;
+}): Promise<CheckoutPayment | null> {
+  return updatePaymentIfContractMatches(
+    workspaceId,
+    setupSessionId,
+    contractId,
+    (current) => ({
+      ...current,
+      status: "failed",
+      errorMessage,
+      invoiceId: invoiceId ?? current.invoiceId,
+    })
+  );
+}
+
+// Used when the Metronome call fails synchronously (no webhook will fire).
+// Unconditional overwrite of the entry we just wrote.
+export async function recordCheckoutPaymentSyncFailure({
+  workspaceId,
+  setupSessionId,
+  errorMessage,
+}: {
+  workspaceId: string;
+  setupSessionId: string;
+  errorMessage: string;
+}): Promise<void> {
+  await runOnRedisCache({ origin: REDIS_ORIGIN }, async (cli) => {
+    const raw = await cli.get(redisKey(workspaceId, setupSessionId));
+    if (!raw) {
+      return;
+    }
+    let current: CheckoutPayment;
+    try {
+      current = JSON.parse(raw) as CheckoutPayment;
+    } catch {
+      return;
+    }
+    const updated: CheckoutPayment = {
+      ...current,
+      status: "failed",
+      errorMessage,
+    };
+    await cli.set(
+      redisKey(workspaceId, setupSessionId),
+      JSON.stringify(updated),
+      { EX: TTL_SECONDS }
+    );
+  });
+}

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -1,3 +1,4 @@
+import type { CheckoutSeatType } from "@app/lib/api/checkout/types";
 import config from "@app/lib/api/config";
 import { getMetronomeCustomerStripeCustomerId } from "@app/lib/metronome/client";
 import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
@@ -298,7 +299,7 @@ export const createEmbeddedMetronomeSetupCheckoutSession = async ({
   pricePerSeatCents?: number;
   couponCode?: string;
   user: UserType;
-  seatType?: "pro" | "max";
+  seatType?: CheckoutSeatType;
   targetUserId?: string;
 }): Promise<{ clientSecret: string; sessionId: string }> => {
   const stripe = getStripeClient();

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -286,6 +286,8 @@ export const createEmbeddedMetronomeSetupCheckoutSession = async ({
   pricePerSeatCents,
   couponCode,
   user,
+  seatType,
+  targetUserId,
 }: {
   allowedPaymentMethods?: SupportedPaymentMethod[];
   metronomePackageAlias: string;
@@ -296,6 +298,8 @@ export const createEmbeddedMetronomeSetupCheckoutSession = async ({
   pricePerSeatCents?: number;
   couponCode?: string;
   user: UserType;
+  seatType?: "pro" | "max";
+  targetUserId?: string;
 }): Promise<{ clientSecret: string; sessionId: string }> => {
   const stripe = getStripeClient();
 
@@ -314,6 +318,12 @@ export const createEmbeddedMetronomeSetupCheckoutSession = async ({
   }
   if (couponCode) {
     metadata.couponCode = couponCode;
+  }
+  if (seatType) {
+    metadata.seatType = seatType;
+  }
+  if (targetUserId) {
+    metadata.targetUserId = targetUserId;
   }
 
   const session = await stripe.checkout.sessions.create({

--- a/front/pages/api/w/[wId]/subscriptions/checkout/checkout-payment-status.test.ts
+++ b/front/pages/api/w/[wId]/subscriptions/checkout/checkout-payment-status.test.ts
@@ -4,13 +4,11 @@ import { describe, expect, it, vi } from "vitest";
 
 import handler from "./checkout-payment-status";
 
-const MOCK_SETUP_SESSION_ID = "cs_test_setup_session_123";
 const MOCK_CONTRACT_ID = "contract_abc";
 
 const mockPendingPayment: CheckoutPayment = {
   status: "pending",
   workspaceId: "ws_test",
-  setupSessionId: MOCK_SETUP_SESSION_ID,
   contractId: MOCK_CONTRACT_ID,
   userId: "user_123",
   targetUserId: "user_123",
@@ -18,7 +16,7 @@ const mockPendingPayment: CheckoutPayment = {
   billingPeriod: "monthly",
   currency: "usd",
   initialAmountCents: 3000,
-  uniquenessKey: `checkout-payment-ws_test-${MOCK_SETUP_SESSION_ID}`,
+  uniquenessKey: `checkout-payment-ws_test-${MOCK_CONTRACT_ID}`,
   createdAtMs: 1717497600000,
 };
 
@@ -34,7 +32,7 @@ describe("GET /api/w/[wId]/subscriptions/checkout/checkout-payment-status", () =
       method: "GET",
       role: "user",
     });
-    req.query = { ...req.query, setup_session_id: MOCK_SETUP_SESSION_ID };
+    req.query = { ...req.query, contract_id: MOCK_CONTRACT_ID };
 
     await handler(req, res);
 
@@ -46,14 +44,14 @@ describe("GET /api/w/[wId]/subscriptions/checkout/checkout-payment-status", () =
       method: "POST",
       role: "admin",
     });
-    req.query = { ...req.query, setup_session_id: MOCK_SETUP_SESSION_ID };
+    req.query = { ...req.query, contract_id: MOCK_CONTRACT_ID };
 
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(405);
   });
 
-  it("returns 400 when setup_session_id is missing", async () => {
+  it("returns 400 when contract_id is missing", async () => {
     const { req, res } = await createPrivateApiMockRequest({
       method: "GET",
       role: "admin",
@@ -72,7 +70,7 @@ describe("GET /api/w/[wId]/subscriptions/checkout/checkout-payment-status", () =
       method: "GET",
       role: "admin",
     });
-    req.query = { ...req.query, setup_session_id: MOCK_SETUP_SESSION_ID };
+    req.query = { ...req.query, contract_id: MOCK_CONTRACT_ID };
 
     await handler(req, res);
 
@@ -87,14 +85,14 @@ describe("GET /api/w/[wId]/subscriptions/checkout/checkout-payment-status", () =
       method: "GET",
       role: "admin",
     });
-    req.query = { ...req.query, setup_session_id: MOCK_SETUP_SESSION_ID };
+    req.query = { ...req.query, contract_id: MOCK_CONTRACT_ID };
 
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
     const { checkoutPayment } = res._getJSONData();
     expect(checkoutPayment.status).toBe("pending");
-    expect(checkoutPayment.setupSessionId).toBe(MOCK_SETUP_SESSION_ID);
+    expect(checkoutPayment.contractId).toBe(MOCK_CONTRACT_ID);
     expect(checkoutPayment.seatType).toBe("pro");
     expect(checkoutPayment.billingPeriod).toBe("monthly");
   });
@@ -110,7 +108,7 @@ describe("GET /api/w/[wId]/subscriptions/checkout/checkout-payment-status", () =
       method: "GET",
       role: "admin",
     });
-    req.query = { ...req.query, setup_session_id: MOCK_SETUP_SESSION_ID };
+    req.query = { ...req.query, contract_id: MOCK_CONTRACT_ID };
 
     await handler(req, res);
 
@@ -120,20 +118,20 @@ describe("GET /api/w/[wId]/subscriptions/checkout/checkout-payment-status", () =
     expect(checkoutPayment.invoiceId).toBe("in_test_invoice");
   });
 
-  it("passes the correct workspaceId and setupSessionId to getCheckoutPaymentStatus", async () => {
+  it("passes the correct workspaceId and contractId to getCheckoutPaymentStatus", async () => {
     vi.mocked(getCheckoutPaymentStatus).mockResolvedValue(null);
 
     const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "GET",
       role: "admin",
     });
-    req.query = { ...req.query, setup_session_id: MOCK_SETUP_SESSION_ID };
+    req.query = { ...req.query, contract_id: MOCK_CONTRACT_ID };
 
     await handler(req, res);
 
     expect(getCheckoutPaymentStatus).toHaveBeenCalledWith({
       workspaceId: workspace.sId,
-      setupSessionId: MOCK_SETUP_SESSION_ID,
+      contractId: MOCK_CONTRACT_ID,
     });
   });
 });

--- a/front/pages/api/w/[wId]/subscriptions/checkout/checkout-payment-status.test.ts
+++ b/front/pages/api/w/[wId]/subscriptions/checkout/checkout-payment-status.test.ts
@@ -1,0 +1,139 @@
+import type { CheckoutPayment } from "@app/lib/credits/checkout_payment_status";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { describe, expect, it, vi } from "vitest";
+
+import handler from "./checkout-payment-status";
+
+const MOCK_SETUP_SESSION_ID = "cs_test_setup_session_123";
+const MOCK_CONTRACT_ID = "contract_abc";
+
+const mockPendingPayment: CheckoutPayment = {
+  status: "pending",
+  workspaceId: "ws_test",
+  setupSessionId: MOCK_SETUP_SESSION_ID,
+  contractId: MOCK_CONTRACT_ID,
+  userId: "user_123",
+  targetUserId: "user_123",
+  seatType: "pro",
+  billingPeriod: "monthly",
+  currency: "usd",
+  initialAmountCents: 3000,
+  uniquenessKey: `checkout-payment-ws_test-${MOCK_SETUP_SESSION_ID}`,
+  createdAtMs: 1717497600000,
+};
+
+vi.mock("@app/lib/credits/checkout_payment_status", () => ({
+  getCheckoutPaymentStatus: vi.fn(),
+}));
+
+import { getCheckoutPaymentStatus } from "@app/lib/credits/checkout_payment_status";
+
+describe("GET /api/w/[wId]/subscriptions/checkout/checkout-payment-status", () => {
+  it("returns 403 for non-admin users", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+    req.query = { ...req.query, setup_session_id: MOCK_SETUP_SESSION_ID };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+  });
+
+  it("returns 405 for non-GET methods", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+    req.query = { ...req.query, setup_session_id: MOCK_SETUP_SESSION_ID };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+  });
+
+  it("returns 400 when setup_session_id is missing", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  it("returns null checkoutPayment when getCheckoutPaymentStatus returns null", async () => {
+    vi.mocked(getCheckoutPaymentStatus).mockResolvedValue(null);
+
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+    req.query = { ...req.query, setup_session_id: MOCK_SETUP_SESSION_ID };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData().checkoutPayment).toBeNull();
+  });
+
+  it("returns pending checkoutPayment when found", async () => {
+    vi.mocked(getCheckoutPaymentStatus).mockResolvedValue(mockPendingPayment);
+
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+    req.query = { ...req.query, setup_session_id: MOCK_SETUP_SESSION_ID };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const { checkoutPayment } = res._getJSONData();
+    expect(checkoutPayment.status).toBe("pending");
+    expect(checkoutPayment.setupSessionId).toBe(MOCK_SETUP_SESSION_ID);
+    expect(checkoutPayment.seatType).toBe("pro");
+    expect(checkoutPayment.billingPeriod).toBe("monthly");
+  });
+
+  it("returns succeeded checkoutPayment when found", async () => {
+    vi.mocked(getCheckoutPaymentStatus).mockResolvedValue({
+      ...mockPendingPayment,
+      status: "succeeded",
+      invoiceId: "in_test_invoice",
+    });
+
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+    req.query = { ...req.query, setup_session_id: MOCK_SETUP_SESSION_ID };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const { checkoutPayment } = res._getJSONData();
+    expect(checkoutPayment.status).toBe("succeeded");
+    expect(checkoutPayment.invoiceId).toBe("in_test_invoice");
+  });
+
+  it("passes the correct workspaceId and setupSessionId to getCheckoutPaymentStatus", async () => {
+    vi.mocked(getCheckoutPaymentStatus).mockResolvedValue(null);
+
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+    req.query = { ...req.query, setup_session_id: MOCK_SETUP_SESSION_ID };
+
+    await handler(req, res);
+
+    expect(getCheckoutPaymentStatus).toHaveBeenCalledWith({
+      workspaceId: workspace.sId,
+      setupSessionId: MOCK_SETUP_SESSION_ID,
+    });
+  });
+});

--- a/front/pages/api/w/[wId]/subscriptions/checkout/checkout-payment-status.ts
+++ b/front/pages/api/w/[wId]/subscriptions/checkout/checkout-payment-status.ts
@@ -42,20 +42,20 @@ async function handler(
     });
   }
 
-  const { setup_session_id } = req.query;
-  if (!isString(setup_session_id) || setup_session_id === "") {
+  const { contract_id } = req.query;
+  if (!isString(contract_id) || contract_id === "") {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: "Missing required query parameter: setup_session_id.",
+        message: "Missing required query parameter: contract_id.",
       },
     });
   }
 
   const checkoutPayment = await getCheckoutPaymentStatus({
     workspaceId: auth.getNonNullableWorkspace().sId,
-    setupSessionId: setup_session_id,
+    contractId: contract_id,
   });
 
   return res.status(200).json({ checkoutPayment });

--- a/front/pages/api/w/[wId]/subscriptions/checkout/checkout-payment-status.ts
+++ b/front/pages/api/w/[wId]/subscriptions/checkout/checkout-payment-status.ts
@@ -1,0 +1,66 @@
+// @migration-status: MIGRATED_TO_HONO
+/** @ignoreswagger */
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import type { CheckoutPayment } from "@app/lib/credits/checkout_payment_status";
+import { getCheckoutPaymentStatus } from "@app/lib/credits/checkout_payment_status";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export type GetCheckoutPaymentStatusResponseBody = {
+  checkoutPayment: CheckoutPayment | null;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetCheckoutPaymentStatusResponseBody>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can check checkout payment status.",
+      },
+    });
+  }
+
+  const { setup_session_id } = req.query;
+  if (!isString(setup_session_id) || setup_session_id === "") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing required query parameter: setup_session_id.",
+      },
+    });
+  }
+
+  const checkoutPayment = await getCheckoutPaymentStatus({
+    workspaceId: auth.getNonNullableWorkspace().sId,
+    setupSessionId: setup_session_id,
+  });
+
+  return res.status(200).json({ checkoutPayment });
+}
+
+export default withSessionAuthenticationForWorkspace(handler, {
+  doesNotRequireCanUseProduct: true,
+});

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -323,6 +323,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Skip injecting the OpenAI formatting meta prompt entirely (no markdown/paragraph style guidance)",
     stage: "dust_only",
   },
+  metronome_cp_checkout: {
+    description:
+      "Enable the Metronome-owned payment-gated checkout flow for Business plan activation (replaces direct Stripe charge).",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -766,6 +766,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "use_vertex_for_supported_models"
   | "metronome_billing_usage_page"
   | "user_settings_v2"
+  | "metronome_cp_checkout"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

PR1 of https://github.com/dust-tt/tasks/issues/8594
See issue for the global specs for checkout archi

* Add `metronome_cp_checkout` feature flag 
* Add `isMetronomeCheckoutEnabled(auth)` helper in subscription.ts
* Add `CheckoutSeatType` ("pro"|"max") and `CheckoutBillingPeriod` schemas in lib/api/checkout/types.ts
* Add `seatType` and `targetUserId` optional fields to `createEmbeddedMetronomeSetupCheckoutSession`
* Add `CheckoutPayment` / `CheckoutPaymentStatus` Redis helpers in checkout_payment_status.ts (set/get/succeed/fail/syncFail, per-session key `checkout_payment:{wId}:{sessionId}`, contractId guard)

## Tests

Integration tests

## Risk

None, additive changes

## Deploy Plan

Deploy front