### PR TITLE
fix(mobile): input bar fixes

### DIFF
--- a/x/adrsimon/mobile/Dust/ViewModels/InputBarViewModel.swift
+++ b/x/adrsimon/mobile/Dust/ViewModels/InputBarViewModel.swift
@@ -309,7 +309,10 @@ final class InputBarViewModel: ObservableObject {
             if let transcriptionError = speechService.error {
                 error = transcriptionError
             } else {
-                messageText = speechService.transcribedText
+                let transcribed = speechService.transcribedText
+                if !transcribed.isEmpty {
+                    messageText = messageText.isEmpty ? transcribed : messageText + " " + transcribed
+                }
             }
             speechService.transcribedText = ""
         }
@@ -363,7 +366,6 @@ final class InputBarViewModel: ObservableObject {
             let result = try await operation()
             isSending = false
             messageText = ""
-            selectedAgent = nil
             attachments = []
             selectedCapabilities = []
             selectedKnowledgeItems = []


### PR DESCRIPTION
## Description
Two independent fixes in the chat input bar (from the streaming/chat audit):

- **Agent persistence (audit 3.1):** `performSend` reset `selectedAgent = nil` after every send, so in a conversation with agent X the second reply silently fell back to the global `@dust` agent while the button showed the neutral "Agent" placeholder. The selected agent now persists across replies, matching front's behavior.
- **Voice transcription append (audit 4.4):** `stopVoiceInput` overwrote `messageText` with the transcription, discarding anything already typed. It now appends (space-separated) and no-ops on empty transcriptions.

## Tests
Manual: build green (`make build ENV=dev`). No automated coverage yet.

## Risk
Low — localized to `InputBarViewModel`.