### PR TITLE
fix(mobile): only log out on definitive token refresh failure

### DIFF
--- a/x/adrsimon/mobile/Dust/Services/TokenProvider.swift
+++ b/x/adrsimon/mobile/Dust/Services/TokenProvider.swift
@@ -68,8 +68,11 @@ actor TokenProvider {
                 return response.accessToken
             } catch {
                 logger.error("Token refresh failed: \(error)")
-                refreshFailed = true
-                onSessionExpired?()
+                // Only latch on a definitive 4xx; network errors must stay retryable.
+                if case let APIError.httpError(statusCode, _) = error, (400 ..< 500).contains(statusCode) {
+                    refreshFailed = true
+                    onSessionExpired?()
+                }
                 throw error
             }
         }


### PR DESCRIPTION
## Description
`TokenProvider.refreshFailed` latched on **any** refresh error, including plain network loss, then triggered `onSessionExpired` → forced re-login. Refreshing in airplane mode logged the user out permanently (audit 4.2).

Now the session is expired only on a definitive `4xx` from the refresh endpoint; network errors propagate as retryable so a later attempt can recover.

## Tests
Manual: build green (`make build ENV=dev`). No automated coverage yet.

## Risk
Low — single branch in the refresh error path.