### PR TITLE
fix: pods hover buttons on mobile

### DIFF
--- a/front/components/pod/tasks/SuggestedTaskItem.tsx
+++ b/front/components/pod/tasks/SuggestedTaskItem.tsx
@@ -99,7 +99,7 @@ export const SuggestedTaskItem = memo(function SuggestedTaskItem({
         <div
           className={cn(
             "shrink-0 transition-opacity",
-            "[@media(hover:hover)]:opacity-0 group-hover/suggestion-item:opacity-100 group-focus-within/suggestion-item:opacity-100"
+            "[@media(hover:hover)_and_(pointer:fine)]:opacity-0 group-hover/suggestion-item:opacity-100 group-focus-within/suggestion-item:opacity-100"
           )}
         >
           <Button

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -473,7 +473,7 @@ const NavigationListCollapsibleSection = React.forwardRef<
         className={cn(
           "s-m-1.5 s-flex s-gap-1 s-pr-0.5 s-transition-opacity",
           actionOnHover
-            ? "[@media(hover:hover)]:s-opacity-0 hover:s-opacity-100 group-has-[:focus-visible]/menu-item:s-opacity-100 group-hover/menu-item:s-opacity-100"
+            ? "[@media(hover:hover)_and_(pointer:fine)]:s-opacity-0 hover:s-opacity-100 group-has-[:focus-visible]/menu-item:s-opacity-100 group-hover/menu-item:s-opacity-100"
             : "s-opacity-100"
         )}
         onClick={(e) => {


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8521


This PR fixes pods action buttons being hidden on mobile by refining the CSS media query used to hide hover-triggered buttons.

- Changes `@media(hover:hover)` to `@media(hover:hover) and (pointer:fine)` in `SuggestedTaskItem.tsx` and `NavigationList.tsx`. Some devices report `hover:hover` even though they are touch-first, causing hover-only buttons to be permanently hidden. Adding `pointer:fine` ensures the opacity-0 rule only applies to devices with a fine pointer (e.g. mouse or trackpad), making buttons always visible on touch screens.

## Tests

Manually.

## Risks

<!-- Discuss potential risks and how they will be mitigated. -->

## Deploy Plan

<!-- Outline the deployment steps. -->
