### PR TITLE
Avoid unhandled posthog exceptions and improve logging

### DIFF
--- a/front-api/middlewares/utils.ts
+++ b/front-api/middlewares/utils.ts
@@ -124,6 +124,10 @@ export const unhandledErrorHandler: ErrorHandler = (err, ctx) => {
         name: error.name,
         message: error.message || "unknown",
         stack: error.stack,
+        // `TypeError: fetch failed` and similar wrappers carry the real reason
+        // (ECONNREFUSED, ENOTFOUND, timeouts, ...) on `cause` — log it so these
+        // are diagnosable from the message alone.
+        ...(error.cause ? { cause: error.cause } : {}),
         ...(sequelizeDetails ? { sequelizeDetails } : {}),
       },
       error_stack: error.stack,

--- a/front-api/routes/subtle1.test.ts
+++ b/front-api/routes/subtle1.test.ts
@@ -64,4 +64,14 @@ describe("/subtle1 PostHog proxy", () => {
 
     expect(response.status).toBe(502);
   });
+
+  it("returns 502 instead of an unhandled 500 when the upstream fetch fails", async () => {
+    fetchSpy.mockRejectedValue(new TypeError("fetch failed"));
+
+    const response = await honoApp.request("/subtle1/e/", { method: "POST" });
+
+    expect(response.status).toBe(502);
+    const body = await response.json();
+    expect(body.error.type).toBe("service_unavailable");
+  });
 });

--- a/front-api/routes/subtle1.ts
+++ b/front-api/routes/subtle1.ts
@@ -1,3 +1,5 @@
+import logger from "@app/logger/logger";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { createHono } from "@front-api/lib/hono";
 import type { Context } from "hono";
 import { proxy } from "hono/proxy";
@@ -12,9 +14,10 @@ const POSTHOG_ASSETS_URL = "https://eu-assets.i.posthog.com";
 // Mounted at /subtle1 (root level, not under /api).
 const app = createHono();
 
-const proxyToPostHog = (upstreamBaseUrl: string) => (c: Context) => {
+const proxyToPostHog = (upstreamBaseUrl: string) => async (c: Context) => {
   const url = new URL(c.req.url);
   const upstreamPath = url.pathname.replace(/^\/subtle1/, "");
+  const upstreamUrl = `${upstreamBaseUrl}${upstreamPath}${url.search}`;
 
   // Drop the client's Host header so fetch derives it from the upstream URL;
   // forwarding our own host would break PostHog's routing. Hop-by-hop headers
@@ -22,10 +25,35 @@ const proxyToPostHog = (upstreamBaseUrl: string) => (c: Context) => {
   const headers = new Headers(c.req.raw.headers);
   headers.delete("host");
 
-  return proxy(
-    `${upstreamBaseUrl}${upstreamPath}${url.search}`,
-    new Request(c.req.raw, { headers })
-  );
+  try {
+    return await proxy(upstreamUrl, new Request(c.req.raw, { headers }));
+  } catch (err) {
+    // `proxy` rejects with `TypeError: fetch failed` only on a transport-level
+    // failure reaching PostHog (DNS, connect refused, TLS, socket reset,
+    // timeout) — never on a 4xx/5xx response, which is relayed as a Response.
+    // This is a transient upstream condition, not a bug in our service, so we
+    // surface it as a 502 instead of letting it bubble up as an unhandled 500.
+    const error = normalizeError(err);
+    logger.warn(
+      {
+        upstreamUrl,
+        method: c.req.method,
+        error: { name: error.name, message: error.message },
+        cause: error.cause,
+      },
+      "PostHog proxy upstream fetch failed"
+    );
+
+    return c.json(
+      {
+        error: {
+          type: "service_unavailable",
+          message: `PostHog proxy upstream fetch failed: ${error.message}`,
+        },
+      },
+      502
+    );
+  }
 };
 
 app.all("/static/*", proxyToPostHog(POSTHOG_ASSETS_URL));


### PR DESCRIPTION
  ## Problem

  `POST /subtle1/*` (the PostHog ingestion reverse proxy) was surfacing
  transient upstream network failures as **unhandled 500s**.

  The handler in `routes/subtle1.ts` returns `proxy(...)` directly. When the
  outbound `fetch` to PostHog can't complete at the transport level (DNS,
  connection refused, TLS, socket reset, timeout), undici rejects with
  `TypeError: fetch failed`. Nothing in the route catches it, so the rejection
  propagates to the global `honoApp.onError` handler, which — for any
  non-`HTTPException` — logs `"Unhandled API Error"` and returns a 500.

  These logs were also undiagnosable: the real reason (`ECONNREFUSED`,
  `ENOTFOUND`, timeout, …) lives on `error.cause`, which the handler never
  logged — leaving only the opaque `"fetch failed"`.

  Note this only fires on *transport* failures. A PostHog 4xx/5xx **response**
  is relayed through unchanged and is unaffected.

  ## Changes

  - **`routes/subtle1.ts`** — wrap the `proxy(...)` call in `try/catch` (`catch`
    is authorized here per ERR1, as this guards an external network call). On a
    fetch failure we log a `warn` and return a **502** (`service_unavailable`)
    instead of letting it bubble up as an unhandled 500.
  - **`middlewares/utils.ts`** — `unhandledErrorHandler` now logs `error.cause`
    when present, so future `fetch failed` (and similar wrapped) errors are
    diagnosable from the log alone. Benefits all routes, not just the proxy.
  - **`routes/subtle1.test.ts`** — added a test asserting a rejected upstream
    fetch yields `502` + `service_unavailable`.
## Tests

Added

## Risk

Low

## Deploy Plan

Front