### PR TITLE
fix(nginx): redirect /playground to /playground/ for SPA base path

### DIFF
--- a/dockerfiles/sparkle/sparkle-storybook-nginx.conf
+++ b/dockerfiles/sparkle/sparkle-storybook-nginx.conf
@@ -6,6 +6,11 @@ server {
     gzip_types text/plain text/css application/javascript application/json image/svg+xml;
     gzip_min_length 1024;
 
+    # Redirect /playground to /playground/ so the SPA base path is correct
+    location = /playground {
+        return 301 /playground/;
+    }
+
     # Playground SPA — assets are built with base=/playground/
     location /playground/ {
         root /usr/share/nginx/html;


### PR DESCRIPTION
## Description

Visiting `/playground` (without trailing slash) resulted in nginx falling through to the storybook `location /` block, returning a 404. Added an exact-match redirect so `/playground` → `/playground/`, ensuring the SPA loads correctly regardless of whether the user types the trailing slash.

## Tests

Tested manually by hitting `/playground` and `/playground/` in the browser — both now load the SPA correctly.

## Risk

Low — exact-match location blocks have highest priority in nginx; no other routes are affected.

## Deploy Plan

Requires rebuilding and redeploying the sparkle storybook Docker image.
