### PR TITLE
Reconcile per-user credit states on contract.start

### DIFF
--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -16,6 +16,7 @@ import {
   dispatchSeatLowBalance,
   syncPoolCreditStateFromBalance,
 } from "@app/lib/api/metronome/credit_state_dispatcher";
+import { reconcileWorkspaceUserCreditStates } from "@app/lib/api/metronome/reconcile_credit_state";
 import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
 import { Authenticator } from "@app/lib/auth";
@@ -1220,6 +1221,21 @@ export async function processMetronomeWebhook({
       await syncPoolCreditStateFromBalance({
         workspace,
         metronomeCustomerId: customerId,
+      });
+
+      // Reconcile per-user credit states against the new contract's live
+      // per-seat balances. Seats were synced to this contract at provision
+      // time (`syncContractQuantities` → `syncSeatCount`), but that path does
+      // not touch per-user credit states; now that the contract is active the
+      // balances are live, so this lands each user in the right seat↔pool
+      // state. Without it, a switch that changes seat allocations (e.g. moving
+      // onto a business plan) leaves users stuck in their previous state.
+      // Mirrors the pool reconcile above; pass the new contract id directly
+      // since the subscription swap below may not have happened yet.
+      await reconcileWorkspaceUserCreditStates({
+        workspace: renderLightWorkspaceType({ workspace }),
+        metronomeCustomerId: customerId,
+        metronomeContractId: contractId,
       });
 
       // Read the PLAN_CODE custom field to know which plan to swap the


### PR DESCRIPTION
## Description

Follow-up to the user credit-state reconciliation work (#26830). Reconciles **per-user** credit states when a Metronome contract starts — e.g. when switching a workspace onto a business plan.

**Problem.** The contract-switch flow syncs seats via `provisionMetronomeContract` → `syncContractQuantities` → `syncSeatCount` **directly**, bypassing the `syncMetronomeSeatCountForWorkspace` wrapper that reconciles per-user credit states. So a contract switch updated the seat assignments in Metronome but never reconciled users — they stayed stuck in their previous seat↔pool state.

The reconcile can't be added in `syncContractQuantities`/`syncSeatCount` (they live in `lib/metronome`, below `lib/api`): importing the reconcile there would close a dependency cycle — the same reason the pool-state reconcile already lives in the `contract.start` webhook rather than in `provisionMetronomeContract`.

**Fix.** Reconcile per-user credit states in the `contract.start` webhook, right after the existing pool-credit-state reconcile (`syncPoolCreditStateFromBalance`). This fires when the new contract actually activates — covering both immediate (`current-hour`) and future-dated (`next-hour`/scheduled) swaps — at which point the new contract's per-seat balances are live. The new contract id is passed directly (not resolved from the active subscription), since the subscription swap happens later in the same handler.

`reconcileWorkspaceUserCreditStates` is unchanged from #26830: it fetches the shared inputs once (seat balances, per-user usage, cap thresholds), computes each seated user's expected state from the live source of truth, only writes on drift, and never throws.

## Tests

- No new tests; relies on the existing coverage of `reconcileWorkspaceUserCreditStates` (in `reconcile_credit_state.test.ts`, from #26830) and the unchanged behavior of the rest of the `contract.start` handler.
- Ran `process_webhook.test.ts` (24) and `switch_contract.test.ts` (26) — all pass. Typecheck clean; biome-formatted.

## Risk

- Single added call in the `contract.start` webhook, mirroring the adjacent pool reconcile. The reconcile only writes on drift and never throws, so it can't break the rest of the webhook flow.
- Scoped to the new-pricing Metronome credit-state machinery (no real contracts yet), so blast radius is low.
- Safe to roll back — no schema/migration changes.
- Depends on the helpers introduced in #26830 (stacked on it).

## Deploy Plan

Standard deploy, after/with #26830. No migration.
