### PR TITLE
[front] improve agent/skill search  

### DIFF
--- a/front/components/pages/builder/agents/ManageAgentsPage.tsx
+++ b/front/components/pages/builder/agents/ManageAgentsPage.tsx
@@ -34,7 +34,6 @@ import {
   Page,
   Plus,
   SearchInput,
-  SearchMd,
   Spinner,
   Tabs,
   TabsList,
@@ -64,18 +63,6 @@ export const AGENT_MANAGER_TABS = [
     label: "Archived",
     description: "Archived agents.",
   },
-  {
-    id: "search",
-    label: "Active",
-    icon: SearchMd,
-    description: "Active agents matching your search",
-  },
-  {
-    id: "search_archived",
-    label: "Archived",
-    icon: SearchMd,
-    description: "Archived agents matching your search",
-  },
 ] as const;
 
 export type AssistantManagerTabsType =
@@ -103,17 +90,9 @@ export function ManageAgentsPage() {
   const shouldDisableAgentFetching = isRestrictedFromAgentCreation;
   const isSearchActive = assistantSearch.trim() !== "";
 
-  const [selectedSearchTab, setSelectedSearchTab] = useState<
-    "search" | "search_archived"
-  >("search");
-
   const activeTab = useMemo(() => {
-    if (isSearchActive) {
-      return selectedSearchTab;
-    }
-
     return selectedTab && isValidTab(selectedTab) ? selectedTab : "all_custom";
-  }, [isSearchActive, selectedTab, selectedSearchTab]);
+  }, [selectedTab]);
 
   // only fetch the agents that are relevant to the current scope, except when
   // user searches: search across all agents
@@ -139,9 +118,7 @@ export function ManageAgentsPage() {
     workspaceId: owner.sId,
     agentsGetView: "archived",
     includes: ["usage", "feedbacks", "editors"],
-    disabled:
-      shouldDisableAgentFetching ||
-      (selectedTab !== "archived" && !isSearchActive),
+    disabled: shouldDisableAgentFetching || selectedTab !== "archived",
   });
 
   const agentsByTab = useMemo(() => {
@@ -156,8 +133,11 @@ export function ManageAgentsPage() {
       .sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
 
     const searchLower = assistantSearch.toLowerCase();
-    const filterAndSortBySearch = (agents: LightAgentConfigurationType[]) =>
-      agents
+    const filteredList = (agents: LightAgentConfigurationType[]) => {
+      if (!isSearchActive) {
+        return agents;
+      }
+      return agents
         .filter((a) => subFilter(searchLower, getAgentSearchString(a)))
         .sort((a, b) =>
           compareForFuzzySort(
@@ -166,23 +146,28 @@ export function ManageAgentsPage() {
             getAgentSearchString(b)
           )
         );
+    };
 
     return {
-      // do not show the "all" tab while still loading all agents
-      all_custom: allAgents.filter((a) => a.scope !== "global"),
-      editable_by_me: allAgents.filter((a) => a.canEdit),
-      global: allAgents.filter((a) => a.scope === "global"),
-      archived: archivedAgentConfigurations.sort((a, b) =>
-        a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+      all_custom: filteredList(
+        allAgents.filter((a) => a.scope !== "global")
       ),
-      search: filterAndSortBySearch(agentConfigurations),
-      search_archived: filterAndSortBySearch(archivedAgentConfigurations),
+      editable_by_me: filteredList(allAgents.filter((a) => a.canEdit)),
+      global: filteredList(
+        allAgents.filter((a) => a.scope === "global")
+      ),
+      archived: filteredList(
+        archivedAgentConfigurations.sort((a, b) =>
+          a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+        )
+      ),
     };
   }, [
     agentConfigurations,
     archivedAgentConfigurations,
     selectedTags,
     assistantSearch,
+    isSearchActive,
   ]);
 
   const { uniqueTags } = useMemo(() => {
@@ -229,22 +214,6 @@ export function ManageAgentsPage() {
     await mutateAgentConfigurations();
   };
 
-  // if search is active, show search tabs, otherwise show all tabs except search tabs
-  const visibleTabs = useMemo(() => {
-    const searchTab = AGENT_MANAGER_TABS.find((tab) => tab.id === "search");
-    const searchArchivedTab = AGENT_MANAGER_TABS.find(
-      (tab) => tab.id === "search_archived"
-    );
-    if (!searchTab || !searchArchivedTab) {
-      throw new Error("Unexpected: Search tabs not found");
-    }
-
-    return isSearchActive
-      ? [searchTab, searchArchivedTab]
-      : AGENT_MANAGER_TABS.filter(
-          (tab) => tab.id !== "search" && tab.id !== "search_archived"
-        );
-  }, [isSearchActive]);
 
   const searchBarRef = useRef<HTMLInputElement>(null);
 
@@ -363,31 +332,19 @@ export function ManageAgentsPage() {
                 ) : (
                   <Tabs value={activeTab}>
                     <TabsList>
-                      {visibleTabs.map((tab) => (
+                      {AGENT_MANAGER_TABS.map((tab) => (
                         <TabsTrigger
                           key={tab.id}
                           value={tab.id}
                           label={tab.label}
                           onClick={() => {
-                            if (isSearchActive) {
-                              if (
-                                tab.id === "search" ||
-                                tab.id === "search_archived"
-                              ) {
-                                setSelectedSearchTab(tab.id);
-                              }
-                            } else {
-                              setSelectedTab(tab.id);
-                            }
+                            setSelectedTab(tab.id);
                           }}
                           tooltip={
                             AGENT_MANAGER_TABS.find((t) => t.id === tab.id)
                               ?.description
                           }
-                          isCounter={
-                            tab.id !== "archived" &&
-                            tab.id !== "search_archived"
-                          }
+                          isCounter={tab.id !== "archived"}
                           counterValue={`${agentsByTab[tab.id].length}`}
                         />
                       ))}

--- a/front/components/pages/builder/agents/ManageAgentsPage.tsx
+++ b/front/components/pages/builder/agents/ManageAgentsPage.tsx
@@ -149,13 +149,9 @@ export function ManageAgentsPage() {
     };
 
     return {
-      all_custom: filteredList(
-        allAgents.filter((a) => a.scope !== "global")
-      ),
+      all_custom: filteredList(allAgents.filter((a) => a.scope !== "global")),
       editable_by_me: filteredList(allAgents.filter((a) => a.canEdit)),
-      global: filteredList(
-        allAgents.filter((a) => a.scope === "global")
-      ),
+      global: filteredList(allAgents.filter((a) => a.scope === "global")),
       archived: filteredList(
         archivedAgentConfigurations.sort((a, b) =>
           a.name.toLowerCase().localeCompare(b.name.toLowerCase())
@@ -213,7 +209,6 @@ export function ManageAgentsPage() {
 
     await mutateAgentConfigurations();
   };
-
 
   const searchBarRef = useRef<HTMLInputElement>(null);
 

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -212,7 +212,6 @@ export function ManageSkillsPage() {
     [handleSkillSelect, knownSkillsById, setSkillIdParam]
   );
 
-
   const searchBarRef = useRef<HTMLInputElement>(null);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -27,20 +27,12 @@ import {
   Page,
   Plus,
   SearchInput,
-  SearchMd,
   Spinner,
   Tabs,
   TabsList,
   TabsTrigger,
 } from "@dust-tt/sparkle";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-
-const SKILL_SEARCH_TAB = {
-  id: "search",
-  label: "Searching across all skills",
-  icon: SearchMd,
-  description: "Searching across all skills.",
-} as const;
 
 const SKILL_MANAGER_TABS = [
   {
@@ -96,15 +88,14 @@ export function ManageSkillsPage() {
   const [skillSearch, setSkillSearch] = useState("");
   const [skillIdParam, setSkillIdParam] = useHashParam("skillId");
 
+  const isSearchActive = !isEmptyString(skillSearch);
+
   const activeTab = useMemo(() => {
-    if (!isEmptyString(skillSearch)) {
-      return "search";
-    }
     if (selectedTab && isValidTab(selectedTab)) {
       return selectedTab;
     }
     return "active";
-  }, [selectedTab, skillSearch]);
+  }, [selectedTab]);
 
   const {
     skillsWithRelations: activeSkills,
@@ -120,7 +111,7 @@ export function ManageSkillsPage() {
   } = useSkillsWithRelations({
     owner,
     status: "archived",
-    disabled: activeTab !== "archived",
+    disabled: selectedTab !== "archived",
   });
 
   const {
@@ -136,37 +127,48 @@ export function ManageSkillsPage() {
     const sortedActiveSkills = sortSkillsByName(activeSkills);
     const sortedArchivedSkills = sortSkillsByName(archivedSkills);
 
-    return {
-      active: sortedActiveSkills,
-      editable_by_me: sortedActiveSkills.filter((s) =>
-        s.relations.editors?.some((e) => e.sId === user?.sId)
-      ),
-      default: sortedActiveSkills
-        .filter((s) => s.isDefault || s.relations.editors === null)
-        .sort((a, b) => {
-          // Display first the skills that have no editor (Dust-managed ones).
-          const aNoEditors = a.relations.editors === null;
-          const bNoEditors = b.relations.editors === null;
-          if (aNoEditors !== bNoEditors) {
-            return aNoEditors ? -1 : 1;
-          }
-          // Fallback to a name sort.
-          return a.name.localeCompare(b.name);
-        }),
-      archived: sortedArchivedSkills,
-      search: activeSkills
-        .filter((s) =>
-          subFilter(skillSearch.toLowerCase(), getSkillSearchString(s))
-        )
+    const searchLower = skillSearch.toLowerCase();
+    const filteredList = (
+      skills: SkillWithoutInstructionsAndToolsWithRelationsType[]
+    ) => {
+      if (!isSearchActive) {
+        return skills;
+      }
+      return skills
+        .filter((s) => subFilter(searchLower, getSkillSearchString(s)))
         .sort((a, b) =>
           compareForFuzzySort(
-            skillSearch.toLowerCase(),
+            searchLower,
             getSkillSearchString(a),
             getSkillSearchString(b)
           )
-        ),
+        );
     };
-  }, [activeSkills, archivedSkills, skillSearch, user]);
+
+    return {
+      active: filteredList(sortedActiveSkills),
+      editable_by_me: filteredList(
+        sortedActiveSkills.filter((s) =>
+          s.relations.editors?.some((e) => e.sId === user?.sId)
+        )
+      ),
+      default: filteredList(
+        sortedActiveSkills
+          .filter((s) => s.isDefault || s.relations.editors === null)
+          .sort((a, b) => {
+            // Display first the skills that have no editor (Dust-managed ones).
+            const aNoEditors = a.relations.editors === null;
+            const bNoEditors = b.relations.editors === null;
+            if (aNoEditors !== bNoEditors) {
+              return aNoEditors ? -1 : 1;
+            }
+            // Fallback to a name sort.
+            return a.name.localeCompare(b.name);
+          })
+      ),
+      archived: filteredList(sortedArchivedSkills),
+    };
+  }, [activeSkills, archivedSkills, skillSearch, user, isSearchActive]);
 
   const isLoading = isActiveLoading || isArchivedLoading || isSuggestedLoading;
 
@@ -210,11 +212,6 @@ export function ManageSkillsPage() {
     [handleSkillSelect, knownSkillsById, setSkillIdParam]
   );
 
-  const visibleTabs = useMemo(() => {
-    return !isEmptyString(skillSearch)
-      ? [SKILL_SEARCH_TAB]
-      : SKILL_MANAGER_TABS;
-  }, [skillSearch]);
 
   const searchBarRef = useRef<HTMLInputElement>(null);
 
@@ -312,12 +309,12 @@ export function ManageSkillsPage() {
           <div className="flex flex-col pt-3">
             <Tabs value={activeTab}>
               <TabsList>
-                {visibleTabs.map((tab) => (
+                {SKILL_MANAGER_TABS.map((tab) => (
                   <TabsTrigger
                     key={tab.id}
                     value={tab.id}
                     label={tab.label}
-                    onClick={() => !skillSearch && setSelectedTab(tab.id)}
+                    onClick={() => setSelectedTab(tab.id)}
                     tooltip={tab.description}
                     isCounter={tab.id !== "archived"}
                     counterValue={`${skillsByTab[tab.id].length}`}


### PR DESCRIPTION
## Description
This PR is to improve search functionality in agent/skills management page. When you search we keep the tabs for All, Editable By Me, Default etc so you can filter by keywords on top of it.

It's a bit weird that all is not really all but you can see the number of each category so I think it's okayish? 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
