### PR TITLE
Allow user spend on personal seat

### DIFF
--- a/front/lib/metronome/user_block.test.ts
+++ b/front/lib/metronome/user_block.test.ts
@@ -105,6 +105,49 @@ describe("isUserBlocked", () => {
     expect(blocked).toBeNull();
   });
 
+  it("does not block a 'user_seat' user when the pool is depleted", async () => {
+    redisValues.set("metronome:user_cap:ws_test:u_test", "0");
+    redisValues.set("metronome:pool_depleted:ws_test", "1");
+    redisValues.set("metronome:user_credit_state:ws_test:u_test", "user_seat");
+
+    const blocked = await isUserBlocked("ws_test", "u_test");
+
+    expect(blocked).toBeNull();
+  });
+
+  it("does not block a 'user_seat_low_balance' user when the pool is depleted", async () => {
+    redisValues.set("metronome:user_cap:ws_test:u_test", "0");
+    redisValues.set("metronome:pool_depleted:ws_test", "1");
+    redisValues.set(
+      "metronome:user_credit_state:ws_test:u_test",
+      "user_seat_low_balance"
+    );
+
+    const blocked = await isUserBlocked("ws_test", "u_test");
+
+    expect(blocked).toBeNull();
+  });
+
+  it("blocks an 'on_pool' user when the pool is depleted", async () => {
+    redisValues.set("metronome:user_cap:ws_test:u_test", "0");
+    redisValues.set("metronome:pool_depleted:ws_test", "1");
+    redisValues.set("metronome:user_credit_state:ws_test:u_test", "on_pool");
+
+    const blocked = await isUserBlocked("ws_test", "u_test");
+
+    expect(blocked).toBe("credits_exhausted");
+  });
+
+  it("still blocks a capped 'user_seat' user via their per-user cap when the pool is depleted", async () => {
+    redisValues.set("metronome:user_cap:ws_test:u_test", "1");
+    redisValues.set("metronome:pool_depleted:ws_test", "1");
+    redisValues.set("metronome:user_credit_state:ws_test:u_test", "user_seat");
+
+    const blocked = await isUserBlocked("ws_test", "u_test");
+
+    expect(blocked).toBe("user_cap_reached");
+  });
+
   it("falls back to DB on cold cache and repopulates both flags", async () => {
     mockFetchWorkspaceById.mockResolvedValue({
       sId: "ws_test",

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -37,7 +37,10 @@ import {
   isWorkspaceProgrammaticCreditState,
 } from "@app/types/credits";
 import type { UserCreditState } from "@app/types/memberships";
-import { isUserCreditState } from "@app/types/memberships";
+import {
+  isSpendingFromPersonalSeat,
+  isUserCreditState,
+} from "@app/types/memberships";
 
 export type UserBlockedReason = "credits_exhausted" | "user_cap_reached";
 
@@ -268,32 +271,48 @@ export async function isUserBlocked(
       ])
   );
 
-  if (isBlockFlag(userCap) && isBlockFlag(poolDepleted)) {
-    return deriveBlockedReason({
-      userCapBlocked: userCap === BLOCKED_FLAG,
-      workspacePoolDepleted: poolDepleted === BLOCKED_FLAG,
-    });
-  }
+  let userCapBlocked: boolean;
+  let workspacePoolDepleted: boolean;
 
-  logger.info(
-    {
+  if (isBlockFlag(userCap) && isBlockFlag(poolDepleted)) {
+    userCapBlocked = userCap === BLOCKED_FLAG;
+    workspacePoolDepleted = poolDepleted === BLOCKED_FLAG;
+  } else {
+    logger.info(
+      {
+        workspaceId,
+        userId,
+        userCapCacheHit: isBlockFlag(userCap),
+        workspacePoolCacheHit: isBlockFlag(poolDepleted),
+      },
+      "[MetronomeUserBlock] Cache miss during user blocked check, falling back to DB"
+    );
+
+    const state = await getUserBlockedStateFromDb({ workspaceId, userId });
+    await syncCachedBlockedState({
       workspaceId,
       userId,
-      userCapCacheHit: isBlockFlag(userCap),
-      workspacePoolCacheHit: isBlockFlag(poolDepleted),
-    },
-    "[MetronomeUserBlock] Cache miss during user blocked check, falling back to DB"
-  );
+      userCapBlocked: state.userCapBlocked,
+      workspacePoolDepleted: state.workspacePoolDepleted,
+    });
 
-  const state = await getUserBlockedStateFromDb({ workspaceId, userId });
-  await syncCachedBlockedState({
-    workspaceId,
-    userId,
-    userCapBlocked: state.userCapBlocked,
-    workspacePoolDepleted: state.workspacePoolDepleted,
-  });
+    userCapBlocked = state.userCapBlocked;
+    workspacePoolDepleted = state.workspacePoolDepleted;
+  }
 
-  return deriveBlockedReason(state);
+  // A user spending from their personal seat balance (`user_seat` /
+  // `user_seat_low_balance`) still has their own credits, so workspace pool
+  // depletion must not block them — only their per-user cap can. We only need
+  // the per-user credit state when the pool is depleted, since otherwise it
+  // cannot change the outcome.
+  if (workspacePoolDepleted) {
+    const userCreditState = await getUserCreditState(workspaceId, userId);
+    if (isSpendingFromPersonalSeat(userCreditState)) {
+      workspacePoolDepleted = false;
+    }
+  }
+
+  return deriveBlockedReason({ userCapBlocked, workspacePoolDepleted });
 }
 
 // Per-user credit state (fine-grained state mirroring memberships.creditState).

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -167,6 +167,28 @@ export function isUserCreditState(value: unknown): value is UserCreditState {
   );
 }
 
+/**
+ * Whether a user in the given credit state is currently spending from their
+ * personal seat balance (`user_seat*`) rather than the shared workspace pool.
+ * Such users still have their own credits and are therefore unaffected by
+ * workspace pool depletion — only their own per-user cap (`capped`) can block
+ * them.
+ */
+export function isSpendingFromPersonalSeat(state: UserCreditState): boolean {
+  switch (state) {
+    case "user_seat":
+    case "user_seat_low_balance":
+      return true;
+    case "normal":
+    case "on_pool":
+    case "on_pool_low_balance":
+    case "capped":
+      return false;
+    default:
+      return assertNever(state);
+  }
+}
+
 // Fraction of the personal seat balance / per-user cap at which the
 // low-balance warning bands kick in. Mirrors the seat-low-balance guards in
 // `lib/metronome/user_credit_state_machine.ts` (threshold === 0.2 * allowance)


### PR DESCRIPTION
## Description

On a **seat-based** Metronome plan, a user in the `user_seat` / `user_seat_low_balance` credit state spends from their **personal seat balance**, not the shared workspace pool. But `isUserBlocked` returned `"credits_exhausted"` for *any* user whenever `workspaces.poolCreditState === "depleted"`. As a result, on a brand-new seat-based contract with a depleted pool, even users with a full personal seat balance were blocked from posting messages.

This PR makes pool depletion only block users who are actually spending from the pool.

- `types/memberships.ts`: add `isSpendingFromPersonalSeat(state)` — exhaustive `switch` returning `true` only for `user_seat` / `user_seat_low_balance`.
- `lib/metronome/user_block.ts`: when the pool is depleted, `isUserBlocked` now consults the cached per-user credit state (`getUserCreditState`, with its own read-through DB fallback). A user spending from their personal seat is no longer blocked by pool depletion — only their own per-user cap (`capped` → `user_cap_reached`) can block them. Refactored the cache-hit and DB-fallback paths to share a single `deriveBlockedReason` call.

### Behavior

| User credit state | Pool depleted? | Result |
|---|---|---|
| `user_seat` / `user_seat_low_balance` | yes | **allowed** (was blocked) |
| `on_pool` / `on_pool_low_balance` / `normal` | yes | `credits_exhausted` |
| `capped` (any) | — | `user_cap_reached` |

The `usage-status` endpoint benefits too: a seat user no longer falsely reports `awuStatus: "blocked"` when the pool is depleted (the pool state is still surfaced separately via `poolCreditState`).

## Tests

- Added 4 cases to `lib/metronome/user_block.test.ts`: `user_seat` and `user_seat_low_balance` are **not** blocked on a depleted pool, `on_pool` still is, and a capped seat user still returns `user_cap_reached`.
- All 13 `user_block` tests pass; `tsgo --noEmit` and biome are clean on the changed files.

## Risk

Low. The change only **relaxes** blocking for seat users who legitimately have personal credits; it does not loosen the per-user cap (`capped`) or the pool block for pool-based (`on_pool*`) users. Only shared `lib/`/`types/` modules are touched — no API handler signatures change, so no Next↔Hono handler sync is needed. Safe to roll back (revert restores the prior, stricter behavior).

The extra `getUserCreditState` read only runs when the pool is depleted, and it is Redis-cached with a DB fallback.

## Deploy Plan

Standard deploy. No migrations, no config changes, no coordinated client release required.
