### PR TITLE
feat(cache): add metronome alerts resources to cache registry

### DIFF
--- a/front/types/shared/cache_resource_registry.ts
+++ b/front/types/shared/cache_resource_registry.ts
@@ -209,6 +209,86 @@ export const CACHE_RESOURCE_REGISTRY: CacheResourceDefinition[] = [
     ],
     buildResolverKey: (p) => `slack_users_${p.mcpServerId}`,
   },
+  {
+    id: "metronome_balance_threshold",
+    label: "Metronome balance threshold",
+    fnName: "fetchWorkspaceBalanceThreshold",
+    params: [
+      {
+        key: "metronomeCustomerId",
+        label: "Metronome Customer ID",
+        type: "string",
+        placeholder: "e.g. 550e8400-e29b-41d4-a716-446655440000",
+      },
+      {
+        key: "workspaceId",
+        label: "Workspace sId",
+        type: "string",
+        placeholder: "e.g. abc123",
+      },
+    ],
+    buildResolverKey: (p) => `${p.metronomeCustomerId}-${p.workspaceId}`,
+  },
+  {
+    id: "metronome_per_user_cap_thresholds",
+    label: "Metronome per-user cap thresholds",
+    fnName: "fetchPerUserCapThresholds",
+    params: [
+      {
+        key: "metronomeCustomerId",
+        label: "Metronome Customer ID",
+        type: "string",
+        placeholder: "e.g. 550e8400-e29b-41d4-a716-446655440000",
+      },
+      {
+        key: "workspaceId",
+        label: "Workspace sId",
+        type: "string",
+        placeholder: "e.g. abc123",
+      },
+    ],
+    buildResolverKey: (p) => `${p.metronomeCustomerId}-${p.workspaceId}`,
+  },
+  {
+    id: "metronome_default_cap_thresholds_by_seat_type",
+    label: "Metronome default cap thresholds by seat type",
+    fnName: "fetchDefaultCapThresholdsBySeatType",
+    params: [
+      {
+        key: "metronomeCustomerId",
+        label: "Metronome Customer ID",
+        type: "string",
+        placeholder: "e.g. 550e8400-e29b-41d4-a716-446655440000",
+      },
+      {
+        key: "workspaceId",
+        label: "Workspace sId",
+        type: "string",
+        placeholder: "e.g. abc123",
+      },
+    ],
+    buildResolverKey: (p) => `${p.metronomeCustomerId}-${p.workspaceId}`,
+  },
+  {
+    id: "metronome_workspace_alert_ids",
+    label: "Metronome workspace alert IDs",
+    fnName: "fetchWorkspaceMetronomeAlertIds",
+    params: [
+      {
+        key: "metronomeCustomerId",
+        label: "Metronome Customer ID",
+        type: "string",
+        placeholder: "e.g. 550e8400-e29b-41d4-a716-446655440000",
+      },
+      {
+        key: "workspaceId",
+        label: "Workspace sId",
+        type: "string",
+        placeholder: "e.g. abc123",
+      },
+    ],
+    buildResolverKey: (p) => `${p.metronomeCustomerId}-${p.workspaceId}`,
+  },
 ];
 
 export function getCacheResourceById(


### PR DESCRIPTION
## Description

This PR adds two improvements to Metronome alerts:

1. **Cache registry entries for Metronome alerts** – adds `metronome_balance_threshold`, `metronome_per_user_cap_thresholds`, `metronome_default_cap_thresholds_by_seat_type`, and `metronome_workspace_alert_ids` to the Poke cache resource registry, enabling manual cache inspection and invalidation from the Poke UI.

2. **Fix missing `POOL_CONTRACT_CREDIT_FILTER` on balance threshold alert** – the per-workspace `low_remaining_contract_credit_and_commit_balance_reached` alert was created without filtering to only "pool" contract credits. Without the filter, "excess" recurring credits (used for overage accounting) were included in the balance calculation, causing the alert to fire too early or mask a real pool depletion. The default alerts in `metronome_setup.ts` already had this filter; this brings the workspace-specific alert in line.

Also replaces the hardcoded `"pool"` string in `metronome_setup.ts` with the `CONTRACT_CREDIT_TYPE_POOL` constant for consistency.

> **Note:** Existing workspace balance threshold alerts at the same threshold won't self-correct since `upsertMetronomeAlert` only detects threshold changes. They will be fixed on the next threshold change, or can be manually refreshed via Poke.

## Tests

Manually verified type-check passes.

## Risk

Low. The filter is additive — it narrows which credits are counted, aligning the per-workspace alert with the existing default alerts. No schema or DB changes.

## Deploy Plan

No special steps needed.
