### PR TITLE
[front] checkout: PR2, extract checkout URL logic + prepare for CP

### DIFF
--- a/front-api/routes/w/[wId]/subscriptions/index.ts
+++ b/front-api/routes/w/[wId]/subscriptions/index.ts
@@ -1,4 +1,8 @@
 import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
+import {
+  createCheckoutUrl,
+  PostSubscriptionRequestBody,
+} from "@app/lib/api/subscription/checkout_url";
 import { scheduleMetronomeContractEnd } from "@app/lib/metronome/client";
 import {
   cancelSubscriptionAtPeriodEnd,
@@ -32,11 +36,6 @@ export type PostSubscriptionResponseBody = CheckoutUrlResult;
 export type PatchSubscriptionResponseBody = {
   success: boolean;
 };
-
-const PostSubscriptionRequestBody = z.object({
-  billingPeriod: z.enum(["monthly", "yearly"]),
-  couponCode: z.string().optional(),
-});
 
 const PatchSubscriptionRequestBody = z.object({
   action: z.enum(["cancel_free_trial", "pay_now", "upgrade_to_business"]),
@@ -77,22 +76,26 @@ app.post(
     const body = ctx.req.valid("json");
 
     try {
-      const useMetronomeBilling = await isMetronomeBillingEnabled(auth);
-      const owner = auth.getNonNullableWorkspace();
-      const user = auth.getNonNullableUser().toJSON();
-      const subscription = auth.getNonNullableSubscriptionResource();
+      const { billingPeriod, couponCode, seatType, targetUserId } = body;
 
-      const checkoutUrlResult = await subscription.getCheckoutUrlForUpgrade(
-        owner,
-        user,
-        body.billingPeriod,
-        {
-          useMetronomeBilling,
-          couponCode: body.couponCode,
-        }
-      );
+      const result = await createCheckoutUrl(auth, {
+        billingPeriod,
+        couponCode,
+        seatType,
+        targetUserId,
+      });
+      if (result.isErr()) {
+        const message =
+          result.error.type === "already_on_pro_plan"
+            ? "Workspace is already subscribed to a Pro or Business plan."
+            : "seatType and targetUserId are required for CP checkout.";
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: { type: "invalid_request_error", message },
+        });
+      }
 
-      return ctx.json(checkoutUrlResult);
+      return ctx.json(result.value);
     } catch (error) {
       logger.error({ error }, "Error while subscribing workspace to plan");
       return apiError(ctx, {

--- a/front/lib/api/subscription/checkout_url.ts
+++ b/front/lib/api/subscription/checkout_url.ts
@@ -1,0 +1,255 @@
+import assert from "node:assert";
+import type {
+  CheckoutBillingPeriod,
+  CheckoutSeatType,
+} from "@app/lib/api/checkout/types";
+import { CheckoutSeatTypeSchema } from "@app/lib/api/checkout/types";
+import {
+  isMetronomeBillingEnabled,
+  isMetronomeCheckoutEnabled,
+} from "@app/lib/api/subscription";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  BUSINESS_PLAN_COST_MONTHLY,
+  CP_MAX_SEAT_COST_MONTHLY,
+  CP_MAX_SEAT_COST_YEARLY,
+  CP_PRO_SEAT_COST_MONTHLY,
+  CP_PRO_SEAT_COST_YEARLY,
+  PRO_PLAN_COST_MONTHLY,
+  PRO_PLAN_COST_YEARLY,
+} from "@app/lib/client/subscription";
+import {
+  LEGACY_BUSINESS_PACKAGE_ALIAS,
+  LEGACY_PRO_ANNUAL_PACKAGE_ALIAS,
+  LEGACY_PRO_MONTHLY_PACKAGE_ALIAS,
+} from "@app/lib/metronome/types";
+import {
+  CREDIT_PRICED_BUSINESS_PLAN_CODE,
+  PRO_PLAN_SEAT_29_CODE,
+  PRO_PLAN_SEAT_39_CODE,
+} from "@app/lib/plans/plan_codes";
+import {
+  createEmbeddedMetronomeSetupCheckoutSession,
+  createStripeSubscriptionCheckoutSession,
+  type SupportedPaymentMethod,
+} from "@app/lib/plans/stripe";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import type { BillingPeriod, CheckoutUrlResult } from "@app/types/plan";
+import { Err, Ok, type Result } from "@app/types/shared/result";
+import { z } from "zod";
+
+export const PostSubscriptionRequestBody = z.object({
+  billingPeriod: z.enum(["monthly", "yearly"]),
+  couponCode: z.string().optional(),
+  // CP self-serve checkout fields (only used when metronome_cp_checkout is enabled)
+  seatType: CheckoutSeatTypeSchema.optional(),
+  targetUserId: z.string().optional(),
+});
+
+export type CheckoutUrlError =
+  | { type: "missing_cp_fields" }
+  | { type: "already_on_pro_plan" };
+
+type LegacyPlanParams = {
+  planCode: string;
+  allowedPaymentMethods: SupportedPaymentMethod[];
+  metronomePackageAlias: string;
+  isBusiness: boolean;
+};
+
+function resolveLegacyPlanParams(
+  owner: { metadata?: { isBusiness?: boolean } | null },
+  billingPeriod: BillingPeriod
+): LegacyPlanParams {
+  const isBusiness = !!owner.metadata?.isBusiness;
+  return isBusiness
+    ? {
+        isBusiness: true,
+        planCode: PRO_PLAN_SEAT_39_CODE,
+        allowedPaymentMethods: [
+          "card",
+          "sepa_debit",
+        ] satisfies SupportedPaymentMethod[],
+        metronomePackageAlias: LEGACY_BUSINESS_PACKAGE_ALIAS,
+      }
+    : {
+        isBusiness: false,
+        planCode: PRO_PLAN_SEAT_29_CODE,
+        allowedPaymentMethods: ["card"] satisfies SupportedPaymentMethod[],
+        metronomePackageAlias:
+          billingPeriod === "yearly"
+            ? LEGACY_PRO_ANNUAL_PACKAGE_ALIAS
+            : LEGACY_PRO_MONTHLY_PACKAGE_ALIAS,
+      };
+}
+
+async function createCPCheckoutUrl(
+  auth: Authenticator,
+  {
+    seatType,
+    billingPeriod,
+    targetUserId,
+    couponCode,
+  }: {
+    seatType: CheckoutSeatType;
+    billingPeriod: CheckoutBillingPeriod;
+    targetUserId: string;
+    couponCode?: string;
+  }
+): Promise<CheckoutUrlResult> {
+  const owner = auth.getNonNullableWorkspace();
+  const user = auth.getNonNullableUser().toJSON();
+
+  // Prices in USD cents. Yearly = per-month price × 12.
+  const monthlyPrice =
+    seatType === "pro" ? CP_PRO_SEAT_COST_MONTHLY : CP_MAX_SEAT_COST_MONTHLY;
+  const yearlyMonthlyPrice =
+    seatType === "pro" ? CP_PRO_SEAT_COST_YEARLY : CP_MAX_SEAT_COST_YEARLY;
+  const pricePerSeatCents =
+    billingPeriod === "monthly"
+      ? monthlyPrice * 100
+      : yearlyMonthlyPrice * 12 * 100;
+
+  const { clientSecret, sessionId } =
+    await createEmbeddedMetronomeSetupCheckoutSession({
+      allowedPaymentMethods: ["card"],
+      metronomePackageAlias: "business-usd",
+      owner,
+      planCode: CREDIT_PRICED_BUSINESS_PLAN_CODE,
+      billingPeriod,
+      seatCount: 1,
+      pricePerSeatCents,
+      couponCode,
+      user,
+      seatType,
+      targetUserId,
+    });
+
+  return { mode: "embedded", clientSecret, sessionId };
+}
+
+async function createLegacyMetronomeCheckoutUrl(
+  auth: Authenticator,
+  billingPeriod: BillingPeriod,
+  {
+    planParams,
+    couponCode,
+  }: {
+    planParams: LegacyPlanParams;
+    couponCode?: string;
+  }
+): Promise<CheckoutUrlResult> {
+  const owner = auth.getNonNullableWorkspace();
+  const user = auth.getNonNullableUser().toJSON();
+  const { planCode, allowedPaymentMethods, metronomePackageAlias, isBusiness } =
+    planParams;
+
+  const seatCount = await MembershipResource.countActiveSeatsInWorkspace(
+    owner.sId
+  );
+
+  const pricePerMonth = isBusiness
+    ? BUSINESS_PLAN_COST_MONTHLY
+    : billingPeriod === "yearly"
+      ? PRO_PLAN_COST_YEARLY
+      : PRO_PLAN_COST_MONTHLY;
+  const pricePerMonthCents = pricePerMonth * 100;
+  const monthsInPeriod = !isBusiness && billingPeriod === "yearly" ? 12 : 1;
+  const pricePerSeatCents = pricePerMonthCents * monthsInPeriod;
+
+  const { clientSecret, sessionId } =
+    await createEmbeddedMetronomeSetupCheckoutSession({
+      allowedPaymentMethods,
+      metronomePackageAlias,
+      owner,
+      planCode,
+      billingPeriod,
+      seatCount,
+      pricePerSeatCents,
+      couponCode,
+      user,
+    });
+
+  return { mode: "embedded", clientSecret, sessionId };
+}
+
+async function createLegacyStripeCheckoutUrl(
+  auth: Authenticator,
+  billingPeriod: BillingPeriod,
+  planParams: LegacyPlanParams
+): Promise<CheckoutUrlResult> {
+  const owner = auth.getNonNullableWorkspace();
+  const user = auth.getNonNullableUser().toJSON();
+  const { planCode, allowedPaymentMethods, metronomePackageAlias } = planParams;
+
+  const checkoutUrl = await createStripeSubscriptionCheckoutSession({
+    owner,
+    user,
+    billingPeriod,
+    planCode,
+    metronomePackageAlias,
+    allowedPaymentMethods,
+  });
+
+  assert(
+    checkoutUrl,
+    `Cannot subscribe to plan ${planCode}: error while creating checkout session (URL is null).`
+  );
+
+  return { mode: "hosted", checkoutUrl };
+}
+
+export async function createCheckoutUrl(
+  auth: Authenticator,
+  {
+    billingPeriod,
+    couponCode,
+    seatType,
+    targetUserId,
+  }: {
+    billingPeriod: BillingPeriod;
+    couponCode?: string;
+    seatType?: CheckoutSeatType;
+    targetUserId?: string;
+  }
+): Promise<Result<CheckoutUrlResult, CheckoutUrlError>> {
+  const useMetronomeCheckout = await isMetronomeCheckoutEnabled(auth);
+  if (useMetronomeCheckout) {
+    if (!seatType || !targetUserId) {
+      return new Err({ type: "missing_cp_fields" });
+    }
+    return new Ok(
+      await createCPCheckoutUrl(auth, {
+        seatType,
+        billingPeriod,
+        targetUserId,
+        couponCode,
+      })
+    );
+  }
+
+  const owner = auth.getNonNullableWorkspace();
+  const subscription = auth.getNonNullableSubscriptionResource();
+
+  const isAlreadyOnProPlan =
+    await subscription.isSubscriptionOnProOrBusinessPlan(owner);
+  if (isAlreadyOnProPlan) {
+    return new Err({ type: "already_on_pro_plan" });
+  }
+
+  const planParams = resolveLegacyPlanParams(owner, billingPeriod);
+
+  const useMetronomeBilling = await isMetronomeBillingEnabled(auth);
+  if (useMetronomeBilling) {
+    return new Ok(
+      await createLegacyMetronomeCheckoutUrl(auth, billingPeriod, {
+        planParams,
+        couponCode,
+      })
+    );
+  }
+
+  return new Ok(
+    await createLegacyStripeCheckoutUrl(auth, billingPeriod, planParams)
+  );
+}

--- a/front/lib/client/subscription.ts
+++ b/front/lib/client/subscription.ts
@@ -12,6 +12,12 @@ export const PRO_PLAN_COST_MONTHLY = 29;
 export const PRO_PLAN_COST_YEARLY = 27;
 export const BUSINESS_PLAN_COST_MONTHLY = 45;
 
+// Credit-priced (CP) self-serve seat prices
+export const CP_PRO_SEAT_COST_MONTHLY = 30;
+export const CP_PRO_SEAT_COST_YEARLY = 24;
+export const CP_MAX_SEAT_COST_MONTHLY = 150;
+export const CP_MAX_SEAT_COST_YEARLY = 120;
+
 export function formatPriceWithCurrency(
   price: number,
   currency: SupportedCurrency

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -340,7 +340,19 @@ export const createEmbeddedMetronomeSetupCheckoutSession = async ({
       enabled: true,
     },
     redirect_on_completion: "if_required",
-    return_url: `${config.getAppUrl()}/w/${owner.sId}/subscription/checkout?billingPeriod=${billingPeriod}&setup_session_id={CHECKOUT_SESSION_ID}`,
+    return_url: (() => {
+      const params = new URLSearchParams({
+        billingPeriod,
+        setup_session_id: "{CHECKOUT_SESSION_ID}",
+      });
+      if (seatType) {
+        params.set("seatType", seatType);
+      }
+      if (targetUserId) {
+        params.set("targetUserId", targetUserId);
+      }
+      return `${config.getAppUrl()}/w/${owner.sId}/subscription/checkout?${params.toString()}`;
+    })(),
     consent_collection: {
       terms_of_service: "required",
     },

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -1,13 +1,7 @@
-import assert from "node:assert";
 import { sendProactiveTrialCancelledEmail } from "@app/lib/api/email";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
 import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
-import {
-  BUSINESS_PLAN_COST_MONTHLY,
-  PRO_PLAN_COST_MONTHLY,
-  PRO_PLAN_COST_YEARLY,
-} from "@app/lib/client/subscription";
 import { DustError } from "@app/lib/error";
 import { scheduleMetronomeContractEnd } from "@app/lib/metronome/client";
 import {
@@ -18,11 +12,7 @@ import {
   syncContractQuantities,
 } from "@app/lib/metronome/contracts";
 import { invalidateContractCache } from "@app/lib/metronome/plan_type";
-import {
-  LEGACY_BUSINESS_PACKAGE_ALIAS,
-  LEGACY_PRO_ANNUAL_PACKAGE_ALIAS,
-  LEGACY_PRO_MONTHLY_PACKAGE_ALIAS,
-} from "@app/lib/metronome/types";
+import { LEGACY_BUSINESS_PACKAGE_ALIAS } from "@app/lib/metronome/types";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
@@ -37,19 +27,15 @@ import {
   isProPlanPrefix,
   isUpgraded,
   isWhitelistedBusinessPlan,
-  PRO_PLAN_SEAT_29_CODE,
   PRO_PLAN_SEAT_39_CODE,
 } from "@app/lib/plans/plan_codes";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import {
   cancelSubscriptionImmediately,
-  createEmbeddedMetronomeSetupCheckoutSession,
   createStripeBusinessSubscription,
-  createStripeSubscriptionCheckoutSession,
   getBusinessProPlanProductId,
   getProPlanProductId,
   getStripeSubscription,
-  type SupportedPaymentMethod,
 } from "@app/lib/plans/stripe";
 import { getTrialVersionForPlan, isTrial } from "@app/lib/plans/trial/limits";
 import { REPORT_USAGE_METADATA_KEY } from "@app/lib/plans/usage/types";
@@ -74,8 +60,6 @@ import {
 } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import {
-  type BillingPeriod,
-  type CheckoutUrlResult,
   type EnterpriseUpgradeFormType,
   isSubscriptionMetronomeBilled,
   type PlanType,
@@ -87,11 +71,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { sendUserOperationMessage } from "@app/types/shared/user_operation";
-import type {
-  LightWorkspaceType,
-  UserType,
-  WorkspaceType,
-} from "@app/types/user";
+import type { LightWorkspaceType, WorkspaceType } from "@app/types/user";
 import keyBy from "lodash/keyBy";
 import type { Attributes, CreationAttributes, Transaction } from "sequelize";
 import { Op } from "sequelize";
@@ -1227,104 +1207,6 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     }
   }
 
-  async getCheckoutUrlForUpgrade(
-    owner: WorkspaceType,
-    user: UserType,
-    billingPeriod: BillingPeriod,
-    {
-      useMetronomeBilling,
-      couponCode,
-    }: {
-      useMetronomeBilling: boolean;
-      couponCode?: string;
-    }
-  ): Promise<CheckoutUrlResult> {
-    const isBusiness = !!owner.metadata?.isBusiness;
-    const { planCode, allowedPaymentMethods, metronomePackageAlias } =
-      isBusiness
-        ? {
-            planCode: PRO_PLAN_SEAT_39_CODE,
-            allowedPaymentMethods: [
-              "card",
-              "sepa_debit",
-            ] satisfies SupportedPaymentMethod[],
-            metronomePackageAlias: LEGACY_BUSINESS_PACKAGE_ALIAS,
-          }
-        : {
-            planCode: PRO_PLAN_SEAT_29_CODE,
-            allowedPaymentMethods: ["card"] satisfies SupportedPaymentMethod[],
-            metronomePackageAlias:
-              billingPeriod === "yearly"
-                ? LEGACY_PRO_ANNUAL_PACKAGE_ALIAS
-                : LEGACY_PRO_MONTHLY_PACKAGE_ALIAS,
-          };
-
-    const proPlan = await SubscriptionResource.findPlanOrThrow(planCode);
-
-    // We verify that the workspace is not already subscribed to the Pro plan product.
-    const isAlreadyOnProPlan =
-      await this.isSubscriptionOnProOrBusinessPlan(owner);
-    assert(
-      !isAlreadyOnProPlan,
-      `Cannot subscribe to plan ${planCode}: already subscribed to a Pro plan.`
-    );
-
-    if (useMetronomeBilling) {
-      const seatCount = await MembershipResource.countActiveSeatsInWorkspace(
-        owner.sId
-      );
-
-      // Per-period per-seat price in cents. Business has no yearly variant.
-      const pricePerMonth = isBusiness
-        ? BUSINESS_PLAN_COST_MONTHLY
-        : billingPeriod === "yearly"
-          ? PRO_PLAN_COST_YEARLY
-          : PRO_PLAN_COST_MONTHLY;
-      const pricePerMonthCents = pricePerMonth * 100;
-      const monthsInPeriod = !isBusiness && billingPeriod === "yearly" ? 12 : 1;
-      const pricePerSeatCents = pricePerMonthCents * monthsInPeriod;
-
-      const { clientSecret, sessionId } =
-        await createEmbeddedMetronomeSetupCheckoutSession({
-          allowedPaymentMethods,
-          metronomePackageAlias,
-          owner,
-          planCode,
-          billingPeriod,
-          seatCount,
-          pricePerSeatCents,
-          couponCode,
-          user,
-        });
-      return {
-        mode: "embedded",
-        clientSecret,
-        sessionId,
-        plan: renderPlanFromModel({ plan: proPlan }),
-      };
-    }
-
-    const checkoutUrl = await createStripeSubscriptionCheckoutSession({
-      owner,
-      user,
-      billingPeriod,
-      planCode,
-      metronomePackageAlias,
-      allowedPaymentMethods,
-    });
-
-    assert(
-      checkoutUrl,
-      `Cannot subscribe to plan ${planCode}: error while creating checkout session (URL is null).`
-    );
-
-    return {
-      mode: "hosted",
-      checkoutUrl,
-      plan: renderPlanFromModel({ plan: proPlan }),
-    };
-  }
-
   async delete(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}
@@ -1725,7 +1607,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     return activeSubscription;
   }
 
-  private async isSubscriptionOnProOrBusinessPlan(
+  async isSubscriptionOnProOrBusinessPlan(
     owner: WorkspaceType
   ): Promise<boolean> {
     // Check Stripe first (shadow-billed subscriptions have both IDs).

--- a/front/pages/api/w/[wId]/subscriptions/index.ts
+++ b/front/pages/api/w/[wId]/subscriptions/index.ts
@@ -2,6 +2,10 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
+import {
+  createCheckoutUrl,
+  PostSubscriptionRequestBody,
+} from "@app/lib/api/subscription/checkout_url";
 import type { Authenticator } from "@app/lib/auth";
 import { scheduleMetronomeContractEnd } from "@app/lib/metronome/client";
 import {
@@ -27,11 +31,6 @@ type PatchSubscriptionResponseBody = {
 export type GetSubscriptionsResponseBody = {
   subscriptions: SubscriptionType[];
 };
-
-export const PostSubscriptionRequestBody = z.object({
-  billingPeriod: z.enum(["monthly", "yearly"]),
-  couponCode: z.string().optional(),
-});
 
 export const PatchSubscriptionRequestBody = z.object({
   action: z.enum(["cancel_free_trial", "pay_now", "upgrade_to_business"]),
@@ -91,22 +90,27 @@ async function handler(
       }
 
       try {
-        const useMetronomeBilling = await isMetronomeBillingEnabled(auth);
-        const owner = auth.getNonNullableWorkspace();
-        const user = auth.getNonNullableUser().toJSON();
-        const subscription = auth.getNonNullableSubscriptionResource();
+        const { billingPeriod, couponCode, seatType, targetUserId } =
+          bodyValidation.data;
 
-        const checkoutUrlResult = await subscription.getCheckoutUrlForUpgrade(
-          owner,
-          user,
-          bodyValidation.data.billingPeriod,
-          {
-            useMetronomeBilling,
-            couponCode: bodyValidation.data.couponCode,
-          }
-        );
+        const result = await createCheckoutUrl(auth, {
+          billingPeriod,
+          couponCode,
+          seatType,
+          targetUserId,
+        });
+        if (result.isErr()) {
+          const message =
+            result.error.type === "already_on_pro_plan"
+              ? "Workspace is already subscribed to a Pro or Business plan."
+              : "seatType and targetUserId are required for CP checkout.";
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: { type: "invalid_request_error", message },
+          });
+        }
 
-        return res.status(200).json(checkoutUrlResult);
+        return res.status(200).json(result.value);
       } catch (error) {
         logger.error({ error }, "Error while subscribing workspace to plan");
         return apiError(req, res, {

--- a/front/types/plan.ts
+++ b/front/types/plan.ts
@@ -171,10 +171,5 @@ export const FreePlanUpgradeFormSchema = z.object({
 export type FreePlanUpgradeFormType = z.infer<typeof FreePlanUpgradeFormSchema>;
 
 export type CheckoutUrlResult =
-  | { mode: "hosted"; checkoutUrl: string; plan: PlanType }
-  | {
-      mode: "embedded";
-      clientSecret: string;
-      sessionId: string;
-      plan: PlanType;
-    };
+  | { mode: "hosted"; checkoutUrl: string }
+  | { mode: "embedded"; clientSecret: string; sessionId: string };


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/8594
See the issue for global view

- Moves getCheckoutUrlForUpgrade out of SubscriptionResource into a new checkout_url.ts module (createCheckoutUrl)
- co-locates the request body schema
- adds CP seat price constants
- threads seatType/targetUserId into the Stripe setup session return URL
- removes the unused plan field from CheckoutUrlResult (no consumer was reading it)

No behavior change on existing paths
purely preparatory for the CP activation backend.

## Tests

Tested locally the checkout with Stripe and the one with Metronome to guarantee the same behavior as before

## Risk

Low, refactoring only + tests

## Deploy Plan

Deploy front
