### PR TITLE
fix(metronome): add POOL_CONTRACT_CREDIT_FILTER to balance threshold alert

### DIFF
--- a/front/lib/metronome/alerts/balance_threshold.ts
+++ b/front/lib/metronome/alerts/balance_threshold.ts
@@ -3,7 +3,11 @@ import {
   findMetronomeAlert,
   upsertMetronomeAlert,
 } from "@app/lib/metronome/alerts";
-import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import {
+  CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
+  CONTRACT_CREDIT_TYPE_POOL,
+  getCreditTypeAwuId,
+} from "@app/lib/metronome/constants";
 import {
   bestEffortInvalidateCacheWithRedis,
   cacheWithRedis,
@@ -48,6 +52,13 @@ export async function upsertMetronomeBalanceThresholdAlert({
     credit_type_id: getCreditTypeAwuId(),
     customer_id: metronomeCustomerId,
     uniqueness_key: balanceThresholdAlertUniquenessKey(workspaceId),
+    custom_field_filters: [
+      {
+        entity: "ContractCredit",
+        key: CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
+        value: CONTRACT_CREDIT_TYPE_POOL,
+      },
+    ],
   });
   if (upsertResult.isErr()) {
     return new Err(upsertResult.error);

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -16,6 +16,7 @@ import { DEFAULT_ALERT_UNIQUENESS_KEYS } from "@app/lib/metronome/alerts/default
 import { getMetronomeClient } from "@app/lib/metronome/client";
 import {
   CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
+  CONTRACT_CREDIT_TYPE_POOL,
   CREDIT_TYPE_USD_ID,
   DEV_CREDIT_TYPE_AWU_ID,
   PLAN_CODE_CUSTOM_FIELD_KEY,
@@ -1521,7 +1522,7 @@ const POOL_CONTRACT_CREDIT_FILTER: NonNullable<
 >[number] = {
   entity: "ContractCredit",
   key: CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
-  value: "pool",
+  value: CONTRACT_CREDIT_TYPE_POOL,
 };
 
 // Default alerts applied to all customers (no `customer_id` set on create):


### PR DESCRIPTION
## Description

The per-workspace `low_remaining_contract_credit_and_commit_balance_reached` alert (`upsertMetronomeBalanceThresholdAlert`) was created without a `custom_field_filters` entry, while the three equivalent default alerts in `metronome_setup.ts` all include `POOL_CONTRACT_CREDIT_FILTER`. Without the filter, "excess" recurring credits (used for overage accounting) were counted in the remaining balance, causing the alert to fire too early or mask a real pool depletion.

This PR adds the same `ContractCredit / DUST_CONTRACT_CREDIT_TYPE = pool` filter to the workspace-specific alert. Also replaces the hardcoded `"pool"` string in `metronome_setup.ts` with the `CONTRACT_CREDIT_TYPE_POOL` constant.

> Note: existing workspace alerts at the same threshold won't self-correct (upsert only detects threshold changes). They'll fix on the next threshold change, or can be refreshed manually.

## Tests

Manually verified type-check passes.

## Risk

Low — the filter is additive, narrowing which credits are counted to match the existing default alerts. No schema or DB changes.
