### PR TITLE
Fix user transition on cap resolved

### DIFF
--- a/front/lib/api/metronome/credit_state_dispatcher.test.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.test.ts
@@ -1,9 +1,10 @@
+import { fetchLiveUserCreditInputs } from "@app/lib/metronome/live_user_credit_inputs";
 import { transitionUserCreditState } from "@app/lib/metronome/user_credit_state_machine";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   dispatchPerUserCapReached,
@@ -20,11 +21,30 @@ vi.mock("@app/lib/metronome/user_credit_state_machine", async () => {
   };
 });
 
+vi.mock("@app/lib/metronome/live_user_credit_inputs", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/live_user_credit_inputs")
+  >("@app/lib/metronome/live_user_credit_inputs");
+  return {
+    ...actual,
+    fetchLiveUserCreditInputs: vi.fn(),
+  };
+});
+
 const TEST_METRONOME_CUSTOMER_ID = "cust_test_xxx";
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(transitionUserCreditState).mockResolvedValue(new Ok("on_pool"));
+  vi.mocked(transitionUserCreditState).mockResolvedValue(new Ok("user_seat"));
+  vi.mocked(fetchLiveUserCreditInputs).mockResolvedValue(
+    new Ok({
+      seatBalanceAwu: 40000,
+      seatStartingBalanceAwu: 40000,
+      effectiveCapAwuCredits: null,
+      capSource: "none",
+      consumedAwuCredits: null,
+    })
+  );
 });
 
 describe("credit_state_dispatcher per-user caps", () => {
@@ -56,7 +76,7 @@ describe("credit_state_dispatcher per-user caps", () => {
     );
   });
 
-  it("dispatchPerUserCapResolved transitions any seat type", async () => {
+  it("dispatchPerUserCapResolved passes the live balance into the transition context", async () => {
     const workspaceType = await WorkspaceFactory.metronome({
       metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
     });
@@ -71,16 +91,82 @@ describe("credit_state_dispatcher per-user caps", () => {
       seatType: "max",
     });
 
+    // A max seat that still has personal balance — the state machine resolves
+    // the band from this snapshot (verified in the state machine tests).
+    vi.mocked(fetchLiveUserCreditInputs).mockResolvedValue(
+      new Ok({
+        seatBalanceAwu: 40000,
+        seatStartingBalanceAwu: 40000,
+        effectiveCapAwuCredits: 50000,
+        capSource: "override",
+        consumedAwuCredits: 10000,
+      })
+    );
+
     await dispatchPerUserCapResolved({
       workspace,
       userId: user.sId,
     });
 
+    expect(fetchLiveUserCreditInputs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: workspaceType.sId,
+        userId: user.sId,
+        seatType: "max",
+        metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
+      })
+    );
     expect(transitionUserCreditState).toHaveBeenCalledWith(
-      // createMembership seeds pro/max seats at user_seat (their initial state).
       expect.objectContaining({ seatType: "max", creditState: "user_seat" }),
       { type: "per_user_cap_resolved" },
-      { workspaceId: workspaceType.sId, userId: user.sId }
+      {
+        workspaceId: workspaceType.sId,
+        userId: user.sId,
+        seatType: "max",
+        liveBalance: {
+          seatBalanceAwu: 40000,
+          seatStartingBalanceAwu: 40000,
+          perUserCapAwuCredits: 50000,
+          consumedAwuCredits: 10000,
+        },
+      }
+    );
+  });
+
+  it("dispatchPerUserCapResolved dispatches without a live balance when the read fails", async () => {
+    const workspaceType = await WorkspaceFactory.metronome({
+      metronomeCustomerId: TEST_METRONOME_CUSTOMER_ID,
+    });
+    const workspace = await WorkspaceResource.fetchById(workspaceType.sId);
+    expect(workspace).not.toBeNull();
+    if (!workspace) {
+      throw new Error("Workspace not found");
+    }
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspaceType, user, {
+      role: "user",
+      seatType: "max",
+    });
+
+    vi.mocked(fetchLiveUserCreditInputs).mockResolvedValue(
+      new Err(new Error("metronome unavailable"))
+    );
+
+    await dispatchPerUserCapResolved({
+      workspace,
+      userId: user.sId,
+    });
+
+    // No snapshot → the transition defaults to on_pool (resolved by the machine).
+    expect(transitionUserCreditState).toHaveBeenCalledWith(
+      expect.objectContaining({ seatType: "max", creditState: "user_seat" }),
+      { type: "per_user_cap_resolved" },
+      {
+        workspaceId: workspaceType.sId,
+        userId: user.sId,
+        seatType: "max",
+        liveBalance: undefined,
+      }
     );
   });
 });

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -9,6 +9,7 @@ import {
 import { listMetronomeBalances } from "@app/lib/metronome/client";
 import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
 import { invalidateWorkspacePoolCredits } from "@app/lib/metronome/credit_balance";
+import { fetchLiveUserCreditInputs } from "@app/lib/metronome/live_user_credit_inputs";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import { transitionProgrammaticCreditState } from "@app/lib/metronome/programmatic_credit_state_machine";
 import {
@@ -20,6 +21,7 @@ import {
   clearWorkspaceProgrammaticWarned,
   setWorkspaceProgrammaticWarned,
 } from "@app/lib/metronome/user_block";
+import type { LiveUserSeatBalance } from "@app/lib/metronome/user_credit_state_machine";
 import { transitionUserCreditState } from "@app/lib/metronome/user_credit_state_machine";
 import type { WorkspaceCreditEvent } from "@app/lib/metronome/workspace_credit_state_machine";
 import { transitionWorkspaceCreditState } from "@app/lib/metronome/workspace_credit_state_machine";
@@ -404,15 +406,78 @@ export async function dispatchPerUserCapResolved({
     return new Ok(undefined);
   }
 
+  // Resolving the per-user cap only clears the cap dimension; the seat↔pool band
+  // the user lands in depends on their live balance. Read it from Metronome and
+  // pass it into the transition context so the state machine picks the correct
+  // band (a seat-based user with personal balance left → `user_seat` /
+  // `user_seat_low_balance`; otherwise the pool). When the live read isn't
+  // available the transition defaults to `on_pool` and the reconcile / billing
+  // webhooks correct it later.
+  const liveBalance = await resolveLiveBalanceForCapResolved({
+    workspace,
+    userId,
+    seatType: membership.seatType,
+  });
+
   const result = await transitionUserCreditState(
     membership,
     { type: "per_user_cap_resolved" },
-    { workspaceId: workspace.sId, userId }
+    {
+      workspaceId: workspace.sId,
+      userId,
+      seatType: membership.seatType,
+      liveBalance,
+    }
   );
   if (result.isErr()) {
     return result;
   }
   return new Ok(undefined);
+}
+
+// Read the live per-user balance snapshot used to resolve the seat↔pool band on
+// cap resolution. Returns `undefined` when there's no Metronome customer or the
+// live read fails — the transition then defaults to `on_pool`.
+async function resolveLiveBalanceForCapResolved({
+  workspace,
+  userId,
+  seatType,
+}: {
+  workspace: WorkspaceResource;
+  userId: string;
+  seatType: MembershipSeatType | null;
+}): Promise<LiveUserSeatBalance | undefined> {
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId) {
+    return undefined;
+  }
+
+  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+    workspace.id
+  );
+  const metronomeContractId = subscription?.metronomeContractId ?? null;
+
+  const liveResult = await fetchLiveUserCreditInputs({
+    workspaceId: workspace.sId,
+    userId,
+    seatType,
+    metronomeCustomerId,
+    metronomeContractId,
+  });
+  if (liveResult.isErr()) {
+    logger.warn(
+      { workspaceId: workspace.sId, userId, seatType, err: liveResult.error },
+      "[CreditStateDispatcher] per_user_cap_resolved: live balance read failed, defaulting to on_pool"
+    );
+    return undefined;
+  }
+
+  return {
+    seatBalanceAwu: liveResult.value.seatBalanceAwu,
+    seatStartingBalanceAwu: liveResult.value.seatStartingBalanceAwu,
+    perUserCapAwuCredits: liveResult.value.effectiveCapAwuCredits,
+    consumedAwuCredits: liveResult.value.consumedAwuCredits,
+  };
 }
 
 export async function dispatchPoolExhausted({

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -6,17 +6,17 @@ import type { MetronomeCapAlertInfo } from "@app/lib/metronome/alerts/spend_limi
 import {
   getCachedDefaultCapThresholdsBySeatType,
   getCachedPerUserCapThresholds,
-  getMetronomeDefaultUserCapAlertForSeatType,
-  getMetronomePerUserCap,
 } from "@app/lib/metronome/alerts/spend_limits";
 import { listMetronomeSeatBalances } from "@app/lib/metronome/client";
-import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import {
+  awuSeatBalanceForUser,
+  fetchLiveUserCreditInputs,
+} from "@app/lib/metronome/live_user_credit_inputs";
 import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
 import {
   expectedProgrammaticCreditStateFromAlerts,
   setProgrammaticCreditStateReconciled,
 } from "@app/lib/metronome/programmatic_credit_state_machine";
-import type { MetronomeSeatBalance } from "@app/lib/metronome/types";
 import { setUserCreditStateReconciled } from "@app/lib/metronome/user_credit_state_machine";
 import {
   expectedPoolCreditStateFromBalance,
@@ -109,22 +109,6 @@ export type ReconcileCreditStateReport =
 // comparing the persisted state with the expected one (see USER_CREDIT_STATES).
 function normalizeUserCreditState(state: UserCreditState): UserCreditState {
   return state === "normal" ? "on_pool" : state;
-}
-
-// The remaining + full AWU seat balance for a user, read from the live
-// per-seat balances. Returns null when the user has no individual AWU seat
-// allocation (pool-based seat), so callers treat them as spending from the pool.
-function awuSeatBalanceForUser(
-  seatBalances: MetronomeSeatBalance[],
-  userId: string
-): { balanceAwu: number; startingBalanceAwu: number } | null {
-  const awuCreditTypeId = getCreditTypeAwuId();
-  const seat = seatBalances.find((b) => b.seat_id === userId);
-  const awu = seat?.balances.find((b) => b.credit_type_id === awuCreditTypeId);
-  if (!awu) {
-    return null;
-  }
-  return { balanceAwu: awu.balance, startingBalanceAwu: awu.starting_balance };
 }
 
 /**
@@ -312,84 +296,23 @@ async function reconcileUser({
   const seatType = membership.seatType;
   const metronomeContractId = auth.subscription()?.metronomeContractId ?? null;
 
-  // Live per-user seat balance (the seat↔pool dimension's source of truth).
-  let seatBalanceAwu: number | null = null;
-  let seatStartingBalanceAwu: number | null = null;
-  if (metronomeContractId) {
-    const seatBalancesResult = await listMetronomeSeatBalances({
-      metronomeCustomerId,
-      metronomeContractId,
-    });
-    if (seatBalancesResult.isErr()) {
-      return new Err(
-        new Error(
-          `Failed to read seat balances: ${seatBalancesResult.error.message}`
-        )
-      );
-    }
-    const seat = awuSeatBalanceForUser(seatBalancesResult.value, userId);
-    if (seat) {
-      seatBalanceAwu = seat.balanceAwu;
-      seatStartingBalanceAwu = seat.startingBalanceAwu;
-    }
-  }
-
-  // Resolve the effective per-user cap threshold (in AWU credits, seat
-  // allowance included): the user-specific override if present, otherwise the
-  // seat-type default. `null` means no cap is configured for this user.
-  let effectiveCapAwuCredits: number | null = null;
-  let capSource: "override" | "default" | "none" = "none";
-
-  const overrideResult = await getMetronomePerUserCap({
-    metronomeCustomerId,
+  const liveResult = await fetchLiveUserCreditInputs({
     workspaceId: workspace.sId,
     userId,
+    seatType,
+    metronomeCustomerId,
+    metronomeContractId,
   });
-  if (overrideResult.isErr()) {
-    return new Err(
-      new Error(`Failed to read per-user cap: ${overrideResult.error.message}`)
-    );
+  if (liveResult.isErr()) {
+    return liveResult;
   }
-  if (overrideResult.value) {
-    effectiveCapAwuCredits = overrideResult.value.alert.threshold;
-    capSource = "override";
-  } else {
-    const normalizedSeatType = normalizeToPoolLimitSeatType(seatType);
-    if (normalizedSeatType) {
-      const defaultResult = await getMetronomeDefaultUserCapAlertForSeatType({
-        metronomeCustomerId,
-        workspaceId: workspace.sId,
-        seatType: normalizedSeatType,
-      });
-      if (defaultResult.isErr()) {
-        return new Err(
-          new Error(
-            `Failed to read default per-user cap: ${defaultResult.error.message}`
-          )
-        );
-      }
-      if (defaultResult.value) {
-        effectiveCapAwuCredits = defaultResult.value.alert.threshold;
-        capSource = "default";
-      }
-    }
-  }
-
-  // Consumption is only needed for the cap bands (capped / on_pool_low_balance),
-  // which require a configured cap; skip the fetch otherwise.
-  let consumedAwuCredits: number | null = null;
-  if (effectiveCapAwuCredits !== null && metronomeContractId) {
-    const usageResult = await fetchPerUserAwuUsage({
-      metronomeCustomerId,
-      metronomeContractId,
-    });
-    if (usageResult.isErr()) {
-      return new Err(
-        new Error(`Failed to read per-user usage: ${usageResult.error.message}`)
-      );
-    }
-    consumedAwuCredits = usageResult.value.get(userId) ?? 0;
-  }
+  const {
+    seatBalanceAwu,
+    seatStartingBalanceAwu,
+    effectiveCapAwuCredits,
+    capSource,
+    consumedAwuCredits,
+  } = liveResult.value;
 
   const expectedState = expectedUserCreditState({
     seatType,

--- a/front/lib/metronome/live_user_credit_inputs.test.ts
+++ b/front/lib/metronome/live_user_credit_inputs.test.ts
@@ -1,0 +1,143 @@
+import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import { fetchLiveUserCreditInputs } from "@app/lib/metronome/live_user_credit_inputs";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockListMetronomeSeatBalances,
+  mockFetchPerUserAwuUsage,
+  mockGetMetronomePerUserCap,
+  mockGetMetronomeDefaultUserCapAlertForSeatType,
+} = vi.hoisted(() => ({
+  mockListMetronomeSeatBalances: vi.fn(),
+  mockFetchPerUserAwuUsage: vi.fn(),
+  mockGetMetronomePerUserCap: vi.fn(),
+  mockGetMetronomeDefaultUserCapAlertForSeatType: vi.fn(),
+}));
+
+vi.mock("@app/lib/metronome/client", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/client")
+  >("@app/lib/metronome/client");
+  return {
+    ...actual,
+    listMetronomeSeatBalances: mockListMetronomeSeatBalances,
+  };
+});
+
+vi.mock("@app/lib/metronome/per_user_usage", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/per_user_usage")
+  >("@app/lib/metronome/per_user_usage");
+  return { ...actual, fetchPerUserAwuUsage: mockFetchPerUserAwuUsage };
+});
+
+vi.mock("@app/lib/metronome/alerts/spend_limits", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/alerts/spend_limits")
+  >("@app/lib/metronome/alerts/spend_limits");
+  return {
+    ...actual,
+    getMetronomePerUserCap: mockGetMetronomePerUserCap,
+    getMetronomeDefaultUserCapAlertForSeatType:
+      mockGetMetronomeDefaultUserCapAlertForSeatType,
+  };
+});
+
+const CUSTOMER_ID = "cust_test";
+const CONTRACT_ID = "ct_test";
+const USER_ID = "user_test";
+
+function seatBalance(balanceAwu: number, startingAwu: number) {
+  return [
+    {
+      seat_id: USER_ID,
+      balances: [
+        {
+          credit_type_id: getCreditTypeAwuId(),
+          balance: balanceAwu,
+          starting_balance: startingAwu,
+        },
+      ],
+    },
+  ];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFetchPerUserAwuUsage.mockResolvedValue(new Ok(new Map<string, number>()));
+  mockGetMetronomePerUserCap.mockResolvedValue(new Ok(null));
+  mockGetMetronomeDefaultUserCapAlertForSeatType.mockResolvedValue(
+    new Ok(null)
+  );
+});
+
+describe("fetchLiveUserCreditInputs", () => {
+  it("reads the live seat balance for a seat-based user", async () => {
+    mockListMetronomeSeatBalances.mockResolvedValue(
+      new Ok(seatBalance(40000, 40000))
+    );
+
+    const result = await fetchLiveUserCreditInputs({
+      workspaceId: "ws_test",
+      userId: USER_ID,
+      seatType: "max",
+      metronomeCustomerId: CUSTOMER_ID,
+      metronomeContractId: CONTRACT_ID,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.seatBalanceAwu).toBe(40000);
+      expect(result.value.seatStartingBalanceAwu).toBe(40000);
+      // No cap configured → cap fields null, usage not fetched.
+      expect(result.value.effectiveCapAwuCredits).toBeNull();
+      expect(result.value.capSource).toBe("none");
+      expect(result.value.consumedAwuCredits).toBeNull();
+    }
+  });
+
+  it("resolves the per-user cap override and consumed usage when configured", async () => {
+    mockListMetronomeSeatBalances.mockResolvedValue(
+      new Ok(seatBalance(0, 40000))
+    );
+    mockGetMetronomePerUserCap.mockResolvedValue(
+      new Ok({ alert: { threshold: 50000 } })
+    );
+    mockFetchPerUserAwuUsage.mockResolvedValue(
+      new Ok(new Map<string, number>([[USER_ID, 10000]]))
+    );
+
+    const result = await fetchLiveUserCreditInputs({
+      workspaceId: "ws_test",
+      userId: USER_ID,
+      seatType: "max",
+      metronomeCustomerId: CUSTOMER_ID,
+      metronomeContractId: CONTRACT_ID,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.seatBalanceAwu).toBe(0);
+      expect(result.value.effectiveCapAwuCredits).toBe(50000);
+      expect(result.value.capSource).toBe("override");
+      expect(result.value.consumedAwuCredits).toBe(10000);
+    }
+  });
+
+  it("surfaces an Err when the live seat-balance read fails", async () => {
+    mockListMetronomeSeatBalances.mockResolvedValue(
+      new Err(new Error("metronome down"))
+    );
+
+    const result = await fetchLiveUserCreditInputs({
+      workspaceId: "ws_test",
+      userId: USER_ID,
+      seatType: "max",
+      metronomeCustomerId: CUSTOMER_ID,
+      metronomeContractId: CONTRACT_ID,
+    });
+
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/front/lib/metronome/live_user_credit_inputs.ts
+++ b/front/lib/metronome/live_user_credit_inputs.ts
@@ -1,0 +1,163 @@
+// Fetches the live Metronome inputs that determine a single user's credit
+// state (per-seat AWU balance + effective per-user cap + consumed usage). The
+// mapping from these inputs to a `UserCreditState` lives in
+// `expectedUserCreditState` (called by reconcile and by the state machine's
+// `per_user_cap_resolved` resolver) — this module only reads the raw numbers.
+//
+// Lives in its own module so both the reconcile path
+// (`reconcile_credit_state.ts`) and the per-user-cap-resolved dispatch
+// (`credit_state_dispatcher.ts`) can reach it without an import cycle — the
+// reconcile module imports the dispatcher, so the dispatcher cannot import the
+// reconcile module back.
+
+import {
+  getMetronomeDefaultUserCapAlertForSeatType,
+  getMetronomePerUserCap,
+} from "@app/lib/metronome/alerts/spend_limits";
+import { listMetronomeSeatBalances } from "@app/lib/metronome/client";
+import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
+import type { MetronomeSeatBalance } from "@app/lib/metronome/types";
+import type { MembershipSeatType } from "@app/types/memberships";
+import { normalizeToPoolLimitSeatType } from "@app/types/memberships";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+// The remaining + full AWU seat balance for a user, read from the live
+// per-seat balances. Returns null when the user has no individual AWU seat
+// allocation (pool-based seat), so callers treat them as spending from the pool.
+export function awuSeatBalanceForUser(
+  seatBalances: MetronomeSeatBalance[],
+  userId: string
+): { balanceAwu: number; startingBalanceAwu: number } | null {
+  const awuCreditTypeId = getCreditTypeAwuId();
+  const seat = seatBalances.find((b) => b.seat_id === userId);
+  const awu = seat?.balances.find((b) => b.credit_type_id === awuCreditTypeId);
+  if (!awu) {
+    return null;
+  }
+  return { balanceAwu: awu.balance, startingBalanceAwu: awu.starting_balance };
+}
+
+export type LiveUserCreditInputs = {
+  // Live Metronome per-seat AWU balance for this user: `seatBalanceAwu` is the
+  // amount remaining, `seatStartingBalanceAwu` the full allocation granted for
+  // the period (e.g. 8000 for a pro seat). Both null for pool-based seats with
+  // no individual allocation. The remaining/starting ratio drives the
+  // user_seat ↔ user_seat_low_balance band.
+  seatBalanceAwu: number | null;
+  seatStartingBalanceAwu: number | null;
+  effectiveCapAwuCredits: number | null;
+  capSource: "override" | "default" | "none";
+  consumedAwuCredits: number | null;
+};
+
+/**
+ * Read the live source-of-truth inputs for a single user's credit state: the
+ * live per-seat AWU balance, the effective per-user cap (user override →
+ * seat-type default), and the consumed AWU usage. Callers feed these into
+ * `expectedUserCreditState` (directly, or via the state machine context) to
+ * derive the actual state — this only reads the numbers.
+ *
+ * Surfaces Metronome read failures as `Err` so callers can fall back.
+ */
+export async function fetchLiveUserCreditInputs({
+  workspaceId,
+  userId,
+  seatType,
+  metronomeCustomerId,
+  metronomeContractId,
+}: {
+  workspaceId: string;
+  userId: string;
+  seatType: MembershipSeatType | null;
+  metronomeCustomerId: string;
+  metronomeContractId: string | null;
+}): Promise<Result<LiveUserCreditInputs, Error>> {
+  // Live per-user seat balance (the seat↔pool dimension's source of truth).
+  let seatBalanceAwu: number | null = null;
+  let seatStartingBalanceAwu: number | null = null;
+  if (metronomeContractId) {
+    const seatBalancesResult = await listMetronomeSeatBalances({
+      metronomeCustomerId,
+      metronomeContractId,
+    });
+    if (seatBalancesResult.isErr()) {
+      return new Err(
+        new Error(
+          `Failed to read seat balances: ${seatBalancesResult.error.message}`
+        )
+      );
+    }
+    const seat = awuSeatBalanceForUser(seatBalancesResult.value, userId);
+    if (seat) {
+      seatBalanceAwu = seat.balanceAwu;
+      seatStartingBalanceAwu = seat.startingBalanceAwu;
+    }
+  }
+
+  // Resolve the effective per-user cap threshold (in AWU credits, seat
+  // allowance included): the user-specific override if present, otherwise the
+  // seat-type default. `null` means no cap is configured for this user.
+  let effectiveCapAwuCredits: number | null = null;
+  let capSource: LiveUserCreditInputs["capSource"] = "none";
+
+  const overrideResult = await getMetronomePerUserCap({
+    metronomeCustomerId,
+    workspaceId,
+    userId,
+  });
+  if (overrideResult.isErr()) {
+    return new Err(
+      new Error(`Failed to read per-user cap: ${overrideResult.error.message}`)
+    );
+  }
+  if (overrideResult.value) {
+    effectiveCapAwuCredits = overrideResult.value.alert.threshold;
+    capSource = "override";
+  } else {
+    const normalizedSeatType = normalizeToPoolLimitSeatType(seatType);
+    if (normalizedSeatType) {
+      const defaultResult = await getMetronomeDefaultUserCapAlertForSeatType({
+        metronomeCustomerId,
+        workspaceId,
+        seatType: normalizedSeatType,
+      });
+      if (defaultResult.isErr()) {
+        return new Err(
+          new Error(
+            `Failed to read default per-user cap: ${defaultResult.error.message}`
+          )
+        );
+      }
+      if (defaultResult.value) {
+        effectiveCapAwuCredits = defaultResult.value.alert.threshold;
+        capSource = "default";
+      }
+    }
+  }
+
+  // Consumption is only needed for the cap bands (capped / on_pool_low_balance),
+  // which require a configured cap; skip the fetch otherwise.
+  let consumedAwuCredits: number | null = null;
+  if (effectiveCapAwuCredits !== null && metronomeContractId) {
+    const usageResult = await fetchPerUserAwuUsage({
+      metronomeCustomerId,
+      metronomeContractId,
+    });
+    if (usageResult.isErr()) {
+      return new Err(
+        new Error(`Failed to read per-user usage: ${usageResult.error.message}`)
+      );
+    }
+    consumedAwuCredits = usageResult.value.get(userId) ?? 0;
+  }
+
+  return new Ok({
+    seatBalanceAwu,
+    seatStartingBalanceAwu,
+    effectiveCapAwuCredits,
+    capSource,
+    consumedAwuCredits,
+  });
+}

--- a/front/lib/metronome/user_credit_state_machine.test.ts
+++ b/front/lib/metronome/user_credit_state_machine.test.ts
@@ -203,6 +203,107 @@ describe("UserCreditStateMachine — transitions", () => {
       "on_pool"
     );
   });
+
+  it("capped + per_user_cap_resolved with personal seat balance → user_seat", async () => {
+    const membership = makeMembership("capped", "max");
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "per_user_cap_resolved" },
+      {
+        ...baseCtx,
+        seatType: "max",
+        liveBalance: {
+          seatBalanceAwu: 40000,
+          seatStartingBalanceAwu: 40000,
+          perUserCapAwuCredits: null,
+          consumedAwuCredits: null,
+        },
+      }
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("user_seat");
+    }
+    expect(membership.updateCreditState).toHaveBeenCalledWith(
+      "user_seat",
+      undefined
+    );
+    expect(mockClearUserCapBlocked).toHaveBeenCalledWith("ws_test", "u_test");
+    expect(mockSetUserCreditState).toHaveBeenCalledWith(
+      "ws_test",
+      "u_test",
+      "user_seat"
+    );
+  });
+
+  it("capped + per_user_cap_resolved with a low personal balance → user_seat_low_balance", async () => {
+    const membership = makeMembership("capped", "max");
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "per_user_cap_resolved" },
+      {
+        ...baseCtx,
+        seatType: "max",
+        liveBalance: {
+          seatBalanceAwu: 5000,
+          seatStartingBalanceAwu: 40000,
+          perUserCapAwuCredits: null,
+          consumedAwuCredits: null,
+        },
+      }
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("user_seat_low_balance");
+    }
+    expect(membership.updateCreditState).toHaveBeenCalledWith(
+      "user_seat_low_balance",
+      undefined
+    );
+  });
+
+  it("capped + per_user_cap_resolved with an exhausted seat and pool room → on_pool", async () => {
+    const membership = makeMembership("capped", "max");
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "per_user_cap_resolved" },
+      {
+        ...baseCtx,
+        seatType: "max",
+        liveBalance: {
+          seatBalanceAwu: 0,
+          seatStartingBalanceAwu: 40000,
+          perUserCapAwuCredits: 50000,
+          consumedAwuCredits: 10000,
+        },
+      }
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("on_pool");
+    }
+    expect(membership.updateCreditState).toHaveBeenCalledWith(
+      "on_pool",
+      undefined
+    );
+  });
+
+  it("capped + per_user_cap_resolved without a live balance → on_pool (default)", async () => {
+    const membership = makeMembership("capped", "max");
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "per_user_cap_resolved" },
+      { ...baseCtx, seatType: "max" }
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("on_pool");
+    }
+    expect(membership.updateCreditState).toHaveBeenCalledWith(
+      "on_pool",
+      undefined
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/front/lib/metronome/user_credit_state_machine.ts
+++ b/front/lib/metronome/user_credit_state_machine.ts
@@ -12,6 +12,7 @@ import type {
   MembershipSeatType,
   UserCreditState,
 } from "@app/types/memberships";
+import { expectedUserCreditState } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -21,11 +22,31 @@ import {
   PRO_SEAT_MONTHLY_AWU_CREDITS,
 } from "./setup_new_pricing";
 
+/**
+ * Live per-user balance snapshot used to resolve the seat↔pool band when a
+ * per-user cap resolves. Fields mirror the inputs of `expectedUserCreditState`.
+ * `null` fields mean "unknown" (e.g. pool-based seat with no individual
+ * allocation, or no configured cap), handled the same way as in reconciliation.
+ */
+export type LiveUserSeatBalance = {
+  seatBalanceAwu: number | null;
+  seatStartingBalanceAwu: number | null;
+  perUserCapAwuCredits: number | null;
+  consumedAwuCredits: number | null;
+};
+
 export type UserCreditContext = {
   workspaceId: string;
   userId: string;
   /** Seat type of the membership — required by guards on seat-balance transitions. */
   seatType?: MembershipSeatType | null;
+  /**
+   * Live balance snapshot. When present, the `per_user_cap_resolved` transition
+   * recomputes the correct seat↔pool band from it (user_seat /
+   * user_seat_low_balance / on_pool / on_pool_low_balance) instead of defaulting
+   * to `on_pool`. Absent for events that don't carry balance data.
+   */
+  liveBalance?: LiveUserSeatBalance;
 };
 
 export type UserCreditEvent =
@@ -79,6 +100,21 @@ type UserCreditTransition = {
   guard?: UserCreditGuard;
   to: UserCreditState;
 };
+
+// Seat↔pool band a user should land in when their per-user cap resolves,
+// derived from the live balance snapshot carried in the context. Used by the
+// guards on the `per_user_cap_resolved` transitions below (mirroring how the
+// `seat_balance_exhausted` guards branch on seat type / pool limit). Without a
+// snapshot we can't distinguish seat from pool, so default to the pool.
+function targetAfterCapResolved(ctx: UserCreditContext): UserCreditState {
+  if (!ctx.liveBalance) {
+    return "on_pool";
+  }
+  return expectedUserCreditState({
+    seatType: ctx.seatType ?? null,
+    ...ctx.liveBalance,
+  });
+}
 
 function syncUserCapCacheForState(
   state: UserCreditState,
@@ -149,8 +185,57 @@ const TRANSITIONS: UserCreditTransition[] = [
     event: "admin_raised_user_cap",
     to: "on_pool",
   },
+  // per_user_cap_resolved: the cap dimension cleared, so re-derive the seat↔pool
+  // band from the live balance snapshot and route to it via guards (same shape
+  // as the seat_balance_exhausted transitions below). A seat-based user who
+  // still has personal balance lands back in `user_seat` /
+  // `user_seat_low_balance`; otherwise they spend from the pool. The unguarded
+  // entry last is the default — also the no-snapshot case (reconcile / billing
+  // webhooks correct it later).
   {
-    from: ["on_pool", "on_pool_low_balance", "capped"],
+    from: [
+      "user_seat",
+      "user_seat_low_balance",
+      "on_pool",
+      "on_pool_low_balance",
+      "capped",
+    ],
+    event: "per_user_cap_resolved",
+    guard: (ctx) => targetAfterCapResolved(ctx) === "user_seat",
+    to: "user_seat",
+  },
+  {
+    from: [
+      "user_seat",
+      "user_seat_low_balance",
+      "on_pool",
+      "on_pool_low_balance",
+      "capped",
+    ],
+    event: "per_user_cap_resolved",
+    guard: (ctx) => targetAfterCapResolved(ctx) === "user_seat_low_balance",
+    to: "user_seat_low_balance",
+  },
+  {
+    from: [
+      "user_seat",
+      "user_seat_low_balance",
+      "on_pool",
+      "on_pool_low_balance",
+      "capped",
+    ],
+    event: "per_user_cap_resolved",
+    guard: (ctx) => targetAfterCapResolved(ctx) === "on_pool_low_balance",
+    to: "on_pool_low_balance",
+  },
+  {
+    from: [
+      "user_seat",
+      "user_seat_low_balance",
+      "on_pool",
+      "on_pool_low_balance",
+      "capped",
+    ],
     event: "per_user_cap_resolved",
     to: "on_pool",
   },


### PR DESCRIPTION
## Description

Fixes the user credit-state transition when a per-user spend cap resolves.

When a `capped` user's per-user cap resolved (billing-cycle renewal, or an admin raising/removing their cap), the state machine ran a fixed `per_user_cap_resolved → on_pool` transition. That hardcoded target ignored the user's actual balance, so a seat-based user who still had personal seat allowance was wrongly dropped onto the workspace pool instead of returning to `user_seat` — and a pool user near their cap missed `on_pool_low_balance`.

The seat↔pool band can't be derived from the event graph alone; it depends on the live seat balance. The fix feeds that balance into the transition's **context** and lets the state machine resolve the correct band itself (via the existing `expectedUserCreditState`), so the user lands in whichever of `user_seat` / `user_seat_low_balance` / `on_pool` / `on_pool_low_balance` actually matches.

Changes:
- **`user_credit_state_machine.ts`** — `UserCreditContext` gains an optional `liveBalance` snapshot. `per_user_cap_resolved` becomes four **guarded** transitions (same pattern as `seat_balance_exhausted`): a small `targetAfterCapResolved(ctx)` helper computes the band from the snapshot, guards route to `user_seat` / `user_seat_low_balance` / `on_pool_low_balance`, and the unguarded entry defaults to `on_pool` (also the no-snapshot case).
- **`credit_state_dispatcher.ts`** — `dispatchPerUserCapResolved` reads the live balance and passes it into the transition context. This covers both triggers: the billing webhook and the admin spend-limit change. If the live read fails, it dispatches without a snapshot and the transition defaults to `on_pool` (reconcile / billing webhooks correct it later).
- **`live_user_credit_inputs.ts`** (new) — a small Metronome read helper (`fetchLiveUserCreditInputs`) that reads the three live inputs (seat balance, effective per-user cap, consumed usage). Pure I/O; the inputs→state mapping stays in `expectedUserCreditState`. It's a separate module only to avoid an import cycle (`reconcile_credit_state` already imports `credit_state_dispatcher`).
- **`reconcile_credit_state.ts`** — reuses the shared read helper instead of its own inline copy of the same fetch logic (no behavior change).

No new state machine and no second source of truth: there's still one machine (`user_credit_state_machine.ts`) and one inputs→state mapping (`expectedUserCreditState`).

## Tests

- `user_credit_state_machine.test.ts` — added cases for `per_user_cap_resolved` resolving to `user_seat`, `user_seat_low_balance`, `on_pool` (exhausted seat + pool room), and the no-snapshot default `on_pool`.
- `credit_state_dispatcher.test.ts` — asserts the live balance is threaded into the transition context, and that a failed read dispatches without a snapshot.
- `live_user_credit_inputs.test.ts` — covers the fetch helper (seat balance read, cap override + usage, read-failure → `Err`).
- Full metronome suite green; `tsgo --noEmit` and biome clean on the changed files.

## Risk

Low. Behavior only changes on `per_user_cap_resolved`, and only to place the user in a more accurate band; the cap block itself (`capped` / `per_user_cap_reached`) is unchanged. On a failed Metronome read it degrades to the previous `on_pool` behavior. Single state machine / source of truth preserved. Safe to roll back (revert restores the fixed `→ on_pool` transition).

## Deploy Plan

Standard deploy. No migrations, no config changes, no coordinated client release.
