### PR TITLE
Outlook tool: Allow sending mails from shared account

### DIFF
--- a/front/lib/api/actions/servers/outlook/mail_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/mail_metadata.ts
@@ -250,6 +250,14 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
         .describe(
           "Whether to save the sent email to the Sent Items folder. Defaults to true."
         ),
+      sharedMailboxAddress: z
+        .string()
+        .optional()
+        .describe(
+          "The email address of the shared mailbox to send from (e.g. 'support@company.com'). " +
+            "Leave empty to send from your own mailbox. " +
+            "Note: the shared mailbox address must be known in advance — there is no API to auto-discover it."
+        ),
     },
     stake: "high",
     displayLabels: {
@@ -396,7 +404,7 @@ export const OUTLOOK_MAIL_SERVER = {
       provider: "microsoft_tools",
       supported_use_cases: ["personal_actions", "platform_actions"],
       scope:
-        "Mail.ReadWrite.Shared Mail.Send Contacts.ReadWrite Contacts.ReadWrite.Shared User.Read SensitivityLabel.Read offline_access",
+        "Mail.ReadWrite.Shared Mail.Send Mail.Send.Shared Contacts.ReadWrite Contacts.ReadWrite.Shared User.Read SensitivityLabel.Read offline_access",
       availableScopes: [
         {
           value: "Mail.ReadWrite",
@@ -415,6 +423,14 @@ export const OUTLOOK_MAIL_SERVER = {
           value: "Mail.Send",
           label: "Send mail",
           description: "Send emails on behalf of the signed-in user.",
+          required: true,
+          impliedBy: "Mail.Send.Shared",
+        },
+        {
+          value: "Mail.Send.Shared",
+          label: "Send mail from shared mailboxes",
+          description: "Send emails from shared and delegated mailboxes.",
+          fallbackScope: "Mail.Send",
         },
         {
           value: "Contacts.ReadWrite",

--- a/front/lib/api/actions/servers/outlook/tools/mail.ts
+++ b/front/lib/api/actions/servers/outlook/tools/mail.ts
@@ -1056,6 +1056,7 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
       contentType = "text",
       body,
       saveToSentItems = true,
+      sharedMailboxAddress,
     },
     { authInfo }
   ) => {
@@ -1063,6 +1064,8 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
     if (!accessToken) {
       return new Err(new MCPError("Authentication required"));
     }
+
+    const basePath = getMailboxBasePath(sharedMailboxAddress);
 
     const message: Record<string, unknown> = {
       subject,
@@ -1074,6 +1077,12 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
         emailAddress: { address: email },
       })),
     };
+
+    if (sharedMailboxAddress) {
+      message.from = {
+        emailAddress: { address: sharedMailboxAddress },
+      };
+    }
 
     if (cc && cc.length > 0) {
       message.ccRecipients = cc.map((email) => ({
@@ -1093,16 +1102,20 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
       }));
     }
 
-    const response = await fetchFromOutlook("/me/sendMail", accessToken, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        message,
-        saveToSentItems,
-      }),
-    });
+    const response = await fetchFromOutlook(
+      `${basePath}/sendMail`,
+      accessToken,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          message,
+          saveToSentItems,
+        }),
+      }
+    );
 
     if (!response.ok) {
       const errorText = await getErrorText(response);


### PR DESCRIPTION
## Description

Fixes the inability to send emails from a shared Outlook mailbox. The `send_mail` tool now accepts an optional `sharedMailboxAddress` parameter: when provided, the API call is routed to `/users/{sharedMailboxAddress}/sendMail` (via the existing `getMailboxBasePath` helper) instead of `/me/sendMail`, and the message `from` field is set accordingly.

The `Mail.Send.Shared` scope is also added to the Outlook mail server's required scopes (with `Mail.Send` as a fallback) so Microsoft Graph can actually authorize sending on behalf of a shared mailbox. `Mail.Send` is also marked as `required: true` in `availableScopes`.

## Tests

Manually test by connecting the Outlook tool with a Microsoft account that has Send As / Full Access permission on a shared mailbox, then invoking `send_mail` with the `sharedMailboxAddress` field set to the shared mailbox address.

## Risk

`Mail.Send.Shared` is already in the list of requested OAuth scopes of our "Dust - Tools" app. So this PR shouldn't prompt existing Microsoft-connected users to re-consent.

## Deploy Plan

Deploy `front`.