### PR TITLE
[front] feat: add workspace_analytics shared query-input layer

### DIFF
--- a/front/lib/api/actions/servers/workspace_analytics/query_input.test.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/query_input.test.ts
@@ -1,0 +1,109 @@
+import {
+  MAX_QUERY_WINDOW_DAYS,
+  resolveTimeWindow,
+} from "@app/lib/api/actions/servers/workspace_analytics/query_input";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("resolveTimeWindow", () => {
+  describe("explicit range", () => {
+    it("resolves a valid range to inclusive day bounds", () => {
+      const r = resolveTimeWindow({
+        startDate: "2026-01-01",
+        endDate: "2026-01-31",
+      });
+      expect(r.isOk()).toBe(true);
+      if (r.isOk()) {
+        expect(r.value.startDate).toBe("2026-01-01T00:00:00.000Z");
+        expect(r.value.endDate).toBe("2026-01-31T23:59:59.999Z");
+        expect(r.value.label).toBe("2026-01-01 to 2026-01-31");
+        expect(r.value.timezone).toBe("UTC");
+      }
+    });
+
+    it("errors when only one bound is provided", () => {
+      expect(resolveTimeWindow({ startDate: "2026-01-01" }).isErr()).toBe(true);
+      expect(resolveTimeWindow({ endDate: "2026-01-01" }).isErr()).toBe(true);
+    });
+
+    it("errors when endDate is before startDate", () => {
+      expect(
+        resolveTimeWindow({
+          startDate: "2026-02-01",
+          endDate: "2026-01-01",
+        }).isErr()
+      ).toBe(true);
+    });
+
+    it(`accepts an inclusive span of exactly ${MAX_QUERY_WINDOW_DAYS} days`, () => {
+      // 2026-01-01 .. 2026-04-10 inclusive = 100 days.
+      expect(
+        resolveTimeWindow({
+          startDate: "2026-01-01",
+          endDate: "2026-04-10",
+        }).isOk()
+      ).toBe(true);
+    });
+
+    it(`errors when the inclusive span exceeds ${MAX_QUERY_WINDOW_DAYS} days`, () => {
+      // 2026-01-01 .. 2026-04-11 inclusive = 101 days.
+      expect(
+        resolveTimeWindow({
+          startDate: "2026-01-01",
+          endDate: "2026-04-11",
+        }).isErr()
+      ).toBe(true);
+    });
+
+    it("errors on an invalid calendar date", () => {
+      expect(
+        resolveTimeWindow({
+          startDate: "2026-13-40",
+          endDate: "2026-13-41",
+        }).isErr()
+      ).toBe(true);
+    });
+  });
+
+  it("errors on an invalid timezone", () => {
+    expect(
+      resolveTimeWindow({ period: "this_month", timezone: "Not/AZone" }).isErr()
+    ).toBe(true);
+  });
+
+  describe("relative periods (fixed clock at 2026-06-15T12:00:00Z)", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-06-15T12:00:00.000Z"));
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("resolves this_month to the calendar month to date (UTC)", () => {
+      const r = resolveTimeWindow({ period: "this_month" });
+      expect(r.isOk()).toBe(true);
+      if (r.isOk()) {
+        expect(r.value.startDate).toBe("2026-06-01T00:00:00.000Z");
+        expect(r.value.endDate).toBe("2026-06-15T12:00:00.000Z");
+        expect(r.value.label).toBe("June 2026");
+      }
+    });
+
+    it("resolves last_7_days to a 7-day window ending now", () => {
+      const r = resolveTimeWindow({ period: "last_7_days" });
+      expect(r.isOk()).toBe(true);
+      if (r.isOk()) {
+        expect(r.value.startDate).toBe("2026-06-09T00:00:00.000Z");
+      }
+    });
+
+    it("falls back to the provided default period when none is given", () => {
+      const r = resolveTimeWindow({}, "last_30_days");
+      expect(r.isOk()).toBe(true);
+      if (r.isOk()) {
+        expect(r.value.startDate).toBe("2026-05-17T00:00:00.000Z");
+        expect(r.value.label).toBe("the last 30 days");
+      }
+    });
+  });
+});

--- a/front/lib/api/actions/servers/workspace_analytics/query_input.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/query_input.ts
@@ -1,3 +1,4 @@
+import { timezoneSchema } from "@app/lib/api/assistant/observability/utils";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -44,10 +45,9 @@ export const timeWindowSchema = {
     .describe(
       "End date (YYYY-MM-DD), inclusive. Provide together with startDate."
     ),
-  timezone: z
-    .string()
-    .optional()
-    .describe("IANA timezone used to resolve the window. Defaults to UTC."),
+  timezone: timezoneSchema.describe(
+    "IANA timezone used to resolve the window. Defaults to UTC."
+  ),
 };
 
 // Shared filter fragment for message-based usage tools.

--- a/front/lib/api/actions/servers/workspace_analytics/query_input.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/query_input.ts
@@ -1,0 +1,162 @@
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import moment from "moment-timezone";
+import { z } from "zod";
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+// Caps the span an explicit start/end range may scan so a single query can't
+// sweep an unbounded history. Relative periods are bounded by construction and
+// are never rejected.
+export const MAX_QUERY_WINDOW_DAYS = 100;
+
+export const ANALYTICS_PERIODS = [
+  "this_month",
+  "last_7_days",
+  "last_30_days",
+  "last_90_days",
+  "this_quarter",
+] as const;
+export type AnalyticsPeriod = (typeof ANALYTICS_PERIODS)[number];
+
+// Shared time-window input fragment. Either a relative `period` or an explicit
+// startDate/endDate range; explicit dates win.
+export const timeWindowSchema = {
+  period: z
+    .enum(ANALYTICS_PERIODS)
+    .optional()
+    .describe(
+      "Relative time window. Ignored when startDate/endDate are provided. " +
+        "Defaults to the tool's natural window if omitted."
+    ),
+  startDate: z
+    .string()
+    .regex(DATE_RE)
+    .optional()
+    .describe(
+      "Start date (YYYY-MM-DD). Provide together with endDate for a custom range."
+    ),
+  endDate: z
+    .string()
+    .regex(DATE_RE)
+    .optional()
+    .describe(
+      "End date (YYYY-MM-DD), inclusive. Provide together with startDate."
+    ),
+  timezone: z
+    .string()
+    .optional()
+    .describe("IANA timezone used to resolve the window. Defaults to UTC."),
+};
+
+// Shared filter fragment for message-based usage tools.
+export const usageFilterSchema = {
+  source: z
+    .string()
+    .optional()
+    .describe(
+      "Filter to a single message origin (context_origin), e.g. web, slack, " +
+        "api, extension, cli, or 'unknown' for messages with no recorded origin."
+    ),
+  agentIds: z
+    .array(z.string())
+    .optional()
+    .describe("Restrict to messages from these agent sIds."),
+  userIds: z
+    .array(z.string())
+    .optional()
+    .describe("Restrict to messages from these user sIds."),
+};
+
+export type TimeWindowInput = {
+  period?: AnalyticsPeriod;
+  startDate?: string;
+  endDate?: string;
+  timezone?: string;
+};
+
+export type ResolvedTimeWindow = {
+  startDate: string;
+  endDate: string;
+  label: string;
+  timezone: string;
+};
+
+// Resolves a TimeWindowInput into concrete ISO start/end instants plus a human
+// label. Explicit startDate/endDate take precedence over `period`; when nothing
+// is provided, falls back to `defaultPeriod`.
+export function resolveTimeWindow(
+  input: TimeWindowInput,
+  defaultPeriod: AnalyticsPeriod = "this_month"
+): Result<ResolvedTimeWindow, string> {
+  const timezone = input.timezone ?? "UTC";
+  if (!moment.tz.zone(timezone)) {
+    return new Err(`Invalid timezone: ${timezone}`);
+  }
+
+  if (input.startDate || input.endDate) {
+    if (!input.startDate || !input.endDate) {
+      return new Err(
+        "Provide both startDate and endDate for a custom range, or neither."
+      );
+    }
+    const start = moment.tz(input.startDate, "YYYY-MM-DD", true, timezone);
+    const end = moment.tz(input.endDate, "YYYY-MM-DD", true, timezone);
+    if (!start.isValid() || !end.isValid()) {
+      return new Err("startDate and endDate must be valid YYYY-MM-DD dates.");
+    }
+    if (end.isBefore(start)) {
+      return new Err("endDate must be on or after startDate.");
+    }
+    const inclusiveDays = end.diff(start, "days") + 1;
+    if (inclusiveDays > MAX_QUERY_WINDOW_DAYS) {
+      return new Err(
+        `The query window cannot exceed ${MAX_QUERY_WINDOW_DAYS} days. ` +
+          "Narrow the date range, or use a relative period."
+      );
+    }
+    return new Ok({
+      startDate: start.startOf("day").toISOString(),
+      endDate: end.endOf("day").toISOString(),
+      label: `${input.startDate} to ${input.endDate}`,
+      timezone,
+    });
+  }
+
+  const period = input.period ?? defaultPeriod;
+  const now = moment.tz(timezone);
+  let start: moment.Moment;
+  let label: string;
+  switch (period) {
+    case "this_month":
+      start = now.clone().startOf("month");
+      label = now.format("MMMM YYYY");
+      break;
+    case "last_7_days":
+      start = now.clone().subtract(6, "days").startOf("day");
+      label = "the last 7 days";
+      break;
+    case "last_30_days":
+      start = now.clone().subtract(29, "days").startOf("day");
+      label = "the last 30 days";
+      break;
+    case "last_90_days":
+      start = now.clone().subtract(89, "days").startOf("day");
+      label = "the last 90 days";
+      break;
+    case "this_quarter":
+      start = now.clone().startOf("quarter");
+      label = `Q${now.quarter()} ${now.year()}`;
+      break;
+    default:
+      return assertNever(period);
+  }
+
+  return new Ok({
+    startDate: start.toISOString(),
+    endDate: now.toISOString(),
+    label,
+    timezone,
+  });
+}

--- a/front/lib/api/actions/servers/workspace_analytics/query_input.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/query_input.ts
@@ -23,7 +23,7 @@ export type AnalyticsPeriod = (typeof ANALYTICS_PERIODS)[number];
 
 // Shared time-window input fragment. Either a relative `period` or an explicit
 // startDate/endDate range; explicit dates win.
-export const timeWindowSchema = {
+export const timeWindowSchemaShape = {
   period: z
     .enum(ANALYTICS_PERIODS)
     .optional()
@@ -50,6 +50,8 @@ export const timeWindowSchema = {
   ),
 };
 
+export const timeWindowInputSchema = z.object(timeWindowSchemaShape);
+
 // Shared filter fragment for message-based usage tools.
 export const usageFilterSchema = {
   source: z
@@ -69,12 +71,7 @@ export const usageFilterSchema = {
     .describe("Restrict to messages from these user sIds."),
 };
 
-export type TimeWindowInput = {
-  period?: AnalyticsPeriod;
-  startDate?: string;
-  endDate?: string;
-  timezone?: string;
-};
+export type TimeWindowInput = z.input<typeof timeWindowInputSchema>;
 
 export type ResolvedTimeWindow = {
   startDate: string;


### PR DESCRIPTION
## Description

Add the standalone input layer the workspace_analytics tools will build on: timeWindowSchema and usageFilterSchema (source / agentIds / userIds) plus resolveTimeWindow, which turns a relative period or an explicit YYYY-MM-DD range into concrete ISO start/end instants and a human label. Explicit ranges win over period, are validated (both bounds required, ordering, valid timezone) and are capped at MAX_QUERY_WINDOW_DAYS (100, inclusive) to bound the scanned history.

No wiring yet; consumed by the MCP server tools in a follow-up. Unit-tested.

timezone logic is worth refactoring to a shared lib. Will do it in another PR

## Tests

Unit

## Risk

None, not used yet

## Deploy Plan

front