### PR TITLE
Move shared API contracts out of pages/api

### DIFF
--- a/front-api/routes/poke/plans.ts
+++ b/front-api/routes/poke/plans.ts
@@ -1,7 +1,7 @@
+import { MAX_DOCUMENT_UPSERT_SIZE_MB } from "@app/lib/data_sources";
 import { PlanModel } from "@app/lib/models/plan";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
-import { config as documentBodyParserConfig } from "@app/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]";
 import type { PlanType } from "@app/types/plan";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
@@ -86,15 +86,14 @@ app.post(
   async (ctx): HandlerResult<UpsertPokePlanResponseBody> => {
     const body = ctx.req.valid("json");
 
-    const { sizeLimit } = documentBodyParserConfig.api.bodyParser;
-    const maxSizeMb = parseInt(sizeLimit.replace("mb", ""), 10);
-
-    if (body.limits.dataSources.documents.sizeMb >= maxSizeMb) {
+    if (
+      body.limits.dataSources.documents.sizeMb >= MAX_DOCUMENT_UPSERT_SIZE_MB
+    ) {
       return apiError(ctx, {
         status_code: 400,
         api_error: {
           type: "invalid_request_error",
-          message: `Document size limit must be less than ${maxSizeMb}MB.`,
+          message: `Document size limit must be less than ${MAX_DOCUMENT_UPSERT_SIZE_MB}MB.`,
         },
       });
     }

--- a/front-api/routes/w/[wId]/invitations/[iId]/index.ts
+++ b/front-api/routes/w/[wId]/invitations/[iId]/index.ts
@@ -3,9 +3,9 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
+import type { PostMemberInvitationsResponseBody } from "@app/lib/api/invitation";
+import { PostMemberInvitationBodySchema } from "@app/lib/api/invitation";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
-import type { PostMemberInvitationsResponseBody } from "@app/pages/api/w/[wId]/invitations/[iId]/index";
-import { PostMemberInvitationBodySchema } from "@app/pages/api/w/[wId]/invitations/[iId]/index";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/invitations/index.ts
+++ b/front-api/routes/w/[wId]/invitations/index.ts
@@ -1,10 +1,12 @@
-import { handleMembershipInvitations } from "@app/lib/api/invitation";
-import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import type {
   GetWorkspaceInvitationsResponseBody,
   PostInvitationResponseBody,
-} from "@app/pages/api/w/[wId]/invitations/index";
-import { PostInvitationRequestBodySchema } from "@app/pages/api/w/[wId]/invitations/index";
+} from "@app/lib/api/invitation";
+import {
+  handleMembershipInvitations,
+  PostInvitationRequestBodySchema,
+} from "@app/lib/api/invitation";
+import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/members/me/agent_favorite.ts
+++ b/front-api/routes/w/[wId]/members/me/agent_favorite.ts
@@ -1,7 +1,9 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import { setAgentUserFavorite } from "@app/lib/api/assistant/user_relation";
-import type { PostAgentUserFavoriteResponseBody } from "@app/pages/api/w/[wId]/members/me/agent_favorite";
-import { PostAgentUserFavoriteRequestBodySchema } from "@app/pages/api/w/[wId]/members/me/agent_favorite";
+import type { PostAgentUserFavoriteResponseBody } from "@app/lib/api/assistant/user_relation";
+import {
+  PostAgentUserFavoriteRequestBodySchema,
+  setAgentUserFavorite,
+} from "@app/lib/api/assistant/user_relation";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -1,3 +1,4 @@
+import { AttachedKnowledgeSchema } from "@app/lib/api/skills/schemas";
 import { resolveAdditionalRequestedSpaceModelIds } from "@app/lib/api/skills/space_requirements";
 import { getFeatureFlags } from "@app/lib/auth";
 import { pruneOutdatedSkillEditSuggestions } from "@app/lib/reinforcement/skill_suggestion_pruning";
@@ -7,7 +8,6 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { isResourceSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
-import { AttachedKnowledgeSchema } from "@app/pages/api/w/[wId]/skills";
 import type {
   SkillType,
   SkillWithRelationsType,

--- a/front/lib/api/assistant/user_relation.ts
+++ b/front/lib/api/assistant/user_relation.ts
@@ -3,6 +3,21 @@ import type { Authenticator } from "@app/lib/auth";
 import { AgentUserRelationModel } from "@app/lib/models/agent/agent";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { z } from "zod";
+
+export type PostAgentUserFavoriteResponseBody = {
+  agentId: string;
+  userFavorite: boolean;
+};
+
+export const PostAgentUserFavoriteRequestBodySchema = z.object({
+  agentId: z.string(),
+  userFavorite: z.boolean(),
+});
+
+export type PostAgentUserFavoriteRequestBody = z.infer<
+  typeof PostAgentUserFavoriteRequestBodySchema
+>;
 
 export async function setAgentUserFavorite({
   auth,

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -31,14 +31,46 @@ import type {
   UserType,
   WorkspaceType,
 } from "@app/types/user";
+import { ActiveRoleSchema } from "@app/types/user";
 import sgMail from "@sendgrid/mail";
 import { escape } from "html-escaper";
 import type { Transaction } from "sequelize";
 import { Op } from "sequelize";
+import { z } from "zod";
 
 import { MembershipInvitationResource } from "../resources/membership_invitation_resource";
 
 const EMAIL_CONCURRENCY = 8;
+
+export type GetWorkspaceInvitationsResponseBody = {
+  invitations: MembershipInvitationType[];
+};
+
+export const PostInvitationRequestBodySchema = z.array(
+  z.object({
+    email: z.string(),
+    role: ActiveRoleSchema,
+  })
+);
+
+export type PostInvitationRequestBody = z.infer<
+  typeof PostInvitationRequestBodySchema
+>;
+
+export type PostInvitationResponseBody = {
+  success: boolean;
+  email: string;
+  error_message?: string;
+}[];
+
+export type PostMemberInvitationsResponseBody = {
+  invitation: MembershipInvitationType;
+};
+
+export const PostMemberInvitationBodySchema = z.object({
+  status: z.enum(["revoked", "pending"]),
+  initialRole: ActiveRoleSchema,
+});
 
 export async function getInvitation(
   auth: Authenticator,

--- a/front/lib/api/skills/schemas.ts
+++ b/front/lib/api/skills/schemas.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+// Schema for knowledge attached to a skill.
+export const AttachedKnowledgeSchema = z.object({
+  dataSourceViewId: z.string(),
+  nodeId: z.string(),
+  spaceId: z.string(),
+  title: z.string(),
+});

--- a/front/lib/data_sources.ts
+++ b/front/lib/data_sources.ts
@@ -12,6 +12,12 @@ import type {
 import type { DataSourceViewType } from "@app/types/data_source_view";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 
+// Maximum request body size accepted by the document upsert endpoint, in megabytes. 16MB
+// accommodates 5MB document content (MAX_LARGE_DOCUMENT_TXT_LEN in connectors) plus ~3x JSON
+// encoding overhead for escaping. The Next.js body-parser `config` in the documents endpoint must
+// stay in sync with this value (Next requires a string literal there for static analysis).
+export const MAX_DOCUMENT_UPSERT_SIZE_MB = 16;
+
 // TODO(DURABLE AGENTS 2025-06-25): Remove RetrievalDocumentResource support.
 export function getDisplayNameForDocument(document: CoreAPIDocument): string {
   const titleTagPrefix = "title:";

--- a/front/lib/invitations.ts
+++ b/front/lib/invitations.ts
@@ -1,11 +1,11 @@
 // Maximum allowed number of unconsumed invitations per workspace per day.
 
 import type { ConfirmDataType } from "@app/components/Confirm";
-import { clientFetch } from "@app/lib/egress/client";
 import type {
   PostInvitationRequestBody,
   PostInvitationResponseBody,
-} from "@app/pages/api/w/[wId]/invitations";
+} from "@app/lib/api/invitation";
+import { clientFetch } from "@app/lib/egress/client";
 import type { MembershipInvitationType } from "@app/types/membership_invitation";
 import type { ActiveRoleType, RoleType, WorkspaceType } from "@app/types/user";
 import type { NotificationType } from "@dust-tt/sparkle";

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -8,6 +8,7 @@ import type {
   ToolLatencyRow,
   ToolLatencyView,
 } from "@app/lib/api/assistant/observability/tool_latency";
+import type { PostAgentUserFavoriteRequestBody } from "@app/lib/api/assistant/user_relation";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   emptyArray,
@@ -38,7 +39,6 @@ import type { GetVersionMarkersResponse } from "@app/pages/api/w/[wId]/assistant
 import type { GetAgentUsageResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage";
 import type { GetSlackChannelsLinkedWithAgentResponseBody } from "@app/pages/api/w/[wId]/assistant/builder/slack/channels_linked_with_agent";
 import type { GetMemberResponseBody } from "@app/pages/api/w/[wId]/members/[uId]";
-import type { PostAgentUserFavoriteRequestBody } from "@app/pages/api/w/[wId]/members/me/agent_favorite";
 import type {
   AgentConfigurationType,
   AgentsGetViewType,

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -1,9 +1,9 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import type { GetMembersUsageResponseBody } from "@app/lib/api/credits/members_usage";
+import type { GetWorkspaceInvitationsResponseBody } from "@app/lib/api/invitation";
 import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import { debounce } from "@app/lib/utils/debounce";
-import type { GetWorkspaceInvitationsResponseBody } from "@app/pages/api/w/[wId]/invitations";
 import type { GetMembersResponseBody } from "@app/pages/api/w/[wId]/members";
 import type {
   GetUserSpendLimitResponseBody,

--- a/front/pages/api/w/[wId]/invitations/[iId]/index.ts
+++ b/front/pages/api/w/[wId]/invitations/[iId]/index.ts
@@ -6,24 +6,14 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { PostMemberInvitationsResponseBody } from "@app/lib/api/invitation";
+import { PostMemberInvitationBodySchema } from "@app/lib/api/invitation";
 import type { Authenticator } from "@app/lib/auth";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { MembershipInvitationType } from "@app/types/membership_invitation";
-import { ActiveRoleSchema } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export type PostMemberInvitationsResponseBody = {
-  invitation: MembershipInvitationType;
-};
-
-export const PostMemberInvitationBodySchema = z.object({
-  status: z.enum(["revoked", "pending"]),
-  initialRole: ActiveRoleSchema,
-});
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/invitations/index.ts
+++ b/front/pages/api/w/[wId]/invitations/index.ts
@@ -1,37 +1,20 @@
 // @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { handleMembershipInvitations } from "@app/lib/api/invitation";
+import type {
+  GetWorkspaceInvitationsResponseBody,
+  PostInvitationResponseBody,
+} from "@app/lib/api/invitation";
+import {
+  handleMembershipInvitations,
+  PostInvitationRequestBodySchema,
+} from "@app/lib/api/invitation";
 import type { Authenticator } from "@app/lib/auth";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { MembershipInvitationType } from "@app/types/membership_invitation";
-import { ActiveRoleSchema } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export type GetWorkspaceInvitationsResponseBody = {
-  invitations: MembershipInvitationType[];
-};
-
-export const PostInvitationRequestBodySchema = z.array(
-  z.object({
-    email: z.string(),
-    role: ActiveRoleSchema,
-  })
-);
-
-export type PostInvitationRequestBody = z.infer<
-  typeof PostInvitationRequestBodySchema
->;
-
-export type PostInvitationResponseBody = {
-  success: boolean;
-  email: string;
-  error_message?: string;
-}[];
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/members/me/agent_favorite.ts
+++ b/front/pages/api/w/[wId]/members/me/agent_favorite.ts
@@ -1,28 +1,17 @@
 // @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import { setAgentUserFavorite } from "@app/lib/api/assistant/user_relation";
+import type { PostAgentUserFavoriteResponseBody } from "@app/lib/api/assistant/user_relation";
+import {
+  PostAgentUserFavoriteRequestBodySchema,
+  setAgentUserFavorite,
+} from "@app/lib/api/assistant/user_relation";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export type PostAgentUserFavoriteResponseBody = {
-  agentId: string;
-  userFavorite: boolean;
-};
-
-export const PostAgentUserFavoriteRequestBodySchema = z.object({
-  agentId: z.string(),
-  userFavorite: z.boolean(),
-});
-
-export type PostAgentUserFavoriteRequestBody = z.infer<
-  typeof PostAgentUserFavoriteRequestBodySchema
->;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -1,6 +1,7 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { AttachedKnowledgeSchema } from "@app/lib/api/skills/schemas";
 import { resolveAdditionalRequestedSpaceModelIds } from "@app/lib/api/skills/space_requirements";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { pruneOutdatedSkillEditSuggestions } from "@app/lib/reinforcement/skill_suggestion_pruning";
@@ -11,7 +12,6 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { isResourceSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
-import { AttachedKnowledgeSchema } from "@app/pages/api/w/[wId]/skills";
 import type {
   SkillType,
   SkillWithRelationsType,

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -2,6 +2,7 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
+import { AttachedKnowledgeSchema } from "@app/lib/api/skills/schemas";
 import { resolveAdditionalRequestedSpaceModelIds } from "@app/lib/api/skills/space_requirements";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -40,14 +41,6 @@ export type PostSkillResponseBody = {
 const SkillStatusSchema = z
   .enum(["active", "archived", "suggested"])
   .optional();
-
-// Schema for attached knowledge.
-export const AttachedKnowledgeSchema = z.object({
-  dataSourceViewId: z.string(),
-  nodeId: z.string(),
-  spaceId: z.string(),
-  title: z.string(),
-});
 
 // Request body schema for POST.
 const PostSkillRequestBodySchema = z.intersection(


### PR DESCRIPTION
  ## What & why

  Step toward fully removing `front/pages/api` (Next) in favor of Hono (`front-api`).

  Several Hono routes import **runtime values** (zod schemas + a Next body-parser
  `config` object) directly from Next page files under `@app/pages/api/*`. These
  value imports break the `front-api` esbuild bundle once the Next handlers are
  The root cause is that shared contracts (request schemas, response types) live
  *inside* the page handler files. This PR moves them into framework-neutral
  modules so both the Next handler and the Hono route import from the same place,
  removing every build-breaking value import from `front-api`.

  This is the **first batch** — only the value imports that block the Hono build.
  The remaining ~261 type-only imports from `@app/pages/api` (erased by esbuild,
  so non-blocking) will be migrated in a follow-up before `pages/api` is deleted.

  ## Changes

  | Symbol(s) moved | New home | Unblocked front-api route |
  |---|---|---|
  | `"16mb"` body limit → `MAX_DOCUMENT_UPSERT_SIZE_MB` | `lib/data_sources.ts` | `poke/plans.ts` |
  | `AttachedKnowledgeSchema` | `lib/api/skills/schemas.ts` (new) | `w/[wId]/skills/[sId]/index.ts` |
  | `PostInvitationRequestBodySchema` + invitation index types | `lib/api/invitation.ts` | `w/[wId]/invitations/index.ts` |
  | `PostAgentUserFavoriteRequestBodySchema` + type | `lib/api/assistant/user_relation.ts` | `w/[wId]/members/me/agent_favorite.ts` |
  | `PostMemberInvitationBodySchema` + type | `lib/api/invitation.ts` | `w/[wId]/invitations/[iId]/index.ts` |

  App-side consumers repointed at the new locations: `lib/invitations.ts`,
  `lib/swr/memberships.ts`, `lib/swr/assistants.ts`, and the Next
  `w/[wId]/skills/[sId]` page.

  The Next `documents/[documentId]` page keeps its literal `"16mb"` `config`
  (Next requires a string literal for static analysis); the new constant is the
  documented source of truth to keep in sync.

## Tests

All pass

## Risk

Fairly low, just moving things around

## Deploy Plan

Front