### PR TITLE
[BYOK] Shorten regional models update error message

### DIFF
--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -127,7 +127,7 @@ export function useUpdateWorkspaceRegionalModelsOnly({
           sendNotification({
             type: "error",
             title: "Update failed",
-            description: "Failed to update regional models setting.",
+            description: "Some active agents may not be eligible for regional models.",
           });
           return false;
         }


### PR DESCRIPTION
## Description

Shortens the error notification shown when updating the regional-models-only workspace setting fails, to a concise "Some active agents may not be eligible for regional models."

## Tests

Tested locally.

## Risk

None.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`