### PR TITLE
move member + template API contracts out of pages/api

### DIFF
--- a/front-api/routes/poke/templates/index.ts
+++ b/front-api/routes/poke/templates/index.ts
@@ -1,8 +1,8 @@
 import { USED_MODEL_CONFIGS } from "@app/components/providers/model_configs";
 import { buildSharedTemplateAttributes } from "@app/lib/api/poke/templates";
 import { config as regionConfig } from "@app/lib/api/regions/config";
+import type { AssistantTemplateListType } from "@app/lib/resources/template_resource";
 import { TemplateResource } from "@app/lib/resources/template_resource";
-import type { AssistantTemplateListType } from "@app/pages/api/templates";
 import {
   CreateTemplateFormSchema,
   isTemplateTagCodeArray,

--- a/front-api/routes/w/[wId]/members/[uId]/index.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/index.ts
@@ -7,15 +7,15 @@ import {
   revokeAndTrackMembership,
   updateMembershipRoleAndTrack,
 } from "@app/lib/api/membership";
+import type {
+  GetMemberResponseBody,
+  PostMemberResponseBody,
+} from "@app/lib/api/user";
 import { getUserForWorkspace } from "@app/lib/api/user";
 import { getFeatureFlags } from "@app/lib/auth";
 import { showDebugTools } from "@app/lib/development";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import logger from "@app/logger/logger";
-import type {
-  GetMemberResponseBody,
-  PostMemberResponseBody,
-} from "@app/pages/api/w/[wId]/members/[uId]/index";
 import { isMembershipRoleType } from "@app/types/memberships";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";

--- a/front/components/agent_builder/AgentTemplateGrid.tsx
+++ b/front/components/agent_builder/AgentTemplateGrid.tsx
@@ -1,5 +1,5 @@
 import { getUniqueTemplateTags } from "@app/components/agent_builder/utils";
-import type { AssistantTemplateListType } from "@app/pages/api/templates";
+import type { AssistantTemplateListType } from "@app/lib/resources/template_resource";
 import type {
   TemplateTagCodeType,
   TemplateTagsType,

--- a/front/components/agent_builder/utils.ts
+++ b/front/components/agent_builder/utils.ts
@@ -1,5 +1,5 @@
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
-import type { AssistantTemplateListType } from "@app/pages/api/templates";
+import type { AssistantTemplateListType } from "@app/lib/resources/template_resource";
 import type { TemplateTagCodeType } from "@app/types/assistant/templates";
 import { useController } from "react-hook-form";
 

--- a/front/components/poke/templates/TemplatesDataTable.tsx
+++ b/front/components/poke/templates/TemplatesDataTable.tsx
@@ -1,4 +1,4 @@
-import type { FetchAssistantTemplatesResponse } from "@app/pages/api/templates";
+import type { FetchAssistantTemplatesResponse } from "@app/lib/resources/template_resource";
 import { usePokeAssistantTemplates, usePokePullTemplates } from "@app/poke/swr";
 import type {
   TemplateTagCodeType,

--- a/front/lib/api/poke/templates.ts
+++ b/front/lib/api/poke/templates.ts
@@ -1,7 +1,7 @@
 import { config } from "@app/lib/api/regions/config";
+import type { FetchAssistantTemplatesResponse } from "@app/lib/resources/template_resource";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import logger from "@app/logger/logger";
-import type { FetchAssistantTemplatesResponse } from "@app/pages/api/templates";
 import type { FetchAgentTemplateResponse } from "@app/pages/api/templates/[tId]";
 import type { ModelConfig } from "@app/types/assistant/models/types";
 import type {

--- a/front/lib/api/user.ts
+++ b/front/lib/api/user.ts
@@ -14,6 +14,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type {
   LightWorkspaceType,
+  RoleType,
   UserType,
   UserTypeWithExtensionWorkspaces,
   UserTypeWithWorkspaces,
@@ -21,6 +22,26 @@ import type {
 
 import { MembershipResource } from "../resources/membership_resource";
 import { findWorkOSOrganizationsForUserId } from "./workos/organization_membership";
+
+export type GetMemberResponseBody = {
+  member: {
+    id: string;
+    username: string;
+    email: string;
+    firstName: string;
+    lastName: string | null;
+    fullName: string;
+    image: string | null;
+    revoked: boolean;
+    role: RoleType;
+    startAt: string | null;
+    endAt: string | null;
+  };
+};
+
+export type PostMemberResponseBody = {
+  member: UserTypeWithWorkspaces;
+};
 
 /**
  * Returns the acting user for an authenticated request. Falls back to looking up the user by

--- a/front/lib/resources/template_resource.ts
+++ b/front/lib/resources/template_resource.ts
@@ -196,3 +196,11 @@ export class TemplateResource extends BaseResource<TemplateModel> {
     };
   }
 }
+
+export type AssistantTemplateListType = ReturnType<
+  TemplateResource["toListJSON"]
+>;
+
+export interface FetchAssistantTemplatesResponse {
+  templates: AssistantTemplateListType[];
+}

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -9,7 +9,9 @@ import type {
   ToolLatencyView,
 } from "@app/lib/api/assistant/observability/tool_latency";
 import type { PostAgentUserFavoriteRequestBody } from "@app/lib/api/assistant/user_relation";
+import type { GetMemberResponseBody } from "@app/lib/api/user";
 import { clientFetch } from "@app/lib/egress/client";
+import type { FetchAssistantTemplatesResponse } from "@app/lib/resources/template_resource";
 import {
   emptyArray,
   getErrorFromResponse,
@@ -18,7 +20,6 @@ import {
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import { BROWSER_TIMEZONE } from "@app/lib/swr/workspaces";
-import type { FetchAssistantTemplatesResponse } from "@app/pages/api/templates";
 import type { FetchAgentTemplateResponse } from "@app/pages/api/templates/[tId]";
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { GetAgentMcpConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/mcp_configurations";
@@ -38,7 +39,6 @@ import type { GetUsageMetricsResponse } from "@app/pages/api/w/[wId]/assistant/a
 import type { GetVersionMarkersResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/version-markers";
 import type { GetAgentUsageResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage";
 import type { GetSlackChannelsLinkedWithAgentResponseBody } from "@app/pages/api/w/[wId]/assistant/builder/slack/channels_linked_with_agent";
-import type { GetMemberResponseBody } from "@app/pages/api/w/[wId]/members/[uId]";
 import type {
   AgentConfigurationType,
   AgentsGetViewType,

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -127,7 +127,8 @@ export function useUpdateWorkspaceRegionalModelsOnly({
           sendNotification({
             type: "error",
             title: "Update failed",
-            description: "Some active agents may not be eligible for regional models.",
+            description:
+              "Some active agents may not be eligible for regional models.",
           });
           return false;
         }

--- a/front/migrations/20250928_check_templates_id_match.ts
+++ b/front/migrations/20250928_check_templates_id_match.ts
@@ -10,7 +10,7 @@ import type { Logger } from "@app/logger/logger";
 import type {
   AssistantTemplateListType,
   FetchAssistantTemplatesResponse,
-} from "@app/pages/api/templates";
+} from "@app/lib/resources/template_resource";
 import { makeScript } from "@app/scripts/helpers";
 
 async function computeTemplateIdMatches({

--- a/front/pages/api/poke/templates/index.ts
+++ b/front/pages/api/poke/templates/index.ts
@@ -6,9 +6,9 @@ import { buildSharedTemplateAttributes } from "@app/lib/api/poke/templates";
 import { config as regionConfig } from "@app/lib/api/regions/config";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
+import type { AssistantTemplateListType } from "@app/lib/resources/template_resource";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { AssistantTemplateListType } from "@app/pages/api/templates";
 import {
   CreateTemplateFormSchema,
   isTemplateTagCodeArray,

--- a/front/pages/api/templates/index.ts
+++ b/front/pages/api/templates/index.ts
@@ -1,17 +1,10 @@
 // @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
+import type { FetchAssistantTemplatesResponse } from "@app/lib/resources/template_resource";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type AssistantTemplateListType = ReturnType<
-  TemplateResource["toListJSON"]
->;
-
-export interface FetchAssistantTemplatesResponse {
-  templates: AssistantTemplateListType[];
-}
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/members/[uId]/index.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.ts
@@ -10,6 +10,10 @@ import {
   revokeAndTrackMembership,
   updateMembershipRoleAndTrack,
 } from "@app/lib/api/membership";
+import type {
+  GetMemberResponseBody,
+  PostMemberResponseBody,
+} from "@app/lib/api/user";
 import { getUserForWorkspace } from "@app/lib/api/user";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
@@ -20,28 +24,7 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isMembershipRoleType } from "@app/types/memberships";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import type { RoleType, UserTypeWithWorkspaces } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetMemberResponseBody = {
-  member: {
-    id: string;
-    username: string;
-    email: string;
-    firstName: string;
-    lastName: string | null;
-    fullName: string;
-    image: string | null;
-    revoked: boolean;
-    role: RoleType;
-    startAt: string | null;
-    endAt: string | null;
-  };
-};
-
-export type PostMemberResponseBody = {
-  member: UserTypeWithWorkspaces;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/poke/swr/index.ts
+++ b/front/poke/swr/index.ts
@@ -1,11 +1,11 @@
 import type { LLMTrace } from "@app/lib/api/llm/traces/types";
 import { clientFetch } from "@app/lib/egress/client";
+import type { FetchAssistantTemplatesResponse } from "@app/lib/resources/template_resource";
 import { emptyArray, useFetcher } from "@app/lib/swr/swr";
 import type { PokeFetchAssistantTemplateResponse } from "@app/pages/api/poke/templates/[tId]";
 import type { PullTemplatesResponseBody } from "@app/pages/api/poke/templates/pull";
 import type { GetDocumentsResponseBody } from "@app/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/documents";
 import type { GetTablesResponseBody } from "@app/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/tables";
-import type { FetchAssistantTemplatesResponse } from "@app/pages/api/templates";
 import { useCallback, useMemo, useState } from "react";
 import type { Fetcher } from "swr";
 import useSWR from "swr";


### PR DESCRIPTION
  ## What & why

  Follow-up to the previous batch, continuing the removal of `front/pages/api`
  (Next) in favor of Hono (`front-api`).

  That batch moved the **value** imports (zod schemas / Next `config`) that broke
  the `front-api` esbuild bundle. This batch moves the last **type-only** imports
  that `front-api` still pulls from `@app/pages/api`. Type-only imports are erased
  by esbuild so they don't break the bundle, but they block the eventual deletion
  of `pages/api`. With this PR, **`front-api` has zero references to
  `@app/pages/api`**.

  As before, the fix is to relocate the shared contracts out of the Next page
  handler files into framework-neutral modules that both the Next handler and the
  Hono route import from.

  ## Changes

  | Symbol(s) moved | New home | Why there |
  |---|---|---|
  | `GetMemberResponseBody`, `PostMemberResponseBody` | `lib/api/user.ts` | Member response shapes; the page already imports `getUserForWorkspace` from here |
  | `AssistantTemplateListType`, `FetchAssistantTemplatesResponse` | `lib/resources/template_resource.ts` | `AssistantTemplateListType = ReturnType<TemplateResource["toListJSON"]>` — co-located with the method it derives from |

  Consumers repointed at the new locations:

  - **members types:** Next `w/[wId]/members/[uId]` page, front-api
    `w/[wId]/members/[uId]` route, `lib/swr/assistants.ts`
  - **template types:** Next `templates` + `poke/templates` pages, front-api
    `poke/templates` route, `components/agent_builder/{utils,AgentTemplateGrid}`,
    `components/poke/templates/TemplatesDataTable`, `poke/swr/index`,
    `lib/api/poke/templates`, `lib/swr/assistants`, and the
    `20250928_check_templates_id_match` migration

  No behavior changes — pure relocation of types. Files that already imported
  `TemplateResource` now import the types from the same module (Biome merged the
  value + type imports).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
