### PR TITLE
Fabien/pricing/switching seat alert

### DIFF
--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -6,8 +6,14 @@ import {
 } from "@app/lib/api/audit/workos_audit";
 import type { AuditLogActor } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
+import {
+  getMetronomePerUserCap,
+  upsertMetronomePerUserCapAlert,
+  upsertMetronomePerUserWarningAlert,
+} from "@app/lib/metronome/alerts/spend_limits";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import {
+  getAwuAllocationForSeatType,
   getDefaultSeatTypeForContract,
   getProductSeatTypes,
 } from "@app/lib/metronome/seat_types";
@@ -33,6 +39,7 @@ import type {
   MembershipRoleType,
   MembershipSeatType,
 } from "@app/types/memberships";
+import { normalizeToPoolLimitSeatType } from "@app/types/memberships";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type {
@@ -408,6 +415,134 @@ export async function updateMembershipRoleAndTrack({
 }
 
 /**
+ * When a user's seat type changes, their per-user cap alert threshold must be
+ * recalculated. The threshold is `seatAllowance + poolLimit`; the pool limit
+ * (what the admin entered) stays the same, but the seat allowance portion
+ * changes with the new seat type.
+ *
+ * Best-effort: failures are logged but do not block the seat change.
+ */
+async function recalculatePerUserCapAlertForSeatChange({
+  workspace,
+  userId,
+  previousSeatType,
+  newSeatType,
+}: {
+  workspace: LightWorkspaceType;
+  userId: string;
+  previousSeatType: MembershipSeatType;
+  newSeatType: MembershipSeatType;
+}): Promise<void> {
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId) {
+    return;
+  }
+
+  // Check if this user has a per-user override.
+  const capResult = await getMetronomePerUserCap({
+    metronomeCustomerId,
+    workspaceId: workspace.sId,
+    userId,
+  });
+  if (capResult.isErr() || !capResult.value) {
+    // If there is no custom cap override for the user, nothing to do
+    // They are using the default limits which are already in place.
+    return;
+  }
+
+  const currentThresholdAwuCredits = capResult.value.alert.threshold;
+
+  // Compute the pool limit from the old seat's allowance.
+  const contract = await getActiveContract(workspace.sId);
+  if (!contract) {
+    return;
+  }
+  const productSeatTypes = await getProductSeatTypes();
+
+  const previousNormalized = normalizeToPoolLimitSeatType(previousSeatType);
+  const newNormalized = normalizeToPoolLimitSeatType(newSeatType);
+  if (!previousNormalized || !newNormalized) {
+    return;
+  }
+
+  const previousAllowanceAwuCredits = getAwuAllocationForSeatType(
+    contract,
+    previousNormalized,
+    productSeatTypes
+  );
+  const newAllowanceAwuCredits = getAwuAllocationForSeatType(
+    contract,
+    newNormalized,
+    productSeatTypes
+  );
+
+  // Same allowance → nothing to recalculate (e.g. pro ↔ pro_yearly).
+  if (previousAllowanceAwuCredits === newAllowanceAwuCredits) {
+    return;
+  }
+
+  const poolLimitAwuCredits = Math.max(
+    0,
+    currentThresholdAwuCredits - previousAllowanceAwuCredits
+  );
+  const newThresholdAwuCredits = newAllowanceAwuCredits + poolLimitAwuCredits;
+
+  const upsertResult = await upsertMetronomePerUserCapAlert({
+    metronomeCustomerId,
+    workspaceId: workspace.sId,
+    userId,
+    awuCredits: newThresholdAwuCredits,
+  });
+  if (upsertResult.isErr()) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        userId,
+        previousSeatType,
+        newSeatType,
+        previousThresholdAwuCredits: currentThresholdAwuCredits,
+        newThresholdAwuCredits,
+        err: upsertResult.error,
+      },
+      "[Membership] Failed to recalculate per-user cap alert after seat change"
+    );
+    return;
+  }
+
+  // Also update the companion warning alert.
+  const warningResult = await upsertMetronomePerUserWarningAlert({
+    metronomeCustomerId,
+    workspaceId: workspace.sId,
+    userId,
+    capAwuCredits: newThresholdAwuCredits,
+  });
+  if (warningResult.isErr()) {
+    logger.warn(
+      {
+        workspaceId: workspace.sId,
+        userId,
+        newThresholdAwuCredits,
+        err: warningResult.error,
+      },
+      "[Membership] Failed to recalculate per-user warning alert after seat change"
+    );
+  }
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      userId,
+      previousSeatType,
+      newSeatType,
+      previousThresholdAwuCredits: currentThresholdAwuCredits,
+      newThresholdAwuCredits,
+      poolLimitAwuCredits,
+    },
+    "[Membership] Recalculated per-user cap alert after seat change"
+  );
+}
+
+/**
  * Update a membership's seat type and re-sync Metronome accordingly. All
  * Metronome state changes (including scheduling decisions) flow through
  * `syncSeatCount`, which classifies the transition generically based on
@@ -553,6 +688,14 @@ export async function updateMembershipSeatAndTrack({
         workspace,
         newSeatType,
         author,
+      });
+      // Recalculate the per-user cap alert threshold so the pool limit
+      // portion stays the same despite the change in seat allowance.
+      await recalculatePerUserCapAlertForSeatChange({
+        workspace,
+        userId: user.sId,
+        previousSeatType,
+        newSeatType,
       });
       resultingActiveSeatType = newSeatType;
       break;

--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -422,7 +422,7 @@ export async function updateMembershipRoleAndTrack({
  *
  * Best-effort: failures are logged but do not block the seat change.
  */
-async function recalculatePerUserCapAlertForSeatChange({
+export async function recalculatePerUserCapAlertForSeatChange({
   workspace,
   userId,
   previousSeatType,

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -1,3 +1,4 @@
+import { recalculatePerUserCapAlertForSeatChange } from "@app/lib/api/membership";
 import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import { isPAYGEnabled } from "@app/lib/credits/credit_payg";
@@ -107,6 +108,26 @@ export async function dispatchSeatBalanceResolved({
       "[CreditStateDispatcher] dispatchSeatBalanceResolved: no active membership, skipping"
     );
     return;
+  }
+
+  // If the user's seat type changed (deferred seat switch just took effect),
+  // recalculate their per-user cap alert so the pool limit portion stays
+  // correct despite the new seat allowance.
+  const previousMembership =
+    await MembershipResource.getRecentlyEndedMembershipOfUserInWorkspace({
+      user,
+      workspace: lightWorkspace,
+    });
+  if (
+    previousMembership &&
+    previousMembership.seatType !== membership.seatType
+  ) {
+    await recalculatePerUserCapAlertForSeatChange({
+      workspace: lightWorkspace,
+      userId,
+      previousSeatType: previousMembership.seatType,
+      newSeatType: membership.seatType,
+    });
   }
 
   const result = await transitionUserCreditState(

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -412,6 +412,32 @@ export class MembershipResource extends BaseResource<MembershipModel> {
   }
 
   /**
+   * Returns the most recently ended membership row for a user in a workspace,
+   * only if it ended within the last 24 hours. Used to detect a deferred seat
+   * change that just took effect. Returns `null` if no row ended recently
+   * (avoids matching stale historical rows from older seat changes).
+   */
+  static async getRecentlyEndedMembershipOfUserInWorkspace({
+    user,
+    workspace,
+  }: {
+    user: UserResource;
+    workspace: LightWorkspaceType;
+  }): Promise<MembershipResource | null> {
+    const oneDayAgoMs = 24 * 60 * 60 * 1000;
+    const cutoff = new Date(Date.now() - oneDayAgoMs);
+    const row = await this.model.findOne({
+      where: {
+        userId: user.id,
+        workspaceId: workspace.id,
+        endAt: { [Op.lte]: new Date(), [Op.gte]: cutoff },
+      },
+      order: [["endAt", "DESC"]],
+    });
+    return row ? new MembershipResource(this.model, row.get()) : null;
+  }
+
+  /**
    * Returns true when the user has *any* prior membership row in the
    * workspace — current, future-scheduled, or revoked. Used to enforce
    * that `"free"` is a one-shot starter tier: it can only be assigned at


### PR DESCRIPTION
## Description
 
When a user change seat, we must recompute the limit if they have a custom cap set.
To do that, we retrieve previous cap from metronome (it's actually seat capacity + pool cap) and send a new cap which include the new seat capacity instead.

There are 2 ways to change seat:
 - directly from the UI (easy, we know previous and new seat)
 - deferred downgrade at the end of the month (we have to guess what used to be previous membership)


## Tests

not tested

## Risk

low, if someone actually change seat 24h before the end of contract the limit might become inacurate :/

## Deploy Plan

deploy front
