### PR TITLE
move poke data-plane API contracts out of pages/api

### DIFF
--- a/front/components/poke/data_source_views/table.tsx
+++ b/front/components/poke/data_source_views/table.tsx
@@ -1,8 +1,8 @@
 import { makeColumnsForDataSourceViews } from "@app/components/poke/data_source_views/columns";
 import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
+import type { DataSourceViewWithUsage } from "@app/lib/api/poke/data_source_views";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
-import type { DataSourceViewWithUsage } from "@app/pages/api/poke/workspaces/[wId]/data_source_views";
 import { usePokeDataSourceViews } from "@app/poke/swr/data_source_views";
 import type { LightWorkspaceType } from "@app/types/user";
 

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -6,6 +6,7 @@ import {
   PokeTableRow,
 } from "@app/components/poke/shadcn/ui/table";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
+import type { CheckStuckResponseBody } from "@app/lib/api/data_sources/check_stuck";
 import { isWebhookBasedProvider } from "@app/lib/connector_providers";
 import { clientFetch } from "@app/lib/egress/client";
 import {
@@ -13,7 +14,6 @@ import {
   formatTimestampToFriendlyDate,
   timeAgoFrom,
 } from "@app/lib/utils";
-import type { CheckStuckResponseBody } from "@app/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/check-stuck";
 import type { InternalConnectorType } from "@app/types/connectors/connectors_api";
 import type { CoreAPIDataSource } from "@app/types/core/data_source";
 import type { DataSourceType } from "@app/types/data_source";

--- a/front/components/poke/pages/DataSourcePage.tsx
+++ b/front/components/poke/pages/DataSourcePage.tsx
@@ -7,13 +7,13 @@ import {
   PokeAlertDescription,
 } from "@app/components/poke/shadcn/ui/alert";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
+import type { FeaturesType } from "@app/lib/api/poke/data_sources";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { getDisplayNameForDocument } from "@app/lib/data_sources";
 import { clientFetch } from "@app/lib/egress/client";
 import { useAppRouter, useRequiredPathParam } from "@app/lib/platform";
 import { decodeSqids, timeAgoFrom } from "@app/lib/utils";
-import type { FeaturesType } from "@app/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/details";
 import { usePokeDocuments, usePokeTables } from "@app/poke/swr";
 import { usePokePageMetadata } from "@app/poke/swr/currentPage";
 import { usePokeDataSourceDetails } from "@app/poke/swr/data_source_details";

--- a/front/components/poke/pages/ProjectPage.tsx
+++ b/front/components/poke/pages/ProjectPage.tsx
@@ -5,8 +5,8 @@ import { ProjectConnectorKnowledgeDataTable } from "@app/components/poke/project
 import { ProjectTasksDataTable } from "@app/components/poke/projects/tasks/table";
 import { ViewProjectWorkflowTable } from "@app/components/poke/projects/workflow/view";
 import { ViewSpaceViewTable } from "@app/components/poke/spaces/view";
+import type { PokeGetSpaceDetails } from "@app/lib/api/poke/spaces";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
-import type { PokeGetSpaceDetails } from "@app/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/details";
 import { LinkWrapper } from "@dust-tt/sparkle";
 
 interface ProjectPageProps {

--- a/front/lib/api/poke/data_source_views.ts
+++ b/front/lib/api/poke/data_source_views.ts
@@ -1,0 +1,25 @@
+import type { AgentsUsageType } from "@app/types/data_source";
+import type {
+  DataSourceViewContentNode,
+  DataSourceViewType,
+} from "@app/types/data_source_view";
+import type { PokeDataSourceViewType } from "@app/types/poke";
+
+export type DataSourceViewWithUsage = DataSourceViewType & {
+  usage: AgentsUsageType | null;
+};
+
+export type PokeListDataSourceViews = {
+  data_source_views: DataSourceViewWithUsage[];
+};
+
+export type PokeGetDataSourceViewDetails = {
+  dataSourceView: PokeDataSourceViewType;
+};
+
+export type PokeGetDataSourceViewContentNodes = {
+  nodes: DataSourceViewContentNode[];
+  total: number;
+  totalIsAccurate: boolean;
+  nextPageCursor: string | null;
+};

--- a/front/lib/api/poke/data_sources.ts
+++ b/front/lib/api/poke/data_sources.ts
@@ -1,0 +1,55 @@
+import type { InternalConnectorType } from "@app/types/connectors/connectors_api";
+import type { SlackAutoReadPattern } from "@app/types/connectors/slack";
+import type { CoreAPITable } from "@app/types/core/core_api";
+import type {
+  CoreAPIDataSource,
+  CoreAPIDocument,
+} from "@app/types/core/data_source";
+import type { DataSourceType } from "@app/types/data_source";
+import type { DataSourceViewType } from "@app/types/data_source_view";
+import type { DocumentType } from "@app/types/document";
+
+export type PokeListDataSources = {
+  data_sources: DataSourceType[];
+};
+
+export type FeaturesType = {
+  slackBotEnabled: boolean;
+  googleDrivePdfEnabled: boolean;
+  googleDriveLargeFilesEnabled: boolean;
+  microsoftPdfEnabled: boolean;
+  microsoftLargeFilesEnabled: boolean;
+  googleDriveCsvEnabled: boolean;
+  microsoftCsvEnabled: boolean;
+  githubCodeSyncEnabled: boolean;
+  githubUseProxyEnabled: boolean;
+  autoReadChannelPatterns: SlackAutoReadPattern[];
+};
+
+export type PokeGetDataSourceDetails = {
+  dataSource: DataSourceType;
+  dataSourceViews: DataSourceViewType[];
+  coreDataSource: CoreAPIDataSource;
+  connector: InternalConnectorType | null;
+  features: FeaturesType;
+  temporalWorkspace: string;
+  temporalRunningWorkflows: {
+    workflowId: string;
+    runId: string;
+    status: string;
+  }[];
+};
+
+export type PokeGetDocument = {
+  document: CoreAPIDocument;
+};
+
+export type GetDocumentsResponseBody = {
+  documents: Array<DocumentType>;
+  total: number;
+};
+
+export type GetTablesResponseBody = {
+  tables: Array<CoreAPITable>;
+  total: number;
+};

--- a/front/lib/api/poke/spaces.ts
+++ b/front/lib/api/poke/spaces.ts
@@ -1,0 +1,14 @@
+import type { PokeSpaceType } from "@app/types/poke";
+import type { PodMetadataType } from "@app/types/project_metadata";
+import type { SpaceType } from "@app/types/space";
+import type { UserTypeWithWorkspaces } from "@app/types/user";
+
+export type PokeListSpaces = {
+  spaces: SpaceType[];
+};
+
+export type PokeGetSpaceDetails = {
+  members: Record<string, UserTypeWithWorkspaces[]>;
+  metadata: PodMetadataType | null;
+  space: PokeSpaceType;
+};

--- a/front/pages/api/poke/workspaces/[wId]/data_source_views/[dsvId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_source_views/[dsvId]/details.ts
@@ -1,19 +1,15 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { PokeGetDataSourceViewDetails } from "@app/lib/api/poke/data_source_views";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { dataSourceViewToPokeJSON } from "@app/lib/poke/utils";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { PokeDataSourceViewType } from "@app/types/poke";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeGetDataSourceViewDetails = {
-  dataSourceView: PokeDataSourceViewType;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/data_source_views/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_source_views/index.ts
@@ -2,21 +2,12 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { listDataSourceViewsWithUsage } from "@app/lib/api/data_source_view";
+import type { PokeListDataSourceViews } from "@app/lib/api/poke/data_source_views";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
-import type { AgentsUsageType } from "@app/types/data_source";
-import type { DataSourceViewType } from "@app/types/data_source_view";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type DataSourceViewWithUsage = DataSourceViewType & {
-  usage: AgentsUsageType | null;
-};
-
-export type PokeListDataSourceViews = {
-  data_source_views: DataSourceViewWithUsage[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/check-stuck.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/check-stuck.ts
@@ -10,8 +10,6 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export type { CheckStuckResponseBody };
-
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<CheckStuckResponseBody>>,

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/details.ts
@@ -2,6 +2,10 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import type {
+  FeaturesType,
+  PokeGetDataSourceDetails,
+} from "@app/lib/api/poke/data_sources";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
@@ -11,41 +15,11 @@ import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { InternalConnectorType } from "@app/types/connectors/connectors_api";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
-import type { SlackAutoReadPattern } from "@app/types/connectors/slack";
 import { isSlackAutoReadPatterns } from "@app/types/connectors/slack";
 import { CoreAPI } from "@app/types/core/core_api";
-import type { CoreAPIDataSource } from "@app/types/core/data_source";
-import type { DataSourceType } from "@app/types/data_source";
-import type { DataSourceViewType } from "@app/types/data_source_view";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 import type { NextApiRequest, NextApiResponse } from "next";
-export type FeaturesType = {
-  slackBotEnabled: boolean;
-  googleDrivePdfEnabled: boolean;
-  googleDriveLargeFilesEnabled: boolean;
-  microsoftPdfEnabled: boolean;
-  microsoftLargeFilesEnabled: boolean;
-  googleDriveCsvEnabled: boolean;
-  microsoftCsvEnabled: boolean;
-  githubCodeSyncEnabled: boolean;
-  githubUseProxyEnabled: boolean;
-  autoReadChannelPatterns: SlackAutoReadPattern[];
-};
-
-export type PokeGetDataSourceDetails = {
-  dataSource: DataSourceType;
-  dataSourceViews: DataSourceViewType[];
-  coreDataSource: CoreAPIDataSource;
-  connector: InternalConnectorType | null;
-  features: FeaturesType;
-  temporalWorkspace: string;
-  temporalRunningWorkflows: {
-    workflowId: string;
-    runId: string;
-    status: string;
-  }[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/document.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/document.ts
@@ -2,19 +2,15 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import type { PokeGetDocument } from "@app/lib/api/poke/data_sources";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import { CoreAPI } from "@app/types/core/core_api";
-import type { CoreAPIDocument } from "@app/types/core/data_source";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeGetDocument = {
-  document: CoreAPIDocument;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/documents/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/documents/index.ts
@@ -2,20 +2,15 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import type { GetDocumentsResponseBody } from "@app/lib/api/poke/data_sources";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import { CoreAPI } from "@app/types/core/core_api";
-import type { DocumentType } from "@app/types/document";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetDocumentsResponseBody = {
-  documents: Array<DocumentType>;
-  total: number;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/tables/index.ts
@@ -2,20 +2,15 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import type { GetTablesResponseBody } from "@app/lib/api/poke/data_sources";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
-import type { CoreAPITable } from "@app/types/core/core_api";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetTablesResponseBody = {
-  tables: Array<CoreAPITable>;
-  total: number;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/index.ts
@@ -1,17 +1,13 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { PokeListDataSources } from "@app/lib/api/poke/data_sources";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { DataSourceType } from "@app/types/data_source";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeListDataSources = {
-  data_sources: DataSourceType[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
@@ -6,12 +6,12 @@ import {
   getCursorPaginationParams,
   SortingParamsCodec,
 } from "@app/lib/api/pagination";
+import type { PokeGetDataSourceViewContentNodes } from "@app/lib/api/poke/data_source_views";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { apiError } from "@app/logger/withlogging";
 import { ContentNodesViewTypeCodec } from "@app/types/connectors/content_nodes";
-import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -24,13 +24,6 @@ const GetContentNodesOrChildrenRequestBody = z.object({
   viewType: ContentNodesViewTypeCodec,
   sorting: SortingParamsCodec.optional(),
 });
-
-export type PokeGetDataSourceViewContentNodes = {
-  nodes: DataSourceViewContentNode[];
-  total: number;
-  totalIsAccurate: boolean;
-  nextPageCursor: string | null;
-};
 
 // This endpoints serves two purposes:
 // 1. Fetch content nodes for a given data source view.

--- a/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/details.ts
@@ -1,6 +1,7 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { PokeGetSpaceDetails } from "@app/lib/api/poke/spaces";
 import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
@@ -9,16 +10,8 @@ import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_res
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { PokeSpaceType } from "@app/types/poke";
-import type { PodMetadataType } from "@app/types/project_metadata";
 import type { UserTypeWithWorkspaces } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeGetSpaceDetails = {
-  members: Record<string, UserTypeWithWorkspaces[]>;
-  metadata: PodMetadataType | null;
-  space: PokeSpaceType;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/spaces/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/spaces/index.ts
@@ -1,17 +1,13 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { PokeListSpaces } from "@app/lib/api/poke/spaces";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { SpaceType } from "@app/types/space";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeListSpaces = {
-  spaces: SpaceType[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/poke/swr/data_source_details.ts
+++ b/front/poke/swr/data_source_details.ts
@@ -1,5 +1,5 @@
+import type { PokeGetDataSourceDetails } from "@app/lib/api/poke/data_sources";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeGetDataSourceDetails } from "@app/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/details";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/data_source_view_details.ts
+++ b/front/poke/swr/data_source_view_details.ts
@@ -1,5 +1,5 @@
+import type { PokeGetDataSourceViewDetails } from "@app/lib/api/poke/data_source_views";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeGetDataSourceViewDetails } from "@app/pages/api/poke/workspaces/[wId]/data_source_views/[dsvId]/details";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/data_source_views.ts
+++ b/front/poke/swr/data_source_views.ts
@@ -1,11 +1,11 @@
 import type { CursorPaginationParams } from "@app/lib/api/pagination";
-import { createUseInfiniteContentNodes } from "@app/lib/swr/data_source_views";
-import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
   DataSourceViewWithUsage,
+  PokeGetDataSourceViewContentNodes,
   PokeListDataSourceViews,
-} from "@app/pages/api/poke/workspaces/[wId]/data_source_views";
-import type { PokeGetDataSourceViewContentNodes } from "@app/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes";
+} from "@app/lib/api/poke/data_source_views";
+import { createUseInfiniteContentNodes } from "@app/lib/swr/data_source_views";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
 import type { DataSourceViewType } from "@app/types/data_source_view";

--- a/front/poke/swr/data_sources.ts
+++ b/front/poke/swr/data_sources.ts
@@ -1,5 +1,5 @@
+import type { PokeListDataSources } from "@app/lib/api/poke/data_sources";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeListDataSources } from "@app/pages/api/poke/workspaces/[wId]/data_sources";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/document.ts
+++ b/front/poke/swr/document.ts
@@ -1,5 +1,5 @@
+import type { PokeGetDocument } from "@app/lib/api/poke/data_sources";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeGetDocument } from "@app/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/document";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/index.ts
+++ b/front/poke/swr/index.ts
@@ -1,11 +1,13 @@
 import type { LLMTrace } from "@app/lib/api/llm/traces/types";
+import type {
+  GetDocumentsResponseBody,
+  GetTablesResponseBody,
+} from "@app/lib/api/poke/data_sources";
 import { clientFetch } from "@app/lib/egress/client";
 import type { FetchAssistantTemplatesResponse } from "@app/lib/resources/template_resource";
 import { emptyArray, useFetcher } from "@app/lib/swr/swr";
 import type { PokeFetchAssistantTemplateResponse } from "@app/pages/api/poke/templates/[tId]";
 import type { PullTemplatesResponseBody } from "@app/pages/api/poke/templates/pull";
-import type { GetDocumentsResponseBody } from "@app/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/documents";
-import type { GetTablesResponseBody } from "@app/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/tables";
 import { useCallback, useMemo, useState } from "react";
 import type { Fetcher } from "swr";
 import useSWR from "swr";

--- a/front/poke/swr/space_details.ts
+++ b/front/poke/swr/space_details.ts
@@ -1,5 +1,5 @@
+import type { PokeGetSpaceDetails } from "@app/lib/api/poke/spaces";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeGetSpaceDetails } from "@app/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/details";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/spaces.ts
+++ b/front/poke/swr/spaces.ts
@@ -1,5 +1,5 @@
+import type { PokeListSpaces } from "@app/lib/api/poke/spaces";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeListSpaces } from "@app/pages/api/poke/workspaces/[wId]/spaces";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
 


### PR DESCRIPTION
  ## What & why

  Continues the removal of `front/pages/api` (Next) in favor of Hono. This is the
  first of several **poke** sub-rounds, covering the poke **data plane**
  (data sources, data source views, spaces).

  As in the previous batches, the issue is that shared response-body contracts are
  defined *inside* the poke page handler files and imported across the poke
  UI/SWR layer, which blocks deleting `pages/api`. The fix is to relocate those
  types into framework-neutral modules under `lib/api/poke` that both the Next
  handler and the consumers import from.

  This batch is **type-only** (no zod schemas / runtime values), so there is no
  behavior change — purely moving type definitions and repointing imports.

  ## Changes

  New neutral modules and the types moved into them:

  | New module | Types |
  |---|---|
  | `lib/api/poke/data_sources.ts` | `PokeListDataSources`, `FeaturesType`, `PokeGetDataSourceDetails`, `PokeGetDocument`, `GetDocumentsResponseBody`, `GetTablesResponseBody` |
  | `lib/api/poke/data_source_views.ts` | `DataSourceViewWithUsage`, `PokeListDataSourceViews`, `PokeGetDataSourceViewDetails`, `PokeGetDataSourceViewContentNodes` |
  | `lib/api/poke/spaces.ts` | `PokeListSpaces`, `PokeGetSpaceDetails` |

  - 11 poke pages under `pages/api/poke/workspaces/[wId]/{data_sources,data_source_views,spaces}/*`
    now import their response types from the new modules, and drop the
    dependency imports that only existed to build those type defs.
  - `CheckStuckResponseBody` already lived in a neutral module
    (`lib/api/data_sources/check_stuck`) and was only *re-exported* by the
    `check-stuck` page — removed that re-export and pointed its consumer
    (`components/poke/data_sources/view.tsx`) at the real source.
  - 14 consumer imports across `front/poke/swr/*` and `front/components/poke/*`
    repointed at the new modules. Biome merged the now-duplicate imports (e.g.
    `poke/swr/data_source_views.ts`).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
