### PR TITLE
fix(front): show current webhook source name in agent builder triggers

### DIFF
--- a/front/components/agent_builder/triggers/TriggerSelectionPage.tsx
+++ b/front/components/agent_builder/triggers/TriggerSelectionPage.tsx
@@ -75,7 +75,7 @@ export function TriggerSelectionPageContent({
                 <ActionCard
                   key={view.sId}
                   icon={getIcon(normalizeWebhookIcon(view.icon))}
-                  label={view.webhookSource.name}
+                  label={view.customName}
                   description={
                     view.description ||
                     `Trigger this agent with ${view.customName}.`

--- a/front/components/agent_builder/triggers/webhook/webhookEditionFormSchema.ts
+++ b/front/components/agent_builder/triggers/webhook/webhookEditionFormSchema.ts
@@ -38,7 +38,7 @@ export function getWebhookFormDefaultValues({
     name:
       trigger?.name ??
       (webhookSourceView
-        ? `${webhookSourceView?.webhookSource.name}` +
+        ? `${webhookSourceView?.customName}` +
           (webhookSourceView?.provider
             ? ` - ${asDisplayName(webhookSourceView?.provider)}`
             : "")


### PR DESCRIPTION
## Description

The agent builder read the immutable `webhookSource.name` in two spots instead of the current `customName`:

- the trigger selection card label
- the default name seeded for a new webhook trigger

So after a webhook source was renamed, it still surfaced under its historical name (and the selection card label disagreed with its own search, which already matched on `customName`). Both now use `customName`.

Solves https://github.com/dust-tt/tasks/issues/8421

## Tests

Manual: renamed a webhook source, confirmed the selection card and new-trigger default name reflect the new name.

## Risk

Low — two-line display change.

## Deploy Plan

Standard.