### PR TITLE
[codex] Add Dust Support skill

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -116,10 +116,9 @@ Only use the ${AGENT_ROUTER_SERVER_NAME}${TOOL_NAME_SEPARATOR}${SUGGEST_AGENTS_T
   goDeepInstructions: `If a request is particularly complex (requires deep exploration of company data, multiple web searches, SQL queries, or 3+ steps of tool use), or if the user explicitly asks for a "deep dive", "deep research", or "comprehensive analysis", enable the "Go Deep" skill to delegate work across sub-agents for more thorough research.`,
 
   supportSkillActivation: `<dust_platform_support_guidelines>
-If the request is clearly about Dust itself, enable the "Dust Support" skill before answering.
-This includes questions about how to use Dust, Dust capabilities or limits, unexpected Dust behavior, Dust errors, or preparing a public Dust bug report.
-When the Dust Support skill is available, do not answer Dust support questions from memory or generic company-data search first. Enable and use Dust Support so the response is grounded on public Dust-specific sources.
-Do not enable Dust Support for generic help requests, non-Dust products, or ambiguous mentions of "dust" that are not clearly about the Dust platform.
+For clear Dust platform support requests, enable the "Dust Support" skill before answering.
+This includes Dust usage, capabilities, limits, unexpected behavior, errors, or preparing a public Dust bug report.
+Do not enable it for generic help requests, non-Dust products, or ambiguous mentions of "dust".
 </dust_platform_support_guidelines>`,
 
   memory: `<memory_guidelines>

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -115,28 +115,11 @@ Only use the ${AGENT_ROUTER_SERVER_NAME}${TOOL_NAME_SEPARATOR}${SUGGEST_AGENTS_T
 
   goDeepInstructions: `If a request is particularly complex (requires deep exploration of company data, multiple web searches, SQL queries, or 3+ steps of tool use), or if the user explicitly asks for a "deep dive", "deep research", or "comprehensive analysis", enable the "Go Deep" skill to delegate work across sub-agents for more thorough research.`,
 
-  help: `<dust_platform_support_guidelines>
-Follow these guidelines when the user unambiguously asks support questions specifically about how to use Dust features, or needs help understanding Dust.
-If the request is ambiguous, or not clearly a support request about how to use the Dust platform, do not assume it is and do not follow these guidelines.
-The vast majority of the time, the user is not asking for help with Dust.
-
-1. Perform web searches using site:dust.tt to find up-to-date information about Dust and, at the same time, fetch https://docs.dust.tt/llms.txt to easily view the documentation site map.
-2. Provide clear, straightforward answers with accuracy and empathy.
-3. Use bullet points and steps to guide the user effectively.
-4. NEVER invent features or capabilities that Dust does not have.
-5. NEVER make promises about future features.
-6. Only refer to URLs that are mentioned in the documentation or search results - do not make up URLs about Dust.
-7. At the end of your answer about Dust, provide these helpful links:
-   - Official documentation: https://docs.dust.tt
-   - Community support on Slack: https://dust-community.tightknit.community/join
-
-Examples of help queries:
-- "How do I create an agent in Dust?"
-- "What are Dust's data source capabilities?"
-- "Can Dust integrate with Slack?"
-- "How does Dust's memory feature work?"
-
-Remember: Always base your answers on the documentation. If you don't know the answer after searching, be honest about it.
+  supportSkillActivation: `<dust_platform_support_guidelines>
+If the request is clearly about Dust itself, enable the "Dust Support" skill before answering.
+This includes questions about how to use Dust, Dust capabilities or limits, unexpected Dust behavior, Dust errors, or preparing a public Dust bug report.
+When the Dust Support skill is available, do not answer Dust support questions from memory or generic company-data search first. Enable and use Dust Support so the response is grounded on public Dust-specific sources.
+Do not enable Dust Support for generic help requests, non-Dust products, or ambiguous mentions of "dust" that are not clearly about the Dust platform.
 </dust_platform_support_guidelines>`,
 
   memory: `<memory_guidelines>
@@ -259,7 +242,7 @@ function buildInstructions({
     INSTRUCTION_SECTIONS.primary,
     INSTRUCTION_SECTIONS.instructions,
     hasDeepDive && INSTRUCTION_SECTIONS.goDeepInstructions,
-    INSTRUCTION_SECTIONS.help,
+    INSTRUCTION_SECTIONS.supportSkillActivation,
     hasAgentMemory && INSTRUCTION_SECTIONS.memory,
   ].filter((part): part is string => typeof part === "string");
 
@@ -491,6 +474,7 @@ function _getDustLikeGlobalAgent(
       "sandbox",
       "projects",
       "plan_mode",
+      "support",
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
     omittedThinking: omittedThinking ?? false,

--- a/front/lib/api/assistant/global_agents/global_agents.test.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.test.ts
@@ -43,6 +43,35 @@ async function createAuthenticatorWithFlags(flags: WhitelistableFeature[]) {
 }
 
 describe("getGlobalAgents custom model agents", () => {
+  it("routes Dust support intent through the Dust Support skill", async () => {
+    const auth = await createAuthenticatorWithFlags([]);
+
+    const agents = await getGlobalAgents(
+      auth,
+      [GLOBAL_AGENTS_SID.DUST],
+      "full"
+    );
+
+    expect(agents).toHaveLength(1);
+    expect(agents[0].instructions).toContain(
+      'If the request is clearly about Dust itself, enable the "Dust Support" skill before answering.'
+    );
+    expect(agents[0].instructions).toContain(
+      "This includes questions about how to use Dust"
+    );
+    expect(agents[0].instructions).toContain(
+      "Enable and use Dust Support so the response is grounded on public Dust-specific sources."
+    );
+    expect(agents[0].instructions).toContain(
+      "Do not enable Dust Support for generic help requests"
+    );
+    expect(agents[0].instructions).not.toContain(
+      "https://dust-community.tightknit.community/join"
+    );
+    expect(agents[0].skills).toContain("discover_skills");
+    expect(agents[0].skills).toContain("support");
+  });
+
   it("hides custom Dust agents without the custom model feature flag", async () => {
     const auth = await createAuthenticatorWithFlags([
       "dust_internal_global_agents",

--- a/front/lib/api/assistant/global_agents/global_agents.test.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.test.ts
@@ -54,16 +54,13 @@ describe("getGlobalAgents custom model agents", () => {
 
     expect(agents).toHaveLength(1);
     expect(agents[0].instructions).toContain(
-      'If the request is clearly about Dust itself, enable the "Dust Support" skill before answering.'
+      'For clear Dust platform support requests, enable the "Dust Support" skill before answering.'
     );
     expect(agents[0].instructions).toContain(
-      "This includes questions about how to use Dust"
+      "This includes Dust usage, capabilities, limits"
     );
     expect(agents[0].instructions).toContain(
-      "Enable and use Dust Support so the response is grounded on public Dust-specific sources."
-    );
-    expect(agents[0].instructions).toContain(
-      "Do not enable Dust Support for generic help requests"
+      'Do not enable it for generic help requests, non-Dust products, or ambiguous mentions of "dust".'
     );
     expect(agents[0].instructions).not.toContain(
       "https://dust-community.tightknit.community/join"

--- a/front/lib/resources/skill/code_defined/global_registry.ts
+++ b/front/lib/resources/skill/code_defined/global_registry.ts
@@ -10,6 +10,7 @@ import {
   type GlobalSkillDefinition,
 } from "@app/lib/resources/skill/code_defined/shared";
 import { skillAuthoringSkill } from "@app/lib/resources/skill/code_defined/skill_authoring";
+import { supportSkill } from "@app/lib/resources/skill/code_defined/support";
 import { xlsxSkill } from "@app/lib/resources/skill/code_defined/xlsx";
 import type { AllSkillConfigurationFindOptions } from "@app/lib/resources/skill/types";
 import { serializeSkillTag } from "@app/lib/skills/format";
@@ -22,6 +23,7 @@ const GLOBAL_SKILLS_ARRAY = ensureUniqueSIds([
   pptxSkill,
   projectsSkill,
   skillAuthoringSkill,
+  supportSkill,
   xlsxSkill,
 ] as const);
 

--- a/front/lib/resources/skill/code_defined/support.test.ts
+++ b/front/lib/resources/skill/code_defined/support.test.ts
@@ -1,0 +1,66 @@
+import { WEB_SEARCH_BROWSE_SERVER_NAME } from "@app/lib/api/actions/servers/web_search_browse/metadata";
+import { GlobalSkillsRegistry } from "@app/lib/resources/skill/code_defined/global_registry";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { describe, expect, it } from "vitest";
+
+describe("support code-defined skill", () => {
+  it("is a discoverable global skill grounded on public Dust support surfaces", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    const support = await GlobalSkillsRegistry.getById(
+      authenticator,
+      "support"
+    );
+
+    expect(support).toMatchObject({
+      sId: "support",
+      name: "Dust Support",
+      icon: "ActionHandHeartIcon",
+      mcpServers: [
+        { name: WEB_SEARCH_BROWSE_SERVER_NAME },
+        {
+          name: "data_sources_file_system",
+          serverNameOverride: "company_data",
+        },
+        { name: "data_warehouses" },
+      ],
+      inheritAgentConfigurationDataSources: true,
+    });
+    expect(support?.instructions).toContain("https://docs.dust.tt/llms.txt");
+    expect(support?.instructions).toContain(
+      "https://github.com/dust-tt/dust/issues"
+    );
+    expect(support?.instructions).toContain("https://community.dust.tt");
+    expect(support?.instructions).toContain(
+      "https://dust-community.tightknit.community/join"
+    );
+    expect(support?.instructions).toContain(
+      "workspace-provided Dust documentation"
+    );
+    expect(support?.instructions).toContain("Mandatory first step");
+    expect(support?.instructions).toContain(
+      "Do not use company data or data warehouses as the first or only evidence source"
+    );
+    expect(support?.instructions).toContain("Hard non-commit rules");
+    expect(support?.instructions).toContain(
+      "NEVER invent Dust features, capabilities, limits, URLs, policies, support channels, or timelines"
+    );
+    expect(support?.instructions).toContain(
+      "NEVER make promises about future features"
+    );
+    expect(support?.instructions).toContain("Escalation path");
+    expect(support?.instructions).toContain(
+      "For unresolved public how-to questions"
+    );
+    expect(support?.agentFacingDescription).toContain(
+      "configured workspace data only for user-provided Dust context"
+    );
+    expect(support?.instructions).toContain("Do not file GitHub issues");
+
+    const discoverableSkills =
+      await SkillResource.listDiscoverable(authenticator);
+
+    expect(discoverableSkills.map((skill) => skill.sId)).toContain("support");
+  });
+});

--- a/front/lib/resources/skill/code_defined/support.test.ts
+++ b/front/lib/resources/skill/code_defined/support.test.ts
@@ -35,12 +35,13 @@ describe("support code-defined skill", () => {
     expect(support?.instructions).toContain(
       "https://dust-community.tightknit.community/join"
     );
-    expect(support?.instructions).toContain(
-      "workspace-provided Dust documentation"
-    );
+    expect(support?.instructions).toContain("IT-maintained Dust runbooks");
     expect(support?.instructions).toContain("Mandatory first step");
     expect(support?.instructions).toContain(
-      "Do not use company data or data warehouses as the first or only evidence source"
+      "Do not use workspace knowledge tools as the first or only evidence source"
+    );
+    expect(support?.instructions).toContain(
+      "Do not search arbitrary company data for general Dust support questions"
     );
     expect(support?.instructions).toContain("Hard non-commit rules");
     expect(support?.instructions).toContain(
@@ -54,7 +55,7 @@ describe("support code-defined skill", () => {
       "For unresolved public how-to questions"
     );
     expect(support?.agentFacingDescription).toContain(
-      "configured workspace data only for user-provided Dust context"
+      "workspace knowledge only for user-provided or workspace-specific Dust context"
     );
     expect(support?.instructions).toContain("Do not file GitHub issues");
 

--- a/front/lib/resources/skill/code_defined/support.test.ts
+++ b/front/lib/resources/skill/code_defined/support.test.ts
@@ -17,15 +17,7 @@ describe("support code-defined skill", () => {
       sId: "support",
       name: "Dust Support",
       icon: "ActionHandHeartIcon",
-      mcpServers: [
-        { name: WEB_SEARCH_BROWSE_SERVER_NAME },
-        {
-          name: "data_sources_file_system",
-          serverNameOverride: "company_data",
-        },
-        { name: "data_warehouses" },
-      ],
-      inheritAgentConfigurationDataSources: true,
+      mcpServers: [{ name: WEB_SEARCH_BROWSE_SERVER_NAME }],
     });
     expect(support?.instructions).toContain("https://docs.dust.tt/llms.txt");
     expect(support?.instructions).toContain(
@@ -35,14 +27,7 @@ describe("support code-defined skill", () => {
     expect(support?.instructions).toContain(
       "https://dust-community.tightknit.community/join"
     );
-    expect(support?.instructions).toContain("IT-maintained Dust runbooks");
     expect(support?.instructions).toContain("Mandatory first step");
-    expect(support?.instructions).toContain(
-      "Do not use workspace knowledge tools as the first or only evidence source"
-    );
-    expect(support?.instructions).toContain(
-      "Do not search arbitrary company data for general Dust support questions"
-    );
     expect(support?.instructions).toContain("Hard non-commit rules");
     expect(support?.instructions).toContain(
       "NEVER invent Dust features, capabilities, limits, URLs, policies, support channels, or timelines"
@@ -55,7 +40,10 @@ describe("support code-defined skill", () => {
       "For unresolved public how-to questions"
     );
     expect(support?.agentFacingDescription).toContain(
-      "workspace knowledge only for user-provided or workspace-specific Dust context"
+      "Ground answers on public Dust docs, public code/issues, and community knowledge"
+    );
+    expect(support?.instructions).toContain(
+      "NEVER search arbitrary company data"
     );
     expect(support?.instructions).toContain("Do not file GitHub issues");
 

--- a/front/lib/resources/skill/code_defined/support.ts
+++ b/front/lib/resources/skill/code_defined/support.ts
@@ -7,15 +7,14 @@ Ground every answer on the best available Dust-specific evidence. Start with pub
 - Dust open-source code and public issues: https://github.com/dust-tt/dust and https://github.com/dust-tt/dust/issues
 - Dust community knowledge from https://community.dust.tt and Community support on Slack: https://dust-community.tightknit.community/join
 
-Mandatory first step: before answering, call the web search/browse tools against the public Dust surfaces above. Prefer searches scoped to Dust domains and direct browsing of https://docs.dust.tt/llms.txt, relevant docs pages, public GitHub issues, or public community pages. Do not use workspace knowledge tools as the first or only evidence source for Dust support questions. If public web search or browse is unavailable or fails, say that the public sources could not be checked instead of answering from memory as if verified.
-
-After checking public Dust surfaces, use workspace knowledge tools only for Dust-specific context that the user or workspace provides, such as IT-maintained Dust runbooks, onboarding docs, model/provider policies, connector setup notes, custom data-source conventions, or other workspace-specific Dust guidance. Do not search arbitrary company data for general Dust support questions. Do not rely on private Dust support systems, Plain, internal boards, internal runbooks, account inspection tools, or any non-public escalation path. Never claim to have access to those systems.
+Mandatory first step: before answering, call the web search/browse tools against the public Dust surfaces above. Prefer searches scoped to Dust domains and direct browsing of https://docs.dust.tt/llms.txt, relevant docs pages, public GitHub issues, or public community pages. If public web search or browse is unavailable or fails, say that the public sources could not be checked instead of answering from memory as if verified.
 
 Hard non-commit rules:
 - NEVER invent Dust features, capabilities, limits, URLs, policies, support channels, or timelines.
 - NEVER make promises about future features, bug fixes, migrations, SLAs, credits, refunds, or account outcomes.
 - NEVER say that a bug was accepted, prioritized, escalated, assigned, or fixed unless a public source explicitly says so.
 - NEVER claim to have checked a user's workspace, account, billing state, logs, Plain tickets, internal runbooks, internal dashboards, or private GitHub state.
+- NEVER search arbitrary company data, private Dust support systems, Plain, internal boards, internal runbooks, account inspection tools, or any non-public escalation path.
 - Only refer to Dust URLs that appear in Dust documentation, public search results, public GitHub, or the public community surfaces listed above.
 
 Classify the request before answering:
@@ -41,15 +40,10 @@ export const supportSkill = {
   agentFacingDescription:
     "Use when the user asks how to use Dust, asks about Dust capabilities or limits, " +
     "hits unexpected Dust behavior, sees errors, or may need help qualifying a public " +
-    "bug report. Start from public Dust docs, public code/issues, and community " +
-    "knowledge; use workspace knowledge only for user-provided or workspace-specific Dust context.",
+    "bug report. Ground answers on public Dust docs, public code/issues, and " +
+    "community knowledge.",
   instructions: SUPPORT_INSTRUCTIONS,
-  mcpServers: [
-    { name: WEB_SEARCH_BROWSE_SERVER_NAME },
-    { name: "data_sources_file_system", serverNameOverride: "company_data" },
-    { name: "data_warehouses" },
-  ],
+  mcpServers: [{ name: WEB_SEARCH_BROWSE_SERVER_NAME }],
   version: 1,
   icon: "ActionHandHeartIcon",
-  inheritAgentConfigurationDataSources: true,
 } as const satisfies GlobalSkillDefinition;

--- a/front/lib/resources/skill/code_defined/support.ts
+++ b/front/lib/resources/skill/code_defined/support.ts
@@ -2,8 +2,6 @@ import { WEB_SEARCH_BROWSE_SERVER_NAME } from "@app/lib/api/actions/servers/web_
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
 
 const SUPPORT_INSTRUCTIONS = `
-Use this skill when the user asks for help with Dust itself, asks how to use a Dust feature, asks about Dust capabilities or limits, or reports unexpected Dust behavior.
-
 Ground every answer on the best available Dust-specific evidence. Start with public Dust surfaces:
 - Dust documentation: https://docs.dust.tt and the documentation map at https://docs.dust.tt/llms.txt
 - Dust open-source code and public issues: https://github.com/dust-tt/dust and https://github.com/dust-tt/dust/issues

--- a/front/lib/resources/skill/code_defined/support.ts
+++ b/front/lib/resources/skill/code_defined/support.ts
@@ -1,0 +1,57 @@
+import { WEB_SEARCH_BROWSE_SERVER_NAME } from "@app/lib/api/actions/servers/web_search_browse/metadata";
+import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
+
+const SUPPORT_INSTRUCTIONS = `
+Use this skill when the user asks for help with Dust itself, asks how to use a Dust feature, asks about Dust capabilities or limits, or reports unexpected Dust behavior.
+
+Ground every answer on the best available Dust-specific evidence. Start with public Dust surfaces:
+- Dust documentation: https://docs.dust.tt and the documentation map at https://docs.dust.tt/llms.txt
+- Dust open-source code and public issues: https://github.com/dust-tt/dust and https://github.com/dust-tt/dust/issues
+- Dust community knowledge from https://community.dust.tt and Community support on Slack: https://dust-community.tightknit.community/join
+
+Mandatory first step: before answering, call the web search/browse tools against the public Dust surfaces above. Prefer searches scoped to Dust domains and direct browsing of https://docs.dust.tt/llms.txt, relevant docs pages, public GitHub issues, or public community pages. Do not use company data or data warehouses as the first or only evidence source for Dust support questions. If public web search or browse is unavailable or fails, say that the public sources could not be checked instead of answering from memory as if verified.
+
+When company data or data warehouse access is configured, use those sources only after checking public Dust surfaces and only for user-provided or workspace-provided Dust documentation, product notes, or relevant context. Do not rely on private Dust support systems, Plain, internal boards, internal runbooks, account inspection tools, or any non-public escalation path. Never claim to have access to those systems.
+
+Hard non-commit rules:
+- NEVER invent Dust features, capabilities, limits, URLs, policies, support channels, or timelines.
+- NEVER make promises about future features, bug fixes, migrations, SLAs, credits, refunds, or account outcomes.
+- NEVER say that a bug was accepted, prioritized, escalated, assigned, or fixed unless a public source explicitly says so.
+- NEVER claim to have checked a user's workspace, account, billing state, logs, Plain tickets, internal runbooks, internal dashboards, or private GitHub state.
+- Only refer to Dust URLs that appear in Dust documentation, public search results, public GitHub, or the public community surfaces listed above.
+
+Classify the request before answering:
+1. How-to or capability question: answer directly from public docs, public community knowledge, public code, or public issues. Keep the answer practical and include steps when useful.
+2. Suspected product bug: help the user qualify the report. Ask for or summarize reproducible steps, expected behavior, actual behavior, visible errors, relevant public feature names, and environment details. Remind the user not to include private workspace data.
+3. Billing, security, account recovery, or other private escalation: explain that this skill is grounded only on public information and cannot inspect private account or workspace state. Direct the user to their official Dust support or customer-success channel if they have one, but do not invent contact details. If no official private support channel is known from public sources or the user's context, say so and keep the answer limited to public guidance.
+
+For suspected bugs, search public GitHub issues for an existing match before recommending a new report. If no matching issue is found, guide the user to the public issue tracker at https://github.com/dust-tt/dust/issues and mention the Dust community at https://community.dust.tt as the public Q&A and discussion surface. Do not file GitHub issues or present an internal escalation path. If the user asks for help preparing a report, provide a concise report outline they can review and submit themselves.
+
+Escalation path:
+- For unresolved public how-to questions, point users to the official documentation at https://docs.dust.tt and Community support on Slack at https://dust-community.tightknit.community/join.
+- For suspected product bugs, point users to matching public GitHub issues when one exists; otherwise guide them to https://github.com/dust-tt/dust/issues with a report outline.
+- For private billing, security, account recovery, workspace access, or customer-specific incidents, do not troubleshoot as if you can inspect private state. Tell the user to use their official Dust support or customer-success channel, and do not provide unverified contact URLs or emails.
+
+Be explicit about uncertainty. If public sources do not answer the question, say so and state which public surfaces you checked.
+`.trim();
+
+export const supportSkill = {
+  sId: "support",
+  name: "Dust Support",
+  userFacingDescription:
+    "Get help with Dust using public docs, open-source issues, and community knowledge.",
+  agentFacingDescription:
+    "Use when the user asks how to use Dust, asks about Dust capabilities or limits, " +
+    "hits unexpected Dust behavior, sees errors, or may need help qualifying a public " +
+    "bug report. Start from public Dust docs, public code/issues, and community " +
+    "knowledge; use configured workspace data only for user-provided Dust context.",
+  instructions: SUPPORT_INSTRUCTIONS,
+  mcpServers: [
+    { name: WEB_SEARCH_BROWSE_SERVER_NAME },
+    { name: "data_sources_file_system", serverNameOverride: "company_data" },
+    { name: "data_warehouses" },
+  ],
+  version: 1,
+  icon: "ActionHandHeartIcon",
+  inheritAgentConfigurationDataSources: true,
+} as const satisfies GlobalSkillDefinition;

--- a/front/lib/resources/skill/code_defined/support.ts
+++ b/front/lib/resources/skill/code_defined/support.ts
@@ -9,9 +9,9 @@ Ground every answer on the best available Dust-specific evidence. Start with pub
 - Dust open-source code and public issues: https://github.com/dust-tt/dust and https://github.com/dust-tt/dust/issues
 - Dust community knowledge from https://community.dust.tt and Community support on Slack: https://dust-community.tightknit.community/join
 
-Mandatory first step: before answering, call the web search/browse tools against the public Dust surfaces above. Prefer searches scoped to Dust domains and direct browsing of https://docs.dust.tt/llms.txt, relevant docs pages, public GitHub issues, or public community pages. Do not use company data or data warehouses as the first or only evidence source for Dust support questions. If public web search or browse is unavailable or fails, say that the public sources could not be checked instead of answering from memory as if verified.
+Mandatory first step: before answering, call the web search/browse tools against the public Dust surfaces above. Prefer searches scoped to Dust domains and direct browsing of https://docs.dust.tt/llms.txt, relevant docs pages, public GitHub issues, or public community pages. Do not use workspace knowledge tools as the first or only evidence source for Dust support questions. If public web search or browse is unavailable or fails, say that the public sources could not be checked instead of answering from memory as if verified.
 
-When company data or data warehouse access is configured, use those sources only after checking public Dust surfaces and only for user-provided or workspace-provided Dust documentation, product notes, or relevant context. Do not rely on private Dust support systems, Plain, internal boards, internal runbooks, account inspection tools, or any non-public escalation path. Never claim to have access to those systems.
+After checking public Dust surfaces, use workspace knowledge tools only for Dust-specific context that the user or workspace provides, such as IT-maintained Dust runbooks, onboarding docs, model/provider policies, connector setup notes, custom data-source conventions, or other workspace-specific Dust guidance. Do not search arbitrary company data for general Dust support questions. Do not rely on private Dust support systems, Plain, internal boards, internal runbooks, account inspection tools, or any non-public escalation path. Never claim to have access to those systems.
 
 Hard non-commit rules:
 - NEVER invent Dust features, capabilities, limits, URLs, policies, support channels, or timelines.
@@ -44,7 +44,7 @@ export const supportSkill = {
     "Use when the user asks how to use Dust, asks about Dust capabilities or limits, " +
     "hits unexpected Dust behavior, sees errors, or may need help qualifying a public " +
     "bug report. Start from public Dust docs, public code/issues, and community " +
-    "knowledge; use configured workspace data only for user-provided Dust context.",
+    "knowledge; use workspace knowledge only for user-provided or workspace-specific Dust context.",
   instructions: SUPPORT_INSTRUCTIONS,
   mcpServers: [
     { name: WEB_SEARCH_BROWSE_SERVER_NAME },

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -127,7 +127,8 @@ export function useUpdateWorkspaceRegionalModelsOnly({
           sendNotification({
             type: "error",
             title: "Update failed",
-            description: "Some active agents may not be eligible for regional models.",
+            description:
+              "Some active agents may not be eligible for regional models.",
           });
           return false;
         }


### PR DESCRIPTION
## Description

Adds a code-defined `Dust Support` global skill for Dust platform support questions.

The skill gives support answers a clear public-source-first path: Dust docs, the docs `llms.txt` map, public GitHub code/issues, and public community surfaces. It stays self-contained and does not use workspace/company data or data warehouses; custom skills can add workspace-specific Dust context when needed.

This also routes `@dust` support intent through the new skill instead of keeping the full support policy in the base `@dust` prompt. The skill carries the detailed escalation path and hard non-commit rules: no invented Dust capabilities, URLs, timelines, support channels, private-state inspection, or claims that issues were escalated/fixed without public evidence.

Refs dust-tt/tasks#8667.

## Tests

- `npx biome check front/lib/resources/skill/code_defined/support.ts front/lib/resources/skill/code_defined/support.test.ts front/lib/api/assistant/global_agents/configurations/dust/dust.ts front/lib/api/assistant/global_agents/global_agents.test.ts`
- `cd front && NODE_ENV=test FRONT_DATABASE_URI=$TEST_FRONT_DATABASE_URI REDIS_URI=$TEST_REDIS_URI REDIS_CACHE_URI=$TEST_REDIS_URI npx vitest --run lib/resources/skill/code_defined/support.test.ts lib/api/assistant/global_agents/global_agents.test.ts`
- `git diff --check`
- Manual local UI regression: confirmed the support conversation enables `Dust Support` and selects `web_search_browse` for public Dust evidence.

Could not complete local `npm run --workspace @dust-tt/front tsgo` after rebasing onto latest `origin/main`: it currently fails in `pages/api/v1/w/[wId]/feature_flags.ts` on a feature-flag type mismatch unrelated to this diff.

## Risk

Low. This adds a new default global skill and narrows `@dust` support behavior to enable that skill for clearly Dust-specific requests. The main behavioral risk is over-activation on ambiguous mentions of Dust, mitigated by explicit activation guidance requiring the request to be clearly about the Dust platform.

Rollback is straightforward: remove the skill from the global registry and `@dust` skill list, and restore the previous inline support prompt.

## Deploy Plan

Standard deploy on `front`. No migration, no backfill, and no configuration change required.