### PR TITLE
Handle seat type changes in the future

### DIFF
--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -1404,7 +1404,7 @@ export async function processMetronomeWebhook({
         });
 
         // A new seat segment starting means a seat type was activated (e.g.
-        // a planned Pro→Max upgrade takes effect). Re-sync the seat count so
+        // a planned Pro→Max downgrade takes effect). Re-sync the seat count so
         // the per-user allocation is reassigned and each user's credit state
         // reflects the new seat type.
         if (

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -24,6 +24,7 @@ import {
   syncPoolCreditStateFromBalance,
 } from "@app/lib/api/metronome/credit_state_dispatcher";
 import { reconcileWorkspaceUserCreditStates } from "@app/lib/api/metronome/reconcile_credit_state";
+import { syncMetronomeSeatCountForWorkspace } from "@app/lib/api/metronome/seat_sync";
 import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
 import { Authenticator } from "@app/lib/auth";
@@ -308,6 +309,17 @@ async function stampCommitCreditType({
     `[Metronome Webhook] ${eventType}: stamped DUST_CONTRACT_CREDIT_TYPE=pool on commit`
   );
   return new Ok(undefined);
+}
+
+// Returns true when the credit is an individual AWU seat credit — i.e. the
+// per-user recurring credit that backs a Pro/Max seat allocation. Used to
+// decide whether a segment event should trigger a seat sync + user credit state
+// reconciliation.
+function isSeatAwuCredit(credit: Credit): boolean {
+  return (
+    credit.subscription_config?.allocation === "INDIVIDUAL" &&
+    credit.access_schedule?.credit_type?.id === getCreditTypeAwuId()
+  );
 }
 
 // Reconcile the workspace pool credit state from a commit/credit segment or
@@ -1157,7 +1169,6 @@ export async function processMetronomeWebhook({
     case "contract.archive":
     case "contract.create":
     case "credit.archive":
-    case "credit.segment.end":
     case "invoice.billing_provider_error":
     case "invoice.finalized":
       break;
@@ -1390,6 +1401,23 @@ export async function processMetronomeWebhook({
           metronomeCustomerId,
           commitOrCredit: creditResult.value,
         });
+
+        // A new seat segment starting means a seat type was activated (e.g.
+        // a planned Pro→Max upgrade takes effect). Re-sync the seat count so
+        // the per-user allocation is reassigned and each user's credit state
+        // reflects the new seat type.
+        if (
+          event.type === "credit.segment.start" &&
+          isSeatAwuCredit(creditResult.value)
+        ) {
+          await syncMetronomeSeatCountForWorkspace({
+            workspace: renderLightWorkspaceType({ workspace }),
+          });
+          logger.info(
+            { metronomeCustomerId, creditId, workspaceId: workspace.sId },
+            "[Metronome Webhook] credit.segment.start: seat credit activated, seat sync triggered"
+          );
+        }
       }
 
       if (event.type === "credit.segment.start") {
@@ -1410,6 +1438,34 @@ export async function processMetronomeWebhook({
         if (grantResult.isErr()) {
           return grantResult;
         }
+      }
+      break;
+    }
+
+    case "credit.segment.end": {
+      const { customer_id: metronomeCustomerId, credit_id: creditId } = event;
+
+      const creditResult = await getMetronomeCredit({
+        metronomeCustomerId,
+        creditId,
+      });
+      if (creditResult.isErr()) {
+        return new Err(
+          new ProcessMetronomeWebhookError(
+            "processing_failed",
+            `Error fetching credit: ${creditResult.error.message}`
+          )
+        );
+      }
+
+      if (creditResult.value && isSeatAwuCredit(creditResult.value)) {
+        await syncMetronomeSeatCountForWorkspace({
+          workspace: renderLightWorkspaceType({ workspace }),
+        });
+        logger.info(
+          { metronomeCustomerId, creditId, workspaceId: workspace.sId },
+          "[Metronome Webhook] credit.segment.end: seat credit deactivated, seat sync triggered"
+        );
       }
       break;
     }

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -24,7 +24,6 @@ import {
   syncPoolCreditStateFromBalance,
 } from "@app/lib/api/metronome/credit_state_dispatcher";
 import { reconcileWorkspaceUserCreditStates } from "@app/lib/api/metronome/reconcile_credit_state";
-import { syncMetronomeSeatCountForWorkspace } from "@app/lib/api/metronome/seat_sync";
 import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
 import { Authenticator } from "@app/lib/auth";
@@ -89,6 +88,7 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
+import { launchSyncMetronomeSeatCountWorkflow } from "@app/temporal/metronome_events_queue/client";
 import { launchScheduleWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
 import { normalizeToPoolLimitSeatType } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
@@ -1410,8 +1410,8 @@ export async function processMetronomeWebhook({
           event.type === "credit.segment.start" &&
           isSeatAwuCredit(creditResult.value)
         ) {
-          await syncMetronomeSeatCountForWorkspace({
-            workspace: renderLightWorkspaceType({ workspace }),
+          await launchSyncMetronomeSeatCountWorkflow({
+            workspaceId: workspace.sId,
           });
           logger.info(
             { metronomeCustomerId, creditId, workspaceId: workspace.sId },
@@ -1459,8 +1459,8 @@ export async function processMetronomeWebhook({
       }
 
       if (creditResult.value && isSeatAwuCredit(creditResult.value)) {
-        await syncMetronomeSeatCountForWorkspace({
-          workspace: renderLightWorkspaceType({ workspace }),
+        await launchSyncMetronomeSeatCountWorkflow({
+          workspaceId: workspace.sId,
         });
         logger.info(
           { metronomeCustomerId, creditId, workspaceId: workspace.sId },

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -1169,6 +1169,7 @@ export async function processMetronomeWebhook({
     case "contract.archive":
     case "contract.create":
     case "credit.archive":
+    case "credit.segment.end":
     case "invoice.billing_provider_error":
     case "invoice.finalized":
       break;
@@ -1438,34 +1439,6 @@ export async function processMetronomeWebhook({
         if (grantResult.isErr()) {
           return grantResult;
         }
-      }
-      break;
-    }
-
-    case "credit.segment.end": {
-      const { customer_id: metronomeCustomerId, credit_id: creditId } = event;
-
-      const creditResult = await getMetronomeCredit({
-        metronomeCustomerId,
-        creditId,
-      });
-      if (creditResult.isErr()) {
-        return new Err(
-          new ProcessMetronomeWebhookError(
-            "processing_failed",
-            `Error fetching credit: ${creditResult.error.message}`
-          )
-        );
-      }
-
-      if (creditResult.value && isSeatAwuCredit(creditResult.value)) {
-        await launchSyncMetronomeSeatCountWorkflow({
-          workspaceId: workspace.sId,
-        });
-        logger.info(
-          { metronomeCustomerId, creditId, workspaceId: workspace.sId },
-          "[Metronome Webhook] credit.segment.end: seat credit deactivated, seat sync triggered"
-        );
       }
       break;
     }

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -88,7 +88,7 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
-import { launchSyncMetronomeSeatCountWorkflow } from "@app/temporal/metronome_events_queue/client";
+import { launchReconcileWorkspaceUserCreditStatesWorkflow } from "@app/temporal/metronome_events_queue/client";
 import { launchScheduleWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
 import { normalizeToPoolLimitSeatType } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
@@ -1411,12 +1411,12 @@ export async function processMetronomeWebhook({
           event.type === "credit.segment.start" &&
           isSeatAwuCredit(creditResult.value)
         ) {
-          await launchSyncMetronomeSeatCountWorkflow({
+          await launchReconcileWorkspaceUserCreditStatesWorkflow({
             workspaceId: workspace.sId,
           });
           logger.info(
             { metronomeCustomerId, creditId, workspaceId: workspace.sId },
-            "[Metronome Webhook] credit.segment.start: seat credit activated, seat sync triggered"
+            "[Metronome Webhook] credit.segment.start: seat credit activated, reconcile triggered"
           );
         }
       }

--- a/front/temporal/metronome_events_queue/activities.ts
+++ b/front/temporal/metronome_events_queue/activities.ts
@@ -61,7 +61,7 @@ export async function cleanMetronomeInvoiceActivity({
  * Run a seat count sync for a workspace. Extracted as a dedicated activity so
  * the seat sync can be launched as a separate, workspace-scoped workflow (see
  * `syncMetronomeSeatCountWorkflow`) — this lets Temporal deduplicate the N
- * concurrent `credit.segment.start` events that fire during a seat-type upgrade
+ * concurrent `credit.segment.start` events that fire during a seat-type downgrade
  * (one per seat) down to a single execution per workspace.
  */
 export async function syncMetronomeSeatCountActivity({

--- a/front/temporal/metronome_events_queue/activities.ts
+++ b/front/temporal/metronome_events_queue/activities.ts
@@ -1,7 +1,9 @@
 import { processMetronomeWebhook } from "@app/lib/api/metronome/process_webhook";
+import { syncMetronomeSeatCountForWorkspace } from "@app/lib/api/metronome/seat_sync";
 import type { MetronomeWebhookEvent } from "@app/lib/metronome/webhook_events";
 import { cleanAndFinalizeMetronomeDraftInvoice } from "@app/lib/plans/stripe";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
 
 /**
  * Temporal wrapper around `processMetronomeWebhook`. The handler has already
@@ -52,5 +54,31 @@ export async function cleanMetronomeInvoiceActivity({
   });
   if (result.isErr()) {
     throw new Error(result.error.error_message);
+  }
+}
+
+/**
+ * Run a seat count sync for a workspace. Extracted as a dedicated activity so
+ * the seat sync can be launched as a separate, workspace-scoped workflow (see
+ * `syncMetronomeSeatCountWorkflow`) — this lets Temporal deduplicate the N
+ * concurrent `credit.segment.start` events that fire during a seat-type upgrade
+ * (one per seat) down to a single execution per workspace.
+ */
+export async function syncMetronomeSeatCountActivity({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): Promise<void> {
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  if (!workspace) {
+    throw new Error(
+      `[Metronome Seat Sync] Workspace ${workspaceId} not found at activity start`
+    );
+  }
+  const result = await syncMetronomeSeatCountForWorkspace({
+    workspace: renderLightWorkspaceType({ workspace }),
+  });
+  if (result.isErr()) {
+    throw result.error;
   }
 }

--- a/front/temporal/metronome_events_queue/activities.ts
+++ b/front/temporal/metronome_events_queue/activities.ts
@@ -1,7 +1,8 @@
 import { processMetronomeWebhook } from "@app/lib/api/metronome/process_webhook";
-import { syncMetronomeSeatCountForWorkspace } from "@app/lib/api/metronome/seat_sync";
+import { reconcileWorkspaceUserCreditStates } from "@app/lib/api/metronome/reconcile_credit_state";
 import type { MetronomeWebhookEvent } from "@app/lib/metronome/webhook_events";
 import { cleanAndFinalizeMetronomeDraftInvoice } from "@app/lib/plans/stripe";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 
@@ -58,13 +59,18 @@ export async function cleanMetronomeInvoiceActivity({
 }
 
 /**
- * Run a seat count sync for a workspace. Extracted as a dedicated activity so
- * the seat sync can be launched as a separate, workspace-scoped workflow (see
- * `syncMetronomeSeatCountWorkflow`) — this lets Temporal deduplicate the N
- * concurrent `credit.segment.start` events that fire during a seat-type downgrade
- * (one per seat) down to a single execution per workspace.
+ * Reconcile per-user credit states for a workspace after a seat segment starts.
+ * Extracted as a dedicated activity so it can be launched as a separate,
+ * workspace-scoped workflow (see `reconcileWorkspaceCreditStatesWorkflow`) — this
+ * lets Temporal deduplicate the N concurrent `credit.segment.start` events that
+ * fire during a seat-type change (one per seat) down to a single execution per
+ * workspace.
+ *
+ * Metronome at schedule time (via `syncSeatCount` with a future `startingAt`).
+ * When `credit.segment.start` fires the assignment is already correct; we only
+ * need to invalidate and recalculate each user's credit state.
  */
-export async function syncMetronomeSeatCountActivity({
+export async function reconcileWorkspaceUserCreditStatesActivity({
   workspaceId,
 }: {
   workspaceId: string;
@@ -72,13 +78,21 @@ export async function syncMetronomeSeatCountActivity({
   const workspace = await WorkspaceResource.fetchById(workspaceId);
   if (!workspace) {
     throw new Error(
-      `[Metronome Seat Sync] Workspace ${workspaceId} not found at activity start`
+      `[Metronome Reconcile] Workspace ${workspaceId} not found at activity start`
     );
   }
-  const result = await syncMetronomeSeatCountForWorkspace({
-    workspace: renderLightWorkspaceType({ workspace }),
-  });
-  if (result.isErr()) {
-    throw result.error;
+  if (!workspace.metronomeCustomerId) {
+    return;
   }
+  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+    workspace.id
+  );
+  if (!subscription?.metronomeContractId) {
+    return;
+  }
+  await reconcileWorkspaceUserCreditStates({
+    workspace: renderLightWorkspaceType({ workspace }),
+    metronomeCustomerId: workspace.metronomeCustomerId,
+    metronomeContractId: subscription.metronomeContractId,
+  });
 }

--- a/front/temporal/metronome_events_queue/client.ts
+++ b/front/temporal/metronome_events_queue/client.ts
@@ -5,6 +5,7 @@ import { QUEUE_NAME } from "@app/temporal/metronome_events_queue/config";
 import {
   cleanMetronomeInvoiceWorkflow,
   metronomeEventsWorkflow,
+  syncMetronomeSeatCountWorkflow,
 } from "@app/temporal/metronome_events_queue/workflows";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -13,6 +14,7 @@ import {
   WorkflowExecutionAlreadyStartedError,
   WorkflowIdReusePolicy,
 } from "@temporalio/client";
+import { WorkflowIdConflictPolicy } from "@temporalio/common";
 
 /**
  * Outcome of attempting to enqueue a Metronome webhook event for processing.
@@ -118,5 +120,42 @@ export async function launchCleanMetronomeInvoiceWorkflow({
       return new Ok("already_started");
     }
     return new Err(normalizeError(err));
+  }
+}
+
+/**
+ * Launch a deduplicated seat-count sync for a workspace. Uses a stable
+ * workspace-scoped workflow ID with `WorkflowIdConflictPolicy.USE_EXISTING` so
+ * that the N concurrent `credit.segment.start` events fired during a seat-type
+ * upgrade collapse to a single workflow execution. After a sync completes,
+ * `WorkflowIdReusePolicy.ALLOW_DUPLICATE` allows a fresh run for the next
+ * upgrade event. Errors are logged but not propagated — a sync launch failure
+ * must not cause the parent webhook workflow to retry.
+ */
+export async function launchSyncMetronomeSeatCountWorkflow({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): Promise<void> {
+  const client = await getTemporalClientForFrontNamespace();
+  const workflowId = `metronome-seat-sync-${workspaceId}`;
+
+  try {
+    await client.workflow.start(syncMetronomeSeatCountWorkflow, {
+      args: [{ workspaceId }],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+      workflowIdReusePolicy: WorkflowIdReusePolicy.ALLOW_DUPLICATE,
+      workflowIdConflictPolicy: WorkflowIdConflictPolicy.USE_EXISTING,
+    });
+    logger.info(
+      { workflowId, workspaceId },
+      "[Metronome Seat Sync] Launched seat sync workflow"
+    );
+  } catch (err) {
+    logger.error(
+      { workflowId, workspaceId, err },
+      "[Metronome Seat Sync] Failed to launch seat sync workflow"
+    );
   }
 }

--- a/front/temporal/metronome_events_queue/client.ts
+++ b/front/temporal/metronome_events_queue/client.ts
@@ -5,7 +5,7 @@ import { QUEUE_NAME } from "@app/temporal/metronome_events_queue/config";
 import {
   cleanMetronomeInvoiceWorkflow,
   metronomeEventsWorkflow,
-  syncMetronomeSeatCountWorkflow,
+  reconcileWorkspaceUserCreditStatesWorkflow,
 } from "@app/temporal/metronome_events_queue/workflows";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -124,24 +124,24 @@ export async function launchCleanMetronomeInvoiceWorkflow({
 }
 
 /**
- * Launch a deduplicated seat-count sync for a workspace. Uses a stable
+ * Launch a deduplicated credit-state reconcile for a workspace. Uses a stable
  * workspace-scoped workflow ID with `WorkflowIdConflictPolicy.USE_EXISTING` so
  * that the N concurrent `credit.segment.start` events fired during a seat-type
- * upgrade collapse to a single workflow execution. After a sync completes,
- * `WorkflowIdReusePolicy.ALLOW_DUPLICATE` allows a fresh run for the next
- * upgrade event. Errors are logged but not propagated — a sync launch failure
- * must not cause the parent webhook workflow to retry.
+ * change collapse to a single workflow execution. After a reconcile completes,
+ * `WorkflowIdReusePolicy.ALLOW_DUPLICATE` allows a fresh run for the next event.
+ * Errors are logged but not propagated — a launch failure must not cause the
+ * parent webhook workflow to retry.
  */
-export async function launchSyncMetronomeSeatCountWorkflow({
+export async function launchReconcileWorkspaceUserCreditStatesWorkflow({
   workspaceId,
 }: {
   workspaceId: string;
 }): Promise<void> {
   const client = await getTemporalClientForFrontNamespace();
-  const workflowId = `metronome-seat-sync-${workspaceId}`;
+  const workflowId = `metronome-reconcile-${workspaceId}`;
 
   try {
-    await client.workflow.start(syncMetronomeSeatCountWorkflow, {
+    await client.workflow.start(reconcileWorkspaceUserCreditStatesWorkflow, {
       args: [{ workspaceId }],
       taskQueue: QUEUE_NAME,
       workflowId,
@@ -150,12 +150,12 @@ export async function launchSyncMetronomeSeatCountWorkflow({
     });
     logger.info(
       { workflowId, workspaceId },
-      "[Metronome Seat Sync] Launched seat sync workflow"
+      "[Metronome Reconcile] Launched credit state reconcile workflow"
     );
   } catch (err) {
     logger.error(
       { workflowId, workspaceId, err },
-      "[Metronome Seat Sync] Failed to launch seat sync workflow"
+      "[Metronome Reconcile] Failed to launch credit state reconcile workflow"
     );
   }
 }

--- a/front/temporal/metronome_events_queue/workflows.ts
+++ b/front/temporal/metronome_events_queue/workflows.ts
@@ -5,7 +5,7 @@ import { proxyActivities } from "@temporalio/workflow";
 const {
   processMetronomeWebhookActivity,
   cleanMetronomeInvoiceActivity,
-  syncMetronomeSeatCountActivity,
+  reconcileWorkspaceUserCreditStatesActivity,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "5 minutes",
 });
@@ -35,17 +35,17 @@ export async function cleanMetronomeInvoiceWorkflow({
   await cleanMetronomeInvoiceActivity({ invoiceId, workspaceId });
 }
 /**
- * Dedicated workflow for syncing a workspace's Metronome seat count. Using a
- * separate workflow (rather than calling the sync inline in
+ * Dedicated workflow for reconciling per-user credit states after a seat segment
+ * starts. Using a separate workflow (rather than calling reconcile inline in
  * `metronomeEventsWorkflow`) lets us assign a stable, workspace-scoped workflow
  * ID and set `WorkflowIdConflictPolicy.USE_EXISTING` — so the N concurrent
- * `credit.segment.start` events fired during a seat-type downgrade collapse to a
- * single execution instead of hammering Metronome and the DB N times.
+ * `credit.segment.start` events fired during a seat-type change collapse to a
+ * single execution instead of hammering the DB N times.
  */
-export async function syncMetronomeSeatCountWorkflow({
+export async function reconcileWorkspaceUserCreditStatesWorkflow({
   workspaceId,
 }: {
   workspaceId: string;
 }): Promise<void> {
-  await syncMetronomeSeatCountActivity({ workspaceId });
+  await reconcileWorkspaceUserCreditStatesActivity({ workspaceId });
 }

--- a/front/temporal/metronome_events_queue/workflows.ts
+++ b/front/temporal/metronome_events_queue/workflows.ts
@@ -2,10 +2,13 @@ import type { MetronomeWebhookEvent } from "@app/lib/metronome/webhook_events";
 import type * as activities from "@app/temporal/metronome_events_queue/activities";
 import { proxyActivities } from "@temporalio/workflow";
 
-const { processMetronomeWebhookActivity, cleanMetronomeInvoiceActivity } =
-  proxyActivities<typeof activities>({
-    startToCloseTimeout: "5 minutes",
-  });
+const {
+  processMetronomeWebhookActivity,
+  cleanMetronomeInvoiceActivity,
+  syncMetronomeSeatCountActivity,
+} = proxyActivities<typeof activities>({
+  startToCloseTimeout: "5 minutes",
+});
 
 export async function metronomeEventsWorkflow({
   event,
@@ -30,4 +33,19 @@ export async function cleanMetronomeInvoiceWorkflow({
   workspaceId: string;
 }): Promise<void> {
   await cleanMetronomeInvoiceActivity({ invoiceId, workspaceId });
+}
+/**
+ * Dedicated workflow for syncing a workspace's Metronome seat count. Using a
+ * separate workflow (rather than calling the sync inline in
+ * `metronomeEventsWorkflow`) lets us assign a stable, workspace-scoped workflow
+ * ID and set `WorkflowIdConflictPolicy.USE_EXISTING` — so the N concurrent
+ * `credit.segment.start` events fired during a seat-type upgrade collapse to a
+ * single execution instead of hammering Metronome and the DB N times.
+ */
+export async function syncMetronomeSeatCountWorkflow({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): Promise<void> {
+  await syncMetronomeSeatCountActivity({ workspaceId });
 }

--- a/front/temporal/metronome_events_queue/workflows.ts
+++ b/front/temporal/metronome_events_queue/workflows.ts
@@ -39,7 +39,7 @@ export async function cleanMetronomeInvoiceWorkflow({
  * separate workflow (rather than calling the sync inline in
  * `metronomeEventsWorkflow`) lets us assign a stable, workspace-scoped workflow
  * ID and set `WorkflowIdConflictPolicy.USE_EXISTING` — so the N concurrent
- * `credit.segment.start` events fired during a seat-type upgrade collapse to a
+ * `credit.segment.start` events fired during a seat-type downgrade collapse to a
  * single execution instead of hammering Metronome and the DB N times.
  */
 export async function syncMetronomeSeatCountWorkflow({


### PR DESCRIPTION
## Description

When a future-dated seat-type change (e.g. Pro → Max downgrade) takes effect, Metronome fires one `credit.segment.start` event per seat. This PR hooks into that event to reconcile each user's credit state after the new seat tier activates.

On `credit.segment.start` for an individual AWU seat credit (identified by a new `isSeatAwuCredit()` helper that checks `allocation === "INDIVIDUAL"` and the credit type ID), `launchReconcileWorkspaceUserCreditStatesWorkflow` is launched. Crucially, **only credit states are reconciled, not the seat count** — the seat assignment was already pushed to Metronome at schedule time via `syncSeatCount` with a future `startingAt`, so the assignment is already correct when the event fires. A new dedicated Temporal workflow (`reconcileWorkspaceUserCreditStatesWorkflow`) and its activity are added to the `metronome_events_queue`. To avoid N parallel reconciles for the N seats that change at the same moment, the workflow client uses `WorkflowIdConflictPolicy.USE_EXISTING` with a stable workspace-scoped ID, collapsing all concurrent events to a single execution; `WorkflowIdReusePolicy.ALLOW_DUPLICATE` then allows a fresh run for subsequent changes. Launch errors are caught and logged but never propagated, so the parent webhook workflow is never impacted.

## Tests

Tested manually. No automated tests added (the new code paths are thin wrappers over the existing `reconcileWorkspaceUserCreditStates` which has its own test coverage).

## Risk

Low. The reconcile workflow is fire-and-forget from the webhook's perspective (errors are swallowed), so it cannot cause retries or failures in the existing webhook processing flow. The reconcile function itself never throws and only writes on drift.

## Deploy Plan

Deploy `front`.