### PR TITLE
move poke agents/skills API contracts out of pages/api

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
@@ -1,24 +1,14 @@
 import { listsAgentConfigurationVersions } from "@app/lib/api/assistant/configuration/agent";
 import { getAuthors, getEditors } from "@app/lib/api/assistant/editors";
+import type { PokeGetAgentDetails } from "@app/lib/api/poke/agent_configurations";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import { isGlobalAgentId } from "@app/types/assistant/assistant";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
-import type { SpaceType } from "@app/types/space";
-import type { UserType } from "@app/types/user";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export type PokeGetAgentDetails = {
-  agentConfigurations: AgentConfigurationType[];
-  authors: UserType[];
-  lastVersionEditors: UserType[];
-  spaces: SpaceType[];
-  skillsByVersion: Record<number, SkillType[]>;
-};
 
 const ParamsSchema = z.object({
   aId: z.string(),

--- a/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/observability/datasource-retrieval.ts
+++ b/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/observability/datasource-retrieval.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import type { DatasourceRetrievalData } from "@app/lib/api/assistant/observability/datasource_retrieval";
 import { fetchDatasourceRetrievalMetrics } from "@app/lib/api/assistant/observability/datasource_retrieval";
+import type { PokeGetDatasourceRetrievalResponse } from "@app/lib/api/poke/agent_configurations";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -15,11 +15,6 @@ const QuerySchema = z.object({
 const ParamsSchema = z.object({
   aId: z.string(),
 });
-
-export type PokeGetDatasourceRetrievalResponse = {
-  datasources: DatasourceRetrievalData[];
-  total: number;
-};
 
 // Mounted at /api/poke/workspaces/:wId/agent_configurations/:aId/observability/datasource-retrieval.
 const app = pokeApp();

--- a/front-api/routes/poke/workspaces/[wId]/agent_configurations/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/agent_configurations/index.ts
@@ -1,7 +1,9 @@
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import { getAuthors } from "@app/lib/api/assistant/editors";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
-import type { UserType } from "@app/types/user";
+import type {
+  PokeAgentConfigurationType,
+  PokeGetAgentConfigurationsResponseBody,
+} from "@app/lib/api/poke/agent_configurations";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -9,14 +11,6 @@ import { z } from "zod";
 
 import agentId from "./[aId]";
 import importRoute from "./import";
-
-export type PokeAgentConfigurationType = LightAgentConfigurationType & {
-  versionAuthor?: UserType | null;
-};
-
-export type PokeGetAgentConfigurationsResponseBody = {
-  agentConfigurations: PokeAgentConfigurationType[];
-};
 
 const ListAgentConfigurationsQuerySchema = z.object({
   view: z.enum(["admin_internal", "archived"]),

--- a/front-api/routes/poke/workspaces/[wId]/assistants/[aId]/suggestions.ts
+++ b/front-api/routes/poke/workspaces/[wId]/assistants/[aId]/suggestions.ts
@@ -1,13 +1,9 @@
+import type { PokeListSuggestions } from "@app/lib/api/poke/agent_configurations";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
-import type { AgentSuggestionType } from "@app/types/suggestions/agent_suggestion";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export type PokeListSuggestions = {
-  suggestions: AgentSuggestionType[];
-};
 
 const DeleteSuggestionQuerySchema = z.object({
   sId: z.string(),

--- a/front-api/routes/poke/workspaces/[wId]/data_source_views/[dsvId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_source_views/[dsvId]/details.ts
@@ -1,14 +1,10 @@
+import type { PokeGetDataSourceViewDetails } from "@app/lib/api/poke/data_source_views";
 import { dataSourceViewToPokeJSON } from "@app/lib/poke/utils";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
-import type { PokeDataSourceViewType } from "@app/types/poke";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export type PokeGetDataSourceViewDetails = {
-  dataSourceView: PokeDataSourceViewType;
-};
 
 const ParamsSchema = z.object({
   dsvId: z.string(),

--- a/front-api/routes/poke/workspaces/[wId]/data_source_views/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_source_views/index.ts
@@ -1,18 +1,9 @@
 import { listDataSourceViewsWithUsage } from "@app/lib/api/data_source_view";
-import type { AgentsUsageType } from "@app/types/data_source";
-import type { DataSourceViewType } from "@app/types/data_source_view";
+import type { PokeListDataSourceViews } from "@app/lib/api/poke/data_source_views";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
 import dsvId from "./[dsvId]";
-
-export type DataSourceViewWithUsage = DataSourceViewType & {
-  usage: AgentsUsageType | null;
-};
-
-export type PokeListDataSourceViews = {
-  data_source_views: DataSourceViewWithUsage[];
-};
 
 // Mounted at /api/poke/workspaces/:wId/data_source_views.
 const app = pokeApp();

--- a/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/details.ts
@@ -1,16 +1,16 @@
 import config from "@app/lib/api/config";
+import type {
+  FeaturesType,
+  PokeGetDataSourceDetails,
+} from "@app/lib/api/poke/data_sources";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { getTemporalClientForConnectorsNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import type { InternalConnectorType } from "@app/types/connectors/connectors_api";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
-import type { SlackAutoReadPattern } from "@app/types/connectors/slack";
 import { isSlackAutoReadPatterns } from "@app/types/connectors/slack";
 import { CoreAPI } from "@app/types/core/core_api";
-import type { CoreAPIDataSource } from "@app/types/core/data_source";
-import type { DataSourceType } from "@app/types/data_source";
-import type { DataSourceViewType } from "@app/types/data_source_view";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
@@ -20,33 +20,6 @@ import { z } from "zod";
 const ParamsSchema = z.object({
   dsId: z.string(),
 });
-
-export type FeaturesType = {
-  slackBotEnabled: boolean;
-  googleDrivePdfEnabled: boolean;
-  googleDriveLargeFilesEnabled: boolean;
-  microsoftPdfEnabled: boolean;
-  microsoftLargeFilesEnabled: boolean;
-  googleDriveCsvEnabled: boolean;
-  microsoftCsvEnabled: boolean;
-  githubCodeSyncEnabled: boolean;
-  githubUseProxyEnabled: boolean;
-  autoReadChannelPatterns: SlackAutoReadPattern[];
-};
-
-export type PokeGetDataSourceDetails = {
-  dataSource: DataSourceType;
-  dataSourceViews: DataSourceViewType[];
-  coreDataSource: CoreAPIDataSource;
-  connector: InternalConnectorType | null;
-  features: FeaturesType;
-  temporalWorkspace: string;
-  temporalRunningWorkflows: {
-    workflowId: string;
-    runId: string;
-    status: string;
-  }[];
-};
 
 // Mounted at /api/poke/workspaces/:wId/data_sources/:dsId/details.
 const app = pokeApp();

--- a/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/document.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/document.ts
@@ -1,16 +1,12 @@
 import config from "@app/lib/api/config";
+import type { PokeGetDocument } from "@app/lib/api/poke/data_sources";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
 import { CoreAPI } from "@app/types/core/core_api";
-import type { CoreAPIDocument } from "@app/types/core/data_source";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export type PokeGetDocument = {
-  document: CoreAPIDocument;
-};
 
 const QuerySchema = z.object({
   documentId: z.string(),

--- a/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/documents/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/documents/index.ts
@@ -1,8 +1,8 @@
 import config from "@app/lib/api/config";
+import type { GetDocumentsResponseBody } from "@app/lib/api/poke/data_sources";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
 import { CoreAPI } from "@app/types/core/core_api";
-import type { DocumentType } from "@app/types/document";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -17,11 +17,6 @@ const ParamsSchema = z.object({
   dsId: z.string(),
 });
 
-export type PokeGetDocumentsResponseBody = {
-  documents: DocumentType[];
-  total: number;
-};
-
 // Mounted at /api/poke/workspaces/:wId/data_sources/:dsId/documents.
 const app = pokeApp();
 
@@ -29,7 +24,7 @@ app.get(
   "/",
   validate("param", ParamsSchema),
   validate("query", QuerySchema),
-  async (ctx): HandlerResult<PokeGetDocumentsResponseBody> => {
+  async (ctx): HandlerResult<GetDocumentsResponseBody> => {
     const auth = ctx.get("auth");
     const { dsId } = ctx.req.valid("param");
     const { limit, offset } = ctx.req.valid("query");

--- a/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/tables/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_sources/[dsId]/tables/index.ts
@@ -1,17 +1,12 @@
 import config from "@app/lib/api/config";
+import type { GetTablesResponseBody } from "@app/lib/api/poke/data_sources";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
-import type { CoreAPITable } from "@app/types/core/core_api";
 import { CoreAPI } from "@app/types/core/core_api";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export type GetTablesResponseBody = {
-  tables: Array<CoreAPITable>;
-  total: number;
-};
 
 const QuerySchema = z.object({
   limit: z.coerce.number().int().nonnegative().optional().default(10),

--- a/front-api/routes/poke/workspaces/[wId]/data_sources/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_sources/index.ts
@@ -1,13 +1,9 @@
+import type { PokeListDataSources } from "@app/lib/api/poke/data_sources";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import type { DataSourceType } from "@app/types/data_source";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
 import dsId from "./[dsId]";
-
-export type PokeListDataSources = {
-  data_sources: DataSourceType[];
-};
 
 // Mounted at /api/poke/workspaces/:wId/data_sources.
 const app = pokeApp();

--- a/front-api/routes/poke/workspaces/[wId]/skill_suggestions/[suggestionId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skill_suggestions/[suggestionId]/details.ts
@@ -1,16 +1,10 @@
+import type { PokeGetSkillSuggestionDetails } from "@app/lib/api/poke/skills";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
-import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export type PokeGetSkillSuggestionDetails = {
-  suggestion: SkillSuggestionType;
-  skillInstructionsHtml: string | null;
-  skillAgentFacingDescription: string | null;
-};
 
 const ParamsSchema = z.object({
   suggestionId: z.string(),

--- a/front-api/routes/poke/workspaces/[wId]/skills/[sId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/[sId]/details.ts
@@ -1,18 +1,10 @@
+import type { PokeGetSkillDetails } from "@app/lib/api/poke/skills";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
-import type { SpaceType } from "@app/types/space";
-import type { UserType } from "@app/types/user";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export type PokeGetSkillDetails = {
-  skill: SkillType;
-  editedByUser: UserType | null;
-  spaces: SpaceType[];
-};
 
 const ParamsSchema = z.object({
   sId: z.string(),

--- a/front-api/routes/poke/workspaces/[wId]/skills/[sId]/suggestions.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/[sId]/suggestions.ts
@@ -1,14 +1,10 @@
+import type { PokeListSkillSuggestions } from "@app/lib/api/poke/skills";
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
-import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
 import { SKILL_SUGGESTION_SOURCES } from "@app/types/suggestions/skill_suggestion";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export type PokeListSkillSuggestions = {
-  suggestions: SkillSuggestionType[];
-};
 
 const DeleteSuggestionQuerySchema = z.object({
   suggestionSId: z.string(),

--- a/front-api/routes/poke/workspaces/[wId]/skills/[sId]/versions.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/[sId]/versions.ts
@@ -1,13 +1,9 @@
+import type { PokeGetSkillVersions } from "@app/lib/api/poke/skills";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import type { SkillWithVersionType } from "@app/types/assistant/skill_configuration";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export type PokeGetSkillVersions = {
-  versions: SkillWithVersionType[];
-};
 
 const ParamsSchema = z.object({
   sId: z.string(),

--- a/front-api/routes/poke/workspaces/[wId]/skills/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/index.ts
@@ -1,14 +1,10 @@
+import type { GetPokeSkillsResponseBody } from "@app/lib/api/poke/skills";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
 import sId from "./[sId]";
 import suggestions from "./suggestions";
-
-export type GetPokeSkillsResponseBody = {
-  skills: SkillType[];
-};
 
 // Mounted at /api/poke/workspaces/:wId/skills.
 const app = pokeApp();

--- a/front-api/routes/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front-api/routes/poke/workspaces/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
@@ -1,8 +1,8 @@
 import { getContentNodesForDataSourceView } from "@app/lib/api/data_source_view";
 import { getCursorPaginationParams } from "@app/lib/api/pagination";
+import type { PokeGetDataSourceViewContentNodes } from "@app/lib/api/poke/data_source_views";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { ContentNodesViewTypeCodec } from "@app/types/connectors/content_nodes";
-import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
@@ -31,13 +31,6 @@ const ParamsSchema = z.object({
   dsvId: z.string(),
   spaceId: z.string(),
 });
-
-export type PokeGetDataSourceViewContentNodes = {
-  nodes: DataSourceViewContentNode[];
-  total: number;
-  totalIsAccurate: boolean;
-  nextPageCursor: string | null;
-};
 
 // Mounted at /api/poke/workspaces/:wId/spaces/:spaceId/data_source_views/:dsvId/content-nodes.
 const app = pokeApp();

--- a/front-api/routes/poke/workspaces/[wId]/spaces/[spaceId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/spaces/[spaceId]/details.ts
@@ -1,20 +1,13 @@
+import type { PokeGetSpaceDetails } from "@app/lib/api/poke/spaces";
 import { getMembers } from "@app/lib/api/workspace";
 import { spaceToPokeJSON } from "@app/lib/poke/utils";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import type { PokeSpaceType } from "@app/types/poke";
-import type { PodMetadataType } from "@app/types/project_metadata";
 import type { UserTypeWithWorkspaces } from "@app/types/user";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export type PokeGetSpaceDetails = {
-  members: Record<string, UserTypeWithWorkspaces[]>;
-  metadata: PodMetadataType | null;
-  space: PokeSpaceType;
-};
 
 const ParamsSchema = z.object({
   spaceId: z.string(),

--- a/front-api/routes/poke/workspaces/[wId]/spaces/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/spaces/index.ts
@@ -1,13 +1,9 @@
+import type { PokeListSpaces } from "@app/lib/api/poke/spaces";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import type { SpaceType } from "@app/types/space";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
 import spaceId from "./[spaceId]";
-
-export type PokeListSpaces = {
-  spaces: SpaceType[];
-};
 
 // Mounted at /api/poke/workspaces/:wId/spaces.
 const app = pokeApp();

--- a/front/components/poke/assistants/columns.tsx
+++ b/front/components/poke/assistants/columns.tsx
@@ -1,8 +1,8 @@
 import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
 import config from "@app/lib/api/config";
+import type { PokeAgentConfigurationType } from "@app/lib/api/poke/agent_configurations";
 import { clientFetch } from "@app/lib/egress/client";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
-import type { PokeAgentConfigurationType } from "@app/pages/api/poke/workspaces/[wId]/agent_configurations";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Download01,

--- a/front/components/poke/assistants/table.tsx
+++ b/front/components/poke/assistants/table.tsx
@@ -1,11 +1,11 @@
 import { makeColumnsForAssistants } from "@app/components/poke/assistants/columns";
 import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
+import type { PokeAgentConfigurationType } from "@app/lib/api/poke/agent_configurations";
 import { clientFetch } from "@app/lib/egress/client";
 import type { AppRouter } from "@app/lib/platform";
 import { useAppRouter } from "@app/lib/platform";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
-import type { PokeAgentConfigurationType } from "@app/pages/api/poke/workspaces/[wId]/agent_configurations";
 import { usePokeAgentConfigurations } from "@app/poke/swr/agent_configurations";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { LightWorkspaceType } from "@app/types/user";

--- a/front/lib/api/poke/agent_configurations.ts
+++ b/front/lib/api/poke/agent_configurations.ts
@@ -1,0 +1,34 @@
+import type { DatasourceRetrievalData } from "@app/lib/api/assistant/observability/datasource_retrieval";
+import type {
+  AgentConfigurationType,
+  LightAgentConfigurationType,
+} from "@app/types/assistant/agent";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
+import type { SpaceType } from "@app/types/space";
+import type { AgentSuggestionType } from "@app/types/suggestions/agent_suggestion";
+import type { UserType } from "@app/types/user";
+
+export type PokeAgentConfigurationType = LightAgentConfigurationType & {
+  versionAuthor?: UserType | null;
+};
+
+export type PokeGetAgentConfigurationsResponseBody = {
+  agentConfigurations: PokeAgentConfigurationType[];
+};
+
+export type PokeGetAgentDetails = {
+  agentConfigurations: AgentConfigurationType[];
+  authors: UserType[];
+  lastVersionEditors: UserType[];
+  spaces: SpaceType[];
+  skillsByVersion: Record<number, SkillType[]>;
+};
+
+export type PokeGetDatasourceRetrievalResponse = {
+  datasources: DatasourceRetrievalData[];
+  total: number;
+};
+
+export type PokeListSuggestions = {
+  suggestions: AgentSuggestionType[];
+};

--- a/front/lib/api/poke/data_source_views.ts
+++ b/front/lib/api/poke/data_source_views.ts
@@ -1,13 +1,8 @@
-import type { AgentsUsageType } from "@app/types/data_source";
-import type {
-  DataSourceViewContentNode,
-  DataSourceViewType,
-} from "@app/types/data_source_view";
+import type { DataSourceViewWithUsage } from "@app/lib/api/data_source_view";
+import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import type { PokeDataSourceViewType } from "@app/types/poke";
 
-export type DataSourceViewWithUsage = DataSourceViewType & {
-  usage: AgentsUsageType | null;
-};
+export type { DataSourceViewWithUsage };
 
 export type PokeListDataSourceViews = {
   data_source_views: DataSourceViewWithUsage[];

--- a/front/lib/api/poke/skills.ts
+++ b/front/lib/api/poke/skills.ts
@@ -1,0 +1,43 @@
+import type {
+  SkillType,
+  SkillWithVersionType,
+} from "@app/types/assistant/skill_configuration";
+import type { SpaceType } from "@app/types/space";
+import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
+import type { UserType } from "@app/types/user";
+
+export type GetPokeSkillsResponseBody = {
+  skills: SkillType[];
+};
+
+// Request body for the poke skill-suggestion endpoint. The runtime validation schema lives with
+// its only consumer, the handler (front-api/routes/poke/workspaces/[wId]/skills/suggestions.ts);
+// this type only needs to describe the shape the client sends.
+export type PostSkillSuggestionBodyType = {
+  name: string;
+  userFacingDescription: string;
+  agentFacingDescription: string;
+  instructions: string;
+  icon: string | null;
+  mcpServerViewIds: string[];
+};
+
+export type PokeGetSkillDetails = {
+  skill: SkillType;
+  editedByUser: UserType | null;
+  spaces: SpaceType[];
+};
+
+export type PokeGetSkillVersions = {
+  versions: SkillWithVersionType[];
+};
+
+export type PokeListSkillSuggestions = {
+  suggestions: SkillSuggestionType[];
+};
+
+export type PokeGetSkillSuggestionDetails = {
+  suggestion: SkillSuggestionType;
+  skillInstructionsHtml: string | null;
+  skillAgentFacingDescription: string | null;
+};

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
@@ -3,27 +3,17 @@
 import { listsAgentConfigurationVersions } from "@app/lib/api/assistant/configuration/agent";
 import { getAuthors, getEditors } from "@app/lib/api/assistant/editors";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { PokeGetAgentDetails } from "@app/lib/api/poke/agent_configurations";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import { isGlobalAgentId } from "@app/types/assistant/assistant";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
-import type { SpaceType } from "@app/types/space";
-import type { UserType } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeGetAgentDetails = {
-  agentConfigurations: AgentConfigurationType[];
-  authors: UserType[];
-  lastVersionEditors: UserType[];
-  spaces: SpaceType[];
-  skillsByVersion: Record<number, SkillType[]>;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/observability/datasource-retrieval.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/observability/datasource-retrieval.ts
@@ -2,9 +2,9 @@
 // @migration-status: MIGRATED_TO_HONO
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import type { DatasourceRetrievalData } from "@app/lib/api/assistant/observability/datasource_retrieval";
 import { fetchDatasourceRetrievalMetrics } from "@app/lib/api/assistant/observability/datasource_retrieval";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { PokeGetDatasourceRetrievalResponse } from "@app/lib/api/poke/agent_configurations";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
@@ -17,11 +17,6 @@ import { fromError } from "zod-validation-error";
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
 });
-
-export type PokeGetDatasourceRetrievalResponse = {
-  datasources: DatasourceRetrievalData[];
-  total: number;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/index.ts
@@ -3,23 +3,17 @@
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import { getAuthors } from "@app/lib/api/assistant/editors";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type {
+  PokeAgentConfigurationType,
+  PokeGetAgentConfigurationsResponseBody,
+} from "@app/lib/api/poke/agent_configurations";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { UserType } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export type PokeAgentConfigurationType = LightAgentConfigurationType & {
-  versionAuthor?: UserType | null;
-};
-
-export type PokeGetAgentConfigurationsResponseBody = {
-  agentConfigurations: PokeAgentConfigurationType[];
-};
 
 const GetAgentConfigurationsQuerySchema = z.object({
   view: z.enum(["admin_internal", "archived"]),

--- a/front/pages/api/poke/workspaces/[wId]/assistants/[aId]/suggestions.ts
+++ b/front/pages/api/poke/workspaces/[wId]/assistants/[aId]/suggestions.ts
@@ -1,18 +1,14 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { PokeListSuggestions } from "@app/lib/api/poke/agent_configurations";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
-import type { AgentSuggestionType } from "@app/types/suggestions/agent_suggestion";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeListSuggestions = {
-  suggestions: AgentSuggestionType[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/skill_suggestions/[suggestionId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skill_suggestions/[suggestionId]/details.ts
@@ -1,6 +1,7 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { PokeGetSkillSuggestionDetails } from "@app/lib/api/poke/skills";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -8,14 +9,7 @@ import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_res
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
-import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeGetSkillSuggestionDetails = {
-  suggestion: SkillSuggestionType;
-  skillInstructionsHtml: string | null;
-  skillAgentFacingDescription: string | null;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/skills/[sId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skills/[sId]/details.ts
@@ -1,22 +1,14 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { PokeGetSkillDetails } from "@app/lib/api/poke/skills";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { SpaceType } from "@app/types/space";
-import type { UserType } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeGetSkillDetails = {
-  skill: SkillType;
-  editedByUser: UserType | null;
-  spaces: SpaceType[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/skills/[sId]/suggestions.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skills/[sId]/suggestions.ts
@@ -1,19 +1,15 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { PokeListSkillSuggestions } from "@app/lib/api/poke/skills";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
-import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
 import { SKILL_SUGGESTION_SOURCES } from "@app/types/suggestions/skill_suggestion";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeListSkillSuggestions = {
-  suggestions: SkillSuggestionType[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/skills/[sId]/versions.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skills/[sId]/versions.ts
@@ -1,18 +1,14 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { PokeGetSkillVersions } from "@app/lib/api/poke/skills";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { SkillWithVersionType } from "@app/types/assistant/skill_configuration";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeGetSkillVersions = {
-  versions: SkillWithVersionType[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/skills/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skills/index.ts
@@ -1,18 +1,14 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { GetPokeSkillsResponseBody } from "@app/lib/api/poke/skills";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetPokeSkillsResponseBody = {
-  skills: SkillType[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/skills/suggestions.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skills/suggestions.ts
@@ -27,10 +27,6 @@ const PostSkillSuggestionBodySchema = z.object({
   mcpServerViewIds: z.array(z.string()),
 });
 
-export type PostSkillSuggestionBodyType = z.infer<
-  typeof PostSkillSuggestionBodySchema
->;
-
 export type PostPokeSkillSuggestionResponseBody = {
   skill: SkillType;
 };

--- a/front/poke/swr/agent_configurations.ts
+++ b/front/poke/swr/agent_configurations.ts
@@ -1,5 +1,5 @@
+import type { PokeGetAgentConfigurationsResponseBody } from "@app/lib/api/poke/agent_configurations";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeGetAgentConfigurationsResponseBody } from "@app/pages/api/poke/workspaces/[wId]/agent_configurations";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/agent_details.ts
+++ b/front/poke/swr/agent_details.ts
@@ -1,7 +1,9 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import type {
+  PokeGetAgentDetails,
+  PokeGetDatasourceRetrievalResponse,
+} from "@app/lib/api/poke/agent_configurations";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeGetAgentDetails } from "@app/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/details";
-import type { PokeGetDatasourceRetrievalResponse } from "@app/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/observability/datasource-retrieval";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/skill_details.ts
+++ b/front/poke/swr/skill_details.ts
@@ -1,6 +1,8 @@
+import type {
+  PokeGetSkillDetails,
+  PokeGetSkillVersions,
+} from "@app/lib/api/poke/skills";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeGetSkillDetails } from "@app/pages/api/poke/workspaces/[wId]/skills/[sId]/details";
-import type { PokeGetSkillVersions } from "@app/pages/api/poke/workspaces/[wId]/skills/[sId]/versions";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/skill_suggestion_details.ts
+++ b/front/poke/swr/skill_suggestion_details.ts
@@ -1,5 +1,5 @@
+import type { PokeGetSkillSuggestionDetails } from "@app/lib/api/poke/skills";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeGetSkillSuggestionDetails } from "@app/pages/api/poke/workspaces/[wId]/skill_suggestions/[suggestionId]/details";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/skill_suggestions.ts
+++ b/front/poke/swr/skill_suggestions.ts
@@ -1,5 +1,5 @@
+import type { PokeListSkillSuggestions } from "@app/lib/api/poke/skills";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeListSkillSuggestions } from "@app/pages/api/poke/workspaces/[wId]/skills/[sId]/suggestions";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/skills.ts
+++ b/front/poke/swr/skills.ts
@@ -1,4 +1,8 @@
 import { useSendNotification } from "@app/hooks/useNotification";
+import type {
+  GetPokeSkillsResponseBody,
+  PostSkillSuggestionBodyType,
+} from "@app/lib/api/poke/skills";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   emptyArray,
@@ -6,8 +10,6 @@ import {
   useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
-import type { GetPokeSkillsResponseBody } from "@app/pages/api/poke/workspaces/[wId]/skills";
-import type { PostSkillSuggestionBodyType } from "@app/pages/api/poke/workspaces/[wId]/skills/suggestions";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";

--- a/front/poke/swr/suggestions.ts
+++ b/front/poke/swr/suggestions.ts
@@ -1,5 +1,5 @@
+import type { PokeListSuggestions } from "@app/lib/api/poke/agent_configurations";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeListSuggestions } from "@app/pages/api/poke/workspaces/[wId]/assistants/[aId]/suggestions";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
 


### PR DESCRIPTION
  Description

  ## What & why

  Continues the removal of `front/pages/api` (Next) in favor of Hono. This is the
  second poke sub-round, covering poke **agents & skills** (agent configurations,
  skills, skill suggestions, assistant suggestions).
  under `lib/api/poke` that both the Next handler and the consumers import from.

  This batch is **type-only** — no runtime values are moved into `lib/api` (see
  the schema note below) — so there is no behavior change.

  ## Changes

  New neutral modules and the types moved into them:

  | New module | Types |
  |---|---|
  | `lib/api/poke/agent_configurations.ts` | `PokeAgentConfigurationType`, `PokeGetAgentConfigurationsResponseBody`, `PokeGetAgentDetails`, `PokeGetDatasourceRetrievalResponse`, `PokeListSuggestions` |
  | `lib/api/poke/skills.ts` | `GetPokeSkillsResponseBody`, `PostSkillSuggestionBodyType`, `PokeGetSkillDetails`, `PokeGetSkillVersions`, `PokeListSkillSuggestions`, `PokeGetSkillSuggestionDetails` |

  - 10 poke pages under `pages/api/poke/workspaces/[wId]/{agent_configurations,skills,skill_suggestions,assistants}/*`
    now import their contracts from the new modules, dropping the dependency
    imports that only existed to build the type defs.
  - 12 consumer imports across `front/poke/swr/*` and
    `front/components/poke/assistants/*` repointed at the new modules. Biome
    merged the now-duplicate imports.
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
