### PR TITLE
[Skill Builder] Move spaces under instructions

### DIFF
--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -229,11 +229,11 @@ export default function SkillBuilder({
               specific needs before saving.
             </ContentMessage>
           )}
+          <SkillBuilderAgentFacingDescriptionSection />
+          <SkillBuilderInstructionsSection />
           <SkillBuilderRequestedSpacesSection
             initialRequestedSpaceIds={skill?.requestedSpaceIds}
           />
-          <SkillBuilderAgentFacingDescriptionSection />
-          <SkillBuilderInstructionsSection />
           {hasFeature("sandbox_tools") && <SkillBuilderFilesSection />}
           {!enableSkillReferences && (
             <SkillBuilderToolsSection extendedSkill={extendedSkill} />

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -236,7 +236,9 @@ export function SkillBuilderRequestedSpacesSection({
             Spaces and Pods
           </h3>
           <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-            Set what knowledge and capabilities the skill can access.
+            Choose which spaces and Pods this skill can access. The skill can
+            use their knowledge and capabilities, and only users with access to
+            all selected spaces and Pods can use it.
           </p>
         </div>
         <Button
@@ -250,9 +252,9 @@ export function SkillBuilderRequestedSpacesSection({
       {nonGlobalSpacesWithRestrictions.length > 0 && (
         <div className="mb-4 w-full">
           <ContentMessage variant="golden" size="lg">
-            Based on your selection of spaces, Pods, knowledge, and
-            capabilities, this skill can only be used by users with access
-            to:&nbsp;
+            This skill can access knowledge and capabilities from these spaces
+            and Pods, and only users with access to all of them can use
+            it:&nbsp;
             <strong>
               {nonGlobalSpacesWithRestrictions
                 .map((space) => space.name)


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8610
Follows https://github.com/dust-tt/dust/pull/26606

Moves the Skill Builder Spaces and Pods section below Instructions to match Agent Builder placement.

Updates the spaces copy to explain that selected spaces and Pods define both what knowledge and capabilities the skill can access and which users can use it.

## Risks

Blast radius: Skill Builder spaces section placement and explanatory copy.
Risk: low

## Deploy Plan
- pmrr
- deploy front
