### PR TITLE
[front] refactor: extract shared timezone lib

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/analytics/active-users.ts
+++ b/front-api/routes/poke/workspaces/[wId]/analytics/active-users.ts
@@ -1,10 +1,8 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type { ActiveUsersMetricsPoint } from "@app/lib/api/assistant/observability/active_users_metrics";
 import { fetchActiveUsersMetrics } from "@app/lib/api/assistant/observability/active_users_metrics";
-import {
-  daysToDateRange,
-  timezoneSchema,
-} from "@app/lib/api/assistant/observability/utils";
+import { daysToDateRange } from "@app/lib/api/assistant/observability/utils";
+import { timezoneSchema } from "@app/lib/api/timezone";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";

--- a/front-api/routes/poke/workspaces/[wId]/analytics/usage-metrics.ts
+++ b/front-api/routes/poke/workspaces/[wId]/analytics/usage-metrics.ts
@@ -4,10 +4,8 @@ import type {
   UsageMetricsInterval,
 } from "@app/lib/api/assistant/observability/messages_metrics";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
-import {
-  buildAgentAnalyticsBaseQuery,
-  timezoneSchema,
-} from "@app/lib/api/assistant/observability/utils";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { timezoneSchema } from "@app/lib/api/timezone";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";

--- a/front-api/routes/w/[wId]/analytics/active-users.ts
+++ b/front-api/routes/w/[wId]/analytics/active-users.ts
@@ -1,10 +1,8 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type { ActiveUsersMetricsPoint } from "@app/lib/api/assistant/observability/active_users_metrics";
 import { fetchActiveUsersMetrics } from "@app/lib/api/assistant/observability/active_users_metrics";
-import {
-  daysToDateRange,
-  timezoneSchema,
-} from "@app/lib/api/assistant/observability/utils";
+import { daysToDateRange } from "@app/lib/api/assistant/observability/utils";
+import { timezoneSchema } from "@app/lib/api/timezone";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/analytics/skill-usage.ts
+++ b/front-api/routes/w/[wId]/analytics/skill-usage.ts
@@ -1,10 +1,8 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type { SkillUsagePoint } from "@app/lib/api/assistant/observability/skill_usage";
 import { fetchSkillUsageMetrics } from "@app/lib/api/assistant/observability/skill_usage";
-import {
-  buildAgentAnalyticsBaseQuery,
-  timezoneSchema,
-} from "@app/lib/api/assistant/observability/utils";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { timezoneSchema } from "@app/lib/api/timezone";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/analytics/tool-usage.ts
+++ b/front-api/routes/w/[wId]/analytics/tool-usage.ts
@@ -1,10 +1,8 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type { ToolUsagePoint } from "@app/lib/api/assistant/observability/tool_usage";
 import { fetchToolUsageMetrics } from "@app/lib/api/assistant/observability/tool_usage";
-import {
-  buildAgentAnalyticsBaseQuery,
-  timezoneSchema,
-} from "@app/lib/api/assistant/observability/utils";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { timezoneSchema } from "@app/lib/api/timezone";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/analytics/usage-metrics.ts
+++ b/front-api/routes/w/[wId]/analytics/usage-metrics.ts
@@ -4,10 +4,8 @@ import type {
   UsageMetricsInterval,
 } from "@app/lib/api/assistant/observability/messages_metrics";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
-import {
-  buildAgentAnalyticsBaseQuery,
-  timezoneSchema,
-} from "@app/lib/api/assistant/observability/utils";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { timezoneSchema } from "@app/lib/api/timezone";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/analytics/users-export.ts
+++ b/front-api/routes/w/[wId]/analytics/users-export.ts
@@ -6,8 +6,8 @@ import {
 import {
   buildAgentAnalyticsBaseQuery,
   daysToDateRange,
-  timezoneSchema,
 } from "@app/lib/api/assistant/observability/utils";
+import { timezoneSchema } from "@app/lib/api/timezone";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/error_rate.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/error_rate.ts
@@ -1,10 +1,8 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
-import {
-  buildAgentAnalyticsBaseQuery,
-  timezoneSchema,
-} from "@app/lib/api/assistant/observability/utils";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { timezoneSchema } from "@app/lib/api/timezone";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/latency.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/latency.ts
@@ -1,10 +1,8 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
-import {
-  buildAgentAnalyticsBaseQuery,
-  timezoneSchema,
-} from "@app/lib/api/assistant/observability/utils";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { timezoneSchema } from "@app/lib/api/timezone";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics.ts
@@ -1,10 +1,8 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
-import {
-  buildAgentAnalyticsBaseQuery,
-  timezoneSchema,
-} from "@app/lib/api/assistant/observability/utils";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { timezoneSchema } from "@app/lib/api/timezone";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";

--- a/front/lib/api/actions/servers/workspace_analytics/query_input.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/query_input.ts
@@ -1,4 +1,4 @@
-import { timezoneSchema } from "@app/lib/api/assistant/observability/utils";
+import { isValidTimezone, timezoneSchema } from "@app/lib/api/timezone";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -88,7 +88,7 @@ export function resolveTimeWindow(
   defaultPeriod: AnalyticsPeriod = "this_month"
 ): Result<ResolvedTimeWindow, string> {
   const timezone = input.timezone ?? "UTC";
-  if (!moment.tz.zone(timezone)) {
+  if (!isValidTimezone(timezone)) {
     return new Err(`Invalid timezone: ${timezone}`);
   }
 

--- a/front/lib/api/assistant/observability/utils.ts
+++ b/front/lib/api/assistant/observability/utils.ts
@@ -1,17 +1,6 @@
 import { contextOriginFilter } from "@app/lib/api/assistant/observability/context_origin";
 import type { estypes } from "@elastic/elasticsearch";
 import moment from "moment-timezone";
-import { z } from "zod";
-
-const VALID_TIMEZONES = new Set(moment.tz.names());
-
-export const timezoneSchema = z
-  .string()
-  .optional()
-  .default("UTC")
-  .refine((tz) => VALID_TIMEZONES.has(tz), {
-    message: "Invalid IANA timezone",
-  });
 
 export function daysToDateRange(
   days: number,

--- a/front/lib/api/timezone.test.ts
+++ b/front/lib/api/timezone.test.ts
@@ -1,0 +1,30 @@
+import { isValidTimezone, timezoneSchema } from "@app/lib/api/timezone";
+import { describe, expect, it } from "vitest";
+
+describe("isValidTimezone", () => {
+  it("accepts valid IANA timezones", () => {
+    expect(isValidTimezone("UTC")).toBe(true);
+    expect(isValidTimezone("Europe/Paris")).toBe(true);
+    expect(isValidTimezone("America/New_York")).toBe(true);
+  });
+
+  it("rejects invalid or empty timezones", () => {
+    expect(isValidTimezone("Not/AZone")).toBe(false);
+    expect(isValidTimezone("")).toBe(false);
+    expect(isValidTimezone("utc")).toBe(false);
+  });
+});
+
+describe("timezoneSchema", () => {
+  it("defaults to UTC when omitted", () => {
+    expect(timezoneSchema.parse(undefined)).toBe("UTC");
+  });
+
+  it("passes through a valid timezone", () => {
+    expect(timezoneSchema.parse("Europe/Paris")).toBe("Europe/Paris");
+  });
+
+  it("rejects an invalid timezone", () => {
+    expect(timezoneSchema.safeParse("Not/AZone").success).toBe(false);
+  });
+});

--- a/front/lib/api/timezone.ts
+++ b/front/lib/api/timezone.ts
@@ -1,0 +1,16 @@
+import moment from "moment-timezone";
+import { z } from "zod";
+
+const VALID_TIMEZONES = new Set(moment.tz.names());
+
+export function isValidTimezone(timezone: string): boolean {
+  return VALID_TIMEZONES.has(timezone);
+}
+
+export const timezoneSchema = z
+  .string()
+  .optional()
+  .default("UTC")
+  .refine((timezone) => isValidTimezone(timezone), {
+    message: "Invalid IANA timezone",
+  });

--- a/front/pages/api/poke/workspaces/[wId]/analytics/active-users.ts
+++ b/front/pages/api/poke/workspaces/[wId]/analytics/active-users.ts
@@ -2,11 +2,9 @@
 // @migration-status: MIGRATED_TO_HONO
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { fetchActiveUsersMetrics } from "@app/lib/api/assistant/observability/active_users_metrics";
-import {
-  daysToDateRange,
-  timezoneSchema,
-} from "@app/lib/api/assistant/observability/utils";
+import { daysToDateRange } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { timezoneSchema } from "@app/lib/api/timezone";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";

--- a/front/pages/api/poke/workspaces/[wId]/analytics/usage-metrics.ts
+++ b/front/pages/api/poke/workspaces/[wId]/analytics/usage-metrics.ts
@@ -2,11 +2,9 @@
 // @migration-status: MIGRATED_TO_HONO
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
-import {
-  buildAgentAnalyticsBaseQuery,
-  timezoneSchema,
-} from "@app/lib/api/assistant/observability/utils";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { timezoneSchema } from "@app/lib/api/timezone";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";

--- a/front/pages/api/w/[wId]/analytics/active-users.ts
+++ b/front/pages/api/w/[wId]/analytics/active-users.ts
@@ -4,11 +4,9 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type { ActiveUsersMetricsPoint } from "@app/lib/api/assistant/observability/active_users_metrics";
 import { fetchActiveUsersMetrics } from "@app/lib/api/assistant/observability/active_users_metrics";
-import {
-  daysToDateRange,
-  timezoneSchema,
-} from "@app/lib/api/assistant/observability/utils";
+import { daysToDateRange } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { timezoneSchema } from "@app/lib/api/timezone";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";

--- a/front/pages/api/w/[wId]/analytics/skill-usage.ts
+++ b/front/pages/api/w/[wId]/analytics/skill-usage.ts
@@ -4,11 +4,9 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type { SkillUsagePoint } from "@app/lib/api/assistant/observability/skill_usage";
 import { fetchSkillUsageMetrics } from "@app/lib/api/assistant/observability/skill_usage";
-import {
-  buildAgentAnalyticsBaseQuery,
-  timezoneSchema,
-} from "@app/lib/api/assistant/observability/utils";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { timezoneSchema } from "@app/lib/api/timezone";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";

--- a/front/pages/api/w/[wId]/analytics/tool-usage.ts
+++ b/front/pages/api/w/[wId]/analytics/tool-usage.ts
@@ -4,11 +4,9 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type { ToolUsagePoint } from "@app/lib/api/assistant/observability/tool_usage";
 import { fetchToolUsageMetrics } from "@app/lib/api/assistant/observability/tool_usage";
-import {
-  buildAgentAnalyticsBaseQuery,
-  timezoneSchema,
-} from "@app/lib/api/assistant/observability/utils";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { timezoneSchema } from "@app/lib/api/timezone";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";

--- a/front/pages/api/w/[wId]/analytics/usage-metrics.ts
+++ b/front/pages/api/w/[wId]/analytics/usage-metrics.ts
@@ -7,11 +7,9 @@ import type {
   UsageMetricsInterval,
 } from "@app/lib/api/assistant/observability/messages_metrics";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
-import {
-  buildAgentAnalyticsBaseQuery,
-  timezoneSchema,
-} from "@app/lib/api/assistant/observability/utils";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { timezoneSchema } from "@app/lib/api/timezone";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";

--- a/front/pages/api/w/[wId]/analytics/users-export.ts
+++ b/front/pages/api/w/[wId]/analytics/users-export.ts
@@ -9,9 +9,9 @@ import {
 import {
   buildAgentAnalyticsBaseQuery,
   daysToDateRange,
-  timezoneSchema,
 } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { timezoneSchema } from "@app/lib/api/timezone";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/error_rate.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/error_rate.ts
@@ -4,11 +4,9 @@ import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type { MessageMetricsPoint } from "@app/lib/api/assistant/observability/messages_metrics";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
-import {
-  buildAgentAnalyticsBaseQuery,
-  timezoneSchema,
-} from "@app/lib/api/assistant/observability/utils";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { timezoneSchema } from "@app/lib/api/timezone";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/latency.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/latency.ts
@@ -4,11 +4,9 @@ import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type { MessageMetricsPoint } from "@app/lib/api/assistant/observability/messages_metrics";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
-import {
-  buildAgentAnalyticsBaseQuery,
-  timezoneSchema,
-} from "@app/lib/api/assistant/observability/utils";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { timezoneSchema } from "@app/lib/api/timezone";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics.ts
@@ -7,11 +7,9 @@ import type {
   UsageMetricsInterval,
 } from "@app/lib/api/assistant/observability/messages_metrics";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
-import {
-  buildAgentAnalyticsBaseQuery,
-  timezoneSchema,
-} from "@app/lib/api/assistant/observability/utils";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { timezoneSchema } from "@app/lib/api/timezone";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";


### PR DESCRIPTION
## Description

Move timezoneSchema out of observability/utils.ts into a dedicated leaf module lib/api/timezone.ts and add isValidTimezone, so timezone validation has a single source of truth. The zod schema's refine and any runtime check now share the same VALID_TIMEZONES set and can't drift.

Repoint all front analytics/observability callers and their front-api Hono mirrors to @app/lib/api/timezone, and use isValidTimezone in the workspace analytics resolveTimeWindow runtime guard. Add unit tests for the new module.

## Tests

Add a few unit tests on lib/api/timezone.ts

## Risk

None
## Deploy Plan

front