### PR TITLE
Hide banner for seat-based plans

### DIFF
--- a/front-api/routes/w/[wId]/metronome/contract.test.ts
+++ b/front-api/routes/w/[wId]/metronome/contract.test.ts
@@ -126,6 +126,7 @@ describe("/api/w/[wId]/metronome/contract", () => {
           mauTiers: null,
           contractEndingAtMs: new Date("2025-05-01T00:00:00.000Z").getTime(),
           hasSeatSubscription: false,
+          hasPersonalCreditSeats: false,
         },
       });
       expect(vi.mocked(getMetronomeContractById)).toHaveBeenCalledWith({

--- a/front/components/navigation/AppStatusBanner.tsx
+++ b/front/components/navigation/AppStatusBanner.tsx
@@ -7,6 +7,7 @@ import {
 } from "@app/lib/plans/plan_codes";
 import { useAppStatus } from "@app/lib/swr/useAppStatus";
 import { useWorkspaceUsageStatus } from "@app/lib/swr/user";
+import { useMetronomeContract } from "@app/lib/swr/workspaces";
 import { DEFAULT_EMBEDDING_PROVIDER_ID } from "@app/types/assistant/models/embedding";
 import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
 import type { SubscriptionType } from "@app/types/plan";
@@ -217,7 +218,23 @@ function UsageStatusBanner({ owner }: UsageStatusBannerProps) {
   // blocked) or when it has run into pay-as-you-go overage.
   const isPoolDepleted = poolCreditState === "depleted";
   const isPoolOverage = poolCreditState === "overage";
-  const showPoolBanner = isAdmin(owner) && (isPoolDepleted || isPoolOverage);
+
+  // When the contract sells seats that carry personal credits (pro/max/free),
+  // those users spend their own credits before the shared pool and keep working
+  // even when the pool is depleted/in overage (mirrors the personal-seat
+  // carve-out in `isUserBlocked`). The pool banner's "out of credits / agents
+  // blocked" message would be misleading there, so we suppress it. Only fetch
+  // the contract (a Metronome API call) when the banner would otherwise show.
+  const poolStateWouldBanner =
+    isAdmin(owner) && (isPoolDepleted || isPoolOverage);
+  const { contract, isMetronomeContractLoading } = useMetronomeContract({
+    workspaceId: owner.sId,
+    disabled: !poolStateWouldBanner,
+  });
+  const showPoolBanner =
+    poolStateWouldBanner &&
+    !isMetronomeContractLoading &&
+    !contract?.hasPersonalCreditSeats;
   const showAwuBanner = awuStatus !== "normal";
   const showProgrammaticBanner =
     isAdmin(owner) && programmaticCreditStatus !== "active";

--- a/front/lib/api/credits/metronome_contract.ts
+++ b/front/lib/api/credits/metronome_contract.ts
@@ -87,18 +87,25 @@ export async function getMetronomeContractSummary(
     ? new Date(contract.ending_before).getTime()
     : null;
 
-  const productSeatTypes = await getProductSeatTypes();
-  const soldSeatTypes = getSeatSubscriptionsFromContract(
-    contract,
-    productSeatTypes
-  );
-  const hasPersonalCreditSeats = [...soldSeatTypes.keys()].some(isSeatBased);
+  // `hasContractSeatSubscription` short-circuits on MAU/seat-less contracts
+  // before touching the product map; only resolve seat types (and the cached
+  // product map) when the contract actually sells seats.
+  const hasSeatSubscription = await hasContractSeatSubscription(contract);
+  let hasPersonalCreditSeats = false;
+  if (hasSeatSubscription) {
+    const productSeatTypes = await getProductSeatTypes();
+    const soldSeatTypes = getSeatSubscriptionsFromContract(
+      contract,
+      productSeatTypes
+    );
+    hasPersonalCreditSeats = [...soldSeatTypes.keys()].some(isSeatBased);
+  }
 
   return new Ok({
     planFamily,
     mauTiers,
     contractEndingAtMs,
-    hasSeatSubscription: await hasContractSeatSubscription(contract),
+    hasSeatSubscription,
     hasPersonalCreditSeats,
   });
 }

--- a/front/lib/api/credits/metronome_contract.ts
+++ b/front/lib/api/credits/metronome_contract.ts
@@ -6,8 +6,13 @@ import {
   reactivateWorkspaceContract,
 } from "@app/lib/metronome/contract_lifecycle";
 import { parseMauTiers } from "@app/lib/metronome/mau_sync";
+import {
+  getProductSeatTypes,
+  getSeatSubscriptionsFromContract,
+} from "@app/lib/metronome/seat_types";
 import { hasContractSeatSubscription } from "@app/lib/metronome/seats";
 import { isEnterprisePlanPrefix } from "@app/lib/plans/plan_codes";
+import { isSeatBased } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -24,6 +29,14 @@ export type MetronomeContractSummary = {
   contractEndingAtMs: number | null;
   /** True if the contract has at least one seat-billed subscription */
   hasSeatSubscription: boolean;
+  /**
+   * True if the contract sells at least one seat type that carries a personal
+   * (per-user) credit allocation — pro/max/free seats. Such users spend their
+   * personal credits before falling back to the shared workspace pool, so they
+   * keep working even when the pool is depleted/in overage. False for
+   * pool-based contracts (workspace seats only) and MAU contracts.
+   */
+  hasPersonalCreditSeats: boolean;
 };
 
 /**
@@ -74,11 +87,19 @@ export async function getMetronomeContractSummary(
     ? new Date(contract.ending_before).getTime()
     : null;
 
+  const productSeatTypes = await getProductSeatTypes();
+  const soldSeatTypes = getSeatSubscriptionsFromContract(
+    contract,
+    productSeatTypes
+  );
+  const hasPersonalCreditSeats = [...soldSeatTypes.keys()].some(isSeatBased);
+
   return new Ok({
     planFamily,
     mauTiers,
     contractEndingAtMs,
     hasSeatSubscription: await hasContractSeatSubscription(contract),
+    hasPersonalCreditSeats,
   });
 }
 

--- a/front/pages/api/w/[wId]/metronome/contract.test.ts
+++ b/front/pages/api/w/[wId]/metronome/contract.test.ts
@@ -123,6 +123,7 @@ describe("/api/w/[wId]/metronome/contract", () => {
           mauTiers: null,
           contractEndingAtMs: new Date("2025-05-01T00:00:00.000Z").getTime(),
           hasSeatSubscription: false,
+          hasPersonalCreditSeats: false,
         },
       });
       expect(vi.mocked(getMetronomeContractById)).toHaveBeenCalledWith({


### PR DESCRIPTION
## Description

The workspace usage banner (`UsageStatusBanner`) shows an "out of credits / agents blocked" message to admins whenever the shared credit pool is `depleted` or in `overage`. On contracts that sell seats carrying **personal credits** (pro/max/free seats), those users spend their own per-user credits before falling back to the shared pool, so they keep working even when the pool is depleted — exactly the carve-out already implemented server-side in `isUserBlocked` (`isSpendingFromPersonalSeat`). The banner ignored this, so the message was misleading for these contracts.

This PR suppresses the pool depleted/overage banner whenever the contract sells seats that carry personal credits.

Changes:
- Add `hasPersonalCreditSeats` to `MetronomeContractSummary`, computed from the seat types the contract actually sells (`getSeatSubscriptionsFromContract` + `isSeatBased` → true for pro/max/free, false for pool-based workspace seats and MAU contracts). Note: `hasSeatSubscription` was not a usable signal here since every contract has seat subscriptions.
- `UsageStatusBanner` suppresses the pool banner when `contract.hasPersonalCreditSeats` is true. The contract is only fetched (a Metronome API call) when the banner would otherwise show (`disabled` tied to admin + depleted/overage), and the banner is gated on `!isMetronomeContractLoading` to avoid a flash.
- The AWU per-user cap and programmatic API cap banners are unchanged.

## Tests

- Updated the Next and Hono `metronome/contract` endpoint tests to assert the new `hasPersonalCreditSeats` field.
- Type-checked the touched files.

Behavior:
- Seat-based contract (personal credits) → pool banner hidden (depleted and overage).
- Pool-based contract → unchanged, banner still shown.
- Contract fetch fails / returns null → banner shown (safe fallback to existing behavior).

## Risk

Low. Frontend-only banner suppression plus an additive, optional field on a private, admin-only endpoint; no change to the underlying usage-status data or to enforcement (`isUserBlocked` is untouched). Safe to roll back.

Edge case worth noting: on a mixed contract (both personal-credit and pool-based workspace seats), the banner is hidden if any sold seat type carries personal credits, even though pool-based users on that contract would still be blocked by depletion.

## Deploy Plan

Standard deploy, no migrations or ordering constraints.
