### PR TITLE
move poke projects/conversations/triggers contracts into lib/api/poke

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/config.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/config.ts
@@ -1,16 +1,11 @@
 import config from "@app/lib/api/config";
+import type { PokeGetConversationConfig } from "@app/lib/api/poke/conversations";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export type PokeGetConversationConfig = {
-  conversationDataSourceId: string | null;
-  langfuseUiBaseUrl: string | null;
-  temporalWorkspace: string;
-};
 
 const ParamsSchema = z.object({
   cId: z.string(),

--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/reinforcement_test_case.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/reinforcement_test_case.ts
@@ -1,7 +1,15 @@
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
-import type { AvailableTool } from "@app/lib/api/assistant/workspace_capabilities";
 import { listAvailableTools } from "@app/lib/api/assistant/workspace_capabilities";
+import type {
+  GetReinforcementTestCaseResponseBody,
+  ReinforcementTestCaseMockAction,
+  ReinforcementTestCaseMockFeedback,
+  ReinforcementTestCaseMockMessage,
+  ReinforcementTestCaseMockSkillConfig,
+  ReinforcementTestCaseMockSkillTool,
+  ReinforcementTestCaseType,
+} from "@app/lib/api/poke/conversations";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import {
@@ -17,56 +25,6 @@ import { z } from "zod";
 const ParamsSchema = z.object({
   cId: z.string(),
 });
-
-interface ReinforcementTestCaseMockAction {
-  functionCallName: string;
-  status: "succeeded" | "failed";
-  params?: Record<string, unknown>;
-  output?: string | null;
-}
-
-interface ReinforcementTestCaseMockFeedback {
-  direction: "up" | "down";
-  comment?: string;
-}
-
-interface ReinforcementTestCaseMockMessage {
-  role: "user" | "agent";
-  content: string;
-  feedback?: ReinforcementTestCaseMockFeedback;
-  actions?: ReinforcementTestCaseMockAction[];
-}
-
-interface ReinforcementTestCaseMockSkillTool {
-  name: string;
-  sId: string;
-}
-
-interface ReinforcementTestCaseMockSkillConfig {
-  name: string;
-  sId: string;
-  description?: string;
-  instructions?: string;
-  tools?: ReinforcementTestCaseMockSkillTool[];
-}
-
-interface ReinforcementTestCaseWorkspaceContext {
-  tools: AvailableTool[];
-}
-
-export interface ReinforcementTestCaseType {
-  scenarioId: string;
-  type: "analysis";
-  skillConfigs: ReinforcementTestCaseMockSkillConfig[];
-  conversation: ReinforcementTestCaseMockMessage[];
-  workspaceContext: ReinforcementTestCaseWorkspaceContext;
-  expectedToolCalls: [];
-  judgeCriteria: string;
-}
-
-export type PokeGetReinforcementTestCaseResponseBody = {
-  testCase: ReinforcementTestCaseType;
-};
 
 function serializeActionOutput(
   output: Array<{ type: string; text?: string }> | null | undefined
@@ -89,7 +47,7 @@ const app = pokeApp();
 app.get(
   "/",
   validate("param", ParamsSchema),
-  async (ctx): HandlerResult<PokeGetReinforcementTestCaseResponseBody> => {
+  async (ctx): HandlerResult<GetReinforcementTestCaseResponseBody> => {
     const auth = ctx.get("auth");
     const { cId } = ctx.req.valid("param");
 

--- a/front-api/routes/poke/workspaces/[wId]/conversations/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/index.ts
@@ -1,22 +1,14 @@
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type {
-  ConversationVisibility,
-  ConversationWithoutContentType,
-} from "@app/types/assistant/conversation";
+  PokeListConversationItem,
+  PokeListConversations,
+} from "@app/lib/api/poke/conversations";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
 import conversationId from "./[cId]";
-
-export type PokeListConversationItem = ConversationWithoutContentType & {
-  visibility?: ConversationVisibility;
-};
-
-export type PokeListConversations = {
-  conversations: PokeListConversationItem[];
-};
 
 const ListConversationsQuerySchema = z.object({
   agentId: z.string().optional(),

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/connector-knowledge.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/connector-knowledge.ts
@@ -1,19 +1,10 @@
-import {
-  listProjectKnowledgeFromConnectors,
-  type ProjectKnowledgeFromConnectorItem,
-} from "@app/lib/api/projects/context";
+import type { PokeListProjectKnowledgeFromConnectors } from "@app/lib/api/poke/projects";
+import { listProjectKnowledgeFromConnectors } from "@app/lib/api/projects/context";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export type PokeProjectKnowledgeFromConnectorItem =
-  ProjectKnowledgeFromConnectorItem;
-
-export type PokeListProjectKnowledgeFromConnectors = {
-  items: PokeProjectKnowledgeFromConnectorItem[];
-};
 
 const ParamsSchema = z.object({
   projectId: z.string(),

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/tasks-workflow.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/tasks-workflow.ts
@@ -1,30 +1,18 @@
 import config from "@app/lib/api/config";
+import type {
+  PokeGetProjectWorkflow,
+  PokeProjectWorkflowInfo,
+} from "@app/lib/api/poke/projects";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import {
   describeTemporalWorkflow,
   getTemporalClientForFrontNamespace,
 } from "@app/lib/temporal";
-import type { PodMetadataType } from "@app/types/project_metadata";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export type PokeProjectWorkflowInfo = {
-  workflowId: string;
-  runId: string;
-  status: string;
-  startTime: number | null;
-  closeTime: number | null;
-};
-
-export type PokeGetProjectWorkflow = {
-  metadata: PodMetadataType | null;
-  temporalNamespace: string;
-  workflowId: string;
-  latestWorkflow: PokeProjectWorkflowInfo | null;
-};
 
 const ParamsSchema = z.object({
   projectId: z.string(),

--- a/front-api/routes/poke/workspaces/[wId]/projects/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/index.ts
@@ -1,17 +1,9 @@
-import {
-  listAllProjectsWithAdminMetadata,
-  type ProjectWithAdminMetadata,
-} from "@app/lib/api/projects/list";
+import type { PokeListProjects } from "@app/lib/api/poke/projects";
+import { listAllProjectsWithAdminMetadata } from "@app/lib/api/projects/list";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
 import projectId from "./[projectId]";
-
-export type PokeProjectType = ProjectWithAdminMetadata;
-
-export type PokeListProjects = {
-  projects: PokeProjectType[];
-};
 
 // Mounted at /api/poke/workspaces/:wId/projects.
 const app = pokeApp();

--- a/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/details.ts
@@ -1,19 +1,11 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import type { PokeGetTriggerDetails } from "@app/lib/api/poke/triggers";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
-import type { TriggerType } from "@app/types/assistant/triggers";
-import type { UserType } from "@app/types/user";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export type PokeGetTriggerDetails = {
-  trigger: TriggerType;
-  agent: LightAgentConfigurationType;
-  editorUser: UserType | null;
-};
 
 const ParamsSchema = z.object({
   tId: z.string(),

--- a/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/execution_stats.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/execution_stats.ts
@@ -1,20 +1,10 @@
+import type { PokeGetTriggerExecutionStats } from "@app/lib/api/poke/triggers";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export type PokeGetTriggerExecutionStats = {
-  statusBreakdown: Record<string, number>;
-  dailyVolume: Array<{
-    date: string;
-    succeeded: number;
-    failed: number;
-    notMatched: number;
-    rateLimited: number;
-  }>;
-};
 
 const ParamsSchema = z.object({
   tId: z.string(),

--- a/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/webhook_requests.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/[tId]/webhook_requests.ts
@@ -1,23 +1,11 @@
+import type { PokeGetWebhookRequestsResponseBody } from "@app/lib/api/poke/triggers";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { fetchRecentWebhookRequestTriggersWithPayload } from "@app/lib/triggers/webhook";
-import type { WebhookRequestTriggerStatus } from "@app/types/assistant/triggers";
 import { WEBHOOK_REQUEST_TRIGGER_STATUSES } from "@app/types/assistant/triggers";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export interface PokeGetWebhookRequestsResponseBody {
-  requests: {
-    id: number;
-    timestamp: number;
-    status: WebhookRequestTriggerStatus;
-    payload?: {
-      headers?: Record<string, string | string[]>;
-      body?: unknown;
-    };
-  }[];
-}
 
 const WebhookRequestsQuerySchema = z.object({
   limit: z.coerce.number().int().positive().optional(),

--- a/front-api/routes/poke/workspaces/[wId]/triggers/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/index.ts
@@ -1,20 +1,12 @@
+import type { PokeListTriggers } from "@app/lib/api/poke/triggers";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
-import {
-  listTriggersWithProviderAndEditor,
-  type TriggerWithProviderAndEditor,
-} from "@app/lib/triggers/admin/list_with_metadata";
+import { listTriggersWithProviderAndEditor } from "@app/lib/triggers/admin/list_with_metadata";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
 import tId from "./[tId]";
-
-export type TriggerWithProviderType = TriggerWithProviderAndEditor;
-
-export type PokeListTriggers = {
-  triggers: TriggerWithProviderType[];
-};
 
 const DeleteTriggerQuerySchema = z.object({
   tId: z.string(),

--- a/front/components/poke/conversation/agent_table.tsx
+++ b/front/components/poke/conversation/agent_table.tsx
@@ -1,7 +1,7 @@
 import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
+import type { PokeListConversationItem } from "@app/lib/api/poke/conversations";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
-import type { PokeListConversationItem } from "@app/pages/api/poke/workspaces/[wId]/conversations";
 import type { PokeConversationsFetchProps } from "@app/poke/swr/conversation";
 import { usePokeConversations } from "@app/poke/swr/conversation";
 import type { LightWorkspaceType } from "@app/types/user";

--- a/front/components/poke/projects/columns.tsx
+++ b/front/components/poke/projects/columns.tsx
@@ -1,6 +1,6 @@
 import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
+import type { PokeProjectType } from "@app/lib/api/poke/projects";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
-import type { PokeProjectType } from "@app/pages/api/poke/workspaces/[wId]/projects";
 import type { WorkspaceType } from "@app/types/user";
 import { LinkWrapper } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";

--- a/front/components/poke/projects/connector_knowledge/columns.tsx
+++ b/front/components/poke/projects/connector_knowledge/columns.tsx
@@ -1,6 +1,6 @@
 import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
+import type { PokeProjectKnowledgeFromConnectorItem } from "@app/lib/api/poke/projects";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
-import type { PokeProjectKnowledgeFromConnectorItem } from "@app/pages/api/poke/workspaces/[wId]/projects/[projectId]/connector-knowledge";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Chip, LinkWrapper, Tooltip } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";

--- a/front/components/poke/triggers/columns.tsx
+++ b/front/components/poke/triggers/columns.tsx
@@ -1,8 +1,8 @@
 import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
+import type { TriggerWithProviderType } from "@app/lib/api/poke/triggers";
 import { clientFetch } from "@app/lib/egress/client";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { describeScheduleConfig } from "@app/lib/utils/schedule_description";
-import type { TriggerWithProviderType } from "@app/pages/api/poke/workspaces/[wId]/triggers";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { TriggerType } from "@app/types/assistant/triggers";
 import type { LightWorkspaceType } from "@app/types/user";

--- a/front/lib/api/poke/conversations.ts
+++ b/front/lib/api/poke/conversations.ts
@@ -1,0 +1,69 @@
+import type { AvailableTool } from "@app/lib/api/assistant/workspace_capabilities";
+import type {
+  ConversationVisibility,
+  ConversationWithoutContentType,
+} from "@app/types/assistant/conversation";
+
+export type PokeListConversationItem = ConversationWithoutContentType & {
+  visibility?: ConversationVisibility;
+};
+
+export type PokeListConversations = {
+  conversations: PokeListConversationItem[];
+};
+
+export type PokeGetConversationConfig = {
+  conversationDataSourceId: string | null;
+  langfuseUiBaseUrl: string | null;
+  temporalWorkspace: string;
+};
+
+export interface ReinforcementTestCaseMockAction {
+  functionCallName: string;
+  status: "succeeded" | "failed";
+  params?: Record<string, unknown>;
+  output?: string | null;
+}
+
+export interface ReinforcementTestCaseMockFeedback {
+  direction: "up" | "down";
+  comment?: string;
+}
+
+export interface ReinforcementTestCaseMockMessage {
+  role: "user" | "agent";
+  content: string;
+  feedback?: ReinforcementTestCaseMockFeedback;
+  actions?: ReinforcementTestCaseMockAction[];
+}
+
+export interface ReinforcementTestCaseMockSkillTool {
+  name: string;
+  sId: string;
+}
+
+export interface ReinforcementTestCaseMockSkillConfig {
+  name: string;
+  sId: string;
+  description?: string;
+  instructions?: string;
+  tools?: ReinforcementTestCaseMockSkillTool[];
+}
+
+export interface ReinforcementTestCaseWorkspaceContext {
+  tools: AvailableTool[];
+}
+
+export interface ReinforcementTestCaseType {
+  scenarioId: string;
+  type: "analysis";
+  skillConfigs: ReinforcementTestCaseMockSkillConfig[];
+  conversation: ReinforcementTestCaseMockMessage[];
+  workspaceContext: ReinforcementTestCaseWorkspaceContext;
+  expectedToolCalls: [];
+  judgeCriteria: string;
+}
+
+export type GetReinforcementTestCaseResponseBody = {
+  testCase: ReinforcementTestCaseType;
+};

--- a/front/lib/api/poke/projects.ts
+++ b/front/lib/api/poke/projects.ts
@@ -1,0 +1,36 @@
+import type { ProjectKnowledgeFromConnectorItem } from "@app/lib/api/projects/context";
+import type { ProjectWithAdminMetadata } from "@app/lib/api/projects/list";
+import type { PodMetadataType } from "@app/types/project_metadata";
+import type { PodTaskType } from "@app/types/project_task";
+
+export type PokeProjectType = ProjectWithAdminMetadata;
+
+export type PokeListProjects = {
+  projects: PokeProjectType[];
+};
+
+export type PokeProjectKnowledgeFromConnectorItem =
+  ProjectKnowledgeFromConnectorItem;
+
+export type PokeListProjectKnowledgeFromConnectors = {
+  items: PokeProjectKnowledgeFromConnectorItem[];
+};
+
+export type PokeListProjectTasks = {
+  tasks: PodTaskType[];
+};
+
+export type PokeProjectWorkflowInfo = {
+  workflowId: string;
+  runId: string;
+  status: string;
+  startTime: number | null;
+  closeTime: number | null;
+};
+
+export type PokeGetProjectWorkflow = {
+  metadata: PodMetadataType | null;
+  temporalNamespace: string;
+  workflowId: string;
+  latestWorkflow: PokeProjectWorkflowInfo | null;
+};

--- a/front/lib/api/poke/triggers.ts
+++ b/front/lib/api/poke/triggers.ts
@@ -1,0 +1,42 @@
+import type { TriggerWithProviderAndEditor } from "@app/lib/triggers/admin/list_with_metadata";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type {
+  TriggerType,
+  WebhookRequestTriggerStatus,
+} from "@app/types/assistant/triggers";
+import type { UserType } from "@app/types/user";
+
+export type TriggerWithProviderType = TriggerWithProviderAndEditor;
+
+export type PokeListTriggers = {
+  triggers: TriggerWithProviderType[];
+};
+
+export interface PokeGetWebhookRequestsResponseBody {
+  requests: {
+    id: number;
+    timestamp: number;
+    status: WebhookRequestTriggerStatus;
+    payload?: {
+      headers?: Record<string, string | string[]>;
+      body?: unknown;
+    };
+  }[];
+}
+
+export type PokeGetTriggerExecutionStats = {
+  statusBreakdown: Record<string, number>;
+  dailyVolume: Array<{
+    date: string;
+    succeeded: number;
+    failed: number;
+    notMatched: number;
+    rateLimited: number;
+  }>;
+};
+
+export type PokeGetTriggerDetails = {
+  trigger: TriggerType;
+  agent: LightAgentConfigurationType;
+  editorUser: UserType | null;
+};

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/config.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/config.ts
@@ -2,6 +2,7 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import type { PokeGetConversationConfig } from "@app/lib/api/poke/conversations";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -10,12 +11,6 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeGetConversationConfig = {
-  conversationDataSourceId: string | null;
-  langfuseUiBaseUrl: string | null;
-  temporalWorkspace: string;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/reinforcement_test_case.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/reinforcement_test_case.ts
@@ -2,9 +2,17 @@
 // @migration-status: MIGRATED_TO_HONO
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
-import type { AvailableTool } from "@app/lib/api/assistant/workspace_capabilities";
 import { listAvailableTools } from "@app/lib/api/assistant/workspace_capabilities";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type {
+  GetReinforcementTestCaseResponseBody,
+  ReinforcementTestCaseMockAction,
+  ReinforcementTestCaseMockFeedback,
+  ReinforcementTestCaseMockMessage,
+  ReinforcementTestCaseMockSkillConfig,
+  ReinforcementTestCaseMockSkillTool,
+  ReinforcementTestCaseType,
+} from "@app/lib/api/poke/conversations";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
@@ -18,56 +26,6 @@ import type { WithAPIErrorResponse } from "@app/types/error";
 import type { ModelId } from "@app/types/shared/model_id";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-interface ReinforcementTestCaseMockAction {
-  functionCallName: string;
-  status: "succeeded" | "failed";
-  params?: Record<string, unknown>;
-  output?: string | null;
-}
-
-interface ReinforcementTestCaseMockFeedback {
-  direction: "up" | "down";
-  comment?: string;
-}
-
-interface ReinforcementTestCaseMockMessage {
-  role: "user" | "agent";
-  content: string;
-  feedback?: ReinforcementTestCaseMockFeedback;
-  actions?: ReinforcementTestCaseMockAction[];
-}
-
-interface ReinforcementTestCaseMockSkillTool {
-  name: string;
-  sId: string;
-}
-
-interface ReinforcementTestCaseMockSkillConfig {
-  name: string;
-  sId: string;
-  description?: string;
-  instructions?: string;
-  tools?: ReinforcementTestCaseMockSkillTool[];
-}
-
-interface ReinforcementTestCaseWorkspaceContext {
-  tools: AvailableTool[];
-}
-
-export interface ReinforcementTestCaseType {
-  scenarioId: string;
-  type: "analysis";
-  skillConfigs: ReinforcementTestCaseMockSkillConfig[];
-  conversation: ReinforcementTestCaseMockMessage[];
-  workspaceContext: ReinforcementTestCaseWorkspaceContext;
-  expectedToolCalls: [];
-  judgeCriteria: string;
-}
-
-export type GetReinforcementTestCaseResponseBody = {
-  testCase: ReinforcementTestCaseType;
-};
 
 function serializeActionOutput(
   output: Array<{ type: string; text?: string }> | null | undefined

--- a/front/pages/api/poke/workspaces/[wId]/conversations/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/index.ts
@@ -1,25 +1,17 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type {
+  PokeListConversationItem,
+  PokeListConversations,
+} from "@app/lib/api/poke/conversations";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { apiError } from "@app/logger/withlogging";
-import type {
-  ConversationVisibility,
-  ConversationWithoutContentType,
-} from "@app/types/assistant/conversation";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeListConversationItem = ConversationWithoutContentType & {
-  visibility?: ConversationVisibility;
-};
-
-export type PokeListConversations = {
-  conversations: PokeListConversationItem[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/projects/[projectId]/connector-knowledge.ts
+++ b/front/pages/api/poke/workspaces/[wId]/projects/[projectId]/connector-knowledge.ts
@@ -2,10 +2,8 @@
 // @migration-status: MIGRATED_TO_HONO
 
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
-import {
-  listProjectKnowledgeFromConnectors,
-  type ProjectKnowledgeFromConnectorItem,
-} from "@app/lib/api/projects/context";
+import type { PokeListProjectKnowledgeFromConnectors } from "@app/lib/api/poke/projects";
+import { listProjectKnowledgeFromConnectors } from "@app/lib/api/projects/context";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -13,13 +11,6 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeProjectKnowledgeFromConnectorItem =
-  ProjectKnowledgeFromConnectorItem;
-
-export type PokeListProjectKnowledgeFromConnectors = {
-  items: PokeProjectKnowledgeFromConnectorItem[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/projects/[projectId]/tasks-workflow.ts
+++ b/front/pages/api/poke/workspaces/[wId]/projects/[projectId]/tasks-workflow.ts
@@ -2,6 +2,10 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import type {
+  PokeGetProjectWorkflow,
+  PokeProjectWorkflowInfo,
+} from "@app/lib/api/poke/projects";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
@@ -12,24 +16,8 @@ import {
 } from "@app/lib/temporal";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { PodMetadataType } from "@app/types/project_metadata";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeProjectWorkflowInfo = {
-  workflowId: string;
-  runId: string;
-  status: string;
-  startTime: number | null;
-  closeTime: number | null;
-};
-
-export type PokeGetProjectWorkflow = {
-  metadata: PodMetadataType | null;
-  temporalNamespace: string;
-  workflowId: string;
-  latestWorkflow: PokeProjectWorkflowInfo | null;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/projects/[projectId]/tasks.ts
+++ b/front/pages/api/poke/workspaces/[wId]/projects/[projectId]/tasks.ts
@@ -1,19 +1,15 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { PokeListProjectTasks } from "@app/lib/api/poke/projects";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { PodTaskType } from "@app/types/project_task";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeListProjectTasks = {
-  tasks: PodTaskType[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/projects/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/projects/index.ts
@@ -1,21 +1,13 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
-import {
-  listAllProjectsWithAdminMetadata,
-  type ProjectWithAdminMetadata,
-} from "@app/lib/api/projects/list";
+import type { PokeListProjects } from "@app/lib/api/poke/projects";
+import { listAllProjectsWithAdminMetadata } from "@app/lib/api/projects/list";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeProjectType = ProjectWithAdminMetadata;
-
-export type PokeListProjects = {
-  projects: PokeProjectType[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/triggers/[tId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/triggers/[tId]/details.ts
@@ -2,22 +2,14 @@
 // @migration-status: MIGRATED_TO_HONO
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { PokeGetTriggerDetails } from "@app/lib/api/poke/triggers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
-import type { TriggerType } from "@app/types/assistant/triggers";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { UserType } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeGetTriggerDetails = {
-  trigger: TriggerType;
-  agent: LightAgentConfigurationType;
-  editorUser: UserType | null;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/triggers/[tId]/execution_stats.ts
+++ b/front/pages/api/poke/workspaces/[wId]/triggers/[tId]/execution_stats.ts
@@ -1,6 +1,7 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { PokeGetTriggerExecutionStats } from "@app/lib/api/poke/triggers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
@@ -9,17 +10,6 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeGetTriggerExecutionStats = {
-  statusBreakdown: Record<string, number>;
-  dailyVolume: Array<{
-    date: string;
-    succeeded: number;
-    failed: number;
-    notMatched: number;
-    rateLimited: number;
-  }>;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/triggers/[tId]/webhook_requests.ts
+++ b/front/pages/api/poke/workspaces/[wId]/triggers/[tId]/webhook_requests.ts
@@ -1,6 +1,7 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { PokeGetWebhookRequestsResponseBody } from "@app/lib/api/poke/triggers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
@@ -11,18 +12,6 @@ import { WEBHOOK_REQUEST_TRIGGER_STATUSES } from "@app/types/assistant/triggers"
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export interface PokeGetWebhookRequestsResponseBody {
-  requests: {
-    id: number;
-    timestamp: number;
-    status: WebhookRequestTriggerStatus;
-    payload?: {
-      headers?: Record<string, string | string[]>;
-      body?: unknown;
-    };
-  }[];
-}
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/triggers/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/triggers/index.ts
@@ -1,22 +1,14 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { PokeListTriggers } from "@app/lib/api/poke/triggers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
-import {
-  listTriggersWithProviderAndEditor,
-  type TriggerWithProviderAndEditor,
-} from "@app/lib/triggers/admin/list_with_metadata";
+import { listTriggersWithProviderAndEditor } from "@app/lib/triggers/admin/list_with_metadata";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type TriggerWithProviderType = TriggerWithProviderAndEditor;
-
-export type PokeListTriggers = {
-  triggers: TriggerWithProviderType[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/poke/swr/conversation.ts
+++ b/front/poke/swr/conversation.ts
@@ -1,5 +1,5 @@
+import type { PokeListConversations } from "@app/lib/api/poke/conversations";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeListConversations } from "@app/pages/api/poke/workspaces/[wId]/conversations";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/conversation_config.ts
+++ b/front/poke/swr/conversation_config.ts
@@ -1,5 +1,5 @@
+import type { PokeGetConversationConfig } from "@app/lib/api/poke/conversations";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeGetConversationConfig } from "@app/pages/api/poke/workspaces/[wId]/conversations/[cId]/config";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/project_connector_knowledge.ts
+++ b/front/poke/swr/project_connector_knowledge.ts
@@ -1,5 +1,5 @@
+import type { PokeListProjectKnowledgeFromConnectors } from "@app/lib/api/poke/projects";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeListProjectKnowledgeFromConnectors } from "@app/pages/api/poke/workspaces/[wId]/projects/[projectId]/connector-knowledge";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/project_tasks.ts
+++ b/front/poke/swr/project_tasks.ts
@@ -1,5 +1,5 @@
+import type { PokeListProjectTasks } from "@app/lib/api/poke/projects";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeListProjectTasks } from "@app/pages/api/poke/workspaces/[wId]/projects/[projectId]/tasks";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/project_tasks_workflow.ts
+++ b/front/poke/swr/project_tasks_workflow.ts
@@ -1,5 +1,5 @@
+import type { PokeGetProjectWorkflow } from "@app/lib/api/poke/projects";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeGetProjectWorkflow } from "@app/pages/api/poke/workspaces/[wId]/projects/[projectId]/tasks-workflow";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/projects.ts
+++ b/front/poke/swr/projects.ts
@@ -1,5 +1,5 @@
+import type { PokeListProjects } from "@app/lib/api/poke/projects";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeListProjects } from "@app/pages/api/poke/workspaces/[wId]/projects";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/reinforcement_test_case.ts
+++ b/front/poke/swr/reinforcement_test_case.ts
@@ -1,6 +1,6 @@
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { GetReinforcementTestCaseResponseBody } from "@app/lib/api/poke/conversations";
 import { clientFetch } from "@app/lib/egress/client";
-import type { GetReinforcementTestCaseResponseBody } from "@app/pages/api/poke/workspaces/[wId]/conversations/[cId]/reinforcement_test_case";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useState } from "react";
 

--- a/front/poke/swr/trigger_details.ts
+++ b/front/poke/swr/trigger_details.ts
@@ -1,5 +1,5 @@
+import type { PokeGetTriggerDetails } from "@app/lib/api/poke/triggers";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeGetTriggerDetails } from "@app/pages/api/poke/workspaces/[wId]/triggers/[tId]/details";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/trigger_execution_stats.ts
+++ b/front/poke/swr/trigger_execution_stats.ts
@@ -1,5 +1,5 @@
+import type { PokeGetTriggerExecutionStats } from "@app/lib/api/poke/triggers";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeGetTriggerExecutionStats } from "@app/pages/api/poke/workspaces/[wId]/triggers/[tId]/execution_stats";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/triggers.ts
+++ b/front/poke/swr/triggers.ts
@@ -1,6 +1,8 @@
+import type {
+  PokeGetWebhookRequestsResponseBody,
+  PokeListTriggers,
+} from "@app/lib/api/poke/triggers";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeListTriggers } from "@app/pages/api/poke/workspaces/[wId]/triggers";
-import type { PokeGetWebhookRequestsResponseBody } from "@app/pages/api/poke/workspaces/[wId]/triggers/[tId]/webhook_requests";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { WebhookRequestTriggerStatus } from "@app/types/assistant/triggers";
 import type { LightWorkspaceType } from "@app/types/user";


### PR DESCRIPTION
  ## What & why

  Continues removing `front/pages/api` (Next) in favor of Hono. Third poke
  sub-round, covering **projects, conversations, and triggers**.

  Applies the consolidation invariant we settled on: after Next is gone, each
  contract lives in exactly **one** place — `lib/api/poke/*` when the frontend
  needs it (imported by Next handler, Hono handler, and the client alike), or
  Hono-only for server-only contracts. No type is duplicated across lib and a
  Hono handler.

  This batch is type-only (no runtime schemas moved into lib), so there is no
  behavior change.

  ## Changes

  New lib modules, with the Next page, the Hono route, and the frontend all
  importing from them:

  | Module | Types |
  |---|---|
  | `lib/api/poke/projects.ts` | `PokeProjectType`, `PokeListProjects`, `PokeProjectKnowledgeFromConnectorItem`, `PokeListProjectKnowledgeFromConnectors`, `PokeListProjectTasks`, `PokeProjectWorkflowInfo`, `PokeGetProjectWorkflow` |
  | `lib/api/poke/conversations.ts` | `PokeListConversationItem`, `PokeListConversations`, `PokeGetConversationConfig`, the reinforcement test-case interface tree + `GetReinforcementTestCaseResponseBody` |
  | `lib/api/poke/triggers.ts` | `TriggerWithProviderType`, `PokeListTriggers`, `PokeGetWebhookRequestsResponseBody`, `PokeGetTriggerExecutionStats`, `PokeGetTriggerDetails` |

  - 11 Next pages + 11 Hono routes repointed at lib; local type defs deleted and
    def-only dependency imports removed.
  - Two Hono-side name mismatches collapsed onto the lib name (the Hono routes
    had `PokeGetReinforcementTestCaseResponseBody` while Next/frontend used
    `GetReinforcementTestCaseResponseBody`).
  - 14 frontend consumers (`poke/swr/*`, `components/poke/*`) repointed.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
