### PR TITLE
feat(skill builder) font support for skill files upload in skill builder

### DIFF
--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -28,6 +28,7 @@ import type {
 import {
   isInteractiveContentType,
   isSupportedAudioContentType,
+  isSupportedFontContentType,
   isSupportedImageContentType,
   TABLE_PREFIX,
 } from "@app/types/files";
@@ -518,6 +519,11 @@ const getProcessingFunction = ({
 
   // Processing is assumed to be irrelevant for internal mime types.
   if (isDustMimeType(contentType)) {
+    return undefined;
+  }
+
+  // Fonts are binary assets used as-is — no processing needed.
+  if (isSupportedFontContentType(contentType)) {
     return undefined;
   }
 

--- a/front/lib/api/files/use_cases/skill_attachment.ts
+++ b/front/lib/api/files/use_cases/skill_attachment.ts
@@ -61,6 +61,13 @@ const SKILL_ATTACHMENT_CONTENT_TYPES = [
   "text/x-perl",
   "text/x-perl-script",
   "message/rfc822",
+
+  // Fonts (used as-is by agents in Frames or the Computer).
+  "font/woff",
+  "font/woff2",
+  "font/otf",
+  "font/ttf",
+  "font/collection",
 ] as const satisfies readonly AllSupportedFileContentType[];
 
 export type SkillAttachmentContentType =

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -853,13 +853,27 @@ export function extensionsForContentType(
   return [];
 }
 
+function isFormatAllowedForUseCase(
+  format: (typeof FILE_FORMATS)[keyof typeof FILE_FORMATS],
+  useCase?: FileUseCase
+): boolean {
+  if (!("allowedFileUploadUseCases" in format)) {
+    return true;
+  }
+  return useCase
+    ? format.allowedFileUploadUseCases.some((uc) => uc === useCase)
+    : false;
+}
+
 export function getSupportedFileExtensions(
-  cat: FileFormatCategory | undefined = undefined
+  cat?: FileFormatCategory,
+  useCase?: FileUseCase
 ) {
   return uniq(
     removeNulls(
       Object.values(FILE_FORMATS).flatMap((format) =>
-        !("allowedFileUploadUseCases" in format) && (!cat || format.cat === cat)
+        isFormatAllowedForUseCase(format, useCase) &&
+        (!cat || format.cat === cat)
           ? format.exts
           : []
       )
@@ -867,11 +881,11 @@ export function getSupportedFileExtensions(
   );
 }
 
-export function getSupportedNonImageFileExtensions() {
+export function getSupportedNonImageFileExtensions(useCase?: FileUseCase) {
   return uniq(
     removeNulls(
       Object.values(FILE_FORMATS).flatMap((format) =>
-        !("allowedFileUploadUseCases" in format) && format.cat !== "image"
+        isFormatAllowedForUseCase(format, useCase) && format.cat !== "image"
           ? format.exts
           : []
       )
@@ -879,11 +893,11 @@ export function getSupportedNonImageFileExtensions() {
   );
 }
 
-export function getSupportedNonImageMimeTypes() {
+export function getSupportedNonImageMimeTypes(useCase?: FileUseCase) {
   return uniq(
     removeNulls(
       Object.entries(FILE_FORMATS).map(([key, value]) =>
-        !("allowedFileUploadUseCases" in value) && value.cat !== "image"
+        isFormatAllowedForUseCase(value, useCase) && value.cat !== "image"
           ? (key as SupportedNonImageContentType)
           : null
       )

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -594,6 +594,17 @@ export const FILE_FORMATS = {
   // Chrome sometimes uses video/webm for audio files, and we can still process them as audio only files
   "video/webm": { cat: "audio", exts: [".webm"], isSafeToDisplay: true },
 
+  // Fonts (binary assets used as-is by skill attachments / Frames).
+  "font/woff": { cat: "data", exts: [".woff"], isSafeToDisplay: false },
+  "font/woff2": { cat: "data", exts: [".woff2"], isSafeToDisplay: false },
+  "font/otf": { cat: "data", exts: [".otf"], isSafeToDisplay: false },
+  "font/ttf": { cat: "data", exts: [".ttf"], isSafeToDisplay: false },
+  "font/collection": {
+    cat: "data",
+    exts: [".ttc", ".otc"],
+    isSafeToDisplay: false,
+  },
+
   // Unknown.
   "application/octet-stream": {
     cat: "data",
@@ -763,6 +774,25 @@ export function isSupportedAudioContentType(
   return false;
 }
 
+export type SupportedFontContentType =
+  | "font/woff"
+  | "font/woff2"
+  | "font/otf"
+  | "font/ttf"
+  | "font/collection";
+
+export function isSupportedFontContentType(
+  contentType: string
+): contentType is SupportedFontContentType {
+  return (
+    contentType === "font/woff" ||
+    contentType === "font/woff2" ||
+    contentType === "font/otf" ||
+    contentType === "font/ttf" ||
+    contentType === "font/collection"
+  );
+}
+
 export function getFileFormatCategory(
   contentType: string
 ): FileFormatCategory | null {
@@ -842,6 +872,12 @@ const EXTENSION_CONTENT_TYPE_OVERRIDES: Record<
   ".tsv": "text/tsv",
   ".xls": "application/vnd.ms-excel",
   ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".otf": "font/otf",
+  ".ttf": "font/ttf",
+  ".ttc": "font/collection",
+  ".otc": "font/collection",
 };
 
 export function stripMimeParameters(contentType: string): string {

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -395,6 +395,10 @@ type FileFormat = {
    * - Any file type that could contain executable code
    */
   isSafeToDisplay: boolean;
+  // When set, restricts which upload use cases expose this format in their file picker.
+  // Possible values: conversation, avatar, tool_output, skill_attachment, upsert_document,
+  // folders_document, upsert_table, project_context. Omit to allow in all contexts.
+  allowedFileUploadUseCases?: readonly FileUseCase[];
 };
 
 // NOTE: if we add more content types, we need to update the public api package. (but the
@@ -594,15 +598,36 @@ export const FILE_FORMATS = {
   // Chrome sometimes uses video/webm for audio files, and we can still process them as audio only files
   "video/webm": { cat: "audio", exts: [".webm"], isSafeToDisplay: true },
 
-  // Fonts (binary assets used as-is by skill attachments / Frames).
-  "font/woff": { cat: "data", exts: [".woff"], isSafeToDisplay: false },
-  "font/woff2": { cat: "data", exts: [".woff2"], isSafeToDisplay: false },
-  "font/otf": { cat: "data", exts: [".otf"], isSafeToDisplay: false },
-  "font/ttf": { cat: "data", exts: [".ttf"], isSafeToDisplay: false },
+  // Fonts — skill attachments only.
+  "font/woff": {
+    cat: "data",
+    exts: [".woff"],
+    isSafeToDisplay: false,
+    allowedFileUploadUseCases: ["skill_attachment"],
+  },
+  "font/woff2": {
+    cat: "data",
+    exts: [".woff2"],
+    isSafeToDisplay: false,
+    allowedFileUploadUseCases: ["skill_attachment"],
+  },
+  "font/otf": {
+    cat: "data",
+    exts: [".otf"],
+    isSafeToDisplay: false,
+    allowedFileUploadUseCases: ["skill_attachment"],
+  },
+  "font/ttf": {
+    cat: "data",
+    exts: [".ttf"],
+    isSafeToDisplay: false,
+    allowedFileUploadUseCases: ["skill_attachment"],
+  },
   "font/collection": {
     cat: "data",
     exts: [".ttc", ".otc"],
     isSafeToDisplay: false,
+    allowedFileUploadUseCases: ["skill_attachment"],
   },
 
   // Unknown.
@@ -834,7 +859,9 @@ export function getSupportedFileExtensions(
   return uniq(
     removeNulls(
       Object.values(FILE_FORMATS).flatMap((format) =>
-        !cat || format.cat === cat ? format.exts : []
+        !("allowedFileUploadUseCases" in format) && (!cat || format.cat === cat)
+          ? format.exts
+          : []
       )
     )
   );
@@ -844,7 +871,9 @@ export function getSupportedNonImageFileExtensions() {
   return uniq(
     removeNulls(
       Object.values(FILE_FORMATS).flatMap((format) =>
-        format.cat !== "image" ? format.exts : []
+        !("allowedFileUploadUseCases" in format) && format.cat !== "image"
+          ? format.exts
+          : []
       )
     )
   );
@@ -854,7 +883,9 @@ export function getSupportedNonImageMimeTypes() {
   return uniq(
     removeNulls(
       Object.entries(FILE_FORMATS).map(([key, value]) =>
-        value.cat !== "image" ? (key as SupportedNonImageContentType) : null
+        !("allowedFileUploadUseCases" in value) && value.cat !== "image"
+          ? (key as SupportedNonImageContentType)
+          : null
       )
     )
   );

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -256,7 +256,6 @@ export type PostWebhookTriggerResponseType = z.infer<
 type OtherContentType = keyof typeof supportedOtherFileFormats;
 type ImageContentType = keyof typeof supportedImageFileFormats;
 type AudioContentType = keyof typeof supportedAudioFileFormats;
-type FontContentType = keyof typeof supportedFontFileFormats;
 
 const supportedOtherContentTypes = Object.keys(
   supportedOtherFileFormats
@@ -267,9 +266,6 @@ const supportedImageContentTypes = Object.keys(
 const supportedAudioContentTypes = Object.keys(
   supportedAudioFileFormats
 ) as AudioContentType[];
-const supportedFontContentTypes = Object.keys(
-  supportedFontFileFormats
-) as FontContentType[];
 
 export const supportedFileExtensions = [
   ...Object.keys(supportedOtherFileFormats),
@@ -279,13 +275,11 @@ export const supportedFileExtensions = [
 export type SupportedFileContentType =
   | OtherContentType
   | ImageContentType
-  | AudioContentType
-  | FontContentType;
+  | AudioContentType;
 const supportedUploadableContentType = [
   ...supportedOtherContentTypes,
   ...supportedImageContentTypes,
   ...supportedAudioContentTypes,
-  ...supportedFontContentTypes,
 ] as SupportedFileContentType[];
 
 const SupportedContentFragmentTypeSchema = FlexibleEnumSchema<

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -237,6 +237,14 @@ export const supportedAudioFileFormats = {
   "video/webm": [".webm"],
 } as const;
 
+export const supportedFontFileFormats = {
+  "font/woff": [".woff"],
+  "font/woff2": [".woff2"],
+  "font/otf": [".otf"],
+  "font/ttf": [".ttf"],
+  "font/collection": [".ttc", ".otc"],
+} as const;
+
 // Webhook trigger endpoint (skeleton) response type
 export const PostWebhookTriggerResponseSchema = z.object({
   success: z.literal(true),
@@ -248,6 +256,7 @@ export type PostWebhookTriggerResponseType = z.infer<
 type OtherContentType = keyof typeof supportedOtherFileFormats;
 type ImageContentType = keyof typeof supportedImageFileFormats;
 type AudioContentType = keyof typeof supportedAudioFileFormats;
+type FontContentType = keyof typeof supportedFontFileFormats;
 
 const supportedOtherContentTypes = Object.keys(
   supportedOtherFileFormats
@@ -258,6 +267,9 @@ const supportedImageContentTypes = Object.keys(
 const supportedAudioContentTypes = Object.keys(
   supportedAudioFileFormats
 ) as AudioContentType[];
+const supportedFontContentTypes = Object.keys(
+  supportedFontFileFormats
+) as FontContentType[];
 
 export const supportedFileExtensions = [
   ...Object.keys(supportedOtherFileFormats),
@@ -267,17 +279,20 @@ export const supportedFileExtensions = [
 export type SupportedFileContentType =
   | OtherContentType
   | ImageContentType
-  | AudioContentType;
+  | AudioContentType
+  | FontContentType;
 const supportedUploadableContentType = [
   ...supportedOtherContentTypes,
   ...supportedImageContentTypes,
   ...supportedAudioContentTypes,
+  ...supportedFontContentTypes,
 ] as SupportedFileContentType[];
 
 const SupportedContentFragmentTypeSchema = FlexibleEnumSchema<
   | keyof typeof supportedOtherFileFormats
   | keyof typeof supportedImageFileFormats
   | keyof typeof supportedAudioFileFormats
+  | keyof typeof supportedFontFileFormats
   | (typeof INTERNAL_MIME_TYPES_VALUES)[number]
   // Legacy content types still retuned by the API when rendering old messages.
   | "dust-application/slack"
@@ -287,6 +302,7 @@ const SupportedFileContentFragmentTypeSchema = FlexibleEnumSchema<
   | keyof typeof supportedOtherFileFormats
   | keyof typeof supportedImageFileFormats
   | keyof typeof supportedAudioFileFormats
+  | keyof typeof supportedFontFileFormats
 >();
 
 const FrameContentTypeSchema = z.literal("application/vnd.dust.frame");


### PR DESCRIPTION
## Description

Adds font file format support (`woff`, `woff2`, `otf`, `ttf`, `ttc`, `otc`) to the skill attachment use case, enabling skill builders to upload font files that agents can use directly at runtime (e.g., in Frames or the Computer tool). Font files are registered as binary `data`-category assets with no processing step — they are passed through as-is, so the upsert pipeline returns `undefined` for their processing function rather than hitting `assertNever`.

Changes span three layers:
- `front/types/files.ts`: registers font MIME types in `FILE_FORMATS`, adds `SupportedFontContentType` type and `isSupportedFontContentType` guard, and extends the extension→content-type override map.
- `front/lib/api/files/upsert.ts`: short-circuits processing for font content types.
- `front/lib/api/files/use_cases/skill_attachment.ts`: whitelists the five font MIME types for the `skill_attachment` use case.
- `sdks/js/src/types.ts`: exposes `supportedFontFileFormats` and includes `FontContentType` in the SDK's union of supported content types.

Solving : 
<img width="1920" height="948" alt="image" src="https://github.com/user-attachments/assets/b51e5320-665f-45d4-b6d7-91d4fae7e492" />

## Tests

Tested manually by uploading font files via the skill builder UI and verifying they are accepted and stored without errors. No new automated tests added (no processing logic to unit-test).

## Risk

Low. Font types are additive — existing file validation and processing paths are unaffected. The only behavioural change is that font MIME types no longer fall through to `assertNever`.

## Deploy Plan

Deploy front.