### PR TITLE
move poke credits/groups/webhook_sources/mcp_server_views contracts into lib/api/poke

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/credits/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/credits/index.ts
@@ -1,41 +1,19 @@
 import { metronomeBalanceToDisplayData } from "@app/lib/api/credits/metronome_balances";
+import type {
+  PokeListCreditsResponseBody,
+  PokeUnifiedCreditRow,
+} from "@app/lib/api/poke/credits";
 import { listMetronomeBalances } from "@app/lib/metronome/client";
 import { getCreditTypeProgrammaticUsdId } from "@app/lib/metronome/constants";
 import { isMetronomeExcessCredit } from "@app/lib/metronome/types";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import logger from "@app/logger/logger";
-import type { CreditDisplayData, CreditType } from "@app/types/credits";
+import type { CreditDisplayData } from "@app/types/credits";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
 import awuPoolSummary from "./awu-pool-summary";
 import membersUsage from "./members-usage";
-
-export type PokeCreditType = {
-  id: number;
-  createdAt: string;
-  type: CreditType;
-  initialAmountMicroUsd: number;
-  consumedAmountMicroUsd: number;
-  remainingAmountMicroUsd: number;
-  startDate: string | null;
-  expirationDate: string | null;
-  discount: number | null;
-  invoiceOrLineItemId: string | null;
-  metronomeCreditId: string | null;
-};
-
-export type PokeUnifiedCreditRow = {
-  rowKey: string;
-  internal: PokeCreditType | null;
-  metronome: CreditDisplayData | null;
-};
-
-export type PokeListCreditsResponseBody = {
-  rows: PokeUnifiedCreditRow[];
-  excessCreditsLast30DaysMicroUsd: number;
-  hasMetronome: boolean;
-};
 
 // Mounted at /api/poke/workspaces/:wId/credits.
 const app = pokeApp();

--- a/front-api/routes/poke/workspaces/[wId]/groups/[groupId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/groups/[groupId]/details.ts
@@ -1,16 +1,10 @@
+import type { PokeGetGroupDetails } from "@app/lib/api/poke/groups";
 import { getGroupMembersWithWorkspaces } from "@app/lib/api/workspace";
 import { GroupResource } from "@app/lib/resources/group_resource";
-import type { GroupType } from "@app/types/groups";
-import type { UserTypeWithWorkspaces } from "@app/types/user";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export type PokeGetGroupDetails = {
-  members: UserTypeWithWorkspaces[];
-  group: GroupType;
-};
 
 const ParamsSchema = z.object({
   groupId: z.string(),

--- a/front-api/routes/poke/workspaces/[wId]/groups/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/groups/index.ts
@@ -1,13 +1,9 @@
+import type { PokeListGroups } from "@app/lib/api/poke/groups";
 import { GroupResource } from "@app/lib/resources/group_resource";
-import type { GroupType } from "@app/types/groups";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
 import groupId from "./[groupId]";
-
-export type PokeListGroups = {
-  groups: GroupType[];
-};
 
 // Mounted at /api/poke/workspaces/:wId/groups.
 const app = pokeApp();

--- a/front-api/routes/poke/workspaces/[wId]/mcp/views/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/mcp/views/index.ts
@@ -1,14 +1,10 @@
-import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { PokeListMCPServerViews } from "@app/lib/api/poke/mcp_server_views";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export type PokeListMCPServerViews = {
-  serverViews: MCPServerViewType[];
-};
 
 const QuerySchema = z.object({
   globalSpaceOnly: z.enum(["true", "false"]).optional(),

--- a/front-api/routes/poke/workspaces/[wId]/mcp_server_views/[svId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/mcp_server_views/[svId]/details.ts
@@ -1,14 +1,10 @@
+import type { PokeGetMCPServerViewDetails } from "@app/lib/api/poke/mcp_server_views";
 import { mcpServerViewToPokeJSON } from "@app/lib/poke/utils";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import type { PokeMCPServerViewType } from "@app/types/poke";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export type PokeGetMCPServerViewDetails = {
-  mcpServerView: PokeMCPServerViewType;
-};
 
 const ParamsSchema = z.object({
   svId: z.string(),

--- a/front-api/routes/poke/workspaces/[wId]/webhook_sources/[wsId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/webhook_sources/[wsId]/details.ts
@@ -1,22 +1,10 @@
+import type { PokeGetWebhookSourceDetails } from "@app/lib/api/poke/webhook_sources";
 import { getWebhookSourceAdminDetails } from "@app/lib/api/webhook_source";
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
-import type { TriggerType } from "@app/types/assistant/triggers";
-import type {
-  WebhookSourceForAdminType,
-  WebhookSourceViewForAdminType,
-} from "@app/types/triggers/webhooks";
-import type { UserType } from "@app/types/user";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export type PokeGetWebhookSourceDetails = {
-  webhookSource: WebhookSourceForAdminType;
-  views: WebhookSourceViewForAdminType[];
-  triggers: Array<TriggerType & { editorUser: UserType | null }>;
-  requestStats: { last24h: number; last7d: number; last30d: number };
-};
 
 const ParamsSchema = z.object({
   wsId: z.string(),

--- a/front-api/routes/poke/workspaces/[wId]/webhook_sources/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/webhook_sources/index.ts
@@ -1,15 +1,9 @@
+import type { PokeListWebhookSources } from "@app/lib/api/poke/webhook_sources";
 import { listWebhookSourcesWithCounts } from "@app/lib/api/webhook_source";
-import type { WebhookSourceType } from "@app/types/triggers/webhooks";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
 import wsId from "./[wsId]";
-
-export type PokeListWebhookSources = {
-  webhookSources: Array<
-    WebhookSourceType & { viewCount: number; triggerCount: number }
-  >;
-};
 
 // Mounted at /api/poke/workspaces/:wId/webhook_sources.
 const app = pokeApp();

--- a/front/components/poke/credits/columns.tsx
+++ b/front/components/poke/credits/columns.tsx
@@ -1,7 +1,7 @@
 import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
 import { TYPE_COLORS } from "@app/components/workspace/CreditsList";
+import type { PokeUnifiedCreditRow } from "@app/lib/api/poke/credits";
 import { getMetronomeCommitOrCreditUrl } from "@app/lib/metronome/urls";
-import type { PokeUnifiedCreditRow } from "@app/pages/api/poke/workspaces/[wId]/credits";
 import { dateToHumanReadable } from "@app/types/shared/utils/date_utils";
 import { Chip, LinkWrapper } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";

--- a/front/components/poke/credits/table.tsx
+++ b/front/components/poke/credits/table.tsx
@@ -30,7 +30,7 @@ function PokeChartFallback() {
 }
 
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
-import type { PokeUnifiedCreditRow } from "@app/pages/api/poke/workspaces/[wId]/credits";
+import type { PokeUnifiedCreditRow } from "@app/lib/api/poke/credits";
 import type { PokeCreditsData } from "@app/poke/swr/credits";
 import { usePokeCredits } from "@app/poke/swr/credits";
 import type { SubscriptionType } from "@app/types/plan";

--- a/front/components/poke/webhook_sources/columns.tsx
+++ b/front/components/poke/webhook_sources/columns.tsx
@@ -1,6 +1,6 @@
 import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
+import type { PokeListWebhookSources } from "@app/lib/api/poke/webhook_sources";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
-import type { PokeListWebhookSources } from "@app/pages/api/poke/workspaces/[wId]/webhook_sources";
 import type { LightWorkspaceType } from "@app/types/user";
 import { LinkWrapper } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";

--- a/front/lib/api/poke/credits.ts
+++ b/front/lib/api/poke/credits.ts
@@ -1,0 +1,27 @@
+import type { CreditDisplayData, CreditType } from "@app/types/credits";
+
+export type PokeCreditType = {
+  id: number;
+  createdAt: string;
+  type: CreditType;
+  initialAmountMicroUsd: number;
+  consumedAmountMicroUsd: number;
+  remainingAmountMicroUsd: number;
+  startDate: string | null;
+  expirationDate: string | null;
+  discount: number | null;
+  invoiceOrLineItemId: string | null;
+  metronomeCreditId: string | null;
+};
+
+export type PokeUnifiedCreditRow = {
+  rowKey: string;
+  internal: PokeCreditType | null;
+  metronome: CreditDisplayData | null;
+};
+
+export type PokeListCreditsResponseBody = {
+  rows: PokeUnifiedCreditRow[];
+  excessCreditsLast30DaysMicroUsd: number;
+  hasMetronome: boolean;
+};

--- a/front/lib/api/poke/groups.ts
+++ b/front/lib/api/poke/groups.ts
@@ -1,0 +1,11 @@
+import type { GroupType } from "@app/types/groups";
+import type { UserTypeWithWorkspaces } from "@app/types/user";
+
+export type PokeListGroups = {
+  groups: GroupType[];
+};
+
+export type PokeGetGroupDetails = {
+  members: UserTypeWithWorkspaces[];
+  group: GroupType;
+};

--- a/front/lib/api/poke/mcp_server_views.ts
+++ b/front/lib/api/poke/mcp_server_views.ts
@@ -1,0 +1,10 @@
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { PokeMCPServerViewType } from "@app/types/poke";
+
+export type PokeListMCPServerViews = {
+  serverViews: MCPServerViewType[];
+};
+
+export type PokeGetMCPServerViewDetails = {
+  mcpServerView: PokeMCPServerViewType;
+};

--- a/front/lib/api/poke/webhook_sources.ts
+++ b/front/lib/api/poke/webhook_sources.ts
@@ -1,0 +1,20 @@
+import type { TriggerType } from "@app/types/assistant/triggers";
+import type {
+  WebhookSourceForAdminType,
+  WebhookSourceType,
+  WebhookSourceViewForAdminType,
+} from "@app/types/triggers/webhooks";
+import type { UserType } from "@app/types/user";
+
+export type PokeListWebhookSources = {
+  webhookSources: Array<
+    WebhookSourceType & { viewCount: number; triggerCount: number }
+  >;
+};
+
+export type PokeGetWebhookSourceDetails = {
+  webhookSource: WebhookSourceForAdminType;
+  views: WebhookSourceViewForAdminType[];
+  triggers: Array<TriggerType & { editorUser: UserType | null }>;
+  requestStats: { last24h: number; last7d: number; last30d: number };
+};

--- a/front/lib/resources/credit_resource.ts
+++ b/front/lib/resources/credit_resource.ts
@@ -1,3 +1,4 @@
+import type { PokeCreditType } from "@app/lib/api/poke/credits";
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { CreditModel } from "@app/lib/resources/storage/models/credits";
@@ -5,7 +6,6 @@ import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
-import type { PokeCreditType } from "@app/pages/api/poke/workspaces/[wId]/credits";
 import type { CreditDisplayData } from "@app/types/credits";
 import {
   CREDIT_EXPIRATION_DAYS,

--- a/front/pages/api/poke/workspaces/[wId]/credits/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/credits/index.ts
@@ -2,6 +2,10 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { metronomeBalanceToDisplayData } from "@app/lib/api/credits/metronome_balances";
+import type {
+  PokeListCreditsResponseBody,
+  PokeUnifiedCreditRow,
+} from "@app/lib/api/poke/credits";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { listMetronomeBalances } from "@app/lib/metronome/client";
@@ -10,35 +14,9 @@ import { isMetronomeExcessCredit } from "@app/lib/metronome/types";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
-import type { CreditDisplayData, CreditType } from "@app/types/credits";
+import type { CreditDisplayData } from "@app/types/credits";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeCreditType = {
-  id: number;
-  createdAt: string;
-  type: CreditType;
-  initialAmountMicroUsd: number;
-  consumedAmountMicroUsd: number;
-  remainingAmountMicroUsd: number;
-  startDate: string | null;
-  expirationDate: string | null;
-  discount: number | null;
-  invoiceOrLineItemId: string | null;
-  metronomeCreditId: string | null;
-};
-
-export type PokeUnifiedCreditRow = {
-  rowKey: string;
-  internal: PokeCreditType | null;
-  metronome: CreditDisplayData | null;
-};
-
-export type PokeListCreditsResponseBody = {
-  rows: PokeUnifiedCreditRow[];
-  excessCreditsLast30DaysMicroUsd: number;
-  hasMetronome: boolean;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/groups/[groupId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/groups/[groupId]/details.ts
@@ -1,20 +1,14 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { PokeGetGroupDetails } from "@app/lib/api/poke/groups";
 import { getGroupMembersWithWorkspaces } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { GroupType } from "@app/types/groups";
-import type { UserTypeWithWorkspaces } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeGetGroupDetails = {
-  members: UserTypeWithWorkspaces[];
-  group: GroupType;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/groups/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/groups/index.ts
@@ -1,17 +1,13 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { PokeListGroups } from "@app/lib/api/poke/groups";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { GroupType } from "@app/types/groups";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeListGroups = {
-  groups: GroupType[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/mcp/views/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/mcp/views/index.ts
@@ -1,7 +1,7 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
-import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { PokeListMCPServerViews } from "@app/lib/api/poke/mcp_server_views";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -9,10 +9,6 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeListMCPServerViews = {
-  serverViews: MCPServerViewType[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/mcp_server_views/[svId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/mcp_server_views/[svId]/details.ts
@@ -1,18 +1,14 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { PokeGetMCPServerViewDetails } from "@app/lib/api/poke/mcp_server_views";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { mcpServerViewToPokeJSON } from "@app/lib/poke/utils";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { PokeMCPServerViewType } from "@app/types/poke";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeGetMCPServerViewDetails = {
-  mcpServerView: PokeMCPServerViewType;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/webhook_sources/[wsId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/webhook_sources/[wsId]/details.ts
@@ -1,27 +1,15 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { PokeGetWebhookSourceDetails } from "@app/lib/api/poke/webhook_sources";
 import { getWebhookSourceAdminDetails } from "@app/lib/api/webhook_source";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { TriggerType } from "@app/types/assistant/triggers";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
-import type {
-  WebhookSourceForAdminType,
-  WebhookSourceViewForAdminType,
-} from "@app/types/triggers/webhooks";
-import type { UserType } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeGetWebhookSourceDetails = {
-  webhookSource: WebhookSourceForAdminType;
-  views: WebhookSourceViewForAdminType[];
-  triggers: Array<TriggerType & { editorUser: UserType | null }>;
-  requestStats: { last24h: number; last7d: number; last30d: number };
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/webhook_sources/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/webhook_sources/index.ts
@@ -1,20 +1,14 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { PokeListWebhookSources } from "@app/lib/api/poke/webhook_sources";
 import { listWebhookSourcesWithCounts } from "@app/lib/api/webhook_source";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
-import type { WebhookSourceType } from "@app/types/triggers/webhooks";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeListWebhookSources = {
-  webhookSources: Array<
-    WebhookSourceType & { viewCount: number; triggerCount: number }
-  >;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -13,8 +13,8 @@ import type {
 import type { WindowSize } from "@app/lib/api/analytics/time_utils";
 import type { AwuPoolSummaryResponseBody } from "@app/lib/api/credits/awu_pool_summary";
 import type { GetMembersUsageResponseBody } from "@app/lib/api/credits/members_usage";
+import type { PokeListCreditsResponseBody } from "@app/lib/api/poke/credits";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeListCreditsResponseBody } from "@app/pages/api/poke/workspaces/[wId]/credits";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/group_details.ts
+++ b/front/poke/swr/group_details.ts
@@ -1,5 +1,5 @@
+import type { PokeGetGroupDetails } from "@app/lib/api/poke/groups";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeGetGroupDetails } from "@app/pages/api/poke/workspaces/[wId]/groups/[groupId]/details";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/groups.ts
+++ b/front/poke/swr/groups.ts
@@ -1,5 +1,5 @@
+import type { PokeListGroups } from "@app/lib/api/poke/groups";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeListGroups } from "@app/pages/api/poke/workspaces/[wId]/groups";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/mcp_server_view_details.ts
+++ b/front/poke/swr/mcp_server_view_details.ts
@@ -1,5 +1,5 @@
+import type { PokeGetMCPServerViewDetails } from "@app/lib/api/poke/mcp_server_views";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeGetMCPServerViewDetails } from "@app/pages/api/poke/workspaces/[wId]/mcp_server_views/[svId]/details";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/mcp_server_views.ts
+++ b/front/poke/swr/mcp_server_views.ts
@@ -1,5 +1,5 @@
+import type { PokeListMCPServerViews } from "@app/lib/api/poke/mcp_server_views";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeListMCPServerViews } from "@app/pages/api/poke/workspaces/[wId]/mcp/views";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/webhook_source_details.ts
+++ b/front/poke/swr/webhook_source_details.ts
@@ -1,5 +1,5 @@
+import type { PokeGetWebhookSourceDetails } from "@app/lib/api/poke/webhook_sources";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeGetWebhookSourceDetails } from "@app/pages/api/poke/workspaces/[wId]/webhook_sources/[wsId]/details";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/webhook_sources.ts
+++ b/front/poke/swr/webhook_sources.ts
@@ -1,5 +1,5 @@
+import type { PokeListWebhookSources } from "@app/lib/api/poke/webhook_sources";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeListWebhookSources } from "@app/pages/api/poke/workspaces/[wId]/webhook_sources";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
 


### PR DESCRIPTION
  ## What & why

  Continues removing `front/pages/api` (Next) in favor of Hono. First batch of the
  poke long-tail ("sub-round D"), covering four workspace-scoped admin resources:
  **credits, groups, webhook_sources, mcp_server_views**.

  Applies the single-source invariant: a contract the frontend needs lives only in
  `lib/api/poke/*`, imported by the Next handler, the Hono handler, and the client
  alike — no type duplicated across lib and a Hono route. Type-only, no behavior
  change.

  ## Changes

  New lib modules, imported by all three sides:

  | Module | Types |
  |---|---|
  | `lib/api/poke/credits.ts` | `PokeCreditType`, `PokeUnifiedCreditRow`, `PokeListCreditsResponseBody` |
  | `lib/api/poke/groups.ts` | `PokeListGroups`, `PokeGetGroupDetails` |
  | `lib/api/poke/webhook_sources.ts` | `PokeListWebhookSources`, `PokeGetWebhookSourceDetails` |
  | `lib/api/poke/mcp_server_views.ts` | `PokeListMCPServerViews`, `PokeGetMCPServerViewDetails` |

  - 7 Next pages + 7 Hono routes repointed at lib; local type defs deleted and
    def-only dependency imports removed (the `credits` handlers keep
    `CreditDisplayData`, which they still use).
  - 11 consumers repointed (`poke/swr/*`, `components/poke/*`), plus
    `lib/resources/credit_resource.ts`, which consumes `PokeCreditType` — now from
    lib. No runtime cycle, since that import is type-only.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
