### PR TITLE
Attribute sub-agent usage to the originating API key (attribution only)

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -924,10 +924,13 @@ export async function postUserMessage(
       transaction: t,
     });
 
-    // Enrich context with auth data for analytics tracking.
+    // Enrich context with auth data for analytics tracking. When an attribution
+    // key is set (internal system-key calls like run_agent forward the original
+    // caller's key name), attribute usage to it instead of the request's own key;
+    // this drives api_key_name in usage analytics without affecting authorization.
     const enrichedContext: UserMessageContext = {
       ...context,
-      apiKeyId: auth.key()?.id ?? null,
+      apiKeyId: auth.attributionKeyId() ?? auth.key()?.id ?? null,
       authMethod: auth.authMethod(),
     };
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -930,7 +930,7 @@ export async function postUserMessage(
     // this drives api_key_name in usage analytics without affecting authorization.
     const enrichedContext: UserMessageContext = {
       ...context,
-      apiKeyId: auth.attributionKeyId() ?? auth.key()?.id ?? null,
+      apiKeyId: auth.attributionKeyModelId() ?? auth.key()?.id ?? null,
       authMethod: auth.authMethod(),
     };
 

--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -10,6 +10,7 @@ import {
 } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 
+import { KeyResource } from "@app/lib/resources/key_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { getClientIp } from "@app/lib/utils/request";
 import type { NextApiRequestWithContext } from "@app/logger/withlogging";
@@ -477,18 +478,25 @@ export function withPublicAPIAuthentication<T>(
           )) ?? workspaceAuth;
       }
 
-      // If we have a system key, we can override the key name from http headers.
-      // This is only used for run_agent API call, to keep the original key name and get proper analytics.
+      // When authenticated with the workspace system key, an internal caller can
+      // pass the original API key name via header so usage is *attributed* to that
+      // key (e.g. run_agent / deep-dive sub-agents). This is attribution only: we
+      // resolve the name to a key within the same workspace and attach it as an
+      // attribution key. We never swap the authenticator's actual key, so
+      // authorization (role, caps, system-key checks) is unaffected.
       const apiKeyNameFromHeader = getApiKeyNameFromHeaders(req.headers);
       const key = workspaceAuth.key();
       if (apiKeyNameFromHeader && key && key.isSystem) {
-        workspaceAuth = workspaceAuth.exchangeKey({
-          id: key.id,
+        const attributionKey = await KeyResource.fetchByName(workspaceAuth, {
           name: apiKeyNameFromHeader,
-          isSystem: key.isSystem,
-          role: key.role,
-          monthlyCapMicroUsd: key.monthlyCapMicroUsd,
+          onlyActive: true,
         });
+        if (attributionKey && !attributionKey.isSystem) {
+          workspaceAuth = workspaceAuth.withAttributionKey({
+            id: attributionKey.id,
+            name: attributionKey.name,
+          });
+        }
       }
       setClientIpOnAuth(workspaceAuth, req);
 

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1209,7 +1209,7 @@ export class Authenticator {
     return this._attributionKey ?? null;
   }
 
-  attributionKeyId(): ModelId | null {
+  attributionKeyModelId(): ModelId | null {
     return this._attributionKey?.id ?? null;
   }
 

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -96,6 +96,7 @@ export interface AuthenticatorType {
   subscriptionId: string | null;
   isByok: boolean;
   key?: KeyAuthType;
+  attributionKey?: { id: ModelId; name: string };
   clientIp?: string;
 }
 
@@ -108,6 +109,10 @@ export interface AuthenticatorType {
  */
 export class Authenticator {
   _key?: KeyAuthType;
+  // Attribution-only key reference. Records which API key a request should be
+  // *attributed* to for usage analytics, independently of `_key`. It never
+  // influences authorization (role, caps, system-key checks all read `_key`).
+  _attributionKey?: { id: ModelId; name: string };
   _role: RoleType;
   _subscription: SubscriptionResource | null;
   _user: UserResource | null;
@@ -126,6 +131,7 @@ export class Authenticator {
     authMethod,
     subscription,
     key,
+    attributionKey,
     providersHealth,
     clientIp,
   }: {
@@ -136,6 +142,7 @@ export class Authenticator {
     authMethod: AuthMethodType;
     subscription?: SubscriptionResource | null;
     key?: KeyAuthType;
+    attributionKey?: { id: ModelId; name: string };
     providersHealth?: ProvidersHealth | null;
     clientIp?: string;
   }) {
@@ -149,6 +156,7 @@ export class Authenticator {
     this._subscription = subscription || null;
     this._authMethod = authMethod;
     this._key = key;
+    this._attributionKey = attributionKey;
     this._providersHealth = providersHealth ?? null;
     this._clientIp = clientIp;
     if (user) {
@@ -1197,6 +1205,37 @@ export class Authenticator {
     return this._key ?? null;
   }
 
+  attributionKey(): { id: ModelId; name: string } | null {
+    return this._attributionKey ?? null;
+  }
+
+  attributionKeyId(): ModelId | null {
+    return this._attributionKey?.id ?? null;
+  }
+
+  // Returns a copy of this authenticator carrying an attribution-only key
+  // reference. Used to attribute usage to the original caller's key when an
+  // internal flow re-authenticates with the workspace system key (e.g. run_agent
+  // sub-agents). This is attribution only: `_key` is left untouched, so role,
+  // caps and system-key checks keep operating on the actual (system) key.
+  withAttributionKey(attributionKey: {
+    id: ModelId;
+    name: string;
+  }): Authenticator {
+    return new Authenticator({
+      authMethod: this._authMethod,
+      key: this._key,
+      attributionKey,
+      role: this._role,
+      groupModelIds: this._groupModelIds,
+      user: this._user,
+      subscription: this._subscription,
+      workspace: this._workspace,
+      clientIp: this._clientIp,
+      providersHealth: this._providersHealth,
+    });
+  }
+
   toJSON(): AuthenticatorType {
     const workspace = this._workspace;
     assert(workspace, "Workspace is required to serialize Authenticator");
@@ -1210,6 +1249,7 @@ export class Authenticator {
       subscriptionId: this._subscription?.sId ?? null,
       isByok: this.plan()?.isByok ?? false,
       key: this._key,
+      attributionKey: this._attributionKey,
       clientIp: this._clientIp,
     };
   }
@@ -1261,6 +1301,7 @@ export class Authenticator {
       groupModelIds: groupIds,
       subscription,
       key: authType.key,
+      attributionKey: authType.attributionKey,
       providersHealth,
       clientIp: authType.clientIp,
     });
@@ -1630,12 +1671,16 @@ export function getApiKeyNameFromHeaders(headers: {
 }
 
 export function getApiKeyNameHeader(auth: Authenticator) {
-  const key = auth.key();
-  if (!key || !key.name) {
+  // Prefer the attribution key name over the request's own key so the original
+  // caller's key name propagates transitively through nested internal system-key
+  // calls (e.g. a sub-agent that itself spawns sub-agents). Without this, a nested
+  // call would forward the system key name ("DustSystemKey") and lose attribution.
+  const name = auth.attributionKey()?.name ?? auth.key()?.name;
+  if (!name) {
     return undefined;
   }
 
   return {
-    [DustApiKeyNameHeader]: key.name,
+    [DustApiKeyNameHeader]: name,
   };
 }

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -311,14 +311,20 @@ export async function emitMetronomeUsageEventsActivity(
     }
   }
 
-  // Resolve API key name from the stored numeric FK.
+  // Resolve API key name from the stored numeric FK. We deliberately never surface
+  // the workspace system key ("DustSystemKey") as the API key name: sub-agent runs
+  // and other internal flows authenticate with the system key, but that is an
+  // implementation detail, not a meaningful billing attribution. In those cases we
+  // leave the API key name unset (it surfaces as "unknown" in the event).
   let apiKeyName: string | null = null;
   if (userMessage?.userContextApiKeyId) {
     const key = await KeyResource.fetchByWorkspaceAndId({
       workspace,
       id: userMessage.userContextApiKeyId,
     });
-    apiKeyName = key?.name ?? null;
+    if (key && !key.isSystem) {
+      apiKeyName = key.name;
+    }
   }
 
   // Get LLM run usages.


### PR DESCRIPTION
https://github.com/dust-tt/tasks/issues/8571

## Description

> **Stacked on #26790** (base branch `use-parent-agent-name-key`). Review/merge that one first; this PR's diff is only the API-key attribution.

Fix API key attribution for sub-agent runs (`run_agent` / `agent_handover`) — e.g. the `dust-task` / `dust-planning` runs spawned by the **Go Deep** agent — which were all surfacing under the workspace system key (`DustSystemKey`) in usage analytics, with no link to the originating API key.

**Root cause.** Sub-agents re-authenticate to the Dust API with the workspace system key. Usage analytics resolves `api_key_name` from the persisted key id (`userContextApiKeyId`), which is always the system key for these flows. The pre-existing `x-dust-api-key-name` header (#19280) only overrode the *in-memory* key name, never the persisted id — so once analytics switched to id-based resolution (#20746) the header became a no-op and everything collapsed to `DustSystemKey`.

**Changes — attribution-only key propagation, never touching `auth.key()`:**
- `Authenticator` gains an attribution-only key reference (`withAttributionKey` / `attributionKeyId`), separate from `_key` and persisted through `toJSON`/`fromJSON`. It **never** affects authorization — role, caps, and system-key checks all keep reading `_key`.
- `withPublicAPIAuthentication` resolves the `x-dust-api-key-name` header to a key **within the same workspace** (`KeyResource.fetchByName`) and attaches it as the attribution key, instead of overriding the auth key.
- User messages persist `apiKeyId = attributionKeyId ?? key.id`, so id-based analytics resolve the real originating key.
- `getApiKeyNameHeader` forwards the attribution name, so attribution propagates **transitively** through nested sub-agents and across the Temporal boundary.
- Metronome events never surface the system key as `api_key_name` (keyless internal runs → `unknown`).

**Result:** API-rooted Go Deep runs attribute to the real customer key at every depth; web/session-rooted runs (no key) resolve to `unknown` instead of `DustSystemKey`. Only the key *name* travels over the wire (no ModelId), preserving SEC2.

## Tests

- `tsgo --noEmit` clean; `biome check` clean.
- `lib/api/assistant/conversation.test.ts` — 82/82 pass.
- Verified `auth.key()` (and therefore authorization) is untouched, and that `_attributionKey` round-trips through `toJSON`/`fromJSON`.

## Risk

Low–medium. Attribution-only — authorization paths untouched. Behavior change to be aware of: the per-key monthly cap accounting (name-based ES sum, `key_cap.ts`) will now include sub-agent usage attributed to a real key. Forward-only and rollback-safe: no schema/data migration, past events are not rewritten.

## Deploy Plan

Deploy front (after #26790). No migration. Forward-only — does not backfill or rewrite past usage events.
