### PR TITLE
pricing: store the per user credit pool limit in DB

### DIFF
--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
@@ -3,6 +3,7 @@ import * as spendLimits from "@app/lib/metronome/alerts/spend_limits";
 import * as perUserUsage from "@app/lib/metronome/per_user_usage";
 import * as planType from "@app/lib/metronome/plan_type";
 import * as seatTypes from "@app/lib/metronome/seat_types";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
@@ -20,7 +21,6 @@ vi.mock("@app/lib/metronome/alerts/spend_limits", async () => {
     ...actual,
     upsertMetronomePerUserCapAlert: vi.fn(),
     clearMetronomePerUserCapAlert: vi.fn(),
-    getMetronomePerUserCap: vi.fn(),
     getMetronomeDefaultUserCapAlertForSeatType: vi.fn(),
   };
 });
@@ -84,7 +84,6 @@ beforeEach(() => {
   vi.mocked(spendLimits.clearMetronomePerUserCapAlert).mockResolvedValue(
     new Ok(undefined)
   );
-  vi.mocked(spendLimits.getMetronomePerUserCap).mockResolvedValue(new Ok(null));
   vi.mocked(
     spendLimits.getMetronomeDefaultUserCapAlertForSeatType
   ).mockResolvedValue(new Ok(null));
@@ -239,7 +238,7 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
   });
 
   describe("GET", () => {
-    it("returns unlimited when no per-user alert exists", async () => {
+    it("returns unlimited when no override is persisted", async () => {
       const workspace = await makeMetronomeWorkspaceWithCustomer();
       const { user } = await createPrivateApiMockRequest({
         method: "GET",
@@ -255,30 +254,24 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
       expect(await response.json()).toEqual({ kind: "unlimited" });
     });
 
-    it("returns limited with threshold when alert exists", async () => {
-      vi.mocked(spendLimits.getMetronomePerUserCap).mockResolvedValueOnce(
-        new Ok({
-          alert: {
-            id: TEST_ALERT_ID,
-            name: "test alert",
-            status: "enabled",
-            threshold: 2500,
-            type: "spend_threshold_reached",
-            updated_at: "2024-01-01T00:00:00Z",
-          },
-          customer_status: "ok",
-        })
-      );
-
+    it("returns limited with the override persisted on the membership", async () => {
       const workspace = await makeMetronomeWorkspaceWithCustomer();
-      const { user } = await createPrivateApiMockRequest({
+      const targetUser = await UserFactory.basic();
+      const membership = await MembershipFactory.associate(
+        workspace,
+        targetUser,
+        { role: "user" }
+      );
+      await membership.updatePoolCapOverride(2500);
+
+      await createPrivateApiMockRequest({
         method: "GET",
         role: "admin",
         workspace,
       });
 
       const response = await honoApp.request(
-        spendLimitUrl(workspace.sId, user.sId)
+        spendLimitUrl(workspace.sId, targetUser.sId)
       );
 
       expect(response.status).toBe(200);
@@ -293,9 +286,12 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
     it("clears alert + dispatches resolved for unlimited", async () => {
       const workspace = await makeMetronomeWorkspaceWithCustomer();
       const targetUser = await UserFactory.basic();
-      await MembershipFactory.associate(workspace, targetUser, {
-        role: "user",
-      });
+      const membership = await MembershipFactory.associate(
+        workspace,
+        targetUser,
+        { role: "user" }
+      );
+      await membership.updatePoolCapOverride(1200);
 
       await createPrivateApiMockRequest({
         method: "PUT",
@@ -330,6 +326,14 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
         expect.objectContaining({ userId: targetUser.sId })
       );
       expect(spendLimits.upsertMetronomePerUserCapAlert).not.toHaveBeenCalled();
+
+      // The persisted override is cleared.
+      const updatedMembership =
+        await MembershipResource.getActiveMembershipOfUserInWorkspace({
+          user: targetUser,
+          workspace,
+        });
+      expect(updatedMembership?.poolCapOverrideAwuCredits).toBeNull();
     });
 
     it("syncs alert + dispatches resolved when usage is below cap", async () => {
@@ -377,6 +381,14 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
       expect(
         creditStateDispatcher.dispatchPerUserCapReached
       ).not.toHaveBeenCalled();
+
+      // The pool-only override is persisted on the membership.
+      const updatedMembership =
+        await MembershipResource.getActiveMembershipOfUserInWorkspace({
+          user: targetUser,
+          workspace,
+        });
+      expect(updatedMembership?.poolCapOverrideAwuCredits).toBe(1500);
     });
 
     it("dispatches reached when usage is at/above cap", async () => {

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1,8 +1,11 @@
 import type { Authenticator } from "@app/lib/auth";
-import type { MetronomeCapAlertInfo } from "@app/lib/metronome/alerts/spend_limits";
+import type {
+  MetronomeCapAlertIds,
+  MetronomeCapAlertInfo,
+} from "@app/lib/metronome/alerts/spend_limits";
 import {
   getCachedDefaultCapThresholdsBySeatType,
-  getCachedPerUserCapThresholds,
+  getCachedPerUserCapAlertIds,
   getMetronomeDefaultUserCapAlertForSeatType,
   getMetronomeDefaultUserWarningAlertForSeatType,
   listMetronomePerUserCapsForWorkspace,
@@ -12,6 +15,7 @@ import {
   fetchPerUserAwuUsage,
   getCachedPerUserAwuUsage,
 } from "@app/lib/metronome/per_user_usage";
+import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_types";
 import {
   buildSeatDataByUserId,
   getCachedSeatDataByUserId,
@@ -213,13 +217,13 @@ async function fetchSeatDataForMembersTable({
   }
 }
 
-async function fetchPerUserCapOverridesUncached({
+async function fetchPerUserCapAlertIdsUncached({
   metronomeCustomerId,
   workspaceId,
 }: {
   metronomeCustomerId: string;
   workspaceId: string;
-}): Promise<Map<string, MetronomeCapAlertInfo>> {
+}): Promise<Map<string, MetronomeCapAlertIds>> {
   const [capsResult, warningsResult] = await Promise.all([
     listMetronomePerUserCapsForWorkspace({ metronomeCustomerId, workspaceId }),
     listMetronomePerUserWarningAlertsForWorkspace({
@@ -230,16 +234,15 @@ async function fetchPerUserCapOverridesUncached({
   if (capsResult.isErr()) {
     logger.warn(
       { err: capsResult.error, workspaceId },
-      "[MembersUsage] Failed to fetch per-user spend caps"
+      "[MembersUsage] Failed to fetch per-user spend cap alerts"
     );
     return new Map();
   }
   const warnings = warningsResult.isErr() ? new Map() : warningsResult.value;
 
-  const caps = new Map<string, MetronomeCapAlertInfo>();
+  const caps = new Map<string, MetronomeCapAlertIds>();
   for (const [userId, entry] of capsResult.value) {
     caps.set(userId, {
-      threshold: entry.alert.threshold,
       alertId: entry.alert.id,
       warningAlertId: warnings.get(userId)?.alert.id ?? null,
     });
@@ -294,48 +297,76 @@ async function fetchDefaultCapsBySeatTypeUncached({
 }
 
 /**
- * Resolve the effective per-user spend limit for the members table:
- *   - if the user has a per-user override, the override threshold wins
- *   - otherwise, the workspace default for the user's seat type applies
- *   - otherwise, the user is uncapped (`null`)
- *
- * Returns per-user overrides and per-seat-type default thresholds.
+ * Resolve the inputs needed to compute the effective per-user spend limit for
+ * the members table:
+ *   - the per-seat-type default cap thresholds (Metronome alerts)
+ *   - the per-seat-type seat allowances, used to derive the total threshold
+ *     from the pool-only override persisted on each membership
+ *   - the per-user override alerts, fetched from Metronome only when alert
+ *     deep links are requested (the override *threshold* comes from the DB)
  */
 async function fetchEffectivePerUserSpendLimits({
   metronomeCustomerId,
   workspaceId,
+  includeAlertLinks,
 }: {
   metronomeCustomerId: string | null;
   workspaceId: string;
+  includeAlertLinks: boolean;
 }): Promise<{
-  perUserOverrides: Map<string, MetronomeCapAlertInfo>;
+  perUserOverrideAlerts: Map<string, MetronomeCapAlertIds>;
   defaultAwuCreditsBySeatType: Partial<
     Record<NormalizedPoolLimitSeatType, MetronomeCapAlertInfo>
   >;
+  seatAllowanceBySeatType: Partial<Record<NormalizedPoolLimitSeatType, number>>;
 }> {
   if (!metronomeCustomerId) {
-    return { perUserOverrides: new Map(), defaultAwuCreditsBySeatType: {} };
+    return {
+      perUserOverrideAlerts: new Map(),
+      defaultAwuCreditsBySeatType: {},
+      seatAllowanceBySeatType: {},
+    };
   }
 
-  const [perUserOverrides, defaultAwuCreditsBySeatType] = await Promise.all([
-    fetchPerUserCapOverrides({ metronomeCustomerId, workspaceId }),
-    fetchDefaultCapsBySeatType({ metronomeCustomerId, workspaceId }),
-  ]);
+  const [perUserOverrideAlerts, defaultAwuCreditsBySeatType] =
+    await Promise.all([
+      includeAlertLinks
+        ? fetchPerUserCapAlertIds({ metronomeCustomerId, workspaceId })
+        : Promise.resolve(new Map<string, MetronomeCapAlertIds>()),
+      fetchDefaultCapsBySeatType({ metronomeCustomerId, workspaceId }),
+    ]);
 
-  return { perUserOverrides, defaultAwuCreditsBySeatType };
+  let seatAllowanceBySeatType: Partial<
+    Record<NormalizedPoolLimitSeatType, number>
+  > = {};
+  try {
+    seatAllowanceBySeatType =
+      await getSeatAllowancesByNormalizedSeatType(workspaceId);
+  } catch (err) {
+    logger.warn(
+      { err: normalizeError(err), workspaceId },
+      "[MembersUsage] Failed to resolve seat allowances, degrading to pool-only override thresholds"
+    );
+  }
+
+  return {
+    perUserOverrideAlerts,
+    defaultAwuCreditsBySeatType,
+    seatAllowanceBySeatType,
+  };
 }
 
-async function fetchPerUserCapOverrides({
+async function fetchPerUserCapAlertIds({
   metronomeCustomerId,
   workspaceId,
 }: {
   metronomeCustomerId: string;
   workspaceId: string;
-}): Promise<Map<string, MetronomeCapAlertInfo>> {
+}): Promise<Map<string, MetronomeCapAlertIds>> {
   try {
     return new Map(
       Object.entries(
-        await getCachedPerUserCapThresholds({
+        await getCachedPerUserCapAlertIds({
           metronomeCustomerId,
           workspaceId,
         })
@@ -344,9 +375,9 @@ async function fetchPerUserCapOverrides({
   } catch (err) {
     logger.warn(
       { err: normalizeError(err), workspaceId },
-      "[MembersUsage] Failed to read cached per-user spend caps, falling back to uncached fetch"
+      "[MembersUsage] Failed to read cached per-user spend cap alert ids, falling back to uncached fetch"
     );
-    return fetchPerUserCapOverridesUncached({
+    return fetchPerUserCapAlertIdsUncached({
       metronomeCustomerId,
       workspaceId,
     });
@@ -433,9 +464,14 @@ export async function getMembersUsage({
     fetchEffectivePerUserSpendLimits({
       metronomeCustomerId: metronomeCustomerId ?? null,
       workspaceId: workspace.sId,
+      includeAlertLinks,
     }),
   ]);
-  const { perUserOverrides, defaultAwuCreditsBySeatType } = perUserSpendLimits;
+  const {
+    perUserOverrideAlerts,
+    defaultAwuCreditsBySeatType,
+    seatAllowanceBySeatType,
+  } = perUserSpendLimits;
 
   const { memberships } = membershipsResult;
 
@@ -468,31 +504,38 @@ export async function getMembersUsage({
       totalConsumedCredits - consumedFromAllowanceAwuCredits;
 
     // Resolve the default cap for this member's seat type, and the user's
-    // override if any. Each carries the backing Metronome alert id so the UI
-    // can deep-link to the effective cap.
+    // override if any. The override threshold is derived from the pool-only
+    // value persisted on the membership plus the seat allowance; the
+    // Metronome alert ids are only resolved for deep links.
     const normalizedSeatType = normalizeToPoolLimitSeatType(
       membership.seatType
     );
     const defaultCap = normalizedSeatType
       ? (defaultAwuCreditsBySeatType[normalizedSeatType] ?? null)
       : null;
-    const overrideCap = perUserOverrides.get(userId) ?? null;
+    const overrideAwuCredits =
+      membership.poolCapOverrideAwuCredits !== null
+        ? membership.poolCapOverrideAwuCredits +
+          (normalizedSeatType
+            ? (seatAllowanceBySeatType[normalizedSeatType] ?? 0)
+            : 0)
+        : null;
 
     const spendLimitSource = resolveEffectiveSpendLimitSource({
-      overrideAwuCredits: overrideCap?.threshold ?? null,
+      overrideAwuCredits,
       defaultAwuCredits: defaultCap?.threshold ?? null,
     });
-    const effectiveCap =
+    const effectiveCapAlert =
       spendLimitSource === "override"
-        ? overrideCap
+        ? (perUserOverrideAlerts.get(userId) ?? null)
         : spendLimitSource === "default"
           ? defaultCap
           : null;
     const spendLimitAlertId = includeAlertLinks
-      ? (effectiveCap?.alertId ?? null)
+      ? (effectiveCapAlert?.alertId ?? null)
       : null;
     const spendLimitWarningAlertId = includeAlertLinks
-      ? (effectiveCap?.warningAlertId ?? null)
+      ? (effectiveCapAlert?.warningAlertId ?? null)
       : null;
 
     return [
@@ -512,7 +555,7 @@ export async function getMembersUsage({
         scheduledSeatType: scheduled?.seatType ?? null,
         scheduledSeatChangeAt: scheduled?.startAt.toISOString() ?? null,
         spendLimitAwuCredits: resolveEffectiveSpendLimitAwuCredits({
-          overrideAwuCredits: overrideCap?.threshold ?? null,
+          overrideAwuCredits,
           defaultAwuCredits: defaultCap?.threshold ?? null,
         }),
         spendLimitSource,

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -417,6 +417,7 @@ export async function dispatchPerUserCapResolved({
     workspace,
     userId,
     seatType: membership.seatType,
+    poolCapOverrideAwuCredits: membership.poolCapOverrideAwuCredits,
   });
 
   const result = await transitionUserCreditState(
@@ -442,10 +443,12 @@ async function resolveLiveBalanceForCapResolved({
   workspace,
   userId,
   seatType,
+  poolCapOverrideAwuCredits,
 }: {
   workspace: WorkspaceResource;
   userId: string;
   seatType: MembershipSeatType | null;
+  poolCapOverrideAwuCredits: number | null;
 }): Promise<LiveUserSeatBalance | undefined> {
   const { metronomeCustomerId } = workspace;
   if (!metronomeCustomerId) {
@@ -461,6 +464,7 @@ async function resolveLiveBalanceForCapResolved({
     workspaceId: workspace.sId,
     userId,
     seatType,
+    poolCapOverrideAwuCredits,
     metronomeCustomerId,
     metronomeContractId,
   });

--- a/front/lib/api/metronome/reconcile_credit_state.test.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.test.ts
@@ -12,12 +12,10 @@ import { reconcileWorkspaceUserCreditStates } from "./reconcile_credit_state";
 const {
   mockListMetronomeSeatBalances,
   mockFetchPerUserAwuUsage,
-  mockGetCachedPerUserCapThresholds,
   mockGetCachedDefaultCapThresholdsBySeatType,
 } = vi.hoisted(() => ({
   mockListMetronomeSeatBalances: vi.fn(),
   mockFetchPerUserAwuUsage: vi.fn(),
-  mockGetCachedPerUserCapThresholds: vi.fn(),
   mockGetCachedDefaultCapThresholdsBySeatType: vi.fn(),
 }));
 
@@ -44,7 +42,6 @@ vi.mock("@app/lib/metronome/alerts/spend_limits", async () => {
   >("@app/lib/metronome/alerts/spend_limits");
   return {
     ...actual,
-    getCachedPerUserCapThresholds: mockGetCachedPerUserCapThresholds,
     getCachedDefaultCapThresholdsBySeatType:
       mockGetCachedDefaultCapThresholdsBySeatType,
   };
@@ -69,7 +66,6 @@ function seatBalance(userId: string, balanceAwu: number, startingAwu: number) {
 beforeEach(() => {
   vi.clearAllMocks();
   mockFetchPerUserAwuUsage.mockResolvedValue(new Ok(new Map<string, number>()));
-  mockGetCachedPerUserCapThresholds.mockResolvedValue({});
   mockGetCachedDefaultCapThresholdsBySeatType.mockResolvedValue({});
 });
 

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -3,10 +3,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { isPAYGEnabled } from "@app/lib/credits/credit_payg";
 import { getMetronomeProgrammaticCapAlertStates } from "@app/lib/metronome/alerts/programmatic_cap";
 import type { MetronomeCapAlertInfo } from "@app/lib/metronome/alerts/spend_limits";
-import {
-  getCachedDefaultCapThresholdsBySeatType,
-  getCachedPerUserCapThresholds,
-} from "@app/lib/metronome/alerts/spend_limits";
+import { getCachedDefaultCapThresholdsBySeatType } from "@app/lib/metronome/alerts/spend_limits";
 import { listMetronomeSeatBalances } from "@app/lib/metronome/client";
 import {
   awuSeatBalanceForUser,
@@ -17,6 +14,7 @@ import {
   expectedProgrammaticCreditStateFromAlerts,
   setProgrammaticCreditStateReconciled,
 } from "@app/lib/metronome/programmatic_credit_state_machine";
+import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_types";
 import { setUserCreditStateReconciled } from "@app/lib/metronome/user_credit_state_machine";
 import {
   expectedPoolCreditStateFromBalance,
@@ -300,6 +298,9 @@ async function reconcileUser({
     workspaceId: workspace.sId,
     userId,
     seatType,
+    // Pool-only override persisted on the membership; the live-inputs helper
+    // adds the seat allowance back to get the total threshold.
+    poolCapOverrideAwuCredits: membership.poolCapOverrideAwuCredits,
     metronomeCustomerId,
     metronomeContractId,
   });
@@ -400,16 +401,16 @@ export async function reconcileWorkspaceUserCreditStates({
   const seatBalances = seatBalancesResult.value;
   const usageByUser = usageResult.value;
 
-  // The cap-threshold caches (Metronome alert list) and the membership query
-  // (DB) can genuinely throw, so they stay wrapped — the ERR1-authorised case.
-  let capOverrides: Record<string, MetronomeCapAlertInfo>;
+  // The cap-threshold caches (Metronome alert list / contract) and the
+  // membership query (DB) can genuinely throw, so they stay wrapped — the
+  // ERR1-authorised case. The per-user overrides themselves come from the
+  // memberships (pool-only values); the seat allowances are needed to derive
+  // the total thresholds.
+  let seatAllowances: Partial<Record<NormalizedPoolLimitSeatType, number>>;
   let defaultCaps: Record<NormalizedPoolLimitSeatType, MetronomeCapAlertInfo>;
   let memberships: MembershipResource[];
   try {
-    capOverrides = await getCachedPerUserCapThresholds({
-      metronomeCustomerId,
-      workspaceId,
-    });
+    seatAllowances = await getSeatAllowancesByNormalizedSeatType(workspaceId);
     defaultCaps = await getCachedDefaultCapThresholdsBySeatType({
       metronomeCustomerId,
       workspaceId,
@@ -439,10 +440,12 @@ export async function reconcileWorkspaceUserCreditStates({
 
     const normalizedSeatType = normalizeToPoolLimitSeatType(seatType);
     const effectiveCapAwuCredits =
-      capOverrides[userId]?.threshold ??
-      (normalizedSeatType
-        ? (defaultCaps[normalizedSeatType]?.threshold ?? null)
-        : null);
+      membership.poolCapOverrideAwuCredits !== null
+        ? membership.poolCapOverrideAwuCredits +
+          (normalizedSeatType ? (seatAllowances[normalizedSeatType] ?? 0) : 0)
+        : normalizedSeatType
+          ? (defaultCaps[normalizedSeatType]?.threshold ?? null)
+          : null;
 
     const seat = awuSeatBalanceForUser(seatBalances, userId);
     const expectedState = expectedUserCreditState({

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -13,19 +13,13 @@ import {
   clearMetronomePerUserCapAlert,
   clearMetronomePerUserWarningAlert,
   getMetronomeDefaultUserCapAlertForSeatType,
-  getMetronomePerUserCap,
   upsertMetronomePerUserCapAlert,
   upsertMetronomePerUserWarningAlert,
 } from "@app/lib/metronome/alerts/spend_limits";
 import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
-import { getActiveContract } from "@app/lib/metronome/plan_type";
-import {
-  getAwuAllocationForSeatType,
-  getProductSeatTypes,
-} from "@app/lib/metronome/seat_types";
+import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_types";
 import { clearUserAwuWarned } from "@app/lib/metronome/user_block";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
-import type { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
 import { normalizeToPoolLimitSeatType } from "@app/types/memberships";
@@ -66,34 +60,21 @@ export class UserSpendLimitError extends Error {
 }
 
 /**
- * Resolve the seat AWU allowance for a user based on their membership seat
- * type and the active contract. Returns 0 when the contract or seat type
- * can't be resolved (e.g. free seats, no contract).
+ * Resolve the seat AWU allowance for a membership based on its seat type and
+ * the active contract. Returns 0 when the contract or seat type can't be
+ * resolved (e.g. free seats, no contract).
  */
 async function resolveUserSeatAllowance(
   auth: Authenticator,
-  user: UserResource
+  membership: MembershipResource
 ): Promise<number> {
   const workspace = auth.getNonNullableWorkspace();
-  const membership =
-    await MembershipResource.getActiveMembershipOfUserInWorkspace({
-      user,
-      workspace,
-    });
-  const normalizedSeatType = normalizeToPoolLimitSeatType(membership?.seatType);
+  const normalizedSeatType = normalizeToPoolLimitSeatType(membership.seatType);
   if (!normalizedSeatType) {
     return 0;
   }
-  const contract = await getActiveContract(workspace.sId);
-  if (!contract) {
-    return 0;
-  }
-  const productSeatTypes = await getProductSeatTypes();
-  return getAwuAllocationForSeatType(
-    contract,
-    normalizedSeatType,
-    productSeatTypes
-  );
+  const allowances = await getSeatAllowancesByNormalizedSeatType(workspace.sId);
+  return allowances[normalizedSeatType] ?? 0;
 }
 
 export async function getUserSpendLimit(
@@ -120,26 +101,21 @@ export async function getUserSpendLimit(
     );
   }
 
-  const result = await getMetronomePerUserCap({
-    metronomeCustomerId: workspace.metronomeCustomerId,
-    workspaceId: workspace.sId,
-    userId: user.sId,
-  });
-  if (result.isErr()) {
-    return new Err(
-      new UserSpendLimitError("metronome_error", result.error.message)
-    );
-  }
-
-  if (!result.value) {
+  // The override persisted on the membership is the source of truth (the
+  // Metronome alert is derived from it, with the seat allowance added).
+  const membership =
+    await MembershipResource.getActiveMembershipOfUserInWorkspace({
+      user,
+      workspace,
+    });
+  if (!membership || membership.poolCapOverrideAwuCredits === null) {
     return new Ok({ kind: "unlimited" });
   }
 
-  // The Metronome threshold includes the seat allowance. Subtract it to
-  // return the pool-only portion (what the admin entered).
-  const seatAllowance = await resolveUserSeatAllowance(auth, user);
-  const poolAwuCredits = result.value.alert.threshold - seatAllowance;
-  return new Ok({ kind: "limited", awuCredits: poolAwuCredits });
+  return new Ok({
+    kind: "limited",
+    awuCredits: membership.poolCapOverrideAwuCredits,
+  });
 }
 
 /**
@@ -254,6 +230,27 @@ export async function setUserSpendLimit(
     );
   }
 
+  const membership =
+    await MembershipResource.getActiveMembershipOfUserInWorkspace({
+      user,
+      workspace,
+    });
+  if (!membership) {
+    return new Err(
+      new UserSpendLimitError(
+        "user_not_found",
+        "Could not find an active membership for the user in this workspace."
+      )
+    );
+  }
+
+  // Persist the admin's intent first: the membership is the source of truth,
+  // the Metronome alerts below are derived enforcement (a failed sync can be
+  // retried and re-derives from this value).
+  await membership.updatePoolCapOverride(
+    limit.kind === "limited" ? limit.awuCredits : null
+  );
+
   let transitionedTo: "reached" | "resolved" | null;
 
   switch (limit.kind) {
@@ -288,13 +285,8 @@ export async function setUserSpendLimit(
       void clearUserAwuWarned(workspace.sId, user.sId);
 
       // Look up the user's seat type to find the matching default cap.
-      const membership =
-        await MembershipResource.getActiveMembershipOfUserInWorkspace({
-          user,
-          workspace,
-        });
       const normalizedSeatType = normalizeToPoolLimitSeatType(
-        membership?.seatType
+        membership.seatType
       );
 
       let defaultAlert = null;
@@ -339,7 +331,7 @@ export async function setUserSpendLimit(
     case "limited": {
       // The admin enters pool credits. Add the seat allowance to get the
       // total Metronome threshold.
-      const seatAllowance = await resolveUserSeatAllowance(auth, user);
+      const seatAllowance = await resolveUserSeatAllowance(auth, membership);
       const totalAwuCredits = limit.awuCredits + seatAllowance;
 
       const upsertResult = await upsertMetronomePerUserCapAlert({

--- a/front/lib/metronome/alerts/spend_limits.ts
+++ b/front/lib/metronome/alerts/spend_limits.ts
@@ -251,16 +251,25 @@ export type MetronomeCapAlertInfo = {
   warningAlertId: string | null;
 };
 
-async function fetchPerUserCapThresholds(args: {
+// The Metronome alert ids backing a per-user cap override, for dashboard deep
+// links. Intentionally carries no threshold: the cap value lives on the
+// membership (`poolCapOverrideAwuCredits`), and the alert's threshold can lag
+// it (e.g. after a seat-type change) until the next override write re-syncs.
+export type MetronomeCapAlertIds = {
+  alertId: string;
+  warningAlertId: string | null;
+};
+
+async function fetchPerUserCapAlertIds(args: {
   metronomeCustomerId: string;
   workspaceId: string;
-}): Promise<Record<string, MetronomeCapAlertInfo>> {
+}): Promise<Record<string, MetronomeCapAlertIds>> {
   const capPrefix = perUserAlertUniquenessKeyPrefix(args.workspaceId);
   const warningPrefix = perUserWarningAlertUniquenessKeyPrefix(
     args.workspaceId
   );
 
-  const capByUser = new Map<string, { threshold: number; alertId: string }>();
+  const capIdByUser = new Map<string, string>();
   const warningIdByUser = new Map<string, string>();
 
   // Single scan: the per-user cap and its 80% warning share the customer alert
@@ -277,10 +286,7 @@ async function fetchPerUserCapThresholds(args: {
       if (key.startsWith(capPrefix)) {
         const userId = key.slice(capPrefix.length);
         if (userId) {
-          capByUser.set(userId, {
-            threshold: entry.alert.threshold,
-            alertId: entry.alert.id,
-          });
+          capIdByUser.set(userId, entry.alert.id);
         }
       } else if (key.startsWith(warningPrefix)) {
         const userId = key.slice(warningPrefix.length);
@@ -293,26 +299,26 @@ async function fetchPerUserCapThresholds(args: {
     throw normalizeError(err);
   }
 
-  const caps: Record<string, MetronomeCapAlertInfo> = {};
-  for (const [userId, cap] of capByUser) {
+  const caps: Record<string, MetronomeCapAlertIds> = {};
+  for (const [userId, alertId] of capIdByUser) {
     caps[userId] = {
-      ...cap,
+      alertId,
       warningAlertId: warningIdByUser.get(userId) ?? null,
     };
   }
   return caps;
 }
 
-export const getCachedPerUserCapThresholds = cacheWithRedis(
-  fetchPerUserCapThresholds,
+export const getCachedPerUserCapAlertIds = cacheWithRedis(
+  fetchPerUserCapAlertIds,
   spendLimitCacheResolver,
   { ttlMs: SPEND_LIMIT_CACHE_TTL_MS }
 );
 
-const invalidateCachedPerUserCapThresholds = bestEffortInvalidateCacheWithRedis(
-  fetchPerUserCapThresholds,
+const invalidateCachedPerUserCapAlertIds = bestEffortInvalidateCacheWithRedis(
+  fetchPerUserCapAlertIds,
   spendLimitCacheResolver,
-  "members-usage per-user spend caps"
+  "members-usage per-user spend cap alert ids"
 );
 
 /**
@@ -437,7 +443,7 @@ export async function upsertMetronomePerUserCapAlert({
     },
     "[Metronome PerUserCap] Synced per-user cap alert"
   );
-  await invalidateCachedPerUserCapThresholds({
+  await invalidateCachedPerUserCapAlertIds({
     metronomeCustomerId,
     workspaceId,
   });
@@ -476,7 +482,7 @@ export async function clearMetronomePerUserCapAlert({
       "[Metronome PerUserCap] Cleared per-user cap alert"
     );
   }
-  await invalidateCachedPerUserCapThresholds({
+  await invalidateCachedPerUserCapAlertIds({
     metronomeCustomerId,
     workspaceId,
   });

--- a/front/lib/metronome/live_user_credit_inputs.test.ts
+++ b/front/lib/metronome/live_user_credit_inputs.test.ts
@@ -6,12 +6,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const {
   mockListMetronomeSeatBalances,
   mockFetchPerUserAwuUsage,
-  mockGetMetronomePerUserCap,
   mockGetMetronomeDefaultUserCapAlertForSeatType,
 } = vi.hoisted(() => ({
   mockListMetronomeSeatBalances: vi.fn(),
   mockFetchPerUserAwuUsage: vi.fn(),
-  mockGetMetronomePerUserCap: vi.fn(),
   mockGetMetronomeDefaultUserCapAlertForSeatType: vi.fn(),
 }));
 
@@ -38,7 +36,6 @@ vi.mock("@app/lib/metronome/alerts/spend_limits", async () => {
   >("@app/lib/metronome/alerts/spend_limits");
   return {
     ...actual,
-    getMetronomePerUserCap: mockGetMetronomePerUserCap,
     getMetronomeDefaultUserCapAlertForSeatType:
       mockGetMetronomeDefaultUserCapAlertForSeatType,
   };
@@ -66,7 +63,6 @@ function seatBalance(balanceAwu: number, startingAwu: number) {
 beforeEach(() => {
   vi.clearAllMocks();
   mockFetchPerUserAwuUsage.mockResolvedValue(new Ok(new Map<string, number>()));
-  mockGetMetronomePerUserCap.mockResolvedValue(new Ok(null));
   mockGetMetronomeDefaultUserCapAlertForSeatType.mockResolvedValue(
     new Ok(null)
   );
@@ -82,6 +78,7 @@ describe("fetchLiveUserCreditInputs", () => {
       workspaceId: "ws_test",
       userId: USER_ID,
       seatType: "max",
+      poolCapOverrideAwuCredits: null,
       metronomeCustomerId: CUSTOMER_ID,
       metronomeContractId: CONTRACT_ID,
     });
@@ -101,9 +98,6 @@ describe("fetchLiveUserCreditInputs", () => {
     mockListMetronomeSeatBalances.mockResolvedValue(
       new Ok(seatBalance(0, 40000))
     );
-    mockGetMetronomePerUserCap.mockResolvedValue(
-      new Ok({ alert: { threshold: 50000 } })
-    );
     mockFetchPerUserAwuUsage.mockResolvedValue(
       new Ok(new Map<string, number>([[USER_ID, 10000]]))
     );
@@ -112,6 +106,9 @@ describe("fetchLiveUserCreditInputs", () => {
       workspaceId: "ws_test",
       userId: USER_ID,
       seatType: "max",
+      // Pool-only override from the membership; no contract resolves for
+      // "ws_test" so the seat allowance is 0 and the total cap equals it.
+      poolCapOverrideAwuCredits: 50000,
       metronomeCustomerId: CUSTOMER_ID,
       metronomeContractId: CONTRACT_ID,
     });
@@ -134,6 +131,7 @@ describe("fetchLiveUserCreditInputs", () => {
       workspaceId: "ws_test",
       userId: USER_ID,
       seatType: "max",
+      poolCapOverrideAwuCredits: null,
       metronomeCustomerId: CUSTOMER_ID,
       metronomeContractId: CONTRACT_ID,
     });

--- a/front/lib/metronome/live_user_credit_inputs.ts
+++ b/front/lib/metronome/live_user_credit_inputs.ts
@@ -10,18 +10,17 @@
 // reconcile module imports the dispatcher, so the dispatcher cannot import the
 // reconcile module back.
 
-import {
-  getMetronomeDefaultUserCapAlertForSeatType,
-  getMetronomePerUserCap,
-} from "@app/lib/metronome/alerts/spend_limits";
+import { getMetronomeDefaultUserCapAlertForSeatType } from "@app/lib/metronome/alerts/spend_limits";
 import { listMetronomeSeatBalances } from "@app/lib/metronome/client";
 import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
 import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
+import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_types";
 import type { MetronomeSeatBalance } from "@app/lib/metronome/types";
 import type { MembershipSeatType } from "@app/types/memberships";
 import { normalizeToPoolLimitSeatType } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 // The remaining + full AWU seat balance for a user, read from the live
 // per-seat balances. Returns null when the user has no individual AWU seat
@@ -59,18 +58,26 @@ export type LiveUserCreditInputs = {
  * `expectedUserCreditState` (directly, or via the state machine context) to
  * derive the actual state — this only reads the numbers.
  *
+ * `poolCapOverrideAwuCredits` is the pool-only override persisted on the
+ * membership (`memberships.poolCapOverrideAwuCredits`) — the source of truth
+ * for per-user overrides. When set, the seat allowance is added back to get
+ * the total cap threshold; the seat-type default alert is only consulted when
+ * no override is set.
+ *
  * Surfaces Metronome read failures as `Err` so callers can fall back.
  */
 export async function fetchLiveUserCreditInputs({
   workspaceId,
   userId,
   seatType,
+  poolCapOverrideAwuCredits,
   metronomeCustomerId,
   metronomeContractId,
 }: {
   workspaceId: string;
   userId: string;
   seatType: MembershipSeatType | null;
+  poolCapOverrideAwuCredits: number | null;
   metronomeCustomerId: string;
   metronomeContractId: string | null;
 }): Promise<Result<LiveUserCreditInputs, Error>> {
@@ -98,42 +105,46 @@ export async function fetchLiveUserCreditInputs({
 
   // Resolve the effective per-user cap threshold (in AWU credits, seat
   // allowance included): the user-specific override if present, otherwise the
-  // seat-type default. `null` means no cap is configured for this user.
+  // seat-type default. `null` means no cap is configured for this user. The
+  // override is the pool-only value persisted on the membership; the seat
+  // allowance is added back to get the total threshold.
   let effectiveCapAwuCredits: number | null = null;
   let capSource: LiveUserCreditInputs["capSource"] = "none";
 
-  const overrideResult = await getMetronomePerUserCap({
-    metronomeCustomerId,
-    workspaceId,
-    userId,
-  });
-  if (overrideResult.isErr()) {
-    return new Err(
-      new Error(`Failed to read per-user cap: ${overrideResult.error.message}`)
-    );
-  }
-  if (overrideResult.value) {
-    effectiveCapAwuCredits = overrideResult.value.alert.threshold;
-    capSource = "override";
-  } else {
-    const normalizedSeatType = normalizeToPoolLimitSeatType(seatType);
+  const normalizedSeatType = normalizeToPoolLimitSeatType(seatType);
+  if (poolCapOverrideAwuCredits !== null) {
+    let seatAllowance = 0;
     if (normalizedSeatType) {
-      const defaultResult = await getMetronomeDefaultUserCapAlertForSeatType({
-        metronomeCustomerId,
-        workspaceId,
-        seatType: normalizedSeatType,
-      });
-      if (defaultResult.isErr()) {
+      try {
+        const allowances =
+          await getSeatAllowancesByNormalizedSeatType(workspaceId);
+        seatAllowance = allowances[normalizedSeatType] ?? 0;
+      } catch (err) {
         return new Err(
           new Error(
-            `Failed to read default per-user cap: ${defaultResult.error.message}`
+            `Failed to resolve seat allowance: ${normalizeError(err).message}`
           )
         );
       }
-      if (defaultResult.value) {
-        effectiveCapAwuCredits = defaultResult.value.alert.threshold;
-        capSource = "default";
-      }
+    }
+    effectiveCapAwuCredits = poolCapOverrideAwuCredits + seatAllowance;
+    capSource = "override";
+  } else if (normalizedSeatType) {
+    const defaultResult = await getMetronomeDefaultUserCapAlertForSeatType({
+      metronomeCustomerId,
+      workspaceId,
+      seatType: normalizedSeatType,
+    });
+    if (defaultResult.isErr()) {
+      return new Err(
+        new Error(
+          `Failed to read default per-user cap: ${defaultResult.error.message}`
+        )
+      );
+    }
+    if (defaultResult.value) {
+      effectiveCapAwuCredits = defaultResult.value.alert.threshold;
+      capSource = "default";
     }
   }
 

--- a/front/lib/metronome/seat_types.ts
+++ b/front/lib/metronome/seat_types.ts
@@ -1,9 +1,16 @@
 import { listMetronomeProducts } from "@app/lib/metronome/client";
 import { SEAT_TYPE_CUSTOM_FIELD_KEY } from "@app/lib/metronome/constants";
 import type { CachedContract } from "@app/lib/metronome/plan_type";
+import { getActiveContract } from "@app/lib/metronome/plan_type";
 import { cacheWithRedis, invalidateCacheWithRedis } from "@app/lib/utils/cache";
-import type { MembershipSeatType } from "@app/types/memberships";
-import { isMembershipSeatType } from "@app/types/memberships";
+import type {
+  MembershipSeatType,
+  NormalizedPoolLimitSeatType,
+} from "@app/types/memberships";
+import {
+  isMembershipSeatType,
+  NORMALIZED_POOL_LIMIT_SEAT_TYPES,
+} from "@app/types/memberships";
 import type { Subscription } from "@metronome/sdk/resources";
 
 /**
@@ -393,4 +400,30 @@ export function getAwuAllocationForSeatType(
 ): number {
   return getAwuAllocationInfoForSeatType(contract, seatType, productSeatTypes)
     .credits;
+}
+
+/**
+ * Resolve the seat AWU allowance for each normalized pool-limit seat type of
+ * the workspace's active contract. Returns an empty record when the workspace
+ * has no active contract. Used to derive total per-user cap thresholds (pool
+ * override + seat allowance) from the pool-only override persisted on
+ * memberships.
+ */
+export async function getSeatAllowancesByNormalizedSeatType(
+  workspaceId: string
+): Promise<Partial<Record<NormalizedPoolLimitSeatType, number>>> {
+  const contract = await getActiveContract(workspaceId);
+  if (!contract) {
+    return {};
+  }
+  const productSeatTypes = await getProductSeatTypes();
+  const allowances: Partial<Record<NormalizedPoolLimitSeatType, number>> = {};
+  for (const seatType of NORMALIZED_POOL_LIMIT_SEAT_TYPES) {
+    allowances[seatType] = getAwuAllocationForSeatType(
+      contract,
+      seatType,
+      productSeatTypes
+    );
+  }
+  return allowances;
 }

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -1477,6 +1477,19 @@ export class MembershipResource extends BaseResource<MembershipModel> {
   }
 
   /**
+   * Update the per-user pool cap override (in AWU credits, seat allowance
+   * excluded) of an active membership in place. `null` clears the override,
+   * letting the seat-type default apply. Callers are responsible for syncing
+   * the derived Metronome alerts.
+   */
+  async updatePoolCapOverride(
+    poolCapOverrideAwuCredits: number | null,
+    transaction?: Transaction
+  ): Promise<void> {
+    await this.update({ poolCapOverrideAwuCredits }, transaction);
+  }
+
+  /**
    * Schedule a seat-type change at a future date by closing the current
    * row at `scheduledAt` and inserting a future row that becomes active
    * once `scheduledAt` is reached. Both rows coexist during the window;

--- a/front/lib/resources/storage/models/membership.ts
+++ b/front/lib/resources/storage/models/membership.ts
@@ -21,6 +21,12 @@ export class MembershipModel extends WorkspaceAwareModel<MembershipModel> {
   declare firstUsedAt: Date | null;
   declare seatType: CreationOptional<MembershipSeatType>;
   declare creditState: CreationOptional<UserCreditState>;
+  // Admin-set per-user cap on workspace-pool AWU consumption, in AWU credits,
+  // excluding the seat allowance (i.e. exactly what the admin entered). NULL
+  // means no override — the seat-type default applies. The Metronome
+  // `spend_threshold_reached` alert (threshold = override + seat allowance)
+  // is derived from this value and remains the enforcement mechanism.
+  declare poolCapOverrideAwuCredits: number | null;
 
   declare userId: ForeignKey<UserModel["id"]>;
   declare user: NonAttribute<UserModel>;
@@ -67,6 +73,11 @@ MembershipModel.init(
       type: DataTypes.STRING,
       allowNull: false,
       defaultValue: "on_pool",
+    },
+    poolCapOverrideAwuCredits: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      defaultValue: null,
     },
   },
   {

--- a/front/migrations/20260605_backfill_membership_pool_cap_overrides.ts
+++ b/front/migrations/20260605_backfill_membership_pool_cap_overrides.ts
@@ -1,0 +1,139 @@
+import { listMetronomePerUserCapsForWorkspace } from "@app/lib/metronome/alerts/spend_limits";
+import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_types";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import { normalizeToPoolLimitSeatType } from "@app/types/memberships";
+
+/**
+ * Backfill `memberships.poolCapOverrideAwuCredits` from the existing Metronome
+ * per-user cap alerts. The alert threshold is the total cap (pool override +
+ * seat allowance); we subtract the current seat allowance to recover the
+ * pool-only value the admin entered, which is what the column stores.
+ *
+ * Idempotent: memberships already carrying the expected value are skipped.
+ *
+ * Pass `--wId <workspaceId>` to run on a single workspace.
+ */
+makeScript(
+  {
+    wId: {
+      type: "string",
+      required: false,
+      description: "Run on a single workspace (sId).",
+    },
+  },
+  async ({ execute, wId }, logger) => {
+    let updated = 0;
+    let alreadySet = 0;
+    let skipped = 0;
+
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        const { metronomeCustomerId } = workspace;
+        if (!metronomeCustomerId) {
+          return;
+        }
+
+        const capsResult = await listMetronomePerUserCapsForWorkspace({
+          metronomeCustomerId,
+          workspaceId: workspace.sId,
+        });
+        if (capsResult.isErr()) {
+          logger.error(
+            { workspaceId: workspace.sId, err: capsResult.error },
+            "Failed to list per-user cap alerts; skipping workspace."
+          );
+          return;
+        }
+        const caps = capsResult.value;
+        if (caps.size === 0) {
+          return;
+        }
+
+        const seatAllowances = await getSeatAllowancesByNormalizedSeatType(
+          workspace.sId
+        );
+
+        const users = await UserResource.fetchByIds([...caps.keys()]);
+        const userById = new Map(users.map((u) => [u.sId, u]));
+        const { memberships } = await MembershipResource.getActiveMemberships({
+          workspace,
+          users,
+        });
+        const membershipByUserModelId = new Map(
+          memberships.map((m) => [m.userId, m])
+        );
+
+        for (const [userId, entry] of caps) {
+          const user = userById.get(userId);
+          const membership = user
+            ? membershipByUserModelId.get(user.id)
+            : undefined;
+          if (!membership) {
+            logger.warn(
+              { workspaceId: workspace.sId, userId },
+              "Per-user cap alert without an active membership; skipping."
+            );
+            skipped++;
+            continue;
+          }
+
+          const normalizedSeatType = normalizeToPoolLimitSeatType(
+            membership.seatType
+          );
+          const seatAllowance = normalizedSeatType
+            ? (seatAllowances[normalizedSeatType] ?? 0)
+            : 0;
+          const poolCapOverrideAwuCredits =
+            entry.alert.threshold - seatAllowance;
+          if (poolCapOverrideAwuCredits < 0) {
+            logger.warn(
+              {
+                workspaceId: workspace.sId,
+                userId,
+                threshold: entry.alert.threshold,
+                seatAllowance,
+              },
+              "Alert threshold below seat allowance; skipping."
+            );
+            skipped++;
+            continue;
+          }
+
+          if (
+            membership.poolCapOverrideAwuCredits === poolCapOverrideAwuCredits
+          ) {
+            alreadySet++;
+            continue;
+          }
+
+          logger.info(
+            {
+              workspaceId: workspace.sId,
+              userId,
+              threshold: entry.alert.threshold,
+              seatAllowance,
+              poolCapOverrideAwuCredits,
+              previous: membership.poolCapOverrideAwuCredits,
+            },
+            execute
+              ? "Backfilling pool cap override."
+              : "Would backfill pool cap override."
+          );
+          if (execute) {
+            await membership.updatePoolCapOverride(poolCapOverrideAwuCredits);
+          }
+          updated++;
+        }
+      },
+      { wId }
+    );
+
+    logger.info(
+      { updated, alreadySet, skipped },
+      execute ? "Backfill completed." : "Dry run completed."
+    );
+  }
+);

--- a/front/migrations/db/migration_667.sql
+++ b/front/migrations/db/migration_667.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jun 5, 2026
+ALTER TABLE "public"."memberships" ADD COLUMN "poolCapOverrideAwuCredits" INTEGER;

--- a/front/pages/api/w/[wId]/members/[uId]/spend_limit.test.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/spend_limit.test.ts
@@ -2,6 +2,7 @@ import * as creditStateDispatcher from "@app/lib/api/metronome/credit_state_disp
 import * as defaultUserCapAlert from "@app/lib/metronome/alerts/spend_limits";
 import * as perUserAlerts from "@app/lib/metronome/alerts/spend_limits";
 import * as perUserUsage from "@app/lib/metronome/per_user_usage";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { mockCustomerAlert } from "@app/tests/utils/mocks/metronome";
@@ -21,7 +22,6 @@ vi.mock("@app/lib/metronome/alerts/spend_limits", async () => {
     ...actual,
     upsertMetronomePerUserCapAlert: vi.fn(),
     clearMetronomePerUserCapAlert: vi.fn(),
-    getMetronomePerUserCap: vi.fn(),
     getMetronomeDefaultUserCapAlertForSeatType: vi.fn(),
   };
 });
@@ -62,9 +62,6 @@ beforeEach(() => {
   );
   vi.mocked(perUserAlerts.clearMetronomePerUserCapAlert).mockResolvedValue(
     new Ok(undefined)
-  );
-  vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValue(
-    new Ok(null)
   );
   vi.mocked(perUserUsage.fetchPerUserAwuUsage).mockResolvedValue(
     new Ok(new Map())
@@ -203,7 +200,7 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
   });
 
   describe("GET", () => {
-    it("returns unlimited when no per-user alert exists", async () => {
+    it("returns unlimited when no override is persisted", async () => {
       const workspace = await makeMetronomeWorkspaceWithCustomer();
       const { req, res, user } = await createPrivateApiMockRequest({
         method: "GET",
@@ -218,28 +215,22 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
       expect(res._getJSONData()).toEqual({ kind: "unlimited" });
     });
 
-    it("returns limited with threshold when alert exists", async () => {
-      vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValueOnce(
-        new Ok({
-          alert: {
-            id: TEST_ALERT_ID,
-            name: "test alert",
-            status: "enabled",
-            threshold: 2500,
-            type: "spend_threshold_reached",
-            updated_at: "2024-01-01T00:00:00Z",
-          },
-          customer_status: "ok",
-        })
-      );
-
+    it("returns limited with the override persisted on the membership", async () => {
       const workspace = await makeMetronomeWorkspaceWithCustomer();
-      const { req, res, user } = await createPrivateApiMockRequest({
+      const targetUser = await UserFactory.basic();
+      const membership = await MembershipFactory.associate(
+        workspace,
+        targetUser,
+        { role: "user" }
+      );
+      await membership.updatePoolCapOverride(2500);
+
+      const { req, res } = await createPrivateApiMockRequest({
         method: "GET",
         role: "admin",
         workspace,
       });
-      req.query.uId = user.sId;
+      req.query.uId = targetUser.sId;
 
       await handler(req, res);
 
@@ -252,9 +243,12 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
     it("clears alert + dispatches resolved for unlimited with no default", async () => {
       const workspace = await makeMetronomeWorkspaceWithCustomer();
       const targetUser = await UserFactory.basic();
-      await MembershipFactory.associate(workspace, targetUser, {
-        role: "user",
-      });
+      const membership = await MembershipFactory.associate(
+        workspace,
+        targetUser,
+        { role: "user" }
+      );
+      await membership.updatePoolCapOverride(1200);
 
       const { req, res } = await createPrivateApiMockRequest({
         method: "PUT",
@@ -288,6 +282,14 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
       ).not.toHaveBeenCalled();
       // No default → no usage fetch needed; behavior matches pre-PR-A.
       expect(perUserUsage.fetchPerUserAwuUsage).not.toHaveBeenCalled();
+
+      // The persisted override is cleared.
+      const updatedMembership =
+        await MembershipResource.getActiveMembershipOfUserInWorkspace({
+          user: targetUser,
+          workspace,
+        });
+      expect(updatedMembership?.poolCapOverrideAwuCredits).toBeNull();
     });
 
     it("clears alert + dispatches reached for unlimited when default exists and usage is over it", async () => {
@@ -424,6 +426,14 @@ describe("/api/w/[wId]/members/[uId]/spend_limit", () => {
       expect(
         creditStateDispatcher.dispatchPerUserCapReached
       ).not.toHaveBeenCalled();
+
+      // The pool-only override is persisted on the membership.
+      const updatedMembership =
+        await MembershipResource.getActiveMembershipOfUserInWorkspace({
+          user: targetUser,
+          workspace,
+        });
+      expect(updatedMembership?.poolCapOverrideAwuCredits).toBe(1500);
     });
 
     it("dispatches reached when usage is at/above cap", async () => {

--- a/front/types/shared/cache_resource_registry.ts
+++ b/front/types/shared/cache_resource_registry.ts
@@ -230,9 +230,9 @@ export const CACHE_RESOURCE_REGISTRY: CacheResourceDefinition[] = [
     buildResolverKey: (p) => `${p.metronomeCustomerId}-${p.workspaceId}`,
   },
   {
-    id: "metronome_per_user_cap_thresholds",
-    label: "Metronome per-user cap thresholds",
-    fnName: "fetchPerUserCapThresholds",
+    id: "metronome_per_user_cap_alert_ids",
+    label: "Metronome per-user cap alert ids",
+    fnName: "fetchPerUserCapAlertIds",
     params: [
       {
         key: "metronomeCustomerId",


### PR DESCRIPTION
## Description

Store the per user credit pool limit in the membership in DB to avoid relying on metronome of the value.

## Tests

updated tests

## Risk
low

## Deploy Plan

lock front
merge
apply migrations
deploy front and front-sse
unlock front
