### PR TITLE
[Skill Builder] Add capability detail actions to slash menus

### DIFF
--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -1,6 +1,5 @@
 import { CreateMCPServerDialog } from "@app/components/actions/mcp/create/CreateMCPServerDialog";
-import { MCPServerDetails } from "@app/components/actions/mcp/MCPServerDetails";
-import { SkillDetailsSheet } from "@app/components/skills/SkillDetailsSheet";
+import { CapabilityDetailsSheets } from "@app/components/shared/CapabilityDetailsSheets";
 import {
   getMcpServerViewDescription,
   getMcpServerViewDisplayName,
@@ -15,10 +14,7 @@ import {
   useAvailableMCPServers,
   useMCPServerViewsFromSpaces,
 } from "@app/lib/swr/mcp_servers";
-import {
-  useSkills,
-  useSkillWithRelations,
-} from "@app/lib/swr/skill_configurations";
+import { useSkills } from "@app/lib/swr/skill_configurations";
 import { useSpaces } from "@app/lib/swr/spaces";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import {
@@ -26,10 +22,7 @@ import {
   TRACKING_AREAS,
   trackEvent,
 } from "@app/lib/tracking";
-import type {
-  SkillWithoutInstructionsAndToolsType,
-  SkillWithRelationsType,
-} from "@app/types/assistant/skill_configuration";
+import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
 import type { UserType, WorkspaceType } from "@app/types/user";
@@ -336,15 +329,11 @@ export function CapabilitiesPicker({
   const [pendingServerToAdd, setPendingServerToAdd] =
     useState<MCPServerType | null>(null);
 
-  // Detail sheet state
-  const [selectedSkillForDetails, setSelectedSkillForDetails] =
-    useState<SkillWithRelationsType | null>(null);
+  const [selectedSkillIdForDetails, setSelectedSkillIdForDetails] = useState<
+    string | null
+  >(null);
   const [selectedServerViewForDetails, setSelectedServerViewForDetails] =
     useState<MCPServerViewType | null>(null);
-
-  const { fetchSkillWithRelations } = useSkillWithRelations(owner, {
-    onSuccess: ({ skill }) => setSelectedSkillForDetails(skill),
-  });
 
   const shouldFetchToolsData =
     isOpen || isClosing || isSettingUpServer || !!pendingServerToAdd;
@@ -650,7 +639,7 @@ export function CapabilitiesPicker({
               items={capabilityPickerItems}
               onItemSelect={selectCapabilityPickerItem}
               onSkillDetails={(skillId) => {
-                void fetchSkillWithRelations(skillId);
+                setSelectedSkillIdForDetails(skillId);
                 setIsOpen(false);
               }}
               onToolDetails={(serverView) => {
@@ -708,21 +697,13 @@ export function CapabilitiesPicker({
         />
       )}
 
-      {user && (
-        <SkillDetailsSheet
-          skill={selectedSkillForDetails}
-          onClose={() => setSelectedSkillForDetails(null)}
-          owner={owner}
-          user={user}
-        />
-      )}
-
-      <MCPServerDetails
+      <CapabilityDetailsSheets
         owner={owner}
-        mcpServerView={selectedServerViewForDetails}
-        isOpen={!!selectedServerViewForDetails}
-        onClose={() => setSelectedServerViewForDetails(null)}
-        readOnly
+        user={user}
+        selectedSkillId={selectedSkillIdForDetails}
+        selectedMCPServerView={selectedServerViewForDetails}
+        onCloseSkill={() => setSelectedSkillIdForDetails(null)}
+        onCloseTool={() => setSelectedServerViewForDetails(null)}
       />
     </>
   );

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -18,6 +18,7 @@ import useCustomEditor from "@app/components/editor/input_bar/useCustomEditor";
 import useHandleMentions from "@app/components/editor/input_bar/useHandleMentions";
 import useUrlHandler from "@app/components/editor/input_bar/useUrlHandler";
 import { getIcon } from "@app/components/resources/resources_icons";
+import { CapabilityDetailsSheets } from "@app/components/shared/CapabilityDetailsSheets";
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useVoiceTranscriberService } from "@app/hooks/useVoiceTranscriberService";
@@ -265,6 +266,14 @@ const InputBarContainer = ({
   const onSelectRef = useRef<
     ((capability: InputBarSlashSuggestionCapability) => void) | undefined
   >(undefined);
+  const onDetailsRef = useRef<
+    ((capability: InputBarSlashSuggestionCapability) => void) | undefined
+  >(undefined);
+  const [selectedSkillIdForDetails, setSelectedSkillIdForDetails] = useState<
+    string | null
+  >(null);
+  const [selectedServerViewForDetails, setSelectedServerViewForDetails] =
+    useState<MCPServerViewType | null>(null);
   selectedMCPServerViewIdsRef.current = selectedMCPServerViewIds;
   shouldEnableSlashSuggestionRef.current = shouldEnableSlashSuggestion;
 
@@ -483,6 +492,19 @@ const InputBarContainer = ({
     queueMicrotask(() => editorRef.current?.commands.focus());
   };
 
+  onDetailsRef.current = (capability: InputBarSlashSuggestionCapability) => {
+    switch (capability.kind) {
+      case "skill":
+        setSelectedSkillIdForDetails(capability.skill.sId);
+        break;
+      case "tool":
+        setSelectedServerViewForDetails(capability.serverView);
+        break;
+      default:
+        assertNeverAndIgnore(capability);
+    }
+  };
+
   // Current space is taken from the conversation (if already set) or from the space prop (if provided).
   const spaceId = conversation?.spaceId ?? space?.sId ?? undefined;
 
@@ -500,6 +522,7 @@ const InputBarContainer = ({
     slashSuggestion: {
       enabledRef: shouldEnableSlashSuggestionRef,
       onSelectRef,
+      onDetailsRef,
       selectedMCPServerViewIdsRef,
     },
     placeholderOverride: disableInput ? submitBlockMessage : placeholder,
@@ -1093,6 +1116,15 @@ const InputBarContainer = ({
 
   return (
     <>
+      <CapabilityDetailsSheets
+        owner={owner}
+        user={user}
+        selectedSkillId={selectedSkillIdForDetails}
+        selectedMCPServerView={selectedServerViewForDetails}
+        onCloseSkill={() => setSelectedSkillIdForDetails(null)}
+        onCloseTool={() => setSelectedServerViewForDetails(null)}
+      />
+
       {isCompact && (
         <div
           className={cn(

--- a/front/components/editor/SkillInstructionsEditor.tsx
+++ b/front/components/editor/SkillInstructionsEditor.tsx
@@ -101,6 +101,8 @@ interface SkillInstructionsSkillReferencesOptions {
   enableSkillReferences: boolean;
   onSelectSkill?: (skill: SlashCommandSkillSuggestion) => void;
   onSelectTool?: (tool: MCPServerViewType) => void;
+  onSkillDetails?: (skill: SlashCommandSkillSuggestion) => void;
+  onToolDetails?: (tool: MCPServerViewType) => void;
   owner?: LightWorkspaceType;
 }
 
@@ -119,12 +121,16 @@ function buildSkillInstructionsEditableExtensions({
   includeSkillSuggestions,
   onSelectSkill,
   onSelectTool,
+  onSkillDetails,
+  onToolDetails,
   owner,
 }: {
   currentSkillId?: string | null;
   includeSkillSuggestions: boolean;
   onSelectSkill?: (skill: SlashCommandSkillSuggestion) => void;
   onSelectTool?: (tool: MCPServerViewType) => void;
+  onSkillDetails?: (skill: SlashCommandSkillSuggestion) => void;
+  onToolDetails?: (tool: MCPServerViewType) => void;
   owner?: LightWorkspaceType;
 }) {
   return [
@@ -133,6 +139,8 @@ function buildSkillInstructionsEditableExtensions({
       includeSkillSuggestions,
       onSelectSkill,
       onSelectTool,
+      onSkillDetails,
+      onToolDetails,
       owner,
     }),
     AgentInstructionDiffExtension,
@@ -160,6 +168,8 @@ export function useSkillInstructionsEditor({
   const currentSkillId = skillReferences?.currentSkillId ?? null;
   const onSelectSkill = skillReferences?.onSelectSkill;
   const onSelectTool = skillReferences?.onSelectTool;
+  const onSkillDetails = skillReferences?.onSkillDetails;
+  const onToolDetails = skillReferences?.onToolDetails;
   const owner = skillReferences?.owner;
   const includeSkillSuggestions = enableSkillReferences && !!owner;
   const editableExtensions = useMemo(
@@ -169,6 +179,8 @@ export function useSkillInstructionsEditor({
         includeSkillSuggestions,
         onSelectSkill,
         onSelectTool,
+        onSkillDetails,
+        onToolDetails,
         owner,
       }),
     [
@@ -176,6 +188,8 @@ export function useSkillInstructionsEditor({
       includeSkillSuggestions,
       onSelectSkill,
       onSelectTool,
+      onSkillDetails,
+      onToolDetails,
       owner,
     ]
   );

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -89,12 +89,23 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
     "clientRect" | "command" | "query"
   > & {
     onClose: () => void;
+    onDetailsRef?: RefObject<
+      ((capability: InputBarSlashSuggestionCapability) => void) | undefined
+    >;
     owner: LightWorkspaceType;
     selectedMCPServerViewIdsRef: RefObject<Set<string>>;
   }
 >(
   (
-    { clientRect, command, query, onClose, owner, selectedMCPServerViewIdsRef },
+    {
+      clientRect,
+      command,
+      query,
+      onClose,
+      onDetailsRef,
+      owner,
+      selectedMCPServerViewIdsRef,
+    },
     ref
   ) => {
     const dropdownRef = useRef<SlashCommandDropdownRef>(null);
@@ -191,6 +202,24 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
         header="Capabilities"
         listMaxHeightClassName={LIST_MAX_HEIGHT_CLASS_NAME}
         onClose={onClose}
+        onItemDetails={
+          onDetailsRef
+            ? (item) => {
+                const capability = filteredCapabilities.find((capability) =>
+                  capability.kind === "skill"
+                    ? capability.skill.sId === item.id
+                    : capability.serverView.sId === item.id
+                );
+
+                if (!capability) {
+                  return;
+                }
+
+                onDetailsRef.current?.(capability);
+                onClose();
+              }
+            : undefined
+        }
         showScrollFade
         size="wide"
       />

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -86,7 +86,7 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
   SlashCommandDropdownRef,
   Pick<
     SuggestionProps<InputBarSlashSuggestionCapability>,
-    "clientRect" | "command" | "query"
+    "clientRect" | "command" | "editor" | "query" | "range"
   > & {
     onClose: () => void;
     onDetailsRef?: RefObject<
@@ -100,7 +100,9 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
     {
       clientRect,
       command,
+      editor,
       query,
+      range,
       onClose,
       onDetailsRef,
       owner,
@@ -215,6 +217,7 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
                   return;
                 }
 
+                editor.chain().focus().deleteRange(range).run();
                 onDetailsRef.current?.(capability);
                 onClose();
               }

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension.tsx
@@ -46,6 +46,9 @@ export interface InputBarSlashSuggestionExtensionOptions {
   onSelectRef: RefObject<
     ((capability: InputBarSlashSuggestionCapability) => void) | undefined
   >;
+  onDetailsRef?: RefObject<
+    ((capability: InputBarSlashSuggestionCapability) => void) | undefined
+  >;
   selectedMCPServerViewIdsRef: RefObject<Set<string>>;
   onActiveChangeRef?: RefObject<((active: boolean) => void) | undefined>;
 }
@@ -70,6 +73,7 @@ export const InputBarSlashSuggestionExtension =
         owner: undefined,
         enabledRef: { current: false },
         onSelectRef: { current: undefined },
+        onDetailsRef: { current: undefined },
         selectedMCPServerViewIdsRef: { current: new Set<string>() },
       };
     },
@@ -133,6 +137,7 @@ export const InputBarSlashSuggestionExtension =
                   props: {
                     ...props,
                     onClose: closeSuggestionDropdown,
+                    onDetailsRef: extensionOptions.onDetailsRef,
                     owner,
                     selectedMCPServerViewIdsRef:
                       extensionOptions.selectedMCPServerViewIdsRef,
@@ -156,6 +161,7 @@ export const InputBarSlashSuggestionExtension =
                 component?.updateProps({
                   ...props,
                   onClose: closeSuggestionDropdown,
+                  onDetailsRef: extensionOptions.onDetailsRef,
                   owner,
                   selectedMCPServerViewIdsRef:
                     extensionOptions.selectedMCPServerViewIdsRef,

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -1,7 +1,9 @@
 import type { SlashCommandSkillSuggestion } from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import {
+  Button,
   cn,
+  DotsHorizontal,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -67,6 +69,7 @@ export interface SlashCommandDropdownProps
   header?: string;
   listMaxHeightClassName?: `max-h-${string}`;
   onClose?: () => void;
+  onItemDetails?: (item: SlashCommand) => void;
   showScrollFade?: boolean;
   size?: "default" | "wide";
 }
@@ -88,6 +91,7 @@ export const SlashCommandDropdown = forwardRef<
       header,
       listMaxHeightClassName = DEFAULT_LIST_MAX_HEIGHT_CLASS_NAME,
       onClose,
+      onItemDetails,
       showScrollFade = false,
       size = "default",
     },
@@ -287,6 +291,9 @@ export const SlashCommandDropdown = forwardRef<
                       items[index - 1]?.sectionLabel !== item.sectionLabel
                         ? item.sectionLabel
                         : undefined;
+                    const canShowDetails =
+                      !!onItemDetails &&
+                      !!(item.data?.skill || item.data?.tool);
                     const menuItem = (
                       <DropdownMenuItem
                         icon={item.icon}
@@ -294,13 +301,28 @@ export const SlashCommandDropdown = forwardRef<
                         label={item.label}
                         description={item.description}
                         truncateText
+                        endComponent={
+                          canShowDetails ? (
+                            <Button
+                              icon={DotsHorizontal}
+                              variant="outline"
+                              size="mini"
+                              className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                e.preventDefault();
+                                onItemDetails?.(item);
+                              }}
+                            />
+                          ) : undefined
+                        }
                         onClick={() => selectItem(index)}
                         onMouseEnter={() => setSelectedIndex(index)}
-                        className={
-                          index === selectedIndex
-                            ? "bg-muted-background dark:bg-muted-night [transition-duration:0ms]"
-                            : ""
-                        }
+                        className={cn(
+                          "group",
+                          index === selectedIndex &&
+                            "bg-muted-background dark:bg-muted-night [transition-duration:0ms]"
+                        )}
                       />
                     );
 

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
@@ -191,6 +191,8 @@ interface SkillBuilderSlashCommandDropdownProps
   currentSkillId?: string | null;
   includeSkillSuggestions: boolean;
   onClose: () => void;
+  onSkillDetails?: (skill: SlashCommandSkillSuggestion) => void;
+  onToolDetails?: (tool: MCPServerViewType) => void;
   owner?: LightWorkspaceType;
   showCapabilitiesOnly: boolean;
 }
@@ -211,6 +213,8 @@ const SkillBuilderSlashCommandDropdownWithSkills = forwardRef<
       currentSkillId,
       items,
       onClose,
+      onSkillDetails,
+      onToolDetails,
       owner,
       query,
       showCapabilitiesOnly,
@@ -279,6 +283,22 @@ const SkillBuilderSlashCommandDropdownWithSkills = forwardRef<
           isCapabilitiesLoading ? "Loading capabilities…" : "No commands found"
         }
         onClose={onClose}
+        onItemDetails={
+          onSkillDetails || onToolDetails
+            ? (item) => {
+                if (item.data?.skill) {
+                  onSkillDetails?.(item.data.skill);
+                  onClose();
+                  return;
+                }
+
+                if (item.data?.tool) {
+                  onToolDetails?.(item.data.tool.view);
+                  onClose();
+                }
+              }
+            : undefined
+        }
         size="wide"
       />
     );
@@ -319,8 +339,10 @@ SkillBuilderSlashCommandDropdown.displayName =
 export interface SlashCommandExtensionOptions {
   currentSkillId?: string | null;
   includeSkillSuggestions: boolean;
+  onSkillDetails?: (skill: SlashCommandSkillSuggestion) => void;
   onSelectSkill?: (skill: SlashCommandSkillSuggestion) => void;
   onSelectTool?: (tool: MCPServerViewType) => void;
+  onToolDetails?: (tool: MCPServerViewType) => void;
   owner?: LightWorkspaceType;
   suggestion: Partial<SuggestionOptions>;
 }
@@ -355,8 +377,10 @@ export const SlashCommandExtension =
       return {
         currentSkillId: null,
         includeSkillSuggestions: false,
+        onSkillDetails: undefined,
         onSelectSkill: undefined,
         onSelectTool: undefined,
+        onToolDetails: undefined,
         owner: undefined,
         suggestion: {
           char: "/",
@@ -482,6 +506,8 @@ export const SlashCommandExtension =
                       includeSkillSuggestions:
                         extensionOptions.includeSkillSuggestions,
                       onClose: closeSuggestionDropdown,
+                      onSkillDetails: extensionOptions.onSkillDetails,
+                      onToolDetails: extensionOptions.onToolDetails,
                       owner: extensionOptions.owner,
                       showCapabilitiesOnly:
                         props.range.from ===
@@ -506,6 +532,8 @@ export const SlashCommandExtension =
                   includeSkillSuggestions:
                     extensionOptions.includeSkillSuggestions,
                   onClose: closeSuggestionDropdown,
+                  onSkillDetails: extensionOptions.onSkillDetails,
+                  onToolDetails: extensionOptions.onToolDetails,
                   owner: extensionOptions.owner,
                   showCapabilitiesOnly:
                     props.range.from ===

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
@@ -186,7 +186,7 @@ export function buildSkillBuilderSlashCommandItems({
 interface SkillBuilderSlashCommandDropdownProps
   extends Pick<
     SuggestionProps<SlashCommand>,
-    "clientRect" | "command" | "items" | "query"
+    "clientRect" | "command" | "editor" | "items" | "query" | "range"
   > {
   currentSkillId?: string | null;
   includeSkillSuggestions: boolean;
@@ -211,12 +211,14 @@ const SkillBuilderSlashCommandDropdownWithSkills = forwardRef<
       clientRect,
       command,
       currentSkillId,
+      editor,
       items,
       onClose,
       onSkillDetails,
       onToolDetails,
       owner,
       query,
+      range,
       showCapabilitiesOnly,
     },
     ref
@@ -287,12 +289,14 @@ const SkillBuilderSlashCommandDropdownWithSkills = forwardRef<
           onSkillDetails || onToolDetails
             ? (item) => {
                 if (item.data?.skill) {
+                  editor.chain().focus().deleteRange(range).run();
                   onSkillDetails?.(item.data.skill);
                   onClose();
                   return;
                 }
 
                 if (item.data?.tool) {
+                  editor.chain().focus().deleteRange(range).run();
                   onToolDetails?.(item.data.tool.view);
                   onClose();
                 }

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -209,6 +209,9 @@ export interface CustomEditorProps {
     onSelectRef: React.RefObject<
       ((capability: InputBarSlashSuggestionCapability) => void) | undefined
     >;
+    onDetailsRef?: React.RefObject<
+      ((capability: InputBarSlashSuggestionCapability) => void) | undefined
+    >;
     selectedMCPServerViewIdsRef: React.RefObject<Set<string>>;
   };
   // Override the default editor placeholder (e.g. to show a blocked-state reason).
@@ -352,6 +355,7 @@ export const buildEditorExtensions = ({
         owner,
         enabledRef: slashSuggestion.enabledRef,
         onSelectRef: slashSuggestion.onSelectRef,
+        onDetailsRef: slashSuggestion.onDetailsRef,
         selectedMCPServerViewIdsRef:
           slashSuggestion.selectedMCPServerViewIdsRef,
         onActiveChangeRef: onSuggestionActiveChangeRef,

--- a/front/components/shared/CapabilityDetailsSheets.tsx
+++ b/front/components/shared/CapabilityDetailsSheets.tsx
@@ -1,0 +1,51 @@
+import { MCPServerDetails } from "@app/components/actions/mcp/MCPServerDetails";
+import { SkillDetailsSheet } from "@app/components/skills/SkillDetailsSheet";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { useSkill } from "@app/lib/swr/skill_configurations";
+import type { UserType, WorkspaceType } from "@app/types/user";
+
+interface CapabilityDetailsSheetsProps {
+  owner: WorkspaceType;
+  user: UserType | null;
+  selectedSkillId: string | null;
+  selectedMCPServerView: MCPServerViewType | null;
+  onCloseSkill: () => void;
+  onCloseTool: () => void;
+}
+
+export function CapabilityDetailsSheets({
+  owner,
+  user,
+  selectedSkillId,
+  selectedMCPServerView,
+  onCloseSkill,
+  onCloseTool,
+}: CapabilityDetailsSheetsProps) {
+  const { skill } = useSkill({
+    workspaceId: owner.sId,
+    skillId: selectedSkillId,
+    withRelations: true,
+    disabled: !selectedSkillId,
+  });
+
+  return (
+    <>
+      {user && (
+        <SkillDetailsSheet
+          skill={skill ?? null}
+          owner={owner}
+          user={user}
+          onClose={onCloseSkill}
+        />
+      )}
+
+      <MCPServerDetails
+        owner={owner}
+        mcpServerView={selectedMCPServerView}
+        isOpen={selectedMCPServerView !== null}
+        onClose={onCloseTool}
+        readOnly
+      />
+    </>
+  );
+}

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -9,6 +9,7 @@ import {
   SkillInstructionsEditorContent,
   useSkillInstructionsEditor,
 } from "@app/components/editor/SkillInstructionsEditor";
+import { CapabilityDetailsSheets } from "@app/components/shared/CapabilityDetailsSheets";
 import { SKILL_BUILDER_INSTRUCTIONS_BLUR_EVENT } from "@app/components/skill_builder/events";
 import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
 import type {
@@ -40,7 +41,7 @@ import type { Editor } from "@tiptap/react";
 import type { Config } from "dompurify";
 import DOMPurify from "dompurify";
 import debounce from "lodash/debounce";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useController, useFormContext } from "react-hook-form";
 
 const INSTRUCTIONS_FIELD_NAME = "instructions";
@@ -268,8 +269,18 @@ export function SkillBuilderInstructionsEditor({
   const referencedSkillIdsRef = useRef<
     SkillBuilderFormData["referencedSkillIds"]
   >([]);
-  const { owner, skillId, selectedSuggestionId, setAcceptInstructionEdits } =
-    useSkillBuilderContext();
+  const {
+    owner,
+    user,
+    skillId,
+    selectedSuggestionId,
+    setAcceptInstructionEdits,
+  } = useSkillBuilderContext();
+  const [selectedSkillIdForDetails, setSelectedSkillIdForDetails] = useState<
+    string | null
+  >(null);
+  const [selectedServerViewForDetails, setSelectedServerViewForDetails] =
+    useState<MCPServerViewType | null>(null);
   const { hasFeature } = useFeatureFlags();
   const hasReinforcementFeature =
     hasFeature("reinforced_agents") && hasFeature("reinforcement_ui");
@@ -496,6 +507,17 @@ export function SkillBuilderInstructionsEditor({
     [onReferencedSkillIdsChange, onReferencedSkillsChange]
   );
 
+  const handleSkillDetails = useCallback(
+    (skill: SlashCommandSkillSuggestion) => {
+      setSelectedSkillIdForDetails(skill.sId);
+    },
+    []
+  );
+
+  const handleToolDetails = useCallback((tool: MCPServerViewType) => {
+    setSelectedServerViewForDetails(tool);
+  }, []);
+
   const { suggestions, isSuggestionsLoading } = useSkillSuggestions({
     skillId,
     states: ["pending"],
@@ -512,8 +534,10 @@ export function SkillBuilderInstructionsEditor({
     skillReferences: {
       currentSkillId: skillId,
       enableSkillReferences,
+      onSkillDetails: handleSkillDetails,
       onSelectSkill: handleSelectSkillReference,
       onSelectTool: handleSelectToolReference,
+      onToolDetails: handleToolDetails,
       owner,
     },
     onUpdate: handleUpdate,
@@ -878,30 +902,41 @@ export function SkillBuilderInstructionsEditor({
   ]);
 
   return (
-    <div className="space-y-1 p-px">
-      <div className="group relative overflow-hidden rounded-xl">
-        <SkillInstructionsEditorContent
-          editor={editor}
-          isReadOnly={hasSuggestions}
-        />
-        {enableSkillReferences && (
-          <SkillBuilderInstructionsReferenceSummary
-            attachedKnowledge={attachedKnowledgeField.value}
-            containerRef={instructionReferenceSummaryRef}
-            hasError={displayError}
-            instructions={instructionsField.value ?? ""}
-            onReferenceClick={handleReferenceClick}
-            referencedSkills={referencedSkills}
-            tools={tools}
+    <>
+      <div className="space-y-1 p-px">
+        <div className="group relative overflow-hidden rounded-xl">
+          <SkillInstructionsEditorContent
+            editor={editor}
+            isReadOnly={hasSuggestions}
           />
+          {enableSkillReferences && (
+            <SkillBuilderInstructionsReferenceSummary
+              attachedKnowledge={attachedKnowledgeField.value}
+              containerRef={instructionReferenceSummaryRef}
+              hasError={displayError}
+              instructions={instructionsField.value ?? ""}
+              onReferenceClick={handleReferenceClick}
+              referencedSkills={referencedSkills}
+              tools={tools}
+            />
+          )}
+        </div>
+
+        {instructionsFieldState.error && (
+          <div className="dark:text-warning-night ml-2 text-xs text-warning">
+            {instructionsFieldState.error.message}
+          </div>
         )}
       </div>
 
-      {instructionsFieldState.error && (
-        <div className="dark:text-warning-night ml-2 text-xs text-warning">
-          {instructionsFieldState.error.message}
-        </div>
-      )}
-    </div>
+      <CapabilityDetailsSheets
+        owner={owner}
+        user={user}
+        selectedSkillId={selectedSkillIdForDetails}
+        selectedMCPServerView={selectedServerViewForDetails}
+        onCloseSkill={() => setSelectedSkillIdForDetails(null)}
+        onCloseTool={() => setSelectedServerViewForDetails(null)}
+      />
+    </>
   );
 }


### PR DESCRIPTION
## Description
Related to https://github.com/dust-tt/tasks/issues/8614

Adds the hover ellipsis action to slash capability suggestions in the input bar and Skill Builder, opening the existing skill/tool detail sheets. Also factors the shared detail sheet rendering so the capabilities picker and slash flows use the same component.

## Risks
Blast radius: input bar capability slash suggestions, Skill Builder capability slash suggestions, and the existing capabilities picker detail sheets.
Risk: standard

## Deploy Plan
- pmrr
- deploy front

## Tests
- [x] NODE_ENV=test npm test -- components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.test.ts components/editor/extensions/skill_builder/SlashCommandExtension.test.ts components/editor/extensions/skill_builder/ToolNode.test.ts lib/editor/skill_instructions_preprocessing.test.ts