### PR TITLE
[Skill Builder] Open capability details from inline chips

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -523,6 +523,7 @@ const InputBarContainer = ({
       enabledRef: shouldEnableSlashSuggestionRef,
       onSelectRef,
       onDetailsRef,
+      onSkillDetails: setSelectedSkillIdForDetails,
       selectedMCPServerViewIdsRef,
     },
     placeholderOverride: disableInput ? submitBlockMessage : placeholder,
@@ -1225,6 +1226,7 @@ const InputBarContainer = ({
                     label={getMcpServerViewDisplayName(msv)}
                     icon={getIcon(msv.server.icon)}
                     className="m-0.5 hidden bg-background text-foreground dark:bg-background-night dark:text-foreground-night xs:flex"
+                    onClick={() => setSelectedServerViewForDetails(msv)}
                     onRemove={() => {
                       onMCPServerViewDeselect(msv);
                     }}
@@ -1233,6 +1235,7 @@ const InputBarContainer = ({
                     size="xs"
                     icon={getIcon(msv.server.icon)}
                     className="m-0.5 flex bg-background text-foreground dark:bg-background-night dark:text-foreground-night xs:hidden"
+                    onClick={() => setSelectedServerViewForDetails(msv)}
                     onRemove={() => {
                       onMCPServerViewDeselect(msv);
                     }}

--- a/front/components/editor/SkillInstructionsEditor.tsx
+++ b/front/components/editor/SkillInstructionsEditor.tsx
@@ -104,7 +104,6 @@ interface SkillInstructionsSkillReferencesOptions {
   onSkillDetails?: (skill: SlashCommandSkillSuggestion) => void;
   onSkillNodeDetails?: (skillId: string) => void;
   onToolDetails?: (tool: MCPServerViewType) => void;
-  onToolNodeDetails?: (tool: MCPServerViewType) => void;
   owner?: LightWorkspaceType;
 }
 
@@ -173,7 +172,6 @@ export function useSkillInstructionsEditor({
   const onSkillDetails = skillReferences?.onSkillDetails;
   const onSkillNodeDetails = skillReferences?.onSkillNodeDetails;
   const onToolDetails = skillReferences?.onToolDetails;
-  const onToolNodeDetails = skillReferences?.onToolNodeDetails;
   const owner = skillReferences?.owner;
   const includeSkillSuggestions = enableSkillReferences && !!owner;
   const editableExtensions = useMemo(
@@ -203,14 +201,14 @@ export function useSkillInstructionsEditor({
       buildSkillInstructionsExtensions(isReadOnly, editableExtensions, {
         enableSkillReferences,
         onSkillNodeDetails,
-        onToolNodeDetails,
+        onToolDetails,
       }),
     [
       editableExtensions,
       enableSkillReferences,
       isReadOnly,
       onSkillNodeDetails,
-      onToolNodeDetails,
+      onToolDetails,
     ]
   );
 

--- a/front/components/editor/SkillInstructionsEditor.tsx
+++ b/front/components/editor/SkillInstructionsEditor.tsx
@@ -102,7 +102,9 @@ interface SkillInstructionsSkillReferencesOptions {
   onSelectSkill?: (skill: SlashCommandSkillSuggestion) => void;
   onSelectTool?: (tool: MCPServerViewType) => void;
   onSkillDetails?: (skill: SlashCommandSkillSuggestion) => void;
+  onSkillNodeDetails?: (skillId: string) => void;
   onToolDetails?: (tool: MCPServerViewType) => void;
+  onToolNodeDetails?: (tool: MCPServerViewType) => void;
   owner?: LightWorkspaceType;
 }
 
@@ -169,7 +171,9 @@ export function useSkillInstructionsEditor({
   const onSelectSkill = skillReferences?.onSelectSkill;
   const onSelectTool = skillReferences?.onSelectTool;
   const onSkillDetails = skillReferences?.onSkillDetails;
+  const onSkillNodeDetails = skillReferences?.onSkillNodeDetails;
   const onToolDetails = skillReferences?.onToolDetails;
+  const onToolNodeDetails = skillReferences?.onToolNodeDetails;
   const owner = skillReferences?.owner;
   const includeSkillSuggestions = enableSkillReferences && !!owner;
   const editableExtensions = useMemo(
@@ -198,8 +202,16 @@ export function useSkillInstructionsEditor({
     () =>
       buildSkillInstructionsExtensions(isReadOnly, editableExtensions, {
         enableSkillReferences,
+        onSkillNodeDetails,
+        onToolNodeDetails,
       }),
-    [editableExtensions, enableSkillReferences, isReadOnly]
+    [
+      editableExtensions,
+      enableSkillReferences,
+      isReadOnly,
+      onSkillNodeDetails,
+      onToolNodeDetails,
+    ]
   );
 
   // Track if initial content has been set

--- a/front/components/editor/extensions/input_bar/SkillNode.tsx
+++ b/front/components/editor/extensions/input_bar/SkillNode.tsx
@@ -3,16 +3,35 @@ import {
   SkillNode as SkillNodeBase,
 } from "@app/components/editor/extensions/skill_builder/SkillNode";
 import { SkillNodeComponent } from "@app/components/editor/input_bar/SkillNodeComponent";
+import type { NodeViewProps } from "@tiptap/core";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 
 export type { SkillNodeAttributes } from "@app/components/editor/extensions/skill_builder/SkillNode";
 export { SKILL_NODE_TYPE };
 
+interface SkillNodeOptions {
+  onSkillDetails?: (skillId: string) => void;
+}
+
 // Interactive variant of SkillNode that adds the React node view. The
 // schema-only base lives in skill_builder/SkillNode so server-side code can
 // register the node without pulling in React.
-export const SkillNode = SkillNodeBase.extend({
+export const SkillNode = SkillNodeBase.extend<SkillNodeOptions>({
+  addOptions() {
+    return {
+      ...this.parent?.(),
+      onSkillDetails: undefined,
+    };
+  },
+
   addNodeView() {
-    return ReactNodeViewRenderer(SkillNodeComponent);
+    return ReactNodeViewRenderer((props: NodeViewProps) => (
+      <SkillNodeComponent
+        node={{
+          attrs: props.node.attrs,
+        }}
+        onDetails={this.options.onSkillDetails}
+      />
+    ));
   },
 });

--- a/front/components/editor/extensions/skill_builder/ToolNodeWithView.tsx
+++ b/front/components/editor/extensions/skill_builder/ToolNodeWithView.tsx
@@ -6,9 +6,18 @@ import { ToolNode } from "@app/components/editor/extensions/skill_builder/ToolNo
 import type { ToolNodeAttributes } from "@app/components/editor/extensions/skill_builder/ToolNodeTypes";
 import { useMaybeMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { NodeViewProps } from "@tiptap/react";
 import { NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
 import { useMemo } from "react";
+
+interface ToolNodeWithViewOptions {
+  onToolDetails?: (tool: MCPServerViewType) => void;
+}
+
+interface ToolNodeViewProps extends NodeViewProps {
+  onToolDetails?: (tool: MCPServerViewType) => void;
+}
 
 function useToolNodeDisplay(attrs: ToolNodeAttributes) {
   const ctx = useMaybeMCPServerViewsContext();
@@ -19,6 +28,7 @@ function useToolNodeDisplay(attrs: ToolNodeAttributes) {
         kind: "tool" as const,
         title: attrs.toolName,
         toolIcon: attrs.toolIcon,
+        view: null,
       };
     }
 
@@ -44,31 +54,49 @@ function useToolNodeDisplay(attrs: ToolNodeAttributes) {
       kind: "tool" as const,
       title: labeledView?.label ?? getMcpServerViewDisplayName(view),
       toolIcon: view.server.icon,
+      view,
     };
   }, [attrs.mcpServerViewId, attrs.toolIcon, attrs.toolName, ctx]);
 }
 
-function ToolNodeView({ node }: NodeViewProps) {
+function ToolNodeView({ node, onToolDetails }: ToolNodeViewProps) {
   const attrs: ToolNodeAttributes = {
     mcpServerViewId: node.attrs.mcpServerViewId,
     toolIcon: node.attrs.toolIcon,
     toolName: node.attrs.toolName,
   };
   const display = useToolNodeDisplay(attrs);
+  const handleClick =
+    display.kind === "tool" && display.view && onToolDetails
+      ? () => onToolDetails(display.view)
+      : undefined;
 
   return (
     <NodeViewWrapper className="inline-flex align-middle">
       {display.kind === "error" ? (
         <ToolErrorChip title={display.title} />
       ) : (
-        <ToolChip title={display.title} toolIcon={display.toolIcon} />
+        <ToolChip
+          title={display.title}
+          toolIcon={display.toolIcon}
+          onClick={handleClick}
+        />
       )}
     </NodeViewWrapper>
   );
 }
 
-export const ToolNodeWithView = ToolNode.extend({
+export const ToolNodeWithView = ToolNode.extend<ToolNodeWithViewOptions>({
+  addOptions() {
+    return {
+      ...this.parent?.(),
+      onToolDetails: undefined,
+    };
+  },
+
   addNodeView() {
-    return ReactNodeViewRenderer(ToolNodeView);
+    return ReactNodeViewRenderer((props: NodeViewProps) => (
+      <ToolNodeView {...props} onToolDetails={this.options.onToolDetails} />
+    ));
   },
 });

--- a/front/components/editor/input_bar/SkillNodeComponent.tsx
+++ b/front/components/editor/input_bar/SkillNodeComponent.tsx
@@ -15,9 +15,13 @@ interface SkillNodeComponentProps {
       skillUnavailable?: boolean;
     };
   };
+  onDetails?: (skillId: string) => void;
 }
 
-export function SkillNodeComponent({ node }: SkillNodeComponentProps) {
+export function SkillNodeComponent({
+  node,
+  onDetails,
+}: SkillNodeComponentProps) {
   if (node.attrs.skillUnavailable === true) {
     return (
       <NodeViewWrapper className="inline-flex align-middle">
@@ -42,6 +46,9 @@ export function SkillNodeComponent({ node }: SkillNodeComponentProps) {
 
   const skillIcon = node.attrs.skillIcon ?? null;
   const skillName = node.attrs.skillName ?? "Skill";
+  const skillId = node.attrs.skillId;
+  const handleClick =
+    skillId && onDetails ? () => onDetails(skillId) : undefined;
 
   return (
     <NodeViewWrapper className="inline-flex align-middle">
@@ -49,6 +56,7 @@ export function SkillNodeComponent({ node }: SkillNodeComponentProps) {
         label={skillName}
         icon={getSkillIcon(skillIcon)}
         color="white"
+        onClick={handleClick}
         size="xs"
       />
     </NodeViewWrapper>

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -212,6 +212,7 @@ export interface CustomEditorProps {
     onDetailsRef?: React.RefObject<
       ((capability: InputBarSlashSuggestionCapability) => void) | undefined
     >;
+    onSkillDetails?: (skillId: string) => void;
     selectedMCPServerViewIdsRef: React.RefObject<Set<string>>;
   };
   // Override the default editor placeholder (e.g. to show a blocked-state reason).
@@ -331,7 +332,9 @@ export const buildEditorExtensions = ({
         onActiveChange: notifySuggestionActiveChange,
       }),
     }),
-    SkillNode,
+    SkillNode.configure({
+      onSkillDetails: slashSuggestion?.onSkillDetails,
+    }),
     createEmojiExtension({ onActiveChange: notifySuggestionActiveChange }),
     Placeholder.configure({
       placeholder: ({ node }) => {

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -514,6 +514,10 @@ export function SkillBuilderInstructionsEditor({
     []
   );
 
+  const handleSkillNodeDetails = useCallback((skillId: string) => {
+    setSelectedSkillIdForDetails(skillId);
+  }, []);
+
   const handleToolDetails = useCallback((tool: MCPServerViewType) => {
     setSelectedServerViewForDetails(tool);
   }, []);
@@ -535,9 +539,11 @@ export function SkillBuilderInstructionsEditor({
       currentSkillId: skillId,
       enableSkillReferences,
       onSkillDetails: handleSkillDetails,
+      onSkillNodeDetails: handleSkillNodeDetails,
       onSelectSkill: handleSelectSkillReference,
       onSelectTool: handleSelectToolReference,
       onToolDetails: handleToolDetails,
+      onToolNodeDetails: handleToolDetails,
       owner,
     },
     onUpdate: handleUpdate,

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -514,10 +514,6 @@ export function SkillBuilderInstructionsEditor({
     []
   );
 
-  const handleSkillNodeDetails = useCallback((skillId: string) => {
-    setSelectedSkillIdForDetails(skillId);
-  }, []);
-
   const handleToolDetails = useCallback((tool: MCPServerViewType) => {
     setSelectedServerViewForDetails(tool);
   }, []);
@@ -539,11 +535,10 @@ export function SkillBuilderInstructionsEditor({
       currentSkillId: skillId,
       enableSkillReferences,
       onSkillDetails: handleSkillDetails,
-      onSkillNodeDetails: handleSkillNodeDetails,
+      onSkillNodeDetails: setSelectedSkillIdForDetails,
       onSelectSkill: handleSelectSkillReference,
       onSelectTool: handleSelectToolReference,
       onToolDetails: handleToolDetails,
-      onToolNodeDetails: handleToolDetails,
       owner,
     },
     onUpdate: handleUpdate,

--- a/front/lib/editor/build_skill_instructions_extensions.ts
+++ b/front/lib/editor/build_skill_instructions_extensions.ts
@@ -24,7 +24,7 @@ export const INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT = 120_000;
 interface BuildSkillInstructionsExtensionsOptions {
   enableSkillReferences?: boolean;
   onSkillNodeDetails?: (skillId: string) => void;
-  onToolNodeDetails?: (tool: MCPServerViewType) => void;
+  onToolDetails?: (tool: MCPServerViewType) => void;
 }
 
 /**
@@ -39,7 +39,7 @@ export function buildSkillInstructionsExtensions(
   {
     enableSkillReferences = false,
     onSkillNodeDetails,
-    onToolNodeDetails,
+    onToolDetails,
   }: BuildSkillInstructionsExtensionsOptions = {}
 ): Extensions {
   const baseExtensions: Extensions = [
@@ -103,9 +103,7 @@ export function buildSkillInstructionsExtensions(
   ];
 
   if (enableSkillReferences) {
-    baseExtensions.push(
-      ToolNodeWithView.configure({ onToolDetails: onToolNodeDetails })
-    );
+    baseExtensions.push(ToolNodeWithView.configure({ onToolDetails }));
   }
 
   baseExtensions.push(

--- a/front/lib/editor/build_skill_instructions_extensions.ts
+++ b/front/lib/editor/build_skill_instructions_extensions.ts
@@ -13,6 +13,7 @@ import {
 } from "@app/components/editor/extensions/skill_builder/RawMarkdownBlock";
 import { ToolNodeWithView } from "@app/components/editor/extensions/skill_builder/ToolNodeWithView";
 import { LinkExtension } from "@app/components/editor/input_bar/LinkExtension";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { markdownStyles } from "@dust-tt/sparkle";
 import type { Extensions } from "@tiptap/core";
 import { Markdown } from "@tiptap/markdown";
@@ -22,6 +23,8 @@ export const INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT = 120_000;
 
 interface BuildSkillInstructionsExtensionsOptions {
   enableSkillReferences?: boolean;
+  onSkillNodeDetails?: (skillId: string) => void;
+  onToolNodeDetails?: (tool: MCPServerViewType) => void;
 }
 
 /**
@@ -35,6 +38,8 @@ export function buildSkillInstructionsExtensions(
   editableExtensions: Extensions = [],
   {
     enableSkillReferences = false,
+    onSkillNodeDetails,
+    onToolNodeDetails,
   }: BuildSkillInstructionsExtensionsOptions = {}
 ): Extensions {
   const baseExtensions: Extensions = [
@@ -98,7 +103,9 @@ export function buildSkillInstructionsExtensions(
   ];
 
   if (enableSkillReferences) {
-    baseExtensions.push(ToolNodeWithView);
+    baseExtensions.push(
+      ToolNodeWithView.configure({ onToolDetails: onToolNodeDetails })
+    );
   }
 
   baseExtensions.push(
@@ -108,7 +115,9 @@ export function buildSkillInstructionsExtensions(
   );
 
   if (enableSkillReferences) {
-    baseExtensions.push(SkillNode);
+    baseExtensions.push(
+      SkillNode.configure({ onSkillDetails: onSkillNodeDetails })
+    );
   }
 
   if (!isReadOnly) {


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/8614

Follows https://github.com/dust-tt/dust/pull/26892

Lets Skill Builder users click inline skill and tool chips to open the same detail sheets used by the slash menu actions. Tool chips open once their server view is resolved; unavailable references keep their existing warning display.

## Risks
Blast radius: inline skill/tool chips in Skill Builder instructions.
Risk: low

## Deploy Plan
- pmrr
- deploy front

## Tests
- [x] NODE_ENV=test npm test -- components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.test.ts components/editor/extensions/skill_builder/SlashCommandExtension.test.ts components/editor/extensions/skill_builder/ToolNode.test.ts lib/editor/skill_instructions_preprocessing.test.ts