### PR TITLE
Seat→pool transition based on remaining credits

### DIFF
--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -15,6 +15,7 @@ import {
   fetchPerUserAwuUsage,
   getCachedPerUserAwuUsage,
 } from "@app/lib/metronome/per_user_usage";
+import { getActiveContract } from "@app/lib/metronome/plan_type";
 import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_types";
 import {
   buildSeatDataByUserId,
@@ -408,6 +409,75 @@ async function fetchDefaultCapsBySeatType({
       workspaceId,
     });
   }
+}
+
+/**
+ * Compute the fraction of per-user cap credits still available for `userId`
+ * in the current billing period (0–1). Returns `null` when no cap is
+ * configured for this user (treat as unlimited).
+ *
+ * Reuses the same cached fetchers as `getMembersUsage` so repeated calls
+ * within the same cache window are free.
+ */
+export async function fetchRemainingCapCreditsPercentageForUser({
+  metronomeCustomerId,
+  workspaceId,
+  userId,
+  seatType,
+  poolCapOverrideAwuCredits,
+}: {
+  metronomeCustomerId: string | null;
+  workspaceId: string;
+  userId: string;
+  seatType: MembershipSeatType | null | undefined;
+  poolCapOverrideAwuCredits: number | null;
+}): Promise<number | null> {
+  const contract = metronomeCustomerId
+    ? await getActiveContract(workspaceId)
+    : null;
+  const metronomeContractId = contract?.id ?? null;
+
+  const [
+    perUserTotalConsumedCredits,
+    { defaultAwuCreditsBySeatType, seatAllowanceBySeatType },
+  ] = await Promise.all([
+    fetchPerUserUsageCreditsForMembersTable({
+      metronomeCustomerId,
+      metronomeContractId,
+    }),
+    fetchEffectivePerUserSpendLimits({
+      metronomeCustomerId,
+      workspaceId,
+      includeAlertLinks: false,
+    }),
+  ]);
+
+  const normalizedSeatType = normalizeToPoolLimitSeatType(seatType);
+  const defaultCap = normalizedSeatType
+    ? (defaultAwuCreditsBySeatType[normalizedSeatType] ?? null)
+    : null;
+
+  // Mirror `getMembersUsage`: the override threshold stored on the membership is
+  // the pool-only portion; add the seat allowance to get the total threshold.
+  const overrideAwuCredits =
+    poolCapOverrideAwuCredits !== null
+      ? poolCapOverrideAwuCredits +
+        (normalizedSeatType
+          ? (seatAllowanceBySeatType[normalizedSeatType] ?? 0)
+          : 0)
+      : null;
+
+  const spendLimitAwuCredits = resolveEffectiveSpendLimitAwuCredits({
+    overrideAwuCredits,
+    defaultAwuCredits: defaultCap?.threshold ?? null,
+  });
+
+  if (!spendLimitAwuCredits) {
+    return null;
+  }
+
+  const consumed = perUserTotalConsumedCredits.get(userId) ?? 0;
+  return Math.max(0, (spendLimitAwuCredits - consumed) / spendLimitAwuCredits);
 }
 
 export async function getMembersUsage({

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -1,3 +1,4 @@
+import { fetchRemainingCapCreditsPercentageForUser } from "@app/lib/api/credits/members_usage";
 import { recalculatePerUserCapAlertForSeatChange } from "@app/lib/api/membership";
 import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
@@ -168,11 +169,24 @@ export async function dispatchSeatBalanceExhausted({
     userId,
     seatType: membership.seatType,
   });
+  const remainingCapCreditsPercentage =
+    await fetchRemainingCapCreditsPercentageForUser({
+      metronomeCustomerId: workspace.metronomeCustomerId,
+      workspaceId: workspace.sId,
+      userId,
+      seatType: membership.seatType,
+      poolCapOverrideAwuCredits: membership.poolCapOverrideAwuCredits,
+    });
 
   const result = await transitionUserCreditState(
     membership,
     { type: "seat_balance_exhausted", poolLimitAwuCredits },
-    { workspaceId: workspace.sId, userId, seatType: membership.seatType }
+    {
+      workspaceId: workspace.sId,
+      userId,
+      seatType: membership.seatType,
+      remainingCapCreditsPercentage,
+    }
   );
   if (result.isErr()) {
     logger.warn(

--- a/front/lib/metronome/user_credit_state_machine.test.ts
+++ b/front/lib/metronome/user_credit_state_machine.test.ts
@@ -450,6 +450,159 @@ describe("UserCreditStateMachine — seat_balance_exhausted", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// remainingCapCreditsPercentage guards
+// ---------------------------------------------------------------------------
+
+describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCreditsPercentage", () => {
+  // Guard 2: cap fully exhausted (0 %) beats pool room → capped.
+  it("user_seat + pro + 0% cap remaining + pool limit > 0 → capped", async () => {
+    const membership = makeMembership("user_seat", "pro");
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "seat_balance_exhausted", poolLimitAwuCredits: 5000 },
+      { ...baseCtx, seatType: "pro", remainingCapCreditsPercentage: 0 }
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("capped");
+    }
+    expect(membership.updateCreditState).toHaveBeenCalledWith(
+      "capped",
+      undefined
+    );
+    expect(mockSetUserCapBlocked).toHaveBeenCalledWith("ws_test", "u_test");
+  });
+
+  // Guard 2: same as above from user_seat_low_balance.
+  it("user_seat_low_balance + pro + 0% cap remaining + pool limit > 0 → capped", async () => {
+    const membership = makeMembership("user_seat_low_balance", "pro");
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "seat_balance_exhausted", poolLimitAwuCredits: 5000 },
+      { ...baseCtx, seatType: "pro", remainingCapCreditsPercentage: 0 }
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("capped");
+    }
+    expect(membership.updateCreditState).toHaveBeenCalledWith(
+      "capped",
+      undefined
+    );
+    expect(mockSetUserCapBlocked).toHaveBeenCalledWith("ws_test", "u_test");
+  });
+
+  // Guard 3: < 20 % cap remaining → on_pool_low_balance.
+  it("user_seat + pro + 10% cap remaining → on_pool_low_balance", async () => {
+    const membership = makeMembership("user_seat", "pro");
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
+      { ...baseCtx, seatType: "pro", remainingCapCreditsPercentage: 0.1 }
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("on_pool_low_balance");
+    }
+    expect(membership.updateCreditState).toHaveBeenCalledWith(
+      "on_pool_low_balance",
+      undefined
+    );
+    expect(mockSetUserAwuWarned).toHaveBeenCalledWith("ws_test", "u_test");
+    expect(mockSetUserCapBlocked).not.toHaveBeenCalled();
+  });
+
+  // Guard 3: boundary — exactly 19 % (just below 0.2) → on_pool_low_balance.
+  it("user_seat + pro + 19% cap remaining → on_pool_low_balance", async () => {
+    const membership = makeMembership("user_seat", "pro");
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
+      { ...baseCtx, seatType: "pro", remainingCapCreditsPercentage: 0.19 }
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("on_pool_low_balance");
+    }
+    expect(membership.updateCreditState).toHaveBeenCalledWith(
+      "on_pool_low_balance",
+      undefined
+    );
+  });
+
+  // Guard 4: exactly 20 % is NOT < 0.2, so guard 3 does not fire → on_pool.
+  it("user_seat + pro + exactly 20% cap remaining → on_pool (not low balance)", async () => {
+    const membership = makeMembership("user_seat", "pro");
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
+      { ...baseCtx, seatType: "pro", remainingCapCreditsPercentage: 0.2 }
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("on_pool");
+    }
+    expect(membership.updateCreditState).toHaveBeenCalledWith(
+      "on_pool",
+      undefined
+    );
+    expect(mockSetUserCapBlocked).not.toHaveBeenCalled();
+  });
+
+  // Guard 4: ample cap remaining → on_pool.
+  it("user_seat + pro + 50% cap remaining → on_pool", async () => {
+    const membership = makeMembership("user_seat", "pro");
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
+      { ...baseCtx, seatType: "pro", remainingCapCreditsPercentage: 0.5 }
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("on_pool");
+    }
+    expect(membership.updateCreditState).toHaveBeenCalledWith(
+      "on_pool",
+      undefined
+    );
+    expect(mockSetUserCapBlocked).not.toHaveBeenCalled();
+  });
+
+  // Guard 4: null percentage (no cap configured) → on_pool (guard 3 skipped).
+  it("user_seat + pro + null cap percentage → on_pool", async () => {
+    const membership = makeMembership("user_seat", "pro");
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
+      { ...baseCtx, seatType: "pro", remainingCapCreditsPercentage: null }
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("on_pool");
+    }
+    expect(membership.updateCreditState).toHaveBeenCalledWith(
+      "on_pool",
+      undefined
+    );
+  });
+
+  // Guard 1 (free seat) takes precedence regardless of percentage.
+  it("user_seat + free + 50% cap remaining → capped (free-seat guard wins)", async () => {
+    const membership = makeMembership("user_seat", "free");
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
+      { ...baseCtx, seatType: "free", remainingCapCreditsPercentage: 0.5 }
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("capped");
+    }
+    expect(mockSetUserCapBlocked).toHaveBeenCalledWith("ws_test", "u_test");
+  });
+});
+
 describe("UserCreditStateMachine — seat_low_balance", () => {
   it("user_seat + max threshold + max seat → user_seat_low_balance", async () => {
     const membership = makeMembership("user_seat", "max");

--- a/front/lib/metronome/user_credit_state_machine.ts
+++ b/front/lib/metronome/user_credit_state_machine.ts
@@ -47,6 +47,12 @@ export type UserCreditContext = {
    * to `on_pool`. Absent for events that don't carry balance data.
    */
   liveBalance?: LiveUserSeatBalance;
+  /**
+   * Fraction of the user's per-user cap credits still remaining (0–1).
+   * Required by guards on `seat_balance_exhausted` for paid seats to decide
+   * whether to land on `on_pool`, `on_pool_low_balance`, or `capped`.
+   */
+  remainingCapCreditsPercentage?: number | null;
 };
 
 export type UserCreditEvent =
@@ -239,26 +245,36 @@ const TRANSITIONS: UserCreditTransition[] = [
     event: "per_user_cap_resolved",
     to: "on_pool",
   },
-
   // Seat balance exhausted. Order matters: most specific guard first.
   //  1. Free seats → always capped (no pool access).
-  //  2. Paid seats with pool limit = 0 → capped (no pool budget).
-  //  3. Paid seats with pool limit > 0 or null (unlimited) → on_pool.
   {
     from: ["user_seat", "user_seat_low_balance", "capped"],
     event: "seat_balance_exhausted",
     guard: (ctx) => ctx.seatType === "free",
     to: "capped",
   },
+  // 2. Paid seats whose per-user cap is also exhausted (0 % remaining) or with pool limit = 0 → capped (no pool budget).
   {
     from: ["user_seat", "user_seat_low_balance", "capped"],
     event: "seat_balance_exhausted",
     guard: (ctx, event) =>
       ctx.seatType !== "free" &&
       event.type === "seat_balance_exhausted" &&
-      event.poolLimitAwuCredits === 0,
+      (event.poolLimitAwuCredits === 0 ||
+        ctx.remainingCapCreditsPercentage === 0),
     to: "capped",
   },
+  // 3. Paid seats with < 20 % of cap remaining → on_pool_low_balance.
+  {
+    from: ["user_seat", "user_seat_low_balance"],
+    event: "seat_balance_exhausted",
+    guard: (ctx) =>
+      ctx.seatType !== "free" &&
+      ctx.remainingCapCreditsPercentage != null &&
+      ctx.remainingCapCreditsPercentage < 0.2,
+    to: "on_pool_low_balance",
+  },
+  // 4. Paid seats with ≥ 20 % of cap remaining, with pool limit > 0 or null (unlimited) → on_pool
   {
     from: ["user_seat", "user_seat_low_balance", "on_pool"],
     event: "seat_balance_exhausted",

--- a/front/lib/metronome/user_credit_state_machine.ts
+++ b/front/lib/metronome/user_credit_state_machine.ts
@@ -12,7 +12,11 @@ import type {
   MembershipSeatType,
   UserCreditState,
 } from "@app/types/memberships";
-import { expectedUserCreditState } from "@app/types/memberships";
+import {
+  CAP_WARNING_FRACTION,
+  expectedUserCreditState,
+  SEAT_LOW_BALANCE_FRACTION,
+} from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -271,7 +275,7 @@ const TRANSITIONS: UserCreditTransition[] = [
     guard: (ctx) =>
       ctx.seatType !== "free" &&
       ctx.remainingCapCreditsPercentage != null &&
-      ctx.remainingCapCreditsPercentage < 0.2,
+      ctx.remainingCapCreditsPercentage < 1 - CAP_WARNING_FRACTION,
     to: "on_pool_low_balance",
   },
   // 4. Paid seats with ≥ 20 % of cap remaining, with pool limit > 0 or null (unlimited) → on_pool
@@ -292,7 +296,8 @@ const TRANSITIONS: UserCreditTransition[] = [
     event: "seat_low_balance",
     guard: (ctx, event) =>
       event.type === "seat_low_balance" &&
-      event.threshold === 0.2 * MAX_SEAT_MONTHLY_AWU_CREDITS &&
+      event.threshold ===
+        SEAT_LOW_BALANCE_FRACTION * MAX_SEAT_MONTHLY_AWU_CREDITS &&
       (ctx.seatType === "max" || ctx.seatType === "max_yearly"),
     to: "user_seat_low_balance",
   },

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -193,8 +193,8 @@ export function isSpendingFromPersonalSeat(state: UserCreditState): boolean {
 // low-balance warning bands kick in. Mirrors the seat-low-balance guards in
 // `lib/metronome/user_credit_state_machine.ts` (threshold === 0.2 * allowance)
 // and `USER_AWU_WARNING_PERCENTAGE` (0.8) backing the per-user warning alerts.
-const SEAT_LOW_BALANCE_FRACTION = 0.2;
-const CAP_WARNING_FRACTION = 0.8;
+export const SEAT_LOW_BALANCE_FRACTION = 0.2;
+export const CAP_WARNING_FRACTION = 0.8;
 
 /**
  * The credit state a freshly-allocated seat should start in, derived purely


### PR DESCRIPTION
## Description

When a paid seat's balance is exhausted and the user transitions to the pool, the state machine previously only checked `poolLimitAwuCredits` to decide `on_pool` vs `capped`. This PR enriches that decision with the fraction of per-user cap credits still available (`remainingCapCreditsPercentage`):

- **0 % remaining** (cap also exhausted) → `capped` (no pool access, same as pool limit = 0).
- **< 20 % remaining** → `on_pool_low_balance` (enters pool but with a low-balance warning).
- **≥ 20 % remaining** (or no cap configured) → `on_pool` as before.

A new helper `fetchRemainingCapCreditsPercentageForUser` is introduced in `members_usage.ts` to compute this ratio, reusing the same cached Metronome fetchers already used by `getMembersUsage`. `dispatchSeatBalanceExhausted` fetches this value and threads it into the `transitionUserCreditState` context via the new `remainingCapCreditsPercentage` field on `UserCreditContext`.

## Tests

Added unit tests in `user_credit_state_machine.test.ts`.

## Risk

Low. The change only affects the `seat_balance_exhausted` transition for paid seats. Free seats and the `on_pool` re-evaluation paths are unchanged. On a Metronome read failure the new field is absent and the existing fallback guards apply.

## Deploy Plan

Deploy front.