### PR TITLE
[front] Adapt design

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -31,7 +31,6 @@ import {
   AlertCircle,
   ArrowUp,
   Button,
-  CoinsStacked03,
   ContentMessage,
   DropdownMenu,
   DropdownMenuContent,
@@ -42,7 +41,6 @@ import {
   PieChart01,
   SearchInput,
   Spinner,
-  Tooltip,
 } from "@dust-tt/sparkle";
 import type { PaginationState, SortingState } from "@tanstack/react-table";
 import { useCallback, useEffect, useState } from "react";
@@ -52,45 +50,6 @@ function formatCredits(credits: number): string {
 }
 
 const DEFAULT_PAGE_SIZE = 25;
-
-interface CreditPoolUsageBarProps {
-  totalCredits: number;
-  consumedCredits: number;
-}
-
-function CreditPoolUsageBar({
-  totalCredits,
-  consumedCredits,
-}: CreditPoolUsageBarProps) {
-  const consumedPercentage =
-    totalCredits > 0
-      ? Math.min((consumedCredits / totalCredits) * 100, 100)
-      : 0;
-
-  return (
-    <Page.Vertical gap="xs" align="stretch">
-      <div
-        className="flex h-2 w-full overflow-hidden rounded-full bg-muted-foreground/10 dark:bg-muted-foreground-night/10"
-        role="progressbar"
-        aria-label="Workspace Credits Pool usage"
-        aria-valuenow={Math.round(consumedPercentage)}
-        aria-valuemin={0}
-        aria-valuemax={100}
-      >
-        <Tooltip
-          tooltipTriggerAsChild
-          label={`${formatCredits(consumedCredits)} credits consumed`}
-          trigger={
-            <div
-              className="h-full shrink-0 bg-highlight transition-all dark:bg-highlight-night"
-              style={{ width: `${consumedPercentage}%` }}
-            />
-          }
-        />
-      </div>
-    </Page.Vertical>
-  );
-}
 
 export function UsagePage() {
   const owner = useWorkspace();
@@ -234,56 +193,7 @@ export function UsagePage() {
           </Page.P>
         </Page.Vertical>
 
-        <Page.Vertical gap="sm" align="stretch">
-          <div className="flex items-center justify-between">
-            <span className="text-[16px] font-medium leading-[24px] tracking-[-0.32px] text-foreground dark:text-foreground-night">
-              Workspace Credits Pool
-            </span>
-            {!isAwuPoolSummaryLoading && (
-              <div className="flex flex-col items-end gap-0.5">
-                <span className="flex items-center gap-1.5 text-[18px] font-semibold leading-[26px] tracking-[-0.36px] text-foreground dark:text-foreground-night">
-                  <Icon
-                    visual={CoinsStacked03}
-                    size="sm"
-                    className="text-muted-foreground dark:text-muted-foreground-night"
-                  />
-                  {formatCredits(totalConsumedCredits)} /{" "}
-                  {formatCredits(initialTotalCredits)}
-                </span>
-                <div className="flex items-center gap-2">
-                  {overageCredits !== null && overageCredits > 0 && (
-                    <span className="text-xs font-medium text-muted-foreground dark:text-muted-foreground-night">
-                      {formatCredits(overageCredits)} overage credits.
-                    </span>
-                  )}
-                  {isEnterprise ? (
-                    <Tooltip
-                      tooltipTriggerAsChild
-                      label="Contact your Dust sales representative to top up."
-                      trigger={
-                        <button
-                          className="flex items-center gap-1 text-xs font-medium text-highlight-500 opacity-50 dark:text-highlight-500-night"
-                          disabled
-                        >
-                          <Icon visual={ArrowUp} size="xs" />
-                          Top up
-                        </button>
-                      }
-                    />
-                  ) : (
-                    <button
-                      className="flex cursor-pointer items-center gap-1 text-xs font-medium text-highlight-500 dark:text-highlight-500-night"
-                      onClick={() => setShowBuyCreditDialog(true)}
-                    >
-                      <Icon visual={ArrowUp} size="xs" />
-                      Top up
-                    </button>
-                  )}
-                </div>
-              </div>
-            )}
-          </div>
-
+        <Page.Vertical gap="xs" align="stretch">
           {isAwuPoolSummaryError && (
             <ContentMessage
               title="Failed to load Workspace Credits Pool"
@@ -295,17 +205,43 @@ export function UsagePage() {
             </ContentMessage>
           )}
 
-          {!isAwuPoolSummaryLoading && !isAwuPoolSummaryError && (
-            <CreditPoolUsageBar
-              totalCredits={initialTotalCredits}
-              consumedCredits={totalConsumedCredits}
-            />
-          )}
-
           {isAwuPoolSummaryLoading && (
             <div className="flex justify-center py-8">
               <Spinner />
             </div>
+          )}
+
+          {!isAwuPoolSummaryLoading && !isAwuPoolSummaryError && (
+            <>
+              <div className="flex items-baseline gap-1">
+                <span className="heading-mono-4xl text-foreground dark:text-foreground-night">
+                  {formatCredits(totalConsumedCredits)}
+                </span>
+                <span className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
+                  /{formatCredits(initialTotalCredits)}
+                </span>
+              </div>
+              <div className="flex items-center gap-2">
+                {overageCredits !== null && overageCredits > 0 && (
+                  <span className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
+                    {formatCredits(overageCredits)} overage credits
+                  </span>
+                )}
+                {isEnterprise ? (
+                  <span className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
+                    Contact your Dust sales representative to buy credits
+                  </span>
+                ) : (
+                  <Button
+                    label="Top up"
+                    icon={ArrowUp}
+                    size="xs"
+                    variant="ghost"
+                    onClick={() => setShowBuyCreditDialog(true)}
+                  />
+                )}
+              </div>
+            </>
           )}
         </Page.Vertical>
 

--- a/front/components/workspace/BuyAwuCreditsDialog.tsx
+++ b/front/components/workspace/BuyAwuCreditsDialog.tsx
@@ -19,7 +19,6 @@ import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import {
   Button,
   CheckCircle,
-  CoinsStacked03,
   Dialog,
   DialogContainer,
   DialogContent,
@@ -80,16 +79,7 @@ interface CreditValueProps {
 }
 
 function CreditValue({ credits }: CreditValueProps) {
-  return (
-    <span className="flex items-center gap-1">
-      <Icon
-        visual={CoinsStacked03}
-        size="xs"
-        className="text-muted-foreground dark:text-muted-foreground-night"
-      />
-      {formatCredits(credits)}
-    </span>
-  );
+  return <span>{formatCredits(credits)}</span>;
 }
 
 interface SummaryRowProps {
@@ -358,7 +348,6 @@ export function BuyAwuCreditsDialog({
                       {isValidAmount && (
                         <span className="flex items-center gap-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
                           {formatCredits(addedCredits)} credits
-                          <Icon visual={CoinsStacked03} size="xs" />
                         </span>
                       )}
                       <div className="ml-auto flex gap-2">

--- a/front/components/workspace/ChangeSeatModal.tsx
+++ b/front/components/workspace/ChangeSeatModal.tsx
@@ -19,7 +19,6 @@ import {
   ButtonGroup,
   Card,
   Chip,
-  CoinsStacked03,
   Cube01,
   Dialog,
   DialogContainer,
@@ -155,7 +154,6 @@ function SeatCard({
       </div>
       {info.awuCredits > 0 && (
         <div className="flex items-center gap-2 text-muted-foreground dark:text-muted-foreground-night">
-          <CoinsStacked03 className="size-4" />
           <span className="text-xs">{formatAwuCredits(info)}</span>
         </div>
       )}

--- a/front/components/workspace/EditSpendLimitModal.tsx
+++ b/front/components/workspace/EditSpendLimitModal.tsx
@@ -8,7 +8,6 @@ import type { WorkspaceType } from "@app/types/user";
 import {
   AlertCircle,
   Avatar,
-  CoinsStacked03,
   ContentMessage,
   Dialog,
   DialogContainer,
@@ -16,7 +15,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  Icon,
   Input,
   RadioGroup,
   RadioGroupItem,
@@ -247,9 +245,6 @@ export function EditSpendLimitModal({
               {kind === "override" && (
                 <div className="flex flex-col gap-1.5 pl-6">
                   <div className="relative">
-                    <div className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground dark:text-muted-foreground-night">
-                      <Icon visual={CoinsStacked03} size="xs" />
-                    </div>
                     <Input
                       id="spend-credit-limit-input"
                       type="text"
@@ -258,13 +253,16 @@ export function EditSpendLimitModal({
                       placeholder="1000"
                       value={creditsInput}
                       onChange={(e) => handleCreditsChange(e.target.value)}
-                      className="pl-8"
                       isError={validationMessage !== null}
                       message={validationMessage ?? undefined}
                       messageStatus={
                         validationMessage !== null ? "error" : undefined
                       }
+                      className="pr-16 text-right"
                     />
+                    <span className="copy-sm pointer-events-none absolute right-3 top-0 flex h-9 items-center text-muted-foreground dark:text-muted-foreground-night">
+                      credits
+                    </span>
                   </div>
                 </div>
               )}

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -7,11 +7,9 @@ import {
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { ANONYMOUS_USER_IMAGE_URL } from "@app/types/user";
 import {
-  CoinsStacked03,
   Cube01,
   DataTable,
   Hexagon01,
-  Icon,
   LoadingBlock,
   type MenuItem,
   SeatMax,
@@ -313,12 +311,7 @@ const billingFrequencyColumn: ColumnDef<RowData, string> = {
 
 const consumedAwuCreditsColumn: ColumnDef<RowData, string> = {
   id: "consumedAwuCredits" as const,
-  header: () => (
-    <span className="flex items-center gap-1.5">
-      <Icon visual={CoinsStacked03} size="xs" />
-      Credits usage
-    </span>
-  ),
+  header: () => <span>Credits usage</span>,
   accessorFn: (row) => row.consumedAwuCredits.toString(),
   cell: (info: Info) => (
     <div className="w-full pr-3">

--- a/front/components/workspace/billing/BillingSeatsOverview.tsx
+++ b/front/components/workspace/billing/BillingSeatsOverview.tsx
@@ -8,7 +8,6 @@ import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Avatar,
-  CoinsStacked03,
   Cube01,
   Hexagon01,
   Icon,
@@ -226,7 +225,6 @@ export function BillingSeatsOverview({ owner }: BillingSeatsOverviewProps) {
                 </div>
                 {primaryPlan.awuCredits > 0 && (
                   <div className="flex items-center gap-2">
-                    <Icon visual={CoinsStacked03} size="xs" />
                     <span>
                       {primaryPlan.awuCredits.toLocaleString()} credits{" "}
                       {formatAwuCreditsPeriod(primaryPlan.awuCreditsPeriod)}

--- a/front/components/workspace/usage/UsageNotificationsCard.tsx
+++ b/front/components/workspace/usage/UsageNotificationsCard.tsx
@@ -2,13 +2,7 @@ import {
   useUpdateUsageNotifications,
   useUsageNotifications,
 } from "@app/lib/swr/usage_settings";
-import {
-  CoinsStacked03,
-  Icon,
-  Input,
-  Page,
-  SettingsList,
-} from "@dust-tt/sparkle";
+import { Input, Page, SettingsList } from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
 
 interface UsageNotificationsCardProps {
@@ -78,9 +72,6 @@ export function UsageNotificationsCard({
           description="Email all workspace admins when your remaining credit balance drops below this amount (in credits). Set to 0 to disable."
           action={
             <div className="relative w-32">
-              <div className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground dark:text-muted-foreground-night">
-                <Icon visual={CoinsStacked03} size="xs" />
-              </div>
               <Input
                 type="text"
                 inputMode="numeric"
@@ -93,8 +84,11 @@ export function UsageNotificationsCard({
                 disabled={
                   isSavingBalanceThreshold || isUsageNotificationsLoading
                 }
-                className="pl-8 text-right"
+                className="pr-16 text-right"
               />
+              <span className="copy-sm pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground dark:text-muted-foreground-night">
+                credits
+              </span>
             </div>
           }
         />

--- a/front/components/workspace/usage/UsageProgrammaticLimitCard.tsx
+++ b/front/components/workspace/usage/UsageProgrammaticLimitCard.tsx
@@ -2,13 +2,7 @@ import {
   useProgrammaticUsageLimit,
   useUpdateProgrammaticUsageLimit,
 } from "@app/lib/swr/usage_settings";
-import {
-  CoinsStacked03,
-  Icon,
-  Input,
-  Page,
-  SettingsList,
-} from "@dust-tt/sparkle";
+import { Input, Page, SettingsList } from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
 
 interface UsageProgrammaticLimitCardProps {
@@ -88,9 +82,6 @@ export function UsageProgrammaticLimitCard({
           description="Maximum credits allowed for programmatic usage per month"
           action={
             <div className="relative w-32">
-              <div className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground dark:text-muted-foreground-night">
-                <Icon visual={CoinsStacked03} size="xs" />
-              </div>
               <Input
                 type="text"
                 inputMode="numeric"
@@ -102,8 +93,11 @@ export function UsageProgrammaticLimitCard({
                 }
                 onBlur={() => void handleCommitLimit()}
                 disabled={isInputDisabled}
-                className="pl-8 text-right"
+                className="pr-16 text-right"
               />
+              <span className="copy-sm pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground dark:text-muted-foreground-night">
+                credits
+              </span>
             </div>
           }
         />

--- a/front/components/workspace/usage/UsageSettingsCard.tsx
+++ b/front/components/workspace/usage/UsageSettingsCard.tsx
@@ -6,13 +6,7 @@ import {
   MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
   MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
 } from "@app/types/credits";
-import {
-  CoinsStacked03,
-  Icon,
-  Input,
-  Page,
-  SettingsList,
-} from "@dust-tt/sparkle";
+import { Input, Page, SettingsList } from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
 
 interface UsageSettingsCardProps {
@@ -76,9 +70,6 @@ export function UsageSettingsCard({ workspaceId }: UsageSettingsCardProps) {
           description="Define the pool credit limit for users in your workspace. This limit is added on top of each seat's built-in allowance."
           action={
             <div className="relative w-32">
-              <div className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground dark:text-muted-foreground-night">
-                <Icon visual={CoinsStacked03} size="xs" />
-              </div>
               <Input
                 type="text"
                 inputMode="numeric"
@@ -89,8 +80,11 @@ export function UsageSettingsCard({ workspaceId }: UsageSettingsCardProps) {
                 }
                 onBlur={() => void handleCommitDefaultLimit()}
                 disabled={isDefaultLimitInputDisabled}
-                className="pl-8 text-right"
+                className="pr-16 text-right"
               />
+              <span className="copy-sm pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground dark:text-muted-foreground-night">
+                credits
+              </span>
             </div>
           }
         />


### PR DESCRIPTION
## Description

Adapts the workspace **Usage** page to match the latest Figma design, and removes the credit (coins) icon across the billing/usage surfaces.

### Usage page — Workspace Credits Pool section
- Removed the **"Workspace Credits Pool"** heading.
- Replaced the **credit pool progress bar** with a plain text readout: the consumed credits as a large number (`heading-mono-4xl`) followed by a smaller muted `/total` (`copy-sm`), baseline-aligned.
- Removed the **credit icon** next to the number.
- Kept the **"Top up"** action and the enterprise "contact sales" state, now rendered with the Sparkle `Button` (`variant="ghost"`, with `tooltip`/`disabled`) instead of a hand-rolled `<button>` + `Tooltip`.
- Dropped the now-unused `CreditPoolUsageBar` component.

### Credit icon removed everywhere
Removed `CoinsStacked03` (import + usage) from:
- `UsagePage.tsx`
- `MembersUsageTable.tsx` ("Credits usage" header)
- `BuyAwuCreditsDialog.tsx` (credit value + added-credits line)
- `ChangeSeatModal.tsx` (seat credits row)
- `EditSpendLimitModal.tsx` (input prefix)
- `UsageSettingsCard.tsx`, `UsageProgrammaticLimitCard.tsx`, `UsageNotificationsCard.tsx` (input prefixes)
- `BillingSeatsOverview.tsx` (seat credits row)

Unused `Icon`/`Tooltip` imports and orphaned wrapper/padding (`pl-8`, `relative` positioning divs) left behind by the icon removal were cleaned up.

### Consistency
Used Sparkle design-system typography utilities (`heading-mono-4xl`, `copy-sm`) and the Sparkle `Button` rather than arbitrary inline Tailwind values, to stay consistent with the rest of the app.

> Note: the "Monthly resets on …" line from the Figma was intentionally dropped — nothing actually resets on a fixed date. The "Top up" link is a neutral `ghost` button rather than a blue text-link, as there's no Sparkle text-link-in-highlight variant (consistency over pixel-match).

## Risk

Low — UI-only changes on the Usage page and billing/usage components. No API, schema, or business-logic changes.

## Tests

- `tsgo --noEmit` clean on all changed files.
- `biome check` passes with no warnings.
