### PR TITLE
feat: add editable property to tools

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -29,7 +29,6 @@ import type {
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { isInternalServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import type {
-  EditableToolConfig,
   MCPToolRetryPolicyType,
   ToolDisplayLabels,
 } from "@app/lib/api/mcp";
@@ -77,7 +76,7 @@ export type ServerSideMCPToolType = Omit<
   // When true, the tool is loaded upfront in the cached tools prefix instead of
   // being deferred behind tool search.
   eager?: boolean;
-  editable?: EditableToolConfig;
+  editableArguments?: string[];
 };
 
 export type ClientSideMCPToolType = Omit<

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -76,7 +76,7 @@ export type ServerSideMCPToolType = Omit<
   // When true, the tool is loaded upfront in the cached tools prefix instead of
   // being deferred behind tool search.
   eager?: boolean;
-  editableArguments?: string[];
+  editableArguments?: readonly string[];
 };
 
 export type ClientSideMCPToolType = Omit<

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -29,6 +29,7 @@ import type {
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { isInternalServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import type {
+  EditableToolConfig,
   MCPToolRetryPolicyType,
   ToolDisplayLabels,
 } from "@app/lib/api/mcp";
@@ -76,6 +77,7 @@ export type ServerSideMCPToolType = Omit<
   // When true, the tool is loaded upfront in the cached tools prefix instead of
   // being deferred behind tool search.
   eager?: boolean;
+  editable?: EditableToolConfig;
 };
 
 export type ClientSideMCPToolType = Omit<

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -246,7 +246,9 @@ export function makeServerSideMCPToolConfigurations(
     ...(tool.timeoutMs && { timeoutMs: tool.timeoutMs }),
     ...(tool.displayLabels && { displayLabels: tool.displayLabels }),
     ...(tool.eager && { eager: true }),
-    ...(tool.editable && { editable: tool.editable }),
+    ...(tool.editableArguments && {
+      editableArguments: tool.editableArguments,
+    }),
     argumentsRequiringApproval: toolsArgumentsRequiringApproval?.[tool.name],
   }));
 }

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -246,6 +246,7 @@ export function makeServerSideMCPToolConfigurations(
     ...(tool.timeoutMs && { timeoutMs: tool.timeoutMs }),
     ...(tool.displayLabels && { displayLabels: tool.displayLabels }),
     ...(tool.eager && { eager: true }),
+    ...(tool.editable && { editable: tool.editable }),
     argumentsRequiringApproval: toolsArgumentsRequiringApproval?.[tool.name],
   }));
 }

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -48,13 +48,6 @@ export type ClientToolHandlers<
   ToolNames extends string = ToolsList[number]["name"],
 > = ToolHandlers<ToolsList, ToolNames, BaseToolHandlerExtra>;
 
-type EditableToolConfig<TSchema extends ZodRawShape> = {
-  isEditable: boolean;
-  editableArguments: ReadonlyArray<
-    Extract<keyof z.infer<z.ZodObject<TSchema>>, string>
-  >;
-};
-
 export interface ToolDefinition<
   TName extends string = string,
   TSchema extends ZodRawShape = ZodRawShape,
@@ -74,6 +67,9 @@ export interface ToolDefinition<
   argumentsRequiringApproval?: ReadonlyArray<
     Extract<keyof z.infer<z.ZodObject<TSchema>>, string>
   >;
+  editableArguments?: ReadonlyArray<
+    Extract<keyof z.infer<z.ZodObject<TSchema>>, string>
+  >;
   handler(
     params: z.infer<z.ZodObject<TSchema>>,
     extra: THandlerExtra
@@ -89,6 +85,9 @@ export type ToolMeta<
 type ValidToolMetadata<T extends readonly ToolMeta[]> = {
   [K in keyof T]: {
     argumentsRequiringApproval?: ReadonlyArray<
+      Extract<keyof z.infer<z.ZodObject<T[K]["schema"]>>, string>
+    >;
+    editableArguments?: ReadonlyArray<
       Extract<keyof z.infer<z.ZodObject<T[K]["schema"]>>, string>
     >;
   };

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -48,6 +48,13 @@ export type ClientToolHandlers<
   ToolNames extends string = ToolsList[number]["name"],
 > = ToolHandlers<ToolsList, ToolNames, BaseToolHandlerExtra>;
 
+type EditableToolConfig<TSchema extends ZodRawShape> = {
+  isEditable: boolean;
+  editableArguments: ReadonlyArray<
+    Extract<keyof z.infer<z.ZodObject<TSchema>>, string>
+  >;
+};
+
 export interface ToolDefinition<
   TName extends string = string,
   TSchema extends ZodRawShape = ZodRawShape,

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -44,7 +44,7 @@ export function registerTool(
           stake: tool.stake,
           displayLabels: tool.displayLabels,
           eager: tool.eager,
-          editable: tool.editable,
+          editableArguments: tool.editableArguments,
         },
       },
     },

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -44,6 +44,7 @@ export function registerTool(
           stake: tool.stake,
           displayLabels: tool.displayLabels,
           eager: tool.eager,
+          editable: tool.editable,
         },
       },
     },

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -35,7 +35,6 @@ import {
 import type { ToolContext } from "@app/lib/actions/types";
 import { ClientSideRedisMCPTransport } from "@app/lib/api/actions/mcp_client_side";
 import type {
-  EditableToolConfig,
   MCPServerType,
   MCPToolType,
   ToolDisplayLabels,
@@ -810,16 +809,11 @@ async function connectToRemoteMCPServer(
 type DustToolMeta = {
   stake?: MCPToolStakeLevelType;
   displayLabels?: ToolDisplayLabels;
-  editable?: EditableToolConfig;
+  editableArguments?: string[];
   argumentsRequiringApproval?: string[];
   timeoutMs?: number;
   eager?: boolean;
 };
-
-const EditableToolConfigSchema = z.object({
-  isEditable: z.boolean(),
-  editableArguments: z.array(z.string()),
-});
 
 function isValidStake(value: unknown): value is MCPToolStakeLevelType {
   return (
@@ -843,12 +837,6 @@ function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((v) => typeof v === "string");
 }
 
-function isValidEditableToolConfig(
-  value: unknown
-): value is EditableToolConfig {
-  return EditableToolConfigSchema.safeParse(value).success;
-}
-
 function isValidTimeout(value: unknown): value is number {
   return typeof value === "number" && value > 0;
 }
@@ -869,8 +857,8 @@ export function getDustToolMeta(
   if (isValidDisplayLabels(dust.displayLabels)) {
     result.displayLabels = dust.displayLabels;
   }
-  if (isValidEditableToolConfig(dust.editable)) {
-    result.editable = dust.editable;
+  if (isStringArray(dust.editableArguments)) {
+    result.editableArguments = dust.editableArguments;
   }
   if (isStringArray(dust.argumentsRequiringApproval)) {
     result.argumentsRequiringApproval = dust.argumentsRequiringApproval;
@@ -898,7 +886,9 @@ export function extractMetadataFromTools(tools: Tool[]): MCPToolType[] {
         ? { displayLabels: dustMeta.displayLabels }
         : {}),
       ...(dustMeta?.eager ? { eager: true } : {}),
-      ...(dustMeta?.editable ? { editable: dustMeta.editable } : {}),
+      ...(dustMeta?.editableArguments
+        ? { editableArguments: dustMeta.editableArguments }
+        : {}),
     };
   });
 }

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -35,6 +35,7 @@ import {
 import type { ToolContext } from "@app/lib/actions/types";
 import { ClientSideRedisMCPTransport } from "@app/lib/api/actions/mcp_client_side";
 import type {
+  EditableToolConfig,
   MCPServerType,
   MCPToolType,
   ToolDisplayLabels,
@@ -809,10 +810,16 @@ async function connectToRemoteMCPServer(
 type DustToolMeta = {
   stake?: MCPToolStakeLevelType;
   displayLabels?: ToolDisplayLabels;
+  editable?: EditableToolConfig;
   argumentsRequiringApproval?: string[];
   timeoutMs?: number;
   eager?: boolean;
 };
+
+const EditableToolConfigSchema = z.object({
+  isEditable: z.boolean(),
+  editableArguments: z.array(z.string()),
+});
 
 function isValidStake(value: unknown): value is MCPToolStakeLevelType {
   return (
@@ -836,6 +843,12 @@ function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((v) => typeof v === "string");
 }
 
+function isValidEditableToolConfig(
+  value: unknown
+): value is EditableToolConfig {
+  return EditableToolConfigSchema.safeParse(value).success;
+}
+
 function isValidTimeout(value: unknown): value is number {
   return typeof value === "number" && value > 0;
 }
@@ -855,6 +868,9 @@ export function getDustToolMeta(
   }
   if (isValidDisplayLabels(dust.displayLabels)) {
     result.displayLabels = dust.displayLabels;
+  }
+  if (isValidEditableToolConfig(dust.editable)) {
+    result.editable = dust.editable;
   }
   if (isStringArray(dust.argumentsRequiringApproval)) {
     result.argumentsRequiringApproval = dust.argumentsRequiringApproval;
@@ -882,6 +898,7 @@ export function extractMetadataFromTools(tools: Tool[]): MCPToolType[] {
         ? { displayLabels: dustMeta.displayLabels }
         : {}),
       ...(dustMeta?.eager ? { eager: true } : {}),
+      ...(dustMeta?.editable ? { editable: dustMeta.editable } : {}),
     };
   });
 }

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -809,7 +809,7 @@ async function connectToRemoteMCPServer(
 type DustToolMeta = {
   stake?: MCPToolStakeLevelType;
   displayLabels?: ToolDisplayLabels;
-  editableArguments?: string[];
+  editableArguments?: readonly string[];
   argumentsRequiringApproval?: string[];
   timeoutMs?: number;
   eager?: boolean;

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -276,10 +276,7 @@ export const GMAIL_TOOLS_METADATA = [
         ),
     },
     stake: "high",
-    editable: {
-      isEditable: true,
-      editableArguments: ["subject"],
-    },
+    editableArguments: ["subject"],
     displayLabels: {
       running: "Sending Gmail email",
       done: "Send Gmail email",

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -278,7 +278,7 @@ export const GMAIL_TOOLS_METADATA = [
     stake: "high",
     editable: {
       isEditable: true,
-      editableArguments: ["subject"] as const,
+      editableArguments: ["subject"],
     },
     displayLabels: {
       running: "Sending Gmail email",

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -276,6 +276,10 @@ export const GMAIL_TOOLS_METADATA = [
         ),
     },
     stake: "high",
+    editable: {
+      isEditable: true,
+      editableArguments: ["subject"] as const,
+    },
     displayLabels: {
       running: "Sending Gmail email",
       done: "Send Gmail email",

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -76,7 +76,7 @@ export type MCPToolType = {
   // being deferred behind tool search. Absent for remote/client-side tools, which
   // therefore default to deferred.
   eager?: boolean;
-  editableArguments?: string[];
+  editableArguments?: readonly string[];
 };
 
 export type MCPServerType = {

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -65,11 +65,6 @@ export type ToolDisplayLabels = {
   icon?: InternalAllowedIconType; // optional per-tool icon override
 };
 
-export type EditableToolConfig = {
-  isEditable: boolean;
-  editableArguments: string[];
-};
-
 export type MCPToolType = {
   name: string;
   description: string;
@@ -81,7 +76,7 @@ export type MCPToolType = {
   // being deferred behind tool search. Absent for remote/client-side tools, which
   // therefore default to deferred.
   eager?: boolean;
-  editable?: EditableToolConfig;
+  editableArguments?: string[];
 };
 
 export type MCPServerType = {

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -65,6 +65,11 @@ export type ToolDisplayLabels = {
   icon?: InternalAllowedIconType; // optional per-tool icon override
 };
 
+export type EditableToolConfig = {
+  isEditable: boolean;
+  editableArguments: string[];
+};
+
 export type MCPToolType = {
   name: string;
   description: string;
@@ -76,6 +81,7 @@ export type MCPToolType = {
   // being deferred behind tool search. Absent for remote/client-side tools, which
   // therefore default to deferred.
   eager?: boolean;
+  editable?: EditableToolConfig;
 };
 
 export type MCPServerType = {

--- a/front/lib/api/mcp_schemas.ts
+++ b/front/lib/api/mcp_schemas.ts
@@ -25,7 +25,7 @@ const MCPToolSchema = z.object({
   description: z.string(),
   inputSchema: z.custom<JSONSchema>().optional(),
   displayLabels: ToolDisplayLabelsSchema.optional(),
-  editableArguments: z.array(z.string()).optional(),
+  editableArguments: z.array(z.string()).readonly().optional(),
 });
 
 const AuthorizationInfoSchema = z.object({

--- a/front/lib/api/mcp_schemas.ts
+++ b/front/lib/api/mcp_schemas.ts
@@ -17,11 +17,6 @@ const ToolDisplayLabelsSchema = z.object({
   done: z.string(),
 });
 
-export const EditableToolConfigSchema = z.object({
-  isEditable: z.boolean(),
-  editableArguments: z.array(z.string()),
-});
-
 // Types are kept in lib/api/mcp.ts to avoid breaking the Temporal bundle.
 // Only schemas are exported from this file.
 
@@ -30,7 +25,7 @@ const MCPToolSchema = z.object({
   description: z.string(),
   inputSchema: z.custom<JSONSchema>().optional(),
   displayLabels: ToolDisplayLabelsSchema.optional(),
-  editable: EditableToolConfigSchema.optional(),
+  editableArguments: z.array(z.string()).optional(),
 });
 
 const AuthorizationInfoSchema = z.object({

--- a/front/lib/api/mcp_schemas.ts
+++ b/front/lib/api/mcp_schemas.ts
@@ -17,6 +17,11 @@ const ToolDisplayLabelsSchema = z.object({
   done: z.string(),
 });
 
+export const EditableToolConfigSchema = z.object({
+  isEditable: z.boolean(),
+  editableArguments: z.array(z.string()),
+});
+
 // Types are kept in lib/api/mcp.ts to avoid breaking the Temporal bundle.
 // Only schemas are exported from this file.
 
@@ -25,6 +30,7 @@ const MCPToolSchema = z.object({
   description: z.string(),
   inputSchema: z.custom<JSONSchema>().optional(),
   displayLabels: ToolDisplayLabelsSchema.optional(),
+  editable: EditableToolConfigSchema.optional(),
 });
 
 const AuthorizationInfoSchema = z.object({


### PR DESCRIPTION
## Description

This PR introduces an `editable` property to MCP tools, allowing tools to declare which of their arguments can be edited by the user before execution.

- Adds `EditableToolConfig` type (`isEditable`, `editableArguments`) in `mcp.ts` and a corresponding Zod schema in `mcp_schemas.ts`
- Propagates the `editable` config through the tool metadata pipeline (`tool_definition.ts`, `wrappers.ts`, `mcp.ts`, `mcp_actions.ts`, `mcp_metadata.ts`)
- Marks the Gmail send email tool's `subject` argument as editable as the first use case

This is the first PR in a stack implementing editable tool inputs end-to-end.

## Tests

Manually.

## Risks
Low.

## Deploy Plan
Standard deployment.
