### PR TITLE
feat: forward editable tool config through blocked action payload

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -389,7 +389,7 @@ export function AgentMessage({
                 conversationId: eventPayload.data.conversationId,
                 created: eventPayload.data.created,
                 inputs: eventPayload.data.inputs,
-                editable: eventPayload.data.editable,
+                editableArguments: eventPayload.data.editableArguments,
                 messageId: eventPayload.data.messageId,
                 metadata: eventPayload.data.metadata,
                 stake: eventPayload.data.stake,

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -389,6 +389,7 @@ export function AgentMessage({
                 conversationId: eventPayload.data.conversationId,
                 created: eventPayload.data.created,
                 inputs: eventPayload.data.inputs,
+                editable: eventPayload.data.editable,
                 messageId: eventPayload.data.messageId,
                 metadata: eventPayload.data.metadata,
                 stake: eventPayload.data.stake,

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -172,6 +172,7 @@ type BlockedToolExecutionVariant =
   | {
       status: "blocked_validation_required";
       authorizationInfo: AuthorizationInfo | null;
+      editable?: EditableToolConfig;
     }
   | {
       status: "blocked_child_action_input_required";

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -172,7 +172,7 @@ type BlockedToolExecutionVariant =
   | {
       status: "blocked_validation_required";
       authorizationInfo: AuthorizationInfo | null;
-      editable?: EditableToolConfig;
+      editableArguments?: string[];
     }
   | {
       status: "blocked_child_action_input_required";

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -172,7 +172,7 @@ type BlockedToolExecutionVariant =
   | {
       status: "blocked_validation_required";
       authorizationInfo: AuthorizationInfo | null;
-      editableArguments?: string[];
+      editableArguments?: readonly string[];
     }
   | {
       status: "blocked_child_action_input_required";

--- a/front/lib/actions/mcp_internal_actions/events.ts
+++ b/front/lib/actions/mcp_internal_actions/events.ts
@@ -3,7 +3,6 @@ import type {
   MCPValidationMetadataType,
 } from "@app/lib/actions/constants";
 import type { UserQuestion } from "@app/lib/actions/types";
-import type { EditableToolConfig } from "@app/lib/api/mcp";
 import type { OAuthProvider } from "@app/types/oauth/lib";
 
 // Identifiers scoping an event to the run context it was emitted from, mirroring the contextType
@@ -113,7 +112,7 @@ export type ToolFileAuthRequiredEvent =
 export interface AgentLoopMCPApproveExecutionEvent
   extends AgentLoopToolExecution {
   type: "tool_approve_execution";
-  editable?: EditableToolConfig;
+  editableArguments?: string[];
 }
 
 export interface SandboxFunctionMCPApproveExecutionEvent

--- a/front/lib/actions/mcp_internal_actions/events.ts
+++ b/front/lib/actions/mcp_internal_actions/events.ts
@@ -112,7 +112,7 @@ export type ToolFileAuthRequiredEvent =
 export interface AgentLoopMCPApproveExecutionEvent
   extends AgentLoopToolExecution {
   type: "tool_approve_execution";
-  editableArguments?: string[];
+  editableArguments?: readonly string[];
 }
 
 export interface SandboxFunctionMCPApproveExecutionEvent

--- a/front/lib/actions/mcp_internal_actions/events.ts
+++ b/front/lib/actions/mcp_internal_actions/events.ts
@@ -3,6 +3,7 @@ import type {
   MCPValidationMetadataType,
 } from "@app/lib/actions/constants";
 import type { UserQuestion } from "@app/lib/actions/types";
+import type { EditableToolConfig } from "@app/lib/api/mcp";
 import type { OAuthProvider } from "@app/types/oauth/lib";
 
 // Identifiers scoping an event to the run context it was emitted from, mirroring the contextType
@@ -112,6 +113,7 @@ export type ToolFileAuthRequiredEvent =
 export interface AgentLoopMCPApproveExecutionEvent
   extends AgentLoopToolExecution {
   type: "tool_approve_execution";
+  editable?: EditableToolConfig;
 }
 
 export interface SandboxFunctionMCPApproveExecutionEvent

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -445,6 +445,11 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       )
         ? mcpServerViewMap.get(action.toolConfiguration.mcpServerViewId)
         : null;
+      const editable = isLightServerSideMCPToolConfiguration(
+        action.toolConfiguration
+      )
+        ? action.toolConfiguration.editable
+        : undefined;
 
       const authorizationInfo = mcpServerView?.getAuthorization() ?? null;
 
@@ -622,6 +627,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
         blockedActionsList.push({
           ...baseActionParams,
           status: action.status,
+          editable,
           metadata: {
             ...baseActionParams.metadata,
           },

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -445,10 +445,10 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       )
         ? mcpServerViewMap.get(action.toolConfiguration.mcpServerViewId)
         : null;
-      const editable = isLightServerSideMCPToolConfiguration(
+      const editableArguments = isLightServerSideMCPToolConfiguration(
         action.toolConfiguration
       )
-        ? action.toolConfiguration.editable
+        ? action.toolConfiguration.editableArguments
         : undefined;
 
       const authorizationInfo = mcpServerView?.getAuthorization() ?? null;
@@ -627,7 +627,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
         blockedActionsList.push({
           ...baseActionParams,
           status: action.status,
-          editable,
+          editableArguments,
           metadata: {
             ...baseActionParams.metadata,
           },

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -6,6 +6,7 @@ import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { makeMCPApproveExecutionEventBase } from "@app/lib/actions/tool_approval_events";
 import { getExecutionStatusFromConfig } from "@app/lib/actions/tool_status";
 import type { StepContext } from "@app/lib/actions/types";
+import { isServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import {
   buildAuditLogTarget,
   emitAuditLogEventDirect,
@@ -312,6 +313,9 @@ async function createActionForTool(
             })),
             configurationId: agentConfiguration.sId,
             conversationId: conversation.sId,
+            editable: isServerSideMCPToolConfiguration(actionConfiguration)
+              ? actionConfiguration.editable
+              : undefined,
             messageId: agentMessage.sId,
           }
         : undefined,

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -313,8 +313,10 @@ async function createActionForTool(
             })),
             configurationId: agentConfiguration.sId,
             conversationId: conversation.sId,
-            editable: isServerSideMCPToolConfiguration(actionConfiguration)
-              ? actionConfiguration.editable
+            editableArguments: isServerSideMCPToolConfiguration(
+              actionConfiguration
+            )
+              ? actionConfiguration.editableArguments
               : undefined,
             messageId: agentMessage.sId,
           }

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1479,11 +1479,6 @@ export type ToolExecutionBlockedStatusType = z.infer<
   typeof ToolExecutionBlockedStatusSchema
 >;
 
-const EditableToolConfigSchema = z.object({
-  isEditable: z.boolean(),
-  editableArguments: z.array(z.string()),
-});
-
 const ToolExecutionMetadataSchema = z.object({
   actionId: z.string(),
   inputs: z.record(z.any()),
@@ -1499,7 +1494,6 @@ const ToolExecutionMetadataSchema = z.object({
 const BlockedActionExecutionSchema = ToolExecutionMetadataSchema.extend({
   messageId: z.string(),
   conversationId: z.string(),
-  editable: EditableToolConfigSchema.optional(),
   status: ToolExecutionBlockedStatusSchema,
   // Present only when status is "blocked_user_answer_required".
   question: UserQuestionItemSchema.optional(),
@@ -1515,7 +1509,6 @@ const MCPApproveExecutionEventSchema = ToolExecutionMetadataSchema.extend({
   configurationId: z.string(),
   conversationId: z.string(),
   created: z.number(),
-  editable: EditableToolConfigSchema.optional(),
   isLastBlockingEventForStep: z.boolean().optional(),
   messageId: z.string(),
 });

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1479,6 +1479,11 @@ export type ToolExecutionBlockedStatusType = z.infer<
   typeof ToolExecutionBlockedStatusSchema
 >;
 
+const EditableToolConfigSchema = z.object({
+  isEditable: z.boolean(),
+  editableArguments: z.array(z.string()),
+});
+
 const ToolExecutionMetadataSchema = z.object({
   actionId: z.string(),
   inputs: z.record(z.any()),
@@ -1494,6 +1499,7 @@ const ToolExecutionMetadataSchema = z.object({
 const BlockedActionExecutionSchema = ToolExecutionMetadataSchema.extend({
   messageId: z.string(),
   conversationId: z.string(),
+  editable: EditableToolConfigSchema.optional(),
   status: ToolExecutionBlockedStatusSchema,
   // Present only when status is "blocked_user_answer_required".
   question: UserQuestionItemSchema.optional(),
@@ -1509,6 +1515,7 @@ const MCPApproveExecutionEventSchema = ToolExecutionMetadataSchema.extend({
   configurationId: z.string(),
   conversationId: z.string(),
   created: z.number(),
+  editable: EditableToolConfigSchema.optional(),
   isLastBlockingEventForStep: z.boolean().optional(),
   messageId: z.string(),
 });


### PR DESCRIPTION
## Description

This PR forwards the `editable` tool configuration through the blocked action payload so the frontend can determine whether a tool's inputs can be edited before execution.

- Adds `EditableToolConfig` (with `isEditable` and `editableArguments` fields) to `BlockedActionExecutionSchema` and `MCPApproveExecutionEventSchema` in the SDK types
- Reads the `editable` field from the tool configuration in `create_tool_actions.ts` and `agent_mcp_action_resource.ts` and includes it in the blocked action event/payload
- Passes `editable` through `AgentMessage.tsx` when building the blocked action state

## Tests

Manually.

## Risks
Low.

## Deploy Plan
Standard deployment.
