### PR TITLE
feat: gmail editable tool ui

### DIFF
--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -1,31 +1,13 @@
+import {
+  getToolOverride,
+  getToolValidationAlwaysAllowLabel,
+  getToolValidationTitle,
+} from "@app/components/actions/blocked/toolValidationLabels";
 import { ToolValidationDetails } from "@app/components/assistant/conversation/ToolValidationDetails";
 import { getIcon } from "@app/components/resources/resources_icons";
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
-import {
-  EDIT_INFORMATION_TOOL_NAME,
-  POD_MANAGER_SERVER_NAME,
-  SET_DEFAULT_AGENT_TOOL_NAME,
-  UPDATE_MEMBERS_TOOL_NAME,
-} from "@app/lib/api/actions/servers/pod_manager/metadata";
-import {
-  isPodManagerDefaultAgentInput,
-  isPodManagerEditInformationInput,
-  isPodManagerUpdateMembersInput,
-} from "@app/lib/api/actions/servers/pod_manager/types";
-import {
-  CREATE_TASKS_TOOL_NAME,
-  POD_TASKS_SERVER_NAME,
-  UPDATE_TASKS_TOOL_NAME,
-} from "@app/lib/api/actions/servers/pod_tasks/metadata";
-import {
-  isPodTasksCreateTasksInput,
-  isPodTasksUpdateTasksInput,
-} from "@app/lib/api/actions/servers/pod_tasks/types";
-import { SANDBOX_FUNCTIONS_SERVER_NAME } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
-import { WAKEUPS_SERVER_NAME } from "@app/lib/api/actions/servers/wakeups/metadata";
 import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
-import { asDisplayName } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import {
   Button,
@@ -36,147 +18,6 @@ import {
   XClose,
 } from "@dust-tt/sparkle";
 import { useMemo, useState } from "react";
-
-type ToolOverride = {
-  title?: (inputs: Record<string, unknown>) => string;
-  approveLabel?: string;
-  alwaysAllowLabel?: (inputs: Record<string, unknown>) => string;
-  detailsExpanded?: boolean;
-};
-
-/** Overrides title, alwaysAllowLabel, and details expansion for specific MCP tools */
-const MCP_TOOL_OVERRIDES: Partial<
-  Record<string, Partial<Record<string, ToolOverride>>>
-> = {
-  "dust-chrome-extension": {
-    interact_with_page: {
-      title: (inputs) => `Allow agent to ${inputs.humanReadableDescription}?`,
-      alwaysAllowLabel: () => "Allow all the interactions with this tab",
-    },
-  },
-  "dust-firefox-extension": {
-    interact_with_page: {
-      title: (inputs) => `Allow agent to ${inputs.humanReadableDescription}?`,
-      alwaysAllowLabel: () => "Allow all the interactions with this tab",
-    },
-  },
-  sandbox: {
-    add_egress_domain: {
-      title: () => `Allow agent to add a domain to the Computer?`,
-      detailsExpanded: true,
-    },
-  },
-  [SANDBOX_FUNCTIONS_SERVER_NAME]: {
-    publish: {
-      title: () => "Publish this function?",
-      approveLabel: "Publish",
-      alwaysAllowLabel: () => "Always allow agent to publish Pod functions",
-    },
-    unpublish: {
-      title: () => "Unpublish this function?",
-      approveLabel: "Unpublish",
-    },
-  },
-  [POD_TASKS_SERVER_NAME]: {
-    [CREATE_TASKS_TOOL_NAME]: {
-      title: (inputs) => {
-        if (!isPodTasksCreateTasksInput(inputs)) {
-          return `Allow agent to create tasks?`;
-        }
-        const count = inputs.tasks.length;
-        return `Allow agent to create ${count} task${count === 1 ? "" : "s"}?`;
-      },
-      alwaysAllowLabel: () => `Always allow agent to create tasks`,
-    },
-    [UPDATE_TASKS_TOOL_NAME]: {
-      title: (inputs) => {
-        if (!isPodTasksUpdateTasksInput(inputs)) {
-          return `Allow agent to update tasks?`;
-        }
-        const count = inputs.tasks.length;
-        const doneCount = inputs.tasks.filter(
-          (task) => task.doneRationale
-        ).length;
-        if (doneCount > 0 && doneCount === count) {
-          return `Allow agent to mark ${count} task${count === 1 ? "" : "s"} as done?`;
-        }
-        if (doneCount > 0) {
-          return `Allow agent to update ${count} task${count === 1 ? "" : "s"} (${doneCount} marked as done)?`;
-        }
-        return `Allow agent to update ${count} task${count === 1 ? "" : "s"}?`;
-      },
-      alwaysAllowLabel: () => `Always allow agent to update tasks`,
-    },
-  },
-  [POD_MANAGER_SERVER_NAME]: {
-    [EDIT_INFORMATION_TOOL_NAME]: {
-      title: (inputs) => {
-        if (!isPodManagerEditInformationInput(inputs)) {
-          return `Allow agent to edit Pod information?`;
-        }
-        const fields: string[] = [];
-        if (inputs.title !== undefined) {
-          fields.push("title");
-        }
-        if (inputs.description !== undefined) {
-          fields.push("description");
-        }
-        if (inputs.access !== undefined) {
-          fields.push("access");
-        }
-        if (inputs.pinnedFramePath !== undefined) {
-          fields.push("pinned frame");
-        }
-        if (fields.length === 0) {
-          return `Allow agent to edit Pod information?`;
-        }
-        return `Allow agent to update Pod ${fields.join(", ")}?`;
-      },
-      alwaysAllowLabel: () => `Always allow agent to edit Pod information`,
-    },
-    [UPDATE_MEMBERS_TOOL_NAME]: {
-      title: (inputs) => {
-        if (!isPodManagerUpdateMembersInput(inputs)) {
-          return `Allow agent to update Pod members?`;
-        }
-        const addCount = Object.keys(inputs.membersToAdd ?? {}).length;
-        const removeCount = inputs.membersToRemove?.length ?? 0;
-        const parts: string[] = [];
-        if (addCount > 0) {
-          parts.push(`add ${addCount}`);
-        }
-        if (removeCount > 0) {
-          parts.push(`remove ${removeCount}`);
-        }
-        return `Allow agent to ${parts.join(" and ")} Pod user${addCount + removeCount === 1 ? "" : "s"}?`;
-      },
-      alwaysAllowLabel: () => `Always allow agent to update Pod members`,
-    },
-    [SET_DEFAULT_AGENT_TOOL_NAME]: {
-      title: (inputs) => {
-        if (!isPodManagerDefaultAgentInput(inputs)) {
-          return `Allow agent to set the Pod default agent?`;
-        }
-        if (inputs.agentName === null) {
-          return `Allow agent to reset the Pod default agent to @dust?`;
-        }
-        return `Allow agent to set the Pod default agent to @${inputs.agentName}?`;
-      },
-      alwaysAllowLabel: () => "Always allow agent to set the Pod default agent",
-    },
-  },
-  [WAKEUPS_SERVER_NAME]: {
-    schedule_wakeup: {
-      title: () => `Allow agent to schedule a wake-up?`,
-    },
-    list_wakeups: {
-      title: () => `Allow agent to list wake-ups?`,
-    },
-    cancel_wakeup: {
-      title: () => `Allow agent to cancel a wake-up?`,
-    },
-  },
-};
 
 // Display data needed to render a tool validation card, for both agent-loop and sandbox-function
 // blocked tool executions.
@@ -241,55 +82,12 @@ export function ToolValidationCard({
     }
   };
 
-  const toolOverride =
-    MCP_TOOL_OVERRIDES[validationRequest.metadata.mcpServerName]?.[
-      validationRequest.metadata.toolName
-    ];
-
-  function getTitle() {
-    if (!canCurrentUserRespond) {
-      return `Permission needed for ${asDisplayName(validationRequest.metadata.mcpServerName)}.`;
-    }
-    if (toolOverride?.title) {
-      return toolOverride.title(validationRequest.inputs);
-    }
-    const subject =
-      validationRequest.metadata.displayedAs === "agent"
-        ? "agent"
-        : validationRequest.metadata.mcpServerName;
-    return `Allow ${asDisplayName(subject)} to ${asDisplayName(validationRequest.metadata.toolName)}?`;
-  }
-
-  function getAlwaysAllowLabel() {
-    if (validationRequest.stake !== "medium") {
-      return "Always allow";
-    }
-    if (toolOverride?.alwaysAllowLabel) {
-      return toolOverride.alwaysAllowLabel(validationRequest.inputs);
-    }
-
-    if (validationRequest.approvalArgsLabel) {
-      return validationRequest.approvalArgsLabel;
-    }
-    const args = validationRequest.argumentsRequiringApproval ?? [];
-    const argValues = args
-      .filter((arg) => validationRequest.inputs[arg] != null)
-      .map((arg) => {
-        const value = validationRequest.inputs[arg];
-        if (Array.isArray(value)) {
-          return value.map(String).join(", ");
-        }
-        return JSON.stringify(value);
-      });
-    return `Always allow agent to ${asDisplayName(validationRequest.metadata.toolName)} ${
-      argValues.length > 0
-        ? ` for the following parameters: ${argValues.join(", ")}`
-        : ""
-    }`;
-  }
-
-  const title = getTitle();
-  const alwaysAllowLabel = getAlwaysAllowLabel();
+  const toolOverride = getToolOverride(validationRequest.metadata);
+  const title = getToolValidationTitle(
+    validationRequest,
+    canCurrentUserRespond
+  );
+  const alwaysAllowLabel = getToolValidationAlwaysAllowLabel(validationRequest);
 
   return (
     <ContentMessage

--- a/front/components/actions/blocked/toolValidationLabels.ts
+++ b/front/components/actions/blocked/toolValidationLabels.ts
@@ -1,0 +1,231 @@
+import type { BlockedToolExecution } from "@app/lib/actions/mcp";
+import {
+  EDIT_INFORMATION_TOOL_NAME,
+  POD_MANAGER_SERVER_NAME,
+  SET_DEFAULT_AGENT_TOOL_NAME,
+  UPDATE_MEMBERS_TOOL_NAME,
+} from "@app/lib/api/actions/servers/pod_manager/metadata";
+import {
+  isPodManagerDefaultAgentInput,
+  isPodManagerEditInformationInput,
+  isPodManagerUpdateMembersInput,
+} from "@app/lib/api/actions/servers/pod_manager/types";
+import {
+  CREATE_TASKS_TOOL_NAME,
+  POD_TASKS_SERVER_NAME,
+  UPDATE_TASKS_TOOL_NAME,
+} from "@app/lib/api/actions/servers/pod_tasks/metadata";
+import {
+  isPodTasksCreateTasksInput,
+  isPodTasksUpdateTasksInput,
+} from "@app/lib/api/actions/servers/pod_tasks/types";
+import { SANDBOX_FUNCTIONS_SERVER_NAME } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
+import { WAKEUPS_SERVER_NAME } from "@app/lib/api/actions/servers/wakeups/metadata";
+import { asDisplayName } from "@app/types/shared/utils/string_utils";
+
+type ToolOverride = {
+  title?: (inputs: Record<string, unknown>) => string;
+  approveLabel?: string;
+  alwaysAllowLabel?: (inputs: Record<string, unknown>) => string;
+  detailsExpanded?: boolean;
+};
+
+// Display data needed to compute the title and always-allow label of a tool validation card, for
+// both agent-loop and sandbox-function blocked tool executions.
+export type ToolValidationLabelData = Pick<
+  BlockedToolExecution,
+  | "stake"
+  | "inputs"
+  | "metadata"
+  | "approvalArgsLabel"
+  | "argumentsRequiringApproval"
+>;
+
+/** Overrides title, alwaysAllowLabel, and details expansion for specific MCP tools */
+const MCP_TOOL_OVERRIDES: Partial<
+  Record<string, Partial<Record<string, ToolOverride>>>
+> = {
+  "dust-chrome-extension": {
+    interact_with_page: {
+      title: (inputs) => `Allow agent to ${inputs.humanReadableDescription}?`,
+      alwaysAllowLabel: () => "Allow all the interactions with this tab",
+    },
+  },
+  "dust-firefox-extension": {
+    interact_with_page: {
+      title: (inputs) => `Allow agent to ${inputs.humanReadableDescription}?`,
+      alwaysAllowLabel: () => "Allow all the interactions with this tab",
+    },
+  },
+  sandbox: {
+    add_egress_domain: {
+      title: () => `Allow agent to add a domain to the Computer?`,
+      detailsExpanded: true,
+    },
+  },
+  [SANDBOX_FUNCTIONS_SERVER_NAME]: {
+    publish: {
+      title: () => "Publish this function?",
+      approveLabel: "Publish",
+      alwaysAllowLabel: () => "Always allow agent to publish Pod functions",
+    },
+    unpublish: {
+      title: () => "Unpublish this function?",
+      approveLabel: "Unpublish",
+    },
+  },
+  [POD_TASKS_SERVER_NAME]: {
+    [CREATE_TASKS_TOOL_NAME]: {
+      title: (inputs) => {
+        if (!isPodTasksCreateTasksInput(inputs)) {
+          return `Allow agent to create tasks?`;
+        }
+        const count = inputs.tasks.length;
+        return `Allow agent to create ${count} task${count === 1 ? "" : "s"}?`;
+      },
+      alwaysAllowLabel: () => `Always allow agent to create tasks`,
+    },
+    [UPDATE_TASKS_TOOL_NAME]: {
+      title: (inputs) => {
+        if (!isPodTasksUpdateTasksInput(inputs)) {
+          return `Allow agent to update tasks?`;
+        }
+        const count = inputs.tasks.length;
+        const doneCount = inputs.tasks.filter(
+          (task) => task.doneRationale
+        ).length;
+        if (doneCount > 0 && doneCount === count) {
+          return `Allow agent to mark ${count} task${count === 1 ? "" : "s"} as done?`;
+        }
+        if (doneCount > 0) {
+          return `Allow agent to update ${count} task${count === 1 ? "" : "s"} (${doneCount} marked as done)?`;
+        }
+        return `Allow agent to update ${count} task${count === 1 ? "" : "s"}?`;
+      },
+      alwaysAllowLabel: () => `Always allow agent to update tasks`,
+    },
+  },
+  [POD_MANAGER_SERVER_NAME]: {
+    [EDIT_INFORMATION_TOOL_NAME]: {
+      title: (inputs) => {
+        if (!isPodManagerEditInformationInput(inputs)) {
+          return `Allow agent to edit Pod information?`;
+        }
+        const fields: string[] = [];
+        if (inputs.title !== undefined) {
+          fields.push("title");
+        }
+        if (inputs.description !== undefined) {
+          fields.push("description");
+        }
+        if (inputs.access !== undefined) {
+          fields.push("access");
+        }
+        if (inputs.pinnedFramePath !== undefined) {
+          fields.push("pinned frame");
+        }
+        if (fields.length === 0) {
+          return `Allow agent to edit Pod information?`;
+        }
+        return `Allow agent to update Pod ${fields.join(", ")}?`;
+      },
+      alwaysAllowLabel: () => `Always allow agent to edit Pod information`,
+    },
+    [UPDATE_MEMBERS_TOOL_NAME]: {
+      title: (inputs) => {
+        if (!isPodManagerUpdateMembersInput(inputs)) {
+          return `Allow agent to update Pod members?`;
+        }
+        const addCount = Object.keys(inputs.membersToAdd ?? {}).length;
+        const removeCount = inputs.membersToRemove?.length ?? 0;
+        const parts: string[] = [];
+        if (addCount > 0) {
+          parts.push(`add ${addCount}`);
+        }
+        if (removeCount > 0) {
+          parts.push(`remove ${removeCount}`);
+        }
+        return `Allow agent to ${parts.join(" and ")} Pod user${addCount + removeCount === 1 ? "" : "s"}?`;
+      },
+      alwaysAllowLabel: () => `Always allow agent to update Pod members`,
+    },
+    [SET_DEFAULT_AGENT_TOOL_NAME]: {
+      title: (inputs) => {
+        if (!isPodManagerDefaultAgentInput(inputs)) {
+          return `Allow agent to set the Pod default agent?`;
+        }
+        if (inputs.agentName === null) {
+          return `Allow agent to reset the Pod default agent to @dust?`;
+        }
+        return `Allow agent to set the Pod default agent to @${inputs.agentName}?`;
+      },
+      alwaysAllowLabel: () => "Always allow agent to set the Pod default agent",
+    },
+  },
+  [WAKEUPS_SERVER_NAME]: {
+    schedule_wakeup: {
+      title: () => `Allow agent to schedule a wake-up?`,
+    },
+    list_wakeups: {
+      title: () => `Allow agent to list wake-ups?`,
+    },
+    cancel_wakeup: {
+      title: () => `Allow agent to cancel a wake-up?`,
+    },
+  },
+};
+
+export function getToolOverride(
+  metadata: ToolValidationLabelData["metadata"]
+): ToolOverride | undefined {
+  return MCP_TOOL_OVERRIDES[metadata.mcpServerName]?.[metadata.toolName];
+}
+
+export function getToolValidationTitle(
+  data: ToolValidationLabelData,
+  canCurrentUserRespond: boolean
+): string {
+  if (!canCurrentUserRespond) {
+    return `Permission needed for ${asDisplayName(data.metadata.mcpServerName)}.`;
+  }
+  const toolOverride = getToolOverride(data.metadata);
+  if (toolOverride?.title) {
+    return toolOverride.title(data.inputs);
+  }
+  const subject =
+    data.metadata.displayedAs === "agent"
+      ? "agent"
+      : data.metadata.mcpServerName;
+  return `Allow ${asDisplayName(subject)} to ${asDisplayName(data.metadata.toolName)}?`;
+}
+
+export function getToolValidationAlwaysAllowLabel(
+  data: ToolValidationLabelData
+): string {
+  if (data.stake !== "medium") {
+    return "Always allow";
+  }
+  const toolOverride = getToolOverride(data.metadata);
+  if (toolOverride?.alwaysAllowLabel) {
+    return toolOverride.alwaysAllowLabel(data.inputs);
+  }
+
+  if (data.approvalArgsLabel) {
+    return data.approvalArgsLabel;
+  }
+  const args = data.argumentsRequiringApproval ?? [];
+  const argValues = args
+    .filter((arg) => data.inputs[arg] != null)
+    .map((arg) => {
+      const value = data.inputs[arg];
+      if (Array.isArray(value)) {
+        return value.map(String).join(", ");
+      }
+      return JSON.stringify(value);
+    });
+  return `Always allow agent to ${asDisplayName(data.metadata.toolName)} ${
+    argValues.length > 0
+      ? ` for the following parameters: ${argValues.join(", ")}`
+      : ""
+  }`;
+}

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -1,16 +1,21 @@
 import { ToolValidationCard } from "@app/components/actions/blocked/ToolValidationCard";
 import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
+import {
+  EditableToolValidation,
+  isEditableToolValidationSupported,
+} from "@app/components/assistant/conversation/editable_tool_validation/EditableToolValidation";
+import type { ValidationRequiredToolExecution } from "@app/components/assistant/conversation/editable_tool_validation/types";
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
-import type { AgentLoopBlockedToolExecution } from "@app/lib/actions/mcp";
-import { useAuth } from "@app/lib/auth/AuthContext";
+import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useValidateAction } from "@app/lib/swr/tool_actions";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 interface MCPToolValidationRequiredProps {
   triggeringUser: UserType | null;
   owner: LightWorkspaceType;
-  blockedAction: AgentLoopBlockedToolExecution;
+  blockedAction: ValidationRequiredToolExecution;
   conversationId?: string | null;
 }
 
@@ -21,6 +26,7 @@ export function MCPToolValidationRequired({
   conversationId,
 }: MCPToolValidationRequiredProps) {
   const { user } = useAuth();
+  const { hasFeature } = useFeatureFlags();
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const {
@@ -34,13 +40,27 @@ export function MCPToolValidationRequired({
     onError: setErrorMessage,
   });
 
+  const canCurrentUserRespond = useMemo(
+    () =>
+      canCurrentUserRespondToParentUserMessage({
+        parentUserId: blockedAction.userId,
+        currentUserId: user?.sId,
+      }),
+    [blockedAction.userId, user?.sId]
+  );
+
+  const isPulsing = isActionPulsing(blockedAction.actionId);
+
+  const handleValidationStart = () => {
+    // Stop pulsing immediately when the user takes an action.
+    stopPulsingAction(blockedAction.actionId);
+    setErrorMessage(null);
+  };
+
   const handleValidation = async (
     approved: MCPValidationOutputType
   ): Promise<boolean> => {
-    // Stop pulsing immediately when the user takes an action.
-    stopPulsingAction(blockedAction.actionId);
-
-    setErrorMessage(null);
+    handleValidationStart();
 
     const result = await validateAction({
       contextType: "agent_loop",
@@ -84,6 +104,34 @@ export function MCPToolValidationRequired({
     return true;
   };
 
+  const shouldUseEditableToolValidation =
+    canCurrentUserRespond &&
+    hasFeature("editable_tool_inputs") &&
+    isEditableToolValidationSupported(blockedAction);
+
+  if (shouldUseEditableToolValidation) {
+    return (
+      <>
+        <EditableToolValidation
+          blockedAction={blockedAction}
+          owner={owner}
+          isPulsing={isPulsing}
+          isValidating={isValidating}
+          onActionCompleted={() =>
+            removeCompletedAction(blockedAction.actionId)
+          }
+          onError={setErrorMessage}
+          onValidationStart={handleValidationStart}
+        />
+        {errorMessage && (
+          <div className="mt-2 text-sm font-medium text-warning-800 dark:text-warning-800-night">
+            {errorMessage}
+          </div>
+        )}
+      </>
+    );
+  }
+
   return (
     <ToolValidationCard
       validationRequest={blockedAction}
@@ -93,7 +141,7 @@ export function MCPToolValidationRequired({
       conversationId={conversationId}
       errorMessage={errorMessage}
       isValidating={isValidating}
-      isPulsing={isActionPulsing(blockedAction.actionId)}
+      isPulsing={isPulsing}
       onValidate={handleValidation}
     />
   );

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -124,7 +124,7 @@ export function MCPToolValidationRequired({
           onValidationStart={handleValidationStart}
         />
         {errorMessage && (
-          <div className="mt-2 text-sm font-medium text-warning-800 dark:text-warning-800-night">
+          <div className="mt-2 text-sm font-medium text-warning-800">
             {errorMessage}
           </div>
         )}

--- a/front/components/assistant/conversation/editable_tool_validation/EditableToolValidation.tsx
+++ b/front/components/assistant/conversation/editable_tool_validation/EditableToolValidation.tsx
@@ -1,0 +1,86 @@
+import { getToolValidationAlwaysAllowLabel } from "@app/components/actions/blocked/toolValidationLabels";
+import { GmailEditableToolValidation } from "@app/components/assistant/conversation/editable_tool_validation/gmail/GmailEditableToolValidation";
+import type { ValidationRequiredToolExecution } from "@app/components/assistant/conversation/editable_tool_validation/types";
+import { useEditAndValidateAction } from "@app/hooks/useEditAndValidateAction";
+import type { MCPValidationOutputType } from "@app/lib/actions/constants";
+import { isInternalMCPServerName } from "@app/lib/actions/mcp_internal_actions/constants";
+import type { LightWorkspaceType } from "@app/types/user";
+
+interface EditableToolValidationProps {
+  blockedAction: ValidationRequiredToolExecution;
+  isPulsing: boolean;
+  isValidating: boolean;
+  onActionCompleted: () => void;
+  onError: (errorMessage: string | null) => void;
+  onValidationStart: () => void;
+  owner: LightWorkspaceType;
+}
+
+export function isEditableToolValidationSupported(
+  blockedAction: ValidationRequiredToolExecution
+): boolean {
+  return !!blockedAction.editable?.isEditable;
+}
+
+export function EditableToolValidation({
+  blockedAction,
+  isPulsing,
+  isValidating,
+  onActionCompleted,
+  onError,
+  onValidationStart,
+  owner,
+}: EditableToolValidationProps) {
+  const { editAndValidateAction, isEditingAndValidating } =
+    useEditAndValidateAction({
+      owner,
+      onError,
+    });
+
+  const canAlwaysAllow =
+    blockedAction.stake === "low" || blockedAction.stake === "medium";
+  const alwaysAllowLabel = canAlwaysAllow
+    ? getToolValidationAlwaysAllowLabel(blockedAction)
+    : null;
+
+  const handleApproveWithEditedArguments = async (input: {
+    editedArguments: Record<string, unknown>;
+    approved: MCPValidationOutputType;
+  }) => {
+    onValidationStart();
+
+    const result = await editAndValidateAction({
+      validationRequest: blockedAction,
+      approvalState: input.approved,
+      editedArguments: input.editedArguments,
+    });
+
+    if (result.success) {
+      onActionCompleted();
+    }
+  };
+
+  const isSubmitting = isValidating || isEditingAndValidating;
+
+  const { mcpServerName } = blockedAction.metadata;
+
+  if (!isInternalMCPServerName(mcpServerName)) {
+    return null;
+  }
+
+  switch (mcpServerName) {
+    case "gmail":
+      return (
+        <GmailEditableToolValidation
+          blockedAction={blockedAction}
+          alwaysAllowLabel={alwaysAllowLabel}
+          isSubmitting={isSubmitting}
+          isPulsing={isPulsing}
+          onApproveWithEditedArguments={handleApproveWithEditedArguments}
+        />
+      );
+
+    default:
+      return null;
+  }
+}

--- a/front/components/assistant/conversation/editable_tool_validation/EditableToolValidation.tsx
+++ b/front/components/assistant/conversation/editable_tool_validation/EditableToolValidation.tsx
@@ -19,7 +19,7 @@ interface EditableToolValidationProps {
 export function isEditableToolValidationSupported(
   blockedAction: ValidationRequiredToolExecution
 ): boolean {
-  return !!blockedAction.editable?.isEditable;
+  return !!blockedAction.editableArguments?.length;
 }
 
 export function EditableToolValidation({

--- a/front/components/assistant/conversation/editable_tool_validation/gmail/GmailEditableToolValidation.tsx
+++ b/front/components/assistant/conversation/editable_tool_validation/gmail/GmailEditableToolValidation.tsx
@@ -1,0 +1,27 @@
+import { GmailSendMailValidation } from "@app/components/assistant/conversation/editable_tool_validation/gmail/tools/GmailSendMailValidation";
+import type { EditableToolValidationComponentProps } from "@app/components/assistant/conversation/editable_tool_validation/types";
+import { isInternalMCPToolName } from "@app/lib/actions/mcp_internal_actions/constants";
+
+export function GmailEditableToolValidation(
+  props: EditableToolValidationComponentProps
+) {
+  const { toolName } = props.blockedAction.metadata;
+
+  if (!isInternalMCPToolName("gmail", toolName)) {
+    return null;
+  }
+
+  // toolName is now narrowed to InternalMCPToolNameType<"gmail">.
+  switch (toolName) {
+    case "send_mail":
+      return (
+        <GmailSendMailValidation
+          key={props.blockedAction.actionId}
+          {...props}
+        />
+      );
+
+    default:
+      return null;
+  }
+}

--- a/front/components/assistant/conversation/editable_tool_validation/gmail/tools/GmailSendMailValidation.tsx
+++ b/front/components/assistant/conversation/editable_tool_validation/gmail/tools/GmailSendMailValidation.tsx
@@ -59,13 +59,9 @@ interface RecipientRowProps {
 
 function RecipientRow({ label, value }: RecipientRowProps) {
   return (
-    <div className="flex gap-2 border-b border-border px-4 py-2 dark:border-border-night">
-      <span className="shrink-0 text-sm text-muted-foreground dark:text-muted-foreground-night">
-        {label}
-      </span>
-      <span className="wrap-break-word text-sm text-foreground dark:text-foreground-night">
-        {value}
-      </span>
+    <div className="flex gap-2 border-b border-border px-4 py-2">
+      <span className="shrink-0 text-sm text-muted-foreground">{label}</span>
+      <span className="wrap-break-word text-sm text-foreground">{value}</span>
     </div>
   );
 }
@@ -119,7 +115,7 @@ export function GmailSendMailValidation({
   };
 
   return (
-    <div className="flex flex-col overflow-hidden rounded-lg border border-border bg-background shadow-md dark:border-border-night dark:bg-background-night">
+    <div className="flex flex-col overflow-hidden rounded-lg border border-border bg-background shadow-md">
       <div className="bg-gray-900 px-4 py-2.5">
         <span className="text-sm font-medium text-white">
           {isReply ? "Reply" : "New Message"}
@@ -129,21 +125,21 @@ export function GmailSendMailValidation({
       {recipientRows.map(({ label, value }) => (
         <RecipientRow key={label} label={label} value={value} />
       ))}
-      <div className="border-b border-border px-4 py-2 dark:border-border-night">
+      <div className="border-b border-border px-4 py-2">
         <input
           {...register("subject")}
           disabled={isSubmitting || isReply}
           placeholder="Subject"
-          className="w-full border-none bg-transparent p-0 text-sm text-foreground outline-none focus:ring-0 placeholder:text-muted-foreground disabled:cursor-not-allowed dark:text-foreground-night dark:placeholder:text-muted-foreground-night"
+          className="w-full border-none bg-transparent p-0 text-sm text-foreground outline-none focus:ring-0 placeholder:text-muted-foreground disabled:cursor-not-allowed"
         />
         {errors.subject && (
-          <p className="mt-1 text-xs text-warning-800 dark:text-warning-800-night">
+          <p className="mt-1 text-xs text-warning-800">
             {errors.subject.message}
           </p>
         )}
       </div>
 
-      <div className="h-64 w-full overflow-auto whitespace-pre-wrap wrap-break-word px-4 py-3 text-sm text-foreground dark:text-foreground-night">
+      <div className="h-64 w-full overflow-auto whitespace-pre-wrap wrap-break-word px-4 py-3 text-sm text-foreground">
         {originalBody}
       </div>
 
@@ -153,7 +149,7 @@ export function GmailSendMailValidation({
         </div>
       )}
 
-      <div className="flex items-center gap-3 border-t border-border px-4 py-2.5 dark:border-border-night">
+      <div className="flex items-center gap-3 border-t border-border px-4 py-2.5">
         <Button
           label="Send"
           variant="highlight"

--- a/front/components/assistant/conversation/editable_tool_validation/gmail/tools/GmailSendMailValidation.tsx
+++ b/front/components/assistant/conversation/editable_tool_validation/gmail/tools/GmailSendMailValidation.tsx
@@ -1,0 +1,193 @@
+import type { EditableToolValidationComponentProps } from "@app/components/assistant/conversation/editable_tool_validation/types";
+import type { GmailSendMailInput } from "@app/lib/api/actions/servers/gmail/types";
+import { isGmailSendMailInput } from "@app/lib/api/actions/servers/gmail/types";
+import {
+  AttachmentChip,
+  Button,
+  Checkbox,
+  Label,
+  Paperclip,
+  Trash01,
+} from "@dust-tt/sparkle";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+// Subject is the only editable argument (see `editableArguments` in the gmail
+// tool metadata); the body is shown read-only.
+interface ComposeFormValues {
+  subject: string;
+}
+
+// Subject is required, unless this is a reply (in which case `send_mail` derives
+// the subject from the original message).
+function getComposeFormSchema(isReply: boolean) {
+  const subjectSchema = z.string().trim();
+
+  return z.object({
+    subject: isReply
+      ? subjectSchema.optional()
+      : subjectSchema.min(1, "Subject is required."),
+  });
+}
+
+// Recipient rows shown read-only, in Gmail's compose order.
+function getRecipientRows(
+  inputs: GmailSendMailInput
+): { label: string; value: string }[] {
+  const rows: { label: string; value: string }[] = [];
+  if (inputs.from) {
+    rows.push({ label: "From", value: inputs.from });
+  }
+  if (inputs.to?.length) {
+    rows.push({ label: "To", value: inputs.to.join(", ") });
+  }
+  if (inputs.cc?.length) {
+    rows.push({ label: "Cc", value: inputs.cc.join(", ") });
+  }
+  if (inputs.bcc?.length) {
+    rows.push({ label: "Bcc", value: inputs.bcc.join(", ") });
+  }
+  return rows;
+}
+
+interface RecipientRowProps {
+  label: string;
+  value: string;
+}
+
+function RecipientRow({ label, value }: RecipientRowProps) {
+  return (
+    <div className="flex gap-2 border-b border-border px-4 py-2 dark:border-border-night">
+      <span className="shrink-0 text-sm text-muted-foreground dark:text-muted-foreground-night">
+        {label}
+      </span>
+      <span className="wrap-break-word text-sm text-foreground dark:text-foreground-night">
+        {value}
+      </span>
+    </div>
+  );
+}
+
+export function GmailSendMailValidation({
+  blockedAction,
+  alwaysAllowLabel,
+  isSubmitting,
+  isPulsing,
+  onApproveWithEditedArguments,
+}: EditableToolValidationComponentProps) {
+  const [neverAskAgain, setNeverAskAgain] = useState(false);
+
+  const inputs = useMemo(
+    () =>
+      isGmailSendMailInput(blockedAction.inputs) ? blockedAction.inputs : null,
+    [blockedAction.inputs]
+  );
+
+  const originalSubject = inputs?.subject ?? "";
+  const originalBody = inputs?.body ?? "";
+  const isReply = !!inputs?.replyToMessageId;
+
+  const formSchema = useMemo(() => getComposeFormSchema(isReply), [isReply]);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ComposeFormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { subject: originalSubject },
+    mode: "onChange",
+  });
+
+  const attachmentName = inputs?.attachmentFilePath?.split("/").pop() ?? null;
+  const recipientRows = inputs ? getRecipientRows(inputs) : [];
+
+  const onApprove = handleSubmit(async ({ subject }) => {
+    await onApproveWithEditedArguments({
+      editedArguments: { subject },
+      approved: neverAskAgain ? "always_approved" : "approved",
+    });
+  });
+
+  const handleReject = async () => {
+    await onApproveWithEditedArguments({
+      editedArguments: {},
+      approved: "rejected",
+    });
+  };
+
+  return (
+    <div className="flex flex-col overflow-hidden rounded-lg border border-border bg-background shadow-md dark:border-border-night dark:bg-background-night">
+      <div className="bg-gray-900 px-4 py-2.5">
+        <span className="text-sm font-medium text-white">
+          {isReply ? "Reply" : "New Message"}
+        </span>
+      </div>
+
+      {recipientRows.map(({ label, value }) => (
+        <RecipientRow key={label} label={label} value={value} />
+      ))}
+      <div className="border-b border-border px-4 py-2 dark:border-border-night">
+        <input
+          {...register("subject")}
+          disabled={isSubmitting || isReply}
+          placeholder="Subject"
+          className="w-full border-none bg-transparent p-0 text-sm text-foreground outline-none focus:ring-0 placeholder:text-muted-foreground disabled:cursor-not-allowed dark:text-foreground-night dark:placeholder:text-muted-foreground-night"
+        />
+        {errors.subject && (
+          <p className="mt-1 text-xs text-warning-800 dark:text-warning-800-night">
+            {errors.subject.message}
+          </p>
+        )}
+      </div>
+
+      <div className="h-64 w-full overflow-auto whitespace-pre-wrap wrap-break-word px-4 py-3 text-sm text-foreground dark:text-foreground-night">
+        {originalBody}
+      </div>
+
+      {attachmentName && (
+        <div className="px-4 py-2">
+          <AttachmentChip label={attachmentName} icon={{ visual: Paperclip }} />
+        </div>
+      )}
+
+      <div className="flex items-center gap-3 border-t border-border px-4 py-2.5 dark:border-border-night">
+        <Button
+          label="Send"
+          variant="highlight"
+          size="sm"
+          isRounded
+          disabled={isSubmitting}
+          isPulsing={isPulsing}
+          onClick={() => void onApprove()}
+        />
+        {alwaysAllowLabel && (
+          <Label
+            htmlFor={`gmail-always-allow-${blockedAction.actionId}`}
+            className="flex cursor-pointer flex-row items-center gap-2 text-xs"
+          >
+            <Checkbox
+              id={`gmail-always-allow-${blockedAction.actionId}`}
+              checked={neverAskAgain}
+              disabled={isSubmitting}
+              onCheckedChange={(check) => setNeverAskAgain(!!check)}
+            />
+            <span className="font-normal">{alwaysAllowLabel}</span>
+          </Label>
+        )}
+        <div className="flex-1" />
+        <Button
+          tooltip="Discard"
+          variant="ghost"
+          size="icon"
+          icon={Trash01}
+          disabled={isSubmitting}
+          isPulsing={isPulsing}
+          onClick={() => void handleReject()}
+        />
+      </div>
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/editable_tool_validation/types.ts
+++ b/front/components/assistant/conversation/editable_tool_validation/types.ts
@@ -1,0 +1,18 @@
+import type { MCPValidationOutputType } from "@app/lib/actions/constants";
+import type { AgentLoopBlockedToolExecution } from "@app/lib/actions/mcp";
+
+export type ValidationRequiredToolExecution = Extract<
+  AgentLoopBlockedToolExecution,
+  { status: "blocked_validation_required" }
+>;
+
+export interface EditableToolValidationComponentProps {
+  blockedAction: ValidationRequiredToolExecution;
+  isSubmitting: boolean;
+  isPulsing: boolean;
+  alwaysAllowLabel: string | null;
+  onApproveWithEditedArguments: (input: {
+    editedArguments: Record<string, unknown>;
+    approved: MCPValidationOutputType;
+  }) => Promise<void>;
+}

--- a/front/hooks/useEditAndValidateAction.ts
+++ b/front/hooks/useEditAndValidateAction.ts
@@ -3,6 +3,7 @@ import type {
   AgentLoopBlockedToolExecution,
 } from "@app/lib/actions/mcp";
 import { useFetcher } from "@app/lib/swr/swr";
+import { isAPIErrorResponse } from "@app/types/error";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useState } from "react";
 
@@ -50,8 +51,12 @@ export function useEditAndValidateAction({
         );
 
         return { success: true };
-      } catch {
-        onError("Failed to edit and approve action. Please try again.");
+      } catch (err) {
+        onError(
+          isAPIErrorResponse(err)
+            ? err.error.message
+            : "Failed to edit and approve action. Please try again."
+        );
         return { success: false };
       } finally {
         setIsEditingAndValidating(false);

--- a/front/hooks/useEditAndValidateAction.ts
+++ b/front/hooks/useEditAndValidateAction.ts
@@ -1,0 +1,64 @@
+import type {
+  ActionApprovalStateType,
+  AgentLoopBlockedToolExecution,
+} from "@app/lib/actions/mcp";
+import { useFetcher } from "@app/lib/swr/swr";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useCallback, useState } from "react";
+
+export function useEditAndValidateAction({
+  owner,
+  onError,
+}: {
+  owner: LightWorkspaceType;
+  onError: (errorMessage: string) => void;
+}) {
+  const { fetcher } = useFetcher();
+  const [isEditingAndValidating, setIsEditingAndValidating] = useState(false);
+
+  const editAndValidateAction = useCallback(
+    async ({
+      validationRequest,
+      approvalState,
+      editedArguments,
+    }: {
+      validationRequest: Pick<
+        AgentLoopBlockedToolExecution,
+        "actionId" | "conversationId" | "messageId"
+      >;
+      approvalState: ActionApprovalStateType;
+      editedArguments: Record<string, unknown>;
+    }) => {
+      setIsEditingAndValidating(true);
+
+      try {
+        // Edit and validate the action. The backend resumes both the conversation
+        // that contains the action and any blocked ancestor conversations.
+        await fetcher(
+          `/api/w/${owner.sId}/assistant/conversations/${validationRequest.conversationId}/messages/${validationRequest.messageId}/edit-and-validate-action`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              actionId: validationRequest.actionId,
+              approvalState,
+              editedArguments,
+            }),
+          }
+        );
+
+        return { success: true };
+      } catch {
+        onError("Failed to edit and approve action. Please try again.");
+        return { success: false };
+      } finally {
+        setIsEditingAndValidating(false);
+      }
+    },
+    [owner.sId, onError, fetcher]
+  );
+
+  return { editAndValidateAction, isEditingAndValidating };
+}

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1585,8 +1585,10 @@ export function isInternalMCPToolName<N extends InternalMCPServerNameType>(
   serverName: N,
   toolName: string
 ): toolName is InternalMCPToolNameType<N> {
-  return INTERNAL_MCP_SERVERS[serverName].metadata.tools.some(
-    (tool) => tool.name === toolName
+  return (
+    INTERNAL_MCP_SERVERS[serverName]?.metadata?.tools?.some(
+      (tool) => tool.name === toolName
+    ) ?? false
   );
 }
 

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1581,6 +1581,15 @@ export function isInternalMCPServerName(
   );
 }
 
+export function isInternalMCPToolName<N extends InternalMCPServerNameType>(
+  serverName: N,
+  toolName: string
+): toolName is InternalMCPToolNameType<N> {
+  return INTERNAL_MCP_SERVERS[serverName].metadata.tools.some(
+    (tool) => tool.name === toolName
+  );
+}
+
 export function isValidInternalMCPServerId(
   workspaceModelId: ModelId,
   sId: string

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -1,4 +1,5 @@
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { GMAIL_SEND_MAIL_SCHEMA } from "@app/lib/api/actions/servers/gmail/types";
 import { z } from "zod";
 
 export const GMAIL_TOOL_NAME = "gmail" as const;
@@ -224,58 +225,7 @@ export const GMAIL_TOOLS_METADATA = [
 - The email will be sent immediately without creating a draft.
 - Use this to send emails when you have all the required information.
 - The email will include proper headers and formatting.`,
-    schema: {
-      to: z
-        .array(z.string())
-        .optional()
-        .describe(
-          "The email addresses of the recipients (optional if replyToMessageId is set, acts as override)."
-        ),
-      cc: z
-        .array(z.string())
-        .optional()
-        .describe(
-          "The CC email addresses (optional, acts as override if replyToMessageId is set)."
-        ),
-      bcc: z
-        .array(z.string())
-        .optional()
-        .describe(
-          "The BCC email addresses (optional, acts as override if replyToMessageId is set)."
-        ),
-      from: z
-        .string()
-        .email()
-        .optional()
-        .describe(
-          "Optional. The email address to send from. Must be configured as a send-as alias in the user's Gmail settings (e.g. a shared Google Group address like team@company.com). If omitted, Gmail will use the authenticated user's primary address."
-        ),
-      subject: z
-        .string()
-        .optional()
-        .describe(
-          "The subject line of the email (required if replyToMessageId is not set, must be omitted if replyToMessageId is set)."
-        ),
-      contentType: z
-        .enum(["text/plain", "text/html"])
-        .optional()
-        .describe(
-          "The content type of the email body, use text/plain for plain text or text/html for HTML (required if replyToMessageId is not set, must be omitted if replyToMessageId is set (forced to text/html))."
-        ),
-      body: z.string().describe("The body of the email"),
-      replyToMessageId: z
-        .string()
-        .optional()
-        .describe(
-          "Optional. The ID of the message to reply to. If provided, the email will be sent as a reply in the existing thread, with proper threading headers and the original message quoted."
-        ),
-      attachmentFilePath: z
-        .string()
-        .optional()
-        .describe(
-          "Optional. Scoped path of the file to attach to the email (e.g. `conversation-<id>/report.pdf` or `pod-<id>/data.csv`)."
-        ),
-    },
+    schema: GMAIL_SEND_MAIL_SCHEMA,
     stake: "high",
     editableArguments: ["subject"],
     displayLabels: {

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -2,6 +2,7 @@ import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_
 import { z } from "zod";
 
 export const GMAIL_TOOL_NAME = "gmail" as const;
+export const GMAIL_SEND_MAIL_TOOL_NAME = "send_mail" as const;
 
 export const GMAIL_TOOLS_METADATA = [
   {

--- a/front/lib/api/actions/servers/gmail/types.ts
+++ b/front/lib/api/actions/servers/gmail/types.ts
@@ -1,0 +1,17 @@
+import {
+  GMAIL_SEND_MAIL_TOOL_NAME,
+  GMAIL_TOOLS_METADATA,
+} from "@app/lib/api/actions/servers/gmail/metadata";
+import { z } from "zod";
+
+const GmailSendMailInputSchema = z.object(
+  GMAIL_TOOLS_METADATA[GMAIL_SEND_MAIL_TOOL_NAME].schema
+);
+
+export type GmailSendMailInput = z.infer<typeof GmailSendMailInputSchema>;
+
+export function isGmailSendMailInput(
+  input: Record<string, unknown>
+): input is GmailSendMailInput {
+  return GmailSendMailInputSchema.safeParse(input).success;
+}

--- a/front/lib/api/actions/servers/gmail/types.ts
+++ b/front/lib/api/actions/servers/gmail/types.ts
@@ -1,12 +1,59 @@
-import {
-  GMAIL_SEND_MAIL_TOOL_NAME,
-  GMAIL_TOOLS_METADATA,
-} from "@app/lib/api/actions/servers/gmail/metadata";
 import { z } from "zod";
 
-const GmailSendMailInputSchema = z.object(
-  GMAIL_TOOLS_METADATA[GMAIL_SEND_MAIL_TOOL_NAME].schema
-);
+export const GMAIL_SEND_MAIL_SCHEMA = {
+  to: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "The email addresses of the recipients (optional if replyToMessageId is set, acts as override)."
+    ),
+  cc: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "The CC email addresses (optional, acts as override if replyToMessageId is set)."
+    ),
+  bcc: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "The BCC email addresses (optional, acts as override if replyToMessageId is set)."
+    ),
+  from: z
+    .string()
+    .email()
+    .optional()
+    .describe(
+      "Optional. The email address to send from. Must be configured as a send-as alias in the user's Gmail settings (e.g. a shared Google Group address like team@company.com). If omitted, Gmail will use the authenticated user's primary address."
+    ),
+  subject: z
+    .string()
+    .optional()
+    .describe(
+      "The subject line of the email (required if replyToMessageId is not set, must be omitted if replyToMessageId is set)."
+    ),
+  contentType: z
+    .enum(["text/plain", "text/html"])
+    .optional()
+    .describe(
+      "The content type of the email body, use text/plain for plain text or text/html for HTML (required if replyToMessageId is not set, must be omitted if replyToMessageId is set (forced to text/html))."
+    ),
+  body: z.string().describe("The body of the email"),
+  replyToMessageId: z
+    .string()
+    .optional()
+    .describe(
+      "Optional. The ID of the message to reply to. If provided, the email will be sent as a reply in the existing thread, with proper threading headers and the original message quoted."
+    ),
+  attachmentFilePath: z
+    .string()
+    .optional()
+    .describe(
+      "Optional. Scoped path of the file to attach to the email (e.g. `conversation-<id>/report.pdf` or `pod-<id>/data.csv`)."
+    ),
+};
+
+const GmailSendMailInputSchema = z.object(GMAIL_SEND_MAIL_SCHEMA);
 
 export type GmailSendMailInput = z.infer<typeof GmailSendMailInputSchema>;
 


### PR DESCRIPTION
## Description

This PR adds an editable UI for the Gmail `send_mail` tool validation, allowing users to review and edit the email subject before approving or discarding the action.

- Adds a `GmailSendMailValidation` component rendering a compose view with read-only recipients/body and an editable subject field.
- Introduces an `EditableToolValidation` component that routes to the correct tool-specific UI based on the MCP server/tool name.
- Adds a `useEditAndValidateAction` hook to call the edit-and-validate endpoint with the user's edited arguments.
- Updates `MCPToolValidationRequired` to use the new editable UI when the `editable_tool_inputs` feature flag is enabled and the blocked action supports editing.



https://github.com/user-attachments/assets/8844c5ce-3f08-4f91-9735-fdf4d1b3752d



## Tests

Manually.

## Risks
Low. Hidden behind feature flag.

## Deploy Plan
Standard deployment.
