### PR TITLE
fix(credits): reset programmatic credit state machine on limit change

### DIFF
--- a/front/lib/api/credits/programmatic_usage_limit.ts
+++ b/front/lib/api/credits/programmatic_usage_limit.ts
@@ -2,6 +2,7 @@ import {
   buildAuditLogTarget,
   emitAuditLogEvent,
 } from "@app/lib/api/audit/workos_audit";
+import { dispatchProgrammaticCapReset } from "@app/lib/api/metronome/credit_state_dispatcher";
 import type { AuditLogContext } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
 import {
@@ -9,6 +10,7 @@ import {
   getMetronomeProgrammaticCap,
   upsertMetronomeProgrammaticCapAlerts,
 } from "@app/lib/metronome/alerts/programmatic_cap";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -91,6 +93,14 @@ export async function syncProgrammaticUsageLimit({
         `Failed to sync Metronome programmatic cap alerts: ${alertResult.error.message}`
       )
     );
+  }
+
+  // Reset the state machine so that a stale warning/depleted state from the
+  // previous cap thresholds doesn't linger. Metronome will re-fire webhooks
+  // if the new thresholds are already breached.
+  const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
+  if (workspaceResource) {
+    await dispatchProgrammaticCapReset({ workspace: workspaceResource });
   }
 
   void emitAuditLogEvent({


### PR DESCRIPTION
## Description

`syncProgrammaticUsageLimit` (used by the workspace usage settings UI) was syncing Metronome alerts when the programmatic cap changed, but never resetting the state machine. This meant that if a workspace triggered the warning or depleted state, then the admin raised the cap, the Redis warning flag and the `programmaticCreditState` would remain stuck in the old state until the next billing cycle or manual reconciliation via Poke.

The Poke plugin `manage_programmatic_monthly_cap` already had the correct behavior — it calls `dispatchProgrammaticCapReset` after every alert upsert/clear. This PR brings `syncProgrammaticUsageLimit` in line with it.

## Tests

Manually verified the fix by tracing the code path: after any cap upsert or clear, `dispatchProgrammaticCapReset` transitions the state machine to `active` and clears the Redis warning flag. Metronome will re-fire webhooks if the new thresholds are already breached.
