### PR TITLE
feat(voice): animate partial transcripts with AnimatedText

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -771,10 +771,14 @@ const InputBarContainer = ({
 
   const voiceLiveTranscriberService = useVoiceLiveTranscriberService({
     owner,
+    onPartialTranscript: (text) => {
+      editorService.setVoicePartialText(text);
+    },
     onTranscribeDelta: (text) => {
-      editorService.appendText(text);
+      editorService.commitVoicePartialText(text);
     },
     onTranscribeComplete: () => {
+      editorService.finalizeVoicePartial();
       if (isCompactRef.current) {
         void submitCompactVoiceMessageRef.current?.();
       }

--- a/front/components/editor/extensions/VoicePartialExtension.tsx
+++ b/front/components/editor/extensions/VoicePartialExtension.tsx
@@ -1,0 +1,47 @@
+import { AnimatedText } from "@dust-tt/sparkle";
+import type { NodeViewProps } from "@tiptap/core";
+import { Node } from "@tiptap/core";
+import { NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
+
+function VoicePartialNodeView({ node }: NodeViewProps) {
+  return (
+    <NodeViewWrapper as="span" className="inline">
+      <AnimatedText variant="muted">{node.attrs.text as string}</AnimatedText>
+    </NodeViewWrapper>
+  );
+}
+
+export const VoicePartialNode = Node.create({
+  name: "voicePartial",
+  group: "inline",
+  inline: true,
+  atom: true,
+  selectable: false,
+
+  addAttributes() {
+    return {
+      text: { default: "" },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "span[data-voice-partial]" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ["span", { ...HTMLAttributes, "data-voice-partial": "" }];
+  },
+
+  // Used by doc.textBetween and plain-text extractions.
+  renderText({ node }) {
+    return node.attrs.text as string;
+  },
+
+  // Used by @tiptap/markdown when serializing to markdown (e.g. on submit while
+  // a partial is still pending). Outputs the partial text as-is.
+  renderMarkdown: (node) => (node.attrs?.text as string) ?? "",
+
+  addNodeView() {
+    return ReactNodeViewRenderer(VoicePartialNodeView);
+  },
+});

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -12,6 +12,7 @@ import { SkillNode } from "@app/components/editor/extensions/input_bar/SkillNode
 import { URLDetectionExtension } from "@app/components/editor/extensions/input_bar/URLDetectionExtension";
 import { URLStorageExtension } from "@app/components/editor/extensions/input_bar/URLStorageExtension";
 import { MentionExtension } from "@app/components/editor/extensions/MentionExtension";
+import { VoicePartialNode } from "@app/components/editor/extensions/VoicePartialExtension";
 import { BlockquoteExtension } from "@app/components/editor/input_bar/BlockquoteExtension";
 import { cleanupPastedHTML } from "@app/components/editor/input_bar/cleanupPastedHTML";
 import { emojiPluginKey } from "@app/components/editor/input_bar/emojiSuggestion";
@@ -54,6 +55,97 @@ const useEditorService = (editor: Editor | null) => {
       // Append text at the end of the document (always at the end, regardless of cursor position).
       appendText: (text: string) => {
         editor?.chain().focus("end").insertContent(text).run();
+      },
+      // Insert or update the animated voicePartial node at the end of the document.
+      // Called on each partial transcript while voice recording is active.
+      setVoicePartialText: (text: string) => {
+        if (!editor) {
+          return;
+        }
+        let partialPos: number | null = null;
+        editor.state.doc.descendants((node, pos) => {
+          if (node.type.name === "voicePartial" && partialPos === null) {
+            partialPos = pos;
+            return false;
+          }
+          return true;
+        });
+        if (partialPos !== null) {
+          const p = partialPos;
+          editor
+            .chain()
+            .command(({ tr }) => {
+              tr.setNodeMarkup(p, undefined, { text });
+              return true;
+            })
+            .run();
+        } else {
+          editor
+            .chain()
+            .focus("end")
+            .insertContent({ type: "voicePartial", attrs: { text } })
+            .run();
+        }
+      },
+      // Replace the voicePartial node with the committed plain text.
+      // Called when the transcription engine finalizes a segment.
+      commitVoicePartialText: (committedText: string) => {
+        if (!editor) {
+          return;
+        }
+        let found = false;
+        editor.state.doc.descendants((node, pos) => {
+          if (node.type.name === "voicePartial" && !found) {
+            found = true;
+            const nodeSize = node.nodeSize;
+            editor
+              .chain()
+              .command(({ tr }) => {
+                if (committedText) {
+                  tr.replaceWith(
+                    pos,
+                    pos + nodeSize,
+                    editor.schema.text(committedText)
+                  );
+                } else {
+                  tr.delete(pos, pos + nodeSize);
+                }
+                return true;
+              })
+              .run();
+            return false;
+          }
+          return true;
+        });
+        if (!found && committedText) {
+          editor.chain().focus("end").insertContent(committedText).run();
+        }
+      },
+      // Convert any pending voicePartial node to plain text in place.
+      // Called when recording stops to finalize whatever partial was last shown.
+      finalizeVoicePartial: () => {
+        if (!editor) {
+          return;
+        }
+        editor.state.doc.descendants((node, pos) => {
+          if (node.type.name === "voicePartial") {
+            const text = node.attrs.text as string;
+            const nodeSize = node.nodeSize;
+            editor
+              .chain()
+              .command(({ tr }) => {
+                if (text) {
+                  tr.replaceWith(pos, pos + nodeSize, editor.schema.text(text));
+                } else {
+                  tr.delete(pos, pos + nodeSize);
+                }
+                return true;
+              })
+              .run();
+            return false;
+          }
+          return true;
+        });
       },
       // Insert mention helper function.
       insertMention: ({
@@ -341,6 +433,7 @@ export const buildEditorExtensions = ({
     SkillNode.configure({
       onSkillDetails: slashSuggestion?.onSkillDetails,
     }),
+    VoicePartialNode,
     createEmojiExtension({ onActiveChange: notifySuggestionActiveChange }),
     Placeholder.configure({
       placeholder: ({ node }) => {

--- a/front/hooks/useVoiceLiveTranscriberService.ts
+++ b/front/hooks/useVoiceLiveTranscriberService.ts
@@ -17,6 +17,9 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 interface UseVoiceLiveTranscriberServiceParams {
   owner: LightWorkspaceType;
+  // Called on each partial transcript — insert or update the pending animated node.
+  onPartialTranscript?: (text: string) => void;
+  // Called when the engine commits a segment — replace the animated node with plain text.
   onTranscribeDelta?: (text: string) => void;
   onTranscribeComplete?: () => void;
   onError?: (error: Error) => void;
@@ -24,13 +27,30 @@ interface UseVoiceLiveTranscriberServiceParams {
 
 export type VoiceLiveTranscriberService = VoiceTranscriberService;
 
-function float32ToInt16(input: Float32Array): Int16Array {
-  const output = new Int16Array(input.length);
-  for (let i = 0; i < input.length; i++) {
-    const s = Math.max(-1, Math.min(1, input[i]));
-    output[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
+// AudioWorklet processor: converts float32 PCM to int16 and transfers the buffer
+// to the main thread. Runs on the dedicated audio-rendering thread (not main thread).
+const PCM_WORKLET_CODE = `
+class PCMProcessor extends AudioWorkletProcessor {
+  process(inputs) {
+    const input = inputs[0];
+    if (input && input[0]) {
+      const float32 = input[0];
+      const int16 = new Int16Array(float32.length);
+      for (let i = 0; i < float32.length; i++) {
+        const s = Math.max(-1, Math.min(1, float32[i]));
+        int16[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
+      }
+      this.port.postMessage(int16.buffer, [int16.buffer]);
+    }
+    return true;
   }
-  return output;
+}
+registerProcessor('pcm-processor', PCMProcessor);
+`;
+
+function createPCMWorkletURL(): string {
+  const blob = new Blob([PCM_WORKLET_CODE], { type: "application/javascript" });
+  return URL.createObjectURL(blob);
 }
 
 function arrayBufferToBase64(buffer: ArrayBuffer): string {
@@ -40,6 +60,7 @@ function arrayBufferToBase64(buffer: ArrayBuffer): string {
 
 export function useVoiceLiveTranscriberService({
   owner,
+  onPartialTranscript,
   onTranscribeDelta,
   onTranscribeComplete,
   onError,
@@ -50,11 +71,13 @@ export function useVoiceLiveTranscriberService({
 
   const streamRef = useRef<MediaStream | null>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
-  const processorRef = useRef<ScriptProcessorNode | null>(null);
+  const processorRef = useRef<AudioWorkletNode | null>(null);
   const analyserRef = useRef<AnalyserNode | null>(null);
   const levelIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
   // Keep latest callbacks in refs so the stable SDK closures always see fresh values.
+  const onPartialTranscriptRef = useRef(onPartialTranscript);
+  onPartialTranscriptRef.current = onPartialTranscript;
   const onTranscribeDeltaRef = useRef(onTranscribeDelta);
   onTranscribeDeltaRef.current = onTranscribeDelta;
   const onErrorRef = useRef(onError);
@@ -86,6 +109,10 @@ export function useVoiceLiveTranscriberService({
     setLevel(0);
   }, []);
 
+  const handlePartialTranscript = useCallback(({ text }: { text: string }) => {
+    onPartialTranscriptRef.current?.(text);
+  }, []);
+
   const handleCommittedTranscript = useCallback(
     ({ text }: { text: string }) => {
       onTranscribeDeltaRef.current?.(text);
@@ -109,6 +136,7 @@ export function useVoiceLiveTranscriberService({
     audioFormat: AudioFormat.PCM_16000,
     sampleRate: 16000,
     commitStrategy: CommitStrategy.VAD,
+    onPartialTranscript: handlePartialTranscript,
     onCommittedTranscript: handleCommittedTranscript,
     onError: handleError,
   });
@@ -170,20 +198,19 @@ export function useVoiceLiveTranscriberService({
         setLevel
       );
 
-      // ScriptProcessorNode captures raw PCM and forwards it to Scribe.
-      // eslint-disable-next-line deprecation/deprecation
-      const processor = audioContext.createScriptProcessor(4096, 1, 1);
-      processorRef.current = processor;
-      source.connect(processor);
-      // ScriptProcessorNode must be connected to destination to fire onaudioprocess.
-      processor.connect(audioContext.destination);
+      // AudioWorkletNode captures raw PCM on the audio thread and posts int16 buffers
+      // to the main thread, which forwards them to Scribe.
+      const workletUrl = createPCMWorkletURL();
+      await audioContext.audioWorklet.addModule(workletUrl);
+      URL.revokeObjectURL(workletUrl);
 
-      processor.onaudioprocess = (e) => {
-        const inputData = e.inputBuffer.getChannelData(0);
-        const int16 = float32ToInt16(inputData);
-        const b64 = arrayBufferToBase64(int16.buffer as ArrayBuffer);
+      const workletNode = new AudioWorkletNode(audioContext, "pcm-processor");
+      workletNode.port.onmessage = (event: MessageEvent<ArrayBuffer>) => {
+        const b64 = arrayBufferToBase64(event.data);
         scribeRef.current.sendAudio(b64, { sampleRate: 16000 });
       };
+      source.connect(workletNode);
+      processorRef.current = workletNode;
 
       setStatus("recording");
     } catch (err) {


### PR DESCRIPTION
## Description

Partial speech-to-text transcripts from ElevenLabs Scribe now appear immediately in the input bar as the user speaks, instead of only showing text after a segment is committed. Each partial transcript is rendered as an animated `AnimatedText` (muted shimmer) node — indicating it's still being refined — and is replaced in-place when a new partial arrives or replaced with plain text when the engine commits the segment.

Stacked on top of #26750.

**How it works:**
- A new `VoicePartialNode` TipTap extension introduces an inline atom node that renders `<AnimatedText variant="muted">` via `ReactNodeViewRenderer`. The animation signals "live / may still change."
- `editorService` gains three new methods: `setVoicePartialText` (insert/update the node), `commitVoicePartialText` (replace with finalized plain text), and `finalizeVoicePartial` (convert any pending node to plain text on stop).
- `useVoiceLiveTranscriberService` now wires up `onPartialTranscript` from the ElevenLabs SDK in addition to the existing `onCommittedTranscript`, and the callback signatures are simplified (no character-length tracking needed — the node handles identity).
- If the user submits while a partial is still pending, `renderMarkdown` on the node outputs the partial text as-is so nothing is lost.

## Tests

Tested manually: speak a sentence, observe the shimmering partial text appear and update word-by-word, then solidify into plain text on commit. Also verified that submitting mid-partial includes the partial text in the message.

## Risk

Low — the `voicePartial` node is ephemeral (never persisted to the DB or serialized to markdown storage). Existing committed-transcript flow is unchanged as a fallback.
