### PR TITLE
Extract scoped path classification helpers into mount_path.ts

### DIFF
--- a/front/lib/api/files/mount_path.test.ts
+++ b/front/lib/api/files/mount_path.test.ts
@@ -1,16 +1,22 @@
 import {
+  buildCanonicalScopedPathFromVizScope,
   disambiguateFileName,
   getBaseMountPathForWorkspace,
   getConversationFilePath,
   getConversationFilesBasePath,
   getPodFilesBasePath,
   getProjectFilesBasePath,
+  isAgentScopedPath,
+  isCanonicalScopedPath,
+  isLegacyScopedPath,
+  legacyScopedPathsMatch,
   makeProcessedMountFileName,
   normalizeAndValidateMountRelativeFilePath,
   normalizeMountParentRelativePath,
   parseProcessedFilename,
   parseScopedFilePath,
   ResolveScopedMountFilePathError,
+  resolveCanonicalScopedPath,
   resolveMountFilePath,
   resolveMountFileSourcePath,
   resolveMoveSourcePath,
@@ -122,6 +128,140 @@ describe("mount_path helpers", () => {
 
     it("returns null when nothing follows pods/", () => {
       expect(toProjectMountFilePath("w/ws1/pods/")).toBeNull();
+    });
+  });
+
+  describe("scoped path classification", () => {
+    it("detects canonical scoped paths", () => {
+      expect(isCanonicalScopedPath("conversation-conv_abc/report.csv")).toBe(
+        true
+      );
+      expect(isCanonicalScopedPath("pod-pod_xyz/data.csv")).toBe(true);
+      expect(isCanonicalScopedPath("conversation-/file.csv")).toBe(false);
+      expect(isCanonicalScopedPath("conversation/file.csv")).toBe(false);
+    });
+
+    it("detects legacy scoped paths", () => {
+      expect(isLegacyScopedPath("conversation/report.csv")).toBe(true);
+      expect(isLegacyScopedPath("pod/data.csv")).toBe(true);
+      expect(isLegacyScopedPath("project/data.csv")).toBe(true);
+      expect(isLegacyScopedPath("conversation-conv_abc/report.csv")).toBe(
+        false
+      );
+    });
+
+    it("detects any agent scoped path", () => {
+      expect(isAgentScopedPath("conversation-conv_abc/report.csv")).toBe(true);
+      expect(isAgentScopedPath("conversation/report.csv")).toBe(true);
+      expect(isAgentScopedPath("hello/world")).toBe(false);
+    });
+  });
+
+  describe("resolveCanonicalScopedPath", () => {
+    const frameContext = {
+      conversationId: "conv_abc",
+      spaceId: "pod_xyz",
+    };
+
+    it("passes through canonical paths unchanged", () => {
+      expect(
+        resolveCanonicalScopedPath(
+          "conversation-conv_abc/chart.png",
+          frameContext
+        )
+      ).toBe("conversation-conv_abc/chart.png");
+    });
+
+    it("resolves legacy conversation paths under frame context", () => {
+      expect(
+        resolveCanonicalScopedPath("conversation/chart.png", frameContext)
+      ).toBe("conversation-conv_abc/chart.png");
+    });
+
+    it("resolves legacy pod and project paths under frame context", () => {
+      expect(resolveCanonicalScopedPath("pod/data.csv", frameContext)).toBe(
+        "pod-pod_xyz/data.csv"
+      );
+      expect(resolveCanonicalScopedPath("project/data.csv", frameContext)).toBe(
+        "pod-pod_xyz/data.csv"
+      );
+    });
+
+    it("returns null when frame context is missing", () => {
+      expect(
+        resolveCanonicalScopedPath("conversation/chart.png", {
+          conversationId: null,
+          spaceId: null,
+        })
+      ).toBeNull();
+    });
+  });
+
+  describe("buildCanonicalScopedPathFromVizScope", () => {
+    const frameContext = {
+      conversationId: "conv_abc",
+      spaceId: "pod_xyz",
+    };
+
+    it("builds canonical conversation paths when ids match", () => {
+      const result = buildCanonicalScopedPathFromVizScope(
+        { kind: "canonical-conversation", id: "conv_abc" },
+        "report.csv",
+        frameContext
+      );
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBe("conversation-conv_abc/report.csv");
+      }
+    });
+
+    it("rejects canonical conversation paths when ids mismatch", () => {
+      const result = buildCanonicalScopedPathFromVizScope(
+        { kind: "canonical-conversation", id: "conv_other" },
+        "report.csv",
+        frameContext
+      );
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.code).toBe("conversation_context_mismatch");
+      }
+    });
+
+    it("builds legacy conversation paths from frame context", () => {
+      const result = buildCanonicalScopedPathFromVizScope(
+        { kind: "legacy", prefix: "conversation" },
+        "report.csv",
+        frameContext
+      );
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBe("conversation-conv_abc/report.csv");
+      }
+    });
+
+    it("returns missing_pod_context when legacy pod path has no space", () => {
+      const result = buildCanonicalScopedPathFromVizScope(
+        { kind: "legacy", prefix: "pod" },
+        "report.csv",
+        { conversationId: "conv_abc", spaceId: null }
+      );
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.code).toBe("missing_pod_context");
+      }
+    });
+  });
+
+  describe("legacyScopedPathsMatch", () => {
+    it("matches exact legacy paths and project/pod aliases", () => {
+      expect(legacyScopedPathsMatch("pod/data.csv", "pod/data.csv")).toBe(true);
+      expect(legacyScopedPathsMatch("pod/data.csv", "project/data.csv")).toBe(
+        true
+      );
+      expect(
+        legacyScopedPathsMatch("pod/data.csv", "conversation/data.csv")
+      ).toBe(false);
+      expect(legacyScopedPathsMatch(undefined, "pod/data.csv")).toBe(false);
     });
   });
 

--- a/front/lib/api/files/mount_path.ts
+++ b/front/lib/api/files/mount_path.ts
@@ -7,6 +7,8 @@
 //                     the same Pod.
 
 import {
+  LEGACY_PREFIX_CONVERSATION,
+  LEGACY_PREFIX_PROJECT,
   SCOPED_PREFIX_CONVERSATION,
   SCOPED_PREFIX_POD,
 } from "@app/lib/api/file_system/types";
@@ -14,6 +16,7 @@ import type { FileResource } from "@app/lib/resources/file_resource";
 import type { AllSupportedFileContentType } from "@app/types/files";
 import { extensionsForContentType } from "@app/types/files";
 import { Err, Ok, type Result } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import path from "path";
 import { z } from "zod";
 
@@ -243,6 +246,179 @@ export function parseScopedFilePath(filePath: string): ScopedFilePath | null {
     return null;
   }
   return { prefix: prefixResult.data, rel: filePath.slice(slashIdx + 1) };
+}
+
+/** Conversation/pod context used to resolve legacy scoped paths for a frame. */
+export type FrameScopedPathContext = {
+  conversationId: string | null;
+  spaceId: string | null;
+};
+
+function getScopedPathPrefix(scopedPath: string): string | null {
+  const slashIdx = scopedPath.indexOf("/");
+  if (slashIdx <= 0) {
+    return null;
+  }
+  return scopedPath.slice(0, slashIdx);
+}
+
+/**
+ * True for canonical agent-visible paths (`conversation-{id}/...`, `pod-{id}/...`).
+ * The id segment after the prefix must be non-empty.
+ */
+export function isCanonicalScopedPath(scopedPath: string): boolean {
+  const prefix = getScopedPathPrefix(scopedPath);
+  if (!prefix) {
+    return false;
+  }
+
+  if (prefix.startsWith(SCOPED_PREFIX_CONVERSATION)) {
+    return prefix.length > SCOPED_PREFIX_CONVERSATION.length;
+  }
+
+  if (prefix.startsWith(SCOPED_PREFIX_POD)) {
+    return prefix.length > SCOPED_PREFIX_POD.length;
+  }
+
+  return false;
+}
+
+/** True for legacy bare-prefix paths (`conversation/...`, `pod/...`, `project/...`). */
+export function isLegacyScopedPath(scopedPath: string): boolean {
+  const prefix = getScopedPathPrefix(scopedPath);
+  if (!prefix) {
+    return false;
+  }
+
+  return (
+    prefix === LEGACY_PREFIX_CONVERSATION ||
+    prefix === "pod" ||
+    prefix === LEGACY_PREFIX_PROJECT
+  );
+}
+
+/** True for any agent-visible scoped path (canonical or legacy). */
+export function isAgentScopedPath(scopedPath: string): boolean {
+  return isCanonicalScopedPath(scopedPath) || isLegacyScopedPath(scopedPath);
+}
+
+/**
+ * Resolve a legacy scoped path to its canonical form under the frame context.
+ * Canonical paths are returned unchanged.
+ */
+export function resolveCanonicalScopedPath(
+  scopedPath: string,
+  frameContext: FrameScopedPathContext
+): string | null {
+  if (isCanonicalScopedPath(scopedPath)) {
+    return scopedPath;
+  }
+
+  if (!isLegacyScopedPath(scopedPath)) {
+    return null;
+  }
+
+  const slashIdx = scopedPath.indexOf("/");
+  const prefix = scopedPath.slice(0, slashIdx);
+  const rel = path.posix.normalize(scopedPath.slice(slashIdx + 1));
+
+  if (rel.startsWith("..") || rel.startsWith("/")) {
+    return null;
+  }
+
+  switch (prefix) {
+    case LEGACY_PREFIX_CONVERSATION: {
+      if (!frameContext.conversationId) {
+        return null;
+      }
+      return `${SCOPED_PREFIX_CONVERSATION}${frameContext.conversationId}/${rel}`;
+    }
+    case "pod":
+    case LEGACY_PREFIX_PROJECT: {
+      if (!frameContext.spaceId) {
+        return null;
+      }
+      return `${SCOPED_PREFIX_POD}${frameContext.spaceId}/${rel}`;
+    }
+    default:
+      return null;
+  }
+}
+
+export type BuildCanonicalScopedPathError =
+  | { code: "missing_conversation_context" }
+  | { code: "missing_pod_context" }
+  | { code: "conversation_context_mismatch" }
+  | { code: "pod_context_mismatch" };
+
+/**
+ * Build the canonical scoped path from a parsed viz URL scope + relative path.
+ * Used by viz file-serving endpoints; enforces frame-context match on canonical scopes.
+ */
+export function buildCanonicalScopedPathFromVizScope(
+  scope: ParsedVizScope,
+  normalizedRel: string,
+  frameContext: FrameScopedPathContext
+): Result<string, BuildCanonicalScopedPathError> {
+  switch (scope.kind) {
+    case "canonical-conversation": {
+      if (scope.id !== frameContext.conversationId) {
+        return new Err({ code: "conversation_context_mismatch" });
+      }
+      return new Ok(
+        `${SCOPED_PREFIX_CONVERSATION}${scope.id}/${normalizedRel}`
+      );
+    }
+
+    case "canonical-pod": {
+      if (scope.id !== frameContext.spaceId) {
+        return new Err({ code: "pod_context_mismatch" });
+      }
+      return new Ok(`${SCOPED_PREFIX_POD}${scope.id}/${normalizedRel}`);
+    }
+
+    case "legacy": {
+      if (scope.prefix === "conversation") {
+        if (!frameContext.conversationId) {
+          return new Err({ code: "missing_conversation_context" });
+        }
+        return new Ok(
+          `${SCOPED_PREFIX_CONVERSATION}${frameContext.conversationId}/${normalizedRel}`
+        );
+      }
+
+      if (!frameContext.spaceId) {
+        return new Err({ code: "missing_pod_context" });
+      }
+      return new Ok(
+        `${SCOPED_PREFIX_POD}${frameContext.spaceId}/${normalizedRel}`
+      );
+    }
+
+    default:
+      return assertNever(scope);
+  }
+}
+
+/** Match a requested legacy scoped path against a stored legacy alias. */
+export function legacyScopedPathsMatch(
+  storedLegacyPath: string | undefined,
+  requestedRef: string
+): boolean {
+  if (!storedLegacyPath) {
+    return false;
+  }
+
+  if (storedLegacyPath === requestedRef) {
+    return true;
+  }
+
+  // Older frame code may request `project/...` while the stored alias uses `pod/...`.
+  return (
+    requestedRef.startsWith(`${LEGACY_PREFIX_PROJECT}/`) &&
+    storedLegacyPath ===
+      `pod/${requestedRef.slice(`${LEGACY_PREFIX_PROJECT}/`.length)}`
+  );
 }
 
 export class ResolveScopedMountFilePathError extends Error {

--- a/front/lib/api/viz/extract_file_refs.ts
+++ b/front/lib/api/viz/extract_file_refs.ts
@@ -1,41 +1,12 @@
-// Ported from viz/app/lib/parseFileRefs.ts — keep both copies in sync until deduped into a shared package.
+// Ported from viz/app/lib/parseFileRefs.ts — keep classification in sync with
+// `isAgentScopedPath` in front/lib/api/files/mount_path.ts until deduped into a shared package.
+import { isAgentScopedPath } from "@app/lib/api/files/mount_path";
 import logger from "@app/logger/logger";
 import ts from "typescript";
 
 export type FileRef =
   | { type: "fileId"; fileId: string }
   | { type: "path"; scopedPath: string };
-
-// Mirrors front's `parseRawVizScope` contract. Canonical scopes are `${PREFIX}-{id}/...`;
-// the bare prefixes are legacy forms still emitted by older frame code.
-const SCOPED_PREFIX_CONVERSATION = "conversation";
-const SCOPED_PREFIX_POD = "pod";
-const SCOPED_PREFIX_PROJECT = "project";
-
-function isScopedPath(value: string): boolean {
-  const slashIdx = value.indexOf("/");
-  if (slashIdx <= 0) {
-    return false;
-  }
-  const prefix = value.slice(0, slashIdx);
-
-  // Canonical, portable scopes are what frame code is instructed to use, e.g.
-  // `conversation-{conversationId}/report.csv` or `pod-{podId}/notes.md`. This mirrors the
-  // server contract in front's `parseRawVizScope`: the id after the prefix must be non-empty.
-  if (
-    prefix.startsWith(`${SCOPED_PREFIX_CONVERSATION}-`) ||
-    prefix.startsWith(`${SCOPED_PREFIX_POD}-`)
-  ) {
-    return !prefix.endsWith("-");
-  }
-
-  // Legacy bare prefixes, still used by older frame code.
-  return (
-    prefix === SCOPED_PREFIX_CONVERSATION ||
-    prefix === SCOPED_PREFIX_POD ||
-    prefix === SCOPED_PREFIX_PROJECT
-  );
-}
 
 export function extractFileRefs(code: string): FileRef[] {
   const refs = new Map<string, FileRef>();
@@ -47,7 +18,7 @@ export function extractFileRefs(code: string): FileRef[] {
 
     if (/^fil_[a-zA-Z0-9]{10,}$/.test(value)) {
       refs.set(value, { type: "fileId", fileId: value });
-    } else if (isScopedPath(value)) {
+    } else if (isAgentScopedPath(value)) {
       refs.set(value, { type: "path", scopedPath: value });
     }
   };

--- a/viz/app/lib/parseFileRefs.ts
+++ b/viz/app/lib/parseFileRefs.ts
@@ -1,4 +1,5 @@
-// Ported to front/lib/api/viz/extract_file_refs.ts — keep both copies in sync until deduped into a shared package.
+// Ported to front/lib/api/viz/extract_file_refs.ts — keep `isScopedPath` in sync with
+// `isAgentScopedPath` in front/lib/api/files/mount_path.ts until deduped into a shared package.
 import logger from "@viz/app/lib/logger";
 import ts from "typescript";
 


### PR DESCRIPTION
## Description

Centralizes all viz scoped-path logic into `mount_path.ts` as canonical shared helpers, eliminating the duplicated `isScopedPath` function in `extract_file_refs.ts`.

New exports in `mount_path.ts`: `isCanonicalScopedPath`, `isLegacyScopedPath`, `isAgentScopedPath`, `resolveCanonicalScopedPath`, `buildCanonicalScopedPathFromVizScope`, `legacyScopedPathsMatch`, and the `FrameScopedPathContext` type. `extract_file_refs.ts` now imports `isAgentScopedPath` instead of maintaining its own copy. `viz/app/lib/parseFileRefs.ts` sync comment updated to reference the canonical location.

First PR in a 3-way split — subsequent PRs wire these helpers into `authorized_file_access.ts` and the viz file-serving endpoints.

## Tests

Added comprehensive unit tests in `mount_path.test.ts` covering all new helpers: path classification (canonical/legacy/agent), `resolveCanonicalScopedPath` (pass-through, legacy resolution, missing context), `buildCanonicalScopedPathFromVizScope` (id match/mismatch, legacy prefixes, missing context), and `legacyScopedPathsMatch` (exact match, `project/` ↔ `pod/` alias).

## Risk

Low. Pure extraction — `isAgentScopedPath` is semantically identical to the removed `isScopedPath`. No runtime behavior changes. No DB migrations.

## Deploy Plan

Deploy front when base branch (`sflory/copy-extractfilerefs-in-front`) is ready.
